### PR TITLE
Bug Fix: Allow Null Correct Answer in Human Annotations Testset

### DIFF
--- a/agenta-backend/agenta_backend/services/evaluation_service.py
+++ b/agenta-backend/agenta_backend/services/evaluation_service.py
@@ -458,7 +458,7 @@ def _extend_with_evaluation(evaluation_type: EvaluationType):
 
 def _extend_with_correct_answer(evaluation_type: EvaluationType, row: dict):
     correct_answer = {}
-    if row["correct_answer"]:
+    if row.get("correct_answer") is not None:
         correct_answer["correct_answer"] = row["correct_answer"]
     return correct_answer
 

--- a/agenta-backend/agenta_backend/services/evaluation_service.py
+++ b/agenta-backend/agenta_backend/services/evaluation_service.py
@@ -457,7 +457,7 @@ def _extend_with_evaluation(evaluation_type: EvaluationType):
 
 
 def _extend_with_correct_answer(evaluation_type: EvaluationType, row: dict):
-    correct_answer = {"correct_answer":""}
+    correct_answer = {"correct_answer": ""}
     if row.get("correct_answer") is not None:
         correct_answer["correct_answer"] = row["correct_answer"]
     return correct_answer

--- a/agenta-backend/agenta_backend/services/evaluation_service.py
+++ b/agenta-backend/agenta_backend/services/evaluation_service.py
@@ -457,7 +457,7 @@ def _extend_with_evaluation(evaluation_type: EvaluationType):
 
 
 def _extend_with_correct_answer(evaluation_type: EvaluationType, row: dict):
-    correct_answer = {}
+    correct_answer = {"correct_answer":""}
     if row.get("correct_answer") is not None:
         correct_answer["correct_answer"] = row["correct_answer"]
     return correct_answer


### PR DESCRIPTION
## Description
This PR resolves the KeyError when creating a human evaluation with a testset data that does not have the correct_answer column.

### Related Issue
Closes #1331