### PR TITLE
(frontend)[AGE-1258]: Highlighting of variables in LLM-as-a-Judge is functional but coloring is buggy

### DIFF
--- a/agenta-web/src/components/pages/evaluations/autoEvaluation/EvaluatorsModal/ConfigureEvaluator/Messages.tsx
+++ b/agenta-web/src/components/pages/evaluations/autoEvaluation/EvaluatorsModal/ConfigureEvaluator/Messages.tsx
@@ -95,7 +95,7 @@ export const Messages: React.FC<MessagesProps> = ({value = [], onChange}) => {
                                 >
                                     <Editor
                                         height="120px"
-                                        defaultLanguage="plaintext"
+                                        language="markdown"
                                         value={value[index]?.content || ""}
                                         options={{
                                             minimap: {enabled: false},
@@ -124,7 +124,7 @@ export const Messages: React.FC<MessagesProps> = ({value = [], onChange}) => {
                                         }}
                                         beforeMount={(monaco) => {
                                             // Add custom token provider for highlighting text between curly braces
-                                            monaco.languages.setMonarchTokensProvider("plaintext", {
+                                            monaco.languages.setMonarchTokensProvider("markdown", {
                                                 tokenizer: {
                                                     root: [[/{[^}]*}/, "variable"]],
                                                 },


### PR DESCRIPTION
Closes [AGE-1258](https://linear.app/agenta/issue/AGE-1258/bug-highlighting-of-variables-in-llm-as-a-judge-is-functional-but)