### PR TITLE
[fix] Resolve litellm issue in llm-as-a-judge

### DIFF
--- a/sdk/agenta/sdk/decorators/tracing.py
+++ b/sdk/agenta/sdk/decorators/tracing.py
@@ -18,6 +18,7 @@ from agenta.sdk.contexts.tracing import (
 from agenta.sdk.tracing.conventions import parse_span_kind
 from agenta.sdk.utils.exceptions import suppress
 from agenta.sdk.utils.logging import get_module_logger
+from agenta.sdk.utils.otel import debug_otel_context
 from opentelemetry import context as otel_context
 from opentelemetry.baggage import get_all, set_baggage
 from opentelemetry.context import attach, detach, get_current
@@ -77,7 +78,7 @@ class instrument:  # pylint: disable=invalid-name
             @wraps(handler)
             def astream_wrapper(*args, **kwargs):
                 with tracing_context_manager(context=TracingContext.get()):
-                    # debug_otel_context("[BEFORE STREAM] [BEFORE SETUP]")
+                    # debug_otel_context("[ASYNC] [BEFORE STREAM] [BEFORE SETUP]")
 
                     self._parse_type_and_kind()
 
@@ -147,6 +148,8 @@ class instrument:  # pylint: disable=invalid-name
             @wraps(handler)
             def stream_wrapper(*args, **kwargs):
                 with tracing_context_manager(context=TracingContext.get()):
+                    # debug_otel_context("[.SYNC] [BEFORE STREAM] [BEFORE SETUP]")
+
                     self._parse_type_and_kind()
 
                     token = self._attach_baggage()
@@ -210,6 +213,8 @@ class instrument:  # pylint: disable=invalid-name
             @wraps(handler)
             async def awrapper(*args, **kwargs):
                 with tracing_context_manager(context=TracingContext.get()):
+                    # debug_otel_context("[ASYNC] [BEFORE BATCH] [BEFORE SETUP]")
+
                     self._parse_type_and_kind()
 
                     token = self._attach_baggage()
@@ -243,6 +248,8 @@ class instrument:  # pylint: disable=invalid-name
         @wraps(handler)
         def wrapper(*args, **kwargs):
             with tracing_context_manager(context=TracingContext.get()):
+                # debug_otel_context("[.SYNC] [BEFORE BATCH] [BEFORE SETUP]")
+
                 self._parse_type_and_kind()
 
                 token = self._attach_baggage()

--- a/sdk/agenta/sdk/tracing/exporters.py
+++ b/sdk/agenta/sdk/tracing/exporters.py
@@ -1,14 +1,18 @@
-from typing import Sequence, Dict, List, Optional, Any
+from typing import Sequence, Dict, List, Optional
 from threading import Thread
 from os import environ
 from uuid import UUID
 
-from opentelemetry.exporter.otlp.proto.http.trace_exporter import OTLPSpanExporter
+from opentelemetry.exporter.otlp.proto.http.trace_exporter import (
+    OTLPSpanExporter,
+)
+from opentelemetry.sdk.trace import (
+    ReadableSpan,
+)
 from opentelemetry.sdk.trace.export import (
     ConsoleSpanExporter,
     SpanExporter,
     SpanExportResult,
-    ReadableSpan,
 )
 
 from agenta.sdk.utils.constants import TRUTHY
@@ -40,7 +44,7 @@ class InlineTraceExporter(SpanExporter):
         spans: Sequence[ReadableSpan],
     ) -> SpanExportResult:
         if self._shutdown:
-            return
+            return SpanExportResult.SUCCESS
 
         with suppress():
             for span in spans:
@@ -51,7 +55,7 @@ class InlineTraceExporter(SpanExporter):
 
                 self._registry[trace_id].append(span)
 
-            return
+            return SpanExportResult.SUCCESS
 
     def shutdown(self) -> None:
         self._shutdown = True
@@ -122,7 +126,7 @@ class OTLPExporter(OTLPSpanExporter):
                     #     "[SPAN]  [EXPORT]",
                     #     trace_id=UUID(int=trace_id).hex,
                     #     span_id=UUID(int=span_id).hex[-16:],
-                    #     span_attributes=_span.attributes,
+                    #     # span_attributes=_span.attributes,
                     # )
 
                 serialized_spans.append(super().export(_spans))
@@ -154,7 +158,7 @@ class OTLPExporter(OTLPSpanExporter):
 
                     # log.debug(
                     #     "[SPAN] [_EXPORT]",
-                    #     data=serialized_data,
+                    #     # data=serialized_data,
                     #     resp=resp,
                     # )
 

--- a/sdk/agenta/sdk/tracing/processors.py
+++ b/sdk/agenta/sdk/tracing/processors.py
@@ -1,5 +1,6 @@
 from threading import Lock
 from typing import Dict, List, Optional
+from uuid import UUID
 
 
 from agenta.sdk.contexts.tracing import TracingContext
@@ -58,11 +59,13 @@ class TraceProcessor(SpanProcessor):
         trace_id = span.context.trace_id
         span_id = span.context.span_id
 
-        # log.debug(
-        #     "[SPAN] [START] ",
-        #     trace_id=UUID(int=trace_id).hex,
-        #     span_id=UUID(int=span_id).hex[-16:],
-        # )
+        # if not self.inline:
+        #     log.debug(
+        #         "[SPAN] [START] ",
+        #         trace_id=UUID(int=trace_id).hex,
+        #         span_id=UUID(int=span_id).hex[-16:],
+        #         span_name=span.name,
+        #     )
 
         for key in self.references.keys():
             ref = self.references[key]
@@ -173,11 +176,13 @@ class TraceProcessor(SpanProcessor):
         trace_id = span.context.trace_id
         span_id = span.context.span_id
 
-        # log.debug(
-        #     "[SPAN] [END]   ",
-        #     trace_id=UUID(int=trace_id).hex,
-        #     span_id=UUID(int=span_id).hex[-16:],
-        # )
+        # if not self.inline:
+        #     log.debug(
+        #         "[SPAN] [END]   ",
+        #         trace_id=UUID(int=trace_id).hex,
+        #         span_id=UUID(int=span_id).hex[-16:],
+        #         span_name=span.name,
+        #     )
 
         self._spans.setdefault(trace_id, []).append(span)
         self._registry.setdefault(trace_id, {})


### PR DESCRIPTION
## Problem
When running batch evaluations with `auto_ai_critique_v0`, the `_configure_litellm` function was called on each invocation, creating a new `LitellmHandler` instance and replacing `litellm.callbacks` each time. This caused a race condition where the old handler's `log_pre_api_call` would create a span, but `async_log_success_event` would be called on the new handler instance (which didn't have that span in its `self.span` dictionary), leaving the span orphaned and never ended. Since the `TraceProcessor` only exports traces when all spans have ended, the orphan span blocked the entire trace from being exported, causing "`Trace missing`" errors for subsequent evaluations.

## Solution
The fix adds an idempotency check (`_litellm_configured` flag) to ensure the callback handler is only registered once per process lifetime.