### PR TITLE
[AGE-1540](frontend): Latest variant version is not shown in the Configure evaluator

### DIFF
--- a/agenta-web/src/lib/hooks/useStatelessVariant/middlewares/appSchemaMiddleware.ts
+++ b/agenta-web/src/lib/hooks/useStatelessVariant/middlewares/appSchemaMiddleware.ts
@@ -34,19 +34,6 @@ const appSchemaMiddleware: PlaygroundMiddleware = (useSWRNext: SWRHook) => {
                     }
                     const cachedValue = cache.get(url)?.data
 
-                    if (cachedValue) {
-                        if (
-                            !config.initialVariants ||
-                            (!!config.initialVariants &&
-                                isEqual(
-                                    cachedValue.variants.map((v) => v.id),
-                                    config.initialVariants.map((v) => v.id),
-                                ))
-                        ) {
-                            return cachedValue
-                        }
-                    }
-
                     let state = structuredClone(cachedValue || initialState) as Data
 
                     if (!fetcher) {
@@ -115,8 +102,6 @@ const appSchemaMiddleware: PlaygroundMiddleware = (useSWRNext: SWRHook) => {
                 compare: (a, b) => {
                     return isEqual(a, b)
                 },
-                revalidateOnFocus: false,
-                revalidateOnReconnect: false,
             })
         }
         return useImplementation({key, fetcher, config})


### PR DESCRIPTION
Closes [AGE-1540](https://linear.app/agenta/issue/AGE-1540/[bug]-latest-variant-version-is-not-shown-in-the-configure-evaluator)