### PR TITLE
fix (bug): resolve error when starting application variant container

### DIFF
--- a/agenta-backend/agenta_backend/services/app_manager.py
+++ b/agenta-backend/agenta_backend/services/app_manager.py
@@ -44,6 +44,7 @@ else:
     from agenta_backend.services import deployment_manager
 
 if isCloudEE():
+    from agenta_backend.commons.services import db_manager_ee
     from agenta_backend.commons.services import (
         api_key_service,
     )  # noqa pylint: disable-all
@@ -106,9 +107,10 @@ async def start_variant(
         )
         if isCloudEE():
             user = await db_manager.get_user(user_uid=user_uid)
+            project = await db_manager_ee.get_project_by_id(project_id=project_id)
             api_key = await api_key_service.create_api_key(
                 str(user.id),
-                project_id=project_id,
+                workspace_id=str(project.workspace_id),
                 expiration_date=None,
                 hidden=True,
             )


### PR DESCRIPTION
## Description
This PR resolve the `TypeError` got from `create_api_key` service function when starting an application variant docker container in oss/cloud-dev.

### Related Issue
Closes [AGE-978](https://linear.app/agenta/issue/AGE-978/[bug]-unable-to-create-new-application)