### PR TITLE
Ehancement - Add Error Message for Missing Templates and Reorder API Key Check

### DIFF
--- a/agenta-backend/agenta_backend/routers/container_router.py
+++ b/agenta-backend/agenta_backend/routers/container_router.py
@@ -1,7 +1,7 @@
 import uuid
 import asyncio
-from typing import List
 from pathlib import Path
+from typing import List, Union
 from fastapi import UploadFile, APIRouter
 from fastapi.responses import JSONResponse
 from agenta_backend.config import settings
@@ -78,15 +78,15 @@ async def build_image(app_name: str, variant_name: str, tar_file: UploadFile) ->
 
 
 @router.get("/templates/")
-async def container_templates() -> List[Template]:
+async def container_templates() -> Union[List[Template], str]:
     """Returns a list of container templates.
 
     Returns:
         a list of `Template` objects.
     """
-    docker_arch = await check_docker_arch()
+    docker_arch =  await check_docker_arch()
     if docker_arch == "unknown":
-        return []
+        return "No templates were found, this is a mistake, please fill an issue"
     templates = get_templates(docker_arch)
     return templates
 

--- a/agenta-web/src/components/CreateApp/AppTemplateCard.tsx
+++ b/agenta-web/src/components/CreateApp/AppTemplateCard.tsx
@@ -3,9 +3,11 @@ import {Card, Typography} from "antd"
 interface Props {
     title: string
     onClick: () => void
+    body: string
+    noTemplate: boolean
 }
 
-const AppTemplateCard: React.FC<Props> = ({title, onClick}) => {
+const AppTemplateCard: React.FC<Props> = ({title, onClick, body, noTemplate}) => {
     const {Text} = Typography
     return (
         <Card
@@ -20,7 +22,17 @@ const AppTemplateCard: React.FC<Props> = ({title, onClick}) => {
             }}
             onClick={onClick}
         >
-            <Text>{title}</Text>
+            <Text style={{
+                marginTop: "0px",
+            }}>{title}</Text>
+           
+           {noTemplate ? (
+                <p>
+                   {body} <a href="https://github.com/Agenta-AI/agenta/issues/new">here</a>.
+                </p>
+            ) : (
+                <p>{body}</p>
+            )}
         </Card>
     )
 }


### PR DESCRIPTION
### Issue 1: Error Message for Missing Templates
When templates are unavailable due to an unknown architecture, an error message now informs users with clarity. The message reads: "No templates were found, this is a mistake. Please [fill an issue](https://github.com/Agenta-AI/agenta/issues/new)." This provides better feedback and guidance to users.

### Issue 2: API Key Logic Improvement
I've reorganized the API key logic to prioritize user experience. Now, before attempting to fetch and start an image, we first confirm the presence of an API key. If no key is found, a modal prompts users to navigate to the API key view. This enhances usability and reduces errors.

Please review and provide your insights on these enhancements. Thank you!