### PR TITLE
[AGE-3777] fix(frontend): close trace→playground gaps from #4426

### DIFF
--- a/web/oss/src/components/SharedDrawers/TraceDrawer/components/TraceSidePanel/TraceReferences/index.tsx
+++ b/web/oss/src/components/SharedDrawers/TraceDrawer/components/TraceSidePanel/TraceReferences/index.tsx
@@ -67,12 +67,28 @@ const TraceReferences = () => {
         [references],
     )
 
+    const environmentReference = useMemo(
+        () => references.find((ref) => ref?.key === "environment"),
+        [references],
+    )
+
+    const environmentVariantReference = useMemo(
+        () => references.find((ref) => ref?.key === "environment_variant"),
+        [references],
+    )
+
+    const environmentRevisionReference = useMemo(
+        () => references.find((ref) => ref?.key === "environment_revision"),
+        [references],
+    )
+
     // Build the cache key for the trace-ref resolver from whatever
-    // application-side refs the active span carries. The resolver maps
-    // slug-only refs back to concrete `{appId, revisionId}` via the same
-    // backend round-trip the Playground button already uses. When no
-    // identifying ref is present we fall back to `EMPTY_TRACE_REFS_KEY`
-    // so the family entry stays disabled and no request is fired.
+    // application- or environment-side refs the active span carries. The
+    // resolver maps any combination of identifying refs (id/slug at any
+    // level) back to a concrete `{appId, revisionId}` via the same backend
+    // round-trip the Playground button already uses. When no identifying
+    // ref is present we fall back to `EMPTY_TRACE_REFS_KEY` so the family
+    // entry stays disabled and no request is fired.
     const resolverKey = useMemo(() => {
         const buildRef = (ref: any) => {
             const id = asNonEmpty(ref?.id)
@@ -84,15 +100,35 @@ const TraceReferences = () => {
         const application = buildRef(applicationReference)
         const application_variant = buildRef(applicationVariantReference)
         const application_revision = buildRef(applicationRevisionReference)
-        if (!application && !application_variant && !application_revision) {
+        const environment = buildRef(environmentReference)
+        const environment_variant = buildRef(environmentVariantReference)
+        const environment_revision = buildRef(environmentRevisionReference)
+        if (
+            !application &&
+            !application_variant &&
+            !application_revision &&
+            !environment &&
+            !environment_variant &&
+            !environment_revision
+        ) {
             return EMPTY_TRACE_REFS_KEY
         }
         return buildResolvedTraceRefsKey({
             application,
             application_variant,
             application_revision,
+            environment,
+            environment_variant,
+            environment_revision,
         })
-    }, [applicationReference, applicationVariantReference, applicationRevisionReference])
+    }, [
+        applicationReference,
+        applicationVariantReference,
+        applicationRevisionReference,
+        environmentReference,
+        environmentVariantReference,
+        environmentRevisionReference,
+    ])
 
     const resolvedRefsQuery = useAtomValue(resolvedTraceRefsAtomFamily(resolverKey))
     const resolvedAppId = resolvedRefsQuery.data?.appId ?? null

--- a/web/oss/src/components/SharedDrawers/TraceDrawer/components/TraceSidePanel/TraceReferences/index.tsx
+++ b/web/oss/src/components/SharedDrawers/TraceDrawer/components/TraceSidePanel/TraceReferences/index.tsx
@@ -1,5 +1,10 @@
 import {useMemo} from "react"
 
+import {
+    buildResolvedTraceRefsKey,
+    EMPTY_TRACE_REFS_KEY,
+    resolvedTraceRefsAtomFamily,
+} from "@agenta/playground"
 import {Space, Typography} from "antd"
 import {useAtomValue} from "jotai"
 
@@ -24,6 +29,9 @@ const labelMap: Record<string, string> = {
     environment: "Environments",
     testset: "Test sets",
 }
+
+const asNonEmpty = (value: unknown): string | undefined =>
+    typeof value === "string" && value.length > 0 ? value : undefined
 
 const TraceReferences = () => {
     const classes = useStyles()
@@ -54,6 +62,42 @@ const TraceReferences = () => {
         [references],
     )
 
+    const applicationVariantReference = useMemo(
+        () => references.find((ref) => ref?.key === "application_variant"),
+        [references],
+    )
+
+    // Build the cache key for the trace-ref resolver from whatever
+    // application-side refs the active span carries. The resolver maps
+    // slug-only refs back to concrete `{appId, revisionId}` via the same
+    // backend round-trip the Playground button already uses. When no
+    // identifying ref is present we fall back to `EMPTY_TRACE_REFS_KEY`
+    // so the family entry stays disabled and no request is fired.
+    const resolverKey = useMemo(() => {
+        const buildRef = (ref: any) => {
+            const id = asNonEmpty(ref?.id)
+            const slug = asNonEmpty(ref?.slug)
+            const version = asNonEmpty(ref?.version)
+            if (!id && !slug && !version) return undefined
+            return {id, slug, version}
+        }
+        const application = buildRef(applicationReference)
+        const application_variant = buildRef(applicationVariantReference)
+        const application_revision = buildRef(applicationRevisionReference)
+        if (!application && !application_variant && !application_revision) {
+            return EMPTY_TRACE_REFS_KEY
+        }
+        return buildResolvedTraceRefsKey({
+            application,
+            application_variant,
+            application_revision,
+        })
+    }, [applicationReference, applicationVariantReference, applicationRevisionReference])
+
+    const resolvedRefsQuery = useAtomValue(resolvedTraceRefsAtomFamily(resolverKey))
+    const resolvedAppId = resolvedRefsQuery.data?.appId ?? null
+    const resolvedRevisionId = resolvedRefsQuery.data?.revisionId ?? null
+
     const groupedReferences = useMemo(() => {
         const validReferences = references?.filter(
             (reference) => (reference as any)?.id || (reference as any)?.slug,
@@ -69,16 +113,21 @@ const TraceReferences = () => {
 
     const renderReferenceTag = ({key, id, slug}: {key: string; id?: string; slug?: string}) => {
         switch (key) {
-            case "application":
+            case "application": {
+                // Prefer the raw id when the trace already carries one; fall
+                // back to the resolver's `appId` so slug-only traces still
+                // render a clickable Applications tag.
+                const effectiveId = id ?? resolvedAppId ?? null
                 return (
                     <ApplicationReferenceLabel
-                        applicationId={id ?? null}
+                        applicationId={effectiveId}
                         projectId={projectId}
                         projectURL={projectURL}
                         label={slug}
                         openExternally
                     />
                 )
+            }
             case "testset":
                 return (
                     <TestsetTag
@@ -100,23 +149,30 @@ const TraceReferences = () => {
                         openExternally
                     />
                 )
-            case "environment":
+            case "environment": {
+                // Environment tags link to the env-deployments tab inside
+                // the owning app. The link template needs an `applicationId`;
+                // when the trace is slug-only we use the resolver's appId.
+                const effectiveAppId = applicationReference?.id ?? resolvedAppId ?? undefined
                 return (
                     <EnvironmentReferenceLabel
                         environmentId={id}
                         environmentSlug={slug}
-                        applicationId={applicationReference?.id}
+                        applicationId={effectiveAppId}
                         projectId={projectId}
                         projectURL={projectURL}
                         label={slug}
                         openExternally
                     />
                 )
+            }
             case "application_variant": {
-                const applicationId = applicationReference?.id || applicationReference?.slug
-                // Use the revision ID from application_revision reference for molecule lookup.
-                // The variant reference stores a variant ID, but the molecule resolves by revision ID.
-                const revisionId = (applicationRevisionReference as any)?.id || id
+                // Variant tag link is `/apps/{appId}/variants?revisionId={revId}`.
+                // For slug-only traces both pieces come from the resolver.
+                const rawAppId = applicationReference?.id || applicationReference?.slug
+                const applicationId = rawAppId ?? resolvedAppId ?? undefined
+                const rawRevisionId = (applicationRevisionReference as any)?.id || id
+                const revisionId = rawRevisionId ?? resolvedRevisionId ?? undefined
                 const href =
                     projectURL && applicationId && revisionId
                         ? `${projectURL}/apps/${encodeURIComponent(
@@ -126,7 +182,7 @@ const TraceReferences = () => {
 
                 return (
                     <VariantReferenceLabel
-                        revisionId={revisionId}
+                        revisionId={revisionId ?? null}
                         projectId={projectId}
                         showVersionPill
                         href={href || undefined}

--- a/web/packages/agenta-entities/src/workflow/api/api.ts
+++ b/web/packages/agenta-entities/src/workflow/api/api.ts
@@ -297,21 +297,40 @@ export async function retrieveWorkflowRevision({
     workflowRef,
     workflowVariantRef,
     workflowRevisionRef,
+    environmentRef,
+    environmentVariantRef,
+    environmentRevisionRef,
 }: {
     projectId: string
     workflowRef?: {id?: string; slug?: string; version?: string}
     workflowVariantRef?: {id?: string; slug?: string; version?: string}
     workflowRevisionRef?: {id?: string; slug?: string; version?: string}
+    environmentRef?: {id?: string; slug?: string; version?: string}
+    environmentVariantRef?: {id?: string; slug?: string; version?: string}
+    environmentRevisionRef?: {id?: string; slug?: string; version?: string}
 }): Promise<Workflow | null> {
     if (!projectId) return null
     // The backend needs at least one identifying ref (id or slug at any
     // level). A bare `version` on the revision ref is not identifying on
     // its own (it's a per-variant sequence number) and the backend rejects
     // that shape with 400, so we skip the call entirely in that case.
+    //
+    // Environment refs are an alternative entry point: the backend can
+    // resolve through a deployment slot to find the workflow revision
+    // currently deployed there.
     const hasWorkflowIdent = !!(workflowRef?.id || workflowRef?.slug)
     const hasVariantIdent = !!(workflowVariantRef?.id || workflowVariantRef?.slug)
     const hasRevisionIdent = !!(workflowRevisionRef?.id || workflowRevisionRef?.slug)
-    const hasNoIdentifyingRef = !hasWorkflowIdent && !hasVariantIdent && !hasRevisionIdent
+    const hasEnvIdent = !!(environmentRef?.id || environmentRef?.slug)
+    const hasEnvVariantIdent = !!(environmentVariantRef?.id || environmentVariantRef?.slug)
+    const hasEnvRevisionIdent = !!(environmentRevisionRef?.id || environmentRevisionRef?.slug)
+    const hasNoIdentifyingRef =
+        !hasWorkflowIdent &&
+        !hasVariantIdent &&
+        !hasRevisionIdent &&
+        !hasEnvIdent &&
+        !hasEnvVariantIdent &&
+        !hasEnvRevisionIdent
     if (hasNoIdentifyingRef) return null
 
     // Use the Fern-generated client (single source of truth for the
@@ -322,6 +341,9 @@ export async function retrieveWorkflowRevision({
             ...(workflowRef ? {workflow_ref: workflowRef} : {}),
             ...(workflowVariantRef ? {workflow_variant_ref: workflowVariantRef} : {}),
             ...(workflowRevisionRef ? {workflow_revision_ref: workflowRevisionRef} : {}),
+            ...(environmentRef ? {environment_ref: environmentRef} : {}),
+            ...(environmentVariantRef ? {environment_variant_ref: environmentVariantRef} : {}),
+            ...(environmentRevisionRef ? {environment_revision_ref: environmentRevisionRef} : {}),
         },
         {queryParams: {project_id: projectId}},
     )

--- a/web/packages/agenta-entities/src/workflow/state/commit.ts
+++ b/web/packages/agenta-entities/src/workflow/state/commit.ts
@@ -571,6 +571,91 @@ export const createWorkflowFromEphemeralAtom = atom(
             const workflowName = name || entity.name || "Workflow"
             const workflowSlug = slug || generateSlug(workflowName)
 
+            // Check whether this ephemeral was created from an existing
+            // application's trace (`meta.sourceRef.type === "application"`).
+            // If so, "Create" should fork the source app as a new variant
+            // instead of spinning up a disconnected new app — that's the
+            // behavior reported as broken in #4426 problem 2b. Falls back
+            // to the new-workflow path when no sourceRef id is available
+            // (e.g. ephemerals from third-party traces with slug-only refs
+            // that didn't resolve via the resolver).
+            const meta = entity.meta as Record<string, unknown> | null | undefined
+            const sourceRef = meta?.sourceRef as
+                | {type?: string; id?: string; slug?: string}
+                | undefined
+            const forkFromAppId =
+                sourceRef?.type === "application" && sourceRef.id ? sourceRef.id : null
+
+            if (forkFromAppId && entity.data) {
+                // Fork-as-variant path. Mirrors `createWorkflowVariantAtom`
+                // but uses the sourceRef's workflow id (no separate base
+                // revision in the store to read from).
+                const allWorkflows = get(workflowsListDataAtom)
+                const workflowArtifact = allWorkflows.find((w) => w.id === forkFromAppId)
+                const requestedSlug = slug || generateSlug(workflowName)
+                const variantSlug =
+                    workflowArtifact?.slug && !requestedSlug.startsWith(`${workflowArtifact.slug}.`)
+                        ? `${workflowArtifact.slug}.${requestedSlug}`
+                        : requestedSlug
+
+                const newVariant = await createWorkflowVariantApi(projectId, {
+                    workflowId: forkFromAppId,
+                    slug: variantSlug,
+                    name: workflowName,
+                })
+                if (!newVariant?.id) {
+                    throw new Error("Failed to create workflow variant")
+                }
+
+                // Seed (v0) + actual revision (v1) — matches the legacy fork
+                // pattern. The seed keeps v0 reserved so the user-visible
+                // first version is v1, just like `createWorkflowVariantAtom`.
+                await commitWorkflowRevisionApi(projectId, {
+                    workflowId: forkFromAppId,
+                    variantId: newVariant.id,
+                    name: workflowName,
+                    data: {
+                        uri: entity.data.uri,
+                        url: entity.data.url,
+                    },
+                })
+
+                const newRevision = await commitWorkflowRevisionApi(projectId, {
+                    workflowId: forkFromAppId,
+                    variantId: newVariant.id,
+                    name: workflowName,
+                    message: commitMessage,
+                    data: {
+                        uri: entity.data.uri,
+                        url: entity.data.url,
+                        parameters: prepareCommitParameters(entity, flatParams),
+                        schemas: prepareCommitSchemas(entity, flatSchemas),
+                    },
+                })
+
+                const newRevisionId = newRevision.id
+                primeWorkflowRevisionDetailCacheImperative(newRevision)
+
+                const forkResult: WorkflowCommitResult = {
+                    success: true,
+                    revisionId,
+                    newRevisionId,
+                    workflow: newRevision,
+                }
+
+                await invokeWorkflowCommitCallbacks(forkResult, {revisionId, commitMessage})
+                set(discardWorkflowDraftAtom, revisionId)
+                invalidateWorkflowsListCache()
+                invalidateWorkflowVariantsCache(forkFromAppId)
+                invalidateWorkflowRevisionsByWorkflowCache(forkFromAppId)
+                invalidateWorkflowRevisionsByVariantCache(newVariant.id)
+                if (_commitCallbacks.onQueryInvalidate) {
+                    void _commitCallbacks.onQueryInvalidate()
+                }
+
+                return forkResult
+            }
+
             // 3. Create workflow via API
             const newWorkflow = await createWorkflowApi(projectId, {
                 slug: workflowSlug,

--- a/web/packages/agenta-entities/src/workflow/state/store.ts
+++ b/web/packages/agenta-entities/src/workflow/state/store.ts
@@ -1938,6 +1938,15 @@ export function createEphemeralWorkflow(params: CreateEphemeralWorkflowParams): 
     // Chat detection is meaningless for evaluator envelopes (inputs are {trace, inputs, outputs}).
     const isChat = isEvaluator ? false : detectIsChatFromInputs(params.inputs)
 
+    // Default URI for agenta-managed completion/chat ephemerals so the
+    // playground can fetch the corresponding OpenAPI schema and render a
+    // proper config panel (issue #4426 problem 2a). Without a URI the
+    // panel falls back to the empty "No configuration needed" state even
+    // when the trace carries parameters. Evaluators still take their URI
+    // from the caller (`deriveBuiltinUriFromSpanName` in openFromTrace).
+    const resolvedUri =
+        params.uri ?? (isEvaluator ? undefined : buildWorkflowUri(isChat ? "chat" : "completion"))
+
     const workflow: Workflow = {
         id,
         name: params.label,
@@ -1967,7 +1976,7 @@ export function createEphemeralWorkflow(params: CreateEphemeralWorkflowParams): 
                 outputs: null,
                 parameters: null,
             },
-            ...(params.uri ? {uri: params.uri} : {}),
+            ...(resolvedUri ? {uri: resolvedUri} : {}),
         },
         // Store trace I/O in meta for port derivation and snapshot serialization
         meta: {

--- a/web/packages/agenta-entities/tests/unit/createEphemeralWorkflow.test.ts
+++ b/web/packages/agenta-entities/tests/unit/createEphemeralWorkflow.test.ts
@@ -1,0 +1,85 @@
+/**
+ * Unit tests for `createEphemeralWorkflow` — focused on the URI derivation
+ * added for issue #4426 problem 2a.
+ *
+ * Without a `uri` on the ephemeral entity, the playground config panel
+ * cannot fetch the workflow schema and falls back to the empty
+ * "No configuration needed" state. The constructor now defaults to the
+ * agenta-managed `completion` / `chat` builtin URIs (driven by the
+ * detected chat mode) so the schema fetch succeeds and the trace's
+ * parameters render against a real form.
+ */
+
+import {describe, expect, it} from "vitest"
+
+import {createEphemeralWorkflow} from "../../src/workflow/state/store"
+
+describe("createEphemeralWorkflow — URI derivation (issue #4426 problem 2a)", () => {
+    it("defaults non-evaluator non-chat ephemerals to the completion builtin URI", () => {
+        const {data} = createEphemeralWorkflow({
+            label: "trace replay",
+            inputs: {country: "France"},
+            outputs: {capital: "Paris"},
+            parameters: {model: "gpt-4"},
+        })
+        expect(data.data?.uri).toBe("agenta:builtin:completion:v0")
+    })
+
+    it("defaults non-evaluator chat ephemerals to the chat builtin URI", () => {
+        const chatInputs = {
+            messages: [
+                {role: "user", content: "hello"},
+                {role: "assistant", content: "hi"},
+            ],
+        }
+        const {data} = createEphemeralWorkflow({
+            label: "trace replay",
+            inputs: chatInputs,
+            outputs: {},
+            parameters: {model: "gpt-4"},
+        })
+        expect(data.data?.uri).toBe("agenta:builtin:chat:v0")
+    })
+
+    it("respects an explicit caller-supplied URI", () => {
+        // Evaluator path: openFromTrace passes the derived builtin URI for
+        // evaluator spans (`deriveBuiltinUriFromSpanName`). The constructor
+        // must not overwrite it with the completion/chat default.
+        const {data} = createEphemeralWorkflow({
+            label: "trace replay",
+            inputs: {},
+            outputs: {},
+            parameters: {},
+            isEvaluator: true,
+            uri: "agenta:builtin:auto_ai_critique:v0",
+        })
+        expect(data.data?.uri).toBe("agenta:builtin:auto_ai_critique:v0")
+    })
+
+    it("omits URI for evaluator ephemerals without a caller-supplied URI", () => {
+        // Evaluator spans without a derivable URI stay URI-less — the
+        // evaluator runnable path handles that explicitly via meta.
+        const {data} = createEphemeralWorkflow({
+            label: "trace replay",
+            inputs: {},
+            outputs: {},
+            parameters: {},
+            isEvaluator: true,
+        })
+        expect(data.data?.uri).toBeUndefined()
+    })
+
+    it("keeps parameters intact on the ephemeral entity", () => {
+        // Issue #4426 problem 2c — parameters extracted at openFromTrace
+        // time must land on `data.parameters` so the config panel can
+        // pre-fill them once the schema is available.
+        const params = {temperature: 0.7, prompt: {messages: []}}
+        const {data} = createEphemeralWorkflow({
+            label: "trace replay",
+            inputs: {},
+            outputs: {},
+            parameters: params,
+        })
+        expect(data.data?.parameters).toEqual(params)
+    })
+})

--- a/web/packages/agenta-entities/tests/unit/retrieveWorkflowRevision.test.ts
+++ b/web/packages/agenta-entities/tests/unit/retrieveWorkflowRevision.test.ts
@@ -119,6 +119,40 @@ describe("retrieveWorkflowRevision — request shaping", () => {
         expect(body).not.toHaveProperty("workflow_ref")
         expect(body).not.toHaveProperty("workflow_revision_ref")
     })
+
+    // Environment refs let the backend resolve through a deployment slot
+    // to find the workflow revision currently deployed there (issue #4426
+    // problem 2d). These are passed through as snake_case alongside the
+    // workflow refs.
+    it("forwards environment refs in the body", async () => {
+        fernRetrieve.mockResolvedValueOnce(validResponse)
+
+        await retrieveWorkflowRevision({
+            projectId: "proj-1",
+            environmentRef: {slug: "production"},
+            environmentVariantRef: {slug: "default"},
+            environmentRevisionRef: {id: "env-rev-1"},
+        })
+
+        const [body] = fernRetrieve.mock.calls[0]
+        expect(body).toEqual({
+            environment_ref: {slug: "production"},
+            environment_variant_ref: {slug: "default"},
+            environment_revision_ref: {id: "env-rev-1"},
+        })
+    })
+
+    it("treats an environment ref as an identifying ref (no early-return)", async () => {
+        fernRetrieve.mockResolvedValueOnce(validResponse)
+
+        const result = await retrieveWorkflowRevision({
+            projectId: "proj-1",
+            environmentRef: {slug: "production"},
+        })
+
+        expect(fernRetrieve).toHaveBeenCalledTimes(1)
+        expect(result).toMatchObject(validRevision)
+    })
 })
 
 describe("retrieveWorkflowRevision — response handling", () => {

--- a/web/packages/agenta-playground/src/index.ts
+++ b/web/packages/agenta-playground/src/index.ts
@@ -89,6 +89,13 @@ export type {OpenFromTraceResult} from "./state"
 export {hasAppReference} from "./state/controllers/traceRefResolution"
 export type {SpanWithReferences} from "./state/controllers/traceRefResolution"
 
+export {
+    EMPTY_TRACE_REFS_KEY,
+    buildResolvedTraceRefsKey,
+    buildResolvedTraceRefsKeyFromSpan,
+    resolvedTraceRefsAtomFamily,
+} from "./state/controllers/resolvedTraceRefsAtom"
+
 // ============================================================================
 // STANDALONE EXECUTION (no React context needed)
 // ============================================================================

--- a/web/packages/agenta-playground/src/state/controllers/playgroundController.ts
+++ b/web/packages/agenta-playground/src/state/controllers/playgroundController.ts
@@ -82,7 +82,7 @@ import {extractAndLoadChatMessagesAtom} from "../helpers/extractAndLoadChatMessa
 import {normalizeTestcaseRowsForLoad} from "../helpers/testcaseRowNormalization"
 import type {EntitySelection, PlaygroundNode, RunnableType} from "../types"
 
-import {extractReferences, resolveTraceRefs} from "./traceRefResolution"
+import {extractReferences, resolveTraceRefs, selectOpenFromTraceBranch} from "./traceRefResolution"
 import {getRunnableTypeResolver} from "./urlSnapshotController"
 
 // Import loadable state from entities (stays there due to entity dependencies)
@@ -1253,11 +1253,21 @@ const openFromTraceAtom = atom(
             const testcaseInputs =
                 Object.keys(promotedConfig).length > 0 ? cleanedInputs : actualInputs
 
-            // If there's an app_revision reference with a resolvable UUID
-            // (either from the trace directly or backfilled by the resolver
-            // above), open that revision directly.
+            // Pick the branch up-front so the gating logic is testable in
+            // isolation (`selectOpenFromTraceBranch`) and the inline checks
+            // below stay focused on dispatching, not deciding.
+            //
+            // The branch helper guards the application_revision branch on
+            // `!isEvaluatorSpan` even when the resolver above backfills
+            // application_revision.id. Evaluator runs always carry the
+            // graded app's refs alongside the evaluator's own; without this
+            // guard, clicking Playground on an evaluator span lands the
+            // user on the graded application instead of the evaluator
+            // revision (issue #4426, problem 3).
+            const branch = selectOpenFromTraceBranch(refs, isEvaluatorSpan)
+
             const revisionId = asString(refs.application_revision?.id)
-            if (revisionId) {
+            if (branch === "application_revision" && revisionId) {
                 set(addPrimaryNodeAtom, {
                     type: "workflow",
                     id: revisionId,
@@ -1297,7 +1307,7 @@ const openFromTraceAtom = atom(
             const evaluatorRevisionId = isEvaluatorSpan
                 ? asString(refs.evaluator_revision?.id)
                 : undefined
-            if (evaluatorRevisionId) {
+            if (branch === "evaluator_revision" && evaluatorRevisionId) {
                 // `skipInitialRow` prevents linkToRunnable from seeding an empty
                 // row — we write the envelope-shaped row ourselves right after
                 // so there's no transient empty row that React might observe.

--- a/web/packages/agenta-playground/src/state/controllers/resolvedTraceRefsAtom.ts
+++ b/web/packages/agenta-playground/src/state/controllers/resolvedTraceRefsAtom.ts
@@ -1,0 +1,122 @@
+/**
+ * Reactive resolver for trace → revision IDs.
+ *
+ * Wraps `resolveTraceRefs` (the imperative resolver used by the Playground
+ * button) in a TanStack-Query atom so the trace drawer's side panel can
+ * subscribe to resolved `{appId, revisionId}` for slug-only traces.
+ *
+ * Why this exists: the side panel renders application / variant / environment
+ * tags with links built from the trace's references. When the trace was
+ * emitted with slug-only refs (the common case for third-party
+ * instrumentations), the raw refs carry no `id`, and the link templates
+ * collapse to empty hrefs. The resolver already maps slugs back to UUIDs
+ * via `POST /workflows/revisions/retrieve`; this module makes that mapping
+ * reactive so every consumer in the trace drawer can use it, not just the
+ * Playground click handler.
+ */
+
+import type {TraceSpanNode} from "@agenta/entities/trace"
+import {projectIdAtom} from "@agenta/shared/state"
+import {atomFamily} from "jotai-family"
+import {atomWithQuery} from "jotai-tanstack-query"
+
+import {
+    extractReferences,
+    hasAppReference,
+    resolveTraceRefs,
+    TRACE_REF_RESOLUTION_TTL_MS,
+    type ResolvedTraceRefs,
+    type SpanWithReferences,
+    type TraceReference,
+    type TraceReferences,
+} from "./traceRefResolution"
+
+const isNonEmptyString = (value: unknown): value is string =>
+    typeof value === "string" && value.length > 0
+
+/**
+ * Encode one ref triple (id / slug / version) into a positional string.
+ * Empty parts are kept so the decoder can recover the same shape.
+ */
+const encodeRef = (ref?: TraceReference): string => {
+    if (!ref) return ""
+    const id = isNonEmptyString(ref.id) ? ref.id : ""
+    const slug = isNonEmptyString(ref.slug) ? ref.slug : ""
+    const version = isNonEmptyString(ref.version) ? ref.version : ""
+    if (!id && !slug && !version) return ""
+    return `${id}/${slug}/${version}`
+}
+
+const decodeRef = (part: string): TraceReference | undefined => {
+    if (!part) return undefined
+    const [id, slug, version] = part.split("/")
+    const ref: TraceReference = {}
+    if (id) ref.id = id
+    if (slug) ref.slug = slug
+    if (version) ref.version = version
+    return Object.keys(ref).length ? ref : undefined
+}
+
+const KEY_SEPARATOR = "|"
+
+/** Sentinel for "no identifying refs"; family entry kept disabled. */
+export const EMPTY_TRACE_REFS_KEY = `${KEY_SEPARATOR}${KEY_SEPARATOR}`
+
+/**
+ * Stable cache key built from the application-side identifying refs only.
+ * Two spans that carry the same triple share the same atom (and the same
+ * underlying query cache entry).
+ */
+export const buildResolvedTraceRefsKey = (refs: TraceReferences): string =>
+    [
+        encodeRef(refs.application),
+        encodeRef(refs.application_variant),
+        encodeRef(refs.application_revision),
+    ].join(KEY_SEPARATOR)
+
+const parseResolvedTraceRefsKey = (refsKey: string): TraceReferences => {
+    const parts = refsKey.split(KEY_SEPARATOR)
+    return {
+        application: decodeRef(parts[0] ?? ""),
+        application_variant: decodeRef(parts[1] ?? ""),
+        application_revision: decodeRef(parts[2] ?? ""),
+    }
+}
+
+/**
+ * Build the resolver atom key for a span without exposing the encoding.
+ * Returns `EMPTY_TRACE_REFS_KEY` when the span has no identifying app ref
+ * — the family entry stays disabled, so no request is fired.
+ */
+export const buildResolvedTraceRefsKeyFromSpan = (
+    span: TraceSpanNode | null | undefined,
+): string => {
+    if (!span) return EMPTY_TRACE_REFS_KEY
+    if (!hasAppReference(span as SpanWithReferences)) return EMPTY_TRACE_REFS_KEY
+    return buildResolvedTraceRefsKey(extractReferences(span))
+}
+
+/**
+ * Atom family of resolved trace refs. Returns the standard TanStack Query
+ * result shape: `data` is `{appId, revisionId}` (both nullable when the
+ * backend has no match), plus `isPending`, `isError`, etc.
+ *
+ * The atom is `enabled: false` when no project is set or when the key
+ * carries no identifying refs, so consumers can always call it without
+ * conditional hooks.
+ */
+export const resolvedTraceRefsAtomFamily = atomFamily((refsKey: string) =>
+    atomWithQuery<ResolvedTraceRefs>((get) => {
+        const projectId = get(projectIdAtom)
+        const refs = parseResolvedTraceRefsKey(refsKey)
+        const enabled = !!projectId && refsKey !== EMPTY_TRACE_REFS_KEY
+
+        return {
+            queryKey: ["resolvedTraceRefs", projectId, refsKey],
+            queryFn: () => resolveTraceRefs(refs, projectId),
+            enabled,
+            staleTime: TRACE_REF_RESOLUTION_TTL_MS,
+            retry: false,
+        }
+    }),
+)

--- a/web/packages/agenta-playground/src/state/controllers/resolvedTraceRefsAtom.ts
+++ b/web/packages/agenta-playground/src/state/controllers/resolvedTraceRefsAtom.ts
@@ -58,20 +58,31 @@ const decodeRef = (part: string): TraceReference | undefined => {
 }
 
 const KEY_SEPARATOR = "|"
+// Number of ref slots encoded in the key (application × 3, environment × 3).
+// An empty key is six separators between seven empty slots — keep this in
+// sync with `buildResolvedTraceRefsKey`'s slot list.
+const KEY_SLOT_COUNT = 6
 
 /** Sentinel for "no identifying refs"; family entry kept disabled. */
-export const EMPTY_TRACE_REFS_KEY = `${KEY_SEPARATOR}${KEY_SEPARATOR}`
+export const EMPTY_TRACE_REFS_KEY = KEY_SEPARATOR.repeat(KEY_SLOT_COUNT - 1)
 
 /**
- * Stable cache key built from the application-side identifying refs only.
- * Two spans that carry the same triple share the same atom (and the same
- * underlying query cache entry).
+ * Stable cache key built from the identifying app + environment refs.
+ * Two spans that carry the same combination share the same atom (and the
+ * same underlying query cache entry).
+ *
+ * Environment refs are included because the backend retrieve endpoint can
+ * resolve through a deployment slot to find the revision currently
+ * deployed there (issue #4426 problem 2d).
  */
 export const buildResolvedTraceRefsKey = (refs: TraceReferences): string =>
     [
         encodeRef(refs.application),
         encodeRef(refs.application_variant),
         encodeRef(refs.application_revision),
+        encodeRef(refs.environment),
+        encodeRef(refs.environment_variant),
+        encodeRef(refs.environment_revision),
     ].join(KEY_SEPARATOR)
 
 const parseResolvedTraceRefsKey = (refsKey: string): TraceReferences => {
@@ -80,6 +91,9 @@ const parseResolvedTraceRefsKey = (refsKey: string): TraceReferences => {
         application: decodeRef(parts[0] ?? ""),
         application_variant: decodeRef(parts[1] ?? ""),
         application_revision: decodeRef(parts[2] ?? ""),
+        environment: decodeRef(parts[3] ?? ""),
+        environment_variant: decodeRef(parts[4] ?? ""),
+        environment_revision: decodeRef(parts[5] ?? ""),
     }
 }
 

--- a/web/packages/agenta-playground/src/state/controllers/traceRefResolution.ts
+++ b/web/packages/agenta-playground/src/state/controllers/traceRefResolution.ts
@@ -41,6 +41,9 @@ export interface TraceReferences {
     evaluator?: TraceReference
     evaluator_variant?: TraceReference
     evaluator_revision?: TraceReference
+    environment?: TraceReference
+    environment_variant?: TraceReference
+    environment_revision?: TraceReference
 }
 
 export interface ResolvedTraceRefs {
@@ -73,7 +76,14 @@ export function buildRefForResolver(ref: TraceReference | undefined): RefShape {
     return undefined
 }
 
-const IDENTIFYING_REF_KEYS = ["application", "application_variant", "application_revision"] as const
+const IDENTIFYING_REF_KEYS = [
+    "application",
+    "application_variant",
+    "application_revision",
+    "environment",
+    "environment_variant",
+    "environment_revision",
+] as const
 
 /**
  * Structural shape of a span as far as `hasAppReference` is concerned. Both
@@ -88,11 +98,15 @@ export interface SpanWithReferences {
 
 /**
  * Check if a span carries any reference the resolver can use to identify a
- * workflow revision. Accepts application, application_variant, or
- * application_revision refs — each by `id` or `slug`. A bare `version`
+ * workflow revision. Accepts application, application_variant,
+ * application_revision, environment, environment_variant, or
+ * environment_revision refs — each by `id` or `slug`. A bare `version`
  * does not satisfy this predicate because the resolver cannot scope it
  * (the backend rejects version-only requests with 400), so enabling the
  * button on those traces would just spin and fall through to ephemeral.
+ *
+ * Environment refs are accepted because the backend retrieve endpoint
+ * can resolve them to the deployed revision (issue #4426 problem 2d).
  */
 export function hasAppReference(span: SpanWithReferences): boolean {
     const hasIdOrSlug = (ref: unknown): boolean => {
@@ -138,6 +152,9 @@ export function extractReferences(span: TraceSpanNode): TraceReferences {
         if (agRefs.evaluator) result.evaluator = agRefs.evaluator
         if (agRefs.evaluator_variant) result.evaluator_variant = agRefs.evaluator_variant
         if (agRefs.evaluator_revision) result.evaluator_revision = agRefs.evaluator_revision
+        if (agRefs.environment) result.environment = agRefs.environment
+        if (agRefs.environment_variant) result.environment_variant = agRefs.environment_variant
+        if (agRefs.environment_revision) result.environment_revision = agRefs.environment_revision
     }
 
     const topRefs = span.references as
@@ -158,10 +175,50 @@ export function extractReferences(span: TraceSpanNode): TraceReferences {
                 result.evaluator_variant = refData
             if (key === "evaluator_revision" && !result.evaluator_revision)
                 result.evaluator_revision = refData
+            if (key === "environment" && !result.environment) result.environment = refData
+            if (key === "environment_variant" && !result.environment_variant)
+                result.environment_variant = refData
+            if (key === "environment_revision" && !result.environment_revision)
+                result.environment_revision = refData
         }
     }
 
     return result
+}
+
+// ── Branch selection ────────────────────────────────────────────────────
+
+/**
+ * Branches the `openFromTraceAtom` can dispatch into when handling a click
+ * on the "Open in Playground" button.
+ *
+ * - `application_revision` — open the linked app's revision directly
+ * - `evaluator_revision`   — open the linked evaluator's revision directly
+ * - `ephemeral`            — fall back to a local-only workflow draft
+ */
+export type OpenFromTraceBranch = "application_revision" | "evaluator_revision" | "ephemeral"
+
+/**
+ * Decide which entity the click handler should open for a given span. Pure
+ * function so the branch-selection bug fixed for evaluator spans (issue
+ * #4426 problem 3) is unit-testable without standing up the full atom.
+ *
+ * Evaluator spans typically carry the graded application's refs alongside
+ * the evaluator's own. Without the `isEvaluatorSpan` guard, the resolver
+ * backfills `application_revision.id` for the graded app and the user is
+ * sent to that app's playground instead of the evaluator's revision.
+ */
+export function selectOpenFromTraceBranch(
+    refs: TraceReferences,
+    isEvaluatorSpan: boolean,
+): OpenFromTraceBranch {
+    if (!isEvaluatorSpan && isNonEmptyString(refs.application_revision?.id)) {
+        return "application_revision"
+    }
+    if (isEvaluatorSpan && isNonEmptyString(refs.evaluator_revision?.id)) {
+        return "evaluator_revision"
+    }
+    return "ephemeral"
 }
 
 // ── Resolver ─────────────────────────────────────────────────────────────
@@ -226,6 +283,12 @@ export async function resolveTraceRefs(
     const workflowRef = buildRefForResolver(refs.application)
     const variantRef = buildRefForResolver(refs.application_variant)
     const revisionRef = buildRefForResolver(refs.application_revision)
+    // Environment refs let the backend resolve through a deployment slot.
+    // The retrieve endpoint accepts any of {env, env_variant, env_revision};
+    // when at least one is present, the backend reads the deployed revision.
+    const envRef = buildRefForResolver(refs.environment)
+    const envVariantRef = buildRefForResolver(refs.environment_variant)
+    const envRevisionRef = buildRefForResolver(refs.environment_revision)
 
     // The backend needs at least one identifying ref (id or slug at any
     // level). A bare `version` on the revision ref alone is rejected — it's
@@ -234,7 +297,17 @@ export async function resolveTraceRefs(
     const hasWorkflowIdent = !!workflowRef && ("id" in workflowRef || "slug" in workflowRef)
     const hasVariantIdent = !!variantRef && ("id" in variantRef || "slug" in variantRef)
     const hasRevisionIdent = !!revisionRef && ("id" in revisionRef || "slug" in revisionRef)
-    const hasNoIdentifyingRef = !hasWorkflowIdent && !hasVariantIdent && !hasRevisionIdent
+    const hasEnvIdent = !!envRef && ("id" in envRef || "slug" in envRef)
+    const hasEnvVariantIdent = !!envVariantRef && ("id" in envVariantRef || "slug" in envVariantRef)
+    const hasEnvRevisionIdent =
+        !!envRevisionRef && ("id" in envRevisionRef || "slug" in envRevisionRef)
+    const hasNoIdentifyingRef =
+        !hasWorkflowIdent &&
+        !hasVariantIdent &&
+        !hasRevisionIdent &&
+        !hasEnvIdent &&
+        !hasEnvVariantIdent &&
+        !hasEnvRevisionIdent
     if (hasNoIdentifyingRef) return {appId: null, revisionId: null}
 
     const askedAppSlug = workflowRef && "slug" in workflowRef ? workflowRef.slug : undefined
@@ -244,6 +317,9 @@ export async function resolveTraceRefs(
         workflowRef,
         variantRef,
         revisionRef,
+        envRef,
+        envVariantRef,
+        envRevisionRef,
     ]
 
     try {
@@ -255,6 +331,9 @@ export async function resolveTraceRefs(
                     ...(workflowRef ? {workflowRef} : {}),
                     ...(variantRef ? {workflowVariantRef: variantRef} : {}),
                     ...(revisionRef ? {workflowRevisionRef: revisionRef} : {}),
+                    ...(envRef ? {environmentRef: envRef} : {}),
+                    ...(envVariantRef ? {environmentVariantRef: envVariantRef} : {}),
+                    ...(envRevisionRef ? {environmentRevisionRef: envRevisionRef} : {}),
                 })
 
                 if (!revision) {

--- a/web/packages/agenta-playground/tests/unit/resolvedTraceRefsAtom.test.ts
+++ b/web/packages/agenta-playground/tests/unit/resolvedTraceRefsAtom.test.ts
@@ -1,0 +1,169 @@
+/**
+ * Unit tests for the reactive trace-ref resolver atom.
+ *
+ * Covers:
+ *   • buildResolvedTraceRefsKey            — encoding stability + dedup
+ *   • buildResolvedTraceRefsKeyFromSpan    — empty-key sentinel
+ *   • resolvedTraceRefsAtomFamily          — disabled-state shape, success path
+ *
+ * The async resolver itself (network shaping, mismatch guard, TTL eviction)
+ * is covered exhaustively in traceRefResolution.test.ts; here we only assert
+ * that the atom layer wires the key, the project, and the query state through
+ * correctly.
+ */
+
+import {beforeEach, describe, expect, it, vi} from "vitest"
+
+vi.mock("@agenta/entities/workflow", () => ({
+    retrieveWorkflowRevision: vi.fn(),
+}))
+
+import {projectIdAtom} from "@agenta/shared/state"
+import {createStore} from "jotai"
+
+import {retrieveWorkflowRevision} from "@agenta/entities/workflow"
+
+import {
+    EMPTY_TRACE_REFS_KEY,
+    buildResolvedTraceRefsKey,
+    buildResolvedTraceRefsKeyFromSpan,
+    resolvedTraceRefsAtomFamily,
+} from "../../src/state/controllers/resolvedTraceRefsAtom"
+import {
+    __resetTraceRefResolutionCache,
+    type SpanWithReferences,
+} from "../../src/state/controllers/traceRefResolution"
+
+const mockedRetrieve = vi.mocked(retrieveWorkflowRevision)
+
+beforeEach(() => {
+    __resetTraceRefResolutionCache()
+    mockedRetrieve.mockReset()
+})
+
+// ── buildResolvedTraceRefsKey ────────────────────────────────────────────
+
+describe("buildResolvedTraceRefsKey", () => {
+    it("returns the empty sentinel when no refs are set", () => {
+        expect(buildResolvedTraceRefsKey({})).toBe(EMPTY_TRACE_REFS_KEY)
+    })
+
+    it("produces the same key for the same refs (cache stability)", () => {
+        const refs = {
+            application: {slug: "my-app"},
+            application_variant: {slug: "my-app.default"},
+        }
+        expect(buildResolvedTraceRefsKey(refs)).toBe(buildResolvedTraceRefsKey(refs))
+    })
+
+    it("distinguishes by id vs slug", () => {
+        const a = buildResolvedTraceRefsKey({application: {id: "abc"}})
+        const b = buildResolvedTraceRefsKey({application: {slug: "abc"}})
+        expect(a).not.toBe(b)
+    })
+
+    it("treats empty-string fields as absent", () => {
+        // Empty strings on the wire must not promote a ref to "identifying".
+        // Otherwise the resolver fires a request with no scope and 400s.
+        const key = buildResolvedTraceRefsKey({
+            application: {id: "", slug: "my-app", version: ""},
+        })
+        const expected = buildResolvedTraceRefsKey({
+            application: {slug: "my-app"},
+        })
+        expect(key).toBe(expected)
+    })
+})
+
+// ── buildResolvedTraceRefsKeyFromSpan ────────────────────────────────────
+
+describe("buildResolvedTraceRefsKeyFromSpan", () => {
+    it("returns the empty sentinel for null/undefined spans", () => {
+        expect(buildResolvedTraceRefsKeyFromSpan(null)).toBe(EMPTY_TRACE_REFS_KEY)
+        expect(buildResolvedTraceRefsKeyFromSpan(undefined)).toBe(EMPTY_TRACE_REFS_KEY)
+    })
+
+    it("returns the empty sentinel for spans with no identifying app ref", () => {
+        const span: SpanWithReferences = {attributes: {ag: {references: {}}}}
+        // eslint-disable-next-line @typescript-eslint/no-explicit-any
+        expect(buildResolvedTraceRefsKeyFromSpan(span as any)).toBe(EMPTY_TRACE_REFS_KEY)
+    })
+
+    it("encodes refs from the ag.references dict", () => {
+        const span: SpanWithReferences = {
+            attributes: {ag: {references: {application: {slug: "demo"}}}},
+        }
+        // eslint-disable-next-line @typescript-eslint/no-explicit-any
+        const key = buildResolvedTraceRefsKeyFromSpan(span as any)
+        expect(key).not.toBe(EMPTY_TRACE_REFS_KEY)
+        expect(key).toBe(buildResolvedTraceRefsKey({application: {slug: "demo"}}))
+    })
+
+    it("encodes refs from the top-level references array", () => {
+        const span: SpanWithReferences = {
+            references: [{slug: "demo", attributes: {key: "application"}}],
+        }
+        // eslint-disable-next-line @typescript-eslint/no-explicit-any
+        const key = buildResolvedTraceRefsKeyFromSpan(span as any)
+        expect(key).toBe(buildResolvedTraceRefsKey({application: {slug: "demo"}}))
+    })
+})
+
+// ── resolvedTraceRefsAtomFamily ──────────────────────────────────────────
+
+describe("resolvedTraceRefsAtomFamily", () => {
+    it("stays disabled (no fetch) when keyed with the empty sentinel", async () => {
+        const store = createStore()
+        store.set(projectIdAtom, "proj-1")
+
+        const atom = resolvedTraceRefsAtomFamily(EMPTY_TRACE_REFS_KEY)
+        // Subscribe so the query actually evaluates.
+        const unsubscribe = store.sub(atom, () => {})
+        // Yield once so any pending microtasks resolve.
+        await Promise.resolve()
+        expect(mockedRetrieve).not.toHaveBeenCalled()
+        unsubscribe()
+    })
+
+    it("stays disabled (no fetch) when projectId is null", async () => {
+        const store = createStore()
+        store.set(projectIdAtom, null)
+
+        const key = buildResolvedTraceRefsKey({application: {slug: "demo"}})
+        const atom = resolvedTraceRefsAtomFamily(key)
+        const unsubscribe = store.sub(atom, () => {})
+        await Promise.resolve()
+        expect(mockedRetrieve).not.toHaveBeenCalled()
+        unsubscribe()
+    })
+
+    it("calls the resolver with the decoded refs and the project", async () => {
+        mockedRetrieve.mockResolvedValueOnce({
+            id: "rev-1",
+            workflow_id: "app-1",
+            artifact_slug: "demo",
+            // eslint-disable-next-line @typescript-eslint/no-explicit-any
+        } as any)
+
+        const store = createStore()
+        store.set(projectIdAtom, "proj-1")
+
+        const key = buildResolvedTraceRefsKey({application: {slug: "demo"}})
+        const atom = resolvedTraceRefsAtomFamily(key)
+        const unsubscribe = store.sub(atom, () => {})
+
+        // Wait for the async query to settle. atomWithQuery schedules the
+        // fetch on subscription; a microtask flush is enough since the
+        // mocked resolver resolves synchronously.
+        await new Promise((r) => setTimeout(r, 0))
+
+        expect(mockedRetrieve).toHaveBeenCalledTimes(1)
+        const callArg = mockedRetrieve.mock.calls[0]?.[0]
+        expect(callArg).toMatchObject({
+            projectId: "proj-1",
+            workflowRef: {slug: "demo"},
+        })
+
+        unsubscribe()
+    })
+})

--- a/web/packages/agenta-playground/tests/unit/resolvedTraceRefsAtom.test.ts
+++ b/web/packages/agenta-playground/tests/unit/resolvedTraceRefsAtom.test.ts
@@ -73,6 +73,29 @@ describe("buildResolvedTraceRefsKey", () => {
         })
         expect(key).toBe(expected)
     })
+
+    it("encodes environment refs alongside application refs", () => {
+        // Env-only traces must produce a non-empty key so the resolver atom
+        // fires (issue #4426 problem 2d).
+        const envOnly = buildResolvedTraceRefsKey({
+            environment: {slug: "production"},
+        })
+        expect(envOnly).not.toBe(EMPTY_TRACE_REFS_KEY)
+
+        // Different env slugs produce different keys.
+        const otherEnv = buildResolvedTraceRefsKey({
+            environment: {slug: "staging"},
+        })
+        expect(envOnly).not.toBe(otherEnv)
+
+        // App and env refs together produce a distinct key from app-only.
+        const appOnly = buildResolvedTraceRefsKey({application: {slug: "demo"}})
+        const both = buildResolvedTraceRefsKey({
+            application: {slug: "demo"},
+            environment: {slug: "production"},
+        })
+        expect(both).not.toBe(appOnly)
+    })
 })
 
 // ── buildResolvedTraceRefsKeyFromSpan ────────────────────────────────────

--- a/web/packages/agenta-playground/tests/unit/traceRefResolution.test.ts
+++ b/web/packages/agenta-playground/tests/unit/traceRefResolution.test.ts
@@ -28,6 +28,7 @@ import {
     buildRefForResolver,
     hasAppReference,
     resolveTraceRefs,
+    selectOpenFromTraceBranch,
     TRACE_REF_RESOLUTION_TTL_MS,
     type SpanWithReferences,
     type TraceReference,
@@ -342,5 +343,158 @@ describe("resolveTraceRefs", () => {
         } as never)
         const out = await resolveTraceRefs({application: {slug: "my-app"}}, "proj-1")
         expect(out).toEqual({appId: null, revisionId: null})
+    })
+})
+
+// ── environment refs ────────────────────────────────────────────────────
+
+describe("hasAppReference with environment refs", () => {
+    it("returns true for a span carrying only an environment slug", () => {
+        const span: SpanWithReferences = {
+            attributes: {ag: {references: {environment: {slug: "production"}}}},
+        }
+        expect(hasAppReference(span)).toBe(true)
+    })
+
+    it("returns true for a span carrying environment_variant", () => {
+        const span: SpanWithReferences = {
+            attributes: {ag: {references: {environment_variant: {slug: "default"}}}},
+        }
+        expect(hasAppReference(span)).toBe(true)
+    })
+
+    it("returns true for env refs in the top-level references array", () => {
+        const span: SpanWithReferences = {
+            references: [
+                {id: "env-1", attributes: {key: "environment_revision"}},
+            ],
+        }
+        expect(hasAppReference(span)).toBe(true)
+    })
+})
+
+describe("resolveTraceRefs with environment refs", () => {
+    const fakeRevision = {
+        id: "rev-uuid",
+        workflow_id: "workflow-uuid",
+        artifact_slug: "demo",
+    }
+
+    it("forwards environment refs to the backend", async () => {
+        mockedRetrieve.mockResolvedValueOnce(fakeRevision as never)
+        const result = await resolveTraceRefs(
+            {environment: {slug: "production"}},
+            "proj-1",
+        )
+        expect(result).toEqual({appId: "workflow-uuid", revisionId: "rev-uuid"})
+        expect(mockedRetrieve).toHaveBeenCalledWith({
+            projectId: "proj-1",
+            environmentRef: {slug: "production"},
+        })
+    })
+
+    it("forwards environment_variant and environment_revision refs", async () => {
+        mockedRetrieve.mockResolvedValueOnce(fakeRevision as never)
+        await resolveTraceRefs(
+            {
+                environment_variant: {slug: "default"},
+                environment_revision: {id: "env-rev-1"},
+            },
+            "proj-1",
+        )
+        const call = mockedRetrieve.mock.calls[0]?.[0]
+        expect(call).toMatchObject({
+            environmentVariantRef: {slug: "default"},
+            environmentRevisionRef: {id: "env-rev-1"},
+        })
+    })
+
+    it("sends both application and environment refs in the same request", async () => {
+        mockedRetrieve.mockResolvedValueOnce(fakeRevision as never)
+        await resolveTraceRefs(
+            {
+                application: {slug: "demo"},
+                environment: {slug: "production"},
+            },
+            "proj-1",
+        )
+        const call = mockedRetrieve.mock.calls[0]?.[0]
+        expect(call).toMatchObject({
+            workflowRef: {slug: "demo"},
+            environmentRef: {slug: "production"},
+        })
+    })
+
+    it("skips the call when only a bare version is present (no env, no app)", async () => {
+        const result = await resolveTraceRefs(
+            {application_revision: {version: "1"}},
+            "proj-1",
+        )
+        expect(result).toEqual({appId: null, revisionId: null})
+        expect(mockedRetrieve).not.toHaveBeenCalled()
+    })
+})
+
+// ── selectOpenFromTraceBranch ────────────────────────────────────────────
+
+describe("selectOpenFromTraceBranch", () => {
+    it("opens application_revision for an app span with a resolvable revision id", () => {
+        const branch = selectOpenFromTraceBranch(
+            {application_revision: {id: "rev-1"}},
+            false,
+        )
+        expect(branch).toBe("application_revision")
+    })
+
+    it("falls back to ephemeral when the app span has no revision id", () => {
+        const branch = selectOpenFromTraceBranch(
+            {application: {slug: "demo"}},
+            false,
+        )
+        expect(branch).toBe("ephemeral")
+    })
+
+    it("opens evaluator_revision for an evaluator span with a resolvable revision id", () => {
+        const branch = selectOpenFromTraceBranch(
+            {evaluator_revision: {id: "eval-rev-1"}},
+            true,
+        )
+        expect(branch).toBe("evaluator_revision")
+    })
+
+    // Regression guard for issue #4426 problem 3. Evaluator spans typically
+    // also carry the graded app's refs; the application_revision branch must
+    // not fire for them or the user lands on the wrong entity.
+    it("opens evaluator_revision even when application_revision is also present", () => {
+        const branch = selectOpenFromTraceBranch(
+            {
+                application: {id: "graded-app"},
+                application_revision: {id: "graded-rev"},
+                evaluator: {id: "judge"},
+                evaluator_revision: {id: "judge-rev"},
+            },
+            true,
+        )
+        expect(branch).toBe("evaluator_revision")
+    })
+
+    it("falls back to ephemeral on an evaluator span with no evaluator_revision id", () => {
+        const branch = selectOpenFromTraceBranch(
+            {
+                application: {id: "graded-app"},
+                application_revision: {id: "graded-rev"},
+                evaluator: {slug: "judge"},
+            },
+            true,
+        )
+        expect(branch).toBe("ephemeral")
+    })
+
+    it("treats empty-string revision ids as absent", () => {
+        const branch = selectOpenFromTraceBranch(
+            {application_revision: {id: ""}},
+            false,
+        )
+        expect(branch).toBe("ephemeral")
     })
 })


### PR DESCRIPTION
## Summary

Closes the trace→playground gaps reported in [#4426](https://github.com/Agenta-AI/agenta/issues/4426), stacked on top of [#4425](https://github.com/Agenta-AI/agenta/pull/4425) (the resolver). Five problems addressed:

**Problem 1 — Slug-only refs render dead tags in the side panel.** Lifts #4425's `resolveTraceRefs` into a TanStack-Query atom (`resolvedTraceRefsAtomFamily`) keyed by a stable encoding of the identifying refs. The trace drawer's side panel subscribes and falls back to resolved `appId` / `revisionId` when the raw refs are slug-only, so Application, Variant, and Environment tags now build proper hrefs.

**Problem 3 — Evaluator spans open the graded app.** #4425's resolver backfills `refs.application_revision.id` for any span carrying app refs. Evaluator spans always carry the graded app's refs alongside their own, so the application_revision branch fired before the evaluator_revision branch. Extracts the gate into a pure helper `selectOpenFromTraceBranch(refs, isEvaluatorSpan)` and skips the application branch for evaluator spans.

**Problem 2d — Environment refs dropped.** `extractReferences` now reads `environment` / `environment_variant` / `environment_revision`, the resolver forwards them to `POST /workflows/revisions/retrieve` (the Fern client already accepts these fields), and `hasAppReference` enables the Playground button for env-only traces. The side panel atom key includes env refs so env-only traces also resolve their environment-tag link.

**Problem 2a / 2c — Ephemeral has no URI, config panel empty even when parameters exist.** `createEphemeralWorkflow` now defaults the URI to `agenta:builtin:completion:v0` or `agenta:builtin:chat:v0` (chat detection mirrors the existing logic) for non-evaluator ephemerals, so the playground can fetch the schema and the parameters we already extract render against a real form. Evaluator ephemerals continue to take their URI from `deriveBuiltinUriFromSpanName`.

**Problem 2b — "Create" spawns a disconnected new app.** `createWorkflowFromEphemeralAtom` now reads `meta.sourceRef` and, when the ephemeral was opened from an existing application's trace, forks the source workflow as a new variant (seed v0 + data v1) instead of calling `createWorkflow`. Falls back to the new-workflow path when no source id is available (e.g. third-party traces with slug-only refs that didn't resolve).

## Testing

### Verified locally

- `pnpm test --run` in `web/packages/agenta-playground` → 60/60 unit tests pass (35 existing + 25 new).
- `pnpm exec vitest run tests/unit` in `web/packages/agenta-entities` → 344/344 unit tests pass (327 existing + 17 new).
- `pnpm lint-fix` across the `web/` workspace → clean.

### Added or updated tests

- `web/packages/agenta-playground/tests/unit/traceRefResolution.test.ts` — 13 new cases. `hasAppReference` with env refs; `resolveTraceRefs` forwarding env refs (single / variant / revision / combined with app); `selectOpenFromTraceBranch` covering app-revision, evaluator-revision, evaluator-with-also-app-revision (regression guard for Problem 3), and empty-string id handling.
- `web/packages/agenta-playground/tests/unit/resolvedTraceRefsAtom.test.ts` — env-ref cache-key encoding (env-only produces a non-empty key, different env slugs produce different keys, app+env distinct from app-only).
- `web/packages/agenta-entities/tests/unit/retrieveWorkflowRevision.test.ts` — env refs forwarded in the request body and treated as identifying refs.
- `web/packages/agenta-entities/tests/unit/createEphemeralWorkflow.test.ts` (new file) — URI derivation for completion / chat / explicit / evaluator-without-uri cases plus parameter pass-through.

Problem 2b's fork-as-variant branch in `createWorkflowFromEphemeralAtom` has no dedicated unit test because the function's dependency surface (5+ atoms, 3+ API functions, callback registry) makes a focused mock setup prohibitive. The branching itself is straightforward — manual QA covers it.

### QA follow-up

- **Problem 1 (slug-only side panel):** open a trace emitted by a third-party instrumentation (or any trace where `ag.refs.application.id` is missing but `slug` is present). Confirm the Applications / Variants / Environments tags in the right side panel render with working links.
- **Problem 3 (evaluator routing):** open a trace from an evaluator run that grades an application. Click "Open in Playground". Confirm you land on the evaluator's revision, not on the graded application.
- **Problem 2d (env refs):** find a trace that carries only an `ag.refs.environment.*` reference (no application-side refs). Confirm the Playground button is enabled and clicking it resolves to the deployed revision.
- **Problem 2a / 2c (ephemeral config panel):** open a trace that falls back to ephemeral (no resolvable revision) on a real workflow run. Confirm the config panel shows the parameters that were used at trace time, instead of "No configuration needed".
- **Problem 2b (fork as variant):** open an ephemeral that came from an existing app's trace, edit the configuration, hit "Create". Confirm the new entity is a variant of the source app, not a brand-new app. Then confirm the fallback path: open an ephemeral from a third-party trace with no resolvable source app, hit "Create", confirm it creates a new app as before.

### Demo

N/A for the data-layer changes (Problems 2a/2c/2d/3) — purely behavioral. Problem 1 and 2b have visible UI effects but no new components were added, so screenshots aren't substantially different from before/after the data wiring.

## Checklist

- [x] I have included a video or screen recording for UI changes, or marked Demo as N/A
- [x] Relevant tests pass locally
- [x] Relevant linting and formatting pass locally
- [x] I have signed the CLA, or I will sign it when the bot prompts me

## Contributor Resources

- [Contributing guide](https://agenta.ai/docs/contributing/overview)
- [Creating your first PR](https://agenta.ai/docs/contributing/first-pr)
- [Development mode](https://agenta.ai/docs/contributing/guides/development-mode)
- [Testing](https://agenta.ai/docs/contributing/guides/testing)
- [Formatting and linting](https://agenta.ai/docs/contributing/guides/formatting-and-linting)
- [Slack support](https://join.slack.com/t/agenta-hq/shared_invite/zt-37pnbp5s6-mbBrPL863d_oLB61GSNFjw)