### PR TITLE
[fix] Resolve retrieve-related issue 14: C1.1b denormalize parent slugs

### DIFF
--- a/api/ee/databases/postgres/migrations/core/versions/c11b3a4d5e6f_denormalize_parent_slugs.py
+++ b/api/ee/databases/postgres/migrations/core/versions/c11b3a4d5e6f_denormalize_parent_slugs.py
@@ -1,0 +1,53 @@
+"""Denormalize parent slugs onto variant and revision rows
+
+Adds `artifact_slug` to variant tables and `artifact_slug` + `variant_slug`
+to revision tables across the four git-pattern entity sets (workflow,
+query, testset, environment), then backfills the new columns from the
+parent tables. Read paths use the denormalized values directly instead of
+join loads / secondary IN queries.
+
+Revision ID: c11b3a4d5e6f
+Revises: b2c3d4e5f7a8
+Create Date: 2026-05-26 17:00:00.000000
+
+"""
+
+from typing import Sequence, Union
+
+from alembic import op
+import sqlalchemy as sa
+
+from oss.databases.postgres.migrations.core.data_migrations.denormalize_slugs import (
+    ENTITIES,
+    revision_backfill_sql,
+    variant_backfill_sql,
+)
+
+
+revision: str = "c11b3a4d5e6f"
+down_revision: Union[str, None] = "b2c3d4e5f7a8"
+branch_labels: Union[str, Sequence[str], None] = None
+depends_on: Union[str, Sequence[str], None] = None
+
+
+def upgrade() -> None:
+    conn = op.get_bind()
+
+    for artifacts, variants, revisions in ENTITIES:
+        op.add_column(variants, sa.Column("artifact_slug", sa.String(), nullable=True))
+        op.add_column(revisions, sa.Column("artifact_slug", sa.String(), nullable=True))
+        op.add_column(revisions, sa.Column("variant_slug", sa.String(), nullable=True))
+
+        conn.execute(
+            sa.text(variant_backfill_sql(variants=variants, artifacts=artifacts))
+        )
+        conn.execute(
+            sa.text(revision_backfill_sql(revisions=revisions, variants=variants))
+        )
+
+
+def downgrade() -> None:
+    for _artifacts, variants, revisions in ENTITIES:
+        op.drop_column(revisions, "variant_slug")
+        op.drop_column(revisions, "artifact_slug")
+        op.drop_column(variants, "artifact_slug")

--- a/api/oss/databases/postgres/migrations/core/data_migrations/denormalize_slugs.py
+++ b/api/oss/databases/postgres/migrations/core/data_migrations/denormalize_slugs.py
@@ -1,0 +1,44 @@
+"""Helpers for the C1.1b parent-slug denormalization backfill.
+
+Lifted into its own module so the migration-level SQL can be unit-tested
+without importing `alembic`. C1.1b denormalizes `artifact_slug` onto
+variant rows and `artifact_slug` + `variant_slug` onto revision rows
+across the four git-pattern entity tables so read paths can skip the
+join load.
+"""
+
+from typing import Tuple
+
+
+ENTITIES: Tuple[Tuple[str, str, str], ...] = (
+    ("workflow_artifacts", "workflow_variants", "workflow_revisions"),
+    ("query_artifacts", "query_variants", "query_revisions"),
+    ("testset_artifacts", "testset_variants", "testset_revisions"),
+    ("environment_artifacts", "environment_variants", "environment_revisions"),
+)
+
+
+def variant_backfill_sql(*, variants: str, artifacts: str) -> str:
+    return f"""
+        UPDATE {variants} AS v
+        SET artifact_slug = a.slug
+        FROM {artifacts} AS a
+        WHERE v.project_id = a.project_id
+          AND v.artifact_id = a.id
+          AND v.artifact_slug IS DISTINCT FROM a.slug
+    """
+
+
+def revision_backfill_sql(*, revisions: str, variants: str) -> str:
+    return f"""
+        UPDATE {revisions} AS r
+        SET artifact_slug = v.artifact_slug,
+            variant_slug = v.slug
+        FROM {variants} AS v
+        WHERE r.project_id = v.project_id
+          AND r.variant_id = v.id
+          AND (
+              r.artifact_slug IS DISTINCT FROM v.artifact_slug
+              OR r.variant_slug IS DISTINCT FROM v.slug
+          )
+    """

