### PR TITLE
Fix removing variants

### DIFF
--- a/agenta-cli/agenta/client/client.py
+++ b/agenta-cli/agenta/client/client.py
@@ -268,7 +268,7 @@ def remove_variant(variant_id: str, host: str, api_key: str = None):
         None
     """
     response = requests.delete(
-        f"{host}/{BACKEND_URL_SUFFIX}/variants/{variant_id}",
+        f"{host}/{BACKEND_URL_SUFFIX}/variants/{variant_id}/",
         headers={
             "Content-Type": "application/json",
             "Authorization": api_key if api_key is not None else None,

--- a/agenta-cli/agenta/config.py
+++ b/agenta-cli/agenta/config.py
@@ -1,4 +1,4 @@
-from pydantic import BaseSettings
+from pydantic.v1 import BaseSettings
 
 import os
 import toml


### PR DESCRIPTION
This PR fixes;

- Deleting Variants in Cloud: This was caused by a missing `/` in the endpoint url. It works without using Localhost but not in Cloud due to Server Configuration. 
- Pydantic Import Error in the CLI. `PydanticImportError: BaseSettings has been moved to the pydantic-settings package. See https://docs.pydantic.dev/2.0.2/migration/#basesettings-has-moved-to-pydantic-settings for more details.` This was caused by the upgrade to Pydantic v2. In `pydantic-V2`, Settings management has been moved to a separate package named `pydantic-settings`. 

   The previous way was;
   ```bash
   from pydantic import BaseSettings 
   ```
   The new way was to do;
   ```bash
   from pydantic_settings import BaseSettings
   ```
However, installing `pydantic-settings` failed because of dependency mismatch. Hence the best solution I found to use was to import `BaseSettings` from `pydantic.v1`
   ```bash
   from pydantic.v1 import BaseSettings
   ```