### PR TITLE
[Feature]: Display a "Not Optimized for Mobile" overlay to users trying to access Agenta app from browsers with narrow width 

### DIFF
--- a/agenta-web/src/components/NoMobilePageWrapper/NoMobilePageWrapper.tsx
+++ b/agenta-web/src/components/NoMobilePageWrapper/NoMobilePageWrapper.tsx
@@ -1,5 +1,5 @@
 import {type PropsWithChildren, useState, useCallback} from "react"
-import {Typography, Button} from "antd"
+import {Typography, Button, theme} from "antd"
 import clsx from "clsx"
 import useResizeObserver from "@/hooks/useResizeObserver"
 import {createUseStyles} from "react-jss"
@@ -14,20 +14,23 @@ const useStyles = createUseStyles((theme: JSSTheme) => ({
     },
 }))
 
+const {useToken} = theme
+
 const NoMobilePageWrapper: React.FC<PropsWithChildren> = ({children}) => {
     const [dismissed, setDismissed] = useState(false)
     const [shouldDisplay, setShouldDisplay] = useState(false)
     const {overlay} = useStyles()
     const {pathname} = useRouter()
+    const {token} = useToken()
 
     const observerCallback = useCallback((bounds: DOMRectReadOnly) => {
         setShouldDisplay(() => {
             if (dismissed) return false // keep hidden if already dismissed by the user
             if (!MOBILE_UNOPTIMIZED_APP_ROUTES.some((route) => pathname.startsWith(route))) return false
             
-            return bounds.width < 768
+            return bounds.width < token.screenMD
         })
-    }, [dismissed, pathname])
+    }, [dismissed, pathname, token.screenMD])
     
     useResizeObserver(
         observerCallback,

--- a/agenta-web/src/components/NoMobilePageWrapper/NoMobilePageWrapper.tsx
+++ b/agenta-web/src/components/NoMobilePageWrapper/NoMobilePageWrapper.tsx
@@ -6,7 +6,7 @@ import {createUseStyles} from "react-jss"
 import {JSSTheme} from "@/lib/Types"
 import {Transition} from "@headlessui/react"
 import {useRouter} from "next/router"
-import { MOBILE_UNOPTIMIZED_APP_ROUTES } from "./assets/constants"
+import {MOBILE_UNOPTIMIZED_APP_ROUTES} from "./assets/constants"
 
 const useStyles = createUseStyles((theme: JSSTheme) => ({
     overlay: {
@@ -23,19 +23,20 @@ const NoMobilePageWrapper: React.FC<PropsWithChildren> = ({children}) => {
     const {pathname} = useRouter()
     const {token} = useToken()
 
-    const observerCallback = useCallback((bounds: DOMRectReadOnly) => {
-        setShouldDisplay(() => {
-            if (dismissed) return false // keep hidden if already dismissed by the user
-            if (!MOBILE_UNOPTIMIZED_APP_ROUTES.some((route) => pathname.startsWith(route))) return false
-            
-            return bounds.width < token.screenMD
-        })
-    }, [dismissed, pathname, token.screenMD])
-    
-    useResizeObserver(
-        observerCallback,
-        typeof window !== "undefined" ? document.body : undefined,
+    const observerCallback = useCallback(
+        (bounds: DOMRectReadOnly) => {
+            setShouldDisplay(() => {
+                if (dismissed) return false // keep hidden if already dismissed by the user
+                if (!MOBILE_UNOPTIMIZED_APP_ROUTES.some((route) => pathname.startsWith(route)))
+                    return false
+
+                return bounds.width < token.screenMD
+            })
+        },
+        [dismissed, pathname, token.screenMD],
     )
+
+    useResizeObserver(observerCallback, typeof window !== "undefined" ? document.body : undefined)
 
     const handleDismiss = () => {
         setDismissed(true)

--- a/agenta-web/src/components/NoMobilePageWrapper/NoMobilePageWrapper.tsx
+++ b/agenta-web/src/components/NoMobilePageWrapper/NoMobilePageWrapper.tsx
@@ -6,20 +6,13 @@ import {createUseStyles} from "react-jss"
 import {JSSTheme} from "@/lib/Types"
 import {Transition} from "@headlessui/react"
 import {useRouter} from "next/router"
+import { MOBILE_UNOPTIMIZED_APP_ROUTES } from "./assets/constants"
 
 const useStyles = createUseStyles((theme: JSSTheme) => ({
     overlay: {
         background: `${theme.colorBgContainer}`,
     },
 }))
-
-// List of routes where the component should be displayed
-const APP_ROUTES = [
-    "/apps",
-    "/observability",
-    "/settings",
-    "/testsets"
-]
 
 const NoMobilePageWrapper: React.FC<PropsWithChildren> = ({children}) => {
     const [dismissed, setDismissed] = useState(false)
@@ -28,9 +21,9 @@ const NoMobilePageWrapper: React.FC<PropsWithChildren> = ({children}) => {
     const {pathname} = useRouter()
 
     const observerCallback = useCallback((bounds: DOMRectReadOnly) => {
-        setShouldDisplay((prevShouldDisplay) => {
+        setShouldDisplay(() => {
             if (dismissed) return false // keep hidden if already dismissed by the user
-            if (!APP_ROUTES.some((route) => pathname.startsWith(route))) return false
+            if (!MOBILE_UNOPTIMIZED_APP_ROUTES.some((route) => pathname.startsWith(route))) return false
             
             return bounds.width < 768
         })

--- a/agenta-web/src/components/NoMobilePageWrapper/NoMobilePageWrapper.tsx
+++ b/agenta-web/src/components/NoMobilePageWrapper/NoMobilePageWrapper.tsx
@@ -1,0 +1,75 @@
+import {type PropsWithChildren, useState, useCallback} from "react"
+import {Typography, Button} from "antd"
+import clsx from "clsx"
+import useResizeObserver from "@/hooks/useResizeObserver"
+import {createUseStyles} from "react-jss"
+import {JSSTheme} from "@/lib/Types"
+import {Transition} from "@headlessui/react"
+import {useRouter} from "next/router"
+
+const useStyles = createUseStyles((theme: JSSTheme) => ({
+    overlay: {
+        background: `${theme.colorBgContainer}`,
+    },
+}))
+
+// List of routes where the component should be displayed
+const APP_ROUTES = [
+    "/apps",
+    "/observability",
+    "/settings",
+    "/testsets"
+]
+
+const NoMobilePageWrapper: React.FC<PropsWithChildren> = ({children}) => {
+    const [dismissed, setDismissed] = useState(false)
+    const [shouldDisplay, setShouldDisplay] = useState(false)
+    const {overlay} = useStyles()
+    const {pathname} = useRouter()
+
+    const observerCallback = useCallback((bounds: DOMRectReadOnly) => {
+        setShouldDisplay((prevShouldDisplay) => {
+            if (dismissed) return false // keep hidden if already dismissed by the user
+            if (!APP_ROUTES.some((route) => pathname.startsWith(route))) return false
+            
+            return bounds.width < 768
+        })
+    }, [dismissed, pathname])
+    
+    useResizeObserver(
+        observerCallback,
+        typeof window !== "undefined" ? document.body : undefined,
+    )
+
+    const handleDismiss = () => {
+        setDismissed(true)
+    }
+
+    return (
+        <Transition
+            show={!dismissed && shouldDisplay}
+            enter="transition-opacity duration-75"
+            enterFrom="opacity-0"
+            enterTo="opacity-100"
+            leave="transition-opacity duration-150"
+            leaveFrom="opacity-100"
+            leaveTo="opacity-0"
+            className={clsx([
+                "fixed top-0 left-0 right-0 bottom-0", // overlay the entire screen
+                "flex flex-col items-center justify-center gap-4", // flex config
+                "z-[9999]",
+                overlay, // TODO: better theme connected tailwind color classes
+            ])}
+            unmount
+        >
+            <Typography.Text className="w-8/12 text-center leading-1 text-lg">
+                Agenta works better in larger laptop or desktop screens.
+            </Typography.Text>
+            <Button type="primary" size="large" onClick={handleDismiss}>
+                View anyway
+            </Button>
+        </Transition>
+    )
+}
+
+export default NoMobilePageWrapper

--- a/agenta-web/src/components/NoMobilePageWrapper/assets/constants.ts
+++ b/agenta-web/src/components/NoMobilePageWrapper/assets/constants.ts
@@ -1,0 +1,2 @@
+// List of routes where the component should be displayed
+export const MOBILE_UNOPTIMIZED_APP_ROUTES = ["/apps", "/observability", "/settings", "/testsets"]

--- a/agenta-web/src/components/NoMobilePageWrapper/assets/constants.ts
+++ b/agenta-web/src/components/NoMobilePageWrapper/assets/constants.ts
@@ -1,2 +1,9 @@
 // List of routes where the component should be displayed
-export const MOBILE_UNOPTIMIZED_APP_ROUTES = ["/apps", "/observability", "/settings", "/testsets"]
+export const MOBILE_UNOPTIMIZED_APP_ROUTES = [
+    "/apps",
+    "/observability",
+    "/settings",
+    "/testsets",
+    "/evaluations",
+    "/workspaces",
+]

--- a/agenta-web/src/hooks/useResizeObserver.ts
+++ b/agenta-web/src/hooks/useResizeObserver.ts
@@ -1,26 +1,27 @@
 import {useLayoutEffect, useRef} from "react"
 
-function useResizeObserver<T extends HTMLDivElement>(
-    callback: (entry: ResizeObserverEntry["contentRect"]) => void,
-) {
+const useResizeObserver = <T extends HTMLDivElement>(
+    callback?: (entry: ResizeObserverEntry["contentRect"]) => void,
+    element?: HTMLElement,
+ ) => {
     const ref = useRef<T>(null)
 
     useLayoutEffect(() => {
-        const element = ref?.current
+        const _element = ref?.current || element
 
-        if (!element) {
+        if (!_element) {
             return
         }
 
         const observer = new ResizeObserver((entries) => {
-            callback(entries[0].contentRect)
+            callback?.(entries[0].contentRect)
         })
 
-        observer.observe(element)
+        observer.observe(_element)
         return () => {
             observer.disconnect()
         }
-    }, [callback, ref])
+    }, [callback, element, ref])
 
     return ref
 }

--- a/agenta-web/src/hooks/useResizeObserver.ts
+++ b/agenta-web/src/hooks/useResizeObserver.ts
@@ -3,7 +3,7 @@ import {useLayoutEffect, useRef} from "react"
 const useResizeObserver = <T extends HTMLDivElement>(
     callback?: (entry: ResizeObserverEntry["contentRect"]) => void,
     element?: HTMLElement,
- ) => {
+) => {
     const ref = useRef<T>(null)
 
     useLayoutEffect(() => {

--- a/agenta-web/src/pages/_app.tsx
+++ b/agenta-web/src/pages/_app.tsx
@@ -17,9 +17,12 @@ import "ag-grid-community/styles/ag-grid.css"
 import "ag-grid-community/styles/ag-theme-alpine.css"
 import {Inter} from "next/font/google"
 
-const NoMobilePageWrapper = dynamic(() => import("@/components/NoMobilePageWrapper/NoMobilePageWrapper"), {
-    ssr: false
-})
+const NoMobilePageWrapper = dynamic(
+    () => import("@/components/NoMobilePageWrapper/NoMobilePageWrapper"),
+    {
+        ssr: false,
+    },
+)
 
 const inter = Inter({
     subsets: ["latin"],

--- a/agenta-web/src/pages/_app.tsx
+++ b/agenta-web/src/pages/_app.tsx
@@ -2,6 +2,7 @@ import {useEffect} from "react"
 import type {AppProps} from "next/app"
 import {useRouter} from "next/router"
 import Head from "next/head"
+import dynamic from "next/dynamic"
 
 import posthog from "posthog-js"
 import {PostHogProvider} from "posthog-js/react"
@@ -15,6 +16,10 @@ import ProjectContextProvider from "@/contexts/project.context"
 import "ag-grid-community/styles/ag-grid.css"
 import "ag-grid-community/styles/ag-theme-alpine.css"
 import {Inter} from "next/font/google"
+
+const NoMobilePageWrapper = dynamic(() => import("@/components/NoMobilePageWrapper/NoMobilePageWrapper"), {
+    ssr: false
+})
 
 const inter = Inter({
     subsets: ["latin"],
@@ -60,6 +65,7 @@ export default function App({Component, pageProps}: AppProps) {
                                 <AppContextProvider>
                                     <Layout>
                                         <Component {...pageProps} />
+                                        <NoMobilePageWrapper />
                                     </Layout>
                                 </AppContextProvider>
                             </ProjectContextProvider>

--- a/agenta-web/src/pages/_app.tsx
+++ b/agenta-web/src/pages/_app.tsx
@@ -9,6 +9,7 @@ import {PostHogProvider} from "posthog-js/react"
 
 import "@/styles/globals.css"
 import Layout from "@/components/Layout/Layout"
+import {dynamicComponent} from "@/lib/helpers/dynamic"
 import ThemeContextProvider from "@/components/Layout/ThemeContextProvider"
 import AppContextProvider from "@/contexts/app.context"
 import ProfileContextProvider from "@/contexts/profile.context"
@@ -17,12 +18,7 @@ import "ag-grid-community/styles/ag-grid.css"
 import "ag-grid-community/styles/ag-theme-alpine.css"
 import {Inter} from "next/font/google"
 
-const NoMobilePageWrapper = dynamic(
-    () => import("@/components/NoMobilePageWrapper/NoMobilePageWrapper"),
-    {
-        ssr: false,
-    },
-)
+const NoMobilePageWrapper = dynamicComponent("NoMobilePageWrapper/NoMobilePageWrapper")
 
 const inter = Inter({
     subsets: ["latin"],


### PR DESCRIPTION
closes [AGE-1407](https://linear.app/agenta/issue/AGE-1407/not-optimized-for-mobile-warning-screen)

### What has changed?
- new component has been created to display a message to users accessing Agenta from browsers with narrow viewports.

### What else?
- minor improvement to the shared useResizeObserver hook so that it can observe an element passed as an argument. Useful to observe window size changes