### PR TITLE
fix(frontend): invalidate appVariantRevisions cache when variants are mutated [PR#5/4]

### DIFF
--- a/web/oss/src/components/Playground/state/atoms/queries.ts
+++ b/web/oss/src/components/Playground/state/atoms/queries.ts
@@ -107,6 +107,7 @@ export const invalidatePlaygroundQueriesAtom = atom(null, async () => {
         queryClient.invalidateQueries({queryKey: ["variants"]}),
         queryClient.invalidateQueries({queryKey: ["variantRevisions"]}),
         queryClient.invalidateQueries({queryKey: ["appVariants"]}),
+        queryClient.invalidateQueries({queryKey: ["appVariantRevisions"]}),
     ])
 
     // Then refetch with type: 'all' to bypass cache
@@ -121,6 +122,10 @@ export const invalidatePlaygroundQueriesAtom = atom(null, async () => {
         }),
         queryClient.refetchQueries({
             queryKey: ["appVariants"],
+            type: "all",
+        }),
+        queryClient.refetchQueries({
+            queryKey: ["appVariantRevisions"],
             type: "all",
         }),
     ])

--- a/web/oss/src/lib/hooks/useAppVariantRevisions.ts
+++ b/web/oss/src/lib/hooks/useAppVariantRevisions.ts
@@ -125,7 +125,7 @@ export const useAppVariantRevisions = (appId?: string | null) => {
 
     const query = useQuery({
         queryKey: ["appVariantRevisions", projectId, appId],
-        staleTime: 60_000,
+        staleTime: 15_000,
         enabled: Boolean(appId && projectId),
         queryFn: async () => {
             if (!appId || !projectId) return [] as EnhancedVariant[]


### PR DESCRIPTION
## Summary

- Add `appVariantRevisions` query key to `invalidatePlaygroundQueriesAtom` so the evaluation modal receives fresh variant data after mutations
- Reduce `staleTime` from 60s to 15s in `useAppVariantRevisions` for faster cache refresh

## Problem

When a new variant was created in the playground, the evaluation modal would show stale data because the `["appVariantRevisions"]` query was not being invalidated when variants were mutated.

## Solution

Updated `invalidatePlaygroundQueriesAtom` to also invalidate and refetch `appVariantRevisions` queries, ensuring all variant-related consumers receive fresh data after create/save operations.
