### PR TITLE
[Enhancement] Enable automatic migration for first-time users and optionally for returning users

### DIFF
--- a/.github/workflows/run-backend-tests.yml
+++ b/.github/workflows/run-backend-tests.yml
@@ -33,9 +33,6 @@ jobs:
         run: |
           sleep 10 && curl -i http://localhost/api/openapi.json
 
-      - name: Apply Schema Migration
-        run:  docker exec -w /app/agenta_backend/migrations/postgres agenta-backend-test alembic -c alembic.oss.ini upgrade head
-
       - name: Restart Backend Service To Fetch Template Images
         run: docker container restart agenta-backend-test
 

--- a/.github/workflows/run-frontend-tests.yml
+++ b/.github/workflows/run-frontend-tests.yml
@@ -46,9 +46,6 @@ jobs:
           curl http://localhost/api/organizations/own/
           curl http://localhost/api/containers/templates/
 
-      - name: Apply Schema Migration
-        run:  docker exec -w /app/agenta_backend/migrations/postgres agenta-backend-test alembic -c alembic.oss.ini upgrade head
-
       - name: Set Node.js 18
         uses: actions/setup-node@v4
         with:

--- a/agenta-backend/agenta_backend/migrations/postgres/README.md
+++ b/agenta-backend/agenta_backend/migrations/postgres/README.md
@@ -31,7 +31,7 @@ The above command will create a script that contains the changes that was made t
 ### Applying Migrations
 
 ```bash
-alembic -c alembic.oss.ini upgrade head
+docker exec -w /app/agenta_backend/migrations/postgres agenta-backend-1 alembic -c alembic.oss.ini upgrade head
 ```
 
 The above command will be used to apply the changes in the script created to the database table(s).

--- a/agenta-backend/agenta_backend/migrations/postgres/utils.py
+++ b/agenta-backend/agenta_backend/migrations/postgres/utils.py
@@ -104,7 +104,7 @@ async def get_pending_migrations():
 
 def run_alembic_migration():
     """
-    Applies migration for first-time users.
+    Applies migration for first-time users and also checks the environment variable "AGENTA_AUTO_MIGRATIONS" to determine whether to apply migrations for returning users.
     """
 
     APPLY_MIGRATIONS = os.environ.get("AGENTA_AUTO_MIGRATIONS")

--- a/docker-compose.gh.yml
+++ b/docker-compose.gh.yml
@@ -60,6 +60,8 @@ services:
         depends_on:
             postgres:
                 condition: service_healthy
+            apply_alembic_migration:
+                condition: service_completed_successfully
         restart: always
 
     apply_alembic_migration:

--- a/docker-compose.gh.yml
+++ b/docker-compose.gh.yml
@@ -63,7 +63,7 @@ services:
         restart: always
 
     apply_alembic_migration:
-        build: ./agenta-backend
+        build: ghcr.io/agenta-ai/agenta-backend
         command: sh -c "python -c 'from agenta_backend.migrations.postgres.utils import run_alembic_migration; run_alembic_migration()'"
         environment:
             - FEATURE_FLAG=oss
@@ -72,7 +72,6 @@ services:
             - AGENTA_AUTO_MIGRATIONS=false
         volumes:
             - /var/run/docker.sock:/var/run/docker.sock
-            - ./agenta-backend/agenta_backend:/app/agenta_backend
         depends_on:
           postgres:
             condition: service_healthy

--- a/docker-compose.gh.yml
+++ b/docker-compose.gh.yml
@@ -62,6 +62,23 @@ services:
                 condition: service_healthy
         restart: always
 
+    apply_alembic_migration:
+        build: ./agenta-backend
+        command: sh -c "python -c 'from agenta_backend.migrations.postgres.utils import run_alembic_migration; run_alembic_migration()'"
+        environment:
+            - FEATURE_FLAG=oss
+            - POSTGRES_URI=postgresql+asyncpg://username:password@postgres:5432/agenta_oss
+            - ALEMBIC_CFG_PATH=/app/agenta_backend/migrations/postgres/alembic.oss.ini
+            - AGENTA_AUTO_MIGRATIONS=false
+        volumes:
+            - /var/run/docker.sock:/var/run/docker.sock
+            - ./agenta-backend/agenta_backend:/app/agenta_backend
+        depends_on:
+          postgres:
+            condition: service_healthy
+        networks:
+            - agenta-network
+
     agenta-web:
         container_name: agenta-web-1
         image: ghcr.io/agenta-ai/agenta-web

--- a/docker-compose.prod.yml
+++ b/docker-compose.prod.yml
@@ -65,6 +65,23 @@ services:
                 condition: service_healthy
         restart: always
 
+    apply_alembic_migration:
+        build: ./agenta-backend
+        command: sh -c "python -c 'from agenta_backend.migrations.postgres.utils import run_alembic_migration; run_alembic_migration()'"
+        environment:
+            - FEATURE_FLAG=oss
+            - POSTGRES_URI=postgresql+asyncpg://username:password@postgres:5432/agenta_oss
+            - ALEMBIC_CFG_PATH=/app/agenta_backend/migrations/postgres/alembic.oss.ini
+            - AGENTA_AUTO_MIGRATIONS=false
+        volumes:
+            - /var/run/docker.sock:/var/run/docker.sock
+            - ./agenta-backend/agenta_backend:/app/agenta_backend
+        depends_on:
+          postgres:
+            condition: service_healthy
+        networks:
+            - agenta-network
+
     agenta-web:
         build:
             context: ./agenta-web

--- a/docker-compose.prod.yml
+++ b/docker-compose.prod.yml
@@ -63,6 +63,8 @@ services:
         depends_on:
             postgres:
                 condition: service_healthy
+            apply_alembic_migration:
+                condition: service_completed_successfully
         restart: always
 
     apply_alembic_migration:

