### PR TITLE
#543 improve error message when failing to serve variant

### DIFF
--- a/agenta-cli/agenta/cli/helper.py
+++ b/agenta-cli/agenta/cli/helper.py
@@ -2,6 +2,8 @@ from pathlib import Path
 from typing import Any, List, MutableMapping
 import click
 import toml
+import sys
+import traceback
 from agenta.client import client
 from agenta.client.api_models import AppVariant
 
@@ -70,3 +72,13 @@ def display_app_variant(variant: AppVariant):
     click.echo(
         click.style("-" * 50, bold=True, fg="white")
     )  # a line for separating each variant
+
+
+def trace_error(file_name, function_name, message=None, e=None):
+    if message != None and e != None:
+        error_msg = f"Trace: Failed at {file_name}.{function_name}\n\nMessage: {message}:\n\nError: {str(e)}\n\n" 
+    elif e == None and message != None:
+        error_msg = f"Trace: Failed at {file_name}.{function_name}\n\nMessage: {message}\n\n"
+    elif message == None and e != None:
+        error_msg = f"Trace: Failed at {file_name}.{function_name}\n\Error: {e}\n\n"
+    click.echo(click.style(error_msg, fg="red"))

--- a/agenta-cli/agenta/cli/helper.py
+++ b/agenta-cli/agenta/cli/helper.py
@@ -76,9 +76,11 @@ def display_app_variant(variant: AppVariant):
 
 def trace_error(file_name, function_name, message=None, e=None):
     if message != None and e != None:
-        error_msg = f"Trace: Failed at {file_name}.{function_name}\n\nMessage: {message}:\n\nError: {str(e)}\n\n" 
+        error_msg = f"Trace: Failed at {file_name}.{function_name}\n\nMessage: {message}:\n\nError: {str(e)}\n\n"
     elif e == None and message != None:
-        error_msg = f"Trace: Failed at {file_name}.{function_name}\n\nMessage: {message}\n\n"
+        error_msg = (
+            f"Trace: Failed at {file_name}.{function_name}\n\nMessage: {message}\n\n"
+        )
     elif message == None and e != None:
         error_msg = f"Trace: Failed at {file_name}.{function_name}\n\Error: {e}\n\n"
     click.echo(click.style(error_msg, fg="red"))

--- a/agenta-cli/agenta/cli/helper.py
+++ b/agenta-cli/agenta/cli/helper.py
@@ -82,5 +82,5 @@ def trace_error(file_name, function_name, message=None, e=None):
             f"Trace: Failed at {file_name}.{function_name}\n\nMessage: {message}\n\n"
         )
     elif message == None and e != None:
-        error_msg = f"Trace: Failed at {file_name}.{function_name}\n\Error: {e}\n\n"
+        error_msg = f"Trace: Failed at {file_name}.{function_name}\n\nError: {e}\n\n"
     click.echo(click.style(error_msg, fg="red"))

--- a/agenta-cli/agenta/cli/variant_commands.py
+++ b/agenta-cli/agenta/cli/variant_commands.py
@@ -122,16 +122,16 @@ def add_variant(app_folder: str, file_name: str, host: str) -> str:
 
             # Last step us to save the config file
             toml.dump(config, config_file.open("w"))
-            
+
         else:
             click.echo(
                 click.style(f"Adding variant {variant_name} to server...", fg="yellow")
             )
             client.add_variant_to_server(app_name, variant_name, image, host)
-            
+
             # Last step us to save the config file
             toml.dump(config, config_file.open("w"))
-            
+
     except Exception as ex:
         if overwrite:
             click.echo(click.style(f"Error while updating variant: {ex}", fg="red"))
@@ -195,7 +195,7 @@ def start_variant(variant_name: str, app_folder: str, host: str):
         endpoint = client.start_variant(app_name, variant_name, host=host)
     except Exception as e:
         click.echo(click.style(f"Error while fetching uri: {e}", fg="red"))
-        
+
     click.echo("\n" + click.style("Congratulations! 🎉", bold=True, fg="green"))
     click.echo(
         click.style(f"Your app has been deployed locally as an API. 🚀", fg="cyan")
@@ -360,7 +360,11 @@ def serve_cli(app_folder: str, file_name: str):
         )
         click.echo(click.style(f"{error_msg}", fg="red"))
     except Exception as e:
