### PR TITLE
[3642] fix(sdk): align Perplexity provider kind

### DIFF
--- a/sdk/agenta/sdk/assets.py
+++ b/sdk/agenta/sdk/assets.py
@@ -161,7 +161,9 @@ supported_llm_models = {
         "openrouter/google/gemini-2.0-flash-001",
         "openrouter/perplexity/sonar-reasoning",
     ],
-    "perplexity": [
+    # NOTE: provider kind must match Secrets API enums ("perplexityai").
+    # Models remain "perplexity/..." but the provider key is used to match secrets.
+    "perplexityai": [
         "perplexity/sonar",
         "perplexity/sonar-pro",
         "perplexity/sonar-reasoning",

--- a/sdk/agenta/sdk/workflows/runners/daytona.py
+++ b/sdk/agenta/sdk/workflows/runners/daytona.py
@@ -131,7 +131,8 @@ class DaytonaRunner(CodeRunner):
             "mistralai": "MISTRALAI_API_KEY",
             "anthropic": "ANTHROPIC_API_KEY",
             "perplexityai": "PERPLEXITYAI_API_KEY",
-            "togetherai": "TOGETHERAI_API_KEY",
+            # Secret kind is "together_ai" (underscore) even though the env var is TOGETHERAI_API_KEY
+            "together_ai": "TOGETHERAI_API_KEY",
             "openrouter": "OPENROUTER_API_KEY",
             "gemini": "GEMINI_API_KEY",
         }

--- a/web/oss/src/components/SelectLLMProvider/index.tsx
+++ b/web/oss/src/components/SelectLLMProvider/index.tsx
@@ -43,7 +43,7 @@ const PROVIDER_ICON_MAP: Record<string, string> = {
     cohere: "Cohere",
     deepinfra: "DeepInfra",
     openrouter: "OpenRouter",
-    perplexity: "Perplexity AI",
+    perplexityai: "Perplexity AI",
     together_ai: "Together AI",
     vertex_ai: "Google Vertex AI",
     bedrock: "AWS Bedrock",


### PR DESCRIPTION
## What
- Align Perplexity model provider kind in the SDK model registry with Secrets API enums (`perplexityai`) so provider settings resolve correctly.
- Fix Perplexity key in the `SelectLLMProvider` icon map (`perplexityai`).
- Fix Together AI secret-kind key in the Daytona runner env var mapping (`together_ai`).

## Why
Perplexity runs could not resolve provider credentials due to a `perplexity` vs `perplexityai` provider-kind mismatch, resulting in `InvalidSecretsV0Error`.

## Notes
- Quick audit found the same kind of mismatch for Together AI in the Daytona runner (`togetherai` vs `together_ai`).

## Testing
- Not run (tests currently disabled in this repo).

Fixes #3642
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/agenta-ai/agenta/pull/3648" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open with Devin">
  </picture>
</a>
<!-- devin-review-badge-end -->
