### PR TITLE
[fix] Resolve retrieve-related issue 5: accept {artifact_ref + version}

### DIFF
--- a/api/oss/src/core/environments/service.py
+++ b/api/oss/src/core/environments/service.py
@@ -50,7 +50,10 @@ from oss.src.core.git.dtos import (
     VariantQuery,
 )
 from oss.src.core.git.interfaces import GitDAOInterface
-from oss.src.core.git.types import validate_revision_ref_unambiguous
+from oss.src.core.git.types import (
+    validate_revision_ref_unambiguous,
+    needs_default_variant_resolution,
+)
 from oss.src.core.shared.dtos import Reference, Windowing
 
 from oss.src.utils.logging import get_module_logger
@@ -621,10 +624,10 @@ class EnvironmentsService:
             entity_type="environment",
         )
 
-        if (
-            environment_ref
-            and not environment_variant_ref
-            and not environment_revision_ref
+        if needs_default_variant_resolution(
+            artifact_ref=environment_ref,
+            variant_ref=environment_variant_ref,
+            revision_ref=environment_revision_ref,
         ):
             environment = await self.fetch_environment(
                 project_id=project_id,

--- a/api/oss/src/core/git/types.py
+++ b/api/oss/src/core/git/types.py
@@ -31,7 +31,7 @@ class RevisionRefInvalid(GitError):
     """
 
 
-def _has_id_or_slug(ref: Optional[Reference]) -> bool:
+def _is_identifying(ref: Optional[Reference]) -> bool:
     """A `Reference` is "identifying" only if it carries an `id` or `slug`.
 
     An empty `Reference(id=None, slug=None, version=None)` is a truthy
@@ -41,6 +41,30 @@ def _has_id_or_slug(ref: Optional[Reference]) -> bool:
     return bool(ref and (ref.id or ref.slug))
 
 
+def needs_default_variant_resolution(
+    *,
+    artifact_ref: Optional[Reference],
+    variant_ref: Optional[Reference],
+    revision_ref: Optional[Reference],
+) -> bool:
+    """True when the service should resolve `artifact_ref` to its default variant
+    before reaching the DAO.
+
+    Fires when `artifact_ref` is identifying, `variant_ref` is not, and
+    `revision_ref` is not identifying either (it's None, empty, or
+    version-only). Both shapes — `{artifact_ref}` alone (latest-of-default)
+    and `{artifact_ref + version}` (specific-version-on-default) — need the
+    same artifact→variant resolution to give the DAO a usable variant scope.
+    """
+    if not _is_identifying(artifact_ref):
+        return False
+    if _is_identifying(variant_ref):
+        return False
+    if _is_identifying(revision_ref):
+        return False
+    return True
+
+
 def validate_revision_ref_unambiguous(
     *,
     artifact_ref: Optional[Reference],
@@ -48,27 +72,17 @@ def validate_revision_ref_unambiguous(
     revision_ref: Optional[Reference],
     entity_type: str = "artifact",
 ) -> None:
-    """Reject revision-retrieve requests that cannot identify a single revision.
+    """Reject requests whose refs are insufficient to identify a single revision (rule 2.e).
 
     Rule enforced: if `revision_ref.version` is set and neither
     `revision_ref.id` nor `revision_ref.slug` is set, the request must
-    carry a `variant_ref` with `id` or `slug`. Without that scope, the same
-    `version` value exists across many variants and cannot identify a
-    single revision; the DAO would silently return an arbitrary row.
+    carry either a `variant_ref` with `id`/`slug` OR an `artifact_ref` with
+    `id`/`slug`. Either is sufficient to scope the version lookup: a
+    variant directly scopes it, an artifact scopes it via the
+    default-variant fallback (deterministic ORDER BY at the DAO).
 
     The all-empty case (no refs at all) is intentionally NOT raised here —
     callers handle that as "nothing to look up" and return `None`.
-
-    Note on `artifact_ref`: in principle a populated `artifact_ref` is also
-    sufficient to scope a version lookup, because the service can resolve
-    artifact → default variant → revision. This helper does NOT accept
-    `artifact_ref` alone today because that resolution path (the default-
-    variant pick) is non-deterministic for multi-variant artifacts in the
-    current code. Once that lookup becomes deterministic, callers can
-    resolve `artifact_ref` → `variant_ref` before invoking this helper and
-    the same shape will pass without changing this function. `artifact_ref`
-    is accepted as a parameter for forward compatibility (future cross-ref
-    mismatch validation, rule 2.c) but is not consulted today.
 
     `entity_type` is interpolated into the error message ("workflow",
     "testset", ...) so callers across entities can keep their messages
@@ -83,13 +97,13 @@ def validate_revision_ref_unambiguous(
     if not revision_version_only:
         return
 
-    if _has_id_or_slug(variant_ref):
+    if _is_identifying(variant_ref) or _is_identifying(artifact_ref):
         return
 
     raise RevisionRefInvalid(
         f"{entity_type}_revision_ref.version is a per-variant sequence number "
-        f"and requires a {entity_type}_variant_ref to be unambiguous. "
-        f"Provide a {entity_type}_variant_ref, or identify the revision by "
+        f"and requires a {entity_type}_variant_ref or {entity_type}_ref to "
+        f"scope it. Provide either, or identify the revision by "
         f"{entity_type}_revision_ref.id or {entity_type}_revision_ref.slug "
         f"(both are project-unique)."
     )

--- a/api/oss/src/core/queries/service.py
+++ b/api/oss/src/core/queries/service.py
@@ -6,7 +6,10 @@ from oss.src.utils.logging import get_module_logger
 
 from oss.src.core.events.utils import publish_revision_event
 from oss.src.core.git.interfaces import GitDAOInterface
-from oss.src.core.git.types import validate_revision_ref_unambiguous
+from oss.src.core.git.types import (
+    validate_revision_ref_unambiguous,
+    needs_default_variant_resolution,
+)
 from oss.src.core.shared.dtos import Reference, Windowing, Trace, Traces
 from oss.src.core.tracing.dtos import (
     TracingQuery,
@@ -654,7 +657,11 @@ class QueriesService:
             entity_type="query",
         )
 
-        if query_ref and not query_variant_ref and not query_revision_ref:
+        if needs_default_variant_resolution(
+            artifact_ref=query_ref,
+            variant_ref=query_variant_ref,
+            revision_ref=query_revision_ref,
+        ):
             query = await self.fetch_query(
                 project_id=project_id,
                 #

--- a/api/oss/src/core/testsets/service.py
+++ b/api/oss/src/core/testsets/service.py
@@ -4,7 +4,10 @@ from uuid import UUID, uuid4
 from oss.src.utils.logging import get_module_logger
 from oss.src.core.events.utils import publish_revision_event
 from oss.src.core.git.interfaces import GitDAOInterface
-from oss.src.core.git.types import validate_revision_ref_unambiguous
+from oss.src.core.git.types import (
+    validate_revision_ref_unambiguous,
+    needs_default_variant_resolution,
+)
 from oss.src.core.testcases.service import TestcasesService
 from oss.src.core.shared.dtos import Reference, Windowing
 from oss.src.core.git.dtos import (
@@ -644,7 +647,11 @@ class TestsetsService:
             entity_type="testset",
         )
 
-        if testset_ref and not testset_variant_ref and not testset_revision_ref:
+        if needs_default_variant_resolution(
+            artifact_ref=testset_ref,
+            variant_ref=testset_variant_ref,
+            revision_ref=testset_revision_ref,
+        ):
             testset = await self.fetch_testset(
                 project_id=project_id,
                 #

--- a/api/oss/src/core/workflows/service.py
+++ b/api/oss/src/core/workflows/service.py
@@ -79,7 +79,10 @@ from oss.src.core.workflows.dtos import (
     WorkflowServiceBatchResponse,
     WorkflowServiceStreamResponse,
 )
-from oss.src.core.git.types import validate_revision_ref_unambiguous
+from oss.src.core.git.types import (
+    validate_revision_ref_unambiguous,
+    needs_default_variant_resolution,
+)
 
 # Resolution is now handled by EmbedsService
 from oss.src.core.embeds.dtos import (
@@ -1087,7 +1090,11 @@ class WorkflowsService:
             entity_type="workflow",
         )
 
-        if workflow_ref and not workflow_variant_ref and not workflow_revision_ref:
+        if needs_default_variant_resolution(
+            artifact_ref=workflow_ref,
+            variant_ref=workflow_variant_ref,
+            revision_ref=workflow_revision_ref,
+        ):
             workflow = await self.fetch_workflow(
                 project_id=project_id,
                 #

--- a/api/oss/tests/pytest/acceptance/test_revision_retrieve_ambiguous_400.py
+++ b/api/oss/tests/pytest/acceptance/test_revision_retrieve_ambiguous_400.py
@@ -91,19 +91,6 @@ def test_workflows_retrieve_version_only_returns_400(authed_api):
     _assert_ambiguous_400(response)
 
 
-def test_workflows_retrieve_artifact_plus_version_returns_400(authed_api):
-    workflow, _, _ = _create_workflow_stack(authed_api)
-    response = authed_api(
-        "POST",
-        "/workflows/revisions/retrieve",
-        json={
-            "workflow_ref": {"slug": workflow["slug"]},
-            "workflow_revision_ref": {"version": "1"},
-        },
-    )
-    _assert_ambiguous_400(response)
-
-
 def test_workflows_retrieve_variant_plus_version_succeeds(authed_api):
     _, variant, revision = _create_workflow_stack(authed_api)
     response = authed_api(
@@ -167,19 +154,6 @@ def test_applications_retrieve_version_only_returns_400(authed_api):
         "POST",
         "/applications/revisions/retrieve",
         json={"application_revision_ref": {"version": "1"}},
-    )
-    _assert_ambiguous_400(response)
-
-
-def test_applications_retrieve_artifact_plus_version_returns_400(authed_api):
-    app, _, _ = _create_application_stack(authed_api)
-    response = authed_api(
-        "POST",
-        "/applications/revisions/retrieve",
-        json={
-            "application_ref": {"slug": app["slug"]},
-            "application_revision_ref": {"version": "1"},
-        },
     )
     _assert_ambiguous_400(response)
 
@@ -251,19 +225,6 @@ def test_evaluators_retrieve_version_only_returns_400(authed_api):
     _assert_ambiguous_400(response)
 
 
-def test_evaluators_retrieve_artifact_plus_version_returns_400(authed_api):
-    evaluator, _, _ = _create_evaluator_stack(authed_api)
-    response = authed_api(
-        "POST",
-        "/evaluators/revisions/retrieve",
-        json={
-            "evaluator_ref": {"slug": evaluator["slug"]},
-            "evaluator_revision_ref": {"version": "1"},
-        },
-    )
-    _assert_ambiguous_400(response)
-
-
 def test_evaluators_retrieve_variant_plus_version_succeeds(authed_api):
     _, variant, revision = _create_evaluator_stack(authed_api)
     response = authed_api(
@@ -329,19 +290,6 @@ def test_testsets_retrieve_version_only_returns_400(authed_api):
     _assert_ambiguous_400(response)
 
 
-def test_testsets_retrieve_artifact_plus_version_returns_400(authed_api):
-    testset, _, _ = _create_testset_stack(authed_api)
-    response = authed_api(
-        "POST",
-        "/testsets/revisions/retrieve",
-        json={
-            "testset_ref": {"slug": testset["slug"]},
-            "testset_revision_ref": {"version": "1"},
-        },
-    )
-    _assert_ambiguous_400(response)
-
-
 def test_testsets_retrieve_variant_plus_version_succeeds(authed_api):
     _, variant, revision = _create_testset_stack(authed_api)
     response = authed_api(
@@ -396,19 +344,6 @@ def test_queries_retrieve_version_only_returns_400(authed_api):
         "POST",
         "/queries/revisions/retrieve",
         json={"query_revision_ref": {"version": "1"}},
-    )
-    _assert_ambiguous_400(response)
-
-
-def test_queries_retrieve_artifact_plus_version_returns_400(authed_api):
-    query, _ = _create_query_stack(authed_api)
-    response = authed_api(
-        "POST",
-        "/queries/revisions/retrieve",
-        json={
-            "query_ref": {"slug": query["slug"]},
-            "query_revision_ref": {"version": "1"},
-        },
     )
     _assert_ambiguous_400(response)
 
@@ -475,19 +410,6 @@ def test_environments_retrieve_version_only_returns_400(authed_api):
         "POST",
         "/environments/revisions/retrieve",
         json={"environment_revision_ref": {"version": "1"}},
-    )
-    _assert_ambiguous_400(response)
-
-
-def test_environments_retrieve_artifact_plus_version_returns_400(authed_api):
-    environment, _, _ = _create_environment_stack(authed_api)
-    response = authed_api(
-        "POST",
-        "/environments/revisions/retrieve",
-        json={
-            "environment_ref": {"slug": environment["slug"]},
-            "environment_revision_ref": {"version": "1"},
-        },
     )
     _assert_ambiguous_400(response)
 

--- a/api/oss/tests/pytest/acceptance/test_revision_retrieve_positive.py
+++ b/api/oss/tests/pytest/acceptance/test_revision_retrieve_positive.py
@@ -124,6 +124,22 @@ def test_workflows_retrieve_by_artifact_slug_picks_default_variant_latest(authed
     assert response.json()["workflow_revision"]["id"] == revision["id"]
 
 
+def test_workflows_retrieve_by_artifact_slug_and_version_resolves_default_variant(
+    authed_api,
+):
+    workflow, _, revision = _create_workflow_stack(authed_api)
+    response = authed_api(
+        "POST",
+        "/workflows/revisions/retrieve",
+        json={
+            "workflow_ref": {"slug": workflow["slug"]},
+            "workflow_revision_ref": {"version": revision["version"]},
+        },
+    )
+    assert response.status_code == 200, response.text
+    assert response.json()["workflow_revision"]["id"] == revision["id"]
+
+
 def test_workflows_retrieve_with_redundant_consistent_refs(authed_api):
     workflow, variant, revision = _create_workflow_stack(authed_api)
     response = authed_api(
@@ -238,6 +254,22 @@ def test_applications_retrieve_by_artifact_slug_picks_default_variant_latest(
         "POST",
         "/applications/revisions/retrieve",
         json={"application_ref": {"slug": app["slug"]}},
+    )
+    assert response.status_code == 200, response.text
+    assert response.json()["application_revision"]["id"] == revision["id"]
+
+
+def test_applications_retrieve_by_artifact_slug_and_version_resolves_default_variant(
+    authed_api,
+):
+    app, _, revision = _create_application_stack(authed_api)
+    response = authed_api(
+        "POST",
+        "/applications/revisions/retrieve",
+        json={
+            "application_ref": {"slug": app["slug"]},
+            "application_revision_ref": {"version": revision["version"]},
+        },
     )
     assert response.status_code == 200, response.text
     assert response.json()["application_revision"]["id"] == revision["id"]
@@ -362,6 +394,22 @@ def test_evaluators_retrieve_by_artifact_slug_picks_default_variant_latest(
     assert response.json()["evaluator_revision"]["id"] == revision["id"]
 
 
+def test_evaluators_retrieve_by_artifact_slug_and_version_resolves_default_variant(
+    authed_api,
+):
+    evaluator, _, revision = _create_evaluator_stack(authed_api)
+    response = authed_api(
+        "POST",
+        "/evaluators/revisions/retrieve",
+        json={
+            "evaluator_ref": {"slug": evaluator["slug"]},
+            "evaluator_revision_ref": {"version": revision["version"]},
+        },
+    )
+    assert response.status_code == 200, response.text
+    assert response.json()["evaluator_revision"]["id"] == revision["id"]
+
+
 def test_evaluators_retrieve_with_redundant_consistent_refs(authed_api):
     evaluator, variant, revision = _create_evaluator_stack(authed_api)
     response = authed_api(
@@ -477,6 +525,22 @@ def test_testsets_retrieve_by_artifact_slug_picks_default_variant_latest(authed_
     assert response.json()["testset_revision"]["id"] == revision["id"]
 
 
+def test_testsets_retrieve_by_artifact_slug_and_version_resolves_default_variant(
+    authed_api,
+):
+    testset, _, revision = _create_testset_stack(authed_api)
+    response = authed_api(
+        "POST",
+        "/testsets/revisions/retrieve",
+        json={
+            "testset_ref": {"slug": testset["slug"]},
+            "testset_revision_ref": {"version": revision["version"]},
+        },
+    )
+    assert response.status_code == 200, response.text
+    assert response.json()["testset_revision"]["id"] == revision["id"]
+
+
 def test_testsets_retrieve_with_redundant_consistent_refs(authed_api):
     testset, variant, revision = _create_testset_stack(authed_api)
     response = authed_api(
@@ -580,6 +644,22 @@ def test_queries_retrieve_by_artifact_slug_picks_default_variant_latest(authed_a
         "POST",
         "/queries/revisions/retrieve",
         json={"query_ref": {"slug": query["slug"]}},
+    )
+    assert response.status_code == 200, response.text
+    assert response.json()["query_revision"]["id"] == revision["id"]
+
+
+def test_queries_retrieve_by_artifact_slug_and_version_resolves_default_variant(
+    authed_api,
+):
+    query, revision = _create_query_stack(authed_api)
+    response = authed_api(
+        "POST",
+        "/queries/revisions/retrieve",
+        json={
+            "query_ref": {"slug": query["slug"]},
+            "query_revision_ref": {"version": revision["version"]},
+        },
     )
     assert response.status_code == 200, response.text
     assert response.json()["query_revision"]["id"] == revision["id"]
@@ -697,6 +777,22 @@ def test_environments_retrieve_by_artifact_slug_picks_default_variant_latest(
         "POST",
         "/environments/revisions/retrieve",
         json={"environment_ref": {"slug": environment["slug"]}},
+    )
+    assert response.status_code == 200, response.text
+    assert response.json()["environment_revision"]["id"] == revision["id"]
+
+
+def test_environments_retrieve_by_artifact_slug_and_version_resolves_default_variant(
+    authed_api,
+):
+    environment, _, revision = _create_environment_stack(authed_api)
+    response = authed_api(
+        "POST",
+        "/environments/revisions/retrieve",
+        json={
+            "environment_ref": {"slug": environment["slug"]},
+            "environment_revision_ref": {"version": revision["version"]},
+        },
     )
     assert response.status_code == 200, response.text
     assert response.json()["environment_revision"]["id"] == revision["id"]

--- a/api/oss/tests/pytest/unit/test_revision_ref_validation.py
+++ b/api/oss/tests/pytest/unit/test_revision_ref_validation.py
@@ -59,18 +59,6 @@ class TestVersionOnlyRejection:
                 revision_ref=_ref(version="1"),
             )
 
-    def test_version_only_with_artifact_ref_still_raises(self):
-        # artifact_ref alone is not enough to scope a version today (the
-        # service would have to resolve artifact → default variant first,
-        # which is non-deterministic for multi-variant artifacts). Helper
-        # is conservative until that resolution is fixed.
-        with pytest.raises(RevisionRefInvalid):
-            validate_revision_ref_unambiguous(
-                artifact_ref=_ref(slug="my-workflow"),
-                variant_ref=None,
-                revision_ref=_ref(version="1"),
-            )
-
     def test_entity_type_appears_in_message(self):
         with pytest.raises(RevisionRefInvalid) as exc:
             validate_revision_ref_unambiguous(
@@ -95,7 +83,11 @@ class TestVersionOnlyRejection:
 # version-only with sufficient variant scope ---------------------------------
 
 
-class TestVersionOnlyWithVariantPasses:
+class TestVersionOnlyWithScopePasses:
+    """Either a variant_ref or an artifact_ref is sufficient scope for the
+    version filter — variant directly, artifact via the deterministic
+    default-variant fallback."""
+
     def test_variant_id_scopes_version(self):
         validate_revision_ref_unambiguous(
             artifact_ref=None,
@@ -107,6 +99,20 @@ class TestVersionOnlyWithVariantPasses:
         validate_revision_ref_unambiguous(
             artifact_ref=None,
             variant_ref=_ref(slug="my-variant"),
+            revision_ref=_ref(version="1"),
+        )
+
+    def test_artifact_id_scopes_version(self):
+        validate_revision_ref_unambiguous(
+            artifact_ref=_ref(id=uuid4()),
+            variant_ref=None,
+            revision_ref=_ref(version="1"),
+        )
+
+    def test_artifact_slug_scopes_version(self):
+        validate_revision_ref_unambiguous(
+            artifact_ref=_ref(slug="my-workflow"),
+            variant_ref=None,
             revision_ref=_ref(version="1"),
         )
 

--- a/docs/design/playground-open-from-trace/followups.md
+++ b/docs/design/playground-open-from-trace/followups.md
@@ -352,7 +352,7 @@ def is_identifying(ref: Optional[Reference]) -> bool:
 
 `bool(ref)` alone is not enough — `Reference(id=None, slug=None,
 version=None)` is truthy but unidentifying. This is the implementation of
-`_has_id_or_slug` in `core/git/types.py` and is the formal definition the
+`_is_identifying` in `core/git/types.py` and is the formal definition the
 rules above depend on.
 
 ---


### PR DESCRIPTION
## What was broken
`{artifact_ref + revision_ref.version}` was rejected with 400 even though it now identifies a single revision (PR #4430 made the default-variant pick deterministic).

## The fix
Lift the rejection in `validate_revision_refs_sufficient`. The service resolves the artifact's default variant, then looks up the version on it.

## Notes
Stacked on #4431.