### PR TITLE
feat(frontend): raise playground image upload limit

### DIFF
--- a/web/oss/src/components/Playground/Components/PlaygroundVariantPropertyControl/assets/PromptImageUpload/index.tsx
+++ b/web/oss/src/components/Playground/Components/PlaygroundVariantPropertyControl/assets/PromptImageUpload/index.tsx
@@ -14,7 +14,7 @@ import {PromptImageUploadProps} from "./types"
 
 const {Dragger} = Upload
 
-const MAX_SIZE = 750 * 1024
+const MAX_SIZE = 5 * 1024 * 1024 // 5MB
 const ALLOWED_TYPES = ["image/jpeg", "image/png", "image/webp", "image/gif"]
 
 const PromptImageUpload = ({
@@ -90,7 +90,7 @@ const PromptImageUpload = ({
         }
 
         if (file.size > MAX_SIZE) {
-            setError("Image size must be less than 750KB.")
+            setError("Image size must be less than 5MB.")
             return
         }
 


### PR DESCRIPTION
## Summary
- raise the prompt image upload limit in the playground from 750KB to 5MB and update the validation message accordingly

## Testing
- not run (per instructions)


------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_691cd67c1b788330816ce7cb36383557)