### PR TITLE
fix(frontend) renamed observability table time column name

### DIFF
--- a/agenta-web/src/components/pages/observability/ObservabilityDashboard.tsx
+++ b/agenta-web/src/components/pages/observability/ObservabilityDashboard.tsx
@@ -204,15 +204,17 @@ const ObservabilityDashboard = () => {
             ),
         },
         {
-            title: "Start time",
-            key: "start_time",
-            dataIndex: ["time", "start"],
+            title: "Timestamp",
+            key: "timestamp",
+            dataIndex: ["lifecycle", "created_at"],
             width: 200,
             onHeaderCell: () => ({
                 style: {minWidth: 200},
             }),
             render: (_, record) => {
-                return <div>{dayjs(record.time.start).format("HH:mm:ss DD MMM YYYY")}</div>
+                return (
+                    <div>{dayjs(record.lifecycle?.created_at).format("HH:mm:ss DD MMM YYYY")}</div>
+                )
             },
         },
         {


### PR DESCRIPTION
### Description

This PR aims to fix the observability table 'Start time' column name by renaming it to 'Timestamp'.

### Related Issue

Closes [AGE-1268](https://linear.app/agenta/issue/AGE-1268/ux-bug-ambiguous-time-columns-in-traces-table)