### PR TITLE
fix(sdk): record invocation parameters on the root span

### DIFF
--- a/sdks/python/agenta/sdk/middlewares/running/resolver.py
+++ b/sdks/python/agenta/sdk/middlewares/running/resolver.py
@@ -10,6 +10,7 @@ from agenta.sdk.models.workflows import (
     WorkflowRevisionData,
 )
 from agenta.sdk.contexts.running import RunningContext
+from agenta.sdk.contexts.tracing import TracingContext
 from agenta.sdk.engines.running.utils import (
     retrieve_handler,
 )
@@ -454,5 +455,7 @@ class ResolverMiddleware:
 
         if revision:
             request.data.parameters = request.data.parameters or revision.parameters
+
+        TracingContext.get().parameters = request.data.parameters
 
         return await call_next(request)

--- a/sdks/python/oss/tests/pytest/utils/test_resolver_middleware.py
+++ b/sdks/python/oss/tests/pytest/utils/test_resolver_middleware.py
@@ -4,11 +4,13 @@ Unit tests for the ResolverMiddleware and related helpers.
 Tests cover:
 - _has_embed_markers() detection of @ag.embed in various config structures
 - ResolverMiddleware skipping resolve_embeds() when no markers present
+- ResolverMiddleware mirroring resolved parameters onto TracingContext
 """
 
 import pytest
 from unittest.mock import AsyncMock, MagicMock, patch
 
+from agenta.sdk.contexts.tracing import TracingContext, tracing_context_manager
 from agenta.sdk.middlewares.running.resolver import _has_embed_markers
 
 
@@ -179,7 +181,8 @@ class TestResolverMiddlewareEmbedGate:
         ):
             mw = ResolverMiddleware()
             call_next = AsyncMock(return_value="result")
-            await mw(request, call_next)
+            with tracing_context_manager(TracingContext()):
+                await mw(request, call_next)
 
         mock_resolve_embeds.assert_not_called()
 
@@ -232,7 +235,8 @@ class TestResolverMiddlewareEmbedGate:
         ):
             mw = ResolverMiddleware()
             call_next = AsyncMock(return_value="result")
-            await mw(request, call_next)
+            with tracing_context_manager(TracingContext()):
+                await mw(request, call_next)
 
         mock_resolve_embeds.assert_called_once_with(
             parameters=params_with_embed,
@@ -281,6 +285,217 @@ class TestResolverMiddlewareEmbedGate:
         ):
             mw = ResolverMiddleware()
             call_next = AsyncMock(return_value="result")
-            await mw(request, call_next)
+            with tracing_context_manager(TracingContext()):
+                await mw(request, call_next)
 
         mock_resolve_embeds.assert_not_called()
+
+
+class TestResolverMiddlewareTracingParameters:
+    """Tests that ResolverMiddleware mirrors the resolved parameters onto
+    TracingContext, so the root span records them under ag.meta.configuration.
+
+    The middleware must populate TracingContext.parameters with whatever the
+    handler will ultimately receive on request.data.parameters. That covers:
+    - parameters supplied directly in the invoke payload
+    - parameters fetched from a revision via data.revision or references
+    - parameters after @ag.embed expansion
+    """
+
+    @pytest.mark.asyncio
+    async def test_mirrors_parameters_supplied_in_request(self):
+        """
+        When the caller sends parameters in the invoke payload, those exact
+        parameters must land on TracingContext.parameters.
+        """
+        from agenta.sdk.middlewares.running.resolver import ResolverMiddleware
+        from agenta.sdk.models.workflows import (
+            WorkflowInvokeRequest,
+            WorkflowRequestData,
+        )
+
+        request_params = {"prompt": {"llm_config": {"model": "gpt-4o-mini"}}}
+
+        request = WorkflowInvokeRequest(
+            credentials="test-creds",
+            flags={"resolve": True},
+            data=WorkflowRequestData(
+                parameters=request_params,
+                revision={"data": {"uri": "test://uri"}},
+            ),
+        )
+
+        with (
+            patch(
+                "agenta.sdk.middlewares.running.resolver.resolve_handler",
+                new_callable=AsyncMock,
+                return_value=MagicMock(),
+            ),
+            patch(
+                "agenta.sdk.middlewares.running.resolver.resolve_embeds",
+                new_callable=AsyncMock,
+            ),
+            tracing_context_manager(TracingContext()),
+        ):
+            mw = ResolverMiddleware()
+            call_next = AsyncMock(return_value="result")
+            await mw(request, call_next)
+
+            assert TracingContext.get().parameters == request_params
+
+    @pytest.mark.asyncio
+    async def test_mirrors_parameters_fetched_from_revision(self):
+        """
+        When the caller sends no parameters but the revision carries them,
+        the revision's parameters must land on TracingContext.parameters.
+        """
+        from agenta.sdk.middlewares.running.resolver import ResolverMiddleware
+        from agenta.sdk.models.workflows import (
+            WorkflowInvokeRequest,
+            WorkflowRequestData,
+        )
+
+        revision_params = {"model": "gpt-4", "temperature": 0.7}
+
+        request = WorkflowInvokeRequest(
+            credentials="test-creds",
+            flags={"resolve": True},
+            data=WorkflowRequestData(
+                revision={
+                    "data": {
+                        "uri": "test://uri",
+                        "parameters": revision_params,
+                    }
+                }
+            ),
+        )
+
+        with (
+            patch(
+                "agenta.sdk.middlewares.running.resolver.resolve_handler",
+                new_callable=AsyncMock,
+                return_value=MagicMock(),
+            ),
+            patch(
+                "agenta.sdk.middlewares.running.resolver.resolve_embeds",
+                new_callable=AsyncMock,
+            ),
+            tracing_context_manager(TracingContext()),
+        ):
+            mw = ResolverMiddleware()
+            call_next = AsyncMock(return_value="result")
+            await mw(request, call_next)
+
+            assert TracingContext.get().parameters == revision_params
+
+    @pytest.mark.asyncio
+    async def test_mirrors_parameters_fetched_via_reference_hydration(self):
+        """
+        When the caller sends references but no data.revision and no
+        data.parameters, the middleware must call resolve_references, hydrate
+        the revision, and mirror the hydrated parameters onto TracingContext.
+
+        This is the regression path the fix specifically calls out: the other
+        tests seed data.revision directly and so bypass reference hydration.
+        """
+        from agenta.sdk.middlewares.running.resolver import ResolverMiddleware
+        from agenta.sdk.models.workflows import (
+            WorkflowInvokeRequest,
+            WorkflowRequestData,
+            WorkflowRevisionData,
+        )
+
+        hydrated_params = {"model": "gpt-4o-mini", "temperature": 0.2}
+
+        request = WorkflowInvokeRequest(
+            credentials="test-creds",
+            flags={"resolve": True},
+            references={
+                "application": {"slug": "my-app"},
+                "application_variant": {"slug": "my-app.default"},
+            },
+            data=WorkflowRequestData(),
+        )
+
+        hydrated_revision = WorkflowRevisionData(
+            uri="test://uri",
+            parameters=hydrated_params,
+        )
+
+        with (
+            patch(
+                "agenta.sdk.middlewares.running.resolver.resolve_references",
+                new_callable=AsyncMock,
+                return_value=hydrated_revision,
+            ) as mock_resolve_references,
+            patch(
+                "agenta.sdk.middlewares.running.resolver.resolve_handler",
+                new_callable=AsyncMock,
+                return_value=MagicMock(),
+            ),
+            patch(
+                "agenta.sdk.middlewares.running.resolver.resolve_embeds",
+                new_callable=AsyncMock,
+            ),
+            tracing_context_manager(TracingContext()),
+        ):
+            mw = ResolverMiddleware()
+            call_next = AsyncMock(return_value="result")
+            await mw(request, call_next)
+
+            mock_resolve_references.assert_called_once()
+            assert TracingContext.get().parameters == hydrated_params
+
+    @pytest.mark.asyncio
+    async def test_mirrors_parameters_after_embed_expansion(self):
+        """
+        When the revision parameters contain @ag.embed markers and resolve is
+        enabled, the post-expansion parameters (not the pre-expansion ones)
+        must land on TracingContext.parameters.
+        """
+        from agenta.sdk.middlewares.running.resolver import ResolverMiddleware
+        from agenta.sdk.models.workflows import (
+            WorkflowInvokeRequest,
+            WorkflowRequestData,
+        )
+
+        params_with_embed = {
+            "prompt": {
+                "@ag.embed": {
+                    "@ag.references": {"workflow_revision": {"slug": "base"}},
+                }
+            }
+        }
+        resolved_params = {"prompt": {"messages": [{"role": "system"}]}}
+
+        request = WorkflowInvokeRequest(
+            credentials="test-creds",
+            flags={"resolve": True},
+            data=WorkflowRequestData(
+                revision={
+                    "data": {
+                        "uri": "test://uri",
+                        "parameters": params_with_embed,
+                    }
+                }
+            ),
+        )
+
+        with (
+            patch(
+                "agenta.sdk.middlewares.running.resolver.resolve_handler",
+                new_callable=AsyncMock,
+                return_value=MagicMock(),
+            ),
+            patch(
+                "agenta.sdk.middlewares.running.resolver.resolve_embeds",
+                new_callable=AsyncMock,
+                return_value=resolved_params,
+            ),
+            tracing_context_manager(TracingContext()),
+        ):
+            mw = ResolverMiddleware()
+            call_next = AsyncMock(return_value="result")
+            await mw(request, call_next)
+
+            assert TracingContext.get().parameters == resolved_params


### PR DESCRIPTION
## Symptom

Invoking a chat or completion app from the playground produced traces with `ag.meta.configuration = {}` on the root span, even though the invoke payload carried a full `parameters` object (prompt, llm_config, etc).

The handler still received the parameters and the call ran correctly. Only the trace was empty.

## Cause

The tracing decorator at `sdks/python/agenta/sdk/decorators/tracing.py:393-397` reads `TracingContext.parameters` when setting the root span's configuration attribute:

```python
if span.parent is None:
    span.set_attributes(
        attributes={"configuration": context.parameters or {}},
        namespace="meta",
    )
```

`TracingContext.parameters` is declared as a field in `sdks/python/agenta/sdk/contexts/tracing.py:15`, but no code in the SDK ever assigned to it. A grep across the repo for any writer was empty. So the root span always recorded the `{}` fallback.

The `workflow.invoke` method populates `tracing_ctx.credentials`, `flags`, `tags`, `meta`, `references`, and `links` (`decorators/running.py:346-356`), but not `parameters`. Only `running_ctx.parameters` is set (line 374), and the tracing decorator does not read from `RunningContext`.

## Fix

`ResolverMiddleware` mirrors the resolved parameters onto the tracing context after it merges request and revision values:

```python
TracingContext.get().parameters = request.data.parameters
```

The resolver is the single funnel where both invocation paths converge:

- parameters supplied directly in the invoke payload (playground case)
- parameters fetched from a revision via references (programmatic-by-ref case)

It also runs after `@ag.embed` expansion. So whatever the handler is about to receive is what the trace records.

## Test plan

- [x] `pytest sdks/python/oss/tests/pytest/utils/test_resolver_middleware.py -v` (22 passed)
- [x] Three new tests in `TestResolverMiddlewareTracingParameters` cover the three resolver paths: request-supplied, revision-fetched, and post-embed-expansion
- [x] Existing `TestResolverMiddlewareEmbedGate` tests now wrap the middleware in `tracing_context_manager` to mirror production usage. Without the wrapper, the mutation would land on a throwaway default context and silently pass even if the assignment regressed.
- [ ] Manual: invoke a chat app from the playground, open the resulting trace, verify the root span carries `ag.meta.configuration` populated with the prompt and llm_config