### PR TITLE
fix(frontend): made observability table rows 50 default

### DIFF
--- a/agenta-web/src/contexts/observability.context.tsx
+++ b/agenta-web/src/contexts/observability.context.tsx
@@ -72,7 +72,7 @@ const ObservabilityContextProvider: React.FC<PropsWithChildren> = ({children}) =
             : [],
     )
     const [sort, setSort] = useState<SortResult>({} as SortResult)
-    const [pagination, setPagination] = useState({page: 1, size: 10})
+    const [pagination, setPagination] = useState({page: 1, size: 50})
 
     const fetchTraces = async () => {
         try {


### PR DESCRIPTION
Closes [AGE-1368](https://linear.app/agenta/issue/AGE-1368/set-default-rows-per-page-feature-in-observability-table-to-50)