### PR TITLE
docs: minor fixes to testset documentation

### DIFF
--- a/docs/docs/evaluation/evaluation-from-sdk/02-managing-testsets.mdx
+++ b/docs/docs/evaluation/evaluation-from-sdk/02-managing-testsets.mdx
@@ -15,19 +15,6 @@ This guide covers how to create, list, and retrieve testsets using the Agenta SD
   Open in Google Colaboratory
 </GoogleColabButton>
 
-:::tip Async examples
-Agenta's SDK uses async APIs. In Jupyter/Colab you can use top-level `await`. In a regular Python script, wrap async code like this:
-
-```python
-import asyncio
-
-async def main():
-    ...
-
-asyncio.run(main())
-```
-:::
-
 ## Creating a Testset
 
 Use `ag.testsets.acreate()` to create a new testset with data:

--- a/docs/docs/evaluation/managing-test-sets/02-create-programatically.mdx
+++ b/docs/docs/evaluation/managing-test-sets/02-create-programatically.mdx
@@ -5,6 +5,10 @@ description: "Learn how to create test sets using the API or SDK"
 sidebar_position: 2
 ---
 
+:::tip
+For a complete guide on managing test sets with the SDK (including listing, retrieving, and updating), see [Managing Testsets](/evaluation/evaluation-from-sdk/managing-testsets).
+:::
+
 ## Overview
 
 Creating test sets programmatically allows you to automate test set generation, integrate with your CI/CD pipeline, or dynamically generate test cases from existing data sources.

--- a/examples/jupyter/evaluation/testset-management.ipynb
+++ b/examples/jupyter/evaluation/testset-management.ipynb
@@ -15,9 +15,19 @@
    "id": "2430bced",
    "metadata": {},
    "source": [
-    "## Initialize Agenta\n",
+    "## Install and Initialize Agenta\n",
     "\n",
-    "First, let's set up the Agenta client with your API credentials:\n"
+    "First, install the Agenta SDK and set up the client with your API credentials:\n"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "id": "install-agenta",
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "!pip install -qU agenta"
    ]
   },
   {


### PR DESCRIPTION
## Summary

- Add `pip install agenta` to the testset-management Colab notebook
- Remove redundant "Async examples" tip from managing-testsets documentation
- Add cross-reference tip in create-programatically docs pointing to the detailed SDK guide