### PR TITLE
[Enhancement]: Add fail-safe logic to compute duration when running evaluations

### DIFF
--- a/agenta-backend/agenta_backend/services/llm_apps_service.py
+++ b/agenta-backend/agenta_backend/services/llm_apps_service.py
@@ -58,12 +58,24 @@ def extract_result_from_response(response: dict):
             if "tree" in response:
                 trace_tree = response.get("tree", {}).get("nodes", [])[0]
 
-                latency = (
-                    get_nested_value(
-                        trace_tree, ["metrics", "acc", "duration", "total"]
-                    )
-                    / 1000
+                duration_ms = get_nested_value(
+                    trace_tree, ["metrics", "acc", "duration", "total"]
                 )
+                if duration_ms:
+                    duration_seconds = duration_ms / 1000
+                else:
+                    start_time = get_nested_value(trace_tree, ["time", "start"])
+                    end_time = get_nested_value(trace_tree, ["time", "end"])
+
+                    if start_time and end_time:
+                        duration_seconds = (
+                            datetime.fromisoformat(end_time)
+                            - datetime.fromisoformat(start_time)
+                        ).total_seconds()
+                    else:
+                        duration_seconds = None
+
+                latency = duration_seconds
                 cost = get_nested_value(
                     trace_tree, ["metrics", "acc", "costs", "total"]
                 )


### PR DESCRIPTION
## Description  
This PR resolves an issue where evaluations fail in `cloud.beta` due to a missing `metrics` attribute in the `SpanDTO`. The issue stemmed from the templates using an outdated version of the SDK, which prevented the computation of duration and latency for evaluation runs, leading to errors.  

The templates have been updated to use the latest SDK version. Additionally, a fail-safe logic has been implemented to compute the duration using the `TimeDTO`, ensuring evaluations can proceed without errors even if the `metrics` attribute is unavailable.  

### Related Issue
Closes [AGE-1448](https://linear.app/agenta/issue/AGE-1448/[sdk-x-evaluations]-missing-metrics-attribute-in-spandto-causes)