### PR TITLE
Issue 1210/prompt versioning connecting evaluation

### DIFF
--- a/agenta-backend/agenta_backend/models/api/evaluation_model.py
+++ b/agenta-backend/agenta_backend/models/api/evaluation_model.py
@@ -118,7 +118,7 @@ class HumanEvaluation(BaseModel):
     variant_ids: List[str]
     variant_names: List[str]
     variant_revision_ids: List[str]
-    variant_revisions: List[str]  # the revision / version of each of the variants
+    revisions: List[str]  # the revision / version of each of the variants
     testset_id: str
     testset_name: str
     status: str

--- a/agenta-backend/agenta_backend/models/api/evaluation_model.py
+++ b/agenta-backend/agenta_backend/models/api/evaluation_model.py
@@ -63,6 +63,8 @@ class Evaluation(BaseModel):
     user_username: str
     variant_ids: List[str]
     variant_names: List[str]
+    variant_revision_ids: List[str]
+    revisions: List[str]
     testset_id: str
     testset_name: str
     status: str

--- a/agenta-backend/agenta_backend/models/api/evaluation_model.py
+++ b/agenta-backend/agenta_backend/models/api/evaluation_model.py
@@ -117,6 +117,8 @@ class HumanEvaluation(BaseModel):
     evaluation_type: str
     variant_ids: List[str]
     variant_names: List[str]
+    variant_revision_ids: List[str]
+    variant_revisions: List[str]  # the revision / version of each of the variants
     testset_id: str
     testset_name: str
     status: str

