### PR TITLE
Add creating a tag after bumping versions

### DIFF
--- a/.github/workflows/bump-versions.yml
+++ b/.github/workflows/bump-versions.yml
@@ -71,6 +71,14 @@ jobs:
             echo "VERSIONS_MATCH=false" >> $GITHUB_OUTPUT
           fi
 
+      - name: Create and push tag
+        if: steps.bump_versions.outputs.VERSIONS_MATCH == 'true'
+        run: |
+          git config --global user.name "${{ github.actor }}"
+          git config --global user.email "${{ github.actor_id }}+${{ github.actor }}@users.noreply.github.com"
+          git tag -a "v${{ steps.bump_versions.outputs.NEW_VERSION }}" -m "Version ${{ steps.bump_versions.outputs.NEW_VERSION }}"
+          git push origin "v${{ steps.bump_versions.outputs.NEW_VERSION }}"
+
       - name: Create Pull Request
         if: steps.bump_versions.outputs.VERSIONS_MATCH == 'true'
         uses: peter-evans/create-pull-request@v6


### PR DESCRIPTION
Automatically creates a git tag when bumping versions so we don't do it manually.
It's also useful in case we forgot to do a git release and we merged new commits, we simply select the non-released tag from the release config page