### PR TITLE
[feat]: Added warning UIs for `testset` disconnect & change

### DIFF
--- a/web/oss/src/components/Playground/Components/Modals/TestsetDisconnectConfirmModal/index.tsx
+++ b/web/oss/src/components/Playground/Components/Modals/TestsetDisconnectConfirmModal/index.tsx
@@ -1,17 +1,41 @@
 import {loadableController} from "@agenta/entities/loadable"
 import {playgroundController} from "@agenta/playground"
+import {EnhancedModal, ModalContent} from "@agenta/ui"
 import {message} from "@agenta/ui/app-message"
 import {Button, Typography} from "antd"
 import {useAtomValue, useSetAtom} from "jotai"
 
-import EnhancedModal from "@/oss/components/EnhancedUIs/Modal"
 import {initialState, testsetDisconnectConfirmModalAtom} from "./store/state"
 
 const TestsetDisconnectConfirmModal = () => {
-    const {open, loadableId, isSaving} = useAtomValue(testsetDisconnectConfirmModalAtom)
+    const {open, loadableId, isSaving, intent, meta, onComplete} = useAtomValue(
+        testsetDisconnectConfirmModalAtom,
+    )
     const setModalState = useSetAtom(testsetDisconnectConfirmModalAtom)
     const disconnectAndReset = useSetAtom(playgroundController.actions.disconnectAndResetToLocal)
     const commitChanges = useSetAtom(loadableController.actions.commitChanges)
+
+    const targetName = meta?.targetTestsetName?.trim() || null
+    const isChangeIntent = intent === "change-testset"
+
+    const title = isChangeIntent
+        ? targetName
+            ? `Load ${targetName} test set?`
+            : "Load different test set?"
+        : "Save changes?"
+
+    const descriptionLine1 = isChangeIntent
+        ? targetName
+            ? `You have unsaved changes. Do you want to save them before loading ${targetName} test set?`
+            : "You have unsaved changes. Do you want to save them before loading a different test set?"
+        : "You have unsaved changes. Do you want to save them before disconnecting the testset?"
+
+    const descriptionLine2 = isChangeIntent
+        ? "Loading testcases from a different testset will remove any previously loaded testcases."
+        : "Unsaved testcases will convert into local testcases."
+
+    const discardLabel = isChangeIntent ? "Discard & Load" : "Discard & disconnect"
+    const saveLabel = isChangeIntent ? "Save & load" : "Save & disconnect"
 
     const handleCancel = () => {
         if (isSaving) return
@@ -21,6 +45,7 @@ const TestsetDisconnectConfirmModal = () => {
     const handleDiscardAndDisconnect = () => {
         if (!loadableId || isSaving) return
         disconnectAndReset(loadableId)
+        onComplete?.()
         setModalState(initialState)
     }
 
@@ -31,6 +56,7 @@ const TestsetDisconnectConfirmModal = () => {
         try {
             await commitChanges(loadableId)
             disconnectAndReset(loadableId)
+            onComplete?.()
             setModalState(initialState)
             message.success("Testset updated successfully")
         } catch (err) {
@@ -49,25 +75,20 @@ const TestsetDisconnectConfirmModal = () => {
                         Cancel
                     </Button>
                     <Button danger onClick={handleDiscardAndDisconnect} disabled={isSaving}>
-                        Discard &amp; disconnect
+                        {discardLabel}
                     </Button>
                     <Button type="primary" onClick={handleSaveAndDisconnect} loading={isSaving}>
-                        Save &amp; disconnect
+                        {saveLabel}
                     </Button>
                 </div>
             }
-            title={"Save changes?"}
+            title={title}
             width={500}
         >
-            <div className="flex flex-col gap-1">
-                <Typography.Text>
-                    You have unsaved changes. Do you want to save them before disconnecting the
-                    testset?
-                </Typography.Text>
-                <Typography.Text>
-                    Unsaved testcases will convert into local testcases.
-                </Typography.Text>
-            </div>
+            <ModalContent gap="small">
+                <Typography.Text>{descriptionLine1}</Typography.Text>
+                <Typography.Text>{descriptionLine2}</Typography.Text>
+            </ModalContent>
         </EnhancedModal>
     )
 }

--- a/web/oss/src/components/Playground/Components/Modals/TestsetDisconnectConfirmModal/store/state.ts
+++ b/web/oss/src/components/Playground/Components/Modals/TestsetDisconnectConfirmModal/store/state.ts
@@ -1,15 +1,26 @@
 import {atom} from "jotai"
 
+export type TestsetUnsavedChangesIntent = "disconnect" | "change-testset"
+
 interface TestsetDisconnectConfirmModalState {
     open: boolean
     loadableId: string | null
     isSaving: boolean
+    intent: TestsetUnsavedChangesIntent
+    meta?: {
+        targetTestsetName?: string | null
+    }
+    /** Called after the user confirms (save or discard). Lets the opener decide what happens next. */
+    onComplete?: () => void
 }
 
 export const initialState: TestsetDisconnectConfirmModalState = {
     open: false,
     loadableId: null,
     isSaving: false,
+    intent: "disconnect",
+    meta: undefined,
+    onComplete: undefined,
 }
 
 export const testsetDisconnectConfirmModalAtom =

--- a/web/oss/src/components/Playground/Components/TestsetDropdown/index.tsx
+++ b/web/oss/src/components/Playground/Components/TestsetDropdown/index.tsx
@@ -21,9 +21,9 @@ import {
 import {
     TestsetSelectionModal,
     type PreviewPanelRenderProps,
-    type TestsetSelectionMode,
     type TestsetSelectionPayload,
 } from "@agenta/playground-ui/components"
+import {message} from "@agenta/ui/app-message"
 import {
     ArrowsLeftRightIcon,
     CaretDownIcon,
@@ -34,8 +34,8 @@ import {
     XCircleIcon,
 } from "@phosphor-icons/react"
 import type {MenuProps} from "antd"
-import {Button, Dropdown, Input, Typography, message} from "antd"
-import {atom, useAtomValue, useSetAtom, useStore} from "jotai"
+import {Button, Dropdown, Input, Typography} from "antd"
+import {atom, useAtom, useAtomValue, useSetAtom, useStore} from "jotai"
 import dynamic from "next/dynamic"
 
 import {
@@ -47,10 +47,11 @@ import {saveNewTestsetAtom} from "@/oss/state/entities/testset/mutations"
 import {projectIdAtom} from "@/oss/state/project/selectors/project"
 
 import TestsetDisconnectConfirmModal from "../Modals/TestsetDisconnectConfirmModal"
+import {testsetDisconnectConfirmModalAtom} from "../Modals/TestsetDisconnectConfirmModal/store/state"
 
 import {CreateTestsetCardWrapper} from "./CreateTestsetCardWrapper"
+import {testsetSelectionModalModeAtom, testsetSyncCommitModalOpenAtom} from "./store/modalState"
 import {TestsetPreviewPanelWrapper} from "./TestsetPreviewPanelWrapper"
-import {testsetDisconnectConfirmModalAtom} from "../Modals/TestsetDisconnectConfirmModal/store/state"
 
 // ── Lazy-loaded AddToTestset drawer ────────────────────────────────────────
 const TestsetDrawer = dynamic(
@@ -258,7 +259,7 @@ export function TestsetDropdown() {
 
     // ── TestsetSelectionModal state ─────────────────────────────────────────
     // null = closed, "load" = connect/change, "edit" = manage testcases
-    const [selectionModalMode, setSelectionModalMode] = useState<TestsetSelectionMode | null>(null)
+    const [selectionModalMode, setSelectionModalMode] = useAtom(testsetSelectionModalModeAtom)
 
     // ── Load/Change mode: connect or replace testset ───────────────────────
     const handleLoadConfirm = useCallback(
@@ -378,6 +379,7 @@ export function TestsetDropdown() {
                 open: true,
                 loadableId,
                 isSaving: false,
+                intent: "disconnect",
             })
             return
         }
@@ -385,8 +387,28 @@ export function TestsetDropdown() {
         disconnectAndReset(loadableId)
     }, [loadableId, hasLocalChanges, setDisconnectConfirmModalState, disconnectAndReset])
 
+    const handleChangeTestset = useCallback(() => {
+        if (!loadableId) return
+
+        if (hasLocalChanges) {
+            setDisconnectConfirmModalState({
+                open: true,
+                loadableId,
+                isSaving: false,
+                intent: "change-testset",
+                meta: {
+                    targetTestsetName: null,
+                },
+                onComplete: () => setSelectionModalMode("load"),
+            })
+            return
+        }
+
+        setSelectionModalMode("load")
+    }, [loadableId, hasLocalChanges, setDisconnectConfirmModalState, setSelectionModalMode])
+
     // ── Sync changes (EntityCommitModal) ───────────────────────────────────
-    const [syncOpen, setSyncOpen] = useState(false)
+    const [syncOpen, setSyncOpen] = useAtom(testsetSyncCommitModalOpenAtom)
     const [newTestsetName, setNewTestsetName] = useState("")
     const [currentSyncMode, setCurrentSyncMode] = useState("commit")
     const syncModeRef = useRef("commit")
@@ -493,7 +515,7 @@ export function TestsetDropdown() {
                 key: "change",
                 icon: <ArrowsLeftRightIcon size={14} />,
                 label: "Change testset",
-                onClick: () => setSelectionModalMode("load"),
+                onClick: handleChangeTestset,
             },
             {
                 key: "add-to-testset",
@@ -517,6 +539,7 @@ export function TestsetDropdown() {
         hasSuccessfulResults,
         handleSyncOpen,
         handleDisconnect,
+        handleChangeTestset,
         handleAddToTestset,
     ])
 

--- a/web/oss/src/components/Playground/Components/TestsetDropdown/store/modalState.ts
+++ b/web/oss/src/components/Playground/Components/TestsetDropdown/store/modalState.ts
@@ -1,0 +1,5 @@
+import type {TestsetSelectionMode} from "@agenta/playground-ui/components"
+import {atom} from "jotai"
+
+export const testsetSelectionModalModeAtom = atom<TestsetSelectionMode | null>(null)
+export const testsetSyncCommitModalOpenAtom = atom(false)


### PR DESCRIPTION
## What's new??

Added warning modals for testset sync on the playground to make sure the user gets a proper message before disconnecting the testset and changing the testset connection.

Note: This modal only appears when we have changes to sync

<details>
When disconnecting the testset

<img width="2938" height="1558" alt="image" src="https://github.com/user-attachments/assets/73c52861-658b-4e6f-a7e3-97bf0e18089e" />

When changing the testset

<img width="2924" height="1554" alt="image" src="https://github.com/user-attachments/assets/85e95d06-827e-4ea2-a458-e3aee33446f8" />


</details>

## QA
- Go to playground
- Connect a testset
- Make changes to the testcases on the playground
- Try to disconnect the testset, now you should be able to see the warning modal
- Try changing the testset, now you should be able to see the warning modal
- Make sure all the buttons work as expected on the modals