### PR TITLE
[AGE-3471] fix(frontend): chat message actions to hover

### DIFF
--- a/web/oss/src/components/Playground/Components/Modals/CommitVariantChangesModal/index.tsx
+++ b/web/oss/src/components/Playground/Components/Modals/CommitVariantChangesModal/index.tsx
@@ -129,9 +129,7 @@ const CommitVariantChangesModal: React.FC<CommitVariantChangesModalProps> = ({
 
             try {
                 const variantIdForDeployment =
-                    resultVariant?.variant_id ||
-                    resultVariant?.variantId ||
-                    variant?.variantId
+                    resultVariant?.variant_id || resultVariant?.variantId || variant?.variantId
 
                 const revisionIdForDeployment =
                     resultVariant?.id ||

--- a/web/oss/src/components/Playground/adapters/TurnMessageHeaderOptions.tsx
+++ b/web/oss/src/components/Playground/adapters/TurnMessageHeaderOptions.tsx
@@ -154,7 +154,12 @@ const TurnMessageHeaderOptions = ({
     }, [text])
 
     return (
-        <div className={clsx("flex items-center gap-1 relative", className)}>
+        <div
+            className={clsx(
+                "flex items-center gap-1 relative invisible group-hover/item:visible",
+                className,
+            )}
+        >
             {onRerun ? (
                 <EnhancedButton
                     icon={<ArrowClockwise size={14} />}


### PR DESCRIPTION
## Summary
- Show buttons on the message component only on hover in the playground chat

### Issue
- https://linear.app/agenta/issue/AGE-3471/bug-icon-for-tools-in-chat-components-should-only-be-shown-on-hover
- #3085 