### PR TITLE
fix(frontend): block deletion of an app's last revision

### DIFF
--- a/web/oss/src/components/Playground/Components/Modals/DeleteVariantModal/Content.tsx
+++ b/web/oss/src/components/Playground/Components/Modals/DeleteVariantModal/Content.tsx
@@ -174,6 +174,22 @@ const DeleteVariantContent = ({revisionIds, forceVariantIds = [], onClose}: Prop
     const totalSelectedCount = uniqueRevisionIds.length
     const isBulkDelete = deletionPlan.variants.length > 0 || totalSelectedCount > 1
 
+    // Check if deleting the last non-draft revision for any variant
+    const deletingLastRevision = useMemo(() => {
+        for (const group of Object.values(variantGroups)) {
+            const totalNonDraft = group.totalIds.length
+            const selectedNonDraft = group.selectedIds.length
+            // If deleting entire variant or selecting all revisions
+            if (group.deleteEntireVariant || selectedNonDraft >= totalNonDraft) {
+                // Check if this is the only variant being deleted
+                if (Object.keys(variantGroups).length === 1) {
+                    return true
+                }
+            }
+        }
+        return false
+    }, [variantGroups])
+
     const onDeleteVariant = useCallback(async () => {
         setIsMutating(true)
         try {
@@ -271,17 +287,28 @@ const DeleteVariantContent = ({revisionIds, forceVariantIds = [], onClose}: Prop
                 </div>
             </div>
 
+            {deletingLastRevision && (
+                <div className="rounded-md bg-amber-50 p-3 text-amber-800">
+                    <Text strong>Cannot delete the only revision.</Text>
+                    <Text> Delete the app instead.</Text>
+                </div>
+            )}
+
             <div className="flex items-center justify-end gap-2">
                 <Button onClick={onClose}>Cancel</Button>
                 <Button
                     type="primary"
                     danger
                     loading={isMutating}
-                    disabled={isMutating || totalSelectedCount === 0}
+                    disabled={isMutating || totalSelectedCount === 0 || deletingLastRevision}
                     icon={<Trash size={14} />}
                     onClick={onDeleteVariant}
                 >
-                    {isBulkDelete ? "Delete selected" : "Delete"}
+                    {deletingLastRevision
+                        ? "Cannot delete the only revision"
+                        : isBulkDelete
+                            ? "Delete selected"
+                            : "Delete"}
                 </Button>
             </div>
         </section>


### PR DESCRIPTION
## Summary

Prevents users from deleting the last revision of an app from the Playground. When attempting to delete the only revision:

- The confirm button is disabled
- A clear message explains why: "Cannot delete the only revision. Delete the app instead."

This addresses the UX issue where deleting the last revision left the Playground in a broken state with no feedback.

## Changes

In :

1. Added  useMemo hook to detect when user is attempting to delete the last non-draft revision
2. Updated the delete button to be disabled when  is true
3. Added warning message below the revision list showing why deletion is blocked
4. Changed button text to "Cannot delete the only revision" when blocked

## Testing

1. Open an app with a single revision
2. Try to delete it via the Playground header menu (⋯ → Delete)
3. Observe: The confirm button is disabled and shows "Cannot delete the only revision"
4. Observe: Warning message appears explaining to delete the app instead

Closes #3892