### PR TITLE
[FE Fix] Fix evaluation scenario output cells in comparison mode

### DIFF
--- a/web/oss/src/components/EvalRunDetails/Table.tsx
+++ b/web/oss/src/components/EvalRunDetails/Table.tsx
@@ -18,6 +18,7 @@ import {
 } from "@/oss/components/InfiniteVirtualTable/hooks/useTableExport"
 
 import useComparisonPaginations from "../EvalRunDetails2/hooks/useComparisonPaginations"
+import useComparisonSchemas from "../EvalRunDetails2/hooks/useComparisonSchemas"
 
 import {MAX_COMPARISON_RUNS, compareRunIdsAtom, getComparisonColor} from "./atoms/compare"
 import {effectiveProjectIdAtom} from "./atoms/run"
@@ -149,7 +150,11 @@ const EvalRunDetailsTable = ({
         })
     }, [active, comparePaginations, compareSlots])
 
-    const etlColumns = useEtlColumns({projectId, runId, schema: runSchema})
+    // Each comparison run's own schema — comparison rows resolve their
+    // application/output cells against it (step keys differ from base run).
+    const comparisonSchemas = useComparisonSchemas({compareSlots})
+
+    const etlColumns = useEtlColumns({projectId, runId, schema: runSchema, comparisonSchemas})
 
     // Page-level hydrate — predicate-aware: with an active filter it
     // fetches the entity slices the filter needs to be evaluated; with no
