### PR TITLE
fix(frontend): delete evaluation redirection url

### DIFF
--- a/agenta-web/src/components/pages/evaluations/evaluationScenarios/EvaluationScenarios.tsx
+++ b/agenta-web/src/components/pages/evaluations/evaluationScenarios/EvaluationScenarios.tsx
@@ -334,7 +334,7 @@ const EvaluationScenarios: React.FC<Props> = () => {
             message: "Are you sure you want to delete this evaluation?",
             onOk: () =>
                 deleteEvaluations([evaluationId])
-                    .then(() => router.push(`/apps/${appId}/evaluations/results`))
+                    .then(() => router.push(`/apps/${appId}/evaluations`))
                     .catch(console.error),
         })
     }


### PR DESCRIPTION
### Description

This PR aims to fix the evaluation delete redirection URL.

### Related Issue

Closes [AGE-1248](https://linear.app/agenta/issue/AGE-1248/bug-when-deleting-an-evaluation-from-the-evaluation-results-page)