### PR TITLE
Use Generator Expressions Instead of List Comprehensions

### DIFF
--- a/agenta-backend/agenta_backend/services/app_manager.py
+++ b/agenta-backend/agenta_backend/services/app_manager.py
@@ -392,7 +392,7 @@ async def add_variant_based_on_image(
     variants = await db_manager.list_app_variants_for_app_id(
         app_id=str(app.id), **user_org_data
     )
-    already_exists = any([av for av in variants if av.variant_name == variant_name])
+    already_exists = any(av for av in variants if av.variant_name == variant_name)
     if already_exists:
         logger.error("App variant with the same name already exists")
         raise ValueError("App variant with the same name already exists")

--- a/agenta-backend/agenta_backend/services/db_manager.py
+++ b/agenta-backend/agenta_backend/services/db_manager.py
@@ -753,7 +753,7 @@ async def add_variant_from_base_and_config(
     app_variant_for_base = await list_variants_for_base(base_db)
 
     already_exists = any(
-        [av for av in app_variant_for_base if av.config_name == new_config_name]
+        av for av in app_variant_for_base if av.config_name == new_config_name
     )
     if already_exists:
         raise ValueError("App variant with the same name already exists")


### PR DESCRIPTION
In Python, when we use list comprehensions, it's like we've created the entire pile of apples and asked the interpreter to hold onto it. Sometimes, a better practice involves using generator expressions, which create iterators that yield objects one at a time. For large data sets, this can turn a slow, memory-intensive operation into a relatively fast one. What do you think?

Using generator expressions instead of list comprehensions can lead to better performance. This is especially true for functions such as anywhere it's not always necessary to evaluate the entire list before returning. For other functions such as max or sum it means that the program does not need to store the entire list in memory. These performance effects become more noticeable as the sizes of the lists involved grow larger.

This codemod replaces the use of a list comprehension expression with a generator expression within certain function calls. Generators allow for lazy evaluation of the iterator, which can have performance benefits.

The changes from this code look like this:

```
- result = sum([x for x in range(1000)])
+ result = sum(x for x in range(1000))
```

References:

- https://pylint.readthedocs.io/en/latest/user_guide/messages/refactor/use-a-generator.html
- https://docs.python.org/3/glossary.html#term-generator-expression
- https://docs.python.org/3/glossary.html#term-list-comprehension