@@ -390,12 +395,42 @@ const EvalRunDetailsTable = ({
             const hasComparisons = compareRunIds.length > 0
             const shouldCompare = isBaseRow && hasComparisons
 
+            // Resolve each compared run's matching scenarioId from the rows the
+            // table already paginated, using the same testcaseId → scenarioIndex
+            // matching as mergedRows. Carried forward so the focus drawer renders
+            // compare outputs without re-resolving from an orphaned paginated atom.
+            let compareScenarioIds: Record<string, string | null> | undefined
+            if (shouldCompare) {
+                const baseTestcaseId = record.testcaseId
+                const baseScenarioIndex = record.scenarioIndex
+                const resolved: Record<string, string | null> = {}
+                compareSlots.forEach((slotRunId, idx) => {
+                    if (!slotRunId) return
+                    const slotRows = compareRowsBySlot[idx] ?? []
+                    let counterpart: PreviewTableRow | undefined
+                    if (baseTestcaseId) {
+                        counterpart = slotRows.find(
+                            (row) => row && !row.__isSkeleton && row.testcaseId === baseTestcaseId,
+                        )
+                    }
+                    if (!counterpart && typeof baseScenarioIndex === "number") {
+                        counterpart = slotRows.find(
+                            (row) =>
+                                row && !row.__isSkeleton && row.scenarioIndex === baseScenarioIndex,
+                        )
+                    }
+                    resolved[slotRunId] = counterpart?.scenarioId ?? counterpart?.id ?? null
+                })
+                compareScenarioIds = resolved
+            }
+
             const focusTarget = {
                 focusRunId: targetRunId,
                 focusScenarioId: scenarioId,
                 compareMode: shouldCompare,
                 testcaseId: shouldCompare ? record.testcaseId : undefined,
                 scenarioIndex: shouldCompare ? record.scenarioIndex : undefined,
+                compareScenarioIds,
             }
             if (process.env.NEXT_PUBLIC_EVAL_RUN_DEBUG === "true") {
                 console.info("[EvalRunDetails2][Table] row click", {focusTarget, record})
@@ -405,7 +440,7 @@ const EvalRunDetailsTable = ({
             // (the table has an isolated Jotai Provider, so useSetAtom would write to the wrong store)
             patchFocusDrawerQueryParams(focusTarget)
         },
-        [runId, compareRunIds],
+        [runId, compareRunIds, compareSlots, compareRowsBySlot],
     )
 
     const handleLoadMore = useCallback(() => {

--- a/web/oss/src/components/EvalRunDetails/etl/useEtlColumns.tsx
+++ b/web/oss/src/components/EvalRunDetails/etl/useEtlColumns.tsx
@@ -39,6 +39,13 @@ export interface UseEtlColumnsArgs {
     projectId: string | null
     runId: string | null
     schema: RunSchema | null
+    /**
+     * Each comparison run's own schema, keyed by runId. Comparison rows
+     * resolve their application/output cells against the comparison run's
+     * schema — its invocation step keys (and app slug) differ from the base
+     * run's, so resolving against the base schema yields no match ("—").
+     */
+    comparisonSchemas?: Record<string, RunSchema | null>
 }
 
 /**
@@ -49,6 +56,7 @@ export const useEtlColumns = ({
     projectId,
     runId,
     schema,
+    comparisonSchemas,
 }: UseEtlColumnsArgs): ColumnsType<PreviewTableRow> => {
     return useMemo<ColumnsType<PreviewTableRow>>(() => {
         if (!schema || !projectId || !runId) return []
@@ -99,17 +107,34 @@ export const useEtlColumns = ({
                         if (record.__isSkeleton || !record.scenarioId) {
                             return <EtlSkeletonCell />
                         }
+                        // Comparison rows carry their own runId. Resolve them
+                        // against the comparison run's *own* schema — its
+                        // invocation step keys differ from the base run's, so
+                        // resolving against the base schema finds no result
+                        // and the cell renders "—".
+                        const cellRunId = record.runId ?? runId
+                        const isComparison = cellRunId !== runId
+                        const cellSchema = isComparison
+                            ? (comparisonSchemas?.[cellRunId] ?? null)
+                            : schema
+                        // Comparison run's schema not resolved yet — keep a
+                        // skeleton rather than flashing "—".
+                        if (isComparison && !cellSchema) {
+                            return <EtlSkeletonCell />
+                        }
                         return (
                             <EtlResolvedCell
                                 projectId={projectId}
-                                // Comparison rows carry their own runId.
-                                runId={record.runId ?? runId}
+                                runId={cellRunId}
                                 scenarioId={record.scenarioId}
                                 scenarioStatus={record.status}
                                 columnKind={leaf.kind}
-                                columnGroupSlug={leaf.groupSlug}
+                                // Match comparison columns by kind + name only:
+                                // the group slug is derived from the app slug,
+                                // which differs per run.
+                                columnGroupSlug={isComparison ? null : leaf.groupSlug}
                                 columnName={leaf.name}
-                                schema={schema}
+                                schema={cellSchema}
                             />
                         )
                     },
@@ -124,5 +149,5 @@ export const useEtlColumns = ({
                 children,
             }
         })
-    }, [projectId, runId, schema])
+    }, [projectId, runId, schema, comparisonSchemas])
 }

--- a/web/oss/src/components/EvalRunDetails/state/focusDrawerAtom.ts
+++ b/web/oss/src/components/EvalRunDetails/state/focusDrawerAtom.ts
@@ -11,6 +11,14 @@ export interface FocusTarget {
     compareMode?: boolean
     testcaseId?: string | null
     scenarioIndex?: number | null
+    /**
+     * Compared-run scenarioIds resolved by the table at click time, keyed by
+     * compare runId. The table is the single place that has correctly
+     * paginated + matched compare rows; carrying the resolved ids forward lets
+     * the focus drawer render compare outputs without re-resolving them from a
+     * separately-keyed (and never-populated) paginated atom instance.
+     */
+    compareScenarioIds?: Record<string, string | null>
 }
 
 export interface FocusDrawerState extends FocusTarget {
@@ -29,17 +37,31 @@ export const focusDrawerAtom = atomWithImmer<FocusDrawerState>(initialFocusDrawe
 
 export const focusScenarioAtom = atom<FocusTarget | null>((get) => {
     const state = get(focusDrawerAtom) as FocusDrawerState
-    const {focusRunId, focusScenarioId, compareMode, testcaseId, scenarioIndex} = state
+    const {
+        focusRunId,
+        focusScenarioId,
+        compareMode,
+        testcaseId,
+        scenarioIndex,
+        compareScenarioIds,
+    } = state
     if (!focusScenarioId) return null
-    return {focusRunId, focusScenarioId, compareMode, testcaseId, scenarioIndex}
+    return {focusRunId, focusScenarioId, compareMode, testcaseId, scenarioIndex, compareScenarioIds}
 })
 
 export const isFocusDrawerOpenAtom = atom((get) => (get(focusDrawerAtom) as FocusDrawerState).open)
 
 export const focusDrawerTargetAtom = atom<FocusTarget>((get) => {
     const state = get(focusDrawerAtom) as FocusDrawerState
-    const {focusRunId, focusScenarioId, compareMode, testcaseId, scenarioIndex} = state
-    return {focusRunId, focusScenarioId, compareMode, testcaseId, scenarioIndex}
+    const {
+        focusRunId,
+        focusScenarioId,
+        compareMode,
+        testcaseId,
+        scenarioIndex,
+        compareScenarioIds,
+    } = state
+    return {focusRunId, focusScenarioId, compareMode, testcaseId, scenarioIndex, compareScenarioIds}
 })
 
 export const setFocusDrawerTargetAtom = atom(null, (_get, set, target: FocusTarget) => {
@@ -58,6 +80,7 @@ export const setFocusDrawerTargetAtom = atom(null, (_get, set, target: FocusTarg
         draft.compareMode = target.compareMode
         draft.testcaseId = target.testcaseId
         draft.scenarioIndex = target.scenarioIndex
+        draft.compareScenarioIds = target.compareScenarioIds
     })
 })
 
@@ -78,6 +101,7 @@ export const openFocusDrawerAtom = atom(null, (_get, set, target: FocusTarget) =
             draft.compareMode = target.compareMode
             draft.testcaseId = target.testcaseId
             draft.scenarioIndex = target.scenarioIndex
+            draft.compareScenarioIds = target.compareScenarioIds
         }
     })
 })
@@ -108,6 +132,7 @@ export const applyFocusDrawerStateAtom = atom(
             draft.compareMode = next.compareMode
             draft.testcaseId = next.testcaseId
             draft.scenarioIndex = next.scenarioIndex
+            draft.compareScenarioIds = next.compareScenarioIds
         })
     },
 )
