### PR TITLE
fix(frontend): custom workflow playground crash on Optional array fields

### DIFF
--- a/web/oss/src/lib/shared/variant/genericTransformer/helpers/anyOf.ts
+++ b/web/oss/src/lib/shared/variant/genericTransformer/helpers/anyOf.ts
@@ -6,7 +6,7 @@ import type {
     CompoundMetadata,
 } from "../types"
 
-import {createBaseMetadata, createMetadata} from "./metadata"
+import {createMetadata} from "./metadata"
 import {processObjectSchema} from "./objects"
 import {isSchema} from "./schema"
 
@@ -81,12 +81,15 @@ export function processAnyOfSchema(schema: SchemaProperty): ConfigMetadata {
     // ----- Generic mixed union handling -----
     const nonNullSchemas = schema.anyOf.filter((s) => !("type" in s && s.type === "null"))
 
-    // If there is only one meaningful branch, fall back to previous behaviour
+    // If there is only one meaningful branch, use full metadata creation to preserve
+    // nested structure (e.g., itemMetadata for arrays)
     if (nonNullSchemas.length === 1) {
+        const fullMetadata = createMetadata(nonNullSchemas[0])
         return {
-            ...createBaseMetadata(nonNullSchemas[0]),
-            title: schema.title ?? nonNullSchemas[0].title,
-            description: schema.description ?? nonNullSchemas[0].description,
+            ...fullMetadata,
+            title: schema.title ?? nonNullSchemas[0].title ?? fullMetadata.title,
+            description:
+                schema.description ?? nonNullSchemas[0].description ?? fullMetadata.description,
             nullable: schema.anyOf.length !== nonNullSchemas.length,
         }
     }


### PR DESCRIPTION
## Summary

Fixes a crash in the playground when creating custom workflows that use `PromptTemplate`. The UI failed to render because array fields lost their `itemMetadata` during schema processing.

## The Problem

When the frontend parses an OpenAPI schema, it transforms each field into metadata that describes how to render the UI. The `PromptTemplate` model has a field `input_keys` with type `Optional[List[str]]`. Pydantic converts this to:

```json
{
  "anyOf": [
    {"type": "array", "items": {"type": "string"}},
    {"type": "null"}
  ]
}
```

The code in `anyOf.ts` filters out the null branch (it only marks the field as nullable) and processes the remaining branches. When only one branch remains, it took a shortcut: it called `createBaseMetadata()` to extract basic properties like type, title, and description.

The problem is that `createBaseMetadata()` does not recurse into nested structures. For arrays, it skipped the `items` property entirely. The resulting metadata had no `itemMetadata`, which caused a crash when the UI tried to read `itemMetadata.type`.

## The Fix

Replace `createBaseMetadata()` with `createMetadata()` for single-branch anyOf schemas. The full processor recurses into arrays and creates `itemMetadata` properly.

```diff
-    ...createBaseMetadata(nonNullSchemas[0]),
+    const fullMetadata = createMetadata(nonNullSchemas[0])
+    ...fullMetadata,
```

## Why Completion Apps Were Not Affected

The completion app schema does not include `PromptTemplate` in its request body. It only has simple `inputs`. The frontend never traversed `input_keys`, so it never hit the buggy code path.

Custom workflows include `ag_config`, which references `PromptTemplate`. The frontend processes every field, including `input_keys`, which triggered the crash.

## Testing

1. Created a custom workflow with `PromptTemplate`
2. Verified the playground loads without errors
3. Verified the completion app still works