### PR TITLE
[ci] Add ARM builds

### DIFF
--- a/.github/workflows/42-railway-build.yml
+++ b/.github/workflows/42-railway-build.yml
@@ -98,7 +98,7 @@ jobs:
           } >> "$GITHUB_STEP_SUMMARY"
 
   build-and-push:
-    name: build (${{ matrix.image_name }} / ${{ matrix.arch }})
+    name: build-image
     needs: prepare
     if: needs.prepare.outputs.build_images == 'true'
     runs-on: ${{ matrix.runner }}
@@ -128,7 +128,7 @@ jobs:
             needs_sdk: true
           # Per-arch config (runner + platform string)
           - arch: amd64
-            runner: ubuntu-latest
+            runner: ubuntu-24.04
             platform: linux/amd64
           - arch: arm64
             runner: ubuntu-24.04-arm
@@ -161,6 +161,12 @@ jobs:
           file: ${{ matrix.dockerfile }}
           push: true
           platforms: ${{ matrix.platform }}
+          # Skip SLSA provenance + SBOM attestations. They produce extra
+          # `unknown/unknown` entries in the manifest list and we don't consume
+          # them for preview images. Re-enable if signed/verifiable releases
+          # become a requirement.
+          provenance: false
+          sbom: false
           tags: ghcr.io/agenta-ai/${{ matrix.image_name }}:${{ needs.prepare.outputs.image_tag }}-${{ matrix.arch }}
           # Per-arch cache refs so amd64 and arm64 don't clobber each other.
           cache-from: |
@@ -205,7 +211,7 @@ jobs:
           echo "- Built \`${{ matrix.image_name }}:${{ needs.prepare.outputs.image_tag }}-${{ matrix.arch }}\`" >> "$GITHUB_STEP_SUMMARY"
 
   merge-manifests:
-    name: Merge multi-arch manifests (${{ matrix.image_name }})
+    name: merge-manifest
     needs: [prepare, build-and-push]
     if: needs.prepare.outputs.build_images == 'true'
     runs-on: ubuntu-latest

--- a/.github/workflows/42-railway-build.yml
+++ b/.github/workflows/42-railway-build.yml
@@ -98,14 +98,22 @@ jobs:
           } >> "$GITHUB_STEP_SUMMARY"
 
   build-and-push:
-    name: build (${{ matrix.image_name }})
+    name: build (${{ matrix.image_name }} / ${{ matrix.arch }})
     needs: prepare
     if: needs.prepare.outputs.build_images == 'true'
-    runs-on: ubuntu-latest
+    runs-on: ${{ matrix.runner }}
     strategy:
       fail-fast: false
       matrix:
+        image_name:
+          - agenta-api
+          - agenta-web
+          - agenta-services
+        arch:
+          - amd64
+          - arm64
         include:
+          # Per-service config (build context, Dockerfile, SDK injection)
           - image_name: agenta-api
             context: api
             dockerfile: api/oss/docker/Dockerfile.gh
@@ -118,6 +126,13 @@ jobs:
             context: services
             dockerfile: services/oss/docker/Dockerfile.gh
             needs_sdk: true
+          # Per-arch config (runner + platform string)
+          - arch: amd64
+            runner: ubuntu-latest
+            platform: linux/amd64
+          - arch: arm64
+            runner: ubuntu-24.04-arm
+            platform: linux/arm64
     steps:
       - uses: actions/checkout@v6
 
@@ -139,24 +154,26 @@ jobs:
           rm -rf "${{ matrix.context }}/clients"
           cp -R clients "${{ matrix.context }}/clients"
 
-      - name: Build and push image
+      - name: Build and push per-arch image
         uses: docker/build-push-action@v6
         with:
           context: ${{ matrix.context }}
           file: ${{ matrix.dockerfile }}
           push: true
-          tags: ghcr.io/agenta-ai/${{ matrix.image_name }}:${{ needs.prepare.outputs.image_tag }}
+          platforms: ${{ matrix.platform }}
+          tags: ghcr.io/agenta-ai/${{ matrix.image_name }}:${{ needs.prepare.outputs.image_tag }}-${{ matrix.arch }}
+          # Per-arch cache refs so amd64 and arm64 don't clobber each other.
           cache-from: |
-            type=registry,ref=ghcr.io/agenta-ai/${{ matrix.image_name }}:buildcache-shared
-            type=registry,ref=ghcr.io/agenta-ai/${{ matrix.image_name }}:buildcache-${{ needs.prepare.outputs.cache_scope }}
+            type=registry,ref=ghcr.io/agenta-ai/${{ matrix.image_name }}:buildcache-shared-${{ matrix.arch }}
+            type=registry,ref=ghcr.io/agenta-ai/${{ matrix.image_name }}:buildcache-${{ needs.prepare.outputs.cache_scope }}-${{ matrix.arch }}
           cache-to: |
-            type=registry,ref=ghcr.io/agenta-ai/${{ matrix.image_name }}:buildcache-shared,mode=max
-            type=registry,ref=ghcr.io/agenta-ai/${{ matrix.image_name }}:buildcache-${{ needs.prepare.outputs.cache_scope }},mode=max
+            type=registry,ref=ghcr.io/agenta-ai/${{ matrix.image_name }}:buildcache-shared-${{ matrix.arch }},mode=max
+            type=registry,ref=ghcr.io/agenta-ai/${{ matrix.image_name }}:buildcache-${{ needs.prepare.outputs.cache_scope }}-${{ matrix.arch }},mode=max
 
       - name: Verify SDK source path in image
         if: matrix.image_name == 'agenta-api' || matrix.image_name == 'agenta-services'
         run: |
