### PR TITLE
[Feature]: Implement JSON Diff Evaluator

### DIFF
--- a/agenta-backend/agenta_backend/pytest.ini
+++ b/agenta-backend/agenta_backend/pytest.ini
@@ -1,2 +1,0 @@
-[pytest]
-DATABASE_MODE=test

--- a/agenta-backend/agenta_backend/resources/evaluators/evaluators.py
+++ b/agenta-backend/agenta_backend/resources/evaluators/evaluators.py
@@ -102,14 +102,21 @@ evaluators = [
                 "type": "boolean",
                 "default": False,
                 "advanced": True,
-                "description": "If set to True, we will compare the keys and the values type. Otherwise, we will compare the keys, the values and the values type."
+                "description": "If set to True, we will compare the keys and the values type. Otherwise, we will compare the keys, the values and the values type.",
             },
             "predict_keys": {
                 "label": "Include prediction keys",
                 "type": "boolean",
                 "default": False,
                 "advanced": True,
-                "description": "If set to True, we will check the reference (ground truth) keys. Othwerise, we will check both the reference (ground truth) and prediction (app output) keys."
+                "description": "If set to True, we will check the reference (ground truth) keys. Othwerise, we will check both the reference (ground truth) and prediction (app output) keys.",
+            },
+            "case_insensitive_keys": {
+                "label": "Enable Case-sensitive keys",
+                "type": "boolean",
+                "default": False,
+                "advanced": True,
+                "description": "If set to True, we will treat keys as case-insensitive, meaning 'key', 'Key', and 'KEY' would all be considered equivalent. Otherwise, we will not.",
             },
             "correct_answer_key": {
                 "label": "Expected Answer Column",
@@ -119,7 +126,7 @@ evaluators = [
                 "ground_truth_key": True,  # Tells the frontend that is the name of the column in the test set that should be shown as a ground truth to the user
                 "description": "The name of the column in the test data that contains the correct answer",
             },
-        }
+        },
     },
     {
         "name": "AI Critique",

--- a/agenta-backend/agenta_backend/resources/evaluators/evaluators.py
+++ b/agenta-backend/agenta_backend/resources/evaluators/evaluators.py
@@ -92,6 +92,36 @@ evaluators = [
         "description": "JSON Field Match evaluator compares specific fields within JSON (JavaScript Object Notation) data. This matching can involve finding similarities or correspondences between fields in different JSON objects.",
     },
     {
+        "name": "JSON Diff Match",
+        "key": "auto_json_diff",
+        "direct_use": False,
+        "description": "JSON Diff evaluator compares two JSON objects to identify differences. It highlights discrepancies, additions, deletions, and modifications between the objects, providing a clear report of how they differ.",
+        "settings_template": {
+            "compare_schema_only": {
+                "label": "Compare Schema Only",
+                "type": "boolean",
+                "default": False,
+                "advanced": True,
+                "description": "If set to True, we will compare the keys and the values type. Otherwise, we will compare the keys, the values and the values type."
+            },
+            "predict_keys": {
+                "label": "Include prediction keys",
+                "type": "boolean",
+                "default": False,
+                "advanced": True,
+                "description": "If set to True, we will check the reference (ground truth) keys. Othwerise, we will check both the reference (ground truth) and prediction (app output) keys."
+            },
+            "correct_answer_key": {
+                "label": "Expected Answer Column",
+                "default": "correct_answer",
+                "type": "string",
+                "advanced": True,  # Tells the frontend that this setting is advanced and should be hidden by default
+                "ground_truth_key": True,  # Tells the frontend that is the name of the column in the test set that should be shown as a ground truth to the user
+                "description": "The name of the column in the test data that contains the correct answer",
+            },
+        }
+    },
+    {
         "name": "AI Critique",
         "key": "auto_ai_critique",
         "direct_use": False,

--- a/agenta-backend/agenta_backend/services/evaluators_service.py
+++ b/agenta-backend/agenta_backend/services/evaluators_service.py
@@ -2,7 +2,7 @@ import re
 import json
 import logging
 import traceback
-from typing import Any, Dict
+from typing import Any, Dict, Union
 
 import httpx
 from openai import OpenAI
@@ -476,6 +476,134 @@ def auto_contains_json(
         )
 
 
+def flatten_json(json_obj: Union[list, dict]) -> Dict[str, Any]:
+    """
+    This function takes a (nested) JSON object and flattens it into a single-level dictionary where each key represents the path to the value in the original JSON structure. This is done recursively, ensuring that the full hierarchical context is preserved in the keys.
+
+    Args:
+        json_obj (Union[list, dict]): The (nested) JSON object to flatten. It can be either a dictionary or a list.
+
+    Returns:
+        Dict[str, Any]: The flattened JSON object as a dictionary, with keys representing the paths to the values in the original structure.
+    """
+
+    output = {}
+
+    def flatten(obj: Union[list, dict], path: str = "") -> None:
+        if isinstance(obj, dict):
+            for key, value in obj.items():
+                new_key = f"{path}.{key}" if path else key
+                if isinstance(value, (dict, list)):
+                    flatten(value, new_key)
+                else:
+                    output[new_key] = value
+
+        elif isinstance(obj, list):
+            for index, value in enumerate(obj):
+                new_key = f"{path}.{index}" if path else str(index)
+                if isinstance(value, (dict, list)):
+                    flatten(value, new_key)
+                else:
+                    output[new_key] = value
+
+    flatten(json_obj)
+    return output
+
+
+def compare_jsons(
+    ground_truth: Union[list, dict],
+    app_output: Union[list, dict],
+    settings_values: dict,
+):
+    """
+    This function takes two JSON objects (ground truth and application output), flattens them using the `flatten_json` function, and then compares the fields.
+
+    Args:
+        ground_truth (list | dict): The ground truth
+        app_output (list | dict): The application output
+        settings_values: dict: The advanced configuration of the evaluator
+
+    Returns:
+        the average score between both JSON objects
+    """
+
+    def normalize_keys(d: Dict[str, Any], case_insensitive: bool) -> Dict[str, Any]:
+        if not case_insensitive:
+            return d
+        return {k.lower(): v for k, v in d.items()}
+
+    def diff(ground_truth: Any, app_output: Any, compare_schema_only: bool) -> float:
+        gt_key, gt_value = next(iter(ground_truth.items()))
+        ao_key, ao_value = next(iter(app_output.items()))
+
+        if compare_schema_only:
+            return (
+                1.0 if (gt_key == ao_key and type(gt_value) == type(ao_value)) else 0.0
+            )
+        return 1.0 if (gt_key == ao_key and gt_value == ao_value) else 0.0
+
+    flattened_ground_truth = flatten_json(ground_truth)
+    flattened_app_output = flatten_json(app_output)
+
+    keys = flattened_ground_truth.keys()
+    if settings_values.get("predict_keys", False):
+        keys = set(keys).union(flattened_app_output.keys())
+
+    cumulated_score = 0.0
+    no_of_keys = len(keys)
+
+    compare_schema_only = settings_values.get("compare_schema_only", False)
+    case_insensitive_keys = settings_values.get("case_insensitive_keys", False)
+    flattened_ground_truth = normalize_keys(
+        flattened_ground_truth, case_insensitive_keys
+    )
+    flattened_app_output = normalize_keys(flattened_app_output, case_insensitive_keys)
+
+    for key in keys:
+        ground_truth_value = flattened_ground_truth.get(key, None)
+        llm_app_output_value = flattened_app_output.get(key, None)
+
+        key_score = 0.0
+        if ground_truth_value and llm_app_output_value:
+            key_score += diff(
+                {key: ground_truth_value},
+                {key: llm_app_output_value},
+                compare_schema_only,
+            )
+
+        cumulated_score += key_score
+
+    average_score = cumulated_score / no_of_keys
+    return average_score
+
+
+def auto_json_diff(
+    inputs: Dict[str, Any],  # pylint: disable=unused-argument
+    output: Any,
+    data_point: Dict[str, Any],  # pylint: disable=unused-argument
+    app_params: Dict[str, Any],  # pylint: disable=unused-argument
+    settings_values: Dict[str, Any],  # pylint: disable=unused-argument
+    lm_providers_keys: Dict[str, Any],  # pylint: disable=unused-argument
+) -> Result:
+    try:
+        correct_answer = get_correct_answer(data_point, settings_values)
+        average_score = compare_jsons(
+            ground_truth=json.loads(correct_answer),
+            app_output=json.loads(output),
+            settings_values=settings_values,
+        )
+        return Result(type="number", value=average_score)
+    except (ValueError, json.JSONDecodeError, Exception):
+        return Result(
+            type="error",
+            value=None,
+            error=Error(
+                message="Error during JSON diff evaluation",
+                stacktrace=traceback.format_exc(),
+            ),
+        )
+
+
 def levenshtein_distance(s1, s2):
     if len(s1) < len(s2):
         return levenshtein_distance(s2, s1)  # pylint: disable=arguments-out-of-order
@@ -589,6 +717,7 @@ EVALUATOR_FUNCTIONS = {
     "auto_contains_any": auto_contains_any,
     "auto_contains_all": auto_contains_all,
     "auto_contains_json": auto_contains_json,
+    "auto_json_diff": auto_json_diff,
     "auto_levenshtein_distance": auto_levenshtein_distance,
     "auto_similarity_match": auto_similarity_match,
 }

--- a/agenta-backend/agenta_backend/services/evaluators_service.py
+++ b/agenta-backend/agenta_backend/services/evaluators_service.py
@@ -565,7 +565,7 @@ def compare_jsons(
 
         key_score = 0.0
         if ground_truth_value and llm_app_output_value:
-            key_score += diff(
+            key_score = diff(
                 {key: ground_truth_value},
                 {key: llm_app_output_value},
                 compare_schema_only,

--- a/agenta-backend/agenta_backend/services/evaluators_service.py
+++ b/agenta-backend/agenta_backend/services/evaluators_service.py
@@ -588,7 +588,7 @@ def auto_json_diff(
     try:
         correct_answer = get_correct_answer(data_point, settings_values)
         average_score = compare_jsons(
-            ground_truth=json.loads(correct_answer),
+            ground_truth=correct_answer,
             app_output=json.loads(output),
             settings_values=settings_values,
         )

--- a/agenta-backend/agenta_backend/tasks/evaluations.py
+++ b/agenta-backend/agenta_backend/tasks/evaluations.py
@@ -432,6 +432,7 @@ async def aggregate_evaluator_results(
             "auto_contains_any",
             "auto_contains_all",
             "auto_contains_json",
+            "auto_json_diff",
             "auto_levenshtein_distance",
         ]:
             result = aggregation_service.aggregate_float(results)

--- a/agenta-backend/agenta_backend/tests/unit/test_evaluators.py
+++ b/agenta-backend/agenta_backend/tests/unit/test_evaluators.py
@@ -179,37 +179,56 @@ def test_auto_contains_json(output, expected):
     "ground_truth, app_output, settings_values, expected_score",
     [
         (
-            {"user": {"name": "John", "details": {"age": 30, "location": "New York"}}},
-            {"user": {"name": "John", "details": {"age": 30, "location": "New York"}}},
+            {
+                "correct_answer": {
+                    "user": {
+                        "name": "John",
+                        "details": {"age": 30, "location": "New York"},
+                    }
+                }
+            },
+            '{"user": {"name": "John", "details": {"age": 30, "location": "New York"}}}',
             {
                 "predict_keys": True,
                 "compare_schema_only": False,
                 "case_insensitive_keys": False,
+                "correct_answer_key": "correct_answer",
             },
             1.0,
         ),
         (
-            {"user": {"name": "John", "details": {"age": 30, "location": "New York"}}},
             {
-                "user": {
-                    "name": "John",
-                    "details": {"age": "30", "location": "New York"},
+                "correct_answer": {
+                    "user": {
+                        "name": "John",
+                        "details": {"age": 30, "location": "New York"},
+                    }
                 }
             },
+            '{"user": {"name": "John", "details": {"age": "30", "location": "New York"}}}',
             {
                 "predict_keys": True,
                 "compare_schema_only": True,
                 "case_insensitive_keys": False,
+                "correct_answer_key": "correct_answer",
             },
             0.6666666666666666,
         ),
         (
-            {"user": {"name": "John", "details": {"age": 30, "location": "New York"}}},
-            {"USER": {"NAME": "John", "DETAILS": {"AGE": 30, "LOCATION": "New York"}}},
+            {
+                "correct_answer": {
+                    "user": {
+                        "name": "John",
+                        "details": {"age": 30, "location": "New York"},
+                    }
+                }
+            },
+            '{"USER": {"NAME": "John", "DETAILS": {"AGE": 30, "LOCATION": "New York"}}}',
             {
                 "predict_keys": True,
                 "compare_schema_only": False,
                 "case_insensitive_keys": True,
+                "correct_answer_key": "correct_answer",
             },
             0.5,
         ),

--- a/agenta-backend/agenta_backend/tests/unit/test_evaluators.py
+++ b/agenta-backend/agenta_backend/tests/unit/test_evaluators.py
@@ -8,6 +8,7 @@ from agenta_backend.services.evaluators_service import (
     auto_contains_any,
     auto_contains_all,
     auto_contains_json,
+    auto_json_diff,
 )
 
 
@@ -172,6 +173,51 @@ def test_auto_contains_all(output, substrings, case_sensitive, expected):
 def test_auto_contains_json(output, expected):
     result = auto_contains_json({}, output, {}, {}, {}, {})
     assert result.value == expected
+
+
+@pytest.mark.parametrize(
+    "ground_truth, app_output, settings_values, expected_score",
+    [
+        (
+            {"user": {"name": "John", "details": {"age": 30, "location": "New York"}}},
+            {"user": {"name": "John", "details": {"age": 30, "location": "New York"}}},
+            {
+                "predict_keys": True,
+                "compare_schema_only": False,
+                "case_insensitive_keys": False,
+            },
+            1.0,
+        ),
+        (
+            {"user": {"name": "John", "details": {"age": 30, "location": "New York"}}},
+            {
+                "user": {
+                    "name": "John",
+                    "details": {"age": "30", "location": "New York"},
+                }
+            },
+            {
+                "predict_keys": True,
+                "compare_schema_only": True,
+                "case_insensitive_keys": False,
+            },
+            0.6666666666666666,
+        ),
+        (
+            {"user": {"name": "John", "details": {"age": 30, "location": "New York"}}},
+            {"USER": {"NAME": "John", "DETAILS": {"AGE": 30, "LOCATION": "New York"}}},
+            {
+                "predict_keys": True,
+                "compare_schema_only": False,
+                "case_insensitive_keys": True,
+            },
+            0.5,
+        ),
+    ],
+)
+def test_auto_json_diff(ground_truth, app_output, settings_values, expected_score):
+    result = auto_json_diff({}, app_output, ground_truth, {}, settings_values, {})
+    assert result.value == expected_score
 
 
 @pytest.mark.parametrize(

--- a/agenta-web/src/lib/enums.ts
+++ b/agenta-web/src/lib/enums.ts
@@ -17,4 +17,5 @@ export enum EvaluationType {
     auto_webhook_test = "auto_webhook_test",
     single_model_test = "single_model_test",
     field_match_test = "field_match_test",
+    auto_json_diff = "auto_json_diff"
 }

--- a/agenta-web/src/lib/enums.ts
+++ b/agenta-web/src/lib/enums.ts
@@ -17,5 +17,5 @@ export enum EvaluationType {
     auto_webhook_test = "auto_webhook_test",
     single_model_test = "single_model_test",
     field_match_test = "field_match_test",
-    auto_json_diff = "auto_json_diff"
+    auto_json_diff = "auto_json_diff",
 }

--- a/agenta-web/src/lib/helpers/utils.ts
+++ b/agenta-web/src/lib/helpers/utils.ts
@@ -41,6 +41,7 @@ export const EvaluationTypeLabels: Record<EvaluationType, string> = {
     [EvaluationType.custom_code_run]: "Custom Code Run",
     [EvaluationType.auto_regex_test]: "Regex Test",
     [EvaluationType.field_match_test]: "JSON Field Match",
+    [EvaluationType.auto_json_diff]: "JSON Diff Match",
     [EvaluationType.auto_webhook_test]: "Webhook Test",
     [EvaluationType.single_model_test]: "Single Model Test",
 }

--- a/agenta-web/src/services/evaluations/api/index.ts
+++ b/agenta-web/src/services/evaluations/api/index.ts
@@ -41,6 +41,7 @@ const evaluatorIconsMap = {
     auto_webhook_test: webhookImg,
     auto_ai_critique: aiImg,
     auto_custom_code_run: codeImg,
+    auto_json_diff: bracketCurlyImg,
     auto_contains_json: bracketCurlyImg,
 }
 


### PR DESCRIPTION
## Description
This PR introduces a JSON Diff Evaluator that compares the structure and content of two JSON objects (ground truth and application output). The evaluator flattens both JSON objects and compares their fields, providing a similarity score. This implementation includes additional features for advanced configuration.

### Related Issue
Closes [AGE-286](https://linear.app/agenta/issue/AGE-286/create-a-json-evaluator)

### Features
- **Flattening JSON Objects**: Recursively converts nested JSON objects into a single-level dictionary with hierarchical keys.
- **Key Comparison Settings**:
  - `predict_keys`: When enabled, includes keys from both ground truth and application output in the comparison.
  - `compare_schema_only`: When enabled, compares only the schema (keys and types) rather than the values.
  - `case_insensitive_keys`: When enabled, treats keys as case-insensitive.
  
### Changes
- Added `flatten_json` function to handle the flattening of JSON objects.
- Added `compare_jsons` function to perform the comparison and generate a similarity score.
- Implemented `diff` function to calculate the similarity score between individual keys and values.
- Implemented `auto_json_diff` evaluator function that integrates `compare_json` function.
- Added unit tests using `pytest` to ensure the correctness of `auto_json_diff` function.
