### PR TITLE
Refactor/add function to fetch corresponding object UUID

### DIFF
--- a/agenta-backend/agenta_backend/services/db_manager.py
+++ b/agenta-backend/agenta_backend/services/db_manager.py
@@ -63,6 +63,7 @@ else:
     )
 from agenta_backend.models.db_models import (
     TemplateDB,
+    IDsMappingDB,
     AppVariantRevisionsDB,
     HumanEvaluationVariantDB,
     EvaluationScenarioResultDB,
@@ -3094,3 +3095,25 @@ async def check_if_evaluation_contains_failed_evaluation_scenarios(
         if not count:
             return False
         return count > 0
+
+
+async def fetch_corresponding_object_uuid(table_name: str, object_id: str) -> str:
+    """
+    Fetches a corresponding object uuid.
+
+    Args:
+        table_name (str):  The table name
+        object_id (str):   The object identifier
+
+    Returns:
+        The corresponding object uuid as string.
+    """
+
+    async with db_engine.get_session() as session:
+        result = await session.execute(
+            select(IDsMappingDB)
+            .filter_by(table_name=table_name, objectid=object_id)
+            .options(load_only(IDsMappingDB.uuid))  # type: ignore
+        )
+        object_mapping = result.scalars().first()
+        return str(object_mapping.uuid)

--- a/agenta-backend/agenta_backend/services/db_manager.py
+++ b/agenta-backend/agenta_backend/services/db_manager.py
@@ -3111,9 +3111,7 @@ async def fetch_corresponding_object_uuid(table_name: str, object_id: str) -> st
 
     async with db_engine.get_session() as session:
         result = await session.execute(
-            select(IDsMappingDB)
-            .filter_by(table_name=table_name, objectid=object_id)
-            .options(load_only(IDsMappingDB.uuid))  # type: ignore
+            select(IDsMappingDB).filter_by(table_name=table_name, objectid=object_id)
         )
         object_mapping = result.scalars().first()
         return str(object_mapping.uuid)


### PR DESCRIPTION
## Description
This PR adds a function to fetch the corresponding object UUID (as string) from the database.

### Example (how-to use)
```python

from agenta_backend.services import db_manager
...

app_object_id = "66893cd16c27dd6b19d2230b"
app_uuid_as_str = await db_manager.fetch_corresponding_object_uuid(
    table_name="app_db", object_id=app_object_id
)
print(app_uuid_as_str) 
# 019087e0-0ea5-7623-a103-de9cb67f229a
```