### PR TITLE
feat(sdk): upgrade MiniMax default model list to M3

### DIFF
--- a/sdks/python/agenta/sdk/utils/assets.py
+++ b/sdks/python/agenta/sdk/utils/assets.py
@@ -184,11 +184,7 @@ supported_llm_models = {
         "together_ai/Qwen/Qwen2.5-72B-Instruct-Turbo",
     ],
     "minimax": [
-        "minimax/MiniMax-M2.5",
-        "minimax/MiniMax-M2.5-lightning",
-        "minimax/MiniMax-M2.1",
-        "minimax/MiniMax-M2.1-lightning",
-        "minimax/MiniMax-M2",
+        "minimax/MiniMax-M3",
     ],
 }
 


### PR DESCRIPTION
## Summary

Upgrade the `minimax` provider entry in `supported_llm_models` to surface the latest MiniMax flagship model (`MiniMax-M3`) and prune the deprecated older series.

## Changes

`sdks/python/agenta/sdk/utils/assets.py`:
- Add `minimax/MiniMax-M3`.
- Remove the deprecated `MiniMax-M2.5`, `MiniMax-M2.5-lightning`, `MiniMax-M2.1`, `MiniMax-M2.1-lightning`, and `MiniMax-M2` entries.

No other files needed changes — every other `minimax` reference in the repo (env vars, provider enums, helm templates, icons, transforms, etc.) is at the provider level and does not enumerate specific model IDs.

## Why

`MiniMax-M3` is the new flagship from MiniMax ([release notes](https://platform.minimax.io/docs/guides/text-generation)): 512K context window, 128K max output, image input, accessible over both OpenAI-compatible and Anthropic-compatible interfaces. The older M2.x line is being deprecated by the upstream provider.

## Note on the litellm model-registry test

`test_supported_llm_models.py` asserts every model in `supported_llm_models` exists in `litellm.model_cost`. The latest `litellm` release (1.86.2) and `main` do not yet include `minimax/MiniMax-M3` (only the M2.x entries), so that single parametrized case will fail until litellm registers M3 (cf. the precedent for M2: BerriAI/litellm#15950). The model still routes correctly through the `minimax/` prefix at runtime; only the cost-metadata lookup is missing.

Happy to follow up by filing the litellm-registry PR, or to gate this PR on the litellm release if you prefer.

## Test plan

- [x] `ruff format` and `ruff check` clean on the changed file
- [x] `supported_llm_models["minimax"]` now resolves to `["minimax/MiniMax-M3"]`
- [ ] Smoke-test M3 against `https://api.minimax.io/v1` via the LiteLLM `minimax/` route once registered