### PR TITLE
[Feat]: implement Test set drawer UI

### DIFF
--- a/agenta-web/src/components/GenericDrawer/index.tsx
+++ b/agenta-web/src/components/GenericDrawer/index.tsx
@@ -7,11 +7,11 @@ type GenericDrawerProps = {
     headerExtra?: ReactNode
     mainContent: ReactNode
     sideContent?: ReactNode
-    drawerWidth?: number
+    initialWidth?: number
 } & React.ComponentProps<typeof Drawer>
 
 const GenericDrawer = ({...props}: GenericDrawerProps) => {
-    const initialWidth = props.drawerWidth || 1200
+    const initialWidth = props.initialWidth || 1200
     const [drawerWidth, setDrawerWidth] = useState(initialWidth)
 
     return (

--- a/agenta-web/src/components/GenericDrawer/index.tsx
+++ b/agenta-web/src/components/GenericDrawer/index.tsx
@@ -7,10 +7,12 @@ type GenericDrawerProps = {
     headerExtra?: ReactNode
     mainContent: ReactNode
     sideContent?: ReactNode
+    drawerWidth?: number
 } & React.ComponentProps<typeof Drawer>
 
 const GenericDrawer = ({...props}: GenericDrawerProps) => {
-    const [drawerWidth, setDrawerWidth] = useState(1200)
+    const initialWidth = props.drawerWidth || 1200
+    const [drawerWidth, setDrawerWidth] = useState(initialWidth)
 
     return (
         <Drawer
@@ -28,15 +30,15 @@ const GenericDrawer = ({...props}: GenericDrawerProps) => {
                     {props.expandable && (
                         <Button
                             onClick={() => {
-                                if (drawerWidth === 1200) {
+                                if (drawerWidth === initialWidth) {
                                     setDrawerWidth(1920)
                                 } else {
-                                    setDrawerWidth(1200)
+                                    setDrawerWidth(initialWidth)
                                 }
                             }}
                             type="text"
                             icon={
-                                drawerWidth === 1200 ? (
+                                drawerWidth === initialWidth ? (
                                     <FullscreenOutlined />
                                 ) : (
                                     <FullscreenExitOutlined />

--- a/agenta-web/src/components/pages/observability/ObservabilityDashboard.tsx
+++ b/agenta-web/src/components/pages/observability/ObservabilityDashboard.tsx
@@ -14,7 +14,7 @@ import {useAppId} from "@/hooks/useAppId"
 import {useQueryParam} from "@/hooks/useQuery"
 import {formatCurrency, formatLatency, formatTokenUsage} from "@/lib/helpers/formatters"
 import {getNodeById} from "@/lib/helpers/observability_helpers"
-import {Filter, FilterConditions, JSSTheme} from "@/lib/Types"
+import {Filter, FilterConditions, JSSTheme, KeyValuePair} from "@/lib/Types"
 import {_AgentaRootsResponse} from "@/services/observability/types"
 import {ReloadOutlined, SwapOutlined} from "@ant-design/icons"
 import {
@@ -83,7 +83,7 @@ const ObservabilityDashboard = () => {
     const [isTestsetDrawerOpen, setIsTestsetDrawerOpen] = useState(false)
     const [selectedRowKeys, setSelectedRowKeys] = useState<React.Key[]>([])
     const [testsetDrawerData, setTestsetDrawerData] = useState<
-        {key: string; data: Record<string, any>}[]
+        {key: string; data: KeyValuePair; id: number}[]
     >([])
     const [columns, setColumns] = useState<ColumnsType<_AgentaRootsResponse>>([
         {
@@ -504,7 +504,7 @@ const ObservabilityDashboard = () => {
 
         const extractData = traces
             .filter((trace) => selectedRowKeys.includes(trace.key))
-            .flatMap((trace) => ({data: trace.data, key: trace.key}))
+            .flatMap((trace, idx) => ({data: trace.data, key: trace.key, id: idx + 1}))
 
         if (extractData.length > 0) {
             setTestsetDrawerData(extractData as any)

--- a/agenta-web/src/components/pages/observability/ObservabilityDashboard.tsx
+++ b/agenta-web/src/components/pages/observability/ObservabilityDashboard.tsx
@@ -35,12 +35,13 @@ import dayjs from "dayjs"
 import {useRouter} from "next/router"
 import React, {useCallback, useEffect, useMemo, useState} from "react"
 import {createUseStyles} from "react-jss"
-import {Export} from "@phosphor-icons/react"
+import {Database, Export} from "@phosphor-icons/react"
 import {getAppValues} from "@/contexts/app.context"
 import {convertToCsv, downloadCsv} from "@/lib/helpers/fileManipulations"
 import {useUpdateEffect} from "usehooks-ts"
 import {getStringOrJson} from "@/lib/helpers/utils"
 import ObservabilityContextProvider, {useObservabilityData} from "@/contexts/observability.context"
+import TestsetDrawer from "./drawer/TestsetDrawer"
 
 const useStyles = createUseStyles((theme: JSSTheme) => ({
     title: {
@@ -79,6 +80,7 @@ const ObservabilityDashboard = () => {
     const [selectedTraceId, setSelectedTraceId] = useQueryParam("trace", "")
     const [editColumns, setEditColumns] = useState<string[]>(["span_type", "key", "usage"])
     const [isFilterColsDropdownOpen, setIsFilterColsDropdownOpen] = useState(false)
+    const [isTestsetDrawerOpen, setIsTestsetDrawerOpen] = useState(false)
     const [columns, setColumns] = useState<ColumnsType<_AgentaRootsResponse>>([
         {
             title: "ID",
@@ -536,6 +538,13 @@ const ObservabilityDashboard = () => {
                         >
                             Export as CSV
                         </Button>
+                        <Button
+                            onClick={() => setIsTestsetDrawerOpen(true)}
+                            icon={<Database size={14} />}
+                            disabled={traces.length === 0}
+                        >
+                            Add test set
+                        </Button>
                         <EditColumns
                             isOpen={isFilterColsDropdownOpen}
                             handleOpenChange={setIsFilterColsDropdownOpen}
@@ -614,6 +623,8 @@ const ObservabilityDashboard = () => {
                     onChange={onPaginationChange}
                 />
             </div>
+
+            <TestsetDrawer open={isTestsetDrawerOpen} setOpen={setIsTestsetDrawerOpen} />
 
             {activeTrace && !!traces?.length && (
                 <GenericDrawer

--- a/agenta-web/src/components/pages/observability/ObservabilityDashboard.tsx
+++ b/agenta-web/src/components/pages/observability/ObservabilityDashboard.tsx
@@ -502,55 +502,14 @@ const ObservabilityDashboard = () => {
     const getMatchingTracesByDataKeys = () => {
         if (!traces?.length) return []
 
-        // step 1: extract data from the trace - skiped children for now
-        // TODO: get the traces children nodes as well
         const extractData = traces
             .filter((trace) => selectedRowKeys.includes(trace.key))
-            .flatMap((trace) => {
-                const {data, key, ...rest} = trace
-                return {data, key}
-            })
+            .flatMap((trace) => ({data: trace.data, key: trace.key}))
 
-        // step 2: compare each array keys with each other to check similarities
-        const similarObjects = findSimilarObjects(extractData)
-        if (similarObjects.length > 0) {
-            setTestsetDrawerData(similarObjects as any)
+        if (extractData.length > 0) {
+            setTestsetDrawerData(extractData as any)
             setIsTestsetDrawerOpen(true)
         }
-    }
-
-    const findSimilarObjects = (array: any[]): any[][] => {
-        const getKeySignature = (obj: any): string => {
-            // Function to extract nested keys
-            const extractKeys = (obj: any, prefix = ""): string[] =>
-                Object.keys(obj).flatMap((key) => {
-                    const fullPath = prefix ? `${prefix}.${key}` : key
-
-                    return typeof obj[key] === "object" &&
-                        obj[key] !== null &&
-                        !Array.isArray(obj[key])
-                        ? extractKeys(obj[key], fullPath)
-                        : fullPath
-                })
-
-            // Return the normalized keys as a string
-            return extractKeys(obj).sort().join(",")
-        }
-
-        // Group objects by their key structure and return groups with more than one item
-        const groups = array.reduce<Record<string, any[]>>((acc, item) => {
-            const keySignature = getKeySignature(item)
-            acc[keySignature] = acc[keySignature] || []
-            acc[keySignature].push(item)
-            return acc
-        }, {})
-
-        const mostSimilarGroup = Object.values(groups).reduce(
-            (maxGroup, currentGroup) =>
-                currentGroup.length > maxGroup.length ? currentGroup : maxGroup,
-            [],
-        )
-        return mostSimilarGroup
     }
 
     return (
@@ -699,9 +658,9 @@ const ObservabilityDashboard = () => {
                     open={isTestsetDrawerOpen}
                     data={testsetDrawerData}
                     onClose={() => {
-                        setIsTestsetDrawerOpen(false)
                         setSelectedRowKeys([])
                         setTestsetDrawerData([])
+                        setIsTestsetDrawerOpen(false)
                     }}
                 />
             )}

--- a/agenta-web/src/components/pages/observability/ObservabilityDashboard.tsx
+++ b/agenta-web/src/components/pages/observability/ObservabilityDashboard.tsx
@@ -499,15 +499,13 @@ const ObservabilityDashboard = () => {
     const getTestsetTraceData = () => {
         if (!traces?.length) return []
 
-        const extractData = traces.reduce<TestsetTraceData[]>((acc, trace, idx) => {
-            if (selectedRowKeys.includes(trace.key)) {
-                acc.push({data: trace.data as KeyValuePair, key: trace.key, id: idx + 1})
-            }
-            return acc
-        }, [])
+        const extractData = selectedRowKeys.map((key, idx) => {
+            const node = getNodeById(traces, key as string)
+            return {data: node?.data as KeyValuePair, key: node?.key, id: idx + 1}
+        })
 
         if (extractData.length > 0) {
-            setTestsetDrawerData(extractData)
+            setTestsetDrawerData(extractData as TestsetTraceData[])
         }
     }
 

--- a/agenta-web/src/components/pages/observability/ObservabilityDashboard.tsx
+++ b/agenta-web/src/components/pages/observability/ObservabilityDashboard.tsx
@@ -81,6 +81,7 @@ const ObservabilityDashboard = () => {
     const [editColumns, setEditColumns] = useState<string[]>(["span_type", "key", "usage"])
     const [isFilterColsDropdownOpen, setIsFilterColsDropdownOpen] = useState(false)
     const [isTestsetDrawerOpen, setIsTestsetDrawerOpen] = useState(false)
+    const [selectedRowKeys, setSelectedRowKeys] = useState<React.Key[]>([])
     const [columns, setColumns] = useState<ColumnsType<_AgentaRootsResponse>>([
         {
             title: "ID",
@@ -264,6 +265,12 @@ const ObservabilityDashboard = () => {
 
         return () => clearInterval(interval)
     }, [])
+
+    const rowSelection = {
+        onChange: (selectedRowKeys: React.Key[]) => {
+            setSelectedRowKeys(selectedRowKeys)
+        },
+    }
 
     const selectedItem = useMemo(
         () => (traces?.length ? getNodeById(traces, selected) : null),
@@ -541,7 +548,7 @@ const ObservabilityDashboard = () => {
                         <Button
                             onClick={() => setIsTestsetDrawerOpen(true)}
                             icon={<Database size={14} />}
-                            disabled={traces.length === 0}
+                            disabled={traces.length === 0 || selectedRowKeys.length === 0}
                         >
                             Add test set
                         </Button>
@@ -558,6 +565,12 @@ const ObservabilityDashboard = () => {
 
             <div className="flex flex-col gap-2">
                 <Table
+                    rowSelection={{
+                        type: "checkbox",
+                        columnWidth: 48,
+                        selectedRowKeys,
+                        ...rowSelection,
+                    }}
                     loading={isLoading}
                     columns={mergedColumns as TableColumnType<_AgentaRootsResponse>[]}
                     dataSource={traces}

--- a/agenta-web/src/components/pages/observability/drawer/TestsetDrawer.tsx
+++ b/agenta-web/src/components/pages/observability/drawer/TestsetDrawer.tsx
@@ -92,18 +92,21 @@ const TestsetDrawer = ({onClose, data, ...props}: Props) => {
     )
 
     // predefind options
-    const customSelectOptions = useMemo(
-        () => [
+    const customSelectOptions = (divider = true) => {
+        return [
             {value: "create", label: "Create New"},
-            {
-                value: "divider",
-                label: <Divider className="!my-1" />,
-                className: "!p-0 !m-0 !min-h-0.5 !cursor-default",
-                disabled: true,
-            },
-        ],
-        [],
-    )
+            ...(divider
+                ? [
+                      {
+                          value: "divider",
+                          label: <Divider className="!my-1" />,
+                          className: "!p-0 !m-0 !min-h-0.5 !cursor-default",
+                          disabled: true,
+                      },
+                  ]
+                : []),
+        ]
+    }
 
     const onTestsetOptionChange = async (option: {label: string; value: string}) => {
         const {value, label} = option
@@ -406,7 +409,7 @@ const TestsetDrawer = ({onClose, data, ...props}: Props) => {
                                     }
                                     onChange={onTestsetOptionChange}
                                     options={[
-                                        ...customSelectOptions,
+                                        ...customSelectOptions(listOfTestsets.length > 0),
                                         ...listOfTestsets.map((item: testset) => ({
                                             value: item._id,
                                             label: item.name,
@@ -558,7 +561,9 @@ const TestsetDrawer = ({onClose, data, ...props}: Props) => {
                                                             }
                                                             options={[
                                                                 ...(testset.id
-                                                                    ? customSelectOptions
+                                                                    ? customSelectOptions(
+                                                                          columnOptions.length > 0,
+                                                                      )
                                                                     : []),
                                                                 ...columnOptions?.map((column) => ({
                                                                     value: column,

--- a/agenta-web/src/components/pages/observability/drawer/TestsetDrawer.tsx
+++ b/agenta-web/src/components/pages/observability/drawer/TestsetDrawer.tsx
@@ -297,7 +297,9 @@ const TestsetDrawer = ({onClose, data, ...props}: Props) => {
         const seenValues = new Set<string>()
 
         return mappingData.some((item) => {
-            const columnValues = [item.column, item.newColumn].filter(Boolean)
+            const columnValues = [item.column, item.newColumn]
+                .filter(Boolean)
+                .filter((value) => value !== "create")
 
             return columnValues.some((value) => {
                 if (seenValues.has(value as string)) return true

--- a/agenta-web/src/components/pages/observability/drawer/TestsetDrawer.tsx
+++ b/agenta-web/src/components/pages/observability/drawer/TestsetDrawer.tsx
@@ -1,0 +1,254 @@
+import GenericDrawer from "@/components/GenericDrawer"
+import {ArrowRight, Copy, PencilSimple, Plus, Trash} from "@phosphor-icons/react"
+import {Button, Checkbox, Divider, DrawerProps, Input, Radio, Select, Table, Typography} from "antd"
+import React, {useState} from "react"
+import {useAppTheme} from "@/components/Layout/ThemeContextProvider"
+import {Editor} from "@monaco-editor/react"
+import {createUseStyles} from "react-jss"
+import {JSSTheme} from "@/lib/Types"
+
+const useStyles = createUseStyles((theme: JSSTheme) => ({
+    editor: {
+        border: `1px solid ${theme.colorBorder}`,
+        borderRadius: theme.borderRadius,
+        overflow: "hidden",
+        "& .monaco-editor": {
+            width: "0 !important",
+        },
+    },
+    drawerHeading: {
+        fontSize: theme.fontSizeLG,
+        lineHeight: theme.lineHeightLG,
+        fontWeight: theme.fontWeightMedium,
+    },
+    container: {
+        display: "flex",
+        flexDirection: "column",
+        gap: 4,
+    },
+    label: {
+        fontWeight: theme.fontWeightMedium,
+    },
+}))
+
+const TestsetDrawer = ({open, setOpen}: any) => {
+    const {appTheme} = useAppTheme()
+    const classes = useStyles()
+    const [isNewTestset, setIsNewTestset] = useState(false)
+    const [testset, setTestset] = useState("")
+    const [testsetName, setTestsetName] = useState("")
+    const [formatType, setFormatType] = useState("json")
+
+    const onClose = () => {
+        setOpen(false)
+    }
+
+    // predifind options
+    const customSelectOptions = [
+        {value: "create", label: "Create New Test set"},
+        {
+            value: "divider",
+            label: <Divider className="!my-1" />,
+            className: "!p-0 !m-0 !min-h-0.5 !cursor-default",
+            disabled: true,
+        },
+    ]
+
+    const handleChange = (value: string) => {}
+
+    const onTestsetOptionChange = (value: string) => {
+        if (value === "create") {
+            setIsNewTestset(true)
+        } else {
+            setIsNewTestset(false)
+        }
+        setTestset(value)
+    }
+
+    const testsetOptions = [
+        ...customSelectOptions,
+        {value: "jack", label: "Jack"},
+        {value: "lucy", label: "Lucy"},
+    ]
+
+    const Content = () => {
+        return (
+            <section className="w-full flex flex-col gap-6">
+                <Typography.Text className={classes.drawerHeading}>
+                    Spans selected 65
+                </Typography.Text>
+
+                <div className={classes.container}>
+                    <Typography.Text className={classes.label}>Test set</Typography.Text>
+                    <div className="flex gap-2">
+                        <Select
+                            style={{width: 200}}
+                            placeholder="Select Test set"
+                            value={testset}
+                            onChange={onTestsetOptionChange}
+                            options={testsetOptions}
+                        />
+
+                        {isNewTestset && (
+                            <div className="relative">
+                                <Input
+                                    style={{width: 200}}
+                                    value={testsetName}
+                                    onChange={(e) => setTestsetName(e.target.value)}
+                                    placeholder="Test set name"
+                                />
+                                <PencilSimple size={14} className="absolute top-[8px] right-2" />
+                            </div>
+                        )}
+                    </div>
+                </div>
+
+                <div className={classes.container}>
+                    <Typography.Text className={classes.label}>Data preview</Typography.Text>
+
+                    <div className="flex justify-between items-center mb-2">
+                        <Select
+                            style={{width: 200}}
+                            onChange={handleChange}
+                            options={[
+                                {value: "jack", label: "Jack"},
+                                {value: "lucy", label: "Lucy"},
+                            ]}
+                        />
+                        <div className="flex justify-between items-center gap-2">
+                            <Radio.Group
+                                options={[
+                                    {label: "JSON", value: "json"},
+                                    {label: "YAML", value: "yaml"},
+                                ]}
+                                onChange={(e) => setFormatType(e.target.value)}
+                                value={formatType}
+                                optionType="button"
+                            />
+                            <Button icon={<Copy size={16} />} />
+                        </div>
+                    </div>
+
+                    <Editor
+                        className={classes.editor}
+                        height={210}
+                        language={"json"}
+                        theme={`vs-${appTheme}`}
+                        value={"JSON"}
+                        options={{
+                            wordWrap: "on",
+                            minimap: {enabled: false},
+                            scrollBeyondLastLine: false,
+                            automaticLayout: true,
+                            readOnly: true,
+                            lineNumbers: "off",
+                            lineDecorationsWidth: 0,
+                            scrollbar: {
+                                verticalScrollbarSize: 8,
+                                horizontalScrollbarSize: 8,
+                            },
+                        }}
+                    />
+                </div>
+
+                <div className={classes.container}>
+                    <Typography.Text className={classes.label}>Mapping</Typography.Text>
+                    <div className="flex flex-col gap-2">
+                        {[1, 2].map(() => (
+                            <div className="flex items-center justify-between gap-2">
+                                <Select
+                                    style={{width: 200}}
+                                    onChange={handleChange}
+                                    options={[
+                                        {value: "jack", label: "Jack"},
+                                        {value: "lucy", label: "Lucy"},
+                                    ]}
+                                />
+                                <ArrowRight size={16} />
+                                <Select
+                                    style={{width: 320}}
+                                    onChange={handleChange}
+                                    options={[
+                                        {value: "jack", label: "Jack"},
+                                        {value: "lucy", label: "Lucy"},
+                                    ]}
+                                />
+                                <Button icon={<Trash />} />
+                            </div>
+                        ))}
+                    </div>
+
+                    <Button type="dashed" className="mt-1" style={{width: 200}} icon={<Plus />}>
+                        Add field
+                    </Button>
+                </div>
+
+                <div className={classes.container}>
+                    <Typography.Text className={classes.label}>Preview</Typography.Text>
+                    <div className="flex items-center gap-4 mb-2">
+                        <Select
+                            style={{width: 200}}
+                            onChange={handleChange}
+                            options={[
+                                {value: "jack", label: "Jack"},
+                                {value: "lucy", label: "Lucy"},
+                            ]}
+                        />
+                        <Checkbox>Show last 5 test set entries</Checkbox>
+                    </div>
+
+                    <div>
+                        <Table
+                            className="ph-no-capture"
+                            columns={[
+                                {
+                                    title: "country",
+                                    dataIndex: "country",
+                                    key: "country",
+                                    onHeaderCell: () => ({
+                                        style: {minWidth: 160},
+                                    }),
+                                },
+                                {
+                                    title: "ground_truth",
+                                    dataIndex: "ground_truth",
+                                    key: "ground_truth",
+                                    onHeaderCell: () => ({
+                                        style: {minWidth: 160},
+                                    }),
+                                },
+
+                                {
+                                    title: "flag",
+                                    dataIndex: "flag",
+                                    key: "flag",
+                                    onHeaderCell: () => ({
+                                        style: {minWidth: 160},
+                                    }),
+                                },
+                            ]}
+                            // dataSource={evaluationsList}
+                            scroll={{x: true}}
+                            bordered
+                            pagination={false}
+                        />
+                    </div>
+                </div>
+            </section>
+        )
+    }
+    return (
+        <>
+            <GenericDrawer
+                open={open}
+                onClose={onClose}
+                expandable
+                drawerWidth={640}
+                headerExtra="Add to test set"
+                mainContent={<Content />}
+            />
+        </>
+    )
+}
+
+export default TestsetDrawer

--- a/agenta-web/src/components/pages/observability/drawer/TestsetDrawer.tsx
+++ b/agenta-web/src/components/pages/observability/drawer/TestsetDrawer.tsx
@@ -475,7 +475,8 @@ const TestsetDrawer = ({onClose, data, ...props}: Props) => {
                                             >
                                                 <Select
                                                     style={{width: elementWidth}}
-                                                    value={data.data}
+                                                    placeholder="Select a mapped data key"
+                                                    value={data.data || undefined}
                                                     onChange={(value) =>
                                                         onMappingOptionChange({
                                                             pathName: "data",
@@ -490,7 +491,8 @@ const TestsetDrawer = ({onClose, data, ...props}: Props) => {
                                                     {!isNewTestset && (
                                                         <Select
                                                             style={{width: "100%"}}
-                                                            value={data.column}
+                                                            placeholder="Select a column"
+                                                            value={data.column || undefined}
                                                             onChange={(value) =>
                                                                 onMappingOptionChange({
                                                                     pathName: "column",

--- a/agenta-web/src/components/pages/observability/drawer/TestsetDrawer.tsx
+++ b/agenta-web/src/components/pages/observability/drawer/TestsetDrawer.tsx
@@ -117,6 +117,15 @@ const TestsetDrawer = ({onClose, data, ...props}: Props) => {
                     setTableRows(data.csvdata)
                 }
             }
+
+            if (mappingOptions.length > 0 && value) {
+                setMappingData((prevMappingData) =>
+                    mappingOptions.map((item, index) => ({
+                        ...prevMappingData[index],
+                        data: item.value,
+                    })),
+                )
+            }
         } catch (error) {
             message.error("Failed to laod Test sets!")
         }
@@ -168,18 +177,6 @@ const TestsetDrawer = ({onClose, data, ...props}: Props) => {
 
         return Array.from(uniquePaths).map((item) => ({value: item}))
     }, [data])
-
-    useEffect(() => {
-        // auto render mapping component with data
-        if (mappingOptions.length > 0) {
-            setMappingData((prevMappingData) =>
-                mappingOptions.map((item, index) => ({
-                    ...prevMappingData[index],
-                    data: item.value,
-                })),
-            )
-        }
-    }, [mappingOptions])
 
     const columnOptions = useMemo(() => {
         const selectedColumns = mappingData
@@ -435,99 +432,111 @@ const TestsetDrawer = ({onClose, data, ...props}: Props) => {
 
                         <div className={classes.container}>
                             <Typography.Text className={classes.label}>Mapping</Typography.Text>
-                            <div className="flex flex-col gap-2">
-                                {mappingData.map((data, idx) => (
-                                    <div
-                                        key={idx}
-                                        className="flex items-center justify-between gap-2"
-                                    >
-                                        <Select
-                                            style={{width: elementWidth}}
-                                            value={data.data}
-                                            onChange={(value) =>
-                                                onMappingOptionChange({
-                                                    pathName: "data",
-                                                    value,
-                                                    idx,
-                                                })
-                                            }
-                                            options={mappingOptions}
-                                        />
-                                        <ArrowRight size={16} />
-                                        <div className="flex-1 flex gap-2 items-center">
-                                            {!isNewTestset && (
+                            {testset.id ? (
+                                <>
+                                    <div className="flex flex-col gap-2">
+                                        {mappingData.map((data, idx) => (
+                                            <div
+                                                key={idx}
+                                                className="flex items-center justify-between gap-2"
+                                            >
                                                 <Select
-                                                    style={{width: "100%"}}
-                                                    value={data.column}
+                                                    style={{width: elementWidth}}
+                                                    value={data.data}
                                                     onChange={(value) =>
                                                         onMappingOptionChange({
-                                                            pathName: "column",
+                                                            pathName: "data",
                                                             value,
                                                             idx,
                                                         })
                                                     }
-                                                    options={[
-                                                        ...(testset.id ? customSelectOptions : []),
-                                                        ...columnOptions?.map((column) => ({
-                                                            value: column,
-                                                            lable: column,
-                                                        })),
-                                                    ]}
+                                                    options={mappingOptions}
                                                 />
-                                            )}
+                                                <ArrowRight size={16} />
+                                                <div className="flex-1 flex gap-2 items-center">
+                                                    {!isNewTestset && (
+                                                        <Select
+                                                            style={{width: "100%"}}
+                                                            value={data.column}
+                                                            onChange={(value) =>
+                                                                onMappingOptionChange({
+                                                                    pathName: "column",
+                                                                    value,
+                                                                    idx,
+                                                                })
+                                                            }
+                                                            options={[
+                                                                ...(testset.id
+                                                                    ? customSelectOptions
+                                                                    : []),
+                                                                ...columnOptions?.map((column) => ({
+                                                                    value: column,
+                                                                    lable: column,
+                                                                })),
+                                                            ]}
+                                                        />
+                                                    )}
 
-                                            {data.column === "create" || isNewTestset ? (
-                                                <div className="w-full relative">
-                                                    <Input
-                                                        style={{width: "100%"}}
-                                                        value={data.newColumn || ""}
-                                                        onChange={(e) =>
-                                                            onMappingOptionChange({
-                                                                pathName: "newColumn",
-                                                                value: e.target.value,
-                                                                idx,
-                                                            })
-                                                        }
-                                                        placeholder="Column name"
-                                                    />
-                                                    <PencilSimple
-                                                        size={14}
-                                                        className="absolute top-[8px] right-2"
-                                                    />
+                                                    {data.column === "create" || isNewTestset ? (
+                                                        <div className="w-full relative">
+                                                            <Input
+                                                                style={{width: "100%"}}
+                                                                value={data.newColumn || ""}
+                                                                onChange={(e) =>
+                                                                    onMappingOptionChange({
+                                                                        pathName: "newColumn",
+                                                                        value: e.target.value,
+                                                                        idx,
+                                                                    })
+                                                                }
+                                                                placeholder="Column name"
+                                                            />
+                                                            <PencilSimple
+                                                                size={14}
+                                                                className="absolute top-[8px] right-2"
+                                                            />
+                                                        </div>
+                                                    ) : null}
                                                 </div>
-                                            ) : null}
-                                        </div>
 
-                                        <Button
-                                            icon={<Trash />}
-                                            onClick={() =>
-                                                setMappingData(
-                                                    mappingData.filter((_, index) => index !== idx),
-                                                )
-                                            }
-                                        />
+                                                <Button
+                                                    icon={<Trash />}
+                                                    onClick={() =>
+                                                        setMappingData(
+                                                            mappingData.filter(
+                                                                (_, index) => index !== idx,
+                                                            ),
+                                                        )
+                                                    }
+                                                />
+                                            </div>
+                                        ))}
                                     </div>
-                                ))}
-                            </div>
 
-                            <Button
-                                type="dashed"
-                                className="mt-1"
-                                style={{width: elementWidth}}
-                                icon={<Plus />}
-                                onClick={() =>
-                                    setMappingData([
-                                        ...mappingData,
-                                        {
-                                            data: "",
-                                            column: isNewTestset ? "create" : "",
-                                            newColumn: "",
-                                        },
-                                    ])
-                                }
-                            >
-                                Add field
-                            </Button>
+                                    <Button
+                                        type="dashed"
+                                        className="mt-1"
+                                        style={{width: elementWidth}}
+                                        icon={<Plus />}
+                                        onClick={() =>
+                                            setMappingData([
+                                                ...mappingData,
+                                                {
+                                                    data: "",
+                                                    column: isNewTestset ? "create" : "",
+                                                    newColumn: "",
+                                                },
+                                            ])
+                                        }
+                                    >
+                                        Add field
+                                    </Button>
+                                </>
+                            ) : (
+                                <Typography.Text>
+                                    Please select a test set to create mappings
+                                </Typography.Text>
+                            )}
                         </div>
 
                         <div className={classes.container}>

--- a/agenta-web/src/components/pages/observability/drawer/TraceContent.tsx
+++ b/agenta-web/src/components/pages/observability/drawer/TraceContent.tsx
@@ -1,5 +1,5 @@
 import ResultTag from "@/components/ResultTag/ResultTag"
-import {JSSTheme} from "@/lib/Types"
+import {JSSTheme, KeyValuePair} from "@/lib/Types"
 import {ArrowRight, Database, PlusCircle, Rocket, Timer} from "@phosphor-icons/react"
 import {Button, Divider, Space, Tabs, TabsProps, Typography} from "antd"
 import React, {useState} from "react"
@@ -87,10 +87,6 @@ const TraceContent = ({activeTrace}: TraceContentProps) => {
     const [tab, setTab] = useState("overview")
     const {icon, bgColor, color} = statusMapper(activeTrace.node.type)
     const [isTestsetDrawerOpen, setIsTestsetDrawerOpen] = useState(false)
-
-    const testsetDrawerData = () => {
-        return [{data: activeTrace.data, key: activeTrace.key, id: 1}]
-    }
 
     const transformDataInputs = (data: any) => {
         return Object.keys(data).reduce((acc, curr) => {
@@ -279,6 +275,7 @@ const TraceContent = ({activeTrace}: TraceContentProps) => {
                             <Button
                                 className="flex items-center"
                                 onClick={() => setIsTestsetDrawerOpen(true)}
+                                disabled={!activeTrace.key}
                             >
                                 <Database size={14} />
                                 Add to testset
@@ -368,7 +365,7 @@ const TraceContent = ({activeTrace}: TraceContentProps) => {
             {isTestsetDrawerOpen && (
                 <TestsetDrawer
                     open={isTestsetDrawerOpen}
-                    data={testsetDrawerData() as any}
+                    data={[{data: activeTrace.data as KeyValuePair, key: activeTrace.key, id: 1}]}
                     onClose={() => setIsTestsetDrawerOpen(false)}
                 />
             )}

--- a/agenta-web/src/components/pages/observability/drawer/TraceContent.tsx
+++ b/agenta-web/src/components/pages/observability/drawer/TraceContent.tsx
@@ -263,15 +263,6 @@ const TraceContent = ({activeTrace}: TraceContentProps) => {
                         </Typography.Text>
 
                         <Space>
-                            {/* {!activeTrace.parent && activeTrace.refs?.application?.id && (
-                                <Button
-                                    className="flex items-center"
-                                    href={`/apps/${activeTrace.refs.application?.id}/playground`}
-                                >
-                                    <Rocket size={14} />
-                                    Open in playground
-                                </Button>
-                            )} */}
                             <Button
                                 className="flex items-center"
                                 onClick={() => setIsTestsetDrawerOpen(true)}
@@ -369,14 +360,6 @@ const TraceContent = ({activeTrace}: TraceContentProps) => {
                     onClose={() => setIsTestsetDrawerOpen(false)}
                 />
             )}
-            {/* <Divider type="vertical" className="h-full m-0" />
-            <div className="w-[320px] p-4 flex flex-col gap-4">
-                <Typography.Text className={classes.title}>Evaluation</Typography.Text>
-
-                <Space direction="vertical">
-                    <ResultTag value1="Evaluator Name" value2={"70"} />
-                </Space>
-            </div> */}
         </div>
     )
 }

--- a/agenta-web/src/components/pages/observability/drawer/TraceContent.tsx
+++ b/agenta-web/src/components/pages/observability/drawer/TraceContent.tsx
@@ -11,6 +11,7 @@ import {statusMapper} from "../components/AvatarTreeContent"
 import {formatCurrency, formatLatency, formatTokenUsage} from "@/lib/helpers/formatters"
 import StatusRenderer from "../components/StatusRenderer"
 import AccordionTreePanel from "../components/AccordionTreePanel"
+import TestsetDrawer from "./TestsetDrawer"
 
 interface TraceContentProps {
     activeTrace: _AgentaRootsResponse
@@ -85,6 +86,11 @@ const TraceContent = ({activeTrace}: TraceContentProps) => {
     const classes = useStyles()
     const [tab, setTab] = useState("overview")
     const {icon, bgColor, color} = statusMapper(activeTrace.node.type)
+    const [isTestsetDrawerOpen, setIsTestsetDrawerOpen] = useState(false)
+
+    const testsetDrawerData = () => {
+        return [{data: activeTrace.data, key: activeTrace.key, id: 1}]
+    }
 
     const transformDataInputs = (data: any) => {
         return Object.keys(data).reduce((acc, curr) => {
@@ -260,8 +266,8 @@ const TraceContent = ({activeTrace}: TraceContentProps) => {
                             {activeTrace.node.name}
                         </Typography.Text>
 
-                        {/* <Space>
-                            {!activeTrace.parent && activeTrace.refs?.application?.id && (
+                        <Space>
+                            {/* {!activeTrace.parent && activeTrace.refs?.application?.id && (
                                 <Button
                                     className="flex items-center"
                                     href={`/apps/${activeTrace.refs.application?.id}/playground`}
@@ -269,12 +275,15 @@ const TraceContent = ({activeTrace}: TraceContentProps) => {
                                     <Rocket size={14} />
                                     Open in playground
                                 </Button>
-                            )}
-                            <Button className="flex items-center">
+                            )} */}
+                            <Button
+                                className="flex items-center"
+                                onClick={() => setIsTestsetDrawerOpen(true)}
+                            >
                                 <Database size={14} />
                                 Add to testset
                             </Button>
-                        </Space> */}
+                        </Space>
                     </div>
                     <Divider className="m-0" />
                 </div>
@@ -356,6 +365,13 @@ const TraceContent = ({activeTrace}: TraceContentProps) => {
                     />
                 </div>
             </div>
+            {isTestsetDrawerOpen && (
+                <TestsetDrawer
+                    open={isTestsetDrawerOpen}
+                    data={testsetDrawerData() as any}
+                    onClose={() => setIsTestsetDrawerOpen(false)}
+                />
+            )}
             {/* <Divider type="vertical" className="h-full m-0" />
             <div className="w-[320px] p-4 flex flex-col gap-4">
                 <Typography.Text className={classes.title}>Evaluation</Typography.Text>

--- a/agenta-web/src/lib/helpers/utils.ts
+++ b/agenta-web/src/lib/helpers/utils.ts
@@ -359,3 +359,20 @@ export const filterVariantParameters = ({
 export const formatVariantIdWithHash = (variantId: string) => {
     return `# ${variantId.split("-")[0]}`
 }
+
+export const collectKeyPathsFromObject = (obj: any, prefix = ""): string[] => {
+    const paths: string[] = []
+
+    for (const [key, value] of Object.entries(obj)) {
+        const fullPath = prefix ? `${prefix}.${key}` : key
+
+        if (value && typeof value === "object" && !Array.isArray(value)) {
+            const nestedPaths = collectKeyPathsFromObject(value, fullPath)
+            paths.push(...nestedPaths)
+        } else {
+            paths.push(fullPath)
+        }
+    }
+
+    return paths
+}


### PR DESCRIPTION
### Description

This PR aims to add a feature to save observability traces as testset.

### Related Issue
Closes [AGE-1337](https://linear.app/agenta/issue/AGE-1337/implement-add-to-test-set-drawer)

### QA 

1. **Verify Traces**: Ensure traces are visible in the Observability section.  

2. **Select Traces and Open Test Set Drawer**: Select multiple traces using checkboxes and click **'Add Test Set'** to open the drawer.  

3. **Choose or Create Test Set**:  
   - Select an existing Test Set or create a new one.  
   - Use the **Data Preview** dropdown to view your selected traces and confirm trace keys are automatically mapped in the **Mapping** section.  

4. **Manage Columns**:  
   - For existing Test Sets, select columns; for new Test Sets, add column names.  
   - Ensure a **warning** appears if duplicate columns are selected.  

5. **Preview Data**: Confirm data is visible immediately after column selection and verify preview options work for both **all data** and specific subsets.  

6. **Save Test Set**: Ensure the Test Set saves successfully without errors.  