### PR TITLE
(fix)[AGE-3731]: Deploy action from overview does nothing

### DIFF
--- a/web/oss/src/components/pages/overview/variants/VariantsOverview.tsx
+++ b/web/oss/src/components/pages/overview/variants/VariantsOverview.tsx
@@ -3,8 +3,10 @@ import {useCallback, useMemo} from "react"
 import {Rocket} from "@phosphor-icons/react"
 import {Button, Typography} from "antd"
 import clsx from "clsx"
+import {useSetAtom} from "jotai"
 import Link from "next/link"
 
+import {openDeployVariantModalAtom} from "@/oss/components/Playground/Components/Modals/DeployVariantModal/store/deployVariantModalStore"
 import type {RegistryRevisionRow} from "@/oss/components/VariantsComponents/store/registryStore"
 import type {RegistryColumnActions} from "@/oss/components/VariantsComponents/Table/assets/registryColumns"
 import RegistryTable from "@/oss/components/VariantsComponents/Table/RegistryTable"
@@ -18,6 +20,7 @@ const VariantsOverview = () => {
     const [, updateQuery] = useQuery()
     const {appURL} = useURL()
     const {goToPlayground} = usePlaygroundNavigation()
+    const openDeployVariantModal = useSetAtom(openDeployVariantModalAtom)
 
     const handleRowClick = useCallback(
         (record: RegistryRevisionRow) => {
@@ -40,12 +43,25 @@ const VariantsOverview = () => {
         [goToPlayground],
     )
 
+    const handleDeploy = useCallback(
+        (record: RegistryRevisionRow) => {
+            openDeployVariantModal({
+                parentVariantId: null,
+                revisionId: record.revisionId,
+                variantName: record.variantName,
+                revision: record.version ?? 0,
+            })
+        },
+        [openDeployVariantModal],
+    )
+
     const columnActions = useMemo<RegistryColumnActions>(
         () => ({
             handleOpenDetails: handleRowClick,
             handleOpenInPlayground,
+            handleDeploy,
         }),
-        [handleRowClick, handleOpenInPlayground],
+        [handleRowClick, handleOpenInPlayground, handleDeploy],
     )
 
     return (


### PR DESCRIPTION
## Summary
<!-- What changed? -->
<!-- Why was this change needed? -->
<!-- What problem does it solve? -->
<!-- For fixes, explain how the change addresses the root cause. -->
This PR fixes a bug where clicking "Deploy" from the three-dot menu on the Overview page did nothing — the handleDeploy action was missing from the VariantsOverview column actions

## Testing
### Verified locally
<!-- What did you run or verify locally? Be specific. -->

### Added or updated tests
<!-- What tests did you add or update? Include unit, integration, and end-to-end coverage when relevant. Write N/A if none. -->

### QA follow-up
<!-- What still needs QA? List flows, browsers, environments, edge cases, or data conditions to validate. Write N/A if none. -->
- On the Overview page, click the three-dot menu next to any prompt in "Recent Prompts" → "Deploy" should open the deploy modal with Dev/Staging/Prod options
- Complete a deploy from the modal and confirm it succeeds
- Verify the other three-dot actions still work: "View details", "Open in Playground", "Delete"
- Confirm deploy from the full Variants page still works (no regression)

## Demo
<!-- Required for UI changes. Add screenshots, GIFs, or a short video. -->
<!-- If this is not a UI change, write N/A. -->
<img width="1154" height="664" alt="Screenshot 2026-04-16 at 10 53 52 AM" src="https://github.com/user-attachments/assets/ef9b1618-f4d3-4cc3-9740-6674fe545648" />


## Checklist
- [x] I have included a video or screen recording for UI changes, or marked Demo as N/A
- [x] Relevant tests pass locally
- [x] Relevant linting and formatting pass locally
- [x] I have signed the CLA, or I will sign it when the bot prompts me

## Contributor Resources
- [Contributing guide](https://agenta.ai/docs/contributing/overview)
- [Creating your first PR](https://agenta.ai/docs/contributing/first-pr)
- [Development mode](https://agenta.ai/docs/contributing/guides/development-mode)
- [Testing](https://agenta.ai/docs/contributing/guides/testing)
- [Formatting and linting](https://agenta.ai/docs/contributing/guides/formatting-and-linting)
- [Slack support](https://join.slack.com/t/agenta-hq/shared_invite/zt-37pnbp5s6-mbBrPL863d_oLB61GSNFjw)
