### PR TITLE
chore(sdk): update supported LLM model list

### DIFF
--- a/sdk/agenta/sdk/utils/assets.py
+++ b/sdk/agenta/sdk/utils/assets.py
@@ -5,6 +5,7 @@ from litellm import cost_calculator
 
 supported_llm_models = {
     "anthropic": [
+        "anthropic/claude-opus-4-7",
         "anthropic/claude-opus-4-6",
         "anthropic/claude-sonnet-4-6",
         "anthropic/claude-opus-4-5",
@@ -52,8 +53,10 @@ supported_llm_models = {
         "gemini/gemini-2.0-flash",
         "gemini/gemini-2.0-flash-001",
         "gemini/gemini-2.0-flash-lite",
+        "gemini/gemini-1.5-flash",
     ],
     "groq": [
+        "groq/moonshotai/kimi-k2-instruct-0905",
         "groq/meta-llama/llama-4-maverick-17b-128e-instruct",
         "groq/meta-llama/llama-4-scout-17b-16e-instruct",
         "groq/llama-3.3-70b-versatile",
@@ -69,7 +72,12 @@ supported_llm_models = {
         "mistral/mistral-large-latest",
     ],
     "openai": [
+        "gpt-5.5-pro",
+        "gpt-5.5",
+        "gpt-5.4-pro",
         "gpt-5.4",
+        "gpt-5.4-mini",
+        "gpt-5.4-nano",
         "gpt-5.2-pro",
         "gpt-5.2-chat-latest",
         "gpt-5.2",


### PR DESCRIPTION
## Summary

- Audit `sdk/agenta/sdk/utils/assets.py` against `litellm.model_cost` (litellm 1.83.14, ~2700 entries)
- Add 8 newly-released models that were missing from the supported list

## Models added

- **Anthropic** — `claude-opus-4-7`
- **OpenAI** — `gpt-5.5`, `gpt-5.5-pro`, `gpt-5.4-pro`, `gpt-5.4-mini`, `gpt-5.4-nano`
- **Gemini** — `gemini-1.5-flash` (still widely used per the skill guide)
- **Groq** — `moonshotai/kimi-k2-instruct-0905`

Models deliberately skipped:
- Dated snapshots (e.g. `gpt-5.5-2026-04-23`, `claude-opus-4-7-20260416`) — convention here is to list aliases, not pinned dates
- `gpt-5.3-chat-latest` — only the `chat-latest` alias exists in litellm; no plain `gpt-5.3` base model
- Audio/music (`lyria-3-*`), moderation (`llama-guard-4`, `gpt-oss-safeguard-20b`), and `gemini-3.1-pro-preview-customtools`

## Test plan

- [x] All 136 entries resolve in `litellm.model_cost` (was 131 + 5 minimax that landed on main)
- [x] No duplicates within any provider list
- [x] `ruff format` and `ruff check` pass
- [ ] CI / `pytest sdk/oss/tests/pytest/unit/test_supported_llm_models.py`
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/agenta-ai/agenta/pull/4243" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open in Devin Review">
  </picture>
</a>
<!-- devin-review-badge-end -->
