### PR TITLE
fix(frontend): navigate to demo from any org

### DIFF
--- a/web/ee/src/components/GetStarted/GetStarted.tsx
+++ b/web/ee/src/components/GetStarted/GetStarted.tsx
@@ -10,6 +10,7 @@ import {
     useStyles as useTracingStyles,
 } from "@/oss/components/pages/app-management/modals/SetupTracingModal"
 import {usePostHogAg} from "@/oss/lib/helpers/analytics/hooks/usePostHogAg"
+import {useOrgData} from "@/oss/state/org"
 import {cacheWorkspaceOrgPair} from "@/oss/state/org/selectors/org"
 import {useProjectData} from "@/oss/state/project/hooks"
 import {buildPostLoginPath, waitForWorkspaceContext} from "@/oss/state/url/postLoginRedirect"
@@ -22,11 +23,13 @@ const GetStarted = () => {
     const tracingClasses = useTracingStyles()
     const router = useRouter()
     const posthog = usePostHogAg()
+    const {orgs, changeSelectedOrg} = useOrgData()
     const {projects} = useProjectData()
 
     const demoProject = useMemo(() => projects.find((project) => project.is_demo), [projects])
     const demoWorkspaceId = demoProject?.workspace_id || demoProject?.organization_id || undefined
     const demoOrganizationId = demoProject?.organization_id || undefined
+    const demoOrgId = useMemo(() => orgs.find((org) => org.flags?.is_demo)?.id, [orgs])
 
     const view = useMemo<ViewState>(() => {
         const path = router.query.path
@@ -66,20 +69,33 @@ const GetStarted = () => {
             selection: "demo",
         })
 
-        if (!demoProject || !demoWorkspaceId) {
-            message.error("Demo project is not available.")
+        if (demoProject && demoWorkspaceId) {
+            if (demoOrganizationId) {
+                cacheWorkspaceOrgPair(demoWorkspaceId, demoOrganizationId)
+            }
+            router.push(
+                `/w/${encodeURIComponent(demoWorkspaceId)}/p/${encodeURIComponent(
+                    demoProject.project_id,
+                )}/apps`,
+            )
             return
         }
 
-        if (demoOrganizationId) {
-            cacheWorkspaceOrgPair(demoWorkspaceId, demoOrganizationId)
+        if (demoOrgId) {
+            await changeSelectedOrg(demoOrgId)
+            return
         }
-        router.push(
-            `/w/${encodeURIComponent(demoWorkspaceId)}/p/${encodeURIComponent(
-                demoProject.project_id,
-            )}/apps`,
-        )
-    }, [demoOrganizationId, demoProject, demoWorkspaceId, posthog, router])
+
+        message.error("Demo project is not available.")
+    }, [
+        changeSelectedOrg,
+        demoOrganizationId,
+        demoOrgId,
+        demoProject,
+        demoWorkspaceId,
+        posthog,
+        router,
+    ])
 
     const handleSelection = useCallback(
         async (selection: "trace" | "eval" | "test_prompt") => {


### PR DESCRIPTION
## What changed
- Update Get Started and Home welcome-card demo CTAs to fall back to switching to the demo org when the current workspace’s project list doesn’t include a demo project.
- Keep existing behavior when a demo project is already present in the current projects list.

## Why
When users are currently in a non-demo organization, the in-memory `projects` list is scoped to that org/workspace. That means `projects.find(p => p.is_demo)` can be empty even though a demo org exists and is accessible, which caused a false "Demo project is not available" error.

## How to test
1. Login with a user that has access to the demo org.
2. While selected on a non-demo org, go to `/get-started` and click "Explore demo workspace".
3. On Home, click "Explore demo project" in the welcome cards.
4. Verify both routes take you into the demo workspace/project instead of erroring.

## Lint
- Ran `pnpm lint-fix` in `web/`.
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/agenta-ai/agenta/pull/3640" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open with Devin">
  </picture>
</a>
<!-- devin-review-badge-end -->
