### PR TITLE
fix(ci): prevent Railway gateway auth header overflows

### DIFF
--- a/docs/design/railway-gateway-header-buffers/README.md
+++ b/docs/design/railway-gateway-header-buffers/README.md
@@ -1,0 +1,9 @@
+# Railway Gateway Header Buffers
+
+This workspace tracks the fix for Railway preview and test failures caused by the gateway returning `upstream sent too big header while reading response header from upstream` during auth session refresh.
+
+Files:
+- `context.md` - background, problem statement, goals, and non-goals
+- `research.md` - findings from code and workflow inspection
+- `plan.md` - execution plan for the fix and verification
+- `status.md` - current progress, decisions, and follow-ups

--- a/docs/design/railway-gateway-header-buffers/context.md
+++ b/docs/design/railway-gateway-header-buffers/context.md
@@ -1,0 +1,27 @@
+# Context
+
+## Background
+
+Railway preview and CI traffic reaches the app through `hosting/railway/oss/gateway/nginx.conf`.
+
+After the Railway CI refactor in `#4016`, preview deployments began exercising the auth bootstrap and session refresh path more consistently. The gateway logs now show:
+
+`upstream sent too big header while reading response header from upstream`
+
+for `POST /api/auth/session/refresh`.
+
+## Problem Statement
+
+The gateway uses Nginx defaults for upstream response header buffering. Session refresh responses can emit a large `Set-Cookie` header, which can overflow the default proxy header buffer and cause Nginx to fail the request before it reaches the client.
+
+## Goals
+
+- Increase Railway gateway proxy header buffering enough to handle auth refresh responses.
+- Keep the fix scoped to the Railway gateway path that CI and previews use.
+- Validate that the change is small, safe, and easy to reason about.
+
+## Non-Goals
+
+- Redesign auth/session payload size.
+- Change preview environment naming or workflow wiring.
+- Refactor non-Railway Nginx configs in the same patch unless needed for the fix.

--- a/docs/design/railway-gateway-header-buffers/plan.md
+++ b/docs/design/railway-gateway-header-buffers/plan.md
@@ -1,0 +1,7 @@
+# Plan
+
+1. Update `hosting/railway/oss/gateway/nginx.conf` with explicit upstream proxy buffer sizes.
+2. Keep the change scoped to the Railway gateway used by preview deploys and CI.
+3. Review the diff to confirm no unrelated deployment behavior changes.
+4. Commit on a dedicated branch and open a PR describing the workflow regression trigger and gateway fix.
+5. Watch CI results, especially Railway preview/auth-related checks, and confirm whether the auth refresh error disappears.

--- a/docs/design/railway-gateway-header-buffers/research.md
+++ b/docs/design/railway-gateway-header-buffers/research.md
@@ -1,0 +1,24 @@
+# Research
+
+## Observations
+
+- `hosting/railway/oss/gateway/nginx.conf` has no `proxy_buffer_size`, `proxy_buffers`, or `proxy_busy_buffers_size` directives.
+- The error occurs while reading response headers from `/api/auth/session/refresh`, which strongly suggests an oversized upstream header, typically `Set-Cookie`.
+- `hosting/railway/oss/gateway/nginx.conf` was introduced without these directives and has not previously contained them.
+- `#4016` added a unified Railway test workflow and auth bootstrap path that makes session refresh traffic happen early and reliably.
+- `hosting/railway/oss/scripts/preview-resolve-env.sh` defaults preview deployments to a Railway environment named `production`, which explains `gateway-production-*.up.railway.app` preview domains.
+
+## Working Theory
+
+The root product bug is missing Nginx proxy header buffer tuning in the Railway gateway. The CI/workflow changes in `#4016` exposed it by driving requests through `/api/auth/session/refresh` more often.
+
+## Candidate Fix
+
+Set explicit proxy buffer sizes in the Railway gateway `server` block, near the existing timeout directives, so larger auth refresh headers fit without overflowing default buffers.
+
+Suggested values:
+- `proxy_buffer_size 16k`
+- `proxy_buffers 4 16k`
+- `proxy_busy_buffers_size 16k`
+
+These values are conservative, common for auth-heavy apps, and should be sufficient for large cookie headers without materially changing routing behavior.

--- a/docs/design/railway-gateway-header-buffers/status.md
+++ b/docs/design/railway-gateway-header-buffers/status.md
@@ -1,0 +1,17 @@
+# Status
+
+## Current State
+
+- Investigated preview gateway logs and traced the failure to Nginx upstream header buffering during auth session refresh.
+- Confirmed the Railway gateway config lacks proxy buffer tuning.
+- Confirmed `#4016` changed Railway preview/test execution in a way that likely exposed the latent bug.
+- Added explicit proxy buffer sizing to the Railway gateway to handle larger auth refresh response headers.
+
+## Decisions
+
+- Fix only the Railway gateway in this patch to minimize scope and directly address the failing preview/CI path.
+
+## Next Steps
+
+- Commit and open a PR.
+- Monitor CI to confirm the fix resolves the gateway error.

--- a/hosting/railway/oss/gateway/nginx.conf
+++ b/hosting/railway/oss/gateway/nginx.conf
@@ -27,6 +27,12 @@ http {
         proxy_read_timeout 60s;
         proxy_send_timeout 60s;
 
+        # Session refresh can emit a large Set-Cookie header. Increase upstream
+        # proxy buffers so auth responses do not overflow Nginx defaults.
+        proxy_buffer_size 16k;
+        proxy_buffers 4 16k;
+        proxy_busy_buffers_size 16k;
+
         location /api/ {
             set $api_upstream "api.railway.internal:8000";
             rewrite ^/api/(.*)$ /$1 break;


### PR DESCRIPTION
## Summary
- increase the Railway gateway proxy header buffers so `/api/auth/session/refresh` responses with large cookies do not overflow default nginx limits
- document how the Railway CI refactor in `#4016` exposed the latent gateway buffering issue in preview environments
- keep the fix scoped to the Railway gateway path used by preview deploys and CI

## Validation
- validated the updated gateway template with `nginx -t` inside `nginx:1.27-alpine` after running `envsubst`
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/agenta-ai/agenta/pull/4023" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open with Devin">
  </picture>
</a>
<!-- devin-review-badge-end -->
