### PR TITLE
(frontend)[Vault Hot Fix]: Stale secret state causing 404 when adding secrets after deletion

### DIFF
--- a/agenta-web/src/components/pages/settings/Secrets/Secrets.tsx
+++ b/agenta-web/src/components/pages/settings/Secrets/Secrets.tsx
@@ -87,6 +87,7 @@ export default function Secrets() {
                                             })
                                             const newLlmProviderKeys = [...llmProviderKeys]
                                             newLlmProviderKeys[i].key = ""
+                                            newLlmProviderKeys[i].id = ""
                                             setLlmProviderKeys(newLlmProviderKeys)
                                             messageAPI.warning("The secret is deleted")
                                         } finally {


### PR DESCRIPTION
### Description
When you delete a secret, and try to create/add a new one, the request [fails](https://www.awesomescreenshot.com/video/35015204?key=8c690e749450befb1aad2f908aa03e1e) with a 404. But when you reload the page, and try to create/add a new one, it works. I think that in the first instance, the state saves the deleted secret id which results to a 404.