### PR TITLE
fix(sdk): AGE-480 Update litellm callbacks with new SDK

### DIFF
--- a/agenta-cli/agenta/client/backend/resources/observability/client.py
+++ b/agenta-cli/agenta/client/backend/resources/observability/client.py
@@ -16,7 +16,6 @@ from ...types.http_validation_error import HttpValidationError
 from ...types.span_detail import SpanDetail
 from ...types.trace_detail import TraceDetail
 from ...types.with_pagination import WithPagination
-from agenta.sdk.tracing.logger import llm_logger as logging
 
 try:
     import pydantic.v1 as pydantic  # type: ignore
@@ -191,7 +190,6 @@ class ObservabilityClient:
             ],
         )
         """
-
         _response = self._client_wrapper.httpx_client.request(
             "POST",
             urllib.parse.urljoin(
@@ -771,7 +769,6 @@ class AsyncObservabilityClient:
             ],
         )
         """
-
         _response = await self._client_wrapper.httpx_client.request(
             "POST",
             urllib.parse.urljoin(

--- a/agenta-cli/agenta/client/backend/resources/observability/client.py
+++ b/agenta-cli/agenta/client/backend/resources/observability/client.py
@@ -16,6 +16,7 @@ from ...types.http_validation_error import HttpValidationError
 from ...types.span_detail import SpanDetail
 from ...types.trace_detail import TraceDetail
 from ...types.with_pagination import WithPagination
+from agenta.sdk.tracing.logger import llm_logger as logging
 
 try:
     import pydantic.v1 as pydantic  # type: ignore
@@ -190,6 +191,7 @@ class ObservabilityClient:
             ],
         )
         """
+
         _response = self._client_wrapper.httpx_client.request(
             "POST",
             urllib.parse.urljoin(
@@ -769,6 +771,7 @@ class AsyncObservabilityClient:
             ],
         )
         """
