### PR TITLE
fix(sdk): define tracing response types locally instead of importing from Fern client

### DIFF
--- a/sdk/agenta/sdk/types.py
+++ b/sdk/agenta/sdk/types.py
@@ -9,7 +9,31 @@ from starlette.responses import StreamingResponse
 
 
 from agenta.sdk.assets import supported_llm_models, model_metadata
-from agenta.client.backend.types import AgentaNodesResponse, AgentaNodeDto
+
+
+# SDK-internal types for inline trace responses.
+# These were previously imported from Fern-generated client types, but are now
+# defined locally since they are SDK-internal models not exposed by the API.
+
+
+class AgentaNodeDto(BaseModel):
+    """SDK-internal type for inline trace node representation.
+
+    This type accepts arbitrary fields via extra="allow" since it's
+    constructed from span dictionaries with dynamic keys.
+    """
+
+    model_config = ConfigDict(extra="allow")
+
+
+class AgentaNodesResponse(BaseModel):
+    """SDK-internal type for inline trace response."""
+
+    version: str
+    nodes: List[AgentaNodeDto] = []
+    count: Optional[int] = None
+
+    model_config = ConfigDict(extra="allow")
 
 
 @dataclass


### PR DESCRIPTION
## Summary
- Define `AgentaNodeDto` and `AgentaNodesResponse` locally in SDK
- Remove dependency on Fern-generated types that may not exist in future SDK generations

## Changes
**sdk/agenta/sdk/types.py**: Added local definitions for `AgentaNodeDto` and `AgentaNodesResponse`, replacing the import from `agenta.client.backend.types`.

## Why
These types are SDK-internal models used for inline trace responses. They were previously imported from Fern-generated client types, but:

1. Those types aren't actually exposed by any API endpoint (they're internal API models)
2. The current cloud API OpenAPI spec doesn't include these types
3. Future Fern SDK regenerations may not include them

Defining them locally makes the SDK self-contained and independent of Fern generation quirks.

## Type Definitions
```python
class AgentaNodeDto(BaseModel):
    """SDK-internal type for inline trace node representation."""
    model_config = ConfigDict(extra="allow")

class AgentaNodesResponse(BaseModel):
    """SDK-internal type for inline trace response."""
    version: str
    nodes: List[AgentaNodeDto] = []
    count: Optional[int] = None
    model_config = ConfigDict(extra="allow")
```

## Testing
- Types are compatible with existing usage in `sdk/agenta/sdk/tracing/inline.py` and `sdk/agenta/sdk/engines/tracing/inline.py`
- Uses `extra="allow"` to accept arbitrary fields when constructed from span dictionaries
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/agenta-ai/agenta/pull/3442">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open with Devin">
  </picture>
</a>
<!-- devin-review-badge-end -->
