### PR TITLE
fix(frontend): improve variant deletion handling

### DIFF
--- a/web/oss/src/components/Playground/Components/Modals/DeleteVariantModal/DeleteVariantModalWrapper.tsx
+++ b/web/oss/src/components/Playground/Components/Modals/DeleteVariantModal/DeleteVariantModalWrapper.tsx
@@ -3,19 +3,19 @@ import {useAtomValue, useSetAtom} from "jotai"
 import {
     closeDeleteVariantModalAtom,
     deleteVariantModalOpenAtom,
-    deleteVariantModalVariantIdAtom,
+    deleteVariantModalRevisionIdsAtom,
 } from "./store/deleteVariantModalStore"
 
 import DeleteVariantModal from "."
 
 const DeleteVariantModalWrapper = () => {
     const open = useAtomValue(deleteVariantModalOpenAtom)
-    const variantId = useAtomValue(deleteVariantModalVariantIdAtom)
+    const revisionIds = useAtomValue(deleteVariantModalRevisionIdsAtom)
     const close = useSetAtom(closeDeleteVariantModalAtom)
 
-    if (!variantId) return null
+    if (!revisionIds || revisionIds.length === 0) return null
 
-    return <DeleteVariantModal open={open} onCancel={() => close()} variantId={variantId} />
+    return <DeleteVariantModal open={open} onCancel={() => close()} revisionIds={revisionIds} />
 }
 
 export default DeleteVariantModalWrapper

