### PR TITLE
fix: surface actual provider error messages in evaluation table

### DIFF
--- a/web/oss/src/components/EvalRunDetails/atoms/runInvocationAction.ts
+++ b/web/oss/src/components/EvalRunDetails/atoms/runInvocationAction.ts
@@ -208,7 +208,11 @@ export const triggerRunInvocationAtom = atom(
                     traceId: result.traceId ?? undefined,
                     status: "failure",
                     references,
-                    error: {message: errorMessage},
+                    error: {
+                        message: errorMessage,
+                        ...(result.error?.stacktrace ? {stacktrace: result.error.stacktrace} : {}),
+                        ...(result.error?.type ? {type: result.error.type} : {}),
+                    },
                 })
 
                 await updateScenarioStatus(scenarioId, EvaluationStatus.FAILURE)

--- a/web/oss/src/components/EvaluationRunsTablePOC/actions/navigationActions.ts
+++ b/web/oss/src/components/EvaluationRunsTablePOC/actions/navigationActions.ts
@@ -1,5 +1,3 @@
-import type {MouseEvent} from "react"
-
 import {message} from "@agenta/ui/app-message"
 import {getDefaultStore} from "jotai"
 import Router from "next/router"
@@ -22,14 +20,6 @@ const store = getDefaultStore()
 const getUrlState = (): URLState => store.get(urlAtom) as URLState
 
 const getActiveAppId = (): string | null => store.get(routerAppIdAtom)
