### PR TITLE
Fix structured output modal prompt copy

### DIFF
--- a/web/oss/src/components/Playground/Components/PlaygroundVariantPropertyControl/assets/PlaygroundOutputControl/index.tsx
+++ b/web/oss/src/components/Playground/Components/PlaygroundVariantPropertyControl/assets/PlaygroundOutputControl/index.tsx
@@ -254,8 +254,7 @@ const PlaygroundOutputControl = ({
                     onOk={saveChanges}
                 >
                     <Typography.Text>
-                        Define the JSON schema for the structured output of the prompt:{" "}
-                        <b className="capitalize">{promptName || "no name"}</b>
+                        Define the JSON schema for the structured output of the prompt
                     </Typography.Text>
                     <PlaygroundVariantPropertyControlWrapper className="w-full max-w-full overflow-y-auto mt-2 flex [&_>_div]:!w-auto [&_>_div]:!grow">
                         <div className="flex flex-col w-full gap-1 mb-2 [&_.agenta-shared-editor]:box-border">


### PR DESCRIPTION
## Summary
- remove incorrect prompt name suffix from structured output modal description
- keep modal instructions concise for defining JSON schema

## Testing
- pnpm format-fix (fails: pnpm not available in environment)


------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_6933287daf248330959c6133c81e55a0)