### PR TITLE
[3994] fix(frontend): avoid crypto.randomUUID on HTTP

### DIFF
--- a/web/packages/agenta-entities/src/runnable/utils.ts
+++ b/web/packages/agenta-entities/src/runnable/utils.ts
@@ -6,7 +6,7 @@
 
 import {getAgentaApiUrl} from "@agenta/shared/api"
 import {projectIdAtom} from "@agenta/shared/state"
-import {getValueAtPath} from "@agenta/shared/utils"
+import {getValueAtPath, generateId} from "@agenta/shared/utils"
 import {getDefaultStore} from "jotai/vanilla"
 
 import {parseEvaluatorKeyFromUri} from "../evaluator/core"
@@ -1182,7 +1182,7 @@ export async function executeRunnable(
     options: ExecuteRunnableOptions,
 ): Promise<ExecutionResult> {
     const {inputs, abortSignal, rawBody, headers: optionHeaders} = options
-    const executionId = crypto.randomUUID()
+    const executionId = generateId()
     const startedAt = new Date().toISOString()
 
     // Route evaluator execution to the evaluator run endpoint

--- a/web/packages/agenta-entities/src/workflow/api/api.ts
+++ b/web/packages/agenta-entities/src/workflow/api/api.ts
@@ -15,7 +15,7 @@
  */
 
 import {getAgentaApiUrl, axios} from "@agenta/shared/api"
-import {dereferenceSchema} from "@agenta/shared/utils"
+import {dereferenceSchema, generateId} from "@agenta/shared/utils"
 
 import {extractAllEndpointSchemas, type OpenAPISpec} from "../../legacyAppRevision/api/schemaUtils"
 import {parseRevisionUri, safeParseWithLogging} from "../../shared"
@@ -582,7 +582,7 @@ export async function createWorkflow(
             {
                 workflow_revision: {
                     workflow_id: workflowId,
-                    slug: crypto.randomUUID().replace(/-/g, "").slice(0, 12),
+                    slug: generateId().replace(/-/g, "").slice(0, 12),
                     flags: payload.flags,
                     data: payload.data,
                 },
@@ -728,7 +728,7 @@ export async function updateWorkflow(
                 workflow_revision: {
                     workflow_id: payload.id,
                     workflow_variant_id: payload.variantId ?? undefined,
-                    slug: crypto.randomUUID().replace(/-/g, "").slice(0, 12),
+                    slug: generateId().replace(/-/g, "").slice(0, 12),
                     name: payload.name ?? undefined,
                     flags: payload.flags,
                     data: payload.data,
@@ -785,7 +785,7 @@ export async function commitWorkflowRevisionApi(
             workflow_revision: {
                 workflow_id: payload.workflowId,
                 workflow_variant_id: payload.variantId ?? undefined,
-                slug: payload.slug ?? crypto.randomUUID().replace(/-/g, "").slice(0, 12),
+                slug: payload.slug ?? generateId().replace(/-/g, "").slice(0, 12),
                 name: payload.name ?? undefined,
                 flags: payload.flags,
                 data: payload.data,

--- a/web/packages/agenta-playground/src/state/execution/executionRunner.ts
+++ b/web/packages/agenta-playground/src/state/execution/executionRunner.ts
@@ -10,6 +10,7 @@ import {
     type StageExecutionResult,
     type EntitySelection,
 } from "@agenta/entities/runnable"
+import {generateId} from "@agenta/shared/utils"
 import type {Getter, Setter} from "jotai"
 import {getDefaultStore} from "jotai/vanilla"
 
@@ -669,7 +670,7 @@ async function executeViaFetch(params: {
     }
 }): Promise<ExecutionResult> {
     const {invocationUrl, requestBody, headers, abortSignal, normalizeResponse} = params
-    const executionId = crypto.randomUUID()
+    const executionId = generateId()
     const startedAt = new Date().toISOString()
 
     try {


### PR DESCRIPTION
## Summary
- replace direct `crypto.randomUUID()` calls in runnable execution and workflow revision code with `generateId()` from `@agenta/shared/utils`
- preserve existing slug behavior by continuing to derive 12-character slugs from UUIDs without relying on secure browser contexts
- fix playground and workflow actions when the app is served over plain HTTP or a LAN IP instead of HTTPS/`localhost`

## Validation
- ran `pnpm lint` in `web/`
- verified there are no remaining `crypto.randomUUID()` usages under `web/packages`
- deployed the fix to a fresh dev instance and confirmed the updated frontend is served from the new container

Closes #3994.
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/agenta-ai/agenta/pull/4020" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open with Devin">
  </picture>
</a>
<!-- devin-review-badge-end -->
