### PR TITLE
Fea  cli   file name to specify the file name with the code instead of running app.py

### DIFF
--- a/agenta-cli/agenta/cli/variant_commands.py
+++ b/agenta-cli/agenta/cli/variant_commands.py
@@ -18,7 +18,7 @@ def variant():
     pass
 
 
-def add_variant(variant_name: str, app_folder: str) -> str:
+def add_variant(variant_name: str, app_folder: str, file_name: str) -> str:
     """Add a new variant.
     Returns the name of the variant. (useful for serve)"""
 
@@ -34,9 +34,9 @@ def add_variant(variant_name: str, app_folder: str) -> str:
     app_name = config['app-name']
 
     # check files in folder
-    app_file = app_path / 'app.py'
+    app_file = app_path / file_name
     if not app_file.exists():
-        click.echo(click.style("No app.py exists! Please make sure you are in the right directory", fg='red'))
+        click.echo(click.style(f"No {file_name} exists! Please make sure you are in the right directory", fg='red'))
         return None
     env_file = app_path / '.env'
     if not env_file.exists():
@@ -60,7 +60,7 @@ def add_variant(variant_name: str, app_folder: str) -> str:
     if not overwrite:
         config['variants'].append(variant_name)
     try:
-        tar_path = build_tar_docker_container(folder=app_path)
+        tar_path = build_tar_docker_container(folder=app_path, file_name=file_name)
         image: Image = client.send_docker_tar(app_name, variant_name, tar_path)
         # docker_image: DockerImage = build_and_upload_docker_image(
         #     folder=app_path, app_name=app_name, variant_name=variant_name)
@@ -222,9 +222,10 @@ def remove_variant_cli(variant_name: str, app_folder: str):
 
 @variant.command(name='serve')
 @click.option('--app_folder', default='.')
-def serve_cli(app_folder: str):
+@click.option('--file_name', default='app.py', help="The name of the file to run")
+def serve_cli(app_folder: str, file_name: str):
     """Adds a variant to the web ui and serves the api locally."""
-    variant_name = add_variant(variant_name='', app_folder=app_folder)
+    variant_name = add_variant(variant_name='', app_folder=app_folder, file_name=file_name)
     if variant_name:  # otherwise we either failed or we were doing an update and we don't need to manually start the variant!!
         start_variant(variant_name=variant_name, app_folder=app_folder)
 
@@ -232,7 +233,8 @@ def serve_cli(app_folder: str):
 @variant.command(name='add')
 @click.option('--app_folder', default='.')
 @click.option('--variant_name', default='')
-def add_variant_cli(variant_name: str, app_folder: str):
+@click.option('--file_name', default='app.py', help="The name of the file to run")
+def add_variant_cli(variant_name: str, app_folder: str, file_name: str):
     """Builds the code into a new variant and add it to the platform"""
     return add_variant(variant_name, app_folder)
 
@@ -242,7 +244,7 @@ def add_variant_cli(variant_name: str, app_folder: str):
 @click.option('--app_folder', default=".")
 def start_variant_cli(variant_name: str, app_folder: str):
     """Start a variant."""
-    start_variant(variant_name, app_folder)
+    start_variant(variant_name, app_folder, file_name)
 
 
 @variant.command(name='list')

--- a/agenta-cli/agenta/docker/docker-assets/main.py
+++ b/agenta-cli/agenta/docker/docker-assets/main.py
@@ -1,6 +1,6 @@
 from uvicorn import run
 import agenta
-import app  # This will register the routes with the FastAPI application
+import _app  # This will register the routes with the FastAPI application
 import os
 try:
     import ingest

--- a/agenta-cli/agenta/docker/docker_utils.py
+++ b/agenta-cli/agenta/docker/docker_utils.py
@@ -1,11 +1,12 @@
 import logging
 import os
 import shutil
+import tarfile
+import tempfile
 from pathlib import Path
 from tempfile import TemporaryDirectory
-import json
+
 import docker
-import tarfile
 from agenta.config import settings
 from docker.models.images import Image
 
@@ -27,16 +28,16 @@ def create_dockerfile(out_folder: Path):
     return dockerfile_path
 
 
-def build_tar_docker_container(folder: Path) -> Path:
+def build_tar_docker_container(folder: Path, file_name: Path) -> Path:
     """Builds the tar file container the files needed for the docker container
 
     Arguments:
         folder -- the path containing the code for the app
-
+        file_name -- the file containing the main code of the app
     Returns:
         the path to the created tar file
     """
