### PR TITLE
chore(infra): use per-service container WORKDIR

### DIFF
--- a/api/ee/databases/postgres/migrations/core/README.md
+++ b/api/ee/databases/postgres/migrations/core/README.md
@@ -13,7 +13,7 @@ Note that autogenerate sometimes does not detect all database changes and it is 
 To make migrations after creating a new table schema or modifying a current column in a table, run the following commands:
 
 ```bash
-docker exec -e PYTHONPATH=/app -w /app/ee/databases/postgres/migrations/core agenta-ee-dev-api-1 alembic -c alembic.ini revision --autogenerate -m "migration message"
+docker exec -e PYTHONPATH=/api -w /api/ee/databases/postgres/migrations/core agenta-ee-dev-api-1 alembic -c alembic.ini revision --autogenerate -m "migration message"
 ```
 
 The above command will create a script that contains the changes that was made to the database schema. Kindly update "migration message" with a message that is clear to indicate what change was made. Here are some examples:
@@ -25,11 +25,11 @@ The above command will create a script that contains the changes that was made t
 ### Applying Migrations
 
 ```bash
-docker exec -e PYTHONPATH=/app -w /app/ee/databases/postgres/migrations/core agenta-ee-dev-api-1 alembic -c alembic.ini upgrade head
+docker exec -e PYTHONPATH=/api -w /api/ee/databases/postgres/migrations/core agenta-ee-dev-api-1 alembic -c alembic.ini upgrade head
 ```
 
 The above command will be used to apply the changes in the script created to the database table(s). If you'd like to revert the migration, run the following command:
 
 ```bash
-docker exec -e PYTHONPATH=/app -w /app/ee/databases/postgres/migrations/core agenta-ee-dev-api-1 alembic -c alembic.ini downgrade head
+docker exec -e PYTHONPATH=/api -w /api/ee/databases/postgres/migrations/core agenta-ee-dev-api-1 alembic -c alembic.ini downgrade head
 ```

--- a/api/ee/databases/postgres/migrations/core/alembic.ini
+++ b/api/ee/databases/postgres/migrations/core/alembic.ini
@@ -1,7 +1,7 @@
 # A generic, single database configuration.
 
 [alembic]
-script_location = /app/ee/databases/postgres/migrations/core
+script_location = /api/ee/databases/postgres/migrations/core
 
 # template used to generate migration file names; The default value is %%(rev)s_%%(slug)s
 # Uncomment the line below if you want the files to be prepended with date and time

--- a/api/ee/databases/postgres/migrations/tracing/README copy.md
+++ b/api/ee/databases/postgres/migrations/tracing/README copy.md
@@ -13,7 +13,7 @@ Note that autogenerate sometimes does not detect all database changes and it is 
 To make migrations after creating a new table schema or modifying a current column in a table, run the following commands:
 
 ```bash
-docker exec -e PYTHONPATH=/app -w /app/ee/databases/postgres/migrations/core agenta-ee-dev-api-1 alembic -c alembic.ini revision --autogenerate -m "migration message"
+docker exec -e PYTHONPATH=/api -w /api/ee/databases/postgres/migrations/core agenta-ee-dev-api-1 alembic -c alembic.ini revision --autogenerate -m "migration message"
 ```
 
 The above command will create a script that contains the changes that was made to the database schema. Kindly update "migration message" with a message that is clear to indicate what change was made. Here are some examples:
@@ -25,11 +25,11 @@ The above command will create a script that contains the changes that was made t
 ### Applying Migrations
 
 ```bash
-docker exec -e PYTHONPATH=/app -w /app/ee/databases/postgres/migrations/core agenta-ee-dev-api-1 alembic -c alembic.ini upgrade head
+docker exec -e PYTHONPATH=/api -w /api/ee/databases/postgres/migrations/core agenta-ee-dev-api-1 alembic -c alembic.ini upgrade head
 ```
 
 The above command will be used to apply the changes in the script created to the database table(s). If you'd like to revert the migration, run the following command:
 
 ```bash
-docker exec -e PYTHONPATH=/app -w /app/ee/databases/postgres/migrations/core agenta-ee-dev-api-1 alembic -c alembic.ini downgrade head
+docker exec -e PYTHONPATH=/api -w /api/ee/databases/postgres/migrations/core agenta-ee-dev-api-1 alembic -c alembic.ini downgrade head
 ```

--- a/api/ee/databases/postgres/migrations/tracing/alembic.ini
+++ b/api/ee/databases/postgres/migrations/tracing/alembic.ini
@@ -2,7 +2,7 @@
 
 [alembic]
 # path to migration scripts
-script_location = /app/ee/databases/postgres/migrations/tracing
+script_location = /api/ee/databases/postgres/migrations/tracing
 
 # template used to generate migration file names; The default value is %%(rev)s_%%(slug)s
 # Uncomment the line below if you want the files to be prepended with date and time

--- a/api/ee/docker/Dockerfile.dev
+++ b/api/ee/docker/Dockerfile.dev
@@ -1,6 +1,6 @@
 FROM python:3.11-slim-bookworm
 
-WORKDIR /app
+WORKDIR /api
 
 RUN apt-get update && \
     apt-get install -y curl gnupg2 lsb-release && \
@@ -28,7 +28,7 @@ RUN ARCH=$(dpkg --print-architecture) && \
 RUN pip install --upgrade pip \
     && pip install poetry
 
-COPY ./pyproject.toml /app/
+COPY ./pyproject.toml /api/
 
 RUN poetry config virtualenvs.create false \
     && poetry install --no-interaction --no-ansi
@@ -36,11 +36,14 @@ RUN poetry config virtualenvs.create false \
 RUN groupadd --gid 10001 agenta && \
     useradd --uid 10001 --gid 10001 --shell /bin/false --create-home agenta
 
-COPY --chown=agenta:agenta ./ee /app/ee/
-COPY --chown=agenta:agenta ./oss /app/oss/
-COPY --chown=agenta:agenta ./entrypoints /app/entrypoints/
+COPY --chown=agenta:agenta ./ee /api/ee/
+COPY --chown=agenta:agenta ./oss /api/oss/
+COPY --chown=agenta:agenta ./entrypoints /api/entrypoints/
 
-ENV PYTHONPATH=/sdk:$PYTHONPATH
+ENV PYTHONPATH=/sdks/python:/clients/python:$PYTHONPATH
+
+RUN echo "/clients/python" > /usr/local/lib/python3.11/site-packages/agenta_client_path.pth \
+    && echo "/sdks/python" >> /usr/local/lib/python3.11/site-packages/agenta_client_path.pth
 
 COPY ./oss/src/crons/queries.sh /queries.sh
 COPY ./oss/src/crons/queries.txt /etc/cron.d/queries-cron
@@ -54,8 +57,8 @@ RUN chmod +x /queries.sh /meters.sh /spans.sh \
     && for f in /etc/cron.d/queries-cron /etc/cron.d/meters-cron /etc/cron.d/spans-cron; do sed -i -e '$a\' "$f"; done \
     && cat /etc/cron.d/queries-cron /etc/cron.d/meters-cron /etc/cron.d/spans-cron \
         | sed -E 's/^(([^[:space:]]+[[:space:]]+){5})root[[:space:]]+/\1/' \
-        | sed 's| >> /proc/1/fd/1 2>&1||' > /app/crontab \
-    && chown agenta:agenta /app/crontab
+        | sed 's| >> /proc/1/fd/1 2>&1||' > /api/crontab \
+    && chown agenta:agenta /api/crontab
 
 USER 10001
 

--- a/api/ee/docker/Dockerfile.gh
+++ b/api/ee/docker/Dockerfile.gh
@@ -2,7 +2,7 @@ FROM python:3.11-slim-bookworm AS builder
 
 ARG POETRY_VERSION=2.3.1
 
-WORKDIR /app
+WORKDIR /api
 
 ENV PIP_DISABLE_PIP_VERSION_CHECK=1 \
     PIP_NO_CACHE_DIR=0 \
@@ -13,7 +13,7 @@ ENV PIP_DISABLE_PIP_VERSION_CHECK=1 \
 RUN --mount=type=cache,id=pip-api,target=/root/.cache/pip \
     pip install --timeout=300 "poetry==${POETRY_VERSION}" "poetry-plugin-export"
 
-COPY ./pyproject.toml ./poetry.lock* /app/
+COPY ./pyproject.toml ./poetry.lock* /api/
 
 # Create clean venv, install app deps, strip heavy unused deps, add stubs
 # Merged into one layer so stripped files don't persist in a previous layer.
@@ -44,21 +44,21 @@ RUN --mount=type=cache,id=pip-api,target=/root/.cache/pip \
     && find /opt/venv -type d -name __pycache__ -exec rm -rf {} + 2>/dev/null; true
 
 # Copy and install SDK first (changes less frequently than app code)
-RUN mkdir -p /app/sdk
-COPY ./sd[k] /app/sdk/
+COPY ./sdks/python /sdks/python/
+COPY ./clients/python /clients/python/
 
 RUN --mount=type=cache,id=pip-api,target=/root/.cache/pip \
-    if [ -f /app/sdk/pyproject.toml ]; then \
+    if [ -f /sdks/python/pyproject.toml ]; then \
         . /opt/venv/bin/activate && \
         pip install pip && \
-        pip install --editable /app/sdk && \
+        pip install --editable /sdks/python && \
         (pip uninstall -y pip 2>/dev/null || true); \
     fi
 
 # Copy app code last (changes more frequently)
-COPY ./ee /app/ee/
-COPY ./oss /app/oss/
-COPY ./entrypoints /app/entrypoints/
+COPY ./ee /api/ee/
+COPY ./oss /api/oss/
+COPY ./entrypoints /api/entrypoints/
 
 
 FROM python:3.11-slim-bookworm AS runner
@@ -67,11 +67,11 @@ ARG BUILD_DATE
 ARG VCS_REF
 ARG VERSION=0.0.0
 
-WORKDIR /app
+WORKDIR /api
 
 ENV PYTHONDONTWRITEBYTECODE=1 \
     PYTHONUNBUFFERED=1 \
-    PYTHONPATH=/app:/app/sdk \
+    PYTHONPATH=/api:/sdks/python:/clients/python \
     PATH="/opt/venv/bin:${PATH}"
 
 # Hardcode bookworm codename to avoid pulling in lsb-release (+ perl ~56MB)
@@ -113,10 +113,11 @@ COPY --chmod=644 ./ee/src/crons/spans.txt /etc/cron.d/spans-cron
 COPY --from=builder /opt/venv /opt/venv
 
 # Copy app code last (changes most frequently)
-COPY --chown=agenta:agenta --from=builder /app/ee /app/ee
-COPY --chown=agenta:agenta --from=builder /app/oss /app/oss
-COPY --chown=agenta:agenta --from=builder /app/entrypoints /app/entrypoints
-COPY --chown=agenta:agenta --from=builder /app/sdk /app/sdk
+COPY --chown=agenta:agenta --from=builder /api/ee /api/ee
+COPY --chown=agenta:agenta --from=builder /api/oss /api/oss
+COPY --chown=agenta:agenta --from=builder /api/entrypoints /api/entrypoints
+COPY --chown=agenta:agenta --from=builder /sdks/python /sdks/python
+COPY --chown=agenta:agenta --from=builder /clients/python /clients/python
 
 # Generate supercronic-compatible crontab (strip user field and /proc redirects)
 RUN set -eux; \
