### PR TITLE
fix(PricingCard): Hovering plan selection cards breaks modal layout

### DIFF
--- a/web/ee/src/components/pages/settings/Billing/Modals/PricingModal/assets/PricingCard/index.tsx
+++ b/web/ee/src/components/pages/settings/Billing/Modals/PricingModal/assets/PricingCard/index.tsx
@@ -32,7 +32,7 @@ const PricingCard = ({plan, currentPlan, onOptionClick, isLoading}: PricingCardP
         <Card
             hoverable
             key={plan.plan}
-            className={`relative w-full md:w-1/3`}
+            className={`relative w-full md:w-1/3 hover:z-10`}
             title={plan.title}
             classNames={{
                 body: "!p-3 flex-1",


### PR DESCRIPTION
## Summary
<!-- What changed? -->
<!-- Why was this change needed? -->
<!-- What problem does it solve? -->
<!-- For fixes, explain how the change addresses the root cause. -->

## Testing
### Verified locally
<!-- What did you run or verify locally? Be specific. -->

### Added or updated tests
<!-- What tests did you add or update? Include unit, integration, and end-to-end coverage when relevant. Write N/A if none. -->

### QA follow-up
<!-- What still needs QA? List flows, browsers, environments, edge cases, or data conditions to validate. Write N/A if none. -->

## Demo
<!-- Required for UI changes. Add screenshots, GIFs, or a short video. -->
<!-- If this is not a UI change, write N/A. -->

## Checklist
- [ ] I have included a video or screen recording for UI changes, or marked Demo as N/A
- [ ] Relevant tests pass locally
- [ ] Relevant linting and formatting pass locally
- [ ] I have signed the CLA, or I will sign it when the bot prompts me

## Contributor Resources
- [Contributing guide](https://agenta.ai/docs/contributing/overview)
- [Creating your first PR](https://agenta.ai/docs/contributing/first-pr)
- [Development mode](https://agenta.ai/docs/contributing/guides/development-mode)
- [Testing](https://agenta.ai/docs/contributing/guides/testing)
- [Formatting and linting](https://agenta.ai/docs/contributing/guides/formatting-and-linting)
- [Slack support](https://join.slack.com/t/agenta-hq/shared_invite/zt-37pnbp5s6-mbBrPL863d_oLB61GSNFjw)
