### PR TITLE
docs(roadmap): add trace usage limits to backlog

### DIFF
--- a/docs/src/data/roadmap.ts
+++ b/docs/src/data/roadmap.ts
@@ -483,6 +483,20 @@ export const inProgressFeatures: PlannedFeature[] = [
 
 export const plannedFeatures: PlannedFeature[] = [
   {
+    id: "trace-usage-limits",
+    title: "Usage Limits for Traces (Hard and Soft Caps)",
+    description:
+      "Set usage limits for traces at the project level. Configure a hard cap to stop accepting new traces once the limit is reached, or a soft cap to receive an alert while continuing to accept traces. Gives teams cost predictability and control in production.",
+    githubUrl: "https://github.com/Agenta-AI/agenta/discussions/3784",
+    labels: [
+      {
+        name: "Observability",
+        color: "DE74FF",
+      },
+    ],
+  },
+
+  {
     id: "prompt-caching-sdk",
     title: "Prompt Caching in the SDK",
     description: "We are adding the ability to cache prompts in the SDK.",


### PR DESCRIPTION
## Summary

- Adds "Usage Limits for Traces (Hard and Soft Caps)" to the planned features (backlog) in the roadmap
- Links to the new discussion: https://github.com/Agenta-AI/agenta/discussions/3784

This feature allows users to set hard caps (block traces) or soft caps (alert and continue) at the project level for cost predictability.
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/agenta-ai/agenta/pull/3785" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open with Devin">
  </picture>
</a>
<!-- devin-review-badge-end -->
