### PR TITLE
CLI: Resolve bug causing variant not to serve (again)

### DIFF
--- a/agenta-cli/agenta/client/backend/types/app_variant_output.py
+++ b/agenta-cli/agenta/client/backend/types/app_variant_output.py
@@ -18,7 +18,7 @@ class AppVariantOutput(pydantic.BaseModel):
     variant_name: str
     parameters: typing.Optional[typing.Dict[str, typing.Any]]
     previous_variant_name: typing.Optional[str]
-    organization_id: str
+    organization_id: typing.Optional[str]
     user_id: str
     base_name: str
     base_id: str

--- a/agenta-cli/pyproject.toml
+++ b/agenta-cli/pyproject.toml
@@ -1,6 +1,6 @@
 [tool.poetry]
 name = "agenta"
-version = "0.12.4"
+version = "0.12.5"
 description = "The SDK for agenta is an open-source LLMOps platform."
 readme = "README.md"
 authors = ["Mahmoud Mabrouk <mahmoud@agenta.ai>"]


### PR DESCRIPTION
## Description
This PR fixes a bug that occurs when reserving a variant from the CLI in OSS.

### Bug:
```bash
Checking and updating config file...
Failed during configuration check.
Error message: 1 validation error for ParsingModel[List[agenta.client.backend.types.app_variant_output.AppVariantOutput]]
__root__ -> 0 -> organization_id
  field required (type=value_error.missing)
```

### Additional Information
Merging this PR will update the agenta (SDK) version in pypi to 0.12.5