--- a/agenta-backend/agenta_backend/models/converters.py
+++ b/agenta-backend/agenta_backend/models/converters.py
@@ -116,8 +116,14 @@ async def human_evaluation_db_to_pydantic(
         evaluation_type=evaluation_db.evaluation_type,
         variant_ids=[str(variant) for variant in evaluation_db.variants],
         variant_names=variant_names,
-        variant_revision_ids=[str(variant_revision) for variant_revision in evaluation_db.variant_revisions],
-        variant_revisions=[str(variant_revision.revision) for variant_revision in evaluation_db.variant_revisions],
+        variant_revision_ids=[
+            str(variant_revision)
+            for variant_revision in evaluation_db.variant_revisions
+        ],
+        variant_revisions=[
+            str(variant_revision.revision)
+            for variant_revision in evaluation_db.variant_revisions
+        ],
         testset_id=str(evaluation_db.testset.id),
         testset_name=evaluation_db.testset.name,
         created_at=evaluation_db.created_at,

--- a/agenta-backend/agenta_backend/models/converters.py
+++ b/agenta-backend/agenta_backend/models/converters.py
@@ -106,6 +106,13 @@ async def human_evaluation_db_to_pydantic(
         variant = await db_manager.get_app_variant_instance_by_id(str(variant_id))
         variant_name = variant.variant_name if variant else str(variant_id)
         variant_names.append(str(variant_name))
+    revisions = []
+    for variant_revision_id in evaluation_db.variant_revisions:
+        variant_revision = await db_manager.get_app_variant_revision_by_id(
+            str(variant_revision_id)
+        )
+        revision = variant_revision.revision
+        revisions.append(str(revision))
 
     return HumanEvaluation(
         id=str(evaluation_db.id),
@@ -120,10 +127,7 @@ async def human_evaluation_db_to_pydantic(
             str(variant_revision)
             for variant_revision in evaluation_db.variant_revisions
         ],
-        revisions=[
-            str(variant_revision.revision)
-            for variant_revision in evaluation_db.variant_revisions
-        ],
+        revisions=revisions,
         testset_id=str(evaluation_db.testset.id),
         testset_name=evaluation_db.testset.name,
         created_at=evaluation_db.created_at,

--- a/agenta-backend/agenta_backend/models/converters.py
+++ b/agenta-backend/agenta_backend/models/converters.py
@@ -79,7 +79,10 @@ async def evaluation_db_to_pydantic(
         str(evaluation_db.variant)
     )
     variant_name = variant.variant_name if variant else str(evaluation_db.variant)
-
+    variant_revision = await db_manager.get_app_variant_revision_by_id(
+        str(evaluation_db.variant_revision)
+    )
+    revision = str(variant_revision.revision)
     return Evaluation(
         id=str(evaluation_db.id),
         app_id=str(evaluation_db.app.id),
@@ -87,6 +90,8 @@ async def evaluation_db_to_pydantic(
         user_username=evaluation_db.user.username or "",
         status=evaluation_db.status,
         variant_ids=[str(evaluation_db.variant)],
+        variant_revision_ids=[str(evaluation_db.variant_revision)],
+        revisions=[revision],
         variant_names=[variant_name],
         testset_id=str(evaluation_db.testset.id),
         testset_name=evaluation_db.testset.name,

--- a/agenta-backend/agenta_backend/models/converters.py
+++ b/agenta-backend/agenta_backend/models/converters.py
@@ -120,7 +120,7 @@ async def human_evaluation_db_to_pydantic(
             str(variant_revision)
             for variant_revision in evaluation_db.variant_revisions
         ],
-        variant_revisions=[
+        revisions=[
             str(variant_revision.revision)
             for variant_revision in evaluation_db.variant_revisions
         ],

--- a/agenta-backend/agenta_backend/models/converters.py
+++ b/agenta-backend/agenta_backend/models/converters.py
@@ -116,6 +116,8 @@ async def human_evaluation_db_to_pydantic(
         evaluation_type=evaluation_db.evaluation_type,
         variant_ids=[str(variant) for variant in evaluation_db.variants],
         variant_names=variant_names,
+        variant_revision_ids=[str(variant_revision) for variant_revision in evaluation_db.variant_revisions],
+        variant_revisions=[str(variant_revision.revision) for variant_revision in evaluation_db.variant_revisions],
         testset_id=str(evaluation_db.testset.id),
         testset_name=evaluation_db.testset.name,
         created_at=evaluation_db.created_at,

--- a/agenta-backend/agenta_backend/models/db_models.py
+++ b/agenta-backend/agenta_backend/models/db_models.py
@@ -287,6 +287,7 @@ class EvaluationDB(Document):
     status: str = Field(default="EVALUATION_INITIALIZED")
     testset: Link[TestSetDB]
     variant: PydanticObjectId
+    variant_revision: PydanticObjectId
     evaluators_configs: List[PydanticObjectId]
     aggregated_results: List[AggregatedResult]
     created_at: datetime = Field(default=datetime.utcnow())

--- a/agenta-backend/agenta_backend/models/db_models.py
+++ b/agenta-backend/agenta_backend/models/db_models.py
@@ -253,6 +253,7 @@ class HumanEvaluationDB(Document):
     status: str
     evaluation_type: str
     variants: List[PydanticObjectId]
+    variant_revisions: List[PydanticObjectId]
     testset: Link[TestSetDB]
     created_at: Optional[datetime] = Field(default=datetime.utcnow())
     updated_at: Optional[datetime] = Field(default=datetime.utcnow())

--- a/agenta-backend/agenta_backend/routers/variants_router.py
+++ b/agenta-backend/agenta_backend/routers/variants_router.py
@@ -313,7 +313,7 @@ async def get_variant(
         app_variant = await db_manager.fetch_app_variant_by_id(
             app_variant_id=variant_id
         )
-        app_variant_revisions = await db_manager.fetch_app_variant_revision_by_variant(
+        app_variant_revisions = await db_manager.list_app_variant_revisions_by_variant(
             app_variant_id=variant_id
         )
         return await converters.app_variant_db_and_revision_to_extended_output(

--- a/agenta-backend/agenta_backend/services/db_manager.py
+++ b/agenta-backend/agenta_backend/services/db_manager.py
@@ -1653,7 +1653,8 @@ async def create_new_evaluation(
     user: UserDB,
     testset: TestSetDB,
     status: str,
-    variant: AppVariantDB,
+    variant: str,
+    variant_revision: str,
     evaluators_configs: List[str],
 ) -> EvaluationDB:
     """Create a new evaluation scenario.
@@ -1667,6 +1668,7 @@ async def create_new_evaluation(
         testset=testset,
         status=status,
         variant=variant,
+        variant_revision=variant_revision,
         evaluators_configs=evaluators_configs,
         aggregated_results=[],
         created_at=datetime.now().isoformat(),

--- a/agenta-backend/agenta_backend/services/db_manager.py
+++ b/agenta-backend/agenta_backend/services/db_manager.py
@@ -1225,7 +1225,7 @@ async def update_variant_parameters(
         raise ValueError("Issue updating variant parameters")
 
 
-async def get_app_variant_instance_by_id(variant_id: str):
+async def get_app_variant_instance_by_id(variant_id: str) -> AppVariantDB:
     """Get the app variant object from the database with the provided id.
 
     Arguments:
@@ -1239,6 +1239,25 @@ async def get_app_variant_instance_by_id(variant_id: str):
         AppVariantDB.id == ObjectId(variant_id), fetch_links=True
     )
     return app_variant_db
+
+
+async def get_app_variant_revision_by_id(
+    variant_revision_id: str, fetch_links=False
+) -> AppVariantRevisionsDB:
+    """Get the app variant revision object from the database with the provided id.
+
+    Arguments:
+        variant_revision_id (str): The app variant revision unique identifier
+
+    Returns:
+        AppVariantDB: instance of app variant object
+    """
+
+    variant_revision_db = await AppVariantRevisionsDB.find_one(
+        AppVariantRevisionsDB.id == ObjectId(variant_revision_id),
+        fetch_links=fetch_links,
+    )
+    return variant_revision_db
 
 
 async def fetch_testset_by_id(testset_id: str) -> Optional[TestSetDB]:

--- a/agenta-backend/agenta_backend/services/db_manager.py
+++ b/agenta-backend/agenta_backend/services/db_manager.py
@@ -193,7 +193,7 @@ async def fetch_app_variant_by_id(
 
 
 async def fetch_app_variant_revision_by_variant(
-    app_variant_id: str, revision: int = None
+    app_variant_id: str, revision: int
 ) -> AppVariantRevisionsDB:
     """Fetches app variant revision by variant id and revision
 
@@ -205,16 +205,12 @@ async def fetch_app_variant_revision_by_variant(
         AppVariantRevisionDB
     """
     assert app_variant_id is not None, "app_variant_id cannot be None"
-    if revision:
-        app_variant_revision = await AppVariantRevisionsDB.find_one(
-            AppVariantRevisionsDB.variant.id == ObjectId(app_variant_id),
-            AppVariantRevisionsDB.revision == revision,
-        )
-    else:
-        app_variant_revision = await AppVariantRevisionsDB.find(
-            AppVariantRevisionsDB.variant.id == ObjectId(app_variant_id),
-            fetch_links=True,
-        ).to_list()
+    assert revision is not None, "revision cannot be None"
+    app_variant_revision = await AppVariantRevisionsDB.find_one(
+        AppVariantRevisionsDB.variant.id == ObjectId(app_variant_id),
+        AppVariantRevisionsDB.revision == revision,
+    )
+
     if app_variant_revision is None:
         raise Exception(
             f"app variant revision  for app_variant {app_variant_id} and revision {revision} not found"

--- a/agenta-backend/agenta_backend/services/evaluation_service.py
+++ b/agenta-backend/agenta_backend/services/evaluation_service.py
@@ -622,14 +622,18 @@ async def create_new_human_evaluation(
         )
 
     variants = [ObjectId(variant_id) for variant_id in payload.variant_ids]
+    variant_dbs = [
+        await db_manager.fetch_app_variant_by_id(variant_id)
+        for variant_id in payload.variant_ids
+    ]
 
     testset = await db_manager.fetch_testset_by_id(testset_id=payload.testset_id)
     # Initialize and save evaluation instance to database
     variant_revisions = [
         await db_manager.fetch_app_variant_revision_by_variant(
-            str(variant.id), int(variant.revision)
+            str(variant_db.id), int(variant_db.revision)
         )
-        for variant in variants
+        for variant_db in variant_dbs
     ]
     eval_instance = HumanEvaluationDB(
         app=app,
@@ -638,7 +642,9 @@ async def create_new_human_evaluation(
         status=payload.status,
         evaluation_type=payload.evaluation_type,
         variants=variants,
-        variant_revisions=variant_revisions,
+        variant_revisions=[
+            ObjectId(str(variant_revision.id)) for variant_revision in variant_revisions
+        ],
         testset=testset,
         created_at=current_time,
         updated_at=current_time,

--- a/agenta-backend/agenta_backend/services/evaluation_service.py
+++ b/agenta-backend/agenta_backend/services/evaluation_service.py
@@ -625,6 +625,12 @@ async def create_new_human_evaluation(
 
     testset = await db_manager.fetch_testset_by_id(testset_id=payload.testset_id)
     # Initialize and save evaluation instance to database
+    variant_revisions = [
+        await db_manager.fetch_app_variant_revision_by_variant(
+            str(variant.id), int(variant.revision)
+        )
+        for variant in variants
+    ]
     eval_instance = HumanEvaluationDB(
         app=app,
         organization=app.organization,  # Assuming user has an organization_id attribute
@@ -632,6 +638,7 @@ async def create_new_human_evaluation(
         status=payload.status,
         evaluation_type=payload.evaluation_type,
         variants=variants,
+        variant_revisions=variant_revisions,
         testset=testset,
         created_at=current_time,
         updated_at=current_time,

--- a/agenta-backend/agenta_backend/services/evaluation_service.py
+++ b/agenta-backend/agenta_backend/services/evaluation_service.py
@@ -688,6 +688,10 @@ async def create_new_evaluation(
     app = await db_manager.fetch_app_by_id(app_id=app_id)
 
     testset = await db_manager.fetch_testset_by_id(testset_id)
+    variant_db = await db_manager.get_app_variant_instance_by_id(variant_id)
+    variant_revision = await db_manager.fetch_app_variant_revision_by_variant(
+        variant_id, variant_db.revision
+    )
 
     evaluation_db = await db_manager.create_new_evaluation(
         app=app,
@@ -696,6 +700,7 @@ async def create_new_evaluation(
         testset=testset,
         status=EvaluationStatusEnum.EVALUATION_STARTED,
         variant=variant_id,
+        variant_revision=str(variant_revision.id),
         evaluators_configs=evaluator_config_ids,
     )
     return await converters.evaluation_db_to_pydantic(evaluation_db)

--- a/agenta-web/src/lib/Types.ts
+++ b/agenta-web/src/lib/Types.ts
@@ -178,7 +178,7 @@ export interface EvaluationResponseType {
     status: string
     evaluation_type: string
     variant_revision_ids: string[]
-    variant_revisions: string[] // The revision number
+    revisions: string[] // The revision number
     evaluation_type_settings: {
         similarity_threshold: number
         regex_pattern: string

--- a/agenta-web/src/lib/Types.ts
+++ b/agenta-web/src/lib/Types.ts
@@ -177,6 +177,8 @@ export interface EvaluationResponseType {
     app_id: string
     status: string
     evaluation_type: string
+    variant_revision_ids: string[]
+    variant_revisions: string[] // The revision number
     evaluation_type_settings: {
         similarity_threshold: number
         regex_pattern: string


### PR DESCRIPTION
Added variant revision to schemas in evaluation and humanevaluation. 
When we create a new evaluation (both kinds) the backend always links the last revision for each variant to the evaluation document. 
When we GET the evaluation, we provide the ids of the revisions, and the number of the revisions linked to that evaluation (normal and human evaluation)