### PR TITLE
doc(docs): Update documentation for v96.0 unified invoke API

### DIFF
--- a/docs/blog/entries/unified-invoke-api.mdx
+++ b/docs/blog/entries/unified-invoke-api.mdx
@@ -1,0 +1,303 @@
+---
+title: "Unified Invoke API"
+slug: unified-invoke-api
+date: 2026-04-14
+tags: [v0.96.0]
+description: "All application invocation endpoints are now unified into a single /v0/invoke endpoint with a structured request/response format. Includes a full migration guide from the legacy endpoints."
+---
+
+# Unified Invoke API
+
+## Overview
+
+In v0.96.0, we unified all application invocation endpoints into a single `POST /services/{service}/v0/invoke` endpoint. The four legacy endpoints (`/generate`, `/generate_deployed`, `/test`, `/run`) are replaced by one consistent interface with structured references and a cleaner response format.
+
+The old endpoints will continue to work temporarily via an adapter layer, but we strongly recommend migrating to the new format.
+
+## What Changed
+
+### Single Endpoint
+
+All invocations now go through one endpoint:
+
+```
+POST /services/{service}/v0/invoke
+```
+
+This replaces:
+- `POST /services/{service}/generate` (draft testing)
+- `POST /services/{service}/test` (draft testing)
+- `POST /services/{service}/generate_deployed` (deployed config)
+- `POST /services/{service}/run` (deployed config)
+
+### New Request Format
+
+The most common use case is calling a prompt deployed to an environment using `generate_deployed`. Here is how that changes end-to-end:
+
+**Before** — `POST /services/completion/generate_deployed`
+```python
+response = requests.post(
+    "https://cloud.agenta.ai/services/completion/generate_deployed",
+    headers={
+        "Content-Type": "application/json",
+        "Authorization": f"ApiKey {api_key}",
+    },
+    json={
+        "environment": "production",
+        "app": "my-app",
+        "inputs": {"country": "France"},
+    },
+)
+
+result = response.json()
+print(result["data"])       # "The capital of France is Paris."
+print(result["tree_id"])    # trace ID for observability
+```
+
+**After** — `POST /services/completion/v0/invoke`
+```python
+response = requests.post(
+    "https://cloud.agenta.ai/services/completion/v0/invoke",
+    headers={
+        "Content-Type": "application/json",
+        "Authorization": f"ApiKey {api_key}",
+    },
+    json={
+        "data": {
+            "inputs": {"country": "France"},
+        },
+        "references": {
+            "application": {"slug": "my-app"},
+            "environment": {"slug": "production"},
+        },
+        "selector": {"key": "my-app.revision"},
+    },
+)
+
+result = response.json()
+print(result["data"]["outputs"])  # "The capital of France is Paris."
+print(result["trace_id"])         # trace ID for observability
+```
+
+The request body is now structured into three sections: `data` (your inputs and optional parameters), `references` (which app/environment/variant to target), and `selector` (the key used to resolve the deployed revision).
+
+Key changes:
+- `inputs` moves to `data.inputs`
+- `messages` merges into `data.inputs.messages`
+- `ag_config` becomes `data.parameters`
+- Flat params (`app`, `variant_slug`, `environment`, etc.) become structured `references`
+- New `selector.key` field for environment-based resolution
+- `?application_id=` query parameter removed — use `references.application.id` instead
+
+:::info Understanding the selector key
+When invoking via an environment (without specifying a variant/revision), the `selector.key` tells the system which deployed revision to resolve. The format is `{app_slug}.revision` — for example, if your application slug is `my-app`, the key is `my-app.revision`. This field is not needed when invoking a specific variant and revision directly.
+:::
+
+### New Response Format
+
+**Before:**
+```json
+{
+  "version": "3.0",
+  "data": "The capital of France is Paris.",
+  "content_type": "text/plain",
+  "tree_id": "0ef1d6b7-84c3-4b8a-705b-ae5974e51954"
+}
+```
+
+**After:**
+```json
+{
+  "version": "2025-07-14",
+  "status": {"code": null, "message": null, "stacktrace": null},
+  "trace_id": "0ef1d6b7-84c3-4b8a-705b-ae5974e51954",
+  "span_id": "a1b2c3d4e5f6",
+  "data": {
+    "outputs": "The capital of France is Paris."
+  }
+}
+```
+
+Key changes:
+- `version` changed from `"3.0"` to `"2025-07-14"` (date-based versioning)
+- `data` (direct value) becomes `data.outputs` (nested)
+- `content_type` removed
+- `tree_id` replaced by `trace_id` and `span_id`
+- New `status` object for error reporting
+
+## Migration Guide
+
+### Quick Reference Table
+
+| Old | New |
+|-----|-----|
+| `POST /services/{svc}/run` | `POST /services/{svc}/v0/invoke` |
+| `POST /services/{svc}/generate_deployed` | `POST /services/{svc}/v0/invoke` |
+| `POST /services/{svc}/generate` | `POST /services/{svc}/v0/invoke` |
+| `POST /services/{svc}/test` | `POST /services/{svc}/v0/invoke` |
+| `"inputs": {...}` | `"data": {"inputs": {...}}` |
+| `"messages": [...]` | `"data": {"inputs": {"messages": [...]}}` |
+| `"ag_config": {...}` | `"data": {"parameters": {...}}` |
+| `"environment": "prod"` | `"references": {"environment": {"slug": "prod"}}` |
+| `"app": "my-app"` | `"references": {"application": {"slug": "my-app"}}` |
+| `"variant_slug": "v1"` | `"references": {"application_variant": {"slug": "v1"}}` |
+| `"variant_version": 1` | `"references": {"application_revision": {"version": "1"}}` |
+| Response `"data": "text"` | Response `"data": {"outputs": "text"}` |
+| Response `"tree_id"` | Response `"trace_id"` |
+
+### Example: Invoking a Deployed Prompt (Completion)
+
+**Before:**
+```python
+import requests
+
+response = requests.post(
+    "https://cloud.agenta.ai/services/completion/run",
+    headers={
+        "Content-Type": "application/json",
+        "Authorization": f"ApiKey {api_key}",
+    },
+    json={
+        "environment": "production",
+        "app": "my-app",
+        "inputs": {"country": "France"},
+    },
+)
+data = response.json()
+print(data["data"])  # "The capital of France is Paris."
+```
+
+**After:**
+```python
+import requests
+
+response = requests.post(
+    "https://cloud.agenta.ai/services/completion/v0/invoke",
+    headers={
+        "Content-Type": "application/json",
+        "Authorization": f"ApiKey {api_key}",
+    },
+    json={
+        "data": {
+            "inputs": {"country": "France"},
+        },
+        "references": {
+            "application": {"slug": "my-app"},
+            "environment": {"slug": "production"},
+        },
+        "selector": {"key": "my-app.revision"},
+    },
+)
+data = response.json()
+print(data["data"]["outputs"])  # "The capital of France is Paris."
+```
+
+### Example: Invoking a Chat Application
+
+**Before:**
+```python
+response = requests.post(
+    "https://cloud.agenta.ai/services/chat/run",
+    headers={
+        "Content-Type": "application/json",
+        "Authorization": f"ApiKey {api_key}",
+    },
+    json={
+        "environment": "production",
+        "app": "my-chat",
+        "inputs": {"context": "Be helpful."},
+        "messages": [{"role": "user", "content": "Hello!"}],
+    },
+)
+```
+
+**After:**
+```python
+response = requests.post(
+    "https://cloud.agenta.ai/services/chat/v0/invoke",
+    headers={
+        "Content-Type": "application/json",
+        "Authorization": f"ApiKey {api_key}",
+    },
+    json={
+        "data": {
+            "inputs": {
+                "context": "Be helpful.",
+                "messages": [{"role": "user", "content": "Hello!"}],
+            },
+        },
+        "references": {
+            "application": {"slug": "my-chat"},
+            "environment": {"slug": "production"},
+        },
+        "selector": {"key": "my-chat.revision"},
+    },
+)
+```
+
+### Example: Testing with Draft Configuration
+
+**Before:**
+```python
+response = requests.post(
+    "https://cloud.agenta.ai/services/completion/generate?application_id=xxx",
+    headers={
+        "Content-Type": "application/json",
+        "Authorization": f"ApiKey {api_key}",
+    },
+    json={
+        "inputs": {"country": "France"},
+        "ag_config": {
+            "prompt": {
+                "messages": [{"role": "user", "content": "Capital of {{country}}?"}],
+                "llm_config": {"model": "gpt-4o-mini"},
+                "template_format": "curly",
+            }
+        },
+    },
+)
+```
+
+**After:**
+```python
+response = requests.post(
+    "https://cloud.agenta.ai/services/completion/v0/invoke",
+    headers={
+        "Content-Type": "application/json",
+        "Authorization": f"ApiKey {api_key}",
+    },
+    json={
+        "data": {
+            "inputs": {"country": "France"},
+            "parameters": {
+                "prompt": {
+                    "messages": [{"role": "user", "content": "Capital of {{country}}?"}],
+                    "llm_config": {"model": "gpt-4o-mini"},
+                    "template_format": "curly",
+                }
+            },
+        },
+        "references": {
+            "application": {"id": "xxx"},
+        },
+    },
+)
+```
+
+## SDK Unchanged
+
+The Python SDK (`ag.ConfigManager.get_from_registry()`) continues to work with the same interface. The SDK handles the new API format internally. No changes needed in your SDK code.
+
+```python
+# This still works exactly the same
+config = ag.ConfigManager.get_from_registry(
+    app_slug="my-app",
+    variant_slug="default",
+    variant_version=1,
+)
+
+config = ag.ConfigManager.get_from_registry(
+    app_slug="my-app",
+    environment_slug="production",
+)
+```

