### PR TITLE
Enable support for cloud hosted agenta in Agenta CLI

### DIFF
--- a/agenta-cli/agenta/cli/helper.py
+++ b/agenta-cli/agenta/cli/helper.py
@@ -7,18 +7,19 @@ from agenta.client.api_models import AppVariant
 
 
 def update_variants_from_backend(
-    app_id: str, config: MutableMapping[str, Any], host: str
+    app_id: str, config: MutableMapping[str, Any], host: str, api_key: str = None
 ) -> MutableMapping[str, Any]:
     """Reads the list of variants from the backend and updates the config accordingly
 
     Arguments:
         app_id -- the app id
         config -- the config loaded using toml.load
+        api_key -- the api key to use for authentication
 
     Returns:
         a new config object later to be saved using toml.dump(config, config_file.open('w'))
     """
-    variants: List[AppVariant] = client.list_variants(app_id, host)
+    variants: List[AppVariant] = client.list_variants(app_id, host, api_key)
     config["variants"] = [variant.variant_name for variant in variants]
     config["variant_ids"] = [variant.variant_id for variant in variants]
     return config
@@ -33,11 +34,12 @@ def update_config_from_backend(config_file: Path, host: str):
     assert config_file.exists(), "Config file does not exist!"
     config = toml.load(config_file)
     app_id = config["app_id"]
+    api_key = config.get("api_key", None)
     if "variants" not in config:
         config["variants"] = []
     if "variant_ids" not in config:
         config["variant_ids"] = []
-    config = update_variants_from_backend(app_id, config, host)
+    config = update_variants_from_backend(app_id, config, host, api_key)
     toml.dump(config, config_file.open("w"))
 
 

--- a/agenta-cli/agenta/cli/main.py
+++ b/agenta-cli/agenta/cli/main.py
@@ -88,15 +88,27 @@ def init(app_name: str):
                     )
 
     where_question = questionary.select(
-        "Are you running agenta locally?", choices=["Yes", "No"]
+        "Where are you running agenta?", choices=["On my local machine", "On a remote machine", "On agenta cloud"]
     ).ask()
 
-    if where_question == "Yes":
+    if where_question == "On my local machine":
         backend_host = "http://localhost"
-    elif where_question == "No":
+    elif where_question == "On a remote machine":
         backend_host = questionary.text(
             "Please provide the IP or URL of your remote host"
         ).ask()
+    elif where_question == "On agenta cloud":
+        backend_host = "https://stage.agenta.ai"
+        
+        api_key = questionary.text(
+            "Please provide your API key:"
+        ).ask();
+        
+        if api_key is None: # User pressed Ctrl+C
+            sys.exit(0)
+        
+        client.validate_api_key(api_key, backend_host)
+        
     elif where_question is None:  # User pressed Ctrl+C
         sys.exit(0)
     backend_host = (
@@ -106,10 +118,10 @@ def init(app_name: str):
     )
 
     # Get app_id after creating new app in the backend server
-    app_id = client.create_new_app(app_name, backend_host)
+    app_id = client.create_new_app(app_name, backend_host, api_key if where_question == "On agenta cloud" else None)
 
     # Set app toml configuration
-    config = {"app_name": app_name, "app_id": app_id, "backend_host": backend_host}
+    config = {"app_name": app_name, "app_id": app_id, "backend_host": backend_host, "api_key": api_key if where_question == "On agenta cloud" else None }
     with open("config.toml", "w") as config_file:
         toml.dump(config, config_file)
 

--- a/agenta-cli/agenta/cli/main.py
+++ b/agenta-cli/agenta/cli/main.py
@@ -88,7 +88,8 @@ def init(app_name: str):
                     )
 
     where_question = questionary.select(
-        "Where are you running agenta?", choices=["On my local machine", "On a remote machine", "On agenta cloud"]
+        "Where are you running agenta?",
+        choices=["On my local machine", "On a remote machine", "On agenta cloud"],
     ).ask()
 
     if where_question == "On my local machine":
