### PR TITLE
Update version to 0.6.3 and add register_default method as an alias for default

### DIFF
--- a/agenta-cli/agenta/sdk/agenta_init.py
+++ b/agenta-cli/agenta/sdk/agenta_init.py
@@ -83,6 +83,10 @@ class Config:
         else:
             self.persist = True
 
+    def register_default(self, overwrite=True, **kwargs):
+        """alias for default"""
+        return self.default(overwrite=overwrite, **kwargs)
+
     def default(self, overwrite=True, **kwargs):
         """Saves the default parameters to the app_name and base_name in case they are not already saved.
         Args:

--- a/agenta-cli/pyproject.toml
+++ b/agenta-cli/pyproject.toml
@@ -1,6 +1,6 @@
 [tool.poetry]
 name = "agenta"
-version = "0.6.2"
+version = "0.6.3"
 description = "The SDK for agenta is an open-source LLMOps platform."
 readme = "README.md"
 authors = ["Mahmoud Mabrouk <mahmoud@agenta.ai>"]


### PR DESCRIPTION
This pull request updates the version of the `agenta` SDK to 0.6.3 and adds a new method `register_default` as an alias for the existing `default` method. The `register_default` method allows for easier registration of default parameters. This change improves the usability and flexibility of the SDK.