### PR TITLE
[Bug] TypeError: e.localeCompare is not a function

### DIFF
--- a/agenta-web/src/lib/helpers/evaluate.ts
+++ b/agenta-web/src/lib/helpers/evaluate.ts
@@ -333,10 +333,20 @@ const getCustomComparator = (type: CellDataType) => (valueA: string, valueB: str
         const num = parseFloat(val || "0")
         return isNaN(num) ? 0 : num
     }
-    if (type === "date") return dayjs(valueA).diff(dayjs(valueB))
-    if (type === "text") return valueA.localeCompare(valueB)
-    if (type === "number") return getNumber(valueA) - getNumber(valueB)
-    return 0
+
+    valueA = String(valueA)
+    valueB = String(valueB)
+
+    switch (type) {
+        case "date":
+            return dayjs(valueA).diff(dayjs(valueB))
+        case "text":
+            return valueA.localeCompare(valueB)
+        case "number":
+            return getNumber(valueA) - getNumber(valueB)
+        default:
+            return 0
+    }
 }
 
 export const removeCorrectAnswerPrefix = (str: string) => {


### PR DESCRIPTION
### Description 
Fix Custom Comparator to Convert Boolean Type to Text

### Related Issue
Closes [AGE-419](https://linear.app/agenta/issue/AGE-419/[bug]-typeerror-elocalecompare-is-not-a-function)

### Steps to Reproduce the Issue:
1. Create an evaluator, e.g., Exact Match.
2. Start a new evaluation with the evaluator.
3. Go to the Evaluation Results page.
4. Click on the Evaluator column with boolean values to rearrange the order.
5. See Error.

https://github.com/user-attachments/assets/8566b725-1cf2-4156-a6f3-3283d2738018

