### PR TITLE
Fix 502 Bad Gateway Issue by Exposing Backend Server Port (8000)

### DIFF
--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -9,6 +9,7 @@ services:
             - /var/run/docker.sock:/var/run/docker.sock
         networks:
             - agenta-network
+            
     backend:
         build: ./agenta-backend
         environment:
@@ -31,6 +32,8 @@ services:
 
         networks:
             - agenta-network
+        ports:
+            - 8000:8000
         command:
             [
                 "uvicorn",


### PR DESCRIPTION
Hi @mmabrouk,

This PR addresses the 502 bad gateway issue that was surfacing when accessing the backend server. The problem was caused by the backend server's port (8000) not being exposed, resulting in the gateway's error.