### PR TITLE
[3832] chore(api): add canonical non-preview mounts and hide preview aliases

### DIFF
--- a/api/entrypoints/routers.py
+++ b/api/entrypoints/routers.py
@@ -476,25 +476,59 @@ app.include_router(
 
 app.include_router(
     router=invocations.router,
+    prefix="/invocations",
+    tags=["Invocations"],
+)
+
+app.include_router(
+    router=invocations.router,
     prefix="/preview/invocations",
     tags=["Invocations"],
+    include_in_schema=False,
+)
+
+app.include_router(
+    router=annotations.router,
+    prefix="/annotations",
+    tags=["Annotations"],
 )
 
 app.include_router(
     router=annotations.router,
     prefix="/preview/annotations",
     tags=["Annotations"],
+    include_in_schema=False,
+)
+
+app.include_router(
+    router=testcases.router,
+    prefix="/testcases",
+    tags=["Testcases"],
 )
 
 app.include_router(
     router=testcases.router,
     prefix="/preview/testcases",
     tags=["Testcases"],
+    include_in_schema=False,
+)
+
+app.include_router(
+    router=testsets.router,
+    prefix="/testsets",
+    tags=["Testsets"],
 )
 
 app.include_router(
     router=testsets.router,
     prefix="/preview/testsets",
+    tags=["Testsets"],
+    include_in_schema=False,
+)
+
+app.include_router(
+    router=simple_testsets.router,
+    prefix="/simple/testsets",
     tags=["Testsets"],
 )
 
@@ -502,11 +536,25 @@ app.include_router(
     router=simple_testsets.router,
     prefix="/preview/simple/testsets",
     tags=["Testsets"],
+    include_in_schema=False,
+)
+
+app.include_router(
+    router=queries.router,
+    prefix="/queries",
+    tags=["Queries"],
 )
 
 app.include_router(
     router=queries.router,
     prefix="/preview/queries",
+    tags=["Queries"],
+    include_in_schema=False,
+)
+
+app.include_router(
+    router=simple_queries.router,
+    prefix="/simple/queries",
     tags=["Queries"],
 )
 
@@ -514,6 +562,7 @@ app.include_router(
     router=simple_queries.router,
     prefix="/preview/simple/queries",
     tags=["Queries"],
+    include_in_schema=False,
 )
 
 app.include_router(
@@ -524,7 +573,20 @@ app.include_router(
 
 app.include_router(
     router=applications.router,
+    prefix="/applications",
+    tags=["Applications"],
+)
+
+app.include_router(
+    router=applications.router,
     prefix="/preview/applications",
+    tags=["Applications"],
+    include_in_schema=False,
+)
+
+app.include_router(
+    router=simple_applications.router,
+    prefix="/simple/applications",
     tags=["Applications"],
 )
 
@@ -532,12 +594,20 @@ app.include_router(
     router=simple_applications.router,
     prefix="/preview/simple/applications",
     tags=["Applications"],
+    include_in_schema=False,
+)
+
+app.include_router(
+    router=workflows.router,
+    prefix="/workflows",
+    tags=["Workflows"],
 )
 
 app.include_router(
     router=workflows.router,
     prefix="/preview/workflows",
     tags=["Workflows"],
+    include_in_schema=False,
 )
 
 app.include_router(
@@ -548,7 +618,20 @@ app.include_router(
 
 app.include_router(
     router=evaluators.router,
+    prefix="/evaluators",
+    tags=["Evaluators"],
+)
+
+app.include_router(
+    router=evaluators.router,
     prefix="/preview/evaluators",
+    tags=["Evaluators"],
+    include_in_schema=False,
+)
+
+app.include_router(
+    router=simple_evaluators.router,
+    prefix="/simple/evaluators",
     tags=["Evaluators"],
 )
 
@@ -556,6 +639,7 @@ app.include_router(
     router=simple_evaluators.router,
     prefix="/preview/simple/evaluators",
     tags=["Evaluators"],
+    include_in_schema=False,
 )
 
 app.include_router(
@@ -578,7 +662,20 @@ app.include_router(
 
 app.include_router(
     router=evaluations.router,
+    prefix="/evaluations",
+    tags=["Evaluations"],
+)
+
+app.include_router(
+    router=evaluations.router,
     prefix="/preview/evaluations",
+    tags=["Evaluations"],
+    include_in_schema=False,
+)
+
+app.include_router(
+    router=simple_evaluations.router,
+    prefix="/simple/evaluations",
     tags=["Evaluations"],
 )
 
@@ -586,6 +683,7 @@ app.include_router(
     router=simple_evaluations.router,
     prefix="/preview/simple/evaluations",
     tags=["Evaluations"],
+    include_in_schema=False,
 )
 
 app.include_router(

--- a/docs/design/preview-route-normalization/README.md
+++ b/docs/design/preview-route-normalization/README.md
@@ -1,0 +1,21 @@
+# Preview Route Normalization
+
+This workspace tracks the plan to keep legacy `/preview/*` endpoints working while introducing canonical non-preview mounts and exposing only canonical paths in OpenAPI.
+
+## Prompt
+
+Create a migration plan for preview route cleanup, identify which routes are safe vs open risk, and track migration status for frontend and SDK consumers.
+
+## Documents
+
+- `context.md` - Why this change exists, goals, and constraints.
+- `research.md` - Current route inventory, usage findings, and risk notes.
+- `route-matrix.md` - Per-route safety and migration status (API + frontend + SDK).
+- `plan.md` - Phased rollout plan with exit criteria.
+- `status.md` - Current execution status, decisions, and next actions.
+
+## Current headline
+
+- Feasible approach: dual-mount routes, hide preview mounts from schema (`include_in_schema=False`), then migrate clients.
+- Most domains are safe to add now.
+- `environments` remains open/risky due existing legacy `/environments` router also mounted.

--- a/docs/design/preview-route-normalization/context.md
+++ b/docs/design/preview-route-normalization/context.md
@@ -1,0 +1,30 @@
+# Context
+
+## Background
+
+The API currently exposes many domain routers under `/preview/*`. Some domains already have canonical non-preview mounts (for example tracing), while others do not. We want to normalize public API paths so that OpenAPI shows canonical non-preview endpoints, while old preview paths remain available for a transition window.
+
+## Problem statement
+
+- API consumers currently depend on preview paths across both frontend and SDK.
+- If we switch paths abruptly, we risk breaking runtime behavior.
+- If we expose both preview and non-preview paths in OpenAPI at the same time, we risk duplicate operations and confusing generated clients.
+
+## Goals
+
+- Add canonical non-preview mounts where safe.
+- Keep preview mounts live during migration.
+- Expose only canonical paths in OpenAPI.
+- Track migration status for frontend and SDK before removing preview mounts.
+
+## Non-goals
+
+- Removing preview mounts in the same change.
+- Rewriting route internals or service logic.
+- Full endpoint redesign.
+
+## Constraints
+
+- Existing clients must remain functional during migration.
+- OpenAPI should avoid duplicated endpoint surfaces for the same handlers.
+- Legacy routers in `api/oss/src/routers/*` still coexist with new fastapi routers in `api/oss/src/apis/fastapi/*`.

--- a/docs/design/preview-route-normalization/plan.md
+++ b/docs/design/preview-route-normalization/plan.md
@@ -1,0 +1,92 @@
+# Execution Plan
+
+## Phase 1 - API dual-mount foundation
+
+Scope:
+
+- For each `safe-now` family, add canonical non-preview mount in `api/entrypoints/routers.py`.
+- Keep existing preview mounts active.
+- Set preview mounts to `include_in_schema=False`.
+
+Deliverables:
+
+- Canonical routes available at runtime.
+- OpenAPI shows only canonical routes for migrated families.
+
+Exit criteria:
+
+- API boots successfully.
+- OpenAPI generation succeeds without duplicate operation warnings impacting clients.
+- Existing preview callers continue to work.
+
+## Phase 2 - Frontend migration
+
+Scope:
+
+- Update web callers from `/preview/*` to canonical routes for migrated families.
+- Prioritize highest-usage families first: evaluations, testsets, testcases, evaluators.
+
+Deliverables:
+
+- No frontend production code paths depend on preview prefixes for migrated families.
+
+Exit criteria:
+
+- Search in `web/` shows zero matches for migrated `/preview/*` prefixes (excluding tests/fixtures where intentionally retained).
+
+## Phase 3 - SDK migration
+
+Scope:
+
+- Update SDK managers and evaluation helpers from preview to canonical routes.
+- Ensure generated docs and examples use canonical paths.
+
+Deliverables:
+
+- SDK runtime calls use canonical routes for migrated families.
+
+Exit criteria:
+
+- Search in `sdk/` shows zero matches for migrated `/preview/*` prefixes.
+
+## Phase 4 - Environments decision
+
+Scope:
+
+- Validate compatibility strategy for environments due prefix overlap with legacy `/environments` router.
+- Decide whether to:
+  - dual-mount new environments on `/environments`, or
+  - keep preview until legacy `/environments` is retired, then cut over.
+
+Deliverables:
+
+- Signed-off approach and implementation task list.
+
+Exit criteria:
+
+- No ambiguity on `/environments/*` behavior.
+- OpenAPI and runtime behavior are both verified.
+
+## Phase 5 - Preview removal
+
+Scope:
+
+- Remove preview mounts for fully migrated families.
+
+Deliverables:
+
+- No preview mounts remaining for completed families.
+
+Exit criteria:
+
+- Frontend and SDK references are gone.
+- No regressions in API usage monitoring.
+
+## Rollout order recommendation
+
+1. tracing migration (already dual-mounted)
+2. evaluations + evaluators
+3. testsets + testcases
+4. queries + applications + workflows
+5. invocations + annotations
+6. environments (after explicit decision)

--- a/docs/design/preview-route-normalization/research.md
+++ b/docs/design/preview-route-normalization/research.md
@@ -1,0 +1,76 @@
+# Research
+
+## API mount inventory
+
+Source: `api/entrypoints/routers.py`.
+
+Preview mounts currently present:
+
+- `/preview/tracing`
+- `/preview/invocations`
+- `/preview/annotations`
+- `/preview/testcases`
+- `/preview/testsets`
+- `/preview/simple/testsets`
+- `/preview/queries`
+- `/preview/simple/queries`
+- `/preview/applications`
+- `/preview/simple/applications`
+- `/preview/workflows`
+- `/preview/evaluators`
+- `/preview/simple/evaluators`
+- `/preview/environments`
+- `/preview/simple/environments`
+- `/preview/evaluations`
+- `/preview/simple/evaluations`
+
+Notable existing non-preview mount:
+
+- `/tracing` already exists next to `/preview/tracing`, and preview tracing is already marked `include_in_schema=False`.
+
+## Legacy route overlap check
+
+Legacy routers (`api/oss/src/routers/*`) are still mounted for several old prefixes.
+
+Key overlap risk:
+
+- Legacy `/environments` is already mounted and serves `/deploy/` via `api/oss/src/routers/environment_router.py`.
+- New environments routers are currently mounted under `/preview/environments` and `/preview/simple/environments`.
+- Moving new environments router to `/environments` is possible but requires careful conflict and behavior validation.
+
+## Consumer usage snapshot
+
+File-level usage counts by mounted preview prefix (web + SDK search):
+
+- `/preview/tracing`: web 4, sdk 1
+- `/preview/invocations`: web 0, sdk 0
+- `/preview/annotations`: web 4, sdk 0
+- `/preview/testcases`: web 12, sdk 0
+- `/preview/testsets`: web 20, sdk 1
+- `/preview/simple/testsets`: web 5, sdk 1
+- `/preview/queries`: web 4, sdk 0
+- `/preview/simple/queries`: web 1, sdk 0
+- `/preview/applications`: web 0, sdk 1
+- `/preview/simple/applications`: web 0, sdk 1
+- `/preview/workflows`: web 1, sdk 1
+- `/preview/evaluators`: web 2, sdk 1
+- `/preview/simple/evaluators`: web 4, sdk 1
+- `/preview/environments`: web 0, sdk 0
+- `/preview/simple/environments`: web 0, sdk 0
+- `/preview/evaluations`: web 21, sdk 4
+- `/preview/simple/evaluations`: web 2, sdk 1
+
+Interpretation:
+
+- Evaluations/testsets/testcases/evaluators are the highest-usage preview surfaces.
+- Environments has no current client usage in web/SDK, but has server-side overlap risk.
+
+## OpenAPI strategy
+
+For each migrated route family:
+
+1. Add canonical non-preview mount.
+2. Keep preview mount for compatibility.
+3. Set preview mount `include_in_schema=False` so only canonical paths remain in OpenAPI.
+
+This is the same pattern currently used for tracing.

--- a/docs/design/preview-route-normalization/route-matrix.md
+++ b/docs/design/preview-route-normalization/route-matrix.md
@@ -1,0 +1,41 @@
+# Route Matrix
+
+Legend:
+
+- `done`: canonical mount added and preview hidden from OpenAPI.
+- `open`: requires additional design/validation before adding canonical mount.
+- `blocked`: client migration is pending (API dual-mount available).
+- `not-started`: migration work not yet applied.
+- `n/a`: no usage found in current web/SDK scans.
+
+| Route family | Preview mount(s) | Canonical target(s) | Add canonical status | Frontend migration | SDK migration | Notes |
+| --- | --- | --- | --- | --- | --- | --- |
+| tracing | `/preview/tracing` | `/tracing` | done | not-started (uses preview in 4 files) | not-started (uses preview in 1 file) | Canonical already exists; preview already hidden from schema. |
+| invocations | `/preview/invocations` | `/invocations` | done | n/a | n/a | Canonical mount added; preview hidden from schema. |
+| annotations | `/preview/annotations` | `/annotations` | done | blocked (preview in 4 files) | n/a | Frontend migration needed. |
+| testcases | `/preview/testcases` | `/testcases` | done | blocked (preview in 12 files) | n/a | High frontend touch count. |
+| testsets | `/preview/testsets`, `/preview/simple/testsets` | `/testsets`, `/simple/testsets` | done | blocked (preview in 20 + 5 files) | blocked (preview in 1 + 1 files) | High blast radius in web and entities package. |
+| queries | `/preview/queries`, `/preview/simple/queries` | `/queries`, `/simple/queries` | done | blocked (preview in 4 + 1 files) | n/a | Include revisions/query endpoints under new prefix. |
+| applications | `/preview/applications`, `/preview/simple/applications` | `/applications`, `/simple/applications` | done | n/a | blocked (preview in 1 + 1 files) | SDK managers use these paths. |
+| workflows | `/preview/workflows` | `/workflows` | done | blocked (preview in 1 file) | blocked (preview in 1 file) | Mostly invoke-related usage. |
+| evaluators | `/preview/evaluators`, `/preview/simple/evaluators` | `/evaluators`, `/simple/evaluators` | done | blocked (preview in 2 + 4 files) | blocked (preview in 1 + 1 files) | Used by eval UI + SDK manager. |
+| environments | `/preview/environments`, `/preview/simple/environments` | `/environments`, `/simple/environments` | open | n/a | n/a | Legacy `/environments` router already mounted; requires conflict and behavior validation. |
+| evaluations | `/preview/evaluations`, `/preview/simple/evaluations` | `/evaluations`, `/simple/evaluations` | done | blocked (preview in 21 + 2 files) | blocked (preview in 4 + 1 files) | Highest active preview usage in web+SDK. |
+
+## Safe-now set
+
+- invocations
+- annotations
+- testcases
+- testsets (+ simple)
+- queries (+ simple)
+- applications (+ simple)
+- workflows
+- evaluators (+ simple)
+- evaluations (+ simple)
+
+## Open set
+
+- environments (+ simple)
+  - Primary reason: coexistence with legacy `/environments` router mounted from `api/oss/src/routers/environment_router.py`.
+  - Needs explicit verification of route matching behavior, generated OpenAPI clarity, and backward compatibility for `/environments/deploy/`.

--- a/docs/design/preview-route-normalization/status.md
+++ b/docs/design/preview-route-normalization/status.md
@@ -1,0 +1,34 @@
+# Status
+
+Date: 2026-02-25
+
+## Overall
+
+- State: Phase 1 implemented for all safe-now families.
+- Immediate next step: migrate frontend and SDK callers from `/preview/*` to canonical paths.
+
+## Add canonical routes (API)
+
+- done: tracing, invocations, annotations, testcases, testsets (+ simple), queries (+ simple), applications (+ simple), workflows, evaluators (+ simple), evaluations (+ simple)
+- open: environments (+ simple) due legacy `/environments` overlap requiring explicit verification
+
+## Frontend migration status
+
+- not-started: tracing, annotations, testcases, testsets (+ simple), queries (+ simple), workflows, evaluators (+ simple), evaluations (+ simple)
+- n/a (no current usage found): invocations, applications (+ simple), environments (+ simple)
+
+## SDK migration status
+
+- not-started: tracing, testsets (+ simple), applications (+ simple), workflows, evaluators (+ simple), evaluations (+ simple)
+- n/a (no current usage found): invocations, annotations, testcases, queries (+ simple), environments (+ simple)
+
+## Risks and blockers
+
+- OpenAPI duplication risk if preview mounts are left in schema after adding canonical mounts.
+- Environments prefix overlap with legacy router may cause ambiguous behavior if not validated carefully.
+- High-usage families (evaluations/testsets/testcases/evaluators) need coordinated frontend + SDK migration to avoid long tail preview dependency.
+
+## Decision log
+
+- Use tracing migration pattern broadly: dual-mount + hide preview in schema.
+- Treat environments as a dedicated decision point (do not batch into safe-now migration set).


### PR DESCRIPTION
## Summary
- add canonical non-preview mounts for safe route families while keeping existing `/preview/*` routes for runtime backward compatibility
- hide migrated preview mounts from OpenAPI by setting `include_in_schema=False`, so the schema advertises only canonical paths
- add a planning workspace documenting route safety, migration status for frontend/SDK, and the phased rollout plan

## Scope
- Implemented for: invocations, annotations, testcases, testsets, simple testsets, queries, simple queries, applications, simple applications, workflows, evaluators, simple evaluators, evaluations, simple evaluations
- Left unchanged (open/risky): environments/simple environments due existing legacy `/environments` router overlap

Closes #3832
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/agenta-ai/agenta/pull/3834" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open with Devin">
  </picture>
</a>
<!-- devin-review-badge-end -->
