### PR TITLE
feat: migrate tracing web client from deprecated to new API endpoints

### DIFF
--- a/web/oss/src/services/tracing/api/index.ts
+++ b/web/oss/src/services/tracing/api/index.ts
@@ -25,8 +25,8 @@ export const fetchAllPreviewTraces = async (
     const projectId = ensureProjectId()
     const applicationId = ensureAppId(appId)
 
-    // New query endpoint expects POST with JSON body
-    const url = new URL(`${base}/tracing/spans/query`)
+    // POST /spans/query — always returns flat spans (focus param removed)
+    const url = new URL(`${base}/spans/query`)
     if (projectId) url.searchParams.set("project_id", projectId)
     if (applicationId) url.searchParams.set("application_id", applicationId)
 
@@ -41,6 +41,9 @@ export const fetchAllPreviewTraces = async (
             } catch {
                 payload.filter = value
             }
+        } else if (key === "focus") {
+            // `focus` is no longer accepted by POST /spans/query — skip it.
+            return
         } else {
             payload[key] = value
         }
@@ -94,7 +97,7 @@ export const fetchAllPreviewTracesWithMeta = async (
     const projectId = ensureProjectId()
     const applicationId = ensureAppId(appId)
 
-    const url = new URL(`${base}/tracing/spans/query`)
+    const url = new URL(`${base}/spans/query`)
     if (projectId) url.searchParams.set("project_id", projectId)
     if (applicationId) url.searchParams.set("application_id", applicationId)
 
@@ -109,6 +112,8 @@ export const fetchAllPreviewTracesWithMeta = async (
             } catch {
                 payload.filter = value
             }
+        } else if (key === "focus") {
+            return
         } else {
             payload[key] = value
         }
