### PR TITLE
Add traceback for error handling in LLM Apps service

### DIFF
--- a/agenta-backend/agenta_backend/services/llm_apps_service.py
+++ b/agenta-backend/agenta_backend/services/llm_apps_service.py
@@ -1,6 +1,7 @@
 import json
 import logging
 import asyncio
+import traceback
 import aiohttp
 from typing import Any, Dict, List
 
@@ -31,7 +32,8 @@ async def make_payload(
     for param in openapi_parameters:
         if param["type"] == "input":
             payload[param["name"]] = datapoint.get(param["name"], "")
-        elif param["type"] == "dict":  # in case of dynamic inputs (as in our templates)
+        # in case of dynamic inputs (as in our templates)
+        elif param["type"] == "dict":
             # let's get the list of the dynamic inputs
             if (
                 param["name"] in parameters
@@ -109,7 +111,9 @@ async def invoke_app(
                     type="error",
                     error=Error(
                         message=f"{e.code}: {error_message}",
-                        stacktrace=str(e),
+                        stacktrace="".join(
+                            traceback.format_exception(None, e, e.__traceback__)
+                        ),
                     ),
                 )
             )
@@ -122,7 +126,9 @@ async def invoke_app(
                     type="error",
                     error=Error(
                         message="Unexpected error while invoking the LLM App",
-                        stacktrace=str(e),
+                        stacktrace="".join(
+                            traceback.format_exception(None, e, e.__traceback__)
+                        ),
                     ),
                 )
             )

--- a/agenta-backend/agenta_backend/services/llm_apps_service.py
+++ b/agenta-backend/agenta_backend/services/llm_apps_service.py
@@ -8,7 +8,6 @@ from typing import Any, Dict, List
 
 from agenta_backend.models.db_models import InvokationResult, Result, Error
 from agenta_backend.utils import common
-
 # Set logger
 logger = logging.getLogger(__name__)
 logger.setLevel(logging.DEBUG)
@@ -99,13 +98,14 @@ async def invoke_app(
 
         except aiohttp.ClientResponseError as e:
             error_message = f"HTTP error {e.status}: {e.message}"
-            logger.error(f"HTTP error occurred during request: {error_message}")
+            logger.error(
+                f"HTTP error occurred during request: {error_message}")
             common.capture_exception_in_sentry(e)
         except aiohttp.ClientConnectionError as e:
             error_message = f"Connection error: {str(e)}"
             logger.error(error_message)
             common.capture_exception_in_sentry(e)
-        except aiohttp.TimeoutError as e:
+        except aiohttp.ServerTimeoutError as e:
             error_message = "Request timed out"
             logger.error(error_message)
             common.capture_exception_in_sentry(e)
@@ -162,7 +162,8 @@ async def run_with_retry(
             return result
         except aiohttp.ClientError as e:
             last_exception = e
-            print(f"Error in evaluation. Retrying in {retry_delay} seconds:", e)
+            print(
+                f"Error in evaluation. Retrying in {retry_delay} seconds:", e)
             await asyncio.sleep(retry_delay)
             retries += 1
         except Exception as e:

--- a/agenta-backend/agenta_backend/services/llm_apps_service.py
+++ b/agenta-backend/agenta_backend/services/llm_apps_service.py
@@ -8,6 +8,7 @@ from typing import Any, Dict, List
 
 from agenta_backend.models.db_models import InvokationResult, Result, Error
 from agenta_backend.utils import common
+
 # Set logger
 logger = logging.getLogger(__name__)
 logger.setLevel(logging.DEBUG)
@@ -98,15 +99,14 @@ async def invoke_app(
 
         except aiohttp.ClientResponseError as e:
             error_message = f"HTTP error {e.status}: {e.message}"
-            logger.error(
-                f"HTTP error occurred during request: {error_message}")
-            common.capture_exception_in_sentry(e)
-        except aiohttp.ClientConnectionError as e:
-            error_message = f"Connection error: {str(e)}"
-            logger.error(error_message)
+            logger.error(f"HTTP error occurred during request: {error_message}")
             common.capture_exception_in_sentry(e)
         except aiohttp.ServerTimeoutError as e:
             error_message = "Request timed out"
+            logger.error(error_message)
+            common.capture_exception_in_sentry(e)
+        except aiohttp.ClientConnectionError as e:
+            error_message = f"Connection error: {str(e)}"
             logger.error(error_message)
             common.capture_exception_in_sentry(e)
         except json.JSONDecodeError as e:
@@ -162,8 +162,7 @@ async def run_with_retry(
             return result
         except aiohttp.ClientError as e:
             last_exception = e
-            print(
-                f"Error in evaluation. Retrying in {retry_delay} seconds:", e)
+            print(f"Error in evaluation. Retrying in {retry_delay} seconds:", e)
             await asyncio.sleep(retry_delay)
             retries += 1
         except Exception as e:

--- a/agenta-backend/agenta_backend/services/llm_apps_service.py
+++ b/agenta-backend/agenta_backend/services/llm_apps_service.py
@@ -100,8 +100,7 @@ async def invoke_app(
         except aiohttp.ClientResponseError as e:
             error_message = f"HTTP error {e.status}: {e.message}"
             stacktrace = "".join(traceback.format_exception_only(type(e), e))
-            logger.error(
-                f"HTTP error occurred during request: {error_message}")
+            logger.error(f"HTTP error occurred during request: {error_message}")
             common.capture_exception_in_sentry(e)
         except aiohttp.ServerTimeoutError as e:
             error_message = "Request timed out"
@@ -166,8 +165,7 @@ async def run_with_retry(
             return result
         except aiohttp.ClientError as e:
             last_exception = e
-            print(
-                f"Error in evaluation. Retrying in {retry_delay} seconds:", e)
+            print(f"Error in evaluation. Retrying in {retry_delay} seconds:", e)
             await asyncio.sleep(retry_delay)
             retries += 1
         except Exception as e:

--- a/agenta-backend/agenta_backend/utils/common.py
+++ b/agenta-backend/agenta_backend/utils/common.py
@@ -4,6 +4,7 @@ from typing import Any, Callable
 
 from fastapi.types import DecoratedCallable
 from fastapi import APIRouter as FastAPIRouter
+from sentry_sdk import capture_exception
 
 logger = logging.getLogger(__name__)
 logger.setLevel(logging.DEBUG)
@@ -76,3 +77,8 @@ def isCloudDev():
 
 def isOss():
     return os.environ["FEATURE_FLAG"] == "oss"
+
+
+def capture_exception_in_sentry(e: Exception):
+    if isCloudProd():
+        capture_exception(e)


### PR DESCRIPTION
This pull request adds a traceback for error handling in the LLM Apps service. The traceback is generated using the `traceback` module and provides more detailed information about the error that occurred during app invocation.

It also instruments evaluation exceptions in sentry