### PR TITLE
fix(frontend): observability status render issue

### DIFF
--- a/agenta-web/src/components/pages/observability/components/StatusRenderer.tsx
+++ b/agenta-web/src/components/pages/observability/components/StatusRenderer.tsx
@@ -1,21 +1,10 @@
 import {_AgentaRootsResponse, NodeStatusCode, NodeStatusDTO} from "@/services/observability/types"
-import {
-    CheckCircleOutlined,
-    ClockCircleOutlined,
-    CloseCircleOutlined,
-    InfoCircleOutlined,
-} from "@ant-design/icons"
+import {CheckCircleOutlined, CloseCircleOutlined, InfoCircleOutlined} from "@ant-design/icons"
 import {Space, Tag, Tooltip} from "antd"
 import React from "react"
 
 export const statusMapper = (status: NodeStatusCode) => {
     switch (status) {
-        case NodeStatusCode.UNSET:
-            return {
-                label: "initiated",
-                color: "blue",
-                icon: <ClockCircleOutlined />,
-            }
         case NodeStatusCode.ERROR:
             return {
                 label: "failed",


### PR DESCRIPTION
### Description

This PR aims to fix the status render issue in the observability table

### Related Issue

Closes [AGE-1185](https://linear.app/agenta/issue/AGE-1185/success-status-are-shown-as-initiated-in-the-ui)