### PR TITLE
Hotfix when API key is wrong in CLI

### DIFF
--- a/agenta-cli/agenta/cli/main.py
+++ b/agenta-cli/agenta/cli/main.py
@@ -153,18 +153,21 @@ def init(app_name: str, backend_host: str):
             try:
                 key_prefix = api_key.split(".")[0]
                 client.validate_api_key(key_prefix=key_prefix)
-
-                # Make request to fetch user organizations after api key validation
+            except Exception as ex:
+                click.echo(
+                    click.style(
+                        f"Error: Unable to validate API key.\nError: {ex}", fg="red"
+                    )
+                )
+                sys.exit(1)
+            # Make request to fetch user organizations after api key validation
+            try:
                 organizations = client.list_organizations()
                 if len(organizations) >= 1:
                     user_organizations = organizations
             except Exception as ex:
-                if ex.status_code == 401:
-                    click.echo(click.style("Error: Invalid API key", fg="red"))
-                    sys.exit(1)
-                else:
-                    click.echo(click.style(f"Error: {ex}", fg="red"))
-                    sys.exit(1)
+                click.echo(click.style(f"Error: {ex}", fg="red"))
+                sys.exit(1)
 
         filtered_org = None
         if where_question == "On agenta cloud":


### PR DESCRIPTION
Closes  #1469


The issue is that when calling the api authentication endpoint without the right key, we don't get a 401 but a 500. This should be fixed in the backend side, this just a hotfixe to the error message.

@aybruhm can you please look into the core issue (us not returning 401 but 500 when authentication failes). @aakrem This is the right behavior, no?