### PR TITLE
fix(frontend): Fix posthog hook to keep getSurveys functionality

### DIFF
--- a/agenta-web/src/lib/helpers/analytics/AgPosthogProvider.tsx
+++ b/agenta-web/src/lib/helpers/analytics/AgPosthogProvider.tsx
@@ -1,4 +1,4 @@
-import {useCallback, useEffect, useRef, useState} from "react"
+import {useCallback, useEffect, useState} from "react"
 import {useRouter} from "next/router"
 import {useAtom} from "jotai"
 import {posthogAtom, type PostHogConfig} from "./store/atoms"


### PR DESCRIPTION
closes [AGE-1418](https://linear.app/agenta/issue/AGE-1418/improve-posthog-imports)

### What has changed?
- In the initial implementation, we couldn't access `getSurveys` which led to an infinite rendering loop during testing. This PR fixes that.