### PR TITLE
fix(api): add missing VIEW permissions to RBAC viewer role

### DIFF
--- a/api/ee/src/models/shared_models.py
+++ b/api/ee/src/models/shared_models.py
@@ -163,12 +163,19 @@ class Permission(str, Enum):
             #
             cls.VIEW_WORKFLOWS,
             cls.VIEW_EVALUATORS,
+            cls.VIEW_QUERIES,
             cls.VIEW_TESTSETS,
             cls.VIEW_ANNOTATIONS,
+            cls.VIEW_INVOCATIONS,
             cls.VIEW_SPANS,
             cls.VIEW_FOLDERS,
             cls.VIEW_API_KEYS,
             cls.VIEW_ENVIRONMENTS,
+            cls.VIEW_EVALUATION_RUNS,
+            cls.VIEW_EVALUATION_SCENARIOS,
+            cls.VIEW_EVALUATION_RESULTS,
+            cls.VIEW_EVALUATION_METRICS,
+            cls.VIEW_EVALUATION_QUEUES,
         ]
         defaults = {
             WorkspaceRole.OWNER: [p for p in cls],


### PR DESCRIPTION
## Summary

- Adds missing VIEW permissions to the viewer role in RBAC: `VIEW_EVALUATION_RUNS`, `VIEW_EVALUATION_SCENARIOS`, `VIEW_EVALUATION_RESULTS`, `VIEW_EVALUATION_METRICS`, `VIEW_EVALUATION_QUEUES`, `VIEW_QUERIES`, `VIEW_INVOCATIONS`.
- Demo members (`is_demo=true`) were getting 403 on read-only endpoints because the RBAC check is always enforced for them (bypasses the "RBAC not entitled" shortcut), and the viewer role lacked these permissions.
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/agenta-ai/agenta/pull/3663" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open with Devin">
  </picture>
</a>
<!-- devin-review-badge-end -->
