### PR TITLE
fix(sdk): AGE-504 Fix Tracing with LiteLLM

### DIFF
--- a/agenta-cli/agenta/sdk/decorators/llm_entrypoint.py
+++ b/agenta-cli/agenta/sdk/decorators/llm_entrypoint.py
@@ -309,6 +309,7 @@ class entrypoint(BaseDecorator):
                         remaining_steps -= 1
 
                 trace = ag.tracing.dump_trace()
+                ag.tracing.flush_spans()
                 tracing_context.reset(token)
 
             if isinstance(result, Context):

--- a/agenta-cli/agenta/sdk/decorators/llm_entrypoint.py
+++ b/agenta-cli/agenta/sdk/decorators/llm_entrypoint.py
@@ -141,7 +141,7 @@ class entrypoint(BaseDecorator):
             )
 
             entrypoint_result = await self.execute_function(
-                func, True, *args, params=func_params, config_params=config_params
+                func, *args, params=func_params, config_params=config_params
             )
 
             return entrypoint_result
@@ -194,7 +194,7 @@ class entrypoint(BaseDecorator):
             )
 
             entrypoint_result = await self.execute_function(
-                func, False, *args, params=func_params, config_params=config_params
+                func, *args, params=func_params, config_params=config_params
             )
 
             return entrypoint_result
@@ -272,9 +272,7 @@ class entrypoint(BaseDecorator):
             if name in func_params and func_params[name] is not None:
                 func_params[name] = self.ingest_file(func_params[name])
 
-    async def execute_function(
-        self, func: Callable[..., Any], wait_for_spans: bool, *args, **func_params
-    ):
+    async def execute_function(self, func: Callable[..., Any], *args, **func_params):
         """Execute the function and handle any exceptions."""
 
         try:
@@ -283,6 +281,7 @@ class entrypoint(BaseDecorator):
             For synchronous functions, it calls them directly, while for asynchronous functions,
             it awaits their execution.
             """
+            WAIT_FOR_SPANS = True
             TIMEOUT = 10
             TIMESTEP = 0.01
             NOFSTEPS = TIMEOUT / TIMESTEP
@@ -302,7 +301,7 @@ class entrypoint(BaseDecorator):
                 result = func(*args, **func_params["params"])
 
             if token is not None:
-                if wait_for_spans:
+                if WAIT_FOR_SPANS:
                     remaining_steps = NOFSTEPS
 
                     while not ag.tracing.is_trace_ready() and remaining_steps > 0:
@@ -528,7 +527,6 @@ class entrypoint(BaseDecorator):
         result = loop.run_until_complete(
             self.execute_function(
                 func,
-                True,
                 **{"params": args_func_params, "config_params": args_config_params},
             )
         )

--- a/agenta-cli/agenta/sdk/tracing/tracing_context.py
+++ b/agenta-cli/agenta/sdk/tracing/tracing_context.py
@@ -23,9 +23,5 @@ class TracingContext:
     def __str__(self) -> str:
         return self.__repr__()
 
-    def push(self, span) -> None:
-        self.active_span = span
-        self.spans[span.id] = span
-
 
 tracing_context = ContextVar(CURRENT_TRACING_CONTEXT_KEY, default=None)


### PR DESCRIPTION
## Description
- Add detached spans (operation can now be performed on `active_span` or on `spans[span_id]`)
- Add `wait_for_spans()` before `dump_trace()` (async span closures now finish before `dump_trace()`), w/ timeout
- Fix litellm callbacks with the two features above

## Related issues
- AGE-504: Fix litellm issue with `dump_trace()`

## QA
- run the `single prompt` app from our templates in `oss`