### PR TITLE
fix(frontend): widen playground variant selector dropdown

### DIFF
--- a/web/oss/src/components/Playground/Components/Menus/SelectVariant/index.tsx
+++ b/web/oss/src/components/Playground/Components/Menus/SelectVariant/index.tsx
@@ -304,7 +304,7 @@ const SelectVariant = ({
 
     // Normal mode: standard picker
     return (
-        <div style={style ?? {width: 120}}>
+        <div style={style ?? {width: 200}}>
             <EntityPicker<PlaygroundRevisionSelectionResult>
                 variant="tree-select"
                 adapter={adapter}


### PR DESCRIPTION
## Summary

The variant/prompt name dropdown in the playground header was only 120px wide, causing prompt names to be truncated and unreadable.

Increases the default width from 120px to 200px in `SelectVariant`.

### File Changed

- `web/oss/src/components/Playground/Components/Menus/SelectVariant/index.tsx`
<!-- devin-review-badge-begin -->
<img width="2150" height="1406" alt="CleanShot 2026-02-26 at 19 31 25@2x" src="https://github.com/user-attachments/assets/50801dab-26dc-42c9-9437-2fc649006d71" />

---

<a href="https://app.devin.ai/review/agenta-ai/agenta/pull/3844" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open with Devin">
  </picture>
</a>
<!-- devin-review-badge-end -->
