### PR TITLE
Running Agenta on different ports

### DIFF
--- a/agenta-backend/agenta_backend/services/app_manager.py
+++ b/agenta-backend/agenta_backend/services/app_manager.py
@@ -93,9 +93,8 @@ async def start_variant(
         if domain_name is None or domain_name == "http://localhost":
             # in the case of agenta running locally, the containers can access the host machine via this address
             domain_name = (
-                "http://host.docker.internal"  # unclear why this stopped working
+                f"http://host.docker.internal:{os.environ.get('AGENTA_PORT','80')}"
             )
-            # domain_name = "http://localhost"
 
         env_vars = {} if env_vars is None else env_vars  # type: ignore
         env_vars.update(

--- a/agenta-backend/agenta_backend/services/docker_utils.py
+++ b/agenta-backend/agenta_backend/services/docker_utils.py
@@ -124,7 +124,7 @@ def start_container(
             logs = container.logs().decode("utf-8")
             raise Exception(f"Container exited immediately. Docker Logs: {logs}")
         return {
-            "uri": f"{os.environ['DOMAIN_NAME']}/{uri_path}",
+            "uri": f"{os.environ['DOMAIN_NAME']}{':' + os.environ['AGENTA_PORT'] if os.environ.get('AGENTA_PORT') else ''}/{uri_path}",
             "container_id": container.id,
             "container_name": container_name,
         }

--- a/docker-compose.gh.yml
+++ b/docker-compose.gh.yml
@@ -1,9 +1,9 @@
 services:
     reverse-proxy:
         image: traefik:v2.10
-        command: --api.dashboard=true --api.insecure=true --providers.docker --entrypoints.web.address=:80
+        command: --api.dashboard=true --api.insecure=true --providers.docker --entrypoints.web.address=:${AGENTA_PORT:-80}
         ports:
-            - "80:80"
+            - "${AGENTA_PORT:-80}:${AGENTA_PORT:-80}"
             - "8080:8080"
         volumes:
             - /var/run/docker.sock:/var/run/docker.sock
@@ -28,6 +28,7 @@ services:
             - CELERY_RESULT_BACKEND=redis://redis:6379/0
             - REGISTRY_REPO_NAME=agentaai
             - DOCKER_HUB_URL=https://hub.docker.com/v2/repositories
+            - AGENTA_PORT=${AGENTA_PORT:-80}
         command:
             [
                 "uvicorn",
@@ -95,6 +96,7 @@ services:
             - NEXT_PUBLIC_AGENTA_API_URL=${DOMAIN_NAME:-http://localhost}
             - NEXT_PUBLIC_FF=oss
             - NEXT_PUBLIC_TELEMETRY_TRACKING_ENABLED=true
+            - AGENTA_PORT=${AGENTA_PORT:-80}
         restart: always
 
     redis:

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -1,9 +1,9 @@
 services:
     reverse-proxy:
         image: traefik:v2.10
-        command: --api.dashboard=true --api.insecure=true --providers.docker --entrypoints.web.address=:80
+        command: --api.dashboard=true --api.insecure=true --providers.docker --entrypoints.web.address=:${AGENTA_PORT:-80}
         ports:
-            - "80:80"
+            - "${AGENTA_PORT:-80}:${AGENTA_PORT:-80}"
             - "8080:8080"
         volumes:
             - /var/run/docker.sock:/var/run/docker.sock
@@ -29,6 +29,7 @@ services:
             - CELERY_RESULT_BACKEND=redis://redis:6379/0
             - REGISTRY_REPO_NAME=agentaai
             - DOCKER_HUB_URL=https://hub.docker.com/v2/repositories
+            - AGENTA_PORT=${AGENTA_PORT:-80}
         volumes:
             - ./agenta-backend/agenta_backend:/app/agenta_backend
             - ./agenta-backend/migrations:/app/migrations
@@ -104,6 +105,7 @@ services:
             - "traefik.http.services.agenta-web.loadbalancer.server.port=3000"
         environment:
             - NEXT_PUBLIC_POSTHOG_API_KEY=phc_hmVSxIjTW1REBHXgj2aw4HW9X6CXb6FzerBgP9XenC7
+            - NEXT_PUBLIC_AGENTA_API_URL=${DOMAIN_NAME:-http://localhost}:${AGENTA_PORT:-80}
         restart: always
 
     redis:

--- a/docs/docs/self-host/host-locally.mdx
+++ b/docs/docs/self-host/host-locally.mdx
@@ -43,10 +43,19 @@ docker compose -f "docker-compose.yml" up -d --build
 
 Open your browser and go to [http://localhost](http://localhost). If you see the Agenta web interface, you're good to go.
 
-<details>
-<summary>Troubleshooting</summary>
-  The most likely reason for failure is a port conflict. To check whether this is the case please check whether the containers for agenta are all running (agenta-web, agenta-backend, mongodb and redis) and check the logs for the containers agenta-web and agenta-backend.
+## FAQ
+
+** How do I run agenta on a different port? **
+
+You can set the port by setting the `AGENTA_PORT` environment variable before starting the containers. For example:
+
+```bash
+export AGENTA_PORT=90
+docker compose -f "docker-compose.yml" up -d --build
+```
+
+** Troubleshooting **
+
+The most likely reason for failure is a port conflict. To check whether this is the case please check whether the containers for agenta are all running and check the logs for the containers agenta-web and agenta-backend.
 
 If that is not the problem, please [file an issue in github](https://github.com/Agenta-AI/agenta/issues/new/choose) or reach out on [#support on Slack](https://join.slack.com/t/agenta-hq/shared_invite/zt-1zsafop5i-Y7~ZySbhRZvKVPV5DO_7IA). We are very active there and **should answer within minutes** (European time).
-
-</details>


### PR DESCRIPTION
Closes #1909 
Closes #1915
Closes #1907

# To QA

- [x] Running agenta oss locally using docker-compose 
- [x] Running agenta oss locally using docker-compose.gh
- [x] Running agenta oss locally with env var AGENTA_PORT=90 using docker-compose, 
- [x] Running agenta oss locally with env var AGENTA_PORT=90 using docker-compose.gh
- [x] Deploying to oss and testing 
- [x] Deploying to staging and testing

In each step we need to test whether, we can create an app, we can interact with it in the playground, we can run an eval on it. 
