### PR TITLE
[feat] Disable collapsible in the playground when there is only one prompt

### DIFF
--- a/web/oss/src/components/EvalRunDetails2/components/views/ConfigurationView/components/PromptConfigCard.tsx
+++ b/web/oss/src/components/EvalRunDetails2/components/views/ConfigurationView/components/PromptConfigCard.tsx
@@ -286,6 +286,8 @@ const PromptConfigCard = ({
         )
     }
 
+    const disablePromptCollapse = combinedPrompts.length === 1
+
     return (
         <div className={className}>
             <PromptsSourceProvider promptsByRevision={promptsMap}>
@@ -304,6 +306,7 @@ const PromptConfigCard = ({
                                       variantId={normalizedVariantId}
                                       promptId={String(promptKey)}
                                       viewOnly
+                                      disableCollapse={disablePromptCollapse}
                                   />
                               )
                           })

--- a/web/oss/src/components/Playground/Components/PlaygroundVariantConfig/assets/Editors.tsx
+++ b/web/oss/src/components/Playground/Components/PlaygroundVariantConfig/assets/Editors.tsx
@@ -38,6 +38,8 @@ const PlaygroundVariantConfigEditors = ({
         )
     }
 
+    const disablePromptCollapse = promptIds.length === 1
+
     return (
         <div className={clsx("flex flex-col", className)} {...divProps}>
             {promptIds.map((promptId) => (
@@ -45,6 +47,7 @@ const PlaygroundVariantConfigEditors = ({
                     key={`${variantId}:${promptId as string}`}
                     promptId={promptId}
                     variantId={variantId}
+                    disableCollapse={disablePromptCollapse}
                 />
             ))}
             <PlaygroundVariantCustomProperties

--- a/web/oss/src/components/Playground/Components/PlaygroundVariantConfigPrompt/index.tsx
+++ b/web/oss/src/components/Playground/Components/PlaygroundVariantConfigPrompt/index.tsx
@@ -32,6 +32,8 @@ const PlaygroundVariantConfigPrompt: React.FC<PlaygroundVariantConfigPromptCompo
     promptId,
     className,
     viewOnly = false,
+    disableCollapse = false,
+    expandIcon: expandIconProp,
     ...props
 }) => {
     const defaultActiveKey = useRef(["1"])
@@ -41,6 +43,15 @@ const PlaygroundVariantConfigPrompt: React.FC<PlaygroundVariantConfigPromptCompo
         () => [
             {
                 key: "1",
+                ...(disableCollapse
+                    ? {
+                          // Avoid AntD "disabled" styling (cursor: not-allowed).
+                          // Make it effectively non-collapsible by allowing toggling only via icon,
+                          // then removing the icon.
+                          collapsible: "icon" as const,
+                          showArrow: false,
+                      }
+                    : {}),
                 classNames: {
                     body: "!border-t-0 !pt-0",
                     header: "z-10",
@@ -63,17 +74,18 @@ const PlaygroundVariantConfigPrompt: React.FC<PlaygroundVariantConfigPromptCompo
                 ),
             },
         ],
-        [variantId, promptId, viewOnly],
+        [variantId, promptId, viewOnly, disableCollapse],
     )
 
     return (
         <Collapse
+            {...props}
             ghost
             className={clsx("rounded-none", className, classes.collapseContainer)}
             bordered={false}
             defaultActiveKey={defaultActiveKey.current}
             items={items}
-            {...props}
+            expandIcon={disableCollapse ? () => null : expandIconProp}
         />
     )
 }

--- a/web/oss/src/components/Playground/Components/PlaygroundVariantConfigPrompt/types.d.ts
+++ b/web/oss/src/components/Playground/Components/PlaygroundVariantConfigPrompt/types.d.ts
@@ -10,6 +10,11 @@ export interface PlaygroundVariantConfigPromptComponentProps extends CollapsePro
     promptId: string
     /** Whether the prompt is mutable or view only */
     viewOnly?: boolean
+    /**
+     * Disables collapsing behavior for the prompt panel (keeps the content shown).
+     * Useful when the parent wants the prompt section to be always expanded.
+     */
+    disableCollapse?: boolean
 }
 
 /**

--- a/web/oss/src/components/Playground/v2/components/Drawers/PromptFocusDrawer/index.tsx
+++ b/web/oss/src/components/Playground/v2/components/Drawers/PromptFocusDrawer/index.tsx
@@ -50,6 +50,7 @@ const PromptFocusDrawer: React.FC<PromptFocusDrawerProps> = ({variantId, ...prop
                         key={promptId as string}
                         promptId={promptId}
                         variantId={variantId}
+                        disableCollapse={promptIds.length === 1}
                     />
                 ))}
             </Drawer>

--- a/web/oss/src/components/Playground/v2/components/PlaygroundVariantHistory/index.tsx
+++ b/web/oss/src/components/Playground/v2/components/PlaygroundVariantHistory/index.tsx
@@ -46,6 +46,7 @@ const PlaygroundVariantHistory: React.FC<PlaygroundVariantHistoryProps> = ({vari
                             key={promptId as string}
                             promptId={promptId}
                             variantId={variantId}
+                            disableCollapse={promptIds.length === 1}
                         />
                     ))}
 

--- a/web/oss/src/components/VariantsComponents/Drawers/VariantDrawer/assets/VariantDrawerContent/index.tsx
+++ b/web/oss/src/components/VariantsComponents/Drawers/VariantDrawer/assets/VariantDrawerContent/index.tsx
@@ -154,6 +154,9 @@ const VariantDrawerContent = ({
         }
     }, [showOriginal, appSchema, selectedVariant, uriInfo?.routePath])
 
+    const disableOriginalPromptCollapse = originalPromptIds.length === 1
+    const disablePromptCollapse = (promptIds?.length || 0) === 1
+
     const tabItems = useMemo(() => {
         return [
             appStatus
@@ -176,6 +179,7 @@ const VariantDrawerContent = ({
                                           variantId={(selectedVariant as any)?.id || variantId}
                                           className="[&_.ant-collapse-content-box>div>div]:!w-[97%] border border-solid border-[#0517290F]"
                                           viewOnly
+                                          disableCollapse={disableOriginalPromptCollapse}
                                       />
                                   ))}
                                   <PlaygroundVariantCustomProperties
@@ -194,6 +198,7 @@ const VariantDrawerContent = ({
                                       promptId={promptId}
                                       variantId={selectedVariant?.id}
                                       className="[&_.ant-collapse-content-box>div>div]:!w-[97%] border border-solid border-[#0517290F]"
+                                      disableCollapse={disablePromptCollapse}
                                   />
                               ))}
 
@@ -226,6 +231,8 @@ const VariantDrawerContent = ({
         originalPrompts,
         originalPromptIds,
         isLoading,
+        disableOriginalPromptCollapse,
+        disablePromptCollapse,
     ])
     const drawerState = useAtomValue(variantDrawerAtom)
     const clearJsonOverride = useSetAtom(


### PR DESCRIPTION
The fact that the configuration of the prompt is collapsible in the playground although there is only one prompt is bad for usability (since any time you don't click on the right place while editing the model you end up collapsing the prompt by mistake). 

This PR fixes that

Demo with single prompt

https://github.com/user-attachments/assets/96982cd7-af7a-42b0-9340-25fba95412fa


Demo with custom workflow with one or multiple prompts

https://github.com/user-attachments/assets/a0e224a3-deba-45e0-abd6-e76280dbde4d

