### PR TITLE
Fix: error when pulling environment configuration

### DIFF
--- a/agenta-backend/agenta_backend/services/app_manager.py
+++ b/agenta-backend/agenta_backend/services/app_manager.py
@@ -103,7 +103,7 @@ async def start_variant(
         if isCloudEE():
             api_key = await api_key_service.create_api_key(
                 str(db_app_variant.user.uid),
-                workspace_id=str(db_app_variant.workspace),
+                workspace_id=str(db_app_variant.workspace.id),
                 expiration_date=None,
                 hidden=True,
             )

--- a/agenta-cli/agenta/sdk/agenta_init.py
+++ b/agenta-cli/agenta/sdk/agenta_init.py
@@ -91,7 +91,7 @@ class AgentaSingleton:
                 "Warning: Your configuration will not be saved permanently since base_id is not provided."
             )
 
-        self.config = Config(base_id=self.base_id, host=self.host)  # type: ignore
+        self.config = Config(base_id=self.base_id, host=self.host, api_key=self.api_key)  # type: ignore
 
 
 class Config:

--- a/agenta-cli/pyproject.toml
+++ b/agenta-cli/pyproject.toml
@@ -1,6 +1,6 @@
 [tool.poetry]
 name = "agenta"
-version = "0.17.3"
+version = "0.17.4a0"
 description = "The SDK for agenta is an open-source LLMOps platform."
 readme = "README.md"
 authors = ["Mahmoud Mabrouk <mahmoud@agenta.ai>"]


### PR DESCRIPTION
Publishing a variant to an environment currently fails to pull the environment's configuration due to an invalid API key, causing unexpected behaviour. This PR resolves the issue.