### PR TITLE
[Bug Fix]: gitignore are overwritten when runnning agenta init

### DIFF
--- a/agenta-backend/agenta_backend/services/deployment_manager.py
+++ b/agenta-backend/agenta_backend/services/deployment_manager.py
@@ -4,14 +4,15 @@ from typing import Dict
 
 from agenta_backend.utils.common import isCloudEE
 from agenta_backend.models.api.api_models import Image
-from agenta_backend.models.db_models import AppVariantDB, DeploymentDB, ImageDB
+from agenta_backend.models.db_models import AppVariantDB, DeploymentDB
 from agenta_backend.services import db_manager, docker_utils
 from docker.errors import DockerException
 
 logger = logging.getLogger(__name__)
 logger.setLevel(logging.DEBUG)
 
-agenta_template_repo = os.getenv("AGENTA_TEMPLATE_REPO")
+
+agenta_registry_repo = os.getenv("REGISTRY_REPO_NAME")
 
 
 async def start_service(
@@ -134,9 +135,9 @@ async def validate_image(image: Image) -> bool:
         msg = "Image tags cannot be empty"
         logger.error(msg)
         raise ValueError(msg)
-    if not image.tags.startswith(agenta_template_repo):
+    if not image.tags.startswith(agenta_registry_repo):
         raise ValueError(
-            "Image should have a tag starting with the registry name (agenta-server)"
+            f"Image should have a tag starting with the registry name ({agenta_registry_repo})\n Image Tags: {image.tags}"
         )
     if image not in docker_utils.list_images():
         raise DockerException(

--- a/agenta-backend/agenta_backend/services/docker_utils.py
+++ b/agenta-backend/agenta_backend/services/docker_utils.py
@@ -10,7 +10,7 @@ from agenta_backend.models.api.api_models import (
     Dict,
 )
 
-agenta_template_repo = os.getenv("AGENTA_TEMPLATE_REPO")
+agenta_registry_repo = os.getenv("REGISTRY_REPO_NAME")
 
 client = docker.from_env()
 
@@ -56,7 +56,7 @@ def list_images() -> List[Image]:
     registry_images = [
         Image(type="image", docker_id=image.id, tags=image.tags[0])
         for image in all_images
-        if len(image.tags) > 0 and image.tags[0].startswith(agenta_template_repo)
+        if len(image.tags) > 0 and image.tags[0].startswith(agenta_registry_repo)
     ]
     return registry_images
 

--- a/agenta-cli/agenta/cli/main.py
+++ b/agenta-cli/agenta/cli/main.py
@@ -248,8 +248,9 @@ def init(app_name: str, backend_host: str):
         gitignore_content = (
             "# Environments \nenv/\nvenv/\nENV/\nenv.bak/\nvenv.bak/\nmyenv/\n"
         )
-        with open(".gitignore", "w") as gitignore_file:
-            gitignore_file.write(gitignore_content)
+        if not os.path.exists(".agentaignore"):
+            with open(".agentaignore", "w") as gitignore_file:
+                gitignore_file.write(gitignore_content)
 
         click.echo("App initialized successfully")
         if init_option == "Start from template":

--- a/agenta-cli/agenta/docker/docker_utils.py
+++ b/agenta-cli/agenta/docker/docker_utils.py
@@ -52,11 +52,10 @@ def build_tar_docker_container(folder: Path, file_name: Path) -> Path:
     shutil.copy(Path(__file__).parent / "docker-assets" / "entrypoint.sh", folder)
 
     # Read the contents of .gitignore file
-    gitignore_content = ""
-    gitignore_file_path = folder / ".gitignore"
-    if gitignore_file_path.exists():
-        with open(gitignore_file_path, "r") as gitignore_file:
-            gitignore_content = gitignore_file.read()
+    agentaignore_file_path = folder / ".agentaignore"
+    if agentaignore_file_path.exists():
+        with open(agentaignore_file_path, "r") as agentaignore_file:
+            agentaignore_content = agentaignore_file.read()
 
     # Create a temporary directory
     with tempfile.TemporaryDirectory() as temp_dir:
@@ -64,7 +63,7 @@ def build_tar_docker_container(folder: Path, file_name: Path) -> Path:
 
         # Clean - remove '/' from every files and folders in the gitignore contents
         sanitized_patterns = [
-            pattern.replace("/", "") for pattern in gitignore_content.splitlines()
+            pattern.replace("/", "") for pattern in agentaignore_content.splitlines()
         ]
 
         # Function to ignore files based on the patterns

--- a/agenta-cli/agenta/docker/docker_utils.py
+++ b/agenta-cli/agenta/docker/docker_utils.py
@@ -51,6 +51,9 @@ def build_tar_docker_container(folder: Path, file_name: Path) -> Path:
     shutil.copy(Path(__file__).parent / "docker-assets" / "lambda_function.py", folder)
     shutil.copy(Path(__file__).parent / "docker-assets" / "entrypoint.sh", folder)
 
+    # Initialize agentaignore_content with an empty string
+    agentaignore_content = ""
+
     # Read the contents of .gitignore file
     agentaignore_file_path = folder / ".agentaignore"
     if agentaignore_file_path.exists():


### PR DESCRIPTION
## Description
This PR renames `.gitignore` to `.agentaignore` and prevents it from being overwritten when re-running `agenta init`.

### Related Issue
Closes #1509

### Additional Information
During testing, I encountered an issue where starting a variant failed after successfully building the variant Docker image. This was caused by an incorrect repository name in line 15 of `agenta-backend/agenta_backend/services/deployment_manager.py` and line 13 of `agenta-backend/agenta_backend/services/docker_utils.py`. This error has also been fixed in this PR.