### PR TITLE
[3845] feat(observability): support lexicographic string range filters

### DIFF
--- a/api/oss/src/core/tracing/utils.py
+++ b/api/oss/src/core/tracing/utils.py
@@ -1144,14 +1144,14 @@ def _parse_enum_field_condition(condition: Condition, enum: type) -> None:
 
 
 def _parse_string_field_condition(condition: Condition) -> None:
-    if condition.operator not in _C_OPS + _S_OPS + _L_OPS + _E_OPS:
+    if condition.operator not in _C_OPS + _N_OPS + _S_OPS + _L_OPS + _E_OPS:
         raise FilteringException(
-            "'status_message' only supports comparison, string, list, and existence operators.",
+            "'status_message' only supports comparison, numeric, string, list, and existence operators.",
         )
 
-    if condition.operator in _S_OPS + _L_OPS and condition.value is None:
+    if condition.operator in _N_OPS + _S_OPS + _L_OPS and condition.value is None:
         raise FilteringException(
-            "'status_message' value is required and thus never null for string and list operators.",
+            "'status_message' value is required and thus never null for numeric, string, and list operators.",
         )
 
     if condition.operator in _E_OPS and condition.value is not None:

--- a/api/oss/src/dbs/postgres/tracing/utils.py
+++ b/api/oss/src/dbs/postgres/tracing/utils.py
@@ -522,6 +522,14 @@ def _handle_string_field(
                 value=value,
             )
         )
