### PR TITLE
feat(backend): AGE-276 and AGE-471 Improves LLM-as-a-judge reliability

### DIFF
--- a/agenta-backend/agenta_backend/resources/evaluators/evaluators.py
+++ b/agenta-backend/agenta_backend/resources/evaluators/evaluators.py
@@ -145,7 +145,7 @@ evaluators = [
         },
     },
     {
-        "name": "AI Critique",
+        "name": "LLM-as-a-judge",
         "key": "auto_ai_critique",
         "direct_use": False,
         "settings_template": {

--- a/agenta-backend/agenta_backend/services/evaluators_service.py
+++ b/agenta-backend/agenta_backend/services/evaluators_service.py
@@ -281,7 +281,7 @@ def auto_ai_critique(
 
         client = OpenAI(api_key=openai_api_key)
         response = client.chat.completions.create(
-            model="gpt-3.5-turbo", messages=messages, temperature=0.8
+            model="gpt-3.5-turbo", messages=messages, temperature=0.01
         )
 
         evaluation_output = response.choices[0].message.content.strip()


### PR DESCRIPTION
Improves the reliabilty of LLM as a judge by using a lower temperature (as done in Ragas for instance) and rename AI critic to the standard name LLM as a judge (in the FE, renaming it in both places would break previously configured evaluators)