### PR TITLE
fix(api): prevent org update from overwriting unset fields

### DIFF
--- a/api/ee/src/routers/organization_router.py
+++ b/api/ee/src/routers/organization_router.py
@@ -198,13 +198,7 @@ async def update_organization(
 
         organization = await update_an_organization(
             organization_id,
-            OrganizationUpdateDTO(
-                slug=payload.slug,
-                name=payload.name,
-                description=payload.description,
-                flags=payload.flags,
-                updated_at=payload.updated_at,
-            ),
+            OrganizationUpdateDTO(**payload.model_dump(exclude_unset=True)),
         )
 
         return organization


### PR DESCRIPTION
## Summary

- Fixes a bug where setting an organization slug would overwrite the org name with `None`.
- Fixes a follow-up bug where renaming the org after a slug was set would fail with `"Invalid request data for organization update."`.

## Root Cause

The router in `organization_router.py` explicitly passed all fields (including `None` defaults) when constructing `OrganizationUpdateDTO`. This caused Pydantic to mark every field as "set," defeating the `model_dump(exclude_unset=True)` guard in the DB layer. Two consequences:

1. Updating only the slug also wrote `name=None` to the database.
2. After a slug was set, any subsequent update included `slug=None` in the payload. The DB layer interpreted this as an attempt to change the slug and raised a `ValueError`.

## Fix

Forward only client-provided fields using `payload.model_dump(exclude_unset=True)` when constructing the DTO:

```python
# Before
OrganizationUpdateDTO(
    slug=payload.slug,
    name=payload.name,
    description=payload.description,
    flags=payload.flags,
    updated_at=payload.updated_at,
)

# After
OrganizationUpdateDTO(**payload.model_dump(exclude_unset=True))
```
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/agenta-ai/agenta/pull/4039" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open with Devin">
  </picture>
</a>
<!-- devin-review-badge-end -->
