### PR TITLE
fix/Removed duplicate Mistral option

### DIFF
--- a/web/oss/src/components/ModelRegistry/Drawers/ConfigureProviderDrawer/assets/ConfigureProviderDrawerContent.tsx
+++ b/web/oss/src/components/ModelRegistry/Drawers/ConfigureProviderDrawer/assets/ConfigureProviderDrawerContent.tsx
@@ -19,6 +19,14 @@ import {ConfigureProviderDrawerContentProps} from "./types"
 
 const {Text} = Typography
 
+/** Legacy API slug `mistralai`; canonical slug is {@link SecretDTOProvider.MISTRAL}. Kept on the enum for typing/API parity only. */
+const MISTRAL_LEGACY_PROVIDER_SLUG = SecretDTOProvider.MISTRALAI
+
+/** Maps legacy `mistralai` to canonical `mistral` for form + select state; all other slugs unchanged. */
+function mistralLegacySlugToCanonical(provider: string): string {
+    return provider === MISTRAL_LEGACY_PROVIDER_SLUG ? SecretDTOProvider.MISTRAL : provider
+}
+
 /**
  * Optional render metadata you can attach to each PROVIDER_FIELDS item.
  * Example:
@@ -116,7 +124,9 @@ const ConfigureProviderDrawerContent = ({
 
     // Build provider options for SelectLLMProviderBase
     const providerOptions = useMemo<ProviderGroup[]>(() => {
-        const allProviders = [...new Set([...standardProviders, ...customProviders])]
+        // MistralAI (legacy slug) is not shown in the UI, it's mapped to Mistral 
+        const standardForUi = standardProviders.filter((p) => p !== MISTRAL_LEGACY_PROVIDER_SLUG)
+        const allProviders = [...new Set([...standardForUi, ...customProviders])]
         return allProviders.map((key) => {
             const label = PROVIDER_LABELS[key] ?? capitalize(key)
             return {
@@ -143,9 +153,14 @@ const ConfigureProviderDrawerContent = ({
 
     useEffect(() => {
         if (selectedProvider) {
+
+            const rawProvider = selectedProvider.provider ?? ""
             form.setFieldsValue({
                 ...selectedProvider,
-                provider: selectedProvider.provider ?? "",
+                // Map legacy `mistralai` to canonical `mistral` for form + select state
+                provider: mistralLegacySlugToCanonical(
+                    typeof rawProvider === "string" ? rawProvider : String(rawProvider),
+                ),
             })
         } else {
             form.resetFields()

--- a/web/oss/src/components/ModelRegistry/Drawers/ConfigureProviderDrawer/assets/ConfigureProviderDrawerContent.tsx
+++ b/web/oss/src/components/ModelRegistry/Drawers/ConfigureProviderDrawer/assets/ConfigureProviderDrawerContent.tsx
@@ -19,14 +19,6 @@ import {ConfigureProviderDrawerContentProps} from "./types"
 
 const {Text} = Typography
 
-/** Legacy API slug `mistralai`; canonical slug is {@link SecretDTOProvider.MISTRAL}. Kept on the enum for typing/API parity only. */
-const MISTRAL_LEGACY_PROVIDER_SLUG = SecretDTOProvider.MISTRALAI
-
-/** Maps legacy `mistralai` to canonical `mistral` for form + select state; all other slugs unchanged. */
-function mistralLegacySlugToCanonical(provider: string): string {
-    return provider === MISTRAL_LEGACY_PROVIDER_SLUG ? SecretDTOProvider.MISTRAL : provider
-}
-
 /**
  * Optional render metadata you can attach to each PROVIDER_FIELDS item.
  * Example:
@@ -124,9 +116,7 @@ const ConfigureProviderDrawerContent = ({
 
     // Build provider options for SelectLLMProviderBase
     const providerOptions = useMemo<ProviderGroup[]>(() => {
-        // MistralAI (legacy slug) is not shown in the UI, it's mapped to Mistral
-        const standardForUi = standardProviders.filter((p) => p !== MISTRAL_LEGACY_PROVIDER_SLUG)
-        const allProviders = [...new Set([...standardForUi, ...customProviders])]
+        const allProviders = [...new Set([...standardProviders, ...customProviders])]
         return allProviders.map((key) => {
             const label = PROVIDER_LABELS[key] ?? capitalize(key)
             return {
@@ -153,18 +143,15 @@ const ConfigureProviderDrawerContent = ({
 
     useEffect(() => {
         if (selectedProvider) {
-            const rawProvider = selectedProvider.provider ?? ""
+            const rawProvider = String(selectedProvider.provider ?? "")
             form.setFieldsValue({
                 ...selectedProvider,
-                // Map legacy `mistralai` to canonical `mistral` for form + select state
-                provider: mistralLegacySlugToCanonical(
-                    typeof rawProvider === "string" ? rawProvider : String(rawProvider),
-                ),
+                provider: PROVIDER_KINDS[rawProvider] ?? rawProvider,
             })
         } else {
             form.resetFields()
         }
-    }, [selectedProvider, form])
+    }, [selectedProvider])
 
     const onSubmit = async (values: LlmProvider) => {
         try {

--- a/web/oss/src/components/ModelRegistry/Drawers/ConfigureProviderDrawer/assets/ConfigureProviderDrawerContent.tsx
+++ b/web/oss/src/components/ModelRegistry/Drawers/ConfigureProviderDrawer/assets/ConfigureProviderDrawerContent.tsx
@@ -153,7 +153,6 @@ const ConfigureProviderDrawerContent = ({
 
     useEffect(() => {
         if (selectedProvider) {
-
             const rawProvider = selectedProvider.provider ?? ""
             form.setFieldsValue({
                 ...selectedProvider,
@@ -165,7 +164,7 @@ const ConfigureProviderDrawerContent = ({
         } else {
             form.resetFields()
         }
-    }, [selectedProvider])
+    }, [selectedProvider, form])
 
     const onSubmit = async (values: LlmProvider) => {
         try {

--- a/web/oss/src/components/ModelRegistry/Drawers/ConfigureProviderDrawer/assets/ConfigureProviderDrawerContent.tsx
+++ b/web/oss/src/components/ModelRegistry/Drawers/ConfigureProviderDrawer/assets/ConfigureProviderDrawerContent.tsx
@@ -124,7 +124,7 @@ const ConfigureProviderDrawerContent = ({
 
     // Build provider options for SelectLLMProviderBase
     const providerOptions = useMemo<ProviderGroup[]>(() => {
-        // MistralAI (legacy slug) is not shown in the UI, it's mapped to Mistral 
+        // MistralAI (legacy slug) is not shown in the UI, it's mapped to Mistral
         const standardForUi = standardProviders.filter((p) => p !== MISTRAL_LEGACY_PROVIDER_SLUG)
         const allProviders = [...new Set([...standardForUi, ...customProviders])]
         return allProviders.map((key) => {

--- a/web/oss/src/lib/Types.ts
+++ b/web/oss/src/lib/Types.ts
@@ -146,7 +146,6 @@ export enum SecretDTOProvider {
     ALEPHALPHA = "alephalpha",
     GROQ = "groq",
     MISTRAL = "mistral",
-    MISTRALAI = "mistralai",
     ANTHROPIC = "anthropic",
     PERPLEXITYAI = "perplexityai",
     TOGETHERAI = "together_ai",
@@ -174,14 +173,18 @@ export const PROVIDER_LABELS: Record<string, string> = {
     custom: "Custom Provider",
 }
 
-export const PROVIDER_KINDS: Record<string, string> = Object.entries(PROVIDER_LABELS).reduce(
-    (acc, [kind, label]) => {
-        acc[kind] = kind
-        acc[label.toLowerCase()] = kind
-        return acc
-    },
-    {} as Record<string, string>,
-)
+export const PROVIDER_KINDS: Record<string, string> = {
+    ...Object.entries(PROVIDER_LABELS).reduce(
+        (acc, [kind, label]) => {
+            acc[kind] = kind
+            acc[label.toLowerCase()] = kind
+            return acc
+        },
+        {} as Record<string, string>,
+    ),
+    // Normalize legacy "mistralai" slug to canonical "mistral"
+    mistralai: "mistral",
+}
 
 interface VaultModels {
     slug: string


### PR DESCRIPTION
## Summary
<!-- What changed? -->
<!-- Why was this change needed? -->
<!-- What problem does it solve? -->
<!-- For fixes, explain how the change addresses the root cause. -->

- Mistral was shown twice inside the dropdown for adding a Custom or Standard provider
- This PR fixes the UI showing Mistral option twice, one was being displayed for the legacy 'MistralAI' and one for 'Mistral'
- The provider dropdown listed Mistral twice because the frontend enumerated both mistral and legacy mistralai, and both labels are “Mistral AI 
- In the backend, inside `api/oss/src/core/secrets/dtos.py` , Backend already normalizes legacy MistralAI to canonical Mistral lines 100-102, see below
```
            # Accept the legacy provider slug on input, but persist the canonical value.
            if data.get("kind") == StandardProviderKind.MISTRALAI.value:
                data["kind"] = StandardProviderKind.MISTRAL.value

```


- Now UI is aligned with backend

## Testing
### Verified locally
<!-- What did you run or verify locally? Be specific. -->

- Locally verified, I can set Mistral API key inside Custom and Standard provider and successfully run a completion inside Playground
- Locally, verified I see one Mistral option

### Added or updated tests
<!-- What tests did you add or update? Include unit, integration, and end-to-end coverage when relevant. Write N/A if none. -->

N/A

### QA follow-up
<!-- What still needs QA? List flows, browsers, environments, edge cases, or data conditions to validate. Write N/A if none. -->

N/A

## Demo
<!-- Required for UI changes. Add screenshots, GIFs, or a short video. -->
<!-- If this is not a UI change, write N/A. -->

**Before:**
<img width="2120" height="1662" alt="image" src="https://github.com/user-attachments/assets/0f6b5dc3-99f4-4b9f-80f4-50a590dc3796" />

**After:**
<img width="2120" height="1662" alt="image" src="https://github.com/user-attachments/assets/f074850e-37a6-4354-93f0-77ca65542ab7" />


## Checklist
- [x] I have included a video or screen recording for UI changes, or marked Demo as N/A
- [ ] Relevant tests pass locally
- [x] Relevant linting and formatting pass locally
- [x] I have signed the CLA, or I will sign it when the bot prompts me

## Contributor Resources
- [Contributing guide](https://agenta.ai/docs/contributing/overview)
- [Creating your first PR](https://agenta.ai/docs/contributing/first-pr)
- [Development mode](https://agenta.ai/docs/contributing/guides/development-mode)
- [Testing](https://agenta.ai/docs/contributing/guides/testing)
- [Formatting and linting](https://agenta.ai/docs/contributing/guides/formatting-and-linting)
- [Slack support](https://join.slack.com/t/agenta-hq/shared_invite/zt-37pnbp5s6-mbBrPL863d_oLB61GSNFjw)
- - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - 