### PR TITLE
Enhancement - Add support for configurable Agenta Cloud URL in CLI

### DIFF
--- a/agenta-cli/agenta/cli/helper.py
+++ b/agenta-cli/agenta/cli/helper.py
@@ -57,13 +57,16 @@ def set_global_config(var_name: str, var_value: Any) -> None:
         toml.dump(global_config, config_file)
 
 
-def get_api_key() -> str:
+def get_api_key(backend_host: str) -> str:
     """
     Retrieve or request the API key for accessing the Agenta platform.
 
     This function first looks for an existing API key in the global config file.
     If found, it prompts the user to confirm whether they'd like to use that key.
     If not found, it asks the user to input a new key.
+
+    Args:
+        backend_host (str): The URL to the backend
 
     Returns:
         str: The API key to be used for accessing the Agenta platform.
@@ -85,7 +88,7 @@ def get_api_key() -> str:
             sys.exit(0)
 
     api_key = questionary.text(
-        "(You can get your API Key here: https://cloud.agenta.ai/settings?tab=apiKeys) "
+        f"(You can get your API Key here: {backend_host}/settings?tab=apiKeys) "
         "Please provide your API key:"
     ).ask()
 

--- a/agenta-cli/agenta/cli/helper.py
+++ b/agenta-cli/agenta/cli/helper.py
@@ -57,13 +57,16 @@ def set_global_config(var_name: str, var_value: Any) -> None:
         toml.dump(global_config, config_file)
 
 
-def get_api_key() -> str:
+def get_api_key(backend_host: str) -> str:
     """
     Retrieve or request the API key for accessing the Agenta platform.
 
     This function first looks for an existing API key in the global config file.
     If found, it prompts the user to confirm whether they'd like to use that key.
     If not found, it asks the user to input a new key.
+
+    Args:
+        backend_host (str): The URL of the backend host.
 
     Returns:
         str: The API key to be used for accessing the Agenta platform.
@@ -85,7 +88,7 @@ def get_api_key() -> str:
             sys.exit(0)
 
     api_key = questionary.text(
-        "(You can get your API Key here: https://cloud.agenta.ai/settings?tab=apiKeys) "
+        f"(You can get your API Key here: {backend_host}/settings?tab=apiKeys) "
         "Please provide your API key:"
     ).ask()
 

--- a/agenta-cli/agenta/cli/helper.py
+++ b/agenta-cli/agenta/cli/helper.py
@@ -57,16 +57,13 @@ def set_global_config(var_name: str, var_value: Any) -> None:
         toml.dump(global_config, config_file)
 
 
