### PR TITLE
Fix removing variants in cloud

### DIFF
--- a/agenta-cli/agenta/client/client.py
+++ b/agenta-cli/agenta/client/client.py
@@ -268,7 +268,7 @@ def remove_variant(variant_id: str, host: str, api_key: str = None):
         None
     """
     response = requests.delete(
-        f"{host}/{BACKEND_URL_SUFFIX}/variants/{variant_id}",
+        f"{host}/{BACKEND_URL_SUFFIX}/variants/{variant_id}/",
         headers={
             "Content-Type": "application/json",
             "Authorization": api_key if api_key is not None else None,

--- a/agenta-cli/agenta/config.py
+++ b/agenta-cli/agenta/config.py
@@ -1,4 +1,4 @@
-from pydantic import BaseSettings
+from pydantic.v1 import BaseSettings
 
 import os
 import toml

--- a/agenta-cli/agenta/config.py
+++ b/agenta-cli/agenta/config.py
@@ -1,4 +1,4 @@
-from pydantic.v1 import BaseSettings
+from pydantic import BaseSettings
 
 import os
 import toml


### PR DESCRIPTION
This PR fixes;

- Deleting Variants in Cloud: This was caused by a missing `/` in the endpoint url. It works without using Localhost but not in Cloud due to Server Configuration. 