### PR TITLE
fix(frontend): Prevent rendering pages without required context information

### DIFF
--- a/agenta-web/src/components/Layout/Layout.tsx
+++ b/agenta-web/src/components/Layout/Layout.tsx
@@ -205,7 +205,7 @@ const App: React.FC<LayoutProps> = ({children}) => {
     }, [appTheme])
 
     // wait unitl we have the app id, if its an app route
-    if (isAppRoute && !appId) return null
+    if (isAppRoute && (!appId || !project)) return null
 
     if (appId && !currentApp && !isLoading && !error)
         return (


### PR DESCRIPTION
### Context

The issues reported after the QA testing of release checkpoint 1, was caused by rendering pages without full context information. On cloud, this led to queries to the backend using default projectId, and broke first landing on pages that required this data.

## What has changed
- we are now preventing rendering page components if we don't have `appId` or `project` values