### PR TITLE
chore(sdk): update supported LLM model list

### DIFF
--- a/sdk/agenta/sdk/assets.py
+++ b/sdk/agenta/sdk/assets.py
@@ -43,6 +43,7 @@ supported_llm_models = {
     ],
     "gemini": [
         "gemini/gemini-3.1-pro-preview",
+        "gemini/gemini-3.1-flash-lite-preview",
         "gemini/gemini-3-pro-preview",
         "gemini/gemini-3-flash-preview",
         "gemini/gemini-2.5-pro",
@@ -66,6 +67,8 @@ supported_llm_models = {
         "groq/meta-llama/llama-4-scout-17b-16e-instruct",
         "groq/llama-3.3-70b-versatile",
         "groq/llama-3.1-8b-instant",
+        "groq/openai/gpt-oss-120b",
+        "groq/openai/gpt-oss-20b",
         "groq/qwen/qwen3-32b",
     ],
     "mistral": [
@@ -75,10 +78,10 @@ supported_llm_models = {
         "mistral/mistral-large-latest",
     ],
     "openai": [
+        "gpt-5.4",
         "gpt-5.2-pro",
         "gpt-5.2-chat-latest",
         "gpt-5.2",
-        "gpt-5.1-codex",
         "gpt-5.1-chat-latest",
         "gpt-5.1",
         "gpt-5-pro",
@@ -92,7 +95,9 @@ supported_llm_models = {
         "o3-mini",
         "o1-pro",
         "o1",
+        "o1-preview",
         "o1-mini",
+        "gpt-5.1-codex",
         "codex-mini-latest",
         "gpt-4.5-preview",
         "gpt-4.1-nano",


### PR DESCRIPTION
## Summary
- Add newly available models to the supported LLM model list: `gpt-5.4`, `o1-preview`, `gemini-3.1-flash-lite-preview`, `groq/openai/gpt-oss-120b`, `groq/openai/gpt-oss-20b`
- All models validated against litellm's model cost registry
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/agenta-ai/agenta/pull/3926" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open with Devin">
  </picture>
</a>
<!-- devin-review-badge-end -->