@@ -125,8 +126,8 @@ RUN set -eux; \
     done; \
     cat /etc/cron.d/queries-cron /etc/cron.d/meters-cron /etc/cron.d/spans-cron \
         | sed -E 's/^(([^[:space:]]+[[:space:]]+){5})root[[:space:]]+/\1/' \
-        | sed 's| >> /proc/1/fd/1 2>&1||' > /app/crontab && \
-    chown agenta:agenta /app/crontab
+        | sed 's| >> /proc/1/fd/1 2>&1||' > /api/crontab && \
+    chown agenta:agenta /api/crontab
 
 USER 10001
 

--- a/api/oss/databases/postgres/migrations/core/README.md
+++ b/api/oss/databases/postgres/migrations/core/README.md
@@ -14,7 +14,7 @@ To make migrations after creating a new table schema or modifying a current colu
 
 
 ```bash
-docker exec -e PYTHONPATH=/app -w /app/oss/databases/postgres/migrations/core agenta-oss-dev-api-1 alembic -c alembic.ini revision --autogenerate -m "migration message"
+docker exec -e PYTHONPATH=/api -w /api/oss/databases/postgres/migrations/core agenta-oss-dev-api-1 alembic -c alembic.ini revision --autogenerate -m "migration message"
 ```
 
 The above command will create a script that contains the changes that was made to the database schema. Kindly update "migration message" with a message that is clear to indicate what change was made. Here are some examples:
@@ -26,7 +26,7 @@ The above command will create a script that contains the changes that was made t
 ### Applying Migrations
 
 ```bash
-docker exec -e PYTHONPATH=/app -w /app/oss/databases/postgres/migrations/core agenta-oss-dev-api-1 alembic -c alembic.ini upgrade head
+docker exec -e PYTHONPATH=/api -w /api/oss/databases/postgres/migrations/core agenta-oss-dev-api-1 alembic -c alembic.ini upgrade head
 ```
 
 The above command will be used to apply the changes in the script created to the database table(s).

--- a/api/oss/databases/postgres/migrations/core/alembic.ini
+++ b/api/oss/databases/postgres/migrations/core/alembic.ini
@@ -2,7 +2,7 @@
 
 [alembic]
 # path to migration scripts
-script_location = /app/oss/databases/postgres/migrations/core
+script_location = /api/oss/databases/postgres/migrations/core
 
 # template used to generate migration file names; The default value is %%(rev)s_%%(slug)s
 # Uncomment the line below if you want the files to be prepended with date and time

--- a/api/oss/databases/postgres/migrations/tracing/README.md
+++ b/api/oss/databases/postgres/migrations/tracing/README.md
@@ -14,7 +14,7 @@ To make migrations after creating a new table schema or modifying a current colu
 
 
 ```bash
-docker exec -e PYTHONPATH=/app -w /app/oss/databases/postgres/migrations/tracing agenta-oss-dev-api-1 alembic -c alembic.ini revision --autogenerate -m "migration message"
+docker exec -e PYTHONPATH=/api -w /api/oss/databases/postgres/migrations/tracing agenta-oss-dev-api-1 alembic -c alembic.ini revision --autogenerate -m "migration message"
 ```
 
 The above command will create a script that contains the changes that was made to the database schema. Kindly update "migration message" with a message that is clear to indicate what change was made. Here are some examples:
@@ -26,7 +26,7 @@ The above command will create a script that contains the changes that was made t
 ### Applying Migrations
 
 ```bash
-docker exec -e PYTHONPATH=/app -w /app/oss/databases/postgres/migrations/tracing agenta-oss-dev-api-1 alembic -c alembic.ini upgrade head
+docker exec -e PYTHONPATH=/api -w /api/oss/databases/postgres/migrations/tracing agenta-oss-dev-api-1 alembic -c alembic.ini upgrade head
 ```
 
 The above command will be used to apply the changes in the script created to the database table(s).

--- a/api/oss/databases/postgres/migrations/tracing/alembic.ini
+++ b/api/oss/databases/postgres/migrations/tracing/alembic.ini
@@ -2,7 +2,7 @@
 
 [alembic]
 # path to migration scripts
-script_location = /app/oss/databases/postgres/migrations/tracing
+script_location = /api/oss/databases/postgres/migrations/tracing
 
 # template used to generate migration file names; The default value is %%(rev)s_%%(slug)s
 # Uncomment the line below if you want the files to be prepended with date and time

--- a/api/oss/docker/Dockerfile.dev
+++ b/api/oss/docker/Dockerfile.dev
@@ -1,6 +1,6 @@
 FROM python:3.11-slim-bookworm
 
-WORKDIR /app
+WORKDIR /api
 
 RUN apt-get update && \
     apt-get install -y curl gnupg2 lsb-release && \
@@ -28,7 +28,7 @@ RUN ARCH=$(dpkg --print-architecture) && \
 RUN pip install --upgrade pip \
     && pip install poetry
 
-COPY ./pyproject.toml /app/
+COPY ./pyproject.toml /api/
 
 RUN poetry config virtualenvs.create false \
     && poetry install --no-interaction --no-ansi
@@ -37,10 +37,13 @@ RUN poetry config virtualenvs.create false \
 RUN groupadd --gid 10001 agenta && \
     useradd --uid 10001 --gid 10001 --shell /bin/false --create-home agenta
 
-COPY --chown=agenta:agenta ./oss /app/oss/
-COPY --chown=agenta:agenta ./entrypoints /app/entrypoints/
+COPY --chown=agenta:agenta ./oss /api/oss/
+COPY --chown=agenta:agenta ./entrypoints /api/entrypoints/
 
-ENV PYTHONPATH=/sdk:$PYTHONPATH
+ENV PYTHONPATH=/sdks/python:/clients/python:$PYTHONPATH
+
+RUN echo "/clients/python" > /usr/local/lib/python3.11/site-packages/agenta_client_path.pth \
+    && echo "/sdks/python" >> /usr/local/lib/python3.11/site-packages/agenta_client_path.pth
 
 COPY ./oss/src/crons/queries.sh /queries.sh
 COPY ./oss/src/crons/queries.txt /etc/cron.d/queries-cron
@@ -49,8 +52,8 @@ RUN chmod +x /queries.sh \
     && chmod 0644 /etc/cron.d/queries-cron \
     && sed -i -e '$a\' /etc/cron.d/queries-cron \
     && sed -E 's/^(([^[:space:]]+[[:space:]]+){5})root[[:space:]]+/\1/' /etc/cron.d/queries-cron \
-        | sed 's| >> /proc/1/fd/1 2>&1||' > /app/crontab \
-    && chown agenta:agenta /app/crontab
+        | sed 's| >> /proc/1/fd/1 2>&1||' > /api/crontab \
+    && chown agenta:agenta /api/crontab
 
 #
 #

--- a/api/oss/docker/Dockerfile.gh
+++ b/api/oss/docker/Dockerfile.gh
@@ -2,7 +2,7 @@ FROM python:3.11-slim-bookworm AS builder
 
 ARG POETRY_VERSION=2.3.1
 
-WORKDIR /app
+WORKDIR /api
 
 ENV PIP_DISABLE_PIP_VERSION_CHECK=1 \
     PIP_NO_CACHE_DIR=0 \
@@ -13,7 +13,7 @@ ENV PIP_DISABLE_PIP_VERSION_CHECK=1 \
 RUN --mount=type=cache,id=pip-api,target=/root/.cache/pip \
     pip install --timeout=300 "poetry==${POETRY_VERSION}" "poetry-plugin-export"
 
-COPY ./pyproject.toml ./poetry.lock* /app/
+COPY ./pyproject.toml ./poetry.lock* /api/
 
 # Create clean venv, install app deps, strip heavy unused deps, add stubs
 # Merged into one layer so stripped files don't persist in a previous layer.
@@ -44,20 +44,20 @@ RUN --mount=type=cache,id=pip-api,target=/root/.cache/pip \
     && find /opt/venv -type d -name __pycache__ -exec rm -rf {} + 2>/dev/null; true
 
 # Copy and install SDK first (changes less frequently than app code)
-RUN mkdir -p /app/sdk
-COPY ./sd[k] /app/sdk/
+COPY ./sdks/python /sdks/python/
+COPY ./clients/python /clients/python/
 
 RUN --mount=type=cache,id=pip-api,target=/root/.cache/pip \
-    if [ -f /app/sdk/pyproject.toml ]; then \
+    if [ -f /sdks/python/pyproject.toml ]; then \
         . /opt/venv/bin/activate && \
         pip install pip && \
-        pip install --editable /app/sdk && \
+        pip install --editable /sdks/python && \
         (pip uninstall -y pip 2>/dev/null || true); \
     fi
 
 # Copy app code last (changes more frequently)
-COPY ./oss /app/oss/
-COPY ./entrypoints /app/entrypoints/
+COPY ./oss /api/oss/
+COPY ./entrypoints /api/entrypoints/
 
 
 FROM python:3.11-slim-bookworm AS runner
@@ -66,11 +66,11 @@ ARG BUILD_DATE
 ARG VCS_REF
 ARG VERSION=0.0.0
 
-WORKDIR /app
+WORKDIR /api
 
 ENV PYTHONDONTWRITEBYTECODE=1 \
     PYTHONUNBUFFERED=1 \
-    PYTHONPATH=/app:/app/sdk \
+    PYTHONPATH=/api:/sdks/python:/clients/python \
     PATH="/opt/venv/bin:${PATH}"
 
 # Hardcode bookworm codename to avoid pulling in lsb-release (+ perl ~56MB).
@@ -109,9 +109,10 @@ COPY --chmod=644 ./oss/src/crons/queries.txt /etc/cron.d/queries-cron
 COPY --from=builder /opt/venv /opt/venv
 
 # Copy app code last (changes most frequently)
-COPY --chown=agenta:agenta --from=builder /app/oss /app/oss
-COPY --chown=agenta:agenta --from=builder /app/entrypoints /app/entrypoints
-COPY --chown=agenta:agenta --from=builder /app/sdk /app/sdk
+COPY --chown=agenta:agenta --from=builder /api/oss /api/oss
+COPY --chown=agenta:agenta --from=builder /api/entrypoints /api/entrypoints
+COPY --chown=agenta:agenta --from=builder /sdks/python /sdks/python
+COPY --chown=agenta:agenta --from=builder /clients/python /clients/python
 
 # Generate supercronic-compatible crontab (strip user field and /proc redirects)
 RUN set -eux; \
@@ -119,8 +120,8 @@ RUN set -eux; \
         sed -i -e '$a\' "${cron_file}"; \
     done; \
     sed -E 's/^(([^[:space:]]+[[:space:]]+){5})root[[:space:]]+/\1/' /etc/cron.d/queries-cron \
-        | sed 's| >> /proc/1/fd/1 2>&1||' > /app/crontab && \
-    chown agenta:agenta /app/crontab
+        | sed 's| >> /proc/1/fd/1 2>&1||' > /api/crontab && \
+    chown agenta:agenta /api/crontab
 
 USER 10001
 

