### PR TITLE
Fix issue with gh docker compose

### DIFF
--- a/docker-compose.gh.yml
+++ b/docker-compose.gh.yml
@@ -133,9 +133,10 @@ services:
             - agenta-network
 
     celery_worker:
-        build: ./agenta-backend
+        container_name: celery-worker-1
+        image: ghcr.io/agenta-ai/agenta-backend
         command: >
-            watchmedo auto-restart --directory=./agenta_backend --pattern=*.py --recursive -- celery -A agenta_backend.main.celery_app worker --concurrency=1 --loglevel=INFO
+            celery -A agenta_backend.main.celery_app worker --concurrency=1 --loglevel=INFO
         environment:
             - MONGODB_URI=mongodb://username:password@mongo:27017
             - REDIS_URL=redis://redis:6379/0


### PR DESCRIPTION
This pull request fixes the issue with the gh docker compose. The celery_worker service in the docker-compose.yml file has been updated to use the image from ghcr.io/agenta-ai/agenta-backend and the watchmedo command has been removed from the command section.