--- a/web/oss/src/components/Playground/Components/Modals/DeleteVariantModal/assets/DeleteVariantButton/types.d.ts
+++ b/web/oss/src/components/Playground/Components/Modals/DeleteVariantModal/assets/DeleteVariantButton/types.d.ts
@@ -1,7 +1,7 @@
 import {ButtonProps} from "antd"
 
 export interface DeleteVariantButtonProps extends ButtonProps {
-    variantId: string
+    variantId: string | string[]
     label?: React.ReactNode
     icon?: boolean
     children?: React.ReactNode

--- a/web/oss/src/components/Playground/Components/Modals/DeleteVariantModal/index.tsx
+++ b/web/oss/src/components/Playground/Components/Modals/DeleteVariantModal/index.tsx
@@ -6,11 +6,11 @@ import {DeleteVariantModalProps} from "./types"
 type EnhancedProps = Omit<React.ComponentProps<typeof EnhancedModal>, "children">
 type Props = EnhancedProps & DeleteVariantModalProps
 
-const DeleteVariantModal = ({variantId, ...props}: Props) => {
+const DeleteVariantModal = ({revisionIds, ...props}: Props) => {
     return (
         <EnhancedModal centered title="Are you sure you want to delete?" footer={null} {...props}>
             <DeleteVariantContent
-                variantId={variantId}
+                revisionIds={revisionIds}
                 onClose={() => props.onCancel?.({} as any)}
             />
         </EnhancedModal>

--- a/web/oss/src/components/Playground/Components/Modals/DeleteVariantModal/store/deleteVariantModalStore.ts
+++ b/web/oss/src/components/Playground/Components/Modals/DeleteVariantModal/store/deleteVariantModalStore.ts
@@ -2,18 +2,21 @@ import {atom} from "jotai"
 
 interface DeleteVariantModalState {
     open: boolean
-    variantId?: string
+    revisionIds: string[]
 }
 
-export const deleteVariantModalAtom = atom<DeleteVariantModalState>({open: false})
+export const deleteVariantModalAtom = atom<DeleteVariantModalState>({open: false, revisionIds: []})
 
-export const openDeleteVariantModalAtom = atom(null, (get, set, variantId: string) => {
-    set(deleteVariantModalAtom, {open: true, variantId})
+export const openDeleteVariantModalAtom = atom(null, (get, set, revisionIds: string | string[]) => {
+    const uniqueIds = Array.from(new Set([revisionIds].flat().filter(Boolean))) as string[]
+    set(deleteVariantModalAtom, {open: true, revisionIds: uniqueIds})
 })
 
 export const closeDeleteVariantModalAtom = atom(null, (get, set) => {
-    set(deleteVariantModalAtom, {open: false, variantId: undefined})
+    set(deleteVariantModalAtom, {open: false, revisionIds: []})
 })
 
 export const deleteVariantModalOpenAtom = atom((get) => get(deleteVariantModalAtom).open)
-export const deleteVariantModalVariantIdAtom = atom((get) => get(deleteVariantModalAtom).variantId)
+export const deleteVariantModalRevisionIdsAtom = atom(
+    (get) => get(deleteVariantModalAtom).revisionIds,
+)

--- a/web/oss/src/components/Playground/Components/Modals/DeleteVariantModal/types.d.ts
+++ b/web/oss/src/components/Playground/Components/Modals/DeleteVariantModal/types.d.ts
@@ -1,5 +1,5 @@
 import {ModalProps} from "antd"
 
 export interface DeleteVariantModalProps extends ModalProps {
-    variantId: string
+    revisionIds: string[]
 }

--- a/web/oss/src/components/VariantsComponents/Dropdown/VariantDropdown/index.tsx
+++ b/web/oss/src/components/VariantsComponents/Dropdown/VariantDropdown/index.tsx
@@ -54,7 +54,7 @@ const VariantDropdown = ({
                 },
             },
         ],
-        [record],
+        [handleDeleteVariant, handleDeploy, handleOpenDetails, handleOpenInPlayground, record],
     )
     return (
         <Dropdown trigger={["click"]} styles={{root: {width: 180}}} menu={{items}}>

--- a/web/oss/src/components/VariantsComponents/Table/assets/getVariantColumns.tsx
+++ b/web/oss/src/components/VariantsComponents/Table/assets/getVariantColumns.tsx
@@ -72,13 +72,38 @@ const ActionCell = memo(
         record,
         handleOpenDetails,
         handleOpenInPlayground,
+        selectedRowKeys,
     }: {
         record: EnhancedVariant
         handleOpenDetails?: (record: EnhancedVariant) => void
         handleOpenInPlayground?: (record: EnhancedVariant) => void
+        selectedRowKeys?: (string | number)[]
     }) => {
         const openDeleteVariantModal = useSetAtom(openDeleteVariantModalAtom)
         const openDeployVariantModal = useSetAtom(openDeployVariantModalAtom)
+
+        const resolveDeletionTargets = useCallback(
+            (r: EnhancedVariant) => {
+                const selection = Array.from(new Set((selectedRowKeys || []).map(String)))
+                const recordKey = String((r as any)._revisionId ?? (r as any)._id ?? (r as any).id)
+                const recordSelected = selection.includes(recordKey)
+
+                if (recordSelected && selection.length > 0) {
+                    return selection
+                }
+
+                const childKeys = ((r as any).children || [])
+                    .map((child: any) => String(child?._revisionId ?? child?.id))
+                    .filter((id: string | null | undefined) => Boolean(id))
+
+                if (childKeys.length > 0) {
+                    return Array.from(new Set([recordKey, ...childKeys]))
+                }
+
+                return [recordKey]
+            },
+            [selectedRowKeys],
+        )
 
         const onDeploy = useCallback(
             (r: EnhancedVariant) => {
@@ -98,9 +123,9 @@ const ActionCell = memo(
         const onDelete = useCallback(
             (r: EnhancedVariant) => {
                 // Open the global DeleteVariant modal immediately; it will perform its own pre-check
-                openDeleteVariantModal(r.id)
+                openDeleteVariantModal(resolveDeletionTargets(r))
             },
-            [openDeleteVariantModal],
+            [openDeleteVariantModal, resolveDeletionTargets],
         )
 
         return (
@@ -121,12 +146,14 @@ export const getColumns = ({
     showEnvBadges,
     showActionsDropdown,
     showStableName = false,
+    selectedRowKeys,
 }: {
     showEnvBadges: boolean
     handleOpenDetails?: (record: EnhancedVariant) => void
     handleOpenInPlayground?: (record: EnhancedVariant) => void
     showActionsDropdown: boolean
     showStableName?: boolean
+    selectedRowKeys?: (string | number)[]
 }): ColumnsType<EnhancedVariant> => {
     const columns: ColumnsType<EnhancedVariant> = [
         {
@@ -209,6 +236,7 @@ export const getColumns = ({
                     record={record}
                     handleOpenDetails={handleOpenDetails}
                     handleOpenInPlayground={handleOpenInPlayground}
+                    selectedRowKeys={selectedRowKeys}
                 />
             ),
         })

--- a/web/oss/src/components/VariantsComponents/index.tsx
+++ b/web/oss/src/components/VariantsComponents/index.tsx
@@ -2,7 +2,7 @@
 import {useCallback, useEffect, useMemo, useState} from "react"
 
 import {SwapOutlined} from "@ant-design/icons"
-import {CodeSimpleIcon, Rocket} from "@phosphor-icons/react"
+import {CodeSimpleIcon} from "@phosphor-icons/react"
 import {Button, Flex, Input, Radio, Space, Tabs, Typography} from "antd"
 import {getDefaultStore, useAtomValue, useSetAtom} from "jotai"
 import {useRouter} from "next/router"
@@ -14,31 +14,32 @@ import {usePlaygroundNavigation} from "@/oss/hooks/usePlaygroundNavigation"
 import {useQueryParam} from "@/oss/hooks/useQuery"
 import useURL from "@/oss/hooks/useURL"
 import {formatDate24} from "@/oss/lib/helpers/dateTimeHelper"
+import {useEnvironments} from "@/oss/services/deployment/hooks/useEnvironments"
 import {useQueryParamState} from "@/oss/state/appState"
+import {deploymentRevisionsWithAppIdQueryAtomFamily} from "@/oss/state/deployment/atoms/revisions"
 import {variantsPendingAtom} from "@/oss/state/loadingSelectors"
 import {promptsAtomFamily} from "@/oss/state/newPlayground/core/prompts"
+import {deployedVariantByEnvironmentAtomFamily} from "@/oss/state/variant/atoms/fetcher"
 import {
     selectedVariantsCountAtom,
     variantTableSelectionAtomFamily,
 } from "@/oss/state/variant/atoms/selection"
-import {deploymentRevisionsWithAppIdQueryAtomFamily} from "@/oss/state/deployment/atoms/revisions"
-import {useEnvironments} from "@/oss/services/deployment/hooks/useEnvironments"
-import {deployedVariantByEnvironmentAtomFamily} from "@/oss/state/variant/atoms/fetcher"
 import {
     modelNameByRevisionIdAtomFamily,
     revisionListAtom,
     variantDisplayNameByIdAtomFamily,
 } from "@/oss/state/variant/selectors/variant"
 
+import DeploymentsDashboard from "../DeploymentsDashboard"
+import {envRevisionsAtom} from "../DeploymentsDashboard/atoms"
+import {openDeploymentsDrawerAtom} from "../DeploymentsDashboard/modals/store/deploymentDrawerStore"
+import DeployVariantButton from "../Playground/Components/Modals/DeployVariantModal/assets/DeployVariantButton"
+
 import {
     openComparisonModalAtom,
     comparisonSelectionScopeAtom,
 } from "./Modals/VariantComparisonModal/store/comparisonModalStore"
-import DeploymentsDashboard from "../DeploymentsDashboard"
 import VariantsTable from "./Table"
-import DeployVariantButton from "../Playground/Components/Modals/DeployVariantModal/assets/DeployVariantButton"
-import {envRevisionsAtom} from "../DeploymentsDashboard/atoms"
-import {openDeploymentsDrawerAtom} from "../DeploymentsDashboard/modals/store/deploymentDrawerStore"
 
 // Comparison modal is opened via atoms; no local deploy/delete modals here
 
@@ -120,7 +121,7 @@ const VariantsDashboard = () => {
             const children = sorted.slice(1)
             groups.push({
                 ...latest,
-                _parentVariant: true,
+                _isParentRow: true,
                 children,
             })
         })


### PR DESCRIPTION
## Summary
- keep parent variant metadata intact when grouping registry rows so deletion logic can resolve variants correctly
- make variant table actions use the current selection and child revisions when opening the delete modal
- update the delete modal to handle multiple revisions or full variants, including clearer messaging and validation

## Testing
- pnpm lint-fix *(fails: existing lint errors in unrelated files)*

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_69449f0e0970832190c80fb7d46e8436)