### PR TITLE
docs: update testset docs to new SDK

### DIFF
--- a/api/ee/tests/manual/evaluations/sdk/testset-management.ipynb
+++ b/api/ee/tests/manual/evaluations/sdk/testset-management.ipynb
@@ -120,8 +120,8 @@
     "print(f\"   Slug: {testset.slug}\")\n",
     "print(f\"   Description: {testset.description}\")\n",
     "\n",
-    "# Save the ID for later use\n",
-    "testset_id = testset.id"
+    "# Save the parent testset ID for later use\n",
+    "testset_id = testset.testset_id or testset.id"
    ]
   },
   {
@@ -137,8 +137,10 @@
     "   Description: A testset of countries and their capitals for geography evaluation\n",
     "```\n",
     "\n",
-    "The `create_testset` function returns a `SimpleTestset` object with the following fields:\n",
-    "- `id`: Unique UUID for the testset\n",
+    "The `acreate` function returns a `TestsetRevision` object with the following fields:\n",
+    "- `id`: The revision UUID\n",
+    "- `testset_id`: The parent testset UUID\n",
+    "- `version`: The revision version\n",
     "- `name`: The name you provided\n",
     "- `slug`: A shortened identifier\n",
     "- `description`: Your description\n",

--- a/docs/docs/evaluation/_evaluation-from-sdk/01-quick-start.mdx
+++ b/docs/docs/evaluation/_evaluation-from-sdk/01-quick-start.mdx
@@ -29,41 +29,51 @@ pip install -U agenta
 ## Quick example
 
 ```python
+import asyncio
 import agenta as ag
-from agenta.client.api import AgentaApi
+from agenta.sdk.evaluations import aevaluate
 
-# Initialize the SDK
-client = AgentaApi(
-    base_url="https://cloud.agenta.ai/api",
-    api_key="your-api-key"
+ag.init(host="https://cloud.agenta.ai", api_key="your-api-key")
+
+@ag.application(
+    slug="capital_finder",
+    name="Capital Finder",
 )
-
-# Create a test set
-test_set = client.testsets.create_testset(
-    request={
-        "name": "my_test_set",
-        "csvdata": [
-            {"input": "Hello", "expected": "Hi there!"},
-            {"input": "How are you?", "expected": "I'm doing well!"}
-        ]
+async def capital_finder(country: str):
+    capitals = {
+        "Germany": "Berlin",
+        "France": "Paris",
     }
+    return capitals.get(country, "Unknown")
+
+@ag.evaluator(
+    slug="exact_match",
+    name="Exact Match",
 )
+async def exact_match(expected: str, outputs: str):
+    return {
+        "score": 1.0 if outputs == expected else 0.0,
+        "success": outputs == expected,
+    }
 
-# Run evaluation
-evaluation = client.evaluations.create_evaluation(
-    app_id="your-app-id",
-    variant_ids=["variant-id"],
-    testset_id=test_set.id,
-    evaluators_configs=["evaluator-config-id"]
-)
+async def run():
+    testset = await ag.testsets.acreate(
+        name="my_test_set",
+        data=[
+            {"country": "Germany", "expected": "Berlin"},
+            {"country": "France", "expected": "Paris"},
+        ],
+    )
 
-# Check status
-status = client.evaluations.fetch_evaluation_status(evaluation.id)
-print(f"Evaluation status: {status}")
+    result = await aevaluate(
+        testsets=[testset.id],
+        applications=[capital_finder],
+        evaluators=[exact_match],
+    )
+    return result
 
-# Get results when complete
-results = client.evaluations.fetch_evaluation_results(evaluation.id)
-print(results)
+result = asyncio.run(run())
+print(result)
 ```
 
 ## Next steps

--- a/docs/docs/evaluation/_evaluation-from-sdk/02-setup-configuration.mdx
+++ b/docs/docs/evaluation/_evaluation-from-sdk/02-setup-configuration.mdx
@@ -18,7 +18,7 @@ pip install -U agenta
 ## Initialize the SDK client
 
 ```python
-from agenta.client.api import AgentaApi
+import agenta as ag
 
 app_id = "667d8cfad1812781f7e375d9"
 
@@ -29,8 +29,8 @@ api_key = "EUqJGOUu.xxxx"
 # Host
 host = "https://cloud.agenta.ai"
 
-# Initialize the client
-client = AgentaApi(base_url=host + "/api", api_key=api_key)
+# Initialize the SDK
+ag.init(host=host, api_key=api_key)
 ```
 
 ## Configuration options

--- a/docs/docs/evaluation/_evaluation-from-sdk/03-managing-test-sets.mdx
+++ b/docs/docs/evaluation/_evaluation-from-sdk/03-managing-test-sets.mdx
@@ -5,35 +5,61 @@ description: "Learn how to create, load, and manage test sets using the SDK"
 sidebar_position: 3
 ---
 
-<!-- TODO: Replace with new SDK evaluation content -->
-
-## Creating test sets
+## Creating, retrieving, and updating test sets
 
 ```python
-from agenta.client.types.new_testset import NewTestset
+import asyncio
+import agenta as ag
 
-csvdata = [
-    {"country": "france", "capital": "Paris"},
-    {"country": "Germany", "capital": "Berlin"}
-]
+# Initialize from environment variables if set (AGENTA_HOST, AGENTA_API_KEY)
+ag.init()
 
-response = client.testsets.create_testset(
-    request=NewTestset(name="test set", csvdata=csvdata)
-)
-test_set_id = response.id
+async def main():
+    # Create a testset (returns a TestsetRevision)
+    created = await ag.testsets.acreate(
+        name="test set",
+        data=[
+            {"country": "France", "capital": "Paris"},
+            {"country": "Germany", "capital": "Berlin"},
+        ],
+    )
+
+    testset_id = created.testset_id or created.id
+    print(f"Testset ID: {testset_id}")
+    print(f"Revision ID: {created.id}")
+
+    # Retrieve the latest revision for a testset
+    retrieved = await ag.testsets.aretrieve(testset_id=testset_id)
+    if retrieved:
+        print(f"Retrieved testset revision: {retrieved.id}")
+        print(f"Version: {retrieved.version}")
+
+    # Update the testset data
+    await ag.testsets.aedit(
+        testset_id=testset_id,
+        name="test set v2",
+        data=[
+            {"country": "France", "capital": "Paris"},
+            {"country": "Germany", "capital": "Berlin"},
+            {"country": "Spain", "capital": "Madrid"},
+        ],
+    )
+
+    # Fetch the latest revision after editing
+    updated = await ag.testsets.aretrieve(testset_id=testset_id)
+    if updated:
+        print(f"Latest revision ID: {updated.id}")
+        print(f"Version: {updated.version}")
+
+asyncio.run(main())
 ```
-
-## Loading existing test sets
-
-<!-- TODO: Add content for loading test sets -->
-
-## Updating test sets
-
-<!-- TODO: Add content for updating test sets -->
 
 ## Deleting test sets
 
-<!-- TODO: Add content for deleting test sets -->
+The SDK does not currently expose delete helpers. To archive or delete testsets directly, use the API endpoints:
+
+- [Archive simple testset](/reference/api/archive-simple-testset)
+- [Unarchive simple testset](/reference/api/unarchive-simple-testset)
 
 ## Next steps
 

--- a/docs/docs/evaluation/_evaluation-from-sdk/04-configuring-evaluators.mdx
+++ b/docs/docs/evaluation/_evaluation-from-sdk/04-configuring-evaluators.mdx
@@ -5,46 +5,41 @@ description: "Learn how to configure built-in and custom evaluators using the SD
 sidebar_position: 4
 ---
 
-<!-- TODO: Replace with new SDK evaluation content -->
-
 ## Creating evaluators
 
-### Custom code evaluator
-
-Let's create a custom code evaluator that returns 1.0 if the first letter of the app output is uppercase:
+### Custom evaluator
 
 ```python
-code_snippet = """
-from typing import Dict
+import agenta as ag
 
-def evaluate(
-    app_params: Dict[str, str],
-    inputs: Dict[str, str],
-    output: str,  # output of the llm app
-    datapoint: Dict[str, str]  # contains the testset row
-) -> float:
-    if output and output[0].isupper():
-        return 1.0
-    else:
-        return 0.0
-"""
-
-response = client.evaluators.create_new_evaluator_config(
-    app_id=app_id,
-    name="capital_letter_evaluator",
-    evaluator_key="auto_custom_code_run",
-    settings_values={"code": code_snippet}
+@ag.evaluator(
+    slug="capital_letter_evaluator",
+    name="Capital Letter Evaluator",
 )
-letter_match_eval_id = response.id
+async def capital_letter_evaluator(outputs: str):
+    is_capitalized = bool(outputs) and outputs[0].isupper()
+    return {
+        "score": 1.0 if is_capitalized else 0.0,
+        "success": is_capitalized,
+    }
 ```
 
-## Using built-in evaluators
+### Built-in evaluators
 
-<!-- TODO: Add content for using built-in evaluators -->
+Agenta ships built-in evaluators you can configure directly:
+
+```python
+from agenta.sdk.workflows import builtin
+
+exact_match = builtin.auto_exact_match(
+    name="Capital Exact Match",
+    correct_answer_key="capital",
+)
+```
 
 ## Configuring evaluator settings
 
-<!-- TODO: Add content for configuring evaluator settings -->
+Built-in evaluators accept parameters (like `correct_answer_key`) when you construct them, so you can tailor scoring to your testset schema.
 
 ## Next steps
 

--- a/docs/docs/evaluation/_evaluation-from-sdk/05-running-evaluations.mdx
+++ b/docs/docs/evaluation/_evaluation-from-sdk/05-running-evaluations.mdx
@@ -5,55 +5,35 @@ description: "Learn how to run evaluations programmatically using the SDK"
 sidebar_position: 5
 ---
 
-<!-- TODO: Replace with new SDK evaluation content -->
-
 ## Running an evaluation
 
-First, let's grab the first variant in the app:
-
 ```python
-response = client.apps.list_app_variants(app_id=app_id)
-print(response)
-myvariant_id = response[0].variant_id
-```
+import asyncio
+import agenta as ag
+from agenta.sdk.evaluations import aevaluate
 
-Then, let's start the evaluation jobs:
+# Initialize from environment variables if set (AGENTA_HOST, AGENTA_API_KEY)
+ag.init()
 
-```python
-from agenta.client.types.llm_run_rate_limit import LlmRunRateLimit
+# Assume `testset`, `capital_finder`, and `capital_letter_evaluator` are already defined
+async def main():
+    result = await aevaluate(
+        name="My Evaluation",
+        # You can pass a testset revision id (recommended)
+        testsets=[testset.id],
+        applications=[capital_finder],
+        evaluators=[capital_letter_evaluator],
+    )
 
-rate_limit_config = LlmRunRateLimit(
-    batch_size=10,  # number of rows to call in parallel
-    max_retries=3,  # max number of time to retry a failed llm call
-    retry_delay=2,  # delay before retrying a failed llm call
-    delay_between_batches=5,  # delay between batches
-)
+    print(f"Run ID: {result['run'].id}")
+    return result
 
-response = client.evaluations.create_evaluation(
-    app_id=app_id,
-    variant_ids=[myvariant_id],
-    testset_id=test_set_id,
-    evaluators_configs=[letter_match_eval_id],
-    rate_limit=rate_limit_config
-)
-print(response)
+result = asyncio.run(main())
 ```
 
 ## Checking evaluation status
 
-Now we can check for the status of the job:
-
-```python
-client.evaluations.fetch_evaluation_status('667d98fbd1812781f7e3761a')
-```
-
-## Configuring rate limits
-
-<!-- TODO: Add more details about rate limit configuration -->
-
-## Handling errors
-
-<!-- TODO: Add content for error handling -->
+`aevaluate()` prints progress as it runs. You can also look up the run in the UI using the run ID printed above.
 
 ## Next steps
 

--- a/docs/docs/evaluation/_evaluation-from-sdk/06-viewing-results.mdx
+++ b/docs/docs/evaluation/_evaluation-from-sdk/06-viewing-results.mdx
@@ -5,40 +5,28 @@ description: "Learn how to retrieve and analyze evaluation results using the SDK
 sidebar_position: 6
 ---
 
-<!-- TODO: Replace with new SDK evaluation content -->
-
 ## Fetching overall results
 
-As soon as the evaluation is done, we can fetch the overall results:
+`aevaluate()` returns the run, scenarios, and metrics in a single object. You can inspect the metrics directly:
 
 ```python
-response = client.evaluations.fetch_evaluation_results('667d98fbd1812781f7e3761a')
-
-results = [
-    (evaluator["evaluator_config"]["name"], evaluator["result"])
-    for evaluator in response["results"]
-]
-print(results)
+metrics = result["metrics"]
+print(metrics)
 ```
 
 ## Fetching detailed results
 
-Get detailed results for each test case:
+Use the built-in display helper to render a detailed report:
 
 ```python
-detailed_results = client.evaluations.fetch_evaluation_scenarios(
-    evaluations_ids='667d98fbd1812781f7e3761a'
-)
-print(detailed_results)
+import asyncio
+from agenta.sdk.evaluations import display
+
+async def main():
+    await display(result)
+
+asyncio.run(main())
 ```
-
-## Analyzing results
-
-<!-- TODO: Add content for analyzing results -->
-
-## Exporting results
-
-<!-- TODO: Add content for exporting results -->
 
 ## Next steps
 

--- a/docs/docs/evaluation/evaluation-from-sdk/02-managing-testsets.mdx
+++ b/docs/docs/evaluation/evaluation-from-sdk/02-managing-testsets.mdx
@@ -15,6 +15,19 @@ This guide covers how to create, list, and retrieve testsets using the Agenta SD
   Open in Google Colaboratory
 </GoogleColabButton>
 
+:::tip Async examples
+Agenta's SDK uses async APIs. In Jupyter/Colab you can use top-level `await`. In a regular Python script, wrap async code like this:
+
+```python
+import asyncio
+
+async def main():
+    ...
+
+asyncio.run(main())
+```
+:::
+
 ## Creating a Testset
 
 Use `ag.testsets.acreate()` to create a new testset with data:
@@ -35,7 +48,9 @@ testset = await ag.testsets.acreate(
     name="Country Capitals",
 )
 
-print(f"Created testset with ID: {testset.id}")
+testset_id = testset.testset_id or testset.id
+print(f"Testset ID: {testset_id}")
+print(f"Revision ID: {testset.id}")
 print(f"Name: {testset.name}")
 print(f"Slug: {testset.slug}")
 ```
@@ -48,9 +63,11 @@ print(f"Slug: {testset.slug}")
 - `name`: The name of your testset.
 
 **Returns:** A `TestsetRevision` object containing:
-- `id`: The UUID of the created testset
+- `id`: The UUID of the created testset revision
+- `testset_id`: The parent testset UUID (stable across revisions)
 - `name`: The testset name
-- `slug`: The testset slug
+- `slug`: The revision slug
+- `version`: The revision version string (e.g. "1")
 - `data`: The test data (with `testcases` structure)
 
 **Sample Output:**
@@ -95,7 +112,9 @@ testset = await ag.testsets.aupsert(
     ],
 )
 
-print(f"Upserted testset with ID: {testset.id}")
+testset_id = testset.testset_id or testset.id
+print(f"Testset ID: {testset_id}")
+print(f"Revision ID: {testset.id}")
 ```
 
   </TabItem>
@@ -127,7 +146,8 @@ testsets = await ag.testsets.alist()
 
 print(f"Found {len(testsets)} testsets:")
 for testset in testsets:
-    print(f"  - {testset.name} (ID: {testset.id})")
+    testset_id = testset.testset_id or testset.id
+    print(f"  - {testset.name} (testset_id: {testset_id})")
 ```
 
   </TabItem>
@@ -135,10 +155,11 @@ for testset in testsets:
 
 **Parameters:** None required.
 
-**Returns:** A list of `TestsetRevision` objects, each containing:
-- `id`: The testset UUID
+**Returns:** A list of `TestsetRevision` objects. For each item:
+- `id`: The latest revision UUID
+- `testset_id`: The parent testset UUID
 - `name`: The testset name
-- `slug`: The testset slug
+- `slug`: The revision slug
 - Additional metadata fields
 
 **Sample Output:**
@@ -210,7 +231,7 @@ else:
 ```
 
 :::info
-Currently using the legacy testset API. When retrieving a testset, the function returns a `TestsetRevision` object with version "1". In the future, this will support the new versioning system where each update creates a new revision.
+Testsets are versioned. Each update via `ag.testsets.aedit()` or `ag.testsets.aupsert()` creates a new `TestsetRevision`, while the parent `testset_id` stays the same.
 :::
 
 ## Retrieving a Testset by Name
@@ -240,7 +261,8 @@ async def get_testset_by_name(name: str):
 testset = await get_testset_by_name("Country Capitals")
 
 if testset:
-    print(f"Found testset: {testset.name} with ID: {testset.id}")
+    testset_id = testset.testset_id or testset.id
+    print(f"Found testset: {testset.name} (testset_id: {testset_id}, revision_id: {testset.id})")
 else:
     print("Testset not found")
 ```

--- a/docs/docs/evaluation/managing-test-sets/02-create-programatically.mdx
+++ b/docs/docs/evaluation/managing-test-sets/02-create-programatically.mdx
@@ -11,14 +11,14 @@ Creating test sets programmatically allows you to automate test set generation, 
 
 ## Creating via API
 
-You can upload a test set using our API. Find the [API endpoint reference here](/reference/api/upload-file).
+You can create a versioned testset using the simple testset API. Find the [API endpoint reference here](/reference/api/create-simple-testset).
 
 Here's an example of such a call:
 
 **HTTP Request:**
 
 ```
-POST /testsets
+POST /preview/simple/testsets/
 
 ```
 
@@ -26,58 +26,65 @@ POST /testsets
 
 ```json
 {
-  "name": "testsetname",
-  "csvdata": [
-    { "column1": "row1col1", "column2": "row1col2" },
-    { "column1": "row2col1", "column2": "row2col2" }
-  ]
+  "testset": {
+    "slug": "countries-capitals",
+    "name": "countries_capitals",
+    "data": {
+      "testcases": [
+        {"data": {"country": "France", "capital": "Paris"}},
+        {"data": {"country": "Germany", "capital": "Berlin"}}
+      ]
+    }
+  }
 }
 ```
 
 ### Example with curl
 
 ```bash
-curl -X POST "https://cloud.agenta.ai/api/testsets" \
+curl -X POST "https://cloud.agenta.ai/api/preview/simple/testsets/" \
   -H "Content-Type: application/json" \
   -H "Authorization: ApiKey YOUR_API_KEY" \
   -d '{
-    "name": "my_test_set",
-    "csvdata": [
-      {"input": "Hello", "expected": "Hi there!"},
-      {"input": "How are you?", "expected": "I am doing well!"}
-    ]
+    "testset": {
+      "slug": "my-test-set",
+      "name": "my_test_set",
+      "data": {
+        "testcases": [
+          {"data": {"input": "Hello", "expected": "Hi there!"}},
+          {"data": {"input": "How are you?", "expected": "I am doing well!"}}
+        ]
+      }
+    }
   }'
 ```
 
 ## Creating via SDK
 
 ```python
