### PR TITLE
Fixes to JSON evaluators

### DIFF
--- a/agenta-backend/agenta_backend/services/evaluators_service.py
+++ b/agenta-backend/agenta_backend/services/evaluators_service.py
@@ -79,18 +79,6 @@ def validate_json_output(
             raise Exception(
                 f"Evaluator {evaluator_key} requires the output to be a JSON string or object."
             )
-
-    if not isinstance(
-        output,
-        (
-            str,
-            dict,
-        ),
-    ):
-        raise Exception(
-            f"Evaluator {evaluator_key} requires the output to be either a JSON string or object, but received {type(output).__name__} instead."
-        )
-
     return output
 
 


### PR DESCRIPTION
Closes: AGE-1016 and AGE-1017

Both contains_json and json_diff were not functioning correctly. I refactored the code, removing validate_json (which was unnecessary—more on that later), and fixed two bugs:

1. We were throwing an exception if the output wasn't JSON, contradicting the evaluator's purpose of scoring based on whether the output is JSON.
2. We weren't parsing strings as dictionaries for the evaluator.

On validate_json:

- Methods should do one thing and one thing only. In this case it was a function that created a string json if the input is a dict **and** validated the input if it is a string
- Methods should have a name that describe what they do. The method did not validate jsons, it did something else
- Whenever we have a method that take two possible data types (string or dict), usually the code is not well written.