### PR TITLE
[#3492] fix(frontend): redirect to apps list when switching orgs from playground

### DIFF
--- a/web/oss/src/state/org/hooks.ts
+++ b/web/oss/src/state/org/hooks.ts
@@ -148,7 +148,17 @@ export const useOrgData = () => {
                 // Extract the current page path to preserve navigation context
                 const projectId = lastUsedProjectId ?? preferredProject?.project_id
                 const currentPathMatch = router.asPath.match(/\/p\/[^/]+\/(.*)/)
-                const currentPagePath = currentPathMatch?.[1]?.split("?")[0] ?? "apps"
+                let currentPagePath = currentPathMatch?.[1]?.split("?")[0] ?? "apps"
+
+                // Redirect to apps list if on app-specific pages (playground, variants, etc.)
+                // These pages reference app IDs that may not exist in the new organization
+                const isAppSpecificPage =
+                    /^apps\/[^/]+\/(playground|overview|evaluations|traces|variants)/.test(
+                        currentPagePath,
+                    )
+                if (isAppSpecificPage) {
+                    currentPagePath = "apps"
+                }
 
                 let href: string
                 if (projectId) {


### PR DESCRIPTION
## Summary

- When switching organizations from app-specific pages (playground, overview, evaluations, traces, variants), redirect to the apps list instead of trying to navigate to the same app path
- This prevents the Playground from breaking when the app ID doesn't exist in the new organization

## Context

When a user is on a Playground page like `/w/orgA/p/projA/apps/appA/playground` and switches to another organization, the system tries to navigate to `/w/orgB/p/projB/apps/appA/playground`. If `appA` doesn't exist in the new organization, the Playground crashes.

## Test plan

- [x] Switch orgs from Playground page → navigates to apps list
- [x] Switch orgs from app overview page → navigates to apps list
- [x] Switch orgs from apps list page → stays on apps list
- [x] Switch orgs from settings page → stays on settings page

Fixes #3492