@@ -99,16 +100,14 @@ def init(app_name: str):
         ).ask()
     elif where_question == "On agenta cloud":
         backend_host = "https://stage.agenta.ai"
-        
-        api_key = questionary.text(
-            "Please provide your API key:"
-        ).ask();
-        
-        if api_key is None: # User pressed Ctrl+C
+
+        api_key = questionary.text("Please provide your API key:").ask()
+
+        if api_key is None:  # User pressed Ctrl+C
             sys.exit(0)
-        
+
         client.validate_api_key(api_key, backend_host)
-        
+
     elif where_question is None:  # User pressed Ctrl+C
         sys.exit(0)
     backend_host = (
@@ -118,10 +117,17 @@ def init(app_name: str):
     )
 
     # Get app_id after creating new app in the backend server
-    app_id = client.create_new_app(app_name, backend_host, api_key if where_question == "On agenta cloud" else None)
+    app_id = client.create_new_app(
+        app_name, backend_host, api_key if where_question == "On agenta cloud" else None
+    )
 
     # Set app toml configuration
-    config = {"app_name": app_name, "app_id": app_id, "backend_host": backend_host, "api_key": api_key if where_question == "On agenta cloud" else None }
+    config = {
+        "app_name": app_name,
+        "app_id": app_id,
+        "backend_host": backend_host,
+        "api_key": api_key if where_question == "On agenta cloud" else None,
+    }
     with open("config.toml", "w") as config_file:
         toml.dump(config, config_file)
 

--- a/agenta-cli/agenta/cli/variant_commands.py
+++ b/agenta-cli/agenta/cli/variant_commands.py
@@ -110,7 +110,9 @@ def add_variant(app_folder: str, file_name: str, host: str) -> str:
                 fg="yellow",
             )
         )
-        image: Image = client.send_docker_tar(app_id, base_name, tar_path, host, api_key)
+        image: Image = client.send_docker_tar(
+            app_id, base_name, tar_path, host, api_key
+        )
         # docker_image: DockerImage = build_and_upload_docker_image(
         #     folder=app_path, app_name=app_name, variant_name=variant_name)
     except Exception as ex:
@@ -128,7 +130,9 @@ def add_variant(app_folder: str, file_name: str, host: str) -> str:
             client.update_variant_image(variant_id, image, host, api_key)
         else:
             click.echo(click.style(f"Adding {variant_name} to server...", fg="yellow"))
-            response = client.add_variant_to_server(app_id, base_name, image, host, api_key)
+            response = client.add_variant_to_server(
+                app_id, base_name, image, host, api_key
+            )
             variant_id = response["variant_id"]
             config["variants"].append(variant_name)
             config["variant_ids"].append(variant_id)

--- a/agenta-cli/agenta/client/client.py
+++ b/agenta-cli/agenta/client/client.py
@@ -251,3 +251,37 @@ def send_docker_tar(app_id: str, base_name: str, tar_path: Path, host: str) -> I
     response.raise_for_status()
     image = Image.parse_obj(response.json())
     return image
+
+
+def validate_api_key(api_key: str, host: str) -> bool:
+    """
+    Validates an API key with the Agenta backend.
+
+    Args:
+        api_key (str): The API key to validate.
+        host (str): The URL of the Agenta backend.
+
+    Returns:
+        bool: Whether the API key is valid or not.
+    """
+    try:
+        headers = {
+            "Authorization": api_key
+        }
+        
+        prefix = api_key.split(".")[0]
+        
+        response = requests.post(
+            f"{host}/{BACKEND_URL_SUFFIX}/keys/{prefix}/validate/",
+            headers=headers,
+            timeout=600,
+        )
+        if response.status_code != 200:
+            error_message = response.json()
+            raise APIRequestError(
+                f"Request to validate api key failed with status code {response.status_code} and error message: {error_message}."
+            )
+        return True
+    except RequestException as e:
+        raise APIRequestError(f"An error occurred while making the request: {e}")
+    