--- a/api/oss/src/crons/queries.sh
+++ b/api/oss/src/crons/queries.sh
@@ -2,7 +2,7 @@
 set -eu
 
 AGENTA_AUTH_KEY="${AGENTA_AUTH_KEY:-replace-me}"
-TRIGGER_INTERVAL=$(awk '/queries\.sh/ {split($1, a, "/"); print (a[2] ? a[2] : 1); exit}' /app/crontab)
+TRIGGER_INTERVAL=$(awk '/queries\.sh/ {split($1, a, "/"); print (a[2] ? a[2] : 1); exit}' /api/crontab)
 NOW_UTC=$(date -u "+%Y-%m-%dT%H:%M:00Z")
 MINUTE=$(date -u "+%M" | sed 's/^0*//')
 ROUNDED_MINUTE=$(( (MINUTE / TRIGGER_INTERVAL) * TRIGGER_INTERVAL ))

--- a/api/oss/src/utils/env.py
+++ b/api/oss/src/utils/env.py
@@ -653,10 +653,10 @@ class AlembicConfig(BaseModel):
     """Database migration configuration"""
 
     cfg_path_core: str = os.getenv("ALEMBIC_CFG_PATH_CORE") or (
-        f"/app/{_LICENSE}/databases/postgres/migrations/core/alembic.ini"
+        f"/api/{_LICENSE}/databases/postgres/migrations/core/alembic.ini"
     )
     cfg_path_tracing: str = os.getenv("ALEMBIC_CFG_PATH_TRACING") or (
-        f"/app/{_LICENSE}/databases/postgres/migrations/tracing/alembic.ini"
+        f"/api/{_LICENSE}/databases/postgres/migrations/tracing/alembic.ini"
     )
 
     model_config = ConfigDict(extra="ignore")

--- a/docs/docs/self-host/01-quick-start.mdx
+++ b/docs/docs/self-host/01-quick-start.mdx
@@ -57,7 +57,7 @@ docker compose -f hosting/docker-compose/oss/docker-compose.gh.yml --env-file ho
 
 2. Run migrations if needed:
 ```bash
-docker exec -e PYTHONPATH=/app -w /app/oss/databases/postgres/migrations/core agenta-oss-gh-api-1 alembic -c alembic.ini upgrade head
+docker exec -e PYTHONPATH=/api -w /api/oss/databases/postgres/migrations/core agenta-oss-gh-api-1 alembic -c alembic.ini upgrade head
 ```
 
 Consult the [upgrading guide](/self-host/upgrading) for more details.

--- a/docs/docs/self-host/02-configuration.mdx
+++ b/docs/docs/self-host/02-configuration.mdx
@@ -120,8 +120,8 @@ Controls migrations and config paths.
 | Variable | Purpose | Default |
 |----------|---------|---------|
 | `ALEMBIC_AUTO_MIGRATIONS` | Auto migrations | `true` |
-| `ALEMBIC_CFG_PATH_CORE` | Core alembic path | `/app/oss/databases/postgres/migrations/core/alembic.ini` |
-| `ALEMBIC_CFG_PATH_TRACING` | Tracing alembic path | `/app/oss/databases/postgres/migrations/tracing/alembic.ini` |
+| `ALEMBIC_CFG_PATH_CORE` | Core alembic path | `/api/oss/databases/postgres/migrations/core/alembic.ini` |
+| `ALEMBIC_CFG_PATH_TRACING` | Tracing alembic path | `/api/oss/databases/postgres/migrations/tracing/alembic.ini` |
 
 ### Databases - Redis {#redis-caching}
 Use one Redis or split to volatile/durable.

--- a/docs/docs/self-host/03-upgrading.mdx
+++ b/docs/docs/self-host/03-upgrading.mdx
@@ -56,7 +56,7 @@ docker compose -f hosting/docker-compose/oss/docker-compose.gh.yml pull
 Before updating services, apply any database schema changes:
 
 ```bash
-docker exec -e PYTHONPATH=/app -w /app/oss/databases/postgres/migrations/core <api-container-name> alembic -c alembic.ini upgrade head
+docker exec -e PYTHONPATH=/api -w /api/oss/databases/postgres/migrations/core <api-container-name> alembic -c alembic.ini upgrade head
 ```
 
 Replace `<api-container-name>` with your actual API container name (e.g., `agenta-oss-gh-api-1`).
@@ -133,13 +133,13 @@ docker ps | grep api
 Apply all pending migrations:
 
 ```bash
-docker exec -e PYTHONPATH=/app -w /app/oss/databases/postgres/migrations/core <api-container-name> alembic -c alembic.ini upgrade head
+docker exec -e PYTHONPATH=/api -w /api/oss/databases/postgres/migrations/core <api-container-name> alembic -c alembic.ini upgrade head
 ```
 
 **Command Breakdown:**
 - `docker exec`: Runs commands inside an existing container
-- `-e PYTHONPATH=/app`: Sets the Python path for the application
-- `-w /app/oss/databases/postgres/migrations/core`: Sets the working directory to the migrations folder
+- `-e PYTHONPATH=/api`: Sets the Python path for the application
+- `-w /api/oss/databases/postgres/migrations/core`: Sets the working directory to the migrations folder
 - `<api-container-name>`: Your actual API container name
 - `alembic -c alembic.ini upgrade head`: Runs all migrations to the latest version
 

--- a/hosting/docker-compose/ee/docker-compose.dev.yml
+++ b/hosting/docker-compose/ee/docker-compose.dev.yml
@@ -41,11 +41,11 @@ services:
         command: sh -c "pnpm dev-ee"
         # === STORAGE ============================================== #
         volumes:
-            - ../../../web/ee/src:/app/ee/src
-            - ../../../web/ee/public:/app/ee/public
-            - ../../../web/oss/src:/app/oss/src
-            - ../../../web/oss/public:/app/oss/public
-            - ../../../web/packages:/app/packages
+            - ../../../web/ee/src:/web/ee/src
+            - ../../../web/ee/public:/web/ee/public
+            - ../../../web/oss/src:/web/oss/src
+            - ../../../web/oss/public:/web/oss/public
+            - ../../../web/packages:/web/packages
         # === CONFIGURATION ======================================== #
         env_file:
             - ${ENV_FILE:-./.env.ee.dev}
@@ -77,16 +77,19 @@ services:
                 "8000",
                 "--reload",
                 "--reload-dir",
-                "/sdk",
+                "/sdks/python",
+                "--reload-dir",
+                "/clients/python",
                 "--root-path",
                 "/api",
             ]
         # === STORAGE ============================================== #
         volumes:
-            - ../../../api/ee:/app/ee
-            - ../../../api/oss:/app/oss
-            - ../../../api/entrypoints:/app/entrypoints
-            - ../../../sdk:/sdk
+            - ../../../api/ee:/api/ee
+            - ../../../api/oss:/api/oss
+            - ../../../api/entrypoints:/api/entrypoints
+            - ../../../sdks/python:/sdks/python
+            - ../../../clients/python:/clients/python
         # === CONFIGURATION ======================================== #
         env_file:
             - ${ENV_FILE:-./.env.ee.dev}
@@ -126,14 +129,15 @@ services:
         image: agenta-ee-dev-api:latest
         # === EXECUTION ============================================ #
         command: >
-            watchmedo auto-restart --directory=/app/ --pattern=*.py --recursive --
+            watchmedo auto-restart --directory=/api/ --pattern=*.py --recursive --
             python -m entrypoints.worker_evaluations
         # === STORAGE ============================================== #
         volumes:
-            - ../../../api/ee:/app/ee
-            - ../../../api/oss:/app/oss
-            - ../../../api/entrypoints:/app/entrypoints
-            - ../../../sdk:/sdk
+            - ../../../api/ee:/api/ee
+            - ../../../api/oss:/api/oss
+            - ../../../api/entrypoints:/api/entrypoints
+            - ../../../sdks/python:/sdks/python
+            - ../../../clients/python:/clients/python
         # === CONFIGURATION ======================================== #
         env_file:
             - ${ENV_FILE:-./.env.ee.dev}
@@ -162,14 +166,15 @@ services:
         image: agenta-ee-dev-api:latest
         # === EXECUTION ============================================ #
         command: >
-            watchmedo auto-restart --directory=/app/ --pattern=*.py --recursive --
+            watchmedo auto-restart --directory=/api/ --pattern=*.py --recursive --
             python -m entrypoints.worker_tracing
         # === STORAGE ============================================== #
         volumes:
-            - ../../../api/ee:/app/ee
-            - ../../../api/oss:/app/oss
-            - ../../../api/entrypoints:/app/entrypoints
-            - ../../../sdk:/sdk
+            - ../../../api/ee:/api/ee
+            - ../../../api/oss:/api/oss
+            - ../../../api/entrypoints:/api/entrypoints
+            - ../../../sdks/python:/sdks/python
+            - ../../../clients/python:/clients/python
         # === CONFIGURATION ======================================== #
         env_file:
             - ${ENV_FILE:-./.env.ee.dev}
@@ -198,14 +203,15 @@ services:
         image: agenta-ee-dev-api:latest
         # === EXECUTION ============================================ #
         command: >
-            watchmedo auto-restart --directory=/app/ --pattern=*.py --recursive --
+            watchmedo auto-restart --directory=/api/ --pattern=*.py --recursive --
             python -m entrypoints.worker_webhooks
         # === STORAGE ============================================== #
         volumes:
-            - ../../../api/ee:/app/ee
-            - ../../../api/oss:/app/oss
-            - ../../../api/entrypoints:/app/entrypoints
-            - ../../../sdk:/sdk
+            - ../../../api/ee:/api/ee
+            - ../../../api/oss:/api/oss
+            - ../../../api/entrypoints:/api/entrypoints
+            - ../../../sdks/python:/sdks/python
+            - ../../../clients/python:/clients/python
         # === CONFIGURATION ======================================== #
         env_file:
             - ${ENV_FILE:-./.env.ee.dev}
@@ -240,14 +246,15 @@ services:
         image: agenta-ee-dev-api:latest
         # === EXECUTION ============================================ #
         command: >
-            watchmedo auto-restart --directory=/app/ --pattern=*.py --recursive --
+            watchmedo auto-restart --directory=/api/ --pattern=*.py --recursive --
             python -m entrypoints.worker_events
         # === STORAGE ============================================== #
         volumes:
-            - ../../../api/ee:/app/ee
-            - ../../../api/oss:/app/oss
-            - ../../../api/entrypoints:/app/entrypoints
-            - ../../../sdk:/sdk
+            - ../../../api/ee:/api/ee
+            - ../../../api/oss:/api/oss
+            - ../../../api/entrypoints:/api/entrypoints
+            - ../../../sdks/python:/sdks/python
+            - ../../../clients/python:/clients/python
         # === CONFIGURATION ======================================== #
         env_file:
             - ${ENV_FILE:-./.env.ee.dev}
