### PR TITLE
feat: created and use production dockerfile for web

### DIFF
--- a/agenta-web/prod.Dockerfile
+++ b/agenta-web/prod.Dockerfile
@@ -1,0 +1,20 @@
+FROM node:18-alpine
+
+WORKDIR /app
+
+# Install only production dependencies
+COPY package.json package-lock.json* ./
+RUN npm ci --omit=dev
+
+# Copy only necessary files
+COPY src ./src
+COPY public ./public
+COPY next.config.js .
+COPY tsconfig.json .
+COPY postcss.config.js .
+
+# Build the Next.js app for production
+RUN npm run build
+
+# Start the production server
+CMD ["npm", "start"]

--- a/docker-compose.prod.yml
+++ b/docker-compose.prod.yml
@@ -48,11 +48,11 @@ services:
   agenta-web:
     build:
       context: ./agenta-web
-      dockerfile: dev.Dockerfile
+      dockerfile: prod.Dockerfile
     volumes:
       - ./agenta-web/src:/app/src
       - ./agenta-web/public:/app/public
-      - ./agenta-web/.env.development.local:/app/.env.development.local
+      # - ./agenta-web/.env.development.local:/app/.env.development.local
     ports:
       - "3000:3000"
     environment:


### PR DESCRIPTION
In this PR, I have:

- [x] Create a Production optimized Dockerfile as `prod.Dockerfile` for Agenta Web
- [x] Use the prod.Dockerfile image in docker-compose.prod.yaml for Production.

When merged, this PR closes #275 but is not yet ready to merge and I need help.

## Issues
Although the prod.Dockerfile created is for building and starting next.js in Production, while testing locally I kept running into issues while running `npm run build` that I couldn't fix. 

first I ran into issues with js-beautify:

```
 > [agenta_agenta-web 10/10] RUN npm run build:
#0 0.590 
#0 0.590 > dashboard@0.1.0 build
#0 0.590 > next build
#0 0.590 
#0 1.140 info  - Linting and checking validity of types...
#0 8.813 Failed to compile.
#0 8.813 
#0 8.813 ./src/code_snippets/endpoints/typescript.ts:1:30
#0 8.813 Type error: Could not find a declaration file for module 'js-beautify'. '/app/node_modules/js-beautify/js/index.js' implicitly has an 'any' type.
#0 8.813   Try `npm i --save-dev @types/js-beautify` if it exists or add a new declaration (.d.ts) file containing `declare module 'js-beautify';`
#0 8.813 
#0 8.813 > 1 | import {js as beautify} from "js-beautify"
#0 8.813     |                              ^
#0 8.813   2 | 
#0 8.813   3 | export default function tsCode(uri: string, params: string): string {
#0 8.813   4 |     const codeString = `import axios from 'axios';
------
failed to solve: executor failed running [/bin/sh -c npm run build]: exit code: 1
```

Then this:

```
 > [agenta_agenta-web 10/10] RUN npm run build:
#0 0.606 
#0 0.606 > dashboard@0.1.0 build
#0 0.606 > next build
#0 0.606 
#0 1.178 info  - Linting and checking validity of types...
#0 9.084 Failed to compile.
#0 9.084 
#0 9.084 ./src/components/AppSelector/AppSelector.tsx:10:43
#0 9.084 Type error: A spread argument must either have a tuple type or be passed to a rest parameter.
#0 9.084 
#0 9.084    8 | import TipsAndFeatures from "./TipsAndFeatures"
#0 9.084    9 | 
#0 9.084 > 10 | const fetcher = (...args: any[]) => fetch(...args).then((res) => res.json())
#0 9.084      |                                           ^
#0 9.084   11 | 
#0 9.084   12 | const AppSelector: React.FC = () => {
#0 9.084   13 |     const [newApp, setNewApp] = useState("")
------
failed to solve: executor failed running [/bin/sh -c npm run build]: exit code: 1
```

Without running docker compose and only running `npm run build` in the agenta-web folder, I get tons of errors:

<img width="1480" alt="image" src="https://github.com/Agenta-AI/agenta/assets/56418363/764418c6-9518-48c5-af6e-fb4ddb9a8f11">

As a result, I'm of the opinion that agenta-web is not optimized for production builds yet. 