### PR TITLE
Add user invitation analytics event

### DIFF
--- a/api/oss/src/services/analytics_service.py
+++ b/api/oss/src/services/analytics_service.py
@@ -43,6 +43,7 @@ ACTIVATION_EVENTS = {
     "spans_created": ("activated_observability", {"ApiKey"}),
     "evaluation_created": ("activated_evaluation", None),
     "app_variant_created": ("activated_playground", None),
+    "user_invitation_sent_v1": ("invited_user_v1", None),
 }
 
 
@@ -346,12 +347,11 @@ def _get_event_name_from_path(
     # <----------- End of Query/Prompt Management Events ------------->
 
     # <----------- User Lifecycle Events ------------->
-    if (
-        method == "POST"
-        and ("/invite" in path)
-        and ("invite" in path_parts and "resend" in path_parts)
-    ):
-        return "invitation_created"
+    if method == "POST" and "invite" in path_parts:
+        if "resend" in path_parts:
+            return "invitation_created"
+        if "accept" not in path_parts:
+            return "user_invitation_sent_v1"
     # <----------- End of User Lifecycle Events ------------->
 
     return None


### PR DESCRIPTION
## Summary
- add a versioned PostHog event for sending user invitations with a paired person property
- emit the new event from the analytics middleware when invite endpoints are called, excluding resend and accept flows

## Testing
- not run (tests not requested)


------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_693163413d448330894aed9556840b6f)