### PR TITLE
[docs] Add PDF support in the Playground to Changelog and Docs

### DIFF
--- a/docs/blog/entries/pdf-support-in-playground.mdx
+++ b/docs/blog/entries/pdf-support-in-playground.mdx
@@ -1,0 +1,99 @@
+---
+title: "PDF Support in the Playground"
+slug: pdf-support-in-playground
+date: 2025-12-17
+tags: [v0.69.0]
+description: "Attach PDFs to chat messages in the Playground. Upload files, provide URLs, or use file IDs from provider APIs. Works across evaluations and observability."
+---
+
+```mdx-code-block
+import Image from "@theme/IdealImage";
+```
+
+The Playground now supports PDF attachments for chat applications. You can include PDF documents in your prompts to build applications that analyze documents, answer questions about content, or extract information from files.
+
+## What is PDF Support?
+
+PDF support lets you attach PDF documents to chat messages when testing prompts in the Playground. The feature works with vision-capable models from OpenAI, Gemini, and Claude. These models can read and understand PDF content to answer questions or perform analysis.
+
+This is useful when you're building applications that need to work with documents. Examples include invoice processing, contract analysis, document Q&A, or content extraction.
+
+## Supported Providers
+
+PDF support works with vision-capable models that handle document inputs.
+
+## How to Attach PDFs
+
+To attach a PDF to a chat message, click "Add attachment" in the message input. You'll see three options:
+
+### Upload a File
+
+Select a PDF from your computer. The file is converted to base64 and sent with your prompt.
+
+### Provide a URL
+
+Paste the URL to a publicly accessible PDF. The model fetches the PDF from the URL.
+
+### Use a File ID
+
+If you've uploaded a file through a provider's API (like the Gemini Files API), you can use the file ID instead. The model retrieves the file from the provider's storage.
+
+## Using PDFs in Evaluations
+
+PDF attachments work in both automatic and human evaluations. You can include PDFs in your test sets and run evaluations across multiple documents.
+
+## PDFs in Observability and Tracing
+
+When you trace requests that include PDFs, you can see the PDF attachment information in the trace data.
+
+## Example Use Cases
+
+### Invoice Processing
+
+Create a prompt that extracts key information from invoices:
+
+```
+Extract the following information from this invoice:
+- Invoice number
+- Date
+- Total amount
+- Vendor name
+- Line items
+
+Return the information as structured JSON.
+```
+
+Attach sample invoices as PDFs. Test the prompt with different invoice formats to ensure reliable extraction across vendors.
+
+### Contract Analysis
+
+Build a prompt that analyzes legal contracts:
+
+```
+Review the attached contract and identify:
+- Key obligations for each party
+- Important dates and deadlines
+- Termination clauses
+- Liability limitations
+
+Provide a summary in plain language.
+```
+
+Attach contract PDFs and verify that the model identifies critical terms consistently.
+
+### Document Q&A
+
+Create an assistant that answers questions about documents:
+
+```
+You are a document assistant. Answer the user's question based on the
+attached PDF. Be specific and cite page numbers when possible.
+
+Question: {{question}}
+```
+
+Attach various document types (reports, manuals, research papers) and test question-answering accuracy across different content.
+
+## Next Steps
+
+Learn more about [using the Playground](/prompt-engineering/playground/using-playground) to develop and test prompts with PDF attachments.

--- a/docs/blog/main.mdx
+++ b/docs/blog/main.mdx
@@ -11,6 +11,16 @@ import Image from "@theme/IdealImage";
 <section class="changelog">
 
 
+### [PDF Support in the Playground](/changelog/pdf-support-in-playground)
+
+_17 December 2025_
+
+**v0.69.0**
+
+The Playground now supports PDF attachments for chat applications. You can attach PDFs by uploading files, providing URLs, or using file IDs from provider APIs. This works with vision-capable models and extends to evaluations and observability. You can now build and test document processing applications like invoice analysis or contract review.
+
+---
+
 ### [Agenta Documentation MCP Server](/changelog/mcp-server)
 
 _14 December 2025_

--- a/docs/docs/prompt-engineering/playground/01-using-playground.mdx
+++ b/docs/docs/prompt-engineering/playground/01-using-playground.mdx
@@ -117,6 +117,20 @@ The playground integrates with Agenta's [prompt management system](/prompt-engin
 2. Changes remain in development until explicitly deployed
 3. Use "Deploy" to push configurations to specific environments (development, staging, production)
 
+## Working with Attachments
+
+For chat applications, you can attach files to messages by clicking "Add attachment" in the message input.
+
+### Image Support
+
+Attach images to chat messages. You can upload image files or provide URLs to images. This works with vision-capable models.
+
+### PDF Support
+
+Attach PDF documents to chat messages. You can upload PDF files, provide URLs, or use file IDs from provider APIs (like Gemini Files API). This works with vision-capable models.
+
+Attachments work in evaluations and observability, enabling systematic testing of applications that process images or documents.
+
 ## Working with Test Sets
 
 ### Loading Existing Test Sets

--- a/docs/src/data/roadmap.ts
+++ b/docs/src/data/roadmap.ts
@@ -25,6 +25,28 @@ export const shippedFeatures: ShippedFeature[] = [
   // Observability: DE74FF
   // Evaluation: 86B7FF
   // Integration: FFA500
+  {
+    id: "pdf-support-playground",
+    title: "PDF Support in the Playground",
+    description:
+      "Attach PDF documents to chat messages in the playground. Upload files, provide URLs, or use file IDs from provider APIs. Works with OpenAI, Gemini, and Claude models. PDFs are supported in evaluations and observability traces.",
+    changelogPath: "/docs/changelog/pdf-support-in-playground",
+    shippedAt: "2025-12-17",
+    labels: [
+      {
+        name: "Playground",
+        color: "BCFF78",
+      },
+      {
+        name: "Evaluation",
+        color: "86B7FF",
+      },
+      {
+        name: "Observability",
+        color: "DE74FF",
+      },
+    ],
+  },
     {
     id: "provider-built-in-tools",
     title: "Provider Built-in Tools in the Playground",
@@ -304,19 +326,6 @@ export const inProgressFeatures: PlannedFeature[] = [
     description:
       "Create folders and subfolders to organize prompts in the playground. Move prompts between folders and search within specific folders to structure prompt libraries.",
     githubUrl: "https://github.com/Agenta-AI/agenta/discussions/2859",
-    labels: [
-      {
-        name: "Playground",
-        color: "BCFF78",
-      },
-    ],
-  },
-  {
-    id: "pdf-support-playground",
-    title: "PDF Support in the Playground",
-    description:
-      "Add PDF support for models that support it (OpenAI, Gemini, etc.) through base64 encoding, URLs, or file IDs. Support extends to human evaluation for reviewing model responses on PDF inputs.",
-    githubUrl: "https://github.com/Agenta-AI/agenta/discussions/2857",
     labels: [
       {
         name: "Playground",


### PR DESCRIPTION
This update introduces the ability to attach PDF documents to chat messages in the Playground. Users can upload files, provide URLs, or use file IDs from provider APIs. This feature is compatible with vision-capable models and enhances evaluations and observability for document processing applications. Documentation has been updated to reflect these changes.