### PR TITLE
[FE Fix]: Markdown / Text switch in playground configs

### DIFF
--- a/web/packages/agenta-entity-ui/src/DrillInView/SchemaControls/MessagesSchemaControl.tsx
+++ b/web/packages/agenta-entity-ui/src/DrillInView/SchemaControls/MessagesSchemaControl.tsx
@@ -204,6 +204,7 @@ export const MessagesSchemaControl = memo(function MessagesSchemaControl({
                 templateFormat="curly"
                 defaultMinimized={disabled}
                 loadingFallback="none"
+                viewModes={["text", "markdown"]}
             />
         </div>
     )

--- a/web/packages/agenta-entity-ui/src/DrillInView/SchemaControls/PromptSchemaControl.tsx
+++ b/web/packages/agenta-entity-ui/src/DrillInView/SchemaControls/PromptSchemaControl.tsx
@@ -487,6 +487,7 @@ export const PromptSchemaControl = memo(function PromptSchemaControl({
                 templateFormat={localTemplateFormat}
                 tokens={stableVariables}
                 loadingFallback="static"
+                viewModes={["text", "markdown"]}
             />
 
             {/* Tools list */}

--- a/web/packages/agenta-playground-ui/src/components/adapters/TurnMessageAdapter.tsx
+++ b/web/packages/agenta-playground-ui/src/components/adapters/TurnMessageAdapter.tsx
@@ -22,7 +22,6 @@ import {
     PromptDocumentUpload,
 } from "@agenta/ui/components/presentational"
 import type {ViewMode} from "@agenta/ui/drill-in"
-import {markdownViewAtom} from "@agenta/ui/editor"
 import type {UploadFile} from "antd"
 import clsx from "clsx"
 import {useAtomValue, useSetAtom} from "jotai"
@@ -219,12 +218,6 @@ const TurnMessageAdapter: React.FC<Props> = ({
     const [viewMode, setViewMode] = useState<ViewMode>("text")
     const isCodeMode = viewMode === "json" || viewMode === "yaml"
     const editorLanguage = viewMode === "yaml" ? "yaml" : "json"
-
-    const setMarkdownView = useSetAtom(markdownViewAtom(editorIdRef.current))
-
-    useEffect(() => {
-        setMarkdownView(viewMode === "markdown")
-    }, [setMarkdownView, viewMode])
 
     const effectiveDisabled = Boolean(disabled)
     const isUserRole = kind === "user" && !isToolKind
@@ -663,6 +656,7 @@ const TurnMessageAdapter: React.FC<Props> = ({
                             isJSON={isCodeMode}
                             isTool={isCodeMode}
                             language={editorLanguage}
+                            markdownView={viewMode === "markdown"}
                             onFocusChange={handleEditorFocusChange}
                             text={p?.json}
                             enableTokens={messageProps?.enableTokens ?? !isCodeMode}
@@ -756,6 +750,7 @@ const TurnMessageAdapter: React.FC<Props> = ({
                         state={editorState}
                         isJSON={isCodeMode}
                         language={editorLanguage}
+                        markdownView={viewMode === "markdown"}
                         enableTokens={messageProps?.enableTokens ?? !isCodeMode}
                         headerRight={
                             <TurnMessageHeaderOptions

--- a/web/packages/agenta-ui/src/ChatMessage/components/ChatMessageEditor.tsx
+++ b/web/packages/agenta-ui/src/ChatMessage/components/ChatMessageEditor.tsx
@@ -1,9 +1,11 @@
-import React, {useMemo} from "react"
+import React, {useEffect, useLayoutEffect, useMemo} from "react"
 
 import {MESSAGE_CONTENT_SCHEMA} from "@agenta/shared/schemas"
+import {useLexicalComposerContext} from "@lexical/react/LexicalComposerContext"
 
 import {SimpleDropdownSelect} from "../../components/presentational/select"
 import {EditorProvider} from "../../Editor/Editor"
+import {SET_MARKDOWN_VIEW} from "../../Editor/plugins/markdown/commands"
 import {SharedEditor, type SharedEditorProps} from "../../SharedEditor"
 import {cn, flexLayouts, gapClasses, justifyClasses} from "../../utils/styles"
 
@@ -64,6 +66,41 @@ export interface ChatMessageEditorProps {
     maxPasteChars?: number
     /** Optional hook for custom handling when a paste exceeds the limit. */
     onPasteLimitExceeded?: SharedEditorProps["onPasteLimitExceeded"]
+    /**
+     * When true, render content as raw markdown source; when false, render rich text.
+     * Setting only the `markdownViewAtom` CSS flag is not enough — the Lexical
+     * editor needs a `SET_MARKDOWN_VIEW` command dispatch to actually swap
+     * between rich-text nodes and a markdown code node. This prop wires that
+     * up via an internal synchronizer mounted inside the EditorProvider.
+     */
+    markdownView?: boolean
+}
+
+/**
+ * Dispatches `SET_MARKDOWN_VIEW` whenever `enabled` changes so the Lexical
+ * editor actually swaps between rich-text and markdown-source views.
+ *
+ * Mirrors VariableControlAdapter's MarkdownViewSynchronizer: a `useLayoutEffect`
+ * handles updates after the MarkdownPlugin handler is registered, and a
+ * deferred `useEffect` + `requestAnimationFrame` re-dispatches once after paint
+ * to cover the initial mount race where this component's layout effect can
+ * fire before the descendant MarkdownPlugin has registered the command.
+ */
+const MarkdownViewSynchronizer: React.FC<{enabled: boolean}> = ({enabled}) => {
+    const [editor] = useLexicalComposerContext()
+
+    useLayoutEffect(() => {
+        editor.dispatchCommand(SET_MARKDOWN_VIEW, enabled)
+    }, [editor, enabled])
+
+    useEffect(() => {
+        const frameId = requestAnimationFrame(() => {
+            editor.dispatchCommand(SET_MARKDOWN_VIEW, enabled)
+        })
+        return () => cancelAnimationFrame(frameId)
+    }, [editor, enabled])
+
+    return null
 }
 
 /**
@@ -181,12 +218,14 @@ const ChatMessageEditor: React.FC<ChatMessageEditorProps> = ({
     isJSON,
     isTool,
     language = "json",
+    markdownView = false,
     ...props
 }) => {
+    const isCodeMode = Boolean(isTool || isJSON)
     return (
         <EditorProvider
-            codeOnly={isTool || isJSON}
-            language={isTool || isJSON ? language : undefined}
+            codeOnly={isCodeMode}
+            language={isCodeMode ? language : undefined}
             enableTokens={Boolean(props.enableTokens)}
             tokens={props.tokens}
             templateFormat={props.templateFormat}
@@ -196,6 +235,11 @@ const ChatMessageEditor: React.FC<ChatMessageEditorProps> = ({
             loadingFallback={props.loadingFallback}
         >
             <ChatMessageEditorInner isJSON={isJSON} language={language} {...props} />
+            {/* Sync markdown view AFTER ChatMessageEditorInner so descendant
+                MarkdownPlugin has registered SET_MARKDOWN_VIEW by the time the
+                synchronizer's effects fire. Only mounted in rich-text mode —
+                code mode editors don't include MarkdownPlugin. */}
+            {!isCodeMode && <MarkdownViewSynchronizer enabled={markdownView} />}
         </EditorProvider>
     )
 }

--- a/web/packages/agenta-ui/src/ChatMessage/components/ChatMessageList.tsx
+++ b/web/packages/agenta-ui/src/ChatMessage/components/ChatMessageList.tsx
@@ -12,12 +12,10 @@ import {
 } from "@agenta/shared/utils"
 import {Copy, MinusCircle, Plus} from "@phosphor-icons/react"
 import {Button, Tooltip} from "antd"
-import {useSetAtom} from "jotai"
 
 import {CollapseToggleButton, getCollapseStyle} from "../../components/presentational/buttons"
 import {ViewModeDropdown} from "../../drill-in/core/ViewModeDropdown"
 import {getViewOptions, type ViewMode} from "../../drill-in/utils/getViewOptions"
-import {markdownViewAtom} from "../../Editor/state/assets/atoms"
 import {message, modal} from "../../utils/appMessageContext"
 import {cn, flexLayouts, gapClasses} from "../../utils/styles"
 import {createSnippetPdfAttachment} from "../utils/snippetAttachment"
@@ -46,6 +44,10 @@ const ChatMessageItem: React.FC<{
     tokens?: string[]
     loadingFallback: "skeleton" | "none" | "static"
     maxPasteChars?: number
+    /** Restrict the view-mode dropdown to a subset (e.g. ["text", "markdown"]
+     *  for config messages where JSON/YAML modes are noise). When omitted,
+     *  the dropdown shows whatever getViewOptions returns for the content. */
+    viewModes?: ChatViewMode[]
     ImagePreview?: React.ComponentType<{
         src: string
         alt: string
@@ -76,6 +78,7 @@ const ChatMessageItem: React.FC<{
     tokens,
     loadingFallback,
     maxPasteChars,
+    viewModes,
     ImagePreview,
     onRoleChange,
     onTextChange,
@@ -98,20 +101,12 @@ const ChatMessageItem: React.FC<{
     const attachments = getAttachments(msg.content ?? null)
     const hasAttachmentsFlag = attachments.length > 0
 
-    // Mirror TurnMessageAdapter: sync Lexical's `markdownView` atom from the
-    // parent-owned viewMode so the editor's CSS class flips when the dropdown
-    // moves into/out of "markdown". The `key={editorId-viewMode}` on the
-    // editor remounts it on every switch so the markdown plugin re-evaluates
-    // on a fresh instance — no manual command dispatch needed.
-    const setMarkdownView = useSetAtom(markdownViewAtom(editorId))
-    useEffect(() => {
-        setMarkdownView(viewMode === "markdown")
-    }, [setMarkdownView, viewMode])
-
-    const viewOptions = useMemo(
-        () => getViewOptions(textContent) as {value: ChatViewMode; label: string}[],
-        [textContent],
-    )
+    const viewOptions = useMemo(() => {
+        const all = getViewOptions(textContent) as {value: ChatViewMode; label: string}[]
+        if (!viewModes || viewModes.length === 0) return all
+        const allowed = new Set(viewModes)
+        return all.filter((opt) => allowed.has(opt.value))
+    }, [textContent, viewModes])
 
     const handleCreateSnippetFromPaste = useCallback(
         ({
@@ -178,6 +173,7 @@ const ChatMessageItem: React.FC<{
                 onChangeText={(text) => onTextChange(index, text)}
                 isJSON={isCodeMode}
                 language={editorLanguage}
+                markdownView={viewMode === "markdown"}
                 enableTokens={enableTokens && !isCodeMode}
                 templateFormat={templateFormat}
                 tokens={tokens}
@@ -300,6 +296,10 @@ export interface ChatMessageListProps {
     loadingFallback?: "skeleton" | "none" | "static"
     /** Block paste operations that would make a message exceed this many characters. */
     maxPasteChars?: number
+    /** Restrict the per-message view-mode dropdown to a subset. Pass
+     *  ["text", "markdown"] for plain-text config messages where JSON/YAML
+     *  modes are noise. When omitted, all four modes are offered. */
+    viewModes?: ChatViewMode[]
 }
 
 /**
@@ -330,6 +330,7 @@ export const ChatMessageList: React.FC<ChatMessageListProps> = ({
     defaultMinimized = false,
     loadingFallback = "skeleton",
     maxPasteChars,
+    viewModes,
 }) => {
     const listInstanceIdRef = useRef(generateKey())
     // Maintain stable React keys for each message position.
@@ -476,6 +477,7 @@ export const ChatMessageList: React.FC<ChatMessageListProps> = ({
                         tokens={tokens}
                         loadingFallback={loadingFallback}
                         maxPasteChars={maxPasteChars}
+                        viewModes={viewModes}
                         ImagePreview={ImagePreview}
                         onRoleChange={handleRoleChange}
                         onTextChange={handleTextChange}

--- a/web/packages/agenta-ui/src/drill-in/FieldRenderers/JsonObjectField.tsx
+++ b/web/packages/agenta-ui/src/drill-in/FieldRenderers/JsonObjectField.tsx
@@ -5,13 +5,10 @@
  * with ChatMessageEditor from @agenta/ui, otherwise uses JSON editor.
  */
 
-import {useEffect, useMemo, useState} from "react"
-
-import {useSetAtom} from "jotai"
+import {useMemo, useState} from "react"
 
 import {ChatMessageEditor} from "@agenta/ui/chat-message"
 
-import {markdownViewAtom} from "../../Editor/state/assets/atoms"
 import {useDrillInUI} from "../context/DrillInUIContext"
 import {ViewModeDropdown} from "../core/ViewModeDropdown"
 import {getViewOptions, type ViewMode} from "../utils/getViewOptions"
@@ -54,11 +51,6 @@ function ChatMessageObjectField({
     const isCodeMode = viewMode === "json" || viewMode === "yaml"
     const editorLanguage: "json" | "yaml" = viewMode === "yaml" ? "yaml" : "json"
 
-    const setMarkdownView = useSetAtom(markdownViewAtom(messageEditorId))
-    useEffect(() => {
-        setMarkdownView(viewMode === "markdown")
-    }, [setMarkdownView, viewMode])
-
     const viewOptions = useMemo(
         () => getViewOptions(content) as {value: ChatViewMode; label: string}[],
         [content],
@@ -73,6 +65,7 @@ function ChatMessageObjectField({
             disabled={!editable}
             isJSON={isCodeMode}
             language={editorLanguage}
+            markdownView={viewMode === "markdown"}
             enableTokens={!isCodeMode}
             templateFormat="curly"
             onChangeRole={(newRole: string) => {


### PR DESCRIPTION
## Summary
fixes broken markdown / text switch

## Testing
### QA follow-up
check evaluator and app playgrounds

## Demo
<img width="793" height="466" alt="Screenshot 2026-05-28 at 23 16 44" src="https://github.com/user-attachments/assets/877bfa4d-7bfd-4720-a282-b10bd6fb1848" />
<img width="789" height="499" alt="Screenshot 2026-05-28 at 23 16 49" src="https://github.com/user-attachments/assets/3373042b-948d-4579-9f3b-a71fcba631fa" />

## Checklist
- [x] I have included a video or screen recording for UI changes, or marked Demo as N/A
- [x] Relevant tests pass locally
- [x] Relevant linting and formatting pass locally
- [x] I have signed the CLA, or I will sign it when the bot prompts me

## Contributor Resources
- [Contributing guide](https://agenta.ai/docs/contributing/overview)
- [Creating your first PR](https://agenta.ai/docs/contributing/first-pr)
- [Development mode](https://agenta.ai/docs/contributing/guides/development-mode)
- [Testing](https://agenta.ai/docs/contributing/guides/testing)
- [Formatting and linting](https://agenta.ai/docs/contributing/guides/formatting-and-linting)
- [Slack support](https://join.slack.com/t/agenta-hq/shared_invite/zt-37pnbp5s6-mbBrPL863d_oLB61GSNFjw)
