### PR TITLE
[AGE-3171] fix(sdk): warn when instrumentation methods called before ag.init()

### DIFF
--- a/sdks/python/agenta/sdk/litellm/litellm.py
+++ b/sdks/python/agenta/sdk/litellm/litellm.py
@@ -1,3 +1,4 @@
+import warnings
 from typing import Dict
 from opentelemetry.trace import SpanKind
 
@@ -10,6 +11,14 @@ log = get_module_logger(__name__)
 
 
 def litellm_handler():
+    if ag.tracing is None:
+        warnings.warn(
+            "ag.callbacks.litellm_handler() called before ag.init(). "
+            "Tracing will be disabled. Call ag.init() before setting up litellm callbacks.",
+            RuntimeWarning,
+            stacklevel=2,
+        )
+
     try:
         from litellm.integrations.custom_logger import (  # pylint: disable=import-outside-toplevel
             CustomLogger as LitellmCustomLogger,

--- a/sdks/python/oss/tests/pytest/unit/test_preinit_warnings.py
+++ b/sdks/python/oss/tests/pytest/unit/test_preinit_warnings.py
@@ -80,21 +80,15 @@ class TestInstrumentDecoratorPreInitWarning:
             with warnings.catch_warnings(record=True) as caught:
                 warnings.simplefilter("always")
 
-                with patch("agenta.tracer") as mock_tracer:
-                    mock_span = MagicMock()
-                    mock_tracer.start_as_current_span.return_value.__enter__ = (
-                        lambda s, *a: mock_span
-                    )
-                    mock_tracer.start_as_current_span.return_value.__exit__ = (
-                        lambda s, *a: None
-                    )
-                    try:
-                        my_fn()
-                    except Exception:
-                        pass
+                # Warning fires first; subsequent code may raise because
+                # ag.tracing is None — that is the expected failure mode.
+                try:
+                    my_fn()
+                except Exception:
+                    pass
 
         runtime_warnings = [w for w in caught if issubclass(w.category, RuntimeWarning)]
-        assert len(runtime_warnings) >= 1
+        assert len(runtime_warnings) >= 1, "Expected RuntimeWarning but none were emitted"
         assert "ag.init()" in str(runtime_warnings[0].message)
 
     def test_instrument_no_warning_after_init(self):
@@ -120,8 +114,8 @@ class TestInstrumentDecoratorPreInitWarning:
                     )
                     try:
                         my_fn()
-                    except Exception:
-                        pass
+                    except Exception as exc:
+                        pytest.fail(f"my_fn() raised unexpectedly: {exc}")
 
         runtime_warnings = [w for w in caught if issubclass(w.category, RuntimeWarning)]
-        assert len(runtime_warnings) == 0
+        assert len(runtime_warnings) == 0, "Unexpected RuntimeWarning after ag.init()"

