### PR TITLE
fix(frontend): Test creation in single model eval does not work in table view

### DIFF
--- a/agenta-web/src/components/EvaluationTable/SingleModelEvaluationTable.tsx
+++ b/agenta-web/src/components/EvaluationTable/SingleModelEvaluationTable.tsx
@@ -193,7 +193,7 @@ const SingleModelEvaluationTable: React.FC<EvaluationTableProps> = ({
         debounce((data: Partial<EvaluationScenario>, scenarioId) => {
             updateEvaluationScenarioData(scenarioId, data)
         }, 800),
-        [evaluationScenarios],
+        [rows],
     )
 
     useEffect(() => {
@@ -278,7 +278,7 @@ const SingleModelEvaluationTable: React.FC<EvaluationTableProps> = ({
             .then(() => {
                 Object.keys(data).forEach((key) => {
                     setRowValue(
-                        evaluationScenarios.findIndex((item) => item.id === id),
+                        rows.findIndex((item) => item.id === id),
                         key,
                         data[key as keyof EvaluationScenario],
                     )

--- a/agenta-web/src/components/Evaluations/EvaluationCardView/index.tsx
+++ b/agenta-web/src/components/Evaluations/EvaluationCardView/index.tsx
@@ -4,8 +4,6 @@ import {
     LeftOutlined,
     LoadingOutlined,
     PlayCircleOutlined,
-    PushpinFilled,
-    PushpinOutlined,
     QuestionCircleOutlined,
     RightOutlined,
 } from "@ant-design/icons"
@@ -18,7 +16,6 @@ import {ABTestingEvaluationTableRow} from "@/components/EvaluationTable/ABTestin
 import AlertPopup from "@/components/AlertPopup/AlertPopup"
 import {useLocalStorage} from "usehooks-ts"
 import {testsetRowToChatMessages} from "@/lib/helpers/testset"
-import {safeParse} from "@/lib/helpers/utils"
 import {debounce} from "lodash"
 import {EvaluationType} from "@/lib/enums"
 import ParamsForm from "@/components/Playground/ParamsForm/ParamsForm"


### PR DESCRIPTION
### Description
This Pull Request addresses an issue in the Single Model Test Evaluation where modifications made to the Expected Output column are not saved when creating a new test set.

### Related Issue
Closes [AGE-399](https://linear.app/agenta/issue/AGE-399/[bug]-test-creation-in-single-model-eval-does-not-work-in-table-view)

### Steps to Reproduce the Issue:
1. Create a single model evaluation.
2. Move to table view.
3. Create an annotation (modify the correct answer).
4. Click on Save test set.
5. You will find that the newly created test set does not include the modifications you made.

[Jam Recording](https://jam.dev/c/f8146d1c-52e6-45bc-b325-16201a7fa7da)