### PR TITLE
Fix SDK eval breadcrumbs

### DIFF
--- a/web/oss/src/components/EvalRunDetails/Table.tsx
+++ b/web/oss/src/components/EvalRunDetails/Table.tsx
@@ -16,6 +16,7 @@ import {
     EXPORT_RESOLVE_SKIP,
     type TableExportColumnContext,
 } from "@/oss/components/InfiniteVirtualTable/hooks/useTableExport"
+import type {EvaluationRunKind} from "@/oss/lib/evaluations/utils/evaluationKind"
 
 import useComparisonPaginations from "../EvalRunDetails2/hooks/useComparisonPaginations"
 import useComparisonSchemas from "../EvalRunDetails2/hooks/useComparisonSchemas"
@@ -53,7 +54,7 @@ type TableRowData = PreviewTableRow
 
 interface EvalRunDetailsTableProps {
     runId: string
-    evaluationType: "auto" | "human" | "online"
+    evaluationType: EvaluationRunKind
     skeletonRowCount?: number
     projectId?: string | null
 }
@@ -500,9 +501,9 @@ const EvalRunDetailsTable = ({
         // Add static metric columns (they have composite keys like "groupId::metricPath")
         if (columnResult?.groups && columnResult?.staticMetricColumns) {
             const metricsForType =
-                evaluationType === "auto"
-                    ? columnResult.staticMetricColumns.auto
-                    : columnResult.staticMetricColumns.human
+                evaluationType === "human"
+                    ? columnResult.staticMetricColumns.human
+                    : columnResult.staticMetricColumns.auto
 
             columnResult.groups
                 .filter((group) => group.kind === "metric")

--- a/web/oss/src/components/EvalRunDetails/atoms/metricProcessor.ts
+++ b/web/oss/src/components/EvalRunDetails/atoms/metricProcessor.ts
@@ -1,4 +1,5 @@
 import axios from "@/oss/lib/api/assets/axiosConfig"
+import type {EvaluationRunKind} from "@/oss/lib/evaluations/utils/evaluationKind"
 import {canonicalizeMetricKey} from "@/oss/lib/metricUtils"
 
 import {wasScenarioRecentlySaved} from "./metrics"
@@ -143,7 +144,7 @@ export const createMetricProcessor = ({
     source,
     evaluationType,
 }: MetricProcessorOptions & {
-    evaluationType?: "auto" | "human" | "online" | null
+    evaluationType?: EvaluationRunKind | null
 }): MetricProcessor => {
     const state: MetricProcessorState = {
         pending: [],

--- a/web/oss/src/components/EvalRunDetails/components/Page.tsx
+++ b/web/oss/src/components/EvalRunDetails/components/Page.tsx
@@ -7,6 +7,7 @@ import Router from "next/router"
 
 import {useQueryParam} from "@/oss/hooks/useQuery"
 import useURL from "@/oss/hooks/useURL"
+import type {EvaluationRunKind} from "@/oss/lib/evaluations/utils/evaluationKind"
 import {useBreadcrumbsEffect} from "@/oss/lib/hooks/useBreadcrumbs"
 
 import {activePreviewProjectIdAtom, activePreviewRunIdAtom} from "../atoms/run"
@@ -15,6 +16,7 @@ import {previewEvalTypeAtom} from "../state/evalType"
 import {syncCompareStateFromUrl} from "../state/urlCompare"
 import {syncFocusDrawerStateFromUrl} from "../state/urlFocusDrawer"
 import EvalRunDetailsTable from "../Table"
+import {buildEvaluationTypeBreadcrumb} from "../utils/evaluationTypeBreadcrumb"
 
 import PreviewEvalRunTabs, {PreviewEvalRunMeta} from "./PreviewEvalRunHeader"
 import ConfigurationView from "./views/ConfigurationView"
@@ -25,7 +27,7 @@ type ViewKey = "overview" | "focus" | "scenarios" | "configuration"
 
 interface EvalRunPreviewPageProps {
     runId: string
-    evaluationType: "auto" | "human" | "online"
+    evaluationType: EvaluationRunKind
     projectId?: string | null
 }
 
@@ -45,18 +47,10 @@ const EvalRunPreviewPage = ({runId, evaluationType, projectId = null}: EvalRunPr
 
     // Map evaluation type to display label and URL kind parameter
     // Labels match EvaluationsView.tsx tab labels
-    const evaluationTypeBreadcrumb = useMemo(() => {
-        const typeMap: Record<string, {label: string; kind: string}> = {
-            auto: {label: "Auto Evals", kind: "auto"},
-            human: {label: "Human Evals", kind: "human"},
-            online: {label: "Live Evals", kind: "online"},
-        }
-        const config = typeMap[evaluationType] ?? {label: "Evaluations", kind: "auto"}
-        return {
-            label: config.label,
-            href: projectURL ? `${projectURL}/evaluations?kind=${config.kind}` : undefined,
-        }
-    }, [evaluationType, projectURL])
+    const evaluationTypeBreadcrumb = useMemo(
+        () => buildEvaluationTypeBreadcrumb({evaluationType, projectURL}),
+        [evaluationType, projectURL],
+    )
 
     // Set breadcrumbs: workspace / project / evaluations [type] (link) / evaluation name
     // Use "appPage" for evaluation type and "appPageDetail" for evaluation name

--- a/web/oss/src/components/EvalRunDetails/components/columnVisibility/ColumnVisibilityPopoverContent.tsx
+++ b/web/oss/src/components/EvalRunDetails/components/columnVisibility/ColumnVisibilityPopoverContent.tsx
@@ -6,6 +6,7 @@ import type {ColumnTreeNode, ColumnVisibilityState} from "@/oss/components/Infin
 import ColumnVisibilityPopoverContentBase, {
     type ColumnVisibilityNodeMeta,
 } from "@/oss/components/InfiniteVirtualTable/components/columnVisibility/ColumnVisibilityPopoverContent"
+import type {EvaluationRunKind} from "@/oss/lib/evaluations/utils/evaluationKind"
 import {humanizeMetricPath} from "@/oss/lib/evaluations/utils/metrics"
 
 import {
@@ -19,7 +20,7 @@ import {buildSkeletonColumnResult} from "../../utils/buildSkeletonColumns"
 import {resolveGroupLabel, humanizeStepKey, titleize} from "../../utils/labelHelpers"
 import StepGroupHeader from "../TableHeaders/StepGroupHeader"
 
-type EvaluationType = "auto" | "human"
+type EvaluationType = EvaluationRunKind
 
 interface ScenarioColumnVisibilityPopoverContentProps {
     runId: string
@@ -45,15 +46,15 @@ const selectColumnsForType = (
 
     const relevantGroups = result.groups.filter((group) => {
         if (group.kind !== "metric") return true
-        return evaluationType === "auto"
-            ? group.id.includes("metrics:auto")
-            : group.id.includes("metrics:human")
+        return evaluationType === "human"
+            ? group.id.includes("metrics:human")
+            : group.id.includes("metrics:auto")
     })
 
     const staticMetrics =
-        evaluationType === "auto"
-            ? {auto: result.staticMetricColumns.auto, human: [] as MetricColumnDefinition[]}
-            : {auto: [] as MetricColumnDefinition[], human: result.staticMetricColumns.human}
+        evaluationType === "human"
+            ? {auto: [] as MetricColumnDefinition[], human: result.staticMetricColumns.human}
+            : {auto: result.staticMetricColumns.auto, human: [] as MetricColumnDefinition[]}
 
     return {
         columns: result.columns,
@@ -158,9 +159,9 @@ const ScenarioColumnVisibilityPopoverContent = ({
             {metric: MetricColumnDefinition; group?: EvaluationTableColumnGroup}
         >()
         const metricsForType =
-            evaluationType === "auto"
-                ? columnData.staticMetricColumns.auto
-                : columnData.staticMetricColumns.human
+            evaluationType === "human"
+                ? columnData.staticMetricColumns.human
+                : columnData.staticMetricColumns.auto
 
         if (!metricsForType.length) return map
 

--- a/web/oss/src/components/EvalRunDetails/evaluationPreviewTableStore.ts
+++ b/web/oss/src/components/EvalRunDetails/evaluationPreviewTableStore.ts
@@ -13,11 +13,11 @@ import {effectiveProjectIdAtom} from "./atoms/run"
 import type {WindowingState, EvaluationScenarioRow} from "./atoms/table"
 import {fetchEvaluationScenarioWindow} from "./atoms/table/scenarios"
 import type {PreviewTableRow} from "./atoms/tableRows"
-import {previewEvalTypeAtom} from "./state/evalType"
+import {previewEvalTypeAtom, type PreviewEvaluationType} from "./state/evalType"
 
 interface EvaluationPreviewMeta {
     projectId: string | null
-    evaluationType: "auto" | "human" | "online" | null
+    evaluationType: PreviewEvaluationType
 }
 
 const createSkeletonRow = ({

--- a/web/oss/src/components/EvalRunDetails/hooks/usePreviewColumns.tsx
+++ b/web/oss/src/components/EvalRunDetails/hooks/usePreviewColumns.tsx
@@ -7,6 +7,7 @@ import type {ColumnTreeNode} from "@/oss/components/InfiniteVirtualTable"
 import ColumnVisibilityMenuTrigger, {
     type ColumnVisibilityNodeMeta,
 } from "@/oss/components/InfiniteVirtualTable/components/columnVisibility/ColumnVisibilityMenuTrigger"
+import type {EvaluationRunKind} from "@/oss/lib/evaluations/utils/evaluationKind"
 import {humanizeMetricPath} from "@/oss/lib/evaluations/utils/metrics"
 
 import {
@@ -26,7 +27,7 @@ type TableRowData = PreviewTableRow
 
 export interface PreviewColumnsArgs {
     columnResult: EvaluationTableColumnsResult | undefined
-    evaluationType: "auto" | "human" | "online"
+    evaluationType: EvaluationRunKind
 }
 
 export interface PreviewColumnsResult {
@@ -42,7 +43,7 @@ export interface PreviewColumnsResult {
 
 const selectColumnsForType = (
     result: EvaluationTableColumnsResult | undefined,
-    evaluationType: "auto" | "human" | "online",
+    evaluationType: EvaluationRunKind,
 ) => {
     if (
         !result ||
@@ -53,7 +54,7 @@ const selectColumnsForType = (
     }
 
     // Online evaluations use auto metrics, human evaluations use human metrics
-    const useAutoMetrics = evaluationType === "auto" || evaluationType === "online"
+    const useAutoMetrics = evaluationType !== "human"
 
     const relevantGroups = result.groups.filter((group) => {
         if (group.kind !== "metric") return true
@@ -86,9 +87,9 @@ const usePreviewColumns = ({
 
     const metricsForType = useMemo(
         () =>
-            evaluationType === "auto" || evaluationType === "online"
-                ? columnData.staticMetricColumns.auto
-                : columnData.staticMetricColumns.human,
+            evaluationType === "human"
+                ? columnData.staticMetricColumns.human
+                : columnData.staticMetricColumns.auto,
         [columnData.staticMetricColumns, evaluationType],
     )
 

--- a/web/oss/src/components/EvalRunDetails/state/evalType.ts
+++ b/web/oss/src/components/EvalRunDetails/state/evalType.ts
@@ -8,7 +8,7 @@ import {
 
 import {evaluationRunQueryAtomFamily} from "../atoms/table/run"
 
-export type PreviewEvaluationType = "auto" | "human" | "online" | null
+export type PreviewEvaluationType = EvaluationRunKind | null
 
 /**
  * Base atom for storing the evaluation type.

--- a/web/oss/src/components/EvalRunDetails/test.tsx
+++ b/web/oss/src/components/EvalRunDetails/test.tsx
@@ -2,14 +2,12 @@ import {useMemo} from "react"
 
 import {useRouter} from "next/router"
 
+import type {EvaluationRunKind} from "@/oss/lib/evaluations/utils/evaluationKind"
+
 import EvalRunPreviewPage from "./components/Page"
 import EvalResultsOnboarding from "./EvalResultsOnboarding"
 
-type EvalRunKind = "auto" | "human" | "online" | "custom"
-
-const EvalRunTestPage = ({type = "auto"}: {type?: EvalRunKind}) => {
-    // Normalize "custom" to "auto", but keep "online" as-is
-    const evaluationType = type === "custom" ? "auto" : type
+const EvalRunTestPage = ({type = "auto"}: {type?: EvaluationRunKind}) => {
     const router = useRouter()
     const evaluationIdParam = router.query?.evaluation_id
     const projectIdParam = router.query?.project_id
@@ -33,11 +31,7 @@ const EvalRunTestPage = ({type = "auto"}: {type?: EvalRunKind}) => {
     return (
         <div className="w-full h-full overflow-hidden flex flex-col" data-tour="eval-results">
             <EvalResultsOnboarding isReady={!!runId} />
-            <EvalRunPreviewPage
-                evaluationType={evaluationType}
-                runId={runId}
-                projectId={projectId}
-            />
+            <EvalRunPreviewPage evaluationType={type} runId={runId} projectId={projectId} />
         </div>
     )
 }

--- a/web/oss/src/components/EvalRunDetails/utils/buildPreviewColumns.tsx
+++ b/web/oss/src/components/EvalRunDetails/utils/buildPreviewColumns.tsx
@@ -5,6 +5,7 @@ import type {ColumnsType, ColumnType} from "antd/es/table"
 import clsx from "clsx"
 
 import {ColumnVisibilityHeader} from "@/oss/components/InfiniteVirtualTable"
+import type {EvaluationRunKind} from "@/oss/lib/evaluations/utils/evaluationKind"
 
 import type {
     EvaluationTableColumn,
@@ -109,7 +110,7 @@ export interface BuildPreviewColumnsArgs<RowType> {
         auto: MetricColumnDefinition[]
         human: MetricColumnDefinition[]
     }
-    evaluationType: "auto" | "human" | "online"
+    evaluationType: EvaluationRunKind
     getRenderer?: (column: EvaluationTableColumn) => ColumnType<RowType>["render"] | undefined
     isSkeletonRow?: (record: RowType) => boolean
     renderSkeleton?: (context: SkeletonRenderContext<RowType>) => React.ReactNode
@@ -211,9 +212,7 @@ export function buildPreviewColumns<RowType>({
     const columnsMap = new Map(columns.map((column) => [column.id, column]))
     // Online evaluations use auto metrics, human evaluations use human metrics
     const metricsForType =
-        evaluationType === "auto" || evaluationType === "online"
-            ? staticMetricColumns.auto
-            : staticMetricColumns.human
+        evaluationType === "human" ? staticMetricColumns.human : staticMetricColumns.auto
 
     const defaultSkeleton = () => (
         <div className="h-3 w-full rounded bg-neutral-200 animate-pulse" />

--- a/web/oss/src/components/EvalRunDetails/utils/buildSkeletonColumns.ts
+++ b/web/oss/src/components/EvalRunDetails/utils/buildSkeletonColumns.ts
@@ -1,3 +1,5 @@
+import type {EvaluationRunKind} from "@/oss/lib/evaluations/utils/evaluationKind"
+
 import type {
     EvaluationColumnKind,
     EvaluationTableColumn,
@@ -91,7 +93,7 @@ const createSkeletonGroupColumns = (
 }
 
 export const buildSkeletonColumnResult = (
-    evaluationType: "auto" | "human" | "online",
+    evaluationType: EvaluationRunKind,
 ): EvaluationTableColumnsResult => {
     const metaColumns = createMetaSkeletonColumns({
         includeTimestamp: evaluationType === "online",

--- a/web/oss/src/components/EvalRunDetails/utils/evaluationTypeBreadcrumb.test.ts
+++ b/web/oss/src/components/EvalRunDetails/utils/evaluationTypeBreadcrumb.test.ts
@@ -1,0 +1,25 @@
+import assert from "node:assert/strict"
+
+import {buildEvaluationTypeBreadcrumb} from "./evaluationTypeBreadcrumb"
+
+assert.deepEqual(
+    buildEvaluationTypeBreadcrumb({
+        evaluationType: "custom",
+        projectURL: "/w/workspace/p/project",
+    }),
+    {
+        label: "SDK Evals",
+        href: "/w/workspace/p/project/evaluations?kind=custom",
+    },
+)
+
+assert.deepEqual(
+    buildEvaluationTypeBreadcrumb({
+        evaluationType: "auto",
+        projectURL: "/w/workspace/p/project",
+    }),
+    {
+        label: "Auto Evals",
+        href: "/w/workspace/p/project/evaluations?kind=auto",
+    },
+)

--- a/web/oss/src/components/EvalRunDetails/utils/evaluationTypeBreadcrumb.ts
+++ b/web/oss/src/components/EvalRunDetails/utils/evaluationTypeBreadcrumb.ts
@@ -1,0 +1,24 @@
+import type {EvaluationRunKind} from "@/oss/lib/evaluations/utils/evaluationKind"
+
+export const EVALUATION_TYPE_BREADCRUMB: Record<EvaluationRunKind, {label: string; kind: string}> =
+    {
+        auto: {label: "Auto Evals", kind: "auto"},
+        human: {label: "Human Evals", kind: "human"},
+        online: {label: "Live Evals", kind: "online"},
+        custom: {label: "SDK Evals", kind: "custom"},
+    }
+
+export const buildEvaluationTypeBreadcrumb = ({
+    evaluationType,
+    projectURL,
+}: {
+    evaluationType: EvaluationRunKind
+    projectURL?: string | null
+}) => {
+    const config = EVALUATION_TYPE_BREADCRUMB[evaluationType]
+
+    return {
+        label: config.label,
+        href: projectURL ? `${projectURL}/evaluations?kind=${config.kind}` : undefined,
+    }
+}


### PR DESCRIPTION
## Summary
- preserve the `custom` evaluation type on eval run detail pages instead of normalizing it to `auto`
- show SDK eval runs under `SDK Evals` breadcrumbs and link back with `kind=custom`
- keep non-human table metrics behavior on the auto metrics path, including SDK/custom evals

Fixes #4549

## Testing
- [x] `pnpm exec tsx --tsconfig oss/tsconfig.json oss/src/components/EvalRunDetails/utils/evaluationTypeBreadcrumb.test.ts`
- [x] `pnpm exec prettier --check oss/src/components/EvalRunDetails/test.tsx oss/src/components/EvalRunDetails/components/Page.tsx oss/src/components/EvalRunDetails/state/evalType.ts oss/src/components/EvalRunDetails/Table.tsx oss/src/components/EvalRunDetails/hooks/usePreviewColumns.tsx oss/src/components/EvalRunDetails/utils/buildPreviewColumns.tsx oss/src/components/EvalRunDetails/utils/buildSkeletonColumns.ts oss/src/components/EvalRunDetails/evaluationPreviewTableStore.ts oss/src/components/EvalRunDetails/components/columnVisibility/ColumnVisibilityPopoverContent.tsx oss/src/components/EvalRunDetails/atoms/metricProcessor.ts oss/src/components/EvalRunDetails/utils/evaluationTypeBreadcrumb.ts oss/src/components/EvalRunDetails/utils/evaluationTypeBreadcrumb.test.ts`
- [x] `pnpm exec next lint --file src/components/EvalRunDetails/test.tsx --file src/components/EvalRunDetails/components/Page.tsx --file src/components/EvalRunDetails/state/evalType.ts --file src/components/EvalRunDetails/Table.tsx --file src/components/EvalRunDetails/hooks/usePreviewColumns.tsx --file src/components/EvalRunDetails/utils/buildPreviewColumns.tsx --file src/components/EvalRunDetails/utils/buildSkeletonColumns.ts --file src/components/EvalRunDetails/evaluationPreviewTableStore.ts --file src/components/EvalRunDetails/components/columnVisibility/ColumnVisibilityPopoverContent.tsx --file src/components/EvalRunDetails/atoms/metricProcessor.ts --file src/components/EvalRunDetails/utils/evaluationTypeBreadcrumb.ts --file src/components/EvalRunDetails/utils/evaluationTypeBreadcrumb.test.ts`
- [ ] `pnpm run types:check` currently fails on existing repository-wide TypeScript errors unrelated to this change; the earlier `evaluationType` narrowing error caused by this patch was resolved.

## Demo
Demo recording is still pending because the Vercel preview currently requires Agenta team authorization and I do not have a runnable preview from this CLI session.

Expected behavior on an SDK/custom eval run detail page: the breadcrumb should read `SDK Evals` and link back with `kind=custom`.

## Checklist
- [x] Linked the related issue: #4549
- [x] Added/updated tests for the breadcrumb helper
- [x] Ran targeted formatting and lint checks listed above
- [ ] Attached a screenshot or video demo
