### PR TITLE
fix(frontend)[AGE-3549]: Single‑choice human evaluators show “No annotation fields available” in Focus view

### DIFF
--- a/web/oss/src/components/SharedDrawers/AnnotateDrawer/assets/transforms.ts
+++ b/web/oss/src/components/SharedDrawers/AnnotateDrawer/assets/transforms.ts
@@ -568,8 +568,8 @@ export const generateNewEvaluatorPayloadData = ({
                 acc[metric.name] = {
                     anyOf: [
                         {
-                            type: ["string", "null"],
-                            enum: [...(acc[metric.name].enum?.filter(Boolean) || []), null],
+                            type: ["string"],
+                            enum: acc[metric.name].enum?.filter(Boolean) || [],
                         },
                     ],
                 }


### PR DESCRIPTION
### Summary
This PR fixes single‑choice human evaluator annotations in Focus view by handling `anyOf`/array‑typed schema fields and filtering null enum values. This ensures annotation fields render correctly for class metrics and prevents the “No annotation fields available” state.


<img width="1085" height="625" alt="Screenshot 2026-01-13 at 1 18 42 PM" src="https://github.com/user-attachments/assets/2e9856ff-119a-4df4-be24-732da15c2479" />
