### PR TITLE
Fix 500 error in non-match testset vs variant input names

### DIFF
--- a/agenta-backend/agenta_backend/services/evaluation_service.py
+++ b/agenta-backend/agenta_backend/services/evaluation_service.py
@@ -196,8 +196,6 @@ async def prepare_csvdata_and_create_evaluation_scenario(
         user: The owner of the evaluation scenario
         app: The app the evaluation is going to belong to
     """
-    
-    print('payload_inputs', payload_inputs)
 
     for datum in csvdata:
         # Check whether the inputs in the test set match the inputs in the variant

--- a/agenta-backend/agenta_backend/services/evaluation_service.py
+++ b/agenta-backend/agenta_backend/services/evaluation_service.py
@@ -190,7 +190,7 @@ async def prepare_csvdata_and_create_evaluation_scenario(
 
     Args:
         csvdata: A list of dictionaries representing the CSV data.
-        inputs: A list of strings representing the names of the inputs in the variant.
+        payload_inputs: A list of strings representing the names of the inputs in the variant.
         evaluation_type: The type of evaluation
         new_evaluation: The instance of EvaluationDB
         user: The owner of the evaluation scenario
@@ -208,7 +208,7 @@ async def prepare_csvdata_and_create_evaluation_scenario(
             await engine.delete(new_evaluation)
             msg = f"""
             Columns in the test set should match the names of the inputs in the variant.
-            Inputs names in variant are: {inputs} while
+            Inputs names in variant are: {[variant_input for variant_input in payload_inputs]} while
             columns in test set are: {[col for col in datum.keys() if col != 'correct_answer']}
             """
             raise HTTPException(


### PR DESCRIPTION
This PR resolves #992 

When the input names in the variant doesn't match the input in the testset, the error is returned properly. 

<img width="1344" alt="image" src="https://github.com/Agenta-AI/agenta/assets/56418363/d322f152-ff78-493c-8db2-6f09c40d704f">
