### PR TITLE
[Bug Fix]: agenta CLI does not work anymore post-release (project structure) 

### DIFF
--- a/agenta-backend/agenta_backend/routers/app_router.py
+++ b/agenta-backend/agenta_backend/routers/app_router.py
@@ -219,6 +219,13 @@ async def create_app(
                     request.state.user_id,
                     Permission.CREATE_APPLICATION,
                 )
+
+            workspace_id_from_apikey = await db_manager_ee.get_workspace_id_from_apikey(
+                api_key_from_headers, request.state.user_id
+            )
+            if payload.workspace_id is None:
+                payload.workspace_id = workspace_id_from_apikey
+
             try:
                 user_org_workspace_data = await get_user_org_and_workspace_id(
                     request.state.user_id

--- a/agenta-backend/agenta_backend/routers/variants_router.py
+++ b/agenta-backend/agenta_backend/routers/variants_router.py
@@ -362,14 +362,16 @@ async def start_variant(
 
     if action.action == VariantActionEnum.START:
         url: URI = await app_manager.start_variant(
-            app_variant_db, str(app_variant_db.project_id), envvars
+            app_variant_db,
+            str(app_variant_db.project_id),
+            envvars,
+            request.state.user_id,
         )
 
         # Deploy to production
         await db_manager.deploy_to_environment(
             environment_name="production",
             variant_id=str(app_variant_db.id),
-            project_id=str(app_variant_db.project_id),
             user_uid=request.state.user_id,
         )
     return url

--- a/agenta-backend/agenta_backend/services/app_manager.py
+++ b/agenta-backend/agenta_backend/services/app_manager.py
@@ -185,7 +185,7 @@ async def update_variant_image(
     )
 
     # Start variant
-    await start_variant(app_variant_db, project_id)
+    await start_variant(app_variant_db, project_id, user_uid=user_uid)
 
 
 async def update_last_modified_by(
@@ -313,9 +313,11 @@ async def terminate_and_remove_app_variant(
                     logger.error(f"Failed to stop and delete service {deployment} {e}")
 
             # If image deletable is True, remove docker image and image db
-            if image.deletable:
+            if image is not None and image.deletable:
                 try:
-                    if isCloudEE():
+                    if isCloudDev() or isOss():
+                        await deployment_manager.remove_image(image)
+                    elif isCloudEE():
                         await deployment_manager.remove_repository(image.tags)  # type: ignore
                     else:
                         await deployment_manager.remove_image(image)


### PR DESCRIPTION
## Description
This PR fixes issues with the Agenta CLI, which stopped working after changes to the project structure were released.

### Related Issue
Closes [AGE-1057](https://linear.app/agenta/issue/AGE-1057/agenta-cli-does-not-work-anymore-post-release-project) (Critical)

### Sibling PR
- [Commons#117](https://github.com/Agenta-AI/agenta-commons/pull/117)

### Changes
- Fix `AssertionError` when creating an app from the CLI due to a missing `workspace_id`.
- Resolve `TypeError` in `start_variant` function caused by a missing argument after the variant image update.

### QA
- Create an app from the CLI while running in cloud-dev environment.
- Re-serve a deployed app to verify that updates are applied correctly.

### Acceptance Tests
- Verify that an app can be successfully created from the CLI in the cloud-dev environment without errors.
- Ensure that the created app can be re-served, confirming the app updates are properly handled.
 