### PR TITLE
fix(docs): resolve duplicate SEO title tags

### DIFF
--- a/docs/docs/custom-workflows/01-overview.mdx
+++ b/docs/docs/custom-workflows/01-overview.mdx
@@ -1,5 +1,6 @@
 ---
-title: "Overview"
+title: "Custom Workflows Overview"
+sidebar_label: "Overview"
 description: "Build playgrounds for complex LLM applications"
 ---
 

--- a/docs/docs/custom-workflows/02-quick-start.mdx
+++ b/docs/docs/custom-workflows/02-quick-start.mdx
@@ -1,5 +1,6 @@
 ---
-title: "Quick Start"
+title: "Quick Start: Custom Workflows"
+sidebar_label: "Quick Start"
 description: "Build your first custom workflow with Agenta"
 ---
 

--- a/docs/docs/evaluation/01-quick-start-ui.mdx
+++ b/docs/docs/evaluation/01-quick-start-ui.mdx
@@ -7,4 +7,8 @@ sidebar_position: 1
 
 import { Redirect } from '@docusaurus/router';
 
+<head>
+  <meta name="robots" content="noindex, nofollow" />
+</head>
+
 <Redirect to="/docs/evaluation/evaluation-from-ui/quick-start" />

--- a/docs/docs/evaluation/evaluation-from-sdk/01-quick-start.mdx
+++ b/docs/docs/evaluation/evaluation-from-sdk/01-quick-start.mdx
@@ -1,5 +1,5 @@
 ---
-title: "Quick Start"
+title: "Quick Start: SDK Evaluation"
 sidebar_label: "Quick Start"
 description: "Learn how to run evaluations programmatically with the Agenta SDK in under 5 minutes"
 sidebar_position: 1

--- a/docs/docs/evaluation/evaluation-from-ui/01-quick-start.mdx
+++ b/docs/docs/evaluation/evaluation-from-ui/01-quick-start.mdx
@@ -1,5 +1,5 @@
 ---
-title: "Quick Start Evaluation from UI"
+title: "Quick Start: Evaluation from UI"
 sidebar_label: "Quick Start"
 description: "Quick start guide for running LLM and prompt evaluations from the Agenta UI"
 sidebar_position: 1

--- a/docs/docs/evaluation/evaluation-from-ui/02-running-evaluations.mdx
+++ b/docs/docs/evaluation/evaluation-from-ui/02-running-evaluations.mdx
@@ -1,5 +1,5 @@
 ---
-title: "Running Evaluations"
+title: "Running Evaluations from the UI"
 sidebar_label: "Running Evaluations"
 description: "Learn how to run evaluations from the Agenta web interface"
 sidebar_position: 2

--- a/docs/docs/evaluation/human-evaluation/01-quick-start.mdx
+++ b/docs/docs/evaluation/human-evaluation/01-quick-start.mdx
@@ -1,5 +1,5 @@
 ---
-title: "Quick Start"
+title: "Quick Start: Human Evaluation"
 sidebar_label: "Quick Start"
 description: "Get started with human evaluation in Agenta"
 sidebar_position: 1

--- a/docs/docs/evaluation/human-evaluation/03-running-evaluations.mdx
+++ b/docs/docs/evaluation/human-evaluation/03-running-evaluations.mdx
@@ -1,5 +1,5 @@
 ---
-title: "Running Evaluations"
+title: "Running Human Evaluations"
 sidebar_label: "Running Evaluations"
 description: "Learn how to run human evaluation sessions in Agenta"
 sidebar_position: 3

--- a/docs/docs/observability/01-overview.mdx
+++ b/docs/docs/observability/01-overview.mdx
@@ -1,5 +1,5 @@
 ---
-title: "Overview"
+title: "LLM Observability Overview"
 sidebar_label: "Overview"
 description: "Complete guide to LLM observability with Agenta - monitor costs, performance, and trace every request with automatic instrumentation for your AI applications"
 sidebar_position: 2

--- a/docs/docs/prompt-engineering/01-quick-start.mdx
+++ b/docs/docs/prompt-engineering/01-quick-start.mdx
@@ -1,5 +1,6 @@
 ---
-title: "Quick Start"
+title: "Quick Start: Prompt Engineering"
+sidebar_label: "Quick Start"
 description: "Create a prompt, deploy it to an environment, and integrate it with your codebase using the Agenta SDK in minutes."
 sidebar_position: 1
 ---

--- a/docs/docs/self-host/01-quick-start.mdx
+++ b/docs/docs/self-host/01-quick-start.mdx
@@ -1,5 +1,6 @@
 ---
-title: Quick Start
+title: "Quick Start: Self-Hosting Agenta"
+sidebar_label: "Quick Start"
 description: "Learn how to deploy Agenta locally using Docker, either on port 80 or a custom port. Step-by-step guide covering installation, configuration, troubleshooting, and version updates"
 sidebar_position: 1
 ---

--- a/docs/docs/tutorials/cookbooks/02-observability_langchain.mdx
+++ b/docs/docs/tutorials/cookbooks/02-observability_langchain.mdx
@@ -1,5 +1,5 @@
 ---
-title: "Tracing and Observability for LangChain with Agenta"
+title: "LangChain Tracing and Observability Cookbook"
 sidebar_label: Tracing for LangChain
 description: Learn how to instrument LangChain traces with Agenta for enhanced LLM observability. This guide covers setup, configuration, and best practices for monitoring LLM applications using LangChain and OpenAI models.
 ---


### PR DESCRIPTION
## Summary

Fixes 17 duplicate title tag issues reported by SEMrush across the docs site. Each page now has a unique `<title>` while `sidebar_label` is preserved to keep navigation unchanged.

## Changes

| Issue | Files | Fix |
|-------|-------|-----|
| Duplicate "Running Evaluations" | `human-evaluation/03-running-evaluations.mdx`, `evaluation-from-ui/02-running-evaluations.mdx` | Renamed to "Running Human Evaluations" and "Running Evaluations from the UI" |
| Duplicate "Overview" | `custom-workflows/01-overview.mdx`, `observability/01-overview.mdx` | Renamed to "Custom Workflows Overview" and "LLM Observability Overview" |
| Duplicate LangChain title | `tutorials/cookbooks/02-observability_langchain.mdx` | Renamed to "LangChain Tracing and Observability Cookbook" |
| Duplicate "Quick Start" (5 pages) | prompt-engineering, self-host, human-evaluation, custom-workflows, evaluation-from-sdk | Added section context: e.g. "Quick Start: Prompt Engineering", "Quick Start: Self-Hosting Agenta", etc. |
| Duplicate "Quick Start: Evaluation from UI" | `evaluation/01-quick-start-ui.mdx`, `evaluation/evaluation-from-ui/01-quick-start.mdx` | Added `noindex` meta to redirect page; fixed destination title |

All `sidebar_label` values are preserved so the sidebar navigation is unaffected.
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/agenta-ai/agenta/pull/3841" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open with Devin">
  </picture>
</a>
<!-- devin-review-badge-end -->
