### PR TITLE
fix(ci): use correct Qdrant collection name for demo traces

### DIFF
--- a/.github/workflows/05-demo-traces.yml
+++ b/.github/workflows/05-demo-traces.yml
@@ -47,7 +47,7 @@ jobs:
           OPENAI_API_KEY: ${{ secrets.DEMO_OPENAI_API_KEY }}
           QDRANT_URL: ${{ secrets.DEMO_QDRANT_URL }}
           QDRANT_API_KEY: ${{ secrets.DEMO_QDRANT_API_KEY }}
-          COLLECTION_NAME: agenta_docs
+          COLLECTION_NAME: agenta_docs_2026_02
           EMBEDDING_MODEL: openai
           TOP_K: '5'
           LLM_MODEL: gpt-4o-mini


### PR DESCRIPTION
## Summary

- The demo trace generation CI workflow (`05-demo-traces.yml`) was using `COLLECTION_NAME: agenta_docs`, which doesn't exist in the Qdrant cluster
- The actual collection with the ingested docs is `agenta_docs_2026_02` (1850 points, openai embeddings)
- This caused `404 Not Found: Collection 'agenta_docs' doesn't exist!` errors in every scheduled run
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/agenta-ai/agenta/pull/3773" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open with Devin">
  </picture>
</a>
<!-- devin-review-badge-end -->