-          IMAGE="ghcr.io/agenta-ai/${{ matrix.image_name }}:${{ needs.prepare.outputs.image_tag }}"
+          IMAGE="ghcr.io/agenta-ai/${{ matrix.image_name }}:${{ needs.prepare.outputs.image_tag }}-${{ matrix.arch }}"
           docker pull "$IMAGE"
           # Redirect stderr and take only the last stdout line so that
           # third-party import noise (e.g. litellm >=1.82 prints a
@@ -174,15 +191,51 @@ jobs:
 
       - name: Verify image runs as non-root
         run: |
-          IMAGE="ghcr.io/agenta-ai/${{ matrix.image_name }}:${{ needs.prepare.outputs.image_tag }}"
+          IMAGE="ghcr.io/agenta-ai/${{ matrix.image_name }}:${{ needs.prepare.outputs.image_tag }}-${{ matrix.arch }}"
           docker pull "$IMAGE"
           USER=$(docker inspect --format='{{.Config.User}}' "$IMAGE")
           if [ -z "$USER" ] || [ "$USER" = "root" ] || [ "$USER" = "0" ]; then
-            echo "::error::${{ matrix.image_name }} runs as root (User='${USER}')"
+            echo "::error::${{ matrix.image_name }} (${{ matrix.arch }}) runs as root (User='${USER}')"
             exit 1
           fi
-          echo "PASS: ${{ matrix.image_name }} runs as User='${USER}'"
+          echo "PASS: ${{ matrix.image_name }} (${{ matrix.arch }}) runs as User='${USER}'"
 
       - name: Summary
         run: |
-          echo "- Built \`${{ matrix.image_name }}:${{ needs.prepare.outputs.image_tag }}\`" >> "$GITHUB_STEP_SUMMARY"
+          echo "- Built \`${{ matrix.image_name }}:${{ needs.prepare.outputs.image_tag }}-${{ matrix.arch }}\`" >> "$GITHUB_STEP_SUMMARY"
+
+  merge-manifests:
+    name: Merge multi-arch manifests (${{ matrix.image_name }})
+    needs: [prepare, build-and-push]
+    if: needs.prepare.outputs.build_images == 'true'
+    runs-on: ubuntu-latest
+    strategy:
+      fail-fast: false
+      matrix:
+        image_name:
+          - agenta-api
+          - agenta-web
+          - agenta-services
+    steps:
+      - name: Log in to GHCR
+        uses: docker/login-action@v3
+        with:
+          registry: ghcr.io
+          username: ${{ github.actor }}
+          password: ${{ secrets.GITHUB_TOKEN }}
+
+      - name: Set up Docker Buildx
+        uses: docker/setup-buildx-action@v4
+
+      - name: Stitch per-arch tags into manifest list
+        env:
+          IMAGE: ghcr.io/agenta-ai/${{ matrix.image_name }}
+          TAG: ${{ needs.prepare.outputs.image_tag }}
+        run: |
+          set -euo pipefail
+          echo "🔹 Merging ${IMAGE}:${TAG}-{amd64,arm64} into ${IMAGE}:${TAG}"
+          docker buildx imagetools create \
+            -t "${IMAGE}:${TAG}" \
+            "${IMAGE}:${TAG}-amd64" \
+            "${IMAGE}:${TAG}-arm64"
+          echo "- Merged \`${{ matrix.image_name }}:${TAG}\` (linux/amd64 + linux/arm64)" >> "$GITHUB_STEP_SUMMARY"


### PR DESCRIPTION
## Summary
Adds `linux/arm64` builds in parallel with the existing `linux/amd64` builds for the Railway preview pipeline. Each tag (e.g. `pr-1234-abcd123`) now resolves to a multi-arch manifest list — `docker pull` on either an x86_64 or M-series host picks the right image automatically.

## What changed
**`.github/workflows/42-railway-build.yml`**
- `build-and-push` job now matrices `image_name × arch`:
  - `amd64` → `ubuntu-latest`
  - `arm64` → `ubuntu-24.04-arm` (GitHub-hosted native ARM runner)
- Each matrix shard pushes a per-arch tag: `<image>:<tag>-amd64` and `<image>:<tag>-arm64`.
- Cache refs are now per-arch (`buildcache-shared-amd64` / `…-arm64`) so the two arches don't invalidate each other's layers.
- Non-root and SDK-path verification runs against the per-arch tag on its native runner (so `docker run` works without emulation).
- New `merge-manifests` job per service stitches `<tag>-amd64` and `<tag>-arm64` into the canonical `<tag>` with `docker buildx imagetools create`. The canonical tag is the manifest list — downstream pulls Just Work.

## Properties
- **No registry / repo changes.** Same GHCR repos, same tag names. Each tag is now a manifest list pointing at two image blobs.
- **No Dockerfile changes.** Bases (`python:3.13-slim-trixie`, `node:24-slim`) are already multi-arch; the API Dockerfile's Supercronic case-match already handled arm64.
- **Native build speed.** No QEMU; each arch builds on its own runner. Build time is roughly unchanged because matrix shards run in parallel.
- **Atomic `latest`-style tag.** The canonical tag only appears after both arches build successfully, so a partial failure never leaves it pointing at a single-arch image.

## Test plan
- [x] Trigger via PR comment / dispatch on a small PR; confirm 6 matrix shards run (3 services × 2 arches) and 3 merge jobs follow.
- [x] `docker buildx imagetools inspect ghcr.io/agenta-ai/agenta-api:pr-<N>-<sha>` shows both `linux/amd64` and `linux/arm64` entries.
- [x] Pull the image on an M-series Mac and on an Intel host; both succeed without `--platform`.
- [x] Non-root verification step passes on both arches.

## Pairs with
- platform repo: `[ci] Add ARM builds`
