### PR TITLE
Fixes argument order for custom code evaluator

### DIFF
--- a/agenta-backend/agenta_backend/services/security/sandbox.py
+++ b/agenta-backend/agenta_backend/services/security/sandbox.py
@@ -91,7 +91,7 @@ def execute_code_safely(
 
     # Call the evaluation function, extract the result if it exists
     # and is a float between 0 and 1
-    result = environment["evaluate"](app_params, inputs, correct_answer, output)
+    result = environment["evaluate"](app_params, inputs, output, correct_answer)
     if isinstance(result, float) and 0 <= result <= 1:
         return result
     return None


### PR DESCRIPTION
Hey, I noticed arguments were fed out of order for custom code evaluators. 
This is the template for the proposed custom evaluator 
```python
from typing import Dict

def evaluate(
    app_params: Dict[str, str],
    inputs: Dict[str, str],
    output: str,
    correct_answer: str
) -> float:
    # ...
    return 0.75  # Replace with your calculated score
```

But currently evaluators are invoked with `result = environment["evaluate"](app_params, inputs, correct_answer, output)`
To me the argument order in the template makes more sense, but it might not be backward compatible for people that worked around it by modifying the signature of the "evaluate" method. 
Let me know which options sounds best to you and I can expand the PR in the desired direction :)
