### PR TITLE
Enhancement - make use of server timezone instead of utc

### DIFF
--- a/agenta-backend/agenta_backend/migrations/17_01_24_pydantic_and_evaluations/20240110001454_initial_migration.py
+++ b/agenta-backend/agenta_backend/migrations/17_01_24_pydantic_and_evaluations/20240110001454_initial_migration.py
@@ -13,8 +13,8 @@ class OrganizationDB(Document):
     type: Optional[str]
     owner: str  # user id
     members: Optional[List[PydanticObjectId]]
-    created_at: Optional[datetime] = Field(default=datetime.utcnow())
-    updated_at: Optional[datetime] = Field(default=datetime.utcnow())
+    created_at: Optional[datetime] = Field(default=datetime.now())
+    updated_at: Optional[datetime] = Field(default=datetime.now())
 
     class Settings:
         name = "organizations"
@@ -25,8 +25,8 @@ class UserDB(Document):
     username: str = Field(default="agenta")
     email: str = Field(default="demo@agenta.ai", unique=True)
     organizations: Optional[List[PydanticObjectId]] = []
-    created_at: Optional[datetime] = Field(default=datetime.utcnow())
-    updated_at: Optional[datetime] = Field(default=datetime.utcnow())
+    created_at: Optional[datetime] = Field(default=datetime.now())
+    updated_at: Optional[datetime] = Field(default=datetime.now())
 
     class Settings:
         name = "users"
@@ -42,8 +42,8 @@ class ImageDB(Document):
     deletable: bool = Field(default=True)
     user: Link[UserDB]
     organization: Link[OrganizationDB]
-    created_at: Optional[datetime] = Field(default=datetime.utcnow())
-    updated_at: Optional[datetime] = Field(default=datetime.utcnow())
+    created_at: Optional[datetime] = Field(default=datetime.now())
+    updated_at: Optional[datetime] = Field(default=datetime.now())
 
     class Settings:
         name = "docker_images"
@@ -53,8 +53,8 @@ class AppDB(Document):
     app_name: str
     organization: Link[OrganizationDB]
     user: Link[UserDB]
-    created_at: Optional[datetime] = Field(default=datetime.utcnow())
-    updated_at: Optional[datetime] = Field(default=datetime.utcnow())
+    created_at: Optional[datetime] = Field(default=datetime.now())
+    updated_at: Optional[datetime] = Field(default=datetime.now())
 
     class Settings:
         name = "app_db"
@@ -67,8 +67,8 @@ class VariantBaseDB(Document):
     base_name: str
     image: Link[ImageDB]
     deployment: Optional[PydanticObjectId]  # Link to deployment
-    created_at: Optional[datetime] = Field(default=datetime.utcnow())
-    updated_at: Optional[datetime] = Field(default=datetime.utcnow())
+    created_at: Optional[datetime] = Field(default=datetime.now())
+    updated_at: Optional[datetime] = Field(default=datetime.now())
 
     class Settings:
         name = "bases"
@@ -77,8 +77,8 @@ class VariantBaseDB(Document):
 class ConfigVersionDB(BaseModel):
     version: int
     parameters: Dict[str, Any]
-    created_at: Optional[datetime] = Field(default=datetime.utcnow())
-    updated_at: Optional[datetime] = Field(default=datetime.utcnow())
+    created_at: Optional[datetime] = Field(default=datetime.now())
+    updated_at: Optional[datetime] = Field(default=datetime.now())
 
 
 class ConfigDB(Document):
@@ -86,8 +86,8 @@ class ConfigDB(Document):
     current_version: int = Field(default=1)
     parameters: Dict[str, Any] = Field(default=dict)
     version_history: List[ConfigVersionDB] = Field(default=[])
-    created_at: Optional[datetime] = Field(default=datetime.utcnow())
-    updated_at: Optional[datetime] = Field(default=datetime.utcnow())
+    created_at: Optional[datetime] = Field(default=datetime.now())
+    updated_at: Optional[datetime] = Field(default=datetime.now())
 
     class Settings:
         name = "configs"
@@ -105,8 +105,8 @@ class AppVariantDB(Document):
     base: Link[VariantBaseDB]
     config_name: Optional[str]
     config: Link[ConfigDB]
