### PR TITLE
[#3659] fix(sdk): correct Together AI env var name lookup in vault middleware

### DIFF
--- a/api/oss/src/core/secrets/dtos.py
+++ b/api/oss/src/core/secrets/dtos.py
@@ -72,6 +72,10 @@ class SecretDTO(BaseModel):
             values["data"] = data
 
         if kind == SecretKind.PROVIDER_KEY.value:
+            # Fix inconsistent API naming - normalize 'together_ai' to 'togetherai'
+            if data.get("kind", "") == "together_ai":
+                data["kind"] = "togetherai"
+
             if not isinstance(data, dict):
                 raise ValueError(
                     "The provided request secret dto is not a valid type for StandardProviderDTO"
@@ -86,10 +90,9 @@ class SecretDTO(BaseModel):
                 )
 
         elif kind == SecretKind.CUSTOM_PROVIDER.value:
-            # Fix inconsistent API naming - Users might enter 'togetherai' but the API requires 'together_ai'
-            # This ensures compatibility with LiteLLM which requires the provider in "together_ai" format
-            if data.get("kind", "") == "togetherai":
-                data["kind"] = "together_ai"
+            # Fix inconsistent API naming - normalize 'together_ai' to 'togetherai'
+            if data.get("kind", "") == "together_ai":
+                data["kind"] = "togetherai"
 
             if not isinstance(data, dict):
                 raise ValueError(

--- a/api/oss/src/core/secrets/enums.py
+++ b/api/oss/src/core/secrets/enums.py
@@ -18,7 +18,7 @@ class StandardProviderKind(str, Enum):
     MISTRALAI = "mistralai"
     ANTHROPIC = "anthropic"
     PERPLEXITYAI = "perplexityai"
-    TOGETHERAI = "together_ai"
+    TOGETHERAI = "togetherai"
     OPENROUTER = "openrouter"
     GEMINI = "gemini"
 
@@ -39,6 +39,6 @@ class CustomProviderKind(str, Enum):
     MISTRALAI = "mistralai"
     ANTHROPIC = "anthropic"
     PERPLEXITYAI = "perplexityai"
-    TOGETHERAI = "together_ai"
+    TOGETHERAI = "togetherai"
     OPENROUTER = "openrouter"
     GEMINI = "gemini"

--- a/sdk/agenta/client/backend/types/custom_provider_kind.py
+++ b/sdk/agenta/client/backend/types/custom_provider_kind.py
@@ -19,7 +19,7 @@ CustomProviderKind = typing.Union[
         "mistralai",
         "anthropic",
         "perplexityai",
-        "together_ai",
+        "togetherai",
         "openrouter",
         "gemini",
     ],

--- a/sdk/agenta/client/backend/types/standard_provider_kind.py
+++ b/sdk/agenta/client/backend/types/standard_provider_kind.py
@@ -14,7 +14,7 @@ StandardProviderKind = typing.Union[
         "mistralai",
         "anthropic",
         "perplexityai",
-        "together_ai",
+        "togetherai",
         "openrouter",
         "gemini",
     ],

--- a/sdk/agenta/sdk/assets.py
+++ b/sdk/agenta/sdk/assets.py
@@ -169,7 +169,7 @@ supported_llm_models = {
         "perplexity/sonar-reasoning",
         "perplexity/sonar-reasoning-pro",
     ],
-    "together_ai": [
+    "togetherai": [
         "together_ai/deepseek-ai/DeepSeek-R1",
         "together_ai/deepseek-ai/DeepSeek-R1-Distill-Llama-70B",
         "together_ai/deepseek-ai/DeepSeek-R1-Distill-Qwen-1.5B",

--- a/sdk/agenta/sdk/workflows/runners/daytona.py
+++ b/sdk/agenta/sdk/workflows/runners/daytona.py
@@ -131,8 +131,7 @@ class DaytonaRunner(CodeRunner):
             "mistralai": "MISTRALAI_API_KEY",
             "anthropic": "ANTHROPIC_API_KEY",
             "perplexityai": "PERPLEXITYAI_API_KEY",
-            # Secret kind is "together_ai" (underscore) even though the env var is TOGETHERAI_API_KEY
-            "together_ai": "TOGETHERAI_API_KEY",
+            "togetherai": "TOGETHERAI_API_KEY",
             "openrouter": "OPENROUTER_API_KEY",
             "gemini": "GEMINI_API_KEY",
         }

--- a/web/oss/src/components/SelectLLMProvider/index.tsx
+++ b/web/oss/src/components/SelectLLMProvider/index.tsx
@@ -44,7 +44,7 @@ const PROVIDER_ICON_MAP: Record<string, string> = {
     deepinfra: "DeepInfra",
     openrouter: "OpenRouter",
     perplexityai: "Perplexity AI",
-    together_ai: "Together AI",
+    togetherai: "Together AI",
     vertex_ai: "Google Vertex AI",
     bedrock: "AWS Bedrock",
     azure: "Azure OpenAI",

--- a/web/oss/src/lib/Types.ts
+++ b/web/oss/src/lib/Types.ts
@@ -451,7 +451,7 @@ export enum SecretDTOProvider {
     MISTRALAI = "mistralai",
     ANTHROPIC = "anthropic",
     PERPLEXITYAI = "perplexityai",
-    TOGETHERAI = "together_ai",
+    TOGETHERAI = "togetherai",
     OPENROUTER = "openrouter",
     GEMINI = "gemini",
 }
@@ -467,7 +467,7 @@ export const PROVIDER_LABELS: Record<string, string> = {
     mistralai: "Mistral AI",
     anthropic: "Anthropic",
     perplexityai: "Perplexity AI",
-    together_ai: "Together AI",
+    togetherai: "Together AI",
     openrouter: "OpenRouter",
     gemini: "Google Gemini",
     vertex_ai: "Google Vertex AI",

--- a/web/oss/src/lib/helpers/llmProviders.ts
+++ b/web/oss/src/lib/helpers/llmProviders.ts
@@ -44,7 +44,7 @@ export const transformSecret = (secrets: CustomSecretDTO[] | StandardSecretDTO[]
                 mistralai: "MISTRALAI_API_KEY",
                 anthropic: "ANTHROPIC_API_KEY",
                 perplexityai: "PERPLEXITYAI_API_KEY",
-                together_ai: "TOGETHERAI_API_KEY",
+                togetherai: "TOGETHERAI_API_KEY",
                 openrouter: "OPENROUTER_API_KEY",
                 gemini: "GEMINI_API_KEY",
             }

--- a/web/packages/agenta-ui/src/SelectLLMProvider/README.md
+++ b/web/packages/agenta-ui/src/SelectLLMProvider/README.md
@@ -160,7 +160,7 @@ if (Icon) return <Icon className="w-4 h-4" />
 Get the display name for a provider key.
 
 ```typescript
-getProviderDisplayName('together_ai') // "Together AI"
+getProviderDisplayName('togetherai') // "Together AI"
 ```
 
 #### `PROVIDER_ICON_MAP`

--- a/web/packages/agenta-ui/src/SelectLLMProvider/utils.ts
+++ b/web/packages/agenta-ui/src/SelectLLMProvider/utils.ts
@@ -24,7 +24,7 @@ export const PROVIDER_ICON_MAP: Record<string, string> = {
     deepinfra: "DeepInfra",
     openrouter: "OpenRouter",
     perplexity: "Perplexity AI",
-    together_ai: "Together AI",
+    togetherai: "Together AI",
     vertex_ai: "Google Vertex AI",
     bedrock: "AWS Bedrock",
     azure: "Azure OpenAI",


### PR DESCRIPTION
  ## Summary                                                                                                      
- Renamed provider kind from `together_ai` to `togetherai` across the full stack (API, SDK, frontend) to align with
  LiteLLM's naming convention.
- The vault middleware uses `f"{provider.upper()}_API_KEY"` to build env var names — with `togetherai` this now correctly produces `TOGETHERAI_API_KEY`.
- Added backward-compat normalizer in **both** `PROVIDER_KEY` and `CUSTOM_PROVIDER` branches of `SecretDTO` validator to handle any existing DB records with the old `together_ai` value.
- LiteLLM model strings (`together_ai/...`) are unchanged — only the provider kind identifier was renamed.
- No override dict or special-case logic needed.

  Closes #3659

 ## Note for maintainers
- `sdk/agenta/client/backend/types/standard_provider_kind.py` and `custom_provider_kind.py` are auto-generated by Fern, the Fern API definition should be updated to use `togetherai` before the next `fern generate` run.

  ## Test plan
  - [x] Verified locally: Together AI model now receives the API key.
  - [x]  Backward compat: old DB records with `together_ai` are normalized on read via `SecretDTO` validator (both
  `PROVIDER_KEY` and `CUSTOM_PROVIDER` paths).

<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/agenta-ai/agenta/pull/3745" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open with Devin">
  </picture>
</a>
<!-- devin-review-badge-end -->
