### PR TITLE
fix(frontend): observability filter column names style

### DIFF
--- a/agenta-web/src/components/Filters/Filters.tsx
+++ b/agenta-web/src/components/Filters/Filters.tsx
@@ -115,6 +115,19 @@ const Filters: React.FC<Props> = ({filterData, columns, onApplyFilter, onClearFi
         setIsFilterOpen(false)
     }
 
+    const mapColumnLabel = useMemo(
+        () =>
+            columns.reduce(
+                (acc, col) => {
+                    acc[col.value] = col.label
+                    return acc
+                },
+                {} as Record<string, string>,
+            ),
+        [columns],
+    )
+    const getColumnLabelFromValue = (key: string) => mapColumnLabel[key] || key
+
     return (
         <Popover
             title={null}
@@ -152,13 +165,17 @@ const Filters: React.FC<Props> = ({filterData, columns, onApplyFilter, onClearFi
                                         labelRender={(label) =>
                                             !label.value ? "Column" : label.label
                                         }
-                                        style={{width: 200}}
                                         popupMatchSelectWidth={220}
+                                        popupClassName="capitalize"
+                                        className="capitalize w-[200px]"
                                         suffixIcon={<CaretDown size={14} />}
                                         onChange={(value) =>
                                             onFilterChange({columnName: "key", value, idx})
                                         }
-                                        value={item.key}
+                                        value={{
+                                            value: item.key,
+                                            label: getColumnLabelFromValue(item.key),
+                                        }}
                                         options={filteredColumns}
                                         disabled={item.isPermanent}
                                     />

--- a/agenta-web/src/components/pages/observability/ObservabilityDashboard.tsx
+++ b/agenta-web/src/components/pages/observability/ObservabilityDashboard.tsx
@@ -170,8 +170,8 @@ const ObservabilityDashboard = () => {
             },
         },
         {
-            title: "Latency",
-            key: "latency",
+            title: "Duration",
+            key: "duration",
             dataIndex: ["time", "span"],
             width: 80,
             onHeaderCell: () => ({


### PR DESCRIPTION
### Description

This PR aims to fix the naming style of the options in the observability filter column select component. And also renamed the table `latency` column to `duration`.