### PR TITLE
sync Tests with new refactoring

### DIFF
--- a/agenta-backend/agenta_backend/tests/test_app_variant_router.py
+++ b/agenta-backend/agenta_backend/tests/test_app_variant_router.py
@@ -37,10 +37,7 @@ async def test_successfully_creates_new_app_variant(get_first_user_object):
     }
 
     # Invoke the function
-    response = await test_client.get(
-        f"http://localhost:8000/app_variant/feedbacks/add/from_template/",
-        json=payload,
-    )
+    response = await add_app_variant_from_template(payload=payload)
 
     # Assertions
     assert response.status_code == 200
@@ -57,3 +54,4 @@ async def test_successfully_creates_new_app_variant(get_first_user_object):
         "config_name": "default",
         "config_id": None
     }
+    

--- a/agenta-backend/agenta_backend/tests/test_app_variant_router.py
+++ b/agenta-backend/agenta_backend/tests/test_app_variant_router.py
@@ -1,0 +1,59 @@
+import httpx
+from odmantic import query
+import pytest
+from agenta_backend.models.db_engine import DBEngine
+from agenta_backend.models.db_models import (
+    UserDB,
+    OrganizationDB,
+)
+from agenta_backend.routers.app_variant import add_app_variant_from_template
+
+# Initialize database engine
+engine = DBEngine().engine()
+
+# Initialize http client
+test_client = httpx.AsyncClient()
+
+
+@pytest.mark.asyncio
+async def test_successfully_creates_new_app_variant(get_first_user_object):
+
+    user = await get_first_user_object
+    query_expression = (OrganizationDB.type == "default") & (
+        OrganizationDB.owner == str(user.id)
+    )
+    user_organization = await engine.find_one(OrganizationDB, query_expression)
+
+    # Prepare test data
+    payload = {
+        "app_name": "myapp",
+        "image_id": "12345",
+        "image_tag": "latest",
+        "env_vars": {
+            "ENV_VAR1": "value1",
+            "ENV_VAR2": "value2"
+        },
+        "organization_id": str(user_organization.id),
+    }
+
+    # Invoke the function
+    response = await test_client.get(
+        f"http://localhost:8000/app_variant/feedbacks/add/from_template/",
+        json=payload,
+    )
+
+    # Assertions
+    assert response.status_code == 200
+    assert response == {
+        "app_id": "12345",
+        "variant_id": "13579",
+        "variant_name": "app",
+        "parameters": {},
+        "previous_variant_name": None,
+        "organization_id": str(user_organization.id),
+        "user_id": "54321",
+        "base_name": "app",
+        "base_id": None,
+        "config_name": "default",
+        "config_id": None
+    }


### PR DESCRIPTION
When merged, this PR closes #666 

I have;
- Created fixtures to for getting a user object to use in tests.
- Created test for creating an app variant from template.

## Errors
Tests keep failing with the error;
```
>       if payload.organization_id is None:
E       AttributeError: 'dict' object has no attribute 'organization_id'

agenta_backend/routers/app_variant.py:524: AttributeError
============================================================================== short test summary info ===============================================================================
FAILED agenta_backend/tests/test_app_variant_router.py::test_successfully_creates_new_app_variant - AttributeError: 'dict' object has no attribute 'organization_id'
```