+    elif isinstance(operator, NumericOperator):
+        clauses.extend(
+            _handle_numeric_operator(
+                attribute=attribute,
+                operator=operator,
+                value=value,
+            )
+        )
     elif isinstance(operator, StringOperator):
         clauses.extend(
             _handle_string_operator(

--- a/docs/design/string-comparison-operators/README.md
+++ b/docs/design/string-comparison-operators/README.md
@@ -1,0 +1,32 @@
+# String Comparison Operators for Tracing Filters
+
+Add lexicographic comparison operators (`>`, `<`, `>=`, `<=`) to string attributes in the tracing/observability filter system.
+
+## Problem
+
+Users store datetime strings in custom attributes (e.g., `tags.created_at = "2024-01-15T10:30:00Z"`) and want to query ranges. Before this work:
+
+- The UI did not expose `gt`/`lt`/`gte`/`lte` for string custom fields
+- String field parsing in core did not allow numeric comparison operators
+- DAO string-field handling did not route numeric operators for plain string columns
+
+## Solution
+
+Reuse existing `NumericOperator` values (`gt`, `lt`, `gte`, `lte`) for strings by allowing them in string parsing and routing them in DAO handling. PostgreSQL naturally supports lexicographic comparison on text, so ISO8601 datetime strings sort correctly.
+
+## Files
+
+| File | Description |
+|------|-------------|
+| [context.md](./context.md) | Background, motivation, user request |
+| [plan.md](./plan.md) | Execution plan with phases |
+| [research.md](./research.md) | Code analysis and implementation details |
+| [status.md](./status.md) | Current progress |
+
+## Effort Estimate
+
+**Low complexity** - ~2-3 hours total
+
+- Backend: ~1 hour (parser + handler routing changes)
+- Frontend: ~1 hour (registry + field config changes)
+- Testing: ~30 min

--- a/docs/design/string-comparison-operators/context.md
+++ b/docs/design/string-comparison-operators/context.md
@@ -1,0 +1,37 @@
+# Context
+
+## User Request
+
+From Slack conversation with a user integrating Agenta for observability:
+
+> "How do we filter by `tags.created_at` in between a date range?"
+
+The user stores a datetime as a string attribute (`tags.created_at = "2024-01-15T10:30:00Z"`) and wants to query spans where this value falls within a range.
+
+## Current Limitation
+
+The tracing filter system has operator families:
+
+| Operator Family | Supports `>` / `<`? | Notes |
+|-----------------|---------------------|-------|
+| `StringOperator` | **No** | Only pattern matching: `contains`, `like`, `startswith`, `endswith`, `matches` |
+| `NumericOperator` | Yes | But casts to `FLOAT` - fails on non-numeric strings |
+| `ComparisonOperator` | No | Only `is` / `is_not` (JSONB containment) |
+
+## Why This Matters
+
+1. **Common use case**: Users store timestamps, version strings, or other ordered data as string attributes
+2. **ISO8601 dates sort lexicographically**: `"2024-01-15" < "2024-01-20"` works as expected with string comparison
+3. **Workaround is clunky**: Storing a separate numeric timestamp field doubles the data
+
+## Goals
+
+1. Enable `gt`, `lt`, `gte`, `lte` operators on string attributes
+2. Support lexicographic comparison (PostgreSQL's natural text ordering)
+3. Expose these operators in the UI for string-type fields
+
+## Non-Goals
+
+- **NOT** adding date/datetime parsing or timezone handling - users are responsible for consistent string formats
+- **NOT** changing how existing operators work
+- **NOT** adding `between` for strings (can be composed with `gte` + `lte`)

--- a/docs/design/string-comparison-operators/plan.md
+++ b/docs/design/string-comparison-operators/plan.md
@@ -1,0 +1,300 @@
+# Execution Plan
+
+## Phase 1: Backend Changes
+
+### 1.1 Reuse numeric operators for string comparisons
+
+No new enum values are needed. `gt`/`lt`/`gte`/`lte` already exist in `NumericOperator` and can be reused for lexicographic string comparisons.
+
+### 1.2 Allow numeric operators on string fields
+
+**File:** `api/oss/src/core/tracing/utils.py`
+
+Update `_parse_string_field_condition()` to accept `_N_OPS` in addition to comparison/string/list/existence ops.
+
+### 1.3 Route numeric operators for string fields in DAO
+
+**File:** `api/oss/src/dbs/postgres/tracing/utils.py`
+
+Update `_handle_string_field()` to dispatch `NumericOperator` through `_handle_numeric_operator()`, which already performs lexicographic comparisons for string values.
+
+### 1.4 Verify attribute-field compatibility
+
+`_parse_attributes_condition()` only checks that `key` is present, and `_handle_attributes_field()` already supports `NumericOperator` values with string casts when needed.
+
+---
+
+## Phase 2: Frontend Changes
+
+### 2.1 Update operator registry
+
+**File:** `web/oss/src/components/pages/observability/assets/filters/operatorRegistry.ts`
+
+Change `forTypes` for comparison operators:
+
+```typescript
+{id: "gt", label: ">", forTypes: ["number", "string"], valueShape: "single"},
+{id: "lt", label: "<", forTypes: ["number", "string"], valueShape: "single"},
+{id: "gte", label: ">=", forTypes: ["number", "string"], valueShape: "single"},
+{id: "lte", label: "<=", forTypes: ["number", "string"], valueShape: "single"},
+```
+
+### 2.2 Add string comparison ops array
+
+**File:** `web/oss/src/components/pages/observability/assets/utils.ts`
+
+```typescript
+export const STRING_COMPARISON_OPS: {value: FilterConditions; label: string}[] = [
+    {value: "gt", label: ">"},
+    {value: "lt", label: "<"},
+    {value: "gte", label: ">="},
+    {value: "lte", label: "<="},
+]
+```
+
+### 2.3 Update custom field operators
+
+**File:** `web/oss/src/components/Filters/helpers/utils.ts`
+
+```typescript
+export const customOperatorIdsForType = (t: CustomValueType): FilterConditions[] =>
+    t === "number"
+        ? ["eq", "neq", "gt", "lt", "gte", "lte"]
+        : t === "boolean"
+          ? ["is", "is_not"]
+          : ["is", "is_not", "contains", "startswith", "endswith", "in", "not_in", "gt", "lt", "gte", "lte"]
+```
+
+---
+
+## Phase 3: E2E Tests
+
+### 3.1 API E2E Tests
+
+**File:** `api/oss/tests/pytest/e2e/tracing/test_spans_queries.py`
+
+Add test cases to the existing `TestSpansQueries` class. Following the existing fixture pattern:
+
+```python
+@pytest.fixture(scope="class")
+def string_comparison_data(authed_api):
+    """Create spans with datetime string attributes for comparison tests."""
+    trace_id = uuid4().hex
+    
+    spans = [
+        {
+            "trace_id": trace_id,
+            "span_id": uuid4().hex[:16],
+            "span_name": "span_jan_15",
+            "span_kind": "SPAN_KIND_SERVER",
+            "start_time": 1705312200,  # 2024-01-15
+            "end_time": 1705315800,
+            "status_code": "STATUS_CODE_OK",
+            "attributes": {
+                "tags": {"created_at": "2024-01-15T10:30:00Z"},
+            },
+        },
+        {
+            "trace_id": trace_id,
+            "span_id": uuid4().hex[:16],
+            "span_name": "span_jan_20",
+            "span_kind": "SPAN_KIND_SERVER",
+            "start_time": 1705744200,  # 2024-01-20
+            "end_time": 1705747800,
+            "status_code": "STATUS_CODE_OK",
+            "attributes": {
+                "tags": {"created_at": "2024-01-20T10:30:00Z"},
+            },
+        },
+        {
+            "trace_id": trace_id,
+            "span_id": uuid4().hex[:16],
+            "span_name": "span_jan_25",
+            "span_kind": "SPAN_KIND_SERVER",
+            "start_time": 1706176200,  # 2024-01-25
+            "end_time": 1706179800,
+            "status_code": "STATUS_CODE_OK",
+            "attributes": {
+                "tags": {"created_at": "2024-01-25T10:30:00Z"},
+            },
+        },
+    ]
+    
+    response = authed_api(
+        "POST",
+        "/preview/tracing/spans/ingest",
+        json={"spans": spans},
+    )
+    assert response.status_code == 202
+    
+    # Wait for ingestion
+    wait_for_response(
+        authed_api,
+        "POST",
+        "/preview/tracing/spans/query",
+        json={
+            "focus": "span",
+            "filter": {"conditions": [{"field": "trace_id", "operator": "is", "value": trace_id}]},
+        },
+        condition_fn=lambda r: r.json().get("count", 0) >= 3,
+    )
+    
+    return {"trace_id": trace_id, "spans": spans}
+
+
+class TestStringComparisonOperators:
+    """Tests for string comparison operators (gt, lt, gte, lte)."""
+
+    @pytest.mark.coverage_smoke
+    @pytest.mark.path_happy
+    def test_string_gt_operator(self, authed_api, string_comparison_data):
+        """Test 'gt' (greater than) operator on string attributes."""
+        trace_id = string_comparison_data["trace_id"]
+        
+        response = authed_api(
+            "POST",
+            "/preview/tracing/spans/query",
+            json={
+                "focus": "span",
+                "filter": {
+                    "conditions": [
+                        {"field": "trace_id", "operator": "is", "value": trace_id},
+                        {"field": "attributes", "key": "tags.created_at", "operator": "gt", "value": "2024-01-15"},
+                    ]
+                },
+            },
+        )
+        
+        assert response.status_code == 200
+        data = response.json()
+        # Should return jan_20 and jan_25 (not jan_15)
+        assert data["count"] == 2
+
+    @pytest.mark.coverage_smoke
+    @pytest.mark.path_happy
+    def test_string_gte_operator(self, authed_api, string_comparison_data):
+        """Test 'gte' (greater than or equal) operator on string attributes."""
+        trace_id = string_comparison_data["trace_id"]
+        
+        response = authed_api(
+            "POST",
+            "/preview/tracing/spans/query",
+            json={
+                "focus": "span",
+                "filter": {
+                    "conditions": [
+                        {"field": "trace_id", "operator": "is", "value": trace_id},
+                        {"field": "attributes", "key": "tags.created_at", "operator": "gte", "value": "2024-01-20"},
+                    ]
+                },
+            },
+        )
+        
+        assert response.status_code == 200
+        data = response.json()
+        # Should return jan_20 and jan_25
+        assert data["count"] == 2
+
+    @pytest.mark.coverage_smoke
+    @pytest.mark.path_happy
+    def test_string_lt_operator(self, authed_api, string_comparison_data):
+        """Test 'lt' (less than) operator on string attributes."""
+        trace_id = string_comparison_data["trace_id"]
+        
+        response = authed_api(
+            "POST",
+            "/preview/tracing/spans/query",
+            json={
+                "focus": "span",
+                "filter": {
+                    "conditions": [
+                        {"field": "trace_id", "operator": "is", "value": trace_id},
+                        {"field": "attributes", "key": "tags.created_at", "operator": "lt", "value": "2024-01-25"},
+                    ]
+                },
+            },
+        )
+        
+        assert response.status_code == 200
+        data = response.json()
+        # Should return jan_15 and jan_20 (not jan_25)
+        assert data["count"] == 2
+
+    @pytest.mark.coverage_smoke
+    @pytest.mark.path_happy
+    def test_string_lte_operator(self, authed_api, string_comparison_data):
+        """Test 'lte' (less than or equal) operator on string attributes."""
+        trace_id = string_comparison_data["trace_id"]
+        
+        response = authed_api(
+            "POST",
+            "/preview/tracing/spans/query",
+            json={
+                "focus": "span",
+                "filter": {
+                    "conditions": [
+                        {"field": "trace_id", "operator": "is", "value": trace_id},
+                        {"field": "attributes", "key": "tags.created_at", "operator": "lte", "value": "2024-01-15"},
+                    ]
+                },
+            },
+        )
+        
+        assert response.status_code == 200
+        data = response.json()
+        # Should return only jan_15
+        assert data["count"] == 1
+
+    @pytest.mark.coverage_smoke
+    @pytest.mark.path_happy
+    def test_string_range_query(self, authed_api, string_comparison_data):
+        """Test combining gte + lt for range query on string attributes."""
+        trace_id = string_comparison_data["trace_id"]
+        
+        response = authed_api(
+            "POST",
+            "/preview/tracing/spans/query",
+            json={
+                "focus": "span",
+                "filter": {
+                    "operator": "and",
+                    "conditions": [
+                        {"field": "trace_id", "operator": "is", "value": trace_id},
+                        {"field": "attributes", "key": "tags.created_at", "operator": "gte", "value": "2024-01-15"},
+                        {"field": "attributes", "key": "tags.created_at", "operator": "lt", "value": "2024-01-25"},
+                    ]
+                },
+            },
+        )
+        
+        assert response.status_code == 200
+        data = response.json()
+        # Should return jan_15 and jan_20 (not jan_25)
+        assert data["count"] == 2
+```
+
+### 3.2 Run Tests
+
+```bash
+# Run only the new string comparison tests
+cd api
+AGENTA_API_URL=http://localhost:10180/api AGENTA_AUTH_KEY=change-me-auth \
+  python -m pytest oss/tests/pytest/e2e/tracing/test_spans_queries.py::TestStringComparisonOperators -v
+
+# Run all tracing tests
+python -m pytest oss/tests/pytest/e2e/tracing/ -v -m coverage_smoke
+```
+
+---
+
+## Checklist
+
+- [x] Backend: Allow numeric operators in `_parse_string_field_condition()`
+- [x] Backend: Route numeric operators in `_handle_string_field()`
+- [x] Tests: Add API E2E tests for string comparison operators
+- [ ] Tests: Run `python -m pytest oss/tests/pytest/e2e/tracing/ -v` (blocked locally: API server not running)
+- [x] Frontend: Update `operatorRegistry.ts` - add `"string"` to `forTypes`
+- [x] Frontend: Add `STRING_COMPARISON_OPS` array in `utils.ts`
+- [x] Frontend: Update `customOperatorIdsForType()` in `helpers/utils.ts`
+- [x] Linting: Run `ruff format && ruff check --fix` in `api/`
+- [x] Linting: Run `pnpm lint-fix` in `web/`

--- a/docs/design/string-comparison-operators/research.md
+++ b/docs/design/string-comparison-operators/research.md
@@ -1,0 +1,224 @@
+# Research
+
+## Backend Architecture
+
+### Operator Flow
+
+```
+API Request (JSON filter)
+    ↓
+api/oss/src/apis/fastapi/tracing/utils.py
+    → _parse_filtering() constructs Filtering DTO
+    ↓
+api/oss/src/core/tracing/utils.py
+    → parse_condition() validates operators per field
+    → _parse_attributes_condition() - minimal validation, just requires key
+    ↓
+api/oss/src/dbs/postgres/tracing/utils.py
+    → _handle_string_operator() generates SQL clauses
+```
+
+### Key Files
+
+#### 1. String Condition Validation
+
+**File:** `api/oss/src/core/tracing/utils.py` (`_parse_string_field_condition`)
+
+```python
+def _parse_string_field_condition(condition: Condition) -> None:
+    if condition.operator not in _C_OPS + _N_OPS + _S_OPS + _L_OPS + _E_OPS:
+        raise FilteringException(...)
+
+    if condition.operator in _N_OPS + _S_OPS + _L_OPS and condition.value is None:
+        raise FilteringException(...)
+```
+
+**Change:** Permit numeric operators (`gt`, `lt`, `gte`, `lte`) for string fields.
+
+#### 2. SQL Handler Routing for String Fields
+
+**File:** `api/oss/src/dbs/postgres/tracing/utils.py` (`_handle_string_field`)
+
+```python
+elif isinstance(operator, NumericOperator):
+    clauses.extend(
+        _handle_numeric_operator(
+            attribute=attribute,
+            operator=operator,
+            value=value,
+        )
+    )
+```
+
+**Change:** Route numeric operators to `_handle_numeric_operator()` for plain string columns.
+
+#### 3. Existing String Handler
+
+**File:** `api/oss/src/dbs/postgres/tracing/utils.py` (lines 177-239)
+
+```python
+def _handle_string_operator(
+    *,
+    attribute: ColumnElement,
+    operator: StringOperator,
+    value: str,
+    options: Optional[TextOptions] = None,
+    key: Optional[str] = None,
+) -> List[ColumnElement]:
+    # ... handles JSONB path extraction if key is provided
+    # ... then applies operator-specific SQL
+```
+
+**No change needed** inside `_handle_string_operator()` itself.
+
+#### 4. Attributes Validation
+
+**File:** `api/oss/src/core/tracing/utils.py` (lines 913-918)
+
+```python
+def _parse_attributes_condition(condition: Condition) -> None:
+    if condition.key is None:
+        raise FilteringException(
+            "'attributes' key is required and thus never null.",
+        )
+```
+
+**No change needed** - attributes field already allows numeric operators and only validates that `key` is present.
+
+### SQL Generation for JSONB String Comparison
+
+When filtering on `attributes.tags.created_at > "2024-01-15"`:
+
+```python
+# Existing flow in _handle_numeric_operator() for attributes with key:
+if key is not None:
+    container, leaf = _to_jsonb_path(attribute, key, leaf_as_text=False)
+    clauses.append(container.op("?")(leaf))  # Ensure key exists
+
+    attribute, _ = _to_jsonb_path(attribute, key)  # Extract as TEXT via ->>
+    attribute = cast(attribute, String)
+
+if operator == NumericOperator.GT:
+    clauses.append(attribute > value)
+elif operator == NumericOperator.LT:
+    clauses.append(attribute < value)
+```
+
+**Generated SQL:**
+
+```sql
+-- For: attributes.tags.created_at > "2024-01-15"
+WHERE attributes->'tags' ? 'created_at'
+  AND CAST(attributes->'tags'->>'created_at' AS VARCHAR) > '2024-01-15'
+```
+
+PostgreSQL's `>` on `VARCHAR` performs lexicographic comparison, so ISO8601 dates sort correctly.
+
+---
+
+## Frontend Architecture
+
+### Operator Definition Flow
+
+```
+operatorRegistry.ts
+    → Defines which operators apply to which types
+    ↓
+utils.ts (STRING_EQU_OPS, NUM_OPS, etc.)
+    → Groups operators for easy reference
+    ↓
+constants.ts (FILTER_COLUMNS)
+    → Each field specifies its operatorOptions
+    ↓
+Filters.tsx
+    → Renders operator dropdown based on field config
+```
+
+### Key Files
+
+#### 1. Operator Registry
+
+**File:** `web/oss/src/components/pages/observability/assets/filters/operatorRegistry.ts` (lines 39-44)
+
+```typescript
+// Currently only for "number" type:
+{id: "gt", label: ">", forTypes: ["number"], valueShape: "single"},
+{id: "lt", label: "<", forTypes: ["number"], valueShape: "single"},
+{id: "gte", label: ">=", forTypes: ["number"], valueShape: "single"},
+{id: "lte", label: "<=", forTypes: ["number"], valueShape: "single"},
+```
+
+**Change:** Add `"string"` to `forTypes`.
+
+#### 2. Operator Arrays
+
+**File:** `web/oss/src/components/pages/observability/assets/utils.ts` (lines 21-56)
+
+```typescript
+export const STRING_EQU_OPS: {value: FilterConditions; label: string}[] = [...]
+export const STRING_SEARCH_OPS: {value: FilterConditions; label: string}[] = [...]
+export const NUM_OPS: {value: FilterConditions; label: string}[] = [...]
+```
+
+**Change:** Add `STRING_COMPARISON_OPS` array.
+
+#### 3. Custom Field Operators
+
+**File:** `web/oss/src/components/Filters/helpers/utils.ts` (lines 159-164)
+
+```typescript
+export const customOperatorIdsForType = (t: CustomValueType): FilterConditions[] =>
+    t === "number"
+        ? ["eq", "neq", "gt", "lt", "gte", "lte"]
+        : t === "boolean"
+          ? ["is", "is_not"]
+          : ["is", "is_not", "contains", "startswith", "endswith", "in", "not_in"]
+```
+
+**Change:** Add `"gt", "lt", "gte", "lte"` to the string case.
+
+#### 4. Field Configuration
+
+**File:** `web/oss/src/components/pages/observability/assets/constants.ts`
+
+Each field's `operatorOptions` array controls what operators appear in the dropdown. For custom/dynamic attributes, this is derived from `customOperatorIdsForType`.
+
+---
+
+## Testing Considerations
+
+### Backend
+
+1. Unit test `_handle_string_operator()` with new operators
+2. Integration test: query spans with `attributes.tags.created_at > "2024-01-15"`
+3. Edge cases:
+   - Empty string comparison
+   - Unicode strings
+   - Very long strings
+
+### Frontend
+
+1. Verify operator dropdown shows `>`, `<`, `>=`, `<=` for string fields
+2. Verify filter payload includes correct operator
+3. Test with custom attributes added via "Add Filter" flow
+
+---
+
+## Alternatives Considered
+
+### 1. Add a `DatetimeOperator` family
+
+**Rejected** because:
+- Requires knowing which attributes contain dates
+- Adds parsing/timezone complexity
+- Lexicographic string comparison works for ISO8601
+
+### 2. Allow `NumericOperator` on strings (skip cast)
+
+**Rejected** because:
+- Confusing semantics (same operator, different behavior based on value type)
+- Would need to detect "is this value numeric?" logic
+
+### 3. Add `btwn` (between) for strings
+
+**Deferred** - can be composed with `gte` + `lte` via `AND`. Add later if users request it.

--- a/docs/design/string-comparison-operators/status.md
+++ b/docs/design/string-comparison-operators/status.md
@@ -1,0 +1,61 @@
+# Status
+
+## Current State: Implemented and Validated on Deployed Instance
+
+**Last updated:** 2026-02-26
+
+---
+
+## Summary
+
+This feature is implemented across backend, frontend, and API E2E tests.
+
+| Layer | Files | Status |
+|-------|-------|--------|
+| Backend | `dtos.py`, `utils.py` | Done |
+| Backend tests | `test_spans_queries.py` | Done |
+| Frontend | `operatorRegistry.ts`, `constants.ts`, `utils.ts`, `helpers/utils.ts` | Done |
+
+**Estimated effort:** 2-3 hours total
+
+---
+
+## Progress
+
+### Backend
+
+- [x] Research: Identified operator enum location
+- [x] Research: Identified SQL handler function
+- [x] Research: Verified no validation blockers
+- [x] Implementation: Allow numeric operators for string fields in parser
+- [x] Implementation: Route numeric operators for string fields in DAO
+- [x] Testing: Add E2E tests to `api/oss/tests/pytest/e2e/tracing/test_spans_queries.py`
+- [x] Testing: Run test class against running API
+
+### Frontend
+
+- [x] Research: Identified operator registry
+- [x] Research: Identified custom field operator mapping
+- [x] Implementation: Update operator registry
+- [x] Implementation: Add `STRING_COMPARISON_OPS`
+- [x] Implementation: Update customOperatorIdsForType
+- [x] Implementation: Add comparison ops to Custom field operator options
+- [x] Linting: Run `pnpm lint-fix` in `web/`
+
+---
+
+## Blockers
+
+None.
+
+---
+
+## Notes
+
+- PostgreSQL lexicographic comparison works correctly for ISO8601 dates
+- No changes needed to validation layer (`_parse_attributes_condition`)
+- The `between` operator is intentionally deferred (can be composed with `gte` + `lte`)
+- API lint/format completed with: `uvx --from ruff==0.14.0 ruff format ...` and `ruff check --fix ...`
+- Validated against deployed instance at `http://144.76.237.122:8280` using:
+  - `AGENTA_API_URL=http://144.76.237.122:8280/api AGENTA_AUTH_KEY=replace-me uvx --from pytest --with requests --with python-dotenv pytest -c /dev/null oss/tests/pytest/e2e/tracing/test_spans_queries.py::TestSpanStringComparisonOperators -v`
+  - Result: `5 passed`

--- a/docs/docs/observability/query-data/01-query-api.mdx
+++ b/docs/docs/observability/query-data/01-query-api.mdx
@@ -304,6 +304,10 @@ For nested attributes, use dot notation:
 
 **`btwn`**: Between (inclusive, provide array `[min, max]`)
 
+`gt`, `gte`, `lt`, and `lte` can also be used for lexicographic comparisons on string values (for example `span_name`, `status_message`, or string attributes).
+
+For datetime strings, use a consistent ISO 8601 format (for example `2024-01-15T10:30:00Z`) so ordering is reliable.
+
 Example filtering by duration:
 
 ```json
@@ -323,6 +327,30 @@ Example using between:
   "key": "ag.metrics.unit.duration",
   "operator": "btwn",
   "value": [500, 2000]
+}
+```
+
+Example filtering a string datetime attribute:
+
+```json
+{
+  "filter": {
+    "operator": "and",
+    "conditions": [
+      {
+        "field": "attributes",
+        "key": "tags.created_at",
+        "operator": "gte",
+        "value": "2024-01-15T00:00:00Z"
+      },
+      {
+        "field": "attributes",
+        "key": "tags.created_at",
+        "operator": "lt",
+        "value": "2024-01-20T00:00:00Z"
+      }
+    ]
+  }
 }
 ```
 

--- a/web/oss/src/components/Filters/helpers/utils.ts
+++ b/web/oss/src/components/Filters/helpers/utils.ts
@@ -161,7 +161,19 @@ export const customOperatorIdsForType = (t: CustomValueType): FilterConditions[]
         ? ["eq", "neq", "gt", "lt", "gte", "lte"]
         : t === "boolean"
           ? ["is", "is_not"]
-          : ["is", "is_not", "contains", "startswith", "endswith", "in", "not_in"]
+          : [
+                "is",
+                "is_not",
+                "contains",
+                "startswith",
+                "endswith",
+                "in",
+                "not_in",
+                "gt",
+                "lt",
+                "gte",
+                "lte",
+            ]
 
 export const operatorOptionsFromIds = (ids: FilterConditions[]) =>
     ids.map((id) => {

--- a/web/oss/src/components/pages/observability/assets/constants.ts
+++ b/web/oss/src/components/pages/observability/assets/constants.ts
@@ -25,6 +25,7 @@ import {SpanCategory} from "@/oss/services/tracing/types"
 import {
     COLLECTION_MEMBERSHIP_OPS,
     NUM_OPS,
+    STRING_COMPARISON_OPS,
     STRING_EQU_AND_CONTAINS_OPS,
     STRING_EQU_OPS,
     STRING_SEARCH_OPS,
@@ -634,6 +635,7 @@ export const FILTER_COLUMNS: FilterMenuNode[] = [
             {value: "endswith", label: "ends with"},
             {value: "in", label: "in"},
             {value: "not_in", label: "not in"},
+            ...STRING_COMPARISON_OPS,
         ],
         valueInput: {kind: "text", placeholder: "Value"},
     },

--- a/web/oss/src/components/pages/observability/assets/filters/operatorRegistry.ts
+++ b/web/oss/src/components/pages/observability/assets/filters/operatorRegistry.ts
@@ -38,10 +38,10 @@ export const OPERATORS: OperatorDef[] = [
     // numeric
     {id: "eq", label: "=", forTypes: ["number"], valueShape: "single"},
     {id: "neq", label: "!=", forTypes: ["number"], valueShape: "single"},
-    {id: "gt", label: ">", forTypes: ["number"], valueShape: "single"},
-    {id: "lt", label: "<", forTypes: ["number"], valueShape: "single"},
-    {id: "gte", label: ">=", forTypes: ["number"], valueShape: "single"},
-    {id: "lte", label: "<=", forTypes: ["number"], valueShape: "single"},
+    {id: "gt", label: ">", forTypes: ["number", "string"], valueShape: "single"},
+    {id: "lt", label: "<", forTypes: ["number", "string"], valueShape: "single"},
+    {id: "gte", label: ">=", forTypes: ["number", "string"], valueShape: "single"},
+    {id: "lte", label: "<=", forTypes: ["number", "string"], valueShape: "single"},
 ]
 
 export const getOperator = (id: FilterConditions) => OPERATORS.find((o) => o.id === id)!

--- a/web/oss/src/components/pages/observability/assets/utils.ts
+++ b/web/oss/src/components/pages/observability/assets/utils.ts
@@ -46,6 +46,13 @@ export const STRING_SEARCH_OPS: {value: FilterConditions; label: string}[] = [
     // {value: "like", label: "like"},
 ]
 
+export const STRING_COMPARISON_OPS: {value: FilterConditions; label: string}[] = [
+    {value: "gt", label: ">"},
+    {value: "lt", label: "<"},
+    {value: "gte", label: ">="},
+    {value: "lte", label: "<="},
+]
+
 export const NUM_OPS: {value: FilterConditions; label: string}[] = [
     {value: "eq", label: "="},
     {value: "neq", label: "!="},


### PR DESCRIPTION
## Summary
- Allow `gt/gte/lt/lte` for string fields in tracing query parsing and DAO routing, enabling lexicographic range filtering for string values (including datetime strings stored in attributes).
- Expose these operators in the Observability filter UI for string/custom fields.
- Add API E2E coverage for string comparison operators and update Query API docs with string range guidance and examples.

## Linked issue
- Closes #3845

## Validation
- `uvx --from ruff==0.14.0 ruff format oss/src/core/tracing/utils.py oss/src/dbs/postgres/tracing/utils.py oss/tests/pytest/e2e/tracing/test_spans_queries.py`
- `uvx --from ruff==0.14.0 ruff check --fix oss/src/core/tracing/utils.py oss/src/dbs/postgres/tracing/utils.py oss/tests/pytest/e2e/tracing/test_spans_queries.py`
- `corepack pnpm lint-fix` (from `web/`)
- `AGENTA_API_URL=http://144.76.237.122:8280/api AGENTA_AUTH_KEY=replace-me uvx --from pytest --with requests --with python-dotenv pytest -c /dev/null oss/tests/pytest/e2e/tracing/test_spans_queries.py::TestSpanStringComparisonOperators -v` (5 passed)

## Manual test steps
1. Open Observability and add a **Custom** filter using key `tags.created_at`.
2. Verify operators `>`, `>=`, `<`, `<=` are available for string custom fields.
3. Use range conditions:
   - `tags.created_at >= 2024-01-15T00:00:00Z`
   - `tags.created_at < 2024-01-20T00:00:00Z`
4. Confirm results include only spans with string datetime values in that lexical range.
5. Via API, POST to `/api/tracing/spans/query` with:
   - `{"field":"attributes","key":"tags.created_at","operator":"gte","value":"2024-01-15T00:00:00Z"}`
   - `{"field":"attributes","key":"tags.created_at","operator":"lt","value":"2024-01-20T00:00:00Z"}`
   and verify filtered results match UI output.
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/agenta-ai/agenta/pull/3846" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open with Devin">
  </picture>
</a>
<!-- devin-review-badge-end -->
