### PR TITLE
refactor(backend): remove code for deleting db and tables

### DIFF
--- a/agenta-backend/agenta_backend/migrations/mongo_to_postgres/db_engine.py
+++ b/agenta-backend/agenta_backend/migrations/mongo_to_postgres/db_engine.py
@@ -106,20 +106,10 @@ class DBEngine:
         Initialize the database based on the mode and create all tables.
         """
         async with self.engine.begin() as conn:
-            # Drop all existing tables (if needed)
-            # await conn.run_sync(Base.metadata.drop_all)
             # Create tables
             for model in models:
                 await conn.run_sync(model.metadata.create_all)
         logger.info(f"Using {self.mode} database...")
-
-    async def remove_db(self) -> None:
-        """
-        Remove the database based on the mode.
-        """
-        async with self.engine.begin() as conn:
-            for model in models:
-                await conn.run_sync(model.metadata.drop_all)
 
     @asynccontextmanager
     async def get_session(self) -> AsyncGenerator[AsyncSession, None]:

--- a/agenta-backend/agenta_backend/migrations/mongo_to_postgres/migration.py
+++ b/agenta-backend/agenta_backend/migrations/mongo_to_postgres/migration.py
@@ -34,7 +34,6 @@ from agenta_backend.models.db_models import (
 )
 
 from agenta_backend.migrations.mongo_to_postgres.utils import (
-    drop_all_tables,
     create_all_tables,
     print_migration_report,
     store_mapping,

--- a/agenta-backend/agenta_backend/migrations/mongo_to_postgres/migration.py
+++ b/agenta-backend/agenta_backend/migrations/mongo_to_postgres/migration.py
@@ -501,7 +501,6 @@ async def transform_evaluation_scenario(scenario):
 
 async def main():
     try:
-        await drop_all_tables()
         await create_all_tables(tables=tables)
         await migrate_collection("users", UserDB, transform_user)
         await migrate_collection("docker_images", ImageDB, transform_image)

--- a/agenta-backend/agenta_backend/migrations/mongo_to_postgres/utils.py
+++ b/agenta-backend/agenta_backend/migrations/mongo_to_postgres/utils.py
@@ -25,16 +25,6 @@ BATCH_SIZE = 1000
 migration_report = {}
 
 
-async def drop_all_tables():
-    """Drop all tables in the database."""
-    async with db_engine.engine.begin() as conn:
-        await conn.run_sync(Base.metadata.reflect)
-        # Drop all tables with CASCADE option
-        for table in reversed(Base.metadata.sorted_tables):
-            await conn.execute(text(f"DROP TABLE IF EXISTS {table.name} CASCADE"))
-    print("\n====================== All tables are dropped.\n")
-
-
 async def create_all_tables(tables):
     """Create all tables in the database."""
     async with db_engine.engine.begin() as conn:

--- a/agenta-backend/agenta_backend/models/db_engine.py
+++ b/agenta-backend/agenta_backend/models/db_engine.py
@@ -114,10 +114,20 @@ class DBEngine:
             raise ValueError("Postgres URI cannot be None.")
 
         async with self.engine.begin() as conn:
-            # Drop and create tables if needed
+            # Drop all existing tables (if needed)
+            # await conn.run_sync(Base.metadata.drop_all)
+            # Create tables
             for model in models:
                 await conn.run_sync(model.metadata.create_all)
-        logger.info(f"Using PostgreSQL database...")
+        logger.info(f"Using {self.mode} database...")
+
+    async def remove_db(self) -> None:
+        """
+        Remove the database based on the mode.
+        """
+        async with self.engine.begin() as conn:
+            for model in models:
+                await conn.run_sync(model.metadata.drop_all)
 
     async def initialize_mongodb(self):
         """

--- a/agenta-backend/agenta_backend/models/db_engine.py
+++ b/agenta-backend/agenta_backend/models/db_engine.py
@@ -114,20 +114,10 @@ class DBEngine:
             raise ValueError("Postgres URI cannot be None.")
 
         async with self.engine.begin() as conn:
-            # Drop all existing tables (if needed)
-            # await conn.run_sync(Base.metadata.drop_all)
-            # Create tables
+            # Drop and create tables if needed
             for model in models:
                 await conn.run_sync(model.metadata.create_all)
-        logger.info(f"Using {self.mode} database...")
-
-    async def remove_db(self) -> None:
-        """
-        Remove the database based on the mode.
-        """
-        async with self.engine.begin() as conn:
-            for model in models:
-                await conn.run_sync(model.metadata.drop_all)
+        logger.info(f"Using PostgreSQL database...")
 
     async def initialize_mongodb(self):
         """
@@ -160,6 +150,15 @@ class DBEngine:
             await self.initialize_async_postgres()
         else:
             await self.initialize_async_postgres()
+
+    async def remove_db(self) -> None:
+        """
+        Remove the database based on the mode.
+        """
+
+        async with self.engine.begin() as conn:
+            for model in models:
+                await conn.run_sync(model.metadata.drop_all)
 
     @asynccontextmanager
     async def get_session(self) -> AsyncGenerator[AsyncSession, None]:

--- a/agenta-backend/agenta_backend/models/db_engine.py
+++ b/agenta-backend/agenta_backend/models/db_engine.py
@@ -151,15 +151,6 @@ class DBEngine:
         else:
             await self.initialize_async_postgres()
 
-    async def remove_db(self) -> None:
-        """
-        Remove the database based on the mode.
-        """
-
-        async with self.engine.begin() as conn:
-            for model in models:
-                await conn.run_sync(model.metadata.drop_all)
-
     @asynccontextmanager
     async def get_session(self) -> AsyncGenerator[AsyncSession, None]:
         session = self.async_session()


### PR DESCRIPTION
The code was used when working on migration with main goal is to have a fresh state of tables when we adjust the migration script.