### PR TITLE
feat: add gpt-5.1 to openai model list

### DIFF
--- a/sdk/agenta/sdk/assets.py
+++ b/sdk/agenta/sdk/assets.py
@@ -64,6 +64,7 @@ supported_llm_models = {
     ],
     "openai": [
         "gpt-5",
+        "gpt-5.1",
         "gpt-5-mini",
         "gpt-5-nano",
         "gpt-4.5-preview",


### PR DESCRIPTION
## Summary
- include the new OpenAI `gpt-5.1` model in the supported LLM registry

## Testing
- not run (tests are currently not working)


------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_6916e66237608330b0c8587bcc299e33)