### PR TITLE
[Bug Fix]: Updating template table fails

### DIFF
--- a/agenta-backend/agenta_backend/services/db_manager.py
+++ b/agenta-backend/agenta_backend/services/db_manager.py
@@ -2417,9 +2417,11 @@ async def add_template(**kwargs: dict) -> str:
     """
 
     async with db_engine.get_session() as session:
-        result = await session.execute(
-            select(TemplateDB).filter_by(tag_id=kwargs["tag_id"])
-        )
+        conditions = [
+            TemplateDB.tag_id == kwargs["tag_id"],
+            TemplateDB.name == kwargs["name"],
+        ]
+        result = await session.execute(select(TemplateDB).where(or_(*conditions)))
         existing_template = result.scalars().first()
 
         if existing_template is None:


### PR DESCRIPTION
## Description
This PR updates the database query used to retrieve templates to include an additional filter condition.

### Related Issue
Closes [AGE-408](https://linear.app/agenta/issue/AGE-408/[bug]-updating-template-table-fails)