@@ -134,7 +139,7 @@ export const fetchPreviewTrace = async (traceId: string) => {
     const base = getBaseUrl()
     const projectId = ensureProjectId()
 
-    const url = new URL(`${base}/tracing/traces/${traceId}`)
+    const url = new URL(`${base}/traces/${traceId}`)
     if (projectId) url.searchParams.set("project_id", projectId)
 
     return fetchJson(url)
@@ -144,7 +149,7 @@ export const deletePreviewTrace = async (traceId: string) => {
     const base = getBaseUrl()
     const projectId = ensureProjectId()
 
-    const url = new URL(`${base}/tracing/traces/${traceId}`)
+    const url = new URL(`${base}/traces/${traceId}`)
     if (projectId) url.searchParams.set("project_id", projectId)
 
     return fetchJson(url, {method: "DELETE"})
@@ -167,7 +172,7 @@ export const fetchSessions = async (params: {
     const projectId = ensureProjectId()
     const applicationId = params.appId ? ensureAppId(params.appId) : undefined
 
-    const url = new URL(`${base}/tracing/sessions/query`)
+    const url = new URL(`${base}/spans/sessions/query`)
     if (projectId) url.searchParams.set("project_id", projectId)
     if (applicationId) url.searchParams.set("application_id", applicationId)
 

--- a/web/packages/agenta-annotation/src/state/controllers/annotationFormController.ts
+++ b/web/packages/agenta-annotation/src/state/controllers/annotationFormController.ts
@@ -635,8 +635,15 @@ async function resolveTraceLinkSpanId({
 
     try {
         const traceResponse = await fetchPreviewTrace(traceId, projectId)
-        const traceKey = traceId.replace(/-/g, "")
-        const traceEntry = traceResponse?.traces?.[traceKey] ?? traceResponse?.traces?.[traceId]
+        // New API returns {count, trace: {trace_id, spans}} — extract spans
+        // from the single trace object. Fallback to legacy traces record shape
+        // for backward compatibility during rollout.
+        const traceEntry =
+            traceResponse?.trace ?? (() => {
+                const traceKey = traceId.replace(/-/g, "")
+                return (traceResponse as any)?.traces?.[traceKey] ??
+                    (traceResponse as any)?.traces?.[traceId]
+            })()
         const rawSpans = traceEntry?.spans ? Object.values(traceEntry.spans) : []
         const spans = rawSpans.filter(
             (span): span is TraceSpan =>

--- a/web/packages/agenta-entities/src/trace/api/api.ts
+++ b/web/packages/agenta-entities/src/trace/api/api.ts
@@ -5,11 +5,14 @@
  * Uses the shared axios instance which should be configured with auth interceptors
  * by the app at startup.
  *
+ * Migrated from deprecated `/tracing/*` endpoints to canonical `/traces/*` and
+ * `/spans/*` endpoints (see #4492).
+ *
  * @example
  * ```typescript
  * import { fetchAllPreviewTraces, fetchPreviewTrace } from '@agenta/entities/trace'
  *
- * const spans = await fetchAllPreviewTraces({ size: 100, focus: 'span' }, appId)
+ * const spans = await fetchAllPreviewTraces({ size: 100 }, appId, projectId)
  * const trace = await fetchPreviewTrace(traceId, projectId)
  * ```
  */
@@ -19,18 +22,24 @@ import {axios, getAgentaApiUrl} from "@agenta/shared/api"
 // See testcase/api/api.ts for rationale — the shared barrel pulls in CSS deps.
 import {safeParseWithLogging} from "../../shared/utils/zodSchema"
 import {
+    sessionIdsResponseSchema,
     spansResponseSchema,
-    tracesResponseSchema,
+    traceIdResponseSchema,
+    traceResponseSchema,
+    type SessionIdsResponse,
     type SpansResponse,
-    type TracesResponse,
+    type TraceIdResponse,
+    type TraceResponse,
 } from "../core"
 
 /**
- * Query parameters for fetching traces/spans
+ * Query parameters for fetching spans.
+ *
+ * Note: `focus` is no longer accepted — `POST /spans/query` always returns
+ * flat spans. For trace-tree views, use `fetchPreviewTrace` instead.
  */
 export interface TraceQueryParams {
     size?: number
-    focus?: "trace" | "span" | "chat"
     format?: string
     filter?: string | Record<string, unknown>
     oldest?: string
@@ -40,26 +49,27 @@ export interface TraceQueryParams {
 }
 
 /**
- * Fetch preview traces/spans from the API.
+ * Fetch spans from the API (flat list).
+ *
+ * Calls `POST /spans/query` which always returns a flat `SpansResponse`.
+ * For trace-tree views, use `fetchPreviewTrace` instead.
  *
  * @param params - Query parameters for filtering
  * @param appId - Application ID (optional)
  * @param projectId - Project ID (required)
- * @returns API response with spans (validated)
+ * @returns Validated SpansResponse
  */
 export async function fetchAllPreviewTraces(
     params: TraceQueryParams = {},
     appId: string,
     projectId: string,
-): Promise<SpansResponse | TracesResponse | null> {
+): Promise<SpansResponse | null> {
     const baseUrl = getAgentaApiUrl()
 
-    // Build query parameters
     const queryParams = new URLSearchParams()
     if (projectId) queryParams.set("project_id", projectId)
     if (appId) queryParams.set("application_id", appId)
 
-    // Build request payload
     const payload: Record<string, unknown> = {}
     Object.entries(params).forEach(([key, value]) => {
         if (value === undefined || value === null) return
@@ -71,68 +81,71 @@ export async function fetchAllPreviewTraces(
             } catch {
                 payload.filter = value
             }
+        } else if (key === "focus") {
+            // `focus` is no longer accepted by POST /spans/query — skip it.
+            return
         } else {
             payload[key] = value
         }
     })
 
     const response = await axios.post(
-        `${baseUrl}/tracing/spans/query?${queryParams.toString()}`,
+        `${baseUrl}/spans/query?${queryParams.toString()}`,
         payload,
     )
 
-    // Try parsing as SpansResponse first (spans array format)
-    const spansResult = spansResponseSchema.safeParse(response.data)
-    if (spansResult.success) {
-        return spansResult.data
-    }
-
-    // Fall back to TracesResponse (traces record format)
-    return safeParseWithLogging(tracesResponseSchema, response.data, "[fetchAllPreviewTraces]")
+    return safeParseWithLogging(spansResponseSchema, response.data, "[fetchAllPreviewTraces]")
 }
 
 /**
- * Fetch a single trace by ID.
+ * Fetch a single trace by ID (with trace-tree structure).
+ *
+ * Calls `GET /traces/{id}` which returns a `TraceResponse` with a single
+ * `trace` object containing `trace_id` and a `spans` record.
  *
  * @param traceId - Trace ID to fetch
  * @param projectId - Project ID
- * @returns Trace span data (validated)
+ * @returns Validated TraceResponse
  */
 export async function fetchPreviewTrace(
     traceId: string,
     projectId: string,
-): Promise<TracesResponse | null> {
+): Promise<TraceResponse | null> {
     const baseUrl = getAgentaApiUrl()
 
     const queryParams = new URLSearchParams()
     if (projectId) queryParams.set("project_id", projectId)
 
     const response = await axios.get(
-        `${baseUrl}/tracing/traces/${traceId}?${queryParams.toString()}`,
+        `${baseUrl}/traces/${traceId}?${queryParams.toString()}`,
     )
 
-    // API returns TracesResponse format with count and traces record
-    return safeParseWithLogging(tracesResponseSchema, response.data, "[fetchPreviewTrace]")
+    return safeParseWithLogging(traceResponseSchema, response.data, "[fetchPreviewTrace]")
 }
 
 /**
  * Delete a trace by ID.
  *
+ * Calls `DELETE /traces/{id}`.
+ *
  * @param traceId - Trace ID to delete
  * @param projectId - Project ID
- * @returns Delete response
+ * @returns Validated TraceIdResponse
  */
-export async function deletePreviewTrace(traceId: string, projectId: string): Promise<unknown> {
+export async function deletePreviewTrace(
+    traceId: string,
+    projectId: string,
+): Promise<TraceIdResponse | null> {
     const baseUrl = getAgentaApiUrl()
 
     const queryParams = new URLSearchParams()
     if (projectId) queryParams.set("project_id", projectId)
 
     const response = await axios.delete(
-        `${baseUrl}/tracing/traces/${traceId}?${queryParams.toString()}`,
+        `${baseUrl}/traces/${traceId}?${queryParams.toString()}`,
     )
 
-    return response.data
+    return safeParseWithLogging(traceIdResponseSchema, response.data, "[deletePreviewTrace]")
 }
 
 /**
@@ -155,14 +168,16 @@ export interface SessionQueryParams {
 /**
  * Fetch sessions with filtering and pagination.
  *
+ * Calls `POST /spans/sessions/query`.
+ *
  * @param params - Session query parameters
  * @param projectId - Project ID
- * @returns Session list response
+ * @returns Validated SessionIdsResponse
  */
 export async function fetchSessions(
     params: SessionQueryParams,
     projectId: string,
-): Promise<unknown> {
+): Promise<SessionIdsResponse | null> {
     const baseUrl = getAgentaApiUrl()
 
     const queryParams = new URLSearchParams()
@@ -171,11 +186,8 @@ export async function fetchSessions(
 
     const payload: Record<string, unknown> = {}
 
-    // Initialize windowing if it doesn't exist but we have a cursor
     if (params.windowing || params.cursor) {
         payload.windowing = {...(params.windowing || {})}
-
-        // If cursor is provided, it goes into windowing.next
         if (params.cursor) {
             ;(payload.windowing as Record<string, unknown>).next = params.cursor
         }
@@ -185,15 +197,14 @@ export async function fetchSessions(
         payload.filter = params.filter
     }
 
-    // Add realtime parameter (true = latest/unstable, false/undefined = all/stable)
     if (params.realtime !== undefined) {
         payload.realtime = params.realtime
     }
 
     const response = await axios.post(
-        `${baseUrl}/tracing/sessions/query?${queryParams.toString()}`,
+        `${baseUrl}/spans/sessions/query?${queryParams.toString()}`,
         payload,
     )
 
-    return response.data
+    return safeParseWithLogging(sessionIdsResponseSchema, response.data, "[fetchSessions]")
 }

--- a/web/packages/agenta-entities/src/trace/api/helpers.ts
+++ b/web/packages/agenta-entities/src/trace/api/helpers.ts
@@ -15,20 +15,33 @@
  * ```
  */
 
-import type {SpansResponse, TracesResponse, TraceSpanNode, TraceSpan} from "../core"
+import type {
+    SpansResponse,
+    TraceResponse,
+    TracesResponse,
+    TraceSpanNode,
+    TraceSpan,
+} from "../core"
 
 /**
- * Type guard for TracesResponse (response with traces object)
+ * Type guard for TracesResponse (legacy response with traces record object).
  */
 export const isTracesResponse = (data: unknown): data is TracesResponse => {
     return typeof data === "object" && data !== null && "traces" in data
 }
 
 /**
- * Type guard for SpansResponse (response with spans array)
+ * Type guard for SpansResponse (response with flat spans array).
  */
 export const isSpansResponse = (data: unknown): data is SpansResponse => {
-    return typeof data === "object" && data !== null && "spans" in data
+    return typeof data === "object" && data !== null && "spans" in data && Array.isArray((data as any).spans)
+}
+
+/**
+ * Type guard for TraceResponse (new single-trace response from GET /traces/{id}).
+ */
+export const isTraceResponse = (data: unknown): data is TraceResponse => {
+    return typeof data === "object" && data !== null && "trace" in data
 }
 
 /**
@@ -76,41 +89,57 @@ export const sortSpansByStartTime = <
 }
 
 /**
- * Transform a TracesResponse into a tree of TraceSpanNodes.
+ * Build a tree of TraceSpanNodes from a spans record.
+ *
+ * Shared by both the legacy `TracesResponse` path and the new `TraceResponse`
+ * path — the inner span structure is identical.
+ */
+const buildSpanTree = (spans: Record<string, unknown> | unknown[]): TraceSpanNode[] => {
+    if (!spans) {
+        return []
+    }
+
+    const spanArray = Object.values(spans).flatMap((span: unknown) => {
+        if (Array.isArray(span)) {
+            return buildSpanTree(span)
+        }
+
+        const spanObj = span as TraceSpan & {spans?: Record<string, unknown>}
+        const node: TraceSpanNode = {
+            ...spanObj,
+        }
+
+        if (spanObj?.spans && Object.keys(spanObj.spans).length > 0) {
+            node.children = buildSpanTree(spanObj.spans)
+        }
+
+        return node
+    })
+
+    return sortSpansByStartTime(spanArray)
+}
+
+/**
+ * Transform a TracesResponse (legacy, with `traces` record) into a tree.
  *
  * @param data - TracesResponse from the API
  * @returns Array of TraceSpanNode trees
  */
 export const transformTracesResponseToTree = (data: TracesResponse): TraceSpanNode[] => {
-    const buildTree = (spans: Record<string, unknown> | unknown[]): TraceSpanNode[] => {
-        if (!spans) {
-            return []
-        }
-
-        const spanArray = Object.values(spans).flatMap((span: unknown) => {
-            if (Array.isArray(span)) {
-                return buildTree(span)
-            }
-
-            const spanObj = span as TraceSpan & {spans?: Record<string, unknown>}
-            const node: TraceSpanNode = {
-                ...spanObj,
-            }
-
-            if (spanObj?.spans && Object.keys(spanObj.spans).length > 0) {
-                node.children = buildTree(spanObj.spans)
-            }
-
-            return node
-        })
-
-        // Sort spans at this hierarchy level by start_time
-        return sortSpansByStartTime(spanArray)
-    }
-
     return Object.values(data.traces).flatMap((trace: {spans?: Record<string, unknown>}) =>
-        buildTree(trace.spans || {}),
+        buildSpanTree(trace.spans || {}),
     )
+}
+
+/**
+ * Transform a TraceResponse (new single-trace from GET /traces/{id}) into a tree.
+ *
+ * @param data - TraceResponse from the API
+ * @returns Array of TraceSpanNode trees (single trace)
+ */
+export const transformTraceResponseToTree = (data: TraceResponse): TraceSpanNode[] => {
+    if (!data.trace?.spans) return []
+    return buildSpanTree(data.trace.spans)
 }
 
 /**

--- a/web/packages/agenta-entities/src/trace/api/index.ts
+++ b/web/packages/agenta-entities/src/trace/api/index.ts
@@ -18,7 +18,9 @@ export {
 export {
     isTracesResponse,
     isSpansResponse,
+    isTraceResponse,
     sortSpansByStartTime,
     transformTracesResponseToTree,
+    transformTraceResponseToTree,
     transformTracingResponse,
 } from "./helpers"

--- a/web/packages/agenta-entities/src/trace/core/index.ts
+++ b/web/packages/agenta-entities/src/trace/core/index.ts
@@ -37,6 +37,12 @@ export {
     type TracesResponse,
     spansResponseSchema,
     type SpansResponse,
+    traceResponseSchema,
+    type TraceResponse,
+    traceIdResponseSchema,
+    type TraceIdResponse,
+    sessionIdsResponseSchema,
+    type SessionIdsResponse,
     type TraceListResponse,
     // Parsing utilities
     parseTraceSpan,

--- a/web/packages/agenta-entities/src/trace/core/schema.ts
+++ b/web/packages/agenta-entities/src/trace/core/schema.ts
@@ -233,6 +233,52 @@ export const spansResponseSchema = z.object({
 })
 export type SpansResponse = z.infer<typeof spansResponseSchema>
 
+/**
+ * Response schema for `GET /traces/{id}`.
+ *
+ * The new endpoint returns a single `trace` object (not a `traces` record).
+ * `spans` inside the trace is a flat record keyed by span_id.
+ */
+export const traceResponseSchema = z.object({
+    count: z.number().optional().default(0),
+    trace: z
+        .object({
+            trace_id: z.string().optional().nullable(),
+            spans: z.record(z.string(), traceSpanSchema).optional().nullable(),
+        })
+        .optional()
+        .nullable(),
+})
+export type TraceResponse = z.infer<typeof traceResponseSchema>
+
+/**
+ * Response schema for `DELETE /traces/{id}`.
+ */
+export const traceIdResponseSchema = z.object({
+    count: z.number(),
+    trace_id: z.string().optional().nullable(),
+})
+export type TraceIdResponse = z.infer<typeof traceIdResponseSchema>
+
+/**
+ * Response schema for `POST /spans/sessions/query`.
+ */
+export const sessionIdsResponseSchema = z.object({
+    count: z.number(),
+    session_ids: z.array(z.string()),
+    windowing: z
+        .object({
+            next: z.string().optional().nullable(),
+            oldest: z.string().optional().nullable(),
+            newest: z.string().optional().nullable(),
+            limit: z.number().optional().nullable(),
+            order: z.enum(["ascending", "descending"]).optional().nullable(),
+        })
+        .optional()
+        .nullable(),
+})
+export type SessionIdsResponse = z.infer<typeof sessionIdsResponseSchema>
+
 // Combined response type for list queries
 export interface TraceListResponse {
     traces: TraceSpanNode[]

--- a/web/packages/agenta-entities/src/trace/index.ts
+++ b/web/packages/agenta-entities/src/trace/index.ts
@@ -84,6 +84,12 @@ export {
     type TracesResponse,
     spansResponseSchema,
     type SpansResponse,
+    traceResponseSchema,
+    type TraceResponse,
+    traceIdResponseSchema,
+    type TraceIdResponse,
+    sessionIdsResponseSchema,
+    type SessionIdsResponse,
     type TraceListResponse,
 } from "./core"
 
@@ -114,8 +120,10 @@ export {
 export {
     isTracesResponse,
     isSpansResponse,
+    isTraceResponse,
     sortSpansByStartTime,
     transformTracesResponseToTree,
+    transformTraceResponseToTree,
     transformTracingResponse,
 } from "./api"
 


### PR DESCRIPTION
## Summary

Migrates 4 of 5 deprecated `/tracing/*` endpoints to their canonical replacements. The analytics endpoint (`/tracing/spans/analytics`) is deferred per [issue author's recommendation](https://github.com/Agenta-AI/agenta/issues/4492#issuecomment-4576748038).

### Endpoint migrations

| Legacy | New | Change Type |
|---|---|---|
| `POST /tracing/spans/query` | `POST /spans/query` | URL + `focus` param removed (always returns flat spans) |
| `GET /tracing/traces/{id}` | `GET /traces/{id}` | URL + response shape (`traces` record → single `trace` object) |
| `DELETE /tracing/traces/{id}` | `DELETE /traces/{id}` | URL-only |
| `POST /tracing/sessions/query` | `POST /spans/sessions/query` | URL-only |

### Files changed (8)

**New Zod schemas** (`web/packages/agenta-entities/src/trace/core/schema.ts`):
- `traceResponseSchema` — for `GET /traces/{id}`: `{count, trace: {trace_id, spans}}`
- `traceIdResponseSchema` — for `DELETE /traces/{id}`: `{count, trace_id}`
- `sessionIdsResponseSchema` — for `POST /spans/sessions/query`: `{count, session_ids, windowing}`

**Entities API** (`web/packages/agenta-entities/src/trace/api/api.ts`):
- `fetchAllPreviewTraces` → `POST /spans/query`, strips `focus` param, always returns `SpansResponse`
- `fetchPreviewTrace` → `GET /traces/{id}`, returns `TraceResponse`
- `deletePreviewTrace` → `DELETE /traces/{id}`, returns `TraceIdResponse`
- `fetchSessions` → `POST /spans/sessions/query`, returns `SessionIdsResponse`

**New helpers** (`web/packages/agenta-entities/src/trace/api/helpers.ts`):
- `isTraceResponse` — type guard for new single-trace response
- `transformTraceResponseToTree` — builds span tree from `TraceResponse`

**OSS API** (`web/oss/src/services/tracing/api/index.ts`):
- URL updates for all 4 endpoints
- `focus` param stripped from `fetchAllPreviewTraces` and `fetchAllPreviewTracesWithMeta`

**Annotation controller** (`web/packages/agenta-annotation/src/state/controllers/annotationFormController.ts`):
- Updated to handle new `{trace: {trace_id, spans}}` shape with legacy fallback

### Backward compatibility

- Existing consumer branching logic (`isTracesResponse`/`isSpansResponse`) continues to work
- `POST /spans/query` always returns `SpansResponse` now, so the `isTracesResponse` branch becomes dead code for list queries (harmless)
- `normalizeTracesResponse()` in drawer stores already handles `.trace` shape
- Analytics endpoint stays on `/tracing/spans/analytics` (deferred to separate PR)

Fixes #4492