### PR TITLE
doc(docs): Expand v0.96 migration guide with fetch endpoint and full removed list

### DIFF
--- a/docs/blog/entries/unified-invoke-api.mdx
+++ b/docs/blog/entries/unified-invoke-api.mdx
@@ -7,11 +7,11 @@ description: "Migration guide from the v0.95 REST API to v0.96. Covers the unifi
 ---
 
 :::warning Guide updated 2026-04-28
-The original version of this guide, published on 2026-04-14, covered only the new invocation endpoint. It did not mention the prompt configuration fetch endpoint, nor the broader REST API restructure. Customers calling endpoints like `GET /apps`, `POST /variants/configs/fetch`, or `/invocations/*` directly hit unexpected 404s and had no documented migration path. This update fills those gaps.
+The original version of this guide did not mention the prompt configuration fetch endpoint and lacked several minor endpoints. This update covers them all.
 :::
 
 :::danger Deprecation deadline: May 31, 2026
-All legacy REST endpoints documented here continue to respond through an adapter layer until **May 31, 2026**. After that date, calls to the old endpoints will return errors. Update your integration before then.
+Every legacy REST endpoint covered in this guide will stop responding on **May 31, 2026**. Until then, an adapter layer keeps the old endpoints working. Update your integration before that date.
 :::
 
 # REST API Migration (v0.96)
@@ -20,12 +20,14 @@ All legacy REST endpoints documented here continue to respond through an adapter
 
 v0.96.0 restructures the REST API. Two changes affect most users who integrate with Agenta for prompt management:
 
