### PR TITLE
Frontend [AGE-1340]: Fix cache related issue that is breaking human a/b eval

### DIFF
--- a/agenta-web/src/components/NewPlayground/hooks/usePlayground/assets/helpers.ts
+++ b/agenta-web/src/components/NewPlayground/hooks/usePlayground/assets/helpers.ts
@@ -36,7 +36,7 @@ export const isPlaygroundEqual = (a?: any, b?: any): boolean => {
     return isEqual(a, b)
 }
 
-const uriFixer = (uri: string) => {
+export const uriFixer = (uri: string) => {
     if (!uri.includes("http://") && !uri.includes("https://")) {
         // for oss.agenta.ai
         uri = `https://${uri}`

--- a/agenta-web/src/lib/hooks/useStatelessVariant/middlewares/appSchemaMiddleware.ts
+++ b/agenta-web/src/lib/hooks/useStatelessVariant/middlewares/appSchemaMiddleware.ts
@@ -35,7 +35,16 @@ const appSchemaMiddleware: PlaygroundMiddleware = (useSWRNext: SWRHook) => {
                     const cachedValue = cache.get(url)?.data
 
                     if (cachedValue) {
-                        return cachedValue
+                        if (
+                            !config.initialVariants ||
+                            (!!config.initialVariants &&
+                                isEqual(
+                                    cachedValue.variants.map((v) => v.id),
+                                    config.initialVariants.map((v) => v.id),
+                                ))
+                        ) {
+                            return cachedValue
+                        }
                     }
 
                     let state = structuredClone(cachedValue || initialState) as Data

--- a/agenta-web/src/services/api.ts
+++ b/agenta-web/src/services/api.ts
@@ -16,6 +16,7 @@ import {
     BaseResponse,
     User,
 } from "@/lib/Types"
+import {uriFixer} from "@/components/NewPlayground/hooks/usePlayground/assets/helpers"
 
 //Prefix convention:
 //  - fetch: GET single entity from server
@@ -59,6 +60,7 @@ export async function fetchVariants(
                 updatedAt: formatDay(variant.updated_at),
                 modifiedById: variant.modified_by_id,
                 createdAt: formatDay(variant.created_at),
+                uri: uriFixer(variant.uri),
             }
             return v
         })


### PR DESCRIPTION
- cache was not being updated due to old transformer not taking into account the `uri` key.
- also improved the case where we return cached data instead of performing a refetch