### PR TITLE
[#3523] fix(api): fix alembic migration self-loop in OSS self-hosting

### DIFF
--- a/api/oss/databases/postgres/migrations/core/versions/a2b3c4d5e6f7_add_retention_helper_indexes.py
+++ b/api/oss/databases/postgres/migrations/core/versions/a2b3c4d5e6f7_add_retention_helper_indexes.py
@@ -1,7 +1,7 @@
 """Add retention helper indexes on projects
 
 Revision ID: a2b3c4d5e6f7
-Revises: a2b3c4d5e6f7
+Revises: c3b2a1d4e5f6
 Create Date: 2025-01-06 12:00:00.000000
 
 """
@@ -13,7 +13,7 @@ from sqlalchemy import text
 
 # revision identifiers, used by Alembic.
 revision: str = "a2b3c4d5e6f7"
-down_revision: Union[str, None] = "a2b3c4d5e6f7"
+down_revision: Union[str, None] = "c3b2a1d4e5f6"
 branch_labels: Union[str, Sequence[str], None] = None
 depends_on: Union[str, Sequence[str], None] = None
 


### PR DESCRIPTION
## Summary

- Fix alembic migration self-loop that prevented fresh OSS self-hosted deployments from starting
- The migration file `a2b3c4d5e6f7_add_retention_helper_indexes.py` had `down_revision` pointing to itself instead of the previous migration (`c3b2a1d4e5f6`)

## Problem

When setting up Agenta OSS self-hosted following the documentation, the `alembic` container fails with:

```
alembic.util.exc.CommandError: Self-loop is detected in revisions (a2b3c4d5e6f7)
```

## Root Cause

In commit e50dd447, the OSS migration file was created with a copy/paste error where both `revision` and `down_revision` were set to the same value (`a2b3c4d5e6f7`).

## Testing

1. Deployed fresh OSS instance with the bug - reproduced the exact error
2. Applied the fix
3. Redeployed - migrations run successfully and the application starts correctly

Fixes #3523