### PR TITLE
fix(frontend): filter non-aggregatable evaluator string metrics

### DIFF
--- a/docs/design/eval-metric-type-filtering/README.md
+++ b/docs/design/eval-metric-type-filtering/README.md
@@ -1,0 +1,10 @@
+# Evaluation Metric Type Filtering
+
+Text metrics like `reason` are incorrectly showing in aggregation views (overview table, histograms, spider chart). This workspace documents the root cause and fix.
+
+## Files
+
+- **context.md**: Problem statement, goals, non-goals
+- **research.md**: Technical investigation findings
+- **plan.md**: Implementation plan with phases
+- **status.md**: Progress updates

--- a/docs/design/eval-metric-type-filtering/context.md
+++ b/docs/design/eval-metric-type-filtering/context.md
@@ -1,0 +1,50 @@
+# Context
+
+## Problem
+
+Text metrics like `reason` (string explanations from evaluators) are showing up in evaluation aggregation views where they do not belong:
+
+1. **Overview summary table**: Shows aggregated stats for `reason` alongside `score` and `success`
+2. **Spider chart**: Attempts to plot `reason` as a numeric dimension
+3. **Histogram comparison**: Tries to render distribution charts for text values
+
+These views should only aggregate numeric and boolean metrics. Text fields have no meaningful average, median, or distribution.
+
+## Why it happens
+
+SDK-based evaluators (like DeepEval) return outputs with multiple fields:
+
+```python
+{
+    "score": 0.95,        # numeric - should aggregate
+    "success": True,      # boolean - should aggregate  
+    "reason": "The answer is factually correct because..."  # string - should NOT aggregate
+}
+```
+
+The evaluator schema metadata (`outputs.properties`) comes back empty for these evaluators because they are defined at runtime, not registered with explicit schemas. The frontend cannot determine metric types from schema alone.
+
+However, the backend DOES infer metric types during metrics refresh. Each stat object includes a `type` field:
+
+```json
+{
+    "score": {"type": "numeric/continuous", "mean": 0.95, "count": 5, ...},
+    "success": {"type": "binary", "freq": [...], "count": 5},
+    "reason": {"type": "string", "count": 5}
+}
+```
+
+The frontend preserves this field but never reads it for filtering decisions.
+
+## Goals
+
+1. Exclude text metrics from aggregation views (overview table, spider chart, histograms)
+2. Keep text metrics visible in the main results table (they render fine as text cells)
+3. Correctly include categorical and boolean metrics that have frequency distributions
+4. Handle legacy runs where type metadata may be missing
+
+## Non-goals
+
+- Changing the main results table behavior (it correctly shows all metrics)
+- Modifying the backend API contract (the data is already there)
+- Fixing evaluator schema registration (separate concern)

--- a/docs/design/eval-metric-type-filtering/plan.md
+++ b/docs/design/eval-metric-type-filtering/plan.md
@@ -1,0 +1,92 @@
+# Implementation Plan
+
+## Phase 1: Frontend filtering using existing `stats.type` (immediate fix)
+
+The backend already provides metric type in the stats response. The frontend just needs to read and filter on it.
+
+### Changes
+
+**File:** `web/oss/src/components/EvalRunDetails/components/views/OverviewView/hooks/useRunMetricData.ts`
+
+**Location:** Inside `metricCatalog` useMemo (around line 228)
+
+**Logic:**
+
+1. Add helper function `isAggregatableMetric(stats: BasicStats | undefined): boolean`
+
+2. Check `stats.type` first (authoritative when present):
+   - Include: `numeric/continuous`, `numeric/discrete`, `binary`, `categorical/single`, `categorical/multiple`
+   - Exclude: `string`, `json`
+
+3. Fallback when `stats.type` is missing:
+   - Include if `stats.mean` or `stats.median` or `stats.sum` exists (numeric)
+   - Include if `stats.freq` is a non-empty array (boolean/categorical)
+   - Exclude otherwise (count-only metrics)
+
+4. Filter evaluator metrics in the catalog builder:
+   ```typescript
+   const stats = baseStatsMap[metric.fullKey]
+   if (!isAggregatableMetric(stats)) {
+       return null
+   }
+   ```
+
+5. Filter out nulls before returning.
+
+### Why this is safe
+
+- Numeric metrics always have `mean`, `sum`, etc.
+- Boolean metrics always have `freq` array with true/false entries
+- Categorical metrics always have `freq` array with value entries
+- String/text metrics have only `count`
+- Invocation metrics (cost, latency) have numeric moments
+
+### Testing
+
+1. Run existing DeepEval evaluation
+2. Open overview page
+3. Verify `reason` metric is NOT shown in:
+   - Summary table
+   - Spider chart
+   - Histogram comparison
+4. Verify `score` and `success` metrics ARE shown
+5. Check invocation metrics (cost, latency, tokens) still appear
+
+## Phase 2: Persist metric type in run mapping column metadata (future enhancement)
+
+This phase adds explicit type metadata to the API contract. Not required for the immediate fix since `stats.type` already works.
+
+### API changes
+
+**File:** `api/oss/src/core/evaluations/types.py`
+
+Add optional field to `EvaluationRunDataMappingColumn`:
+
+```python
+class EvaluationRunDataMappingColumn(BaseModel):
+    kind: str
+    name: str
+    metric_type: Optional[str] = None  # NEW
+```
+
+**File:** `api/oss/src/core/evaluations/service.py`
+
+Populate `metric_type` in:
+- `_make_evaluation_run_data()` when building annotation mappings
+- `_update_run_mappings_from_inferred_metrics()` when adding inferred metrics
+
+### Frontend changes
+
+**File:** `web/oss/src/lib/evaluations/buildRunIndex.ts`
+
+Read `m.column.metric_type` and propagate to column definitions.
+
+**File:** `web/oss/src/components/EvalRunDetails/atoms/table/columns.ts`
+
+Use column-level `metricType` as primary source, fall back to evaluator schema.
+
+### Benefits
+
+- Type metadata survives without re-fetching stats
+- Cleaner data contract
+- Works for runs where metrics refresh has not been triggered

