### PR TITLE
[fix] Resolve tracing inconsistencies in ingest/query

### DIFF
--- a/api/oss/src/apis/fastapi/tracing/models.py
+++ b/api/oss/src/apis/fastapi/tracing/models.py
@@ -52,6 +52,7 @@ class SpanRequest(BaseModel):
 class OTelLinksResponse(BaseModel):
     count: int = 0
     links: Optional[OTelLinks] = None
+    dropped: Optional[OTelLinks] = None
 
 
 class LinkResponse(BaseModel):

--- a/api/oss/src/apis/fastapi/tracing/router.py
+++ b/api/oss/src/apis/fastapi/tracing/router.py
@@ -221,17 +221,21 @@ class TracingRouter:
             except Exception:
                 log.warning("[tracing] Soft quota check failed", exc_info=True)
 
+        dropped: OTelLinks = []
+
         links = await self.service.ingest_spans(
             organization_id=UUID(request.state.organization_id),
             project_id=UUID(request.state.project_id),
             user_id=UUID(request.state.user_id),
             spans=spans_request.spans,
             traces=spans_request.traces,
+            dropped=dropped,
         )
 
         link_response = OTelLinksResponse(
-            count=len(links),
+            count=len(links) + len(dropped),
             links=links,
+            dropped=dropped or None,
         )
 
         return link_response

--- a/api/oss/src/core/tracing/dtos.py
+++ b/api/oss/src/core/tracing/dtos.py
@@ -24,6 +24,8 @@ from agenta.sdk.models.tracing import (  # noqa: F401
     TraceType,
     SpanType,
     AgMetricEntryAttributes,
+    AgVectorMetricEntryAttributes,
+    AgScalarMetricEntryAttributes,
     AgMetricsAttributes,
     AgTypeAttributes,
     AgDataAttributes,

--- a/api/oss/src/core/tracing/service.py
+++ b/api/oss/src/core/tracing/service.py
@@ -173,6 +173,7 @@ class TracingService:
         user_id: UUID,
         spans: Optional[OTelFlatSpans] = None,
         traces: Optional[OTelTraceTree] = None,
+        dropped: Optional[OTelLinks] = None,
     ) -> OTelLinks:
         _spans: Dict[str, Union[OTelSpan, OTelFlatSpans]] = dict()
 
@@ -202,7 +203,7 @@ class TracingService:
                                 )
                             )
 
