### PR TITLE
[FE fix] Improve trace output styling

### DIFF
--- a/web/oss/src/components/DrillInView/TraceSpanDrillInView.tsx
+++ b/web/oss/src/components/DrillInView/TraceSpanDrillInView.tsx
@@ -583,7 +583,7 @@ export const TraceSpanDrillInView = memo(
                                     />
                                 </div>
                             ) : (
-                                <div className="mx-1 my-2 rounded-md bg-[#F6F8FB]">
+                                <div className="mx-1 my-2 rounded-md bg-white">
                                     <TextModeViewer
                                         editorId={`trace-span-${textViewerId}`}
                                         value={textOutput}

--- a/web/oss/src/components/DrillInView/TraceSpanDrillInView.tsx
+++ b/web/oss/src/components/DrillInView/TraceSpanDrillInView.tsx
@@ -222,7 +222,7 @@ const TextModeViewer = ({
             showToolbar={false}
             enableTokens={false}
             readOnly
-            className="[&_.editor-inner]:!border-0 [&_.editor-inner]:!rounded-none [&_.editor-container]:!bg-transparent [&_.editor-input]:!min-h-0 [&_.editor-input]:!px-4 [&_.editor-input]:!py-[6px] [&_.editor-paragraph]:!mb-1 [&_.editor-paragraph:last-child]:!mb-0 [&_.editor-input.markdown-view_.editor-code]:!m-0 [&_.editor-input.markdown-view_.editor-code]:!p-0 [&_.editor-input.markdown-view_.editor-code]:!bg-transparent"
+            className="[&_.editor-inner]:!border-0 [&_.editor-inner]:!rounded-none [&_.editor-container]:!bg-transparent [&_.editor-input]:!min-h-0 [&_.editor-input]:!px-4 [&_.editor-input]:!py-[6px] [&_.editor-input]:!text-[12.5px] [&_.editor-paragraph]:!mb-1 [&_.editor-paragraph:last-child]:!mb-0 [&_.editor-input.markdown-view_.editor-code]:!m-0 [&_.editor-input.markdown-view_.editor-code]:!p-0 [&_.editor-input.markdown-view_.editor-code]:!bg-transparent"
         >
             <MarkdownModeSync isMarkdownView={mode === "text"} />
             <EditorWrapper


### PR DESCRIPTION
## Summary
fixes the reported issue: 

> The outputs in tracing when strings are shown with grey background (even in markdown) we should simply use white background like in pretty

## Testing
### QA follow-up
check the trace output information in the drawer

## Checklist
- [x] I have included a video or screen recording for UI changes, or marked Demo as N/A
- [x] Relevant tests pass locally
- [x] Relevant linting and formatting pass locally
- [x] I have signed the CLA, or I will sign it when the bot prompts me

## Contributor Resources
- [Contributing guide](https://agenta.ai/docs/contributing/overview)
- [Creating your first PR](https://agenta.ai/docs/contributing/first-pr)
- [Development mode](https://agenta.ai/docs/contributing/guides/development-mode)
- [Testing](https://agenta.ai/docs/contributing/guides/testing)
- [Formatting and linting](https://agenta.ai/docs/contributing/guides/formatting-and-linting)
- [Slack support](https://join.slack.com/t/agenta-hq/shared_invite/zt-37pnbp5s6-mbBrPL863d_oLB61GSNFjw)
