### PR TITLE
fix(docs): add OpenTelemetry session tracking pointer

### DIFF
--- a/docs/docs/observability/trace-with-python-sdk/09-track-chat-sessions.mdx
+++ b/docs/docs/observability/trace-with-python-sdk/09-track-chat-sessions.mdx
@@ -5,6 +5,10 @@ description: "Learn how to track multi-turn conversations and chat sessions"
 sidebar_position: 9
 ---
 
+:::info
+This guide covers tracking chat sessions with the Agenta Python SDK. For JavaScript/TypeScript or other OpenTelemetry-based clients, see the [session tracking with OpenTelemetry guide](/observability/trace-with-opentelemetry/session-tracking).
+:::
+
 Chat applications often span multiple requests and traces. Session tracking groups related interactions together so you can analyze complete conversations and user journeys.
 
 ## What are sessions?


### PR DESCRIPTION
## Summary
- add info callout to the Python SDK chat session tracking guide pointing readers to the OpenTelemetry session tracking docs for JS/TS and other languages

## Testing
- not run (tests currently unavailable)

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_6952c451f8648330ae0e699de3f2fca4)