### PR TITLE
fix(frontend) BaseResponse in WebUI when dict-style

### DIFF
--- a/agenta-web/src/lib/helpers/utils.ts
+++ b/agenta-web/src/lib/helpers/utils.ts
@@ -342,5 +342,5 @@ export const getStringOrJson = (value: any) => {
         ? value
         : typeof value?.data === "string"
           ? value?.data
-          : JSON.stringify(value, null, 2)
+          : JSON.stringify(value.data, null, 2)
 }


### PR DESCRIPTION
## Description

- Fixes `BaseResponse` in WebUI when dict-style

## QA

- Using SDK v0.21+ (with `BaseResponse`), try a `str`-style output and a `dict`-style output. Both should work.