### PR TITLE
ci(railway): surface preview deploy failures in CI logs + add retries + Fix wait for test

### DIFF
--- a/.github/workflows/41-railway-setup.yml
+++ b/.github/workflows/41-railway-setup.yml
@@ -73,9 +73,44 @@ jobs:
           chmod +x hosting/railway/oss/scripts/*.sh
           # shellcheck source=/dev/null
           source hosting/railway/oss/scripts/preview-resolve-env.sh
-          hosting/railway/oss/scripts/bootstrap.sh
+
+          # Persist the full bootstrap output so the "Upload setup log" step can
+          # publish it as an artifact, regardless of live-log truncation.
+          log_file="${GITHUB_WORKSPACE:-$PWD}/railway-setup-${PR_NUMBER:-unknown}.log"
+
+          set +e
+          hosting/railway/oss/scripts/bootstrap.sh 2>&1 | tee "$log_file"
+          setup_status=${PIPESTATUS[0]}
+          set -e
+
           echo "project_name=${RAILWAY_PROJECT_NAME}" >> "$GITHUB_OUTPUT"
           echo "environment_name=${RAILWAY_ENVIRONMENT_NAME}" >> "$GITHUB_OUTPUT"
+
+          if [ "$setup_status" -ne 0 ]; then
+            {
+              echo "### Railway Preview Setup — Failed"
+              echo
+              echo "<details><summary>Setup log (last 100 lines)</summary>"
+              echo
+              echo '```'
+              tail -n 100 "$log_file" 2>/dev/null
+              echo '```'
+              echo "</details>"
+            } >> "$GITHUB_STEP_SUMMARY"
+            exit "$setup_status"
+          fi
+
+      - name: Upload setup log
+        if: always()
+        # Diagnostics only: a failed/duplicate upload must never fail the job.
+        continue-on-error: true
+        uses: actions/upload-artifact@v4
+        with:
+          name: railway-setup-log-${{ inputs.pr_number }}
+          path: railway-setup-*.log
+          if-no-files-found: ignore
+          overwrite: true
+          retention-days: 7
 
       - name: Summary
         run: |

--- a/.github/workflows/43-railway-deploy.yml
+++ b/.github/workflows/43-railway-deploy.yml
@@ -182,7 +182,10 @@ jobs:
           # this job so the root cause (e.g. a Postgres crash-loop) is visible
           # here instead of only in the Railway dashboard.
           if [ "$deploy_failed" = "true" ]; then
-            dump_railway_logs
+            # Tee into the persisted log so the uploaded artifact and the
+            # step-summary tail include the Railway service logs too, not just
+            # the (possibly truncated) live Actions log.
+            dump_railway_logs 2>&1 | tee -a "$log_file"
           fi
 
           status_label="Deployed"

--- a/.github/workflows/43-railway-deploy.yml
+++ b/.github/workflows/43-railway-deploy.yml
@@ -112,11 +112,10 @@ jobs:
           # shellcheck source=/dev/null
           source hosting/railway/oss/scripts/preview-resolve-env.sh
 
-          log_file="$(mktemp)"
-          cleanup() {
-            rm -f "$log_file"
-          }
-          trap cleanup EXIT
+          # Keep the log in the workspace so the "Upload deploy log" step can
+          # publish it as an artifact. GitHub's live log can truncate streamed
+          # output, so we always persist a full copy.
+          log_file="${GITHUB_WORKSPACE:-$PWD}/railway-deploy-${PR_NUMBER:-unknown}.log"
 
           project="$RAILWAY_PROJECT_NAME"
           environment_name="$RAILWAY_ENVIRONMENT_NAME"
@@ -177,12 +176,54 @@ jobs:
           echo "environment_name=${environment_name}" >> "$GITHUB_OUTPUT"
           echo "railway_logs_url=${railway_logs_url}" >> "$GITHUB_OUTPUT"
 
-          trap - EXIT
-          cleanup
+          # Best-effort diagnostics; never let these change the step outcome.
+          set +e
+          # On failure, pull the tail of the key services' Railway logs into
+          # this job so the root cause (e.g. a Postgres crash-loop) is visible
+          # here instead of only in the Railway dashboard.
+          if [ "$deploy_failed" = "true" ]; then
+            dump_railway_logs
+          fi
+
+          status_label="Deployed"
+          [ "$deploy_failed" = "true" ] && status_label="Failed"
+          {
+            echo "### Railway Preview Deploy"
+            echo
+            echo "| Item | Value |"
+            echo "| --- | --- |"
+            echo "| PR | \`${PR_NUMBER}\` |"
+            echo "| Image tag | \`${IMAGE_TAG}\` |"
+            echo "| Status | ${status_label} |"
+            [ -n "$url" ] && echo "| Preview URL | ${url} |"
+            [ -n "$railway_logs_url" ] && echo "| Railway logs | [Open logs](${railway_logs_url}) |"
+            if [ "$deploy_failed" = "true" ]; then
+              echo
+              echo "<details><summary>Deploy log (last 100 lines)</summary>"
+              echo
+              echo '```'
+              tail -n 100 "$log_file" 2>/dev/null
+              echo '```'
+              echo "</details>"
+            fi
+          } >> "$GITHUB_STEP_SUMMARY"
+          set -e
 
           if [ "$deploy_failed" = "true" ]; then
             exit 1
           fi
+
+      - name: Upload deploy log
+        if: always()
+        # Diagnostics only: a failed/duplicate upload must never fail the job.
+        continue-on-error: true
+        uses: actions/upload-artifact@v4
+        with:
+          name: railway-deploy-log-${{ inputs.pr_number }}
+          path: railway-deploy-*.log
+          if-no-files-found: ignore
+          overwrite: true
+          retention-days: 7
 
       - name: Post preview URL as PR comment
         if: inputs.pr_number != '' && steps.deploy.outputs.preview_url != ''

--- a/.github/workflows/44-railway-tests.yml
+++ b/.github/workflows/44-railway-tests.yml
@@ -286,7 +286,7 @@ jobs:
         if: steps.auth_bootstrap.outputs.enabled == 'true'
         uses: actions/setup-node@v4
         with:
-          node-version: "24"
+          node-version: "22"
 
       - name: Install pnpm
         if: steps.auth_bootstrap.outputs.enabled == 'true'
@@ -321,15 +321,14 @@ jobs:
         working-directory: web/tests
         run: pnpm exec playwright install-deps chromium
 
-      # Browser binaries. The download stalls post-100% on these runners, so cap
-      # each attempt and retry rather than hanging the job. On a cache hit this
-      # is a quick no-op. DEBUG=pw:install is left on temporarily to trace any
-      # remaining stall; drop it once runs are green.
+      # Browser binaries. Root cause of the original ~6h hang: Playwright 1.59's
+      # zip extraction deadlocks on Node 24 (reproduced locally: Node 22/23
+      # extract in ~16s, Node 24 hangs indefinitely). The job is pinned to Node
+      # 22 (LTS) above, which fixes it. The cache makes this a no-op on a hit,
+      # and the retry + per-attempt timeout guard against any transient stall.
       - name: Install Playwright browser
         if: steps.auth_bootstrap.outputs.enabled == 'true'
         working-directory: web/tests
-        env:
-          DEBUG: pw:install
         run: |
           for attempt in 1 2 3; do
             echo "::group::playwright install chromium (attempt ${attempt}/3)"
@@ -633,7 +632,7 @@ jobs:
       - name: Setup Node.js
         uses: actions/setup-node@v4
         with:
-          node-version: "24"
+          node-version: "22"
 
       - name: Install pnpm
         uses: pnpm/action-setup@v4

--- a/.github/workflows/44-railway-tests.yml
+++ b/.github/workflows/44-railway-tests.yml
@@ -235,6 +235,8 @@ jobs:
     needs: prepare
     if: needs.prepare.outputs.needs_deployment == 'true'
     runs-on: ubuntu-latest
+    # Failsafe: a stalled apt/browser install must never hang the job for ~6h.
+    timeout-minutes: 15
     steps:
       - name: Wait for deployed web and API
         env:
@@ -294,10 +296,36 @@ jobs:
         working-directory: web
         run: pnpm install --no-frozen-lockfile --filter agenta-web-tests...
 
-      - name: Install Playwright browser
+      # DEBUG (temporary): confirm whether the hang is the browser download or
+      # the `--with-deps` apt step. Splits the two, traces apt, and caps each so
+      # the step can't hang. Revert to a single hardened install once confirmed.
+      - name: Install Playwright browser (DEBUG)
         if: steps.auth_bootstrap.outputs.enabled == 'true'
         working-directory: web/tests
-        run: pnpm exec playwright install --with-deps chromium
+        run: |
+          set -x
+          echo "::group::environment"
+          uname -a || true
+          grep -h PRETTY_NAME /etc/os-release || true
+          { [ -t 0 ] && echo "stdin IS a tty" || echo "stdin is NOT a tty"; }
+          echo "needrestart config:"
+          sudo grep -rsiE "nrconf|restart" /etc/needrestart/ 2>/dev/null | head || echo "(none)"
+          echo "dpkg lock holder:"
+          sudo lsof /var/lib/dpkg/lock-frontend 2>/dev/null || echo "(free or lsof missing)"
+          echo "::endgroup::"
+
+          echo "::group::1) browser download only (no sudo) — expected fast (~15s)"
+          time timeout 180 pnpm exec playwright install chromium || echo "DOWNLOAD failed/timed out exit=$?"
+          echo "::endgroup::"
+
+          echo "::group::2) install-deps (sudo apt) UNGUARDED, 240s cap, pw:install trace"
+          export DEBUG=pw:install
+          set +e
+          time timeout --signal=KILL 240 pnpm exec playwright install-deps chromium
+          rc=$?
+          set -e
+          echo "DEPS exit=$rc  (124/137 => hung in apt -> confirms --with-deps is the culprit)"
+          echo "::endgroup::"
 
       - name: Bootstrap auth with global setup
         if: steps.auth_bootstrap.outputs.enabled == 'true'

--- a/.github/workflows/44-railway-tests.yml
+++ b/.github/workflows/44-railway-tests.yml
@@ -296,36 +296,51 @@ jobs:
         working-directory: web
         run: pnpm install --no-frozen-lockfile --filter agenta-web-tests...
 
-      # DEBUG (temporary): confirm whether the hang is the browser download or
-      # the `--with-deps` apt step. Splits the two, traces apt, and caps each so
-      # the step can't hang. Revert to a single hardened install once confirmed.
-      - name: Install Playwright browser (DEBUG)
+      # Cache the downloaded browsers. On a cache hit `playwright install` is a
+      # no-op, which avoids the chromium download entirely — and that download
+      # is what stalls: the debug trace showed the 170 MiB transfer hitting 100%
+      # in ~2s, then the install hanging (no progress) until killed. apt deps
+      # were never the problem (they finished in ~10s).
+      - name: Cache Playwright browsers
+        id: pw-cache
+        if: steps.auth_bootstrap.outputs.enabled == 'true'
+        uses: actions/cache@v4
+        with:
+          path: ~/.cache/ms-playwright
+          key: playwright-${{ runner.os }}-${{ hashFiles('web/pnpm-lock.yaml') }}
+          restore-keys: |
+            playwright-${{ runner.os }}-
+
+      # OS libraries for chromium. This is the fast, reliable part (~10s); kept
+      # as its own step so a browser-download stall can't be confused with it.
+      - name: Install Playwright system dependencies
         if: steps.auth_bootstrap.outputs.enabled == 'true'
         working-directory: web/tests
+        run: pnpm exec playwright install-deps chromium
+
+      # Browser binaries. The download stalls post-100% on these runners, so cap
+      # each attempt and retry rather than hanging the job. On a cache hit this
+      # is a quick no-op. DEBUG=pw:install is left on temporarily to trace any
+      # remaining stall; drop it once runs are green.
+      - name: Install Playwright browser
+        if: steps.auth_bootstrap.outputs.enabled == 'true'
+        working-directory: web/tests
+        env:
+          DEBUG: pw:install
         run: |
-          set -x
-          echo "::group::environment"
-          uname -a || true
-          grep -h PRETTY_NAME /etc/os-release || true
-          { [ -t 0 ] && echo "stdin IS a tty" || echo "stdin is NOT a tty"; }
-          echo "needrestart config:"
-          sudo grep -rsiE "nrconf|restart" /etc/needrestart/ 2>/dev/null | head || echo "(none)"
-          echo "dpkg lock holder:"
-          sudo lsof /var/lib/dpkg/lock-frontend 2>/dev/null || echo "(free or lsof missing)"
-          echo "::endgroup::"
-
-          echo "::group::1) browser download only (no sudo) — expected fast (~15s)"
-          time timeout 180 pnpm exec playwright install chromium || echo "DOWNLOAD failed/timed out exit=$?"
-          echo "::endgroup::"
-
-          echo "::group::2) install-deps (sudo apt) UNGUARDED, 240s cap, pw:install trace"
-          export DEBUG=pw:install
-          set +e
-          time timeout --signal=KILL 240 pnpm exec playwright install-deps chromium
-          rc=$?
-          set -e
-          echo "DEPS exit=$rc  (124/137 => hung in apt -> confirms --with-deps is the culprit)"
-          echo "::endgroup::"
+          for attempt in 1 2 3; do
+            echo "::group::playwright install chromium (attempt ${attempt}/3)"
+            if timeout 180 pnpm exec playwright install chromium; then
+              echo "::endgroup::"
+              echo "browser install succeeded on attempt ${attempt}"
+              exit 0
+            fi
+            echo "::endgroup::"
+            echo "attempt ${attempt} stalled or failed; retrying after 5s..."
+            sleep 5
+          done
+          echo "playwright browser install failed after 3 attempts" >&2
+          exit 1
 
       - name: Bootstrap auth with global setup
         if: steps.auth_bootstrap.outputs.enabled == 'true'

--- a/.github/workflows/44-railway-tests.yml
+++ b/.github/workflows/44-railway-tests.yml
@@ -235,8 +235,11 @@ jobs:
     needs: prepare
     if: needs.prepare.outputs.needs_deployment == 'true'
     runs-on: ubuntu-latest
-    # Failsafe: a stalled apt/browser install must never hang the job for ~6h.
-    timeout-minutes: 15
+    # Backstop only: the real hangs are bounded per-step (wait_for caps at ~10m,
+    # the browser install retries with a 180s/attempt cap). This guards against
+    # an unexpected hang without cutting off a legitimately slow run (deploy
+    # readiness wait + cold browser install can take ~20m).
+    timeout-minutes: 30
     steps:
       - name: Wait for deployed web and API
         env:

--- a/hosting/railway/oss/scripts/bootstrap.sh
+++ b/hosting/railway/oss/scripts/bootstrap.sh
@@ -7,6 +7,8 @@ ROOT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")/../../../.." && pwd)"
 # shellcheck source=lib.sh
 source "$(dirname "${BASH_SOURCE[0]}")/lib.sh"
 
+install_error_trap
+
 PROJECT_NAME="${RAILWAY_PROJECT_NAME:-agenta-oss-railway}"
 ENV_NAME="${RAILWAY_ENVIRONMENT_NAME:-staging}"
 SOURCE_COMPOSE_FILE="${RAILWAY_SOURCE_COMPOSE_FILE:-$(railway_source_compose_file "$ROOT_DIR")}"

--- a/hosting/railway/oss/scripts/bootstrap.sh
+++ b/hosting/railway/oss/scripts/bootstrap.sh
@@ -39,9 +39,19 @@ require_railway_auth() {
 
     # Verify the token actually works. A revoked or invalid token will cause
     # every subsequent call to fail with a confusing "Unauthorized" error.
+    # Distinguish a genuine auth failure from rate-limiting / transient network
+    # errors (where the token is fine) so the log points at the real cause.
     local whoami_output
     whoami_output="$(railway_call whoami 2>&1)" || {
-        printf "Railway authentication failed. The token appears to be invalid or revoked.\n" >&2
+        if printf "%s" "$whoami_output" | grep -qiE "rate.?limit"; then
+            printf "Railway auth check could not complete: the API is rate-limiting requests (retries exhausted).\n" >&2
+            printf "This is throttling, not a bad token. Re-run once the rate-limit window clears.\n" >&2
+        elif printf "%s" "$whoami_output" | grep -qiE "timed out|error sending request|failed to fetch|connection (reset|refused|closed)|temporarily unavailable|service unavailable|bad gateway|gateway time-?out"; then
+            printf "Railway auth check could not complete: transient network error reaching the Railway API.\n" >&2
+            printf "The token is likely fine; this is usually temporary. Re-run.\n" >&2
+        else
+            printf "Railway authentication failed. The token appears to be invalid or revoked.\n" >&2
+        fi
         printf "Output: %s\n" "$whoami_output" >&2
         exit 1
     }

--- a/hosting/railway/oss/scripts/configure.sh
+++ b/hosting/railway/oss/scripts/configure.sh
@@ -110,10 +110,18 @@ upsert_service_vars() {
     local svc_id
     svc_id="$(_service_id "$service")"
     if [ -z "$svc_id" ]; then
-        printf "Could not resolve service id for '%s' in environment '%s'\n" "$service" "$ENV_NAME" >&2
-        return 1
+        # Name didn't match the cached status JSON (e.g. unexpected casing). Don't
+        # hard-fail the deploy where the CLI's --service would have worked; fall
+        # back to it.
+        printf "Could not resolve service id for '%s'; falling back to CLI variable set.\n" "$service" >&2
+        railway_call variable set --service "$service" --environment "$ENV_NAME" --skip-deploys "$@" >/dev/null
+        return 0
     fi
 
+    # replace:false makes the merge intent explicit: configure.sh calls set_vars
+    # then set_optional_vars for the same service and relies on accumulation.
+    # (Verified the API already defaults to merge, but pinning it avoids any
+    # future default change silently wiping earlier variables.)
     local vars_json payload
     vars_json="$(_vars_to_json "$@")"
     payload="$(jq -nc \
@@ -122,7 +130,7 @@ upsert_service_vars() {
         --arg s "$svc_id" \
         --argjson vars "$vars_json" \
         '{query: "mutation($input: VariableCollectionUpsertInput!){ variableCollectionUpsert(input: $input) }",
-          variables: {input: {projectId: $p, environmentId: $e, serviceId: $s, skipDeploys: true, variables: $vars}}}')"
+          variables: {input: {projectId: $p, environmentId: $e, serviceId: $s, skipDeploys: true, replace: false, variables: $vars}}}')"
 
     _railway_graphql "$payload" >/dev/null
 }

--- a/hosting/railway/oss/scripts/configure.sh
+++ b/hosting/railway/oss/scripts/configure.sh
@@ -17,6 +17,13 @@ AGENTA_AUTH_KEY="${AGENTA_AUTH_KEY:-replace-me}"
 AGENTA_CRYPT_KEY="${AGENTA_CRYPT_KEY:-replace-me}"
 POSTGRES_PASSWORD="${POSTGRES_PASSWORD:-}"
 
+# Populated by resolve_railway_ids() after `railway link`. Used by the GraphQL
+# variableCollectionUpsert path; left empty -> upsert_service_vars falls back
+# to the CLI.
+RAILWAY_PROJECT_ID=""
+RAILWAY_ENVIRONMENT_ID=""
+RAILWAY_STATUS_JSON=""
+
 resolve_postgres_password() {
     if [ -n "$POSTGRES_PASSWORD" ]; then
         return 0
@@ -49,10 +56,81 @@ require_railway_auth() {
     }
 }
 
+# resolve_railway_ids: cache the project/environment IDs and status JSON used by
+# the GraphQL variableCollectionUpsert path. No-op (CLI fallback) when there is
+# no API token or the IDs cannot be resolved.
+resolve_railway_ids() {
+    [ -n "${RAILWAY_API_TOKEN:-}" ] || return 0
+    RAILWAY_STATUS_JSON="$(railway_call status --json 2>/dev/null || true)"
+    [ -n "$RAILWAY_STATUS_JSON" ] || return 0
+    RAILWAY_PROJECT_ID="$(printf '%s' "$RAILWAY_STATUS_JSON" | jq -r '.id // empty' 2>/dev/null || true)"
+    RAILWAY_ENVIRONMENT_ID="$(printf '%s' "$RAILWAY_STATUS_JSON" \
+        | jq -r --arg e "$ENV_NAME" '[.environments.edges[].node | select(.name==$e) | .id][0] // empty' 2>/dev/null || true)"
+    if [ -z "$RAILWAY_PROJECT_ID" ] || [ -z "$RAILWAY_ENVIRONMENT_ID" ]; then
+        printf "Note: could not resolve Railway project/environment IDs; using CLI variable set.\n" >&2
+        RAILWAY_PROJECT_ID=""
+    fi
+}
+
+# _service_id <service-name> -> serviceId, from the cached status JSON.
+_service_id() {
+    printf '%s' "$RAILWAY_STATUS_JSON" | jq -r --arg n "$1" --arg e "$ENV_NAME" \
+        '[.environments.edges[].node | select(.name==$e)
+          | .serviceInstances.edges[].node | select(.serviceName==$n) | .serviceId][0] // empty' 2>/dev/null || true
+}
+
+# _vars_to_json KEY=VALUE ... -> {"KEY":"VALUE",...}  (split on the first '=')
+_vars_to_json() {
+    local json='{}' kv key val
+    for kv in "$@"; do
+        key="${kv%%=*}"
+        val="${kv#*=}"
+        json="$(jq -c --arg k "$key" --arg v "$val" '. + {($k): $v}' <<<"$json")"
+    done
+    printf '%s' "$json"
+}
+
+# upsert_service_vars <service> KEY=VALUE ...
+# Sets all given variables for a service in ONE variableCollectionUpsert
+# (skipDeploys) via the GraphQL API — Railway's recommended path, which avoids
+# the CLI fanning out to one slow variableUpsert per key. Falls back to the CLI
+# when no API token / IDs are available. Reference values like
+# ${{Postgres.POSTGRES_PASSWORD}} are stored verbatim and resolved by Railway at
+# render time, exactly as with the CLI.
+upsert_service_vars() {
+    local service="$1"
+    shift
+    [ "$#" -gt 0 ] || return 0
+
+    if [ -z "${RAILWAY_API_TOKEN:-}" ] || [ -z "$RAILWAY_PROJECT_ID" ]; then
+        railway_call variable set --service "$service" --environment "$ENV_NAME" --skip-deploys "$@" >/dev/null
+        return 0
+    fi
+
+    local svc_id
+    svc_id="$(_service_id "$service")"
+    if [ -z "$svc_id" ]; then
+        printf "Could not resolve service id for '%s' in environment '%s'\n" "$service" "$ENV_NAME" >&2
+        return 1
+    fi
+
+    local vars_json payload
+    vars_json="$(_vars_to_json "$@")"
+    payload="$(jq -nc \
+        --arg p "$RAILWAY_PROJECT_ID" \
+        --arg e "$RAILWAY_ENVIRONMENT_ID" \
+        --arg s "$svc_id" \
+        --argjson vars "$vars_json" \
+        '{query: "mutation($input: VariableCollectionUpsertInput!){ variableCollectionUpsert(input: $input) }",
+          variables: {input: {projectId: $p, environmentId: $e, serviceId: $s, skipDeploys: true, variables: $vars}}}')"
+
+    _railway_graphql "$payload" >/dev/null
+}
+
 set_vars() {
     local service="$1"
     shift
-    railway_call variable set --service "$service" --environment "$ENV_NAME" --skip-deploys "$@" >/dev/null
+    upsert_service_vars "$service" "$@"
 }
 
 set_optional_vars() {
@@ -68,7 +146,7 @@ set_optional_vars() {
     done
 
     if [ "${#args[@]}" -gt 0 ]; then
-        railway_call variable set --service "$service" --environment "$ENV_NAME" --skip-deploys "${args[@]}" >/dev/null
+        upsert_service_vars "$service" "${args[@]}"
     fi
 }
 
@@ -101,6 +179,10 @@ main() {
     fi
 
     railway_call link --project "$PROJECT_NAME" --environment "$ENV_NAME" --json >/dev/null
+
+    # Resolve IDs for the GraphQL variableCollectionUpsert path (after link, so
+    # the project/environment/services exist and are linked).
+    resolve_railway_ids
 
     railway_call domain --service gateway --json >/dev/null 2>&1 || true
 

--- a/hosting/railway/oss/scripts/configure.sh
+++ b/hosting/railway/oss/scripts/configure.sh
@@ -5,6 +5,8 @@ set -euo pipefail
 # shellcheck source=lib.sh
 source "$(dirname "${BASH_SOURCE[0]}")/lib.sh"
 
+install_error_trap
+
 PROJECT_NAME="${RAILWAY_PROJECT_NAME:-agenta-oss-railway}"
 ENV_NAME="${RAILWAY_ENVIRONMENT_NAME:-staging}"
 SKIP_UNSETS="${CONFIGURE_SKIP_UNSETS:-false}"

--- a/hosting/railway/oss/scripts/deploy-from-images.sh
+++ b/hosting/railway/oss/scripts/deploy-from-images.sh
@@ -8,6 +8,8 @@ TMP_DIR="$(mktemp -d)"
 # shellcheck source=lib.sh
 source "$(dirname "${BASH_SOURCE[0]}")/lib.sh"
 
+install_error_trap
+
 cleanup() {
     rm -rf "$TMP_DIR"
 }

--- a/hosting/railway/oss/scripts/lib.sh
+++ b/hosting/railway/oss/scripts/lib.sh
@@ -198,6 +198,73 @@ railway_call() {
     done
 }
 
+# _railway_graphql: POST a GraphQL request to Railway's backboard API using
+# RAILWAY_API_TOKEN. Used for variableCollectionUpsert, which sets all of a
+# service's variables in ONE mutation — Railway's recommended path, since the
+# CLI's `variable set` fans out to one (server-side expensive) variableUpsert
+# per key. On success prints the response body to stdout and returns 0. Retries
+# on transient network / 429 / 5xx / timeout with the same backoff as
+# railway_call; failure output is redacted.
+#
+# Usage: _railway_graphql '<json-payload>'
+#
+# Environment variables:
+#   RAILWAY_GRAPHQL_URL       Endpoint (default: backboard.railway.com/graphql/v2)
+#   RAILWAY_GRAPHQL_TIMEOUT   Per-attempt curl timeout in seconds (default: 90)
+#   RAILWAY_RETRY_MAX/DELAY   Shared with railway_call
+_railway_graphql() {
+    local payload="$1"
+    local endpoint="${RAILWAY_GRAPHQL_URL:-https://backboard.railway.com/graphql/v2}"
+    local token="${RAILWAY_API_TOKEN:-${RAILWAY_TOKEN:-}}"
+    local max_attempts="${RAILWAY_RETRY_MAX:-5}"
+    local delay="${RAILWAY_RETRY_DELAY:-10}"
+    local timeout_s="${RAILWAY_GRAPHQL_TIMEOUT:-90}"
+    local attempt=1
+
+    while [ "$attempt" -le "$max_attempts" ]; do
+        local raw http body curl_rc
+        # `set +Ee` so a curl failure neither trips errexit nor fires the ERR
+        # trap; we classify and retry here. -w appends the HTTP status on its
+        # own line after the (single-line) JSON body.
+        raw="$(set +Ee; curl -sS --max-time "$timeout_s" -w $'\n%{http_code}' \
+            -X POST "$endpoint" \
+            -H "Authorization: Bearer ${token}" \
+            -H "Content-Type: application/json" \
+            --data "$payload" 2>&1)" && curl_rc=0 || curl_rc=$?
+        http="${raw##*$'\n'}"
+        body="${raw%$'\n'*}"
+
+        # Success = curl ok + HTTP 200 + no GraphQL "errors" array.
+        if [ "$curl_rc" -eq 0 ] && [ "$http" = "200" ] \
+            && ! printf '%s' "$body" | grep -q '"errors"'; then
+            printf '%s\n' "$body"
+            return 0
+        fi
+
+        local retryable=0
+        if [ "$curl_rc" -ne 0 ]; then
+            retryable=1                                   # network error / timeout
+        elif printf '%s' "$http" | grep -qE '^(429|5[0-9][0-9])$'; then
+            retryable=1                                   # rate-limit / server error
+        elif printf '%s' "$body" | grep -qiE "rate.?limit|timed out|temporarily unavailable|service unavailable"; then
+            retryable=1
+        fi
+
+        if [ "$retryable" -eq 1 ] && [ "$attempt" -lt "$max_attempts" ]; then
+            printf "railway graphql: transient (http=%s curl=%s), retrying in %ds (attempt %d/%d)\n" \
+                "$http" "$curl_rc" "$delay" "$attempt" "$max_attempts" >&2
+            sleep "$delay"
+            delay=$((delay * 2))
+            attempt=$((attempt + 1))
+            continue
+        fi
+
+        printf "railway graphql request failed (http=%s curl=%s)\n" "$http" "$curl_rc" >&2
+        [ -n "$body" ] && printf "%s\n" "$body" | _railway_redact >&2
+        return 1
+    done
+}
+
 # install_error_trap: Turn a bare "exit 1" into a diagnostic that names the
 # failing command and prints a short call stack. Call once near the top of a
 # script, after sourcing this file. Enables errtrace (set -E) so the trap also

--- a/hosting/railway/oss/scripts/lib.sh
+++ b/hosting/railway/oss/scripts/lib.sh
@@ -112,7 +112,10 @@ railway_call() {
     local exit_code
 
     while [ "$attempt" -le "$max_attempts" ]; do
-        output="$(railway "$@" 2>&1)" && exit_code=0 || exit_code=$?
+        # `set +Ee` inside the subshell so a non-zero exit from `railway`
+        # neither trips errexit nor fires an inherited ERR trap. This wrapper
+        # handles rate-limit retries and reports failures itself.
+        output="$(set +Ee; railway "$@" 2>&1)" && exit_code=0 || exit_code=$?
 
         if printf "%s" "$output" | grep -qi "ratelimit\|rate.limit\|rate limit"; then
             if [ "$attempt" -eq "$max_attempts" ]; then
@@ -128,8 +131,79 @@ railway_call() {
             continue
         fi
 
-        # Not a rate-limit error. Print output and return the original exit code.
-        printf "%s\n" "$output"
+        # Not a rate-limit error.
+        if [ "$exit_code" -eq 0 ]; then
+            # Success: emit on stdout so callers can capture the output.
+            printf "%s\n" "$output"
+        else
+            # Failure: emit on stderr so callers that redirect stdout to
+            # /dev/null still surface the underlying railway error.
+            [ -n "$output" ] && printf "%s\n" "$output" >&2
+        fi
         return "$exit_code"
     done
+}
+
+# install_error_trap: Turn a bare "exit 1" into a diagnostic that names the
+# failing command and prints a short call stack. Call once near the top of a
+# script, after sourcing this file. Enables errtrace (set -E) so the trap also
+# fires for failures inside functions.
+#
+# railway_call disables errtrace inside its own command substitution, so
+# tolerated failures (callers using `|| true`) do not reach this trap.
+_railway_on_error() {
+    # The same failure can unwind through several stack frames; report once.
+    [ -n "${_RAILWAY_ERR_HANDLED:-}" ] && return 0
+    _RAILWAY_ERR_HANDLED=1
+
+    local exit_code="$1"
+    local cmd="$2"
+
+    printf '\n[railway][FAIL] command failed (exit %s): %s\n' "$exit_code" "$cmd" >&2
+
+    local i
+    for ((i = 1; i < ${#FUNCNAME[@]}; i++)); do
+        printf '    at %s (%s:%s)\n' \
+            "${FUNCNAME[i]}" "${BASH_SOURCE[i]}" "${BASH_LINENO[i - 1]}" >&2
+    done
+
+    # Surface a GitHub Actions annotation when running in CI.
+    if [ "${GITHUB_ACTIONS:-}" = "true" ]; then
+        printf '::error::[railway] command failed (exit %s): %s\n' "$exit_code" "$cmd" >&2
+    fi
+}
+
+install_error_trap() {
+    set -E
+    trap '_railway_on_error "$?" "$BASH_COMMAND"' ERR
+}
+
+# dump_railway_logs: Best-effort snapshot of Railway service logs, for CI
+# debugging. Uses --lines (non-streaming) and --latest (works even when a
+# deployment failed or is crash-looping), wrapped in a hard timeout so it can
+# never hang or fail the caller. Requires a linked project/environment.
+#
+# Usage: dump_railway_logs [service ...]   (defaults to the core infra set)
+#
+# Environment variables:
+#   RAILWAY_LOG_TAIL      Lines to fetch per service (default: 50)
+#   RAILWAY_LOG_TIMEOUT   Per-service timeout in seconds (default: 30)
+dump_railway_logs() {
+    local services=("$@")
+    if [ "${#services[@]}" -eq 0 ]; then
+        services=(Postgres redis alembic api supertokens web)
+    fi
+
+    local lines="${RAILWAY_LOG_TAIL:-50}"
+    local timeout_s="${RAILWAY_LOG_TIMEOUT:-30}"
+    local svc
+
+    for svc in "${services[@]}"; do
+        printf '\n===== railway logs (last %s lines): %s =====\n' "$lines" "$svc" >&2
+        timeout "$timeout_s" \
+            railway logs --service "$svc" --lines "$lines" --latest >&2 2>&1 \
+            || printf '(no logs available for service: %s)\n' "$svc" >&2
+    done
+
+    return 0
 }

--- a/hosting/railway/oss/scripts/lib.sh
+++ b/hosting/railway/oss/scripts/lib.sh
@@ -105,19 +105,33 @@ _railway_redact() {
         -e 's#(://[A-Za-z0-9._~-]+:)[^@[:space:]/]+@#\1***REDACTED***@#g'
 }
 
-# railway_call: Run a railway CLI command, retrying on rate-limit responses.
+# railway_call: Run a railway CLI command with smart, context-aware retries.
 #
-# Railway returns "You are being ratelimited. Please try again later" on
-# HTTP 429. This wrapper detects that message and backs off with exponential
-# backoff before retrying.
+# Railway's GraphQL API (backboard.railway.com) intermittently rate-limits
+# (HTTP 429) and, far more often for us, times out write mutations such as
+# `variable set` ("operation timed out" / "error sending request"). This
+# wrapper retries the cases that are safe + useful to retry, and fails fast on
+# the rest:
 #
-# Usage:
-#   railway_call [railway args...]
+#   - rate-limit          -> always retried. A 429 is a clean rejection: the
+#                            request was not processed, so a retry cannot
+#                            duplicate work.
+#   - transient network   -> retried ONLY for idempotent commands. A timed-out
+#     (timeout/5xx/reset)    mutation may have already succeeded server-side, so
+#                            we do NOT blind-retry non-idempotent creates
+#                            (`init`, `add`, `environment new`, `volume add`):
+#                            that risks duplicate projects/services/volumes.
+#                            `variable set` (our actual offender) is an
+#                            idempotent upsert, so it is retried.
+#   - anything else       -> not retried. Deterministic errors ("not found",
+#                            "unauthorized", "No service linked") fail fast
+#                            instead of burning the backoff budget.
+#
+# Backoff is exponential. Failure output is redacted (see _railway_redact).
 #
 # Environment variables:
-#   RAILWAY_RETRY_MAX     Max retry attempts (default: 5)
-#   RAILWAY_RETRY_DELAY   Initial delay in seconds (default: 10)
-#
+#   RAILWAY_RETRY_MAX     Max attempts (default: 5)
+#   RAILWAY_RETRY_DELAY   Initial backoff delay in seconds (default: 10)
 railway_call() {
     local max_attempts="${RAILWAY_RETRY_MAX:-5}"
     local delay="${RAILWAY_RETRY_DELAY:-10}"
@@ -125,36 +139,61 @@ railway_call() {
     local output
     local exit_code
 
+    # Is this a non-idempotent create? If so, an ambiguous timeout must not be
+    # blind-retried (the resource may already exist). Rate-limit retries are
+    # still safe because a 429 is rejected before any work is done.
+    local idempotent=1
+    case "$1" in
+        init | add) idempotent=0 ;;
+        environment) [ "${2:-}" = "new" ] && idempotent=0 ;;
+        volume) [ "${2:-}" = "add" ] && idempotent=0 ;;
+    esac
+
     while [ "$attempt" -le "$max_attempts" ]; do
         # `set +Ee` inside the subshell so a non-zero exit from `railway`
         # neither trips errexit nor fires an inherited ERR trap. This wrapper
-        # handles rate-limit retries and reports failures itself.
+        # handles retries and reports failures itself.
         output="$(set +Ee; railway "$@" 2>&1)" && exit_code=0 || exit_code=$?
 
-        if printf "%s" "$output" | grep -qi "ratelimit\|rate.limit\|rate limit"; then
-            if [ "$attempt" -eq "$max_attempts" ]; then
-                printf "railway %s: rate-limited after %d attempts\n" \
-                    "$(printf '%s' "$*" | _railway_redact)" "$max_attempts" >&2
-                printf "%s\n" "$output" | _railway_redact >&2
-                return 1
-            fi
-            printf "railway %s: rate-limited, retrying in %ds (attempt %d/%d)\n" \
-                "$1" "$delay" "$attempt" "$max_attempts" >&2
+        # Success: emit on stdout so callers can capture the output.
+        if [ "$exit_code" -eq 0 ]; then
+            printf "%s\n" "$output"
+            return 0
+        fi
+
+        # Classify the failure to decide whether a retry is safe + useful.
+        local kind="error"
+        if printf "%s" "$output" | grep -qiE "ratelimit|rate.?limit"; then
+            kind="rate-limit"
+        elif printf "%s" "$output" | grep -qiE "timed out|error sending request|failed to fetch|error trying to connect|connection (reset|refused|closed|error)|temporarily unavailable|service unavailable|bad gateway|gateway time-?out|broken pipe|unexpected eof|tls handshake"; then
+            kind="transient"
+        fi
+
+        local retryable=0
+        case "$kind" in
+            rate-limit) retryable=1 ;;
+            transient) [ "$idempotent" -eq 1 ] && retryable=1 ;;
+        esac
+
+        if [ "$retryable" -eq 1 ] && [ "$attempt" -lt "$max_attempts" ]; then
+            printf "railway %s: %s, retrying in %ds (attempt %d/%d)\n" \
+                "$1" "$kind" "$delay" "$attempt" "$max_attempts" >&2
             sleep "$delay"
             delay=$((delay * 2))
             attempt=$((attempt + 1))
             continue
         fi
 
-        # Not a rate-limit error.
-        if [ "$exit_code" -eq 0 ]; then
-            # Success: emit on stdout so callers can capture the output.
-            printf "%s\n" "$output"
-        else
-            # Failure: emit on stderr (redacted) so callers that redirect
-            # stdout to /dev/null still surface the underlying railway error.
-            [ -n "$output" ] && printf "%s\n" "$output" | _railway_redact >&2
+        # Give up: not retryable, attempts exhausted, or an ambiguous timeout
+        # on a non-idempotent create. Surface the (redacted) railway error.
+        if [ "$retryable" -eq 1 ]; then
+            printf "railway %s: %s — giving up after %d attempts\n" \
+                "$1" "$kind" "$attempt" >&2
+        elif [ "$kind" = "transient" ] && [ "$idempotent" -eq 0 ]; then
+            printf "railway %s: %s on non-idempotent command — not retrying (may have partially succeeded)\n" \
+                "$1" "$kind" >&2
         fi
+        [ -n "$output" ] && printf "%s\n" "$output" | _railway_redact >&2
         return "$exit_code"
     done
 }

--- a/hosting/railway/oss/scripts/lib.sh
+++ b/hosting/railway/oss/scripts/lib.sh
@@ -91,6 +91,20 @@ require_compose_redis_image() {
     printf "%s" "$image"
 }
 
+# _railway_redact: Mask secret values before they are logged. Reads stdin and
+# writes redacted text to stdout. Masks the value of any KEY=VALUE token whose
+# (uppercase) key contains PASSWORD/TOKEN/SECRET/KEY, plus the password segment
+# of any scheme://user:password@host URL. Keeps diagnostic output safe to print
+# and to upload as a CI artifact even when a failing command echoes its args.
+#
+# Applied only to failure/diagnostic output, never to the success path that
+# callers parse (e.g. `variable list -k` results).
+_railway_redact() {
+    sed -E \
+        -e 's/([A-Z0-9_]*(PASSWORD|TOKEN|SECRET|KEY)[A-Z0-9_]*[[:space:]]*=[[:space:]]*)[^[:space:]]+/\1***REDACTED***/g' \
+        -e 's#(://[A-Za-z0-9._~-]+:)[^@[:space:]/]+@#\1***REDACTED***@#g'
+}
+
 # railway_call: Run a railway CLI command, retrying on rate-limit responses.
 #
 # Railway returns "You are being ratelimited. Please try again later" on
