### PR TITLE
Fix: resolved the title warning issue

### DIFF
--- a/agenta-web/src/pages/_app.tsx
+++ b/agenta-web/src/pages/_app.tsx
@@ -1,6 +1,7 @@
 import {useEffect} from "react"
 import type {AppProps} from "next/app"
 import {useRouter} from "next/router"
+import Head from "next/head"
 
 import posthog from "posthog-js"
 import {PostHogProvider} from "posthog-js/react"
@@ -39,16 +40,22 @@ export default function App({Component, pageProps}: AppProps) {
         }
     }, [])
     return (
-        <PostHogProvider client={posthog}>
-            <ThemeContextProvider>
-                <ProfileContextProvider>
-                    <AppContextProvider>
-                        <Layout>
-                            <Component {...pageProps} />
-                        </Layout>
-                    </AppContextProvider>
-                </ProfileContextProvider>
-            </ThemeContextProvider>
-        </PostHogProvider>
+        <>
+            <Head>
+                <title>Agenta: The LLMOps platform.</title>
+                <link rel="shortcut icon" href="/assets/favicon.ico" />
+            </Head>
+            <PostHogProvider client={posthog}>
+                <ThemeContextProvider>
+                    <ProfileContextProvider>
+                        <AppContextProvider>
+                            <Layout>
+                                <Component {...pageProps} />
+                            </Layout>
+                        </AppContextProvider>
+                    </ProfileContextProvider>
+                </ThemeContextProvider>
+            </PostHogProvider>
+        </>
     )
 }

--- a/agenta-web/src/pages/_document.tsx
+++ b/agenta-web/src/pages/_document.tsx
@@ -3,10 +3,7 @@ import {Html, Head, Main, NextScript} from "next/document"
 export default function Document() {
     return (
         <Html lang="en" className="antialiased">
-            <Head>
-                <title>Agenta: The LLMOps platform.</title>
-                <link rel="shortcut icon" href="/assets/favicon.ico" />
-            </Head>
+            <Head />
             <body>
                 <Main />
                 <NextScript />


### PR DESCRIPTION
**Description:**

`Warning: <title> should not be used in _document.js's <Head>.` 

Fixed the title warning issue by moving the title element from the`_document.tsx` file to the `_app.tsx` file.

**Resources:**
- [<title> should not be used in _document.js <Head>](https://nextjs.org/docs/messages/no-document-title)
- [Missing Document Components](https://nextjs.org/docs/messages/missing-document-component)