### PR TITLE
[Fix] single bracket variable detection in the new playground

### DIFF
--- a/agenta-web/src/components/NewPlayground/hooks/usePlayground/assets/inputHelpers.ts
+++ b/agenta-web/src/components/NewPlayground/hooks/usePlayground/assets/inputHelpers.ts
@@ -21,7 +21,7 @@ import {PlaygroundStateData} from "../types"
  * @returns Array of variable names found in the string
  */
 export function extractVariables(input: string): string[] {
-    const variablePattern = /\{\s*(\w+)\s*\}/g
+    const variablePattern = /\{\{\s*(\w+)\s*\}\}/g
     const variables: string[] = []
 
     let match: RegExpExecArray | null


### PR DESCRIPTION
closes [AGE-1516](https://linear.app/agenta/issue/AGE-1516/fix-single-bracket-dynamic-variable-identification-in-the-new)
