### PR TITLE
fix(auth): route new email/password signups to post-signup onboarding

### DIFF
--- a/web/oss/src/components/pages/auth/EmailPasswordAuth/index.tsx
+++ b/web/oss/src/components/pages/auth/EmailPasswordAuth/index.tsx
@@ -48,11 +48,12 @@ const EmailPasswordAuth = ({
                 })
             } else {
                 setMessage({message: "Verification successful", type: "success"})
-                const {createdNewRecipeUser, user} = response as {
-                    createdNewRecipeUser?: boolean
+                const {user} = response as {
                     user?: {loginMethods?: unknown[]}
                 }
-                await handleAuthSuccess({createdNewRecipeUser, user})
+                // signUp() doesn't return createdNewRecipeUser (only signInUp does).
+                // Since signUp always creates a new user, we explicitly set it to true.
+                await handleAuthSuccess({createdNewRecipeUser: true, user})
             }
         } catch (error) {
             authErrorMsg(error)


### PR DESCRIPTION
## Summary

- Fixes bug where new users signing up with email/password bypassed the `/post-signup` onboarding screen and went directly to the workspace
- Root cause: SuperTokens `signUp()` doesn't return `createdNewRecipeUser` field (only `signInUp()` does), so `isNewUser` was always false since `Boolean(undefined) === false`
- Fix: Explicitly pass `createdNewRecipeUser: true` since `signUp()` with status "OK" always means a new user was created

## Test plan

- [ ] Sign up with a new email/password on demo environment
- [ ] Verify user is routed to `/post-signup` onboarding screen
- [ ] Complete onboarding and verify normal workspace navigation works

🤖 Generated with [Claude Code](https://claude.com/claude-code)