### PR TITLE
[fix] Extend guardrails to all git-based entities

### DIFF
--- a/api/oss/src/apis/fastapi/applications/models.py
+++ b/api/oss/src/apis/fastapi/applications/models.py
@@ -369,17 +369,31 @@ class ApplicationRevisionRetrieveRequest(BaseModel):
     application_ref: Optional[Reference] = Field(
         default=None,
         description=(
-            "Application reference. When only an application is supplied, the "
-            "latest revision of its default variant is returned."
+            "Application artifact to look up. Identifies the artifact by `id` "
+            "or `slug` (both project-unique). When no variant_ref or "
+            "revision_ref is provided, returns the latest revision of an "
+            "arbitrary variant of this application."
         ),
     )
     application_variant_ref: Optional[Reference] = Field(
         default=None,
-        description="Variant reference. Returns the latest revision on that variant.",
+        description=(
+            "Application variant to look up. Identifies the variant by `id` "
+            "or `slug` (both project-unique). When no revision_ref is "
+            "provided, returns the latest revision of this variant."
+        ),
     )
     application_revision_ref: Optional[Reference] = Field(
         default=None,
-        description="Revision reference. Returns that exact revision.",
+        description=(
+            "Application revision to look up. "
+            "`id` alone identifies a revision (project-unique). "
+            "`slug` alone identifies a revision (project-unique). "
+            "`version` alone is a per-variant sequence number and is **not** "
+            "sufficient on its own; it must be combined with an "
+            "`application_variant_ref`. Sending only `version` without a "
+            "variant ref returns HTTP 400."
+        ),
     )
     environment_ref: Optional[Reference] = Field(
         default=None,

--- a/api/oss/src/apis/fastapi/applications/router.py
+++ b/api/oss/src/apis/fastapi/applications/router.py
@@ -10,7 +10,7 @@ from oss.src.utils.caching import invalidate_cache
 
 from oss.src.core.events.utils import publish_revision_event
 
-from oss.src.core.git.types import VariantForkError
+from oss.src.core.git.types import VariantForkError, RevisionRefInvalid
 from oss.src.core.shared.dtos import (
     Reference,
 )
@@ -1178,13 +1178,19 @@ class ApplicationsRouter:
                 detail="Application deploy requires environment refs.",
             )
 
-        application_revision = await self.applications_service.fetch_application_revision(
-            project_id=UUID(request.state.project_id),
-            #
-            application_ref=application_deploy_request.application_ref,
-            application_variant_ref=application_deploy_request.application_variant_ref,
-            application_revision_ref=application_deploy_request.application_revision_ref,
-        )
+        try:
+            application_revision = await self.applications_service.fetch_application_revision(
+                project_id=UUID(request.state.project_id),
+                #
+                application_ref=application_deploy_request.application_ref,
+                application_variant_ref=application_deploy_request.application_variant_ref,
+                application_revision_ref=application_deploy_request.application_revision_ref,
+            )
+        except RevisionRefInvalid as e:
+            raise HTTPException(
+                status_code=status.HTTP_400_BAD_REQUEST,
+                detail=e.message,
+            ) from e
 
         if not application_revision:
             raise HTTPException(
@@ -1384,23 +1390,29 @@ class ApplicationsRouter:
                         detail="Environment-backed application retrieve requires key.",
                     )
 
