### PR TITLE
[fix] Add exponential backoff to retry in prompts

### DIFF
--- a/api/oss/tests/pytest/unit/evaluators/test_catalog_types.py
+++ b/api/oss/tests/pytest/unit/evaluators/test_catalog_types.py
@@ -51,7 +51,7 @@ def test_catalog_types_include_message_messages_model_and_prompt_template():
     ]
     assert set(retry_object_schema["properties"]) == {
         "max_retries",
-        "delay_ms",
+        "base_delay",
     }
     assert retry_policy_schema["enum"] == [
         "off",

--- a/docs/docs/prompt-engineering/integrating-prompts/07-fallback-models-and-retry.mdx
+++ b/docs/docs/prompt-engineering/integrating-prompts/07-fallback-models-and-retry.mdx
@@ -51,7 +51,7 @@ Example fetched configuration:
     ],
     "retry_config": {
       "max_retries": 1,
-      "delay_ms": 500
+      "base_delay": 500
     },
     "retry_policy": "capacity",
     "fallback_policy": "capacity",
@@ -62,4 +62,4 @@ Example fetched configuration:
 
 Use these fields if you want your application to match the behavior tested in the playground.
 
-If a prompt has no fallback models, `fallback_configs` can be empty, `null`, or missing. If no fallback policy is set, fallback behavior is off. Retry is off unless `retry_policy` is explicitly set, and `retry_config` controls the retry count and delay.
+If a prompt has no fallback models, `fallback_configs` can be empty, `null`, or missing. If no fallback policy is set, fallback behavior is off. Retry is off unless `retry_policy` is explicitly set, and `retry_config` controls the retry count and base delay. The delay between retries doubles on each attempt (exponential backoff): the first retry waits `base_delay` ms, the second waits `base_delay * 2` ms, and so on.

--- a/docs/docs/reference/sdk/01-configuration-management.mdx
+++ b/docs/docs/reference/sdk/01-configuration-management.mdx
@@ -303,8 +303,8 @@ All configuration data must be nested under the `prompt` key.
 | prompt.fallback_configs | array or null | Ordered backup model configurations |
 | prompt.fallback_configs[].model | string | Required model identifier for each fallback model |
 | prompt.retry_config | object or null | Retry settings applied to each attempted model |
-| prompt.retry_config.max_retries | integer | Number of extra attempts after the first failed attempt |
-| prompt.retry_config.delay_ms | integer | Wait time between retry attempts, in milliseconds |
+| prompt.retry_config.max_retries | integer (0–5) | Number of extra attempts after the first failed attempt |
+| prompt.retry_config.base_delay | integer (100–1000) | Base delay in milliseconds before the first retry; doubles on each subsequent attempt |
 | prompt.retry_policy | string or null | Error policy for retrying the same model. Options: `off`, `availability`, `capacity`, `transient`, or `any` |
 | prompt.fallback_policy | string or null | Error policy for moving to a fallback model. Options: `off`, `availability`, `capacity`, `access`, `context`, or `any` |
 
@@ -339,7 +339,7 @@ All configuration data must be nested under the `prompt` key.
     ],
     "retry_config": {
       "max_retries": 1,
-      "delay_ms": 500
+      "base_delay": 500
     },
     "retry_policy": "capacity",
     "fallback_policy": "capacity",

--- a/docs/docs/reference/sdk/03-custom-workflow.mdx
+++ b/docs/docs/reference/sdk/03-custom-workflow.mdx
@@ -74,7 +74,7 @@ PromptTemplate(
     input_keys=["var1", "var2"],
     llm_config=ModelConfig(...),
     fallback_configs=[ModelConfig(model="...")],
-    retry_config=RetryConfig(max_retries=1, delay_ms=500),
+    retry_config=RetryConfig(max_retries=1, base_delay=500),
     retry_policy=RetryPolicy.CAPACITY,
     fallback_policy=FallbackPolicy.CAPACITY,
 )
