### PR TITLE
fix(api): backfill evaluator schemas for metrics

### DIFF
--- a/api/oss/src/core/evaluations/service.py
+++ b/api/oss/src/core/evaluations/service.py
@@ -937,7 +937,8 @@ class EvaluationsService:
 
                     steps_metrics_keys[step.key] += [
                         {
-                            "path": "attributes.ag.data." + metric_key.get("path", ""),
+                            "path": "attributes.ag.data.outputs."
+                            + metric_key.get("path", ""),
                             "type": metric_key.get("type", ""),
                         }
                         for metric_key in metrics_keys

--- a/api/oss/src/core/git/dtos.py
+++ b/api/oss/src/core/git/dtos.py
@@ -70,7 +70,7 @@ class RevisionCreate(Slug, Header, Metadata):
 
 
 class RevisionEdit(Identifier, Header, Metadata):
-    pass
+    data: Optional[Data] = None
 
 
 class RevisionQuery(Header, Metadata):

--- a/api/oss/src/dbs/postgres/git/dao.py
+++ b/api/oss/src/dbs/postgres/git/dao.py
@@ -1058,6 +1058,8 @@ class GitDAO(GitDAOInterface):
             revision_dbe.deleted_at = None
             revision_dbe.updated_by_id = user_id
             revision_dbe.deleted_by_id = None
+            if revision_edit.data is not None:
+                revision_dbe.data = revision_edit.data
 
             await session.commit()
 


### PR DESCRIPTION
## Summary
- infer missing evaluator output schemas during annotation creation and persist them to evaluator revisions
- allow revision data updates for schema backfill and align service format metric paths with outputs

## Testing
- not run (ruff unavailable in environment)