### PR TITLE
add default seed to ai_critique OpenAI call in evaluators_service.py

### DIFF
--- a/agenta-backend/agenta_backend/services/evaluators_service.py
+++ b/agenta-backend/agenta_backend/services/evaluators_service.py
@@ -272,7 +272,7 @@ def auto_ai_critique(
 
         client = OpenAI(api_key=openai_api_key)
         response = client.chat.completions.create(
-            model="gpt-3.5-turbo", messages=messages, temperature=0.8
+            model="gpt-3.5-turbo", messages=messages, temperature=0.8, seed=42
         )
 
         evaluation_output = response.choices[0].message.content.strip()


### PR DESCRIPTION
pass fixed seed=42 to OpenAI to ensure replicability and consistency in the ai critique