@@ -87,7 +87,7 @@ PromptTemplate(
 - `input_keys` (List[str]): Variables expected in the template
 - `llm_config` (ModelConfig): Model and parameter settings
 - `fallback_configs` (List[ModelConfig]): Optional ordered backup model settings
-- `retry_config` (RetryConfig): Optional retry count and delay settings for each attempted model
+- `retry_config` (RetryConfig): Optional retry count and base delay (ms) settings for each attempted model; delay doubles on each subsequent attempt
 - `retry_policy` (RetryPolicy): Optional policy for which errors can retry the same model
 - `fallback_policy` (FallbackPolicy): Optional policy for when Agenta can move to a fallback model
 

--- a/sdk/agenta/sdk/engines/running/handlers.py
+++ b/sdk/agenta/sdk/engines/running/handlers.py
@@ -1924,8 +1924,18 @@ def _apply_responses_bridge_if_needed(
     return provider_settings
 
 
-def _coerce_retry_config(retry_config: Optional[RetryConfig]) -> RetryConfig:
-    return retry_config or RetryConfig()
+def _coerce_retry_config(
+    retry_config: Optional[RetryConfig],
+    retry_policy: Optional[RetryPolicy] = None,
+) -> RetryConfig:
+    policy = _coerce_retry_policy(retry_policy)
+    config = retry_config or RetryConfig()
+    if policy != RetryPolicy.OFF:
+        return RetryConfig(
+            max_retries=config.max_retries if config.max_retries is not None else 1,
+            base_delay=config.base_delay if config.base_delay is not None else 1000,
+        )
+    return config
 
 
 def _coerce_retry_policy(retry_policy: Optional[RetryPolicy]) -> RetryPolicy:
@@ -2027,9 +2037,9 @@ def _should_retry(
     retry_config: Optional[RetryConfig],
     retry_policy: Optional[RetryPolicy],
 ) -> bool:
-    config = _coerce_retry_config(retry_config)
+    config = _coerce_retry_config(retry_config, retry_policy)
     policy = _coerce_retry_policy(retry_policy)
-    if config.max_retries <= 0 or policy == RetryPolicy.OFF:
+    if not config.max_retries or policy == RetryPolicy.OFF:
         return False
 
     category = _classify_retry_error(error)
@@ -2084,8 +2094,8 @@ async def _run_prompt_llm_config_with_retry(
     retry_policy: Optional[RetryPolicy],
     messages: Optional[List[Message]] = None,
 ):
-    config = _coerce_retry_config(retry_config)
-    attempts = config.max_retries + 1
+    config = _coerce_retry_config(retry_config, retry_policy)
+    attempts = (config.max_retries or 0) + 1
     last_error = None
 
     for attempt in range(attempts):
@@ -2121,8 +2131,8 @@ async def _run_prompt_llm_config_with_retry(
                 retry_policy=retry_policy,
             ):
                 break
-            if config.delay_ms > 0:
-                await asyncio.sleep(config.delay_ms / 1000)
+            if config.base_delay is not None:
+                await asyncio.sleep((config.base_delay / 1000) * (2**attempt))
 
     raise last_error  # type: ignore[misc]
 

--- a/sdk/agenta/sdk/utils/types.py
+++ b/sdk/agenta/sdk/utils/types.py
@@ -622,8 +622,8 @@ class RetryPolicy(str, Enum):
 
 
 class RetryConfig(BaseModel):
-    max_retries: int = Field(default=0, ge=0)
-    delay_ms: int = Field(default=0, ge=0)
+    max_retries: Optional[int] = Field(default=None, ge=0, le=5)
+    base_delay: Optional[int] = Field(default=None, ge=100, le=1000)
 
 
 class FallbackPolicy(str, Enum):

--- a/sdk/oss/tests/pytest/unit/test_prompt_template_extensions.py
+++ b/sdk/oss/tests/pytest/unit/test_prompt_template_extensions.py
@@ -49,8 +49,8 @@ def test_new_prompt_template_fields_coerce_at_runtime():
 
     assert _prompt_llm_configs(prompt) == [prompt.llm_config]
     assert _coerce_retry_config(prompt.retry_config) == RetryConfig(
-        max_retries=0,
-        delay_ms=0,
+        max_retries=None,
+        base_delay=None,
     )
     assert _coerce_retry_policy(prompt.retry_policy) == RetryPolicy.OFF
     assert _coerce_fallback_policy(prompt.fallback_policy) == FallbackPolicy.OFF
@@ -135,7 +135,7 @@ def test_prompt_template_catalog_schema_exposes_fallback_model_ref():
     ]
     assert set(retry_object_schema["properties"]) == {
         "max_retries",
-        "delay_ms",
+        "base_delay",
     }
     assert retry_policy_schema["enum"] == [
         "off",

--- a/web/packages/agenta-entity-ui/src/DrillInView/components/PlaygroundConfigSection.tsx
+++ b/web/packages/agenta-entity-ui/src/DrillInView/components/PlaygroundConfigSection.tsx
@@ -129,7 +129,7 @@ const RETRY_POLICY_OPTIONS = ["off", "availability", "capacity", "transient", "a
 )
 const DEFAULT_RETRY_CONFIG = {
     max_retries: null as number | null,
-    delay_ms: null as number | null,
+    base_delay: null as number | null,
 }
 const PROMPT_EXTENSION_KEYS = [
     "fallback_configs",
@@ -832,10 +832,10 @@ function PlaygroundConfigSection({
                 typeof retryConfig.max_retries === "number"
                     ? retryConfig.max_retries
                     : DEFAULT_RETRY_CONFIG.max_retries,
-            delay_ms:
-                typeof retryConfig.delay_ms === "number"
-                    ? retryConfig.delay_ms
-                    : DEFAULT_RETRY_CONFIG.delay_ms,
+            base_delay:
+                typeof retryConfig.base_delay === "number"
+                    ? retryConfig.base_delay
+                    : DEFAULT_RETRY_CONFIG.base_delay,
         }),
         [retryConfig],
     )
@@ -897,7 +897,7 @@ function PlaygroundConfigSection({
     )
 
     const handleRetryConfigFieldChange = useCallback(
-        (key: "max_retries" | "delay_ms", nextValue: number | null) => {
+        (key: "max_retries" | "base_delay", nextValue: number | null) => {
             const nextMaxRetries =
                 key === "max_retries"
                     ? nextValue
@@ -913,17 +913,17 @@ function PlaygroundConfigSection({
                 return
             }
 
-            const nextDelayMs =
-                key === "delay_ms"
+            const nextBaseDelay =
+                key === "base_delay"
                     ? nextValue
-                    : typeof retryConfig.delay_ms === "number"
-                      ? retryConfig.delay_ms
-                      : DEFAULT_RETRY_CONFIG.delay_ms
+                    : typeof retryConfig.base_delay === "number"
+                      ? retryConfig.base_delay
+                      : DEFAULT_RETRY_CONFIG.base_delay
             const nextRetryConfig: Record<string, unknown> = {
                 max_retries: nextMaxRetries,
             }
-            if (typeof nextDelayMs === "number") {
-                nextRetryConfig.delay_ms = nextDelayMs
+            if (typeof nextBaseDelay === "number") {
+                nextRetryConfig.base_delay = nextBaseDelay
             }
 
             updatePromptRootField("retry_config", nextRetryConfig)
@@ -1249,7 +1249,7 @@ function PlaygroundConfigSection({
                                                           | undefined
                                                   }
                                                   maxRetries={effectiveRetryConfig.max_retries}
-                                                  delayMs={effectiveRetryConfig.delay_ms}
+                                                  baseDelay={effectiveRetryConfig.base_delay}
                                                   onPolicyChange={handleRetryPolicyChange}
                                                   onConfigFieldChange={handleRetryConfigFieldChange}
                                                   disabled={disabled}
@@ -1266,7 +1266,7 @@ function PlaygroundConfigSection({
         [
             activeConfigureTab,
             disabled,
-            effectiveRetryConfig.delay_ms,
+            effectiveRetryConfig.base_delay,
             effectiveRetryConfig.max_retries,
             fallbackConfigKeys,
             fallbackConfigs,

--- a/web/packages/agenta-entity-ui/src/DrillInView/components/PlaygroundConfigSection/RetryConfigTab.tsx
+++ b/web/packages/agenta-entity-ui/src/DrillInView/components/PlaygroundConfigSection/RetryConfigTab.tsx
@@ -22,9 +22,9 @@ export interface RetryConfigTabProps {
     retryPolicySchema?: EntitySchemaProperty
     retryConfigSchema?: EntitySchemaProperty
     maxRetries: number | null
-    delayMs: number | null
+    baseDelay: number | null
     onPolicyChange: (nextValue: string | null) => void
-    onConfigFieldChange: (key: "max_retries" | "delay_ms", nextValue: number | null) => void
+    onConfigFieldChange: (key: "max_retries" | "base_delay", nextValue: number | null) => void
     disabled?: boolean
 }
 
@@ -34,7 +34,7 @@ export const RetryConfigTab = memo(function RetryConfigTab({
     retryPolicySchema,
     retryConfigSchema,
     maxRetries,
-    delayMs,
+    baseDelay,
     onPolicyChange,
     onConfigFieldChange,
     disabled,
@@ -51,15 +51,13 @@ export const RetryConfigTab = memo(function RetryConfigTab({
     const retryRequiredMessage = "Set max retries first."
 
     const renderNumberField = (
-        key: "max_retries" | "delay_ms",
+        key: "max_retries" | "base_delay",
         value: number | null,
         fallbackDescription: string,
     ) => {
         const schema = resolveAnyOfSchema(retryConfigProperties[key])
         const title = getSchemaText(schema?.title)
         const description = getSchemaText(schema?.description)
-        const maxOverride =
-            key === "delay_ms" && typeof schema?.maximum !== "number" ? 10000 : undefined
 
         return (
             <NumberSliderControl
@@ -69,9 +67,8 @@ export const RetryConfigTab = memo(function RetryConfigTab({
                 value={value}
                 onChange={(nextValue) => onConfigFieldChange(key, nextValue)}
                 description={description || fallbackDescription}
-                disabled={disabled || (key === "delay_ms" && !isRetryEnabled)}
-                disabledReason={key === "delay_ms" ? retryRequiredMessage : undefined}
-                max={maxOverride}
+                disabled={disabled || (key === "base_delay" && !isRetryEnabled)}
+                disabledReason={key === "base_delay" ? retryRequiredMessage : undefined}
             />
         )
     }
@@ -83,7 +80,11 @@ export const RetryConfigTab = memo(function RetryConfigTab({
                 maxRetries,
                 "Each model is retried this many times before moving to the next.",
             )}
-            {renderNumberField("delay_ms", delayMs, "Delay before each retry in milliseconds")}
+            {renderNumberField(
+                "base_delay",
+                baseDelay,
+                "Base delay (ms) before the first retry; doubles on each subsequent attempt.",
+            )}
             <div className="flex flex-col gap-1">
                 <div className="flex flex-col gap-0.5">
                     <Typography.Text>{policyTitle}</Typography.Text>


### PR DESCRIPTION
## PR description

### feat(sdk): exponential backoff for LLM prompt retries

#### What

Replaces the fixed-delay retry in the prompt execution engine with exponential backoff, and tightens the `RetryConfig` model with proper bounds and optional semantics. Updates all UI copy and published docs to match.

#### Changes

**SDK — `types.py`**
- `RetryConfig.max_retries`: `int = 0` → `Optional[int] = None`, range `[0, 5]`
- `RetryConfig.delay_ms` → `base_delay`: `Optional[int] = None`, range `[100, 1000]` ms

**SDK — `handlers.py`**
- `_coerce_retry_config` takes `retry_policy` and fills safe defaults when policy is active and fields are `None` (`max_retries=1`, `base_delay=1000`)
- Sleep formula: `(base_delay / 1000) * 2^attempt` — first sleep equals `base_delay`, doubles each retry
- Both `_should_retry` and `_run_prompt_llm_config_with_retry` pass policy through to coercion

**Frontend — `agenta-entity-ui`**
- `RetryConfigTab`: `delayMs` → `baseDelay`, field key `"delay_ms"` → `"base_delay"`, description updated, hardcoded `max=10000` slider override removed
- `PlaygroundConfigSection`: all references updated

**Docs**
- `07-fallback-models-and-retry.mdx`: JSON example + prose updated
- `01-configuration-management.mdx`: reference table + JSON example updated
- `03-custom-workflow.mdx`: code example + parameter description updated

**Tests**
- Schema property assertions and coercion default assertions updated in SDK and API unit tests

---

## Summary of changes and implications

### Model (`sdk/agenta/sdk/utils/types.py`)
- `RetryConfig.max_retries`: `int = 0` → `Optional[int] = None`, capped at 5
- `RetryConfig.delay_ms` renamed to `base_delay`: `Optional[int] = None`, constrained to 100–1000 ms
- `None` is the canonical "not configured" state for both fields

### Retry execution (`sdk/agenta/sdk/engines/running/handlers.py`)
- `_coerce_retry_config` now accepts `retry_policy` and fills safe defaults when the policy is active and a field is `None`: `max_retries → 1`, `base_delay → 1000`
- Sleep formula changed from fixed `delay_ms / 1000` to exponential `(base_delay / 1000) * 2^attempt` (attempt is 0-indexed, so first sleep = `base_delay`, second = `base_delay * 2`, etc.)
- Both `_should_retry` and `_run_prompt_llm_config_with_retry` pass `retry_policy` through to coercion so defaults apply consistently

### Retry schedule

| attempt | sleep at base_delay=100ms | sleep at base_delay=1000ms |
|---------|--------------------------|---------------------------|
| 0 | 100ms | 1s |
| 1 | 200ms | 2s |
| 2 | 400ms | 4s |
| 3 | 800ms | 8s |
| 4 | 1600ms | 16s |

Max retries is capped at 5, giving a worst-case total wait of ~3.1s at 100ms base and ~31s at 1000ms base.

### Frontend (`agenta-entity-ui`)
- `RetryConfigTab`: prop `delayMs` → `baseDelay`, field key `"delay_ms"` → `"base_delay"`, slider description updated to reflect exponential behavior; removed hardcoded `max=10000` override (bounds now come from schema)
- `PlaygroundConfigSection`: all `delay_ms` references updated throughout

### Docs (`docs/docs/`)
- `prompt-engineering/integrating-prompts/07-fallback-models-and-retry.mdx`: JSON example updated, prose updated to describe exponential backoff
- `reference/sdk/01-configuration-management.mdx`: reference table updated (`delay_ms` → `base_delay` with range), JSON example updated
- `reference/sdk/03-custom-workflow.mdx`: code example and parameter description updated

### Tests
- Schema property assertions updated (`"delay_ms"` → `"base_delay"`) in SDK and API unit tests
- `_coerce_retry_config` default assertions updated to reflect `None` defaults