@@ -282,7 +289,7 @@ services:
         image: agenta-ee-dev-api:latest
         # === EXECUTION ============================================ #
         init: true
-        command: supercronic /app/crontab
+        command: supercronic /api/crontab
         # === STORAGE ============================================== #
         volumes:
             - ../../../api/oss/src/crons/queries.sh:/queries.sh
@@ -312,10 +319,11 @@ services:
         command: sh -c "python -m ee.databases.postgres.migrations.runner"
         # === STORAGE ============================================== #
         volumes:
-            - ../../../api/ee:/app/ee
-            - ../../../api/oss:/app/oss
-            - ../../../api/entrypoints:/app/entrypoints
-            - ../../../sdk:/sdk
+            - ../../../api/ee:/api/ee
+            - ../../../api/oss:/api/oss
+            - ../../../api/entrypoints:/api/entrypoints
+            - ../../../sdks/python:/sdks/python
+            - ../../../clients/python:/clients/python
         # === CONFIGURATION ======================================== #
         env_file:
             - ${ENV_FILE:-./.env.ee.dev}
@@ -343,14 +351,17 @@ services:
                 "8080",
                 "--reload",
                 "--reload-dir",
-                "/sdk",
+                "/sdks/python",
+                "--reload-dir",
+                "/clients/python",
                 "--root-path",
                 "/services",
             ]
         # === STORAGE ============================================== #
         volumes:
-            - ../../../services:/app
-            - ../../../sdk:/sdk
+            - ../../../services:/services
+            - ../../../sdks/python:/sdks/python
+            - ../../../clients/python:/clients/python
         # === CONFIGURATION ======================================== #
         env_file:
             - ${ENV_FILE:-./.env.ee.dev}

--- a/hosting/docker-compose/ee/docker-compose.gh.local.yml
+++ b/hosting/docker-compose/ee/docker-compose.gh.local.yml
@@ -236,7 +236,7 @@ services:
             dockerfile: ee/docker/Dockerfile.gh
         # === EXECUTION ============================================ #
         init: true
-        command: supercronic /app/crontab
+        command: supercronic /api/crontab
         # === CONFIGURATION ======================================== #
         env_file:
             - ${ENV_FILE:-./.env.ee.gh}

--- a/hosting/docker-compose/ee/docker-compose.gh.yml
+++ b/hosting/docker-compose/ee/docker-compose.gh.yml
@@ -229,7 +229,7 @@ services:
         image: ghcr.io/agenta-ai/${AGENTA_API_IMAGE_NAME:-internal-ee-agenta-api}:${AGENTA_API_IMAGE_TAG:-latest}
         # === EXECUTION ============================================ #
         init: true
-        command: supercronic /app/crontab
+        command: supercronic /api/crontab
         # === CONFIGURATION ======================================== #
         env_file:
             - ${ENV_FILE:-./.env.ee.gh}

--- a/hosting/docker-compose/ee/env.ee.dev.example
+++ b/hosting/docker-compose/ee/env.ee.dev.example
@@ -83,8 +83,8 @@ AGENTA_CRYPT_KEY=replace-me
 # Databases - Alembic (migrations)
 # ================================================================== #
 # ALEMBIC_AUTO_MIGRATIONS=true
-# ALEMBIC_CFG_PATH_CORE=/app/ee/databases/postgres/migrations/core/alembic.ini
-# ALEMBIC_CFG_PATH_TRACING=/app/ee/databases/postgres/migrations/tracing/alembic.ini
+# ALEMBIC_CFG_PATH_CORE=/api/ee/databases/postgres/migrations/core/alembic.ini
+# ALEMBIC_CFG_PATH_TRACING=/api/ee/databases/postgres/migrations/tracing/alembic.ini
 
 # ================================================================== #
 # Databases - Redis

--- a/hosting/docker-compose/ee/env.ee.gh.example
+++ b/hosting/docker-compose/ee/env.ee.gh.example
@@ -83,8 +83,8 @@ AGENTA_CRYPT_KEY=replace-me
 # Databases - Alembic (migrations)
 # ================================================================== #
 # ALEMBIC_AUTO_MIGRATIONS=true
-# ALEMBIC_CFG_PATH_CORE=/app/ee/databases/postgres/migrations/core/alembic.ini
-# ALEMBIC_CFG_PATH_TRACING=/app/ee/databases/postgres/migrations/tracing/alembic.ini
+# ALEMBIC_CFG_PATH_CORE=/api/ee/databases/postgres/migrations/core/alembic.ini
+# ALEMBIC_CFG_PATH_TRACING=/api/ee/databases/postgres/migrations/tracing/alembic.ini
 
 # ================================================================== #
 # Databases - Redis

--- a/hosting/docker-compose/oss/docker-compose.dev.yml
+++ b/hosting/docker-compose/oss/docker-compose.dev.yml
@@ -43,9 +43,9 @@ services:
         volumes:
             #
             #
-            - ../../../web/oss/src:/app/oss/src
-            - ../../../web/oss/public:/app/oss/public
-            - ../../../web/packages:/app/packages
+            - ../../../web/oss/src:/web/oss/src
+            - ../../../web/oss/public:/web/oss/public
+            - ../../../web/packages:/web/packages
         # === CONFIGURATION ======================================== #
         env_file:
             - ${ENV_FILE:-./.env.oss.dev}
@@ -77,16 +77,19 @@ services:
                 "8000",
                 "--reload",
                 "--reload-dir",
-                "/sdk",
+                "/sdks/python",
+                "--reload-dir",
+                "/clients/python",
                 "--root-path",
                 "/api",
             ]
         # === STORAGE ============================================== #
         volumes:
             #
-            - ../../../api/oss:/app/oss
-            - ../../../api/entrypoints:/app/entrypoints
-            - ../../../sdk:/sdk
+            - ../../../api/oss:/api/oss
+            - ../../../api/entrypoints:/api/entrypoints
+            - ../../../sdks/python:/sdks/python
+            - ../../../clients/python:/clients/python
         # === CONFIGURATION ======================================== #
         env_file:
             - ${ENV_FILE:-./.env.oss.dev}
@@ -126,14 +129,15 @@ services:
         image: agenta-oss-dev-api:latest
         # === EXECUTION ============================================ #
         command: >
-            watchmedo auto-restart --directory=/app/ --pattern=*.py --recursive --
+            watchmedo auto-restart --directory=/api/ --pattern=*.py --recursive --
             python -m entrypoints.worker_evaluations
         # === STORAGE ============================================== #
         volumes:
             #
-            - ../../../api/oss:/app/oss
-            - ../../../api/entrypoints:/app/entrypoints
-            - ../../../sdk:/sdk
+            - ../../../api/oss:/api/oss
+            - ../../../api/entrypoints:/api/entrypoints
+            - ../../../sdks/python:/sdks/python
+            - ../../../clients/python:/clients/python
         # === CONFIGURATION ======================================== #
         env_file:
             - ${ENV_FILE:-./.env.oss.dev}
@@ -162,14 +166,15 @@ services:
         image: agenta-oss-dev-api:latest
         # === EXECUTION ============================================ #
         command: >
-            watchmedo auto-restart --directory=/app/ --pattern=*.py --recursive --
+            watchmedo auto-restart --directory=/api/ --pattern=*.py --recursive --
             python -m entrypoints.worker_tracing
         # === STORAGE ============================================== #
         volumes:
             #
-            - ../../../api/oss:/app/oss
-            - ../../../api/entrypoints:/app/entrypoints
-            - ../../../sdk:/sdk
+            - ../../../api/oss:/api/oss
+            - ../../../api/entrypoints:/api/entrypoints
+            - ../../../sdks/python:/sdks/python
+            - ../../../clients/python:/clients/python
         # === CONFIGURATION ======================================== #
         env_file:
             - ${ENV_FILE:-./.env.oss.dev}
@@ -198,14 +203,15 @@ services:
         image: agenta-oss-dev-api:latest
         # === EXECUTION ============================================ #
         command: >
-            watchmedo auto-restart --directory=/app/ --pattern=*.py --recursive --
+            watchmedo auto-restart --directory=/api/ --pattern=*.py --recursive --
             python -m entrypoints.worker_webhooks
         # === STORAGE ============================================== #
         volumes:
             #
-            - ../../../api/oss:/app/oss
-            - ../../../api/entrypoints:/app/entrypoints
-            - ../../../sdk:/sdk
+            - ../../../api/oss:/api/oss
+            - ../../../api/entrypoints:/api/entrypoints
+            - ../../../sdks/python:/sdks/python
+            - ../../../clients/python:/clients/python
         # === CONFIGURATION ======================================== #
         env_file:
             - ${ENV_FILE:-./.env.oss.dev}
@@ -240,14 +246,15 @@ services:
         image: agenta-oss-dev-api:latest
         # === EXECUTION ============================================ #
         command: >
-            watchmedo auto-restart --directory=/app/ --pattern=*.py --recursive --
+            watchmedo auto-restart --directory=/api/ --pattern=*.py --recursive --
             python -m entrypoints.worker_events
         # === STORAGE ============================================== #
         volumes:
             #
-            - ../../../api/oss:/app/oss
-            - ../../../api/entrypoints:/app/entrypoints
-            - ../../../sdk:/sdk
+            - ../../../api/oss:/api/oss
+            - ../../../api/entrypoints:/api/entrypoints
+            - ../../../sdks/python:/sdks/python
+            - ../../../clients/python:/clients/python
         # === CONFIGURATION ======================================== #
         env_file:
             - ${ENV_FILE:-./.env.oss.dev}
@@ -282,7 +289,7 @@ services:
         image: agenta-oss-dev-api:latest
         # === EXECUTION ============================================ #
         init: true
-        command: supercronic /app/crontab
+        command: supercronic /api/crontab
         # === STORAGE ============================================== #
         volumes:
             #
@@ -312,9 +319,10 @@ services:
         # === STORAGE ============================================== #
         volumes:
             #
-            - ../../../api/oss:/app/oss
-            - ../../../api/entrypoints:/app/entrypoints
-            - ../../../sdk:/sdk
+            - ../../../api/oss:/api/oss
+            - ../../../api/entrypoints:/api/entrypoints
+            - ../../../sdks/python:/sdks/python
+            - ../../../clients/python:/clients/python
         # === CONFIGURATION ======================================== #
         env_file:
             - ${ENV_FILE:-./.env.oss.dev}
@@ -342,14 +350,17 @@ services:
                 "8080",
                 "--reload",
                 "--reload-dir",
-                "/sdk",
+                "/sdks/python",
+                "--reload-dir",
+                "/clients/python",
                 "--root-path",
                 "/services",
             ]
         # === STORAGE ============================================== #
         volumes:
-            - ../../../services:/app
-            - ../../../sdk:/sdk
+            - ../../../services:/services
+            - ../../../sdks/python:/sdks/python
+            - ../../../clients/python:/clients/python
         # === CONFIGURATION ======================================== #
         env_file:
             - ${ENV_FILE:-./.env.oss.dev}

