### PR TITLE
[#4188] fix(frontend): enable Playground button for all workflow spans

### DIFF
--- a/web/oss/src/components/SharedDrawers/TraceDrawer/components/TraceContent/components/TraceTypeHeader/index.tsx
+++ b/web/oss/src/components/SharedDrawers/TraceDrawer/components/TraceContent/components/TraceTypeHeader/index.tsx
@@ -12,7 +12,6 @@ import dynamic from "next/dynamic"
 import AddToTestsetButton from "@/oss/components/SharedDrawers/AddToTestsetDrawer/components/AddToTestsetButton"
 import AnnotateDrawerButton from "@/oss/components/SharedDrawers/AnnotateDrawer/assets/AnnotateDrawerButton"
 import {openTraceInPlaygroundAtom} from "@/oss/components/SharedDrawers/TraceDrawer/store/openInPlayground"
-import {TraceSpanNode} from "@/oss/services/tracing/types"
 import {useAppNavigation} from "@/oss/state/appState"
 import {urlAtom} from "@/oss/state/url"
 import {buildPlaygroundUrl} from "@/oss/state/url/playground"
@@ -25,27 +24,6 @@ import {TraceTypeHeaderProps} from "./types"
 const DeleteTraceModal = dynamic(() => import("../../../DeleteTraceModal"), {
     ssr: false,
 })
-
-/**
- * Check if a workflow span has an app reference (application or application_revision).
- * Checks ag.references (dict format) and top-level references array.
- */
-function hasAppReference(span: TraceSpanNode): boolean {
-    const attrs = span.attributes as Record<string, unknown> | undefined
-    const ag = attrs?.ag as Record<string, unknown> | undefined
-    const agRefs = ag?.references as Record<string, unknown> | undefined
-    if (agRefs?.application || agRefs?.application_revision) return true
-
-    const topRefs = span.references as {attributes?: {key?: string}}[] | undefined
-    if (Array.isArray(topRefs)) {
-        return topRefs.some(
-            (ref) =>
-                ref.attributes?.key === "application" ||
-                ref.attributes?.key === "application_revision",
-        )
-    }
-    return false
-}
 
 const TraceTypeHeader = ({
     activeTrace,
@@ -73,8 +51,11 @@ const TraceTypeHeader = ({
             return Boolean(agData?.inputs)
         }
 
+        // Workflow spans can always be opened: if an app_revision reference exists,
+        // that revision is opened directly; otherwise an ephemeral workflow is created
+        // from the trace data, even when variant fields are missing or null.
         if (spanType === "workflow") {
-            return hasAppReference(activeTrace)
+            return true
         }
 
         return false


### PR DESCRIPTION
## Summary

Fixes #4188 — the Playground button staying disabled when opening a workflow span whose variant fields are missing or null.

- **Root cause**: `canOpenInPlayground` required `hasAppReference()` to return `true` for workflow spans, meaning only spans with an `application` or `application_revision` reference could enable the button.
- **Fix**: `openFromTraceAtom` already handles workflow spans without app references by creating an ephemeral workflow from the trace data. Removed the `hasAppReference` restriction so the button is enabled for **all** workflow spans — spans with an app revision reference open that revision directly; others fall back to an ephemeral workflow navigated to via the project playground.

## Changes

- `TraceTypeHeader/index.tsx`: removed `hasAppReference` helper, removed unused `TraceSpanNode` import, changed `canOpenInPlayground` for `workflow` spans to return `true` unconditionally.

## Test plan

- [ ] Open a workflow span that has `application_revision` reference → Playground button enabled, opens app playground at that revision
- [ ] Open a workflow span where variant fields are missing/null → Playground button now enabled (was disabled before), opens project playground with an ephemeral workflow built from trace data
- [ ] Open a chat span with inputs → Playground button still enabled as before
- [ ] Open a span of any other type → Playground button still disabled