### PR TITLE
[Hot Fix]: Replace crypto.randomUUID with uuidv4 for ID generation

### DIFF
--- a/agenta-web/src/components/Editor/Editor.tsx
+++ b/agenta-web/src/components/Editor/Editor.tsx
@@ -1,13 +1,9 @@
+import {forwardRef, useCallback, useEffect, useRef} from "react"
+
 import {LexicalComposer} from "@lexical/react/LexicalComposer"
+import {v4 as uuidv4} from "uuid"
 import clsx from "clsx"
-import {
-    $createTextNode,
-    $insertNodes,
-    COMMAND_PRIORITY_LOW,
-    EditorState,
-    LexicalEditor,
-    createCommand,
-} from "lexical"
+import {COMMAND_PRIORITY_LOW, EditorState, LexicalEditor, createCommand} from "lexical"
 import {$getRoot} from "lexical"
 import {$convertFromMarkdownString, $convertToMarkdownString, TRANSFORMERS} from "@lexical/markdown"
 
@@ -17,7 +13,6 @@ import useEditorConfig from "./hooks/useEditorConfig"
 import EditorPlugins from "./plugins"
 
 import type {EditorProps} from "./types"
-import {forwardRef, useCallback, useEffect, useRef} from "react"
 import {mergeRegister} from "@lexical/utils"
 import {useLexicalComposerContext} from "@lexical/react/LexicalComposerContext"
 
@@ -49,7 +44,7 @@ export const ON_HYDRATE_FROM_REMOTE_CONTENT = createCommand<{
 const EditorInner = forwardRef<HTMLDivElement, EditorProps>(
     (
         {
-            id = crypto.randomUUID(),
+            id = uuidv4(),
             initialValue = "",
             onChange,
             placeholder = "Enter some text...",
@@ -178,7 +173,7 @@ const EditorInner = forwardRef<HTMLDivElement, EditorProps>(
 )
 
 const Editor = ({
-    id = crypto.randomUUID(),
+    id = uuidv4(),
     initialValue = "",
     disabled = false,
     className,

--- a/agenta-web/src/components/NewPlayground/assets/utilities/genericTransformer/utilities/string.ts
+++ b/agenta-web/src/components/NewPlayground/assets/utilities/genericTransformer/utilities/string.ts
@@ -1,3 +1,5 @@
+import {v4 as uuidv4} from "uuid"
+
 /** String manipulation utilities */
 export const toCamelCase = (str: string): string =>
     str.replace(/([-_][a-z])/g, (group) => group.toUpperCase().replace(/[-_]/g, ""))
@@ -5,4 +7,4 @@ export const toCamelCase = (str: string): string =>
 export const toSnakeCase = (str: string): string =>
     str.replace(/[A-Z]/g, (letter) => `_${letter.toLowerCase()}`)
 
-export const generateId = () => crypto.randomUUID()
+export const generateId = () => uuidv4()

--- a/agenta-web/src/lib/hooks/useStatelessVariant/assets/genericTransformer/utilities/string.ts
+++ b/agenta-web/src/lib/hooks/useStatelessVariant/assets/genericTransformer/utilities/string.ts
@@ -1,3 +1,5 @@
+import {v4 as uuidv4} from "uuid"
+
 /** String manipulation utilities */
 export const toCamelCase = (str: string): string =>
     str.replace(/([-_][a-z])/g, (group) => group.toUpperCase().replace(/[-_]/g, ""))
@@ -5,4 +7,4 @@ export const toCamelCase = (str: string): string =>
 export const toSnakeCase = (str: string): string =>
     str.replace(/[A-Z]/g, (letter) => `_${letter.toLowerCase()}`)
 
-export const generateId = () => crypto.randomUUID()
+export const generateId = () => uuidv4()


### PR DESCRIPTION
Cloud branch: [hot-fix/-replaced-crypto.random-with-uuidv4-for-id-generation_v2](https://github.com/Agenta-AI/agenta_cloud/tree/hot-fix/-replaced-crypto.random-with-uuidv4-for-id-generation_v2)