### PR TITLE
Fix: renamed dep from openapi to openai

### DIFF
--- a/docs/tutorials/your-first-llm-app.mdx
+++ b/docs/tutorials/your-first-llm-app.mdx
@@ -35,7 +35,7 @@ Finally let's create a requirements.txt and add within it our dependencies
 langchain
 agenta
 python-dotenv
-openapi
+openai
 ```
 
 Install the dependencies:


### PR DESCRIPTION
Hello @mmabrouk, I made an error in the naming 😄. I confused `openai` with `openapi`.