### PR TITLE
fix(TraceDrawer): resolve parameter display issue in input view

### DIFF
--- a/web/oss/src/state/newObservability/selectors/tracing.ts
+++ b/web/oss/src/state/newObservability/selectors/tracing.ts
@@ -42,7 +42,15 @@ export const getAgMetaConfiguration = (span?: TraceSpanNode) =>
 
 export const getAgData = (span?: TraceSpanNode) => span?.attributes?.ag?.data ?? null
 
-export const getAgDataInputs = (span?: TraceSpanNode) => getAgData(span)?.inputs ?? null
+export const getAgDataInputs = (span?: TraceSpanNode) => {
+    const inputs = getAgData(span)?.inputs
+    if (!inputs) return null
+
+    const {parameters, ...rest} = inputs
+
+    if (rest.messages) return rest
+    return rest.inputs ?? rest
+}
 
 export const getAgDataOutputs = (span?: TraceSpanNode) => getAgData(span)?.outputs ?? null
 


### PR DESCRIPTION
Resolves an issue where parameters (like model configuration) were inadvertently displayed within the inputs section of the TraceDrawer overview tab.

closes: https://github.com/Agenta-AI/agenta/issues/3570
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/agenta-ai/agenta/pull/3688" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open with Devin">
  </picture>
</a>
<!-- devin-review-badge-end -->
