### PR TITLE
Feat -  Implement Message Data Type for Chat-Based Applications

### DIFF
--- a/agenta-cli/agenta/__init__.py
+++ b/agenta-cli/agenta/__init__.py
@@ -7,7 +7,7 @@ from .sdk.types import (
     InFile,
     IntParam,
     MultipleChoiceParam,
-    MessagesParam,
+    MessagesInput,
     TextParam,
 )
 from .sdk.utils.preinit import PreInitObject

--- a/agenta-cli/agenta/__init__.py
+++ b/agenta-cli/agenta/__init__.py
@@ -7,6 +7,7 @@ from .sdk.types import (
     InFile,
     IntParam,
     MultipleChoiceParam,
+    MessagesParam,
     TextParam,
 )
 from .sdk.utils.preinit import PreInitObject

--- a/agenta-cli/agenta/sdk/__init__.py
+++ b/agenta-cli/agenta/sdk/__init__.py
@@ -10,6 +10,7 @@ from .types import (
     IntParam,
     MultipleChoiceParam,
     TextParam,
+    MessagesParam
 )
 from .agenta_init import Config, init
 

--- a/agenta-cli/agenta/sdk/__init__.py
+++ b/agenta-cli/agenta/sdk/__init__.py
@@ -10,7 +10,7 @@ from .types import (
     IntParam,
     MultipleChoiceParam,
     TextParam,
-    MessagesParam
+    MessagesParam,
 )
 from .agenta_init import Config, init
 

--- a/agenta-cli/agenta/sdk/__init__.py
+++ b/agenta-cli/agenta/sdk/__init__.py
@@ -10,7 +10,7 @@ from .types import (
     IntParam,
     MultipleChoiceParam,
     TextParam,
-    MessagesParam,
+    MessagesInput,
 )
 from .agenta_init import Config, init
 

--- a/agenta-cli/agenta/sdk/agenta_decorator.py
+++ b/agenta-cli/agenta/sdk/agenta_decorator.py
@@ -381,3 +381,4 @@ def override_schema(openapi_schema: dict, func_name: str, endpoint: str, params:
             and param_val.annotation is MessagesInput
         ):
             subschema = find_in_schema(schema_to_override, param_name, "messages")
+            subschema["default"] = [{"role": "string", "content": "string"}]

--- a/agenta-cli/agenta/sdk/agenta_decorator.py
+++ b/agenta-cli/agenta/sdk/agenta_decorator.py
@@ -25,7 +25,7 @@ from .types import (
     IntParam,
     MultipleChoiceParam,
     TextParam,
-    MessagesParam,
+    MessagesInput,
 )
 
 app = FastAPI()
