### PR TITLE
fix(frontend): default Playground new message role to user

### DIFF
--- a/web/oss/src/components/Playground/hooks/usePlayground/assets/messageHelpers.ts
+++ b/web/oss/src/components/Playground/hooks/usePlayground/assets/messageHelpers.ts
@@ -48,7 +48,7 @@ export const createMessageFromSchema = (
                 !Array.isArray(baseValue) &&
                 "value" in baseValue
             ) {
-                ;(baseValue as any).value = ""
+                ;(baseValue as any).value = "user"
             }
 
             const jsonValue = json?.[key] ?? json?.[toSnakeCase(key)]

--- a/web/oss/src/components/Playground/state/atoms/promptMutations.ts
+++ b/web/oss/src/components/Playground/state/atoms/promptMutations.ts
@@ -26,7 +26,7 @@ export const addPromptMessageMutationAtomFamily = atomFamily((compoundKey: strin
         const metadata = parentMetadata?.itemMetadata
         if (!metadata) return
 
-        const newMessage = createMessageFromSchema(metadata, {role: "", content: ""})
+        const newMessage = createMessageFromSchema(metadata, {role: "user", content: ""})
         if (!newMessage) return
 
         // Mutation recipe for molecule-backed prompts


### PR DESCRIPTION
## What
- Default new Playground prompt messages to `role: \"user\"` so the UI never shows an empty/unspecified role.

## Why
- New messages were created with an empty role (`\"\"`), which rendered as "unspecified" and can violate the role enum expectations.

## Changes
- Set role default to `user` when creating a new prompt message.
- Set schema-based role default to `user` when no role is provided.

## Verification
- `corepack pnpm lint-fix` (web)
- Tests not run (repo note: currently not working)
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/agenta-ai/agenta/pull/3653" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open with Devin">
  </picture>
</a>
<!-- devin-review-badge-end -->
