### PR TITLE
[Enhancement]: remove redundant v2BodySchema in getBodySchemaName

### DIFF
--- a/agenta-web/src/lib/helpers/openapi_parser.ts
+++ b/agenta-web/src/lib/helpers/openapi_parser.ts
@@ -3,20 +3,10 @@
 import {GenericObject, Parameter} from "../Types"
 
 const getBodySchemaName = (schema: GenericObject): string => {
-    // Try v2 structure first
-    const v2BodySchemaRef =
-        schema?.paths?.["/generate"]?.post?.requestBody?.content?.["application/json"]?.schema?.[
-            "allOf"
-        ]?.[0]?.["$ref"]
-
-    // If v2 structure doesn't exist, fall back to v1 structure
-    const v1BodySchemaRef =
+    const bodySchemaRef =
         schema?.paths?.["/generate"]?.post?.requestBody?.content?.["application/json"]?.schema?.[
             "$ref"
         ]
-
-    // Determine the body schema reference to use
-    const bodySchemaRef = v2BodySchemaRef || v1BodySchemaRef
 
     // Return the last part of the reference or an empty string
     return bodySchemaRef?.split("/")?.pop() || ""


### PR DESCRIPTION
## Description
The PR updates the `getBodySchemaName` function by eliminating redundant code that handled the deployed LLM application body schema when pydantic v2. 

### Changes
- Removed v2 schema structure handling from `getBodySchemaName` function