### PR TITLE
[AGE-3773] fix(frontend): remove duplicate 'View details' evaluator menu item

### DIFF
--- a/web/oss/src/components/Evaluators/Table/assets/evaluatorColumns.tsx
+++ b/web/oss/src/components/Evaluators/Table/assets/evaluatorColumns.tsx
@@ -580,13 +580,6 @@ export function createEvaluatorColumns(
                             onClick: (record: EvaluatorTableRow) =>
                                 actions.handleConfigure?.(record),
                         },
-                        {
-                            key: "details",
-                            label: "View details",
-                            icon: <Eye size={16} />,
-                            onClick: (record: EvaluatorTableRow) =>
-                                actions.handleConfigure?.(record),
-                        },
                         {type: "divider" as const},
                         {
                             key: "delete",


### PR DESCRIPTION
## Summary
- Fixes [#4378](https://github.com/Agenta-AI/agenta/issues/4378): the automatic evaluator row menu had two top items — **Configure** and **View details** — that both called `actions.handleConfigure?.(record)` and opened the same drawer.
- The `View details` entry was a stub introduced with the new evaluators table and never got its own handler. Removed it so the menu shows a single, distinct action.

## Change
`web/oss/src/components/Evaluators/Table/assets/evaluatorColumns.tsx` — drop the duplicate `details` menu item from the non-archived, non-human menu. The archived menu's `Open details` (with its own `handleOpen`) is untouched.

## Test plan
- [ ] Open the Evaluators page (non-archived tab) and open the actions menu on an automatic evaluator row.
- [ ] Confirm the menu shows: `Configure` → divider → `Archive` (no `View details`).
- [ ] Click `Configure` and verify the evaluator drawer opens as before.
- [ ] Verify the archived tab still shows `Open details` + `Restore`.
- [ ] Verify the human evaluators tab still shows `Edit` + `Archive`.

## Checklist
- [x] I have included a video or screen recording for UI changes, or marked Demo as N/A
- [x] Relevant tests pass locally
- [x] Relevant linting and formatting pass locally
- [x] I have signed the CLA, or I will sign it when the bot prompts me

## Contributor Resources
- [Contributing guide](https://agenta.ai/docs/contributing/overview)
- [Creating your first PR](https://agenta.ai/docs/contributing/first-pr)
- [Development mode](https://agenta.ai/docs/contributing/guides/development-mode)
- [Testing](https://agenta.ai/docs/contributing/guides/testing)
- [Formatting and linting](https://agenta.ai/docs/contributing/guides/formatting-and-linting)
- [Slack support](https://join.slack.com/t/agenta-hq/shared_invite/zt-37pnbp5s6-mbBrPL863d_oLB61GSNFjw)