@@ -378,8 +378,6 @@ def override_schema(openapi_schema: dict, func_name: str, endpoint: str, params:
             subschema["default"] = param_val
         if (
             isinstance(param_val, inspect.Parameter)
-            and param_val.annotation is MessagesParam
+            and param_val.annotation is MessagesInput
         ):
             subschema = find_in_schema(schema_to_override, param_name, "messages")
-            del subschema["items"]
-            subschema["default"] = param_val.default

--- a/agenta-cli/agenta/sdk/agenta_decorator.py
+++ b/agenta-cli/agenta/sdk/agenta_decorator.py
@@ -381,4 +381,4 @@ def override_schema(openapi_schema: dict, func_name: str, endpoint: str, params:
             and param_val.annotation is MessagesInput
         ):
             subschema = find_in_schema(schema_to_override, param_name, "messages")
-            subschema["default"] = [{"role": "string", "content": "string"}]
+            subschema["default"] = param_val.default

--- a/agenta-cli/agenta/sdk/agenta_decorator.py
+++ b/agenta-cli/agenta/sdk/agenta_decorator.py
@@ -25,6 +25,7 @@ from .types import (
     IntParam,
     MultipleChoiceParam,
     TextParam,
+    MessagesParam
 )
 
 app = FastAPI()
@@ -313,6 +314,7 @@ def override_schema(openapi_schema: dict, func_name: str, endpoint: str, params:
     - The min and max values for each FloatParam instance
     - The min and max values for each IntParam instance
     - The default value for DictInput instance
+    - The default value for MessagesParam instance
     - ... [PLEASE ADD AT EACH CHANGE]
 
     Args:
@@ -374,3 +376,10 @@ def override_schema(openapi_schema: dict, func_name: str, endpoint: str, params:
         if isinstance(param_val, TextParam):
             subschema = find_in_schema(schema_to_override, param_name, "text")
             subschema["default"] = param_val
+        if (
+            isinstance(param_val, inspect.Parameter)
+            and param_val.annotation is MessagesParam
+        ):
+            subschema = find_in_schema(schema_to_override, param_name, "messages")
+            del subschema["items"]
+            subschema["default"] = param_val.default

--- a/agenta-cli/agenta/sdk/agenta_decorator.py
+++ b/agenta-cli/agenta/sdk/agenta_decorator.py
@@ -25,7 +25,7 @@ from .types import (
     IntParam,
     MultipleChoiceParam,
     TextParam,
-    MessagesParam
+    MessagesParam,
 )
 
 app = FastAPI()

--- a/agenta-cli/agenta/sdk/types.py
+++ b/agenta-cli/agenta/sdk/types.py
@@ -98,26 +98,13 @@ class MultipleChoiceParam(str):
         )
 
 
-class MessagesParam(list):
-    def __new__(
-        cls,
-        default: List[Dict[str, Any]] = None,
-        inputs: List[Dict[str, Any]] = None,
-    ):
-        if default is None:
-            default = [{"role": "system", "content": "You are a helpful assistant."}]
+class Message(BaseModel):
+    role: str
+    content: str
+    
 
-        for input_ in default:
-            if not isinstance(input_, dict):
-                raise ValueError("Data type of input in default must be a dict")
-
-        if inputs is not None and not isinstance(inputs, list):
-            raise ValueError("Inputs cannot be None")
-
-        instance = super().__new__(cls, default)
-        instance.inputs = inputs
-        instance.default = default
-        return instance
+class MessagesInput(BaseModel):
+    messages: List[Message]
 
     @classmethod
     def __modify_schema__(cls, field_schema: dict[str, Any]):

--- a/agenta-cli/agenta/sdk/types.py
+++ b/agenta-cli/agenta/sdk/types.py
@@ -1,5 +1,5 @@
 import json
-from typing import Any, Dict, List
+from typing import Any, Dict, List, Self
 
 from pydantic import BaseModel, Extra
 
@@ -103,12 +103,28 @@ class Message(BaseModel):
     content: str
 
 
-class MessagesInput(BaseModel):
-    messages: List[Message]
+class MessagesInput(list):
+    """Messages Input for Chat-completion.
+
+    Parameters:
+        messages (List[Dict[str, str]]): The list of messages inputs. 
+        Required. Each message should be a dictionary with "role" and "content" keys.
+
+    Raises:
+        ValueError: If `messages` is not specified or empty.
+    """
+    
+    def __new__(cls, messages: List[Dict[str, str]] = None) -> Self:
+        if not messages:
+            raise ValueError("Missing required parameter in MessagesInput")
+            
+        instance = super().__new__(cls, messages)
+        instance.messages = messages
+        return instance
 
     @classmethod
     def __modify_schema__(cls, field_schema: dict[str, Any]):
-        field_schema.update({"x-parameter": "messages"})
+        field_schema.update({"x-parameter": "messages", "type": "array"})
 
 
 class Context(BaseModel):

--- a/agenta-cli/agenta/sdk/types.py
+++ b/agenta-cli/agenta/sdk/types.py
@@ -49,9 +49,7 @@ class IntParam(int):
 
 
 class FloatParam(float):
-    def __new__(
-        cls, default: float = 0.5, minval: float = 0.0, maxval: float = 1.0
-    ):
+    def __new__(cls, default: float = 0.5, minval: float = 0.0, maxval: float = 1.0):
         instance = super().__new__(cls, default)
         instance.minval = minval
         instance.maxval = maxval
@@ -82,9 +80,7 @@ class MultipleChoiceParam(str):
 
         if default is None and not choices:
             # raise error if no default value or choices is provided
-            raise ValueError(
-                "You must provide either a default value or choices"
-            )
+            raise ValueError("You must provide either a default value or choices")
 
         instance = super().__new__(cls, default)
         instance.choices = choices

--- a/agenta-cli/agenta/sdk/types.py
+++ b/agenta-cli/agenta/sdk/types.py
@@ -114,6 +114,7 @@ class MessagesInput(list):
         ValueError: If `messages` is not specified or empty.
 
     """
+
     def __new__(cls, messages: List[Dict[str, str]] = None):
         if not messages:
             raise ValueError("Missing required parameter in MessagesInput")

--- a/agenta-cli/agenta/sdk/types.py
+++ b/agenta-cli/agenta/sdk/types.py
@@ -101,7 +101,7 @@ class MultipleChoiceParam(str):
 class Message(BaseModel):
     role: str
     content: str
-    
+
 
 class MessagesInput(BaseModel):
     messages: List[Message]

--- a/agenta-cli/agenta/sdk/types.py
+++ b/agenta-cli/agenta/sdk/types.py
@@ -107,17 +107,17 @@ class MessagesInput(list):
     """Messages Input for Chat-completion.
 
     Parameters:
-        messages (List[Dict[str, str]]): The list of messages inputs. 
+        messages (List[Dict[str, str]]): The list of messages inputs.
         Required. Each message should be a dictionary with "role" and "content" keys.
 
     Raises:
         ValueError: If `messages` is not specified or empty.
     """
-    
+
     def __new__(cls, messages: List[Dict[str, str]] = None) -> Self:
         if not messages:
             raise ValueError("Missing required parameter in MessagesInput")
-            
+
         instance = super().__new__(cls, messages)
         instance.messages = messages
         return instance

--- a/agenta-cli/agenta/sdk/types.py
+++ b/agenta-cli/agenta/sdk/types.py
@@ -49,7 +49,9 @@ class IntParam(int):
 
 
 class FloatParam(float):
-    def __new__(cls, default: float = 0.5, minval: float = 0.0, maxval: float = 1.0):
+    def __new__(
+        cls, default: float = 0.5, minval: float = 0.0, maxval: float = 1.0
+    ):
         instance = super().__new__(cls, default)
         instance.minval = minval
         instance.maxval = maxval
@@ -80,7 +82,9 @@ class MultipleChoiceParam(str):
 
         if default is None and not choices:
             # raise error if no default value or choices is provided
-            raise ValueError("You must provide either a default value or choices")
+            raise ValueError(
+                "You must provide either a default value or choices"
+            )
 
         instance = super().__new__(cls, default)
         instance.choices = choices
@@ -96,6 +100,32 @@ class MultipleChoiceParam(str):
                 "enum": [],
             }
         )
+
+
+class MessagesParam(list):
+    def __new__(
+        cls,
+        default: List[Dict[str, Any]] = None,
+        inputs: List[Dict[str, Any]] = None,
+    ):
+        if default is None:
+            default = [{"role": "system", "content": "You are a helpful assistant."}]
+
+        for input_ in default:
+            if not isinstance(input_, dict):
+                raise ValueError("Data type of input in default must be a dict")
+
+        if inputs is not None and not isinstance(inputs, list):
+            raise ValueError("Inputs cannot be None")
+
+        instance = super().__new__(cls, default)
+        instance.inputs = inputs
+        instance.default = default
+        return instance
+
+    @classmethod
+    def __modify_schema__(cls, field_schema: dict[str, Any]):
+        field_schema.update({"x-parameter": "messages"})
 
 
 class Context(BaseModel):

--- a/agenta-cli/agenta/sdk/types.py
+++ b/agenta-cli/agenta/sdk/types.py
@@ -1,5 +1,5 @@
 import json
-from typing import Any, Dict, List, Self
+from typing import Any, Dict, List
 
 from pydantic import BaseModel, Extra
 
@@ -112,9 +112,9 @@ class MessagesInput(list):
 
     Raises:
         ValueError: If `messages` is not specified or empty.
-    """
 
-    def __new__(cls, messages: List[Dict[str, str]] = None) -> Self:
+    """
+    def __new__(cls, messages: List[Dict[str, str]] = None):
         if not messages:
             raise ValueError("Missing required parameter in MessagesInput")
 

--- a/examples/experimental/startup_feature_ideas/app.py
+++ b/examples/experimental/startup_feature_ideas/app.py
@@ -3,39 +3,26 @@ import openai
 from agenta import FloatParam, MessagesInput
 
 default_prompt = (
-    "Give me 10 feature ideas to implement for a food delivery company in {country}!"
+    "Give me 10 feature ideas to implement for a food delivery company in Nigeria!"
 )
 
-ag.init(app_name="baby_name_generator", base_name="app")
+ag.init(app_name="feature_ideas", base_name="app")
 ag.config.default(
     temperature=FloatParam(0.2),
 )
 
 
 @ag.entrypoint
-def generate(
-    country: str,
-    inputs: MessagesInput,
-) -> str:
-    """
-    Generate a baby name based on the given country and gender.
-
-    Args:
-        country (str): The country to generate the name from.
-        gender (str): The gender of the baby.
-
-    Returns:
-        str: The generated baby name.
-    """
-
+def chat(
+    inputs: MessagesInput = MessagesInput([{"role": "string", "content": "string"}])
+) -> str:    
     messages = [
-        {
-            "role": message.role,
-            "content": message.content.format(country=country),
+        {git s
+            "role": message["role"],
+            "content": message["content"],
         }
-        for message in inputs.messages
+        for message in inputs
     ]
-
     chat_completion = openai.ChatCompletion.create(
         model="gpt-3.5-turbo",
         messages=messages,

--- a/examples/experimental/startup_feature_ideas/app.py
+++ b/examples/experimental/startup_feature_ideas/app.py
@@ -1,6 +1,8 @@
-import agenta as ag
-import openai
 from agenta import FloatParam, MessagesInput
+import agenta as ag
+from openai import OpenAI
+
+client = OpenAI()
 
 default_prompt = (
     "Give me 10 feature ideas to implement for a food delivery company in Nigeria!"
@@ -23,8 +25,6 @@ def chat(
         }
         for message in inputs
     ]
-    chat_completion = openai.ChatCompletion.create(
-        model="gpt-3.5-turbo",
-        messages=messages,
-    )
+    chat_completion = client.chat.completions.create(model="gpt-3.5-turbo",
+                                                     messages=messages)
     return chat_completion.choices[0].message.content

--- a/examples/experimental/startup_feature_ideas/app.py
+++ b/examples/experimental/startup_feature_ideas/app.py
@@ -1,0 +1,43 @@
+import agenta as ag
+import openai
+from agenta import FloatParam, MessagesInput
+
+default_prompt = (
+    "Give me 10 feature ideas to implement for a food delivery company in {country}!"
+)
+
+ag.init(app_name="baby_name_generator", base_name="app")
+ag.config.default(
+    temperature=FloatParam(0.2),
+)
+
+
+@ag.entrypoint
+def generate(
+    country: str,
+    inputs: MessagesInput,
+) -> str:
+    """
+    Generate a baby name based on the given country and gender.
+
+    Args:
+        country (str): The country to generate the name from.
+        gender (str): The gender of the baby.
+
+    Returns:
+        str: The generated baby name.
+    """
+
+    messages = [
+        {
+            "role": message.role,
+            "content": message.content.format(country=country),
+        }
+        for message in inputs.messages
+    ]
+
+    chat_completion = openai.ChatCompletion.create(
+        model="gpt-3.5-turbo",
+        messages=messages,
+    )
+    return chat_completion.choices[0].message.content

--- a/examples/experimental/startup_feature_ideas/app.py
+++ b/examples/experimental/startup_feature_ideas/app.py
@@ -15,9 +15,9 @@ ag.config.default(
 @ag.entrypoint
 def chat(
     inputs: MessagesInput = MessagesInput([{"role": "string", "content": "string"}])
-) -> str:    
+) -> str:
     messages = [
-        {git s
+        {
             "role": message["role"],
             "content": message["content"],
         }

--- a/examples/experimental/startup_feature_ideas/app.py
+++ b/examples/experimental/startup_feature_ideas/app.py
@@ -25,6 +25,7 @@ def chat(
         }
         for message in inputs
     ]
-    chat_completion = client.chat.completions.create(model="gpt-3.5-turbo",
-                                                     messages=messages)
+    chat_completion = client.chat.completions.create(
+        model="gpt-3.5-turbo", messages=messages
+    )
     return chat_completion.choices[0].message.content

--- a/examples/experimental/startup_feature_ideas/requirements.txt
+++ b/examples/experimental/startup_feature_ideas/requirements.txt
@@ -1,0 +1,2 @@
+agenta
+openai


### PR DESCRIPTION
## Description
This PR introduces a new data type for messages within Agenta, allowing users to develop chat-based applications. 

### Related Issue
Closes #869 

### Additional Information
To make use of data type, kindly do the following:

```python
import agenta as ag
from agenta import MessagesInput

...
...

@ag.entrypoint
def chat(
    inputs: MessagesInput = MessagesInput([{"role": "string", "content": "string"}])
) -> str:
    pass
```

See experimental [application](https://github.com/Agenta-AI/agenta/blob/71a3e0a8336c0987ed3bc5254023c0f50bff0497/examples/experimental/startup_feature_ideas/app.py) for usage. Kindly review and identify any areas that may need improvement. Thank you!