### PR TITLE
[fix] Resolve retrieve-related issue 1: stable tie-break for latest-revision

### DIFF
--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -3,13 +3,13 @@ repos:
     hooks:
       - id: ruff-format
         name: ruff format
-        entry: python3 -m ruff format
+        entry: ruff format
         language: system
         types: [python]
         exclude: ^clients/
       - id: ruff-check
         name: ruff check
-        entry: python3 -m ruff check
+        entry: ruff check
         language: system
         types: [python]
         exclude: ^clients/

--- a/api/oss/src/apis/fastapi/applications/models.py
+++ b/api/oss/src/apis/fastapi/applications/models.py
@@ -361,9 +361,9 @@ class ApplicationRevisionCommitRequest(BaseModel):
 class ApplicationRevisionRetrieveRequest(BaseModel):
     """Request body for `POST /applications/revisions/retrieve`.
 
-    Resolves to a single revision by one of several reference types. Exactly one
-    reference path is needed; the most specific wins when several are provided.
-    See the [Applications guide](/reference/api-guide/applications#invocation).
+    Resolves to a single revision by one or more reference types. Every
+    reference supplied must agree with the resolved revision; contradictions
+    return HTTP 400. See the [Applications guide](/reference/api-guide/applications#invocation).
     """
 
     application_ref: Optional[Reference] = Field(
@@ -371,8 +371,8 @@ class ApplicationRevisionRetrieveRequest(BaseModel):
         description=(
             "Application artifact to look up. Identifies the artifact by `id` "
             "or `slug` (both project-unique). When no variant_ref or "
-            "revision_ref is provided, returns the latest revision of an "
-            "arbitrary variant of this application."
+            "revision_ref is provided, returns the latest revision of the "
+            "application's default variant."
         ),
     )
     application_variant_ref: Optional[Reference] = Field(

--- a/api/oss/src/apis/fastapi/applications/router.py
+++ b/api/oss/src/apis/fastapi/applications/router.py
@@ -10,11 +10,7 @@ from oss.src.utils.caching import invalidate_cache
 
 from oss.src.core.events.utils import publish_revision_event
 
-from oss.src.core.git.types import (
-    VariantForkError,
-    RetrieveRefsInsufficient,
-    RetrieveRefsInconsistent,
-)
+from oss.src.apis.fastapi.git.exceptions import handle_git_exceptions
 from oss.src.core.shared.dtos import (
     Reference,
 )
@@ -1066,6 +1062,7 @@ class ApplicationsRouter:
         return application_variants_response
 
     @intercept_exceptions()
+    @handle_git_exceptions()
     async def fork_application_variant(
         self,
         request: Request,
@@ -1105,20 +1102,12 @@ class ApplicationsRouter:
             if not fork_request.application_variant_id:
                 fork_request.application_variant_id = application_variant_id
 
-        try:
-            application_variant = (
-                await self.applications_service.fork_application_variant(
-                    project_id=UUID(request.state.project_id),
-                    user_id=UUID(request.state.user_id),
-                    #
-                    application_fork=fork_request,
-                )
-            )
-        except VariantForkError as e:
-            raise HTTPException(
-                status_code=status.HTTP_400_BAD_REQUEST,
-                detail=e.message,
-            ) from e
+        application_variant = await self.applications_service.fork_application_variant(
+            project_id=UUID(request.state.project_id),
+            user_id=UUID(request.state.user_id),
+            #
+            application_fork=fork_request,
+        )
 
         application_variant_response = ApplicationVariantResponse(
             count=1 if application_variant else 0,
@@ -1130,6 +1119,7 @@ class ApplicationsRouter:
     # APPLICATION REVISIONS ----------------------------------------------------
 
     @intercept_exceptions()
+    @handle_git_exceptions()
     async def deploy_application_revision(
         self,
         request: Request,
@@ -1182,19 +1172,13 @@ class ApplicationsRouter:
                 detail="Application deploy requires environment refs.",
             )
 
-        try:
-            application_revision = await self.applications_service.fetch_application_revision(
-                project_id=UUID(request.state.project_id),
-                #
-                application_ref=application_deploy_request.application_ref,
-                application_variant_ref=application_deploy_request.application_variant_ref,
-                application_revision_ref=application_deploy_request.application_revision_ref,
-            )
-        except (RetrieveRefsInsufficient, RetrieveRefsInconsistent) as e:
-            raise HTTPException(
-                status_code=status.HTTP_400_BAD_REQUEST,
-                detail=e.message,
-            ) from e
+        application_revision = await self.applications_service.fetch_application_revision(
+            project_id=UUID(request.state.project_id),
+            #
+            application_ref=application_deploy_request.application_ref,
+            application_variant_ref=application_deploy_request.application_variant_ref,
+            application_revision_ref=application_deploy_request.application_revision_ref,
+        )
 
         if not application_revision:
             raise HTTPException(
@@ -1303,6 +1287,7 @@ class ApplicationsRouter:
 
     @intercept_exceptions()
     @suppress_exceptions(default=ApplicationRevisionResponse(), exclude=[HTTPException])
+    @handle_git_exceptions()
     async def retrieve_application_revision(
         self,
         request: Request,
@@ -1394,29 +1379,23 @@ class ApplicationsRouter:
                         detail="Environment-backed application retrieve requires key.",
                     )
 
-        try:
-            (
-                application_revision,
-                resolution_info,
-            ) = await self.applications_service.retrieve_application_revision(
-                project_id=UUID(request.state.project_id),
-                #
-                environment_ref=environment_ref,
-                environment_variant_ref=environment_variant_ref,
-                environment_revision_ref=environment_revision_ref,
-                key=key,
-                #
-                application_ref=application_ref,
-                application_variant_ref=application_variant_ref,
-                application_revision_ref=application_revision_ref,
-                #
-                resolve=application_revision_retrieve_request.resolve or False,
-            )
-        except (RetrieveRefsInsufficient, RetrieveRefsInconsistent) as e:
-            raise HTTPException(
-                status_code=status.HTTP_400_BAD_REQUEST,
-                detail=e.message,
-            ) from e
+        (
+            application_revision,
+            resolution_info,
+        ) = await self.applications_service.retrieve_application_revision(
+            project_id=UUID(request.state.project_id),
+            #
+            environment_ref=environment_ref,
+            environment_variant_ref=environment_variant_ref,
+            environment_revision_ref=environment_revision_ref,
+            key=key,
+            #
+            application_ref=application_ref,
+            application_variant_ref=application_variant_ref,
+            application_revision_ref=application_revision_ref,
+            #
+            resolve=application_revision_retrieve_request.resolve or False,
+        )
 
         if environment_lookup_requested and not application_revision:
             raise HTTPException(

--- a/api/oss/src/apis/fastapi/applications/router.py
+++ b/api/oss/src/apis/fastapi/applications/router.py
@@ -10,7 +10,11 @@ from oss.src.utils.caching import invalidate_cache
 
 from oss.src.core.events.utils import publish_revision_event
 
-from oss.src.core.git.types import VariantForkError, RevisionRefInvalid
+from oss.src.core.git.types import (
+    VariantForkError,
+    RetrieveRefsInsufficient,
+    RetrieveRefsInconsistent,
+)
 from oss.src.core.shared.dtos import (
     Reference,
 )
@@ -1186,7 +1190,7 @@ class ApplicationsRouter:
                 application_variant_ref=application_deploy_request.application_variant_ref,
                 application_revision_ref=application_deploy_request.application_revision_ref,
             )
-        except RevisionRefInvalid as e:
+        except (RetrieveRefsInsufficient, RetrieveRefsInconsistent) as e:
             raise HTTPException(
                 status_code=status.HTTP_400_BAD_REQUEST,
                 detail=e.message,
@@ -1408,7 +1412,7 @@ class ApplicationsRouter:
                 #
                 resolve=application_revision_retrieve_request.resolve or False,
             )
-        except RevisionRefInvalid as e:
+        except (RetrieveRefsInsufficient, RetrieveRefsInconsistent) as e:
             raise HTTPException(
                 status_code=status.HTTP_400_BAD_REQUEST,
                 detail=e.message,

--- a/api/oss/src/apis/fastapi/environments/router.py
+++ b/api/oss/src/apis/fastapi/environments/router.py
@@ -8,7 +8,7 @@ from oss.src.utils.logging import get_module_logger
 from oss.src.utils.exceptions import intercept_exceptions, suppress_exceptions
 
 from oss.src.core.events.utils import publish_revision_event
-from oss.src.core.git.types import RevisionRefInvalid
+from oss.src.core.git.types import RetrieveRefsInsufficient, RetrieveRefsInconsistent
 
 from oss.src.core.shared.dtos import (
     Reference,
@@ -769,7 +769,7 @@ class EnvironmentsRouter:
                 #
                 resolve=bool(environment_revision_retrieve_request.resolve),
             )
-        except RevisionRefInvalid as e:
+        except (RetrieveRefsInsufficient, RetrieveRefsInconsistent) as e:
             raise HTTPException(
                 status_code=status.HTTP_400_BAD_REQUEST,
                 detail=e.message,

--- a/api/oss/src/apis/fastapi/environments/router.py
+++ b/api/oss/src/apis/fastapi/environments/router.py
@@ -8,7 +8,7 @@ from oss.src.utils.logging import get_module_logger
 from oss.src.utils.exceptions import intercept_exceptions, suppress_exceptions
 
 from oss.src.core.events.utils import publish_revision_event
-from oss.src.core.git.types import RetrieveRefsInsufficient, RetrieveRefsInconsistent
+from oss.src.apis.fastapi.git.exceptions import handle_git_exceptions
 
 from oss.src.core.shared.dtos import (
     Reference,
@@ -742,6 +742,7 @@ class EnvironmentsRouter:
     # ENVIRONMENT REVISIONS ------------------------------------------------
 
     @intercept_exceptions()
+    @handle_git_exceptions()
     async def retrieve_environment_revision(
         self,
         request: Request,
@@ -756,24 +757,18 @@ class EnvironmentsRouter:
             ):
                 raise FORBIDDEN_EXCEPTION  # type: ignore
 
-        try:
-            (
-                environment_revision,
-                resolution_info,
-            ) = await self.environments_service.retrieve_environment_revision(
-                project_id=UUID(request.state.project_id),
-                #
-                environment_ref=environment_revision_retrieve_request.environment_ref,  # type: ignore
-                environment_variant_ref=environment_revision_retrieve_request.environment_variant_ref,  # type: ignore
-                environment_revision_ref=environment_revision_retrieve_request.environment_revision_ref,  # type: ignore
-                #
-                resolve=bool(environment_revision_retrieve_request.resolve),
-            )
-        except (RetrieveRefsInsufficient, RetrieveRefsInconsistent) as e:
-            raise HTTPException(
-                status_code=status.HTTP_400_BAD_REQUEST,
-                detail=e.message,
-            ) from e
+        (
+            environment_revision,
+            resolution_info,
+        ) = await self.environments_service.retrieve_environment_revision(
+            project_id=UUID(request.state.project_id),
+            #
+            environment_ref=environment_revision_retrieve_request.environment_ref,  # type: ignore
+            environment_variant_ref=environment_revision_retrieve_request.environment_variant_ref,  # type: ignore
+            environment_revision_ref=environment_revision_retrieve_request.environment_revision_ref,  # type: ignore
+            #
+            resolve=bool(environment_revision_retrieve_request.resolve),
+        )
 
         environment_revision_response = EnvironmentRevisionResponse(
             count=1 if environment_revision else 0,

--- a/api/oss/src/apis/fastapi/evaluators/models.py
+++ b/api/oss/src/apis/fastapi/evaluators/models.py
@@ -285,7 +285,10 @@ class EvaluatorRevisionCommitRequest(BaseModel):
 class EvaluatorRevisionRetrieveRequest(BaseModel):
     """Body for retrieving one revision, either by direct reference or through an environment key.
 
-    Provide one of: an evaluator / variant / revision reference, or an environment reference plus `key`.
+    Provide an evaluator / variant / revision reference, an environment
+    reference (with `key` derived from the evaluator slug by default), or a
+    combination of both. Every reference supplied must agree with the
+    resolved revision; contradictions return HTTP 400.
     """
 
     evaluator_ref: Optional[Reference] = Field(
@@ -293,8 +296,8 @@ class EvaluatorRevisionRetrieveRequest(BaseModel):
         description=(
             "Evaluator artifact to look up. Identifies the artifact by `id` "
             "or `slug` (both project-unique). When no variant_ref or "
-            "revision_ref is provided, returns the latest revision of an "
-            "arbitrary variant of this evaluator."
+            "revision_ref is provided, returns the latest revision of the "
+            "evaluator's default variant."
         ),
     )
     evaluator_variant_ref: Optional[Reference] = Field(

--- a/api/oss/src/apis/fastapi/evaluators/router.py
+++ b/api/oss/src/apis/fastapi/evaluators/router.py
@@ -1344,14 +1344,6 @@ class EvaluatorsRouter:
         )
         environment_lookup_requested = environment_refs_requested or key is not None
 
-        if evaluator_lookup_requested and environment_lookup_requested:
-            raise HTTPException(
-                status_code=status.HTTP_400_BAD_REQUEST,
-                detail=(
-                    "Provide either evaluator refs or environment refs with key, not both."
-                ),
-            )
-
         if not evaluator_lookup_requested and not environment_lookup_requested:
             raise HTTPException(
                 status_code=status.HTTP_400_BAD_REQUEST,
@@ -1368,10 +1360,24 @@ class EvaluatorsRouter:
                 )
 
             if not key:
-                raise HTTPException(
-                    status_code=status.HTTP_400_BAD_REQUEST,
-                    detail="Environment-backed evaluator retrieve requires key.",
-                )
+                if evaluator_ref and evaluator_ref.slug:
+                    key = f"{evaluator_ref.slug}.revision"
+                elif evaluator_ref and evaluator_ref.id:
+                    evaluator = await self.evaluators_service.fetch_evaluator(
+                        project_id=UUID(request.state.project_id),
+                        evaluator_ref=evaluator_ref,
+                    )
+                    if not evaluator or not evaluator.slug:
+                        raise HTTPException(
+                            status_code=status.HTTP_400_BAD_REQUEST,
+                            detail="Environment-backed evaluator retrieve could not derive key from evaluator slug.",
+                        )
+                    key = f"{evaluator.slug}.revision"
+                else:
+                    raise HTTPException(
+                        status_code=status.HTTP_400_BAD_REQUEST,
+                        detail="Environment-backed evaluator retrieve requires key.",
+                    )
 
         try:
             (

--- a/api/oss/src/apis/fastapi/evaluators/router.py
+++ b/api/oss/src/apis/fastapi/evaluators/router.py
@@ -10,7 +10,11 @@ from oss.src.utils.caching import invalidate_cache
 
 from oss.src.core.events.utils import publish_revision_event
 
-from oss.src.core.git.types import VariantForkError, RevisionRefInvalid
+from oss.src.core.git.types import (
+    VariantForkError,
+    RetrieveRefsInsufficient,
+    RetrieveRefsInconsistent,
+)
 from oss.src.core.shared.dtos import (
     Reference,
 )
@@ -1177,7 +1181,7 @@ class EvaluatorsRouter:
                 evaluator_variant_ref=evaluator_deploy_request.evaluator_variant_ref,
                 evaluator_revision_ref=evaluator_deploy_request.evaluator_revision_ref,
             )
-        except RevisionRefInvalid as e:
+        except (RetrieveRefsInsufficient, RetrieveRefsInconsistent) as e:
             raise HTTPException(
                 status_code=status.HTTP_400_BAD_REQUEST,
                 detail=e.message,
@@ -1387,7 +1391,7 @@ class EvaluatorsRouter:
                 #
                 resolve=evaluator_revision_retrieve_request.resolve or False,
             )
-        except RevisionRefInvalid as e:
+        except (RetrieveRefsInsufficient, RetrieveRefsInconsistent) as e:
             raise HTTPException(
                 status_code=status.HTTP_400_BAD_REQUEST,
                 detail=e.message,

--- a/api/oss/src/apis/fastapi/evaluators/router.py
+++ b/api/oss/src/apis/fastapi/evaluators/router.py
@@ -10,11 +10,7 @@ from oss.src.utils.caching import invalidate_cache
 
 from oss.src.core.events.utils import publish_revision_event
 
-from oss.src.core.git.types import (
-    VariantForkError,
-    RetrieveRefsInsufficient,
-    RetrieveRefsInconsistent,
-)
+from oss.src.apis.fastapi.git.exceptions import handle_git_exceptions
 from oss.src.core.shared.dtos import (
     Reference,
 )
@@ -1062,6 +1058,7 @@ class EvaluatorsRouter:
         return evaluator_variants_response
 
     @intercept_exceptions()  # TODO: FIX ME
+    @handle_git_exceptions()
     async def fork_evaluator_variant(
         self,
         request: Request,
@@ -1097,18 +1094,12 @@ class EvaluatorsRouter:
             if not fork_request.evaluator_variant_id:
                 fork_request.evaluator_variant_id = evaluator_variant_id
 
-        try:
-            evaluator_variant = await self.evaluators_service.fork_evaluator_variant(
-                project_id=UUID(request.state.project_id),
-                user_id=UUID(request.state.user_id),
-                #
-                evaluator_fork=fork_request,
-            )
-        except VariantForkError as e:
-            raise HTTPException(
-                status_code=status.HTTP_400_BAD_REQUEST,
-                detail=e.message,
-            ) from e
+        evaluator_variant = await self.evaluators_service.fork_evaluator_variant(
+            project_id=UUID(request.state.project_id),
+            user_id=UUID(request.state.user_id),
+            #
+            evaluator_fork=fork_request,
+        )
 
         evaluator_variant_response = EvaluatorVariantResponse(
             count=1 if evaluator_variant else 0,
@@ -1120,6 +1111,7 @@ class EvaluatorsRouter:
     # EVALUATOR REVISIONS ------------------------------------------------------
 
     @intercept_exceptions()
+    @handle_git_exceptions()
     async def deploy_evaluator_revision(
         self,
         request: Request,
@@ -1173,19 +1165,13 @@ class EvaluatorsRouter:
                 detail="Evaluator deploy requires environment refs.",
             )
 
-        try:
-            evaluator_revision = await self.evaluators_service.fetch_evaluator_revision(
-                project_id=UUID(request.state.project_id),
-                #
-                evaluator_ref=evaluator_deploy_request.evaluator_ref,
-                evaluator_variant_ref=evaluator_deploy_request.evaluator_variant_ref,
-                evaluator_revision_ref=evaluator_deploy_request.evaluator_revision_ref,
-            )
-        except (RetrieveRefsInsufficient, RetrieveRefsInconsistent) as e:
-            raise HTTPException(
-                status_code=status.HTTP_400_BAD_REQUEST,
-                detail=e.message,
-            ) from e
+        evaluator_revision = await self.evaluators_service.fetch_evaluator_revision(
+            project_id=UUID(request.state.project_id),
+            #
+            evaluator_ref=evaluator_deploy_request.evaluator_ref,
+            evaluator_variant_ref=evaluator_deploy_request.evaluator_variant_ref,
+            evaluator_revision_ref=evaluator_deploy_request.evaluator_revision_ref,
+        )
 
         if not evaluator_revision:
             raise HTTPException(
@@ -1287,6 +1273,7 @@ class EvaluatorsRouter:
         )
 
     @intercept_exceptions()
+    @handle_git_exceptions()
     async def retrieve_evaluator_revision(
         self,
         request: Request,
@@ -1379,29 +1366,23 @@ class EvaluatorsRouter:
                         detail="Environment-backed evaluator retrieve requires key.",
                     )
 
-        try:
-            (
-                evaluator_revision,
-                resolution_info,
-            ) = await self.evaluators_service.retrieve_evaluator_revision(
-                project_id=UUID(request.state.project_id),
-                #
-                environment_ref=environment_ref,
-                environment_variant_ref=environment_variant_ref,
-                environment_revision_ref=environment_revision_ref,
-                key=key,
-                #
-                evaluator_ref=evaluator_ref,
-                evaluator_variant_ref=evaluator_variant_ref,
-                evaluator_revision_ref=evaluator_revision_ref,
-                #
-                resolve=evaluator_revision_retrieve_request.resolve or False,
-            )
-        except (RetrieveRefsInsufficient, RetrieveRefsInconsistent) as e:
-            raise HTTPException(
-                status_code=status.HTTP_400_BAD_REQUEST,
-                detail=e.message,
-            ) from e
+        (
+            evaluator_revision,
+            resolution_info,
+        ) = await self.evaluators_service.retrieve_evaluator_revision(
+            project_id=UUID(request.state.project_id),
+            #
+            environment_ref=environment_ref,
+            environment_variant_ref=environment_variant_ref,
+            environment_revision_ref=environment_revision_ref,
+            key=key,
+            #
+            evaluator_ref=evaluator_ref,
+            evaluator_variant_ref=evaluator_variant_ref,
+            evaluator_revision_ref=evaluator_revision_ref,
+            #
+            resolve=evaluator_revision_retrieve_request.resolve or False,
+        )
 
         if environment_lookup_requested and not evaluator_revision:
             raise HTTPException(

--- a/api/oss/src/apis/fastapi/git/exceptions.py
+++ b/api/oss/src/apis/fastapi/git/exceptions.py
@@ -1,0 +1,64 @@
+"""Typed HTTP exceptions and a translation decorator for git-domain errors.
+
+The git pattern (artifact/variant/revision) is shared across six routers
+(workflows, applications, evaluators, testsets, queries, environments).
+Each router previously translated the same set of core exceptions to HTTP
+400 inline, multiplying boilerplate. This module centralizes that mapping
+so new domain exceptions need updates in one place.
+
+Any new exception added to `oss.src.core.git.types` must be registered
+below: add a typed `*Exception` and a `except` arm in
+`handle_git_exceptions`. The decorator is paired with the existing
+`@intercept_exceptions()` and `@suppress_exceptions(exclude=[HTTPException])`
+on each route; place it on the inside of those decorators so the typed
+HTTP exception is the one re-raised.
+"""
+
+from functools import wraps
+
+from fastapi import HTTPException
+
+from oss.src.core.git.types import (
+    RetrieveRefsInconsistent,
+    RetrieveRefsInsufficient,
+    VariantForkError,
+)
+
+
+class VariantForkErrorException(HTTPException):
+    def __init__(self, message: str = "Variant fork request cannot be fulfilled."):
+        super().__init__(status_code=400, detail=message)
+
+
+class RetrieveRefsInsufficientException(HTTPException):
+    def __init__(
+        self,
+        message: str = "References are insufficient to identify a single revision.",
+    ):
+        super().__init__(status_code=400, detail=message)
+
+
+class RetrieveRefsInconsistentException(HTTPException):
+    def __init__(
+        self,
+        message: str = "References disagree with the resolved revision.",
+    ):
+        super().__init__(status_code=400, detail=message)
+
+
+def handle_git_exceptions():
+    def decorator(func):
+        @wraps(func)
+        async def wrapper(*args, **kwargs):
+            try:
+                return await func(*args, **kwargs)
+            except VariantForkError as e:
+                raise VariantForkErrorException(message=e.message) from e
+            except RetrieveRefsInsufficient as e:
+                raise RetrieveRefsInsufficientException(message=e.message) from e
+            except RetrieveRefsInconsistent as e:
+                raise RetrieveRefsInconsistentException(message=e.message) from e
+
+        return wrapper
+
+    return decorator

--- a/api/oss/src/apis/fastapi/queries/router.py
+++ b/api/oss/src/apis/fastapi/queries/router.py
@@ -9,7 +9,7 @@ from oss.src.utils.exceptions import intercept_exceptions, suppress_exceptions
 from oss.src.utils.caching import get_cache, set_cache
 
 from oss.src.core.events.utils import publish_revision_event
-from oss.src.core.git.types import RetrieveRefsInsufficient, RetrieveRefsInconsistent
+from oss.src.apis.fastapi.git.exceptions import handle_git_exceptions
 
 from oss.src.core.shared.dtos import (
     Reference,
@@ -959,6 +959,7 @@ class QueriesRouter:
 
     @intercept_exceptions()
     @suppress_exceptions(default=QueryRevisionResponse(), exclude=[HTTPException])
+    @handle_git_exceptions()
     async def retrieve_query_revision(
         self,
         request: Request,
@@ -1020,24 +1021,18 @@ class QueriesRouter:
         )
 
         if not query_revision:
-            try:
-                query_revision = await self.queries_service.fetch_query_revision(
-                    project_id=UUID(request.state.project_id),
-                    #
-                    query_ref=query_revision_retrieve_request.query_ref,
-                    query_variant_ref=query_revision_retrieve_request.query_variant_ref,
-                    query_revision_ref=query_revision_retrieve_request.query_revision_ref,
-                    #
-                    include_trace_ids=query_revision_retrieve_request.include_trace_ids,
-                    include_traces=query_revision_retrieve_request.include_traces,
-                    #
-                    windowing=query_revision_retrieve_request.windowing,
-                )
-            except (RetrieveRefsInsufficient, RetrieveRefsInconsistent) as e:
-                raise HTTPException(
-                    status_code=status.HTTP_400_BAD_REQUEST,
-                    detail=e.message,
-                ) from e
+            query_revision = await self.queries_service.fetch_query_revision(
+                project_id=UUID(request.state.project_id),
+                #
+                query_ref=query_revision_retrieve_request.query_ref,
+                query_variant_ref=query_revision_retrieve_request.query_variant_ref,
+                query_revision_ref=query_revision_retrieve_request.query_revision_ref,
+                #
+                include_trace_ids=query_revision_retrieve_request.include_trace_ids,
+                include_traces=query_revision_retrieve_request.include_traces,
+                #
+                windowing=query_revision_retrieve_request.windowing,
+            )
 
             if should_cache:
                 await set_cache(

--- a/api/oss/src/apis/fastapi/queries/router.py
+++ b/api/oss/src/apis/fastapi/queries/router.py
@@ -9,7 +9,7 @@ from oss.src.utils.exceptions import intercept_exceptions, suppress_exceptions
 from oss.src.utils.caching import get_cache, set_cache
 
 from oss.src.core.events.utils import publish_revision_event
-from oss.src.core.git.types import RevisionRefInvalid
+from oss.src.core.git.types import RetrieveRefsInsufficient, RetrieveRefsInconsistent
 
 from oss.src.core.shared.dtos import (
     Reference,
@@ -1033,7 +1033,7 @@ class QueriesRouter:
                     #
                     windowing=query_revision_retrieve_request.windowing,
                 )
-            except RevisionRefInvalid as e:
+            except (RetrieveRefsInsufficient, RetrieveRefsInconsistent) as e:
                 raise HTTPException(
                     status_code=status.HTTP_400_BAD_REQUEST,
                     detail=e.message,

--- a/api/oss/src/apis/fastapi/testsets/router.py
+++ b/api/oss/src/apis/fastapi/testsets/router.py
@@ -28,7 +28,7 @@ from oss.src.utils.caching import set_cache, get_cache
 
 from oss.src.apis.fastapi.shared.utils import compute_next_windowing
 from oss.src.core.events.utils import publish_revision_event
-from oss.src.core.git.types import RevisionRefInvalid
+from oss.src.core.git.types import RetrieveRefsInsufficient, RetrieveRefsInconsistent
 
 from oss.src.core.shared.dtos import (
     Reference,
@@ -1511,7 +1511,7 @@ class TestsetsRouter:
                     #
                     windowing=testset_revision_retrieve_request.windowing,
                 )
-            except RevisionRefInvalid as e:
+            except (RetrieveRefsInsufficient, RetrieveRefsInconsistent) as e:
                 raise HTTPException(
                     status_code=status.HTTP_400_BAD_REQUEST,
                     detail=e.message,

--- a/api/oss/src/apis/fastapi/testsets/router.py
+++ b/api/oss/src/apis/fastapi/testsets/router.py
@@ -28,7 +28,7 @@ from oss.src.utils.caching import set_cache, get_cache
 
 from oss.src.apis.fastapi.shared.utils import compute_next_windowing
 from oss.src.core.events.utils import publish_revision_event
-from oss.src.core.git.types import RetrieveRefsInsufficient, RetrieveRefsInconsistent
+from oss.src.apis.fastapi.git.exceptions import handle_git_exceptions
 
 from oss.src.core.shared.dtos import (
     Reference,
@@ -1444,6 +1444,7 @@ class TestsetsRouter:
 
     @intercept_exceptions()
     @suppress_exceptions(default=TestsetRevisionResponse(), exclude=[HTTPException])
+    @handle_git_exceptions()
     async def retrieve_testset_revision(
         self,
         request: Request,
@@ -1498,24 +1499,18 @@ class TestsetsRouter:
         )
 
         if not testset_revision:
-            try:
-                testset_revision = await self.testsets_service.fetch_testset_revision(
-                    project_id=UUID(request.state.project_id),
-                    #
-                    testset_ref=testset_revision_retrieve_request.testset_ref,
-                    testset_variant_ref=testset_revision_retrieve_request.testset_variant_ref,
-                    testset_revision_ref=testset_revision_retrieve_request.testset_revision_ref,
-                    #
-                    include_testcase_ids=testset_revision_retrieve_request.include_testcase_ids,
-                    include_testcases=testset_revision_retrieve_request.include_testcases,
-                    #
-                    windowing=testset_revision_retrieve_request.windowing,
-                )
-            except (RetrieveRefsInsufficient, RetrieveRefsInconsistent) as e:
-                raise HTTPException(
-                    status_code=status.HTTP_400_BAD_REQUEST,
-                    detail=e.message,
-                ) from e
+            testset_revision = await self.testsets_service.fetch_testset_revision(
+                project_id=UUID(request.state.project_id),
+                #
+                testset_ref=testset_revision_retrieve_request.testset_ref,
+                testset_variant_ref=testset_revision_retrieve_request.testset_variant_ref,
+                testset_revision_ref=testset_revision_retrieve_request.testset_revision_ref,
+                #
+                include_testcase_ids=testset_revision_retrieve_request.include_testcase_ids,
+                include_testcases=testset_revision_retrieve_request.include_testcases,
+                #
+                windowing=testset_revision_retrieve_request.windowing,
+            )
 
             if should_cache:
                 await set_cache(

--- a/api/oss/src/apis/fastapi/workflows/models.py
+++ b/api/oss/src/apis/fastapi/workflows/models.py
@@ -251,13 +251,20 @@ class WorkflowRevisionCommitRequest(BaseModel):
 
 
 class WorkflowRevisionRetrieveRequest(BaseModel):
+    """Request body for `POST /workflows/revisions/retrieve`.
+
+    Resolves to a single revision by one or more reference types. Every
+    reference supplied must agree with the resolved revision; contradictions
+    return HTTP 400.
+    """
+
     workflow_ref: Optional[Reference] = Field(
         default=None,
         description=(
             "Workflow artifact to look up. Identifies the artifact by `id` or "
             "`slug` (both project-unique). When no variant_ref or revision_ref "
-            "is provided, returns the latest revision of an arbitrary variant "
-            "of this workflow."
+            "is provided, returns the latest revision of the workflow's "
+            "default variant."
         ),
     )
     workflow_variant_ref: Optional[Reference] = Field(

--- a/api/oss/src/apis/fastapi/workflows/router.py
+++ b/api/oss/src/apis/fastapi/workflows/router.py
@@ -11,7 +11,11 @@ from oss.src.utils.caching import invalidate_cache
 from oss.src.core.shared.dtos import (
     Reference,
 )
-from oss.src.core.git.types import VariantForkError, RevisionRefInvalid
+from oss.src.core.git.types import (
+    VariantForkError,
+    RetrieveRefsInsufficient,
+    RetrieveRefsInconsistent,
+)
 from oss.src.core.workflows.service import (
     WorkflowsService,
     SimpleWorkflowsService,
@@ -1235,7 +1239,7 @@ class WorkflowsRouter:
         # This route only accepts `workflow_revision_id` as a path param and
         # constructs `Reference(id=workflow_revision_id)`. That shape always
         # satisfies the service's ambiguity validation, so no try/except for
-        # `RevisionRefInvalid` is needed here. The other two call sites
+        # `RetrieveRefsInsufficient` is needed here. The other two call sites
         # (`deploy_workflow_revision` and `retrieve_workflow_revision`) pass
         # through caller-supplied refs and do wrap this call.
         workflow_revision = await self.workflows_service.fetch_workflow_revision(
@@ -1536,7 +1540,7 @@ class WorkflowsRouter:
                 workflow_variant_ref=workflow_deploy_request.workflow_variant_ref,
                 workflow_revision_ref=workflow_deploy_request.workflow_revision_ref,
             )
-        except RevisionRefInvalid as e:
+        except (RetrieveRefsInsufficient, RetrieveRefsInconsistent) as e:
             raise HTTPException(
                 status_code=status.HTTP_400_BAD_REQUEST,
                 detail=e.message,
@@ -1733,7 +1737,7 @@ class WorkflowsRouter:
                 #
                 resolve=workflow_revision_retrieve_request.resolve or False,
             )
-        except RevisionRefInvalid as e:
+        except (RetrieveRefsInsufficient, RetrieveRefsInconsistent) as e:
             raise HTTPException(
                 status_code=status.HTTP_400_BAD_REQUEST,
                 detail=e.message,

--- a/api/oss/src/apis/fastapi/workflows/router.py
+++ b/api/oss/src/apis/fastapi/workflows/router.py
@@ -11,11 +11,7 @@ from oss.src.utils.caching import invalidate_cache
 from oss.src.core.shared.dtos import (
     Reference,
 )
-from oss.src.core.git.types import (
-    VariantForkError,
-    RetrieveRefsInsufficient,
-    RetrieveRefsInconsistent,
-)
+from oss.src.apis.fastapi.git.exceptions import handle_git_exceptions
 from oss.src.core.workflows.service import (
     WorkflowsService,
     SimpleWorkflowsService,
@@ -1149,6 +1145,7 @@ class WorkflowsRouter:
         return workflow_variants_response
 
     @intercept_exceptions()
+    @handle_git_exceptions()
     async def fork_workflow_variant(
         self,
         request: Request,
@@ -1163,18 +1160,12 @@ class WorkflowsRouter:
             ):
                 raise FORBIDDEN_EXCEPTION  # type: ignore
 
-        try:
-            workflow_variant = await self.workflows_service.fork_workflow_variant(
-                project_id=UUID(request.state.project_id),
-                user_id=UUID(request.state.user_id),
-                #
-                workflow_fork=workflow_fork_request.workflow,
-            )
-        except VariantForkError as e:
-            raise HTTPException(
-                status_code=status.HTTP_400_BAD_REQUEST,
-                detail=e.message,
-            ) from e
+        workflow_variant = await self.workflows_service.fork_workflow_variant(
+            project_id=UUID(request.state.project_id),
+            user_id=UUID(request.state.user_id),
+            #
+            workflow_fork=workflow_fork_request.workflow,
+        )
 
         # Invalidate legacy caches so the registry page reflects the forked variant
         await invalidate_cache(project_id=request.state.project_id)
@@ -1236,12 +1227,6 @@ class WorkflowsRouter:
             ):
                 raise FORBIDDEN_EXCEPTION  # type: ignore
 
-        # This route only accepts `workflow_revision_id` as a path param and
-        # constructs `Reference(id=workflow_revision_id)`. That shape always
-        # satisfies the service's ambiguity validation, so no try/except for
-        # `RetrieveRefsInsufficient` is needed here. The other two call sites
-        # (`deploy_workflow_revision` and `retrieve_workflow_revision`) pass
-        # through caller-supplied refs and do wrap this call.
         workflow_revision = await self.workflows_service.fetch_workflow_revision(
             project_id=UUID(request.state.project_id),
             #
@@ -1488,6 +1473,7 @@ class WorkflowsRouter:
         return workflow_revisions_response
 
     @intercept_exceptions()
+    @handle_git_exceptions()
     async def deploy_workflow_revision(
         self,
         request: Request,
@@ -1532,19 +1518,13 @@ class WorkflowsRouter:
                 detail="Workflow deploy requires environment refs.",
             )
 
-        try:
-            workflow_revision = await self.workflows_service.fetch_workflow_revision(
-                project_id=UUID(request.state.project_id),
-                #
-                workflow_ref=workflow_deploy_request.workflow_ref,
-                workflow_variant_ref=workflow_deploy_request.workflow_variant_ref,
-                workflow_revision_ref=workflow_deploy_request.workflow_revision_ref,
-            )
-        except (RetrieveRefsInsufficient, RetrieveRefsInconsistent) as e:
-            raise HTTPException(
-                status_code=status.HTTP_400_BAD_REQUEST,
-                detail=e.message,
-            ) from e
+        workflow_revision = await self.workflows_service.fetch_workflow_revision(
+            project_id=UUID(request.state.project_id),
+            #
+            workflow_ref=workflow_deploy_request.workflow_ref,
+            workflow_variant_ref=workflow_deploy_request.workflow_variant_ref,
+            workflow_revision_ref=workflow_deploy_request.workflow_revision_ref,
+        )
 
         if not workflow_revision:
             raise HTTPException(
@@ -1647,6 +1627,7 @@ class WorkflowsRouter:
 
     @intercept_exceptions()
     @suppress_exceptions(default=WorkflowRevisionResponse(), exclude=[HTTPException])
+    @handle_git_exceptions()
     async def retrieve_workflow_revision(
         self,
         request: Request,
@@ -1725,29 +1706,23 @@ class WorkflowsRouter:
                         detail="Environment-backed workflow retrieve requires key.",
                     )
 
-        try:
-            (
-                workflow_revision,
-                resolution_info,
-            ) = await self.workflows_service.retrieve_workflow_revision(
-                project_id=UUID(request.state.project_id),
-                #
-                environment_ref=environment_ref,
-                environment_variant_ref=environment_variant_ref,
-                environment_revision_ref=environment_revision_ref,
-                key=key,
-                #
-                workflow_ref=workflow_ref,
-                workflow_variant_ref=workflow_variant_ref,
-                workflow_revision_ref=workflow_revision_ref,
-                #
-                resolve=workflow_revision_retrieve_request.resolve or False,
-            )
-        except (RetrieveRefsInsufficient, RetrieveRefsInconsistent) as e:
-            raise HTTPException(
-                status_code=status.HTTP_400_BAD_REQUEST,
-                detail=e.message,
-            ) from e
+        (
+            workflow_revision,
+            resolution_info,
+        ) = await self.workflows_service.retrieve_workflow_revision(
+            project_id=UUID(request.state.project_id),
+            #
+            environment_ref=environment_ref,
+            environment_variant_ref=environment_variant_ref,
+            environment_revision_ref=environment_revision_ref,
+            key=key,
+            #
+            workflow_ref=workflow_ref,
+            workflow_variant_ref=workflow_variant_ref,
+            workflow_revision_ref=workflow_revision_ref,
+            #
+            resolve=workflow_revision_retrieve_request.resolve or False,
+        )
 
         if environment_lookup_requested and not workflow_revision:
             raise HTTPException(

--- a/api/oss/src/apis/fastapi/workflows/router.py
+++ b/api/oss/src/apis/fastapi/workflows/router.py
@@ -1690,14 +1690,6 @@ class WorkflowsRouter:
         )
         environment_lookup_requested = environment_refs_requested or key is not None
 
-        if workflow_lookup_requested and environment_lookup_requested:
-            raise HTTPException(
-                status_code=status.HTTP_400_BAD_REQUEST,
-                detail=(
-                    "Provide either workflow refs or environment refs with key, not both."
-                ),
-            )
-
         if not workflow_lookup_requested and not environment_lookup_requested:
             raise HTTPException(
                 status_code=status.HTTP_400_BAD_REQUEST,
@@ -1714,10 +1706,24 @@ class WorkflowsRouter:
                 )
 
             if not key:
-                raise HTTPException(
-                    status_code=status.HTTP_400_BAD_REQUEST,
-                    detail="Environment-backed workflow retrieve requires key.",
-                )
+                if workflow_ref and workflow_ref.slug:
+                    key = f"{workflow_ref.slug}.revision"
+                elif workflow_ref and workflow_ref.id:
+                    workflow = await self.workflows_service.fetch_workflow(
+                        project_id=UUID(request.state.project_id),
+                        workflow_ref=workflow_ref,
+                    )
+                    if not workflow or not workflow.slug:
+                        raise HTTPException(
+                            status_code=status.HTTP_400_BAD_REQUEST,
+                            detail="Environment-backed workflow retrieve could not derive key from workflow slug.",
+                        )
+                    key = f"{workflow.slug}.revision"
+                else:
+                    raise HTTPException(
+                        status_code=status.HTTP_400_BAD_REQUEST,
+                        detail="Environment-backed workflow retrieve requires key.",
+                    )
 
         try:
             (

--- a/api/oss/src/core/applications/service.py
+++ b/api/oss/src/core/applications/service.py
@@ -21,7 +21,10 @@ from oss.src.core.workflows.dtos import (
     #
 )
 from oss.src.core.shared.dtos import Windowing, Reference
-from oss.src.core.git.types import validate_revision_ref_unambiguous
+from oss.src.core.git.types import (
+    validate_revision_refs_sufficient,
+    validate_variant_refs_sufficient,
+)
 from oss.src.core.workflows.service import WorkflowsService
 
 # Resolution is now handled by EmbedsService
@@ -550,7 +553,11 @@ class ApplicationsService:
         #
         include_archived: Optional[bool] = True,
     ) -> Optional[ApplicationRevision]:
-        validate_revision_ref_unambiguous(
+        validate_variant_refs_sufficient(
+            variant_ref=application_variant_ref,
+            entity_type="application",
+        )
+        validate_revision_refs_sufficient(
             artifact_ref=application_ref,
             variant_ref=application_variant_ref,
             revision_ref=application_revision_ref,

--- a/api/oss/src/core/environments/service.py
+++ b/api/oss/src/core/environments/service.py
@@ -53,6 +53,7 @@ from oss.src.core.git.interfaces import GitDAOInterface
 from oss.src.core.git.types import (
     validate_revision_ref_unambiguous,
     needs_default_variant_resolution,
+    validate_retrieve_refs_consistent,
 )
 from oss.src.core.shared.dtos import Reference, Windowing
 
@@ -624,6 +625,9 @@ class EnvironmentsService:
             entity_type="environment",
         )
 
+        _original_environment_ref = environment_ref
+        _original_environment_variant_ref = environment_variant_ref
+
         if needs_default_variant_resolution(
             artifact_ref=environment_ref,
             variant_ref=environment_variant_ref,
@@ -672,6 +676,20 @@ class EnvironmentsService:
 
         if not revision:
             return None
+
+        validate_retrieve_refs_consistent(
+            artifact_ref=_original_environment_ref,
+            variant_ref=_original_environment_variant_ref,
+            revision_ref=environment_revision_ref,
+            resolved_artifact_id=revision.artifact_id,
+            resolved_artifact_slug=revision.artifact_slug,
+            resolved_variant_id=revision.variant_id,
+            resolved_variant_slug=revision.variant_slug,
+            resolved_revision_id=revision.id,
+            resolved_revision_slug=revision.slug,
+            resolved_revision_version=revision.version,
+            entity_type="environment",
+        )
 
         environment_revision = EnvironmentRevision(
             **revision.model_dump(

--- a/api/oss/src/core/environments/service.py
+++ b/api/oss/src/core/environments/service.py
@@ -681,13 +681,19 @@ class EnvironmentsService:
             artifact_ref=_original_environment_ref,
             variant_ref=_original_environment_variant_ref,
             revision_ref=environment_revision_ref,
-            resolved_artifact_id=revision.artifact_id,
-            resolved_artifact_slug=revision.artifact_slug,
-            resolved_variant_id=revision.variant_id,
-            resolved_variant_slug=revision.variant_slug,
-            resolved_revision_id=revision.id,
-            resolved_revision_slug=revision.slug,
-            resolved_revision_version=revision.version,
+            resolved_artifact_ref=Reference(
+                id=revision.artifact_id,
+                slug=revision.artifact_slug,
+            ),
+            resolved_variant_ref=Reference(
+                id=revision.variant_id,
+                slug=revision.variant_slug,
+            ),
+            resolved_revision_ref=Reference(
+                id=revision.id,
+                slug=revision.slug,
+                version=revision.version,
+            ),
             entity_type="environment",
         )
 

--- a/api/oss/src/core/environments/service.py
+++ b/api/oss/src/core/environments/service.py
@@ -51,7 +51,8 @@ from oss.src.core.git.dtos import (
 )
 from oss.src.core.git.interfaces import GitDAOInterface
 from oss.src.core.git.types import (
-    validate_revision_ref_unambiguous,
+    validate_revision_refs_sufficient,
+    validate_variant_refs_sufficient,
     needs_default_variant_resolution,
     validate_retrieve_refs_consistent,
 )
@@ -414,6 +415,10 @@ class EnvironmentsService:
         #
         include_archived: Optional[bool] = True,
     ) -> Optional[EnvironmentVariant]:
+        validate_variant_refs_sufficient(
+            variant_ref=environment_variant_ref,
+            entity_type="environment",
+        )
         variant = await self.environments_dao.fetch_variant(
             project_id=project_id,
             #
@@ -618,7 +623,7 @@ class EnvironmentsService:
         ):
             return None
 
-        validate_revision_ref_unambiguous(
+        validate_revision_refs_sufficient(
             artifact_ref=environment_ref,
             variant_ref=environment_variant_ref,
             revision_ref=environment_revision_ref,

--- a/api/oss/src/core/environments/service.py
+++ b/api/oss/src/core/environments/service.py
@@ -50,7 +50,10 @@ from oss.src.core.git.dtos import (
     VariantQuery,
 )
 from oss.src.core.git.interfaces import GitDAOInterface
-from oss.src.core.git.types import validate_revision_ref_unambiguous
+from oss.src.core.git.types import (
+    validate_revision_ref_unambiguous,
+    needs_default_variant_resolution,
+)
 from oss.src.core.shared.dtos import Reference, Windowing
 
 from oss.src.utils.logging import get_module_logger
@@ -621,10 +624,10 @@ class EnvironmentsService:
             entity_type="environment",
         )
 
-        if (
-            environment_ref
-            and not environment_variant_ref
-            and not environment_revision_ref
+        if needs_default_variant_resolution(
+            artifact_ref=environment_ref,
+            variant_ref=environment_variant_ref,
+            revision_ref=environment_revision_ref,
         ):
             environment = await self.fetch_environment(
                 project_id=project_id,

--- a/api/oss/src/core/evaluators/service.py
+++ b/api/oss/src/core/evaluators/service.py
@@ -20,7 +20,10 @@ from oss.src.core.workflows.dtos import (
     #
 )
 from oss.src.core.shared.dtos import Windowing, Reference
-from oss.src.core.git.types import validate_revision_ref_unambiguous
+from oss.src.core.git.types import (
+    validate_revision_refs_sufficient,
+    validate_variant_refs_sufficient,
+)
 from oss.src.core.workflows.service import WorkflowsService
 
 # Resolution is now handled by EmbedsService
@@ -553,7 +556,11 @@ class EvaluatorsService:
         #
         include_archived: Optional[bool] = True,
     ) -> Optional[EvaluatorRevision]:
-        validate_revision_ref_unambiguous(
+        validate_variant_refs_sufficient(
+            variant_ref=evaluator_variant_ref,
+            entity_type="evaluator",
+        )
+        validate_revision_refs_sufficient(
             artifact_ref=evaluator_ref,
             variant_ref=evaluator_variant_ref,
             revision_ref=evaluator_revision_ref,

--- a/api/oss/src/core/git/types.py
+++ b/api/oss/src/core/git/types.py
@@ -15,7 +15,7 @@ class VariantForkError(GitError):
     """Raised when a variant fork request cannot be fulfilled."""
 
 
-class RevisionRefInvalid(GitError):
+class RetrieveRefsInsufficient(GitError):
     """Raised when artifact/variant/revision refs are present but cannot
     identify a single revision unambiguously.
 
@@ -28,6 +28,18 @@ class RevisionRefInvalid(GitError):
     Not raised for the all-refs-empty case: the entity service returns
     `None` for that case rather than raising, matching the "nothing to look
     up" contract.
+    """
+
+
+class RetrieveRefsInconsistent(GitError):
+    """Raised when redundant refs disagree with the resolved revision.
+
+    A caller may legitimately repeat identifying refs across the
+    artifact/variant/revision triple, but every redundant identifier must
+    name the same row that the lookup resolved. If `revision_ref.id`
+    resolves to a revision whose `artifact_id` does not match the
+    `artifact_ref.id` the caller sent, the request is rejected — silently
+    favoring one ref would be a footgun.
     """
 
 
@@ -100,10 +112,121 @@ def validate_revision_ref_unambiguous(
     if _is_identifying(variant_ref) or _is_identifying(artifact_ref):
         return
 
-    raise RevisionRefInvalid(
+    raise RetrieveRefsInsufficient(
         f"{entity_type}_revision_ref.version is a per-variant sequence number "
         f"and requires a {entity_type}_variant_ref or {entity_type}_ref to "
         f"scope it. Provide either, or identify the revision by "
         f"{entity_type}_revision_ref.id or {entity_type}_revision_ref.slug "
         f"(both are project-unique)."
     )
+
+
+def _mismatch(
+    ref_field: str,
+    ref_value,
+    resolved_field: str,
+    resolved_value,
+) -> Optional[str]:
+    if ref_value is None or resolved_value is None:
+        return None
+    if str(ref_value) == str(resolved_value):
+        return None
+    return (
+        f"{ref_field}={ref_value!r} does not match resolved revision's "
+        f"{resolved_field}={resolved_value!r}"
+    )
+
+
+def validate_retrieve_refs_consistent(
+    *,
+    artifact_ref: Optional[Reference],
+    variant_ref: Optional[Reference],
+    revision_ref: Optional[Reference],
+    resolved_artifact_id=None,
+    resolved_artifact_slug: Optional[str] = None,
+    resolved_variant_id=None,
+    resolved_variant_slug: Optional[str] = None,
+    resolved_revision_id=None,
+    resolved_revision_slug: Optional[str] = None,
+    resolved_revision_version: Optional[int] = None,
+    entity_type: str = "artifact",
+) -> None:
+    """Reject requests where caller-supplied refs contradict the resolved revision (rule 2.d enforcement).
+
+    The retrieve API tolerates redundant refs (the same revision identified
+    by multiple of `{artifact_ref, variant_ref, revision_ref}`) because they
+    are useful for sanity-check shapes. But every redundant identifier must
+    name the same row the lookup resolved — otherwise silently favoring one
+    ref over another is a footgun. The version field is the one exception:
+    it's a per-variant sequence number and lookup-by-id ignores it, so a
+    redundant version that disagrees is still a contradiction worth
+    rejecting.
+
+    None-valued caller fields are skipped (only present-but-wrong fails).
+    None-valued resolved fields are skipped too — caller asked for a
+    consistency check the DAO can't service, which is a no-op rather than a
+    failure.
+    """
+    mismatches: list[str] = []
+    if artifact_ref is not None:
+        mismatches.append(
+            _mismatch(
+                f"{entity_type}_ref.id",
+                artifact_ref.id,
+                "artifact_id",
+                resolved_artifact_id,
+            )
+        )
+        mismatches.append(
+            _mismatch(
+                f"{entity_type}_ref.slug",
+                artifact_ref.slug,
+                "artifact_slug",
+                resolved_artifact_slug,
+            )
+        )
+    if variant_ref is not None:
+        mismatches.append(
+            _mismatch(
+                f"{entity_type}_variant_ref.id",
+                variant_ref.id,
+                "variant_id",
+                resolved_variant_id,
+            )
+        )
+        mismatches.append(
+            _mismatch(
+                f"{entity_type}_variant_ref.slug",
+                variant_ref.slug,
+                "variant_slug",
+                resolved_variant_slug,
+            )
+        )
+    if revision_ref is not None:
+        mismatches.append(
+            _mismatch(
+                f"{entity_type}_revision_ref.id",
+                revision_ref.id,
+                "id",
+                resolved_revision_id,
+            )
+        )
+        mismatches.append(
+            _mismatch(
+                f"{entity_type}_revision_ref.slug",
+                revision_ref.slug,
+                "slug",
+                resolved_revision_slug,
+            )
+        )
+        if revision_ref.version is not None and resolved_revision_version is not None:
+            if str(revision_ref.version) != str(resolved_revision_version):
+                mismatches.append(
+                    f"{entity_type}_revision_ref.version="
+                    f"{revision_ref.version!r} does not match resolved "
+                    f"revision's version={resolved_revision_version!r}"
+                )
+
+    errors = [m for m in mismatches if m]
+    if errors:
+        raise RetrieveRefsInconsistent("; ".join(errors))

--- a/api/oss/src/core/git/types.py
+++ b/api/oss/src/core/git/types.py
@@ -77,7 +77,7 @@ def needs_default_variant_resolution(
     return True
 
 
-def validate_revision_ref_unambiguous(
+def validate_revision_refs_sufficient(
     *,
     artifact_ref: Optional[Reference],
     variant_ref: Optional[Reference],
@@ -118,6 +118,35 @@ def validate_revision_ref_unambiguous(
         f"scope it. Provide either, or identify the revision by "
         f"{entity_type}_revision_ref.id or {entity_type}_revision_ref.slug "
         f"(both are project-unique)."
+    )
+
+
+def validate_variant_refs_sufficient(
+    *,
+    variant_ref: Optional[Reference],
+    entity_type: str = "artifact",
+) -> None:
+    """Reject `variant_ref` shapes that can never identify a variant.
+
+    Variants carry `id` and `slug` but no `version` field — version is a
+    per-variant counter living on revisions. A `variant_ref` populated with
+    only `version` is nonsense the DAO would silently drop, so reject it at
+    the boundary.
+
+    Identifying `variant_ref` (id/slug, optionally with redundant version
+    that the DAO ignores) is left alone — C3's consistency check covers the
+    "redundant but wrong" case.
+    """
+    if variant_ref is None:
+        return
+    if _is_identifying(variant_ref):
+        return
+    if variant_ref.version is None:
+        return
+    raise RetrieveRefsInsufficient(
+        f"{entity_type}_variant_ref carries only `version`, but variants "
+        f"have no `version` field. Identify the variant by "
+        f"{entity_type}_variant_ref.id or {entity_type}_variant_ref.slug."
     )
 
 

--- a/api/oss/src/core/git/types.py
+++ b/api/oss/src/core/git/types.py
@@ -142,13 +142,9 @@ def validate_retrieve_refs_consistent(
     artifact_ref: Optional[Reference],
     variant_ref: Optional[Reference],
     revision_ref: Optional[Reference],
-    resolved_artifact_id=None,
-    resolved_artifact_slug: Optional[str] = None,
-    resolved_variant_id=None,
-    resolved_variant_slug: Optional[str] = None,
-    resolved_revision_id=None,
-    resolved_revision_slug: Optional[str] = None,
-    resolved_revision_version: Optional[int] = None,
+    resolved_artifact_ref: Optional[Reference] = None,
+    resolved_variant_ref: Optional[Reference] = None,
+    resolved_revision_ref: Optional[Reference] = None,
     entity_type: str = "artifact",
 ) -> None:
     """Reject requests where caller-supplied refs contradict the resolved revision (rule 2.d enforcement).
@@ -167,14 +163,14 @@ def validate_retrieve_refs_consistent(
     consistency check the DAO can't service, which is a no-op rather than a
     failure.
     """
-    mismatches: list[str] = []
-    if artifact_ref is not None:
+    mismatches: list[Optional[str]] = []
+    if artifact_ref is not None and resolved_artifact_ref is not None:
         mismatches.append(
             _mismatch(
                 f"{entity_type}_ref.id",
                 artifact_ref.id,
                 "artifact_id",
-                resolved_artifact_id,
+                resolved_artifact_ref.id,
             )
         )
         mismatches.append(
@@ -182,16 +178,16 @@ def validate_retrieve_refs_consistent(
                 f"{entity_type}_ref.slug",
                 artifact_ref.slug,
                 "artifact_slug",
-                resolved_artifact_slug,
+                resolved_artifact_ref.slug,
             )
         )
-    if variant_ref is not None:
+    if variant_ref is not None and resolved_variant_ref is not None:
         mismatches.append(
             _mismatch(
                 f"{entity_type}_variant_ref.id",
                 variant_ref.id,
                 "variant_id",
-                resolved_variant_id,
+                resolved_variant_ref.id,
             )
         )
         mismatches.append(
@@ -199,16 +195,16 @@ def validate_retrieve_refs_consistent(
                 f"{entity_type}_variant_ref.slug",
                 variant_ref.slug,
                 "variant_slug",
-                resolved_variant_slug,
+                resolved_variant_ref.slug,
             )
         )
-    if revision_ref is not None:
+    if revision_ref is not None and resolved_revision_ref is not None:
         mismatches.append(
             _mismatch(
                 f"{entity_type}_revision_ref.id",
                 revision_ref.id,
                 "id",
-                resolved_revision_id,
+                resolved_revision_ref.id,
             )
         )
         mismatches.append(
@@ -216,15 +212,18 @@ def validate_retrieve_refs_consistent(
                 f"{entity_type}_revision_ref.slug",
                 revision_ref.slug,
                 "slug",
-                resolved_revision_slug,
+                resolved_revision_ref.slug,
             )
         )
-        if revision_ref.version is not None and resolved_revision_version is not None:
-            if str(revision_ref.version) != str(resolved_revision_version):
+        if (
+            revision_ref.version is not None
+            and resolved_revision_ref.version is not None
+        ):
+            if str(revision_ref.version) != str(resolved_revision_ref.version):
                 mismatches.append(
                     f"{entity_type}_revision_ref.version="
                     f"{revision_ref.version!r} does not match resolved "
-                    f"revision's version={resolved_revision_version!r}"
+                    f"revision's version={resolved_revision_ref.version!r}"
                 )
 
     errors = [m for m in mismatches if m]

--- a/api/oss/src/core/git/types.py
+++ b/api/oss/src/core/git/types.py
@@ -31,7 +31,7 @@ class RevisionRefInvalid(GitError):
     """
 
 
-def _has_id_or_slug(ref: Optional[Reference]) -> bool:
+def _is_identifying(ref: Optional[Reference]) -> bool:
     """A `Reference` is "identifying" only if it carries an `id` or `slug`.
 
     An empty `Reference(id=None, slug=None, version=None)` is a truthy
@@ -41,6 +41,30 @@ def _has_id_or_slug(ref: Optional[Reference]) -> bool:
     return bool(ref and (ref.id or ref.slug))
 
 
+def needs_default_variant_resolution(
+    *,
+    artifact_ref: Optional[Reference],
+    variant_ref: Optional[Reference],
+    revision_ref: Optional[Reference],
+) -> bool:
+    """True when the service should resolve `artifact_ref` to its default variant
+    before reaching the DAO.
+
+    Fires when `artifact_ref` is identifying, `variant_ref` is not, and
+    `revision_ref` is not identifying either (it's None, empty, or
+    version-only). Both shapes — `{artifact_ref}` alone (latest-of-default)
+    and `{artifact_ref + version}` (specific-version-on-default) — need the
+    same artifact→variant resolution to give the DAO a usable variant scope.
+    """
+    if not _is_identifying(artifact_ref):
+        return False
+    if _is_identifying(variant_ref):
+        return False
+    if _is_identifying(revision_ref):
+        return False
+    return True
+
+
 def validate_revision_ref_unambiguous(
     *,
     artifact_ref: Optional[Reference],
@@ -48,27 +72,17 @@ def validate_revision_ref_unambiguous(
     revision_ref: Optional[Reference],
     entity_type: str = "artifact",
 ) -> None:
-    """Reject revision-retrieve requests that cannot identify a single revision.
+    """Reject requests whose refs are insufficient to identify a single revision (rule 2.e).
 
     Rule enforced: if `revision_ref.version` is set and neither
     `revision_ref.id` nor `revision_ref.slug` is set, the request must
-    carry a `variant_ref` with `id` or `slug`. Without that scope, the same
-    `version` value exists across many variants and cannot identify a
-    single revision; the DAO would silently return an arbitrary row.
+    carry either a `variant_ref` with `id`/`slug` OR an `artifact_ref` with
+    `id`/`slug`. Either is sufficient to scope the version lookup: a
+    variant directly scopes it, an artifact scopes it via the
+    default-variant fallback (deterministic ORDER BY at the DAO).
 
     The all-empty case (no refs at all) is intentionally NOT raised here —
     callers handle that as "nothing to look up" and return `None`.
-
-    Note on `artifact_ref`: in principle a populated `artifact_ref` is also
-    sufficient to scope a version lookup, because the service can resolve
-    artifact → default variant → revision. This helper does NOT accept
-    `artifact_ref` alone today because that resolution path (the default-
-    variant pick) is non-deterministic for multi-variant artifacts in the
-    current code. Once that lookup becomes deterministic, callers can
-    resolve `artifact_ref` → `variant_ref` before invoking this helper and
-    the same shape will pass without changing this function. `artifact_ref`
-    is accepted as a parameter for forward compatibility (future cross-ref
-    mismatch validation, rule 2.c) but is not consulted today.
 
     `entity_type` is interpolated into the error message ("workflow",
     "testset", ...) so callers across entities can keep their messages
@@ -83,13 +97,13 @@ def validate_revision_ref_unambiguous(
     if not revision_version_only:
         return
 
-    if _has_id_or_slug(variant_ref):
+    if _is_identifying(variant_ref) or _is_identifying(artifact_ref):
         return
 
     raise RevisionRefInvalid(
         f"{entity_type}_revision_ref.version is a per-variant sequence number "
-        f"and requires a {entity_type}_variant_ref to be unambiguous. "
-        f"Provide a {entity_type}_variant_ref, or identify the revision by "
+        f"and requires a {entity_type}_variant_ref or {entity_type}_ref to "
+        f"scope it. Provide either, or identify the revision by "
         f"{entity_type}_revision_ref.id or {entity_type}_revision_ref.slug "
         f"(both are project-unique)."
     )

--- a/api/oss/src/core/git/types.py
+++ b/api/oss/src/core/git/types.py
@@ -1,3 +1,93 @@
+"""Git-pattern domain rules for artifact/variant/revision references.
+
+This module owns the shape of `revisions/retrieve` across every git-backed
+entity (workflows, applications, evaluators, testsets, queries,
+environments). Changes here propagate uniformly. The rules below are the
+contract every entity service implements before delegating to its DAO.
+
+Reference shapes
+================
+
+A `Reference(id, slug, version)` is *identifying* iff it carries an `id`
+or a `slug`. Both are project-unique. A bare `version` (with no `id` or
+`slug`) is a per-variant sequence number on its own — not a project-wide
+identifier — and never identifies a row.
+
+Variants do not have versions: a `variant_ref` carrying only `version`
+is rejected outright by `validate_variant_refs_sufficient`.
+
+A revision can be identified by:
+
+  * `revision_ref.id`                                — project-unique.
+  * `revision_ref.slug`                              — project-unique.
+  * `variant_ref` (id/slug) + `revision_ref.version` — version is scoped
+    to the variant.
+
+Rule 2.a — minimal identifying request
+---------------------------------------
+
+Any single identifying reference resolves a single revision:
+
+  * `{revision_ref.id}` or `{revision_ref.slug}` → that revision.
+  * `{variant_ref}`                              → latest revision on the
+    variant (stable tie-break: `created_at DESC, id DESC`).
+  * `{artifact_ref}`                             → latest revision on the
+    artifact's default variant (default variant picked by
+    `created_at ASC, id ASC LIMIT 1`).
+
+Env-path: `{environment_ref + key}` resolves to the revision currently
+deployed under that key. When `key` is omitted but `artifact_ref` has a
+slug, the key is derived as `{artifact_slug}.revision`.
+
+Rule 2.b — redundant-consistent request
+----------------------------------------
+
+A caller may repeat identifying refs across the
+artifact/variant/revision triple, or mix entity refs with env refs.
+Every redundant identifier must name the same row that the lookup
+resolved. Validated post-resolution by
+`validate_retrieve_refs_consistent`.
+
+Rule 2.c — inconsistent request
+--------------------------------
+
+When any redundant ref contradicts the resolved revision (different
+`id`, different `slug`, or — for revisions inside a variant — different
+`version`), `RetrieveRefsInconsistent` is raised. Routers translate this
+to HTTP 400 with a `*_ref` field name in the message.
+
+Rule 2.d — insufficient request that picks a default
+-----------------------------------------------------
+
+When refs are minimal but unambiguous (single variant, single artifact,
+env-ref + key), the rules above pick deterministically.
+
+Rule 2.e — insufficient request that cannot pick
+-------------------------------------------------
+
+When refs are present but cannot identify a single revision —
+`{revision_ref:{version}}` alone, `{variant_ref:{version}}` alone, or
+env refs without a `key` and without an artifact-ref to derive the key
+from — `RetrieveRefsInsufficient` is raised. Routers translate this to
+HTTP 400.
+
+Empty request (`{}`) resolves to `None` at the service layer; routers
+that require at least one identifying input (env-path-only routers like
+applications) reject it at the boundary.
+
+Exception registry
+==================
+
+`VariantForkError`, `RetrieveRefsInsufficient`, and
+`RetrieveRefsInconsistent` are translated to HTTP responses by
+`@handle_git_exceptions()` in
+`api/oss/src/apis/fastapi/git/exceptions.py`. Any new git-domain
+exception added here must also be registered there.
+
+See `docs/design/playground-open-from-trace/followups.md` for the design
+record that drove these rules.
+"""
+
 from typing import Optional
 
 from oss.src.core.shared.dtos import Reference

--- a/api/oss/src/core/queries/service.py
+++ b/api/oss/src/core/queries/service.py
@@ -9,6 +9,7 @@ from oss.src.core.git.interfaces import GitDAOInterface
 from oss.src.core.git.types import (
     validate_revision_ref_unambiguous,
     needs_default_variant_resolution,
+    validate_retrieve_refs_consistent,
 )
 from oss.src.core.shared.dtos import Reference, Windowing, Trace, Traces
 from oss.src.core.tracing.dtos import (
@@ -657,6 +658,9 @@ class QueriesService:
             entity_type="query",
         )
 
+        _original_query_ref = query_ref
+        _original_query_variant_ref = query_variant_ref
+
         if needs_default_variant_resolution(
             artifact_ref=query_ref,
             variant_ref=query_variant_ref,
@@ -699,6 +703,20 @@ class QueriesService:
 
         if not revision:
             return None
+
+        validate_retrieve_refs_consistent(
+            artifact_ref=_original_query_ref,
+            variant_ref=_original_query_variant_ref,
+            revision_ref=query_revision_ref,
+            resolved_artifact_id=revision.artifact_id,
+            resolved_artifact_slug=revision.artifact_slug,
+            resolved_variant_id=revision.variant_id,
+            resolved_variant_slug=revision.variant_slug,
+            resolved_revision_id=revision.id,
+            resolved_revision_slug=revision.slug,
+            resolved_revision_version=revision.version,
+            entity_type="query",
+        )
 
         _query_revision = QueryRevision(
             **revision.model_dump(mode="json"),

--- a/api/oss/src/core/queries/service.py
+++ b/api/oss/src/core/queries/service.py
@@ -7,7 +7,8 @@ from oss.src.utils.logging import get_module_logger
 from oss.src.core.events.utils import publish_revision_event
 from oss.src.core.git.interfaces import GitDAOInterface
 from oss.src.core.git.types import (
-    validate_revision_ref_unambiguous,
+    validate_revision_refs_sufficient,
+    validate_variant_refs_sufficient,
     needs_default_variant_resolution,
     validate_retrieve_refs_consistent,
 )
@@ -432,6 +433,10 @@ class QueriesService:
         query_ref: Optional[Reference] = None,
         query_variant_ref: Optional[Reference] = None,
     ) -> Optional[QueryVariant]:
+        validate_variant_refs_sufficient(
+            variant_ref=query_variant_ref,
+            entity_type="query",
+        )
         variant = await self.queries_dao.fetch_variant(
             project_id=project_id,
             #
@@ -651,7 +656,11 @@ class QueriesService:
         if not query_ref and not query_variant_ref and not query_revision_ref:
             return None
 
-        validate_revision_ref_unambiguous(
+        validate_variant_refs_sufficient(
+            variant_ref=query_variant_ref,
+            entity_type="query",
+        )
+        validate_revision_refs_sufficient(
             artifact_ref=query_ref,
             variant_ref=query_variant_ref,
             revision_ref=query_revision_ref,

--- a/api/oss/src/core/queries/service.py
+++ b/api/oss/src/core/queries/service.py
@@ -6,7 +6,10 @@ from oss.src.utils.logging import get_module_logger
 
 from oss.src.core.events.utils import publish_revision_event
 from oss.src.core.git.interfaces import GitDAOInterface
-from oss.src.core.git.types import validate_revision_ref_unambiguous
+from oss.src.core.git.types import (
+    validate_revision_ref_unambiguous,
+    needs_default_variant_resolution,
+)
 from oss.src.core.shared.dtos import Reference, Windowing, Trace, Traces
 from oss.src.core.tracing.dtos import (
     TracingQuery,
@@ -654,7 +657,11 @@ class QueriesService:
             entity_type="query",
         )
 
-        if query_ref and not query_variant_ref and not query_revision_ref:
+        if needs_default_variant_resolution(
+            artifact_ref=query_ref,
+            variant_ref=query_variant_ref,
+            revision_ref=query_revision_ref,
+        ):
             query = await self.fetch_query(
                 project_id=project_id,
                 #

--- a/api/oss/src/core/queries/service.py
+++ b/api/oss/src/core/queries/service.py
@@ -708,13 +708,19 @@ class QueriesService:
             artifact_ref=_original_query_ref,
             variant_ref=_original_query_variant_ref,
             revision_ref=query_revision_ref,
-            resolved_artifact_id=revision.artifact_id,
-            resolved_artifact_slug=revision.artifact_slug,
-            resolved_variant_id=revision.variant_id,
-            resolved_variant_slug=revision.variant_slug,
-            resolved_revision_id=revision.id,
-            resolved_revision_slug=revision.slug,
-            resolved_revision_version=revision.version,
+            resolved_artifact_ref=Reference(
+                id=revision.artifact_id,
+                slug=revision.artifact_slug,
+            ),
+            resolved_variant_ref=Reference(
+                id=revision.variant_id,
+                slug=revision.variant_slug,
+            ),
+            resolved_revision_ref=Reference(
+                id=revision.id,
+                slug=revision.slug,
+                version=revision.version,
+            ),
             entity_type="query",
         )
 

--- a/api/oss/src/core/testsets/service.py
+++ b/api/oss/src/core/testsets/service.py
@@ -4,7 +4,10 @@ from uuid import UUID, uuid4
 from oss.src.utils.logging import get_module_logger
 from oss.src.core.events.utils import publish_revision_event
 from oss.src.core.git.interfaces import GitDAOInterface
-from oss.src.core.git.types import validate_revision_ref_unambiguous
+from oss.src.core.git.types import (
+    validate_revision_ref_unambiguous,
+    needs_default_variant_resolution,
+)
 from oss.src.core.testcases.service import TestcasesService
 from oss.src.core.shared.dtos import Reference, Windowing
 from oss.src.core.git.dtos import (
@@ -644,7 +647,11 @@ class TestsetsService:
             entity_type="testset",
         )
 
-        if testset_ref and not testset_variant_ref and not testset_revision_ref:
+        if needs_default_variant_resolution(
+            artifact_ref=testset_ref,
+            variant_ref=testset_variant_ref,
+            revision_ref=testset_revision_ref,
+        ):
             testset = await self.fetch_testset(
                 project_id=project_id,
                 #

--- a/api/oss/src/core/testsets/service.py
+++ b/api/oss/src/core/testsets/service.py
@@ -5,7 +5,8 @@ from oss.src.utils.logging import get_module_logger
 from oss.src.core.events.utils import publish_revision_event
 from oss.src.core.git.interfaces import GitDAOInterface
 from oss.src.core.git.types import (
-    validate_revision_ref_unambiguous,
+    validate_revision_refs_sufficient,
+    validate_variant_refs_sufficient,
     needs_default_variant_resolution,
     validate_retrieve_refs_consistent,
 )
@@ -428,6 +429,10 @@ class TestsetsService:
         testset_ref: Optional[Reference] = None,
         testset_variant_ref: Optional[Reference] = None,
     ) -> Optional[TestsetVariant]:
+        validate_variant_refs_sufficient(
+            variant_ref=testset_variant_ref,
+            entity_type="testset",
+        )
         variant = await self.testsets_dao.fetch_variant(
             project_id=project_id,
             #
@@ -641,7 +646,11 @@ class TestsetsService:
         if not testset_ref and not testset_variant_ref and not testset_revision_ref:
             return None
 
-        validate_revision_ref_unambiguous(
+        validate_variant_refs_sufficient(
+            variant_ref=testset_variant_ref,
+            entity_type="testset",
+        )
+        validate_revision_refs_sufficient(
             artifact_ref=testset_ref,
             variant_ref=testset_variant_ref,
             revision_ref=testset_revision_ref,

--- a/api/oss/src/core/testsets/service.py
+++ b/api/oss/src/core/testsets/service.py
@@ -7,6 +7,7 @@ from oss.src.core.git.interfaces import GitDAOInterface
 from oss.src.core.git.types import (
     validate_revision_ref_unambiguous,
     needs_default_variant_resolution,
+    validate_retrieve_refs_consistent,
 )
 from oss.src.core.testcases.service import TestcasesService
 from oss.src.core.shared.dtos import Reference, Windowing
@@ -647,6 +648,9 @@ class TestsetsService:
             entity_type="testset",
         )
 
+        _original_testset_ref = testset_ref
+        _original_testset_variant_ref = testset_variant_ref
+
         if needs_default_variant_resolution(
             artifact_ref=testset_ref,
             variant_ref=testset_variant_ref,
@@ -689,6 +693,20 @@ class TestsetsService:
 
         if not revision:
             return None
+
+        validate_retrieve_refs_consistent(
+            artifact_ref=_original_testset_ref,
+            variant_ref=_original_testset_variant_ref,
+            revision_ref=testset_revision_ref,
+            resolved_artifact_id=revision.artifact_id,
+            resolved_artifact_slug=revision.artifact_slug,
+            resolved_variant_id=revision.variant_id,
+            resolved_variant_slug=revision.variant_slug,
+            resolved_revision_id=revision.id,
+            resolved_revision_slug=revision.slug,
+            resolved_revision_version=revision.version,
+            entity_type="testset",
+        )
 
         testset_revision = TestsetRevision(
             **revision.model_dump(

--- a/api/oss/src/core/testsets/service.py
+++ b/api/oss/src/core/testsets/service.py
@@ -698,13 +698,19 @@ class TestsetsService:
             artifact_ref=_original_testset_ref,
             variant_ref=_original_testset_variant_ref,
             revision_ref=testset_revision_ref,
-            resolved_artifact_id=revision.artifact_id,
-            resolved_artifact_slug=revision.artifact_slug,
-            resolved_variant_id=revision.variant_id,
-            resolved_variant_slug=revision.variant_slug,
-            resolved_revision_id=revision.id,
-            resolved_revision_slug=revision.slug,
-            resolved_revision_version=revision.version,
+            resolved_artifact_ref=Reference(
+                id=revision.artifact_id,
+                slug=revision.artifact_slug,
+            ),
+            resolved_variant_ref=Reference(
+                id=revision.variant_id,
+                slug=revision.variant_slug,
+            ),
+            resolved_revision_ref=Reference(
+                id=revision.id,
+                slug=revision.slug,
+                version=revision.version,
+            ),
             entity_type="testset",
         )
 

--- a/api/oss/src/core/workflows/service.py
+++ b/api/oss/src/core/workflows/service.py
@@ -1147,13 +1147,19 @@ class WorkflowsService:
             artifact_ref=_original_workflow_ref,
             variant_ref=_original_workflow_variant_ref,
             revision_ref=workflow_revision_ref,
-            resolved_artifact_id=revision.artifact_id,
-            resolved_artifact_slug=revision.artifact_slug,
-            resolved_variant_id=revision.variant_id,
-            resolved_variant_slug=revision.variant_slug,
-            resolved_revision_id=revision.id,
-            resolved_revision_slug=revision.slug,
-            resolved_revision_version=revision.version,
+            resolved_artifact_ref=Reference(
+                id=revision.artifact_id,
+                slug=revision.artifact_slug,
+            ),
+            resolved_variant_ref=Reference(
+                id=revision.variant_id,
+                slug=revision.variant_slug,
+            ),
+            resolved_revision_ref=Reference(
+                id=revision.id,
+                slug=revision.slug,
+                version=revision.version,
+            ),
             entity_type="workflow",
         )
 

--- a/api/oss/src/core/workflows/service.py
+++ b/api/oss/src/core/workflows/service.py
@@ -80,7 +80,8 @@ from oss.src.core.workflows.dtos import (
     WorkflowServiceStreamResponse,
 )
 from oss.src.core.git.types import (
-    validate_revision_ref_unambiguous,
+    validate_revision_refs_sufficient,
+    validate_variant_refs_sufficient,
     needs_default_variant_resolution,
     validate_retrieve_refs_consistent,
 )
@@ -833,6 +834,10 @@ class WorkflowsService:
         #
         include_archived: Optional[bool] = True,
     ) -> Optional[WorkflowVariant]:
+        validate_variant_refs_sufficient(
+            variant_ref=workflow_variant_ref,
+            entity_type="workflow",
+        )
         variant = await self.workflows_dao.fetch_variant(
             project_id=project_id,
             #
@@ -1084,7 +1089,11 @@ class WorkflowsService:
         if not workflow_ref and not workflow_variant_ref and not workflow_revision_ref:
             return None
 
-        validate_revision_ref_unambiguous(
+        validate_variant_refs_sufficient(
+            variant_ref=workflow_variant_ref,
+            entity_type="workflow",
+        )
+        validate_revision_refs_sufficient(
             artifact_ref=workflow_ref,
             variant_ref=workflow_variant_ref,
             revision_ref=workflow_revision_ref,

--- a/api/oss/src/core/workflows/service.py
+++ b/api/oss/src/core/workflows/service.py
@@ -79,7 +79,10 @@ from oss.src.core.workflows.dtos import (
     WorkflowServiceBatchResponse,
     WorkflowServiceStreamResponse,
 )
-from oss.src.core.git.types import validate_revision_ref_unambiguous
+from oss.src.core.git.types import (
+    validate_revision_ref_unambiguous,
+    needs_default_variant_resolution,
+)
 
 # Resolution is now handled by EmbedsService
 from oss.src.core.embeds.dtos import (
@@ -1087,7 +1090,11 @@ class WorkflowsService:
             entity_type="workflow",
         )
 
-        if workflow_ref and not workflow_variant_ref and not workflow_revision_ref:
+        if needs_default_variant_resolution(
+            artifact_ref=workflow_ref,
+            variant_ref=workflow_variant_ref,
+            revision_ref=workflow_revision_ref,
+        ):
             workflow = await self.fetch_workflow(
                 project_id=project_id,
                 #

--- a/api/oss/src/core/workflows/service.py
+++ b/api/oss/src/core/workflows/service.py
@@ -82,6 +82,7 @@ from oss.src.core.workflows.dtos import (
 from oss.src.core.git.types import (
     validate_revision_ref_unambiguous,
     needs_default_variant_resolution,
+    validate_retrieve_refs_consistent,
 )
 
 # Resolution is now handled by EmbedsService
@@ -1090,6 +1091,9 @@ class WorkflowsService:
             entity_type="workflow",
         )
 
+        _original_workflow_ref = workflow_ref
+        _original_workflow_variant_ref = workflow_variant_ref
+
         if needs_default_variant_resolution(
             artifact_ref=workflow_ref,
             variant_ref=workflow_variant_ref,
@@ -1138,6 +1142,20 @@ class WorkflowsService:
 
         if not revision:
             return None
+
+        validate_retrieve_refs_consistent(
+            artifact_ref=_original_workflow_ref,
+            variant_ref=_original_workflow_variant_ref,
+            revision_ref=workflow_revision_ref,
+            resolved_artifact_id=revision.artifact_id,
+            resolved_artifact_slug=revision.artifact_slug,
+            resolved_variant_id=revision.variant_id,
+            resolved_variant_slug=revision.variant_slug,
+            resolved_revision_id=revision.id,
+            resolved_revision_slug=revision.slug,
+            resolved_revision_version=revision.version,
+            entity_type="workflow",
+        )
 
         _workflow_revision = WorkflowRevision(
             **revision.model_dump(mode="json"),

--- a/api/oss/src/dbs/postgres/git/dao.py
+++ b/api/oss/src/dbs/postgres/git/dao.py
@@ -1091,7 +1091,10 @@ class GitDAO(GitDAOInterface):
                 if revision_ref and revision_ref.version:
                     stmt = stmt.filter(self.RevisionDBE.version == revision_ref.version)  # type: ignore
                 else:
-                    stmt = stmt.order_by(self.RevisionDBE.created_at.desc())  # type: ignore
+                    stmt = stmt.order_by(
+                        self.RevisionDBE.created_at.desc(),  # type: ignore
+                        self.RevisionDBE.id.desc(),  # type: ignore
+                    )
                     stmt = stmt.offset(0)
 
             if not applied_identifying_filter:

--- a/api/oss/src/dbs/postgres/git/dao.py
+++ b/api/oss/src/dbs/postgres/git/dao.py
@@ -499,6 +499,8 @@ class GitDAO(GitDAOInterface):
                 )
             )
 
+            pick_default_variant = False
+
             if variant_ref:
                 if variant_ref.id:
                     stmt = stmt.filter(self.VariantDBE.id == variant_ref.id)  # type: ignore
@@ -510,6 +512,7 @@ class GitDAO(GitDAOInterface):
                 if artifact_ref.id:
                     stmt = stmt.filter(self.VariantDBE.artifact_id == artifact_ref.id)  # type: ignore
                     applied_identifying_filter = True
+                    pick_default_variant = True
                 elif artifact_ref.slug:
                     stmt = stmt.join(
                         self.ArtifactDBE,
@@ -518,9 +521,16 @@ class GitDAO(GitDAOInterface):
                         self.ArtifactDBE.slug == artifact_ref.slug,  # type: ignore
                     )
                     applied_identifying_filter = True
+                    pick_default_variant = True
 
             if not applied_identifying_filter:
                 return None
+
+            if pick_default_variant:
+                stmt = stmt.order_by(
+                    self.VariantDBE.created_at.asc(),  # type: ignore
+                    self.VariantDBE.id.asc(),  # type: ignore
+                )
 
             if include_archived is not True:
                 stmt = stmt.filter(self.VariantDBE.deleted_at.is_(None))  # type: ignore

--- a/api/oss/src/dbs/postgres/git/dao.py
+++ b/api/oss/src/dbs/postgres/git/dao.py
@@ -486,6 +486,8 @@ class GitDAO(GitDAOInterface):
         if not artifact_ref and not variant_ref:
             return None
 
+        applied_identifying_filter = False
+
         async with engine.core_session() as session:
             stmt = (
                 select(self.VariantDBE)
@@ -500,11 +502,25 @@ class GitDAO(GitDAOInterface):
             if variant_ref:
                 if variant_ref.id:
                     stmt = stmt.filter(self.VariantDBE.id == variant_ref.id)  # type: ignore
+                    applied_identifying_filter = True
                 elif variant_ref.slug:
                     stmt = stmt.filter(self.VariantDBE.slug == variant_ref.slug)  # type: ignore
+                    applied_identifying_filter = True
             elif artifact_ref:
                 if artifact_ref.id:
                     stmt = stmt.filter(self.VariantDBE.artifact_id == artifact_ref.id)  # type: ignore
+                    applied_identifying_filter = True
+                elif artifact_ref.slug:
+                    stmt = stmt.join(
+                        self.ArtifactDBE,
+                        self.VariantDBE.artifact_id == self.ArtifactDBE.id,  # type: ignore
+                    ).filter(
+                        self.ArtifactDBE.slug == artifact_ref.slug,  # type: ignore
+                    )
+                    applied_identifying_filter = True
+
+            if not applied_identifying_filter:
+                return None
 
             if include_archived is not True:
                 stmt = stmt.filter(self.VariantDBE.deleted_at.is_(None))  # type: ignore

--- a/api/oss/tests/pytest/acceptance/test_env_backed_retrieve_policy.py
+++ b/api/oss/tests/pytest/acceptance/test_env_backed_retrieve_policy.py
@@ -1,0 +1,87 @@
+"""Acceptance: env-backed retrieve policy is consistent across entities.
+
+Three retrieve endpoints support an environment-ref path:
+  /workflows/revisions/retrieve
+  /applications/revisions/retrieve
+  /evaluators/revisions/retrieve
+
+All three should:
+  - Reject {} (no entity refs, no env refs, no key) with 400.
+  - Reject env-backed retrieve when env refs are present without a `key`
+    AND no artifact_ref to derive it from.
+  - Path-mixing (entity refs AND env refs) is allowed at the policy
+    boundary; downstream services may surface a 4xx for unresolvable
+    cases but not here.
+"""
+
+from uuid import uuid4
+
+
+def _assert_400(response):
+    assert response.status_code == 400, response.text
+
+
+def test_workflows_retrieve_empty_request_returns_400(authed_api):
+    response = authed_api("POST", "/workflows/revisions/retrieve", json={})
+    _assert_400(response)
+
+
+def test_applications_retrieve_empty_request_returns_400(authed_api):
+    response = authed_api("POST", "/applications/revisions/retrieve", json={})
+    _assert_400(response)
+
+
+def test_evaluators_retrieve_empty_request_returns_400(authed_api):
+    response = authed_api("POST", "/evaluators/revisions/retrieve", json={})
+    _assert_400(response)
+
+
+def test_workflows_env_refs_without_key_or_artifact_returns_400(authed_api):
+    response = authed_api(
+        "POST",
+        "/workflows/revisions/retrieve",
+        json={"environment_ref": {"slug": f"env-{uuid4().hex[:8]}"}},
+    )
+    _assert_400(response)
+
+
+def test_evaluators_env_refs_without_key_or_artifact_returns_400(authed_api):
+    response = authed_api(
+        "POST",
+        "/evaluators/revisions/retrieve",
+        json={"environment_ref": {"slug": f"env-{uuid4().hex[:8]}"}},
+    )
+    _assert_400(response)
+
+
+def test_applications_env_refs_without_key_or_artifact_returns_400(authed_api):
+    response = authed_api(
+        "POST",
+        "/applications/revisions/retrieve",
+        json={"environment_ref": {"slug": f"env-{uuid4().hex[:8]}"}},
+    )
+    _assert_400(response)
+
+
+def test_workflows_path_mixing_does_not_return_400_at_policy_boundary(authed_api):
+    response = authed_api(
+        "POST",
+        "/workflows/revisions/retrieve",
+        json={
+            "workflow_ref": {"slug": f"wf-{uuid4().hex[:8]}"},
+            "environment_ref": {"slug": f"env-{uuid4().hex[:8]}"},
+        },
+    )
+    assert response.status_code != 400, response.text
+
+
+def test_evaluators_path_mixing_does_not_return_400_at_policy_boundary(authed_api):
+    response = authed_api(
+        "POST",
+        "/evaluators/revisions/retrieve",
+        json={
+            "evaluator_ref": {"slug": f"ev-{uuid4().hex[:8]}"},
+            "environment_ref": {"slug": f"env-{uuid4().hex[:8]}"},
+        },
+    )
+    assert response.status_code != 400, response.text

--- a/api/oss/tests/pytest/acceptance/test_revision_retrieve_ambiguous_400.py
+++ b/api/oss/tests/pytest/acceptance/test_revision_retrieve_ambiguous_400.py
@@ -91,19 +91,6 @@ def test_workflows_retrieve_version_only_returns_400(authed_api):
     _assert_ambiguous_400(response)
 
 
-def test_workflows_retrieve_artifact_plus_version_returns_400(authed_api):
-    workflow, _, _ = _create_workflow_stack(authed_api)
-    response = authed_api(
-        "POST",
-        "/workflows/revisions/retrieve",
-        json={
-            "workflow_ref": {"slug": workflow["slug"]},
-            "workflow_revision_ref": {"version": "1"},
-        },
-    )
-    _assert_ambiguous_400(response)
-
-
 def test_workflows_retrieve_variant_plus_version_succeeds(authed_api):
     _, variant, revision = _create_workflow_stack(authed_api)
     response = authed_api(
@@ -167,19 +154,6 @@ def test_applications_retrieve_version_only_returns_400(authed_api):
         "POST",
         "/applications/revisions/retrieve",
         json={"application_revision_ref": {"version": "1"}},
-    )
-    _assert_ambiguous_400(response)
-
-
-def test_applications_retrieve_artifact_plus_version_returns_400(authed_api):
-    app, _, _ = _create_application_stack(authed_api)
-    response = authed_api(
-        "POST",
-        "/applications/revisions/retrieve",
-        json={
-            "application_ref": {"slug": app["slug"]},
-            "application_revision_ref": {"version": "1"},
-        },
     )
     _assert_ambiguous_400(response)
 
@@ -251,19 +225,6 @@ def test_evaluators_retrieve_version_only_returns_400(authed_api):
     _assert_ambiguous_400(response)
 
 
-def test_evaluators_retrieve_artifact_plus_version_returns_400(authed_api):
-    evaluator, _, _ = _create_evaluator_stack(authed_api)
-    response = authed_api(
-        "POST",
-        "/evaluators/revisions/retrieve",
-        json={
-            "evaluator_ref": {"slug": evaluator["slug"]},
-            "evaluator_revision_ref": {"version": "1"},
-        },
-    )
-    _assert_ambiguous_400(response)
-
-
 def test_evaluators_retrieve_variant_plus_version_succeeds(authed_api):
     _, variant, revision = _create_evaluator_stack(authed_api)
     response = authed_api(
@@ -329,19 +290,6 @@ def test_testsets_retrieve_version_only_returns_400(authed_api):
     _assert_ambiguous_400(response)
 
 
-def test_testsets_retrieve_artifact_plus_version_returns_400(authed_api):
-    testset, _, _ = _create_testset_stack(authed_api)
-    response = authed_api(
-        "POST",
-        "/testsets/revisions/retrieve",
-        json={
-            "testset_ref": {"slug": testset["slug"]},
-            "testset_revision_ref": {"version": "1"},
-        },
-    )
-    _assert_ambiguous_400(response)
-
-
 def test_testsets_retrieve_variant_plus_version_succeeds(authed_api):
     _, variant, revision = _create_testset_stack(authed_api)
     response = authed_api(
@@ -396,19 +344,6 @@ def test_queries_retrieve_version_only_returns_400(authed_api):
         "POST",
         "/queries/revisions/retrieve",
         json={"query_revision_ref": {"version": "1"}},
-    )
-    _assert_ambiguous_400(response)
-
-
-def test_queries_retrieve_artifact_plus_version_returns_400(authed_api):
-    query, _ = _create_query_stack(authed_api)
-    response = authed_api(
-        "POST",
-        "/queries/revisions/retrieve",
-        json={
-            "query_ref": {"slug": query["slug"]},
-            "query_revision_ref": {"version": "1"},
-        },
     )
     _assert_ambiguous_400(response)
 
@@ -475,19 +410,6 @@ def test_environments_retrieve_version_only_returns_400(authed_api):
         "POST",
         "/environments/revisions/retrieve",
         json={"environment_revision_ref": {"version": "1"}},
-    )
-    _assert_ambiguous_400(response)
-
-
-def test_environments_retrieve_artifact_plus_version_returns_400(authed_api):
-    environment, _, _ = _create_environment_stack(authed_api)
-    response = authed_api(
-        "POST",
-        "/environments/revisions/retrieve",
-        json={
-            "environment_ref": {"slug": environment["slug"]},
-            "environment_revision_ref": {"version": "1"},
-        },
     )
     _assert_ambiguous_400(response)
 

--- a/api/oss/tests/pytest/acceptance/test_revision_retrieve_ambiguous_400.py
+++ b/api/oss/tests/pytest/acceptance/test_revision_retrieve_ambiguous_400.py
@@ -1,6 +1,6 @@
 """Acceptance: ambiguous revision-retrieve requests return HTTP 400.
 
-The shared `validate_revision_ref_unambiguous` helper protects every
+The shared `validate_revision_refs_sufficient` helper protects every
 git-backed entity's retrieve endpoint against the version-only-no-variant
 trap. These tests assert the 400 surfaces correctly across all six
 endpoints — applications, evaluators, queries, testsets, environments,

--- a/api/oss/tests/pytest/acceptance/test_revision_retrieve_env_path.py
+++ b/api/oss/tests/pytest/acceptance/test_revision_retrieve_env_path.py
@@ -1,0 +1,442 @@
+"""Acceptance: env-backed revision-retrieve coverage (C8 second pass).
+
+Pins env-path behavior on the three routers that accept env refs:
+applications, evaluators, workflows. Each test provisions a real
+artifact + variant + revision and deploys the revision to an environment
+under the default `{artifact_slug}.revision` key, then exercises:
+
+  * 2.a (env path): `{env_ref + key}` → 200, returns the deployed revision.
+  * 2.d (env path, default key): `{env_ref + artifact_ref}` (no `key`,
+    derived from the artifact slug) → 200.
+  * 2.b (redundant-consistent path-mixing): `{env_ref + key +
+    artifact_ref (matching)}` → 200.
+  * 2.c (path-mixed inconsistent): `{env_ref + key + revision_ref.id}`
+    where the revision_ref does NOT match what env+key resolves to → 400.
+
+The workflows/applications/evaluators routers all funnel into the same
+service-layer pipeline, so the matrix is intentionally symmetric.
+"""
+
+from uuid import uuid4
+
+
+# environment helpers ----------------------------------------------------------
+
+
+def _create_environment_with_deployment(authed_api, *, key, payload):
+    """Create an environment + variant + revision that deploys `payload`
+    under the given `key`. Returns the env, variant and revision rows.
+    """
+    slug = uuid4().hex[:12]
+    response = authed_api(
+        "POST",
+        "/environments/",
+        json={"environment": {"slug": f"env-{slug}"}},
+    )
+    assert response.status_code == 200, response.text
+    env = response.json()["environment"]
+
+    response = authed_api(
+        "POST",
+        "/environments/variants/",
+        json={
+            "environment_variant": {
+                "slug": f"envv-{slug}",
+                "environment_id": env["id"],
+            }
+        },
+    )
+    assert response.status_code == 200, response.text
+    env_variant = response.json()["environment_variant"]
+
+    response = authed_api(
+        "POST",
+        "/environments/revisions/commit",
+        json={
+            "environment_revision_commit": {
+                "slug": f"envr-{slug}",
+                "environment_id": env["id"],
+                "environment_variant_id": env_variant["id"],
+                "data": {"references": {key: payload}},
+            }
+        },
+    )
+    assert response.status_code == 200, response.text
+    env_revision = response.json()["environment_revision"]
+    return env, env_variant, env_revision
+
+
+# workflows --------------------------------------------------------------------
+
+
+def _create_workflow_stack(authed_api):
+    slug = uuid4().hex[:12]
+    response = authed_api(
+        "POST",
+        "/workflows/",
+        json={"workflow": {"slug": f"wf-{slug}"}},
+    )
+    assert response.status_code == 200, response.text
+    workflow = response.json()["workflow"]
+
+    response = authed_api(
+        "POST",
+        "/workflows/variants/",
+        json={
+            "workflow_variant": {
+                "slug": f"wfv-{slug}",
+                "workflow_id": workflow["id"],
+            }
+        },
+    )
+    assert response.status_code == 200, response.text
+    variant = response.json()["workflow_variant"]
+
+    response = authed_api(
+        "POST",
+        "/workflows/revisions/",
+        json={
+            "workflow_revision": {
+                "slug": f"wfr-{slug}",
+                "workflow_variant_id": variant["id"],
+                "workflow_id": workflow["id"],
+            }
+        },
+    )
+    assert response.status_code == 200, response.text
+    revision = response.json()["workflow_revision"]
+    return workflow, variant, revision
+
+
+def _deploy_workflow_to_env(authed_api, workflow, variant, revision):
+    key = f"{workflow['slug']}.revision"
+    payload = {
+        "workflow": {"id": workflow["id"], "slug": workflow["slug"]},
+        "workflow_variant": {"id": variant["id"], "slug": variant["slug"]},
+        "workflow_revision": {
+            "id": revision["id"],
+            "version": revision.get("version") or "1",
+        },
+    }
+    return _create_environment_with_deployment(authed_api, key=key, payload=payload)
+
+
+def test_workflows_env_retrieve_by_env_slug_and_key(authed_api):
+    workflow, variant, revision = _create_workflow_stack(authed_api)
+    env, _, _ = _deploy_workflow_to_env(authed_api, workflow, variant, revision)
+
+    response = authed_api(
+        "POST",
+        "/workflows/revisions/retrieve",
+        json={
+            "environment_ref": {"slug": env["slug"]},
+            "key": f"{workflow['slug']}.revision",
+        },
+    )
+    assert response.status_code == 200, response.text
+    assert response.json()["workflow_revision"]["id"] == revision["id"]
+
+
+def test_workflows_env_retrieve_default_key_from_artifact_slug(authed_api):
+    workflow, variant, revision = _create_workflow_stack(authed_api)
+    env, _, _ = _deploy_workflow_to_env(authed_api, workflow, variant, revision)
+
+    response = authed_api(
+        "POST",
+        "/workflows/revisions/retrieve",
+        json={
+            "environment_ref": {"slug": env["slug"]},
+            "workflow_ref": {"slug": workflow["slug"]},
+        },
+    )
+    assert response.status_code == 200, response.text
+    assert response.json()["workflow_revision"]["id"] == revision["id"]
+
+
+def test_workflows_env_retrieve_with_redundant_consistent_artifact(authed_api):
+    workflow, variant, revision = _create_workflow_stack(authed_api)
+    env, _, _ = _deploy_workflow_to_env(authed_api, workflow, variant, revision)
+
+    response = authed_api(
+        "POST",
+        "/workflows/revisions/retrieve",
+        json={
+            "environment_ref": {"slug": env["slug"]},
+            "key": f"{workflow['slug']}.revision",
+            "workflow_ref": {"id": workflow["id"], "slug": workflow["slug"]},
+        },
+    )
+    assert response.status_code == 200, response.text
+    assert response.json()["workflow_revision"]["id"] == revision["id"]
+
+
+def test_workflows_env_retrieve_path_mixed_inconsistent_revision_returns_400(
+    authed_api,
+):
+    workflow, variant, revision = _create_workflow_stack(authed_api)
+    env, _, _ = _deploy_workflow_to_env(authed_api, workflow, variant, revision)
+
+    _, _, unrelated_revision = _create_workflow_stack(authed_api)
+
+    response = authed_api(
+        "POST",
+        "/workflows/revisions/retrieve",
+        json={
+            "environment_ref": {"slug": env["slug"]},
+            "key": f"{workflow['slug']}.revision",
+            "workflow_revision_ref": {"id": unrelated_revision["id"]},
+        },
+    )
+    assert response.status_code == 400, response.text
+
+
+# applications -----------------------------------------------------------------
+
+
+def _create_application_stack(authed_api):
+    slug = uuid4().hex[:12]
+    flags = {"is_application": True, "is_evaluator": False, "is_snippet": False}
+    response = authed_api(
+        "POST",
+        "/applications/",
+        json={"application": {"slug": f"app-{slug}", "flags": flags}},
+    )
+    assert response.status_code == 200, response.text
+    app = response.json()["application"]
+
+    response = authed_api(
+        "POST",
+        "/applications/variants/",
+        json={
+            "application_variant": {
+                "slug": f"appv-{slug}",
+                "application_id": app["id"],
+                "flags": flags,
+            }
+        },
+    )
+    assert response.status_code == 200, response.text
+    variant = response.json()["application_variant"]
+
+    response = authed_api(
+        "POST",
+        "/applications/revisions/commit",
+        json={
+            "application_revision_commit": {
+                "application_id": app["id"],
+                "application_variant_id": variant["id"],
+                "data": {"parameters": {"model": "test-model"}},
+            }
+        },
+    )
+    assert response.status_code == 200, response.text
+    revision = response.json()["application_revision"]
+    return app, variant, revision
+
+
+def _deploy_application_to_env(authed_api, app, variant, revision):
+    key = f"{app['slug']}.revision"
+    payload = {
+        "application": {"id": app["id"], "slug": app["slug"]},
+        "application_variant": {"id": variant["id"], "slug": variant["slug"]},
+        "application_revision": {
+            "id": revision["id"],
+            "version": revision.get("version") or "1",
+        },
+    }
+    return _create_environment_with_deployment(authed_api, key=key, payload=payload)
+
+
+def test_applications_env_retrieve_by_env_slug_and_key(authed_api):
+    app, variant, revision = _create_application_stack(authed_api)
+    env, _, _ = _deploy_application_to_env(authed_api, app, variant, revision)
+
+    response = authed_api(
+        "POST",
+        "/applications/revisions/retrieve",
+        json={
+            "environment_ref": {"slug": env["slug"]},
+            "key": f"{app['slug']}.revision",
+        },
+    )
+    assert response.status_code == 200, response.text
+    assert response.json()["application_revision"]["id"] == revision["id"]
+
+
+def test_applications_env_retrieve_default_key_from_artifact_slug(authed_api):
+    app, variant, revision = _create_application_stack(authed_api)
+    env, _, _ = _deploy_application_to_env(authed_api, app, variant, revision)
+
+    response = authed_api(
+        "POST",
+        "/applications/revisions/retrieve",
+        json={
+            "environment_ref": {"slug": env["slug"]},
+            "application_ref": {"slug": app["slug"]},
+        },
+    )
+    assert response.status_code == 200, response.text
+    assert response.json()["application_revision"]["id"] == revision["id"]
+
+
+def test_applications_env_retrieve_with_redundant_consistent_artifact(authed_api):
+    app, variant, revision = _create_application_stack(authed_api)
+    env, _, _ = _deploy_application_to_env(authed_api, app, variant, revision)
+
+    response = authed_api(
+        "POST",
+        "/applications/revisions/retrieve",
+        json={
+            "environment_ref": {"slug": env["slug"]},
+            "key": f"{app['slug']}.revision",
+            "application_ref": {"id": app["id"], "slug": app["slug"]},
+        },
+    )
+    assert response.status_code == 200, response.text
+    assert response.json()["application_revision"]["id"] == revision["id"]
+
+
+def test_applications_env_retrieve_path_mixed_inconsistent_revision_returns_400(
+    authed_api,
+):
+    app, variant, revision = _create_application_stack(authed_api)
+    env, _, _ = _deploy_application_to_env(authed_api, app, variant, revision)
+
+    _, _, unrelated_revision = _create_application_stack(authed_api)
+
+    response = authed_api(
+        "POST",
+        "/applications/revisions/retrieve",
+        json={
+            "environment_ref": {"slug": env["slug"]},
+            "key": f"{app['slug']}.revision",
+            "application_revision_ref": {"id": unrelated_revision["id"]},
+        },
+    )
+    assert response.status_code == 400, response.text
+
+
+# evaluators -------------------------------------------------------------------
+
+
+def _create_evaluator_stack(authed_api):
+    slug = uuid4().hex[:12]
+    flags = {"is_evaluator": True}
+    response = authed_api(
+        "POST",
+        "/evaluators/",
+        json={"evaluator": {"slug": f"ev-{slug}", "flags": flags}},
+    )
+    assert response.status_code == 200, response.text
+    evaluator = response.json()["evaluator"]
+
+    response = authed_api(
+        "POST",
+        "/evaluators/variants/",
+        json={
+            "evaluator_variant": {
+                "slug": f"evv-{slug}",
+                "evaluator_id": evaluator["id"],
+                "flags": flags,
+            }
+        },
+    )
+    assert response.status_code == 200, response.text
+    variant = response.json()["evaluator_variant"]
+
+    response = authed_api(
+        "POST",
+        "/evaluators/revisions/commit",
+        json={
+            "evaluator_revision_commit": {
+                "evaluator_id": evaluator["id"],
+                "evaluator_variant_id": variant["id"],
+                "data": {"parameters": {"threshold": 0.5}},
+            }
+        },
+    )
+    assert response.status_code == 200, response.text
+    revision = response.json()["evaluator_revision"]
+    return evaluator, variant, revision
+
+
+def _deploy_evaluator_to_env(authed_api, evaluator, variant, revision):
+    key = f"{evaluator['slug']}.revision"
+    payload = {
+        "evaluator": {"id": evaluator["id"], "slug": evaluator["slug"]},
+        "evaluator_variant": {"id": variant["id"], "slug": variant["slug"]},
+        "evaluator_revision": {
+            "id": revision["id"],
+            "version": revision.get("version") or "1",
+        },
+    }
+    return _create_environment_with_deployment(authed_api, key=key, payload=payload)
+
+
+def test_evaluators_env_retrieve_by_env_slug_and_key(authed_api):
+    evaluator, variant, revision = _create_evaluator_stack(authed_api)
+    env, _, _ = _deploy_evaluator_to_env(authed_api, evaluator, variant, revision)
+
+    response = authed_api(
+        "POST",
+        "/evaluators/revisions/retrieve",
+        json={
+            "environment_ref": {"slug": env["slug"]},
+            "key": f"{evaluator['slug']}.revision",
+        },
+    )
+    assert response.status_code == 200, response.text
+    assert response.json()["evaluator_revision"]["id"] == revision["id"]
+
+
+def test_evaluators_env_retrieve_default_key_from_artifact_slug(authed_api):
+    evaluator, variant, revision = _create_evaluator_stack(authed_api)
+    env, _, _ = _deploy_evaluator_to_env(authed_api, evaluator, variant, revision)
+
+    response = authed_api(
+        "POST",
+        "/evaluators/revisions/retrieve",
+        json={
+            "environment_ref": {"slug": env["slug"]},
+            "evaluator_ref": {"slug": evaluator["slug"]},
+        },
+    )
+    assert response.status_code == 200, response.text
+    assert response.json()["evaluator_revision"]["id"] == revision["id"]
+
+
+def test_evaluators_env_retrieve_with_redundant_consistent_artifact(authed_api):
+    evaluator, variant, revision = _create_evaluator_stack(authed_api)
+    env, _, _ = _deploy_evaluator_to_env(authed_api, evaluator, variant, revision)
+
+    response = authed_api(
+        "POST",
+        "/evaluators/revisions/retrieve",
+        json={
+            "environment_ref": {"slug": env["slug"]},
+            "key": f"{evaluator['slug']}.revision",
+            "evaluator_ref": {"id": evaluator["id"], "slug": evaluator["slug"]},
+        },
+    )
+    assert response.status_code == 200, response.text
+    assert response.json()["evaluator_revision"]["id"] == revision["id"]
+
+
+def test_evaluators_env_retrieve_path_mixed_inconsistent_revision_returns_400(
+    authed_api,
+):
+    evaluator, variant, revision = _create_evaluator_stack(authed_api)
+    env, _, _ = _deploy_evaluator_to_env(authed_api, evaluator, variant, revision)
+
+    _, _, unrelated_revision = _create_evaluator_stack(authed_api)
+
+    response = authed_api(
+        "POST",
+        "/evaluators/revisions/retrieve",
+        json={
+            "environment_ref": {"slug": env["slug"]},
+            "key": f"{evaluator['slug']}.revision",
+            "evaluator_revision_ref": {"id": unrelated_revision["id"]},
+        },
+    )
+    assert response.status_code == 400, response.text

--- a/api/oss/tests/pytest/acceptance/test_revision_retrieve_inconsistent_400.py
+++ b/api/oss/tests/pytest/acceptance/test_revision_retrieve_inconsistent_400.py
@@ -1,0 +1,348 @@
+"""Acceptance: inconsistent revision-retrieve requests return HTTP 400.
+
+The shared `validate_retrieve_refs_consistent` helper rejects requests where
+caller-supplied artifact/variant/revision refs disagree with the resolved
+revision's identity. These tests assert the 400 surfaces correctly across
+all six entities — applications, evaluators, queries, testsets,
+environments, workflows.
+
+For each entity:
+
+  * A `_create_*_stack` helper provisions a real artifact + variant +
+    revision so consistency can be evaluated against a real row.
+  * One negative test: pass a `revision_ref.id` together with an
+    `artifact_ref.slug` that does NOT belong to that revision. Must return
+    400 with the offending field mentioned in the detail.
+
+Each test creates its own fixture so the tests don't share global state.
+"""
+
+from uuid import uuid4
+
+
+def _assert_inconsistent_400(response):
+    assert response.status_code == 400, response.text
+    body = response.json()
+    detail = body.get("detail", "")
+    assert "does not match" in detail or "_ref" in detail, body
+
+
+def _create_workflow_stack(authed_api):
+    slug = uuid4().hex[:12]
+    response = authed_api(
+        "POST",
+        "/workflows/",
+        json={"workflow": {"slug": f"wf-{slug}"}},
+    )
+    assert response.status_code == 200, response.text
+    workflow = response.json()["workflow"]
+
+    response = authed_api(
+        "POST",
+        "/workflows/variants/",
+        json={
+            "workflow_variant": {
+                "slug": f"wfv-{slug}",
+                "workflow_id": workflow["id"],
+            }
+        },
+    )
+    assert response.status_code == 200, response.text
+    variant = response.json()["workflow_variant"]
+
+    response = authed_api(
+        "POST",
+        "/workflows/revisions/",
+        json={
+            "workflow_revision": {
+                "slug": f"wfr-{slug}",
+                "workflow_variant_id": variant["id"],
+                "workflow_id": workflow["id"],
+            }
+        },
+    )
+    assert response.status_code == 200, response.text
+    revision = response.json()["workflow_revision"]
+    return workflow, variant, revision
+
+
+def test_workflows_retrieve_artifact_slug_disagrees_with_revision_id_returns_400(
+    authed_api,
+):
+    _, _, revision = _create_workflow_stack(authed_api)
+    response = authed_api(
+        "POST",
+        "/workflows/revisions/retrieve",
+        json={
+            "workflow_ref": {"slug": f"unrelated-{uuid4().hex[:8]}"},
+            "workflow_revision_ref": {"id": revision["id"]},
+        },
+    )
+    _assert_inconsistent_400(response)
+
+
+def _create_application_stack(authed_api):
+    slug = uuid4().hex[:12]
+    flags = {"is_application": True, "is_evaluator": False, "is_snippet": False}
+    response = authed_api(
+        "POST",
+        "/applications/",
+        json={"application": {"slug": f"app-{slug}", "flags": flags}},
+    )
+    assert response.status_code == 200, response.text
+    app = response.json()["application"]
+
+    response = authed_api(
+        "POST",
+        "/applications/variants/",
+        json={
+            "application_variant": {
+                "slug": f"appv-{slug}",
+                "application_id": app["id"],
+                "flags": flags,
+            }
+        },
+    )
+    assert response.status_code == 200, response.text
+    variant = response.json()["application_variant"]
+
+    response = authed_api(
+        "POST",
+        "/applications/revisions/commit",
+        json={
+            "application_revision_commit": {
+                "application_id": app["id"],
+                "application_variant_id": variant["id"],
+                "data": {"parameters": {"model": "test-model"}},
+            }
+        },
+    )
+    assert response.status_code == 200, response.text
+    revision = response.json()["application_revision"]
+    return app, variant, revision
+
+
+def test_applications_retrieve_artifact_slug_disagrees_with_revision_id_returns_400(
+    authed_api,
+):
+    _, _, revision = _create_application_stack(authed_api)
+    response = authed_api(
+        "POST",
+        "/applications/revisions/retrieve",
+        json={
+            "application_ref": {"slug": f"unrelated-{uuid4().hex[:8]}"},
+            "application_revision_ref": {"id": revision["id"]},
+        },
+    )
+    _assert_inconsistent_400(response)
+
+
+def _create_evaluator_stack(authed_api):
+    slug = uuid4().hex[:12]
+    flags = {"is_application": False, "is_evaluator": True, "is_snippet": False}
+    response = authed_api(
+        "POST",
+        "/evaluators/",
+        json={"evaluator": {"slug": f"ev-{slug}", "flags": flags}},
+    )
+    assert response.status_code == 200, response.text
+    evaluator = response.json()["evaluator"]
+
+    response = authed_api(
+        "POST",
+        "/evaluators/variants/",
+        json={
+            "evaluator_variant": {
+                "slug": f"evv-{slug}",
+                "evaluator_id": evaluator["id"],
+                "flags": flags,
+            }
+        },
+    )
+    assert response.status_code == 200, response.text
+    variant = response.json()["evaluator_variant"]
+
+    response = authed_api(
+        "POST",
+        "/evaluators/revisions/commit",
+        json={
+            "evaluator_revision_commit": {
+                "evaluator_id": evaluator["id"],
+                "evaluator_variant_id": variant["id"],
+                "data": {"parameters": {"model": "test-model"}},
+            }
+        },
+    )
+    assert response.status_code == 200, response.text
+    revision = response.json()["evaluator_revision"]
+    return evaluator, variant, revision
+
+
+def test_evaluators_retrieve_artifact_slug_disagrees_with_revision_id_returns_400(
+    authed_api,
+):
+    _, _, revision = _create_evaluator_stack(authed_api)
+    response = authed_api(
+        "POST",
+        "/evaluators/revisions/retrieve",
+        json={
+            "evaluator_ref": {"slug": f"unrelated-{uuid4().hex[:8]}"},
+            "evaluator_revision_ref": {"id": revision["id"]},
+        },
+    )
+    _assert_inconsistent_400(response)
+
+
+def _create_testset_stack(authed_api):
+    slug = uuid4().hex[:12]
+    response = authed_api(
+        "POST",
+        "/testsets/",
+        json={"testset": {"slug": f"ts-{slug}"}},
+    )
+    assert response.status_code == 200, response.text
+    testset = response.json()["testset"]
+
+    response = authed_api(
+        "POST",
+        "/testsets/variants/",
+        json={
+            "testset_variant": {
+                "slug": f"tsv-{slug}",
+                "testset_id": testset["id"],
+            }
+        },
+    )
+    assert response.status_code == 200, response.text
+    variant = response.json()["testset_variant"]
+
+    response = authed_api(
+        "POST",
+        "/testsets/revisions/commit",
+        json={
+            "testset_revision_commit": {
+                "testset_id": testset["id"],
+                "testset_variant_id": variant["id"],
+                "data": {"testcases": []},
+            }
+        },
+    )
+    assert response.status_code == 200, response.text
+    revision = response.json()["testset_revision"]
+    return testset, variant, revision
+
+
+def test_testsets_retrieve_artifact_slug_disagrees_with_revision_id_returns_400(
+    authed_api,
+):
+    _, _, revision = _create_testset_stack(authed_api)
+    response = authed_api(
+        "POST",
+        "/testsets/revisions/retrieve",
+        json={
+            "testset_ref": {"slug": f"unrelated-{uuid4().hex[:8]}"},
+            "testset_revision_ref": {"id": revision["id"]},
+        },
+    )
+    _assert_inconsistent_400(response)
+
+
+def _create_query_stack(authed_api):
+    slug = uuid4().hex[:12]
+    response = authed_api(
+        "POST",
+        "/simple/queries/",
+        json={
+            "query": {
+                "slug": f"qry-{slug}",
+                "name": f"qry-{slug}",
+                "data": {"windowing": {"limit": 50}},
+            }
+        },
+    )
+    assert response.status_code == 200, response.text
+    query = response.json()["query"]
+
+    response = authed_api(
+        "POST",
+        "/queries/revisions/commit",
+        json={
+            "query_revision_commit": {
+                "query_id": query["id"],
+                "query_variant_id": query["variant_id"],
+                "data": {"windowing": {"limit": 50}},
+            }
+        },
+    )
+    assert response.status_code == 200, response.text
+    revision = response.json()["query_revision"]
+    return query, revision
+
+
+def test_queries_retrieve_artifact_slug_disagrees_with_revision_id_returns_400(
+    authed_api,
+):
+    _, revision = _create_query_stack(authed_api)
+    response = authed_api(
+        "POST",
+        "/queries/revisions/retrieve",
+        json={
+            "query_ref": {"slug": f"unrelated-{uuid4().hex[:8]}"},
+            "query_revision_ref": {"id": revision["id"]},
+        },
+    )
+    _assert_inconsistent_400(response)
+
+
+def _create_environment_stack(authed_api):
+    slug = uuid4().hex[:12]
+    response = authed_api(
+        "POST",
+        "/environments/",
+        json={"environment": {"slug": f"env-{slug}"}},
+    )
+    assert response.status_code == 200, response.text
+    environment = response.json()["environment"]
+
+    response = authed_api(
+        "POST",
+        "/environments/variants/",
+        json={
+            "environment_variant": {
+                "slug": f"envv-{slug}",
+                "environment_id": environment["id"],
+            }
+        },
+    )
+    assert response.status_code == 200, response.text
+    variant = response.json()["environment_variant"]
+
+    response = authed_api(
+        "POST",
+        "/environments/revisions/commit",
+        json={
+            "environment_revision_commit": {
+                "environment_id": environment["id"],
+                "environment_variant_id": variant["id"],
+                "data": {"references": {}},
+            }
+        },
+    )
+    assert response.status_code == 200, response.text
+    revision = response.json()["environment_revision"]
+    return environment, variant, revision
+
+
+def test_environments_retrieve_artifact_slug_disagrees_with_revision_id_returns_400(
+    authed_api,
+):
+    _, _, revision = _create_environment_stack(authed_api)
+    response = authed_api(
+        "POST",
+        "/environments/revisions/retrieve",
+        json={
+            "environment_ref": {"slug": f"unrelated-{uuid4().hex[:8]}"},
+            "environment_revision_ref": {"id": revision["id"]},
+        },
+    )
+    _assert_inconsistent_400(response)

--- a/api/oss/tests/pytest/acceptance/test_revision_retrieve_positive.py
+++ b/api/oss/tests/pytest/acceptance/test_revision_retrieve_positive.py
@@ -124,6 +124,22 @@ def test_workflows_retrieve_by_artifact_slug_picks_default_variant_latest(authed
     assert response.json()["workflow_revision"]["id"] == revision["id"]
 
 
+def test_workflows_retrieve_by_artifact_slug_and_version_resolves_default_variant(
+    authed_api,
+):
+    workflow, _, revision = _create_workflow_stack(authed_api)
+    response = authed_api(
+        "POST",
+        "/workflows/revisions/retrieve",
+        json={
+            "workflow_ref": {"slug": workflow["slug"]},
+            "workflow_revision_ref": {"version": revision["version"]},
+        },
+    )
+    assert response.status_code == 200, response.text
+    assert response.json()["workflow_revision"]["id"] == revision["id"]
+
+
 def test_workflows_retrieve_with_redundant_consistent_refs(authed_api):
     workflow, variant, revision = _create_workflow_stack(authed_api)
     response = authed_api(
@@ -238,6 +254,22 @@ def test_applications_retrieve_by_artifact_slug_picks_default_variant_latest(
         "POST",
         "/applications/revisions/retrieve",
         json={"application_ref": {"slug": app["slug"]}},
+    )
+    assert response.status_code == 200, response.text
+    assert response.json()["application_revision"]["id"] == revision["id"]
+
+
+def test_applications_retrieve_by_artifact_slug_and_version_resolves_default_variant(
+    authed_api,
+):
+    app, _, revision = _create_application_stack(authed_api)
+    response = authed_api(
+        "POST",
+        "/applications/revisions/retrieve",
+        json={
+            "application_ref": {"slug": app["slug"]},
+            "application_revision_ref": {"version": revision["version"]},
+        },
     )
     assert response.status_code == 200, response.text
     assert response.json()["application_revision"]["id"] == revision["id"]
@@ -362,6 +394,22 @@ def test_evaluators_retrieve_by_artifact_slug_picks_default_variant_latest(
     assert response.json()["evaluator_revision"]["id"] == revision["id"]
 
 
+def test_evaluators_retrieve_by_artifact_slug_and_version_resolves_default_variant(
+    authed_api,
+):
+    evaluator, _, revision = _create_evaluator_stack(authed_api)
+    response = authed_api(
+        "POST",
+        "/evaluators/revisions/retrieve",
+        json={
+            "evaluator_ref": {"slug": evaluator["slug"]},
+            "evaluator_revision_ref": {"version": revision["version"]},
+        },
+    )
+    assert response.status_code == 200, response.text
+    assert response.json()["evaluator_revision"]["id"] == revision["id"]
+
+
 def test_evaluators_retrieve_with_redundant_consistent_refs(authed_api):
     evaluator, variant, revision = _create_evaluator_stack(authed_api)
     response = authed_api(
@@ -477,6 +525,22 @@ def test_testsets_retrieve_by_artifact_slug_picks_default_variant_latest(authed_
     assert response.json()["testset_revision"]["id"] == revision["id"]
 
 
+def test_testsets_retrieve_by_artifact_slug_and_version_resolves_default_variant(
+    authed_api,
+):
+    testset, _, revision = _create_testset_stack(authed_api)
+    response = authed_api(
+        "POST",
+        "/testsets/revisions/retrieve",
+        json={
+            "testset_ref": {"slug": testset["slug"]},
+            "testset_revision_ref": {"version": revision["version"]},
+        },
+    )
+    assert response.status_code == 200, response.text
+    assert response.json()["testset_revision"]["id"] == revision["id"]
+
+
 def test_testsets_retrieve_with_redundant_consistent_refs(authed_api):
     testset, variant, revision = _create_testset_stack(authed_api)
     response = authed_api(
@@ -580,6 +644,22 @@ def test_queries_retrieve_by_artifact_slug_picks_default_variant_latest(authed_a
         "POST",
         "/queries/revisions/retrieve",
         json={"query_ref": {"slug": query["slug"]}},
+    )
+    assert response.status_code == 200, response.text
+    assert response.json()["query_revision"]["id"] == revision["id"]
+
+
+def test_queries_retrieve_by_artifact_slug_and_version_resolves_default_variant(
+    authed_api,
+):
+    query, revision = _create_query_stack(authed_api)
+    response = authed_api(
+        "POST",
+        "/queries/revisions/retrieve",
+        json={
+            "query_ref": {"slug": query["slug"]},
+            "query_revision_ref": {"version": revision["version"]},
+        },
     )
     assert response.status_code == 200, response.text
     assert response.json()["query_revision"]["id"] == revision["id"]
@@ -697,6 +777,22 @@ def test_environments_retrieve_by_artifact_slug_picks_default_variant_latest(
         "POST",
         "/environments/revisions/retrieve",
         json={"environment_ref": {"slug": environment["slug"]}},
+    )
+    assert response.status_code == 200, response.text
+    assert response.json()["environment_revision"]["id"] == revision["id"]
+
+
+def test_environments_retrieve_by_artifact_slug_and_version_resolves_default_variant(
+    authed_api,
+):
+    environment, _, revision = _create_environment_stack(authed_api)
+    response = authed_api(
+        "POST",
+        "/environments/revisions/retrieve",
+        json={
+            "environment_ref": {"slug": environment["slug"]},
+            "environment_revision_ref": {"version": revision["version"]},
+        },
     )
     assert response.status_code == 200, response.text
     assert response.json()["environment_revision"]["id"] == revision["id"]

--- a/api/oss/tests/pytest/acceptance/test_revision_retrieve_positive.py
+++ b/api/oss/tests/pytest/acceptance/test_revision_retrieve_positive.py
@@ -1,0 +1,717 @@
+"""Acceptance: positive cases for revision-retrieve across all git-backed entities.
+
+Pins the behavior of rules 2.a (unique/minimal/sufficient/consistent),
+2.b (unique/redundant/sufficient/consistent), and 2.d (unique/minimal/
+insufficient/consistent → latest-revision and default-variant fallbacks)
+across applications, evaluators, queries, testsets, environments, and
+workflows.
+
+This is C8's first pass per
+docs/design/playground-open-from-trace/followups.md. Each entity is
+exercised through six positive cases:
+
+  1. {revision_ref: {id}}                                  → 2.a
+  2. {revision_ref: {slug}}                                → 2.a
+  3. {variant_ref: {slug}, revision_ref: {version}}        → 2.a
+  4. {variant_ref: {slug}}                                  → 2.d (latest)
+  5. {artifact_ref: {slug}}                                 → 2.d (default variant + latest)
+  6. {artifact_ref, variant_ref, revision_ref: {id}} all consistent  → 2.b
+
+Each test creates its own minimal fixture so the suite has no
+cross-test state.
+"""
+
+from uuid import uuid4
+
+
+# workflows --------------------------------------------------------------------
+
+
+def _create_workflow_stack(authed_api):
+    slug = uuid4().hex[:12]
+    response = authed_api(
+        "POST",
+        "/workflows/",
+        json={"workflow": {"slug": f"wf-{slug}"}},
+    )
+    assert response.status_code == 200, response.text
+    workflow = response.json()["workflow"]
+
+    response = authed_api(
+        "POST",
+        "/workflows/variants/",
+        json={
+            "workflow_variant": {
+                "slug": f"wfv-{slug}",
+                "workflow_id": workflow["id"],
+            }
+        },
+    )
+    assert response.status_code == 200, response.text
+    variant = response.json()["workflow_variant"]
+
+    response = authed_api(
+        "POST",
+        "/workflows/revisions/",
+        json={
+            "workflow_revision": {
+                "slug": f"wfr-{slug}",
+                "workflow_variant_id": variant["id"],
+                "workflow_id": workflow["id"],
+            }
+        },
+    )
+    assert response.status_code == 200, response.text
+    revision = response.json()["workflow_revision"]
+    return workflow, variant, revision
+
+
+def test_workflows_retrieve_by_revision_id(authed_api):
+    _, _, revision = _create_workflow_stack(authed_api)
+    response = authed_api(
+        "POST",
+        "/workflows/revisions/retrieve",
+        json={"workflow_revision_ref": {"id": revision["id"]}},
+    )
+    assert response.status_code == 200, response.text
+    assert response.json()["workflow_revision"]["id"] == revision["id"]
+
+
+def test_workflows_retrieve_by_revision_slug(authed_api):
+    _, _, revision = _create_workflow_stack(authed_api)
+    response = authed_api(
+        "POST",
+        "/workflows/revisions/retrieve",
+        json={"workflow_revision_ref": {"slug": revision["slug"]}},
+    )
+    assert response.status_code == 200, response.text
+    assert response.json()["workflow_revision"]["id"] == revision["id"]
+
+
+def test_workflows_retrieve_by_variant_slug_and_version(authed_api):
+    _, variant, revision = _create_workflow_stack(authed_api)
+    response = authed_api(
+        "POST",
+        "/workflows/revisions/retrieve",
+        json={
+            "workflow_variant_ref": {"slug": variant["slug"]},
+            "workflow_revision_ref": {"version": revision["version"]},
+        },
+    )
+    assert response.status_code == 200, response.text
+    assert response.json()["workflow_revision"]["id"] == revision["id"]
+
+
+def test_workflows_retrieve_by_variant_slug_picks_latest(authed_api):
+    _, variant, revision = _create_workflow_stack(authed_api)
+    response = authed_api(
+        "POST",
+        "/workflows/revisions/retrieve",
+        json={"workflow_variant_ref": {"slug": variant["slug"]}},
+    )
+    assert response.status_code == 200, response.text
+    assert response.json()["workflow_revision"]["id"] == revision["id"]
+
+
+def test_workflows_retrieve_by_artifact_slug_picks_default_variant_latest(authed_api):
+    workflow, _, revision = _create_workflow_stack(authed_api)
+    response = authed_api(
+        "POST",
+        "/workflows/revisions/retrieve",
+        json={"workflow_ref": {"slug": workflow["slug"]}},
+    )
+    assert response.status_code == 200, response.text
+    assert response.json()["workflow_revision"]["id"] == revision["id"]
+
+
+def test_workflows_retrieve_with_redundant_consistent_refs(authed_api):
+    workflow, variant, revision = _create_workflow_stack(authed_api)
+    response = authed_api(
+        "POST",
+        "/workflows/revisions/retrieve",
+        json={
+            "workflow_ref": {"slug": workflow["slug"]},
+            "workflow_variant_ref": {"slug": variant["slug"]},
+            "workflow_revision_ref": {"id": revision["id"]},
+        },
+    )
+    assert response.status_code == 200, response.text
+    assert response.json()["workflow_revision"]["id"] == revision["id"]
+
+
+# applications -----------------------------------------------------------------
+
+
+def _create_application_stack(authed_api):
+    slug = uuid4().hex[:12]
+    flags = {"is_application": True, "is_evaluator": False, "is_snippet": False}
+    response = authed_api(
+        "POST",
+        "/applications/",
+        json={"application": {"slug": f"app-{slug}", "flags": flags}},
+    )
+    assert response.status_code == 200, response.text
+    app = response.json()["application"]
+
+    response = authed_api(
+        "POST",
+        "/applications/variants/",
+        json={
+            "application_variant": {
+                "slug": f"appv-{slug}",
+                "application_id": app["id"],
+                "flags": flags,
+            }
+        },
+    )
+    assert response.status_code == 200, response.text
+    variant = response.json()["application_variant"]
+
+    response = authed_api(
+        "POST",
+        "/applications/revisions/commit",
+        json={
+            "application_revision_commit": {
+                "application_id": app["id"],
+                "application_variant_id": variant["id"],
+                "data": {"parameters": {"model": "test-model"}},
+            }
+        },
+    )
+    assert response.status_code == 200, response.text
+    revision = response.json()["application_revision"]
+    return app, variant, revision
+
+
+def test_applications_retrieve_by_revision_id(authed_api):
+    _, _, revision = _create_application_stack(authed_api)
+    response = authed_api(
+        "POST",
+        "/applications/revisions/retrieve",
+        json={"application_revision_ref": {"id": revision["id"]}},
+    )
+    assert response.status_code == 200, response.text
+    assert response.json()["application_revision"]["id"] == revision["id"]
+
+
+def test_applications_retrieve_by_revision_slug(authed_api):
+    _, _, revision = _create_application_stack(authed_api)
+    response = authed_api(
+        "POST",
+        "/applications/revisions/retrieve",
+        json={"application_revision_ref": {"slug": revision["slug"]}},
+    )
+    assert response.status_code == 200, response.text
+    assert response.json()["application_revision"]["id"] == revision["id"]
+
+
+def test_applications_retrieve_by_variant_slug_and_version(authed_api):
+    _, variant, revision = _create_application_stack(authed_api)
+    response = authed_api(
+        "POST",
+        "/applications/revisions/retrieve",
+        json={
+            "application_variant_ref": {"slug": variant["slug"]},
+            "application_revision_ref": {"version": revision["version"]},
+        },
+    )
+    assert response.status_code == 200, response.text
+    assert response.json()["application_revision"]["id"] == revision["id"]
+
+
+def test_applications_retrieve_by_variant_slug_picks_latest(authed_api):
+    _, variant, revision = _create_application_stack(authed_api)
+    response = authed_api(
+        "POST",
+        "/applications/revisions/retrieve",
+        json={"application_variant_ref": {"slug": variant["slug"]}},
+    )
+    assert response.status_code == 200, response.text
+    assert response.json()["application_revision"]["id"] == revision["id"]
+
+
+def test_applications_retrieve_by_artifact_slug_picks_default_variant_latest(
+    authed_api,
+):
+    app, _, revision = _create_application_stack(authed_api)
+    response = authed_api(
+        "POST",
+        "/applications/revisions/retrieve",
+        json={"application_ref": {"slug": app["slug"]}},
+    )
+    assert response.status_code == 200, response.text
+    assert response.json()["application_revision"]["id"] == revision["id"]
+
+
+def test_applications_retrieve_with_redundant_consistent_refs(authed_api):
+    app, variant, revision = _create_application_stack(authed_api)
+    response = authed_api(
+        "POST",
+        "/applications/revisions/retrieve",
+        json={
+            "application_ref": {"slug": app["slug"]},
+            "application_variant_ref": {"slug": variant["slug"]},
+            "application_revision_ref": {"id": revision["id"]},
+        },
+    )
+    assert response.status_code == 200, response.text
+    assert response.json()["application_revision"]["id"] == revision["id"]
+
+
+# evaluators -------------------------------------------------------------------
+
+
+def _create_evaluator_stack(authed_api):
+    slug = uuid4().hex[:12]
+    flags = {"is_application": False, "is_evaluator": True, "is_snippet": False}
+    response = authed_api(
+        "POST",
+        "/evaluators/",
+        json={"evaluator": {"slug": f"ev-{slug}", "flags": flags}},
+    )
+    assert response.status_code == 200, response.text
+    evaluator = response.json()["evaluator"]
+
+    response = authed_api(
+        "POST",
+        "/evaluators/variants/",
+        json={
+            "evaluator_variant": {
+                "slug": f"evv-{slug}",
+                "evaluator_id": evaluator["id"],
+                "flags": flags,
+            }
+        },
+    )
+    assert response.status_code == 200, response.text
+    variant = response.json()["evaluator_variant"]
+
+    response = authed_api(
+        "POST",
+        "/evaluators/revisions/commit",
+        json={
+            "evaluator_revision_commit": {
+                "evaluator_id": evaluator["id"],
+                "evaluator_variant_id": variant["id"],
+                "data": {"parameters": {"model": "test-model"}},
+            }
+        },
+    )
+    assert response.status_code == 200, response.text
+    revision = response.json()["evaluator_revision"]
+    return evaluator, variant, revision
+
+
+def test_evaluators_retrieve_by_revision_id(authed_api):
+    _, _, revision = _create_evaluator_stack(authed_api)
+    response = authed_api(
+        "POST",
+        "/evaluators/revisions/retrieve",
+        json={"evaluator_revision_ref": {"id": revision["id"]}},
+    )
+    assert response.status_code == 200, response.text
+    assert response.json()["evaluator_revision"]["id"] == revision["id"]
+
+
+def test_evaluators_retrieve_by_revision_slug(authed_api):
+    _, _, revision = _create_evaluator_stack(authed_api)
+    response = authed_api(
+        "POST",
+        "/evaluators/revisions/retrieve",
+        json={"evaluator_revision_ref": {"slug": revision["slug"]}},
+    )
+    assert response.status_code == 200, response.text
+    assert response.json()["evaluator_revision"]["id"] == revision["id"]
+
+
+def test_evaluators_retrieve_by_variant_slug_and_version(authed_api):
+    _, variant, revision = _create_evaluator_stack(authed_api)
+    response = authed_api(
+        "POST",
+        "/evaluators/revisions/retrieve",
+        json={
+            "evaluator_variant_ref": {"slug": variant["slug"]},
+            "evaluator_revision_ref": {"version": revision["version"]},
+        },
+    )
+    assert response.status_code == 200, response.text
+    assert response.json()["evaluator_revision"]["id"] == revision["id"]
+
+
+def test_evaluators_retrieve_by_variant_slug_picks_latest(authed_api):
+    _, variant, revision = _create_evaluator_stack(authed_api)
+    response = authed_api(
+        "POST",
+        "/evaluators/revisions/retrieve",
+        json={"evaluator_variant_ref": {"slug": variant["slug"]}},
+    )
+    assert response.status_code == 200, response.text
+    assert response.json()["evaluator_revision"]["id"] == revision["id"]
+
+
+def test_evaluators_retrieve_by_artifact_slug_picks_default_variant_latest(
+    authed_api,
+):
+    evaluator, _, revision = _create_evaluator_stack(authed_api)
+    response = authed_api(
+        "POST",
+        "/evaluators/revisions/retrieve",
+        json={"evaluator_ref": {"slug": evaluator["slug"]}},
+    )
+    assert response.status_code == 200, response.text
+    assert response.json()["evaluator_revision"]["id"] == revision["id"]
+
+
+def test_evaluators_retrieve_with_redundant_consistent_refs(authed_api):
+    evaluator, variant, revision = _create_evaluator_stack(authed_api)
+    response = authed_api(
+        "POST",
+        "/evaluators/revisions/retrieve",
+        json={
+            "evaluator_ref": {"slug": evaluator["slug"]},
+            "evaluator_variant_ref": {"slug": variant["slug"]},
+            "evaluator_revision_ref": {"id": revision["id"]},
+        },
+    )
+    assert response.status_code == 200, response.text
+    assert response.json()["evaluator_revision"]["id"] == revision["id"]
+
+
+# testsets ---------------------------------------------------------------------
+
+
+def _create_testset_stack(authed_api):
+    slug = uuid4().hex[:12]
+    response = authed_api(
+        "POST",
+        "/testsets/",
+        json={"testset": {"slug": f"ts-{slug}"}},
+    )
+    assert response.status_code == 200, response.text
+    testset = response.json()["testset"]
+
+    response = authed_api(
+        "POST",
+        "/testsets/variants/",
+        json={
+            "testset_variant": {
+                "slug": f"tsv-{slug}",
+                "testset_id": testset["id"],
+            }
+        },
+    )
+    assert response.status_code == 200, response.text
+    variant = response.json()["testset_variant"]
+
+    response = authed_api(
+        "POST",
+        "/testsets/revisions/commit",
+        json={
+            "testset_revision_commit": {
+                "testset_id": testset["id"],
+                "testset_variant_id": variant["id"],
+                "data": {"testcases": []},
+            }
+        },
+    )
+    assert response.status_code == 200, response.text
+    revision = response.json()["testset_revision"]
+    return testset, variant, revision
+
+
+def test_testsets_retrieve_by_revision_id(authed_api):
+    _, _, revision = _create_testset_stack(authed_api)
+    response = authed_api(
+        "POST",
+        "/testsets/revisions/retrieve",
+        json={"testset_revision_ref": {"id": revision["id"]}},
+    )
+    assert response.status_code == 200, response.text
+    assert response.json()["testset_revision"]["id"] == revision["id"]
+
+
+def test_testsets_retrieve_by_revision_slug(authed_api):
+    _, _, revision = _create_testset_stack(authed_api)
+    response = authed_api(
+        "POST",
+        "/testsets/revisions/retrieve",
+        json={"testset_revision_ref": {"slug": revision["slug"]}},
+    )
+    assert response.status_code == 200, response.text
+    assert response.json()["testset_revision"]["id"] == revision["id"]
+
+
+def test_testsets_retrieve_by_variant_slug_and_version(authed_api):
+    _, variant, revision = _create_testset_stack(authed_api)
+    response = authed_api(
+        "POST",
+        "/testsets/revisions/retrieve",
+        json={
+            "testset_variant_ref": {"slug": variant["slug"]},
+            "testset_revision_ref": {"version": revision["version"]},
+        },
+    )
+    assert response.status_code == 200, response.text
+    assert response.json()["testset_revision"]["id"] == revision["id"]
+
+
+def test_testsets_retrieve_by_variant_slug_picks_latest(authed_api):
+    _, variant, revision = _create_testset_stack(authed_api)
+    response = authed_api(
+        "POST",
+        "/testsets/revisions/retrieve",
+        json={"testset_variant_ref": {"slug": variant["slug"]}},
+    )
+    assert response.status_code == 200, response.text
+    assert response.json()["testset_revision"]["id"] == revision["id"]
+
+
+def test_testsets_retrieve_by_artifact_slug_picks_default_variant_latest(authed_api):
+    testset, _, revision = _create_testset_stack(authed_api)
+    response = authed_api(
+        "POST",
+        "/testsets/revisions/retrieve",
+        json={"testset_ref": {"slug": testset["slug"]}},
+    )
+    assert response.status_code == 200, response.text
+    assert response.json()["testset_revision"]["id"] == revision["id"]
+
+
+def test_testsets_retrieve_with_redundant_consistent_refs(authed_api):
+    testset, variant, revision = _create_testset_stack(authed_api)
+    response = authed_api(
+        "POST",
+        "/testsets/revisions/retrieve",
+        json={
+            "testset_ref": {"slug": testset["slug"]},
+            "testset_variant_ref": {"slug": variant["slug"]},
+            "testset_revision_ref": {"id": revision["id"]},
+        },
+    )
+    assert response.status_code == 200, response.text
+    assert response.json()["testset_revision"]["id"] == revision["id"]
+
+
+# queries ----------------------------------------------------------------------
+
+
+def _create_query_stack(authed_api):
+    slug = uuid4().hex[:12]
+    response = authed_api(
+        "POST",
+        "/simple/queries/",
+        json={
+            "query": {
+                "slug": f"qry-{slug}",
+                "name": f"qry-{slug}",
+                "data": {"windowing": {"limit": 50}},
+            }
+        },
+    )
+    assert response.status_code == 200, response.text
+    query = response.json()["query"]
+
+    response = authed_api(
+        "POST",
+        "/queries/revisions/commit",
+        json={
+            "query_revision_commit": {
+                "query_id": query["id"],
+                "query_variant_id": query["variant_id"],
+                "data": {"windowing": {"limit": 50}},
+            }
+        },
+    )
+    assert response.status_code == 200, response.text
+    revision = response.json()["query_revision"]
+    return query, revision
+
+
+def test_queries_retrieve_by_revision_id(authed_api):
+    _, revision = _create_query_stack(authed_api)
+    response = authed_api(
+        "POST",
+        "/queries/revisions/retrieve",
+        json={"query_revision_ref": {"id": revision["id"]}},
+    )
+    assert response.status_code == 200, response.text
+    assert response.json()["query_revision"]["id"] == revision["id"]
+
+
+def test_queries_retrieve_by_revision_slug(authed_api):
+    _, revision = _create_query_stack(authed_api)
+    response = authed_api(
+        "POST",
+        "/queries/revisions/retrieve",
+        json={"query_revision_ref": {"slug": revision["slug"]}},
+    )
+    assert response.status_code == 200, response.text
+    assert response.json()["query_revision"]["id"] == revision["id"]
+
+
+def test_queries_retrieve_by_variant_id_and_version(authed_api):
+    query, revision = _create_query_stack(authed_api)
+    response = authed_api(
+        "POST",
+        "/queries/revisions/retrieve",
+        json={
+            "query_variant_ref": {"id": query["variant_id"]},
+            "query_revision_ref": {"version": revision["version"]},
+        },
+    )
+    assert response.status_code == 200, response.text
+    assert response.json()["query_revision"]["id"] == revision["id"]
+
+
+def test_queries_retrieve_by_variant_id_picks_latest(authed_api):
+    query, revision = _create_query_stack(authed_api)
+    response = authed_api(
+        "POST",
+        "/queries/revisions/retrieve",
+        json={"query_variant_ref": {"id": query["variant_id"]}},
+    )
+    assert response.status_code == 200, response.text
+    assert response.json()["query_revision"]["id"] == revision["id"]
+
+
+def test_queries_retrieve_by_artifact_slug_picks_default_variant_latest(authed_api):
+    query, revision = _create_query_stack(authed_api)
+    response = authed_api(
+        "POST",
+        "/queries/revisions/retrieve",
+        json={"query_ref": {"slug": query["slug"]}},
+    )
+    assert response.status_code == 200, response.text
+    assert response.json()["query_revision"]["id"] == revision["id"]
+
+
+def test_queries_retrieve_with_redundant_consistent_refs(authed_api):
+    query, revision = _create_query_stack(authed_api)
+    response = authed_api(
+        "POST",
+        "/queries/revisions/retrieve",
+        json={
+            "query_ref": {"slug": query["slug"]},
+            "query_variant_ref": {"id": query["variant_id"]},
+            "query_revision_ref": {"id": revision["id"]},
+        },
+    )
+    assert response.status_code == 200, response.text
+    assert response.json()["query_revision"]["id"] == revision["id"]
+
+
+# environments -----------------------------------------------------------------
+
+
+def _create_environment_stack(authed_api):
+    slug = uuid4().hex[:12]
+    response = authed_api(
+        "POST",
+        "/environments/",
+        json={"environment": {"slug": f"env-{slug}"}},
+    )
+    assert response.status_code == 200, response.text
+    environment = response.json()["environment"]
+
+    response = authed_api(
+        "POST",
+        "/environments/variants/",
+        json={
+            "environment_variant": {
+                "slug": f"envv-{slug}",
+                "environment_id": environment["id"],
+            }
+        },
+    )
+    assert response.status_code == 200, response.text
+    variant = response.json()["environment_variant"]
+
+    response = authed_api(
+        "POST",
+        "/environments/revisions/commit",
+        json={
+            "environment_revision_commit": {
+                "environment_id": environment["id"],
+                "environment_variant_id": variant["id"],
+                "data": {"references": {}},
+            }
+        },
+    )
+    assert response.status_code == 200, response.text
+    revision = response.json()["environment_revision"]
+    return environment, variant, revision
+
+
+def test_environments_retrieve_by_revision_id(authed_api):
+    _, _, revision = _create_environment_stack(authed_api)
+    response = authed_api(
+        "POST",
+        "/environments/revisions/retrieve",
+        json={"environment_revision_ref": {"id": revision["id"]}},
+    )
+    assert response.status_code == 200, response.text
+    assert response.json()["environment_revision"]["id"] == revision["id"]
+
+
+def test_environments_retrieve_by_revision_slug(authed_api):
+    _, _, revision = _create_environment_stack(authed_api)
+    response = authed_api(
+        "POST",
+        "/environments/revisions/retrieve",
+        json={"environment_revision_ref": {"slug": revision["slug"]}},
+    )
+    assert response.status_code == 200, response.text
+    assert response.json()["environment_revision"]["id"] == revision["id"]
+
+
+def test_environments_retrieve_by_variant_slug_and_version(authed_api):
+    _, variant, revision = _create_environment_stack(authed_api)
+    response = authed_api(
+        "POST",
+        "/environments/revisions/retrieve",
+        json={
+            "environment_variant_ref": {"slug": variant["slug"]},
+            "environment_revision_ref": {"version": revision["version"]},
+        },
+    )
+    assert response.status_code == 200, response.text
+    assert response.json()["environment_revision"]["id"] == revision["id"]
+
+
+def test_environments_retrieve_by_variant_slug_picks_latest(authed_api):
+    _, variant, revision = _create_environment_stack(authed_api)
+    response = authed_api(
+        "POST",
+        "/environments/revisions/retrieve",
+        json={"environment_variant_ref": {"slug": variant["slug"]}},
+    )
+    assert response.status_code == 200, response.text
+    assert response.json()["environment_revision"]["id"] == revision["id"]
+
+
+def test_environments_retrieve_by_artifact_slug_picks_default_variant_latest(
+    authed_api,
+):
+    environment, _, revision = _create_environment_stack(authed_api)
+    response = authed_api(
+        "POST",
+        "/environments/revisions/retrieve",
+        json={"environment_ref": {"slug": environment["slug"]}},
+    )
+    assert response.status_code == 200, response.text
+    assert response.json()["environment_revision"]["id"] == revision["id"]
+
+
+def test_environments_retrieve_with_redundant_consistent_refs(authed_api):
+    environment, variant, revision = _create_environment_stack(authed_api)
+    response = authed_api(
+        "POST",
+        "/environments/revisions/retrieve",
+        json={
+            "environment_ref": {"slug": environment["slug"]},
+            "environment_variant_ref": {"slug": variant["slug"]},
+            "environment_revision_ref": {"id": revision["id"]},
+        },
+    )
+    assert response.status_code == 200, response.text
+    assert response.json()["environment_revision"]["id"] == revision["id"]

--- a/api/oss/tests/pytest/acceptance/test_variant_ref_version_only_400.py
+++ b/api/oss/tests/pytest/acceptance/test_variant_ref_version_only_400.py
@@ -1,0 +1,68 @@
+"""Acceptance: variant_ref with only `version` returns HTTP 400.
+
+Variants have no `version` field — version is a per-variant counter living
+on revisions. A request like `{*_variant_ref: {version: "1"}}` is nonsense
+the DAO would silently drop. The shared `validate_variant_refs_sufficient`
+helper rejects it; these tests pin that behavior across all six entities.
+"""
+
+
+def _assert_variant_400(response):
+    assert response.status_code == 400, response.text
+    body = response.json()
+    detail = body.get("detail", "")
+    assert "variant_ref" in detail, body
+
+
+def test_workflows_retrieve_variant_version_only_returns_400(authed_api):
+    response = authed_api(
+        "POST",
+        "/workflows/revisions/retrieve",
+        json={"workflow_variant_ref": {"version": "1"}},
+    )
+    _assert_variant_400(response)
+
+
+def test_applications_retrieve_variant_version_only_returns_400(authed_api):
+    response = authed_api(
+        "POST",
+        "/applications/revisions/retrieve",
+        json={"application_variant_ref": {"version": "1"}},
+    )
+    _assert_variant_400(response)
+
+
+def test_evaluators_retrieve_variant_version_only_returns_400(authed_api):
+    response = authed_api(
+        "POST",
+        "/evaluators/revisions/retrieve",
+        json={"evaluator_variant_ref": {"version": "1"}},
+    )
+    _assert_variant_400(response)
+
+
+def test_testsets_retrieve_variant_version_only_returns_400(authed_api):
+    response = authed_api(
+        "POST",
+        "/testsets/revisions/retrieve",
+        json={"testset_variant_ref": {"version": "1"}},
+    )
+    _assert_variant_400(response)
+
+
+def test_queries_retrieve_variant_version_only_returns_400(authed_api):
+    response = authed_api(
+        "POST",
+        "/queries/revisions/retrieve",
+        json={"query_variant_ref": {"version": "1"}},
+    )
+    _assert_variant_400(response)
+
+
+def test_environments_retrieve_variant_version_only_returns_400(authed_api):
+    response = authed_api(
+        "POST",
+        "/environments/revisions/retrieve",
+        json={"environment_variant_ref": {"version": "1"}},
+    )
+    _assert_variant_400(response)

--- a/api/oss/tests/pytest/unit/test_retrieve_refs_consistency.py
+++ b/api/oss/tests/pytest/unit/test_retrieve_refs_consistency.py
@@ -28,13 +28,9 @@ class TestAllRefsAbsent:
             artifact_ref=None,
             variant_ref=None,
             revision_ref=None,
-            resolved_artifact_id=uuid4(),
-            resolved_artifact_slug="my-artifact",
-            resolved_variant_id=uuid4(),
-            resolved_variant_slug="my-variant",
-            resolved_revision_id=uuid4(),
-            resolved_revision_slug="my-revision",
-            resolved_revision_version=1,
+            resolved_artifact_ref=_ref(id=uuid4(), slug="my-artifact"),
+            resolved_variant_ref=_ref(id=uuid4(), slug="my-variant"),
+            resolved_revision_ref=_ref(id=uuid4(), slug="my-revision", version="1"),
         )
 
     def test_no_resolved_fields_passes(self):
@@ -49,9 +45,9 @@ class TestAllRefsAbsent:
             artifact_ref=_ref(),
             variant_ref=_ref(),
             revision_ref=_ref(),
-            resolved_artifact_id=uuid4(),
-            resolved_variant_id=uuid4(),
-            resolved_revision_id=uuid4(),
+            resolved_artifact_ref=_ref(id=uuid4()),
+            resolved_variant_ref=_ref(id=uuid4()),
+            resolved_revision_ref=_ref(id=uuid4()),
         )
 
 
@@ -61,7 +57,7 @@ class TestArtifactConsistency:
             artifact_ref=_ref(slug="my-artifact"),
             variant_ref=None,
             revision_ref=None,
-            resolved_artifact_slug="my-artifact",
+            resolved_artifact_ref=_ref(slug="my-artifact"),
         )
 
     def test_artifact_slug_mismatch_raises(self):
@@ -70,7 +66,7 @@ class TestArtifactConsistency:
                 artifact_ref=_ref(slug="wrong-artifact"),
                 variant_ref=None,
                 revision_ref=None,
-                resolved_artifact_slug="my-artifact",
+                resolved_artifact_ref=_ref(slug="my-artifact"),
             )
         assert "artifact_ref.slug" in exc.value.message
         assert "wrong-artifact" in exc.value.message
@@ -84,7 +80,7 @@ class TestArtifactConsistency:
                 artifact_ref=_ref(id=wrong_id),
                 variant_ref=None,
                 revision_ref=None,
-                resolved_artifact_id=right_id,
+                resolved_artifact_ref=_ref(id=right_id),
             )
         assert "artifact_ref.id" in exc.value.message
 
@@ -94,7 +90,7 @@ class TestArtifactConsistency:
             artifact_ref=_ref(id=same),
             variant_ref=None,
             revision_ref=None,
-            resolved_artifact_id=same,
+            resolved_artifact_ref=_ref(id=same),
         )
 
     def test_entity_type_appears_in_message(self):
@@ -103,7 +99,7 @@ class TestArtifactConsistency:
                 artifact_ref=_ref(slug="wrong"),
                 variant_ref=None,
                 revision_ref=None,
-                resolved_artifact_slug="right",
+                resolved_artifact_ref=_ref(slug="right"),
                 entity_type="testset",
             )
         assert "testset_ref.slug" in exc.value.message
@@ -116,7 +112,7 @@ class TestVariantConsistency:
                 artifact_ref=None,
                 variant_ref=_ref(slug="wrong-variant"),
                 revision_ref=None,
-                resolved_variant_slug="my-variant",
+                resolved_variant_ref=_ref(slug="my-variant"),
             )
         assert "variant_ref.slug" in exc.value.message
 
@@ -126,7 +122,7 @@ class TestVariantConsistency:
             artifact_ref=None,
             variant_ref=_ref(id=same),
             revision_ref=None,
-            resolved_variant_id=same,
+            resolved_variant_ref=_ref(id=same),
         )
 
 
@@ -137,7 +133,7 @@ class TestRevisionConsistency:
                 artifact_ref=None,
                 variant_ref=None,
                 revision_ref=_ref(slug="wrong-rev"),
-                resolved_revision_slug="my-rev",
+                resolved_revision_ref=_ref(slug="my-rev"),
             )
         assert "revision_ref.slug" in exc.value.message
 
@@ -147,7 +143,7 @@ class TestRevisionConsistency:
                 artifact_ref=None,
                 variant_ref=None,
                 revision_ref=_ref(version="2"),
-                resolved_revision_version=1,
+                resolved_revision_ref=_ref(version="1"),
             )
         assert "revision_ref.version" in exc.value.message
 
@@ -156,7 +152,7 @@ class TestRevisionConsistency:
             artifact_ref=None,
             variant_ref=None,
             revision_ref=_ref(version="1"),
-            resolved_revision_version=1,
+            resolved_revision_ref=_ref(version="1"),
         )
 
 
@@ -169,13 +165,9 @@ class TestCrossFieldConsistency:
             artifact_ref=_ref(id=a_id, slug="art"),
             variant_ref=_ref(id=v_id, slug="var"),
             revision_ref=_ref(id=r_id, slug="rev", version="3"),
-            resolved_artifact_id=a_id,
-            resolved_artifact_slug="art",
-            resolved_variant_id=v_id,
-            resolved_variant_slug="var",
-            resolved_revision_id=r_id,
-            resolved_revision_slug="rev",
-            resolved_revision_version=3,
+            resolved_artifact_ref=_ref(id=a_id, slug="art"),
+            resolved_variant_ref=_ref(id=v_id, slug="var"),
+            resolved_revision_ref=_ref(id=r_id, slug="rev", version="3"),
         )
 
     def test_multiple_mismatches_reported_together(self):
@@ -184,8 +176,8 @@ class TestCrossFieldConsistency:
                 artifact_ref=_ref(slug="wrong-art"),
                 variant_ref=_ref(slug="wrong-var"),
                 revision_ref=None,
-                resolved_artifact_slug="art",
-                resolved_variant_slug="var",
+                resolved_artifact_ref=_ref(slug="art"),
+                resolved_variant_ref=_ref(slug="var"),
             )
         assert "artifact_ref.slug" in exc.value.message
         assert "variant_ref.slug" in exc.value.message
@@ -198,7 +190,7 @@ class TestExceptionType:
                 artifact_ref=_ref(slug="wrong"),
                 variant_ref=None,
                 revision_ref=None,
-                resolved_artifact_slug="right",
+                resolved_artifact_ref=_ref(slug="right"),
             )
 
     def test_exception_message_attribute(self):
@@ -207,7 +199,7 @@ class TestExceptionType:
                 artifact_ref=_ref(slug="wrong"),
                 variant_ref=None,
                 revision_ref=None,
-                resolved_artifact_slug="right",
+                resolved_artifact_ref=_ref(slug="right"),
             )
         assert exc.value.message
         assert isinstance(exc.value.message, str)

--- a/api/oss/tests/pytest/unit/test_retrieve_refs_consistency.py
+++ b/api/oss/tests/pytest/unit/test_retrieve_refs_consistency.py
@@ -1,0 +1,213 @@
+"""Unit tests for the shared retrieve-refs consistency validator.
+
+`validate_retrieve_refs_consistent` checks that every identifying field in
+the caller-supplied artifact/variant/revision refs agrees with the
+corresponding field on the resolved revision. Mismatch raises
+`RetrieveRefsInconsistent`, which the router translates to HTTP 400.
+"""
+
+from uuid import uuid4
+
+import pytest
+
+from oss.src.core.git.types import (
+    GitError,
+    RetrieveRefsInconsistent,
+    validate_retrieve_refs_consistent,
+)
+from oss.src.core.shared.dtos import Reference
+
+
+def _ref(*, id=None, slug=None, version=None):
+    return Reference(id=id, slug=slug, version=version)
+
+
+class TestAllRefsAbsent:
+    def test_no_caller_refs_passes(self):
+        validate_retrieve_refs_consistent(
+            artifact_ref=None,
+            variant_ref=None,
+            revision_ref=None,
+            resolved_artifact_id=uuid4(),
+            resolved_artifact_slug="my-artifact",
+            resolved_variant_id=uuid4(),
+            resolved_variant_slug="my-variant",
+            resolved_revision_id=uuid4(),
+            resolved_revision_slug="my-revision",
+            resolved_revision_version=1,
+        )
+
+    def test_no_resolved_fields_passes(self):
+        validate_retrieve_refs_consistent(
+            artifact_ref=_ref(slug="my-artifact"),
+            variant_ref=_ref(slug="my-variant"),
+            revision_ref=_ref(version="1"),
+        )
+
+    def test_empty_refs_pass(self):
+        validate_retrieve_refs_consistent(
+            artifact_ref=_ref(),
+            variant_ref=_ref(),
+            revision_ref=_ref(),
+            resolved_artifact_id=uuid4(),
+            resolved_variant_id=uuid4(),
+            resolved_revision_id=uuid4(),
+        )
+
+
+class TestArtifactConsistency:
+    def test_artifact_slug_match_passes(self):
+        validate_retrieve_refs_consistent(
+            artifact_ref=_ref(slug="my-artifact"),
+            variant_ref=None,
+            revision_ref=None,
+            resolved_artifact_slug="my-artifact",
+        )
+
+    def test_artifact_slug_mismatch_raises(self):
+        with pytest.raises(RetrieveRefsInconsistent) as exc:
+            validate_retrieve_refs_consistent(
+                artifact_ref=_ref(slug="wrong-artifact"),
+                variant_ref=None,
+                revision_ref=None,
+                resolved_artifact_slug="my-artifact",
+            )
+        assert "artifact_ref.slug" in exc.value.message
+        assert "wrong-artifact" in exc.value.message
+        assert "my-artifact" in exc.value.message
+
+    def test_artifact_id_mismatch_raises(self):
+        wrong_id = uuid4()
+        right_id = uuid4()
+        with pytest.raises(RetrieveRefsInconsistent) as exc:
+            validate_retrieve_refs_consistent(
+                artifact_ref=_ref(id=wrong_id),
+                variant_ref=None,
+                revision_ref=None,
+                resolved_artifact_id=right_id,
+            )
+        assert "artifact_ref.id" in exc.value.message
+
+    def test_artifact_id_match_passes(self):
+        same = uuid4()
+        validate_retrieve_refs_consistent(
+            artifact_ref=_ref(id=same),
+            variant_ref=None,
+            revision_ref=None,
+            resolved_artifact_id=same,
+        )
+
+    def test_entity_type_appears_in_message(self):
+        with pytest.raises(RetrieveRefsInconsistent) as exc:
+            validate_retrieve_refs_consistent(
+                artifact_ref=_ref(slug="wrong"),
+                variant_ref=None,
+                revision_ref=None,
+                resolved_artifact_slug="right",
+                entity_type="testset",
+            )
+        assert "testset_ref.slug" in exc.value.message
+
+
+class TestVariantConsistency:
+    def test_variant_slug_mismatch_raises(self):
+        with pytest.raises(RetrieveRefsInconsistent) as exc:
+            validate_retrieve_refs_consistent(
+                artifact_ref=None,
+                variant_ref=_ref(slug="wrong-variant"),
+                revision_ref=None,
+                resolved_variant_slug="my-variant",
+            )
+        assert "variant_ref.slug" in exc.value.message
+
+    def test_variant_id_match_passes(self):
+        same = uuid4()
+        validate_retrieve_refs_consistent(
+            artifact_ref=None,
+            variant_ref=_ref(id=same),
+            revision_ref=None,
+            resolved_variant_id=same,
+        )
+
+
+class TestRevisionConsistency:
+    def test_revision_slug_mismatch_raises(self):
+        with pytest.raises(RetrieveRefsInconsistent) as exc:
+            validate_retrieve_refs_consistent(
+                artifact_ref=None,
+                variant_ref=None,
+                revision_ref=_ref(slug="wrong-rev"),
+                resolved_revision_slug="my-rev",
+            )
+        assert "revision_ref.slug" in exc.value.message
+
+    def test_revision_version_mismatch_raises(self):
+        with pytest.raises(RetrieveRefsInconsistent) as exc:
+            validate_retrieve_refs_consistent(
+                artifact_ref=None,
+                variant_ref=None,
+                revision_ref=_ref(version="2"),
+                resolved_revision_version=1,
+            )
+        assert "revision_ref.version" in exc.value.message
+
+    def test_revision_version_match_passes(self):
+        validate_retrieve_refs_consistent(
+            artifact_ref=None,
+            variant_ref=None,
+            revision_ref=_ref(version="1"),
+            resolved_revision_version=1,
+        )
+
+
+class TestCrossFieldConsistency:
+    def test_all_match_passes(self):
+        a_id = uuid4()
+        v_id = uuid4()
+        r_id = uuid4()
+        validate_retrieve_refs_consistent(
+            artifact_ref=_ref(id=a_id, slug="art"),
+            variant_ref=_ref(id=v_id, slug="var"),
+            revision_ref=_ref(id=r_id, slug="rev", version="3"),
+            resolved_artifact_id=a_id,
+            resolved_artifact_slug="art",
+            resolved_variant_id=v_id,
+            resolved_variant_slug="var",
+            resolved_revision_id=r_id,
+            resolved_revision_slug="rev",
+            resolved_revision_version=3,
+        )
+
+    def test_multiple_mismatches_reported_together(self):
+        with pytest.raises(RetrieveRefsInconsistent) as exc:
+            validate_retrieve_refs_consistent(
+                artifact_ref=_ref(slug="wrong-art"),
+                variant_ref=_ref(slug="wrong-var"),
+                revision_ref=None,
+                resolved_artifact_slug="art",
+                resolved_variant_slug="var",
+            )
+        assert "artifact_ref.slug" in exc.value.message
+        assert "variant_ref.slug" in exc.value.message
+
+
+class TestExceptionType:
+    def test_inconsistent_is_git_error(self):
+        with pytest.raises(GitError):
+            validate_retrieve_refs_consistent(
+                artifact_ref=_ref(slug="wrong"),
+                variant_ref=None,
+                revision_ref=None,
+                resolved_artifact_slug="right",
+            )
+
+    def test_exception_message_attribute(self):
+        with pytest.raises(RetrieveRefsInconsistent) as exc:
+            validate_retrieve_refs_consistent(
+                artifact_ref=_ref(slug="wrong"),
+                variant_ref=None,
+                revision_ref=None,
+                resolved_artifact_slug="right",
+            )
+        assert exc.value.message
+        assert isinstance(exc.value.message, str)

--- a/api/oss/tests/pytest/unit/test_retrieve_refs_sufficiency.py
+++ b/api/oss/tests/pytest/unit/test_retrieve_refs_sufficiency.py
@@ -1,9 +1,10 @@
-"""Unit tests for the shared revision-ref ambiguity validator.
+"""Unit tests for the shared retrieve-refs sufficiency validators.
 
-The helper lives in `core/git/types.py` and protects the retrieve flow for
+The helpers live in `core/git/types.py` and protect the retrieve flow for
 every git-backed entity (workflows, applications, evaluators, testsets,
-queries, environments) against the version-only-no-variant trap that used
-to return arbitrary project-wide rows.
+queries, environments) against caller-supplied refs that cannot identify a
+single revision: the version-only-no-scope trap (revision side) and the
+variant_ref-with-only-version nonsense shape (variant side).
 """
 
 from uuid import uuid4
@@ -12,7 +13,8 @@ import pytest
 
 from oss.src.core.git.types import (
     RetrieveRefsInsufficient,
-    validate_revision_ref_unambiguous,
+    validate_revision_refs_sufficient,
+    validate_variant_refs_sufficient,
 )
 from oss.src.core.shared.dtos import Reference
 
@@ -33,7 +35,7 @@ class TestVersionOnlyRejection:
 
     def test_version_only_no_variant_raises(self):
         with pytest.raises(RetrieveRefsInsufficient) as exc:
-            validate_revision_ref_unambiguous(
+            validate_revision_refs_sufficient(
                 artifact_ref=None,
                 variant_ref=None,
                 revision_ref=_ref(version="1"),
@@ -43,7 +45,7 @@ class TestVersionOnlyRejection:
     def test_version_only_with_empty_variant_ref_raises(self):
         # Reference(id=None, slug=None, version=None) is truthy but unidentifying.
         with pytest.raises(RetrieveRefsInsufficient):
-            validate_revision_ref_unambiguous(
+            validate_revision_refs_sufficient(
                 artifact_ref=None,
                 variant_ref=_ref(),
                 revision_ref=_ref(version="1"),
@@ -53,7 +55,7 @@ class TestVersionOnlyRejection:
         # A variant_ref whose only field is `version` doesn't scope anything
         # — version isn't an identifier for the variant either.
         with pytest.raises(RetrieveRefsInsufficient):
-            validate_revision_ref_unambiguous(
+            validate_revision_refs_sufficient(
                 artifact_ref=None,
                 variant_ref=_ref(version="3"),
                 revision_ref=_ref(version="1"),
@@ -61,7 +63,7 @@ class TestVersionOnlyRejection:
 
     def test_entity_type_appears_in_message(self):
         with pytest.raises(RetrieveRefsInsufficient) as exc:
-            validate_revision_ref_unambiguous(
+            validate_revision_refs_sufficient(
                 artifact_ref=None,
                 variant_ref=None,
                 revision_ref=_ref(version="1"),
@@ -72,7 +74,7 @@ class TestVersionOnlyRejection:
 
     def test_entity_type_default_is_artifact(self):
         with pytest.raises(RetrieveRefsInsufficient) as exc:
-            validate_revision_ref_unambiguous(
+            validate_revision_refs_sufficient(
                 artifact_ref=None,
                 variant_ref=None,
                 revision_ref=_ref(version="1"),
@@ -89,35 +91,35 @@ class TestVersionOnlyWithScopePasses:
     default-variant fallback."""
 
     def test_variant_id_scopes_version(self):
-        validate_revision_ref_unambiguous(
+        validate_revision_refs_sufficient(
             artifact_ref=None,
             variant_ref=_ref(id=uuid4()),
             revision_ref=_ref(version="1"),
         )
 
     def test_variant_slug_scopes_version(self):
-        validate_revision_ref_unambiguous(
+        validate_revision_refs_sufficient(
             artifact_ref=None,
             variant_ref=_ref(slug="my-variant"),
             revision_ref=_ref(version="1"),
         )
 
     def test_artifact_id_scopes_version(self):
-        validate_revision_ref_unambiguous(
+        validate_revision_refs_sufficient(
             artifact_ref=_ref(id=uuid4()),
             variant_ref=None,
             revision_ref=_ref(version="1"),
         )
 
     def test_artifact_slug_scopes_version(self):
-        validate_revision_ref_unambiguous(
+        validate_revision_refs_sufficient(
             artifact_ref=_ref(slug="my-workflow"),
             variant_ref=None,
             revision_ref=_ref(version="1"),
         )
 
     def test_variant_id_with_artifact_also_passes(self):
-        validate_revision_ref_unambiguous(
+        validate_revision_refs_sufficient(
             artifact_ref=_ref(slug="my-workflow"),
             variant_ref=_ref(id=uuid4()),
             revision_ref=_ref(version="1"),
@@ -129,14 +131,14 @@ class TestVersionOnlyWithScopePasses:
 
 class TestRevisionIdOrSlugAlwaysSufficient:
     def test_revision_id_alone(self):
-        validate_revision_ref_unambiguous(
+        validate_revision_refs_sufficient(
             artifact_ref=None,
             variant_ref=None,
             revision_ref=_ref(id=uuid4()),
         )
 
     def test_revision_slug_alone(self):
-        validate_revision_ref_unambiguous(
+        validate_revision_refs_sufficient(
             artifact_ref=None,
             variant_ref=None,
             revision_ref=_ref(slug="my-revision"),
@@ -144,14 +146,14 @@ class TestRevisionIdOrSlugAlwaysSufficient:
 
     def test_revision_id_with_version_ignores_version(self):
         # The id is project-unique; version becomes a redundant hint.
-        validate_revision_ref_unambiguous(
+        validate_revision_refs_sufficient(
             artifact_ref=None,
             variant_ref=None,
             revision_ref=_ref(id=uuid4(), version="1"),
         )
 
     def test_revision_slug_with_version_ignores_version(self):
-        validate_revision_ref_unambiguous(
+        validate_revision_refs_sufficient(
             artifact_ref=None,
             variant_ref=None,
             revision_ref=_ref(slug="my-rev", version="1"),
@@ -166,35 +168,35 @@ class TestNonTriggering:
     ambiguity and leaves all others to the caller."""
 
     def test_all_refs_none(self):
-        validate_revision_ref_unambiguous(
+        validate_revision_refs_sufficient(
             artifact_ref=None,
             variant_ref=None,
             revision_ref=None,
         )
 
     def test_all_refs_empty(self):
-        validate_revision_ref_unambiguous(
+        validate_revision_refs_sufficient(
             artifact_ref=_ref(),
             variant_ref=_ref(),
             revision_ref=_ref(),
         )
 
     def test_artifact_only(self):
-        validate_revision_ref_unambiguous(
+        validate_revision_refs_sufficient(
             artifact_ref=_ref(slug="my-workflow"),
             variant_ref=None,
             revision_ref=None,
         )
 
     def test_variant_only(self):
-        validate_revision_ref_unambiguous(
+        validate_revision_refs_sufficient(
             artifact_ref=None,
             variant_ref=_ref(slug="my-variant"),
             revision_ref=None,
         )
 
     def test_artifact_and_variant_no_revision(self):
-        validate_revision_ref_unambiguous(
+        validate_revision_refs_sufficient(
             artifact_ref=_ref(slug="my-workflow"),
             variant_ref=_ref(slug="my-variant"),
             revision_ref=None,
@@ -209,7 +211,7 @@ class TestExceptionType:
         from oss.src.core.git.types import GitError
 
         with pytest.raises(GitError):
-            validate_revision_ref_unambiguous(
+            validate_revision_refs_sufficient(
                 artifact_ref=None,
                 variant_ref=None,
                 revision_ref=_ref(version="1"),
@@ -217,7 +219,7 @@ class TestExceptionType:
 
     def test_exception_message_attribute(self):
         with pytest.raises(RetrieveRefsInsufficient) as exc:
-            validate_revision_ref_unambiguous(
+            validate_revision_refs_sufficient(
                 artifact_ref=None,
                 variant_ref=None,
                 revision_ref=_ref(version="1"),
@@ -225,3 +227,48 @@ class TestExceptionType:
         # Has the .message attribute carried by GitError base.
         assert exc.value.message
         assert isinstance(exc.value.message, str)
+
+
+# variant_ref carrying only `version` --------------------------------------
+
+
+class TestVariantVersionOnlyRejection:
+    """A `variant_ref` populated with only `version` is nonsense — variants
+    have no `version` field. Reject at the boundary."""
+
+    def test_variant_version_only_raises(self):
+        with pytest.raises(RetrieveRefsInsufficient) as exc:
+            validate_variant_refs_sufficient(variant_ref=_ref(version="1"))
+        assert "variant_ref" in exc.value.message
+
+    def test_entity_type_appears_in_variant_message(self):
+        with pytest.raises(RetrieveRefsInsufficient) as exc:
+            validate_variant_refs_sufficient(
+                variant_ref=_ref(version="1"),
+                entity_type="testset",
+            )
+        assert "testset_variant_ref" in exc.value.message
+
+
+class TestVariantSufficientShapesPass:
+    def test_none_passes(self):
+        validate_variant_refs_sufficient(variant_ref=None)
+
+    def test_empty_ref_passes(self):
+        validate_variant_refs_sufficient(variant_ref=_ref())
+
+    def test_id_only_passes(self):
+        validate_variant_refs_sufficient(variant_ref=_ref(id=uuid4()))
+
+    def test_slug_only_passes(self):
+        validate_variant_refs_sufficient(variant_ref=_ref(slug="my-variant"))
+
+    def test_id_with_redundant_version_passes(self):
+        validate_variant_refs_sufficient(
+            variant_ref=_ref(id=uuid4(), version="1"),
+        )
+
+    def test_slug_with_redundant_version_passes(self):
+        validate_variant_refs_sufficient(
+            variant_ref=_ref(slug="my-variant", version="1"),
+        )

--- a/api/oss/tests/pytest/unit/test_revision_ref_validation.py
+++ b/api/oss/tests/pytest/unit/test_revision_ref_validation.py
@@ -59,18 +59,6 @@ class TestVersionOnlyRejection:
                 revision_ref=_ref(version="1"),
             )
 
-    def test_version_only_with_artifact_ref_still_raises(self):
-        # artifact_ref alone is not enough to scope a version today (the
-        # service would have to resolve artifact → default variant first,
-        # which is non-deterministic for multi-variant artifacts). Helper
-        # is conservative until that resolution is fixed.
-        with pytest.raises(RevisionRefInvalid):
-            validate_revision_ref_unambiguous(
-                artifact_ref=_ref(slug="my-workflow"),
-                variant_ref=None,
-                revision_ref=_ref(version="1"),
-            )
-
     def test_entity_type_appears_in_message(self):
         with pytest.raises(RevisionRefInvalid) as exc:
             validate_revision_ref_unambiguous(
@@ -95,7 +83,11 @@ class TestVersionOnlyRejection:
 # version-only with sufficient variant scope ---------------------------------
 
 
-class TestVersionOnlyWithVariantPasses:
+class TestVersionOnlyWithScopePasses:
+    """Either a variant_ref or an artifact_ref is sufficient scope for the
+    version filter — variant directly, artifact via the deterministic
+    default-variant fallback."""
+
     def test_variant_id_scopes_version(self):
         validate_revision_ref_unambiguous(
             artifact_ref=None,
@@ -107,6 +99,20 @@ class TestVersionOnlyWithVariantPasses:
         validate_revision_ref_unambiguous(
             artifact_ref=None,
             variant_ref=_ref(slug="my-variant"),
+            revision_ref=_ref(version="1"),
+        )
+
+    def test_artifact_id_scopes_version(self):
+        validate_revision_ref_unambiguous(
+            artifact_ref=_ref(id=uuid4()),
+            variant_ref=None,
+            revision_ref=_ref(version="1"),
+        )
+
+    def test_artifact_slug_scopes_version(self):
+        validate_revision_ref_unambiguous(
+            artifact_ref=_ref(slug="my-workflow"),
+            variant_ref=None,
             revision_ref=_ref(version="1"),
         )
 

--- a/api/oss/tests/pytest/unit/test_revision_ref_validation.py
+++ b/api/oss/tests/pytest/unit/test_revision_ref_validation.py
@@ -11,7 +11,7 @@ from uuid import uuid4
 import pytest
 
 from oss.src.core.git.types import (
-    RevisionRefInvalid,
+    RetrieveRefsInsufficient,
     validate_revision_ref_unambiguous,
 )
 from oss.src.core.shared.dtos import Reference
@@ -32,7 +32,7 @@ class TestVersionOnlyRejection:
     variant scope and must raise."""
 
     def test_version_only_no_variant_raises(self):
-        with pytest.raises(RevisionRefInvalid) as exc:
+        with pytest.raises(RetrieveRefsInsufficient) as exc:
             validate_revision_ref_unambiguous(
                 artifact_ref=None,
                 variant_ref=None,
@@ -42,7 +42,7 @@ class TestVersionOnlyRejection:
 
     def test_version_only_with_empty_variant_ref_raises(self):
         # Reference(id=None, slug=None, version=None) is truthy but unidentifying.
-        with pytest.raises(RevisionRefInvalid):
+        with pytest.raises(RetrieveRefsInsufficient):
             validate_revision_ref_unambiguous(
                 artifact_ref=None,
                 variant_ref=_ref(),
@@ -52,7 +52,7 @@ class TestVersionOnlyRejection:
     def test_version_only_with_variant_having_only_version_raises(self):
         # A variant_ref whose only field is `version` doesn't scope anything
         # — version isn't an identifier for the variant either.
-        with pytest.raises(RevisionRefInvalid):
+        with pytest.raises(RetrieveRefsInsufficient):
             validate_revision_ref_unambiguous(
                 artifact_ref=None,
                 variant_ref=_ref(version="3"),
@@ -60,7 +60,7 @@ class TestVersionOnlyRejection:
             )
 
     def test_entity_type_appears_in_message(self):
-        with pytest.raises(RevisionRefInvalid) as exc:
+        with pytest.raises(RetrieveRefsInsufficient) as exc:
             validate_revision_ref_unambiguous(
                 artifact_ref=None,
                 variant_ref=None,
@@ -71,7 +71,7 @@ class TestVersionOnlyRejection:
         assert "testset_variant_ref" in exc.value.message
 
     def test_entity_type_default_is_artifact(self):
-        with pytest.raises(RevisionRefInvalid) as exc:
+        with pytest.raises(RetrieveRefsInsufficient) as exc:
             validate_revision_ref_unambiguous(
                 artifact_ref=None,
                 variant_ref=None,
@@ -216,7 +216,7 @@ class TestExceptionType:
             )
 
     def test_exception_message_attribute(self):
-        with pytest.raises(RevisionRefInvalid) as exc:
+        with pytest.raises(RetrieveRefsInsufficient) as exc:
             validate_revision_ref_unambiguous(
                 artifact_ref=None,
                 variant_ref=None,

--- a/docs/design/playground-open-from-trace/followups.md
+++ b/docs/design/playground-open-from-trace/followups.md
@@ -352,7 +352,7 @@ def is_identifying(ref: Optional[Reference]) -> bool:
 
 `bool(ref)` alone is not enough — `Reference(id=None, slug=None,
 version=None)` is truthy but unidentifying. This is the implementation of
-`_has_id_or_slug` in `core/git/types.py` and is the formal definition the
+`_is_identifying` in `core/git/types.py` and is the formal definition the
 rules above depend on.
 
 ---

--- a/docs/design/playground-open-from-trace/followups.md
+++ b/docs/design/playground-open-from-trace/followups.md
@@ -664,19 +664,47 @@ without `{environment_variant_ref}` or `{environment_ref}`.
 If C1's default-variant rule lets `{artifact_ref + variant.version}` resolve
 deterministically, accept it via the C2 pattern.
 
-### C5. Centralize env-backed retrieve rules — fixes D5 + D11 + D12
+### C5. Unify git-ref retrieval rules across paths and entities — fixes D5 + D11 + D12
 
-Move the `key` requirement, the `key = f"{slug}.revision"` derivation, and the
-path-mixing policy out of the three routers into a shared utility (call site:
-new `apis/fastapi/shared/env_resolution.py` or `core/git/env_resolution.py`).
-Define and document:
+C5 covers two layers of unification:
 
-- When `key` is required vs derivable (default-key rule from D11).
-- Whether path-mixing is allowed and how it's resolved (rule from D10).
-  Recommended: allow mixing, enforce consistency via C3.
+**Service-layer pipeline (six entities).** All six services'
+`fetch_*_revision` carry the same pipeline today:
+`validate_variant_refs_sufficient → validate_revision_refs_sufficient →
+snapshot caller refs → needs_default_variant_resolution → fetch_artifact →
+fetch_variant → fetch_revision → validate_retrieve_refs_consistent → wrap
+DTO`. That pipeline should be extracted into a shared template so adding a
+seventh git-backed entity (or evolving any of the six steps) happens in one
+place.
 
-After this lands, applications/workflows/evaluators all call the same helper
-and exhibit the same behavior.
+**Router-layer env-backed retrieve policy (three routers).** The
+`*_revision_retrieve` endpoints for applications, workflows, and evaluators
+should share:
+
+- `key` is required for env-backed lookups, derived from `artifact_ref.slug`
+  as `f"{slug}.revision"` when missing (D11 default-key rule).
+- Path-mixing is allowed; rely on C3's consistency check to reject
+  contradictions after resolution (D10 path-mixing rule).
+- Neither path identifying → 400.
+
+This PR aligns the three routers inline so they exhibit the same behavior;
+the actual helper extraction (both layers) is deferred to C5b.
+
+### C5b. Extract the unified retrieval blocks into shared helpers — deferred
+
+Once C5 has aligned both layers inline, factor the duplicated blocks into
+shared helpers:
+
+- Service-layer pipeline → e.g., `core/git/retrieve.py` or a mixin on the
+  existing git service base.
+- Router-layer env-resolution → e.g.,
+  `apis/fastapi/shared/utils.py:plan_env_backed_retrieve`.
+
+Bundle with C10's exception-translation decorator extraction — both touch
+the same boilerplate (router try/except + retrieve_*_revision call) and
+share the same six per-entity duplicates. Deferred so the alignment ships
+first as small, low-risk changes; the extractions are mechanical refactors
+afterwards.
 
 ### C6. Stable tie-break for latest-revision ordering — fixes D7
 

--- a/docs/design/playground-open-from-trace/followups.md
+++ b/docs/design/playground-open-from-trace/followups.md
@@ -1,0 +1,777 @@
+# Follow-ups: revision-retrieve reference resolution
+
+Companion to [`retrieve-endpoint-audit.md`](./retrieve-endpoint-audit.md). The audit doc describes the
+original bug, the data model, and PR #4418's guardrails. PR #4422 extended those
+guardrails to every git-backed entity by factoring the version-only check into
+`core/git/types.py::validate_revision_ref_unambiguous`.
+
+This document captures what is **still wrong or incomplete** about reference
+resolution at the retrieve surface, evaluated against the five rules below. The
+breadth concern (do the changes apply uniformly across all git-backed entities)
+is fully resolved by PR #4422 and is intentionally not discussed here.
+
+The retrieve endpoints accept **two parallel resolution paths** that the rules
+must cover together:
+
+- **Entity-ref path:** `{artifact_ref, variant_ref, revision_ref}` triple
+  identifying a revision directly.
+- **Environment-ref path:** `{environment_ref, environment_variant_ref,
+  environment_revision_ref, key}` resolving to an environment revision, which
+  in turn contains a deployment map keyed by `key` whose value is an entity-ref
+  triple.
+
+Both paths feed into the same downstream lookup. Their interaction (when both
+are sent, when neither is sent, when `key` is missing or implicit) is part of
+the rule surface.
+
+**Testing baseline (applies to every C item below):** every rule, every
+fallback, and every discrepancy needs **both positive and negative tests**.
+A change that adds a 400 case must also pin the corresponding 200 case
+(and vice versa). PR #4422 set this precedent with
+`test_revision_retrieve_ambiguous_400.py` covering 400s alongside positive
+controls; the same discipline applies to every follow-on. C8 is the central
+place this is tracked, but it is a baseline expectation across the whole
+plan, not a C8-specific concern.
+
+---
+
+## Section 1 — The five rules
+
+Every request to a `/{entity}/revisions/retrieve` endpoint falls into exactly
+one of five cases. The cases apply to **both** the entity-ref path and the
+environment-ref path, and to combinations of the two.
+
+Notation: a `Reference` carries optional `id`, `slug`, and `version`. We say a
+reference is **identifying** if it has an `id` or `slug` (both project-unique)
+and **non-identifying** otherwise (empty, or `version`-only).
+
+A request is **path-mixed** if it carries identifying refs from both the
+entity-ref path and the environment-ref path. Today, applications and workflows
+silently let the environment-ref path win and overwrite entity refs from the
+environment's deployment map. Evaluators reject path-mixed requests with 400.
+Neither is documented as the rule; both are observable behavior.
+
+### 2.a — Unique, minimal, sufficient, consistent
+
+Exactly one identifying piece per level, nothing extra. The resolver picks one
+revision deterministically.
+
+**Entity-ref examples:**
+
+- `{revision_ref: {id: <uuid>}}`
+- `{revision_ref: {slug: "my-revision"}}`
+- `{variant_ref: {slug: "my-variant"}, revision_ref: {version: "1"}}`
+- `{artifact_ref: {slug: "my-workflow"}}` *(implies default variant + latest)*
+
+**Environment-ref examples:**
+
+- `{environment_ref: {slug: "production"}, key: "my-app.revision"}`
+  *(latest env revision, lookup the `my-app.revision` slot)*
+- `{environment_revision_ref: {id: <env-rev-uuid>}, key: "my-app.revision"}`
+  *(pinned env revision, same slot lookup)*
+
+**Path-mixed (today applications/workflows only):** none qualify as 2.a; any
+mix means at least one path is redundant — see 2.b/2.c.
+
+**Expected behavior:** 200, returned revision matches the references.
+
+### 2.b — Unique, redundant, sufficient, consistent
+
+More identifying information than needed, but every piece is consistent with
+what precedence picks.
+
+**Entity-ref examples:**
+
+- `{artifact_ref: {slug: "my-app"}, variant_ref: {slug: "v1"}, revision_ref: {id: <uuid>}}`
+  where the resolved revision's variant slug is `"v1"` and its artifact slug is
+  `"my-app"`.
+
+**Environment-ref examples:**
+
+- `{environment_ref: {slug: "production"}, environment_variant_ref: {slug: "v1"}, environment_revision_ref: {version: "3"}, key: "my-app.revision"}`
+  where all three refs and the version consistently identify the same env
+  revision.
+
+**Path-mixed examples:** path-mixing is only redundant when each path
+*independently* identifies a target. Cases:
+
+- `{application_revision_ref: {id: <uuid>}, environment_ref: {slug: "production"}, key: "my-app.revision"}`
+  — entity-path resolves a revision via `application_revision_ref.id`; env-path
+  independently resolves the same revision via the env deployment map. Both
+  paths fully determine the answer; they agree.
+- `{application_ref: {slug: "my-app"}, environment_ref: {slug: "production"}, key: "my-app.revision"}`
+  — env deployment map under the explicit `"my-app.revision"` slot returns
+  refs whose application slug is `"my-app"`. The caller's `application_ref` is
+  redundant because the explicit `key` makes the entity ref non-load-bearing.
+  Consistent.
+
+Counter-example, NOT path-mixed redundant: `{application_ref: {slug: "my-app"},
+environment_ref: {slug: "production"}}` without `key`. The `application_ref` is
+load-bearing here — it's what the default-key rule uses to derive the key. See
+2.d.
+
+**Expected behavior:** 200. Redundancy is silently fine when it's consistent.
+
+### 2.c — Unique, redundant, sufficient, inconsistent
+
+Precedence still picks a single target, but a lower-precedence ref contradicts
+the chosen one.
+
+**Entity-ref examples:**
+
+- `{artifact_ref: {slug: "my-app"}, revision_ref: {id: <uuid>}}` where the
+  revision identified by `id` does NOT belong to `"my-app"`.
+- `{variant_ref: {slug: "v1"}, revision_ref: {id: <uuid>}}` where the
+  revision's variant is not `"v1"`.
+
+**Environment-ref examples:**
+
+- `{environment_ref: {slug: "production"}, environment_revision_ref: {id: <uuid>}}`
+  where the env revision identified by `id` does NOT belong to the
+  `"production"` env.
+
+**Path-mixed examples:** as with 2.b, only genuinely redundant inputs qualify.
+
+- `{application_revision_ref: {id: <uuid>}, environment_ref: {slug: "production"}, key: "my-app.revision"}`
+  where the env deployment map under that key resolves to a different revision
+  than the one `application_revision_ref.id` points at. Both paths fully
+  determine an answer; the answers disagree.
+- `{application_ref: {slug: "different-app"}, environment_ref: {slug: "production"}, key: "my-app.revision"}`
+  — the explicit `key` makes the env path self-sufficient. The env deployment
+  under `"my-app.revision"` returns refs whose application slug is `"my-app"`,
+  not `"different-app"`. The redundant `application_ref` contradicts.
+
+**Expected behavior:** 400 (or 422) naming the conflicting field. Today, all
+inconsistencies in this case are silently absorbed — see D1 and D10.
+
+### 2.d — Unique, minimal, insufficient, consistent
+
+Information given does not by itself identify a single revision, but
+deterministic fallback rules close the gap.
+
+The three fallback rules (see also the precedence-and-defaults reference
+section below):
+
+- **Latest revision:** when a variant is identified but no revision is.
+- **Default variant:** when only the artifact is identified.
+- **Default key (`<artifact.slug>.revision`):** when the env-backed path is
+  used and `key` is missing but the entity's `artifact_ref` is identified.
+  Applications already does this; workflows and evaluators do not.
+
+**Entity-ref examples:**
+
+- `{variant_ref: {slug: "v1"}}` → latest revision of `v1`.
+- `{artifact_ref: {slug: "my-app"}}` → latest revision of `my-app`'s default
+  variant.
+- `{artifact_ref: {slug: "my-app"}, revision_ref: {version: "1"}}` → version 1
+  of `my-app`'s default variant. **This is a 2.d case under the rule.** Today
+  the helper rejects it with 400 because the default-variant fallback isn't
+  deterministic (D2). The 400 is the current bug, not the rule — see D3.
+
+**Environment-ref examples:**
+
+- `{environment_ref: {slug: "production"}, key: "my-app.revision"}` → latest
+  revision of `production` env, then look up `"my-app.revision"` slot.
+- `{environment_ref: {slug: "production"}, application_ref: {slug: "my-app"}}`
+  → applications-only today: derives `key = "my-app.revision"` and resolves
+  via the env's latest revision.
+
+**Path-mixed examples:**
+
+- `{environment_ref: {slug: "production"}, application_ref: {slug: "my-app"}}`
+  with no explicit `key` — applications derives the key from the application
+  slug (default-key rule); workflows and evaluators reject the same request
+  with 400 "requires key".
+
+**Expected behavior:** 200 when the fallback chain resolves a single revision;
+404 only if no fallback target exists (artifact has no variants, env has no
+deployment under that key, etc.). All fallback rules must be deterministic
+and consistent across entities.
+
+### 2.e — Non-unique or insufficient
+
+Precedence and fallback together still cannot identify a single revision.
+
+**Entity-ref examples:**
+
+- `{}` — nothing to look up.
+- `{revision_ref: {version: "1"}}` — version is per-variant; no variant
+  context.
+
+**Environment-ref examples:**
+
+- `{environment_ref: {slug: "production"}}` with no `key` and no derivable
+  artifact ref. The env revision is identified, but which deployment slot
+  inside it the caller wants is unspecified.
+- `{environment_revision_ref: {version: "3"}}` alone — env revision `version`
+  is per-env-variant; same trap as the entity-side version-only case.
+- `{key: "my-app.revision"}` with no environment_ref — there's no environment
+  to look up the key in.
+
+**Path-mixed examples:** none specifically — path-mixed requests fall into
+2.b, 2.c, or 2.d depending on consistency.
+
+**Expected behavior:** 400 with a clear message naming what is missing or
+ambiguous. The error must distinguish "you gave me nothing" from "you gave me
+something that cannot be resolved."
+
+---
+
+## Section 1.5 — Precedence and defaults reference
+
+The single source of truth for how the resolver picks a revision. Every rule
+in Section 1 is an application of these.
+
+### Precedence within a single `Reference`
+
+Within `Reference(id, slug, version)`:
+
+1. `id` — used if set. Globally unique. Ends the lookup.
+2. `slug` — used only if `id` is unset. Project-unique. Ends the lookup.
+3. `version` — used only if both `id` and `slug` are unset. **Per-variant for
+   revisions, per-artifact for variants.** Only valid when scoped by an
+   identifying parent ref.
+
+A `Reference` with only `version` populated is "non-identifying" because it
+carries no project-scoped identifier.
+
+### Precedence across entity refs
+
+Given `(artifact_ref, variant_ref, revision_ref)`:
+
+1. **`revision_ref`** with `id` or `slug` ends the lookup. Other refs are
+   either consistent (2.b, return 200) or inconsistent (2.c, return 400 —
+   future behavior; today: 2.b absorbs 2.c silently).
+2. **`variant_ref`** with `id` or `slug` scopes the lookup. Combined with
+   `revision_ref.version` if set, otherwise falls back to latest revision.
+3. **`artifact_ref`** with `id` or `slug` scopes the lookup. Falls back to
+   default variant, then to latest revision (or `revision_ref.version` if
+   supplied).
+
+### Precedence across environment refs
+
+Given `(environment_ref, environment_variant_ref, environment_revision_ref,
+key)`:
+
+1. **`environment_revision_ref`** with `id` or `slug` picks the env revision
+   directly. Other env refs are consistent (2.b) or inconsistent (2.c).
+2. **`environment_variant_ref`** with `id` or `slug` scopes the env lookup.
+   Combined with `environment_revision_ref.version` if set, otherwise falls
+   back to latest env revision.
+3. **`environment_ref`** with `id` or `slug` scopes the env lookup. Falls
+   back to default env variant, then to latest env revision.
+
+After resolving an env revision, the `key` selects a slot in its deployment
+map; the slot value is an entity-ref triple processed by the entity-ref
+precedence rules above.
+
+### Precedence between paths (entity-ref vs environment-ref)
+
+**The rule:** environment-ref handling is uniform across all git-backed
+entities. When both paths carry identifying information:
+
+1. The env path resolves an env revision and selects a deployment slot via
+   `key` (explicit or derived — see default-key rule).
+2. The slot contains an entity-ref triple. That triple is the env path's
+   answer.
+3. Any entity refs the caller also supplied are *redundant* with the env
+   path's answer (only when path-mixing is genuinely redundant — see 2.b
+   discussion). They must be consistent; otherwise 400 (2.c).
+4. The default-key rule (`key = "<artifact.slug>.revision"` when `key` is
+   missing and `artifact_ref` is identified) applies uniformly. It is the
+   only mechanism by which an entity ref participates in env-path resolution
+   without being redundant.
+
+**Current state — non-compliance is the open bug:**
+
+- **Applications (today):** environment-ref path wins. Entity refs are
+  silently overwritten by the env deployment map. Default-key rule is
+  implemented. Path-mixed inconsistencies are silently absorbed (D10).
+- **Workflows (today):** environment-ref path wins, same silent overwrite.
+  Default-key rule NOT implemented; missing `key` returns 400 (D11).
+- **Evaluators (today):** path-mixed requests return 400 unconditionally
+  (D12). Default-key rule NOT implemented; missing `key` returns 400 (D11).
+
+Each entity diverges from the rule in a different way. D10, D11, D12 track
+the three divergences. The fix is C5 (centralized env-resolution helper)
+applied to all three routers — see Section 3.
+
+### Defaults
+
+Three default rules close 2.d's insufficiency gaps. Each has a target rule
+that the codebase is expected to satisfy. Non-compliance is an open bug.
+
+- **Latest revision** — when the variant is identified but no revision is.
+
+  Target rule: deterministic pick over revisions of the variant. Tie-break
+  must be stable.
+
+  Current state: `ORDER BY created_at DESC LIMIT 1` on the revision table,
+  scoped to the variant. Tie-break under equal `created_at` is
+  non-deterministic. Open bug: D7.
+
+- **Default variant** — when only the artifact is identified.
+
+  Target rule: each artifact has exactly one variant marked with an
+  explicit `is_default: bool` column. The default-variant pick is `SELECT *
+  FROM variants WHERE artifact_id = ? AND is_default IS TRUE LIMIT 1`. The
+  column is set on artifact creation and is mutable via a dedicated
+  set-default endpoint. A partial unique index `(artifact_id) WHERE
+  is_default IS TRUE` enforces at most one default per artifact.
+
+  Current state (interim, accepted until the flag lands): `fetch_variant`
+  in `dbs/postgres/git/dao.py` does `LIMIT 1` with no `ORDER BY`. Worse,
+  the `artifact_ref.slug` branch is missing entirely — only
+  `artifact_ref.id` filters by artifact; an `artifact_ref` carrying only a
+  `slug` reduces the query to `WHERE project_id = ? LIMIT 1`, returning an
+  arbitrary variant from any artifact in the project. The slug-only case
+  was already broken before this design surfaced it. Open bugs: D2 (no
+  default rule), D2.1 (slug-only `artifact_ref` ignored).
+
+- **Default key** — when the env-backed path is used without an explicit
+  `key` but with an identified `artifact_ref`.
+
+  Target rule: derive `key = f"{<artifact>.slug}.revision"` from the
+  identified artifact ref. Applies uniformly across all git-backed
+  entities that support env-backed retrieve (applications, evaluators,
+  workflows). After resolution, the env-resolved entity refs must be
+  consistency-checked against the caller-supplied `artifact_ref` that
+  produced the derivation — if the env deployment under the derived key
+  resolves to a different artifact, return 400 (2.c on the way out).
+
+  Current state: applications derives the key but does not consistency-
+  check (D15). Workflows and evaluators do not derive at all and return
+  400 on missing key (D11). Open bugs: D11, D15.
+
+### Identifying-ref test
+
+```python
+def is_identifying(ref: Optional[Reference]) -> bool:
+    return bool(ref and (ref.id or ref.slug))
+```
+
+`bool(ref)` alone is not enough — `Reference(id=None, slug=None,
+version=None)` is truthy but unidentifying. This is the implementation of
+`_has_id_or_slug` in `core/git/types.py` and is the formal definition the
+rules above depend on.
+
+---
+
+## Section 2 — Current discrepancies
+
+What today's code does versus what the rules require.
+
+### D1. `2.c` is not enforced on the entity-ref path
+
+When `revision_ref.id` (or `.slug`) is supplied alongside an `artifact_ref` or
+`variant_ref` that does NOT correspond to the resolved revision, the server
+silently uses the revision and ignores the other refs. Audit doc calls this
+**Bug D**. No 400 is raised, no warning is logged. Affects all six entity
+retrieve endpoints.
+
+### D2. `2.d` default-variant fallback is non-deterministic
+
+`fetch_*_variant(artifact_ref)` in `dbs/postgres/git/dao.py:476` does
+`LIMIT 1` with **no `ORDER BY`**. For multi-variant artifacts, the chosen
+variant is whatever Postgres surfaces first. Audit doc calls this **Bug C**.
+There is no "default variant" concept in the data model today. Target rule
+under the Defaults reference is an explicit `is_default: bool` column on the
+variant table.
+
+### D2.1. `fetch_variant(artifact_ref={slug})` ignores the slug
+
+`GitDAO.fetch_variant` (`dbs/postgres/git/dao.py:500-507`) only filters by
+`artifact_ref.id`. When the caller passes `artifact_ref.slug` without `id`,
+no `WHERE artifact.slug = ?` clause is added. Combined with D2's missing
+`ORDER BY`, the query reduces to `SELECT * FROM variants WHERE project_id =
+? LIMIT 1` — returning an arbitrary variant from any artifact in the
+project. This is independent of D2 (D2 is "no rule for multi-variant
+artifacts"; D2.1 is "slug-only artifact_ref is structurally ignored") and
+must be fixed even if D2's default-variant flag lands.
+
+### D3. `2.d` `{artifact_ref + version}` is rejected, not resolved
+
+PR #4422's helper rejects `{artifact_ref + revision_ref:{version}}` because
+accepting it would require the default-variant fallback that D2 leaves
+broken. The reject is correct *given* D2 but means 2.d is under-implemented:
+a case that the data model can answer is currently a 400.
+
+### D4. Variant-by-version analog of 2.e is not caught
+
+The helper rejects `{revision_ref:{version}}` because revision `version` is
+per-variant. But `variant.version` is per-artifact, so `{variant_ref:{version}}`
+without an `artifact_ref` is the same trap. Today the helper accepts it
+because the variant `version` field is not inspected. Affects any retrieve
+that passes through `fetch_*_variant({version})`.
+
+### D5. Env-backed `key` rules are not centralized
+
+Per-router behavior:
+
+- **Applications:** auto-derives `key = f"{application.slug}.revision"` from
+  an identified `application_ref`.
+- **Workflows:** rejects missing `key` with 400 unconditionally.
+- **Evaluators:** rejects missing `key` with 400 unconditionally.
+
+No shared utility encodes the rule; no test pins it; the three routers each
+have their own copy.
+
+### D6. Docs site lies about behavior
+
+PR #4418/#4422 fixed the per-field descriptions on the 6 request models. But
+[`02-fetch-prompt-programatically.mdx`](../../docs/prompt-engineering/integrating-prompts/02-fetch-prompt-programatically.mdx)
+still shows only the full-triple-ref shape and never mentions the env-backed
+path's `key` rule or the default-key behavior. Audit doc calls this **Bug F**.
+
+No single user-facing document states the five rules or the
+precedence-and-defaults reference. The audit doc is internal; field
+descriptions are per-endpoint.
+
+### D7. No deterministic tie-break for "latest revision"
+
+When 2.d falls back to "latest revision of this variant," the DAO uses
+`ORDER BY created_at DESC LIMIT 1`. If two revisions on the same variant
+share a `created_at` timestamp, the picked revision is arbitrary.
+
+### D8. No precedence test coverage
+
+PR #4422 covers 2.e (rejection of insufficient refs) with unit + acceptance
+tests. It does not cover 2.b, 2.c, 2.d, or any of the env-path or path-mixed
+variants. Until tests exist for those cases, regressions in any of D1–D7 and
+D10–D13 are unobservable.
+
+### D9. The five rules are not codified anywhere in the codebase
+
+`validate_revision_ref_unambiguous` enforces a fragment of 2.e. There is no
+constant, comment block, or single doc string that lists the five rules,
+the precedence orders, or the default rules so future maintainers can match
+new validation to the right rule. This document is the first attempt at
+codifying them.
+
+### D10. `2.c` is not enforced on the env-ref path or across paths
+
+Two related gaps:
+
+- **Within the env-ref path:** `{environment_ref + environment_revision_ref}`
+  where the revision belongs to a different env is silently absorbed —
+  mirror of D1 at the env level.
+- **Across paths:** applications and workflows silently let the env-ref path
+  win when path-mixed. If the entity refs the caller sent contradict the
+  env's deployment-map contents, no error is raised. Evaluators rejects
+  path-mixing entirely (different overreach — D12).
+
+### D11. Default-key rule is inconsistent across entities
+
+Applications derives `key` from `application_ref.slug`. Workflows and
+evaluators do not. Same input shape, different behavior per entity — a 2.d
+fallback that is partially implemented. Either all three should derive (and
+testsets/queries/environments don't have env-backed retrieve so they're
+out of scope), or none should.
+
+### D12. Evaluators over-restricts path-mixing
+
+`/evaluators/revisions/retrieve` returns 400 on any request that carries both
+entity refs and env refs. That's a policy decision (refuse redundancy) that
+applications and workflows do not share. None of the three is documented as
+the rule; the evaluators rejection is observable behavior, not a designed
+constraint.
+
+### D13. `{environment_revision_ref: {version: "X"}}` is the env-side D4
+
+Env revisions have a `version` column too, per env variant. Sending only
+`environment_revision_ref: {version: "3"}` falls into the same trap as the
+entity-side: no env-variant context, so the version is unscoped. Today the
+service-level validation does not catch this on the env-ref path.
+
+### D14. `key`-only without env is silently accepted (or silently empty)
+
+`{key: "my-app.revision"}` with no `environment_ref` and no entity refs hits
+the application's `application_lookup_requested or environment_lookup_requested`
+gate, where `environment_lookup_requested = environment_refs_requested or
+key is not None`. So `key` alone passes the gate but then `environment_refs_requested`
+is false → returns 400 "requires environment refs." That's correct.
+But the error message doesn't surface the actual mistake (sent `key` without
+env refs) — it just says "requires environment refs." Minor; lumped here for
+completeness.
+
+### D15. Derived `key` is not consistency-checked on the way out
+
+Applications today derives `key = f"{application.slug}.revision"` when the
+caller supplies an identified `application_ref` but no explicit `key`. The
+derived key is used to look up a slot in the env deployment map. The slot's
+entity-ref triple is then returned as-is.
+
+There is no check that the slot's resolved revision actually belongs to the
+`application_ref` that produced the derivation. So if the env's deployment
+under `"my-app.revision"` resolves to refs for a different application
+(stale deployment, manual env edit, etc.), the caller gets back a revision
+that contradicts the artifact ref they sent. This is the on-the-way-out
+analog of 2.c for the default-key path. Caught by C3's consistency check
+once it lands.
+
+---
+
+## Section 3 — What needs to change
+
+Each item maps to one or more discrepancies above. Order is suggested
+implementation order; dependencies are noted.
+
+### C1a. Make default-variant pick deterministic via ORDER BY — fixes D2 (interim)
+
+Smallest possible fix. In `GitDAO.fetch_variant(artifact_ref)` at
+`dbs/postgres/git/dao.py:476`, when the caller supplies `artifact_ref` but no
+`variant_ref`, add `ORDER BY created_at ASC, id ASC` before the `LIMIT 1`.
+First-created variant wins. Matches the existing latest-revision ordering
+pattern, deterministic under ties.
+
+No schema change. ~2 lines. Unblocks C2.
+
+### C1b. Add `is_default` flag in `variant.flags` (JSONB) — replaces C1a target
+
+The real fix. `is_default` is **not a new column** — variant tables already
+carry a nullable `flags` JSONB column via the shared `FlagsDBA` mixin
+(`dbs/postgres/shared/dbas.py:198`). The default-variant marker is a key
+inside that JSON, not a top-level column.
+
+Migration is correspondingly lighter than a schema migration:
+
+1. **Backfill:** for each artifact, update its earliest-created variant's
+   `flags` to merge in `{"is_default": true}`. Idempotent: re-running
+   leaves a project with an existing default untouched. One Alembic data
+   migration per entity table (workflows, applications, evaluators,
+   testsets, queries, environments).
+2. **Index for fast lookup** — project-scoped to match existing variant
+   indexes (slug uniqueness is `(project_id, slug)`):
+   - **Partial expression index** on `(project_id, artifact_id) WHERE
+     (flags->>'is_default')::boolean IS TRUE`. Doubles as both the
+     uniqueness constraint (at most one default per artifact per project)
+     and the lookup index for the default-variant query. Single index
+     seek.
+3. **Service mutation:** `set_default_variant(artifact_id, variant_id)`
+   flips the flag under a transaction — unsets the previous default,
+   sets the new one. The partial-unique index makes the transaction safe
+   under concurrent calls (one will lose the index conflict and retry).
+4. **DAO read:** `GitDAO.fetch_variant(artifact_ref={id|slug})` adds
+   `WHERE (flags->>'is_default')::boolean IS TRUE` when no `variant_ref`
+   is supplied. Replaces C1a's `ORDER BY`.
+5. **Schema DTO:** add `is_default: Optional[bool]` to the variant flags
+   DTO (each entity's `*Flags` model) so the API can read/set it.
+
+Lands last (see suggested order), since it's the highest-blast-radius
+change and every other improvement is fine with C1a in the interim.
+
+### C1.1. Fix slug-only `artifact_ref` in `fetch_variant` — fixes D2.1
+
+Independent of C1's data-model change. In `dbs/postgres/git/dao.py:500-507`,
+extend the `artifact_ref` branch to also filter by `artifact_ref.slug` via a
+join on the artifact table when `artifact_ref.id` is unset. Mirror what
+`fetch_revision` already does for variant slugs. No migration, ~5 lines.
+
+Lands before C1's flag is wired into the same DAO method so the slug-only
+case is correct under both the interim and the post-C1 behavior.
+
+### C1.1b. Denormalize parent slugs onto variant and revision rows — perf
+
+Today `artifact_slug` (on variants) and `artifact_slug` / `variant_slug` (on
+revisions) are not stored — they're populated by the DAO via either join
+loads (`selectinload(VariantDBE.artifact)` at
+`dbs/postgres/git/dao.py:493`) or separate `IN` queries
+(`fetch_variants`, `fetch_revisions` at lines 331-337, 726-764, 1291-1302),
+then assigned to the DTO at lines 526, 831, 1117-1120. Every read path that
+returns slugs pays this cost.
+
+C3's consistency check (D1, D10, D15) needs these slugs on the resolved
+revision to compare against caller-supplied refs. Same with any caller
+that wants to render slugs in the UI without a second round trip. Without
+denormalization, C3 either re-joins or accepts more latency on every
+retrieve.
+
+The fix:
+
+1. Add nullable columns to the variant table: `artifact_slug`. Add to the
+   revision table: `artifact_slug`, `variant_slug`. All on the shared
+   git-pattern mixin so all six entities pick them up at once.
+2. Backfill from the parent tables in the same Alembic migration.
+3. Maintain the denormalized values on writes:
+   - On variant create: copy `artifact.slug` into `variant.artifact_slug`.
+   - On revision create: copy `variant.artifact_slug` and `variant.slug`.
+   - On artifact slug rename: cascade to the artifact's variants and
+     revisions. If artifact slugs are not renamable today, this is moot
+     and the doc-string should note that constraint.
+   - On variant slug rename: cascade to the variant's revisions. Same
+     caveat.
+4. DAO read paths drop the join load and the secondary `IN` queries —
+   slugs come directly from the row.
+5. Index choices: only add indexes if a query plan needs them. The
+   primary use is reading slugs already returned by id-based lookups, so
+   no new index is needed by default. Add `(project_id, artifact_slug)`
+   on the revision table only if a query filters by it.
+
+Trade-off: write paths grow a column copy (essentially free); rename
+paths grow a cascading update (expensive if slugs are renamed often;
+likely rare today). Net: cheaper reads everywhere in exchange for two
+new columns and a write-path responsibility.
+
+Lands after C1b. Both are migrations; bundling makes the variant-table
+schema change a single ALTER. The two are independent but share blast
+radius.
+
+### C2. Accept `{artifact_ref + version}` and resolve via default variant — fixes D3
+
+After C1, lift the helper's rejection of this shape. Two equivalent placements:
+
+- **C2a.** In each entity service, before the helper call: if `revision_ref`
+  has only `version`, `variant_ref` is unidentified, and `artifact_ref` is
+  identified, resolve `artifact_ref → default_variant` and set `variant_ref`.
+  Then call the helper. The helper itself does not change.
+- **C2b.** Pass a resolver callback into the helper and have it do the
+  resolution. Cleaner-looking but couples the validator to artifact lookups.
+
+C2a matches the existing pattern. The helper's docstring already anticipates
+C2a — no signature change needed.
+
+### C3. Reject inconsistent redundant refs — fixes D1 + D10 + D15
+
+After resolution but before returning, compare the resolved revision's
+artifact/variant identity against what the caller sent:
+
+- **Entity-ref path:** if `revision_ref.id|slug` resolved a revision, check
+  `artifact_ref` and `variant_ref` match the resolved revision's
+  `artifact_id`/`variant_id`/slugs.
+- **Env-ref path:** if `environment_revision_ref.id|slug` resolved an env
+  revision, check `environment_ref` and `environment_variant_ref` match the
+  resolved revision's env identity.
+- **Across paths (explicit `key`):** if both paths produced identifying refs,
+  check the env-deployment-map resolution matches the entity refs the
+  caller supplied.
+- **Across paths (derived `key`):** when `key` was derived from
+  `artifact_ref.slug` (default-key rule), the env's slot resolution must
+  still belong to that same artifact. Otherwise the derived key looked up
+  a slot the caller didn't actually mean — D15.
+
+On mismatch, raise a new `RevisionRefInconsistent(GitError)` and surface as
+400 naming the conflicting field. The exception and validator live in
+`core/git/types.py` next to `RevisionRefInvalid`.
+
+### C4. Catch variant-by-version analog — fixes D4 + D13
+
+Extend the helper (or add a sibling `validate_variant_ref_unambiguous`) to
+reject `{variant_ref:{version}}` without an `artifact_ref` (`id` or `slug`).
+Same shape, same reasoning. Call it from `fetch_*_variant` paths. Mirror the
+same check for the env-side: reject `{environment_revision_ref:{version}}`
+without `{environment_variant_ref}` or `{environment_ref}`.
+
+If C1's default-variant rule lets `{artifact_ref + variant.version}` resolve
+deterministically, accept it via the C2 pattern.
+
+### C5. Centralize env-backed retrieve rules — fixes D5 + D11 + D12
+
+Move the `key` requirement, the `key = f"{slug}.revision"` derivation, and the
+path-mixing policy out of the three routers into a shared utility (call site:
+new `apis/fastapi/shared/env_resolution.py` or `core/git/env_resolution.py`).
+Define and document:
+
+- When `key` is required vs derivable (default-key rule from D11).
+- Whether path-mixing is allowed and how it's resolved (rule from D10).
+  Recommended: allow mixing, enforce consistency via C3.
+
+After this lands, applications/workflows/evaluators all call the same helper
+and exhibit the same behavior.
+
+### C6. Stable tie-break for latest-revision ordering — fixes D7
+
+Change the DAO's latest-revision query from `ORDER BY created_at DESC LIMIT 1`
+to `ORDER BY created_at DESC, id DESC LIMIT 1`. One line in `git/dao.py`.
+
+### C7. Update user-facing docs — fixes D6
+
+- Update [02-fetch-prompt-programatically.mdx](../../docs/prompt-engineering/integrating-prompts/02-fetch-prompt-programatically.mdx)
+  to show all valid request shapes for the entity-ref path AND the
+  environment-ref path (with and without explicit `key`).
+- Cross-link the OpenAPI field descriptions to a single "How references
+  resolve" section that states the five rules, the precedence orders, and
+  the default rules.
+- Mention the 400 cases explicitly (per-endpoint, not just in a global page).
+
+### C8. Test coverage for every rule — fixes D8
+
+Parametrize tests by entity and by path. Cases:
+
+- **2.a (entity path):** one assert per identifying shape (`revision.id`,
+  `revision.slug`, `(variant, version)`, `artifact` alone post-C1).
+- **2.a (env path):** `{env_ref, key}` and `{env_revision_ref, key}`.
+- **2.b (entity + env consistent):** redundant-consistent triples + redundant
+  path-mixed → 200.
+- **2.c (entity, env, and path-mixed inconsistent):** all three flavors of
+  inconsistency → 400.
+- **2.d (entity):** `{variant_ref}`, `{artifact_ref}`, `{artifact_ref + version}`
+  (post-C2) → resolved correctly.
+- **2.d (env):** `{env_ref, key}` resolves to latest env revision +
+  deployment map lookup; default-key rule (post-C5) on every applicable entity
+  → 200.
+- **2.e:** existing PR #4422 coverage + variant-by-version + env-revision-
+  version-only + `key` without env.
+
+PR #4422's `test_revision_retrieve_ambiguous_400.py` is the seed for the 2.e
+cases; the rest of the file grows to cover the others.
+
+### C9. Codify the rules and defaults in code — fixes D9
+
+A module docstring on `core/git/types.py` (or a dedicated `core/git/README.md`)
+that states the five rules, the precedence orders, the default rules, and
+the identifying-ref test. Links to this document for the discrepancies and
+change plan.
+
+---
+
+## Suggested landing order
+
+Every C item appears below. Ordering reflects dependencies and blast radius.
+C1b is last because it's the only change that touches data and indexes
+across all six entity tables.
+
+1. **C6** — stable tie-break for `latest_revision` (`ORDER BY created_at
+   DESC, id DESC`). One line, no behavior change for any working request.
+2. **C1.1** — fix `fetch_variant(artifact_ref={slug})` to actually filter
+   by slug via a join. Independent of C1's default-variant work; correct
+   under both the C1a interim and the C1b target.
+3. **C1a** — deterministic default-variant pick via `ORDER BY created_at
+   ASC, id ASC LIMIT 1`. Interim of C1b. Unblocks C2 immediately without
+   the migration of C1b.
+4. **C8 (first pass)** — pin existing behavior for 2.a, 2.b, 2.d before
+   any further change. Catches accidental regressions in the next steps.
+5. **C2** — lift the helper's `{artifact_ref + version}` rejection now
+   that C1a makes the default-variant pick deterministic.
+6. **C3** — new `RevisionRefInconsistent` exception, post-resolution
+   consistency checks for entity-ref path, env-ref path, across-paths
+   (explicit `key`), and across-paths (derived `key` / D15).
+7. **C4** — variant-by-version analog of the helper, plus the env-side
+   `{environment_revision_ref:{version}}` mirror.
+8. **C5** — centralize env-backed retrieve rules (`key` requirement,
+   default-key derivation, path-mixing policy) in a shared utility.
+   Unblocks D11 and D12 fixes in one move; applications/workflows/
+   evaluators all call the same helper afterward.
+9. **C8 (second pass)** — extend coverage to 2.c, env-path cases, and
+   path-mixed cases now that the C3/C4/C5 behavior is stable.
+10. **C7** — user-facing docs sweep. Can run in parallel with C5/C8.
+11. **C9** — codify the five rules, precedence orders, and defaults in
+    `core/git/types.py` (or a dedicated `core/git/README.md`). Can run
+    in parallel with C7.
+12. **C1b** — `is_default` flag in `variant.flags` JSONB, backfill,
+    partial-unique index, set-default mutation, DAO read. Penultimate
+    because it touches every entity's variant data; safe to land after
+    the behavior-changing items because C1a holds the line in the
+    meantime. After C1b ships, C1a's `ORDER BY` becomes dead code and
+    can be removed in the same PR (or a follow-up).
+13. **C1.1b** — denormalize parent slugs onto variant and revision rows
+    (`artifact_slug` on variants; `artifact_slug` + `variant_slug` on
+    revisions). Backfill, write-path maintenance, DAO simplification.
+    Last because it's the largest migration in scope (two tables, six
+    entities) and depends on the rename-cascade decision being settled.
+    Bundling with C1b is optional but reduces the number of variant-
+    table ALTERs.
+
+C6, C1.1, C1a, C2, C3, C4, C7, C9 are each small, scoped PRs (one to a
+few files). C5 touches three routers but adds no schema. C7/C8 are
+docs/tests sweeps. C1b and C1.1b are the data-migration PRs and bring
+up the rear.

--- a/docs/design/playground-open-from-trace/followups.md
+++ b/docs/design/playground-open-from-trace/followups.md
@@ -722,6 +722,69 @@ that states the five rules, the precedence orders, the default rules, and
 the identifying-ref test. Links to this document for the discrepancies and
 change plan.
 
+### C10. Unify git-domain exception → HTTP translation — refactor
+
+Today every router that calls a git-pattern service catches the domain
+exception inline and translates to `HTTPException(400, detail=e.message)`.
+Inventory at this commit:
+
+- **12 inline `except` blocks** across 6 routers (workflows, applications,
+  evaluators, testsets, queries, environments).
+- **2 domain exceptions** today: `VariantForkError`, `RevisionRefInvalid`.
+- **+1 from C3:** `RevisionRefInconsistent`.
+- **+1 possibly from C4:** a variant-ref-version helper exception.
+
+Each new git-domain exception multiplies the boilerplate by the number of
+call sites. The codebase already has a cleaner pattern in `folders/`:
+
+- Typed `*Exception(HTTPException)` classes in
+  `apis/fastapi/folders/models.py`.
+- A domain decorator `@handle_folder_exceptions()` in
+  `apis/fastapi/folders/router.py:41` that maps core exceptions to typed
+  HTTP exceptions in one place.
+
+Apply the same shape to the git domain:
+
+1. Define typed exceptions in `apis/fastapi/shared/git_exceptions.py` (or
+   similar): `VariantForkErrorException`, `RevisionRefInvalidException`,
+   `RevisionRefInconsistentException`. All inherit from
+   `BadRequestException` (from `utils/exceptions.py:226`) which already
+   carries the 400 status.
+2. Define `@handle_git_exceptions()` decorator in the same module that
+   wraps a route function and maps each core exception to its typed
+   counterpart. Mirror `handle_folder_exceptions` at
+   `apis/fastapi/folders/router.py:41`.
+3. Apply the decorator to every retrieve/deploy/fork route across all six
+   routers. Remove the 12 inline `except` blocks. Net delta: -50 lines or
+   so across the routers, +30 lines in the shared module.
+4. Document in the module docstring that any new git-domain exception
+   added to `core/git/types.py` must also be registered in the decorator
+   and given a typed counterpart. Add a comment at the top of
+   `core/git/types.py` pointing at the registration site.
+
+Trade-offs against the current inline pattern:
+
+- **Pro:** new domain exceptions need updates in one place (the decorator
+  and typed-exception module), not N call sites.
+- **Pro:** typed exceptions can carry structured detail (`field`, `path`)
+  on top of the message, matching how `FolderNameInvalidException` is
+  shaped today. Useful for C3 where the error message names a specific
+  field — clients can parse it programmatically.
+- **Con:** indirection — reading a router no longer shows which
+  exceptions become which HTTP responses; you have to look at the
+  decorator. Mitigated by keeping the decorator small and naming each
+  mapping clearly.
+- **Con:** decorator placement matters with the existing
+  `@intercept_exceptions()` and `@suppress_exceptions()` stack. Need to
+  insert `@handle_git_exceptions()` between the route body and any
+  `suppress_exceptions(exclude=[HTTPException])` so the typed exception
+  is in the exclude list and gets re-raised. Same pattern as today's
+  inline `HTTPException` raise — no behavior change.
+
+Lands as a refactor, not a behavior change. No new tests beyond
+re-running the existing 400-assertions, which will continue to pass
+since the status code and message text are preserved.
+
 ---
 
 ## Suggested landing order
@@ -753,17 +816,22 @@ across all six entity tables.
    evaluators all call the same helper afterward.
 9. **C8 (second pass)** — extend coverage to 2.c, env-path cases, and
    path-mixed cases now that the C3/C4/C5 behavior is stable.
-10. **C7** — user-facing docs sweep. Can run in parallel with C5/C8.
-11. **C9** — codify the five rules, precedence orders, and defaults in
+10. **C10** — unify git-domain exception → HTTP translation. Replace the
+    12 inline `except` blocks with a `@handle_git_exceptions()` decorator
+    and typed `*Exception(BadRequestException)` classes. Lands after C3
+    and C4 so the new exceptions get migrated in one sweep. Pure
+    refactor; no behavior change.
+11. **C7** — user-facing docs sweep. Can run in parallel with C5/C8/C10.
+12. **C9** — codify the five rules, precedence orders, and defaults in
     `core/git/types.py` (or a dedicated `core/git/README.md`). Can run
     in parallel with C7.
-12. **C1b** — `is_default` flag in `variant.flags` JSONB, backfill,
+13. **C1b** — `is_default` flag in `variant.flags` JSONB, backfill,
     partial-unique index, set-default mutation, DAO read. Penultimate
     because it touches every entity's variant data; safe to land after
     the behavior-changing items because C1a holds the line in the
     meantime. After C1b ships, C1a's `ORDER BY` becomes dead code and
     can be removed in the same PR (or a follow-up).
-13. **C1.1b** — denormalize parent slugs onto variant and revision rows
+14. **C1.1b** — denormalize parent slugs onto variant and revision rows
     (`artifact_slug` on variants; `artifact_slug` + `variant_slug` on
     revisions). Backfill, write-path maintenance, DAO simplification.
     Last because it's the largest migration in scope (two tables, six

--- a/docs/design/playground-open-from-trace/followups.md
+++ b/docs/design/playground-open-from-trace/followups.md
@@ -3,7 +3,7 @@
 Companion to [`retrieve-endpoint-audit.md`](./retrieve-endpoint-audit.md). The audit doc describes the
 original bug, the data model, and PR #4418's guardrails. PR #4422 extended those
 guardrails to every git-backed entity by factoring the version-only check into
-`core/git/types.py::validate_revision_ref_unambiguous`.
+`core/git/types.py::validate_revision_refs_sufficient`.
 
 This document captures what is **still wrong or incomplete** about reference
 resolution at the retrieve surface, evaluated against the five rules below. The
@@ -442,7 +442,7 @@ D10–D13 are unobservable.
 
 ### D9. The five rules are not codified anywhere in the codebase
 
-`validate_revision_ref_unambiguous` enforces a fragment of 2.e. There is no
+`validate_revision_refs_sufficient` enforces a fragment of 2.e. There is no
 constant, comment block, or single doc string that lists the five rules,
 the precedence orders, or the default rules so future maintainers can match
 new validation to the right rule. This document is the first attempt at
@@ -655,7 +655,7 @@ On mismatch, raise a new `RetrieveRefsInconsistent(GitError)` and surface as
 
 ### C4. Catch variant-by-version analog — fixes D4 + D13
 
-Extend the helper (or add a sibling `validate_variant_ref_unambiguous`) to
+Extend the helper (or add a sibling `validate_variant_refs_sufficient`) to
 reject `{variant_ref:{version}}` without an `artifact_ref` (`id` or `slug`).
 Same shape, same reasoning. Call it from `fetch_*_variant` paths. Mirror the
 same check for the env-side: reject `{environment_revision_ref:{version}}`

--- a/docs/design/playground-open-from-trace/followups.md
+++ b/docs/design/playground-open-from-trace/followups.md
@@ -649,9 +649,9 @@ artifact/variant identity against what the caller sent:
   still belong to that same artifact. Otherwise the derived key looked up
   a slot the caller didn't actually mean — D15.
 
-On mismatch, raise a new `RevisionRefInconsistent(GitError)` and surface as
+On mismatch, raise a new `RetrieveRefsInconsistent(GitError)` and surface as
 400 naming the conflicting field. The exception and validator live in
-`core/git/types.py` next to `RevisionRefInvalid`.
+`core/git/types.py` next to `RetrieveRefsInsufficient`.
 
 ### C4. Catch variant-by-version analog — fixes D4 + D13
 
@@ -730,8 +730,8 @@ Inventory at this commit:
 
 - **12 inline `except` blocks** across 6 routers (workflows, applications,
   evaluators, testsets, queries, environments).
-- **2 domain exceptions** today: `VariantForkError`, `RevisionRefInvalid`.
-- **+1 from C3:** `RevisionRefInconsistent`.
+- **2 domain exceptions** today: `VariantForkError`, `RetrieveRefsInsufficient`.
+- **+1 from C3:** `RetrieveRefsInconsistent`.
 - **+1 possibly from C4:** a variant-ref-version helper exception.
 
 Each new git-domain exception multiplies the boilerplate by the number of
@@ -746,8 +746,8 @@ call sites. The codebase already has a cleaner pattern in `folders/`:
 Apply the same shape to the git domain:
 
 1. Define typed exceptions in `apis/fastapi/shared/git_exceptions.py` (or
-   similar): `VariantForkErrorException`, `RevisionRefInvalidException`,
-   `RevisionRefInconsistentException`. All inherit from
+   similar): `VariantForkErrorException`, `RetrieveRefsInsufficientException`,
+   `RetrieveRefsInconsistentException`. All inherit from
    `BadRequestException` (from `utils/exceptions.py:226`) which already
    carries the 400 status.
 2. Define `@handle_git_exceptions()` decorator in the same module that
@@ -805,7 +805,7 @@ across all six entity tables.
    any further change. Catches accidental regressions in the next steps.
 5. **C2** — lift the helper's `{artifact_ref + version}` rejection now
    that C1a makes the default-variant pick deterministic.
-6. **C3** — new `RevisionRefInconsistent` exception, post-resolution
+6. **C3** — new `RetrieveRefsInconsistent` exception, post-resolution
    consistency checks for entity-ref path, env-ref path, across-paths
    (explicit `key`), and across-paths (derived `key` / D15).
 7. **C4** — variant-by-version analog of the helper, plus the env-side

--- a/docs/docs/prompt-engineering/integrating-prompts/02-fetch-prompt-programatically.mdx
+++ b/docs/docs/prompt-engineering/integrating-prompts/02-fetch-prompt-programatically.mdx
@@ -263,6 +263,19 @@ curl -X POST "https://cloud.agenta.ai/api/applications/revisions/retrieve" \
   </TabItem>
 </Tabs>
 
+## How the request resolves
+
+You can identify the revision you want with any combination of:
+
+- `application_revision_ref` — by `id` or `slug`, or by `version` paired with a `application_variant_ref`.
+- `application_variant_ref` — picks the latest revision on that variant.
+- `application_ref` — picks the latest revision on the application's default variant.
+- `environment_ref` (+ optional `key`) — picks the revision currently deployed to that environment under the default key `{application_slug}.revision`.
+
+You may supply more than one reference. Every reference you send must agree with the resolved revision; if any contradicts, the endpoint returns `400 Bad Request` and the response detail names the field that disagreed.
+
+The endpoint also returns `400` when the references are not sufficient to identify a single revision — for example, when only `application_revision_ref.version` is provided (a per-variant sequence number with no variant context), or when only `application_variant_ref.version` is provided (variants do not have versions).
+
 ## Response Format
 
 The SDK returns the configuration parameters directly as a dictionary. When using the REST API, the response contains the full revision data including configuration under `params` along with reference metadata:

--- a/docs/docs/reference/api-guide/04-versioning.mdx
+++ b/docs/docs/reference/api-guide/04-versioning.mdx
@@ -60,12 +60,12 @@ The response contains the new revision with its `id`, `version`, `author`, `date
 References are how you point at something in the versioning tree. Each reference is a small object that identifies an artifact, variant, or revision.
 
 :::info
-A reference can be supplied as an `id`, a `slug`, or (for revisions) a `slug` plus `version`. For example:
+A reference can be supplied as an `id`, a `slug`, or — for revisions paired with a variant — a `version`. For example:
 
 ```json
 {"application_revision_ref": {"id": "019d9531-2e44-7c3a-b8cb-d6d8e675c18d"}}
-{"application_variant_ref": {"slug": "production"}}
-{"application_revision_ref": {"slug": "production", "version": 3}}
+{"application_variant_ref": {"slug": "default"}}
+{"application_variant_ref": {"slug": "default"}, "application_revision_ref": {"version": "3"}}
 {"environment_ref": {"slug": "production"}}
 ```
 :::
@@ -79,11 +79,19 @@ curl -X POST "$AGENTA_HOST/api/applications/revisions/retrieve" \
 
 The retrieve endpoint accepts any of:
 
-- `application_revision_ref`: a specific revision by `id` or by `slug` + `version`.
+- `application_revision_ref`: a specific revision by `id` or by `slug`.
+- `application_variant_ref` + `application_revision_ref.version`: a specific revision on that variant.
 - `application_variant_ref`: the latest revision on that variant.
-- `environment_ref`: the revision currently deployed to that environment.
+- `application_ref`: the latest revision on the artifact's default variant.
+- `environment_ref` (+ optional `key`): the revision currently deployed to that environment. The default key is `{application_slug}.revision`; provide an explicit `key` if you deployed the application under a different name.
 
-Only one reference is needed. If several are supplied, the most specific one wins: a revision reference is used over a variant reference, and a variant reference is used over an environment reference.
+You may pass several references in the same request — for example, `application_ref` plus `application_revision_ref.id` — but every supplied reference must agree with the resolved revision. The request returns `400 Bad Request` if:
+
+- A `revision_ref` carries only `version` (or a `variant_ref` carries only `version`) without an enclosing variant or artifact context. `version` is a per-variant sequence number; on its own it does not name a single revision.
+- A `variant_ref` carries only `version`. Variants do not have versions.
+- Any redundant reference contradicts the resolved revision. The detail message names the field that did not match.
+
+When the request is identifying but the row no longer exists, the endpoint returns `404 Not Found` rather than `400`.
 
 ## Listing revision history
 


### PR DESCRIPTION
## What was broken
Two revisions with the same `created_at` could swap places between `/revisions/retrieve` calls because the DAO had no tie-break. Every subsequent C-item depends on a stable answer.

## The fix
Add `created_at DESC, id DESC` to the DAO's `latest_revision` query. No behavior change for any well-ordered fixture.

## Notes
Stacked on #4418. First of 12 PRs (#4428–#4439).