### PR TITLE
feature : develop Endpoint to Fetch LLM Application Variant Parameters

### DIFF
--- a/agenta-backend/agenta_backend/routers/app_variant.py
+++ b/agenta-backend/agenta_backend/routers/app_variant.py
@@ -96,6 +96,8 @@ async def get_variant_by_name(
     except ValueError as e:
         # Handle ValueErrors and return 400 status code
         raise HTTPException(status_code=400, detail=str(e))
+    except HTTPException as e:
+        raise e
     except Exception as e:
         # Handle all other exceptions and return 500 status code
         raise HTTPException(status_code=500, detail=str(e))

--- a/agenta-backend/agenta_backend/routers/app_variant.py
+++ b/agenta-backend/agenta_backend/routers/app_variant.py
@@ -68,11 +68,11 @@ async def get_variant_by_name(
     stoken_session: SessionContainer = Depends(verify_session()),
 ):
     """Fetches a specific app variant based on the given app_name and variant_name.
-    
+
     Arguments:
         app_name (str): The name of the app to query.
         variant_name (str): The name of the variant to query.
-        
+
     Raises:
         HTTPException: Raises 404 if no matching variant is found,
                        400 for ValueError, or 500 for any other exceptions.
@@ -84,16 +84,16 @@ async def get_variant_by_name(
     try:
         # Retrieve the user and organization ID based on the session token
         kwargs = await get_user_and_org_id(stoken_session)
-        
+
         # Fetch the app variant using the provided app_name and variant_name
         app_variant = await db_manager.get_app_variant_by_app_name_and_variant_name(
             app_name=app_name, variant_name=variant_name, **kwargs
         )
-        
+
         # Check if the fetched app variant is None and raise 404 if it is
         if app_variant is None:
             raise HTTPException(status_code=404, detail="App Variant not found")
-        
+
         return app_variant
     except ValueError as e:
         # Handle ValueErrors and return 400 status code
@@ -105,6 +105,7 @@ async def get_variant_by_name(
     except Exception as e:
         # Handle all other exceptions and return 500 status code
         raise HTTPException(status_code=500, detail=str(e))
+
 
 @router.get("/list_apps/", response_model=List[App])
 async def list_apps(

--- a/agenta-backend/agenta_backend/routers/app_variant.py
+++ b/agenta-backend/agenta_backend/routers/app_variant.py
@@ -89,19 +89,13 @@ async def get_variant_by_name(
         app_variant = await db_manager.get_app_variant_by_app_name_and_variant_name(
             app_name=app_name, variant_name=variant_name, **kwargs
         )
-
         # Check if the fetched app variant is None and raise 404 if it is
         if app_variant is None:
-            raise HTTPException(status_code=404, detail="App Variant not found")
-
+            raise HTTPException(status_code=500, detail="App Variant not found")
         return app_variant
     except ValueError as e:
         # Handle ValueErrors and return 400 status code
         raise HTTPException(status_code=400, detail=str(e))
-    except HTTPException as e:
-        # FIXME: This is a temporary fix to avoid returning 500 status code
-        # Re-raise caught HTTPExceptions
-        raise
     except Exception as e:
         # Handle all other exceptions and return 500 status code
         raise HTTPException(status_code=500, detail=str(e))

--- a/agenta-backend/agenta_backend/routers/app_variant.py
+++ b/agenta-backend/agenta_backend/routers/app_variant.py
@@ -61,6 +61,51 @@ async def list_app_variants(
         raise HTTPException(status_code=500, detail=str(e))
 
 
+@router.get("/get_variant_by_name/", response_model=AppVariant)
+async def get_variant_by_name(
+    app_name: str,
+    variant_name: str,
+    stoken_session: SessionContainer = Depends(verify_session()),
+):
+    """Fetches a specific app variant based on the given app_name and variant_name.
+    
+    Arguments:
+        app_name (str): The name of the app to query.
+        variant_name (str): The name of the variant to query.
+        
+    Raises:
+        HTTPException: Raises 404 if no matching variant is found,
+                       400 for ValueError, or 500 for any other exceptions.
+
+    Returns:
+        AppVariant: The fetched app variant.
+    """
+
+    try:
+        # Retrieve the user and organization ID based on the session token
+        kwargs = await get_user_and_org_id(stoken_session)
+        
+        # Fetch the app variant using the provided app_name and variant_name
+        app_variant = await db_manager.get_app_variant_by_app_name_and_variant_name(
+            app_name=app_name, variant_name=variant_name, **kwargs
+        )
+        
+        # Check if the fetched app variant is None and raise 404 if it is
+        if app_variant is None:
+            raise HTTPException(status_code=404, detail="App Variant not found")
+        
+        return app_variant
+    except ValueError as e:
+        # Handle ValueErrors and return 400 status code
+        raise HTTPException(status_code=400, detail=str(e))
+    except HTTPException as e:
+        # FIXME: This is a temporary fix to avoid returning 500 status code
+        # Re-raise caught HTTPExceptions
+        raise
+    except Exception as e:
+        # Handle all other exceptions and return 500 status code
+        raise HTTPException(status_code=500, detail=str(e))
+
 @router.get("/list_apps/", response_model=List[App])
 async def list_apps(
     stoken_session: SessionContainer = Depends(verify_session()),

--- a/agenta-backend/agenta_backend/services/db_manager.py
+++ b/agenta-backend/agenta_backend/services/db_manager.py
@@ -250,7 +250,7 @@ async def get_app_variant_by_app_name_and_variant_name(
     Args:
         app_name (str): Name of the app.
         variant_name (str): Name of the variant.
-        show_soft_deleted (bool, optional): Whether to include soft-deleted items. Defaults to False.
+        show_soft_deleted: if true, returns soft deleted variants as well
         **kwargs (dict): Additional keyword arguments.
 
     Returns:

--- a/agenta-backend/agenta_backend/services/db_manager.py
+++ b/agenta-backend/agenta_backend/services/db_manager.py
@@ -240,8 +240,53 @@ async def list_app_variants(
     return app_variants
 
 async def get_app_variant_by_app_name_and_variant_name(
-    app_name: str = None, variant_name: str = None, show_soft_deleted=False, **kwargs: dict
+    app_name: str, 
+    variant_name: str, 
+    show_soft_deleted: bool = False, 
+    **kwargs: dict
 ) -> AppVariant:
+    """Fetches an app variant based on app_name and variant_name.
+    
+    Args:
+        app_name (str): Name of the app.
+        variant_name (str): Name of the variant.
+        show_soft_deleted (bool, optional): Whether to include soft-deleted items. Defaults to False.
+        **kwargs (dict): Additional keyword arguments.
+
+    Returns:
+        AppVariant: The fetched app variant.
+    """
+    
+    # Get the user object using the user ID
+    user = await get_user_object(kwargs["uid"])
+
+    # Construct the base query for the user
+    users_query = query.eq(AppVariantDB.user_id, user.id)
+
+    # Construct the query for soft-deleted items
+    soft_delete_query = query.eq(AppVariantDB.is_deleted, show_soft_deleted)
+
+    # Construct the final query filters
+    query_filters = (
+        query.eq(AppVariantDB.app_name, app_name) &
+        query.eq(AppVariantDB.variant_name, variant_name) &
+        users_query &
+        soft_delete_query
+    )
+
+    # Perform the database query
+    app_variants_db = await engine.find(
+        AppVariantDB,
+        query_filters,
+        sort=(AppVariantDB.app_name, AppVariantDB.variant_name),
+    )
+
+    # Convert the database object to AppVariant and return it
+    # Assuming that find will return a list, take the first element if it exists
+    app_variant: AppVariant = app_variant_db_to_pydantic(app_variants_db[0]) if app_variants_db else None
+    
+    return app_variant
+
 
     # Get user object
     user = await get_user_object(kwargs["uid"])

--- a/agenta-backend/agenta_backend/services/db_manager.py
+++ b/agenta-backend/agenta_backend/services/db_manager.py
@@ -239,14 +239,12 @@ async def list_app_variants(
     ]
     return app_variants
 
+
 async def get_app_variant_by_app_name_and_variant_name(
-    app_name: str, 
-    variant_name: str, 
-    show_soft_deleted: bool = False, 
-    **kwargs: dict
+    app_name: str, variant_name: str, show_soft_deleted: bool = False, **kwargs: dict
 ) -> AppVariant:
     """Fetches an app variant based on app_name and variant_name.
-    
+
     Args:
         app_name (str): Name of the app.
         variant_name (str): Name of the variant.
@@ -256,7 +254,7 @@ async def get_app_variant_by_app_name_and_variant_name(
     Returns:
         AppVariant: The fetched app variant.
     """
-    
+
     # Get the user object using the user ID
     user = await get_user_object(kwargs["uid"])
 
@@ -268,10 +266,10 @@ async def get_app_variant_by_app_name_and_variant_name(
 
     # Construct the final query filters
     query_filters = (
-        query.eq(AppVariantDB.app_name, app_name) &
-        query.eq(AppVariantDB.variant_name, variant_name) &
-        users_query &
-        soft_delete_query
+        query.eq(AppVariantDB.app_name, app_name)
+        & query.eq(AppVariantDB.variant_name, variant_name)
+        & users_query
+        & soft_delete_query
     )
 
     # Perform the database query
@@ -283,10 +281,11 @@ async def get_app_variant_by_app_name_and_variant_name(
 
     # Convert the database object to AppVariant and return it
     # Assuming that find will return a list, take the first element if it exists
-    app_variant: AppVariant = app_variant_db_to_pydantic(app_variants_db[0]) if app_variants_db else None
-    
-    return app_variant
+    app_variant: AppVariant = (
+        app_variant_db_to_pydantic(app_variants_db[0]) if app_variants_db else None
+    )
 
+    return app_variant
 
     # Get user object
     user = await get_user_object(kwargs["uid"])
@@ -302,10 +301,10 @@ async def get_app_variant_by_app_name_and_variant_name(
 
     # Final query
     query_filters = (
-        query.eq(AppVariantDB.app_name, app_name) &
-        query.eq(AppVariantDB.variant_name, variant_name) &
-        users_query &
-        soft_delete_query
+        query.eq(AppVariantDB.app_name, app_name)
+        & query.eq(AppVariantDB.variant_name, variant_name)
+        & users_query
+        & soft_delete_query
     )
 
     app_variants_db = await engine.find(
@@ -316,8 +315,10 @@ async def get_app_variant_by_app_name_and_variant_name(
 
     # Convert to AppVariant (assuming app_variant_db_to_pydantic returns AppVariant)
     # Here I assume that find will return a list and take the first element.
-    app_variant: AppVariant = app_variant_db_to_pydantic(app_variants_db[0]) if app_variants_db else None
-    
+    app_variant: AppVariant = (
+        app_variant_db_to_pydantic(app_variants_db[0]) if app_variants_db else None
+    )
+
     return app_variant
 
 

--- a/agenta-backend/agenta_backend/services/db_manager.py
+++ b/agenta-backend/agenta_backend/services/db_manager.py
@@ -287,40 +287,6 @@ async def get_app_variant_by_app_name_and_variant_name(
 
     return app_variant
 
-    # Get user object
-    user = await get_user_object(kwargs["uid"])
-
-    if app_name is None or variant_name is None:
-        raise ValueError("App name or variant name is None")
-
-    # Base query
-    users_query = query.eq(AppVariantDB.user_id, user.id)
-
-    # Handle soft deleted
-    soft_delete_query = query.eq(AppVariantDB.is_deleted, show_soft_deleted)
-
-    # Final query
-    query_filters = (
-        query.eq(AppVariantDB.app_name, app_name)
-        & query.eq(AppVariantDB.variant_name, variant_name)
-        & users_query
-        & soft_delete_query
-    )
-
-    app_variants_db = await engine.find(
-        AppVariantDB,
-        query_filters,
-        sort=(AppVariantDB.app_name, AppVariantDB.variant_name),
-    )
-
-    # Convert to AppVariant (assuming app_variant_db_to_pydantic returns AppVariant)
-    # Here I assume that find will return a list and take the first element.
-    app_variant: AppVariant = (
-        app_variant_db_to_pydantic(app_variants_db[0]) if app_variants_db else None
-    )
-
-    return app_variant
-
 
 async def list_apps(**kwargs: dict) -> List[App]:
     """

--- a/agenta-backend/tests/test_router_app_variant.py
+++ b/agenta-backend/tests/test_router_app_variant.py
@@ -82,6 +82,13 @@ def test_list_app_variant():
     assert response.json() == []
 
 
+def test_get_variant_by_name_with_invalid_names():
+    response = client.get(
+        "/app_variant/get_variant_by_name/?app_name=invalid&variant_name=invalid"
+    )
+    assert response.status_code == 500
+
+
 def test_list_app_variant_after_manual_add(app_variant, image):
     # This is the function from db_manager.py
     add_variant_based_on_image(app_variant, image)

--- a/agenta-backend/tests/test_router_app_variant.py
+++ b/agenta-backend/tests/test_router_app_variant.py
@@ -81,6 +81,8 @@ def test_list_app_variant():
     assert response.status_code == 200
     assert response.json() == []
 
+def test_get_variant_by_name():
+    // TODO: Add test for get_variant_by_name
 
 def test_list_app_variant_after_manual_add(app_variant, image):
     # This is the function from db_manager.py

--- a/agenta-backend/tests/test_router_app_variant.py
+++ b/agenta-backend/tests/test_router_app_variant.py
@@ -81,9 +81,6 @@ def test_list_app_variant():
     assert response.status_code == 200
     assert response.json() == []
 
-def test_get_variant_by_name():
-    // TODO: Add test for get_variant_by_name
-
 def test_list_app_variant_after_manual_add(app_variant, image):
     # This is the function from db_manager.py
     add_variant_based_on_image(app_variant, image)

--- a/agenta-backend/tests/test_router_app_variant.py
+++ b/agenta-backend/tests/test_router_app_variant.py
@@ -81,6 +81,7 @@ def test_list_app_variant():
     assert response.status_code == 200
     assert response.json() == []
 
+
 def test_list_app_variant_after_manual_add(app_variant, image):
     # This is the function from db_manager.py
     add_variant_based_on_image(app_variant, image)

--- a/agenta-cli/agenta/client/client.py
+++ b/agenta-cli/agenta/client/client.py
@@ -82,6 +82,7 @@ def list_variants(app_name: str, host: str) -> List[AppVariant]:
     app_variants = response.json()
     return [AppVariant(**variant) for variant in app_variants]
 
+
 def get_variant_by_name(app_name: str, variant_name: str, host: str) -> AppVariant:
     """Gets a variant by name
 
@@ -103,6 +104,7 @@ def get_variant_by_name(app_name: str, variant_name: str, host: str) -> AppVaria
         raise APIRequestError(
             f"Request to get_variant_by_name endpoint failed with status code {response.status_code} and error message: {error_message}."
         )
+
 
 def remove_variant(app_name: str, variant_name: str, host: str):
     """Removes a variant from the backend

--- a/agenta-cli/agenta/client/client.py
+++ b/agenta-cli/agenta/client/client.py
@@ -82,6 +82,27 @@ def list_variants(app_name: str, host: str) -> List[AppVariant]:
     app_variants = response.json()
     return [AppVariant(**variant) for variant in app_variants]
 
+def get_variant_by_name(app_name: str, variant_name: str, host: str) -> AppVariant:
+    """Gets a variant by name
+
+    Arguments:
+        app_name -- the app name
+        variant_name -- the variant name
+
+    Returns:
+        the variant using the pydantic model
+    """
+    response = requests.get(
+        f"{host}/{BACKEND_URL_SUFFIX}/app_variant/get_variant_by_name/?app_name={app_name}&variant_name={variant_name}",
+        timeout=600,
+    )
+
+    # Check for successful request
+    if response.status_code != 200:
+        error_message = response.json()
+        raise APIRequestError(
+            f"Request to get_variant_by_name endpoint failed with status code {response.status_code} and error message: {error_message}."
+        )
 
 def remove_variant(app_name: str, variant_name: str, host: str):
     """Removes a variant from the backend


### PR DESCRIPTION
### Summary
This (Draft) PR addresses the API for fetching a specific app variant based on app_name and variant_name. The API parameters are passed as query parameters.
Related to Issue #571 

### Example Request
`GET /api/app_variant/get_variant_by_name/?app_name=test&variant_name=v1
`

### Issues to Address

**Unit Testing**: I still need to complete the `def test_get_variant_by_name()` function. Any suggestions on what parameters should be used for testing would be appreciated.

**Exception Handling**: Encountering an issue where the intended _404_ error is not being triggered as expected. Despite the condition `if app_variant is None` being met, a _500_ error is raised instead of a _404_ error. This happens when I remove the block `except HTTPException as e: raise`. Refer to [this line](https://github.com/yeokyeong-yanolja/agenta/blob/914e821eba660876351b737acae924e038534e6d/agenta-backend/agenta_backend/routers/app_variant.py#L94C1-L104) for more details.