-        (
-            application_revision,
-            resolution_info,
-        ) = await self.applications_service.retrieve_application_revision(
-            project_id=UUID(request.state.project_id),
-            #
-            environment_ref=environment_ref,
-            environment_variant_ref=environment_variant_ref,
-            environment_revision_ref=environment_revision_ref,
-            key=key,
-            #
-            application_ref=application_ref,
-            application_variant_ref=application_variant_ref,
-            application_revision_ref=application_revision_ref,
-            #
-            resolve=application_revision_retrieve_request.resolve or False,
-        )
+        try:
+            (
+                application_revision,
+                resolution_info,
+            ) = await self.applications_service.retrieve_application_revision(
+                project_id=UUID(request.state.project_id),
+                #
+                environment_ref=environment_ref,
+                environment_variant_ref=environment_variant_ref,
+                environment_revision_ref=environment_revision_ref,
+                key=key,
+                #
+                application_ref=application_ref,
+                application_variant_ref=application_variant_ref,
+                application_revision_ref=application_revision_ref,
+                #
+                resolve=application_revision_retrieve_request.resolve or False,
+            )
+        except RevisionRefInvalid as e:
+            raise HTTPException(
+                status_code=status.HTTP_400_BAD_REQUEST,
+                detail=e.message,
+            ) from e
 
         if environment_lookup_requested and not application_revision:
             raise HTTPException(

--- a/api/oss/src/apis/fastapi/environments/models.py
+++ b/api/oss/src/apis/fastapi/environments/models.py
@@ -1,6 +1,6 @@
 from typing import Optional, List
 
-from pydantic import BaseModel
+from pydantic import BaseModel, Field
 
 from oss.src.core.shared.dtos import (
     Windowing,
@@ -128,9 +128,35 @@ class EnvironmentRevisionCommitRequest(BaseModel):
 
 
 class EnvironmentRevisionRetrieveRequest(BaseModel):
-    environment_ref: Optional[Reference] = None
-    environment_variant_ref: Optional[Reference] = None
-    environment_revision_ref: Optional[Reference] = None
+    environment_ref: Optional[Reference] = Field(
+        default=None,
+        description=(
+            "Environment artifact to look up. Identifies the artifact by "
+            "`id` or `slug` (both project-unique). When no variant_ref or "
+            "revision_ref is provided, returns the latest revision of an "
+            "arbitrary variant of this environment."
+        ),
+    )
+    environment_variant_ref: Optional[Reference] = Field(
+        default=None,
+        description=(
+            "Environment variant to look up. Identifies the variant by `id` "
+            "or `slug` (both project-unique). When no revision_ref is "
+            "provided, returns the latest revision of this variant."
+        ),
+    )
+    environment_revision_ref: Optional[Reference] = Field(
+        default=None,
+        description=(
+            "Environment revision to look up. "
+            "`id` alone identifies a revision (project-unique). "
+            "`slug` alone identifies a revision (project-unique). "
+            "`version` alone is a per-variant sequence number and is **not** "
+            "sufficient on its own; it must be combined with an "
+            "`environment_variant_ref`. Sending only `version` without a "
+            "variant ref returns HTTP 400."
+        ),
+    )
     resolve: Optional[bool] = None  # Optionally resolve embeds on retrieve
 
 

--- a/api/oss/src/apis/fastapi/environments/router.py
+++ b/api/oss/src/apis/fastapi/environments/router.py
@@ -8,6 +8,7 @@ from oss.src.utils.logging import get_module_logger
 from oss.src.utils.exceptions import intercept_exceptions, suppress_exceptions
 
 from oss.src.core.events.utils import publish_revision_event
+from oss.src.core.git.types import RevisionRefInvalid
 
 from oss.src.core.shared.dtos import (
     Reference,
@@ -755,18 +756,24 @@ class EnvironmentsRouter:
             ):
                 raise FORBIDDEN_EXCEPTION  # type: ignore
 
-        (
-            environment_revision,
-            resolution_info,
-        ) = await self.environments_service.retrieve_environment_revision(
-            project_id=UUID(request.state.project_id),
-            #
-            environment_ref=environment_revision_retrieve_request.environment_ref,  # type: ignore
-            environment_variant_ref=environment_revision_retrieve_request.environment_variant_ref,  # type: ignore
-            environment_revision_ref=environment_revision_retrieve_request.environment_revision_ref,  # type: ignore
-            #
-            resolve=bool(environment_revision_retrieve_request.resolve),
-        )
+        try:
+            (
+                environment_revision,
+                resolution_info,
+            ) = await self.environments_service.retrieve_environment_revision(
+                project_id=UUID(request.state.project_id),
+                #
+                environment_ref=environment_revision_retrieve_request.environment_ref,  # type: ignore
+                environment_variant_ref=environment_revision_retrieve_request.environment_variant_ref,  # type: ignore
+                environment_revision_ref=environment_revision_retrieve_request.environment_revision_ref,  # type: ignore
+                #
+                resolve=bool(environment_revision_retrieve_request.resolve),
+            )
+        except RevisionRefInvalid as e:
+            raise HTTPException(
+                status_code=status.HTTP_400_BAD_REQUEST,
+                detail=e.message,
+            ) from e
 
         environment_revision_response = EnvironmentRevisionResponse(
             count=1 if environment_revision else 0,

--- a/api/oss/src/apis/fastapi/evaluators/models.py
+++ b/api/oss/src/apis/fastapi/evaluators/models.py
@@ -290,15 +290,32 @@ class EvaluatorRevisionRetrieveRequest(BaseModel):
 
     evaluator_ref: Optional[Reference] = Field(
         default=None,
-        description="Retrieve the latest revision of this evaluator.",
+        description=(
+            "Evaluator artifact to look up. Identifies the artifact by `id` "
+            "or `slug` (both project-unique). When no variant_ref or "
+            "revision_ref is provided, returns the latest revision of an "
+            "arbitrary variant of this evaluator."
+        ),
     )
     evaluator_variant_ref: Optional[Reference] = Field(
         default=None,
-        description="Retrieve the latest revision on this variant.",
+        description=(
+            "Evaluator variant to look up. Identifies the variant by `id` or "
+            "`slug` (both project-unique). When no revision_ref is provided, "
+            "returns the latest revision of this variant."
+        ),
     )
     evaluator_revision_ref: Optional[Reference] = Field(
         default=None,
-        description="Retrieve this specific revision.",
+        description=(
+            "Evaluator revision to look up. "
+            "`id` alone identifies a revision (project-unique). "
+            "`slug` alone identifies a revision (project-unique). "
+            "`version` alone is a per-variant sequence number and is **not** "
+            "sufficient on its own; it must be combined with an "
+            "`evaluator_variant_ref`. Sending only `version` without a "
+            "variant ref returns HTTP 400."
+        ),
     )
     environment_ref: Optional[Reference] = Field(
         default=None,

--- a/api/oss/src/apis/fastapi/evaluators/router.py
+++ b/api/oss/src/apis/fastapi/evaluators/router.py
@@ -10,7 +10,7 @@ from oss.src.utils.caching import invalidate_cache
 
 from oss.src.core.events.utils import publish_revision_event
 
-from oss.src.core.git.types import VariantForkError
+from oss.src.core.git.types import VariantForkError, RevisionRefInvalid
 from oss.src.core.shared.dtos import (
     Reference,
 )
@@ -1169,13 +1169,19 @@ class EvaluatorsRouter:
                 detail="Evaluator deploy requires environment refs.",
             )
 
-        evaluator_revision = await self.evaluators_service.fetch_evaluator_revision(
-            project_id=UUID(request.state.project_id),
-            #
-            evaluator_ref=evaluator_deploy_request.evaluator_ref,
-            evaluator_variant_ref=evaluator_deploy_request.evaluator_variant_ref,
-            evaluator_revision_ref=evaluator_deploy_request.evaluator_revision_ref,
-        )
+        try:
+            evaluator_revision = await self.evaluators_service.fetch_evaluator_revision(
+                project_id=UUID(request.state.project_id),
+                #
+                evaluator_ref=evaluator_deploy_request.evaluator_ref,
+                evaluator_variant_ref=evaluator_deploy_request.evaluator_variant_ref,
+                evaluator_revision_ref=evaluator_deploy_request.evaluator_revision_ref,
+            )
+        except RevisionRefInvalid as e:
+            raise HTTPException(
+                status_code=status.HTTP_400_BAD_REQUEST,
+                detail=e.message,
+            ) from e
 
         if not evaluator_revision:
             raise HTTPException(
@@ -1363,23 +1369,29 @@ class EvaluatorsRouter:
                     detail="Environment-backed evaluator retrieve requires key.",
                 )
 
-        (
-            evaluator_revision,
-            resolution_info,
-        ) = await self.evaluators_service.retrieve_evaluator_revision(
-            project_id=UUID(request.state.project_id),
-            #
-            environment_ref=environment_ref,
-            environment_variant_ref=environment_variant_ref,
-            environment_revision_ref=environment_revision_ref,
-            key=key,
-            #
-            evaluator_ref=evaluator_ref,
-            evaluator_variant_ref=evaluator_variant_ref,
-            evaluator_revision_ref=evaluator_revision_ref,
-            #
-            resolve=evaluator_revision_retrieve_request.resolve or False,
-        )
+        try:
+            (
+                evaluator_revision,
+                resolution_info,
+            ) = await self.evaluators_service.retrieve_evaluator_revision(
+                project_id=UUID(request.state.project_id),
+                #
+                environment_ref=environment_ref,
+                environment_variant_ref=environment_variant_ref,
+                environment_revision_ref=environment_revision_ref,
+                key=key,
+                #
+                evaluator_ref=evaluator_ref,
+                evaluator_variant_ref=evaluator_variant_ref,
+                evaluator_revision_ref=evaluator_revision_ref,
+                #
+                resolve=evaluator_revision_retrieve_request.resolve or False,
+            )
+        except RevisionRefInvalid as e:
+            raise HTTPException(
+                status_code=status.HTTP_400_BAD_REQUEST,
+                detail=e.message,
+            ) from e
 
         if environment_lookup_requested and not evaluator_revision:
             raise HTTPException(

--- a/api/oss/src/apis/fastapi/queries/models.py
+++ b/api/oss/src/apis/fastapi/queries/models.py
@@ -1,6 +1,6 @@
 from typing import Optional, List
 
-from pydantic import BaseModel
+from pydantic import BaseModel, Field
 
 from oss.src.core.shared.dtos import (
     Reference,
@@ -135,9 +135,35 @@ class QueryRevisionsLogRequest(BaseModel):
 
 
 class QueryRevisionRetrieveRequest(BaseModel):
-    query_ref: Optional[Reference] = None
-    query_variant_ref: Optional[Reference] = None
-    query_revision_ref: Optional[Reference] = None
+    query_ref: Optional[Reference] = Field(
+        default=None,
+        description=(
+            "Query artifact to look up. Identifies the artifact by `id` or "
+            "`slug` (both project-unique). When no variant_ref or "
+            "revision_ref is provided, returns the latest revision of an "
+            "arbitrary variant of this query."
+        ),
+    )
+    query_variant_ref: Optional[Reference] = Field(
+        default=None,
+        description=(
+            "Query variant to look up. Identifies the variant by `id` or "
+            "`slug` (both project-unique). When no revision_ref is provided, "
+            "returns the latest revision of this variant."
+        ),
+    )
+    query_revision_ref: Optional[Reference] = Field(
+        default=None,
+        description=(
+            "Query revision to look up. "
+            "`id` alone identifies a revision (project-unique). "
+            "`slug` alone identifies a revision (project-unique). "
+            "`version` alone is a per-variant sequence number and is **not** "
+            "sufficient on its own; it must be combined with a "
+            "`query_variant_ref`. Sending only `version` without a variant "
+            "ref returns HTTP 400."
+        ),
+    )
     #
     include_trace_ids: Optional[bool] = None
     include_traces: Optional[bool] = None

--- a/api/oss/src/apis/fastapi/queries/router.py
+++ b/api/oss/src/apis/fastapi/queries/router.py
@@ -9,6 +9,7 @@ from oss.src.utils.exceptions import intercept_exceptions, suppress_exceptions
 from oss.src.utils.caching import get_cache, set_cache
 
 from oss.src.core.events.utils import publish_revision_event
+from oss.src.core.git.types import RevisionRefInvalid
 
 from oss.src.core.shared.dtos import (
     Reference,
@@ -1019,18 +1020,24 @@ class QueriesRouter:
         )
 
         if not query_revision:
-            query_revision = await self.queries_service.fetch_query_revision(
-                project_id=UUID(request.state.project_id),
-                #
-                query_ref=query_revision_retrieve_request.query_ref,
-                query_variant_ref=query_revision_retrieve_request.query_variant_ref,
-                query_revision_ref=query_revision_retrieve_request.query_revision_ref,
-                #
-                include_trace_ids=query_revision_retrieve_request.include_trace_ids,
-                include_traces=query_revision_retrieve_request.include_traces,
-                #
-                windowing=query_revision_retrieve_request.windowing,
-            )
+            try:
+                query_revision = await self.queries_service.fetch_query_revision(
+                    project_id=UUID(request.state.project_id),
+                    #
+                    query_ref=query_revision_retrieve_request.query_ref,
+                    query_variant_ref=query_revision_retrieve_request.query_variant_ref,
+                    query_revision_ref=query_revision_retrieve_request.query_revision_ref,
+                    #
+                    include_trace_ids=query_revision_retrieve_request.include_trace_ids,
+                    include_traces=query_revision_retrieve_request.include_traces,
+                    #
+                    windowing=query_revision_retrieve_request.windowing,
+                )
+            except RevisionRefInvalid as e:
+                raise HTTPException(
+                    status_code=status.HTTP_400_BAD_REQUEST,
+                    detail=e.message,
+                ) from e
 
             if should_cache:
                 await set_cache(

--- a/api/oss/src/apis/fastapi/testsets/models.py
+++ b/api/oss/src/apis/fastapi/testsets/models.py
@@ -226,15 +226,32 @@ class TestsetRevisionCommitRequest(BaseModel):
 class TestsetRevisionRetrieveRequest(BaseModel):
     testset_ref: Optional[Reference] = Field(
         default=None,
-        description="Testset reference. If only the testset is provided, the latest revision on its default variant is returned.",
+        description=(
+            "Testset artifact to look up. Identifies the artifact by `id` or "
+            "`slug` (both project-unique). When no variant_ref or "
+            "revision_ref is provided, returns the latest revision of an "
+            "arbitrary variant of this testset."
+        ),
     )
     testset_variant_ref: Optional[Reference] = Field(
         default=None,
-        description="Variant reference. Returns the latest revision on that variant.",
+        description=(
+            "Testset variant to look up. Identifies the variant by `id` or "
+            "`slug` (both project-unique). When no revision_ref is provided, "
+            "returns the latest revision of this variant."
+        ),
     )
     testset_revision_ref: Optional[Reference] = Field(
         default=None,
-        description="Revision reference. Returns that specific revision.",
+        description=(
+            "Testset revision to look up. "
+            "`id` alone identifies a revision (project-unique). "
+            "`slug` alone identifies a revision (project-unique). "
+            "`version` alone is a per-variant sequence number and is **not** "
+            "sufficient on its own; it must be combined with a "
+            "`testset_variant_ref`. Sending only `version` without a variant "
+            "ref returns HTTP 400."
+        ),
     )
     #
     include_testcase_ids: Optional[bool] = Field(

--- a/api/oss/src/apis/fastapi/testsets/router.py
+++ b/api/oss/src/apis/fastapi/testsets/router.py
@@ -28,6 +28,7 @@ from oss.src.utils.caching import set_cache, get_cache
 
 from oss.src.apis.fastapi.shared.utils import compute_next_windowing
 from oss.src.core.events.utils import publish_revision_event
+from oss.src.core.git.types import RevisionRefInvalid
 
 from oss.src.core.shared.dtos import (
     Reference,
@@ -1497,18 +1498,24 @@ class TestsetsRouter:
         )
 
         if not testset_revision:
-            testset_revision = await self.testsets_service.fetch_testset_revision(
-                project_id=UUID(request.state.project_id),
-                #
-                testset_ref=testset_revision_retrieve_request.testset_ref,
-                testset_variant_ref=testset_revision_retrieve_request.testset_variant_ref,
-                testset_revision_ref=testset_revision_retrieve_request.testset_revision_ref,
-                #
-                include_testcase_ids=testset_revision_retrieve_request.include_testcase_ids,
-                include_testcases=testset_revision_retrieve_request.include_testcases,
-                #
-                windowing=testset_revision_retrieve_request.windowing,
-            )
+            try:
+                testset_revision = await self.testsets_service.fetch_testset_revision(
+                    project_id=UUID(request.state.project_id),
+                    #
+                    testset_ref=testset_revision_retrieve_request.testset_ref,
+                    testset_variant_ref=testset_revision_retrieve_request.testset_variant_ref,
+                    testset_revision_ref=testset_revision_retrieve_request.testset_revision_ref,
+                    #
+                    include_testcase_ids=testset_revision_retrieve_request.include_testcase_ids,
+                    include_testcases=testset_revision_retrieve_request.include_testcases,
+                    #
+                    windowing=testset_revision_retrieve_request.windowing,
+                )
+            except RevisionRefInvalid as e:
+                raise HTTPException(
+                    status_code=status.HTTP_400_BAD_REQUEST,
+                    detail=e.message,
+                ) from e
 
             if should_cache:
                 await set_cache(

--- a/api/oss/src/apis/fastapi/workflows/router.py
+++ b/api/oss/src/apis/fastapi/workflows/router.py
@@ -11,8 +11,7 @@ from oss.src.utils.caching import invalidate_cache
 from oss.src.core.shared.dtos import (
     Reference,
 )
-from oss.src.core.git.types import VariantForkError
-from oss.src.core.workflows.dtos import WorkflowRefInvalid
+from oss.src.core.git.types import VariantForkError, RevisionRefInvalid
 from oss.src.core.workflows.service import (
     WorkflowsService,
     SimpleWorkflowsService,
@@ -1236,7 +1235,7 @@ class WorkflowsRouter:
         # This route only accepts `workflow_revision_id` as a path param and
         # constructs `Reference(id=workflow_revision_id)`. That shape always
         # satisfies the service's ambiguity validation, so no try/except for
-        # `WorkflowRefInvalid` is needed here. The other two call sites
+        # `RevisionRefInvalid` is needed here. The other two call sites
         # (`deploy_workflow_revision` and `retrieve_workflow_revision`) pass
         # through caller-supplied refs and do wrap this call.
         workflow_revision = await self.workflows_service.fetch_workflow_revision(
@@ -1537,7 +1536,7 @@ class WorkflowsRouter:
                 workflow_variant_ref=workflow_deploy_request.workflow_variant_ref,
                 workflow_revision_ref=workflow_deploy_request.workflow_revision_ref,
             )
-        except WorkflowRefInvalid as e:
+        except RevisionRefInvalid as e:
             raise HTTPException(
                 status_code=status.HTTP_400_BAD_REQUEST,
                 detail=e.message,
@@ -1734,7 +1733,7 @@ class WorkflowsRouter:
                 #
                 resolve=workflow_revision_retrieve_request.resolve or False,
             )
-        except WorkflowRefInvalid as e:
+        except RevisionRefInvalid as e:
             raise HTTPException(
                 status_code=status.HTTP_400_BAD_REQUEST,
                 detail=e.message,

--- a/api/oss/src/core/applications/service.py
+++ b/api/oss/src/core/applications/service.py
@@ -554,7 +554,7 @@ class ApplicationsService:
             artifact_ref=application_ref,
             variant_ref=application_variant_ref,
             revision_ref=application_revision_ref,
-            artifact_kind="application",
+            entity_type="application",
         )
 
         workflow_revision = await self.workflows_service.fetch_workflow_revision(

--- a/api/oss/src/core/applications/service.py
+++ b/api/oss/src/core/applications/service.py
@@ -21,6 +21,7 @@ from oss.src.core.workflows.dtos import (
     #
 )
 from oss.src.core.shared.dtos import Windowing, Reference
+from oss.src.core.git.types import validate_revision_ref_unambiguous
 from oss.src.core.workflows.service import WorkflowsService
 
 # Resolution is now handled by EmbedsService
@@ -549,6 +550,13 @@ class ApplicationsService:
         #
         include_archived: Optional[bool] = True,
     ) -> Optional[ApplicationRevision]:
+        validate_revision_ref_unambiguous(
+            artifact_ref=application_ref,
+            variant_ref=application_variant_ref,
+            revision_ref=application_revision_ref,
+            artifact_kind="application",
+        )
+
         workflow_revision = await self.workflows_service.fetch_workflow_revision(
             project_id=project_id,
             #

--- a/api/oss/src/core/environments/service.py
+++ b/api/oss/src/core/environments/service.py
@@ -618,7 +618,7 @@ class EnvironmentsService:
             artifact_ref=environment_ref,
             variant_ref=environment_variant_ref,
             revision_ref=environment_revision_ref,
-            artifact_kind="environment",
+            entity_type="environment",
         )
 
         if (

--- a/api/oss/src/core/environments/service.py
+++ b/api/oss/src/core/environments/service.py
@@ -50,6 +50,7 @@ from oss.src.core.git.dtos import (
     VariantQuery,
 )
 from oss.src.core.git.interfaces import GitDAOInterface
+from oss.src.core.git.types import validate_revision_ref_unambiguous
 from oss.src.core.shared.dtos import Reference, Windowing
 
 from oss.src.utils.logging import get_module_logger
@@ -612,6 +613,13 @@ class EnvironmentsService:
             and not environment_revision_ref
         ):
             return None
+
+        validate_revision_ref_unambiguous(
+            artifact_ref=environment_ref,
+            variant_ref=environment_variant_ref,
+            revision_ref=environment_revision_ref,
+            artifact_kind="environment",
+        )
 
         if (
             environment_ref

--- a/api/oss/src/core/evaluators/service.py
+++ b/api/oss/src/core/evaluators/service.py
@@ -20,6 +20,7 @@ from oss.src.core.workflows.dtos import (
     #
 )
 from oss.src.core.shared.dtos import Windowing, Reference
+from oss.src.core.git.types import validate_revision_ref_unambiguous
 from oss.src.core.workflows.service import WorkflowsService
 
 # Resolution is now handled by EmbedsService
@@ -552,6 +553,13 @@ class EvaluatorsService:
         #
         include_archived: Optional[bool] = True,
     ) -> Optional[EvaluatorRevision]:
+        validate_revision_ref_unambiguous(
+            artifact_ref=evaluator_ref,
+            variant_ref=evaluator_variant_ref,
+            revision_ref=evaluator_revision_ref,
+            artifact_kind="evaluator",
+        )
+
         workflow_revision = await self.workflows_service.fetch_workflow_revision(
             project_id=project_id,
             #

--- a/api/oss/src/core/evaluators/service.py
+++ b/api/oss/src/core/evaluators/service.py
@@ -557,7 +557,7 @@ class EvaluatorsService:
             artifact_ref=evaluator_ref,
             variant_ref=evaluator_variant_ref,
             revision_ref=evaluator_revision_ref,
-            artifact_kind="evaluator",
+            entity_type="evaluator",
         )
 
         workflow_revision = await self.workflows_service.fetch_workflow_revision(

--- a/api/oss/src/core/git/types.py
+++ b/api/oss/src/core/git/types.py
@@ -1,3 +1,8 @@
+from typing import Optional
+
+from oss.src.core.shared.dtos import Reference
+
+
 class GitError(Exception):
     """Base exception for git-pattern domain errors."""
 
@@ -8,3 +13,83 @@ class GitError(Exception):
 
 class VariantForkError(GitError):
     """Raised when a variant fork request cannot be fulfilled."""
+
+
+class RevisionRefInvalid(GitError):
+    """Raised when artifact/variant/revision refs are present but cannot
+    identify a single revision unambiguously.
+
+    Currently raised when `revision_ref` carries only `version` (no `id`,
+    no `slug`) and no `variant_ref` with `id`/`slug` is provided. A revision
+    version is a per-variant sequence number and requires a variant context
+    to be unambiguous. `revision_ref.id` and `revision_ref.slug` are both
+    project-unique and remain valid alone.
+
+    Not raised for the all-refs-empty case: the entity service returns
+    `None` for that case rather than raising, matching the "nothing to look
+    up" contract.
+    """
+
+
+def _has_id_or_slug(ref: Optional[Reference]) -> bool:
+    """A `Reference` is "identifying" only if it carries an `id` or `slug`.
+
+    An empty `Reference(id=None, slug=None, version=None)` is a truthy
+    Python object but does not actually scope a lookup, so callers must
+    test for a populated identifier rather than relying on `bool(ref)`.
+    """
+    return bool(ref and (ref.id or ref.slug))
+
+
+def validate_revision_ref_unambiguous(
+    *,
+    artifact_ref: Optional[Reference],
+    variant_ref: Optional[Reference],
+    revision_ref: Optional[Reference],
+    artifact_kind: str = "artifact",
+) -> None:
+    """Reject revision-retrieve requests that cannot identify a single revision.
+
+    Rule enforced: if `revision_ref.version` is set and neither
+    `revision_ref.id` nor `revision_ref.slug` is set, the request must
+    carry a `variant_ref` with `id` or `slug`. Without that scope, the same
+    `version` value exists across many variants and cannot identify a
+    single revision; the DAO would silently return an arbitrary row.
+
+    The all-empty case (no refs at all) is intentionally NOT raised here —
+    callers handle that as "nothing to look up" and return `None`.
+
+    Note on `artifact_ref`: in principle a populated `artifact_ref` is also
+    sufficient to scope a version lookup, because the service can resolve
+    artifact → default variant → revision. This helper does NOT accept
+    `artifact_ref` alone today because that resolution path (the default-
+    variant pick) is non-deterministic for multi-variant artifacts in the
+    current code. Once that lookup becomes deterministic, callers can
+    resolve `artifact_ref` → `variant_ref` before invoking this helper and
+    the same shape will pass without changing this function. `artifact_ref`
+    is accepted as a parameter for forward compatibility (future cross-ref
+    mismatch validation, rule 2.c) but is not consulted today.
+
+    `artifact_kind` is interpolated into the error message ("workflow",
+    "testset", ...) so callers across entities can keep their messages
+    accurate without duplicating the logic.
+    """
+    revision_version_only = bool(
+        revision_ref
+        and revision_ref.version
+        and not revision_ref.id
+        and not revision_ref.slug
+    )
+    if not revision_version_only:
+        return
+
+    if _has_id_or_slug(variant_ref):
+        return
+
+    raise RevisionRefInvalid(
+        f"{artifact_kind}_revision_ref.version is a per-variant sequence number "
+        f"and requires a {artifact_kind}_variant_ref to be unambiguous. "
+        f"Provide a {artifact_kind}_variant_ref, or identify the revision by "
+        f"{artifact_kind}_revision_ref.id or {artifact_kind}_revision_ref.slug "
+        f"(both are project-unique)."
+    )

--- a/api/oss/src/core/git/types.py
+++ b/api/oss/src/core/git/types.py
@@ -46,7 +46,7 @@ def validate_revision_ref_unambiguous(
     artifact_ref: Optional[Reference],
     variant_ref: Optional[Reference],
     revision_ref: Optional[Reference],
-    artifact_kind: str = "artifact",
+    entity_type: str = "artifact",
 ) -> None:
     """Reject revision-retrieve requests that cannot identify a single revision.
 
@@ -70,7 +70,7 @@ def validate_revision_ref_unambiguous(
     is accepted as a parameter for forward compatibility (future cross-ref
     mismatch validation, rule 2.c) but is not consulted today.
 
-    `artifact_kind` is interpolated into the error message ("workflow",
+    `entity_type` is interpolated into the error message ("workflow",
     "testset", ...) so callers across entities can keep their messages
     accurate without duplicating the logic.
     """
@@ -87,9 +87,9 @@ def validate_revision_ref_unambiguous(
         return
 
     raise RevisionRefInvalid(
-        f"{artifact_kind}_revision_ref.version is a per-variant sequence number "
-        f"and requires a {artifact_kind}_variant_ref to be unambiguous. "
-        f"Provide a {artifact_kind}_variant_ref, or identify the revision by "
-        f"{artifact_kind}_revision_ref.id or {artifact_kind}_revision_ref.slug "
+        f"{entity_type}_revision_ref.version is a per-variant sequence number "
+        f"and requires a {entity_type}_variant_ref to be unambiguous. "
+        f"Provide a {entity_type}_variant_ref, or identify the revision by "
+        f"{entity_type}_revision_ref.id or {entity_type}_revision_ref.slug "
         f"(both are project-unique)."
     )

--- a/api/oss/src/core/queries/service.py
+++ b/api/oss/src/core/queries/service.py
@@ -651,7 +651,7 @@ class QueriesService:
             artifact_ref=query_ref,
             variant_ref=query_variant_ref,
             revision_ref=query_revision_ref,
-            artifact_kind="query",
+            entity_type="query",
         )
 
         if query_ref and not query_variant_ref and not query_revision_ref:

--- a/api/oss/src/core/queries/service.py
+++ b/api/oss/src/core/queries/service.py
@@ -6,6 +6,7 @@ from oss.src.utils.logging import get_module_logger
 
 from oss.src.core.events.utils import publish_revision_event
 from oss.src.core.git.interfaces import GitDAOInterface
+from oss.src.core.git.types import validate_revision_ref_unambiguous
 from oss.src.core.shared.dtos import Reference, Windowing, Trace, Traces
 from oss.src.core.tracing.dtos import (
     TracingQuery,
@@ -645,6 +646,13 @@ class QueriesService:
     ) -> Optional[QueryRevision]:
         if not query_ref and not query_variant_ref and not query_revision_ref:
             return None
+
+        validate_revision_ref_unambiguous(
+            artifact_ref=query_ref,
+            variant_ref=query_variant_ref,
+            revision_ref=query_revision_ref,
+            artifact_kind="query",
+        )
 
         if query_ref and not query_variant_ref and not query_revision_ref:
             query = await self.fetch_query(

--- a/api/oss/src/core/testsets/service.py
+++ b/api/oss/src/core/testsets/service.py
@@ -4,6 +4,7 @@ from uuid import UUID, uuid4
 from oss.src.utils.logging import get_module_logger
 from oss.src.core.events.utils import publish_revision_event
 from oss.src.core.git.interfaces import GitDAOInterface
+from oss.src.core.git.types import validate_revision_ref_unambiguous
 from oss.src.core.testcases.service import TestcasesService
 from oss.src.core.shared.dtos import Reference, Windowing
 from oss.src.core.git.dtos import (
@@ -635,6 +636,13 @@ class TestsetsService:
     ) -> Optional[TestsetRevision]:
         if not testset_ref and not testset_variant_ref and not testset_revision_ref:
             return None
+
+        validate_revision_ref_unambiguous(
+            artifact_ref=testset_ref,
+            variant_ref=testset_variant_ref,
+            revision_ref=testset_revision_ref,
+            artifact_kind="testset",
+        )
 
         if testset_ref and not testset_variant_ref and not testset_revision_ref:
             testset = await self.fetch_testset(

--- a/api/oss/src/core/testsets/service.py
+++ b/api/oss/src/core/testsets/service.py
@@ -641,7 +641,7 @@ class TestsetsService:
             artifact_ref=testset_ref,
             variant_ref=testset_variant_ref,
             revision_ref=testset_revision_ref,
-            artifact_kind="testset",
+            entity_type="testset",
         )
 
         if testset_ref and not testset_variant_ref and not testset_revision_ref:

--- a/api/oss/src/core/workflows/dtos.py
+++ b/api/oss/src/core/workflows/dtos.py
@@ -450,34 +450,3 @@ class WorkflowCatalogPreset(WorkflowCatalogMappingMixin, Header):
 
     flags: Optional[WorkflowCatalogFlags] = None
     data: Optional[WorkflowRevisionData] = None
-
-
-# ------------------------------------------------------------------------------
-# Exceptions
-# ------------------------------------------------------------------------------
-
-
-class WorkflowRefInvalid(Exception):
-    """Raised when the supplied workflow/variant/revision refs are present but
-    cannot identify a single revision unambiguously.
-
-    Currently raised when `workflow_revision_ref` carries only `version` (no
-    `id`, no `slug`) and no `workflow_variant_ref` is provided. A revision
-    version is a per-variant sequence number and requires a variant context.
-    `revision_ref.id` and `revision_ref.slug` are both project-unique and do
-    not require this.
-
-    Not raised for the all-refs-empty case: `fetch_workflow_revision` returns
-    `None` for that case rather than raising, matching its "nothing to look
-    up" contract.
-    """
-
-    def __init__(
-        self,
-        message: str = "Workflow refs do not identify a single revision unambiguously.",
-    ):
-        self.message = message
-        super().__init__(message)
-
-
-# ------------------------------------------------------------------------------

--- a/api/oss/src/core/workflows/service.py
+++ b/api/oss/src/core/workflows/service.py
@@ -78,9 +78,8 @@ from oss.src.core.workflows.dtos import (
     WorkflowServiceRequest,
     WorkflowServiceBatchResponse,
     WorkflowServiceStreamResponse,
-    #
-    WorkflowRefInvalid,
 )
+from oss.src.core.git.types import validate_revision_ref_unambiguous
 
 # Resolution is now handled by EmbedsService
 from oss.src.core.embeds.dtos import (
@@ -1081,38 +1080,12 @@ class WorkflowsService:
         if not workflow_ref and not workflow_variant_ref and not workflow_revision_ref:
             return None
 
-        # Reject ambiguous requests early.
-        #
-        # A revision `version` is a per-variant sequence number ("1", "2", ...).
-        # Without a variant context, the same version exists across many variants
-        # and cannot identify a single revision. The DAO would otherwise silently
-        # drop the version filter and return an arbitrary project-wide row.
-        #
-        # `workflow_revision_ref.id` and `workflow_revision_ref.slug` are both
-        # project-unique and remain valid on their own — only the version-only
-        # case is rejected here.
-        #
-        # Check the variant_ref for a populated identifier rather than just
-        # truthiness: an empty `Reference(id=None, slug=None, version=None)`
-        # is a truthy Python object but does not actually scope the lookup.
-        variant_identified = bool(
-            workflow_variant_ref
-            and (workflow_variant_ref.id or workflow_variant_ref.slug)
+        validate_revision_ref_unambiguous(
+            artifact_ref=workflow_ref,
+            variant_ref=workflow_variant_ref,
+            revision_ref=workflow_revision_ref,
+            artifact_kind="workflow",
         )
-        if (
-            workflow_revision_ref
-            and workflow_revision_ref.version
-            and not workflow_revision_ref.id
-            and not workflow_revision_ref.slug
-            and not variant_identified
-        ):
-            raise WorkflowRefInvalid(
-                "workflow_revision_ref.version is a per-variant sequence number "
-                "and requires a workflow_variant_ref to be unambiguous. "
-                "Provide a workflow_variant_ref, or identify the revision by "
-                "workflow_revision_ref.id or workflow_revision_ref.slug "
-                "(both are project-unique)."
-            )
 
         if workflow_ref and not workflow_variant_ref and not workflow_revision_ref:
             workflow = await self.fetch_workflow(

--- a/api/oss/src/core/workflows/service.py
+++ b/api/oss/src/core/workflows/service.py
@@ -1084,7 +1084,7 @@ class WorkflowsService:
             artifact_ref=workflow_ref,
             variant_ref=workflow_variant_ref,
             revision_ref=workflow_revision_ref,
-            artifact_kind="workflow",
+            entity_type="workflow",
         )
 
         if workflow_ref and not workflow_variant_ref and not workflow_revision_ref:

--- a/api/oss/tests/pytest/acceptance/test_revision_retrieve_ambiguous_400.py
+++ b/api/oss/tests/pytest/acceptance/test_revision_retrieve_ambiguous_400.py
@@ -4,11 +4,24 @@ The shared `validate_revision_ref_unambiguous` helper protects every
 git-backed entity's retrieve endpoint against the version-only-no-variant
 trap. These tests assert the 400 surfaces correctly across all six
 endpoints — applications, evaluators, queries, testsets, environments,
-workflows — and that legitimate requests in the same neighborhood still
-succeed.
+workflows — and that legitimate `{variant_ref + revision_ref:{version}}`
+requests in the same neighborhood still succeed.
 
-Each entity test creates its own minimal fixture (artifact + variant +
-revision) so the tests don't share global state.
+For each entity:
+
+  * A `_create_*_stack` helper provisions a real artifact + variant +
+    revision so the positive control has something to find. The negative
+    tests reuse the artifact slug; the variant and revision exist to
+    satisfy the positive control fixture.
+
+  * Two negative tests: `{revision_ref:{version}}` alone and
+    `{artifact_ref + revision_ref:{version}}`. Both must return 400 with
+    `version` and `variant_ref` in the error detail.
+
+  * One positive test: `{variant_ref:{slug} + revision_ref:{version}}`
+    must return 200 and resolve to the revision created in the fixture.
+
+Each test creates its own fixture so the tests don't share global state.
 """
 
 from uuid import uuid4
@@ -92,7 +105,6 @@ def test_workflows_retrieve_artifact_plus_version_returns_400(authed_api):
 
 
 def test_workflows_retrieve_variant_plus_version_succeeds(authed_api):
-    """Sanity check: the same request shape with a variant_ref must still work."""
     _, variant, revision = _create_workflow_stack(authed_api)
     response = authed_api(
         "POST",
@@ -133,7 +145,21 @@ def _create_application_stack(authed_api):
     )
     assert response.status_code == 200, response.text
     variant = response.json()["application_variant"]
-    return app, variant
+
+    response = authed_api(
+        "POST",
+        "/applications/revisions/commit",
+        json={
+            "application_revision_commit": {
+                "application_id": app["id"],
+                "application_variant_id": variant["id"],
+                "data": {"parameters": {"model": "test-model"}},
+            }
+        },
+    )
+    assert response.status_code == 200, response.text
+    revision = response.json()["application_revision"]
+    return app, variant, revision
 
 
 def test_applications_retrieve_version_only_returns_400(authed_api):
@@ -146,7 +172,7 @@ def test_applications_retrieve_version_only_returns_400(authed_api):
 
 
 def test_applications_retrieve_artifact_plus_version_returns_400(authed_api):
-    app, _ = _create_application_stack(authed_api)
+    app, _, _ = _create_application_stack(authed_api)
     response = authed_api(
         "POST",
         "/applications/revisions/retrieve",
@@ -156,6 +182,20 @@ def test_applications_retrieve_artifact_plus_version_returns_400(authed_api):
         },
     )
     _assert_ambiguous_400(response)
+
+
+def test_applications_retrieve_variant_plus_version_succeeds(authed_api):
+    _, variant, revision = _create_application_stack(authed_api)
+    response = authed_api(
+        "POST",
+        "/applications/revisions/retrieve",
+        json={
+            "application_variant_ref": {"slug": variant["slug"]},
+            "application_revision_ref": {"version": revision["version"]},
+        },
+    )
+    assert response.status_code == 200, response.text
+    assert response.json()["application_revision"]["id"] == revision["id"]
 
 
 # evaluators -------------------------------------------------------------------
@@ -185,7 +225,21 @@ def _create_evaluator_stack(authed_api):
     )
     assert response.status_code == 200, response.text
     variant = response.json()["evaluator_variant"]
-    return evaluator, variant
+
+    response = authed_api(
+        "POST",
+        "/evaluators/revisions/commit",
+        json={
+            "evaluator_revision_commit": {
+                "evaluator_id": evaluator["id"],
+                "evaluator_variant_id": variant["id"],
+                "data": {"parameters": {"model": "test-model"}},
+            }
+        },
+    )
+    assert response.status_code == 200, response.text
+    revision = response.json()["evaluator_revision"]
+    return evaluator, variant, revision
 
 
 def test_evaluators_retrieve_version_only_returns_400(authed_api):
@@ -198,7 +252,7 @@ def test_evaluators_retrieve_version_only_returns_400(authed_api):
 
 
 def test_evaluators_retrieve_artifact_plus_version_returns_400(authed_api):
-    evaluator, _ = _create_evaluator_stack(authed_api)
+    evaluator, _, _ = _create_evaluator_stack(authed_api)
     response = authed_api(
         "POST",
         "/evaluators/revisions/retrieve",
@@ -208,6 +262,20 @@ def test_evaluators_retrieve_artifact_plus_version_returns_400(authed_api):
         },
     )
     _assert_ambiguous_400(response)
+
+
+def test_evaluators_retrieve_variant_plus_version_succeeds(authed_api):
+    _, variant, revision = _create_evaluator_stack(authed_api)
+    response = authed_api(
+        "POST",
+        "/evaluators/revisions/retrieve",
+        json={
+            "evaluator_variant_ref": {"slug": variant["slug"]},
+            "evaluator_revision_ref": {"version": revision["version"]},
+        },
+    )
+    assert response.status_code == 200, response.text
+    assert response.json()["evaluator_revision"]["id"] == revision["id"]
 
 
 # testsets ---------------------------------------------------------------------
@@ -235,7 +303,21 @@ def _create_testset_stack(authed_api):
     )
     assert response.status_code == 200, response.text
     variant = response.json()["testset_variant"]
-    return testset, variant
+
+    response = authed_api(
+        "POST",
+        "/testsets/revisions/commit",
+        json={
+            "testset_revision_commit": {
+                "testset_id": testset["id"],
+                "testset_variant_id": variant["id"],
+                "data": {"testcases": []},
+            }
+        },
+    )
+    assert response.status_code == 200, response.text
+    revision = response.json()["testset_revision"]
+    return testset, variant, revision
 
 
 def test_testsets_retrieve_version_only_returns_400(authed_api):
@@ -248,7 +330,7 @@ def test_testsets_retrieve_version_only_returns_400(authed_api):
 
 
 def test_testsets_retrieve_artifact_plus_version_returns_400(authed_api):
-    testset, _ = _create_testset_stack(authed_api)
+    testset, _, _ = _create_testset_stack(authed_api)
     response = authed_api(
         "POST",
         "/testsets/revisions/retrieve",
@@ -260,19 +342,24 @@ def test_testsets_retrieve_artifact_plus_version_returns_400(authed_api):
     _assert_ambiguous_400(response)
 
 
+def test_testsets_retrieve_variant_plus_version_succeeds(authed_api):
+    _, variant, revision = _create_testset_stack(authed_api)
+    response = authed_api(
+        "POST",
+        "/testsets/revisions/retrieve",
+        json={
+            "testset_variant_ref": {"slug": variant["slug"]},
+            "testset_revision_ref": {"version": revision["version"]},
+        },
+    )
+    assert response.status_code == 200, response.text
+    assert response.json()["testset_revision"]["id"] == revision["id"]
+
+
 # queries ----------------------------------------------------------------------
 
 
-def test_queries_retrieve_version_only_returns_400(authed_api):
-    response = authed_api(
-        "POST",
-        "/queries/revisions/retrieve",
-        json={"query_revision_ref": {"version": "1"}},
-    )
-    _assert_ambiguous_400(response)
-
-
-def test_queries_retrieve_artifact_plus_version_returns_400(authed_api):
+def _create_query_stack(authed_api):
     slug = uuid4().hex[:12]
     response = authed_api(
         "POST",
@@ -290,6 +377,33 @@ def test_queries_retrieve_artifact_plus_version_returns_400(authed_api):
 
     response = authed_api(
         "POST",
+        "/queries/revisions/commit",
+        json={
+            "query_revision_commit": {
+                "query_id": query["id"],
+                "query_variant_id": query["variant_id"],
+                "data": {"windowing": {"limit": 50}},
+            }
+        },
+    )
+    assert response.status_code == 200, response.text
+    revision = response.json()["query_revision"]
+    return query, revision
+
+
+def test_queries_retrieve_version_only_returns_400(authed_api):
+    response = authed_api(
+        "POST",
+        "/queries/revisions/retrieve",
+        json={"query_revision_ref": {"version": "1"}},
+    )
+    _assert_ambiguous_400(response)
+
+
+def test_queries_retrieve_artifact_plus_version_returns_400(authed_api):
+    query, _ = _create_query_stack(authed_api)
+    response = authed_api(
+        "POST",
         "/queries/revisions/retrieve",
         json={
             "query_ref": {"slug": query["slug"]},
@@ -297,6 +411,21 @@ def test_queries_retrieve_artifact_plus_version_returns_400(authed_api):
         },
     )
     _assert_ambiguous_400(response)
+
+
+def test_queries_retrieve_variant_plus_version_succeeds(authed_api):
+    query, revision = _create_query_stack(authed_api)
+    # Queries use a single auto-created variant per query; identify it by id.
+    response = authed_api(
+        "POST",
+        "/queries/revisions/retrieve",
+        json={
+            "query_variant_ref": {"id": query["variant_id"]},
+            "query_revision_ref": {"version": revision["version"]},
+        },
+    )
+    assert response.status_code == 200, response.text
+    assert response.json()["query_revision"]["id"] == revision["id"]
 
 
 # environments -----------------------------------------------------------------
@@ -324,7 +453,21 @@ def _create_environment_stack(authed_api):
     )
     assert response.status_code == 200, response.text
     variant = response.json()["environment_variant"]
-    return environment, variant
+
+    response = authed_api(
+        "POST",
+        "/environments/revisions/commit",
+        json={
+            "environment_revision_commit": {
+                "environment_id": environment["id"],
+                "environment_variant_id": variant["id"],
+                "data": {"references": {}},
+            }
+        },
+    )
+    assert response.status_code == 200, response.text
+    revision = response.json()["environment_revision"]
+    return environment, variant, revision
 
 
 def test_environments_retrieve_version_only_returns_400(authed_api):
@@ -337,7 +480,7 @@ def test_environments_retrieve_version_only_returns_400(authed_api):
 
 
 def test_environments_retrieve_artifact_plus_version_returns_400(authed_api):
-    environment, _ = _create_environment_stack(authed_api)
+    environment, _, _ = _create_environment_stack(authed_api)
     response = authed_api(
         "POST",
         "/environments/revisions/retrieve",
@@ -347,3 +490,17 @@ def test_environments_retrieve_artifact_plus_version_returns_400(authed_api):
         },
     )
     _assert_ambiguous_400(response)
+
+
+def test_environments_retrieve_variant_plus_version_succeeds(authed_api):
+    _, variant, revision = _create_environment_stack(authed_api)
+    response = authed_api(
+        "POST",
+        "/environments/revisions/retrieve",
+        json={
+            "environment_variant_ref": {"slug": variant["slug"]},
+            "environment_revision_ref": {"version": revision["version"]},
+        },
+    )
+    assert response.status_code == 200, response.text
+    assert response.json()["environment_revision"]["id"] == revision["id"]

--- a/api/oss/tests/pytest/acceptance/test_revision_retrieve_ambiguous_400.py
+++ b/api/oss/tests/pytest/acceptance/test_revision_retrieve_ambiguous_400.py
@@ -1,0 +1,349 @@
+"""Acceptance: ambiguous revision-retrieve requests return HTTP 400.
+
+The shared `validate_revision_ref_unambiguous` helper protects every
+git-backed entity's retrieve endpoint against the version-only-no-variant
+trap. These tests assert the 400 surfaces correctly across all six
+endpoints — applications, evaluators, queries, testsets, environments,
+workflows — and that legitimate requests in the same neighborhood still
+succeed.
+
+Each entity test creates its own minimal fixture (artifact + variant +
+revision) so the tests don't share global state.
+"""
+
+from uuid import uuid4
+
+
+# helpers ----------------------------------------------------------------------
+
+
+def _assert_ambiguous_400(response):
+    assert response.status_code == 400, response.text
+    # The error message should mention the version field and the variant ref
+    # so the caller can see why their request was rejected.
+    body = response.json()
+    detail = body.get("detail", "")
+    assert "version" in detail, body
+    assert "variant_ref" in detail, body
+
+
+# workflows --------------------------------------------------------------------
+
+
+def _create_workflow_stack(authed_api):
+    slug = uuid4().hex[:12]
+    response = authed_api(
+        "POST",
+        "/workflows/",
+        json={"workflow": {"slug": f"wf-{slug}"}},
+    )
+    assert response.status_code == 200, response.text
+    workflow = response.json()["workflow"]
+
+    response = authed_api(
+        "POST",
+        "/workflows/variants/",
+        json={
+            "workflow_variant": {
+                "slug": f"wfv-{slug}",
+                "workflow_id": workflow["id"],
+            }
+        },
+    )
+    assert response.status_code == 200, response.text
+    variant = response.json()["workflow_variant"]
+
+    response = authed_api(
+        "POST",
+        "/workflows/revisions/",
+        json={
+            "workflow_revision": {
+                "slug": f"wfr-{slug}",
+                "workflow_variant_id": variant["id"],
+                "workflow_id": workflow["id"],
+            }
+        },
+    )
+    assert response.status_code == 200, response.text
+    revision = response.json()["workflow_revision"]
+    return workflow, variant, revision
+
+
+def test_workflows_retrieve_version_only_returns_400(authed_api):
+    response = authed_api(
+        "POST",
+        "/workflows/revisions/retrieve",
+        json={"workflow_revision_ref": {"version": "1"}},
+    )
+    _assert_ambiguous_400(response)
+
+
+def test_workflows_retrieve_artifact_plus_version_returns_400(authed_api):
+    workflow, _, _ = _create_workflow_stack(authed_api)
+    response = authed_api(
+        "POST",
+        "/workflows/revisions/retrieve",
+        json={
+            "workflow_ref": {"slug": workflow["slug"]},
+            "workflow_revision_ref": {"version": "1"},
+        },
+    )
+    _assert_ambiguous_400(response)
+
+
+def test_workflows_retrieve_variant_plus_version_succeeds(authed_api):
+    """Sanity check: the same request shape with a variant_ref must still work."""
+    _, variant, revision = _create_workflow_stack(authed_api)
+    response = authed_api(
+        "POST",
+        "/workflows/revisions/retrieve",
+        json={
+            "workflow_variant_ref": {"slug": variant["slug"]},
+            "workflow_revision_ref": {"version": revision["version"]},
+        },
+    )
+    assert response.status_code == 200, response.text
+    assert response.json()["workflow_revision"]["id"] == revision["id"]
+
+
+# applications -----------------------------------------------------------------
+
+
+def _create_application_stack(authed_api):
+    slug = uuid4().hex[:12]
+    flags = {"is_application": True, "is_evaluator": False, "is_snippet": False}
+    response = authed_api(
+        "POST",
+        "/applications/",
+        json={"application": {"slug": f"app-{slug}", "flags": flags}},
+    )
+    assert response.status_code == 200, response.text
+    app = response.json()["application"]
+
+    response = authed_api(
+        "POST",
+        "/applications/variants/",
+        json={
+            "application_variant": {
+                "slug": f"appv-{slug}",
+                "application_id": app["id"],
+                "flags": flags,
+            }
+        },
+    )
+    assert response.status_code == 200, response.text
+    variant = response.json()["application_variant"]
+    return app, variant
+
+
+def test_applications_retrieve_version_only_returns_400(authed_api):
+    response = authed_api(
+        "POST",
+        "/applications/revisions/retrieve",
+        json={"application_revision_ref": {"version": "1"}},
+    )
+    _assert_ambiguous_400(response)
+
+
+def test_applications_retrieve_artifact_plus_version_returns_400(authed_api):
+    app, _ = _create_application_stack(authed_api)
+    response = authed_api(
+        "POST",
+        "/applications/revisions/retrieve",
+        json={
+            "application_ref": {"slug": app["slug"]},
+            "application_revision_ref": {"version": "1"},
+        },
+    )
+    _assert_ambiguous_400(response)
+
+
+# evaluators -------------------------------------------------------------------
+
+
+def _create_evaluator_stack(authed_api):
+    slug = uuid4().hex[:12]
+    flags = {"is_application": False, "is_evaluator": True, "is_snippet": False}
+    response = authed_api(
+        "POST",
+        "/evaluators/",
+        json={"evaluator": {"slug": f"ev-{slug}", "flags": flags}},
+    )
+    assert response.status_code == 200, response.text
+    evaluator = response.json()["evaluator"]
+
+    response = authed_api(
+        "POST",
+        "/evaluators/variants/",
+        json={
+            "evaluator_variant": {
+                "slug": f"evv-{slug}",
+                "evaluator_id": evaluator["id"],
+                "flags": flags,
+            }
+        },
+    )
+    assert response.status_code == 200, response.text
+    variant = response.json()["evaluator_variant"]
+    return evaluator, variant
+
+
+def test_evaluators_retrieve_version_only_returns_400(authed_api):
+    response = authed_api(
+        "POST",
+        "/evaluators/revisions/retrieve",
+        json={"evaluator_revision_ref": {"version": "1"}},
+    )
+    _assert_ambiguous_400(response)
+
+
+def test_evaluators_retrieve_artifact_plus_version_returns_400(authed_api):
+    evaluator, _ = _create_evaluator_stack(authed_api)
+    response = authed_api(
+        "POST",
+        "/evaluators/revisions/retrieve",
+        json={
+            "evaluator_ref": {"slug": evaluator["slug"]},
+            "evaluator_revision_ref": {"version": "1"},
+        },
+    )
+    _assert_ambiguous_400(response)
+
+
+# testsets ---------------------------------------------------------------------
+
+
+def _create_testset_stack(authed_api):
+    slug = uuid4().hex[:12]
+    response = authed_api(
+        "POST",
+        "/testsets/",
+        json={"testset": {"slug": f"ts-{slug}"}},
+    )
+    assert response.status_code == 200, response.text
+    testset = response.json()["testset"]
+
+    response = authed_api(
+        "POST",
+        "/testsets/variants/",
+        json={
+            "testset_variant": {
+                "slug": f"tsv-{slug}",
+                "testset_id": testset["id"],
+            }
+        },
+    )
+    assert response.status_code == 200, response.text
+    variant = response.json()["testset_variant"]
+    return testset, variant
+
+
+def test_testsets_retrieve_version_only_returns_400(authed_api):
+    response = authed_api(
+        "POST",
+        "/testsets/revisions/retrieve",
+        json={"testset_revision_ref": {"version": "1"}},
+    )
+    _assert_ambiguous_400(response)
+
+
+def test_testsets_retrieve_artifact_plus_version_returns_400(authed_api):
+    testset, _ = _create_testset_stack(authed_api)
+    response = authed_api(
+        "POST",
+        "/testsets/revisions/retrieve",
+        json={
+            "testset_ref": {"slug": testset["slug"]},
+            "testset_revision_ref": {"version": "1"},
+        },
+    )
+    _assert_ambiguous_400(response)
+
+
+# queries ----------------------------------------------------------------------
+
+
+def test_queries_retrieve_version_only_returns_400(authed_api):
+    response = authed_api(
+        "POST",
+        "/queries/revisions/retrieve",
+        json={"query_revision_ref": {"version": "1"}},
+    )
+    _assert_ambiguous_400(response)
+
+
+def test_queries_retrieve_artifact_plus_version_returns_400(authed_api):
+    slug = uuid4().hex[:12]
+    response = authed_api(
+        "POST",
+        "/simple/queries/",
+        json={
+            "query": {
+                "slug": f"qry-{slug}",
+                "name": f"qry-{slug}",
+                "data": {"windowing": {"limit": 50}},
+            }
+        },
+    )
+    assert response.status_code == 200, response.text
+    query = response.json()["query"]
+
+    response = authed_api(
+        "POST",
+        "/queries/revisions/retrieve",
+        json={
+            "query_ref": {"slug": query["slug"]},
+            "query_revision_ref": {"version": "1"},
+        },
+    )
+    _assert_ambiguous_400(response)
+
+
+# environments -----------------------------------------------------------------
+
+
+def _create_environment_stack(authed_api):
+    slug = uuid4().hex[:12]
+    response = authed_api(
+        "POST",
+        "/environments/",
+        json={"environment": {"slug": f"env-{slug}"}},
+    )
+    assert response.status_code == 200, response.text
+    environment = response.json()["environment"]
+
+    response = authed_api(
+        "POST",
+        "/environments/variants/",
+        json={
+            "environment_variant": {
+                "slug": f"envv-{slug}",
+                "environment_id": environment["id"],
+            }
+        },
+    )
+    assert response.status_code == 200, response.text
+    variant = response.json()["environment_variant"]
+    return environment, variant
+
+
+def test_environments_retrieve_version_only_returns_400(authed_api):
+    response = authed_api(
+        "POST",
+        "/environments/revisions/retrieve",
+        json={"environment_revision_ref": {"version": "1"}},
+    )
+    _assert_ambiguous_400(response)
+
+
+def test_environments_retrieve_artifact_plus_version_returns_400(authed_api):
+    environment, _ = _create_environment_stack(authed_api)
+    response = authed_api(
+        "POST",
+        "/environments/revisions/retrieve",
+        json={
+            "environment_ref": {"slug": environment["slug"]},
+            "environment_revision_ref": {"version": "1"},
+        },
+    )
+    _assert_ambiguous_400(response)

--- a/api/oss/tests/pytest/unit/test_revision_ref_validation.py
+++ b/api/oss/tests/pytest/unit/test_revision_ref_validation.py
@@ -1,0 +1,221 @@
+"""Unit tests for the shared revision-ref ambiguity validator.
+
+The helper lives in `core/git/types.py` and protects the retrieve flow for
+every git-backed entity (workflows, applications, evaluators, testsets,
+queries, environments) against the version-only-no-variant trap that used
+to return arbitrary project-wide rows.
+"""
+
+from uuid import uuid4
+
+import pytest
+
+from oss.src.core.git.types import (
+    RevisionRefInvalid,
+    validate_revision_ref_unambiguous,
+)
+from oss.src.core.shared.dtos import Reference
+
+
+# helpers ---------------------------------------------------------------------
+
+
+def _ref(*, id=None, slug=None, version=None):
+    return Reference(id=id, slug=slug, version=version)
+
+
+# version-only revision_ref ---------------------------------------------------
+
+
+class TestVersionOnlyRejection:
+    """`revision_ref.version` alone (no id, no slug) is ambiguous without a
+    variant scope and must raise."""
+
+    def test_version_only_no_variant_raises(self):
+        with pytest.raises(RevisionRefInvalid) as exc:
+            validate_revision_ref_unambiguous(
+                artifact_ref=None,
+                variant_ref=None,
+                revision_ref=_ref(version="1"),
+            )
+        assert "version" in exc.value.message
+
+    def test_version_only_with_empty_variant_ref_raises(self):
+        # Reference(id=None, slug=None, version=None) is truthy but unidentifying.
+        with pytest.raises(RevisionRefInvalid):
+            validate_revision_ref_unambiguous(
+                artifact_ref=None,
+                variant_ref=_ref(),
+                revision_ref=_ref(version="1"),
+            )
+
+    def test_version_only_with_variant_having_only_version_raises(self):
+        # A variant_ref whose only field is `version` doesn't scope anything
+        # — version isn't an identifier for the variant either.
+        with pytest.raises(RevisionRefInvalid):
+            validate_revision_ref_unambiguous(
+                artifact_ref=None,
+                variant_ref=_ref(version="3"),
+                revision_ref=_ref(version="1"),
+            )
+
+    def test_version_only_with_artifact_ref_still_raises(self):
+        # artifact_ref alone is not enough to scope a version today (the
+        # service would have to resolve artifact → default variant first,
+        # which is non-deterministic for multi-variant artifacts). Helper
+        # is conservative until that resolution is fixed.
+        with pytest.raises(RevisionRefInvalid):
+            validate_revision_ref_unambiguous(
+                artifact_ref=_ref(slug="my-workflow"),
+                variant_ref=None,
+                revision_ref=_ref(version="1"),
+            )
+
+    def test_artifact_kind_appears_in_message(self):
+        with pytest.raises(RevisionRefInvalid) as exc:
+            validate_revision_ref_unambiguous(
+                artifact_ref=None,
+                variant_ref=None,
+                revision_ref=_ref(version="1"),
+                artifact_kind="testset",
+            )
+        assert "testset_revision_ref.version" in exc.value.message
+        assert "testset_variant_ref" in exc.value.message
+
+    def test_artifact_kind_default_is_artifact(self):
+        with pytest.raises(RevisionRefInvalid) as exc:
+            validate_revision_ref_unambiguous(
+                artifact_ref=None,
+                variant_ref=None,
+                revision_ref=_ref(version="1"),
+            )
+        assert "artifact_revision_ref.version" in exc.value.message
+
+
+# version-only with sufficient variant scope ---------------------------------
+
+
+class TestVersionOnlyWithVariantPasses:
+    def test_variant_id_scopes_version(self):
+        validate_revision_ref_unambiguous(
+            artifact_ref=None,
+            variant_ref=_ref(id=uuid4()),
+            revision_ref=_ref(version="1"),
+        )
+
+    def test_variant_slug_scopes_version(self):
+        validate_revision_ref_unambiguous(
+            artifact_ref=None,
+            variant_ref=_ref(slug="my-variant"),
+            revision_ref=_ref(version="1"),
+        )
+
+    def test_variant_id_with_artifact_also_passes(self):
+        validate_revision_ref_unambiguous(
+            artifact_ref=_ref(slug="my-workflow"),
+            variant_ref=_ref(id=uuid4()),
+            revision_ref=_ref(version="1"),
+        )
+
+
+# revision_ref with id or slug is always sufficient --------------------------
+
+
+class TestRevisionIdOrSlugAlwaysSufficient:
+    def test_revision_id_alone(self):
+        validate_revision_ref_unambiguous(
+            artifact_ref=None,
+            variant_ref=None,
+            revision_ref=_ref(id=uuid4()),
+        )
+
+    def test_revision_slug_alone(self):
+        validate_revision_ref_unambiguous(
+            artifact_ref=None,
+            variant_ref=None,
+            revision_ref=_ref(slug="my-revision"),
+        )
+
+    def test_revision_id_with_version_ignores_version(self):
+        # The id is project-unique; version becomes a redundant hint.
+        validate_revision_ref_unambiguous(
+            artifact_ref=None,
+            variant_ref=None,
+            revision_ref=_ref(id=uuid4(), version="1"),
+        )
+
+    def test_revision_slug_with_version_ignores_version(self):
+        validate_revision_ref_unambiguous(
+            artifact_ref=None,
+            variant_ref=None,
+            revision_ref=_ref(slug="my-rev", version="1"),
+        )
+
+
+# nothing-to-look-up cases ---------------------------------------------------
+
+
+class TestNonTriggering:
+    """Cases that must NOT raise: the helper is scoped to one specific
+    ambiguity and leaves all others to the caller."""
+
+    def test_all_refs_none(self):
+        validate_revision_ref_unambiguous(
+            artifact_ref=None,
+            variant_ref=None,
+            revision_ref=None,
+        )
+
+    def test_all_refs_empty(self):
+        validate_revision_ref_unambiguous(
+            artifact_ref=_ref(),
+            variant_ref=_ref(),
+            revision_ref=_ref(),
+        )
+
+    def test_artifact_only(self):
+        validate_revision_ref_unambiguous(
+            artifact_ref=_ref(slug="my-workflow"),
+            variant_ref=None,
+            revision_ref=None,
+        )
+
+    def test_variant_only(self):
+        validate_revision_ref_unambiguous(
+            artifact_ref=None,
+            variant_ref=_ref(slug="my-variant"),
+            revision_ref=None,
+        )
+
+    def test_artifact_and_variant_no_revision(self):
+        validate_revision_ref_unambiguous(
+            artifact_ref=_ref(slug="my-workflow"),
+            variant_ref=_ref(slug="my-variant"),
+            revision_ref=None,
+        )
+
+
+# exception type --------------------------------------------------------------
+
+
+class TestExceptionType:
+    def test_revision_ref_invalid_is_git_error(self):
+        from oss.src.core.git.types import GitError
+
+        with pytest.raises(GitError):
+            validate_revision_ref_unambiguous(
+                artifact_ref=None,
+                variant_ref=None,
+                revision_ref=_ref(version="1"),
+            )
+
+    def test_exception_message_attribute(self):
+        with pytest.raises(RevisionRefInvalid) as exc:
+            validate_revision_ref_unambiguous(
+                artifact_ref=None,
+                variant_ref=None,
+                revision_ref=_ref(version="1"),
+            )
+        # Has the .message attribute carried by GitError base.
+        assert exc.value.message
+        assert isinstance(exc.value.message, str)

--- a/api/oss/tests/pytest/unit/test_revision_ref_validation.py
+++ b/api/oss/tests/pytest/unit/test_revision_ref_validation.py
@@ -71,18 +71,18 @@ class TestVersionOnlyRejection:
                 revision_ref=_ref(version="1"),
             )
 
-    def test_artifact_kind_appears_in_message(self):
+    def test_entity_type_appears_in_message(self):
         with pytest.raises(RevisionRefInvalid) as exc:
             validate_revision_ref_unambiguous(
                 artifact_ref=None,
                 variant_ref=None,
                 revision_ref=_ref(version="1"),
-                artifact_kind="testset",
+                entity_type="testset",
             )
         assert "testset_revision_ref.version" in exc.value.message
         assert "testset_variant_ref" in exc.value.message
 
-    def test_artifact_kind_default_is_artifact(self):
+    def test_entity_type_default_is_artifact(self):
         with pytest.raises(RevisionRefInvalid) as exc:
             validate_revision_ref_unambiguous(
                 artifact_ref=None,


### PR DESCRIPTION
## Summary

Extends the workflow retrieve-side guardrails from PR #4418 to **all six git-backed entities** (applications, evaluators, queries, testsets, environments, workflows) by factoring the validation into a single shared helper. Closes the gap where the same ambiguous request shape that returned a clean 400 on `/workflows/revisions/retrieve` would return either an unintelligible 500 (applications, evaluators) or silently swallowed `None` (testsets, queries, environments).

Builds on `b8c1ce5c4` from PR #4418 — the DAO bailout introduced there protects every entity at the DB layer, but the service-level validation and HTTP 400 translation existed only in workflows. This PR completes the parity.

## What changed

**Shared validator (new):** `api/oss/src/core/git/types.py`
- New exception `RevisionRefInvalid(GitError)` — replaces workflow-specific `WorkflowRefInvalid`.
- New helper `validate_revision_ref_unambiguous(artifact_ref, variant_ref, revision_ref, entity_type)` — single source of truth for the version-only-no-variant rule. Accepts `entity_type` so each entity gets an entity-specific error message without duplicating the rule.
- Internal `_has_id_or_slug(ref)` — explicit check that a `Reference` actually identifies (not just truthy).

**Workflows:** `WorkflowRefInvalid` removed from `core/workflows/dtos.py`; service uses the shared helper. Workflows router updated to import `RevisionRefInvalid` instead.

**Five other entities:** each `core/*/service.py` now calls the helper at the top of `fetch_*_revision`. Each `apis/fastapi/*/router.py` retrieves/deploys that pass caller refs through now wrap with `try/except RevisionRefInvalid → HTTPException(400)`, matching the existing `VariantForkError` pattern in the same routers.

**Field docstrings:** the 5 `*RevisionRetrieveRequest` request models (applications, evaluators, testsets, queries, environments) get the same accurate field descriptions PR #4418 introduced on `WorkflowRevisionRetrieveRequest`. Stops saying "by `id`, or by `slug` + `version`" which is misleading on both counts.

## Behavior change matrix

For request `{*_revision_ref: {version: "1"}}` (or `{*_ref + *_revision_ref: {version}}`):

| Entity | Before | After |
|---|---|---|
| workflows | HTTP 400 (PR #4418) | HTTP 400 (unchanged, shared helper) |
| applications | HTTP 500 (uncaught `WorkflowRefInvalid` → generic intercept) | HTTP 400 |
| evaluators | HTTP 500 (same) | HTTP 400 |
| testsets | silent `None` (DAO bailout from #4418) | HTTP 400 |
| queries | silent `None` (same) | HTTP 400 |
| environments | silent `None` (same) | HTTP 400 |

Nothing that worked before stops working. Requests that previously returned wrong data or 500s now return a clear 400 explaining the ambiguity.

## What's NOT in this PR

Tracked by the [audit doc](docs/design/playground-open-from-trace/retrieve-endpoint-audit.md) from PR #4418:

- **Accepting `{artifact_ref + version}` by resolving to a default variant first** — requires fixing identified bug (non-deterministic `fetch_*_variant(artifact_ref)`) first. The helper docstring explicitly notes that once that resolution becomes deterministic, callers can resolve `artifact_ref → variant_ref` before invoking the helper and the same shape will pass without changing the helper.
- Rules enforcement (A through E).
- DAO `artifact_ref` parameter refactor.
- Frontend caller normalization.

## Tests

- **Unit:** `api/oss/tests/pytest/unit/test_revision_ref_validation.py` (16 cases). Covers: version-only rejection across all permutations of empty/identifying variant_refs; version-only-with-artifact still rejected (documents the conservative stance); id-and-slug always sufficient; all-empty doesn't raise; `artifact_kind` interpolated into the error message; `RevisionRefInvalid` is a `GitError`.
- **Acceptance:** `api/oss/tests/pytest/acceptance/test_revision_retrieve_ambiguous_400.py` — for each of the 6 entities, both `{revision_ref:{version}}` and `{artifact_ref + revision_ref:{version}}` return 400 with `version` and `variant_ref` in the detail. Plus a positive control on workflows confirming `{variant_ref + revision_ref:{version}}` still returns 200.

## Test plan

- [x] `ruff format` and `ruff check` clean on api/ ✅
- [ ] Unit tests pass (`py-run-tests` from `api/`)
- [ ] Acceptance tests pass against a running stack
- [ ] No existing caller in `core/embeds/utils.py`, `core/applications/service.py`, `core/evaluations/tasks/legacy.py`, or `core/workflows/service.py` (internal) hits the new validation — they all send id-based or full-triple-ref shapes, audited by PR #4418's commit message
- [ ] Frontend `playgroundController.ts` continues to work; the separate FE PR (Bug F follow-up from #4418) will normalize it to never send the ambiguous shape
