### PR TITLE
Refactor evaluations backend

### DIFF
--- a/agenta-backend/agenta_backend/models/converters.py
+++ b/agenta-backend/agenta_backend/models/converters.py
@@ -57,26 +57,23 @@ logger = logging.getLogger(__name__)
 logger.setLevel(logging.DEBUG)
 
 
-def evaluation_db_to_simple_evaluation_output(
-    evaluation_db: EvaluationDB,
+def human_evaluation_db_to_simple_evaluation_output(
+    human_evaluation_db: HumanEvaluationDB,
 ) -> SimpleEvaluationOutput:
     return SimpleEvaluationOutput(
-        id=str(evaluation_db.id),
-        app_id=str(evaluation_db.app.id),
-        status=evaluation_db.status,
-        evaluation_type=evaluation_db.evaluation_type,
-        variant_ids=[str(variant) for variant in evaluation_db.variants],
+        id=str(human_evaluation_db.id),
+        app_id=str(human_evaluation_db.app.id),
+        status=human_evaluation_db.status,
+        evaluation_type=human_evaluation_db.evaluation_type,
+        variant_ids=[str(variant) for variant in human_evaluation_db.variants],
     )
 
 
 async def evaluation_db_to_pydantic(
     evaluation_db: EvaluationDB,
 ) -> Evaluation:
-    variant_names = []
-    for variant_id in evaluation_db.variants:
-        variant = await db_manager.get_app_variant_instance_by_id(str(variant_id))
-        variant_name = variant.variant_name if variant else str(variant_id)
-        variant_names.append(str(variant_name))
+    variant = await db_manager.get_app_variant_instance_by_id(str(evaluation_db.variant))
+    variant_name = variant.variant_name if variant else str(evaluation_db.variant)
 
     return Evaluation(
         id=str(evaluation_db.id),
@@ -84,8 +81,8 @@ async def evaluation_db_to_pydantic(
         user_id=str(evaluation_db.user.id),
         user_username=evaluation_db.user.username or "",
         status=evaluation_db.status,
-        variant_ids=[str(variant) for variant in evaluation_db.variants],
-        variant_names=variant_names,
+        variant_ids=[str(evaluation_db.variant)],
+        variant_names=[variant_name],
         testset_id=str(evaluation_db.testset.id),
         testset_name=evaluation_db.testset.name,
         aggregated_results=await aggregated_result_to_pydantic(

--- a/agenta-backend/agenta_backend/models/converters.py
+++ b/agenta-backend/agenta_backend/models/converters.py
@@ -72,7 +72,9 @@ def human_evaluation_db_to_simple_evaluation_output(
 async def evaluation_db_to_pydantic(
     evaluation_db: EvaluationDB,
 ) -> Evaluation:
-    variant = await db_manager.get_app_variant_instance_by_id(str(evaluation_db.variant))
+    variant = await db_manager.get_app_variant_instance_by_id(
+        str(evaluation_db.variant)
+    )
     variant_name = variant.variant_name if variant else str(evaluation_db.variant)
 
     return Evaluation(

--- a/agenta-backend/agenta_backend/models/db_models.py
+++ b/agenta-backend/agenta_backend/models/db_models.py
@@ -284,7 +284,7 @@ class EvaluationDB(Document):
     user: Link[UserDB]
     status: str = Field(default="EVALUATION_INITIALIZED")
     testset: Link[TestSetDB]
-    variants: List[PydanticObjectId]
+    variant: PydanticObjectId
     evaluators_configs: List[PydanticObjectId]
     aggregated_results: List[AggregatedResult]
     created_at: datetime = Field(default=datetime.utcnow())

--- a/agenta-backend/agenta_backend/routers/evaluation_router.py
+++ b/agenta-backend/agenta_backend/routers/evaluation_router.py
@@ -60,30 +60,22 @@ async def create_evaluation(
         if app is None:
             raise HTTPException(status_code=404, detail="App not found")
 
-        app_data = jsonable_encoder(app)
         evaluations = []
 
         for variant_id in payload.variant_ids:
-            new_evaluation_data = {
-                "app_id": payload.app_id,
-                "variant_id": variant_id,  # Only this variant ID
-                "evaluators_configs": payload.evaluators_configs,
-                "testset_id": payload.testset_id,
-                "rate_limit": payload.rate_limit.dict(),
-            }
-
             evaluation = await evaluation_service.create_new_evaluation(
-                app_data=app_data,
-                new_evaluation_data=new_evaluation_data,
-                evaluators_configs=payload.evaluators_configs,
+                app_id=payload.app_id,
+                variant_id=variant_id,
+                evaluator_config_ids=payload.evaluators_configs,
+                testset_id=payload.testset_id
             )
 
             evaluate.delay(
-                app_data,
-                new_evaluation_data,
-                evaluation.id,
-                evaluation.testset_id,
-            )
+                app_id=payload.app_id,
+                variant_id=variant_id,
+                evaluators_config_ids=payload.evaluators_configs,
+                testset_id=payload.testset_id,
+                rate_limit_config=payload.rate_limit.dict())
             evaluations.append(evaluation)
 
         return evaluations

--- a/agenta-backend/agenta_backend/routers/evaluation_router.py
+++ b/agenta-backend/agenta_backend/routers/evaluation_router.py
@@ -75,6 +75,7 @@ async def create_evaluation(
                 variant_id=variant_id,
                 evaluators_config_ids=payload.evaluators_configs,
                 testset_id=payload.testset_id,
+                evaluation_id=evaluation.id,
                 rate_limit_config=payload.rate_limit.dict())
             evaluations.append(evaluation)
 

--- a/agenta-backend/agenta_backend/routers/evaluation_router.py
+++ b/agenta-backend/agenta_backend/routers/evaluation_router.py
@@ -66,7 +66,7 @@ async def create_evaluation(
         for variant_id in payload.variant_ids:
             new_evaluation_data = {
                 "app_id": payload.app_id,
-                "variant_ids": [variant_id],  # Only this variant ID
+                "variant_id": variant_id,  # Only this variant ID
                 "evaluators_configs": payload.evaluators_configs,
                 "testset_id": payload.testset_id,
                 "rate_limit": payload.rate_limit.dict(),

--- a/agenta-backend/agenta_backend/routers/evaluation_router.py
+++ b/agenta-backend/agenta_backend/routers/evaluation_router.py
@@ -67,7 +67,7 @@ async def create_evaluation(
                 app_id=payload.app_id,
                 variant_id=variant_id,
                 evaluator_config_ids=payload.evaluators_configs,
-                testset_id=payload.testset_id
+                testset_id=payload.testset_id,
             )
 
             evaluate.delay(
@@ -76,7 +76,8 @@ async def create_evaluation(
                 evaluators_config_ids=payload.evaluators_configs,
                 testset_id=payload.testset_id,
                 evaluation_id=evaluation.id,
-                rate_limit_config=payload.rate_limit.dict())
+                rate_limit_config=payload.rate_limit.dict(),
+            )
             evaluations.append(evaluation)
 
         return evaluations

--- a/agenta-backend/agenta_backend/routers/evaluators_router.py
+++ b/agenta-backend/agenta_backend/routers/evaluators_router.py
@@ -104,10 +104,10 @@ async def create_new_evaluator_config(
 
 
 @router.put("/configs/{evaluator_config_id}/", response_model=EvaluatorConfig)
-async def get_evaluator_config(
+async def update_evaluator_config(
     evaluator_config_id: str, payload: UpdateEvaluatorConfig
 ):
-    """Endpoint to fetch evaluator configurations for a specific app.
+    """Endpoint to update evaluator configurations for a specific app.
 
     Returns:
         List[EvaluatorConfigDB]: A list of evaluator configuration objects.

--- a/agenta-backend/agenta_backend/routers/human_evaluation_router.py
+++ b/agenta-backend/agenta_backend/routers/human_evaluation_router.py
@@ -74,11 +74,10 @@ async def create_evaluation(
         if app is None:
             raise HTTPException(status_code=404, detail="App not found")
 
-        new_evaluation_db = await evaluation_service.create_new_human_evaluation(
+        new_human_evaluation_db = await evaluation_service.create_new_human_evaluation(
             payload, **user_org_data
         )
-        print(new_evaluation_db)
-        return converters.evaluation_db_to_simple_evaluation_output(new_evaluation_db)
+        return converters.human_evaluation_db_to_simple_evaluation_output(new_human_evaluation_db)
     except KeyError:
         raise HTTPException(
             status_code=400,

--- a/agenta-backend/agenta_backend/routers/human_evaluation_router.py
+++ b/agenta-backend/agenta_backend/routers/human_evaluation_router.py
@@ -77,7 +77,9 @@ async def create_evaluation(
         new_human_evaluation_db = await evaluation_service.create_new_human_evaluation(
             payload, **user_org_data
         )
-        return converters.human_evaluation_db_to_simple_evaluation_output(new_human_evaluation_db)
+        return converters.human_evaluation_db_to_simple_evaluation_output(
+            new_human_evaluation_db
+        )
     except KeyError:
         raise HTTPException(
             status_code=400,

--- a/agenta-backend/agenta_backend/services/db_manager.py
+++ b/agenta-backend/agenta_backend/services/db_manager.py
@@ -1607,7 +1607,7 @@ async def create_new_evaluation(
     user: UserDB,
     testset: TestSetDB,
     status: str,
-    variants: [AppVariantDB],
+    variants: AppVariantDB,
     evaluators_configs: List[str],
 ) -> EvaluationDB:
     """Create a new evaluation scenario.

--- a/agenta-backend/agenta_backend/services/db_manager.py
+++ b/agenta-backend/agenta_backend/services/db_manager.py
@@ -1607,7 +1607,7 @@ async def create_new_evaluation(
     user: UserDB,
     testset: TestSetDB,
     status: str,
-    variants: AppVariantDB,
+    variant: AppVariantDB,
     evaluators_configs: List[str],
 ) -> EvaluationDB:
     """Create a new evaluation scenario.
@@ -1620,7 +1620,7 @@ async def create_new_evaluation(
         user=user,
         testset=testset,
         status=status,
-        variants=variants,
+        variant=variant,
         evaluators_configs=evaluators_configs,
         aggregated_results=[],
         created_at=datetime.now().isoformat(),

--- a/agenta-backend/agenta_backend/services/evaluation_service.py
+++ b/agenta-backend/agenta_backend/services/evaluation_service.py
@@ -597,7 +597,7 @@ async def delete_evaluations(evaluation_ids: List[str], **user_org_data: dict) -
 
 async def create_new_human_evaluation(
     payload: NewHumanEvaluation, **user_org_data: dict
-) -> EvaluationDB:
+) -> HumanEvaluationDB:
     """
     Create a new evaluation based on the provided payload and additional arguments.
 
@@ -606,7 +606,7 @@ async def create_new_human_evaluation(
         **user_org_data (dict): Additional keyword arguments, e.g., user id.
 
     Returns:
-        EvaluationDB
+        HumanEvaluationDB
     """
     user = await get_user(user_uid=user_org_data["uid"])
 
@@ -683,7 +683,7 @@ async def create_new_evaluation(
         user=app.user,
         testset=testset,
         status=EvaluationStatusEnum.EVALUATION_STARTED,
-        variants=new_evaluation.variant_ids,
+        variant=new_evaluation.variant_id,
         evaluators_configs=new_evaluation.evaluators_configs,
     )
     return await converters.evaluation_db_to_pydantic(evaluation_db)

--- a/agenta-backend/agenta_backend/services/evaluation_service.py
+++ b/agenta-backend/agenta_backend/services/evaluation_service.py
@@ -658,24 +658,27 @@ async def create_new_human_evaluation(
 
 
 async def create_new_evaluation(
-    app_data: dict, new_evaluation_data: dict, evaluators_configs: List[str]
+    app_id: str,
+    variant_id: str,
+    evaluator_config_ids: List[str],
+    testset_id: str,
 ) -> Evaluation:
     """
-    Create a new evaluation.
+    Create a new evaluation in the db
 
     Args:
-        app_data (dict): Required app data
-        new_evaluation_data (dict): Required new evaluation data
-        evaluators_configs (List[str]): List of evaluator configurations
+        app_id (str): The ID of the app.
+        variant_id (str): The ID of the variant.
+        evaluator_config_ids (List[str]): The IDs of the evaluator configurations.
+        testset_id (str): The ID of the testset.
 
     Returns:
-        Evaluation
+        Evaluation: The newly created evaluation.
     """
 
-    new_evaluation = NewEvaluation(**new_evaluation_data)
-    app = AppDB(**app_data)
+    app = await db_manager.fetch_app_by_id(app_id=app_id)
 
-    testset = await db_manager.fetch_testset_by_id(new_evaluation.testset_id)
+    testset = await db_manager.fetch_testset_by_id(testset_id)
 
     evaluation_db = await db_manager.create_new_evaluation(
         app=app,
@@ -683,8 +686,8 @@ async def create_new_evaluation(
         user=app.user,
         testset=testset,
         status=EvaluationStatusEnum.EVALUATION_STARTED,
-        variant=new_evaluation.variant_id,
-        evaluators_configs=new_evaluation.evaluators_configs,
+        variant=variant_id,
+        evaluators_configs=evaluator_config_ids,
     )
     return await converters.evaluation_db_to_pydantic(evaluation_db)
 

--- a/agenta-backend/agenta_backend/services/evaluators_service.py
+++ b/agenta-backend/agenta_backend/services/evaluators_service.py
@@ -50,9 +50,7 @@ def auto_regex_test(
     settings_values: Dict[str, Any],
 ) -> Result:
     re_pattern = re.compile(settings_values["regex_pattern"], re.IGNORECASE)
-    result = (
-        bool(re_pattern.search(output)) == settings_values["regex_should_match"]
-    )
+    result = bool(re_pattern.search(output)) == settings_values["regex_should_match"]
     return Result(type="bool", value=result)
 
 
@@ -118,7 +116,6 @@ def auto_ai_critique(
     correct_answer: str,
     app_params: Dict[str, Any],
     settings_values: Dict[str, Any],
-
 ) -> str:
     """Evaluate a response using an AI critique based on provided
      - An evaluation prompt,
@@ -196,11 +193,7 @@ def evaluate(
         raise ValueError(f"Evaluation method '{evaluator_key}' not found.")
     try:
         return evaluation_function(
-            inputs,
-            output,
-            correct_answer,
-            app_params,
-            settings_values
+            inputs, output, correct_answer, app_params, settings_values
         )
     except Exception as exc:
         raise RuntimeError(

--- a/agenta-backend/agenta_backend/services/llm_apps_service.py
+++ b/agenta-backend/agenta_backend/services/llm_apps_service.py
@@ -44,8 +44,9 @@ async def invoke_app(
                 input_name_ = input_name["name"]
                 inputs_dict[input_name_] = datapoint.get(input_name_, "")
         elif param["type"] == "messages":
-            # payload[param["name"]] = datapoint.get(param["name"], "")
-            payload[param["name"]] = datapoint.get("chat", "")  # TODO: Right now the FE is saving chats always under the column name chats. The whole logic for handling chats and dynamic inputs is convoluted and needs rework in time.
+            # TODO: Right now the FE is saving chats always under the column name chats. The whole logic for handling chats and dynamic inputs is convoluted and needs rework in time.
+            payload[param["name"]] = json.loads(datapoint.get("chat", ""))
+
         elif param["type"] == "file_url":
             payload[param["name"]] = datapoint.get(param["name"], "")
         else:

--- a/agenta-backend/agenta_backend/services/llm_apps_service.py
+++ b/agenta-backend/agenta_backend/services/llm_apps_service.py
@@ -13,9 +13,7 @@ logger.setLevel(logging.DEBUG)
 
 
 async def make_payload(
-    datapoint: Any,
-    parameters: Dict,
-    openapi_parameters: List[Dict]
+    datapoint: Any, parameters: Dict, openapi_parameters: List[Dict]
 ) -> Dict:
     """
     Constructs the payload for invoking an app based on OpenAPI parameters.
@@ -51,10 +49,7 @@ async def make_payload(
 
 
 async def invoke_app(
-    uri: str,
-    datapoint: Any,
-    parameters: Dict,
-    openapi_parameters: List[Dict]
+    uri: str, datapoint: Any, parameters: Dict, openapi_parameters: List[Dict]
 ) -> AppOutput:
     """
     Invokes an app for one datapoint using the openapi_parameters to determine

--- a/agenta-backend/agenta_backend/services/llm_apps_service.py
+++ b/agenta-backend/agenta_backend/services/llm_apps_service.py
@@ -1,37 +1,55 @@
 import asyncio
+import json
 import logging
-from typing import Any, List
-
-from agenta_backend.models.api.evaluation_model import AppOutput
+from typing import Any, Dict, List
 
 import httpx
 
+from agenta_backend.models.api.evaluation_model import AppOutput
 
 # Set logger
 logger = logging.getLogger(__name__)
 logger.setLevel(logging.DEBUG)
 
 
-async def get_llm_app_output(uri: str, datapoint: Any, parameters: dict) -> AppOutput:
-    prompt_user = replace_placeholders(parameters["prompt_user"], datapoint)
-    prompt_system = replace_placeholders(parameters["prompt_system"], datapoint)
+async def invoke_app(
+    uri: str, datapoint: Any, parameters: Dict, openapi_parameters: List[Dict]
+) -> AppOutput:
+    """
+    Invokes an app for one datapoint.
+    Uses the openapi_parameters from the openapi.json to determine how to invoke the app
+
+    Args:
+        uri (str): The URI of the app to invoke.
+        datapoint (Any): The data to be sent to the app.
+        parameters (Dict): The parameters required by the app taken from the db.
+        openapi_parameters (List[Dict]): The OpenAPI parameters of the app.
+
+    Returns:
+        AppOutput: The output of the app.
+
+    Raises:
+        httpx.HTTPError: If the POST request fails.
+    """
 
     url = f"{uri}/generate"
 
-    payload = {
-        "temperature": parameters["temperature"],
-        "model": parameters["model"],
-        "max_tokens": parameters["max_tokens"],
-        "prompt_system": prompt_system,
-        "prompt_user": prompt_user,
-        "top_p": parameters["top_p"],
-        "frequence_penalty": parameters["frequence_penalty"],
-        "presence_penalty": parameters["presence_penalty"],
-        "inputs": {
-            input_item["name"]: datapoint.get(input_item["name"], "")
-            for input_item in parameters["inputs"]
-        },
-    }
+    payload = {}
+    inputs_dict = {}
+    for param in openapi_parameters:
+        if param["type"] == "input":
+            payload[param["name"]] = datapoint.get(param["name"], "")
+        elif param["type"] == "dict":
+            for input_name in parameters[param["name"]]:
+                inputs_dict[input_name] = datapoint.get(input_name, "")
+        elif param["type"] == "messages":
+            payload[param["name"]] = datapoint.get(param["name"], "")
+        elif param["type"] == "file_url":
+            payload[param["name"]] = datapoint.get(param["name"], "")
+        else:
+            payload[param["name"]] = parameters[param["name"]]
+    if len(inputs_dict) > 0:
+        payload["inputs"] = inputs_dict
 
     async with httpx.AsyncClient() as client:
         response = await client.post(
@@ -42,13 +60,33 @@ async def get_llm_app_output(uri: str, datapoint: Any, parameters: dict) -> AppO
 
 
 async def run_with_retry(
-    uri: str, input_data: Any, parameters: dict, max_retry_count: int, retry_delay: int
+    uri: str,
+    input_data: Any,
+    parameters: Dict,
+    max_retry_count: int,
+    retry_delay: int,
+    openapi_parameters: List[Dict],
 ) -> AppOutput:
+    """
+    Runs the specified app with retry mechanism.
+
+    Args:
+        uri (str): The URI of the app.
+        input_data (Any): The input data for the app.
+        parameters (Dict): The parameters for the app.
+        max_retry_count (int): The maximum number of retries.
+        retry_delay (int): The delay between retries in seconds.
+        openapi_parameters (List[Dict]): The OpenAPI parameters for the app.
+
+    Returns:
+        AppOutput: The output of the app.
+
+    """
     retries = 0
     last_exception = None
     while retries < max_retry_count:
         try:
-            result = await get_llm_app_output(uri, input_data, parameters)
+            result = await invoke_app(uri, input_data, parameters, openapi_parameters)
             return result
         except (httpx.TimeoutException, httpx.ConnectTimeout, httpx.ConnectError) as e:
             last_exception = e
@@ -61,8 +99,20 @@ async def run_with_retry(
 
 
 async def batch_invoke(
-    uri: str, testset_data: List[dict], parameters: dict, rate_limit_config: dict
+    uri: str, testset_data: List[Dict], parameters: Dict, rate_limit_config: Dict
 ) -> List[AppOutput]:
+    """
+    Invokes the LLm apps in batches, processing the testset data.
+
+    Args:
+        uri (str): The URI of the LLm app.
+        testset_data (List[Dict]): The testset data to be processed.
+        parameters (Dict): The parameters for the LLm app.
+        rate_limit_config (Dict): The rate limit configuration.
+
+    Returns:
+        List[AppOutput]: The list of app outputs after running all batches.
+    """
     batch_size = rate_limit_config[
         "batch_size"
     ]  # Number of testset to make in each batch
@@ -77,6 +127,7 @@ async def batch_invoke(
     ]  # Delay between batches (in seconds)
 
     list_of_app_outputs: List[AppOutput] = []  # Outputs after running all batches
+    openapi_parameters = await get_parameters_from_openapi(uri + "/openapi.json")
 
     async def run_batch(start_idx: int):
         print(f"Preparing {start_idx} batch...")
@@ -84,7 +135,12 @@ async def batch_invoke(
         for index in range(start_idx, end_idx):
             try:
                 batch_output: AppOutput = await run_with_retry(
-                    uri, testset_data[index], parameters, max_retries, retry_delay
+                    uri,
+                    testset_data[index],
+                    parameters,
+                    max_retries,
+                    retry_delay,
+                    openapi_parameters,
                 )
                 list_of_app_outputs.append(batch_output)
                 print(f"Adding outputs to batch {start_idx}")
@@ -104,7 +160,48 @@ async def batch_invoke(
     return list_of_app_outputs
 
 
-def replace_placeholders(text, data):
-    for key, value in data.items():
-        text = text.replace(f"{{{key}}}", value)
-    return text
+async def get_parameters_from_openapi(uri: str) -> List[Dict]:
+    """
+    Parse the OpenAI schema of an LLM app to return list of parameters that it takes with their type as determined by the x-parameter
+    Args:
+    uri (str): The URI of the OpenAPI schema.
+
+    Returns:
+        list: A list of parameters. Each a dict with name and type.
+        Type can be one of: input, text, choice, float, dict, bool, int, file_url, messages.
+
+    Raises:
+        KeyError: If the required keys are not found in the schema.
+
+    """
+
+    schema = await _get_openai_json_from_uri(uri)
+
+    try:
+        body_schema_name = (
+            schema["paths"]["/generate"]["post"]["requestBody"]["content"][
+                "application/json"
+            ]["schema"]["$ref"]
+            .split("/")
+            .pop()
+        )
+    except KeyError:
+        body_schema_name = ""
+
+    try:
+        properties = schema["components"]["schemas"][body_schema_name]["properties"]
+    except KeyError:
+        properties = {}
+
+    parameters = []
+    for name, param in properties.items():
+        parameters.append({"name": name, "type": param.get("x-parameter", "input")})
+
+    return parameters
+
+
+async def _get_openai_json_from_uri(uri):
+    async with httpx.AsyncClient() as client:
+        resp = await client.get(uri)
+        json_data = json.loads(resp.text)
+        return json_data

--- a/agenta-backend/agenta_backend/services/llm_apps_service.py
+++ b/agenta-backend/agenta_backend/services/llm_apps_service.py
@@ -44,7 +44,8 @@ async def invoke_app(
                 input_name_ = input_name["name"]
                 inputs_dict[input_name_] = datapoint.get(input_name_, "")
         elif param["type"] == "messages":
-            payload[param["name"]] = datapoint.get(param["name"], "")
+            # payload[param["name"]] = datapoint.get(param["name"], "")
+            payload[param["name"]] = datapoint.get("chat", "")  # TODO: Right now the FE is saving chats always under the column name chats. The whole logic for handling chats and dynamic inputs is convoluted and needs rework in time.
         elif param["type"] == "file_url":
             payload[param["name"]] = datapoint.get(param["name"], "")
         else:
@@ -53,6 +54,7 @@ async def invoke_app(
         payload["inputs"] = inputs_dict
 
     async with httpx.AsyncClient() as client:
+        logger.debug(f"Invoking app {uri} with payload {payload}")
         response = await client.post(
             url, json=payload, timeout=httpx.Timeout(timeout=5, read=None, write=5)
         )

--- a/agenta-backend/agenta_backend/services/llm_apps_service.py
+++ b/agenta-backend/agenta_backend/services/llm_apps_service.py
@@ -41,7 +41,8 @@ async def invoke_app(
             payload[param["name"]] = datapoint.get(param["name"], "")
         elif param["type"] == "dict":
             for input_name in parameters[param["name"]]:
-                inputs_dict[input_name] = datapoint.get(input_name, "")
+                input_name_ = input_name["name"]
+                inputs_dict[input_name_] = datapoint.get(input_name_, "")
         elif param["type"] == "messages":
             payload[param["name"]] = datapoint.get(param["name"], "")
         elif param["type"] == "file_url":

--- a/agenta-backend/agenta_backend/tasks/evaluations.py
+++ b/agenta-backend/agenta_backend/tasks/evaluations.py
@@ -85,7 +85,7 @@ def evaluate(
         evaluators_aggregated_data = {
             evaluator_config_db.id: {
                 "evaluator_key": evaluator_config.evaluator_key,
-                "results": []
+                "results": [],
             }
             for evaluator_config_db in evaluator_config_dbs
         }
@@ -99,22 +99,20 @@ def evaluate(
             )
         )
 
-        openapi_parameters = loop.run_until_complete(llm_apps_service.get_parameters_from_openapi(uri + "/openapi.json"))
+        openapi_parameters = loop.run_until_complete(
+            llm_apps_service.get_parameters_from_openapi(uri + "/openapi.json")
+        )
         # 4. Evaluate the app ourputss
 
         if len(testset_db.csvdata) != len(app_outputs):
             loop.run_until_complete(
                 update_evaluation(evaluation_id, {"status": "EVALUATION_FAILED"})
             )
-            self.update_state(
-                state=states.FAILURE)
+            self.update_state(state=states.FAILURE)
 
-            raise ValueError(
-                "Length of csv data and app_outputs are not the same"
-            )
+            raise ValueError("Length of csv data and app_outputs are not the same")
             return
         for data_point, app_output in zip(testset_db.csvdata, app_outputs):
-
             # 2. We prepare the inputs
             logger.debug(f"Preparing inputs for data point: {data_point}")
             list_inputs = get_app_inputs(app_variant_parameters, openapi_parameters)
@@ -123,7 +121,11 @@ def evaluate(
                 EvaluationScenarioInputDB(
                     name=input_item["name"],
                     type="text",
-                    value=data_point[input_item["name"] if input_item["type"] != "messages" else "chat"],  # TODO: We need to remove the hardcoding of chat as name for chat inputs from the FE
+                    value=data_point[
+                        input_item["name"]
+                        if input_item["type"] != "messages"
+                        else "chat"
+                    ],  # TODO: We need to remove the hardcoding of chat as name for chat inputs from the FE
                 )
                 for input_item in list_inputs
             ]
@@ -172,8 +174,7 @@ def evaluate(
         loop.run_until_complete(
             update_evaluation(evaluation_id, {"status": "EVALUATION_FAILED"})
         )
-        self.update_state(
-            state=states.FAILURE)
+        self.update_state(state=states.FAILURE)
 
         return
 
@@ -227,7 +228,9 @@ async def aggregate_evaluator_results(
 
 def _get_deployment_uri(deployment_db) -> str:
     #!NOTE: do not remove! this will be used in github workflow!
-    backend_environment = os.environ.get("ENVIRONMENT")  # TODO @abram rename the environment variable to something other than environment!!!
+    backend_environment = os.environ.get(
+        "ENVIRONMENT"
+    )  # TODO @abram rename the environment variable to something other than environment!!!
     if backend_environment is not None and backend_environment == "github":
         return f"http://{deployment_db.container_name}"  # TODO: @abram Remove this from here. Move it to the deployment manager
     else:

--- a/agenta-backend/agenta_backend/tasks/evaluations.py
+++ b/agenta-backend/agenta_backend/tasks/evaluations.py
@@ -233,7 +233,7 @@ def get_app_inputs(app_variant_parameters, openapi_parameters) -> List[Dict[str,
             list_inputs.append({"name": param["name"], "type": "input"})
         elif param["type"] == "dict":
             for input_name in app_variant_parameters[param["name"]]:
-                list_inputs.append({"name": input_name, "type": "dict_input"})
+                list_inputs.append({"name": input_name["name"], "type": "dict_input"})
         elif param["type"] == "messages":
             list_inputs.append({"name": param["name"], "type": "messages"})
         elif param["type"] == "file_url":


### PR DESCRIPTION
### Status:

- Lightly tested with simple prompt template (works)
- Now testing with cli applications
### Bugs fixed:
- The way we handle inputs (@aakrem and @aybruhm please take a look at this for the future)
- Call to evaluate (mix-up outputs / correct_answer)
- Failure state not propagating to FE
- Chat applications working, however the test set outputs is saved wrongly in FE

Additionally I refactored the inputs to the evaluate task and the evaluation services.