-from agenta.client.api import AgentaApi
-from agenta.client.types.new_testset import NewTestset
+import asyncio
+import agenta as ag
 
-# Initialize the client
-client = AgentaApi(
-    base_url="https://cloud.agenta.ai/api",
-    api_key="your-api-key"
-)
+ag.init(host="https://cloud.agenta.ai", api_key="your-api-key")
 
-# Create test set data
-csvdata = [
-    {"country": "France", "capital": "Paris"},
-    {"country": "Germany", "capital": "Berlin"},
-    {"country": "Spain", "capital": "Madrid"}
-]
+async def main():
+    # Create test set data
+    csvdata = [
+        {"country": "France", "capital": "Paris"},
+        {"country": "Germany", "capital": "Berlin"},
+        {"country": "Spain", "capital": "Madrid"},
+    ]
 
-# Create the test set
-response = client.testsets.create_testset(
-    request=NewTestset(
+    # Create the testset (returns a TestsetRevision)
+    testset = await ag.testsets.acreate(
         name="countries_capitals",
-        csvdata=csvdata
+        data=csvdata,
     )
-)
 
-test_set_id = response.id
-print(f"Created test set with ID: {test_set_id}")
+    testset_revision_id = testset.id
+    print(f"Created testset revision with ID: {testset_revision_id}")
+
+asyncio.run(main())
 ```
 
 ## Next steps

--- a/docs/docs/tutorials/sdk/_evaluate-with-SDK.mdx
+++ b/docs/docs/tutorials/sdk/_evaluate-with-SDK.mdx
@@ -40,12 +40,7 @@ This operation is managed through TaskIQ tasks. The interactions with the LLM ap
 # In this example we will use the default template single_prompt which has the prompt "Determine the capital of {country}"
 
 # You can find the application ID in the URL. For example, in the URL https://cloud.agenta.ai/apps/666dde95962bbaffdb0072b5/playground?variant=app.default, the application ID is `666dde95962bbaffdb0072b5`.
-from agenta.client.client import AgentaApi
-# Let's list the applications
-client.apps.list_apps()
-```
-
-```python
+import agenta as ag
 
 app_id = "667d8cfad1812781f7e375d9"
 
@@ -55,101 +50,102 @@ api_key = "EUqJGOUu.xxxx"
 # Host.
 host = "https://cloud.agenta.ai"
 
-# Initialize the client
+# Initialize the SDK
+ag.init(host=host, api_key=api_key)
+```
 
-client = AgentaApi(base_url=host + "/api", api_key=api_key)
+## Define the application
+
+```python
+@ag.application(
+    slug="capital_finder",
+    name="Capital Finder",
+)
+async def capital_finder(country: str):
+    capitals = {
+        "Germany": "Berlin",
+        "France": "Paris",
+    }
+    return capitals.get(country, "Unknown")
 ```
 
 ## Create a test set
 
 ```python
-from agenta.client.types.new_testset import NewTestset
+import asyncio
+import agenta as ag
+
+# Assumes `ag.init(...)` has already been called.
 
 csvdata = [
-        {"country": "france", "capital": "Paris"},
-        {"country": "Germany", "capital": "paris"}
-    ]
+    {"country": "France", "capital": "Paris"},
+    {"country": "Germany", "capital": "Paris"},
+]
 
-response = client.testsets.create_testset(request=NewTestset(name="test set", csvdata=csvdata))
-test_set_id = response.id
+async def main():
+    # Create a testset (returns a TestsetRevision)
+    created = await ag.testsets.acreate(name="test set", data=csvdata)
+    testset_id = created.testset_id or created.id
 
-# let's now update it
+    # Update the testset data
+    await ag.testsets.aedit(
+        testset_id=testset_id,
+        name="test set",
+        data=[
+            {"country": "France", "capital": "Paris"},
+            {"country": "Germany", "capital": "Berlin"},
+        ],
+    )
 
-csvdata = [
-        {"country": "france", "capital": "Paris"},
-        {"country": "Germany", "capital": "Berlin"}
-    ]
+    # Fetch the latest revision after editing
+    updated = await ag.testsets.aretrieve(testset_id=testset_id)
+    return updated
 
-client.testsets.update_testset(testset_id=test_set_id, request=NewTestset(name="test set", csvdata=csvdata))
+updated = asyncio.run(main())
+print(f"Latest revision ID: {updated.id}")
 ```
 
 # Create evaluators
 
 ```python
-# Create an evaluator that performs an exact match comparison on the 'capital' column
-# You can find the list of evaluator keys and evaluators and their configurations in https://github.com/Agenta-AI/agenta/blob/main/agenta-backend/agenta_backend/resources/evaluators/evaluators.py
-response = client.evaluators.create_new_evaluator_config(app_id=app_id, name="capital_evaluator", evaluator_key="auto_exact_match", settings_values={"correct_answer_key": "capital"})
-exact_match_eval_id = response.id
+@ag.evaluator(
+    slug="capital_exact_match",
+    name="Capital Exact Match",
+)
+async def exact_match(capital: str, outputs: str):
+    return {
+        "score": 1.0 if outputs == capital else 0.0,
+        "success": outputs == capital,
+    }
 
-code_snippet = """
-from typing import Dict
-
-def evaluate(
-    app_params: Dict[str, str],
-    inputs: Dict[str, str],
-    output: str,  # output of the llm app
-    datapoint: Dict[str, str]  # contains the testset row
-) -> float:
-    if output and output[0].isupper():
-        return 1.0
-    else:
-        return 0.0
-"""
-
-response = client.evaluators.create_new_evaluator_config(app_id=app_id, name="capital_letter_evaluator", evaluator_key="auto_custom_code_run", settings_values={"code": code_snippet})
-letter_match_eval_id = response.id
-```
-
-```python
-# get list of all evaluators
-client.evaluators.get_evaluator_configs(app_id=app_id)
+@ag.evaluator(
+    slug="capital_letter_match",
+    name="Capital Letter Match",
+)
+async def letter_match(outputs: str):
+    is_capitalized = bool(outputs) and outputs[0].isupper()
+    return {
+        "score": 1.0 if is_capitalized else 0.0,
+        "success": is_capitalized,
+    }
 ```
 
 # Run an evaluation
 
 ```python
-response = client.apps.list_app_variants(app_id=app_id)
-print(response)
-myvariant_id = response[0].variant_id
-```
+import asyncio
+from agenta.sdk.evaluations import aevaluate
 
-```python
-# Run an evaluation
-from agenta.client.types.llm_run_rate_limit import LlmRunRateLimit
-response = client.evaluations.create_evaluation(app_id=app_id, variant_ids=[myvariant_id], testset_id=test_set_id, evaluators_configs=[exact_match_eval_id, letter_match_eval_id],
-                                                rate_limit=LlmRunRateLimit(
-        batch_size=10, # number of rows to call in parallel
-        max_retries=3, # max number of time to retry a failed llm call
-        retry_delay=2, # delay before retrying a failed llm call
-        delay_between_batches=5, # delay between batches
-    ),)
-print(response)
-```
+async def main():
+    result = await aevaluate(
+        name="Capital evaluation",
+        testsets=[updated.id],
+        applications=[capital_finder],
+        evaluators=[exact_match, letter_match],
+    )
 
-```python
-# check the status
-client.evaluations.fetch_evaluation_status('667d98fbd1812781f7e3761a')
-```
+    print(result)
+    return result
 
-```python
-# fetch the overall results
-response = client.evaluations.fetch_evaluation_results('667d98fbd1812781f7e3761a')
-
-results = [(evaluator["evaluator_config"]["name"], evaluator["result"]) for evaluator in response["results"]]
-# End of  Selection
-```
-
-```python
-# fetch the detailed results
-client.evaluations.fetch_evaluation_scenarios(evaluations_ids='667d98fbd1812781f7e3761a')
+result = asyncio.run(main())
 ```

--- a/examples/jupyter/evaluation/quick-start.ipynb
+++ b/examples/jupyter/evaluation/quick-start.ipynb
@@ -330,7 +330,7 @@
      "output_type": "stream",
      "text": [
       "📝 Creating testset...\n",
-      "✅ Testset created with ID: 019a783b-7894-7c80-a5ce-25005d745f5f\n",
+      "✅ Testset revision created with ID: 019a783b-7894-7c80-a5ce-25005d745f5f\n",
       "   Contains 4 test cases\n",
       "\n"
      ]
@@ -349,7 +349,7 @@
     "if not testset or not testset.id:\n",
     "    print(\"❌ Failed to create testset\")\n",
     "else:\n",
-    "    print(f\"✅ Testset created with ID: {testset.id}\")\n",
+    "    print(f\"✅ Testset revision created with ID: {testset.id}\")\n",
     "    print(f\"   Contains {len(test_data)} test cases\\n\")"
    ]
   },

