### PR TITLE
fix(tool): AGE-512 fix issues in postgres container

### DIFF
--- a/docker-assets/postgres/init-db.sql
+++ b/docker-assets/postgres/init-db.sql
@@ -1,1 +1,11 @@
-CREATE DATABASE agenta_oss;
+-- Create the username role with a password
+CREATE ROLE username WITH LOGIN PASSWORD 'password';
+
+-- Grant necessary permissions to username
+GRANT ALL PRIVILEGES ON DATABASE agenta_oss TO username;
+
+-- Connect to the agenta_oss database
+\c agenta_oss
+
+-- Grant schema permissions to username
+GRANT ALL ON SCHEMA public TO username;

--- a/docker-assets/postgres/init-db.sql
+++ b/docker-assets/postgres/init-db.sql
@@ -1,5 +1,25 @@
+DO $$ 
+BEGIN
+   IF NOT EXISTS (
+      SELECT 
+      FROM   pg_catalog.pg_database 
+      WHERE  datname = 'agenta_oss') THEN
+      CREATE DATABASE agenta_oss;
+   END IF;
+END
+$$;
+
 -- Create the username role with a password
-CREATE ROLE username WITH LOGIN PASSWORD 'password';
+DO $$
+BEGIN
+   IF NOT EXISTS (
+      SELECT 
+      FROM   pg_catalog.pg_roles 
+      WHERE  rolname = 'username') THEN
+      CREATE ROLE username WITH LOGIN PASSWORD 'password';
+   END IF;
+END
+$$;
 
 -- Grant necessary permissions to username
 GRANT ALL PRIVILEGES ON DATABASE agenta_oss TO username;

--- a/docker-compose.gh.yml
+++ b/docker-compose.gh.yml
@@ -75,8 +75,8 @@ services:
         volumes:
             - /var/run/docker.sock:/var/run/docker.sock
         depends_on:
-          postgres:
-            condition: service_healthy
+            postgres:
+                condition: service_healthy
         networks:
             - agenta-network
 
@@ -158,7 +158,7 @@ services:
             - postgresdb-data:/var/lib/postgresql/data/
             - ./docker-assets/postgres/init-db.sql:/docker-entrypoint-initdb.d/init-db.sql
         healthcheck:
-            test: ["CMD-SHELL", "pg_isready -U postgres"]
+            test: ["CMD-SHELL", "pg_isready -U username -d agenta_oss"]
             interval: 10s
             timeout: 5s
             retries: 5

--- a/docker-compose.prod.yml
+++ b/docker-compose.prod.yml
@@ -79,8 +79,8 @@ services:
             - /var/run/docker.sock:/var/run/docker.sock
             - ./agenta-backend/agenta_backend:/app/agenta_backend
         depends_on:
-          postgres:
-            condition: service_healthy
+            postgres:
+                condition: service_healthy
         networks:
             - agenta-network
 
@@ -161,7 +161,7 @@ services:
             - postgresdb-data:/var/lib/postgresql/data/
             - ./docker-assets/postgres/init-db.sql:/docker-entrypoint-initdb.d/init-db.sql
         healthcheck:
-            test: ["CMD-SHELL", "pg_isready -U postgres"]
+            test: ["CMD-SHELL", "pg_isready -U username -d agenta_oss"]
             interval: 10s
             timeout: 5s
             retries: 5

--- a/docker-compose.test.yml
+++ b/docker-compose.test.yml
@@ -79,8 +79,8 @@ services:
             - /var/run/docker.sock:/var/run/docker.sock
             - ./agenta-backend/agenta_backend:/app/agenta_backend
         depends_on:
-          postgres:
-            condition: service_healthy
+            postgres:
+                condition: service_healthy
         networks:
             - agenta-network
 
@@ -165,7 +165,7 @@ services:
         volumes:
             - postgresdb-data:/var/lib/postgresql/data/
         healthcheck:
-            test: ["CMD-SHELL", "pg_isready -U postgres"]
+            test: ["CMD-SHELL", "pg_isready -U username -d agenta_oss"]
             interval: 10s
             timeout: 5s
             retries: 5

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -81,8 +81,8 @@ services:
             - ./agenta-backend/migrations:/app/migrations
             - ./agenta-backend/agenta_backend:/app/agenta_backend
         depends_on:
-          postgres:
-            condition: service_healthy
+            postgres:
+                condition: service_healthy
         networks:
             - agenta-network
 
@@ -152,7 +152,6 @@ services:
 
     postgres:
         image: postgres:16.2
-        container_name: postgres
         restart: always
         environment:
             POSTGRES_USER: username
@@ -166,7 +165,7 @@ services:
             - postgresdb-data:/var/lib/postgresql/data/
             - ./docker-assets/postgres/init-db.sql:/docker-entrypoint-initdb.d/init-db.sql
         healthcheck:
-            test: ["CMD-SHELL", "pg_isready -U postgres"]
+            test: ["CMD-SHELL", "pg_isready -U username"]
             interval: 10s
             timeout: 5s
             retries: 5

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -165,7 +165,7 @@ services:
             - postgresdb-data:/var/lib/postgresql/data/
             - ./docker-assets/postgres/init-db.sql:/docker-entrypoint-initdb.d/init-db.sql
         healthcheck:
-            test: ["CMD-SHELL", "pg_isready -U username"]
+            test: ["CMD-SHELL", "pg_isready -U username -d agenta_oss"]
             interval: 10s
             timeout: 5s
             retries: 5


### PR DESCRIPTION
This PR fixes:
- the clash of postgres containers between oss and cloud
- the fatal error in the postgres error about role does not exist 
```
2024-08-06 10:24:24.775 UTC [40] FATAL:  role "postgres" does not exist
```

NOTES:
- Won't solve the issue of having cloud and oss run together. 
- postgres Volume should be deleted to have this working without issues.