### PR TITLE
[hotfix] Resolve flaky deployments

### DIFF
--- a/.all-contributorsrc
+++ b/.all-contributorsrc
@@ -586,6 +586,16 @@
       "contributions": [
         "bug"
       ]
+    },
+    {
+      "login": "axelray-dev",
+      "name": "AxelRay",
+      "avatar_url": "https://avatars.githubusercontent.com/u/110029405?v=4",
+      "profile": "https://github.com/axelray-dev",
+      "contributions": [
+        "platform",
+        "doc"
+      ]
     }
   ],
   "contributorsPerLine": 7,

--- a/README.md
+++ b/README.md
@@ -191,7 +191,7 @@ We welcome contributions of all kinds, from filing issues and sharing ideas to i
 ## Contributors ✨
 
 <!-- ALL-CONTRIBUTORS-BADGE:START - Do not remove or modify this section -->
-[![All Contributors](https://img.shields.io/badge/all_contributors-62-orange.svg?style=flat-square)](#contributors-)
+[![All Contributors](https://img.shields.io/badge/all_contributors-63-orange.svg?style=flat-square)](#contributors-)
 <!-- ALL-CONTRIBUTORS-BADGE:END -->
 
 Thanks goes to these wonderful people ([emoji key](https://allcontributors.org/docs/en/emoji-key)):
@@ -280,6 +280,7 @@ Thanks goes to these wonderful people ([emoji key](https://allcontributors.org/d
       <td align="center" valign="top" width="14.28%"><a href="https://endoze.github.io"><img src="https://avatars.githubusercontent.com/u/997161?v=4?s=100" width="100px;" alt="Endoze"/><br /><sub><b>Endoze</b></sub></a><br /><a href="#infra-endoze" title="Infrastructure (Hosting, Build-Tools, etc)">🚇</a> <a href="https://github.com/Agenta-AI/agenta/commits?author=endoze" title="Documentation">📖</a></td>
       <td align="center" valign="top" width="14.28%"><a href="https://github.com/anshk8"><img src="https://avatars.githubusercontent.com/u/141085661?v=4?s=100" width="100px;" alt="Ansh Kakkar"/><br /><sub><b>Ansh Kakkar</b></sub></a><br /><a href="https://github.com/Agenta-AI/agenta/issues?q=author%3Aanshk8" title="Bug reports">🐛</a></td>
       <td align="center" valign="top" width="14.28%"><a href="https://github.com/Devarsh05"><img src="https://avatars.githubusercontent.com/u/116822773?v=4?s=100" width="100px;" alt="Devarsh Prajapati"/><br /><sub><b>Devarsh Prajapati</b></sub></a><br /><a href="https://github.com/Agenta-AI/agenta/issues?q=author%3ADevarsh05" title="Bug reports">🐛</a></td>
+      <td align="center" valign="top" width="14.28%"><a href="https://github.com/axelray-dev"><img src="https://avatars.githubusercontent.com/u/110029405?v=4?s=100" width="100px;" alt="AxelRay"/><br /><sub><b>AxelRay</b></sub></a><br /><a href="#platform-axelray-dev" title="Packaging/porting to new platform">📦</a> <a href="https://github.com/Agenta-AI/agenta/commits?author=axelray-dev" title="Documentation">📖</a></td>
     </tr>
   </tbody>
 </table>

--- a/web/oss/src/components/DeploymentsDashboard/index.tsx
+++ b/web/oss/src/components/DeploymentsDashboard/index.tsx
@@ -21,6 +21,7 @@ import DeploymentsTable from "./Table/DeploymentsTable"
 interface DeploymentsDashboardProps {
     environmentId: string | null
     environmentName: string
+    environmentSlug: string
     /** The currently deployed app revision ID (for disabling revert on current deploy) */
     currentDeployedRevisionId?: string | null
 }
@@ -28,6 +29,7 @@ interface DeploymentsDashboardProps {
 const DeploymentsDashboard: FC<DeploymentsDashboardProps> = ({
     environmentId,
     environmentName,
+    environmentSlug,
     currentDeployedRevisionId,
 }) => {
     const {mutateAsync: publish} = useAtomValue(publishMutationAtom)
@@ -94,7 +96,7 @@ const DeploymentsDashboard: FC<DeploymentsDashboardProps> = ({
                 onConfirm: async (noteValue) => {
                     await publish({
                         revisionId: record.deployedRevisionId!,
-                        environmentSlug: environmentName,
+                        environmentSlug,
                         applicationId: workflowData?.workflow_id || "",
                         workflowVariantId: workflowData?.workflow_variant_id ?? undefined,
                         variantSlug:
@@ -107,7 +109,7 @@ const DeploymentsDashboard: FC<DeploymentsDashboardProps> = ({
                 },
             })
         },
-        [environmentName, openDeploymentConfirmationModal, publish],
+        [environmentSlug, environmentName, openDeploymentConfirmationModal, publish],
     )
 
     const columnActions = useMemo<DeploymentColumnActions>(

--- a/web/oss/src/components/DeploymentsDashboard/modals/SelectDeployVariantModalContent.tsx
+++ b/web/oss/src/components/DeploymentsDashboard/modals/SelectDeployVariantModalContent.tsx
@@ -78,11 +78,26 @@ function useCurrentDeployment(envName: string, appId: string | null) {
     }, [appId, envName, envQuery.data])
 }
 
+function resolveEnvironmentSlug(
+    envName: string,
+    environments: {name?: string | null; slug?: string | null}[],
+): string | null {
+    if (!envName) return null
+    const match = environments.find(
+        (env) =>
+            env.slug === envName ||
+            env.name === envName ||
+            env.name?.toLowerCase() === envName.toLowerCase(),
+    )
+    return match?.slug ?? null
+}
+
 export const useSelectDeployVariant = () => {
     const state = useAtomValue(selectDeployVariantStateAtom)
     const close = useSetAtom(closeSelectDeployVariantModalAtom)
     const {mutateAsync: publish, isPending} = useAtomValue(publishMutationAtom)
     const appId = useAtomValue(routerAppIdAtom)
+    const envListQuery = useAtomValue(environmentsListQueryAtomFamily(false))
 
     const [selectedRowKeys, setSelectedRowKeys] = useState<(string | number)[]>([])
     const [note, setNote] = useState("")
@@ -100,6 +115,14 @@ export const useSelectDeployVariant = () => {
         if (!row) return
 
         const envName = state.envName
+        const environmentSlug = resolveEnvironmentSlug(
+            envName,
+            envListQuery.data?.environments ?? [],
+        )
+        if (!environmentSlug) {
+            message.error(`Environment "${envName}" not found`)
+            return
+        }
 
         // Resolve application slug from the workflows list
         const store = getDefaultStore()
@@ -110,7 +133,7 @@ export const useSelectDeployVariant = () => {
         try {
             await publish({
                 revisionId: row.revisionId,
-                environmentSlug: envName,
+                environmentSlug,
                 applicationId: row.workflowId || appId || "",
                 workflowVariantId: row.variantId || undefined,
                 variantSlug: row.variantSlug || undefined,
@@ -124,7 +147,7 @@ export const useSelectDeployVariant = () => {
             const errorMessage = e instanceof Error ? e.message : "Deployment failed"
             message.error(errorMessage)
         }
-    }, [state.envName, publish, appId, note, close])
+    }, [state.envName, envListQuery.data, publish, appId, note, close])
 
     return {
         close,

--- a/web/oss/src/components/EvaluationRunsTablePOC/atoms/fetchAutoEvaluationRuns.ts
+++ b/web/oss/src/components/EvaluationRunsTablePOC/atoms/fetchAutoEvaluationRuns.ts
@@ -197,7 +197,7 @@ const extractPreviewRunMeta = (run: PreviewEvaluationRun): PreviewRunColumnMeta 
         ? evaluatorDefsRaw
               .map((evaluator: any) => ({
                   id: normalizeString(evaluator?.id),
-                  slug: normalizeString(evaluator?.slug ?? evaluator?.key),
+                  slug: normalizeString(evaluator?.slug),
                   name: normalizeString(evaluator?.name) ?? normalizeString(evaluator?.label),
               }))
               .filter((item: any) => item.id || item.slug || item.name)

--- a/web/oss/src/components/EvaluationRunsTablePOC/hooks/useEvaluationRunsColumns/index.tsx
+++ b/web/oss/src/components/EvaluationRunsTablePOC/hooks/useEvaluationRunsColumns/index.tsx
@@ -232,10 +232,7 @@ const useEvaluationRunsColumns = ({
                     evaluatorHandles.projectId = projectId
                 }
                 const evaluatorRef = resolveEvaluatorReferenceCandidate(refs)
-                const slugCandidate =
-                    evaluatorHandles.slug ??
-                    normalizeString(evaluatorRef?.slug) ??
-                    normalizeString(evaluatorRef?.key)
+                const slugCandidate = evaluatorHandles.slug ?? normalizeString(evaluatorRef?.slug)
                 const groupKey =
                     slugCandidate ??
                     evaluatorHandles.id ??

--- a/web/oss/src/components/EvaluationRunsTablePOC/hooks/useEvaluationRunsColumns/index.tsx
+++ b/web/oss/src/components/EvaluationRunsTablePOC/hooks/useEvaluationRunsColumns/index.tsx
@@ -214,7 +214,8 @@ const useEvaluationRunsColumns = ({
             const stepInfoMap = new Map<
                 string,
                 {
-                    slug: string
+                    slug: string | null
+                    groupKey: string
                     label: string
                     id: string | null
                     handles: EvaluatorHandles
@@ -234,7 +235,10 @@ const useEvaluationRunsColumns = ({
                 const slugCandidate =
                     evaluatorHandles.slug ??
                     normalizeString(evaluatorRef?.slug) ??
-                    normalizeString(evaluatorRef?.key) ??
+                    normalizeString(evaluatorRef?.key)
+                const groupKey =
+                    slugCandidate ??
+                    evaluatorHandles.id ??
                     normalizeString(evaluatorRef?.id) ??
                     normalizeString(step.key) ??
                     step.key
@@ -242,9 +246,11 @@ const useEvaluationRunsColumns = ({
                     evaluatorHandles.name ??
                     normalizeString(evaluatorRef?.name) ??
                     slugCandidate ??
+                    groupKey ??
                     step.key
                 stepInfoMap.set(step.key, {
-                    slug: slugCandidate ?? step.key,
+                    slug: slugCandidate,
+                    groupKey,
                     label: humanizeEvaluatorName(labelCandidate ?? step.key),
                     id: evaluatorHandles.id ?? normalizeString(evaluatorRef?.id) ?? null,
                     handles: evaluatorHandles,
@@ -261,7 +267,7 @@ const useEvaluationRunsColumns = ({
                 const metricPath = normalizeString(mapping?.path)
                 if (!metricPath) return
                 const canonicalPath = canonicalizeMetricKey(metricPath)
-                const descriptorId = `${stepInfo.slug}:${canonicalPath}`
+                const descriptorId = `${stepInfo.groupKey}:${canonicalPath}`
                 const metricLabelSource = mapping?.name ?? metricPath
                 const metricLabel = humanizeMetricPath(metricLabelSource ?? metricPath)
                 const outputType = normalizeString(mapping?.outputType)?.toLowerCase() ?? null
@@ -273,17 +279,17 @@ const useEvaluationRunsColumns = ({
                 const referenceIdCandidate =
                     handles.id ?? handles.revisionId ?? handles.variantId ?? stepInfo.id ?? null
 
-                let group = groups.get(stepInfo.slug)
+                let group = groups.get(stepInfo.groupKey)
                 if (!group) {
                     group = {
-                        id: stepInfo.slug,
+                        id: stepInfo.groupKey,
                         label: stepInfo.label,
                         referenceId: referenceIdCandidate,
                         projectIds: new Set<string>(),
                         handles: handles,
                         metrics: new Map<string, RunMetricDescriptor>(),
                     }
-                    groups.set(stepInfo.slug, group)
+                    groups.set(stepInfo.groupKey, group)
                 }
                 if (referenceIdCandidate && !group.referenceId) {
                     group.referenceId = referenceIdCandidate
@@ -308,7 +314,7 @@ const useEvaluationRunsColumns = ({
                         stepKeysByRunId: {[runId]: stepKey},
                         metricPathsByRunId: {[runId]: metricPath},
                         evaluatorRef: {
-                            slug: handles.slug ?? stepInfo.slug,
+                            slug: handles.slug ?? stepInfo.slug ?? null,
                             id: handles.id ?? null,
                             variantId: handles.variantId ?? null,
                             variantSlug: handles.variantSlug ?? null,
@@ -336,7 +342,7 @@ const useEvaluationRunsColumns = ({
                     }
                     const priorRef = descriptor.evaluatorRef ?? {}
                     descriptor.evaluatorRef = {
-                        slug: priorRef.slug ?? handles.slug ?? stepInfo.slug,
+                        slug: priorRef.slug ?? handles.slug ?? stepInfo.slug ?? null,
                         id: priorRef.id ?? handles.id ?? null,
                         variantId: priorRef.variantId ?? handles.variantId ?? null,
                         variantSlug: priorRef.variantSlug ?? handles.variantSlug ?? null,

--- a/web/oss/src/components/EvaluationRunsTablePOC/hooks/useEvaluationRunsColumns/utils.tsx
+++ b/web/oss/src/components/EvaluationRunsTablePOC/hooks/useEvaluationRunsColumns/utils.tsx
@@ -63,11 +63,8 @@ export const resolveEvaluatorHandles = (
 
     const slug =
         normalizeString(evaluator.slug) ??
-        normalizeString(evaluator.key) ??
         normalizeString(evaluatorVariant.slug) ??
-        normalizeString(evaluatorVariant.key) ??
         normalizeString(evaluatorRevision.slug) ??
-        normalizeString(evaluatorRevision.key) ??
         null
 
     const name =
@@ -78,11 +75,9 @@ export const resolveEvaluatorHandles = (
 
     const id = normalizeString(evaluator.id)
     const variantId = normalizeString(evaluatorVariant.id)
-    const variantSlug =
-        normalizeString(evaluatorVariant.slug) ?? normalizeString(evaluatorVariant.key) ?? null
+    const variantSlug = normalizeString(evaluatorVariant.slug) ?? null
     const revisionId = normalizeString(evaluatorRevision.id)
-    const revisionSlug =
-        normalizeString(evaluatorRevision.slug) ?? normalizeString(evaluatorRevision.key) ?? null
+    const revisionSlug = normalizeString(evaluatorRevision.slug) ?? null
 
     return {
         slug,

--- a/web/oss/src/components/References/atoms/entityReferences.ts
+++ b/web/oss/src/components/References/atoms/entityReferences.ts
@@ -422,7 +422,7 @@ const toEnvironmentReference = (
     appId: string | null,
 ): EnvironmentReference => ({
     id: null, // Entity deployment doesn't expose environment ID
-    slug: env.name,
+    slug: env.slug,
     name: env.name,
     appId: appId ?? null,
     deployedAppVariantId: env.deployedVariantId ?? null,

--- a/web/oss/src/components/VariantsComponents/index.tsx
+++ b/web/oss/src/components/VariantsComponents/index.tsx
@@ -383,6 +383,7 @@ const VariantsDashboard = () => {
             <DeploymentsDashboard
                 environmentId={selectedEnvironmentId}
                 environmentName={selectedEnv || ""}
+                environmentSlug={selectedEnvironmentEntity?.slug ?? selectedEnv ?? ""}
                 currentDeployedRevisionId={currentDeployedRevisionId}
             />
         </div>

--- a/web/oss/src/components/pages/overview/deployments/DeploymentDrawer/index.tsx
+++ b/web/oss/src/components/pages/overview/deployments/DeploymentDrawer/index.tsx
@@ -97,13 +97,13 @@ const DeploymentDrawer = ({
 
         const built = createParams(
             synthesized,
-            selectedEnvironment?.name || "none",
+            selectedEnvironment?.slug || "none",
             "add_a_value",
             currentApp,
             {flags: {is_chat: isChat}},
         )
         return built
-    }, [inputPorts, currentApp, selectedEnvironment?.name, isChat])
+    }, [inputPorts, currentApp, selectedEnvironment?.slug, isChat])
 
     const invokeLlmUrl = (uri && uri.trim()) || ""
 
@@ -114,9 +114,9 @@ const DeploymentDrawer = ({
     }
 
     const fetchConfigCodeSnippet: Record<string, string> = {
-        python: fetchConfigpythonCode(currentApp?.slug ?? "", selectedEnvironment?.name!, ""),
-        bash: fetchConfigcURLCode(currentApp?.slug ?? "", selectedEnvironment?.name!, ""),
-        typescript: fetchConfigtsCode(currentApp?.slug ?? "", selectedEnvironment?.name!, ""),
+        python: fetchConfigpythonCode(currentApp?.slug ?? "", selectedEnvironment?.slug!, ""),
+        bash: fetchConfigcURLCode(currentApp?.slug ?? "", selectedEnvironment?.slug!, ""),
+        typescript: fetchConfigtsCode(currentApp?.slug ?? "", selectedEnvironment?.slug!, ""),
     }
 
     const handleOpenSelectDeployVariantModal = () => {

--- a/web/oss/src/components/pages/overview/deployments/DeploymentModal.tsx
+++ b/web/oss/src/components/pages/overview/deployments/DeploymentModal.tsx
@@ -31,7 +31,7 @@ const DeploymentModal = ({
 
             await publish({
                 revisionId: selectedVariant.id,
-                environmentSlug: selectedEnvironment.name,
+                environmentSlug: selectedEnvironment.slug,
                 applicationId: selectedVariant.workflow_id || "",
                 workflowVariantId: selectedVariant.workflow_variant_id ?? undefined,
                 variantSlug:

--- a/web/oss/src/pages/w/[workspace_id]/p/[project_id]/apps/[app_id]/endpoints/index.tsx
+++ b/web/oss/src/pages/w/[workspace_id]/p/[project_id]/apps/[app_id]/endpoints/index.tsx
@@ -98,7 +98,7 @@ const createParamsFromSchema = (
 }
 
 /**
- * Build example params JSON from synthesized Parameter[] + environment name.
+ * Build example params JSON from synthesized Parameter[] + environment slug.
  * Used by DeploymentDrawer and UseApiContent for environment-based code snippets.
  */
 export const createParams = (

--- a/web/oss/src/pages/w/[workspace_id]/p/[project_id]/apps/[app_id]/endpoints/index.tsx
+++ b/web/oss/src/pages/w/[workspace_id]/p/[project_id]/apps/[app_id]/endpoints/index.tsx
@@ -67,7 +67,7 @@ const {Text, Title} = Typography
  */
 const createParamsFromSchema = (
     inputSchema: Record<string, unknown> | null,
-    environmentName: string,
+    environmentSlug: string,
     isChat: boolean,
     appSlug: string | null,
 ): string => {
@@ -91,7 +91,7 @@ const createParamsFromSchema = (
         data: {inputs},
         references: {
             ...(appSlug ? {application: {slug: appSlug}} : {}),
-            environment: {slug: environmentName},
+            environment: {slug: environmentSlug},
         },
     }
     return JSON.stringify(params, null, 2)
@@ -103,7 +103,7 @@ const createParamsFromSchema = (
  */
 export const createParams = (
     inputParams: Parameter[] | null,
-    environmentName: string,
+    environmentSlug: string,
     value: string | number,
     app?: {name?: string | null; slug?: string | null; flags?: {is_chat?: boolean} | null} | null,
     revision?: {flags?: {is_chat?: boolean} | null} | null,
@@ -130,7 +130,7 @@ export const createParams = (
         data: {inputs},
         references: {
             ...(appSlug ? {application: {slug: appSlug}} : {}),
-            environment: {slug: environmentName},
+            environment: {slug: environmentSlug},
         },
     }
     return JSON.stringify(params, null, 2)
@@ -204,11 +204,11 @@ function VariantEndpointContent() {
         () =>
             createParamsFromSchema(
                 inputSchema,
-                selectedEnvironment?.name || "none",
+                selectedEnvironment?.slug || "none",
                 isChat,
                 currentApp?.slug ?? null,
             ),
-        [inputSchema, selectedEnvironment?.name, isChat, currentApp?.slug],
+        [inputSchema, selectedEnvironment?.slug, isChat, currentApp?.slug],
     )
 
     const appSlug = currentApp?.slug ?? ""
@@ -275,7 +275,7 @@ function VariantEndpointContent() {
                 icon: <HistoryOutlined />,
                 children: (
                     <DeploymentHistory
-                        environmentSlug={selectedEnvironment?.name ?? ""}
+                        environmentSlug={selectedEnvironment?.slug ?? ""}
                         appId={appId}
                     />
                 ),

--- a/web/packages/agenta-annotation/src/state/controllers/annotationSessionController.ts
+++ b/web/packages/agenta-annotation/src/state/controllers/annotationSessionController.ts
@@ -556,15 +556,14 @@ const testsetSyncEvaluatorsAtom = atom<TestsetSyncEvaluator[]>((get) => {
             step.references?.evaluator_variant?.slug ??
             deriveEvaluatorSlugFromStepKey(step.key) ??
             evaluatorEntity?.slug ??
-            step.references?.evaluator_revision?.slug ??
-            workflowId
+            step.references?.evaluator_revision?.slug
 
         if (!slug && !workflowId) continue
         const key = workflowId ?? slug
         if (!key) continue
 
         byKey.set(key, {
-            slug: slug ?? key ?? "",
+            slug: slug ?? "",
             name,
             workflowId,
         })

--- a/web/packages/agenta-entities/src/environment/state/appDeployments.ts
+++ b/web/packages/agenta-entities/src/environment/state/appDeployments.ts
@@ -26,6 +26,8 @@ import {environmentsListQueryAtomFamily} from "./store"
  * This is the shape all deployment UI components consume.
  */
 export interface AppEnvironmentDeployment {
+    /** Environment slug (e.g., "production") */
+    slug: string
     /** Environment name (e.g., "production") */
     name: string
     /** Variant display name (app prefix stripped) */
@@ -105,6 +107,7 @@ function toAppEnvironmentDeployment(env: Environment, appId: string): AppEnviron
     }
 
     return {
+        slug: env.slug ?? "",
         name: env.name ?? env.slug ?? "",
         deployedVariantName: variantName,
         deployedVariantId: dep?.applicationVariant?.id ?? null,

--- a/web/packages/agenta-entities/src/runnable/deploy.ts
+++ b/web/packages/agenta-entities/src/runnable/deploy.ts
@@ -15,6 +15,8 @@ import {deployToEnvironment} from "../environment/api/mutations"
 import type {Environment} from "../environment/core"
 import {invalidateEnvironmentsListCache} from "../environment/state/environmentMolecule"
 import {environmentsListQueryAtomFamily} from "../environment/state/store"
+import {workflowsListDataAtom, workflowMolecule} from "../workflow"
+import type {Workflow} from "../workflow/core"
 
 // ============================================================================
 // PAYLOAD TYPES
@@ -83,6 +85,19 @@ function resolveAppKey(env: Environment, applicationId: string, applicationSlug?
     return `${applicationId}.revision`
 }
 
+function resolveApplicationSlug(
+    workflows: Workflow[],
+    payload: Pick<PublishPayload, "applicationId" | "applicationSlug" | "revisionId">,
+): string | undefined {
+    if (payload.applicationSlug) return payload.applicationSlug
+
+    const revision = workflowMolecule.get.data(payload.revisionId)
+    const revisionSlug = revision?.workflow_slug ?? revision?.artifact_slug ?? undefined
+    if (revisionSlug) return revisionSlug
+
+    return workflows.find((workflow) => workflow.id === payload.applicationId)?.slug ?? undefined
+}
+
 // ============================================================================
 // PUBLISH MUTATION
 // ============================================================================
@@ -103,6 +118,7 @@ export const publishMutationAtom = atomWithMutation<void, PublishPayload>((get) 
         // Resolve environment from list cache
         const listQuery = get(environmentsListQueryAtomFamily(false))
         const environments = listQuery.data?.environments ?? []
+        const workflows = get(workflowsListDataAtom)
         const env = resolveEnvironmentBySlug(environments, payload.environmentSlug)
 
         if (!env) {
@@ -119,7 +135,8 @@ export const publishMutationAtom = atomWithMutation<void, PublishPayload>((get) 
             )
         }
 
-        const appKey = resolveAppKey(env, payload.applicationId, payload.applicationSlug)
+        const applicationSlug = resolveApplicationSlug(workflows, payload)
+        const appKey = resolveAppKey(env, payload.applicationId, applicationSlug)
 
         await deployToEnvironment({
             projectId,
@@ -129,7 +146,7 @@ export const publishMutationAtom = atomWithMutation<void, PublishPayload>((get) 
             references: {
                 application: {
                     id: payload.applicationId,
-                    slug: payload.applicationSlug,
+                    slug: applicationSlug,
                 },
                 application_variant: {
                     id: payload.workflowVariantId,
@@ -173,6 +190,7 @@ export async function publishToEnvironment(payload: PublishPayload): Promise<voi
 
     const listQuery = store.get(environmentsListQueryAtomFamily(false))
     const environments = listQuery.data?.environments ?? []
+    const workflows = store.get(workflowsListDataAtom)
     const env = resolveEnvironmentBySlug(environments, payload.environmentSlug)
 
     if (!env) {
@@ -183,7 +201,8 @@ export async function publishToEnvironment(payload: PublishPayload): Promise<voi
         throw new Error(`Environment "${payload.environmentSlug}" has no variant_id.`)
     }
 
-    const appKey = resolveAppKey(env, payload.applicationId, payload.applicationSlug)
+    const applicationSlug = resolveApplicationSlug(workflows, payload)
+    const appKey = resolveAppKey(env, payload.applicationId, applicationSlug)
 
     await deployToEnvironment({
         projectId,
@@ -193,7 +212,7 @@ export async function publishToEnvironment(payload: PublishPayload): Promise<voi
         references: {
             application: {
                 id: payload.applicationId,
-                slug: payload.applicationSlug,
+                slug: applicationSlug,
             },
             application_variant: {
                 id: payload.workflowVariantId,


### PR DESCRIPTION
## What changed

Tightened `slug` handling across `web` `environment`, `annotation`, and `evaluation` flows so `slug` fields only carry real `slugs` and never fall back to `names`, `ids`, `step` `keys`, or generic `keys`.

This fixes the `environment` `revision` bug where deploys from the _Playground_ could create `keys` like `<id>.revision` when the `application` `slug` was missing momentarily, and it cleans up related `environment`/`evaluator` paths by separating true `slugs` from synthetic grouping or display identifiers.

## Scoped QA

- [x] Deploy an `application` `revision` from _Playground_ to an `environment` and confirm the `environment` `revision` `key` is `<slug>.revision`, not `<id>.revision`.
- [x] Deploy/revert from the _Deployments_ dashboard and confirm `environment` targeting still works with real `environment` `slugs`.
- [x] Check API snippet/example payloads on the `application` endpoints page and confirm `references.environment.slug` uses the actual `environment` `slug`.
- [x] Verify `environment` cards/drawers/history still render correctly.
- [x] Exercise `annotation`/`testset` sync flows and confirm `evaluator` matching still works correctly.
- [x] Check `evaluation` `metrics` grouping/headers/export paths and confirm grouping still works correctly.