### PR TITLE
Bug/deleting docker image result in an integrity error for variant

### DIFF
--- a/agenta-backend/agenta_backend/models/db_models.py
+++ b/agenta-backend/agenta_backend/models/db_models.py
@@ -176,7 +176,9 @@ class AppVariantDB(Base):
     variant_name = Column(String)
     revision = Column(Integer)
     image_id = Column(
-        UUID(as_uuid=True), ForeignKey("docker_images.id", ondelete="SET NULL")
+        UUID(as_uuid=True),
+        ForeignKey("docker_images.id", ondelete="SET NULL"),
+        nullable=True,
     )
     user_id = Column(UUID(as_uuid=True), ForeignKey("users.id"))
     modified_by_id = Column(UUID(as_uuid=True), ForeignKey("users.id"))


### PR DESCRIPTION
## Description
When reserving an app from the CLI, we delete the Docker image associated with the LLM app container to rebuild and assign a new Docker image. During the deletion of the Docker image (`app_manager.py` line 157 ->  `update_variant_image` function), PostgreSQL raises an `IntegrityError` exception:

```bash
raise translated_error from error
sqlalchemy.exc.IntegrityError: (sqlalchemy.dialects.postgresql.asyncpg.IntegrityError) <class 'asyncpg.exceptions.ForeignKeyViolationError'>: update or delete on table "docker_images" violates foreign key constraint "app_variants_image_id_fkey" on table "app_variants"
DETAIL:  Key (id)=(01908b54-98c0-7528-8604-3653162c7e74) is still referenced from table "app_variants".
[SQL: DELETE FROM docker_images WHERE docker_images.id = $1::UUID]
[parameters: (UUID('01908b54-98c0-7528-8604-3653162c7e74'),)]
(Background on this error at: https://sqlalche.me/e/20/gkpj)
```

This PR addresses the issue by ensuring the `image_id` column in the `app_variants` table allows `NULL` values. Although we had previously defined an ondelete behaviour, the missing `nullable` setting caused PostgreSQL to raise the mentioned error above.