### PR TITLE
[Bug fix]: CLI overwriting an app does not update configuration

### DIFF
--- a/agenta-backend/agenta_backend/models/api/api_models.py
+++ b/agenta-backend/agenta_backend/models/api/api_models.py
@@ -44,7 +44,6 @@ class SaveConfigPayload(BaseModel):
     base_id: str
     config_name: str
     parameters: Dict[str, Any]
-    overwrite: bool
 
 
 class VariantActionEnum(str, Enum):

--- a/agenta-backend/agenta_backend/routers/configs_router.py
+++ b/agenta-backend/agenta_backend/routers/configs_router.py
@@ -53,11 +53,11 @@ async def save_config(
                 variant_to_overwrite = variant_db
                 break
 
-        if (
-            variant_to_overwrite is not None
-        ):
-            if variant_to_overwrite.config_parameters == {}: # type: ignore
-                logger.info(f"Updating variant {str(variant_to_overwrite.id)} parameters with {payload.parameters}")
+        if variant_to_overwrite is not None:
+            if variant_to_overwrite.config_parameters == {}:  # type: ignore
+                logger.info(
+                    f"Updating variant {str(variant_to_overwrite.id)} parameters with {payload.parameters}"
+                )
                 await app_manager.update_variant_parameters(
                     app_variant_id=str(variant_to_overwrite.id),
                     parameters=payload.parameters,

--- a/agenta-backend/agenta_backend/routers/configs_router.py
+++ b/agenta-backend/agenta_backend/routers/configs_router.py
@@ -53,9 +53,11 @@ async def save_config(
                 variant_to_overwrite = variant_db
                 break
 
-        if variant_to_overwrite is not None:
-            if payload.overwrite or variant_to_overwrite.config_parameters == {}:
-                print(f"update_variant_parameters  ===> {payload.overwrite}")
+        if (
+            variant_to_overwrite is not None
+        ):
+            if variant_to_overwrite.config_parameters == {}: # type: ignore
+                logger.info(f"Updating variant {str(variant_to_overwrite.id)} parameters with {payload.parameters}")
                 await app_manager.update_variant_parameters(
                     app_variant_id=str(variant_to_overwrite.id),
                     parameters=payload.parameters,
@@ -73,10 +75,9 @@ async def save_config(
                     status_code=400,
                     detail="Config name already exists. Please use a different name or set overwrite to True.",
                 )
+
         else:
-            print(
-                f"add_variant_from_base_and_config overwrite ===> {payload.overwrite}"
-            )
+            logger.info("Adding variant from base and config")
             await db_manager.add_variant_from_base_and_config(
                 base_db=base_db,
                 new_config_name=payload.config_name,

--- a/agenta-backend/agenta_backend/services/db_manager.py
+++ b/agenta-backend/agenta_backend/services/db_manager.py
@@ -1781,7 +1781,10 @@ async def update_variant_parameters(
             raise NoResultFound(f"App variant with id {app_variant_id} not found")
 
         # Update associated ConfigDB parameters
-        app_variant_db.config_parameters.update(parameters)
+        if parameters == {}:
+            app_variant_db.config_parameters = {}
+        else:
+            app_variant_db.config_parameters.update(parameters)
 
         # ...and variant versioning
         app_variant_db.revision += 1  # type: ignore

--- a/agenta-cli/agenta/cli/variant_commands.py
+++ b/agenta-cli/agenta/cli/variant_commands.py
@@ -478,13 +478,6 @@ def serve_cli(ctx, app_folder: str, file_name: str, overwrite: bool):
         return
 
     try:
-        api_key = helper.get_global_config("api_key")
-    except Exception as e:
-        click.echo(click.style("Failed to retrieve the api key.", fg="red"))
-        click.echo(click.style(f"Error message: {str(e)}", fg="red"))
-        return
-
-    try:
         variant_id = add_variant(
             app_folder=app_folder, file_name=file_name, host=host, overwrite=overwrite
         )

--- a/agenta-cli/agenta/client/api.py
+++ b/agenta-cli/agenta/client/api.py
@@ -1,12 +1,9 @@
-import os
-import toml
 import time
 import click
 from typing import Dict
-from pathlib import Path
-from agenta.client.backend import client
-from agenta.client.api_models import Image
 from requests.exceptions import RequestException
+
+from agenta.client.api_models import Image
 from agenta.client.backend.client import AgentaApi
 from agenta.client.exceptions import APIRequestError
 

--- a/agenta-cli/agenta/client/backend/resources/configs/client.py
+++ b/agenta-cli/agenta/client/backend/resources/configs/client.py
@@ -79,7 +79,6 @@ class ConfigsClient:
         base_id: str,
         config_name: str,
         parameters: typing.Dict[str, typing.Any],
-        overwrite: bool,
     ) -> typing.Any:
         """
         Parameters:
@@ -88,8 +87,6 @@ class ConfigsClient:
             - config_name: str.
 
             - parameters: typing.Dict[str, typing.Any].
-
-            - overwrite: bool.
         ---
         from agenta.client import AgentaApi
 
@@ -101,7 +98,6 @@ class ConfigsClient:
             base_id="base_id",
             config_name="config_name",
             parameters={},
-            overwrite=True,
         )
         """
         _response = self._client_wrapper.httpx_client.request(
@@ -112,7 +108,6 @@ class ConfigsClient:
                     "base_id": base_id,
                     "config_name": config_name,
                     "parameters": parameters,
-                    "overwrite": overwrite,
                 }
             ),
             headers=self._client_wrapper.get_headers(),
@@ -255,7 +250,6 @@ class AsyncConfigsClient:
         base_id: str,
         config_name: str,
         parameters: typing.Dict[str, typing.Any],
-        overwrite: bool,
     ) -> typing.Any:
         """
         Parameters:
@@ -264,8 +258,6 @@ class AsyncConfigsClient:
             - config_name: str.
 
             - parameters: typing.Dict[str, typing.Any].
-
-            - overwrite: bool.
         ---
         from agenta.client import AsyncAgentaApi
 
@@ -288,7 +280,6 @@ class AsyncConfigsClient:
                     "base_id": base_id,
                     "config_name": config_name,
                     "parameters": parameters,
-                    "overwrite": overwrite,
                 }
             ),
             headers=self._client_wrapper.get_headers(),

--- a/agenta-cli/agenta/sdk/agenta_init.py
+++ b/agenta-cli/agenta/sdk/agenta_init.py
@@ -103,7 +103,9 @@ class Config:
             self.persist = False
         else:
             self.persist = True
-            self.client = AgentaApi(base_url=self.host + "/api", api_key="" if not api_key else api_key)
+            self.client = AgentaApi(
+                base_url=self.host + "/api", api_key="" if not api_key else api_key
+            )
 
     def register_default(self, **kwargs):
         """alias for default"""

--- a/agenta-cli/agenta/sdk/agenta_init.py
+++ b/agenta-cli/agenta/sdk/agenta_init.py
@@ -103,35 +103,34 @@ class Config:
             self.persist = False
         else:
             self.persist = True
-            self.client = AgentaApi(base_url=self.host + "/api", api_key=api_key)
+            self.client = AgentaApi(base_url=self.host + "/api", api_key="" if not api_key else api_key)
 
-    def register_default(self, overwrite=False, **kwargs):
+    def register_default(self, **kwargs):
         """alias for default"""
-        return self.default(overwrite=overwrite, **kwargs)
+        return self.default(**kwargs)
 
-    def default(self, overwrite=False, **kwargs):
+    def default(self, **kwargs):
         """Saves the default parameters to the app_name and base_name in case they are not already saved.
         Args:
-            overwrite: Whether to overwrite the existing configuration or not
             **kwargs: A dict containing the parameters
         """
         self.set(
             **kwargs
         )  # In case there is no connectivity, we still can use the default values
         try:
-            self.push(config_name="default", overwrite=overwrite, **kwargs)
+            self.push(config_name="default", **kwargs)
         except Exception as ex:
             logger.warning(
                 "Unable to push the default configuration to the server. %s", str(ex)
             )
 
-    def push(self, config_name: str, overwrite=True, **kwargs):
+    def push(self, config_name: str, **kwargs):
         """Pushes the parameters for the app variant to the server
         Args:
             config_name: Name of the configuration to push to
-            overwrite: Whether to overwrite the existing configuration or not
             **kwargs: A dict containing the parameters
         """
+
         if not self.persist:
             return
         try:
@@ -139,7 +138,6 @@ class Config:
                 base_id=self.base_id,
                 config_name=config_name,
                 parameters=kwargs,
-                overwrite=overwrite,
             )
         except Exception as ex:
             logger.warning(


### PR DESCRIPTION
## Description
This PR resolves the bug that overwrites an app from the CLI, which leads to the configuration not been updated.

### Related Issue
Closes [AGE-396](https://linear.app/agenta/issue/AGE-396/[bug]-overwriting-an-app-from-cli-is-not-updating-the-prompt)

### Changes
- Set `api_key` to an empty string (in OSS) when it is None to avoid fern raising a `NoneType` error during request header serialization.
- Removed the overwrite field from the `SaveConfigPayload` API model and associated arguments to eliminate redundancy and potential confusion.
- Removed the use of the redundant `payload.overwrite` and replaced print statements with `logger.info` for better logging practices in `save_config` API router.
- Ensured that variant parameters are updated accordingly during the overwrite process.
- Removed redundant code in the `serve_cli` variant command in `agenta-cli`.