### PR TITLE
Fix register_default overwrite behavior

### DIFF
--- a/agenta-backend/agenta_backend/routers/configs_router.py
+++ b/agenta-backend/agenta_backend/routers/configs_router.py
@@ -44,7 +44,7 @@ async def save_config(
                 variant_to_overwrite = variant_db
                 break
         if variant_to_overwrite is not None:
-            if payload.overwrite:
+            if payload.overwrite or variant_to_overwrite.config.parameters == {}:
                 print(f"update_variant_parameters  ===> {payload.overwrite}")
                 await app_manager.update_variant_parameters(
                     app_variant_id=str(variant_to_overwrite.id),

--- a/agenta-backend/agenta_backend/services/app_manager.py
+++ b/agenta-backend/agenta_backend/services/app_manager.py
@@ -142,7 +142,9 @@ async def update_variant_image(
     # Update variant with new image
     app_variant_db = await db_manager.update_app_variant(app_variant_db, image=db_image)
     # Update variant to remove configuration
-    await db_manager.update_variant_parameters(app_variant_db=app_variant_db, parameters={})
+    await db_manager.update_variant_parameters(
+        app_variant_db=app_variant_db, parameters={}
+    )
     # Start variant
     await start_variant(app_variant_db, **kwargs)
 

--- a/agenta-backend/agenta_backend/services/app_manager.py
+++ b/agenta-backend/agenta_backend/services/app_manager.py
@@ -141,6 +141,8 @@ async def update_variant_image(
     await db_manager.update_base(app_variant_db.base, image=db_image)
     # Update variant with new image
     app_variant_db = await db_manager.update_app_variant(app_variant_db, image=db_image)
+    # Update variant to remove configuration
+    await db_manager.update_variant_parameters(app_variant_db=app_variant_db, parameters={})
     # Start variant
     await start_variant(app_variant_db, **kwargs)
 

--- a/agenta-backend/agenta_backend/services/app_manager.py
+++ b/agenta-backend/agenta_backend/services/app_manager.py
@@ -139,12 +139,13 @@ async def update_variant_image(
     )
     # Update base with new image
     await db_manager.update_base(app_variant_db.base, image=db_image)
-    # Update variant with new image
-    app_variant_db = await db_manager.update_app_variant(app_variant_db, image=db_image)
     # Update variant to remove configuration
     await db_manager.update_variant_parameters(
         app_variant_db=app_variant_db, parameters={}
     )
+    # Update variant with new image
+    app_variant_db = await db_manager.update_app_variant(app_variant_db, image=db_image)
+
     # Start variant
     await start_variant(app_variant_db, **kwargs)
 

--- a/agenta-cli/agenta/sdk/agenta_init.py
+++ b/agenta-cli/agenta/sdk/agenta_init.py
@@ -1,3 +1,5 @@
+from agenta.client.exceptions import APIRequestError
+from agenta.client.backend.client import AgentaApi
 import os
 import logging
 from typing import Any, Optional
@@ -7,8 +9,6 @@ from .utils.globals import set_global
 logger = logging.getLogger(__name__)
 logger.setLevel(logging.DEBUG)
 
-from agenta.client.backend.client import AgentaApi
-from agenta.client.exceptions import APIRequestError
 
 BACKEND_URL_SUFFIX = os.environ.get("BACKEND_URL_SUFFIX", "api")
 CLIENT_API_KEY = os.environ.get("AGENTA_API_KEY")
@@ -104,11 +104,11 @@ class Config:
         else:
             self.persist = True
 
-    def register_default(self, overwrite=True, **kwargs):
+    def register_default(self, overwrite=False, **kwargs):
         """alias for default"""
         return self.default(overwrite=overwrite, **kwargs)
 
-    def default(self, overwrite=True, **kwargs):
+    def default(self, overwrite=False, **kwargs):
         """Saves the default parameters to the app_name and base_name in case they are not already saved.
         Args:
             overwrite: Whether to overwrite the existing configuration or not


### PR DESCRIPTION
This PR fixes the issues in #1102
The issue was that each time register_default was called, the default configuration was resetted to the default specified in the code. In lambda this meant that at each call, the default configuration was resetted.

The solution was to:
- Change the behavior of register_default so that it does not overwrite the parameters unless they are empty (set to {})
- Each time we create a new application or overwrite a new application, we set the parameters to {}

As a result, now register_default only sets the parameters the first time post-deployment. After that it does not do anything. 

Potential issues: Right now POST config now returns an error when register_default is called. Are we handling this?