### PR TITLE
fix (sdk): set default values to FuncResponse sdk type

### DIFF
--- a/agenta-cli/agenta/sdk/decorators/llm_entrypoint.py
+++ b/agenta-cli/agenta/sdk/decorators/llm_entrypoint.py
@@ -201,7 +201,9 @@ class entrypoint(BaseDecorator):
             if isinstance(result, Dict):
                 return FuncResponse(**result, latency=round(latency, 4))
             if isinstance(result, str):
-                return FuncResponse(message=result, latency=round(latency, 4))  # type: ignore
+                return FuncResponse(
+                    message=result, usage=None, cost=None, latency=round(latency, 4)
+                )
             if isinstance(result, int) or isinstance(result, float):
                 return FuncResponse(
                     message=str(result),


### PR DESCRIPTION
## Description
This hotfix assigns `None` as the default value to the `usage` and `cost` fields within the `FuncResponse` SDK type for LLM app outputs that are of type string.