### PR TITLE
fix(api): Add /variants/configs/fetch to CORE_FAST rate limit category

### DIFF
--- a/api/ee/src/core/entitlements/types.py
+++ b/api/ee/src/core/entitlements/types.py
@@ -103,6 +103,7 @@ class Throttle(BaseModel):
 ENDPOINTS = {
     Category.CORE_FAST: [
         (Method.POST, "*/retrieve"),
+        (Method.POST, "/variants/configs/fetch"),
     ],
     Category.CORE_SLOW: [
         # None defined yet


### PR DESCRIPTION
## Summary

- Adds `POST /variants/configs/fetch` to the `CORE_FAST` rate limit category so it gets the higher rate limits (1,200/3,600/36,000 req/min) instead of falling into `STANDARD` (120/360/3,600 req/min)

## Context

`POST /variants/configs/fetch` is the primary config-fetching endpoint, used by:
- SDK `ConfigMiddleware` on every request
- SDK `ConfigManager.get_from_registry()`
- Frontend (variant config loading, playground, eval run details)
- All documented curl examples and "Use API" snippets in the platform

It was missing from the `CORE_FAST` endpoint category, causing it to fall into the `STANDARD` catch-all tier — far too restrictive for a hot-path endpoint that fires on every SDK invocation.
