### PR TITLE
#527 Import Testset from an Endpoint

### DIFF
--- a/agenta-web/src/pages/apps/[app_name]/testsets/index.tsx
+++ b/agenta-web/src/pages/apps/[app_name]/testsets/index.tsx
@@ -36,6 +36,7 @@ const useStyles = createUseStyles({
     linksContainer: {
         display: "flex",
         gap: "10px",
+        flexWrap: "wrap",
     },
     startLink: {
         marginLeft: 10,
@@ -150,6 +151,9 @@ export default function testsets() {
                                 <Button>Create a test set with API</Button>
                             </Link>
                         )}
+                        <Link href={`/apps/${app_name}/testsets/new/endpoint`}>
+                            <Button>Import from Endpoint</Button>
+                        </Link>
                     </div>
 
                     <Link href={`/apps/${app_name}/evaluations`} className={classes.startLink}>

--- a/agenta-web/src/pages/apps/[app_name]/testsets/new/endpoint/index.tsx
+++ b/agenta-web/src/pages/apps/[app_name]/testsets/new/endpoint/index.tsx
@@ -1,0 +1,129 @@
+import axios from "@/lib/helpers/axiosConfig"
+import {Alert, Button, Form, Input, Spin, Typography, message} from "antd"
+import {useRouter} from "next/router"
+import {useState} from "react"
+import {createUseStyles} from "react-jss"
+
+const useStyles = createUseStyles({
+    container: {
+        display: "flex",
+        flexDirection: "column",
+        rowGap: 20,
+        maxWidth: 800,
+    },
+    json: {
+        overflow: "auto",
+    },
+    buttonContainer: {
+        display: "flex",
+        flexDirection: "row",
+        justifyContent: "flex-end",
+    },
+})
+
+type FieldType = {
+    name: string
+    endpoint: string
+}
+
+export default function ImportTestsetFromEndpoint() {
+    const classes = useStyles()
+
+    const router = useRouter()
+    const appName = router.query.app_name?.toString() || ""
+
+    const handleSubmit = async (values: FieldType) => {
+        if (values.name.trim() === "" || values.endpoint.trim() === "") {
+            message.error("Please fill out all fields")
+            return
+        }
+
+        setUploadLoading(true)
+
+        const formData = new FormData()
+        formData.append("endpoint", values.endpoint)
+        formData.append("testset_name", values.name)
+        formData.append("app_name", appName?.toString() || "")
+
+        try {
+            // TODO: move to api.ts
+            await axios.post(
+                `${process.env.NEXT_PUBLIC_AGENTA_API_URL}/api/testsets/endpoint`,
+                formData,
+                {headers: {"Content-Type": "multipart/form-data"}},
+            )
+            router.push(`/apps/${appName}/testsets`)
+        } catch (_) {
+            // Errors will be handled by Axios interceptor
+            // Do nothing here
+        } finally {
+            setUploadLoading(false)
+        }
+    }
+
+    const [uploadLoading, setUploadLoading] = useState(false)
+
+    return (
+        <div className={classes.container}>
+            <Typography.Title level={5}>Import a new Test Set from an endpoint</Typography.Title>
+
+            <Alert
+                message="Endpoint Test Set Format"
+                description={
+                    <>
+                        Currently, we only support the JSON format which must meet the following
+                        requirements:
+                        <ol>
+                            <li>A JSON with an array of rows</li>
+                            <li>
+                                Each row in the array should be an object of column header name as
+                                key and row data as value
+                            </li>
+                        </ol>
+                        Here is an example of a valid JSON file:
+                        <pre className={classes.json}>
+                            {JSON.stringify(
+                                [
+                                    {
+                                        recipe_name: "Chicken Parmesan",
+                                        correct_answer: "Chicken",
+                                    },
+                                    {recipe_name: "a, special, recipe", correct_answer: "Beef"},
+                                ],
+                                null,
+                                2,
+                            )}
+                        </pre>
+                    </>
+                }
+                type="info"
+            />
+
+            <Spin spinning={uploadLoading}>
+                <Form onFinish={handleSubmit} layout="vertical">
+                    <Form.Item<FieldType>
+                        label="Test Set Name"
+                        name="name"
+                        rules={[{required: true, type: "string", whitespace: true}]}
+                    >
+                        <Input placeholder="Test Set Name" />
+                    </Form.Item>
+
+                    <Form.Item<FieldType>
+                        label="Test Set Endpoint"
+                        name="endpoint"
+                        rules={[{required: true, type: "url"}]}
+                    >
+                        <Input placeholder="Endpoint URL" />
+                    </Form.Item>
+
+                    <div className={classes.buttonContainer}>
+                        <Button htmlType="submit" type="primary">
+                            Import Test Set
+                        </Button>
+                    </div>
+                </Form>
+            </Spin>
+        </div>
+    )
+}


### PR DESCRIPTION
related to the issue #527

This PR adds a new method for creating a testset by importing data from an endpoint.
A new button has been added, leading to a new page where users can submit a testset name and endpoint. 
The server will fetch data from the endpoint and save it to the DB like what the `upload` method does. 
Currently I've only handled JSON format response.

I'm not a native English speaker, so if there are any English texts that need modification, please let me know.

Web screenshots:
<img width="1003" alt="스크린샷 2023-09-07 오전 10 21 11" src="https://github.com/Agenta-AI/agenta/assets/124246127/4e0c154a-6da8-4af8-80bb-452270ccd278">

<img width="841" alt="스크린샷 2023-09-07 오전 10 18 35" src="https://github.com/Agenta-AI/agenta/assets/124246127/f0f64a3c-6256-4c3d-a7ce-cfde383f73c6">
