### PR TITLE
Refactor prompts page structure

### DIFF
--- a/web/oss/src/components/pages/prompts/components/PromptsTableSection.tsx
+++ b/web/oss/src/components/pages/prompts/components/PromptsTableSection.tsx
@@ -1,0 +1,136 @@
+import {Dropdown, Input, Space, Button, MenuProps} from "antd"
+import {ColumnsType, TableProps} from "antd/es/table"
+
+import {FolderIcon, PlusIcon, SquaresFourIcon, TrashIcon} from "@phosphor-icons/react"
+
+import {
+    InfiniteDatasetStore,
+    InfiniteVirtualTableFeatureShell,
+    InfiniteVirtualTableRowSelection,
+    TableFeaturePagination,
+    TableScopeConfig,
+} from "@/oss/components/InfiniteVirtualTable"
+
+import {SetupWorkflowIcon} from "./SetupWorkflowIcon"
+import {PromptsTableRow} from "../types"
+
+interface PromptsTableSectionProps {
+    columns: ColumnsType<PromptsTableRow>
+    datasetStore: InfiniteDatasetStore<PromptsTableRow, PromptsTableRow, {projectId: string | null}>
+    tableRows: PromptsTableRow[]
+    rowKeyExtractor: (row: PromptsTableRow) => string
+    tableScope: TableScopeConfig
+    tablePagination: TableFeaturePagination<PromptsTableRow>
+    rowSelection: InfiniteVirtualTableRowSelection<PromptsTableRow>
+    expandable?: TableProps<PromptsTableRow>["expandable"]
+    tableProps?: TableProps<PromptsTableRow>
+    searchTerm: string
+    onSearchChange: (value: string) => void
+    selectedRow: PromptsTableRow | null
+    onDeleteSelected: () => void
+    onOpenNewPrompt: () => void
+    onOpenNewFolder: () => void
+    onSetupWorkflow: () => void
+}
+
+export const PromptsTableSection = ({
+    columns,
+    tableRows,
+    rowKeyExtractor,
+    tableScope,
+    tablePagination,
+    rowSelection,
+    expandable,
+    tableProps,
+    searchTerm,
+    onSearchChange,
+    selectedRow,
+    onDeleteSelected,
+    onOpenNewPrompt,
+    onOpenNewFolder,
+    onSetupWorkflow,
+    datasetStore,
+}: PromptsTableSectionProps) => {
+    const menuItems: MenuProps["items"] = [
+        {
+            key: "new_prompt",
+            icon: <SquaresFourIcon size={16} />,
+            label: "New prompt",
+            onClick: ({domEvent}) => {
+                domEvent.stopPropagation()
+                onOpenNewPrompt()
+            },
+        },
+        {
+            key: "new_folder",
+            icon: <FolderIcon size={16} />,
+            label: "New folder",
+            onClick: ({domEvent}) => {
+                domEvent.stopPropagation()
+                onOpenNewFolder()
+            },
+        },
+        {
+            type: "divider" as const,
+        },
+        {
+            key: "setup_workflow",
+            icon: <SetupWorkflowIcon />,
+            label: "Set up workflow",
+            onClick: ({domEvent}) => {
+                domEvent.stopPropagation()
+                onSetupWorkflow()
+            },
+        },
+    ]
+
+    return (
+        <div className="flex flex-col gap-2 grow">
+            <div className="flex items-center justify-between">
+                <Space>
+                    <Input.Search
+                        placeholder="Search"
+                        allowClear
+                        className="w-[400px]"
+                        value={searchTerm}
+                        onChange={(event) => onSearchChange(event.target.value)}
+                    />
+                </Space>
+
+                <Space>
+                    <Button
+                        icon={<TrashIcon />}
+                        danger
+                        disabled={!selectedRow}
+                        onClick={onDeleteSelected}
+                    >
+                        Delete
+                    </Button>
+
+                    <Dropdown
+                        trigger={["click"]}
+                        overlayStyle={{width: 200}}
+                        placement="bottomLeft"
+                        menu={{items: menuItems}}
+                    >
+                        <Button icon={<PlusIcon />} type="primary">
+                            Create new
+                        </Button>
+                    </Dropdown>
+                </Space>
+            </div>
+
+            <InfiniteVirtualTableFeatureShell<PromptsTableRow>
+                datasetStore={datasetStore}
+                tableScope={tableScope}
+                columns={columns}
+                rowKey={rowKeyExtractor}
+                dataSource={tableRows}
+                pagination={tablePagination}
+                rowSelection={rowSelection}
+                expandable={expandable}
+                tableProps={tableProps}
+            />
+        </div>
+    )
+}

