### PR TITLE
fix(frontend): registry Model column showing system_message text

### DIFF
--- a/web/oss/src/components/VariantsComponents/store/registryStore.ts
+++ b/web/oss/src/components/VariantsComponents/store/registryStore.ts
@@ -56,16 +56,15 @@ export interface RegistryRevisionRow {
 
 /**
  * Recursively picks the model name from a parameters object.
- * Reused from getVariantColumns.tsx logic.
+ * Only returns strings sourced from an explicit model key (model, model_name,
+ * modelName, engine). Arbitrary string values (e.g. system_message, prompts)
+ * are never returned.
  */
 const pickModelFromParams = (value: unknown, depth = 0, visited = new Set<unknown>()): string => {
     if (!value || depth > 6) return ""
+    if (typeof value !== "object") return ""
     if (visited.has(value)) return ""
-    if (typeof value === "object") visited.add(value)
-
-    if (typeof value === "string") {
-        return value.trim()
-    }
+    visited.add(value)
 
     if (Array.isArray(value)) {
         for (const item of value) {
@@ -75,20 +74,14 @@ const pickModelFromParams = (value: unknown, depth = 0, visited = new Set<unknow
         return ""
     }
 
-    if (typeof value === "object") {
-        const obj = value as Record<string, unknown>
-        const directModel = [obj.model, obj.model_name, obj.modelName, obj.engine].find(
-            (candidate) => typeof candidate === "string" && candidate.trim().length > 0,
-        ) as string | undefined
-        if (directModel) return directModel.trim()
+    const obj = value as Record<string, unknown>
+    const directModel = [obj.model, obj.model_name, obj.modelName, obj.engine].find(
+        (candidate) => typeof candidate === "string" && candidate.trim().length > 0,
+    ) as string | undefined
+    if (directModel) return directModel.trim()
 
-        const llmConfig = obj.llm_config ?? obj.llmConfig
-        if (llmConfig) {
-            const result = pickModelFromParams(llmConfig, depth + 1, visited)
-            if (result) return result
-        }
-
-        for (const nested of Object.values(obj)) {
+    for (const nested of Object.values(obj)) {
+        if (nested && typeof nested === "object") {
             const result = pickModelFromParams(nested, depth + 1, visited)
             if (result) return result
         }


### PR DESCRIPTION
## What was broken

A variant config like `{"system_message": "Please answer in German."}` made the registry table's **Model** column display the system message text instead of the empty-state dash.

Before:

| Variant | Model |
| --- | --- |
| my-prompt | Please answer in German. |

After:

| Variant | Model |
| --- | --- |
| my-prompt | — |

## Root cause

`pickModelFromParams` in `web/oss/src/components/VariantsComponents/store/registryStore.ts` walked the entire parameters object and returned the first string it found. The intent was to find a model name nested inside `prompt.llm_config.model` or similar, but the same fallback also returned `system_message`, prompt text, descriptions, or any other string-valued field.

## Fix

The walker now only returns strings sourced from an explicit model key (`model`, `model_name`, `modelName`, `engine`). It still recurses into nested objects and arrays so deeply-nested fields are found (`prompt.llm_config.model` still works), but skips raw string values during recursion. The redundant `llm_config`/`llmConfig` special case was removed since the generic nested walk covers it.

## Test plan

- [ ] Open the registry table for a variant whose config has `system_message` but no model field — Model column shows `—`, not the prompt text.
- [ ] Open the registry table for a normal variant with `prompt.llm_config.model` — Model column still shows the model name.
- [ ] Verify nothing renders wrong for variants whose model lives directly under `model` / `model_name` / `engine` at the root of the parameters object.