### PR TITLE
Handle projects current response in evaluation URL

### DIFF
--- a/sdk/agenta/sdk/evaluations/runs.py
+++ b/sdk/agenta/sdk/evaluations/runs.py
@@ -136,7 +136,14 @@ async def aurl(
         print(response.text)
         raise
 
-    project_info = response.json()
+    response_json = response.json()
+
+    if isinstance(response_json, list):
+        project_info = response_json[0] if response_json else None
+    elif isinstance(response_json, dict):
+        project_info = response_json
+    else:
+        project_info = None
 
     if not project_info:
         return None


### PR DESCRIPTION
## Summary
- handle both object and list payloads returned by `/projects/current` when building evaluation run URLs
- keep evaluation URL generation working even if the endpoint returns a single `ProjectsResponse` object

## Testing
- black agenta/sdk/evaluations/runs.py

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_6929bae125848321bef734af67b163b2)