### PR TITLE
Feat - Integration of be and fe for starting with template

### DIFF
--- a/agenta-backend/agenta_backend/models/api/api_models.py
+++ b/agenta-backend/agenta_backend/models/api/api_models.py
@@ -38,11 +38,14 @@ class App(BaseModel):
     app_name: str
 
 
+class DockerEnvVars(BaseModel):
+    env_vars: Dict[str, str]
+
+
 class CreateAppVariant(BaseModel):
     app_name: str
     image_id: str
     image_tag: str
+    env_vars: Dict[str, str]
 
       
-class DockerEnvVars(BaseModel):
-    env_vars: Dict[str, str]

--- a/agenta-backend/agenta_backend/routers/container_router.py
+++ b/agenta-backend/agenta_backend/routers/container_router.py
@@ -154,7 +154,7 @@ async def create_app_variant_from_image(payload: CreateAppVariant):
         update_variant_image(app_variant, image)
 
     # Start variant
-    url = start_variant(app_variant)
+    url = start_variant(app_variant, payload.env_vars)
 
     return {
         "message": "Variant created and running!",

--- a/agenta-backend/agenta_backend/routers/container_router.py
+++ b/agenta-backend/agenta_backend/routers/container_router.py
@@ -24,6 +24,7 @@ from agenta_backend.models.api.api_models import (
 )
 from agenta_backend.services.container_manager import (
     build_image_job,
+    check_docker_arch,
     get_image_details_from_docker_hub,
     pull_image_from_docker_hub,
 )
@@ -85,7 +86,10 @@ async def container_templates() -> List[Template]:
     Returns:
         a list of `Template` objects.
     """
-    templates = get_templates()
+    docker_arch = await check_docker_arch()
+    if docker_arch == "unknown":
+        return []
+    templates = get_templates(docker_arch)
     return templates
 
 

--- a/agenta-backend/agenta_backend/services/container_manager.py
+++ b/agenta-backend/agenta_backend/services/container_manager.py
@@ -121,7 +121,26 @@ async def retrieve_templates_from_dockerhub(
         return response_data
 
 
-async def retrieve_templates_from_dockerhub_cached():
+async def check_docker_arch() -> str:
+    """Checks the architecture of the Docker system.
+
+    Returns:
+        The architecture mapping for the Docker system.
+    """
+    async with Docker() as docker:
+        info = await docker.system.info()
+        arch_mapping = {
+            "x86_64": "amd",
+            "arm64": "arm",
+            "armhf": "arm",
+            "ppc64le": "ppc",
+            "s390x": "s390",
+            # Add more mappings as needed
+        }
+        return arch_mapping.get(info["Architecture"], "unknown")
+
+
+async def retrieve_templates_from_dockerhub_cached() -> List[dict]:
     """Retrieves templates from Docker Hub and caches the data in Redis for future use.
 
     Returns:
@@ -180,7 +199,7 @@ async def get_image_details_from_docker_hub(
     Returns:
         The "Id" of the image details obtained from Docker Hub.
     """
-    
+
     async with Docker() as docker:
         image_details = await docker.images.inspect(
             f"{repo_owner}/{repo_name}:{image_name}"

--- a/agenta-backend/agenta_backend/services/db_manager.py
+++ b/agenta-backend/agenta_backend/services/db_manager.py
@@ -10,7 +10,7 @@ from agenta_backend.models.api.api_models import (
 from agenta_backend.models.converters import (
     app_variant_db_to_pydantic,
     image_db_to_pydantic,
-    templates_db_to_pydantic
+    templates_db_to_pydantic,
 )
 from agenta_backend.models.db_models import AppVariantDB, ImageDB, TemplateDB
 from agenta_backend.services import helpers
@@ -37,9 +37,13 @@ def get_session():
         yield session
 
 
-def get_templates() -> List[Template]:
+def get_templates(arch: str) -> List[Template]:
     with Session(engine) as session:
-        templates = session.query(TemplateDB).all()
+        templates = (
+            session.query(TemplateDB)
+            .filter(TemplateDB.name.like(f"%{arch}%"))
+            .all()
+        )
     return templates_db_to_pydantic(templates)
 
 

--- a/agenta-web/src/components/AppSelector/AppSelector.tsx
+++ b/agenta-web/src/components/AppSelector/AppSelector.tsx
@@ -1,7 +1,7 @@
 import {useState} from "react"
 import {useRouter} from "next/router"
 import {Space} from "antd"
-import useSWR from "swr"
+import { fetchApps } from "@/lib/services/api"
 import AppCard from "./AppCard"
 import CreateApp from "@/components/CreateApp/CreateApp"
 
@@ -24,11 +24,7 @@ const AppSelector: React.FC = () => {
         setIsModalOpen(false)
     }
 
-    // TODO: move to api.ts
-    const {data, error, isLoading} = useSWR(
-        `${process.env.NEXT_PUBLIC_AGENTA_API_URL}/api/app_variant/list_apps/`,
-        fetcher,
-    )
+    const {data, error, isLoading} = fetchApps()
 
     if (error) return <div>failed to load</div>
     if (isLoading) return <div>loading...</div>

--- a/agenta-web/src/components/CreateApp/AppTemplateCard.tsx
+++ b/agenta-web/src/components/CreateApp/AppTemplateCard.tsx
@@ -2,9 +2,10 @@ import {Card, Typography} from "antd"
 
 interface Props {
     title: string
+    onClick: () => void
 }
 
-const AppTemplateCard: React.FC<Props> = ({title}) => {
+const AppTemplateCard: React.FC<Props> = ({title, onClick}) => {
     const {Text} = Typography
     return (
         <Card
@@ -17,6 +18,7 @@ const AppTemplateCard: React.FC<Props> = ({title}) => {
                 justifyContent: "center",
                 cursor: "pointer",
             }}
+            onClick={onClick}
         >
             <Text>{title}</Text>
         </Card>

--- a/agenta-web/src/components/CreateApp/CreateApp.tsx
+++ b/agenta-web/src/components/CreateApp/CreateApp.tsx
@@ -1,8 +1,12 @@
 import {PlusOutlined} from "@ant-design/icons"
-import {Card, Col, Input, Modal, Row, Typography} from "antd"
-import {useState} from "react"
+import {Card, Col, Input, Modal, Row, Typography, notification} from "antd"
+import {useState, useEffect} from "react"
 import YouTube from "react-youtube"
+import { Template, AppTemplate, TemplateImage } from "@/lib/Types"
+import { isAppNameInputValid } from "@/lib/helpers/utils"
+import {fetchApps, getTemplates, pullTemplateImage, startTemplate} from "@/lib/services/api"
 import AppTemplateCard from "./AppTemplateCard"
+
 
 export default function CreateApp() {
     const {Text, Title} = Typography
@@ -10,6 +14,8 @@ export default function CreateApp() {
     const [isCreateAppModalOpen, setIsCreateAppModalOpen] = useState(false)
     const [isCreateAppFromTemplateModalOpen, setIsCreateAppFromTemplateModalOpen] = useState(false)
     const [isWriteAppModalOpen, setIsWriteAppModalOpen] = useState(false)
+    const [templates, setTemplates] = useState<Template[]>([])
+    const [fetchingTemplate, setFetchingTemplate] = useState(false)
 
     const [newApp, setNewApp] = useState("")
 
@@ -38,6 +44,93 @@ export default function CreateApp() {
 
     const handleCreateAppModalCancel = () => {
         setIsCreateAppModalOpen(false)
+    }
+
+    useEffect(() => {
+        const fetchTemplates = async () => {
+            const data = await getTemplates()
+            setTemplates(data);
+        }
+
+        fetchTemplates()
+    }, []);
+
+    const fetchTemplateImage = async (image_name: string) => {
+        const response = await pullTemplateImage(image_name)
+        if (response) {
+            return response
+        } else {
+            notification.error({
+                message: 'Template Selection',
+                description: 'Failed to fetch template image. Please try again later.',
+                duration: 5,
+            });
+            return null
+        }
+    }
+
+    const retrieveOpenAIKey = () => {
+        const apiKey = localStorage.getItem('openAiToken')
+
+        if (apiKey) {
+            return apiKey
+        } else {
+            notification.error({
+                message: 'OpenAI API Key Missing',
+                description: 'Please provide your OpenAI API key to access this feature.',
+                duration: 5,
+            });
+            return null
+        }
+    }
+
+    const createAppVariantFromTemplateImage = async (app_name: string, image_id: string, image_tag: string) => {
+
+        const OpenAIKey = retrieveOpenAIKey() as string
+        const variantData: AppTemplate = {
+            app_name: app_name,
+            image_id: image_id,
+            image_tag: image_tag,
+            env_vars: {
+                OPENAI_API_KEY: OpenAIKey
+            }
+        }
+        const response  = await startTemplate(variantData)
+        if (response.status == 200) {
+            notification.success({
+                message: 'Template Selection',
+                description: 'App created and running.',
+                duration: 5,
+            });
+            return response
+        } else {
+            notification.error({
+                message: 'Template Selection',
+                description: 'An error occured when trying to start the variant. Ensure that you do not have a variant with the same app name.',
+                duration: 5,
+            });
+        }
+    }
+
+    const handleTemplateCardClick = async (image_name: string) => {
+        setFetchingTemplate(true)
+        
+        const data: TemplateImage = await fetchTemplateImage(image_name)
+        await createAppVariantFromTemplateImage(newApp, data.image_id, data.image_tag)
+
+        setNewApp("")
+        handleCreateAppFromTemplateModalCancel()
+        handleCreateAppModalCancel()
+        setFetchingTemplate(false)
+        
+    };
+
+    const appNameExist = () => {
+        const { data, error, isLoading } = fetchApps();
+        if (data) {
+            return data.some(app => app.app_name === newApp);
+        }
+        return false;
     }
 
     return (
@@ -117,25 +210,67 @@ export default function CreateApp() {
                 }}
             >
                 <Input
-                    placeholder="New app name"
+                    placeholder="New app name (e.g., chat-app)"
                     value={newApp}
                     onChange={(e) => setNewApp(e.target.value)}
                     style={{margin: "10px"}}
                 />
+                {appNameExist() === true && (
+                    <div style={{ color: 'red', marginLeft: "10px" }}>
+                        App name already exist
+                    </div>
+                )}
+                {newApp.length > 0 && !isAppNameInputValid(newApp) && (
+                    <div style={{ color: 'red', marginLeft: "10px" }}>
+                        App name must contain only letters, numbers, underscore, or dash
+                    </div>
+                )}
+
                 <div
                     style={{
-                        width: "100%",
-                        display: "flex",
-                        alignItems: "center",
-                        flexWrap: "wrap",
-                        justifyContent: "space-evenly",
-                        padding: "10px",
+                        width: '100%',
+                        display: 'flex',
+                        alignItems: 'center',
+                        flexWrap: 'wrap',
+                        justifyContent: 'space-evenly',
+                        padding: '10px',
                     }}
+
                 >
-                    <AppTemplateCard title="first" />
-                    <AppTemplateCard title="second" />
-                    <AppTemplateCard title="third" />
-                    <AppTemplateCard title="fourth" />
+                    {templates.map(template => (
+                        <div
+                            key={template.id}
+                            style={{
+                                cursor: newApp.length > 0 && isAppNameInputValid(newApp) ? 'pointer' : 'not-allowed',
+                            }}
+                        >
+                            <AppTemplateCard 
+                                title={template.image.name} 
+                                onClick={() => {
+                                    if (fetchingTemplate && newApp.length > 0 && isAppNameInputValid(newApp)) {
+                                        notification.info({
+                                            message: 'Template Selection',
+                                            description: 'The template image is currently being fetched. Please wait...',
+                                            duration: 2,
+                                        });
+                                    } else if (!fetchingTemplate && newApp.length > 0 && isAppNameInputValid(newApp)) {
+                                        notification.info({
+                                            message: 'Template Selection',
+                                            description: 'Fetching template image...',
+                                            duration: 10,
+                                        });
+                                        handleTemplateCardClick(template.image.name);
+                                    } else {
+                                        notification.warning({
+                                            message: 'Template Selection',
+                                            description: 'Please provide a valid app name to choose a template.',
+                                            duration: 3,
+                                        });
+                                    }
+                                }}
+                            />
+                        </div>
+                    ))}
                 </div>
             </Modal>
 

--- a/agenta-web/src/components/CreateApp/CreateApp.tsx
+++ b/agenta-web/src/components/CreateApp/CreateApp.tsx
@@ -17,6 +17,7 @@ export default function CreateApp() {
     const [templates, setTemplates] = useState<Template[]>([])
     const [fetchingTemplate, setFetchingTemplate] = useState(false)
 
+    const [appNameExist, setAppNameExist] = useState(false)
     const [newApp, setNewApp] = useState("")
 
     const showCreateAppModal = () => {
@@ -99,8 +100,8 @@ export default function CreateApp() {
         if (response.status == 200) {
             notification.success({
                 message: 'Template Selection',
-                description: 'App created and running.',
-                duration: 5,
+                description: 'App has been created and will begin to run.',
+                duration: 15,
             });
             return response
         } else {
@@ -109,6 +110,7 @@ export default function CreateApp() {
                 description: 'An error occured when trying to start the variant. Ensure that you do not have a variant with the same app name.',
                 duration: 5,
             });
+            setFetchingTemplate(false)
         }
     }
 
@@ -125,13 +127,12 @@ export default function CreateApp() {
         
     };
 
-    const appNameExist = () => {
-        const { data, error, isLoading } = fetchApps();
+    const { data, error, isLoading } = fetchApps();
+    useEffect(() => {
         if (data) {
-            return data.some(app => app.app_name === newApp);
+            setAppNameExist(data.some(app => app.app_name === newApp));
         }
-        return false;
-    }
+    }, [data, newApp]);
 
     return (
         <div>
@@ -215,7 +216,7 @@ export default function CreateApp() {
                     onChange={(e) => setNewApp(e.target.value)}
                     style={{margin: "10px"}}
                 />
-                {appNameExist() === true && (
+                {appNameExist && (
                     <div style={{ color: 'red', marginLeft: "10px" }}>
                         App name already exist
                     </div>
@@ -247,11 +248,17 @@ export default function CreateApp() {
                             <AppTemplateCard 
                                 title={template.image.name} 
                                 onClick={() => {
-                                    if (fetchingTemplate && newApp.length > 0 && isAppNameInputValid(newApp)) {
+                                    if (appNameExist) {
+                                        notification.warning({
+                                            message: 'Template Selection',
+                                            description: 'App name already exists. Please choose a different name.',
+                                            duration: 3,
+                                        });
+                                    } else if (fetchingTemplate && newApp.length > 0 && isAppNameInputValid(newApp)) {
                                         notification.info({
                                             message: 'Template Selection',
                                             description: 'The template image is currently being fetched. Please wait...',
-                                            duration: 2,
+                                            duration: 3,
                                         });
                                     } else if (!fetchingTemplate && newApp.length > 0 && isAppNameInputValid(newApp)) {
                                         notification.info({

--- a/agenta-web/src/components/Sidebar/Sidebar.tsx
+++ b/agenta-web/src/components/Sidebar/Sidebar.tsx
@@ -54,6 +54,8 @@ const Sidebar: React.FC = () => {
     const getNavigationPath = (path: string) => {
         if (path === "apps") {
             return "/apps"
+        } else if (path === "keys") {
+            return "/apikeys";
         } else {
             return `/apps/${app_name}/${path}`
         }
@@ -207,6 +209,22 @@ const Sidebar: React.FC = () => {
                     style={{paddingBottom: 24, borderRight: 0}}
                     selectedKeys={selectedKeys}
                 >
+                    <Menu.Item key="apikeys" icon={<LockOutlined />}>
+                        <Tooltip
+                            placement="right"
+                            title="Your api keys that are used in applications"
+                        >
+                            <Link
+                                data-cy="apikeys-link"
+                                href={getNavigationPath("keys")}
+                                style={{width: "100%"}}
+                            >
+                                <Space>
+                                    <span>API keys</span>
+                                </Space>
+                            </Link>
+                        </Tooltip>
+                    </Menu.Item>
                     <Menu.Item key="theme" icon={<DashboardOutlined />} onClick={toggleAppTheme}>
                         <span>{appTheme === "light" ? "Dark mode" : "Light mode"}</span>
                     </Menu.Item>

--- a/agenta-web/src/lib/Types.ts
+++ b/agenta-web/src/lib/Types.ts
@@ -100,10 +100,15 @@ export interface InputParameter {
 }
 
 export interface Template {
-    id: number;
+    id: number
     image: {
-        name: string;
-    };
+        name: string
+    }
+}
+
+export interface TemplateImage {
+    image_tag: string
+    image_id: string
 }
 
 export interface AppTemplate {

--- a/agenta-web/src/lib/Types.ts
+++ b/agenta-web/src/lib/Types.ts
@@ -115,4 +115,7 @@ export interface AppTemplate {
     app_name: string
     image_id: string
     image_tag: string
+    env_vars: {
+        OPENAI_API_KEY: string
+    }
 }

--- a/agenta-web/src/lib/Types.ts
+++ b/agenta-web/src/lib/Types.ts
@@ -99,4 +99,15 @@ export interface InputParameter {
     name: string
 }
 
-export interface AppTemplate {}
+export interface Template {
+    id: number;
+    image: {
+        name: string;
+    };
+}
+
+export interface AppTemplate {
+    app_name: string
+    image_id: string
+    image_tag: string
+}

--- a/agenta-web/src/lib/helpers/utils.ts
+++ b/agenta-web/src/lib/helpers/utils.ts
@@ -61,3 +61,8 @@ export const randString = (len: number) =>
         )
         .replace(/[+/]/g, "")
         .substring(0, len)
+
+
+export const isAppNameInputValid = (input: string) => {
+    return /^[a-zA-Z0-9_-]+$/.test(input);
+};

--- a/agenta-web/src/lib/services/api.ts
+++ b/agenta-web/src/lib/services/api.ts
@@ -413,5 +413,38 @@ export const getTemplates = async () => {
     });
 }
 
-// TODO: integrate with endpoint, improve templateObj type
-export const startTemplate = async (appName: string, templateObj: AppTemplate) => {}
+export const pullTemplateImage = async (image_name: string) => {
+    return fetch(`${process.env.NEXT_PUBLIC_AGENTA_API_URL}/api/containers/templates/${image_name}/images/`, {
+        headers: {
+            "Content-Type": "application/json",
+        },
+    })
+    .then(response => response.json())
+    .then(data => {
+        return data
+    })
+    .catch(error => {
+        console.error('Error fetching template image:', error);
+        throw error
+    });
+}
+
+export const startTemplate = async (templateObj: AppTemplate) => {
+    try {
+        const response = await axios.post(
+            `${process.env.NEXT_PUBLIC_AGENTA_API_URL}/api/containers/variants/create/`,
+            templateObj,
+            {
+                headers: {
+                    accept: "application/json",
+                    "Content-Type": "application/json",
+                },
+            }
+            
+        )
+        return response
+    } catch (error) {
+        console.error(error)
+        throw error
+    }
+}

--- a/agenta-web/src/lib/services/api.ts
+++ b/agenta-web/src/lib/services/api.ts
@@ -398,8 +398,20 @@ export const fetchEvaluationResults = async (evaluationId: string) => {
     }
 }
 
-// TODO: integrate with endpoint
-export const getTemplates = async () => {}
+export const getTemplates = async () => {
+    return fetch(`${process.env.NEXT_PUBLIC_AGENTA_API_URL}/api/containers/templates/`, {
+        headers: {
+            "Content-Type": "application/json",
+        },
+    })
+    .then(response => response.json())
+    .then(data => {
+        return data
+    })
+    .catch(error => {
+        console.error('Error fetching templates:', error);
+    });
+}
 
 // TODO: integrate with endpoint, improve templateObj type
 export const startTemplate = async (appName: string, templateObj: AppTemplate) => {}

--- a/agenta-web/src/lib/services/api.ts
+++ b/agenta-web/src/lib/services/api.ts
@@ -398,6 +398,18 @@ export const fetchEvaluationResults = async (evaluationId: string) => {
     }
 }
 
+export const fetchApps = () => {
+    const {data, error, isLoading} = useSWR(
+        `${process.env.NEXT_PUBLIC_AGENTA_API_URL}/api/app_variant/list_apps/`,
+        fetcher,
+    )
+    return {
+        data: data,
+        error: error,
+        isLoading: isLoading
+    }
+}
+
 export const getTemplates = async () => {
     return fetch(`${process.env.NEXT_PUBLIC_AGENTA_API_URL}/api/containers/templates/`, {
         headers: {

--- a/agenta-web/src/pages/apikeys.tsx
+++ b/agenta-web/src/pages/apikeys.tsx
@@ -1,0 +1,5 @@
+import ApiKeys from "@/components/ApiKeys/ApiKeys"
+
+export default function Key() {
+    return <ApiKeys />
+}


### PR DESCRIPTION
## Description
Integrated backend and frontend for starting with template option.

## Related Issue
Closes #316

## Checklist
- [x]  App screen using the backend to get the list of available templates
- [x] Clicking on the template calls the backend with the api key to start the template and adds the variant
- [x] API Key view should come in the main app menu

Please review the changes and provide feedback. Let me know if any further adjustments are needed.