### PR TITLE
fix: swap images in docs

### DIFF
--- a/docs/prompt_management/integrating.mdx
+++ b/docs/prompt_management/integrating.mdx
@@ -10,13 +10,13 @@ Applications and prompts created in agenta can be integrated into your projects 
 1. **As a Prompt Management System:** Fetch the latest version of prompts/configurations from agenta.
 
 <Frame>
-<img height="200" src="/images/prompt_management/asaproxy.png" />
+<img height="200" src="/images/prompt_management/asapromptmanagement.png" />
 </Frame>
 
 2. **As a Middleware:** Use the applications hosted on agenta directly.
 
 <Frame>
-<img height="200" src="/images/prompt_management/asapromptmanagement.png" />
+<img height="200" src="/images/prompt_management/asaproxy.png" />
 </Frame>
 
 ## Using agenta as Middleware


### PR DESCRIPTION
The images for middleware and prompt management system are flipped in the docs for integrating