### PR TITLE
docs: update roadmap and add trace navigation links changelog

### DIFF
--- a/docs/blog/entries/trace-navigation-links.mdx
+++ b/docs/blog/entries/trace-navigation-links.mdx
@@ -1,0 +1,97 @@
+---
+title: "Navigation Links from Traces to App/Environment/Variant"
+slug: trace-navigation-links
+date: 2026-01-28
+tags: [v0.81.0]
+description: "Clickable links in observability traces to navigate directly to the application, variant, and environment that generated each trace."
+---
+
+# Navigation Links from Traces to App/Environment/Variant
+
+## Overview
+
+You can now click directly from any trace to the application, variant, version, or environment that generated it. This makes debugging much faster. Instead of manually searching for which configuration produced a specific output, you can jump there in one click.
+
+This is especially useful when you're investigating production issues. You see a problematic trace, click through to the exact prompt version, and start iterating immediately.
+
+## Key Capabilities
+
+- **Clickable Application Links**: Jump from a trace to the application that generated it
+- **Variant Navigation**: Go directly to the specific variant and version used
+- **Environment Context**: See and navigate to the environment (production, staging, development) where the trace originated
+- **Drawer Integration**: Links appear in both the trace table and the detailed drawer view
+
+## How to Add References to Your Traces
+
+For the navigation links to appear, you need to store references in your traces. Here's how to do it with the Python SDK and OpenTelemetry.
+
+### Using the Python SDK
+
+```python
+import agenta as ag
+
+ag.init()
+
+# Store references to link traces to your configuration
+ag.tracing.store_refs({
+    "application.slug": "my-chatbot",
+    "variant.slug": "gpt-4-optimized",
+    "variant.version": "3",
+    "environment.slug": "production",
+})
+
+# Your LLM calls are now linked to this configuration
+response = client.chat.completions.create(
+    model="gpt-4",
+    messages=[{"role": "user", "content": "Hello!"}]
+)
+```
+
+### Using OpenTelemetry
+
+If you're using OpenTelemetry for instrumentation, add references as span attributes:
+
+```javascript
+import { trace } from '@opentelemetry/api';
+
+const tracer = trace.getTracer('my-app');
+const span = tracer.startSpan('chat-interaction');
+
+// Add references to link the trace
+span.setAttribute('ag.refs.application.slug', 'my-chatbot');
+span.setAttribute('ag.refs.variant.slug', 'gpt-4-optimized');
+span.setAttribute('ag.refs.variant.version', '3');
+span.setAttribute('ag.refs.environment.slug', 'production');
+
+// Your code here
+span.end();
+```
+
+## Available Reference Keys
+
+You can use any combination of these reference keys:
+
+| Category | Keys |
+|----------|------|
+| Application | `application.slug`, `application.id` |
+| Variant | `variant.slug`, `variant.id`, `variant.version` |
+| Environment | `environment.slug`, `environment.id`, `environment.version` |
+
+## Use Cases
+
+### Debug Production Issues
+When a user reports a problem, find the trace and click through to see exactly which prompt version was used. No more guessing or searching through commit history.
+
+### Compare Configurations
+Filter traces by variant, then click through to compare how different configurations perform. Jump between variants to understand what changed.
+
+### Track Deployments
+See which environment generated each trace. Verify that production is running the expected version by clicking through from any trace.
+
+## Getting Started
+
+Learn more about storing references in our documentation:
+
+- [Reference Prompt Versions (Python SDK)](/observability/trace-with-python-sdk/reference-prompt-versions)
+- [Semantic Conventions (OpenTelemetry)](/observability/trace-with-opentelemetry/semantic-conventions)
+- [Observability Overview](/observability/overview)

--- a/docs/blog/main.mdx
+++ b/docs/blog/main.mdx
@@ -10,7 +10,17 @@ import Image from "@theme/IdealImage";
 
 <section class="changelog">
 
+### [Navigation Links from Traces to App/Environment/Variant](/changelog/trace-navigation-links)
 
+_28 January 2026_
+
+**v0.81.0**
+
+You can now click directly from any trace to the application, variant, or environment that generated it. Links appear in both the trace table and drawer view. This makes debugging faster since you can jump straight to the configuration that produced a specific output.
+
+To enable navigation links, store references in your traces using the Python SDK (`ag.tracing.store_refs()`) or OpenTelemetry span attributes. See the [reference prompt versions guide](/observability/trace-with-python-sdk/reference-prompt-versions) for details.
+
+---
 
 ### [Test Set Versioning and New Test Set UI](/changelog/testset-versioning)
 

