### PR TITLE
Load test sets in playgorund

### DIFF
--- a/agenta-web/src/components/Evaluations/Evaluations.tsx
+++ b/agenta-web/src/components/Evaluations/Evaluations.tsx
@@ -1,7 +1,7 @@
 import {useState, useEffect} from "react"
 import {Button, Col, Dropdown, MenuProps, Radio, RadioChangeEvent, Row, Tag, message} from "antd"
 import {DownOutlined} from "@ant-design/icons"
-import {fetchVariants, getVariantParameters, loadDatasetsList} from "@/lib/services/api"
+import {fetchVariants, getVariantParameters, useLoadDatasetsList} from "@/lib/services/api"
 import {useRouter} from "next/router"
 import {Variant, Parameter} from "@/lib/Types"
 import EvaluationsList from "./EvaluationsList"
@@ -32,7 +32,7 @@ export default function Evaluations() {
 
     const appName = router.query.app_name?.toString() || ""
 
-    const {datasets, isDatasetsLoading, isDatasetsLoadingError} = loadDatasetsList(appName)
+    const {datasets, isDatasetsLoading, isDatasetsLoadingError} = useLoadDatasetsList(appName)
 
     const [variantInputs, setVariantInputs] = useState<string[]>([])
 

--- a/agenta-web/src/components/Playground/LoadTestsModal.tsx
+++ b/agenta-web/src/components/Playground/LoadTestsModal.tsx
@@ -1,0 +1,85 @@
+import {loadDataset, useLoadDatasetsList} from "@/lib/services/api"
+import {Button, Divider, Dropdown, Modal, Select} from "antd"
+import {useRouter} from "next/router"
+import {PropsWithChildren, useState} from "react"
+
+interface Props extends PropsWithChildren {
+    addNewTests: (tests: Record<string, string>[]) => void
+    setNewTests: (tests: Record<string, string>[]) => void
+}
+
+const LoadTestsModal: React.FC<Props> = (props) => {
+    const {addNewTests, setNewTests} = props
+    const router = useRouter()
+    const [isOpen, setIsOpen] = useState(false)
+    const [selectedSet, setSelectedSet] = useState<string>("")
+
+    const appName = router.query.app_name?.toString() || ""
+
+    const {datasets, isDatasetsLoading, isDatasetsLoadingError} = useLoadDatasetsList(appName)
+
+    const options = datasets?.map((item: Record<string, any>) => ({
+        label: item.name,
+        value: item._id,
+    }))
+
+    const handleAddData = () => {
+        loadDataset(selectedSet).then((data) => {
+            addNewTests(data.csvdata)
+        })
+    }
+
+    const handleSetData = () => {
+        loadDataset(selectedSet).then((data) => {
+            setNewTests(data.csvdata)
+        })
+    }
+
+    return (
+        <div>
+            <Modal
+                title="Load tests"
+                open={isOpen}
+                onCancel={() => setIsOpen(false)}
+                footer={
+                    <>
+                        <Button disabled={!selectedSet} onClick={handleAddData}>
+                            Add tests
+                        </Button>
+                        <Button disabled={!selectedSet} onClick={handleSetData}>
+                            Replace tests
+                        </Button>
+                    </>
+                }
+            >
+                <p style={{marginBottom: 10}}>Please select the test set you want to use:</p>
+
+                <Select
+                    style={{minWidth: 120, marginBottom: 20}}
+                    options={options}
+                    placeholder="Select data set"
+                    onSelect={(id) => setSelectedSet(id)}
+                />
+
+                {selectedSet ? (
+                    <>
+                        <p>Click add test to add data to existing test</p>
+                        <p>Click replace tests to replace data of existing tests</p>
+                    </>
+                ) : null}
+                <Divider style={{margin: "24px 0 0 0"}} />
+            </Modal>
+
+            <Button
+                type="primary"
+                size="middle"
+                onClick={() => setIsOpen(true)}
+                loading={isDatasetsLoading}
+            >
+                Load Test sets
+            </Button>
+        </div>
+    )
+}
+
+export default LoadTestsModal

--- a/agenta-web/src/components/Playground/Views/TestView.tsx
+++ b/agenta-web/src/components/Playground/Views/TestView.tsx
@@ -5,6 +5,7 @@ import {callVariant} from "@/lib/services/api"
 import {Parameter} from "@/lib/Types"
 import {renameVariables} from "@/lib/helpers/utils"
 import {TestContext} from "../TestContextProvider"
+import LoadTestsModal from "../LoadTestsModal"
 interface TestViewProps {
     URIPath: string | null
     inputParams: Parameter[] | null
@@ -122,9 +123,28 @@ const App: React.FC<TestViewProps> = ({inputParams, optParams, URIPath}) => {
         setTestList([...testList, {}])
     }
 
+    const handleAddNewTests: (tests: Record<string, string>[]) => void = (tests) => {
+        setTestList([...testList, ...tests])
+    }
+
+    const handleSetNewTests: (tests: Record<string, string>[]) => void = (tests) => {
+        setTestList([...tests])
+    }
+
     return (
         <div>
-            <h2 style={{padding: "0px", marginBottom: "8px"}}>2. Preview and test</h2>
+            <div
+                style={{
+                    display: "flex",
+                    justifyContent: "space-between",
+                    alignItems: "center",
+                    marginRight: "24px",
+                }}
+            >
+                <h2 style={{padding: "0px", marginBottom: "8px"}}>2. Preview and test</h2>
+
+                <LoadTestsModal setNewTests={handleSetNewTests} addNewTests={handleAddNewTests} />
+            </div>
 
             {testList.map((testData, index) => (
                 <BoxComponent

--- a/agenta-web/src/lib/services/api.ts
+++ b/agenta-web/src/lib/services/api.ts
@@ -187,7 +187,7 @@ export async function removeVariant(appName: string, variantName: string) {
  * Loads the list of datasets
  * @returns
  */
-export const loadDatasetsList = (app_name: string) => {
+export const useLoadDatasetsList = (app_name: string) => {
     const {data, error} = useSWR(
         `${process.env.NEXT_PUBLIC_AGENTA_API_URL}/api/datasets?app_name=${app_name}`,
         fetcher,


### PR DESCRIPTION
What: 
https://github.com/Agenta-AI/agenta/issues/107

How: 
Create LoadTestsModal
Fetch test sets list on load of the modal using hook
add ways for users to replace existing test sets or add new items to existing test sets.

Result:

https://github.com/Agenta-AI/agenta/assets/8658374/768bf312-3518-48a6-9181-52421a58e47a

