### PR TITLE
feat: publish w poetry on version change

### DIFF
--- a/.github/workflows/publish.yml
+++ b/.github/workflows/publish.yml
@@ -1,4 +1,4 @@
-name: Publish Python Package
+name: Publish Agenta to PyPI
 
 on:
   push:
@@ -23,7 +23,7 @@ jobs:
       run: |
         curl -sSL https://install.python-poetry.org | python3 -
 
-    - name: Check for version changes
+    - name: Check for agenta version changes
       id: version_check
       run: |
         cd ../../agenta-cli
@@ -36,7 +36,7 @@ jobs:
         echo "::set-output name=version_bumped::true"
       shell: bash
 
-    - name: Build and publish
+    - name: Build and publish agenta to PyPI
       if: steps.version_check.outputs.version_bumped == 'true'
       run: |
         cd ../../agenta-cli

--- a/.github/workflows/publish.yml
+++ b/.github/workflows/publish.yml
@@ -2,6 +2,8 @@ name: Publish Python Package
 
 on:
   push:
+    branches:
+      - main
     paths:
       - '../../agenta-cli/pyproject.toml'
 

--- a/.github/workflows/publish.yml
+++ b/.github/workflows/publish.yml
@@ -1,0 +1,43 @@
+name: Publish Python Package
+
+on:
+  push:
+    paths:
+      - '../../agenta-cli/pyproject.toml'
+
+jobs:
+  deploy:
+    runs-on: ubuntu-latest
+    steps:
+    - name: Check out the repo
+      uses: actions/checkout@v2
+
+    - name: Set up Python
+      uses: actions/setup-python@v2
+      with:
+        python-version: 3.9
+
+    - name: Install poetry
+      run: |
+        curl -sSL https://install.python-poetry.org | python3 -
+
+    - name: Check for version changes
+      id: version_check
+      run: |
+        cd ../../agenta-cli
+        previous_version=$(git describe --abbrev=0 --tags)
+        current_version=$(poetry version --no-interaction | awk '{print $2}')
+        if [ "$previous_version" == "$current_version" ]; then
+          echo "No version change detected. Skipping package publication."
+          exit 0
+        fi
+        echo "::set-output name=version_bumped::true"
+      shell: bash
+
+    - name: Build and publish
+      if: steps.version_check.outputs.version_bumped == 'true'
+      run: |
+        cd ../../agenta-cli
+        poetry build
+        poetry publish --username __token__ --password ${{ secrets.PYPI_API_TOKEN }}
+    


### PR DESCRIPTION
when merged, this PR closes #273 

I've worked on;
- [x] Detecting a version change between the existing release version on GitHub and the version in agenta-cli/pyproject.toml
- [x] If change is detected, build and publish to PyPI

## Note:
- [x] A GitHub Repository Secret 'PYPI_API_TOKEN' needs to be set for the workflow to be able to deploy to PyPI
