### PR TITLE
fix(api): fix foreign key violation during OSS first-user signup

### DIFF
--- a/api/oss/src/core/auth/supertokens/overrides.py
+++ b/api/oss/src/core/auth/supertokens/overrides.py
@@ -55,8 +55,10 @@ from oss.src.core.auth.service import AuthService
 from oss.src.services.exceptions import UnauthorizedException
 from oss.src.services.db_manager import (
     get_user_with_email,
-    check_if_user_exists_and_create_organization,
     check_if_user_invitation_exists,
+    is_first_user_signup,
+    get_oss_organization,
+    setup_oss_organization_for_first_user,
 )
 
 log = get_module_logger(__name__)
@@ -236,28 +238,53 @@ async def _create_account(email: str, uid: str) -> bool:
         "email": email,
     }
 
-    # For OSS: compute organization before calling create_accounts
     # For EE: organization is created inside create_accounts
+    # For OSS: we need to handle first user specially to avoid FK violation
     if is_ee():
         await create_accounts(payload)
     else:
-        # OSS: Compute or get the single organization
-        organization_db = await check_if_user_exists_and_create_organization(
-            user_email=email
-        )
+        # OSS: Check if this is the first user signup
+        first_user = await is_first_user_signup()
 
-        # Verify user can join (invitation check)
-        user_invitation_exists = await check_if_user_invitation_exists(
-            email=email,
-            organization_id=str(organization_db.id),
-        )
-        if not user_invitation_exists:
-            raise UnauthorizedException(
-                detail="You need to be invited by the organization owner to gain access."
+        if first_user:
+            # First user: Create user first, then organization
+            # This avoids the FK violation where org.owner_id references non-existent user
+            user_db = await create_accounts(payload)
+
+            # Now create organization with the real user ID
+            organization_db = await setup_oss_organization_for_first_user(
+                user_id=user_db.id,
+                user_email=email,
             )
 
-        payload["organization_id"] = str(organization_db.id)
-        await create_accounts(payload)
+            # Assign user to organization
+            from oss.src.services.db_manager import _assign_user_to_organization_oss
+
+            await _assign_user_to_organization_oss(
+                user_db=user_db,
+                organization_id=str(organization_db.id),
+                email=email,
+            )
+        else:
+            # Not first user: Get existing organization and check invitation
+            organization_db = await get_oss_organization()
+            if not organization_db:
+                raise UnauthorizedException(
+                    detail="No organization found. Please contact the administrator."
+                )
+
+            # Verify user can join (invitation check)
+            user_invitation_exists = await check_if_user_invitation_exists(
+                email=email,
+                organization_id=str(organization_db.id),
+            )
+            if not user_invitation_exists:
+                raise UnauthorizedException(
+                    detail="You need to be invited by the organization owner to gain access."
+                )
+
+            payload["organization_id"] = str(organization_db.id)
+            await create_accounts(payload)
 
     if env.posthog.enabled and env.posthog.api_key:
         try:

--- a/api/oss/src/services/db_manager.py
+++ b/api/oss/src/services/db_manager.py
@@ -1060,8 +1060,74 @@ async def get_user(user_uid: str) -> UserDB:
         return user
 
 
+async def is_first_user_signup() -> bool:
+    """Check if this is the first user signing up (no users exist yet)."""
+    async with engine.core_session() as session:
+        total_users = (
+            await session.scalar(select(func.count()).select_from(UserDB)) or 0
+        )
+        return total_users == 0
+
+
+async def get_oss_organization() -> Optional[OrganizationDB]:
+    """Get the single OSS organization if it exists."""
+    organizations_db = await get_organizations()
+    if organizations_db:
+        return organizations_db[0]
+    return None
+
+
+async def setup_oss_organization_for_first_user(
+    user_id: uuid.UUID,
+    user_email: str,
+) -> OrganizationDB:
+    """
+    Setup the OSS organization for the first user.
+
+    This should only be called after the user has been created.
+
+    Args:
+        user_id: The UUID of the newly created user
+        user_email: The email of the user (for analytics)
+
+    Returns:
+        OrganizationDB: The created organization
+    """
+    organization_db = await create_organization(
+        name="Organization",
+        owner_id=user_id,
+        created_by_id=user_id,
+    )
+    workspace_db = await create_workspace(
+        name="Default",
+        organization_id=str(organization_db.id),
+    )
+
+    # update default project with organization and workspace ids
+    await create_or_update_default_project(
+        values_to_update={
+            "organization_id": organization_db.id,
+            "workspace_id": workspace_db.id,
+            "project_name": "Default",
+        }
+    )
+
+    analytics_service.capture_oss_deployment_created(
+        user_email=user_email,
+        organization_id=str(organization_db.id),
+    )
+
+    return organization_db
+
+
 async def check_if_user_exists_and_create_organization(user_email: str):
-    """Check if a user with the given email exists and if not, create a new organization for them."""
+    """
+    Check if a user with the given email exists and if not, create a new organization for them.
+
+    DEPRECATED: This function has a bug where it creates an organization before the user exists,
+    causing FK violations. Use is_first_user_signup() + setup_oss_organization_for_first_user() instead.
+    Kept for backward compatibility but should not be called for new signups.
+    """
 
     async with engine.core_session() as session:
         user_query = await session.execute(select(UserDB).filter_by(email=user_email))


### PR DESCRIPTION
## Summary

Fixes a foreign key violation that prevented the first user from signing up in OSS self-hosted deployments.

## Problem

When the first user signs up in OSS, the signup flow tried to create the organization before creating the user. This caused a database error because `organizations.owner_id` has a foreign key constraint referencing `users.id`.

```
sqlalchemy.exc.IntegrityError: insert or update on table "organizations" 
violates foreign key constraint "fk_organizations_owner_id_users"
DETAIL: Key (owner_id)=(...) is not present in table "users".
```

## Root Cause

In `_create_account()` (overrides.py), the OSS code path called `check_if_user_exists_and_create_organization()` before calling `create_accounts()`. The organization creation generated a random UUID for `owner_id` that did not exist in the users table.

## Solution

Restructure the first-user signup flow to match the EE pattern:

1. Check if this is the first user (no users exist)
2. If first user: create the user first, then create the organization with the real user ID
3. If not first user: use the existing organization (unchanged)

## Changes

- `db_manager.py`: Added helper functions `is_first_user_signup()`, `get_oss_organization()`, and `setup_oss_organization_for_first_user()`
- `overrides.py`: Updated `_create_account()` to handle first-user signup correctly

## Testing

Tested on a fresh OSS deployment. First user signup now works. Organization is created with the correct owner_id pointing to the newly created user.

## Risk to EE

None. The changes are guarded by `is_ee()` checks. The EE code path in `_create_account()` remains unchanged.