### PR TITLE
[chore] Add robots.txt to prevent crawler access to cloud agenta

### DIFF
--- a/web/ee/public/robots.txt
+++ b/web/ee/public/robots.txt
@@ -1,0 +1,4 @@
+# Disallow all crawlers from indexing the Agenta Cloud application
+# This is a SaaS application interface, not a public content site
+User-agent: *
+Disallow: /

--- a/web/oss/public/robots.txt
+++ b/web/oss/public/robots.txt
@@ -1,0 +1,4 @@
+# Disallow all crawlers from indexing the Agenta application
+# This is an application interface, not a public content site
+User-agent: *
+Disallow: /


### PR DESCRIPTION
- Added robots.txt to web/ee/public/ (cloud.agenta.ai)
- Added robots.txt to web/oss/public/ (self-hosted instances)
- Disallows all crawlers to protect user privacy and app performance
- Best practice for SaaS applications vs public content sites