### PR TITLE
fix(frontend): removed capitalization from app name

### DIFF
--- a/agenta-web/src/components/AppSelector/AppCard.tsx
+++ b/agenta-web/src/components/AppSelector/AppCard.tsx
@@ -2,7 +2,6 @@ import {Card, Dropdown, Button, Typography, Tag} from "antd"
 import {MoreOutlined} from "@ant-design/icons"
 import {deleteApp} from "@/services/app-selector/api"
 import {useState} from "react"
-import {renameVariablesCapitalizeAll} from "@/lib/helpers/utils"
 import {createUseStyles} from "react-jss"
 import {JSSTheme, ListAppsItem} from "@/lib/Types"
 import {useAppsData} from "@/contexts/app.context"
@@ -83,7 +82,7 @@ const AppCard: React.FC<{
         <>
             <Card
                 className={classes.card}
-                title={renameVariablesCapitalizeAll(app.app_name)}
+                title={app.app_name}
                 onClick={() => router.push(`/apps/${app.app_id}/overview`)}
                 extra={
                     <Dropdown

--- a/agenta-web/src/components/Layout/Layout.tsx
+++ b/agenta-web/src/components/Layout/Layout.tsx
@@ -3,7 +3,7 @@ import {Breadcrumb, Layout, Modal, Space, Typography, theme} from "antd"
 import Sidebar from "../Sidebar/Sidebar"
 import {GithubFilled, LinkedinFilled, TwitterOutlined} from "@ant-design/icons"
 import Link from "next/link"
-import {isDemo, renameVariablesCapitalizeAll} from "@/lib/helpers/utils"
+import {isDemo} from "@/lib/helpers/utils"
 import {useAppTheme} from "./ThemeContextProvider"
 import {useElementSize} from "usehooks-ts"
 import {createUseStyles} from "react-jss"
@@ -84,7 +84,6 @@ const App: React.FC<LayoutProps> = ({children}) => {
     const {user} = useProfileData()
     const {appTheme} = useAppTheme()
     const {currentApp} = useAppsData()
-    const capitalizedAppName = renameVariablesCapitalizeAll(currentApp?.app_name || "")
     const [footerRef, {height: footerHeight}] = useElementSize()
     const classes = useStyles({themeMode: appTheme, footerHeight} as StyleProps)
     const router = useRouter()
@@ -190,7 +189,7 @@ const App: React.FC<LayoutProps> = ({children}) => {
                                                         </div>
                                                     ),
                                                 },
-                                                {title: capitalizedAppName},
+                                                {title: currentApp?.app_name || ""},
                                             ]}
                                         />
                                         <div className={classes.topRightBar}>

--- a/agenta-web/src/components/Sidebar/config.tsx
+++ b/agenta-web/src/components/Sidebar/config.tsx
@@ -1,7 +1,7 @@
 import {useAppId} from "@/hooks/useAppId"
 import {useSession} from "@/hooks/useSession"
 import {dynamicContext} from "@/lib/helpers/dynamic"
-import {isDemo, renameVariablesCapitalizeAll} from "@/lib/helpers/utils"
+import {isDemo} from "@/lib/helpers/utils"
 import {AppstoreOutlined, DatabaseOutlined, RocketOutlined, GithubFilled} from "@ant-design/icons"
 import {useEffect, useState} from "react"
 import {
@@ -41,7 +41,6 @@ export const useSidebarConfig = () => {
     const appId = useAppId()
     const {doesSessionExist} = useSession()
     const {currentApp, recentlyVisitedAppId, apps} = useAppsData()
-    const capitalizedAppName = renameVariablesCapitalizeAll(currentApp?.app_name || "")
     const isOss = !isDemo()
     const [useOrgData, setUseOrgData] = useState<Function>(() => () => "")
 
@@ -80,7 +79,7 @@ export const useSidebarConfig = () => {
         },
         {
             key: `${currentApp?.app_name || ""}_key`,
-            title: capitalizedAppName,
+            title: currentApp?.app_name || "",
             icon: <></>,
             header: true,
         },

--- a/agenta-web/src/pages/apps/[app_id]/overview/index.tsx
+++ b/agenta-web/src/pages/apps/[app_id]/overview/index.tsx
@@ -8,7 +8,6 @@ import VariantsOverview from "@/components/pages/overview/variants/VariantsOverv
 import {useAppsData} from "@/contexts/app.context"
 import {useAppId} from "@/hooks/useAppId"
 import {dynamicComponent} from "@/lib/helpers/dynamic"
-import {renameVariablesCapitalizeAll} from "@/lib/helpers/utils"
 import {Environment, JSSTheme, Variant} from "@/lib/Types"
 import {fetchSingleProfile, fetchVariants} from "@/services/api"
 import {deleteApp} from "@/services/app-selector/api"
@@ -44,7 +43,6 @@ export default function Overview() {
     const appId = useAppId()
     const classes = useStyles()
     const {currentApp} = useAppsData()
-    const capitalizedAppName = renameVariablesCapitalizeAll(currentApp?.app_name || "")
     const [variants, setVariants] = useState<Variant[]>([])
     const [isVariantLoading, setIsVariantLoading] = useState(false)
     const [isDeleteAppModalOpen, setIsDeleteAppModalOpen] = useState(false)
@@ -118,7 +116,7 @@ export default function Overview() {
         <>
             <div className={classes.container}>
                 <Space className="justify-between">
-                    <Title>{capitalizedAppName}</Title>
+                    <Title>{currentApp?.app_name || ""}</Title>
 
                     <Dropdown
                         trigger={["click"]}


### PR DESCRIPTION
### Description
This PR aims to fix the app-name formatting issue by removing the capitalization from the app-name

### Related Issue

Closes [AGE-1329](https://linear.app/agenta/issue/AGE-1329/show-app-name-in-app-management-page-without-automatic-capitalization)