### PR TITLE
fix(frontend): Wrong endpoint in deployment fetch prompt

### DIFF
--- a/agenta-web/src/code_snippets/endpoints/fetch_config/curl.ts
+++ b/agenta-web/src/code_snippets/endpoints/fetch_config/curl.ts
@@ -1,6 +1,6 @@
 export default function cURLCode(baseId: string, env_name: string): string {
     return `
-    curl -X GET "https://cloud.agenta.ai/api/configs?base_id=${baseId}&environment_name=${env_name}" \\
+    curl -X GET "${process.env.NEXT_PUBLIC_AGENTA_API_URL}/api/configs?base_id=${baseId}&environment_name=${env_name}" \\
     -H "Authorization: Bearer YOUR_API_KEY" \\
     -H "Content-Type: application/json" \\
     --connect-timeout 60

--- a/agenta-web/src/code_snippets/endpoints/fetch_config/python.ts
+++ b/agenta-web/src/code_snippets/endpoints/fetch_config/python.ts
@@ -1,7 +1,7 @@
 export default function pythonCode(baseId: string, env_name: string): string {
     return `
     # os.environ["AGENTA_API_KEY"] = "your_api_key" # Only when using cloud
-    # os.environ["AGENTA_HOST"] = "https://cloud.agenta.ai"
+    # os.environ["AGENTA_HOST"] = "${process.env.NEXT_PUBLIC_AGENTA_API_URL}"
 
     from agenta import Agenta
     ag = Agenta()

--- a/agenta-web/src/code_snippets/endpoints/fetch_config/typescript.ts
+++ b/agenta-web/src/code_snippets/endpoints/fetch_config/typescript.ts
@@ -6,7 +6,7 @@ export default function tsCode(baseId: string, env_name: string): string {
 
     const getConfig = async (baseId: string, environmentName: string) => {
         try {
-            const baseUrl = 'https://cloud.agenta.ai/api';
+            const baseUrl = '${process.env.NEXT_PUBLIC_AGENTA_API_URL}/api';
             const params = {
                 base_id: baseId,
                 environment_name: environmentName

--- a/agenta-web/src/pages/apps/[app_id]/testsets/index.tsx
+++ b/agenta-web/src/pages/apps/[app_id]/testsets/index.tsx
@@ -118,11 +118,15 @@ export default function Testsets() {
 
                     {testsets.length > 0 && (
                         <Space className={classes.startLink}>
-                            <Link href={`/apps/${appId}/evaluations/results`}>
+                            <Link
+                                href={`/apps/${appId}/evaluations?selectedEvaluation=auto_evaluation`}
+                            >
                                 <Button>Start an Automatic Evaluation</Button>
                             </Link>
 
-                            <Link href={`/apps/${appId}/evaluations/human_a_b_testing`}>
+                            <Link
+                                href={`/apps/${appId}/evaluations?selectedEvaluation=human_ab_testing`}
+                            >
                                 <Button>Start a Human Evaluation</Button>
                             </Link>
                         </Space>


### PR DESCRIPTION
### Description
This PR fixes the incorrect endpoint in the OSS deployment fetch prompt and the incorrect redirection to evaluation from the test set.

### Related Issues
- Closes [AGE-988](https://linear.app/agenta/issue/AGE-988/[bug]-testset-page-start-evaluation-button-redirecting-to-the-wrong)
- Closes [AGE-971](https://linear.app/agenta/issue/AGE-971/[qa][bug]-wrong-endpoint-in-oss-for-deployment-fetch-prompt-[non)