### PR TITLE
[fix] Fix memory leak in completion endpoint

### DIFF
--- a/sdk/agenta/sdk/litellm/litellm.py
+++ b/sdk/agenta/sdk/litellm/litellm.py
@@ -193,6 +193,9 @@ def litellm_handler():
 
             span.end()
 
+            # Clean up span from dictionary to prevent memory leak
+            del self.span[litellm_call_id]
+
         def log_failure_event(
             self,
             kwargs,
@@ -220,6 +223,9 @@ def litellm_handler():
             span.set_status(status="ERROR")
 
             span.end()
+
+            # Clean up span from dictionary to prevent memory leak
+            del self.span[litellm_call_id]
 
         async def async_log_stream_event(
             self,
@@ -321,6 +327,9 @@ def litellm_handler():
 
             span.end()
 
+            # Clean up span from dictionary to prevent memory leak
+            del self.span[litellm_call_id]
+
         async def async_log_failure_event(
             self,
             kwargs,
@@ -348,5 +357,8 @@ def litellm_handler():
             span.set_status(status="ERROR")
 
             span.end()
+
+            # Clean up span from dictionary to prevent memory leak
+            del self.span[litellm_call_id]
 
     return LitellmHandler()


### PR DESCRIPTION
The LitellmHandler class had a critical memory leak where spans were added to self.span dictionary but never removed after completion. Since a single global instance of LitellmHandler is reused across all requests, this caused unbounded memory growth in the completion service.

Changes:
- Added cleanup of span entries after span.end() in all completion handlers:
  - log_success_event()
  - log_failure_event()
  - async_log_success_event()
  - async_log_failure_event()

This prevents the self.span dictionary from accumulating entries over time, resolving the memory leak that was causing the completion container to use excessive RAM (1350 MB per instance).