### PR TITLE
fix(frontend): prevent markdown editor from scrolling to bottom on Enter key

### DIFF
--- a/web/oss/src/components/Editor/plugins/markdown/markdownPlugin.tsx
+++ b/web/oss/src/components/Editor/plugins/markdown/markdownPlugin.tsx
@@ -123,19 +123,47 @@ const MarkdownPlugin = ({id}: {id: string}) => {
         return editor.registerCommand(
             KEY_ENTER_COMMAND,
             (event) => {
-                editor.update(() => {
+                // Read-only check: determine if cursor is inside a markdown CodeNode
+                const shouldHandle = editor.getEditorState().read(() => {
                     const selection = $getSelection()
                     if (!$isRangeSelection(selection)) return false
-
                     const anchorNode = selection.anchor.getNode()
                     const topNode = anchorNode.getTopLevelElementOrThrow()
-
-                    if ($isCodeNode(topNode) && topNode.getLanguage() === "markdown") {
-                        event?.preventDefault()
-                        selection.insertRawText("\n")
-                        return true
-                    }
+                    return $isCodeNode(topNode) && topNode.getLanguage() === "markdown"
                 })
+
+                if (!shouldHandle) return false
+
+                event?.preventDefault()
+
+                // Save scroll position before inserting text to prevent
+                // the browser from auto-scrolling to the bottom
+                const rootElement = editor.getRootElement()
+                const scrollContainer = rootElement?.closest(
+                    ".agenta-editor-wrapper",
+                ) as HTMLElement | null
+                const savedScrollTop = scrollContainer?.scrollTop ?? 0
+                const savedElementScrollTop = rootElement?.scrollTop ?? 0
+
+                // {discrete: true} ensures DOM is flushed synchronously
+                editor.update(
+                    () => {
+                        const selection = $getSelection()
+                        if ($isRangeSelection(selection)) {
+                            selection.insertRawText("\n")
+                        }
+                    },
+                    {discrete: true},
+                )
+
+                // Restore scroll after DOM flush.
+                // Use rAF to also cover the merge-back update from
+                // the registerUpdateListener that follows this effect.
+                requestAnimationFrame(() => {
+                    if (scrollContainer) scrollContainer.scrollTop = savedScrollTop
+                    if (rootElement) rootElement.scrollTop = savedElementScrollTop
+                })
+
                 return true
             },
             COMMAND_PRIORITY_HIGH,
@@ -157,12 +185,27 @@ const MarkdownPlugin = ({id}: {id: string}) => {
                 const trailingNodes = children.slice(index + 1)
 
                 if (trailingNodes.length > 0) {
+                    // Save scroll position before merging trailing nodes back,
+                    // as this second editor.update() can also trigger scroll jumps
+                    const rootElement = editor.getRootElement()
+                    const scrollContainer = rootElement?.closest(
+                        ".agenta-editor-wrapper",
+                    ) as HTMLElement | null
+                    const savedScrollTop = scrollContainer?.scrollTop ?? 0
+                    const savedElementScrollTop = rootElement?.scrollTop ?? 0
+
                     editor.update(() => {
                         for (const node of trailingNodes) {
                             const content = node.getTextContent()
                             markdownCodeNode.append($createTextNode("\n" + content))
                             node.remove()
                         }
+                    })
+
+                    // Restore scroll after the merge-back DOM update
+                    requestAnimationFrame(() => {
+                        if (scrollContainer) scrollContainer.scrollTop = savedScrollTop
+                        if (rootElement) rootElement.scrollTop = savedElementScrollTop
                     })
                 }
             })

--- a/web/packages/agenta-ui/src/Editor/plugins/markdown/markdownPlugin.tsx
+++ b/web/packages/agenta-ui/src/Editor/plugins/markdown/markdownPlugin.tsx
@@ -124,19 +124,47 @@ const MarkdownPlugin = ({id}: {id: string}) => {
         return editor.registerCommand(
             KEY_ENTER_COMMAND,
             (event) => {
-                editor.update(() => {
+                // Read-only check: determine if cursor is inside a markdown CodeNode
+                const shouldHandle = editor.getEditorState().read(() => {
                     const selection = $getSelection()
                     if (!$isRangeSelection(selection)) return false
-
                     const anchorNode = selection.anchor.getNode()
                     const topNode = anchorNode.getTopLevelElementOrThrow()
-
-                    if ($isCodeNode(topNode) && topNode.getLanguage() === "markdown") {
-                        event?.preventDefault()
-                        selection.insertRawText("\n")
-                        return true
-                    }
+                    return $isCodeNode(topNode) && topNode.getLanguage() === "markdown"
                 })
+
+                if (!shouldHandle) return false
+
+                event?.preventDefault()
+
+                // Save scroll position before inserting text to prevent
+                // the browser from auto-scrolling to the bottom
+                const rootElement = editor.getRootElement()
+                const scrollContainer = rootElement?.closest(
+                    ".agenta-editor-wrapper",
+                ) as HTMLElement | null
+                const savedScrollTop = scrollContainer?.scrollTop ?? 0
+                const savedElementScrollTop = rootElement?.scrollTop ?? 0
+
+                // {discrete: true} ensures DOM is flushed synchronously
+                editor.update(
+                    () => {
+                        const selection = $getSelection()
+                        if ($isRangeSelection(selection)) {
+                            selection.insertRawText("\n")
+                        }
+                    },
+                    {discrete: true},
+                )
+
+                // Restore scroll after DOM flush.
+                // Use rAF to also cover the merge-back update from
+                // the registerUpdateListener that follows this effect.
+                requestAnimationFrame(() => {
+                    if (scrollContainer) scrollContainer.scrollTop = savedScrollTop
+                    if (rootElement) rootElement.scrollTop = savedElementScrollTop
+                })
+
                 return true
             },
             COMMAND_PRIORITY_HIGH,
@@ -158,6 +186,15 @@ const MarkdownPlugin = ({id}: {id: string}) => {
                 const trailingNodes = children.slice(index + 1)
 
                 if (trailingNodes.length > 0) {
+                    // Save scroll position before merging trailing nodes back,
+                    // as this second editor.update() can also trigger scroll jumps
+                    const rootElement = editor.getRootElement()
+                    const scrollContainer = rootElement?.closest(
+                        ".agenta-editor-wrapper",
+                    ) as HTMLElement | null
+                    const savedScrollTop = scrollContainer?.scrollTop ?? 0
+                    const savedElementScrollTop = rootElement?.scrollTop ?? 0
+
                     editor.update(() => {
                         for (const node of trailingNodes) {
                             const content = node.getTextContent()
@@ -166,6 +203,12 @@ const MarkdownPlugin = ({id}: {id: string}) => {
                             )
                             node.remove()
                         }
+                    })
+
+                    // Restore scroll after the merge-back DOM update
+                    requestAnimationFrame(() => {
+                        if (scrollContainer) scrollContainer.scrollTop = savedScrollTop
+                        if (rootElement) rootElement.scrollTop = savedElementScrollTop
                     })
                 }
             })


### PR DESCRIPTION
## Summary

Fixes a bug where pressing Enter in the markdown editing mode of the prompt editor causes it to scroll to the bottom of the text, forcing the user to re-scroll after every newline.

### Root Cause

Two issues in the `KEY_ENTER_COMMAND` handler in `markdownPlugin.tsx`:

1. **Scroll jump from `insertRawText("\n")`** — Lexical reconciles the DOM and sets the browser selection at the new cursor position, which triggers the browser's native scroll-into-view behavior on the caret.

2. **Command handler always returned `true`** — The handler unconditionally claimed to handle the Enter key even when the cursor was NOT in a markdown CodeNode, preventing Lexical's default rich-text Enter behavior from running in non-markdown mode.

3. **Merge-back update listener** — A `registerUpdateListener` that merges trailing nodes back into the CodeNode runs a second `editor.update()` cycle, causing an additional scroll jump after the first restore.

### Fix

- Use a **read-only check** (`editor.getEditorState().read()`) to determine if we're in a markdown CodeNode before entering the update
- Return `false` early when not in markdown mode, so Lexical's default Enter handling works normally
- **Save scroll position** before the insertion, flush DOM synchronously with `{discrete: true}`, then **restore via `requestAnimationFrame`**
- Add the same scroll save/restore protection to the merge-back `registerUpdateListener`

### Files Changed

- `web/packages/agenta-ui/src/Editor/plugins/markdown/markdownPlugin.tsx`
- `web/oss/src/components/Editor/plugins/markdown/markdownPlugin.tsx`
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/agenta-ai/agenta/pull/3843" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open with Devin">
  </picture>
</a>
<!-- devin-review-badge-end -->
