### PR TITLE
[fix] Resolve Incorrect Development Env Ordering in Playground

### DIFF
--- a/web/packages/agenta-entities/src/environment/state/appDeployments.ts
+++ b/web/packages/agenta-entities/src/environment/state/appDeployments.ts
@@ -126,6 +126,16 @@ const ENV_ORDER: Record<string, number> = {
 
 const EmptyEnvs: AppEnvironmentDeployment[] = []
 
+function sortByCanonicalEnvOrder(
+    envs: AppEnvironmentDeployment[],
+): AppEnvironmentDeployment[] {
+    if (envs.length <= 1) return envs
+    return [...envs].sort(
+        (a, b) =>
+            (ENV_ORDER[a.name.toLowerCase()] ?? 99) - (ENV_ORDER[b.name.toLowerCase()] ?? 99),
+    )
+}
+
 // ============================================================================
 // PARAMETERIZED ATOM FAMILIES
 // ============================================================================
@@ -164,12 +174,7 @@ export const appEnvironmentsAtomFamily = atomFamily((appId: string) =>
         appEnvironmentsQueryAtomFamily(appId),
         (res) => {
             const envs: AppEnvironmentDeployment[] = res?.data ?? EmptyEnvs
-            if (envs.length <= 1) return envs
-            return [...envs].sort(
-                (a, b) =>
-                    (ENV_ORDER[a.name.toLowerCase()] ?? 99) -
-                    (ENV_ORDER[b.name.toLowerCase()] ?? 99),
-            )
+            return sortByCanonicalEnvOrder(envs)
         },
         deepEqual,
     ),
@@ -177,7 +182,14 @@ export const appEnvironmentsAtomFamily = atomFamily((appId: string) =>
 
 /**
  * Loadable query state for a given appId (exposes isPending, isError, refetch).
+ * `data` is sorted the same as {@link appEnvironmentsAtomFamily} (development → staging → production).
  */
 export const appEnvironmentsLoadableAtomFamily = atomFamily((appId: string) =>
-    atom((get) => get(appEnvironmentsQueryAtomFamily(appId))),
+    atom((get) => {
+        const res = get(appEnvironmentsQueryAtomFamily(appId))
+        return {
+            ...res,
+            data: sortByCanonicalEnvOrder(res.data ?? EmptyEnvs),
+        }
+    }),
 )

--- a/web/packages/agenta-entities/src/environment/state/appDeployments.ts
+++ b/web/packages/agenta-entities/src/environment/state/appDeployments.ts
@@ -129,7 +129,9 @@ const EmptyEnvs: AppEnvironmentDeployment[] = []
 function sortByCanonicalEnvOrder(envs: AppEnvironmentDeployment[]): AppEnvironmentDeployment[] {
     if (envs.length <= 1) return envs
     return [...envs].sort(
-        (a, b) => (ENV_ORDER[a.name.toLowerCase()] ?? 99) - (ENV_ORDER[b.name.toLowerCase()] ?? 99),
+        (a, b) =>
+            (ENV_ORDER[a.name.toLowerCase()] ?? 99) -
+            (ENV_ORDER[b.name.toLowerCase()] ?? 99),
     )
 }
 

--- a/web/packages/agenta-entities/src/environment/state/appDeployments.ts
+++ b/web/packages/agenta-entities/src/environment/state/appDeployments.ts
@@ -126,13 +126,10 @@ const ENV_ORDER: Record<string, number> = {
 
 const EmptyEnvs: AppEnvironmentDeployment[] = []
 
-function sortByCanonicalEnvOrder(
-    envs: AppEnvironmentDeployment[],
-): AppEnvironmentDeployment[] {
+function sortByCanonicalEnvOrder(envs: AppEnvironmentDeployment[]): AppEnvironmentDeployment[] {
     if (envs.length <= 1) return envs
     return [...envs].sort(
-        (a, b) =>
-            (ENV_ORDER[a.name.toLowerCase()] ?? 99) - (ENV_ORDER[b.name.toLowerCase()] ?? 99),
+        (a, b) => (ENV_ORDER[a.name.toLowerCase()] ?? 99) - (ENV_ORDER[b.name.toLowerCase()] ?? 99),
     )
 }
 


### PR DESCRIPTION
## Summary
<!-- What changed? -->
<!-- Why was this change needed? -->
<!-- What problem does it solve? -->
<!-- For fixes, explain how the change addresses the root cause. -->

- Inside Playground, if we hit "Deploy Model", the ordering of the environments was Development, Production, Staging
- The correct ordering of Development, Staging, Production can be found inside Registry Deployements
- Registry Deployments used sorting as seen inside `appEnvironmentsQueryAtomFamily` 
- I moved that sorting logic to a helper function called `sortByCanonicalEnvOrder()` for usage in both areas


## Testing
### Verified locally
<!-- What did you run or verify locally? Be specific. -->

- Ran Linting locally and it passed

### Added or updated tests
<!-- What tests did you add or update? Include unit, integration, and end-to-end coverage when relevant. Write N/A if none. -->
N/A

### QA follow-up
<!-- What still needs QA? List flows, browsers, environments, edge cases, or data conditions to validate. Write N/A if none. -->
N/A

## Demo
<!-- Required for UI changes. Add screenshots, GIFs, or a short video. -->
<!-- If this is not a UI change, write N/A. -->

**Before:**
<img width="1767" height="1424" alt="image" src="https://github.com/user-attachments/assets/092958f6-b29a-42f1-90de-54c5beb8d073" />


**After:**
<img width="1776" height="1327" alt="image" src="https://github.com/user-attachments/assets/b43e7dbf-b1b8-4aac-b6d5-f67866538eba" />


## Checklist
- [x] I have included a video or screen recording for UI changes, or marked Demo as N/A
- [ ] Relevant tests pass locally
- [ ] Relevant linting and formatting pass locally
- [x] I have signed the CLA, or I will sign it when the bot prompts me

## Contributor Resources
- [Contributing guide](https://agenta.ai/docs/contributing/overview)
- [Creating your first PR](https://agenta.ai/docs/contributing/first-pr)
- [Development mode](https://agenta.ai/docs/contributing/guides/development-mode)
- [Testing](https://agenta.ai/docs/contributing/guides/testing)
- [Formatting and linting](https://agenta.ai/docs/contributing/guides/formatting-and-linting)
- [Slack support](https://join.slack.com/t/agenta-hq/shared_invite/zt-37pnbp5s6-mbBrPL863d_oLB61GSNFjw)
