### PR TITLE
[AGE-3516] fix(frontend): refresh model hub cache per project

### DIFF
--- a/web/oss/src/state/app/atoms/vault.ts
+++ b/web/oss/src/state/app/atoms/vault.ts
@@ -38,7 +38,7 @@ export const vaultSecretsQueryAtom = atomWithQuery((get) => {
     const projectId = get(projectIdAtom)
 
     return {
-        queryKey: ["vault", "secrets", user?.id],
+        queryKey: ["vault", "secrets", user?.id, projectId],
         queryFn: fetchVaultSecret,
         staleTime: 1000 * 60 * 5, // 5 minutes
         refetchOnWindowFocus: false,


### PR DESCRIPTION
## Summary
- include the current project id in the vault secrets query key so Model Hub API keys are fetched per project
- ensure cached provider state is refreshed when switching projects

## Testing
- pnpm lint-fix


------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_6946f581984c8330aa0dd11aace8c4a7)