### PR TITLE
fix(frontend): show email in PostHog replays

### DIFF
--- a/web/oss/src/lib/helpers/analytics/hooks/usePostHogAg.ts
+++ b/web/oss/src/lib/helpers/analytics/hooks/usePostHogAg.ts
@@ -23,6 +23,16 @@ export const usePostHogAg = (): ExtendedPostHog | null => {
     const analyticsId = isDemo() && user?.email ? user.email : baseDistinctId
     const identifiedRef = useRef<string | null>(null)
     const aliasedRef = useRef(false)
+
+    const personProps = useMemo(() => {
+        if (!user?.email) return null
+
+        const props: Record<string, unknown> = {email: user.email}
+        if (user.username) {
+            props.username = user.username
+        }
+        return props
+    }, [user?.email, user?.username])
     const baseCapture = posthog?.capture?.bind(posthog)
     const baseIdentify = posthog?.identify?.bind(posthog)
     const capture: PostHog["capture"] = useCallback(
@@ -64,8 +74,12 @@ export const usePostHogAg = (): ExtendedPostHog | null => {
             aliasedRef.current = true
         }
         identifiedRef.current = analyticsId
-        identify(analyticsId)
-    }, [analyticsId, baseDistinctId, identify, posthog, user?.email])
+        if (personProps) {
+            identify(analyticsId, personProps)
+        } else {
+            identify(analyticsId)
+        }
+    }, [analyticsId, baseDistinctId, identify, personProps, posthog, user?.email])
 
     if (!posthog) return null
     return Object.assign(posthog, {identify, capture}) as ExtendedPostHog


### PR DESCRIPTION
## Summary
This PR sets PostHog person properties when we identify a user.

PostHog shows a UUID in Session Replay when it falls back to `distinct_id`. You can change that in PostHog by setting a person display name property. This PR ensures that the user has an `email` person property so PostHog can display it.

## Background
We identify early with a generated distinct id to avoid losing events when PostHog is configured with `defaultIdentifiedOnly`.

That early identify can show up as a UUID in Session Replay lists. The details panel already shows the email because we can load it later from the profile. The list still uses UUID when PostHog is configured to display `distinct_id`.

PostHog documents that you can change this with Project settings. See "Person display name" in the PostHog docs.

## Fix
When we have a user email, we call `identify` with person properties.
- `email`: The user email.
- `username`: The username when available.

This keeps the early identify behavior. It adds enough data for PostHog to display email.

## Manual QA
1. In PostHog, set Project settings, then Person display name, then choose `email`.
2. Log in to cloud.agenta.ai.
3. Open Session Replay.
4. Confirm the recording list shows the email instead of the UUID.
5. Open the person. Confirm you still see the email in person properties.