@@ -119,8 +133,9 @@ railway_call() {
 
         if printf "%s" "$output" | grep -qi "ratelimit\|rate.limit\|rate limit"; then
             if [ "$attempt" -eq "$max_attempts" ]; then
-                printf "railway %s: rate-limited after %d attempts\n" "$*" "$max_attempts" >&2
-                printf "%s\n" "$output" >&2
+                printf "railway %s: rate-limited after %d attempts\n" \
+                    "$(printf '%s' "$*" | _railway_redact)" "$max_attempts" >&2
+                printf "%s\n" "$output" | _railway_redact >&2
                 return 1
             fi
             printf "railway %s: rate-limited, retrying in %ds (attempt %d/%d)\n" \
@@ -136,9 +151,9 @@ railway_call() {
             # Success: emit on stdout so callers can capture the output.
             printf "%s\n" "$output"
         else
-            # Failure: emit on stderr so callers that redirect stdout to
-            # /dev/null still surface the underlying railway error.
-            [ -n "$output" ] && printf "%s\n" "$output" >&2
+            # Failure: emit on stderr (redacted) so callers that redirect
+            # stdout to /dev/null still surface the underlying railway error.
+            [ -n "$output" ] && printf "%s\n" "$output" | _railway_redact >&2
         fi
         return "$exit_code"
     done
@@ -157,7 +172,10 @@ _railway_on_error() {
     _RAILWAY_ERR_HANDLED=1
 
     local exit_code="$1"
-    local cmd="$2"
+    # Redact secrets: $BASH_COMMAND can contain secret-bearing args (e.g.
+    # `railway variable set ... AGENTA_AUTH_KEY=...`).
+    local cmd
+    cmd="$(printf '%s' "$2" | _railway_redact)"
 
     printf '\n[railway][FAIL] command failed (exit %s): %s\n' "$exit_code" "$cmd" >&2
 
@@ -197,12 +215,17 @@ dump_railway_logs() {
     local lines="${RAILWAY_LOG_TAIL:-50}"
     local timeout_s="${RAILWAY_LOG_TIMEOUT:-30}"
     local svc
+    local logs
 
     for svc in "${services[@]}"; do
         printf '\n===== railway logs (last %s lines): %s =====\n' "$lines" "$svc" >&2
-        timeout "$timeout_s" \
-            railway logs --service "$svc" --lines "$lines" --latest >&2 2>&1 \
-            || printf '(no logs available for service: %s)\n' "$svc" >&2
+        # Capture first so the exit status reflects railway/timeout (not the
+        # redactor), then print redacted (service logs may embed DB URIs).
+        if logs="$(timeout "$timeout_s" railway logs --service "$svc" --lines "$lines" --latest 2>&1)"; then
+            printf '%s\n' "$logs" | _railway_redact >&2
+        else
+            printf '(no logs available for service: %s)\n' "$svc" >&2
+        fi
     done
 
     return 0

--- a/hosting/railway/oss/scripts/lib.sh
+++ b/hosting/railway/oss/scripts/lib.sh
@@ -134,17 +134,21 @@ _railway_redact() {
 #   RAILWAY_RETRY_DELAY   Initial backoff delay in seconds (default: 10)
 railway_call() {
     local max_attempts="${RAILWAY_RETRY_MAX:-5}"
+    [ "$max_attempts" -ge 1 ] 2>/dev/null || max_attempts=1
     local delay="${RAILWAY_RETRY_DELAY:-10}"
     local attempt=1
     local output
     local exit_code
 
-    # Is this a non-idempotent create? If so, an ambiguous timeout must not be
-    # blind-retried (the resource may already exist). Rate-limit retries are
-    # still safe because a 429 is rejected before any work is done.
+    # Is this a non-idempotent / side-effecting command? If so, an ambiguous
+    # timeout must not be blind-retried: the server may have already accepted
+    # the request, so a retry could duplicate the resource (`init`/`add`/
+    # `environment new`/`volume add`) or trigger a second deployment (`up`/
+    # `redeploy`). Rate-limit retries stay safe for all commands because a 429
+    # is rejected before any work is done.
     local idempotent=1
     case "$1" in
-        init | add) idempotent=0 ;;
+        init | add | up | redeploy) idempotent=0 ;;
         environment) [ "${2:-}" = "new" ] && idempotent=0 ;;
         volume) [ "${2:-}" = "add" ] && idempotent=0 ;;
     esac
@@ -217,6 +221,7 @@ _railway_graphql() {
     local endpoint="${RAILWAY_GRAPHQL_URL:-https://backboard.railway.com/graphql/v2}"
     local token="${RAILWAY_API_TOKEN:-${RAILWAY_TOKEN:-}}"
     local max_attempts="${RAILWAY_RETRY_MAX:-5}"
+    [ "$max_attempts" -ge 1 ] 2>/dev/null || max_attempts=1
     local delay="${RAILWAY_RETRY_DELAY:-10}"
     local timeout_s="${RAILWAY_GRAPHQL_TIMEOUT:-90}"
     local attempt=1


### PR DESCRIPTION
## Why

A failed Railway preview deploy used to surface only `Process completed with exit code 1` — the real cause was swallowed by `>/dev/null`, hidden in the Railway dashboard, or truncated from the live Actions log. This PR makes those failures debuggable **and** fixes the underlying failures we found while debugging them.

> Scope note: this started as a pure-diagnostics change but grew, because the diagnostics immediately surfaced three real, deterministic failures (Railway variable-set latency, a Playwright/Node-24 hang, and misleading auth errors). All are fixed here and individually validated. Happy to split the `variableCollectionUpsert` change into its own PR if preferred — flagging it explicitly since it's a live deploy-path change, not a diagnostics-only one.

## What changed

**Diagnostics (the original goal)**
- `install_error_trap`: a bare `exit 1` becomes the failing command + exit code + a `file:line` call stack.
- `railway_call`: failure output goes to **stderr** (so callers that send stdout to `/dev/null` still surface the error), with **secret redaction** on every diagnostic path.
- `dump_railway_logs`: on a failed deploy, pulls the tail of key services' Railway logs into the job, and tees it into the uploaded artifact.
- Setup/deploy stream to a workspace log uploaded as an artifact (survives live-log truncation) + a step-summary.

**Deploy reliability (found via the diagnostics)**
- **Context-aware retries** in `railway_call`: retry rate-limit always; retry transient network/timeout only for **idempotent** commands. `init`/`add`/`environment new`/`volume add` (create) and `up`/`redeploy` (deploy-triggering) are **not** blind-retried on an ambiguous timeout, to avoid duplicate resources/deployments.
- **`variableCollectionUpsert`** (`configure.sh`): per Railway support, `variable set` latency is server-side in the `variableUpsert` resolver and the CLI fans out to one upsert *per key*. We now set all of a service's vars in **one atomic GraphQL mutation** (`skipDeploys:true`, `replace:false`) — ~13 calls/deploy instead of ~50-100 — via a new `_railway_graphql` helper. Falls back to the CLI when no API token is present.
- **Clearer auth errors** (`bootstrap.sh`): a rate-limited/transient `whoami` no longer reports "token invalid or revoked."

**Test workflow (`44-railway-tests.yml`)**
- **Pinned the Playwright jobs to Node 22.** Root cause of a ~6h `wait-for-readiness` hang: Playwright 1.59's zip extraction deadlocks on Node 24 (reproduced locally — Node 22/23 extract in ~16s, Node 24 hangs).
- Split `install-deps` from the browser download, cache `~/.cache/ms-playwright`, retry the install with a per-attempt timeout, and add `timeout-minutes: 30`.

## Validation
- **`variableCollectionUpsert` (live preview project):** confirmed reference values (`${{gateway.RAILWAY_PUBLIC_DOMAIN}}`, `${{Postgres.POSTGRES_PASSWORD}}`) resolve correctly, `=`-in-value is preserved, and the mutation **merges** (set_vars then set_optional_vars on the same service both survive — verified empirically, and pinned with `replace:false`).
- **Node 24 hang:** reproduced locally (Node 24 killed at 240s; Node 22 = 17s, exit 0).
- **`railway_call`:** unit-tested the retry classification (rate-limit retried; timeout retried for `variable`, not for `init`/`up`/`redeploy`; deterministic fails fast; `RETRY_MAX=0` floored to 1); redaction and ERR-trap suites pass.
- A real preview run reached and passed `setup` + `deploy` with these changes (the only remaining intermittent blocker is Railway-side API latency/throttling, which Railway has acknowledged and increased our token headroom for).

## Safety
No change flips a passing run to failing: the retries can only turn red→green or add latency; `variableCollectionUpsert` falls back to the CLI without a token and merges (no var loss); the artifact-upload steps are `continue-on-error`. Secrets are redacted from all diagnostic output.