### PR TITLE
feat(frontend): enhance prompts page app actions

### DIFF
--- a/web/oss/src/components/pages/prompts/modals/MoveFolderModal.tsx
+++ b/web/oss/src/components/pages/prompts/modals/MoveFolderModal.tsx
@@ -3,7 +3,7 @@ import {DataNode} from "antd/es/tree"
 import React from "react"
 
 interface MoveFolderModalProps {
-    folderName?: string | null
+    itemName?: string | null
     open: boolean
     onCancel: () => void
     onMove: () => void
@@ -16,7 +16,7 @@ interface MoveFolderModalProps {
 }
 
 const MoveFolderModal = ({
-    folderName,
+    itemName,
     open,
     onCancel,
     onMove,
@@ -39,13 +39,14 @@ const MoveFolderModal = ({
         >
             <div className="flex flex-col gap-2">
                 <div className="text-gray-500">
-                    Moving <span className="font-medium">{folderName || "folder"}</span>
+                    Moving <span className="font-medium">{itemName || "folder"}</span>
                 </div>
 
                 <div className="text-gray-500">Select folder</div>
 
                 <Tree
                     selectable
+                    showIcon
                     treeData={treeData}
                     selectedKeys={moveSelection ? [moveSelection] : []}
                     onSelect={(keys) => setMoveSelection((keys[0] as string) || null)}

--- a/web/oss/src/services/app-selector/api/index.ts
+++ b/web/oss/src/services/app-selector/api/index.ts
@@ -165,6 +165,22 @@ export const updateAppName = async (appId: string, appName: string, ignoreAxiosE
     return response.data
 }
 
+export const updateAppFolder = async (
+    appId: string,
+    folderId: string | null,
+    ignoreAxiosError = false,
+) => {
+    const {projectId} = getProjectValues()
+
+    const response = await axios.patch(
+        `${getAgentaApiUrl()}/apps/${appId}?project_id=${projectId}`,
+        {id: appId, folder_id: folderId},
+        {_ignoreError: ignoreAxiosError} as any,
+    )
+
+    return response.data
+}
+
 export const createAndStartTemplate = async ({
     appName,
     providerKey,


### PR DESCRIPTION
## Summary
- add app-specific actions for opening, renaming, moving, and deleting from the prompts page
- support moving apps via drag and drop and include app nodes in the move destination tree
- add API helper to update an app's folder assignment

## Testing
- pnpm format-fix

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_6938f8dea86483219199b3ab3a32eb1c)