### PR TITLE
[3452] fix(frontend): update testset API modal to preview endpoints

### DIFF
--- a/web/oss/src/code_snippets/testsets/create_with_json/curl.ts
+++ b/web/oss/src/code_snippets/testsets/create_with_json/curl.ts
@@ -3,12 +3,17 @@ import {isDemo} from "@/oss/lib/helpers/utils"
 export default function cURLCode(uri: string, params: string): string {
     return `curl -X POST ${uri} \
 -H 'Content-Type: application/json' \
-${!isDemo() ? "" : "-H 'Authorization: your_api_key'"} \
+ ${!isDemo() ? "" : "-H 'Authorization: your_api_key'"} \
 -d '{
-        "name": "your_testset_name",
-        "csvdata": [
-            {"column1": "value1", "column2": "value2"},
-            {"column1": "value3", "column2": "value4"}
-        ]
+        "testset": {
+            "slug": "your-testset-slug",
+            "name": "your_testset_name",
+            "data": {
+                "testcases": [
+                    {"data": {"column1": "value1", "column2": "value2"}},
+                    {"data": {"column1": "value3", "column2": "value4"}}
+                ]
+            }
+        }
     }'`
 }

--- a/web/oss/src/code_snippets/testsets/create_with_json/python.ts
+++ b/web/oss/src/code_snippets/testsets/create_with_json/python.ts
@@ -5,17 +5,23 @@ export default function pythonCode(uri: string, params: string): string {
 import json
 
 url = '${uri}'
+
 data = {
-    "name": "your_testset_name",
-    "csvdata": [
-        {"column1": "value1", "column2": "value2"},
-        {"column1": "value3", "column2": "value4"}
-    ]
+    "testset": {
+        "slug": "your-testset-slug",
+        "name": "your_testset_name",
+        "data": {
+            "testcases": [
+                {"data": {"column1": "value1", "column2": "value2"}},
+                {"data": {"column1": "value3", "column2": "value4"}},
+            ]
+        },
+    }
 }
 
-response = requests.post(url, data=json.dumps(data), headers={'Content-Type': 'application/json'${
-        !isDemo() ? "" : ", 'Authorization': 'your_api_key'"
-    }})
+headers = {'Content-Type': 'application/json'${!isDemo() ? "" : ", 'Authorization': 'your_api_key'"}}
+
+response = requests.post(url, data=json.dumps(data), headers=headers)
 
 print(response.status_code)
 print(response.json())

--- a/web/oss/src/code_snippets/testsets/create_with_json/typescript.ts
+++ b/web/oss/src/code_snippets/testsets/create_with_json/typescript.ts
@@ -6,12 +6,18 @@ export default function tsCode(uri: string, params: string): string {
     const codeString = `import axios from 'axios';
 
 const url = '${uri}';
+
 const data = {
-    name: 'your_testset_name',
-    csvdata: [
-        {column1: 'value1', column2: 'value2'},
-        {column1: 'value3', column2: 'value4'}
-    ]
+    testset: {
+        slug: 'your-testset-slug',
+        name: 'your_testset_name',
+        data: {
+            testcases: [
+                {data: {column1: 'value1', column2: 'value2'}},
+                {data: {column1: 'value3', column2: 'value4'}},
+            ],
+        },
+    },
 };
 
 axios.post(url, data${!isDemo() ? "" : ", {headers: {Authorization: 'your_api_key'}}"})

--- a/web/oss/src/code_snippets/testsets/create_with_upload/curl.ts
+++ b/web/oss/src/code_snippets/testsets/create_with_upload/curl.ts
@@ -1,9 +1,10 @@
 import {isDemo} from "@/oss/lib/helpers/utils"
 
 export default function cURLCode(uri: string): string {
-    return `curl -X POST ${uri} \\
--H 'Content-Type: multipart/form-data' \\
--F 'file=@/oss/path/to/your/file.csv' \\
--F 'testset_name=your_testset_name' \\
+    return `curl -X POST ${uri} \
+-H 'Content-Type: multipart/form-data' \
+-F 'file=@/oss/path/to/your/file.csv' \
+-F 'file_type=csv' \
+-F 'testset_name=your_testset_name' \
 ${!isDemo() ? "" : "-H 'Authorization: your_api_key'"}`
 }

--- a/web/oss/src/code_snippets/testsets/create_with_upload/python.ts
+++ b/web/oss/src/code_snippets/testsets/create_with_upload/python.ts
@@ -9,7 +9,10 @@ testset_name = 'your_testset_name'
 
 with open(file_path, 'rb') as file:
     files = {'file': file}
-    data = {'testset_name': testset_name}
+    data = {
+        'testset_name': testset_name,
+        'file_type': 'csv',
+    }
     response = requests.post(url, files=files, data=data${
         !isDemo() ? "" : ", headers={'Authorization': 'your_api_key'}"
     })

--- a/web/oss/src/code_snippets/testsets/create_with_upload/typescript.ts
+++ b/web/oss/src/code_snippets/testsets/create_with_upload/typescript.ts
@@ -13,6 +13,7 @@ export default function tsCode(uri: string): string {
 
     const formData = new FormData();
     formData.append('file', fs.createReadStream(filePath));
+    formData.append('file_type', 'csv');
     formData.append('testset_name', testsetName);
 
     const config = {

--- a/web/oss/src/components/pages/testset/modals/CreateTestsetFromApi.tsx
+++ b/web/oss/src/components/pages/testset/modals/CreateTestsetFromApi.tsx
@@ -73,11 +73,21 @@ const CreateTestsetFromApi: React.FC<Props> = ({setCurrent, onCancel}) => {
     const [uploadType, setUploadType] = useState<"csv" | "json">("csv")
     const [selectedLang, setSelectedLang] = useState("python")
 
-    const uploadURI = `${getAgentaApiUrl()}/testsets/upload`
-    const jsonURI = `${getAgentaApiUrl()}/testsets`
+    const uploadURI = `${getAgentaApiUrl()}/preview/simple/testsets/upload`
+    const jsonURI = `${getAgentaApiUrl()}/preview/simple/testsets/`
 
     const params = `{
-    "name": "testset_name",}`
+    "testset": {
+        "slug": "your-testset-slug",
+        "name": "your_testset_name",
+        "data": {
+            "testcases": [
+                {"data": {"column1": "value1", "column2": "value2"}},
+                {"data": {"column1": "value3", "column2": "value4"}}
+            ]
+        }
+    }
+}`
 
     const jsonCodeSnippets: Record<string, string> = {
         python: pythonCode(jsonURI, params),
@@ -116,7 +126,7 @@ const CreateTestsetFromApi: React.FC<Props> = ({setCurrent, onCancel}) => {
                     </Radio.Group>
                 </div>
 
-                <Text>Use this endpoint to create a new Testset for your App using JSON</Text>
+                <Text>Use these endpoints to create a testset via JSON or upload a file</Text>
 
                 <div>
                     <Tabs


### PR DESCRIPTION
## Summary
- Updates the “Create a testset with API” modal to use `/api/preview/simple/testsets/*` endpoints instead of legacy `/api/testsets/*`.
- Updates the embedded code snippets (Python/TypeScript/cURL) to match the preview/simple payload shape and multipart upload parameters.

## Why
The modal currently instructs users to call legacy testset endpoints that are deprecated (and in at least one case currently erroring). This PR aligns the UI with the current backend + SDK behavior and the updated docs.

## Changes
- `web/oss/src/components/pages/testset/modals/CreateTestsetFromApi.tsx`
- `web/oss/src/code_snippets/testsets/create_with_json/*`
- `web/oss/src/code_snippets/testsets/create_with_upload/*`

## Validation
- `pnpm lint-fix` (in `web/`)

## Follow-ups
This does not change the Playground “load testset” flow; that still uses legacy `fetchTestset`/`csvdata` and is tracked separately.