### PR TITLE
CLI tests only run when triggered

### DIFF
--- a/.github/workflows/cli-commands-tests.yml
+++ b/.github/workflows/cli-commands-tests.yml
@@ -7,6 +7,7 @@ on:
         paths:
             - "agenta-backend/**"
             - "agenta-cli/**"
+            
 
 jobs:
     serve-to-oss:

--- a/.github/workflows/cli-commands-tests.yml
+++ b/.github/workflows/cli-commands-tests.yml
@@ -1,13 +1,16 @@
 name: cli commands tests
 
 on:
+    workflow_dispatch:
     pull_request:
+        types: [labeled]
         paths:
             - "agenta-backend/**"
             - "agenta-cli/**"
 
 jobs:
     serve-to-oss:
+        if: contains(github.event.pull_request.labels.*.name, 'run-cli-tests')
         runs-on: ubuntu-latest
         environment: oss
         steps:


### PR DESCRIPTION
CLI tests are triggered by adding the label run-cli-tests