### PR TITLE
fix(frontend)[AGE-3543] Empty table on first evaluation run until refresh

### DIFF
--- a/web/oss/src/components/EvalRunDetails/Table.tsx
+++ b/web/oss/src/components/EvalRunDetails/Table.tsx
@@ -833,6 +833,7 @@ const EvalRunDetailsTable = ({
                 <InfiniteVirtualTableFeatureShell<TableRowData>
                     datasetStore={evaluationPreviewDatasetStore}
                     tableScope={tableScope}
+                    store={store}
                     columns={previewColumns.columns}
                     rowKey={(record) => record.key}
                     tableClassName={clsx(


### PR DESCRIPTION
### Summary
This PR fixes issue where the evaluation table appears empty when you first open an evaluation run until the page is refreshed

Closes #3362 