### PR TITLE
(frontend)[AGE-1374]: Regression wrong time shown in traces

### DIFF
--- a/agenta-web/src/components/Playground/Views/TestView.tsx
+++ b/agenta-web/src/components/Playground/Views/TestView.tsx
@@ -219,7 +219,7 @@ const BoxComponent: React.FC<BoxComponentProps> = ({
         }
     }, [traceSpans])
 
-    const activeTrace = useMemo(() => (traces ? traces[0] ?? null : null), [traces])
+    const activeTrace = useMemo(() => (traces ? (traces[0] ?? null) : null), [traces])
     const [selected, setSelected] = useState("")
 
     useEffect(() => {
@@ -623,7 +623,7 @@ const App: React.FC<TestViewProps> = ({
                         const firstTraceNode = tree.nodes[0]
                         newDataList[index] = {
                             cost: firstTraceNode?.metrics?.acc?.costs?.total ?? null,
-                            latency: firstTraceNode?.metrics?.acc?.duration?.total / 1000 ?? null,
+                            latency: firstTraceNode?.metrics?.acc?.duration?.total / 1000 || null,
                             usage: firstTraceNode?.metrics?.acc?.tokens?.total ?? null,
                         }
                     }

--- a/agenta-web/src/components/Playground/Views/TestView.tsx
+++ b/agenta-web/src/components/Playground/Views/TestView.tsx
@@ -219,7 +219,7 @@ const BoxComponent: React.FC<BoxComponentProps> = ({
         }
     }, [traceSpans])
 
-    const activeTrace = useMemo(() => (traces ? (traces[0] ?? null) : null), [traces])
+    const activeTrace = useMemo(() => (traces ? traces[0] ?? null : null), [traces])
     const [selected, setSelected] = useState("")
 
     useEffect(() => {

--- a/agenta-web/src/components/pages/observability/ObservabilityDashboard.tsx
+++ b/agenta-web/src/components/pages/observability/ObservabilityDashboard.tsx
@@ -182,8 +182,8 @@ const ObservabilityDashboard = () => {
                 <div>
                     {formatLatency(
                         record?.metrics?.acc?.duration?.total
-                            ? record?.metrics?.acc?.duration?.total
-                            : record?.metrics?.acc?.tokens?.total / 1000,
+                            ? record?.metrics?.acc?.duration?.total / 1000
+                            : null,
                     )}
                 </div>
             ),

--- a/agenta-web/src/components/pages/observability/drawer/TraceContent.tsx
+++ b/agenta-web/src/components/pages/observability/drawer/TraceContent.tsx
@@ -299,8 +299,8 @@ const TraceContent = ({activeTrace}: TraceContentProps) => {
                                 <Timer size={14} />{" "}
                                 {formatLatency(
                                     activeTrace?.metrics?.acc?.duration?.total
-                                        ? activeTrace?.metrics?.acc?.duration?.total
-                                        : activeTrace?.metrics?.acc?.tokens?.total / 1000,
+                                        ? activeTrace?.metrics?.acc?.duration?.total / 1000
+                                        : null,
                                 )}
                             </div>
                         }

--- a/agenta-web/src/components/pages/observability/drawer/TraceTree.tsx
+++ b/agenta-web/src/components/pages/observability/drawer/TraceTree.tsx
@@ -98,8 +98,8 @@ const TreeContent = ({value}: {value: _AgentaRootsResponse}) => {
                         <Timer />
                         {formatLatency(
                             metrics?.acc?.duration?.total
-                                ? metrics?.acc?.duration?.total
-                                : metrics?.acc?.tokens?.total / 1000,
+                                ? metrics?.acc?.duration?.total / 1000
+                                : null,
                         )}
                     </div>
 


### PR DESCRIPTION
Closes [AGE-1374](https://linear.app/agenta/issue/AGE-1374/[bug]-regression-wrong-time-shown-in-traces)