### PR TITLE
[Enhancement]: Display SDK Version in Deployed Applications (openapi.json)

### DIFF
--- a/agenta-cli/agenta/cli/main.py
+++ b/agenta-cli/agenta/cli/main.py
@@ -47,9 +47,9 @@ def check_latest_version() -> Union[str, None]:
 
 
 def notify_update(available_version: str):
-    import pkg_resources
+    import importlib.metadata
 
-    installed_version = pkg_resources.get_distribution("agenta").version
+    installed_version = importlib.metadata.version("agenta")
     if available_version > installed_version:
         click.echo(
             click.style(

--- a/agenta-cli/agenta/sdk/decorators/routing.py
+++ b/agenta-cli/agenta/sdk/decorators/routing.py
@@ -18,6 +18,7 @@ from agenta.sdk.middleware.auth import AuthorizationMiddleware
 from agenta.sdk.context.routing import routing_context_manager, routing_context
 from agenta.sdk.context.tracing import tracing_context
 from agenta.sdk.router import router
+from agenta.sdk.utils import helpers
 from agenta.sdk.utils.exceptions import suppress
 from agenta.sdk.utils.logging import log
 from agenta.sdk.types import (
@@ -286,6 +287,9 @@ class entrypoint:
         ### --- Update OpenAPI --- #
         app.openapi_schema = None  # Forces FastAPI to re-generate the schema
         openapi_schema = app.openapi()
+
+        # Inject the current version of the SDK into the openapi_schema
+        openapi_schema["agenta_sdk"] = {"version": helpers.get_current_version()}
 
         for route in entrypoint.routes:
             self.override_schema(

--- a/agenta-cli/agenta/sdk/utils/helpers.py
+++ b/agenta-cli/agenta/sdk/utils/helpers.py
@@ -1,0 +1,8 @@
+import importlib.metadata
+
+
+def get_current_version():
+    """Returns the current version of Agenta's SDK."""
+
+    version = importlib.metadata.version("agenta")
+    return version

--- a/agenta-cli/pyproject.toml
+++ b/agenta-cli/pyproject.toml
@@ -1,6 +1,6 @@
 [tool.poetry]
 name = "agenta"
-version = "0.28.0"
+version = "0.28.2a1"
 description = "The SDK for agenta is an open-source LLMOps platform."
 readme = "README.md"
 authors = ["Mahmoud Mabrouk <mahmoud@agenta.ai>"]

--- a/agenta-cli/pyproject.toml
+++ b/agenta-cli/pyproject.toml
@@ -1,6 +1,6 @@
 [tool.poetry]
 name = "agenta"
-version = "0.28.2a1"
+version = "0.28.0"
 description = "The SDK for agenta is an open-source LLMOps platform."
 readme = "README.md"
 authors = ["Mahmoud Mabrouk <mahmoud@agenta.ai>"]


### PR DESCRIPTION
## Description

This PR enhances the debugging process by displaying the current SDK version directly in the deployed application openapi.json. Previously, identifying the SDK version after deploying to cloud templates (staging or beta) required a lengthy process involving manual steps through AWS and CloudWatch logs.

### Related Issue
Closes [AGE-1449](https://linear.app/agenta/issue/AGE-1449/display-sdk-version-in-agenta-playground-interface)
