### PR TITLE
Enhancement/#304 speed up docker build time

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -2,6 +2,7 @@
 /docs/_build/
 __pycache__/
 .env
+env/
 tests/poetry.lock
 agenta-cli/agenta/templates/main.py
 agenta-cli/agenta/templates/agenta.py

--- a/agenta-cli/agenta/docker/docker-assets/Dockerfile.template
+++ b/agenta-cli/agenta/docker/docker-assets/Dockerfile.template
@@ -13,4 +13,3 @@ EXPOSE 80
 
 CMD ["./entrypoint.sh"]
 # uvicorn agenta_backend.main:app --reload --host 0.0.0.0 --port 8881
-# TODO: add root_path as env variable and give it to the docker to solve the docs issue

--- a/agenta-cli/agenta/docker/docker-assets/Dockerfile.template
+++ b/agenta-cli/agenta/docker/docker-assets/Dockerfile.template
@@ -1,4 +1,4 @@
-FROM devgenix/agenta-llm-template:latest
+FROM agentaai/templates:main
 
 ARG ROOT_PATH=/
 ENV ROOT_PATH=${ROOT_PATH}

--- a/agenta-cli/agenta/docker/docker-assets/Dockerfile.template
+++ b/agenta-cli/agenta/docker/docker-assets/Dockerfile.template
@@ -1,4 +1,4 @@
-FROM python:3.10-slim
+FROM devgenix/agenta-llm-template:latest
 
 ARG ROOT_PATH=/
 ENV ROOT_PATH=${ROOT_PATH}
@@ -7,10 +7,8 @@ WORKDIR /app
 
 COPY . .
 
-RUN pip install --upgrade pip && \
-    pip install --no-cache-dir -r requirements.txt
+RUN pip install --no-cache-dir -r requirements.txt
 
-RUN pip install fastapi uvicorn python-dotenv
 EXPOSE 80
 
 CMD ["./entrypoint.sh"]

--- a/agenta-cli/agenta/templates/simple_prompt/requirements.txt
+++ b/agenta-cli/agenta/templates/simple_prompt/requirements.txt
@@ -1,3 +1,0 @@
-langchain
-openai
-agenta


### PR DESCRIPTION
This PR adds functionality to speed up build times for docker images at variant serve by using an already built base template image.
When merged, this PR closes #304 

Here is the template dockerfile for the template image at https://hub.docker.com/r/devgenix/agenta-llm-template:

```
FROM python:3.10-slim

# Install common dependencies for all images
RUN pip install --upgrade pip \
    && pip install poetry \
    && pip install langchain agenta fastapi llama_index openai cohere python-dotenv fastapi uvicorn

```

Testing locally, this cuts the build time from 10+ minutes to less than a minute. 