### PR TITLE
[fix] update upload testset docs link

### DIFF
--- a/web/oss/src/components/pages/testset/modals/UploadTestset.tsx
+++ b/web/oss/src/components/pages/testset/modals/UploadTestset.tsx
@@ -278,7 +278,7 @@ const UploadTestset: React.FC<Props> = ({setCurrent, onCancel}) => {
                                         )}
 
                                         <Typography.Link
-                                            href="https://agenta.ai/docs/evaluation/create-testsets#creating-a-testset-from-a-csv-or-json"
+                                            href="https://agenta.ai/docs/evaluation/managing-test-sets/upload-csv"
                                             target="_blank"
                                         >
                                             <Button>Read the docs</Button>


### PR DESCRIPTION
## Summary
- update the UploadTestset modal documentation link to point to the new upload CSV page

## Testing
- pnpm format-fix *(fails: pnpm not installed in environment)*

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_6932b4029750833094e135bbda215b81)