### PR TITLE
fix edge case llm-as-a-judge

### DIFF
--- a/agenta-backend/agenta_backend/services/evaluators_service.py
+++ b/agenta-backend/agenta_backend/services/evaluators_service.py
@@ -363,7 +363,7 @@ async def auto_ai_critique(
         output = validate_string_output("ai_critique", output)
         correct_answer = get_correct_answer(data_point, settings_values)
         inputs = {
-            "prompt_user": app_params.get("prompt_user", "").format(**data_point),
+            "prompt_user": app_params.get("prompt_user", ""),
             "prediction": output,
             "ground_truth": correct_answer,
             **data_point,


### PR DESCRIPTION
This PR fixes an edge case in llm as a judge.

The function `async def auto_ai_critique` prepares the inputs for the llm-as-a-judge. One of the thing it does is preparing the input prompt of the application, which can be then used in the prompt of the llm-as-a-judge.

What is does it that it fills the variables in that prompt. However that does not work in the case of custom workflows, since sometimes the variables of the prompt are not available to the app (they are substeps).

I have removed the formatting of that string and resolved the problem.

This variable anyways is useless. Since it assumes the prompt is in a variable called prompt_user, it is only kept for now for backward compatibility. 