### PR TITLE
hot fix

### DIFF
--- a/agenta-backend/agenta_backend/routers/evaluation_router.py
+++ b/agenta-backend/agenta_backend/routers/evaluation_router.py
@@ -547,7 +547,9 @@ async def execute_custom_evaluation(
     # Execute custom code evaluation
     formatted_inputs = format_inputs(payload.inputs)
     formatted_outputs = format_outputs(payload.outputs)
-    output = list(formatted_outputs.values())[0]  # for now we expect one output as a string
+    output = list(formatted_outputs.values())[
+        0
+    ]  # for now we expect one output as a string
     result = await execute_custom_code_evaluation(
         evaluation_id,
         payload.app_id,

--- a/agenta-backend/agenta_backend/routers/evaluation_router.py
+++ b/agenta-backend/agenta_backend/routers/evaluation_router.py
@@ -547,10 +547,11 @@ async def execute_custom_evaluation(
     # Execute custom code evaluation
     formatted_inputs = format_inputs(payload.inputs)
     formatted_outputs = format_outputs(payload.outputs)
+    output = list(formatted_outputs.values())[0]  # for now we expect one output as a string
     result = await execute_custom_code_evaluation(
         evaluation_id,
         payload.app_id,
-        formatted_outputs,  # gets the output of the app variant
+        output,
         payload.correct_answer,
         payload.variant_id,
         formatted_inputs,

--- a/agenta-backend/agenta_backend/services/evaluation_service.py
+++ b/agenta-backend/agenta_backend/services/evaluation_service.py
@@ -717,7 +717,8 @@ async def execute_custom_code_evaluation(
         result: The result of the executed custom code
     """
     logger.debug(
-        f"evaluation_id {evaluation_id} | app_id {app_id} | variant_id {variant_id} | inputs {inputs} | output {output} | correct_answer {correct_answer}")
+        f"evaluation_id {evaluation_id} | app_id {app_id} | variant_id {variant_id} | inputs {inputs} | output {output} | correct_answer {correct_answer}"
+    )
     # Get user object
     user = await get_user_object(user_org_data["uid"])
 

--- a/agenta-backend/agenta_backend/services/evaluation_service.py
+++ b/agenta-backend/agenta_backend/services/evaluation_service.py
@@ -1,3 +1,4 @@
+import logging
 from agenta_backend.services.security.sandbox import execute_code_safely
 from bson import ObjectId
 from datetime import datetime
@@ -36,6 +37,9 @@ from agenta_backend.models.db_models import (
 from langchain.chains import LLMChain
 from langchain.llms import OpenAI
 from langchain.prompts import PromptTemplate
+
+logger = logging.getLogger(__name__)
+logger.setLevel(logging.DEBUG)
 
 
 class UpdateEvaluationScenarioError(Exception):
@@ -712,7 +716,8 @@ async def execute_custom_code_evaluation(
     Returns:
         result: The result of the executed custom code
     """
-
+    logger.debug(
+        f"evaluation_id {evaluation_id} | app_id {app_id} | variant_id {variant_id} | inputs {inputs} | output {output} | correct_answer {correct_answer}")
     # Get user object
     user = await get_user_object(user_org_data["uid"])
 


### PR DESCRIPTION
Issue was that frontend was sending outputs in the format

{ variant_id: output}
while backend was expecting a string for the output


Right now the fix is hacky! 

@MohammedMaaz @aybruhm How do you suggest we have some clean solution that is also extendable in the future (to multiple outputs maybe).