-
-export const shouldIgnoreRowClick = (event: MouseEvent<HTMLElement>) => {
-    const target = event.target as HTMLElement | null
-    if (!target) return false
-    const interactiveSelector =
-        "button, a, input, textarea, select, [role='button'], [role='menuitem'], [role='checkbox'], .ant-checkbox, .ant-checkbox-input, .ant-checkbox-inner, .ant-checkbox-wrapper, .ant-btn, .ant-select, .ant-dropdown-trigger"
-    return Boolean(target.closest(interactiveSelector))
-}
 
 interface NavigateToRunParams {
     record: EvaluationRunTableRow

--- a/web/oss/src/components/EvaluationRunsTablePOC/components/EvaluationRunsTable/index.tsx
+++ b/web/oss/src/components/EvaluationRunsTablePOC/components/EvaluationRunsTable/index.tsx
@@ -13,6 +13,7 @@ import {activePreviewProjectIdAtom} from "@/oss/components/EvalRunDetails/atoms/
 import {clearAllMetricStatsCaches} from "@/oss/components/EvalRunDetails/atoms/runMetrics"
 import {
     InfiniteVirtualTableFeatureShell,
+    shouldIgnoreRowClick,
     type TableFeaturePagination,
     type TableScopeConfig,
 } from "@/oss/components/InfiniteVirtualTable"
@@ -34,7 +35,6 @@ import {
 } from "@/oss/lib/onboarding"
 import {useQueryParamState} from "@/oss/state/appState"
 
-import {shouldIgnoreRowClick} from "../../actions/navigationActions"
 import {
     evaluationRunsDeleteContextAtom,
     evaluationRunsTableFetchEnabledAtom,

--- a/web/oss/src/components/InfiniteVirtualTable/hooks/useTableManager.tsx
+++ b/web/oss/src/components/InfiniteVirtualTable/hooks/useTableManager.tsx
@@ -27,26 +27,36 @@ import useTableExport from "./useTableExport"
 const dummySearchAtom = atom("")
 
 /**
- * Helper to detect if a click event should be ignored for row navigation
+ * Default CSS selectors for interactive elements that should not trigger row navigation.
+ * Consolidated from all table implementations to ensure consistent click-through behavior.
+ */
+export const INTERACTIVE_ROW_SELECTORS = [
+    "button",
+    "a",
+    "input",
+    "textarea",
+    "select",
+    "[role='button']",
+    "[role='menuitem']",
+    "[role='checkbox']",
+    "[data-interactive]",
+    ".ant-dropdown-trigger",
+    ".ant-checkbox-wrapper",
+    ".ant-checkbox",
+    ".ant-checkbox-input",
+    ".ant-checkbox-inner",
+    ".ant-btn",
+    ".ant-select",
+].join(", ")
+
+/**
+ * Helper to detect if a click event should be ignored for row navigation.
  * Returns true if the click was on an interactive element (button, link, dropdown, etc.)
  */
 export const shouldIgnoreRowClick = (event: MouseEvent<HTMLElement>): boolean => {
     const target = event.target as HTMLElement
-
-    // Check if clicking on interactive elements
-    if (
-        target.closest("button") ||
-        target.closest("a") ||
-        target.closest(".ant-dropdown-trigger") ||
-        target.closest(".ant-checkbox-wrapper") ||
-        target.closest(".ant-select") ||
-        target.closest("input") ||
-        target.closest("textarea")
-    ) {
-        return true
-    }
-
-    return false
+    if (!target) return false
+    return Boolean(target.closest(INTERACTIVE_ROW_SELECTORS))
 }
 
 /** Configuration for built-in search. When provided, the hook manages search state internally. */

--- a/web/oss/src/components/TestcasesTableNew/components/TestcasesTableShell.tsx
+++ b/web/oss/src/components/TestcasesTableNew/components/TestcasesTableShell.tsx
@@ -1,10 +1,11 @@
-import {useCallback, useMemo, useState} from "react"
+import React, {useCallback, useMemo, useState} from "react"
 
 import {
     ColumnVisibilityMenuTrigger,
     defaultHeaderVariant,
     detectColumnTypes,
     InfiniteVirtualTableFeatureShell,
+    shouldIgnoreRowClick,
     type TableScopeConfig,
     type TypeChipConfig,
     useTypeChipFeature,
@@ -758,7 +759,10 @@ export function TestcasesTableShell(props: TestcasesTableShellProps) {
             size: "small" as const,
             bordered: true,
             onRow: (record: TestcaseTableRow) => ({
-                onClick: () => onRowClick(record),
+                onClick: (event: React.MouseEvent) => {
+                    if (shouldIgnoreRowClick(event)) return
+                    onRowClick(record)
+                },
                 className: "cursor-pointer hover:bg-gray-50",
             }),
         }),

--- a/web/oss/src/components/pages/observability/components/ObservabilityTable/index.tsx
+++ b/web/oss/src/components/pages/observability/components/ObservabilityTable/index.tsx
@@ -1,6 +1,6 @@
 import {type Key, type ReactNode, useCallback, useEffect, useMemo, useState} from "react"
 
-import {InfiniteVirtualTableFeatureShell} from "@agenta/ui/table"
+import {InfiniteVirtualTableFeatureShell, shouldIgnoreRowClick} from "@agenta/ui/table"
 import type {TableFeaturePagination, TableScopeConfig} from "@agenta/ui/table"
 import {useAtomValue, useSetAtom, useStore} from "jotai"
 import dynamic from "next/dynamic"
@@ -307,7 +307,10 @@ const ObservabilityTable = () => {
                         sticky: true,
                         style: {cursor: "pointer"},
                         onRow: (record, index) => ({
-                            onClick: () => handleTraceRowClick(record),
+                            onClick: (event) => {
+                                if (shouldIgnoreRowClick(event)) return
+                                handleTraceRowClick(record)
+                            },
                             "data-tour": index === 0 ? "trace-row" : undefined,
                         }),
                     }}

--- a/web/oss/src/components/pages/observability/components/SessionsTable/index.tsx
+++ b/web/oss/src/components/pages/observability/components/SessionsTable/index.tsx
@@ -1,6 +1,6 @@
 import {useCallback, useEffect, useMemo, useState} from "react"
 
-import {InfiniteVirtualTableFeatureShell} from "@agenta/ui/table"
+import {InfiniteVirtualTableFeatureShell, shouldIgnoreRowClick} from "@agenta/ui/table"
 import type {TableFeaturePagination, TableScopeConfig} from "@agenta/ui/table"
 import {useAtomValue, useSetAtom} from "jotai"
 import dynamic from "next/dynamic"
@@ -141,7 +141,10 @@ const SessionsTable: React.FC = () => {
                         bordered: true,
                         loading: isLoading && sessionIds.length === 0,
                         onRow: (record) => ({
-                            onClick: () => openDrawer({sessionId: record.session_id}),
+                            onClick: (event) => {
+                                if (shouldIgnoreRowClick(event)) return
+                                openDrawer({sessionId: record.session_id})
+                            },
                             style: {cursor: "pointer"},
                         }),
                     }}