--- a/web/oss/src/components/pages/prompts/hooks/usePromptsColumns.tsx
+++ b/web/oss/src/components/pages/prompts/hooks/usePromptsColumns.tsx
@@ -1,0 +1,195 @@
+import {useMemo} from "react"
+
+import {Dropdown, Button, Space, MenuProps} from "antd"
+import {ColumnsType} from "antd/es/table"
+import {MoreOutlined} from "@ant-design/icons"
+
+import {
+    FolderDashedIcon,
+    FolderIcon,
+    GearSixIcon,
+    NoteIcon,
+    PencilSimpleIcon,
+    TrashIcon,
+} from "@phosphor-icons/react"
+
+import {ListAppsItem} from "@/oss/lib/Types"
+import {formatDay} from "@/oss/lib/helpers/dateTimeHelper"
+
+import {FolderTreeNode} from "../assets/utils"
+import {PromptsTableRow} from "../types"
+
+interface UsePromptsColumnsProps {
+    onFolderClick: (folder: FolderTreeNode) => void
+    onRenameFolder: (folderId: string) => void
+    onDeleteFolder: (folderId: string) => void
+    onMoveItem: (item: PromptsTableRow) => void
+    onOpenAppOverview: (appId: string) => void
+    onOpenEditAppModal: (app: ListAppsItem) => void
+    onOpenDeleteAppModal: (app: ListAppsItem) => void
+}
+
+export const usePromptsColumns = ({
+    onFolderClick,
+    onRenameFolder,
+    onDeleteFolder,
+    onMoveItem,
+    onOpenAppOverview,
+    onOpenEditAppModal,
+    onOpenDeleteAppModal,
+}: UsePromptsColumnsProps) =>
+    useMemo<ColumnsType<PromptsTableRow>>(
+        () => [
+            {
+                title: "Name",
+                key: "name",
+                width: 420,
+                ellipsis: true,
+                render: (_, record) => {
+                    const isFolder = record.type === "folder"
+                    const name = isFolder ? record.name : record.app_name
+
+                    return (
+                        <Space size={8} className="truncate">
+                            {isFolder ? <FolderIcon size={16} /> : <NoteIcon size={16} />}
+                            <span className="truncate">{name}</span>
+                        </Space>
+                    )
+                },
+            },
+            {
+                title: "Date modified",
+                key: "dateModified",
+                dataIndex: "updated_at",
+                width: 200,
+                render: (_, record) => <div>{formatDay({date: record.updated_at})}</div>,
+            },
+            {
+                title: "Type",
+                key: "type",
+                width: 160,
+                render: (_, record) =>
+                    record.type === "folder" ? "Folder" : record.app_type || "App",
+            },
+            {
+                title: <GearSixIcon size={16} />,
+                key: "actions",
+                width: 56,
+                fixed: "right",
+                align: "center",
+                render: (_, record) => {
+                    const isFolder = record.type === "folder"
+
+                    const folderActions: MenuProps["items"] = [
+                        {
+                            key: "open_folder",
+                            label: "Open",
+                            icon: <NoteIcon size={16} />,
+                            onClick: (e) => {
+                                e.domEvent.stopPropagation()
+                                onFolderClick(record as FolderTreeNode)
+                            },
+                        },
+                        {
+                            key: "rename_folder",
+                            label: "Rename",
+                            icon: <PencilSimpleIcon size={16} />,
+                            onClick: (e) => {
+                                e.domEvent.stopPropagation()
+                                onRenameFolder(record.id as string)
+                            },
+                        },
+                        {
+                            key: "move_folder",
+                            label: "Move",
+                            icon: <FolderDashedIcon size={16} />,
+                            onClick: (e) => {
+                                e.domEvent.stopPropagation()
+                                onMoveItem(record)
+                            },
+                        },
+                        {
+                            type: "divider",
+                        },
+                        {
+                            key: "delete_folder",
+                            label: "Delete",
+                            icon: <TrashIcon size={16} />,
+                            danger: true,
+                            onClick: (e) => {
+                                e.domEvent.stopPropagation()
+                                onDeleteFolder(record.id as string)
+                            },
+                        },
+                    ]
+
+                    const appActions: MenuProps["items"] = [
+                        {
+                            key: "open_app",
+                            label: "Open",
+                            icon: <NoteIcon size={16} />,
+                            onClick: (e) => {
+                                e.domEvent.stopPropagation()
+                                onOpenAppOverview(record.app_id)
+                            },
+                        },
+                        {
+                            key: "rename_app",
+                            label: "Rename",
+                            icon: <PencilSimpleIcon size={16} />,
+                            onClick: (e) => {
+                                e.domEvent.stopPropagation()
+                                onOpenEditAppModal(record as ListAppsItem)
+                            },
+                        },
+                        {
+                            key: "move_app",
+                            label: "Move",
+                            icon: <FolderDashedIcon size={16} />,
+                            onClick: (e) => {
+                                e.domEvent.stopPropagation()
+                                onMoveItem(record)
+                            },
+                        },
+                        {
+                            type: "divider",
+                        },
+                        {
+                            key: "delete_app",
+                            label: "Delete",
+                            icon: <TrashIcon size={16} />,
+                            danger: true,
+                            onClick: (e) => {
+                                e.domEvent.stopPropagation()
+                                onOpenDeleteAppModal(record as ListAppsItem)
+                            },
+                        },
+                    ]
+
+                    return (
+                        <Dropdown
+                            trigger={["click"]}
+                            overlayStyle={{width: 180}}
+                            menu={{items: isFolder ? folderActions : appActions}}
+                        >
+                            <Button
+                                type="text"
+                                onClick={(e) => e.stopPropagation()}
+                                icon={<MoreOutlined />}
+                                size="small"
+                            />
+                        </Dropdown>
+                    )
+                },
+            },
+        ],
+        [
+            onDeleteFolder,
+            onFolderClick,
+            onMoveItem,
+            onOpenAppOverview,
+            onOpenDeleteAppModal,
+            onOpenEditAppModal,
+            onRenameFolder,
+        ],
+    )

