### PR TITLE
Potential fix for code scanning alert no. 113: Workflow does not contain permissions

### DIFF
--- a/.github/workflows/01-create-release-branch.yml
+++ b/.github/workflows/01-create-release-branch.yml
@@ -1,4 +1,7 @@
 name: 01 - create release branch
+permissions:
+  contents: write
+  pull-requests: write
 
 on:
   workflow_dispatch:


### PR DESCRIPTION
Potential fix for [https://github.com/Agenta-AI/agenta/security/code-scanning/113](https://github.com/Agenta-AI/agenta/security/code-scanning/113)

To fix the problem, add a `permissions` block specifying the minimum required permissions for jobs to function, either at the workflow root (applies to all jobs) or to each job individually (for finer granularity). For workflows that create or update repository contents, create branches/tags, and open PRs, the minimal permissions necessary are usually `contents: write` (for pushing code/tags) and `pull-requests: write` (for opening PRs). The CodeQL recommendation is to start with `contents: read`, but here, both jobs require write access:  
- The `bump-version` job uses `peter-evans/create-pull-request` that creates branches/PRs.
- The `create-tag` job pushes git tags (`contents: write`).  

Therefore, set:
```yaml
permissions:
  contents: write
  pull-requests: write
```
near the top of the workflow (below `name` and above `on:`). This covers both jobs, unless you want even more granular job-level permissions (not required for this fix).

**Where to change:**  
Edit `.github/workflows/01-create-release-branch.yml`, and add the above `permissions:` block after `name:` (i.e., before `on:`).

No additional methods, imports, or definitions are needed; this is entirely within the YAML workflow file.

---


_Suggested fixes powered by Copilot Autofix. Review carefully before merging._
