### PR TITLE
 [Bug fix]: CLI overwriting an app does not update configuration #1863 

### DIFF
--- a/agenta-backend/agenta_backend/services/db_manager.py
+++ b/agenta-backend/agenta_backend/services/db_manager.py
@@ -1781,7 +1781,10 @@ async def update_variant_parameters(
             raise NoResultFound(f"App variant with id {app_variant_id} not found")
 
         # Update associated ConfigDB parameters
-        app_variant_db.config_parameters.update(parameters)
+        if parameters == {}:
+            app_variant_db.config_parameters = {}
+        else:
+            app_variant_db.config_parameters.update(parameters)
 
         # ...and variant versioning
         app_variant_db.revision += 1  # type: ignore

--- a/agenta-cli/agenta/sdk/agenta_init.py
+++ b/agenta-cli/agenta/sdk/agenta_init.py
@@ -95,7 +95,7 @@ class AgentaSingleton:
 
 
 class Config:
-    def __init__(self, base_id: str, host: str, api_key: str = ""):
+    def __init__(self, base_id: str, host: str, api_key: Optional[str]):
         self.base_id = base_id
         self.host = host
 
@@ -103,7 +103,9 @@ class Config:
             self.persist = False
         else:
             self.persist = True
-            self.client = AgentaApi(base_url=self.host + "/api", api_key=api_key)
+            self.client = AgentaApi(
+                base_url=self.host + "/api", api_key=api_key if api_key else ""
+            )
 
     def register_default(self, overwrite=False, **kwargs):
         """alias for default"""


### PR DESCRIPTION
## Description
This PR resolves the bug that overwrites an app from the CLI, which leads to the configuration not been updated.

### Related Issue
Closes [AGE-396](https://linear.app/agenta/issue/AGE-396/[bug]-overwriting-an-app-from-cli-is-not-updating-the-prompt)