--- a/docs/blog/main.mdx
+++ b/docs/blog/main.mdx
@@ -10,6 +10,18 @@ import Image from "@theme/IdealImage";
 
 <section class="changelog">
 
+### [Unified Invoke API](/changelog/unified-invoke-api)
+
+_14 April 2026_
+
+**v0.96.0**
+
+All application invocation endpoints (`/generate`, `/generate_deployed`, `/test`, `/run`) are now unified into a single `POST /services/{service}/v0/invoke` endpoint. The new format uses structured `references` for targeting applications and environments, and returns outputs under `data.outputs` with `trace_id` and `span_id` for observability.
+
+The old endpoints remain available temporarily via an adapter. See the [full migration guide](/changelog/unified-invoke-api) for before/after examples.
+
+---
+
 ### [Webhooks and GitHub Automations for Prompt Deployments](/changelog/deployment-webhooks-and-github-automations)
 
 _11 March 2026_

--- a/docs/docs/concepts/01-concepts.mdx
+++ b/docs/docs/concepts/01-concepts.mdx
@@ -63,9 +63,13 @@ Every **variant** is **versioned** and each **version** is immutable. When you m
 
 ### Environments
 
-**Environments** are the interfaces where your deployed variants are accessible. You can deploy a **version** of a **variant** to an **environment**. Each **environment** has a user-defined environment name (e.g. development, staging, production) that specifies its context or stage.
+**Environments** are the interfaces where your deployed variants are accessible. You can deploy a **version** of a **variant** to an **environment**. Each **environment** has an environment name (e.g. development, staging, production) that specifies its context or stage.
 
