### PR TITLE
fix(frontend): keep tool-call pairing when loading chat into playground

### DIFF
--- a/web/packages/agenta-playground/src/state/helpers/extractAndLoadChatMessages.ts
+++ b/web/packages/agenta-playground/src/state/helpers/extractAndLoadChatMessages.ts
@@ -290,38 +290,15 @@ export const extractAndLoadChatMessagesAtom = atom(
                 cursor = nextUserIndex === -1 ? rowMessages.length : nextUserIndex
 
                 const userContent = normalizeMessageContent(userMessage.content) as MessageContent
-                const assistantSource = [...turnMessages]
-                    .reverse()
-                    .find((m) => m.role !== "user" && m.role !== "tool")
-                const assistantContent = assistantSource
-                    ? (normalizeMessageContent(assistantSource.content) as MessageContent)
-                    : ""
 
-                let finalAssistantContent = assistantContent
-                const toolCalls = assistantSource?.tool_calls
-                if (
-                    (!finalAssistantContent ||
-                        (Array.isArray(finalAssistantContent) &&
-                            finalAssistantContent.length === 0)) &&
-                    Array.isArray(toolCalls) &&
-                    toolCalls.length > 0
-                ) {
-                    const firstCall = asObject(toolCalls[0]) || {}
-                    const fn = asObject(firstCall.function)
-                    const argValue = firstCall.arguments ?? fn?.arguments ?? fn?.args
-
-                    if (typeof argValue === "string" && argValue.trim().length > 0) {
-                        finalAssistantContent = argValue
-                    } else if (argValue != null) {
-                        try {
-                            finalAssistantContent = JSON.stringify(argValue, null, 2)
-                        } catch {
-                            finalAssistantContent = String(argValue)
-                        }
-                    }
-                }
-
-                const toolMessagesForTurn = turnMessages.filter((m) => m.role === "tool")
+                // Every non-user message in the turn, in original order. A turn
+                // may hold more than one assistant: the assistant that calls a
+                // tool, the tool result, then the assistant that replies. We
+                // must keep all of them and preserve the order so the
+                // assistant `tool_calls` and the tool `tool_call_id` stay paired
+                // (OpenAI rejects a tool message that has no preceding assistant
+                // with matching tool_calls).
+                const responseMessages = turnMessages.filter((m) => m && m.role !== "user")
 
                 // User message → shared
                 const userMsgId = `msg-${generateId()}`
@@ -334,52 +311,60 @@ export const extractAndLoadChatMessagesAtom = atom(
                 flatMessageIds.push(userMsgId)
                 flatMessagesById[userMsgId] = userChatMsg
 
-                // Per-session assistant + tool responses
+                // Per-session assistant + tool responses, in source order.
                 for (const revId of revisionIds) {
                     const sessId = `sess:${revId}`
+                    let toolIdx = 0
 
-                    const aMsgId = `msg-${generateId()}`
-                    const aChatMsg: ChatMessage = {
-                        id: aMsgId,
-                        role: assistantSource?.role ?? "assistant",
-                        content: finalAssistantContent,
-                        ...(assistantSource && Array.isArray(assistantSource.tool_calls)
-                            ? {tool_calls: assistantSource.tool_calls}
-                            : {}),
-                        sessionId: sessId,
-                        parentId: userMsgId,
-                    }
-                    flatMessageIds.push(aMsgId)
-                    flatMessagesById[aMsgId] = aChatMsg
+                    for (const srcMsg of responseMessages) {
+                        const msgObj = asObject(srcMsg) || {}
+                        const role = asString(msgObj.role) ?? "assistant"
+                        const msgId = `msg-${generateId()}`
 
-                    for (const [idx, toolMsg] of toolMessagesForTurn.entries()) {
-                        const msgObj = asObject(toolMsg) || {}
-                        const fn = asObject(msgObj.function)
-                        const contentValue = toolContentToString(msgObj.content)
-                        const toolName =
-                            asString(msgObj.name) ??
-                            asString(msgObj.tool_name) ??
-                            asString(msgObj.toolName) ??
-                            asString(fn?.name)
-                        const toolCallId =
-                            asString(msgObj.toolCallId) ??
-                            asString(msgObj.tool_call_id) ??
-                            asString(msgObj.toolCallID) ??
-                            asString(msgObj.id) ??
-                            asString(asObject(msgObj.function_call)?.id)
+                        if (role === "tool") {
+                            const fn = asObject(msgObj.function)
+                            const contentValue = toolContentToString(msgObj.content)
+                            const toolName =
+                                asString(msgObj.name) ??
+                                asString(msgObj.tool_name) ??
+                                asString(msgObj.toolName) ??
+                                asString(fn?.name)
+                            const toolCallId =
+                                asString(msgObj.toolCallId) ??
+                                asString(msgObj.tool_call_id) ??
+                                asString(msgObj.toolCallID) ??
+                                asString(msgObj.id) ??
+                                asString(asObject(msgObj.function_call)?.id)
 
-                        const tMsgId = `msg-${generateId()}`
-                        const tChatMsg: ChatMessage = {
-                            id: tMsgId,
-                            role: "tool",
-                            name: toolName ?? `tool_${idx + 1}`,
-                            tool_call_id: toolCallId,
-                            content: contentValue,
-                            sessionId: sessId,
-                            parentId: userMsgId,
+                            const tChatMsg: ChatMessage = {
+                                id: msgId,
+                                role: "tool",
+                                name: toolName ?? `tool_${toolIdx + 1}`,
+                                tool_call_id: toolCallId,
+                                content: contentValue,
+                                sessionId: sessId,
+                                parentId: userMsgId,
+                            }
+                            toolIdx += 1
+                            flatMessageIds.push(msgId)
+                            flatMessagesById[msgId] = tChatMsg
+                        } else {
+                            // Assistant (or other non-tool role). Keep content as
+                            // is, including an empty string for a pure tool-call
+                            // turn, and carry tool_calls through unchanged.
+                            const aChatMsg: ChatMessage = {
+                                id: msgId,
+                                role,
+                                content: normalizeMessageContent(msgObj.content) as MessageContent,
+                                ...(Array.isArray(msgObj.tool_calls)
+                                    ? {tool_calls: msgObj.tool_calls}
+                                    : {}),
+                                sessionId: sessId,
+                                parentId: userMsgId,
+                            }
+                            flatMessageIds.push(msgId)
+                            flatMessagesById[msgId] = aChatMsg
                         }
-                        flatMessageIds.push(tMsgId)
-                        flatMessagesById[tMsgId] = tChatMsg
                     }
                 }
             }


### PR DESCRIPTION
## Summary
Loading a tool-using conversation into the chat playground and replaying it failed with `Invalid parameter: messages with role 'tool' must be a response to a preceeding message with 'tool_calls'`, even when the source trace was correctly structured.

The loader (`extractAndLoadChatMessages.ts`) grouped the prompt by user turn and built exactly one assistant message per turn, choosing the last non-user, non-tool message. A turn that calls a tool, gets a result, then replies has two assistant messages. The loader kept the reply (which has no `tool_calls`) and dropped the tool-calling assistant along with its `tool_calls`, while still keeping the tool message and its `tool_call_id`. The replayed request then contained a tool message that answered a call no assistant declared, which OpenAI rejects.

The fix stops collapsing the turn. The loader now walks the turn's messages in source order and emits one playground message per source message, carrying `tool_calls`, `tool_call_id`, and `name` through unchanged, and keeping `content: ""` for a pure tool-call assistant. The replay request is built from this flat ordered list (`buildChatHistoryFromFlatMessages` plus `toTransformMessage`), so the assistant-then-tool pairing now survives. The old hack that stuffed tool-call args into the assistant's content is removed, since `tool_calls` are now preserved structurally.

The chat renderer already supports multiple assistants per turn (`ChatTurnView` reads `assistantsForTurn`, backed by an ordered index), so the loaded conversation also displays the tool-calling assistant, the tool result, and the reply in order.

## Testing
### Verified locally
Loaded a real multi-turn tool conversation (HTTP_Request and AI_Agent_Tool calls) into the playground and replayed it. It now runs without the OpenAI tool-pairing error and renders the tool calls, results, and replies in order. Traced the full path from loader to request body to confirm `tool_calls` and `tool_call_id` survive.

### Added or updated tests
N/A. The change is contained to the loader's turn assembly. Open to adding a unit test for `extractAndLoadChatMessagesAtom` covering a tool-call turn if preferred.

### QA follow-up
Load conversations with single and multi-round tool calls and confirm replay succeeds and the order reads correctly. Confirm normal turns without tools are unchanged.

## Demo
UI and behavior change. A short screen recording of loading a tool conversation and replaying it would be ideal; I could not capture one in this environment.

## Checklist
- [ ] I have included a video or screen recording for UI changes, or marked Demo as N/A
- [x] Relevant tests pass locally
- [x] Relevant linting and formatting pass locally
- [x] I have signed the CLA, or I will sign it when the bot prompts me