### PR TITLE
Prevent custom provider name conflicts

### DIFF
--- a/web/oss/src/components/ModelRegistry/Drawers/ConfigureProviderDrawer/assets/ConfigureProviderDrawerContent.tsx
+++ b/web/oss/src/components/ModelRegistry/Drawers/ConfigureProviderDrawer/assets/ConfigureProviderDrawerContent.tsx
@@ -108,6 +108,10 @@ const ConfigureProviderDrawerContent = ({
         () => [...customProviders, ...standardProviders],
         [standardProviders, customProviders],
     )
+    const defaultProviderNames = useMemo(
+        () => new Set(standardProviders.map((provider) => provider.toLowerCase())),
+        [standardProviders],
+    )
 
     const providerValue = useWatch("provider", form) || ""
     const normalizedProviderKind = useMemo(() => {
@@ -224,6 +228,15 @@ const ConfigureProviderDrawerContent = ({
                                                               if (!isAppNameInputValid(value)) {
                                                                   return Promise.reject(
                                                                       "Name must contain only letters, numbers, underscore, or dash without any spaces.",
+                                                                  )
+                                                              }
+                                                              if (
+                                                                  defaultProviderNames.has(
+                                                                      value.trim().toLowerCase(),
+                                                                  )
+                                                              ) {
+                                                                  return Promise.reject(
+                                                                      "Name cannot match a default provider. Please choose a different name.",
                                                                   )
                                                               }
                                                               return Promise.resolve()


### PR DESCRIPTION
## Context

Context is that the user created a custom provider for Open Router called it Open Router and then broke things because our SDK did not know whether to call a custom provider or call the default provider Open Router. The PR fixes this by not allowing names for custom providers that are the same as our default providers. 

## Summary
- add validation to block custom provider names that match built-in provider identifiers when configuring custom providers

## Testing
- pnpm format-fix

## QA
- [ ] Making sure the custom provider UI still works fine
- [ ] Making sure you cannot create custom providers with the same name as our default providers

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_691efe70d83c8330858d8228eb2a7580)