-def get_api_key(backend_host: str) -> str:
+def get_api_key() -> str:
     """
     Retrieve or request the API key for accessing the Agenta platform.
 
     This function first looks for an existing API key in the global config file.
     If found, it prompts the user to confirm whether they'd like to use that key.
     If not found, it asks the user to input a new key.
-
-    Args:
-        backend_host (str): The URL to the backend
 
     Returns:
         str: The API key to be used for accessing the Agenta platform.
@@ -88,7 +85,7 @@ def get_api_key(backend_host: str) -> str:
             sys.exit(0)
 
     api_key = questionary.text(
-        f"(You can get your API Key here: {backend_host}/settings?tab=apiKeys) "
+        "(You can get your API Key here: https://cloud.agenta.ai/settings?tab=apiKeys) "
         "Please provide your API key:"
     ).ask()
 

--- a/agenta-cli/agenta/cli/main.py
+++ b/agenta-cli/agenta/cli/main.py
@@ -73,9 +73,8 @@ def cli():
 
 
 @click.command()
-@click.option("--working_dir", default=".")
 @click.option("--app_name", default="")
-def init(working_dir: str, app_name: str):
+def init(app_name: str):
     """Initialize a new Agenta app with the template files."""
     if not app_name:
         while True:
@@ -90,11 +89,6 @@ def init(working_dir: str, app_name: str):
                         "Invalid input. Please use only alphanumeric characters without spaces."
                     )
 
-    # Get config.toml from current working directory
-    app_folder = Path(working_dir)
-    config_file = app_folder / "config.toml"
-    loaded_config = toml.load(config_file)
-
     try:
         where_question = questionary.select(
             "Where are you running agenta?",
@@ -108,8 +102,9 @@ def init(working_dir: str, app_name: str):
                 "Please provide the IP or URL of your remote host"
             ).ask()
         elif where_question == "On agenta cloud":
-            if loaded_config:
-                backend_host = loaded_config["backend_host"]
+            global_backend_host = helper.get_global_config("host")
+            if global_backend_host:
+                backend_host = global_backend_host
             else:
                 backend_host = "https://cloud.agenta.ai"
 

--- a/agenta-cli/agenta/cli/main.py
+++ b/agenta-cli/agenta/cli/main.py
@@ -104,7 +104,7 @@ def init(app_name: str):
         elif where_question == "On agenta cloud":
             backend_host = "https://cloud.agenta.ai"
 
-            api_key = helper.get_api_key(backend_host)
+            api_key = helper.get_api_key()
             client.validate_api_key(api_key, backend_host)
 
         elif where_question is None:  # User pressed Ctrl+C

--- a/agenta-cli/agenta/cli/main.py
+++ b/agenta-cli/agenta/cli/main.py
@@ -102,12 +102,7 @@ def init(app_name: str):
                 "Please provide the IP or URL of your remote host"
             ).ask()
         elif where_question == "On agenta cloud":
-            backend_host = questionary.text(
-                "Please provide the URL for the backend host. Defaults to: https://cloud.agenta.ai",
-            ).ask()
-            backend_host = (
-                "https://cloud.agenta.ai" if not backend_host else backend_host
-            )
+            backend_host = "https://cloud.agenta.ai"
 
             api_key = helper.get_api_key(backend_host)
             client.validate_api_key(api_key, backend_host)

--- a/agenta-cli/agenta/cli/main.py
+++ b/agenta-cli/agenta/cli/main.py
@@ -73,8 +73,9 @@ def cli():
 
 
 @click.command()
+@click.option("--working_dir", default=".")
 @click.option("--app_name", default="")
-def init(app_name: str):
+def init(working_dir: str, app_name: str):
     """Initialize a new Agenta app with the template files."""
     if not app_name:
         while True:
@@ -89,6 +90,11 @@ def init(app_name: str):
                         "Invalid input. Please use only alphanumeric characters without spaces."
                     )
 
+    # Get config.toml from current working directory
+    app_folder = Path(working_dir)
+    config_file = app_folder / "config.toml"
+    loaded_config = toml.load(config_file)
+
     try:
         where_question = questionary.select(
             "Where are you running agenta?",
@@ -102,7 +108,10 @@ def init(app_name: str):
                 "Please provide the IP or URL of your remote host"
             ).ask()
         elif where_question == "On agenta cloud":
-            backend_host = "https://cloud.agenta.ai"
+            if loaded_config:
+                backend_host = loaded_config["backend_host"]
+            else:
+                backend_host = "https://cloud.agenta.ai"
 
             api_key = helper.get_api_key()
             client.validate_api_key(api_key, backend_host)

--- a/agenta-cli/agenta/cli/main.py
+++ b/agenta-cli/agenta/cli/main.py
@@ -108,7 +108,7 @@ def init(app_name: str):
             else:
                 backend_host = "https://cloud.agenta.ai"
 
-            api_key = helper.get_api_key()
+            api_key = helper.get_api_key(backend_host)
             client.validate_api_key(api_key, backend_host)
 
         elif where_question is None:  # User pressed Ctrl+C

--- a/agenta-cli/agenta/cli/main.py
+++ b/agenta-cli/agenta/cli/main.py
@@ -8,9 +8,10 @@ import click
 import questionary
 import toml
 
-from agenta.client import client
-from agenta.cli import variant_commands
 from agenta.cli import helper
+from agenta.client import client
+from agenta.cli import variant_configs
+from agenta.cli import variant_commands
 
 
 def print_version(ctx, param, value):
@@ -192,6 +193,7 @@ def init(app_name: str):
 
 # Add the commands to the CLI group
 cli.add_command(init)
+cli.add_command(variant_configs.config)
 cli.add_command(variant_commands.variant)
 
 if __name__ == "__main__":

--- a/agenta-cli/agenta/cli/main.py
+++ b/agenta-cli/agenta/cli/main.py
@@ -101,8 +101,14 @@ def init(app_name: str):
                 "Please provide the IP or URL of your remote host"
             ).ask()
         elif where_question == "On agenta cloud":
-            backend_host = "https://cloud.agenta.ai"
-            api_key = helper.get_api_key()
+            backend_host = questionary.text(
+                "Please provide the URL for the backend host. Defaults to: https://cloud.agenta.ai",
+            ).ask()
+            backend_host = (
+                "https://cloud.agenta.ai" if not backend_host else backend_host
+            )
+
+            api_key = helper.get_api_key(backend_host)
             client.validate_api_key(api_key, backend_host)
 
         elif where_question is None:  # User pressed Ctrl+C

--- a/agenta-cli/agenta/cli/variant_configs.py
+++ b/agenta-cli/agenta/cli/variant_configs.py
@@ -24,12 +24,12 @@ def update_backend_host(app_folder: str, backend_host: str):
     app_folder = Path(app_folder)
     config_file = app_folder / "config.toml"
     if not config_file.exists():
-        click.echo(
-            click.style(
-                f"Config file not found in {app_folder}. Make sure you are in the right folder and that you have run agenta init first.",
-                fg="red",
-            )
-        )
+        # Set app toml configuration
+        config = {
+            "backend_host": backend_host,
+        }
+        with open("config.toml", "w") as config_file:
+            toml.dump(config, config_file)
         return
 
     # Update the config file
@@ -39,7 +39,7 @@ def update_backend_host(app_folder: str, backend_host: str):
 
 
 @config.command(
-    name="url",
+    name="set-host",
     context_settings=dict(
         ignore_unknown_options=True,
         allow_extra_args=True,

--- a/agenta-cli/agenta/cli/variant_configs.py
+++ b/agenta-cli/agenta/cli/variant_configs.py
@@ -1,7 +1,5 @@
-from pathlib import Path
-
 import click
-import toml
+from agenta.cli import helper
 
 
 @click.group()
@@ -10,7 +8,7 @@ def config():
     pass
 
 
-def update_backend_host(app_folder: str, backend_host: str):
+def update_backend_host(backend_host: str):
     """Check the config file and update the backend URL
 
     Arguments:
@@ -19,23 +17,9 @@ def update_backend_host(app_folder: str, backend_host: str):
     """
 
     click.echo(
-        click.style("\nChecking and updating backend host...", fg="bright_black")
+        click.style("\nChecking and updating global backend host...", fg="bright_black")
     )
-    app_folder = Path(app_folder)
-    config_file = app_folder / "config.toml"
-    if not config_file.exists():
-        # Set app toml configuration
-        config = {
-            "backend_host": backend_host,
-        }
-        with open("config.toml", "w") as config_file:
-            toml.dump(config, config_file)
-        return
-
-    # Update the config file
-    config = toml.load(config_file)
-    config["backend_host"] = backend_host
-    toml.dump(config, config_file.open("w"))
+    helper.set_global_config("host", backend_host)
 
 
 @config.command(
@@ -45,12 +29,11 @@ def update_backend_host(app_folder: str, backend_host: str):
         allow_extra_args=True,
     ),
 )
-@click.option("--app_folder", default=".")
 @click.option(
     "--backend_host", default=None, help="The URL of the backend host to use."
 )
 @click.pass_context
-def set_config_url(ctx, app_folder: str, backend_host: str):
+def set_config_url(ctx, backend_host: str):
     """Set the backend URL in the app configuration"""
 
     try:
@@ -60,7 +43,7 @@ def set_config_url(ctx, app_folder: str, backend_host: str):
             else:
                 click.echo(click.style("Backend host URL not specified", fg="red"))
 
-        update_backend_host(app_folder, backend_host)
+        update_backend_host(backend_host)
         click.echo(click.style("Backend host updated successfully! 🎉\n"))
     except Exception as ex:
         click.echo(click.style(f"Error updating backend host: {ex}", fg="red"))

--- a/agenta-cli/agenta/cli/variant_configs.py
+++ b/agenta-cli/agenta/cli/variant_configs.py
@@ -1,0 +1,66 @@
+from pathlib import Path
+
+import click
+import toml
+
+
+@click.group()
+def config():
+    """Commands for variants configurations"""
+    pass
+
+
+def update_backend_host(app_folder: str, backend_host: str):
+    """Check the config file and update the backend URL
+
+    Arguments:
+        app_folder -- the app folder
+        backend_host -- the backend host
+    """
+
+    click.echo(
+        click.style("\nChecking and updating backend host...", fg="bright_black")
+    )
+    app_folder = Path(app_folder)
+    config_file = app_folder / "config.toml"
+    if not config_file.exists():
+        click.echo(
+            click.style(
+                f"Config file not found in {app_folder}. Make sure you are in the right folder and that you have run agenta init first.",
+                fg="red",
+            )
+        )
+        return
+
+    # Update the config file
+    config = toml.load(config_file)
+    config["backend_host"] = backend_host
+    toml.dump(config, config_file.open("w"))
+
+
+@config.command(
+    name="url",
+    context_settings=dict(
+        ignore_unknown_options=True,
+        allow_extra_args=True,
+    ),
+)
+@click.option("--app_folder", default=".")
+@click.option(
+    "--backend_host", default=None, help="The URL of the backend host to use."
+)
+@click.pass_context
+def set_config_url(ctx, app_folder: str, backend_host: str):
+    """Set the backend URL in the app configuration"""
+
+    try:
+        if not backend_host:
+            if ctx.args:
+                backend_host = ctx.args[0]
+            else:
+                click.echo(click.style("Backend host URL not specified", fg="red"))
+
+        update_backend_host(app_folder, backend_host)
+        click.echo(click.style("Backend host updated successfully! 🎉\n"))
+    except Exception as ex:
+        click.echo(click.style(f"Error updating backend host: {ex}", fg="red"))


### PR DESCRIPTION
## Description
Currently, the CLI defaults to the cloud backend host when the cloud option is selected, which may not be desirable for all use cases. With this update, users can set the URL they want to use, enabling them to seamlessly switch between the various environment of Agenta as per their development needs. 

To set the URL, run the command, `agenta config set-host https://example.com`.

### Related Issue
Closes [C_180](https://github.com/Agenta-AI/agenta_cloud/issues/180)