### PR TITLE
Fix issue where Evaluation Results don't load when individual Evaluation Scenarios fail

### DIFF
--- a/agenta-backend/agenta_backend/models/converters.py
+++ b/agenta-backend/agenta_backend/models/converters.py
@@ -254,10 +254,14 @@ def evaluation_scenario_db_to_pydantic(
             EvaluationScenarioOutput(**scenario_output.dict())
             for scenario_output in evaluation_scenario_db.outputs
         ],
-        correct_answers=[
-            CorrectAnswer(**correct_answer.dict())
-            for correct_answer in evaluation_scenario_db.correct_answers
-        ],
+        correct_answers=(
+            [
+                CorrectAnswer(**correct_answer.dict())
+                for correct_answer in evaluation_scenario_db.correct_answers
+            ]
+            if evaluation_scenario_db.correct_answers is not None
+            else None
+        ),
         is_pinned=evaluation_scenario_db.is_pinned or False,
         note=evaluation_scenario_db.note or "",
         results=evaluation_scenarios_results_to_pydantic(

--- a/agenta-backend/agenta_backend/routers/evaluation_router.py
+++ b/agenta-backend/agenta_backend/routers/evaluation_router.py
@@ -1,5 +1,6 @@
 import secrets
 import logging
+import traceback
 from typing import Any, List
 
 from fastapi.responses import JSONResponse
@@ -270,6 +271,7 @@ async def fetch_evaluation_scenarios(
         return eval_scenarios
 
     except Exception as exc:
+        logger.error(str(traceback.format_exc()))
         raise HTTPException(status_code=500, detail=str(exc))
 
 


### PR DESCRIPTION
**Description**
- Catch None-related issue in Optional[...] field: EvaluationResult.correct_answers
- Adds logger.error(e) for exception in evaluation router

**Related Issues**
Not linked yet.