### PR TITLE
[fix] Resolve retrieve-related issue 6: reject inconsistent retrieve refs

### DIFF
--- a/api/oss/src/apis/fastapi/applications/models.py
+++ b/api/oss/src/apis/fastapi/applications/models.py
@@ -361,9 +361,9 @@ class ApplicationRevisionCommitRequest(BaseModel):
 class ApplicationRevisionRetrieveRequest(BaseModel):
     """Request body for `POST /applications/revisions/retrieve`.
 
-    Resolves to a single revision by one of several reference types. Exactly one
-    reference path is needed; the most specific wins when several are provided.
-    See the [Applications guide](/reference/api-guide/applications#invocation).
+    Resolves to a single revision by one or more reference types. Every
+    reference supplied must agree with the resolved revision; contradictions
+    return HTTP 400. See the [Applications guide](/reference/api-guide/applications#invocation).
     """
 
     application_ref: Optional[Reference] = Field(
@@ -371,8 +371,8 @@ class ApplicationRevisionRetrieveRequest(BaseModel):
         description=(
             "Application artifact to look up. Identifies the artifact by `id` "
             "or `slug` (both project-unique). When no variant_ref or "
-            "revision_ref is provided, returns the latest revision of an "
-            "arbitrary variant of this application."
+            "revision_ref is provided, returns the latest revision of the "
+            "application's default variant."
         ),
     )
     application_variant_ref: Optional[Reference] = Field(

--- a/api/oss/src/apis/fastapi/applications/router.py
+++ b/api/oss/src/apis/fastapi/applications/router.py
@@ -10,11 +10,7 @@ from oss.src.utils.caching import invalidate_cache
 
 from oss.src.core.events.utils import publish_revision_event
 
-from oss.src.core.git.types import (
-    VariantForkError,
-    RetrieveRefsInsufficient,
-    RetrieveRefsInconsistent,
-)
+from oss.src.apis.fastapi.git.exceptions import handle_git_exceptions
 from oss.src.core.shared.dtos import (
     Reference,
 )
@@ -1066,6 +1062,7 @@ class ApplicationsRouter:
         return application_variants_response
 
     @intercept_exceptions()
+    @handle_git_exceptions()
     async def fork_application_variant(
         self,
         request: Request,
@@ -1105,20 +1102,12 @@ class ApplicationsRouter:
             if not fork_request.application_variant_id:
                 fork_request.application_variant_id = application_variant_id
 
-        try:
-            application_variant = (
-                await self.applications_service.fork_application_variant(
-                    project_id=UUID(request.state.project_id),
-                    user_id=UUID(request.state.user_id),
-                    #
-                    application_fork=fork_request,
-                )
-            )
-        except VariantForkError as e:
-            raise HTTPException(
-                status_code=status.HTTP_400_BAD_REQUEST,
-                detail=e.message,
-            ) from e
+        application_variant = await self.applications_service.fork_application_variant(
+            project_id=UUID(request.state.project_id),
+            user_id=UUID(request.state.user_id),
+            #
+            application_fork=fork_request,
+        )
 
         application_variant_response = ApplicationVariantResponse(
             count=1 if application_variant else 0,
@@ -1130,6 +1119,7 @@ class ApplicationsRouter:
     # APPLICATION REVISIONS ----------------------------------------------------
 
     @intercept_exceptions()
+    @handle_git_exceptions()
     async def deploy_application_revision(
         self,
         request: Request,
@@ -1182,19 +1172,13 @@ class ApplicationsRouter:
                 detail="Application deploy requires environment refs.",
             )
 
-        try:
-            application_revision = await self.applications_service.fetch_application_revision(
-                project_id=UUID(request.state.project_id),
-                #
-                application_ref=application_deploy_request.application_ref,
-                application_variant_ref=application_deploy_request.application_variant_ref,
-                application_revision_ref=application_deploy_request.application_revision_ref,
-            )
-        except (RetrieveRefsInsufficient, RetrieveRefsInconsistent) as e:
-            raise HTTPException(
-                status_code=status.HTTP_400_BAD_REQUEST,
-                detail=e.message,
-            ) from e
+        application_revision = await self.applications_service.fetch_application_revision(
+            project_id=UUID(request.state.project_id),
+            #
+            application_ref=application_deploy_request.application_ref,
+            application_variant_ref=application_deploy_request.application_variant_ref,
+            application_revision_ref=application_deploy_request.application_revision_ref,
+        )
 
         if not application_revision:
             raise HTTPException(
@@ -1303,6 +1287,7 @@ class ApplicationsRouter:
 
     @intercept_exceptions()
     @suppress_exceptions(default=ApplicationRevisionResponse(), exclude=[HTTPException])
+    @handle_git_exceptions()
     async def retrieve_application_revision(
         self,
         request: Request,
@@ -1394,29 +1379,23 @@ class ApplicationsRouter:
                         detail="Environment-backed application retrieve requires key.",
                     )
 
-        try:
-            (
-                application_revision,
-                resolution_info,
-            ) = await self.applications_service.retrieve_application_revision(
-                project_id=UUID(request.state.project_id),
-                #
-                environment_ref=environment_ref,
-                environment_variant_ref=environment_variant_ref,
-                environment_revision_ref=environment_revision_ref,
-                key=key,
-                #
-                application_ref=application_ref,
-                application_variant_ref=application_variant_ref,
-                application_revision_ref=application_revision_ref,
-                #
-                resolve=application_revision_retrieve_request.resolve or False,
-            )
-        except (RetrieveRefsInsufficient, RetrieveRefsInconsistent) as e:
-            raise HTTPException(
-                status_code=status.HTTP_400_BAD_REQUEST,
-                detail=e.message,
-            ) from e
+        (
+            application_revision,
+            resolution_info,
+        ) = await self.applications_service.retrieve_application_revision(
+            project_id=UUID(request.state.project_id),
+            #
+            environment_ref=environment_ref,
+            environment_variant_ref=environment_variant_ref,
+            environment_revision_ref=environment_revision_ref,
+            key=key,
+            #
+            application_ref=application_ref,
+            application_variant_ref=application_variant_ref,
+            application_revision_ref=application_revision_ref,
+            #
+            resolve=application_revision_retrieve_request.resolve or False,
+        )
 
         if environment_lookup_requested and not application_revision:
             raise HTTPException(

--- a/api/oss/src/apis/fastapi/applications/router.py
+++ b/api/oss/src/apis/fastapi/applications/router.py
@@ -10,7 +10,11 @@ from oss.src.utils.caching import invalidate_cache
 
 from oss.src.core.events.utils import publish_revision_event
 
-from oss.src.core.git.types import VariantForkError, RevisionRefInvalid
+from oss.src.core.git.types import (
+    VariantForkError,
+    RetrieveRefsInsufficient,
+    RetrieveRefsInconsistent,
+)
 from oss.src.core.shared.dtos import (
     Reference,
 )
@@ -1186,7 +1190,7 @@ class ApplicationsRouter:
                 application_variant_ref=application_deploy_request.application_variant_ref,
                 application_revision_ref=application_deploy_request.application_revision_ref,
             )
-        except RevisionRefInvalid as e:
+        except (RetrieveRefsInsufficient, RetrieveRefsInconsistent) as e:
             raise HTTPException(
                 status_code=status.HTTP_400_BAD_REQUEST,
                 detail=e.message,
@@ -1408,7 +1412,7 @@ class ApplicationsRouter:
                 #
                 resolve=application_revision_retrieve_request.resolve or False,
             )
-        except RevisionRefInvalid as e:
+        except (RetrieveRefsInsufficient, RetrieveRefsInconsistent) as e:
             raise HTTPException(
                 status_code=status.HTTP_400_BAD_REQUEST,
                 detail=e.message,

--- a/api/oss/src/apis/fastapi/environments/router.py
+++ b/api/oss/src/apis/fastapi/environments/router.py
@@ -8,7 +8,7 @@ from oss.src.utils.logging import get_module_logger
 from oss.src.utils.exceptions import intercept_exceptions, suppress_exceptions
 
 from oss.src.core.events.utils import publish_revision_event
-from oss.src.core.git.types import RevisionRefInvalid
+from oss.src.core.git.types import RetrieveRefsInsufficient, RetrieveRefsInconsistent
 
 from oss.src.core.shared.dtos import (
     Reference,
@@ -769,7 +769,7 @@ class EnvironmentsRouter:
                 #
                 resolve=bool(environment_revision_retrieve_request.resolve),
             )
-        except RevisionRefInvalid as e:
+        except (RetrieveRefsInsufficient, RetrieveRefsInconsistent) as e:
             raise HTTPException(
                 status_code=status.HTTP_400_BAD_REQUEST,
                 detail=e.message,

--- a/api/oss/src/apis/fastapi/environments/router.py
+++ b/api/oss/src/apis/fastapi/environments/router.py
@@ -8,7 +8,7 @@ from oss.src.utils.logging import get_module_logger
 from oss.src.utils.exceptions import intercept_exceptions, suppress_exceptions
 
 from oss.src.core.events.utils import publish_revision_event
-from oss.src.core.git.types import RetrieveRefsInsufficient, RetrieveRefsInconsistent
+from oss.src.apis.fastapi.git.exceptions import handle_git_exceptions
 
 from oss.src.core.shared.dtos import (
     Reference,
@@ -742,6 +742,7 @@ class EnvironmentsRouter:
     # ENVIRONMENT REVISIONS ------------------------------------------------
 
     @intercept_exceptions()
+    @handle_git_exceptions()
     async def retrieve_environment_revision(
         self,
         request: Request,
@@ -756,24 +757,18 @@ class EnvironmentsRouter:
             ):
                 raise FORBIDDEN_EXCEPTION  # type: ignore
 
-        try:
-            (
-                environment_revision,
-                resolution_info,
-            ) = await self.environments_service.retrieve_environment_revision(
-                project_id=UUID(request.state.project_id),
-                #
-                environment_ref=environment_revision_retrieve_request.environment_ref,  # type: ignore
-                environment_variant_ref=environment_revision_retrieve_request.environment_variant_ref,  # type: ignore
-                environment_revision_ref=environment_revision_retrieve_request.environment_revision_ref,  # type: ignore
-                #
-                resolve=bool(environment_revision_retrieve_request.resolve),
-            )
-        except (RetrieveRefsInsufficient, RetrieveRefsInconsistent) as e:
-            raise HTTPException(
-                status_code=status.HTTP_400_BAD_REQUEST,
-                detail=e.message,
-            ) from e
+        (
+            environment_revision,
+            resolution_info,
+        ) = await self.environments_service.retrieve_environment_revision(
+            project_id=UUID(request.state.project_id),
+            #
+            environment_ref=environment_revision_retrieve_request.environment_ref,  # type: ignore
+            environment_variant_ref=environment_revision_retrieve_request.environment_variant_ref,  # type: ignore
+            environment_revision_ref=environment_revision_retrieve_request.environment_revision_ref,  # type: ignore
+            #
+            resolve=bool(environment_revision_retrieve_request.resolve),
+        )
 
         environment_revision_response = EnvironmentRevisionResponse(
             count=1 if environment_revision else 0,

--- a/api/oss/src/apis/fastapi/evaluators/models.py
+++ b/api/oss/src/apis/fastapi/evaluators/models.py
@@ -285,7 +285,10 @@ class EvaluatorRevisionCommitRequest(BaseModel):
 class EvaluatorRevisionRetrieveRequest(BaseModel):
     """Body for retrieving one revision, either by direct reference or through an environment key.
 
-    Provide one of: an evaluator / variant / revision reference, or an environment reference plus `key`.
+    Provide an evaluator / variant / revision reference, an environment
+    reference (with `key` derived from the evaluator slug by default), or a
+    combination of both. Every reference supplied must agree with the
+    resolved revision; contradictions return HTTP 400.
     """
 
     evaluator_ref: Optional[Reference] = Field(
@@ -293,8 +296,8 @@ class EvaluatorRevisionRetrieveRequest(BaseModel):
         description=(
             "Evaluator artifact to look up. Identifies the artifact by `id` "
             "or `slug` (both project-unique). When no variant_ref or "
-            "revision_ref is provided, returns the latest revision of an "
-            "arbitrary variant of this evaluator."
+            "revision_ref is provided, returns the latest revision of the "
+            "evaluator's default variant."
         ),
     )
     evaluator_variant_ref: Optional[Reference] = Field(

--- a/api/oss/src/apis/fastapi/evaluators/router.py
+++ b/api/oss/src/apis/fastapi/evaluators/router.py
@@ -1344,14 +1344,6 @@ class EvaluatorsRouter:
         )
         environment_lookup_requested = environment_refs_requested or key is not None
 
-        if evaluator_lookup_requested and environment_lookup_requested:
-            raise HTTPException(
-                status_code=status.HTTP_400_BAD_REQUEST,
-                detail=(
-                    "Provide either evaluator refs or environment refs with key, not both."
-                ),
-            )
-
         if not evaluator_lookup_requested and not environment_lookup_requested:
             raise HTTPException(
                 status_code=status.HTTP_400_BAD_REQUEST,
@@ -1368,10 +1360,24 @@ class EvaluatorsRouter:
                 )
 
             if not key:
-                raise HTTPException(
-                    status_code=status.HTTP_400_BAD_REQUEST,
-                    detail="Environment-backed evaluator retrieve requires key.",
-                )
+                if evaluator_ref and evaluator_ref.slug:
+                    key = f"{evaluator_ref.slug}.revision"
+                elif evaluator_ref and evaluator_ref.id:
+                    evaluator = await self.evaluators_service.fetch_evaluator(
+                        project_id=UUID(request.state.project_id),
+                        evaluator_ref=evaluator_ref,
+                    )
+                    if not evaluator or not evaluator.slug:
+                        raise HTTPException(
+                            status_code=status.HTTP_400_BAD_REQUEST,
+                            detail="Environment-backed evaluator retrieve could not derive key from evaluator slug.",
+                        )
+                    key = f"{evaluator.slug}.revision"
+                else:
+                    raise HTTPException(
+                        status_code=status.HTTP_400_BAD_REQUEST,
+                        detail="Environment-backed evaluator retrieve requires key.",
+                    )
 
         try:
             (

--- a/api/oss/src/apis/fastapi/evaluators/router.py
+++ b/api/oss/src/apis/fastapi/evaluators/router.py
@@ -10,7 +10,11 @@ from oss.src.utils.caching import invalidate_cache
 
 from oss.src.core.events.utils import publish_revision_event
 
-from oss.src.core.git.types import VariantForkError, RevisionRefInvalid
+from oss.src.core.git.types import (
+    VariantForkError,
+    RetrieveRefsInsufficient,
+    RetrieveRefsInconsistent,
+)
 from oss.src.core.shared.dtos import (
     Reference,
 )
@@ -1177,7 +1181,7 @@ class EvaluatorsRouter:
                 evaluator_variant_ref=evaluator_deploy_request.evaluator_variant_ref,
                 evaluator_revision_ref=evaluator_deploy_request.evaluator_revision_ref,
             )
-        except RevisionRefInvalid as e:
+        except (RetrieveRefsInsufficient, RetrieveRefsInconsistent) as e:
             raise HTTPException(
                 status_code=status.HTTP_400_BAD_REQUEST,
                 detail=e.message,
@@ -1387,7 +1391,7 @@ class EvaluatorsRouter:
                 #
                 resolve=evaluator_revision_retrieve_request.resolve or False,
             )
-        except RevisionRefInvalid as e:
+        except (RetrieveRefsInsufficient, RetrieveRefsInconsistent) as e:
             raise HTTPException(
                 status_code=status.HTTP_400_BAD_REQUEST,
                 detail=e.message,

--- a/api/oss/src/apis/fastapi/evaluators/router.py
+++ b/api/oss/src/apis/fastapi/evaluators/router.py
@@ -10,11 +10,7 @@ from oss.src.utils.caching import invalidate_cache
 
 from oss.src.core.events.utils import publish_revision_event
 
-from oss.src.core.git.types import (
-    VariantForkError,
-    RetrieveRefsInsufficient,
-    RetrieveRefsInconsistent,
-)
+from oss.src.apis.fastapi.git.exceptions import handle_git_exceptions
 from oss.src.core.shared.dtos import (
     Reference,
 )
@@ -1062,6 +1058,7 @@ class EvaluatorsRouter:
         return evaluator_variants_response
 
     @intercept_exceptions()  # TODO: FIX ME
+    @handle_git_exceptions()
     async def fork_evaluator_variant(
         self,
         request: Request,
@@ -1097,18 +1094,12 @@ class EvaluatorsRouter:
             if not fork_request.evaluator_variant_id:
                 fork_request.evaluator_variant_id = evaluator_variant_id
 
-        try:
-            evaluator_variant = await self.evaluators_service.fork_evaluator_variant(
-                project_id=UUID(request.state.project_id),
-                user_id=UUID(request.state.user_id),
-                #
-                evaluator_fork=fork_request,
-            )
-        except VariantForkError as e:
-            raise HTTPException(
-                status_code=status.HTTP_400_BAD_REQUEST,
-                detail=e.message,
-            ) from e
+        evaluator_variant = await self.evaluators_service.fork_evaluator_variant(
+            project_id=UUID(request.state.project_id),
+            user_id=UUID(request.state.user_id),
+            #
+            evaluator_fork=fork_request,
+        )
 
         evaluator_variant_response = EvaluatorVariantResponse(
             count=1 if evaluator_variant else 0,
@@ -1120,6 +1111,7 @@ class EvaluatorsRouter:
     # EVALUATOR REVISIONS ------------------------------------------------------
 
     @intercept_exceptions()
+    @handle_git_exceptions()
     async def deploy_evaluator_revision(
         self,
         request: Request,
@@ -1173,19 +1165,13 @@ class EvaluatorsRouter:
                 detail="Evaluator deploy requires environment refs.",
             )
 
-        try:
-            evaluator_revision = await self.evaluators_service.fetch_evaluator_revision(
-                project_id=UUID(request.state.project_id),
-                #
-                evaluator_ref=evaluator_deploy_request.evaluator_ref,
-                evaluator_variant_ref=evaluator_deploy_request.evaluator_variant_ref,
-                evaluator_revision_ref=evaluator_deploy_request.evaluator_revision_ref,
-            )
-        except (RetrieveRefsInsufficient, RetrieveRefsInconsistent) as e:
-            raise HTTPException(
-                status_code=status.HTTP_400_BAD_REQUEST,
-                detail=e.message,
-            ) from e
+        evaluator_revision = await self.evaluators_service.fetch_evaluator_revision(
+            project_id=UUID(request.state.project_id),
+            #
+            evaluator_ref=evaluator_deploy_request.evaluator_ref,
+            evaluator_variant_ref=evaluator_deploy_request.evaluator_variant_ref,
+            evaluator_revision_ref=evaluator_deploy_request.evaluator_revision_ref,
+        )
 
         if not evaluator_revision:
             raise HTTPException(
@@ -1287,6 +1273,7 @@ class EvaluatorsRouter:
         )
 
     @intercept_exceptions()
+    @handle_git_exceptions()
     async def retrieve_evaluator_revision(
         self,
         request: Request,
@@ -1379,29 +1366,23 @@ class EvaluatorsRouter:
                         detail="Environment-backed evaluator retrieve requires key.",
                     )
 
-        try:
-            (
-                evaluator_revision,
-                resolution_info,
-            ) = await self.evaluators_service.retrieve_evaluator_revision(
-                project_id=UUID(request.state.project_id),
-                #
-                environment_ref=environment_ref,
-                environment_variant_ref=environment_variant_ref,
-                environment_revision_ref=environment_revision_ref,
-                key=key,
-                #
-                evaluator_ref=evaluator_ref,
-                evaluator_variant_ref=evaluator_variant_ref,
-                evaluator_revision_ref=evaluator_revision_ref,
-                #
-                resolve=evaluator_revision_retrieve_request.resolve or False,
-            )
-        except (RetrieveRefsInsufficient, RetrieveRefsInconsistent) as e:
-            raise HTTPException(
-                status_code=status.HTTP_400_BAD_REQUEST,
-                detail=e.message,
-            ) from e
+        (
+            evaluator_revision,
+            resolution_info,
+        ) = await self.evaluators_service.retrieve_evaluator_revision(
+            project_id=UUID(request.state.project_id),
+            #
+            environment_ref=environment_ref,
+            environment_variant_ref=environment_variant_ref,
+            environment_revision_ref=environment_revision_ref,
+            key=key,
+            #
+            evaluator_ref=evaluator_ref,
+            evaluator_variant_ref=evaluator_variant_ref,
+            evaluator_revision_ref=evaluator_revision_ref,
+            #
+            resolve=evaluator_revision_retrieve_request.resolve or False,
+        )
 
         if environment_lookup_requested and not evaluator_revision:
             raise HTTPException(

--- a/api/oss/src/apis/fastapi/git/exceptions.py
+++ b/api/oss/src/apis/fastapi/git/exceptions.py
@@ -1,0 +1,64 @@
+"""Typed HTTP exceptions and a translation decorator for git-domain errors.
+
+The git pattern (artifact/variant/revision) is shared across six routers
+(workflows, applications, evaluators, testsets, queries, environments).
+Each router previously translated the same set of core exceptions to HTTP
+400 inline, multiplying boilerplate. This module centralizes that mapping
+so new domain exceptions need updates in one place.
+
+Any new exception added to `oss.src.core.git.types` must be registered
+below: add a typed `*Exception` and a `except` arm in
+`handle_git_exceptions`. The decorator is paired with the existing
+`@intercept_exceptions()` and `@suppress_exceptions(exclude=[HTTPException])`
+on each route; place it on the inside of those decorators so the typed
+HTTP exception is the one re-raised.
+"""
+
+from functools import wraps
+
+from fastapi import HTTPException
+
+from oss.src.core.git.types import (
+    RetrieveRefsInconsistent,
+    RetrieveRefsInsufficient,
+    VariantForkError,
+)
+
+
+class VariantForkErrorException(HTTPException):
+    def __init__(self, message: str = "Variant fork request cannot be fulfilled."):
+        super().__init__(status_code=400, detail=message)
+
+
+class RetrieveRefsInsufficientException(HTTPException):
+    def __init__(
+        self,
+        message: str = "References are insufficient to identify a single revision.",
+    ):
+        super().__init__(status_code=400, detail=message)
+
+
+class RetrieveRefsInconsistentException(HTTPException):
+    def __init__(
+        self,
+        message: str = "References disagree with the resolved revision.",
+    ):
+        super().__init__(status_code=400, detail=message)
+
+
+def handle_git_exceptions():
+    def decorator(func):
+        @wraps(func)
+        async def wrapper(*args, **kwargs):
+            try:
+                return await func(*args, **kwargs)
+            except VariantForkError as e:
+                raise VariantForkErrorException(message=e.message) from e
+            except RetrieveRefsInsufficient as e:
+                raise RetrieveRefsInsufficientException(message=e.message) from e
+            except RetrieveRefsInconsistent as e:
+                raise RetrieveRefsInconsistentException(message=e.message) from e
+
+        return wrapper
+
+    return decorator

--- a/api/oss/src/apis/fastapi/queries/router.py
+++ b/api/oss/src/apis/fastapi/queries/router.py
@@ -9,7 +9,7 @@ from oss.src.utils.exceptions import intercept_exceptions, suppress_exceptions
 from oss.src.utils.caching import get_cache, set_cache
 
 from oss.src.core.events.utils import publish_revision_event
-from oss.src.core.git.types import RetrieveRefsInsufficient, RetrieveRefsInconsistent
+from oss.src.apis.fastapi.git.exceptions import handle_git_exceptions
 
 from oss.src.core.shared.dtos import (
     Reference,
@@ -959,6 +959,7 @@ class QueriesRouter:
 
     @intercept_exceptions()
     @suppress_exceptions(default=QueryRevisionResponse(), exclude=[HTTPException])
+    @handle_git_exceptions()
     async def retrieve_query_revision(
         self,
         request: Request,
@@ -1020,24 +1021,18 @@ class QueriesRouter:
         )
 
         if not query_revision:
-            try:
-                query_revision = await self.queries_service.fetch_query_revision(
-                    project_id=UUID(request.state.project_id),
-                    #
-                    query_ref=query_revision_retrieve_request.query_ref,
-                    query_variant_ref=query_revision_retrieve_request.query_variant_ref,
-                    query_revision_ref=query_revision_retrieve_request.query_revision_ref,
-                    #
-                    include_trace_ids=query_revision_retrieve_request.include_trace_ids,
-                    include_traces=query_revision_retrieve_request.include_traces,
-                    #
-                    windowing=query_revision_retrieve_request.windowing,
-                )
-            except (RetrieveRefsInsufficient, RetrieveRefsInconsistent) as e:
-                raise HTTPException(
-                    status_code=status.HTTP_400_BAD_REQUEST,
-                    detail=e.message,
-                ) from e
+            query_revision = await self.queries_service.fetch_query_revision(
+                project_id=UUID(request.state.project_id),
+                #
+                query_ref=query_revision_retrieve_request.query_ref,
+                query_variant_ref=query_revision_retrieve_request.query_variant_ref,
+                query_revision_ref=query_revision_retrieve_request.query_revision_ref,
+                #
+                include_trace_ids=query_revision_retrieve_request.include_trace_ids,
+                include_traces=query_revision_retrieve_request.include_traces,
+                #
+                windowing=query_revision_retrieve_request.windowing,
+            )
 
             if should_cache:
                 await set_cache(

--- a/api/oss/src/apis/fastapi/queries/router.py
+++ b/api/oss/src/apis/fastapi/queries/router.py
@@ -9,7 +9,7 @@ from oss.src.utils.exceptions import intercept_exceptions, suppress_exceptions
 from oss.src.utils.caching import get_cache, set_cache
 
 from oss.src.core.events.utils import publish_revision_event
-from oss.src.core.git.types import RevisionRefInvalid
+from oss.src.core.git.types import RetrieveRefsInsufficient, RetrieveRefsInconsistent
 
 from oss.src.core.shared.dtos import (
     Reference,
@@ -1033,7 +1033,7 @@ class QueriesRouter:
                     #
                     windowing=query_revision_retrieve_request.windowing,
                 )
-            except RevisionRefInvalid as e:
+            except (RetrieveRefsInsufficient, RetrieveRefsInconsistent) as e:
                 raise HTTPException(
                     status_code=status.HTTP_400_BAD_REQUEST,
                     detail=e.message,

--- a/api/oss/src/apis/fastapi/testsets/router.py
+++ b/api/oss/src/apis/fastapi/testsets/router.py
@@ -28,7 +28,7 @@ from oss.src.utils.caching import set_cache, get_cache
 
 from oss.src.apis.fastapi.shared.utils import compute_next_windowing
 from oss.src.core.events.utils import publish_revision_event
-from oss.src.core.git.types import RevisionRefInvalid
+from oss.src.core.git.types import RetrieveRefsInsufficient, RetrieveRefsInconsistent
 
 from oss.src.core.shared.dtos import (
     Reference,
@@ -1511,7 +1511,7 @@ class TestsetsRouter:
                     #
                     windowing=testset_revision_retrieve_request.windowing,
                 )
-            except RevisionRefInvalid as e:
+            except (RetrieveRefsInsufficient, RetrieveRefsInconsistent) as e:
                 raise HTTPException(
                     status_code=status.HTTP_400_BAD_REQUEST,
                     detail=e.message,

--- a/api/oss/src/apis/fastapi/testsets/router.py
+++ b/api/oss/src/apis/fastapi/testsets/router.py
@@ -28,7 +28,7 @@ from oss.src.utils.caching import set_cache, get_cache
 
 from oss.src.apis.fastapi.shared.utils import compute_next_windowing
 from oss.src.core.events.utils import publish_revision_event
-from oss.src.core.git.types import RetrieveRefsInsufficient, RetrieveRefsInconsistent
+from oss.src.apis.fastapi.git.exceptions import handle_git_exceptions
 
 from oss.src.core.shared.dtos import (
     Reference,
@@ -1444,6 +1444,7 @@ class TestsetsRouter:
 
     @intercept_exceptions()
     @suppress_exceptions(default=TestsetRevisionResponse(), exclude=[HTTPException])
+    @handle_git_exceptions()
     async def retrieve_testset_revision(
         self,
         request: Request,
@@ -1498,24 +1499,18 @@ class TestsetsRouter:
         )
 
         if not testset_revision:
-            try:
-                testset_revision = await self.testsets_service.fetch_testset_revision(
-                    project_id=UUID(request.state.project_id),
-                    #
-                    testset_ref=testset_revision_retrieve_request.testset_ref,
-                    testset_variant_ref=testset_revision_retrieve_request.testset_variant_ref,
-                    testset_revision_ref=testset_revision_retrieve_request.testset_revision_ref,
-                    #
-                    include_testcase_ids=testset_revision_retrieve_request.include_testcase_ids,
-                    include_testcases=testset_revision_retrieve_request.include_testcases,
-                    #
-                    windowing=testset_revision_retrieve_request.windowing,
-                )
-            except (RetrieveRefsInsufficient, RetrieveRefsInconsistent) as e:
-                raise HTTPException(
-                    status_code=status.HTTP_400_BAD_REQUEST,
-                    detail=e.message,
-                ) from e
+            testset_revision = await self.testsets_service.fetch_testset_revision(
+                project_id=UUID(request.state.project_id),
+                #
+                testset_ref=testset_revision_retrieve_request.testset_ref,
+                testset_variant_ref=testset_revision_retrieve_request.testset_variant_ref,
+                testset_revision_ref=testset_revision_retrieve_request.testset_revision_ref,
+                #
+                include_testcase_ids=testset_revision_retrieve_request.include_testcase_ids,
+                include_testcases=testset_revision_retrieve_request.include_testcases,
+                #
+                windowing=testset_revision_retrieve_request.windowing,
+            )
 
             if should_cache:
                 await set_cache(

--- a/api/oss/src/apis/fastapi/workflows/models.py
+++ b/api/oss/src/apis/fastapi/workflows/models.py
@@ -251,13 +251,20 @@ class WorkflowRevisionCommitRequest(BaseModel):
 
 
 class WorkflowRevisionRetrieveRequest(BaseModel):
+    """Request body for `POST /workflows/revisions/retrieve`.
+
+    Resolves to a single revision by one or more reference types. Every
+    reference supplied must agree with the resolved revision; contradictions
+    return HTTP 400.
+    """
+
     workflow_ref: Optional[Reference] = Field(
         default=None,
         description=(
             "Workflow artifact to look up. Identifies the artifact by `id` or "
             "`slug` (both project-unique). When no variant_ref or revision_ref "
-            "is provided, returns the latest revision of an arbitrary variant "
-            "of this workflow."
+            "is provided, returns the latest revision of the workflow's "
+            "default variant."
         ),
     )
     workflow_variant_ref: Optional[Reference] = Field(

--- a/api/oss/src/apis/fastapi/workflows/router.py
+++ b/api/oss/src/apis/fastapi/workflows/router.py
@@ -11,7 +11,11 @@ from oss.src.utils.caching import invalidate_cache
 from oss.src.core.shared.dtos import (
     Reference,
 )
-from oss.src.core.git.types import VariantForkError, RevisionRefInvalid
+from oss.src.core.git.types import (
+    VariantForkError,
+    RetrieveRefsInsufficient,
+    RetrieveRefsInconsistent,
+)
 from oss.src.core.workflows.service import (
     WorkflowsService,
     SimpleWorkflowsService,
@@ -1235,7 +1239,7 @@ class WorkflowsRouter:
         # This route only accepts `workflow_revision_id` as a path param and
         # constructs `Reference(id=workflow_revision_id)`. That shape always
         # satisfies the service's ambiguity validation, so no try/except for
-        # `RevisionRefInvalid` is needed here. The other two call sites
+        # `RetrieveRefsInsufficient` is needed here. The other two call sites
         # (`deploy_workflow_revision` and `retrieve_workflow_revision`) pass
         # through caller-supplied refs and do wrap this call.
         workflow_revision = await self.workflows_service.fetch_workflow_revision(
@@ -1536,7 +1540,7 @@ class WorkflowsRouter:
                 workflow_variant_ref=workflow_deploy_request.workflow_variant_ref,
                 workflow_revision_ref=workflow_deploy_request.workflow_revision_ref,
             )
-        except RevisionRefInvalid as e:
+        except (RetrieveRefsInsufficient, RetrieveRefsInconsistent) as e:
             raise HTTPException(
                 status_code=status.HTTP_400_BAD_REQUEST,
                 detail=e.message,
@@ -1733,7 +1737,7 @@ class WorkflowsRouter:
                 #
                 resolve=workflow_revision_retrieve_request.resolve or False,
             )
-        except RevisionRefInvalid as e:
+        except (RetrieveRefsInsufficient, RetrieveRefsInconsistent) as e:
             raise HTTPException(
                 status_code=status.HTTP_400_BAD_REQUEST,
                 detail=e.message,

--- a/api/oss/src/apis/fastapi/workflows/router.py
+++ b/api/oss/src/apis/fastapi/workflows/router.py
@@ -11,11 +11,7 @@ from oss.src.utils.caching import invalidate_cache
 from oss.src.core.shared.dtos import (
     Reference,
 )
-from oss.src.core.git.types import (
-    VariantForkError,
-    RetrieveRefsInsufficient,
-    RetrieveRefsInconsistent,
-)
+from oss.src.apis.fastapi.git.exceptions import handle_git_exceptions
 from oss.src.core.workflows.service import (
     WorkflowsService,
     SimpleWorkflowsService,
@@ -1149,6 +1145,7 @@ class WorkflowsRouter:
         return workflow_variants_response
 
     @intercept_exceptions()
+    @handle_git_exceptions()
     async def fork_workflow_variant(
         self,
         request: Request,
@@ -1163,18 +1160,12 @@ class WorkflowsRouter:
             ):
                 raise FORBIDDEN_EXCEPTION  # type: ignore
 
-        try:
-            workflow_variant = await self.workflows_service.fork_workflow_variant(
-                project_id=UUID(request.state.project_id),
-                user_id=UUID(request.state.user_id),
-                #
-                workflow_fork=workflow_fork_request.workflow,
-            )
-        except VariantForkError as e:
-            raise HTTPException(
-                status_code=status.HTTP_400_BAD_REQUEST,
-                detail=e.message,
-            ) from e
+        workflow_variant = await self.workflows_service.fork_workflow_variant(
+            project_id=UUID(request.state.project_id),
+            user_id=UUID(request.state.user_id),
+            #
+            workflow_fork=workflow_fork_request.workflow,
+        )
 
         # Invalidate legacy caches so the registry page reflects the forked variant
         await invalidate_cache(project_id=request.state.project_id)
@@ -1236,12 +1227,6 @@ class WorkflowsRouter:
             ):
                 raise FORBIDDEN_EXCEPTION  # type: ignore
 
-        # This route only accepts `workflow_revision_id` as a path param and
-        # constructs `Reference(id=workflow_revision_id)`. That shape always
-        # satisfies the service's ambiguity validation, so no try/except for
-        # `RetrieveRefsInsufficient` is needed here. The other two call sites
-        # (`deploy_workflow_revision` and `retrieve_workflow_revision`) pass
-        # through caller-supplied refs and do wrap this call.
         workflow_revision = await self.workflows_service.fetch_workflow_revision(
             project_id=UUID(request.state.project_id),
             #
@@ -1488,6 +1473,7 @@ class WorkflowsRouter:
         return workflow_revisions_response
 
     @intercept_exceptions()
+    @handle_git_exceptions()
     async def deploy_workflow_revision(
         self,
         request: Request,
@@ -1532,19 +1518,13 @@ class WorkflowsRouter:
                 detail="Workflow deploy requires environment refs.",
             )
 
-        try:
-            workflow_revision = await self.workflows_service.fetch_workflow_revision(
-                project_id=UUID(request.state.project_id),
-                #
-                workflow_ref=workflow_deploy_request.workflow_ref,
-                workflow_variant_ref=workflow_deploy_request.workflow_variant_ref,
-                workflow_revision_ref=workflow_deploy_request.workflow_revision_ref,
-            )
-        except (RetrieveRefsInsufficient, RetrieveRefsInconsistent) as e:
-            raise HTTPException(
-                status_code=status.HTTP_400_BAD_REQUEST,
-                detail=e.message,
-            ) from e
+        workflow_revision = await self.workflows_service.fetch_workflow_revision(
+            project_id=UUID(request.state.project_id),
+            #
+            workflow_ref=workflow_deploy_request.workflow_ref,
+            workflow_variant_ref=workflow_deploy_request.workflow_variant_ref,
+            workflow_revision_ref=workflow_deploy_request.workflow_revision_ref,
+        )
 
         if not workflow_revision:
             raise HTTPException(
@@ -1647,6 +1627,7 @@ class WorkflowsRouter:
 
     @intercept_exceptions()
     @suppress_exceptions(default=WorkflowRevisionResponse(), exclude=[HTTPException])
+    @handle_git_exceptions()
     async def retrieve_workflow_revision(
         self,
         request: Request,
@@ -1725,29 +1706,23 @@ class WorkflowsRouter:
                         detail="Environment-backed workflow retrieve requires key.",
                     )
 
-        try:
-            (
-                workflow_revision,
-                resolution_info,
-            ) = await self.workflows_service.retrieve_workflow_revision(
-                project_id=UUID(request.state.project_id),
-                #
-                environment_ref=environment_ref,
-                environment_variant_ref=environment_variant_ref,
-                environment_revision_ref=environment_revision_ref,
-                key=key,
-                #
-                workflow_ref=workflow_ref,
-                workflow_variant_ref=workflow_variant_ref,
-                workflow_revision_ref=workflow_revision_ref,
-                #
-                resolve=workflow_revision_retrieve_request.resolve or False,
-            )
-        except (RetrieveRefsInsufficient, RetrieveRefsInconsistent) as e:
-            raise HTTPException(
-                status_code=status.HTTP_400_BAD_REQUEST,
-                detail=e.message,
-            ) from e
+        (
+            workflow_revision,
+            resolution_info,
+        ) = await self.workflows_service.retrieve_workflow_revision(
+            project_id=UUID(request.state.project_id),
+            #
+            environment_ref=environment_ref,
+            environment_variant_ref=environment_variant_ref,
+            environment_revision_ref=environment_revision_ref,
+            key=key,
+            #
+            workflow_ref=workflow_ref,
+            workflow_variant_ref=workflow_variant_ref,
+            workflow_revision_ref=workflow_revision_ref,
+            #
+            resolve=workflow_revision_retrieve_request.resolve or False,
+        )
 
         if environment_lookup_requested and not workflow_revision:
             raise HTTPException(

--- a/api/oss/src/apis/fastapi/workflows/router.py
+++ b/api/oss/src/apis/fastapi/workflows/router.py
@@ -1690,14 +1690,6 @@ class WorkflowsRouter:
         )
         environment_lookup_requested = environment_refs_requested or key is not None
 
-        if workflow_lookup_requested and environment_lookup_requested:
-            raise HTTPException(
-                status_code=status.HTTP_400_BAD_REQUEST,
-                detail=(
-                    "Provide either workflow refs or environment refs with key, not both."
-                ),
-            )
-
         if not workflow_lookup_requested and not environment_lookup_requested:
             raise HTTPException(
                 status_code=status.HTTP_400_BAD_REQUEST,
@@ -1714,10 +1706,24 @@ class WorkflowsRouter:
                 )
 
             if not key:
-                raise HTTPException(
-                    status_code=status.HTTP_400_BAD_REQUEST,
-                    detail="Environment-backed workflow retrieve requires key.",
-                )
+                if workflow_ref and workflow_ref.slug:
+                    key = f"{workflow_ref.slug}.revision"
+                elif workflow_ref and workflow_ref.id:
+                    workflow = await self.workflows_service.fetch_workflow(
+                        project_id=UUID(request.state.project_id),
+                        workflow_ref=workflow_ref,
+                    )
+                    if not workflow or not workflow.slug:
+                        raise HTTPException(
+                            status_code=status.HTTP_400_BAD_REQUEST,
+                            detail="Environment-backed workflow retrieve could not derive key from workflow slug.",
+                        )
+                    key = f"{workflow.slug}.revision"
+                else:
+                    raise HTTPException(
+                        status_code=status.HTTP_400_BAD_REQUEST,
+                        detail="Environment-backed workflow retrieve requires key.",
+                    )
 
         try:
             (

--- a/api/oss/src/core/applications/service.py
+++ b/api/oss/src/core/applications/service.py
@@ -21,7 +21,10 @@ from oss.src.core.workflows.dtos import (
     #
 )
 from oss.src.core.shared.dtos import Windowing, Reference
-from oss.src.core.git.types import validate_revision_ref_unambiguous
+from oss.src.core.git.types import (
+    validate_revision_refs_sufficient,
+    validate_variant_refs_sufficient,
+)
 from oss.src.core.workflows.service import WorkflowsService
 
 # Resolution is now handled by EmbedsService
@@ -550,7 +553,11 @@ class ApplicationsService:
         #
         include_archived: Optional[bool] = True,
     ) -> Optional[ApplicationRevision]:
-        validate_revision_ref_unambiguous(
+        validate_variant_refs_sufficient(
+            variant_ref=application_variant_ref,
+            entity_type="application",
+        )
+        validate_revision_refs_sufficient(
             artifact_ref=application_ref,
             variant_ref=application_variant_ref,
             revision_ref=application_revision_ref,

--- a/api/oss/src/core/environments/service.py
+++ b/api/oss/src/core/environments/service.py
@@ -53,6 +53,7 @@ from oss.src.core.git.interfaces import GitDAOInterface
 from oss.src.core.git.types import (
     validate_revision_ref_unambiguous,
     needs_default_variant_resolution,
+    validate_retrieve_refs_consistent,
 )
 from oss.src.core.shared.dtos import Reference, Windowing
 
@@ -624,6 +625,9 @@ class EnvironmentsService:
             entity_type="environment",
         )
 
+        _original_environment_ref = environment_ref
+        _original_environment_variant_ref = environment_variant_ref
+
         if needs_default_variant_resolution(
             artifact_ref=environment_ref,
             variant_ref=environment_variant_ref,
@@ -672,6 +676,20 @@ class EnvironmentsService:
 
         if not revision:
             return None
+
+        validate_retrieve_refs_consistent(
+            artifact_ref=_original_environment_ref,
+            variant_ref=_original_environment_variant_ref,
+            revision_ref=environment_revision_ref,
+            resolved_artifact_id=revision.artifact_id,
+            resolved_artifact_slug=revision.artifact_slug,
+            resolved_variant_id=revision.variant_id,
+            resolved_variant_slug=revision.variant_slug,
+            resolved_revision_id=revision.id,
+            resolved_revision_slug=revision.slug,
+            resolved_revision_version=revision.version,
+            entity_type="environment",
+        )
 
         environment_revision = EnvironmentRevision(
             **revision.model_dump(

--- a/api/oss/src/core/environments/service.py
+++ b/api/oss/src/core/environments/service.py
@@ -681,13 +681,19 @@ class EnvironmentsService:
             artifact_ref=_original_environment_ref,
             variant_ref=_original_environment_variant_ref,
             revision_ref=environment_revision_ref,
-            resolved_artifact_id=revision.artifact_id,
-            resolved_artifact_slug=revision.artifact_slug,
-            resolved_variant_id=revision.variant_id,
-            resolved_variant_slug=revision.variant_slug,
-            resolved_revision_id=revision.id,
-            resolved_revision_slug=revision.slug,
-            resolved_revision_version=revision.version,
+            resolved_artifact_ref=Reference(
+                id=revision.artifact_id,
+                slug=revision.artifact_slug,
+            ),
+            resolved_variant_ref=Reference(
+                id=revision.variant_id,
+                slug=revision.variant_slug,
+            ),
+            resolved_revision_ref=Reference(
+                id=revision.id,
+                slug=revision.slug,
+                version=revision.version,
+            ),
             entity_type="environment",
         )
 

--- a/api/oss/src/core/environments/service.py
+++ b/api/oss/src/core/environments/service.py
@@ -51,7 +51,8 @@ from oss.src.core.git.dtos import (
 )
 from oss.src.core.git.interfaces import GitDAOInterface
 from oss.src.core.git.types import (
-    validate_revision_ref_unambiguous,
+    validate_revision_refs_sufficient,
+    validate_variant_refs_sufficient,
     needs_default_variant_resolution,
     validate_retrieve_refs_consistent,
 )
@@ -414,6 +415,10 @@ class EnvironmentsService:
         #
         include_archived: Optional[bool] = True,
     ) -> Optional[EnvironmentVariant]:
+        validate_variant_refs_sufficient(
+            variant_ref=environment_variant_ref,
+            entity_type="environment",
+        )
         variant = await self.environments_dao.fetch_variant(
             project_id=project_id,
             #
@@ -618,7 +623,7 @@ class EnvironmentsService:
         ):
             return None
 
-        validate_revision_ref_unambiguous(
+        validate_revision_refs_sufficient(
             artifact_ref=environment_ref,
             variant_ref=environment_variant_ref,
             revision_ref=environment_revision_ref,

--- a/api/oss/src/core/evaluators/service.py
+++ b/api/oss/src/core/evaluators/service.py
@@ -20,7 +20,10 @@ from oss.src.core.workflows.dtos import (
     #
 )
 from oss.src.core.shared.dtos import Windowing, Reference
-from oss.src.core.git.types import validate_revision_ref_unambiguous
+from oss.src.core.git.types import (
+    validate_revision_refs_sufficient,
+    validate_variant_refs_sufficient,
+)
 from oss.src.core.workflows.service import WorkflowsService
 
 # Resolution is now handled by EmbedsService
@@ -553,7 +556,11 @@ class EvaluatorsService:
         #
         include_archived: Optional[bool] = True,
     ) -> Optional[EvaluatorRevision]:
-        validate_revision_ref_unambiguous(
+        validate_variant_refs_sufficient(
+            variant_ref=evaluator_variant_ref,
+            entity_type="evaluator",
+        )
+        validate_revision_refs_sufficient(
             artifact_ref=evaluator_ref,
             variant_ref=evaluator_variant_ref,
             revision_ref=evaluator_revision_ref,

--- a/api/oss/src/core/git/types.py
+++ b/api/oss/src/core/git/types.py
@@ -15,7 +15,7 @@ class VariantForkError(GitError):
     """Raised when a variant fork request cannot be fulfilled."""
 
 
-class RevisionRefInvalid(GitError):
+class RetrieveRefsInsufficient(GitError):
     """Raised when artifact/variant/revision refs are present but cannot
     identify a single revision unambiguously.
 
@@ -28,6 +28,18 @@ class RevisionRefInvalid(GitError):
     Not raised for the all-refs-empty case: the entity service returns
     `None` for that case rather than raising, matching the "nothing to look
     up" contract.
+    """
+
+
+class RetrieveRefsInconsistent(GitError):
+    """Raised when redundant refs disagree with the resolved revision.
+
+    A caller may legitimately repeat identifying refs across the
+    artifact/variant/revision triple, but every redundant identifier must
+    name the same row that the lookup resolved. If `revision_ref.id`
+    resolves to a revision whose `artifact_id` does not match the
+    `artifact_ref.id` the caller sent, the request is rejected — silently
+    favoring one ref would be a footgun.
     """
 
 
@@ -100,10 +112,121 @@ def validate_revision_ref_unambiguous(
     if _is_identifying(variant_ref) or _is_identifying(artifact_ref):
         return
 
-    raise RevisionRefInvalid(
+    raise RetrieveRefsInsufficient(
         f"{entity_type}_revision_ref.version is a per-variant sequence number "
         f"and requires a {entity_type}_variant_ref or {entity_type}_ref to "
         f"scope it. Provide either, or identify the revision by "
         f"{entity_type}_revision_ref.id or {entity_type}_revision_ref.slug "
         f"(both are project-unique)."
     )
+
+
+def _mismatch(
+    ref_field: str,
+    ref_value,
+    resolved_field: str,
+    resolved_value,
+) -> Optional[str]:
+    if ref_value is None or resolved_value is None:
+        return None
+    if str(ref_value) == str(resolved_value):
+        return None
+    return (
+        f"{ref_field}={ref_value!r} does not match resolved revision's "
+        f"{resolved_field}={resolved_value!r}"
+    )
+
+
+def validate_retrieve_refs_consistent(
+    *,
+    artifact_ref: Optional[Reference],
+    variant_ref: Optional[Reference],
+    revision_ref: Optional[Reference],
+    resolved_artifact_id=None,
+    resolved_artifact_slug: Optional[str] = None,
+    resolved_variant_id=None,
+    resolved_variant_slug: Optional[str] = None,
+    resolved_revision_id=None,
+    resolved_revision_slug: Optional[str] = None,
+    resolved_revision_version: Optional[int] = None,
+    entity_type: str = "artifact",
+) -> None:
+    """Reject requests where caller-supplied refs contradict the resolved revision (rule 2.d enforcement).
+
+    The retrieve API tolerates redundant refs (the same revision identified
+    by multiple of `{artifact_ref, variant_ref, revision_ref}`) because they
+    are useful for sanity-check shapes. But every redundant identifier must
+    name the same row the lookup resolved — otherwise silently favoring one
+    ref over another is a footgun. The version field is the one exception:
+    it's a per-variant sequence number and lookup-by-id ignores it, so a
+    redundant version that disagrees is still a contradiction worth
+    rejecting.
+
+    None-valued caller fields are skipped (only present-but-wrong fails).
+    None-valued resolved fields are skipped too — caller asked for a
+    consistency check the DAO can't service, which is a no-op rather than a
+    failure.
+    """
+    mismatches: list[str] = []
+    if artifact_ref is not None:
+        mismatches.append(
+            _mismatch(
+                f"{entity_type}_ref.id",
+                artifact_ref.id,
+                "artifact_id",
+                resolved_artifact_id,
+            )
+        )
+        mismatches.append(
+            _mismatch(
+                f"{entity_type}_ref.slug",
+                artifact_ref.slug,
+                "artifact_slug",
+                resolved_artifact_slug,
+            )
+        )
+    if variant_ref is not None:
+        mismatches.append(
+            _mismatch(
+                f"{entity_type}_variant_ref.id",
+                variant_ref.id,
+                "variant_id",
+                resolved_variant_id,
+            )
+        )
+        mismatches.append(
+            _mismatch(
+                f"{entity_type}_variant_ref.slug",
+                variant_ref.slug,
+                "variant_slug",
+                resolved_variant_slug,
+            )
+        )
+    if revision_ref is not None:
+        mismatches.append(
+            _mismatch(
+                f"{entity_type}_revision_ref.id",
+                revision_ref.id,
+                "id",
+                resolved_revision_id,
+            )
+        )
+        mismatches.append(
+            _mismatch(
+                f"{entity_type}_revision_ref.slug",
+                revision_ref.slug,
+                "slug",
+                resolved_revision_slug,
+            )
+        )
+        if revision_ref.version is not None and resolved_revision_version is not None:
+            if str(revision_ref.version) != str(resolved_revision_version):
+                mismatches.append(
+                    f"{entity_type}_revision_ref.version="
+                    f"{revision_ref.version!r} does not match resolved "
+                    f"revision's version={resolved_revision_version!r}"
+                )
+
+    errors = [m for m in mismatches if m]
+    if errors:
+        raise RetrieveRefsInconsistent("; ".join(errors))

--- a/api/oss/src/core/git/types.py
+++ b/api/oss/src/core/git/types.py
@@ -77,7 +77,7 @@ def needs_default_variant_resolution(
     return True
 
 
-def validate_revision_ref_unambiguous(
+def validate_revision_refs_sufficient(
     *,
     artifact_ref: Optional[Reference],
     variant_ref: Optional[Reference],
@@ -118,6 +118,35 @@ def validate_revision_ref_unambiguous(
         f"scope it. Provide either, or identify the revision by "
         f"{entity_type}_revision_ref.id or {entity_type}_revision_ref.slug "
         f"(both are project-unique)."
+    )
+
+
+def validate_variant_refs_sufficient(
+    *,
+    variant_ref: Optional[Reference],
+    entity_type: str = "artifact",
+) -> None:
+    """Reject `variant_ref` shapes that can never identify a variant.
+
+    Variants carry `id` and `slug` but no `version` field — version is a
+    per-variant counter living on revisions. A `variant_ref` populated with
+    only `version` is nonsense the DAO would silently drop, so reject it at
+    the boundary.
+
+    Identifying `variant_ref` (id/slug, optionally with redundant version
+    that the DAO ignores) is left alone — C3's consistency check covers the
+    "redundant but wrong" case.
+    """
+    if variant_ref is None:
+        return
+    if _is_identifying(variant_ref):
+        return
+    if variant_ref.version is None:
+        return
+    raise RetrieveRefsInsufficient(
+        f"{entity_type}_variant_ref carries only `version`, but variants "
+        f"have no `version` field. Identify the variant by "
+        f"{entity_type}_variant_ref.id or {entity_type}_variant_ref.slug."
     )
 
 

--- a/api/oss/src/core/git/types.py
+++ b/api/oss/src/core/git/types.py
@@ -142,13 +142,9 @@ def validate_retrieve_refs_consistent(
     artifact_ref: Optional[Reference],
     variant_ref: Optional[Reference],
     revision_ref: Optional[Reference],
-    resolved_artifact_id=None,
-    resolved_artifact_slug: Optional[str] = None,
-    resolved_variant_id=None,
-    resolved_variant_slug: Optional[str] = None,
-    resolved_revision_id=None,
-    resolved_revision_slug: Optional[str] = None,
-    resolved_revision_version: Optional[int] = None,
+    resolved_artifact_ref: Optional[Reference] = None,
+    resolved_variant_ref: Optional[Reference] = None,
+    resolved_revision_ref: Optional[Reference] = None,
     entity_type: str = "artifact",
 ) -> None:
     """Reject requests where caller-supplied refs contradict the resolved revision (rule 2.d enforcement).
@@ -167,14 +163,14 @@ def validate_retrieve_refs_consistent(
     consistency check the DAO can't service, which is a no-op rather than a
     failure.
     """
-    mismatches: list[str] = []
-    if artifact_ref is not None:
+    mismatches: list[Optional[str]] = []
+    if artifact_ref is not None and resolved_artifact_ref is not None:
         mismatches.append(
             _mismatch(
                 f"{entity_type}_ref.id",
                 artifact_ref.id,
                 "artifact_id",
-                resolved_artifact_id,
+                resolved_artifact_ref.id,
             )
         )
         mismatches.append(
@@ -182,16 +178,16 @@ def validate_retrieve_refs_consistent(
                 f"{entity_type}_ref.slug",
                 artifact_ref.slug,
                 "artifact_slug",
-                resolved_artifact_slug,
+                resolved_artifact_ref.slug,
             )
         )
-    if variant_ref is not None:
+    if variant_ref is not None and resolved_variant_ref is not None:
         mismatches.append(
             _mismatch(
                 f"{entity_type}_variant_ref.id",
                 variant_ref.id,
                 "variant_id",
-                resolved_variant_id,
+                resolved_variant_ref.id,
             )
         )
         mismatches.append(
@@ -199,16 +195,16 @@ def validate_retrieve_refs_consistent(
                 f"{entity_type}_variant_ref.slug",
                 variant_ref.slug,
                 "variant_slug",
-                resolved_variant_slug,
+                resolved_variant_ref.slug,
             )
         )
-    if revision_ref is not None:
+    if revision_ref is not None and resolved_revision_ref is not None:
         mismatches.append(
             _mismatch(
                 f"{entity_type}_revision_ref.id",
                 revision_ref.id,
                 "id",
-                resolved_revision_id,
+                resolved_revision_ref.id,
             )
         )
         mismatches.append(
@@ -216,15 +212,18 @@ def validate_retrieve_refs_consistent(
                 f"{entity_type}_revision_ref.slug",
                 revision_ref.slug,
                 "slug",
-                resolved_revision_slug,
+                resolved_revision_ref.slug,
             )
         )
-        if revision_ref.version is not None and resolved_revision_version is not None:
-            if str(revision_ref.version) != str(resolved_revision_version):
+        if (
+            revision_ref.version is not None
+            and resolved_revision_ref.version is not None
+        ):
+            if str(revision_ref.version) != str(resolved_revision_ref.version):
                 mismatches.append(
                     f"{entity_type}_revision_ref.version="
                     f"{revision_ref.version!r} does not match resolved "
-                    f"revision's version={resolved_revision_version!r}"
+                    f"revision's version={resolved_revision_ref.version!r}"
                 )
 
     errors = [m for m in mismatches if m]

--- a/api/oss/src/core/git/types.py
+++ b/api/oss/src/core/git/types.py
@@ -1,3 +1,93 @@
+"""Git-pattern domain rules for artifact/variant/revision references.
+
+This module owns the shape of `revisions/retrieve` across every git-backed
+entity (workflows, applications, evaluators, testsets, queries,
+environments). Changes here propagate uniformly. The rules below are the
+contract every entity service implements before delegating to its DAO.
+
+Reference shapes
+================
+
+A `Reference(id, slug, version)` is *identifying* iff it carries an `id`
+or a `slug`. Both are project-unique. A bare `version` (with no `id` or
+`slug`) is a per-variant sequence number on its own — not a project-wide
+identifier — and never identifies a row.
+
+Variants do not have versions: a `variant_ref` carrying only `version`
+is rejected outright by `validate_variant_refs_sufficient`.
+
+A revision can be identified by:
+
+  * `revision_ref.id`                                — project-unique.
+  * `revision_ref.slug`                              — project-unique.
+  * `variant_ref` (id/slug) + `revision_ref.version` — version is scoped
+    to the variant.
+
+Rule 2.a — minimal identifying request
+---------------------------------------
+
+Any single identifying reference resolves a single revision:
+
+  * `{revision_ref.id}` or `{revision_ref.slug}` → that revision.
+  * `{variant_ref}`                              → latest revision on the
+    variant (stable tie-break: `created_at DESC, id DESC`).
+  * `{artifact_ref}`                             → latest revision on the
+    artifact's default variant (default variant picked by
+    `created_at ASC, id ASC LIMIT 1`).
+
+Env-path: `{environment_ref + key}` resolves to the revision currently
+deployed under that key. When `key` is omitted but `artifact_ref` has a
+slug, the key is derived as `{artifact_slug}.revision`.
+
+Rule 2.b — redundant-consistent request
+----------------------------------------
+
+A caller may repeat identifying refs across the
+artifact/variant/revision triple, or mix entity refs with env refs.
+Every redundant identifier must name the same row that the lookup
+resolved. Validated post-resolution by
+`validate_retrieve_refs_consistent`.
+
+Rule 2.c — inconsistent request
+--------------------------------
+
+When any redundant ref contradicts the resolved revision (different
+`id`, different `slug`, or — for revisions inside a variant — different
+`version`), `RetrieveRefsInconsistent` is raised. Routers translate this
+to HTTP 400 with a `*_ref` field name in the message.
+
+Rule 2.d — insufficient request that picks a default
+-----------------------------------------------------
+
+When refs are minimal but unambiguous (single variant, single artifact,
+env-ref + key), the rules above pick deterministically.
+
+Rule 2.e — insufficient request that cannot pick
+-------------------------------------------------
+
+When refs are present but cannot identify a single revision —
+`{revision_ref:{version}}` alone, `{variant_ref:{version}}` alone, or
+env refs without a `key` and without an artifact-ref to derive the key
+from — `RetrieveRefsInsufficient` is raised. Routers translate this to
+HTTP 400.
+
+Empty request (`{}`) resolves to `None` at the service layer; routers
+that require at least one identifying input (env-path-only routers like
+applications) reject it at the boundary.
+
+Exception registry
+==================
+
+`VariantForkError`, `RetrieveRefsInsufficient`, and
+`RetrieveRefsInconsistent` are translated to HTTP responses by
+`@handle_git_exceptions()` in
+`api/oss/src/apis/fastapi/git/exceptions.py`. Any new git-domain
+exception added here must also be registered there.
+
+See `docs/design/playground-open-from-trace/followups.md` for the design
+record that drove these rules.
+"""
+
 from typing import Optional
 
 from oss.src.core.shared.dtos import Reference

--- a/api/oss/src/core/queries/service.py
+++ b/api/oss/src/core/queries/service.py
@@ -9,6 +9,7 @@ from oss.src.core.git.interfaces import GitDAOInterface
 from oss.src.core.git.types import (
     validate_revision_ref_unambiguous,
     needs_default_variant_resolution,
+    validate_retrieve_refs_consistent,
 )
 from oss.src.core.shared.dtos import Reference, Windowing, Trace, Traces
 from oss.src.core.tracing.dtos import (
@@ -657,6 +658,9 @@ class QueriesService:
             entity_type="query",
         )
 
+        _original_query_ref = query_ref
+        _original_query_variant_ref = query_variant_ref
+
         if needs_default_variant_resolution(
             artifact_ref=query_ref,
             variant_ref=query_variant_ref,
@@ -699,6 +703,20 @@ class QueriesService:
 
         if not revision:
             return None
+
+        validate_retrieve_refs_consistent(
+            artifact_ref=_original_query_ref,
+            variant_ref=_original_query_variant_ref,
+            revision_ref=query_revision_ref,
+            resolved_artifact_id=revision.artifact_id,
+            resolved_artifact_slug=revision.artifact_slug,
+            resolved_variant_id=revision.variant_id,
+            resolved_variant_slug=revision.variant_slug,
+            resolved_revision_id=revision.id,
+            resolved_revision_slug=revision.slug,
+            resolved_revision_version=revision.version,
+            entity_type="query",
+        )
 
         _query_revision = QueryRevision(
             **revision.model_dump(mode="json"),

--- a/api/oss/src/core/queries/service.py
+++ b/api/oss/src/core/queries/service.py
@@ -7,7 +7,8 @@ from oss.src.utils.logging import get_module_logger
 from oss.src.core.events.utils import publish_revision_event
 from oss.src.core.git.interfaces import GitDAOInterface
 from oss.src.core.git.types import (
-    validate_revision_ref_unambiguous,
+    validate_revision_refs_sufficient,
+    validate_variant_refs_sufficient,
     needs_default_variant_resolution,
     validate_retrieve_refs_consistent,
 )
@@ -432,6 +433,10 @@ class QueriesService:
         query_ref: Optional[Reference] = None,
         query_variant_ref: Optional[Reference] = None,
     ) -> Optional[QueryVariant]:
+        validate_variant_refs_sufficient(
+            variant_ref=query_variant_ref,
+            entity_type="query",
+        )
         variant = await self.queries_dao.fetch_variant(
             project_id=project_id,
             #
@@ -651,7 +656,11 @@ class QueriesService:
         if not query_ref and not query_variant_ref and not query_revision_ref:
             return None
 
-        validate_revision_ref_unambiguous(
+        validate_variant_refs_sufficient(
+            variant_ref=query_variant_ref,
+            entity_type="query",
+        )
+        validate_revision_refs_sufficient(
             artifact_ref=query_ref,
             variant_ref=query_variant_ref,
             revision_ref=query_revision_ref,

--- a/api/oss/src/core/queries/service.py
+++ b/api/oss/src/core/queries/service.py
@@ -708,13 +708,19 @@ class QueriesService:
             artifact_ref=_original_query_ref,
             variant_ref=_original_query_variant_ref,
             revision_ref=query_revision_ref,
-            resolved_artifact_id=revision.artifact_id,
-            resolved_artifact_slug=revision.artifact_slug,
-            resolved_variant_id=revision.variant_id,
-            resolved_variant_slug=revision.variant_slug,
-            resolved_revision_id=revision.id,
-            resolved_revision_slug=revision.slug,
-            resolved_revision_version=revision.version,
+            resolved_artifact_ref=Reference(
+                id=revision.artifact_id,
+                slug=revision.artifact_slug,
+            ),
+            resolved_variant_ref=Reference(
+                id=revision.variant_id,
+                slug=revision.variant_slug,
+            ),
+            resolved_revision_ref=Reference(
+                id=revision.id,
+                slug=revision.slug,
+                version=revision.version,
+            ),
             entity_type="query",
         )
 

--- a/api/oss/src/core/testsets/service.py
+++ b/api/oss/src/core/testsets/service.py
@@ -5,7 +5,8 @@ from oss.src.utils.logging import get_module_logger
 from oss.src.core.events.utils import publish_revision_event
 from oss.src.core.git.interfaces import GitDAOInterface
 from oss.src.core.git.types import (
-    validate_revision_ref_unambiguous,
+    validate_revision_refs_sufficient,
+    validate_variant_refs_sufficient,
     needs_default_variant_resolution,
     validate_retrieve_refs_consistent,
 )
@@ -428,6 +429,10 @@ class TestsetsService:
         testset_ref: Optional[Reference] = None,
         testset_variant_ref: Optional[Reference] = None,
     ) -> Optional[TestsetVariant]:
+        validate_variant_refs_sufficient(
+            variant_ref=testset_variant_ref,
+            entity_type="testset",
+        )
         variant = await self.testsets_dao.fetch_variant(
             project_id=project_id,
             #
@@ -641,7 +646,11 @@ class TestsetsService:
         if not testset_ref and not testset_variant_ref and not testset_revision_ref:
             return None
 
-        validate_revision_ref_unambiguous(
+        validate_variant_refs_sufficient(
+            variant_ref=testset_variant_ref,
+            entity_type="testset",
+        )
+        validate_revision_refs_sufficient(
             artifact_ref=testset_ref,
             variant_ref=testset_variant_ref,
             revision_ref=testset_revision_ref,

--- a/api/oss/src/core/testsets/service.py
+++ b/api/oss/src/core/testsets/service.py
@@ -7,6 +7,7 @@ from oss.src.core.git.interfaces import GitDAOInterface
 from oss.src.core.git.types import (
     validate_revision_ref_unambiguous,
     needs_default_variant_resolution,
+    validate_retrieve_refs_consistent,
 )
 from oss.src.core.testcases.service import TestcasesService
 from oss.src.core.shared.dtos import Reference, Windowing
@@ -647,6 +648,9 @@ class TestsetsService:
             entity_type="testset",
         )
 
+        _original_testset_ref = testset_ref
+        _original_testset_variant_ref = testset_variant_ref
+
         if needs_default_variant_resolution(
             artifact_ref=testset_ref,
             variant_ref=testset_variant_ref,
@@ -689,6 +693,20 @@ class TestsetsService:
 
         if not revision:
             return None
+
+        validate_retrieve_refs_consistent(
+            artifact_ref=_original_testset_ref,
+            variant_ref=_original_testset_variant_ref,
+            revision_ref=testset_revision_ref,
+            resolved_artifact_id=revision.artifact_id,
+            resolved_artifact_slug=revision.artifact_slug,
+            resolved_variant_id=revision.variant_id,
+            resolved_variant_slug=revision.variant_slug,
+            resolved_revision_id=revision.id,
+            resolved_revision_slug=revision.slug,
+            resolved_revision_version=revision.version,
+            entity_type="testset",
+        )
 
         testset_revision = TestsetRevision(
             **revision.model_dump(

--- a/api/oss/src/core/testsets/service.py
+++ b/api/oss/src/core/testsets/service.py
@@ -698,13 +698,19 @@ class TestsetsService:
             artifact_ref=_original_testset_ref,
             variant_ref=_original_testset_variant_ref,
             revision_ref=testset_revision_ref,
-            resolved_artifact_id=revision.artifact_id,
-            resolved_artifact_slug=revision.artifact_slug,
-            resolved_variant_id=revision.variant_id,
-            resolved_variant_slug=revision.variant_slug,
-            resolved_revision_id=revision.id,
-            resolved_revision_slug=revision.slug,
-            resolved_revision_version=revision.version,
+            resolved_artifact_ref=Reference(
+                id=revision.artifact_id,
+                slug=revision.artifact_slug,
+            ),
+            resolved_variant_ref=Reference(
+                id=revision.variant_id,
+                slug=revision.variant_slug,
+            ),
+            resolved_revision_ref=Reference(
+                id=revision.id,
+                slug=revision.slug,
+                version=revision.version,
+            ),
             entity_type="testset",
         )
 

--- a/api/oss/src/core/workflows/service.py
+++ b/api/oss/src/core/workflows/service.py
@@ -1147,13 +1147,19 @@ class WorkflowsService:
             artifact_ref=_original_workflow_ref,
             variant_ref=_original_workflow_variant_ref,
             revision_ref=workflow_revision_ref,
-            resolved_artifact_id=revision.artifact_id,
-            resolved_artifact_slug=revision.artifact_slug,
-            resolved_variant_id=revision.variant_id,
-            resolved_variant_slug=revision.variant_slug,
-            resolved_revision_id=revision.id,
-            resolved_revision_slug=revision.slug,
-            resolved_revision_version=revision.version,
+            resolved_artifact_ref=Reference(
+                id=revision.artifact_id,
+                slug=revision.artifact_slug,
+            ),
+            resolved_variant_ref=Reference(
+                id=revision.variant_id,
+                slug=revision.variant_slug,
+            ),
+            resolved_revision_ref=Reference(
+                id=revision.id,
+                slug=revision.slug,
+                version=revision.version,
+            ),
             entity_type="workflow",
         )
 

--- a/api/oss/src/core/workflows/service.py
+++ b/api/oss/src/core/workflows/service.py
@@ -80,7 +80,8 @@ from oss.src.core.workflows.dtos import (
     WorkflowServiceStreamResponse,
 )
 from oss.src.core.git.types import (
-    validate_revision_ref_unambiguous,
+    validate_revision_refs_sufficient,
+    validate_variant_refs_sufficient,
     needs_default_variant_resolution,
     validate_retrieve_refs_consistent,
 )
@@ -833,6 +834,10 @@ class WorkflowsService:
         #
         include_archived: Optional[bool] = True,
     ) -> Optional[WorkflowVariant]:
+        validate_variant_refs_sufficient(
+            variant_ref=workflow_variant_ref,
+            entity_type="workflow",
+        )
         variant = await self.workflows_dao.fetch_variant(
             project_id=project_id,
             #
@@ -1084,7 +1089,11 @@ class WorkflowsService:
         if not workflow_ref and not workflow_variant_ref and not workflow_revision_ref:
             return None
 
-        validate_revision_ref_unambiguous(
+        validate_variant_refs_sufficient(
+            variant_ref=workflow_variant_ref,
+            entity_type="workflow",
+        )
+        validate_revision_refs_sufficient(
             artifact_ref=workflow_ref,
             variant_ref=workflow_variant_ref,
             revision_ref=workflow_revision_ref,

--- a/api/oss/src/core/workflows/service.py
+++ b/api/oss/src/core/workflows/service.py
@@ -82,6 +82,7 @@ from oss.src.core.workflows.dtos import (
 from oss.src.core.git.types import (
     validate_revision_ref_unambiguous,
     needs_default_variant_resolution,
+    validate_retrieve_refs_consistent,
 )
 
 # Resolution is now handled by EmbedsService
@@ -1090,6 +1091,9 @@ class WorkflowsService:
             entity_type="workflow",
         )
 
+        _original_workflow_ref = workflow_ref
+        _original_workflow_variant_ref = workflow_variant_ref
+
         if needs_default_variant_resolution(
             artifact_ref=workflow_ref,
             variant_ref=workflow_variant_ref,
@@ -1138,6 +1142,20 @@ class WorkflowsService:
 
         if not revision:
             return None
+
+        validate_retrieve_refs_consistent(
+            artifact_ref=_original_workflow_ref,
+            variant_ref=_original_workflow_variant_ref,
+            revision_ref=workflow_revision_ref,
+            resolved_artifact_id=revision.artifact_id,
+            resolved_artifact_slug=revision.artifact_slug,
+            resolved_variant_id=revision.variant_id,
+            resolved_variant_slug=revision.variant_slug,
+            resolved_revision_id=revision.id,
+            resolved_revision_slug=revision.slug,
+            resolved_revision_version=revision.version,
+            entity_type="workflow",
+        )
 
         _workflow_revision = WorkflowRevision(
             **revision.model_dump(mode="json"),

--- a/api/oss/tests/pytest/acceptance/test_env_backed_retrieve_policy.py
+++ b/api/oss/tests/pytest/acceptance/test_env_backed_retrieve_policy.py
@@ -1,0 +1,87 @@
+"""Acceptance: env-backed retrieve policy is consistent across entities.
+
+Three retrieve endpoints support an environment-ref path:
+  /workflows/revisions/retrieve
+  /applications/revisions/retrieve
+  /evaluators/revisions/retrieve
+
+All three should:
+  - Reject {} (no entity refs, no env refs, no key) with 400.
+  - Reject env-backed retrieve when env refs are present without a `key`
+    AND no artifact_ref to derive it from.
+  - Path-mixing (entity refs AND env refs) is allowed at the policy
+    boundary; downstream services may surface a 4xx for unresolvable
+    cases but not here.
+"""
+
+from uuid import uuid4
+
+
+def _assert_400(response):
+    assert response.status_code == 400, response.text
+
+
+def test_workflows_retrieve_empty_request_returns_400(authed_api):
+    response = authed_api("POST", "/workflows/revisions/retrieve", json={})
+    _assert_400(response)
+
+
+def test_applications_retrieve_empty_request_returns_400(authed_api):
+    response = authed_api("POST", "/applications/revisions/retrieve", json={})
+    _assert_400(response)
+
+
+def test_evaluators_retrieve_empty_request_returns_400(authed_api):
+    response = authed_api("POST", "/evaluators/revisions/retrieve", json={})
+    _assert_400(response)
+
+
+def test_workflows_env_refs_without_key_or_artifact_returns_400(authed_api):
+    response = authed_api(
+        "POST",
+        "/workflows/revisions/retrieve",
+        json={"environment_ref": {"slug": f"env-{uuid4().hex[:8]}"}},
+    )
+    _assert_400(response)
+
+
+def test_evaluators_env_refs_without_key_or_artifact_returns_400(authed_api):
+    response = authed_api(
+        "POST",
+        "/evaluators/revisions/retrieve",
+        json={"environment_ref": {"slug": f"env-{uuid4().hex[:8]}"}},
+    )
+    _assert_400(response)
+
+
+def test_applications_env_refs_without_key_or_artifact_returns_400(authed_api):
+    response = authed_api(
+        "POST",
+        "/applications/revisions/retrieve",
+        json={"environment_ref": {"slug": f"env-{uuid4().hex[:8]}"}},
+    )
+    _assert_400(response)
+
+
+def test_workflows_path_mixing_does_not_return_400_at_policy_boundary(authed_api):
+    response = authed_api(
+        "POST",
+        "/workflows/revisions/retrieve",
+        json={
+            "workflow_ref": {"slug": f"wf-{uuid4().hex[:8]}"},
+            "environment_ref": {"slug": f"env-{uuid4().hex[:8]}"},
+        },
+    )
+    assert response.status_code != 400, response.text
+
+
+def test_evaluators_path_mixing_does_not_return_400_at_policy_boundary(authed_api):
+    response = authed_api(
+        "POST",
+        "/evaluators/revisions/retrieve",
+        json={
+            "evaluator_ref": {"slug": f"ev-{uuid4().hex[:8]}"},
+            "environment_ref": {"slug": f"env-{uuid4().hex[:8]}"},
+        },
+    )
+    assert response.status_code != 400, response.text

--- a/api/oss/tests/pytest/acceptance/test_revision_retrieve_ambiguous_400.py
+++ b/api/oss/tests/pytest/acceptance/test_revision_retrieve_ambiguous_400.py
@@ -1,6 +1,6 @@
 """Acceptance: ambiguous revision-retrieve requests return HTTP 400.
 
-The shared `validate_revision_ref_unambiguous` helper protects every
+The shared `validate_revision_refs_sufficient` helper protects every
 git-backed entity's retrieve endpoint against the version-only-no-variant
 trap. These tests assert the 400 surfaces correctly across all six
 endpoints — applications, evaluators, queries, testsets, environments,

--- a/api/oss/tests/pytest/acceptance/test_revision_retrieve_env_path.py
+++ b/api/oss/tests/pytest/acceptance/test_revision_retrieve_env_path.py
@@ -1,0 +1,442 @@
+"""Acceptance: env-backed revision-retrieve coverage (C8 second pass).
+
+Pins env-path behavior on the three routers that accept env refs:
+applications, evaluators, workflows. Each test provisions a real
+artifact + variant + revision and deploys the revision to an environment
+under the default `{artifact_slug}.revision` key, then exercises:
+
+  * 2.a (env path): `{env_ref + key}` → 200, returns the deployed revision.
+  * 2.d (env path, default key): `{env_ref + artifact_ref}` (no `key`,
+    derived from the artifact slug) → 200.
+  * 2.b (redundant-consistent path-mixing): `{env_ref + key +
+    artifact_ref (matching)}` → 200.
+  * 2.c (path-mixed inconsistent): `{env_ref + key + revision_ref.id}`
+    where the revision_ref does NOT match what env+key resolves to → 400.
+
+The workflows/applications/evaluators routers all funnel into the same
+service-layer pipeline, so the matrix is intentionally symmetric.
+"""
+
+from uuid import uuid4
+
+
+# environment helpers ----------------------------------------------------------
+
+
+def _create_environment_with_deployment(authed_api, *, key, payload):
+    """Create an environment + variant + revision that deploys `payload`
+    under the given `key`. Returns the env, variant and revision rows.
+    """
+    slug = uuid4().hex[:12]
+    response = authed_api(
+        "POST",
+        "/environments/",
+        json={"environment": {"slug": f"env-{slug}"}},
+    )
+    assert response.status_code == 200, response.text
+    env = response.json()["environment"]
+
+    response = authed_api(
+        "POST",
+        "/environments/variants/",
+        json={
+            "environment_variant": {
+                "slug": f"envv-{slug}",
+                "environment_id": env["id"],
+            }
+        },
+    )
+    assert response.status_code == 200, response.text
+    env_variant = response.json()["environment_variant"]
+
+    response = authed_api(
+        "POST",
+        "/environments/revisions/commit",
+        json={
+            "environment_revision_commit": {
+                "slug": f"envr-{slug}",
+                "environment_id": env["id"],
+                "environment_variant_id": env_variant["id"],
+                "data": {"references": {key: payload}},
+            }
+        },
+    )
+    assert response.status_code == 200, response.text
+    env_revision = response.json()["environment_revision"]
+    return env, env_variant, env_revision
+
+
+# workflows --------------------------------------------------------------------
+
+
+def _create_workflow_stack(authed_api):
+    slug = uuid4().hex[:12]
+    response = authed_api(
+        "POST",
+        "/workflows/",
+        json={"workflow": {"slug": f"wf-{slug}"}},
+    )
+    assert response.status_code == 200, response.text
+    workflow = response.json()["workflow"]
+
+    response = authed_api(
+        "POST",
+        "/workflows/variants/",
+        json={
+            "workflow_variant": {
+                "slug": f"wfv-{slug}",
+                "workflow_id": workflow["id"],
+            }
+        },
+    )
+    assert response.status_code == 200, response.text
+    variant = response.json()["workflow_variant"]
+
+    response = authed_api(
+        "POST",
+        "/workflows/revisions/",
+        json={
+            "workflow_revision": {
+                "slug": f"wfr-{slug}",
+                "workflow_variant_id": variant["id"],
+                "workflow_id": workflow["id"],
+            }
+        },
+    )
+    assert response.status_code == 200, response.text
+    revision = response.json()["workflow_revision"]
+    return workflow, variant, revision
+
+
+def _deploy_workflow_to_env(authed_api, workflow, variant, revision):
+    key = f"{workflow['slug']}.revision"
+    payload = {
+        "workflow": {"id": workflow["id"], "slug": workflow["slug"]},
+        "workflow_variant": {"id": variant["id"], "slug": variant["slug"]},
+        "workflow_revision": {
+            "id": revision["id"],
+            "version": revision.get("version") or "1",
+        },
+    }
+    return _create_environment_with_deployment(authed_api, key=key, payload=payload)
+
+
+def test_workflows_env_retrieve_by_env_slug_and_key(authed_api):
+    workflow, variant, revision = _create_workflow_stack(authed_api)
+    env, _, _ = _deploy_workflow_to_env(authed_api, workflow, variant, revision)
+
+    response = authed_api(
+        "POST",
+        "/workflows/revisions/retrieve",
+        json={
+            "environment_ref": {"slug": env["slug"]},
+            "key": f"{workflow['slug']}.revision",
+        },
+    )
+    assert response.status_code == 200, response.text
+    assert response.json()["workflow_revision"]["id"] == revision["id"]
+
+
+def test_workflows_env_retrieve_default_key_from_artifact_slug(authed_api):
+    workflow, variant, revision = _create_workflow_stack(authed_api)
+    env, _, _ = _deploy_workflow_to_env(authed_api, workflow, variant, revision)
+
+    response = authed_api(
+        "POST",
+        "/workflows/revisions/retrieve",
+        json={
+            "environment_ref": {"slug": env["slug"]},
+            "workflow_ref": {"slug": workflow["slug"]},
+        },
+    )
+    assert response.status_code == 200, response.text
+    assert response.json()["workflow_revision"]["id"] == revision["id"]
+
+
+def test_workflows_env_retrieve_with_redundant_consistent_artifact(authed_api):
+    workflow, variant, revision = _create_workflow_stack(authed_api)
+    env, _, _ = _deploy_workflow_to_env(authed_api, workflow, variant, revision)
+
+    response = authed_api(
+        "POST",
+        "/workflows/revisions/retrieve",
+        json={
+            "environment_ref": {"slug": env["slug"]},
+            "key": f"{workflow['slug']}.revision",
+            "workflow_ref": {"id": workflow["id"], "slug": workflow["slug"]},
+        },
+    )
+    assert response.status_code == 200, response.text
+    assert response.json()["workflow_revision"]["id"] == revision["id"]
+
+
+def test_workflows_env_retrieve_path_mixed_inconsistent_revision_returns_400(
+    authed_api,
+):
+    workflow, variant, revision = _create_workflow_stack(authed_api)
+    env, _, _ = _deploy_workflow_to_env(authed_api, workflow, variant, revision)
+
+    _, _, unrelated_revision = _create_workflow_stack(authed_api)
+
+    response = authed_api(
+        "POST",
+        "/workflows/revisions/retrieve",
+        json={
+            "environment_ref": {"slug": env["slug"]},
+            "key": f"{workflow['slug']}.revision",
+            "workflow_revision_ref": {"id": unrelated_revision["id"]},
+        },
+    )
+    assert response.status_code == 400, response.text
+
+
+# applications -----------------------------------------------------------------
+
+
+def _create_application_stack(authed_api):
+    slug = uuid4().hex[:12]
+    flags = {"is_application": True, "is_evaluator": False, "is_snippet": False}
+    response = authed_api(
+        "POST",
+        "/applications/",
+        json={"application": {"slug": f"app-{slug}", "flags": flags}},
+    )
+    assert response.status_code == 200, response.text
+    app = response.json()["application"]
+
+    response = authed_api(
+        "POST",
+        "/applications/variants/",
+        json={
+            "application_variant": {
+                "slug": f"appv-{slug}",
+                "application_id": app["id"],
+                "flags": flags,
+            }
+        },
+    )
+    assert response.status_code == 200, response.text
+    variant = response.json()["application_variant"]
+
+    response = authed_api(
+        "POST",
+        "/applications/revisions/commit",
+        json={
+            "application_revision_commit": {
+                "application_id": app["id"],
+                "application_variant_id": variant["id"],
+                "data": {"parameters": {"model": "test-model"}},
+            }
+        },
+    )
+    assert response.status_code == 200, response.text
+    revision = response.json()["application_revision"]
+    return app, variant, revision
+
+
+def _deploy_application_to_env(authed_api, app, variant, revision):
+    key = f"{app['slug']}.revision"
+    payload = {
+        "application": {"id": app["id"], "slug": app["slug"]},
+        "application_variant": {"id": variant["id"], "slug": variant["slug"]},
+        "application_revision": {
+            "id": revision["id"],
+            "version": revision.get("version") or "1",
+        },
+    }
+    return _create_environment_with_deployment(authed_api, key=key, payload=payload)
+
+
+def test_applications_env_retrieve_by_env_slug_and_key(authed_api):
+    app, variant, revision = _create_application_stack(authed_api)
+    env, _, _ = _deploy_application_to_env(authed_api, app, variant, revision)
+
+    response = authed_api(
+        "POST",
+        "/applications/revisions/retrieve",
+        json={
+            "environment_ref": {"slug": env["slug"]},
+            "key": f"{app['slug']}.revision",
+        },
+    )
+    assert response.status_code == 200, response.text
+    assert response.json()["application_revision"]["id"] == revision["id"]
+
+
+def test_applications_env_retrieve_default_key_from_artifact_slug(authed_api):
+    app, variant, revision = _create_application_stack(authed_api)
+    env, _, _ = _deploy_application_to_env(authed_api, app, variant, revision)
+
+    response = authed_api(
+        "POST",
+        "/applications/revisions/retrieve",
+        json={
+            "environment_ref": {"slug": env["slug"]},
+            "application_ref": {"slug": app["slug"]},
+        },
+    )
+    assert response.status_code == 200, response.text
+    assert response.json()["application_revision"]["id"] == revision["id"]
+
+
+def test_applications_env_retrieve_with_redundant_consistent_artifact(authed_api):
+    app, variant, revision = _create_application_stack(authed_api)
+    env, _, _ = _deploy_application_to_env(authed_api, app, variant, revision)
+
+    response = authed_api(
+        "POST",
+        "/applications/revisions/retrieve",
+        json={
+            "environment_ref": {"slug": env["slug"]},
+            "key": f"{app['slug']}.revision",
+            "application_ref": {"id": app["id"], "slug": app["slug"]},
+        },
+    )
+    assert response.status_code == 200, response.text
+    assert response.json()["application_revision"]["id"] == revision["id"]
+
+
+def test_applications_env_retrieve_path_mixed_inconsistent_revision_returns_400(
+    authed_api,
+):
+    app, variant, revision = _create_application_stack(authed_api)
+    env, _, _ = _deploy_application_to_env(authed_api, app, variant, revision)
+
+    _, _, unrelated_revision = _create_application_stack(authed_api)
+
+    response = authed_api(
+        "POST",
+        "/applications/revisions/retrieve",
+        json={
+            "environment_ref": {"slug": env["slug"]},
+            "key": f"{app['slug']}.revision",
+            "application_revision_ref": {"id": unrelated_revision["id"]},
+        },
+    )
+    assert response.status_code == 400, response.text
+
+
+# evaluators -------------------------------------------------------------------
+
+
+def _create_evaluator_stack(authed_api):
+    slug = uuid4().hex[:12]
+    flags = {"is_evaluator": True}
+    response = authed_api(
+        "POST",
+        "/evaluators/",
+        json={"evaluator": {"slug": f"ev-{slug}", "flags": flags}},
+    )
+    assert response.status_code == 200, response.text
+    evaluator = response.json()["evaluator"]
+
+    response = authed_api(
+        "POST",
+        "/evaluators/variants/",
+        json={
+            "evaluator_variant": {
+                "slug": f"evv-{slug}",
+                "evaluator_id": evaluator["id"],
+                "flags": flags,
+            }
+        },
+    )
+    assert response.status_code == 200, response.text
+    variant = response.json()["evaluator_variant"]
+
+    response = authed_api(
+        "POST",
+        "/evaluators/revisions/commit",
+        json={
+            "evaluator_revision_commit": {
+                "evaluator_id": evaluator["id"],
+                "evaluator_variant_id": variant["id"],
+                "data": {"parameters": {"threshold": 0.5}},
+            }
+        },
+    )
+    assert response.status_code == 200, response.text
+    revision = response.json()["evaluator_revision"]
+    return evaluator, variant, revision
+
+
+def _deploy_evaluator_to_env(authed_api, evaluator, variant, revision):
+    key = f"{evaluator['slug']}.revision"
+    payload = {
+        "evaluator": {"id": evaluator["id"], "slug": evaluator["slug"]},
+        "evaluator_variant": {"id": variant["id"], "slug": variant["slug"]},
+        "evaluator_revision": {
+            "id": revision["id"],
+            "version": revision.get("version") or "1",
+        },
+    }
+    return _create_environment_with_deployment(authed_api, key=key, payload=payload)
+
+
+def test_evaluators_env_retrieve_by_env_slug_and_key(authed_api):
+    evaluator, variant, revision = _create_evaluator_stack(authed_api)
+    env, _, _ = _deploy_evaluator_to_env(authed_api, evaluator, variant, revision)
+
+    response = authed_api(
+        "POST",
+        "/evaluators/revisions/retrieve",
+        json={
+            "environment_ref": {"slug": env["slug"]},
+            "key": f"{evaluator['slug']}.revision",
+        },
+    )
+    assert response.status_code == 200, response.text
+    assert response.json()["evaluator_revision"]["id"] == revision["id"]
+
+
+def test_evaluators_env_retrieve_default_key_from_artifact_slug(authed_api):
+    evaluator, variant, revision = _create_evaluator_stack(authed_api)
+    env, _, _ = _deploy_evaluator_to_env(authed_api, evaluator, variant, revision)
+
+    response = authed_api(
+        "POST",
+        "/evaluators/revisions/retrieve",
+        json={
+            "environment_ref": {"slug": env["slug"]},
+            "evaluator_ref": {"slug": evaluator["slug"]},
+        },
+    )
+    assert response.status_code == 200, response.text
+    assert response.json()["evaluator_revision"]["id"] == revision["id"]
+
+
+def test_evaluators_env_retrieve_with_redundant_consistent_artifact(authed_api):
+    evaluator, variant, revision = _create_evaluator_stack(authed_api)
+    env, _, _ = _deploy_evaluator_to_env(authed_api, evaluator, variant, revision)
+
+    response = authed_api(
+        "POST",
+        "/evaluators/revisions/retrieve",
+        json={
+            "environment_ref": {"slug": env["slug"]},
+            "key": f"{evaluator['slug']}.revision",
+            "evaluator_ref": {"id": evaluator["id"], "slug": evaluator["slug"]},
+        },
+    )
+    assert response.status_code == 200, response.text
+    assert response.json()["evaluator_revision"]["id"] == revision["id"]
+
+
+def test_evaluators_env_retrieve_path_mixed_inconsistent_revision_returns_400(
+    authed_api,
+):
+    evaluator, variant, revision = _create_evaluator_stack(authed_api)
+    env, _, _ = _deploy_evaluator_to_env(authed_api, evaluator, variant, revision)
+
+    _, _, unrelated_revision = _create_evaluator_stack(authed_api)
+
+    response = authed_api(
+        "POST",
+        "/evaluators/revisions/retrieve",
+        json={
+            "environment_ref": {"slug": env["slug"]},
+            "key": f"{evaluator['slug']}.revision",
+            "evaluator_revision_ref": {"id": unrelated_revision["id"]},
+        },
+    )
+    assert response.status_code == 400, response.text

--- a/api/oss/tests/pytest/acceptance/test_revision_retrieve_inconsistent_400.py
+++ b/api/oss/tests/pytest/acceptance/test_revision_retrieve_inconsistent_400.py
@@ -1,0 +1,348 @@
+"""Acceptance: inconsistent revision-retrieve requests return HTTP 400.
+
+The shared `validate_retrieve_refs_consistent` helper rejects requests where
+caller-supplied artifact/variant/revision refs disagree with the resolved
+revision's identity. These tests assert the 400 surfaces correctly across
+all six entities — applications, evaluators, queries, testsets,
+environments, workflows.
+
+For each entity:
+
+  * A `_create_*_stack` helper provisions a real artifact + variant +
+    revision so consistency can be evaluated against a real row.
+  * One negative test: pass a `revision_ref.id` together with an
+    `artifact_ref.slug` that does NOT belong to that revision. Must return
+    400 with the offending field mentioned in the detail.
+
+Each test creates its own fixture so the tests don't share global state.
+"""
+
+from uuid import uuid4
+
+
+def _assert_inconsistent_400(response):
+    assert response.status_code == 400, response.text
+    body = response.json()
+    detail = body.get("detail", "")
+    assert "does not match" in detail or "_ref" in detail, body
+
+
+def _create_workflow_stack(authed_api):
+    slug = uuid4().hex[:12]
+    response = authed_api(
+        "POST",
+        "/workflows/",
+        json={"workflow": {"slug": f"wf-{slug}"}},
+    )
+    assert response.status_code == 200, response.text
+    workflow = response.json()["workflow"]
+
+    response = authed_api(
+        "POST",
+        "/workflows/variants/",
+        json={
+            "workflow_variant": {
+                "slug": f"wfv-{slug}",
+                "workflow_id": workflow["id"],
+            }
+        },
+    )
+    assert response.status_code == 200, response.text
+    variant = response.json()["workflow_variant"]
+
+    response = authed_api(
+        "POST",
+        "/workflows/revisions/",
+        json={
+            "workflow_revision": {
+                "slug": f"wfr-{slug}",
+                "workflow_variant_id": variant["id"],
+                "workflow_id": workflow["id"],
+            }
+        },
+    )
+    assert response.status_code == 200, response.text
+    revision = response.json()["workflow_revision"]
+    return workflow, variant, revision
+
+
+def test_workflows_retrieve_artifact_slug_disagrees_with_revision_id_returns_400(
+    authed_api,
+):
+    _, _, revision = _create_workflow_stack(authed_api)
+    response = authed_api(
+        "POST",
+        "/workflows/revisions/retrieve",
+        json={
+            "workflow_ref": {"slug": f"unrelated-{uuid4().hex[:8]}"},
+            "workflow_revision_ref": {"id": revision["id"]},
+        },
+    )
+    _assert_inconsistent_400(response)
+
+
+def _create_application_stack(authed_api):
+    slug = uuid4().hex[:12]
+    flags = {"is_application": True, "is_evaluator": False, "is_snippet": False}
+    response = authed_api(
+        "POST",
+        "/applications/",
+        json={"application": {"slug": f"app-{slug}", "flags": flags}},
+    )
+    assert response.status_code == 200, response.text
+    app = response.json()["application"]
+
+    response = authed_api(
+        "POST",
+        "/applications/variants/",
+        json={
+            "application_variant": {
+                "slug": f"appv-{slug}",
+                "application_id": app["id"],
+                "flags": flags,
+            }
+        },
+    )
+    assert response.status_code == 200, response.text
+    variant = response.json()["application_variant"]
+
+    response = authed_api(
+        "POST",
+        "/applications/revisions/commit",
+        json={
+            "application_revision_commit": {
+                "application_id": app["id"],
+                "application_variant_id": variant["id"],
+                "data": {"parameters": {"model": "test-model"}},
+            }
+        },
+    )
+    assert response.status_code == 200, response.text
+    revision = response.json()["application_revision"]
+    return app, variant, revision
+
+
+def test_applications_retrieve_artifact_slug_disagrees_with_revision_id_returns_400(
+    authed_api,
+):
+    _, _, revision = _create_application_stack(authed_api)
+    response = authed_api(
+        "POST",
+        "/applications/revisions/retrieve",
+        json={
+            "application_ref": {"slug": f"unrelated-{uuid4().hex[:8]}"},
+            "application_revision_ref": {"id": revision["id"]},
+        },
+    )
+    _assert_inconsistent_400(response)
+
+
+def _create_evaluator_stack(authed_api):
+    slug = uuid4().hex[:12]
+    flags = {"is_application": False, "is_evaluator": True, "is_snippet": False}
+    response = authed_api(
+        "POST",
+        "/evaluators/",
+        json={"evaluator": {"slug": f"ev-{slug}", "flags": flags}},
+    )
+    assert response.status_code == 200, response.text
+    evaluator = response.json()["evaluator"]
+
+    response = authed_api(
+        "POST",
+        "/evaluators/variants/",
+        json={
+            "evaluator_variant": {
+                "slug": f"evv-{slug}",
+                "evaluator_id": evaluator["id"],
+                "flags": flags,
+            }
+        },
+    )
+    assert response.status_code == 200, response.text
+    variant = response.json()["evaluator_variant"]
+
+    response = authed_api(
+        "POST",
+        "/evaluators/revisions/commit",
+        json={
+            "evaluator_revision_commit": {
+                "evaluator_id": evaluator["id"],
+                "evaluator_variant_id": variant["id"],
+                "data": {"parameters": {"model": "test-model"}},
+            }
+        },
+    )
+    assert response.status_code == 200, response.text
+    revision = response.json()["evaluator_revision"]
+    return evaluator, variant, revision
+
+
+def test_evaluators_retrieve_artifact_slug_disagrees_with_revision_id_returns_400(
+    authed_api,
+):
+    _, _, revision = _create_evaluator_stack(authed_api)
+    response = authed_api(
+        "POST",
+        "/evaluators/revisions/retrieve",
+        json={
+            "evaluator_ref": {"slug": f"unrelated-{uuid4().hex[:8]}"},
+            "evaluator_revision_ref": {"id": revision["id"]},
+        },
+    )
+    _assert_inconsistent_400(response)
+
+
+def _create_testset_stack(authed_api):
+    slug = uuid4().hex[:12]
+    response = authed_api(
+        "POST",
+        "/testsets/",
+        json={"testset": {"slug": f"ts-{slug}"}},
+    )
+    assert response.status_code == 200, response.text
+    testset = response.json()["testset"]
+
+    response = authed_api(
+        "POST",
+        "/testsets/variants/",
+        json={
+            "testset_variant": {
+                "slug": f"tsv-{slug}",
+                "testset_id": testset["id"],
+            }
+        },
+    )
+    assert response.status_code == 200, response.text
+    variant = response.json()["testset_variant"]
+
+    response = authed_api(
+        "POST",
+        "/testsets/revisions/commit",
+        json={
+            "testset_revision_commit": {
+                "testset_id": testset["id"],
+                "testset_variant_id": variant["id"],
+                "data": {"testcases": []},
+            }
+        },
+    )
+    assert response.status_code == 200, response.text
+    revision = response.json()["testset_revision"]
+    return testset, variant, revision
+
+
+def test_testsets_retrieve_artifact_slug_disagrees_with_revision_id_returns_400(
+    authed_api,
+):
+    _, _, revision = _create_testset_stack(authed_api)
+    response = authed_api(
+        "POST",
+        "/testsets/revisions/retrieve",
+        json={
+            "testset_ref": {"slug": f"unrelated-{uuid4().hex[:8]}"},
+            "testset_revision_ref": {"id": revision["id"]},
+        },
+    )
+    _assert_inconsistent_400(response)
+
+
+def _create_query_stack(authed_api):
+    slug = uuid4().hex[:12]
+    response = authed_api(
+        "POST",
+        "/simple/queries/",
+        json={
+            "query": {
+                "slug": f"qry-{slug}",
+                "name": f"qry-{slug}",
+                "data": {"windowing": {"limit": 50}},
+            }
+        },
+    )
+    assert response.status_code == 200, response.text
+    query = response.json()["query"]
+
+    response = authed_api(
+        "POST",
+        "/queries/revisions/commit",
+        json={
+            "query_revision_commit": {
+                "query_id": query["id"],
+                "query_variant_id": query["variant_id"],
+                "data": {"windowing": {"limit": 50}},
+            }
+        },
+    )
+    assert response.status_code == 200, response.text
+    revision = response.json()["query_revision"]
+    return query, revision
+
+
+def test_queries_retrieve_artifact_slug_disagrees_with_revision_id_returns_400(
+    authed_api,
+):
+    _, revision = _create_query_stack(authed_api)
+    response = authed_api(
+        "POST",
+        "/queries/revisions/retrieve",
+        json={
+            "query_ref": {"slug": f"unrelated-{uuid4().hex[:8]}"},
+            "query_revision_ref": {"id": revision["id"]},
+        },
+    )
+    _assert_inconsistent_400(response)
+
+
+def _create_environment_stack(authed_api):
+    slug = uuid4().hex[:12]
+    response = authed_api(
+        "POST",
+        "/environments/",
+        json={"environment": {"slug": f"env-{slug}"}},
+    )
+    assert response.status_code == 200, response.text
+    environment = response.json()["environment"]
+
+    response = authed_api(
+        "POST",
+        "/environments/variants/",
+        json={
+            "environment_variant": {
+                "slug": f"envv-{slug}",
+                "environment_id": environment["id"],
+            }
+        },
+    )
+    assert response.status_code == 200, response.text
+    variant = response.json()["environment_variant"]
+
+    response = authed_api(
+        "POST",
+        "/environments/revisions/commit",
+        json={
+            "environment_revision_commit": {
+                "environment_id": environment["id"],
+                "environment_variant_id": variant["id"],
+                "data": {"references": {}},
+            }
+        },
+    )
+    assert response.status_code == 200, response.text
+    revision = response.json()["environment_revision"]
+    return environment, variant, revision
+
+
+def test_environments_retrieve_artifact_slug_disagrees_with_revision_id_returns_400(
+    authed_api,
+):
+    _, _, revision = _create_environment_stack(authed_api)
+    response = authed_api(
+        "POST",
+        "/environments/revisions/retrieve",
+        json={
+            "environment_ref": {"slug": f"unrelated-{uuid4().hex[:8]}"},
+            "environment_revision_ref": {"id": revision["id"]},
+        },
+    )
+    _assert_inconsistent_400(response)

--- a/api/oss/tests/pytest/acceptance/test_variant_ref_version_only_400.py
+++ b/api/oss/tests/pytest/acceptance/test_variant_ref_version_only_400.py
@@ -1,0 +1,68 @@
+"""Acceptance: variant_ref with only `version` returns HTTP 400.
+
+Variants have no `version` field — version is a per-variant counter living
+on revisions. A request like `{*_variant_ref: {version: "1"}}` is nonsense
+the DAO would silently drop. The shared `validate_variant_refs_sufficient`
+helper rejects it; these tests pin that behavior across all six entities.
+"""
+
+
+def _assert_variant_400(response):
+    assert response.status_code == 400, response.text
+    body = response.json()
+    detail = body.get("detail", "")
+    assert "variant_ref" in detail, body
+
+
+def test_workflows_retrieve_variant_version_only_returns_400(authed_api):
+    response = authed_api(
+        "POST",
+        "/workflows/revisions/retrieve",
+        json={"workflow_variant_ref": {"version": "1"}},
+    )
+    _assert_variant_400(response)
+
+
+def test_applications_retrieve_variant_version_only_returns_400(authed_api):
+    response = authed_api(
+        "POST",
+        "/applications/revisions/retrieve",
+        json={"application_variant_ref": {"version": "1"}},
+    )
+    _assert_variant_400(response)
+
+
+def test_evaluators_retrieve_variant_version_only_returns_400(authed_api):
+    response = authed_api(
+        "POST",
+        "/evaluators/revisions/retrieve",
+        json={"evaluator_variant_ref": {"version": "1"}},
+    )
+    _assert_variant_400(response)
+
+
+def test_testsets_retrieve_variant_version_only_returns_400(authed_api):
+    response = authed_api(
+        "POST",
+        "/testsets/revisions/retrieve",
+        json={"testset_variant_ref": {"version": "1"}},
+    )
+    _assert_variant_400(response)
+
+
+def test_queries_retrieve_variant_version_only_returns_400(authed_api):
+    response = authed_api(
+        "POST",
+        "/queries/revisions/retrieve",
+        json={"query_variant_ref": {"version": "1"}},
+    )
+    _assert_variant_400(response)
+
+
+def test_environments_retrieve_variant_version_only_returns_400(authed_api):
+    response = authed_api(
+        "POST",
+        "/environments/revisions/retrieve",
+        json={"environment_variant_ref": {"version": "1"}},
+    )
+    _assert_variant_400(response)

--- a/api/oss/tests/pytest/unit/test_retrieve_refs_consistency.py
+++ b/api/oss/tests/pytest/unit/test_retrieve_refs_consistency.py
@@ -28,13 +28,9 @@ class TestAllRefsAbsent:
             artifact_ref=None,
             variant_ref=None,
             revision_ref=None,
-            resolved_artifact_id=uuid4(),
-            resolved_artifact_slug="my-artifact",
-            resolved_variant_id=uuid4(),
-            resolved_variant_slug="my-variant",
-            resolved_revision_id=uuid4(),
-            resolved_revision_slug="my-revision",
-            resolved_revision_version=1,
+            resolved_artifact_ref=_ref(id=uuid4(), slug="my-artifact"),
+            resolved_variant_ref=_ref(id=uuid4(), slug="my-variant"),
+            resolved_revision_ref=_ref(id=uuid4(), slug="my-revision", version="1"),
         )
 
     def test_no_resolved_fields_passes(self):
@@ -49,9 +45,9 @@ class TestAllRefsAbsent:
             artifact_ref=_ref(),
             variant_ref=_ref(),
             revision_ref=_ref(),
-            resolved_artifact_id=uuid4(),
-            resolved_variant_id=uuid4(),
-            resolved_revision_id=uuid4(),
+            resolved_artifact_ref=_ref(id=uuid4()),
+            resolved_variant_ref=_ref(id=uuid4()),
+            resolved_revision_ref=_ref(id=uuid4()),
         )
 
 
@@ -61,7 +57,7 @@ class TestArtifactConsistency:
             artifact_ref=_ref(slug="my-artifact"),
             variant_ref=None,
             revision_ref=None,
-            resolved_artifact_slug="my-artifact",
+            resolved_artifact_ref=_ref(slug="my-artifact"),
         )
 
     def test_artifact_slug_mismatch_raises(self):
@@ -70,7 +66,7 @@ class TestArtifactConsistency:
                 artifact_ref=_ref(slug="wrong-artifact"),
                 variant_ref=None,
                 revision_ref=None,
-                resolved_artifact_slug="my-artifact",
+                resolved_artifact_ref=_ref(slug="my-artifact"),
             )
         assert "artifact_ref.slug" in exc.value.message
         assert "wrong-artifact" in exc.value.message
@@ -84,7 +80,7 @@ class TestArtifactConsistency:
                 artifact_ref=_ref(id=wrong_id),
                 variant_ref=None,
                 revision_ref=None,
-                resolved_artifact_id=right_id,
+                resolved_artifact_ref=_ref(id=right_id),
             )
         assert "artifact_ref.id" in exc.value.message
 
@@ -94,7 +90,7 @@ class TestArtifactConsistency:
             artifact_ref=_ref(id=same),
             variant_ref=None,
             revision_ref=None,
-            resolved_artifact_id=same,
+            resolved_artifact_ref=_ref(id=same),
         )
 
     def test_entity_type_appears_in_message(self):
@@ -103,7 +99,7 @@ class TestArtifactConsistency:
                 artifact_ref=_ref(slug="wrong"),
                 variant_ref=None,
                 revision_ref=None,
-                resolved_artifact_slug="right",
+                resolved_artifact_ref=_ref(slug="right"),
                 entity_type="testset",
             )
         assert "testset_ref.slug" in exc.value.message
@@ -116,7 +112,7 @@ class TestVariantConsistency:
                 artifact_ref=None,
                 variant_ref=_ref(slug="wrong-variant"),
                 revision_ref=None,
-                resolved_variant_slug="my-variant",
+                resolved_variant_ref=_ref(slug="my-variant"),
             )
         assert "variant_ref.slug" in exc.value.message
 
@@ -126,7 +122,7 @@ class TestVariantConsistency:
             artifact_ref=None,
             variant_ref=_ref(id=same),
             revision_ref=None,
-            resolved_variant_id=same,
+            resolved_variant_ref=_ref(id=same),
         )
 
 
@@ -137,7 +133,7 @@ class TestRevisionConsistency:
                 artifact_ref=None,
                 variant_ref=None,
                 revision_ref=_ref(slug="wrong-rev"),
-                resolved_revision_slug="my-rev",
+                resolved_revision_ref=_ref(slug="my-rev"),
             )
         assert "revision_ref.slug" in exc.value.message
 
@@ -147,7 +143,7 @@ class TestRevisionConsistency:
                 artifact_ref=None,
                 variant_ref=None,
                 revision_ref=_ref(version="2"),
-                resolved_revision_version=1,
+                resolved_revision_ref=_ref(version="1"),
             )
         assert "revision_ref.version" in exc.value.message
 
@@ -156,7 +152,7 @@ class TestRevisionConsistency:
             artifact_ref=None,
             variant_ref=None,
             revision_ref=_ref(version="1"),
-            resolved_revision_version=1,
+            resolved_revision_ref=_ref(version="1"),
         )
 
 
@@ -169,13 +165,9 @@ class TestCrossFieldConsistency:
             artifact_ref=_ref(id=a_id, slug="art"),
             variant_ref=_ref(id=v_id, slug="var"),
             revision_ref=_ref(id=r_id, slug="rev", version="3"),
-            resolved_artifact_id=a_id,
-            resolved_artifact_slug="art",
-            resolved_variant_id=v_id,
-            resolved_variant_slug="var",
-            resolved_revision_id=r_id,
-            resolved_revision_slug="rev",
-            resolved_revision_version=3,
+            resolved_artifact_ref=_ref(id=a_id, slug="art"),
+            resolved_variant_ref=_ref(id=v_id, slug="var"),
+            resolved_revision_ref=_ref(id=r_id, slug="rev", version="3"),
         )
 
     def test_multiple_mismatches_reported_together(self):
@@ -184,8 +176,8 @@ class TestCrossFieldConsistency:
                 artifact_ref=_ref(slug="wrong-art"),
                 variant_ref=_ref(slug="wrong-var"),
                 revision_ref=None,
-                resolved_artifact_slug="art",
-                resolved_variant_slug="var",
+                resolved_artifact_ref=_ref(slug="art"),
+                resolved_variant_ref=_ref(slug="var"),
             )
         assert "artifact_ref.slug" in exc.value.message
         assert "variant_ref.slug" in exc.value.message
@@ -198,7 +190,7 @@ class TestExceptionType:
                 artifact_ref=_ref(slug="wrong"),
                 variant_ref=None,
                 revision_ref=None,
-                resolved_artifact_slug="right",
+                resolved_artifact_ref=_ref(slug="right"),
             )
 
     def test_exception_message_attribute(self):
@@ -207,7 +199,7 @@ class TestExceptionType:
                 artifact_ref=_ref(slug="wrong"),
                 variant_ref=None,
                 revision_ref=None,
-                resolved_artifact_slug="right",
+                resolved_artifact_ref=_ref(slug="right"),
             )
         assert exc.value.message
         assert isinstance(exc.value.message, str)

--- a/api/oss/tests/pytest/unit/test_retrieve_refs_consistency.py
+++ b/api/oss/tests/pytest/unit/test_retrieve_refs_consistency.py
@@ -1,0 +1,213 @@
+"""Unit tests for the shared retrieve-refs consistency validator.
+
+`validate_retrieve_refs_consistent` checks that every identifying field in
+the caller-supplied artifact/variant/revision refs agrees with the
+corresponding field on the resolved revision. Mismatch raises
+`RetrieveRefsInconsistent`, which the router translates to HTTP 400.
+"""
+
+from uuid import uuid4
+
+import pytest
+
+from oss.src.core.git.types import (
+    GitError,
+    RetrieveRefsInconsistent,
+    validate_retrieve_refs_consistent,
+)
+from oss.src.core.shared.dtos import Reference
+
+
+def _ref(*, id=None, slug=None, version=None):
+    return Reference(id=id, slug=slug, version=version)
+
+
+class TestAllRefsAbsent:
+    def test_no_caller_refs_passes(self):
+        validate_retrieve_refs_consistent(
+            artifact_ref=None,
+            variant_ref=None,
+            revision_ref=None,
+            resolved_artifact_id=uuid4(),
+            resolved_artifact_slug="my-artifact",
+            resolved_variant_id=uuid4(),
+            resolved_variant_slug="my-variant",
+            resolved_revision_id=uuid4(),
+            resolved_revision_slug="my-revision",
+            resolved_revision_version=1,
+        )
+
+    def test_no_resolved_fields_passes(self):
+        validate_retrieve_refs_consistent(
+            artifact_ref=_ref(slug="my-artifact"),
+            variant_ref=_ref(slug="my-variant"),
+            revision_ref=_ref(version="1"),
+        )
+
+    def test_empty_refs_pass(self):
+        validate_retrieve_refs_consistent(
+            artifact_ref=_ref(),
+            variant_ref=_ref(),
+            revision_ref=_ref(),
+            resolved_artifact_id=uuid4(),
+            resolved_variant_id=uuid4(),
+            resolved_revision_id=uuid4(),
+        )
+
+
+class TestArtifactConsistency:
+    def test_artifact_slug_match_passes(self):
+        validate_retrieve_refs_consistent(
+            artifact_ref=_ref(slug="my-artifact"),
+            variant_ref=None,
+            revision_ref=None,
+            resolved_artifact_slug="my-artifact",
+        )
+
+    def test_artifact_slug_mismatch_raises(self):
+        with pytest.raises(RetrieveRefsInconsistent) as exc:
+            validate_retrieve_refs_consistent(
+                artifact_ref=_ref(slug="wrong-artifact"),
+                variant_ref=None,
+                revision_ref=None,
+                resolved_artifact_slug="my-artifact",
+            )
+        assert "artifact_ref.slug" in exc.value.message
+        assert "wrong-artifact" in exc.value.message
+        assert "my-artifact" in exc.value.message
+
+    def test_artifact_id_mismatch_raises(self):
+        wrong_id = uuid4()
+        right_id = uuid4()
+        with pytest.raises(RetrieveRefsInconsistent) as exc:
+            validate_retrieve_refs_consistent(
+                artifact_ref=_ref(id=wrong_id),
+                variant_ref=None,
+                revision_ref=None,
+                resolved_artifact_id=right_id,
+            )
+        assert "artifact_ref.id" in exc.value.message
+
+    def test_artifact_id_match_passes(self):
+        same = uuid4()
+        validate_retrieve_refs_consistent(
+            artifact_ref=_ref(id=same),
+            variant_ref=None,
+            revision_ref=None,
+            resolved_artifact_id=same,
+        )
+
+    def test_entity_type_appears_in_message(self):
+        with pytest.raises(RetrieveRefsInconsistent) as exc:
+            validate_retrieve_refs_consistent(
+                artifact_ref=_ref(slug="wrong"),
+                variant_ref=None,
+                revision_ref=None,
+                resolved_artifact_slug="right",
+                entity_type="testset",
+            )
+        assert "testset_ref.slug" in exc.value.message
+
+
+class TestVariantConsistency:
+    def test_variant_slug_mismatch_raises(self):
+        with pytest.raises(RetrieveRefsInconsistent) as exc:
+            validate_retrieve_refs_consistent(
+                artifact_ref=None,
+                variant_ref=_ref(slug="wrong-variant"),
+                revision_ref=None,
+                resolved_variant_slug="my-variant",
+            )
+        assert "variant_ref.slug" in exc.value.message
+
+    def test_variant_id_match_passes(self):
+        same = uuid4()
+        validate_retrieve_refs_consistent(
+            artifact_ref=None,
+            variant_ref=_ref(id=same),
+            revision_ref=None,
+            resolved_variant_id=same,
+        )
+
+
+class TestRevisionConsistency:
+    def test_revision_slug_mismatch_raises(self):
+        with pytest.raises(RetrieveRefsInconsistent) as exc:
+            validate_retrieve_refs_consistent(
+                artifact_ref=None,
+                variant_ref=None,
+                revision_ref=_ref(slug="wrong-rev"),
+                resolved_revision_slug="my-rev",
+            )
+        assert "revision_ref.slug" in exc.value.message
+
+    def test_revision_version_mismatch_raises(self):
+        with pytest.raises(RetrieveRefsInconsistent) as exc:
+            validate_retrieve_refs_consistent(
+                artifact_ref=None,
+                variant_ref=None,
+                revision_ref=_ref(version="2"),
+                resolved_revision_version=1,
+            )
+        assert "revision_ref.version" in exc.value.message
+
+    def test_revision_version_match_passes(self):
+        validate_retrieve_refs_consistent(
+            artifact_ref=None,
+            variant_ref=None,
+            revision_ref=_ref(version="1"),
+            resolved_revision_version=1,
+        )
+
+
+class TestCrossFieldConsistency:
+    def test_all_match_passes(self):
+        a_id = uuid4()
+        v_id = uuid4()
+        r_id = uuid4()
+        validate_retrieve_refs_consistent(
+            artifact_ref=_ref(id=a_id, slug="art"),
+            variant_ref=_ref(id=v_id, slug="var"),
+            revision_ref=_ref(id=r_id, slug="rev", version="3"),
+            resolved_artifact_id=a_id,
+            resolved_artifact_slug="art",
+            resolved_variant_id=v_id,
+            resolved_variant_slug="var",
+            resolved_revision_id=r_id,
+            resolved_revision_slug="rev",
+            resolved_revision_version=3,
+        )
+
+    def test_multiple_mismatches_reported_together(self):
+        with pytest.raises(RetrieveRefsInconsistent) as exc:
+            validate_retrieve_refs_consistent(
+                artifact_ref=_ref(slug="wrong-art"),
+                variant_ref=_ref(slug="wrong-var"),
+                revision_ref=None,
+                resolved_artifact_slug="art",
+                resolved_variant_slug="var",
+            )
+        assert "artifact_ref.slug" in exc.value.message
+        assert "variant_ref.slug" in exc.value.message
+
+
+class TestExceptionType:
+    def test_inconsistent_is_git_error(self):
+        with pytest.raises(GitError):
+            validate_retrieve_refs_consistent(
+                artifact_ref=_ref(slug="wrong"),
+                variant_ref=None,
+                revision_ref=None,
+                resolved_artifact_slug="right",
+            )
+
+    def test_exception_message_attribute(self):
+        with pytest.raises(RetrieveRefsInconsistent) as exc:
+            validate_retrieve_refs_consistent(
+                artifact_ref=_ref(slug="wrong"),
+                variant_ref=None,
+                revision_ref=None,
+                resolved_artifact_slug="right",
+            )
+        assert exc.value.message
+        assert isinstance(exc.value.message, str)

--- a/api/oss/tests/pytest/unit/test_retrieve_refs_sufficiency.py
+++ b/api/oss/tests/pytest/unit/test_retrieve_refs_sufficiency.py
@@ -1,9 +1,10 @@
-"""Unit tests for the shared revision-ref ambiguity validator.
+"""Unit tests for the shared retrieve-refs sufficiency validators.
 
-The helper lives in `core/git/types.py` and protects the retrieve flow for
+The helpers live in `core/git/types.py` and protect the retrieve flow for
 every git-backed entity (workflows, applications, evaluators, testsets,
-queries, environments) against the version-only-no-variant trap that used
-to return arbitrary project-wide rows.
+queries, environments) against caller-supplied refs that cannot identify a
+single revision: the version-only-no-scope trap (revision side) and the
+variant_ref-with-only-version nonsense shape (variant side).
 """
 
 from uuid import uuid4
@@ -12,7 +13,8 @@ import pytest
 
 from oss.src.core.git.types import (
     RetrieveRefsInsufficient,
-    validate_revision_ref_unambiguous,
+    validate_revision_refs_sufficient,
+    validate_variant_refs_sufficient,
 )
 from oss.src.core.shared.dtos import Reference
 
@@ -33,7 +35,7 @@ class TestVersionOnlyRejection:
 
     def test_version_only_no_variant_raises(self):
         with pytest.raises(RetrieveRefsInsufficient) as exc:
-            validate_revision_ref_unambiguous(
+            validate_revision_refs_sufficient(
                 artifact_ref=None,
                 variant_ref=None,
                 revision_ref=_ref(version="1"),
@@ -43,7 +45,7 @@ class TestVersionOnlyRejection:
     def test_version_only_with_empty_variant_ref_raises(self):
         # Reference(id=None, slug=None, version=None) is truthy but unidentifying.
         with pytest.raises(RetrieveRefsInsufficient):
-            validate_revision_ref_unambiguous(
+            validate_revision_refs_sufficient(
                 artifact_ref=None,
                 variant_ref=_ref(),
                 revision_ref=_ref(version="1"),
@@ -53,7 +55,7 @@ class TestVersionOnlyRejection:
         # A variant_ref whose only field is `version` doesn't scope anything
         # — version isn't an identifier for the variant either.
         with pytest.raises(RetrieveRefsInsufficient):
-            validate_revision_ref_unambiguous(
+            validate_revision_refs_sufficient(
                 artifact_ref=None,
                 variant_ref=_ref(version="3"),
                 revision_ref=_ref(version="1"),
@@ -61,7 +63,7 @@ class TestVersionOnlyRejection:
 
     def test_entity_type_appears_in_message(self):
         with pytest.raises(RetrieveRefsInsufficient) as exc:
-            validate_revision_ref_unambiguous(
+            validate_revision_refs_sufficient(
                 artifact_ref=None,
                 variant_ref=None,
                 revision_ref=_ref(version="1"),
@@ -72,7 +74,7 @@ class TestVersionOnlyRejection:
 
     def test_entity_type_default_is_artifact(self):
         with pytest.raises(RetrieveRefsInsufficient) as exc:
-            validate_revision_ref_unambiguous(
+            validate_revision_refs_sufficient(
                 artifact_ref=None,
                 variant_ref=None,
                 revision_ref=_ref(version="1"),
@@ -89,35 +91,35 @@ class TestVersionOnlyWithScopePasses:
     default-variant fallback."""
 
     def test_variant_id_scopes_version(self):
-        validate_revision_ref_unambiguous(
+        validate_revision_refs_sufficient(
             artifact_ref=None,
             variant_ref=_ref(id=uuid4()),
             revision_ref=_ref(version="1"),
         )
 
     def test_variant_slug_scopes_version(self):
-        validate_revision_ref_unambiguous(
+        validate_revision_refs_sufficient(
             artifact_ref=None,
             variant_ref=_ref(slug="my-variant"),
             revision_ref=_ref(version="1"),
         )
 
     def test_artifact_id_scopes_version(self):
-        validate_revision_ref_unambiguous(
+        validate_revision_refs_sufficient(
             artifact_ref=_ref(id=uuid4()),
             variant_ref=None,
             revision_ref=_ref(version="1"),
         )
 
     def test_artifact_slug_scopes_version(self):
-        validate_revision_ref_unambiguous(
+        validate_revision_refs_sufficient(
             artifact_ref=_ref(slug="my-workflow"),
             variant_ref=None,
             revision_ref=_ref(version="1"),
         )
 
     def test_variant_id_with_artifact_also_passes(self):
-        validate_revision_ref_unambiguous(
+        validate_revision_refs_sufficient(
             artifact_ref=_ref(slug="my-workflow"),
             variant_ref=_ref(id=uuid4()),
             revision_ref=_ref(version="1"),
@@ -129,14 +131,14 @@ class TestVersionOnlyWithScopePasses:
 
 class TestRevisionIdOrSlugAlwaysSufficient:
     def test_revision_id_alone(self):
-        validate_revision_ref_unambiguous(
+        validate_revision_refs_sufficient(
             artifact_ref=None,
             variant_ref=None,
             revision_ref=_ref(id=uuid4()),
         )
 
     def test_revision_slug_alone(self):
-        validate_revision_ref_unambiguous(
+        validate_revision_refs_sufficient(
             artifact_ref=None,
             variant_ref=None,
             revision_ref=_ref(slug="my-revision"),
@@ -144,14 +146,14 @@ class TestRevisionIdOrSlugAlwaysSufficient:
 
     def test_revision_id_with_version_ignores_version(self):
         # The id is project-unique; version becomes a redundant hint.
-        validate_revision_ref_unambiguous(
+        validate_revision_refs_sufficient(
             artifact_ref=None,
             variant_ref=None,
             revision_ref=_ref(id=uuid4(), version="1"),
         )
 
     def test_revision_slug_with_version_ignores_version(self):
-        validate_revision_ref_unambiguous(
+        validate_revision_refs_sufficient(
             artifact_ref=None,
             variant_ref=None,
             revision_ref=_ref(slug="my-rev", version="1"),
@@ -166,35 +168,35 @@ class TestNonTriggering:
     ambiguity and leaves all others to the caller."""
 
     def test_all_refs_none(self):
-        validate_revision_ref_unambiguous(
+        validate_revision_refs_sufficient(
             artifact_ref=None,
             variant_ref=None,
             revision_ref=None,
         )
 
     def test_all_refs_empty(self):
-        validate_revision_ref_unambiguous(
+        validate_revision_refs_sufficient(
             artifact_ref=_ref(),
             variant_ref=_ref(),
             revision_ref=_ref(),
         )
 
     def test_artifact_only(self):
-        validate_revision_ref_unambiguous(
+        validate_revision_refs_sufficient(
             artifact_ref=_ref(slug="my-workflow"),
             variant_ref=None,
             revision_ref=None,
         )
 
     def test_variant_only(self):
-        validate_revision_ref_unambiguous(
+        validate_revision_refs_sufficient(
             artifact_ref=None,
             variant_ref=_ref(slug="my-variant"),
             revision_ref=None,
         )
 
     def test_artifact_and_variant_no_revision(self):
-        validate_revision_ref_unambiguous(
+        validate_revision_refs_sufficient(
             artifact_ref=_ref(slug="my-workflow"),
             variant_ref=_ref(slug="my-variant"),
             revision_ref=None,
@@ -209,7 +211,7 @@ class TestExceptionType:
         from oss.src.core.git.types import GitError
 
         with pytest.raises(GitError):
-            validate_revision_ref_unambiguous(
+            validate_revision_refs_sufficient(
                 artifact_ref=None,
                 variant_ref=None,
                 revision_ref=_ref(version="1"),
@@ -217,7 +219,7 @@ class TestExceptionType:
 
     def test_exception_message_attribute(self):
         with pytest.raises(RetrieveRefsInsufficient) as exc:
-            validate_revision_ref_unambiguous(
+            validate_revision_refs_sufficient(
                 artifact_ref=None,
                 variant_ref=None,
                 revision_ref=_ref(version="1"),
@@ -225,3 +227,48 @@ class TestExceptionType:
         # Has the .message attribute carried by GitError base.
         assert exc.value.message
         assert isinstance(exc.value.message, str)
+
+
+# variant_ref carrying only `version` --------------------------------------
+
+
+class TestVariantVersionOnlyRejection:
+    """A `variant_ref` populated with only `version` is nonsense — variants
+    have no `version` field. Reject at the boundary."""
+
+    def test_variant_version_only_raises(self):
+        with pytest.raises(RetrieveRefsInsufficient) as exc:
+            validate_variant_refs_sufficient(variant_ref=_ref(version="1"))
+        assert "variant_ref" in exc.value.message
+
+    def test_entity_type_appears_in_variant_message(self):
+        with pytest.raises(RetrieveRefsInsufficient) as exc:
+            validate_variant_refs_sufficient(
+                variant_ref=_ref(version="1"),
+                entity_type="testset",
+            )
+        assert "testset_variant_ref" in exc.value.message
+
+
+class TestVariantSufficientShapesPass:
+    def test_none_passes(self):
+        validate_variant_refs_sufficient(variant_ref=None)
+
+    def test_empty_ref_passes(self):
+        validate_variant_refs_sufficient(variant_ref=_ref())
+
+    def test_id_only_passes(self):
+        validate_variant_refs_sufficient(variant_ref=_ref(id=uuid4()))
+
+    def test_slug_only_passes(self):
+        validate_variant_refs_sufficient(variant_ref=_ref(slug="my-variant"))
+
+    def test_id_with_redundant_version_passes(self):
+        validate_variant_refs_sufficient(
+            variant_ref=_ref(id=uuid4(), version="1"),
+        )
+
+    def test_slug_with_redundant_version_passes(self):
+        validate_variant_refs_sufficient(
+            variant_ref=_ref(slug="my-variant", version="1"),
+        )

--- a/api/oss/tests/pytest/unit/test_revision_ref_validation.py
+++ b/api/oss/tests/pytest/unit/test_revision_ref_validation.py
@@ -11,7 +11,7 @@ from uuid import uuid4
 import pytest
 
 from oss.src.core.git.types import (
-    RevisionRefInvalid,
+    RetrieveRefsInsufficient,
     validate_revision_ref_unambiguous,
 )
 from oss.src.core.shared.dtos import Reference
@@ -32,7 +32,7 @@ class TestVersionOnlyRejection:
     variant scope and must raise."""
 
     def test_version_only_no_variant_raises(self):
-        with pytest.raises(RevisionRefInvalid) as exc:
+        with pytest.raises(RetrieveRefsInsufficient) as exc:
             validate_revision_ref_unambiguous(
                 artifact_ref=None,
                 variant_ref=None,
@@ -42,7 +42,7 @@ class TestVersionOnlyRejection:
 
     def test_version_only_with_empty_variant_ref_raises(self):
         # Reference(id=None, slug=None, version=None) is truthy but unidentifying.
-        with pytest.raises(RevisionRefInvalid):
+        with pytest.raises(RetrieveRefsInsufficient):
             validate_revision_ref_unambiguous(
                 artifact_ref=None,
                 variant_ref=_ref(),
@@ -52,7 +52,7 @@ class TestVersionOnlyRejection:
     def test_version_only_with_variant_having_only_version_raises(self):
         # A variant_ref whose only field is `version` doesn't scope anything
         # — version isn't an identifier for the variant either.
-        with pytest.raises(RevisionRefInvalid):
+        with pytest.raises(RetrieveRefsInsufficient):
             validate_revision_ref_unambiguous(
                 artifact_ref=None,
                 variant_ref=_ref(version="3"),
@@ -60,7 +60,7 @@ class TestVersionOnlyRejection:
             )
 
     def test_entity_type_appears_in_message(self):
-        with pytest.raises(RevisionRefInvalid) as exc:
+        with pytest.raises(RetrieveRefsInsufficient) as exc:
             validate_revision_ref_unambiguous(
                 artifact_ref=None,
                 variant_ref=None,
@@ -71,7 +71,7 @@ class TestVersionOnlyRejection:
         assert "testset_variant_ref" in exc.value.message
 
     def test_entity_type_default_is_artifact(self):
-        with pytest.raises(RevisionRefInvalid) as exc:
+        with pytest.raises(RetrieveRefsInsufficient) as exc:
             validate_revision_ref_unambiguous(
                 artifact_ref=None,
                 variant_ref=None,
@@ -216,7 +216,7 @@ class TestExceptionType:
             )
 
     def test_exception_message_attribute(self):
-        with pytest.raises(RevisionRefInvalid) as exc:
+        with pytest.raises(RetrieveRefsInsufficient) as exc:
             validate_revision_ref_unambiguous(
                 artifact_ref=None,
                 variant_ref=None,

--- a/docs/design/playground-open-from-trace/followups.md
+++ b/docs/design/playground-open-from-trace/followups.md
@@ -664,19 +664,47 @@ without `{environment_variant_ref}` or `{environment_ref}`.
 If C1's default-variant rule lets `{artifact_ref + variant.version}` resolve
 deterministically, accept it via the C2 pattern.
 
-### C5. Centralize env-backed retrieve rules — fixes D5 + D11 + D12
+### C5. Unify git-ref retrieval rules across paths and entities — fixes D5 + D11 + D12
 
-Move the `key` requirement, the `key = f"{slug}.revision"` derivation, and the
-path-mixing policy out of the three routers into a shared utility (call site:
-new `apis/fastapi/shared/env_resolution.py` or `core/git/env_resolution.py`).
-Define and document:
+C5 covers two layers of unification:
 
-- When `key` is required vs derivable (default-key rule from D11).
-- Whether path-mixing is allowed and how it's resolved (rule from D10).
-  Recommended: allow mixing, enforce consistency via C3.
+**Service-layer pipeline (six entities).** All six services'
+`fetch_*_revision` carry the same pipeline today:
+`validate_variant_refs_sufficient → validate_revision_refs_sufficient →
+snapshot caller refs → needs_default_variant_resolution → fetch_artifact →
+fetch_variant → fetch_revision → validate_retrieve_refs_consistent → wrap
+DTO`. That pipeline should be extracted into a shared template so adding a
+seventh git-backed entity (or evolving any of the six steps) happens in one
+place.
 
-After this lands, applications/workflows/evaluators all call the same helper
-and exhibit the same behavior.
+**Router-layer env-backed retrieve policy (three routers).** The
+`*_revision_retrieve` endpoints for applications, workflows, and evaluators
+should share:
+
+- `key` is required for env-backed lookups, derived from `artifact_ref.slug`
+  as `f"{slug}.revision"` when missing (D11 default-key rule).
+- Path-mixing is allowed; rely on C3's consistency check to reject
+  contradictions after resolution (D10 path-mixing rule).
+- Neither path identifying → 400.
+
+This PR aligns the three routers inline so they exhibit the same behavior;
+the actual helper extraction (both layers) is deferred to C5b.
+
+### C5b. Extract the unified retrieval blocks into shared helpers — deferred
+
+Once C5 has aligned both layers inline, factor the duplicated blocks into
+shared helpers:
+
+- Service-layer pipeline → e.g., `core/git/retrieve.py` or a mixin on the
+  existing git service base.
+- Router-layer env-resolution → e.g.,
+  `apis/fastapi/shared/utils.py:plan_env_backed_retrieve`.
+
+Bundle with C10's exception-translation decorator extraction — both touch
+the same boilerplate (router try/except + retrieve_*_revision call) and
+share the same six per-entity duplicates. Deferred so the alignment ships
+first as small, low-risk changes; the extractions are mechanical refactors
+afterwards.
 
 ### C6. Stable tie-break for latest-revision ordering — fixes D7
 

--- a/docs/design/playground-open-from-trace/followups.md
+++ b/docs/design/playground-open-from-trace/followups.md
@@ -3,7 +3,7 @@
 Companion to [`retrieve-endpoint-audit.md`](./retrieve-endpoint-audit.md). The audit doc describes the
 original bug, the data model, and PR #4418's guardrails. PR #4422 extended those
 guardrails to every git-backed entity by factoring the version-only check into
-`core/git/types.py::validate_revision_ref_unambiguous`.
+`core/git/types.py::validate_revision_refs_sufficient`.
 
 This document captures what is **still wrong or incomplete** about reference
 resolution at the retrieve surface, evaluated against the five rules below. The
@@ -442,7 +442,7 @@ D10–D13 are unobservable.
 
 ### D9. The five rules are not codified anywhere in the codebase
 
-`validate_revision_ref_unambiguous` enforces a fragment of 2.e. There is no
+`validate_revision_refs_sufficient` enforces a fragment of 2.e. There is no
 constant, comment block, or single doc string that lists the five rules,
 the precedence orders, or the default rules so future maintainers can match
 new validation to the right rule. This document is the first attempt at
@@ -655,7 +655,7 @@ On mismatch, raise a new `RetrieveRefsInconsistent(GitError)` and surface as
 
 ### C4. Catch variant-by-version analog — fixes D4 + D13
 
-Extend the helper (or add a sibling `validate_variant_ref_unambiguous`) to
+Extend the helper (or add a sibling `validate_variant_refs_sufficient`) to
 reject `{variant_ref:{version}}` without an `artifact_ref` (`id` or `slug`).
 Same shape, same reasoning. Call it from `fetch_*_variant` paths. Mirror the
 same check for the env-side: reject `{environment_revision_ref:{version}}`

--- a/docs/design/playground-open-from-trace/followups.md
+++ b/docs/design/playground-open-from-trace/followups.md
@@ -649,9 +649,9 @@ artifact/variant identity against what the caller sent:
   still belong to that same artifact. Otherwise the derived key looked up
   a slot the caller didn't actually mean — D15.
 
-On mismatch, raise a new `RevisionRefInconsistent(GitError)` and surface as
+On mismatch, raise a new `RetrieveRefsInconsistent(GitError)` and surface as
 400 naming the conflicting field. The exception and validator live in
-`core/git/types.py` next to `RevisionRefInvalid`.
+`core/git/types.py` next to `RetrieveRefsInsufficient`.
 
 ### C4. Catch variant-by-version analog — fixes D4 + D13
 
@@ -730,8 +730,8 @@ Inventory at this commit:
 
 - **12 inline `except` blocks** across 6 routers (workflows, applications,
   evaluators, testsets, queries, environments).
-- **2 domain exceptions** today: `VariantForkError`, `RevisionRefInvalid`.
-- **+1 from C3:** `RevisionRefInconsistent`.
+- **2 domain exceptions** today: `VariantForkError`, `RetrieveRefsInsufficient`.
+- **+1 from C3:** `RetrieveRefsInconsistent`.
 - **+1 possibly from C4:** a variant-ref-version helper exception.
 
 Each new git-domain exception multiplies the boilerplate by the number of
@@ -746,8 +746,8 @@ call sites. The codebase already has a cleaner pattern in `folders/`:
 Apply the same shape to the git domain:
 
 1. Define typed exceptions in `apis/fastapi/shared/git_exceptions.py` (or
-   similar): `VariantForkErrorException`, `RevisionRefInvalidException`,
-   `RevisionRefInconsistentException`. All inherit from
+   similar): `VariantForkErrorException`, `RetrieveRefsInsufficientException`,
+   `RetrieveRefsInconsistentException`. All inherit from
    `BadRequestException` (from `utils/exceptions.py:226`) which already
    carries the 400 status.
 2. Define `@handle_git_exceptions()` decorator in the same module that
@@ -805,7 +805,7 @@ across all six entity tables.
    any further change. Catches accidental regressions in the next steps.
 5. **C2** — lift the helper's `{artifact_ref + version}` rejection now
    that C1a makes the default-variant pick deterministic.
-6. **C3** — new `RevisionRefInconsistent` exception, post-resolution
+6. **C3** — new `RetrieveRefsInconsistent` exception, post-resolution
    consistency checks for entity-ref path, env-ref path, across-paths
    (explicit `key`), and across-paths (derived `key` / D15).
 7. **C4** — variant-by-version analog of the helper, plus the env-side

--- a/docs/docs/prompt-engineering/integrating-prompts/02-fetch-prompt-programatically.mdx
+++ b/docs/docs/prompt-engineering/integrating-prompts/02-fetch-prompt-programatically.mdx
@@ -263,6 +263,19 @@ curl -X POST "https://cloud.agenta.ai/api/applications/revisions/retrieve" \
   </TabItem>
 </Tabs>
 
+## How the request resolves
+
+You can identify the revision you want with any combination of:
+
+- `application_revision_ref` — by `id` or `slug`, or by `version` paired with a `application_variant_ref`.
+- `application_variant_ref` — picks the latest revision on that variant.
+- `application_ref` — picks the latest revision on the application's default variant.
+- `environment_ref` (+ optional `key`) — picks the revision currently deployed to that environment under the default key `{application_slug}.revision`.
+
+You may supply more than one reference. Every reference you send must agree with the resolved revision; if any contradicts, the endpoint returns `400 Bad Request` and the response detail names the field that disagreed.
+
+The endpoint also returns `400` when the references are not sufficient to identify a single revision — for example, when only `application_revision_ref.version` is provided (a per-variant sequence number with no variant context), or when only `application_variant_ref.version` is provided (variants do not have versions).
+
 ## Response Format
 
 The SDK returns the configuration parameters directly as a dictionary. When using the REST API, the response contains the full revision data including configuration under `params` along with reference metadata:

--- a/docs/docs/reference/api-guide/04-versioning.mdx
+++ b/docs/docs/reference/api-guide/04-versioning.mdx
@@ -60,12 +60,12 @@ The response contains the new revision with its `id`, `version`, `author`, `date
 References are how you point at something in the versioning tree. Each reference is a small object that identifies an artifact, variant, or revision.
 
 :::info
-A reference can be supplied as an `id`, a `slug`, or (for revisions) a `slug` plus `version`. For example:
+A reference can be supplied as an `id`, a `slug`, or — for revisions paired with a variant — a `version`. For example:
 
 ```json
 {"application_revision_ref": {"id": "019d9531-2e44-7c3a-b8cb-d6d8e675c18d"}}
-{"application_variant_ref": {"slug": "production"}}
-{"application_revision_ref": {"slug": "production", "version": 3}}
+{"application_variant_ref": {"slug": "default"}}
+{"application_variant_ref": {"slug": "default"}, "application_revision_ref": {"version": "3"}}
 {"environment_ref": {"slug": "production"}}
 ```
 :::
@@ -79,11 +79,19 @@ curl -X POST "$AGENTA_HOST/api/applications/revisions/retrieve" \
 
 The retrieve endpoint accepts any of:
 
-- `application_revision_ref`: a specific revision by `id` or by `slug` + `version`.
+- `application_revision_ref`: a specific revision by `id` or by `slug`.
+- `application_variant_ref` + `application_revision_ref.version`: a specific revision on that variant.
 - `application_variant_ref`: the latest revision on that variant.
-- `environment_ref`: the revision currently deployed to that environment.
+- `application_ref`: the latest revision on the artifact's default variant.
+- `environment_ref` (+ optional `key`): the revision currently deployed to that environment. The default key is `{application_slug}.revision`; provide an explicit `key` if you deployed the application under a different name.
 
-Only one reference is needed. If several are supplied, the most specific one wins: a revision reference is used over a variant reference, and a variant reference is used over an environment reference.
+You may pass several references in the same request — for example, `application_ref` plus `application_revision_ref.id` — but every supplied reference must agree with the resolved revision. The request returns `400 Bad Request` if:
+
+- A `revision_ref` carries only `version` (or a `variant_ref` carries only `version`) without an enclosing variant or artifact context. `version` is a per-variant sequence number; on its own it does not name a single revision.
+- A `variant_ref` carries only `version`. Variants do not have versions.
+- Any redundant reference contradicts the resolved revision. The detail message names the field that did not match.
+
+When the request is identifying but the row no longer exists, the endpoint returns `404 Not Found` rather than `400`.
 
 ## Listing revision history
 


### PR DESCRIPTION
## What was broken
When a request mixed identifying refs that disagreed (e.g. `revision_ref.id` plus an `artifact_ref.slug` that does not belong to that revision), the server silently honored the most specific one and returned a revision the caller did not ask for.

## The fix
Introduce `RetrieveRefsInconsistent` and `validate_retrieve_refs_consistent`. After the DAO resolves a revision, the helper compares every caller-supplied id/slug/version against the resolved row. Any disagreement returns 400 with the offending `*_ref` field named in the detail.

## Notes
Stacked on #4432.