--- a/docker-compose.test.yml
+++ b/docker-compose.test.yml
@@ -70,7 +70,7 @@ services:
         command: sh -c "python -c 'from agenta_backend.migrations.postgres.utils import run_alembic_migration; run_alembic_migration()'"
         environment:
             - FEATURE_FLAG=oss
-            - POSTGRES_URI=postgresql+asyncpg://username:password@postgres:5432/agenta_oss
+            - POSTGRES_URI=postgresql+asyncpg://username:password@postgres:5432
             - ALEMBIC_CFG_PATH=/app/agenta_backend/migrations/postgres/alembic.oss.ini
             - AGENTA_AUTO_MIGRATIONS=true
         volumes:

--- a/docker-compose.test.yml
+++ b/docker-compose.test.yml
@@ -60,6 +60,8 @@ services:
         depends_on:
             postgres:
                 condition: service_healthy
+            apply_alembic_migration:
+                condition: service_completed_successfully
         extra_hosts:
             - host.docker.internal:host-gateway
         networks:

--- a/docker-compose.test.yml
+++ b/docker-compose.test.yml
@@ -65,6 +65,23 @@ services:
         networks:
             - agenta-network
 
+    apply_alembic_migration:
+        build: ./agenta-backend
+        command: sh -c "python -c 'from agenta_backend.migrations.postgres.utils import run_alembic_migration; run_alembic_migration()'"
+        environment:
+            - FEATURE_FLAG=oss
+            - POSTGRES_URI=postgresql+asyncpg://username:password@postgres:5432/agenta_oss
+            - ALEMBIC_CFG_PATH=/app/agenta_backend/migrations/postgres/alembic.oss.ini
+            - AGENTA_AUTO_MIGRATIONS=true
+        volumes:
+            - /var/run/docker.sock:/var/run/docker.sock
+            - ./agenta-backend/agenta_backend:/app/agenta_backend
+        depends_on:
+          postgres:
+            condition: service_healthy
+        networks:
+            - agenta-network
+
     agenta-web:
         build:
             context: ./agenta-web

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -64,7 +64,26 @@ services:
         depends_on:
             postgres:
                 condition: service_healthy
+            apply_alembic_migration:
+                condition: service_completed_successfully
         restart: always
+
+    apply_alembic_migration:
+        build: ./agenta-backend
+        command: sh -c "python -c 'from agenta_backend.migrations.postgres.utils import run_alembic_migration; run_alembic_migration()'"
+        environment:
+            - FEATURE_FLAG=oss
+            - POSTGRES_URI=postgresql+asyncpg://username:password@postgres:5432/agenta_oss
+            - ALEMBIC_CFG_PATH=/app/agenta_backend/migrations/postgres/alembic.oss.ini
+            - AGENTA_AUTO_MIGRATIONS=false
+        volumes:
+            - /var/run/docker.sock:/var/run/docker.sock
+            - ./agenta-backend/agenta_backend:/app/agenta_backend
+        depends_on:
+          postgres:
+            condition: service_healthy
+        networks:
+            - agenta-network
 
     agenta-web:
         build:

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -78,6 +78,7 @@ services:
             - AGENTA_AUTO_MIGRATIONS=false
         volumes:
             - /var/run/docker.sock:/var/run/docker.sock
+            - ./agenta-backend/migrations:/app/migrations
             - ./agenta-backend/agenta_backend:/app/agenta_backend
         depends_on:
           postgres:

--- a/docs/self-host/migration/applying-schema-migration.mdx
+++ b/docs/self-host/migration/applying-schema-migration.mdx
@@ -7,7 +7,7 @@ This guide provides step-by-step instructions for applying schema migration to y
 
 Schema migration is different from [Migration to PostgreSQL](https://docs.agenta.ai/self-host/migration/migration-to-postgres). Schema migration involves modifying the database schema (such as creating, altering, or dropping tables and columns) to match the application's current requirements.
 
-### Steps-by-Steps Guide
+### Applying the Migration
 
 To apply schema migrations, you can use the following command. This sets the working directory to `/app/agenta_backend/migrations/postgres` in the backend container before executing the Alembic command. It ensures that Alembic looks for the configuration file `alembic.oss.ini` and other necessary files in the specified directory.
 
@@ -20,3 +20,7 @@ docker exec -w /app/agenta_backend/migrations/postgres agenta-backend-1 alembic 
 After completing the migration, ensure you check the data integrity in PostgreSQL by accessing Agenta on the web and verifying that your data is intact and everything works fine.
 
 In the event that you encounter issues and need to revert the schema migration, you can revert by running `alembic -c alembic.oss.ini downgrade head`. Afterwards, create a GitHub issue describing the problem you encountered.
+
+### Auto Migration
+
+In some cases, you would prefer that these migrations are applied to the application automatically without you running the `alembic upgrade` command. In this case, you need to update the value of `AGENTA_AUTO_MIGRATION` to `true` in `apply_alembic_migration` service, located in the compose file you're about to run (or are running already).


### PR DESCRIPTION
## Description
This PR introduces a db migration service that automatically applies Alembic migrations for first-time users. Returning users can also have migrations applied automatically, depending on the configured environment settings.

### Related Issue
Closes [AGE-506](https://linear.app/agenta/issue/AGE-506/enable-automatic-migration-for-first-time-users-and-optionally-for)

### QA
- **Clean Up Resources:** Remove all containers, volumes, and images related to Agenta.
- **Start Services:** Run docker-compose up to start the services.
- **Verify Backend Start:** Wait until the backend services are fully started.
- **Test Application Creation:** Navigate to http://localhost/apps and attempt to create an app from a template.
- **Check for Success:** If the templates are visible, Alembic migrations were applied successfully.