### PR TITLE
import resources using docker client only for the right environments

### DIFF
--- a/agenta-backend/agenta_backend/routers/app_router.py
+++ b/agenta-backend/agenta_backend/routers/app_router.py
@@ -8,8 +8,6 @@ from fastapi import APIRouter, HTTPException, Request
 from agenta_backend.services.selectors import get_user_own_org
 from agenta_backend.services import (
     app_manager,
-    docker_utils,
-    container_manager,
     db_manager,
 )
 from agenta_backend.utils.common import (
@@ -26,6 +24,11 @@ from agenta_backend.models.api.api_models import (
     EnvironmentOutput,
 )
 from agenta_backend.models import converters
+
+if os.environ["FEATURE_FLAG"] not in ["ee"]:
+    from agenta_backend.services import (
+        docker_utils
+    )
 
 if os.environ["FEATURE_FLAG"] in ["cloud", "ee", "demo"]:
     from agenta_backend.ee.services.selectors import (

--- a/agenta-backend/agenta_backend/routers/app_router.py
+++ b/agenta-backend/agenta_backend/routers/app_router.py
@@ -22,7 +22,7 @@ from agenta_backend.models.api.api_models import (
     AppVariantOutput,
     AddVariantFromImagePayload,
     EnvironmentOutput,
-    Image
+    Image,
 )
 from agenta_backend.models import converters
 
@@ -39,7 +39,7 @@ if os.environ["FEATURE_FLAG"] in ["cloud"]:
     )  # noqa pylint: disable-all
 elif os.environ["FEATURE_FLAG"] in ["ee"]:
     from agenta_backend.ee.services import (
-        deployment_manager
+        deployment_manager,
     )  # noqa pylint: disable-all
 else:
     from agenta_backend.services import deployment_manager

--- a/agenta-backend/agenta_backend/routers/app_router.py
+++ b/agenta-backend/agenta_backend/routers/app_router.py
@@ -26,9 +26,7 @@ from agenta_backend.models.api.api_models import (
 from agenta_backend.models import converters
 
 if os.environ["FEATURE_FLAG"] not in ["ee"]:
-    from agenta_backend.services import (
-        docker_utils
-    )
+    from agenta_backend.services import docker_utils
 
 if os.environ["FEATURE_FLAG"] in ["cloud", "ee", "demo"]:
     from agenta_backend.ee.services.selectors import (

--- a/agenta-backend/agenta_backend/routers/container_router.py
+++ b/agenta-backend/agenta_backend/routers/container_router.py
@@ -24,10 +24,6 @@ if os.environ["FEATURE_FLAG"] in ["ee"]:
 else:
     from agenta_backend.services import container_manager
 
-
-if os.environ["FEATURE_FLAG"] in ["oss", "cloud"]:
-    from agenta_backend.services.docker_utils import restart_container
-
 import logging
 
 logger = logging.getLogger(__name__)
@@ -97,7 +93,7 @@ async def restart_docker_container(
         container_id = deployment.container_id
 
         logger.debug(f"Restarting container with id: {container_id}")
-        restart_container(container_id)
+        container_manager.restart_container(container_id)
         return {"message": "Please wait a moment. The container is now restarting."}
     except Exception as ex:
         return JSONResponse({"message": str(ex)}, status_code=500)

--- a/agenta-backend/agenta_backend/routers/container_router.py
+++ b/agenta-backend/agenta_backend/routers/container_router.py
@@ -7,7 +7,6 @@ from agenta_backend.models.api.api_models import (
     Template,
 )
 from agenta_backend.services import db_manager
-from agenta_backend.services.docker_utils import restart_container
 from fastapi import APIRouter, Request, UploadFile, HTTPException
 from fastapi.responses import JSONResponse
 
@@ -18,11 +17,16 @@ if os.environ["FEATURE_FLAG"] in ["cloud", "ee", "demo"]:
 else:
     from agenta_backend.services.selectors import get_user_and_org_id
 
-if os.environ["FEATURE_FLAG"] in ["cloud", "ee"]:
+if os.environ["FEATURE_FLAG"] in ["cloud"]:
+    from agenta_backend.ee.services import container_manager
+if os.environ["FEATURE_FLAG"] in ["ee"]:
     from agenta_backend.ee.services import container_manager
 else:
     from agenta_backend.services import container_manager
 
+
+if os.environ["FEATURE_FLAG"] in ["oss", "cloud"]:
+    from agenta_backend.services.docker_utils import restart_container
 
 import logging
 

--- a/agenta-backend/agenta_backend/services/app_manager.py
+++ b/agenta-backend/agenta_backend/services/app_manager.py
@@ -22,7 +22,7 @@ if os.environ["FEATURE_FLAG"] in ["cloud"]:
     )  # noqa pylint: disable-all
 elif os.environ["FEATURE_FLAG"] in ["ee"]:
     from agenta_backend.ee.services import (
-        deployment_manager
+        deployment_manager,
     )  # noqa pylint: disable-all
 else:
     from agenta_backend.services import deployment_manager

--- a/agenta-backend/agenta_backend/services/app_manager.py
+++ b/agenta-backend/agenta_backend/services/app_manager.py
@@ -20,6 +20,10 @@ if os.environ["FEATURE_FLAG"] in ["cloud"]:
     from agenta_backend.ee.services import (
         lambda_deployment_manager as deployment_manager,
     )  # noqa pylint: disable-all
+elif os.environ["FEATURE_FLAG"] in ["ee"]:
+    from agenta_backend.ee.services import (
+        deployment_manager
+    )  # noqa pylint: disable-all
 else:
     from agenta_backend.services import deployment_manager
 

--- a/agenta-backend/agenta_backend/services/container_manager.py
+++ b/agenta-backend/agenta_backend/services/container_manager.py
@@ -19,6 +19,7 @@ from agenta_backend.models.api.api_models import Image
 from agenta_backend.models.db_models import (
     AppDB,
 )
+from agenta_backend.services import docker_utils
 
 client = docker.from_env()
 
@@ -188,3 +189,11 @@ async def get_image_details_from_docker_hub(
             f"{repo_owner}/{repo_name}:{image_name}"
         )
         return image_details["Id"]
+
+def restart_container(container_id: str):
+    """Restart docker container.
+
+    Args:
+        container_id (str): The id of the container to restart.
+    """
+    docker_utils.restart_container(container_id)

--- a/agenta-backend/agenta_backend/services/container_manager.py
+++ b/agenta-backend/agenta_backend/services/container_manager.py
@@ -127,61 +127,6 @@ def build_image_job(
         raise HTTPException(status_code=500, detail=str(ex))
 
 
-@backoff.on_exception(backoff.expo, (ConnectError, CancelledError), max_tries=5)
-async def retrieve_templates_from_dockerhub(
-    url: str, repo_owner: str, repo_name: str
-) -> Union[List[dict], dict]:
-    """
-    Business logic to retrieve templates from DockerHub.
-
-    Args:
-        url (str): The URL endpoint for retrieving templates. Should contain placeholders `{}`
-            for the `repo_owner` and `repo_name` values to be inserted. For example:
-            `https://hub.docker.com/v2/repositories/{}/{}/tags`.
-        repo_owner (str): The owner or organization of the repository from which templates are to be retrieved.
-        repo_name (str): The name of the repository where the templates are located.
-
-    Returns:
-        tuple: A tuple containing two values.
-    """
-
-    async with httpx.AsyncClient() as client:
-        response = await client.get(
-            f"{url.format(repo_owner, repo_name)}/tags", timeout=10
-        )
-        if response.status_code == 200:
-            response_data = response.json()
-            return response_data
-
-        response_data = response.json()
-        return response_data
-
-
-@backoff.on_exception(
-    backoff.expo, (ConnectError, TimeoutException, CancelledError), max_tries=5
-)
-async def get_templates_info_from_s3(url: str) -> Dict[str, Dict[str, Any]]:
-    """
-    Business logic to retrieve templates information from S3.
-
-    Args:
-        url (str): The URL endpoint for retrieving templates info.
-
-    Returns:
-        response_data (Dict[str, Dict[str, Any]]): A dictionary \
-            containing dictionaries of templates information.
-    """
-
-    async with httpx.AsyncClient() as client:
-        response = await client.get(url, timeout=10)
-        if response.status_code == 200:
-            response_data = response.json()
-            return response_data
-
-        response_data = response.json()
-        return response_data
-
-
 async def check_docker_arch() -> str:
     """Checks the architecture of the Docker system.
 

--- a/agenta-backend/agenta_backend/services/container_manager.py
+++ b/agenta-backend/agenta_backend/services/container_manager.py
@@ -190,6 +190,7 @@ async def get_image_details_from_docker_hub(
         )
         return image_details["Id"]
 
+
 def restart_container(container_id: str):
     """Restart docker container.
 

--- a/agenta-backend/agenta_backend/services/templates_manager.py
+++ b/agenta-backend/agenta_backend/services/templates_manager.py
@@ -1,10 +1,18 @@
 import json
+import backoff
 from typing import Any, Dict, List
-
+import httpx
+import os
 from agenta_backend.config import settings
-from agenta_backend.services import container_manager, db_manager
+from agenta_backend.services import db_manager
 from agenta_backend.utils import redis_utils
+from httpx import ConnectError, TimeoutException
+from asyncio.exceptions import CancelledError
 
+if os.environ["FEATURE_FLAG"] in ["oss", "cloud"]:
+    from agenta_backend.services import container_manager
+
+from typing import Union
 
 async def update_and_sync_templates(cache: bool = True) -> None:
     """
@@ -75,7 +83,7 @@ async def retrieve_templates_from_dockerhub_cached(cache: bool) -> List[dict]:
             return json.loads(cached_data.decode("utf-8"))
 
     # If not cached, fetch data from Docker Hub and cache it in Redis
-    response = await container_manager.retrieve_templates_from_dockerhub(
+    response = await retrieve_templates_from_dockerhub(
         settings.docker_hub_url,
         settings.docker_hub_repo_owner,
         settings.docker_hub_repo_name,
@@ -107,7 +115,7 @@ async def retrieve_templates_info_from_s3(
             return json.loads(cached_data)
 
     # If not cached, fetch data from Docker Hub and cache it in Redis
-    response = await container_manager.get_templates_info_from_s3(
+    response = await get_templates_info_from_s3(
         "https://llm-app-json.s3.eu-central-1.amazonaws.com/llm_info.json"
     )
 
@@ -115,3 +123,60 @@ async def retrieve_templates_info_from_s3(
     r.set("temp_data", json.dumps(response), ex=900)
     print("Using network call...")
     return response
+
+
+@backoff.on_exception(backoff.expo, (ConnectError, CancelledError), max_tries=5)
+async def retrieve_templates_from_dockerhub(
+    url: str, repo_owner: str, repo_name: str
+) -> Union[List[dict], dict]:
+    """
+    Business logic to retrieve templates from DockerHub.
+
+    Args:
+        url (str): The URL endpoint for retrieving templates. Should contain placeholders `{}`
+            for the `repo_owner` and `repo_name` values to be inserted. For example:
+            `https://hub.docker.com/v2/repositories/{}/{}/tags`.
+        repo_owner (str): The owner or organization of the repository from which templates are to be retrieved.
+        repo_name (str): The name of the repository where the templates are located.
+
+    Returns:
+        tuple: A tuple containing two values.
+    """
+
+    async with httpx.AsyncClient() as client:
+        response = await client.get(
+            f"{url.format(repo_owner, repo_name)}/tags", timeout=10
+        )
+        if response.status_code == 200:
+            response_data = response.json()
+            return response_data
+
+        response_data = response.json()
+        return response_data
+
+
+@backoff.on_exception(
+    backoff.expo, (ConnectError, TimeoutException, CancelledError), max_tries=5
+)
+
+
+async def get_templates_info_from_s3(url: str) -> Dict[str, Dict[str, Any]]:
+    """
+    Business logic to retrieve templates information from S3.
+
+    Args:
+        url (str): The URL endpoint for retrieving templates info.
+
+    Returns:
+        response_data (Dict[str, Dict[str, Any]]): A dictionary \
+            containing dictionaries of templates information.
+    """
+
+    async with httpx.AsyncClient() as client:
+        response = await client.get(url, timeout=10)
+        if response.status_code == 200:
+            response_data = response.json()
+            return response_data
+
+        response_data = response.json()
+        return response_data

--- a/agenta-backend/agenta_backend/services/templates_manager.py
+++ b/agenta-backend/agenta_backend/services/templates_manager.py
@@ -14,6 +14,7 @@ if os.environ["FEATURE_FLAG"] in ["oss", "cloud"]:
 
 from typing import Union
 
+
 async def update_and_sync_templates(cache: bool = True) -> None:
     """
     Updates and synchronizes templates by retrieving templates from DockerHub and S3, adding new templates to the database,
@@ -158,8 +159,6 @@ async def retrieve_templates_from_dockerhub(
 @backoff.on_exception(
     backoff.expo, (ConnectError, TimeoutException, CancelledError), max_tries=5
 )
-
-
 async def get_templates_info_from_s3(url: str) -> Dict[str, Dict[str, Any]]:
     """
     Business logic to retrieve templates information from S3.


### PR DESCRIPTION
- Adjust importing resources using docker client only for the right environments.
- Moved 2 methods to the templates manager as they belongs there.
