### PR TITLE
fix(api): resolve OpenAPI spec generation issues for Fern SDK

### DIFF
--- a/api/entrypoints/routers.py
+++ b/api/entrypoints/routers.py
@@ -394,6 +394,7 @@ app.include_router(
     router=tracing.router,
     prefix="/preview/tracing",
     tags=["Deprecated"],
+    include_in_schema=False,
 )
 
 app.include_router(

--- a/api/oss/src/apis/fastapi/evaluations/router.py
+++ b/api/oss/src/apis/fastapi/evaluations/router.py
@@ -1772,6 +1772,7 @@ class SimpleEvaluationsRouter:
             endpoint=self.start_evaluation,
             response_model=SimpleEvaluationResponse,
             response_model_exclude_none=True,
+            operation_id="start_simple_evaluation",
         )
 
         # POST /api/simple/evaluations/{evaluation_id}/stop


### PR DESCRIPTION
## Summary
- Exclude deprecated `/preview/tracing/*` routes from OpenAPI schema to prevent duplicate type declarations
- Add explicit `operation_id` to simple evaluations start endpoint to prevent collision with legacy evaluation endpoint

## Changes
1. **api/entrypoints/routers.py**: Added `include_in_schema=False` to the deprecated tracing router mount. This keeps the deprecated endpoints functional for backward compatibility while removing them from the OpenAPI spec.

2. **api/oss/src/apis/fastapi/evaluations/router.py**: Added `operation_id="start_simple_evaluation"` to the `/{evaluation_id}/start` route to avoid collision with the legacy `start_evaluation` operationId.

## Why
These changes fix issues that cause Fern SDK generation to fail:
- Duplicate type declarations from deprecated endpoints sharing request types with current endpoints
- OperationId collision between two different evaluation start endpoints

## Testing
- API behavior is unchanged
- Deprecated endpoints remain functional
- OpenAPI spec should no longer have duplicate definitions