--- a/web/oss/src/components/pages/prompts/hooks/usePromptsFolderTree.tsx
+++ b/web/oss/src/components/pages/prompts/hooks/usePromptsFolderTree.tsx
@@ -1,0 +1,205 @@
+import {useCallback, useMemo, useState} from "react"
+import {DataNode} from "antd/es/tree"
+
+import {ListAppsItem} from "@/oss/lib/Types"
+import {Folder} from "@/oss/services/folders/types"
+import {FolderIcon, NoteIcon} from "@phosphor-icons/react"
+
+import {FolderTreeItem, buildFolderTree} from "../assets/utils"
+import {PromptsTableRow} from "../types"
+
+interface UsePromptsFolderTreeProps {
+    foldersData?: {folders?: Folder[]} | null
+    apps: ListAppsItem[]
+    isLoadingFolders: boolean
+    isLoadingApps: boolean
+}
+
+export const usePromptsFolderTree = ({
+    foldersData,
+    apps,
+    isLoadingFolders,
+    isLoadingApps,
+}: UsePromptsFolderTreeProps) => {
+    const [searchTerm, setSearchTerm] = useState("")
+    const [currentFolderId, setCurrentFolderId] = useState<string | null>(null)
+
+    const isLoadingInitialData = useMemo(
+        () => isLoadingFolders || isLoadingApps || !foldersData,
+        [foldersData, isLoadingApps, isLoadingFolders],
+    )
+
+    const {roots, foldersById} = useMemo(() => {
+        const folders = foldersData?.folders ?? []
+
+        return buildFolderTree(folders, apps)
+    }, [apps, foldersData])
+
+    const treeData: DataNode[] = useMemo(() => {
+        const buildNodes = (nodes: FolderTreeItem[]): DataNode[] =>
+            nodes.map((node) => {
+                const isFolder = node.type === "folder"
+                const childNodes = isFolder ? buildNodes(node.children ?? []) : undefined
+                const hasChildren = (childNodes?.length ?? 0) > 0
+
+                return {
+                    key: isFolder ? (node.id as string) : node.app_id,
+                    title: isFolder ? node.name : node.app_name,
+                    children: hasChildren ? childNodes : undefined,
+                    selectable: isFolder,
+                    disableCheckbox: !isFolder,
+                    disabled: !isFolder,
+                    icon: isFolder ? <FolderIcon size={16} /> : <NoteIcon size={16} />,
+                }
+            })
+
+        return buildNodes(roots)
+    }, [roots])
+
+    const moveDestinationName = useCallback(
+        (folderId: string | null) => (folderId ? (foldersById[folderId]?.name ?? folderId) : null),
+        [foldersById],
+    )
+
+    const moveItemName = useCallback(
+        (item: FolderTreeItem | null) => item?.name ?? item?.app_name ?? null,
+        [],
+    )
+
+    const deleteFolderName = useCallback(
+        (folderId: string | null) => (folderId ? (foldersById[folderId]?.name ?? null) : null),
+        [foldersById],
+    )
+
+    const visibleRows: FolderTreeItem[] = useMemo(() => {
+        if (!currentFolderId) return roots
+        const current = foldersById[currentFolderId]
+        return current?.children ?? roots
+    }, [currentFolderId, roots, foldersById])
+
+    const filteredRows: FolderTreeItem[] = useMemo(() => {
+        const normalizedSearchTerm = searchTerm.trim().toLowerCase()
+        const rowsToFilter = normalizedSearchTerm ? roots : visibleRows
+
+        if (!normalizedSearchTerm) return rowsToFilter
+
+        const matchesSearch = (item: FolderTreeItem) => {
+            const name = item.type === "folder" ? item.name : item.app_name
+            return (name ?? "").toLowerCase().includes(normalizedSearchTerm)
+        }
+
+        const filterNode = (item: FolderTreeItem): FolderTreeItem | null => {
+            if (item.type === "folder") {
+                const filteredChildren = (item.children ?? [])
+                    .map(filterNode)
+                    .filter(Boolean) as FolderTreeItem[]
+
+                if (matchesSearch(item) || filteredChildren.length) {
+                    return {
+                        ...item,
+                        children: filteredChildren,
+                    }
+                }
+
+                return null
+            }
+
+            return matchesSearch(item) ? item : null
+        }
+
+        return rowsToFilter.map(filterNode).filter(Boolean) as FolderTreeItem[]
+    }, [roots, searchTerm, visibleRows])
+
+    const searchExpandedRowKeys = useMemo(() => {
+        if (!searchTerm.trim()) return []
+
+        const expanded: string[] = []
+
+        const collectFolderIds = (items: FolderTreeItem[]) => {
+            items.forEach((item) => {
+                if (item.type !== "folder") return
+
+                if (item.children && item.children.length > 0) {
+                    expanded.push(item.id as string)
+                    collectFolderIds(item.children)
+                }
+            })
+        }
+
+        collectFolderIds(filteredRows)
+
+        return expanded
+    }, [filteredRows, searchTerm])
+
+    const getRowKey = useCallback(
+        (item: FolderTreeItem) => (item.type === "folder" ? (item.id as string) : item.app_id),
+        [],
+    )
+
+    const tableRows: PromptsTableRow[] = useMemo(() => {
+        if (isLoadingInitialData) return []
+
+        const sanitizeNode = (item: FolderTreeItem): PromptsTableRow => {
+            const baseNode: PromptsTableRow = {
+                ...item,
+                key: getRowKey(item),
+                __isSkeleton: false,
+            }
+
+            if (item.type !== "folder") {
+                return baseNode
+            }
+
+            const childItems = (item.children ?? []).map(sanitizeNode)
+
+            if (childItems.length === 0) {
+                const {children, ...rest} = baseNode
+                return rest as PromptsTableRow
+            }
+
+            return {
+                ...baseNode,
+                children: childItems,
+            }
+        }
+
+        return filteredRows.map(sanitizeNode)
+    }, [filteredRows, getRowKey, isLoadingInitialData])
+
+    const flattenedTableRows = useMemo(() => {
+        const items: PromptsTableRow[] = []
+
+        const traverse = (nodes: PromptsTableRow[]) => {
+            nodes.forEach((node) => {
+                items.push(node)
+                if (node.children?.length) {
+                    traverse(node.children)
+                }
+            })
+        }
+
+        traverse(tableRows)
+
+        return items
+    }, [tableRows])
+
+    return {
+        currentFolderId,
+        setCurrentFolderId,
+        searchTerm,
+        setSearchTerm,
+        foldersById,
+        roots,
+        treeData,
+        moveDestinationName,
+        moveItemName,
+        deleteFolderName,
+        isLoadingInitialData,
+        visibleRows,
+        filteredRows,
+        searchExpandedRowKeys,
+        tableRows,
+        flattenedTableRows,
+        getRowKey,
+    }
+}

