### PR TITLE
[fix] Fix inverted Text/Markdown view in playground message editors

### DIFF
--- a/web/oss/src/styles/globals.css
+++ b/web/oss/src/styles/globals.css
@@ -184,6 +184,13 @@ body {
 
     > .editor-input.markdown-view > .editor-code {
         background-color: transparent;
+        /* Text mode shows the raw source as plain prose, not code. Use the
+           editor's proportional font instead of the monospace code face, and
+           drop the code-block padding/margins so the text aligns with the
+           rich-text (markdown) view's left edge and top. */
+        font-family: inherit;
+        padding: 0;
+        margin: 0;
     }
     > .editor-input:not(.markdown-view) > .editor-code {
         &:after {
@@ -197,6 +204,30 @@ body {
             color: rgba(0, 0, 0, 0.5);
         }
     }
+}
+
+/* Align the message text with the first character of the role label above it,
+   with the same symmetric horizontal inset on the role, the text, and the
+   placeholder. The single inset value lives in --ag-message-inline-pad.
+
+   Notes:
+   - The role label is an antd Button whose default padding is wider than the
+     inset (Tailwind's px-2 on it loses to antd), so it is pinned with !important.
+   - The text is padded here in CSS rather than via an editor prop because
+     ChatMessageEditor renders the Editor with `noProvider`, a mode where
+     `className`/`editorClassName` is currently dropped (known bug, tracked
+     separately). JSON/code editors are excluded; they have a line-number gutter. */
+.agenta-chat-message-editor {
+    --ag-message-inline-pad: 8px;
+}
+.agenta-chat-message-editor .message-user-select {
+    padding-inline: var(--ag-message-inline-pad) !important;
+}
+.agenta-chat-message-editor .editor-input:not(.code-only) {
+    padding-inline: var(--ag-message-inline-pad);
+}
+.agenta-chat-message-editor .editor-placeholder {
+    left: var(--ag-message-inline-pad);
 }
 
 /** Align the input search with the search box **/

--- a/web/packages/agenta-playground-ui/src/components/adapters/TurnMessageAdapter.tsx
+++ b/web/packages/agenta-playground-ui/src/components/adapters/TurnMessageAdapter.tsx
@@ -21,7 +21,7 @@ import {
     PromptImageUpload,
     PromptDocumentUpload,
 } from "@agenta/ui/components/presentational"
-import {messageViewModeAtom} from "@agenta/ui/drill-in"
+import {messageViewModeAtom, toMessageViewMode} from "@agenta/ui/drill-in"
 import type {UploadFile} from "antd"
 import clsx from "clsx"
 import {useAtom, useAtomValue, useSetAtom} from "jotai"
@@ -216,9 +216,12 @@ const TurnMessageAdapter: React.FC<Props> = ({
         return fallback
     }, [computedText, msg])
     // Shared + persisted across all message editors (see messageViewModeAtom).
+    // The atom is typed `ViewMode` (can hold "form"), so coerce to a mode this
+    // editor can actually render before deriving any mode-dependent state.
     const [viewMode, setViewMode] = useAtom(messageViewModeAtom)
-    const isCodeMode = viewMode === "json" || viewMode === "yaml"
-    const editorLanguage = viewMode === "yaml" ? "yaml" : "json"
+    const chatViewMode = toMessageViewMode(viewMode)
+    const isCodeMode = chatViewMode === "json" || chatViewMode === "yaml"
+    const editorLanguage = chatViewMode === "yaml" ? "yaml" : "json"
 
     const effectiveDisabled = Boolean(disabled)
     const isUserRole = kind === "user" && !isToolKind
@@ -657,7 +660,7 @@ const TurnMessageAdapter: React.FC<Props> = ({
                             isJSON={isCodeMode}
                             isTool={isCodeMode}
                             language={editorLanguage}
-                            markdownView={viewMode === "text"}
+                            markdownView={chatViewMode === "text"}
                             onFocusChange={handleEditorFocusChange}
                             text={p?.json}
                             enableTokens={messageProps?.enableTokens ?? !isCodeMode}
@@ -687,7 +690,7 @@ const TurnMessageAdapter: React.FC<Props> = ({
                                     resultHashes={propsResultHashes ?? resultHashes}
                                     results={results}
                                     text={p?.json ?? editorText}
-                                    viewMode={viewMode}
+                                    viewMode={chatViewMode}
                                     onViewModeChange={setViewMode}
                                     collapsed={isMessageCollapsed}
                                     allowFileUpload={isUserRole && !effectiveDisabled}
@@ -751,7 +754,7 @@ const TurnMessageAdapter: React.FC<Props> = ({
                         state={editorState}
                         isJSON={isCodeMode}
                         language={editorLanguage}
-                        markdownView={viewMode === "text"}
+                        markdownView={chatViewMode === "text"}
                         enableTokens={messageProps?.enableTokens ?? !isCodeMode}
                         headerRight={
                             <TurnMessageHeaderOptions
@@ -762,7 +765,7 @@ const TurnMessageAdapter: React.FC<Props> = ({
                                 resultHashes={propsResultHashes ?? resultHashes}
                                 results={results}
                                 text={editorText}
-                                viewMode={viewMode}
+                                viewMode={chatViewMode}
                                 onViewModeChange={setViewMode}
                                 collapsed={isMessageCollapsed}
                                 allowFileUpload={isUserRole && !effectiveDisabled}

--- a/web/packages/agenta-playground-ui/src/components/adapters/TurnMessageAdapter.tsx
+++ b/web/packages/agenta-playground-ui/src/components/adapters/TurnMessageAdapter.tsx
@@ -21,10 +21,10 @@ import {
     PromptImageUpload,
     PromptDocumentUpload,
 } from "@agenta/ui/components/presentational"
-import type {ViewMode} from "@agenta/ui/drill-in"
+import {messageViewModeAtom} from "@agenta/ui/drill-in"
 import type {UploadFile} from "antd"
 import clsx from "clsx"
-import {useAtomValue, useSetAtom} from "jotai"
+import {useAtom, useAtomValue, useSetAtom} from "jotai"
 import JSON5 from "json5"
 import {v4 as uuidv4} from "uuid"
 
@@ -215,7 +215,8 @@ const TurnMessageAdapter: React.FC<Props> = ({
 
         return fallback
     }, [computedText, msg])
-    const [viewMode, setViewMode] = useState<ViewMode>("text")
+    // Shared + persisted across all message editors (see messageViewModeAtom).
+    const [viewMode, setViewMode] = useAtom(messageViewModeAtom)
     const isCodeMode = viewMode === "json" || viewMode === "yaml"
     const editorLanguage = viewMode === "yaml" ? "yaml" : "json"
 
@@ -656,7 +657,7 @@ const TurnMessageAdapter: React.FC<Props> = ({
                             isJSON={isCodeMode}
                             isTool={isCodeMode}
                             language={editorLanguage}
-                            markdownView={viewMode === "markdown"}
+                            markdownView={viewMode === "text"}
                             onFocusChange={handleEditorFocusChange}
                             text={p?.json}
                             enableTokens={messageProps?.enableTokens ?? !isCodeMode}
@@ -750,7 +751,7 @@ const TurnMessageAdapter: React.FC<Props> = ({
                         state={editorState}
                         isJSON={isCodeMode}
                         language={editorLanguage}
-                        markdownView={viewMode === "markdown"}
+                        markdownView={viewMode === "text"}
                         enableTokens={messageProps?.enableTokens ?? !isCodeMode}
                         headerRight={
                             <TurnMessageHeaderOptions

--- a/web/packages/agenta-playground-ui/src/components/adapters/VariableControlAdapter.tsx
+++ b/web/packages/agenta-playground-ui/src/components/adapters/VariableControlAdapter.tsx
@@ -522,7 +522,7 @@ const VariableControlAdapter: React.FC<VariableControlAdapterProps> = ({
                 enableTokens={!editorProps?.codeOnly}
                 disabled={isEffectivelyDisabled}
             >
-                <MarkdownViewSynchronizer enabled={viewMode === "markdown"} />
+                <MarkdownViewSynchronizer enabled={viewMode === "text"} />
                 <SharedEditor
                     id={editorId}
                     noProvider

--- a/web/packages/agenta-ui/src/ChatMessage/components/ChatMessageEditor.tsx
+++ b/web/packages/agenta-ui/src/ChatMessage/components/ChatMessageEditor.tsx
@@ -214,7 +214,17 @@ const ChatMessageEditorInner: React.FC<ChatMessageEditorProps> = ({
             placeholder={placeholder}
             disabled={disabled}
             state={disabled ? "readOnly" : state}
-            className={cn("relative", flexLayouts.column, gapClasses.xs, "rounded-md", className)}
+            // `agenta-chat-message-editor` is the styling hook used in globals.css
+            // to align the message text with the role label (see that file). The
+            // padding can't go through `editorClassName` because ChatMessageEditor
+            // renders the Editor with `noProvider`, where `className` is dropped.
+            className={cn(
+                "agenta-chat-message-editor relative",
+                flexLayouts.column,
+                gapClasses.xs,
+                "rounded-md",
+                className,
+            )}
             footer={footer}
             onFocusChange={onFocusChange}
             maxPasteChars={maxPasteChars}

--- a/web/packages/agenta-ui/src/ChatMessage/components/ChatMessageList.tsx
+++ b/web/packages/agenta-ui/src/ChatMessage/components/ChatMessageList.tsx
@@ -12,9 +12,11 @@ import {
 } from "@agenta/shared/utils"
 import {Copy, MinusCircle, Plus} from "@phosphor-icons/react"
 import {Button, Tooltip} from "antd"
+import {useAtom} from "jotai"
 
 import {CollapseToggleButton, getCollapseStyle} from "../../components/presentational/buttons"
 import {ViewModeDropdown} from "../../drill-in/core/ViewModeDropdown"
+import {messageViewModeAtom} from "../../drill-in/state/messageViewModeAtom"
 import {getViewOptions, type ViewMode} from "../../drill-in/utils/getViewOptions"
 import {message, modal} from "../../utils/appMessageContext"
 import {cn, flexLayouts, gapClasses} from "../../utils/styles"
@@ -89,7 +91,8 @@ const ChatMessageItem: React.FC<{
     onToggleMinimize,
 }) => {
     const containerRef = useRef<HTMLDivElement>(null)
-    const [viewMode, setViewMode] = useState<ChatViewMode>("text")
+    // Shared + persisted across all message editors (see messageViewModeAtom).
+    const [viewMode, setViewMode] = useAtom(messageViewModeAtom)
     const isCodeMode = viewMode === "json" || viewMode === "yaml"
     const editorLanguage: "json" | "yaml" = viewMode === "yaml" ? "yaml" : "json"
 
@@ -173,7 +176,7 @@ const ChatMessageItem: React.FC<{
                 onChangeText={(text) => onTextChange(index, text)}
                 isJSON={isCodeMode}
                 language={editorLanguage}
-                markdownView={viewMode === "markdown"}
+                markdownView={viewMode === "text"}
                 enableTokens={enableTokens && !isCodeMode}
                 templateFormat={templateFormat}
                 tokens={tokens}
@@ -196,7 +199,7 @@ const ChatMessageItem: React.FC<{
                         )}
                     >
                         <ViewModeDropdown<ChatViewMode>
-                            value={viewMode}
+                            value={viewMode as ChatViewMode}
                             options={viewOptions}
                             onChange={setViewMode}
                         />

--- a/web/packages/agenta-ui/src/ChatMessage/components/ChatMessageList.tsx
+++ b/web/packages/agenta-ui/src/ChatMessage/components/ChatMessageList.tsx
@@ -17,7 +17,7 @@ import {useAtom} from "jotai"
 import {CollapseToggleButton, getCollapseStyle} from "../../components/presentational/buttons"
 import {ViewModeDropdown} from "../../drill-in/core/ViewModeDropdown"
 import {messageViewModeAtom} from "../../drill-in/state/messageViewModeAtom"
-import {getViewOptions, type ViewMode} from "../../drill-in/utils/getViewOptions"
+import {getViewOptions, toMessageViewMode, type ViewMode} from "../../drill-in/utils/getViewOptions"
 import {message, modal} from "../../utils/appMessageContext"
 import {cn, flexLayouts, gapClasses} from "../../utils/styles"
 import {createSnippetPdfAttachment} from "../utils/snippetAttachment"
@@ -92,9 +92,12 @@ const ChatMessageItem: React.FC<{
 }) => {
     const containerRef = useRef<HTMLDivElement>(null)
     // Shared + persisted across all message editors (see messageViewModeAtom).
+    // The atom is typed `ViewMode` (can hold "form"), so coerce to a mode this
+    // editor can actually render before deriving any mode-dependent state.
     const [viewMode, setViewMode] = useAtom(messageViewModeAtom)
-    const isCodeMode = viewMode === "json" || viewMode === "yaml"
-    const editorLanguage: "json" | "yaml" = viewMode === "yaml" ? "yaml" : "json"
+    const chatViewMode = toMessageViewMode(viewMode)
+    const isCodeMode = chatViewMode === "json" || chatViewMode === "yaml"
+    const editorLanguage: "json" | "yaml" = chatViewMode === "yaml" ? "yaml" : "json"
 
     const isToolResponse = msg.role === "tool"
     const hasToolCalls = Boolean(msg.tool_calls && msg.tool_calls.length > 0)
@@ -176,7 +179,7 @@ const ChatMessageItem: React.FC<{
                 onChangeText={(text) => onTextChange(index, text)}
                 isJSON={isCodeMode}
                 language={editorLanguage}
-                markdownView={viewMode === "text"}
+                markdownView={chatViewMode === "text"}
                 enableTokens={enableTokens && !isCodeMode}
                 templateFormat={templateFormat}
                 tokens={tokens}
@@ -199,7 +202,7 @@ const ChatMessageItem: React.FC<{
                         )}
                     >
                         <ViewModeDropdown<ChatViewMode>
-                            value={viewMode as ChatViewMode}
+                            value={chatViewMode}
                             options={viewOptions}
                             onChange={setViewMode}
                         />

--- a/web/packages/agenta-ui/src/ChatMessage/components/MarkdownToggleButton.tsx
+++ b/web/packages/agenta-ui/src/ChatMessage/components/MarkdownToggleButton.tsx
@@ -22,11 +22,11 @@ const MarkdownToggleButton = ({id}: MarkdownToggleButtonProps) => {
     }, [editor])
 
     return (
-        <Tooltip title={markdownView ? "Preview text" : "Preview markdown"}>
+        <Tooltip title={markdownView ? "Preview markdown" : "Preview text"}>
             <Button
                 type="text"
                 size="small"
-                icon={markdownView ? <TextAa size={14} /> : <MarkdownLogoIcon size={14} />}
+                icon={markdownView ? <MarkdownLogoIcon size={14} /> : <TextAa size={14} />}
                 onClick={onToggleMarkdown}
                 className={cn(flexLayouts.rowCenter, justifyClasses.center)}
             />

--- a/web/packages/agenta-ui/src/drill-in/FieldRenderers/JsonObjectField.tsx
+++ b/web/packages/agenta-ui/src/drill-in/FieldRenderers/JsonObjectField.tsx
@@ -65,7 +65,7 @@ function ChatMessageObjectField({
             disabled={!editable}
             isJSON={isCodeMode}
             language={editorLanguage}
-            markdownView={viewMode === "markdown"}
+            markdownView={viewMode === "text"}
             enableTokens={!isCodeMode}
             templateFormat="curly"
             onChangeRole={(newRole: string) => {

--- a/web/packages/agenta-ui/src/drill-in/index.ts
+++ b/web/packages/agenta-ui/src/drill-in/index.ts
@@ -128,6 +128,7 @@ export {
 } from "./utils"
 export {getViewOptions} from "./utils/getViewOptions"
 export type {ViewMode, ViewOption} from "./utils/getViewOptions"
+export {messageViewModeAtom} from "./state/messageViewModeAtom"
 
 // ============================================================================
 // FIELD RENDERERS

--- a/web/packages/agenta-ui/src/drill-in/index.ts
+++ b/web/packages/agenta-ui/src/drill-in/index.ts
@@ -126,8 +126,8 @@ export {
     canToggleRawMode,
     detectDataType,
 } from "./utils"
-export {getViewOptions} from "./utils/getViewOptions"
-export type {ViewMode, ViewOption} from "./utils/getViewOptions"
+export {getViewOptions, toMessageViewMode} from "./utils/getViewOptions"
+export type {ViewMode, MessageViewMode, ViewOption} from "./utils/getViewOptions"
 export {messageViewModeAtom} from "./state/messageViewModeAtom"
 
 // ============================================================================

--- a/web/packages/agenta-ui/src/drill-in/state/messageViewModeAtom.ts
+++ b/web/packages/agenta-ui/src/drill-in/state/messageViewModeAtom.ts
@@ -1,0 +1,19 @@
+import {atomWithStorage} from "jotai/utils"
+
+import type {ViewMode} from "../utils/getViewOptions"
+
+/**
+ * Shared, persisted view mode for chat / prompt message editors.
+ *
+ * Replaces the per-message local `useState` so that:
+ *  - switching one message's view (Text / Markdown / JSON / YAML) switches every
+ *    message editor at once, and
+ *  - the choice survives a page refresh (persisted to localStorage).
+ *
+ * Scope note: this is a single app-wide atom, so it is shared by every consumer
+ * of the message editors (playground prompt + chat turns, and also the drill-in
+ * message fields). The key is intentionally not namespaced to "playground".
+ *
+ * Defaults to "text" so messages open as plain, raw text.
+ */
+export const messageViewModeAtom = atomWithStorage<ViewMode>("agenta:message-view-mode", "text")

--- a/web/packages/agenta-ui/src/drill-in/utils/getViewOptions.ts
+++ b/web/packages/agenta-ui/src/drill-in/utils/getViewOptions.ts
@@ -1,5 +1,17 @@
 export type ViewMode = "text" | "markdown" | "json" | "yaml" | "form"
 
+/** The view modes a chat / prompt message editor can render ("form" is for objects). */
+export type MessageViewMode = Exclude<ViewMode, "form">
+
+/**
+ * Coerce a (possibly app-wide / persisted) view mode to one a message editor can
+ * render. The shared `messageViewModeAtom` is typed `ViewMode`, so it can hold
+ * "form"; falling back to "text" keeps the dropdown and editor consistent instead
+ * of silently casting and rendering an unsupported mode.
+ */
+export const toMessageViewMode = (mode: ViewMode): MessageViewMode =>
+    mode === "form" ? "text" : mode
+
 export interface ViewOption {
     value: ViewMode
     label: string


### PR DESCRIPTION
## Context
In the playground message editors, the Text/Markdown toggle was inverted. The default mode is "Text", but it rendered markdown, and picking "Markdown" showed the raw source. The dropdown mapped `markdownView` to the wrong boolean (`viewMode === "markdown"`), and `markdownView={true}` means "show raw source", so every label did the opposite of what it said. The live markdown toggle button had the same inverted icon/tooltip.

On top of that, the Text mode rendered in a monospace code font with code-block padding, and the message text did not line up with the role label above it.

## Changes
- **Swap fix.** Map `markdownView` to `viewMode === "text"` everywhere a message editor is rendered: chat turns (`TurnMessageAdapter`), prompt messages (`ChatMessageList`), variable inputs (`VariableControlAdapter`), and the JSON object field (`JsonObjectField`). Now "Text" shows raw text and "Markdown" renders, matching the labels. Default is "Text".
- **Toggle button.** Fixed the inverted icon and tooltip on the live `MarkdownToggleButton` (when raw source is shown it now offers "Preview markdown", and vice versa).
- **Shared, persisted mode.** Replaced the per-message `useState` with a shared `atomWithStorage` (`messageViewModeAtom`), so switching one message switches all of them and the choice survives a refresh.
- **Text mode styling.** Text mode now uses the editor's proportional font instead of monospace, with spacing that matches the rendered markdown view. Message text and placeholder align with the first character of the role label.

Before: default "Text" showed rendered markdown; "Markdown" showed raw monospace source.
After: default "Text" shows raw proportional text; "Markdown" renders.

## Notes
- The mode atom is intentionally a single app-wide preference, so it is also shared by the drill-in message fields, not only the playground. The storage key reflects that (`agenta:message-view-mode`).
- The text-alignment padding is applied via `globals.css` (scoped to `.agenta-chat-message-editor`) rather than the `editorClassName` prop, because `ChatMessageEditor` renders the editor with `noProvider`, a mode where `Editor` currently drops `className`. That `noProvider` bug is tracked as a separate follow-up; a stacked PR will fix it and migrate this padding to the prop.
- Same swap also exists in the observability drill-in viewer (`DrillInContent`); left out of this PR since fixing it changes that surface's behavior and needs its own verification.

## Tests
- `tsc --noEmit` passes for `@agenta/ui` and `@agenta/playground-ui`.
- Prettier and ESLint pass on the changed files.
- Manually verified in the running app: default Text mode, correct swap, proportional font, and role/text alignment.