### PR TITLE
fix(frontend): restore sidebar copy and logout menu

### DIFF
--- a/web/oss/src/components/Sidebar/components/ListOfOrgs.tsx
+++ b/web/oss/src/components/Sidebar/components/ListOfOrgs.tsx
@@ -1,6 +1,13 @@
 import {memo, useEffect, useMemo, useRef, useState} from "react"
 
-import {ArrowsLeftRight, CaretDown, PencilSimple, Trash, CopyIcon} from "@phosphor-icons/react"
+import {
+    ArrowsLeftRight,
+    CaretDown,
+    PencilSimple,
+    Trash,
+    CopyIcon,
+    SignOut,
+} from "@phosphor-icons/react"
 import {useMutation} from "@tanstack/react-query"
 import {
     Button,
@@ -21,6 +28,7 @@ import {useRouter} from "next/router"
 import Session from "supertokens-auth-react/recipe/session"
 
 import AlertPopup from "@/oss/components/AlertPopup/AlertPopup"
+import {useSession} from "@/oss/hooks/useSession"
 import {isEE} from "@/oss/lib/helpers/isEE"
 import {getUsernameFromEmail} from "@/oss/lib/helpers/utils"
 import {checkOrganizationAccess} from "@/oss/services/organization/api"
@@ -57,7 +65,7 @@ interface ListOfOrgsProps extends Omit<DropdownProps, "menu" | "children"> {
      */
     overrideOrganizationId?: string
     /**
-     * When false, organization items remain visible but are not actionable.
+     * When false, organization items remain visible but are not actionable. Logout remains actionable.
      */
     organizationSelectionEnabled?: boolean
 }
@@ -77,6 +85,7 @@ const ListOfOrgs = ({
     }
     const router = useRouter()
     const {user} = useProfileData()
+    const {logout} = useSession()
     const {
         selectedOrg: selectedOrganization,
         orgs: organizations,
@@ -232,12 +241,24 @@ const ListOfOrgs = ({
             items.push({
                 key: "create-organization",
                 label: (
-                    <div className="flex items-center gap-2 text-primary-500">
-                        <span className="font-medium">+ New organization</span>
+                    <div className="flex items-center gap-2">
+                        <span className="text-gray-900">+ New organization</span>
                     </div>
                 ),
             })
+            items.push({type: "divider", key: "organizations-actions-divider"})
         }
+
+        items.push({
+            key: "logout",
+            danger: true,
+            label: (
+                <div className="flex items-center gap-2">
+                    <SignOut size={16} />
+                    Logout
+                </div>
+            ),
+        })
 
         return items
     }, [effectiveSelectedId, interactive, organizationSelectionEnabled, organizations, user?.id])
@@ -435,6 +456,16 @@ const ListOfOrgs = ({
         if (keyString === "create-organization") {
             setOrganizationDropdownOpen(false)
             setCreateModalOpen(true)
+            return
+        }
+
+        if (keyString === "logout") {
+            setOrganizationDropdownOpen(false)
+            AlertPopup({
+                title: "Logout",
+                message: "Are you sure you want to logout?",
+                onOk: logout,
+            })
             return
         }
 

--- a/web/oss/src/components/Sidebar/components/SidebarMenu.tsx
+++ b/web/oss/src/components/Sidebar/components/SidebarMenu.tsx
@@ -1,4 +1,4 @@
-import {memo, useCallback, useMemo} from "react"
+import {memo, useCallback} from "react"
 
 import {Menu, Tag, Tooltip} from "antd"
 import clsx from "clsx"
@@ -12,34 +12,13 @@ const SidebarMenu: React.FC<SidebarMenuProps> = ({
     collapsed,
     mode = "inline",
 }) => {
-    const clickHandlers = useMemo(() => {
-        const map = new Map<string, {onClick?: (e: React.MouseEvent) => void; hasLink: boolean}>()
-        const walk = (list: SidebarConfig[]) => {
-            list.forEach((item) => {
-                if (item.submenu) {
-                    walk(item.submenu)
-                    return
-                }
-                if (item.header) return
-                map.set(item.key, {onClick: item.onClick, hasLink: Boolean(item.link)})
-            })
-        }
-        walk(items)
-        return map
-    }, [items])
-
     const transformItems = useCallback(
         (items: SidebarConfig[]): any => {
             return items.flatMap((item): any => {
-                const icon = item.icon ? (
-                    <span className="inline-flex items-center justify-center w-4 h-4 shrink-0">
-                        {item.icon}
-                    </span>
-                ) : undefined
                 if (item.submenu) {
                     return {
                         key: item.key,
-                        icon,
+                        icon: item.icon,
                         label: (
                             <>
                                 {item.title} {item.tag && <Tag color="lime">{item.tag}</Tag>}
@@ -73,7 +52,7 @@ const SidebarMenu: React.FC<SidebarMenuProps> = ({
                 } else {
                     const node = item.link ? (
                         <Link
-                            className="w-full block"
+                            className="w-full"
                             href={item.link}
                             onClick={item.onClick}
                             target={item.link?.startsWith("http") ? "_blank" : undefined}
@@ -81,16 +60,15 @@ const SidebarMenu: React.FC<SidebarMenuProps> = ({
                             {item.title} {item.tag && <Tag color="lime">{item.tag}</Tag>}
                         </Link>
                     ) : (
-                        <span className="w-full block">
+                        <span className="w-full" onClick={item.onClick}>
                             {item.title} {item.tag && <Tag color="lime">{item.tag}</Tag>}
                         </span>
                     )
 
                     const menuItem = {
-                        icon,
+                        icon: item.icon,
                         key: item.key,
                         disabled: item.disabled,
-                        danger: item.danger,
                         label: collapsed ? (
                             <Tooltip title={item.tooltip} placement="right" mouseEnterDelay={0.8}>
                                 <div className="flex items-center justify-center w-full">
@@ -109,21 +87,12 @@ const SidebarMenu: React.FC<SidebarMenuProps> = ({
         [items, collapsed],
     )
 
-    const {onClick: menuOnClick, ...restMenuProps} = menuProps || {}
-
     return (
         <Menu
             mode={mode}
             items={transformItems(items)}
-            onClick={(info) => {
-                const handler = clickHandlers.get(info.key as string)
-                if (handler?.onClick && !handler.hasLink) {
-                    handler.onClick(info.domEvent as unknown as React.MouseEvent)
-                }
-                menuOnClick?.(info)
-            }}
             {...(mode === "inline" ? {inlineCollapsed: collapsed} : {})}
-            {...restMenuProps}
+            {...menuProps}
             className={clsx([
                 "!overflow-x-hidden",
                 "[&_.ant-menu-item]:flex [&_.ant-menu-item]:items-center",

--- a/web/oss/src/components/Sidebar/hooks/useSidebarConfig/index.tsx
+++ b/web/oss/src/components/Sidebar/hooks/useSidebarConfig/index.tsx
@@ -1,4 +1,4 @@
-import {GithubFilled} from "@ant-design/icons"
+import {AppstoreOutlined, DatabaseOutlined, GithubFilled} from "@ant-design/icons"
 import {
     ChartDonut,
     ChartLineUp,
@@ -15,12 +15,8 @@ import {
     ChatCircle,
     Gauge,
     HouseIcon,
-    GridFour,
-    Database,
-    SignOut,
 } from "@phosphor-icons/react"
 
-import AlertPopup from "@/oss/components/AlertPopup/AlertPopup"
 import {useCrispChat} from "@/oss/hooks/useCrispChat"
 import {useSession} from "@/oss/hooks/useSession"
 import useURL from "@/oss/hooks/useURL"
@@ -31,7 +27,7 @@ import {useOrgData} from "@/oss/state/org"
 import {SidebarConfig} from "../../types"
 
 export const useSidebarConfig = () => {
-    const {doesSessionExist, logout} = useSession()
+    const {doesSessionExist} = useSession()
     const {currentApp, recentlyVisitedAppId} = useAppsData()
     const {selectedOrg} = useOrgData()
     const {toggle, isVisible, isCrispEnabled} = useCrispChat()
@@ -51,14 +47,14 @@ export const useSidebarConfig = () => {
             key: "project-prompts-link",
             title: "Prompts",
             link: `${projectURL}/prompts`,
-            icon: <GridFour size={16} />,
+            icon: <AppstoreOutlined size={16} />,
             disabled: !hasProjectURL,
         },
         {
             key: "app-testsets-link",
             title: "Testsets",
             link: `${projectURL}/testsets`,
-            icon: <Database size={16} />,
+            icon: <DatabaseOutlined size={16} />,
             disabled: !hasProjectURL,
         },
         {
@@ -132,29 +128,39 @@ export const useSidebarConfig = () => {
         },
         {
             key: "settings-link",
-            title: "Open Settings",
+            title: "Settings",
             link: `${projectURL}/settings`,
             icon: <Gear size={16} />,
             isBottom: true,
-            tooltip: "Open Settings",
+            tooltip: "Settings",
             disabled: !hasProjectURL,
         },
         {
-            key: "invite-members-link",
-            title: "Invite Members",
+            key: "invite-teammate-link",
+            title: "Invite Teammate",
             link: `${projectURL}/settings?tab=workspace&inviteModal=open`,
             icon: <PaperPlane size={16} />,
             isBottom: true,
-            tooltip: "Invite Members",
+            tooltip: "Invite Teammate",
             isHidden: !doesSessionExist || !selectedOrg,
             disabled: !hasProjectURL,
         },
         {
-            key: "resources-link",
-            title: "Browse Resources",
+            key: "support-chat-link",
+            title: `Live Chat Support: ${isVisible ? "On" : "Off"}`,
+            icon: <ChatCircle size={16} />,
+            isBottom: true,
+            isHidden: !isDemo() || !isCrispEnabled,
+            onClick: (e) => {
+                e.preventDefault()
+                toggle()
+            },
+        },
+        {
+            key: "help-docs-link",
+            title: "Help & Docs",
             icon: <Question size={16} />,
             isBottom: true,
-            tooltip: "Browse Resources",
             submenu: [
                 {
                     key: "docs",
@@ -174,16 +180,6 @@ export const useSidebarConfig = () => {
                     title: "Slack Support",
                     link: "https://join.slack.com/t/agenta-hq/shared_invite/zt-37pnbp5s6-mbBrPL863d_oLB61GSNFjw",
                     icon: <SlackLogo size={16} />,
-                },
-                {
-                    key: "support-chat-link",
-                    title: `Chat Support (${isVisible ? "ON" : "OFF"})`,
-                    icon: <ChatCircle size={16} />,
-                    isHidden: !isDemo() || !isCrispEnabled,
-                    onClick: (e) => {
-                        e.preventDefault()
-                        toggle()
-                    },
                     divider: true,
                 },
                 {
@@ -193,23 +189,6 @@ export const useSidebarConfig = () => {
                     icon: <Phone size={16} />,
                 },
             ],
-            divider: true,
-        },
-        {
-            key: "logout",
-            title: "Log out",
-            icon: <SignOut size={16} />,
-            isBottom: true,
-            isHidden: !doesSessionExist,
-            danger: true,
-            onClick: (e) => {
-                e.preventDefault()
-                AlertPopup({
-                    title: "Logout",
-                    message: "Are you sure you want to logout?",
-                    onOk: logout,
-                })
-            },
         },
     ]
 

--- a/web/oss/src/components/Sidebar/types.d.ts
+++ b/web/oss/src/components/Sidebar/types.d.ts
@@ -16,7 +16,6 @@ export interface SidebarConfig {
     divider?: boolean
     header?: boolean
     disabled?: boolean
-    danger?: boolean
 }
 
 export interface SidebarMenuProps {


### PR DESCRIPTION
## Summary
- restore main sidebar labels for settings/invite and Help & Docs submenu
- move live chat back to the main sidebar and remove logout from main menu
- add logout back to the organization dropdown and normalize the + New organization styling

<img width="534" height="1908" alt="CleanShot 2026-01-10 at 13 27 24@2x" src="https://github.com/user-attachments/assets/09e18eb9-1910-4111-a9ec-4c51e83109c6" />
<img width="492" height="742" alt="CleanShot 2026-01-10 at 13 27 33@2x" src="https://github.com/user-attachments/assets/6739a48f-dc47-4bc7-8c78-5a86949a7585" />
