### PR TITLE
fix(frontend): sync playground run variables with live prompt edits

### DIFF
--- a/web/oss/src/state/newPlayground/mutations/webWorkerIntegration.ts
+++ b/web/oss/src/state/newPlayground/mutations/webWorkerIntegration.ts
@@ -204,17 +204,18 @@ function computeVariableValues(
 
 // Resolve the set of allowed variable keys for a given revision
 function resolveAllowedVariableKeys(get: any, revisionId: string): ResolvedVariableKeys {
-    // Prefer runnableBridge input ports (single source of truth)
-    const ports = (get(runnableBridge.inputPorts(revisionId)) || []) as {key?: string}[]
-    const ordered = ports.map((p) => p?.key).filter((k): k is string => !!k)
-    if (ordered.length > 0) {
-        return {ordered, set: new Set(ordered)}
-    }
-
-    // Fallback to prompt variables if bridge input ports are unavailable
+    // Prefer live prompt variables so renamed {{variables}} are reflected immediately
+    // during playground editing, even before entity-level input ports refresh.
     const promptVars = (get(promptVariablesAtomFamily(revisionId)) || []) as string[]
     const keys = (promptVars || []).filter((k) => typeof k === "string" && k.length > 0)
-    return {ordered: keys, set: new Set(keys)}
+    if (keys.length > 0) {
+        return {ordered: keys, set: new Set(keys)}
+    }
+
+    // Fallback to runnableBridge input ports (schema/entity-derived keys)
+    const ports = (get(runnableBridge.inputPorts(revisionId)) || []) as {key?: string}[]
+    const ordered = ports.map((p) => p?.key).filter((k): k is string => !!k)
+    return {ordered, set: new Set(ordered)}
 }
 
 export const triggerWebWorkerTestAtom = atom(


### PR DESCRIPTION
## Summary
- prioritize live prompt-derived variable keys when building playground run payloads so renamed template variables are used immediately
- keep runnable input ports as a fallback when no live prompt variables are available
- run frontend linting with `corepack pnpm lint-fix` and validate the fix path used by worker payload assembly

## Why
When users rename prompt variables (for example `{{country}}` to `{{page}}`), runs could still send stale input keys from entity-derived ports. This change makes run payload variables follow the latest prompt edits to avoid mismatched inputs.
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/agenta-ai/agenta/pull/3904" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open with Devin">
  </picture>
</a>
<!-- devin-review-badge-end -->
