### PR TITLE
[FE Fix]: Rename providers table Status column to API Key

### DIFF
--- a/web/oss/src/components/pages/settings/Secrets/SecretProviderTable/index.tsx
+++ b/web/oss/src/components/pages/settings/Secrets/SecretProviderTable/index.tsx
@@ -45,9 +45,9 @@ const SecretProviderTable = ({type}: {type: "standard" | "custom"}) => {
             ...(!isCustom
                 ? [
                       {
-                          title: "Status",
-                          dataIndex: "status",
-                          key: "status",
+                          title: "API Key",
+                          dataIndex: "key",
+                          key: "apiKey",
                           onHeaderCell: () => ({
                               style: {minWidth: 160},
                           }),


### PR DESCRIPTION
## Summary
The standard-providers table column was labeled Status but its cell renders the masked API key (or a Configure button), never a status. Renamed the header to API Key and aligned dataIndex with the key field.

## Testing
### QA follow-up
check the table in settings

## Checklist
- [ ] I have included a video or screen recording for UI changes, or marked Demo as N/A
- [x] Relevant tests pass locally
- [x] Relevant linting and formatting pass locally
- [x] I have signed the CLA, or I will sign it when the bot prompts me

## Contributor Resources
- [Contributing guide](https://agenta.ai/docs/contributing/overview)
- [Creating your first PR](https://agenta.ai/docs/contributing/first-pr)
- [Development mode](https://agenta.ai/docs/contributing/guides/development-mode)
- [Testing](https://agenta.ai/docs/contributing/guides/testing)
- [Formatting and linting](https://agenta.ai/docs/contributing/guides/formatting-and-linting)
- [Slack support](https://join.slack.com/t/agenta-hq/shared_invite/zt-37pnbp5s6-mbBrPL863d_oLB61GSNFjw)
