### PR TITLE
Fix - resolve mixed content issue error

### DIFF
--- a/agenta-web/src/lib/services/api.ts
+++ b/agenta-web/src/lib/services/api.ts
@@ -479,7 +479,7 @@ export const fetchCustomEvaluationNames = async (
     ignoreAxiosError: boolean = false,
 ) => {
     const response = await axios.get(
-        `${process.env.NEXT_PUBLIC_AGENTA_API_URL}/api/evaluations/custom_evaluation/${app_name}/names`,
+        `${process.env.NEXT_PUBLIC_AGENTA_API_URL}/api/evaluations/custom_evaluation/${app_name}/names/`,
         {_ignoreError: ignoreAxiosError} as any,
     )
     return response


### PR DESCRIPTION
This PR resolves the following errors:

Mixed Content: The page at 'https://xxxxxxxx' was loaded over HTTPS, but requested an insecure XMLHttpRequest endpoint 'https://xxxxxxxx'. This request has been blocked; the content must be served over HTTPS.
