### PR TITLE
fix(eval): surface invocation error stacktrace in evaluation table

### DIFF
--- a/web/oss/src/components/EvalRunDetails/atoms/runInvocationAction.ts
+++ b/web/oss/src/components/EvalRunDetails/atoms/runInvocationAction.ts
@@ -201,6 +201,9 @@ export const triggerRunInvocationAtom = atom(
             } else {
                 // Record failure in step result
                 const errorMessage = result.error?.message ?? "Invocation failed"
+                const errorStacktrace = Array.isArray(result.error?.stacktrace)
+                    ? result.error.stacktrace.join("\n")
+                    : result.error?.stacktrace
                 await upsertStepResultWithInvocation({
                     runId,
                     scenarioId,
@@ -208,7 +211,7 @@ export const triggerRunInvocationAtom = atom(
                     traceId: result.traceId ?? undefined,
                     status: "failure",
                     references,
-                    error: {message: errorMessage},
+                    error: {message: errorMessage, ...(errorStacktrace ? {stacktrace: errorStacktrace} : {})},
                 })
 
                 await updateScenarioStatus(scenarioId, EvaluationStatus.FAILURE)

--- a/web/packages/agenta-entities/src/runnable/types.ts
+++ b/web/packages/agenta-entities/src/runnable/types.ts
@@ -204,6 +204,7 @@ export interface ExecutionResult {
     error?: {
         message: string
         code?: string
+        stacktrace?: string | string[]
     }
     trace?: TraceInfo
     metrics?: ExecutionMetrics
@@ -226,6 +227,7 @@ export interface StageExecutionResult {
     error?: {
         message: string
         code?: string
+        stacktrace?: string | string[]
     }
     traceId: string | null
     metrics?: ExecutionMetrics

--- a/web/packages/agenta-playground/src/executeWorkflowRevision.ts
+++ b/web/packages/agenta-playground/src/executeWorkflowRevision.ts
@@ -62,7 +62,7 @@ export interface ExecuteWorkflowRevisionResult {
     structuredOutput?: unknown
     traceId?: string | null
     spanId?: string | null
-    error?: {message: string; code?: string}
+    error?: {message: string; code?: string; stacktrace?: string | string[]}
 }
 
 // ============================================================================

--- a/web/packages/agenta-playground/src/state/execution/executionRunner.ts
+++ b/web/packages/agenta-playground/src/state/execution/executionRunner.ts
@@ -167,7 +167,7 @@ interface ExecutionSessionLifecycleCallbacks {
         chainResults?: RunResult["chainResults"]
     }) => void
     onComplete: (payload: {result: Partial<RunResult>}) => void
-    onFail: (payload: {error: {message: string; code?: string}; traceId?: string | null}) => void
+    onFail: (payload: {error: {message: string; code?: string; stacktrace?: string | string[]}; traceId?: string | null}) => void
     onCancel: () => void
 }
 
@@ -639,6 +639,7 @@ async function executeViaFetch(params: {
         if (!response.ok) {
             const errorText = await response.text()
             let errorMessage = `Request failed with status ${response.status}`
+            let errorStacktrace: string | string[] | undefined
             let traceId: string | null = null
 
             try {
@@ -646,8 +647,10 @@ async function executeViaFetch(params: {
                 traceId = extractTraceIdFromPayload(errorData)
                 if (errorData?.status?.message) {
                     errorMessage = errorData.status.message
+                    errorStacktrace = errorData.status.stacktrace
                 } else if (errorData?.detail?.message) {
                     errorMessage = errorData.detail.message
+                    errorStacktrace = errorData.detail.stacktrace
                 } else if (typeof errorData?.detail === "string") {
                     errorMessage = errorData.detail
                 }
@@ -660,7 +663,7 @@ async function executeViaFetch(params: {
                 status: "error",
                 startedAt,
                 completedAt: new Date().toISOString(),
-                error: {message: errorMessage},
+                error: {message: errorMessage, ...(errorStacktrace ? {stacktrace: errorStacktrace} : {})},
                 ...(traceId ? {trace: {id: traceId}} : {}),
             }
         }

--- a/web/packages/agenta-playground/src/state/execution/types.ts
+++ b/web/packages/agenta-playground/src/state/execution/types.ts
@@ -165,7 +165,7 @@ export interface RunResult {
     /** Hash of result for comparison (optional) */
     resultHash?: string | null
     /** Error details if status is "error" */
-    error?: {message: string; code?: string} | null
+    error?: {message: string; code?: string; stacktrace?: string | string[]} | null
     /** Timestamp when execution started (ms) */
     startedAt?: number
     /** Timestamp when execution completed (ms) */


### PR DESCRIPTION
## Summary
<!-- What changed? -->
<!-- Why was this change needed? -->
<!-- What problem does it solve? -->
<!-- For fixes, explain how the change addresses the root cause. -->

Closes #3324

When a LLM invocation fails during evaluation, the Python SDK returns both a `message` and a `stacktrace` in the error status body. The frontend was silently dropping the stacktrace, so the `InvocationCell` popover only ever showed the generic error message — making it hard to diagnose the root cause.

**Root cause:** `executeViaFetch` in `executionRunner.ts` only read `errorData.status.message` from the server response, never `errorData.status.stacktrace`. The gap then propagated through `onFail` → `executeWorkflowRevision` → `runInvocationAction`, which passed only `{message}` to `upsertStepResultWithInvocation`.

**What changed:**
- Added `stacktrace?: string | string[]` to `ExecutionResult`, `StageExecutionResult`, `RunResult`, and `ExecuteWorkflowRevisionResult` error shapes so the field is typed end-to-end
- `executeViaFetch` now extracts `stacktrace` from both the `status` and `detail` error branches
- `runInvocationAction` normalises `string[]` frames (joined with `\n`) and passes `stacktrace` through to `upsertStepResultWithInvocation`
- No UI changes required — `InvocationCell` and `upsertStepResultWithInvocation` already had full stacktrace support; the fix is purely in the data pipeline

## Testing
### Verified locally
<!-- What did you run or verify locally? Be specific. -->

Traced the full data path by code inspection: Python SDK `normalizer.py` → HTTP response body → `executeViaFetch` → `onFail` → `executeWorkflowRevision` → `runInvocationAction` → `upsertStepResultWithInvocation` → stored `error.stacktrace` field. Confirmed `InvocationCell` already renders `stepError.stacktrace` in the popover when the field is present.

### Added or updated tests
<!-- What tests did you add or update? Include unit, integration, and end-to-end coverage when relevant. Write N/A if none. -->

N/A

### QA follow-up
<!-- What still needs QA? List flows, browsers, environments, edge cases, or data conditions to validate. Write N/A if none. -->

- Trigger an evaluation run using an invalid API key or a rate-limited key so the invocation fails
- Confirm the Invocation cell shows the error message
- Open the cell popover and confirm the full provider stacktrace is now visible
- Confirm successful invocations are unaffected

## Demo
<!-- Required for UI changes. Add screenshots, GIFs, or a short video. -->
<!-- If this is not a UI change, write N/A. -->

N/A — this is a data-pipeline fix with no UI layout changes. The `InvocationCell` popover already renders `stepError.stacktrace` when present; the fix ensures that field is now populated from the server response.

## Checklist
- [x] I have included a video or screen recording for UI changes, or marked Demo as N/A
- [ ] Relevant tests pass locally
- [ ] Relevant linting and formatting pass locally
- [ ] I have signed the CLA, or I will sign it when the bot prompts me

## Contributor Resources
- [Contributing guide](https://agenta.ai/docs/contributing/overview)
- [Creating your first PR](https://agenta.ai/docs/contributing/first-pr)
- [Development mode](https://agenta.ai/docs/contributing/guides/development-mode)
- [Testing](https://agenta.ai/docs/contributing/guides/testing)
- [Formatting and linting](https://agenta.ai/docs/contributing/guides/formatting-and-linting)
- [Slack support](https://join.slack.com/t/agenta-hq/shared_invite/zt-37pnbp5s6-mbBrPL863d_oLB61GSNFjw)