@@ -159,7 +184,24 @@ export const compareScenarioMatchesAtom = atom<CompareScenarioInfo[]>((get) => {
             return
         }
 
-        // Try to find matching scenario in this run
+        // Prefer the scenarioId the table already resolved at click time. The
+        // table paginates compare runs at its own pageSize, so re-resolving
+        // here via combinedRowsAtomFamily with a different pageSize reads an
+        // orphaned (never-populated) atom instance and yields null — leaving
+        // compare outputs blank. The carried-forward id avoids that entirely.
+        const providedScenarioId = focus.compareScenarioIds?.[compareRunId]
+        if (providedScenarioId) {
+            results.push({
+                runId: compareRunId,
+                scenarioId: providedScenarioId,
+                compareIndex: idx + 1,
+            })
+            return
+        }
+
+        // Fallback (e.g. reload with the drawer reopened from URL, where the
+        // table-resolved ids aren't in memory): match against the paginated
+        // rows directly.
         const combinedRowsAtom = evaluationPreviewTableStore.atoms.combinedRowsAtomFamily({
             scopeId: compareRunId,
             pageSize: 1000, // Use a large page size to search through scenarios

--- a/web/oss/src/components/EvalRunDetails/state/urlFocusDrawer.ts
+++ b/web/oss/src/components/EvalRunDetails/state/urlFocusDrawer.ts
@@ -102,6 +102,9 @@ export const syncFocusDrawerStateFromUrl = (nextUrl?: string) => {
             compareMode: currentState.compareMode,
             testcaseId: currentState.testcaseId,
             scenarioIndex: currentState.scenarioIndex,
+            // Not URL-serialized — preserve the in-memory ids across shallow
+            // route changes so compare outputs survive a router callback.
+            compareScenarioIds: currentState.compareScenarioIds,
         }
 
         const alreadyOpen =
@@ -158,6 +161,7 @@ export const patchFocusDrawerQueryParams = (target: FocusTarget) => {
             compareMode: target.compareMode,
             testcaseId: target.testcaseId,
             scenarioIndex: target.scenarioIndex,
+            compareScenarioIds: target.compareScenarioIds,
         }
         store.set(applyFocusDrawerStateAtom, {
             ...nextTarget,

--- a/web/oss/src/components/EvalRunDetails2/hooks/useComparisonSchemas.ts
+++ b/web/oss/src/components/EvalRunDetails2/hooks/useComparisonSchemas.ts
@@ -1,0 +1,51 @@
+import {useMemo} from "react"
+
+import type {RunSchema} from "@agenta/entities/evaluationRun/etl"
+import {atom} from "jotai"
+import {LOW_PRIORITY, useAtomValueWithSchedule} from "jotai-scheduler"
+
+import {evaluationRunQueryAtomFamily} from "@/oss/components/EvalRunDetails/atoms/table"
+
+interface UseComparisonSchemasArgs {
+    compareSlots: (string | null)[]
+}
+
+/**
+ * Resolve each comparison run's own schema (steps + mappings), keyed by
+ * runId.
+ *
+ * Comparison-row application/output cells must resolve against the
+ * *comparison* run's schema — its invocation step keys differ from the base
+ * run's, so `resolveMappings` against the base schema finds no matching
+ * result and the cell renders "—". This hook fetches every compare slot's
+ * run payload (cached via `evaluationRunQueryAtomFamily`) and extracts its
+ * schema so the table can hand each comparison row the right one.
+ *
+ * Reads all slots through a single derived atom (same approach as
+ * `useComparisonPaginations`) to avoid calling a hook per slot.
+ */
+const useComparisonSchemas = ({
+    compareSlots,
+}: UseComparisonSchemasArgs): Record<string, RunSchema | null> => {
+    const schemasAtom = useMemo(
+        () =>
+            atom((get) => {
+                const out: Record<string, RunSchema | null> = {}
+                for (const runId of compareSlots) {
+                    if (!runId) continue
+                    const query = get(evaluationRunQueryAtomFamily(runId))
+                    const data = query.data?.rawRun?.data
+                    const steps = data?.steps
+                    const mappings = data?.mappings
+                    out[runId] =
+                        Array.isArray(steps) && Array.isArray(mappings) ? {steps, mappings} : null
+                }
+                return out
+            }),
+        [compareSlots],
+    )
+
+    return useAtomValueWithSchedule(schemasAtom, {priority: LOW_PRIORITY})
+}
+
+export default useComparisonSchemas


### PR DESCRIPTION
## Summary
compared scenarios were not showing outputs, now they should

## Testing
### QA follow-up
check evaluation run scenarios table in compare mode

## Demo
<img width="1102" height="802" alt="Screenshot 2026-05-29 at 10 56 40" src="https://github.com/user-attachments/assets/68efe2a4-5712-480f-ab46-4bc36461aabe" />

## Checklist
- [x] I have included a video or screen recording for UI changes, or marked Demo as N/A
- [x] Relevant tests pass locally
- [x] Relevant linting and formatting pass locally
- [x] I have signed the CLA, or I will sign it when the bot prompts me

## Contributor Resources
- [Contributing guide](https://agenta.ai/docs/contributing/overview)
- [Creating your first PR](https://agenta.ai/docs/contributing/first-pr)
- [Development mode](https://agenta.ai/docs/contributing/guides/development-mode)
- [Testing](https://agenta.ai/docs/contributing/guides/testing)
- [Formatting and linting](https://agenta.ai/docs/contributing/guides/formatting-and-linting)
- [Slack support](https://join.slack.com/t/agenta-hq/shared_invite/zt-37pnbp5s6-mbBrPL863d_oLB61GSNFjw)
