### PR TITLE
[Hot fix]: ignore permission to check human evaluation access in the case object_db is None

### DIFF
--- a/agenta-backend/agenta_backend/routers/container_router.py
+++ b/agenta-backend/agenta_backend/routers/container_router.py
@@ -180,7 +180,7 @@ async def construct_app_container_url(
         object_db = None
 
     # Check app access
-    if isCloudEE():
+    if isCloudEE() and object_db is not None:
         has_permission = await check_action_access(
             user_uid=request.state.user_id,
             object=object_db,


### PR DESCRIPTION
## Description
This PR is a hot fix in the backend to address the issue where permission access for application being triggered when the variant had been deleted.

### Parent PR
[AGE-414](https://github.com/Agenta-AI/agenta/pull/1872)

### Changes
- Updated condition to ensure that permission to view evaluation is triggered only when `object_db` is provided.
