### PR TITLE
fix(ci): stop aliasing RAILWAY_API_TOKEN to RAILWAY_TOKEN

### DIFF
--- a/hosting/railway/oss/scripts/lib.sh
+++ b/hosting/railway/oss/scripts/lib.sh
@@ -3,10 +3,6 @@
 # Shared helpers for Railway deployment scripts.
 # Source this file; do not execute it directly.
 
-if [ -z "${RAILWAY_TOKEN:-}" ] && [ -n "${RAILWAY_API_TOKEN:-}" ]; then
-    export RAILWAY_TOKEN="$RAILWAY_API_TOKEN"
-fi
-
 railway_repo_root() {
     cd "$(dirname "${BASH_SOURCE[0]}")/../../../.." && pwd
 }

--- a/hosting/railway/oss/scripts/preview-resolve-env.sh
+++ b/hosting/railway/oss/scripts/preview-resolve-env.sh
@@ -4,10 +4,6 @@ set -euo pipefail
 
 ROOT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")/../../../.." && pwd)"
 
-if [ -z "${RAILWAY_TOKEN:-}" ] && [ -n "${RAILWAY_API_TOKEN:-}" ]; then
-    export RAILWAY_TOKEN="$RAILWAY_API_TOKEN"
-fi
-
 PREVIEW_PROJECT_PREFIX="${RAILWAY_PREVIEW_PROJECT_PREFIX:-agenta-oss-pr}"
 PREVIEW_KEY="${RAILWAY_PREVIEW_KEY:-${PR_NUMBER:-${GITHUB_PR_NUMBER:-}}}"
 


### PR DESCRIPTION
## Summary

Restore Railway preview CI by removing a token env-var aliasing that was added in `c0baede6f` (\"some clean-up\", May 19) and silently broke every preview run since.

- File: `hosting/railway/oss/scripts/preview-resolve-env.sh`
- Removed 4 lines that copied `RAILWAY_API_TOKEN` into `RAILWAY_TOKEN`.

## What happened

The Railway CLI exposes **two different** env vars that look interchangeable but are not (per [docs.railway.com/guides/cli](https://docs.railway.com/guides/cli)):

| Env var | Token kind | Scope |
| --- | --- | --- |
| `RAILWAY_TOKEN` | **Project token** | project-scoped commands only |
| `RAILWAY_API_TOKEN` | **Account / workspace token** | `project list`, `project init`, `whoami`, etc. |

Our preview scripts (`bootstrap.sh`, `configure.sh`, `deploy-from-images.sh`, ...) need account-level access because they enumerate and create Railway projects. Commit `6952242c5` (Feb 2026) deliberately switched the CI workflows from `RAILWAY_TOKEN` to `RAILWAY_API_TOKEN` for that reason:

```yaml
# .github/workflows/41-railway-setup.yml
env:
  RAILWAY_API_TOKEN: ${{ secrets.RAILWAY_TOKEN }}   # secret holds an account token
```

On **2026-05-19 at 14:44 UTC**, commit `c0baede6f` (\"some clean-up\") added this block at the top of `preview-resolve-env.sh`:

```sh
if [ -z \"${RAILWAY_TOKEN:-}\" ] && [ -n \"${RAILWAY_API_TOKEN:-}\" ]; then
    export RAILWAY_TOKEN=\"$RAILWAY_API_TOKEN\"
fi
```

That re-creates the very collision `6952242c5` fixed. When both vars are set to the same account token, the CLI prioritises `RAILWAY_TOKEN` (= project token semantics), and every account-level call returns:

> Unauthorized. Please check that your RAILWAY_TOKEN is valid and has access to the resource you're trying to use.

Reproduction against Railway (using a known-good account token):

```
$ RAILWAY_API_TOKEN=<acct> railway whoami
Logged in as Mahmoud Mabrouk (mahmoud@agenta.ai) 👋

$ RAILWAY_TOKEN=<acct> railway whoami
Unauthorized. Please check that your RAILWAY_TOKEN is valid …

$ RAILWAY_API_TOKEN=<acct> RAILWAY_TOKEN=<acct> railway whoami
Failed to fetch: error decoding response body

$ RAILWAY_API_TOKEN=<acct> RAILWAY_TOKEN=<acct> railway project list --json
Unauthorized. …
```

The CI failure timeline confirms it:

- Last green run of `14-check-pr-preview.yml`: **2026-05-19 16:42 UTC** (on a branch that pre-dated the bad commit in its merge base)
- First failure: **2026-05-19 17:11 UTC** — and **every** run since fails identically on the `setup / setup` job, regardless of branch contents
- Failing log line: `Railway authentication failed. The token appears to be invalid or revoked.` from `require_railway_auth` in `bootstrap.sh`

The GitHub secret itself is fine — the token I tested locally returns the right user and lists `agenta-oss-pr-*` projects in the Agenta workspace. The bug was entirely in the script.

## Fix

Drop the aliasing. The workflow already exports the correct env (`RAILWAY_API_TOKEN`), and the rest of the scripts already check both vars in `require_railway_auth` so nothing else needs to change. Local invocations should set `RAILWAY_API_TOKEN` (already documented in `hosting/railway/oss/README.md`).

## Test plan

- [ ] CI run of `14-check-pr-preview.yml` on this PR completes the `setup / setup` job (i.e. `railway whoami` succeeds inside `bootstrap.sh`).
- [ ] `deploy` and `tests` jobs run to completion (they were skipped while setup failed).
- [ ] Local sanity: `RAILWAY_API_TOKEN=<acct> source hosting/railway/oss/scripts/preview-resolve-env.sh && railway whoami` returns `Logged in as …`.