### PR TITLE
[Fe fix] Evaluation scenarios filter display names

### DIFF
--- a/web/oss/src/components/EvalRunDetails/etl/ScenarioFilterBar.tsx
+++ b/web/oss/src/components/EvalRunDetails/etl/ScenarioFilterBar.tsx
@@ -135,13 +135,33 @@ const ScenarioFilterBar = ({runId}: ScenarioFilterBarProps) => {
         [schema, resolveValueType],
     )
     const fieldByKey = useMemo(() => new Map(fields.map((f) => [encodeField(f), f])), [fields])
+
+    // The filter-schema group label is a humanified slug (e.g. "Rubic
+    // Zn3a"). The table column headers resolve the evaluator's configured
+    // name onto every column as `evaluatorName` — reuse that here, keyed by
+    // evaluator slug, so filter options read as evaluator names not slugs.
+    const evaluatorNameBySlug = useMemo(() => {
+        const map = new Map<string, string>()
+        for (const col of columnResult?.columns ?? []) {
+            if (col.evaluatorSlug && col.evaluatorName) {
+                map.set(col.evaluatorSlug, col.evaluatorName)
+            }
+        }
+        return map
+    }, [columnResult])
+
     const fieldOptions = useMemo(
         () =>
-            fields.map((f) => ({
-                value: encodeField(f),
-                label: `${f.groupLabel} · ${f.label}`,
-            })),
-        [fields],
+            fields.map((f) => {
+                const groupLabel =
+                    (f.groupSlug ? evaluatorNameBySlug.get(f.groupSlug) : undefined) ??
+                    f.groupLabel
+                return {
+                    value: encodeField(f),
+                    label: `${groupLabel} · ${f.label}`,
+                }
+            }),
+        [fields, evaluatorNameBySlug],
     )
 
     // Run graph carries no filterable columns — hide the bar entirely.

--- a/web/oss/src/components/EvalRunDetails/etl/ScenarioFilterBar.tsx
+++ b/web/oss/src/components/EvalRunDetails/etl/ScenarioFilterBar.tsx
@@ -154,8 +154,7 @@ const ScenarioFilterBar = ({runId}: ScenarioFilterBarProps) => {
         () =>
             fields.map((f) => {
                 const groupLabel =
-                    (f.groupSlug ? evaluatorNameBySlug.get(f.groupSlug) : undefined) ??
-                    f.groupLabel
+                    (f.groupSlug ? evaluatorNameBySlug.get(f.groupSlug) : undefined) ?? f.groupLabel
                 return {
                     value: encodeField(f),
                     label: `${groupLabel} · ${f.label}`,


### PR DESCRIPTION
## Summary
was using slugs, now using names

## Testing
### QA follow-up
check filter options for eval run scenario table filtering

## Checklist
- [x] I have included a video or screen recording for UI changes, or marked Demo as N/A
- [x] Relevant tests pass locally
- [x] Relevant linting and formatting pass locally
- [x] I have signed the CLA, or I will sign it when the bot prompts me

## Contributor Resources
- [Contributing guide](https://agenta.ai/docs/contributing/overview)
- [Creating your first PR](https://agenta.ai/docs/contributing/first-pr)
- [Development mode](https://agenta.ai/docs/contributing/guides/development-mode)
- [Testing](https://agenta.ai/docs/contributing/guides/testing)
- [Formatting and linting](https://agenta.ai/docs/contributing/guides/formatting-and-linting)
- [Slack support](https://join.slack.com/t/agenta-hq/shared_invite/zt-37pnbp5s6-mbBrPL863d_oLB61GSNFjw)
