### PR TITLE
[Bug Fix]: Resolve race condition => Base deployment issue

### DIFF
--- a/agenta-backend/agenta_backend/routers/app_router.py
+++ b/agenta-backend/agenta_backend/routers/app_router.py
@@ -241,7 +241,7 @@ async def add_variant_from_image(
                 status_code=500,
                 detail="Image should have a tag starting with the registry name (agenta-server)",
             )
-        elif deployment_manager.validate_image(image) is False:
+        elif await deployment_manager.validate_image(image) is False:
             raise HTTPException(status_code=404, detail="Image not found")
 
     try:

--- a/agenta-backend/agenta_backend/services/db_manager.py
+++ b/agenta-backend/agenta_backend/services/db_manager.py
@@ -1153,9 +1153,6 @@ async def update_variant_parameters(
     try:
         logging.debug("Updating variant parameters")
 
-        # Update AppVariantDB parameters
-        app_variant_db.parameters = parameters
-
         # Update associated ConfigDB parameters and versioning
         config_db = app_variant_db.config
         new_version = config_db.current_version + 1
@@ -1168,9 +1165,9 @@ async def update_variant_parameters(
         )
         config_db.current_version = new_version
         config_db.parameters = parameters
-        # Save updated ConfigDB and AppVariantDB
+
+        # Save updated ConfigDB
         await engine.save(config_db)
-        await engine.save(app_variant_db)
 
     except Exception as e:
         logging.error(f"Issue updating variant parameters: {e}")


### PR DESCRIPTION
## Description
This PR resolves the race condition bug.

### Changes Made:
 - Removed `await engine.save(app_variant_db)`  to prevent race conditions during deployment updates.
- Set `await` to ensure validate_image in the deployment manager runs successfully.

### Related Issue
Closes #904 