### PR TITLE
[Hot Fix]: Filtering of non-demo project organizations

### DIFF
--- a/agenta-web/src/components/Sidebar/Sidebar.tsx
+++ b/agenta-web/src/components/Sidebar/Sidebar.tsx
@@ -32,10 +32,10 @@ const Sidebar: React.FC = () => {
     const menu = useSidebarConfig()
     const {user} = useProfileData()
     const {logout} = useSession()
-    const {project} = useProjectData()
+    const {project, projects} = useProjectData()
     const {selectedOrg, orgs, changeSelectedOrg} = useOrgData()
     const [isHovered, setIsHovered] = useState(false)
-    const dropdownItems = useDropdownItems({logout, orgs, selectedOrg, user, project})
+    const dropdownItems = useDropdownItems({logout, orgs, selectedOrg, user, project, projects})
 
     const isSidebarExpanded = useMemo(() => collapsed && !isHovered, [collapsed, isHovered])
 

--- a/agenta-web/src/components/Sidebar/hooks/useDropdownItems/index.tsx
+++ b/agenta-web/src/components/Sidebar/hooks/useDropdownItems/index.tsx
@@ -15,11 +15,18 @@ export const useDropdownItems = ({
     orgs,
     project,
     logout,
+    projects,
 }: UseDropdownItemsProps) => {
+    const filteredOrgs = useMemo(() => {
+        return projects.flatMap((project) =>
+            orgs.filter((org) => org.id === project.organization_id && !project.is_demo),
+        )
+    }, [projects, orgs])
+
     const dropdownItems = useMemo(() => {
         if (selectedOrg?.id && user?.id && isDemo()) {
             return [
-                ...orgs.map((org: any) => ({
+                ...filteredOrgs.map((org: any) => ({
                     key: org.id,
                     label: (
                         <Space>
@@ -58,7 +65,7 @@ export const useDropdownItems = ({
         } else {
             return []
         }
-    }, [logout, orgs, project?.is_demo, selectedOrg?.id, user?.id])
+    }, [logout, filteredOrgs, project?.is_demo, selectedOrg?.id, user?.id])
 
     return dropdownItems
 }

--- a/agenta-web/src/components/Sidebar/hooks/useDropdownItems/types.d.ts
+++ b/agenta-web/src/components/Sidebar/hooks/useDropdownItems/types.d.ts
@@ -7,4 +7,5 @@ export type UseDropdownItemsProps = {
     orgs: Org[]
     project: ProjectsResponse | null
     logout: () => void
+    projects: ProjectsResponse[]
 }


### PR DESCRIPTION
This PR updates the logic for filtering organizations linked to projects while ensuring that demo projects are excluded.