### PR TITLE
fix: update column className to maxWidth for better layout in observa…

### DIFF
--- a/web/oss/src/components/pages/observability/assets/getObservabilityColumns.tsx
+++ b/web/oss/src/components/pages/observability/assets/getObservabilityColumns.tsx
@@ -102,7 +102,7 @@ export const getObservabilityColumns = ({evaluatorSlugs}: ObservabilityColumnsPr
             title: "Inputs",
             key: "inputs",
             width: 400,
-            className: "overflow-hidden text-ellipsis whitespace-nowrap max-w-[400px]",
+            maxWidth: 400,
             render: (_, record) => {
                 const inputs = getTraceInputs(record)
                 const {data: sanitizedInputs} = sanitizeDataWithBlobUrls(inputs)
@@ -119,7 +119,7 @@ export const getObservabilityColumns = ({evaluatorSlugs}: ObservabilityColumnsPr
             title: "Outputs",
             key: "outputs",
             width: 400,
-            className: "overflow-hidden text-ellipsis whitespace-nowrap max-w-[400px]",
+            maxWidth: 400,
             render: (_, record) => {
                 const outputs = getTraceOutputs(record)
                 const {data: sanitizedOutputs} = sanitizeDataWithBlobUrls(outputs)


### PR DESCRIPTION
## Summary
<!-- What changed? -->
<!-- Why was this change needed? -->
<!-- What problem does it solve? -->
<!-- For fixes, explain how the change addresses the root cause. -->
Fixed header/row misalignment in the observability table on large screens by replacing the CSS `max-w-[400px]` class (which only applied to body cells) with a proper `maxWidth: 400` column property that constrains both header and body cells consistently.

## Testing
### Verified locally
<!-- What did you run or verify locally? Be specific. -->

### Added or updated tests
<!-- What tests did you add or update? Include unit, integration, and end-to-end coverage when relevant. Write N/A if none. -->

### QA follow-up
<!-- What still needs QA? List flows, browsers, environments, edge cases, or data conditions to validate. Write N/A if none. -->

## Demo
<!-- Required for UI changes. Add screenshots, GIFs, or a short video. -->
<!-- If this is not a UI change, write N/A. -->
<img width="1320" height="793" alt="Screenshot 2026-05-07 at 1 37 30 PM" src="https://github.com/user-attachments/assets/38e2f538-0195-443e-95bf-fb7d95956eb0" />


## Checklist
- [x] I have included a video or screen recording for UI changes, or marked Demo as N/A
- [x] Relevant tests pass locally
- [x] Relevant linting and formatting pass locally
- [x] I have signed the CLA, or I will sign it when the bot prompts me

## Contributor Resources
- [Contributing guide](https://agenta.ai/docs/contributing/overview)
- [Creating your first PR](https://agenta.ai/docs/contributing/first-pr)
- [Development mode](https://agenta.ai/docs/contributing/guides/development-mode)
- [Testing](https://agenta.ai/docs/contributing/guides/testing)
- [Formatting and linting](https://agenta.ai/docs/contributing/guides/formatting-and-linting)
- [Slack support](https://join.slack.com/t/agenta-hq/shared_invite/zt-37pnbp5s6-mbBrPL863d_oLB61GSNFjw)
