### PR TITLE
[3324] fix(frontend): show actual evaluation error messages

### DIFF
--- a/web/oss/src/components/pages/evaluations/cellRenderers/cellRenderers.tsx
+++ b/web/oss/src/components/pages/evaluations/cellRenderers/cellRenderers.tsx
@@ -58,6 +58,12 @@ const useStyles = createUseStyles((theme: JSSTheme) => ({
             borderRadius: "50%",
         },
     },
+    statusLabel: {
+        minWidth: 0,
+        overflow: "hidden",
+        textOverflow: "ellipsis",
+        whiteSpace: "nowrap",
+    },
     dot: {
         height: 3,
         aspectRatio: 1 / 1,
@@ -256,14 +262,20 @@ export const StatusRenderer = memo(
         const {label, color} = statusMapper(token)(params.data?.status.value as EvaluationStatus)
         const errorMsg = params.data?.status.error?.message
         const errorStacktrace = params.data?.status.error?.stacktrace
+        const statusLabel = errorMsg || label
+        const tooltipTitle = errorMsg
+            ? [label, errorMsg, errorStacktrace].filter(Boolean).join("\n\n")
+            : undefined
 
         return (
             <Typography.Text className={classes.statusCell}>
                 <div style={{backgroundColor: color}} />
-                <span>{label}</span>
+                <Tooltip title={tooltipTitle}>
+                    <span className={classes.statusLabel}>{statusLabel}</span>
+                </Tooltip>
                 {errorMsg && (
                     <span style={{marginRight: 2}}>
-                        <Tooltip title={errorStacktrace ? errorStacktrace : ""}>
+                        <Tooltip title={tooltipTitle}>
                             <InfoCircleOutlined />
                         </Tooltip>
                     </span>


### PR DESCRIPTION
## Summary

Fixes #3324.

This updates the evaluation status cell to surface the actual error message when a run status includes `status.error.message`, instead of only showing the generic status label. The tooltip now includes the status label, visible error message, and stacktrace when available, so users can see both the actionable provider message and technical details.

## Changes

- Display `status.error.message` directly in the status cell when present
- Keep long error text truncated with ellipsis in the table cell
- Include the generic status label and stacktrace in the tooltip for diagnostic context

## Testing

- `npx --yes prettier@3.7.4 --check web/oss/src/components/pages/evaluations/cellRenderers/cellRenderers.tsx`

## Notes

I could not run the full frontend type/lint suite locally because this checkout did not have dependencies installed and the local environment does not expose a `pnpm` shim. The change is scoped to one renderer and preserves the existing status mapping behavior when no error message is present.