--- a/web/oss/src/components/pages/prompts/hooks/usePromptsSelection.ts
+++ b/web/oss/src/components/pages/prompts/hooks/usePromptsSelection.ts
@@ -1,0 +1,48 @@
+import {Key, useEffect, useMemo, useState} from "react"
+
+import {InfiniteVirtualTableRowSelection} from "@/oss/components/InfiniteVirtualTable"
+
+import {FolderTreeItem} from "../assets/utils"
+import {PromptsTableRow} from "../types"
+
+interface UsePromptsSelectionParams {
+    flattenedTableRows: PromptsTableRow[]
+    getRowKey: (item: FolderTreeItem) => string
+}
+
+export const usePromptsSelection = ({flattenedTableRows, getRowKey}: UsePromptsSelectionParams) => {
+    const [selectedRowKeys, setSelectedRowKeys] = useState<string[]>([])
+    const [selectedRow, setSelectedRow] = useState<FolderTreeItem | null>(null)
+
+    const rowSelection = useMemo<InfiniteVirtualTableRowSelection<PromptsTableRow>>(
+        () => ({
+            type: "radio",
+            selectedRowKeys,
+            onChange: (keys: Key[], selectedRows: PromptsTableRow[]) => {
+                setSelectedRowKeys(keys as string[])
+                setSelectedRow(selectedRows[0] ?? null)
+            },
+        }),
+        [selectedRowKeys],
+    )
+
+    useEffect(() => {
+        if (!selectedRowKeys.length) {
+            setSelectedRow(null)
+            return
+        }
+
+        const currentKey = selectedRowKeys[0]
+        const currentRow = flattenedTableRows.find((item) => getRowKey(item) === currentKey) ?? null
+
+        if (!currentRow) {
+            setSelectedRowKeys([])
+            setSelectedRow(null)
+            return
+        }
+
+        setSelectedRow(currentRow)
+    }, [flattenedTableRows, getRowKey, selectedRowKeys])
+
+    return {selectedRowKeys, setSelectedRowKeys, selectedRow, setSelectedRow, rowSelection}
+}