-    created_at: Optional[datetime] = Field(default=datetime.utcnow())
-    updated_at: Optional[datetime] = Field(default=datetime.utcnow())
+    created_at: Optional[datetime] = Field(default=datetime.now())
+    updated_at: Optional[datetime] = Field(default=datetime.now())
 
     is_deleted: bool = Field(  # TODO: deprecated. remove
         default=False
@@ -128,8 +128,8 @@ class OldAppVariantDB(Document):
     bases: Link[VariantBaseDB]
     config_name: Optional[str]
     configs: Link[ConfigDB]
-    created_at: Optional[datetime] = Field(default=datetime.utcnow())
-    updated_at: Optional[datetime] = Field(default=datetime.utcnow())
+    created_at: Optional[datetime] = Field(default=datetime.now())
+    updated_at: Optional[datetime] = Field(default=datetime.now())
 
     is_deleted: bool = Field(  # TODO: deprecated. remove
         default=False
@@ -145,8 +145,8 @@ class TestSetDB(Document):
     csvdata: List[Dict[str, str]]
     user: Link[UserDB]
     organization: Link[OrganizationDB]
-    created_at: Optional[datetime] = Field(default=datetime.utcnow())
-    updated_at: Optional[datetime] = Field(default=datetime.utcnow())
+    created_at: Optional[datetime] = Field(default=datetime.now())
+    updated_at: Optional[datetime] = Field(default=datetime.now())
 
     class Settings:
         name = "testsets"
@@ -171,8 +171,8 @@ class OldEvaluationDB(Document):
     evaluation_type_settings: Optional[OldEvaluationTypeSettings]
     variants: Optional[List[PydanticObjectId]]
     testsets: Link[TestSetDB]
-    created_at: Optional[datetime] = Field(default=datetime.utcnow())
-    updated_at: Optional[datetime] = Field(default=datetime.utcnow())
+    created_at: Optional[datetime] = Field(default=datetime.now())
+    updated_at: Optional[datetime] = Field(default=datetime.now())
 
     class Settings:
         name = "evaluations"
@@ -187,8 +187,8 @@ class EvaluationDB(Document):
     evaluation_type_settings: Optional[OldEvaluationTypeSettings]
     variants: Optional[List[PydanticObjectId]]
     testset: Link[TestSetDB]
-    created_at: Optional[datetime] = Field(default=datetime.utcnow())
-    updated_at: Optional[datetime] = Field(default=datetime.utcnow())
+    created_at: Optional[datetime] = Field(default=datetime.now())
+    updated_at: Optional[datetime] = Field(default=datetime.now())
 
     class Settings:
         name = "evaluations"
@@ -213,8 +213,8 @@ class OldEvaluationScenarioDB(Document):
     vote: Optional[str]
     score: Optional[Any]
     correct_answer: Optional[str]
-    created_at: Optional[datetime] = Field(default=datetime.utcnow())
-    updated_at: Optional[datetime] = Field(default=datetime.utcnow())
+    created_at: Optional[datetime] = Field(default=datetime.now())
+    updated_at: Optional[datetime] = Field(default=datetime.now())
     is_pinned: Optional[bool]
     note: Optional[str]
 
@@ -231,8 +231,8 @@ class EvaluationScenarioDB(Document):
     vote: Optional[str]
     score: Optional[Any]
     correct_answer: Optional[str]
-    created_at: Optional[datetime] = Field(default=datetime.utcnow())
-    updated_at: Optional[datetime] = Field(default=datetime.utcnow())
+    created_at: Optional[datetime] = Field(default=datetime.now())
+    updated_at: Optional[datetime] = Field(default=datetime.now())
     is_pinned: Optional[bool]
     note: Optional[str]
 

--- a/agenta-backend/agenta_backend/migrations/17_01_24_pydantic_and_evaluations/20240110132547_create_exact_match_evaluator_config.py
+++ b/agenta-backend/agenta_backend/migrations/17_01_24_pydantic_and_evaluations/20240110132547_create_exact_match_evaluator_config.py
@@ -12,8 +12,8 @@ class UserDB(Document):
     username: str = Field(default="agenta")
     email: str = Field(default="demo@agenta.ai", unique=True)
     organizations: Optional[List[PydanticObjectId]] = []
-    created_at: Optional[datetime] = Field(default=datetime.utcnow())
-    updated_at: Optional[datetime] = Field(default=datetime.utcnow())
+    created_at: Optional[datetime] = Field(default=datetime.now())
+    updated_at: Optional[datetime] = Field(default=datetime.now())
 
     class Settings:
         name = "users"
@@ -25,8 +25,8 @@ class OrganizationDB(Document):
     type: Optional[str]
     owner: str  # user id
     members: Optional[List[PydanticObjectId]]
-    created_at: Optional[datetime] = Field(default=datetime.utcnow())
-    updated_at: Optional[datetime] = Field(default=datetime.utcnow())
+    created_at: Optional[datetime] = Field(default=datetime.now())
+    updated_at: Optional[datetime] = Field(default=datetime.now())
 
     class Settings:
         name = "organizations"
@@ -36,8 +36,8 @@ class AppDB(Document):
     app_name: str
     organization: Link[OrganizationDB]
     user: Link[UserDB]
-    created_at: Optional[datetime] = Field(default=datetime.utcnow())
-    updated_at: Optional[datetime] = Field(default=datetime.utcnow())
+    created_at: Optional[datetime] = Field(default=datetime.now())
+    updated_at: Optional[datetime] = Field(default=datetime.now())
 
     class Settings:
         name = "app_db"
@@ -50,8 +50,8 @@ class EvaluatorConfigDB(Document):
     name: str
     evaluator_key: str
     settings_values: Optional[Dict[str, Any]]
-    created_at: datetime = Field(default=datetime.utcnow())
-    updated_at: datetime = Field(default=datetime.utcnow())
+    created_at: datetime = Field(default=datetime.now())
+    updated_at: datetime = Field(default=datetime.now())
 
     class Settings:
         name = "evaluators_configs"

--- a/agenta-backend/agenta_backend/migrations/17_01_24_pydantic_and_evaluations/20240110165900_evaluations_revamp.py
+++ b/agenta-backend/agenta_backend/migrations/17_01_24_pydantic_and_evaluations/20240110165900_evaluations_revamp.py
@@ -12,8 +12,8 @@ class OrganizationDB(Document):
     type: Optional[str]
     owner: str  # user id
     members: Optional[List[PydanticObjectId]]
-    created_at: Optional[datetime] = Field(default=datetime.utcnow())
-    updated_at: Optional[datetime] = Field(default=datetime.utcnow())
+    created_at: Optional[datetime] = Field(default=datetime.now())
+    updated_at: Optional[datetime] = Field(default=datetime.now())
 
     class Settings:
         name = "organizations"
@@ -24,8 +24,8 @@ class UserDB(Document):
     username: str = Field(default="agenta")
     email: str = Field(default="demo@agenta.ai", unique=True)
     organizations: Optional[List[PydanticObjectId]] = []
-    created_at: Optional[datetime] = Field(default=datetime.utcnow())
-    updated_at: Optional[datetime] = Field(default=datetime.utcnow())
+    created_at: Optional[datetime] = Field(default=datetime.now())
+    updated_at: Optional[datetime] = Field(default=datetime.now())
 
     class Settings:
         name = "users"
@@ -35,8 +35,8 @@ class AppDB(Document):
     app_name: str
     organization: Link[OrganizationDB]
     user: Link[UserDB]
-    created_at: Optional[datetime] = Field(default=datetime.utcnow())
-    updated_at: Optional[datetime] = Field(default=datetime.utcnow())
+    created_at: Optional[datetime] = Field(default=datetime.now())
+    updated_at: Optional[datetime] = Field(default=datetime.now())
 
     class Settings:
         name = "app_db"
@@ -48,8 +48,8 @@ class TestSetDB(Document):
     csvdata: List[Dict[str, str]]
     user: Link[UserDB]
     organization: Link[OrganizationDB]
-    created_at: Optional[datetime] = Field(default=datetime.utcnow())
-    updated_at: Optional[datetime] = Field(default=datetime.utcnow())
+    created_at: Optional[datetime] = Field(default=datetime.now())
+    updated_at: Optional[datetime] = Field(default=datetime.now())
 
     class Settings:
         name = "testsets"
@@ -62,8 +62,8 @@ class EvaluatorConfigDB(Document):
     name: str
     evaluator_key: str
     settings_values: Optional[Dict[str, Any]]
-    created_at: datetime = Field(default=datetime.utcnow())
-    updated_at: datetime = Field(default=datetime.utcnow())
+    created_at: datetime = Field(default=datetime.now())
+    updated_at: datetime = Field(default=datetime.now())
 
     class Settings:
         name = "evaluators_configs"
@@ -87,8 +87,8 @@ class HumanEvaluationDB(Document):
     evaluation_type: str
     variants: List[PydanticObjectId]
     testset: Link[TestSetDB]
-    created_at: Optional[datetime] = Field(default=datetime.utcnow())
-    updated_at: Optional[datetime] = Field(default=datetime.utcnow())
+    created_at: Optional[datetime] = Field(default=datetime.now())
+    updated_at: Optional[datetime] = Field(default=datetime.now())
 
     class Settings:
         name = "human_evaluations"
@@ -103,8 +103,8 @@ class EvaluationDB(Document):
     variant: PydanticObjectId
     evaluators_configs: List[PydanticObjectId]
     aggregated_results: List[AggregatedResult]
-    created_at: datetime = Field(default=datetime.utcnow())
-    updated_at: datetime = Field(default=datetime.utcnow())
+    created_at: datetime = Field(default=datetime.now())
+    updated_at: datetime = Field(default=datetime.now())
 
     class Settings:
         name = "new_evaluations"
@@ -130,8 +130,8 @@ class OldEvaluationDB(Document):
     variants: List[PydanticObjectId]
     version: str = Field("odmantic")
     testset: Link[TestSetDB]
-    created_at: Optional[datetime] = Field(default=datetime.utcnow())
-    updated_at: Optional[datetime] = Field(default=datetime.utcnow())
+    created_at: Optional[datetime] = Field(default=datetime.now())
+    updated_at: Optional[datetime] = Field(default=datetime.now())
 
     class Settings:
         name = "evaluations"
@@ -144,8 +144,8 @@ class OldCustomEvaluationDB(Document):
     app: Link[AppDB]
     user: Link[UserDB]
     organization: Link[OrganizationDB]
-    created_at: Optional[datetime] = Field(default=datetime.utcnow())
-    updated_at: Optional[datetime] = Field(default=datetime.utcnow())
+    created_at: Optional[datetime] = Field(default=datetime.now())
+    updated_at: Optional[datetime] = Field(default=datetime.now())
 
     class Settings:
         name = "custom_evaluations"

--- a/agenta-backend/agenta_backend/migrations/17_01_24_pydantic_and_evaluations/20240112120721_evaluation_scenarios_revamp.py
+++ b/agenta-backend/agenta_backend/migrations/17_01_24_pydantic_and_evaluations/20240112120721_evaluation_scenarios_revamp.py
@@ -12,8 +12,8 @@ class OrganizationDB(Document):
     type: Optional[str]
     owner: str  # user id
     members: Optional[List[PydanticObjectId]]
-    created_at: Optional[datetime] = Field(default=datetime.utcnow())
-    updated_at: Optional[datetime] = Field(default=datetime.utcnow())
+    created_at: Optional[datetime] = Field(default=datetime.now())
+    updated_at: Optional[datetime] = Field(default=datetime.now())
 
     class Settings:
         name = "organizations"
@@ -24,8 +24,8 @@ class UserDB(Document):
     username: str = Field(default="agenta")
     email: str = Field(default="demo@agenta.ai", unique=True)
     organizations: Optional[List[PydanticObjectId]] = []
-    created_at: Optional[datetime] = Field(default=datetime.utcnow())
-    updated_at: Optional[datetime] = Field(default=datetime.utcnow())
+    created_at: Optional[datetime] = Field(default=datetime.now())
+    updated_at: Optional[datetime] = Field(default=datetime.now())
 
     class Settings:
         name = "users"
@@ -35,8 +35,8 @@ class AppDB(Document):
     app_name: str
     organization: Link[OrganizationDB]
     user: Link[UserDB]
-    created_at: Optional[datetime] = Field(default=datetime.utcnow())
-    updated_at: Optional[datetime] = Field(default=datetime.utcnow())
+    created_at: Optional[datetime] = Field(default=datetime.now())
+    updated_at: Optional[datetime] = Field(default=datetime.now())
 
     class Settings:
         name = "app_db"
@@ -48,8 +48,8 @@ class TestSetDB(Document):
     csvdata: List[Dict[str, str]]
     user: Link[UserDB]
     organization: Link[OrganizationDB]
-    created_at: Optional[datetime] = Field(default=datetime.utcnow())
-    updated_at: Optional[datetime] = Field(default=datetime.utcnow())
+    created_at: Optional[datetime] = Field(default=datetime.now())
+    updated_at: Optional[datetime] = Field(default=datetime.now())
 
     class Settings:
         name = "testsets"
@@ -62,8 +62,8 @@ class EvaluatorConfigDB(Document):
     name: str
     evaluator_key: str
     settings_values: Optional[Dict[str, Any]] = None
-    created_at: datetime = Field(default=datetime.utcnow())
-    updated_at: datetime = Field(default=datetime.utcnow())
+    created_at: datetime = Field(default=datetime.now())
+    updated_at: datetime = Field(default=datetime.now())
 
     class Settings:
         name = "evaluators_configs"
@@ -113,8 +113,8 @@ class HumanEvaluationDB(Document):
     evaluation_type: str
     variants: List[PydanticObjectId]
     testset: Link[TestSetDB]
-    created_at: Optional[datetime] = Field(default=datetime.utcnow())
-    updated_at: Optional[datetime] = Field(default=datetime.utcnow())
+    created_at: Optional[datetime] = Field(default=datetime.now())
+    updated_at: Optional[datetime] = Field(default=datetime.now())
 
     class Settings:
         name = "human_evaluations"
@@ -129,8 +129,8 @@ class HumanEvaluationScenarioDB(Document):
     vote: Optional[str]
     score: Optional[Any]
     correct_answer: Optional[str]
-    created_at: Optional[datetime] = Field(default=datetime.utcnow())
-    updated_at: Optional[datetime] = Field(default=datetime.utcnow())
+    created_at: Optional[datetime] = Field(default=datetime.now())
+    updated_at: Optional[datetime] = Field(default=datetime.now())
     is_pinned: Optional[bool]
     note: Optional[str]
 
@@ -147,8 +147,8 @@ class EvaluationDB(Document):
     variant: PydanticObjectId
     evaluators_configs: List[PydanticObjectId]
     aggregated_results: List[AggregatedResult]
-    created_at: datetime = Field(default=datetime.utcnow())
-    updated_at: datetime = Field(default=datetime.utcnow())
+    created_at: datetime = Field(default=datetime.now())
+    updated_at: datetime = Field(default=datetime.now())
 
     class Settings:
         name = "new_evaluations"
@@ -166,8 +166,8 @@ class EvaluationScenarioDB(Document):
     note: Optional[str]
     evaluators_configs: List[PydanticObjectId]
     results: List[EvaluationScenarioResult]
-    created_at: datetime = Field(default=datetime.utcnow())
-    updated_at: datetime = Field(default=datetime.utcnow())
+    created_at: datetime = Field(default=datetime.now())
+    updated_at: datetime = Field(default=datetime.now())
 
     class Settings:
         name = "new_evaluation_scenarios"
@@ -203,8 +203,8 @@ class OldEvaluationDB(Document):
     variants: List[PydanticObjectId]
     version: str = Field("odmantic")
     testset: Link[TestSetDB]
-    created_at: Optional[datetime] = Field(default=datetime.utcnow())
-    updated_at: Optional[datetime] = Field(default=datetime.utcnow())
+    created_at: Optional[datetime] = Field(default=datetime.now())
+    updated_at: Optional[datetime] = Field(default=datetime.now())
 
     class Settings:
         name = "evaluations"
@@ -220,8 +220,8 @@ class OldEvaluationScenarioDB(Document):
     version: str = Field("odmantic")
     score: Optional[Any]
     correct_answer: Optional[str]
-    created_at: Optional[datetime] = Field(default=datetime.utcnow())
-    updated_at: Optional[datetime] = Field(default=datetime.utcnow())
+    created_at: Optional[datetime] = Field(default=datetime.now())
+    updated_at: Optional[datetime] = Field(default=datetime.now())
     is_pinned: Optional[bool]
     note: Optional[str]
 

--- a/agenta-backend/agenta_backend/migrations/17_01_24_pydantic_and_evaluations/20240112120740_human_a_b_evaluation_scenarios.py
+++ b/agenta-backend/agenta_backend/migrations/17_01_24_pydantic_and_evaluations/20240112120740_human_a_b_evaluation_scenarios.py
@@ -12,8 +12,8 @@ class OrganizationDB(Document):
     type: Optional[str]
     owner: str  # user id
     members: Optional[List[PydanticObjectId]]
-    created_at: Optional[datetime] = Field(default=datetime.utcnow())
-    updated_at: Optional[datetime] = Field(default=datetime.utcnow())
+    created_at: Optional[datetime] = Field(default=datetime.now())
+    updated_at: Optional[datetime] = Field(default=datetime.now())
 
     class Settings:
         name = "organizations"
@@ -24,8 +24,8 @@ class UserDB(Document):
     username: str = Field(default="agenta")
     email: str = Field(default="demo@agenta.ai", unique=True)
     organizations: Optional[List[PydanticObjectId]] = []
-    created_at: Optional[datetime] = Field(default=datetime.utcnow())
-    updated_at: Optional[datetime] = Field(default=datetime.utcnow())
+    created_at: Optional[datetime] = Field(default=datetime.now())
+    updated_at: Optional[datetime] = Field(default=datetime.now())
 
     class Settings:
         name = "users"
@@ -35,8 +35,8 @@ class AppDB(Document):
     app_name: str
     organization: Link[OrganizationDB]
     user: Link[UserDB]
-    created_at: Optional[datetime] = Field(default=datetime.utcnow())
-    updated_at: Optional[datetime] = Field(default=datetime.utcnow())
+    created_at: Optional[datetime] = Field(default=datetime.now())
+    updated_at: Optional[datetime] = Field(default=datetime.now())
 
     class Settings:
         name = "app_db"
@@ -48,8 +48,8 @@ class TestSetDB(Document):
     csvdata: List[Dict[str, str]]
     user: Link[UserDB]
     organization: Link[OrganizationDB]
-    created_at: Optional[datetime] = Field(default=datetime.utcnow())
-    updated_at: Optional[datetime] = Field(default=datetime.utcnow())
+    created_at: Optional[datetime] = Field(default=datetime.now())
+    updated_at: Optional[datetime] = Field(default=datetime.now())
 
     class Settings:
         name = "testsets"
@@ -62,8 +62,8 @@ class EvaluatorConfigDB(Document):
     name: str
     evaluator_key: str
     settings_values: Optional[Dict[str, Any]] = None
-    created_at: datetime = Field(default=datetime.utcnow())
-    updated_at: datetime = Field(default=datetime.utcnow())
+    created_at: datetime = Field(default=datetime.now())
+    updated_at: datetime = Field(default=datetime.now())
 
     class Settings:
         name = "evaluators_configs"
@@ -113,8 +113,8 @@ class HumanEvaluationDB(Document):
     evaluation_type: str
     variants: List[PydanticObjectId]
     testset: Link[TestSetDB]
-    created_at: Optional[datetime] = Field(default=datetime.utcnow())
-    updated_at: Optional[datetime] = Field(default=datetime.utcnow())
+    created_at: Optional[datetime] = Field(default=datetime.now())
+    updated_at: Optional[datetime] = Field(default=datetime.now())
 
     class Settings:
         name = "human_evaluations"
@@ -129,8 +129,8 @@ class HumanEvaluationScenarioDB(Document):
     vote: Optional[str]
     score: Optional[Any]
     correct_answer: Optional[str]
-    created_at: Optional[datetime] = Field(default=datetime.utcnow())
-    updated_at: Optional[datetime] = Field(default=datetime.utcnow())
+    created_at: Optional[datetime] = Field(default=datetime.now())
+    updated_at: Optional[datetime] = Field(default=datetime.now())
     is_pinned: Optional[bool]
     note: Optional[str]
 
@@ -147,8 +147,8 @@ class EvaluationDB(Document):
     variant: PydanticObjectId
     evaluators_configs: List[PydanticObjectId]
     aggregated_results: List[AggregatedResult]
-    created_at: datetime = Field(default=datetime.utcnow())
-    updated_at: datetime = Field(default=datetime.utcnow())
+    created_at: datetime = Field(default=datetime.now())
+    updated_at: datetime = Field(default=datetime.now())
 
     class Settings:
         name = "new_evaluations"
@@ -166,8 +166,8 @@ class EvaluationScenarioDB(Document):
     note: Optional[str]
     evaluators_configs: List[PydanticObjectId]
     results: List[EvaluationScenarioResult]
-    created_at: datetime = Field(default=datetime.utcnow())
-    updated_at: datetime = Field(default=datetime.utcnow())
+    created_at: datetime = Field(default=datetime.now())
+    updated_at: datetime = Field(default=datetime.now())
 
     class Settings:
         name = "new_evaluation_scenarios"
@@ -203,8 +203,8 @@ class OldEvaluationDB(Document):
     variants: List[PydanticObjectId]
     version: str = Field("odmantic")
     testset: Link[TestSetDB]
-    created_at: Optional[datetime] = Field(default=datetime.utcnow())
-    updated_at: Optional[datetime] = Field(default=datetime.utcnow())
+    created_at: Optional[datetime] = Field(default=datetime.now())
+    updated_at: Optional[datetime] = Field(default=datetime.now())
 
     class Settings:
         name = "evaluations"
@@ -220,8 +220,8 @@ class OldEvaluationScenarioDB(Document):
     version: str = Field("odmantic")
     score: Optional[Any]
     correct_answer: Optional[str]
-    created_at: Optional[datetime] = Field(default=datetime.utcnow())
-    updated_at: Optional[datetime] = Field(default=datetime.utcnow())
+    created_at: Optional[datetime] = Field(default=datetime.now())
+    updated_at: Optional[datetime] = Field(default=datetime.now())
     is_pinned: Optional[bool]
     note: Optional[str]
 

--- a/agenta-backend/agenta_backend/migrations/17_01_24_pydantic_and_evaluations/20240112120800_human_single_model_evaluation_scenarios.py
+++ b/agenta-backend/agenta_backend/migrations/17_01_24_pydantic_and_evaluations/20240112120800_human_single_model_evaluation_scenarios.py
@@ -12,8 +12,8 @@ class OrganizationDB(Document):
     type: Optional[str]
     owner: str  # user id
     members: Optional[List[PydanticObjectId]]
-    created_at: Optional[datetime] = Field(default=datetime.utcnow())
-    updated_at: Optional[datetime] = Field(default=datetime.utcnow())
+    created_at: Optional[datetime] = Field(default=datetime.now())
+    updated_at: Optional[datetime] = Field(default=datetime.now())
 
     class Settings:
         name = "organizations"
@@ -24,8 +24,8 @@ class UserDB(Document):
     username: str = Field(default="agenta")
     email: str = Field(default="demo@agenta.ai", unique=True)
     organizations: Optional[List[PydanticObjectId]] = []
-    created_at: Optional[datetime] = Field(default=datetime.utcnow())
-    updated_at: Optional[datetime] = Field(default=datetime.utcnow())
+    created_at: Optional[datetime] = Field(default=datetime.now())
+    updated_at: Optional[datetime] = Field(default=datetime.now())
 
     class Settings:
         name = "users"
@@ -35,8 +35,8 @@ class AppDB(Document):
     app_name: str
     organization: Link[OrganizationDB]
     user: Link[UserDB]
-    created_at: Optional[datetime] = Field(default=datetime.utcnow())
-    updated_at: Optional[datetime] = Field(default=datetime.utcnow())
+    created_at: Optional[datetime] = Field(default=datetime.now())
+    updated_at: Optional[datetime] = Field(default=datetime.now())
 
     class Settings:
         name = "app_db"
@@ -48,8 +48,8 @@ class TestSetDB(Document):
     csvdata: List[Dict[str, str]]
     user: Link[UserDB]
     organization: Link[OrganizationDB]
-    created_at: Optional[datetime] = Field(default=datetime.utcnow())
-    updated_at: Optional[datetime] = Field(default=datetime.utcnow())
+    created_at: Optional[datetime] = Field(default=datetime.now())
+    updated_at: Optional[datetime] = Field(default=datetime.now())
 
     class Settings:
         name = "testsets"
@@ -62,8 +62,8 @@ class EvaluatorConfigDB(Document):
     name: str
     evaluator_key: str
     settings_values: Optional[Dict[str, Any]] = None
-    created_at: datetime = Field(default=datetime.utcnow())
-    updated_at: datetime = Field(default=datetime.utcnow())
+    created_at: datetime = Field(default=datetime.now())
+    updated_at: datetime = Field(default=datetime.now())
 
     class Settings:
         name = "evaluators_configs"
@@ -113,8 +113,8 @@ class HumanEvaluationDB(Document):
     evaluation_type: str
     variants: List[PydanticObjectId]
     testset: Link[TestSetDB]
-    created_at: Optional[datetime] = Field(default=datetime.utcnow())
-    updated_at: Optional[datetime] = Field(default=datetime.utcnow())
+    created_at: Optional[datetime] = Field(default=datetime.now())
+    updated_at: Optional[datetime] = Field(default=datetime.now())
 
     class Settings:
         name = "human_evaluations"
@@ -129,8 +129,8 @@ class HumanEvaluationScenarioDB(Document):
     vote: Optional[str]
     score: Optional[Any]
     correct_answer: Optional[str]
-    created_at: Optional[datetime] = Field(default=datetime.utcnow())
-    updated_at: Optional[datetime] = Field(default=datetime.utcnow())
+    created_at: Optional[datetime] = Field(default=datetime.now())
+    updated_at: Optional[datetime] = Field(default=datetime.now())
     is_pinned: Optional[bool]
     note: Optional[str]
 
@@ -147,8 +147,8 @@ class EvaluationDB(Document):
     variant: PydanticObjectId
     evaluators_configs: List[PydanticObjectId]
     aggregated_results: List[AggregatedResult]
-    created_at: datetime = Field(default=datetime.utcnow())
-    updated_at: datetime = Field(default=datetime.utcnow())
+    created_at: datetime = Field(default=datetime.now())
+    updated_at: datetime = Field(default=datetime.now())
 
     class Settings:
         name = "new_evaluations"
@@ -166,8 +166,8 @@ class EvaluationScenarioDB(Document):
     note: Optional[str]
     evaluators_configs: List[PydanticObjectId]
     results: List[EvaluationScenarioResult]
-    created_at: datetime = Field(default=datetime.utcnow())
-    updated_at: datetime = Field(default=datetime.utcnow())
+    created_at: datetime = Field(default=datetime.now())
+    updated_at: datetime = Field(default=datetime.now())
 
     class Settings:
         name = "new_evaluation_scenarios"
@@ -203,8 +203,8 @@ class OldEvaluationDB(Document):
     variants: List[PydanticObjectId]
     version: str = Field("odmantic")
     testset: Link[TestSetDB]
-    created_at: Optional[datetime] = Field(default=datetime.utcnow())
-    updated_at: Optional[datetime] = Field(default=datetime.utcnow())
+    created_at: Optional[datetime] = Field(default=datetime.now())
+    updated_at: Optional[datetime] = Field(default=datetime.now())
 
     class Settings:
         name = "evaluations"
@@ -220,8 +220,8 @@ class OldEvaluationScenarioDB(Document):
     version: str = Field("odmantic")
     score: Optional[Any]
     correct_answer: Optional[str]
-    created_at: Optional[datetime] = Field(default=datetime.utcnow())
-    updated_at: Optional[datetime] = Field(default=datetime.utcnow())
+    created_at: Optional[datetime] = Field(default=datetime.now())
+    updated_at: Optional[datetime] = Field(default=datetime.now())
     is_pinned: Optional[bool]
     note: Optional[str]
 

--- a/agenta-backend/agenta_backend/migrations/17_01_24_pydantic_and_evaluations/20240113131802_new_evaluation_results_aggregation.py
+++ b/agenta-backend/agenta_backend/migrations/17_01_24_pydantic_and_evaluations/20240113131802_new_evaluation_results_aggregation.py
@@ -12,8 +12,8 @@ class OrganizationDB(Document):
     type: Optional[str]
     owner: str  # user id
     members: Optional[List[PydanticObjectId]]
-    created_at: Optional[datetime] = Field(default=datetime.utcnow())
-    updated_at: Optional[datetime] = Field(default=datetime.utcnow())
+    created_at: Optional[datetime] = Field(default=datetime.now())
+    updated_at: Optional[datetime] = Field(default=datetime.now())
 
     class Settings:
         name = "organizations"
@@ -24,8 +24,8 @@ class UserDB(Document):
     username: str = Field(default="agenta")
     email: str = Field(default="demo@agenta.ai", unique=True)
     organizations: Optional[List[PydanticObjectId]] = []
-    created_at: Optional[datetime] = Field(default=datetime.utcnow())
-    updated_at: Optional[datetime] = Field(default=datetime.utcnow())
+    created_at: Optional[datetime] = Field(default=datetime.now())
+    updated_at: Optional[datetime] = Field(default=datetime.now())
 
     class Settings:
         name = "users"
@@ -35,8 +35,8 @@ class AppDB(Document):
     app_name: str
     organization: Link[OrganizationDB]
     user: Link[UserDB]
-    created_at: Optional[datetime] = Field(default=datetime.utcnow())
-    updated_at: Optional[datetime] = Field(default=datetime.utcnow())
+    created_at: Optional[datetime] = Field(default=datetime.now())
+    updated_at: Optional[datetime] = Field(default=datetime.now())
 
     class Settings:
         name = "app_db"
@@ -48,8 +48,8 @@ class TestSetDB(Document):
     csvdata: List[Dict[str, str]]
     user: Link[UserDB]
     organization: Link[OrganizationDB]
-    created_at: Optional[datetime] = Field(default=datetime.utcnow())
-    updated_at: Optional[datetime] = Field(default=datetime.utcnow())
+    created_at: Optional[datetime] = Field(default=datetime.now())
+    updated_at: Optional[datetime] = Field(default=datetime.now())
 
     class Settings:
         name = "testsets"
@@ -90,8 +90,8 @@ class EvaluationDB(Document):
     variant: PydanticObjectId
     evaluators_configs: List[PydanticObjectId]
     aggregated_results: List[AggregatedResult]
-    created_at: datetime = Field(default=datetime.utcnow())
-    updated_at: datetime = Field(default=datetime.utcnow())
+    created_at: datetime = Field(default=datetime.now())
+    updated_at: datetime = Field(default=datetime.now())
 
     class Settings:
         name = "new_evaluations"
@@ -109,8 +109,8 @@ class EvaluationScenarioDB(Document):
     note: Optional[str]
     evaluators_configs: List[PydanticObjectId]
     results: List[EvaluationScenarioResult]
-    created_at: datetime = Field(default=datetime.utcnow())
-    updated_at: datetime = Field(default=datetime.utcnow())
+    created_at: datetime = Field(default=datetime.now())
+    updated_at: datetime = Field(default=datetime.now())
 
     class Settings:
         name = "new_evaluation_scenarios"
@@ -287,7 +287,7 @@ class Forward:
             )
             auto_evaluation.status = "EVALUATION_FINISHED"
             auto_evaluation.aggregated_results = aggregated_results
-            auto_evaluation.updated_at = datetime.utcnow().isoformat()
+            auto_evaluation.updated_at = datetime.now().isoformat()
             await auto_evaluation.save()
 
 

--- a/agenta-backend/agenta_backend/migrations/17_01_24_pydantic_and_evaluations/20240113204909_change_odmantic_reference_to_link.py
+++ b/agenta-backend/agenta_backend/migrations/17_01_24_pydantic_and_evaluations/20240113204909_change_odmantic_reference_to_link.py
@@ -15,7 +15,7 @@ class APIKeyDB(Document):
     rate_limit: int = Field(default=0)
     hidden: Optional[bool] = Field(default=False)
     expiration_date: Optional[datetime]
-    created_at: Optional[datetime] = datetime.utcnow()
+    created_at: Optional[datetime] = datetime.now()
     updated_at: Optional[datetime]
 
     class Settings:
@@ -36,8 +36,8 @@ class OrganizationDB(Document):
     owner: str  # user id
     members: Optional[List[PydanticObjectId]]
     invitations: Optional[List[InvitationDB]] = []
-    created_at: Optional[datetime] = Field(default=datetime.utcnow())
-    updated_at: Optional[datetime] = Field(default=datetime.utcnow())
+    created_at: Optional[datetime] = Field(default=datetime.now())
+    updated_at: Optional[datetime] = Field(default=datetime.now())
 
     class Settings:
         name = "organizations"
@@ -48,8 +48,8 @@ class UserDB(Document):
     username: str = Field(default="agenta")
     email: str = Field(default="demo@agenta.ai", unique=True)
     organizations: Optional[List[PydanticObjectId]] = []
-    created_at: Optional[datetime] = Field(default=datetime.utcnow())
-    updated_at: Optional[datetime] = Field(default=datetime.utcnow())
+    created_at: Optional[datetime] = Field(default=datetime.now())
+    updated_at: Optional[datetime] = Field(default=datetime.now())
 
     class Settings:
         name = "users"
@@ -65,8 +65,8 @@ class ImageDB(Document):
     deletable: bool = Field(default=True)
     user: Link[UserDB]
     organization: Link[OrganizationDB]
-    created_at: Optional[datetime] = Field(default=datetime.utcnow())
-    updated_at: Optional[datetime] = Field(default=datetime.utcnow())
+    created_at: Optional[datetime] = Field(default=datetime.now())
+    updated_at: Optional[datetime] = Field(default=datetime.now())
 
     class Settings:
         name = "docker_images"
@@ -76,8 +76,8 @@ class AppDB(Document):
     app_name: str
     organization: Link[OrganizationDB]
     user: Link[UserDB]
-    created_at: Optional[datetime] = Field(default=datetime.utcnow())
-    updated_at: Optional[datetime] = Field(default=datetime.utcnow())
+    created_at: Optional[datetime] = Field(default=datetime.now())
+    updated_at: Optional[datetime] = Field(default=datetime.now())
 
     class Settings:
         name = "app_db"
@@ -91,8 +91,8 @@ class DeploymentDB(Document):
     container_id: Optional[str]
     uri: Optional[str]
     status: str
-    created_at: Optional[datetime] = Field(default=datetime.utcnow())
-    updated_at: Optional[datetime] = Field(default=datetime.utcnow())
+    created_at: Optional[datetime] = Field(default=datetime.now())
+    updated_at: Optional[datetime] = Field(default=datetime.now())
 
     class Settings:
         name = "deployments"
@@ -105,8 +105,8 @@ class VariantBaseDB(Document):
     base_name: str
     image: Link[ImageDB]
     deployment: Optional[PydanticObjectId]  # Link to deployment
-    created_at: Optional[datetime] = Field(default=datetime.utcnow())
-    updated_at: Optional[datetime] = Field(default=datetime.utcnow())
+    created_at: Optional[datetime] = Field(default=datetime.now())
+    updated_at: Optional[datetime] = Field(default=datetime.now())
 
     class Settings:
         name = "bases"
@@ -115,8 +115,8 @@ class VariantBaseDB(Document):
 class ConfigVersionDB(BaseModel):
     version: int
     parameters: Dict[str, Any]
-    created_at: Optional[datetime] = Field(default=datetime.utcnow())
-    updated_at: Optional[datetime] = Field(default=datetime.utcnow())
+    created_at: Optional[datetime] = Field(default=datetime.now())
+    updated_at: Optional[datetime] = Field(default=datetime.now())
 
 
 class ConfigDB(Document):
@@ -124,8 +124,8 @@ class ConfigDB(Document):
     current_version: int = Field(default=1)
     parameters: Dict[str, Any] = Field(default=dict)
     version_history: List[ConfigVersionDB] = Field(default=[])
-    created_at: Optional[datetime] = Field(default=datetime.utcnow())
-    updated_at: Optional[datetime] = Field(default=datetime.utcnow())
+    created_at: Optional[datetime] = Field(default=datetime.now())
+    updated_at: Optional[datetime] = Field(default=datetime.now())
 
     class Settings:
         name = "configs"
@@ -143,8 +143,8 @@ class AppVariantDB(Document):
     base: Link[VariantBaseDB]
     config_name: Optional[str]
     config: Link[ConfigDB]
-    created_at: Optional[datetime] = Field(default=datetime.utcnow())
-    updated_at: Optional[datetime] = Field(default=datetime.utcnow())
+    created_at: Optional[datetime] = Field(default=datetime.now())
+    updated_at: Optional[datetime] = Field(default=datetime.now())
 
     is_deleted: bool = Field(  # TODO: deprecated. remove
         default=False
@@ -161,7 +161,7 @@ class AppEnvironmentDB(Document):
     organization: Link[OrganizationDB]
     deployed_app_variant: Optional[PydanticObjectId]
     deployment: Optional[PydanticObjectId]  # reference to deployment
-    created_at: Optional[datetime] = Field(default=datetime.utcnow())
+    created_at: Optional[datetime] = Field(default=datetime.now())
 
     class Settings:
         name = "environments"
@@ -189,8 +189,8 @@ class TestSetDB(Document):
     csvdata: List[Dict[str, str]]
     user: Link[UserDB]
     organization: Link[OrganizationDB]
-    created_at: Optional[datetime] = Field(default=datetime.utcnow())
-    updated_at: Optional[datetime] = Field(default=datetime.utcnow())
+    created_at: Optional[datetime] = Field(default=datetime.now())
+    updated_at: Optional[datetime] = Field(default=datetime.now())
 
     class Settings:
         name = "testsets"
@@ -203,8 +203,8 @@ class EvaluatorConfigDB(Document):
     name: str
     evaluator_key: str
     settings_values: Optional[Dict[str, Any]] = None
-    created_at: datetime = Field(default=datetime.utcnow())
-    updated_at: datetime = Field(default=datetime.utcnow())
+    created_at: datetime = Field(default=datetime.now())
+    updated_at: datetime = Field(default=datetime.now())
 
     class Settings:
         name = "evaluators_configs"
@@ -254,8 +254,8 @@ class HumanEvaluationDB(Document):
     evaluation_type: str
     variants: List[PydanticObjectId]
     testset: Link[TestSetDB]
-    created_at: Optional[datetime] = Field(default=datetime.utcnow())
-    updated_at: Optional[datetime] = Field(default=datetime.utcnow())
+    created_at: Optional[datetime] = Field(default=datetime.now())
+    updated_at: Optional[datetime] = Field(default=datetime.now())
 
     class Settings:
         name = "human_evaluations"
@@ -270,8 +270,8 @@ class HumanEvaluationScenarioDB(Document):
     vote: Optional[str]
     score: Optional[Any]
     correct_answer: Optional[str]
-    created_at: Optional[datetime] = Field(default=datetime.utcnow())
-    updated_at: Optional[datetime] = Field(default=datetime.utcnow())
+    created_at: Optional[datetime] = Field(default=datetime.now())
+    updated_at: Optional[datetime] = Field(default=datetime.now())
     is_pinned: Optional[bool]
     note: Optional[str]
 
@@ -288,8 +288,8 @@ class EvaluationDB(Document):
     variant: PydanticObjectId
     evaluators_configs: List[PydanticObjectId]
     aggregated_results: List[AggregatedResult]
-    created_at: datetime = Field(default=datetime.utcnow())
-    updated_at: datetime = Field(default=datetime.utcnow())
+    created_at: datetime = Field(default=datetime.now())
+    updated_at: datetime = Field(default=datetime.now())
 
     class Settings:
         name = "evaluations"
@@ -307,8 +307,8 @@ class EvaluationScenarioDB(Document):
     note: Optional[str]
     evaluators_configs: List[PydanticObjectId]
     results: List[EvaluationScenarioResult]
-    created_at: datetime = Field(default=datetime.utcnow())
-    updated_at: datetime = Field(default=datetime.utcnow())
+    created_at: datetime = Field(default=datetime.now())
+    updated_at: datetime = Field(default=datetime.now())
 
     class Settings:
         name = "evaluation_scenarios"

--- a/agenta-backend/agenta_backend/migrations/24_01_24_error_and_result/20240124174954_evaluation_error_handling.py
+++ b/agenta-backend/agenta_backend/migrations/24_01_24_error_and_result/20240124174954_evaluation_error_handling.py
@@ -12,8 +12,8 @@ class OrganizationDB(Document):
     type: Optional[str]
     owner: str  # user id
     members: Optional[List[PydanticObjectId]]
-    created_at: Optional[datetime] = Field(default=datetime.utcnow())
-    updated_at: Optional[datetime] = Field(default=datetime.utcnow())
+    created_at: Optional[datetime] = Field(default=datetime.now())
+    updated_at: Optional[datetime] = Field(default=datetime.now())
 
     class Settings:
         name = "organizations"
@@ -24,8 +24,8 @@ class UserDB(Document):
     username: str = Field(default="agenta")
     email: str = Field(default="demo@agenta.ai", unique=True)
     organizations: Optional[List[PydanticObjectId]] = []
-    created_at: Optional[datetime] = Field(default=datetime.utcnow())
-    updated_at: Optional[datetime] = Field(default=datetime.utcnow())
+    created_at: Optional[datetime] = Field(default=datetime.now())
+    updated_at: Optional[datetime] = Field(default=datetime.now())
 
     class Settings:
         name = "users"
@@ -35,8 +35,8 @@ class AppDB(Document):
     app_name: str
     organization: Link[OrganizationDB]
     user: Link[UserDB]
-    created_at: Optional[datetime] = Field(default=datetime.utcnow())
-    updated_at: Optional[datetime] = Field(default=datetime.utcnow())
+    created_at: Optional[datetime] = Field(default=datetime.now())
+    updated_at: Optional[datetime] = Field(default=datetime.now())
 
     class Settings:
         name = "app_db"
@@ -48,8 +48,8 @@ class TestSetDB(Document):
     csvdata: List[Dict[str, str]]
     user: Link[UserDB]
     organization: Link[OrganizationDB]
-    created_at: Optional[datetime] = Field(default=datetime.utcnow())
-    updated_at: Optional[datetime] = Field(default=datetime.utcnow())
+    created_at: Optional[datetime] = Field(default=datetime.now())
+    updated_at: Optional[datetime] = Field(default=datetime.now())
 
     class Settings:
         name = "testsets"
@@ -62,8 +62,8 @@ class EvaluatorConfigDB(Document):
     name: str
     evaluator_key: str
     settings_values: Optional[Dict[str, Any]]
-    created_at: datetime = Field(default=datetime.utcnow())
-    updated_at: datetime = Field(default=datetime.utcnow())
+    created_at: datetime = Field(default=datetime.now())
+    updated_at: datetime = Field(default=datetime.now())
 
     class Settings:
         name = "evaluators_configs"
@@ -88,8 +88,8 @@ class EvaluationDB(Document):
     variant: PydanticObjectId
     evaluators_configs: List[PydanticObjectId]
     aggregated_results: List[AggregatedResult]
-    created_at: datetime = Field(default=datetime.utcnow())
-    updated_at: datetime = Field(default=datetime.utcnow())
+    created_at: datetime = Field(default=datetime.now())
+    updated_at: datetime = Field(default=datetime.now())
 
     class Settings:
         name = "new_evaluations"
@@ -116,8 +116,8 @@ class NewEvaluationDB(Document):
     variant: PydanticObjectId
     evaluators_configs: List[PydanticObjectId]
     aggregated_results: List[AggregatedResult]
-    created_at: datetime = Field(default=datetime.utcnow())
-    updated_at: datetime = Field(default=datetime.utcnow())
+    created_at: datetime = Field(default=datetime.now())
+    updated_at: datetime = Field(default=datetime.now())
 
     class Settings:
         name = "new_evaluations"

--- a/agenta-backend/agenta_backend/migrations/24_01_24_error_and_result/20240124225808_evaluation_scenario_error_handling.py
+++ b/agenta-backend/agenta_backend/migrations/24_01_24_error_and_result/20240124225808_evaluation_scenario_error_handling.py
@@ -12,8 +12,8 @@ class OrganizationDB(Document):
     type: Optional[str]
     owner: str  # user id
     members: Optional[List[PydanticObjectId]]
-    created_at: Optional[datetime] = Field(default=datetime.utcnow())
-    updated_at: Optional[datetime] = Field(default=datetime.utcnow())
+    created_at: Optional[datetime] = Field(default=datetime.now())
+    updated_at: Optional[datetime] = Field(default=datetime.now())
 
     class Settings:
         name = "organizations"
@@ -24,8 +24,8 @@ class UserDB(Document):
     username: str = Field(default="agenta")
     email: str = Field(default="demo@agenta.ai", unique=True)
     organizations: Optional[List[PydanticObjectId]] = []
-    created_at: Optional[datetime] = Field(default=datetime.utcnow())
-    updated_at: Optional[datetime] = Field(default=datetime.utcnow())
+    created_at: Optional[datetime] = Field(default=datetime.now())
+    updated_at: Optional[datetime] = Field(default=datetime.now())
 
     class Settings:
         name = "users"
@@ -35,8 +35,8 @@ class AppDB(Document):
     app_name: str
     organization: Link[OrganizationDB]
     user: Link[UserDB]
-    created_at: Optional[datetime] = Field(default=datetime.utcnow())
-    updated_at: Optional[datetime] = Field(default=datetime.utcnow())
+    created_at: Optional[datetime] = Field(default=datetime.now())
+    updated_at: Optional[datetime] = Field(default=datetime.now())
 
     class Settings:
         name = "app_db"
@@ -48,8 +48,8 @@ class TestSetDB(Document):
     csvdata: List[Dict[str, str]]
     user: Link[UserDB]
     organization: Link[OrganizationDB]
-    created_at: Optional[datetime] = Field(default=datetime.utcnow())
-    updated_at: Optional[datetime] = Field(default=datetime.utcnow())
+    created_at: Optional[datetime] = Field(default=datetime.now())
+    updated_at: Optional[datetime] = Field(default=datetime.now())
 
     class Settings:
         name = "testsets"
@@ -62,8 +62,8 @@ class EvaluatorConfigDB(Document):
     name: str
     evaluator_key: str
     settings_values: Optional[Dict[str, Any]]
-    created_at: datetime = Field(default=datetime.utcnow())
-    updated_at: datetime = Field(default=datetime.utcnow())
+    created_at: datetime = Field(default=datetime.now())
+    updated_at: datetime = Field(default=datetime.now())
 
     class Settings:
         name = "evaluators_configs"
@@ -88,8 +88,8 @@ class EvaluationDB(Document):
     variant: PydanticObjectId
     evaluators_configs: List[PydanticObjectId]
     aggregated_results: List[AggregatedResult]
-    created_at: datetime = Field(default=datetime.utcnow())
-    updated_at: datetime = Field(default=datetime.utcnow())
+    created_at: datetime = Field(default=datetime.now())
+    updated_at: datetime = Field(default=datetime.now())
 
     class Settings:
         name = "new_evaluations"
@@ -123,8 +123,8 @@ class EvaluationScenarioDB(Document):
     note: Optional[str]
     evaluators_configs: List[PydanticObjectId]
     results: List[EvaluationScenarioResult]
-    created_at: datetime = Field(default=datetime.utcnow())
-    updated_at: datetime = Field(default=datetime.utcnow())
+    created_at: datetime = Field(default=datetime.now())
+    updated_at: datetime = Field(default=datetime.now())
 
     class Settings:
         name = "new_evaluation_scenarios"
@@ -155,8 +155,8 @@ class NewEvaluationDB(Document):
     variant: PydanticObjectId
     evaluators_configs: List[PydanticObjectId]
     aggregated_results: List[AggregatedResult]
-    created_at: datetime = Field(default=datetime.utcnow())
-    updated_at: datetime = Field(default=datetime.utcnow())
+    created_at: datetime = Field(default=datetime.now())
+    updated_at: datetime = Field(default=datetime.now())
 
     class Settings:
         name = "new_evaluations"
@@ -174,8 +174,8 @@ class NewEvaluationScenarioDB(Document):
     note: Optional[str]
     evaluators_configs: List[PydanticObjectId]
     results: List[EvaluationScenarioResult]
-    created_at: datetime = Field(default=datetime.utcnow())
-    updated_at: datetime = Field(default=datetime.utcnow())
+    created_at: datetime = Field(default=datetime.now())
+    updated_at: datetime = Field(default=datetime.now())
 
     class Settings:
         name = "new_evaluation_scenarios"

--- a/agenta-backend/agenta_backend/migrations/30_01_24_prompt_versioning/20240130133518_updating_app_variant.py
+++ b/agenta-backend/agenta_backend/migrations/30_01_24_prompt_versioning/20240130133518_updating_app_variant.py
@@ -14,7 +14,7 @@ class APIKeyDB(Document):
     rate_limit: int = Field(default=0)
     hidden: Optional[bool] = Field(default=False)
     expiration_date: Optional[datetime]
-    created_at: Optional[datetime] = datetime.utcnow()
+    created_at: Optional[datetime] = datetime.now()
     updated_at: Optional[datetime]
 
     class Settings:
@@ -35,8 +35,8 @@ class OrganizationDB(Document):
     owner: str  # user id
     members: Optional[List[PydanticObjectId]]
     invitations: Optional[List[InvitationDB]] = []
-    created_at: Optional[datetime] = Field(default=datetime.utcnow())
-    updated_at: Optional[datetime] = Field(default=datetime.utcnow())
+    created_at: Optional[datetime] = Field(default=datetime.now())
+    updated_at: Optional[datetime] = Field(default=datetime.now())
 
     class Settings:
         name = "organizations"
@@ -47,8 +47,8 @@ class UserDB(Document):
     username: str = Field(default="agenta")
     email: str = Field(default="demo@agenta.ai", unique=True)
     organizations: Optional[List[PydanticObjectId]] = []
-    created_at: Optional[datetime] = Field(default=datetime.utcnow())
-    updated_at: Optional[datetime] = Field(default=datetime.utcnow())
+    created_at: Optional[datetime] = Field(default=datetime.now())
+    updated_at: Optional[datetime] = Field(default=datetime.now())
 
     class Settings:
         name = "users"
@@ -64,8 +64,8 @@ class ImageDB(Document):
     deletable: bool = Field(default=True)
     user: Link[UserDB]
     organization: Link[OrganizationDB]
-    created_at: Optional[datetime] = Field(default=datetime.utcnow())
-    updated_at: Optional[datetime] = Field(default=datetime.utcnow())
+    created_at: Optional[datetime] = Field(default=datetime.now())
+    updated_at: Optional[datetime] = Field(default=datetime.now())
 
     class Settings:
         name = "docker_images"
@@ -75,8 +75,8 @@ class AppDB(Document):
     app_name: str
     organization: Link[OrganizationDB]
     user: Link[UserDB]
-    created_at: Optional[datetime] = Field(default=datetime.utcnow())
-    updated_at: Optional[datetime] = Field(default=datetime.utcnow())
+    created_at: Optional[datetime] = Field(default=datetime.now())
+    updated_at: Optional[datetime] = Field(default=datetime.now())
 
     class Settings:
         name = "app_db"
@@ -90,8 +90,8 @@ class DeploymentDB(Document):
     container_id: Optional[str]
     uri: Optional[str]
     status: str
-    created_at: Optional[datetime] = Field(default=datetime.utcnow())
-    updated_at: Optional[datetime] = Field(default=datetime.utcnow())
+    created_at: Optional[datetime] = Field(default=datetime.now())
+    updated_at: Optional[datetime] = Field(default=datetime.now())
 
     class Settings:
         name = "deployments"
@@ -104,8 +104,8 @@ class VariantBaseDB(Document):
     base_name: str
     image: Link[ImageDB]
     deployment: Optional[PydanticObjectId]  # Link to deployment
-    created_at: Optional[datetime] = Field(default=datetime.utcnow())
-    updated_at: Optional[datetime] = Field(default=datetime.utcnow())
+    created_at: Optional[datetime] = Field(default=datetime.now())
+    updated_at: Optional[datetime] = Field(default=datetime.now())
 
     class Settings:
         name = "bases"
@@ -114,8 +114,8 @@ class VariantBaseDB(Document):
 class ConfigVersionDB(BaseModel):
     version: int
     parameters: Dict[str, Any]
-    created_at: Optional[datetime] = Field(default=datetime.utcnow())
-    updated_at: Optional[datetime] = Field(default=datetime.utcnow())
+    created_at: Optional[datetime] = Field(default=datetime.now())
+    updated_at: Optional[datetime] = Field(default=datetime.now())
 
 
 class OldConfigDB(Document):
@@ -123,8 +123,8 @@ class OldConfigDB(Document):
     current_version: int = Field(default=1)
     parameters: Dict[str, Any] = Field(default=dict)
     version_history: List[ConfigVersionDB] = Field(default=[])
-    created_at: Optional[datetime] = Field(default=datetime.utcnow())
-    updated_at: Optional[datetime] = Field(default=datetime.utcnow())
+    created_at: Optional[datetime] = Field(default=datetime.now())
+    updated_at: Optional[datetime] = Field(default=datetime.now())
 
     class Settings:
         name = "configs"
@@ -142,8 +142,8 @@ class AppVariantDB(Document):
     base: Link[VariantBaseDB]
     config_name: Optional[str]
     config: Link[OldConfigDB]
-    created_at: Optional[datetime] = Field(default=datetime.utcnow())
-    updated_at: Optional[datetime] = Field(default=datetime.utcnow())
+    created_at: Optional[datetime] = Field(default=datetime.now())
+    updated_at: Optional[datetime] = Field(default=datetime.now())
 
     is_deleted: bool = Field(  # TODO: deprecated. remove
         default=False
@@ -160,7 +160,7 @@ class AppEnvironmentDB(Document):
     organization: Link[OrganizationDB]
     deployed_app_variant: Optional[PydanticObjectId]
     deployment: Optional[PydanticObjectId]  # reference to deployment
-    created_at: Optional[datetime] = Field(default=datetime.utcnow())
+    created_at: Optional[datetime] = Field(default=datetime.now())
 
     class Settings:
         name = "environments"
@@ -172,8 +172,8 @@ class TestSetDB(Document):
     csvdata: List[Dict[str, str]]
     user: Link[UserDB]
     organization: Link[OrganizationDB]
-    created_at: Optional[datetime] = Field(default=datetime.utcnow())
-    updated_at: Optional[datetime] = Field(default=datetime.utcnow())
+    created_at: Optional[datetime] = Field(default=datetime.now())
+    updated_at: Optional[datetime] = Field(default=datetime.now())
 
     class Settings:
         name = "testsets"
@@ -199,8 +199,8 @@ class NewAppVariantDB(Document):
     base: Link[VariantBaseDB]
     config_name: Optional[str]
     config: ConfigDB
-    created_at: Optional[datetime] = Field(default=datetime.utcnow())
-    updated_at: Optional[datetime] = Field(default=datetime.utcnow())
+    created_at: Optional[datetime] = Field(default=datetime.now())
+    updated_at: Optional[datetime] = Field(default=datetime.now())
 
     is_deleted: bool = Field(  # TODO: deprecated. remove
         default=False

--- a/agenta-backend/agenta_backend/migrations/30_01_24_prompt_versioning/20240130133544_create_app_variant_revision.py
+++ b/agenta-backend/agenta_backend/migrations/30_01_24_prompt_versioning/20240130133544_create_app_variant_revision.py
@@ -15,7 +15,7 @@ class APIKeyDB(Document):
     rate_limit: int = Field(default=0)
     hidden: Optional[bool] = Field(default=False)
     expiration_date: Optional[datetime]
-    created_at: Optional[datetime] = datetime.utcnow()
+    created_at: Optional[datetime] = datetime.now()
     updated_at: Optional[datetime]
 
     class Settings:
@@ -36,8 +36,8 @@ class OrganizationDB(Document):
     owner: str  # user id
     members: Optional[List[PydanticObjectId]]
     invitations: Optional[List[InvitationDB]] = []
-    created_at: Optional[datetime] = Field(default=datetime.utcnow())
-    updated_at: Optional[datetime] = Field(default=datetime.utcnow())
+    created_at: Optional[datetime] = Field(default=datetime.now())
+    updated_at: Optional[datetime] = Field(default=datetime.now())
 
     class Settings:
         name = "organizations"
@@ -48,8 +48,8 @@ class UserDB(Document):
     username: str = Field(default="agenta")
     email: str = Field(default="demo@agenta.ai", unique=True)
     organizations: Optional[List[PydanticObjectId]] = []
-    created_at: Optional[datetime] = Field(default=datetime.utcnow())
-    updated_at: Optional[datetime] = Field(default=datetime.utcnow())
+    created_at: Optional[datetime] = Field(default=datetime.now())
+    updated_at: Optional[datetime] = Field(default=datetime.now())
 
     class Settings:
         name = "users"
@@ -65,8 +65,8 @@ class ImageDB(Document):
     deletable: bool = Field(default=True)
     user: Link[UserDB]
     organization: Link[OrganizationDB]
-    created_at: Optional[datetime] = Field(default=datetime.utcnow())
-    updated_at: Optional[datetime] = Field(default=datetime.utcnow())
+    created_at: Optional[datetime] = Field(default=datetime.now())
+    updated_at: Optional[datetime] = Field(default=datetime.now())
 
     class Settings:
         name = "docker_images"
@@ -76,8 +76,8 @@ class AppDB(Document):
     app_name: str
     organization: Link[OrganizationDB]
     user: Link[UserDB]
-    created_at: Optional[datetime] = Field(default=datetime.utcnow())
-    updated_at: Optional[datetime] = Field(default=datetime.utcnow())
+    created_at: Optional[datetime] = Field(default=datetime.now())
+    updated_at: Optional[datetime] = Field(default=datetime.now())
 
     class Settings:
         name = "app_db"
@@ -91,8 +91,8 @@ class DeploymentDB(Document):
     container_id: Optional[str]
     uri: Optional[str]
     status: str
-    created_at: Optional[datetime] = Field(default=datetime.utcnow())
-    updated_at: Optional[datetime] = Field(default=datetime.utcnow())
+    created_at: Optional[datetime] = Field(default=datetime.now())
+    updated_at: Optional[datetime] = Field(default=datetime.now())
 
     class Settings:
         name = "deployments"
@@ -105,8 +105,8 @@ class VariantBaseDB(Document):
     base_name: str
     image: Link[ImageDB]
     deployment: Optional[PydanticObjectId]  # Link to deployment
-    created_at: Optional[datetime] = Field(default=datetime.utcnow())
-    updated_at: Optional[datetime] = Field(default=datetime.utcnow())
+    created_at: Optional[datetime] = Field(default=datetime.now())
+    updated_at: Optional[datetime] = Field(default=datetime.now())
 
     class Settings:
         name = "bases"
@@ -115,8 +115,8 @@ class VariantBaseDB(Document):
 class ConfigVersionDB(BaseModel):
     version: int
     parameters: Dict[str, Any]
-    created_at: Optional[datetime] = Field(default=datetime.utcnow())
-    updated_at: Optional[datetime] = Field(default=datetime.utcnow())
+    created_at: Optional[datetime] = Field(default=datetime.now())
+    updated_at: Optional[datetime] = Field(default=datetime.now())
 
 
 class OldConfigDB(Document):
@@ -124,8 +124,8 @@ class OldConfigDB(Document):
     current_version: int = Field(default=1)
     parameters: Dict[str, Any] = Field(default=dict)
     version_history: List[ConfigVersionDB] = Field(default=[])
-    created_at: Optional[datetime] = Field(default=datetime.utcnow())
-    updated_at: Optional[datetime] = Field(default=datetime.utcnow())
+    created_at: Optional[datetime] = Field(default=datetime.now())
+    updated_at: Optional[datetime] = Field(default=datetime.now())
 
     class Settings:
         name = "configs"
@@ -143,8 +143,8 @@ class AppVariantDB(Document):
     base: Link[VariantBaseDB]
     config_name: Optional[str]
     config: Link[OldConfigDB]
-    created_at: Optional[datetime] = Field(default=datetime.utcnow())
-    updated_at: Optional[datetime] = Field(default=datetime.utcnow())
+    created_at: Optional[datetime] = Field(default=datetime.now())
+    updated_at: Optional[datetime] = Field(default=datetime.now())
 
     is_deleted: bool = Field(  # TODO: deprecated. remove
         default=False
@@ -161,7 +161,7 @@ class AppEnvironmentDB(Document):
     organization: Link[OrganizationDB]
     deployed_app_variant: Optional[PydanticObjectId]
     deployment: Optional[PydanticObjectId]  # reference to deployment
-    created_at: Optional[datetime] = Field(default=datetime.utcnow())
+    created_at: Optional[datetime] = Field(default=datetime.now())
 
     class Settings:
         name = "app_environment_db"
@@ -189,8 +189,8 @@ class TestSetDB(Document):
     csvdata: List[Dict[str, str]]
     user: Link[UserDB]
     organization: Link[OrganizationDB]
-    created_at: Optional[datetime] = Field(default=datetime.utcnow())
-    updated_at: Optional[datetime] = Field(default=datetime.utcnow())
+    created_at: Optional[datetime] = Field(default=datetime.now())
+    updated_at: Optional[datetime] = Field(default=datetime.now())
 
     class Settings:
         name = "testsets"
@@ -203,8 +203,8 @@ class EvaluatorConfigDB(Document):
     name: str
     evaluator_key: str
     settings_values: Dict[str, Any] = Field(default=dict)
-    created_at: datetime = Field(default=datetime.utcnow())
-    updated_at: datetime = Field(default=datetime.utcnow())
+    created_at: datetime = Field(default=datetime.now())
+    updated_at: datetime = Field(default=datetime.now())
 
     class Settings:
         name = "evaluators_configs"
@@ -254,8 +254,8 @@ class HumanEvaluationDB(Document):
     evaluation_type: str
     variants: List[PydanticObjectId]
     testset: Link[TestSetDB]
-    created_at: Optional[datetime] = Field(default=datetime.utcnow())
-    updated_at: Optional[datetime] = Field(default=datetime.utcnow())
+    created_at: Optional[datetime] = Field(default=datetime.now())
+    updated_at: Optional[datetime] = Field(default=datetime.now())
 
     class Settings:
         name = "human_evaluations"
@@ -270,8 +270,8 @@ class HumanEvaluationScenarioDB(Document):
     vote: Optional[str]
     score: Optional[Any]
     correct_answer: Optional[str]
-    created_at: Optional[datetime] = Field(default=datetime.utcnow())
-    updated_at: Optional[datetime] = Field(default=datetime.utcnow())
+    created_at: Optional[datetime] = Field(default=datetime.now())
+    updated_at: Optional[datetime] = Field(default=datetime.now())
     is_pinned: Optional[bool]
     note: Optional[str]
 
@@ -288,8 +288,8 @@ class EvaluationDB(Document):
     variant: PydanticObjectId
     evaluators_configs: List[PydanticObjectId]
     aggregated_results: List[AggregatedResult]
-    created_at: datetime = Field(default=datetime.utcnow())
-    updated_at: datetime = Field(default=datetime.utcnow())
+    created_at: datetime = Field(default=datetime.now())
+    updated_at: datetime = Field(default=datetime.now())
 
     class Settings:
         name = "new_evaluations"
@@ -307,8 +307,8 @@ class EvaluationScenarioDB(Document):
     note: Optional[str]
     evaluators_configs: List[PydanticObjectId]
     results: List[EvaluationScenarioResult]
-    created_at: datetime = Field(default=datetime.utcnow())
-    updated_at: datetime = Field(default=datetime.utcnow())
+    created_at: datetime = Field(default=datetime.now())
+    updated_at: datetime = Field(default=datetime.now())
 
     class Settings:
         name = "new_evaluation_scenarios"
@@ -322,7 +322,7 @@ class SpanDB(Document):
     start_time: datetime
     duration: Optional[int]
     status: str  # initiated, completed, stopped, cancelled
-    end_time: datetime = Field(default=datetime.utcnow())
+    end_time: datetime = Field(default=datetime.now())
     inputs: Optional[List[str]]
     outputs: Optional[List[str]]
     prompt_template: Optional[str]
@@ -343,7 +343,7 @@ class Feedback(BaseModel):
     score: Optional[float]
     meta: Optional[Dict[str, Any]]
     created_at: datetime
-    updated_at: datetime = Field(default=datetime.utcnow())
+    updated_at: datetime = Field(default=datetime.now())
 
 
 class TraceDB(Document):
@@ -351,7 +351,7 @@ class TraceDB(Document):
     variant_id: str
     spans: List[PydanticObjectId]
     start_time: datetime
-    end_time: datetime = Field(default=datetime.utcnow())
+    end_time: datetime = Field(default=datetime.now())
     cost: Optional[float]
     latency: float
     status: str  # initiated, completed, stopped, cancelled, failed
@@ -384,8 +384,8 @@ class NewAppVariantDB(Document):
     base: Link[VariantBaseDB]
     config_name: Optional[str]
     config: ConfigDB
-    created_at: Optional[datetime] = Field(default=datetime.utcnow())
-    updated_at: Optional[datetime] = Field(default=datetime.utcnow())
+    created_at: Optional[datetime] = Field(default=datetime.now())
+    updated_at: Optional[datetime] = Field(default=datetime.now())
 
     is_deleted: bool = Field(  # TODO: deprecated. remove
         default=False
@@ -401,8 +401,8 @@ class NewAppVariantRevisionsDB(Document):
     modified_by: Link[UserDB]
     base: Link[VariantBaseDB]
     config: ConfigDB
-    created_at: Optional[datetime] = Field(default=datetime.utcnow())
-    updated_at: Optional[datetime] = Field(default=datetime.utcnow())
+    created_at: Optional[datetime] = Field(default=datetime.now())
+    updated_at: Optional[datetime] = Field(default=datetime.now())
 
     class Settings:
         name = "app_variant_revisions"
@@ -416,7 +416,7 @@ class NewAppEnvironmentDB(Document):
     deployed_app_variant: Optional[PydanticObjectId]
     deployed_app_variant_revision: Optional[Link[NewAppVariantRevisionsDB]]
     deployment: Optional[PydanticObjectId]  # reference to deployment
-    created_at: Optional[datetime] = Field(default=datetime.utcnow())
+    created_at: Optional[datetime] = Field(default=datetime.now())
 
     class Settings:
         name = "app_environment_db"

--- a/agenta-backend/agenta_backend/migrations/30_01_24_prompt_versioning/20240130133603_updating_app_environment.py
+++ b/agenta-backend/agenta_backend/migrations/30_01_24_prompt_versioning/20240130133603_updating_app_environment.py
@@ -15,7 +15,7 @@ class APIKeyDB(Document):
     rate_limit: int = Field(default=0)
     hidden: Optional[bool] = Field(default=False)
     expiration_date: Optional[datetime]
-    created_at: Optional[datetime] = datetime.utcnow()
+    created_at: Optional[datetime] = datetime.now()
     updated_at: Optional[datetime]
 
     class Settings:
@@ -36,8 +36,8 @@ class OrganizationDB(Document):
     owner: str  # user id
     members: Optional[List[PydanticObjectId]]
     invitations: Optional[List[InvitationDB]] = []
-    created_at: Optional[datetime] = Field(default=datetime.utcnow())
-    updated_at: Optional[datetime] = Field(default=datetime.utcnow())
+    created_at: Optional[datetime] = Field(default=datetime.now())
+    updated_at: Optional[datetime] = Field(default=datetime.now())
 
     class Settings:
         name = "organizations"
@@ -48,8 +48,8 @@ class UserDB(Document):
     username: str = Field(default="agenta")
     email: str = Field(default="demo@agenta.ai", unique=True)
     organizations: Optional[List[PydanticObjectId]] = []
-    created_at: Optional[datetime] = Field(default=datetime.utcnow())
-    updated_at: Optional[datetime] = Field(default=datetime.utcnow())
+    created_at: Optional[datetime] = Field(default=datetime.now())
+    updated_at: Optional[datetime] = Field(default=datetime.now())
 
     class Settings:
         name = "users"
@@ -65,8 +65,8 @@ class ImageDB(Document):
     deletable: bool = Field(default=True)
     user: Link[UserDB]
     organization: Link[OrganizationDB]
-    created_at: Optional[datetime] = Field(default=datetime.utcnow())
-    updated_at: Optional[datetime] = Field(default=datetime.utcnow())
+    created_at: Optional[datetime] = Field(default=datetime.now())
+    updated_at: Optional[datetime] = Field(default=datetime.now())
 
     class Settings:
         name = "docker_images"
@@ -76,8 +76,8 @@ class AppDB(Document):
     app_name: str
     organization: Link[OrganizationDB]
     user: Link[UserDB]
-    created_at: Optional[datetime] = Field(default=datetime.utcnow())
-    updated_at: Optional[datetime] = Field(default=datetime.utcnow())
+    created_at: Optional[datetime] = Field(default=datetime.now())
+    updated_at: Optional[datetime] = Field(default=datetime.now())
 
     class Settings:
         name = "app_db"
@@ -91,8 +91,8 @@ class DeploymentDB(Document):
     container_id: Optional[str]
     uri: Optional[str]
     status: str
-    created_at: Optional[datetime] = Field(default=datetime.utcnow())
-    updated_at: Optional[datetime] = Field(default=datetime.utcnow())
+    created_at: Optional[datetime] = Field(default=datetime.now())
+    updated_at: Optional[datetime] = Field(default=datetime.now())
 
     class Settings:
         name = "deployments"
@@ -105,8 +105,8 @@ class VariantBaseDB(Document):
     base_name: str
     image: Link[ImageDB]
     deployment: Optional[PydanticObjectId]  # Link to deployment
-    created_at: Optional[datetime] = Field(default=datetime.utcnow())
-    updated_at: Optional[datetime] = Field(default=datetime.utcnow())
+    created_at: Optional[datetime] = Field(default=datetime.now())
+    updated_at: Optional[datetime] = Field(default=datetime.now())
 
     class Settings:
         name = "bases"
@@ -115,8 +115,8 @@ class VariantBaseDB(Document):
 class ConfigVersionDB(BaseModel):
     version: int
     parameters: Dict[str, Any]
-    created_at: Optional[datetime] = Field(default=datetime.utcnow())
-    updated_at: Optional[datetime] = Field(default=datetime.utcnow())
+    created_at: Optional[datetime] = Field(default=datetime.now())
+    updated_at: Optional[datetime] = Field(default=datetime.now())
 
 
 class OldConfigDB(Document):
@@ -124,8 +124,8 @@ class OldConfigDB(Document):
     current_version: int = Field(default=1)
     parameters: Dict[str, Any] = Field(default=dict)
     version_history: List[ConfigVersionDB] = Field(default=[])
-    created_at: Optional[datetime] = Field(default=datetime.utcnow())
-    updated_at: Optional[datetime] = Field(default=datetime.utcnow())
+    created_at: Optional[datetime] = Field(default=datetime.now())
+    updated_at: Optional[datetime] = Field(default=datetime.now())
 
     class Settings:
         name = "configs"
@@ -143,8 +143,8 @@ class AppVariantDB(Document):
     base: Link[VariantBaseDB]
     config_name: Optional[str]
     config: Link[OldConfigDB]
-    created_at: Optional[datetime] = Field(default=datetime.utcnow())
-    updated_at: Optional[datetime] = Field(default=datetime.utcnow())
+    created_at: Optional[datetime] = Field(default=datetime.now())
+    updated_at: Optional[datetime] = Field(default=datetime.now())
 
     is_deleted: bool = Field(  # TODO: deprecated. remove
         default=False
@@ -161,7 +161,7 @@ class AppEnvironmentDB(Document):
     organization: Link[OrganizationDB]
     deployed_app_variant: Optional[PydanticObjectId]
     deployment: Optional[PydanticObjectId]  # reference to deployment
-    created_at: Optional[datetime] = Field(default=datetime.utcnow())
+    created_at: Optional[datetime] = Field(default=datetime.now())
 
     class Settings:
         name = "environments"
@@ -189,8 +189,8 @@ class TestSetDB(Document):
     csvdata: List[Dict[str, str]]
     user: Link[UserDB]
     organization: Link[OrganizationDB]
-    created_at: Optional[datetime] = Field(default=datetime.utcnow())
-    updated_at: Optional[datetime] = Field(default=datetime.utcnow())
+    created_at: Optional[datetime] = Field(default=datetime.now())
+    updated_at: Optional[datetime] = Field(default=datetime.now())
 
     class Settings:
         name = "testsets"
@@ -203,8 +203,8 @@ class EvaluatorConfigDB(Document):
     name: str
     evaluator_key: str
     settings_values: Dict[str, Any] = Field(default=dict)
-    created_at: datetime = Field(default=datetime.utcnow())
-    updated_at: datetime = Field(default=datetime.utcnow())
+    created_at: datetime = Field(default=datetime.now())
+    updated_at: datetime = Field(default=datetime.now())
 
     class Settings:
         name = "evaluators_configs"
@@ -254,8 +254,8 @@ class HumanEvaluationDB(Document):
     evaluation_type: str
     variants: List[PydanticObjectId]
     testset: Link[TestSetDB]
-    created_at: Optional[datetime] = Field(default=datetime.utcnow())
-    updated_at: Optional[datetime] = Field(default=datetime.utcnow())
+    created_at: Optional[datetime] = Field(default=datetime.now())
+    updated_at: Optional[datetime] = Field(default=datetime.now())
 
     class Settings:
         name = "human_evaluations"
@@ -270,8 +270,8 @@ class HumanEvaluationScenarioDB(Document):
     vote: Optional[str]
     score: Optional[Any]
     correct_answer: Optional[str]
-    created_at: Optional[datetime] = Field(default=datetime.utcnow())
-    updated_at: Optional[datetime] = Field(default=datetime.utcnow())
+    created_at: Optional[datetime] = Field(default=datetime.now())
+    updated_at: Optional[datetime] = Field(default=datetime.now())
     is_pinned: Optional[bool]
     note: Optional[str]
 
@@ -288,8 +288,8 @@ class EvaluationDB(Document):
     variant: PydanticObjectId
     evaluators_configs: List[PydanticObjectId]
     aggregated_results: List[AggregatedResult]
-    created_at: datetime = Field(default=datetime.utcnow())
-    updated_at: datetime = Field(default=datetime.utcnow())
+    created_at: datetime = Field(default=datetime.now())
+    updated_at: datetime = Field(default=datetime.now())
 
     class Settings:
         name = "new_evaluations"
@@ -307,8 +307,8 @@ class EvaluationScenarioDB(Document):
     note: Optional[str]
     evaluators_configs: List[PydanticObjectId]
     results: List[EvaluationScenarioResult]
-    created_at: datetime = Field(default=datetime.utcnow())
-    updated_at: datetime = Field(default=datetime.utcnow())
+    created_at: datetime = Field(default=datetime.now())
+    updated_at: datetime = Field(default=datetime.now())
 
     class Settings:
         name = "new_evaluation_scenarios"
@@ -322,7 +322,7 @@ class SpanDB(Document):
     start_time: datetime
     duration: Optional[int]
     status: str  # initiated, completed, stopped, cancelled
-    end_time: datetime = Field(default=datetime.utcnow())
+    end_time: datetime = Field(default=datetime.now())
     inputs: Optional[List[str]]
     outputs: Optional[List[str]]
     prompt_template: Optional[str]
@@ -343,7 +343,7 @@ class Feedback(BaseModel):
     score: Optional[float]
     meta: Optional[Dict[str, Any]]
     created_at: datetime
-    updated_at: datetime = Field(default=datetime.utcnow())
+    updated_at: datetime = Field(default=datetime.now())
 
 
 class TraceDB(Document):
@@ -351,7 +351,7 @@ class TraceDB(Document):
     variant_id: str
     spans: List[PydanticObjectId]
     start_time: datetime
-    end_time: datetime = Field(default=datetime.utcnow())
+    end_time: datetime = Field(default=datetime.now())
     cost: Optional[float]
     latency: float
     status: str  # initiated, completed, stopped, cancelled, failed
@@ -384,8 +384,8 @@ class NewAppVariantDB(Document):
     base: Link[VariantBaseDB]
     config_name: Optional[str]
     config: ConfigDB
-    created_at: Optional[datetime] = Field(default=datetime.utcnow())
-    updated_at: Optional[datetime] = Field(default=datetime.utcnow())
+    created_at: Optional[datetime] = Field(default=datetime.now())
+    updated_at: Optional[datetime] = Field(default=datetime.now())
 
     is_deleted: bool = Field(  # TODO: deprecated. remove
         default=False
@@ -401,8 +401,8 @@ class NewAppVariantRevisionsDB(Document):
     modified_by: Link[UserDB]
     base: Link[VariantBaseDB]
     config: ConfigDB
-    created_at: Optional[datetime] = Field(default=datetime.utcnow())
-    updated_at: Optional[datetime] = Field(default=datetime.utcnow())
+    created_at: Optional[datetime] = Field(default=datetime.now())
+    updated_at: Optional[datetime] = Field(default=datetime.now())
 
     class Settings:
         name = "app_variant_revisions"
@@ -416,7 +416,7 @@ class NewAppEnvironmentDB(Document):
     deployed_app_variant: Optional[PydanticObjectId]
     deployed_app_variant_revision: Optional[Link[NewAppVariantRevisionsDB]]
     deployment: Optional[PydanticObjectId]  # reference to deployment
-    created_at: Optional[datetime] = Field(default=datetime.utcnow())
+    created_at: Optional[datetime] = Field(default=datetime.now())
 
     class Settings:
         name = "environments"

--- a/agenta-backend/agenta_backend/migrations/30_01_24_prompt_versioning/20240130140202_connection_evaluation.py
+++ b/agenta-backend/agenta_backend/migrations/30_01_24_prompt_versioning/20240130140202_connection_evaluation.py
@@ -12,7 +12,7 @@ class APIKeyDB(Document):
     rate_limit: int = Field(default=0)
     hidden: Optional[bool] = Field(default=False)
     expiration_date: Optional[datetime]
-    created_at: Optional[datetime] = datetime.utcnow()
+    created_at: Optional[datetime] = datetime.now()
     updated_at: Optional[datetime]
 
     class Settings:
@@ -33,8 +33,8 @@ class OrganizationDB(Document):
     owner: str  # user id
     members: Optional[List[PydanticObjectId]]
     invitations: Optional[List[InvitationDB]] = []
-    created_at: Optional[datetime] = Field(default=datetime.utcnow())
-    updated_at: Optional[datetime] = Field(default=datetime.utcnow())
+    created_at: Optional[datetime] = Field(default=datetime.now())
+    updated_at: Optional[datetime] = Field(default=datetime.now())
 
     class Settings:
         name = "organizations"
@@ -45,8 +45,8 @@ class UserDB(Document):
     username: str = Field(default="agenta")
     email: str = Field(default="demo@agenta.ai", unique=True)
     organizations: Optional[List[PydanticObjectId]] = []
-    created_at: Optional[datetime] = Field(default=datetime.utcnow())
-    updated_at: Optional[datetime] = Field(default=datetime.utcnow())
+    created_at: Optional[datetime] = Field(default=datetime.now())
+    updated_at: Optional[datetime] = Field(default=datetime.now())
 
     class Settings:
         name = "users"
@@ -62,8 +62,8 @@ class ImageDB(Document):
     deletable: bool = Field(default=True)
     user: Link[UserDB]
     organization: Link[OrganizationDB]
-    created_at: Optional[datetime] = Field(default=datetime.utcnow())
-    updated_at: Optional[datetime] = Field(default=datetime.utcnow())
+    created_at: Optional[datetime] = Field(default=datetime.now())
+    updated_at: Optional[datetime] = Field(default=datetime.now())
 
     class Settings:
         name = "docker_images"
@@ -73,8 +73,8 @@ class AppDB(Document):
     app_name: str
     organization: Link[OrganizationDB]
     user: Link[UserDB]
-    created_at: Optional[datetime] = Field(default=datetime.utcnow())
-    updated_at: Optional[datetime] = Field(default=datetime.utcnow())
+    created_at: Optional[datetime] = Field(default=datetime.now())
+    updated_at: Optional[datetime] = Field(default=datetime.now())
 
     class Settings:
         name = "app_db"
@@ -88,8 +88,8 @@ class DeploymentDB(Document):
     container_id: Optional[str]
     uri: Optional[str]
     status: str
-    created_at: Optional[datetime] = Field(default=datetime.utcnow())
-    updated_at: Optional[datetime] = Field(default=datetime.utcnow())
+    created_at: Optional[datetime] = Field(default=datetime.now())
+    updated_at: Optional[datetime] = Field(default=datetime.now())
 
     class Settings:
         name = "deployments"
@@ -102,8 +102,8 @@ class VariantBaseDB(Document):
     base_name: str
     image: Link[ImageDB]
     deployment: Optional[PydanticObjectId]  # Link to deployment
-    created_at: Optional[datetime] = Field(default=datetime.utcnow())
-    updated_at: Optional[datetime] = Field(default=datetime.utcnow())
+    created_at: Optional[datetime] = Field(default=datetime.now())
+    updated_at: Optional[datetime] = Field(default=datetime.now())
 
     class Settings:
         name = "bases"
@@ -128,8 +128,8 @@ class AppVariantDB(Document):
     base: Link[VariantBaseDB]
     config_name: Optional[str]
     config: ConfigDB
-    created_at: Optional[datetime] = Field(default=datetime.utcnow())
-    updated_at: Optional[datetime] = Field(default=datetime.utcnow())
+    created_at: Optional[datetime] = Field(default=datetime.now())
+    updated_at: Optional[datetime] = Field(default=datetime.now())
     is_deleted: bool = Field(  # TODO: deprecated. remove
         default=False
     )  # soft deletion for using the template variants
@@ -144,8 +144,8 @@ class AppVariantRevisionsDB(Document):
     modified_by: Link[UserDB]
     base: Link[VariantBaseDB]
     config: ConfigDB
-    created_at: Optional[datetime] = Field(default=datetime.utcnow())
-    updated_at: Optional[datetime] = Field(default=datetime.utcnow())
+    created_at: Optional[datetime] = Field(default=datetime.now())
+    updated_at: Optional[datetime] = Field(default=datetime.now())
 
     class Settings:
         name = "app_variant_revisions"
@@ -159,7 +159,7 @@ class AppEnvironmentDB(Document):
     deployed_app_variant: Optional[PydanticObjectId]
     deployed_app_variant_revision: Optional[Link[AppVariantRevisionsDB]]
     deployment: Optional[PydanticObjectId]  # reference to deployment
-    created_at: Optional[datetime] = Field(default=datetime.utcnow())
+    created_at: Optional[datetime] = Field(default=datetime.now())
 
     class Settings:
         name = "environments"
@@ -187,8 +187,8 @@ class TestSetDB(Document):
     csvdata: List[Dict[str, str]]
     user: Link[UserDB]
     organization: Link[OrganizationDB]
-    created_at: Optional[datetime] = Field(default=datetime.utcnow())
-    updated_at: Optional[datetime] = Field(default=datetime.utcnow())
+    created_at: Optional[datetime] = Field(default=datetime.now())
+    updated_at: Optional[datetime] = Field(default=datetime.now())
 
     class Settings:
         name = "testsets"
@@ -201,8 +201,8 @@ class EvaluatorConfigDB(Document):
     name: str
     evaluator_key: str
     settings_values: Dict[str, Any] = Field(default=dict)
-    created_at: datetime = Field(default=datetime.utcnow())
-    updated_at: datetime = Field(default=datetime.utcnow())
+    created_at: datetime = Field(default=datetime.now())
+    updated_at: datetime = Field(default=datetime.now())
 
     class Settings:
         name = "evaluators_configs"
@@ -258,8 +258,8 @@ class OldHumanEvaluationDB(Document):
     evaluation_type: str
     variants: List[PydanticObjectId]
     testset: Link[TestSetDB]
-    created_at: Optional[datetime] = Field(default=datetime.utcnow())
-    updated_at: Optional[datetime] = Field(default=datetime.utcnow())
+    created_at: Optional[datetime] = Field(default=datetime.now())
+    updated_at: Optional[datetime] = Field(default=datetime.now())
 
     class Settings:
         name = "human_evaluations"
@@ -274,8 +274,8 @@ class HumanEvaluationDB(Document):
     variants: List[PydanticObjectId]
     variants_revisions: List[PydanticObjectId]
     testset: Link[TestSetDB]
-    created_at: Optional[datetime] = Field(default=datetime.utcnow())
-    updated_at: Optional[datetime] = Field(default=datetime.utcnow())
+    created_at: Optional[datetime] = Field(default=datetime.now())
+    updated_at: Optional[datetime] = Field(default=datetime.now())
 
     class Settings:
         name = "human_evaluations"
@@ -290,8 +290,8 @@ class OldEvaluationDB(Document):
     variant: PydanticObjectId
     evaluators_configs: List[PydanticObjectId]
     aggregated_results: List[AggregatedResult]
-    created_at: datetime = Field(default=datetime.utcnow())
-    updated_at: datetime = Field(default=datetime.utcnow())
+    created_at: datetime = Field(default=datetime.now())
+    updated_at: datetime = Field(default=datetime.now())
 
     class Settings:
         name = "new_evaluations"
@@ -307,8 +307,8 @@ class EvaluationDB(Document):
     variant_revision: Optional[PydanticObjectId]
     evaluators_configs: List[PydanticObjectId]
     aggregated_results: List[AggregatedResult]
-    created_at: datetime = Field(default=datetime.utcnow())
-    updated_at: datetime = Field(default=datetime.utcnow())
+    created_at: datetime = Field(default=datetime.now())
+    updated_at: datetime = Field(default=datetime.now())
 
     class Settings:
         name = "new_evaluations"

--- a/agenta-backend/agenta_backend/models/api/organization_models.py
+++ b/agenta-backend/agenta_backend/models/api/organization_models.py
@@ -5,8 +5,8 @@ from pydantic import BaseModel, Field
 
 
 class TimestampModel(BaseModel):
-    created_at: datetime = Field(datetime.utcnow())
-    updated_at: datetime = Field(datetime.utcnow())
+    created_at: datetime = Field(datetime.now())
+    updated_at: datetime = Field(datetime.now())
 
 
 class Organization(BaseModel):

--- a/agenta-backend/agenta_backend/models/api/user_models.py
+++ b/agenta-backend/agenta_backend/models/api/user_models.py
@@ -4,8 +4,8 @@ from pydantic import BaseModel, Field
 
 
 class TimestampModel(BaseModel):
-    created_at: datetime = Field(datetime.utcnow())
-    updated_at: datetime = Field(datetime.utcnow())
+    created_at: datetime = Field(datetime.now())
+    updated_at: datetime = Field(datetime.now())
 
 
 class User(TimestampModel):
@@ -19,4 +19,4 @@ class User(TimestampModel):
 class UserUpdate(BaseModel):
     username: Optional[str]
     email: Optional[str]
-    updated_at: datetime = Field(datetime.utcnow())
+    updated_at: datetime = Field(datetime.now())

--- a/agenta-backend/agenta_backend/models/db_models.py
+++ b/agenta-backend/agenta_backend/models/db_models.py
@@ -13,7 +13,7 @@ class APIKeyDB(Document):
     rate_limit: int = Field(default=0)
     hidden: Optional[bool] = Field(default=False)
     expiration_date: Optional[datetime]
-    created_at: Optional[datetime] = datetime.utcnow()
+    created_at: Optional[datetime] = datetime.now()
     updated_at: Optional[datetime]
 
     class Settings:
@@ -34,8 +34,8 @@ class OrganizationDB(Document):
     owner: str  # user id
     members: Optional[List[PydanticObjectId]]
     invitations: Optional[List[InvitationDB]] = []
-    created_at: Optional[datetime] = Field(default=datetime.utcnow())
-    updated_at: Optional[datetime] = Field(default=datetime.utcnow())
+    created_at: Optional[datetime] = Field(default=datetime.now())
+    updated_at: Optional[datetime] = Field(default=datetime.now())
 
     class Settings:
         name = "organizations"
@@ -46,8 +46,8 @@ class UserDB(Document):
     username: str = Field(default="agenta")
     email: str = Field(default="demo@agenta.ai", unique=True)
     organizations: Optional[List[PydanticObjectId]] = []
-    created_at: Optional[datetime] = Field(default=datetime.utcnow())
-    updated_at: Optional[datetime] = Field(default=datetime.utcnow())
+    created_at: Optional[datetime] = Field(default=datetime.now())
+    updated_at: Optional[datetime] = Field(default=datetime.now())
 
     class Settings:
         name = "users"
@@ -63,8 +63,8 @@ class ImageDB(Document):
     deletable: bool = Field(default=True)
     user: Link[UserDB]
     organization: Link[OrganizationDB]
-    created_at: Optional[datetime] = Field(default=datetime.utcnow())
-    updated_at: Optional[datetime] = Field(default=datetime.utcnow())
+    created_at: Optional[datetime] = Field(default=datetime.now())
+    updated_at: Optional[datetime] = Field(default=datetime.now())
 
     class Settings:
         name = "docker_images"
@@ -74,8 +74,8 @@ class AppDB(Document):
     app_name: str
     organization: Link[OrganizationDB]
     user: Link[UserDB]
-    created_at: Optional[datetime] = Field(default=datetime.utcnow())
-    updated_at: Optional[datetime] = Field(default=datetime.utcnow())
+    created_at: Optional[datetime] = Field(default=datetime.now())
+    updated_at: Optional[datetime] = Field(default=datetime.now())
 
     class Settings:
         name = "app_db"
@@ -89,8 +89,8 @@ class DeploymentDB(Document):
     container_id: Optional[str]
     uri: Optional[str]
     status: str
-    created_at: Optional[datetime] = Field(default=datetime.utcnow())
-    updated_at: Optional[datetime] = Field(default=datetime.utcnow())
+    created_at: Optional[datetime] = Field(default=datetime.now())
+    updated_at: Optional[datetime] = Field(default=datetime.now())
 
     class Settings:
         name = "deployments"
@@ -103,8 +103,8 @@ class VariantBaseDB(Document):
     base_name: str
     image: Link[ImageDB]
     deployment: Optional[PydanticObjectId]  # Link to deployment
-    created_at: Optional[datetime] = Field(default=datetime.utcnow())
-    updated_at: Optional[datetime] = Field(default=datetime.utcnow())
+    created_at: Optional[datetime] = Field(default=datetime.now())
+    updated_at: Optional[datetime] = Field(default=datetime.now())
 
     class Settings:
         name = "bases"
@@ -129,8 +129,8 @@ class AppVariantDB(Document):
     base: Link[VariantBaseDB]
     config_name: Optional[str]
     config: ConfigDB
-    created_at: Optional[datetime] = Field(default=datetime.utcnow())
-    updated_at: Optional[datetime] = Field(default=datetime.utcnow())
+    created_at: Optional[datetime] = Field(default=datetime.now())
+    updated_at: Optional[datetime] = Field(default=datetime.now())
 
     is_deleted: bool = Field(  # TODO: deprecated. remove
         default=False
@@ -146,8 +146,8 @@ class AppVariantRevisionsDB(Document):
     modified_by: Link[UserDB]
     base: Link[VariantBaseDB]
     config: ConfigDB
-    created_at: Optional[datetime] = Field(default=datetime.utcnow())
-    updated_at: Optional[datetime] = Field(default=datetime.utcnow())
+    created_at: Optional[datetime] = Field(default=datetime.now())
+    updated_at: Optional[datetime] = Field(default=datetime.now())
 
     class Settings:
         name = "app_variant_revisions"
@@ -161,7 +161,7 @@ class AppEnvironmentDB(Document):
     deployed_app_variant: Optional[PydanticObjectId]
     deployed_app_variant_revision: Optional[Link[AppVariantRevisionsDB]]
     deployment: Optional[PydanticObjectId]  # reference to deployment
-    created_at: Optional[datetime] = Field(default=datetime.utcnow())
+    created_at: Optional[datetime] = Field(default=datetime.now())
 
     class Settings:
         name = "environments"
@@ -189,8 +189,8 @@ class TestSetDB(Document):
     csvdata: List[Dict[str, str]]
     user: Link[UserDB]
     organization: Link[OrganizationDB]
-    created_at: Optional[datetime] = Field(default=datetime.utcnow())
-    updated_at: Optional[datetime] = Field(default=datetime.utcnow())
+    created_at: Optional[datetime] = Field(default=datetime.now())
+    updated_at: Optional[datetime] = Field(default=datetime.now())
 
     class Settings:
         name = "testsets"
@@ -203,8 +203,8 @@ class EvaluatorConfigDB(Document):
     name: str
     evaluator_key: str
     settings_values: Dict[str, Any] = Field(default=dict)
-    created_at: datetime = Field(default=datetime.utcnow())
-    updated_at: datetime = Field(default=datetime.utcnow())
+    created_at: datetime = Field(default=datetime.now())
+    updated_at: datetime = Field(default=datetime.now())
 
     class Settings:
         name = "evaluators_configs"
@@ -264,8 +264,8 @@ class HumanEvaluationDB(Document):
     variants: List[PydanticObjectId]
     variants_revisions: List[PydanticObjectId]
     testset: Link[TestSetDB]
-    created_at: Optional[datetime] = Field(default=datetime.utcnow())
-    updated_at: Optional[datetime] = Field(default=datetime.utcnow())
+    created_at: Optional[datetime] = Field(default=datetime.now())
+    updated_at: Optional[datetime] = Field(default=datetime.now())
 
     class Settings:
         name = "human_evaluations"
@@ -280,8 +280,8 @@ class HumanEvaluationScenarioDB(Document):
     vote: Optional[str]
     score: Optional[Any]
     correct_answer: Optional[str]
-    created_at: Optional[datetime] = Field(default=datetime.utcnow())
-    updated_at: Optional[datetime] = Field(default=datetime.utcnow())
+    created_at: Optional[datetime] = Field(default=datetime.now())
+    updated_at: Optional[datetime] = Field(default=datetime.now())
     is_pinned: Optional[bool]
     note: Optional[str]
 
@@ -299,8 +299,8 @@ class EvaluationDB(Document):
     variant_revision: PydanticObjectId
     evaluators_configs: List[PydanticObjectId]
     aggregated_results: List[AggregatedResult]
-    created_at: datetime = Field(default=datetime.utcnow())
-    updated_at: datetime = Field(default=datetime.utcnow())
+    created_at: datetime = Field(default=datetime.now())
+    updated_at: datetime = Field(default=datetime.now())
 
     class Settings:
         name = "new_evaluations"
@@ -318,8 +318,8 @@ class EvaluationScenarioDB(Document):
     note: Optional[str]
     evaluators_configs: List[PydanticObjectId]
     results: List[EvaluationScenarioResult]
-    created_at: datetime = Field(default=datetime.utcnow())
-    updated_at: datetime = Field(default=datetime.utcnow())
+    created_at: datetime = Field(default=datetime.now())
+    updated_at: datetime = Field(default=datetime.now())
 
     class Settings:
         name = "new_evaluation_scenarios"
@@ -333,7 +333,7 @@ class SpanDB(Document):
     start_time: datetime
     duration: Optional[int]
     status: str  # initiated, completed, stopped, cancelled
-    end_time: datetime = Field(default=datetime.utcnow())
+    end_time: datetime = Field(default=datetime.now())
     inputs: Optional[List[str]]
     outputs: Optional[List[str]]
     prompt_template: Optional[str]
@@ -354,7 +354,7 @@ class Feedback(BaseModel):
     score: Optional[float]
     meta: Optional[Dict[str, Any]]
     created_at: datetime
-    updated_at: datetime = Field(default=datetime.utcnow())
+    updated_at: datetime = Field(default=datetime.now())
 
 
 class TraceDB(Document):
@@ -362,7 +362,7 @@ class TraceDB(Document):
     variant_id: str
     spans: List[PydanticObjectId]
     start_time: datetime
-    end_time: datetime = Field(default=datetime.utcnow())
+    end_time: datetime = Field(default=datetime.now())
     cost: Optional[float]
     latency: float
     status: str  # initiated, completed, stopped, cancelled, failed

--- a/agenta-backend/agenta_backend/services/db_manager.py
+++ b/agenta-backend/agenta_backend/services/db_manager.py
@@ -1710,8 +1710,8 @@ async def create_new_evaluation_scenario(
         note=note,
         evaluators_configs=evaluators_configs,
         results=results,
-        created_at=datetime.utcnow(),
-        updated_at=datetime.utcnow(),
+        created_at=datetime.now(),
+        updated_at=datetime.now(),
     )
     await evaluation_scenario.create()
     return evaluation_scenario
@@ -1726,7 +1726,7 @@ async def update_evaluation_with_aggregated_results(
         raise ValueError("Evaluation not found")
 
     evaluation.aggregated_results = aggregated_results
-    evaluation.updated_at = datetime.utcnow().isoformat()
+    evaluation.updated_at = datetime.now().isoformat()
 
     await evaluation.save()
     return evaluation

--- a/agenta-backend/agenta_backend/services/evaluation_service.py
+++ b/agenta-backend/agenta_backend/services/evaluation_service.py
@@ -182,8 +182,8 @@ async def prepare_csvdata_and_create_evaluation_scenario(
 
         evaluation_scenario_payload = {
             **{
-                "created_at": datetime.utcnow(),
-                "updated_at": datetime.utcnow(),
+                "created_at": datetime.now(),
+                "updated_at": datetime.now(),
             },
             **_extend_with_evaluation(evaluation_type),
             **_extend_with_correct_answer(evaluation_type, datum),
@@ -235,8 +235,8 @@ async def create_evaluation_scenario(
         is_pinned=False,
         note="",
         **_extend_with_evaluation(evaluation.evaluation_type),
-        created_at=datetime.utcnow(),
-        updated_at=datetime.utcnow(),
+        created_at=datetime.now(),
+        updated_at=datetime.now(),
     )
 
     await new_eval_scenario.create()
@@ -356,7 +356,7 @@ async def update_human_evaluation_scenario(
     )
 
     updated_data = evaluation_scenario_data.dict()
-    updated_data["updated_at"] = datetime.utcnow()
+    updated_data["updated_at"] = datetime.now()
     new_eval_set = {}
 
     if updated_data["score"] is not None and evaluation_type in [
@@ -612,7 +612,7 @@ async def create_new_human_evaluation(
     """
     user = await get_user(user_uid=user_org_data["uid"])
 
-    current_time = datetime.utcnow()
+    current_time = datetime.now()
 
     # Fetch app
     app = await db_manager.fetch_app_by_id(app_id=payload.app_id)

--- a/agenta-backend/agenta_backend/services/event_db_manager.py
+++ b/agenta-backend/agenta_backend/services/event_db_manager.py
@@ -179,7 +179,7 @@ async def add_feedback_to_trace(
         user_id=str(user.id),
         feedback=payload.feedback,
         score=payload.score,
-        created_at=datetime.utcnow(),
+        created_at=datetime.now(),
     )
 
     trace = await TraceDB.find_one(TraceDB.id == ObjectId(trace_id), fetch_links=True)

--- a/agenta-backend/agenta_backend/tests/variants_main_router/conftest.py
+++ b/agenta-backend/agenta_backend/tests/variants_main_router/conftest.py
@@ -122,10 +122,10 @@ def spans_db_data():
             "meta": {},
             "event_name": "call",
             "event_type": "fixture_call",
-            "start_time": str(datetime.utcnow()),
+            "start_time": str(datetime.now()),
             "duration": 8.30,
             "status": "initiated",
-            "end_time": str(datetime.utcnow()),
+            "end_time": str(datetime.now()),
             "inputs": ["string"],
             "outputs": ["string"],
             "prompt_template": "string",
@@ -140,10 +140,10 @@ def spans_db_data():
             "meta": {},
             "event_name": "call",
             "event_type": "fixture_call",
-            "start_time": str(datetime.utcnow()),
+            "start_time": str(datetime.now()),
             "duration": 13.30,
             "status": "initiated",
-            "end_time": str(datetime.utcnow()),
+            "end_time": str(datetime.now()),
             "inputs": ["string"],
             "outputs": ["string"],
             "prompt_template": "string",
@@ -158,10 +158,10 @@ def spans_db_data():
             "meta": {},
             "event_name": "call",
             "event_type": "fixture_call",
-            "start_time": str(datetime.utcnow()),
+            "start_time": str(datetime.now()),
             "duration": 18.30,
             "status": "initiated",
-            "end_time": str(datetime.utcnow()),
+            "end_time": str(datetime.now()),
             "inputs": ["string"],
             "outputs": ["string"],
             "prompt_template": "string",
@@ -179,8 +179,8 @@ def image_create_data():
     return {
         "docker_id": "sha256:xxxxxxxxxxxxxxxxxxxxxxxxxxxxx",
         "tags": "agentaai/templates_v2:local_test_prompt",
-        "created_at": datetime.utcnow(),
-        "updated_at": datetime.utcnow(),
+        "created_at": datetime.now(),
+        "updated_at": datetime.now(),
     }
 
 
@@ -189,8 +189,8 @@ def app_variant_create_data():
     return {
         "variant_name": "v1",
         "parameters": {},
-        "created_at": datetime.utcnow(),
-        "updated_at": datetime.utcnow(),
+        "created_at": datetime.now(),
+        "updated_at": datetime.now(),
     }
 
 
@@ -202,8 +202,8 @@ def trace_create_data():
         "status": "completed",
         "token_consumption": 638,
         "tags": ["string"],
-        "start_time": str(datetime.utcnow()),
-        "end_time": str(datetime.utcnow()),
+        "start_time": str(datetime.now()),
+        "end_time": str(datetime.now()),
     }
 
 


### PR DESCRIPTION
### Description
Making use of UTC timezone when inserting a record or records with Python to the mongo database results in a weird behaviour; making use of the same timestamp, even after some minutes intervals. This PR fixes that by changing from UTC timezone to the server timezone. 

UTC Timezone:
![image](https://github.com/Agenta-AI/agenta/assets/55067204/8d972948-a6c4-4b74-8abf-9d34b36dd198)

Server Timezone:
![image](https://github.com/Agenta-AI/agenta/assets/55067204/decc2e7f-461a-4b11-b919-9ab91ee289b9)

