### PR TITLE
340 | Feature: Warn users when unsaved changes in payground variants

### DIFF
--- a/agenta-web/src/components/Playground/Playground.tsx
+++ b/agenta-web/src/components/Playground/Playground.tsx
@@ -1,27 +1,24 @@
 import React, {useState, useEffect} from "react"
 import {Tabs, message} from "antd"
 import ViewNavigation from "./ViewNavigation"
-import VariantRemovalWarningModal from "./VariantRemovalWarningModal"
 import NewVariantModal from "./NewVariantModal"
-import {fetchEnvironments, fetchVariants, removeVariant} from "@/lib/services/api"
+import {fetchEnvironments, fetchVariants} from "@/lib/services/api"
 import {Variant, PlaygroundTabsItem, Environment} from "@/lib/Types"
 import {SyncOutlined} from "@ant-design/icons"
 import {useRouter} from "next/router"
+import {useQueryParam} from "@/hooks/useQuery"
+import AlertPopup from "../AlertPopup/AlertPopup"
 
 const Playground: React.FC = () => {
     const router = useRouter()
     const appId = router.query.app_id as string
     const [templateVariantName, setTemplateVariantName] = useState("") // We use this to save the template variant name when the user creates a new variant
-    const [activeKey, setActiveKey] = useState("1")
+    const [activeKey, setActiveKey] = useQueryParam("variant")
     const [isModalOpen, setIsModalOpen] = useState(false)
     const [variants, setVariants] = useState<Variant[]>([]) // These are the variants that exist in the backend
     const [isLoading, setIsLoading] = useState(true)
     const [isError, setIsError] = useState(false)
     const [newVariantName, setNewVariantName] = useState("") // This is the name of the new variant that the user is creating
-    const [isWarningModalOpen1, setRemovalWarningModalOpen1] = useState(false)
-    const [isWarningModalOpen2, setRemovalWarningModalOpen2] = useState(false)
-    const [removalVariantName, setRemovalVariantName] = useState<string | null>(null)
-    const [isDeleteLoading, setIsDeleteLoading] = useState(false)
     const [messageApi, contextHolder] = message.useMessage()
 
     const addTab = () => {
@@ -90,7 +87,7 @@ const Playground: React.FC = () => {
             const backendVariants = await fetchVariants(appId)
             if (backendVariants.length > 0) {
                 setVariants(backendVariants)
-                setActiveKey(backendVariants[0].variantName)
+                if (!activeKey) setActiveKey(backendVariants[0].variantName)
             }
             setIsLoading(false)
         } catch (error) {
@@ -119,29 +116,6 @@ const Playground: React.FC = () => {
     if (isError) return <div>failed to load variants for app {appId}</div>
     if (isLoading) return <div>loading variants...</div>
 
-    const handleRemove = () => {
-        if (removalVariantName) {
-            removeTab()
-        }
-        setRemovalWarningModalOpen1(false)
-    }
-    const handleBackendRemove = async () => {
-        if (removalVariantName) {
-            setIsDeleteLoading(true)
-            // only call the backend if the variant is persistent
-            const toRemove = variants.find((variant) => variant.variantName === removalVariantName)
-            if (toRemove?.persistent) await removeVariant(toRemove.variantId)
-
-            removeTab()
-            setIsDeleteLoading(false)
-        }
-        setRemovalWarningModalOpen1(false)
-        removedSuccessfully()
-    }
-
-    const handleCancel1 = () => setRemovalWarningModalOpen1(false)
-    const handleCancel2 = () => setRemovalWarningModalOpen2(false)
-
     /**
      * Called when the variant is saved for the first time to the backend
      * after this point, the variant cannot be removed from the tab menu
@@ -158,10 +132,31 @@ const Playground: React.FC = () => {
             })
         })
     }
-    const removedSuccessfully = () => {
-        messageApi.open({
-            type: "success",
-            content: "Variant removed successfully!",
+
+    const deleteVariant = (deleteAction?: Function) => {
+        AlertPopup({
+            title: "Delete Variant",
+            message: (
+                <span>
+                    You're about to delete this variant. This action is irreversible.
+                    <br />
+                    Are you sure you want to proceed?
+                </span>
+            ),
+            okButtonProps: {
+                type: "primary",
+                danger: true,
+            },
+            onOk: async () => {
+                try {
+                    if (deleteAction) await deleteAction()
+                    removeTab()
+                    messageApi.open({
+                        type: "success",
+                        content: "Variant removed successfully!",
+                    })
+                } catch {}
+            },
         })
     }
 
@@ -173,11 +168,9 @@ const Playground: React.FC = () => {
             <ViewNavigation
                 variant={variant}
                 handlePersistVariant={handlePersistVariant}
-                setRemovalVariantName={setRemovalVariantName}
-                setRemovalWarningModalOpen={setRemovalWarningModalOpen2}
-                isDeleteLoading={isDeleteLoading && removalVariantName === variant.variantName}
                 environments={environments}
                 onAdd={fetchData}
+                deleteVariant={deleteVariant}
             />
         ),
         closable: !variant.persistent,
@@ -201,12 +194,11 @@ const Playground: React.FC = () => {
                     type="editable-card"
                     activeKey={activeKey}
                     onChange={setActiveKey}
-                    onEdit={(targetKey, action) => {
+                    onEdit={(_, action) => {
                         if (action === "add") {
                             setIsModalOpen(true)
                         } else if (action === "remove") {
-                            setRemovalVariantName(targetKey as string)
-                            setRemovalWarningModalOpen1(true)
+                            deleteVariant()
                         }
                     }}
                     items={tabItems}
@@ -221,18 +213,6 @@ const Playground: React.FC = () => {
                 setNewVariantName={setNewVariantName}
                 newVariantName={newVariantName}
                 setTemplateVariantName={setTemplateVariantName}
-            />
-            <VariantRemovalWarningModal
-                isModalOpen={isWarningModalOpen1}
-                setIsModalOpen={setRemovalWarningModalOpen1}
-                handleRemove={handleRemove}
-                handleCancel={handleCancel1}
-            />
-            <VariantRemovalWarningModal
-                isModalOpen={isWarningModalOpen2}
-                setIsModalOpen={setRemovalWarningModalOpen2}
-                handleRemove={handleBackendRemove}
-                handleCancel={handleCancel2}
             />
         </div>
     )

--- a/agenta-web/src/components/Playground/ViewNavigation.tsx
+++ b/agenta-web/src/components/Playground/ViewNavigation.tsx
@@ -8,17 +8,20 @@ import {useRouter} from "next/router"
 import {useState} from "react"
 import axios from "axios"
 import {createUseStyles} from "react-jss"
-import {getAppContainerURL, restartAppVariantContainer, waitForAppToStart} from "@/lib/services/api"
+import {
+    getAppContainerURL,
+    removeVariant,
+    restartAppVariantContainer,
+    waitForAppToStart,
+} from "@/lib/services/api"
 import {useAppsData} from "@/contexts/app.context"
 
 interface Props {
     variant: Variant
     handlePersistVariant: (variantName: string) => void
-    setRemovalVariantName: (variantName: string) => void
-    setRemovalWarningModalOpen: (value: boolean) => void
-    isDeleteLoading: boolean
     environments: Environment[]
     onAdd: () => void
+    deleteVariant: (deleteAction?: Function) => void
 }
 
 const useStyles = createUseStyles({
@@ -33,11 +36,9 @@ const useStyles = createUseStyles({
 const ViewNavigation: React.FC<Props> = ({
     variant,
     handlePersistVariant,
-    setRemovalVariantName,
-    setRemovalWarningModalOpen,
-    isDeleteLoading,
     environments,
     onAdd,
+    deleteVariant,
 }) => {
     const classes = useStyles()
     const router = useRouter()
@@ -162,10 +163,8 @@ const ViewNavigation: React.FC<Props> = ({
                             type="primary"
                             danger
                             onClick={() => {
-                                setRemovalVariantName(variant.variantName)
-                                setRemovalWarningModalOpen(true)
+                                deleteVariant(() => removeVariant(variant.variantId))
                             }}
-                            loading={isDeleteLoading}
                         >
                             <Tooltip placement="bottom" title="Delete the variant permanently">
                                 Delete Variant
@@ -188,9 +187,7 @@ const ViewNavigation: React.FC<Props> = ({
                         onOptParamsChange={saveOptParams}
                         handlePersistVariant={handlePersistVariant}
                         isPersistent={variant.persistent} // if the variant persists in the backend, then saveoptparams will need to know to update and not save new variant
-                        setRemovalVariantName={setRemovalVariantName}
-                        setRemovalWarningModalOpen={setRemovalWarningModalOpen}
-                        isDeleteLoading={isDeleteLoading}
+                        deleteVariant={deleteVariant}
                         isParamsCollapsed={isParamsCollapsed}
                         setIsParamsCollapsed={setIsParamsCollapsed}
                         environments={environments}

--- a/agenta-web/src/components/Playground/ViewNavigation.tsx
+++ b/agenta-web/src/components/Playground/ViewNavigation.tsx
@@ -22,6 +22,8 @@ interface Props {
     environments: Environment[]
     onAdd: () => void
     deleteVariant: (deleteAction?: Function) => void
+    getHelpers: (helpers: {save: Function; delete: Function}) => void
+    onStateChange: (isDirty: boolean) => void
 }
 
 const useStyles = createUseStyles({
@@ -39,6 +41,8 @@ const ViewNavigation: React.FC<Props> = ({
     environments,
     onAdd,
     deleteVariant,
+    getHelpers,
+    onStateChange,
 }) => {
     const classes = useStyles()
     const router = useRouter()
@@ -192,6 +196,8 @@ const ViewNavigation: React.FC<Props> = ({
                         setIsParamsCollapsed={setIsParamsCollapsed}
                         environments={environments}
                         onAdd={onAdd}
+                        getHelpers={getHelpers}
+                        onStateChange={onStateChange}
                     />
                 </Col>
             </Row>

--- a/agenta-web/src/components/Playground/Views/ParametersView.tsx
+++ b/agenta-web/src/components/Playground/Views/ParametersView.tsx
@@ -1,7 +1,7 @@
 import {Environment, Parameter, Variant} from "@/lib/Types"
 import type {CollapseProps} from "antd"
 import {Button, Col, Collapse, Row, Space, Tooltip, message} from "antd"
-import React, {useState} from "react"
+import React, {useEffect, useState} from "react"
 import {createUseStyles} from "react-jss"
 import {ModelParameters, ObjectParameters, StringParameters} from "./ParametersCards"
 import PublishVariantModal from "./PublishVariantModal"
@@ -26,6 +26,8 @@ interface Props {
     environments: Environment[]
     onAdd: () => void
     deleteVariant: (deleteAction?: Function) => void
+    getHelpers: (helpers: {save: Function; delete: Function}) => void
+    onStateChange: (isDirty: boolean) => void
 }
 
 const useStyles = createUseStyles({
@@ -62,6 +64,8 @@ const ParametersView: React.FC<Props> = ({
     environments,
     onAdd,
     deleteVariant,
+    getHelpers,
+    onStateChange,
 }) => {
     const classes = useStyles()
     const [messageApi, contextHolder] = message.useMessage()
@@ -78,6 +82,7 @@ const ParametersView: React.FC<Props> = ({
             param.name === name ? {...param, default: newVal} : param,
         )
         setUnSavedChanges(true)
+        onStateChange(true)
         newOptParams && onOptParamsChange(newOptParams, false, false)
     }
 
@@ -96,6 +101,7 @@ const ParametersView: React.FC<Props> = ({
                     onClose: () => handlePersistVariant(variant.variantName),
                 })
                 setUnSavedChanges(false)
+                onStateChange(false)
                 res(true)
             })
         })
@@ -106,28 +112,36 @@ const ParametersView: React.FC<Props> = ({
             if (variant.persistent) {
                 return removeVariant(variant.variantId).then(() => {
                     setUnSavedChanges(false)
+                    onStateChange(false)
                 })
             }
         })
     }
 
-    useBlockNavigation(unSavedChanges && currVariant === variant.variantName, {
-        title: "Unsaved changes",
-        message: (
-            <span>
-                You have unsaved changes in variant <strong>{variant.variantName}</strong>. Do you
-                want to save these changes before leaving the page?
-            </span>
-        ),
-        width: 500,
-        okText: "Save",
-        onOk: onSave,
-        onCancel: async () => {
-            setUnSavedChanges(false)
-            return true
-        },
-        cancelText: "Proceed without saving",
-    })
+    // useBlockNavigation(unSavedChanges && currVariant === variant.variantName, {
+    //     title: "Unsaved changes",
+    //     message: (
+    //         <span>
+    //             You have unsaved changes in variant <strong>{variant.variantName}</strong>. Do you
+    //             want to save these changes before leaving the page?
+    //         </span>
+    //     ),
+    //     width: 500,
+    //     okText: "Save",
+    //     onOk: onSave,
+    //     onCancel: async () => {
+    //         setUnSavedChanges(false)
+    //         return true
+    //     },
+    //     cancelText: "Proceed without saving",
+    // })
+
+    useEffect(() => {
+        getHelpers({
+            save: onSave,
+            delete: handleDelete,
+        })
+    }, [getHelpers])
 
     const items: CollapseProps["items"] = [
         {

--- a/agenta-web/src/components/Playground/Views/ParametersView.tsx
+++ b/agenta-web/src/components/Playground/Views/ParametersView.tsx
@@ -5,8 +5,6 @@ import React, {useEffect, useState} from "react"
 import {createUseStyles} from "react-jss"
 import {ModelParameters, ObjectParameters, StringParameters} from "./ParametersCards"
 import PublishVariantModal from "./PublishVariantModal"
-import useBlockNavigation from "@/hooks/useBlockNavigation"
-import {useQueryParam} from "@/hooks/useQuery"
 import {removeVariant} from "@/lib/services/api"
 
 interface Props {
@@ -71,8 +69,10 @@ const ParametersView: React.FC<Props> = ({
     const [messageApi, contextHolder] = message.useMessage()
     const [isPublishModalOpen, setPublishModalOpen] = useState(false)
     const isVariantExisting = !!variant.variantId
-    const [unSavedChanges, setUnSavedChanges] = useState(variant.persistent === false)
-    const [currVariant] = useQueryParam("variant")
+
+    useEffect(() => {
+        onStateChange(variant.persistent === false)
+    }, [])
 
     const onChange = (param: Parameter, newValue: number | string) => {
         handleParamChange(param.name, newValue)
@@ -81,7 +81,6 @@ const ParametersView: React.FC<Props> = ({
         const newOptParams = optParams?.map((param) =>
             param.name === name ? {...param, default: newVal} : param,
         )
-        setUnSavedChanges(true)
         onStateChange(true)
         newOptParams && onOptParamsChange(newOptParams, false, false)
     }
@@ -100,7 +99,6 @@ const ParametersView: React.FC<Props> = ({
                     content: "Changes saved successfully!",
                     onClose: () => handlePersistVariant(variant.variantName),
                 })
-                setUnSavedChanges(false)
                 onStateChange(false)
                 res(true)
             })
@@ -111,30 +109,11 @@ const ParametersView: React.FC<Props> = ({
         deleteVariant(() => {
             if (variant.persistent) {
                 return removeVariant(variant.variantId).then(() => {
-                    setUnSavedChanges(false)
                     onStateChange(false)
                 })
             }
         })
     }
-
-    // useBlockNavigation(unSavedChanges && currVariant === variant.variantName, {
-    //     title: "Unsaved changes",
-    //     message: (
-    //         <span>
-    //             You have unsaved changes in variant <strong>{variant.variantName}</strong>. Do you
-    //             want to save these changes before leaving the page?
-    //         </span>
-    //     ),
-    //     width: 500,
-    //     okText: "Save",
-    //     onOk: onSave,
-    //     onCancel: async () => {
-    //         setUnSavedChanges(false)
-    //         return true
-    //     },
-    //     cancelText: "Proceed without saving",
-    // })
 
     useEffect(() => {
         getHelpers({

--- a/agenta-web/src/hooks/useBlockNavigation.ts
+++ b/agenta-web/src/hooks/useBlockNavigation.ts
@@ -2,11 +2,16 @@ import AlertPopup, {AlertPopupProps} from "@/components/AlertPopup/AlertPopup"
 import Router from "next/router"
 import {useEffect, useRef} from "react"
 
-const useBlockNavigation = (_blocking: boolean, _props: AlertPopupProps) => {
+const useBlockNavigation = (
+    _blocking: boolean,
+    _props: AlertPopupProps,
+    _shouldAlert?: (newRoute: string) => boolean,
+) => {
     // whether the popup has been opened
     const opened = useRef(false)
     const blocking = useRef(_blocking)
     const props = useRef(_props)
+    const shouldAlert = useRef(_shouldAlert)
 
     useEffect(() => {
         blocking.current = _blocking
@@ -17,11 +22,17 @@ const useBlockNavigation = (_blocking: boolean, _props: AlertPopupProps) => {
     }, [_props])
 
     useEffect(() => {
+        shouldAlert.current = _shouldAlert
+    }, [_shouldAlert])
+
+    useEffect(() => {
         // prevent from reload or closing tab
         window.onbeforeunload = () => true
 
         const handler = (newRoute: string) => {
             if (opened.current || !blocking.current) return
+
+            if (shouldAlert.current && !shouldAlert.current(newRoute)) return
 
             opened.current = true
             AlertPopup({

--- a/agenta-web/src/hooks/useBlockNavigation.ts
+++ b/agenta-web/src/hooks/useBlockNavigation.ts
@@ -1,58 +1,74 @@
 import AlertPopup, {AlertPopupProps} from "@/components/AlertPopup/AlertPopup"
 import Router from "next/router"
-import {useEffect, useState} from "react"
+import {useEffect, useRef} from "react"
 
-const useBlockNavigation = (blocking: boolean, props: AlertPopupProps) => {
+const useBlockNavigation = (_blocking: boolean, _props: AlertPopupProps) => {
     // whether the popup has been opened
-    const [opened, setOpened] = useState(false)
+    const opened = useRef(false)
+    const blocking = useRef(_blocking)
+    const props = useRef(_props)
 
     useEffect(() => {
-        if (blocking && !opened) {
-            // prevent from reload or closing tab
-            window.onbeforeunload = () => true
+        blocking.current = _blocking
+    }, [_blocking])
 
-            const handler = (newRoute: string) => {
-                setOpened(true)
-                AlertPopup({
-                    ...props,
-                    onOk: async () => {
-                        if (props.onOk) {
-                            const res = await props.onOk()
-                            if (res) {
-                                Router.push(newRoute)
-                            } else {
-                                setOpened(false)
-                            }
-                        } else {
+    useEffect(() => {
+        props.current = _props
+    }, [_props])
+
+    useEffect(() => {
+        // prevent from reload or closing tab
+        window.onbeforeunload = () => true
+
+        const handler = (newRoute: string) => {
+            if (opened.current || !blocking.current) return
+
+            opened.current = true
+            AlertPopup({
+                okButtonProps: {
+                    type: "primary",
+                    ...(props.current.okButtonProps || {}),
+                },
+                ...props.current,
+                onOk: async () => {
+                    if (props.current.onOk) {
+                        const res = await props.current.onOk()
+                        if (res) {
                             Router.push(newRoute)
-                        }
-                    },
-                    onCancel: async () => {
-                        if (props.onCancel) {
-                            const res = await props.onCancel()
-                            if (res) {
-                                Router.push(newRoute)
-                            } else {
-                                setOpened(false)
-                            }
                         } else {
-                            Router.push(newRoute)
                         }
-                    },
-                    cancellable: false,
-                })
+                    } else {
+                        Router.push(newRoute)
+                    }
+                    opened.current = false
+                    blocking.current = false
+                },
+                onCancel: async () => {
+                    if (props.current.onCancel) {
+                        const res = await props.current.onCancel()
+                        if (res) {
+                            Router.push(newRoute)
+                        } else {
+                        }
+                    } else {
+                        Router.push(newRoute)
+                    }
+                    opened.current = false
+                    blocking.current = false
+                },
+                cancellable: false,
+            })
 
-                //block NextJS navigation until user confirms or cancels
-                throw "cancelRouteChange"
-            }
-
-            Router.events.on("routeChangeStart", handler)
-            return () => {
-                window.onbeforeunload = null
-                Router.events.off("routeChangeStart", handler)
-            }
+            //block NextJS navigation until user confirms or cancels
+            throw "cancelRouteChange"
         }
-    }, [blocking, props, opened])
+
+        Router.events.on("routeChangeStart", handler)
+        return () => {
+            window.onbeforeunload = null
+            Router.events.off("routeChangeStart", handler)
+        }
+    }, [])
 }
 
 export default useBlockNavigation

--- a/agenta-web/src/hooks/useQuery.ts
+++ b/agenta-web/src/hooks/useQuery.ts
@@ -18,7 +18,7 @@ function getUpdateQuery(router: NextRouter, method: Method) {
         })
 
         router[method]({
-            pathname: router.pathname,
+            pathname: window.location.pathname,
             query: newQuery,
         })
     }


### PR DESCRIPTION
- warn for unsaved changes in variant
- playground refactoring
- bug fixes

Implementation Details:

We prompt users for unsaved changes as soon as they leave the variant tab. That includes not only leaving the playground page, but also switching to one variant from another within the playground. Also, variant tabs are now controlled by query params instead of the local React state, meaning that the playground URL now persists the selected variant tab.