### PR TITLE
Revert "[Enhancement]: Logs are not fetched in cloud"

### DIFF
--- a/agenta-web/src/lib/services/api.ts
+++ b/agenta-web/src/lib/services/api.ts
@@ -580,8 +580,6 @@ export const waitForAppToStart = async ({
 }) => {
     const _variant = variant || (await fetchVariants(appId, true))[0]
     if (_variant) {
-        let stopperFunc: Function | null = null
-
         const {stopper, promise} = shortPoll(
             () =>
                 getVariantParametersFromOpenAPI(
@@ -589,16 +587,10 @@ export const waitForAppToStart = async ({
                     _variant.variantId,
                     _variant.baseId,
                     true,
-                ).then(() => {
-                    if (stopperFunc) stopperFunc()
-                    stopper()
-                }),
+                ).then(() => stopper()),
             {delayMs: interval, timeoutMs: timeout},
         )
-
-        stopperFunc = stopper
-
-        return {stopper: stopperFunc, promise}
+        await promise
     }
 }
 


### PR DESCRIPTION
Reverts Agenta-AI/agenta#1685
Reverting this PR as it's breaking the familiar behavior of opening an app once it got created.
We are displaying logs faster then waiting the the app from being ready