### PR TITLE
(fix)[AGE-3727]: Prompt editor cursor jumps to top while typing

### DIFF
--- a/web/packages/agenta-ui/src/ChatMessage/components/ChatMessageList.tsx
+++ b/web/packages/agenta-ui/src/ChatMessage/components/ChatMessageList.tsx
@@ -27,6 +27,7 @@ import ToolMessageHeader from "./ToolMessageHeader"
 const ChatMessageItem: React.FC<{
     msg: SimpleChatMessage
     index: number
+    editorId: string
     disabled?: boolean
     messageClassName?: string
     placeholder: string
@@ -56,6 +57,7 @@ const ChatMessageItem: React.FC<{
 }> = ({
     msg,
     index,
+    editorId,
     disabled,
     messageClassName,
     placeholder,
@@ -142,7 +144,7 @@ const ChatMessageItem: React.FC<{
             style={getCollapseStyle(isMinimized, 72)}
         >
             <ChatMessageEditor
-                id={`chat-msg-${index}`}
+                id={editorId}
                 role={msg.role}
                 text={textContent}
                 disabled={disabled}
@@ -171,7 +173,7 @@ const ChatMessageItem: React.FC<{
                             "invisible group-hover/item:visible",
                         )}
                     >
-                        <MarkdownToggleButton id={`chat-msg-${index}`} />
+                        <MarkdownToggleButton id={editorId} />
                         {allowFileUpload && !disabled && (
                             <AttachmentButton
                                 onAddImage={(url) => onAddImage(index, url)}
@@ -299,6 +301,7 @@ export const ChatMessageList: React.FC<ChatMessageListProps> = ({
     loadingFallback = "skeleton",
     maxPasteChars,
 }) => {
+    const listInstanceIdRef = useRef(generateKey())
     // Maintain stable React keys for each message position.
     // This prevents React from reusing the wrong component instance
     // when messages are added or removed from the middle of the list.
@@ -417,37 +420,46 @@ export const ChatMessageList: React.FC<ChatMessageListProps> = ({
 
     return (
         <div className={cn(flexLayouts.column, gapClasses.sm, className)}>
-            {messages.map((msg, index) => (
-                <ChatMessageItem
-                    key={stableKeys[index]}
-                    msg={msg}
-                    index={index}
-                    disabled={disabled}
-                    messageClassName={messageClassName}
-                    placeholder={placeholder}
-                    isMinimized={minimizedMessages[stableKeys[index]] ?? false}
-                    showControls={showControls}
-                    showRemoveButton={showRemoveButton}
-                    showCopyButton={showCopyButton}
-                    allowFileUpload={allowFileUpload}
-                    enableTokens={enableTokens}
-                    templateFormat={templateFormat}
-                    tokens={tokens}
-                    loadingFallback={loadingFallback}
-                    maxPasteChars={maxPasteChars}
-                    ImagePreview={ImagePreview}
-                    onRoleChange={handleRoleChange}
-                    onTextChange={handleTextChange}
-                    onRemove={handleRemoveMessage}
-                    onAddImage={handleAddImage}
-                    onAddFile={handleAddFile}
-                    onRemoveAttachment={handleRemoveAttachment}
-                    onToggleMinimize={(i) => {
-                        const key = stableKeys[i]
-                        setMinimizedMessages((prev) => ({...prev, [key]: !prev[key]}))
-                    }}
-                />
-            ))}
+            {messages.map((msg, index) => {
+                const rowKey = stableKeys[index]
+                // Scope editor ids to the list instance so markdown-view state,
+                // Lexical namespaces, and other editor-local caches never bleed
+                // across separate prompt/message lists that share the same row index.
+                const editorId = `chat-msg-${listInstanceIdRef.current}-${rowKey}`
+
+                return (
+                    <ChatMessageItem
+                        key={rowKey}
+                        msg={msg}
+                        index={index}
+                        editorId={editorId}
+                        disabled={disabled}
+                        messageClassName={messageClassName}
+                        placeholder={placeholder}
+                        isMinimized={minimizedMessages[rowKey] ?? false}
+                        showControls={showControls}
+                        showRemoveButton={showRemoveButton}
+                        showCopyButton={showCopyButton}
+                        allowFileUpload={allowFileUpload}
+                        enableTokens={enableTokens}
+                        templateFormat={templateFormat}
+                        tokens={tokens}
+                        loadingFallback={loadingFallback}
+                        maxPasteChars={maxPasteChars}
+                        ImagePreview={ImagePreview}
+                        onRoleChange={handleRoleChange}
+                        onTextChange={handleTextChange}
+                        onRemove={handleRemoveMessage}
+                        onAddImage={handleAddImage}
+                        onAddFile={handleAddFile}
+                        onRemoveAttachment={handleRemoveAttachment}
+                        onToggleMinimize={(i) => {
+                            const key = stableKeys[i]
+                            setMinimizedMessages((prev) => ({...prev, [key]: !prev[key]}))
+                        }}
+                    />
+                )
+            })}
             {showControls && !disabled && (
                 <Button
                     variant="outlined"

--- a/web/packages/agenta-ui/src/Editor/Editor.tsx
+++ b/web/packages/agenta-ui/src/Editor/Editor.tsx
@@ -20,10 +20,12 @@ import clsx from "clsx"
 import {useSetAtom} from "jotai"
 import yaml from "js-yaml"
 import {
+    BLUR_COMMAND,
     COMMAND_PRIORITY_HIGH,
     COMMAND_PRIORITY_LOW,
     EditorState,
     LexicalEditor,
+    FOCUS_COMMAND,
     type AnyLexicalExtensionArgument,
     configExtension,
     createCommand,
@@ -441,10 +443,89 @@ const EditorInner = forwardRef<HTMLDivElement, EditorProps>(
         }, [editor, view])
 
         const isInitRef = useRef(false)
+        const lastHydratedRef = useRef<string>("")
+        const lastEmittedTextRef = useRef<string>("")
+        const onChangeDebounceRef = useRef<ReturnType<typeof setTimeout> | null>(null)
+        const isFocusedRef = useRef(false)
+        const pendingHydrationOnBlurRef = useRef<string | null>(null)
 
         useEffect(() => {
             editor.setEditable(!disabled)
         }, [disabled, editor])
+
+        const hydrateRichTextFromControlledValue = useCallback(
+            (next: string) => {
+                if (codeOnly) {
+                    return false
+                }
+
+                // If this value is just our own onChange echoing back, skip hydration.
+                // The markdown round-trip (serialize → emit → hydrate → deserialize)
+                // can produce different text than $getRoot().getTextContent() due to
+                // trailing newline differences, causing an infinite re-hydration loop.
+                if (next === lastEmittedTextRef.current) {
+                    return false
+                }
+
+                // Compare with actual editor content serialized as markdown, not plain text.
+                // Using $getRoot().getTextContent() would strip markdown formatting (headings,
+                // code fences, etc.) causing false mismatches after markdown paste/conversion.
+                let currentContent = ""
+                editor.getEditorState().read(() => {
+                    currentContent = $getRichTextAsMarkdownString()
+                })
+
+                if (currentContent === next) {
+                    return false
+                }
+
+                lastHydratedRef.current = next
+                editor.dispatchCommand(ON_HYDRATE_FROM_REMOTE_CONTENT, {
+                    hydrateWithRemoteContent: next,
+                    parentId: "",
+                })
+
+                return true
+            },
+            [codeOnly, editor],
+        )
+
+        useEffect(() => {
+            if (codeOnly) {
+                return
+            }
+
+            return mergeRegister(
+                editor.registerCommand(
+                    FOCUS_COMMAND,
+                    () => {
+                        isFocusedRef.current = true
+                        return false
+                    },
+                    COMMAND_PRIORITY_LOW,
+                ),
+                editor.registerCommand(
+                    BLUR_COMMAND,
+                    () => {
+                        isFocusedRef.current = false
+
+                        const pendingValue = pendingHydrationOnBlurRef.current
+                        pendingHydrationOnBlurRef.current = null
+
+                        if (!pendingValue) {
+                            return false
+                        }
+
+                        setTimeout(() => {
+                            hydrateRichTextFromControlledValue(pendingValue)
+                        }, 0)
+
+                        return false
+                    },
+                    COMMAND_PRIORITY_LOW,
+                ),
+            )
+        }, [codeOnly, editor, hydrateRichTextFromControlledValue])
 
         useEffect(() => {
             /**
@@ -489,10 +570,6 @@ const EditorInner = forwardRef<HTMLDivElement, EditorProps>(
                 ),
             )
         }, [codeOnly, editor])
-
-        const lastHydratedRef = useRef<string>("")
-        const lastEmittedTextRef = useRef<string>("")
-        const onChangeDebounceRef = useRef<ReturnType<typeof setTimeout> | null>(null)
 
         useEffect(
             () => () => {
@@ -664,31 +741,17 @@ const EditorInner = forwardRef<HTMLDivElement, EditorProps>(
             if (codeOnly) return
             const next = effectiveValue || ""
 
-            // If this value is just our own onChange echoing back, skip hydration.
-            // The markdown round-trip (serialize → emit → hydrate → deserialize)
-            // can produce different text than $getRoot().getTextContent() due to
-            // trailing newline differences, causing an infinite re-hydration loop.
-            if (next === lastEmittedTextRef.current) {
+            // Rich-text markdown transforms can normalize content as the user types.
+            // Re-hydrating while focused rebuilds the Lexical document and can kick
+            // the caret to the start/end of the editor. Defer any non-echo sync until blur.
+            if (editor.isEditable() && isFocusedRef.current) {
+                pendingHydrationOnBlurRef.current = next
                 return
             }
 
-            // Compare with actual editor content serialized as markdown, not plain text.
-            // Using $getRoot().getTextContent() would strip markdown formatting (headings,
-            // code fences, etc.) causing false mismatches after markdown paste/conversion.
-            let currentContent = ""
-            editor.getEditorState().read(() => {
-                currentContent = $getRichTextAsMarkdownString()
-            })
-            // Skip if content already matches (no change needed)
-            if (currentContent === next) {
-                return
-            }
-            lastHydratedRef.current = next
-            editor.dispatchCommand(ON_HYDRATE_FROM_REMOTE_CONTENT, {
-                hydrateWithRemoteContent: next,
-                parentId: "",
-            })
-        }, [effectiveValue])
+            pendingHydrationOnBlurRef.current = null
+            hydrateRichTextFromControlledValue(next)
+        }, [codeOnly, editor, effectiveValue, hydrateRichTextFromControlledValue])
 
         return (
             <div className="editor-container w-full overflow-hidden relative min-h-[inherit]">

--- a/web/packages/agenta-ui/src/Editor/Editor.tsx
+++ b/web/packages/agenta-ui/src/Editor/Editor.tsx
@@ -516,9 +516,7 @@ const EditorInner = forwardRef<HTMLDivElement, EditorProps>(
                             return false
                         }
 
-                        setTimeout(() => {
-                            hydrateRichTextFromControlledValue(pendingValue)
-                        }, 0)
+                        hydrateRichTextFromControlledValue(pendingValue)
 
                         return false
                     },


### PR DESCRIPTION
## Summary
<!-- What changed? -->
<!-- Why was this change needed? -->
<!-- What problem does it solve? -->
<!-- For fixes, explain how the change addresses the root cause. -->
This fixes a prompt editor issue where the cursor could jump to the start or end of the text while typing in markdown-rich prompt messages

The root cause was that the rich-text editor could re-hydrate from the controlled value while the user was still focused and editing. When markdown normalization or upstream value sync produced a slightly different serialized value, the editor could rebuild its content mid-edit and lose the active caret position

This change defers rich-text hydration while the editor is focused and only applies any pending external sync after blur, which prevents in-place typing from being interrupted by editor rehydration

## Testing
### Verified locally
<!-- What did you run or verify locally? Be specific. -->

### Added or updated tests
<!-- What tests did you add or update? Include unit, integration, and end-to-end coverage when relevant. Write N/A if none. -->

### QA follow-up
<!-- What still needs QA? List flows, browsers, environments, edge cases, or data conditions to validate. Write N/A if none. -->
- Validate typing in Playground prompt editors with markdown-heavy content
- Validate long prompts with headings, lists, and structured output enabled
- Validate typing in multiple messages, not just the first system prompt
- Validate no regressions for external value sync after blur

## Demo
<!-- Required for UI changes. Add screenshots, GIFs, or a short video. -->
<!-- If this is not a UI change, write N/A. -->

## Checklist
- [x] I have included a video or screen recording for UI changes, or marked Demo as N/A
- [x] Relevant tests pass locally
- [x] Relevant linting and formatting pass locally
- [x] I have signed the CLA, or I will sign it when the bot prompts me

## Contributor Resources
- [Contributing guide](https://agenta.ai/docs/contributing/overview)
- [Creating your first PR](https://agenta.ai/docs/contributing/first-pr)
- [Development mode](https://agenta.ai/docs/contributing/guides/development-mode)
- [Testing](https://agenta.ai/docs/contributing/guides/testing)
- [Formatting and linting](https://agenta.ai/docs/contributing/guides/formatting-and-linting)
- [Slack support](https://join.slack.com/t/agenta-hq/shared_invite/zt-37pnbp5s6-mbBrPL863d_oLB61GSNFjw)