--- a/sdks/python/oss/tests/pytest/unit/test_preinit_warnings.py
+++ b/sdks/python/oss/tests/pytest/unit/test_preinit_warnings.py
@@ -1,0 +1,127 @@
+"""
+Tests that instrumentation methods emit RuntimeWarning when called before ag.init().
+"""
+
+import warnings
+import pytest
+from unittest.mock import patch, MagicMock
+
+
+class TestLitellmHandlerPreInitWarning:
+    """ag.callbacks.litellm_handler() should warn when ag.tracing is None."""
+
+    def test_litellm_handler_warns_when_called_before_init(self):
+        with patch("agenta.tracing", None):
+            with warnings.catch_warnings(record=True) as caught:
+                warnings.simplefilter("always")
+
+                # litellm may not be installed in test env; mock the import
+                mock_logger = MagicMock()
+                mock_logger.__name__ = "CustomLogger"
+
+                with patch.dict(
+                    "sys.modules",
+                    {
+                        "litellm": MagicMock(),
+                        "litellm.integrations": MagicMock(),
+                        "litellm.integrations.custom_logger": MagicMock(
+                            CustomLogger=mock_logger
+                        ),
+                    },
+                ):
+                    from agenta.sdk.litellm.litellm import litellm_handler
+
+                    litellm_handler()
+
+        runtime_warnings = [w for w in caught if issubclass(w.category, RuntimeWarning)]
+        assert len(runtime_warnings) == 1
+        assert "ag.init()" in str(runtime_warnings[0].message)
+        assert "litellm_handler" in str(runtime_warnings[0].message)
+
+    def test_litellm_handler_no_warning_after_init(self):
+        mock_tracing = MagicMock()
+
+        with patch("agenta.tracing", mock_tracing):
+            with warnings.catch_warnings(record=True) as caught:
+                warnings.simplefilter("always")
+
+                mock_logger = MagicMock()
+                mock_logger.__name__ = "CustomLogger"
+
+                with patch.dict(
+                    "sys.modules",
+                    {
+                        "litellm": MagicMock(),
+                        "litellm.integrations": MagicMock(),
+                        "litellm.integrations.custom_logger": MagicMock(
+                            CustomLogger=mock_logger
+                        ),
+                    },
+                ):
+                    from agenta.sdk.litellm.litellm import litellm_handler
+
+                    litellm_handler()
+
+        runtime_warnings = [w for w in caught if issubclass(w.category, RuntimeWarning)]
+        assert len(runtime_warnings) == 0
+
+
+class TestInstrumentDecoratorPreInitWarning:
+    """@ag.instrument() should warn at function call time when ag.tracing is None."""
+
+    def test_instrument_warns_on_call_before_init(self):
+        from agenta.sdk.decorators.tracing import instrument
+
+        @instrument()
+        def my_fn():
+            return "result"
+
+        with patch("agenta.tracing", None):
+            with warnings.catch_warnings(record=True) as caught:
+                warnings.simplefilter("always")
+
+                with patch("agenta.tracer") as mock_tracer:
+                    mock_span = MagicMock()
+                    mock_tracer.start_as_current_span.return_value.__enter__ = (
+                        lambda s, *a: mock_span
+                    )
+                    mock_tracer.start_as_current_span.return_value.__exit__ = (
+                        lambda s, *a: None
+                    )
+                    try:
+                        my_fn()
+                    except Exception:
+                        pass
+
+        runtime_warnings = [w for w in caught if issubclass(w.category, RuntimeWarning)]
+        assert len(runtime_warnings) >= 1
+        assert "ag.init()" in str(runtime_warnings[0].message)
+
+    def test_instrument_no_warning_after_init(self):
+        from agenta.sdk.decorators.tracing import instrument
+
+        @instrument()
+        def my_fn():
+            return "result"
+
+        mock_tracing = MagicMock()
+
+        with patch("agenta.tracing", mock_tracing):
+            with warnings.catch_warnings(record=True) as caught:
+                warnings.simplefilter("always")
+
+                with patch("agenta.tracer") as mock_tracer:
+                    mock_span = MagicMock()
+                    mock_tracer.start_as_current_span.return_value.__enter__ = (
+                        lambda s, *a: mock_span
+                    )
+                    mock_tracer.start_as_current_span.return_value.__exit__ = (
+                        lambda s, *a: None
+                    )
+                    try:
+                        my_fn()
+                    except Exception:
+                        pass
+
+        runtime_warnings = [w for w in caught if issubclass(w.category, RuntimeWarning)]
+        assert len(runtime_warnings) == 0


### PR DESCRIPTION
## Problem

Closes #3171

Calling `ag.callbacks.litellm_handler()` before `ag.init()` silently
registered a handler that produced no-op spans with zero indication
anything was wrong. Developers had no way to discover the issue.

## Fix

Added a `RuntimeWarning` in `litellm_handler()` when `ag.tracing is None`:

```python
if ag.tracing is None:
    warnings.warn(
        "ag.callbacks.litellm_handler() called before ag.init(). "
        "Tracing will be disabled. Call ag.init() before setting up litellm callbacks.",
        RuntimeWarning,
        stacklevel=2,
    )
