### PR TITLE
[fix] Resolve Auth preflight and OTP state flakiness

### DIFF
--- a/web/oss/src/pages/auth/[[...path]].tsx
+++ b/web/oss/src/pages/auth/[[...path]].tsx
@@ -407,6 +407,12 @@ const Auth = () => {
     }, [emailSubmitted])
 
     useEffect(() => {
+        if (!emailSubmitted && isLoginCodeVisible) {
+            setIsLoginCodeVisible(false)
+        }
+    }, [emailSubmitted, isLoginCodeVisible])
+
+    useEffect(() => {
         if (!socialAvailable && !emailSubmitted) {
             setShowEmailForm(true)
         }

--- a/web/oss/src/services/project/index.ts
+++ b/web/oss/src/services/project/index.ts
@@ -1,5 +1,5 @@
 import axios from "@/oss/lib/api/assets/axiosConfig"
-import {fetchJson, getBaseUrl} from "@/oss/lib/api/assets/fetchClient"
+import {fetchJson, getAuthToken, getBaseUrl} from "@/oss/lib/api/assets/fetchClient"
 import {getAgentaApiUrl} from "@/oss/lib/helpers/api"
 
 import {ProjectsResponse} from "./types"
@@ -12,6 +12,9 @@ import {ProjectsResponse} from "./types"
 //  - delete: DELETE data from server
 
 export const fetchAllProjects = async (): Promise<ProjectsResponse[]> => {
+    const token = await getAuthToken()
+    if (!token) return []
+
     const base = getBaseUrl()
     const url = new URL("api/projects", base)
 
@@ -19,6 +22,7 @@ export const fetchAllProjects = async (): Promise<ProjectsResponse[]> => {
         const data = await fetchJson(url)
         return Array.isArray(data) ? data : []
     } catch (error) {
+        if ((error as any)?.status === 401) return []
         console.error("Failed to fetch projects", error)
         return []
     }

--- a/web/oss/src/state/project/selectors/project.ts
+++ b/web/oss/src/state/project/selectors/project.ts
@@ -11,6 +11,7 @@ import {appIdentifiersAtom, appStateSnapshotAtom, requestNavigationAtom} from "@
 import {selectedOrgAtom, selectedOrgIdAtom} from "@/oss/state/org/selectors/org"
 import {profileQueryAtom} from "@/oss/state/profile"
 import {sessionExistsAtom} from "@/oss/state/session"
+import {jwtReadyAtom} from "@/oss/state/session/jwt"
 
 // Re-export the shared projectIdAtom so all OSS code uses the same atom as entity packages
 export {projectIdAtom}
@@ -95,6 +96,7 @@ export const clearLastUsedProjectId = (workspaceId: string | null) => {
 export const projectsQueryAtom = atomWithQuery<ProjectsResponse[]>((get) => {
     const workspaceId = get(selectedOrgIdAtom)
     const snapshot = get(appStateSnapshotAtom)
+    const jwtReady = Boolean((get(jwtReadyAtom) as any)?.data)
     const isAcceptRoute = snapshot.pathname.startsWith("/workspaces/accept")
     return {
         queryKey: ["projects", workspaceId || ""],
@@ -106,6 +108,7 @@ export const projectsQueryAtom = atomWithQuery<ProjectsResponse[]>((get) => {
         refetchOnMount: false,
         enabled:
             get(sessionExistsAtom) &&
+            jwtReady &&
             !!(get(profileQueryAtom)?.data as User)?.id &&
             !isAcceptRoute &&
             !!workspaceId,

--- a/web/oss/src/state/session/jwt.ts
+++ b/web/oss/src/state/session/jwt.ts
@@ -4,23 +4,28 @@ import {getJWT} from "@/oss/services/api"
 
 import {sessionExistsAtom} from "./atoms"
 
+const wait = (ms: number) => new Promise((resolve) => setTimeout(resolve, ms))
+
 /**
  * jwtReadyAtom becomes `true` once a non-empty JWT is available in SuperTokens storage.
- * We poll it once on mount; the value is cached as it has an infinite staleTime.
- * Whenever the session starts (sessionExistsAtom true) but JWT is still empty,
- * the query function runs again and resolves when the token appears.
+ * On reload, SuperTokens can report that a session exists before the access
+ * token is readable, so this query waits briefly instead of caching `false`.
  */
 export const jwtReadyAtom = atomWithQuery<boolean>((get) => ({
     queryKey: ["jwt-ready"],
     queryFn: async () => {
-        const token = await getJWT()
+        for (let attempt = 0; attempt < 20; attempt += 1) {
+            const token = await getJWT()
+            if (token) return true
 
-        // In test environment, consider JWT ready if test JWT is available
-        if (!token && typeof process !== "undefined" && process.env.NODE_ENV === "test") {
-            return !!(process.env.VITEST_TEST_JWT || process.env.TEST_JWT)
+            if (typeof process !== "undefined" && process.env.NODE_ENV === "test") {
+                return !!(process.env.VITEST_TEST_JWT || process.env.TEST_JWT)
+            }
+
+            await wait(100)
         }
 
-        return !!token
+        return false
     },
     enabled:
         get(sessionExistsAtom) ||


### PR DESCRIPTION
## What changed
This fixes two auth-side issues: protected project queries now wait for a usable token, and the auth page resets an invalid OTP-visible state that could hide the email form.

It also adds a defensive `fetchAllProjects()` guard so project fetches return early when no token is available yet.

## Why
On reload, the app could issue protected requests before SuperTokens had made an access token available, leading to unauthenticated `/api/projects` calls. Separately, the auth page could land in a state where OTP UI visibility hid the email entry form before an email had actually been submitted.

## Impact
Protected project queries should no longer fire prematurely during auth refresh, and the auth page should no longer show a blank area under the social login divider.

## Validation
- pre-commit hooks
- prettier
- turbo lint
- gitleaks
- manual validation of auth reload and auth page rendering in local dev