### PR TITLE
fix(frontend): render tool message body in tracing beautified view

### DIFF
--- a/web/oss/src/components/DrillInView/BeautifiedJsonView.tsx
+++ b/web/oss/src/components/DrillInView/BeautifiedJsonView.tsx
@@ -302,6 +302,13 @@ const getMessageContentDisplay = (
         if (textPart) textParts.push(textPart)
     }
 
+    // Nothing recognizable inside the parsed parts (e.g. a tool message whose
+    // content is a JSON array of `{response: ...}` envelopes we don't know).
+    // Fall back to the raw payload so the bubble isn't empty.
+    if (textParts.length === 0 && structuredParts.length === 0) {
+        return {text: getMessageText(content), structuredParts: []}
+    }
+
     return {text: textParts.join("\n"), structuredParts}
 }
 


### PR DESCRIPTION
## Symptom

In the Tracing Drawer's **Beautified** view, a chat span containing a `role: \"tool\"` message would show the role label bubble but **no body** — even when `content` was clearly populated.

Reproducing trace (the user's example): a `tool` message whose `content` is a JSON-stringified array of `{response: [{type: \"text\", text: \"...\"}, ...]}` envelopes (the retrieval result returned from a custom vector-store tool). Nothing rendered under the bubble.

## Root cause

In `web/oss/src/components/DrillInView/BeautifiedJsonView.tsx`:

1. `getMessageContentDisplay` calls `getMessageContentParts`. Because `content` was a JSON-stringified **array**, `tryParseJsonString` succeeded and returned the parsed array as `parts`.
2. Each part `{response: [...]}` had no recognized envelope (`type: \"text\"`, `type: \"tool-result\"`, etc.) and no top-level `text` / `content` string — so `getStructuredMessagePart` and `getMessagePartText` returned `null`.
3. `getMessageContentDisplay` returned `{text: \"\", structuredParts: []}` — the raw string was discarded.
4. In `MessageNodeRow`, `parsedContent` short-circuits on empty `text`, and the body's `!hasText && !hasToolCalls && !hasStructuredParts` guard returned `null`.

## Fix

One added fallback inside `getMessageContentDisplay`: when parts processing produces no text and no structured parts, route the original `content` through `getMessageText`. That repopulates `text` with the raw JSON string. The existing `parsedContent` branch in `MessageNodeRow` then JSON-parses it and renders the result via `RecursiveNode` + `simplifyValue` (which already unwraps the inner `{type: \"text\", text: \"...\"}` parts into readable strings).

### Before / after

- **Before:** tool bubble is empty.
- **After:** tool bubble shows an expandable tree of the retrieved documents, with each text part inlined.

## Test plan

- [ ] Open the Tracing Drawer on a trace with a `role: \"tool\"` message whose `content` is a JSON-stringified array of unknown envelopes (e.g. RAG retrieval result). Switch to Beautified view. Body now renders.
- [ ] System / user / assistant bubbles with plain string content still render correctly.
- [ ] Assistant message with `tool_calls` still renders the tool-call list.
- [ ] Tool message with a recognized `tool-result` envelope (`{type: \"tool-result\", output: {...}}`) still hits the structured-parts path (not the new fallback).
- [ ] Tool message with a plain non-JSON string still renders as text.

## Notes

- `BeautifiedJsonView.tsx` lives in the app layer (`web/oss/src/components/DrillInView/`) and has no existing unit-test suite, so this was verified by code reading + lint; no test was added.
- Lint clean: \`pnpm lint-fix\` from \`web/\`.