### PR TITLE
[3171] chore(SDK): warn when instrument() is called before ag.init()

### DIFF
--- a/sdk/agenta/sdk/decorators/tracing.py
+++ b/sdk/agenta/sdk/decorators/tracing.py
@@ -16,6 +16,7 @@ from agenta.sdk.contexts.tracing import (
     tracing_context_manager,
 )
 from agenta.sdk.tracing.conventions import parse_span_kind
+from agenta.sdk.agenta_init import AgentaSingleton
 from agenta.sdk.utils.exceptions import suppress
 from agenta.sdk.utils.logging import get_module_logger
 from opentelemetry import context as otel_context
@@ -66,7 +67,19 @@ class instrument:  # pylint: disable=invalid-name
         self.aggregate = aggregate
         self.annotate = annotate
 
+    @staticmethod
+    def _warn_if_not_initialized(handler_name: str) -> None:
+        if not AgentaSingleton._initialized:
+            log.warning(
+                "ag.instrument() called on '%s' before ag.init(). "
+                "Tracing will not work until ag.init() is called. "
+                "Please call ag.init() before using @ag.instrument().",
+                handler_name,
+            )
+
     def __call__(self, handler: Callable[..., Any]):
+        self._warn_if_not_initialized(handler.__name__)
+
         is_coroutine_function = iscoroutinefunction(handler)
         is_sync_generator = isgeneratorfunction(handler)
         is_async_generator = isasyncgenfunction(handler)


### PR DESCRIPTION
## Summary

Adds a warning when `@ag.instrument()` is applied to a function before `ag.init()` has been called. Currently this results in silent errors where tracing does not work.

## Changes

In `sdk/agenta/sdk/decorators/tracing.py`:
- Added `_warn_if_not_initialized()` static method that checks `AgentaSingleton._initialized`
- Called at the start of `instrument.__call__()` so the warning fires when the decorator is applied
- Uses the existing `get_module_logger` for consistent logging

The warning message includes actionable guidance: "Please call ag.init() before using @ag.instrument()."

## Testing

- `ruff format` and `ruff check` pass with no issues
- The warning only fires when `_initialized` is False, so existing code that calls `ag.init()` first sees no change

Closes #3171

This contribution was developed with AI assistance (Claude Code).