### PR TITLE
fix(frontend): correct logo aspect ratio

### DIFF
--- a/web/ee/src/components/PostSignupForm/PostSignupForm.tsx
+++ b/web/ee/src/components/PostSignupForm/PostSignupForm.tsx
@@ -423,7 +423,7 @@ const PostSignupForm = () => {
                     src="/assets/Agenta-logo-full-light.png"
                     alt="agenta-ai"
                     width={114}
-                    height={40}
+                    height={39}
                 />
 
                 <ListOfOrgs

--- a/web/ee/src/pages/get-started/index.tsx
+++ b/web/ee/src/pages/get-started/index.tsx
@@ -14,7 +14,7 @@ export default function GetStartedPage() {
                     src="/assets/Agenta-logo-full-light.png"
                     alt="agenta-ai"
                     width={114}
-                    height={40}
+                    height={39}
                 />
 
                 <ListOfOrgs

--- a/web/oss/src/pages/auth/[[...path]].tsx
+++ b/web/oss/src/pages/auth/[[...path]].tsx
@@ -426,7 +426,7 @@ const Auth = () => {
                     src="/assets/Agenta-logo-full-light.png"
                     alt="agenta-ai"
                     width={114}
-                    height={40}
+                    height={39}
                     className={clsx(["absolute", "top-4 lg:top-14", "left-4 lg:left-14"])}
                 />
                 <div className="h-[680px] w-[400px] flex flex-col justify-start gap-8 mx-auto mt-10">

--- a/web/oss/src/pages/get-started/index.tsx
+++ b/web/oss/src/pages/get-started/index.tsx
@@ -10,7 +10,7 @@ export default function GetStartedPage() {
                     src="/assets/Agenta-logo-full-light.png"
                     alt="agenta-ai"
                     width={114}
-                    height={40}
+                    height={39}
                 />
             </section>
 


### PR DESCRIPTION
## Summary
- Fix logo aspect ratio in get-started, auth, and post-signup pages
- Changed height from 40 to 39 for width=114 to match the actual image aspect ratio (2.96:1)

## Details
The Agenta logo image is 2605x880 pixels (aspect ratio 2.96:1). The previous dimensions of 114x40 gave an aspect ratio of 2.85:1, causing slight horizontal squishing (~4%).

## Stacked on
- #3387 (feat/add-demo-project-choice-to-onboarding-screen)
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/agenta-ai/agenta/pull/3565">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open with Devin">
  </picture>
</a>
<!-- devin-review-badge-end -->
