### PR TITLE
fix(frontend): show Query column only when online evaluations exist

### DIFF
--- a/web/oss/src/components/EvaluationRunsTablePOC/hooks/useEvaluationRunsColumns/index.tsx
+++ b/web/oss/src/components/EvaluationRunsTablePOC/hooks/useEvaluationRunsColumns/index.tsx
@@ -176,23 +176,6 @@ const useEvaluationRunsColumns = ({
             : newBlueprint
     }, [stableRows, evaluationKind])
 
-    const ensuredReferenceBlueprint = useMemo(() => {
-        if (evaluationKind !== "all") {
-            return referenceBlueprint
-        }
-        const hasQueryColumn = referenceBlueprint.some((descriptor) => descriptor.role === "query")
-        if (hasQueryColumn) {
-            return referenceBlueprint
-        }
-        const fallbackDescriptor: ReferenceColumnDescriptor = {
-            slotIndex: referenceBlueprint.length,
-            role: "query",
-            roleOrdinal: 1,
-            label: "Query",
-        }
-        return [...referenceBlueprint, fallbackDescriptor]
-    }, [evaluationKind, referenceBlueprint])
-
     const invocationMetricDescriptors = useMemo(
         () =>
             INVOCATION_METRIC_KEYS.map(
@@ -741,7 +724,7 @@ const useEvaluationRunsColumns = ({
             })
         }
 
-        ensuredReferenceBlueprint
+        referenceBlueprint
             .filter(
                 (descriptor) => descriptor.role !== "evaluator" && descriptor.role !== "variant",
             )
@@ -857,7 +840,7 @@ const useEvaluationRunsColumns = ({
     }, [
         evaluationKind,
         metricNodes,
-        ensuredReferenceBlueprint,
+        referenceBlueprint,
         onOpenDetails,
         onVariantNavigation,
         onTestsetNavigation,

--- a/web/oss/src/components/EvaluationRunsTablePOC/utils/referenceSchema.ts
+++ b/web/oss/src/components/EvaluationRunsTablePOC/utils/referenceSchema.ts
@@ -171,96 +171,69 @@ export const buildReferenceSequence = (meta?: PreviewRunColumnMeta | null): Refe
     return slots
 }
 
-interface DraftEntry {
-    slotIndex: number
-    totals: number
-    roleCounts: Partial<Record<ReferenceRole, number>>
+interface RoleStats {
+    count: number
     stepTypes: Set<string>
     origins: Set<string>
 }
 
-const pickDominantRole = (counts: Partial<Record<ReferenceRole, number>>): ReferenceRole | null => {
-    let winner: ReferenceRole | null = null
-    let max = 0
-    ROLE_ORDER.forEach((role) => {
-        const count = counts[role] ?? 0
-        if (count > max) {
-            winner = role
-            max = count
-        }
-    })
-    return winner
-}
-
 const buildFallbackBlueprint = (evaluationKind: EvaluationRunKind): ReferenceColumnDescriptor[] => {
     const fallbackRoles = ROLE_EVALUATION_FALLBACK[evaluationKind] ?? ROLE_ORDER
-    const perRoleOrdinal: Record<ReferenceRole, number> = {
-        application: 0,
-        variant: 0,
-        testset: 0,
-        query: 0,
-        evaluator: 0,
-    }
-    return fallbackRoles.map((role, index) => {
-        const ordinal = ++perRoleOrdinal[role]
-        return {
-            slotIndex: index,
-            role,
-            roleOrdinal: ordinal,
-            label: ordinal === 1 ? ROLE_LABEL[role] : `${ROLE_LABEL[role]} ${ordinal}`,
-        }
-    })
+    return fallbackRoles.map((role, index) => ({
+        slotIndex: index,
+        role,
+        roleOrdinal: 1,
+        label: ROLE_LABEL[role],
+    }))
 }
 
 export const buildReferenceBlueprint = (
     rows: EvaluationRunTableRow[],
     evaluationKind: EvaluationRunKind,
 ): ReferenceColumnDescriptor[] => {
-    const drafts: DraftEntry[] = []
+    // Collect which roles appear across all rows
+    const roleStats: Record<ReferenceRole, RoleStats> = {
+        testset: {count: 0, stepTypes: new Set(), origins: new Set()},
+        query: {count: 0, stepTypes: new Set(), origins: new Set()},
+        application: {count: 0, stepTypes: new Set(), origins: new Set()},
+        variant: {count: 0, stepTypes: new Set(), origins: new Set()},
+        evaluator: {count: 0, stepTypes: new Set(), origins: new Set()},
+    }
+
+    let hasAnyData = false
+
     rows.forEach((row) => {
         if (row.__isSkeleton || !row.previewMeta) return
+        hasAnyData = true
         const sequence = buildReferenceSequence(row.previewMeta)
-        sequence.forEach((slot, index) => {
-            const draft = drafts[index] ?? {
-                slotIndex: index,
-                totals: 0,
-                roleCounts: {},
-                stepTypes: new Set<string>(),
-                origins: new Set<string>(),
-            }
-            draft.totals += 1
-            draft.roleCounts[slot.role] = (draft.roleCounts[slot.role] ?? 0) + 1
-            if (slot.stepType) draft.stepTypes.add(slot.stepType)
-            if (slot.origin) draft.origins.add(slot.origin)
-            drafts[index] = draft
+        sequence.forEach((slot) => {
+            const stats = roleStats[slot.role]
+            stats.count += 1
+            if (slot.stepType) stats.stepTypes.add(slot.stepType)
+            if (slot.origin) stats.origins.add(slot.origin)
         })
     })
 
-    const effectiveDrafts = drafts.filter((draft) => draft.totals > 0)
-    if (!effectiveDrafts.length) {
+    if (!hasAnyData) {
         return buildFallbackBlueprint(evaluationKind)
     }
 
-    const perRoleOrdinal: Record<ReferenceRole, number> = {
-        application: 0,
-        variant: 0,
-        testset: 0,
-        query: 0,
-        evaluator: 0,
-    }
-
-    return effectiveDrafts.map((draft) => {
-        const role = pickDominantRole(draft.roleCounts) ?? "application"
-        const ordinal = ++perRoleOrdinal[role]
-        return {
-            slotIndex: draft.slotIndex,
+    // Build columns for roles that appear in the data, ordered by ROLE_ORDER
+    const result: ReferenceColumnDescriptor[] = []
+    ROLE_ORDER.forEach((role) => {
+        const stats = roleStats[role]
+        if (stats.count === 0) return
+        result.push({
+            slotIndex: result.length,
             role,
-            roleOrdinal: ordinal,
-            label: ordinal === 1 ? ROLE_LABEL[role] : `${ROLE_LABEL[role]} ${ordinal}`,
-            sampleOrigin: draft.origins.values().next().value ?? null,
-            sampleStepType: draft.stepTypes.values().next().value ?? null,
-        }
+            roleOrdinal: 1,
+            label: ROLE_LABEL[role],
+            sampleStepType: stats.stepTypes.values().next().value ?? null,
+            sampleOrigin: stats.origins.values().next().value ?? null,
+        })
     })
+
+    return result.length > 0 ? result : buildFallbackBlueprint(evaluationKind)
 }
 
 export const getSlotByRoleOrdinal = (


### PR DESCRIPTION
## Problem

The Query column appeared in the evaluations table even when there were no online evaluations. Users who only had auto evaluations would see an empty Query column.

## Root Cause

The `buildReferenceBlueprint` function used a slot-based algorithm that merged columns by positional index. Different evaluation types have different column structures:

- Auto evaluations: `[testset, application, evaluator]` at positions 0, 1, 2
- Online evaluations: `[query, evaluator]` at positions 0, 1

When mixing evaluation types in the "All Evals" tab, the algorithm counted roles per position and picked the "dominant" role. If auto evaluations outnumbered online evaluations, the testset role won at position 0 and the query role was lost entirely.

To work around this, `ensuredReferenceBlueprint` forcibly added a Query column whenever `evaluationKind === "all"`. This caused the opposite problem: the Query column appeared even when no online evaluations existed.

## Solution

We refactored `buildReferenceBlueprint` to use a role-based algorithm instead of a slot-based one. The new approach:

1. Iterates through all rows and collects which roles appear (testset, query, application, variant, evaluator).
2. Creates one column for each role that exists in the data.
3. Orders columns by `ROLE_ORDER`: testset, query, application, variant, evaluator.

This ensures that a column appears if and only if its role exists in at least one row. We also removed `ensuredReferenceBlueprint` since the blueprint builder now handles this correctly.

## Changes

- `referenceSchema.ts`: Replaced slot-based merging with role-based collection in `buildReferenceBlueprint`.
- `useEvaluationRunsColumns/index.tsx`: Removed `ensuredReferenceBlueprint` and use `referenceBlueprint` directly.

## QA

Tested the following scenarios:

1. "All Evals" tab with only auto evaluations: Query column does not appear.
2. "Online Evals" tab with online evaluations: Query column appears.
3. "All Evals" tab with mixed auto and online evaluations: Query column appears.
4. "Auto Evals" tab: Query column does not appear.
5. Switching between tabs updates columns correctly.



https://github.com/user-attachments/assets/02fc2c6f-7452-402b-a2e9-324fe2c47443

