### PR TITLE
fix(api): redact sensitive headers from webhook delivery records

### DIFF
--- a/api/oss/src/tasks/taskiq/webhooks/tasks.py
+++ b/api/oss/src/tasks/taskiq/webhooks/tasks.py
@@ -56,9 +56,29 @@ NON_OVERRIDABLE_HEADERS = {
     "authorization",
 }
 
+REDACTED_HEADERS = {
+    "authorization",
+    "x-agenta-signature",
+}
+
+REDACTED_VALUE = "[REDACTED]"
+
 
 def _is_retryable(status_code: int) -> bool:
     return status_code >= 500
+
+
+def _redact_headers(headers: dict[str, str]) -> dict[str, str]:
+    """Return a copy of *headers* with sensitive values replaced by a placeholder.
+
+    Used to build the header dict stored in delivery records so that
+    secrets (Authorization tokens, HMAC signatures) are never persisted.
+    """
+
+    return {
+        k: (REDACTED_VALUE if k.lower() in REDACTED_HEADERS else v)
+        for k, v in headers.items()
+    }
 
 
 def _merge_headers(
@@ -265,7 +285,9 @@ async def deliver_webhook(
         user_headers=headers,
         system_headers=system_headers,
     )
-    base_data = base_data.model_copy(update={"headers": request_headers})
+    base_data = base_data.model_copy(
+        update={"headers": _redact_headers(request_headers)}
+    )
 
     try:
         async with httpx.AsyncClient(timeout=WEBHOOK_TIMEOUT) as client:


### PR DESCRIPTION
## Summary

- Webhook delivery records were persisting `Authorization` tokens and `X-Agenta-Signature` HMAC values in plaintext in the `data.headers` JSON column
- Delivery records are audit logs — they should never contain secrets
- This adds a `_redact_headers()` step that replaces sensitive header values with `[REDACTED]` before the delivery is stored in the database
- The actual HTTP request still uses the full unredacted headers — only the persisted copy is sanitized

## Details

When `auth_mode=authorization`, the decrypted signing secret was stored verbatim in `data.headers.Authorization`. When `auth_mode=signature`, the HMAC signature was stored in `data.headers.X-Agenta-Signature`. Both were then returned by the delivery query API and visible in any delivery log viewer.

The fix is minimal: after merging headers for the HTTP request, a redacted copy is stored in `base_data.headers` (used for DB persistence), while the original `request_headers` continues to be used for the actual HTTP call.
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/agenta-ai/agenta/pull/3988" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open with Devin">
  </picture>
</a>
<!-- devin-review-badge-end -->
