### PR TITLE
fix(docker): correct Traefik port mapping in OSS gh compose

### DIFF
--- a/hosting/docker-compose/oss/docker-compose.gh.yml
+++ b/hosting/docker-compose/oss/docker-compose.gh.yml
@@ -361,12 +361,12 @@ services:
         command:
             - --api.dashboard=true
             - --providers.docker
-            - --entrypoints.web.address=:${TRAEFIK_PORT:-80}
+            - --entrypoints.web.address=:80
         env_file:
             - ${ENV_FILE:-./.env.oss.gh}
 
         ports:
-            - "${TRAEFIK_PORT:-80}:${TRAEFIK_PORT:-80}"
+            - "${TRAEFIK_PORT:-80}:80"
             - "${TRAEFIK_UI_PORT:-8080}:8080"
 
         restart: always


### PR DESCRIPTION
## Summary

Fix incorrect Traefik port configuration in the OSS `gh` (GitHub/production) Docker Compose file.

## The Bug

The Traefik configuration incorrectly used a variable for **both** the host port AND the container port:

```yaml
# Before (buggy)
command:
    - --entrypoints.web.address=:${TRAEFIK_PORT:-80}  # Container listens on variable port
ports:
    - "${TRAEFIK_PORT:-80}:${TRAEFIK_PORT:-80}"       # Maps variable:variable
```

This breaks when `TRAEFIK_PORT` is set to anything other than 80 because:
1. All service labels use `entrypoints=web` which references the entrypoint listening on port 80
2. If Traefik listens on port 9080 internally, the entrypoint definition doesn't match the labels
3. Routing fails silently

## The Fix

Keep the container port fixed at 80, only parameterize the host port:

```yaml
# After (fixed)
command:
    - --entrypoints.web.address=:80                   # Container always listens on 80
ports:
    - "${TRAEFIK_PORT:-80}:80"                        # Maps variable:fixed
```

## Why This Pattern

The standard Docker networking pattern is:
- **Container port**: Fixed, internal to the container network
- **Host port**: Variable, for external access

This allows:
- Consistent internal routing (services always connect via fixed ports)
- Flexible external exposure (host can map any available port)

## Test Plan
- [ ] Deploy with default `TRAEFIK_PORT` (80) - should work as before
- [ ] Deploy with custom `TRAEFIK_PORT=9080` - should now work correctly

🤖 Generated with [Claude Code](https://claude.com/claude-code)