### PR TITLE
[3253] fix(frontend): keep evaluator name after commit

### DIFF
--- a/web/oss/src/components/pages/evaluations/autoEvaluation/EvaluatorsModal/ConfigureEvaluator/index.tsx
+++ b/web/oss/src/components/pages/evaluations/autoEvaluation/EvaluatorsModal/ConfigureEvaluator/index.tsx
@@ -569,7 +569,7 @@ const ConfigureEvaluator = ({
                             {/* Evaluator Name & Actions */}
                             <div className="h-[48px] px-4 flex items-center justify-between border-0 border-b border-solid border-gray-200 bg-white flex-shrink-0 sticky top-0 z-10">
                                 <Typography.Text className="font-semibold text-[14px]">
-                                    {formName || "New evaluator"}
+                                    {headerName || "New evaluator"}
                                 </Typography.Text>
                                 <Space>
                                     <Button type="text" onClick={() => form.resetFields()}>


### PR DESCRIPTION
## Fixes
- #3253

<img width="1462" height="870" alt="image" src="https://github.com/user-attachments/assets/7791ef0b-8553-4cf5-a3d0-d303bfa32cd4" />

## QA
- Configure an auto evaluator
- Add a name in the input field
- Commit the changes. The input name should be displayed after the commit in the header section

> Previously, it was becoming the "New evaluator" after hitting the commit
