### PR TITLE
chore(docs): update roadmap with annotation queues and evaluator playground

### DIFF
--- a/docs/src/data/roadmap.ts
+++ b/docs/src/data/roadmap.ts
@@ -485,6 +485,32 @@ export const inProgressFeatures: PlannedFeature[] = [
       },
     ],
   },
+  {
+    id: "annotation-queues-traces",
+    title: "Annotation Queues for Traces",
+    description:
+      "Annotation queues let you define a set of traces to review, assign them to team members, and track annotation progress — all from within Agenta.",
+    githubUrl: "https://github.com/Agenta-AI/agenta/discussions/4009",
+    labels: [
+      {
+        name: "Observability",
+        color: "DE74FF",
+      },
+    ],
+  },
+  {
+    id: "evaluator-playground-updates",
+    title: "Updates to the Evaluator Playground",
+    description:
+      "A richer editing experience for LLM-as-a-Judge and other evaluators, with inline test runs and the ability to evaluate evaluators against a labeled test set to measure agreement with ground truth.",
+    githubUrl: "https://github.com/Agenta-AI/agenta/discussions/4011",
+    labels: [
+      {
+        name: "Evaluation",
+        color: "86B7FF",
+      },
+    ],
+  },
 
   {
     id: "agents-from-ui",
@@ -502,6 +528,23 @@ export const inProgressFeatures: PlannedFeature[] = [
 ];
 
 export const plannedFeatures: PlannedFeature[] = [
+  {
+    id: "annotation-queue-label-testsets",
+    title: "Annotation Queue to Label Test Sets",
+    description:
+      "Turn annotated traces into labeled test cases directly from an annotation queue. Export reviewed traces with ground-truth labels as a new or existing test set in one action.",
+    githubUrl: "https://github.com/Agenta-AI/agenta/discussions/4010",
+    labels: [
+      {
+        name: "Evaluation",
+        color: "86B7FF",
+      },
+      {
+        name: "Observability",
+        color: "DE74FF",
+      },
+    ],
+  },
   {
     id: "trace-usage-limits",
     title: "Usage Limits for Traces (Hard and Soft Caps)",


### PR DESCRIPTION
## What

Updates the public roadmap (`docs/src/data/roadmap.ts`) with 3 new items:

**In Progress:**
- Annotation Queues for Traces — [#4009](https://github.com/Agenta-AI/agenta/discussions/4009)
- Updates to the Evaluator Playground (evaluate LLM-as-a-Judge evaluators) — [#4011](https://github.com/Agenta-AI/agenta/discussions/4011)

**Planned:**
- Annotation Queue to Label Test Sets — [#4010](https://github.com/Agenta-AI/agenta/discussions/4010)
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/agenta-ai/agenta/pull/4013" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open with Devin">
  </picture>
</a>
<!-- devin-review-badge-end -->
