### PR TITLE
[fix] Resolve retrieve-related issue 9: cover env-path and path-mixed cases

### DIFF
--- a/api/oss/src/apis/fastapi/applications/models.py
+++ b/api/oss/src/apis/fastapi/applications/models.py
@@ -361,9 +361,9 @@ class ApplicationRevisionCommitRequest(BaseModel):
 class ApplicationRevisionRetrieveRequest(BaseModel):
     """Request body for `POST /applications/revisions/retrieve`.
 
-    Resolves to a single revision by one of several reference types. Exactly one
-    reference path is needed; the most specific wins when several are provided.
-    See the [Applications guide](/reference/api-guide/applications#invocation).
+    Resolves to a single revision by one or more reference types. Every
+    reference supplied must agree with the resolved revision; contradictions
+    return HTTP 400. See the [Applications guide](/reference/api-guide/applications#invocation).
     """
 
     application_ref: Optional[Reference] = Field(
@@ -371,8 +371,8 @@ class ApplicationRevisionRetrieveRequest(BaseModel):
         description=(
             "Application artifact to look up. Identifies the artifact by `id` "
             "or `slug` (both project-unique). When no variant_ref or "
-            "revision_ref is provided, returns the latest revision of an "
-            "arbitrary variant of this application."
+            "revision_ref is provided, returns the latest revision of the "
+            "application's default variant."
         ),
     )
     application_variant_ref: Optional[Reference] = Field(

--- a/api/oss/src/apis/fastapi/applications/router.py
+++ b/api/oss/src/apis/fastapi/applications/router.py
@@ -10,11 +10,7 @@ from oss.src.utils.caching import invalidate_cache
 
 from oss.src.core.events.utils import publish_revision_event
 
-from oss.src.core.git.types import (
-    VariantForkError,
-    RetrieveRefsInsufficient,
-    RetrieveRefsInconsistent,
-)
+from oss.src.apis.fastapi.git.exceptions import handle_git_exceptions
 from oss.src.core.shared.dtos import (
     Reference,
 )
@@ -1066,6 +1062,7 @@ class ApplicationsRouter:
         return application_variants_response
 
     @intercept_exceptions()
+    @handle_git_exceptions()
     async def fork_application_variant(
         self,
         request: Request,
@@ -1105,20 +1102,12 @@ class ApplicationsRouter:
             if not fork_request.application_variant_id:
                 fork_request.application_variant_id = application_variant_id
 
-        try:
-            application_variant = (
-                await self.applications_service.fork_application_variant(
-                    project_id=UUID(request.state.project_id),
-                    user_id=UUID(request.state.user_id),
-                    #
-                    application_fork=fork_request,
-                )
-            )
-        except VariantForkError as e:
-            raise HTTPException(
-                status_code=status.HTTP_400_BAD_REQUEST,
-                detail=e.message,
-            ) from e
+        application_variant = await self.applications_service.fork_application_variant(
+            project_id=UUID(request.state.project_id),
+            user_id=UUID(request.state.user_id),
+            #
+            application_fork=fork_request,
+        )
 
         application_variant_response = ApplicationVariantResponse(
             count=1 if application_variant else 0,
@@ -1130,6 +1119,7 @@ class ApplicationsRouter:
     # APPLICATION REVISIONS ----------------------------------------------------
 
     @intercept_exceptions()
+    @handle_git_exceptions()
     async def deploy_application_revision(
         self,
         request: Request,
@@ -1182,19 +1172,13 @@ class ApplicationsRouter:
                 detail="Application deploy requires environment refs.",
             )
 
-        try:
-            application_revision = await self.applications_service.fetch_application_revision(
-                project_id=UUID(request.state.project_id),
-                #
-                application_ref=application_deploy_request.application_ref,
-                application_variant_ref=application_deploy_request.application_variant_ref,
-                application_revision_ref=application_deploy_request.application_revision_ref,
-            )
-        except (RetrieveRefsInsufficient, RetrieveRefsInconsistent) as e:
-            raise HTTPException(
-                status_code=status.HTTP_400_BAD_REQUEST,
-                detail=e.message,
-            ) from e
+        application_revision = await self.applications_service.fetch_application_revision(
+            project_id=UUID(request.state.project_id),
+            #
+            application_ref=application_deploy_request.application_ref,
+            application_variant_ref=application_deploy_request.application_variant_ref,
+            application_revision_ref=application_deploy_request.application_revision_ref,
+        )
 
         if not application_revision:
             raise HTTPException(
@@ -1303,6 +1287,7 @@ class ApplicationsRouter:
 
     @intercept_exceptions()
     @suppress_exceptions(default=ApplicationRevisionResponse(), exclude=[HTTPException])
+    @handle_git_exceptions()
     async def retrieve_application_revision(
         self,
         request: Request,
@@ -1394,29 +1379,23 @@ class ApplicationsRouter:
                         detail="Environment-backed application retrieve requires key.",
                     )
 
-        try:
-            (
-                application_revision,
-                resolution_info,
-            ) = await self.applications_service.retrieve_application_revision(
-                project_id=UUID(request.state.project_id),
-                #
-                environment_ref=environment_ref,
-                environment_variant_ref=environment_variant_ref,
-                environment_revision_ref=environment_revision_ref,
-                key=key,
-                #
-                application_ref=application_ref,
-                application_variant_ref=application_variant_ref,
-                application_revision_ref=application_revision_ref,
-                #
-                resolve=application_revision_retrieve_request.resolve or False,
-            )
-        except (RetrieveRefsInsufficient, RetrieveRefsInconsistent) as e:
-            raise HTTPException(
-                status_code=status.HTTP_400_BAD_REQUEST,
-                detail=e.message,
-            ) from e
+        (
+            application_revision,
+            resolution_info,
+        ) = await self.applications_service.retrieve_application_revision(
+            project_id=UUID(request.state.project_id),
+            #
+            environment_ref=environment_ref,
+            environment_variant_ref=environment_variant_ref,
+            environment_revision_ref=environment_revision_ref,
+            key=key,
+            #
+            application_ref=application_ref,
+            application_variant_ref=application_variant_ref,
+            application_revision_ref=application_revision_ref,
+            #
+            resolve=application_revision_retrieve_request.resolve or False,
+        )
 
         if environment_lookup_requested and not application_revision:
             raise HTTPException(

--- a/api/oss/src/apis/fastapi/environments/router.py
+++ b/api/oss/src/apis/fastapi/environments/router.py
@@ -8,7 +8,7 @@ from oss.src.utils.logging import get_module_logger
 from oss.src.utils.exceptions import intercept_exceptions, suppress_exceptions
 
 from oss.src.core.events.utils import publish_revision_event
-from oss.src.core.git.types import RetrieveRefsInsufficient, RetrieveRefsInconsistent
+from oss.src.apis.fastapi.git.exceptions import handle_git_exceptions
 
 from oss.src.core.shared.dtos import (
     Reference,
@@ -742,6 +742,7 @@ class EnvironmentsRouter:
     # ENVIRONMENT REVISIONS ------------------------------------------------
 
     @intercept_exceptions()
+    @handle_git_exceptions()
     async def retrieve_environment_revision(
         self,
         request: Request,
@@ -756,24 +757,18 @@ class EnvironmentsRouter:
             ):
                 raise FORBIDDEN_EXCEPTION  # type: ignore
 
-        try:
-            (
-                environment_revision,
-                resolution_info,
-            ) = await self.environments_service.retrieve_environment_revision(
-                project_id=UUID(request.state.project_id),
-                #
-                environment_ref=environment_revision_retrieve_request.environment_ref,  # type: ignore
-                environment_variant_ref=environment_revision_retrieve_request.environment_variant_ref,  # type: ignore
-                environment_revision_ref=environment_revision_retrieve_request.environment_revision_ref,  # type: ignore
-                #
-                resolve=bool(environment_revision_retrieve_request.resolve),
-            )
-        except (RetrieveRefsInsufficient, RetrieveRefsInconsistent) as e:
-            raise HTTPException(
-                status_code=status.HTTP_400_BAD_REQUEST,
-                detail=e.message,
-            ) from e
+        (
+            environment_revision,
+            resolution_info,
+        ) = await self.environments_service.retrieve_environment_revision(
+            project_id=UUID(request.state.project_id),
+            #
+            environment_ref=environment_revision_retrieve_request.environment_ref,  # type: ignore
+            environment_variant_ref=environment_revision_retrieve_request.environment_variant_ref,  # type: ignore
+            environment_revision_ref=environment_revision_retrieve_request.environment_revision_ref,  # type: ignore
+            #
+            resolve=bool(environment_revision_retrieve_request.resolve),
+        )
 
         environment_revision_response = EnvironmentRevisionResponse(
             count=1 if environment_revision else 0,

--- a/api/oss/src/apis/fastapi/evaluators/models.py
+++ b/api/oss/src/apis/fastapi/evaluators/models.py
@@ -285,7 +285,10 @@ class EvaluatorRevisionCommitRequest(BaseModel):
 class EvaluatorRevisionRetrieveRequest(BaseModel):
     """Body for retrieving one revision, either by direct reference or through an environment key.
 
-    Provide one of: an evaluator / variant / revision reference, or an environment reference plus `key`.
+    Provide an evaluator / variant / revision reference, an environment
+    reference (with `key` derived from the evaluator slug by default), or a
+    combination of both. Every reference supplied must agree with the
+    resolved revision; contradictions return HTTP 400.
     """
 
     evaluator_ref: Optional[Reference] = Field(
@@ -293,8 +296,8 @@ class EvaluatorRevisionRetrieveRequest(BaseModel):
         description=(
             "Evaluator artifact to look up. Identifies the artifact by `id` "
             "or `slug` (both project-unique). When no variant_ref or "
-            "revision_ref is provided, returns the latest revision of an "
-            "arbitrary variant of this evaluator."
+            "revision_ref is provided, returns the latest revision of the "
+            "evaluator's default variant."
         ),
     )
     evaluator_variant_ref: Optional[Reference] = Field(

--- a/api/oss/src/apis/fastapi/evaluators/router.py
+++ b/api/oss/src/apis/fastapi/evaluators/router.py
@@ -10,11 +10,7 @@ from oss.src.utils.caching import invalidate_cache
 
 from oss.src.core.events.utils import publish_revision_event
 
-from oss.src.core.git.types import (
-    VariantForkError,
-    RetrieveRefsInsufficient,
-    RetrieveRefsInconsistent,
-)
+from oss.src.apis.fastapi.git.exceptions import handle_git_exceptions
 from oss.src.core.shared.dtos import (
     Reference,
 )
@@ -1062,6 +1058,7 @@ class EvaluatorsRouter:
         return evaluator_variants_response
 
     @intercept_exceptions()  # TODO: FIX ME
+    @handle_git_exceptions()
     async def fork_evaluator_variant(
         self,
         request: Request,
@@ -1097,18 +1094,12 @@ class EvaluatorsRouter:
             if not fork_request.evaluator_variant_id:
                 fork_request.evaluator_variant_id = evaluator_variant_id
 
-        try:
-            evaluator_variant = await self.evaluators_service.fork_evaluator_variant(
-                project_id=UUID(request.state.project_id),
-                user_id=UUID(request.state.user_id),
-                #
-                evaluator_fork=fork_request,
-            )
-        except VariantForkError as e:
-            raise HTTPException(
-                status_code=status.HTTP_400_BAD_REQUEST,
-                detail=e.message,
-            ) from e
+        evaluator_variant = await self.evaluators_service.fork_evaluator_variant(
+            project_id=UUID(request.state.project_id),
+            user_id=UUID(request.state.user_id),
+            #
+            evaluator_fork=fork_request,
+        )
 
         evaluator_variant_response = EvaluatorVariantResponse(
             count=1 if evaluator_variant else 0,
@@ -1120,6 +1111,7 @@ class EvaluatorsRouter:
     # EVALUATOR REVISIONS ------------------------------------------------------
 
     @intercept_exceptions()
+    @handle_git_exceptions()
     async def deploy_evaluator_revision(
         self,
         request: Request,
@@ -1173,19 +1165,13 @@ class EvaluatorsRouter:
                 detail="Evaluator deploy requires environment refs.",
             )
 
-        try:
-            evaluator_revision = await self.evaluators_service.fetch_evaluator_revision(
-                project_id=UUID(request.state.project_id),
-                #
-                evaluator_ref=evaluator_deploy_request.evaluator_ref,
-                evaluator_variant_ref=evaluator_deploy_request.evaluator_variant_ref,
-                evaluator_revision_ref=evaluator_deploy_request.evaluator_revision_ref,
-            )
-        except (RetrieveRefsInsufficient, RetrieveRefsInconsistent) as e:
-            raise HTTPException(
-                status_code=status.HTTP_400_BAD_REQUEST,
-                detail=e.message,
-            ) from e
+        evaluator_revision = await self.evaluators_service.fetch_evaluator_revision(
+            project_id=UUID(request.state.project_id),
+            #
+            evaluator_ref=evaluator_deploy_request.evaluator_ref,
+            evaluator_variant_ref=evaluator_deploy_request.evaluator_variant_ref,
+            evaluator_revision_ref=evaluator_deploy_request.evaluator_revision_ref,
+        )
 
         if not evaluator_revision:
             raise HTTPException(
@@ -1287,6 +1273,7 @@ class EvaluatorsRouter:
         )
 
     @intercept_exceptions()
+    @handle_git_exceptions()
     async def retrieve_evaluator_revision(
         self,
         request: Request,
@@ -1379,29 +1366,23 @@ class EvaluatorsRouter:
                         detail="Environment-backed evaluator retrieve requires key.",
                     )
 
-        try:
-            (
-                evaluator_revision,
-                resolution_info,
-            ) = await self.evaluators_service.retrieve_evaluator_revision(
-                project_id=UUID(request.state.project_id),
-                #
-                environment_ref=environment_ref,
-                environment_variant_ref=environment_variant_ref,
-                environment_revision_ref=environment_revision_ref,
-                key=key,
-                #
-                evaluator_ref=evaluator_ref,
-                evaluator_variant_ref=evaluator_variant_ref,
-                evaluator_revision_ref=evaluator_revision_ref,
-                #
-                resolve=evaluator_revision_retrieve_request.resolve or False,
-            )
-        except (RetrieveRefsInsufficient, RetrieveRefsInconsistent) as e:
-            raise HTTPException(
-                status_code=status.HTTP_400_BAD_REQUEST,
-                detail=e.message,
-            ) from e
+        (
+            evaluator_revision,
+            resolution_info,
+        ) = await self.evaluators_service.retrieve_evaluator_revision(
+            project_id=UUID(request.state.project_id),
+            #
+            environment_ref=environment_ref,
+            environment_variant_ref=environment_variant_ref,
+            environment_revision_ref=environment_revision_ref,
+            key=key,
+            #
+            evaluator_ref=evaluator_ref,
+            evaluator_variant_ref=evaluator_variant_ref,
+            evaluator_revision_ref=evaluator_revision_ref,
+            #
+            resolve=evaluator_revision_retrieve_request.resolve or False,
+        )
 
         if environment_lookup_requested and not evaluator_revision:
             raise HTTPException(

--- a/api/oss/src/apis/fastapi/git/exceptions.py
+++ b/api/oss/src/apis/fastapi/git/exceptions.py
@@ -1,0 +1,64 @@
+"""Typed HTTP exceptions and a translation decorator for git-domain errors.
+
+The git pattern (artifact/variant/revision) is shared across six routers
+(workflows, applications, evaluators, testsets, queries, environments).
+Each router previously translated the same set of core exceptions to HTTP
+400 inline, multiplying boilerplate. This module centralizes that mapping
+so new domain exceptions need updates in one place.
+
+Any new exception added to `oss.src.core.git.types` must be registered
+below: add a typed `*Exception` and a `except` arm in
+`handle_git_exceptions`. The decorator is paired with the existing
+`@intercept_exceptions()` and `@suppress_exceptions(exclude=[HTTPException])`
+on each route; place it on the inside of those decorators so the typed
+HTTP exception is the one re-raised.
+"""
+
+from functools import wraps
+
+from fastapi import HTTPException
+
+from oss.src.core.git.types import (
+    RetrieveRefsInconsistent,
+    RetrieveRefsInsufficient,
+    VariantForkError,
+)
+
+
+class VariantForkErrorException(HTTPException):
+    def __init__(self, message: str = "Variant fork request cannot be fulfilled."):
+        super().__init__(status_code=400, detail=message)
+
+
+class RetrieveRefsInsufficientException(HTTPException):
+    def __init__(
+        self,
+        message: str = "References are insufficient to identify a single revision.",
+    ):
+        super().__init__(status_code=400, detail=message)
+
+
+class RetrieveRefsInconsistentException(HTTPException):
+    def __init__(
+        self,
+        message: str = "References disagree with the resolved revision.",
+    ):
+        super().__init__(status_code=400, detail=message)
+
+
+def handle_git_exceptions():
+    def decorator(func):
+        @wraps(func)
+        async def wrapper(*args, **kwargs):
+            try:
+                return await func(*args, **kwargs)
+            except VariantForkError as e:
+                raise VariantForkErrorException(message=e.message) from e
+            except RetrieveRefsInsufficient as e:
+                raise RetrieveRefsInsufficientException(message=e.message) from e
+            except RetrieveRefsInconsistent as e:
+                raise RetrieveRefsInconsistentException(message=e.message) from e
+
+        return wrapper
+
+    return decorator

--- a/api/oss/src/apis/fastapi/queries/router.py
+++ b/api/oss/src/apis/fastapi/queries/router.py
@@ -9,7 +9,7 @@ from oss.src.utils.exceptions import intercept_exceptions, suppress_exceptions
 from oss.src.utils.caching import get_cache, set_cache
 
 from oss.src.core.events.utils import publish_revision_event
-from oss.src.core.git.types import RetrieveRefsInsufficient, RetrieveRefsInconsistent
+from oss.src.apis.fastapi.git.exceptions import handle_git_exceptions
 
 from oss.src.core.shared.dtos import (
     Reference,
@@ -959,6 +959,7 @@ class QueriesRouter:
 
     @intercept_exceptions()
     @suppress_exceptions(default=QueryRevisionResponse(), exclude=[HTTPException])
+    @handle_git_exceptions()
     async def retrieve_query_revision(
         self,
         request: Request,
@@ -1020,24 +1021,18 @@ class QueriesRouter:
         )
 
         if not query_revision:
-            try:
-                query_revision = await self.queries_service.fetch_query_revision(
-                    project_id=UUID(request.state.project_id),
-                    #
-                    query_ref=query_revision_retrieve_request.query_ref,
-                    query_variant_ref=query_revision_retrieve_request.query_variant_ref,
-                    query_revision_ref=query_revision_retrieve_request.query_revision_ref,
-                    #
-                    include_trace_ids=query_revision_retrieve_request.include_trace_ids,
-                    include_traces=query_revision_retrieve_request.include_traces,
-                    #
-                    windowing=query_revision_retrieve_request.windowing,
-                )
-            except (RetrieveRefsInsufficient, RetrieveRefsInconsistent) as e:
-                raise HTTPException(
-                    status_code=status.HTTP_400_BAD_REQUEST,
-                    detail=e.message,
-                ) from e
+            query_revision = await self.queries_service.fetch_query_revision(
+                project_id=UUID(request.state.project_id),
+                #
+                query_ref=query_revision_retrieve_request.query_ref,
+                query_variant_ref=query_revision_retrieve_request.query_variant_ref,
+                query_revision_ref=query_revision_retrieve_request.query_revision_ref,
+                #
+                include_trace_ids=query_revision_retrieve_request.include_trace_ids,
+                include_traces=query_revision_retrieve_request.include_traces,
+                #
+                windowing=query_revision_retrieve_request.windowing,
+            )
 
             if should_cache:
                 await set_cache(

--- a/api/oss/src/apis/fastapi/testsets/router.py
+++ b/api/oss/src/apis/fastapi/testsets/router.py
@@ -28,7 +28,7 @@ from oss.src.utils.caching import set_cache, get_cache
 
 from oss.src.apis.fastapi.shared.utils import compute_next_windowing
 from oss.src.core.events.utils import publish_revision_event
-from oss.src.core.git.types import RetrieveRefsInsufficient, RetrieveRefsInconsistent
+from oss.src.apis.fastapi.git.exceptions import handle_git_exceptions
 
 from oss.src.core.shared.dtos import (
     Reference,
@@ -1444,6 +1444,7 @@ class TestsetsRouter:
 
     @intercept_exceptions()
     @suppress_exceptions(default=TestsetRevisionResponse(), exclude=[HTTPException])
+    @handle_git_exceptions()
     async def retrieve_testset_revision(
         self,
         request: Request,
@@ -1498,24 +1499,18 @@ class TestsetsRouter:
         )
 
         if not testset_revision:
-            try:
-                testset_revision = await self.testsets_service.fetch_testset_revision(
-                    project_id=UUID(request.state.project_id),
-                    #
-                    testset_ref=testset_revision_retrieve_request.testset_ref,
-                    testset_variant_ref=testset_revision_retrieve_request.testset_variant_ref,
-                    testset_revision_ref=testset_revision_retrieve_request.testset_revision_ref,
-                    #
-                    include_testcase_ids=testset_revision_retrieve_request.include_testcase_ids,
-                    include_testcases=testset_revision_retrieve_request.include_testcases,
-                    #
-                    windowing=testset_revision_retrieve_request.windowing,
-                )
-            except (RetrieveRefsInsufficient, RetrieveRefsInconsistent) as e:
-                raise HTTPException(
-                    status_code=status.HTTP_400_BAD_REQUEST,
-                    detail=e.message,
-                ) from e
+            testset_revision = await self.testsets_service.fetch_testset_revision(
+                project_id=UUID(request.state.project_id),
+                #
+                testset_ref=testset_revision_retrieve_request.testset_ref,
+                testset_variant_ref=testset_revision_retrieve_request.testset_variant_ref,
+                testset_revision_ref=testset_revision_retrieve_request.testset_revision_ref,
+                #
+                include_testcase_ids=testset_revision_retrieve_request.include_testcase_ids,
+                include_testcases=testset_revision_retrieve_request.include_testcases,
+                #
+                windowing=testset_revision_retrieve_request.windowing,
+            )
 
             if should_cache:
                 await set_cache(

--- a/api/oss/src/apis/fastapi/workflows/models.py
+++ b/api/oss/src/apis/fastapi/workflows/models.py
@@ -251,13 +251,20 @@ class WorkflowRevisionCommitRequest(BaseModel):
 
 
 class WorkflowRevisionRetrieveRequest(BaseModel):
+    """Request body for `POST /workflows/revisions/retrieve`.
+
+    Resolves to a single revision by one or more reference types. Every
+    reference supplied must agree with the resolved revision; contradictions
+    return HTTP 400.
+    """
+
     workflow_ref: Optional[Reference] = Field(
         default=None,
         description=(
             "Workflow artifact to look up. Identifies the artifact by `id` or "
             "`slug` (both project-unique). When no variant_ref or revision_ref "
-            "is provided, returns the latest revision of an arbitrary variant "
-            "of this workflow."
+            "is provided, returns the latest revision of the workflow's "
+            "default variant."
         ),
     )
     workflow_variant_ref: Optional[Reference] = Field(

--- a/api/oss/src/apis/fastapi/workflows/router.py
+++ b/api/oss/src/apis/fastapi/workflows/router.py
@@ -11,11 +11,7 @@ from oss.src.utils.caching import invalidate_cache
 from oss.src.core.shared.dtos import (
     Reference,
 )
-from oss.src.core.git.types import (
-    VariantForkError,
-    RetrieveRefsInsufficient,
-    RetrieveRefsInconsistent,
-)
+from oss.src.apis.fastapi.git.exceptions import handle_git_exceptions
 from oss.src.core.workflows.service import (
     WorkflowsService,
     SimpleWorkflowsService,
@@ -1149,6 +1145,7 @@ class WorkflowsRouter:
         return workflow_variants_response
 
     @intercept_exceptions()
+    @handle_git_exceptions()
     async def fork_workflow_variant(
         self,
         request: Request,
@@ -1163,18 +1160,12 @@ class WorkflowsRouter:
             ):
                 raise FORBIDDEN_EXCEPTION  # type: ignore
 
-        try:
-            workflow_variant = await self.workflows_service.fork_workflow_variant(
-                project_id=UUID(request.state.project_id),
-                user_id=UUID(request.state.user_id),
-                #
-                workflow_fork=workflow_fork_request.workflow,
-            )
-        except VariantForkError as e:
-            raise HTTPException(
-                status_code=status.HTTP_400_BAD_REQUEST,
-                detail=e.message,
-            ) from e
+        workflow_variant = await self.workflows_service.fork_workflow_variant(
+            project_id=UUID(request.state.project_id),
+            user_id=UUID(request.state.user_id),
+            #
+            workflow_fork=workflow_fork_request.workflow,
+        )
 
         # Invalidate legacy caches so the registry page reflects the forked variant
         await invalidate_cache(project_id=request.state.project_id)
@@ -1236,12 +1227,6 @@ class WorkflowsRouter:
             ):
                 raise FORBIDDEN_EXCEPTION  # type: ignore
 
-        # This route only accepts `workflow_revision_id` as a path param and
-        # constructs `Reference(id=workflow_revision_id)`. That shape always
-        # satisfies the service's ambiguity validation, so no try/except for
-        # `RetrieveRefsInsufficient` is needed here. The other two call sites
-        # (`deploy_workflow_revision` and `retrieve_workflow_revision`) pass
-        # through caller-supplied refs and do wrap this call.
         workflow_revision = await self.workflows_service.fetch_workflow_revision(
             project_id=UUID(request.state.project_id),
             #
@@ -1488,6 +1473,7 @@ class WorkflowsRouter:
         return workflow_revisions_response
 
     @intercept_exceptions()
+    @handle_git_exceptions()
     async def deploy_workflow_revision(
         self,
         request: Request,
@@ -1532,19 +1518,13 @@ class WorkflowsRouter:
                 detail="Workflow deploy requires environment refs.",
             )
 
-        try:
-            workflow_revision = await self.workflows_service.fetch_workflow_revision(
-                project_id=UUID(request.state.project_id),
-                #
-                workflow_ref=workflow_deploy_request.workflow_ref,
-                workflow_variant_ref=workflow_deploy_request.workflow_variant_ref,
-                workflow_revision_ref=workflow_deploy_request.workflow_revision_ref,
-            )
-        except (RetrieveRefsInsufficient, RetrieveRefsInconsistent) as e:
-            raise HTTPException(
-                status_code=status.HTTP_400_BAD_REQUEST,
-                detail=e.message,
-            ) from e
+        workflow_revision = await self.workflows_service.fetch_workflow_revision(
+            project_id=UUID(request.state.project_id),
+            #
+            workflow_ref=workflow_deploy_request.workflow_ref,
+            workflow_variant_ref=workflow_deploy_request.workflow_variant_ref,
+            workflow_revision_ref=workflow_deploy_request.workflow_revision_ref,
+        )
 
         if not workflow_revision:
             raise HTTPException(
@@ -1647,6 +1627,7 @@ class WorkflowsRouter:
 
     @intercept_exceptions()
     @suppress_exceptions(default=WorkflowRevisionResponse(), exclude=[HTTPException])
+    @handle_git_exceptions()
     async def retrieve_workflow_revision(
         self,
         request: Request,
@@ -1725,29 +1706,23 @@ class WorkflowsRouter:
                         detail="Environment-backed workflow retrieve requires key.",
                     )
 
-        try:
-            (
-                workflow_revision,
-                resolution_info,
-            ) = await self.workflows_service.retrieve_workflow_revision(
-                project_id=UUID(request.state.project_id),
-                #
-                environment_ref=environment_ref,
-                environment_variant_ref=environment_variant_ref,
-                environment_revision_ref=environment_revision_ref,
-                key=key,
-                #
-                workflow_ref=workflow_ref,
-                workflow_variant_ref=workflow_variant_ref,
-                workflow_revision_ref=workflow_revision_ref,
-                #
-                resolve=workflow_revision_retrieve_request.resolve or False,
-            )
-        except (RetrieveRefsInsufficient, RetrieveRefsInconsistent) as e:
-            raise HTTPException(
-                status_code=status.HTTP_400_BAD_REQUEST,
-                detail=e.message,
-            ) from e
+        (
+            workflow_revision,
+            resolution_info,
+        ) = await self.workflows_service.retrieve_workflow_revision(
+            project_id=UUID(request.state.project_id),
+            #
+            environment_ref=environment_ref,
+            environment_variant_ref=environment_variant_ref,
+            environment_revision_ref=environment_revision_ref,
+            key=key,
+            #
+            workflow_ref=workflow_ref,
+            workflow_variant_ref=workflow_variant_ref,
+            workflow_revision_ref=workflow_revision_ref,
+            #
+            resolve=workflow_revision_retrieve_request.resolve or False,
+        )
 
         if environment_lookup_requested and not workflow_revision:
             raise HTTPException(

--- a/api/oss/src/core/git/types.py
+++ b/api/oss/src/core/git/types.py
@@ -1,3 +1,93 @@
+"""Git-pattern domain rules for artifact/variant/revision references.
+
+This module owns the shape of `revisions/retrieve` across every git-backed
+entity (workflows, applications, evaluators, testsets, queries,
+environments). Changes here propagate uniformly. The rules below are the
+contract every entity service implements before delegating to its DAO.
+
+Reference shapes
+================
+
+A `Reference(id, slug, version)` is *identifying* iff it carries an `id`
+or a `slug`. Both are project-unique. A bare `version` (with no `id` or
+`slug`) is a per-variant sequence number on its own — not a project-wide
+identifier — and never identifies a row.
+
+Variants do not have versions: a `variant_ref` carrying only `version`
+is rejected outright by `validate_variant_refs_sufficient`.
+
+A revision can be identified by:
+
+  * `revision_ref.id`                                — project-unique.
+  * `revision_ref.slug`                              — project-unique.
+  * `variant_ref` (id/slug) + `revision_ref.version` — version is scoped
+    to the variant.
+
+Rule 2.a — minimal identifying request
+---------------------------------------
+
+Any single identifying reference resolves a single revision:
+
+  * `{revision_ref.id}` or `{revision_ref.slug}` → that revision.
+  * `{variant_ref}`                              → latest revision on the
+    variant (stable tie-break: `created_at DESC, id DESC`).
+  * `{artifact_ref}`                             → latest revision on the
+    artifact's default variant (default variant picked by
+    `created_at ASC, id ASC LIMIT 1`).
+
+Env-path: `{environment_ref + key}` resolves to the revision currently
+deployed under that key. When `key` is omitted but `artifact_ref` has a
+slug, the key is derived as `{artifact_slug}.revision`.
+
+Rule 2.b — redundant-consistent request
+----------------------------------------
+
+A caller may repeat identifying refs across the
+artifact/variant/revision triple, or mix entity refs with env refs.
+Every redundant identifier must name the same row that the lookup
+resolved. Validated post-resolution by
+`validate_retrieve_refs_consistent`.
+
+Rule 2.c — inconsistent request
+--------------------------------
+
+When any redundant ref contradicts the resolved revision (different
+`id`, different `slug`, or — for revisions inside a variant — different
+`version`), `RetrieveRefsInconsistent` is raised. Routers translate this
+to HTTP 400 with a `*_ref` field name in the message.
+
+Rule 2.d — insufficient request that picks a default
+-----------------------------------------------------
+
+When refs are minimal but unambiguous (single variant, single artifact,
+env-ref + key), the rules above pick deterministically.
+
+Rule 2.e — insufficient request that cannot pick
+-------------------------------------------------
+
+When refs are present but cannot identify a single revision —
+`{revision_ref:{version}}` alone, `{variant_ref:{version}}` alone, or
+env refs without a `key` and without an artifact-ref to derive the key
+from — `RetrieveRefsInsufficient` is raised. Routers translate this to
+HTTP 400.
+
+Empty request (`{}`) resolves to `None` at the service layer; routers
+that require at least one identifying input (env-path-only routers like
+applications) reject it at the boundary.
+
+Exception registry
+==================
+
+`VariantForkError`, `RetrieveRefsInsufficient`, and
+`RetrieveRefsInconsistent` are translated to HTTP responses by
+`@handle_git_exceptions()` in
+`api/oss/src/apis/fastapi/git/exceptions.py`. Any new git-domain
+exception added here must also be registered there.
+
+See `docs/design/playground-open-from-trace/followups.md` for the design
+record that drove these rules.
+"""
+
 from typing import Optional
 
 from oss.src.core.shared.dtos import Reference

--- a/api/oss/tests/pytest/acceptance/test_revision_retrieve_env_path.py
+++ b/api/oss/tests/pytest/acceptance/test_revision_retrieve_env_path.py
@@ -1,0 +1,442 @@
+"""Acceptance: env-backed revision-retrieve coverage (C8 second pass).
+
+Pins env-path behavior on the three routers that accept env refs:
+applications, evaluators, workflows. Each test provisions a real
+artifact + variant + revision and deploys the revision to an environment
+under the default `{artifact_slug}.revision` key, then exercises:
+
+  * 2.a (env path): `{env_ref + key}` → 200, returns the deployed revision.
+  * 2.d (env path, default key): `{env_ref + artifact_ref}` (no `key`,
+    derived from the artifact slug) → 200.
+  * 2.b (redundant-consistent path-mixing): `{env_ref + key +
+    artifact_ref (matching)}` → 200.
+  * 2.c (path-mixed inconsistent): `{env_ref + key + revision_ref.id}`
+    where the revision_ref does NOT match what env+key resolves to → 400.
+
+The workflows/applications/evaluators routers all funnel into the same
+service-layer pipeline, so the matrix is intentionally symmetric.
+"""
+
+from uuid import uuid4
+
+
+# environment helpers ----------------------------------------------------------
+
+
+def _create_environment_with_deployment(authed_api, *, key, payload):
+    """Create an environment + variant + revision that deploys `payload`
+    under the given `key`. Returns the env, variant and revision rows.
+    """
+    slug = uuid4().hex[:12]
+    response = authed_api(
+        "POST",
+        "/environments/",
+        json={"environment": {"slug": f"env-{slug}"}},
+    )
+    assert response.status_code == 200, response.text
+    env = response.json()["environment"]
+
+    response = authed_api(
+        "POST",
+        "/environments/variants/",
+        json={
+            "environment_variant": {
+                "slug": f"envv-{slug}",
+                "environment_id": env["id"],
+            }
+        },
+    )
+    assert response.status_code == 200, response.text
+    env_variant = response.json()["environment_variant"]
+
+    response = authed_api(
+        "POST",
+        "/environments/revisions/commit",
+        json={
+            "environment_revision_commit": {
+                "slug": f"envr-{slug}",
+                "environment_id": env["id"],
+                "environment_variant_id": env_variant["id"],
+                "data": {"references": {key: payload}},
+            }
+        },
+    )
+    assert response.status_code == 200, response.text
+    env_revision = response.json()["environment_revision"]
+    return env, env_variant, env_revision
+
+
+# workflows --------------------------------------------------------------------
+
+
+def _create_workflow_stack(authed_api):
+    slug = uuid4().hex[:12]
+    response = authed_api(
+        "POST",
+        "/workflows/",
+        json={"workflow": {"slug": f"wf-{slug}"}},
+    )
+    assert response.status_code == 200, response.text
+    workflow = response.json()["workflow"]
+
+    response = authed_api(
+        "POST",
+        "/workflows/variants/",
+        json={
+            "workflow_variant": {
+                "slug": f"wfv-{slug}",
+                "workflow_id": workflow["id"],
+            }
+        },
+    )
+    assert response.status_code == 200, response.text
+    variant = response.json()["workflow_variant"]
+
+    response = authed_api(
+        "POST",
+        "/workflows/revisions/",
+        json={
+            "workflow_revision": {
+                "slug": f"wfr-{slug}",
+                "workflow_variant_id": variant["id"],
+                "workflow_id": workflow["id"],
+            }
+        },
+    )
+    assert response.status_code == 200, response.text
+    revision = response.json()["workflow_revision"]
+    return workflow, variant, revision
+
+
+def _deploy_workflow_to_env(authed_api, workflow, variant, revision):
+    key = f"{workflow['slug']}.revision"
+    payload = {
+        "workflow": {"id": workflow["id"], "slug": workflow["slug"]},
+        "workflow_variant": {"id": variant["id"], "slug": variant["slug"]},
+        "workflow_revision": {
+            "id": revision["id"],
+            "version": revision.get("version") or "1",
+        },
+    }
+    return _create_environment_with_deployment(authed_api, key=key, payload=payload)
+
+
+def test_workflows_env_retrieve_by_env_slug_and_key(authed_api):
+    workflow, variant, revision = _create_workflow_stack(authed_api)
+    env, _, _ = _deploy_workflow_to_env(authed_api, workflow, variant, revision)
+
+    response = authed_api(
+        "POST",
+        "/workflows/revisions/retrieve",
+        json={
+            "environment_ref": {"slug": env["slug"]},
+            "key": f"{workflow['slug']}.revision",
+        },
+    )
+    assert response.status_code == 200, response.text
+    assert response.json()["workflow_revision"]["id"] == revision["id"]
+
+
+def test_workflows_env_retrieve_default_key_from_artifact_slug(authed_api):
+    workflow, variant, revision = _create_workflow_stack(authed_api)
+    env, _, _ = _deploy_workflow_to_env(authed_api, workflow, variant, revision)
+
+    response = authed_api(
+        "POST",
+        "/workflows/revisions/retrieve",
+        json={
+            "environment_ref": {"slug": env["slug"]},
+            "workflow_ref": {"slug": workflow["slug"]},
+        },
+    )
+    assert response.status_code == 200, response.text
+    assert response.json()["workflow_revision"]["id"] == revision["id"]
+
+
+def test_workflows_env_retrieve_with_redundant_consistent_artifact(authed_api):
+    workflow, variant, revision = _create_workflow_stack(authed_api)
+    env, _, _ = _deploy_workflow_to_env(authed_api, workflow, variant, revision)
+
+    response = authed_api(
+        "POST",
+        "/workflows/revisions/retrieve",
+        json={
+            "environment_ref": {"slug": env["slug"]},
+            "key": f"{workflow['slug']}.revision",
+            "workflow_ref": {"id": workflow["id"], "slug": workflow["slug"]},
+        },
+    )
+    assert response.status_code == 200, response.text
+    assert response.json()["workflow_revision"]["id"] == revision["id"]
+
+
+def test_workflows_env_retrieve_path_mixed_inconsistent_revision_returns_400(
+    authed_api,
+):
+    workflow, variant, revision = _create_workflow_stack(authed_api)
+    env, _, _ = _deploy_workflow_to_env(authed_api, workflow, variant, revision)
+
+    _, _, unrelated_revision = _create_workflow_stack(authed_api)
+
+    response = authed_api(
+        "POST",
+        "/workflows/revisions/retrieve",
+        json={
+            "environment_ref": {"slug": env["slug"]},
+            "key": f"{workflow['slug']}.revision",
+            "workflow_revision_ref": {"id": unrelated_revision["id"]},
+        },
+    )
+    assert response.status_code == 400, response.text
+
+
+# applications -----------------------------------------------------------------
+
+
+def _create_application_stack(authed_api):
+    slug = uuid4().hex[:12]
+    flags = {"is_application": True, "is_evaluator": False, "is_snippet": False}
+    response = authed_api(
+        "POST",
+        "/applications/",
+        json={"application": {"slug": f"app-{slug}", "flags": flags}},
+    )
+    assert response.status_code == 200, response.text
+    app = response.json()["application"]
+
+    response = authed_api(
+        "POST",
+        "/applications/variants/",
+        json={
+            "application_variant": {
+                "slug": f"appv-{slug}",
+                "application_id": app["id"],
+                "flags": flags,
+            }
+        },
+    )
+    assert response.status_code == 200, response.text
+    variant = response.json()["application_variant"]
+
+    response = authed_api(
+        "POST",
+        "/applications/revisions/commit",
+        json={
+            "application_revision_commit": {
+                "application_id": app["id"],
+                "application_variant_id": variant["id"],
+                "data": {"parameters": {"model": "test-model"}},
+            }
+        },
+    )
+    assert response.status_code == 200, response.text
+    revision = response.json()["application_revision"]
+    return app, variant, revision
+
+
+def _deploy_application_to_env(authed_api, app, variant, revision):
+    key = f"{app['slug']}.revision"
+    payload = {
+        "application": {"id": app["id"], "slug": app["slug"]},
+        "application_variant": {"id": variant["id"], "slug": variant["slug"]},
+        "application_revision": {
+            "id": revision["id"],
+            "version": revision.get("version") or "1",
+        },
+    }
+    return _create_environment_with_deployment(authed_api, key=key, payload=payload)
+
+
+def test_applications_env_retrieve_by_env_slug_and_key(authed_api):
+    app, variant, revision = _create_application_stack(authed_api)
+    env, _, _ = _deploy_application_to_env(authed_api, app, variant, revision)
+
+    response = authed_api(
+        "POST",
+        "/applications/revisions/retrieve",
+        json={
+            "environment_ref": {"slug": env["slug"]},
+            "key": f"{app['slug']}.revision",
+        },
+    )
+    assert response.status_code == 200, response.text
+    assert response.json()["application_revision"]["id"] == revision["id"]
+
+
+def test_applications_env_retrieve_default_key_from_artifact_slug(authed_api):
+    app, variant, revision = _create_application_stack(authed_api)
+    env, _, _ = _deploy_application_to_env(authed_api, app, variant, revision)
+
+    response = authed_api(
+        "POST",
+        "/applications/revisions/retrieve",
+        json={
+            "environment_ref": {"slug": env["slug"]},
+            "application_ref": {"slug": app["slug"]},
+        },
+    )
+    assert response.status_code == 200, response.text
+    assert response.json()["application_revision"]["id"] == revision["id"]
+
+
+def test_applications_env_retrieve_with_redundant_consistent_artifact(authed_api):
+    app, variant, revision = _create_application_stack(authed_api)
+    env, _, _ = _deploy_application_to_env(authed_api, app, variant, revision)
+
+    response = authed_api(
+        "POST",
+        "/applications/revisions/retrieve",
+        json={
+            "environment_ref": {"slug": env["slug"]},
+            "key": f"{app['slug']}.revision",
+            "application_ref": {"id": app["id"], "slug": app["slug"]},
+        },
+    )
+    assert response.status_code == 200, response.text
+    assert response.json()["application_revision"]["id"] == revision["id"]
+
+
+def test_applications_env_retrieve_path_mixed_inconsistent_revision_returns_400(
+    authed_api,
+):
+    app, variant, revision = _create_application_stack(authed_api)
+    env, _, _ = _deploy_application_to_env(authed_api, app, variant, revision)
+
+    _, _, unrelated_revision = _create_application_stack(authed_api)
+
+    response = authed_api(
+        "POST",
+        "/applications/revisions/retrieve",
+        json={
+            "environment_ref": {"slug": env["slug"]},
+            "key": f"{app['slug']}.revision",
+            "application_revision_ref": {"id": unrelated_revision["id"]},
+        },
+    )
+    assert response.status_code == 400, response.text
+
+
+# evaluators -------------------------------------------------------------------
+
+
+def _create_evaluator_stack(authed_api):
+    slug = uuid4().hex[:12]
+    flags = {"is_evaluator": True}
+    response = authed_api(
+        "POST",
+        "/evaluators/",
+        json={"evaluator": {"slug": f"ev-{slug}", "flags": flags}},
+    )
+    assert response.status_code == 200, response.text
+    evaluator = response.json()["evaluator"]
+
+    response = authed_api(
+        "POST",
+        "/evaluators/variants/",
+        json={
+            "evaluator_variant": {
+                "slug": f"evv-{slug}",
+                "evaluator_id": evaluator["id"],
+                "flags": flags,
+            }
+        },
+    )
+    assert response.status_code == 200, response.text
+    variant = response.json()["evaluator_variant"]
+
+    response = authed_api(
+        "POST",
+        "/evaluators/revisions/commit",
+        json={
+            "evaluator_revision_commit": {
+                "evaluator_id": evaluator["id"],
+                "evaluator_variant_id": variant["id"],
+                "data": {"parameters": {"threshold": 0.5}},
+            }
+        },
+    )
+    assert response.status_code == 200, response.text
+    revision = response.json()["evaluator_revision"]
+    return evaluator, variant, revision
+
+
+def _deploy_evaluator_to_env(authed_api, evaluator, variant, revision):
+    key = f"{evaluator['slug']}.revision"
+    payload = {
+        "evaluator": {"id": evaluator["id"], "slug": evaluator["slug"]},
+        "evaluator_variant": {"id": variant["id"], "slug": variant["slug"]},
+        "evaluator_revision": {
+            "id": revision["id"],
+            "version": revision.get("version") or "1",
+        },
+    }
+    return _create_environment_with_deployment(authed_api, key=key, payload=payload)
+
+
+def test_evaluators_env_retrieve_by_env_slug_and_key(authed_api):
+    evaluator, variant, revision = _create_evaluator_stack(authed_api)
+    env, _, _ = _deploy_evaluator_to_env(authed_api, evaluator, variant, revision)
+
+    response = authed_api(
+        "POST",
+        "/evaluators/revisions/retrieve",
+        json={
+            "environment_ref": {"slug": env["slug"]},
+            "key": f"{evaluator['slug']}.revision",
+        },
+    )
+    assert response.status_code == 200, response.text
+    assert response.json()["evaluator_revision"]["id"] == revision["id"]
+
+
+def test_evaluators_env_retrieve_default_key_from_artifact_slug(authed_api):
+    evaluator, variant, revision = _create_evaluator_stack(authed_api)
+    env, _, _ = _deploy_evaluator_to_env(authed_api, evaluator, variant, revision)
+
+    response = authed_api(
+        "POST",
+        "/evaluators/revisions/retrieve",
+        json={
+            "environment_ref": {"slug": env["slug"]},
+            "evaluator_ref": {"slug": evaluator["slug"]},
+        },
+    )
+    assert response.status_code == 200, response.text
+    assert response.json()["evaluator_revision"]["id"] == revision["id"]
+
+
+def test_evaluators_env_retrieve_with_redundant_consistent_artifact(authed_api):
+    evaluator, variant, revision = _create_evaluator_stack(authed_api)
+    env, _, _ = _deploy_evaluator_to_env(authed_api, evaluator, variant, revision)
+
+    response = authed_api(
+        "POST",
+        "/evaluators/revisions/retrieve",
+        json={
+            "environment_ref": {"slug": env["slug"]},
+            "key": f"{evaluator['slug']}.revision",
+            "evaluator_ref": {"id": evaluator["id"], "slug": evaluator["slug"]},
+        },
+    )
+    assert response.status_code == 200, response.text
+    assert response.json()["evaluator_revision"]["id"] == revision["id"]
+
+
+def test_evaluators_env_retrieve_path_mixed_inconsistent_revision_returns_400(
+    authed_api,
+):
+    evaluator, variant, revision = _create_evaluator_stack(authed_api)
+    env, _, _ = _deploy_evaluator_to_env(authed_api, evaluator, variant, revision)
+
+    _, _, unrelated_revision = _create_evaluator_stack(authed_api)
+
+    response = authed_api(
+        "POST",
+        "/evaluators/revisions/retrieve",
+        json={
+            "environment_ref": {"slug": env["slug"]},
+            "key": f"{evaluator['slug']}.revision",
+            "evaluator_revision_ref": {"id": unrelated_revision["id"]},
+        },
+    )
+    assert response.status_code == 400, response.text

--- a/docs/docs/prompt-engineering/integrating-prompts/02-fetch-prompt-programatically.mdx
+++ b/docs/docs/prompt-engineering/integrating-prompts/02-fetch-prompt-programatically.mdx
@@ -263,6 +263,19 @@ curl -X POST "https://cloud.agenta.ai/api/applications/revisions/retrieve" \
   </TabItem>
 </Tabs>
 
+## How the request resolves
+
+You can identify the revision you want with any combination of:
+
+- `application_revision_ref` — by `id` or `slug`, or by `version` paired with a `application_variant_ref`.
+- `application_variant_ref` — picks the latest revision on that variant.
+- `application_ref` — picks the latest revision on the application's default variant.
+- `environment_ref` (+ optional `key`) — picks the revision currently deployed to that environment under the default key `{application_slug}.revision`.
+
+You may supply more than one reference. Every reference you send must agree with the resolved revision; if any contradicts, the endpoint returns `400 Bad Request` and the response detail names the field that disagreed.
+
+The endpoint also returns `400` when the references are not sufficient to identify a single revision — for example, when only `application_revision_ref.version` is provided (a per-variant sequence number with no variant context), or when only `application_variant_ref.version` is provided (variants do not have versions).
+
 ## Response Format
 
 The SDK returns the configuration parameters directly as a dictionary. When using the REST API, the response contains the full revision data including configuration under `params` along with reference metadata:

--- a/docs/docs/reference/api-guide/04-versioning.mdx
+++ b/docs/docs/reference/api-guide/04-versioning.mdx
@@ -60,12 +60,12 @@ The response contains the new revision with its `id`, `version`, `author`, `date
 References are how you point at something in the versioning tree. Each reference is a small object that identifies an artifact, variant, or revision.
 
 :::info
-A reference can be supplied as an `id`, a `slug`, or (for revisions) a `slug` plus `version`. For example:
+A reference can be supplied as an `id`, a `slug`, or — for revisions paired with a variant — a `version`. For example:
 
 ```json
 {"application_revision_ref": {"id": "019d9531-2e44-7c3a-b8cb-d6d8e675c18d"}}
-{"application_variant_ref": {"slug": "production"}}
-{"application_revision_ref": {"slug": "production", "version": 3}}
+{"application_variant_ref": {"slug": "default"}}
+{"application_variant_ref": {"slug": "default"}, "application_revision_ref": {"version": "3"}}
 {"environment_ref": {"slug": "production"}}
 ```
 :::
@@ -79,11 +79,19 @@ curl -X POST "$AGENTA_HOST/api/applications/revisions/retrieve" \
 
 The retrieve endpoint accepts any of:
 
-- `application_revision_ref`: a specific revision by `id` or by `slug` + `version`.
+- `application_revision_ref`: a specific revision by `id` or by `slug`.
+- `application_variant_ref` + `application_revision_ref.version`: a specific revision on that variant.
 - `application_variant_ref`: the latest revision on that variant.
-- `environment_ref`: the revision currently deployed to that environment.
+- `application_ref`: the latest revision on the artifact's default variant.
+- `environment_ref` (+ optional `key`): the revision currently deployed to that environment. The default key is `{application_slug}.revision`; provide an explicit `key` if you deployed the application under a different name.
 
-Only one reference is needed. If several are supplied, the most specific one wins: a revision reference is used over a variant reference, and a variant reference is used over an environment reference.
+You may pass several references in the same request — for example, `application_ref` plus `application_revision_ref.id` — but every supplied reference must agree with the resolved revision. The request returns `400 Bad Request` if:
+
+- A `revision_ref` carries only `version` (or a `variant_ref` carries only `version`) without an enclosing variant or artifact context. `version` is a per-variant sequence number; on its own it does not name a single revision.
+- A `variant_ref` carries only `version`. Variants do not have versions.
+- Any redundant reference contradicts the resolved revision. The detail message names the field that did not match.
+
+When the request is identifying but the row no longer exists, the endpoint returns `404 Not Found` rather than `400`.
 
 ## Listing revision history
 


### PR DESCRIPTION
## What was broken
PR #4431 pinned the entity-path rules (2.a/2.b/2.d) but left env-path coverage thin. Rule 2.c (path-mixed inconsistent) had no acceptance test at all.

## The fix
Add `test_revision_retrieve_env_path.py` covering the workflows/applications/evaluators env-path: `{env_ref + key}`, default-key derivation from `artifact_ref.slug`, redundant-consistent path-mixing (200), and path-mixed inconsistent (400).

## Notes
Stacked on #4435.