### PR TITLE
fix(frontend)[AGE-3639]: Onboarding “Start evaluation” bypasses dropdown and starts human eval

### DIFF
--- a/web/oss/src/components/EmptyState/EmptyState.tsx
+++ b/web/oss/src/components/EmptyState/EmptyState.tsx
@@ -16,9 +16,10 @@ export interface EmptyStateProps {
     title: string
     description: string
     primaryCta: {
-        label: string
-        onClick: () => void
+        label?: string
+        onClick?: () => void
         icon?: ReactNode
+        node?: ReactNode
     }
     secondaryCta?: {
         label: string
@@ -129,15 +130,17 @@ const EmptyState = ({
 
                 {/* CTAs */}
                 <div className="mb-8 flex flex-wrap items-center justify-center gap-4">
-                    <Button
-                        type="primary"
-                        size="large"
-                        onClick={primaryCta.onClick}
-                        icon={primaryCta.icon}
-                        className="!px-8"
-                    >
-                        {primaryCta.label}
-                    </Button>
+                    {primaryCta.node ?? (
+                        <Button
+                            type="primary"
+                            size="large"
+                            onClick={primaryCta.onClick}
+                            icon={primaryCta.icon}
+                            className="!px-8"
+                        >
+                            {primaryCta.label}
+                        </Button>
+                    )}
 
                     {secondaryCta ? (
                         <Button

--- a/web/oss/src/components/EvaluationRunsTablePOC/components/EvaluationRunsCreateButton.tsx
+++ b/web/oss/src/components/EvaluationRunsTablePOC/components/EvaluationRunsCreateButton.tsx
@@ -1,7 +1,7 @@
 import {useCallback, useEffect, useMemo} from "react"
 
 import {PlusIcon} from "@phosphor-icons/react"
-import {Button, Dropdown, Tooltip, type MenuProps} from "antd"
+import {Button, Dropdown, Tooltip, type ButtonProps, type MenuProps} from "antd"
 import {useAtom, useAtomValue} from "jotai"
 
 import {
@@ -51,7 +51,17 @@ const isSupportedCreateType = (value: unknown): value is SupportedCreateType => 
 
 const FALLBACK_CREATE_TYPE: SupportedCreateType = "auto"
 
-const EvaluationRunsCreateButton = () => {
+interface EvaluationRunsCreateButtonProps {
+    label?: string
+    size?: ButtonProps["size"]
+    className?: string
+}
+
+const EvaluationRunsCreateButton = ({
+    label,
+    size = "middle",
+    className,
+}: EvaluationRunsCreateButtonProps) => {
     const {createEnabled, createTooltip, evaluationKind, defaultCreateType, scope} = useAtomValue(
         evaluationRunsTableHeaderStateAtom,
     )
@@ -155,8 +165,10 @@ const EvaluationRunsCreateButton = () => {
                             type="primary"
                             icon={<PlusIcon size={16} />}
                             disabled={!createEnabled}
+                            size={size}
+                            className={className}
                         >
-                            New Evaluation
+                            {label ?? "New Evaluation"}
                         </Button>
                     </Dropdown>
                 ) : (
@@ -165,8 +177,10 @@ const EvaluationRunsCreateButton = () => {
                         icon={<PlusIcon size={16} />}
                         disabled={!createEnabled}
                         onClick={openCreateModal}
+                        size={size}
+                        className={className}
                     >
-                        New evaluation
+                        {label ?? "New evaluation"}
                     </Button>
                 )}
             </div>

--- a/web/oss/src/components/EvaluationRunsTablePOC/components/EvaluationRunsTable/index.tsx
+++ b/web/oss/src/components/EvaluationRunsTablePOC/components/EvaluationRunsTable/index.tsx
@@ -448,7 +448,7 @@ const EvaluationRunsTableActive = ({
                 return <EmptyStateSdkEvaluation onOpenSetupModal={openSdkSetupModal} />
             case "all":
             default:
-                return <EmptyStateAllEvaluations onCreateEvaluation={openCreateModal} />
+                return <EmptyStateAllEvaluations />
         }
     }, [
         evaluationKind,

--- a/web/oss/src/components/pages/evaluations/allEvaluations/EmptyStateAllEvaluations/EmptyStateAllEvaluations.tsx
+++ b/web/oss/src/components/pages/evaluations/allEvaluations/EmptyStateAllEvaluations/EmptyStateAllEvaluations.tsx
@@ -1,19 +1,22 @@
-import {Play} from "@phosphor-icons/react"
-
 import EmptyState from "@/oss/components/EmptyState"
 import {EMPTY_STATE_VIDEOS} from "@/oss/components/EmptyState/videos"
+import EvaluationRunsCreateButton from "@/oss/components/EvaluationRunsTablePOC/components/EvaluationRunsCreateButton"
 
-const EmptyStateAllEvaluations = ({onCreateEvaluation}: {onCreateEvaluation: () => void}) => {
+const EmptyStateAllEvaluations = () => {
     return (
         <EmptyState
             videoId={EMPTY_STATE_VIDEOS.evaluation}
-            previewAlt="Evaluation workflow demonstration"
-            title="Get Started with Evaluations"
-            description="Compare prompt versions, catch regressions, and measure quality automatically. Create evaluation templates and let Agenta score your outputs."
+            previewAlt="All evaluation types overview"
+            title="Get Started with All Evaluations"
+            description="Track auto, human, live, and SDK evaluations in one place. Start an evaluation by choosing the type that matches your workflow."
             primaryCta={{
-                label: "Run Evaluation",
-                onClick: onCreateEvaluation,
-                icon: <Play size={16} />,
+                node: (
+                    <EvaluationRunsCreateButton
+                        label="Start evaluation"
+                        size="large"
+                        className="!px-8"
+                    />
+                ),
             }}
             secondaryCta={{
                 label: "Learn More",


### PR DESCRIPTION
### Summary
- Fixed onboarding behavior on All Evals empty state so “Start evaluation” now uses the same evaluation-type dropdown flow as the header create button (instead of directly starting human eval).

- Updated All Evals empty-state copy to be distinct from Auto Evals and clearly describe the cross-type view (auto, human, live, SDK).


<img width="1354" height="850" alt="Screenshot 2026-02-11 at 11 07 32 AM" src="https://github.com/user-attachments/assets/781124a2-cd9f-4039-a471-11c9557de94c" />


Closes #3713 
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/agenta-ai/agenta/pull/3731" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open with Devin">
  </picture>
</a>
<!-- devin-review-badge-end -->
