### PR TITLE
fix(api,sdk): allow dotted reference slugs in tracing ingest

### DIFF
--- a/api/oss/src/core/tracing/utils/attributes.py
+++ b/api/oss/src/core/tracing/utils/attributes.py
@@ -5,6 +5,7 @@ from json import loads as json_loads, JSONDecodeError
 from re import match
 from typing import Any, Dict, Optional, Tuple, Union
 
+from agenta.sdk.models.shared import URL_SAFE_SLUG
 from pydantic import ValidationError
 
 from oss.src.core.shared.dtos import Data, Flags, Meta, Tags
@@ -20,8 +21,6 @@ from oss.src.core.tracing.dtos import (
     SpanType,
     TraceType,
 )
-
-URL_SAFE = r"^[a-zA-Z0-9_-]+$"
 
 REFERENCE_KEYS = [
     "testcase",
@@ -220,7 +219,7 @@ def initialize_ag_attributes(attributes: Optional[dict]) -> dict:
                     entry["id"] = str(references_dict[key]["id"])
                 if references_dict[key].get("slug") is not None:
                     entry["slug"] = str(references_dict[key]["slug"])
-                    if entry["slug"] and not match(URL_SAFE, entry["slug"]):
+                    if entry["slug"] and not match(URL_SAFE_SLUG, entry["slug"]):
                         entry["slug"] = None
                 if references_dict[key].get("version") is not None:
                     entry["version"] = str(references_dict[key]["version"])

--- a/api/oss/tests/pytest/unit/tracing/utils/test_attributes.py
+++ b/api/oss/tests/pytest/unit/tracing/utils/test_attributes.py
@@ -69,6 +69,64 @@ def test_initialize_ag_attributes_cleans_known_fields_and_tracks_unsupported():
     assert "refs" not in ag["unsupported"]
 
 
+def test_initialize_ag_attributes_preserves_dotted_reference_slugs():
+    cleaned = initialize_ag_attributes(
+        {
+            "ag": {
+                "references": {
+                    "application_variant": {"slug": "n8n.default"},
+                    "application": {"slug": "n8n"},
+                }
+            }
+        }
+    )
+
+    references = cleaned["ag"]["references"]
+
+    assert references["application_variant"]["slug"] == "n8n.default"
+    assert references["application"]["slug"] == "n8n"
+
+
+def test_initialize_ag_attributes_nulls_unsafe_reference_slugs():
+    cleaned = initialize_ag_attributes(
+        {
+            "ag": {
+                "references": {
+                    "application": {"slug": "a/b"},
+                    "application_variant": {"slug": "has space"},
+                    "query": {"slug": "with?query"},
+                }
+            }
+        }
+    )
+
+    references = cleaned["ag"]["references"]
+
+    assert references["application"] == {}
+    assert references["application_variant"] == {}
+    assert references["query"] == {}
+
+
+def test_initialize_ag_attributes_nulls_path_traversal_reference_slugs():
+    cleaned = initialize_ag_attributes(
+        {
+            "ag": {
+                "references": {
+                    "application": {"slug": "."},
+                    "application_variant": {"slug": ".."},
+                    "query": {"slug": ".hidden"},
+                }
+            }
+        }
+    )
+
+    references = cleaned["ag"]["references"]
+
+    assert references["application"] == {}
+    assert references["application_variant"] == {}
+    assert references["query"] == {}
+
+
 def test_ag_metrics_accept_scalar_duration_errors_and_vector_tokens_costs():
     attrs = AgAttributes.model_validate(
         {

--- a/sdks/python/agenta/sdk/models/shared.py
+++ b/sdks/python/agenta/sdk/models/shared.py
@@ -55,6 +55,9 @@ Schema = Dict[str, FullJson]  # type: ignore
 Mappings = Dict[str, str]
 
 
+URL_SAFE_SLUG = r"^[a-zA-Z0-9_\-][a-zA-Z0-9_.\-]*$"
+
+
 class Lifecycle(BaseModel):
     created_at: Optional[datetime] = None
     updated_at: Optional[datetime] = None
@@ -87,7 +90,7 @@ class Slug(BaseModel):
     @field_validator("slug")
     def check_url_safety(cls, v):
         if v is not None:
-            if not match(r"^[a-zA-Z0-9_.\-]+$", v):
+            if not match(URL_SAFE_SLUG, v):
                 raise ValueError("'slug' must be URL-safe.")
         return v
 


### PR DESCRIPTION
## What was broken

A trace emitted with `ag.refs.application_variant.slug = "n8n.default"` (the canonical `<app_slug>.<variant_name>` form the SDK itself produces) was stored with the variant reference's slug silently set to `None`. The reference collapsed to `{}`, the trace was not linked to the variant, and "open in playground" did not work.

The OTLP ingest cleaner validated reference slugs against `^[a-zA-Z0-9_-]+$`, stricter than:

- the SDK's `Slug` validator (`^[a-zA-Z0-9_.\-]+$`),
- the `workflow_variants.slug` DB column (plain `character varying`, no constraint),
- and the canonical Agenta variant slug used in the docs (`get_from_registry(app_slug="n8n", variant_slug="n8n.default", ...)`).

So the platform stored dotted variant slugs while the cleaner silently dropped any reference to them.

## The fix

One source-of-truth regex constant, `URL_SAFE_SLUG`, now lives in `sdks/python/agenta/sdk/models/shared.py`. Both the SDK's `Slug` validator and the tracing cleaner import it, so they cannot drift again.

```python
URL_SAFE_SLUG = r"^[a-zA-Z0-9_\-][a-zA-Z0-9_.\-]*$"
```

The first character must be alphanumeric, `_`, or `-`. Dots may only appear inside or at the end. That admits the canonical `n8n.default` form, and rejects exactly `.`, exactly `..`, and any leading-dot form like `.hidden`. RFC 3986 treats `.` and `..` as reserved relative path segments, so they have no business in a slug used inside a URL path.

Before, on a trace with `ag.refs.application_variant.slug = "n8n.default"`:

```jsonc
"ag.references": {
  "application":          {"slug": "n8n"},
  "application_variant":  {},
  "application_revision": {"version": "1"}
}
```

After:

```jsonc
"ag.references": {
  "application":          {"slug": "n8n"},
  "application_variant":  {"slug": "n8n.default"},
  "application_revision": {"version": "1"}
}
```

## Tests

Two regression tests added in `api/oss/tests/pytest/unit/tracing/utils/test_attributes.py`:

- `test_initialize_ag_attributes_preserves_dotted_reference_slugs` confirms `n8n.default` survives cleaning.
- `test_initialize_ag_attributes_nulls_path_traversal_reference_slugs` confirms `.`, `..`, and `.hidden` are nulled.

The existing "bad slug" case (a space) continues to assert the entry collapses to `{}`. Ran the full tracing unit suite (75/75 pass) plus a 60-case standalone regex sanity check covering RFC unreserved chars, URL syntax chars, unicode, whitespace, and path-traversal forms.

## Related

A separate PR (`fix/workflows-retrieve-guardrails`) tackles the same "open in playground from trace" user story at the retrieve endpoint. These are independent bugs at different layers and can ship in either order.