### PR TITLE
fix(frontend): include chat messages in API snippet

### DIFF
--- a/web/oss/src/pages/w/[workspace_id]/p/[project_id]/apps/[app_id]/endpoints/index.tsx
+++ b/web/oss/src/pages/w/[workspace_id]/p/[project_id]/apps/[app_id]/endpoints/index.tsx
@@ -70,9 +70,10 @@ export const createParams = (
             secondaryParams[item.name] = item.default || value
         }
     })
-    const isChat = Array.isArray(inputParams)
+    const hasMessagesParam = Array.isArray(inputParams)
         ? inputParams.some((p) => p?.name === "messages")
         : false
+    const isChat = app?.app_type === "chat" || hasMessagesParam
     if (isChat) {
         mainParams["messages"] = [
             {


### PR DESCRIPTION
## Summary
- detect chat apps when building API snippet parameters by checking the app type
- always include a sample `messages` array alongside `inputs` for chat apps so the generated request matches the expected payload

## Testing
- Not run (not requested)

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_691df9088804833080bd769aa3fac04d)