### PR TITLE
fix(frontend) Autocomplete Showing testcase. Prefix in Evalutor Playground

### DIFF
--- a/web/oss/src/components/pages/evaluations/autoEvaluation/EvaluatorsModal/ConfigureEvaluator/AdvancedSettings.tsx
+++ b/web/oss/src/components/pages/evaluations/autoEvaluation/EvaluatorsModal/ConfigureEvaluator/AdvancedSettings.tsx
@@ -83,7 +83,7 @@ const AdvancedSettings: React.FC<AdvancedSettingsProps> = ({settings, selectedTe
                             ) : (field.type === "string" || field.type === "regex") &&
                               selectedTestcase.testcase ? (
                                 <AutoComplete
-                                    options={generatePaths(selectedTestcase)}
+                                    options={generatePaths(selectedTestcase.testcase)}
                                     filterOption={(inputValue, option) =>
                                         option!.value
                                             .toUpperCase()


### PR DESCRIPTION
### Problem:
The autocomplete for correct_answer_key showed testcase.column_name instead of just column_name. 

### Root Cause:
generatePaths(selectedTestcase) was called with the wrapper object { testcase: {...} } instead of the actual testcase data. 

### Fix:
Changed to generatePaths(selectedTestcase.testcase) to generate paths from the testcase data directly.
