### PR TITLE
Refactor: remove StyleProps type to eliminate code duplication

### DIFF
--- a/agenta-web/src/components/AppSelector/AppSelector.tsx
+++ b/agenta-web/src/components/AppSelector/AppSelector.tsx
@@ -2,7 +2,7 @@ import {useState, useEffect, useMemo} from "react"
 import {PlusOutlined} from "@ant-design/icons"
 import {Input, Modal, ConfigProvider, theme, Card, Button, notification, Divider} from "antd"
 import AppCard from "./AppCard"
-import {Template, GenericObject} from "@/lib/Types"
+import {Template, GenericObject, StyleProps} from "@/lib/Types"
 import {useAppTheme} from "../Layout/ThemeContextProvider"
 import TipsAndFeatures from "./TipsAndFeatures"
 import Welcome from "./Welcome"
@@ -22,9 +22,6 @@ import {LlmProvider, getAllProviderLlmKeys} from "@/lib/helpers/llmProviders"
 import ResultComponent from "../ResultComponent/ResultComponent"
 import {dynamicContext} from "@/lib/helpers/dynamic"
 
-type StyleProps = {
-    themeMode: "dark" | "light"
-}
 
 const useStyles = createUseStyles({
     container: ({themeMode}: StyleProps) => ({

--- a/agenta-web/src/components/AppSelector/AppSelector.tsx
+++ b/agenta-web/src/components/AppSelector/AppSelector.tsx
@@ -22,7 +22,6 @@ import {LlmProvider, getAllProviderLlmKeys} from "@/lib/helpers/llmProviders"
 import ResultComponent from "../ResultComponent/ResultComponent"
 import {dynamicContext} from "@/lib/helpers/dynamic"
 
-
 const useStyles = createUseStyles({
     container: ({themeMode}: StyleProps) => ({
         marginTop: 10,

--- a/agenta-web/src/components/AppSelector/TipsAndFeatures.tsx
+++ b/agenta-web/src/components/AppSelector/TipsAndFeatures.tsx
@@ -3,14 +3,11 @@ import {BulbFilled} from "@ant-design/icons"
 import {Space} from "antd"
 import {useAppTheme} from "../Layout/ThemeContextProvider"
 import {MDXProvider} from "@mdx-js/react"
+import {StyleProps} from "@/lib/Types"
 
 import slide1 from "../../welcome-highlights/tip1.mdx"
 import slide2 from "../../welcome-highlights/tip2.mdx"
 import {createUseStyles} from "react-jss"
-
-type StyleProps = {
-    themeMode: "dark" | "light"
-}
 
 const useStyles = createUseStyles({
     container: ({themeMode}: StyleProps) => ({

--- a/agenta-web/src/components/AppSelector/Welcome.tsx
+++ b/agenta-web/src/components/AppSelector/Welcome.tsx
@@ -3,10 +3,7 @@ import React from "react"
 import {useAppTheme} from "../Layout/ThemeContextProvider"
 import {createUseStyles} from "react-jss"
 import {CheckCircleFilled, ClockCircleOutlined} from "@ant-design/icons"
-
-type StyleProps = {
-    themeMode: "dark" | "light"
-}
+import {StyleProps} from "@/lib/Types"
 
 const useStyles = createUseStyles({
     head: {

--- a/agenta-web/src/components/AppSelector/modals/AddNewAppModal.tsx
+++ b/agenta-web/src/components/AppSelector/modals/AddNewAppModal.tsx
@@ -3,10 +3,7 @@ import {AppstoreAddOutlined, CodeOutlined} from "@ant-design/icons"
 import {Col, Modal, Row, Typography} from "antd"
 import React from "react"
 import {createUseStyles} from "react-jss"
-
-type StyleProps = {
-    themeMode: "dark" | "light"
-}
+import {StyleProps} from "@/lib/Types"
 
 const useStyles = createUseStyles({
     modal: {

--- a/agenta-web/src/components/AppSelector/modals/MaxAppModal.tsx
+++ b/agenta-web/src/components/AppSelector/modals/MaxAppModal.tsx
@@ -3,10 +3,7 @@ import {AppstoreAddOutlined, CodeOutlined} from "@ant-design/icons"
 import {Col, Modal, Row, Typography} from "antd"
 import React from "react"
 import {createUseStyles} from "react-jss"
-
-type StyleProps = {
-    themeMode: "dark" | "light"
-}
+import {StyleProps} from "@/lib/Types"
 
 const useStyles = createUseStyles({
     modal: {

--- a/agenta-web/src/components/AppSelector/modals/WriteOwnAppModal.tsx
+++ b/agenta-web/src/components/AppSelector/modals/WriteOwnAppModal.tsx
@@ -6,10 +6,7 @@ import React, {useEffect, useRef} from "react"
 import {createUseStyles} from "react-jss"
 import YouTube, {YouTubeProps} from "react-youtube"
 import {isDemo} from "@/lib/helpers/utils"
-
-type StyleProps = {
-    themeMode: "dark" | "light"
-}
+import {StyleProps} from "@/lib/Types"
 
 const useStyles = createUseStyles({
     modal: ({themeMode}: StyleProps) => ({

--- a/agenta-web/src/components/Evaluations/AutomaticEvaluationResult.tsx
+++ b/agenta-web/src/components/Evaluations/AutomaticEvaluationResult.tsx
@@ -7,7 +7,7 @@ import {Button, Spin, Statistic, Table, Typography} from "antd"
 import {useRouter} from "next/router"
 import {useEffect, useState} from "react"
 import {ColumnsType} from "antd/es/table"
-import {Evaluation, GenericObject} from "@/lib/Types"
+import {Evaluation, GenericObject, StyleProps} from "@/lib/Types"
 import {DeleteOutlined} from "@ant-design/icons"
 import {EvaluationFlow, EvaluationType} from "@/lib/enums"
 import {createUseStyles} from "react-jss"
@@ -39,10 +39,6 @@ interface EvaluationListTableDataType {
     createdAt: string
     revisions: string[]
     variant_revision_ids: string[]
-}
-
-type StyleProps = {
-    themeMode: "dark" | "light"
 }
 
 const useStyles = createUseStyles({

--- a/agenta-web/src/components/Evaluations/EvaluationCardView/EvaluationVariantCard.tsx
+++ b/agenta-web/src/components/Evaluations/EvaluationCardView/EvaluationVariantCard.tsx
@@ -1,13 +1,9 @@
 import {useAppTheme} from "@/components/Layout/ThemeContextProvider"
-import {Evaluation, Variant} from "@/lib/Types"
+import {Evaluation, Variant, StyleProps} from "@/lib/Types"
 import {Typography} from "antd"
 import React from "react"
 import {createUseStyles} from "react-jss"
 import {VARIANT_COLORS} from "."
-
-type StyleProps = {
-    themeMode: "dark" | "light"
-}
 
 const useStyles = createUseStyles({
     root: ({themeMode}: StyleProps) => ({

--- a/agenta-web/src/components/Evaluations/HumanEvaluationResult.tsx
+++ b/agenta-web/src/components/Evaluations/HumanEvaluationResult.tsx
@@ -4,7 +4,7 @@ import {Button, Spin, Statistic, Table, Typography} from "antd"
 import {useRouter} from "next/router"
 import {useEffect, useState} from "react"
 import {ColumnsType} from "antd/es/table"
-import {EvaluationResponseType} from "@/lib/Types"
+import {EvaluationResponseType, StyleProps} from "@/lib/Types"
 import {DeleteOutlined} from "@ant-design/icons"
 import {EvaluationFlow, EvaluationType} from "@/lib/enums"
 import {createUseStyles} from "react-jss"
@@ -45,10 +45,6 @@ export interface HumanEvaluationListTableDataType {
     revisions: string[]
     variant_revision_ids: string[]
     variantNames: string[]
-}
-
-type StyleProps = {
-    themeMode: "dark" | "light"
 }
 
 const useStyles = createUseStyles({

--- a/agenta-web/src/components/HumanEvaluationModal/HumanEvaluationModal.tsx
+++ b/agenta-web/src/components/HumanEvaluationModal/HumanEvaluationModal.tsx
@@ -1,5 +1,5 @@
 import React, {useEffect, useState} from "react"
-import {GenericObject, JSSTheme, Parameter, Variant} from "@/lib/Types"
+import {GenericObject, JSSTheme, Parameter, Variant, StyleProps} from "@/lib/Types"
 import {fetchVariants} from "@/services/api"
 import {createNewEvaluation} from "@/services/human-evaluations/api"
 import {isDemo} from "@/lib/helpers/utils"
@@ -15,10 +15,6 @@ import {createUseStyles} from "react-jss"
 import EvaluationErrorModal from "../Evaluations/EvaluationErrorModal"
 import {dynamicComponent} from "@/lib/helpers/dynamic"
 import {useLoadTestsetsList} from "@/services/testsets/api"
-
-type StyleProps = {
-    themeMode: "dark" | "light"
-}
 
 const useStyles = createUseStyles((theme: JSSTheme) => ({
     evaluationContainer: {

--- a/agenta-web/src/components/Layout/Layout.tsx
+++ b/agenta-web/src/components/Layout/Layout.tsx
@@ -28,11 +28,11 @@ import moonIcon from "@/media/night.png"
 import sunIcon from "@/media/sun.png"
 import {useProfileData} from "@/contexts/profile.context"
 import {ThemeProvider} from "react-jss"
+import {StyleProps as MainStyleProps} from "@/lib/Types"
 
 const {Content, Footer} = Layout
 
-type StyleProps = {
-    themeMode: "dark" | "light"
+interface StyleProps extends MainStyleProps {
     footerHeight: number
 }
 

--- a/agenta-web/src/components/Playground/AddToTestSetDrawer/AddToTestSetDrawer.tsx
+++ b/agenta-web/src/components/Playground/AddToTestSetDrawer/AddToTestSetDrawer.tsx
@@ -1,6 +1,6 @@
 import AlertPopup from "@/components/AlertPopup/AlertPopup"
 import {useAppTheme} from "../../Layout/ThemeContextProvider"
-import {ChatMessage, ChatRole, GenericObject, testset} from "@/lib/Types"
+import {ChatMessage, ChatRole, GenericObject, testset, StyleProps} from "@/lib/Types"
 import {removeKeys, renameVariables} from "@/lib/helpers/utils"
 import {
     createNewTestset,
@@ -28,10 +28,6 @@ import {createUseStyles} from "react-jss"
 import {useLocalStorage, useUpdateEffect} from "usehooks-ts"
 import ChatInputs from "@/components/ChatInputs/ChatInputs"
 import _ from "lodash"
-
-type StyleProps = {
-    themeMode: "dark" | "light"
-}
 
 const useStyles = createUseStyles({
     footer: {

--- a/agenta-web/src/components/Playground/Views/TestView.tsx
+++ b/agenta-web/src/components/Playground/Views/TestView.tsx
@@ -2,7 +2,15 @@ import React, {useContext, useEffect, useRef, useState} from "react"
 import {Button, Input, Card, Row, Col, Space, Form, Modal} from "antd"
 import {CaretRightOutlined, CloseCircleOutlined, PlusOutlined} from "@ant-design/icons"
 import {callVariant} from "@/services/api"
-import {ChatMessage, ChatRole, GenericObject, JSSTheme, Parameter, Variant, StyleProps} from "@/lib/Types"
+import {
+    ChatMessage,
+    ChatRole,
+    GenericObject,
+    JSSTheme,
+    Parameter,
+    Variant,
+    StyleProps,
+} from "@/lib/Types"
 import {batchExecute, randString, removeKeys} from "@/lib/helpers/utils"
 import LoadTestsModal from "../LoadTestsModal"
 import AddToTestSetDrawer from "../AddToTestSetDrawer/AddToTestSetDrawer"

--- a/agenta-web/src/components/Playground/Views/TestView.tsx
+++ b/agenta-web/src/components/Playground/Views/TestView.tsx
@@ -2,7 +2,7 @@ import React, {useContext, useEffect, useRef, useState} from "react"
 import {Button, Input, Card, Row, Col, Space, Form, Modal} from "antd"
 import {CaretRightOutlined, CloseCircleOutlined, PlusOutlined} from "@ant-design/icons"
 import {callVariant} from "@/services/api"
-import {ChatMessage, ChatRole, GenericObject, JSSTheme, Parameter, Variant} from "@/lib/Types"
+import {ChatMessage, ChatRole, GenericObject, JSSTheme, Parameter, Variant, StyleProps} from "@/lib/Types"
 import {batchExecute, randString, removeKeys} from "@/lib/helpers/utils"
 import LoadTestsModal from "../LoadTestsModal"
 import AddToTestSetDrawer from "../AddToTestSetDrawer/AddToTestSetDrawer"
@@ -29,10 +29,6 @@ const promptRevision: any = dynamicService("promptVersioning/api")
 
 dayjs.extend(relativeTime)
 dayjs.extend(duration)
-
-type StyleProps = {
-    themeMode: "dark" | "light"
-}
 
 const {TextArea} = Input
 const LOADING_TEXT = "Loading..."

--- a/agenta-web/src/components/SecondaryButton/SecondaryButton.tsx
+++ b/agenta-web/src/components/SecondaryButton/SecondaryButton.tsx
@@ -10,10 +10,6 @@ type SecondaryBtnProps = {
     onClick: () => void
 }
 
-type StyleProps = {
-    themeMode: "dark" | "light"
-}
-
 const SecondaryButton: React.FC<SecondaryBtnProps> = ({children, ...props}) => {
     const {appTheme} = useAppTheme()
 

--- a/agenta-web/src/lib/Types.ts
+++ b/agenta-web/src/lib/Types.ts
@@ -488,3 +488,7 @@ export type PaginationQuery = {
     page: number
     pageSize: number
 }
+
+export type StyleProps = {
+    themeMode: "dark" | "light"
+}


### PR DESCRIPTION
**Description:**
Refactored the codebase by removing all the `StyleProps` types, which is currently leading to code duplication.

**Changes:**
1. Declared a `StyleProps` type in the `Types.ts` file.
2. Imported the `StyleProps` type wherever it is used.