### PR TITLE
feat: add reset password functionality to workspace UI

### DIFF
--- a/web/oss/src/components/pages/settings/WorkspaceManage/cellRenderers.tsx
+++ b/web/oss/src/components/pages/settings/WorkspaceManage/cellRenderers.tsx
@@ -3,7 +3,7 @@ import {useState} from "react"
 import type {User} from "@agenta/shared/types"
 import {message} from "@agenta/ui/app-message"
 import {EditOutlined, MoreOutlined, SyncOutlined} from "@ant-design/icons"
-import {ArrowClockwise, Trash} from "@phosphor-icons/react"
+import {ArrowClockwise, Key, Trash} from "@phosphor-icons/react"
 import {Button, Dropdown, Input, Modal, Space, Tag, Tooltip, Typography} from "antd"
 
 import AlertPopup from "@/oss/components/AlertPopup/AlertPopup"
@@ -12,7 +12,7 @@ import {isEmailInvitationsEnabled} from "@/oss/lib/helpers/isEE"
 import {useEntitlements} from "@/oss/lib/helpers/useEntitlements"
 import {snakeToTitle} from "@/oss/lib/helpers/utils"
 import {WorkspaceMember} from "@/oss/lib/Types"
-import {updateUsername} from "@/oss/services/profile"
+import {resetPassword, updateUsername} from "@/oss/services/profile"
 import {
     assignWorkspaceRole,
     removeFromWorkspace,
@@ -22,6 +22,9 @@ import {
 import {useOrgData} from "@/oss/state/org"
 import {useProfileData} from "@/oss/state/profile"
 import {useWorkspaceRoles} from "@/oss/state/workspace"
+
+import GenerateResetLinkModal from "./Modals/GenerateResetLinkModal"
+import PasswordResetLinkModal from "./Modals/PasswordResetLinkModal"
 
 export const Actions: React.FC<{
     member: WorkspaceMember
@@ -39,6 +42,10 @@ export const Actions: React.FC<{
     const {refetch: refetchProfile} = useProfileData()
     const [renameOpen, setRenameOpen] = useState(false)
     const [renameValue, setRenameValue] = useState(user.username || "")
+    const [generateResetLinkOpen, setGenerateResetLinkOpen] = useState(false)
+    const [resetLinkOpen, setResetLinkOpen] = useState(false)
+    const [resetLink, setResetLink] = useState("")
+    const [resetLoading, setResetLoading] = useState(false)
 
     if (hidden && !selfMenu) return null
 
@@ -90,6 +97,24 @@ export const Actions: React.FC<{
         }
     }
 
+    const handleResetPassword = async () => {
+        setResetLoading(true)
+        try {
+            const link = await resetPassword(user.id)
+            setGenerateResetLinkOpen(false)
+            setResetLink(link)
+            setResetLinkOpen(true)
+        } catch (error: any) {
+            const detail =
+                error?.response?.data?.detail ||
+                error?.message ||
+                "Unable to generate reset password link"
+            message.error(detail)
+        } finally {
+            setResetLoading(false)
+        }
+    }
+
     return (
         <>
             <Dropdown
@@ -123,6 +148,19 @@ export const Actions: React.FC<{
                                             onClick: (e: any) => {
                                                 e.domEvent.stopPropagation()
                                                 handleResendInvite()
+                                            },
+                                        },
+                                    ]
+                                  : []),
+                              ...(isMember
+                                  ? [
+                                        {
+                                            key: "reset_password",
+                                            label: "Reset password",
+                                            icon: <Key size={16} />,
+                                            onClick: (e: any) => {
+                                                e.domEvent.stopPropagation()
+                                                setGenerateResetLinkOpen(true)
                                             },
                                         },
                                     ]
@@ -165,6 +203,21 @@ export const Actions: React.FC<{
                     placeholder="New username"
                 />
             </Modal>
+
+            <GenerateResetLinkModal
+                open={generateResetLinkOpen}
+                username={user.username}
+                onCancel={() => setGenerateResetLinkOpen(false)}
+                onOk={handleResetPassword}
+                confirmLoading={resetLoading}
+            />
+
+            <PasswordResetLinkModal
+                open={resetLinkOpen}
+                username={user.username}
+                generatedLink={resetLink}
+                onCancel={() => setResetLinkOpen(false)}
+            />
         </>
     )
 }

--- a/web/oss/src/services/profile/index.ts
+++ b/web/oss/src/services/profile/index.ts
@@ -56,3 +56,17 @@ export const changePassword = async (payload: {
         body: JSON.stringify(payload),
     })
 }
+
+/**
+ * Generate a password reset link for a user (admin action).
+ * Returns the reset password link string.
+ */
+export const resetPassword = async (userId: string): Promise<string> => {
+    const base = getBaseUrl()
+    const url = new URL("api/profile/reset-password", base)
+    url.searchParams.set("user_id", userId)
+    const data = await fetchJson<string>(url, {
+        method: "POST",
+    })
+    return data
+}


### PR DESCRIPTION
## Summary

Wire the existing `GenerateResetLinkModal` and `PasswordResetLinkModal` components into the Actions dropdown in the workspace members table, enabling workspace admins to generate password reset links for users.

## Changes

### `web/oss/src/services/profile/index.ts`
- Added `resetPassword(userId)` API function that calls `POST /profile/reset-password?user_id=...`

### `web/oss/src/components/pages/settings/WorkspaceManage/cellRenderers.tsx`
- Added **"Reset password"** menu item in the Actions dropdown for workspace members (visible only for other members, not for self)
- Added `handleResetPassword` handler that:
  1. Opens the `GenerateResetLinkModal` confirmation dialog
  2. Calls the reset password API on confirmation
  3. Shows the `PasswordResetLinkModal` with the generated link for copying

## How it works

1. Click the gear icon (⋮) on any workspace member row
2. Select **"Reset password"** from the dropdown
3. A confirmation dialog appears: *"Are you sure you want to generate reset password link?"*
4. Click **"Generate Link"** to confirm
5. The API generates a SuperTokens password reset link
6. A modal displays the link with a **Copy** button for sharing with the user

## Screenshots

The existing `GenerateResetLinkModal` and `PasswordResetLinkModal` components were already implemented but not wired up — this PR connects them to the UI.

Closes #2572