### PR TITLE
update: remove path limitation

### DIFF
--- a/.github/workflows/publish.yml
+++ b/.github/workflows/publish.yml
@@ -4,8 +4,6 @@ on:
   push:
     branches:
       - main
-    paths:
-      - '../../agenta-cli/pyproject.toml'
 
 jobs:
   deploy:


### PR DESCRIPTION
@mmabrouk Suspected issue for why this didn't work is the path limitation I set in the workflow which specifies that the workflow should only run when a push event happens on the main branch and the `pyproject.toml` was modified. 

I've now removed that and the workflow should run whenever main is updated. 