### PR TITLE
[fix] workflow-related fork issues

### DIFF
--- a/api/oss/src/apis/fastapi/applications/router.py
+++ b/api/oss/src/apis/fastapi/applications/router.py
@@ -8,6 +8,7 @@ from oss.src.utils.logging import get_module_logger
 from oss.src.utils.exceptions import intercept_exceptions, suppress_exceptions
 from oss.src.utils.caching import invalidate_cache
 
+from oss.src.core.git.types import VariantForkError
 from oss.src.core.shared.dtos import (
     Reference,
 )
@@ -972,12 +973,20 @@ class ApplicationsRouter:
             if not fork_request.application_variant_id:
                 fork_request.application_variant_id = application_variant_id
 
-        application_variant = await self.applications_service.fork_application_variant(
-            project_id=UUID(request.state.project_id),
-            user_id=UUID(request.state.user_id),
-            #
-            application_fork=fork_request,
-        )
+        try:
+            application_variant = (
+                await self.applications_service.fork_application_variant(
+                    project_id=UUID(request.state.project_id),
+                    user_id=UUID(request.state.user_id),
+                    #
+                    application_fork=fork_request,
+                )
+            )
+        except VariantForkError as e:
+            raise HTTPException(
+                status_code=status.HTTP_400_BAD_REQUEST,
+                detail=e.message,
+            ) from e
 
         application_variant_response = ApplicationVariantResponse(
             count=1 if application_variant else 0,

--- a/api/oss/src/apis/fastapi/evaluators/router.py
+++ b/api/oss/src/apis/fastapi/evaluators/router.py
@@ -8,6 +8,7 @@ from oss.src.utils.logging import get_module_logger
 from oss.src.utils.exceptions import intercept_exceptions, suppress_exceptions
 from oss.src.utils.caching import invalidate_cache
 
+from oss.src.core.git.types import VariantForkError
 from oss.src.core.shared.dtos import (
     Reference,
 )
@@ -974,12 +975,18 @@ class EvaluatorsRouter:
             if not fork_request.evaluator_variant_id:
                 fork_request.evaluator_variant_id = evaluator_variant_id
 
-        evaluator_variant = await self.evaluators_service.fork_evaluator_variant(
-            project_id=UUID(request.state.project_id),
-            user_id=UUID(request.state.user_id),
-            #
-            evaluator_fork=fork_request,
-        )
+        try:
+            evaluator_variant = await self.evaluators_service.fork_evaluator_variant(
+                project_id=UUID(request.state.project_id),
+                user_id=UUID(request.state.user_id),
+                #
+                evaluator_fork=fork_request,
+            )
+        except VariantForkError as e:
+            raise HTTPException(
+                status_code=status.HTTP_400_BAD_REQUEST,
+                detail=e.message,
+            ) from e
 
         evaluator_variant_response = EvaluatorVariantResponse(
             count=1 if evaluator_variant else 0,

--- a/api/oss/src/apis/fastapi/workflows/router.py
+++ b/api/oss/src/apis/fastapi/workflows/router.py
@@ -11,6 +11,7 @@ from oss.src.utils.caching import invalidate_cache
 from oss.src.core.shared.dtos import (
     Reference,
 )
+from oss.src.core.git.types import VariantForkError
 from oss.src.core.workflows.service import (
     WorkflowsService,
     SimpleWorkflowsService,
@@ -1005,12 +1006,18 @@ class WorkflowsRouter:
             ):
                 raise FORBIDDEN_EXCEPTION  # type: ignore
 
-        workflow_variant = await self.workflows_service.fork_workflow_variant(
-            project_id=UUID(request.state.project_id),
-            user_id=UUID(request.state.user_id),
-            #
-            workflow_fork=workflow_fork_request.workflow,
-        )
+        try:
+            workflow_variant = await self.workflows_service.fork_workflow_variant(
+                project_id=UUID(request.state.project_id),
+                user_id=UUID(request.state.user_id),
+                #
+                workflow_fork=workflow_fork_request.workflow,
+            )
+        except VariantForkError as e:
+            raise HTTPException(
+                status_code=status.HTTP_400_BAD_REQUEST,
+                detail=e.message,
+            ) from e
 
         # Invalidate legacy caches so the registry page reflects the forked variant
         await invalidate_cache(project_id=request.state.project_id)

--- a/api/oss/src/core/git/types.py
+++ b/api/oss/src/core/git/types.py
@@ -1,0 +1,10 @@
+class GitError(Exception):
+    """Base exception for git-pattern domain errors."""
+
+    def __init__(self, message: str):
+        self.message = message
+        super().__init__(message)
+
+
+class VariantForkError(GitError):
+    """Raised when a variant fork request cannot be fulfilled."""

--- a/api/oss/src/dbs/postgres/git/dao.py
+++ b/api/oss/src/dbs/postgres/git/dao.py
@@ -9,6 +9,7 @@ from oss.src.utils.logging import get_module_logger
 from oss.src.core.shared.exceptions import EntityCreationConflict
 from oss.src.core.shared.dtos import Reference, Windowing
 from oss.src.core.git.interfaces import GitDAOInterface
+from oss.src.core.git.types import VariantForkError
 from oss.src.core.git.dtos import (
     Artifact,
     ArtifactCreate,
@@ -816,7 +817,7 @@ class GitDAO(GitDAOInterface):
 
     # --------------------------------------------------------------------------
 
-    @suppress_exceptions()
+    @suppress_exceptions(exclude=[VariantForkError])
     async def fork_variant(
         self,
         *,
@@ -825,6 +826,16 @@ class GitDAO(GitDAOInterface):
         #
         artifact_fork: ArtifactFork,
     ) -> Optional[Variant]:
+        if artifact_fork.variant is None:
+            raise VariantForkError(
+                "Fork requires a 'variant' payload describing the new variant."
+            )
+
+        if not artifact_fork.variant_id and not artifact_fork.revision_id:
+            raise VariantForkError(
+                "Fork requires a source reference: 'variant_id' or 'revision_id'."
+            )
+
         source_revisions = await self.log_revisions(
             project_id=project_id,
             #
@@ -836,7 +847,11 @@ class GitDAO(GitDAOInterface):
         )
 
         if not source_revisions:
-            return None
+            raise VariantForkError(
+                "Fork source has no revisions to copy. "
+                "Verify 'variant_id'/'revision_id' resolve to an existing variant "
+                "with at least one committed revision."
+            )
 
         source_variant = await self.fetch_variant(
             project_id=project_id,
@@ -845,7 +860,7 @@ class GitDAO(GitDAOInterface):
         )
 
         if not source_variant:
-            return None
+            raise VariantForkError("Fork source variant could not be resolved.")
 
         variant_create = VariantCreate(
             slug=artifact_fork.variant.slug,
@@ -897,29 +912,30 @@ class GitDAO(GitDAOInterface):
                 revision_commit=revision_commit,
             )
 
-        revision_commit = RevisionCommit(
-            slug=artifact_fork.revision.slug,
-            #
-            name=artifact_fork.revision.name,
-            description=artifact_fork.revision.description,
-            #
-            flags=artifact_fork.revision.flags,
-            tags=artifact_fork.revision.tags,
-            meta=artifact_fork.revision.meta,
-            #
-            message=artifact_fork.revision.message,
-            data=artifact_fork.revision.data or source_revisions[0].data,
-            #
-            artifact_id=target_variant.artifact_id,
-            variant_id=target_variant.id,
-        )
+        if artifact_fork.revision is not None:
+            revision_commit = RevisionCommit(
+                slug=artifact_fork.revision.slug,
+                #
+                name=artifact_fork.revision.name,
+                description=artifact_fork.revision.description,
+                #
+                flags=artifact_fork.revision.flags,
+                tags=artifact_fork.revision.tags,
+                meta=artifact_fork.revision.meta,
+                #
+                message=artifact_fork.revision.message,
+                data=artifact_fork.revision.data or source_revisions[0].data,
+                #
+                artifact_id=target_variant.artifact_id,
+                variant_id=target_variant.id,
+            )
 
-        await self.commit_revision(
-            project_id=project_id,
-            user_id=user_id,
-            #
-            revision_commit=revision_commit,
-        )
+            await self.commit_revision(
+                project_id=project_id,
+                user_id=user_id,
+                #
+                revision_commit=revision_commit,
+            )
 
         return target_variant  # type: ignore
 

--- a/api/oss/tests/pytest/acceptance/workflows/test_workflow_lineage.py
+++ b/api/oss/tests/pytest/acceptance/workflows/test_workflow_lineage.py
@@ -451,3 +451,123 @@ class TestWorkflowRevisionsLineage:
         response_data = response.json()
         assert response_data["count"] == 2
         # ----------------------------------------------------------------------
+
+    def test_fork_workflow_variant_without_revision(self, authed_api, mock_data):
+        # Forking a variant without supplying a new tip revision should succeed
+        # and copy the source revisions without appending a new commit.
+        # ACT ------------------------------------------------------------------
+        workflow_variant_id = mock_data["workflow_variants"][0]["id"]
+
+        workflow_variant_slug = uuid4()
+
+        response = authed_api(
+            "POST",
+            "/workflows/variants/fork",
+            json={
+                "workflow": {
+                    "workflow_variant_id": workflow_variant_id,
+                    "workflow_variant": {
+                        "slug": f"workflow-variant-{workflow_variant_slug}-norev-fork",
+                        "name": f"Workflow Variant {workflow_variant_slug}",
+                    },
+                }
+            },
+        )
+        # ----------------------------------------------------------------------
+
+        # ASSERT ---------------------------------------------------------------
+        assert response.status_code == 200
+        response_data = response.json()
+        assert response_data["count"] == 1
+
+        workflow_variant = response_data["workflow_variant"]
+
+        response = authed_api(
+            "POST",
+            "/workflows/revisions/log",
+            json={
+                "workflow": {
+                    "workflow_variant_id": workflow_variant["id"],
+                },
+            },
+        )
+
+        assert response.status_code == 200
+        response_data = response.json()
+        # 3 copied from source, no extra tip commit appended
+        assert response_data["count"] == 3
+        # ----------------------------------------------------------------------
+
+    def test_fork_workflow_variant_missing_variant_payload(self, authed_api, mock_data):
+        # Forking without a 'workflow_variant' block must return a structured 400,
+        # not HTTP 200 with count=0.
+        # ACT ------------------------------------------------------------------
+        workflow_variant_id = mock_data["workflow_variants"][0]["id"]
+
+        response = authed_api(
+            "POST",
+            "/workflows/variants/fork",
+            json={
+                "workflow": {
+                    "workflow_variant_id": workflow_variant_id,
+                }
+            },
+        )
+        # ----------------------------------------------------------------------
+
+        # ASSERT ---------------------------------------------------------------
+        assert response.status_code == 400
+        assert "variant" in response.json()["detail"].lower()
+        # ----------------------------------------------------------------------
+
+    def test_fork_workflow_variant_missing_source_ref(self, authed_api, mock_data):
+        # Forking without any source reference must return 400.
+        # ACT ------------------------------------------------------------------
+        workflow_variant_slug = uuid4()
+
+        response = authed_api(
+            "POST",
+            "/workflows/variants/fork",
+            json={
+                "workflow": {
+                    "workflow_variant": {
+                        "slug": f"workflow-variant-{workflow_variant_slug}-nosrc-fork",
+                        "name": f"Workflow Variant {workflow_variant_slug}",
+                    },
+                }
+            },
+        )
+        # ----------------------------------------------------------------------
+
+        # ASSERT ---------------------------------------------------------------
+        assert response.status_code == 400
+        detail = response.json()["detail"].lower()
+        assert "variant_id" in detail or "revision_id" in detail
+        # ----------------------------------------------------------------------
+
+    def test_fork_workflow_variant_unknown_source(self, authed_api, mock_data):
+        # Forking from a variant_id that does not resolve must return 400.
+        # ACT ------------------------------------------------------------------
+        bogus_variant_id = str(uuid4())
+
+        workflow_variant_slug = uuid4()
+
+        response = authed_api(
+            "POST",
+            "/workflows/variants/fork",
+            json={
+                "workflow": {
+                    "workflow_variant_id": bogus_variant_id,
+                    "workflow_variant": {
+                        "slug": f"workflow-variant-{workflow_variant_slug}-bogus-fork",
+                        "name": f"Workflow Variant {workflow_variant_slug}",
+                    },
+                }
+            },
+        )
+        # ----------------------------------------------------------------------
+
+        # ASSERT ---------------------------------------------------------------
+        assert response.status_code == 400
+        assert "revision" in response.json()["detail"].lower()
+        # ----------------------------------------------------------------------


### PR DESCRIPTION
## Description

POST /workflows/variants/fork silently returned {"count": 0} for any invalid/partial payload.

Made the trailing tip revision optional (fork now works when the user only supplies workflow_variant + a source ref), and converted the remaining misuses into a typed VariantForkError that the routers surface as HTTP 400 with a structured detail.

Same DAO backs workflows, applications, evaluators, and queries forks — all four endpoints are fixed by this change. Routers for workflows/applications/evaluators now translate VariantForkError → 400.

## Cause

The shared fork_variant DAO is wrapped in @suppress_exceptions(), so the AttributeError raised when the caller omitted the optional revision / workflow_revision block was swallowed into None → empty response.

## Fixes

- core/git/types.py — new module with GitError / VariantForkError.
- dbs/postgres/git/dao.py::fork_variant — validate inputs (missing variant, missing source ref, unresolved source revisions) with VariantForkError; guard the optional tip revision commit; @suppress_exceptions(exclude=[VariantForkError]).
- apis/fastapi/{workflows,applications,evaluators}/router.py — catch VariantForkError → HTTPException(400, detail=...).
- tests/pytest/acceptance/workflows/test_workflow_lineage.py — 4 new tests: fork without revision (succeeds, copies history), missing variant payload (400), missing source ref (400), unknown source (400).