### PR TITLE
feat(frontend): Run-on mode selector for the evaluator playground

### DIFF
--- a/web/oss/src/components/Evaluators/components/ConfigureEvaluator/EvaluatorPlaygroundHeader.tsx
+++ b/web/oss/src/components/Evaluators/components/ConfigureEvaluator/EvaluatorPlaygroundHeader.tsx
@@ -20,7 +20,14 @@ import {Button, Tooltip, Typography} from "antd"
 import {useAtomValue, useSetAtom} from "jotai"
 import dynamic from "next/dynamic"
 
-import {disconnectAppFromEvaluatorAtom, selectedAppLabelAtom} from "./atoms"
+import {
+    disconnectAppFromEvaluatorAtom,
+    effectiveRunOnModeAtom,
+    runOnModeAtom,
+    selectedAppLabelAtom,
+    type RunOnMode,
+} from "./atoms"
+import RunOnSelector from "./RunOnSelector"
 
 const TestsetDropdown = dynamic(
     () => import("@/oss/components/Playground/Components/TestsetDropdown"),
@@ -77,6 +84,23 @@ const EvaluatorPlaygroundHeader: React.FC<EvaluatorPlaygroundHeaderProps> = ({
         disconnectApp()
     }, [disconnectApp])
 
+    // Run-on mode — drives which loaders are surfaced. A connected app forces
+    // "app" mode (see effectiveRunOnModeAtom); the stored mode only matters when
+    // nothing is connected.
+    const runOnMode = useAtomValue(effectiveRunOnModeAtom)
+    const setRunOnMode = useSetAtom(runOnModeAtom)
+    const handlePickRunOn = useCallback(
+        (next: RunOnMode) => {
+            if (next === "trace") return // disabled, not selectable
+            // Leaving "app" mode means dropping the connected app so the graph
+            // returns to standalone-evaluator shape.
+            if (next === "data") disconnectApp()
+            setRunOnMode(next)
+        },
+        [disconnectApp, setRunOnMode],
+    )
+    const isAppMode = runOnMode === "app"
+
     // Check if we have an app node (depth-0 with a different entity than evaluator)
     const hasAppSelected = nodes.some((n) => n.depth === 0 && n.entityId !== evaluatorEntityId)
 
@@ -100,15 +124,18 @@ const EvaluatorPlaygroundHeader: React.FC<EvaluatorPlaygroundHeaderProps> = ({
             </div>
 
             <div className="flex min-w-0 flex-1 items-center justify-end gap-1">
-                <EntityPicker<WorkflowRevisionSelectionResult>
-                    variant="popover-cascader"
-                    adapter={appWorkflowAdapter}
-                    onSelect={onAppSelect}
-                    size="small"
-                    placeholder={selectedAppLabel ?? "Select app"}
-                    popupFooter={popupFooter}
-                />
-                {hasAppSelected && (
+                <RunOnSelector mode={runOnMode} onPick={handlePickRunOn} />
+                {isAppMode && (
+                    <EntityPicker<WorkflowRevisionSelectionResult>
+                        variant="popover-cascader"
+                        adapter={appWorkflowAdapter}
+                        onSelect={onAppSelect}
+                        size="small"
+                        placeholder={selectedAppLabel ?? "Select app"}
+                        popupFooter={popupFooter}
+                    />
+                )}
+                {isAppMode && hasAppSelected && (
                     <Tooltip title="Disconnect app">
                         <Button
                             type="text"

--- a/web/oss/src/components/Evaluators/components/ConfigureEvaluator/RunOnSelector.tsx
+++ b/web/oss/src/components/Evaluators/components/ConfigureEvaluator/RunOnSelector.tsx
@@ -1,0 +1,295 @@
+/**
+ * RunOnSelector
+ *
+ * The "Run on" control for the evaluator playground header. A leading dropdown
+ * that names the data source the evaluator runs against and draws the resulting
+ * data-flow, so the empty/first state explains itself instead of leaving the
+ * user with two disconnected loaders.
+ *
+ * Three modes:
+ *  - Run directly on data  (Data → Evaluator → Score)
+ *  - Run on an app         (Data → App → Output → Evaluator → Score) — default
+ *  - Run on a trace        (Trace → Evaluator → Score) — disabled for now
+ *
+ * All colors come from the live antd token (`theme.useToken()`) so the control
+ * follows light/dark mode automatically.
+ */
+
+import {useState} from "react"
+
+import {AppstoreOutlined} from "@ant-design/icons"
+import {
+    CaretDownIcon,
+    CheckIcon,
+    DatabaseIcon,
+    GavelIcon,
+    TreeViewIcon,
+} from "@phosphor-icons/react"
+import {Button, Dropdown, theme} from "antd"
+import type {GlobalToken} from "antd"
+import clsx from "clsx"
+
+import type {RunOnMode} from "./atoms"
+
+// The app icon used across the product (the sidebar "Prompts" item). Wrapped so
+// it accepts the same `size`/`style` props as the phosphor icons it sits beside.
+const AppIcon = ({size = 16, style}: {size?: number; style?: React.CSSProperties}) => (
+    <AppstoreOutlined style={{fontSize: size, ...style}} />
+)
+
+// ── flow pills ──────────────────────────────────────────────────────────────
+
+type FlowVariant = "data" | "app" | "out" | "eval" | "trace"
+
+interface FlowNode {
+    label: string
+    variant: FlowVariant
+}
+
+const flowStyle = (token: GlobalToken, variant: FlowVariant): React.CSSProperties => {
+    switch (variant) {
+        case "data":
+            return {background: token.blue1, color: token.blue7, borderColor: token.blue2}
+        case "app":
+            return {
+                background: token.colorPrimaryBg,
+                color: token.colorText,
+                borderColor: token.colorPrimaryBorder,
+            }
+        case "out":
+            return {background: token.green1, color: token.green7, borderColor: token.green3}
+        case "eval":
+            // index 7 (not 6) so the text brightens under the dark algorithm —
+            // purple6 lands dark-on-dark and disappears on a dark background.
+            return {background: token.purple1, color: token.purple7, borderColor: token.purple3}
+        case "trace":
+            return {background: token.cyan1, color: token.cyan7, borderColor: token.cyan3}
+    }
+}
+
+const FlowIcon = ({variant}: {variant: FlowVariant}) => {
+    switch (variant) {
+        case "data":
+            return <DatabaseIcon size={12} />
+        case "app":
+            return <AppIcon size={12} />
+        case "eval":
+            return <GavelIcon size={12} />
+        case "trace":
+            return <TreeViewIcon size={12} />
+        default:
+            return null
+    }
+}
+
+const FlowPills = ({steps, token}: {steps: FlowNode[]; token: GlobalToken}) => (
+    <div className="flex flex-wrap items-center gap-y-1">
+        {steps.map((step, i) => (
+            <span key={`${step.label}-${i}`} className="flex items-center">
+                {i > 0 && (
+                    <span className="px-1.5 text-[12px]" style={{color: token.colorTextQuaternary}}>
+                        →
+                    </span>
+                )}
+                <span
+                    className="inline-flex items-center gap-1 whitespace-nowrap rounded-full border border-solid px-2 py-[3px] text-[11px] leading-none"
+                    style={flowStyle(token, step.variant)}
+                >
+                    <FlowIcon variant={step.variant} />
+                    {step.label}
+                </span>
+            </span>
+        ))}
+    </div>
+)
+
+// ── modes ───────────────────────────────────────────────────────────────────
+
+interface ModeDef {
+    key: RunOnMode
+    /** Full label shown in the dropdown option. */
+    label: string
+    /** Short label shown after "Run on:" in the trigger button. */
+    shortLabel: string
+    Icon: React.ComponentType<{size?: number; style?: React.CSSProperties}>
+    desc: string
+    flow: FlowNode[]
+    badge?: "default" | "soon"
+    disabled?: boolean
+}
+
+const MODES: ModeDef[] = [
+    {
+        key: "data",
+        label: "Run directly on a test case",
+        shortLabel: "Test case",
+        Icon: DatabaseIcon,
+        desc: "Evaluate data you provide. Connect a test set, or type the input and output in by hand.",
+        flow: [
+            {label: "Data", variant: "data"},
+            {label: "Evaluator", variant: "eval"},
+            {label: "Score", variant: "out"},
+        ],
+    },
+    {
+        key: "app",
+        label: "Run on an app output",
+        shortLabel: "App output",
+        Icon: AppIcon,
+        badge: "default",
+        desc: "Run an app over your data, then the evaluator grades its output. The usual evaluation flow.",
+        flow: [
+            {label: "Data", variant: "data"},
+            {label: "App", variant: "app"},
+            {label: "Output", variant: "out"},
+            {label: "Evaluator", variant: "eval"},
+            {label: "Score", variant: "out"},
+        ],
+    },
+    {
+        key: "trace",
+        label: "Run on a trace",
+        shortLabel: "Trace",
+        Icon: TreeViewIcon,
+        badge: "soon",
+        disabled: true,
+        desc: "Pull the input and output straight from a logged trace in Observability.",
+        flow: [
+            {label: "Trace", variant: "trace"},
+            {label: "Evaluator", variant: "eval"},
+            {label: "Score", variant: "out"},
+        ],
+    },
+]
+
+// ── component ───────────────────────────────────────────────────────────────
+
+interface RunOnSelectorProps {
+    mode: RunOnMode
+    onPick: (mode: RunOnMode) => void
+}
+
+const RunOnSelector = ({mode, onPick}: RunOnSelectorProps) => {
+    const {token} = theme.useToken()
+    const [open, setOpen] = useState(false)
+    const [hovered, setHovered] = useState<RunOnMode | null>(null)
+    const current = MODES.find((m) => m.key === mode) ?? MODES.find((m) => m.key === "app")!
+
+    const overlay = (
+        <div
+            className="w-[460px] rounded-lg border border-solid p-1.5"
+            style={{
+                background: token.colorBgElevated,
+                borderColor: token.colorBorderSecondary,
+                boxShadow: token.boxShadowSecondary,
+            }}
+        >
+            <div
+                className="px-2.5 pb-1.5 pt-1 text-[11px] font-semibold uppercase tracking-[0.04em]"
+                style={{color: token.colorTextQuaternary}}
+            >
+                What should the evaluator run on?
+            </div>
+            {MODES.map((m) => {
+                const selected = m.key === mode
+                const isHovered = hovered === m.key
+                const background = selected
+                    ? token.controlItemBgActive
+                    : isHovered && !m.disabled
+                      ? token.colorFillTertiary
+                      : "transparent"
+                return (
+                    <div
+                        key={m.key}
+                        role="button"
+                        aria-disabled={m.disabled}
+                        onMouseEnter={() => setHovered(m.key)}
+                        onMouseLeave={() => setHovered((h) => (h === m.key ? null : h))}
+                        onClick={() => {
+                            if (m.disabled) return
+                            onPick(m.key)
+                            setOpen(false)
+                        }}
+                        className={clsx(
+                            "flex items-start gap-3 rounded-md p-2.5",
+                            m.disabled ? "cursor-default opacity-55" : "cursor-pointer",
+                        )}
+                        style={{background}}
+                    >
+                        <span
+                            className="mt-0.5 flex w-[18px] shrink-0 justify-center"
+                            style={{color: token.colorPrimary}}
+                        >
+                            {selected && <CheckIcon size={16} />}
+                        </span>
+                        <div className="min-w-0 flex-1">
+                            <div
+                                className="flex items-center gap-2 text-[14px] font-medium"
+                                style={{color: token.colorText}}
+                            >
+                                <m.Icon size={15} />
+                                {m.label}
+                                {m.badge === "default" && (
+                                    <span
+                                        className="rounded-full px-[7px] py-px text-[10.5px] font-semibold"
+                                        style={{
+                                            background: token.colorPrimary,
+                                            color: token.colorTextLightSolid,
+                                        }}
+                                    >
+                                        default
+                                    </span>
+                                )}
+                                {m.badge === "soon" && (
+                                    <span
+                                        className="rounded-full px-[7px] py-px text-[10.5px] font-semibold"
+                                        style={{background: token.gold1, color: token.gold8}}
+                                    >
+                                        soon
+                                    </span>
+                                )}
+                            </div>
+                            <div
+                                className="mt-0.5 text-[12.5px] leading-snug"
+                                style={{color: token.colorTextTertiary}}
+                            >
+                                {m.desc}
+                            </div>
+                            <div className="mt-2">
+                                <FlowPills steps={m.flow} token={token} />
+                            </div>
+                        </div>
+                    </div>
+                )
+            })}
+        </div>
+    )
+
+    return (
+        <Dropdown
+            open={open}
+            onOpenChange={setOpen}
+            trigger={["click"]}
+            placement="bottomLeft"
+            popupRender={() => overlay}
+        >
+            <Button
+                size="small"
+                className="flex items-center gap-1.5 font-medium"
+                style={{
+                    background: token.colorPrimaryBg,
+                    borderColor: token.colorPrimaryBorder,
+                }}
+            >
+                <span className="font-normal" style={{color: token.colorTextTertiary}}>
+                    Run on:
+                </span>
+                <current.Icon size={14} style={{color: token.colorText}} />
+                <span className="truncate">{current.shortLabel}</span>
+                <CaretDownIcon size={12} style={{color: token.colorTextTertiary}} />
+            </Button>
+        </Dropdown>
+    )
+}
+
+export default RunOnSelector

--- a/web/oss/src/components/Evaluators/components/ConfigureEvaluator/SelectAppEmptyState.tsx
+++ b/web/oss/src/components/Evaluators/components/ConfigureEvaluator/SelectAppEmptyState.tsx
@@ -1,0 +1,56 @@
+/**
+ * SelectAppEmptyState
+ *
+ * Centered empty state shown in the run/generation panel when the evaluator is
+ * in "Run on an app" mode but no app is connected yet. The evaluator can't run
+ * until an app is picked, so this guides the user to the one action that
+ * unblocks them. Shared by the evaluator playground page and the
+ * evaluator-creation drawer so both read identically.
+ */
+
+import {EntityPicker} from "@agenta/entity-ui"
+import type {
+    EntitySelectionAdapter,
+    WorkflowRevisionSelectionResult,
+} from "@agenta/entity-ui/selection"
+import {AppstoreOutlined} from "@ant-design/icons"
+import {Typography, theme} from "antd"
+
+interface SelectAppEmptyStateProps {
+    adapter: EntitySelectionAdapter<WorkflowRevisionSelectionResult>
+    onSelect: (selection: WorkflowRevisionSelectionResult) => void
+    selectedAppLabel?: string | null
+}
+
+const SelectAppEmptyState = ({adapter, onSelect, selectedAppLabel}: SelectAppEmptyStateProps) => {
+    const {token} = theme.useToken()
+
+    return (
+        <div className="flex max-w-[340px] flex-col items-center gap-4">
+            <div
+                className="flex h-14 w-14 items-center justify-center rounded-full"
+                style={{background: token.colorPrimaryBg, color: token.colorPrimary}}
+            >
+                <AppstoreOutlined style={{fontSize: 26}} />
+            </div>
+            <div className="flex flex-col gap-1 text-center">
+                <Typography.Text className="text-[15px] font-semibold">
+                    Select an app to run the evaluator on
+                </Typography.Text>
+                <Typography.Text type="secondary" className="text-[13px] leading-snug">
+                    The evaluator grades this app&apos;s output. Pick which app to run, then fill
+                    its inputs or load a test set.
+                </Typography.Text>
+            </div>
+            <EntityPicker<WorkflowRevisionSelectionResult>
+                variant="popover-cascader"
+                adapter={adapter}
+                onSelect={onSelect}
+                size="middle"
+                placeholder={selectedAppLabel ?? "Select app"}
+            />
+        </div>
+    )
+}
+
+export default SelectAppEmptyState

--- a/web/oss/src/components/Evaluators/components/ConfigureEvaluator/atoms.ts
+++ b/web/oss/src/components/Evaluators/components/ConfigureEvaluator/atoms.ts
@@ -84,6 +84,53 @@ export const persistedTestsetSelectionAtom = atom(
 )
 
 // ============================================================================
+// RUN-ON MODE
+// ============================================================================
+
+/**
+ * What the evaluator runs on:
+ *  - "data"  → run directly on data you provide (test set or manual input/output)
+ *  - "app"   → run an app over the data, then grade its output (the usual flow)
+ *  - "trace" → grade the input/output of a logged trace (not yet available)
+ *
+ * "app" is the default so a fresh playground guides the user down the most
+ * common path (pick an app → run against it). The "trace" mode is disabled in
+ * the UI for now.
+ */
+export type RunOnMode = "data" | "app" | "trace"
+
+const runOnModeByProjectAtom = atomWithStorage<Record<string, RunOnMode>>(
+    "agenta:evaluator:run-on-mode",
+    {},
+)
+
+/** Read/write the persisted run-on mode for the current project (default "app"). */
+export const runOnModeAtom = atom(
+    (get) => {
+        const projectId = get(projectIdAtom) || "__global__"
+        return get(runOnModeByProjectAtom)[projectId] ?? "app"
+    },
+    (get, set, next: RunOnMode) => {
+        const projectId = get(projectIdAtom) || "__global__"
+        const all = get(runOnModeByProjectAtom)
+        set(runOnModeByProjectAtom, {...all, [projectId]: next})
+    },
+)
+
+/**
+ * The mode actually in effect.
+ *
+ * A connected app (downstream evaluator node) always means we're in "app" mode,
+ * regardless of the stored preference — the node graph is the source of truth.
+ * Only when nothing is connected do we fall back to the stored mode.
+ */
+export const effectiveRunOnModeAtom = atom<RunOnMode>((get) => {
+    const nodes = get(playgroundNodesAtom)
+    if (nodes.some((n) => n.depth > 0)) return "app"
+    return get(runOnModeAtom)
+})
+
+// ============================================================================
 // DERIVED SELECTORS
 // ============================================================================
 
@@ -201,6 +248,13 @@ export const connectAppToEvaluatorAtom = atom(
         // display label is derived from the depth-0 node's `label` via
         // `selectedAppLabelAtom`, so no extra write needed here.
         set(persistedAppSelectionAtom, {appRevisionId, appLabel})
+
+        // Pin the stored run-on mode to "app" too. While connected,
+        // `effectiveRunOnModeAtom` overrides to "app" regardless, but the
+        // stored mode is what we fall back to on disconnect — without this a
+        // user who connected an app from "data" mode would snap back to the
+        // testcase panel on disconnect instead of the "Select an app" state.
+        set(runOnModeAtom, "app")
     },
 )
 

--- a/web/oss/src/components/Evaluators/components/ConfigureEvaluator/index.tsx
+++ b/web/oss/src/components/Evaluators/components/ConfigureEvaluator/index.tsx
@@ -30,8 +30,15 @@ import {OSSPlaygroundShell} from "@/oss/components/Playground/OSSPlaygroundShell
 import SharedGenerationResultUtils from "@/oss/components/SharedGenerationResultUtils"
 import {playgroundSyncAtom} from "@/oss/state/url/playground"
 
-import {connectAppToEvaluatorAtom, evaluatorConfigEntityIdsAtom} from "./atoms"
+import {
+    connectAppToEvaluatorAtom,
+    effectiveRunOnModeAtom,
+    evaluatorConfigEntityIdsAtom,
+    hasAppConnectedAtom,
+    selectedAppLabelAtom,
+} from "./atoms"
 import EvaluatorPlaygroundHeader from "./EvaluatorPlaygroundHeader"
+import SelectAppEmptyState from "./SelectAppEmptyState"
 
 const PlaygroundMainView = dynamic(
     () => import("@/oss/components/Playground/Components/MainLayout"),
@@ -71,6 +78,14 @@ const ConfigureEvaluatorPageInner = () => {
 
     const configEntityIds = useAtomValue(evaluatorConfigEntityIdsAtom)
     const connectApp = useSetAtom(connectAppToEvaluatorAtom)
+    const selectedAppLabel = useAtomValue(selectedAppLabelAtom)
+    const hasAppConnected = useAtomValue(hasAppConnectedAtom)
+    const runOnMode = useAtomValue(effectiveRunOnModeAtom)
+
+    // In "Run on an app" mode with no app connected yet, the run panel surfaces
+    // the app selector (mirrors the evaluator-creation drawer) so the default
+    // path — pick an app → run against it — is the obvious next step.
+    const runDisabled = runOnMode === "app" && !hasAppConnected
 
     // Read the current evaluator entity from playground nodes
     // Phase 1: evaluator is at depth 0 (primary, standalone run)
@@ -119,6 +134,17 @@ const ConfigureEvaluatorPageInner = () => {
         [connectApp, evaluatorNode],
     )
 
+    const runDisabledContent = useMemo(
+        () => (
+            <SelectAppEmptyState
+                adapter={appWorkflowAdapter}
+                onSelect={handleAppSelect}
+                selectedAppLabel={selectedAppLabel}
+            />
+        ),
+        [appWorkflowAdapter, handleAppSelect, selectedAppLabel],
+    )
+
     const providers = useMemo(
         () =>
             ({
@@ -132,12 +158,21 @@ const ConfigureEvaluatorPageInner = () => {
 
     return (
         <OSSPlaygroundShell providers={providers}>
-            <div className="flex flex-col w-full h-full overflow-hidden">
+            {/* Definite height (viewport minus the app topbar) so the run panel's
+             * `h-full` centering resolves — same pattern as the app playground
+             * (`Playground.tsx`). With a plain `h-full` here the chain collapses
+             * to content height and the empty state sticks to the top. */}
+            <div className="flex flex-col w-full h-[calc(100dvh-75px)] overflow-hidden">
                 <EvaluatorPlaygroundHeader
                     appWorkflowAdapter={appWorkflowAdapter}
                     onAppSelect={handleAppSelect}
                 />
-                <PlaygroundMainView mode="evaluator" configEntityIdsOverride={configEntityIds} />
+                <PlaygroundMainView
+                    mode="evaluator"
+                    configEntityIdsOverride={configEntityIds}
+                    runDisabled={runDisabled}
+                    runDisabledContent={runDisabledContent}
+                />
             </div>
         </OSSPlaygroundShell>
     )

--- a/web/oss/src/components/pages/evaluations/NewEvaluation/Components/CreateEvaluatorDrawer/index.tsx
+++ b/web/oss/src/components/pages/evaluations/NewEvaluation/Components/CreateEvaluatorDrawer/index.tsx
@@ -40,6 +40,7 @@ import {
     hasAppConnectedAtom,
     selectedAppLabelAtom,
 } from "@/oss/components/Evaluators/components/ConfigureEvaluator/atoms"
+import SelectAppEmptyState from "@/oss/components/Evaluators/components/ConfigureEvaluator/SelectAppEmptyState"
 import {clearEvaluatorWorkflowCache} from "@/oss/components/Evaluators/store/evaluatorsPaginatedStore"
 import PlaygroundTestcaseEditor from "@/oss/components/Playground/Components/PlaygroundTestcaseEditor"
 import {OSSPlaygroundShell} from "@/oss/components/Playground/OSSPlaygroundShell"
@@ -214,18 +215,11 @@ const DrawerContent = ({
 
     const runDisabledContent = useMemo(
         () => (
-            <>
-                <Typography.Text type="secondary" className="text-sm">
-                    Select an app to run the evaluator chain
-                </Typography.Text>
-                <EntityPicker<WorkflowRevisionSelectionResult>
-                    variant="popover-cascader"
-                    adapter={appWorkflowAdapter}
-                    onSelect={handleAppSelect}
-                    size="middle"
-                    placeholder={selectedAppLabel ?? "Select app"}
-                />
-            </>
+            <SelectAppEmptyState
+                adapter={appWorkflowAdapter}
+                onSelect={handleAppSelect}
+                selectedAppLabel={selectedAppLabel}
+            />
         ),
         [appWorkflowAdapter, handleAppSelect, selectedAppLabel],
     )


### PR DESCRIPTION
## Why

The evaluator (LLM-as-a-judge) playground's empty/first state doesn't explain itself. The header offers two disconnected loaders — an app picker and a test-set picker — with no indication of how they relate or what you're supposed to do first. New users open it and stall: do I load a test set? an app? both? And the relationship ("the app runs, then the evaluator grades its output") is invisible.

## What

Adds a single **Run on** control to the evaluator playground header that names the data source and draws the resulting data-flow. Three modes:

- **Run directly on a test case** — `Data → Evaluator → Score`
- **Run on an app output** *(default)* — `Data → App → Output → Evaluator → Score`
- **Run on a trace** — `Trace → Evaluator → Score` *(disabled for now)*

## Notes on behavior:

1. I made sure that the default behavior is "Run on an app output.", where the we show a centered **"Select an app"** empty state. The evaluator can't run until you pick one. 

## Notes on the implementation

- @ardaerzin The mode is **persisted per project**. This however imo not the best behaviorI considered keying the mode by evaluator id instead, but the app and test-set selections are themselves per project, so moving only the mode would make the three inconsistent. The right behavior is probably to scope all three per app/evaluator — might be worth a follow-up PR to fix.
- On known issue is that when the user selects from test set, we show inputs and outputs as Form. However you cannot fill the inputs as Form, you need to switch to JSON first. I did not want to touch the defaults there since I was afraid of breaking something else. Maybe we would want to change the default to JSON always if the data is empty? wdyt @ardaerzin 

## Scope

- **Evaluator playground only.** The prompt/completion playground is intentionally untouched.

## Demo (with sound)

https://github.com/user-attachments/assets/0ff52920-4b6f-4205-99db-5bbb49b82389

