### PR TITLE
fix(frontend)[AGE-3630]: Deleted variants still returned in registry/playground lists

### DIFF
--- a/web/oss/src/components/Playground/Components/Modals/DeleteVariantModal/DeleteVariantModalWrapper.tsx
+++ b/web/oss/src/components/Playground/Components/Modals/DeleteVariantModal/DeleteVariantModalWrapper.tsx
@@ -2,6 +2,7 @@ import {useAtomValue, useSetAtom} from "jotai"
 
 import {
     closeDeleteVariantModalAtom,
+    deleteVariantModalForceVariantIdsAtom,
     deleteVariantModalOpenAtom,
     deleteVariantModalRevisionIdsAtom,
 } from "./store/deleteVariantModalStore"
@@ -11,11 +12,19 @@ import DeleteVariantModal from "."
 const DeleteVariantModalWrapper = () => {
     const open = useAtomValue(deleteVariantModalOpenAtom)
     const revisionIds = useAtomValue(deleteVariantModalRevisionIdsAtom)
+    const forceVariantIds = useAtomValue(deleteVariantModalForceVariantIdsAtom)
     const close = useSetAtom(closeDeleteVariantModalAtom)
 
     if (!revisionIds || revisionIds.length === 0) return null
 
-    return <DeleteVariantModal open={open} onCancel={() => close()} revisionIds={revisionIds} />
+    return (
+        <DeleteVariantModal
+            open={open}
+            onCancel={() => close()}
+            revisionIds={revisionIds}
+            forceVariantIds={forceVariantIds}
+        />
+    )
 }
 
 export default DeleteVariantModalWrapper

--- a/web/oss/src/components/Playground/Components/Modals/DeleteVariantModal/index.tsx
+++ b/web/oss/src/components/Playground/Components/Modals/DeleteVariantModal/index.tsx
@@ -6,11 +6,12 @@ import {DeleteVariantModalProps} from "./types"
 type EnhancedProps = Omit<React.ComponentProps<typeof EnhancedModal>, "children">
 type Props = EnhancedProps & DeleteVariantModalProps
 
-const DeleteVariantModal = ({revisionIds, ...props}: Props) => {
+const DeleteVariantModal = ({revisionIds, forceVariantIds, ...props}: Props) => {
     return (
         <EnhancedModal centered title="Are you sure you want to delete?" footer={null} {...props}>
             <DeleteVariantContent
                 revisionIds={revisionIds}
+                forceVariantIds={forceVariantIds}
                 onClose={() => props.onCancel?.({} as any)}
             />
         </EnhancedModal>

--- a/web/oss/src/components/Playground/Components/Modals/DeleteVariantModal/store/deleteVariantModalStore.ts
+++ b/web/oss/src/components/Playground/Components/Modals/DeleteVariantModal/store/deleteVariantModalStore.ts
@@ -3,20 +3,50 @@ import {atom} from "jotai"
 interface DeleteVariantModalState {
     open: boolean
     revisionIds: string[]
+    forceVariantIds: string[]
 }
 
-export const deleteVariantModalAtom = atom<DeleteVariantModalState>({open: false, revisionIds: []})
+export interface OpenDeleteVariantModalPayload {
+    revisionIds: string | string[]
+    forceVariantIds?: string[]
+}
 
-export const openDeleteVariantModalAtom = atom(null, (get, set, revisionIds: string | string[]) => {
-    const uniqueIds = Array.from(new Set([revisionIds].flat().filter(Boolean))) as string[]
-    set(deleteVariantModalAtom, {open: true, revisionIds: uniqueIds})
+export const deleteVariantModalAtom = atom<DeleteVariantModalState>({
+    open: false,
+    revisionIds: [],
+    forceVariantIds: [],
 })
 
+export const openDeleteVariantModalAtom = atom(
+    null,
+    (get, set, payloadOrRevisionIds: string | string[] | OpenDeleteVariantModalPayload) => {
+        const payload =
+            typeof payloadOrRevisionIds === "object" && "revisionIds" in payloadOrRevisionIds
+                ? payloadOrRevisionIds
+                : {revisionIds: payloadOrRevisionIds}
+        const uniqueRevisionIds = Array.from(
+            new Set([payload.revisionIds].flat().filter(Boolean)),
+        ) as string[]
+        const uniqueForceVariantIds = Array.from(
+            new Set((payload.forceVariantIds || []).filter(Boolean)),
+        ) as string[]
+
+        set(deleteVariantModalAtom, {
+            open: true,
+            revisionIds: uniqueRevisionIds,
+            forceVariantIds: uniqueForceVariantIds,
+        })
+    },
+)
+
 export const closeDeleteVariantModalAtom = atom(null, (get, set) => {
-    set(deleteVariantModalAtom, {open: false, revisionIds: []})
+    set(deleteVariantModalAtom, {open: false, revisionIds: [], forceVariantIds: []})
 })
 
 export const deleteVariantModalOpenAtom = atom((get) => get(deleteVariantModalAtom).open)
 export const deleteVariantModalRevisionIdsAtom = atom(
     (get) => get(deleteVariantModalAtom).revisionIds,
+)
+export const deleteVariantModalForceVariantIdsAtom = atom(
+    (get) => get(deleteVariantModalAtom).forceVariantIds,
 )

--- a/web/oss/src/components/Playground/Components/Modals/DeleteVariantModal/types.d.ts
+++ b/web/oss/src/components/Playground/Components/Modals/DeleteVariantModal/types.d.ts
@@ -2,4 +2,5 @@ import {ModalProps} from "antd"
 
 export interface DeleteVariantModalProps extends ModalProps {
     revisionIds: string[]
+    forceVariantIds?: string[]
 }


### PR DESCRIPTION
### Summary
Fixes registry delete behavior for variants/revisions so the correct delete API is used, modal counts are accurate, and UI state refreshes consistently after deletion.

#### What Changed
- Added explicit delete intent plumbing (forceVariantIds) through delete modal state/props.
- Updated table delete action to pass variant-level intent when deleting grouped parent variant rows.
- Kept revision-row delete behavior on revision delete endpoint.
- Fixed delete modal revision totals to count only visible server revisions (avoids incorrect 1 of 2 revisions messaging).
- Always invalidate playground/registry queries after delete to prevent stale rows from lingering.



Closes #3672 