### PR TITLE
test(ci): cross-PR cache proof for Railway preview builds

### DIFF
--- a/.github/workflows/06-railway-preview-build.yml
+++ b/.github/workflows/06-railway-preview-build.yml
@@ -27,17 +27,18 @@ concurrency:
   cancel-in-progress: true
 
 jobs:
-  build-and-push:
+  prepare:
     if: github.event_name == 'workflow_dispatch' || !github.event.pull_request.draft
     runs-on: ubuntu-latest
     outputs:
-      image_tag: ${{ steps.tag.outputs.image_tag }}
-      pr_number: ${{ steps.tag.outputs.pr_number }}
+      image_tag: ${{ steps.meta.outputs.image_tag }}
+      pr_number: ${{ steps.meta.outputs.pr_number }}
+      cache_scope: ${{ steps.meta.outputs.cache_scope }}
     steps:
       - uses: actions/checkout@v4
 
-      - name: Determine image tag
-        id: tag
+      - name: Determine build metadata
+        id: meta
         run: |
           PR="${{ github.event.pull_request.number || inputs.pr_number }}"
           SHA="$(git rev-parse --short HEAD)"
@@ -48,14 +49,6 @@ jobs:
             TAG="manual-${SHA}"
           fi
 
-          echo "image_tag=${TAG}" >> "$GITHUB_OUTPUT"
-          echo "pr_number=${PR}" >> "$GITHUB_OUTPUT"
-          echo "Image tag: ${TAG}"
-
-      - name: Determine cache scope
-        id: cache
-        run: |
-          PR="${{ steps.tag.outputs.pr_number }}"
           if [ -n "$PR" ]; then
             CACHE_SCOPE="pr-${PR}"
           else
@@ -67,8 +60,45 @@ jobs:
 
           CACHE_SCOPE="${CACHE_SCOPE:0:80}"
 
+          echo "image_tag=${TAG}" >> "$GITHUB_OUTPUT"
+          echo "pr_number=${PR}" >> "$GITHUB_OUTPUT"
           echo "cache_scope=${CACHE_SCOPE}" >> "$GITHUB_OUTPUT"
+          echo "Image tag: ${TAG}"
           echo "Cache scope: ${CACHE_SCOPE}"
+
+      - name: Summary
+        run: |
+          TAG="${{ steps.meta.outputs.image_tag }}"
+          echo "### Railway Preview Images" >> "$GITHUB_STEP_SUMMARY"
+          echo "" >> "$GITHUB_STEP_SUMMARY"
+          echo "| Image | Tag |" >> "$GITHUB_STEP_SUMMARY"
+          echo "|-------|-----|" >> "$GITHUB_STEP_SUMMARY"
+          echo "| agenta-api | \`${TAG}\` |" >> "$GITHUB_STEP_SUMMARY"
+          echo "| agenta-web | \`${TAG}\` |" >> "$GITHUB_STEP_SUMMARY"
+          echo "| agenta-services | \`${TAG}\` |" >> "$GITHUB_STEP_SUMMARY"
+          echo "" >> "$GITHUB_STEP_SUMMARY"
+          echo "- Cache scope: \`${{ steps.meta.outputs.cache_scope }}\`" >> "$GITHUB_STEP_SUMMARY"
+          echo "- Shared cache: \`buildcache-shared\`" >> "$GITHUB_STEP_SUMMARY"
+
+  build-and-push:
+    needs: prepare
+    if: needs.prepare.outputs.image_tag != ''
+    runs-on: ubuntu-latest
+    strategy:
+      fail-fast: false
+      matrix:
+        include:
+          - image_name: agenta-api
+            context: api
+            dockerfile: api/oss/docker/Dockerfile.gh
+          - image_name: agenta-web
+            context: web
+            dockerfile: web/oss/docker/Dockerfile.gh
+          - image_name: agenta-services
+            context: services
+            dockerfile: services/oss/docker/Dockerfile.gh
+    steps:
+      - uses: actions/checkout@v4
 
       - name: Log in to GHCR
         uses: docker/login-action@v3
@@ -80,67 +110,29 @@ jobs:
       - name: Set up Docker Buildx
         uses: docker/setup-buildx-action@v3
 
-      - name: Build and push API image
+      - name: Build and push image
         uses: docker/build-push-action@v6
         with:
-          context: api
-          file: api/oss/docker/Dockerfile.gh
+          context: ${{ matrix.context }}
+          file: ${{ matrix.dockerfile }}
           push: true
-          tags: ghcr.io/agenta-ai/agenta-api:${{ steps.tag.outputs.image_tag }}
+          tags: ghcr.io/agenta-ai/${{ matrix.image_name }}:${{ needs.prepare.outputs.image_tag }}
           cache-from: |
-            type=registry,ref=ghcr.io/agenta-ai/agenta-api:buildcache-shared
-            type=registry,ref=ghcr.io/agenta-ai/agenta-api:buildcache-${{ steps.cache.outputs.cache_scope }}
+            type=registry,ref=ghcr.io/agenta-ai/${{ matrix.image_name }}:buildcache-shared
+            type=registry,ref=ghcr.io/agenta-ai/${{ matrix.image_name }}:buildcache-${{ needs.prepare.outputs.cache_scope }}
           cache-to: |
