### PR TITLE
[FE Fix]: Refresh prompts page table after prompt creation

### DIFF
--- a/web/oss/src/components/WorkflowRevisionDrawerWrapper/index.tsx
+++ b/web/oss/src/components/WorkflowRevisionDrawerWrapper/index.tsx
@@ -69,6 +69,7 @@ import {
 import EvaluatorPlaygroundHeader from "@/oss/components/Evaluators/components/ConfigureEvaluator/EvaluatorPlaygroundHeader"
 import {clearEvaluatorWorkflowCache} from "@/oss/components/Evaluators/store/evaluatorsPaginatedStore"
 import {invalidateAppManagementWorkflowQueries} from "@/oss/components/pages/app-management/store"
+import {invalidatePromptsWorkflowQueries} from "@/oss/components/pages/prompts/store"
 import CommitVariantChangesButton from "@/oss/components/Playground/Components/Modals/CommitVariantChangesModal/assets/CommitVariantChangesButton"
 import DeployVariantButton from "@/oss/components/Playground/Components/Modals/DeployVariantModal/assets/DeployVariantButton"
 import PlaygroundTestcaseEditor from "@/oss/components/Playground/Components/PlaygroundTestcaseEditor"
@@ -525,6 +526,13 @@ const useDrawerCreateCommitCallback = () => {
                     // (commit.ts:590) doesn't cover the app-management
                     // paginated store.
                     void invalidateAppManagementWorkflowQueries()
+
+                    // Same problem on the Prompts page: it reads its own
+                    // ["prompts-workflows"] query, which neither the shared
+                    // invalidation nor the app-management one touches. Without
+                    // this the new prompt is missing from the list until a
+                    // manual reload.
+                    void invalidatePromptsWorkflowQueries()
 
                     drawerCallbackRef.current?.({
                         newAppId,

--- a/web/oss/src/components/pages/prompts/store.ts
+++ b/web/oss/src/components/pages/prompts/store.ts
@@ -8,6 +8,7 @@
 
 import type {Workflow} from "@agenta/entities/workflow"
 import {queryWorkflows} from "@agenta/entities/workflow"
+import {queryClient} from "@agenta/shared/api"
 import {projectIdAtom} from "@agenta/shared/state"
 import {atom} from "jotai"
 import {atomWithQuery, queryClientAtom} from "jotai-tanstack-query"
@@ -192,3 +193,17 @@ export const refetchWorkflowsAtom = atom(null, (_get) => {
     const query = _get(workflowsQueryAtom)
     query.refetch()
 })
+
+/**
+ * Invalidate the prompts-page workflows list cache.
+ *
+ * Prompt creation runs inside the workflow drawer and then navigates to the
+ * playground, so the prompts page is unmounted while the new prompt commits.
+ * With `staleTime: 30_000` + `refetchOnWindowFocus: false`, React Query serves
+ * the stale list when the user returns and the new prompt is missing until a
+ * manual reload. Invalidating here marks the query stale so it refetches on the
+ * next mount (and refetches immediately if the page is still mounted).
+ */
+export async function invalidatePromptsWorkflowQueries() {
+    await queryClient.invalidateQueries({queryKey: ["prompts-workflows"], exact: false})
+}


### PR DESCRIPTION
## Summary
Added invalidatePromptsWorkflowQueries() and call it in the app-create commit branch so the prompts list refetches on next mount.

## Testing
### QA follow-up
create a new app from prompts page and check if the table shows correct data [after going back] without a manual reload

## Checklist
- [ ] I have included a video or screen recording for UI changes, or marked Demo as N/A
- [x] Relevant tests pass locally
- [x] Relevant linting and formatting pass locally
- [x] I have signed the CLA, or I will sign it when the bot prompts me

## Contributor Resources
- [Contributing guide](https://agenta.ai/docs/contributing/overview)
- [Creating your first PR](https://agenta.ai/docs/contributing/first-pr)
- [Development mode](https://agenta.ai/docs/contributing/guides/development-mode)
- [Testing](https://agenta.ai/docs/contributing/guides/testing)
- [Formatting and linting](https://agenta.ai/docs/contributing/guides/formatting-and-linting)
- [Slack support](https://join.slack.com/t/agenta-hq/shared_invite/zt-37pnbp5s6-mbBrPL863d_oLB61GSNFjw)