--- a/api/oss/databases/postgres/migrations/core/versions/c11b3a4d5e6f_denormalize_parent_slugs.py
+++ b/api/oss/databases/postgres/migrations/core/versions/c11b3a4d5e6f_denormalize_parent_slugs.py
@@ -1,0 +1,53 @@
+"""Denormalize parent slugs onto variant and revision rows
+
+Adds `artifact_slug` to variant tables and `artifact_slug` + `variant_slug`
+to revision tables across the four git-pattern entity sets (workflow,
+query, testset, environment), then backfills the new columns from the
+parent tables. Read paths use the denormalized values directly instead of
+join loads / secondary IN queries.
+
+Revision ID: c11b3a4d5e6f
+Revises: e6f7a8b9c0d1
+Create Date: 2026-05-26 17:00:00.000000
+
+"""
+
+from typing import Sequence, Union
+
+from alembic import op
+import sqlalchemy as sa
+
+from oss.databases.postgres.migrations.core.data_migrations.denormalize_slugs import (
+    ENTITIES,
+    revision_backfill_sql,
+    variant_backfill_sql,
+)
+
+
+revision: str = "c11b3a4d5e6f"
+down_revision: Union[str, None] = "e6f7a8b9c0d1"
+branch_labels: Union[str, Sequence[str], None] = None
+depends_on: Union[str, Sequence[str], None] = None
+
+
+def upgrade() -> None:
+    conn = op.get_bind()
+
+    for artifacts, variants, revisions in ENTITIES:
+        op.add_column(variants, sa.Column("artifact_slug", sa.String(), nullable=True))
+        op.add_column(revisions, sa.Column("artifact_slug", sa.String(), nullable=True))
+        op.add_column(revisions, sa.Column("variant_slug", sa.String(), nullable=True))
+
+        conn.execute(
+            sa.text(variant_backfill_sql(variants=variants, artifacts=artifacts))
+        )
+        conn.execute(
+            sa.text(revision_backfill_sql(revisions=revisions, variants=variants))
+        )
+
+
+def downgrade() -> None:
+    for _artifacts, variants, revisions in ENTITIES:
+        op.drop_column(revisions, "variant_slug")
+        op.drop_column(revisions, "artifact_slug")
+        op.drop_column(variants, "artifact_slug")

--- a/api/oss/src/dbs/postgres/git/dao.py
+++ b/api/oss/src/dbs/postgres/git/dao.py
@@ -453,6 +453,16 @@ class GitDAO(GitDAOInterface):
 
         try:
             async with engine.core_session() as session:
+                artifact_row = await session.execute(
+                    select(self.ArtifactDBE.slug)  # type: ignore
+                    .filter(self.ArtifactDBE.project_id == project_id)  # type: ignore
+                    .filter(self.ArtifactDBE.id == variant_create.artifact_id)  # type: ignore
+                    .limit(1)
+                )
+                artifact_slug = artifact_row.scalar_one_or_none()
+                if artifact_slug is not None:
+                    variant_dbe.artifact_slug = artifact_slug
+
                 session.add(variant_dbe)
 
                 await session.commit()
@@ -489,14 +499,8 @@ class GitDAO(GitDAOInterface):
         applied_identifying_filter = False
 
         async with engine.core_session() as session:
