### PR TITLE
Feat: saved variant tabs position 

### DIFF
--- a/agenta-web/src/components/AppSelector/AppCard.tsx
+++ b/agenta-web/src/components/AppSelector/AppCard.tsx
@@ -91,6 +91,8 @@ const AppCard: React.FC<{
         } catch (error) {
             console.error(error)
         } finally {
+            // remove variant tabs position index from LS
+            localStorage.removeItem(`tabIndex_${app.app_id}`)
             setVisibleDelete(false)
             setConfirmLoading(false)
         }


### PR DESCRIPTION
**Description**
Currently, the variant tabs can be reordered by users, but the positions reset to default when the page get refreshed. This enhancement aims to improve user experience by saving and restoring the tab order using Local storage.

**Preview**

https://github.com/Agenta-AI/agenta/assets/87828904/f52b2fb6-b6ba-44e2-bb76-a5219f97cc28


**Issue**
Closes #1789 