### PR TITLE
fix(api): align evaluation invocation step key with SDK slug

### DIFF
--- a/api/oss/src/core/evaluations/service.py
+++ b/api/oss/src/core/evaluations/service.py
@@ -82,7 +82,6 @@ from oss.src.core.applications.services import ApplicationsService
 
 from oss.src.core.evaluations.utils import filter_scenario_ids
 
-from oss.src.utils.helpers import get_slug_from_name_and_id
 from oss.src.core.evaluations.utils import get_metrics_keys_from_schema
 
 
@@ -2271,12 +2270,14 @@ class SimpleEvaluationsService:
                     )
                     return None
 
-                application_revision_slug = get_slug_from_name_and_id(
-                    str(application_revision.name),
-                    application_revision.id,
-                )
+                if not application_revision.slug:
+                    log.warn(
+                        "[EVAL] [run] [make] [failure] application revision is missing slug",
+                        id=application_revision.id,
+                    )
+                    return None
 
-                step_key = "application-" + application_revision_slug
+                step_key = "application-" + application_revision.slug
 
                 application_invocation_steps_keys.append(step_key)
 


### PR DESCRIPTION
## Summary

Evaluation outputs were missing in the Eval Run Details UI because invocation results could not be matched to their invocation column. The match key is `step_key`.

This PR aligns API step key generation with SDK behavior for application invocation steps.

## Root cause

For each evaluation run:

1. The API builds run metadata (`steps` and `mappings`) in `api/oss/src/core/evaluations/service.py`.
2. The SDK logs per-scenario results with a `step_key` in `sdk/agenta/sdk/evaluations/preview/evaluate.py`.
3. The frontend joins run mappings and results by exact string equality on `step_key`.

The SDK uses the revision slug directly:

- `application_slug = application_revision.slug`
- `step_key = "application-" + application_slug`

The API previously recomputed a value with:

- `get_slug_from_name_and_id(str(application_revision.slug), application_revision.id)`

That recomputation can diverge from the stored revision slug, depending on how the revision slug was created. When they diverge, frontend joins fail and invocation outputs do not render.

## Fix

In `api/oss/src/core/evaluations/service.py`:

- Stop recomputing application invocation step keys with `get_slug_from_name_and_id`.
- Use the same source as the SDK: `application_revision.slug`.
- Add a defensive guard that returns early if the revision slug is missing.

New behavior:

- `step_key = "application-" + application_revision.slug`

This guarantees parity with SDK result logging.

## Why this is safe

- Step keys are opaque identifiers used only for joining run mappings to results.
- The frontend does not parse their internal format. It performs exact string matches.
- Aligning API to SDK removes fragile recomputation and makes key generation deterministic.
- Existing runs keep their historical keys. New runs generated after this change will consistently match SDK-logged results.

## Research notes

During debugging, we verified:

- Invocation output values exist in traces at `attributes.ag.data.outputs`.
- UI renderers already handle object outputs correctly.
- Missing output display was a join failure, not a rendering failure.
- The failure point was key mismatch between API run mappings and SDK result entries.