### PR TITLE
[Fix] Prevent redirection from ProtectedRoute component if there's another route change is already happening

### DIFF
--- a/agenta-web/src/components/ProtectedRoute/ProtectedRoute.tsx
+++ b/agenta-web/src/components/ProtectedRoute/ProtectedRoute.tsx
@@ -12,20 +12,16 @@ const ProtectedRoute: React.FC<PropsWithChildren> = ({children}) => {
     const isBusy = useRef(false)
 
     useEffect(() => {
-        const startHandler = (newRoute: string) => {
-            isBusy.current = true
-        }
-        const endHandler = (newRoute: string) => {
-            isBusy.current = false
-        }
+        const startHandler = (_newRoute: string) => (isBusy.current = true)
+        const endHandler = (_newRoute: string) => (isBusy.current = false)
 
-        Router.events.on("routeChangeStart", startHandler)
-        Router.events.on("routeChangeComplete", endHandler)
+        router.events.on("routeChangeStart", startHandler)
+        router.events.on("routeChangeComplete", endHandler)
         return () => {
-            Router.events.off("routeChangeStart", startHandler)
-            Router.events.off("routeChangeComplete", endHandler)
+            router.events.off("routeChangeStart", startHandler)
+            router.events.off("routeChangeComplete", endHandler)
         }
-    }, [])
+    }, [router])
 
     useEffect(() => {
         if (isBusy.current) return

--- a/agenta-web/src/components/ProtectedRoute/ProtectedRoute.tsx
+++ b/agenta-web/src/components/ProtectedRoute/ProtectedRoute.tsx
@@ -1,5 +1,5 @@
 import {useSession} from "@/hooks/useSession"
-import Router, {useRouter} from "next/router"
+import {useRouter} from "next/router"
 import React, {PropsWithChildren, useEffect, useRef, useState} from "react"
 import {useProjectData} from "@/contexts/project.context"
 


### PR DESCRIPTION
### Context
During my implementation of new tests, I'd encountered a few cases, where the redirection logic inside ProtectedRoute was cancelling direction of new users to `/post-signup` 

### What has changed
- ProtectedRoute now listens to router events and do not perform a push, if router is already in progress of changing routes