### PR TITLE
fix(frontend): improve playground config panel layout

### DIFF
--- a/web/packages/agenta-entity-ui/src/DrillInView/SchemaControls/TextInputControl.tsx
+++ b/web/packages/agenta-entity-ui/src/DrillInView/SchemaControls/TextInputControl.tsx
@@ -131,6 +131,7 @@ export const TextInputControl = memo(function TextInputControl({
             description={tooltipText}
             withTooltip={withTooltip && !!label}
             direction="vertical"
+            gap={isMultiline ? "sm" : "xs"}
             className={cn(className)}
         >
             {inputContent}

--- a/web/packages/agenta-entity-ui/src/DrillInView/components/PlaygroundConfigSection.tsx
+++ b/web/packages/agenta-entity-ui/src/DrillInView/components/PlaygroundConfigSection.tsx
@@ -1517,6 +1517,10 @@ function PlaygroundConfigSection({
     }
 
     // ========== RENDER ==========
+    const hasTopLevelObjectSection = Object.values(parameters).some(
+        (value) => value !== null && typeof value === "object" && !Array.isArray(value),
+    )
+
     return (
         <div className={clsx("flex flex-col", className)}>
             {viewMode !== "form" ? (
@@ -1558,20 +1562,27 @@ function PlaygroundConfigSection({
                     )}
                 </div>
             ) : (
-                <MoleculeDrillInView
-                    key={`form-${discardVersionRef.current}`}
-                    entityId={revisionId}
-                    molecule={drillInAdapter}
-                    editable={!disabled && !useServerData}
-                    rootTitle="Configuration"
-                    showBreadcrumb={false}
-                    collapsible={false}
-                    slots={{
-                        fieldHeader: fieldHeaderSlot,
-                        fieldActions: fieldActionsSlot,
-                        fieldContent: fieldContentSlot,
-                    }}
-                />
+                <>
+                    {!hasTopLevelObjectSection && (
+                        <div className="flex items-center w-full px-3 py-2 bg-[#FAFAFB] sticky top-[48px] z-[2]">
+                            <span className="capitalize font-medium text-sm">Config</span>
+                        </div>
+                    )}
+                    <MoleculeDrillInView
+                        key={`form-${discardVersionRef.current}`}
+                        entityId={revisionId}
+                        molecule={drillInAdapter}
+                        editable={!disabled && !useServerData}
+                        rootTitle="Configuration"
+                        showBreadcrumb={false}
+                        collapsible={false}
+                        slots={{
+                            fieldHeader: fieldHeaderSlot,
+                            fieldActions: fieldActionsSlot,
+                            fieldContent: fieldContentSlot,
+                        }}
+                    />
+                </>
             )}
         </div>
     )

--- a/web/packages/agenta-ui/src/components/presentational/inputs/LabeledField.tsx
+++ b/web/packages/agenta-ui/src/components/presentational/inputs/LabeledField.tsx
@@ -40,6 +40,8 @@ export interface LabeledFieldProps {
     size?: "xs" | "sm" | "md"
     /** Layout direction */
     direction?: "vertical" | "horizontal"
+    /** Gap between label and control (vertical direction only). Defaults to "xs" (4px). */
+    gap?: "xs" | "sm" | "md"
     /** Children (the actual control) */
     children: ReactNode
     /** Additional CSS classes */
@@ -61,6 +63,7 @@ export function LabeledField({
     tooltipPlacement = "right",
     size = "xs",
     direction = "vertical",
+    gap = "xs",
     children,
     className,
 }: LabeledFieldProps) {
@@ -77,7 +80,7 @@ export function LabeledField({
         <div
             className={cn(
                 direction === "vertical"
-                    ? cn(flexLayouts.column, gapClasses.xs)
+                    ? cn(flexLayouts.column, gapClasses[gap])
                     : cn(flexLayouts.rowCenter, gapClasses.sm),
                 className,
             )}


### PR DESCRIPTION
## Summary

Two small fixes to how the playground left panel renders custom configs.

**1. "Config" header for scalar-only configs**

Before: a custom app whose schema exposes only top-level scalars (e.g. `{temperature, system_prompt}`) renders a header-less list of inputs, with no visual anchor at the top of the panel.

After: a static "Config" header appears whenever no top-level object section already provides one. Object sections like `prompt`, `advanced_settings`, and `feedback_config` keep their existing collapsible headers, so no double headers.

**2. Breathing room between textarea label and box**

Before: `LabeledField` uses `gap-1` (4px) between label and control. Looks cramped when the control is a multi-line `<textarea>`.

After: a new optional `gap` prop on `LabeledField` (defaults to `xs`, unchanged for every existing caller). `TextInputControl` opts into `gap="sm"` (8px) when the field is multi-line.

## Test plan
- [ ] Open a custom app with only top-level scalars: "Config" header visible at top.
- [ ] Open a standard prompt app: "Prompt" / "Advanced settings" headers unchanged, no extra "Config" above.
- [ ] Open any variant with a multi-line text field (e.g. `system_prompt`): 8px between label and textarea, not 4px.
- [ ] Single-line text inputs, sliders, selects: visually unchanged.