### PR TITLE
fix(api): invalidate entitlements cache on plan switch

### DIFF
--- a/api/ee/src/core/subscriptions/service.py
+++ b/api/ee/src/core/subscriptions/service.py
@@ -9,6 +9,7 @@ import stripe
 
 from oss.src.utils.logging import get_module_logger
 from oss.src.utils.env import env
+from oss.src.utils.caching import invalidate_cache
 
 from ee.src.core.subscriptions.types import (
     SubscriptionDTO,
@@ -304,5 +305,11 @@ class SubscriptionsService:
             raise EventException(
                 f"Invalid subscription event {event} for organization ID: {organization_id}"
             )
+
+        # Invalidate the entitlements subscription cache so the new plan takes effect immediately
+        await invalidate_cache(
+            namespace="entitlements:subscription",
+            key={"organization_id": organization_id},
+        )
 
         return subscription


### PR DESCRIPTION
## Summary

- Add cache invalidation for entitlements subscription cache when a plan is switched
- Ensures that plan changes (upgrades/downgrades) take effect immediately without waiting for cache expiry

## Problem

When a user switched their subscription plan (e.g., from Pro to Business), the entitlements cache was not being invalidated. This caused:
- The old plan's entitlements to remain in effect
- Features like SSO and Domains to be blocked even after upgrading to Business
- Users had to wait for cache expiry or manually clear Redis to see their new plan's features

## Solution

Added a call to `invalidate_cache()` at the end of `process_event()` in the subscription service, which clears the `entitlements:subscription` cache for the organization after any subscription event is processed.

## Testing

1. Create a new organization with Pro plan
2. Try to access SSO settings (should be blocked)
3. Upgrade to Business plan
4. SSO settings should now be accessible immediately (no Redis flush needed)

https://github.com/user-attachments/assets/75b0fb39-37ff-4055-97e2-ce3db7dac00f



