### PR TITLE
(frontend)[AGE-1461]: Window not responding after switching between workspaces while in an app

### DIFF
--- a/agenta-web/src/components/Layout/Layout.tsx
+++ b/agenta-web/src/components/Layout/Layout.tsx
@@ -19,7 +19,6 @@ import {Lightning} from "@phosphor-icons/react"
 import packageJsonData from "../../../package.json"
 import {useProjectData} from "@/contexts/project.context"
 import {dynamicContext} from "@/lib/helpers/dynamic"
-import NoResultsFound from "../NoResultsFound/NoResultsFound"
 
 const {Content, Footer} = Layout
 const {Text} = Typography

--- a/agenta-web/src/components/Layout/Layout.tsx
+++ b/agenta-web/src/components/Layout/Layout.tsx
@@ -101,11 +101,11 @@ const useStyles = createUseStyles((theme: JSSTheme) => ({
         minHeight: "100vh",
         alignItems: "center",
         justifyContent: "center",
-        "& h1": {
+        "& .ant-typography:nth-of-type(1)": {
             fontSize: 24,
             fontWeight: 600,
         },
-        "& p": {
+        "& .ant-typography:nth-of-type(2)": {
             fontSize: 14,
             marginTop: 8,
         },
@@ -210,8 +210,8 @@ const App: React.FC<LayoutProps> = ({children}) => {
     if (appId && !currentApp)
         return (
             <div className={classes.notFoundContainer}>
-                <h1>404 - Page Not Found</h1>
-                <p>This page could not be found.</p>
+                <Typography.Text>404 - Page Not Found</Typography.Text>
+                <Typography.Text>This page could not be found.</Typography.Text>
 
                 <Button type="primary" onClick={() => router.push("/apps")}>
                     Back To Apps

--- a/agenta-web/src/components/Layout/Layout.tsx
+++ b/agenta-web/src/components/Layout/Layout.tsx
@@ -1,5 +1,5 @@
 import React, {useEffect, useMemo, useState} from "react"
-import {Breadcrumb, ConfigProvider, Layout, Modal, Space, Typography, theme} from "antd"
+import {Breadcrumb, Button, ConfigProvider, Layout, Modal, Space, Typography, theme} from "antd"
 import Sidebar from "../Sidebar/Sidebar"
 import {GithubFilled, LinkedinFilled, TwitterOutlined} from "@ant-design/icons"
 import Link from "next/link"
@@ -19,6 +19,7 @@ import {Lightning} from "@phosphor-icons/react"
 import packageJsonData from "../../../package.json"
 import {useProjectData} from "@/contexts/project.context"
 import {dynamicContext} from "@/lib/helpers/dynamic"
+import NoResultsFound from "../NoResultsFound/NoResultsFound"
 
 const {Content, Footer} = Layout
 const {Text} = Typography
@@ -93,6 +94,21 @@ const useStyles = createUseStyles((theme: JSSTheme) => ({
         fontWeight: 500,
         "& span": {
             fontWeight: 600,
+        },
+    },
+    notFoundContainer: {
+        display: "flex",
+        flexDirection: "column",
+        minHeight: "100vh",
+        alignItems: "center",
+        justifyContent: "center",
+        "& h1": {
+            fontSize: 24,
+            fontWeight: 600,
+        },
+        "& p": {
+            fontSize: 14,
+            marginTop: 8,
         },
     },
 }))
@@ -190,7 +206,19 @@ const App: React.FC<LayoutProps> = ({children}) => {
     }, [appTheme])
 
     // wait unitl we have the app id, if its an app route
-    if (isAppRoute && (!appId || !currentApp)) return null
+    if (isAppRoute && !appId) return null
+
+    if (appId && !currentApp)
+        return (
+            <div className={classes.notFoundContainer}>
+                <h1>404 - Page Not Found</h1>
+                <p>This page could not be found.</p>
+
+                <Button type="primary" onClick={() => router.push("/apps")}>
+                    Back To Apps
+                </Button>
+            </div>
+        )
 
     const isAuthRoute =
         router.pathname.includes("/auth") || router.pathname.includes("/post-signup")


### PR DESCRIPTION
### Description

Jam Recording: https://jam.dev/c/2c9d927b-52c7-4d8d-b95d-a718d44d8e66

The problem occurs because we switched workspaces in this example to `DEMO_WORKSPACE`. When clicking the browser's back button, it attempts to load an app at `/apps/ADD_ID/traces` that belongs to the previous workspace, which doesn’t exist in the current workspace

Closes [AGE-1461](https://linear.app/agenta/issue/AGE-1461/[bug]-window-not-responding-after-switching-between-workspaces-while)