### PR TITLE
[Hot Fix]: Improve handling of app_type

### DIFF
--- a/agenta-web/src/components/Playground/index.tsx
+++ b/agenta-web/src/components/Playground/index.tsx
@@ -35,7 +35,7 @@ const PlaygroundRouter = () => {
             </div>
         )
     } else if (!!app) {
-        if (app.app_type?.includes(" (old)") || app.app_type === "custom") {
+        if (!app.app_type || app.app_type.includes(" (old)") || app.app_type === "custom") {
             return <OldPlayground />
         } else {
             if (!router.query.playground) {

--- a/agenta-web/src/lib/hooks/useVariants.ts
+++ b/agenta-web/src/lib/hooks/useVariants.ts
@@ -4,6 +4,7 @@ import useStatelessVariants from "./useStatelessVariant"
 export const useVariants = (app) =>
     !app
         ? () => {}
-        : app.app_type.includes("old") || app.app_type.includes("custom")
+        : !app.app_type ||
+            (!!app.app_type && (app.app_type.includes("old") || app.app_type.includes("custom")))
           ? useLegacyVariants
           : useStatelessVariants


### PR DESCRIPTION
Currently we're receiving app_type as null in some applications, and that breaks the webUi for the users of those applications. This PR fixes that problem and allows affected users to use "legacy playground"