### PR TITLE
feat(frontend): add 'New evaluation' button and setup modal to SDK Evals tab

### DIFF
--- a/web/oss/src/components/EvaluationRunsTablePOC/atoms/context.ts
+++ b/web/oss/src/components/EvaluationRunsTablePOC/atoms/context.ts
@@ -33,7 +33,7 @@ export interface EvaluationRunsTableContext {
     activeAppId: string | null
     storageKey: string
     createSupported: boolean
-    createEvaluationType: "auto" | "human" | "online"
+    createEvaluationType: "auto" | "human" | "online" | "custom"
 }
 
 export const defaultEvaluationRunsTableOverrides: EvaluationRunsTableOverrides = {
@@ -109,10 +109,17 @@ export const evaluationRunsTableContextAtom = atom<EvaluationRunsTableContext>((
     const appSegment = scope === "app" ? (explicitAppId ?? "app") : (explicitAppId ?? "all-apps")
     const scopeId = `${projectSegment}::${appSegment}::${evaluationKind}`
     const storageKey = `evaluation-runs:columns:${scopeId}`
-    const standardCreateSupported = isAutoOrHuman || evaluationKind === "online"
+    const standardCreateSupported =
+        isAutoOrHuman || evaluationKind === "online" || evaluationKind === "custom"
     const createSupported = evaluationKind === "all" ? true : standardCreateSupported
     const createEvaluationType =
-        evaluationKind === "human" ? "human" : evaluationKind === "online" ? "online" : "auto"
+        evaluationKind === "custom"
+            ? "custom"
+            : evaluationKind === "human"
+              ? "human"
+              : evaluationKind === "online"
+                ? "online"
+                : "auto"
 
     const context: EvaluationRunsTableContext = {
         projectId,

--- a/web/oss/src/components/EvaluationRunsTablePOC/components/EvaluationRunsCreateButton.tsx
+++ b/web/oss/src/components/EvaluationRunsTablePOC/components/EvaluationRunsCreateButton.tsx
@@ -12,9 +12,12 @@ import {
 } from "../atoms/view"
 import type {ConcreteEvaluationRunKind} from "../types"
 
-type SupportedCreateType = Extract<ConcreteEvaluationRunKind, "auto" | "human" | "online">
+type SupportedCreateType = Extract<
+    ConcreteEvaluationRunKind,
+    "auto" | "human" | "online" | "custom"
+>
 
-const SUPPORTED_CREATE_TYPES: SupportedCreateType[] = ["auto", "human", "online"]
+const SUPPORTED_CREATE_TYPES: SupportedCreateType[] = ["auto", "human", "online", "custom"]
 
 const createTypeCopy: Record<
     SupportedCreateType,
@@ -34,6 +37,11 @@ const createTypeCopy: Record<
         title: "Live evaluation",
         description: "Send production traffic to variants and compare live metrics.",
         short: "Live",
+    },
+    custom: {
+        title: "SDK evaluation",
+        description: "Run evaluations programmatically using the Agenta SDK.",
+        short: "SDK",
     },
 }
 

--- a/web/oss/src/components/EvaluationRunsTablePOC/components/EvaluationRunsTable/index.tsx
+++ b/web/oss/src/components/EvaluationRunsTablePOC/components/EvaluationRunsTable/index.tsx
@@ -81,6 +81,10 @@ const OnlineEvaluationDrawer = dynamic(
     () => import("@/oss/components/pages/evaluations/onlineEvaluation/OnlineEvaluationDrawer"),
     {ssr: false},
 )
+const SetupEvaluationModal = dynamic(
+    () => import("@/oss/components/pages/evaluations/SetupEvaluationModal"),
+    {ssr: false},
+)
 const InactiveTablePlaceholder = ({className}: {className?: string}) => (
     <div className={clsx("flex h-full min-h-0 flex-col gap-4", className)}>
         <div className="flex flex-wrap items-center justify-between gap-3">
@@ -665,7 +669,9 @@ const EvaluationRunsTableActive = ({
             />
 
             {createSupported ? (
-                selectedCreateType === "online" ? (
+                selectedCreateType === "custom" ? (
+                    <SetupEvaluationModal open={isCreateModalOpen} onCancel={closeCreateModal} />
+                ) : selectedCreateType === "online" ? (
                     <OnlineEvaluationDrawer
                         open={isCreateModalOpen}
                         onClose={closeCreateModal}

--- a/web/oss/src/components/pages/evaluations/SetupEvaluationModal/index.tsx
+++ b/web/oss/src/components/pages/evaluations/SetupEvaluationModal/index.tsx
@@ -1,0 +1,162 @@
+import {useState} from "react"
+
+import {CloseOutlined} from "@ant-design/icons"
+import {Book, Play} from "@phosphor-icons/react"
+import {Button, ModalProps, Typography} from "antd"
+
+import EnhancedModal from "@/oss/components/EnhancedUIs/Modal"
+import ApiKeyInput from "@/oss/components/pages/app-management/components/ApiKeyInput"
+import {useStyles} from "@/oss/components/pages/app-management/modals/SetupTracingModal/assets/styles"
+import {TracingCodeComponent} from "@/oss/components/pages/app-management/modals/SetupTracingModal/components/TracingCodeComponent"
+
+const {Text, Title} = Typography
+
+const CODE_SNIPPET = `import asyncio
+import agenta as ag
+from agenta.sdk.evaluations import aevaluate
+
+# Initialize SDK
+ag.init()
+
+# Define test data
+test_data = [
+    {"country": "Germany", "capital": "Berlin"},
+    {"country": "France", "capital": "Paris"},
+    {"country": "Spain", "capital": "Madrid"},
+    {"country": "Italy", "capital": "Rome"},
+]
+
+# Create application
+@ag.application(
+    slug="capital_finder",
+    name="Capital Finder",
+)
+async def capital_finder(country: str):
+    capitals = {
+        "Germany": "Berlin",
+        "France": "Paris",
+        "Spain": "Madrid",
+        "Italy": "Rome",
+    }
+    return capitals.get(country, "Unknown")
+
+# Create evaluator
+@ag.evaluator(
+    slug="exact_match",
+    name="Exact Match",
+)
+async def exact_match(capital: str, outputs: str):
+    is_correct = outputs == capital
+    return {
+        "score": 1.0 if is_correct else 0.0,
+        "success": is_correct,
+    }
+
+# Run evaluation
+async def main():
+    testset = await ag.testsets.acreate(
+        name="Country Capitals",
+        data=test_data,
+    )
+
+    result = await aevaluate(
+        testsets=[testset.id],
+        applications=[capital_finder],
+        evaluators=[exact_match],
+    )
+
+    print(f"Evaluation complete!")
+
+if __name__ == "__main__":
+    asyncio.run(main())`
+
+const SetupEvaluationModalContent = ({
+    classes,
+    onCancel,
+}: {
+    classes: ReturnType<typeof useStyles>
+    onCancel: ModalProps["onCancel"]
+}) => {
+    const [apiKeyValue, setApiKeyValue] = useState("")
+
+    return (
+        <div className="h-full flex flex-col">
+            <div className={classes.modalHeader}>
+                <Button
+                    onClick={() => onCancel?.({} as any)}
+                    type="text"
+                    icon={<CloseOutlined />}
+                />
+                <Text>Evaluate from SDK</Text>
+
+                <div className="flex gap-2 items-center">
+                    <Button
+                        icon={<Play size={16} className="mt-1" />}
+                        href="https://colab.research.google.com/github/agenta-ai/agenta/blob/main/examples/jupyter/evaluation/quick-start.ipynb"
+                        target="_blank"
+                    >
+                        Run in colab
+                    </Button>
+                    <Button
+                        target="_blank"
+                        href="https://agenta.ai/docs/evaluation/evaluation-from-sdk/quick-start"
+                        icon={<Book size={16} className="mt-1" />}
+                    >
+                        Read the docs
+                    </Button>
+                </div>
+            </div>
+            <div className={classes.modalBody}>
+                <div className="flex flex-col gap-1 mb-4">
+                    <Title style={{margin: 0}}>Evaluate from SDK</Title>
+                    <Text>
+                        Evaluate complex AI apps to compare changes and ensure they are reliable.
+                    </Text>
+                </div>
+
+                <ApiKeyInput apiKeyValue={apiKeyValue} onApiKeyChange={setApiKeyValue} />
+
+                <div className="flex flex-col gap-4 mt-4">
+                    <TracingCodeComponent
+                        command={{
+                            title: "Install the required packages",
+                            code: "pip install -U agenta",
+                        }}
+                        index={0}
+                    />
+                    <TracingCodeComponent
+                        command={{
+                            title: "Run the evaluation",
+                            code: CODE_SNIPPET,
+                        }}
+                        index={1}
+                    />
+                </div>
+            </div>
+        </div>
+    )
+}
+
+const SetupEvaluationModal = (props: ModalProps) => {
+    const classes = useStyles()
+
+    return (
+        <EnhancedModal
+            footer={null}
+            title={null}
+            className={classes.modalContainer}
+            width={720}
+            closeIcon={null}
+            styles={{
+                container: {
+                    height: 832,
+                },
+            }}
+            {...props}
+        >
+            <SetupEvaluationModalContent classes={classes} onCancel={props.onCancel} />
+        </EnhancedModal>
+    )
+}
+
+export default SetupEvaluationModal


### PR DESCRIPTION
## Summary

- Adds a **"New evaluation"** button to the SDK Evals tab (same position/style as auto/human/online tabs)
- Clicking opens a **SetupEvaluationModal** — same layout as the Setup Tracing modal (EnhancedModal, custom header with close + action buttons, scrollable body)
- Modal content: API key generation, `pip install` command, and a full Python evaluation code snippet
- Header includes "Run in colab" and "Read the docs" links

## Changes

| File | Change |
|------|--------|
| `SetupEvaluationModal/index.tsx` | **New** — Modal component reusing `EnhancedModal`, `ApiKeyInput`, and `TracingCodeComponent` |
| `atoms/context.ts` | Enable `createSupported` for `custom` (SDK) evaluation kind |
| `EvaluationRunsCreateButton.tsx` | Add `"custom"` to supported create types with SDK copy |
| `EvaluationRunsTable/index.tsx` | Wire `SetupEvaluationModal` render for custom type |
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/agenta-ai/agenta/pull/3559">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open with Devin">
  </picture>
</a>
<!-- devin-review-badge-end -->
