### PR TITLE
Warn users when they leave the playground without saving a variant

### DIFF
--- a/agenta-web/src/components/Playground/ViewNavigation.tsx
+++ b/agenta-web/src/components/Playground/ViewNavigation.tsx
@@ -45,7 +45,7 @@ const ViewNavigation: React.FC<Props> = ({
     useBlockNavigation(unSavedChanges, {
         title: "Unsaved changes",
         message:
-            "You have unsaved changes in your test set. Do you want to save these changes before leaving the page?",
+            "You have unsaved changes in your playground. Do you want to save these changes before leaving the page?",
         okText: "Save",
         onOk: async () => {
             await saveOptParams(optParams!, true, variant.persistent)

--- a/agenta-web/src/components/Playground/ViewNavigation.tsx
+++ b/agenta-web/src/components/Playground/ViewNavigation.tsx
@@ -7,6 +7,9 @@ import {Variant} from "@/lib/Types"
 import {useRouter} from "next/router"
 import {useState} from "react"
 import {is} from "cypress/types/bluebird"
+import useBlockNavigation from "@/hooks/useBlockNavigation"
+import {useUpdateEffect} from "usehooks-ts"
+import useStateCallback from "@/hooks/useStateCallback"
 
 interface Props {
     variant: Variant
@@ -34,7 +37,28 @@ const ViewNavigation: React.FC<Props> = ({
         isParamSaveLoading,
         saveOptParams,
         isLoading,
+        isChanged,
     } = useVariant(appName, variant)
+
+    const [unSavedChanges, setUnSavedChanges] = useStateCallback(false)
+
+    useBlockNavigation(unSavedChanges, {
+        title: "Unsaved changes",
+        message:
+            "You have unsaved changes in your test set. Do you want to save these changes before leaving the page?",
+        okText: "Save",
+        onOk: async () => {
+            await saveOptParams(optParams!, true, variant.persistent)
+            return !!optParams
+        },
+        cancelText: "Proceed without saving",
+    })
+
+    useUpdateEffect(() => {
+        if (isChanged) {
+            setUnSavedChanges(true)
+        }
+    }, [optParams])
 
     const [isParamsCollapsed, setIsParamsCollapsed] = useState("1")
 

--- a/agenta-web/src/lib/hooks/useVariant.ts
+++ b/agenta-web/src/lib/hooks/useVariant.ts
@@ -22,7 +22,7 @@ export function useVariant(appName: string, variant: Variant) {
     const [isError, setIsError] = useState(false)
     const [error, setError] = useState<Error | null>(null)
     const [isParamSaveLoading, setIsParamSaveLoading] = useState(false)
-    const [isChanged, setIsChanged] = useState(false);
+    const [isChanged, setIsChanged] = useState(false)
 
     useEffect(() => {
         const fetchParameters = async () => {
@@ -50,7 +50,7 @@ export function useVariant(appName: string, variant: Variant) {
 
         return () => {
             setTimeout(() => {
-setIsChanged(true)
+                setIsChanged(true)
             }, 100)
         }
     }, [appName, variant])
@@ -100,6 +100,6 @@ setIsChanged(true)
         error,
         isParamSaveLoading,
         saveOptParams,
-        isChanged
+        isChanged,
     }
 }

--- a/agenta-web/src/lib/hooks/useVariant.ts
+++ b/agenta-web/src/lib/hooks/useVariant.ts
@@ -22,9 +22,11 @@ export function useVariant(appName: string, variant: Variant) {
     const [isError, setIsError] = useState(false)
     const [error, setError] = useState<Error | null>(null)
     const [isParamSaveLoading, setIsParamSaveLoading] = useState(false)
+    const [isChanged, setIsChanged] = useState(false);
 
     useEffect(() => {
         const fetchParameters = async () => {
+            setIsChanged(false)
             setIsLoading(true)
             setIsError(false)
             try {
@@ -45,6 +47,12 @@ export function useVariant(appName: string, variant: Variant) {
         }
 
         fetchParameters()
+
+        return () => {
+            setTimeout(() => {
+setIsChanged(true)
+            }, 100)
+        }
     }, [appName, variant])
 
     useEffect(() => {
@@ -92,5 +100,6 @@ export function useVariant(appName: string, variant: Variant) {
         error,
         isParamSaveLoading,
         saveOptParams,
+        isChanged
     }
 }


### PR DESCRIPTION
issue #340 : Warn users if they attempt to navigate outside of the playground with an unsaved configuration.