### PR TITLE
Move templates to backend

### DIFF
--- a/agenta-backend/agenta_backend/migrations/mongo_to_postgres/docker-compose.migration.yml
+++ b/agenta-backend/agenta_backend/migrations/mongo_to_postgres/docker-compose.migration.yml
@@ -27,7 +27,6 @@ services:
             - POSTHOG_API_KEY=phc_hmVSxIjTW1REBHXgj2aw4HW9X6CXb6FzerBgP9XenC7
             - CELERY_BROKER_URL=amqp://guest@rabbitmq//
             - CELERY_RESULT_BACKEND=redis://redis:6379/0
-            - TEMPLATES_BASE_URL=https://llm-app-json.s3.eu-central-1.amazonaws.com
             - REGISTRY_REPO_NAME=agentaai
             - DOCKER_HUB_URL=https://hub.docker.com/v2/repositories
         volumes:

--- a/agenta-backend/agenta_backend/resources/templates/templates.py
+++ b/agenta-backend/agenta_backend/resources/templates/templates.py
@@ -1,0 +1,20 @@
+templates_info = {
+    "chat_openai": {
+        "name": "Single Prompt OpenAI",
+        "description": "Sample single prompt application using different OpenAI models",
+    },
+    "technical_startup_ideas": {
+        "name": "Chat Application OpenAI",
+        "description": "Sample Chat application using different OpenAI models",
+    },
+}
+
+
+def get_oss_templates():
+    """
+    Returns a list of templates.
+
+    Returns:
+        List[dict]: A list of template dictionaries.
+    """
+    return templates_info

