### PR TITLE
Add gemini 3 flash preview model to supported list

### DIFF
--- a/sdk/agenta/sdk/assets.py
+++ b/sdk/agenta/sdk/assets.py
@@ -28,6 +28,7 @@ supported_llm_models = {
     ],
     "gemini": [
         "gemini/gemini-3-pro-preview",
+        "gemini/gemini-3-flash-preview",
         "gemini/gemini-2.5-pro",
         "gemini/gemini-2.5-pro-preview-05-06",
         "gemini/gemini-2.5-flash",


### PR DESCRIPTION
## Summary
- add gemini-3-flash-preview to the supported Gemini model list for completions and chat

## Testing
- not run (tests currently unavailable)


------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_6942e8e963488330a038bb56455a0cdc)