### PR TITLE
(enhancement)[AGE-3712]: Use evaluation table component in observability

### DIFF
--- a/web/ee/src/components/pages/settings/Billing/Modals/PricingModal/assets/PricingModalContent/index.tsx
+++ b/web/ee/src/components/pages/settings/Billing/Modals/PricingModal/assets/PricingModalContent/index.tsx
@@ -82,7 +82,7 @@ const PricingModalContent = ({onCancelSubscription, onCloseModal}: PricingModalC
     return (
         <section className="mx-auto flex flex-col gap-2 mt-4">
             <Typography.Text className=" font-medium">Choose your plan</Typography.Text>
-            <div className="flex flex-col md:flex-row gap-4">
+            <div className="flex flex-col md:flex-row gap-4 p-1">
                 {plans?.map((plan) => (
                     <PricingCard
                         key={plan.title}

--- a/web/oss/src/components/InfiniteVirtualTable/atoms/columnHiddenKeys.ts
+++ b/web/oss/src/components/InfiniteVirtualTable/atoms/columnHiddenKeys.ts
@@ -81,17 +81,16 @@ const hiddenKeysAtomFamily = atomFamily(
         const storageAtom = atomWithStorage<Key[]>(storageKey, defaults)
 
         return atom(
-            (get, set) => {
+            (get) => {
                 const meta = get(metaAtom)
                 if (meta.version !== version) {
-                    set(storageAtom, defaults)
-                    set(metaAtom, {version, updatedAt: Date.now()})
                     return defaults
                 }
                 return get(storageAtom)
             },
             (get, set, next: Key[] | ((prev: Key[]) => Key[])) => {
-                const current = get(storageAtom)
+                const meta = get(metaAtom)
+                const current = meta.version !== version ? defaults : get(storageAtom)
                 const resolved = typeof next === "function" ? next(current) : next
                 set(storageAtom, resolved)
                 set(metaAtom, {version, updatedAt: Date.now()})

--- a/web/oss/src/components/InfiniteVirtualTable/hooks/useInfiniteScroll.ts
+++ b/web/oss/src/components/InfiniteVirtualTable/hooks/useInfiniteScroll.ts
@@ -1,7 +1,7 @@
 import {useCallback, useEffect, useRef} from "react"
 
 interface UseInfiniteScrollOptions {
-    loadMore: () => void
+    loadMore?: () => void
     scrollThreshold?: number
 }
 
@@ -31,7 +31,7 @@ const useInfiniteScroll = ({loadMore, scrollThreshold = 300}: UseInfiniteScrollO
                 const distanceToBottom =
                     target.scrollHeight - target.scrollTop - target.clientHeight
 
-                if (distanceToBottom < scrollThreshold) {
+                if (distanceToBottom < scrollThreshold && loadMore) {
                     loadMore()
                 }
             })

--- a/web/oss/src/components/InfiniteVirtualTable/hooks/useResizableColumns.ts
+++ b/web/oss/src/components/InfiniteVirtualTable/hooks/useResizableColumns.ts
@@ -165,8 +165,42 @@ export const useResizableColumns = <RowType>({
                         width,
                         minWidth: resolvedMinWidth,
                         children: nextChildren,
-                        onHeaderCell: () =>
-                            buildHeaderCellProps(colKey, width ?? undefined, resolvedMinWidth),
+                        onHeaderCell: (col) => {
+                            const existingHeaderProps =
+                                typeof column.onHeaderCell === "function"
+                                    ? column.onHeaderCell(col)
+                                    : undefined
+                            const resizeHeaderProps = buildHeaderCellProps(
+                                colKey,
+                                width ?? undefined,
+                                resolvedMinWidth,
+                            )
+
+                            return {
+                                ...(existingHeaderProps ?? {}),
+                                ...resizeHeaderProps,
+                                style: {
+                                    ...(existingHeaderProps?.style ?? {}),
+                                    minWidth: resolvedMinWidth,
+                                },
+                            }
+                        },
+                        onCell: (record, index) => {
+                            const existingCellProps =
+                                typeof column.onCell === "function"
+                                    ? column.onCell(record, index)
+                                    : undefined
+
+                            return {
+                                ...(existingCellProps ?? {}),
+                                style: {
+                                    ...(existingCellProps?.style ?? {}),
+                                    width,
+                                    minWidth: width,
+                                    maxWidth: width,
+                                },
+                            }
+                        },
                     } as typeof colEntry
                 }
 
@@ -193,7 +227,42 @@ export const useResizableColumns = <RowType>({
                     key: colKey,
                     width,
                     minWidth: resolvedMinWidth,
-                    onHeaderCell: () => buildHeaderCellProps(colKey, width, resolvedMinWidth),
+                    onHeaderCell: (col) => {
+                        const existingHeaderProps =
+                            typeof column.onHeaderCell === "function"
+                                ? column.onHeaderCell(col)
+                                : undefined
+                        const resizeHeaderProps = buildHeaderCellProps(
+                            colKey,
+                            width,
+                            resolvedMinWidth,
+                        )
+
+                        return {
+                            ...(existingHeaderProps ?? {}),
+                            ...resizeHeaderProps,
+                            style: {
+                                ...(existingHeaderProps?.style ?? {}),
+                                minWidth: resolvedMinWidth,
+                            },
+                        }
+                    },
+                    onCell: (record, index) => {
+                        const existingCellProps =
+                            typeof column.onCell === "function"
+                                ? column.onCell(record, index)
+                                : undefined
+
+                        return {
+                            ...(existingCellProps ?? {}),
+                            style: {
+                                ...(existingCellProps?.style ?? {}),
+                                width,
+                                minWidth: width,
+                                maxWidth: width,
+                            },
+                        }
+                    },
                 } as typeof colEntry
             }),
         [buildHeaderCellProps, columnWidths, minWidth],

--- a/web/oss/src/components/InfiniteVirtualTable/hooks/useSmartResizableColumns.ts
+++ b/web/oss/src/components/InfiniteVirtualTable/hooks/useSmartResizableColumns.ts
@@ -334,7 +334,38 @@ export const useSmartResizableColumns = <RowType>({
                     key: colKey,
                     width,
                     minWidth: meta.minWidth,
-                    onHeaderCell: () => buildHeaderCellProps(colKey, width, meta.minWidth),
+                    onHeaderCell: (col) => {
+                        const existingHeaderProps =
+                            typeof column.onHeaderCell === "function"
+                                ? column.onHeaderCell(col)
+                                : undefined
+                        const resizeHeaderProps = buildHeaderCellProps(colKey, width, meta.minWidth)
+
+                        return {
+                            ...(existingHeaderProps ?? {}),
+                            ...resizeHeaderProps,
+                            style: {
+                                ...(existingHeaderProps?.style ?? {}),
+                                minWidth: meta.minWidth,
+                            },
+                        }
+                    },
+                    onCell: (record, index) => {
+                        const existingCellProps =
+                            typeof column.onCell === "function"
+                                ? column.onCell(record, index)
+                                : undefined
+
+                        return {
+                            ...(existingCellProps ?? {}),
+                            style: {
+                                ...(existingCellProps?.style ?? {}),
+                                width,
+                                minWidth: width,
+                                maxWidth: width,
+                            },
+                        }
+                    },
                 } as typeof colEntry
             }),
         [buildHeaderCellProps],

--- a/web/oss/src/components/InfiniteVirtualTable/types.ts
+++ b/web/oss/src/components/InfiniteVirtualTable/types.ts
@@ -266,7 +266,7 @@ export interface ExpandableRowConfig<RecordType, ChildType = unknown> {
 export interface InfiniteVirtualTableProps<RecordType, ExpandedChildType = unknown> {
     columns: ColumnsType<RecordType>
     dataSource: RecordType[]
-    loadMore: () => void
+    loadMore?: () => void
     rowKey: TableProps<RecordType>["rowKey"]
     active?: boolean
     scrollThreshold?: number

--- a/web/oss/src/components/pages/observability/assets/getObservabilityColumns.tsx
+++ b/web/oss/src/components/pages/observability/assets/getObservabilityColumns.tsx
@@ -1,8 +1,15 @@
 import {SmartCellContent} from "@agenta/ui/cell-renderers"
 import {CopyTooltip as TooltipWithCopyAction} from "@agenta/ui/copy-tooltip"
 import {Tag} from "antd"
-import {ColumnsType} from "antd/es/table"
 
+import {
+    ColumnVisibilityMenuTrigger,
+    createActionsCell,
+    createComponentCell,
+    createTableColumns,
+    type InfiniteTableRowBase,
+    type TableColumnConfig,
+} from "@/oss/components/InfiniteVirtualTable"
 import {sanitizeDataWithBlobUrls} from "@/oss/lib/helpers/utils"
 import {TraceSpanNode} from "@/oss/services/tracing/types"
 import {
@@ -18,185 +25,234 @@ import CostCell from "../components/CostCell"
 import DurationCell from "../components/DurationCell"
 import EvaluatorMetricsCell from "../components/EvaluatorMetricsCell"
 import NodeNameCell from "../components/NodeNameCell"
+import ActionsCell from "../components/ObservabilityTable/components/ActionsCell"
 import StatusRenderer from "../components/StatusRenderer"
 import TimestampCell from "../components/TimestampCell"
 import UsageCell from "../components/UsageCell"
 
-interface ObservabilityColumnsProps {
-    evaluatorSlugs: string[]
+export interface ObservabilityTraceRow extends TraceSpanNode, InfiniteTableRowBase {
+    key: string
+    __isSkeleton: false
 }
 
-export const getObservabilityColumns = ({evaluatorSlugs}: ObservabilityColumnsProps) => {
-    const columns: ColumnsType<TraceSpanNode> = [
+interface ObservabilityColumnsProps {
+    evaluatorSlugs: string[]
+    onOpenTrace: (record: ObservabilityTraceRow) => void
+    onDeleteTrace: (record: ObservabilityTraceRow) => void
+    onAddToTestset: (record: ObservabilityTraceRow) => void
+}
+
+export const getObservabilityColumns = ({
+    evaluatorSlugs,
+    onOpenTrace,
+    onDeleteTrace,
+    onAddToTestset,
+}: ObservabilityColumnsProps) => {
+    const evaluatorColumns =
+        evaluatorSlugs.length <= 1
+            ? [
+                  {
+                      title: "Evaluators",
+                      key: "evaluators",
+                      width: 260,
+                      minWidth: 240,
+                      cell: createComponentCell<ObservabilityTraceRow>({
+                          render: (record) =>
+                              evaluatorSlugs[0] ? (
+                                  <EvaluatorMetricsCell
+                                      invocationKey={`${record.invocationIds?.trace_id || ""}:${record.invocationIds?.span_id || ""}`}
+                                      evaluatorSlug={evaluatorSlugs[0]}
+                                  />
+                              ) : (
+                                  <span className="text-gray-500">-</span>
+                              ),
+                      }),
+                  } satisfies TableColumnConfig<ObservabilityTraceRow>,
+              ]
+            : [
+                  {
+                      title: "Evaluators",
+                      key: "evaluators",
+                      visibilityLabel: "Evaluators",
+                      children: evaluatorSlugs.map((evaluatorSlug) => ({
+                          title: evaluatorSlug,
+                          key: evaluatorSlug,
+                          width: 260,
+                          minWidth: 240,
+                          visibilityLabel: evaluatorSlug,
+                          cell: createComponentCell<ObservabilityTraceRow>({
+                              render: (record) => (
+                                  <EvaluatorMetricsCell
+                                      invocationKey={`${record.invocationIds?.trace_id || ""}:${record.invocationIds?.span_id || ""}`}
+                                      evaluatorSlug={evaluatorSlug}
+                                  />
+                              ),
+                          }),
+                      })),
+                  } satisfies TableColumnConfig<ObservabilityTraceRow>,
+              ]
+
+    const columns: TableColumnConfig<ObservabilityTraceRow>[] = [
         {
             title: "ID",
-            dataIndex: ["span_id"],
             key: "key",
             width: 200,
-            onHeaderCell: () => ({
-                style: {minWidth: 200},
-            }),
+            minWidth: 200,
             defaultHidden: true,
-            fixed: "left",
-            render: (_, record) => {
-                const spanId = record.span_id || ""
-                const shortId = spanId ? spanId.split("-")[0] : "-"
-                return (
-                    <TooltipWithCopyAction copyText={spanId || ""} title="Copy span id">
-                        <Tag className="font-mono bg-[#0517290F]" bordered={false}>
-                            # {shortId}
-                        </Tag>
-                    </TooltipWithCopyAction>
-                )
-            },
+            cell: createComponentCell<ObservabilityTraceRow>({
+                render: (record) => {
+                    const spanId = record.span_id || ""
+                    const shortId = spanId ? spanId.split("-")[0] : "-"
+
+                    return (
+                        <TooltipWithCopyAction copyText={spanId} title="Copy span id">
+                            <Tag className="font-mono bg-[#0517290F]" bordered={false}>
+                                # {shortId}
+                            </Tag>
+                        </TooltipWithCopyAction>
+                    )
+                },
+            }),
         },
         {
             title: "Name",
-            dataIndex: ["span_name"],
             key: "name",
-            ellipsis: true,
             width: 200,
-            onHeaderCell: () => ({
-                style: {minWidth: 200},
-            }),
-            onCell: () => ({
-                style: {verticalAlign: "middle"},
-            }),
+            minWidth: 200,
+            ellipsis: true,
             fixed: "left",
-            render: (_, record) => <NodeNameCell name={record.span_name} type={record.span_type} />,
+            cell: createComponentCell<ObservabilityTraceRow>({
+                render: (record) => (
+                    <NodeNameCell name={record.span_name ?? ""} type={record.span_type} />
+                ),
+            }),
         },
         {
             title: "Span type",
             key: "span_type",
-            dataIndex: ["span_type"],
-            defaultHidden: true,
             width: 200,
-            onHeaderCell: () => ({
-                style: {minWidth: 200},
+            minWidth: 200,
+            defaultHidden: true,
+            cell: createComponentCell<ObservabilityTraceRow>({
+                render: (record) => <div>{record.span_type ?? "-"}</div>,
             }),
-            render: (_, record) => {
-                return <div>{record.span_type}</div>
-            },
         },
         {
             title: "Inputs",
             key: "inputs",
             width: 400,
+            minWidth: 320,
             className: "overflow-hidden text-ellipsis whitespace-nowrap max-w-[400px]",
-            render: (_, record) => {
-                const inputs = getTraceInputs(record)
-                const {data: sanitizedInputs} = sanitizeDataWithBlobUrls(inputs)
-                return (
-                    <LastInputMessageCell
-                        value={sanitizedInputs}
-                        keyPrefix={`trace-input-${record.span_id}`}
-                        className="h-[112px] overflow-hidden"
-                    />
-                )
-            },
+            cell: createComponentCell<ObservabilityTraceRow>({
+                render: (record) => {
+                    const inputs = getTraceInputs(record)
+                    const {data: sanitizedInputs} = sanitizeDataWithBlobUrls(inputs)
+
+                    return (
+                        <LastInputMessageCell
+                            value={sanitizedInputs}
+                            keyPrefix={`trace-input-${record.span_id}`}
+                            className="h-[112px] overflow-hidden"
+                        />
+                    )
+                },
+            }),
         },
         {
             title: "Outputs",
             key: "outputs",
             width: 400,
+            minWidth: 320,
             className: "overflow-hidden text-ellipsis whitespace-nowrap max-w-[400px]",
-            render: (_, record) => {
-                const outputs = getTraceOutputs(record)
-                const {data: sanitizedOutputs} = sanitizeDataWithBlobUrls(outputs)
-                return (
-                    <SmartCellContent
-                        value={sanitizedOutputs}
-                        keyPrefix={`trace-output-${record.span_id}`}
-                        maxLines={4}
-                        chatPreference="output"
-                        className="h-[112px] overflow-hidden"
-                    />
-                )
-            },
+            cell: createComponentCell<ObservabilityTraceRow>({
+                render: (record) => {
+                    const outputs = getTraceOutputs(record)
+                    const {data: sanitizedOutputs} = sanitizeDataWithBlobUrls(outputs)
+
+                    return (
+                        <SmartCellContent
+                            value={sanitizedOutputs}
+                            keyPrefix={`trace-output-${record.span_id}`}
+                            maxLines={4}
+                            chatPreference="output"
+                            className="h-[112px] overflow-hidden"
+                        />
+                    )
+                },
+            }),
         },
-        {
-            title: "Evaluators",
-            key: "evaluators",
-            align: "start",
-            children: evaluatorSlugs.map((evaluatorSlug) => ({
-                title: "",
-                key: evaluatorSlug,
-                onHeaderCell: () => ({
-                    style: {display: "none"},
-                }),
-                render: (_, record) => (
-                    <EvaluatorMetricsCell
-                        invocationKey={`${record.invocationIds?.trace_id || ""}:${record.invocationIds?.span_id || ""}`}
-                        evaluatorSlug={evaluatorSlug}
-                    />
-                ),
-            })),
-        },
+        ...evaluatorColumns,
         {
             title: "Duration",
             key: "duration",
-            dataIndex: ["time", "span"],
             width: 90,
-            onHeaderCell: () => ({
-                style: {minWidth: 90},
+            minWidth: 90,
+            cell: createComponentCell<ObservabilityTraceRow>({
+                render: (record) => <DurationCell ms={getLatency(record)} />,
             }),
-            render: (_, record) => {
-                const duration = getLatency(record)
-                return <DurationCell ms={duration} />
-            },
         },
         {
             title: "Cost",
             key: "cost",
-            dataIndex: ["attributes", "ag", "metrics", "costs", "cumulative", "total"],
             width: 90,
-            onHeaderCell: () => ({
-                style: {minWidth: 90},
+            minWidth: 90,
+            cell: createComponentCell<ObservabilityTraceRow>({
+                render: (record) => <CostCell cost={getCost(record)} />,
             }),
-            render: (_, record) => {
-                const cost = getCost(record)
-                return <CostCell cost={cost} />
-            },
         },
         {
             title: "Usage",
             key: "usage",
-            dataIndex: ["attributes", "ag", "metrics", "tokens", "cumulative", "total"],
             width: 90,
-            onHeaderCell: () => ({
-                style: {minWidth: 90},
+            minWidth: 90,
+            cell: createComponentCell<ObservabilityTraceRow>({
+                render: (record) => <UsageCell tokens={getTokens(record)} />,
             }),
-            render: (_, record) => {
-                const tokens = getTokens(record)
-                return <UsageCell tokens={tokens} />
-            },
         },
         {
             title: "Timestamp",
             key: "timestamp",
-            dataIndex: ["created_at"],
             width: 200,
-            onHeaderCell: () => ({
-                style: {minWidth: 200},
+            minWidth: 200,
+            cell: createComponentCell<ObservabilityTraceRow>({
+                render: (record) => <TimestampCell timestamp={record.created_at} />,
             }),
-            render: (_, record) => <TimestampCell timestamp={record?.created_at} />,
         },
         {
             title: "Status",
             key: "status",
-            dataIndex: ["status_code"],
             width: 160,
-            onHeaderCell: () => ({
-                style: {minWidth: 160},
+            minWidth: 160,
+            cell: createComponentCell<ObservabilityTraceRow>({
+                render: (record) =>
+                    StatusRenderer({
+                        status: record.status_code,
+                        message: record.status_message,
+                        showMore: true,
+                    }),
             }),
-            render: (_, record) =>
-                StatusRenderer({
-                    status: record.status_code,
-                    message: record.status_message,
-                    showMore: true,
-                }),
+        },
+        {
+            title: <ColumnVisibilityMenuTrigger variant="icon" />,
+            key: "actions",
+            width: 61,
+            minWidth: 56,
+            fixed: "right",
+            align: "center",
+            visibilityLocked: true,
+            exportEnabled: false,
+            cell: createActionsCell<ObservabilityTraceRow>({
+                render: (record) => (
+                    <ActionsCell
+                        record={record}
+                        onOpenTrace={onOpenTrace}
+                        onAddToTestset={onAddToTestset}
+                        onDeleteTrace={onDeleteTrace}
+                    />
+                ),
+            }),
         },
     ]
 
-    return columns
+    return createTableColumns<ObservabilityTraceRow>(columns)
 }

--- a/web/oss/src/components/pages/observability/components/ObservabilityHeader/index.tsx
+++ b/web/oss/src/components/pages/observability/components/ObservabilityHeader/index.tsx
@@ -29,7 +29,6 @@ import getFilterColumns from "../../assets/getFilterColumns"
 import {ObservabilityHeaderProps} from "../../assets/types"
 import {AUTO_REFRESH_INTERVAL} from "../../constants"
 
-const EditColumns = dynamic(() => import("@/oss/components/Filters/EditColumns"), {ssr: false})
 const Filters = dynamic(() => import("@/oss/components/Filters/Filters"), {ssr: false})
 const Sort = dynamic(() => import("@/oss/components/Filters/Sort"), {ssr: false})
 
@@ -94,6 +93,18 @@ const AutoRefreshControl: React.FC<{
     )
 }
 
+const resolveTraceId = (trace: any) =>
+    String(
+        trace?.trace_id ||
+            trace?.invocationIds?.trace_id ||
+            trace?.node?.trace_id ||
+            trace?.root?.id ||
+            trace?.traceId ||
+            trace?.trace?.id ||
+            trace?.span_id ||
+            "",
+    )
+
 const ObservabilityHeader = ({
     columns,
     componentType,
@@ -125,7 +136,6 @@ const ObservabilityHeader = ({
         selectedRowKeys,
         setSelectedRowKeys,
         setTestsetDrawerData,
-        setEditColumns,
         fetchAnnotations,
         fetchTraces,
         autoRefresh: hookAutoRefresh,
@@ -266,7 +276,11 @@ const ObservabilityHeader = ({
 
         const extractData = selectedRowKeys.map((key, idx) => {
             const node = getNodeById(traces, key as string)
-            return {data: getAgData(node) as KeyValuePair, key: node?.key, id: idx + 1}
+            return {
+                data: getAgData(node) as KeyValuePair,
+                key: node?.span_id ?? node?.key,
+                id: idx + 1,
+            }
         })
 
         if (extractData.length > 0) {
@@ -390,7 +404,8 @@ const ObservabilityHeader = ({
                 new Set(
                     traces
                         .filter((trace) => selectedRowKeys.includes(trace.span_id))
-                        .map((trace) => trace.trace_id),
+                        .map(resolveTraceId)
+                        .filter(Boolean),
                 ),
             ),
             onClose: () => {
@@ -399,6 +414,36 @@ const ObservabilityHeader = ({
             },
         })
     }, [traces, selectedRowKeys, setDeleteModalState, setSelectedRowKeys, handleRefresh])
+
+    const traceSecondaryActions =
+        componentType === "traces" ? (
+            <Space size="small">
+                <EnhancedButton
+                    type="text"
+                    aria-label={isExporting ? "Cancel export" : "Export traces"}
+                    icon={<ExportIcon size={14} className="mt-0.5" />}
+                    onClick={() => {
+                        if (isExporting) {
+                            exportAbortRef.current?.abort()
+                            return
+                        }
+
+                        onExport()
+                    }}
+                    disabled={!isExporting && traces.length === 0}
+                    tooltipProps={{title: isExporting ? "Cancel export" : "Export"}}
+                />
+                <EnhancedButton
+                    type="text"
+                    danger
+                    aria-label="Delete selected traces"
+                    icon={<TrashIcon size={14} />}
+                    onClick={onDelete}
+                    disabled={selectedRowKeys.length === 0}
+                    tooltipProps={{title: "Delete selected"}}
+                />
+            </Space>
+        ) : null
 
     return (
         <>
@@ -499,6 +544,7 @@ const ObservabilityHeader = ({
                             />
                         )}
                     </div>
+                    {isScrolled ? traceSecondaryActions : null}
                 </div>
                 {!isScrolled && componentType === "traces" ? (
                     <div className="w-full flex items-center justify-between">
@@ -510,37 +556,7 @@ const ObservabilityHeader = ({
                             </Radio.Group>
                         </Space>
                         <Space>
-                            <Button
-                                type="text"
-                                onClick={() => {
-                                    if (isExporting) {
-                                        exportAbortRef.current?.abort()
-                                        return
-                                    }
-
-                                    onExport()
-                                }}
-                                icon={<ExportIcon size={14} className="mt-0.5" />}
-                                disabled={!isExporting && traces.length === 0}
-                            >
-                                {isExporting ? "Cancel export" : "Export"}
-                            </Button>
-
-                            <EditColumns
-                                columns={columns}
-                                uniqueKey="observability-table-columns"
-                                onChange={(keys) => {
-                                    setEditColumns(keys)
-                                }}
-                            />
-                            <Button
-                                onClick={onDelete}
-                                icon={<TrashIcon size={14} />}
-                                disabled={selectedRowKeys.length === 0}
-                                danger
-                            >
-                                Delete
-                            </Button>
+                            {traceSecondaryActions}
                             <Button
                                 onClick={() => getTestsetTraceData()}
                                 icon={<DatabaseIcon size={14} />}

--- a/web/oss/src/components/pages/observability/components/ObservabilityTable/components/ActionsCell.tsx
+++ b/web/oss/src/components/pages/observability/components/ObservabilityTable/components/ActionsCell.tsx
@@ -1,0 +1,76 @@
+import {memo, useMemo} from "react"
+
+import {MoreOutlined} from "@ant-design/icons"
+import {ArrowSquareOut, DatabaseIcon, TrashIcon} from "@phosphor-icons/react"
+import {Button, Dropdown, type MenuProps, Tooltip} from "antd"
+
+import type {ObservabilityTraceRow} from "@/oss/components/pages/observability/assets/getObservabilityColumns"
+
+const CELL_CLASS =
+    "flex h-full w-full min-w-0 items-center justify-center px-2 [&_.ant-btn]:h-8 [&_.ant-btn]:w-8"
+
+interface ObservabilityActionsCellProps {
+    record: ObservabilityTraceRow
+    onOpenTrace: (record: ObservabilityTraceRow) => void
+    onAddToTestset: (record: ObservabilityTraceRow) => void
+    onDeleteTrace: (record: ObservabilityTraceRow) => void
+}
+
+const ObservabilityActionsCell = ({
+    record,
+    onOpenTrace,
+    onAddToTestset,
+    onDeleteTrace,
+}: ObservabilityActionsCellProps) => {
+    const items = useMemo<MenuProps["items"]>(
+        () => [
+            {
+                key: "open-trace",
+                label: "Open trace",
+                icon: <ArrowSquareOut size={16} />,
+                onClick: (event) => {
+                    event.domEvent.stopPropagation()
+                    onOpenTrace(record)
+                },
+            },
+            {
+                key: "add-to-testset",
+                label: "Add to testset",
+                icon: <DatabaseIcon size={16} />,
+                onClick: (event) => {
+                    event.domEvent.stopPropagation()
+                    onAddToTestset(record)
+                },
+            },
+            {type: "divider"},
+            {
+                key: "delete-trace",
+                label: "Delete trace",
+                icon: <TrashIcon size={16} />,
+                danger: true,
+                onClick: (event) => {
+                    event.domEvent.stopPropagation()
+                    onDeleteTrace(record)
+                },
+            },
+        ],
+        [onAddToTestset, onDeleteTrace, onOpenTrace, record],
+    )
+
+    return (
+        <div className={CELL_CLASS}>
+            <Dropdown trigger={["click"]} menu={{items}} styles={{root: {width: 200}}}>
+                <Tooltip title="Actions">
+                    <Button
+                        type="text"
+                        shape="circle"
+                        icon={<MoreOutlined />}
+                        onClick={(event) => event.stopPropagation()}
+                    />
+                </Tooltip>
+            </Dropdown>
+        </div>
+    )
+}
+
+export default memo(ObservabilityActionsCell)

--- a/web/oss/src/components/pages/observability/components/ObservabilityTable/index.tsx
+++ b/web/oss/src/components/pages/observability/components/ObservabilityTable/index.tsx
@@ -355,6 +355,7 @@ const ObservabilityTable = () => {
                     <InfiniteVirtualTable<ObservabilityTraceRow>
                         columns={columns}
                         dataSource={traceRows}
+                        loadMore={handleLoadMore}
                         rowKey={(record) => record.key}
                         rowSelection={rowSelection}
                         resizableColumns

--- a/web/oss/src/components/pages/observability/components/ObservabilityTable/index.tsx
+++ b/web/oss/src/components/pages/observability/components/ObservabilityTable/index.tsx
@@ -1,21 +1,35 @@
-import {useCallback, useEffect, useMemo, useState} from "react"
+import {type Key, useCallback, useEffect, useMemo, useState} from "react"
 
-import {Button, Table, TableColumnType} from "antd"
-import {ColumnsType} from "antd/es/table"
+import {Button, type TableProps} from "antd"
 import {useAtomValue, useSetAtom} from "jotai"
 import dynamic from "next/dynamic"
 
-import {filterColumns} from "@/oss/components/Filters/EditColumns/assets/helper"
-import ResizableTitle from "@/oss/components/ResizableTitle"
+import {
+    InfiniteVirtualTable,
+    shouldIgnoreRowClick,
+    type ColumnVisibilityState,
+} from "@/oss/components/InfiniteVirtualTable"
+import {deleteTraceModalAtom} from "@/oss/components/SharedDrawers/TraceDrawer/components/DeleteTraceModal/store/atom"
 import {setTraceDrawerActiveSpanAtom} from "@/oss/components/SharedDrawers/TraceDrawer/store/traceDrawerStore"
 import {isNewUserAtom} from "@/oss/lib/onboarding"
 import {onboardingStorageUserIdAtom} from "@/oss/lib/onboarding/atoms"
+import {type KeyValuePair} from "@/oss/lib/Types"
 import {TraceSpanNode} from "@/oss/services/tracing/types"
 import {useQueryParamState} from "@/oss/state/appState"
-import {annotationEvaluatorSlugsAtom, useObservability} from "@/oss/state/newObservability"
-import {hasReceivedTracesAtom} from "@/oss/state/newObservability/atoms/controls"
+import {
+    annotationEvaluatorSlugsAtom,
+    getAgData,
+    useObservability,
+} from "@/oss/state/newObservability"
+import {
+    DEFAULT_OBSERVABILITY_HIDDEN_COLUMNS,
+    hasReceivedTracesAtom,
+} from "@/oss/state/newObservability/atoms/controls"
 
-import {getObservabilityColumns} from "../../assets/getObservabilityColumns"
+import {
+    getObservabilityColumns,
+    type ObservabilityTraceRow,
+} from "../../assets/getObservabilityColumns"
 import {AUTO_REFRESH_INTERVAL} from "../../constants"
 
 const ObservabilityHeader = dynamic(() => import("../ObservabilityHeader"), {ssr: false})
@@ -54,15 +68,27 @@ const collectEvaluatorSlugsFromTraces = (traces: TraceSpanNode[]) => {
     return Array.from(slugs)
 }
 
+const resolveTraceId = (record: TraceSpanNode) =>
+    String(
+        record.trace_id ||
+            (record as any)?.invocationIds?.trace_id ||
+            (record as any)?.node?.trace_id ||
+            (record as any)?.root?.id ||
+            (record as any)?.traceId ||
+            (record as any)?.trace?.id ||
+            record.span_id ||
+            "",
+    )
+
 const ObservabilityTable = () => {
     const {
         traces,
         isLoading,
-        traceTabs,
         fetchTraces,
         selectedTraceId,
         setSelectedTraceId,
         editColumns,
+        setEditColumns,
         selectedRowKeys,
         setSelectedRowKeys,
         testsetDrawerData,
@@ -77,6 +103,7 @@ const ObservabilityTable = () => {
         fetchAnnotations,
     } = useObservability()
     const setTraceDrawerActiveSpan = useSetAtom(setTraceDrawerActiveSpanAtom)
+    const setDeleteModalState = useSetAtom(deleteTraceModalAtom)
     const isNewUser = useAtomValue(isNewUserAtom)
     const onboardingStorageUserId = useAtomValue(onboardingStorageUserIdAtom)
     const hasReceivedTraces = useAtomValue(hasReceivedTracesAtom)
@@ -112,16 +139,6 @@ const ObservabilityTable = () => {
         return [...ordered, ...remaining]
     }, [annotationEvaluatorSlugs, traceEvaluatorSlugs])
 
-    const initialColumns = useMemo(
-        () => getObservabilityColumns({evaluatorSlugs}),
-        [evaluatorSlugs],
-    )
-    const [columns, setColumns] = useState<ColumnsType<TraceSpanNode>>(initialColumns)
-
-    useEffect(() => {
-        setColumns(initialColumns)
-    }, [initialColumns])
-
     useEffect(() => {
         if (traceParam && traceParam !== selectedTraceId) {
             setSelectedTraceId(traceParam)
@@ -149,11 +166,10 @@ const ObservabilityTable = () => {
         if (!selectedNode) {
             setSelectedNode(activeTrace?.span_id || "")
         }
-    }, [activeTrace, selectedNode])
+    }, [activeTrace, selectedNode, setSelectedNode])
 
     const [refreshTrigger, setRefreshTrigger] = useState(0)
 
-    // Auto-refresh logic: refresh every 15 seconds when enabled
     const handleRefresh = useCallback(async () => {
         await Promise.all([fetchAnnotations(), fetchTraces()])
         setRefreshTrigger((prev) => prev + 1)
@@ -175,16 +191,6 @@ const ObservabilityTable = () => {
         fetchMoreTraces().catch((error) => console.error("Failed to fetch more traces", error))
     }, [fetchMoreTraces, hasMoreTraces, isFetchingMore])
 
-    const rowSelection = {
-        onChange: (keys: React.Key[]) => {
-            setSelectedRowKeys(keys)
-        },
-        columnWidth: 48,
-        getCheckboxProps: (record: TraceSpanNode) => ({
-            "data-tour": record.span_id === traces[0]?.span_id ? "trace-checkbox" : undefined,
-        }),
-    }
-
     const showTableLoading = isLoading && traces.length === 0
     const isEmptyState = traces.length === 0 && !isLoading
     const showOnboarding = isNewUser && !hasReceivedTraces
@@ -195,27 +201,143 @@ const ObservabilityTable = () => {
         }
     }, [onboardingStorageUserId, traces.length, hasReceivedTraces, setHasReceivedTraces])
 
-    const handleResize =
-        (key: string) =>
-        (_: any, {size}: {size: {width: number}}) => {
-            setColumns((cols) => {
-                return cols.map((col) => ({
-                    ...col,
-                    width: col.key === key ? size.width : col.width,
+    const buildTestsetTraceData = useCallback(
+        (nodes: TraceSpanNode[]) =>
+            nodes
+                .map((node, idx) => ({
+                    data: getAgData(node) as KeyValuePair,
+                    key: node.span_id ?? "",
+                    id: idx + 1,
                 }))
-            })
-        }
+                .filter((item) => item.key),
+        [],
+    )
 
-    const mergedColumns = useMemo(() => {
-        return filterColumns(columns, editColumns).map((col) => ({
-            ...col,
-            width: col.width || 200,
-            onHeaderCell: (column: TableColumnType<TraceSpanNode[]>) => ({
-                width: column.width,
-                onResize: handleResize(column.key?.toString()!),
+    const handleAddTraceToTestset = useCallback(
+        (record: ObservabilityTraceRow) => {
+            const data = buildTestsetTraceData([record])
+            if (data.length > 0) {
+                setTestsetDrawerData(data)
+            }
+        },
+        [buildTestsetTraceData, setTestsetDrawerData],
+    )
+
+    const openTraceRecord = useCallback(
+        (record: TraceSpanNode) => {
+            setSelectedNode(record.span_id ?? "")
+
+            const targetTraceId = resolveTraceId(record)
+            const targetSpanId = String(record.span_id || "")
+
+            if (!targetTraceId) {
+                console.warn("TraceDrawer: unable to determine trace id for record", record)
+                return
+            }
+
+            setSelectedTraceId(targetTraceId)
+            setTraceDrawerActiveSpan(targetSpanId || null)
+            setTraceParam(targetTraceId)
+            if (targetSpanId) {
+                setSpanParam(targetSpanId)
+            } else {
+                setSpanParam(undefined)
+            }
+        },
+        [
+            setSelectedNode,
+            setSelectedTraceId,
+            setSpanParam,
+            setTraceDrawerActiveSpan,
+            setTraceParam,
+        ],
+    )
+
+    const handleDeleteTrace = useCallback(
+        (record: ObservabilityTraceRow) => {
+            const traceId = resolveTraceId(record)
+            if (!traceId) return
+
+            setDeleteModalState({
+                isOpen: true,
+                traceIds: [traceId],
+                onClose: () => {
+                    setSelectedRowKeys([])
+                    handleRefresh()
+                },
+            })
+        },
+        [handleRefresh, setDeleteModalState, setSelectedRowKeys],
+    )
+
+    const traceRows = useMemo<ObservabilityTraceRow[]>(
+        () =>
+            traces.map((trace, index) => ({
+                ...trace,
+                key: String(trace.span_id || trace.key || trace.trace_id || `trace-${index}`),
+                __isSkeleton: false,
+            })),
+        [traces],
+    )
+
+    const columns = useMemo(
+        () =>
+            getObservabilityColumns({
+                evaluatorSlugs,
+                onOpenTrace: openTraceRecord,
+                onDeleteTrace: handleDeleteTrace,
+                onAddToTestset: handleAddTraceToTestset,
             }),
-        }))
-    }, [columns, editColumns])
+        [evaluatorSlugs, handleAddTraceToTestset, handleDeleteTrace, openTraceRecord],
+    )
+
+    const handleColumnVisibilityStateChange = useCallback(
+        (state: ColumnVisibilityState<ObservabilityTraceRow>) => {
+            const nextHiddenKeys = state.hiddenKeys
+                .map((key) => String(key))
+                .filter((key) => key !== "actions")
+            if (nextHiddenKeys.join("|") === editColumns.join("|")) return
+            setEditColumns(nextHiddenKeys)
+        },
+        [editColumns, setEditColumns],
+    )
+
+    const rowSelection = useMemo(
+        () => ({
+            type: "checkbox" as const,
+            selectedRowKeys,
+            onChange: (keys: Key[]) => {
+                setSelectedRowKeys(keys)
+            },
+            columnWidth: 48,
+            getCheckboxProps: (record: ObservabilityTraceRow) => ({
+                "data-tour":
+                    record.span_id === traceRows[0]?.span_id ? "trace-checkbox" : undefined,
+            }),
+        }),
+        [selectedRowKeys, setSelectedRowKeys, traceRows],
+    )
+
+    const tableProps = useMemo<TableProps<ObservabilityTraceRow>>(
+        () => ({
+            loading: showTableLoading,
+            bordered: true,
+            sticky: {
+                offsetHeader: 0,
+                offsetScroll: 0,
+            },
+            tableLayout: "fixed",
+            onRow: (record, index) => ({
+                onClick: (event) => {
+                    if (shouldIgnoreRowClick(event)) return
+                    openTraceRecord(record)
+                },
+                style: {cursor: "pointer"},
+                "data-tour": index === 0 ? "trace-row" : undefined,
+            }),
+        }),
+        [openTraceRecord, showTableLoading],
+    )
 
     return (
         <div className="flex flex-col gap-6">
@@ -230,71 +352,23 @@ const ObservabilityTable = () => {
                 <EmptyObservability showOnboarding={showOnboarding} />
             ) : (
                 <div className="flex flex-col gap-2">
-                    <Table
-                        className="[&_.ant-table-tbody_.ant-table-cell]:align-top"
-                        rowSelection={{
-                            type: "checkbox",
-                            columnWidth: 48,
-                            selectedRowKeys,
-                            ...rowSelection,
+                    <InfiniteVirtualTable<ObservabilityTraceRow>
+                        columns={columns}
+                        dataSource={traceRows}
+                        rowKey={(record) => record.key}
+                        rowSelection={rowSelection}
+                        resizableColumns
+                        scopeId="observability-traces-table"
+                        tableClassName="[&_.ant-table-tbody_.ant-table-cell]:align-top"
+                        tableProps={tableProps}
+                        columnVisibility={{
+                            storageKey: "observability-table-columns",
+                            defaultHiddenKeys: [...DEFAULT_OBSERVABILITY_HIDDEN_COLUMNS],
+                            onStateChange: handleColumnVisibilityStateChange,
                         }}
-                        loading={showTableLoading}
-                        columns={mergedColumns as TableColumnType<TraceSpanNode>[]}
-                        dataSource={traces}
-                        bordered
-                        style={{cursor: "pointer"}}
-                        sticky={{
-                            offsetHeader: 0,
-                            offsetScroll: 0,
-                        }}
-                        onRow={(record, index) => ({
-                            onClick: () => {
-                                setSelectedNode(record.span_id)
-                                const isSpanView = traceTabs === "span"
-
-                                const targetTraceId = String(
-                                    record.trace_id ||
-                                        (record as any)?.invocationIds?.trace_id ||
-                                        (record as any)?.node?.trace_id ||
-                                        (record as any)?.root?.id ||
-                                        (record as any)?.traceId ||
-                                        (record as any)?.trace?.id ||
-                                        record.span_id ||
-                                        "",
-                                )
-
-                                const targetSpanId = isSpanView
-                                    ? String(record.span_id || "")
-                                    : String(record.span_id || "")
-
-                                if (!targetTraceId) {
-                                    console.warn(
-                                        "TraceDrawer: unable to determine trace id for record",
-                                        record,
-                                    )
-                                    return
-                                }
-
-                                setSelectedTraceId(targetTraceId)
-                                setTraceDrawerActiveSpan(targetSpanId || null)
-                                setTraceParam(targetTraceId)
-                                if (targetSpanId) {
-                                    setSpanParam(targetSpanId)
-                                } else {
-                                    setSpanParam(undefined)
-                                }
-                            },
-                            "data-tour": index === 0 ? "trace-row" : undefined,
-                        })}
-                        components={{
-                            header: {
-                                cell: ResizableTitle,
-                            },
-                        }}
-                        pagination={false}
-                        scroll={{x: "max-content"}}
                     />
-                    {hasMoreTraces && (
+
+                    {hasMoreTraces ? (
                         <Button
                             onClick={handleLoadMore}
                             disabled={isFetchingMore}
@@ -303,7 +377,7 @@ const ObservabilityTable = () => {
                         >
                             {isFetchingMore ? "Loading…" : "Click here to load more"}
                         </Button>
-                    )}
+                    ) : null}
                 </div>
             )}
 

--- a/web/oss/src/state/newObservability/atoms/controls.ts
+++ b/web/oss/src/state/newObservability/atoms/controls.ts
@@ -182,8 +182,9 @@ export const filtersAtom = atom(
 // Table/UI controls -----------------------------------------------------------
 export const selectedTraceIdAtom = atom<string>("")
 export const selectedNodeAtom = atom<string>("")
+export const DEFAULT_OBSERVABILITY_HIDDEN_COLUMNS = ["span_type", "key", "tag"] as const
 export const editColumnsAtomFamily = atomFamily((_tab: ObservabilityTabInfo) =>
-    atom<string[]>(["span_type", "key", "usage", "tag"]),
+    atom<string[]>([...DEFAULT_OBSERVABILITY_HIDDEN_COLUMNS]),
 )
 export const editColumnsAtom = atom(
     (get) => get(editColumnsAtomFamily(get(observabilityTabAtom))),


### PR DESCRIPTION
## Summary
<!-- What changed? -->
<!-- Why was this change needed? -->
<!-- What problem does it solve? -->
<!-- For fixes, explain how the change addresses the root cause. -->

## Testing
### Verified locally
<!-- What did you run or verify locally? Be specific. -->

### Added or updated tests
<!-- What tests did you add or update? Include unit, integration, and end-to-end coverage when relevant. Write N/A if none. -->

### QA follow-up
<!-- What still needs QA? List flows, browsers, environments, edge cases, or data conditions to validate. Write N/A if none. -->

## Demo
<!-- Required for UI changes. Add screenshots, GIFs, or a sh
<img width="1043" height="750" alt="Screenshot 2026-03-24 at 1 47 49 PM" src="https://github.com/user-attachments/assets/48a1cb59-703b-4d11-8245-89a7e8bfd884" />
ort video. -->
<!-- If this is not a UI change, write N/A. -->


## Checklist
- [ ] I have included a video or screen recording for UI changes, or marked Demo as N/A
- [ ] Relevant tests pass locally
- [ ] Relevant linting and formatting pass locally
- [ ] I have signed the CLA, or I will sign it when the bot prompts me

## Contributor Resources
- [Contributing guide](https://agenta.ai/docs/contributing/overview)
- [Creating your first PR](https://agenta.ai/docs/contributing/first-pr)
- [Development mode](https://agenta.ai/docs/contributing/guides/development-mode)
- [Testing](https://agenta.ai/docs/contributing/guides/testing)
- [Formatting and linting](https://agenta.ai/docs/contributing/guides/formatting-and-linting)
- [Slack support](https://join.slack.com/t/agenta-hq/shared_invite/zt-37pnbp5s6-mbBrPL863d_oLB61GSNFjw)
