### PR TITLE
(frontend)[AGE-1262]: Values that are set to 0 are lost when exiting and re-entering

### DIFF
--- a/agenta-web/src/components/Evaluations/EvaluationCardView/EvaluationVotePanel.tsx
+++ b/agenta-web/src/components/Evaluations/EvaluationCardView/EvaluationVotePanel.tsx
@@ -270,7 +270,7 @@ const NumericScoreVote: React.FC<NumericScoreVoteProps> = ({
                     >
                         <InputNumber
                             defaultValue={
-                                value.find((item) => item.variantId === variant.variantId)?.score ||
+                                value.find((item) => item.variantId === variant.variantId)?.score ??
                                 undefined
                             }
                             min={min}


### PR DESCRIPTION
Closes [AGE-1262](https://linear.app/agenta/issue/AGE-1262/bug-values-that-are-set-to-0-are-lost-when-exiting-and-re-entering)