### PR TITLE
docs: add product update for AI prompt refinement

### DIFF
--- a/SOCIAL_ANNOUNCEMENTS.md
+++ b/SOCIAL_ANNOUNCEMENTS.md
@@ -1,5 +1,46 @@
 # Social Announcements
 
+## AI Prompt Refinement
+
+### LinkedIn
+
+Are you still writing your prompts by hand? AI is much better at writing prompts.
+
+When we talked to our users, we discovered that a lot of them copy-pasted the prompt into ChatGPT, edited it there, and then went back. So we improved the flow. Now you click the wand icon, type what you want to change, and get back your refined version.
+
+The prompt refiner itself was built with Agenta, and it includes all the best practices for writing clear prompts that work well.
+
+Since we started using it internally, my flow is just talking through what I want using Wispr Flow ("make it more concise", "add output format constraints") and hitting refine. Prompt iteration got way faster.
+
+Try it in the Playground: https://cloud.agenta.ai
+
+### Twitter/X
+
+Tweet 1:
+New in Agenta: AI prompt refinement in the Playground. Click the wand icon, describe what you want to change, get a refined prompt back. Iterative. Diff view. Editable before applying.
+
+Tweet 2:
+Changelog: https://agenta.ai/docs/changelog/refine-ai
+
+### Slack (#announcements)
+
+**AI Prompt Refinement is live in the Playground**
+
+You can now refine prompts with AI directly in the Playground:
+
+- Click the wand icon on any prompt section
+- Describe what you want to change in plain English
+- Get a refined version with a summary of changes
+- Iterate: each round builds on the previous result
+- Toggle diff view to see exactly what changed
+- Edit the result before applying
+
+There's also a quick "Optimize using best practices" shortcut.
+
+Changelog: https://agenta.ai/docs/changelog/refine-ai
+
+---
+
 ## Enterprise Compliance Features
 
 ### LinkedIn

--- a/docs/blog/entries/refine-ai.mdx
+++ b/docs/blog/entries/refine-ai.mdx
@@ -1,0 +1,52 @@
+---
+title: "AI-Powered Prompt Refinement in the Playground"
+slug: refine-ai
+date: 2026-02-25
+tags: [v0.84.0]
+description: "Refine your prompts with AI directly in the playground. Describe what you want to improve and get a refined version with an explanation of the changes."
+---
+
+{/* NOTE: Do NOT add an H1 heading here. The frontmatter title is automatically rendered as H1 by Docusaurus. */}
+
+## The Problem
+
+Prompt engineering is iterative. You write a prompt, test it, notice it's too vague or missing constraints, and rewrite it. Each cycle requires you to figure out *how* to improve it, not just *what* to improve. That's the hard part.
+
+## The Solution
+
+You can now refine prompts with AI directly in the playground. Click the wand icon on any prompt section, describe what you want to change in plain English, and get back a refined version with an explanation of what changed and why.
+
+<div style={{display: "flex", justifyContent: "center", marginTop: "20px", marginBottom: "20px", flexDirection: "column", alignItems: "center"}}>
+  <iframe
+    width="100%"
+    height="500"
+    src="https://www.youtube.com/embed/V2hHC8hZEeE"
+    title="AI-Powered Prompt Refinement"
+    frameBorder="0"
+    allow="accelerometer; autoplay; clipboard-write; encrypted-media; gyroscope; picture-in-picture; web-share"
+    allowFullScreen
+  ></iframe>
+</div>
+
+## How It Works
+
+1. Open a prompt in the playground and click the **wand icon** in the prompt section header.
+2. A two-panel modal opens. On the left, type what you want to improve (e.g., "add output format instructions" or "make it more concise"). On the right, see the refined prompt.
+3. Each refinement builds on the previous result, so you can iterate. Ask for one change, review it, then ask for another.
+4. Toggle the **Diff view** to see exactly what changed compared to the original.
+5. Edit the refined prompt directly if you want to adjust anything before applying.
+6. Click **Use refined prompt** to apply the changes to your playground session.
+
+You can also use the built-in quick action "Optimize the prompt using best practices" for a one-click improvement.
+
+## What You Can Do
+
+- **Describe improvements in plain English**: "Add a constraint that the output must be valid JSON" or "Make the tone more professional."
+- **Iterate**: Each refinement uses the latest version, so you can make incremental changes across multiple rounds.
+- **Review diffs**: Toggle the diff view to see a side-by-side comparison of the original and refined prompts.
+- **Edit before applying**: The refined prompt is fully editable. Adjust anything before committing.
+- **Quick optimize**: Use the built-in "Optimize the prompt using best practices" shortcut for an instant improvement.
+
+## Getting Started
+
+Open any prompt in the playground. Look for the wand icon in the prompt section header. If you don't see it, the feature may not be enabled for your organization yet.

--- a/docs/blog/main.mdx
+++ b/docs/blog/main.mdx
@@ -10,6 +10,28 @@ import Image from "@theme/IdealImage";
 
 <section class="changelog">
 
