### PR TITLE
fix(frontend): Stop polling for human evaluation runs

### DIFF
--- a/web/oss/src/components/EvalRunDetails/atoms/table/run.ts
+++ b/web/oss/src/components/EvalRunDetails/atoms/table/run.ts
@@ -3,6 +3,7 @@ import {atomWithQuery} from "jotai-tanstack-query"
 
 import axios from "@/oss/lib/api/assets/axiosConfig"
 import {buildRunIndex} from "@/oss/lib/evaluations/buildRunIndex"
+import {deriveEvaluationKind} from "@/oss/lib/evaluations/utils/evaluationKind"
 import {snakeToCamelCaseKeys} from "@/oss/lib/helpers/casing"
 import {
     getPreviewRunBatcher,
@@ -321,6 +322,10 @@ export const evaluationRunQueryAtomFamily = atomFamily((runId: string | null) =>
             refetchInterval: (query) => {
                 const status =
                     query.state.data?.rawRun?.status ?? query.state.data?.camelRun?.status
+                const kind = deriveEvaluationKind(
+                    query.state.data?.rawRun ?? query.state.data?.camelRun ?? null,
+                )
+                if (kind === "human") return false
                 return isTerminalStatus(status) ? false : 5000
             },
             queryFn: async () => {

--- a/web/oss/src/components/EvaluationRunsTablePOC/hooks/useEvaluationRunsPolling.ts
+++ b/web/oss/src/components/EvaluationRunsTablePOC/hooks/useEvaluationRunsPolling.ts
@@ -25,6 +25,7 @@ const POLLING_INTERVAL_MS = 5_000
  */
 const isRowInProgress = (row: EvaluationRunTableRow): boolean => {
     if (row.__isSkeleton) return false
+    if (row.evaluationKind === "human") return false
     const status = row.status
     if (!status) return false
     return IN_PROGRESS_STATUSES.has(status)


### PR DESCRIPTION
### Summary
Stop unnecessary 5s polling for human evaluation runs by skipping run-list polling on human rows and disabling refetch intervals for human run details.