### PR TITLE
Fix: cleared 'Create a New Variant' modal input data

### DIFF
--- a/agenta-web/src/components/Playground/NewVariantModal.tsx
+++ b/agenta-web/src/components/Playground/NewVariantModal.tsx
@@ -13,7 +13,6 @@ interface Props {
     setNewVariantName: (value: string) => void
     newVariantName: string
     setTemplateVariantName: (value: string) => void
-    templateVariantName: string
 }
 
 const useStyles = createUseStyles({
@@ -30,7 +29,6 @@ const NewVariantModal: React.FC<Props> = ({
     setNewVariantName,
     newVariantName,
     setTemplateVariantName,
-    templateVariantName,
 }) => {
     const classes = useStyles()
     const [variantPlaceHolder, setVariantPlaceHolder] = useState("Source Variant")
@@ -63,6 +61,7 @@ const NewVariantModal: React.FC<Props> = ({
             onCancel={() => setIsModalOpen(false)}
             centered
             okButtonProps={{disabled: !isInputValid}} // Disable OK button if input is not valid
+            destroyOnClose
         >
             <Space direction="vertical" size={20}>
                 <div>
@@ -72,7 +71,6 @@ const NewVariantModal: React.FC<Props> = ({
                         data-cy="new-variant-modal-select"
                         placeholder="Select a variant"
                         onChange={handleTemplateVariantChange}
-                        value={templateVariantName}
                         options={variants.map((variant) => ({
                             value: variant.variantName,
                             label: (
@@ -87,7 +85,6 @@ const NewVariantModal: React.FC<Props> = ({
                     <Input
                         addonBefore={variantPlaceHolder}
                         onChange={handleVariantNameChange}
-                        value={newVariantName}
                         data-cy="new-variant-modal-input"
                     />
                 </div>

--- a/agenta-web/src/components/Playground/NewVariantModal.tsx
+++ b/agenta-web/src/components/Playground/NewVariantModal.tsx
@@ -13,6 +13,7 @@ interface Props {
     setNewVariantName: (value: string) => void
     newVariantName: string
     setTemplateVariantName: (value: string) => void
+    templateVariantName: string
 }
 
 const useStyles = createUseStyles({
@@ -29,6 +30,7 @@ const NewVariantModal: React.FC<Props> = ({
     setNewVariantName,
     newVariantName,
     setTemplateVariantName,
+    templateVariantName,
 }) => {
     const classes = useStyles()
     const [variantPlaceHolder, setVariantPlaceHolder] = useState("Source Variant")
@@ -70,6 +72,7 @@ const NewVariantModal: React.FC<Props> = ({
                         data-cy="new-variant-modal-select"
                         placeholder="Select a variant"
                         onChange={handleTemplateVariantChange}
+                        value={templateVariantName}
                         options={variants.map((variant) => ({
                             value: variant.variantName,
                             label: (
@@ -84,6 +87,7 @@ const NewVariantModal: React.FC<Props> = ({
                     <Input
                         addonBefore={variantPlaceHolder}
                         onChange={handleVariantNameChange}
+                        value={newVariantName}
                         data-cy="new-variant-modal-input"
                     />
                 </div>

--- a/agenta-web/src/components/Playground/Playground.tsx
+++ b/agenta-web/src/components/Playground/Playground.tsx
@@ -89,8 +89,6 @@ const Playground: React.FC = () => {
             setVariants((prevState: any) => [...prevState, newVariant])
             setActiveKey(updateNewVariantName)
             setUnsavedVariants((prev) => ({...prev, [newVariant.variantName!]: false}))
-            setTemplateVariantName("")
-            setNewVariantName("")
         } catch (error) {
             message.error("Failed to add new variant. Please try again later.")
             console.error("Error adding new variant:", error)
@@ -405,7 +403,6 @@ const Playground: React.FC = () => {
                 setNewVariantName={setNewVariantName}
                 newVariantName={newVariantName}
                 setTemplateVariantName={setTemplateVariantName}
-                templateVariantName={templateVariantName}
             />
         </div>
     )

--- a/agenta-web/src/components/Playground/Playground.tsx
+++ b/agenta-web/src/components/Playground/Playground.tsx
@@ -89,6 +89,8 @@ const Playground: React.FC = () => {
             setVariants((prevState: any) => [...prevState, newVariant])
             setActiveKey(updateNewVariantName)
             setUnsavedVariants((prev) => ({...prev, [newVariant.variantName!]: false}))
+            setTemplateVariantName("")
+            setNewVariantName("")
         } catch (error) {
             message.error("Failed to add new variant. Please try again later.")
             console.error("Error adding new variant:", error)
@@ -403,6 +405,7 @@ const Playground: React.FC = () => {
                 setNewVariantName={setNewVariantName}
                 newVariantName={newVariantName}
                 setTemplateVariantName={setTemplateVariantName}
+                templateVariantName={templateVariantName}
             />
         </div>
     )


### PR DESCRIPTION
**Description**

Cleared the input data from the 'Create a New Variant' modal after successfully creating a variant to enhance user experience.

**Issue**
Closes #1790 
