### PR TITLE
[#3525] fix(api): return 404 for non-existent testset in PUT endpoint

### DIFF
--- a/api/oss/src/apis/fastapi/testsets/router.py
+++ b/api/oss/src/apis/fastapi/testsets/router.py
@@ -16,14 +16,13 @@ from fastapi import (
     File,
     Form,
     Query,
-    Depends,
     HTTPException,
 )
 
 from oss.src.utils.common import is_ee
 from oss.src.utils.logging import get_module_logger
 from oss.src.utils.exceptions import intercept_exceptions, suppress_exceptions
-from oss.src.utils.caching import get_cache, set_cache, invalidate_cache
+from oss.src.utils.caching import set_cache
 
 from oss.src.apis.fastapi.shared.utils import compute_next_windowing
 
@@ -35,27 +34,10 @@ from oss.src.core.testcases.dtos import (
 )
 from oss.src.core.testsets.dtos import (
     TestsetFlags,
-    Testset,
-    TestsetCreate,
-    TestsetEdit,
-    TestsetQuery,
-    #
-    TestsetVariant,
-    TestsetVariantCreate,
-    TestsetVariantEdit,
-    TestsetVariantQuery,
-    #
     TestsetRevisionData,
-    TestsetRevision,
-    TestsetRevisionCreate,
-    TestsetRevisionEdit,
-    TestsetRevisionQuery,
-    TestsetRevisionCommit,
-    #
     SimpleTestset,
     SimpleTestsetCreate,
     SimpleTestsetEdit,
-    SimpleTestsetQuery,
 )
 from oss.src.core.testsets.service import (
     TestsetsService,
@@ -91,9 +73,6 @@ from oss.src.apis.fastapi.testsets.models import (
     SimpleTestsetsResponse,
 )
 from oss.src.apis.fastapi.testsets.utils import (
-    parse_testset_revision_retrieve_request_from_params,
-    parse_testset_revision_retrieve_request_from_body,
-    #
     csv_file_to_json_array,
     json_file_to_json_array,
     json_array_to_json_object,
@@ -1540,7 +1519,24 @@ class SimpleTestsetsRouter:
                 raise FORBIDDEN_EXCEPTION  # type: ignore
 
         if str(testset_id) != str(simple_testset_edit_request.testset.id):
-            return SimpleTestsetResponse()
+            raise HTTPException(
+                status_code=status.HTTP_400_BAD_REQUEST,
+                detail="Testset ID in path does not match testset ID in request body.",
+            )
+
+        # Check if testset exists before attempting to edit
+        existing_testset = (
+            await self.simple_testsets_service.testsets_service.fetch_testset(
+                project_id=UUID(request.state.project_id),
+                testset_ref=Reference(id=testset_id),
+            )
+        )
+
+        if existing_testset is None:
+            raise HTTPException(
+                status_code=status.HTTP_404_NOT_FOUND,
+                detail=f"Testset with ID '{testset_id}' does not exist.",
+            )
 
         _normalize_testcase_dedup_ids_in_request(
             simple_testset_edit_request.testset.data.testcases


### PR DESCRIPTION
## Summary

- Return 404 Not Found when attempting to edit a testset that doesn't exist
- Return 400 Bad Request when the testset ID in the path doesn't match the ID in the request body
- Check testset existence before attempting to edit

## Context

The PUT `/preview/simple/testsets/:id` endpoint was returning `200 OK` with `{"count": 0}` when the testset ID does not exist. This is semantically incorrect:

1. A 200 status means the request succeeded, but no resource was updated
2. Clients expect 2xx responses to indicate success
3. Status codes exist to avoid parsing the response body to detect failures
4. HTTP status codes drive alerting and dashboards; a 200 won't trigger error alerts

## Test plan

- [x] PUT with non-existent testset ID → returns 404 Not Found
- [x] PUT with mismatched path/body IDs → returns 400 Bad Request
- [x] PUT with valid testset ID → returns 200 OK with updated testset

Fixes #3525
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/agenta-ai/agenta/pull/3544">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open with Devin">
  </picture>
</a>
<!-- devin-review-badge-end -->
