### PR TITLE
[fix] Render markdown headings by level instead of uppercasing

### DIFF
--- a/web/oss/src/styles/editor-theme.css
+++ b/web/oss/src/styles/editor-theme.css
@@ -187,25 +187,44 @@ h1 {
     margin-bottom: 0;
 }
 
-.editor-heading-h1 {
-    font-size: 18px;
+.editor-heading-h1,
+.editor-heading-h2,
+.editor-heading-h3,
+.editor-heading-h4,
+.editor-heading-h5,
+.editor-heading-h6 {
     color: rgb(5, 5, 5);
-    font-weight: 400;
+    font-weight: 600;
     margin: 0;
-    margin-bottom: 12px;
+    margin-top: 16px;
+    margin-bottom: 8px;
     padding: 0;
-    line-height: 1.5;
+    line-height: 1.3;
+}
+
+.editor-heading-h1 {
+    font-size: 24px;
 }
 
 .editor-heading-h2 {
+    font-size: 20px;
+}
+
+.editor-heading-h3 {
+    font-size: 17px;
+}
+
+.editor-heading-h4 {
     font-size: 15px;
+}
+
+.editor-heading-h5 {
+    font-size: 14px;
+}
+
+.editor-heading-h6 {
+    font-size: 13px;
     color: rgb(101, 103, 107);
-    font-weight: 700;
-    margin: 0;
-    margin-top: 10px;
-    padding: 0;
-    text-transform: uppercase;
-    line-height: 1.35;
 }
 
 .editor-quote {
@@ -686,10 +705,14 @@ pre::-webkit-scrollbar-thumb {
 .dark .other a {
     color: rgba(255, 255, 255, 0.65);
 }
-.dark .editor-heading-h1 {
+.dark .editor-heading-h1,
+.dark .editor-heading-h2,
+.dark .editor-heading-h3,
+.dark .editor-heading-h4,
+.dark .editor-heading-h5 {
     color: rgba(255, 255, 255, 0.85);
 }
-.dark .editor-heading-h2,
+.dark .editor-heading-h6,
 .dark .editor-quote {
     color: rgba(255, 255, 255, 0.65);
 }


### PR DESCRIPTION
## Context
In the playground and the beautified markdown view, every `## Heading` you typed rendered in all caps. The Lexical editor theme applied `text-transform: uppercase` to H2, so it rewrote your own prompt text. H1 also rendered lighter than H2, and H3 to H6 had no styling and fell back to browser defaults, so the heading hierarchy looked inconsistent.

## Changes
Replaced the H1/H2-only rules in `web/oss/src/styles/editor-theme.css` with one shared rule for H1 to H6 (same color, weight 600, spacing, line-height) plus a descending size scale. Removed the uppercase transform. Extended the dark-mode override to cover all six levels so the new explicit colors do not render dark-on-dark.

Before: `## Some Heading` showed as `SOME HEADING`.
After: it shows as `Some Heading`, sized by its level.

Size scale: H1 24px, H2 20px, H3 17px, H4 15px, H5 14px, H6 13px (muted).
<img width="3024" height="5345" alt="CleanShot 2026-06-04 at 19 22 14@2x" src="https://github.com/user-attachments/assets/304f8292-cacb-4699-a10f-0f02461411c4" />

<img width="2404" height="1526" alt="CleanShot 2026-06-04 at 19 22 30@2x" src="https://github.com/user-attachments/assets/05eab730-f962-48e9-b8ba-20a97f2cc08c" />
