### PR TITLE
feat(web): add Invoke LLM snippets for variants & fix code snippets

### DIFF
--- a/web/oss/src/code_snippets/endpoints/fetch_config/python.ts
+++ b/web/oss/src/code_snippets/endpoints/fetch_config/python.ts
@@ -1,18 +1,17 @@
 import {getEnv} from "@/oss/lib/helpers/dynamicEnv"
 
 export default function pythonCode(appName: string, env_name: string, apiKey: string): string {
-    return `
-import os
+    return `import os
 import agenta as ag
 
-os.environ["AGENTA_API_KEY"] = "${apiKey}" # Add your API key here
+os.environ["AGENTA_API_KEY"] = "${apiKey}"
 os.environ["AGENTA_HOST"] = "${getEnv("NEXT_PUBLIC_AGENTA_API_URL")}"
 
 ag.init()
 config = ag.ConfigManager.get_from_registry(
     app_slug="${appName}",
-    environment_slug="${env_name}"       
- )
+    environment_slug="${env_name}",
+)
 print(config)
 `
 }

--- a/web/oss/src/code_snippets/endpoints/fetch_config/typescript.ts
+++ b/web/oss/src/code_snippets/endpoints/fetch_config/typescript.ts
@@ -22,8 +22,8 @@ const getConfig = async (appName: string, environmentSlug: string) => {
             },
         }, {
             headers: {
-                'Content-Type': 'application/json',    
-                'Authorization': "ApiKey ${apiKey}", // Add your API key here
+                'Content-Type': 'application/json',
+                'Authorization': "ApiKey ${apiKey}",
             },
         });
 

--- a/web/oss/src/code_snippets/endpoints/fetch_variant/curl.ts
+++ b/web/oss/src/code_snippets/endpoints/fetch_variant/curl.ts
@@ -1,13 +1,14 @@
+import {getEnv} from "@/oss/lib/helpers/dynamicEnv"
+
 export const buildCurlSnippet = (
     appSlug: string,
     variantSlug: string,
     variantVersion: number,
     apiKey: string,
 ) => {
-    return `# Fetch configuration by variant
-curl -X POST "https://cloud.agenta.ai/api/variants/configs/fetch" \\
+    return `curl -X POST "${getEnv("NEXT_PUBLIC_AGENTA_API_URL")}/variants/configs/fetch" \\
   -H "Content-Type: application/json" \\
-  -H "Authorization: Bearer ${apiKey}" \\
+  -H "Authorization: ApiKey ${apiKey}" \\
   -d '{
     "variant_ref": {
       "slug": "${variantSlug}",

--- a/web/oss/src/code_snippets/endpoints/fetch_variant/python.ts
+++ b/web/oss/src/code_snippets/endpoints/fetch_variant/python.ts
@@ -3,13 +3,12 @@ export const buildPythonSnippet = (
     variantSlug: string,
     variantVersion: number,
 ) => {
-    return `# Fetch configuration by variant
-import agenta as ag
+    return `import agenta as ag
 
 config = ag.ConfigManager.get_from_registry(
     app_slug="${appSlug}",
     variant_slug="${variantSlug}",
-    variant_version=${variantVersion}  # Optional: If not provided, fetches the latest version
+    variant_version=${variantVersion},
 )
 
 print("Fetched configuration:")

--- a/web/oss/src/code_snippets/endpoints/fetch_variant/typescript.ts
+++ b/web/oss/src/code_snippets/endpoints/fetch_variant/typescript.ts
@@ -1,32 +1,33 @@
+import {getEnv} from "@/oss/lib/helpers/dynamicEnv"
+
 export const buildTypescriptSnippet = (
     appSlug: string,
     variantSlug: string,
     variantVersion: number,
     apiKey: string,
 ) => {
-    return `// Fetch configuration by variant
-    const fetchResponse = await fetch('https://cloud.agenta.ai/api/variants/configs/fetch', {
+    return `const fetchResponse = await fetch('${getEnv("NEXT_PUBLIC_AGENTA_API_URL")}/variants/configs/fetch', {
     method: 'POST',
     headers: {
         'Content-Type': 'application/json',
-        'Authorization': 'Bearer ${apiKey}'
+        'Authorization': 'ApiKey ${apiKey}',
     },
     body: JSON.stringify({
         variant_ref: {
-        slug: '${variantSlug}',
-        version: ${variantVersion},
-        id: null
+            slug: '${variantSlug}',
+            version: ${variantVersion},
+            id: null,
         },
         application_ref: {
-        slug: '${appSlug}',
-        version: null,
-        id: null
-        }
-    })
-    });
+            slug: '${appSlug}',
+            version: null,
+            id: null,
+        },
+    }),
+});
 
-    const config = await fetchResponse.json();
-    console.log('Fetched configuration:');
-    console.log(config);
-    `
+const config = await fetchResponse.json();
+console.log('Fetched configuration:');
+console.log(config);
+`
 }

--- a/web/oss/src/code_snippets/endpoints/invoke_llm_app/curl.ts
+++ b/web/oss/src/code_snippets/endpoints/invoke_llm_app/curl.ts
@@ -2,10 +2,9 @@ export default function cURLCode(uri: string, params: string, apiKey: string): s
     const parsedParams = JSON.parse(params)
     const isChat = parsedParams.messages !== undefined
 
-    return `# Add your API key to the Authorization header
-curl -X POST "${uri}" \\
+    return `curl -X POST "${uri}" \\
 -H "Content-Type: application/json" \\
--H "Authorization: ApiKey ${apiKey}" \\${isChat ? '\n-H "Baggage: ag.session.id=your_session_id" \\ # Optional: track chat sessions' : ""}
+-H "Authorization: ApiKey ${apiKey}" \\${isChat ? '\n-H "Baggage: ag.session.id=your_session_id" \\' : ""}
 -d '${params}'
 `
 }

--- a/web/oss/src/code_snippets/endpoints/invoke_llm_app/python.ts
+++ b/web/oss/src/code_snippets/endpoints/invoke_llm_app/python.ts
@@ -8,8 +8,8 @@ import json
 url = "${uri}"
 params = ${params}
 headers = {
-    "Content-Type": "application/json",    
-    "Authorization": "ApiKey ${apiKey}", # Add your API key here${isChat ? '\n    "Baggage": "ag.session.id=your_session_id", # Optional: track chat sessions' : ""}
+    "Content-Type": "application/json",
+    "Authorization": "ApiKey ${apiKey}",${isChat ? '\n    "Baggage": "ag.session.id=your_session_id",' : ""}
 }
 
 response = requests.post(url, json=params, headers=headers)

--- a/web/oss/src/code_snippets/endpoints/invoke_llm_app/typescript.ts
+++ b/web/oss/src/code_snippets/endpoints/invoke_llm_app/typescript.ts
@@ -11,7 +11,7 @@ const generate = async () => {
     const data = ${params};
     const headers = {
         "Content-Type": "application/json",
-        "Authorization": "ApiKey ${apiKey}", // Add your API key here${isChat ? '\n        "Baggage": "ag.session.id=your_session_id" // Optional: track chat sessions' : ""}
+        "Authorization": "ApiKey ${apiKey}",${isChat ? '\n        "Baggage": "ag.session.id=your_session_id",' : ""}
     };
 
     const response = await axios.post(url, data, { headers });


### PR DESCRIPTION
## Summary
Add 'Invoke LLM' code snippets to the Variant Use API drawer and fix various snippet issues.

**Stacked on:** #3329

## Changes

### Variant Use API drawer
- Add 'Invoke LLM' code snippets to `VariantUseApiContent`, matching the deployment drawer functionality
- Use `variant_slug` and `variant_version` in request body params
- Reuse `LanguageCodeBlock` component for consistent UI

### Code snippet fixes
- Fix `fetch_variant` snippets to use dynamic URL instead of hardcoded `cloud.agenta.ai`
- Fix Authorization header from `Bearer` to `ApiKey` for consistency
- Remove inline comments from all snippets (curl, python, typescript) that were breaking copy-paste functionality
- Ensure all generated snippets are directly pastable into terminal/editor

## Testing
Tested with live endpoint - snippets work correctly when pasted directly.