### PR TITLE
[Bug Fix]: enhance image validation and app variant update logic for cloud-dev environment

### DIFF
--- a/agenta-backend/agenta_backend/services/db_manager.py
+++ b/agenta-backend/agenta_backend/services/db_manager.py
@@ -2609,9 +2609,18 @@ async def update_app_variant(
             if hasattr(app_variant, key):
                 setattr(app_variant, key, value)
 
+        relationships_to_load_in_session = [
+            "user",
+            "app",
+            "image",
+            "base",
+        ]
+        if isCloudEE():
+            relationships_to_load_in_session.append("organization")
+
         await session.commit()
         await session.refresh(
-            app_variant, attribute_names=["user", "app", "image", "base"]
+            app_variant, attribute_names=relationships_to_load_in_session
         )
 
         return app_variant

--- a/agenta-backend/agenta_backend/services/deployment_manager.py
+++ b/agenta-backend/agenta_backend/services/deployment_manager.py
@@ -136,10 +136,15 @@ async def validate_image(image: Image) -> bool:
         msg = "Image tags cannot be empty"
         logger.error(msg)
         raise ValueError(msg)
+
+    if isCloudEE():
+        image = Image(**image.model_dump(exclude={"workspace", "organization"}))
+
     if not image.tags.startswith(agenta_registry_repo):
         raise ValueError(
             f"Image should have a tag starting with the registry name ({agenta_registry_repo})\n Image Tags: {image.tags}"
         )
+
     if image not in docker_utils.list_images():
         raise DockerException(
             f"Image {image.docker_id} with tags {image.tags} not found"


### PR DESCRIPTION
## Description
This PR introduces enhancements to ensure that re-serving a variant in the cloud-dev environment works as expected.

### Related Issue
Closes [AGE-511](https://linear.app/agenta/issue/AGE-511/[cli]-cant-re-serve-overwrite-variant-in-cloud-dev)

### Changes Included:
- **Image Validation Logic Update:**  
  - In the cloud-dev environment, certain fields like `workspace` and `organization` are stripped off before validation, since they are not used during this process.
- **App Variant Update Enhancement:**  
  - In the cloud-ev environment, the `organization` relationship is now loaded when updating an app variant to ensure the model is fully refreshed in the session.

### What to QA (in cloud-dev and oss)
- **App Creation from the CLI**
    - Create and serve an app from the CLI
    - Navigate to the app playground URL to ensure that it is working
    - Update the app variant code/configuration and re-serve to see if the changes are reflected 

### Acceptance Tests
- Ensure that app creating and re-serving from the CLI works
- Ensure that app creation from the UI template works