-        click.echo(click.style(f"Failed to start container with LLM app: \n {str(e)}", fg="red"))
+        click.echo(
+            click.style(
+                f"Failed to start container with LLM app: \n {str(e)}", fg="red"
+            )
+        )
 
 
 @variant.command(name="list")

--- a/agenta-cli/agenta/cli/variant_commands.py
+++ b/agenta-cli/agenta/cli/variant_commands.py
@@ -124,6 +124,10 @@ def add_variant(app_folder: str, file_name: str, host: str) -> str:
                 click.style(f"Adding variant {variant_name} to server...", fg="yellow")
             )
             client.add_variant_to_server(app_name, variant_name, image, host)
+            
+            # Last step us to save the config file
+            toml.dump(config, config_file.open("w"))
+            
     except Exception as ex:
         if overwrite:
             click.echo(click.style(f"Error while updating variant: {ex}", fg="red"))
@@ -144,8 +148,7 @@ def add_variant(app_folder: str, file_name: str, host: str) -> str:
                 fg="green",
             )
         )
-    # Last step us to save the config file
-    toml.dump(config, config_file.open("w"))
+
     if overwrite:
         # In the case we are overwriting, don't return anything. Otherwise the command server would attempt to start the container which would result in an error!!!
         # TODO: Improve this stupid design
@@ -349,7 +352,7 @@ def serve_cli(app_folder: str, file_name: str):
         )
         click.echo(click.style(f"{error_msg}", fg="red"))
     except Exception as e:
-        click.echo(click.style(f"Error message: {str(e)}", fg="red"))
+        click.echo(click.style(f"Failed to start container with LLM app: \n {str(e)}", fg="red"))
 
 
 @variant.command(name="list")

--- a/agenta-cli/agenta/cli/variant_commands.py
+++ b/agenta-cli/agenta/cli/variant_commands.py
@@ -119,6 +119,10 @@ def add_variant(app_folder: str, file_name: str, host: str) -> str:
                 )
             )
             client.update_variant_image(app_name, variant_name, image, host)
+
+            # Last step us to save the config file
+            toml.dump(config, config_file.open("w"))
+            
         else:
             click.echo(
                 click.style(f"Adding variant {variant_name} to server...", fg="yellow")

--- a/agenta-cli/agenta/cli/variant_commands.py
+++ b/agenta-cli/agenta/cli/variant_commands.py
@@ -191,7 +191,11 @@ def start_variant(variant_name: str, app_folder: str, host: str):
             "Please choose a variant", choices=config["variants"]
         ).ask()
 
