### PR TITLE
Evaluation command hot fix

### DIFF
--- a/agenta-web/cypress/support/commands/evaluations.ts
+++ b/agenta-web/cypress/support/commands/evaluations.ts
@@ -28,7 +28,7 @@ Cypress.Commands.add("createVariant", () => {
     })
 
     cy.get('[data-cy="create-from-template"]').click()
-    cy.get('[data-cy="create-app-button"]').click()
+    cy.get('[data-cy="create-app-button"]').eq(0).click()
     const appName = randString(5)
 
     cy.get('[data-cy="enter-app-name-modal"]')


### PR DESCRIPTION
### Description
Modified the test command to target the initial `create-app-button` attribute to resolve test failure caused by the appearance of two identical attributes when starting from the Template.