### PR TITLE
Add support for Azure, Llama2, Palm VertexAI, Cohere, Anthropic, Replicate Models - using litellm 

### DIFF
--- a/agenta-backend/pyproject.toml
+++ b/agenta-backend/pyproject.toml
@@ -17,6 +17,7 @@ sqlmodel = "^0.0.8"
 motor = "^3.1.2"
 python-multipart = "^0.0.6"
 openai = "^0.27.8"
+litellm = "^0.1.400"
 langchain = "^0.0.256"
 
 

--- a/examples/baby_name_generator/app.py
+++ b/examples/baby_name_generator/app.py
@@ -1,6 +1,7 @@
 import os
 
 import openai
+from litellm import completion
 from agenta import FloatParam, TextParam, post
 from fastapi import Body
 from jinja2 import Template
@@ -19,9 +20,9 @@ def generate(
     prompt = template.render(country=country, gender=gender)
 
     openai.api_key = os.environ.get("OPENAI_API_KEY")  # make sure to set this manually!
-    chat_completion = openai.ChatCompletion.create(
+    chat_completion = completion(
         model="gpt-3.5-turbo", messages=[{"role": "user", "content": prompt}]
     )
 
-    result = chat_completion.choices[0].message.content
+    result = chat_completion['choices'][0]['message']['content']
     return result


### PR DESCRIPTION
This PR adds support for models from all the above mentioned providers using https://github.com/BerriAI/litellm/

Here's a sample of how it's used:

```python
from litellm import completion, acompletion

## set ENV variables
# ENV variables can be set in .env file, too. Example in .env.example
os.environ["OPENAI_API_KEY"] = "openai key"
os.environ["COHERE_API_KEY"] = "cohere key"

messages = [{ "content": "Hello, how are you?","role": "user"}]

# openai call
response = completion(model="gpt-3.5-turbo", messages=messages)

# llama2 call
model_name = "replicate/llama-2-70b-chat:2c1608e18606fad2812020dc541930f2d0495ce32eee50074220b87300bc16e1"
response = completion(model_name, messages)

# cohere call
response = completion("command-nightly", messages)

# anthropic call
response = completion(model="claude-instant-1", messages=messages)
```
