### PR TITLE
missing requirement in chain of prompts example, fixes #3618

### DIFF
--- a/examples/python/custom_workflows/chain_of_prompts/requirements.txt
+++ b/examples/python/custom_workflows/chain_of_prompts/requirements.txt
@@ -2,3 +2,4 @@ agenta
 openai
 python-dotenv
 opentelemetry-instrumentation-openai
+uvicorn


### PR DESCRIPTION
added the uvicorn requirement to the chain of prompts workflow python example requirements file