-            stmt = (
-                select(self.VariantDBE)
-                .options(
-                    selectinload(self.VariantDBE.artifact),  # type: ignore
-                )
-                .filter(
-                    self.VariantDBE.project_id == project_id,  # type: ignore
-                )
+            stmt = select(self.VariantDBE).filter(
+                self.VariantDBE.project_id == project_id,  # type: ignore
             )
 
             pick_default_variant = False
@@ -547,10 +551,6 @@ class GitDAO(GitDAOInterface):
             variant = map_dbe_to_dto(
                 DTO=Variant,
                 dbe=variant_dbe,  # type: ignore
-            )
-
-            variant.artifact_slug = (
-                variant_dbe.artifact.slug if variant_dbe.artifact else None
             )
 
             return variant
@@ -1030,6 +1030,20 @@ class GitDAO(GitDAOInterface):
 
         try:
             async with engine.core_session() as session:
+                variant_row = await session.execute(
+                    select(
+                        self.VariantDBE.slug,  # type: ignore
+                        self.VariantDBE.artifact_slug,  # type: ignore
+                    )
+                    .filter(self.VariantDBE.project_id == project_id)  # type: ignore
+                    .filter(self.VariantDBE.id == revision_create.variant_id)  # type: ignore
+                    .limit(1)
+                )
+                variant_row_first = variant_row.first()
+                if variant_row_first is not None:
+                    revision_dbe.variant_slug = variant_row_first[0]
+                    revision_dbe.artifact_slug = variant_row_first[1]
+
                 session.add(revision_dbe)
 
                 await session.commit()

--- a/api/oss/src/dbs/postgres/git/dbas.py
+++ b/api/oss/src/dbs/postgres/git/dbas.py
@@ -1,4 +1,4 @@
-from sqlalchemy import Column, UUID
+from sqlalchemy import Column, String, UUID
 
 from oss.src.dbs.postgres.shared.dbas import (
     IdentifierDBA,
@@ -44,6 +44,11 @@ class VariantDBA(
         nullable=False,
     )
 
+    artifact_slug = Column(
+        String,
+        nullable=True,
+    )
+
 
 class RevisionDBA(
     IdentifierDBA,
@@ -64,7 +69,17 @@ class RevisionDBA(
         nullable=False,
     )
 
+    artifact_slug = Column(
+        String,
+        nullable=True,
+    )
+
     variant_id = Column(
         UUID(as_uuid=True),
         nullable=False,
+    )
+
+    variant_slug = Column(
+        String,
+        nullable=True,
     )

--- a/api/oss/tests/pytest/unit/migrations/test_denormalize_slugs.py
+++ b/api/oss/tests/pytest/unit/migrations/test_denormalize_slugs.py
@@ -1,0 +1,74 @@
+"""Unit tests for the C1.1b parent-slug denormalization migration."""
+
+from oss.databases.postgres.migrations.core.data_migrations.denormalize_slugs import (
+    ENTITIES,
+    revision_backfill_sql,
+    variant_backfill_sql,
+)
+
+
+def test_covers_four_entity_sets():
+    assert ENTITIES == (
+        ("workflow_artifacts", "workflow_variants", "workflow_revisions"),
+        ("query_artifacts", "query_variants", "query_revisions"),
+        ("testset_artifacts", "testset_variants", "testset_revisions"),
+        (
+            "environment_artifacts",
+            "environment_variants",
+            "environment_revisions",
+        ),
+    )
+
+
+def test_variant_backfill_joins_on_project_id_and_artifact_id():
+    sql = variant_backfill_sql(
+        variants="workflow_variants",
+        artifacts="workflow_artifacts",
+    )
+
+    assert "UPDATE workflow_variants AS v" in sql
+    assert "FROM workflow_artifacts AS a" in sql
+    assert "v.project_id = a.project_id" in sql
+    assert "v.artifact_id = a.id" in sql
+
+
+def test_variant_backfill_is_idempotent():
+    sql = variant_backfill_sql(
+        variants="workflow_variants",
+        artifacts="workflow_artifacts",
+    )
+
+    assert "v.artifact_slug IS DISTINCT FROM a.slug" in sql
+
+
+def test_revision_backfill_copies_both_slugs_from_variant():
+    sql = revision_backfill_sql(
+        revisions="workflow_revisions",
+        variants="workflow_variants",
+    )
+
+    assert "SET artifact_slug = v.artifact_slug" in sql
+    assert "variant_slug = v.slug" in sql
+    assert "r.project_id = v.project_id" in sql
+    assert "r.variant_id = v.id" in sql
+
+
+def test_revision_backfill_is_idempotent():
+    sql = revision_backfill_sql(
+        revisions="workflow_revisions",
+        variants="workflow_variants",
+    )
+
+    assert "r.artifact_slug IS DISTINCT FROM v.artifact_slug" in sql
+    assert "r.variant_slug IS DISTINCT FROM v.slug" in sql
+
+
+def test_backfill_sql_is_table_parametrized():
+    for artifacts, variants, revisions in ENTITIES:
+        v_sql = variant_backfill_sql(variants=variants, artifacts=artifacts)
+        assert f"UPDATE {variants} AS v" in v_sql
+        assert f"FROM {artifacts} AS a" in v_sql
+
+        r_sql = revision_backfill_sql(revisions=revisions, variants=variants)
+        assert f"UPDATE {revisions} AS r" in r_sql
+        assert f"FROM {variants} AS v" in r_sql


### PR DESCRIPTION
## Summary
- Reordered: C1.1b now lands first (off C9), C1b stacks on top.
- Adds nullable `artifact_slug` to `VariantDBA` and nullable `artifact_slug` + `variant_slug` to `RevisionDBA` so the existing DTO fields are backed by physical columns instead of join loads / secondary IN queries.
- Migration `c11b3a4d5e6f` (OSS + EE) adds the columns and backfills them from parent rows across the four git-pattern entity sets (workflow, query, testset, environment).
- `GitDAO.create_variant` reads `ArtifactDBE.slug` and stamps `artifact_slug`. `GitDAO.create_revision` reads `VariantDBE.slug` and `VariantDBE.artifact_slug` and stamps both. New rows therefore do not depend on the backfill.
- `GitDAO.fetch_variant` drops `selectinload(artifact)` and the manual `variant.artifact_slug = ...` reassignment since `map_dbe_to_dto` now sources the value from the column. Other read paths (multi-fetch, fork, revision fetches) keep their explicit join + reassignment as a defensive tie-breaker until a follow-up cleanup; behavior is unchanged.

## Test plan
- [x] `ruff format` + `ruff check` clean
- [x] Unit tests: `api/oss/tests/pytest/unit/migrations/test_denormalize_slugs.py` (6 tests covering four-entity coverage, join shape, idempotency under reruns, both-column copy, table parametrization)
- [x] Existing consistency + sufficiency suites still pass (73 tests on this tip)
- [ ] Acceptance run against `hosting/docker-compose/ee/.env.ee.dev`

Refs: `docs/design/playground-open-from-trace/followups.md` C1.1b

(Previous PR #4446 was auto-closed by GitHub when the base swap of the stacked PR caused all commits to be reachable from the prior base; this is the replacement.)

🤖 Generated with [Claude Code](https://claude.com/claude-code)