### PR TITLE
fix(frontend): always show general observability

### DIFF
--- a/agenta-web/src/components/Sidebar/config.tsx
+++ b/agenta-web/src/components/Sidebar/config.tsx
@@ -60,6 +60,12 @@ export const useSidebarConfig = () => {
             tooltip: "Create new applications or switch between your existing projects.",
             link: "/apps",
             icon: <AppstoreOutlined />,
+        },
+        {
+            key: "app-observability-link",
+            title: "Observability",
+            link: `/observability`,
+            icon: <ChartLineUp />,
             divider: apps.length === 0 ? true : false,
         },
         {
@@ -68,13 +74,6 @@ export const useSidebarConfig = () => {
             tooltip: "Create and manage testsets for evaluation purposes.",
             link: `/apps/testsets`,
             icon: <DatabaseOutlined />,
-            isHidden: apps.length === 0,
-        },
-        {
-            key: "app-observability-link",
-            title: "Observability",
-            link: `/observability`,
-            icon: <ChartLineUp />,
             divider: true,
             isHidden: apps.length === 0,
         },


### PR DESCRIPTION
### Desccription

This PR aims to fix the visibility of the general observability, right now it only shows when there is an app, but the correct behavior is always to show general observability.


### Related Issue

Closes [AGE-1309](https://linear.app/agenta/issue/AGE-1309/[bug]-the-general-observability-page-is-not-shown-when-there-are-no)