### PR TITLE
fix(sdk): AGE-272 Propagate func errors up in @ag.instrument() wrappers

### DIFF
--- a/agenta-cli/agenta/sdk/decorators/llm_entrypoint.py
+++ b/agenta-cli/agenta/sdk/decorators/llm_entrypoint.py
@@ -83,9 +83,11 @@ class entrypoint(BaseDecorator):
                 {"config": config_params, "environment": "playground"}
             )
 
+            # Exceptions are all handled inside self.execute_function()
             llm_result = await self.execute_function(
                 func, *args, params=func_params, config_params=config_params
             )
+
             return llm_result
 
         @functools.wraps(func)

--- a/agenta-cli/agenta/sdk/decorators/tracing.py
+++ b/agenta-cli/agenta/sdk/decorators/tracing.py
@@ -66,11 +66,15 @@ class instrument(BaseDecorator):
                 return result
 
             except Exception as e:
+                result = {
+                    "message": str(e),
+                    "stacktrace": traceback.format_exc(),
+                }
                 self.tracing.set_span_attribute(
                     {"traceback_exception": traceback.format_exc()}
                 )
                 self.tracing.update_span_status(span=span, value="ERROR")
-                self.tracing.end_span(outputs={})
+                self.tracing.end_span(outputs=result)
                 raise e
 
         @wraps(func)
@@ -98,11 +102,15 @@ class instrument(BaseDecorator):
                 return result
 
             except Exception as e:
+                result = {
+                    "message": str(e),
+                    "stacktrace": traceback.format_exc(),
+                }
                 self.tracing.set_span_attribute(
                     {"traceback_exception": traceback.format_exc()}
                 )
                 self.tracing.update_span_status(span=span, value="ERROR")
-                self.tracing.end_span(outputs={})
+                self.tracing.end_span(outputs=result)
                 raise e
 
         return async_wrapper if is_coroutine_function else sync_wrapper

--- a/agenta-cli/agenta/sdk/decorators/tracing.py
+++ b/agenta-cli/agenta/sdk/decorators/tracing.py
@@ -58,19 +58,20 @@ class instrument(BaseDecorator):
             try:
                 result = await func(*args, **kwargs)
                 self.tracing.update_span_status(span=span, value="OK")
-            except Exception as e:
-                result = str(e)
-                self.tracing.set_span_attribute(
-                    {"traceback_exception": traceback.format_exc()}
-                )
-                self.tracing.update_span_status(span=span, value="ERROR")
-            finally:
                 self.tracing.end_span(
                     outputs=(
                         {"message": result} if not isinstance(result, dict) else result
                     )
                 )
-            return result
+                return result
+
+            except Exception as e:
+                self.tracing.set_span_attribute(
+                    {"traceback_exception": traceback.format_exc()}
+                )
+                self.tracing.update_span_status(span=span, value="ERROR")
+                self.tracing.end_span(outputs={})
+                raise e
 
         @wraps(func)
         def sync_wrapper(*args, **kwargs):
@@ -89,17 +90,19 @@ class instrument(BaseDecorator):
             try:
                 result = func(*args, **kwargs)
                 self.tracing.update_span_status(span=span, value="OK")
-            except Exception as e:
-                result = str(e)
-                self.tracing.set_span_attribute(
-                    {"traceback_exception": traceback.format_exc()}
-                )
-                self.tracing.update_span_status(span=span, value="ERROR")
-            finally:
                 self.tracing.end_span(
                     outputs=(
                         {"message": result} if not isinstance(result, dict) else result
                     )
                 )
+                return result
+
+            except Exception as e:
+                self.tracing.set_span_attribute(
+                    {"traceback_exception": traceback.format_exc()}
+                )
+                self.tracing.update_span_status(span=span, value="ERROR")
+                self.tracing.end_span(outputs={})
+                raise e
 
         return async_wrapper if is_coroutine_function else sync_wrapper

--- a/agenta-cli/pyproject.toml
+++ b/agenta-cli/pyproject.toml
@@ -1,6 +1,6 @@
 [tool.poetry]
 name = "agenta"
-version = "0.17.5"
+version = "0.17.6-alpha.1"
 description = "The SDK for agenta is an open-source LLMOps platform."
 readme = "README.md"
 authors = ["Mahmoud Mabrouk <mahmoud@agenta.ai>"]

--- a/agenta-cli/pyproject.toml
+++ b/agenta-cli/pyproject.toml
@@ -1,6 +1,6 @@
 [tool.poetry]
 name = "agenta"
-version = "0.17.6a1"
+version = "0.17.5"
 description = "The SDK for agenta is an open-source LLMOps platform."
 readme = "README.md"
 authors = ["Mahmoud Mabrouk <mahmoud@agenta.ai>"]

--- a/agenta-cli/pyproject.toml
+++ b/agenta-cli/pyproject.toml
@@ -1,6 +1,6 @@
 [tool.poetry]
 name = "agenta"
-version = "0.17.6-alpha.1"
+version = "0.17.6a1"
 description = "The SDK for agenta is an open-source LLMOps platform."
 readme = "README.md"
 authors = ["Mahmoud Mabrouk <mahmoud@agenta.ai>"]


### PR DESCRIPTION
Func errors used to be set as func result. Now they are propagated up by forwarding the exception up (raise e).