### PR TITLE
[fix] Mislabeled annotations

### DIFF
--- a/api/oss/src/core/annotations/service.py
+++ b/api/oss/src/core/annotations/service.py
@@ -195,7 +195,7 @@ class AnnotationsService:
             project_id=project_id,
             user_id=user_id,
             #
-            name=simple_evaluator.name if simple_evaluator else None,
+            name=simple_evaluator.slug if simple_evaluator else None,
             #
             flags=annotation_flags,
             tags=annotation_create.tags,

--- a/api/oss/src/core/evaluations/service.py
+++ b/api/oss/src/core/evaluations/service.py
@@ -156,6 +156,32 @@ def _first_reference_id(
     return None
 
 
+def _is_invocation_query(data: Any) -> bool:
+    """Live evaluations require the query filter to target invocation traces.
+
+    Returns True only when the query's filtering contains a top-level
+    condition with field="trace_type", operator="is", value="invocation".
+    """
+    filtering = getattr(data, "filtering", None)
+    if filtering is None:
+        return False
+
+    for condition in filtering.conditions or []:
+        field = getattr(condition, "field", None)
+        if field != "trace_type":
+            continue
+
+        operator = getattr(condition, "operator", None)
+        if operator != "is":
+            continue
+
+        value = getattr(condition, "value", None)
+        if value == "invocation":
+            return True
+
+    return False
+
+
 class EvaluationsService:
     def __init__(
         self,
@@ -209,6 +235,22 @@ class EvaluationsService:
             user_id = run.created_by_id
 
             try:
+                if not await self._is_live_run_valid(
+                    project_id=project_id,
+                    run=run,
+                ):
+                    log.warning(
+                        "[LIVE] Closing invalid live run (null data or non-invocation trace_type).",
+                        project_id=project_id,
+                        run_id=run.id,
+                    )
+                    await self._close_live_run(
+                        project_id=project_id,
+                        user_id=user_id,
+                        run=run,
+                    )
+                    continue
+
                 log.info(
                     "[LIVE] Dispatching...",
                     project_id=project_id,
@@ -238,6 +280,71 @@ class EvaluationsService:
                 log.error(f"[LIVE] Error refreshing run {run.id}: {e}", exc_info=True)
 
         return True
+
+    async def _is_live_run_valid(
+        self,
+        *,
+        project_id: UUID,
+        run: EvaluationRun,
+    ) -> bool:
+        """Every query step must reference a revision with data targeting invocation traces."""
+        if not run.data or not run.data.steps:
+            return False
+
+        query_revision_ids: List[UUID] = []
+        for step in run.data.steps:
+            query_ref = (step.references or {}).get("query_revision")
+            if isinstance(query_ref, Reference) and query_ref.id:
+                query_revision_ids.append(query_ref.id)
+
+        if not query_revision_ids:
+            return False
+
+        for query_revision_id in query_revision_ids:
+            query_revision = await self.queries_service.fetch_query_revision(
+                project_id=project_id,
+                #
+                query_revision_ref=Reference(id=query_revision_id),
+            )
+
+            if not query_revision or not query_revision.data:
+                return False
+
+            if not _is_invocation_query(query_revision.data):
+                return False
+
+        return True
+
+    async def _close_live_run(
+        self,
+        *,
+        project_id: UUID,
+        user_id: UUID,
+        run: EvaluationRun,
+    ) -> None:
+        flags = run.flags.model_copy() if run.flags else EvaluationRunFlags()
+        flags.is_active = False
+        flags.is_closed = True
+
+        await self.edit_run(
+            project_id=project_id,
+            user_id=user_id,
+            #
+            run=EvaluationRunEdit(
+                id=run.id,
+                #
+                name=run.name,
+                description=run.description,
+                #
+                flags=flags,
+                tags=run.tags,
+                meta=run.meta,
+                #
+                status=run.status,
+                #
+                data=run.data,
+            ),
+        )
 
     async def fetch_live_runs(
         self,
@@ -1706,6 +1813,8 @@ class SimpleEvaluationsService:
                 evaluator_steps=evaluation.data.evaluator_steps,
                 #
                 repeats=evaluation.data.repeats,
+                #
+                is_live=evaluation.flags.is_live,
             )
 
             if not run_data:
@@ -1882,6 +1991,8 @@ class SimpleEvaluationsService:
                 evaluator_steps=evaluation.data.evaluator_steps,
                 #
                 repeats=_evaluation.data.repeats,
+                #
+                is_live=(_evaluation.flags.is_live if _evaluation.flags else None),
             )
 
             run_edit = EvaluationRunEdit(
@@ -2351,6 +2462,8 @@ class SimpleEvaluationsService:
         evaluator_steps: Optional[Target] = None,
         #
         repeats: Optional[int] = None,
+        #
+        is_live: Optional[bool] = None,
     ) -> Optional[EvaluationRunData]:
         # IMPLICIT FLAG: is_multivariate=False
         # IMPLICIT FLAG: all_inputs=True
@@ -2381,6 +2494,20 @@ class SimpleEvaluationsService:
                 if not query_revision or not query_revision.slug:
                     log.warning(
                         "[EVAL] [run] [make] [failure] could not find query revision",
+                        id=query_revision_ref.id,
+                    )
+                    return None
+
+                if is_live and not query_revision.data:
+                    log.warning(
+                        "[EVAL] [run] [make] [failure] live evaluation requires query with data",
+                        id=query_revision_ref.id,
+                    )
+                    return None
+
+                if is_live and not _is_invocation_query(query_revision.data):
+                    log.warning(
+                        "[EVAL] [run] [make] [failure] live evaluation requires trace_type=invocation",
                         id=query_revision_ref.id,
                     )
                     return None

--- a/api/oss/src/core/queries/service.py
+++ b/api/oss/src/core/queries/service.py
@@ -983,7 +983,36 @@ class SimpleQueriesService:
             return None
 
         # ----------------------------------------------------------------------
-        # Query revision
+        # Query revision (placeholder v0 — first revision has its fields nulled)
+        # ----------------------------------------------------------------------
+        placeholder_revision_slug = uuid4().hex[-12:]
+
+        _query_revision_create = QueryRevisionCreate(
+            slug=placeholder_revision_slug,
+            #
+            name=simple_query_create.name,
+            description=simple_query_create.description,
+            #
+            flags=simple_query_create.flags,
+            tags=simple_query_create.tags,
+            meta=simple_query_create.meta,
+            #
+            query_id=query.id,
+            query_variant_id=query_variant.id,
+        )
+
+        placeholder_revision = await self.queries_service.create_query_revision(
+            project_id=project_id,
+            user_id=user_id,
+            #
+            query_revision_create=_query_revision_create,
+        )
+
+        if placeholder_revision is None:
+            return None
+
+        # ----------------------------------------------------------------------
+        # Query revision (v1 — carries the actual data)
         # ----------------------------------------------------------------------
         query_revision_slug = uuid4().hex[-12:]
 

--- a/api/oss/src/core/tracing/service.py
+++ b/api/oss/src/core/tracing/service.py
@@ -1007,17 +1007,17 @@ class SimpleTracesService:
 
         references.evaluator = Reference(
             id=evaluator_revision.evaluator_id,
-            slug=(references.evaluator.slug if references.evaluator else None)
-            or (evaluator.slug if evaluator else None),
+            slug=(evaluator.slug if evaluator else None)
+            or (references.evaluator.slug if references.evaluator else None),
         )
         references.evaluator_variant = Reference(
             id=evaluator_revision.evaluator_variant_id,
-            slug=(
+            slug=(evaluator_variant.slug if evaluator_variant else None)
+            or (
                 references.evaluator_variant.slug
                 if references.evaluator_variant
                 else None
-            )
-            or (evaluator_variant.slug if evaluator_variant else None),
+            ),
         )
         references.evaluator_revision = Reference(
             id=evaluator_revision.id,
@@ -1061,6 +1061,12 @@ class SimpleTracesService:
             references=_references,
         )
 
+        span_name = (
+            references.evaluator.slug
+            if references.evaluator and references.evaluator.slug
+            else "annotation"
+        )
+
         otel_links = await self.tracing_service.create_trace(
             organization_id=organization_id,
             project_id=project_id,
@@ -1070,6 +1076,7 @@ class SimpleTracesService:
                     trace_id=trace_id,
                     span_id=span_id,
                     span_type=SpanType.TASK,
+                    span_name=span_name,
                     attributes=_attributes,
                     links=_links,
                 )

--- a/web/oss/src/components/EvalRunDetails/components/Page.tsx
+++ b/web/oss/src/components/EvalRunDetails/components/Page.tsx
@@ -49,7 +49,7 @@ const EvalRunPreviewPage = ({runId, evaluationType, projectId = null}: EvalRunPr
         const typeMap: Record<string, {label: string; kind: string}> = {
             auto: {label: "Auto Evals", kind: "auto"},
             human: {label: "Human Evals", kind: "human"},
-            online: {label: "Online Evals", kind: "online"},
+            online: {label: "Live Evals", kind: "online"},
         }
         const config = typeMap[evaluationType] ?? {label: "Evaluations", kind: "auto"}
         return {

--- a/web/oss/src/components/EvalRunDetails/components/views/SingleScenarioViewerPOC/ScenarioAnnotationPanel/index.tsx
+++ b/web/oss/src/components/EvalRunDetails/components/views/SingleScenarioViewerPOC/ScenarioAnnotationPanel/index.tsx
@@ -210,7 +210,7 @@ const ScenarioAnnotationPanel = ({
                 if (!hasValue) continue
 
                 const references: Record<string, unknown> = {
-                    evaluator: {id: evaluator.id, slug: evaluator.slug},
+                    evaluator: {id: evaluator.id},
                 }
                 if (testsetId) references.testset = {id: testsetId}
                 if (testcaseId) references.testcase = {id: testcaseId}

--- a/web/oss/src/components/SharedDrawers/AnnotateDrawer/assets/transforms.ts
+++ b/web/oss/src/components/SharedDrawers/AnnotateDrawer/assets/transforms.ts
@@ -470,7 +470,6 @@ export const generateNewAnnotationPayloadData = ({
         const references: Record<string, any> = {
             evaluator: {
                 id: evaluator.id,
-                slug: evaluator.slug,
             },
         }
         if (testsetId) references.testset = {id: testsetId}

--- a/web/oss/src/components/pages/evaluations/EvaluationsView.tsx
+++ b/web/oss/src/components/pages/evaluations/EvaluationsView.tsx
@@ -37,7 +37,7 @@ const PROJECT_TAB_ITEMS: {key: AppTabKey; label: string}[] = [
     {key: "all", label: "All Evals"},
     {key: "auto", label: "Auto Evals"},
     {key: "human", label: "Human Evals"},
-    {key: "online", label: "Online Evals"},
+    {key: "online", label: "Live Evals"},
     {key: "custom", label: "SDK Evals"},
 ]
 

--- a/web/oss/src/pages/w/[workspace_id]/p/[project_id]/apps/[app_id]/overview/index.tsx
+++ b/web/oss/src/pages/w/[workspace_id]/p/[project_id]/apps/[app_id]/overview/index.tsx
@@ -2,7 +2,7 @@ import {memo, useState} from "react"
 
 import {PageLayout} from "@agenta/ui"
 import {MoreOutlined} from "@ant-design/icons"
-import {PencilSimple, Trash} from "@phosphor-icons/react"
+import {Copy, PencilSimple, Trash} from "@phosphor-icons/react"
 // TEMPORARY: Disabling name editing
 // import {PencilLine} from "@phosphor-icons/react"
 import {Button, Dropdown, Space, Typography} from "antd"
@@ -15,6 +15,7 @@ import {openDeleteAppModalAtom} from "@/oss/components/pages/app-management/moda
 // import {openEditAppModalAtom} from "@/oss/components/pages/app-management/modals/EditAppModal/store/editAppModalStore"
 import DeploymentOverview from "@/oss/components/pages/overview/deployments/DeploymentOverview"
 import VariantsOverview from "@/oss/components/pages/overview/variants/VariantsOverview"
+import {copyToClipboard} from "@/oss/lib/helpers/copyToClipboard"
 import {useAppsData} from "@/oss/state/app"
 
 const CustomWorkflowHistory: any = dynamic(
@@ -78,6 +79,12 @@ const AppDetailsSection = memo(() => {
                                       //     onClick: () => openEditAppModal(currentApp!),
                                       // },
                                   ]),
+                            {
+                                key: "copy_id",
+                                label: "Copy ID",
+                                icon: <Copy size={16} />,
+                                onClick: () => copyToClipboard(currentApp!.id),
+                            },
                             {
                                 key: "delete_app",
                                 label: "Delete",

--- a/web/packages/agenta-annotation/src/state/controllers/annotationFormController.ts
+++ b/web/packages/agenta-annotation/src/state/controllers/annotationFormController.ts
@@ -1488,7 +1488,6 @@ const submitAnnotationsAtom = atom(null, async (get, set, payload: SubmitAnnotat
                         references: {
                             evaluator: {
                                 id: evalWorkflowId,
-                                slug: evaluator.slug ?? undefined,
                             },
                             ...(stepRefs?.evaluator_revision?.id
                                 ? {evaluator_revision: stepRefs.evaluator_revision}
@@ -1526,7 +1525,6 @@ const submitAnnotationsAtom = atom(null, async (get, set, payload: SubmitAnnotat
                         references: {
                             evaluator: {
                                 id: evalWorkflowId,
-                                slug: evaluator.slug ?? undefined,
                             },
                             ...(stepRefs?.evaluator_revision?.id
                                 ? {evaluator_revision: stepRefs.evaluator_revision}


### PR DESCRIPTION
## What changed
- Add 'Copy ID' to burger menu in prompt page.
- Fix random slug in human feedback in both the observability drawer and the annotation queue page.
- Fix some 'Live'/'Online' copy in web.
- Fix corrupted queries and live evaluations.