--- a/hosting/docker-compose/oss/docker-compose.gh.local.yml
+++ b/hosting/docker-compose/oss/docker-compose.gh.local.yml
@@ -234,7 +234,7 @@ services:
             dockerfile: oss/docker/Dockerfile.gh
         # === EXECUTION ============================================ #
         init: true
-        command: supercronic /app/crontab
+        command: supercronic /api/crontab
         # === CONFIGURATION ======================================== #
         env_file:
             - ${ENV_FILE:-./.env.oss.gh}

--- a/hosting/docker-compose/oss/docker-compose.gh.ssl.yml
+++ b/hosting/docker-compose/oss/docker-compose.gh.ssl.yml
@@ -247,7 +247,7 @@ services:
             dockerfile: oss/docker/Dockerfile.gh
         # === EXECUTION ============================================ #
         init: true
-        command: supercronic /app/crontab
+        command: supercronic /api/crontab
         # === STORAGE ============================================== #
         volumes:
             - /var/run/docker.sock:/var/run/docker.sock
@@ -305,10 +305,6 @@ services:
             --log-level info
             --access-logfile -
             --error-logfile -
-        # === STORAGE ============================================== #
-        volumes:
-            - ../../../services:/app
-            - ../../../sdk:/sdk
         # === CONFIGURATION ======================================== #
         env_file:
             - ${ENV_FILE:-./.env.oss.gh}

--- a/hosting/docker-compose/oss/docker-compose.gh.yml
+++ b/hosting/docker-compose/oss/docker-compose.gh.yml
@@ -250,7 +250,7 @@ services:
         image: ghcr.io/agenta-ai/${AGENTA_API_IMAGE_NAME:-agenta-api}:${AGENTA_API_IMAGE_TAG:-latest}
         # === EXECUTION ============================================ #
         init: true
-        command: supercronic /app/crontab
+        command: supercronic /api/crontab
         # === CONFIGURATION ======================================== #
         env_file:
             - ${ENV_FILE:-./.env.oss.gh}

--- a/hosting/docker-compose/oss/env.oss.dev.example
+++ b/hosting/docker-compose/oss/env.oss.dev.example
@@ -83,8 +83,8 @@ AGENTA_SERVICES_URL=http://localhost/services
 # Databases - Alembic (migrations)
 # ================================================================== #
 # ALEMBIC_AUTO_MIGRATIONS=true
-# ALEMBIC_CFG_PATH_CORE=/app/oss/databases/postgres/migrations/core/alembic.ini
-# ALEMBIC_CFG_PATH_TRACING=/app/oss/databases/postgres/migrations/tracing/alembic.ini
+# ALEMBIC_CFG_PATH_CORE=/api/oss/databases/postgres/migrations/core/alembic.ini
+# ALEMBIC_CFG_PATH_TRACING=/api/oss/databases/postgres/migrations/tracing/alembic.ini
 
 # ================================================================== #
 # Databases - Redis

--- a/hosting/docker-compose/oss/env.oss.gh.example
+++ b/hosting/docker-compose/oss/env.oss.gh.example
@@ -88,8 +88,8 @@ DOCKER_NETWORK_MODE=bridge
 # Databases - Alembic (migrations)
 # ================================================================== #
 # ALEMBIC_AUTO_MIGRATIONS=true
-# ALEMBIC_CFG_PATH_CORE=/app/oss/databases/postgres/migrations/core/alembic.ini
-# ALEMBIC_CFG_PATH_TRACING=/app/oss/databases/postgres/migrations/tracing/alembic.ini
+# ALEMBIC_CFG_PATH_CORE=/api/oss/databases/postgres/migrations/core/alembic.ini
+# ALEMBIC_CFG_PATH_TRACING=/api/oss/databases/postgres/migrations/tracing/alembic.ini
 
 # ================================================================== #
 # Databases - Redis

--- a/hosting/docker-compose/run.sh
+++ b/hosting/docker-compose/run.sh
@@ -309,11 +309,13 @@ fi
 # so that Dockerfile.gh can COPY it (Docker BuildKit doesn't follow symlinks outside context)
 # This is necessary even without --build because docker compose up will auto-build missing images
 if [[ "$STAGE" == "gh.local" ]]; then
-    echo "Copying local SDK into build contexts..."
-    rm -rf api/sdk services/sdk
-    cp -r sdk api/sdk
-    cp -r sdk services/sdk
-    cleanup_sdk_copies() { rm -rf api/sdk services/sdk; }
+    echo "Copying local SDK and client into build contexts..."
+    rm -rf api/sdks services/sdks api/clients services/clients
+    cp -r sdks api/sdks
+    cp -r sdks services/sdks
+    cp -r clients api/clients
+    cp -r clients services/clients
+    cleanup_sdk_copies() { rm -rf api/sdks services/sdks api/clients services/clients; }
     trap cleanup_sdk_copies EXIT
 fi
 

--- a/hosting/helm/agenta-oss/templates/_helpers.tpl
+++ b/hosting/helm/agenta-oss/templates/_helpers.tpl
@@ -153,17 +153,17 @@ oss.databases.postgres.migrations.runner
 
 {{- define "agenta.alembicCfgPathCore" -}}
 {{- if eq (include "agenta.edition" .) "ee" -}}
-/app/ee/databases/postgres/migrations/core/alembic.ini
+/api/ee/databases/postgres/migrations/core/alembic.ini
 {{- else -}}
-/app/oss/databases/postgres/migrations/core/alembic.ini
+/api/oss/databases/postgres/migrations/core/alembic.ini
 {{- end -}}
 {{- end }}
 
 {{- define "agenta.alembicCfgPathTracing" -}}
 {{- if eq (include "agenta.edition" .) "ee" -}}
-/app/ee/databases/postgres/migrations/tracing/alembic.ini
+/api/ee/databases/postgres/migrations/tracing/alembic.ini
 {{- else -}}
-/app/oss/databases/postgres/migrations/tracing/alembic.ini
+/api/oss/databases/postgres/migrations/tracing/alembic.ini
 {{- end -}}
 {{- end }}
 

--- a/hosting/helm/agenta-oss/templates/cron-deployment.yaml
+++ b/hosting/helm/agenta-oss/templates/cron-deployment.yaml
@@ -32,7 +32,7 @@ spec:
           securityContext:
             {{- toYaml . | nindent 12 }}
           {{- end }}
-          command: ["/usr/local/bin/supercronic", "/app/crontab"]
+          command: ["/usr/local/bin/supercronic", "/api/crontab"]
           env:
             {{- include "agenta.commonEnv" . | nindent 12 }}
             {{- range $key, $val := .Values.cron.env }}

--- a/hosting/helm/agenta-oss/templates/web-deployment.yaml
+++ b/hosting/helm/agenta-oss/templates/web-deployment.yaml
@@ -32,7 +32,7 @@ spec:
           securityContext:
             {{- toYaml . | nindent 12 }}
           {{- end }}
-          command: ["/app/entrypoint.sh"]
+          command: ["/web/entrypoint.sh"]
           args: ["node", {{ include "agenta.webServerPath" . | quote }}]
           ports:
             - name: http

--- a/hosting/railway/oss/alembic/Dockerfile
+++ b/hosting/railway/oss/alembic/Dockerfile
@@ -2,8 +2,8 @@
 FROM ghcr.io/agenta-ai/agenta-api:latest
 
 ENV AGENTA_LICENSE=oss
-ENV ALEMBIC_CFG_PATH_CORE=/app/oss/databases/postgres/migrations/core/alembic.ini
-ENV ALEMBIC_CFG_PATH_TRACING=/app/oss/databases/postgres/migrations/tracing/alembic.ini
+ENV ALEMBIC_CFG_PATH_CORE=/api/oss/databases/postgres/migrations/core/alembic.ini
+ENV ALEMBIC_CFG_PATH_TRACING=/api/oss/databases/postgres/migrations/tracing/alembic.ini
 
 COPY create_databases.py /tmp/create_databases.py
 

--- a/hosting/railway/oss/cron/Dockerfile
+++ b/hosting/railway/oss/cron/Dockerfile
@@ -7,8 +7,8 @@ ENV REDIS_URI=redis://redis.railway.internal:6379/0
 ENV REDIS_URI_VOLATILE=redis://redis.railway.internal:6379/0
 ENV REDIS_URI_DURABLE=redis://redis.railway.internal:6379/0
 ENV SUPERTOKENS_CONNECTION_URI=http://supertokens.railway.internal:3567
-ENV ALEMBIC_CFG_PATH_CORE=/app/oss/databases/postgres/migrations/core/alembic.ini
-ENV ALEMBIC_CFG_PATH_TRACING=/app/oss/databases/postgres/migrations/tracing/alembic.ini
+ENV ALEMBIC_CFG_PATH_CORE=/api/oss/databases/postgres/migrations/core/alembic.ini
+ENV ALEMBIC_CFG_PATH_TRACING=/api/oss/databases/postgres/migrations/tracing/alembic.ini
 
 # Run scheduled maintenance jobs via supercronic (non-root compatible)
-CMD ["/usr/local/bin/supercronic", "/app/crontab"]
+CMD ["/usr/local/bin/supercronic", "/api/crontab"]

--- a/hosting/railway/oss/scripts/build-and-push-images.sh
+++ b/hosting/railway/oss/scripts/build-and-push-images.sh
@@ -20,22 +20,36 @@ if ! command -v docker >/dev/null 2>&1; then
     exit 1
 fi
 
-SDK_SOURCE_DIR="$ROOT_DIR/sdk"
-API_SDK_DIR="$ROOT_DIR/api/sdk"
-SERVICES_SDK_DIR="$ROOT_DIR/services/sdk"
+SDKS_SOURCE_DIR="$ROOT_DIR/sdks"
+API_SDKS_DIR="$ROOT_DIR/api/sdks"
+SERVICES_SDKS_DIR="$ROOT_DIR/services/sdks"
 
-if [ ! -d "$SDK_SOURCE_DIR" ]; then
-    printf "Missing SDK directory: %s\n" "$SDK_SOURCE_DIR" >&2
+CLIENTS_SOURCE_DIR="$ROOT_DIR/clients"
+API_CLIENTS_DIR="$ROOT_DIR/api/clients"
+SERVICES_CLIENTS_DIR="$ROOT_DIR/services/clients"
+
+if [ ! -d "$SDKS_SOURCE_DIR" ]; then
+    printf "Missing SDKs directory: %s\n" "$SDKS_SOURCE_DIR" >&2
     exit 1
 fi
 
