### PR TITLE
#549 poetry publish workflows failing when no version is bumped

### DIFF
--- a/.github/workflows/publish.yml
+++ b/.github/workflows/publish.yml
@@ -51,11 +51,11 @@ jobs:
           echo "No version change detected. Skipping package publication."
           exit 78
         fi
-        echo "::set-output name=version_bumped::true"
+        # echo "::set-output name=version_bumped::true"
       shell: bash
 
     - name: Build and publish agenta to PyPI
-      if: steps.version_check.outputs.version_bumped == 'true'
+      # if: steps.version_check.outputs.version_bumped == 'true'
       run: |
         # Navigate to the cli directory
         cd ${{ github.workspace }}

--- a/.github/workflows/publish.yml
+++ b/.github/workflows/publish.yml
@@ -51,11 +51,11 @@ jobs:
           echo "No version change detected. Skipping package publication."
           exit 78
         fi
-        # echo "::set-output name=version_bumped::true"
-      shell: bash
+        echo "::set-output name=version_bumped::true"
+      continue-on-error: true
 
     - name: Build and publish agenta to PyPI
-      # if: steps.version_check.outputs.version_bumped == 'true'
+      if: steps.version_check.outputs.version_bumped == 'true'
       run: |
         # Navigate to the cli directory
         cd ${{ github.workspace }}


### PR DESCRIPTION
When Merged, this PR closes #549 and closes #501

This PR addresses the issue of the 'Publish agenta to PyPI" workflow failing if there's no version bump by continuing the workflow successfully if no version change is detected. 

<img width="1680" alt="image" src="https://github.com/Agenta-AI/agenta/assets/56418363/0d7f06e8-55ad-4e95-9f40-bfd889b2a4a2">
