### PR TITLE
[Bug Fix]: Resolve keyword argument error when deleting human evaluation after KeyError in annotation creation

### DIFF
--- a/agenta-backend/agenta_backend/services/evaluation_service.py
+++ b/agenta-backend/agenta_backend/services/evaluation_service.py
@@ -92,7 +92,7 @@ async def prepare_csvdata_and_create_evaluation_scenario(
             ]
         except KeyError:
             await db_manager.delete_human_evaluation(
-                evaluation_id=str(new_evaluation.id), project_id=project_id
+                evaluation_id=str(new_evaluation.id)
             )
             msg = f"""
             Columns in the test set should match the names of the inputs in the variant.


### PR DESCRIPTION
## Summary
This PR fixes a bug that caused a keyword argument error when attempting to call `delete_human_evaluation` after encountering a `KeyError` during the creation of a human annotation.

### Changes
- Adjusted the `delete_human_evaluation` function call to ensure the correct keyword arguments are passed.

### QA
1. Create a new app using the `simple_prompt` template on the UI.
2. Update the test set key `country` to `name_of_country`.
3. Create a human annotation.

### Acceptance Criteria
You should encounter the following error:

```txt
400: Columns in the test set should match the names of the inputs in the variant. Inputs names in variant are: ['country'] while columns in test set are: ['name_of_country'] 
```

Instead of this:

```txt
delete_human_evaluation() got an unexpected keyword argument 'project_id'
```