--- a/docs/design/eval-metric-type-filtering/research.md
+++ b/docs/design/eval-metric-type-filtering/research.md
@@ -1,0 +1,116 @@
+# Research
+
+## Backend metric type inference
+
+The backend infers metric types in `api/oss/src/core/evaluations/service.py` during `_refresh_metrics()`.
+
+### Type inference flow
+
+1. For evaluators with explicit schemas, types come from `get_metrics_keys_from_schema()` in `api/oss/src/core/evaluations/utils.py:87`.
+
+2. For evaluators without schemas (like SDK-based DeepEval), the backend infers schema from trace outputs via `_infer_evaluator_schema_from_traces()` at line 1141.
+
+3. Types are passed to the tracing analytics service as `MetricSpec(type=..., path=...)`.
+
+4. The analytics service returns stats with a `type` field embedded in each metric object.
+
+### Type values
+
+From `api/oss/src/core/evaluations/utils.py:87`:
+
+| JSON Schema type | Metric type value |
+|------------------|-------------------|
+| `object` (no properties) | `json` |
+| `array` of enum strings | `categorical/multiple` |
+| `boolean` | `binary` |
+| `string` with enum | `categorical/single` |
+| `string` without enum | `string` |
+| `number` | `numeric/continuous` |
+| `integer` | `numeric/discrete` |
+
+## Metrics query response structure
+
+Example from live run `019c9fe5-9721-73a1-bef4-20a224cd2e7e`:
+
+```json
+{
+    "evaluator-b2e52e604c6a": {
+        "attributes.ag.data.outputs.score": {
+            "type": "numeric/continuous",
+            "count": 5,
+            "mean": 1.0,
+            "max": 1.0,
+            "min": 1.0,
+            "sum": 5.0,
+            "range": 0.0,
+            "pcts": {...},
+            "hist": {...}
+        },
+        "attributes.ag.data.outputs.success": {
+            "type": "binary",
+            "count": 5,
+            "freq": [
+                {"value": true, "count": 5, "density": 1.0},
+                {"value": false, "count": 0, "density": 0.0}
+            ],
+            "uniq": [true, false]
+        },
+        "attributes.ag.data.outputs.reason": {
+            "type": "string",
+            "count": 5
+        }
+    }
+}
+```
+
+Key observation: string metrics have only `type` and `count`. No `mean`, `freq`, or other aggregation fields.
+
+## Frontend data flow
+
+1. `previewRunMetricStatsLoadableFamily` fetches metrics via `POST /preview/evaluations/metrics/query`.
+
+2. `normalizeStatValue()` in `runMetrics.ts` processes the response. The `type` field is preserved (not in `STAT_KEYS_TO_DROP`).
+
+3. `useRunMetricData.ts` builds `metricCatalog` from evaluator steps and stats. Currently does not read `stats.type`.
+
+4. Overview components consume `metricCatalog` and render all metrics regardless of type.
+
+## Existing partial filters
+
+Some downstream components already filter on `metricType`:
+
+- `BaseRunMetricsSection.tsx:90`: Filters `metricType === "string"` for histogram eligibility
+- `MetadataSummaryTable.tsx:488`: Similar string filter
+
+These are insufficient because `metricType` comes from evaluator schema, which is often empty. The `stats.type` field is more reliable.
+
+## Main table behavior
+
+The main results table (`EvalRunDetails/atoms/table/columns.ts`) uses a different code path. It falls back to `METRIC_TYPE_FALLBACK = "string"` when schema is missing, which is safe because string metrics render correctly as text cells. The main table does not need filtering.
+
+## Aggregation eligibility logic
+
+A metric should be included in aggregation views if:
+
+1. **Explicit type check**: `stats.type` is one of:
+   - `numeric/continuous`
+   - `numeric/discrete`
+   - `binary`
+   - `categorical/single`
+   - `categorical/multiple`
+
+2. **Fallback for missing type**: Stats object has:
+   - Numeric moments (`mean`, `median`, `sum`, `max`), OR
+   - Frequency distribution (`freq` array with valid entries)
+
+A metric should be excluded if:
+
+1. `stats.type === "string"` or `stats.type === "json"`
+2. Stats has only `count` (no numeric moments, no frequency)
+
+This logic correctly handles:
+- `score` (type=numeric, has mean) -> included
+- `success` (type=binary, has freq) -> included  
+- `reason` (type=string, only count) -> excluded
+- categorical metrics (type=categorical, has freq) -> included
+- invocation cost/latency (no type, but has mean) -> included via fallback

