### PR TITLE
Chore/add support info on suppressed exceptions

### DIFF
--- a/api/oss/src/apis/fastapi/annotations/models.py
+++ b/api/oss/src/apis/fastapi/annotations/models.py
@@ -2,6 +2,8 @@ from typing import Optional, List
 
 from pydantic import BaseModel
 
+from oss.src.utils.exceptions import Support
+
 from oss.src.core.shared.dtos import (
     Link,
     Windowing,
@@ -33,21 +35,21 @@ class AnnotationQueryRequest(BaseModel):
     windowing: Optional[Windowing] = None
 
 
-class AnnotationResponse(BaseModel):
+class AnnotationResponse(Support):
     count: int = 0
     annotation: Optional[Annotation] = None
 
 
-class AnnotationsResponse(BaseModel):
+class AnnotationsResponse(Support):
     count: int = 0
     annotations: List[Annotation] = []
 
 
-class AnnotationLinkResponse(BaseModel):
+class AnnotationLinkResponse(Support):
     count: int = 0
     annotation_link: Optional[Link] = None
 
 
-class AnnotationLinksResponse(BaseModel):
+class AnnotationLinksResponse(Support):
     count: int = 0
     annotation_links: List[Link] = []

--- a/api/oss/src/apis/fastapi/applications/models.py
+++ b/api/oss/src/apis/fastapi/applications/models.py
@@ -2,6 +2,8 @@ from typing import Optional, List
 
 from pydantic import BaseModel
 
+from oss.src.utils.exceptions import Support
+
 from oss.src.core.shared.dtos import (
     Reference,
     Windowing,
@@ -59,12 +61,12 @@ class ApplicationQueryRequest(BaseModel):
     windowing: Optional[Windowing] = None
 
 
-class ApplicationResponse(BaseModel):
+class ApplicationResponse(Support):
     count: int = 0
     application: Optional[Application] = None
 
 
-class ApplicationsResponse(BaseModel):
+class ApplicationsResponse(Support):
     count: int = 0
     applications: List[Application] = []
 
@@ -99,12 +101,12 @@ class ApplicationVariantQueryRequest(BaseModel):
     windowing: Optional[Windowing] = None
 
 
-class ApplicationVariantResponse(BaseModel):
+class ApplicationVariantResponse(Support):
     count: int = 0
     application_variant: Optional[ApplicationVariant] = None
 
 
-class ApplicationVariantsResponse(BaseModel):
+class ApplicationVariantsResponse(Support):
     count: int = 0
     application_variants: List[ApplicationVariant] = []
 
@@ -159,13 +161,13 @@ class ApplicationRevisionDeployRequest(BaseModel):
     message: Optional[str] = None
 
 
-class ApplicationRevisionResponse(BaseModel):
+class ApplicationRevisionResponse(Support):
     count: int = 0
     application_revision: Optional[ApplicationRevision] = None
     resolution_info: Optional[ResolutionInfo] = None  # Included when resolve=True
 
 
-class ApplicationRevisionsResponse(BaseModel):
+class ApplicationRevisionsResponse(Support):
     count: int = 0
     application_revisions: List[ApplicationRevision] = []
 
@@ -191,12 +193,12 @@ class SimpleApplicationQueryRequest(BaseModel):
     windowing: Optional[Windowing] = None
 
 
-class SimpleApplicationResponse(BaseModel):
+class SimpleApplicationResponse(Support):
     count: int = 0
     application: Optional[SimpleApplication] = None
 
 
-class SimpleApplicationsResponse(BaseModel):
+class SimpleApplicationsResponse(Support):
     count: int = 0
     applications: List[SimpleApplication] = []
 
@@ -214,37 +216,37 @@ class ApplicationRevisionResolveRequest(BaseModel):
     error_policy: Optional[ErrorPolicy] = ErrorPolicy.EXCEPTION
 
 
-class ApplicationRevisionResolveResponse(BaseModel):
+class ApplicationRevisionResolveResponse(Support):
     count: int = 0
     application_revision: Optional[ApplicationRevision] = None
     resolution_info: Optional[ResolutionInfo] = None
 
 
-class ApplicationCatalogTypeResponse(BaseModel):
+class ApplicationCatalogTypeResponse(Support):
     count: int = 0
     type: Optional[ApplicationCatalogType] = None
 
 
-class ApplicationCatalogTypesResponse(BaseModel):
+class ApplicationCatalogTypesResponse(Support):
     count: int = 0
     types: List[ApplicationCatalogType] = []
 
 
-class ApplicationCatalogTemplateResponse(BaseModel):
+class ApplicationCatalogTemplateResponse(Support):
     count: int = 0
     template: Optional[ApplicationCatalogTemplate] = None
 
 
-class ApplicationCatalogTemplatesResponse(BaseModel):
+class ApplicationCatalogTemplatesResponse(Support):
     count: int = 0
     templates: List[ApplicationCatalogTemplate] = []
 
 
-class ApplicationCatalogPresetResponse(BaseModel):
+class ApplicationCatalogPresetResponse(Support):
     count: int = 0
     preset: Optional[ApplicationCatalogPreset] = None
 
 
-class ApplicationCatalogPresetsResponse(BaseModel):
+class ApplicationCatalogPresetsResponse(Support):
     count: int = 0
     presets: List[ApplicationCatalogPreset] = []

--- a/api/oss/src/apis/fastapi/environments/models.py
+++ b/api/oss/src/apis/fastapi/environments/models.py
@@ -2,6 +2,8 @@ from typing import Optional, List
 
 from pydantic import BaseModel
 
+from oss.src.utils.exceptions import Support
+
 from oss.src.core.shared.dtos import (
     Windowing,
     Reference,
@@ -56,12 +58,12 @@ class EnvironmentQueryRequest(BaseModel):
     windowing: Optional[Windowing] = None
 
 
-class EnvironmentResponse(BaseModel):
+class EnvironmentResponse(Support):
     count: int = 0
     environment: Optional[Environment] = None
 
 
-class EnvironmentsResponse(BaseModel):
+class EnvironmentsResponse(Support):
     count: int = 0
     environments: List[Environment] = []
 
@@ -88,12 +90,12 @@ class EnvironmentVariantQueryRequest(BaseModel):
     windowing: Optional[Windowing] = None
 
 
-class EnvironmentVariantResponse(BaseModel):
+class EnvironmentVariantResponse(Support):
     count: int = 0
     environment_variant: Optional[EnvironmentVariant] = None
 
 
-class EnvironmentVariantsResponse(BaseModel):
+class EnvironmentVariantsResponse(Support):
     count: int = 0
     environment_variants: List[EnvironmentVariant] = []
 
@@ -139,13 +141,13 @@ class EnvironmentRevisionsLogRequest(BaseModel):
     environment: EnvironmentRevisionsLog
 
 
-class EnvironmentRevisionResponse(BaseModel):
+class EnvironmentRevisionResponse(Support):
     count: int = 0
     environment_revision: Optional[EnvironmentRevision] = None
     resolution_info: Optional[ResolutionInfo] = None  # Included when resolve=True
 
 
-class EnvironmentRevisionsResponse(BaseModel):
+class EnvironmentRevisionsResponse(Support):
     count: int = 0
     environment_revisions: List[EnvironmentRevision] = []
 
@@ -171,12 +173,12 @@ class SimpleEnvironmentQueryRequest(BaseModel):
     windowing: Optional[Windowing] = None
 
 
-class SimpleEnvironmentResponse(BaseModel):
+class SimpleEnvironmentResponse(Support):
     count: int = 0
     environment: Optional[SimpleEnvironment] = None
 
 
-class SimpleEnvironmentsResponse(BaseModel):
+class SimpleEnvironmentsResponse(Support):
     count: int = 0
     environments: List[SimpleEnvironment] = []
 
@@ -194,7 +196,7 @@ class EnvironmentRevisionResolveRequest(BaseModel):
     error_policy: Optional[ErrorPolicy] = ErrorPolicy.EXCEPTION
 
 
-class EnvironmentRevisionResolveResponse(BaseModel):
+class EnvironmentRevisionResolveResponse(Support):
     count: int = 0
     environment_revision: Optional[EnvironmentRevision] = None
     resolution_info: Optional[ResolutionInfo] = None

--- a/api/oss/src/apis/fastapi/evaluations/models.py
+++ b/api/oss/src/apis/fastapi/evaluations/models.py
@@ -4,6 +4,8 @@ from uuid import UUID
 from pydantic import BaseModel
 from fastapi import HTTPException
 
+from oss.src.utils.exceptions import Support
+
 from oss.src.core.shared.dtos import (
     Windowing,
 )
@@ -106,23 +108,23 @@ class EvaluationRunIdsRequest(BaseModel):
     run_ids: List[UUID]
 
 
-class EvaluationRunResponse(BaseModel):
+class EvaluationRunResponse(Support):
     count: int = 0
     run: Optional[EvaluationRun] = None
 
 
-class EvaluationRunsResponse(BaseModel):
+class EvaluationRunsResponse(Support):
     count: int = 0
     runs: List[EvaluationRun] = []
     windowing: Optional[Windowing] = None
 
 
-class EvaluationRunIdResponse(BaseModel):
+class EvaluationRunIdResponse(Support):
     count: int = 0
     run_id: Optional[UUID] = None
 
 
-class EvaluationRunIdsResponse(BaseModel):
+class EvaluationRunIdsResponse(Support):
     count: int = 0
     run_ids: List[UUID] = []
 
@@ -152,24 +154,24 @@ class EvaluationScenarioIdsRequest(BaseModel):
     scenario_ids: List[UUID]
 
 
-class EvaluationScenarioResponse(BaseModel):
+class EvaluationScenarioResponse(Support):
     count: int = 0
     scenario: Optional[EvaluationScenario] = None
 
 
-class EvaluationScenariosResponse(BaseModel):
+class EvaluationScenariosResponse(Support):
     count: int = 0
     scenarios: List[EvaluationScenario] = []
     #
     windowing: Optional[Windowing] = None
 
 
-class EvaluationScenarioIdResponse(BaseModel):
+class EvaluationScenarioIdResponse(Support):
     count: int = 0
     scenario_id: Optional[UUID] = None
 
 
-class EvaluationScenarioIdsResponse(BaseModel):
+class EvaluationScenarioIdsResponse(Support):
     count: int = 0
     scenario_ids: List[UUID] = []
 
@@ -199,22 +201,22 @@ class EvaluationResultIdsRequest(BaseModel):
     result_ids: List[UUID]
 
 
-class EvaluationResultResponse(BaseModel):
+class EvaluationResultResponse(Support):
     count: int = 0
     result: Optional[EvaluationResult] = None
 
 
-class EvaluationResultsResponse(BaseModel):
+class EvaluationResultsResponse(Support):
     count: int = 0
     results: List[EvaluationResult] = []
 
 
-class EvaluationResultIdResponse(BaseModel):
+class EvaluationResultIdResponse(Support):
     count: int = 0
     result_id: Optional[UUID] = None
 
 
-class EvaluationResultIdsResponse(BaseModel):
+class EvaluationResultIdsResponse(Support):
     count: int = 0
     result_ids: List[UUID] = []
 
@@ -244,12 +246,12 @@ class EvaluationMetricsIdsRequest(BaseModel):
     metrics_ids: List[UUID]
 
 
-class EvaluationMetricsResponse(BaseModel):
+class EvaluationMetricsResponse(Support):
     count: int = 0
     metrics: List[EvaluationMetrics] = []
 
 
-class EvaluationMetricsIdsResponse(BaseModel):
+class EvaluationMetricsIdsResponse(Support):
     count: int = 0
     metrics_ids: List[UUID] = []
 
@@ -279,27 +281,27 @@ class EvaluationQueueIdsRequest(BaseModel):
     queue_ids: List[UUID]
 
 
-class EvaluationQueueResponse(BaseModel):
+class EvaluationQueueResponse(Support):
     count: int = 0
     queue: Optional[EvaluationQueue] = None
 
 
-class EvaluationQueuesResponse(BaseModel):
+class EvaluationQueuesResponse(Support):
     count: int = 0
     queues: List[EvaluationQueue] = []
 
 
-class EvaluationQueueIdResponse(BaseModel):
+class EvaluationQueueIdResponse(Support):
     count: int = 0
     queue_id: Optional[UUID] = None
 
 
-class EvaluationQueueIdsResponse(BaseModel):
+class EvaluationQueueIdsResponse(Support):
     count: int = 0
     queue_ids: List[UUID] = []
 
 
-class EvaluationQueueScenarioIdsResponse(BaseModel):
+class EvaluationQueueScenarioIdsResponse(Support):
     count: int = 0
     scenario_ids: List[List[UUID]] = []
 
@@ -329,17 +331,17 @@ class SimpleEvaluationQueryRequest(BaseModel):
     windowing: Optional[Windowing] = None
 
 
-class SimpleEvaluationResponse(BaseModel):
+class SimpleEvaluationResponse(Support):
     count: int = 0
     evaluation: Optional[SimpleEvaluation] = None
 
 
-class SimpleEvaluationsResponse(BaseModel):
+class SimpleEvaluationsResponse(Support):
     count: int = 0
     evaluations: List[SimpleEvaluation] = []
 
 
-class SimpleEvaluationIdResponse(BaseModel):
+class SimpleEvaluationIdResponse(Support):
     count: int = 0
     evaluation_id: Optional[UUID] = None
 
@@ -373,24 +375,24 @@ class SimpleQueueTestcasesCreateRequest(BaseModel):
     testcase_ids: List[UUID]
 
 
-class SimpleQueueResponse(BaseModel):
+class SimpleQueueResponse(Support):
     count: int = 0
     queue: Optional[SimpleQueue] = None
 
 
-class SimpleQueuesResponse(BaseModel):
+class SimpleQueuesResponse(Support):
     count: int = 0
     queues: List[SimpleQueue] = []
     #
     windowing: Optional[Windowing] = None
 
 
-class SimpleQueueIdResponse(BaseModel):
+class SimpleQueueIdResponse(Support):
     count: int = 0
     queue_id: Optional[UUID] = None
 
 
-class SimpleQueueScenariosResponse(BaseModel):
+class SimpleQueueScenariosResponse(Support):
     count: int = 0
     scenarios: List[EvaluationScenario] = []
     #

--- a/api/oss/src/apis/fastapi/evaluators/models.py
+++ b/api/oss/src/apis/fastapi/evaluators/models.py
@@ -2,6 +2,8 @@ from typing import Optional, List, Dict, Any
 
 from pydantic import BaseModel
 
+from oss.src.utils.exceptions import Support
+
 from oss.src.core.shared.dtos import (
     Windowing,
     Reference,
@@ -66,12 +68,12 @@ class EvaluatorForkRequest(BaseModel):
     evaluator: EvaluatorFork
 
 
-class EvaluatorResponse(BaseModel):
+class EvaluatorResponse(Support):
     count: int = 0
     evaluator: Optional[Evaluator] = None
 
 
-class EvaluatorsResponse(BaseModel):
+class EvaluatorsResponse(Support):
     count: int = 0
     evaluators: List[Evaluator] = []
 
@@ -110,12 +112,12 @@ class EvaluatorRevisionsLogRequest(BaseModel):
     evaluator: EvaluatorRevisionsLog
 
 
-class EvaluatorVariantResponse(BaseModel):
+class EvaluatorVariantResponse(Support):
     count: int = 0
     evaluator_variant: Optional[EvaluatorVariant] = None
 
 
-class EvaluatorVariantsResponse(BaseModel):
+class EvaluatorVariantsResponse(Support):
     count: int = 0
     evaluator_variants: List[EvaluatorVariant] = []
 
@@ -170,13 +172,13 @@ class EvaluatorRevisionDeployRequest(BaseModel):
     message: Optional[str] = None
 
 
-class EvaluatorRevisionResponse(BaseModel):
+class EvaluatorRevisionResponse(Support):
     count: int = 0
     evaluator_revision: Optional[EvaluatorRevision] = None
     resolution_info: Optional[ResolutionInfo] = None  # Included when resolve=True
 
 
-class EvaluatorRevisionsResponse(BaseModel):
+class EvaluatorRevisionsResponse(Support):
     count: int = 0
     evaluator_revisions: List[EvaluatorRevision] = []
 
@@ -202,12 +204,12 @@ class SimpleEvaluatorQueryRequest(BaseModel):
     windowing: Optional[Windowing] = None
 
 
-class SimpleEvaluatorResponse(BaseModel):
+class SimpleEvaluatorResponse(Support):
     count: int = 0
     evaluator: Optional[SimpleEvaluator] = None
 
 
-class SimpleEvaluatorsResponse(BaseModel):
+class SimpleEvaluatorsResponse(Support):
     count: int = 0
     evaluators: List[SimpleEvaluator] = []
 
@@ -225,7 +227,7 @@ class EvaluatorRevisionResolveRequest(BaseModel):
     error_policy: Optional[ErrorPolicy] = ErrorPolicy.EXCEPTION
 
 
-class EvaluatorRevisionResolveResponse(BaseModel):
+class EvaluatorRevisionResolveResponse(Support):
     count: int = 0
     evaluator_revision: Optional[EvaluatorRevision] = None
     resolution_info: Optional[ResolutionInfo] = None
@@ -250,7 +252,7 @@ class EvaluatorTemplate(BaseModel):
     archived: Optional[bool] = False
 
 
-class EvaluatorTemplatesResponse(BaseModel):
+class EvaluatorTemplatesResponse(Support):
     count: int = 0
     templates: List[EvaluatorTemplate] = []
 
@@ -258,31 +260,31 @@ class EvaluatorTemplatesResponse(BaseModel):
 # EVALUATORS CATALOG -----------------------------------------------------------
 
 
-class EvaluatorCatalogTypeResponse(BaseModel):
+class EvaluatorCatalogTypeResponse(Support):
     count: int = 0
     type: Optional[EvaluatorCatalogType] = None
 
 
-class EvaluatorCatalogTypesResponse(BaseModel):
+class EvaluatorCatalogTypesResponse(Support):
     count: int = 0
     types: List[EvaluatorCatalogType] = []
 
 
-class EvaluatorCatalogTemplateResponse(BaseModel):
+class EvaluatorCatalogTemplateResponse(Support):
     count: int = 0
     template: Optional[EvaluatorCatalogTemplate] = None
 
 
-class EvaluatorCatalogTemplatesResponse(BaseModel):
+class EvaluatorCatalogTemplatesResponse(Support):
     count: int = 0
     templates: List[EvaluatorCatalogTemplate] = []
 
 
-class EvaluatorCatalogPresetResponse(BaseModel):
+class EvaluatorCatalogPresetResponse(Support):
     count: int = 0
     preset: Optional[EvaluatorCatalogPreset] = None
 
 
-class EvaluatorCatalogPresetsResponse(BaseModel):
+class EvaluatorCatalogPresetsResponse(Support):
     count: int = 0
     presets: List[EvaluatorCatalogPreset] = []

--- a/api/oss/src/apis/fastapi/folders/models.py
+++ b/api/oss/src/apis/fastapi/folders/models.py
@@ -4,6 +4,8 @@ from uuid import UUID
 from pydantic import BaseModel
 from fastapi import HTTPException
 
+from oss.src.utils.exceptions import Support
+
 from oss.src.core.folders.types import (
     Folder,
     FolderCreate,
@@ -24,17 +26,17 @@ class FolderQueryRequest(BaseModel):
     folder: FolderQuery
 
 
-class FolderResponse(BaseModel):
+class FolderResponse(Support):
     count: int = 0
     folder: Optional[Folder] = None
 
 
-class FoldersResponse(BaseModel):
+class FoldersResponse(Support):
     count: int = 0
     folders: List[Folder] = []
 
 
-class FolderIdResponse(BaseModel):
+class FolderIdResponse(Support):
     count: int = 0
     id: Optional[UUID] = None
 

--- a/api/oss/src/apis/fastapi/invocations/models.py
+++ b/api/oss/src/apis/fastapi/invocations/models.py
@@ -2,6 +2,8 @@ from typing import Optional, List
 
 from pydantic import BaseModel
 
+from oss.src.utils.exceptions import Support
+
 from oss.src.core.shared.dtos import (
     Link,
     Windowing,
@@ -32,21 +34,21 @@ class InvocationQueryRequest(BaseModel):
     windowing: Optional[Windowing] = None
 
 
-class InvocationResponse(BaseModel):
+class InvocationResponse(Support):
     count: int = 0
     invocation: Optional[Invocation] = None
 
 
-class InvocationsResponse(BaseModel):
+class InvocationsResponse(Support):
     count: int = 0
     invocations: List[Invocation] = []
 
 
-class InvocationLinkResponse(BaseModel):
+class InvocationLinkResponse(Support):
     count: int = 0
     invocation_link: Optional[Link] = None
 
 
-class InvocationLinksResponse(BaseModel):
+class InvocationLinksResponse(Support):
     count: int = 0
     invocation_links: List[Link] = []

--- a/api/oss/src/apis/fastapi/otlp/models.py
+++ b/api/oss/src/apis/fastapi/otlp/models.py
@@ -3,6 +3,8 @@ from datetime import datetime
 
 from pydantic import BaseModel, ConfigDict
 
+from oss.src.utils.exceptions import Support
+
 from oss.src.core.otel.dtos import (
     OTelSpanDTO,
     SpanDTO,
@@ -12,11 +14,11 @@ from oss.src.core.otel.dtos import (
 )
 
 
-class CollectStatusResponse(BaseModel):
+class CollectStatusResponse(Support):
     status: str
 
 
-class OTelTracingResponse(BaseModel):
+class OTelTracingResponse(Support):
     count: Optional[int] = None
     spans: List[OTelSpanDTO]
 
@@ -91,6 +93,6 @@ class LegacyAnalyticsResponse(LegacySummary):
     data: List[LegacyDataPoint]
 
 
-class OldAnalyticsResponse(BaseModel):
+class OldAnalyticsResponse(Support):
     count: Optional[int] = None
     buckets: List[BucketDTO]

--- a/api/oss/src/apis/fastapi/queries/models.py
+++ b/api/oss/src/apis/fastapi/queries/models.py
@@ -2,6 +2,8 @@ from typing import Optional, List
 
 from pydantic import BaseModel
 
+from oss.src.utils.exceptions import Support
+
 from oss.src.core.shared.dtos import (
     Reference,
     Windowing,
@@ -52,12 +54,12 @@ class QueryQueryRequest(BaseModel):
     windowing: Optional[Windowing] = None
 
 
-class QueryResponse(BaseModel):
+class QueryResponse(Support):
     count: int = 0
     query: Optional[Query] = None
 
 
-class QueriesResponse(BaseModel):
+class QueriesResponse(Support):
     count: int = 0
     queries: List[Query] = []
 
@@ -94,12 +96,12 @@ class QueryVariantForkRequest(BaseModel):
     description: Optional[str] = None
 
 
-class QueryVariantResponse(BaseModel):
+class QueryVariantResponse(Support):
     count: int = 0
     query_variant: Optional[QueryVariant] = None
 
 
-class QueryVariantsResponse(BaseModel):
+class QueryVariantsResponse(Support):
     count: int = 0
     query_variants: List[QueryVariant] = []
 
@@ -146,12 +148,12 @@ class QueryRevisionRetrieveRequest(BaseModel):
     windowing: Optional[Windowing] = None
 
 
-class QueryRevisionResponse(BaseModel):
+class QueryRevisionResponse(Support):
     count: int = 0
     query_revision: Optional[QueryRevision] = None
 
 
-class QueryRevisionsResponse(BaseModel):
+class QueryRevisionsResponse(Support):
     count: int = 0
     query_revisions: List[QueryRevision] = []
 
@@ -177,11 +179,11 @@ class SimpleQueryQueryRequest(BaseModel):
     windowing: Optional[Windowing] = None
 
 
-class SimpleQueryResponse(BaseModel):
+class SimpleQueryResponse(Support):
     count: int = 0
     query: Optional[SimpleQuery] = None
 
 
-class SimpleQueriesResponse(BaseModel):
+class SimpleQueriesResponse(Support):
     count: int = 0
     queries: List[SimpleQuery] = []

--- a/api/oss/src/apis/fastapi/testcases/models.py
+++ b/api/oss/src/apis/fastapi/testcases/models.py
@@ -3,6 +3,8 @@ from uuid import UUID
 
 from pydantic import BaseModel
 
+from oss.src.utils.exceptions import Support
+
 from oss.src.core.shared.dtos import (
     Windowing,
     Reference,
@@ -27,12 +29,12 @@ class TestcasesQueryRequest(BaseModel):
     windowing: Optional[Windowing] = None
 
 
-class TestcaseResponse(BaseModel):
+class TestcaseResponse(Support):
     count: int = 0
     testcase: Optional[Testcase] = None
 
 
-class TestcasesResponse(BaseModel):
+class TestcasesResponse(Support):
     count: int = 0
     testcases: List[Testcase] = []
     windowing: Optional[Windowing] = None

--- a/api/oss/src/apis/fastapi/testsets/models.py
+++ b/api/oss/src/apis/fastapi/testsets/models.py
@@ -2,6 +2,8 @@ from typing import Optional, List
 
 from pydantic import BaseModel
 
+from oss.src.utils.exceptions import Support
+
 from oss.src.core.shared.dtos import (
     Windowing,
     Reference,
@@ -52,12 +54,12 @@ class TestsetQueryRequest(BaseModel):
     windowing: Optional[Windowing] = None
 
 
-class TestsetResponse(BaseModel):
+class TestsetResponse(Support):
     count: int = 0
     testset: Optional[Testset] = None
 
 
-class TestsetsResponse(BaseModel):
+class TestsetsResponse(Support):
     count: int = 0
     testsets: List[Testset] = []
     windowing: Optional[Windowing] = None
@@ -85,12 +87,12 @@ class TestsetVariantQueryRequest(BaseModel):
     windowing: Optional[Windowing] = None
 
 
-class TestsetVariantResponse(BaseModel):
+class TestsetVariantResponse(Support):
     count: int = 0
     testset_variant: Optional[TestsetVariant] = None
 
 
-class TestsetVariantsResponse(BaseModel):
+class TestsetVariantsResponse(Support):
     count: int = 0
     testset_variants: List[TestsetVariant] = []
 
@@ -142,12 +144,12 @@ class TestsetRevisionsLogRequest(BaseModel):
     include_testcases: Optional[bool] = None
 
 
-class TestsetRevisionResponse(BaseModel):
+class TestsetRevisionResponse(Support):
     count: int = 0
     testset_revision: Optional[TestsetRevision] = None
 
 
-class TestsetRevisionsResponse(BaseModel):
+class TestsetRevisionsResponse(Support):
     count: int = 0
     testset_revisions: List[TestsetRevision] = []
 
@@ -173,11 +175,11 @@ class SimpleTestsetQueryRequest(BaseModel):
     windowing: Optional[Windowing] = None
 
 
-class SimpleTestsetResponse(BaseModel):
+class SimpleTestsetResponse(Support):
     count: int = 0
     testset: Optional[SimpleTestset] = None
 
 
-class SimpleTestsetsResponse(BaseModel):
+class SimpleTestsetsResponse(Support):
     count: int = 0
     testsets: List[SimpleTestset] = []

--- a/api/oss/src/apis/fastapi/traces/models.py
+++ b/api/oss/src/apis/fastapi/traces/models.py
@@ -2,6 +2,8 @@ from typing import Optional, List
 
 from pydantic import BaseModel
 
+from oss.src.utils.exceptions import Support
+
 from oss.src.core.shared.dtos import Link, Windowing
 from oss.src.core.tracing.dtos import (
     SimpleTrace,
@@ -27,16 +29,16 @@ class SimpleTraceQueryRequest(BaseModel):
     windowing: Optional[Windowing] = None
 
 
-class SimpleTraceResponse(BaseModel):
+class SimpleTraceResponse(Support):
     count: int = 0
     trace: Optional[SimpleTrace] = None
 
 
-class SimpleTracesResponse(BaseModel):
+class SimpleTracesResponse(Support):
     count: int = 0
     traces: List[SimpleTrace] = []
 
 
-class SimpleTraceLinkResponse(BaseModel):
+class SimpleTraceLinkResponse(Support):
     count: int = 0
     link: Optional[Link] = None

--- a/api/oss/src/apis/fastapi/tracing/models.py
+++ b/api/oss/src/apis/fastapi/tracing/models.py
@@ -2,6 +2,8 @@ from typing import Optional, List
 
 from pydantic import BaseModel
 
+from oss.src.utils.exceptions import Support
+
 from oss.src.core.shared.dtos import (
     Windowing,
     Reference,
@@ -49,63 +51,63 @@ class SpanRequest(BaseModel):
     span: Optional[Span] = None
 
 
-class OTelLinksResponse(BaseModel):
+class OTelLinksResponse(Support):
     count: int = 0
     links: Optional[OTelLinks] = None
 
 
-class LinkResponse(BaseModel):
+class LinkResponse(Support):
     count: int = 0
     link: Optional[Link] = None
 
 
-class LinksResponse(BaseModel):
+class LinksResponse(Support):
     count: int = 0
     links: Optional[Links] = None
 
 
-class TraceIdResponse(BaseModel):
+class TraceIdResponse(Support):
     count: int = 0
     trace_id: Optional[str] = None
 
 
-class TraceIdsResponse(BaseModel):
+class TraceIdsResponse(Support):
     count: int = 0
     trace_ids: List[str] = []
 
 
-class SpanIdResponse(BaseModel):
+class SpanIdResponse(Support):
     count: int = 0
     span_id: Optional[str] = None
 
 
-class SpanIdsResponse(BaseModel):
+class SpanIdsResponse(Support):
     count: int = 0
     span_ids: List[str] = []
 
 
-class OTelTracingResponse(BaseModel):
+class OTelTracingResponse(Support):
     count: int = 0
     spans: Optional[OTelFlatSpans] = None
     traces: Optional[OTelTraceTree] = None
 
 
-class TraceResponse(BaseModel):
+class TraceResponse(Support):
     count: int = 0
     trace: Optional[Trace] = None
 
 
-class TracesResponse(BaseModel):
+class TracesResponse(Support):
     count: int = 0
     traces: Optional[Traces] = None
 
 
-class SpanResponse(BaseModel):
+class SpanResponse(Support):
     count: int = 0
     span: Optional[Span] = None
 
 
-class SpansResponse(BaseModel):
+class SpansResponse(Support):
     count: int = 0
     spans: Optional[Spans] = None
 
@@ -128,12 +130,12 @@ class SpansQueryRequest(BaseModel):
     query_revision_ref: Optional[Reference] = None
 
 
-class OldAnalyticsResponse(BaseModel):
+class OldAnalyticsResponse(Support):
     count: int = 0
     buckets: List[Bucket] = []
 
 
-class AnalyticsResponse(BaseModel):
+class AnalyticsResponse(Support):
     count: int = 0
     buckets: List[MetricsBucket] = []
     #
@@ -147,7 +149,7 @@ class SessionsQueryRequest(BaseModel):
     windowing: Optional[Windowing] = None
 
 
-class SessionIdsResponse(BaseModel):
+class SessionIdsResponse(Support):
     count: int = 0
     session_ids: List[str] = []
     windowing: Optional[Windowing] = None
@@ -159,7 +161,7 @@ class UsersQueryRequest(BaseModel):
     windowing: Optional[Windowing] = None
 
 
-class UserIdsResponse(BaseModel):
+class UserIdsResponse(Support):
     count: int = 0
     user_ids: List[str] = []
     windowing: Optional[Windowing] = None

--- a/api/oss/src/apis/fastapi/workflows/models.py
+++ b/api/oss/src/apis/fastapi/workflows/models.py
@@ -2,6 +2,8 @@ from typing import Optional, List
 
 from pydantic import BaseModel
 
+from oss.src.utils.exceptions import Support
+
 from oss.src.core.shared.dtos import (
     Windowing,
     Reference,
@@ -66,12 +68,12 @@ class WorkflowForkRequest(BaseModel):
     workflow: WorkflowFork
 
 
-class WorkflowResponse(BaseModel):
+class WorkflowResponse(Support):
     count: int = 0
     workflow: Optional[Workflow] = None
 
 
-class WorkflowsResponse(BaseModel):
+class WorkflowsResponse(Support):
     count: int = 0
     workflows: List[Workflow] = []
     windowing: Optional[Windowing] = None
@@ -99,12 +101,12 @@ class WorkflowVariantQueryRequest(BaseModel):
     windowing: Optional[Windowing] = None
 
 
-class WorkflowVariantResponse(BaseModel):
+class WorkflowVariantResponse(Support):
     count: int = 0
     workflow_variant: Optional[WorkflowVariant] = None
 
 
-class WorkflowVariantsResponse(BaseModel):
+class WorkflowVariantsResponse(Support):
     count: int = 0
     workflow_variants: List[WorkflowVariant] = []
     windowing: Optional[Windowing] = None
@@ -167,13 +169,13 @@ class WorkflowRevisionsLogRequest(BaseModel):
     workflow: WorkflowRevisionsLog
 
 
-class WorkflowRevisionResponse(BaseModel):
+class WorkflowRevisionResponse(Support):
     count: int = 0
     workflow_revision: Optional[WorkflowRevision] = None
     resolution_info: Optional[ResolutionInfo] = None  # Included when resolve=True
 
 
-class WorkflowRevisionsResponse(BaseModel):
+class WorkflowRevisionsResponse(Support):
     count: int = 0
     workflow_revisions: List[WorkflowRevision] = []
     windowing: Optional[Windowing] = None
@@ -194,7 +196,7 @@ class WorkflowRevisionResolveRequest(BaseModel):
     error_policy: Optional[ErrorPolicy] = ErrorPolicy.EXCEPTION
 
 
-class WorkflowRevisionResolveResponse(BaseModel):
+class WorkflowRevisionResolveResponse(Support):
     count: int = 0
     workflow_revision: Optional[WorkflowRevision] = None
     resolution_info: Optional[ResolutionInfo] = None
@@ -203,32 +205,32 @@ class WorkflowRevisionResolveResponse(BaseModel):
 # WORKFLOW CATALOG -------------------------------------------------------------
 
 
-class WorkflowCatalogTypeResponse(BaseModel):
+class WorkflowCatalogTypeResponse(Support):
     count: int = 0
     type: Optional[WorkflowCatalogType] = None
 
 
-class WorkflowCatalogTypesResponse(BaseModel):
+class WorkflowCatalogTypesResponse(Support):
     count: int = 0
     types: List[WorkflowCatalogType] = []
 
 
-class WorkflowCatalogTemplateResponse(BaseModel):
+class WorkflowCatalogTemplateResponse(Support):
     count: int = 0
     template: Optional[WorkflowCatalogTemplate] = None
 
 
-class WorkflowCatalogTemplatesResponse(BaseModel):
+class WorkflowCatalogTemplatesResponse(Support):
     count: int = 0
     templates: List[WorkflowCatalogTemplate] = []
 
 
-class WorkflowCatalogPresetResponse(BaseModel):
+class WorkflowCatalogPresetResponse(Support):
     count: int = 0
     preset: Optional[WorkflowCatalogPreset] = None
 
 
-class WorkflowCatalogPresetsResponse(BaseModel):
+class WorkflowCatalogPresetsResponse(Support):
     count: int = 0
     presets: List[WorkflowCatalogPreset] = []
 
@@ -254,11 +256,11 @@ class SimpleWorkflowQueryRequest(BaseModel):
     windowing: Optional[Windowing] = None
 
 
-class SimpleWorkflowResponse(BaseModel):
+class SimpleWorkflowResponse(Support):
     count: int = 0
     workflow: Optional[SimpleWorkflow] = None
 
 
-class SimpleWorkflowsResponse(BaseModel):
+class SimpleWorkflowsResponse(Support):
     count: int = 0
     workflows: List[SimpleWorkflow] = []

--- a/api/oss/src/utils/exceptions.py
+++ b/api/oss/src/utils/exceptions.py
@@ -1,3 +1,4 @@
+from datetime import datetime, timezone
 from typing import Any, Optional, List
 from uuid import uuid4
 from functools import wraps
@@ -5,12 +6,40 @@ from traceback import format_exc
 from contextlib import AbstractContextManager
 
 from fastapi import Request, HTTPException
+from pydantic import BaseModel
 
 from oss.src.utils.logging import get_module_logger
 from oss.src.core.shared.exceptions import EntityCreationConflict
 
 
 log = get_module_logger(__name__)
+
+
+class Support(BaseModel):
+    support_id: Optional[str] = None
+    support_ts: Optional[datetime] = None
+
+
+def build_support() -> Support:
+    return Support(
+        support_id=str(uuid4()),
+        support_ts=datetime.now(timezone.utc),
+    )
+
+
+def attach_support(payload: Any, support: Support) -> Any:
+    if (
+        isinstance(payload, BaseModel)
+        and "support_id" in payload.__class__.model_fields
+    ):
+        return payload.model_copy(
+            update={
+                "support_id": support.support_id,
+                "support_ts": support.support_ts,
+            }
+        )
+
+    return payload
 
 
 def build_entity_creation_conflict_message(
@@ -49,7 +78,7 @@ class suppress(AbstractContextManager):  # pylint: disable=invalid-name
 
     def __exit__(self, exc_type, exc_value, exc_tb):
         if exc_type is not None:
-            support_id = str(uuid4())
+            support = build_support()
 
             if self.verbose is True:
                 if any(isinstance(exc_value, excl) for excl in self.exclude):
@@ -57,7 +86,8 @@ class suppress(AbstractContextManager):  # pylint: disable=invalid-name
 
                 log.warn(
                     f"[SUPPRESSED] {self.message}\n{format_exc()}",
-                    support_id=support_id,
+                    support_id=support.support_id,
+                    support_ts=support.support_ts,
                 )
 
         return True
@@ -79,17 +109,18 @@ def suppress_exceptions(
                 if any(isinstance(exc, excl) for excl in exclude or []):
                     raise
 
-                support_id = str(uuid4())
+                support = build_support()
                 operation_id = func.__name__ if hasattr(func, "__name__") else None
 
                 if verbose is True:
                     log.warn(
                         f"[SUPPRESSED] {message}\n{format_exc()}",
-                        support_id=support_id,
+                        support_id=support.support_id,
+                        support_ts=support.support_ts,
                         operation_id=operation_id,
                     )
 
-                return default
+                return attach_support(default, support)
 
         return wrapper
 
@@ -112,15 +143,18 @@ def intercept_exceptions(
                 if isinstance(e, EntityCreationConflict):
                     e: EntityCreationConflict
 
+                    support = build_support()
                     raise ConflictException(
                         message=build_entity_creation_conflict_message(
                             conflict=e.conflict,
                             default_message=e.message,
                         ),
                         conflict=e.conflict,
+                        support_id=support.support_id,
+                        support_ts=support.support_ts,
                     ) from e
 
-                support_id = str(uuid4())
+                support = build_support()
                 operation_id = func.__name__ if hasattr(func, "__name__") else None
 
                 user_id = None
@@ -153,14 +187,16 @@ def intercept_exceptions(
                 status_code = 500
                 detail = {
                     "message": message,
-                    "support_id": support_id,
+                    "support_id": support.support_id,
+                    "support_ts": support.support_ts,
                     "operation_id": operation_id,
                 }
 
                 if verbose is True:
                     log.error(
                         f"[INTERCEPTED]\n{format_exc()}",
-                        support_id=support_id,
+                        support_id=support.support_id,
+                        support_ts=support.support_ts,
                         operation_id=operation_id,
                         user_id=user_id,
                         organization_id=organization_id,

--- a/api/oss/tests/pytest/unit/utils/test_exceptions.py
+++ b/api/oss/tests/pytest/unit/utils/test_exceptions.py
@@ -1,0 +1,52 @@
+from datetime import timezone
+
+import pytest
+from fastapi import HTTPException
+
+from oss.src.apis.fastapi.workflows.models import WorkflowResponse
+from oss.src.utils.exceptions import (
+    build_support,
+    intercept_exceptions,
+    suppress_exceptions,
+)
+
+
+def test_support_helper_uses_utc_timestamp():
+    support = build_support()
+
+    assert support.support_id is not None
+    assert support.support_ts is not None
+    assert support.support_ts.tzinfo == timezone.utc
+
+
+def test_support_fields_exist_on_api_response_model():
+    assert "support_id" in WorkflowResponse.model_fields
+    assert "support_ts" in WorkflowResponse.model_fields
+
+
+@pytest.mark.asyncio
+async def test_suppress_exceptions_attaches_support_to_response():
+    @suppress_exceptions(default=WorkflowResponse(), verbose=False)
+    async def raise_error():
+        raise RuntimeError("boom")
+
+    result = await raise_error()
+
+    assert isinstance(result, WorkflowResponse)
+    assert result.support_id is not None
+    assert result.support_ts is not None
+    assert result.support_ts.tzinfo == timezone.utc
+
+
+@pytest.mark.asyncio
+async def test_intercept_exceptions_includes_support_metadata():
+    @intercept_exceptions(verbose=False)
+    async def raise_error():
+        raise RuntimeError("boom")
+
+    with pytest.raises(HTTPException) as exc_info:
+        await raise_error()
+
+    detail = exc_info.value.detail
+    assert detail["support_id"]
+    assert detail["support_ts"].tzinfo == timezone.utc


### PR DESCRIPTION
## Description

Add top-level support metadata to API-layer read/query responses and propagate it from the exception wrappers.

## What changed

- Added a shared Support model in application/api/oss/src/utils/exceptions.py with:
  - support_id
  - support_ts in UTC
- Updated suppress_exceptions() so suppressed API responses get populated with support metadata instead of returning an unmarked empty object.
- Updated intercept_exceptions() so unexpected failures include support metadata in the error payload and logs.
- Made the API response DTOs used by suppressed read/query routes inherit Support directly, so the response shape now includes top-level support_id and support_ts.
- Added unit tests covering:
  - UTC support timestamp generation
  - support fields on API response models
  - support attachment on suppressed responses
  - support metadata in intercepted exceptions

## Notes

This change is limited to API-layer read/query response models that use suppress_exceptions().
DAO-layer suppression behavior remains unchanged.