### PR TITLE
fix(frontend): resolve evaluator identifier by slug/key fallback so "Open evaluator registry" navigates correctly

### DIFF
--- a/web/oss/src/components/SharedDrawers/TraceDrawer/hooks/useEvaluatorNavigation.ts
+++ b/web/oss/src/components/SharedDrawers/TraceDrawer/hooks/useEvaluatorNavigation.ts
@@ -13,7 +13,7 @@ interface NavigationTarget {
 
 const getEvaluatorIdentifier = (evaluator: any) => {
     if (!evaluator) return null
-    return evaluator.id
+    return evaluator.id ?? evaluator.slug ?? evaluator.key ?? null
 }
 
 const isHumanEvaluator = (evaluator: any) => {


### PR DESCRIPTION
## Summary

Fixes #4535.

In the trace drawer, the **"Open evaluator registry"** button (rendered by `EvaluatorDetailsPopover`) did not work. The button only renders and navigates when `buildEvaluatorTarget()` returns a non-null target, and that depends on `getEvaluatorIdentifier()` in `useEvaluatorNavigation`.

`getEvaluatorIdentifier()` only read `evaluator.id`:

```ts
return evaluator.id
```

However, `EvaluatorDetailsPopover` itself resolves the identifier as `id || slug || key`. So when an evaluator is identified by `slug`/`key` rather than `id`, `getEvaluatorIdentifier()` returned `undefined`, `buildEvaluatorTarget()` returned `null`, and the button silently did nothing.

## Change

Make the identifier resolution consistent with how the popover reads it, by adding a fallback:

```ts
return evaluator.id ?? evaluator.slug ?? evaluator.key ?? null
```

This restores navigation to the evaluator playground (auto) / evaluators tab (human) for evaluators that don't expose an `id`.

## Notes

This is a minimal, focused change to the identifier resolution only. I wasn't able to run the app to reproduce end-to-end, so please verify against the failing case — happy to adjust if the intended root cause is different.