### PR TITLE
fix(frontend): observability input column data in export results

### DIFF
--- a/agenta-web/src/components/pages/observability/ObservabilityDashboard.tsx
+++ b/agenta-web/src/components/pages/observability/ObservabilityDashboard.tsx
@@ -349,7 +349,7 @@ const ObservabilityDashboard = () => {
                     "Trace ID": trace.key,
                     Name: trace.node.name,
                     "Span type": trace.node.type || "N/A",
-                    Inputs: convertToStringOrJson(trace?.data?.inputs?.topic) || "N/A",
+                    Inputs: convertToStringOrJson(trace?.data?.inputs) || "N/A",
                     Outputs: convertToStringOrJson(trace?.data?.outputs) || "N/A",
                     Duration: formatLatency(trace?.metrics?.acc?.duration.total / 1000),
                     Cost: formatCurrency(trace.metrics?.acc?.costs?.total),


### PR DESCRIPTION
### Description

This PR aims to fix the observability input column data in export results.

### Related Issue 

- Closes [AGE-1372](https://linear.app/agenta/issue/AGE-1372/[bug]-when-exporting-traces-in-observabillity-the-input-column)
- Closes #2294