+### [AI-Powered Prompt Refinement in the Playground](/changelog/refine-ai)
+
+_25 February 2026_
+
+**v0.84.0**
+
+<div style={{display: "flex", justifyContent: "center", marginTop: "20px", marginBottom: "20px", flexDirection: "column", alignItems: "center"}}>
+  <iframe
+    width="100%"
+    height="420"
+    src="https://www.youtube.com/embed/V2hHC8hZEeE"
+    title="AI-Powered Prompt Refinement"
+    frameBorder="0"
+    allow="accelerometer; autoplay; clipboard-write; encrypted-media; gyroscope; picture-in-picture; web-share"
+    allowFullScreen
+  ></iframe>
+</div>
+
+You can now refine prompts with AI directly in the playground. Click the wand icon on any prompt, describe what you want to improve in plain English, and get back a refined version with a summary of changes. Each refinement builds on the last, so you can iterate. Toggle diff view to see exactly what changed, edit the result before applying, or use the quick "Optimize using best practices" shortcut.
+
+---
+
 ### [Enterprise Compliance Features](/changelog/enterprise-compliance-features)
 
 _17 February 2026_

--- a/docs/src/data/roadmap.ts
+++ b/docs/src/data/roadmap.ts
@@ -27,6 +27,20 @@ export const shippedFeatures: ShippedFeature[] = [
   // Integration: FFA500
   // Security: 000000
   {
+    id: "ai-prompt-refinement",
+    title: "AI-Powered Prompt Refinement in the Playground",
+    description:
+      "Refine prompts with AI directly in the playground. Describe what you want to improve and get a refined version with an explanation of the changes.",
+    changelogPath: "/docs/changelog/refine-ai",
+    shippedAt: "2026-02-25",
+    labels: [
+      {
+        name: "Playground",
+        color: "BCFF78",
+      },
+    ],
+  },
+  {
     id: "enterprise-compliance",
     title: "Enterprise Compliance Features",
     description:
@@ -398,19 +412,6 @@ export const inProgressFeatures: PlannedFeature[] = [
     description:
       "Create reusable prompt snippets that can be referenced across multiple prompts. Reference specific versions or always use the latest version to maintain consistency across prompt variants.",
     githubUrl: "https://github.com/Agenta-AI/agenta/discussions/2858",
-    labels: [
-      {
-        name: "Playground",
-        color: "BCFF78",
-      },
-    ],
-  },
-  {
-    id: "ai-prompt-refinement",
-    title: "AI-Powered Prompt Refinement in the Playground",
-    description:
-      "Analyze prompts and suggest improvements based on best practices. Identify issues, propose refined versions, and allow users to accept, modify, or reject suggestions.",
-    githubUrl: "https://github.com/Agenta-AI/agenta/discussions/2861",
     labels: [
       {
         name: "Playground",

--- a/web/oss/src/components/SidebarBanners/data/changelog.json
+++ b/web/oss/src/components/SidebarBanners/data/changelog.json
@@ -1,5 +1,11 @@
 [
     {
+        "id": "changelog-2026-02-25-refine-ai",
+        "title": "AI Prompt Refinement",
+        "description": "Refine prompts with AI in the playground. Describe what to improve and get a refined version.",
+        "link": "https://agenta.ai/docs/changelog/refine-ai"
+    },
+    {
         "id": "changelog-2026-02-17-enterprise-compliance",
         "title": "Enterprise Compliance Features",
         "description": "Multi-org support, SSO, domain verification, and a US region.",
@@ -10,23 +16,5 @@
         "title": "Folders for Prompt Organization",
         "description": "Organize prompts with folders and subfolders. Drag, move, and search.",
         "link": "https://agenta.ai/docs/changelog/prompt-folders"
-    },
-    {
-        "id": "changelog-2026-01-29-onboarding",
-        "title": "Onboarding Widget & Walkthroughs",
-        "description": "Guided tours to help you explore the playground, evaluations, and observability.",
-        "link": "https://agenta.ai/docs/changelog/onboarding-widget-walkthroughs"
-    },
-    {
-        "id": "changelog-2026-01-28-trace-navigation",
-        "title": "Navigate from Traces to Configs",
-        "description": "Click from any trace to the app, variant, or environment that generated it.",
-        "link": "https://agenta.ai/docs/changelog/trace-navigation-links"
-    },
-    {
-        "id": "changelog-2026-01-20-testset-versioning",
-        "title": "Test Set Versioning",
-        "description": "Track test set changes and link evaluations to specific versions.",
-        "link": "https://agenta.ai/docs/changelog/testset-versioning"
     }
 ]


### PR DESCRIPTION
## Summary

- Adds changelog entry for AI-powered prompt refinement in the playground (v0.84.0)
- Adds sidebar announcement card and trims old cards (kept latest 3)
- Moves roadmap item from in-progress to shipped
- Adds social media announcements (LinkedIn, Twitter/X, Slack)

## Files changed

- `docs/blog/entries/refine-ai.mdx` - Detailed changelog entry with YouTube embed
- `docs/blog/main.mdx` - Summary entry at top of changelog
- `docs/src/data/roadmap.ts` - Moved to shipped features
- `web/oss/src/components/SidebarBanners/data/changelog.json` - New card + trimmed to 3
- `SOCIAL_ANNOUNCEMENTS.md` - LinkedIn, Twitter, Slack posts
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/agenta-ai/agenta/pull/3836" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open with Devin">
  </picture>
</a>
<!-- devin-review-badge-end -->
