### PR TITLE
Custom providers disappear bug

### DIFF
--- a/web/oss/src/state/app/hooks/useVaultSecret.ts
+++ b/web/oss/src/state/app/hooks/useVaultSecret.ts
@@ -106,10 +106,13 @@ export const useVaultSecret = () => {
 
     /**
      * Computed loading state considering both data fetching and migration
+     * Note: We only check migrationStatus.migrating, not !migrationStatus.migrated
+     * This is because the vault query is enabled regardless of migration status,
+     * and we want to show data as soon as it's fetched, not wait for migration to complete
      */
     const loading = useMemo(() => {
-        return vaultQuery.isPending || migrationStatus.migrating || !migrationStatus.migrated
-    }, [vaultQuery.isPending, migrationStatus.migrating, migrationStatus.migrated])
+        return vaultQuery.isPending || migrationStatus.migrating
+    }, [vaultQuery.isPending, migrationStatus.migrating])
 
     return {
         loading,


### PR DESCRIPTION
Fixes custom providers disappearing in the playground and model hub.

The `useVaultSecret` hook's loading state incorrectly included `!migrationStatus.migrated`. As `vaultMigrationAtom` resets on page load, this caused the loading state to be `true` even after vault data was fetched, preventing custom providers from being displayed immediately. Removing this check ensures providers are shown as soon as their data is available.

---
Linear Issue: [AGE-3510](https://linear.app/agenta/issue/AGE-3510/bug-custom-providers-disappear-in-playground-and-model-hub)

<a href="https://cursor.com/background-agent?bcId=bc-a16c543a-0505-4250-a2e1-e89194b0229e"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/open-in-cursor-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/open-in-cursor-light.svg"><img alt="Open in Cursor" src="https://cursor.com/open-in-cursor.svg"></picture></a>&nbsp;<a href="https://cursor.com/agents?id=bc-a16c543a-0505-4250-a2e1-e89194b0229e"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/open-in-web-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/open-in-web-light.svg"><img alt="Open in Web" src="https://cursor.com/open-in-web.svg"></picture></a>

