### PR TITLE
Hotfix evaluation

### DIFF
--- a/agenta-backend/agenta_backend/services/evaluators_service.py
+++ b/agenta-backend/agenta_backend/services/evaluators_service.py
@@ -29,7 +29,9 @@ def get_correct_answer(
     Raises:
         ValueError: If the correct answer key is not provided or not found in the data point.
     """
-    correct_answer_key = settings_values.get("correct_answer_key")
+    correct_answer_key = settings_values.get(
+        "correct_answer_key", "correct_answer"
+    )  # hotfix: default added for backward compatibility. Solution is to update the settings in the database.
     if correct_answer_key is None:
         raise ValueError("No correct answer keys provided.")
     if correct_answer_key not in data_point:


### PR DESCRIPTION
**Issue:**
Previous evaluators have not been correctly migrated to include the [correct_answer](file:///Users/mahmoudmabrouk/agenta/code/agenta-core/agenta-backend/agenta_backend/services/evaluators_service.py#33%2C32-33%2C32) setting key.

**Proposed Solution:**
The proper solution is to add a migration that inserts this key with the default value [correct_answer](file:///Users/mahmoudmabrouk/agenta/code/agenta-core/agenta-backend/agenta_backend/services/evaluators_service.py#33%2C32-33%2C32) whenever it does not exist.

**Hotfix:**
This hotfix sets the default to [correct_answer](file:///Users/mahmoudmabrouk/agenta/code/agenta-core/agenta-backend/agenta_backend/services/evaluators_service.py#33%2C32-33%2C32) at runtime if the setting does not exist. However, this is not ideal as it can make bugs difficult to catch later. This hotfix should be removed after implementing the correct fix with the migration.