### PR TITLE
Apps running in agenta have AGENTA_RUNTIME=true

### DIFF
--- a/agenta-backend/agenta_backend/services/app_manager.py
+++ b/agenta-backend/agenta_backend/services/app_manager.py
@@ -101,6 +101,7 @@ async def start_variant(
                 "AGENTA_BASE_ID": str(db_app_variant.base_id),
                 "AGENTA_APP_ID": str(db_app_variant.app_id),
                 "AGENTA_HOST": domain_name,
+                "AGENTA_RUNTIME": "true",
             }
         )
         if isCloudEE():


### PR DESCRIPTION
- Added a new environment variable when the app is started `AGENTA_RUNTIME`
- This allows users to use fetch the configuration from the backend when the app is running locally and from the route when it's running in agenta cloud

```
    if os.getenv("AGENTA_RUNTIME", "false") == "true":
        config = ag.ConfigManager.get_from_route(Config)
    else:
        config = ag.ConfigManager.get_from_registry(
            app_slug="my-app", environment_slug="production"
        )
```