-You can then integrate the **environment** into your codebase to fetch the configuration deployed on that **environment**. Additionally, you can directly invoke the endpoints relating to the **environment** containing the application running with that configuration.
+You can then integrate the **environment** into your codebase to:
+- **Fetch the configuration** deployed on that **environment** using the SDK or API.
+- **Invoke the application** directly through the unified `/v0/invoke` endpoint, referencing the environment by slug.
+
+When invoking via an environment, Agenta resolves the deployed revision using a **key** (formatted as `{app_slug}.revision`). This key maps the environment to the specific application revision that was deployed to it.
 
 By default, applications come with three predefined **environments**:
 

--- a/docs/docs/getting-started/02-quick-start.mdx
+++ b/docs/docs/getting-started/02-quick-start.mdx
@@ -283,23 +283,22 @@ response = client.chat.completions.create(
 
 ```javascript
 const fetchConfigs = async () => {
-  const url = 'https://cloud.agenta.ai/api/variants/configs/fetch';
+  const url = 'https://cloud.agenta.ai/api/preview/applications/revisions/retrieve';
 
   const headers = {
     'Accept': 'application/json',
-    'Authorization': 'YOUR_API_KEY',
+    'Authorization': 'ApiKey YOUR_API_KEY',
     'Content-Type': 'application/json'
   };
 
   const requestData = {
-    environment_ref: {
-      slug: 'production',
-      id: null
-    },
     application_ref: {
-      slug: 'testprompt',
-      id: null
-    }
+      slug: 'testprompt'
+    },
+    environment_ref: {
+      slug: 'production'
+    },
+    key: 'testprompt.revision'
   };
 
   try {
@@ -342,43 +341,23 @@ fetchConfigs();
           "model": "gpt-3.5-turbo",
           "tools": []
         },
-        "user_prompt": "What is the capital of {{country}}?",
-        "system_prompt": "You are an expert in geography",
         "template_format": "curly"
       }
-    }
-  },
+    },
   "url": "https://cloud.agenta.ai/services/completion",
   "application_ref": {
-    "slug": "we",
-    "version": null,
-    "commit_message": null,
+    "slug": "testprompt",
     "id": "0196869b-2337-7d51-8a24-fc3893191b5b"
   },
-  "service_ref": null,
   "variant_ref": {
-    "slug": "key",
+    "slug": "default",
     "version": 1,
-    "commit_message": "variant commit message",
     "id": "0196869b-259c-7e11-ba08-ac316a2d41fa"
   },
   "environment_ref": {
     "slug": "production",
     "version": 1,
-    "commit_message": "test commit message",
     "id": "0196869c-bd67-7f41-b7bb-d1196f87d4e9"
-  },
-  "variant_lifecycle": {
-    "created_at": "2025-04-30T12:10:36.828905+00:00",
-    "updated_at": "2025-04-30T12:10:36.315388+00:00",
-    "updated_by_id": "01966e0a-9094-7562-8d47-87002335e22b",
-    "updated_by": "me@gmail.com"
-  },
-  "environment_lifecycle": {
-    "created_at": "2025-04-30T12:12:21.223715+00:00",
-    "updated_at": "2025-04-30T12:12:21.223715+00:00",
-    "updated_by_id": "01966e0a-9094-7562-8d47-87002335e22b",
-    "updated_by": "me@gmail.com"
   }
 }
 ```

--- a/docs/docs/prompt-engineering/01-quick-start.mdx
+++ b/docs/docs/prompt-engineering/01-quick-start.mdx
@@ -171,23 +171,22 @@ response = client.chat.completions.create(
 
 ```javascript
 const fetchConfigs = async () => {
-  const url = 'https://cloud.agenta.ai/api/variants/configs/fetch';
+  const url = 'https://cloud.agenta.ai/api/preview/applications/revisions/retrieve';
 
   const headers = {
     'Accept': 'application/json',
-    'Authorization': 'YOUR_API_KEY',
+    'Authorization': 'ApiKey YOUR_API_KEY',
     'Content-Type': 'application/json'
   };
 
   const requestData = {
-    environment_ref: {
-      slug: 'production',
-      id: null
-    },
     application_ref: {
-      slug: 'testprompt',
-      id: null
-    }
+      slug: 'testprompt'
+    },
+    environment_ref: {
+      slug: 'production'
+    },
+    key: 'testprompt.revision'
   };
 
   try {
@@ -229,43 +228,23 @@ The response will contain your prompt configuration under `params.prompt`:
           "model": "gpt-3.5-turbo",
           "tools": []
         },
-        "user_prompt": "What is the capital of {{country}}?",
-        "system_prompt": "You are an expert in geography",
         "template_format": "curly"
       }
-    }
-  },
+    },
   "url": "https://cloud.agenta.ai/services/completion",
   "application_ref": {
-    "slug": "we",
-    "version": null,
-    "commit_message": null,
+    "slug": "testprompt",
     "id": "0196869b-2337-7d51-8a24-fc3893191b5b"
   },
-  "service_ref": null,
   "variant_ref": {
-    "slug": "key",
+    "slug": "default",
     "version": 1,
-    "commit_message": "variant commit message",
     "id": "0196869b-259c-7e11-ba08-ac316a2d41fa"
   },
   "environment_ref": {
     "slug": "production",
     "version": 1,
-    "commit_message": "test commit message",
     "id": "0196869c-bd67-7f41-b7bb-d1196f87d4e9"
-  },
-  "variant_lifecycle": {
-    "created_at": "2025-04-30T12:10:36.828905+00:00",
-    "updated_at": "2025-04-30T12:10:36.315388+00:00",
-    "updated_by_id": "01966e0a-9094-7562-8d47-87002335e22b",
-    "updated_by": "me@gmail.com"
-  },
-  "environment_lifecycle": {
-    "created_at": "2025-04-30T12:12:21.223715+00:00",
-    "updated_at": "2025-04-30T12:12:21.223715+00:00",
-    "updated_by_id": "01966e0a-9094-7562-8d47-87002335e22b",
-    "updated_by": "me@gmail.com"
   }
 }
 ```

--- a/docs/docs/prompt-engineering/integrating-prompts/02-fetch-prompt-programatically.mdx
+++ b/docs/docs/prompt-engineering/integrating-prompts/02-fetch-prompt-programatically.mdx
@@ -71,17 +71,15 @@ Example Output:
 
 ```javascript
 // Fetch configuration from production environment (default behavior)
-const fetchResponse = await fetch('https://cloud.agenta.ai/api/variants/configs/fetch', {
+const fetchResponse = await fetch('https://cloud.agenta.ai/api/preview/applications/revisions/retrieve', {
   method: 'POST',
   headers: {
     'Content-Type': 'application/json',
-    'Authorization': 'Bearer YOUR_API_KEY'
+    'Authorization': 'ApiKey YOUR_API_KEY'
   },
   body: JSON.stringify({
     application_ref: {
-      slug: 'my-app-slug',
-      version: null,
-      id: null
+      slug: 'my-app-slug'
     }
   })
 });
@@ -95,14 +93,12 @@ console.log(config);
 
 ```bash
 # Fetch configuration from production environment (default behavior)
-curl -X POST "https://cloud.agenta.ai/api/variants/configs/fetch" \
+curl -X POST "https://cloud.agenta.ai/api/preview/applications/revisions/retrieve" \
   -H "Content-Type: application/json" \
-  -H "Authorization: Bearer YOUR_API_KEY" \
+  -H "Authorization: ApiKey YOUR_API_KEY" \
   -d '{
     "application_ref": {
-      "slug": "my-app-slug",
-      "version": null,
-      "id": null
+      "slug": "my-app-slug"
     }
   }'
 ```
@@ -154,22 +150,21 @@ print(config)
 
 ```javascript
 // Fetch configuration by variant
-const fetchResponse = await fetch('https://cloud.agenta.ai/api/variants/configs/fetch', {
+const fetchResponse = await fetch('https://cloud.agenta.ai/api/preview/applications/revisions/retrieve', {
   method: 'POST',
   headers: {
     'Content-Type': 'application/json',
-    'Authorization': 'Bearer YOUR_API_KEY'
+    'Authorization': 'ApiKey YOUR_API_KEY'
   },
   body: JSON.stringify({
-    variant_ref: {
-      slug: 'my-variant-slug',
-      version: 2,
-      id: null
-    },
     application_ref: {
-      slug: 'my-app-slug',
-      version: null,
-      id: null
+      slug: 'my-app-slug'
+    },
+    application_variant_ref: {
+      slug: 'my-variant-slug'
+    },
+    application_revision_ref: {
+      version: 2
     }
   })
 });
@@ -183,24 +178,27 @@ console.log(config);
 
 ```bash
 # Fetch configuration by variant
-curl -X POST "https://cloud.agenta.ai/api/variants/configs/fetch" \
+curl -X POST "https://cloud.agenta.ai/api/preview/applications/revisions/retrieve" \
   -H "Content-Type: application/json" \
-  -H "Authorization: Bearer YOUR_API_KEY" \
+  -H "Authorization: ApiKey YOUR_API_KEY" \
   -d '{
-    "variant_ref": {
-      "slug": "my-variant-slug",
-      "version": 2,
-      "id": null
-    },
     "application_ref": {
-      "slug": "my-app-slug",
-      "version": null,
-      "id": null
+      "slug": "my-app-slug"
+    },
+    "application_variant_ref": {
+      "slug": "my-variant-slug"
+    },
+    "application_revision_ref": {
+      "version": 2
     }
   }'
 ```
   </TabItem>
 </Tabs>
+
+:::info Understanding the `key` field
+When fetching by environment, the `key` field tells the system which deployed revision to resolve. The format is `{app_slug}.revision` — for example, if your application slug is `my-app`, the key is `my-app.revision`. This field is only needed when fetching by environment reference; it is not required when fetching by variant reference.
+:::
 
 ### Fetching by Environment Reference
 
@@ -223,23 +221,21 @@ print(config)
 
 ```javascript
 // Fetch the latest configuration from the staging environment
-const fetchResponse = await fetch('https://cloud.agenta.ai/api/variants/configs/fetch', {
+const fetchResponse = await fetch('https://cloud.agenta.ai/api/preview/applications/revisions/retrieve', {
   method: 'POST',
   headers: {
     'Content-Type': 'application/json',
-    'Authorization': 'Bearer YOUR_API_KEY'
+    'Authorization': 'ApiKey YOUR_API_KEY'
   },
   body: JSON.stringify({
+    application_ref: {
+      slug: 'my-app'
+    },
     environment_ref: {
       slug: 'staging',
-      version: 1,  // Optional: omit to fetch latest
-      id: null
+      version: 1  // Optional: omit to fetch latest
     },
-    application_ref: {
-      slug: 'my-app',
-      version: null,
-      id: null
-    }
+    key: 'my-app.revision'
   })
 });
 
@@ -252,20 +248,18 @@ console.log(config);
 
 ```bash
 # Fetch the latest configuration from the staging environment
-curl -X POST "https://cloud.agenta.ai/api/variants/configs/fetch" \
+curl -X POST "https://cloud.agenta.ai/api/preview/applications/revisions/retrieve" \
   -H "Content-Type: application/json" \
-  -H "Authorization: Bearer YOUR_API_KEY" \
+  -H "Authorization: ApiKey YOUR_API_KEY" \
   -d '{
+    "application_ref": {
+      "slug": "my-app"
+    },
     "environment_ref": {
       "slug": "staging",
-      "version": 1,
-      "id": null
+      "version": 1
     },
-    "application_ref": {
-      "slug": "my-app",
-      "version": null,
-      "id": null
-    }
+    "key": "my-app.revision"
   }'
 ```
   </TabItem>
@@ -273,7 +267,7 @@ curl -X POST "https://cloud.agenta.ai/api/variants/configs/fetch" \
 
 ## Response Format
 
-The API response contains your prompt configuration under `params`:
+The SDK returns the configuration parameters directly as a dictionary. When using the REST API, the response contains the full revision data including configuration under `params` along with reference metadata:
 
 ```json
 {
@@ -303,7 +297,6 @@ The API response contains your prompt configuration under `params`:
   "url": "https://cloud.agenta.ai/services/completion",
   "application_ref": {
     "slug": "my-app-slug",
-    "version": null,
     "id": "..."
   },
   "variant_ref": {

--- a/docs/docs/prompt-engineering/integrating-prompts/03-proxy-calls.mdx
+++ b/docs/docs/prompt-engineering/integrating-prompts/03-proxy-calls.mdx
@@ -26,7 +26,7 @@ You can find the specific endpoint information to invoke your deployed prompt di
 
 ## Making a Proxy Call
 
-You can invoke your deployed prompt using REST API.
+You can invoke your deployed prompt using REST API. All invocations use the unified `/v0/invoke` endpoint.
 
 Here's how to call your deployed prompt using Python with the requests library:
 
@@ -36,16 +36,31 @@ import requests
 import json
 
 # Endpoint for the proxy service
-url = "https://cloud.agenta.ai/services/completion/run"
+url = "https://cloud.agenta.ai/services/completion/v0/invoke"
 
-# Parameters specifying the environment, application, and input variables
+# Parameters specifying the application, environment, and input variables
 params = {
-  "environment": "development",  # The environment (production, development, staging)
-  "app": "classification",       # Your application name
-  "inputs": {
-    "country": "France"          # Input variables required by your prompt
+  "data": {
+    "inputs": {
+      "country": "France"          # Input variables required by your prompt
+    }
+  },
+  "references": {
+    "application": {
+      "slug": "classification"     # Your application name
+    },
+    "environment": {
+      "slug": "development"        # The environment (production, development, staging)
+    }
+  },
+  "selector": {
+    "key": "classification.revision"  # Resolves the deployed revision for this app
   }
 }
+
+:::info Understanding the selector key
+When invoking via an environment, the `selector.key` tells the system which deployed revision to resolve. The format is `{app_slug}.revision` — for example, if your application slug is `classification`, the key is `classification.revision`. This key is only needed when using environment references; it is not required when invoking a specific variant and revision directly.
+:::
 
 # Required headers including your API key
 headers = {
@@ -61,20 +76,44 @@ data = response.json()
 print(json.dumps(data, indent=4))
 ```
 
+:::tip Invoking a specific variant
+To invoke a specific variant and version instead of an environment deployment, use `application_variant` and `application_revision` references instead of `environment`:
+
+```python
+params = {
+  "data": {
+    "inputs": {"country": "France"}
+  },
+  "references": {
+    "application": {"slug": "classification"},
+    "application_variant": {"slug": "default"},
+    "application_revision": {"version": "2"}
+  }
+}
+```
+:::
+
 ## Understanding the Response
 
 The proxy service returns a structured response with the following fields:
 
 ```json
 {
-    "version": "3.0",                                     // SDK version
-    "data": "The capital of France is Paris.",            // LLM output
-    "content_type": "text/plain",                         // Output format (text/plain or application/json)
-    "tree_id": "0ef1d6b7-84c3-4b8a-705b-ae5974e51954"    // Tree ID for observability
+    "version": "2025-07-14",                               // API version
+    "status": {                                             // Status information
+        "code": null,
+        "message": null,
+        "stacktrace": null
+    },
+    "trace_id": "0ef1d6b7-84c3-4b8a-705b-ae5974e51954",   // Trace ID for observability
+    "span_id": "a1b2c3d4e5f6",                             // Span ID for observability
+    "data": {
+        "outputs": "The capital of France is Paris."        // LLM output
+    }
 }
 ```
 
-The `tree_id` can be used to locate this specific request in the observability dashboard.
+The `trace_id` can be used to locate this specific request in the observability dashboard.
 
 ## Viewing Traces in the Observability Dashboard
 
@@ -95,7 +134,7 @@ The dashboard provides comprehensive insights into your LLM application's behavi
 - Model parameters used
 - Associated costs
 
-## Tracking sessions
+## Tracking Sessions
 
 For chat applications, you can group multiple requests into sessions using the `Baggage` header. This helps you track complete conversations across multiple requests.
 
@@ -107,7 +146,7 @@ session_id = "chat_session_123"
 user_id = "user-456"
 
 response = requests.post(
-    "https://cloud.agenta.ai/services/completion/run",
+    "https://cloud.agenta.ai/services/chat/v0/invoke",
     headers={
         "Content-Type": "application/json",
         "Authorization": f"ApiKey {os.environ['AGENTA_API_KEY']}",
@@ -115,13 +154,18 @@ response = requests.post(
         "Baggage": f"ag.session.id={session_id},ag.user.id={user_id}"
     },
     json={
-        "environment": "development",
-        "app": "chatbot",
-        "inputs": {
-            "message": "Hello"
-        }
+        "data": {
+            "inputs": {
+                "messages": [{"role": "user", "content": "Hello"}]
+            }
+        },
+        "references": {
+            "application": {"slug": "chatbot"},
+            "environment": {"slug": "development"}
+        },
+        "selector": {"key": "chatbot.revision"}
     }
 )
 ```
 
-All requests with the same session ID will be grouped together in the observability dashboard. You can also track users to see who is interacting with your application. 
+All requests with the same session ID will be grouped together in the observability dashboard. You can also track users to see who is interacting with your application.

--- a/docs/docs/prompt-engineering/integrating-prompts/03-proxy-calls.mdx
+++ b/docs/docs/prompt-engineering/integrating-prompts/03-proxy-calls.mdx
@@ -57,11 +57,13 @@ params = {
     "key": "classification.revision"  # Resolves the deployed revision for this app
   }
 }
+```
 
 :::info Understanding the selector key
 When invoking via an environment, the `selector.key` tells the system which deployed revision to resolve. The format is `{app_slug}.revision` — for example, if your application slug is `classification`, the key is `classification.revision`. This key is only needed when using environment references; it is not required when invoking a specific variant and revision directly.
 :::
 
+```python
 # Required headers including your API key
 headers = {
     "Content-Type": "application/json",    

--- a/docs/docs/prompt-engineering/integrating-prompts/05-github.mdx
+++ b/docs/docs/prompt-engineering/integrating-prompts/05-github.mdx
@@ -205,20 +205,17 @@ jobs:
         env:
           AGENTA_API_KEY: ${{ secrets.AGENTA_API_KEY }}
         run: |
-          curl -X POST "https://cloud.agenta.ai/api/variants/configs/fetch" \
+          curl -X POST "https://cloud.agenta.ai/api/preview/applications/revisions/retrieve" \
             -H "Content-Type: application/json" \
-            -H "Authorization: Bearer ${AGENTA_API_KEY}" \
+            -H "Authorization: ApiKey ${AGENTA_API_KEY}" \
             -d '{
               "application_ref": {
-                "slug": "your-app-slug",
-                "version": null,
-                "id": null
+                "slug": "your-app-slug"
               },
               "environment_ref": {
-                "slug": "production",
-                "version": null,
-                "id": null
-              }
+                "slug": "production"
+              },
+              "key": "your-app-slug.revision"
             }' > prompt-config.json
 
       - name: Create pull request if prompt changed

--- a/docs/docs/prompt-engineering/integrating-prompts/06-multimodal-content.mdx
+++ b/docs/docs/prompt-engineering/integrating-prompts/06-multimodal-content.mdx
@@ -103,64 +103,76 @@ When using `file_data`, also provide `filename` and `format` (the MIME type). Wh
 ### Example: sending an image
 
 ```bash
-curl -X POST "https://cloud.agenta.ai/services/chat/run" \
+curl -X POST "https://cloud.agenta.ai/services/chat/v0/invoke" \
   -H "Content-Type: application/json" \
   -H "Authorization: ApiKey YOUR_API_KEY" \
   -d '{
-    "environment": "production",
-    "app": "my-chat-app",
-    "inputs": {},
-    "messages": [
-      {
-        "role": "user",
-        "content": [
-          {"type": "text", "text": "What is in this image?"},
+    "data": {
+      "inputs": {
+        "messages": [
           {
-            "type": "image_url",
-            "image_url": {
-              "url": "data:image/png;base64,iVBORw0KGgoAAAANSUhEUgAAAAEAAAABCAYAAAAfFcSJAAAADUlEQVR42mNk+M9QDwADhgGAWjR9awAAAABJRU5ErkJggg==",
-              "detail": "auto"
-            }
+            "role": "user",
+            "content": [
+              {"type": "text", "text": "What is in this image?"},
+              {
+                "type": "image_url",
+                "image_url": {
+                  "url": "data:image/png;base64,iVBORw0KGgoAAAANSUhEUgAAAAEAAAABCAYAAAAfFcSJAAAADUlEQVR42mNk+M9QDwADhgGAWjR9awAAAABJRU5ErkJggg==",
+                  "detail": "auto"
+                }
+              }
+            ]
           }
         ]
       }
-    ]
+    },
+    "references": {
+      "application": {"slug": "my-chat-app"},
+      "environment": {"slug": "production"}
+    },
+    "selector": {"key": "my-chat-app.revision"}
   }'
 ```
 
 ### Example: sending both image and PDF
 
 ```bash
-curl -X POST "https://cloud.agenta.ai/services/chat/run" \
+curl -X POST "https://cloud.agenta.ai/services/chat/v0/invoke" \
   -H "Content-Type: application/json" \
   -H "Authorization: ApiKey YOUR_API_KEY" \
   -d '{
-    "environment": "production",
-    "app": "my-chat-app",
-    "inputs": {},
-    "messages": [
-      {
-        "role": "user",
-        "content": [
-          {"type": "text", "text": "Summarize this document and describe the attached image."},
+    "data": {
+      "inputs": {
+        "messages": [
           {
-            "type": "image_url",
-            "image_url": {
-              "url": "https://example.com/photo.jpg",
-              "detail": "high"
-            }
-          },
-          {
-            "type": "file",
-            "file": {
-              "file_data": "data:application/pdf;base64,JVBERi0xLjQK...",
-              "filename": "invoice.pdf",
-              "format": "application/pdf"
-            }
+            "role": "user",
+            "content": [
+              {"type": "text", "text": "Summarize this document and describe the attached image."},
+              {
+                "type": "image_url",
+                "image_url": {
+                  "url": "https://example.com/photo.jpg",
+                  "detail": "high"
+                }
+              },
+              {
+                "type": "file",
+                "file": {
+                  "file_data": "data:application/pdf;base64,JVBERi0xLjQK...",
+                  "filename": "invoice.pdf",
+                  "format": "application/pdf"
+                }
+              }
+            ]
           }
         ]
       }
-    ]
+    },
+    "references": {
+      "application": {"slug": "my-chat-app"},
+      "environment": {"slug": "production"}
+    },
+    "selector": {"key": "my-chat-app.revision"}
   }'
 ```
 
@@ -180,38 +192,44 @@ with open("report.pdf", "rb") as f:
     pdf_b64 = base64.b64encode(f.read()).decode("utf-8")
 
 response = requests.post(
-    "https://cloud.agenta.ai/services/chat/run",
+    "https://cloud.agenta.ai/services/chat/v0/invoke",
     headers={
         "Content-Type": "application/json",
         "Authorization": f"ApiKey {os.environ['AGENTA_API_KEY']}",
     },
     json={
-        "environment": "production",
-        "app": "my-chat-app",
-        "inputs": {},
-        "messages": [
-            {
-                "role": "user",
-                "content": [
-                    {"type": "text", "text": "Analyze this image and PDF."},
+        "data": {
+            "inputs": {
+                "messages": [
                     {
-                        "type": "image_url",
-                        "image_url": {
-                            "url": f"data:image/jpeg;base64,{image_b64}",
-                            "detail": "auto",
-                        },
-                    },
-                    {
-                        "type": "file",
-                        "file": {
-                            "file_data": f"data:application/pdf;base64,{pdf_b64}",
-                            "filename": "report.pdf",
-                            "format": "application/pdf",
-                        },
-                    },
+                        "role": "user",
+                        "content": [
+                            {"type": "text", "text": "Analyze this image and PDF."},
+                            {
+                                "type": "image_url",
+                                "image_url": {
+                                    "url": f"data:image/jpeg;base64,{image_b64}",
+                                    "detail": "auto",
+                                },
+                            },
+                            {
+                                "type": "file",
+                                "file": {
+                                    "file_data": f"data:application/pdf;base64,{pdf_b64}",
+                                    "filename": "report.pdf",
+                                    "format": "application/pdf",
+                                },
+                            },
+                        ],
+                    }
                 ],
-            }
-        ],
+            },
+        },
+        "references": {
+            "application": {"slug": "my-chat-app"},
+            "environment": {"slug": "production"},
+        },
+        "selector": {"key": "my-chat-app.revision"},
     },
 )
 
@@ -222,10 +240,13 @@ The response follows the same format as any other gateway call:
 
 ```json
 {
-    "version": "3.0",
-    "data": "The image shows a bar chart comparing...",
-    "content_type": "text/plain",
-    "tree_id": "0ef1d6b7-84c3-4b8a-705b-ae5974e51954"
+    "version": "2025-07-14",
+    "status": {"code": null, "message": null, "stacktrace": null},
+    "trace_id": "0ef1d6b7-84c3-4b8a-705b-ae5974e51954",
+    "span_id": "a1b2c3d4e5f6",
+    "data": {
+        "outputs": "The image shows a bar chart comparing..."
+    }
 }
 ```
 


### PR DESCRIPTION
## Summary
- Updates all documentation to reflect the v96.0 unified `/v0/invoke` endpoint, replacing the legacy `/generate`, `/generate_deployed`, `/test`, and `/run` endpoints
- Updates config fetch examples from `/api/variants/configs/fetch` to `/api/preview/applications/revisions/retrieve`
- Adds a changelog entry with a full migration guide (before/after examples for deployed invoke, chat, and draft testing)

## Files changed
- **Proxy calls doc** — new endpoint, request/response format, session tracking
- **Fetch prompt doc** — updated REST API endpoint and request shapes, added selector key info
- **Multimodal content doc** — updated all gateway examples
- **Concepts doc** — added environment key resolution explanation
- **Quick start docs (x2)** — updated JS/TS API examples
- **GitHub automations doc** — updated curl command
- **Changelog** — new v0.96.0 entry in `main.mdx` + detailed `unified-invoke-api.mdx` migration guide

## Test plan
- [x] Verify docs build successfully (`cd docs && npm run build`)
- [x] Review code examples for correctness against actual API behavior
- [x] Check all internal links resolve properly
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/agenta-ai/agenta/pull/4144" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open with Devin">
  </picture>
</a>
<!-- devin-review-badge-end -->
