### PR TITLE
Fix image deletion in cloud

### DIFF
--- a/agenta-backend/agenta_backend/services/app_manager.py
+++ b/agenta-backend/agenta_backend/services/app_manager.py
@@ -150,6 +150,8 @@ async def update_variant_image(
     await deployment_manager.stop_and_delete_service(deployment)
     await db_manager.remove_deployment(str(deployment.id))
 
+    await db_manager.remove_image(base.image)
+
     # Create a new image instance
     db_image = await db_manager.create_image(
         image_type="image",

--- a/agenta-backend/agenta_backend/services/app_manager.py
+++ b/agenta-backend/agenta_backend/services/app_manager.py
@@ -150,17 +150,6 @@ async def update_variant_image(
     await deployment_manager.stop_and_delete_service(deployment)
     await db_manager.remove_deployment(str(deployment.id))
 
-    if base.image.deletable:
-        try:
-            if isCloudEE():
-                await deployment_manager.remove_repository(base.image.tags)  # type: ignore
-            else:
-                await deployment_manager.remove_image(base.image)
-        except RuntimeError as e:
-            logger.error(f"Failed to remove image {image} {e}")
-        finally:
-            await db_manager.remove_image(base.image)
-
     # Create a new image instance
     db_image = await db_manager.create_image(
         image_type="image",


### PR DESCRIPTION
The original cause of having the bug in overwriting a variant in cloud is the merge of this PR:

https://github.com/Agenta-AI/agenta/pull/1648/files#diff-4af8b049c024bc22c09888d302175367a80b67f5ba7bc0c92e526c5a875d8c0fL154-L155

The removal of `isOssEE()` env is correct however keeping the call to the remove_image was wrong.

The code below was never running and is causing errors in cloud and on top of it not needed.

```
    if isOssEE():
        await deployment_manager.remove_image(base.image)
```