### PR TITLE
fix(frontend): correct Learn More doc links for human & online evals

### DIFF
--- a/web/oss/src/components/pages/evaluations/humanEvaluation/EmptyStateHumanEvaluation/EmptyStateHumanEvaluation.tsx
+++ b/web/oss/src/components/pages/evaluations/humanEvaluation/EmptyStateHumanEvaluation/EmptyStateHumanEvaluation.tsx
@@ -17,7 +17,7 @@ const EmptyStateHumanEvaluation = ({onCreateEvaluation}: {onCreateEvaluation: ()
             }}
             secondaryCta={{
                 label: "Learn More",
-                href: "https://docs.agenta.ai/evaluation/human-evaluation",
+                href: "https://agenta.ai/docs/evaluation/human-evaluation/quick-start",
             }}
         />
     )

--- a/web/oss/src/components/pages/evaluations/onlineEvaluation/EmptyStateOnlineEvaluation/EmptyStateOnlineEvaluation.tsx
+++ b/web/oss/src/components/pages/evaluations/onlineEvaluation/EmptyStateOnlineEvaluation/EmptyStateOnlineEvaluation.tsx
@@ -17,7 +17,7 @@ const EmptyStateOnlineEvaluation = ({onCreateEvaluation}: {onCreateEvaluation: (
             }}
             secondaryCta={{
                 label: "Learn More",
-                href: "https://docs.agenta.ai/evaluation/online-evaluation",
+                href: "https://agenta.ai/docs/evaluation/concepts#evaluation-workflows",
             }}
         />
     )


### PR DESCRIPTION
### Summary
Fix broken Learn More links in Human and Online Evaluation empty states
<img width="1318" height="758" alt="Screenshot 2026-01-29 at 1 56 48 PM" src="https://github.com/user-attachments/assets/a9ec4f4c-66e5-48a0-9fab-4b99202afa2c" />

<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/agenta-ai/agenta/pull/3588">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open with Devin">
  </picture>
</a>
<!-- devin-review-badge-end -->
