### PR TITLE
[Bug Fix]: error connecting to variant served/deployed to agenta using CLI

### DIFF
--- a/agenta-cli/agenta/docker/docker-assets/Dockerfile.cloud.template
+++ b/agenta-cli/agenta/docker/docker-assets/Dockerfile.cloud.template
@@ -3,6 +3,7 @@ FROM public.ecr.aws/s2t9a1r1/agentaai/lambda_templates_public:main
 COPY requirements.txt ${LAMBDA_TASK_ROOT}
 RUN pip install --no-cache-dir --disable-pip-version-check -r requirements.txt
 RUN pip install --no-cache-dir --disable-pip-version-check mangum
+RUN pip install --no-cache-dir --disable-pip-version-check -U agenta
 COPY . ${LAMBDA_TASK_ROOT}
 
 CMD [ "lambda_function.handler" ]

--- a/agenta-cli/agenta/docker/docker-assets/Dockerfile.template
+++ b/agenta-cli/agenta/docker/docker-assets/Dockerfile.template
@@ -5,6 +5,7 @@ WORKDIR /app
 COPY . .
 
 RUN pip install --no-cache-dir --disable-pip-version-check -r requirements.txt
+RUN pip install --no-cache-dir --disable-pip-version-check -U agenta
 
 EXPOSE 80
 


### PR DESCRIPTION
## Description
The Docker templates used to package and deploy the LLM app reuse the cached version of agenta from the main template image. This PR resolves the error by ensuring that agenta is upgraded to the latest version.

### Related Issue
Closes #1649 