### PR TITLE
feat: add configurable slug for entities

### DIFF
--- a/web/oss/src/components/Playground/Components/Modals/CommitVariantChangesModal/index.tsx
+++ b/web/oss/src/components/Playground/Components/Modals/CommitVariantChangesModal/index.tsx
@@ -3,10 +3,11 @@ import {useCallback, useMemo, useState} from "react"
 import {publishMutationAtom} from "@agenta/entities/runnable"
 import {workflowMolecule, createWorkflowFromEphemeralAtom} from "@agenta/entities/workflow"
 import {EntityCommitModal} from "@agenta/entity-ui"
+import type {CommitSubmitParams, CommitCreateFieldsConfig} from "@agenta/entity-ui"
 import {playgroundController} from "@agenta/playground"
 import {EnvironmentTag, environmentColors} from "@agenta/ui"
 import {message} from "@agenta/ui/app-message"
-import {Checkbox, Input, Select, Typography} from "antd"
+import {Checkbox, Select} from "antd"
 import {getDefaultStore, useAtomValue, useSetAtom} from "jotai"
 
 import {
@@ -17,12 +18,15 @@ import {
     registryPaginatedStore,
     clearRegistryVariantNameCache,
 } from "@/oss/components/VariantsComponents/store/registryStore"
-import {isVariantNameInputValid} from "@/oss/lib/helpers/utils"
 import {selectedAppIdAtom} from "@/oss/state/app"
 
 import {CommitVariantChangesModalProps} from "./assets/types"
 
-const {Text} = Typography
+const EVALUATOR_CREATE_FIELDS: CommitCreateFieldsConfig = {nameLabel: "Evaluator name"}
+const VARIANT_CREATE_FIELDS: CommitCreateFieldsConfig = {
+    modes: ["variant"],
+    nameLabel: "Variant name",
+}
 
 const CommitVariantChangesModal: React.FC<CommitVariantChangesModalProps> = ({
     variantId,
@@ -41,7 +45,6 @@ const CommitVariantChangesModal: React.FC<CommitVariantChangesModalProps> = ({
     const createFromEphemeral = useSetAtom(createWorkflowFromEphemeralAtom)
     const {mutateAsync: publish} = useAtomValue(publishMutationAtom)
 
-    const [newVariantName, setNewVariantName] = useState("")
     const [shouldDeploy, setShouldDeploy] = useState(false)
     const [selectedEnvironment, setSelectedEnvironment] = useState<string | null>(null)
 
@@ -59,7 +62,6 @@ const CommitVariantChangesModal: React.FC<CommitVariantChangesModalProps> = ({
 
     const handleClose = useCallback(() => {
         onCancel?.({} as never)
-        setNewVariantName("")
         setShouldDeploy(false)
         setSelectedEnvironment(null)
     }, [onCancel])
@@ -69,24 +71,25 @@ const CommitVariantChangesModal: React.FC<CommitVariantChangesModalProps> = ({
             message: commitMessage,
             mode,
             entityName: editedName,
-        }: {
-            message: string
-            mode?: string
-            entityName?: string
-        }) => {
+            entitySlug: editedSlug,
+        }: CommitSubmitParams) => {
             // Ephemeral entities: create a new workflow via the entities package reducer
             if (isEphemeral) {
                 const result = await createFromEphemeral({
                     revisionId: variantId,
                     commitMessage,
                     name: editedName,
+                    slug: editedSlug,
                 })
 
                 if (!result.success) {
+                    const errorStatus = (result.error as {response?: {status?: number}}).response
+                        ?.status
                     return {
                         success: false,
                         error:
                             "error" in result ? result.error.message : "Failed to create workflow",
+                        errorStatus,
                     }
                 }
 
@@ -102,10 +105,16 @@ const CommitVariantChangesModal: React.FC<CommitVariantChangesModalProps> = ({
             const note = commitMessage
 
             if (selectedMode === "variant") {
+                const variantNameToCreate = editedName?.trim()
+                if (!variantNameToCreate) {
+                    return {success: false, error: "Variant name is required"}
+                }
+
                 const result = await createVariant({
                     baseRevisionId: variantId,
                     baseVariantName: variantName,
-                    newVariantName: newVariantName,
+                    newVariantName: variantNameToCreate,
+                    slug: editedSlug,
                     note,
                     callback: (newRevision, state) => {
                         state.selected = state.selected.map((id) =>
@@ -118,6 +127,7 @@ const CommitVariantChangesModal: React.FC<CommitVariantChangesModalProps> = ({
                     return {
                         success: false,
                         error: result.error || "Failed to create a new variant",
+                        errorStatus: result.errorStatus,
                     }
                 }
 
@@ -140,7 +150,7 @@ const CommitVariantChangesModal: React.FC<CommitVariantChangesModalProps> = ({
                         revisionVersion: newRevisionData?.version ?? undefined,
                         note,
                     })
-                    message.success(`Published ${variantName} to ${selectedEnvironment}`)
+                    message.success(`Published ${variantNameToCreate} to ${selectedEnvironment}`)
                 }
 
                 clearRegistryVariantNameCache()
@@ -196,7 +206,6 @@ const CommitVariantChangesModal: React.FC<CommitVariantChangesModalProps> = ({
             variantId,
             variantName,
             variantSlug,
-            newVariantName,
             shouldDeploy,
             selectedEnvironment,
             publish,
@@ -230,7 +239,7 @@ const CommitVariantChangesModal: React.FC<CommitVariantChangesModalProps> = ({
                 }}
                 onSubmit={handleSubmit}
                 actionLabel="Create"
-                entityNameEditable
+                createEntityFields={EVALUATOR_CREATE_FIELDS}
                 successMessage="Evaluator created successfully"
             />
         )
@@ -247,30 +256,8 @@ const CommitVariantChangesModal: React.FC<CommitVariantChangesModalProps> = ({
             }}
             commitModes={commitModes}
             defaultCommitMode="version"
-            modeLabel={newVariantName || undefined}
             renderModeContent={({mode}) => (
                 <div className="flex flex-col gap-3">
-                    {mode === "variant" && (
-                        <div className="flex flex-col gap-1">
-                            <Input
-                                placeholder="A unique variant name"
-                                value={newVariantName}
-                                status={
-                                    newVariantName && !isVariantNameInputValid(newVariantName)
-                                        ? "error"
-                                        : undefined
-                                }
-                                onChange={(e) => setNewVariantName(e.target.value)}
-                            />
-                            {newVariantName && !isVariantNameInputValid(newVariantName) && (
-                                <Text className="text-xs text-[#EF4444]">
-                                    Variant name must contain only letters, numbers, underscore, or
-                                    dash
-                                </Text>
-                            )}
-                        </div>
-                    )}
-
                     {!isEvaluator && (
                         <>
                             <Checkbox
@@ -292,13 +279,14 @@ const CommitVariantChangesModal: React.FC<CommitVariantChangesModalProps> = ({
                     )}
                 </div>
             )}
-            canSubmit={({mode}) => {
+            canSubmit={({mode, entityName}) => {
                 if (mode === "variant") {
-                    if (!newVariantName || !isVariantNameInputValid(newVariantName)) return false
+                    if (!entityName?.trim()) return false
                 }
                 if (shouldDeploy && !selectedEnvironment) return false
                 return true
             }}
+            createEntityFields={VARIANT_CREATE_FIELDS}
             onSubmit={handleSubmit}
             submitLabel="Commit"
         />

--- a/web/oss/src/components/Playground/Components/TestsetDropdown/index.tsx
+++ b/web/oss/src/components/Playground/Components/TestsetDropdown/index.tsx
@@ -9,7 +9,12 @@ import {useCallback, useMemo, useRef, useState} from "react"
 
 import {loadableController, traceDataSummaryAtomFamily} from "@agenta/entities/loadable"
 import {testcaseMolecule} from "@agenta/entities/testcase"
-import type {CommitModeOption, CommitSubmitParams, CommitSubmitResult} from "@agenta/entity-ui"
+import type {
+    CommitCreateFieldsConfig,
+    CommitModeOption,
+    CommitSubmitParams,
+    CommitSubmitResult,
+} from "@agenta/entity-ui"
 import {EntityCommitModal} from "@agenta/entity-ui"
 import {playgroundController} from "@agenta/playground"
 import {
@@ -63,6 +68,12 @@ const COMMIT_MODES: CommitModeOption[] = [
     {id: "commit", label: "Commit changes"},
     {id: "save-new", label: "Save as new test set"},
 ]
+
+const TESTSET_SAVE_NEW_FIELDS: CommitCreateFieldsConfig = {
+    modes: ["save-new"],
+    nameLabel: "Test set name",
+    defaultName: ({entity}) => entity?.name ?? "",
+}
 
 // ============================================================================
 // TESTSET DROPDOWN COMPONENT
@@ -567,11 +578,7 @@ export function TestsetDropdown() {
                 defaultCommitMode="commit"
                 onModeChange={handleModeChange}
                 canSubmit={canSyncSubmit}
-                createEntityFields={{
-                    modes: ["save-new"],
-                    nameLabel: "Test set name",
-                    defaultName: ({entity}) => entity?.name ?? "",
-                }}
+                createEntityFields={TESTSET_SAVE_NEW_FIELDS}
                 submitLabel={syncSubmitLabel}
                 successMessage="Test set updated successfully"
             />

--- a/web/oss/src/components/Playground/Components/TestsetDropdown/index.tsx
+++ b/web/oss/src/components/Playground/Components/TestsetDropdown/index.tsx
@@ -5,7 +5,7 @@
  * Adapts based on whether the playground is connected to a local or API-backed testset.
  */
 
-import {useCallback, useEffect, useMemo, useRef, useState} from "react"
+import {useCallback, useMemo, useRef, useState} from "react"
 
 import {loadableController, traceDataSummaryAtomFamily} from "@agenta/entities/loadable"
 import {testcaseMolecule} from "@agenta/entities/testcase"
@@ -34,7 +34,7 @@ import {
     XCircleIcon,
 } from "@phosphor-icons/react"
 import type {MenuProps} from "antd"
-import {Button, Dropdown, Input, Typography} from "antd"
+import {Button, Dropdown} from "antd"
 import {atom, useAtom, useAtomValue, useSetAtom, useStore} from "jotai"
 import dynamic from "next/dynamic"
 
@@ -63,41 +63,6 @@ const COMMIT_MODES: CommitModeOption[] = [
     {id: "commit", label: "Commit changes"},
     {id: "save-new", label: "Save as new test set"},
 ]
-
-// ============================================================================
-// SYNC MODE CONTENT
-// Helper component that syncs the current commit mode to parent state via useEffect.
-// This avoids calling setState during render (renderModeContent is called during render).
-// ============================================================================
-
-interface SyncModeContentProps {
-    mode: string | undefined
-    onModeChange: (mode: string) => void
-    newTestsetName: string
-    onNameChange: (name: string) => void
-}
-
-function SyncModeContent({mode, onModeChange, newTestsetName, onNameChange}: SyncModeContentProps) {
-    useEffect(() => {
-        if (mode) onModeChange(mode)
-    }, [mode, onModeChange])
-
-    if (mode !== "save-new") return null
-
-    return (
-        <div className="flex flex-col gap-1 pt-1">
-            <Typography.Text className="text-xs text-[var(--ant-color-text-secondary)]">
-                Test set name
-            </Typography.Text>
-            <Input
-                placeholder="Enter test set name"
-                value={newTestsetName}
-                onChange={(e) => onNameChange(e.target.value)}
-                autoFocus
-            />
-        </div>
-    )
-}
 
 // ============================================================================
 // TESTSET DROPDOWN COMPONENT
@@ -402,12 +367,11 @@ export function TestsetDropdown() {
 
     // ── Sync changes (EntityCommitModal) ───────────────────────────────────
     const [syncOpen, setSyncOpen] = useAtom(testsetSyncCommitModalOpenAtom)
-    const [newTestsetName, setNewTestsetName] = useState("")
     const [currentSyncMode, setCurrentSyncMode] = useState("commit")
     const syncModeRef = useRef("commit")
 
-    const handleModeChange = useCallback((m: string) => {
-        if (syncModeRef.current !== m) {
+    const handleModeChange = useCallback((m: string | undefined) => {
+        if (m && syncModeRef.current !== m) {
             syncModeRef.current = m
             setCurrentSyncMode(m)
         }
@@ -416,26 +380,39 @@ export function TestsetDropdown() {
     const syncSubmitLabel = currentSyncMode === "save-new" ? "Save" : "Commit"
 
     const handleSyncOpen = useCallback(() => {
-        setNewTestsetName("")
         setCurrentSyncMode("commit")
         syncModeRef.current = "commit"
         setSyncOpen(true)
     }, [])
 
     const handleSyncSubmit = useCallback(
-        async ({message, mode: submitMode}: CommitSubmitParams): Promise<CommitSubmitResult> => {
+        async ({
+            message,
+            mode: submitMode,
+            entityName,
+            entitySlug,
+        }: CommitSubmitParams): Promise<CommitSubmitResult> => {
             if (!loadableId) return {success: false, error: "No loadable ID"}
 
             if (submitMode === "save-new") {
-                const trimmedName = newTestsetName.trim()
+                const trimmedName = entityName?.trim()
                 if (!trimmedName) {
                     return {success: false, error: "Test set name is required"}
                 }
                 setLoadableName(loadableId, trimmedName)
-                const result = await saveAsNewTestset(loadableId)
+                const result = await saveAsNewTestset(loadableId, {
+                    commitMessage: message,
+                    slug: entitySlug,
+                })
+                const errorStatus = (result.error as {response?: {status?: number}} | undefined)
+                    ?.response?.status
                 return result.success
                     ? {success: true}
-                    : {success: false, error: result.error?.message ?? "Failed to save"}
+                    : {
+                          success: false,
+                          error: result.error?.message ?? "Failed to save",
+                          errorStatus,
+                      }
             }
 
             try {
@@ -445,27 +422,15 @@ export function TestsetDropdown() {
                 return {success: false, error: err instanceof Error ? err.message : String(err)}
             }
         },
-        [loadableId, newTestsetName, commitChanges, saveAsNewTestset, setLoadableName],
+        [loadableId, commitChanges, saveAsNewTestset, setLoadableName],
     )
 
     const canSyncSubmit = useCallback(
-        ({mode: m}: {mode?: string}) => {
-            if (m === "save-new") return newTestsetName.trim().length > 0
+        ({mode: m, entityName}: {mode?: string; entityName?: string}) => {
+            if (m === "save-new") return Boolean(entityName?.trim())
             return true
         },
-        [newTestsetName],
-    )
-
-    const renderSyncModeContent = useCallback(
-        ({mode: m}: {mode?: string}) => (
-            <SyncModeContent
-                mode={m}
-                onModeChange={handleModeChange}
-                newTestsetName={newTestsetName}
-                onNameChange={setNewTestsetName}
-            />
-        ),
-        [handleModeChange, newTestsetName],
+        [],
     )
 
     // ── Dropdown menu ──────────────────────────────────────────────────────
@@ -600,8 +565,13 @@ export function TestsetDropdown() {
                 onSubmit={handleSyncSubmit}
                 commitModes={COMMIT_MODES}
                 defaultCommitMode="commit"
-                renderModeContent={renderSyncModeContent}
+                onModeChange={handleModeChange}
                 canSubmit={canSyncSubmit}
+                createEntityFields={{
+                    modes: ["save-new"],
+                    nameLabel: "Test set name",
+                    defaultName: ({entity}) => entity?.name ?? "",
+                }}
                 submitLabel={syncSubmitLabel}
                 successMessage="Test set updated successfully"
             />

--- a/web/oss/src/components/pages/app-management/index.tsx
+++ b/web/oss/src/components/pages/app-management/index.tsx
@@ -70,13 +70,19 @@ const AppManagement: React.FC = () => {
     const [isAddAppFromTemplatedModal, setIsAddAppFromTemplatedModal] = useState(false)
     const [isSetupTracingModal, setIsSetupTracingModal] = useState(false)
     const [appName, setAppName] = useState("")
+    const [appSlug, setAppSlug] = useState<string | undefined>(undefined)
     const {error, mutate} = useAppsData()
 
     const {secrets} = useVaultSecret()
     const {selectedOrg} = useOrgData()
 
-    const handleTemplateCardClick = async (templateId: string, submittedAppName: string) => {
+    const handleTemplateCardClick = async (
+        templateId: string,
+        submittedAppName: string,
+        submittedAppSlug?: string,
+    ) => {
         setAppName(submittedAppName)
+        setAppSlug(submittedAppSlug)
         setTemplateKey(templateId)
         setIsAddAppFromTemplatedModal(false)
         setStatusModalOpen(true)
@@ -86,6 +92,7 @@ const AppManagement: React.FC = () => {
         const apiKeys = secrets
         await createAppWithTemplate({
             appName: submittedAppName,
+            slug: submittedAppSlug,
             templateKey: templateId,
             providerKey: isDemo() && apiKeys?.length === 0 ? [] : (apiKeys as LlmProvider[]),
             onStatusChange: async (status, details, appId) => {
@@ -129,7 +136,7 @@ const AppManagement: React.FC = () => {
             await mutate()
             await invalidateAppManagementWorkflowQueries()
         }
-        handleTemplateCardClick(templateKey as string, appName)
+        handleTemplateCardClick(templateKey as string, appName, appSlug)
     }
 
     const onTimeoutRetry = async () => {

--- a/web/oss/src/components/pages/app-management/modals/AddAppFromTemplateModal/assets/styles.ts
+++ b/web/oss/src/components/pages/app-management/modals/AddAppFromTemplateModal/assets/styles.ts
@@ -16,7 +16,7 @@ export const useStyles = createUseStyles((theme: JSSTheme) => ({
     modal: {
         display: "flex",
         flexDirection: "column",
-        gap: 24,
+        gap: 16,
     },
     modalError: {
         color: theme.colorError,

--- a/web/oss/src/components/pages/app-management/modals/AddAppFromTemplateModal/components/AddAppFromTemplateModalContent.tsx
+++ b/web/oss/src/components/pages/app-management/modals/AddAppFromTemplateModal/components/AddAppFromTemplateModalContent.tsx
@@ -1,12 +1,19 @@
-import {useCallback, useMemo, useState} from "react"
+import {useCallback, useEffect, useMemo, useRef, useState} from "react"
 
-import {Typography, Input, Card, Radio, Flex, Button, notification} from "antd"
+import {
+    generateSlugWithExistingSuffix,
+    generateSlugWithSuffix,
+    getSlugSuffix,
+    isValidSlug,
+    regenerateSlugSuffix,
+} from "@agenta/shared/utils"
+import {ArrowClockwise, WarningCircle} from "@phosphor-icons/react"
+import {Button, Card, Flex, Input, notification, Radio, Tag, Typography} from "antd"
 import clsx from "clsx"
 
 import {isAppNameInputValid} from "@/oss/lib/helpers/utils"
 import {GenericObject} from "@/oss/lib/Types"
-import {useAppsData} from "@/oss/state/app"
-import {useTemplates} from "@/oss/state/app"
+import {useAppsData, useTemplates} from "@/oss/state/app"
 
 import {getTemplateKey} from "../../../assets/helpers"
 import {useStyles} from "../assets/styles"
@@ -14,7 +21,11 @@ import {useStyles} from "../assets/styles"
 const {Text} = Typography
 
 interface AddAppFromTemplateModalContentProps {
-    handleTemplateCardClick: (templateId: string, appName: string) => Promise<void>
+    handleTemplateCardClick: (
+        templateId: string,
+        appName: string,
+        appSlug?: string,
+    ) => Promise<void>
 }
 
 const AddAppFromTemplateModalContent = ({
@@ -23,7 +34,10 @@ const AddAppFromTemplateModalContent = ({
     const classes = useStyles()
 
     const [newApp, setNewApp] = useState("")
+    const [newAppSlug, setNewAppSlug] = useState<string | null>(null)
+    const [slugEditing, setSlugEditing] = useState(false)
     const [templateKey, setTemplateKey] = useState<string | undefined>(undefined)
+    const generatedSlugSuffixRef = useRef<string | null>(null)
 
     const {apps} = useAppsData()
     const [{data: allTemplates = [], isLoading: fetchingTemplate}, noTemplateMessage] =
@@ -49,6 +63,70 @@ const AddAppFromTemplateModalContent = ({
     )
 
     const isError = appNameExist || (newApp.length > 0 && !isAppNameInputValid(newApp))
+    const slugValidationError =
+        newAppSlug && !isValidSlug(newAppSlug)
+            ? "Slug may only contain a-z, 0-9, hyphens, underscores, and periods."
+            : null
+
+    useEffect(() => {
+        if (!newApp.trim()) {
+            setNewAppSlug(null)
+            setSlugEditing(false)
+            generatedSlugSuffixRef.current = null
+            return
+        }
+
+        if (slugEditing) return
+
+        const generatedSlug = generateSlugWithExistingSuffix(newApp, generatedSlugSuffixRef.current)
+        generatedSlugSuffixRef.current = getSlugSuffix(generatedSlug)
+        setNewAppSlug(generatedSlug)
+    }, [newApp, slugEditing])
+
+    const handleAppNameChange = useCallback(
+        (value: string) => {
+            setNewApp(value)
+
+            if (!value.trim()) {
+                setNewAppSlug(null)
+                setSlugEditing(false)
+                generatedSlugSuffixRef.current = null
+                return
+            }
+
+            if (slugEditing && !newAppSlug?.trim() && value.trim()) {
+                const generatedSlug = generateSlugWithExistingSuffix(
+                    value,
+                    generatedSlugSuffixRef.current,
+                )
+                generatedSlugSuffixRef.current = getSlugSuffix(generatedSlug)
+                setNewAppSlug(generatedSlug)
+            }
+        },
+        [newAppSlug, slugEditing],
+    )
+
+    const handleSlugInputChange = useCallback((value: string) => {
+        setNewAppSlug(value)
+    }, [])
+
+    const handleRegenerateSlug = useCallback(() => {
+        const generatedSlug = regenerateSlugSuffix(
+            newAppSlug || newApp,
+            generatedSlugSuffixRef.current,
+        )
+        generatedSlugSuffixRef.current = getSlugSuffix(generatedSlug)
+        setNewAppSlug(generatedSlug)
+    }, [newApp, newAppSlug])
+
+    const handleEditSlug = useCallback(() => {
+        if (!newAppSlug && newApp.trim()) {
+            const generatedSlug = generateSlugWithSuffix(newApp)
+            generatedSlugSuffixRef.current = getSlugSuffix(generatedSlug)
+            setNewAppSlug(generatedSlug)
+        }
+        setSlugEditing(true)
+    }, [newApp, newAppSlug])
 
     const handleCreateApp = useCallback(() => {
         if (appNameExist) {
@@ -63,8 +141,14 @@ const AddAppFromTemplateModalContent = ({
                 description: "The template image is currently being fetched. Please wait...",
                 duration: 3,
             })
-        } else if (!fetchingTemplate && newApp.length > 0 && isAppNameInputValid(newApp)) {
-            handleTemplateCardClick(templateKey as string, newApp)
+        } else if (
+            !fetchingTemplate &&
+            newApp.length > 0 &&
+            isAppNameInputValid(newApp) &&
+            newAppSlug &&
+            !slugValidationError
+        ) {
+            handleTemplateCardClick(templateKey as string, newApp, newAppSlug)
         } else {
             notification.warning({
                 message: "Template Selection",
@@ -72,7 +156,15 @@ const AddAppFromTemplateModalContent = ({
                 duration: 3,
             })
         }
-    }, [appNameExist, fetchingTemplate, handleTemplateCardClick, newApp, templateKey])
+    }, [
+        appNameExist,
+        fetchingTemplate,
+        handleTemplateCardClick,
+        newApp,
+        newAppSlug,
+        slugValidationError,
+        templateKey,
+    ])
 
     const handleEnterKeyPress = useCallback(
         (event: React.KeyboardEvent<HTMLInputElement>) => {
@@ -101,7 +193,7 @@ const AddAppFromTemplateModalContent = ({
                 <Input
                     placeholder="Enter a name"
                     value={newApp}
-                    onChange={(e) => setNewApp(e.target.value)}
+                    onChange={(e) => handleAppNameChange(e.target.value)}
                     onKeyDown={handleEnterKeyPress}
                     className={`${isError && classes.inputName}`}
                     allowClear
@@ -118,6 +210,54 @@ const AddAppFromTemplateModalContent = ({
                         spaces.
                     </Typography.Text>
                 )}
+
+                <div className="flex flex-col gap-1">
+                    {slugEditing ? (
+                        <>
+                            <Text className="font-medium">Slug</Text>
+                            <Input
+                                value={newAppSlug ?? ""}
+                                onChange={(e) => handleSlugInputChange(e.target.value)}
+                                status={slugValidationError ? "error" : undefined}
+                                suffix={
+                                    <Button
+                                        type="text"
+                                        size="small"
+                                        icon={<ArrowClockwise size={14} />}
+                                        onClick={handleRegenerateSlug}
+                                        title="Regenerate random suffix"
+                                    />
+                                }
+                            />
+                            {slugValidationError && (
+                                <div className="mt-0.5 flex items-start gap-1 text-[#ff4d4f]">
+                                    <WarningCircle size={16} className="mt-0.5 shrink-0" />
+                                    <span>{slugValidationError}</span>
+                                </div>
+                            )}
+                            {!slugValidationError && (
+                                <Typography.Text type="secondary">
+                                    Edit freely - use the regenerate button to add a random suffix
+                                    back.
+                                </Typography.Text>
+                            )}
+                        </>
+                    ) : (
+                        <div className="flex h-7 items-center gap-2">
+                            {newAppSlug && (
+                                <>
+                                    <Typography.Text className="font-medium">Slug:</Typography.Text>
+                                    <Tag className="bg-gray-100 font-mono text-gray-500 text-[10px]">
+                                        {newAppSlug}
+                                    </Tag>
+                                    <Button type="link" size="small" onClick={handleEditSlug}>
+                                        Edit
+                                    </Button>
+                                </>
+                            )}
+                        </div>
+                    )}
+                </div>
             </div>
 
             <div className="space-y-2">
@@ -146,7 +286,9 @@ const AddAppFromTemplateModalContent = ({
             <div className="flex justify-end">
                 <Button
                     type="primary"
-                    disabled={!newApp || isError || !templateKey}
+                    disabled={
+                        !newApp || isError || !templateKey || !newAppSlug || !!slugValidationError
+                    }
                     onClick={handleCreateApp}
                 >
                     Create New Prompt

--- a/web/oss/src/components/pages/app-management/modals/AddAppFromTemplateModal/components/AddAppFromTemplateModalContent.tsx
+++ b/web/oss/src/components/pages/app-management/modals/AddAppFromTemplateModal/components/AddAppFromTemplateModalContent.tsx
@@ -38,6 +38,7 @@ const AddAppFromTemplateModalContent = ({
     const [slugEditing, setSlugEditing] = useState(false)
     const [templateKey, setTemplateKey] = useState<string | undefined>(undefined)
     const generatedSlugSuffixRef = useRef<string | null>(null)
+    const slugManuallyEditedRef = useRef(false)
 
     const {apps} = useAppsData()
     const [{data: allTemplates = [], isLoading: fetchingTemplate}, noTemplateMessage] =
@@ -73,15 +74,16 @@ const AddAppFromTemplateModalContent = ({
             setNewAppSlug(null)
             setSlugEditing(false)
             generatedSlugSuffixRef.current = null
+            slugManuallyEditedRef.current = false
             return
         }
 
-        if (slugEditing) return
+        if (slugManuallyEditedRef.current) return
 
         const generatedSlug = generateSlugWithExistingSuffix(newApp, generatedSlugSuffixRef.current)
         generatedSlugSuffixRef.current = getSlugSuffix(generatedSlug)
         setNewAppSlug(generatedSlug)
-    }, [newApp, slugEditing])
+    }, [newApp])
 
     const handleAppNameChange = useCallback(
         (value: string) => {
@@ -91,10 +93,11 @@ const AddAppFromTemplateModalContent = ({
                 setNewAppSlug(null)
                 setSlugEditing(false)
                 generatedSlugSuffixRef.current = null
+                slugManuallyEditedRef.current = false
                 return
             }
 
-            if (slugEditing && !newAppSlug?.trim() && value.trim()) {
+            if (!slugManuallyEditedRef.current && !newAppSlug?.trim() && value.trim()) {
                 const generatedSlug = generateSlugWithExistingSuffix(
                     value,
                     generatedSlugSuffixRef.current,
@@ -107,6 +110,7 @@ const AddAppFromTemplateModalContent = ({
     )
 
     const handleSlugInputChange = useCallback((value: string) => {
+        slugManuallyEditedRef.current = true
         setNewAppSlug(value)
     }, [])
 
@@ -243,14 +247,24 @@ const AddAppFromTemplateModalContent = ({
                             )}
                         </>
                     ) : (
-                        <div className="flex h-7 items-center gap-2">
+                        <div className="flex h-7 min-w-0 items-center gap-2">
                             {newAppSlug && (
                                 <>
-                                    <Typography.Text className="font-medium">Slug:</Typography.Text>
-                                    <Tag className="bg-gray-100 font-mono text-gray-500 text-[10px]">
+                                    <Typography.Text className="shrink-0 font-medium">
+                                        Slug:
+                                    </Typography.Text>
+                                    <Tag
+                                        className="min-w-0 max-w-[min(360px,calc(100%-88px))] truncate bg-gray-100 font-mono text-gray-500 text-[10px]"
+                                        title={newAppSlug}
+                                    >
                                         {newAppSlug}
                                     </Tag>
-                                    <Button type="link" size="small" onClick={handleEditSlug}>
+                                    <Button
+                                        type="link"
+                                        size="small"
+                                        className="shrink-0"
+                                        onClick={handleEditSlug}
+                                    >
                                         Edit
                                     </Button>
                                 </>

--- a/web/oss/src/components/pages/app-management/modals/AddAppFromTemplateModal/types.d.ts
+++ b/web/oss/src/components/pages/app-management/modals/AddAppFromTemplateModal/types.d.ts
@@ -1,5 +1,0 @@
-export interface AddAppFromTemplatedModalProps {
-    open: boolean
-    onCancel: () => void
-    handleTemplateCardClick: (templateId: string, appName: string) => Promise<void>
-}

--- a/web/oss/src/components/pages/app-management/modals/AddAppFromTemplateModal/types.ts
+++ b/web/oss/src/components/pages/app-management/modals/AddAppFromTemplateModal/types.ts
@@ -1,0 +1,9 @@
+export interface AddAppFromTemplatedModalProps {
+    open: boolean
+    onCancel: () => void
+    handleTemplateCardClick: (
+        templateId: string,
+        appName: string,
+        appSlug?: string,
+    ) => Promise<void>
+}

--- a/web/oss/src/components/pages/prompts/PromptsPage.tsx
+++ b/web/oss/src/components/pages/prompts/PromptsPage.tsx
@@ -103,6 +103,7 @@ const PromptsPage = () => {
     const [moveSelection, setMoveSelection] = useState<string | null>(null)
     const [templateKey, setTemplateKey] = useState<string | undefined>(undefined)
     const [appName, setAppName] = useState("")
+    const [appSlug, setAppSlug] = useState<string | undefined>(undefined)
     const [fetchingCustomWorkflow, setFetchingCustomWorkflow] = useState(false)
     const [moveEntity, setMoveEntity] = useState<{
         type: "folder" | "app"
@@ -374,8 +375,13 @@ const PromptsPage = () => {
         }
     }
 
-    const handleTemplateCardClick = async (templateId: string, submittedAppName: string) => {
+    const handleTemplateCardClick = async (
+        templateId: string,
+        submittedAppName: string,
+        submittedAppSlug?: string,
+    ) => {
         setAppName(submittedAppName)
+        setAppSlug(submittedAppSlug)
         setTemplateKey(templateId)
         setIsAddAppFromTemplatedModal(false)
         setStatusModalOpen(true)
@@ -385,6 +391,7 @@ const PromptsPage = () => {
 
         await createAppWithTemplate({
             appName: submittedAppName,
+            slug: submittedAppSlug,
             templateKey: templateId,
             folderId: currentFolderId ?? null,
             providerKey: isDemo() && apiKeys?.length === 0 ? [] : (apiKeys as LlmProvider[]),
@@ -415,7 +422,7 @@ const PromptsPage = () => {
             refetchWorkflows()
         }
         if (templateKey) {
-            await handleTemplateCardClick(templateKey, appName)
+            await handleTemplateCardClick(templateKey, appName, appSlug)
         }
     }
 

--- a/web/oss/src/services/app-selector/api/index.ts
+++ b/web/oss/src/services/app-selector/api/index.ts
@@ -110,6 +110,7 @@ export type AppCreationStatusType =
  */
 export const createAppWithTemplate = async ({
     appName,
+    slug,
     providerKey: _providerKey,
     templateKey,
     serviceUrl,
@@ -118,6 +119,7 @@ export const createAppWithTemplate = async ({
     onStatusChange,
 }: {
     appName: string
+    slug?: string
     templateKey: string
     serviceUrl?: string
     providerKey: LlmProvider[]
@@ -132,6 +134,10 @@ export const createAppWithTemplate = async ({
         const {projectId} = getProjectValues()
         const {selectedOrg} = getOrgValues()
 
+        if (!projectId) {
+            throw new Error("Project ID is required to create an app")
+        }
+
         onStatusChange?.("creating_app")
 
         result = await createAppFromTemplate({
@@ -139,6 +145,7 @@ export const createAppWithTemplate = async ({
             organizationId: selectedOrg?.id,
             workspaceId: selectedOrg?.default_workspace.id,
             appName,
+            slug,
             templateKey,
             serviceUrl,
             folderId,

--- a/web/packages/agenta-entities/src/loadable/controller.ts
+++ b/web/packages/agenta-entities/src/loadable/controller.ts
@@ -1173,7 +1173,10 @@ const saveAsNewTestsetAtom = atom(
         get,
         set,
         loadableId: string,
-        _commitMessage?: string,
+        options?: {
+            commitMessage?: string
+            slug?: string
+        },
     ): Promise<SaveAsNewTestsetResult> => {
         const state = get(loadableStateAtomFamily(loadableId))
         const projectId = get(projectIdAtom)
@@ -1208,6 +1211,8 @@ const saveAsNewTestsetAtom = atom(
             const result = await set(saveNewTestsetAtom, {
                 projectId,
                 testsetName: name.trim(),
+                slug: options?.slug,
+                commitMessage: options?.commitMessage,
                 explicitTestcaseData: allTestcaseData,
             })
 

--- a/web/packages/agenta-entities/src/runnable/providerTypes.ts
+++ b/web/packages/agenta-entities/src/runnable/providerTypes.ts
@@ -81,6 +81,7 @@ export interface AppRevisionCreateVariantPayload {
     baseRevisionId?: string
     baseVariantName?: string
     newVariantName: string
+    slug?: string
     note?: string
     callback?: (newRevision: {id: string}, state: {selected: string[]}) => void
 }
@@ -98,6 +99,7 @@ export interface AppRevisionCrudResult {
     newRevisionId?: string
     message?: string
     error?: string
+    errorStatus?: number
 }
 
 /**

--- a/web/packages/agenta-entities/src/testset/api/mutations.ts
+++ b/web/packages/agenta-entities/src/testset/api/mutations.ts
@@ -6,7 +6,7 @@
  */
 
 import {axios, getAgentaApiUrl} from "@agenta/shared/api"
-import {validateUUID} from "@agenta/shared/utils"
+import {slugifyName, validateUUID} from "@agenta/shared/utils"
 
 import type {TestsetRevisionDelta} from "../core"
 
@@ -21,19 +21,16 @@ import type {TestsetRevisionDelta} from "../core"
 export async function createTestset(params: {
     projectId: string
     name: string
+    slug?: string
     testcases?: Record<string, unknown>[]
     commitMessage?: string
 }) {
-    const {projectId, name, testcases = [], commitMessage} = params
+    const {projectId, name, slug: explicitSlug, testcases = [], commitMessage} = params
 
     // Transform testcases to the format expected by the API
     const formattedTestcases = testcases.map((row) => ({data: row}))
 
-    // Create URL-safe slug
-    const slug = name
-        .toLowerCase()
-        .replace(/\s+/g, "_")
-        .replace(/[^a-z0-9_-]/g, "")
+    const slug = explicitSlug || slugifyName(name) || "testset"
 
     const response = await axios.post(
         `${getAgentaApiUrl()}/simple/testsets/`,

--- a/web/packages/agenta-entities/src/testset/state/mutations.ts
+++ b/web/packages/agenta-entities/src/testset/state/mutations.ts
@@ -63,6 +63,19 @@ interface Column {
     name: string
 }
 
+type ErrorWithResponseStatus = Error & {response?: {status?: number}}
+
+function preserveResponseStatus(error: unknown): ErrorWithResponseStatus {
+    const err = (
+        error instanceof Error ? error : new Error(String(error))
+    ) as ErrorWithResponseStatus
+    const status = (error as {response?: {status?: number}})?.response?.status
+    if (status !== undefined) {
+        err.response = {status}
+    }
+    return err
+}
+
 // Derive current columns from testcase entities + revision-level pending ops
 const currentColumnsAtom = atom<Column[]>((get) => {
     const revisionId = get(currentRevisionIdAtom)
@@ -418,6 +431,10 @@ export const saveTestsetAtom = atom(
 export interface SaveNewTestsetParams {
     projectId: string
     testsetName: string
+    /** Slug for the new testset. When provided, overrides API fallback generation. */
+    slug?: string
+    /** Optional initial commit message for the created revision. */
+    commitMessage?: string
     /**
      * Optional explicit testcase data. When provided, this data is used directly
      * instead of reading from newEntityIdsAtom. Used by the loadable controller
@@ -444,7 +461,7 @@ export interface SaveNewTestsetResult {
 export const saveNewTestsetAtom = atom(
     null,
     async (get, set, params: SaveNewTestsetParams): Promise<SaveNewTestsetResult> => {
-        const {projectId, testsetName, explicitTestcaseData} = params
+        const {projectId, testsetName, slug, commitMessage, explicitTestcaseData} = params
 
         if (!projectId || !testsetName.trim()) {
             return {success: false, error: new Error("Missing projectId or testsetName")}
@@ -484,7 +501,9 @@ export const saveNewTestsetAtom = atom(
             const response = await createTestset({
                 projectId,
                 name: testsetName,
+                slug,
                 testcases: testcaseData,
+                commitMessage,
             })
 
             if (response?.revisionId) {
@@ -513,7 +532,7 @@ export const saveNewTestsetAtom = atom(
 
             return {success: false, error: new Error("No revision ID returned from API")}
         } catch (error) {
-            return {success: false, error: error as Error}
+            return {success: false, error: preserveResponseStatus(error)}
         }
     },
 )

--- a/web/packages/agenta-entities/src/testset/state/mutations.ts
+++ b/web/packages/agenta-entities/src/testset/state/mutations.ts
@@ -6,6 +6,7 @@
  */
 
 import {projectIdAtom} from "@agenta/shared/state"
+import {preserveResponseStatus} from "@agenta/shared/utils"
 import {atom} from "jotai"
 
 import {isRecord} from "../../shared"
@@ -61,19 +62,6 @@ const DATA_INTERNAL_FIELDS = new Set([
 interface Column {
     key: string
     name: string
-}
-
-type ErrorWithResponseStatus = Error & {response?: {status?: number}}
-
-function preserveResponseStatus(error: unknown): ErrorWithResponseStatus {
-    const err = (
-        error instanceof Error ? error : new Error(String(error))
-    ) as ErrorWithResponseStatus
-    const status = (error as {response?: {status?: number}})?.response?.status
-    if (status !== undefined) {
-        err.response = {status}
-    }
-    return err
 }
 
 // Derive current columns from testcase entities + revision-level pending ops

--- a/web/packages/agenta-entities/src/workflow/api/createFromTemplate.ts
+++ b/web/packages/agenta-entities/src/workflow/api/createFromTemplate.ts
@@ -30,9 +30,10 @@ export enum AppServiceType {
 
 export interface CreateAppFromTemplateParams {
     projectId: string
-    organizationId?: string
-    workspaceId?: string
+    organizationId?: string | null
+    workspaceId?: string | null
     appName: string
+    slug?: string
     templateKey: string
     serviceUrl?: string
     folderId?: string | null
@@ -152,6 +153,7 @@ function normalizeCatalogKey(templateKey: string): string {
 export async function createAppFromTemplate({
     projectId,
     appName,
+    slug: explicitSlug,
     templateKey,
     serviceUrl,
     folderId,
@@ -194,7 +196,7 @@ export async function createAppFromTemplate({
     onConfiguring?.()
 
     // Step 2: Create workflow with template data
-    const slug = generateSlug(appName)
+    const slug = explicitSlug ?? generateSlug(appName)
 
     const workflow = await createWorkflow(projectId, {
         slug,

--- a/web/packages/agenta-entities/src/workflow/state/commit.ts
+++ b/web/packages/agenta-entities/src/workflow/state/commit.ts
@@ -53,6 +53,17 @@ import {
 // HELPERS
 // ============================================================================
 
+type ErrorWithResponseStatus = Error & {response?: {status?: number}}
+
+function preserveResponseStatus(error: unknown, message: string): ErrorWithResponseStatus {
+    const err = new Error(message) as ErrorWithResponseStatus
+    const status = (error as {response?: {status?: number}})?.response?.status
+    if (status !== undefined) {
+        err.response = {status}
+    }
+    return err
+}
+
 /**
  * Prepare parameters for the commit API.
  * For evaluator workflows, flattens nested params (prompt.messages → prompt_template)
@@ -332,6 +343,8 @@ export interface WorkflowCreateVariantParams {
     baseRevisionId: string
     /** Name for the new variant */
     newVariantName: string
+    /** Slug suffix for the new variant. The workflow slug prefix is preserved internally. */
+    slug?: string
     /** Commit message for the first revision */
     commitMessage?: string
 }
@@ -372,7 +385,7 @@ export const createWorkflowVariantAtom = atom(
         set,
         params: WorkflowCreateVariantParams,
     ): Promise<WorkflowCreateVariantOutcome> => {
-        const {baseRevisionId, newVariantName, commitMessage} = params
+        const {baseRevisionId, newVariantName, slug: explicitSlug, commitMessage} = params
 
         try {
             const projectId = get(projectIdAtom)
@@ -399,9 +412,11 @@ export const createWorkflowVariantAtom = atom(
             const allWorkflows = get(workflowsListDataAtom)
             const workflowArtifact = allWorkflows.find((w) => w.id === workflowId)
             const variantSlugSuffix = generateSlug(newVariantName)
-            const slug = workflowArtifact?.slug
-                ? `${workflowArtifact.slug}.${variantSlugSuffix}`
-                : variantSlugSuffix
+            const requestedSlug = explicitSlug || variantSlugSuffix
+            const slug =
+                workflowArtifact?.slug && !requestedSlug.startsWith(`${workflowArtifact.slug}.`)
+                    ? `${workflowArtifact.slug}.${requestedSlug}`
+                    : requestedSlug
             const newVariant = await createWorkflowVariantApi(projectId, {
                 workflowId,
                 slug,
@@ -475,7 +490,7 @@ export const createWorkflowVariantAtom = atom(
                 newVariantId: newVariant.id,
             }
         } catch (error) {
-            const err = new Error(extractApiErrorMessage(error))
+            const err = preserveResponseStatus(error, extractApiErrorMessage(error))
             return {
                 success: false,
                 error: err,
@@ -498,6 +513,8 @@ export interface WorkflowCreateFromEphemeralParams {
     commitMessage?: string
     /** Display name for the new workflow (overrides entity name) */
     name?: string
+    /** Slug for the new workflow. When provided, overrides auto-generation. */
+    slug?: string
 }
 
 /**
@@ -518,7 +535,7 @@ export interface WorkflowCreateFromEphemeralParams {
 export const createWorkflowFromEphemeralAtom = atom(
     null,
     async (get, set, params: WorkflowCreateFromEphemeralParams): Promise<WorkflowCommitOutcome> => {
-        const {revisionId, commitMessage, name} = params
+        const {revisionId, commitMessage, name, slug} = params
 
         try {
             const projectId = get(projectIdAtom)
@@ -538,7 +555,7 @@ export const createWorkflowFromEphemeralAtom = atom(
 
             // 2. Generate a unique slug (never use the template key)
             const workflowName = name || entity.name || "Workflow"
-            const workflowSlug = generateSlug(workflowName)
+            const workflowSlug = slug || generateSlug(workflowName)
 
             // 3. Create workflow via API
             const newWorkflow = await createWorkflowApi(projectId, {
@@ -585,7 +602,7 @@ export const createWorkflowFromEphemeralAtom = atom(
 
             return result
         } catch (error) {
-            const err = new Error(extractApiErrorMessage(error))
+            const err = preserveResponseStatus(error, extractApiErrorMessage(error))
 
             if (_commitCallbacks.onError) {
                 _commitCallbacks.onError(err, {revisionId, commitMessage})

--- a/web/packages/agenta-entities/src/workflow/state/commit.ts
+++ b/web/packages/agenta-entities/src/workflow/state/commit.ts
@@ -23,7 +23,11 @@
  */
 
 import {projectIdAtom} from "@agenta/shared/state"
-import {extractApiErrorMessage, stripAgentaMetadataDeep} from "@agenta/shared/utils"
+import {
+    extractApiErrorMessage,
+    preserveResponseStatus,
+    stripAgentaMetadataDeep,
+} from "@agenta/shared/utils"
 import {atom, getDefaultStore} from "jotai"
 
 import {flattenEvaluatorConfiguration} from "../../runnable/evaluatorTransforms"
@@ -52,17 +56,6 @@ import {
 // ============================================================================
 // HELPERS
 // ============================================================================
-
-type ErrorWithResponseStatus = Error & {response?: {status?: number}}
-
-function preserveResponseStatus(error: unknown, message: string): ErrorWithResponseStatus {
-    const err = new Error(message) as ErrorWithResponseStatus
-    const status = (error as {response?: {status?: number}})?.response?.status
-    if (status !== undefined) {
-        err.response = {status}
-    }
-    return err
-}
 
 /**
  * Prepare parameters for the commit API.

--- a/web/packages/agenta-entity-ui/src/index.ts
+++ b/web/packages/agenta-entity-ui/src/index.ts
@@ -289,6 +289,7 @@ export {
     type CommitSubmitParams,
     type CommitSubmitResult,
     type CommitModeOption,
+    type CommitCreateFieldsConfig,
     // Commit modal state atoms
     commitModalOpenAtom,
     commitModalEntityAtom,

--- a/web/packages/agenta-entity-ui/src/modals/commit/components/EntityCommitContent.tsx
+++ b/web/packages/agenta-entity-ui/src/modals/commit/components/EntityCommitContent.tsx
@@ -9,6 +9,7 @@ import {useState, useEffect, useRef} from "react"
 
 import {
     formatCount,
+    generateSlugWithExistingSuffix,
     generateSlugWithSuffix,
     getSlugSuffix,
     isValidSlug,
@@ -115,7 +116,10 @@ export function EntityCommitContent({
             return
         }
         if (entityName.trim()) {
-            const generatedSlug = generateSlugWithSuffix(entityName)
+            const generatedSlug = generateSlugWithExistingSuffix(
+                entityName,
+                generatedSlugSuffixRef.current,
+            )
             generatedSlugSuffixRef.current = getSlugSuffix(generatedSlug)
             setEntitySlug(generatedSlug)
             slugInitializedRef.current = true

--- a/web/packages/agenta-entity-ui/src/modals/commit/components/EntityCommitContent.tsx
+++ b/web/packages/agenta-entity-ui/src/modals/commit/components/EntityCommitContent.tsx
@@ -103,37 +103,58 @@ export function EntityCommitContent({
     const setSlugFieldError = useSetAtom(setCommitSlugFieldErrorAtom)
     const slugInitializedRef = useRef(false)
     const generatedSlugSuffixRef = useRef<string | null>(null)
+    const slugManuallyEditedRef = useRef(false)
 
     useEffect(() => {
         if (!entityNameEditable) {
             slugInitializedRef.current = false
             generatedSlugSuffixRef.current = null
+            slugManuallyEditedRef.current = false
+            setSlugEditing(false)
             return
         }
-        if (entitySlug !== null) {
-            generatedSlugSuffixRef.current = getSlugSuffix(entitySlug)
+
+        if (!entityName.trim()) {
+            generatedSlugSuffixRef.current = null
+            slugInitializedRef.current = false
+            slugManuallyEditedRef.current = false
+            setSlugEditing(false)
+            if (entitySlug !== null) {
+                setEntitySlug(null)
+            }
+            return
+        }
+
+        if (slugManuallyEditedRef.current) {
+            generatedSlugSuffixRef.current = entitySlug ? getSlugSuffix(entitySlug) : null
             slugInitializedRef.current = true
             return
         }
-        if (entityName.trim()) {
-            const generatedSlug = generateSlugWithExistingSuffix(
-                entityName,
-                generatedSlugSuffixRef.current,
-            )
-            generatedSlugSuffixRef.current = getSlugSuffix(generatedSlug)
+
+        const generatedSlug = generateSlugWithExistingSuffix(
+            entityName,
+            generatedSlugSuffixRef.current,
+        )
+        generatedSlugSuffixRef.current = getSlugSuffix(generatedSlug)
+
+        if (entitySlug !== generatedSlug) {
             setEntitySlug(generatedSlug)
-            slugInitializedRef.current = true
         }
-    }, [entityNameEditable, entityName, entitySlug, setEntitySlug])
+
+        slugInitializedRef.current = true
+    }, [entityNameEditable, entityName, entitySlug, setEntitySlug, setSlugEditing])
 
     useEffect(() => {
         if (!entityName && !entitySlug) {
             slugInitializedRef.current = false
             generatedSlugSuffixRef.current = null
+            slugManuallyEditedRef.current = false
+            setSlugEditing(false)
         }
-    }, [entityName, entitySlug])
+    }, [entityName, entitySlug, setSlugEditing])
 
     const handleSlugInputChange = (value: string) => {
+        slugManuallyEditedRef.current = true
         setEntitySlug(value)
         setSlugFieldError(null)
     }
@@ -347,12 +368,20 @@ export function EntityCommitContent({
                                         )}
                                     </>
                                 ) : (
-                                    <div className="flex items-center gap-2">
-                                        <Text className="font-medium">Slug:</Text>
-                                        <Tag className="bg-gray-100 font-mono text-gray-500">
+                                    <div className="flex min-w-0 items-center gap-2">
+                                        <Text className="shrink-0 font-medium">Slug:</Text>
+                                        <Tag
+                                            className="min-w-0 max-w-[min(220px,calc(100%-88px))] truncate bg-gray-100 font-mono text-gray-500"
+                                            title={entitySlug}
+                                        >
                                             {entitySlug}
                                         </Tag>
-                                        <Button type="link" size="small" onClick={handleEditClick}>
+                                        <Button
+                                            type="link"
+                                            size="small"
+                                            className="shrink-0"
+                                            onClick={handleEditClick}
+                                        >
                                             Edit
                                         </Button>
                                     </div>

--- a/web/packages/agenta-entity-ui/src/modals/commit/components/EntityCommitContent.tsx
+++ b/web/packages/agenta-entity-ui/src/modals/commit/components/EntityCommitContent.tsx
@@ -5,25 +5,38 @@
  * Supports version info, changes summary, and diff view via adapter.
  */
 
-import {useState, useEffect} from "react"
+import {useState, useEffect, useRef} from "react"
 
-import {formatCount} from "@agenta/shared/utils"
+import {
+    formatCount,
+    generateSlugWithSuffix,
+    getSlugSuffix,
+    isValidSlug,
+    regenerateSlugSuffix,
+} from "@agenta/shared/utils"
 import {CommitMessageInput} from "@agenta/ui/components/presentational"
 import {VersionBadge} from "@agenta/ui/components/presentational"
 import {DiffView} from "@agenta/ui/editor"
 import {cn, textColors} from "@agenta/ui/styles"
-import {Input, Alert, Typography, Radio} from "antd"
+import {ArrowClockwise, WarningCircle} from "@phosphor-icons/react"
+import {Input, Alert, Typography, Radio, Button, Tag} from "antd"
 import {useAtomValue, useSetAtom} from "jotai"
 
 import {
     commitModalEntityNameAtom,
+    commitModalEntitySlugAtom,
     commitModalMessageAtom,
     commitModalErrorAtom,
     commitModalCanCommitAtom,
     commitModalContextAtom,
     commitModalActionLabelAtom,
+    commitModalSlugEditingAtom,
+    commitModalSlugFieldErrorAtom,
     setCommitMessageAtom,
     setCommitEntityNameAtom,
+    setCommitEntitySlugAtom,
+    setCommitSlugEditingAtom,
+    setCommitSlugFieldErrorAtom,
 } from "../state"
 
 // Lazy load DiffView to avoid bundling Lexical editor in _app chunk
@@ -45,6 +58,8 @@ export interface EntityCommitContentProps {
     modeLabel?: string
     /** When true, shows the entity name as an editable input field (for Create flows) */
     entityNameEditable?: boolean
+    /** Label for the editable entity name field. Defaults to "Name". */
+    entityNameLabel?: string
 }
 
 /**
@@ -69,15 +84,79 @@ export function EntityCommitContent({
     extraContent,
     modeLabel,
     entityNameEditable = false,
+    entityNameLabel = "Name",
 }: EntityCommitContentProps) {
     const entityName = useAtomValue(commitModalEntityNameAtom)
+    const entitySlug = useAtomValue(commitModalEntitySlugAtom)
     const message = useAtomValue(commitModalMessageAtom)
     const error = useAtomValue(commitModalErrorAtom)
     const canCommit = useAtomValue(commitModalCanCommitAtom)
     const context = useAtomValue(commitModalContextAtom)
     const actionLabel = useAtomValue(commitModalActionLabelAtom)
+    const slugEditing = useAtomValue(commitModalSlugEditingAtom)
+    const slugFieldError = useAtomValue(commitModalSlugFieldErrorAtom)
     const setMessage = useSetAtom(setCommitMessageAtom)
     const setEntityName = useSetAtom(setCommitEntityNameAtom)
+    const setEntitySlug = useSetAtom(setCommitEntitySlugAtom)
+    const setSlugEditing = useSetAtom(setCommitSlugEditingAtom)
+    const setSlugFieldError = useSetAtom(setCommitSlugFieldErrorAtom)
+    const slugInitializedRef = useRef(false)
+    const generatedSlugSuffixRef = useRef<string | null>(null)
+
+    useEffect(() => {
+        if (!entityNameEditable) {
+            slugInitializedRef.current = false
+            generatedSlugSuffixRef.current = null
+            return
+        }
+        if (entitySlug !== null) {
+            generatedSlugSuffixRef.current = getSlugSuffix(entitySlug)
+            slugInitializedRef.current = true
+            return
+        }
+        if (entityName.trim()) {
+            const generatedSlug = generateSlugWithSuffix(entityName)
+            generatedSlugSuffixRef.current = getSlugSuffix(generatedSlug)
+            setEntitySlug(generatedSlug)
+            slugInitializedRef.current = true
+        }
+    }, [entityNameEditable, entityName, entitySlug, setEntitySlug])
+
+    useEffect(() => {
+        if (!entityName && !entitySlug) {
+            slugInitializedRef.current = false
+            generatedSlugSuffixRef.current = null
+        }
+    }, [entityName, entitySlug])
+
+    const handleSlugInputChange = (value: string) => {
+        setEntitySlug(value)
+        setSlugFieldError(null)
+    }
+
+    const handleRegenerate = () => {
+        const generatedSlug = regenerateSlugSuffix(
+            entitySlug || entityName,
+            generatedSlugSuffixRef.current,
+        )
+        generatedSlugSuffixRef.current = getSlugSuffix(generatedSlug)
+        setEntitySlug(generatedSlug)
+        setSlugFieldError(null)
+    }
+
+    const handleEditClick = () => {
+        if (!entitySlug && entityName.trim()) {
+            const generatedSlug = generateSlugWithSuffix(entityName)
+            generatedSlugSuffixRef.current = getSlugSuffix(generatedSlug)
+            setEntitySlug(generatedSlug)
+        }
+        setSlugEditing(true)
+    }
+
+    const slugValidationError =
+        entitySlug && !isValidSlug(entitySlug)
+            ? "Slug may only contain a-z, 0-9, hyphens, underscores, and periods."
+            : null
 
     // Defer DiffView mounting until after the first paint so the modal
     // shell and form appear immediately without being blocked by Lexical
@@ -206,17 +285,76 @@ export function EntityCommitContent({
 
                 {/* Entity name — editable input for Create flows */}
                 {entityNameEditable && (
-                    <div className="flex flex-col gap-2">
-                        <label htmlFor="entity-name" className="font-medium text-gray-700">
-                            Name
-                        </label>
-                        <Input
-                            id="entity-name"
-                            value={entityName}
-                            onChange={(e) => setEntityName(e.target.value)}
-                            placeholder="Enter a name..."
-                            autoFocus
-                        />
+                    <div className="flex flex-col gap-3">
+                        <div className="flex flex-col gap-2">
+                            <label htmlFor="entity-name" className="font-medium text-gray-700">
+                                {entityNameLabel}
+                            </label>
+                            <Input
+                                id="entity-name"
+                                value={entityName}
+                                onChange={(e) => setEntityName(e.target.value)}
+                                placeholder="Enter a name..."
+                                autoFocus
+                            />
+                        </div>
+
+                        {entitySlug !== null && (
+                            <div className="flex flex-col gap-1">
+                                {slugEditing ? (
+                                    <>
+                                        <label htmlFor="entity-slug" className="font-medium mb-1">
+                                            Slug
+                                        </label>
+                                        <Input
+                                            id="entity-slug"
+                                            value={entitySlug}
+                                            onChange={(e) => handleSlugInputChange(e.target.value)}
+                                            status={
+                                                slugFieldError || slugValidationError
+                                                    ? "error"
+                                                    : undefined
+                                            }
+                                            autoFocus
+                                            suffix={
+                                                <Button
+                                                    type="text"
+                                                    size="small"
+                                                    icon={<ArrowClockwise size={14} />}
+                                                    onClick={handleRegenerate}
+                                                    title="Regenerate random suffix"
+                                                />
+                                            }
+                                        />
+                                        {(slugFieldError || slugValidationError) && (
+                                            <div className="mt-0.5 flex items-start gap-1 text-[#ff4d4f]">
+                                                <WarningCircle
+                                                    size={16}
+                                                    className="mt-0.5 shrink-0"
+                                                />
+                                                <span>{slugFieldError ?? slugValidationError}</span>
+                                            </div>
+                                        )}
+                                        {!slugFieldError && !slugValidationError && (
+                                            <Text className={cn(textColors.tertiary)}>
+                                                Edit freely - use the regenerate button to add a
+                                                random suffix back.
+                                            </Text>
+                                        )}
+                                    </>
+                                ) : (
+                                    <div className="flex items-center gap-2">
+                                        <Text className="font-medium">Slug:</Text>
+                                        <Tag className="bg-gray-100 font-mono text-gray-500">
+                                            {entitySlug}
+                                        </Tag>
+                                        <Button type="link" size="small" onClick={handleEditClick}>
+                                            Edit
+                                        </Button>
+                                    </div>
+                                )}
+                            </div>
+                        )}
                     </div>
                 )}
 
@@ -279,6 +417,7 @@ export function EntityCommitContent({
                         type="error"
                         title={`${actionLabel} failed`}
                         description={error.message}
+                        className="[&_.ant-alert]:!py-5"
                         showIcon
                     />
                 )}

--- a/web/packages/agenta-entity-ui/src/modals/commit/components/EntityCommitModal.tsx
+++ b/web/packages/agenta-entity-ui/src/modals/commit/components/EntityCommitModal.tsx
@@ -7,13 +7,18 @@
 
 import {useEffect, useCallback, useRef, useState, type ReactNode} from "react"
 
-import {extractApiErrorMessage} from "@agenta/shared/utils"
+import {extractApiErrorMessage, generateSlugWithSuffix, isValidSlug} from "@agenta/shared/utils"
 import {message} from "@agenta/ui/app-message"
 import {EnhancedModal} from "@agenta/ui/components/modal"
 import {useAtomValue, useSetAtom} from "jotai"
 
 import {revisionModalAdapter, testsetModalAdapter, variantModalAdapter} from "../../../adapters"
-import type {EntityReference, CommitSubmitResult, CommitSubmitParams} from "../../types"
+import type {
+    EntityReference,
+    CommitSubmitResult,
+    CommitSubmitParams,
+    CommitCreateFieldsConfig,
+} from "../../types"
 import {
     commitModalOpenAtom,
     commitModalContextAtom,
@@ -21,6 +26,7 @@ import {
     commitModalEntityNameAtom,
     commitModalMessageAtom,
     commitModalCanProceedAtom,
+    commitModalEntitySlugAtom,
     commitModalLoadingAtom,
     commitModalActionLabelAtom,
     resetCommitModalAtom,
@@ -29,6 +35,9 @@ import {
     setCommitErrorAtom,
     setCommitLoadingAtom,
     setCommitEntityNameAtom,
+    setCommitEntitySlugAtom,
+    setCommitSlugEditingAtom,
+    setCommitSlugFieldErrorAtom,
 } from "../state"
 
 import {EntityCommitContent, type CommitModeOption} from "./EntityCommitContent"
@@ -40,7 +49,7 @@ void testsetModalAdapter
 void revisionModalAdapter
 void variantModalAdapter
 
-export type {CommitSubmitResult, CommitSubmitParams}
+export type {CommitSubmitResult, CommitSubmitParams, CommitCreateFieldsConfig}
 
 export interface EntityCommitModalProps {
     /** External control - override atom state */
@@ -67,8 +76,18 @@ export interface EntityCommitModalProps {
     defaultCommitMode?: string
     /** Optional extra content rendered between mode selector and commit message */
     renderModeContent?: (params: {mode?: string}) => ReactNode
+    /** Called whenever the selected commit mode changes */
+    onModeChange?: (mode: string | undefined) => void
     /** Additional submit guard from caller (e.g. requires variant name or environment) */
-    canSubmit?: (params: {mode?: string}) => boolean
+    canSubmit?: (params: {mode?: string; entityName?: string; entitySlug?: string}) => boolean
+    /**
+     * Enables the reusable create-name + slug fields.
+     *
+     * Usage:
+     * - `createEntityFields` for create flows without modes.
+     * - `createEntityFields={{modes: ["variant"], nameLabel: "Variant name"}}` for mode-based creates.
+     */
+    createEntityFields?: boolean | CommitCreateFieldsConfig
     /** Whether a commit message is required to proceed. Defaults to false. */
     commitMessageRequired?: boolean
     /** Label for the target in the version display when a non-default mode is selected (e.g. new variant name) */
@@ -79,10 +98,20 @@ export interface EntityCommitModalProps {
      */
     actionLabel?: string
     /**
+     * @deprecated Use `createEntityFields` instead.
      * When true, the entity name is shown as an editable input field.
-     * Useful for "Create" flows where the user should be able to rename before creating.
      */
     entityNameEditable?: boolean
+    /** Modes where the modal should show editable name + slug fields. */
+    entityNameEditableModes?: string[]
+    /** Label for the editable entity name field. Defaults to "Name". */
+    entityNameLabel?: string
+}
+
+const SLUG_CONFLICT_MESSAGE = "A resource with this slug already exists in this project."
+
+function getErrorStatus(error: unknown): number | undefined {
+    return (error as {response?: {status?: number}})?.response?.status
 }
 
 /**
@@ -126,16 +155,21 @@ export function EntityCommitModal({
     commitModes,
     defaultCommitMode,
     renderModeContent,
+    onModeChange,
     canSubmit,
     commitMessageRequired = false,
     modeLabel,
     actionLabel = "Commit",
+    createEntityFields,
     entityNameEditable = false,
+    entityNameEditableModes,
+    entityNameLabel = "Name",
 }: EntityCommitModalProps) {
     const internalOpen = useAtomValue(commitModalOpenAtom)
     const context = useAtomValue(commitModalContextAtom)
     const currentEntity = useAtomValue(commitModalEntityAtom)
     const entityName = useAtomValue(commitModalEntityNameAtom)
+    const entitySlug = useAtomValue(commitModalEntitySlugAtom)
     const commitMessage = useAtomValue(commitModalMessageAtom)
     const canProceed = useAtomValue(commitModalCanProceedAtom)
     const isLoading = useAtomValue(commitModalLoadingAtom)
@@ -148,8 +182,12 @@ export function EntityCommitModal({
     const setCommitError = useSetAtom(setCommitErrorAtom)
     const setCommitLoading = useSetAtom(setCommitLoadingAtom)
     const setEntityName = useSetAtom(setCommitEntityNameAtom)
+    const setEntitySlug = useSetAtom(setCommitEntitySlugAtom)
+    const setSlugEditing = useSetAtom(setCommitSlugEditingAtom)
+    const setSlugFieldError = useSetAtom(setCommitSlugFieldErrorAtom)
     const wasExternallyOpenRef = useRef(false)
     const syncedEntityRef = useRef<{id: string; type: string} | null>(null)
+    const previousCreateFieldsEnabledRef = useRef(false)
     // Track current externalOpen value in a ref to avoid stale closures in afterClose callbacks
     const externalOpenRef = useRef(externalOpen)
     externalOpenRef.current = externalOpen
@@ -161,6 +199,26 @@ export function EntityCommitModal({
     const isExternallyControlled = externalOpen !== undefined
     // Determine actual open state
     const isOpen = isExternallyControlled ? Boolean(externalOpen) : internalOpen
+    const createFieldsEntity = currentEntity ?? externalEntity ?? null
+    const createFieldsConfig =
+        typeof createEntityFields === "object" ? createEntityFields : undefined
+    const createFieldsModes = createFieldsConfig?.modes
+    const createFieldsEnabled =
+        createEntityFields === true ||
+        Boolean(
+            createFieldsConfig &&
+            (!createFieldsModes?.length ||
+                (selectedMode && createFieldsModes.includes(selectedMode))),
+        )
+    const isEntityNameEditable =
+        entityNameEditable ||
+        createFieldsEnabled ||
+        Boolean(selectedMode && entityNameEditableModes?.includes(selectedMode))
+    const configuredNameLabel = createFieldsConfig?.nameLabel
+    const resolvedEntityNameLabel =
+        typeof configuredNameLabel === "function"
+            ? configuredNameLabel({entity: createFieldsEntity, mode: selectedMode})
+            : (configuredNameLabel ?? entityNameLabel)
 
     // Check if diff data is available for dynamic width
     const hasDiffData = context?.diffData?.original && context?.diffData?.modified
@@ -185,6 +243,9 @@ export function EntityCommitModal({
             setCommitError(null)
             setCommitLoading(false)
             setEntityName(null)
+            setEntitySlug(null)
+            setSlugEditing(false)
+            setSlugFieldError(null)
         }
 
         if (!externalOpen) {
@@ -204,6 +265,9 @@ export function EntityCommitModal({
         setCommitError,
         setCommitLoading,
         setEntityName,
+        setEntitySlug,
+        setSlugEditing,
+        setSlugFieldError,
     ])
 
     useEffect(() => {
@@ -211,6 +275,59 @@ export function EntityCommitModal({
             setSelectedMode(defaultCommitMode ?? commitModes?.[0]?.id)
         }
     }, [isOpen, defaultCommitMode, commitModes])
+
+    useEffect(() => {
+        onModeChange?.(selectedMode)
+    }, [selectedMode, onModeChange])
+
+    useEffect(() => {
+        if (!isOpen) {
+            previousCreateFieldsEnabledRef.current = false
+            return
+        }
+
+        const wasCreateFieldsEnabled = previousCreateFieldsEnabledRef.current
+        previousCreateFieldsEnabledRef.current = isEntityNameEditable
+
+        if (isEntityNameEditable && !wasCreateFieldsEnabled) {
+            const configuredDefaultName = createFieldsConfig?.defaultName
+            const defaultCreateName =
+                typeof configuredDefaultName === "function"
+                    ? configuredDefaultName({entity: createFieldsEntity, mode: selectedMode})
+                    : configuredDefaultName !== undefined
+                      ? configuredDefaultName
+                      : createFieldsModes?.length || entityNameEditableModes?.length
+                        ? createFieldsEntity?.name
+                            ? `${createFieldsEntity.name} copy`
+                            : ""
+                        : (createFieldsEntity?.name ?? "")
+            setEntityName(defaultCreateName)
+            setEntitySlug(
+                defaultCreateName.trim() ? generateSlugWithSuffix(defaultCreateName) : null,
+            )
+            setSlugEditing(false)
+            setSlugFieldError(null)
+        }
+
+        if (!isEntityNameEditable && wasCreateFieldsEnabled) {
+            setEntityName(null)
+            setEntitySlug(null)
+            setSlugEditing(false)
+            setSlugFieldError(null)
+        }
+    }, [
+        isOpen,
+        selectedMode,
+        isEntityNameEditable,
+        createFieldsConfig?.defaultName,
+        createFieldsModes,
+        entityNameEditableModes,
+        createFieldsEntity,
+        setEntityName,
+        setEntitySlug,
+        setSlugEditing,
+        setSlugFieldError,
+    ])
 
     const handleClose = useCallback(() => {
         if (!isExternallyControlled) {
@@ -236,8 +353,20 @@ export function EntityCommitModal({
     )
 
     const messageValid = !commitMessageRequired || commitMessage.trim().length > 0
+    const nameSlugValid =
+        !isEntityNameEditable ||
+        (entityName.trim().length > 0 && Boolean(entitySlug) && isValidSlug(entitySlug ?? ""))
     const canProceedWithExtension =
-        canProceed && messageValid && (canSubmit ? canSubmit({mode: selectedMode}) : true)
+        canProceed &&
+        messageValid &&
+        nameSlugValid &&
+        (canSubmit
+            ? canSubmit({
+                  mode: selectedMode,
+                  entityName: entityName || undefined,
+                  entitySlug: entitySlug || undefined,
+              })
+            : true)
 
     const handleConfirm = useCallback(async () => {
         if (onSubmit) {
@@ -245,6 +374,7 @@ export function EntityCommitModal({
 
             setCommitLoading(true)
             setCommitError(null)
+            setSlugFieldError(null)
 
             try {
                 const result = await onSubmit({
@@ -252,9 +382,15 @@ export function EntityCommitModal({
                     message: commitMessage.trim(),
                     mode: selectedMode,
                     entityName: entityName || undefined,
+                    entitySlug: entitySlug || undefined,
                 })
 
                 if (!result.success) {
+                    const isSlugConflict = result.slugConflict || result.errorStatus === 409
+                    if (isSlugConflict) {
+                        setSlugFieldError(SLUG_CONFLICT_MESSAGE)
+                        setSlugEditing(true)
+                    }
                     setCommitError(
                         new Error(extractApiErrorMessage(result.error || "Commit failed")),
                     )
@@ -278,6 +414,10 @@ export function EntityCommitModal({
                 return
             } catch (error) {
                 const msg = extractApiErrorMessage(error)
+                if (getErrorStatus(error) === 409) {
+                    setSlugFieldError(SLUG_CONFLICT_MESSAGE)
+                    setSlugEditing(true)
+                }
                 setCommitError(
                     error instanceof Error ? Object.assign(error, {message: msg}) : new Error(msg),
                 )
@@ -300,8 +440,11 @@ export function EntityCommitModal({
         onSubmit,
         currentEntity,
         entityName,
+        entitySlug,
         setCommitLoading,
         setCommitError,
+        setSlugFieldError,
+        setSlugEditing,
         commitMessage,
         selectedMode,
         isExternallyControlled,
@@ -345,7 +488,8 @@ export function EntityCommitModal({
                 onModeChange={setSelectedMode}
                 extraContent={renderModeContent?.({mode: selectedMode})}
                 modeLabel={modeLabel}
-                entityNameEditable={entityNameEditable}
+                entityNameEditable={isEntityNameEditable}
+                entityNameLabel={resolvedEntityNameLabel}
             />
         </EnhancedModal>
     )

--- a/web/packages/agenta-entity-ui/src/modals/commit/components/index.ts
+++ b/web/packages/agenta-entity-ui/src/modals/commit/components/index.ts
@@ -7,6 +7,7 @@ export type {
     EntityCommitModalProps,
     CommitSubmitParams,
     CommitSubmitResult,
+    CommitCreateFieldsConfig,
 } from "./EntityCommitModal"
 export {EntityCommitTitle} from "./EntityCommitTitle"
 export {EntityCommitContent} from "./EntityCommitContent"

--- a/web/packages/agenta-entity-ui/src/modals/commit/index.ts
+++ b/web/packages/agenta-entity-ui/src/modals/commit/index.ts
@@ -16,6 +16,7 @@ export type {
     CommitSubmitParams,
     CommitSubmitResult,
     CommitModeOption,
+    CommitCreateFieldsConfig,
     EntityCommitContentProps,
 } from "./components"
 

--- a/web/packages/agenta-entity-ui/src/modals/commit/state.ts
+++ b/web/packages/agenta-entity-ui/src/modals/commit/state.ts
@@ -58,6 +58,25 @@ export const commitModalErrorAtom = atomWithReset<Error | null>(null)
  */
 export const commitModalEntityNameOverrideAtom = atomWithReset<string | null>(null)
 
+/**
+ * The slug for the entity being created.
+ * Generated once when the modal opens with a name.
+ * User may edit it or regenerate the suffix.
+ */
+export const commitModalEntitySlugAtom = atomWithReset<string | null>(null)
+
+/**
+ * Whether the slug field is in "editing" mode.
+ * Default state shows the slug as a read-only badge with an Edit link.
+ */
+export const commitModalSlugEditingAtom = atomWithReset(false)
+
+/**
+ * Field-level error for the slug input.
+ * Distinct from commitModalErrorAtom which drives the banner.
+ */
+export const commitModalSlugFieldErrorAtom = atomWithReset<string | null>(null)
+
 // ============================================================================
 // DERIVED ATOMS
 // ============================================================================
@@ -145,6 +164,9 @@ export const resetCommitModalAtom = atom(null, (_get, set) => {
     set(commitModalErrorAtom, RESET)
     set(commitModalActionLabelAtom, RESET)
     set(commitModalEntityNameOverrideAtom, RESET)
+    set(commitModalEntitySlugAtom, RESET)
+    set(commitModalSlugEditingAtom, RESET)
+    set(commitModalSlugFieldErrorAtom, RESET)
 })
 
 /**
@@ -200,6 +222,27 @@ export const setCommitErrorAtom = atom(null, (_get, set, error: Error | null) =>
  */
 export const setCommitEntityNameAtom = atom(null, (_get, set, name: string | null) => {
     set(commitModalEntityNameOverrideAtom, name)
+})
+
+/**
+ * Set the entity slug.
+ */
+export const setCommitEntitySlugAtom = atom(null, (_get, set, slug: string | null) => {
+    set(commitModalEntitySlugAtom, slug)
+})
+
+/**
+ * Set the slug field-level error.
+ */
+export const setCommitSlugFieldErrorAtom = atom(null, (_get, set, error: string | null) => {
+    set(commitModalSlugFieldErrorAtom, error)
+})
+
+/**
+ * Toggle slug editing mode.
+ */
+export const setCommitSlugEditingAtom = atom(null, (_get, set, editing: boolean) => {
+    set(commitModalSlugEditingAtom, editing)
 })
 
 /**

--- a/web/packages/agenta-entity-ui/src/modals/index.ts
+++ b/web/packages/agenta-entity-ui/src/modals/index.ts
@@ -135,6 +135,7 @@ export type {
     CommitSubmitParams,
     CommitSubmitResult,
     CommitModeOption,
+    CommitCreateFieldsConfig,
     UseEntityCommitReturn,
     UseBoundCommitOptions,
     UseBoundCommitReturn,

--- a/web/packages/agenta-entity-ui/src/modals/types.ts
+++ b/web/packages/agenta-entity-ui/src/modals/types.ts
@@ -276,6 +276,10 @@ export interface CommitSubmitResult {
     success: boolean
     newRevisionId?: string
     error?: string
+    /** HTTP status from a failed submit, when available. */
+    errorStatus?: number
+    /** True when failure is known to be a slug collision. */
+    slugConflict?: boolean
 }
 
 export interface CommitSubmitParams {
@@ -284,6 +288,17 @@ export interface CommitSubmitParams {
     mode?: string
     /** The entity name (may have been edited by the user in the modal) */
     entityName?: string
+    /** The entity slug (user-edited or auto-generated, only present in create flows) */
+    entitySlug?: string
+}
+
+export interface CommitCreateFieldsConfig {
+    /** Modes where create fields should be shown. Omit to show them for the whole modal. */
+    modes?: string[]
+    /** Label for the editable entity name field. Defaults to "Name". */
+    nameLabel?: string | ((params: {entity: EntityReference | null; mode?: string}) => string)
+    /** Initial editable name. Defaults to current name, or "current name copy" for mode-based creates. */
+    defaultName?: string | ((params: {entity: EntityReference | null; mode?: string}) => string)
 }
 
 /**
@@ -312,10 +327,24 @@ export interface EntityCommitModalProps {
     defaultCommitMode?: string
     /** Optional extra content rendered between mode selector and commit message */
     renderModeContent?: (params: {mode?: string}) => ReactNode
+    /** Called whenever the selected commit mode changes */
+    onModeChange?: (mode: string | undefined) => void
     /** Additional submit guard from caller (e.g. requires variant name or environment) */
-    canSubmit?: (params: {mode?: string}) => boolean
+    canSubmit?: (params: {mode?: string; entityName?: string; entitySlug?: string}) => boolean
+    /**
+     * Enables the reusable create-name + slug fields.
+     *
+     * Usage:
+     * - `createEntityFields` for create flows without modes.
+     * - `createEntityFields={{modes: ["variant"], nameLabel: "Variant name"}}` for mode-based creates.
+     */
+    createEntityFields?: boolean | CommitCreateFieldsConfig
     /** Label for the target in the version display when a non-default mode is selected (e.g. new variant name) */
     modeLabel?: string
+    /** Modes where the modal should show editable name + slug fields. */
+    entityNameEditableModes?: string[]
+    /** Label for the editable entity name field. Defaults to "Name". */
+    entityNameLabel?: string
 }
 
 // ============================================================================

--- a/web/packages/agenta-playground/src/state/controllers/playgroundController.ts
+++ b/web/packages/agenta-playground/src/state/controllers/playgroundController.ts
@@ -1486,6 +1486,7 @@ const controllerCreateVariantAtom = atom(
         const result = await set(createWorkflowVariantAtom, {
             baseRevisionId,
             newVariantName: payload.newVariantName,
+            slug: payload.slug,
             commitMessage: payload.note,
         })
 
@@ -1493,6 +1494,7 @@ const controllerCreateVariantAtom = atom(
             return {
                 success: false,
                 error: result.error.message,
+                errorStatus: (result.error as {response?: {status?: number}}).response?.status,
             }
         }
 

--- a/web/packages/agenta-shared/src/utils/extractApiErrorMessage.ts
+++ b/web/packages/agenta-shared/src/utils/extractApiErrorMessage.ts
@@ -27,6 +27,28 @@ function extractMessageFromPayload(payload: unknown): string | null {
     return null
 }
 
+export type ErrorWithResponseStatus = Error & {response?: {status?: number}}
+
+/**
+ * Wraps an error value while preserving the HTTP response status, if present.
+ * Pass an explicit `message` to override the message (e.g. when using extractApiErrorMessage).
+ * Omit `message` to preserve the original error message.
+ */
+export function preserveResponseStatus(error: unknown, message?: string): ErrorWithResponseStatus {
+    const err = (
+        message !== undefined
+            ? new Error(message)
+            : error instanceof Error
+              ? error
+              : new Error(String(error))
+    ) as ErrorWithResponseStatus
+    const status = (error as {response?: {status?: number}})?.response?.status
+    if (status !== undefined) {
+        err.response = {status}
+    }
+    return err
+}
+
 /**
  * Extract a human-readable API error message from thrown values, including
  * Axios/Fetch-style payloads like `{detail: {message: "..."}}`.

--- a/web/packages/agenta-shared/src/utils/index.ts
+++ b/web/packages/agenta-shared/src/utils/index.ts
@@ -141,6 +141,7 @@ export {stripAgentaMetadataDeep, stripEnhancedWrappers} from "./valueExtraction"
 
 // Slug utilities
 export {
+    generateSlugWithExistingSuffix,
     generateSlugWithSuffix,
     getSlugSuffix,
     isValidSlug,

--- a/web/packages/agenta-shared/src/utils/index.ts
+++ b/web/packages/agenta-shared/src/utils/index.ts
@@ -102,7 +102,8 @@ export {
 export {dereferenceSchema, type DereferencedSchemaResult} from "./openapi"
 
 // API error utilities
-export {extractApiErrorMessage} from "./extractApiErrorMessage"
+export {extractApiErrorMessage, preserveResponseStatus} from "./extractApiErrorMessage"
+export type {ErrorWithResponseStatus} from "./extractApiErrorMessage"
 
 // Formatting utilities
 export {

--- a/web/packages/agenta-shared/src/utils/index.ts
+++ b/web/packages/agenta-shared/src/utils/index.ts
@@ -139,6 +139,16 @@ export {dataUriToObjectUrl, isBase64, isUrl} from "./dataUri"
 // Value extraction utilities (strip enhanced wrappers / metadata)
 export {stripAgentaMetadataDeep, stripEnhancedWrappers} from "./valueExtraction"
 
+// Slug utilities
+export {
+    generateSlugWithSuffix,
+    getSlugSuffix,
+    isValidSlug,
+    regenerateSlugSuffix,
+    slugifyName,
+    stripSlugSuffix,
+} from "./slug"
+
 // Status inference utilities
 export {
     getStatusColor,

--- a/web/packages/agenta-shared/src/utils/slug.ts
+++ b/web/packages/agenta-shared/src/utils/slug.ts
@@ -47,11 +47,6 @@ export function generateSlugWithExistingSuffix(name: string, suffix?: string | n
     return suffix ? `${base}-${suffix}` : generateSlugWithSuffix(name)
 }
 
-function getRandomSuffix(slug: string): string | null {
-    const match = slug.match(/-([a-z0-9]{4})$/)
-    return match ? match[1] : null
-}
-
 /**
  * Replaces a known generated suffix with a new random 4-character suffix.
  * If the current slug no longer ends with that known suffix, append a new one.
@@ -69,18 +64,19 @@ export function regenerateSlugSuffix(slug: string, suffixToReplace?: string | nu
 }
 
 /**
- * Strips the last hyphen-separated segment if it looks like a 4-character suffix.
- */
-export function stripSlugSuffix(slug: string): string {
-    const suffix = getRandomSuffix(slug)
-    return suffix ? slug.slice(0, -(suffix.length + 1)) : slug
-}
-
-/**
  * Returns the last generated-looking 4-character suffix, if present.
  */
 export function getSlugSuffix(slug: string): string | null {
-    return getRandomSuffix(slug)
+    const match = slug.match(/-([a-z0-9]{4})$/)
+    return match ? match[1] : null
+}
+
+/**
+ * Strips the last hyphen-separated segment if it looks like a 4-character suffix.
+ */
+export function stripSlugSuffix(slug: string): string {
+    const suffix = getSlugSuffix(slug)
+    return suffix ? slug.slice(0, -(suffix.length + 1)) : slug
 }
 
 /**

--- a/web/packages/agenta-shared/src/utils/slug.ts
+++ b/web/packages/agenta-shared/src/utils/slug.ts
@@ -1,0 +1,75 @@
+const SLUG_DIGIT_SET = "0123456789"
+
+function randomDigits(length: number): string {
+    return Array.from(
+        {length},
+        () => SLUG_DIGIT_SET[Math.floor(Math.random() * SLUG_DIGIT_SET.length)],
+    ).join("")
+}
+
+/**
+ * Converts a display name to a URL-safe slug base.
+ * Result is lowercase, hyphen-separated, no leading/trailing hyphens.
+ */
+export function slugifyName(name: string): string {
+    return name
+        .toLowerCase()
+        .trim()
+        .replace(/[^a-z0-9_.\-\s]/g, "")
+        .replace(/\s+/g, "-")
+        .replace(/-+/g, "-")
+        .replace(/^-|-$/g, "")
+}
+
+/**
+ * Generates a slug with a random 4-digit suffix to reduce collision probability.
+ */
+export function generateSlugWithSuffix(name: string): string {
+    const base = slugifyName(name) || "resource"
+    return `${base}-${randomDigits(4)}`
+}
+
+function getRandomSuffix(slug: string): string | null {
+    const match = slug.match(/-(\d{4})$/)
+    return match ? match[1] : null
+}
+
+/**
+ * Replaces a known generated suffix with a new random 4-digit suffix.
+ * If the current slug no longer ends with that known suffix, append a new one.
+ */
+export function regenerateSlugSuffix(slug: string, suffixToReplace?: string | null): string {
+    const normalizedSlug = slugifyName(slug) || "resource"
+    const normalizedSuffix = suffixToReplace?.toLowerCase()
+    const suffixMarker = normalizedSuffix ? `-${normalizedSuffix}` : ""
+    const base =
+        suffixMarker && normalizedSlug.endsWith(suffixMarker)
+            ? normalizedSlug.slice(0, -suffixMarker.length) || "resource"
+            : normalizedSlug
+
+    return `${base}-${randomDigits(4)}`
+}
+
+/**
+ * Strips the last hyphen-separated segment if it looks like a 4-digit suffix.
+ */
+export function stripSlugSuffix(slug: string): string {
+    const suffix = getRandomSuffix(slug)
+    return suffix ? slug.slice(0, -(suffix.length + 1)) : slug
+}
+
+/**
+ * Returns the last generated-looking 4-digit suffix, if present.
+ */
+export function getSlugSuffix(slug: string): string | null {
+    return getRandomSuffix(slug)
+}
+
+/**
+ * Returns true if the slug contains only valid characters.
+ */
+export function isValidSlug(slug: string): boolean {
+    if (slug.length < 1 || slug.length > 255) return false
+    if (/\.{2,}|-{2,}/.test(slug)) return false
+    return /^[a-z0-9][a-z0-9_.\-]*[a-z0-9]$/.test(slug) || /^[a-z0-9]$/.test(slug)
+}

--- a/web/packages/agenta-shared/src/utils/slug.ts
+++ b/web/packages/agenta-shared/src/utils/slug.ts
@@ -1,9 +1,19 @@
-const SLUG_DIGIT_SET = "0123456789"
+const SLUG_SUFFIX_CHAR_SET = "0123456789abcdefghijklmnopqrstuvwxyz"
 
-function randomDigits(length: number): string {
+function randomSuffix(length: number): string {
+    if (globalThis.crypto?.getRandomValues) {
+        const randomValues = new Uint32Array(length)
+        globalThis.crypto.getRandomValues(randomValues)
+
+        return Array.from(
+            randomValues,
+            (value) => SLUG_SUFFIX_CHAR_SET[value % SLUG_SUFFIX_CHAR_SET.length],
+        ).join("")
+    }
+
     return Array.from(
         {length},
-        () => SLUG_DIGIT_SET[Math.floor(Math.random() * SLUG_DIGIT_SET.length)],
+        () => SLUG_SUFFIX_CHAR_SET[Math.floor(Math.random() * SLUG_SUFFIX_CHAR_SET.length)],
     ).join("")
 }
 
@@ -22,20 +32,28 @@ export function slugifyName(name: string): string {
 }
 
 /**
- * Generates a slug with a random 4-digit suffix to reduce collision probability.
+ * Generates a slug with a random 4-character suffix to reduce collision probability.
  */
 export function generateSlugWithSuffix(name: string): string {
     const base = slugifyName(name) || "resource"
-    return `${base}-${randomDigits(4)}`
+    return `${base}-${randomSuffix(4)}`
+}
+
+/**
+ * Updates the slug base from a display name while preserving an existing suffix.
+ */
+export function generateSlugWithExistingSuffix(name: string, suffix?: string | null): string {
+    const base = slugifyName(name) || "resource"
+    return suffix ? `${base}-${suffix}` : generateSlugWithSuffix(name)
 }
 
 function getRandomSuffix(slug: string): string | null {
-    const match = slug.match(/-(\d{4})$/)
+    const match = slug.match(/-([a-z0-9]{4})$/)
     return match ? match[1] : null
 }
 
 /**
- * Replaces a known generated suffix with a new random 4-digit suffix.
+ * Replaces a known generated suffix with a new random 4-character suffix.
  * If the current slug no longer ends with that known suffix, append a new one.
  */
 export function regenerateSlugSuffix(slug: string, suffixToReplace?: string | null): string {
@@ -47,11 +65,11 @@ export function regenerateSlugSuffix(slug: string, suffixToReplace?: string | nu
             ? normalizedSlug.slice(0, -suffixMarker.length) || "resource"
             : normalizedSlug
 
-    return `${base}-${randomDigits(4)}`
+    return `${base}-${randomSuffix(4)}`
 }
 
 /**
- * Strips the last hyphen-separated segment if it looks like a 4-digit suffix.
+ * Strips the last hyphen-separated segment if it looks like a 4-character suffix.
  */
 export function stripSlugSuffix(slug: string): string {
     const suffix = getRandomSuffix(slug)
@@ -59,7 +77,7 @@ export function stripSlugSuffix(slug: string): string {
 }
 
 /**
- * Returns the last generated-looking 4-digit suffix, if present.
+ * Returns the last generated-looking 4-character suffix, if present.
  */
 export function getSlugSuffix(slug: string): string | null {
     return getRandomSuffix(slug)


### PR DESCRIPTION
## **PR Description**

Adds slug display/edit/regenerate support across entity creation and prompt creation flows.

This introduces a reusable slug utility flow that generates a human-readable slug from the entity name with a cryptographically random 4-character alphanumeric suffix. 

Included changes:
- Added shared slug utilities in `@agenta/shared`.
- Added slug display/edit/regenerate UI to entity commit modals for create/save-as-new flows.
- Added slug display/edit/regenerate UI to the Create New Prompt modal.

## **QA Requirements**

1. Create New Prompt modal
- Open Create New Prompt.
- Type a valid prompt name.
- Confirm slug appears below the name field in display mode.
- Confirm slug format is `<slugified-name>-<4 alphanumeric chars>`.
- Click `Edit`.
- Click regenerate.
- Confirm only the suffix changes.
- Change the slug


2. Entity commit modal create/save-as-new flows
- Open a committable entity modal where slug UI should appear.
- Confirm slug displays
- Confirm Edit opens the full slug input.
- Confirm name edits preserve the existing suffix.
- Confirm that regenerate changes the suffix manually.
- Confirm invalid slug blocks save/create.
- Confirm commit-as-existing/new-version flows that should not show slug UI still do not show it.