### PR TITLE
[feat] Add internals support and manual path input to testset drawer mappings

### DIFF
--- a/web/oss/src/components/pages/observability/drawer/TestsetDrawer/TestsetDrawer.tsx
+++ b/web/oss/src/components/pages/observability/drawer/TestsetDrawer/TestsetDrawer.tsx
@@ -1,4 +1,4 @@
-import {useCallback, useMemo, useState} from "react"
+import {useCallback, useEffect, useMemo, useState} from "react"
 
 import Editor from "@monaco-editor/react"
 import {
@@ -192,7 +192,19 @@ const TestsetDrawer = ({
         }
     }
 
-    const mappingOptions = useMemo(() => {
+    const allAvailablePaths = useMemo(() => {
+        const uniquePaths = new Set<string>()
+
+        traceData.forEach((traceItem) => {
+            const traceKeys = collectKeyPathsFromObject(traceItem?.data, "data")
+            traceKeys.forEach((key) => uniquePaths.add(key))
+        })
+
+        return Array.from(uniquePaths).map((item) => ({value: item, label: item}))
+    }, [traceData])
+
+    // Auto-detect and map paths when testset is selected
+    useEffect(() => {
         const uniquePaths = new Set<string>()
 
         traceData.forEach((traceItem) => {
@@ -205,9 +217,10 @@ const TestsetDrawer = ({
                 (item) =>
                     item.startsWith("data.inputs") ||
                     item === "data.outputs" ||
-                    item.startsWith("data.outputs."),
+                    item.startsWith("data.outputs.") ||
+                    item.startsWith("data.internals"),
             )
-            .map((item) => ({value: item}))
+            .map((item) => ({value: item, label: item}))
 
         if (mappedData.length > 0 && testset.id) {
             setMappingData((prevMappingData) => {
@@ -263,9 +276,7 @@ const TestsetDrawer = ({
                 return newMappedData
             })
         }
-
-        return mappedData
-    }, [traceData, testset])
+    }, [traceData, testset.id, selectedTestsetColumns])
 
     const columnOptions = useMemo(() => {
         return selectedTestsetColumns?.map(({column}) => ({
@@ -772,10 +783,17 @@ const TestsetDrawer = ({
                                                 key={idx}
                                                 className="flex items-center justify-between gap-2"
                                             >
-                                                <Select
+                                                <AutoComplete
                                                     style={{width: elementWidth}}
-                                                    placeholder="Select a mapped data key"
+                                                    placeholder="Select or type a data path"
                                                     value={data.data || undefined}
+                                                    onSelect={(value) =>
+                                                        onMappingOptionChange({
+                                                            pathName: "data",
+                                                            value,
+                                                            idx,
+                                                        })
+                                                    }
                                                     onChange={(value) =>
                                                         onMappingOptionChange({
                                                             pathName: "data",
@@ -783,7 +801,13 @@ const TestsetDrawer = ({
                                                             idx,
                                                         })
                                                     }
-                                                    options={mappingOptions}
+                                                    options={allAvailablePaths}
+                                                    filterOption={(inputValue, option) =>
+                                                        option!.value
+                                                            .toUpperCase()
+                                                            .indexOf(inputValue.toUpperCase()) !==
+                                                        -1
+                                                    }
                                                 />
                                                 <ArrowRight size={16} />
                                                 <div className="flex-1 flex gap-2 items-center">


### PR DESCRIPTION
## Context
Creating test cases is hard if the inputs of the span don't map exactly to your prompt. The solution for the moment being is to create a parent function with the exact inputs as the function traced. 
This PR provides another flow. The user can save the parameters in ag.data.internals and can use them for the creation of the test set (without having to change the logic of their code).

## Summary

Enhances the "Add to Testset" drawer to support `ag.data.internals.*` paths in automatic mapping detection and allows users to manually type custom data paths with autocomplete.

## Changes

- **Automatic detection of internals**: Added `data.internals.*` paths to the automatic mapping detection filter, so internals data is now automatically detected and mapped alongside inputs and outputs
- **Manual path input**: Replaced the data path `Select` component with `AutoComplete` to allow users to:
  - Type custom data paths manually (e.g., `data.custom.field`, `attributes.ag.data.internals.something`)
  - Get autocomplete suggestions from all available paths in trace data
  - Use paths that aren't in the filtered automatic detection list

## Technical Details
- Added `allAvailablePaths` useMemo hook to collect all available paths from trace data for autocomplete suggestions
- Updated `mappingOptions` filter to include `data.internals` paths
- Changed data path input from `Select` to `AutoComplete` component with both `onSelect` and `onChange` handlers

## Benefits
- Users can now map internals data to testset columns automatically
- Users have full flexibility to map any data path, not just those in the predefined filter
- Better UX with autocomplete suggestions while maintaining the ability to type custom paths