-            type=registry,ref=ghcr.io/agenta-ai/agenta-api:buildcache-shared,mode=max
-            type=registry,ref=ghcr.io/agenta-ai/agenta-api:buildcache-${{ steps.cache.outputs.cache_scope }},mode=max
-
-      - name: Build and push Web image
-        uses: docker/build-push-action@v6
-        with:
-          context: web
-          file: web/oss/docker/Dockerfile.gh
-          push: true
-          tags: ghcr.io/agenta-ai/agenta-web:${{ steps.tag.outputs.image_tag }}
-          cache-from: |
-            type=registry,ref=ghcr.io/agenta-ai/agenta-web:buildcache-shared
-            type=registry,ref=ghcr.io/agenta-ai/agenta-web:buildcache-${{ steps.cache.outputs.cache_scope }}
-          cache-to: |
-            type=registry,ref=ghcr.io/agenta-ai/agenta-web:buildcache-shared,mode=max
-            type=registry,ref=ghcr.io/agenta-ai/agenta-web:buildcache-${{ steps.cache.outputs.cache_scope }},mode=max
-
-      - name: Build and push Services image
-        uses: docker/build-push-action@v6
-        with:
-          context: services
-          file: services/oss/docker/Dockerfile.gh
-          push: true
-          tags: ghcr.io/agenta-ai/agenta-services:${{ steps.tag.outputs.image_tag }}
-          cache-from: |
-            type=registry,ref=ghcr.io/agenta-ai/agenta-services:buildcache-shared
-            type=registry,ref=ghcr.io/agenta-ai/agenta-services:buildcache-${{ steps.cache.outputs.cache_scope }}
-          cache-to: |
-            type=registry,ref=ghcr.io/agenta-ai/agenta-services:buildcache-shared,mode=max
-            type=registry,ref=ghcr.io/agenta-ai/agenta-services:buildcache-${{ steps.cache.outputs.cache_scope }},mode=max
+            type=registry,ref=ghcr.io/agenta-ai/${{ matrix.image_name }}:buildcache-shared,mode=max
+            type=registry,ref=ghcr.io/agenta-ai/${{ matrix.image_name }}:buildcache-${{ needs.prepare.outputs.cache_scope }},mode=max
 
       - name: Summary
         run: |
-          TAG="${{ steps.tag.outputs.image_tag }}"
-          echo "### Railway Preview Images" >> "$GITHUB_STEP_SUMMARY"
-          echo "" >> "$GITHUB_STEP_SUMMARY"
-          echo "| Image | Tag |" >> "$GITHUB_STEP_SUMMARY"
-          echo "|-------|-----|" >> "$GITHUB_STEP_SUMMARY"
-          echo "| agenta-api | \`${TAG}\` |" >> "$GITHUB_STEP_SUMMARY"
-          echo "| agenta-web | \`${TAG}\` |" >> "$GITHUB_STEP_SUMMARY"
-          echo "| agenta-services | \`${TAG}\` |" >> "$GITHUB_STEP_SUMMARY"
-          echo "" >> "$GITHUB_STEP_SUMMARY"
-          echo "- Cache scope: \`${{ steps.cache.outputs.cache_scope }}\`" >> "$GITHUB_STEP_SUMMARY"
-          echo "- Shared cache: \`buildcache-shared\`" >> "$GITHUB_STEP_SUMMARY"
+          echo "- Built \`${{ matrix.image_name }}:${{ needs.prepare.outputs.image_tag }}\`" >> "$GITHUB_STEP_SUMMARY"
 
   deploy:
-    needs: build-and-push
-    if: needs.build-and-push.outputs.pr_number != ''
+    needs: [prepare, build-and-push]
+    if: needs.prepare.outputs.pr_number != '' && needs.build-and-push.result == 'success'
     uses: ./.github/workflows/07-railway-preview-deploy.yml
     with:
-      image_tag: ${{ needs.build-and-push.outputs.image_tag }}
-      pr_number: ${{ needs.build-and-push.outputs.pr_number }}
+      image_tag: ${{ needs.prepare.outputs.image_tag }}
+      pr_number: ${{ needs.prepare.outputs.pr_number }}
     secrets: inherit

--- a/hosting/railway/oss/README.md
+++ b/hosting/railway/oss/README.md
@@ -196,7 +196,7 @@ The API image defaults to docker-compose hostnames for Redis (`redis-durable:638
 
 First deploys on Railway take longer because Docker layer caches are cold. The app settle window (`RAILWAY_APP_SETTLE_SECONDS`, default 60) may not be enough on very slow builds. If smoke fails because services are still DEPLOYING, wait and re-run smoke manually.
 
-For GitHub preview builds, CI now uses shared BuildKit registry cache tags (`buildcache-shared`) plus PR-scoped tags (`buildcache-pr-<number>`). This keeps repeated PR builds fast and also improves first builds on new PRs by reusing layers from previous runs. Manual workflow dispatches without a PR number use `manual-<sha>` image tags and skip deploy.
+For GitHub preview builds, CI now uses shared BuildKit registry cache tags (`buildcache-shared`) plus PR-scoped tags (`buildcache-pr-<number>`). It also builds API, web, and services images in parallel matrix jobs. This keeps repeated PR builds fast and also improves first builds on new PRs by reusing layers from previous runs. Manual workflow dispatches without a PR number use `manual-<sha>` image tags and skip deploy.
 
 ### Smoke check options
 


### PR DESCRIPTION
## Context
This PR is a temporary validation PR to prove cross-PR cache reuse for Railway preview image builds.

## What to validate
- First run on a different PR number should reuse `buildcache-shared` layers.
- Matrix build stage (api/web/services) should stay fast on this new PR.

## Note
Do not merge. This PR is for CI timing proof only.
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/agenta-ai/agenta/pull/3907" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open with Devin">
  </picture>
</a>
<!-- devin-review-badge-end -->
