### PR TITLE
Troubleshooting - Agenta web failing

### DIFF
--- a/docs/howto/how-to-debug.mdx
+++ b/docs/howto/how-to-debug.mdx
@@ -10,6 +10,7 @@ title: Troubleshooting
     3. [Failure Running Serve](#failure-running-serve)
     4. [Web UI Errors](#web-ui-errors)
     5. [Gateway Error](#gateway-error)
+    6. [Agenta Web Failing](#agenta-web-failing)
 4. [Reporting Issues](#Reporting-Issues)
 
 ## Introduction
@@ -132,9 +133,20 @@ docker volume ls -q -f "name=agenta-*"
 docker volume rm VOLUME_NAME
 ```
 
-Once you have completed these steps, start the application again by running `docker-compose up` and access the backend server by making requests to `http://localhost:8000`. 
+Once you have completed these steps, start the application again by running `docker compose up` and access the backend server by making requests to `http://localhost:8000`. 
 If the issue persists after following these troubleshooting steps, it's essential to investigate further into the Traefik configuration and the interaction between Traefik and the backend server.
 
+### Agenta Web Failing
+
+When accessing the apps page on the frontend, you encounter "failed to load". Proceed to check the logs of the backend server, this could be an `OperationError` problem caused by the database, 
+due to the fact that a column does not exist in a table. 
+
+To resolve this issue:
+
+1. In the `agenta_backend` directory, navigate to the `db` directory, delete `deploy.db` and restart compose 
+2. If the above does not work for you, navigate to the `db_manager.py` module in `agenta_backend/agenta_backend/services/`, and scroll down to line 24 (it might be 22 or 26 on your machine). Change `.create_all(engine)` to `.drop_all(engine)`, after the backend has restarted, change it back to `.create_all(engine)`
+
+Once you have completed either or both of these steps, restart the application again by running `docker compose up`.
 
 ## Reporting Issues
 

--- a/docs/howto/how-to-debug.mdx
+++ b/docs/howto/how-to-debug.mdx
@@ -138,15 +138,21 @@ If the issue persists after following these troubleshooting steps, it's essentia
 
 ### Agenta Web Failing
 
-When accessing the apps page on the frontend, you encounter "failed to load". Proceed to check the logs of the backend server, this could be an `OperationError` problem caused by the database, 
-due to the fact that a column does not exist in a table. 
+Upon attempting to access the apps page on the frontend, an error message stating "failed to load" is encountered. To address this, investigate the logs of the backend server, as this issue might be caused by an OperationError related to the database. Specifically, this could be due to the absence of a column in a table.
 
-To resolve this issue:
+To resolve this problem, follow these steps:
 
-1. In the `agenta_backend` directory, navigate to the `db` directory, delete `deploy.db` and restart compose 
-2. If the above does not work for you, navigate to the `db_manager.py` module in `agenta_backend/agenta_backend/services/`, and scroll down to line 24 (it might be 22 or 26 on your machine). Change `.create_all(engine)` to `.drop_all(engine)`, after the backend has restarted, change it back to `.create_all(engine)`
+1. Navigate to the `db` directory within the `agenta_backend` directory.
+2. Delete the `deploy.db` file.
+3. Restart the application by runing `docker compose up`.
 
-Once you have completed either or both of these steps, restart the application again by running `docker compose up`.
+If the above steps do not yield a solution, proceed as follows:
+
+1. Locate the `db_manager.py` module in `agenta_backend/agenta_backend/services/`.
+2. Scroll down to line 24 (note that the line number might be 22 or 26 on different systems).
+3. Temporarily replace `.create_all(engine)` with `.drop_all(engine)`.
+4. After restarting the backend, revert the change back to `.create_all(engine)`.
+5. After completing either or both of these steps, restart the application by running `docker compose up`.
 
 ## Reporting Issues
 

--- a/docs/howto/how-to-debug.mdx
+++ b/docs/howto/how-to-debug.mdx
@@ -124,10 +124,13 @@ To resolve this issue:
 Verify that the relevant Traefik rule in the `docker-compose.yml` file is properly configured.
 
 2. Prune Docker Resources: kindly follow the commands below to stop and remove all the agenta containers; and to finally prune all the volumes associated with it. 
-- docker stop $(docker ps -q -f "name=agenta-*")
-- docker rm $(docker ps -aq -f "name=agenta-*")
-- docker volume ls -q -f "name=agenta-*"
-- docker volume rm VOLUME_NAME
+
+```bash
+docker stop $(docker ps -q -f "name=agenta-*")
+docker rm $(docker ps -aq -f "name=agenta-*")
+docker volume ls -q -f "name=agenta-*"
+docker volume rm VOLUME_NAME
+```
 
 Once you have completed these steps, start the application again by running `docker-compose up` and access the backend server by making requests to `http://localhost:8000`. 
 If the issue persists after following these troubleshooting steps, it's essential to investigate further into the Traefik configuration and the interaction between Traefik and the backend server.


### PR DESCRIPTION
## Description

When trying to access the apps page on the frontend, an error message appears saying "failed to load" due to an OperationError linked to the database, more specifically the absence of a column in a table. This PR addresses this issue by including a troubleshooting guide in the documentation.
