### PR TITLE
[fix] Resolve retrieve-related issue 13: C1b is_default flag on variants

### DIFF
--- a/api/ee/databases/postgres/migrations/core/versions/c1b0d2a3e4f5_add_is_default_flag_to_variants.py
+++ b/api/ee/databases/postgres/migrations/core/versions/c1b0d2a3e4f5_add_is_default_flag_to_variants.py
@@ -1,0 +1,52 @@
+"""Add is_default flag on variants (workflow/query/testset/environment)
+
+Backfills `flags->>'is_default' = true` on the earliest-created variant
+per `(project_id, artifact_id)` that does not already have one, then adds
+a partial unique index on `(project_id, artifact_id)` filtered by
+`(flags->>'is_default')::boolean IS TRUE`. The index doubles as the
+uniqueness constraint and the lookup index for the default-variant pick
+in `GitDAO.fetch_variant`. Replaces the deterministic ORDER BY interim
+introduced by C1a.
+
+Revision ID: c1b0d2a3e4f5
+Revises: c11b3a4d5e6f
+Create Date: 2026-05-26 16:00:00.000000
+
+"""
+
+from typing import Sequence, Union
+
+from alembic import op
+import sqlalchemy as sa
+
+from oss.databases.postgres.migrations.core.data_migrations.is_default_variants import (
+    VARIANT_TABLES,
+    backfill_sql,
+)
+
+
+revision: str = "c1b0d2a3e4f5"
+down_revision: Union[str, None] = "c11b3a4d5e6f"
+branch_labels: Union[str, Sequence[str], None] = None
+depends_on: Union[str, Sequence[str], None] = None
+
+
+def upgrade() -> None:
+    conn = op.get_bind()
+    for table in VARIANT_TABLES:
+        conn.execute(sa.text(backfill_sql(table)))
+        op.create_index(
+            f"ix_{table}_default_per_artifact",
+            table,
+            ["project_id", "artifact_id"],
+            unique=True,
+            postgresql_where=sa.text("(flags->>'is_default')::boolean IS TRUE"),
+        )
+
+
+def downgrade() -> None:
+    for table in VARIANT_TABLES:
+        op.drop_index(
+            f"ix_{table}_default_per_artifact",
+            table_name=table,
+        )

--- a/api/oss/databases/postgres/migrations/core/data_migrations/is_default_variants.py
+++ b/api/oss/databases/postgres/migrations/core/data_migrations/is_default_variants.py
@@ -1,0 +1,46 @@
+"""Helpers for the C1b is_default-flag backfill.
+
+Lifted into its own module so the migration-level SQL can be unit-tested
+without importing `alembic`, mirroring the workflow_revisions pattern.
+"""
+
+from typing import Tuple
+
+
+VARIANT_TABLES: Tuple[str, ...] = (
+    "workflow_variants",
+    "query_variants",
+    "testset_variants",
+    "environment_variants",
+)
+
+
+def backfill_sql(table: str) -> str:
+    return f"""
+        WITH first_per_artifact AS (
+            SELECT DISTINCT ON (project_id, artifact_id) id, project_id
+            FROM {table}
+            WHERE deleted_at IS NULL
+            ORDER BY project_id, artifact_id, created_at ASC, id ASC
+        ),
+        already_flagged AS (
+            SELECT project_id, artifact_id
+            FROM {table}
+            WHERE (flags->>'is_default')::boolean IS TRUE
+        )
+        UPDATE {table} AS t
+        SET flags = jsonb_set(
+            COALESCE(t.flags, '{{}}'::jsonb),
+            '{{is_default}}',
+            'true'::jsonb,
+            true
+        )
+        FROM first_per_artifact f
+        WHERE t.project_id = f.project_id
+          AND t.id = f.id
+          AND NOT EXISTS (
+              SELECT 1 FROM already_flagged a
+              WHERE a.project_id = t.project_id
+                AND a.artifact_id = t.artifact_id
+          )
+    """

