### PR TITLE
[fix] Text overlap issue in Playground UI

### DIFF
--- a/web/oss/src/components/Playground/Components/PlaygroundGenerations/assets/GenerationHeader/index.tsx
+++ b/web/oss/src/components/Playground/Components/PlaygroundGenerations/assets/GenerationHeader/index.tsx
@@ -68,7 +68,7 @@ const GenerationHeader = ({variantId}: GenerationHeaderProps) => {
     return (
         <div
             className={clsx(
-                "h-[48px] flex justify-between items-center gap-4 sticky top-0 z-1000 !bg-[white]",
+                "h-[48px] flex justify-between items-center gap-4 sticky top-0 z-[1000] !bg-[white]",
                 classes.container,
             )}
         >


### PR DESCRIPTION
<img width="974" height="215" alt="Screenshot 2025-11-12 at 4 22 40 AM" src="https://github.com/user-attachments/assets/f0aad375-ca27-4ed0-8c6e-89b91303b541" />
