### PR TITLE
fix(web): patch mdast-util-to-hast vulnerability [dependabot]

### DIFF
--- a/web/package.json
+++ b/web/package.json
@@ -74,7 +74,8 @@
         ],
         "overrides": {
             "prismjs@<1.30.0": ">=1.30.0",
-            "@babel/runtime@<7.26.10": ">=7.26.10"
+            "@babel/runtime@<7.26.10": ">=7.26.10",
+            "mdast-util-to-hast@<13.2.1": ">=13.2.1"
         }
     }
 }

--- a/web/pnpm-lock.yaml
+++ b/web/pnpm-lock.yaml
@@ -7,6 +7,7 @@ settings:
 overrides:
   prismjs@<1.30.0: '>=1.30.0'
   '@babel/runtime@<7.26.10': '>=7.26.10'
+  mdast-util-to-hast@<13.2.1: '>=13.2.1'
 
 importers:
 
@@ -4059,8 +4060,8 @@ packages:
     resolution: {integrity: sha512-/IXtbwEk5HTPyEwyKX6hGkYXxM9nbj64B+ilVJnC/R6B0pH5G4V3b0pVbL7DBj4tkhBAppbQUlf6F6Xl9LHu1g==}
     engines: {node: '>= 0.4'}
 
-  mdast-util-to-hast@13.2.0:
-    resolution: {integrity: sha512-QGYKEuUsYT9ykKBCMOEDLsU5JRObWQusAolFMeko/tYPufNkRffBAQjIE+99jbA87xv6FgmjLtwjh9wBWajwAA==}
+  mdast-util-to-hast@13.2.1:
+    resolution: {integrity: sha512-cctsq2wp5vTsLIcaymblUriiTcZd0CwWtCbLvrOzYCDZoWyMNV8sZ7krj09FSnsiJi3WVsHLM4k6Dq/yaPyCXA==}
 
   media-typer@0.3.0:
     resolution: {integrity: sha512-dq+qelQ9akHpcOl/gUVRTxVIOkAJ1wR3QAvb4RsVjS8oVoFjDGTc679wJYmUmknUF5HwMLOgb5O+a3KxfWapPQ==}
@@ -8729,7 +8730,7 @@ snapshots:
       comma-separated-tokens: 2.0.3
       hast-util-whitespace: 3.0.0
       html-void-elements: 3.0.0
-      mdast-util-to-hast: 13.2.0
+      mdast-util-to-hast: 13.2.1
       property-information: 7.1.0
       space-separated-tokens: 2.0.2
       stringify-entities: 4.0.4
@@ -9262,7 +9263,7 @@ snapshots:
 
   math-intrinsics@1.1.0: {}
 
-  mdast-util-to-hast@13.2.0:
+  mdast-util-to-hast@13.2.1:
     dependencies:
       '@types/hast': 3.0.4
       '@types/mdast': 4.0.4


### PR DESCRIPTION
## Summary
- Fixes Dependabot alert for `mdast-util-to-hast` unsanitized class attribute vulnerability
- Adds pnpm override to force `mdast-util-to-hast >= 13.2.1` (patched version)
- Updates `pnpm-lock.yaml` with the secure version

## Vulnerability Details
The vulnerability allowed character references to inject unsanitized class names in markdown code blocks. For example:
```markdown
```js&#x20;xss
```
Would create `<pre><code class="language-js xss"></code></pre>`, potentially allowing CSS/JS targeting.

**Fixed in**: mdast-util-to-hast 13.2.1  
**Reference**: https://github.com/syntax-tree/mdast-util-to-hast/security/advisories/GHSA-f5qj-2v2h-3xr7

## Test plan
- [x] Verified lock file updated to 13.2.1
- [ ] CI passes
- [ ] No breaking changes expected (patch version bump, security fix only)