### PR TITLE
Improvements to observability PR

### DIFF
--- a/agenta-backend/agenta_backend/services/app_manager.py
+++ b/agenta-backend/agenta_backend/services/app_manager.py
@@ -95,8 +95,6 @@ async def start_variant(
         env_vars = {} if env_vars is None else env_vars
         env_vars.update(
             {
-                "AGENTA_VARIANT_NAME": db_app_variant.variant_name,
-                "AGENTA_VARIANT_ID": str(db_app_variant.id),
                 "AGENTA_BASE_ID": str(db_app_variant.base.id),
                 "AGENTA_APP_ID": str(db_app_variant.app.id),
                 "AGENTA_HOST": domain_name,

--- a/agenta-cli/agenta/sdk/decorators/tracing.py
+++ b/agenta-cli/agenta/sdk/decorators/tracing.py
@@ -43,9 +43,13 @@ class instrument(BaseDecorator):
         @wraps(func)
         async def async_wrapper(*args, **kwargs):
             result = None
+            func_args = inspect.getfullargspec(func).args
+            input_dict = {name: value for name, value in zip(func_args, args)}
+            input_dict.update(kwargs)
+
             span = self.tracing.start_span(
                 name=func.__name__,
-                input=kwargs,
+                input=input_dict,
                 spankind=self.spankind,
                 config=self.config,
             )
@@ -67,9 +71,13 @@ class instrument(BaseDecorator):
         @wraps(func)
         def sync_wrapper(*args, **kwargs):
             result = None
+            func_args = inspect.getfullargspec(func).args
+            input_dict = {name: value for name, value in zip(func_args, args)}
+            input_dict.update(kwargs)
+
             span = self.tracing.start_span(
                 name=func.__name__,
-                input=kwargs,
+                input=input_dict,
                 spankind=self.spankind,
                 config=self.config,
             )

--- a/agenta-cli/agenta/sdk/tracing/llm_tracing.py
+++ b/agenta-cli/agenta/sdk/tracing/llm_tracing.py
@@ -1,18 +1,16 @@
-# Stdlib Imports
 import os
 from threading import Lock
 from datetime import datetime, timezone
 from typing import Optional, Dict, Any, List, Union
 
-# Own Imports
 from agenta.sdk.tracing.logger import llm_logger
 from agenta.sdk.tracing.tasks_manager import TaskQueue
 from agenta.client.backend.client import AsyncAgentaApi
 from agenta.client.backend.client import AsyncObservabilityClient
 from agenta.client.backend.types.create_span import CreateSpan, SpanKind, SpanStatusCode
 
-# Third Party Imports
 from bson.objectid import ObjectId
+VARIANT_TRACKING_FEATURE_FLAG = False
 
 
 class SingletonMeta(type):
@@ -58,8 +56,6 @@ class Tracing(metaclass=SingletonMeta):
         self,
         host: str,
         app_id: str,
-        variant_id: Optional[str] = None,
-        variant_name: Optional[str] = None,
         api_key: Optional[str] = None,
         max_workers: Optional[int] = None,
     ):
@@ -67,8 +63,6 @@ class Tracing(metaclass=SingletonMeta):
         self.api_key = api_key if api_key is not None else ""
         self.llm_logger = llm_logger
         self.app_id = app_id
-        self.variant_id = variant_id
-        self.variant_name = variant_name
         self.tasks_manager = TaskQueue(
             max_workers if max_workers else 4, logger=llm_logger
         )
@@ -126,8 +120,6 @@ class Tracing(metaclass=SingletonMeta):
             inputs=input,
             name=name,
             app_id=self.app_id,
-            variant_id=self.variant_id,
-            variant_name=self.variant_name,
             config=config,
             spankind=spankind.upper(),
             attributes={},
@@ -155,6 +147,11 @@ class Tracing(metaclass=SingletonMeta):
                 if not config and self.trace_config_cache is not None
                 else None
             )
+            if VARIANT_TRACKING_FEATURE_FLAG:
+                # TODO: we should get the variant_id and variant_name (and environment) from the config object
+                span.variant_id = config.variant_id
+                span.variant_name = config.variant_name,
+
         else:
             span.parent_span_id = self.active_span.id
         self.span_dict[span.id] = span


### PR DESCRIPTION
1. Improving to initialization:
- Initialization now only requires the `app_id` all the rest is optional.
- You can now initialize with the help of `config.toml` create when running `agenta init`
2. Fixing issue with api_key
- Reverted the changes from yesterday. Now the api_key provided by ag.init() is the one that will be used for initializing the client
3. Cleaning up agenta_init
4. Removing the initialization of variant_id: The logic there was wrong. We were always using the name of the variant provided at serve time. I removed the whole logic
5. Adding instrumentation of inputs to all funcitons even when not named 