### PR TITLE
fix(web): skip post-signup page redirect in OSS

### DIFF
--- a/web/oss/src/hooks/usePostAuthRedirect.ts
+++ b/web/oss/src/hooks/usePostAuthRedirect.ts
@@ -95,14 +95,22 @@ const usePostAuthRedirect = () => {
                 if (isInvitedUser) {
                     console.log("[post-auth] redirect invited new user -> /workspaces/accept")
                     await router.push("/workspaces/accept?survey=true")
-                } else {
+                } else if (isEE()) {
+                    // EE: Show post-signup survey/onboarding form
                     console.log("[post-auth] redirect new user -> /post-signup")
                     writePostSignupPending()
                     await resetAuthState()
                     setIsNewUser(true)
                     await router.push("/post-signup")
+                } else {
+                    // OSS: Skip post-signup, go directly to workspace
+                    console.log("[post-auth] OSS new user, skipping post-signup")
+                    setIsNewUser(true)
+                    // Fall through to normal workspace redirect logic below
                 }
-                return
+                if (isInvitedUser || isEE()) {
+                    return
+                }
             }
 
             if (isInvitedUser) {


### PR DESCRIPTION
## Summary

Fixes a 404 error that occurred after the first user signed up in OSS.

## Problem

After signing up, new users in OSS were redirected to `/post-signup`. This page only exists in EE (it shows a survey and onboarding form). In OSS, users saw a 404 error.

## Solution

Check `isEE()` before redirecting to `/post-signup`. In OSS, new users now skip this step and go directly to their workspace.

## Changes

- `usePostAuthRedirect.ts`: Added `isEE()` check before the post-signup redirect

## Code Change

```typescript
if (isNewUser) {
    if (isInvitedUser) {
        await router.push("/workspaces/accept?survey=true")
    } else if (isEE()) {
        // EE: Show post-signup survey (unchanged)
        await router.push("/post-signup")
    } else {
        // OSS: Skip post-signup, go to workspace
    }
}
```

## Testing

Tested on a fresh OSS deployment. After signup, users now land on their workspace instead of a 404 page.

## Risk to EE

None. The EE code path is explicitly preserved with the `isEE()` check.