### PR TITLE
[Frontend/Fix] Cascade failure and cancellation states to downstream evaluators

### DIFF
--- a/web/packages/agenta-playground/src/state/execution/webWorkerIntegration.ts
+++ b/web/packages/agenta-playground/src/state/execution/webWorkerIntegration.ts
@@ -525,20 +525,23 @@ export const triggerExecutionAtom = atom(
                                 },
                             })
 
-                            // When root execution fails, also fail all downstream
-                            // evaluator sessions that were marked as running.
-                            // Without this, evaluators stay in "running" state forever.
-                            for (const n of nodes) {
-                                if (n.depth === 0) continue
-                                if (connections.some((c) => c.targetNodeId === n.id)) {
-                                    set(failRunAtom, {
-                                        loadableId,
-                                        stepId: rowId,
-                                        sessionId: `sess:${rootEntityId}:${n.entityId}`,
-                                        error: {
-                                            message: "Generation failed",
-                                        },
-                                    })
+                            // When root execution fails (full chain only), also fail
+                            // all downstream evaluator sessions that were marked as
+                            // running. Use !params.targetNodeId to match the guard in
+                            // startRunAtom — targeted-root never starts downstream.
+                            if (!params.targetNodeId) {
+                                for (const n of nodes) {
+                                    if (n.depth === 0) continue
+                                    if (connections.some((c) => c.targetNodeId === n.id)) {
+                                        set(failRunAtom, {
+                                            loadableId,
+                                            stepId: rowId,
+                                            sessionId: `sess:${rootEntityId}:${n.entityId}`,
+                                            error: {
+                                                message: "Generation failed",
+                                            },
+                                        })
+                                    }
                                 }
                             }
                             return
@@ -553,20 +556,23 @@ export const triggerExecutionAtom = atom(
                                 ...(traceId !== null ? {traceId} : {}),
                             })
 
-                            // When root execution fails, also fail all downstream
-                            // evaluator sessions that were marked as running.
-                            // Without this, evaluators stay in "running" state forever.
-                            for (const n of nodes) {
-                                if (n.depth === 0) continue
-                                if (connections.some((c) => c.targetNodeId === n.id)) {
-                                    set(failRunAtom, {
-                                        loadableId,
-                                        stepId: rowId,
-                                        sessionId: `sess:${rootEntityId}:${n.entityId}`,
-                                        error: {
-                                            message: "Generation failed",
-                                        },
-                                    })
+                            // When root execution fails (full chain only), also fail
+                            // all downstream evaluator sessions that were marked as
+                            // running. Use !params.targetNodeId to match the guard in
+                            // startRunAtom — targeted-root never starts downstream.
+                            if (!params.targetNodeId) {
+                                for (const n of nodes) {
+                                    if (n.depth === 0) continue
+                                    if (connections.some((c) => c.targetNodeId === n.id)) {
+                                        set(failRunAtom, {
+                                            loadableId,
+                                            stepId: rowId,
+                                            sessionId: `sess:${rootEntityId}:${n.entityId}`,
+                                            error: {
+                                                message: "Generation failed",
+                                            },
+                                        })
+                                    }
                                 }
                             }
                         } else {
@@ -585,8 +591,10 @@ export const triggerExecutionAtom = atom(
                             : sessionId
                         set(cancelRunAtom, {loadableId, stepId: rowId, sessionId: cancelSessionId})
 
-                        // Also cancel downstream evaluator sessions
-                        if (!isTargetingDownstream) {
+                        // Also cancel downstream evaluator sessions (full chain only).
+                        // Use !params.targetNodeId to match startRunAtom guard —
+                        // targeted-root never starts downstream sessions.
+                        if (!params.targetNodeId) {
                             for (const n of nodes) {
                                 if (n.depth === 0) continue
                                 if (connections.some((c) => c.targetNodeId === n.id)) {


### PR DESCRIPTION
When root execution fails or is cancelled, propagate the state to all connected downstream evaluator sessions to prevent them from staying in "running" state indefinitely.
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/agenta-ai/agenta/pull/3960" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open with Devin">
  </picture>
</a>
<!-- devin-review-badge-end -->
