### PR TITLE
fix(frontend): correct observability sessions docs link

### DIFF
--- a/web/oss/src/components/pages/observability/components/SessionsTable/assets/EmptySessions.tsx
+++ b/web/oss/src/components/pages/observability/components/SessionsTable/assets/EmptySessions.tsx
@@ -50,7 +50,10 @@ const EmptySessions = () => {
                     size: "middle",
                     text: "Getting started with sessions",
                     onClick: () =>
-                        window.open("https://agenta.ai/docs/observability/sessions", "_blank"),
+                        window.open(
+                            "https://agenta.ai/docs/observability/trace-with-python-sdk/track-chat-sessions",
+                            "_blank",
+                        ),
                 }}
             />
         </div>


### PR DESCRIPTION
## Summary
- update the empty sessions prompt to point to the correct observability sessions documentation

## Testing
- not run (tests currently unavailable)

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_6952c3e563ac8330b2bdfef291ec7475)