### PR TITLE
fix(frontend): block deletion of an app's last revision (#3892)

### DIFF
--- a/web/oss/src/components/Playground/Components/Modals/DeleteVariantModal/Content.tsx
+++ b/web/oss/src/components/Playground/Components/Modals/DeleteVariantModal/Content.tsx
@@ -13,6 +13,7 @@ import {
     deleteVariantMutationAtom,
     invalidatePlaygroundQueriesAtom,
     moleculeBackedVariantAtomFamily,
+    totalServerRevisionsCountAtom,
 } from "@/oss/components/Playground/state/atoms"
 import {checkIfResourceValidForDeletion} from "@/oss/lib/evaluations/legacy"
 import {deleteSingleVariant} from "@/oss/services/playground/api"
@@ -59,6 +60,7 @@ const DeleteVariantContent = ({revisionIds, forceVariantIds = [], onClose}: Prop
     )
     const variantsQuery = useAtomValue(variantsListAtom)
     const variants = variantsQuery.data ?? []
+    const totalAppServerRevisions = useAtomValue(totalServerRevisionsCountAtom)
 
     const uniqueRevisionIds = useMemo(
         () => Array.from(new Set([revisionIds].flat().filter(Boolean))) as string[],
@@ -73,6 +75,14 @@ const DeleteVariantContent = ({revisionIds, forceVariantIds = [], onClose}: Prop
                 .filter(Boolean) as any[],
         [store, uniqueRevisionIds],
     )
+
+    const selectedServerRevisionsCount = useMemo(
+        () => resolvedRevisions.filter(isVisibleServerRevision).length,
+        [resolvedRevisions],
+    )
+
+    const isDeletingLastRevision =
+        totalAppServerRevisions > 0 && totalAppServerRevisions === selectedServerRevisionsCount
 
     const variantNameMap = useMemo(() => {
         const map: Record<string, string> = {}
@@ -222,6 +232,19 @@ const DeleteVariantContent = ({revisionIds, forceVariantIds = [], onClose}: Prop
                 <Text>
                     One or more variants cannot be deleted because they are currently in use.
                 </Text>
+                <div className="flex items-center justify-end">
+                    <Button type="primary" onClick={onClose}>
+                        Close
+                    </Button>
+                </div>
+            </section>
+        )
+    }
+
+    if (isDeletingLastRevision) {
+        return (
+            <section className="flex flex-col gap-4">
+                <Text>Cannot delete the only revision. Delete the app instead.</Text>
                 <div className="flex items-center justify-end">
                     <Button type="primary" onClick={onClose}>
                         Close

--- a/web/oss/src/components/Playground/state/atoms/index.ts
+++ b/web/oss/src/components/Playground/state/atoms/index.ts
@@ -17,6 +17,7 @@ export {
     playgroundRevisionListAtom,
     playgroundRevisionsReadyAtom,
     playgroundLatestRevisionIdAtom,
+    totalServerRevisionsCountAtom,
     revisionListAtom,
     isComparisonViewAtom,
     appsListAtom,

--- a/web/oss/src/components/Playground/state/atoms/variants.ts
+++ b/web/oss/src/components/Playground/state/atoms/variants.ts
@@ -171,6 +171,14 @@ export const playgroundLatestRevisionIdAtom = selectAtom(
     (a, b) => a === b,
 )
 
+/**
+ * Total count of server-side revisions (non-local drafts) for the current app.
+ */
+export const totalServerRevisionsCountAtom = atom((get) => {
+    const revisions = get(playgroundRevisionListAtom)
+    return revisions.filter((revision: any) => !revision?.isLocalDraft).length
+})
+
 // Re-export types for consumers
 export type {AppListItem, VariantListItem, RevisionListItem}
 


### PR DESCRIPTION
Resolves #3892 

Key Changes Summary:


   * Deletion Blocking Logic:
       * Introduced a check in the DeleteVariantContent component to identify if the user is attempting to delete the
         last revision of an app.
       * Added a specific UI state that displays: "Cannot delete the only revision. Delete the app instead." when this
         condition is met, disabling the deletion action.
   * New State Management:
       * Added a new Jotai atom totalServerRevisionsCountAtom in variants.ts to track the total number of non-local
         (server-side) revisions for the current app.
       * Updated the playground state to include this count, allowing the UI to reactively block deletions based on the
         remaining revision count.
   * UI/UX Improvements:
       * Enhanced the DeleteVariantModal to show a "checking" state while verifying if resources are valid for
         deletion.
       * Improved the deletion summary text to clearly distinguish between deleting entire variants versus individual
         revisions.


  Files modified:
   1. web/oss/src/components/Playground/Components/Modals/DeleteVariantModal/Content.tsx: Added the core blocking logic
      and UI updates.
   2. web/oss/src/components/Playground/state/atoms/variants.ts: Added the totalServerRevisionsCountAtom.
   3. web/oss/src/components/Playground/state/atoms/index.ts: Exported the new atom.