-if [ -e "$API_SDK_DIR" ] || [ -e "$SERVICES_SDK_DIR" ]; then
-    printf "Refusing to overwrite existing sdk build directories in api/ or services/.\n" >&2
+if [ ! -d "$CLIENTS_SOURCE_DIR" ]; then
+    printf "Missing clients directory: %s\n" "$CLIENTS_SOURCE_DIR" >&2
+    exit 1
+fi
+
+if [ -e "$API_SDKS_DIR" ] || [ -e "$SERVICES_SDKS_DIR" ]; then
+    printf "Refusing to overwrite existing sdks build directories in api/ or services/.\n" >&2
+    exit 1
+fi
+
+if [ -e "$API_CLIENTS_DIR" ] || [ -e "$SERVICES_CLIENTS_DIR" ]; then
+    printf "Refusing to overwrite existing clients build directories in api/ or services/.\n" >&2
     exit 1
 fi
 
 cleanup_sdk_dirs() {
-    rm -rf "$API_SDK_DIR" "$SERVICES_SDK_DIR"
+    rm -rf "$API_SDKS_DIR" "$SERVICES_SDKS_DIR" "$API_CLIENTS_DIR" "$SERVICES_CLIENTS_DIR"
 }
 
 trap cleanup_sdk_dirs EXIT
@@ -46,8 +60,10 @@ SERVICES_IMAGE="${REGISTRY}/${NAMESPACE}/agenta-services:${TAG}"
 
 printf "Building local images with tag '%s'\n" "$TAG"
 
-cp -R "$SDK_SOURCE_DIR" "$API_SDK_DIR"
-cp -R "$SDK_SOURCE_DIR" "$SERVICES_SDK_DIR"
+cp -R "$SDKS_SOURCE_DIR" "$API_SDKS_DIR"
+cp -R "$SDKS_SOURCE_DIR" "$SERVICES_SDKS_DIR"
+cp -R "$CLIENTS_SOURCE_DIR" "$API_CLIENTS_DIR"
+cp -R "$CLIENTS_SOURCE_DIR" "$SERVICES_CLIENTS_DIR"
 
 docker build -t "$API_IMAGE" -f "$ROOT_DIR/api/oss/docker/Dockerfile.gh" "$ROOT_DIR/api"
 docker build -t "$WEB_IMAGE" -f "$ROOT_DIR/web/oss/docker/Dockerfile.gh" "$ROOT_DIR/web"

--- a/hosting/railway/oss/scripts/deploy-from-images.sh
+++ b/hosting/railway/oss/scripts/deploy-from-images.sh
@@ -133,7 +133,7 @@ FROM ${AGENTA_WEB_IMAGE}
 ENV HOSTNAME=0.0.0.0
 ENV AGENTA_LICENSE=oss
 
-CMD ["sh", "-lc", "/app/entrypoint.sh node /app/oss/server.js"]
+CMD ["sh", "-lc", "/web/entrypoint.sh node /web/oss/server.js"]
 EOF
 }
 