--- a/agenta-backend/agenta_backend/resources/templates/templates.py
+++ b/agenta-backend/agenta_backend/resources/templates/templates.py
@@ -1,4 +1,4 @@
-templates_info = {
+templates = {
     "chat_openai": {
         "name": "Single Prompt OpenAI",
         "description": "Sample single prompt application using different OpenAI models",
@@ -8,13 +8,3 @@ templates_info = {
         "description": "Sample Chat application using different OpenAI models",
     },
 }
-
-
-def get_oss_templates():
-    """
-    Returns a list of templates.
-
-    Returns:
-        List[dict]: A list of template dictionaries.
-    """
-    return templates_info

--- a/agenta-backend/agenta_backend/services/templates_manager.py
+++ b/agenta-backend/agenta_backend/services/templates_manager.py
@@ -15,15 +15,13 @@ from datetime import datetime, timezone
 
 from agenta_backend.services.helpers import convert_to_utc_datetime
 
+from agenta_backend.resources.templates.templates import (
+    get_oss_templates as get_templates,
+)
+
 if isCloud() or isOss():
     from agenta_backend.services import container_manager
 
-if isCloud():
-    from agenta_backend.commons.resources.templates.templates import get_templates
-elif isOss():
-    from agenta_backend.resources.templates.templates import (
-        get_oss_templates as get_templates,
-    )
 
 templates_base_url = os.getenv("TEMPLATES_BASE_URL")
 agenta_template_repo = os.getenv("AGENTA_TEMPLATE_REPO")

--- a/agenta-backend/agenta_backend/services/templates_manager.py
+++ b/agenta-backend/agenta_backend/services/templates_manager.py
@@ -18,6 +18,13 @@ from agenta_backend.services.helpers import convert_to_utc_datetime
 if isCloud() or isOss():
     from agenta_backend.services import container_manager
 
+if isCloud():
+    from agenta_backend.commons.resources.templates.templates import get_templates
+elif isOss():
+    from agenta_backend.resources.templates.templates import (
+        get_oss_templates as get_templates,
+    )
+
 templates_base_url = os.getenv("TEMPLATES_BASE_URL")
 agenta_template_repo = os.getenv("AGENTA_TEMPLATE_REPO")
 docker_hub_url = os.getenv("DOCKER_HUB_URL")
@@ -37,7 +44,7 @@ async def update_and_sync_templates(cache: bool = True) -> None:
     templates = await retrieve_templates_from_dockerhub_cached(cache)
 
     templates_ids_not_to_remove = []
-    templates_info = get_oss_templates()
+    templates_info = get_templates()
     for temp in templates:
         if temp["name"] in list(templates_info.keys()):
             templates_ids_not_to_remove.append(int(temp["id"]))

--- a/agenta-backend/agenta_backend/services/templates_manager.py
+++ b/agenta-backend/agenta_backend/services/templates_manager.py
@@ -124,28 +124,3 @@ async def retrieve_templates_from_dockerhub(
 
         response_data = response.json()
         return response_data
-
-
-@backoff.on_exception(
-    backoff.expo, (ConnectError, TimeoutException, CancelledError), max_tries=5
-)
-async def get_templates_info_from_s3(url: str) -> Dict[str, Dict[str, Any]]:
-    """
-    Business logic to retrieve templates information from S3.
-
-    Args:
-        url (str): The URL endpoint for retrieving templates info.
-
-    Returns:
-        response_data (Dict[str, Dict[str, Any]]): A dictionary \
-            containing dictionaries of templates information.
-    """
-
-    async with httpx.AsyncClient() as client:
-        response = await client.get(url, timeout=90)
-        if response.status_code == 200:
-            response_data = response.json()
-            return response_data
-
-        response_data = response.json()
-        return response_data

--- a/agenta-backend/agenta_backend/services/templates_manager.py
+++ b/agenta-backend/agenta_backend/services/templates_manager.py
@@ -104,34 +104,6 @@ async def retrieve_templates_from_dockerhub_cached(cache: bool) -> List[dict]:
     return response_data
 
 
-async def retrieve_templates_info_from_s3(
-    cache: bool,
-) -> Dict[str, Dict[str, Any]]:
-    """Retrieves templates information from s3 and caches the data in Redis for future use.
-
-    Args:
-        cache: A boolean value that indicates whether to use the cached data or not.
-
-    Returns:
-        Information about organization in s3 (cached or network-call)
-    """
-
-    r = redis_utils.redis_connection()
-    if cache:
-        cached_data = r.get("temp_data")
-        if cached_data is not None:
-            print("Using cache...")
-            return json.loads(cached_data)
-
-    # If not cached, fetch data from Docker Hub and cache it in Redis
-    response = await get_templates_info_from_s3(f"{templates_base_url}/llm_info.json")
-
-    # Cache the data in Redis for 60 minutes
-    r.set("temp_data", json.dumps(response), ex=900)
-    print("Using network call...")
-    return response
-
-
 @backoff.on_exception(backoff.expo, (ConnectError, CancelledError), max_tries=5)
 async def retrieve_templates_from_dockerhub(
     url: str, repo_name: str

--- a/agenta-backend/agenta_backend/services/templates_manager.py
+++ b/agenta-backend/agenta_backend/services/templates_manager.py
@@ -9,15 +9,12 @@ from httpx import ConnectError, TimeoutException
 from agenta_backend.utils import redis_utils
 from agenta_backend.services import db_manager
 from agenta_backend.utils.common import isCloud, isOss
-from agenta_backend.resources.templates.templates import get_oss_templates
 
 from datetime import datetime, timezone
 
 from agenta_backend.services.helpers import convert_to_utc_datetime
 
-from agenta_backend.resources.templates.templates import (
-    get_oss_templates as get_templates,
-)
+from agenta_backend.resources.templates.templates import templates
 
 if isCloud() or isOss():
     from agenta_backend.services import container_manager
@@ -39,14 +36,14 @@ async def update_and_sync_templates(cache: bool = True) -> None:
     Returns:
         None
     """
-    templates = await retrieve_templates_from_dockerhub_cached(cache)
+    docker_templates = await retrieve_templates_from_dockerhub_cached(cache)
 
     templates_ids_not_to_remove = []
-    templates_info = get_templates()
-    for temp in templates:
-        if temp["name"] in list(templates_info.keys()):
+
+    for temp in docker_templates:
+        if temp["name"] in list(templates.keys()):
             templates_ids_not_to_remove.append(int(temp["id"]))
-            temp_info = templates_info[temp["name"]]
+            temp_info = templates[temp["name"]]
             last_pushed = convert_to_utc_datetime(temp.get("last_pushed"))
 
             template_id = await db_manager.add_template(

--- a/agenta-backend/agenta_backend/services/templates_manager.py
+++ b/agenta-backend/agenta_backend/services/templates_manager.py
@@ -20,7 +20,6 @@ if isCloud() or isOss():
     from agenta_backend.services import container_manager
 
 
-templates_base_url = os.getenv("TEMPLATES_BASE_URL")
 agenta_template_repo = os.getenv("AGENTA_TEMPLATE_REPO")
 docker_hub_url = os.getenv("DOCKER_HUB_URL")
 

--- a/agenta-backend/agenta_backend/services/templates_manager.py
+++ b/agenta-backend/agenta_backend/services/templates_manager.py
@@ -9,6 +9,7 @@ from httpx import ConnectError, TimeoutException
 from agenta_backend.utils import redis_utils
 from agenta_backend.services import db_manager
 from agenta_backend.utils.common import isCloud, isOss
+from agenta_backend.resources.templates.templates import get_oss_templates
 
 from datetime import datetime, timezone
 
@@ -36,7 +37,7 @@ async def update_and_sync_templates(cache: bool = True) -> None:
     templates = await retrieve_templates_from_dockerhub_cached(cache)
 
     templates_ids_not_to_remove = []
-    templates_info = await retrieve_templates_info_from_s3(cache)
+    templates_info = get_oss_templates()
     for temp in templates:
         if temp["name"] in list(templates_info.keys()):
             templates_ids_not_to_remove.append(int(temp["id"]))

--- a/docker-compose.gh.yml
+++ b/docker-compose.gh.yml
@@ -26,7 +26,6 @@ services:
             - DOMAIN_NAME=${DOMAIN_NAME:-http://localhost}
             - CELERY_BROKER_URL=amqp://guest@rabbitmq//
             - CELERY_RESULT_BACKEND=redis://redis:6379/0
-            - TEMPLATES_BASE_URL=https://llm-app-json.s3.eu-central-1.amazonaws.com
             - REGISTRY_REPO_NAME=agentaai
             - DOCKER_HUB_URL=https://hub.docker.com/v2/repositories
         command:

--- a/docker-compose.prod.yml
+++ b/docker-compose.prod.yml
@@ -23,7 +23,6 @@ services:
             - AGENTA_TEMPLATE_REPO=agentaai/templates_v2
             - CELERY_BROKER_URL=amqp://guest@rabbitmq//
             - CELERY_RESULT_BACKEND=redis://redis:6379/0
-            - TEMPLATES_BASE_URL=https://llm-app-json.s3.eu-central-1.amazonaws.com
             - REGISTRY_REPO_NAME=agentaai
             - DOCKER_HUB_URL=https://hub.docker.com/v2/repositories
         volumes:

--- a/docker-compose.test.yml
+++ b/docker-compose.test.yml
@@ -27,7 +27,6 @@ services:
             - ALEMBIC_CFG_PATH=/app/agenta_backend/migrations/postgres/alembic.oss.ini
             - AGENTA_TEMPLATE_REPO=agentaai/templates_v2
             - POSTHOG_API_KEY=phc_hmVSxIjTW1REBHXgj2aw4HW9X6CXb6FzerBgP9XenC7
-            - TEMPLATES_BASE_URL=https://llm-app-json.s3.eu-central-1.amazonaws.com
             - REGISTRY_REPO_NAME=agentaai
             - DOCKER_HUB_URL=https://hub.docker.com/v2/repositories
         volumes:

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -26,7 +26,6 @@ services:
             - POSTHOG_API_KEY=phc_hmVSxIjTW1REBHXgj2aw4HW9X6CXb6FzerBgP9XenC7
             - CELERY_BROKER_URL=amqp://guest@rabbitmq//
             - CELERY_RESULT_BACKEND=redis://redis:6379/0
-            - TEMPLATES_BASE_URL=https://llm-app-json.s3.eu-central-1.amazonaws.com
             - REGISTRY_REPO_NAME=agentaai
             - DOCKER_HUB_URL=https://hub.docker.com/v2/repositories
         volumes:


### PR DESCRIPTION
We want to remove the list of the templates from being hosted in a public s3 bucket as there is no valid reason for having it there. As a result we are moving the list of templates to the backend.
A related PR for commons: https://github.com/Agenta-AI/agenta-commons/pull/122
Issue: https://linear.app/agenta/issue/AGE-1084/