### PR TITLE
ci(docs): add daily cron workflow to update API reference docs

### DIFF
--- a/.github/workflows/09-update-api-docs.yml
+++ b/.github/workflows/09-update-api-docs.yml
@@ -26,7 +26,7 @@ jobs:
           node-version: 20
 
       - name: Download latest OpenAPI spec
-        run: curl -s "https://cloud.agenta.ai/api/openapi.json" -o docs/docs/reference/openapi.json
+        run: curl -sSf "https://cloud.agenta.ai/api/openapi.json" -o docs/docs/reference/openapi.json
 
       - name: Install docs dependencies
         working-directory: docs


### PR DESCRIPTION
## Summary

- Adds a new GitHub Actions workflow (`.github/workflows/09-update-api-docs.yml`) that automatically updates the API reference documentation
- Runs daily at 06:00 UTC via cron schedule (also supports manual `workflow_dispatch`)
- Downloads the latest OpenAPI spec from `https://cloud.agenta.ai/api/openapi.json`, regenerates the Docusaurus API docs, and creates a PR via `peter-evans/create-pull-request@v6` if there are any changes
- If there are no changes, no PR is created; if a PR already exists, it updates it instead of creating duplicates
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/agenta-ai/agenta/pull/3848" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open with Devin">
  </picture>
</a>
<!-- devin-review-badge-end -->
