### PR TITLE
fix (workflow): replace deprecated 'docker-compose' command in test workflow

### DIFF
--- a/.github/workflows/run-backend-tests.yml
+++ b/.github/workflows/run-backend-tests.yml
@@ -27,7 +27,7 @@ jobs:
         run: sudo apt install curl -y
 
       - name: Start Docker Compose
-        run: OPENAI_API_KEY=${{ secrets.NEXT_PUBLIC_OPENAI_API_KEY }} ENVIRONMENT=github docker-compose -f "docker-compose.test.yml" up -d --build
+        run: OPENAI_API_KEY=${{ secrets.NEXT_PUBLIC_OPENAI_API_KEY }} ENVIRONMENT=github docker compose -f "docker-compose.test.yml" up -d --build
 
       - name: Wait for Backend Service
         run: |

--- a/.github/workflows/run-frontend-tests.yml
+++ b/.github/workflows/run-frontend-tests.yml
@@ -33,7 +33,7 @@ jobs:
           NEXT_PUBLIC_OPENAI_API_KEY: ${{ secrets.NEXT_PUBLIC_OPENAI_API_KEY }}
         run: |
           sudo apt install curl -y
-          OPENAI_API_KEY=${{ secrets.NEXT_PUBLIC_OPENAI_API_KEY }} ENVIRONMENT=github docker-compose -f "docker-compose.test.yml" up -d --build
+          OPENAI_API_KEY=${{ secrets.NEXT_PUBLIC_OPENAI_API_KEY }} ENVIRONMENT=github docker compose -f "docker-compose.test.yml" up -d --build
 
       - name: Restart Backend Service To Fetch Template(s)
         run: docker container restart agenta-backend-test


### PR DESCRIPTION
## Description
This PR replaces the use of deprecated docker-compose command to docker compose in the tests' workflow.

See errors:
- https://github.com/Agenta-AI/agenta/actions/runs/10250555963/job/28356547115?pr=1966
- https://github.com/Agenta-AI/agenta/actions/runs/10250555963/job/28356946147?pr=1966