### PR TITLE
fix(frontend): allow moving prompts folders to root

### DIFF
--- a/web/oss/src/components/pages/prompts/assets/utils.ts
+++ b/web/oss/src/components/pages/prompts/assets/utils.ts
@@ -22,6 +22,8 @@ export interface FolderTreeNode extends Folder {
  */
 export type FolderTreeItem = FolderTreeNode | AppTreeNode
 
+export const ROOT_TREE_KEY = "__ROOT__"
+
 export const buildFolderTree = (
     folders: Folder[],
     apps: ListAppsItem[] = [],

--- a/web/oss/src/components/pages/prompts/components/PromptsBreadcrumb.tsx
+++ b/web/oss/src/components/pages/prompts/components/PromptsBreadcrumb.tsx
@@ -23,6 +23,7 @@ interface PromptsBreadcrumbProps {
     onMoveFolder?: (folderId: string | null) => void
     onRenameFolder?: (folderId: string | null) => void
     onDeleteFolder?: (folderId: string | null) => void
+    onDropOnRoot?: () => void
 }
 
 const useStyles = createUseStyles((theme: JSSTheme) => ({
@@ -59,6 +60,7 @@ const PromptsBreadcrumb = ({
     onMoveFolder,
     onRenameFolder,
     onDeleteFolder,
+    onDropOnRoot,
 }: PromptsBreadcrumbProps) => {
     const classes = useStyles()
     const {project} = useProjectData()
@@ -85,6 +87,11 @@ const PromptsBreadcrumb = ({
             base.push({
                 title: project.project_name,
                 onClick: () => onFolderChange?.(null),
+                onDragOver: (event) => event.preventDefault(),
+                onDrop: (event) => {
+                    event.preventDefault()
+                    onDropOnRoot?.()
+                },
             })
         }
 

--- a/web/oss/src/components/pages/prompts/hooks/usePromptsFolderTree.tsx
+++ b/web/oss/src/components/pages/prompts/hooks/usePromptsFolderTree.tsx
@@ -4,7 +4,7 @@ import {DataNode} from "antd/es/tree"
 import {ListAppsItem} from "@/oss/lib/Types"
 import {Folder} from "@/oss/services/folders/types"
 
-import {FolderTreeItem, buildFolderTree} from "../assets/utils"
+import {FolderTreeItem, ROOT_TREE_KEY, buildFolderTree} from "../assets/utils"
 import {PromptsTableRow} from "../types"
 import {getAppTypeIcon} from "../assets/iconHelpers"
 import {FolderFilled} from "@ant-design/icons"
@@ -64,11 +64,29 @@ export const usePromptsFolderTree = ({
                 }
             })
 
-        return buildNodes(roots)
+        const rootNode: DataNode = {
+            key: ROOT_TREE_KEY,
+            title: (
+                <div className="flex items-center gap-2 min-h-6 overflow-hidden">
+                    <span className="flex items-center text-gray-400">
+                        <FolderFilled style={{fontSize: 16, color: "#BDC7D1"}} />
+                    </span>
+                    <span className="truncate font-medium">Root</span>
+                </div>
+            ),
+            children: buildNodes(roots),
+            selectable: true,
+            disableCheckbox: false,
+        }
+
+        return [rootNode]
     }, [roots])
 
     const moveDestinationName = useCallback(
-        (folderId: string | null) => (folderId ? (foldersById[folderId]?.name ?? folderId) : null),
+        (folderId: string | null) => {
+            if (folderId === ROOT_TREE_KEY) return "root"
+            return folderId ? (foldersById[folderId]?.name ?? folderId) : null
+        },
         [foldersById],
     )
 


### PR DESCRIPTION
## Summary
- add a root option to the prompts move tree to support selecting the workspace root
- enable drag-and-drop targets (breadcrumb and table area) to move folders or apps back to the root
- allow move validation and handlers to treat null destinations as valid root moves

## Testing
- pnpm format-fix


------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_693a90bdb6a48321970d3373d72b6505)