### PR TITLE
Add Tooltip for adding all conversation turns in AddToTestSetDrawer

### DIFF
--- a/agenta-web/src/components/Playground/AddToTestSetDrawer/AddToTestSetDrawer.tsx
+++ b/agenta-web/src/components/Playground/AddToTestSetDrawer/AddToTestSetDrawer.tsx
@@ -14,6 +14,7 @@ import {
     Space,
     Switch,
     Typography,
+    Tooltip,
     message,
 } from "antd"
 import {useRouter} from "next/router"
@@ -247,7 +248,12 @@ const AddToTestSetDrawer: React.FC<Props> = ({params, isChatVariant, ...props}) 
                 <div className={classes.footer}>
                     {isChatVariant && (
                         <Space align="center">
-                            <Typography.Text>Turn by Turn:</Typography.Text>
+                            <Tooltip
+                                placement="topLeft"
+                                title="Add each exchange in the conversation as an individual data point"
+                            >
+                                <Typography.Text>Add all conversation turns:</Typography.Text>
+                            </Tooltip>
                             <Switch
                                 checked={Array.isArray(turnModeChat)}
                                 onChange={(checked) => {


### PR DESCRIPTION
This pull request adds a Tooltip component to the AddToTestSetDrawer file. The Tooltip provides a description and functionality for adding all conversation turns as individual data points. This enhancement improves the user experience and makes it easier to add multiple exchanges in a conversation.