### PR TITLE
limit dependabot to only security udates

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -4,18 +4,34 @@ updates:
     directory: "/agenta-backend"
     schedule:
       interval: "daily"
+    groups:
+      security-updates:
+        dependency-type: "production"
+        applies-to: "security-updates"
 
   - package-ecosystem: "pip"
     directory: "/agenta-cli"
     schedule:
       interval: "daily"
+    groups:
+      security-updates:
+        dependency-type: "production"
+        applies-to: "security-updates"
 
   - package-ecosystem: "npm"
     directory: "/agenta-web"
     schedule:
       interval: "daily"
+    groups:
+      security-updates:
+        dependency-type: "production"
+        applies-to: "security-updates"
 
   - package-ecosystem: "npm"
     directory: "/docs"
     schedule:
       interval: "daily"
+    groups:
+      security-updates:
+        dependency-type: "production"
+        applies-to: "security-updates"


### PR DESCRIPTION
This PR is to limit Dependabot to only security updates and not creating PRs whenever a dependency is bumped!