### PR TITLE
Refactor: added command to install celery before starting worker

### DIFF
--- a/docker-compose.gh.yml
+++ b/docker-compose.gh.yml
@@ -138,7 +138,7 @@ services:
         container_name: celery-worker-1
         image: ghcr.io/agenta-ai/agenta-backend
         command: >
-            celery -A agenta_backend.main.celery_app worker --concurrency=1 --loglevel=INFO
+                bash -c "pip install celery && celery -A agenta_backend.main.celery_app worker --concurrency=1 --loglevel=INFO"
         environment:
             - MONGODB_URI=mongodb://username:password@mongo:27017
             - REDIS_URL=redis://redis:6379/0
@@ -146,7 +146,6 @@ services:
             - CELERY_RESULT_BACKEND=redis://redis:6379/0
             - FEATURE_FLAG=oss
         volumes:
-            - ./agenta-backend/agenta_backend:/app/agenta_backend
             - /var/run/docker.sock:/var/run/docker.sock
         depends_on:
             - mongo


### PR DESCRIPTION
## Description
Regarding this [issue](https://github.com/Agenta-AI/agenta/issues/1516), I could not reproduce it (everything worked for me and I was able to view agenta on the web and use the playground), however, I couldn't get the `celery_worker` container to start. This was the error I had:

```bash
Error response from daemon: failed to create a task for container: was unable to create shim task: OCI runtime create failed: runc create failed: unable to start container process: exec: "celery": executable file not found in $PATH: unknown
```
 The above error is because the celery executable is not found in the `celery-worker-1` container.  This PR resolves the error.

**Before fix:**
![image](https://github.com/Agenta-AI/agenta/assets/55067204/dbbb9ef7-3acc-4a7c-a1a7-40f3ad5c7aec)

**After fix:**
![image](https://github.com/Agenta-AI/agenta/assets/55067204/cb50afe6-e3d6-4b27-9c6d-1be3e85fe6e4)
