### PR TITLE
fix(api): enforce demo project viewer permissions regardless of RBAC flag

### DIFF
--- a/api/ee/src/utils/permissions.py
+++ b/api/ee/src/utils/permissions.py
@@ -29,16 +29,33 @@ FORBIDDEN_EXCEPTION = HTTPException(
 )
 
 
+def _get_project_member(
+    user_id: str,
+    members: Sequence[Any],
+) -> Optional[Any]:
+    """Return the project member record for a user, or None."""
+    return next(
+        (m for m in members if str(m.user_id) == user_id),
+        None,
+    )
+
+
 def _get_project_member_role(
     user_id: str,
     members: Sequence[Any],
 ) -> Optional[str]:
     """Return the role of a user in a given project_members list, or None."""
-    member = next(
-        (m for m in members if str(m.user_id) == user_id),
-        None,
-    )
+    member = _get_project_member(user_id, members)
     return getattr(member, "role", None) if member else None
+
+
+def _is_demo_member(
+    user_id: str,
+    members: Sequence[Any],
+) -> bool:
+    """Return True if the user is a demo member (is_demo=True) in the project."""
+    member = _get_project_member(user_id, members)
+    return getattr(member, "is_demo", False) if member else False
 
 
 def _project_is_owner(
@@ -331,23 +348,31 @@ async def check_project_has_role_or_permission(
         permission (Optional[str], optional): The permission to check for. Defaults to None.
     """
 
-    check, _, _ = await check_entitlements(
-        organization_id=project.organization_id,
-        key=Flag.RBAC,
-    )
-
-    if not check:
-        return True
-
     assert role is not None or permission is not None, (
         "Either role or permission must be provided"
     )
 
+    # Fetch project members first - needed for both demo check and permission check
     project_members = await db_manager_ee.get_project_members(
         project_id=str(project.id)
     )
 
-    # OWNER always passes
+    # Check if user is a demo member - demo members always have restricted access
+    # regardless of the organization's RBAC setting
+    is_demo = _is_demo_member(user_id, project_members)
+
+    if not is_demo:
+        # For non-demo members, check if RBAC is enabled
+        # If RBAC is disabled, grant full access (current behavior for paid plans)
+        check, _, _ = await check_entitlements(
+            organization_id=project.organization_id,
+            key=Flag.RBAC,
+        )
+
+        if not check:
+            return True
+
+    # OWNER always passes (but demo members can't be owners by design)
     if _project_is_owner(user_id, project_members):
         return True
 


### PR DESCRIPTION
## Summary

Demo projects were not properly restricting demo users to viewer-only access because they're created on the Hobby plan, which has RBAC disabled. This allowed demo users to create, edit, and delete content.

## Root Cause

Demo organizations use the Hobby (free) plan, which has `Flag.RBAC = False`. When RBAC is disabled, `check_project_has_role_or_permission()` returns `True` immediately, bypassing all permission checks. The `is_demo` flag was stored in the database but never used.

## Solution

Added explicit demo member detection to enforce viewer permissions regardless of RBAC setting:
- `_get_project_member()` - retrieve full project member record
- `_is_demo_member()` - check if user has `is_demo=True` flag
- Modified `check_project_has_role_or_permission()` to skip RBAC bypass for demo members

## Result

Demo members now always have restricted access:
- ✅ Can view applications, testsets, evaluations
- ❌ Cannot create, edit, or delete content

## Test Plan

- Demo users should be able to fetch and view testsets (with the companion PR fix)
- Demo users should get 403 errors when attempting to create/edit content
- Non-demo users on Hobby plan should retain full access (no regression)

🤖 Generated with [Claude Code](https://claude.com/claude-code)