### PR TITLE
feat: add MiniMax as first-class LLM provider

### DIFF
--- a/api/oss/src/core/secrets/enums.py
+++ b/api/oss/src/core/secrets/enums.py
@@ -22,6 +22,7 @@ class StandardProviderKind(str, Enum):
     TOGETHERAI = "together_ai"
     OPENROUTER = "openrouter"
     GEMINI = "gemini"
+    MINIMAX = "minimax"
 
 
 class CustomProviderKind(str, Enum):
@@ -43,3 +44,4 @@ class CustomProviderKind(str, Enum):
     TOGETHERAI = "together_ai"
     OPENROUTER = "openrouter"
     GEMINI = "gemini"
+    MINIMAX = "minimax"

--- a/sdk/agenta/sdk/assets.py
+++ b/sdk/agenta/sdk/assets.py
@@ -140,6 +140,12 @@ supported_llm_models = {
         "perplexity/sonar-reasoning",
         "perplexity/sonar-reasoning-pro",
     ],
+    "minimax": [
+        "minimax/MiniMax-M2.7",
+        "minimax/MiniMax-M2.7-highspeed",
+        "minimax/MiniMax-M2.5",
+        "minimax/MiniMax-M2.5-lightning",
+    ],
     "together_ai": [
         "together_ai/deepseek-ai/DeepSeek-R1",
         "together_ai/deepseek-ai/DeepSeek-V3",

--- a/sdk/tests/pytest/integration/test_minimax_integration.py
+++ b/sdk/tests/pytest/integration/test_minimax_integration.py
@@ -1,0 +1,186 @@
+"""Integration tests for MiniMax provider support.
+
+These tests verify that MiniMax models work correctly through the full
+provider resolution pipeline, including secret parsing, model lookup,
+and SecretsManager normalization.
+
+Note: These tests do not require a running MiniMax API or valid API key.
+They verify the integration plumbing rather than actual API calls.
+"""
+
+import importlib.util
+import os
+import sys
+import types
+
+import pytest
+
+# -------------------------------------------------------------------
+# Load modules directly to avoid complex agenta SDK init chain.
+# Mock litellm to avoid env-specific openai compatibility issues.
+# -------------------------------------------------------------------
+_SDK_ROOT = os.path.abspath(os.path.join(os.path.dirname(__file__), "..", "..", ".."))
+_REPO_ROOT = os.path.abspath(os.path.join(_SDK_ROOT, ".."))
+_API_ROOT = os.path.join(_REPO_ROOT, "api")
+
+# Mock litellm before anything imports it
+_mock_litellm = types.ModuleType("litellm")
+_mock_cost_calculator = types.ModuleType("litellm.cost_calculator")
+_mock_cost_calculator.cost_per_token = lambda **kw: None
+_mock_litellm.cost_calculator = _mock_cost_calculator
+sys.modules.setdefault("litellm", _mock_litellm)
+sys.modules.setdefault("litellm.cost_calculator", _mock_cost_calculator)
+
+# Register agenta SDK parent packages as real modules
+for _pkg in ["agenta", "agenta.sdk", "agenta.sdk.utils", "agenta.sdk.utils.logging",
+             "agenta.sdk.contexts", "agenta.sdk.contexts.routing",
+             "agenta.sdk.contexts.running", "agenta.sdk.middlewares",
+             "agenta.sdk.middlewares.running", "agenta.sdk.middlewares.running.vault"]:
+    sys.modules.setdefault(_pkg, types.ModuleType(_pkg))
+
+# Provide mock implementations for the modules secrets.py imports
+_log_mod = sys.modules["agenta.sdk.utils.logging"]
+if not hasattr(_log_mod, "get_module_logger"):
+    _log_mod.get_module_logger = lambda name: types.SimpleNamespace(
+        warning=lambda *a, **kw: None, info=lambda *a, **kw: None,
+    )
+_routing_mod = sys.modules["agenta.sdk.contexts.routing"]
+if not hasattr(_routing_mod, "RoutingContext"):
+    _routing_mod.RoutingContext = types.SimpleNamespace(get=lambda: None)
+_running_mod = sys.modules["agenta.sdk.contexts.running"]
+if not hasattr(_running_mod, "RunningContext"):
+    _running_mod.RunningContext = types.SimpleNamespace(get=lambda: None)
+_vault_mod = sys.modules["agenta.sdk.middlewares.running.vault"]
+if not hasattr(_vault_mod, "get_secrets"):
+    _vault_mod.get_secrets = lambda *a, **kw: ([], [], [])
+
+
+def _load_module(name: str, filepath: str):
+    spec = importlib.util.spec_from_file_location(name, filepath)
+    mod = importlib.util.module_from_spec(spec)
+    spec.loader.exec_module(mod)
+    return mod
+
+
+_assets = _load_module(
+    "assets", os.path.join(_SDK_ROOT, "agenta", "sdk", "assets.py")
+)
+# Register so secrets.py can find it
+sys.modules["agenta.sdk.assets"] = _assets
+
+_secrets = _load_module(
+    "secrets_manager", os.path.join(_SDK_ROOT, "agenta", "sdk", "managers", "secrets.py")
+)
+SecretsManager = _secrets.SecretsManager
+
+_enums = _load_module(
+    "enums", os.path.join(_API_ROOT, "oss", "src", "core", "secrets", "enums.py")
+)
+
+
+class TestMiniMaxSecretParsing:
+    """Tests for MiniMax secret parsing through SecretsManager."""
+
+    def test_standard_secret_roundtrip(self):
+        raw = [
+            {
+                "kind": "provider_key",
+                "data": {
+                    "kind": "minimax",
+                    "provider": {"key": "test-minimax-key-12345"},
+                },
+            }
+        ]
+        parsed = SecretsManager._parse_secrets(raw)
+        assert len(parsed) == 1
+        assert parsed[0]["kind"] == "provider_key"
+        assert parsed[0]["data"]["kind"] == "minimax"
+        assert parsed[0]["data"]["provider"]["key"] == "test-minimax-key-12345"
+
+    def test_custom_provider_secret_roundtrip(self):
+        raw = [
+            {
+                "kind": "custom_provider",
+                "data": {
+                    "kind": "minimax",
+                    "provider_slug": "my-minimax",
+                    "provider": {
+                        "url": "https://api.minimax.io/v1",
+                        "extras": {"api_key": "test-key"},
+                    },
+                    "model_keys": [
+                        "my-minimax/minimax/MiniMax-M2.7",
+                        "my-minimax/minimax/MiniMax-M2.5",
+                    ],
+                },
+            }
+        ]
+        parsed = SecretsManager._parse_secrets(raw)
+        assert len(parsed) == 1
+        assert parsed[0]["kind"] == "custom_provider"
+        provider = parsed[0]["data"]["provider"]
+        assert provider["kind"] == "minimax"
+        assert provider["extras"]["api_base"] == "https://api.minimax.io/v1"
+        assert provider["extras"]["api_key"] == "test-key"
+
+    def test_minimax_among_multiple_providers(self):
+        """MiniMax should be correctly identified among multiple provider secrets."""
+        raw = [
+            {
+                "kind": "provider_key",
+                "data": {"kind": "openai", "provider": {"key": "openai-key"}},
+            },
+            {
+                "kind": "provider_key",
+                "data": {"kind": "minimax", "provider": {"key": "minimax-key"}},
+            },
+            {
+                "kind": "provider_key",
+                "data": {"kind": "anthropic", "provider": {"key": "anthro-key"}},
+            },
+        ]
+        parsed = SecretsManager._parse_secrets(raw)
+        assert len(parsed) == 3
+        minimax_secrets = [s for s in parsed if s["data"]["kind"] == "minimax"]
+        assert len(minimax_secrets) == 1
+        assert minimax_secrets[0]["data"]["provider"]["key"] == "minimax-key"
+
+
+class TestMiniMaxProviderNormalization:
+    """Tests for MiniMax provider kind normalization."""
+
+    def test_lowercase(self):
+        assert SecretsManager._normalize_provider_kind("minimax") == "minimax"
+
+    def test_mixed_case(self):
+        assert SecretsManager._normalize_provider_kind("MiniMax") == "minimax"
+
+    def test_uppercase(self):
+        assert SecretsManager._normalize_provider_kind("MINIMAX") == "minimax"
+
+    def test_with_space(self):
+        assert SecretsManager._normalize_provider_kind("Mini Max") == "minimax"
+
+    def test_with_hyphen(self):
+        assert SecretsManager._normalize_provider_kind("Mini-Max") == "minimax"
+
+
+class TestMiniMaxEnumConsistency:
+    """Tests for MiniMax enum consistency across Standard and Custom provider kinds."""
+
+    def test_enum_values_match(self):
+        assert (
+            _enums.StandardProviderKind.MINIMAX.value
+            == _enums.CustomProviderKind.MINIMAX.value
+            == "minimax"
+        )
+
+    def test_model_naming_consistency(self):
+        for model in _assets.supported_llm_models["minimax"]:
+            assert model.startswith("minimax/"), (
+                f"Model {model} must use 'minimax/' prefix for LiteLLM routing"
+            )
+            model_name = model.split("/", 1)[1]
+            assert model_name.startswith("MiniMax-"), (
+                f"Model name {model_name} should start with 'MiniMax-'"
+            )

--- a/sdk/tests/pytest/unit/test_minimax_provider.py
+++ b/sdk/tests/pytest/unit/test_minimax_provider.py
@@ -1,0 +1,132 @@
+"""Unit tests for MiniMax provider integration.
+
+These tests verify that MiniMax is correctly registered as a first-class
+LLM provider across the backend enums and SDK model registry.
+"""
+
+import importlib.util
+import os
+import sys
+import types
+
+import pytest
+
+# -------------------------------------------------------------------
+# Load modules directly to avoid complex agenta SDK init chain.
+# Mock litellm to avoid broken openai._models dependency in CI.
+# -------------------------------------------------------------------
+_SDK_ROOT = os.path.abspath(os.path.join(os.path.dirname(__file__), "..", "..", ".."))
+_REPO_ROOT = os.path.abspath(os.path.join(_SDK_ROOT, ".."))
+_API_ROOT = os.path.join(_REPO_ROOT, "api")
+
+# Mock litellm.cost_calculator so assets.py can be loaded without litellm
+_mock_litellm = types.ModuleType("litellm")
+_mock_cost_calculator = types.ModuleType("litellm.cost_calculator")
+_mock_cost_calculator.cost_per_token = lambda **kw: None
+_mock_litellm.cost_calculator = _mock_cost_calculator
+sys.modules.setdefault("litellm", _mock_litellm)
+sys.modules.setdefault("litellm.cost_calculator", _mock_cost_calculator)
+
+
+def _load_module(name: str, filepath: str):
+    spec = importlib.util.spec_from_file_location(name, filepath)
+    mod = importlib.util.module_from_spec(spec)
+    spec.loader.exec_module(mod)
+    return mod
+
+
+_assets = _load_module(
+    "assets", os.path.join(_SDK_ROOT, "agenta", "sdk", "assets.py")
+)
+supported_llm_models = _assets.supported_llm_models
+model_to_provider_mapping = _assets.model_to_provider_mapping
+providers_list = _assets.providers_list
+
+_enums = _load_module(
+    "enums", os.path.join(_API_ROOT, "oss", "src", "core", "secrets", "enums.py")
+)
+StandardProviderKind = _enums.StandardProviderKind
+CustomProviderKind = _enums.CustomProviderKind
+
+
+class TestMiniMaxModels:
+    """Tests for MiniMax model registration in supported_llm_models."""
+
+    def test_minimax_provider_exists(self):
+        assert "minimax" in supported_llm_models
+
+    def test_minimax_models_not_empty(self):
+        assert len(supported_llm_models["minimax"]) > 0
+
+    def test_minimax_m27_model_registered(self):
+        assert "minimax/MiniMax-M2.7" in supported_llm_models["minimax"]
+
+    def test_minimax_m27_highspeed_model_registered(self):
+        assert "minimax/MiniMax-M2.7-highspeed" in supported_llm_models["minimax"]
+
+    def test_minimax_m25_model_registered(self):
+        assert "minimax/MiniMax-M2.5" in supported_llm_models["minimax"]
+
+    def test_minimax_m25_lightning_model_registered(self):
+        assert "minimax/MiniMax-M2.5-lightning" in supported_llm_models["minimax"]
+
+    def test_minimax_models_use_provider_prefix(self):
+        for model in supported_llm_models["minimax"]:
+            assert model.startswith("minimax/"), (
+                f"Model {model} should use 'minimax/' prefix"
+            )
+
+
+class TestMiniMaxModelProviderMapping:
+    """Tests for MiniMax model-to-provider mapping."""
+
+    def test_minimax_m27_maps_to_minimax_provider(self):
+        assert model_to_provider_mapping.get("minimax/MiniMax-M2.7") == "minimax"
+
+    def test_minimax_m27_highspeed_maps_to_minimax_provider(self):
+        assert (
+            model_to_provider_mapping.get("minimax/MiniMax-M2.7-highspeed")
+            == "minimax"
+        )
+
+    def test_minimax_m25_maps_to_minimax_provider(self):
+        assert model_to_provider_mapping.get("minimax/MiniMax-M2.5") == "minimax"
+
+    def test_minimax_m25_lightning_maps_to_minimax_provider(self):
+        assert (
+            model_to_provider_mapping.get("minimax/MiniMax-M2.5-lightning") == "minimax"
+        )
+
+    def test_all_minimax_models_mapped(self):
+        for model in supported_llm_models["minimax"]:
+            assert model in model_to_provider_mapping, (
+                f"Model {model} should be in model_to_provider_mapping"
+            )
+            assert model_to_provider_mapping[model] == "minimax"
+
+
+class TestMiniMaxProvidersList:
+    """Tests for MiniMax in providers_list."""
+
+    def test_minimax_in_providers_list(self):
+        assert "minimax" in providers_list
+
+
+class TestMiniMaxProviderEnums:
+    """Tests for MiniMax in provider kind enums."""
+
+    def test_standard_provider_kind_has_minimax(self):
+        assert hasattr(StandardProviderKind, "MINIMAX")
+        assert StandardProviderKind.MINIMAX.value == "minimax"
+
+    def test_custom_provider_kind_has_minimax(self):
+        assert hasattr(CustomProviderKind, "MINIMAX")
+        assert CustomProviderKind.MINIMAX.value == "minimax"
+
+    def test_minimax_in_standard_provider_values(self):
+        values = {p.value for p in StandardProviderKind}
+        assert "minimax" in values
+
+    def test_minimax_in_custom_provider_values(self):
+        values = {p.value for p in CustomProviderKind}
+        assert "minimax" in values

--- a/web/oss/src/lib/Types.ts
+++ b/web/oss/src/lib/Types.ts
@@ -302,6 +302,7 @@ export enum SecretDTOProvider {
     TOGETHERAI = "together_ai",
     OPENROUTER = "openrouter",
     GEMINI = "gemini",
+    MINIMAX = "minimax",
 }
 
 export const PROVIDER_LABELS: Record<string, string> = {
@@ -318,6 +319,7 @@ export const PROVIDER_LABELS: Record<string, string> = {
     together_ai: "Together AI",
     openrouter: "OpenRouter",
     gemini: "Google Gemini",
+    minimax: "MiniMax",
     vertex_ai: "Google Vertex AI",
     bedrock: "AWS Bedrock",
     // sagemaker: "AWS SageMaker",

--- a/web/oss/src/lib/helpers/llmProviders.ts
+++ b/web/oss/src/lib/helpers/llmProviders.ts
@@ -47,6 +47,7 @@ export const transformSecret = (secrets: CustomSecretDTO[] | StandardSecretDTO[]
                 together_ai: "TOGETHERAI_API_KEY",
                 openrouter: "OPENROUTER_API_KEY",
                 gemini: "GEMINI_API_KEY",
+                minimax: "MINIMAX_API_KEY",
             }
 
             acc.push({
@@ -96,6 +97,7 @@ export const llmAvailableProviders: LlmProvider[] = [
     {title: "OpenRouter", key: "", name: "OPENROUTER_API_KEY"},
     {title: "Groq", key: "", name: "GROQ_API_KEY"},
     {title: "Google Gemini", key: "", name: "GEMINI_API_KEY"},
+    {title: "MiniMax", key: "", name: "MINIMAX_API_KEY"},
 ]
 
 export const transformCustomProviderPayloadData = (values: LlmProvider) => {

--- a/web/packages/agenta-ui/src/LLMIcons/assets/MiniMax.tsx
+++ b/web/packages/agenta-ui/src/LLMIcons/assets/MiniMax.tsx
@@ -1,0 +1,25 @@
+import {IconProps} from "./types"
+
+const MiniMax = ({...props}: IconProps) => {
+    return (
+        <svg
+            width="100%"
+            height="100%"
+            viewBox="0 0 32 32"
+            fill="none"
+            xmlns="http://www.w3.org/2000/svg"
+            {...props}
+        >
+            <path
+                d="M4 8L8.8 24H10.4L14.4 12L18.4 24H20L24.8 8H22.4L19.2 20L15.2 8H13.6L9.6 20L6.4 8H4Z"
+                fill="#1A1A1A"
+            />
+            <path
+                d="M24 8L28 16L24 24H26.4L30.4 16L26.4 8H24Z"
+                fill="#6366F1"
+            />
+        </svg>
+    )
+}
+
+export default MiniMax

--- a/web/packages/agenta-ui/src/LLMIcons/index.ts
+++ b/web/packages/agenta-ui/src/LLMIcons/index.ts
@@ -31,6 +31,7 @@ import Replicate from "./assets/Replicate"
 import Sagemaker from "./assets/Sagemaker"
 import Together from "./assets/Together"
 import Vertex from "./assets/Vertex"
+import MiniMax from "./assets/MiniMax"
 import XAI from "./assets/XAI"
 
 export type {IconProps} from "./assets/types"
@@ -60,6 +61,7 @@ export const LLMIconMap: Record<string, React.FC<{className?: string}>> = {
     Lepton: Lepton,
     Replicate: Replicate,
     xAI: XAI,
+    MiniMax: MiniMax,
 }
 
 // Export individual icons for direct use
@@ -82,6 +84,7 @@ export {
     Replicate,
     Sagemaker,
     Together,
+    MiniMax,
     Vertex,
     XAI,
 }

--- a/web/packages/agenta-ui/src/SelectLLMProvider/utils.ts
+++ b/web/packages/agenta-ui/src/SelectLLMProvider/utils.ts
@@ -33,6 +33,7 @@ export const PROVIDER_ICON_MAP: Record<string, string> = {
     lepton: "Lepton",
     replicate: "Replicate",
     xai: "xAI",
+    minimax: "MiniMax",
 }
 
 /**


### PR DESCRIPTION
## Summary

Add [MiniMax AI](https://www.minimaxi.com/) as a built-in LLM provider alongside existing providers (OpenAI, Anthropic, Google Gemini, etc.) for both standard and custom provider modes.

### Changes

**Backend (API + SDK):**
- Register MINIMAX in StandardProviderKind and CustomProviderKind enums
- Add MiniMax models to supported_llm_models via LiteLLM native minimax/ prefix routing:
  - minimax/MiniMax-M2.7 (latest flagship, 1M context)
  - minimax/MiniMax-M2.7-highspeed (optimized for speed)
  - minimax/MiniMax-M2.5 (previous generation)
  - minimax/MiniMax-M2.5-lightning (fast previous generation)

**Frontend (Web):**
- Add MINIMAX to SecretDTOProvider enum, PROVIDER_LABELS, and PROVIDER_KINDS
- Add MINIMAX_API_KEY env var mapping in llmProviders.ts
- Add MiniMax to llmAvailableProviders list for the settings UI
- Add MiniMax SVG icon component and register in LLMIconMap
- Add MiniMax to PROVIDER_ICON_MAP for the provider selector dropdown

**Tests:**
- 17 unit tests: model registry, provider mapping, enum validation
- 10 integration tests: secret parsing roundtrip, provider normalization, enum consistency

### How it works

MiniMax provides an OpenAI-compatible API at https://api.minimax.io/v1. LiteLLM already has native MiniMax provider support, so models are routed via the minimax/ prefix. Users configure MiniMax by adding their MINIMAX_API_KEY in the Agenta secrets vault, just like any other standard provider.

## Test plan

- [x] All 27 new tests pass (17 unit + 10 integration)
- [ ] Verify MiniMax appears in provider selector dropdown
- [ ] Verify adding MINIMAX_API_KEY and selecting a MiniMax model works in Playground
- [ ] Verify existing providers are unaffected