--- a/docs/design/eval-metric-type-filtering/status.md
+++ b/docs/design/eval-metric-type-filtering/status.md
@@ -1,0 +1,60 @@
+# Status
+
+## Current state
+
+Phase 2 implementation complete. Both overview views and outer evaluation runs table now filter string metrics.
+
+## Progress
+
+- [x] Root cause identified: frontend not reading `stats.type` from metrics response
+- [x] Verified backend provides type info in stats (`numeric/continuous`, `binary`, `string`)
+- [x] Confirmed frontend preserves `type` field through normalization
+- [x] Planning documents created
+- [x] **Phase 1**: Implement `isAggregatableMetric()` helper in overview page
+- [x] **Phase 1**: Add filtering in `metricCatalog` builder
+- [x] **Phase 2**: Update `outputTypesMap` cache from cell stats in outer table
+- [x] Run lint/format (passed)
+- [ ] Test on deployed instance
+- [ ] Create PR
+
+## Implementation summary
+
+### Phase 1: Overview Views (useRunMetricData.ts)
+
+Added to `useRunMetricData.ts`:
+
+1. Constants `AGGREGATABLE_METRIC_TYPES` and `NON_AGGREGATABLE_METRIC_TYPES`
+2. Helper function `isAggregatableMetric(stats)` that:
+   - Reads `stats.type` from backend (authoritative)
+   - Falls back to shape heuristics (has mean/median/freq vs count-only)
+3. Filter in `metricCatalog` builder to exclude non-aggregatable evaluator metrics
+
+### Phase 2: Outer Evaluation Runs Table (RunMetricCell)
+
+The outer table already had filtering via `isMetricHidden()` checking `outputTypesMap`, but this cache was only populated from evaluator schema (which SDK-based evaluators like DeepEval don't have).
+
+Added to `RunMetricCell/index.tsx`:
+
+1. Import `outputTypesMap` utilities from `evaluatorOutputTypes.ts`
+2. New `useEffect` that:
+   - Reads `stats.type` from the metrics API response when cell data loads
+   - Updates the `outputTypesMap` cache with the type info
+   - Uses a ref to prevent duplicate updates for the same metric
+3. This allows the existing column filtering (`isMetricHidden()`) to work correctly once the first row loads
+
+**Data flow**:
+```
+Cell fetches stats → stats includes type: "string" → update outputTypesMap → 
+trigger re-render of columns → isMetricHidden returns true → column hidden
+```
+
+## Blockers
+
+None.
+
+## Decisions
+
+1. Filter at catalog level for overview, cache-based for outer table.
+2. Use `stats.type` as primary signal, fallback to shape heuristics for legacy data.
+3. Main table (inside eval run details) is unaffected (correctly renders all metrics as cells).
+4. Outer table columns are dynamically filtered after first row data loads.

--- a/web/oss/src/components/EvalRunDetails/components/views/OverviewView/hooks/useRunMetricData.ts
+++ b/web/oss/src/components/EvalRunDetails/components/views/OverviewView/hooks/useRunMetricData.ts
@@ -31,6 +31,61 @@ const falseAtom = atom(false)
 const emptyTemporalSeriesAtom = atom<Record<string, TemporalMetricPoint[]>>({})
 const emptyMetricSelectionsAtom = atom<RunMetricSelectionEntry[]>([])
 
+/**
+ * Metric types that can be meaningfully aggregated (mean, distribution, etc.)
+ * These come from the backend stats.type field.
+ */
+const AGGREGATABLE_METRIC_TYPES = new Set([
+    "numeric/continuous",
+    "numeric/discrete",
+    "binary",
+    "categorical/single",
+    "categorical/multiple",
+])
+
+/**
+ * Metric types that should NOT be aggregated (text, JSON objects)
+ */
+const NON_AGGREGATABLE_METRIC_TYPES = new Set(["string", "json"])
+
+/**
+ * Determines if a metric should be included in aggregation views (overview, histograms, spider chart).
+ *
+ * Uses stats.type when available (backend-inferred). Falls back to shape heuristics for legacy data.
+ *
+ * @returns true if the metric can be aggregated, false otherwise
+ */
+const isAggregatableMetric = (stats: BasicStats | undefined): boolean => {
+    if (!stats) return false
+
+    // Check explicit type from backend (most reliable)
+    const statsType = stats.type as string | undefined
+    if (statsType) {
+        if (NON_AGGREGATABLE_METRIC_TYPES.has(statsType)) return false
+        if (AGGREGATABLE_METRIC_TYPES.has(statsType)) return true
+    }
+
+    // Fallback: infer from shape when type is missing (legacy data)
+    // Numeric metrics have statistical moments
+    if (
+        typeof stats.mean === "number" ||
+        typeof stats.median === "number" ||
+        typeof stats.sum === "number" ||
+        typeof stats.max === "number"
+    ) {
+        return true
+    }
+
+    // Boolean/categorical metrics have frequency distribution
+    const freq = stats.freq ?? stats.frequency
+    if (Array.isArray(freq) && freq.length > 0) {
+        return true
+    }
+
+    // Count-only metrics are typically text fields (like reason)
+    return false
+}
+
 export interface RunDescriptor {
     runId: string
     displayName: string
@@ -202,25 +257,31 @@ export const useRunMetricData = (runIds: string[]): RunMetricData => {
 
     const metricCatalog = useMemo(() => {
         const evaluatorMetrics = evaluatorMetricEntries.flatMap((entry) =>
-            entry.metrics.map((metric) => {
-                const metricKey = metric.canonicalKey || metric.rawKey
-                const displayLabel =
-                    humanizeMetricPath(metric.canonicalKey) ||
-                    humanizeMetricPath(metric.rawKey) ||
-                    metric.rawKey.replace(/[_\.]/g, " ")
-                return {
-                    id: `${entry.stepKey}:${metricKey}`,
-                    evaluatorLabel: entry.label,
-                    evaluatorRef: entry.evaluatorRef ?? null,
-                    fallbackEvaluatorLabel: entry.label,
-                    stepKey: entry.stepKey,
-                    canonicalKey: metric.canonicalKey,
-                    rawKey: metric.rawKey,
-                    fullKey: metric.fullKey,
-                    displayLabel,
-                    metricType: metric.metricType,
-                }
-            }),
+            entry.metrics
+                .filter((metric) => {
+                    // Filter out non-aggregatable metrics (e.g., text fields like "reason")
+                    const stats = baseStatsMap[metric.fullKey] as BasicStats | undefined
+                    return isAggregatableMetric(stats)
+                })
+                .map((metric) => {
+                    const metricKey = metric.canonicalKey || metric.rawKey
+                    const displayLabel =
+                        humanizeMetricPath(metric.canonicalKey) ||
+                        humanizeMetricPath(metric.rawKey) ||
+                        metric.rawKey.replace(/[_\.]/g, " ")
+                    return {
+                        id: `${entry.stepKey}:${metricKey}`,
+                        evaluatorLabel: entry.label,
+                        evaluatorRef: entry.evaluatorRef ?? null,
+                        fallbackEvaluatorLabel: entry.label,
+                        stepKey: entry.stepKey,
+                        canonicalKey: metric.canonicalKey,
+                        rawKey: metric.rawKey,
+                        fullKey: metric.fullKey,
+                        displayLabel,
+                        metricType: metric.metricType,
+                    }
+                }),
         )
 
         const invocationMetrics = INVOCATION_METRIC_KEYS.map((key) => ({
@@ -236,7 +297,7 @@ export const useRunMetricData = (runIds: string[]): RunMetricData => {
         }))
 
         return [...evaluatorMetrics, ...invocationMetrics]
-    }, [evaluatorMetricEntries])
+    }, [baseStatsMap, evaluatorMetricEntries])
 
     const selectionSignature = useMemo(() => {
         const metricSig = metricCatalog.map((metric) => metric.id).join("|")

--- a/web/oss/src/components/EvaluationRunsTablePOC/components/cells/RunMetricCell/index.tsx
+++ b/web/oss/src/components/EvaluationRunsTablePOC/components/cells/RunMetricCell/index.tsx
@@ -1,4 +1,4 @@
-import {memo, useEffect, useMemo, type ReactNode} from "react"
+import {memo, useEffect, useMemo, useRef, type ReactNode} from "react"
 
 import {Typography} from "antd"
 import {useSetAtomWithSchedule, LOW_PRIORITY} from "jotai-scheduler"
@@ -7,6 +7,7 @@ import EvaluatorMetricBar from "@/oss/components/Evaluations/EvaluatorMetricBar"
 import SkeletonLine from "@/oss/components/InfiniteVirtualTable/components/common/SkeletonLine"
 import {resolvedMetricLabelsAtomFamily} from "@/oss/components/References/atoms/resolvedMetricLabels"
 import {humanizeMetricPath} from "@/oss/lib/evaluations/utils/metrics"
+import {canonicalizeMetricKey} from "@/oss/lib/metricUtils"
 import {type BasicStats} from "@/oss/lib/metricUtils"
 
 import {
@@ -15,6 +16,11 @@ import {
     formatInvocationMetricValue,
     formatPercent,
 } from "../../../../../lib/runMetrics/formatters"
+import {
+    createEvaluatorOutputTypesKey,
+    getOutputTypesMap,
+    setOutputTypesMap,
+} from "../../../atoms/evaluatorOutputTypes"
 import useRunMetricSelection from "../../../hooks/useRunMetricSelection"
 import type {EvaluationRunTableRow} from "../../../types"
 import type {RunMetricDescriptor} from "../../../types/runMetrics"
@@ -102,6 +108,78 @@ const RunMetricCellContent = memo(
             const label = humanizeMetricPath(stripOutputsNamespace(resolvedKey) ?? resolvedKey)
             setResolvedLabel((prev) => (prev === label ? prev : label))
         }, [isGenericOutputsMetric, selection.state, selection.resolvedKey, setResolvedLabel])
+
+        // Track per-metric cache contributions for this component instance.
+        // Virtualized rows can reuse component instances across different descriptors,
+        // so a single boolean guard can hide valid updates.
+        const contributedOutputTypesRef = useRef<Set<string>>(new Set())
+
+        // Update outputTypesMap cache from stats.type when available
+        // This allows SDK-based evaluators (which don't have schema) to still have their
+        // string metrics filtered out from aggregation columns
+        useEffect(() => {
+            // Only process evaluator metrics
+            if (descriptor.kind !== "evaluator") return
+            if (selection.state !== "hasData") return
+
+            const stats = selection.stats as BasicStats | undefined
+            const statsType = (stats as BasicStats & {type?: string})?.type
+            if (!statsType) return
+
+            const projectId = descriptor.evaluatorRef?.projectId ?? record.projectId ?? null
+            const evaluatorIdentity =
+                descriptor.evaluatorRef?.slug ??
+                descriptor.evaluatorRef?.id ??
+                stepKeyForSelection ??
+                descriptor.stepKey ??
+                null
+            if (!evaluatorIdentity) return
+
+            const outputTypesKey = createEvaluatorOutputTypesKey(projectId, evaluatorIdentity)
+            const currentMap = getOutputTypesMap(outputTypesKey)
+
+            const metricPath = metricPathForSelection ?? descriptor.metricPath
+            if (!metricPath) return
+
+            const canonicalFullPath = canonicalizeMetricKey(metricPath)
+            const metricLeaf = metricPath.includes(".")
+                ? (metricPath.split(".").pop() ?? metricPath)
+                : metricPath
+            const canonicalLeafPath = canonicalizeMetricKey(metricLeaf)
+            const contributionKey = `${outputTypesKey}:${canonicalFullPath}:${statsType}`
+
+            if (contributedOutputTypesRef.current.has(contributionKey)) {
+                return
+            }
+
+            // Only update if we have new information
+            if (
+                currentMap.get(canonicalFullPath) === statsType &&
+                currentMap.get(canonicalLeafPath) === statsType
+            ) {
+                contributedOutputTypesRef.current.add(contributionKey)
+                return
+            }
+
+            // Create a new map with the updated type
+            const newMap = new Map(currentMap)
+            newMap.set(canonicalFullPath, statsType)
+            newMap.set(canonicalLeafPath, statsType)
+            setOutputTypesMap(outputTypesKey, newMap)
+            contributedOutputTypesRef.current.add(contributionKey)
+        }, [
+            descriptor.kind,
+            descriptor.evaluatorRef?.projectId,
+            descriptor.evaluatorRef?.id,
+            descriptor.evaluatorRef?.slug,
+            descriptor.metricPath,
+            descriptor.stepKey,
+            metricPathForSelection,
+            record.projectId,
+            selection.state,
+            selection.stats,
+            stepKeyForSelection,
+        ])
 
         // const resolvedPathsAtom = useMemo(
         //     () => resolvedMetricPathsAtomFamily(descriptor.id),

--- a/web/oss/src/components/EvaluationRunsTablePOC/hooks/useEvaluationRunsColumns/index.tsx
+++ b/web/oss/src/components/EvaluationRunsTablePOC/hooks/useEvaluationRunsColumns/index.tsx
@@ -432,7 +432,7 @@ const useEvaluationRunsColumns = ({
     const isMetricHidden = useCallback(
         (groupId: string, metricPath: string, descriptorOutputType: string | null | undefined) => {
             // First check descriptor's outputType
-            if (descriptorOutputType === "string") {
+            if (isStringOutputType(descriptorOutputType)) {
                 return true
             }
 
@@ -450,12 +450,13 @@ const useEvaluationRunsColumns = ({
                 return false
             }
 
-            // Extract the metric name from the full path
-            const metricName = metricPath.includes(".")
+            const canonicalFullPath = canonicalizeMetricKey(metricPath)
+            const metricLeaf = metricPath.includes(".")
                 ? (metricPath.split(".").pop() ?? metricPath)
                 : metricPath
-            const canonicalPath = canonicalizeMetricKey(metricName)
-            const outputType = outputTypesMap.get(canonicalPath)
+            const canonicalLeafPath = canonicalizeMetricKey(metricLeaf)
+            const outputType =
+                outputTypesMap.get(canonicalFullPath) ?? outputTypesMap.get(canonicalLeafPath)
 
             if (outputType === undefined) {
                 return false
@@ -515,12 +516,18 @@ const useEvaluationRunsColumns = ({
                                 const key = createEvaluatorOutputTypesKey(groupProjectId, groupSlug)
                                 const outputTypesMap = getOutputTypesMap(key)
                                 if (outputTypesMap.size > 0) {
-                                    const metricName = descriptor.metricPath.includes(".")
+                                    const canonicalFullPath = canonicalizeMetricKey(
+                                        descriptor.metricPath,
+                                    )
+                                    const metricLeaf = descriptor.metricPath.includes(".")
                                         ? (descriptor.metricPath.split(".").pop() ??
                                           descriptor.metricPath)
                                         : descriptor.metricPath
-                                    const canonicalPath = canonicalizeMetricKey(metricName)
-                                    enrichedOutputType = outputTypesMap.get(canonicalPath) ?? null
+                                    const canonicalLeafPath = canonicalizeMetricKey(metricLeaf)
+                                    enrichedOutputType =
+                                        outputTypesMap.get(canonicalFullPath) ??
+                                        outputTypesMap.get(canonicalLeafPath) ??
+                                        null
                                 }
                             }
 


### PR DESCRIPTION
## Summary
- filter overview aggregation metric catalogs using backend `stats.type` (with shape-based fallback for legacy data)
- update the outer Evaluation Runs table to populate output-type cache from run-level metric stats so SDK evaluators without schema metadata still hide string metrics
- add planning workspace docs under `docs/design/eval-metric-type-filtering/`

## Validation
- ran `corepack pnpm lint-fix` in `web/`
- ran a subagent code review; no blocking issues remained after fixes
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/agenta-ai/agenta/pull/3864" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open with Devin">
  </picture>
</a>
<!-- devin-review-badge-end -->
