### PR TITLE
fix(frontend)[AGE 3621]: Lock evaluator slug after creation

### DIFF
--- a/web/oss/src/components/SharedDrawers/AnnotateDrawer/assets/CreateEvaluator/index.tsx
+++ b/web/oss/src/components/SharedDrawers/AnnotateDrawer/assets/CreateEvaluator/index.tsx
@@ -330,6 +330,7 @@ const CreateEvaluator = ({
                 >
                     <Input
                         placeholder="Enter a unique slug"
+                        disabled={isEditMode}
                         onChange={() => !slugTouched && setSlugTouched(true)}
                     />
                 </Form.Item>


### PR DESCRIPTION
### Summary
Disables the evaluator slug input in edit mode so only the name remains editable after creation, matching backend immutability.

<img width="839" height="613" alt="Screenshot 2026-02-05 at 9 13 43 AM" src="https://github.com/user-attachments/assets/9be10737-1f7a-4d3e-95a2-fe83c9d85592" />


Closes #3626 