### PR TITLE
[fix] Update test set API documentation link

### DIFF
--- a/web/oss/src/components/pages/testset/modals/CreateTestsetFromApi.tsx
+++ b/web/oss/src/components/pages/testset/modals/CreateTestsetFromApi.tsx
@@ -164,7 +164,7 @@ const CreateTestsetFromApi: React.FC<Props> = ({setCurrent, onCancel}) => {
 
             <div className="w-full flex items-center justify-between">
                 <Typography.Link
-                    href="https://agenta.ai/docs/evaluation/create-testsets#creating-a-testset-using-the-api"
+                    href="https://agenta.ai/docs/evaluation/managing-test-sets/create-programatically"
                     target="_blank"
                     className={classes.subText}
                 >


### PR DESCRIPTION
## Summary
- update the test set creation modal to point to the correct API documentation link

## Testing
- Not run (not available in environment)


------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_6933246763408330a1481c7bafbbd3ef)