### PR TITLE
Bug fix/variant deletion unpublish other variants environment

### DIFF
--- a/agenta-backend/agenta_backend/services/db_manager.py
+++ b/agenta-backend/agenta_backend/services/db_manager.py
@@ -1199,13 +1199,6 @@ async def remove_app_variant_from_db(app_variant_db: AppVariantDB):
     app_variant_revisions = await list_app_variant_revisions_by_variant(app_variant_db)
 
     async with db_engine.get_session() as session:
-        logger.debug("list_environments_by_variant")
-        environments = await list_environments_by_variant(session, app_variant_db)
-
-        # Remove the variant from the associated environments
-        for environment in environments:
-            environment.deployed_app_variant = None
-            await session.commit()
 
         # Delete all the revisions associated with the variant
         for app_variant_revision in app_variant_revisions:

--- a/agenta-backend/agenta_backend/services/db_manager.py
+++ b/agenta-backend/agenta_backend/services/db_manager.py
@@ -1199,7 +1199,6 @@ async def remove_app_variant_from_db(app_variant_db: AppVariantDB):
     app_variant_revisions = await list_app_variant_revisions_by_variant(app_variant_db)
 
     async with db_engine.get_session() as session:
-
         # Delete all the revisions associated with the variant
         for app_variant_revision in app_variant_revisions:
             await session.delete(app_variant_revision)

--- a/agenta-backend/agenta_backend/services/db_manager.py
+++ b/agenta-backend/agenta_backend/services/db_manager.py
@@ -1596,28 +1596,6 @@ async def fetch_app_variant_revision(app_variant: str, revision_number: int):
         return app_variant_revisions
 
 
-async def list_environments_by_variant(
-    session: AsyncSession,
-    app_variant: AppVariantDB,
-):
-    """
-    Returns a list of environments for a given app variant.
-
-    Args:
-        session (AsyncSession): the current ongoing session
-        app_variant (AppVariantDB): The app variant to retrieve environments for.
-
-    Returns:
-        List[AppEnvironmentDB]: A list of AppEnvironmentDB objects.
-    """
-
-    result = await session.execute(
-        select(AppEnvironmentDB).filter_by(app_id=app_variant.app.id)
-    )
-    environments_db = result.scalars().all()
-    return environments_db
-
-
 async def remove_image(image: ImageDB):
     """
     Removes an image from the database.


### PR DESCRIPTION
## Description
This PR ensures that only the targeted variant's environment is affected by the deletion.

### New Behaviour
When a variant is deleted, it automatically sets the `deployed_app_variant_id` and `deployed_app_variant_revision_id` fields in the environment to `NULL`. This means that the variant that was published to an environment has its `deployed_app_variant_id` and `deployed_app_variant_revision_id` fields set to `NULL`.