### PR TITLE
chore: add gemini 3 pro preview model to assets

### DIFF
--- a/sdk/agenta/sdk/assets.py
+++ b/sdk/agenta/sdk/assets.py
@@ -27,9 +27,9 @@ supported_llm_models = {
         "deepinfra/mistralai/Mistral-7B-Instruct-v0.1",
     ],
     "gemini": [
+        "gemini/gemini-3-pro-preview",
         "gemini/gemini-2.5-pro",
         "gemini/gemini-2.5-pro-preview-05-06",
-        "gemini/gemini-3-pro-preview",
         "gemini/gemini-2.5-flash",
         "gemini/gemini-2.5-flash-preview-09-2025",
         "gemini/gemini-2.5-flash-preview-05-20",


### PR DESCRIPTION
## Summary
- add the gemini-3-pro-preview model slug to the Gemini assets list so it can be selected like the other supported models

## Testing
- Not run (per instructions)


------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_691cb0046b108330b1d710803fbfdd13)