### PR TITLE
[Bug Fix]: Filter environment revisions by ascending order

### DIFF
--- a/agenta-backend/agenta_backend/services/db_manager.py
+++ b/agenta-backend/agenta_backend/services/db_manager.py
@@ -12,8 +12,8 @@ from agenta_backend.utils.common import isCloudEE
 from agenta_backend.models.db.postgres_engine import db_engine
 from agenta_backend.services.json_importer_helper import get_json
 
-from sqlalchemy import func, or_
 from sqlalchemy.future import select
+from sqlalchemy import func, or_, asc
 from sqlalchemy.exc import NoResultFound
 from sqlalchemy.ext.asyncio import AsyncSession
 from sqlalchemy.orm import joinedload, aliased, load_only
@@ -1255,7 +1255,10 @@ async def fetch_environment_revisions_for_environment(
             query = query.options(
                 joinedload(AppEnvironmentRevisionDB.modified_by.of_type(UserDB)).load_only(UserDB.username)  # type: ignore
             )
-        result = await session.execute(query)
+
+        result = await session.execute(
+            query.order_by(asc(AppEnvironmentRevisionDB.revision))
+        )
         environment_revisions = result.scalars().all()
         return environment_revisions
 

--- a/agenta-backend/agenta_backend/services/db_manager.py
+++ b/agenta-backend/agenta_backend/services/db_manager.py
@@ -1257,7 +1257,7 @@ async def fetch_environment_revisions_for_environment(
             )
 
         result = await session.execute(
-            query.order_by(asc(AppEnvironmentRevisionDB.revision))
+            query.order_by(asc(AppEnvironmentRevisionDB.created_at))
         )
         environment_revisions = result.scalars().all()
         return environment_revisions


### PR DESCRIPTION
## Description
This PR fixes the deployment history by filtering environment revisions in ascending order.

### Related Issue
Closes [AGE-1060](https://linear.app/agenta/issue/AGE-1060/[bug]-history-of-environment-messy).

### QA
- Create an app from the CLI or UI Template.
- Create a new variant with a different prompt.
- Deploy the new variant to the default environment (production).
- Deploy the default variant to the same default environment (production).

### Acceptance Criteria
The deployment history should be presented in ascending order.