### PR TITLE
Fix key prop issue in ModelName component

### DIFF
--- a/agenta-web/src/components/Playground/Views/GroupedSelect.tsx
+++ b/agenta-web/src/components/Playground/Views/GroupedSelect.tsx
@@ -62,12 +62,12 @@ const getTextContent = (element: React.ReactNode): string => {
 const filterOption = (input: string, option?: {label: React.ReactNode; value: string}) =>
     getTextContent(option?.label).toLowerCase().includes(input.toLowerCase())
 
-export const ModelName: React.FC<{label: string; key: string}> = ({label, key}) => {
+export const ModelName: React.FC<{label: string; value: string}> = ({label, value}) => {
     const classes = useStyles()
 
     return (
         <div className={classes.option}>
-            {iconMap[key] ? React.createElement(iconMap[key]) : null}
+            {iconMap[value] ? React.createElement(iconMap[value]) : null}
             {label}
         </div>
     )
@@ -81,9 +81,9 @@ export const GroupedSelect: React.FC<GroupedSelectProps> = ({
     const classes = useStyles()
 
     const options = Object.entries(choices).map(([groupLabel, groupChoices]) => ({
-        label: <ModelName label={groupLabel} key={groupLabel} />,
+        label: <ModelName label={groupLabel} value={groupLabel} />,
         options: groupChoices.map((choice) => ({
-            label: <ModelName label={choice} key={groupLabel} />,
+            label: <ModelName label={choice} value={groupLabel} />,
             value: choice,
         })),
     }))


### PR DESCRIPTION
This pull request addresses an issue where the `key` prop in the ModelName component was returning undefined values. The key prop was conflicting with React's internal usage, leading to unexpected behavior. By renaming the prop to `value`, the conflict is resolved, and the component functions correctly.