+
         _response = await self._client_wrapper.httpx_client.request(
             "POST",
             urllib.parse.urljoin(

--- a/agenta-cli/agenta/sdk/tracing/callbacks.py
+++ b/agenta-cli/agenta/sdk/tracing/callbacks.py
@@ -35,13 +35,11 @@ def litellm_handler():
 
         def log_pre_api_call(self, model, messages, kwargs):
             logging.debug("log_pre_api_call()")
+
             call_type = kwargs.get("call_type")
             span_kind = (
                 "llm" if call_type in ["completion", "acompletion"] else "embedding"
             )
-
-            if tracing_context.get() is None:
-                self.context_token = tracing_context.set(TracingContext())
 
             ag.tracing.start_span(
                 name=f"{span_kind}_call",
@@ -61,6 +59,7 @@ def litellm_handler():
 
         def log_stream_event(self, kwargs, response_obj, start_time, end_time):
             logging.debug("log_stream_event()")
+
             ag.tracing.set_status(status="OK")
             ag.tracing.end_span(
                 outputs={
@@ -82,6 +81,7 @@ def litellm_handler():
             self, kwargs, response_obj: ModelResponse, start_time, end_time
         ):
             logging.debug("log_success_event()")
+
             ag.tracing.set_status(status="OK")
             ag.tracing.end_span(
                 outputs={
@@ -101,6 +101,7 @@ def litellm_handler():
             self, kwargs, response_obj: ModelResponse, start_time, end_time
         ):
             logging.debug("log_failure_event()")
+
             ag.tracing.set_status(status="ERROR")
             ag.tracing.set_attributes(
                 {
@@ -130,6 +131,7 @@ def litellm_handler():
             self, kwargs, response_obj, start_time, end_time
         ):
             logging.debug("async_log_stream_event()")
+
             ag.tracing.set_status(status="OK")
             ag.tracing.end_span(
                 outputs={
@@ -170,6 +172,7 @@ def litellm_handler():
             self, kwargs, response_obj, start_time, end_time
         ):
             logging.debug("async_log_failure_event()")
+
             ag.tracing.set_status(status="ERROR")
             ag.tracing.set_attributes(
                 {

--- a/agenta-cli/agenta/sdk/tracing/callbacks.py
+++ b/agenta-cli/agenta/sdk/tracing/callbacks.py
@@ -1,8 +1,5 @@
 import agenta as ag
 
-from agenta.sdk.tracing.tracing_context import tracing_context, TracingContext
-from agenta.sdk.tracing.logger import llm_logger as logging
-
 
 def litellm_handler():
     try:
@@ -34,8 +31,6 @@ def litellm_handler():
             return ag.tracing
 
         def log_pre_api_call(self, model, messages, kwargs):
-            logging.debug("log_pre_api_call()")
-
             call_type = kwargs.get("call_type")
             span_kind = (
                 "llm" if call_type in ["completion", "acompletion"] else "embedding"
@@ -58,8 +53,6 @@ def litellm_handler():
             )
 
         def log_stream_event(self, kwargs, response_obj, start_time, end_time):
-            logging.debug("log_stream_event()")
-
             ag.tracing.set_status(status="OK")
             ag.tracing.end_span(
                 outputs={
@@ -80,8 +73,6 @@ def litellm_handler():
         def log_success_event(
             self, kwargs, response_obj: ModelResponse, start_time, end_time
         ):
-            logging.debug("log_success_event()")
-
             ag.tracing.set_status(status="OK")
             ag.tracing.end_span(
                 outputs={
@@ -100,8 +91,6 @@ def litellm_handler():
         def log_failure_event(
             self, kwargs, response_obj: ModelResponse, start_time, end_time
         ):
-            logging.debug("log_failure_event()")
-
             ag.tracing.set_status(status="ERROR")
             ag.tracing.set_attributes(
                 {
@@ -130,8 +119,6 @@ def litellm_handler():
         async def async_log_stream_event(
             self, kwargs, response_obj, start_time, end_time
         ):
-            logging.debug("async_log_stream_event()")
-
             ag.tracing.set_status(status="OK")
             ag.tracing.end_span(
                 outputs={
@@ -152,7 +139,6 @@ def litellm_handler():
         async def async_log_success_event(
             self, kwargs, response_obj, start_time, end_time
         ):
-            logging.debug("async_log_success_event()")
             ag.tracing.set_status(status="OK")
             ag.tracing.end_span(
                 outputs={
@@ -171,8 +157,6 @@ def litellm_handler():
         async def async_log_failure_event(
             self, kwargs, response_obj, start_time, end_time
         ):
-            logging.debug("async_log_failure_event()")
-
             ag.tracing.set_status(status="ERROR")
             ag.tracing.set_attributes(
                 {

--- a/agenta-cli/agenta/sdk/tracing/callbacks.py
+++ b/agenta-cli/agenta/sdk/tracing/callbacks.py
@@ -1,5 +1,8 @@
 import agenta as ag
 
+from agenta.sdk.tracing.tracing_context import tracing_context, TracingContext
+from agenta.sdk.tracing.logger import llm_logger as logging
+
 
 def litellm_handler():
     try:
@@ -23,21 +26,29 @@ def litellm_handler():
             LitellmCustomLogger (object): custom logger that allows us to override the events to capture.
         """
 
+        def __init__(self):
+            self.context_token = None
+
         @property
         def _trace(self):
             return ag.tracing
 
         def log_pre_api_call(self, model, messages, kwargs):
+            logging.debug("log_pre_api_call()")
             call_type = kwargs.get("call_type")
             span_kind = (
                 "llm" if call_type in ["completion", "acompletion"] else "embedding"
             )
-            self._trace.start_span(
+
+            if tracing_context.get() is None:
+                self.context_token = tracing_context.set(TracingContext())
+
+            ag.tracing.start_span(
                 name=f"{span_kind}_call",
                 input={"messages": kwargs["messages"]},
                 spankind=span_kind,
             )
-            self._trace.set_span_attribute(
+            ag.tracing.set_attributes(
                 {
                     "model_config": {
                         "model": kwargs.get("model"),
@@ -49,15 +60,18 @@ def litellm_handler():
             )
 
         def log_stream_event(self, kwargs, response_obj, start_time, end_time):
-            self._trace.update_span_status(span=self._trace.active_span, value="OK")
-            self._trace.end_span(
+            logging.debug("log_stream_event()")
+            ag.tracing.set_status(status="OK")
+            ag.tracing.end_span(
                 outputs={
                     "message": kwargs.get(
                         "complete_streaming_response"
                     ),  # the complete streamed response (only set if `completion(..stream=True)`)
-                    "usage": response_obj.usage.dict()
-                    if hasattr(response_obj, "usage")
-                    else None,  # litellm calculates usage
+                    "usage": (
+                        response_obj.usage.dict()
+                        if hasattr(response_obj, "usage")
+                        else None
+                    ),  # litellm calculates usage
                     "cost": kwargs.get(
                         "response_cost"
                     ),  # litellm calculates response cost
@@ -67,13 +81,16 @@ def litellm_handler():
         def log_success_event(
             self, kwargs, response_obj: ModelResponse, start_time, end_time
         ):
-            self._trace.update_span_status(span=self._trace.active_span, value="OK")
-            self._trace.end_span(
+            logging.debug("log_success_event()")
+            ag.tracing.set_status(status="OK")
+            ag.tracing.end_span(
                 outputs={
                     "message": response_obj.choices[0].message.content,
-                    "usage": response_obj.usage.dict()
-                    if hasattr(response_obj, "usage")
-                    else None,  # litellm calculates usage
+                    "usage": (
+                        response_obj.usage.dict()
+                        if hasattr(response_obj, "usage")
+                        else None
+                    ),  # litellm calculates usage
                     "cost": kwargs.get(
                         "response_cost"
                     ),  # litellm calculates response cost
@@ -83,23 +100,26 @@ def litellm_handler():
         def log_failure_event(
             self, kwargs, response_obj: ModelResponse, start_time, end_time
         ):
-            self._trace.update_span_status(span=self._trace.active_span, value="ERROR")
-            self._trace.set_span_attribute(
+            logging.debug("log_failure_event()")
+            ag.tracing.set_status(status="ERROR")
+            ag.tracing.set_attributes(
                 {
-                    "traceback_exception": kwargs[
-                        "traceback_exception"
-                    ],  # the traceback generated via `traceback.format_exc()`
+                    "traceback_exception": repr(
+                        kwargs["traceback_exception"]
+                    ),  # the traceback generated via `traceback.format_exc()`
                     "call_end_time": kwargs[
                         "end_time"
                     ],  # datetime object of when call was completed
                 },
             )
-            self._trace.end_span(
+            ag.tracing.end_span(
                 outputs={
                     "message": kwargs["exception"],  # the Exception raised
-                    "usage": response_obj.usage.dict()
-                    if hasattr(response_obj, "usage")
-                    else None,  # litellm calculates usage
+                    "usage": (
+                        response_obj.usage.dict()
+                        if hasattr(response_obj, "usage")
+                        else None
+                    ),  # litellm calculates usage
                     "cost": kwargs.get(
                         "response_cost"
                     ),  # litellm calculates response cost
@@ -109,15 +129,18 @@ def litellm_handler():
         async def async_log_stream_event(
             self, kwargs, response_obj, start_time, end_time
         ):
-            self._trace.update_span_status(span=self._trace.active_span, value="OK")
-            self._trace.end_span(
+            logging.debug("async_log_stream_event()")
+            ag.tracing.set_status(status="OK")
+            ag.tracing.end_span(
                 outputs={
                     "message": kwargs.get(
                         "complete_streaming_response"
                     ),  # the complete streamed response (only set if `completion(..stream=True)`)
-                    "usage": response_obj.usage.dict()
-                    if hasattr(response_obj, "usage")
-                    else None,  # litellm calculates usage
+                    "usage": (
+                        response_obj.usage.dict()
+                        if hasattr(response_obj, "usage")
+                        else None
+                    ),  # litellm calculates usage
                     "cost": kwargs.get(
                         "response_cost"
                     ),  # litellm calculates response cost
@@ -127,13 +150,16 @@ def litellm_handler():
         async def async_log_success_event(
             self, kwargs, response_obj, start_time, end_time
         ):
-            self._trace.update_span_status(span=self._trace.active_span, value="OK")
-            self._trace.end_span(
+            logging.debug("async_log_success_event()")
+            ag.tracing.set_status(status="OK")
+            ag.tracing.end_span(
                 outputs={
                     "message": response_obj.choices[0].message.content,
-                    "usage": response_obj.usage.dict()
-                    if hasattr(response_obj, "usage")
-                    else None,  # litellm calculates usage
+                    "usage": (
+                        response_obj.usage.dict()
+                        if hasattr(response_obj, "usage")
+                        else None
+                    ),  # litellm calculates usage
                     "cost": kwargs.get(
                         "response_cost"
                     ),  # litellm calculates response cost
@@ -143,8 +169,9 @@ def litellm_handler():
         async def async_log_failure_event(
             self, kwargs, response_obj, start_time, end_time
         ):
-            self._trace.update_span_status(span=self._trace.active_span, value="ERROR")
-            self._trace.set_span_attribute(
+            logging.debug("async_log_failure_event()")
+            ag.tracing.set_status(status="ERROR")
+            ag.tracing.set_attributes(
                 {
                     "traceback_exception": kwargs[
                         "traceback_exception"
@@ -154,12 +181,14 @@ def litellm_handler():
                     ],  # datetime object of when call was completed
                 },
             )
-            self._trace.end_span(
+            ag.tracing.end_span(
                 outputs={
-                    "message": kwargs["exception"],  # the Exception raised
-                    "usage": response_obj.usage.dict()
-                    if hasattr(response_obj, "usage")
-                    else None,  # litellm calculates usage
+                    "message": repr(kwargs["exception"]),  # the Exception raised
+                    "usage": (
+                        response_obj.usage.dict()
+                        if hasattr(response_obj, "usage")
+                        else None
+                    ),  # litellm calculates usage
                     "cost": kwargs.get(
                         "response_cost"
                     ),  # litellm calculates response cost

--- a/agenta-cli/agenta/sdk/tracing/callbacks.py
+++ b/agenta-cli/agenta/sdk/tracing/callbacks.py
@@ -23,9 +23,6 @@ def litellm_handler():
             LitellmCustomLogger (object): custom logger that allows us to override the events to capture.
         """
 
-        def __init__(self):
-            self.context_token = None
-
         @property
         def _trace(self):
             return ag.tracing

--- a/agenta-cli/agenta/sdk/tracing/llm_tracing.py
+++ b/agenta-cli/agenta/sdk/tracing/llm_tracing.py
@@ -414,7 +414,8 @@ class Tracing(metaclass=SingletonMeta):
             "trace",
             # mock_create_traces(
             self.client.create_traces(
-                trace=tracing.trace_id, spans=tracing.closed_spans  # type: ignore
+                trace=tracing.trace_id,
+                spans=tracing.closed_spans,  # type: ignore
             ),
             self.client,
         )

--- a/agenta-cli/pyproject.toml
+++ b/agenta-cli/pyproject.toml
@@ -1,6 +1,6 @@
 [tool.poetry]
 name = "agenta"
-version = "0.19.7"
+version = "0.19.8a"
 description = "The SDK for agenta is an open-source LLMOps platform."
 readme = "README.md"
 authors = ["Mahmoud Mabrouk <mahmoud@agenta.ai>"]

--- a/agenta-cli/pyproject.toml
+++ b/agenta-cli/pyproject.toml
@@ -1,6 +1,6 @@
 [tool.poetry]
 name = "agenta"
-version = "0.19.8a"
+version = "0.19.8"
 description = "The SDK for agenta is an open-source LLMOps platform."
 readme = "README.md"
 authors = ["Mahmoud Mabrouk <mahmoud@agenta.ai>"]


### PR DESCRIPTION
## Description
- Uses the updated SDK in litellm callbacks
- Properly serializes litellm errors upon failure, with `repr()`

## Related Issues
- AGE-480 : Observability not working for template applications

## QA
Use this app [app.py.zip](https://github.com/user-attachments/files/16411705/app.py.zip) with and without `force-json`,
and you should get this :<img width="1405" alt="Screenshot 2024-07-29 at 13 11 43" src="https://github.com/user-attachments/assets/186e9db0-5fa4-4bd5-91a4-5c16d0d61c9b">

