### PR TITLE
fix(backend): add init db to create cloud-dev db add init db for clouddev

### DIFF
--- a/docker-assets/postgres/init-db-clouddev.sql
+++ b/docker-assets/postgres/init-db-clouddev.sql
@@ -1,0 +1,1 @@
+CREATE DATABASE agenta_cloud_dev;


### PR DESCRIPTION
Closes: add init db to create cloud-dev db

Requires: https://github.com/Agenta-AI/agenta_cloud/pull/402