### PR TITLE
fix(frontend): moved all the query states in the context-api

### DIFF
--- a/agenta-web/src/contexts/observability.context.tsx
+++ b/agenta-web/src/contexts/observability.context.tsx
@@ -8,19 +8,45 @@ import {
 } from "@/services/observability/types"
 import React, {createContext, PropsWithChildren, useContext, useEffect, useState} from "react"
 import {useRouter} from "next/router"
+import {SortResult} from "@/components/Filters/Sort"
+import {Filter} from "@/lib/Types"
 
 type ObservabilityContextType = {
     traces: _AgentaRootsResponse[]
     count: number
     isLoading: boolean
-    fetchTraces: (queries?: string) => void
+    fetchTraces: () => void
+    clearQueryStates: () => void
+    searchQuery: string
+    setSearchQuery: React.Dispatch<React.SetStateAction<string>>
+    traceTabs: TraceTabTypes
+    setTraceTabs: React.Dispatch<React.SetStateAction<TraceTabTypes>>
+    filters: Filter[]
+    setFilters: React.Dispatch<React.SetStateAction<Filter[]>>
+    sort: SortResult
+    setSort: React.Dispatch<React.SetStateAction<SortResult>>
+    pagination: {page: number; size: number}
+    setPagination: React.Dispatch<React.SetStateAction<{page: number; size: number}>>
 }
+
+type TraceTabTypes = "tree" | "node" | "chat"
 
 const initialValues: ObservabilityContextType = {
     traces: [],
     count: 0,
     isLoading: false,
     fetchTraces: () => {},
+    clearQueryStates: () => {},
+    searchQuery: "",
+    setSearchQuery: () => {},
+    traceTabs: "tree",
+    setTraceTabs: () => {},
+    filters: [],
+    setFilters: () => {},
+    sort: {type: "standard", sorted: ""},
+    setSort: () => {},
+    pagination: {page: 1, size: 10},
+    setPagination: () => {},
 }
 
 export const ObservabilityContext = createContext<ObservabilityContextType>(initialValues)
@@ -37,11 +63,20 @@ const ObservabilityContextProvider: React.FC<PropsWithChildren> = ({children}) =
     const [traces, setTraces] = useState<_AgentaRootsResponse[]>([])
     const [traceCount, setTraceCount] = useState(0)
     const [isLoading, setIsLoading] = useState(true)
+    // query states
+    const [searchQuery, setSearchQuery] = useState("")
+    const [traceTabs, setTraceTabs] = useState<TraceTabTypes>("tree")
+    const [filters, setFilters] = useState<Filter[]>([])
+    const [sort, setSort] = useState<SortResult>({} as SortResult)
+    const [pagination, setPagination] = useState({page: 1, size: 10})
 
-    const fetchTraces = async (queries?: string) => {
+    const fetchTraces = async () => {
         try {
             setIsLoading(true)
-            const data = await fetchAllTraces({appId, queries: queries || ""})
+
+            const queries = generateTraceQueryString()
+
+            const data = await fetchAllTraces(queries || "")
 
             const transformedTraces: _AgentaRootsResponse[] = []
 
@@ -77,11 +112,51 @@ const ObservabilityContextProvider: React.FC<PropsWithChildren> = ({children}) =
         }
     }
 
+    const generateTraceQueryString = () => {
+        const queryParts: string[] = []
+
+        if (appId) {
+            queryParts.push(
+                `filtering={"conditions":[{"key":"refs.application.id","operator":"is","value":"${appId}"}]}`,
+            )
+        }
+
+        const focusPoint = traceTabs === "chat" ? "focus=node" : `focus=${traceTabs}`
+        queryParts.push(focusPoint)
+
+        queryParts.push(`size=${pagination.size}`, `page=${pagination.page}`)
+
+        if (filters[0]?.operator) {
+            queryParts.push(`filtering={"conditions":${JSON.stringify(filters)}}`)
+        }
+
+        if (sort) {
+            if (sort.type === "standard") {
+                queryParts.push(`oldest=${sort.sorted}`)
+            } else if (sort.type === "custom" && sort.customRange?.startTime) {
+                queryParts.push(
+                    `oldest=${sort.customRange.startTime}`,
+                    `newest=${sort.customRange.endTime}`,
+                )
+            }
+        }
+
+        return `?${queryParts.join("&")}`
+    }
+
+    const clearQueryStates = () => {
+        setSearchQuery("")
+        setTraceTabs("tree")
+        setFilters([])
+        setSort({} as SortResult)
+        setPagination({page: 1, size: 10})
+    }
+
     useEffect(() => {
         if (appId) {
-            fetchTraces("&focus=tree&size=10&page=1")
+            fetchTraces()
         }
-    }, [appId])
+    }, [appId, filters, traceTabs, sort, pagination])
 
     observabilityContextValues.traces = traces
     observabilityContextValues.isLoading = isLoading
@@ -95,6 +170,17 @@ const ObservabilityContextProvider: React.FC<PropsWithChildren> = ({children}) =
                 isLoading,
                 fetchTraces,
                 count: traceCount || 0,
+                clearQueryStates,
+                searchQuery,
+                setSearchQuery,
+                traceTabs,
+                setTraceTabs,
+                filters,
+                setFilters,
+                sort,
+                setSort,
+                pagination,
+                setPagination,
             }}
         >
             {children}

--- a/agenta-web/src/services/observability/core/index.ts
+++ b/agenta-web/src/services/observability/core/index.ts
@@ -9,12 +9,8 @@ import axios from "@/lib/helpers/axiosConfig"
 //  - update: PUT data to server
 //  - delete: DELETE data from server
 
-export const fetchAllTraces = async ({appId, queries}: {appId: string; queries?: string}) => {
-    const filterByAppId = `filtering={"conditions":[{"key":"refs.application.id","operator":"is","value":"${appId}"}]}`
-
-    const response = await axios.get(
-        `${getAgentaApiUrl()}/api/observability/v1/traces?${filterByAppId}${queries}`,
-    )
+export const fetchAllTraces = async (queries?: string) => {
+    const response = await axios.get(`${getAgentaApiUrl()}/api/observability/v1/traces${queries}`)
     return response.data
 }
 

--- a/agenta-web/src/services/observability/core/index.ts
+++ b/agenta-web/src/services/observability/core/index.ts
@@ -9,8 +9,8 @@ import axios from "@/lib/helpers/axiosConfig"
 //  - update: PUT data to server
 //  - delete: DELETE data from server
 
-export const fetchAllTraces = async (queries?: string) => {
-    const response = await axios.get(`${getAgentaApiUrl()}/api/observability/v1/traces${queries}`)
+export const fetchAllTraces = async (params = {}) => {
+    const response = await axios.get(`${getAgentaApiUrl()}/api/observability/v1/traces`, {params})
     return response.data
 }
 


### PR DESCRIPTION
### Description

This PR aims to fix the query states state-management issue by moving up all the query states in the observability-context file.


### Related Issue

Closes [AGE-1196](https://linear.app/agenta/issue/AGE-1196/move-all-the-query-states-to-the-contextapi-for-better-state)

### QA
- All filters, windowing, and pagination should work as expected.
- Apply a filter, delete the trace, and view the updated data.