### PR TITLE
doc(docs): remove 'coming soon' from Custom SSO

### DIFF
--- a/docs/docs/misc/01-opensource.mdx
+++ b/docs/docs/misc/01-opensource.mdx
@@ -40,7 +40,7 @@ Here's what's available in each version:
 | Automatic Evaluation | ✅ | ✅ |
 | Custom Workflows | ✅ | ✅ |
 | Role-Based Access Control | ❌ | ✅ |
-| Custom SSO (coming soon) | ❌ | ✅ |
+| Custom SSO | ❌ | ✅ |
 | Support | ❌ | ✅ |
 
 ## Self-Hosting Agenta
@@ -68,7 +68,7 @@ Yes, there is no risk of executing any enterprise-restricted code when using the
 All functional features for building and evaluating LLM applications are now open source. The commercial version focuses on enterprise and team needs:
 - Team Management: Role-based access control and multi-team organizations
 - Support: Professional support with SLAs
-- Enterprise Features: Custom SSO (coming soon) and other enterprise-specific capabilities
+- Enterprise Features: Custom SSO and other enterprise-specific capabilities
 
 The open-source version includes evaluations, observability, custom workflows, and prompt management.
 


### PR DESCRIPTION
## Summary
- Removes the "(coming soon)" label from Custom SSO in the feature availability table and FAQ section on the [OSS vs Commercial page](https://agenta.ai/docs/misc/opensource#feature-availability)
- Custom SSO is now available, so the qualifier is no longer needed
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/agenta-ai/agenta/pull/4037" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open with Devin">
  </picture>
</a>
<!-- devin-review-badge-end -->
