### PR TITLE
[4535] fix(frontend): fix evaluator playground navigation from trace drawer

### DIFF
--- a/web/oss/src/components/SharedDrawers/TraceDrawer/components/EvaluatorDetailsPopover.tsx
+++ b/web/oss/src/components/SharedDrawers/TraceDrawer/components/EvaluatorDetailsPopover.tsx
@@ -1,8 +1,10 @@
 import {memo, ReactNode, useMemo} from "react"
 
 import {UserAuthorLabel} from "@agenta/entities/shared/user"
+import {workflowLatestRevisionIdAtomFamily} from "@agenta/entities/workflow"
 import type {Workflow} from "@agenta/entities/workflow"
 import {Button, Popover, Typography} from "antd"
+import {useAtomValue} from "jotai"
 
 import ReferenceTag from "@/oss/components/References/ReferenceTag"
 
@@ -37,6 +39,7 @@ const EvaluatorDetailsPopover = ({
     children,
 }: EvaluatorDetailsPopoverProps) => {
     const {buildEvaluatorTarget, navigateToEvaluator} = useEvaluatorNavigation()
+    const latestRevisionId = useAtomValue(workflowLatestRevisionIdAtomFamily(evaluator?.id || ""))
 
     const evaluatorName = evaluator?.name || fallbackLabel
     const evaluatorId =
@@ -51,7 +54,18 @@ const EvaluatorDetailsPopover = ({
         Boolean((evaluator as any)?.flags?.is_feedback) ||
         Boolean((evaluator as any)?.meta?.is_feedback)
 
-    const target = useMemo(() => buildEvaluatorTarget(evaluator), [buildEvaluatorTarget, evaluator])
+    const evaluatorWithLatestRevision = useMemo(() => {
+        if (!latestRevisionId) return null
+        return {...(evaluator || {}), id: latestRevisionId}
+    }, [evaluator, latestRevisionId])
+
+    const target = useMemo(() => {
+        if (isHuman) {
+            return buildEvaluatorTarget(evaluator)
+        }
+        if (!evaluatorWithLatestRevision) return null
+        return buildEvaluatorTarget(evaluatorWithLatestRevision)
+    }, [isHuman, buildEvaluatorTarget, evaluator, evaluatorWithLatestRevision])
 
     const popoverContent = (
         <div className="w-[250px]">
@@ -112,10 +126,10 @@ const EvaluatorDetailsPopover = ({
                         onClick={(event) => {
                             event?.preventDefault?.()
                             event?.stopPropagation?.()
-                            navigateToEvaluator(evaluator)
+                            navigateToEvaluator(isHuman ? evaluator : evaluatorWithLatestRevision)
                         }}
                     >
-                        Open evaluator registry
+                        {isHuman ? "Open evaluator registry" : "Open evaluator playground"}
                     </Button>
                 ) : null}
             </div>


### PR DESCRIPTION
Fixes #4535.

## Summary

The trace drawer was building evaluator playground links with the evaluator workflow ID, but the playground route expects a workflow revision ID.

This updates EvaluatorDetailsPopover to resolve the latest workflow revision before building playground navigation for automatic evaluators. Human evaluators continue to open the registry route.

The button text now reflects the destination:
- human evaluators: "Open evaluator registry"
- automatic evaluators: "Open evaluator playground"

## Verification

- npx eslint
- npx prettier --check
- git diff --check