--- a/api/oss/databases/postgres/migrations/core/versions/c1b0d2a3e4f5_add_is_default_flag_to_variants.py
+++ b/api/oss/databases/postgres/migrations/core/versions/c1b0d2a3e4f5_add_is_default_flag_to_variants.py
@@ -1,0 +1,52 @@
+"""Add is_default flag on variants (workflow/query/testset/environment)
+
+Backfills `flags->>'is_default' = true` on the earliest-created variant
+per `(project_id, artifact_id)` that does not already have one, then adds
+a partial unique index on `(project_id, artifact_id)` filtered by
+`(flags->>'is_default')::boolean IS TRUE`. The index doubles as the
+uniqueness constraint and the lookup index for the default-variant pick
+in `GitDAO.fetch_variant`. Replaces the deterministic ORDER BY interim
+introduced by C1a.
+
+Revision ID: c1b0d2a3e4f5
+Revises: c11b3a4d5e6f
+Create Date: 2026-05-26 16:00:00.000000
+
+"""
+
+from typing import Sequence, Union
+
+from alembic import op
+import sqlalchemy as sa
+
+from oss.databases.postgres.migrations.core.data_migrations.is_default_variants import (
+    VARIANT_TABLES,
+    backfill_sql,
+)
+
+
+revision: str = "c1b0d2a3e4f5"
+down_revision: Union[str, None] = "c11b3a4d5e6f"
+branch_labels: Union[str, Sequence[str], None] = None
+depends_on: Union[str, Sequence[str], None] = None
+
+
+def upgrade() -> None:
+    conn = op.get_bind()
+    for table in VARIANT_TABLES:
+        conn.execute(sa.text(backfill_sql(table)))
+        op.create_index(
+            f"ix_{table}_default_per_artifact",
+            table,
+            ["project_id", "artifact_id"],
+            unique=True,
+            postgresql_where=sa.text("(flags->>'is_default')::boolean IS TRUE"),
+        )
+
+
+def downgrade() -> None:
+    for table in VARIANT_TABLES:
+        op.drop_index(
+            f"ix_{table}_default_per_artifact",
+            table_name=table,
+        )

--- a/api/oss/src/dbs/postgres/git/dao.py
+++ b/api/oss/src/dbs/postgres/git/dao.py
@@ -463,6 +463,18 @@ class GitDAO(GitDAOInterface):
                 if artifact_slug is not None:
                     variant_dbe.artifact_slug = artifact_slug
 
+                existing_default = await session.execute(
+                    select(self.VariantDBE.id)  # type: ignore
+                    .filter(self.VariantDBE.project_id == project_id)  # type: ignore
+                    .filter(self.VariantDBE.artifact_id == variant_create.artifact_id)  # type: ignore
+                    .filter(self.VariantDBE.flags["is_default"].as_boolean().is_(True))  # type: ignore
+                    .limit(1)
+                )
+                if existing_default.first() is None:
+                    flags = dict(variant_dbe.flags or {})
+                    flags["is_default"] = True
+                    variant_dbe.flags = flags
+
                 session.add(variant_dbe)
 
                 await session.commit()
@@ -530,20 +542,26 @@ class GitDAO(GitDAOInterface):
             if not applied_identifying_filter:
                 return None
 
-            if pick_default_variant:
-                stmt = stmt.order_by(
-                    self.VariantDBE.created_at.asc(),  # type: ignore
-                    self.VariantDBE.id.asc(),  # type: ignore
-                )
-
             if include_archived is not True:
                 stmt = stmt.filter(self.VariantDBE.deleted_at.is_(None))  # type: ignore
 
-            stmt = stmt.limit(1)
-
-            result = await session.execute(stmt)
-
-            variant_dbe = result.scalars().first()
+            if pick_default_variant:
+                flagged_stmt = stmt.filter(
+                    self.VariantDBE.flags["is_default"].as_boolean().is_(True),  # type: ignore
+                ).limit(1)
+                result = await session.execute(flagged_stmt)
+                variant_dbe = result.scalars().first()
+                if variant_dbe is None:
+                    fallback_stmt = stmt.order_by(
+                        self.VariantDBE.created_at.asc(),  # type: ignore
+                        self.VariantDBE.id.asc(),  # type: ignore
+                    ).limit(1)
+                    result = await session.execute(fallback_stmt)
+                    variant_dbe = result.scalars().first()
+            else:
+                stmt = stmt.limit(1)
+                result = await session.execute(stmt)
+                variant_dbe = result.scalars().first()
 
             if not variant_dbe:
                 return None

