### PR TITLE
chore(api): hide duplicate /admin/accounts route from OpenAPI

### DIFF
--- a/api/oss/src/routers/admin_router.py
+++ b/api/oss/src/routers/admin_router.py
@@ -152,6 +152,7 @@ class ReferenceTracker(BaseModel):
     "/accounts",
     operation_id="create_accounts",
     response_model=ScopesResponseModel,
+    include_in_schema=False,
 )
 async def create_accounts(
     entities: EntitiesRequestModel,


### PR DESCRIPTION
## Summary

The legacy `admin_router.create_accounts` endpoint
(`api/oss/src/routers/admin_router.py`) and the new
`fastapi/accounts/router.create_accounts` both surface in the OpenAPI
schema. Fern's TypeScript codegen collapses both to the same method
name (`createAccounts`), forcing downstream Fern post-processors to
disambiguate via a manual rename pass.

This excludes the legacy admin route from the schema with
`include_in_schema=False`, removing the collision at the source.

## Why

This is a prerequisite for cleaner Fern client generation (see the
`feat/sdk/typescript-fern-client` PR, which currently carries a Python
post-processor in `clients/scripts/generate.sh` to rename the duplicate
method). With this fix in place, the post-processor can eventually be
removed.

## Diff

- 1 file changed: `api/oss/src/routers/admin_router.py` (1 insertion)

## Risks

- **Backwards compatibility:** `include_in_schema=False` only hides the
  route from the OpenAPI schema and any auto-generated docs/clients. The
  HTTP endpoint itself (POST `/admin/accounts`) continues to work
  unchanged. Anyone calling it directly via HTTP is unaffected.
- The route is admin-only and unauthenticated callers are already
  rejected — exposure surface does not change.

## QA

- [ ] CI green
- [ ] Hit POST `/admin/accounts` directly (curl or Postman) — should
      return the same response as before
- [ ] Regenerate the Fern Python client locally (`clients/scripts/generate.sh`)
      and verify only one `createAccounts` method appears in the
      generated TS admin client
- [ ] Confirm the `admin_create_accounts` operation in the new
      `fastapi/accounts/router` is still in the OpenAPI schema (it is
      the canonical one going forward)
