### PR TITLE
fix(frontend): trace drawer time, cost font style

### DIFF
--- a/agenta-web/src/components/pages/observability/drawer/TraceContent.tsx
+++ b/agenta-web/src/components/pages/observability/drawer/TraceContent.tsx
@@ -72,6 +72,12 @@ const useStyles = createUseStyles((theme: JSSTheme) => ({
             fontWeight: 400,
         },
     },
+    resultTag: {
+        display: "flex",
+        alignItems: "center",
+        fontFamily: "monospace",
+        gap: 4,
+    },
 }))
 
 const TraceContent = ({activeTrace}: TraceContentProps) => {
@@ -289,19 +295,19 @@ const TraceContent = ({activeTrace}: TraceContentProps) => {
                     <StatusRenderer status={activeTrace.status} />
                     <ResultTag
                         value1={
-                            <>
+                            <div className={classes.resultTag}>
                                 <Timer size={14} />{" "}
                                 {formatLatency(activeTrace?.metrics?.acc?.duration.total / 1000)}
-                            </>
+                            </div>
                         }
                     />
                     <ResultTag
                         value1={
-                            <>
+                            <div className={classes.resultTag}>
                                 <PlusCircle size={14} />
                                 {formatTokenUsage(activeTrace.metrics?.acc?.tokens?.total)} /{" "}
                                 {formatCurrency(activeTrace.metrics?.acc?.costs?.total)}
-                            </>
+                            </div>
                         }
                         popoverContent={
                             <Space direction="vertical">
@@ -324,11 +330,11 @@ const TraceContent = ({activeTrace}: TraceContentProps) => {
                     />
                     <ResultTag
                         value1={
-                            <>
+                            <div className={classes.resultTag}>
                                 {dayjs(activeTrace.time.start).format("DD/MM/YYYY, hh:mm:ss A")}
                                 <ArrowRight size={14} />{" "}
                                 {dayjs(activeTrace.time.end).format("DD/MM/YYYY, hh:mm:ss A")}
-                            </>
+                            </div>
                         }
                     />
                 </div>

--- a/agenta-web/src/components/pages/observability/drawer/TraceTree.tsx
+++ b/agenta-web/src/components/pages/observability/drawer/TraceTree.tsx
@@ -57,7 +57,7 @@ const useStyles = createUseStyles((theme: JSSTheme) => ({
         height: "100%",
         width: "calc(210px - 40px)",
     },
-    treeContent: {
+    treeContentContainer: {
         color: theme.colorTextSecondary,
         "& div": {
             display: "flex",
@@ -65,6 +65,12 @@ const useStyles = createUseStyles((theme: JSSTheme) => ({
             gap: 4,
             fontSize: theme.fontSize,
         },
+    },
+    treeContent: {
+        display: "flex",
+        alignItems: "center",
+        fontFamily: "monospace",
+        gap: 2,
     },
 }))
 
@@ -87,21 +93,21 @@ const TreeContent = ({value}: {value: _AgentaRootsResponse}) => {
                 >
                     {node.name}
                 </Typography.Text>
-                <Space className={classes.treeContent}>
-                    <div>
+                <Space className={classes.treeContentContainer}>
+                    <div className={classes.treeContent}>
                         <Timer />
                         {formatLatency(metrics?.acc?.duration.total / 1000)}
                     </div>
 
                     {metrics?.acc?.costs?.total && (
-                        <div>
+                        <div className={classes.treeContent}>
                             <Coins />
                             {formatCurrency(metrics?.acc?.costs?.total)}
                         </div>
                     )}
 
                     {!!metrics?.acc?.tokens?.total && (
-                        <div>
+                        <div className={classes.treeContent}>
                             <PlusCircle />
                             {formatTokenUsage(metrics?.acc?.tokens?.total)}
                         </div>


### PR DESCRIPTION
### Description

This PR aims to fix the observability trace drawer time, cost, etc, font style by changing the `inter` to `mono` font style.

### Related Issue

Closes [AGE-1271](https://linear.app/agenta/issue/AGE-1271/improvement-use-mono-font-for-typed-data-amount-datetime-etc)