### PR TITLE
feat(frontend): show span parameters in the trace overview

### DIFF
--- a/web/oss/src/components/DrillInView/TraceSpanDrillInView.tsx
+++ b/web/oss/src/components/DrillInView/TraceSpanDrillInView.tsx
@@ -98,6 +98,8 @@ export interface TraceSpanDrillInViewProps extends Omit<
     viewModePreset?: "default" | "message"
     /** Controls collapse behavior for rootScope="span" */
     allowSpanCollapse?: boolean
+    /** When collapsible, start collapsed (default: false) */
+    defaultCollapsed?: boolean
     /** Optional override data for rootScope="span" rendering */
     spanDataOverride?: unknown
 }
@@ -292,6 +294,7 @@ export const TraceSpanDrillInView = memo(
         rootScope = "attributes",
         viewModePreset = "default",
         allowSpanCollapse = true,
+        defaultCollapsed = false,
         spanDataOverride,
     }: TraceSpanDrillInViewProps) => {
         const spanEntityData = useAtomValue(traceSpanMolecule.selectors.data(spanId))
@@ -304,7 +307,7 @@ export const TraceSpanDrillInView = memo(
             imageAttachments,
         } = useMemo(() => sanitizeDataWithBlobUrls(spanData), [spanData])
 
-        const [isCollapsed, setIsCollapsed] = useState(false)
+        const [isCollapsed, setIsCollapsed] = useState(defaultCollapsed)
         const [isSearchOpen, setIsSearchOpen] = useState(false)
         const [searchTerm, setSearchTerm] = useState("")
         const [currentResultIndex, setCurrentResultIndex] = useState(0)

--- a/web/oss/src/components/SharedDrawers/TraceDrawer/components/AccordionTreePanel.tsx
+++ b/web/oss/src/components/SharedDrawers/TraceDrawer/components/AccordionTreePanel.tsx
@@ -52,6 +52,7 @@ type AccordionTreePanelProps = {
     fullEditorHeight?: boolean
     enableSearch?: boolean
     viewModePreset?: "default" | "message"
+    defaultCollapsed?: boolean
 } & React.ComponentProps<typeof Collapse>
 
 /**
@@ -260,6 +261,7 @@ const AccordionTreePanel = ({
     fullEditorHeight = false,
     enableSearch = false,
     viewModePreset = "default",
+    defaultCollapsed = false,
     ...props
 }: AccordionTreePanelProps) => {
     const {token} = theme.useToken()
@@ -474,7 +476,7 @@ const AccordionTreePanel = ({
             )}
             <Collapse
                 {...props}
-                defaultActiveKey={[label]}
+                defaultActiveKey={defaultCollapsed ? [] : [label]}
                 items={[
                     {
                         key: label,

--- a/web/oss/src/components/SharedDrawers/TraceDrawer/components/TraceContent/components/OverviewTabItem/index.tsx
+++ b/web/oss/src/components/SharedDrawers/TraceDrawer/components/TraceContent/components/OverviewTabItem/index.tsx
@@ -12,6 +12,7 @@ import {
     spanDataInputsAtomFamily,
     spanDataInternalsAtomFamily,
     spanDataOutputsAtomFamily,
+    spanDataParametersAtomFamily,
     spanExceptionAtomFamily,
     spanMetaConfigurationAtomFamily,
     spanNodeTypeAtomFamily,
@@ -30,10 +31,11 @@ const OverviewTabItem = ({activeTrace}: {activeTrace: TraceSpanNode}) => {
     const inputsFromSelectors = useAtomValue(spanDataInputsAtomFamily(activeTrace))
     const outputsFromSelectors = useAtomValue(spanDataOutputsAtomFamily(activeTrace))
     const internalsFromSelectors = useAtomValue(spanDataInternalsAtomFamily(activeTrace))
+    const parametersFromSelectors = useAtomValue(spanDataParametersAtomFamily(activeTrace))
     const nodeType = useAtomValue(spanNodeTypeAtomFamily(activeTrace))
     const exception = useAtomValue(spanExceptionAtomFamily(activeTrace))
 
-    const {inputs, outputs, internals} = useMemo(
+    const {inputs, outputs, internals, parameters} = useMemo(
         () => ({
             inputs:
                 entityWithDrillIn.drillIn.getValueAtPath(activeTrace, ["ag", "data", "inputs"]) ??
@@ -47,6 +49,12 @@ const OverviewTabItem = ({activeTrace}: {activeTrace: TraceSpanNode}) => {
                     "data",
                     "internals",
                 ]) ?? internalsFromSelectors,
+            parameters:
+                entityWithDrillIn.drillIn.getValueAtPath(activeTrace, [
+                    "ag",
+                    "data",
+                    "parameters",
+                ]) ?? parametersFromSelectors,
         }),
         [
             activeTrace,
@@ -54,8 +62,14 @@ const OverviewTabItem = ({activeTrace}: {activeTrace: TraceSpanNode}) => {
             inputsFromSelectors,
             outputsFromSelectors,
             internalsFromSelectors,
+            parametersFromSelectors,
         ],
     )
+
+    const hasParameters =
+        parameters != null &&
+        typeof parameters === "object" &&
+        Object.keys(parameters as Record<string, unknown>).length > 0
     const spanEntityId =
         activeTrace?.span_id || activeTrace?.invocationIds?.span_id || activeTrace?.key
     const isEmbeddingSpan = activeTrace?.span_type === "embedding"
@@ -108,6 +122,28 @@ const OverviewTabItem = ({activeTrace}: {activeTrace: TraceSpanNode}) => {
                             value={panels.inputs.value as any}
                             enableFormatSwitcher
                             viewModePreset={panels.inputs.hasMessages ? "message" : "default"}
+                        />
+                    )}
+                </div>
+            ) : null}
+
+            {hasParameters ? (
+                <div className="flex flex-col gap-2">
+                    {spanEntityId ? (
+                        <TraceSpanDrillInView
+                            spanId={spanEntityId}
+                            title="parameters"
+                            editable={false}
+                            rootScope="span"
+                            spanDataOverride={parameters}
+                            defaultCollapsed
+                        />
+                    ) : (
+                        <AccordionTreePanel
+                            label={"parameters"}
+                            value={parameters as any}
+                            enableFormatSwitcher
+                            defaultCollapsed
                         />
                     )}
                 </div>

--- a/web/oss/src/state/newObservability/selectors/tracing.ts
+++ b/web/oss/src/state/newObservability/selectors/tracing.ts
@@ -48,6 +48,8 @@ export const getAgDataOutputs = (span?: TraceSpanNode) => getAgData(span)?.outpu
 
 export const getAgDataInternals = (span?: TraceSpanNode) => getAgData(span)?.internals ?? null
 
+export const getAgDataParameters = (span?: TraceSpanNode) => getAgData(span)?.parameters ?? null
+
 export const getAgNodeType = (span?: TraceSpanNode) => span?.attributes?.ag?.node?.type ?? null
 
 export const getSpanException = (span?: TraceSpanNode) =>
@@ -98,6 +100,10 @@ export const spanDataOutputsAtomFamily = atomFamily((span?: TraceSpanNode) =>
 
 export const spanDataInternalsAtomFamily = atomFamily((span?: TraceSpanNode) =>
     atom(() => getAgDataInternals(span)),
+)
+
+export const spanDataParametersAtomFamily = atomFamily((span?: TraceSpanNode) =>
+    atom(() => getAgDataParameters(span)),
 )
 
 export const spanNodeTypeAtomFamily = atomFamily((span?: TraceSpanNode) =>


### PR DESCRIPTION
## What was missing

When you open a trace span in the observability overview, it shows inputs and outputs but never shows `ag.data.parameters`. For chat spans, that is where the model config and the tool definitions live. So the tools, and the rest of the config, were invisible in the overview.

## The change

This adds a "parameters" panel to the overview, next to inputs and outputs. It renders `ag.data.parameters` in the same beautified view as the other panels. It stays collapsed by default so it does not get in the way, and it only appears when the span actually has parameters.

To support starting collapsed, `TraceSpanDrillInView` and `AccordionTreePanel` each get an optional `defaultCollapsed` prop. The default is `false`, so every existing usage renders exactly as before.

## Note

This is the first of two steps. It makes tools and config visible in the overview. A follow-up will make the playground load these tools correctly when you open such a span.