### PR TITLE
fix: Add to testset drawer freez when adding large dataset

### DIFF
--- a/web/oss/src/components/SharedDrawers/AddToTestsetDrawer/TestsetDrawer.tsx
+++ b/web/oss/src/components/SharedDrawers/AddToTestsetDrawer/TestsetDrawer.tsx
@@ -1,4 +1,4 @@
-import {useCallback, useEffect, useRef, useState} from "react"
+import {useCallback, useEffect, useState} from "react"
 
 import {WarningCircle} from "@phosphor-icons/react"
 import {Button, Input, Typography} from "antd"
@@ -58,28 +58,6 @@ const TestsetDrawer = ({open, spanIds, onClose, initialPath = "ag.data"}: Testse
             initializeWithSpanIds(spanIds)
         }
     }, [spanIds, initializeWithSpanIds])
-
-    // Track if trace data has loaded to trigger entity sync
-    // When trace data entities finish loading (have non-empty data), sync local entities
-    const hasTraceDataLoaded = useRef(false)
-    useEffect(() => {
-        // Check if trace data has actually loaded (has non-empty data objects)
-        const hasData = drawer.traceData.some((t) => t.data && Object.keys(t.data).length > 0)
-
-        // If we haven't synced yet AND data has now loaded AND we have a revision selected
-        if (!hasTraceDataLoaded.current && hasData && drawer.selectedRevisionId) {
-            hasTraceDataLoaded.current = true
-            // Trigger entity sync by calling onNewColumnBlur which updates local entities
-            // with the now-loaded trace data
-            console.log("[TestsetDrawer] Trace data loaded, syncing local entities")
-            drawer.onNewColumnBlur()
-        }
-
-        // Reset the flag when drawer closes
-        if (!open) {
-            hasTraceDataLoaded.current = false
-        }
-    }, [drawer.traceData, drawer.selectedRevisionId, drawer.onNewColumnBlur, open])
 
     const elemRef = useResizeObserver<HTMLDivElement>((rect) => {
         drawer.setIsDrawerExtended(rect.width > 640)

--- a/web/oss/src/components/SharedDrawers/AddToTestsetDrawer/assets/constants.ts
+++ b/web/oss/src/components/SharedDrawers/AddToTestsetDrawer/assets/constants.ts
@@ -1,0 +1,3 @@
+export const PREVIEW_ROW_LIMIT = 5
+export const PREVIEW_ROW_HARD_LIMIT = 20
+export const MAX_TRACE_ANALYSIS_SAMPLE_SIZE = 50

--- a/web/oss/src/components/SharedDrawers/AddToTestsetDrawer/atoms/drawerState.ts
+++ b/web/oss/src/components/SharedDrawers/AddToTestsetDrawer/atoms/drawerState.ts
@@ -14,6 +14,7 @@ import {
     selectedRevisionIdAtom as sharedSelectedRevisionIdAtom,
 } from "@/oss/state/testsetSelection"
 
+import {MAX_TRACE_ANALYSIS_SAMPLE_SIZE} from "../assets/constants"
 import {createMappingId, type Mapping, type TestsetTraceData} from "../assets/types"
 
 import {
@@ -457,15 +458,7 @@ export const updateEditedTraceAtom = atom(
         const queryState = get(traceSpanMolecule.selectors.query(spanId))
         const serverState = queryState.data
 
-        console.log("[updateEditedTraceAtom] Called", {
-            hasUpdatedData: !!updatedData,
-            spanId,
-            hasEntity: !!currentEntity,
-            hasGetValueAtPath: !!getValueAtPath,
-        })
-
         if (!updatedData || !spanId || !currentEntity) {
-            console.log("[updateEditedTraceAtom] Early return - no data or entity")
             return {success: false, error: "No data to update"}
         }
 
@@ -481,10 +474,6 @@ export const updateEditedTraceAtom = atom(
             // Extract the data property (editor wraps in {data: ...})
             const newAgData = (parsedUpdatedData as {data: Record<string, any>}).data
 
-            console.log("[updateEditedTraceAtom] Parsed data", {
-                newAgData,
-            })
-
             // Get current and original ag.data for comparison
             const currentAgData = extractAgData(currentEntity)
             const originalAgData = serverState ? extractAgData(serverState) : currentAgData
@@ -498,21 +487,13 @@ export const updateEditedTraceAtom = atom(
             const currentString = JSON.stringify(normalizedCurrent)
             const originalString = JSON.stringify(normalizedOriginal)
 
-            console.log("[updateEditedTraceAtom] Comparing data", {
-                updatedPreview: updatedString.slice(0, 100),
-                currentPreview: currentString.slice(0, 100),
-                isEqual: updatedString === currentString,
-            })
-
             // No change
             if (updatedString === currentString) {
-                console.log("[updateEditedTraceAtom] No changes detected")
                 return {success: false, error: "No changes detected"}
             }
 
             // If reverting to original, discard draft instead
             if (updatedString === originalString) {
-                console.log("[updateEditedTraceAtom] Reverting to original - discarding draft")
                 set(traceSpanMolecule.actions.discard, spanId)
             } else {
                 // Update entity draft with new ag.data
@@ -522,7 +503,6 @@ export const updateEditedTraceAtom = atom(
                     "ag.data": newAgData,
                 }
 
-                console.log("[updateEditedTraceAtom] Setting entity draft", {spanId})
                 set(traceSpanMolecule.actions.update, spanId, newAttributes)
             }
 
@@ -531,10 +511,6 @@ export const updateEditedTraceAtom = atom(
                 const mappings = get(mappingDataAtom)
                 const traceData = get(traceDataFromEntitiesAtom)
 
-                console.log("[updateEditedTraceAtom] Updating local entities", {
-                    mappingsCount: mappings.length,
-                })
-
                 // eslint-disable-next-line @typescript-eslint/no-require-imports
                 const {updateAllLocalEntitiesAtom} = require("./localEntities")
                 set(updateAllLocalEntitiesAtom, {
@@ -542,7 +518,6 @@ export const updateEditedTraceAtom = atom(
                     mappings,
                     getValueAtPath,
                 })
-                console.log("[updateEditedTraceAtom] Local entities updated")
             }
 
             return {success: true}
@@ -583,8 +558,6 @@ export const revertEditedTraceAtom = atom(
 
         // Discard the entity draft to revert to server state
         set(traceSpanMolecule.actions.discard, spanId)
-
-        console.log("[revertEditedTraceAtom] Discarded draft for span", spanId)
 
         // Update local entities to reflect the reverted data
         if (getValueAtPath) {
@@ -644,9 +617,10 @@ export const spanByIdAtomFamily = traceSpanMolecule.selectors.data
  */
 export const allTracePathsAtom = atom((get) => {
     const traceData = get(traceDataFromEntitiesAtom)
+    const sampledTraceData = traceData.slice(0, MAX_TRACE_ANALYSIS_SAMPLE_SIZE)
 
     const uniquePaths = new Set<string>()
-    traceData.forEach((traceItem) => {
+    sampledTraceData.forEach((traceItem) => {
         // Include object paths (true) so users can manually select them
         const traceKeys = collectKeyPaths(traceItem?.data, "data", true)
         traceKeys.forEach((key) => uniquePaths.add(key))
@@ -671,9 +645,10 @@ export const allTracePathsSelectOptionsAtom = atom((get) => {
  */
 export const leafTracePathsAtom = atom((get) => {
     const traceData = get(traceDataFromEntitiesAtom)
+    const sampledTraceData = traceData.slice(0, MAX_TRACE_ANALYSIS_SAMPLE_SIZE)
 
     const uniquePaths = new Set<string>()
-    traceData.forEach((traceItem) => {
+    sampledTraceData.forEach((traceItem) => {
         // Don't include object paths (false) for auto-mapping
         const traceKeys = collectKeyPaths(traceItem?.data, "data", false)
         traceKeys.forEach((key) => uniquePaths.add(key))
@@ -941,11 +916,13 @@ export const executeAutoMappingAtom = atom(null, (get, set) => {
  */
 export const hasDifferentStructureAtom = atom((get) => {
     const traceData = get(traceDataFromEntitiesAtom)
-    if (traceData.length <= 1) return false
+    const sampledTraceData = traceData.slice(0, MAX_TRACE_ANALYSIS_SAMPLE_SIZE)
 
-    const referencePaths = collectKeyPaths(traceData[0].data).sort().join(",")
-    for (let i = 1; i < traceData.length; i++) {
-        const currentPaths = collectKeyPaths(traceData[i].data).sort().join(",")
+    if (sampledTraceData.length <= 1) return false
+
+    const referencePaths = collectKeyPaths(sampledTraceData[0].data).sort().join(",")
+    for (let i = 1; i < sampledTraceData.length; i++) {
+        const currentPaths = collectKeyPaths(sampledTraceData[i].data).sort().join(",")
         if (currentPaths !== referencePaths) {
             return true
         }

--- a/web/oss/src/components/SharedDrawers/AddToTestsetDrawer/atoms/localEntities.ts
+++ b/web/oss/src/components/SharedDrawers/AddToTestsetDrawer/atoms/localEntities.ts
@@ -14,6 +14,7 @@ import {
 import {newEntityIdsAtom} from "@/oss/state/entities/testcase/testcaseEntity"
 import {currentRevisionIdAtom} from "@/oss/state/entities/testset"
 
+import {PREVIEW_ROW_HARD_LIMIT, PREVIEW_ROW_LIMIT} from "../assets/constants"
 import type {TestsetTraceData} from "../assets/types"
 
 import {localColumnsAtom, selectedRevisionIdAtom as drawerRevisionIdAtom} from "./drawerState"
@@ -74,13 +75,18 @@ export const createLocalEntitiesAtom = atom(
             mappings,
             getValueAtPath,
             isNewTestset = false,
+            previewLimit = PREVIEW_ROW_LIMIT,
         }: {
             traceData: TestsetTraceData[]
             mappings: {data: string; column: string; newColumn?: string}[]
             getValueAtPath: (obj: any, path: string) => any
             isNewTestset?: boolean
+            previewLimit?: number
         },
     ) => {
+        const effectivePreviewLimit = Math.min(previewLimit, PREVIEW_ROW_HARD_LIMIT)
+        const previewTraceData = traceData.slice(0, effectivePreviewLimit)
+
         // Set revision context first
         const revisionId = get(drawerRevisionIdAtom)
         const alreadyCreatedFor = get(localEntitiesCreatedForRevisionAtom)
@@ -146,7 +152,7 @@ export const createLocalEntitiesAtom = atom(
         }
 
         // Build rows array from trace data and mappings
-        const rows: Record<string, unknown>[] = traceData.map((trace) => {
+        const rows: Record<string, unknown>[] = previewTraceData.map((trace) => {
             const mappedData: Record<string, unknown> = {}
             for (const mapping of mappings) {
                 const targetColumn =
@@ -174,7 +180,7 @@ export const createLocalEntitiesAtom = atom(
 
         // Map trace keys to created entity IDs (in same order as input)
         const newMap = new Map<string, string>()
-        traceData.forEach((trace, index) => {
+        previewTraceData.forEach((trace, index) => {
             if (index < result.ids.length) {
                 newMap.set(trace.key, result.ids[index])
             }
@@ -241,15 +247,7 @@ export const updateAllLocalEntitiesAtom = atom(
         const entityMap = get(localEntityMapAtom)
         const revisionId = get(drawerRevisionIdAtom)
 
-        console.log("[updateAllLocalEntitiesAtom] Called", {
-            traceDataLength: traceData.length,
-            mappingsCount: mappings.length,
-            entityMapSize: entityMap.size,
-            revisionId,
-        })
-
         if (entityMap.size === 0) {
-            console.log("[updateAllLocalEntitiesAtom] No entities in map, returning early")
             return
         }
 
@@ -307,11 +305,13 @@ export const updateAllLocalEntitiesAtom = atom(
             }
         }
 
-        // Update each local entity based on its trace data and mappings
-        traceData.forEach((trace) => {
-            const entityId = entityMap.get(trace.key)
-            if (!entityId) {
-                return
+        const traceByKey = new Map(traceData.map((trace) => [trace.key, trace]))
+
+        // Update only preview entities. Full selected trace data is preserved for save.
+        for (const [traceKey, entityId] of entityMap.entries()) {
+            const trace = traceByKey.get(traceKey)
+            if (!trace) {
+                continue
             }
 
             // Get current entity to find columns to remove
@@ -340,27 +340,14 @@ export const updateAllLocalEntitiesAtom = atom(
                 if (!targetColumn) continue
 
                 const value = getValueAtPath(trace, mapping.data)
-                console.log("[updateAllLocalEntitiesAtom] Mapping extraction", {
-                    mappingPath: mapping.data,
-                    targetColumn,
-                    traceDataKeys: Object.keys(trace.data || {}),
-                    traceDataPreview: JSON.stringify(trace.data).slice(0, 200),
-                    extractedValue: value,
-                    valueType: typeof value,
-                })
                 // Preserve objects/arrays as-is, only convert null/undefined to empty string
                 updates[targetColumn] = value === undefined || value === null ? "" : value
             }
 
             if (Object.keys(updates).length > 0) {
-                console.log("[updateAllLocalEntitiesAtom] Updating entity", {
-                    entityId,
-                    traceKey: trace.key,
-                    updates,
-                })
                 set(testcase.actions.update, entityId, updates)
             }
-        })
+        }
     },
 )
 
@@ -417,9 +404,17 @@ export const selectRevisionAtom = atom(
             mappings: {data: string; column: string; newColumn?: string}[]
             getValueAtPath: (obj: any, path: string) => any
             isNewTestset?: boolean
+            previewLimit?: number
         },
     ) => {
-        const {revisionId, traceData, mappings, getValueAtPath, isNewTestset = false} = params
+        const {
+            revisionId,
+            traceData,
+            mappings,
+            getValueAtPath,
+            isNewTestset = false,
+            previewLimit = PREVIEW_ROW_LIMIT,
+        } = params
 
         // Validate inputs - allow "draft" for new testsets
         if (!revisionId) {
@@ -517,7 +512,9 @@ export const selectRevisionAtom = atom(
 
         // === STEP 5: Create local entities via controller ===
         // Build rows array from trace data and mappings
-        const rows: Record<string, unknown>[] = traceData.map((trace) => {
+        const effectivePreviewLimit = Math.min(previewLimit, PREVIEW_ROW_HARD_LIMIT)
+        const previewTraceData = traceData.slice(0, effectivePreviewLimit)
+        const rows: Record<string, unknown>[] = previewTraceData.map((trace) => {
             const mappedData: Record<string, unknown> = {}
             for (const mapping of mappings) {
                 const targetColumn =
@@ -528,14 +525,6 @@ export const selectRevisionAtom = atom(
                 if (!targetColumn) continue
 
                 const value = getValueAtPath(trace, mapping.data)
-                console.log("[selectRevisionAtom] Mapping extraction", {
-                    mappingPath: mapping.data,
-                    targetColumn,
-                    traceDataKeys: Object.keys(trace.data || {}),
-                    traceDataPreview: JSON.stringify(trace.data).slice(0, 200),
-                    extractedValue: value,
-                    valueType: typeof value,
-                })
                 // Preserve objects/arrays as-is, only convert null/undefined to empty string
                 mappedData[targetColumn] = value === undefined || value === null ? "" : value
             }
@@ -553,7 +542,7 @@ export const selectRevisionAtom = atom(
 
         // Map trace keys to created entity IDs (in same order as input)
         const newMap = new Map<string, string>()
-        traceData.forEach((trace, index) => {
+        previewTraceData.forEach((trace, index) => {
             if (index < result.ids.length) {
                 newMap.set(trace.key, result.ids[index])
             }

--- a/web/oss/src/components/SharedDrawers/AddToTestsetDrawer/components/PreviewSection.tsx
+++ b/web/oss/src/components/SharedDrawers/AddToTestsetDrawer/components/PreviewSection.tsx
@@ -1,3 +1,5 @@
+import {useMemo} from "react"
+
 import {Typography} from "antd"
 
 import {useRowHeight} from "@/oss/components/InfiniteVirtualTable"
@@ -7,6 +9,8 @@ import {
     testcaseRowHeightAtom,
     TESTCASE_ROW_HEIGHT_CONFIG,
 } from "@/oss/components/TestcasesTableNew/state/rowHeight"
+
+import {PREVIEW_ROW_LIMIT} from "../assets/constants"
 
 interface PreviewSectionProps {
     selectedRevisionId: string
@@ -27,6 +31,10 @@ export function PreviewSection({
         skipEmptyRevisionInit: true,
     })
     const rowHeight = useRowHeight(testcaseRowHeightAtom, TESTCASE_ROW_HEIGHT_CONFIG)
+    const previewRows = useMemo(
+        () => previewTable.rowRefs.filter((row) => row.__isNew).slice(0, PREVIEW_ROW_LIMIT),
+        [previewTable.rowRefs],
+    )
 
     const title = testcaseCount > 1 ? "4. Preview Testcases" : "4. Preview Testcase"
 
@@ -58,7 +66,8 @@ export function PreviewSection({
                             autoHeight={false}
                             disableDeleteAction={true}
                             scopeIdPrefix="drawer-preview"
-                            maxRows={5}
+                            maxRows={PREVIEW_ROW_LIMIT}
+                            dataSource={previewRows}
                         />
                     ) : (
                         <div className="py-4 px-3 bg-gray-50 rounded-md border border-dashed border-gray-200 text-center">

--- a/web/oss/src/components/SharedDrawers/AddToTestsetDrawer/hooks/useSaveTestset.ts
+++ b/web/oss/src/components/SharedDrawers/AddToTestsetDrawer/hooks/useSaveTestset.ts
@@ -8,8 +8,12 @@ import {
 import {message} from "@agenta/ui/app-message"
 import {useAtom, useAtomValue, useSetAtom} from "jotai"
 
-import {createNewTestset} from "@/oss/services/testsets/api"
-import {currentColumnsAtom, saveTestsetAtom} from "@/oss/state/entities/testcase"
+import {
+    createNewTestset,
+    patchTestsetRevision,
+    type TestsetRevisionDelta,
+} from "@/oss/services/testsets/api"
+import {currentColumnsAtom} from "@/oss/state/entities/testcase"
 import {
     fetchRevisionsList,
     invalidateRevisionsListCache as invalidateOssRevisionsListCache,
@@ -72,8 +76,6 @@ export function useSaveTestset() {
     const mappingData = useAtomValue(mappingDataAtom)
     const currentColumns = useAtomValue(currentColumnsAtom)
 
-    // Entity mutations
-    const executeSaveTestset = useSetAtom(saveTestsetAtom)
     const convertTraceData = useSetAtom(convertTraceDataAtom)
 
     // Revision select setters
@@ -185,21 +187,66 @@ export function useSaveTestset() {
                         return {success: false, error: "Missing testset information"}
                     }
 
-                    // NOTE: We don't call appendTestcasesAtom here because local entities
-                    // are already created by selectRevisionAtom when the user selects a revision.
-                    // Those entities are in newEntityIdsAtom and will be picked up by saveTestsetAtom.
-                    // Calling appendTestcasesAtom would create duplicates because its deduplication
-                    // compares JSON.stringify of rows which may have different column sets.
+                    const mappedColumns = Array.from(
+                        new Set(
+                            mappingData
+                                .map((mapping) =>
+                                    mapping.column === "create" || !mapping.column
+                                        ? mapping.newColumn
+                                        : mapping.column,
+                                )
+                                .filter((column): column is string => !!column),
+                        ),
+                    )
 
-                    // Save via entity mutation
-                    const result = await executeSaveTestset({
-                        projectId,
-                        testsetId: testset.id,
-                        revisionId: selectedRevisionId,
-                        commitMessage: commitMessage || undefined,
-                    })
+                    const rowsToAdd = convertTraceData({
+                        traceData,
+                        mappings: mappingData,
+                        columns: mappedColumns,
+                    }).map((data) => ({data}))
 
-                    if (result.success && result.newRevisionId) {
+                    const newColumnNames = new Set(
+                        localColumns
+                            .filter((column) => column.isNew)
+                            .map((column) => column.column)
+                            .filter(Boolean),
+                    )
+
+                    const operations: TestsetRevisionDelta = {
+                        rows: {
+                            add: rowsToAdd,
+                        },
+                    }
+
+                    if (newColumnNames.size > 0) {
+                        operations.columns = {
+                            add: Array.from(newColumnNames),
+                        }
+                    }
+
+                    const response = await patchTestsetRevision(
+                        testset.id,
+                        operations,
+                        commitMessage || undefined,
+                        selectedRevisionId || undefined,
+                    )
+                    const newRevisionId = response?.testset_revision?.id as string | undefined
+
+                    if (!response?.testset_revision) {
+                        const detail =
+                            (response as {detail?: string; error?: string; message?: string})
+                                ?.detail ||
+                            (response as {detail?: string; error?: string; message?: string})
+                                ?.error ||
+                            (response as {detail?: string; error?: string; message?: string})
+                                ?.message
+
+                        throw new Error(
+                            detail || "Failed to update testset: revision commit was not created",
+                        )
+                    }
+
+                    if (newRevisionId) {
                         message.success(
                             commitMessage
                                 ? `Saved with message: "${commitMessage}"`
@@ -219,8 +266,8 @@ export function useSaveTestset() {
                                 revisions: response.testset_revisions,
                             })
 
-                            setSelectedRevisionId(result.newRevisionId)
-                            revisionSelect.setCurrentRevisionId(result.newRevisionId)
+                            setSelectedRevisionId(newRevisionId)
+                            revisionSelect.setCurrentRevisionId(newRevisionId)
                         } catch (error) {
                             console.error("Failed to reload revisions:", error)
                         }
@@ -229,9 +276,9 @@ export function useSaveTestset() {
                         resetSaveState()
                         options?.onSuccess?.()
 
-                        return {success: true, revisionId: result.newRevisionId}
+                        return {success: true, revisionId: newRevisionId}
                     } else {
-                        throw result.error || new Error("Save failed")
+                        throw new Error("Failed to update testset: missing new revision ID")
                     }
                 }
             } catch (error) {
@@ -249,9 +296,11 @@ export function useSaveTestset() {
             testset.id,
             selectedRevisionId,
             commitMessage,
-            traceData.length,
+            traceData,
+            mappingData,
+            localColumns,
             getExportData,
-            executeSaveTestset,
+            convertTraceData,
             setSelectedRevisionId,
             setRevisionsForTestset,
             revisionSelect,

--- a/web/oss/src/components/SharedDrawers/AddToTestsetDrawer/hooks/useTestsetDrawer.ts
+++ b/web/oss/src/components/SharedDrawers/AddToTestsetDrawer/hooks/useTestsetDrawer.ts
@@ -358,13 +358,9 @@ export function useTestsetDrawer(): UseTestsetDrawerResult {
     const onSaveEditedTrace = useCallback(
         (valueToSave?: string) => {
             const dataToSave = valueToSave || updatedTraceData
-            console.log("[onSaveEditedTrace] Called", {
-                dataToSave: dataToSave?.slice(0, 100),
-            })
             // Always call updateEditedTrace - it handles comparison against original data internally
             // Don't compare against formatDataPreview here because it reflects current (possibly edited) data
             if (dataToSave) {
-                console.log("[onSaveEditedTrace] Calling updateEditedTrace")
                 const result = updateEditedTrace({
                     updatedData: dataToSave,
                     format: editorFormat,
@@ -372,7 +368,6 @@ export function useTestsetDrawer(): UseTestsetDrawerResult {
                     formatData: getYamlOrJson,
                     getValueAtPath, // Pass getValueAtPath to update local entities
                 })
-                console.log("[onSaveEditedTrace] Result:", result)
 
                 if (!result.success && result.error && result.error !== "No changes detected") {
                     message.error(result.error)

--- a/web/oss/src/components/TestcasesTableNew/components/TestcasesTableShell.tsx
+++ b/web/oss/src/components/TestcasesTableNew/components/TestcasesTableShell.tsx
@@ -58,6 +58,8 @@ export interface TestcasesTableShellProps {
     scopeIdPrefix?: string
     /** Maximum number of rows to display (for preview mode) */
     maxRows?: number
+    /** Optional row refs override for capped previews */
+    dataSource?: TestcaseTableRow[]
     /** Callback when add column button is clicked (shown in actions column header) */
     onAddColumn?: () => void
 }
@@ -98,6 +100,7 @@ export function TestcasesTableShell(props: TestcasesTableShellProps) {
         showRowIndex = false,
         scopeIdPrefix = "testcases",
         maxRows,
+        dataSource,
         onAddColumn,
     } = props
 
@@ -585,6 +588,7 @@ export function TestcasesTableShell(props: TestcasesTableShellProps) {
             rowSelection={rowSelection}
             useSettingsDropdown={!hideControls}
             settingsDropdownMenuItems={hideControls ? undefined : rowHeight.menuItems}
+            dataSource={dataSource}
             store={globalStore}
         />
     )


### PR DESCRIPTION
## Summary

Closes #4183.

This fixes the Add to testset drawer freeze when selecting many traces by decoupling preview rendering from the full selected trace set.

## Root Cause

The drawer preview table was visually limited to 5 rows, but the drawer still created local testcase draft entities for every selected trace. Those local entities were then fed through testcase entity state, column derivation, dirty state, and table row preparation, so the UI work still scaled with the full selected trace count.

## QA
- Added bulk traces on the add to testset drawer
- make sure the the ui and the app is working as expected