--- a/docs/src/data/roadmap.ts
+++ b/docs/src/data/roadmap.ts
@@ -26,6 +26,34 @@ export const shippedFeatures: ShippedFeature[] = [
   // Evaluation: 86B7FF
   // Integration: FFA500
   {
+    id: "trace-linking",
+    title: "Navigation Links from Traces to App/Environment/Variant",
+    description:
+      "Clickable links in observability traces to navigate to the application, variant, version, and environment used in each trace. Jump directly to the configuration that generated a specific trace.",
+    changelogPath: "/docs/changelog/trace-navigation-links",
+    shippedAt: "2026-01-28",
+    labels: [
+      {
+        name: "Observability",
+        color: "DE74FF",
+      },
+    ],
+  },
+  {
+    id: "date-range-filtering",
+    title: "Date Range Filtering in Metrics Dashboard",
+    description:
+      "Filter traces by date range in the metrics dashboard. View metrics for the last 6 hours, 24 hours, 7 days, or 30 days.",
+    changelogPath: "/docs/changelog/chat-sessions-observability",
+    shippedAt: "2026-01-09",
+    labels: [
+      {
+        name: "Observability",
+        color: "DE74FF",
+      },
+    ],
+  },
+  {
     id: "testset-versioning",
     title: "Test Set Versioning and New UI",
     description:
@@ -323,15 +351,15 @@ export const shippedFeatures: ShippedFeature[] = [
 ];
 export const inProgressFeatures: PlannedFeature[] = [
   {
-    id: "trace-linking",
-    title: "Navigation Links from Traces to App/Environment/Variant",
+    id: "navigation-in-the-playground",
+    title: "Improving Navigation between Testsets in the Playground",
     description:
-      "Add clickable links in the observability trace and drawer view to navigate to the application, variant, version, and environment used in each trace. Makes it easy to jump directly to the configuration that generated a specific trace.",
-    githubUrl: "https://github.com/Agenta-AI/agenta/discussions/2699",
+      "We are making it easy to use and navigate in the playground with large testsets.",
+    githubUrl: "https://github.com/Agenta-AI/agenta/discussions/2731",
     labels: [
       {
-        name: "Observability",
-        color: "DE74FF",
+        name: "Playground",
+        color: "BCFF78",
       },
     ],
   },
@@ -358,19 +386,6 @@ export const inProgressFeatures: PlannedFeature[] = [
       {
         name: "Playground",
         color: "BCFF78",
-      },
-    ],
-  },
-  {
-    id: "date-range-filtering",
-    title: "Date Range Filtering in Metrics Dashboard",
-    description:
-      "We are adding the ability to filter traces by date range in the metrics dashboard.",
-    githubUrl: "https://github.com/Agenta-AI/agenta/discussions/2774",
-    labels: [
-      {
-        name: "Observability",
-        color: "DE74FF",
       },
     ],
   },
@@ -407,33 +422,6 @@ export const plannedFeatures: PlannedFeature[] = [
       },
     ],
   },
-  {
-    id: "navigation-in-the-playground",
-    title: "Improving Navigation between Testsets in the Playground",
-    description:
-      "We are making it easy to use and navigate in the playground with large testsets  .",
-    githubUrl: "https://github.com/Agenta-AI/agenta/discussions/2731",
-    labels: [
-      {
-        name: "Playground",
-        color: "BCFF78",
-      },
-    ],
-  },
-  {
-    id: "appending-single-test-cases",
-    title: "Appending Single Testcases in the Playground",
-    description:
-      "Using testcases from different testsets is not possible right now in the Playground. We are adding the ability to append a single testcase to a testset.",
-    githubUrl: "https://github.com/Agenta-AI/agenta/discussions/2732",
-    labels: [
-      {
-        name: "Playground",
-        color: "BCFF78",
-      },
-    ],
-  },
-
   {
     id: "prompt-caching-sdk",
     title: "Prompt Caching in the SDK",

--- a/web/oss/src/components/SidebarBanners/data/changelog.json
+++ b/web/oss/src/components/SidebarBanners/data/changelog.json
@@ -1,5 +1,11 @@
 [
     {
+        "id": "changelog-2026-01-28-trace-navigation",
+        "title": "Navigate from Traces to Configs",
+        "description": "Click from any trace to the app, variant, or environment that generated it.",
+        "link": "https://agenta.ai/docs/changelog/trace-navigation-links"
+    },
+    {
         "id": "changelog-2026-01-20-testset-versioning",
         "title": "Test Set Versioning",
         "description": "Track test set changes and link evaluations to specific versions.",


### PR DESCRIPTION
## Summary

- Move **Date Range Filtering in Metrics Dashboard** from in-progress to shipped (links to existing chat-sessions changelog)
- Move **Navigation Links from Traces to App/Environment/Variant** from in-progress to shipped with new changelog entry
- Remove **Appending Single Testcases in the Playground** from roadmap
- Move **Improving Navigation between Testsets in the Playground** from planned to in-progress
- Add detailed changelog entry for trace navigation links feature
- Update sidebar announcement banner

## Changes

| File | Change |
|------|--------|
| `docs/src/data/roadmap.ts` | Updated shipped, in-progress, and planned features |
| `docs/blog/entries/trace-navigation-links.mdx` | New changelog entry with SDK/OpenTelemetry examples |
| `docs/blog/main.mdx` | Added summary entry at top |
| `web/oss/src/components/SidebarBanners/data/changelog.json` | Added announcement |
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/agenta-ai/agenta/pull/3581">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open with Devin">
  </picture>
</a>
<!-- devin-review-badge-end -->