@@ -145,8 +145,8 @@ render_alembic_wrapper() {
 FROM ${AGENTA_API_IMAGE}
 
 ENV AGENTA_LICENSE=oss
-ENV ALEMBIC_CFG_PATH_CORE=/app/oss/databases/postgres/migrations/core/alembic.ini
-ENV ALEMBIC_CFG_PATH_TRACING=/app/oss/databases/postgres/migrations/tracing/alembic.ini
+ENV ALEMBIC_CFG_PATH_CORE=/api/oss/databases/postgres/migrations/core/alembic.ini
+ENV ALEMBIC_CFG_PATH_TRACING=/api/oss/databases/postgres/migrations/tracing/alembic.ini
 
 COPY create_databases.py /tmp/create_databases.py
 CMD ["sh", "-c", "/opt/venv/bin/python /tmp/create_databases.py && /opt/venv/bin/python -m oss.databases.postgres.migrations.runner"]
@@ -179,7 +179,7 @@ render_api_like_wrapper worker-tracing '["python", "-m", "entrypoints.worker_tra
 render_api_like_wrapper worker-evaluations '["python", "-m", "entrypoints.worker_evaluations"]'
 render_api_like_wrapper worker-webhooks '["python", "-m", "entrypoints.worker_webhooks"]'
 render_api_like_wrapper worker-events '["python", "-m", "entrypoints.worker_events"]'
-render_api_like_wrapper cron '["/usr/local/bin/supercronic", "/app/crontab"]'
+render_api_like_wrapper cron '["/usr/local/bin/supercronic", "/api/crontab"]'
 
 export RAILWAY_PROJECT_NAME="$PROJECT_NAME"
 export RAILWAY_ENVIRONMENT_NAME="$ENV_NAME"

--- a/hosting/railway/oss/web/Dockerfile
+++ b/hosting/railway/oss/web/Dockerfile
@@ -4,4 +4,4 @@ FROM ghcr.io/agenta-ai/agenta-web:latest
 ENV HOSTNAME="0.0.0.0"
 ENV AGENTA_LICENSE=oss
 
-CMD ["sh", "-c", "/app/entrypoint.sh node /app/oss/server.js"]
+CMD ["sh", "-c", "/web/entrypoint.sh node /web/oss/server.js"]

--- a/hosting/railway/oss/web/railway.json
+++ b/hosting/railway/oss/web/railway.json
@@ -1,6 +1,6 @@
 {
   "$schema": "https://railway.com/railway.schema.json",
   "deploy": {
-    "startCommand": "/app/entrypoint.sh node /app/oss/server.js"
+    "startCommand": "/web/entrypoint.sh node /web/oss/server.js"
   }
 }

--- a/hosting/railway/oss/worker-evaluations/Dockerfile
+++ b/hosting/railway/oss/worker-evaluations/Dockerfile
@@ -7,8 +7,8 @@ ENV REDIS_URI=redis://redis.railway.internal:6379/0
 ENV REDIS_URI_VOLATILE=redis://redis.railway.internal:6379/0
 ENV REDIS_URI_DURABLE=redis://redis.railway.internal:6379/0
 ENV SUPERTOKENS_CONNECTION_URI=http://supertokens.railway.internal:3567
-ENV ALEMBIC_CFG_PATH_CORE=/app/oss/databases/postgres/migrations/core/alembic.ini
-ENV ALEMBIC_CFG_PATH_TRACING=/app/oss/databases/postgres/migrations/tracing/alembic.ini
+ENV ALEMBIC_CFG_PATH_CORE=/api/oss/databases/postgres/migrations/core/alembic.ini
+ENV ALEMBIC_CFG_PATH_TRACING=/api/oss/databases/postgres/migrations/tracing/alembic.ini
 
 # Background Taskiq worker for evaluation jobs
 CMD ["python", "-m", "entrypoints.worker_evaluations"]

--- a/hosting/railway/oss/worker-events/Dockerfile
+++ b/hosting/railway/oss/worker-events/Dockerfile
@@ -7,8 +7,8 @@ ENV REDIS_URI=redis://redis.railway.internal:6379/0
 ENV REDIS_URI_VOLATILE=redis://redis.railway.internal:6379/0
 ENV REDIS_URI_DURABLE=redis://redis.railway.internal:6379/0
 ENV SUPERTOKENS_CONNECTION_URI=http://supertokens.railway.internal:3567
-ENV ALEMBIC_CFG_PATH_CORE=/app/oss/databases/postgres/migrations/core/alembic.ini
-ENV ALEMBIC_CFG_PATH_TRACING=/app/oss/databases/postgres/migrations/tracing/alembic.ini
+ENV ALEMBIC_CFG_PATH_CORE=/api/oss/databases/postgres/migrations/core/alembic.ini
+ENV ALEMBIC_CFG_PATH_TRACING=/api/oss/databases/postgres/migrations/tracing/alembic.ini
 
 # Background worker for asynchronous event stream processing
 CMD ["python", "-m", "entrypoints.worker_events"]

--- a/hosting/railway/oss/worker-tracing/Dockerfile
+++ b/hosting/railway/oss/worker-tracing/Dockerfile
@@ -7,8 +7,8 @@ ENV REDIS_URI=redis://redis.railway.internal:6379/0
 ENV REDIS_URI_VOLATILE=redis://redis.railway.internal:6379/0
 ENV REDIS_URI_DURABLE=redis://redis.railway.internal:6379/0
 ENV SUPERTOKENS_CONNECTION_URI=http://supertokens.railway.internal:3567
-ENV ALEMBIC_CFG_PATH_CORE=/app/oss/databases/postgres/migrations/core/alembic.ini
-ENV ALEMBIC_CFG_PATH_TRACING=/app/oss/databases/postgres/migrations/tracing/alembic.ini
+ENV ALEMBIC_CFG_PATH_CORE=/api/oss/databases/postgres/migrations/core/alembic.ini
+ENV ALEMBIC_CFG_PATH_TRACING=/api/oss/databases/postgres/migrations/tracing/alembic.ini
 
 # OTLP tracing worker consumes Redis stream and persists spans to Postgres
 CMD ["python", "-m", "entrypoints.worker_tracing"]

--- a/hosting/railway/oss/worker-webhooks/Dockerfile
+++ b/hosting/railway/oss/worker-webhooks/Dockerfile
@@ -7,8 +7,8 @@ ENV REDIS_URI=redis://redis.railway.internal:6379/0
 ENV REDIS_URI_VOLATILE=redis://redis.railway.internal:6379/0
 ENV REDIS_URI_DURABLE=redis://redis.railway.internal:6379/0
 ENV SUPERTOKENS_CONNECTION_URI=http://supertokens.railway.internal:3567
-ENV ALEMBIC_CFG_PATH_CORE=/app/oss/databases/postgres/migrations/core/alembic.ini
-ENV ALEMBIC_CFG_PATH_TRACING=/app/oss/databases/postgres/migrations/tracing/alembic.ini
+ENV ALEMBIC_CFG_PATH_CORE=/api/oss/databases/postgres/migrations/core/alembic.ini
+ENV ALEMBIC_CFG_PATH_TRACING=/api/oss/databases/postgres/migrations/tracing/alembic.ini
 
 # Background worker that dispatches webhook deliveries
 CMD ["python", "-m", "entrypoints.worker_webhooks"]

--- a/services/ee/docker/Dockerfile.dev
+++ b/services/ee/docker/Dockerfile.dev
@@ -1,11 +1,11 @@
 FROM python:3.11-slim-bookworm
 
-WORKDIR /app
+WORKDIR /services
 
 RUN pip install --upgrade pip \
     && pip install poetry
 
-COPY ./pyproject.toml /app/
+COPY ./pyproject.toml /services/
 
 RUN poetry config virtualenvs.create false \
     && poetry install --no-interaction --no-ansi
@@ -13,10 +13,13 @@ RUN poetry config virtualenvs.create false \
 RUN groupadd --gid 10001 agenta && \
     useradd --uid 10001 --gid 10001 --shell /bin/false --create-home agenta
 
-COPY --chown=agenta:agenta ./oss /app/oss/
-COPY --chown=agenta:agenta ./entrypoints /app/entrypoints/
+COPY --chown=agenta:agenta ./oss /services/oss/
+COPY --chown=agenta:agenta ./entrypoints /services/entrypoints/
 
-ENV PYTHONPATH=/sdk:$PYTHONPATH
+ENV PYTHONPATH=/sdks/python:/clients/python:$PYTHONPATH
+
+RUN echo "/clients/python" > /usr/local/lib/python3.11/site-packages/agenta_client_path.pth \
+    && echo "/sdks/python" >> /usr/local/lib/python3.11/site-packages/agenta_client_path.pth
 
 USER 10001
 

--- a/services/ee/docker/Dockerfile.gh
+++ b/services/ee/docker/Dockerfile.gh
@@ -2,7 +2,7 @@ FROM python:3.11-slim-bookworm AS builder
 
 ARG POETRY_VERSION=2.3.1
 
-WORKDIR /app
+WORKDIR /services
 
 ENV PIP_DISABLE_PIP_VERSION_CHECK=1 \
     PIP_NO_CACHE_DIR=0 \
@@ -13,7 +13,7 @@ ENV PIP_DISABLE_PIP_VERSION_CHECK=1 \
 RUN --mount=type=cache,id=pip-services,target=/root/.cache/pip \
     pip install --timeout=300 "poetry==${POETRY_VERSION}" "poetry-plugin-export"
 
-COPY ./pyproject.toml ./poetry.lock* /app/
+COPY ./pyproject.toml ./poetry.lock* /services/
 
 # Create clean venv, install app deps, strip heavy unused deps
 # Merged into one layer so stripped files don't persist in a previous layer.
@@ -38,20 +38,20 @@ RUN --mount=type=cache,id=pip-services,target=/root/.cache/pip \
     && find /opt/venv -type d -name __pycache__ -exec rm -rf {} + 2>/dev/null; true
 
 # Copy and install SDK first (changes less frequently than app code)
-RUN mkdir -p /app/sdk
-COPY ./sd[k] /app/sdk/
+COPY ./sdks/python /sdks/python/
+COPY ./clients/python /clients/python/
 
 RUN --mount=type=cache,id=pip-services,target=/root/.cache/pip \
-    if [ -f /app/sdk/pyproject.toml ]; then \
+    if [ -f /sdks/python/pyproject.toml ]; then \
         . /opt/venv/bin/activate && \
         pip install pip && \
-        pip install --editable /app/sdk && \
+        pip install --editable /sdks/python && \
         (pip uninstall -y pip 2>/dev/null || true); \
     fi
 
 # Copy app code last (changes more frequently)
-COPY ./oss /app/oss/
-COPY ./entrypoints /app/entrypoints/
+COPY ./oss /services/oss/
+COPY ./entrypoints /services/entrypoints/
 
 
 FROM python:3.11-slim-bookworm AS runner
@@ -60,20 +60,21 @@ ARG BUILD_DATE
 ARG VCS_REF
 ARG VERSION=0.0.0
 
-WORKDIR /app
+WORKDIR /services
 
 ENV PYTHONDONTWRITEBYTECODE=1 \
     PYTHONUNBUFFERED=1 \
-    PYTHONPATH=/app:/app/sdk \
+    PYTHONPATH=/services:/sdks/python:/clients/python \
     PATH="/opt/venv/bin:${PATH}"
 
 RUN groupadd --gid 10001 agenta && \
     useradd --uid 10001 --gid 10001 --shell /bin/false --create-home agenta
 
 COPY --from=builder /opt/venv /opt/venv
-COPY --chown=agenta:agenta --from=builder /app/oss /app/oss
-COPY --chown=agenta:agenta --from=builder /app/entrypoints /app/entrypoints
-COPY --chown=agenta:agenta --from=builder /app/sdk /app/sdk
+COPY --chown=agenta:agenta --from=builder /services/oss /services/oss
+COPY --chown=agenta:agenta --from=builder /services/entrypoints /services/entrypoints
+COPY --chown=agenta:agenta --from=builder /sdks/python /sdks/python
+COPY --chown=agenta:agenta --from=builder /clients/python /clients/python
 
 USER 10001
 

--- a/services/oss/docker/Dockerfile.dev
+++ b/services/oss/docker/Dockerfile.dev
@@ -1,11 +1,11 @@
 FROM python:3.11-slim-bookworm
 
-WORKDIR /app
+WORKDIR /services
 
 RUN pip install --upgrade pip \
     && pip install poetry
 
-COPY ./pyproject.toml /app/
+COPY ./pyproject.toml /services/
 
 RUN poetry config virtualenvs.create false \
     && poetry install --no-interaction --no-ansi
@@ -13,10 +13,13 @@ RUN poetry config virtualenvs.create false \
 RUN groupadd --gid 10001 agenta && \
     useradd --uid 10001 --gid 10001 --shell /bin/false --create-home agenta
 
-COPY --chown=agenta:agenta ./oss /app/oss/
-COPY --chown=agenta:agenta ./entrypoints /app/entrypoints/
+COPY --chown=agenta:agenta ./oss /services/oss/
+COPY --chown=agenta:agenta ./entrypoints /services/entrypoints/
 
-ENV PYTHONPATH=/sdk:$PYTHONPATH
+ENV PYTHONPATH=/sdks/python:/clients/python:$PYTHONPATH
+
+RUN echo "/clients/python" > /usr/local/lib/python3.11/site-packages/agenta_client_path.pth \
+    && echo "/sdks/python" >> /usr/local/lib/python3.11/site-packages/agenta_client_path.pth
 
 USER 10001
 

--- a/services/oss/docker/Dockerfile.gh
+++ b/services/oss/docker/Dockerfile.gh
@@ -2,7 +2,7 @@ FROM python:3.11-slim-bookworm AS builder
 
 ARG POETRY_VERSION=2.3.1
 
-WORKDIR /app
+WORKDIR /services
 
 ENV PIP_DISABLE_PIP_VERSION_CHECK=1 \
     PIP_NO_CACHE_DIR=0 \
@@ -13,7 +13,7 @@ ENV PIP_DISABLE_PIP_VERSION_CHECK=1 \
 RUN --mount=type=cache,id=pip-services,target=/root/.cache/pip \
     pip install --timeout=300 "poetry==${POETRY_VERSION}" "poetry-plugin-export"
 
-COPY ./pyproject.toml ./poetry.lock* /app/
+COPY ./pyproject.toml ./poetry.lock* /services/
 
 # Create clean venv, install app deps, strip heavy unused deps
 # Merged into one layer so stripped files don't persist in a previous layer.
@@ -38,20 +38,20 @@ RUN --mount=type=cache,id=pip-services,target=/root/.cache/pip \
     && find /opt/venv -type d -name __pycache__ -exec rm -rf {} + 2>/dev/null; true
 
 # Copy and install SDK first (changes less frequently than app code)
-RUN mkdir -p /app/sdk
-COPY ./sd[k] /app/sdk/
+COPY ./sdks/python /sdks/python/
+COPY ./clients/python /clients/python/
 
 RUN --mount=type=cache,id=pip-services,target=/root/.cache/pip \
-    if [ -f /app/sdk/pyproject.toml ]; then \
+    if [ -f /sdks/python/pyproject.toml ]; then \
         . /opt/venv/bin/activate && \
         pip install pip && \
-        pip install --editable /app/sdk && \
+        pip install --editable /sdks/python && \
         (pip uninstall -y pip 2>/dev/null || true); \
     fi
 
 # Copy app code last (changes more frequently)
-COPY ./oss /app/oss/
-COPY ./entrypoints /app/entrypoints/
+COPY ./oss /services/oss/
+COPY ./entrypoints /services/entrypoints/
 
 
 FROM python:3.11-slim-bookworm AS runner
@@ -60,20 +60,21 @@ ARG BUILD_DATE
 ARG VCS_REF
 ARG VERSION=0.0.0
 
-WORKDIR /app
+WORKDIR /services
 
 ENV PYTHONDONTWRITEBYTECODE=1 \
     PYTHONUNBUFFERED=1 \
-    PYTHONPATH=/app:/app/sdk \
+    PYTHONPATH=/services:/sdks/python:/clients/python \
     PATH="/opt/venv/bin:${PATH}"
 
 RUN groupadd --gid 10001 agenta && \
     useradd --uid 10001 --gid 10001 --shell /bin/false --create-home agenta
 
 COPY --from=builder /opt/venv /opt/venv
-COPY --chown=agenta:agenta --from=builder /app/oss /app/oss
-COPY --chown=agenta:agenta --from=builder /app/entrypoints /app/entrypoints
-COPY --chown=agenta:agenta --from=builder /app/sdk /app/sdk
+COPY --chown=agenta:agenta --from=builder /services/oss /services/oss
+COPY --chown=agenta:agenta --from=builder /services/entrypoints /services/entrypoints
+COPY --chown=agenta:agenta --from=builder /sdks/python /sdks/python
+COPY --chown=agenta:agenta --from=builder /clients/python /clients/python
 
 USER 10001
 

--- a/web/ee/docker/Dockerfile.dev
+++ b/web/ee/docker/Dockerfile.dev
@@ -2,7 +2,7 @@ FROM node:20.18-slim
 
 ENV TURBO_TELEMETRY_DISABLED=1
 
-WORKDIR /app
+WORKDIR /web
 
 # Install jq for JSON parsing
 RUN apt-get update && apt-get install -y jq
@@ -38,11 +38,11 @@ COPY tests/package.json ./tests/
 
 COPY ./pnpm-workspace.yaml ./turbo.json ./
 
-COPY ./entrypoint.sh /app/entrypoint.sh   
+COPY ./entrypoint.sh /web/entrypoint.sh
 
 RUN groupadd --gid 10001 agenta && \
     useradd --uid 10001 --gid 10001 --shell /bin/false --create-home agenta && \
-    chown -R agenta:agenta /app
+    chown -R agenta:agenta /web
 
 USER 10001
 

--- a/web/ee/docker/Dockerfile.gh
+++ b/web/ee/docker/Dockerfile.gh
@@ -1,7 +1,7 @@
 # syntax=docker/dockerfile:1.20
 FROM node:20.18.0-slim AS base
 
-WORKDIR /app
+WORKDIR /web
 
 ENV NEXT_TELEMETRY_DISABLED=1 \
     TURBO_TELEMETRY_DISABLED=1 \
@@ -21,7 +21,7 @@ RUN PNPM_VERSION=$(node -p "require('./package.json').packageManager.split('@')[
 FROM base AS builder
 
 ENV NODE_OPTIONS="--max_old_space_size=4096"
-ENV TURBO_CACHE_DIR="/app/.turbo"
+ENV TURBO_CACHE_DIR="/web/.turbo"
 
 COPY docker/run-turbo-build.sh /usr/local/bin/run-turbo-build.sh
 
@@ -43,9 +43,9 @@ COPY packages/ ./packages/
 COPY oss/ ./oss/
 COPY ee/ ./ee/
 
-RUN --mount=type=cache,id=turbo-ee,target=/app/.turbo \
-    --mount=type=cache,id=nextjs-ee,target=/app/ee/.next/cache \
-    --mount=type=cache,id=nextjs-oss,target=/app/oss/.next/cache \
+RUN --mount=type=cache,id=turbo-ee,target=/web/.turbo \
+    --mount=type=cache,id=nextjs-ee,target=/web/ee/.next/cache \
+    --mount=type=cache,id=nextjs-oss,target=/web/oss/.next/cache \
     --mount=type=secret,id=turbo_team,required=false \
     --mount=type=secret,id=turbo_token,required=false \
     /usr/local/bin/run-turbo-build.sh @agenta/ee
@@ -57,7 +57,7 @@ ARG BUILD_DATE
 ARG VCS_REF
 ARG VERSION=0.0.0
 
-WORKDIR /app
+WORKDIR /web
 
 ENV NEXT_TELEMETRY_DISABLED=1 \
     NODE_ENV=production
@@ -65,11 +65,11 @@ ENV NEXT_TELEMETRY_DISABLED=1 \
 RUN groupadd --gid 10001 agenta && \
     useradd --uid 10001 --gid 10001 --shell /bin/false --create-home agenta
 
-COPY --chown=agenta:agenta --from=builder /app/ee/.next/standalone /app
-COPY --chown=agenta:agenta --from=builder /app/ee/.next/static /app/ee/.next/static
-COPY --chown=agenta:agenta --from=builder /app/ee/public /app/ee/public
-COPY --chown=agenta:agenta --from=builder /app/oss/public /app/oss/public
-COPY --chown=agenta:agenta ./entrypoint.sh /app/entrypoint.sh
+COPY --chown=agenta:agenta --from=builder /web/ee/.next/standalone /web
+COPY --chown=agenta:agenta --from=builder /web/ee/.next/static /web/ee/.next/static
+COPY --chown=agenta:agenta --from=builder /web/ee/public /web/ee/public
+COPY --chown=agenta:agenta --from=builder /web/oss/public /web/oss/public
+COPY --chown=agenta:agenta ./entrypoint.sh /web/entrypoint.sh
 
 USER 10001
 
@@ -79,5 +79,5 @@ LABEL org.opencontainers.image.title="agenta-web-ee" \
     org.opencontainers.image.revision="${VCS_REF}" \
     org.opencontainers.image.created="${BUILD_DATE}"
 
-ENTRYPOINT ["/app/entrypoint.sh"]
+ENTRYPOINT ["/web/entrypoint.sh"]
 EXPOSE 3000

--- a/web/entrypoint.sh
+++ b/web/entrypoint.sh
@@ -7,7 +7,7 @@ if [ "$AGENTA_LICENSE" != "ee" ]; then
 fi
 
 if [ "$ENTRYPOINT_DIR" != "." ]; then
-  ENTRYPOINT_DIR="/app"
+  ENTRYPOINT_DIR="/web"
 fi
 
 # Infer AGENTA_SENDGRID_ENABLED from SENDGRID_API_KEY and sender address

--- a/web/oss/docker/Dockerfile.dev
+++ b/web/oss/docker/Dockerfile.dev
@@ -2,7 +2,7 @@ FROM node:20.18-slim
 
 ENV TURBO_TELEMETRY_DISABLED=1
 
-WORKDIR /app
+WORKDIR /web
 
 # Install jq for JSON parsing
 RUN apt-get update && apt-get install -y jq
@@ -10,7 +10,7 @@ RUN apt-get update && apt-get install -y jq
 # Install dependencies based on the preferred package manager
 COPY package.json yarn.lock* package-lock.json* pnpm-lock.yaml* .npmrc* ./
 COPY patches/ ./patches/
-COPY ./entrypoint.sh /app/entrypoint.sh   
+COPY ./entrypoint.sh /web/entrypoint.sh
 
 # Extract PNPM version and install it
 RUN PNPM_VERSION=$(cat package.json | jq -r '.packageManager | split("@")[1]') && \
@@ -39,7 +39,7 @@ COPY tests/package.json ./tests/
 COPY ./pnpm-workspace.yaml ./turbo.json ./
 RUN groupadd --gid 10001 agenta && \
     useradd --uid 10001 --gid 10001 --shell /bin/false --create-home agenta && \
-    chown -R agenta:agenta /app
+    chown -R agenta:agenta /web
 
 USER 10001
 

--- a/web/oss/docker/Dockerfile.gh
+++ b/web/oss/docker/Dockerfile.gh
@@ -1,7 +1,7 @@
 # syntax=docker/dockerfile:1.20
 FROM node:20.18.0-slim AS base
 
-WORKDIR /app
+WORKDIR /web
 
 ENV NEXT_TELEMETRY_DISABLED=1 \
     TURBO_TELEMETRY_DISABLED=1 \
@@ -21,7 +21,7 @@ RUN PNPM_VERSION=$(node -p "require('./package.json').packageManager.split('@')[
 FROM base AS builder
 
 ENV NODE_OPTIONS="--max_old_space_size=4096"
-ENV TURBO_CACHE_DIR="/app/.turbo"
+ENV TURBO_CACHE_DIR="/web/.turbo"
 
 COPY docker/run-turbo-build.sh /usr/local/bin/run-turbo-build.sh
 
@@ -41,8 +41,8 @@ RUN --mount=type=cache,id=pnpm,target=/pnpm/store \
 COPY packages/ ./packages/
 COPY oss/ ./oss/
 
-RUN --mount=type=cache,id=turbo-oss,target=/app/.turbo \
-    --mount=type=cache,id=nextjs-oss,target=/app/oss/.next/cache \
+RUN --mount=type=cache,id=turbo-oss,target=/web/.turbo \
+    --mount=type=cache,id=nextjs-oss,target=/web/oss/.next/cache \
     --mount=type=secret,id=turbo_team,required=false \
     --mount=type=secret,id=turbo_token,required=false \
     /usr/local/bin/run-turbo-build.sh @agenta/oss
@@ -54,7 +54,7 @@ ARG BUILD_DATE
 ARG VCS_REF
 ARG VERSION=0.0.0
 
-WORKDIR /app
+WORKDIR /web
 
 ENV NEXT_TELEMETRY_DISABLED=1 \
     NODE_ENV=production
@@ -62,10 +62,10 @@ ENV NEXT_TELEMETRY_DISABLED=1 \
 RUN groupadd --gid 10001 agenta && \
     useradd --uid 10001 --gid 10001 --shell /bin/false --create-home agenta
 
-COPY --chown=agenta:agenta --from=builder /app/oss/.next/standalone /app
-COPY --chown=agenta:agenta --from=builder /app/oss/.next/static /app/oss/.next/static
-COPY --chown=agenta:agenta --from=builder /app/oss/public /app/oss/public
-COPY --chown=agenta:agenta ./entrypoint.sh /app/entrypoint.sh
+COPY --chown=agenta:agenta --from=builder /web/oss/.next/standalone /web
+COPY --chown=agenta:agenta --from=builder /web/oss/.next/static /web/oss/.next/static
+COPY --chown=agenta:agenta --from=builder /web/oss/public /web/oss/public
+COPY --chown=agenta:agenta ./entrypoint.sh /web/entrypoint.sh
 
 USER 10001
 
@@ -75,5 +75,5 @@ LABEL org.opencontainers.image.title="agenta-web" \
     org.opencontainers.image.revision="${VCS_REF}" \
     org.opencontainers.image.created="${BUILD_DATE}"
 
-ENTRYPOINT ["/app/entrypoint.sh"]
+ENTRYPOINT ["/web/entrypoint.sh"]
 EXPOSE 3000


### PR DESCRIPTION
## Summary

Containers were uniformly using `/app` as `WORKDIR` regardless of which
service they hosted, which made multi-service compose stacks ambiguous
(e.g. `/app/oss/` could be either the API or the web app depending on
which container you were in) and produced confusing log paths.

This aligns container `WORKDIR` with the service that owns it:

| Service       | WORKDIR     |
|---------------|-------------|
| `api/oss`, `api/ee`         | `/api`      |
| `web/oss`, `web/ee`         | `/web`      |
| `services/oss`, `services/ee` | `/services` |

## What changed

**Containers:**
- `api/{oss,ee}/docker/Dockerfile.{dev,gh}`
- `web/{oss,ee}/docker/Dockerfile.{dev,gh}`
- `services/{oss,ee}/docker/Dockerfile.{dev,gh}`

**Compose stacks:** all `WORKDIR`-relative volume mounts, `watchmedo`
reload directories, and the cron command updated to use the new paths.
- `hosting/docker-compose/{oss,ee}/docker-compose.{dev,gh,gh.local,gh.ssl}.yml`
- `hosting/docker-compose/run.sh`
- `hosting/docker-compose/{oss,ee}/env.{oss,ee}.{dev,gh}.example`

**Helm:**
- `hosting/helm/agenta-oss/templates/_helpers.tpl` — 4 Alembic
  config-path defaults
- `hosting/helm/agenta-oss/templates/web-deployment.yaml`
- `hosting/helm/agenta-oss/templates/cron-deployment.yaml`

**Railway:**
- All worker, cron, web, and alembic Dockerfiles
- `hosting/railway/oss/scripts/build-and-push-images.sh`
- `hosting/railway/oss/scripts/deploy-from-images.sh`
- `hosting/railway/oss/web/railway.json`

**Application code (path strings only):**
- `api/oss/src/utils/env.py` — `AlembicConfig` hardcoded fallback paths
- `api/oss/src/crons/queries.sh` — crontab path in awk command
- `web/entrypoint.sh` — `ENTRYPOINT_DIR` default

**Alembic:**
- 4 `alembic.ini` files — `script_location`
- 4 migration `README.md` files — example commands

**Public docs:**
- `docs/docs/self-host/01-quick-start.mdx`
- `docs/docs/self-host/02-configuration.mdx`
- `docs/docs/self-host/03-upgrading.mdx`

## Diff

- 51 files changed, 313 insertions, 261 deletions

## Risks

- **High blast radius — every container in the stack changes.** Any
  custom Dockerfile/compose override held outside this repo (e.g. a
  customer's compose file that mounts host paths into `/app/...`) will
  break. Internal customers should be notified before merge.
- **Helm chart values overrides:** if any deployment overrides
  `alembicCfgPath` in their values file, those overrides reference the
  old `/app/...` path and need to be updated. Defaults in the chart's
  `_helpers.tpl` move to the new path.
- **Self-hosting docs are also updated.** Anyone running migrations
  manually against an old container gets a stale command from cached
  docs — the upgrade flow includes both the container update and the
  doc update so this is consistent at release time.
- **No application logic changes.** Only paths in Docker, compose,
  helm, alembic config, and env defaults move. The Python `agenta`
  package itself is not touched.

## QA

- [ ] CI green (the existing CI already exercises both Dockerfile.gh
      builds and the dev compose stack)
- [ ] `docker compose -f hosting/docker-compose/oss/docker-compose.dev.yml up`
      starts cleanly; API responds on `/health`; web loads
- [ ] EE equivalent: same with `docker-compose.ee.dev.yml`
- [ ] Helm chart renders and applies cleanly: `helm template` against
      the OSS chart shows the new `/api` path in env vars
- [ ] Run a test alembic migration against a dev container — verify the
      migration runs from `/api/oss/databases/postgres/migrations/...`
- [ ] Cron container: `kubectl logs <cron-pod>` shows queries.sh
      executing from `/api/`
- [ ] Self-host docs render correctly in Docusaurus preview

## Notes

- This is the first of a stack. PRs that follow (`chore/sdk/relocate-...`,
  `feat/sdk/python-fern-client`, `feat/sdk/typescript-fern-client`)
  layer onto this base.
- Originally part of #4239 — split out for independent review.
