### PR TITLE
Update evaluators_service.py

### DIFF
--- a/agenta-backend/agenta_backend/services/evaluators_service.py
+++ b/agenta-backend/agenta_backend/services/evaluators_service.py
@@ -815,7 +815,7 @@ def compare_jsons(
         llm_app_output_value = flattened_app_output.get(key, None)
 
         key_score = 0.0
-        if ground_truth_value and llm_app_output_value:
+        if ground_truth_value is not None and llm_app_output_value is not None:
             key_score = diff(
                 {key: ground_truth_value},
                 {key: llm_app_output_value},


### PR DESCRIPTION
using `is not None` checks instead of truthy checks, which is more explicit and correct for boolean values.

truthy checks fails in the case of `ground_truth_value` and `llm_app_output_value` both equal to a valid False value