### PR TITLE
Bug Fix: Variant Envrionment Deployment

### DIFF
--- a/agenta-backend/agenta_backend/services/db_manager.py
+++ b/agenta-backend/agenta_backend/services/db_manager.py
@@ -575,22 +575,21 @@ async def list_app_variants_for_app_id(
 async def list_bases_for_app_id(
     app_id: str, base_name: Optional[str] = None, **kwargs: dict
 ) -> List[VariantBaseDB]:
+    """List all the bases for the specified app_id
+
+    Args:
+        app_id (str): The ID of the app
+        base_name (str): The name of the base
+
+    Returns:
+        List[VariantBaseDB]: list of VariantBase objects
+    """
+
     assert app_id is not None, "app_id cannot be None"
+    base_query = VariantBaseDB.find(VariantBaseDB.app.id == ObjectId(app_id))
     if base_name:
-        bases_db = (
-            await VariantBaseDB.find(
-                VariantBaseDB.app.id == ObjectId(app_id),
-                VariantBaseDB.base_name == base_name,
-            )
-            .sort("base_name")
-            .to_list()
-        )
-    else:
-        bases_db = (
-            await VariantBaseDB.find(VariantBaseDB.app.id == ObjectId(app_id))
-            .sort("base_name")
-            .to_list()
-        )
+        base_query = base_query.find(VariantBaseDB.base_name == base_name)
+    bases_db = await base_query.sort("base_name").to_list()
     return bases_db
 
 
@@ -605,9 +604,10 @@ async def list_variants_for_base(
         List[AppVariant]: List of AppVariant objects
     """
     assert base is not None, "base cannot be None"
-    query_expressions = AppVariantDB.base.id == ObjectId(base.id)
     app_variants_db = (
-        await AppVariantDB.find(query_expressions, fetch_links=True)
+        await AppVariantDB.find(
+            AppVariantDB.base.id == ObjectId(base.id), fetch_links=True
+        )
         .sort("variant_name")
         .to_list()
     )

--- a/agenta-backend/agenta_backend/services/db_manager.py
+++ b/agenta-backend/agenta_backend/services/db_manager.py
@@ -1721,8 +1721,6 @@ async def create_new_evaluation_scenario(
         note=note,
         evaluators_configs=evaluators_configs,
         results=results,
-        created_at=datetime.now(),
-        updated_at=datetime.now(),
     )
     await evaluation_scenario.create()
     return evaluation_scenario

--- a/agenta-backend/agenta_backend/services/db_manager.py
+++ b/agenta-backend/agenta_backend/services/db_manager.py
@@ -576,10 +576,21 @@ async def list_bases_for_app_id(
     app_id: str, base_name: Optional[str] = None, **kwargs: dict
 ) -> List[VariantBaseDB]:
     assert app_id is not None, "app_id cannot be None"
-    query_expressions = VariantBaseDB.app.id == ObjectId(app_id)
     if base_name:
-        query_expressions += query_expressions(VariantBaseDB.base_name == base_name)
-    bases_db = await VariantBaseDB.find(query_expressions).sort("base_name").to_list()
+        bases_db = (
+            await VariantBaseDB.find(
+                VariantBaseDB.app.id == ObjectId(app_id),
+                VariantBaseDB.base_name == base_name,
+            )
+            .sort("base_name")
+            .to_list()
+        )
+    else:
+        bases_db = (
+            await VariantBaseDB.find(VariantBaseDB.app.id == ObjectId(app_id))
+            .sort("base_name")
+            .to_list()
+        )
     return bases_db
 
 
@@ -1710,8 +1721,8 @@ async def create_new_evaluation_scenario(
         note=note,
         evaluators_configs=evaluators_configs,
         results=results,
-        created_at=datetime.utcnow(),
-        updated_at=datetime.utcnow(),
+        created_at=datetime.now(),
+        updated_at=datetime.now(),
     )
     await evaluation_scenario.create()
     return evaluation_scenario
@@ -1726,7 +1737,7 @@ async def update_evaluation_with_aggregated_results(
         raise ValueError("Evaluation not found")
 
     evaluation.aggregated_results = aggregated_results
-    evaluation.updated_at = datetime.utcnow().isoformat()
+    evaluation.updated_at = datetime.now().isoformat()
 
     await evaluation.save()
     return evaluation

--- a/agenta-cli/agenta/sdk/agenta_init.py
+++ b/agenta-cli/agenta/sdk/agenta_init.py
@@ -75,16 +75,16 @@ class AgentaSingleton:
                 )
             else:
                 try:
-                    get_app_id = client.list_apps(app_name=app_name)
-                    app_id = get_app_id.app_id
+                    apps = client.list_apps(app_name=app_name)
+                    app_id = apps[0].app_id
 
                     if not app_id:
                         raise APIRequestError(
                             f"App with name {app_name} does not exist on the server."
                         )
 
-                    get_base_id = client.list_bases(app_id=app_id, base_name=base_name)
-                    base_id = get_base_id.base_id
+                    bases = client.list_bases(app_id=app_id, base_name=base_name)
+                    base_id = bases[0].base_id
                 except Exception as ex:
                     raise APIRequestError(
                         f"Failed to get base id and/or app_id from the server with error: {ex}"
@@ -171,7 +171,7 @@ class Config:
                     + str(ex)
                 )
         try:
-            self.set(**config["parameters"])
+            self.set(**config.parameters)
         except Exception as ex:
             logger.warning("Failed to set the configuration with error: " + str(ex))
 

--- a/agenta-cli/agenta/sdk/agenta_init.py
+++ b/agenta-cli/agenta/sdk/agenta_init.py
@@ -76,14 +76,19 @@ class AgentaSingleton:
             else:
                 try:
                     apps = client.list_apps(app_name=app_name)
-                    app_id = apps[0].app_id
+                    if len(apps) == 0:
+                        raise APIRequestError(f"App with name {app_name} not found")
 
+                    app_id = apps[0].app_id
                     if not app_id:
                         raise APIRequestError(
                             f"App with name {app_name} does not exist on the server."
                         )
 
                     bases = client.list_bases(app_id=app_id, base_name=base_name)
+                    if len(bases) == 0:
+                        raise APIRequestError(f"No base was found for the app {app_id}")
+
                     base_id = bases[0].base_id
                 except Exception as ex:
                     raise APIRequestError(


### PR DESCRIPTION
## Description
After creating an app from the CLI or UI with the system prompt as follows: "You are an expert in geography." and publish the variant to an environment. If you update the system prompt to include "Answer in Japanese." and publish it to the same environment, calling the endpoint will return responses in English. This PR fixes that bug.

With Bug:
```bash
curl -X POST http://localhost/65bcc828fb1a67f973179d13/erd/app/generate_deployed -H "Content-Type: application/json" -d '{
  "inputs": {
    "country": "Nigeria"
  },
  "environment": "development"
}'

{"message":"The capital of Nigeria is Abuja.","usage":{"completion_tokens":8,"prompt_tokens":25,"total_tokens":33},"cost":5.35e-05,"latency":2.6593}
```

Bug Fix:
```bash
curl -X POST http://localhost/65bcc828fb1a67f973179d13/country_generator/app/generate_deployed -H "Content-Type: application/json" -d '{
  "inputs": {
    "country": "Nigeria"
  },
  "environment": "development"
}'

{"message":"ナイジェリアの首都はアブジャです。","usage":{"completion_tokens":16,"prompt_tokens":30,"total_tokens":46},"cost":7.7e-05,"latency":3.0089}
```