--- a/examples/jupyter/evaluation/testset-management.ipynb
+++ b/examples/jupyter/evaluation/testset-management.ipynb
@@ -90,13 +90,13 @@
    "id": "e2b89655",
    "metadata": {},
    "outputs": [],
-   "source": "# Create a testset with simple data\ntestset = await ag.testsets.acreate(\n    data=[\n        {\"country\": \"Germany\", \"capital\": \"Berlin\"},\n        {\"country\": \"France\", \"capital\": \"Paris\"},\n        {\"country\": \"Spain\", \"capital\": \"Madrid\"},\n        {\"country\": \"Italy\", \"capital\": \"Rome\"},\n        {\"country\": \"Japan\", \"capital\": \"Tokyo\"},\n    ],\n    name=\"Country Capitals\",\n)\n\nprint(f\"✅ Created testset with ID: {testset.id}\")\nprint(f\"   Name: {testset.name}\")\nprint(f\"   Slug: {testset.slug}\")\n\n# Save the ID for later use\ntestset_id = testset.id"
+   "source": "# Create a testset with simple data\ntestset = await ag.testsets.acreate(\n    data=[\n        {\"country\": \"Germany\", \"capital\": \"Berlin\"},\n        {\"country\": \"France\", \"capital\": \"Paris\"},\n        {\"country\": \"Spain\", \"capital\": \"Madrid\"},\n        {\"country\": \"Italy\", \"capital\": \"Rome\"},\n        {\"country\": \"Japan\", \"capital\": \"Tokyo\"},\n    ],\n    name=\"Country Capitals\",\n)\n\nprint(f\"✅ Created testset with ID: {testset.id}\")\nprint(f\"   Name: {testset.name}\")\nprint(f\"   Slug: {testset.slug}\")\n\n# Save the parent testset ID for later use\ntestset_id = testset.testset_id or testset.id"
   },
   {
    "cell_type": "markdown",
    "id": "852d13a8",
    "metadata": {},
-   "source": "**Expected Output:**\n```\n✅ Created testset with ID: 01963413-3d39-7650-80ce-3ad5d688da6c\n   Name: Country Capitals\n   Slug: 3ad5d688da6c\n```\n\nThe `acreate` function returns a `TestsetRevision` object with the following fields:\n- `id`: Unique UUID for the testset\n- `name`: The name you provided\n- `slug`: A shortened identifier\n- `data`: The test data in a structured format"
+   "source": "**Expected Output:**\n```\n✅ Created testset with ID: 01963413-3d39-7650-80ce-3ad5d688da6c\n   Name: Country Capitals\n   Slug: 3ad5d688da6c\n```\n\nThe `acreate` function returns a `TestsetRevision` object with the following fields:\n- `id`: The revision UUID\n- `testset_id`: The parent testset UUID\n- `version`: The revision version\n- `name`: The name you provided\n- `slug`: A shortened identifier\n- `data`: The test data in a structured format"
   },
   {
    "cell_type": "markdown",


### PR DESCRIPTION
## Summary
- Updates evaluation + testset docs/examples to use the current async SDK (`ag.init`, `ag.testsets.*`, `aevaluate`) instead of legacy `client.testsets.*` and legacy `/api/testsets/*` endpoints.
- Fixes code blocks so they run as regular Python scripts (wrap async examples with `asyncio.run(...)`), while still working in notebooks/Colab.
- Clarifies testset versioning by distinguishing `testset_id` (stable) from revision `id` (changes per update).

## Why
Legacy `/api/testsets/*` endpoints are deprecated and currently problematic; these docs were still guiding users toward the old API shape.

## Validation
- Verified against production (`https://cloud.agenta.ai`) using `uv run` scripts (SDK CRUD + direct API calls + `aevaluate`).

## Notes
- API reference docs remain auto-generated from OpenAPI; this PR does not manually edit them.