### PR TITLE
fix(devops)[AGE 3617]: Fix --no-web env loading by resolving ENV_FILE_PATH

### DIFF
--- a/hosting/docker-compose/run.sh
+++ b/hosting/docker-compose/run.sh
@@ -122,11 +122,12 @@ if [[ -z "$ENV_FILE" ]]; then
     ENV_FILE=".env.$LICENSE.$STAGE"
 fi
 
-if [[ "$ENV_FILE" = /* || "$ENV_FILE" == ./* || "$ENV_FILE" == ../* ]]; then
+if [[ "$ENV_FILE" = /* || "$ENV_FILE" == ./* || "$ENV_FILE" == ../* || "$ENV_FILE" == */* ]]; then
     ENV_FILE_PATH="$ENV_FILE"
 else
     ENV_FILE_PATH="./hosting/docker-compose/$LICENSE/$ENV_FILE"
 fi
+
 
 # Export the ENV_FILE to the environment
 export ENV_FILE="$ENV_FILE"


### PR DESCRIPTION
### Summary
Added ENV_FILE_PATH resolution (absolute/relative vs default path) and switched docker compose --env-file to use that resolved path.
In the --no-web flow, it now sources ENV_FILE_PATH before starting the web dev server.

Closes #3603 
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/agenta-ai/agenta/pull/3609" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open with Devin">
  </picture>
</a>
<!-- devin-review-badge-end -->
