### PR TITLE
[FE Fix] hide string-type evaluator metrics from scenario table & filters

### DIFF
--- a/web/oss/src/components/EvalRunDetails/Table.tsx
+++ b/web/oss/src/components/EvalRunDetails/Table.tsx
@@ -149,7 +149,7 @@ const EvalRunDetailsTable = ({
         })
     }, [active, comparePaginations, compareSlots])
 
-    const etlColumns = useEtlColumns({projectId, runId, schema: runSchema})
+    const etlColumns = useEtlColumns({projectId, runId, schema: runSchema, columnResult})
 
     // Page-level hydrate — predicate-aware: with an active filter it
     // fetches the entity slices the filter needs to be evaluated; with no

--- a/web/oss/src/components/EvalRunDetails/Table.tsx
+++ b/web/oss/src/components/EvalRunDetails/Table.tsx
@@ -149,7 +149,7 @@ const EvalRunDetailsTable = ({
         })
     }, [active, comparePaginations, compareSlots])
 
-    const etlColumns = useEtlColumns({projectId, runId, schema: runSchema, columnResult})
+    const etlColumns = useEtlColumns({projectId, runId, schema: runSchema})
 
     // Page-level hydrate — predicate-aware: with an active filter it
     // fetches the entity slices the filter needs to be evaluated; with no

--- a/web/oss/src/components/EvalRunDetails/etl/EtlColumnHeader.tsx
+++ b/web/oss/src/components/EvalRunDetails/etl/EtlColumnHeader.tsx
@@ -3,13 +3,16 @@
  *
  * Renders the nested-header label for a column group. The default
  * `computeColumnGroup` resolver falls back to `Testset <slug>` /
- * `Application <slug>` because it doesn't fetch the entity itself.
+ * `Application <slug>` / `slugToTitle(evaluatorSlug)` because it can't
+ * fetch the entity itself.
  *
  * This header is that override — same pattern production's
  * `StepGroupHeader` uses: subscribe to the entity reference atom by ID
  * and surface the entity's name when available, fall back to the slug
- * otherwise. Evaluator + metrics + other groups already carry
- * `slugToTitle`-rendered labels, so no entity lookup is needed.
+ * otherwise. Applies to testset, application AND evaluator groups so
+ * the table header text never reads as a raw slug (e.g.
+ * "with-reasoning-jifn" / "With Reasoning Jifn") when a real evaluator
+ * name (e.g. "With Reasoning") is known.
  */
 
 import {useMemo} from "react"
@@ -22,11 +25,20 @@ import {
     applicationReferenceQueryAtomFamily,
     testsetReferenceQueryAtomFamily,
 } from "../atoms/references"
+import {evaluationEvaluatorsByRunQueryAtomFamily} from "../atoms/table/evaluators"
 
 const emptyAtom = atom<{data: {name?: string; slug?: string} | null} | null>(null)
