### PR TITLE
fix(frontend): Clear button does not work in playground

### DIFF
--- a/web/packages/agenta-entities/src/loadable/controller.ts
+++ b/web/packages/agenta-entities/src/loadable/controller.ts
@@ -786,6 +786,59 @@ const clearRowsAtom = atom(null, (get, set, loadableId: string) => {
     })
 })
 
+/**
+ * Reset rows for the playground Clear action.
+ *
+ * Local mode returns to a single empty testcase. Connected mode keeps server
+ * testcases in the playground, removes locally-added rows, and discards edits.
+ */
+const resetRowsForPlaygroundClearAtom = atom(null, (get, set, loadableId: string) => {
+    const state = get(loadableStateAtomFamily(loadableId))
+
+    if (state.connectedSourceId) {
+        const newIds = get(newEntityIdsAtom)
+        const newIdSet = new Set(newIds)
+        for (const id of newIds) {
+            set(testcaseMolecule.actions.delete, id)
+        }
+
+        set(clearDeletedIdsAtom)
+        set(testcaseMolecule.actions.discardAll)
+
+        const hiddenTestcaseIds = new Set(
+            [...state.hiddenTestcaseIds].filter((id) => !newIdSet.has(id)),
+        )
+        const displayRowIds = get(testcaseMolecule.atoms.displayRowIds)
+        const visibleRowIds = displayRowIds.filter((id) => !hiddenTestcaseIds.has(id))
+
+        set(loadableStateAtomFamily(loadableId), {
+            ...state,
+            activeRowId: visibleRowIds[0] ?? null,
+            executionResults: {},
+            hiddenTestcaseIds,
+        })
+        return
+    }
+
+    const existingIds = get(testcaseMolecule.atoms.displayRowIds)
+    for (const id of existingIds) {
+        set(testcaseMolecule.actions.delete, id)
+    }
+
+    set(resetTestcaseIdsAtom)
+    set(clearNewEntityIdsAtom)
+    set(clearDeletedIdsAtom)
+
+    const result = set(testcaseMolecule.actions.add, {data: {}})
+
+    set(loadableStateAtomFamily(loadableId), {
+        ...state,
+        activeRowId: result?.id ?? null,
+        executionResults: {},
+        hiddenTestcaseIds: new Set<string>(),
+    })
+})
+
 // ============================================================================
 // COLUMN ACTIONS
 // ============================================================================