-    endpoint = client.start_variant(app_name, variant_name, host=host)
+    try:
+        endpoint = client.start_variant(app_name, variant_name, host=host)
+    except Exception as e:
+        click.echo(click.style(f"Error while fetching uri: {e}", fg="red"))
+        
     click.echo("\n" + click.style("Congratulations! 🎉", bold=True, fg="green"))
     click.echo(
         click.style(f"Your app has been deployed locally as an API. 🚀", fg="cyan")

--- a/agenta-cli/agenta/cli/variant_commands.py
+++ b/agenta-cli/agenta/cli/variant_commands.py
@@ -45,8 +45,9 @@ def add_variant(app_folder: str, file_name: str, host: str) -> str:
     # check files in folder
     app_file = app_path / file_name
     if not app_file.exists():
-
-        message = f"No {file_name} exists! Please make sure you are in the right directory",
+        message = (
+            f"No {file_name} exists! Please make sure you are in the right directory",
+        )
 
         helper.trace_error(__file__, sys._getframe().f_code.co_name, message)
         return None
@@ -71,8 +72,9 @@ def add_variant(app_folder: str, file_name: str, host: str) -> str:
 
     # Validate variant name
     if not re.match("^[a-zA-Z0-9_]+$", variant_name):
-
-        message = "Invalid input. Please use only alphanumeric characters without spaces.",
+        message = (
+            "Invalid input. Please use only alphanumeric characters without spaces.",
+        )
 
         helper.trace_error(__file__, sys._getframe().f_code.co_name, message)
         sys.exit(0)
@@ -132,9 +134,19 @@ def add_variant(app_folder: str, file_name: str, host: str) -> str:
 
     except Exception as ex:
         if overwrite:
-            helper.trace_error(__file__, sys._getframe().f_code.co_name, f"Error while updating variant", ex)
+            helper.trace_error(
+                __file__,
+                sys._getframe().f_code.co_name,
+                f"Error while updating variant",
+                ex,
+            )
         else:
-            helper.trace_error(__file__, sys._getframe().f_code.co_name, f"Error while adding variant", ex)
+            helper.trace_error(
+                __file__,
+                sys._getframe().f_code.co_name,
+                f"Error while adding variant",
+                ex,
+            )
         return None
     if overwrite:
         click.echo(
@@ -177,7 +189,11 @@ def start_variant(variant_name: str, app_folder: str, host: str):
 
     if variant_name:
         if variant_name not in config["variants"]:
-            helper.trace_error(__file__, sys._getframe().f_code.co_name, f"Variant {variant_name} not found in backend. Maybe you removed it in the webUI?")
+            helper.trace_error(
+                __file__,
+                sys._getframe().f_code.co_name,
+                f"Variant {variant_name} not found in backend. Maybe you removed it in the webUI?",
+            )
             return
     else:
         variant_name = questionary.select(
@@ -187,7 +203,9 @@ def start_variant(variant_name: str, app_folder: str, host: str):
     try:
         endpoint = client.start_variant(app_name, variant_name, host=host)
     except Exception as e:
-        helper.trace_error(__file__, sys._getframe().f_code.co_name, f"Error while fetching uri", e)
+        helper.trace_error(
+            __file__, sys._getframe().f_code.co_name, f"Error while fetching uri", e
+        )
 
     click.echo("\n" + click.style("Congratulations! 🎉", bold=True, fg="green"))
     click.echo(
@@ -228,8 +246,11 @@ def remove_variant(variant_name: str, app_folder: str, host: str):
 
     if variant_name:
         if variant_name not in config["variants"]:
-
-            helper.trace_error(__file__, sys._getframe().f_code.co_name, f"Variant {variant_name} not found in backend. Maybe you already removed it in the webUI?")
+            helper.trace_error(
+                __file__,
+                sys._getframe().f_code.co_name,
+                f"Variant {variant_name} not found in backend. Maybe you already removed it in the webUI?",
+            )
             return
     else:
         variant_name = questionary.select(
@@ -238,8 +259,12 @@ def remove_variant(variant_name: str, app_folder: str, host: str):
     try:
         client.remove_variant(app_name, variant_name, host)
     except Exception as ex:
-
-        helper.trace_error(__file__, sys._getframe().f_code.co_name, f"Error while removing variant {variant_name} for App {app_name} from the backend", ex)
+        helper.trace_error(
+            __file__,
+            sys._getframe().f_code.co_name,
+            f"Error while removing variant {variant_name} for App {app_name} from the backend",
+            ex,
+        )
         return
 
     click.echo(
@@ -264,7 +289,11 @@ def list_variants(app_folder: str, host: str):
         for variant in variants:
             helper.display_app_variant(variant)
     else:
-        helper.trace_error(__file__, sys._getframe().f_code.co_name, f"No variants found for app {app_name}")
+        helper.trace_error(
+            __file__,
+            sys._getframe().f_code.co_name,
+            f"No variants found for app {app_name}",
+        )
 
 
 def config_check(app_folder: str):
@@ -278,7 +307,11 @@ def config_check(app_folder: str):
     app_folder = Path(app_folder)
     config_file = app_folder / "config.toml"
     if not config_file.exists():
-        helper.trace_error(__file__, sys._getframe().f_code.co_name, f"Config file not found in {app_folder}. Make sure you are in the right folder and that you have run agenta init first.")
+        helper.trace_error(
+            __file__,
+            sys._getframe().f_code.co_name,
+            f"Config file not found in {app_folder}. Make sure you are in the right folder and that you have run agenta init first.",
+        )
         return
     host = get_host(app_folder)  # TODO: Refactor the whole config thing
     helper.update_config_from_backend(config_file, host=host)
@@ -343,7 +376,12 @@ def serve_cli(app_folder: str, file_name: str):
         helper.trace_error(__file__, sys._getframe().f_code.co_name, error_msg, e)
 
     except Exception as e:
-        helper.trace_error(__file__, sys._getframe().f_code.co_name, "Failed to start container with LLM app", e)
+        helper.trace_error(
+            __file__,
+            sys._getframe().f_code.co_name,
+            "Failed to start container with LLM app",
+            e,
+        )
 
 
 @variant.command(name="list")


### PR DESCRIPTION
This PR improves the detailing of the specific error message when a variant fails to serve with the command `agenta variant serve --file_name <app.py>`

When merged, this PR closes #543 and should help to resolve #542 