+const emptyEvaluatorsAtom = atom({data: [], isPending: false, isFetching: false, isError: false})
 
 interface EtlColumnHeaderProps {
     group: ColumnGroup
+    /**
+     * Run id used to look up the run's evaluator definitions. When the
+     * group is an evaluator the header reads `name` off the matching
+     * definition (matched by id, then slug) instead of the slug-derived
+     * fallback label.
+     */
+    runId: string | null
 }
 
 const pickName = (entity: unknown): string | null => {
@@ -35,7 +47,7 @@ const pickName = (entity: unknown): string | null => {
     return typeof name === "string" && name.length > 0 ? name : null
 }
 
-const EtlColumnHeader = ({group}: EtlColumnHeaderProps) => {
+const EtlColumnHeader = ({group, runId}: EtlColumnHeaderProps) => {
     const refAtom = useMemo(() => {
         if (group.kind === "testset") {
             const id = (group.refs?.testset as {id?: string} | undefined)?.id
@@ -51,16 +63,44 @@ const EtlColumnHeader = ({group}: EtlColumnHeaderProps) => {
     const ref = useAtomValue(refAtom) as {data?: unknown} | null
     const name = pickName(ref?.data ?? null)
 
+    // Evaluator lookup — match by id first, then slug. The atom is a
+    // run-level query that the table already subscribes to elsewhere, so
+    // this is just an additional cheap subscriber.
+    const evaluatorsAtom = useMemo(() => {
+        if (group.kind !== "evaluator" || !runId) return emptyEvaluatorsAtom
+        return evaluationEvaluatorsByRunQueryAtomFamily(runId)
+    }, [group.kind, runId])
+    const evaluatorsQuery = useAtomValue(evaluatorsAtom) as {
+        data: {id?: string; slug?: string; name?: string}[]
+    }
+    const evaluatorName = useMemo(() => {
+        if (group.kind !== "evaluator") return null
+        const refs = group.refs as
+            | {evaluator?: {id?: string; slug?: string}; evaluator_revision?: {slug?: string}}
+            | undefined
+            | null
+        const evaluatorId = refs?.evaluator?.id ?? null
+        const evaluatorSlug = refs?.evaluator?.slug ?? refs?.evaluator_revision?.slug ?? null
+        const match = (evaluatorsQuery.data ?? []).find((e) => {
+            if (evaluatorId && e.id === evaluatorId) return true
+            if (evaluatorSlug && e.slug === evaluatorSlug) return true
+            return false
+        })
+        return pickName(match)
+    }, [group, evaluatorsQuery.data])
+
     const label = useMemo(() => {
         switch (group.kind) {
             case "testset":
                 return name ? `Testset ${name}` : group.label
             case "application":
                 return name ? `Application ${name}` : group.label
+            case "evaluator":
+                return evaluatorName ?? group.label
             default:
                 return group.label
         }
-    }, [group.kind, group.label, name])
+    }, [group.kind, group.label, name, evaluatorName])
 
     return (
         <Tooltip title={label} placement="top">

--- a/web/oss/src/components/EvalRunDetails/etl/EtlColumnHeader.tsx
+++ b/web/oss/src/components/EvalRunDetails/etl/EtlColumnHeader.tsx
@@ -90,17 +90,24 @@ const EtlColumnHeader = ({group, runId}: EtlColumnHeaderProps) => {
     }, [group, evaluatorsQuery.data])
 
     const label = useMemo(() => {
+        // Each non-"other" group is prefixed with its kind ("Testset: …",
+        // "Application: …", "Evaluator: …") so the header reads as a
+        // self-describing pair. Falls back to the slug (or the existing
+        // slug-titled label for evaluator) when the entity name hasn't
+        // loaded — we use `group.slug` directly here, not `group.label`,
+        // because the default labels already embed the kind word and
+        // would double-prefix (e.g. "Testset: Testset completion-tst").
         switch (group.kind) {
             case "testset":
-                return name ? `Testset ${name}` : group.label
+                return `Testset: ${name ?? group.slug ?? "—"}`
             case "application":
-                return name ? `Application ${name}` : group.label
+                return `Application: ${name ?? group.slug ?? "—"}`
             case "evaluator":
-                return evaluatorName ?? group.label
+                return `Evaluator: ${evaluatorName ?? group.label}`
             default:
                 return group.label
         }
-    }, [group.kind, group.label, name, evaluatorName])
+    }, [group.kind, group.label, group.slug, name, evaluatorName])
 
     return (
         <Tooltip title={label} placement="top">

--- a/web/oss/src/components/EvalRunDetails/etl/ScenarioFilterBar.tsx
+++ b/web/oss/src/components/EvalRunDetails/etl/ScenarioFilterBar.tsx
@@ -117,7 +117,13 @@ const ScenarioFilterBar = ({runId}: ScenarioFilterBarProps) => {
     const fields = useMemo(
         () =>
             buildFilterSchema(schema, {resolveValueType}).fields.filter(
-                (f) => FILTERABLE_COLUMN_KINDS[f.groupKind],
+                // String-typed evaluator outputs are excluded for the same
+                // reason they are hidden from the scenario table: their
+                // per-scenario value is a `{type: "string", count: …}` stats
+                // blob that `unwrapStatsForCompare` does not unwrap, so any
+                // filter comparison would compare against a raw object and
+                // never match. See `useEtlColumns.tsx`.
+                (f) => FILTERABLE_COLUMN_KINDS[f.groupKind] && f.valueType !== "string",
             ),
         [schema, resolveValueType],
     )

--- a/web/oss/src/components/EvalRunDetails/etl/ScenarioFilterBar.tsx
+++ b/web/oss/src/components/EvalRunDetails/etl/ScenarioFilterBar.tsx
@@ -116,15 +116,22 @@ const ScenarioFilterBar = ({runId}: ScenarioFilterBarProps) => {
 
     const fields = useMemo(
         () =>
-            buildFilterSchema(schema, {resolveValueType}).fields.filter(
+            buildFilterSchema(schema, {resolveValueType}).fields.filter((f) => {
+                if (!FILTERABLE_COLUMN_KINDS[f.groupKind]) return false
                 // String-typed evaluator outputs are excluded for the same
                 // reason they are hidden from the scenario table: their
                 // per-scenario value is a `{type: "string", count: …}` stats
                 // blob that `unwrapStatsForCompare` does not unwrap, so any
                 // filter comparison would compare against a raw object and
                 // never match. See `useEtlColumns.tsx`.
-                (f) => FILTERABLE_COLUMN_KINDS[f.groupKind] && f.valueType !== "string",
-            ),
+                //
+                // Scoped to `evaluator` kind: `buildColumnValueTypeResolver`
+                // has a column-name-only fallback, so a same-named metrics
+                // column could otherwise inherit an evaluator's string
+                // `metricType` and be incorrectly dropped.
+                if (f.groupKind === "evaluator" && f.valueType === "string") return false
+                return true
+            }),
         [schema, resolveValueType],
     )
     const fieldByKey = useMemo(() => new Map(fields.map((f) => [encodeField(f), f])), [fields])

--- a/web/oss/src/components/EvalRunDetails/etl/ScenarioFilterBar.tsx
+++ b/web/oss/src/components/EvalRunDetails/etl/ScenarioFilterBar.tsx
@@ -116,22 +116,9 @@ const ScenarioFilterBar = ({runId}: ScenarioFilterBarProps) => {
 
     const fields = useMemo(
         () =>
-            buildFilterSchema(schema, {resolveValueType}).fields.filter((f) => {
-                if (!FILTERABLE_COLUMN_KINDS[f.groupKind]) return false
-                // String-typed evaluator outputs are excluded for the same
-                // reason they are hidden from the scenario table: their
-                // per-scenario value is a `{type: "string", count: …}` stats
-                // blob that `unwrapStatsForCompare` does not unwrap, so any
-                // filter comparison would compare against a raw object and
-                // never match. See `useEtlColumns.tsx`.
-                //
-                // Scoped to `evaluator` kind: `buildColumnValueTypeResolver`
-                // has a column-name-only fallback, so a same-named metrics
-                // column could otherwise inherit an evaluator's string
-                // `metricType` and be incorrectly dropped.
-                if (f.groupKind === "evaluator" && f.valueType === "string") return false
-                return true
-            }),
+            buildFilterSchema(schema, {resolveValueType}).fields.filter(
+                (f) => FILTERABLE_COLUMN_KINDS[f.groupKind],
+            ),
         [schema, resolveValueType],
     )
     const fieldByKey = useMemo(() => new Map(fields.map((f) => [encodeField(f), f])), [fields])

--- a/web/oss/src/components/EvalRunDetails/etl/ScenarioFilterBar.tsx
+++ b/web/oss/src/components/EvalRunDetails/etl/ScenarioFilterBar.tsx
@@ -116,9 +116,22 @@ const ScenarioFilterBar = ({runId}: ScenarioFilterBarProps) => {
 
     const fields = useMemo(
         () =>
-            buildFilterSchema(schema, {resolveValueType}).fields.filter(
-                (f) => FILTERABLE_COLUMN_KINDS[f.groupKind],
-            ),
+            buildFilterSchema(schema, {resolveValueType}).fields.filter((f) => {
+                if (!FILTERABLE_COLUMN_KINDS[f.groupKind]) return false
+                // String-typed evaluator outputs are excluded for the same
+                // reason they are hidden from the scenario table: their
+                // per-scenario value is a `{type: "string", count: …}` stats
+                // blob that `unwrapStatsForCompare` does not unwrap, so any
+                // filter comparison would compare against a raw object and
+                // never match. See `useEtlColumns.tsx`.
+                //
+                // Scoped to `evaluator` kind: `buildColumnValueTypeResolver`
+                // has a column-name-only fallback, so a same-named metrics
+                // column could otherwise inherit an evaluator's string
+                // `metricType` and be incorrectly dropped.
+                if (f.groupKind === "evaluator" && f.valueType === "string") return false
+                return true
+            }),
         [schema, resolveValueType],
     )
     const fieldByKey = useMemo(() => new Map(fields.map((f) => [encodeField(f), f])), [fields])

--- a/web/oss/src/components/EvalRunDetails/etl/cells/EtlResolvedCell.tsx
+++ b/web/oss/src/components/EvalRunDetails/etl/cells/EtlResolvedCell.tsx
@@ -47,10 +47,21 @@ import {hydrationVersionAtom} from "../useHydrateScenarios"
 
 type ColumnKind = ColumnGroup["kind"]
 
+// Tuned to match the actual visible line count inside `.scenario-table-cell`
+// at each row-height variant. With `font-size: 13px` and `line-height: 1.6`
+// (~20.8px per line) — defined in `evaluations.css` — the available
+// content height after padding fits roughly:
+//   small  (80px row, 8px padding):  (80 - 16) / 20.8 ≈ 3 lines
+//   medium (160px row, 12px padding): (160 - 24) / 20.8 ≈ 6 lines
+//   large  (280px row, 12px padding): (280 - 24) / 20.8 ≈ 12 lines
+// `-webkit-line-clamp` places its ellipsis at line N — if N exceeds the
+// visible lines, the parent's `overflow: hidden` cuts the text mid-line and
+// the ellipsis is never seen. Matching N to the visible count puts the
+// ellipsis on the last fully-rendered line.
 const MAX_LINES_BY_HEIGHT: Record<ScenarioRowHeight, number> = {
-    small: 4,
-    medium: 9,
-    large: 18,
+    small: 3,
+    medium: 6,
+    large: 12,
 }
 
 /** Entity slices each column kind reads from. */

--- a/web/oss/src/components/EvalRunDetails/etl/cells/EtlResolvedCell.tsx
+++ b/web/oss/src/components/EvalRunDetails/etl/cells/EtlResolvedCell.tsx
@@ -57,7 +57,12 @@ const MAX_LINES_BY_HEIGHT: Record<ScenarioRowHeight, number> = {
 const SLICES_BY_KIND: Record<ColumnKind, ("results" | "metrics" | "testcases" | "traces")[]> = {
     testset: ["results", "testcases"],
     application: ["results", "traces"],
-    evaluator: ["results", "metrics"],
+    // Evaluator outputs come from metrics first, but string-typed outputs
+    // (e.g. an LLM-judge's `reasoning` field) only land in the metric layer
+    // as a `{type: "string", count: N}` placeholder — the real value is on
+    // the annotation trace. Hydrate traces too so `resolveFromTrace` can
+    // find it when `resolveFromMetric` falls through.
+    evaluator: ["results", "metrics", "traces"],
     metrics: ["metrics"],
     other: ["results"],
 }
@@ -212,15 +217,19 @@ const EtlResolvedCell = ({
                     if (cached == null) materializer.request("testcases", {testcaseId})
                 }
             } else if (slice === "traces") {
+                // A scenario can carry multiple traces — typically one per
+                // result (invocation, annotation, …). Materialize every
+                // trace_id so evaluator cells can find the annotation trace
+                // alongside the application's invocation trace.
                 const cachedResults = evaluationResultMolecule.get.byScenario({
                     projectId,
                     runId,
                     scenarioId,
                 })
-                const traceId =
-                    cachedResults?.find((r) => typeof r.trace_id === "string" && r.trace_id)
-                        ?.trace_id ?? null
-                if (traceId) {
+                const traceIds = (cachedResults ?? [])
+                    .map((r) => r.trace_id)
+                    .filter((id): id is string => typeof id === "string" && id.length > 0)
+                for (const traceId of traceIds) {
                     const cached = queryClient.getQueryData(["trace-entity", projectId, traceId])
                     if (cached == null) materializer.request("traces", {traceId})
                 }
@@ -268,13 +277,17 @@ const EtlResolvedCell = ({
                     runId,
                     scenarioId,
                 })
-                const traceId =
-                    cachedResults?.find((r) => typeof r.trace_id === "string" && r.trace_id)
-                        ?.trace_id ?? null
-                if (!traceId) continue
-                const cached = queryClient.getQueryData(["trace-entity", projectId, traceId])
-                if (cached === undefined && !materializer?.hasFailed("traces", {traceId})) {
-                    return true
+                // Check every result's trace_id (not just the first) — a
+                // scenario can carry multiple traces and an evaluator cell
+                // needs the annotation trace, which isn't always result[0].
+                const traceIds = (cachedResults ?? [])
+                    .map((r) => r.trace_id)
+                    .filter((id): id is string => typeof id === "string" && id.length > 0)
+                for (const traceId of traceIds) {
+                    const cached = queryClient.getQueryData(["trace-entity", projectId, traceId])
+                    if (cached === undefined && !materializer?.hasFailed("traces", {traceId})) {
+                        return true
+                    }
                 }
             }
         }

--- a/web/oss/src/components/EvalRunDetails/etl/useEtlColumns.tsx
+++ b/web/oss/src/components/EvalRunDetails/etl/useEtlColumns.tsx
@@ -79,7 +79,14 @@ export const useEtlColumns = ({
                     ),
                     width: WIDTH_BY_KIND[leaf.kind],
                     minWidth: WIDTH_BY_KIND[leaf.kind],
-                    ellipsis: true,
+                    // `ellipsis: true` is intentionally NOT set here. Antd
+                    // applies `white-space: nowrap` to the cell when it is,
+                    // which collapses our multi-line content (e.g. an
+                    // evaluator's `reasoning` string) onto a single line.
+                    // The body cell is `EtlResolvedCell`, which already
+                    // clamps to a row-height-derived line count via
+                    // `-webkit-line-clamp`. The header has its own
+                    // ellipsis-ing inside the `Tooltip` span above.
                     align: "left" as const,
                     render: (_: unknown, record: PreviewTableRow) => {
                         // antd's virtual table can briefly call a cell

--- a/web/oss/src/components/EvalRunDetails/etl/useEtlColumns.tsx
+++ b/web/oss/src/components/EvalRunDetails/etl/useEtlColumns.tsx
@@ -119,7 +119,7 @@ export const useEtlColumns = ({
             return {
                 key: g.group.key,
                 columnVisibilityLabel: g.group.label,
-                title: <EtlColumnHeader group={g.group} />,
+                title: <EtlColumnHeader group={g.group} runId={runId} />,
                 align: "left" as const,
                 children,
             }

--- a/web/oss/src/components/EvalRunDetails/etl/useEtlColumns.tsx
+++ b/web/oss/src/components/EvalRunDetails/etl/useEtlColumns.tsx
@@ -77,19 +77,27 @@ export const useEtlColumns = ({
         // per-row scalar representation. They remain visible in the focus
         // drawer (FocusDrawer reads `columnResult` directly, bypassing
         // this hook).
+        //
+        // The filter is restricted to `evaluator` leaves because
+        // `buildColumnValueTypeResolver` falls back to a column-name-only
+        // lookup — without the kind guard, a same-named testset /
+        // application / other column would inherit the evaluator's
+        // `metricType` and be incorrectly dropped.
         const resolveValueType = buildColumnValueTypeResolver(columnResult ?? undefined)
         const grouped = groupRunColumns(schema.steps, schema.mappings)
             .filter((g) => g.group.kind !== "metrics")
             .map((g) => ({
                 ...g,
-                columns: g.columns.filter(
-                    (leaf) =>
+                columns: g.columns.filter((leaf) => {
+                    if (leaf.kind !== "evaluator") return true
+                    return (
                         resolveValueType({
                             groupKind: leaf.kind,
                             groupSlug: leaf.groupSlug,
                             columnName: leaf.name,
-                        }) !== "string",
-                ),
+                        }) !== "string"
+                    )
+                }),
             }))
             .filter((g) => g.columns.length > 0)
 

--- a/web/oss/src/components/EvalRunDetails/etl/useEtlColumns.tsx
+++ b/web/oss/src/components/EvalRunDetails/etl/useEtlColumns.tsx
@@ -22,9 +22,11 @@ import {groupRunColumns, type ColumnGroup, type RunSchema} from "@agenta/entitie
 import {Tooltip} from "antd"
 import type {ColumnsType} from "antd/es/table"
 
+import type {EvaluationTableColumnsResult} from "../atoms/table"
 import type {PreviewTableRow} from "../atoms/tableRows"
 
 import EtlResolvedCell, {EtlSkeletonCell} from "./cells/EtlResolvedCell"
+import {buildColumnValueTypeResolver} from "./columnValueTypes"
 import EtlColumnHeader from "./EtlColumnHeader"
 
 const WIDTH_BY_KIND: Record<ColumnGroup["kind"], number> = {
@@ -39,6 +41,13 @@ export interface UseEtlColumnsArgs {
     projectId: string | null
     runId: string | null
     schema: RunSchema | null
+    /**
+     * Backend-metadata column result. Used to look up each leaf's
+     * `metricType` so string-typed evaluator outputs are hidden from the
+     * table (they remain in the focus drawer, which reads `columnResult`
+     * directly). When omitted, no type-based filtering is applied.
+     */
+    columnResult?: EvaluationTableColumnsResult | null
 }
 
 /**
@@ -49,6 +58,7 @@ export const useEtlColumns = ({
     projectId,
     runId,
     schema,
+    columnResult,
 }: UseEtlColumnsArgs): ColumnsType<PreviewTableRow> => {
     return useMemo<ColumnsType<PreviewTableRow>>(() => {
         if (!schema || !projectId || !runId) return []
@@ -60,9 +70,28 @@ export const useEtlColumns = ({
         // group is kept on the production path in `Table.tsx` and rendered
         // by the existing metric cell. Emitting an ETL metrics group too
         // would duplicate it.
-        const grouped = groupRunColumns(schema.steps, schema.mappings).filter(
-            (g) => g.group.kind !== "metrics",
-        )
+        //
+        // String-typed evaluator outputs are also hidden from the table:
+        // their per-scenario values resolve through the metric layer as
+        // `{type: "string", count: …}` stats blobs that have no useful
+        // per-row scalar representation. They remain visible in the focus
+        // drawer (FocusDrawer reads `columnResult` directly, bypassing
+        // this hook).
+        const resolveValueType = buildColumnValueTypeResolver(columnResult ?? undefined)
+        const grouped = groupRunColumns(schema.steps, schema.mappings)
+            .filter((g) => g.group.kind !== "metrics")
+            .map((g) => ({
+                ...g,
+                columns: g.columns.filter(
+                    (leaf) =>
+                        resolveValueType({
+                            groupKind: leaf.kind,
+                            groupSlug: leaf.groupSlug,
+                            columnName: leaf.name,
+                        }) !== "string",
+                ),
+            }))
+            .filter((g) => g.columns.length > 0)
 
         return grouped.map((g) => {
             const children = g.columns.map((leaf) => {
@@ -117,5 +146,5 @@ export const useEtlColumns = ({
                 children,
             }
         })
-    }, [projectId, runId, schema])
+    }, [projectId, runId, schema, columnResult])
 }

--- a/web/oss/src/components/EvalRunDetails/etl/useEtlColumns.tsx
+++ b/web/oss/src/components/EvalRunDetails/etl/useEtlColumns.tsx
@@ -22,9 +22,11 @@ import {groupRunColumns, type ColumnGroup, type RunSchema} from "@agenta/entitie
 import {Tooltip} from "antd"
 import type {ColumnsType} from "antd/es/table"
 
+import type {EvaluationTableColumnsResult} from "../atoms/table"
 import type {PreviewTableRow} from "../atoms/tableRows"
 
 import EtlResolvedCell, {EtlSkeletonCell} from "./cells/EtlResolvedCell"
+import {buildColumnValueTypeResolver} from "./columnValueTypes"
 import EtlColumnHeader from "./EtlColumnHeader"
 
 const WIDTH_BY_KIND: Record<ColumnGroup["kind"], number> = {
@@ -39,6 +41,13 @@ export interface UseEtlColumnsArgs {
     projectId: string | null
     runId: string | null
     schema: RunSchema | null
+    /**
+     * Backend-metadata column result. Used to look up each leaf's
+     * `metricType` so string-typed evaluator outputs are hidden from the
+     * table (they remain in the focus drawer, which reads `columnResult`
+     * directly). When omitted, no type-based filtering is applied.
+     */
+    columnResult?: EvaluationTableColumnsResult | null
 }
 
 /**
@@ -49,6 +58,7 @@ export const useEtlColumns = ({
     projectId,
     runId,
     schema,
+    columnResult,
 }: UseEtlColumnsArgs): ColumnsType<PreviewTableRow> => {
     return useMemo<ColumnsType<PreviewTableRow>>(() => {
         if (!schema || !projectId || !runId) return []
@@ -60,9 +70,36 @@ export const useEtlColumns = ({
         // group is kept on the production path in `Table.tsx` and rendered
         // by the existing metric cell. Emitting an ETL metrics group too
         // would duplicate it.
-        const grouped = groupRunColumns(schema.steps, schema.mappings).filter(
-            (g) => g.group.kind !== "metrics",
-        )
+        //
+        // String-typed evaluator outputs are also hidden from the table:
+        // their per-scenario values resolve through the metric layer as
+        // `{type: "string", count: …}` stats blobs that have no useful
+        // per-row scalar representation. They remain visible in the focus
+        // drawer (FocusDrawer reads `columnResult` directly, bypassing
+        // this hook).
+        //
+        // The filter is restricted to `evaluator` leaves because
+        // `buildColumnValueTypeResolver` falls back to a column-name-only
+        // lookup — without the kind guard, a same-named testset /
+        // application / other column would inherit the evaluator's
+        // `metricType` and be incorrectly dropped.
+        const resolveValueType = buildColumnValueTypeResolver(columnResult ?? undefined)
+        const grouped = groupRunColumns(schema.steps, schema.mappings)
+            .filter((g) => g.group.kind !== "metrics")
+            .map((g) => ({
+                ...g,
+                columns: g.columns.filter((leaf) => {
+                    if (leaf.kind !== "evaluator") return true
+                    return (
+                        resolveValueType({
+                            groupKind: leaf.kind,
+                            groupSlug: leaf.groupSlug,
+                            columnName: leaf.name,
+                        }) !== "string"
+                    )
+                }),
+            }))
+            .filter((g) => g.columns.length > 0)
 
         return grouped.map((g) => {
             const children = g.columns.map((leaf) => {
@@ -117,5 +154,5 @@ export const useEtlColumns = ({
                 children,
             }
         })
-    }, [projectId, runId, schema])
+    }, [projectId, runId, schema, columnResult])
 }

--- a/web/oss/src/components/EvalRunDetails/etl/useEtlColumns.tsx
+++ b/web/oss/src/components/EvalRunDetails/etl/useEtlColumns.tsx
@@ -22,11 +22,9 @@ import {groupRunColumns, type ColumnGroup, type RunSchema} from "@agenta/entitie
 import {Tooltip} from "antd"
 import type {ColumnsType} from "antd/es/table"
 
-import type {EvaluationTableColumnsResult} from "../atoms/table"
 import type {PreviewTableRow} from "../atoms/tableRows"
 
 import EtlResolvedCell, {EtlSkeletonCell} from "./cells/EtlResolvedCell"
-import {buildColumnValueTypeResolver} from "./columnValueTypes"
 import EtlColumnHeader from "./EtlColumnHeader"
 
 const WIDTH_BY_KIND: Record<ColumnGroup["kind"], number> = {
@@ -41,13 +39,6 @@ export interface UseEtlColumnsArgs {
     projectId: string | null
     runId: string | null
     schema: RunSchema | null
-    /**
-     * Backend-metadata column result. Used to look up each leaf's
-     * `metricType` so string-typed evaluator outputs are hidden from the
-     * table (they remain in the focus drawer, which reads `columnResult`
-     * directly). When omitted, no type-based filtering is applied.
-     */
-    columnResult?: EvaluationTableColumnsResult | null
 }
 
 /**
@@ -58,7 +49,6 @@ export const useEtlColumns = ({
     projectId,
     runId,
     schema,
-    columnResult,
 }: UseEtlColumnsArgs): ColumnsType<PreviewTableRow> => {
     return useMemo<ColumnsType<PreviewTableRow>>(() => {
         if (!schema || !projectId || !runId) return []
@@ -70,36 +60,9 @@ export const useEtlColumns = ({
         // group is kept on the production path in `Table.tsx` and rendered
         // by the existing metric cell. Emitting an ETL metrics group too
         // would duplicate it.
-        //
-        // String-typed evaluator outputs are also hidden from the table:
-        // their per-scenario values resolve through the metric layer as
-        // `{type: "string", count: …}` stats blobs that have no useful
-        // per-row scalar representation. They remain visible in the focus
-        // drawer (FocusDrawer reads `columnResult` directly, bypassing
-        // this hook).
-        //
-        // The filter is restricted to `evaluator` leaves because
-        // `buildColumnValueTypeResolver` falls back to a column-name-only
-        // lookup — without the kind guard, a same-named testset /
-        // application / other column would inherit the evaluator's
-        // `metricType` and be incorrectly dropped.
-        const resolveValueType = buildColumnValueTypeResolver(columnResult ?? undefined)
-        const grouped = groupRunColumns(schema.steps, schema.mappings)
-            .filter((g) => g.group.kind !== "metrics")
-            .map((g) => ({
-                ...g,
-                columns: g.columns.filter((leaf) => {
-                    if (leaf.kind !== "evaluator") return true
-                    return (
-                        resolveValueType({
-                            groupKind: leaf.kind,
-                            groupSlug: leaf.groupSlug,
-                            columnName: leaf.name,
-                        }) !== "string"
-                    )
-                }),
-            }))
-            .filter((g) => g.columns.length > 0)
+        const grouped = groupRunColumns(schema.steps, schema.mappings).filter(
+            (g) => g.group.kind !== "metrics",
+        )
 
         return grouped.map((g) => {
             const children = g.columns.map((leaf) => {
@@ -154,5 +117,5 @@ export const useEtlColumns = ({
                 children,
             }
         })
-    }, [projectId, runId, schema, columnResult])
+    }, [projectId, runId, schema])
 }

--- a/web/packages/agenta-entities/src/evaluationRun/etl/__tests__/resolveMappings.test.ts
+++ b/web/packages/agenta-entities/src/evaluationRun/etl/__tests__/resolveMappings.test.ts
@@ -332,6 +332,91 @@ describe("annotation step → composeResolvers(metric, trace)", () => {
         assert.equal(col.value, true)
     })
 
+    it("falls through to trace when metric value is a string-type placeholder", () => {
+        // String-typed evaluator outputs (e.g. an LLM-judge `reasoning`
+        // field) only land in the metric layer as a `{type: "string",
+        // count: N}` placeholder — the real value is on the annotation
+        // trace. `resolveFromMetric` must return null for that shape so the
+        // composed `resolveFromTrace` fallback picks the actual string up.
+        const row = makeRow({
+            results: [
+                {
+                    run_id: "r1",
+                    scenario_id: "scen1",
+                    step_key: "eval-1",
+                    trace_id: "trace-eval",
+                    status: "success",
+                },
+            ],
+            metrics: [
+                {
+                    id: "m1",
+                    run_id: "r1",
+                    data: {
+                        "eval-1": {
+                            "attributes.ag.data.outputs.success": {
+                                type: "string",
+                                count: 3,
+                            },
+                        },
+                    },
+                } as unknown as HydratedScenarioRow<TestScenario>["metrics"][number],
+            ],
+            traces: {
+                "trace-eval": {
+                    spans: {
+                        eval_v0: {
+                            attributes: {
+                                ag: {data: {outputs: {success: "the model was correct"}}},
+                            },
+                        },
+                    },
+                },
+            },
+        })
+        const [col] = resolveMappings(row, schema)
+        assert.equal(col.source, "trace")
+        assert.equal(col.value, "the model was correct")
+    })
+
+    it("keeps the metric value when the string-typed entry has distribution data", () => {
+        // A `{type: "string"}` shape that ALSO carries `freq` / `value` /
+        // etc. is real distribution data (not a placeholder) and must be
+        // returned as-is — only the bare `{type, count}` shape falls
+        // through.
+        const row = makeRow({
+            results: [
+                {
+                    run_id: "r1",
+                    scenario_id: "scen1",
+                    step_key: "eval-1",
+                    trace_id: "trace-eval",
+                    status: "success",
+                },
+            ],
+            metrics: [
+                {
+                    id: "m1",
+                    run_id: "r1",
+                    data: {
+                        "eval-1": {
+                            "attributes.ag.data.outputs.success": {
+                                type: "string",
+                                count: 3,
+                                freq: [{value: "yes", count: 2}],
+                            },
+                        },
+                    },
+                } as unknown as HydratedScenarioRow<TestScenario>["metrics"][number],
+            ],
+        })
+        const [col] = resolveMappings(row, schema)
+        assert.equal(col.source, "metric")
+        const v = col.value as {type: string; freq: unknown[]}
+        assert.equal(v.type, "string")
+        assert.deepEqual(v.freq, [{value: "yes", count: 2}])
+    })
+
     it("returns missing when neither metric nor trace has the path", () => {
         const row = makeRow({
             results: [

--- a/web/packages/agenta-entities/src/evaluationRun/etl/resolveMappings.ts
+++ b/web/packages/agenta-entities/src/evaluationRun/etl/resolveMappings.ts
@@ -311,6 +311,33 @@ export const resolveFromTrace: StepResolver = ({result, row, path}) => {
 }
 
 /**
+ * String-typed evaluator outputs (e.g. an LLM-judge's `reasoning` field) are
+ * stored in metric data as a `{type: "string", count: N}` placeholder rather
+ * than the actual string — the backend can't build a distribution over
+ * arbitrary text, so it only records that *some* string was emitted. The
+ * real value lives on the annotation trace and is resolved via
+ * `resolveFromTrace` instead.
+ *
+ * Detect that exact shape (`type: "string"` + numeric `count`, no
+ * distribution / scalar fields) so `resolveFromMetric` can return `null`
+ * and let the composed `resolveFromTrace` fallback take over. Mirrors the
+ * legacy `isStringTypePlaceholder` check in
+ * `EvalRunDetails/atoms/scenarioColumnValues.ts`.
+ */
+function isStringTypeMetricPlaceholder(value: unknown): boolean {
+    if (typeof value !== "object" || value === null) return false
+    const obj = value as Record<string, unknown>
+    if (obj.type !== "string" || typeof obj.count !== "number") return false
+    return (
+        obj.value === undefined &&
+        obj.freq === undefined &&
+        obj.frequency === undefined &&
+        obj.rank === undefined &&
+        obj.mean === undefined
+    )
+}
+
+/**
  * Resolver that reads from `metric.data[step.key][path]`.
  *
  * Metric.data is `{stepKey: {flatAttributePath: valueOrStatsObject}}`. The
@@ -318,6 +345,10 @@ export const resolveFromTrace: StepResolver = ({result, row, path}) => {
  * (not a dot-walk). That matches what the server emits — paths like
  * `"attributes.ag.data.outputs.success"` are baked-in flat keys, not nested
  * objects. Trying to dot-walk would fail.
+ *
+ * Returns `null` (not the placeholder) for string-typed metric outputs so
+ * the composed `resolveFromTrace` fallback can extract the actual string
+ * from the annotation trace.
  */
 export const resolveFromMetric: StepResolver = ({step, row, path}) => {
     for (const m of row.metrics) {
@@ -325,7 +356,9 @@ export const resolveFromMetric: StepResolver = ({step, row, path}) => {
         if (!data) continue
         const bucket = data[step.key] as Record<string, unknown> | undefined
         if (bucket && bucket[path] !== undefined) {
-            return {value: bucket[path], source: "metric"}
+            const value = bucket[path]
+            if (isStringTypeMetricPlaceholder(value)) return null
+            return {value, source: "metric"}
         }
     }
     return null


### PR DESCRIPTION
## Summary

String-typed evaluator outputs (e.g. an LLM-judge `reasoning` field) resolve through the metric layer as `{type: "string", count, ...}` stats blobs. `unwrapStatsForCompare` only unwraps `binary` and `numeric` variants, so the raw stats object falls through to `JSON.stringify` in the cell renderer and is shown as `{"type":"string","count":...}` in every row. The same blob makes filter predicates impossible — equality checks would compare a user string against a stats object and never match.

Drop string-typed leaves at column-build time in `useEtlColumns` and from the filter dropdown in `ScenarioFilterBar` by reusing the existing `buildColumnValueTypeResolver` (the metricType-from-evaluator-schema lookup that already powers the filter bar's value-type detection). The focus drawer is unaffected — it reads `columnResult.groups/columns` directly via `useFocusDrawerSections`, bypassing both code paths, so string metrics still appear there.

## Testing
### Verified locally
reasoning column is not shown

### QA follow-up
- test different output metrics 

## Checklist
- [x] I have included a video or screen recording for UI changes, or marked Demo as N/A
- [x] Relevant tests pass locally
- [x] Relevant linting and formatting pass locally
- [x] I have signed the CLA, or I will sign it when the bot prompts me

## Contributor Resources
- [Contributing guide](https://agenta.ai/docs/contributing/overview)
- [Creating your first PR](https://agenta.ai/docs/contributing/first-pr)
- [Development mode](https://agenta.ai/docs/contributing/guides/development-mode)
- [Testing](https://agenta.ai/docs/contributing/guides/testing)
- [Formatting and linting](https://agenta.ai/docs/contributing/guides/formatting-and-linting)
- [Slack support](https://join.slack.com/t/agenta-hq/shared_invite/zt-37pnbp5s6-mbBrPL863d_oLB61GSNFjw)
