### PR TITLE
Build: change permission of 'entrypoint.sh' to be executable

### DIFF
--- a/agenta-cli/agenta/docker/docker-assets/Dockerfile.template
+++ b/agenta-cli/agenta/docker/docker-assets/Dockerfile.template
@@ -8,5 +8,5 @@ RUN pip install --no-cache-dir --disable-pip-version-check -r requirements.txt
 
 EXPOSE 80
 
+RUN ["chmod", "+x", "./entrypoint.sh"]
 CMD ["./entrypoint.sh"]
-# uvicorn agenta_backend.main:app --reload --host 0.0.0.0 --port 8881


### PR DESCRIPTION
## Description
This PR modifies the permissions of `entrypoint.sh` within the `Dockerfile.template` to make it executable when the `serve` command is executed.

### Related Issue
Closes #1588 