### PR TITLE
[Hotfix]: resolve ChatCompletionMessage object is not subscriptable

### DIFF
--- a/agenta-backend/agenta_backend/services/evaluators_service.py
+++ b/agenta-backend/agenta_backend/services/evaluators_service.py
@@ -275,8 +275,7 @@ def auto_ai_critique(
             model="gpt-3.5-turbo", messages=messages, temperature=0.8
         )
 
-        evaluation_output = response.choices[0].message["content"].strip()
-
+        evaluation_output = response.choices[0].message.content.strip()
         return Result(type="text", value=evaluation_output)
     except Exception as e:  # pylint: disable=broad-except
         return Result(

--- a/docker-compose.test.yml
+++ b/docker-compose.test.yml
@@ -25,7 +25,7 @@ services:
             - DATABASE_MODE=test
             - FEATURE_FLAG=oss
             - OPENAI_API_KEY=${OPENAI_API_KEY}
-            - AGENTA_TEMPLATE_REPO=agentaai/stage_templates
+            - AGENTA_TEMPLATE_REPO=agentaai/templates_v2
             - POSTHOG_API_KEY=phc_hmVSxIjTW1REBHXgj2aw4HW9X6CXb6FzerBgP9XenC7
             - TEMPLATES_BASE_URL=https://llm-app-json.s3.eu-central-1.amazonaws.com
             - REGISTRY_REPO_NAME=agentaai


### PR DESCRIPTION
## Description
This PR resolves the `ChatComletionMessage is not subscriptable` error when running auto ai critique evaluation.

### Additional Information

Full Error Traceback:
```python
[2024-06-07 13:39:28,371: DEBUG/ForkPoolWorker-1] Result: evaluator_config=ObjectId('666309d686a85ea3911dbc99') result=Result(type='error', value=None, error=Error(message='Error during Auto AI Critique', stacktrace="'ChatCompletionMessage' object is not subscriptable"))
[2024-06-07 13:39:28,403: ERROR/ForkPoolWorker-1] Task agenta_backend.tasks.evaluations.evaluate[67ad4369-e935-42e2-b400-fc962af27510] raised unexpected: TypeError('expected string or bytes-like object')
Traceback (most recent call last):
  File "/usr/local/lib/python3.9/site-packages/celery/app/trace.py", line 453, in trace_task
    R = retval = fun(*args, **kwargs)
  File "/usr/local/lib/python3.9/site-packages/celery/app/trace.py", line 736, in __protected_call__
    return self.run(*args, **kwargs)
  File "/app/agenta_backend/tasks/evaluations.py", line 324, in evaluate
    aggregated_results = loop.run_until_complete(
  File "/usr/local/lib/python3.9/asyncio/base_events.py", line 647, in run_until_complete
    return future.result()
  File "/app/agenta_backend/tasks/evaluations.py", line 368, in aggregate_evaluator_results
    result = aggregation_service.aggregate_ai_critique(results)
  File "/app/agenta_backend/services/aggregation_service.py", line 21, in aggregate_ai_critique
    match = re.search(r"\d+", result.value)
  File "/usr/local/lib/python3.9/re.py", line 201, in search
    return _compile(pattern, flags).search(string)
TypeError: expected string or bytes-like object
```