-
+    tarfile_path = folder / "docker.tar.gz"  # output file
     dockerfile_path = create_dockerfile(folder)
     shutil.copytree(Path(__file__).parent.parent / "sdk", folder / "agenta", dirs_exist_ok=True)
     shutil.copy(Path(__file__).parent /
@@ -44,10 +45,15 @@ def build_tar_docker_container(folder: Path) -> Path:
     shutil.copy(Path(__file__).parent /
                 "docker-assets" / "entrypoint.sh", folder)
     # tar the directory
-
-    tarfile_path = folder/"docker.tar.gz"
-    with tarfile.open(tarfile_path, "w:gz") as tar:
-        tar.add(folder, arcname=folder.name)
+    with tempfile.TemporaryDirectory() as temp_dir:
+        temp_path = Path(temp_dir)
+        shutil.copytree(folder, temp_path, dirs_exist_ok=True)
+        if (temp_path / "_app.py").exists():
+            raise ValueError(
+                "File _app.py already exists in the temp folder. You are not allowed to use this name in your code.")
+        shutil.copy(temp_path / file_name, temp_path / "_app.py")
+        with tarfile.open(tarfile_path, "w:gz") as tar:
+            tar.add(temp_path, arcname=folder.name)
     # dockerfile_path.unlink()
     return tarfile_path
 

--- a/agenta-cli/pyproject.toml
+++ b/agenta-cli/pyproject.toml
@@ -1,6 +1,6 @@
 [tool.poetry]
 name = "agenta"
-version = "0.1.13"
+version = "0.1.14"
 description = "Code for the SDK and CLI for the Agenta Lab platform"
 authors = ["Mahmoud Mabrouk <mahmoudmabrouk.mail@gmail.com>"]
 readme = "README.md"

--- a/docs/howto/creating-multiple-app-variants.mdx
+++ b/docs/howto/creating-multiple-app-variants.mdx
@@ -29,7 +29,7 @@ Here are the steps to follow:
 
 ## Multiple Files Workflow
 
-This method involves creating a separate Python file for each variant in the same folder. It allows easy switching between variants without moving between branches.
+This method involves creating a separate Python file for each variant in the same folder (e.g. `variant_1.py`, `variant_2.py`). The file can be named as you wish. Compares to the [Git Branch Workflow](#git-branch-workflow), this workflow allows to easily switch between variants without moving between branches.
 
 To create a variant using this workflow:
 

--- a/docs/howto/creating-multiple-app-variants.mdx
+++ b/docs/howto/creating-multiple-app-variants.mdx
@@ -1,0 +1,46 @@
+---
+title: Creating Multiple App Variants
+---
+
+## How to Create Multiple App Variants in a Single Project
+
+This guide provides instructions on creating multiple variants within one project. A "variant" is a unique version of your app that may feature a different architecture or significant changes in the codebase. (See [the concept guide](/docs/conceptual/concepts#app-variant) for more details on variants.)
+
+## Ways to Create App Variants
+
+We recommend two primary workflows for creating app variants from the command line interface (CLI):
+
+- [Git Branch Workflow](#git-branch-workflow)
+- [Multiple Files Workflow](#multiple-files-workflow)
+
+And one additional method through the web interface:
+
+- [Playground Workflow](#playground-workflow)
+
+## Git Branch Workflow
+
+This approach creates a new Git branch for each variant, enabling version control for each different version of your app.
+
+Here are the steps to follow:
+
+1. For each variant, create a new branch with the command: ```git checkout -b variant_name```
+2. Modify the code in your specific file (replace the content in `app.py`)
+3. Run the following command with the new code, using the same branch name: ```agenta variant serve```
+
+## Multiple Files Workflow
+
+This method involves creating a separate Python file for each variant in the same folder. It allows easy switching between variants without moving between branches.
+
+To create a variant using this workflow:
+
+1. Copy the original Python file for each variant using the command: ```cp app.py variant_name.py```
+2. Run the command ```agenta variant serve --file_name=variant_name.py```
+3. When naming your variants, ensure the variant name aligns with the file name (e.g., `variant_name.py` -> `variant_name`)
+
+
+## Playground Workflow
+
+Alternatively, you can create app variants directly from the Playground interface. To create a new variant, click the '+' symbol on the tabs in Playground.
+
+
+

--- a/docs/howto/creating-multiple-app-variants.mdx
+++ b/docs/howto/creating-multiple-app-variants.mdx
@@ -33,7 +33,7 @@ This method involves creating a separate Python file for each variant in the sam
 
 To create a variant using this workflow:
 
-1. Create a new script for the new variant, either by starting from scratch or copying and older version```cp app.py variant_name.py``` and then modifying it. This file will contain the code for the new variant with @post for the main function.
+1. Create a new script for the new variant, either by starting from scratch or copying and older version```cp app.py variant_name.py``` and then modifying it. This file will contain the code for the new variant with `@post` for the main function.
 2. Run the command ```agenta variant serve --file_name=variant_name.py```
 3. When naming your variants, ensure the variant name aligns with the file name (e.g., `variant_name.py` -> `variant_name`)
 

--- a/docs/howto/creating-multiple-app-variants.mdx
+++ b/docs/howto/creating-multiple-app-variants.mdx
@@ -29,7 +29,7 @@ Here are the steps to follow:
 
 ## Multiple Files Workflow
 
-This method involves creating a separate Python file for each variant in the same folder (e.g. `variant_1.py`, `variant_2.py`). The files can be named as you wish. Compares to the [Git Branch Workflow](#git-branch-workflow), this workflow allows to easily switch between variants without moving between branches.
+This method involves creating a separate Python file for each variant in the same folder (e.g. `variant_1.py`, `variant_2.py`). The files can be named as you wish. Compared to the [Git Branch Workflow](#git-branch-workflow), this workflow allows to easily switch between variants without moving between branches.
 
 To create a variant using this workflow:
 

--- a/docs/howto/creating-multiple-app-variants.mdx
+++ b/docs/howto/creating-multiple-app-variants.mdx
@@ -29,7 +29,7 @@ Here are the steps to follow:
 
 ## Multiple Files Workflow
 
-This method involves creating a separate Python file for each variant in the same folder (e.g. `variant_1.py`, `variant_2.py`). The file can be named as you wish. Compares to the [Git Branch Workflow](#git-branch-workflow), this workflow allows to easily switch between variants without moving between branches.
+This method involves creating a separate Python file for each variant in the same folder (e.g. `variant_1.py`, `variant_2.py`). The files can be named as you wish. Compares to the [Git Branch Workflow](#git-branch-workflow), this workflow allows to easily switch between variants without moving between branches.
 
 To create a variant using this workflow:
 

--- a/docs/howto/creating-multiple-app-variants.mdx
+++ b/docs/howto/creating-multiple-app-variants.mdx
@@ -33,7 +33,7 @@ This method involves creating a separate Python file for each variant in the sam
 
 To create a variant using this workflow:
 
-1. Copy the original Python file for each variant using the command: ```cp app.py variant_name.py```
+1. Create a new script for the new variant, either by starting from scratch or copying and older version```cp app.py variant_name.py``` and then modifying it. This file will contain the code for the new variant with @post for the main function.
 2. Run the command ```agenta variant serve --file_name=variant_name.py```
 3. When naming your variants, ensure the variant name aligns with the file name (e.g., `variant_name.py` -> `variant_name`)
 

--- a/docs/introduction.mdx
+++ b/docs/introduction.mdx
@@ -19,7 +19,6 @@ Agenta is an open-source developer first LLMOps platform to streamline the proce
 
 - **API Deployment Made Easy:** Agenta allows you to deploy your LLM applications as APIs without any additional effort. (Currently only available locally)
 
-
 ## Why choose Agenta for building LLM-apps?
 
 While there are numerous LLMops platforms, we believe Agenta offers unique benefits:

--- a/mint.json
+++ b/mint.json
@@ -60,6 +60,7 @@
     {
       "group": "How-to Guides",
       "pages": [
+        "docs/howto/creating-multiple-app-variants",
         "docs/howto/how-to-debug"
       ]
     },


### PR DESCRIPTION
Added option to enable creating a variant from a any file in the folder.

This allows users to create:

app1.py app2.py app3.py

in the same folder

then run

agenta variant serve --file_name app1.py

agenta variant serve --file_name app2.py

agenta variant serve --file_name app3.py


See documentation for more details