--- a/agenta-cli/agenta/client/client.py
+++ b/agenta-cli/agenta/client/client.py
@@ -8,11 +8,12 @@ from requests.exceptions import RequestException
 
 BACKEND_URL_SUFFIX = os.environ["BACKEND_URL_SUFFIX"]
 
+
 class APIRequestError(Exception):
     """Exception to be raised when an API request fails."""
 
 
-def get_app_by_name(app_name: str, host: str, api_key : str = None) -> str:
+def get_app_by_name(app_name: str, host: str, api_key: str = None) -> str:
     """Get app by its name on the server.
 
     Args:
@@ -57,7 +58,9 @@ def create_new_app(app_name: str, host: str, api_key: str = None) -> str:
     return response.json()["app_id"]
 
 
-def add_variant_to_server(app_id: str, base_name: str, image: Image, host: str, api_key: str = None) -> Dict:
+def add_variant_to_server(
+    app_id: str, base_name: str, image: Image, host: str, api_key: str = None
+) -> Dict:
     """
     Adds a variant to the server.
 
@@ -96,7 +99,10 @@ def add_variant_to_server(app_id: str, base_name: str, image: Image, host: str, 
 
 
 def start_variant(
-    variant_id: str, host: str, env_vars: Optional[Dict[str, str]] = None, api_key: str = None
+    variant_id: str,
+    host: str,
+    env_vars: Optional[Dict[str, str]] = None,
+    api_key: str = None,
 ) -> str:
     """
     Starts or stops a container with the given variant and exposes its endpoint.
@@ -188,7 +194,7 @@ def remove_variant(variant_id: str, host: str, api_key: str = None):
         headers={
             "Content-Type": "application/json",
             "Authorization": api_key if api_key is not None else None,
-            },
+        },
         timeout=600,
     )
 
@@ -229,7 +235,9 @@ def update_variant_image(variant_id: str, image: Image, host: str, api_key: str 
         )
 
 
-def send_docker_tar(app_id: str, base_name: str, tar_path: Path, host: str, api_key: str = None) -> Image:
+def send_docker_tar(
+    app_id: str, base_name: str, tar_path: Path, host: str, api_key: str = None
+) -> Image:
     """
     Sends a Docker tar file to the specified host to build an image for the given app ID and variant name.
 
@@ -282,12 +290,10 @@ def validate_api_key(api_key: str, host: str) -> bool:
         bool: Whether the API key is valid or not.
     """
     try:
-        headers = {
-            "Authorization": api_key
-        }
-        
+        headers = {"Authorization": api_key}
+
         prefix = api_key.split(".")[0]
-        
+
         response = requests.get(
             f"{host}/{BACKEND_URL_SUFFIX}/keys/{prefix}/validate/",
             headers=headers,
@@ -301,4 +307,3 @@ def validate_api_key(api_key: str, host: str) -> bool:
         return True
     except RequestException as e:
         raise APIRequestError(f"An error occurred while making the request: {e}")
-    


### PR DESCRIPTION
When merged, this PR resolves #738 

The following have been done;
- [x] Add option to use Agenta Cloud during `agenta init` setup
- [x] If Agenta Cloud, then get, validate and persist api key. 
- [x] If api key, use it for authentication in requests.

### Test

I have tested that this addresses the target [issue](https://github.com/Agenta-AI/agenta/issues/738) and introduces no breaking changes or bugs. 
- [x] This PR code allows for development of llm apps as usual with Agenta platform running locally. 
- [x] This PR code allows for development with Agenta Cloud, only limited by the feature not being available. 
<img width="826" alt="image" src="https://github.com/Agenta-AI/agenta/assets/56418363/b84799ee-d38e-4acc-8eb6-faba7510004c">

