### PR TITLE
fix(frontend): hide trace children from raw span data

### DIFF
--- a/web/oss/src/components/SharedDrawers/TraceDrawer/components/TraceContent/assets/helpers.ts
+++ b/web/oss/src/components/SharedDrawers/TraceDrawer/components/TraceContent/assets/helpers.ts
@@ -1,0 +1,19 @@
+import {TraceSpanNode} from "@/oss/services/tracing/types"
+
+type TraceSpanNodeWithRawViewFields = TraceSpanNode & {
+    spans?: unknown
+    aggregatedEvaluatorMetrics?: unknown
+}
+
+export const getRawTraceSpanData = (span: TraceSpanNode) => {
+    const {
+        spans: _spans,
+        children: _children,
+        key: _key,
+        invocationIds: _invocationIds,
+        aggregatedEvaluatorMetrics: _aggregatedEvaluatorMetrics,
+        ...rawSpan
+    } = span as TraceSpanNodeWithRawViewFields
+
+    return rawSpan
+}

--- a/web/oss/src/components/SharedDrawers/TraceDrawer/components/TraceContent/index.tsx
+++ b/web/oss/src/components/SharedDrawers/TraceDrawer/components/TraceContent/index.tsx
@@ -10,6 +10,7 @@ import {traceSidePanelOpenAtom} from "@/oss/components/SharedDrawers/TraceDrawer
 
 import TraceSidePanel from "../TraceSidePanel"
 
+import {getRawTraceSpanData} from "./assets/helpers"
 import {useStyles} from "./assets/styles"
 import {TraceContentProps} from "./assets/types"
 import AnnotationTabItem from "./components/AnnotationTabItem"
@@ -71,6 +72,8 @@ const TraceContent = ({
             ]
         }
 
+        const rawActiveTrace = getRawTraceSpanData(activeTrace)
+
         return [
             {
                 key: "overview",
@@ -85,7 +88,7 @@ const TraceContent = ({
                         {spanEntityId ? (
                             <TraceSpanDrillInView
                                 spanId={spanEntityId}
-                                spanDataOverride={activeTrace}
+                                spanDataOverride={rawActiveTrace}
                                 title="Raw Data"
                                 editable={false}
                                 rootScope="span"
@@ -94,7 +97,7 @@ const TraceContent = ({
                         ) : (
                             <AccordionTreePanel
                                 label={"Raw Data"}
-                                value={activeTrace ?? {}}
+                                value={rawActiveTrace}
                                 enableFormatSwitcher
                                 fullEditorHeight
                                 enableSearch


### PR DESCRIPTION
## What was broken
When a user selected a span in the trace tree and opened the Raw Data tab, the JSON included that span's full child subtree. The selected tree node carried both backend child spans in `spans` and frontend tree children in `children`, and the raw view stringified that whole node.

## The fix
The Raw Data tab now projects the selected tree node into a raw-span payload before passing it to `TraceSpanDrillInView`.

Before, the raw payload could include tree and UI fields:

```ts
{
  ...spanFields,
  spans: {...},
  children: [...],
  key: "...",
  invocationIds: {...},
  aggregatedEvaluatorMetrics: {...},
  annotations: [...],
}
```

After, the raw payload keeps the span fields and `annotations`, but drops `spans`, `children`, `key`, `invocationIds`, and `aggregatedEvaluatorMetrics`. The trace tree still receives the original node, so tree rendering and expansion are unchanged.

## Tests / notes
- Ran `pnpm lint-fix` in `web`. ESLint passed.
- This PR is stacked on `feat/trace-key-spans-filter` because both branches touch `TraceContent/index.tsx`.