### PR TITLE
Fix: Ensure CLI catches and reports errors

### DIFF
--- a/agenta-cli/agenta/cli/variant_commands.py
+++ b/agenta-cli/agenta/cli/variant_commands.py
@@ -139,7 +139,7 @@ def add_variant(
 
     except Exception as ex:
         click.echo(click.style(f"Error while building image: {ex}", fg="red"))
-        return None
+        raise
     try:
         if overwrite:
             click.echo(
@@ -166,7 +166,7 @@ def add_variant(
             click.echo(click.style(f"Error while updating variant: {ex}", fg="red"))
         else:
             click.echo(click.style(f"Error while adding variant: {ex}", fg="red"))
-        return None
+        raise
 
     agenta_dir = Path.home() / ".agenta"
     global_toml_file = toml.load(agenta_dir / "config.toml")

--- a/agenta-cli/agenta/cli/variant_commands.py
+++ b/agenta-cli/agenta/cli/variant_commands.py
@@ -461,28 +461,28 @@ def serve_cli(ctx, app_folder: str, file_name: str, overwrite: bool):
             error_msg += "or\n"
             error_msg += ">>> agenta variant serve <filename>.py"
             click.echo(click.style(f"{error_msg}", fg="red"))
-            sys.exit(0)
+            sys.exit(1)
 
     try:
         config_check(app_folder)
     except Exception as e:
         click.echo(click.style("Failed during configuration check.", fg="red"))
         click.echo(click.style(f"Error message: {str(e)}", fg="red"))
-        return
+        sys.exit(1)
 
     try:
         host = get_host(app_folder)
     except Exception as e:
         click.echo(click.style("Failed to retrieve the host.", fg="red"))
         click.echo(click.style(f"Error message: {str(e)}", fg="red"))
-        return
+        sys.exit(1)
 
     try:
         api_key = helper.get_global_config("api_key")
     except Exception as e:
         click.echo(click.style("Failed to retrieve the api key.", fg="red"))
         click.echo(click.style(f"Error message: {str(e)}", fg="red"))
-        return
+        sys.exit(1)
 
     try:
         variant_id = add_variant(
@@ -491,7 +491,7 @@ def serve_cli(ctx, app_folder: str, file_name: str, overwrite: bool):
     except Exception as e:
         click.echo(click.style("Failed to add variant.", fg="red"))
         click.echo(click.style(f"Error message: {str(e)}", fg="red"))
-        return
+        sys.exit(1)
 
     if variant_id:
         try:
@@ -503,9 +503,11 @@ def serve_cli(ctx, app_folder: str, file_name: str, overwrite: bool):
                 "- Second, try restarting the containers (if using Docker Compose)."
             )
             click.echo(click.style(f"{error_msg}", fg="red"))
+            sys.exit(1)
         except Exception as e:
             click.echo(click.style("Failed to start container with LLM app.", fg="red"))
             click.echo(click.style(f"Error message: {str(e)}", fg="red"))
+            sys.exit(1)
 
 
 @variant.command(name="list")


### PR DESCRIPTION
**Problem:**
When running agenta variant serve --overwrite, any resulting error is not caught by the CLI, leading to silent failures in our workflows.

**Solution:**
This PR improves error handling by propagating exceptions in add_variant and incorporating sys.exit(1) calls in serve_cli. These enhancements ensure that errors encountered during variant serving are properly caught and reported, causing the CLI and associated GitHub Actions jobs to fail as intended.

**How to QA it:**
Refer to the example of a silent failure (or any similar workflow job triggered from yesterday):
[Silent Fail Example](https://github.com/Agenta-AI/agenta/actions/runs/10072816938/job/27845533928?pr=1856#step:9:18)

**Impact:**
Once this PR is merged, all PRs triggering the serve-to-cloud workflow will fail until the bug in the cloud is resolved.