--- a/api/oss/tests/pytest/unit/migrations/test_is_default_variants_backfill.py
+++ b/api/oss/tests/pytest/unit/migrations/test_is_default_variants_backfill.py
@@ -1,0 +1,51 @@
+"""Unit tests for the C1b is_default backfill migration."""
+
+from oss.databases.postgres.migrations.core.data_migrations.is_default_variants import (
+    VARIANT_TABLES,
+    backfill_sql,
+)
+
+
+def test_covers_all_four_variant_tables():
+    assert VARIANT_TABLES == (
+        "workflow_variants",
+        "query_variants",
+        "testset_variants",
+        "environment_variants",
+    )
+
+
+def test_backfill_sql_picks_earliest_per_project_and_artifact():
+    sql = backfill_sql("workflow_variants")
+
+    assert "DISTINCT ON (project_id, artifact_id)" in sql
+    assert "ORDER BY project_id, artifact_id, created_at ASC, id ASC" in sql
+
+
+def test_backfill_sql_skips_already_flagged_artifacts():
+    sql = backfill_sql("workflow_variants")
+
+    assert "already_flagged" in sql
+    assert "(flags->>'is_default')::boolean IS TRUE" in sql
+    assert "NOT EXISTS" in sql
+
+
+def test_backfill_sql_uses_jsonb_set_with_coalesce():
+    sql = backfill_sql("workflow_variants")
+
+    assert "jsonb_set" in sql
+    assert "COALESCE(t.flags, '{}'::jsonb)" in sql
+    assert "'true'::jsonb" in sql
+
+
+def test_backfill_sql_ignores_archived_rows():
+    sql = backfill_sql("workflow_variants")
+
+    assert "deleted_at IS NULL" in sql
+
+
+def test_backfill_sql_is_table_parametrized():
+    for table in VARIANT_TABLES:
+        sql = backfill_sql(table)
+        assert f"UPDATE {table} AS t" in sql
+        assert f"FROM {table}" in sql


### PR DESCRIPTION
## Summary
- Stacked on C1.1b (#4447). Replaces the C1a ORDER BY interim with an explicit `is_default` flag stored in `variant.flags` (JSONB) plus a partial unique index that doubles as the lookup index and the at-most-one-default-per-artifact constraint.
- Migrations (OSS + EE chained as `c1b0d2a3e4f5`, off `c11b3a4d5e6f`) backfill the flag on the earliest-created variant per `(project_id, artifact_id)` across the four git-pattern variant tables: workflow, query, testset, environment.
- `GitDAO.fetch_variant` filters by `(flags->>'is_default')::boolean IS TRUE` when no `variant_ref` is provided. Falls back to the C1a ORDER BY when no flagged row exists, so artifacts the backfill missed still get a deterministic answer.
- `GitDAO.create_variant` marks the first variant under an artifact as default, so newly created artifacts never enter the fallback branch.

## Known gaps (followup)
- No `set_default_variant(artifact_id, variant_id)` service method or endpoint yet. The partial unique index prevents two-defaults under concurrent writes but the user-facing switch is not exposed.
- `archive_variant` has no guard against archiving the current default. Archiving the default leaves the artifact with zero flagged rows; `fetch_variant` then falls back to the ORDER BY pick. Reads still resolve deterministically, but the artifact has no explicit default until manually re-flagged.

## Test plan
- [x] `ruff format` + `ruff check` clean on touched files
- [x] Unit tests: `api/oss/tests/pytest/unit/migrations/test_is_default_variants_backfill.py` (6 tests)
- [x] Existing consistency + sufficiency suites still pass (79 tests on this tip)
- [ ] Acceptance run against `hosting/docker-compose/ee/.env.ee.dev`

Refs: `docs/design/playground-open-from-trace/followups.md` C1b / D2

🤖 Generated with [Claude Code](https://claude.com/claude-code)