### PR TITLE
feat(api,docs): restrict organization creation via allowlist

### DIFF
--- a/api/ee/src/core/organizations/exceptions.py
+++ b/api/ee/src/core/organizations/exceptions.py
@@ -34,3 +34,15 @@ class LastOrganizationError(OrganizationError):
             or "Cannot delete your last organization. You must have at least one organization."
         )
         super().__init__(self.message)
+
+
+class OrganizationCreationNotAllowedError(OrganizationError):
+    """Raised when a user is not in the org creation allowlist."""
+
+    def __init__(self, email: str, message: str = None):
+        self.email = email
+        self.message = (
+            message
+            or "You are not allowed to create organizations. Please ask your administrator for an invitation."
+        )
+        super().__init__(self.message)

--- a/api/ee/src/routers/organization_router.py
+++ b/api/ee/src/routers/organization_router.py
@@ -51,7 +51,10 @@ from ee.src.core.organizations.types import (
     OrganizationProviderUpdate,
     OrganizationUpdate as OrganizationUpdateDTO,
 )
-from ee.src.core.organizations.exceptions import OrganizationSlugConflictError
+from ee.src.core.organizations.exceptions import (
+    OrganizationSlugConflictError,
+    OrganizationCreationNotAllowedError,
+)
 
 from ee.src.services.organization_service import (
     OrganizationDomainsService,
@@ -415,6 +418,12 @@ async def create_organization(
             },
             status_code=201,
         )
