### PR TITLE
Fix "Cannot use import statement outside a module" Error

### DIFF
--- a/agenta-web/src/components/Evaluations/Evaluations.tsx
+++ b/agenta-web/src/components/Evaluations/Evaluations.tsx
@@ -7,10 +7,13 @@ import {Variant, Parameter} from "@/lib/Types"
 import EvaluationsList from "./EvaluationsList"
 import {EvaluationFlow, EvaluationType} from "@/lib/enums"
 import {EvaluationTypeLabels} from "@/lib/helpers/utils"
-import Title from "antd/es/typography/Title"
+import { Typography } from "antd";
+
+
 
 export default function Evaluations() {
     const router = useRouter()
+    const { Title } = Typography
     const [areAppVariantsLoading, setAppVariantsLoading] = useState(false)
     const [isError, setIsError] = useState<boolean | string>(false)
     const [variants, setVariants] = useState<any[]>([])


### PR DESCRIPTION
Hi @mmabrouk ,

I've gotten rid of the error that says, Cannot use import statement outside a module. Merging this PR will close #146.