### PR TITLE
fix(backend): predefined app environment order

### DIFF
--- a/agenta-backend/agenta_backend/routers/app_router.py
+++ b/agenta-backend/agenta_backend/routers/app_router.py
@@ -678,8 +678,13 @@ async def list_environments(
             app_id=app_id, project_id=request.state.project_id
         )
         logger.debug(f"environments_db: {environments_db}")
+
+        fixed_order = ["development", "staging", "production"]
+
+        sorted_environments = sorted(environments_db, key=lambda env: (fixed_order + [env.name]).index(env.name))
+
         return [
-            await converters.environment_db_to_output(env) for env in environments_db
+            await converters.environment_db_to_output(env) for env in sorted_environments
         ]
     except Exception as e:
         logger.exception(f"An error occurred: {str(e)}")

--- a/agenta-backend/agenta_backend/routers/app_router.py
+++ b/agenta-backend/agenta_backend/routers/app_router.py
@@ -681,10 +681,13 @@ async def list_environments(
 
         fixed_order = ["development", "staging", "production"]
 
-        sorted_environments = sorted(environments_db, key=lambda env: (fixed_order + [env.name]).index(env.name))
+        sorted_environments = sorted(
+            environments_db, key=lambda env: (fixed_order + [env.name]).index(env.name)
+        )
 
         return [
-            await converters.environment_db_to_output(env) for env in sorted_environments
+            await converters.environment_db_to_output(env)
+            for env in sorted_environments
         ]
     except Exception as e:
         logger.exception(f"An error occurred: {str(e)}")


### PR DESCRIPTION
### Description

This PR aims to fix the predefined app environment list order so that it maintains consistency.


### Related Issue

Closes [AGE-1242](https://linear.app/agenta/issue/AGE-1242/qli-environments-with-predefined-names-in-the-wrong-order)