### PR TITLE
[AGE-3070] fix(frontend): Refresh billing entitlements on window focus

### DIFF
--- a/web/ee/src/state/billing/atoms.ts
+++ b/web/ee/src/state/billing/atoms.ts
@@ -29,7 +29,7 @@ export const usageQueryAtom = atomWithQuery((get) => {
             return response.data as DataUsageType
         },
         staleTime: 1000 * 60 * 2, // 2 minutes
-        refetchOnWindowFocus: false,
+        refetchOnWindowFocus: true,
         refetchOnReconnect: false,
         refetchOnMount: true,
         enabled: !!user && !!projectId,
@@ -63,7 +63,7 @@ export const subscriptionQueryAtom = atomWithQuery((get) => {
             return response.data as SubscriptionType
         },
         staleTime: 1000 * 60 * 5, // 5 minutes
-        refetchOnWindowFocus: false,
+        refetchOnWindowFocus: true,
         refetchOnReconnect: false,
         refetchOnMount: true,
         enabled: sessionExists && !!organizationId && !!user && !!projectId,


### PR DESCRIPTION
## Summary

- Enable `refetchOnWindowFocus: true` for subscription and usage queries
- Ensures billing data refreshes when user returns to the app after completing Stripe checkout

## Problem

After upgrading via Stripe checkout (which opens in a new tab), users had to logout/login to see updated entitlements because:
1. Checkout opens in a new tab (`window.open`)
2. Original tab's TanStack Query cache was stale (5 min staleTime)
3. `refetchOnWindowFocus: false` prevented automatic refresh when returning to the tab

## Solution

Enable `refetchOnWindowFocus: true` for both `subscriptionQueryAtom` and `usageQueryAtom`. The `staleTime` settings still prevent excessive refetches - data is only fetched if stale when window regains focus.

## Testing

1. Open billing page
2. Initiate upgrade (opens Stripe in new tab)
3. Complete checkout
4. Switch back to original tab
5. Billing data should refresh automatically

Closes AGE-3070
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/agenta-ai/agenta/pull/3633" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open with Devin">
  </picture>
</a>
<!-- devin-review-badge-end -->
