### PR TITLE
[Enhancement]: Remove Pydantic warnings in CLI

### DIFF
--- a/agenta-cli/agenta/client/backend/core/pydantic_utilities.py
+++ b/agenta-cli/agenta/client/backend/core/pydantic_utilities.py
@@ -77,8 +77,6 @@ def to_jsonable_with_fallback(
 class UniversalBaseModel(pydantic.BaseModel):
     class Config:
         populate_by_name = True
-        smart_union = True
-        allow_population_by_field_name = True
         json_encoders = {dt.datetime: serialize_datetime}
 
     def json(self, **kwargs: typing.Any) -> str:

--- a/agenta-cli/pyproject.toml
+++ b/agenta-cli/pyproject.toml
@@ -1,6 +1,6 @@
 [tool.poetry]
 name = "agenta"
-version = "0.25.3"
+version = "0.25.4a4"
 description = "The SDK for agenta is an open-source LLMOps platform."
 readme = "README.md"
 authors = ["Mahmoud Mabrouk <mahmoud@agenta.ai>"]


### PR DESCRIPTION
## Description
This PR removes the Pydantic warnings on the CLI.

### Related Issue
Closes [AGE-1059](https://linear.app/agenta/issue/AGE-1059/remove-warnings-when-using-the-cli).

### QA

- Install the pre-release version of agenta==0.25.4a4
- Create an app from the CLI
- Serve the app to either cloud prod, beta or staging (any environment is fine)

### Acceptance Tests
- Verify that there are no CLI warnings on your terminal. 