### PR TITLE
Refactor - move /container/variants/create to app_variant router

### DIFF
--- a/agenta-web/src/lib/services/api.ts
+++ b/agenta-web/src/lib/services/api.ts
@@ -447,7 +447,7 @@ export const pullTemplateImage = async (image_name: string) => {
 export const startTemplate = async (templateObj: AppTemplate) => {
     try {
         const response = await axios.post(
-            `${process.env.NEXT_PUBLIC_AGENTA_API_URL}/api/containers/variants/create/`,
+            `${process.env.NEXT_PUBLIC_AGENTA_API_URL}/api/app_variant/add/from_template/`,
             templateObj,
             {
                 headers: {
@@ -458,7 +458,7 @@ export const startTemplate = async (templateObj: AppTemplate) => {
         )
         return response
     } catch (error) {
-        console.error(error)
+        console.error("Start Template Error => ", error)
         throw error
     }
 }


### PR DESCRIPTION
This pull request addresses the task of refactoring the backend code to enhance code organization. The endpoint `/container/variants/create` has been relocated from the container router to the app_variant router. 