+
+    except OrganizationCreationNotAllowedError as e:
+        raise HTTPException(
+            status_code=403,
+            detail=e.message,
+        ) from e
 
     except Exception:
         log.error(

--- a/api/ee/src/services/commoners.py
+++ b/api/ee/src/services/commoners.py
@@ -8,6 +8,7 @@ from pydantic import BaseModel
 
 from oss.src.utils.logging import get_module_logger
 from oss.src.utils.caching import acquire_lock, release_lock
+from oss.src.utils.common import env
 
 from oss.src.services import db_manager
 from oss.src.utils.common import is_ee
@@ -34,6 +35,7 @@ from ee.src.core.subscriptions.types import get_default_plan
 from ee.src.dbs.postgres.meters.dao import MetersDAO
 from ee.src.core.meters.service import MetersService
 from ee.src.utils.entitlements import check_entitlements, Gauge
+from ee.src.core.organizations.exceptions import OrganizationCreationNotAllowedError
 
 log = get_module_logger(__name__)
 
@@ -46,6 +48,21 @@ subscription_service = SubscriptionsService(
 
 DEMOS = "AGENTA_DEMOS"
 DEMO_ROLE = "viewer"
+
+
+def can_create_organization(email: str) -> bool:
+    """Check if a user is allowed to create organizations.
+
+    When AGENTA_ORG_CREATION_ALLOWLIST is set, only listed emails can create orgs.
+    When not set (None), anyone can create orgs (default behavior).
+    """
+
+    allowlist = env.agenta.org_creation_allowlist
+
+    if allowlist is None:
+        return True
+
+    return email.strip().lower() in allowlist
 
 
 class Demo(BaseModel):
@@ -175,14 +192,20 @@ async def create_accounts(
                 # Add the user to demos
                 await add_user_to_demos(str(user.id))
 
-                # Create organization with workspace and subscription
-                resolved_org_name = organization_name or user_dict["username"]
-                await create_organization_for_signup(
-                    user_id=UUID(str(user.id)),
-                    organization_email=user_dict["email"],
-                    organization_name=resolved_org_name,
-                    organization_description="Default Organization",
-                )
+                # Create organization (unless restricted by allowlist)
+                if can_create_organization(email):
+                    resolved_org_name = organization_name or user_dict["username"]
+                    await create_organization_for_signup(
+                        user_id=UUID(str(user.id)),
+                        organization_email=user_dict["email"],
+                        organization_name=resolved_org_name,
+                        organization_description="Default Organization",
+                    )
+                else:
+                    log.info(
+                        "[scopes] User [%s] not in org creation allowlist, skipping org creation",
+                        user.id,
+                    )
             except Exception:
                 # Setup failed - delete the user to avoid orphaned state
                 log.error(
@@ -314,6 +337,9 @@ async def create_organization_for_user(
     user = await db_manager.get_user(str(user_id))
     if not user:
         raise ValueError(f"User {user_id} not found")
+
+    if not can_create_organization(user.email):
+        raise OrganizationCreationNotAllowedError(email=user.email)
 
     create_org_payload = CreateOrganization(
         name=organization_name,

--- a/api/oss/src/utils/env.py
+++ b/api/oss/src/utils/env.py
@@ -567,6 +567,13 @@ class AgentaConfig(BaseModel):
     demos: str = os.getenv("AGENTA_DEMOS") or ""
     default_plan: str | None = os.getenv("AGENTA_DEFAULT_PLAN") or None
 
+    # None when unset/empty = unrestricted; non-empty set = only these emails can create orgs
+    org_creation_allowlist: set | None = {
+        e.strip().lower()
+        for e in (os.getenv("AGENTA_ORG_CREATION_ALLOWLIST") or "").split(",")
+        if e.strip()
+    } or None
+
     blocked_emails: set = {
         e.strip().lower()
         for e in (os.getenv("AGENTA_BLOCKED_EMAILS") or "").split(",")

--- a/docs/design/ee-self-hosting/doc-1.md
+++ b/docs/design/ee-self-hosting/doc-1.md
@@ -8,16 +8,32 @@ Draft of documentation changes needed after RFC-1 is implemented.
 
 | Variable | Description | Default |
 |----------|-------------|---------|
-| `AGENTA_ORG_CREATORS` | Comma-separated list of emails allowed to create organizations. If not set, any user can create orgs. | Not set (open) |
+| `AGENTA_ORG_CREATION_ALLOWLIST` | Comma-separated list of emails allowed to create organizations. If not set, any user can create orgs. | Not set (open) |
 
 ### Self-Hosted Deployment Guide Updates
 
 - Add section on restricting org creation
-- Example config for single-admin setup: `AGENTA_ORG_CREATORS=admin@company.com`
+- Example config for single-admin setup: `AGENTA_ORG_CREATION_ALLOWLIST=admin@company.com`
 - Explain what happens to users not in the list (account created, must be invited)
 - Explain that this works independently of billing/Stripe
 
+### Important: Pre-invite restricted users
+
+> **Warning:** When using `AGENTA_ORG_CREATION_ALLOWLIST`, restricted users who sign
+> up without a pending invitation will not be able to use the app (the frontend does
+> not currently support "signed in, zero orgs").
+>
+> Always invite users before they sign up (using the invitation flow in organization settings).
+
+### Example configuration
+
+```bash
+AGENTA_ORG_CREATION_ALLOWLIST=admin@company.com
+```
+Only `admin@company.com` can create orgs. All other users must be invited before signing up.
+
 ### Existing docs to update
 
-- EE configuration reference: add `AGENTA_ORG_CREATORS`
+- EE configuration reference: add `AGENTA_ORG_CREATION_ALLOWLIST`
 - Organization management docs: mention the restriction mechanism
+- Note the known frontend limitation and recommend pairing with auto-join or pre-invite

--- a/docs/design/ee-self-hosting/rfc-1.md
+++ b/docs/design/ee-self-hosting/rfc-1.md
@@ -2,7 +2,7 @@
 
 ## Summary
 
-Introduce a simple allowlist to control who can create organizations. If `AGENTA_ORG_CREATORS` is set, only listed emails can create orgs. If not set, anyone can — preserving current behavior.
+Introduce a simple allowlist to control who can create organizations. If `AGENTA_ORG_CREATION_ALLOWLIST` is set, only listed emails can create orgs. If not set, anyone can (preserving current behavior).
 
 ## Motivation
 
@@ -15,7 +15,7 @@ Today, any authenticated user can create unlimited organizations with no checks.
 ### Env var
 
 ```bash
-AGENTA_ORG_CREATORS=admin@company.com,ops@company.com
+AGENTA_ORG_CREATION_ALLOWLIST=admin@company.com,ops@company.com
 ```
 
 - **Not set (default)**: any authenticated user can create orgs. Current behavior. Suitable for cloud.
@@ -42,14 +42,14 @@ There are two user-facing org creation paths:
 **1. Signup auto-creation** (`create_accounts()` in `commoners.py`)
 
 When a new user signs up, an org is auto-created for them. With the restriction:
-- `AGENTA_ORG_CREATORS` not set → auto-create org (current behavior)
+- `AGENTA_ORG_CREATION_ALLOWLIST` not set → auto-create org (current behavior)
 - Set, user in list → auto-create org
 - Set, user NOT in list → create user account but skip org creation. User must be invited.
 
 **2. Explicit org creation** (`POST /organizations/`)
 
 Any authenticated user can call this to create an org. With the restriction:
-- `AGENTA_ORG_CREATORS` not set → allow (current behavior)
+- `AGENTA_ORG_CREATION_ALLOWLIST` not set → allow (current behavior)
 - Set, user in list → allow
 - Set, user NOT in list → HTTP 403
 
@@ -58,16 +58,25 @@ Any authenticated user can call this to create an org. With the restriction:
 ### UX for users who cannot create orgs
 
 When a user signs up but is not in the creator list:
-- User account is created successfully (they can log in)
+- User account is created successfully
 - No org/workspace/project is created
-- They see a "you need an invitation" state in the UI
-- An org creator invites them via the existing invitation flow
+- The user must be invited to an existing org before they can use the app
 
-This requires a frontend change: handle the "user has no orgs" state gracefully instead of assuming every user has at least one org.
+**Important: the frontend does not currently handle the "zero orgs" state gracefully.**
+If a restricted user signs up without auto-join (`AGENTA_ALLOWED_DOMAINS`) or a
+pre-existing invitation, the UI will break — the auth middleware returns 401 for
+bootstrap endpoints because it cannot resolve a default workspace/project, and the
+frontend enters a sign-out loop.
+
+**Operators must pre-invite users before they sign up** (using the invitation flow in organization settings).
+
+A proper frontend fix (supporting "signed in, zero orgs" as a valid state) requires
+changes to the backend auth middleware to allow unscoped sessions for bootstrap
+endpoints. This was deferred as a larger architectural change.
 
 ## What does NOT change
 
-- Cloud behavior: `AGENTA_ORG_CREATORS` not set → current behavior.
+- Cloud behavior: `AGENTA_ORG_CREATION_ALLOWLIST` not set → current behavior.
 - Invitation flow: unchanged. Org owners/admins can still invite users.
 - RBAC: unchanged. Roles and permissions within orgs are not affected.
 - Billing/Stripe: this restriction is completely independent of billing.
@@ -77,7 +86,7 @@ This requires a frontend change: handle the "user has no orgs" state gracefully 
 Typical self-hosted setup:
 
 ```bash
-AGENTA_ORG_CREATORS=admin@company.com
+AGENTA_ORG_CREATION_ALLOWLIST=admin@company.com
 ```
 
 Only `admin@company.com` can create orgs. All other users sign up and wait for an invitation.

--- a/docs/design/ee-self-hosting/status.md
+++ b/docs/design/ee-self-hosting/status.md
@@ -21,10 +21,49 @@
   - Updated `AGENTS.md` with environment config conventions
 - Updated `rfc-0.md` and `plan.md` to match final implementation, including note that frontend billing-enabled detection currently uses the simple web-container env approach and may need backend-sourced config in split deployments
 
+### 2026-03-22
+- Implemented PR 2 (RFC-1): Org creation restriction — **backend only**
+  - Backend: `AGENTA_ORG_CREATION_ALLOWLIST` env var in `env.agenta.org_creation_allowlist` (set of emails, or None when unset)
+  - Backend: `OrganizationCreationNotAllowedError` exception added to `core/organizations/exceptions.py`
+  - Backend: `can_create_organization(email)` guard function in `commoners.py`
+  - Backend: Guard enforced in `create_accounts()` (silent skip on signup) and `create_organization_for_user()` (raises exception)
+  - Backend: `POST /organizations/` catches exception → HTTP 403
+  - Frontend: **not handled** — see known limitation below
+
+### Known Limitation: Frontend does not handle restricted signup gracefully
+
+When `AGENTA_ORG_CREATION_ALLOWLIST` is set and a user who is not in the allowlist
+signs up **without** auto-join (domain-based) or an existing invitation, the frontend
+breaks. The user has a valid session but zero orgs/workspaces. The auth middleware
+returns 401 for `/profile` and `/organizations` (because it requires a resolvable
+workspace/project scope), which triggers the global axios 401 handler to sign the
+user out and redirect to `/auth`. On re-login the same cycle repeats.
+
+**Root cause:** The backend auth middleware (`auth_service.py`) assumes every
+authenticated user has at least one workspace/project. When default workspace
+resolution fails (no orgs), it raises `UnauthorizedException`. The frontend then
+cannot call any bootstrap endpoint (`/profile`, `/organizations`), so it cannot
+distinguish "no orgs, needs invitation" from "actually unauthorized."
+
+**Workaround for operators:**
+- Pre-invite users before they sign up (existing invitation flow).
+  This ensures the user has an org by the time they hit the app.
+
+**What would be needed to fix properly:**
+- Backend: allow a small set of bootstrap endpoints (`/profile`, `/organizations`)
+  to work with an authenticated session that has no workspace/project scope.
+- Backend: add `can_create_organizations` boolean to `/profile` response.
+- Frontend: support "signed in, zero orgs" as a valid app state (show a message
+  instead of entering the normal app shell).
+- This is a larger architectural change to the auth middleware and was deferred.
+
 ### Remaining TODOs
 
 - [ ] Review and finalize `doc-0.md` (self-hosted EE docs)
 - [ ] Review and finalize `doc-1.md` (org creation restriction docs)
 - [ ] QA PR 1: deploy EE without Stripe, verify full flow
 - [ ] QA PR 1: deploy EE with Stripe, verify cloud regression
-- [ ] Implement PR 2 (RFC-1): Org creation restriction — backend + frontend + docs
+- [x] Implement PR 2 (RFC-1): Org creation restriction — backend only
+- [ ] QA PR 2: deploy EE with `AGENTA_ORG_CREATION_ALLOWLIST` + pre-invited user, verify restricted user joins via invite
+- [ ] QA PR 2: deploy without allowlist, verify current behavior preserved
+- [ ] Future: frontend support for "signed in, zero orgs" state (see known limitation above)

--- a/docs/docs/self-host/guides/06-restrict-organization-creation.mdx
+++ b/docs/docs/self-host/guides/06-restrict-organization-creation.mdx
@@ -1,0 +1,29 @@
+---
+title: Restrict Organization Creation
+sidebar_label: Restrict Org Creation
+description: Control which users can create organizations in your self-hosted Agenta Enterprise deployment.
+---
+
+import Admonition from "@theme/Admonition";
+
+<Admonition type="warning" title="Enterprise Feature">
+Organization creation restriction requires an Agenta Enterprise license. <a href="https://cal.com/mahmoud-mabrouk-ogzgey/demo">Book a demo</a> or <a href="mailto:team@agenta.ai">contact our team</a> to get started.
+</Admonition>
+
+Set `AGENTA_ORG_CREATION_ALLOWLIST` to a comma-separated list of emails allowed to create organizations.
+
+```bash
+AGENTA_ORG_CREATION_ALLOWLIST=admin@company.com,ops@company.com
+```
+
+When this variable is set, only the listed emails can create organizations. Everyone else must be invited to an existing one. When it is not set, any user can create organizations (the default).
+
+Restart your Agenta deployment after changing this variable.
+
+:::caution First user must be in the allowlist
+The first user to sign up needs to be in the allowlist. Otherwise, they will not be able to create the initial organization.
+:::
+
+## How restricted users join
+
+Users not in the allowlist can still sign up, but they will not have an organization. You need to either enable auto-join for a domain from **Settings > Access & Security**, or invite users from **Settings > Workspace > Members** before they sign up.


### PR DESCRIPTION
## Summary

- Add `AGENTA_ORG_CREATION_ALLOWLIST` env var to control who can create organizations in self-hosted EE deployments
- When set, only listed emails can create orgs; everyone else must be invited
- Backend-only enforcement: silent skip on signup, 403 on explicit `POST /organizations/`

## Stacked on

This PR is stacked on #4033 (`feat/self-hosted-ee`). Review that one first.

## Changes

**Backend:**
- `env.py`: parse `AGENTA_ORG_CREATION_ALLOWLIST` into `env.agenta.org_creation_allowlist`
- `exceptions.py`: add `OrganizationCreationNotAllowedError`
- `commoners.py`: add `can_create_organization()` guard, enforce in `create_accounts()` (silent skip) and `create_organization_for_user()` (raises)
- `organization_router.py`: catch exception, return 403

**Docs:**
- New self-host guide: "Restrict Organization Creation"
- Updated RFC-1, status.md, doc-1.md

## Known limitation

The frontend does not handle "signed in, zero orgs" gracefully. Operators should invite users before they sign up, or enable domain auto-join from Settings. See the docs page for details.
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/agenta-ai/agenta/pull/4044" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open with Devin">
  </picture>
</a>
<!-- devin-review-badge-end -->
