### PR TITLE
bug: fixes createdAt date in Automatic Evaluation Results

### DIFF
--- a/agenta-web/src/components/Evaluations/AutomaticEvaluationResult.tsx
+++ b/agenta-web/src/components/Evaluations/AutomaticEvaluationResult.tsx
@@ -8,7 +8,6 @@ import {DeleteOutlined} from "@ant-design/icons"
 import {EvaluationTypeLabels} from "@/lib/helpers/utils"
 import {EvaluationFlow, EvaluationType} from "@/lib/enums"
 import {createUseStyles} from "react-jss"
-import {formatDate} from "@/lib/helpers/dateTimeHelper"
 import {useAppTheme} from "../Layout/ThemeContextProvider"
 import {calculateResultsDataAvg} from "@/lib/helpers/evaluate"
 
@@ -103,7 +102,7 @@ export default function AutomaticEvaluationResult() {
                     ) {
                         return {
                             key: item.id,
-                            createdAt: formatDate(item.createdAt),
+                            createdAt: item.createdAt,
                             variants: item.variants,
                             scoresData: result.scores_data,
                             evaluationType: item.evaluationType,


### PR DESCRIPTION
## Description
This pull request addresses an issue where the `formatDate()` function was causing "Invalid Date" errors when applied to the `createdAt` field.

## Screenshot
<img width="972" alt="Screen Shot 2023-10-17 at 9 35 56 AM" src="https://github.com/Agenta-AI/agenta/assets/99529776/2a0f7c4e-a424-43d8-9cac-087c9b0e933e">

