### PR TITLE
fix(ci): stop docs CI from creating daily phantom PRs

### DIFF
--- a/api/ee/src/models/api/api_models.py
+++ b/api/ee/src/models/api/api_models.py
@@ -15,8 +15,8 @@ from oss.src.models.api.api_models import (
 
 
 class TimestampModel(BaseModel):
-    created_at: str = Field(str(datetime.now(timezone.utc)))
-    updated_at: str = Field(str(datetime.now(timezone.utc)))
+    created_at: str = Field(default_factory=lambda: str(datetime.now(timezone.utc)))
+    updated_at: str = Field(default_factory=lambda: str(datetime.now(timezone.utc)))
 
 
 class InviteRequest(BaseModel):

--- a/api/oss/src/models/api/api_models.py
+++ b/api/oss/src/models/api/api_models.py
@@ -8,8 +8,8 @@ from oss.src.models.shared_models import ConfigDB
 
 
 class TimestampModel(BaseModel):
-    created_at: str = Field(str(datetime.now(timezone.utc)))
-    updated_at: str = Field(str(datetime.now(timezone.utc)))
+    created_at: str = Field(default_factory=lambda: str(datetime.now(timezone.utc)))
+    updated_at: str = Field(default_factory=lambda: str(datetime.now(timezone.utc)))
 
 
 class PaginationParam(BaseModel):

--- a/api/oss/src/models/api/user_models.py
+++ b/api/oss/src/models/api/user_models.py
@@ -5,8 +5,8 @@ from pydantic import BaseModel, Field
 
 
 class TimestampModel(BaseModel):
-    created_at: str = Field(str(datetime.now(timezone.utc)))
-    updated_at: str = Field(str(datetime.now(timezone.utc)))
+    created_at: str = Field(default_factory=lambda: str(datetime.now(timezone.utc)))
+    updated_at: str = Field(default_factory=lambda: str(datetime.now(timezone.utc)))
 
 
 class User(TimestampModel):
@@ -20,4 +20,4 @@ class User(TimestampModel):
 class UserUpdate(BaseModel):
     username: Optional[str] = None
     email: Optional[str] = None
-    updated_at: str = Field(str(datetime.now(timezone.utc)))
+    updated_at: str = Field(default_factory=lambda: str(datetime.now(timezone.utc)))


### PR DESCRIPTION
## Summary

- Pydantic `TimestampModel` and `UserUpdate` models used `datetime.now(timezone.utc)` evaluated at **import time** as the default for `created_at`/`updated_at` fields. This baked the server startup timestamp into the OpenAPI schema as a `"default"` value.
- Every time the daily docs CI (`09-update-api-docs.yml`) downloaded the OpenAPI spec, these timestamps differed from the previous run, causing a new PR to be created even though the actual API hadn't changed (e.g. #3882).
- Switched to `default_factory=lambda: str(datetime.now(timezone.utc))` so Pydantic v2 no longer includes these dynamic values in the JSON schema. Zero runtime impact — these defaults were never consumed in practice.

## Changed files

- `api/oss/src/models/api/api_models.py` — `TimestampModel`
- `api/oss/src/models/api/user_models.py` — `TimestampModel` + `UserUpdate`
- `api/ee/src/models/api/api_models.py` — `TimestampModel`
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/agenta-ai/agenta/pull/3886" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open with Devin">
  </picture>
</a>
<!-- devin-review-badge-end -->
