### PR TITLE
feat(frontend): Support multiple variant selection in automatic evaluation modal

### DIFF
--- a/web/oss/src/components/pages/evaluations/NewEvaluation/Components/NewEvaluationModalInner.tsx
+++ b/web/oss/src/components/pages/evaluations/NewEvaluation/Components/NewEvaluationModalInner.tsx
@@ -107,14 +107,13 @@ const NewEvaluationModalInner = ({
     const [selectedTestsetRevisionId, setSelectedTestsetRevisionId] = useState("")
     const [selectedTestsetName, setSelectedTestsetName] = useState("")
     const [selectedTestsetVersion, setSelectedTestsetVersion] = useState<number | null>(null)
-    // Initialize with at most one pre-selected variant (e.g., from playground)
-    const [selectedVariantRevisionIds, setSelectedVariantRevisionIds] = useState<string[]>(() => {
-        const first = preSelectedVariantIds?.[0]
-        return first ? [first] : []
-    })
+    // Initialize with pre-selected variants (e.g., from playground comparison mode)
+    const [selectedVariantRevisionIds, setSelectedVariantRevisionIds] = useState<string[]>(() =>
+        preSelectedVariantIds?.length ? [...preSelectedVariantIds] : [],
+    )
     const [selectedEvalConfigs, setSelectedEvalConfigs] = useState<string[]>([])
     // If variants are pre-selected, start on testset panel; otherwise follow normal flow
-    const hasPreSelectedVariants = Boolean(preSelectedVariantIds?.[0])
+    const hasPreSelectedVariants = Boolean(preSelectedVariantIds?.length)
     const [activePanel, setActivePanel] = useState<string | null>(() =>
         getInitialPanel(hasPreSelectedVariants, isAppScoped),
     )
@@ -212,6 +211,9 @@ const NewEvaluationModalInner = ({
     // Memoised base (deterministic) part of generated name (without random suffix)
     const generatedNameBase = useMemo(() => {
         if (!selectedVariantRevisionIds.length || !selectedTestsetName) return ""
+        if (selectedVariantRevisionIds.length > 1) {
+            return `${selectedVariantRevisionIds.length}-variants-${selectedTestsetName}`
+        }
         const variant = filteredVariants?.find((v) => selectedVariantRevisionIds.includes(v.id))
         if (!variant) return ""
         return `${variant.variantName}-v${variant.revision}-${selectedTestsetName}`

--- a/web/oss/src/components/pages/evaluations/NewEvaluation/Components/SelectVariantSection.tsx
+++ b/web/oss/src/components/pages/evaluations/NewEvaluation/Components/SelectVariantSection.tsx
@@ -23,7 +23,6 @@ const NoResultsFound = dynamic(
 
 const SelectVariantSection = ({
     selectedVariantRevisionIds,
-    selectedTestsetId,
     className,
     setSelectedVariantRevisionIds,
     handlePanelChange,
@@ -49,6 +48,10 @@ const SelectVariantSection = ({
 
     const onSelectVariant = useCallback(
         (selectedRowKeys: React.Key[]) => {
+            if (evaluationType === "auto") {
+                setSelectedVariantRevisionIds(selectedRowKeys as string[])
+                return
+            }
             const selectedId = selectedRowKeys[0] as string | undefined
             if (selectedId) {
                 setSelectedVariantRevisionIds([selectedId])
@@ -57,7 +60,7 @@ const SelectVariantSection = ({
                 setSelectedVariantRevisionIds([])
             }
         },
-        [setSelectedVariantRevisionIds, handlePanelChange],
+        [evaluationType, handlePanelChange, setSelectedVariantRevisionIds],
     )
 
     const onRowClick = useCallback(
@@ -65,9 +68,21 @@ const SelectVariantSection = ({
             const _record = record as EnhancedVariant & {
                 children: EnhancedVariant[]
             }
+            if (evaluationType === "auto") {
+                const nextSelected = selectedVariantRevisionIds.includes(_record.id)
+                    ? selectedVariantRevisionIds.filter((id) => id !== _record.id)
+                    : [...selectedVariantRevisionIds, _record.id]
+                setSelectedVariantRevisionIds(nextSelected)
+                return
+            }
             onSelectVariant([_record.id])
         },
-        [selectedVariantRevisionIds, onSelectVariant],
+        [
+            evaluationType,
+            onSelectVariant,
+            selectedVariantRevisionIds,
+            setSelectedVariantRevisionIds,
+        ],
     )
 
     const variantsNonNull = (filteredVariant || []) as EnhancedVariant[]
@@ -85,7 +100,7 @@ const SelectVariantSection = ({
             <VariantsTable
                 showStableName
                 rowSelection={{
-                    type: "radio",
+                    type: evaluationType === "auto" ? "checkbox" : "radio",
                     selectedRowKeys: selectedVariantRevisionIds,
                     onChange: (selectedRowKeys) => {
                         onSelectVariant(selectedRowKeys)


### PR DESCRIPTION
### Summary
This PR allows support for multiple variant selection when trying to run automatic evaluation

<img width="1232" height="777" alt="Screenshot 2026-01-13 at 2 55 07 PM" src="https://github.com/user-attachments/assets/f330e51d-91d6-47c7-8294-c462756e5c8e" />

Closes #3404 