### PR TITLE
fix(frontend): add DNS provider hint to domain verification instructions

### DIFF
--- a/web/oss/src/components/pages/settings/Organization/index.tsx
+++ b/web/oss/src/components/pages/settings/Organization/index.tsx
@@ -831,19 +831,41 @@ const Organization: FC = () => {
                                                                 </span>
                                                             }
                                                         >
-                                                            <TooltipWithCopyAction
-                                                                copyText={txtRecordName}
-                                                                title="Copy host"
-                                                            >
-                                                                <span
-                                                                    style={{
-                                                                        fontFamily: "monospace",
-                                                                        fontSize: "12px",
-                                                                    }}
+                                                            <div>
+                                                                <TooltipWithCopyAction
+                                                                    copyText={txtRecordName}
+                                                                    title="Copy host"
                                                                 >
-                                                                    {txtRecordName}
-                                                                </span>
-                                                            </TooltipWithCopyAction>
+                                                                    <span
+                                                                        style={{
+                                                                            fontFamily: "monospace",
+                                                                            fontSize: "12px",
+                                                                        }}
+                                                                    >
+                                                                        {txtRecordName}
+                                                                    </span>
+                                                                </TooltipWithCopyAction>
+                                                                <div style={{marginTop: 4}}>
+                                                                    <Text
+                                                                        type="secondary"
+                                                                        style={{fontSize: "11px"}}
+                                                                    >
+                                                                        Some DNS providers (e.g.
+                                                                        Namecheap, GoDaddy,
+                                                                        Cloudflare) automatically
+                                                                        append your domain. If so,
+                                                                        enter only:{" "}
+                                                                        <Text
+                                                                            code
+                                                                            style={{
+                                                                                fontSize: "11px",
+                                                                            }}
+                                                                        >
+                                                                            _agenta-verification
+                                                                        </Text>
+                                                                    </Text>
+                                                                </div>
+                                                            </div>
                                                         </Descriptions.Item>
                                                         <Descriptions.Item
                                                             label={


### PR DESCRIPTION
## Summary

- Adds a helper note below the **Host** field in the domain verification instructions, clarifying that some DNS providers (Namecheap, GoDaddy, Cloudflare) automatically append the domain — so users should enter only `_agenta-verification` instead of the full FQDN.
- Prevents a common misconfiguration where users end up with `_agenta-verification.example.com.example.com` instead of `_agenta-verification.example.com`.
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/agenta-ai/agenta/pull/4042" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open with Devin">
  </picture>
</a>
<!-- devin-review-badge-end -->
