### PR TITLE
[Bug Fix]: Correct permission naming from 'UPDATE_APPLICATION' to 'EDIT_APPLICATION'

### DIFF
--- a/agenta-backend/agenta_backend/routers/app_router.py
+++ b/agenta-backend/agenta_backend/routers/app_router.py
@@ -313,7 +313,7 @@ async def update_app(
             has_permission = await check_action_access(
                 user_uid=request.state.user_id,
                 object=app,
-                permission=Permission.UPDATE_APPLICATION,
+                permission=Permission.EDIT_APPLICATION,
             )
             logger.debug(f"User has Permission to update app: {has_permission}")
             if not has_permission:


### PR DESCRIPTION
## Description
This PR fixes a bug where the incorrect permission `UPDATE_APPLICATION` was being used. It has been updated to the correct permission `EDIT_APPLICATION` to ensure consistent access control across the application.

### Related Issue
Closes [AGE-539](https://linear.app/agenta/issue/AGE-539/endpoint-for-renaming-an-application)

### Changes
- Updated permission from `UPDATE_APPLICATION` to `EDIT_APPLICATION` in relevant parts of the codebase.

### What to QA
- Verify that actions requiring the `EDIT_APPLICATION` permission work correctly and that no access issues are introduced.
