### PR TITLE
fix(frontend): removed autocomplete from llm as a judge

### DIFF
--- a/agenta-web/src/components/pages/evaluations/autoEvaluation/EvaluatorsModal/ConfigureEvaluator/Messages.tsx
+++ b/agenta-web/src/components/pages/evaluations/autoEvaluation/EvaluatorsModal/ConfigureEvaluator/Messages.tsx
@@ -111,6 +111,7 @@ export const Messages: React.FC<MessagesProps> = ({value = [], onChange}) => {
                                             glyphMargin: false,
                                             lineNumbersMinChars: 0, // Reduces the space for line numbers
                                             folding: false,
+                                            quickSuggestions: false,
                                         }}
                                         onChange={(newValue) => {
                                             const currentMessages =


### PR DESCRIPTION
### Description

This PR aims to remove the autocomplete feature from the Monaco editor in LLM as a judge evaluator

### Related Issue

Closes [AGE-1257](https://linear.app/agenta/issue/AGE-1257/bug-remove-autocomplete-from-llm-as-a-judge-configuration-uiasas)