### PR TITLE
feat(SDK): expose __version__ in agenta package

### DIFF
--- a/sdk/agenta/__init__.py
+++ b/sdk/agenta/__init__.py
@@ -1,6 +1,9 @@
 from importlib.metadata import version as _version
 
-__version__ = _version("agenta")
+try:
+    __version__ = _version("agenta")
+except Exception:
+    __version__ = "0.0.0-dev"
 
 from typing import Any, Callable, Optional
 


### PR DESCRIPTION
## Summary

- Adds `__version__` to the `agenta` package by reading it from installed package metadata via `importlib.metadata`
- The version stays in sync with `pyproject.toml` automatically — no hardcoding needed
- Users can now do `import agenta; print(agenta.__version__)` to get the installed version

## Testing

- All 25 passing unit tests continue to pass
- 1 pre-existing failing test (`test_handlers_jinja2_blocks_ssti_payload`) is unrelated to this change
- Linting: `ruff format` and `ruff check --fix` passed with no issues
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/agenta-ai/agenta/pull/3850" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open with Devin">
  </picture>
</a>
<!-- devin-review-badge-end -->
