### PR TITLE
fix(frontend): converted all the buttons to it's default size in app overview page

### DIFF
--- a/agenta-web/src/components/HumanEvaluations/AbTestingEvaluation.tsx
+++ b/agenta-web/src/components/HumanEvaluations/AbTestingEvaluation.tsx
@@ -375,7 +375,6 @@ const AbTestingEvaluation = ({viewType}: {viewType: "evaluation" | "overview"}) 
                                 onClick={(e) => e.stopPropagation()}
                                 type="text"
                                 icon={<MoreOutlined />}
-                                size="small"
                             />
                         </Dropdown>
                     )
@@ -391,18 +390,13 @@ const AbTestingEvaluation = ({viewType}: {viewType: "evaluation" | "overview"}) 
                     <Space>
                         <Title>Human A/B Testing</Title>
                         <Button
-                            size="small"
                             href={`/apps/${appId}/evaluations?selectedEvaluation=ab_testing_evaluation`}
                         >
                             View all
                         </Button>
                     </Space>
 
-                    <Button
-                        icon={<PlusOutlined />}
-                        size="small"
-                        onClick={() => setIsEvalModalOpen(true)}
-                    >
+                    <Button icon={<PlusOutlined />} onClick={() => setIsEvalModalOpen(true)}>
                         Create new
                     </Button>
                 </div>

--- a/agenta-web/src/components/HumanEvaluations/SingleModelEvaluation.tsx
+++ b/agenta-web/src/components/HumanEvaluations/SingleModelEvaluation.tsx
@@ -297,7 +297,6 @@ const SingleModelEvaluation = ({viewType}: {viewType: "evaluation" | "overview"}
                             onClick={(e) => e.stopPropagation()}
                             type="text"
                             icon={<MoreOutlined />}
-                            size="small"
                         />
                     </Dropdown>
                 )
@@ -313,18 +312,13 @@ const SingleModelEvaluation = ({viewType}: {viewType: "evaluation" | "overview"}
                         <Title>Human Annotation</Title>
 
                         <Button
-                            size="small"
                             href={`/apps/${appId}/evaluations?selectedEvaluation=single_model_evaluation`}
                         >
                             View all
                         </Button>
                     </Space>
 
-                    <Button
-                        icon={<PlusOutlined />}
-                        size="small"
-                        onClick={() => setIsEvalModalOpen(true)}
-                    >
+                    <Button icon={<PlusOutlined />} onClick={() => setIsEvalModalOpen(true)}>
                         Create new
                     </Button>
                 </div>

--- a/agenta-web/src/components/pages/overview/automaticEvaluation/AutomaticEvalOverview.tsx
+++ b/agenta-web/src/components/pages/overview/automaticEvaluation/AutomaticEvalOverview.tsx
@@ -392,7 +392,6 @@ const AutomaticEvalOverview = () => {
                             onClick={(e) => e.stopPropagation()}
                             type="text"
                             icon={<MoreOutlined />}
-                            size="small"
                         />
                     </Dropdown>
                 )
@@ -405,15 +404,12 @@ const AutomaticEvalOverview = () => {
             <div className="flex items-center justify-between">
                 <Space>
                     <Title>Automatic Evaluations</Title>
-                    <Button size="small" href={`/apps/${appId}/evaluations`}>
-                        View all
-                    </Button>
+                    <Button href={`/apps/${appId}/evaluations`}>View all</Button>
                 </Space>
 
                 <Space>
                     <Button
                         disabled={compareDisabled}
-                        size="small"
                         type="link"
                         icon={<SwapOutlined />}
                         onClick={() =>
@@ -424,11 +420,7 @@ const AutomaticEvalOverview = () => {
                     >
                         Compare evaluations
                     </Button>
-                    <Button
-                        icon={<PlusOutlined />}
-                        size="small"
-                        onClick={() => setNewEvalModalOpen(true)}
-                    >
+                    <Button icon={<PlusOutlined />} onClick={() => setNewEvalModalOpen(true)}>
                         Create new
                     </Button>
                 </Space>

--- a/agenta-web/src/components/pages/overview/deployments/DeploymentOverview.tsx
+++ b/agenta-web/src/components/pages/overview/deployments/DeploymentOverview.tsx
@@ -145,7 +145,6 @@ const DeploymentOverview = ({
                                         type="text"
                                         onClick={(e) => e.stopPropagation()}
                                         icon={<MoreOutlined />}
-                                        size="small"
                                         className="absolute right-2"
                                     />
                                 </Dropdown>

--- a/agenta-web/src/components/pages/overview/variants/VariantsOverview.tsx
+++ b/agenta-web/src/components/pages/overview/variants/VariantsOverview.tsx
@@ -37,20 +37,6 @@ const useStyles = createUseStyles((theme: JSSTheme) => ({
             fontSize: theme.fontSize,
         },
     },
-    titleLink: {
-        display: "flex",
-        alignItems: "center",
-        gap: theme.paddingXS,
-        border: `1px solid ${theme.colorBorder}`,
-        padding: "1px 7px",
-        height: 24,
-        borderRadius: theme.borderRadius,
-        color: theme.colorText,
-        "&:hover": {
-            borderColor: theme.colorInfoBorderHover,
-            transition: "all 0.2s cubic-bezier(0.645, 0.045, 0.355, 1)",
-        },
-    },
 }))
 
 const VariantsOverview = ({
@@ -260,7 +246,6 @@ const VariantsOverview = ({
                             onClick={(e) => e.stopPropagation()}
                             type="text"
                             icon={<MoreOutlined />}
-                            size="small"
                         />
                     </Dropdown>
                 )
@@ -276,7 +261,6 @@ const VariantsOverview = ({
 
                     <Space>
                         <Button
-                            size="small"
                             type="link"
                             disabled={selectedVariantsToCompare.isCompareDisabled}
                             icon={<SwapOutlined />}
@@ -284,10 +268,13 @@ const VariantsOverview = ({
                         >
                             Compare variants
                         </Button>
-                        <Link href={`/apps/${appId}/playground`} className={classes.titleLink}>
-                            <Rocket size={14} />
+
+                        <Button
+                            icon={<Rocket size={14} className="mt-[3px]" />}
+                            href={`/apps/${appId}/playground`}
+                        >
                             Playground
-                        </Link>
+                        </Button>
                     </Space>
                 </div>
 

--- a/agenta-web/src/pages/apps/[app_id]/overview/index.tsx
+++ b/agenta-web/src/pages/apps/[app_id]/overview/index.tsx
@@ -141,7 +141,7 @@ export default function Overview() {
                             ],
                         }}
                     >
-                        <Button type="text" icon={<MoreOutlined />} size="small" />
+                        <Button type="text" icon={<MoreOutlined />} />
                     </Dropdown>
                 </Space>
 


### PR DESCRIPTION
### Description

This PR aims to fix the button size issue in app-overview page.


### Related issue

Closes [AGE-928](https://linear.app/agenta/issue/AGE-928/app-overview-update-all-buttons-size-to-default)