--- a/web/oss/src/components/pages/prompts/store.ts
+++ b/web/oss/src/components/pages/prompts/store.ts
@@ -1,0 +1,38 @@
+import {atom} from "jotai"
+import {createInfiniteDatasetStore} from "@/oss/components/InfiniteVirtualTable"
+
+import {PromptsTableRow} from "./types"
+
+export const promptsTableMetaAtom = atom({projectId: null as string | null})
+
+export const promptsDatasetStore = createInfiniteDatasetStore<
+    PromptsTableRow,
+    PromptsTableRow,
+    {projectId: string | null}
+>({
+    key: "prompts-table",
+    metaAtom: promptsTableMetaAtom,
+    createSkeletonRow: ({rowKey}) => ({
+        key: rowKey,
+        __isSkeleton: true,
+        type: "folder",
+        id: rowKey,
+        name: "",
+        description: "",
+        children: [],
+    }),
+    mergeRow: ({skeleton, apiRow}) => ({
+        ...skeleton,
+        ...(apiRow ?? {}),
+        __isSkeleton: apiRow?.__isSkeleton ?? skeleton.__isSkeleton,
+    }),
+    isEnabled: () => false,
+    fetchPage: async () => ({
+        rows: [],
+        totalCount: 0,
+        hasMore: false,
+        nextOffset: null,
+        nextCursor: null,
+        nextWindowing: null,
+    }),
+})

--- a/web/oss/src/components/pages/prompts/types.ts
+++ b/web/oss/src/components/pages/prompts/types.ts
@@ -1,0 +1,7 @@
+import {ListAppsItem} from "@/oss/lib/Types"
+import {InfiniteTableRowBase} from "@/oss/components/InfiniteVirtualTable"
+import {FolderTreeItem} from "./assets/utils"
+
+export type PromptsTableRow = (FolderTreeItem & InfiniteTableRowBase) & {
+    children?: PromptsTableRow[]
+}


### PR DESCRIPTION
## Summary
- extract folder tree, selection, and column logic for prompts into dedicated hooks
- introduce a typed prompts table section and shared types/store for the virtual table
- simplify PromptsPage by wiring new utilities while keeping existing behavior

## Testing
- pnpm format-fix


------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_69398688b2008321bbb8e4d771cb977b)