### PR TITLE
fix(frontend): observability LLM traceTab issue

### DIFF
--- a/agenta-web/src/pages/apps/[app_id]/observability/index.tsx
+++ b/agenta-web/src/pages/apps/[app_id]/observability/index.tsx
@@ -455,7 +455,7 @@ const ObservabilityDashboard = ({}: Props) => {
     }, [])
 
     const fetchFilterdTrace = async () => {
-        const focusPoint = traceTabs == "tree" || traceTabs == "node" ? `focus=${traceTabs}` : ""
+        const focusPoint = traceTabs == "chat" ? "focus=node" : `focus=${traceTabs}`
         const filterQuery = filters[0]?.operator
             ? `&filtering={"conditions":${JSON.stringify(filters)}}`
             : ""


### PR DESCRIPTION
### Description

This PR aims to fix the trace llm tab issue in the observability header.


### Related Issue 

Closes [AGE-1176](https://linear.app/agenta/issue/AGE-1176/llm-view-in-observability-table-is-showing-grouped-traces-instead-of)