### PR TITLE
[Bug Fix]: evaluation fails when using gh docker container

### DIFF
--- a/agenta-backend/agenta_backend/services/deployment_manager.py
+++ b/agenta-backend/agenta_backend/services/deployment_manager.py
@@ -147,34 +147,15 @@ async def validate_image(image: Image) -> bool:
     return True
 
 
-def get_deployment_uri(uri: str, app_container_id: str) -> str:
+def get_deployment_uri(uri: str) -> str:
     """
     Replaces localhost with the appropriate hostname in the given URI.
 
     Args:
         uri (str): The URI to be processed.
-        app_container_id (str): The ID of the app container
 
     Returns:
         str: The processed URI.
     """
-
-    if (
-        os.environ.get("USE_LLM_APP_CONTAINER_ID", False)
-        and app_container_id is not None
-    ):
-        # NOTE: For whoever reads this code block
-        # -----------------------------------------
-        # This block of code is used when running evaluations using the GitHub Compose (docker-compose.gh.yml).
-        # 1. host.docker.internal does not work on all platforms (Windows, Linux, and Mac).
-        #    The issue is that trying to reach the LLM app container from the host.docker.internal does not work from within the Celery worker container.
-        #    This is strange as it works using the dev and prod compose files. :/
-        # 2. I am attaching the following resources for when someone (or I, @abram) will invest more time to figure out a much better solution.
-        #    Resources:
-        #    - https://forums.docker.com/t/how-to-reach-localhost-on-host-from-docker-container/113321/4
-        #    - https://stackoverflow.com/questions/70725881/what-is-the-equivalent-of-add-host-host-docker-internalhost-gateway-in-a-comp
-        # 3. The return code in this block will enable the LLM app container to be reachable from within the Celery worker container when using the GitHub Compose file.
-
-        return f"http://{app_container_id[:12]}"
 
     return uri.replace("http://localhost", "http://host.docker.internal")

--- a/agenta-backend/agenta_backend/services/docker_utils.py
+++ b/agenta-backend/agenta_backend/services/docker_utils.py
@@ -81,7 +81,7 @@ def start_container(
         }
 
         # Merge the default labels with environment-specific labels
-        if os.environ["ENVIRONMENT"] == "production":
+        if os.environ.get("ENVIRONMENT") == "production":
             # Production specific labels
             production_labels = {
                 f"traefik.http.routers.{container_name}.rule": f"Host(`{os.environ['BARE_DOMAIN_NAME']}`) && PathPrefix(`/{uri_path}`)",

--- a/agenta-backend/agenta_backend/tasks/evaluations.py
+++ b/agenta-backend/agenta_backend/tasks/evaluations.py
@@ -126,7 +126,7 @@ def evaluate(
         deployment_db = loop.run_until_complete(
             get_deployment_by_id(str(app_variant_db.base.deployment_id))
         )
-        uri = deployment_manager.get_deployment_uri(uri=deployment_db.uri)  # type: ignore
+        uri = deployment_manager.get_deployment_uri(uri=deployment_db.uri, app_container_id=deployment_db.container_id)  # type: ignore
 
         # 2. Initialize vars
         evaluators_aggregated_data = {

--- a/agenta-backend/agenta_backend/tasks/evaluations.py
+++ b/agenta-backend/agenta_backend/tasks/evaluations.py
@@ -126,7 +126,7 @@ def evaluate(
         deployment_db = loop.run_until_complete(
             get_deployment_by_id(str(app_variant_db.base.deployment_id))
         )
-        uri = deployment_manager.get_deployment_uri(uri=deployment_db.uri, app_container_id=deployment_db.container_id)  # type: ignore
+        uri = deployment_manager.get_deployment_uri(uri=deployment_db.uri)  # type: ignore
 
         # 2. Initialize vars
         evaluators_aggregated_data = {

--- a/docker-compose.gh.yml
+++ b/docker-compose.gh.yml
@@ -111,6 +111,7 @@ services:
             - REDIS_URL=redis://redis:6379/0
             - CELERY_BROKER_URL=amqp://guest@rabbitmq//
             - CELERY_RESULT_BACKEND=redis://redis:6379/0
+            - USE_LLM_APP_CONTAINER_ID=true
             - FEATURE_FLAG=oss
         volumes:
             - /var/run/docker.sock:/var/run/docker.sock

--- a/docker-compose.gh.yml
+++ b/docker-compose.gh.yml
@@ -17,7 +17,6 @@ services:
         environment:
             - POSTGRES_URI=postgresql+asyncpg://username:password@postgres:5432/agenta_oss
             - REDIS_URL=redis://redis:6379/0
-            - ENVIRONMENT=production
             - DATABASE_MODE=v2
             - FEATURE_FLAG=oss
             - AGENTA_TEMPLATE_REPO=agentaai/templates_v2

--- a/docker-compose.gh.yml
+++ b/docker-compose.gh.yml
@@ -110,7 +110,6 @@ services:
             - REDIS_URL=redis://redis:6379/0
             - CELERY_BROKER_URL=amqp://guest@rabbitmq//
             - CELERY_RESULT_BACKEND=redis://redis:6379/0
-            - USE_LLM_APP_CONTAINER_ID=true
             - FEATURE_FLAG=oss
         volumes:
             - /var/run/docker.sock:/var/run/docker.sock


### PR DESCRIPTION
## Description
This PR addresses the issue of the LLM app container being unreachable from the `celery_worker` container when using the GitHub Compose file (docker-compose.gh.yml), causing evaluation to fail.

### Related Issue
Closes [AGE-270](https://linear.app/agenta/issue/AGE-270/[bug]-evaluation-fails-when-using-gh-docker-container)