### PR TITLE
ci: add PR comment deploy command

### DIFF
--- a/.github/workflows/05-deploy-from-pr-comment.yml
+++ b/.github/workflows/05-deploy-from-pr-comment.yml
@@ -1,4 +1,9 @@
 name: Deploy from PR Comment
+permissions:
+  contents: read
+  issues: write
+  pull-requests: read
+  actions: write
 
 on:
   issue_comment:


### PR DESCRIPTION
## Summary

- Add GitHub Actions workflow to trigger cloud deployments directly from PR comments
- Eliminates context switching between OSS repo and private deploy repo
- Supports all three environments (staging, demo, beta) with component selection

## Usage

Comment on any PR with:

/deploy staging # Deploy all components to staging
/deploy demo api-only # Deploy only API to demo
/deploy beta web-only # Deploy only web to beta
/deploy staging --migration-check
