### PR TITLE
[fix]: clsx import failure on evaluation run details scenario tab

### DIFF
--- a/web/oss/src/components/EvalRunDetails/Table.tsx
+++ b/web/oss/src/components/EvalRunDetails/Table.tsx
@@ -1,5 +1,6 @@
 import {useCallback, useMemo, useRef} from "react"
 
+import clsx from "clsx"
 import {useAtomValue, useStore} from "jotai"
 
 import {message} from "@/oss/components/AppMessageContext"
@@ -36,7 +37,6 @@ import usePreviewTableData from "./hooks/usePreviewTableData"
 import useRowHeightMenuItems from "./hooks/useRowHeightMenuItems"
 import {scenarioRowHeightAtom} from "./state/rowHeight"
 import {patchFocusDrawerQueryParams} from "./state/urlFocusDrawer"
-import clsx from "clsx"
 
 type TableRowData = PreviewTableRow
 

--- a/web/oss/src/components/pages/observability/components/SessionsTable/index.tsx
+++ b/web/oss/src/components/pages/observability/components/SessionsTable/index.tsx
@@ -10,6 +10,7 @@ import {useSessions} from "@/oss/state/newObservability/hooks/useSessions"
 import {openSessionDrawerWithUrlAtom} from "@/oss/state/url/session"
 
 import {AUTO_REFRESH_INTERVAL} from "../../constants"
+
 import EmptySessions from "./assets/EmptySessions"
 import {getSessionColumns, SessionRow} from "./assets/getSessionColumns"
 


### PR DESCRIPTION
This PR fixes the breaking evaluation on prod
<img width="2938" height="1572" alt="image" src="https://github.com/user-attachments/assets/7c168549-835d-47c3-b46c-aa1ff6734cd7" />