-1. **Invoking a deployed prompt** moves to a single unified endpoint: `POST /services/{service}/v0/invoke`. The legacy `/run`, `/generate`, `/generate_deployed`, and `/test` endpoints still respond through the adapter layer until May 31, 2026.
-2. **Fetching a prompt configuration** moves to `POST /applications/revisions/retrieve`. The legacy `POST /variants/configs/fetch` still responds through the adapter layer until May 31, 2026.
+1. **Invoking a deployed prompt** moves to a single unified endpoint: `POST /services/{service}/v0/invoke`, replacing `/run`, `/generate`, `/generate_deployed`, and `/test`.
+2. **Fetching a prompt configuration** moves to `POST /applications/revisions/retrieve`, replacing `POST /variants/configs/fetch`.
 
 The release also restructures the rest of the REST CRUD surface (apps, variants, environments, traces, annotations, invocations). If you call any of those directly, see the [complete list of affected endpoints](#all-affected-endpoints) at the end of this guide.
 
-If you only call Agenta through the Python SDK (`agenta.ConfigManager`, `agenta.VariantManager`, `agenta.DeploymentManager`), you don't need to migrate. The SDK absorbs every change in this release.
+:::info SDK users don't need to migrate
+If you only call Agenta through the Python SDK (`agenta.ConfigManager`, `agenta.VariantManager`, `agenta.DeploymentManager`), you don't need to change anything. The SDK absorbs every change in this release.
+:::
 
 ## Invoking a deployed prompt
 
@@ -131,7 +133,9 @@ The key field-by-field changes are:
 
 The output value moves from `data` (a direct string) to `data.outputs` (nested). The `tree_id` field becomes `trace_id`, and we now return a `span_id` alongside it. The `content_type` field is removed. A new `status` object reports the operation code, an optional human-readable message, and a stacktrace when the call fails.
 
-### Quick reference
+### Field reference
+
+The following table maps every old field, endpoint, and response key to its new equivalent.
 
 | Old | New |
 |-----|-----|
@@ -149,7 +153,10 @@ The output value moves from `data` (a direct string) to `data.outputs` (nested).
 | Response `"data": "text"` | Response `"data": {"outputs": "text"}` |
 | Response `"tree_id"` | Response `"trace_id"` |
 
-### Invoking a chat application
+<details>
+<summary>More examples: chat applications and draft configurations</summary>
+
+#### Invoking a chat application
 
 Chat applications follow the same pattern. Messages move under `data.inputs.messages`.
 
@@ -195,7 +202,7 @@ response = requests.post(
 )
 ```
 
-### Testing with a draft configuration
+#### Testing with a draft configuration
 
 If you previously sent an inline `ag_config` to test a draft, that block now lives under `data.parameters`.
 
@@ -248,11 +255,11 @@ response = requests.post(
 )
 ```
 
+</details>
+
 ## Fetching a prompt configuration
 
-The canonical endpoint for fetching a prompt configuration is now `POST /applications/revisions/retrieve`. The legacy `POST /variants/configs/fetch` keeps working through the adapter layer until May 31, 2026. After that date it returns errors, so existing integrations should migrate before then.
-
-The new endpoint mirrors the shape of the invocation endpoint. You pass structured references to identify the variant or environment you want to fetch, and the response carries the configuration parameters together with metadata about the revision.
+`POST /variants/configs/fetch` is deprecated and superseded by `POST /applications/revisions/retrieve`. The new endpoint mirrors the shape of the invocation endpoint: you pass structured references to identify the variant or environment you want to fetch, and the response carries the configuration parameters together with metadata about the revision.
 
 ### Fetching by variant and version
 
@@ -281,7 +288,9 @@ curl -X POST "https://cloud.agenta.ai/api/applications/revisions/retrieve" \
   }'
 ```
 
-Note that `version` is now a string. Passing an integer returns a 422 error.
+:::info
+The `version` field is now a string, not an integer.
+:::
 
 ### Fetching by environment
 
@@ -328,123 +337,130 @@ The SDK calls the new endpoint internally and returns the same shape it always h
 
 ## All affected endpoints
 
-Below is the complete list of REST endpoints removed in v0.96.0, grouped by domain. Each row links to the API reference for the replacement. Two patterns recur across the list:
-
-- `GET /resource` becomes `POST /resource/query` with filters in the request body.
-- `DELETE /resource/{id}` becomes `POST /resource/{id}/archive` (soft delete; `POST /resource/{id}/unarchive` restores).
+Below is the complete list of REST endpoints moved in v0.96.0, grouped by domain.
 
 ### Application invocation
 
-| Removed | Replacement |
-|---------|-------------|
-| `POST /services/{svc}/run` | [`POST /services/{svc}/v0/invoke`](#invoking-a-deployed-prompt) |
-| `POST /services/{svc}/generate_deployed` | [`POST /services/{svc}/v0/invoke`](#invoking-a-deployed-prompt) |
-| `POST /services/{svc}/generate` | [`POST /services/{svc}/v0/invoke`](#invoking-a-deployed-prompt) |
-| `POST /services/{svc}/test` | [`POST /services/{svc}/v0/invoke`](#invoking-a-deployed-prompt) |
-| `POST /workflows/invoke` | [`POST /services/{svc}/v0/invoke`](#invoking-a-deployed-prompt) |
-| `POST /workflows/inspect` | [`POST /applications/revisions/resolve`](/reference/api/resolve-application-revision) |
+| Operation | Old | New |
+|-----------|-----|-----|
+| Invoke deployed prompt | `POST /services/{svc}/run` | [`POST /services/{svc}/v0/invoke`](#invoking-a-deployed-prompt) |
+| Invoke deployed prompt (alias) | `POST /services/{svc}/generate_deployed` | [`POST /services/{svc}/v0/invoke`](#invoking-a-deployed-prompt) |
+| Test with draft config | `POST /services/{svc}/generate` | [`POST /services/{svc}/v0/invoke`](#invoking-a-deployed-prompt) |
+| Test with draft config (alias) | `POST /services/{svc}/test` | [`POST /services/{svc}/v0/invoke`](#invoking-a-deployed-prompt) |
+| Invoke a workflow | `POST /workflows/invoke` | [`POST /services/{svc}/v0/invoke`](#invoking-a-deployed-prompt) |
+| Inspect a workflow revision | `POST /workflows/inspect` | [`POST /applications/revisions/resolve`](/reference/api/resolve-application-revision) |
 
 ### Apps CRUD
 
-| Removed | Replacement |
-|---------|-------------|
-| `GET /apps` | [`POST /simple/applications/query`](/reference/api/query-simple-applications) |
-| `POST /apps` | [`POST /simple/applications/`](/reference/api/create-simple-application) |
-| `GET /apps/{id}` | [`GET /applications/{id}`](/reference/api/fetch-application) |
-| `PATCH /apps/{id}` | [`PUT /applications/{id}`](/reference/api/edit-application) |
-| `DELETE /apps/{id}` | [`POST /applications/{id}/archive`](/reference/api/archive-application) |
-| `GET /apps/{id}/variants` | [`POST /applications/variants/query`](/reference/api/query-application-variants) |
-| `GET /apps/{id}/environments` | [`POST /preview/environments/query`](/reference/api/query-environments) |
-| `GET /apps/{id}/revisions/{environment_name}` | [`POST /applications/revisions/retrieve`](#fetching-a-prompt-configuration) |
-| `GET /apps/get_variant_by_env` | [`POST /applications/revisions/retrieve`](#fetching-a-prompt-configuration) |
-| `POST /apps/{id}/variant/from-template` | [`GET /applications/catalog/templates/`](/reference/api/list-application-catalog-templates) then [`POST /applications/variants/`](/reference/api/create-application-variant) |
-| `POST /apps/{id}/variant/from-service` | [`POST /applications/variants/`](/reference/api/create-application-variant) |
+| Operation | Old | New |
+|-----------|-----|-----|
+| List apps | `GET /apps` | [`POST /simple/applications/query`](/reference/api/query-simple-applications) |
+| Create app | `POST /apps` | [`POST /simple/applications/`](/reference/api/create-simple-application) |
+| Fetch app | `GET /apps/{id}` | [`GET /applications/{id}`](/reference/api/fetch-application) |
+| Update app | `PATCH /apps/{id}` | [`PUT /applications/{id}`](/reference/api/edit-application) |
+| Delete app | `DELETE /apps/{id}` | [`POST /applications/{id}/archive`](/reference/api/archive-application) |
+| List variants of an app | `GET /apps/{id}/variants` | [`POST /applications/variants/query`](/reference/api/query-application-variants) |
+| List environments of an app | `GET /apps/{id}/environments` | [`POST /preview/environments/query`](/reference/api/query-environments) |
+| Get deployed revision for an environment | `GET /apps/{id}/revisions/{environment_name}` | [`POST /applications/revisions/retrieve`](#fetching-a-prompt-configuration) |
+| Get variant deployed to an environment | `GET /apps/get_variant_by_env` | [`POST /applications/revisions/retrieve`](#fetching-a-prompt-configuration) |
+| Create variant from template | `POST /apps/{id}/variant/from-template` | [`GET /applications/catalog/templates/`](/reference/api/list-application-catalog-templates) then [`POST /applications/variants/`](/reference/api/create-application-variant) |
+| Create variant from service URL | `POST /apps/{id}/variant/from-service` | [`POST /applications/variants/`](/reference/api/create-application-variant) |
 
 ### Variants CRUD
 
-| Removed | Replacement |
-|---------|-------------|
-| `GET /variants/{id}` | [`GET /applications/variants/{id}`](/reference/api/fetch-application-variant) |
-| `DELETE /variants/{id}` | [`POST /applications/variants/{id}/archive`](/reference/api/archive-application-variant) |
-| `GET /variants/{id}/revisions` | [`POST /applications/revisions/log`](/reference/api/log-application-revisions) |
-| `GET /variants/{id}/revisions/{revision_number}` | [`POST /applications/revisions/retrieve`](#fetching-a-prompt-configuration) |
-| `DELETE /variants/{id}/revisions/{revision_id}` | [`POST /applications/revisions/{id}/archive`](/reference/api/archive-application-revision) |
-| `PUT /variants/{id}/parameters` | [`POST /applications/revisions/commit`](/reference/api/commit-application-revision) |
-| `PUT /variants/{id}/service` | [`PUT /applications/variants/{id}`](/reference/api/edit-application-variant) |
-| `POST /variants/from-base` | [`POST /applications/variants/fork`](/reference/api/fork-application-variant) |
-| `POST /variants/revisions/query` | [`POST /applications/revisions/query`](/reference/api/query-application-revisions) |
+| Operation | Old | New |
+|-----------|-----|-----|
+| Fetch a variant | `GET /variants/{id}` | [`GET /applications/variants/{id}`](/reference/api/fetch-application-variant) |
+| Delete a variant | `DELETE /variants/{id}` | [`POST /applications/variants/{id}/archive`](/reference/api/archive-application-variant) |
+| List variant revisions | `GET /variants/{id}/revisions` | [`POST /applications/revisions/log`](/reference/api/log-application-revisions) |
+| Fetch a variant revision | `GET /variants/{id}/revisions/{revision_number}` | [`POST /applications/revisions/retrieve`](#fetching-a-prompt-configuration) |
+| Delete a variant revision | `DELETE /variants/{id}/revisions/{revision_id}` | [`POST /applications/revisions/{id}/archive`](/reference/api/archive-application-revision) |
+| Update variant parameters | `PUT /variants/{id}/parameters` | [`POST /applications/revisions/commit`](/reference/api/commit-application-revision) |
+| Update variant service URL | `PUT /variants/{id}/service` | [`PUT /applications/variants/{id}`](/reference/api/edit-application-variant) |
+| Fork a variant from a base | `POST /variants/from-base` | [`POST /applications/variants/fork`](/reference/api/fork-application-variant) |
+| Query variant revisions | `POST /variants/revisions/query` | [`POST /applications/revisions/query`](/reference/api/query-application-revisions) |
 
 ### Variant configurations
 
-The git-style operations on variant configurations (commit, fork, history) are now exposed under the `/applications/revisions/*` namespace. The fetch endpoint stays available through the adapter layer until May 31, 2026.
+The git-style operations on variant configurations (commit, fork, history) are now exposed under the `/applications/revisions/*` namespace.
 
-| Removed | Replacement |
-|---------|-------------|
-| `POST /variants/configs/fetch` (adapter shim until May 31, 2026) | [`POST /applications/revisions/retrieve`](#fetching-a-prompt-configuration) |
-| `POST /variants/configs/add` | [`POST /applications/variants/`](/reference/api/create-application-variant) |
-| `POST /variants/configs/commit` | [`POST /applications/revisions/commit`](/reference/api/commit-application-revision) |
-| `POST /variants/configs/delete` | [`POST /applications/variants/{id}/archive`](/reference/api/archive-application-variant) |
-| `POST /variants/configs/deploy` | [`POST /applications/revisions/deploy`](/reference/api/deploy-application-revision) |
-| `POST /variants/configs/fork` | [`POST /applications/variants/fork`](/reference/api/fork-application-variant) |
-| `POST /variants/configs/history` | [`POST /applications/revisions/log`](/reference/api/log-application-revisions) |
-| `POST /variants/configs/list` | [`POST /applications/variants/query`](/reference/api/query-application-variants) |
-| `POST /variants/configs/query` | [`POST /applications/variants/query`](/reference/api/query-application-variants) |
+| Operation | Old | New |
+|-----------|-----|-----|
+| Fetch a configuration | `POST /variants/configs/fetch` | [`POST /applications/revisions/retrieve`](#fetching-a-prompt-configuration) |
+| Create a variant with initial config | `POST /variants/configs/add` | [`POST /applications/variants/`](/reference/api/create-application-variant) |
+| Commit a new configuration revision | `POST /variants/configs/commit` | [`POST /applications/revisions/commit`](/reference/api/commit-application-revision) |
+| Delete a variant | `POST /variants/configs/delete` | [`POST /applications/variants/{id}/archive`](/reference/api/archive-application-variant) |
+| Deploy a configuration to an environment | `POST /variants/configs/deploy` | [`POST /applications/revisions/deploy`](/reference/api/deploy-application-revision) |
+| Fork a variant | `POST /variants/configs/fork` | [`POST /applications/variants/fork`](/reference/api/fork-application-variant) |
+| Get the revision history of a variant | `POST /variants/configs/history` | [`POST /applications/revisions/log`](/reference/api/log-application-revisions) |
+| List variants of an app | `POST /variants/configs/list` | [`POST /applications/variants/query`](/reference/api/query-application-variants) |
+| Query variants with filters | `POST /variants/configs/query` | [`POST /applications/variants/query`](/reference/api/query-application-variants) |
 
 ### Environments and deployments
 
-Deployment is now treated as an action on a revision, not on an environment. To deploy, you commit a revision and then call `applications/revisions/deploy` with both the revision and the target environment.
+:::info Deployment is now an action on a revision
+In v0.95 you deployed by calling `POST /environments/deploy` with a variant ID and an environment name. The environment was the actor; the deployment was a side-effect on the environment.
 
-| Removed | Replacement |
-|---------|-------------|
-| `POST /environments/deploy` | [`POST /applications/revisions/deploy`](/reference/api/deploy-application-revision) |
-| `GET /configs` | [`POST /applications/revisions/query`](/reference/api/query-application-revisions) |
-| `GET /configs/deployment/{revision_id}` | [`POST /preview/environments/revisions/retrieve`](/reference/api/retrieve-environment-revision) |
-| `POST /configs/deployment/{revision_id}/revert` | [`POST /preview/environments/revisions/commit`](/reference/api/commit-environment-revision) |
+In v0.96 you deploy by calling `POST /applications/revisions/deploy` with a revision reference and a target environment reference. The revision is the actor; the environment is just where you point it.
+
+The legacy `/configs/*` endpoints exposed environment-side configuration directly. They split into two new namespaces: `/applications/revisions/*` for the revision lookup itself, and `/preview/environments/revisions/*` for the environment's deployment history (when, who, and which revision was deployed at each point).
+:::
+
+| Operation | Old | New |
+|-----------|-----|-----|
+| Deploy to environment | `POST /environments/deploy` | [`POST /applications/revisions/deploy`](/reference/api/deploy-application-revision) |
+| List configurations | `GET /configs` | [`POST /applications/revisions/query`](/reference/api/query-application-revisions) |
+| Fetch a deployed configuration | `GET /configs/deployment/{revision_id}` | [`POST /preview/environments/revisions/retrieve`](/reference/api/retrieve-environment-revision) |
+| Revert a deployment | `POST /configs/deployment/{revision_id}/revert` | [`POST /preview/environments/revisions/commit`](/reference/api/commit-environment-revision) |
 
 ### Containers
 
-| Removed | Replacement |
-|---------|-------------|
-| `GET /containers/templates` | [`GET /applications/catalog/templates/`](/reference/api/list-application-catalog-templates) |
+| Operation | Old | New |
+|-----------|-----|-----|
+| List built-in templates | `GET /containers/templates` | [`GET /applications/catalog/templates/`](/reference/api/list-application-catalog-templates) |
 
 ### Annotations
 
-Both the legacy `/annotations/*` endpoints and the `/preview/annotations/*` preview endpoints were removed. Annotations now live alongside other observability records under the unified `/simple/traces/*` API.
+Annotations are observability records you attach to a trace or span to capture things like a human rating, an evaluator score, or a correction. They previously lived under `/annotations/*` and `/preview/annotations/*`. Both namespaces were removed. Annotations now share the unified `/simple/traces/*` API with other observability records.
 
-| Removed | Replacement |
-|---------|-------------|
-| `POST /annotations/` | [`POST /simple/traces/`](/reference/api/create-simple-trace) |
-| `POST /annotations/query` | [`POST /simple/traces/query`](/reference/api/query-simple-traces) |
-| `GET /annotations/{trace_id}` | [`GET /simple/traces/{trace_id}`](/reference/api/fetch-simple-trace) |
-| `GET /annotations/{trace_id}/{span_id}` | [`GET /simple/traces/{trace_id}`](/reference/api/fetch-simple-trace) |
-| `PATCH /annotations/{trace_id}` | [`PATCH /simple/traces/{trace_id}`](/reference/api/edit-simple-trace) |
-| `PATCH /annotations/{trace_id}/{span_id}` | [`PATCH /simple/traces/{trace_id}`](/reference/api/edit-simple-trace) |
-| `DELETE /annotations/{trace_id}` | [`DELETE /simple/traces/{trace_id}`](/reference/api/delete-simple-trace) |
-| `DELETE /annotations/{trace_id}/{span_id}` | [`DELETE /simple/traces/{trace_id}`](/reference/api/delete-simple-trace) |
-| `POST /preview/annotations/` | [`POST /simple/traces/`](/reference/api/create-simple-trace) |
-| `POST /preview/annotations/query` | [`POST /simple/traces/query`](/reference/api/query-simple-traces) |
-| `GET /preview/annotations/{trace_id}/{span_id}` | [`GET /simple/traces/{trace_id}`](/reference/api/fetch-simple-trace) |
-| `PATCH /preview/annotations/{trace_id}/{span_id}` | [`PATCH /simple/traces/{trace_id}`](/reference/api/edit-simple-trace) |
-| `DELETE /preview/annotations/{trace_id}/{span_id}` | [`DELETE /simple/traces/{trace_id}`](/reference/api/delete-simple-trace) |
+| Operation | Old | New |
+|-----------|-----|-----|
+| Create an annotation | `POST /annotations/` | [`POST /simple/traces/`](/reference/api/create-simple-trace) |
+| Query annotations | `POST /annotations/query` | [`POST /simple/traces/query`](/reference/api/query-simple-traces) |
+| Fetch an annotation by trace | `GET /annotations/{trace_id}` | [`GET /simple/traces/{trace_id}`](/reference/api/fetch-simple-trace) |
+| Fetch an annotation by trace and span | `GET /annotations/{trace_id}/{span_id}` | [`GET /simple/traces/{trace_id}`](/reference/api/fetch-simple-trace) |
+| Update an annotation by trace | `PATCH /annotations/{trace_id}` | [`PATCH /simple/traces/{trace_id}`](/reference/api/edit-simple-trace) |
+| Update an annotation by trace and span | `PATCH /annotations/{trace_id}/{span_id}` | [`PATCH /simple/traces/{trace_id}`](/reference/api/edit-simple-trace) |
+| Delete an annotation by trace | `DELETE /annotations/{trace_id}` | [`DELETE /simple/traces/{trace_id}`](/reference/api/delete-simple-trace) |
+| Delete an annotation by trace and span | `DELETE /annotations/{trace_id}/{span_id}` | [`DELETE /simple/traces/{trace_id}`](/reference/api/delete-simple-trace) |
+| Create an annotation (preview) | `POST /preview/annotations/` | [`POST /simple/traces/`](/reference/api/create-simple-trace) |
+| Query annotations (preview) | `POST /preview/annotations/query` | [`POST /simple/traces/query`](/reference/api/query-simple-traces) |
+| Fetch an annotation (preview) | `GET /preview/annotations/{trace_id}/{span_id}` | [`GET /simple/traces/{trace_id}`](/reference/api/fetch-simple-trace) |
+| Update an annotation (preview) | `PATCH /preview/annotations/{trace_id}/{span_id}` | [`PATCH /simple/traces/{trace_id}`](/reference/api/edit-simple-trace) |
+| Delete an annotation (preview) | `DELETE /preview/annotations/{trace_id}/{span_id}` | [`DELETE /simple/traces/{trace_id}`](/reference/api/delete-simple-trace) |
 
 ### Invocations
 
-The `/invocations/*` REST endpoints were removed and folded into `/simple/traces/*`. Invocations and annotations are now both first-class records under the same trace API, distinguished by their `kind` field.
+Invocations are observability records that capture a single LLM call: the input, the output, latency, cost, and the model used. They previously lived under `/invocations/*`. They now share the unified `/simple/traces/*` API with annotations, distinguished by the `kind` field on each record.
 
-| Removed | Replacement |
-|---------|-------------|
-| `POST /invocations/` | [`POST /simple/traces/`](/reference/api/create-simple-trace) |
-| `POST /invocations/query` | [`POST /simple/traces/query`](/reference/api/query-simple-traces) |
-| `GET /invocations/{trace_id}` | [`GET /simple/traces/{trace_id}`](/reference/api/fetch-simple-trace) |
-| `GET /invocations/{trace_id}/{span_id}` | [`GET /simple/traces/{trace_id}`](/reference/api/fetch-simple-trace) |
-| `PATCH /invocations/{trace_id}` | [`PATCH /simple/traces/{trace_id}`](/reference/api/edit-simple-trace) |
-| `PATCH /invocations/{trace_id}/{span_id}` | [`PATCH /simple/traces/{trace_id}`](/reference/api/edit-simple-trace) |
-| `DELETE /invocations/{trace_id}` | [`DELETE /simple/traces/{trace_id}`](/reference/api/delete-simple-trace) |
-| `DELETE /invocations/{trace_id}/{span_id}` | [`DELETE /simple/traces/{trace_id}`](/reference/api/delete-simple-trace) |
+| Operation | Old | New |
+|-----------|-----|-----|
+| Create an invocation | `POST /invocations/` | [`POST /simple/traces/`](/reference/api/create-simple-trace) |
+| Query invocations | `POST /invocations/query` | [`POST /simple/traces/query`](/reference/api/query-simple-traces) |
+| Fetch an invocation by trace | `GET /invocations/{trace_id}` | [`GET /simple/traces/{trace_id}`](/reference/api/fetch-simple-trace) |
+| Fetch an invocation by trace and span | `GET /invocations/{trace_id}/{span_id}` | [`GET /simple/traces/{trace_id}`](/reference/api/fetch-simple-trace) |
+| Update an invocation by trace | `PATCH /invocations/{trace_id}` | [`PATCH /simple/traces/{trace_id}`](/reference/api/edit-simple-trace) |
+| Update an invocation by trace and span | `PATCH /invocations/{trace_id}/{span_id}` | [`PATCH /simple/traces/{trace_id}`](/reference/api/edit-simple-trace) |
+| Delete an invocation by trace | `DELETE /invocations/{trace_id}` | [`DELETE /simple/traces/{trace_id}`](/reference/api/delete-simple-trace) |
+| Delete an invocation by trace and span | `DELETE /invocations/{trace_id}/{span_id}` | [`DELETE /simple/traces/{trace_id}`](/reference/api/delete-simple-trace) |
 
 ### Spans
 
-| Removed | Replacement |
-|---------|-------------|
-| `POST /preview/spans/` | [`POST /simple/traces/`](/reference/api/create-simple-trace) |
-| `POST /preview/spans/ingest` | OTLP ingestion endpoint (see [Observability docs](/observability/overview)) |
+| Operation | Old | New |
+|-----------|-----|-----|
+| Create a span | `POST /preview/spans/` | [`POST /simple/traces/`](/reference/api/create-simple-trace) |
+| Ingest spans in bulk | `POST /preview/spans/ingest` | OTLP ingestion endpoint (see [Observability docs](/observability/overview)) |
+
+## Need help?
+
+If you have questions about migrating, reach out on [Slack](https://join.slack.com/t/agenta-hq/shared_invite/zt-37pnbp5s6-mbBrPL863d_oLB61GSNFjw) or reply to the migration email. We are happy to help.

--- a/docs/blog/entries/unified-invoke-api.mdx
+++ b/docs/blog/entries/unified-invoke-api.mdx
@@ -3,20 +3,31 @@ title: "REST API Migration (v0.96)"
 slug: unified-invoke-api
 date: 2026-04-14
 tags: [v0.96.0]
-description: "Migration guide from the v0.95 REST API to v0.96. Covers the unified /v0/invoke endpoint and the removed /apps, /variants/configs, and /preview/annotations endpoints."
+description: "Migration guide from the v0.95 REST API to v0.96. Covers the unified /v0/invoke endpoint, the new prompt configuration fetch endpoint, and a complete list of removed REST endpoints with their replacements."
 ---
+
+:::warning Guide updated 2026-04-28
+The original version of this guide, published on 2026-04-14, covered only the new invocation endpoint. It did not mention the prompt configuration fetch endpoint, nor the broader REST API restructure. Customers calling endpoints like `GET /apps`, `POST /variants/configs/fetch`, or `/invocations/*` directly hit unexpected 404s and had no documented migration path. This update fills those gaps.
+:::
+
+:::danger Deprecation deadline: May 31, 2026
+All legacy REST endpoints documented here continue to respond through an adapter layer until **May 31, 2026**. After that date, calls to the old endpoints will return errors. Update your integration before then.
+:::
 
 # REST API Migration (v0.96)
 
 ## Overview
 
-In v0.96.0, we unified all application invocation endpoints into a single `POST /services/{service}/v0/invoke` endpoint. The four legacy endpoints (`/generate`, `/generate_deployed`, `/test`, `/run`) are replaced by one consistent interface with structured references and a cleaner response format.
+v0.96.0 restructures the REST API. Two changes affect most users who integrate with Agenta for prompt management:
 
-The old endpoints will continue to work temporarily via an adapter layer, but we strongly recommend migrating to the new format.
+1. **Invoking a deployed prompt** moves to a single unified endpoint: `POST /services/{service}/v0/invoke`. The legacy `/run`, `/generate`, `/generate_deployed`, and `/test` endpoints still respond through the adapter layer until May 31, 2026.
+2. **Fetching a prompt configuration** moves to `POST /applications/revisions/retrieve`. The legacy `POST /variants/configs/fetch` still responds through the adapter layer until May 31, 2026.
 
-## What Changed
+The release also restructures the rest of the REST CRUD surface (apps, variants, environments, traces, annotations, invocations). If you call any of those directly, see the [complete list of affected endpoints](#all-affected-endpoints) at the end of this guide.
 
-### Single Endpoint
+If you only call Agenta through the Python SDK (`agenta.ConfigManager`, `agenta.VariantManager`, `agenta.DeploymentManager`), you don't need to migrate. The SDK absorbs every change in this release.
+
+## Invoking a deployed prompt
 
 All invocations now go through one endpoint:
 
@@ -24,17 +35,19 @@ All invocations now go through one endpoint:
 POST /services/{service}/v0/invoke
 ```
 
-This replaces:
+This replaces four legacy endpoints:
+
 - `POST /services/{service}/generate` (draft testing)
 - `POST /services/{service}/test` (draft testing)
 - `POST /services/{service}/generate_deployed` (deployed config)
 - `POST /services/{service}/run` (deployed config)
 
-### New Request Format
+### New request format
 
-The most common use case is calling a prompt deployed to an environment using `generate_deployed`. Here is how that changes end-to-end:
+The most common case is calling a prompt deployed to an environment with `generate_deployed`. Here is how that changes end-to-end.
 
-**Before** — `POST /services/completion/generate_deployed`
+**Before** (`POST /services/completion/generate_deployed`):
+
 ```python
 response = requests.post(
     "https://cloud.agenta.ai/services/completion/generate_deployed",
@@ -50,11 +63,12 @@ response = requests.post(
 )
 
 result = response.json()
-print(result["data"])       # "The capital of France is Paris."
-print(result["tree_id"])    # trace ID for observability
+print(result["data"])     # "The capital of France is Paris."
+print(result["tree_id"])  # trace ID for observability
 ```
 
-**After** — `POST /services/completion/v0/invoke`
+**After** (`POST /services/completion/v0/invoke`):
+
 ```python
 response = requests.post(
     "https://cloud.agenta.ai/services/completion/v0/invoke",
@@ -78,18 +92,20 @@ print(result["data"]["outputs"])  # "The capital of France is Paris."
 print(result["trace_id"])         # trace ID for observability
 ```
 
-The request body is now structured into two sections: `data` (your inputs and optional parameters) and `references` (which application/variant/revision/environment to target).
+The new request body has two top-level sections. `data` carries your inputs and optional configuration parameters. `references` identifies which application, variant, revision, or environment to target.
 
-Key changes:
-- `inputs` moves to `data.inputs`
-- `messages` merges into `data.inputs.messages`
-- `ag_config` becomes `data.parameters`
-- Flat params (`app`, `variant_slug`, `environment`, etc.) become structured `references`
-- `?application_id=` query parameter removed — use `references.application.id` instead
+The key field-by-field changes are:
 
-### New Response Format
+- `inputs` moves under `data.inputs`.
+- `messages` moves under `data.inputs.messages` (for chat applications).
+- `ag_config` becomes `data.parameters`.
+- The flat targeting fields (`app`, `variant_slug`, `variant_version`, `environment`) become structured entries under `references`.
+- The `?application_id=` query parameter is removed. Pass the ID in `references.application.id` instead.
+
+### New response format
 
 **Before:**
+
 ```json
 {
   "version": "3.0",
@@ -100,6 +116,7 @@ Key changes:
 ```
 
 **After:**
+
 ```json
 {
   "version": "2025-07-14",
@@ -112,16 +129,9 @@ Key changes:
 }
 ```
 
-Key changes:
-- `version` changed from `"3.0"` to `"2025-07-14"` (date-based versioning)
-- `data` (direct value) becomes `data.outputs` (nested)
-- `content_type` removed
-- `tree_id` replaced by `trace_id` and `span_id`
-- New `status` object for error reporting
+The output value moves from `data` (a direct string) to `data.outputs` (nested). The `tree_id` field becomes `trace_id`, and we now return a `span_id` alongside it. The `content_type` field is removed. A new `status` object reports the operation code, an optional human-readable message, and a stacktrace when the call fails.
 
-## Migration Guide
-
-### Quick Reference Table
+### Quick reference
 
 | Old | New |
 |-----|-----|
@@ -139,55 +149,12 @@ Key changes:
 | Response `"data": "text"` | Response `"data": {"outputs": "text"}` |
 | Response `"tree_id"` | Response `"trace_id"` |
 
-### Example: Invoking a Deployed Prompt (Completion)
+### Invoking a chat application
+
+Chat applications follow the same pattern. Messages move under `data.inputs.messages`.
 
 **Before:**
-```python
-import requests
 
-response = requests.post(
-    "https://cloud.agenta.ai/services/completion/run",
-    headers={
-        "Content-Type": "application/json",
-        "Authorization": f"ApiKey {api_key}",
-    },
-    json={
-        "environment": "production",
-        "app": "my-app",
-        "inputs": {"country": "France"},
-    },
-)
-data = response.json()
-print(data["data"])  # "The capital of France is Paris."
-```
-
-**After:**
-```python
-import requests
-
-response = requests.post(
-    "https://cloud.agenta.ai/services/completion/v0/invoke",
-    headers={
-        "Content-Type": "application/json",
-        "Authorization": f"ApiKey {api_key}",
-    },
-    json={
-        "data": {
-            "inputs": {"country": "France"},
-        },
-        "references": {
-            "application": {"slug": "my-app"},
-            "environment": {"slug": "production"},
-        },
-    },
-)
-data = response.json()
-print(data["data"]["outputs"])  # "The capital of France is Paris."
-```
-
-### Example: Invoking a Chat Application
-
-**Before:**
 ```python
 response = requests.post(
     "https://cloud.agenta.ai/services/chat/run",
@@ -205,6 +172,7 @@ response = requests.post(
 ```
 
 **After:**
+
 ```python
 response = requests.post(
     "https://cloud.agenta.ai/services/chat/v0/invoke",
@@ -227,9 +195,12 @@ response = requests.post(
 )
 ```
 
-### Example: Testing with Draft Configuration
+### Testing with a draft configuration
+
+If you previously sent an inline `ag_config` to test a draft, that block now lives under `data.parameters`.
 
 **Before:**
+
 ```python
 response = requests.post(
     "https://cloud.agenta.ai/services/completion/generate?application_id=xxx",
@@ -251,6 +222,7 @@ response = requests.post(
 ```
 
 **After:**
+
 ```python
 response = requests.post(
     "https://cloud.agenta.ai/services/completion/v0/invoke",
@@ -276,128 +248,203 @@ response = requests.post(
 )
 ```
 
-## SDK Unchanged
+## Fetching a prompt configuration
 
-The Python SDK (`ag.ConfigManager.get_from_registry()`) continues to work with the same interface. The SDK handles the new API format internally. No changes needed in your SDK code.
+The canonical endpoint for fetching a prompt configuration is now `POST /applications/revisions/retrieve`. The legacy `POST /variants/configs/fetch` keeps working through the adapter layer until May 31, 2026. After that date it returns errors, so existing integrations should migrate before then.
+
+The new endpoint mirrors the shape of the invocation endpoint. You pass structured references to identify the variant or environment you want to fetch, and the response carries the configuration parameters together with metadata about the revision.
+
+### Fetching by variant and version
+
+**Before:**
+
+```bash
+curl -X POST "https://cloud.agenta.ai/api/variants/configs/fetch" \
+  -H "Content-Type: application/json" \
+  -H "Authorization: ApiKey $AGENTA_API_KEY" \
+  -d '{
+    "variant_ref": {"slug": "default", "version": 1},
+    "application_ref": {"slug": "my-app"}
+  }'
+```
+
+**After:**
+
+```bash
+curl -X POST "https://cloud.agenta.ai/api/applications/revisions/retrieve" \
+  -H "Content-Type: application/json" \
+  -H "Authorization: ApiKey $AGENTA_API_KEY" \
+  -d '{
+    "application_ref": {"slug": "my-app"},
+    "application_variant_ref": {"slug": "default"},
+    "application_revision_ref": {"version": "1"}
+  }'
+```
+
+Note that `version` is now a string. Passing an integer returns a 422 error.
+
+### Fetching by environment
+
+To fetch the configuration deployed to an environment, pass the `application_ref` and the `environment_ref` together:
+
+**Before:**
+
+```bash
+curl -X POST "https://cloud.agenta.ai/api/variants/configs/fetch" \
+  -H "Content-Type: application/json" \
+  -H "Authorization: ApiKey $AGENTA_API_KEY" \
+  -d '{
+    "environment_ref": {"slug": "production"},
+    "application_ref": {"slug": "my-app"}
+  }'
+```
+
+**After:**
+
+```bash
+curl -X POST "https://cloud.agenta.ai/api/applications/revisions/retrieve" \
+  -H "Content-Type: application/json" \
+  -H "Authorization: ApiKey $AGENTA_API_KEY" \
+  -d '{
+    "application_ref": {"slug": "my-app"},
+    "environment_ref": {"slug": "production"}
+  }'
+```
+
+The response is the same shape as a variant fetch. It includes the resolved revision metadata so you can tell which version is currently deployed.
+
+### Python SDK unchanged
+
+If you fetch configurations through the SDK, you don't need to change anything:
 
 ```python
-# This still works exactly the same
-config = ag.ConfigManager.get_from_registry(
-    app_slug="my-app",
-    variant_slug="default",
-    variant_version=1,
-)
-
 config = ag.ConfigManager.get_from_registry(
     app_slug="my-app",
     environment_slug="production",
 )
 ```
 
-## Other API Changes
+The SDK calls the new endpoint internally and returns the same shape it always has.
 
-The following REST endpoints were deprecated in v0.96.0. If you call them directly, migrate to the replacements below.
+## All affected endpoints
+
+Below is the complete list of REST endpoints removed in v0.96.0, grouped by domain. Each row links to the API reference for the replacement. Two patterns recur across the list:
+
+- `GET /resource` becomes `POST /resource/query` with filters in the request body.
+- `DELETE /resource/{id}` becomes `POST /resource/{id}/archive` (soft delete; `POST /resource/{id}/unarchive` restores).
+
+### Application invocation
 
 | Removed | Replacement |
 |---------|-------------|
-| `GET /apps` | `POST /simple/applications/query` |
-| `GET /apps/{id}` | `GET /applications/{id}` |
-| `POST /apps` | `POST /simple/applications/` |
-| `PATCH /apps/{id}` | `PUT /applications/{id}` |
-| `DELETE /apps/{id}` | `POST /applications/{id}/archive` |
-| `GET /apps/{id}/variants` | `POST /applications/variants/query` |
-| `GET /apps/{id}/environments` | `POST /preview/environments/query` |
-| `POST /environments/deploy` | `POST /applications/revisions/deploy` |
-| `POST /variants/configs/add` | `POST /applications/revisions/commit` |
-| `POST /variants/configs/commit` | `POST /applications/revisions/commit` |
-| `POST /variants/configs/delete` | `POST /applications/variants/{variant_id}/archive` |
-| `POST /variants/configs/deploy` | `POST /applications/revisions/deploy` |
-| `POST /variants/configs/history` | `POST /applications/revisions/log` |
-| `POST /variants/configs/list` | `POST /applications/variants/query` |
-| `POST /preview/annotations/` | `POST /simple/traces/` |
-| `POST /preview/annotations/query` | `POST /simple/traces/query` |
-| `GET /preview/annotations/{trace_id}/{span_id}` | `GET /simple/traces/{trace_id}` |
-| `PATCH /preview/annotations/{trace_id}/{span_id}` | `PATCH /simple/traces/{trace_id}` |
-| `DELETE /preview/annotations/{trace_id}/{span_id}` | `DELETE /simple/traces/{trace_id}` |
+| `POST /services/{svc}/run` | [`POST /services/{svc}/v0/invoke`](#invoking-a-deployed-prompt) |
+| `POST /services/{svc}/generate_deployed` | [`POST /services/{svc}/v0/invoke`](#invoking-a-deployed-prompt) |
+| `POST /services/{svc}/generate` | [`POST /services/{svc}/v0/invoke`](#invoking-a-deployed-prompt) |
+| `POST /services/{svc}/test` | [`POST /services/{svc}/v0/invoke`](#invoking-a-deployed-prompt) |
+| `POST /workflows/invoke` | [`POST /services/{svc}/v0/invoke`](#invoking-a-deployed-prompt) |
+| `POST /workflows/inspect` | [`POST /applications/revisions/resolve`](/reference/api/resolve-application-revision) |
 
-Below some examples for how to use the new endpoints with more details in the reference and the rest of the documentation.
+### Apps CRUD
 
-### Fetch your applications
+| Removed | Replacement |
+|---------|-------------|
+| `GET /apps` | [`POST /simple/applications/query`](/reference/api/query-simple-applications) |
+| `POST /apps` | [`POST /simple/applications/`](/reference/api/create-simple-application) |
+| `GET /apps/{id}` | [`GET /applications/{id}`](/reference/api/fetch-application) |
+| `PATCH /apps/{id}` | [`PUT /applications/{id}`](/reference/api/edit-application) |
+| `DELETE /apps/{id}` | [`POST /applications/{id}/archive`](/reference/api/archive-application) |
+| `GET /apps/{id}/variants` | [`POST /applications/variants/query`](/reference/api/query-application-variants) |
+| `GET /apps/{id}/environments` | [`POST /preview/environments/query`](/reference/api/query-environments) |
+| `GET /apps/{id}/revisions/{environment_name}` | [`POST /applications/revisions/retrieve`](#fetching-a-prompt-configuration) |
+| `GET /apps/get_variant_by_env` | [`POST /applications/revisions/retrieve`](#fetching-a-prompt-configuration) |
+| `POST /apps/{id}/variant/from-template` | [`GET /applications/catalog/templates/`](/reference/api/list-application-catalog-templates) then [`POST /applications/variants/`](/reference/api/create-application-variant) |
+| `POST /apps/{id}/variant/from-service` | [`POST /applications/variants/`](/reference/api/create-application-variant) |
 
-```bash
-curl -X POST "https://cloud.agenta.ai/api/simple/applications/query" \
-  -H "Content-Type: application/json" \
-  -H "Authorization: ApiKey $AGENTA_API_KEY" \
-  -d '{"windowing": {"limit": 50}}'
-```
+### Variants CRUD
 
-Response:
+| Removed | Replacement |
+|---------|-------------|
+| `GET /variants/{id}` | [`GET /applications/variants/{id}`](/reference/api/fetch-application-variant) |
+| `DELETE /variants/{id}` | [`POST /applications/variants/{id}/archive`](/reference/api/archive-application-variant) |
+| `GET /variants/{id}/revisions` | [`POST /applications/revisions/log`](/reference/api/log-application-revisions) |
+| `GET /variants/{id}/revisions/{revision_number}` | [`POST /applications/revisions/retrieve`](#fetching-a-prompt-configuration) |
+| `DELETE /variants/{id}/revisions/{revision_id}` | [`POST /applications/revisions/{id}/archive`](/reference/api/archive-application-revision) |
+| `PUT /variants/{id}/parameters` | [`POST /applications/revisions/commit`](/reference/api/commit-application-revision) |
+| `PUT /variants/{id}/service` | [`PUT /applications/variants/{id}`](/reference/api/edit-application-variant) |
+| `POST /variants/from-base` | [`POST /applications/variants/fork`](/reference/api/fork-application-variant) |
+| `POST /variants/revisions/query` | [`POST /applications/revisions/query`](/reference/api/query-application-revisions) |
 
-```json
-{
-  "count": 1,
-  "applications": [
-    {
-      "id": "019d952f-5945-71b1-b8cb-d6d8e675c18d",
-      "slug": "chat1",
-      "name": "chat1",
-      "variant_id": "019d952f-5a10-70a3-9f85-81e8ff07ab94",
-      "revision_id": "019d952f-5b6c-7300-a5a0-379ee234263d",
-      "flags": {
-        "is_application": true,
-        "is_chat": true,
-        "is_managed": true,
-        "has_url": true
-      },
-      "data": {
-        "uri": "agenta:builtin:chat:v0",
-        "url": "https://cloud.agenta.ai/services/chat/v0",
-        "schemas": { "parameters": {}, "inputs": {}, "outputs": {} }
-      },
-      "created_at": "2026-04-16T07:26:41.475248Z"
-    }
-  ]
-}
-```
+### Variant configurations
 
-### Add an annotation
+The git-style operations on variant configurations (commit, fork, history) are now exposed under the `/applications/revisions/*` namespace. The fetch endpoint stays available through the adapter layer until May 31, 2026.
 
-```bash
-curl -X POST "https://cloud.agenta.ai/api/simple/traces/" \
-  -H "Content-Type: application/json" \
-  -H "Authorization: ApiKey $AGENTA_API_KEY" \
-  -d '{
-    "trace": {
-      "data": {"outputs": {"score": 5, "comment": "Good response"}},
-      "references": {"evaluator": {"slug": "user-feedback"}},
-      "links": {"invocation": {"trace_id": "0af7651916cd43dd8448eb211c80319c", "span_id": "b7ad6b7169203331"}}
-    }
-  }'
-```
+| Removed | Replacement |
+|---------|-------------|
+| `POST /variants/configs/fetch` (adapter shim until May 31, 2026) | [`POST /applications/revisions/retrieve`](#fetching-a-prompt-configuration) |
+| `POST /variants/configs/add` | [`POST /applications/variants/`](/reference/api/create-application-variant) |
+| `POST /variants/configs/commit` | [`POST /applications/revisions/commit`](/reference/api/commit-application-revision) |
+| `POST /variants/configs/delete` | [`POST /applications/variants/{id}/archive`](/reference/api/archive-application-variant) |
+| `POST /variants/configs/deploy` | [`POST /applications/revisions/deploy`](/reference/api/deploy-application-revision) |
+| `POST /variants/configs/fork` | [`POST /applications/variants/fork`](/reference/api/fork-application-variant) |
+| `POST /variants/configs/history` | [`POST /applications/revisions/log`](/reference/api/log-application-revisions) |
+| `POST /variants/configs/list` | [`POST /applications/variants/query`](/reference/api/query-application-variants) |
+| `POST /variants/configs/query` | [`POST /applications/variants/query`](/reference/api/query-application-variants) |
 
-Response:
+### Environments and deployments
 
-```json
-{
-  "count": 1,
-  "trace": {
-    "trace_id": "bdda8fb878cb49088c8191bc2850a058",
-    "span_id": "acacdf9134bcb7ea",
-    "origin": "custom",
-    "kind": "adhoc",
-    "channel": "api",
-    "data": {"outputs": {"score": 5, "comment": "Good response"}},
-    "references": {"evaluator": {"slug": "user-feedback"}},
-    "links": {
-      "invocation": {
-        "trace_id": "0af7651916cd43dd8448eb211c80319c",
-        "span_id": "b7ad6b7169203331"
-      }
-    }
-  }
-}
-```
+Deployment is now treated as an action on a revision, not on an environment. To deploy, you commit a revision and then call `applications/revisions/deploy` with both the revision and the target environment.
 
-The annotation gets its own `trace_id` and `span_id`. Use those IDs to fetch, update, or delete the annotation later.
+| Removed | Replacement |
+|---------|-------------|
+| `POST /environments/deploy` | [`POST /applications/revisions/deploy`](/reference/api/deploy-application-revision) |
+| `GET /configs` | [`POST /applications/revisions/query`](/reference/api/query-application-revisions) |
+| `GET /configs/deployment/{revision_id}` | [`POST /preview/environments/revisions/retrieve`](/reference/api/retrieve-environment-revision) |
+| `POST /configs/deployment/{revision_id}/revert` | [`POST /preview/environments/revisions/commit`](/reference/api/commit-environment-revision) |
 
-For request body conventions, pagination, and the full endpoint list, see the [REST API Guide](/reference/api-guide/overview).
+### Containers
+
+| Removed | Replacement |
+|---------|-------------|
+| `GET /containers/templates` | [`GET /applications/catalog/templates/`](/reference/api/list-application-catalog-templates) |
+
+### Annotations
+
+Both the legacy `/annotations/*` endpoints and the `/preview/annotations/*` preview endpoints were removed. Annotations now live alongside other observability records under the unified `/simple/traces/*` API.
+
+| Removed | Replacement |
+|---------|-------------|
+| `POST /annotations/` | [`POST /simple/traces/`](/reference/api/create-simple-trace) |
+| `POST /annotations/query` | [`POST /simple/traces/query`](/reference/api/query-simple-traces) |
+| `GET /annotations/{trace_id}` | [`GET /simple/traces/{trace_id}`](/reference/api/fetch-simple-trace) |
+| `GET /annotations/{trace_id}/{span_id}` | [`GET /simple/traces/{trace_id}`](/reference/api/fetch-simple-trace) |
+| `PATCH /annotations/{trace_id}` | [`PATCH /simple/traces/{trace_id}`](/reference/api/edit-simple-trace) |
+| `PATCH /annotations/{trace_id}/{span_id}` | [`PATCH /simple/traces/{trace_id}`](/reference/api/edit-simple-trace) |
+| `DELETE /annotations/{trace_id}` | [`DELETE /simple/traces/{trace_id}`](/reference/api/delete-simple-trace) |
+| `DELETE /annotations/{trace_id}/{span_id}` | [`DELETE /simple/traces/{trace_id}`](/reference/api/delete-simple-trace) |
+| `POST /preview/annotations/` | [`POST /simple/traces/`](/reference/api/create-simple-trace) |
+| `POST /preview/annotations/query` | [`POST /simple/traces/query`](/reference/api/query-simple-traces) |
+| `GET /preview/annotations/{trace_id}/{span_id}` | [`GET /simple/traces/{trace_id}`](/reference/api/fetch-simple-trace) |
+| `PATCH /preview/annotations/{trace_id}/{span_id}` | [`PATCH /simple/traces/{trace_id}`](/reference/api/edit-simple-trace) |
+| `DELETE /preview/annotations/{trace_id}/{span_id}` | [`DELETE /simple/traces/{trace_id}`](/reference/api/delete-simple-trace) |
+
+### Invocations
+
+The `/invocations/*` REST endpoints were removed and folded into `/simple/traces/*`. Invocations and annotations are now both first-class records under the same trace API, distinguished by their `kind` field.
+
+| Removed | Replacement |
+|---------|-------------|
+| `POST /invocations/` | [`POST /simple/traces/`](/reference/api/create-simple-trace) |
+| `POST /invocations/query` | [`POST /simple/traces/query`](/reference/api/query-simple-traces) |
+| `GET /invocations/{trace_id}` | [`GET /simple/traces/{trace_id}`](/reference/api/fetch-simple-trace) |
+| `GET /invocations/{trace_id}/{span_id}` | [`GET /simple/traces/{trace_id}`](/reference/api/fetch-simple-trace) |
+| `PATCH /invocations/{trace_id}` | [`PATCH /simple/traces/{trace_id}`](/reference/api/edit-simple-trace) |
+| `PATCH /invocations/{trace_id}/{span_id}` | [`PATCH /simple/traces/{trace_id}`](/reference/api/edit-simple-trace) |
+| `DELETE /invocations/{trace_id}` | [`DELETE /simple/traces/{trace_id}`](/reference/api/delete-simple-trace) |
+| `DELETE /invocations/{trace_id}/{span_id}` | [`DELETE /simple/traces/{trace_id}`](/reference/api/delete-simple-trace) |
+
+### Spans
+
+| Removed | Replacement |
+|---------|-------------|
+| `POST /preview/spans/` | [`POST /simple/traces/`](/reference/api/create-simple-trace) |
+| `POST /preview/spans/ingest` | OTLP ingestion endpoint (see [Observability docs](/observability/overview)) |

--- a/docs/blog/entries/unified-invoke-api.mdx
+++ b/docs/blog/entries/unified-invoke-api.mdx
@@ -320,7 +320,73 @@ curl -X POST "https://cloud.agenta.ai/api/applications/revisions/retrieve" \
   }'
 ```
 
-The response is the same shape as a variant fetch. It includes the resolved revision metadata so you can tell which version is currently deployed.
+### Response shape
+
+The response shape changed too. The legacy endpoint returned a flat envelope with the configuration under `params` and reference IDs as siblings. The new endpoint wraps the revision in a query envelope, with the configuration nested under `application_revision.data.parameters`.
+
+**Before:**
+
+```json
+{
+  "params": {
+    "prompt": {"...": "..."}
+  },
+  "url": "https://cloud.agenta.ai/services/completion/v0",
+  "application_ref": {
+    "slug": "my-app",
+    "id": "019ce1cd-ccec-76f1-a803-eb1dc9187d57"
+  },
+  "variant_ref": {
+    "slug": "default",
+    "version": 1,
+    "id": "019ce1cd-cd98-7270-b51b-550c58e51e41"
+  },
+  "environment_ref": {
+    "slug": "production",
+    "version": 1,
+    "id": "..."
+  }
+}
+```
+
+**After:**
+
+```json
+{
+  "count": 1,
+  "application_revision": {
+    "id": "019ce1d0-7920-76a0-84b3-bb5a29750634",
+    "slug": "default",
+    "name": "default",
+    "version": "1",
+    "application_id": "019ce1cd-ccec-76f1-a803-eb1dc9187d57",
+    "application_variant_id": "019ce1cd-cd98-7270-b51b-550c58e51e41",
+    "data": {
+      "parameters": {
+        "prompt": {"...": "..."}
+      },
+      "url": "https://cloud.agenta.ai/services/completion/v0",
+      "uri": "agenta:builtin:completion:v0",
+      "schemas": {"...": "..."}
+    },
+    "flags": {"is_application": true, "is_chat": false, "...": "..."},
+    "created_at": "2026-03-12T11:31:02.045131Z"
+  }
+}
+```
+
+If you read fields from the response, here is where each one moved.
+
+| Old | New |
+|-----|-----|
+| `response["params"]` | `response["application_revision"]["data"]["parameters"]` |
+| `response["params"]["prompt"]` | `response["application_revision"]["data"]["parameters"]["prompt"]` |
+| `response["url"]` | `response["application_revision"]["data"]["url"]` |
+| `response["application_ref"]["id"]` | `response["application_revision"]["application_id"]` |
+| `response["variant_ref"]["id"]` | `response["application_revision"]["application_variant_id"]` |
+| `response["variant_ref"]["version"]` | `response["application_revision"]["version"]` |
+
+The new response also exposes the input/output `schemas` under `data.schemas` and a richer set of `flags` (including `is_chat`, `has_url`, etc.), which were not available in the legacy response.
 
 ### Python SDK unchanged
 


### PR DESCRIPTION
## Summary

The original v0.96 migration guide (`docs/blog/entries/unified-invoke-api.mdx`) only covered the unified invoke endpoint. Customers calling `GET /apps`, `POST /variants/configs/fetch`, `/invocations/*`, etc. directly hit unexpected 404s with no documented migration path.

This expands the guide to cover everything that changed in v0.96.

## What's added

- **Prominent May 31, 2026 deprecation deadline callout** matching the customer email
- **Dedicated "Fetching a prompt configuration" section** covering `/variants/configs/fetch` → `/applications/revisions/retrieve`, with before/after examples for variant fetches and environment fetches
- **Complete reference of all 53 REST endpoints removed in v0.96.0**, grouped by domain:
  - Application invocation
  - Apps CRUD
  - Variants CRUD
  - Variant configurations
  - Environments and deployments
  - Containers
  - Annotations (root + preview, both folded into `/simple/traces`)
  - Invocations (also folded into `/simple/traces`)
  - Spans
- Each removed endpoint is mapped to its replacement, with links to the API reference

## Validation

All endpoint paths in the guide were validated against `docs/docs/reference/openapi.json`:

- The `/applications/revisions/*` paths use the correct (non-`/preview/`) prefix that matches the spec
- The fetch-by-environment example does not include the optional `key` field (matches the frontend curl snippet at `web/oss/src/code_snippets/endpoints/fetch_config/curl.ts` and the SDK behavior)
- All replacement paths verified against live production at `eu.cloud.agenta.ai`

## Open for review

Opening as draft so you can leave comments on the prose, structure, and any endpoints I may have categorized or linked incorrectly.

## Test plan
- [x] Render the changelog locally (`cd docs && pnpm start`) and confirm both callouts display correctly
- [x] Click through the API reference links to verify each one resolves
- [x] Review the prose in each new section against the technical writing guidelines