### PR TITLE
Fix/1182 prevent used resources from deletion

### DIFF
--- a/agenta-backend/agenta_backend/models/converters.py
+++ b/agenta-backend/agenta_backend/models/converters.py
@@ -52,6 +52,7 @@ from agenta_backend.models.api.evaluation_model import (
 )
 
 import logging
+from beanie import Link
 
 logger = logging.getLogger(__name__)
 logger.setLevel(logging.DEBUG)
@@ -85,8 +86,12 @@ async def evaluation_db_to_pydantic(
         status=evaluation_db.status,
         variant_ids=[str(evaluation_db.variant)],
         variant_names=[variant_name],
-        testset_id=str(evaluation_db.testset.id),
-        testset_name=evaluation_db.testset.name,
+        testset_id=""
+        if type(evaluation_db.testset) is Link
+        else str(evaluation_db.testset.id),
+        testset_name=""
+        if type(evaluation_db.testset) is Link
+        else str(evaluation_db.testset.name),
         aggregated_results=await aggregated_result_to_pydantic(
             evaluation_db.aggregated_results
         ),
@@ -113,8 +118,12 @@ async def human_evaluation_db_to_pydantic(
         evaluation_type=evaluation_db.evaluation_type,
         variant_ids=[str(variant) for variant in evaluation_db.variants],
         variant_names=variant_names,
-        testset_id=str(evaluation_db.testset.id),
-        testset_name=evaluation_db.testset.name,
+        testset_id=""
+        if type(evaluation_db.testset) is Link
+        else str(evaluation_db.testset.id),
+        testset_name=""
+        if type(evaluation_db.testset) is Link
+        else str(evaluation_db.testset.name),
         created_at=evaluation_db.created_at,
         updated_at=evaluation_db.updated_at,
     )

--- a/agenta-backend/agenta_backend/routers/evaluation_router.py
+++ b/agenta-backend/agenta_backend/routers/evaluation_router.py
@@ -279,3 +279,48 @@ async def fetch_evaluation_scenarios(
     )
 
     return eval_scenarios
+
+
+# Write a GET endpoint that takes in a query param type = "variant" or "testset" or "evaluator config"
+# and a query param id = "variant_id" or "testset_id" or "evaluator_config_id" and returns the evaluation ids
+@router.get(
+    "/evaluation_ids/",
+    response_model=any,
+)
+async def fetch_evaluation_ids(
+    app_id: str,
+    resourceType: str,
+    resourceId: str,
+    request: Request,
+):
+    print("resourceType: ", resourceType)
+    print("resourceId: ", resourceId)
+    """Fetches evaluation ids for a given type and id.
+
+    Arguments:
+        resourceType (str): The type of the object for which to fetch evaluations.
+        resourceId (str): The ID of the object for which to fetch evaluations.
+
+    Raises:
+        HTTPException: If the evaluation is not found or access is denied.
+
+    Returns:
+        List[str]: A list of evaluation ids.
+    """
+    # user_org_data: dict = await get_user_and_org_id(request.state.user_id)
+    # access_app = await check_access_to_app(
+    #     user_org_data=user_org_data,
+    #     app_id=app_id,
+    # )
+    # if not access_app:
+    #     raise HTTPException(
+    #         status_code=403,
+    #         detail=f"You do not have access to this app: {str(app_id)}",
+    #     )
+
+    evaluations = await evaluation_service.fetch_evaluations(resourceType, resourceId)
+    print("evaluations: ", evaluations)
+    evaluation_ids = list(map(lambda x: x.id, evaluations))
+    print("evaluation_ids: ", evaluation_ids)
+
+    return evaluation_ids

--- a/agenta-backend/agenta_backend/routers/evaluation_router.py
+++ b/agenta-backend/agenta_backend/routers/evaluation_router.py
@@ -3,8 +3,8 @@ import secrets
 from typing import Any, List
 
 from fastapi.responses import JSONResponse
-from fastapi.encoders import jsonable_encoder
 from fastapi import HTTPException, Request, status, Response, Query
+from beanie import PydanticObjectId as ObjectId
 
 from agenta_backend.utils.common import APIRouter
 from agenta_backend.models.api.evaluation_model import (
@@ -38,7 +38,7 @@ router = APIRouter()
 
 @router.get(
     "/by_resource/",
-    response_model=Any,
+    response_model=List[ObjectId],
 )
 async def fetch_evaluation_ids(
     app_id: str,
@@ -51,7 +51,7 @@ async def fetch_evaluation_ids(
     Arguments:
         app_id (str): The ID of the app for which to fetch evaluations.
         resource_type (str): The type of resource for which to fetch evaluations.
-        resource_ids List[str]: The IDs of resource for which to fetch evaluations.
+        resource_ids List[ObjectId]: The IDs of resource for which to fetch evaluations.
 
     Raises:
         HTTPException: If the resource_type is invalid or access is denied.

--- a/agenta-backend/agenta_backend/routers/evaluation_router.py
+++ b/agenta-backend/agenta_backend/routers/evaluation_router.py
@@ -4,7 +4,7 @@ from typing import Any, List
 
 from fastapi.responses import JSONResponse
 from fastapi.encoders import jsonable_encoder
-from fastapi import HTTPException, Request, status, Response
+from fastapi import HTTPException, Request, status, Response, Query
 
 from agenta_backend.utils.common import APIRouter
 from agenta_backend.models.api.evaluation_model import (
@@ -34,6 +34,46 @@ else:
 
 # Initialize api router
 router = APIRouter()
+
+
+@router.get(
+    "/by_resource/",
+    response_model=Any,
+)
+async def fetch_evaluation_ids(
+    app_id: str,
+    resource_type: str,
+    request: Request,
+    resource_ids: List[str] = Query(None),
+):
+    """Fetches evaluation ids for a given resource type and id.
+
+    Arguments:
+        app_id (str): The ID of the app for which to fetch evaluations.
+        resource_type (str): The type of resource for which to fetch evaluations.
+        resource_ids List[str]: The IDs of resource for which to fetch evaluations.
+
+    Raises:
+        HTTPException: If the resource_type is invalid or access is denied.
+
+    Returns:
+        List[str]: A list of evaluation ids.
+    """
+    user_org_data: dict = await get_user_and_org_id(request.state.user_id)
+    access_app = await check_access_to_app(
+        user_org_data=user_org_data,
+        app_id=app_id,
+    )
+    if not access_app:
+        raise HTTPException(
+            status_code=403,
+            detail=f"You do not have access to this app: {str(app_id)}",
+        )
+
+    evaluations = await evaluation_service.fetch_evaluations_by_resource(
+        resource_type, resource_ids
+    )
+    return list(map(lambda x: x.id, evaluations))
 
 
 @router.post("/", response_model=List[Evaluation], operation_id="create_evaluation")
@@ -279,48 +319,3 @@ async def fetch_evaluation_scenarios(
     )
 
     return eval_scenarios
-
-
-# Write a GET endpoint that takes in a query param type = "variant" or "testset" or "evaluator config"
-# and a query param id = "variant_id" or "testset_id" or "evaluator_config_id" and returns the evaluation ids
-@router.get(
-    "/evaluation_ids/",
-    response_model=any,
-)
-async def fetch_evaluation_ids(
-    app_id: str,
-    resourceType: str,
-    resourceId: str,
-    request: Request,
-):
-    print("resourceType: ", resourceType)
-    print("resourceId: ", resourceId)
-    """Fetches evaluation ids for a given type and id.
-
-    Arguments:
-        resourceType (str): The type of the object for which to fetch evaluations.
-        resourceId (str): The ID of the object for which to fetch evaluations.
-
-    Raises:
-        HTTPException: If the evaluation is not found or access is denied.
-
-    Returns:
-        List[str]: A list of evaluation ids.
-    """
-    # user_org_data: dict = await get_user_and_org_id(request.state.user_id)
-    # access_app = await check_access_to_app(
-    #     user_org_data=user_org_data,
-    #     app_id=app_id,
-    # )
-    # if not access_app:
-    #     raise HTTPException(
-    #         status_code=403,
-    #         detail=f"You do not have access to this app: {str(app_id)}",
-    #     )
-
-    evaluations = await evaluation_service.fetch_evaluations(resourceType, resourceId)
-    print("evaluations: ", evaluations)
-    evaluation_ids = list(map(lambda x: x.id, evaluations))
-    print("evaluation_ids: ", evaluation_ids)
-
-    return evaluation_ids

--- a/agenta-backend/agenta_backend/services/evaluation_service.py
+++ b/agenta-backend/agenta_backend/services/evaluation_service.py
@@ -34,6 +34,7 @@ from agenta_backend.models.db_models import (
 )
 
 from beanie import PydanticObjectId as ObjectId
+from beanie.operators import Eq
 
 
 logger = logging.getLogger(__name__)
@@ -798,3 +799,19 @@ def remove_duplicates(csvdata):
             unique_entries.append(entry)
 
     return unique_entries
+
+
+def fetch_evaluations(resourceType: str, resourceId: str):
+    if resourceType == "variant":
+        return EvaluationDB.find(EvaluationDB.variant == ObjectId(resourceId)).to_list()
+    elif resourceType == "testset":
+        return EvaluationDB.find(EvaluationDB.testset == ObjectId(resourceId)).to_list()
+    elif resourceType == "evaluator_config":
+        return EvaluationDB.find(
+            Eq(EvaluationDB.evaluators_configs, ObjectId(resourceId))
+        ).to_list()
+    else:
+        raise HTTPException(
+            status_code=400,
+            detail=f"resourceType {resourceType} is not supported",
+        )

--- a/agenta-backend/agenta_backend/services/evaluation_service.py
+++ b/agenta-backend/agenta_backend/services/evaluation_service.py
@@ -801,14 +801,14 @@ def remove_duplicates(csvdata):
     return unique_entries
 
 
-def fetch_evaluations_by_resource(resource_type: str, resource_ids: List[str]):
+async def fetch_evaluations_by_resource(resource_type: str, resource_ids: List[str]):
     ids = list(map(lambda x: ObjectId(x), resource_ids))
     if resource_type == "variant":
-        return EvaluationDB.find(In(EvaluationDB.variant, ids)).to_list()
+        res = await EvaluationDB.find(In(EvaluationDB.variant, ids)).to_list()
     elif resource_type == "testset":
-        return EvaluationDB.find(In(EvaluationDB.testset.id, ids)).to_list()
+        res = await EvaluationDB.find(In(EvaluationDB.testset.id, ids)).to_list()
     elif resource_type == "evaluator_config":
-        return EvaluationDB.find(
+        res = await EvaluationDB.find(
             In(
                 EvaluationDB.evaluators_configs,
                 ids,
@@ -819,3 +819,4 @@ def fetch_evaluations_by_resource(resource_type: str, resource_ids: List[str]):
             status_code=400,
             detail=f"resource_type {resource_type} is not supported",
         )
+    return res

--- a/agenta-web/src/components/Playground/Playground.tsx
+++ b/agenta-web/src/components/Playground/Playground.tsx
@@ -15,6 +15,7 @@ import {arrayMove, SortableContext, horizontalListSortingStrategy} from "@dnd-ki
 import DraggableTabNode from "../DraggableTabNode/DraggableTabNode"
 import {useLocalStorage} from "usehooks-ts"
 import TestContextProvider from "./TestContextProvider"
+import {checkIfResourceValidForDeletion} from "@/lib/helpers/evaluate"
 
 const Playground: React.FC = () => {
     const router = useRouter()
@@ -198,6 +199,17 @@ const Playground: React.FC = () => {
             },
             onOk: async () => {
                 try {
+                    const variantId =
+                        variants.find((item) => item.variantId === tabID.current)?.variantId ||
+                        variants.find((item) => item.variantName === activeKey)?.variantId
+                    if (
+                        variantId &&
+                        !(await checkIfResourceValidForDeletion({
+                            resourceType: "variant",
+                            resourceIds: [variantId],
+                        }))
+                    )
+                        return
                     if (deleteAction) await deleteAction()
                     removeTab()
                     messageApi.open({

--- a/agenta-web/src/lib/helpers/evaluate.ts
+++ b/agenta-web/src/lib/helpers/evaluate.ts
@@ -1,6 +1,9 @@
 import {HumanEvaluationListTableDataType} from "@/components/Evaluations/HumanEvaluationResult"
 import {Evaluation, GenericObject, Variant} from "../Types"
 import {convertToCsv, downloadCsv} from "./fileManipulations"
+import {fetchEvaluatonIdsByResource} from "@/services/evaluations"
+import {getAppValues} from "@/contexts/app.context"
+import AlertPopup from "@/components/AlertPopup/AlertPopup"
 
 export const exportABTestingEvaluationData = (evaluation: Evaluation, rows: GenericObject[]) => {
     const exportRow = rows.map((data, ix) => {
@@ -63,4 +66,31 @@ export const calculateResultsDataAvg = (
 export const getVotesPercentage = (record: HumanEvaluationListTableDataType, index: number) => {
     const variant = record.votesData.variants[index]
     return record.votesData.variants_votes_data[variant]?.percentage
+}
+
+export const checkIfResourceValidForDeletion = async (
+    data: Omit<Parameters<typeof fetchEvaluatonIdsByResource>[0], "appId">,
+) => {
+    const appId = getAppValues().currentApp?.app_id
+    if (!appId) return false
+
+    const response = await fetchEvaluatonIdsByResource({...data, appId})
+    if (response.data.length > 0) {
+        const name =
+            (data.resourceType === "testset"
+                ? "Testset"
+                : data.resourceType === "evaluator_config"
+                  ? "Evaluator"
+                  : "Variant") + (data.resourceIds.length > 1 ? "s" : "")
+
+        const suffix = response.data.length > 1 ? "s" : ""
+        AlertPopup({
+            title: `${name} is in use`,
+            message: `The ${name} is currently in used by ${response.data.length} evaluation${suffix}. Please delete the evaluation${suffix} first.`,
+            cancelText: null,
+            okText: "Ok",
+        })
+        return false
+    }
+    return true
 }

--- a/agenta-web/src/pages/apps/[app_id]/testsets/index.tsx
+++ b/agenta-web/src/pages/apps/[app_id]/testsets/index.tsx
@@ -10,6 +10,7 @@ import {deleteTestsets, useLoadTestsetsList} from "@/lib/services/api"
 import {createUseStyles} from "react-jss"
 import {testset} from "@/lib/Types"
 import {isDemo} from "@/lib/helpers/utils"
+import {checkIfResourceValidForDeletion} from "@/lib/helpers/evaluate"
 
 const useStyles = createUseStyles({
     container: {
@@ -71,6 +72,13 @@ export default function Testsets() {
     const onDelete = async () => {
         const testsetsIds = selectedRowKeys.map((key) => key.toString())
         try {
+            if (
+                !(await checkIfResourceValidForDeletion({
+                    resourceType: "testset",
+                    resourceIds: testsetsIds,
+                }))
+            )
+                return
             await deleteTestsets(testsetsIds)
             mutate()
             setSelectedRowKeys([])

--- a/agenta-web/src/services/evaluations/index.ts
+++ b/agenta-web/src/services/evaluations/index.ts
@@ -263,3 +263,21 @@ export const fetchAllComparisonResults = async (evaluationIds: string[]) => {
         evaluations: scenarioGroups.map((group) => group[0].evaluation),
     }
 }
+
+// Evaluation IDs by resource
+export const fetchEvaluatonIdsByResource = async ({
+    resourceIds,
+    resourceType,
+    appId,
+}: {
+    resourceIds: string[]
+    resourceType: "testset" | "evaluator_config" | "variant"
+    appId: string
+}) => {
+    return axios.get(`/api/evaluations/by_resource`, {
+        params: {resource_ids: resourceIds, resource_type: resourceType, app_id: appId},
+        paramsSerializer: {
+            indexes: null, //no brackets in query params
+        },
+    })
+}


### PR DESCRIPTION
Resolves #1182 

- Prevent deletion of variant, testsets and evaluators if used in an evaluation
- Fixed BE to not crash if a linked resource is deleted