### PR TITLE
(frontend)[AGE-1464]: implement useIsomorphicLayoutEffect hook to prevent using useLayoutEffect on server

### DIFF
--- a/agenta-web/src/hooks/useIsomorphicLayoutEffect.ts
+++ b/agenta-web/src/hooks/useIsomorphicLayoutEffect.ts
@@ -1,0 +1,8 @@
+import {useLayoutEffect, useEffect} from "react"
+
+// useIsomorphicLayoutEffect is a custom hook that uses useLayoutEffect on the client-side
+// (when window is defined) and useEffect on the server-side (when window is undefined).
+// This ensures that the code runs correctly in both client-side and server-side environments.
+const useIsomorphicLayoutEffect = typeof window !== "undefined" ? useLayoutEffect : useEffect
+
+export default useIsomorphicLayoutEffect

--- a/agenta-web/src/hooks/usePostHogAg.ts
+++ b/agenta-web/src/hooks/usePostHogAg.ts
@@ -2,6 +2,7 @@ import {useLayoutEffect} from "react"
 import {isDemo, generateOrRetrieveDistinctId} from "@/lib/helpers/utils"
 import {usePostHog} from "posthog-js/react"
 import {useProfileData} from "@/contexts/profile.context"
+import useIsomorphicLayoutEffect from "./useIsomorphicLayoutEffect"
 
 export const usePostHogAg = () => {
     const trackingEnabled = process.env.NEXT_PUBLIC_TELEMETRY_TRACKING_ENABLED === "true"
@@ -23,11 +24,11 @@ export const usePostHogAg = () => {
         }
     }
 
-    useLayoutEffect(() => {
+    useIsomorphicLayoutEffect(() => {
         if (!trackingEnabled) posthog.opt_out_capturing()
     }, [trackingEnabled])
 
-    useLayoutEffect(() => {
+    useIsomorphicLayoutEffect(() => {
         if (posthog.get_distinct_id() !== _id) identify()
     }, [user?.id])
 


### PR DESCRIPTION
closes [AGE-1464](https://linear.app/agenta/issue/AGE-1464/eliminate-console-warnings-about-using-uselayouteffect-on-server)

### What has changed
- introduced a useIsomorphicLayoutEffect hook

```
// useIsomorphicLayoutEffect is a custom hook that uses useLayoutEffect on the client-side
// (when window is defined) and useEffect on the server-side (when window is undefined).
// This ensures that the code runs correctly in both client-side and server-side environments.
```

I guess the only test is to check that this warning is not getting logged to terminal