--- a/web/oss/src/components/pages/prompts/PromptsPage.tsx
+++ b/web/oss/src/components/pages/prompts/PromptsPage.tsx
@@ -12,6 +12,7 @@ import type {
     TableFeaturePagination,
     TableScopeConfig,
 } from "@agenta/ui/table"
+import {shouldIgnoreRowClick} from "@agenta/ui/table"
 import {message} from "antd"
 import type {TableProps} from "antd/es/table"
 import {useAtomValue, useSetAtom} from "jotai"
@@ -686,7 +687,10 @@ const PromptsPage = () => {
             scroll: {x: "max-content" as const},
             expandable: tableExpandableConfig,
             onRow: (record: PromptsTableRow) => ({
-                onClick: () => handleRowClick(record),
+                onClick: (event: React.MouseEvent) => {
+                    if (shouldIgnoreRowClick(event)) return
+                    handleRowClick(record)
+                },
                 className: "cursor-pointer",
                 draggable: true,
                 onDragStart: (event: any) => {

--- a/web/oss/src/components/pages/settings/WorkspaceManage/cellRenderers.tsx
+++ b/web/oss/src/components/pages/settings/WorkspaceManage/cellRenderers.tsx
@@ -3,7 +3,7 @@ import {useState} from "react"
 import type {User} from "@agenta/shared/types"
 import {message} from "@agenta/ui/app-message"
 import {EditOutlined, MoreOutlined, SyncOutlined} from "@ant-design/icons"
-import {ArrowClockwise, Trash} from "@phosphor-icons/react"
+import {ArrowClockwise, Key, Trash} from "@phosphor-icons/react"
 import {Button, Dropdown, Input, Modal, Space, Tag, Tooltip, Typography} from "antd"
 
 import AlertPopup from "@/oss/components/AlertPopup/AlertPopup"
@@ -12,7 +12,7 @@ import {isEmailInvitationsEnabled} from "@/oss/lib/helpers/isEE"
 import {useEntitlements} from "@/oss/lib/helpers/useEntitlements"
 import {snakeToTitle} from "@/oss/lib/helpers/utils"
 import {WorkspaceMember} from "@/oss/lib/Types"
-import {updateUsername} from "@/oss/services/profile"
+import {resetPassword, updateUsername} from "@/oss/services/profile"
 import {
     assignWorkspaceRole,
     removeFromWorkspace,
@@ -22,6 +22,9 @@ import {
 import {useOrgData} from "@/oss/state/org"
 import {useProfileData} from "@/oss/state/profile"
 import {useWorkspaceRoles} from "@/oss/state/workspace"
+
+import GenerateResetLinkModal from "./Modals/GenerateResetLinkModal"
+import PasswordResetLinkModal from "./Modals/PasswordResetLinkModal"
 
 export const Actions: React.FC<{
     member: WorkspaceMember
@@ -39,6 +42,10 @@ export const Actions: React.FC<{
     const {refetch: refetchProfile} = useProfileData()
     const [renameOpen, setRenameOpen] = useState(false)
     const [renameValue, setRenameValue] = useState(user.username || "")
+    const [generateResetLinkOpen, setGenerateResetLinkOpen] = useState(false)
+    const [resetLinkOpen, setResetLinkOpen] = useState(false)
+    const [resetLink, setResetLink] = useState("")
+    const [resetLoading, setResetLoading] = useState(false)
 
     if (hidden && !selfMenu) return null
 
@@ -90,6 +97,24 @@ export const Actions: React.FC<{
         }
     }
 
+    const handleResetPassword = async () => {
+        setResetLoading(true)
+        try {
+            const link = await resetPassword(user.id)
+            setGenerateResetLinkOpen(false)
+            setResetLink(link)
+            setResetLinkOpen(true)
+        } catch (error: any) {
+            const detail =
+                error?.response?.data?.detail ||
+                error?.message ||
+                "Unable to generate reset password link"
+            message.error(detail)
+        } finally {
+            setResetLoading(false)
+        }
+    }
+
     return (
         <>
             <Dropdown
@@ -123,6 +148,19 @@ export const Actions: React.FC<{
                                             onClick: (e: any) => {
                                                 e.domEvent.stopPropagation()
                                                 handleResendInvite()
+                                            },
+                                        },
+                                    ]
+                                  : []),
+                              ...(isMember
+                                  ? [
+                                        {
+                                            key: "reset_password",
+                                            label: "Reset password",
+                                            icon: <Key size={16} />,
+                                            onClick: (e: any) => {
+                                                e.domEvent.stopPropagation()
+                                                setGenerateResetLinkOpen(true)
                                             },
                                         },
                                     ]
@@ -165,6 +203,21 @@ export const Actions: React.FC<{
                     placeholder="New username"
                 />
             </Modal>
+
+            <GenerateResetLinkModal
+                open={generateResetLinkOpen}
+                username={user.username}
+                onCancel={() => setGenerateResetLinkOpen(false)}
+                onOk={handleResetPassword}
+                confirmLoading={resetLoading}
+            />
+
+            <PasswordResetLinkModal
+                open={resetLinkOpen}
+                username={user.username}
+                generatedLink={resetLink}
+                onCancel={() => setResetLinkOpen(false)}
+            />
         </>
     )
 }

--- a/web/oss/src/services/evaluations/invocations/api.ts
+++ b/web/oss/src/services/evaluations/invocations/api.ts
@@ -69,7 +69,7 @@ export const upsertStepResultWithInvocation = async ({
     status: string
     references?: InvocationReferences
     outputs?: unknown
-    error?: {message: string; stacktrace?: string}
+    error?: {message: string; stacktrace?: string; type?: string}
 }): Promise<void> => {
     const {projectId} = getProjectValues()
 

--- a/web/oss/src/services/profile/index.ts
+++ b/web/oss/src/services/profile/index.ts
@@ -56,3 +56,17 @@ export const changePassword = async (payload: {
         body: JSON.stringify(payload),
     })
 }
+
+/**
+ * Generate a password reset link for a user (admin action).
+ * Returns the reset password link string.
+ */
+export const resetPassword = async (userId: string): Promise<string> => {
+    const base = getBaseUrl()
+    const url = new URL("api/profile/reset-password", base)
+    url.searchParams.set("user_id", userId)
+    const data = await fetchJson<string>(url, {
+        method: "POST",
+    })
+    return data
+}

--- a/web/packages/agenta-annotation-ui/src/components/AnnotationSession/ScenarioListView.tsx
+++ b/web/packages/agenta-annotation-ui/src/components/AnnotationSession/ScenarioListView.tsx
@@ -38,6 +38,7 @@ import {
     EXPORT_RESOLVE_SKIP,
     InfiniteVirtualTableFeatureShell,
     createActionsColumn,
+    shouldIgnoreRowClick,
     type InfiniteVirtualTableRowSelection,
     type TableScopeConfig,
     type TableExportColumnContext,
@@ -1674,8 +1675,7 @@ const ScenarioListView = memo(function ScenarioListView({
 
     // Row click opens annotation drawer
     const handleRowClick = useCallback((_event: React.MouseEvent, record: ScenarioTableRow) => {
-        const target = _event.target as HTMLElement
-        if (target?.closest("[data-ivt-stop-row-click]")) return
+        if (shouldIgnoreRowClick(_event)) return
         setDrawerScenarioId(record.scenarioId)
     }, [])
 

--- a/web/packages/agenta-entities/src/runnable/types.ts
+++ b/web/packages/agenta-entities/src/runnable/types.ts
@@ -204,6 +204,8 @@ export interface ExecutionResult {
     error?: {
         message: string
         code?: string
+        type?: string
+        stacktrace?: string
     }
     trace?: TraceInfo
     metrics?: ExecutionMetrics

--- a/web/packages/agenta-entity-ui/src/shared/EntityTable.tsx
+++ b/web/packages/agenta-entity-ui/src/shared/EntityTable.tsx
@@ -52,6 +52,7 @@ import {bgColors, cn} from "@agenta/ui/styles"
 import {
     buildEntityColumns,
     InfiniteVirtualTableFeatureShell,
+    shouldIgnoreRowClick,
     type BuildEntityColumnsOptions,
     type RowHeightFeatureConfig,
     type TableScopeConfig,
@@ -546,8 +547,10 @@ export function EntityTable<
                     bordered: true,
                     onRow: selectable
                         ? (record) => ({
-                              onClick: () =>
-                                  handleRowSelect(record.id, !selectedIdsSet.has(record.id)),
+                              onClick: (event) => {
+                                  if (shouldIgnoreRowClick(event)) return
+                                  handleRowSelect(record.id, !selectedIdsSet.has(record.id))
+                              },
                               className: cn(
                                   "cursor-pointer",
                                   selectedIdsSet.has(record.id) && bgColors.subtle,

--- a/web/packages/agenta-playground/src/executeWorkflowRevision.ts
+++ b/web/packages/agenta-playground/src/executeWorkflowRevision.ts
@@ -62,7 +62,7 @@ export interface ExecuteWorkflowRevisionResult {
     structuredOutput?: unknown
     traceId?: string | null
     spanId?: string | null
-    error?: {message: string; code?: string}
+    error?: {message: string; code?: string; type?: string; stacktrace?: string}
 }
 
 // ============================================================================

--- a/web/packages/agenta-playground/src/state/execution/executionRunner.ts
+++ b/web/packages/agenta-playground/src/state/execution/executionRunner.ts
@@ -187,7 +187,7 @@ interface ExecutionSessionLifecycleCallbacks {
         chainResults?: RunResult["chainResults"]
     }) => void
     onComplete: (payload: {result: Partial<RunResult>}) => void
-    onFail: (payload: {error: {message: string; code?: string}; traceId?: string | null}) => void
+    onFail: (payload: {error: {message: string; code?: string; type?: string; stacktrace?: string}; traceId?: string | null}) => void
     onCancel: () => void
 }
 
@@ -671,6 +671,9 @@ async function executeViaFetch(params: {
         if (!response.ok) {
             const errorText = await response.text()
             let errorMessage = `Request failed with status ${response.status}`
+            let errorCode: string | undefined
+            let errorType: string | undefined
+            let errorStacktrace: string | undefined
             let traceId: string | null = null
 
             try {
@@ -678,6 +681,10 @@ async function executeViaFetch(params: {
                 traceId = extractTraceIdFromPayload(errorData)
                 if (errorData?.status?.message) {
                     errorMessage = errorData.status.message
+                    errorCode = errorData.status.code?.toString()
+                    errorType = errorData.status.type
+                    const st = errorData.status.stacktrace
+                    errorStacktrace = Array.isArray(st) ? st.join("\n") : st
                 } else if (errorData?.detail?.message) {
                     errorMessage = errorData.detail.message
                 } else if (typeof errorData?.detail === "string") {
@@ -692,12 +699,47 @@ async function executeViaFetch(params: {
                 status: "error",
                 startedAt,
                 completedAt: new Date().toISOString(),
-                error: {message: errorMessage},
+                error: {
+                    message: errorMessage,
+                    ...(errorCode ? {code: errorCode} : {}),
+                    ...(errorType ? {type: errorType} : {}),
+                    ...(errorStacktrace ? {stacktrace: errorStacktrace} : {}),
+                },
                 ...(traceId ? {trace: {id: traceId}} : {}),
             }
         }
 
         const responseData = await response.json()
+
+        // Check for body-level error status (SDK returns HTTP 200 with error in body).
+        // The Python SDK's WorkflowBatchResponse may embed a non-200 status.code
+        // inside the response body even when the HTTP status is 200.
+        const bodyStatus = responseData?.status
+        if (bodyStatus && typeof bodyStatus === "object" && bodyStatus.code && bodyStatus.code !== 200) {
+            const traceId = extractTraceIdFromPayload(responseData)
+            const spanId = extractSpanIdFromPayload(responseData)
+            const st = bodyStatus.stacktrace
+            return {
+                executionId,
+                status: "error",
+                startedAt,
+                completedAt: new Date().toISOString(),
+                error: {
+                    message: bodyStatus.message || "Invocation failed",
+                    ...(bodyStatus.code ? {code: bodyStatus.code.toString()} : {}),
+                    ...(bodyStatus.type ? {type: bodyStatus.type} : {}),
+                    ...(st ? {stacktrace: Array.isArray(st) ? st.join("\n") : st} : {}),
+                },
+                ...(traceId
+                    ? {
+                          trace: {
+                              id: traceId,
+                              ...(spanId ? {spanId} : {}),
+                          },
+                      }
+                    : {}),
+            }
+        }
 
         // Delegate response parsing to entity-level normalizer when provided.
         // Default: unwrap `data` field if present, extract `trace_id`.

--- a/web/packages/agenta-playground/src/state/execution/types.ts
+++ b/web/packages/agenta-playground/src/state/execution/types.ts
@@ -165,7 +165,7 @@ export interface RunResult {
     /** Hash of result for comparison (optional) */
     resultHash?: string | null
     /** Error details if status is "error" */
-    error?: {message: string; code?: string} | null
+    error?: {message: string; code?: string; type?: string; stacktrace?: string} | null
     /** Timestamp when execution started (ms) */
     startedAt?: number
     /** Timestamp when execution completed (ms) */

--- a/web/packages/agenta-ui/src/InfiniteVirtualTable/hooks/useEntityTableState.ts
+++ b/web/packages/agenta-ui/src/InfiniteVirtualTable/hooks/useEntityTableState.ts
@@ -72,6 +72,8 @@ import type {
 } from "../paginated/createPaginatedEntityStore"
 import type {InfiniteTableRowBase} from "../types"
 
+import {INTERACTIVE_ROW_SELECTORS} from "./useTableManager"
+
 // ============================================================================
 // TYPES
 // ============================================================================
@@ -182,19 +184,10 @@ export interface UseEntityTableStateResult<TRow extends InfiniteTableRowBase> {
 // ============================================================================
 
 /**
- * Default selectors for interactive elements that should not trigger row click
+ * Default selectors for interactive elements that should not trigger row click.
+ * Uses the consolidated selector string from useTableManager for consistency.
  */
-const DEFAULT_INTERACTIVE_SELECTORS = [
-    "button",
-    "a",
-    ".ant-dropdown-trigger",
-    ".ant-checkbox-wrapper",
-    ".ant-select",
-    "input",
-    "textarea",
-    "[role='button']",
-    "[data-interactive]",
-]
+const DEFAULT_INTERACTIVE_SELECTORS = INTERACTIVE_ROW_SELECTORS.split(", ")
 
 // ============================================================================
 // HOOK

--- a/web/packages/agenta-ui/src/InfiniteVirtualTable/hooks/useTableManager.tsx
+++ b/web/packages/agenta-ui/src/InfiniteVirtualTable/hooks/useTableManager.tsx
@@ -28,26 +28,36 @@ import useTableExport from "./useTableExport"
 const dummySearchAtom = atom("")
 
 /**
- * Helper to detect if a click event should be ignored for row navigation
+ * Default CSS selectors for interactive elements that should not trigger row navigation.
+ * Consolidated from all table implementations to ensure consistent click-through behavior.
+ */
+export const INTERACTIVE_ROW_SELECTORS = [
+    "button",
+    "a",
+    "input",
+    "textarea",
+    "select",
+    "[role='button']",
+    "[role='menuitem']",
+    "[role='checkbox']",
+    "[data-interactive]",
+    ".ant-dropdown-trigger",
+    ".ant-checkbox-wrapper",
+    ".ant-checkbox",
+    ".ant-checkbox-input",
+    ".ant-checkbox-inner",
+    ".ant-btn",
+    ".ant-select",
+].join(", ")
+
+/**
+ * Helper to detect if a click event should be ignored for row navigation.
  * Returns true if the click was on an interactive element (button, link, dropdown, etc.)
  */
 export const shouldIgnoreRowClick = (event: MouseEvent<HTMLElement>): boolean => {
     const target = event.target as HTMLElement
-
-    // Check if clicking on interactive elements
-    if (
-        target.closest("button") ||
-        target.closest("a") ||
-        target.closest(".ant-dropdown-trigger") ||
-        target.closest(".ant-checkbox-wrapper") ||
-        target.closest(".ant-select") ||
-        target.closest("input") ||
-        target.closest("textarea")
-    ) {
-        return true
-    }
-
-    return false
+    if (!target) return false
+    return Boolean(target.closest(INTERACTIVE_ROW_SELECTORS))
 }
 
 /** Configuration for built-in search. When provided, the hook manages search state internally. */


### PR DESCRIPTION
## Summary

Fixes #3324 — the evaluation table was showing a generic "too many requests" or "Request failed" message instead of the actual provider error (e.g. "OpenAI rate limit exceeded").

### Root cause

Two bugs in the execution data pipeline:

1. **`executeViaFetch` ignored body-level errors on HTTP 200.** The Python SDK returns `WorkflowBatchResponse` with `status.code=424` (and the real error in `status.message`) for downstream API errors (429→424). When the HTTP status matches `status.code`, Path A catches it correctly. But when the SDK returns HTTP 200 with a non-200 `status.code` embedded in the response body, the code unconditionally returned `status: "success"` — the error was silently dropped.

2. **Error metadata was not propagated.** Even when the HTTP error path worked, only `status.message` was extracted. The SDK's `status.type`, `status.code`, and `status.stacktrace` were all dropped before reaching `InvocationCell`.

## Changes

| File | Change |
|---|---|
| `agenta-playground/.../executionRunner.ts` | Detect body-level errors on HTTP 200 (`responseData.status.code !== 200`). Extract `stacktrace`, `type`, `code` from both HTTP-error and body-error paths. Coerce `string[]` stacktrace to `string`. |
| `agenta-entities/.../runnable/types.ts` | Add `type?` and `stacktrace?` to `ExecutionResult.error` |
| `agenta-playground/.../types.ts` | Add `type?` and `stacktrace?` to `RunResult.error` |
| `agenta-playground/.../executeWorkflowRevision.ts` | Add `type?` and `stacktrace?` to `ExecuteWorkflowRevisionResult.error` |
| `EvalRunDetails/.../runInvocationAction.ts` | Pass `stacktrace` and `type` through to `upsertStepResultWithInvocation` |
| `evaluations/invocations/api.ts` | Accept `type?` in error param |

## No UI changes needed

`InvocationCell` already renders `stepError.message` and `stepError.stacktrace` when present. `extractStepError` already reads `error.code`, `error.type`, `error.stacktrace` from persisted step data. The fix is purely in the data pipeline — the fields were being dropped before reaching storage.

## Testing

- Trigger an evaluation with a rate-limited or invalid API key
- The InvocationCell should now show the actual provider error (e.g. "OpenAI rate limit exceeded") instead of "too many requests"
- Hovering the error should show the stacktrace in the popover
- Successful invocations are unaffected

Closes #3324