### PR TITLE
Hotfix/key_injection

### DIFF
--- a/agenta-backend/agenta_backend/routers/variants_router.py
+++ b/agenta-backend/agenta_backend/routers/variants_router.py
@@ -298,17 +298,7 @@ async def start_variant(
     logger.debug("Starting variant %s", variant_id)
 
     # Inject env vars to docker container
-    if isCloudEE():
-        if not os.environ["OPENAI_API_KEY"]:
-            raise HTTPException(
-                status_code=400,
-                detail="Unable to start app container. Please file an issue by clicking on the button below.",
-            )
-        envvars = {
-            "OPENAI_API_KEY": os.environ["OPENAI_API_KEY"],
-        }
-    else:
-        envvars = {} if env_vars is None else env_vars.env_vars
+    envvars = {} if env_vars is None else env_vars.env_vars
 
     if action.action == VariantActionEnum.START:
         url: URI = await app_manager.start_variant(app_variant_db, envvars)

--- a/agenta-cli/agenta/__init__.py
+++ b/agenta-cli/agenta/__init__.py
@@ -1,3 +1,4 @@
+from .sdk.utils.preinit import PreInitObject
 from .sdk.agenta_decorator import app, entrypoint
 from .sdk.context import get_contexts, save_context
 from .sdk.types import (
@@ -14,7 +15,6 @@ from .sdk.types import (
     BinaryParam,
 )
 from .sdk.tracing.decorators import span
-from .sdk.utils.preinit import PreInitObject
 from .sdk.agenta_init import Config, init, llm_tracing
 from .sdk.utils.helper.openai_cost import calculate_token_usage
 


### PR DESCRIPTION
Context:
We are injecting our openai key at start of the variant. Which means we are injecting it also when the user starts an app from code. This resulted in an issue in one user, where they imported openai before agenta, and ended up using our api key instead of theirs (they discovered this because they used an assistant id that did not exist in our account).

Solultion:
I removed the injection of keys at start variant. I have also made a small fix to init to make sure we first load the .env (although the requirement that the user imports agenta before openai is still required.) 