### PR TITLE
Enhancement - speed up starting a template from UI

### DIFF
--- a/agenta-backend/agenta_backend/main.py
+++ b/agenta-backend/agenta_backend/main.py
@@ -44,8 +44,8 @@ async def lifespan(application: FastAPI, cache=True):
     repo_name = settings.docker_hub_repo_name
 
     tags_data = await retrieve_templates_from_dockerhub_cached(cache=cache)
-    templates_info_string = (
-        await retrieve_templates_info_from_dockerhub_cached(cache=cache)
+    templates_info_string = await retrieve_templates_info_from_dockerhub_cached(
+        cache=cache
     )
     templates_info = json.loads(templates_info_string)
 
@@ -76,9 +76,7 @@ async def lifespan(application: FastAPI, cache=True):
                     f"{repo_owner}/{repo_name}", tag["name"]
                 )
                 print(f"Template {tag['id']} added to the database.")
-                print(
-                    f"Template Image {image_res[0]['id']} pulled from DockerHub."
-                )
+                print(f"Template Image {image_res[0]['id']} pulled from DockerHub.")
 
     # Remove old templates from database
     remove_old_template_from_db(templates_in_hub)

--- a/agenta-backend/agenta_backend/main.py
+++ b/agenta-backend/agenta_backend/main.py
@@ -1,6 +1,7 @@
 import json
 from fastapi import FastAPI
 
+from agenta_backend.config import settings
 from agenta_backend.routers import app_variant
 from agenta_backend.routers import testset_router
 from fastapi.middleware.cors import CORSMiddleware
@@ -9,6 +10,9 @@ from agenta_backend.routers import evaluation_router
 from agenta_backend.services.db_manager import (
     add_template,
     remove_old_template_from_db,
+)
+from agenta_backend.services.container_manager import (
+    pull_image_from_docker_hub,
 )
 from agenta_backend.services.cache_manager import (
     retrieve_templates_from_dockerhub_cached,
@@ -35,9 +39,13 @@ async def lifespan(application: FastAPI, cache=True):
         application: FastAPI application.
         cache: A boolean value that indicates whether to use the cached data or not.
     """
+    # Get docker hub config
+    repo_owner = settings.docker_hub_repo_owner
+    repo_name = settings.docker_hub_repo_name
+
     tags_data = await retrieve_templates_from_dockerhub_cached(cache=cache)
-    templates_info_string = await retrieve_templates_info_from_dockerhub_cached(
-        cache=cache
+    templates_info_string = (
+        await retrieve_templates_info_from_dockerhub_cached(cache=cache)
     )
     templates_info = json.loads(templates_info_string)
 
@@ -64,7 +72,13 @@ async def lifespan(application: FastAPI, cache=True):
                         "media_type": tag["media_type"],
                     }
                 )
+                image_res = await pull_image_from_docker_hub(
+                    f"{repo_owner}/{repo_name}", tag["name"]
+                )
                 print(f"Template {tag['id']} added to the database.")
+                print(
+                    f"Template Image {image_res[0]['id']} pulled from DockerHub."
+                )
 
     # Remove old templates from database
     remove_old_template_from_db(templates_in_hub)

--- a/agenta-backend/agenta_backend/routers/container_router.py
+++ b/agenta-backend/agenta_backend/routers/container_router.py
@@ -11,7 +11,6 @@ from agenta_backend.services.db_manager import get_templates
 from agenta_backend.models.api.api_models import Image, Template
 from agenta_backend.services.container_manager import (
     build_image_job,
-    check_docker_arch,
     get_image_details_from_docker_hub,
     pull_image_from_docker_hub,
 )


### PR DESCRIPTION
## Description
This PR address the issue of starting a template from UI for being relatively slow. Setting up a logic to pull the container image(s) when the template for the container has been fetched from Docker Hub solved the issue.

### Related Issue
Closes #423 

Please review and let me know if there are any improvements that I need to make. Thank you.