### PR TITLE
fix(api): correct testsets router to use VIEW_TESTSETS for read operations

### DIFF
--- a/api/oss/src/apis/fastapi/testsets/router.py
+++ b/api/oss/src/apis/fastapi/testsets/router.py
@@ -555,7 +555,7 @@ class TestsetsRouter:
             if not await check_action_access(  # type: ignore
                 user_uid=request.state.user_id,
                 project_id=request.state.project_id,
-                permission=Permission.EDIT_EVALUATORS,  # type: ignore
+                permission=Permission.VIEW_TESTSETS,  # type: ignore
             ):
                 raise FORBIDDEN_EXCEPTION  # type: ignore
 
@@ -671,7 +671,7 @@ class TestsetsRouter:
             if not await check_action_access(  # type: ignore
                 user_uid=request.state.user_id,
                 project_id=request.state.project_id,
-                permission=Permission.EDIT_EVALUATORS,  # type: ignore
+                permission=Permission.VIEW_TESTSETS,  # type: ignore
             ):
                 raise FORBIDDEN_EXCEPTION  # type: ignore
 
@@ -738,7 +738,7 @@ class TestsetsRouter:
             if not await check_action_access(  # type: ignore
                 user_uid=request.state.user_id,
                 project_id=request.state.project_id,
-                permission=Permission.EDIT_EVALUATORS,  # type: ignore
+                permission=Permission.VIEW_TESTSETS,  # type: ignore
             ):
                 raise FORBIDDEN_EXCEPTION  # type: ignore
 
@@ -854,7 +854,7 @@ class TestsetsRouter:
             if not await check_action_access(  # type: ignore
                 user_uid=request.state.user_id,
                 project_id=request.state.project_id,
-                permission=Permission.EDIT_EVALUATORS,  # type: ignore
+                permission=Permission.VIEW_TESTSETS,  # type: ignore
             ):
                 raise FORBIDDEN_EXCEPTION  # type: ignore
 
@@ -890,7 +890,7 @@ class TestsetsRouter:
             if not await check_action_access(  # type: ignore
                 user_uid=request.state.user_id,
                 project_id=request.state.project_id,
-                permission=Permission.EDIT_EVALUATORS,  # type: ignore
+                permission=Permission.VIEW_TESTSETS,  # type: ignore
             ):
                 raise FORBIDDEN_EXCEPTION  # type: ignore
 
@@ -977,7 +977,7 @@ class TestsetsRouter:
             if not await check_action_access(  # type: ignore
                 user_uid=request.state.user_id,
                 project_id=request.state.project_id,
-                permission=Permission.EDIT_EVALUATORS,  # type: ignore
+                permission=Permission.VIEW_TESTSETS,  # type: ignore
             ):
                 raise FORBIDDEN_EXCEPTION  # type: ignore
 
@@ -1183,7 +1183,7 @@ class TestsetsRouter:
             if not await check_action_access(  # type: ignore
                 user_uid=request.state.user_id,
                 project_id=request.state.project_id,
-                permission=Permission.EDIT_EVALUATORS,  # type: ignore
+                permission=Permission.VIEW_TESTSETS,  # type: ignore
             ):
                 raise FORBIDDEN_EXCEPTION  # type: ignore
 
@@ -1260,7 +1260,7 @@ class TestsetsRouter:
             if not await check_action_access(  # type: ignore
                 user_uid=request.state.user_id,
                 project_id=request.state.project_id,
-                permission=Permission.EDIT_EVALUATORS,  # type: ignore
+                permission=Permission.VIEW_TESTSETS,  # type: ignore
             ):
                 raise FORBIDDEN_EXCEPTION  # type: ignore
 


### PR DESCRIPTION
## Summary

Fixed the testsets router to use correct permissions for read operations. The router was incorrectly using `EDIT_EVALUATORS` for all operations, preventing viewers from accessing testsets.

## Changes

Updated the following endpoints to use `VIEW_TESTSETS` instead of `EDIT_EVALUATORS`:
- `fetch_testset`
- `query_testsets` 
- `fetch_testset_variant`
- `query_testset_variants`
- `retrieve_testset_revision`
- `fetch_testset_revision`
- `query_testset_revisions`
- `log_testset_revisions`

Write operations (create, edit, archive, commit) continue to use `EDIT_EVALUATORS` to prevent viewers from modifying content.

## Test Plan

- Viewers should now be able to fetch and query testsets
- Viewers should still be unable to create or edit testsets
- Write operations should remain restricted

🤖 Generated with [Claude Code](https://claude.com/claude-code)