@@ -2422,6 +2475,9 @@ export const testsetLoadable = {
         /** Clear all rows */
         clearRows: clearRowsAtom,
 
+        /** Reset rows for the playground Clear action */
+        resetRowsForPlaygroundClear: resetRowsForPlaygroundClearAtom,
+
         /** Set columns */
         setColumns: setColumnsAtom,
 
@@ -2624,6 +2680,7 @@ const unifiedActions = {
     setRows: testsetLoadable.actions.setRows,
     importRows: testsetLoadable.actions.importRows,
     clearRows: testsetLoadable.actions.clearRows,
+    resetRowsForPlaygroundClear: testsetLoadable.actions.resetRowsForPlaygroundClear,
 
     // Column actions
     setColumns: testsetLoadable.actions.setColumns,

--- a/web/packages/agenta-playground-ui/src/components/ExecutionHeader/index.tsx
+++ b/web/packages/agenta-playground-ui/src/components/ExecutionHeader/index.tsx
@@ -68,7 +68,7 @@ const ExecutionHeader = ({
 
     const runAll = useSetAtom(executionItemController.actions.runAll)
     const cancelAll = useSetAtom(executionItemController.actions.cancelAll)
-    const clearAllRuns = useSetAtom(executionItemController.actions.clearAllRuns)
+    const clearAll = useSetAtom(executionItemController.actions.clearAll)
     const canRunAllChat = useAtomValue(executionController.selectors.canRunAllChatComparison)
 
     // Collapse toggle (single view)
@@ -149,7 +149,7 @@ const ExecutionHeader = ({
 
             <div className="flex items-center gap-2">
                 <Tooltip title="Clear all">
-                    <Button size="small" onClick={() => clearAllRuns()} disabled={isRunning}>
+                    <Button size="small" onClick={() => clearAll()} disabled={isRunning}>
                         Clear
                     </Button>
                 </Tooltip>

--- a/web/packages/agenta-playground/src/state/controllers/executionItemController.ts
+++ b/web/packages/agenta-playground/src/state/controllers/executionItemController.ts
@@ -61,6 +61,7 @@ import {
     triggerExecutionsAtom,
     cancelTestsMutationAtom,
     clearAllRunsMutationAtom,
+    clearAllExecutionItemsMutationAtom,
     clearResponseByRowEntityWithContextAtom,
     setRepetitionCountAtom,
     setRepetitionIndexAtom,
@@ -274,6 +275,9 @@ export const executionItemController = {
 
         /** Clear all run results */
         clearAllRuns: clearAllRunsMutationAtom,
+
+        /** Clear run results and completion-mode testcase inputs */
+        clearAll: clearAllExecutionItemsMutationAtom,
 
         /** Run all tests (handles chat/completion × single/comparison) */
         runAll: runAllWithContextAtom,

--- a/web/packages/agenta-playground/src/state/execution/generationSelectors.ts
+++ b/web/packages/agenta-playground/src/state/execution/generationSelectors.ts
@@ -295,6 +295,22 @@ export const clearAllRunsMutationAtom = atom(null, (get, set) => {
     }
 })
 
+/**
+ * Clear playground results plus completion-mode testcase inputs.
+ */
+export const clearAllExecutionItemsMutationAtom = atom(null, (get, set) => {
+    const isChat = get(isChatModeAtom)
+
+    set(clearAllRunsMutationAtom)
+
+    if (isChat) return
+
+    const loadableId = get(derivedLoadableIdAtom)
+    if (!loadableId) return
+
+    set(loadableController.actions.resetRowsForPlaygroundClear, loadableId)
+})
+
 // ============================================================================
 // CAN RUN ALL CHAT COMPARISON
 // ============================================================================

--- a/web/packages/agenta-playground/src/state/execution/index.ts
+++ b/web/packages/agenta-playground/src/state/execution/index.ts
@@ -287,6 +287,7 @@ export {
     triggerExecutionsAtom,
     // Mutations
     cancelTestsMutationAtom,
+    clearAllExecutionItemsMutationAtom,
     clearAllRunsMutationAtom,
     // Chat comparison
     canRunAllChatComparisonAtom,

--- a/web/packages/agenta-playground/src/state/index.ts
+++ b/web/packages/agenta-playground/src/state/index.ts
@@ -182,6 +182,7 @@ export {isAnyRunningForRowAtomFamily} from "./execution"
 export {
     cancelTestsMutationAtom,
     canRunAllChatComparisonAtom,
+    clearAllExecutionItemsMutationAtom,
     clearAllRunsMutationAtom,
     generationHeaderDataAtomFamily,
     generationVariableRowIdsAtom,


### PR DESCRIPTION
## Summary
- Route the playground Clear button through an execution-item clear action that clears generated output and completion-mode testcase input state.
- Reset local completion playground rows to a single empty testcase.
- For connected testsets, remove locally added testcase rows and discard edits while preserving existing connected testcases.

## Root Cause
The Clear button only used the run-output clearing path, so completion-mode testcase input rows and edited testcase data could remain in the playground after clearing.

## Validation
- `pnpm lint-fix`
- `pnpm --filter @agenta/entities types:check`
- `pnpm --filter @agenta/playground types:check`
- `pnpm --filter @agenta/playground-ui types:check`
- Commit hook: ruff checks skipped for no Python files, web prettier, turbo lint, and staged gitleaks passed
- Pre-push hook: ruff checks skipped for no Python files, web prettier, turbo lint, staged gitleaks, and diff gitleaks passed

Closes #4185