### PR TITLE
Bug Fix - remove .filter() logic that removes parameters that don't have a value

### DIFF
--- a/agenta-web/src/lib/services/api.ts
+++ b/agenta-web/src/lib/services/api.ts
@@ -103,11 +103,9 @@ export async function callVariant(
             mainInputParams[key] = inputParametersDict[key]
         }
     }
-
     optionalParameters = optionalParameters || []
 
     const optParams = optionalParameters
-        .filter((param) => param.default)
         .filter((param) => param.type !== "object") // remove dicts from optional parameters
         .reduce((acc: any, param) => {
             acc[param.name] = param.default


### PR DESCRIPTION
## Description
This PR resolves the issue of saving an empty prompt, which results in re-initializing the prompt. The problem was this line of code: `.filter((param) => param.default)`, which strips off parameters without a default value (even if there was one). 

### Related Issue
Closes #1462 