### PR TITLE
fix(frontend): prevent closing eval-config modal when click outside

### DIFF
--- a/agenta-web/src/components/pages/evaluations/autoEvaluation/EvaluatorsModal/EvaluatorsModal.tsx
+++ b/agenta-web/src/components/pages/evaluations/autoEvaluation/EvaluatorsModal/EvaluatorsModal.tsx
@@ -163,6 +163,7 @@ const EvaluatorsModal = ({...props}: EvaluatorsModalProps) => {
             closeIcon={null}
             title={null}
             className={classes.modalWrapper}
+            maskClosable={false}
             centered
             {...props}
         >


### PR DESCRIPTION
### Description

This PR aims to prevent closing the evaluator config model when clicking outside of it. 

### Related issue
Closes [AGE-1013](https://linear.app/agenta/issue/AGE-1013/clicking-outside-evaluation-configuration-modal-closes-the-modal)