### PR TITLE
Fix: select model component search bar

### DIFF
--- a/agenta-web/src/components/Playground/Views/GroupedSelect.tsx
+++ b/agenta-web/src/components/Playground/Views/GroupedSelect.tsx
@@ -49,20 +49,8 @@ const iconMap: {[key: string]: React.ComponentType<any>} = {
     Gemini: Gemini.Color,
 }
 
-const getTextContent = (element: React.ReactNode): string => {
-    if (typeof element === "string") {
-        return element
-    } else if (React.isValidElement(element) && element.props.children) {
-        return React.Children.toArray(element.props.children).reduce<string>(
-            (acc, child) => acc + getTextContent(child),
-            "",
-        )
-    }
-    return ""
-}
-
 const filterOption = (input: string, option?: {label: React.ReactNode; value: string}) =>
-    getTextContent(option?.label).toLowerCase().includes(input.toLowerCase())
+    (option?.value ?? "").toLowerCase().includes(input.toLowerCase())
 
 export const ModelName: React.FC<{label: string; value: string}> = ({label, value}) => {
     const classes = useStyles()

--- a/agenta-web/src/pages/apps/[app_id]/annotations/human_a_b_testing/[evaluation_id]/index.tsx
+++ b/agenta-web/src/pages/apps/[app_id]/annotations/human_a_b_testing/[evaluation_id]/index.tsx
@@ -1,5 +1,5 @@
 import ABTestingEvaluationTable from "@/components/EvaluationTable/ABTestingEvaluationTable"
-import {Evaluation} from "@/lib/Types"
+import type {Evaluation} from "@/lib/Types"
 import {loadEvaluation, loadEvaluationsScenarios, loadTestset} from "@/lib/services/api"
 import {useRouter} from "next/router"
 import {useEffect, useState} from "react"

--- a/agenta-web/src/pages/apps/[app_id]/annotations/single_model_test/[evaluation_id]/index.tsx
+++ b/agenta-web/src/pages/apps/[app_id]/annotations/single_model_test/[evaluation_id]/index.tsx
@@ -1,4 +1,4 @@
-import {Evaluation, EvaluationScenario, GenericObject} from "@/lib/Types"
+import type {Evaluation, EvaluationScenario, GenericObject} from "@/lib/Types"
 import {loadEvaluation, loadEvaluationsScenarios, loadTestset} from "@/lib/services/api"
 import {useRouter} from "next/router"
 import {useEffect, useState} from "react"


### PR DESCRIPTION
## Description

Fixed the select model componnet search bar by replacing `getTextContent` function with the `options.value` as search query.

Majority of the times the `getTextContent` function return empty string that's why the result was showing empty by replacing it with `options.value` the search bar is functioning now.

## Screenshot
![image](https://github.com/Agenta-AI/agenta/assets/87828904/5db6f9a9-0db4-4718-9149-3d6c005d6f9f)


## Issue

Closes #1717
