### PR TITLE
fix(ci): verify Railway preview images per matrix job

### DIFF
--- a/.github/workflows/06-railway-preview-build.yml
+++ b/.github/workflows/06-railway-preview-build.yml
@@ -149,26 +149,16 @@ jobs:
               ;;
           esac
 
-      - name: Verify images run as non-root
-        env:
-          TAG: ${{ steps.tag.outputs.image_tag }}
+      - name: Verify image runs as non-root
         run: |
-          FAILED=0
-          for IMAGE in agenta-api agenta-web agenta-services; do
-            FULL="ghcr.io/agenta-ai/${IMAGE}:${TAG}"
-            docker pull $FULL
-            USER=$(docker inspect --format='{{.Config.User}}' "$FULL")
-            if [ -z "$USER" ] || [ "$USER" = "root" ] || [ "$USER" = "0" ]; then
-              echo "FAIL: ${IMAGE} runs as root (User='${USER}')"
-              FAILED=1
-            else
-              echo "PASS: ${IMAGE} runs as User='${USER}'"
-            fi
-          done
-          if [ "$FAILED" -eq 1 ]; then
-            echo "::error::One or more images run as root."
+          IMAGE="ghcr.io/agenta-ai/${{ matrix.image_name }}:${{ needs.prepare.outputs.image_tag }}"
+          docker pull "$IMAGE"
+          USER=$(docker inspect --format='{{.Config.User}}' "$IMAGE")
+          if [ -z "$USER" ] || [ "$USER" = "root" ] || [ "$USER" = "0" ]; then
+            echo "::error::${{ matrix.image_name }} runs as root (User='${USER}')"
             exit 1
           fi
+          echo "PASS: ${{ matrix.image_name }} runs as User='${USER}'"
 
       - name: Summary
         run: |


### PR DESCRIPTION
## Summary
- fix the Railway preview non-root verification step to use the image tag from the `prepare` job
- verify only the image built by the current matrix leg so parallel builds do not race on sibling images
- keep the check in the matrix for the fastest path to deploy while preserving the non-root guardrail
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/agenta-ai/agenta/pull/3935" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open with Devin">
  </picture>
</a>
<!-- devin-review-badge-end -->