-        span_dtos = parse_spans_from_request(_spans)
+        span_dtos = parse_spans_from_request(_spans, dropped=dropped)
 
         return await self.ingest_span_dtos(
             organization_id=organization_id,

--- a/api/oss/src/core/tracing/utils/attributes.py
+++ b/api/oss/src/core/tracing/utils/attributes.py
@@ -11,8 +11,9 @@ from oss.src.core.shared.dtos import Data, Flags, Meta, Tags
 from oss.src.core.tracing.dtos import (
     AgAttributes,
     AgDataAttributes,
-    AgMetricEntryAttributes,
     AgMetricsAttributes,
+    AgScalarMetricEntryAttributes,
+    AgVectorMetricEntryAttributes,
     AgTypeAttributes,
     Attributes,
     OTelAttributes,
@@ -69,6 +70,24 @@ def ensure_nested_dict(d: dict, *keys: str) -> dict:
             d[key] = {}
         d = d[key]
     return d
+
+
+def _coerce_scalar_metric_value(value):
+    if isinstance(value, bool):
+        return None
+
+    if isinstance(value, (int, float)):
+        return value
+
+    if isinstance(value, dict):
+        for key in ("total", "count", "value"):
+            nested = value.get(key)
+            if isinstance(nested, bool):
+                return None
+            if isinstance(nested, (int, float)):
+                return nested
+
+    return None
 
 
 def initialize_ag_attributes(attributes: Optional[dict]) -> dict:
@@ -151,13 +170,36 @@ def initialize_ag_attributes(attributes: Optional[dict]) -> dict:
     cleaned_metrics = {}
     for metric_key in AgMetricsAttributes.model_fields:
         raw_entry = ensure_nested_dict(metrics_dict, metric_key)
-        cleaned_entry = {
-            subkey: raw_entry.get(subkey, None)
-            for subkey in AgMetricEntryAttributes.model_fields
-        }
+        entry_fields = (
+            AgScalarMetricEntryAttributes.model_fields
+            if metric_key in {"duration", "errors"}
+            else AgVectorMetricEntryAttributes.model_fields
+        )
+        cleaned_entry = {subkey: raw_entry.get(subkey, None) for subkey in entry_fields}
+
+        for subkey in list(cleaned_entry.keys()):
+            value = cleaned_entry.get(subkey)
+            if value is None:
+                continue
+
+            if metric_key in {"duration", "errors"}:
+                coerced_value = _coerce_scalar_metric_value(value)
+                if coerced_value is None:
+                    unsupported.setdefault("metrics", {}).setdefault(metric_key, {})[
+                        subkey
+                    ] = value
+                    cleaned_entry[subkey] = None
+                else:
+                    cleaned_entry[subkey] = coerced_value
+            elif not isinstance(value, dict):
+                unsupported.setdefault("metrics", {}).setdefault(metric_key, {})[
+                    subkey
+                ] = value
+                cleaned_entry[subkey] = None
+
         cleaned_metrics[metric_key] = cleaned_entry
         for subkey in list(raw_entry.keys()):
-            if subkey not in AgMetricEntryAttributes.model_fields:
+            if subkey not in entry_fields:
                 unsupported.setdefault("metrics", {}).setdefault(metric_key, {})[
                     subkey
                 ] = raw_entry[subkey]

--- a/api/oss/src/core/tracing/utils/parsing.py
+++ b/api/oss/src/core/tracing/utils/parsing.py
@@ -9,6 +9,8 @@ from oss.src.core.tracing.dtos import (
     OTelAttributes,
     OTelFlatSpans,
     OTelHash,
+    OTelLink,
+    OTelLinks,
     OTelReference,
     OTelSpan,
     OTelSpanKind,
@@ -258,7 +260,23 @@ def parse_timestamp_to_datetime(
 # PAYLOAD PARSING
 
 
-def _parse_span_from_request(raw_span: OTelSpan) -> Optional[OTelFlatSpans]:
+def _span_link(raw_span) -> Optional[OTelLink]:
+    trace_id = getattr(raw_span, "trace_id", None)
+    span_id = getattr(raw_span, "span_id", None)
+    if trace_id is None and span_id is None:
+        return None
+
+    return OTelLink(
+        trace_id=str(trace_id) if trace_id is not None else None,
+        span_id=str(span_id) if span_id is not None else None,
+    )
+
+
+def _parse_span_from_request(
+    raw_span: OTelSpan,
+    *,
+    dropped: Optional[OTelLinks] = None,
+) -> Optional[OTelFlatSpans]:
     raw_span_dtos: OTelFlatSpans = []
 
     raw_span.trace_id = parse_trace_id_to_uuid(raw_span.trace_id)
@@ -278,6 +296,10 @@ def _parse_span_from_request(raw_span: OTelSpan) -> Optional[OTelFlatSpans]:
     raw_span.attributes = unmarshall_attributes(raw_span.attributes or {})
     raw_span.attributes = initialize_ag_attributes(raw_span.attributes)
     ag = raw_span.attributes["ag"]
+    metrics = ag.setdefault("metrics", {})
+    if not isinstance(metrics, dict):
+        metrics = {}
+        ag["metrics"] = metrics
 
     type_attrs = AgTypeAttributes.model_validate(ag.get("type", {}))
     raw_span.span_type = type_attrs.span or raw_span.span_type
@@ -287,18 +309,27 @@ def _parse_span_from_request(raw_span: OTelSpan) -> Optional[OTelFlatSpans]:
         duration_ms = round(duration_s * 1_000, 3)
         duration_ms = duration_ms if duration_ms > 0 else None
         if duration_ms is not None:
-            ag["metrics"]["duration"] = {"cumulative": duration_ms}
+            duration = metrics.setdefault("duration", {})
+            if not isinstance(duration, dict):
+                duration = {}
+                metrics["duration"] = duration
+            duration["cumulative"] = duration_ms
 
     if raw_span.events:
-        errors = ag["metrics"]["errors"] = {"incremental": 0}
+        errors = metrics.setdefault("errors", {})
+        if not isinstance(errors, dict):
+            errors = {}
+            metrics["errors"] = errors
+        errors["incremental"] = 0
         for event in raw_span.events:
             event.timestamp = parse_timestamp_to_datetime(event.timestamp)
             if event.name == "exception":
                 errors["incremental"] = (errors.get("incremental") or 0) + 1
+                event_attributes = event.attributes or {}
                 raw_span.exception = {
-                    "message": event.attributes.get("message"),
-                    "type": event.attributes.get("type"),
-                    "stacktrace": event.attributes.get("stacktrace"),
+                    "message": event_attributes.get("message"),
+                    "type": event_attributes.get("type"),
+                    "stacktrace": event_attributes.get("stacktrace"),
                 }
 
     ag_references = ag.get("references")
@@ -335,7 +366,7 @@ def _parse_span_from_request(raw_span: OTelSpan) -> Optional[OTelFlatSpans]:
                 raw_span.hashes = [OTelHash(id=hash_id, attributes={"key": "indirect"})]
 
     if isinstance(raw_span, OTelSpan) and raw_span.spans is not None:
-        raw_span_dtos.extend(parse_spans_from_request(raw_span.spans))
+        raw_span_dtos.extend(parse_spans_from_request(raw_span.spans, dropped=dropped))
         raw_span.spans = None
 
     raw_span_dtos.append(raw_span)
@@ -344,6 +375,8 @@ def _parse_span_from_request(raw_span: OTelSpan) -> Optional[OTelFlatSpans]:
 
 def parse_spans_from_request(
     spans: Dict[str, Union[OTelSpan, OTelFlatSpans]],
+    *,
+    dropped: Optional[OTelLinks] = None,
 ) -> Optional[OTelFlatSpans]:
     raw_span_dtos: OTelFlatSpans = []
     span_dtos: OTelFlatSpans = []
@@ -354,12 +387,20 @@ def parse_spans_from_request(
                 raw_span_dtos.extend(span_group)
             else:
                 raw_span_dtos.append(span_group)
-
-        for span in raw_span_dtos:
-            span_dtos.extend(_parse_span_from_request(span))
     except Exception:
         log.error(f"Error processing spans:\n {format_exc()}")
-        span_dtos = []
+        return []
+
+    for span in raw_span_dtos:
+        link = _span_link(span)
+        try:
+            parsed_span_dtos = _parse_span_from_request(span, dropped=dropped)
+            if parsed_span_dtos:
+                span_dtos.extend(parsed_span_dtos)
+        except Exception:
+            log.error(f"Error processing span:\n {format_exc()}")
+            if dropped is not None and link is not None:
+                dropped.append(link)
 
     return span_dtos
 

--- a/api/oss/src/core/tracing/utils/trees.py
+++ b/api/oss/src/core/tracing/utils/trees.py
@@ -29,7 +29,7 @@ def calculate_and_propagate_metrics(
     span_dtos: List[OTelFlatSpan],
 ) -> List[OTelFlatSpan]:
     """
-    Calculate and propagate costs/tokens for a list of span DTOs.
+    Calculate and propagate costs/tokens/errors for a list of span DTOs.
 
     This must be called BEFORE batching to ensure complete trace trees.
     If called after batching, partial traces will fail to propagate correctly.
@@ -38,7 +38,7 @@ def calculate_and_propagate_metrics(
         span_dtos: List of span DTOs (should be from a complete trace)
 
     Returns:
-        List of span DTOs with calculated and propagated costs/tokens
+        List of span DTOs with calculated and propagated costs/tokens/errors
     """
     if not span_dtos:
         return span_dtos
@@ -55,6 +55,9 @@ def calculate_and_propagate_metrics(
 
     # Propagate tokens up the tree (children to parents)
     cumulate_tokens(span_id_tree, span_idx)
+
+    # Propagate errors up the tree (children to parents)
+    cumulate_errors(span_id_tree, span_idx)
 
     # Return updated span DTOs
     return list(span_idx.values())
@@ -424,6 +427,72 @@ def cumulate_tokens(
                 span.attributes["ag"]["metrics"]["tokens"] = {}
 
             span.attributes["ag"]["metrics"]["tokens"]["cumulative"] = tokens
+
+    _cumulate_tree_dfs(
+        spans_id_tree,
+        spans_idx,
+        _get_incremental,
+        _get_cumulative,
+        _accumulate,
+        _set_cumulative,
+    )
+
+
+def cumulate_errors(
+    spans_id_tree: OrderedDict,
+    spans_idx: Dict[str, OTelFlatSpan],
+) -> None:
+    def _get_incremental(span: OTelFlatSpan):
+        if span.attributes is None:
+            return 0
+
+        value = (
+            span.attributes.get("ag", {})
+            .get("metrics", {})
+            .get("errors", {})
+            .get("incremental", 0)
+        )
+        return value if isinstance(value, (int, float)) else 0
+
+    def _get_cumulative(span: OTelFlatSpan):
+        if span.attributes is None:
+            return 0
+
+        value = (
+            span.attributes.get("ag", {})
+            .get("metrics", {})
+            .get("errors", {})
+            .get("cumulative", 0)
+        )
+        return value if isinstance(value, (int, float)) else 0
+
+    def _accumulate(a, b):
+        return a + b
+
+    def _set_cumulative(span: OTelFlatSpan, errors):
+        if span.attributes is None:
+            span.attributes = {}
+
+        if errors != 0:
+            if "ag" not in span.attributes or not isinstance(
+                span.attributes["ag"],
+                dict,
+            ):
+                span.attributes["ag"] = {}
+
+            if "metrics" not in span.attributes["ag"] or not isinstance(
+                span.attributes["ag"]["metrics"],
+                dict,
+            ):
+                span.attributes["ag"]["metrics"] = {}
+
+            if "errors" not in span.attributes["ag"]["metrics"] or not isinstance(
+                span.attributes["ag"]["metrics"]["errors"],
+                dict,
+            ):
+                span.attributes["ag"]["metrics"]["errors"] = {}
+
+            span.attributes["ag"]["metrics"]["errors"]["cumulative"] = errors
 
     _cumulate_tree_dfs(
         spans_id_tree,

--- a/api/oss/tests/pytest/acceptance/annotations/test_annotations_basics.py
+++ b/api/oss/tests/pytest/acceptance/annotations/test_annotations_basics.py
@@ -218,6 +218,8 @@ class TestAnnotationsBasics:
                     },
                     "tags": {"tag3": "value3"},
                     "meta": {"meta3": "value3"},
+                    "references": {"evaluator": {"slug": evaluator_slug}},
+                    "links": annotation_links,
                 }
             },
         )

--- a/api/oss/tests/pytest/unit/tracing/utils/test_attributes.py
+++ b/api/oss/tests/pytest/unit/tracing/utils/test_attributes.py
@@ -1,3 +1,4 @@
+from oss.src.core.tracing.dtos import AgAttributes
 from oss.src.core.tracing.utils.attributes import (
     ensure_nested_dict,
     initialize_ag_attributes,
@@ -61,10 +62,50 @@ def test_initialize_ag_attributes_cleans_known_fields_and_tracks_unsupported():
 
     assert ag["unsupported"]["type"] == {"legacy": "x"}
     assert ag["unsupported"]["data"] == {"extra": "ignored"}
+    assert ag["metrics"]["duration"]["incremental"] == 1
     assert ag["unsupported"]["metrics"]["duration"] == {"legacy": "x"}
     assert ag["unsupported"]["metrics"]["legacy_metric"] == {"foo": "bar"}
     assert ag["unsupported"]["random"] == "value"
     assert "refs" not in ag["unsupported"]
+
+
+def test_ag_metrics_accept_scalar_duration_errors_and_vector_tokens_costs():
+    attrs = AgAttributes.model_validate(
+        {
+            "metrics": {
+                "duration": {"cumulative": 123.4},
+                "errors": {"incremental": 1},
+                "tokens": {"incremental": {"prompt": 2, "completion": 3, "total": 5}},
+                "costs": {"cumulative": {"prompt": 0.1, "completion": 0.2}},
+            }
+        }
+    )
+
+    metrics = attrs.model_dump(mode="json", exclude_none=True)["metrics"]
+
+    assert metrics["duration"]["cumulative"] == 123.4
+    assert metrics["errors"]["incremental"] == 1
+    assert metrics["tokens"]["incremental"]["total"] == 5
+    assert metrics["costs"]["cumulative"]["prompt"] == 0.1
+
+
+def test_initialize_ag_attributes_normalizes_legacy_dict_duration_errors_to_scalars():
+    cleaned = initialize_ag_attributes(
+        {
+            "ag": {
+                "metrics": {
+                    "duration": {"cumulative": {"total": 123.4}},
+                    "errors": {"incremental": {"total": 2}},
+                }
+            }
+        }
+    )
+
+    metrics = cleaned["ag"]["metrics"]
+
+    assert metrics["duration"]["cumulative"] == 123.4
+    assert metrics["errors"]["incremental"] == 2
+    assert "unsupported" not in cleaned["ag"]
 
 
 def test_marshall_and_unmarshall_round_trip_nested_dict_and_lists():

--- a/api/oss/tests/pytest/unit/tracing/utils/test_parsing.py
+++ b/api/oss/tests/pytest/unit/tracing/utils/test_parsing.py
@@ -192,6 +192,33 @@ def test_parse_spans_from_request_returns_empty_list_on_unexpected_errors():
     assert parsed == []
 
 
+def test_parse_spans_from_request_drops_only_failed_spans_when_collecting_dropped():
+    valid = OTelSpan(
+        trace_id=TRACE_HEX,
+        span_id=SPAN_HEX,
+        span_name="valid",
+        start_time=1_700_000_000,
+        end_time=1_700_000_001,
+        attributes={},
+    )
+    invalid = OTelSpan(
+        trace_id=TRACE_HEX,
+        span_id="not-a-span-id",
+        span_name="invalid",
+        start_time=1_700_000_000,
+        end_time=1_700_000_001,
+        attributes={},
+    )
+    dropped = []
+
+    parsed = parse_spans_from_request({"batch": [valid, invalid]}, dropped=dropped)
+
+    assert [span.span_name for span in parsed] == ["valid"]
+    assert len(dropped) == 1
+    assert dropped[0].trace_id == TRACE_HEX
+    assert dropped[0].span_id == "not-a-span-id"
+
+
 def test_parse_spans_into_response_returns_trace_map_for_trace_focus():
     parsed = _build_request_spans()
 

--- a/api/oss/tests/pytest/unit/tracing/utils/test_trees.py
+++ b/api/oss/tests/pytest/unit/tracing/utils/test_trees.py
@@ -12,6 +12,7 @@ from oss.src.core.tracing.utils.trees import (
     calculate_costs,
     connect_children,
     cumulate_costs,
+    cumulate_errors,
     cumulate_tokens,
     get_span_from_trace,
     infer_and_propagate_trace_type_by_trace,
@@ -39,11 +40,31 @@ def _span(
     completion_tokens: float = 0.0,
     prompt_cost: float = 0.0,
     completion_cost: float = 0.0,
+    errors: int = 0,
     start_offset_s: int = 0,
     span_type: SpanType = SpanType.TASK,
 ) -> OTelFlatSpan:
     total_tokens = prompt_tokens + completion_tokens
     total_cost = prompt_cost + completion_cost
+    metrics = {
+        "tokens": {
+            "incremental": {
+                "prompt": prompt_tokens,
+                "completion": completion_tokens,
+                "total": total_tokens,
+            }
+        },
+        "costs": {
+            "incremental": {
+                "prompt": prompt_cost,
+                "completion": completion_cost,
+                "total": total_cost,
+            }
+        },
+    }
+    if errors:
+        metrics["errors"] = {"incremental": errors}
+
     return OTelFlatSpan(
         trace_id=trace_id,
         span_id=span_id,
@@ -56,22 +77,7 @@ def _span(
             "ag": {
                 "data": {"parameters": {"model": "gpt-4o-mini"}},
                 "meta": {"response": {"model": "gpt-4o-mini"}},
-                "metrics": {
-                    "tokens": {
-                        "incremental": {
-                            "prompt": prompt_tokens,
-                            "completion": completion_tokens,
-                            "total": total_tokens,
-                        }
-                    },
-                    "costs": {
-                        "incremental": {
-                            "prompt": prompt_cost,
-                            "completion": completion_cost,
-                            "total": total_cost,
-                        }
-                    },
-                },
+                "metrics": metrics,
             }
         },
     )
@@ -133,6 +139,34 @@ def test_cumulate_tokens_and_costs_propagate_from_children_to_parent():
     assert root_costs["prompt"] == pytest.approx(0.5)
     assert root_costs["completion"] == pytest.approx(0.7)
     assert root_costs["total"] == pytest.approx(1.2)
+
+
+def test_cumulate_errors_propagates_scalar_counts_from_children_to_parent():
+    root = _span(
+        span_id=ROOT_UUID,
+        span_name="root",
+        errors=1,
+    )
+    child = _span(
+        span_id=CHILD_A_UUID,
+        parent_id=ROOT_UUID,
+        span_name="child",
+        errors=2,
+        start_offset_s=1,
+    )
+
+    span_idx = parse_span_dtos_to_span_idx([root, child])
+    tree = parse_span_idx_to_span_id_tree(span_idx)
+
+    cumulate_errors(tree, span_idx)
+
+    root_errors = span_idx[ROOT_UUID].attributes["ag"]["metrics"]["errors"]
+    child_errors = span_idx[CHILD_A_UUID].attributes["ag"]["metrics"]["errors"]
+
+    assert root_errors["incremental"] == 1
+    assert root_errors["cumulative"] == 3
+    assert child_errors["incremental"] == 2
+    assert child_errors["cumulative"] == 2
 
 
 def test_connect_children_groups_duplicate_child_names_into_lists():
@@ -222,6 +256,7 @@ def test_calculate_and_propagate_metrics_runs_full_pipeline(monkeypatch):
         span_name="child",
         prompt_tokens=2,
         completion_tokens=3,
+        errors=1,
         span_type=SpanType.CHAT,
         start_offset_s=1,
     )
@@ -239,11 +274,13 @@ def test_calculate_and_propagate_metrics_runs_full_pipeline(monkeypatch):
 
     root_tokens = out_idx[ROOT_UUID].attributes["ag"]["metrics"]["tokens"]["cumulative"]
     root_costs = out_idx[ROOT_UUID].attributes["ag"]["metrics"]["costs"]["cumulative"]
+    root_errors = out_idx[ROOT_UUID].attributes["ag"]["metrics"]["errors"]["cumulative"]
 
     assert root_tokens["total"] == 7
     assert round(root_costs["total"], 6) == round(
         (1 * 0.01 + 1 * 0.02) + (2 * 0.01 + 3 * 0.02), 6
     )
+    assert root_errors == 1
 
 
 def test_infer_and_propagate_trace_type_by_trace_preserves_input_order():

--- a/docs/design/homomorphic-tracing-io/findings.md
+++ b/docs/design/homomorphic-tracing-io/findings.md
@@ -1,0 +1,246 @@
+# Findings: Tracing Query/Ingest Round-Trip Failures
+
+> Branch: `fix-non-homomorphic-ingest-and-query-in-tracing`
+> Synced on: `2026-04-22`
+> Skill workflow: `sync-findings`
+> Effective path: `docs/design/homomorphic-tracing-io`
+
+## Sources
+
+- GitHub issue `#4172`: `https://github.com/Agenta-AI/agenta/issues/4172`
+- GitHub issue `#4173`: `https://github.com/Agenta-AI/agenta/issues/4173`
+- Linear linkbacks:
+  - `AGE-3734`: tracing query/ingest schema asymmetry on `ag.metrics.duration.cumulative`
+  - `AGE-3735`: tracing ingest validation errors drop whole batch
+- Local implementation:
+  - `api/oss/src/core/tracing/utils/parsing.py`
+  - `api/oss/src/core/tracing/utils/attributes.py`
+  - `sdk/agenta/sdk/models/tracing.py`
+  - `api/oss/tests/pytest/unit/tracing/utils/test_parsing.py`
+- Related historical context:
+  - `docs/design/best-effort-ingestion/plan.md`
+  - `docs/design/best-effort-ingestion/status.md`
+
+## Sync Summary
+
+- Created this master findings record from open GitHub issues `#4172` and `#4173`.
+- Re-checked both issues against current local code on `2026-04-22`; all currently tracked findings are fixed in this branch.
+- Issue `#4172` maps to duration metric shape drift: ingest writes `duration.cumulative` as a scalar, while the SDK/API tracing model currently expects a metrics dictionary.
+- Issue `#4173` maps to four ingest/query loss paths: missing defensive metric containers after sanitization, `errors.incremental` shape drift, missing `errors.cumulative` for analytics, and a batch-level catch that drops every span after one parse failure.
+- No GitHub review threads were resolved or replied to because the sources are issues, not PR review threads.
+
+## Rules
+
+- `findings.md` is the canonical synced findings record for this branch-scoped tracing fix.
+- Keep non-findings context above `Open Findings`.
+- Preserve GitHub issue provenance in each finding's `Sources`.
+- Treat query/ingest round-trip compatibility as the primary acceptance surface.
+
+## Notes
+
+- The current unit test expectation in `api/oss/tests/pytest/unit/tracing/utils/test_parsing.py` still asserts scalar shapes for computed duration and event-derived error count. That is evidence that scalar duration/errors may be the intended domain shape, not necessarily the bug.
+- Analytics is further evidence that scalar duration is intentional: default analytics queries `attributes.ag.metrics.duration.cumulative`, legacy analytics sums `ag.metrics.duration.cumulative`, and the semantic-conventions docs document `ag.metrics.duration.cumulative` without `.total`.
+- Analytics is not consistent for errors: default analytics queries `attributes.ag.metrics.errors.cumulative`, ingest currently writes `errors.incremental`, and legacy analytics builds an `errors` bucket by filtering exception events rather than reading `ag.metrics.errors`.
+- The prior best-effort ingestion work documented field-level sanitization and per-span isolation as complete, but this branch's current span ingestion path still has a batch-level catch in `parse_spans_from_request`.
+- `api/oss/src/core/tracing/dtos.py` re-exports the canonical tracing models from `sdk/agenta/sdk/models/tracing.py`, so model compatibility has to be handled at the SDK model boundary or before validation.
+- Generated `costs` and `tokens` currently use canonical nested metric dictionaries (`prompt`, `completion`, `total`) in the propagation helpers; the scalar generated-shape findings are specific to `duration` and `errors`.
+
+## Decisions
+
+- `duration` and `errors` are scalar metric entries by contract.
+- `costs` and `tokens` remain keyed metric dictionaries.
+- The SDK/API model should change to accept scalar `cumulative`/`incremental` values for duration and errors.
+- Error counts should keep both scalar semantic levels:
+  - `errors.incremental`: exception count for this span's own events.
+  - `errors.cumulative`: exception count for this span plus children, produced for trace-level analytics.
+- Read/query normalization should preserve existing scalar stored data for duration and errors.
+- Dictionary normalization or backfill for duration/errors is not applicable under this decision.
+
+## Open Questions
+
+- Should the ingest response remain `202 Accepted` with only `count` and `links`, or should it optionally include structured failure counts while preserving OTel write semantics?
+
+## Open Findings
+
+## Closed Findings
+
+### [CLOSED] F3. `parse_spans_from_request` drops the whole batch after one span parse failure
+
+- ID: `F3`
+- Origin: `sync`
+- Lens: `mixed`
+- Severity: `P1`
+- Confidence: `high`
+- Status: `fixed`
+- Category: `Correctness`, `Reliability`
+- Summary: `parse_spans_from_request` wraps flattening and all per-span parsing in one broad `try/except`. One bad span or one enrichment error resets `span_dtos` to `[]`, causing every valid span in the same batch to be lost while the ingest endpoint can still return `202 Accepted`.
+- Evidence:
+  - `api/oss/src/core/tracing/utils/parsing.py:351-362` wraps the whole loop and sets `span_dtos = []` on any exception.
+  - `api/oss/tests/pytest/unit/tracing/utils/test_parsing.py:189-192` currently codifies the all-empty fallback for unexpected errors.
+  - Issue `#4173` reports a customer-visible response of `{"count": 0, "links": []}` for the failed replay path.
+- Files:
+  - `api/oss/src/core/tracing/utils/parsing.py`
+  - `api/oss/tests/pytest/unit/tracing/utils/test_parsing.py`
+- Cause: Error isolation is at batch scope instead of span scope.
+- Explanation: This undermines the intended OTel best-effort behavior. The endpoint accepts the write, but one invalid field or span can erase unrelated valid spans in the same payload before persistence.
+- Suggested Fix:
+  - Split flattening failures from per-span parse failures.
+  - Wrap `_parse_span_from_request(span)` per span, append successful parses, and log enough structured context for failed spans.
+  - Return dropped span links in `dropped` while keeping successful span links in `links`.
+  - Count both successful and dropped links in the response `count`.
+  - Update tests so a mixed batch persists valid spans and drops or quarantines only the failing span.
+  - Consider tracking failure counts internally, even if response shape remains backward-compatible.
+- Alternatives:
+  - Return a hard validation error for the whole batch, but that conflicts with the documented best-effort OTel ingest semantics.
+- Sources:
+  - GitHub issue `#4173`
+  - Linear `AGE-3735`
+
+### [CLOSED] F1. Duration metric shape contract is inconsistent between ingest/query and validation
+
+- ID: `F1`
+- Origin: `sync`
+- Lens: `mixed`
+- Severity: `P1`
+- Confidence: `high`
+- Status: `fixed`
+- Category: `Correctness`, `Compatibility`
+- Summary: The tracing ingest parser computes duration from `start_time`/`end_time` and stores `ag.metrics.duration.cumulative` as a scalar number, while the SDK/API tracing model currently defines `cumulative` as a metrics dictionary. The failure is the non-homomorphic contract: query output can include a scalar shape that ingest validation rejects on replay.
+- Evidence:
+  - `api/oss/src/core/tracing/utils/parsing.py:285-290` assigns `ag["metrics"]["duration"] = {"cumulative": duration_ms}`.
+  - `sdk/agenta/sdk/models/tracing.py:44-46` declares `AgMetricEntryAttributes.cumulative: Optional[Metrics]`, where `Metrics` is a dictionary type.
+  - `api/oss/src/core/tracing/service.py:90-94` defines the default analytics path as `attributes.ag.metrics.duration.cumulative`.
+  - `api/oss/src/dbs/postgres/tracing/dao.py:569-576` legacy analytics sums `ag.metrics.duration.cumulative` as a scalar numeric value.
+  - `docs/docs/observability/trace-with-opentelemetry/03-semantic-conventions.mdx:246-250` documents `ag.metrics.duration.cumulative` without a nested `.total`.
+  - `api/oss/src/core/tracing/dtos.py:22-66` re-exports the SDK tracing models at the API core boundary.
+  - `api/oss/tests/pytest/unit/tracing/utils/test_parsing.py:173-175` currently expects `metrics["duration"]["cumulative"] == 1000.0`.
+- Files:
+  - `api/oss/src/core/tracing/utils/parsing.py`
+  - `sdk/agenta/sdk/models/tracing.py`
+  - `api/oss/src/core/tracing/service.py`
+  - `api/oss/src/dbs/postgres/tracing/dao.py`
+  - `api/oss/src/core/tracing/dtos.py`
+  - `api/oss/tests/pytest/unit/tracing/utils/test_parsing.py`
+- Cause: The runtime/storage/query shape for duration and the Pydantic contract disagree. The scalar shape may be semantically correct for duration, but it is not accepted by the current shared model.
+- Explanation: A customer round-trip flow queries traces from one Agenta instance and ingests them into another. Because query returns the stored scalar duration shape, replaying the queried span feeds a scalar into a model contract that expects a dictionary, which triggers validation/sanitization and contributes to silent data loss.
+- Suggested Fix:
+  - Keep `duration.cumulative` scalar.
+  - Update `AgMetricEntryAttributes` or introduce precise metric DTOs so `duration.cumulative: number` validates.
+  - Preserve existing scalar stored/query data; do not backfill duration to `{total: value}`.
+  - Add unit and acceptance coverage so query output with scalar duration can be ingested again without rewriting metric shapes.
+- Alternatives:
+  - Keep one uniform dict-only metric model for every metric entry; this is consistent but may over-model naturally scalar metrics like duration and error count.
+  - Normalize duration to `{total: value}` everywhere; rejected by product/architecture decision because scalar duration is canonical.
+- Sources:
+  - GitHub issue `#4172`
+  - Linear `AGE-3734`
+
+### [CLOSED] F2. Sanitized metrics can be missing before duration/error enrichment writes into them
+
+- ID: `F2`
+- Origin: `sync`
+- Lens: `mixed`
+- Severity: `P1`
+- Confidence: `high`
+- Status: `fixed`
+- Category: `Correctness`, `Robustness`
+- Summary: After `initialize_ag_attributes` sanitizes invalid `ag.metrics` data into `ag.unsupported`, `_parse_span_from_request` writes into `ag["metrics"]["duration"]` and `ag["metrics"]["errors"]` via chained indexing. If the metrics container is absent or not a dict, this raises and prevents otherwise salvageable spans from being ingested.
+- Evidence:
+  - `api/oss/src/core/tracing/utils/attributes.py:223-246` retries validation after moving invalid top-level fields into `unsupported` and may return a cleaned `ag` payload with invalid metrics quarantined.
+  - `api/oss/src/core/tracing/utils/parsing.py:285-293` writes duration and errors via `ag["metrics"]["duration"]` and `ag["metrics"]["errors"]`.
+  - Issue `#4173` reports this exact path after scalar `metrics.duration.cumulative` is sanitized from queried spans.
+- Files:
+  - `api/oss/src/core/tracing/utils/parsing.py`
+  - `api/oss/src/core/tracing/utils/attributes.py`
+- Cause: Enrichment assumes validation left a writable `ag.metrics` dict in place, but best-effort sanitization can remove or replace invalid metric content.
+- Explanation: The best-effort ingest contract is to preserve valid span data and quarantine unsupported fields. Chained indexing after sanitization turns that recovery path into a hard parse error.
+- Suggested Fix:
+  - Use defensive container creation before enrichment, for example `metrics = ag.setdefault("metrics", {})` followed by per-entry `setdefault`.
+  - Preserve sanitized invalid metric content under `ag.unsupported.metrics` while writing computed `duration` and `errors` into a valid `ag.metrics` container.
+  - Add unit coverage for scalar `duration.cumulative` input plus start/end time enrichment.
+- Alternatives:
+  - Skip duration/error enrichment when metrics were sanitized, but that loses valid derived fields unnecessarily.
+- Sources:
+  - GitHub issue `#4173`
+  - Linear `AGE-3735`
+  - GitHub issue `#4172` as the companion source that creates the invalid scalar shape
+
+### [CLOSED] F4. Error-count metric shape contract is inconsistent between ingest/query and validation
+
+- ID: `F4`
+- Origin: `sync`
+- Lens: `mixed`
+- Severity: `P1`
+- Confidence: `high`
+- Status: `fixed`
+- Category: `Correctness`, `Compatibility`
+- Summary: The tracing ingest parser derives an exception count from span events and stores `ag.metrics.errors.incremental` as a scalar integer, while the SDK/API tracing model currently defines `incremental` as a metrics dictionary. This is the same non-homomorphic metric-entry contract mismatch as duration, on the errors path.
+- Evidence:
+  - `api/oss/src/core/tracing/utils/parsing.py:292-297` assigns `ag["metrics"]["errors"] = {"incremental": 0}` and increments that scalar for exception events.
+  - `sdk/agenta/sdk/models/tracing.py:44-46` declares `AgMetricEntryAttributes.incremental: Optional[Metrics]`, where `Metrics` is a dictionary type.
+  - `api/oss/tests/pytest/unit/tracing/utils/test_parsing.py:173-175` currently expects `metrics["errors"]["incremental"] == 1`.
+  - `api/oss/src/core/tracing/service.py:90-94` currently defines the default analytics path for errors as `attributes.ag.metrics.errors.cumulative`, unlike costs/tokens which point to `.cumulative.total`.
+  - `api/oss/src/dbs/postgres/tracing/dao.py:656-673` legacy analytics does not read `ag.metrics.errors`; it builds the `errors` bucket by adding an exception-event filter to the query.
+  - `api/oss/src/dbs/postgres/tracing/utils.py:1100-1182` new analytics extracts exactly the requested JSON path and only includes it in numeric/continuous stats when that JSON value is a number.
+- Files:
+  - `api/oss/src/core/tracing/utils/parsing.py`
+  - `sdk/agenta/sdk/models/tracing.py`
+  - `api/oss/src/core/tracing/service.py`
+  - `api/oss/src/dbs/postgres/tracing/dao.py`
+  - `api/oss/src/dbs/postgres/tracing/utils.py`
+  - `api/oss/tests/pytest/unit/tracing/utils/test_parsing.py`
+- Cause: The runtime/storage/query shape for event-derived error count and the Pydantic contract disagree. A scalar count may be semantically correct for errors, but it is not accepted by the current shared metric-entry model.
+- Explanation: `AgMetricEntryAttributes` applies the same dict-valued `cumulative`/`incremental` contract to `duration`, `errors`, `tokens`, and `costs`. `costs` and `tokens` naturally need keyed values such as `prompt`, `completion`, and `total`; `errors` is a simple count and currently uses a scalar incremental shape. The bug is that query, ingest validation, and analytics do not share one accepted errors contract.
+- Suggested Fix:
+  - Keep `errors.incremental` scalar for event-derived per-span error count.
+  - Update `AgMetricEntryAttributes` or introduce precise metric DTOs so scalar `errors.incremental` validates.
+  - Produce scalar `errors.cumulative` for trace-level analytics, since default analytics currently requests `attributes.ag.metrics.errors.cumulative`.
+  - Keep `DEFAULT_ANALYTICS_SPECS` pointed at `attributes.ag.metrics.errors.cumulative` once cumulative errors are produced.
+  - Preserve existing scalar stored/query data; do not backfill errors to `{total: value}`.
+  - Add query-to-ingest round-trip coverage for spans with exception events.
+- Alternatives:
+  - Keep one uniform dict-only metric model for every metric entry; this is consistent but may over-model naturally scalar metrics like duration and error count.
+  - Normalize errors to `{total: value}` everywhere; rejected by product/architecture decision because scalar errors are canonical.
+- Sources:
+  - GitHub issue `#4173`
+  - Linear `AGE-3735`
+  - GitHub issue `#4172` as the companion metric-shape issue
+
+### [CLOSED] F5. Error analytics expects `errors.cumulative` but ingest only produces `errors.incremental`
+
+- ID: `F5`
+- Origin: `sync`
+- Lens: `mixed`
+- Severity: `P1`
+- Confidence: `high`
+- Status: `fixed`
+- Category: `Correctness`, `Analytics`
+- Summary: Event parsing records per-span exception counts as scalar `ag.metrics.errors.incremental`, but default analytics queries scalar `ag.metrics.errors.cumulative`. No current propagation helper creates cumulative error counts, so the new analytics default can miss error metrics even after scalar errors are accepted by validation.
+- Evidence:
+  - `api/oss/src/core/tracing/utils/parsing.py:292-297` produces `errors.incremental`.
+  - `api/oss/src/core/tracing/service.py:90-94` default analytics requests `attributes.ag.metrics.errors.cumulative`.
+  - `api/oss/src/core/tracing/utils/trees.py:194-435` propagates cumulative `costs` and `tokens`, but has no equivalent cumulative propagation for `errors`.
+  - `api/oss/src/dbs/postgres/tracing/utils.py:1100-1182` new analytics extracts exactly the requested JSON path and only includes it when that JSON value is numeric.
+  - `api/oss/src/dbs/postgres/tracing/dao.py:656-673` legacy analytics sidesteps this by filtering exception events instead of reading `ag.metrics.errors`.
+- Files:
+  - `api/oss/src/core/tracing/utils/parsing.py`
+  - `api/oss/src/core/tracing/utils/trees.py`
+  - `api/oss/src/core/tracing/service.py`
+  - `api/oss/src/dbs/postgres/tracing/utils.py`
+  - `api/oss/src/dbs/postgres/tracing/dao.py`
+- Cause: Error count has only the incremental write path; the metrics propagation pipeline computes cumulative values for tokens and costs, but not for errors.
+- Explanation: The resolved contract keeps errors scalar, but still needs both `incremental` and `cumulative` levels. `errors.incremental` is correct for the span-local event count. `errors.cumulative` is needed on root spans so trace-level analytics can report total errors across a trace using the existing default analytics spec.
+- Suggested Fix:
+  - Add cumulative error propagation alongside `cumulate_tokens` and `cumulate_costs`.
+  - Treat missing `errors.incremental` as `0`; write `errors.cumulative` only when the cumulative count is non-zero.
+  - Keep `errors.incremental` scalar and produce `errors.cumulative` scalar.
+  - Keep the new analytics default spec pointed at `attributes.ag.metrics.errors.cumulative` while the analytics base query is trace/root-span oriented.
+  - Use `errors.incremental` as a default only if analytics is changed to include all spans or to switch specs based on span-vs-trace focus.
+  - Add unit coverage for a parent/child trace where the child has an exception event and the root receives `errors.cumulative`.
+  - Add analytics coverage proving the default `attributes.ag.metrics.errors.cumulative` spec sees the propagated scalar value.
+- Alternatives:
+  - Change default analytics to `errors.incremental`, but that would undercount trace-level errors on parent/root spans unless the query includes all spans or changes grouping by focus.
+  - Keep legacy event-filter analytics only, but that leaves the new generic analytics endpoint inconsistent with default specs.
+- Sources:
+  - GitHub issue `#4173`
+  - Linear `AGE-3735`

--- a/sdk/agenta/sdk/models/tracing.py
+++ b/sdk/agenta/sdk/models/tracing.py
@@ -41,18 +41,28 @@ class SpanType(Enum):
     UNKNOWN = "unknown"
 
 
-class AgMetricEntryAttributes(BaseModel):
+class AgVectorMetricEntryAttributes(BaseModel):
     cumulative: Optional[Metrics] = None
     incremental: Optional[Metrics] = None
 
     model_config = {"ser_json_exclude_none": True}
 
 
+class AgScalarMetricEntryAttributes(BaseModel):
+    cumulative: Optional[Union[int, float]] = None
+    incremental: Optional[Union[int, float]] = None
+
+    model_config = {"ser_json_exclude_none": True}
+
+
+AgMetricEntryAttributes = AgVectorMetricEntryAttributes
+
+
 class AgMetricsAttributes(BaseModel):
-    duration: Optional[AgMetricEntryAttributes] = None
-    errors: Optional[AgMetricEntryAttributes] = None
-    tokens: Optional[AgMetricEntryAttributes] = None
-    costs: Optional[AgMetricEntryAttributes] = None
+    duration: Optional[AgScalarMetricEntryAttributes] = None
+    errors: Optional[AgScalarMetricEntryAttributes] = None
+    tokens: Optional[AgVectorMetricEntryAttributes] = None
+    costs: Optional[AgVectorMetricEntryAttributes] = None
 
     model_config = {"ser_json_exclude_none": True}
 


### PR DESCRIPTION
## Description 

Fixes tracing ingest/query round-trip mismatches for scalar duration and error metrics.

## What's changed

- Treat `duration` and `errors` as scalar `metrics` entries.
- Keep `tokens` and `costs` as keyed `metrics` dictionaries.
- Normalize legacy dict-shaped `duration`/`errors` payloads into scalars on ingest.
- Propagate `errors.cumulative` for analytics.
- Make `span` ingest best-effort per `span`, returning dropped `links` separately.
- Add unit coverage for scalar `metrics`, legacy normalization, `errors` propagation, and partial ingest drops.