### PR TITLE
Fix SDK eval breadcrumbs for SDK/custom runs

### DIFF
--- a/web/oss/src/components/EvalRunDetails/Table.tsx
+++ b/web/oss/src/components/EvalRunDetails/Table.tsx
@@ -49,6 +49,7 @@ import usePreviewTableData from "./hooks/usePreviewTableData"
 import useRowHeightMenuItems from "./hooks/useRowHeightMenuItems"
 import {scenarioRowHeightAtom} from "./state/rowHeight"
 import {patchFocusDrawerQueryParams} from "./state/urlFocusDrawer"
+import {selectStaticMetricColumnsForEvaluationType} from "./utils/evaluationMetricColumns"
 
 type TableRowData = PreviewTableRow
 
@@ -500,10 +501,10 @@ const EvalRunDetailsTable = ({
 
         // Add static metric columns (they have composite keys like "groupId::metricPath")
         if (columnResult?.groups && columnResult?.staticMetricColumns) {
-            const metricsForType =
-                evaluationType === "auto"
-                    ? columnResult.staticMetricColumns.auto
-                    : columnResult.staticMetricColumns.human
+            const metricsForType = selectStaticMetricColumnsForEvaluationType(
+                columnResult.staticMetricColumns,
+                evaluationType,
+            )
 
             columnResult.groups
                 .filter((group) => group.kind === "metric")

--- a/web/oss/src/components/EvalRunDetails/Table.tsx
+++ b/web/oss/src/components/EvalRunDetails/Table.tsx
@@ -16,6 +16,7 @@ import {
     EXPORT_RESOLVE_SKIP,
     type TableExportColumnContext,
 } from "@/oss/components/InfiniteVirtualTable/hooks/useTableExport"
+import type {EvaluationRunKind} from "@/oss/lib/evaluations/utils/evaluationKind"
 
 import useComparisonPaginations from "../EvalRunDetails2/hooks/useComparisonPaginations"
 import useComparisonSchemas from "../EvalRunDetails2/hooks/useComparisonSchemas"
@@ -53,7 +54,7 @@ type TableRowData = PreviewTableRow
 
 interface EvalRunDetailsTableProps {
     runId: string
-    evaluationType: "auto" | "human" | "online"
+    evaluationType: EvaluationRunKind
     skeletonRowCount?: number
     projectId?: string | null
 }

--- a/web/oss/src/components/EvalRunDetails/atoms/metricProcessor.ts
+++ b/web/oss/src/components/EvalRunDetails/atoms/metricProcessor.ts
@@ -1,4 +1,5 @@
 import axios from "@/oss/lib/api/assets/axiosConfig"
+import type {EvaluationRunKind} from "@/oss/lib/evaluations/utils/evaluationKind"
 import {canonicalizeMetricKey} from "@/oss/lib/metricUtils"
 
 import {wasScenarioRecentlySaved} from "./metrics"
@@ -143,7 +144,7 @@ export const createMetricProcessor = ({
     source,
     evaluationType,
 }: MetricProcessorOptions & {
-    evaluationType?: "auto" | "human" | "online" | null
+    evaluationType?: EvaluationRunKind | null
 }): MetricProcessor => {
     const state: MetricProcessorState = {
         pending: [],

--- a/web/oss/src/components/EvalRunDetails/atoms/table/types.ts
+++ b/web/oss/src/components/EvalRunDetails/atoms/table/types.ts
@@ -1,5 +1,7 @@
 import type {EvaluatorDefinition, MetricColumnDefinition} from "@agenta/entities/workflow"
 
+import type {EvaluationRunKind} from "@/oss/lib/evaluations/utils/evaluationKind"
+
 export type EvaluationColumnKind =
     | "meta"
     | "testset"
@@ -36,7 +38,7 @@ export interface EvaluationTableColumn {
     /** Sticky placement hints */
     sticky?: "left" | "right"
     /** Evaluation types the column should be visible for */
-    visibleFor?: ("auto" | "human" | "online")[]
+    visibleFor?: EvaluationRunKind[]
     /** Last segment of the path used for quick lookups */
     valueKey?: string
     /** Metric key (for annotation columns) */

--- a/web/oss/src/components/EvalRunDetails/components/FocusDrawer.tsx
+++ b/web/oss/src/components/EvalRunDetails/components/FocusDrawer.tsx
@@ -2,6 +2,7 @@ import type {KeyboardEvent, ReactNode} from "react"
 import {memo, useCallback, useMemo, useRef, useState} from "react"
 import {isValidElement} from "react"
 
+import type {MetricColumnDefinition} from "@agenta/entities/workflow"
 import {
     formatMetricDisplay,
     METRIC_PLACEHOLDER as METRIC_EMPTY_PLACEHOLDER,
@@ -26,11 +27,7 @@ import {
     variantReferenceQueryAtomFamily,
 } from "../atoms/references"
 import {runDisplayNameAtomFamily} from "../atoms/runDerived"
-import type {
-    ColumnValueDescriptor,
-    EvaluationTableColumn,
-    MetricColumnDefinition,
-} from "../atoms/table"
+import type {ColumnValueDescriptor, EvaluationTableColumn} from "../atoms/table"
 import type {EvaluationTableColumnGroup} from "../atoms/table"
 import {
     columnValueDescriptorMapAtomFamily,

--- a/web/oss/src/components/EvalRunDetails/components/Page.tsx
+++ b/web/oss/src/components/EvalRunDetails/components/Page.tsx
@@ -7,6 +7,7 @@ import Router from "next/router"
 
 import {useQueryParam} from "@/oss/hooks/useQuery"
 import useURL from "@/oss/hooks/useURL"
+import type {EvaluationRunKind} from "@/oss/lib/evaluations/utils/evaluationKind"
 import {useBreadcrumbsEffect} from "@/oss/lib/hooks/useBreadcrumbs"
 
 import {activePreviewProjectIdAtom, activePreviewRunIdAtom} from "../atoms/run"
@@ -25,7 +26,7 @@ type ViewKey = "overview" | "focus" | "scenarios" | "configuration"
 
 interface EvalRunPreviewPageProps {
     runId: string
-    evaluationType: "auto" | "human" | "online"
+    evaluationType: EvaluationRunKind
     projectId?: string | null
 }
 
@@ -46,12 +47,13 @@ const EvalRunPreviewPage = ({runId, evaluationType, projectId = null}: EvalRunPr
     // Map evaluation type to display label and URL kind parameter
     // Labels match EvaluationsView.tsx tab labels
     const evaluationTypeBreadcrumb = useMemo(() => {
-        const typeMap: Record<string, {label: string; kind: string}> = {
+        const typeMap: Record<EvaluationRunKind, {label: string; kind: string}> = {
             auto: {label: "Auto Evals", kind: "auto"},
             human: {label: "Human Evals", kind: "human"},
             online: {label: "Live Evals", kind: "online"},
+            custom: {label: "SDK Evals", kind: "custom"},
         }
-        const config = typeMap[evaluationType] ?? {label: "Evaluations", kind: "auto"}
+        const config = typeMap[evaluationType]
         return {
             label: config.label,
             href: projectURL ? `${projectURL}/evaluations?kind=${config.kind}` : undefined,

--- a/web/oss/src/components/EvalRunDetails/components/columnVisibility/ColumnVisibilityPopoverContent.tsx
+++ b/web/oss/src/components/EvalRunDetails/components/columnVisibility/ColumnVisibilityPopoverContent.tsx
@@ -1,29 +1,32 @@
 import {useMemo, useCallback, useEffect, useRef} from "react"
 
+import type {MetricColumnDefinition} from "@agenta/entities/workflow"
 import {Typography} from "antd"
 
 import type {ColumnTreeNode, ColumnVisibilityState} from "@/oss/components/InfiniteVirtualTable"
 import ColumnVisibilityPopoverContentBase, {
     type ColumnVisibilityNodeMeta,
 } from "@/oss/components/InfiniteVirtualTable/components/columnVisibility/ColumnVisibilityPopoverContent"
+import type {EvaluationRunKind} from "@/oss/lib/evaluations/utils/evaluationKind"
 import {humanizeMetricPath} from "@/oss/lib/evaluations/utils/metrics"
 
 import {
     type EvaluationTableColumn,
     type EvaluationTableColumnGroup,
     type EvaluationTableColumnsResult,
-    type MetricColumnDefinition,
 } from "../../atoms/table"
 import usePreviewTableData from "../../hooks/usePreviewTableData"
 import {buildSkeletonColumnResult} from "../../utils/buildSkeletonColumns"
+import {
+    selectStaticMetricColumnsForEvaluationType,
+    usesAutoMetricColumns,
+} from "../../utils/evaluationMetricColumns"
 import {resolveGroupLabel, humanizeStepKey, titleize} from "../../utils/labelHelpers"
 import StepGroupHeader from "../TableHeaders/StepGroupHeader"
 
-type EvaluationType = "auto" | "human"
-
 interface ScenarioColumnVisibilityPopoverContentProps {
     runId: string
-    evaluationType: EvaluationType
+    evaluationType: EvaluationRunKind
     controls?: ColumnVisibilityState<any>
     onClose: () => void
     scopeId?: string | null
@@ -33,7 +36,7 @@ interface ScenarioColumnVisibilityPopoverContentProps {
 
 const selectColumnsForType = (
     result: EvaluationTableColumnsResult | undefined,
-    evaluationType: EvaluationType,
+    evaluationType: EvaluationRunKind,
 ) => {
     if (
         !result ||
@@ -43,17 +46,18 @@ const selectColumnsForType = (
         return buildSkeletonColumnResult(evaluationType)
     }
 
+    const useAutoMetrics = usesAutoMetricColumns(evaluationType)
+
     const relevantGroups = result.groups.filter((group) => {
         if (group.kind !== "metric") return true
-        return evaluationType === "auto"
+        return useAutoMetrics
             ? group.id.includes("metrics:auto")
             : group.id.includes("metrics:human")
     })
 
-    const staticMetrics =
-        evaluationType === "auto"
-            ? {auto: result.staticMetricColumns.auto, human: [] as MetricColumnDefinition[]}
-            : {auto: [] as MetricColumnDefinition[], human: result.staticMetricColumns.human}
+    const staticMetrics = useAutoMetrics
+        ? {auto: result.staticMetricColumns.auto, human: [] as MetricColumnDefinition[]}
+        : {auto: [] as MetricColumnDefinition[], human: result.staticMetricColumns.human}
 
     return {
         columns: result.columns,
@@ -157,10 +161,10 @@ const ScenarioColumnVisibilityPopoverContent = ({
             string,
             {metric: MetricColumnDefinition; group?: EvaluationTableColumnGroup}
         >()
-        const metricsForType =
-            evaluationType === "auto"
-                ? columnData.staticMetricColumns.auto
-                : columnData.staticMetricColumns.human
+        const metricsForType = selectStaticMetricColumnsForEvaluationType(
+            columnData.staticMetricColumns,
+            evaluationType,
+        )
 
         if (!metricsForType.length) return map
 

--- a/web/oss/src/components/EvalRunDetails/evaluationPreviewTableStore.ts
+++ b/web/oss/src/components/EvalRunDetails/evaluationPreviewTableStore.ts
@@ -8,6 +8,7 @@ import {
     useInfiniteTablePagination,
 } from "@/oss/components/InfiniteVirtualTable"
 import type {InfiniteDatasetStore} from "@/oss/components/InfiniteVirtualTable/createInfiniteDatasetStore"
+import type {EvaluationRunKind} from "@/oss/lib/evaluations/utils/evaluationKind"
 
 import {effectiveProjectIdAtom} from "./atoms/run"
 import type {WindowingState, EvaluationScenarioRow} from "./atoms/table"
@@ -17,7 +18,7 @@ import {previewEvalTypeAtom} from "./state/evalType"
 
 interface EvaluationPreviewMeta {
     projectId: string | null
-    evaluationType: "auto" | "human" | "online" | null
+    evaluationType: EvaluationRunKind | null
 }
 
 const createSkeletonRow = ({

--- a/web/oss/src/components/EvalRunDetails/hooks/usePreviewColumns.tsx
+++ b/web/oss/src/components/EvalRunDetails/hooks/usePreviewColumns.tsx
@@ -1,6 +1,7 @@
 import {useEffect, useMemo, useCallback, useRef} from "react"
 import type {ReactNode} from "react"
 
+import type {MetricColumnDefinition} from "@agenta/entities/workflow"
 import {Typography} from "antd"
 
 import type {ColumnTreeNode} from "@/oss/components/InfiniteVirtualTable"
@@ -14,7 +15,6 @@ import {
     EvaluationTableColumn,
     EvaluationTableColumnGroup,
     EvaluationTableColumnsResult,
-    MetricColumnDefinition,
 } from "../atoms/table"
 import type {PreviewTableRow} from "../atoms/tableRows"
 import PreviewEvaluationInputCell from "../components/TableCells/InputCell"

--- a/web/oss/src/components/EvalRunDetails/hooks/usePreviewColumns.tsx
+++ b/web/oss/src/components/EvalRunDetails/hooks/usePreviewColumns.tsx
@@ -7,6 +7,7 @@ import type {ColumnTreeNode} from "@/oss/components/InfiniteVirtualTable"
 import ColumnVisibilityMenuTrigger, {
     type ColumnVisibilityNodeMeta,
 } from "@/oss/components/InfiniteVirtualTable/components/columnVisibility/ColumnVisibilityMenuTrigger"
+import type {EvaluationRunKind} from "@/oss/lib/evaluations/utils/evaluationKind"
 import {humanizeMetricPath} from "@/oss/lib/evaluations/utils/metrics"
 
 import {
@@ -26,7 +27,7 @@ type TableRowData = PreviewTableRow
 
 export interface PreviewColumnsArgs {
     columnResult: EvaluationTableColumnsResult | undefined
-    evaluationType: "auto" | "human" | "online"
+    evaluationType: EvaluationRunKind
 }
 
 export interface PreviewColumnsResult {
@@ -42,7 +43,7 @@ export interface PreviewColumnsResult {
 
 const selectColumnsForType = (
     result: EvaluationTableColumnsResult | undefined,
-    evaluationType: "auto" | "human" | "online",
+    evaluationType: EvaluationRunKind,
 ) => {
     if (
         !result ||
@@ -52,8 +53,8 @@ const selectColumnsForType = (
         return buildSkeletonColumnResult(evaluationType)
     }
 
-    // Online evaluations use auto metrics, human evaluations use human metrics
-    const useAutoMetrics = evaluationType === "auto" || evaluationType === "online"
+    // Auto, live, and SDK evaluations use auto metrics; human evaluations use human metrics.
+    const useAutoMetrics = evaluationType !== "human"
 
     const relevantGroups = result.groups.filter((group) => {
         if (group.kind !== "metric") return true
@@ -86,7 +87,7 @@ const usePreviewColumns = ({
 
     const metricsForType = useMemo(
         () =>
-            evaluationType === "auto" || evaluationType === "online"
+            evaluationType !== "human"
                 ? columnData.staticMetricColumns.auto
                 : columnData.staticMetricColumns.human,
         [columnData.staticMetricColumns, evaluationType],

--- a/web/oss/src/components/EvalRunDetails/state/evalType.ts
+++ b/web/oss/src/components/EvalRunDetails/state/evalType.ts
@@ -8,7 +8,7 @@ import {
 
 import {evaluationRunQueryAtomFamily} from "../atoms/table/run"
 
-export type PreviewEvaluationType = "auto" | "human" | "online" | null
+export type PreviewEvaluationType = EvaluationRunKind | null
 
 /**
  * Base atom for storing the evaluation type.

--- a/web/oss/src/components/EvalRunDetails/test.tsx
+++ b/web/oss/src/components/EvalRunDetails/test.tsx
@@ -2,12 +2,12 @@ import {useMemo} from "react"
 
 import {useRouter} from "next/router"
 
+import type {EvaluationRunKind} from "@/oss/lib/evaluations/utils/evaluationKind"
+
 import EvalRunPreviewPage from "./components/Page"
 import EvalResultsOnboarding from "./EvalResultsOnboarding"
 
-type EvalRunKind = "auto" | "human" | "online" | "custom"
-
-const EvalRunTestPage = ({type = "auto"}: {type?: EvalRunKind}) => {
+const EvalRunTestPage = ({type = "auto"}: {type?: EvaluationRunKind}) => {
     const router = useRouter()
     const evaluationIdParam = router.query?.evaluation_id
     const projectIdParam = router.query?.project_id

--- a/web/oss/src/components/EvalRunDetails/test.tsx
+++ b/web/oss/src/components/EvalRunDetails/test.tsx
@@ -8,8 +8,6 @@ import EvalResultsOnboarding from "./EvalResultsOnboarding"
 type EvalRunKind = "auto" | "human" | "online" | "custom"
 
 const EvalRunTestPage = ({type = "auto"}: {type?: EvalRunKind}) => {
-    // Normalize "custom" to "auto", but keep "online" as-is
-    const evaluationType = type === "custom" ? "auto" : type
     const router = useRouter()
     const evaluationIdParam = router.query?.evaluation_id
     const projectIdParam = router.query?.project_id
@@ -33,11 +31,7 @@ const EvalRunTestPage = ({type = "auto"}: {type?: EvalRunKind}) => {
     return (
         <div className="w-full h-full overflow-hidden flex flex-col" data-tour="eval-results">
             <EvalResultsOnboarding isReady={!!runId} />
-            <EvalRunPreviewPage
-                evaluationType={evaluationType}
-                runId={runId}
-                projectId={projectId}
-            />
+            <EvalRunPreviewPage evaluationType={type} runId={runId} projectId={projectId} />
         </div>
     )
 }

--- a/web/oss/src/components/EvalRunDetails/utils/buildPreviewColumns.tsx
+++ b/web/oss/src/components/EvalRunDetails/utils/buildPreviewColumns.tsx
@@ -5,6 +5,7 @@ import type {ColumnsType, ColumnType} from "antd/es/table"
 import clsx from "clsx"
 
 import {ColumnVisibilityHeader} from "@/oss/components/InfiniteVirtualTable"
+import type {EvaluationRunKind} from "@/oss/lib/evaluations/utils/evaluationKind"
 
 import type {
     EvaluationTableColumn,
@@ -109,7 +110,7 @@ export interface BuildPreviewColumnsArgs<RowType> {
         auto: MetricColumnDefinition[]
         human: MetricColumnDefinition[]
     }
-    evaluationType: "auto" | "human" | "online"
+    evaluationType: EvaluationRunKind
     getRenderer?: (column: EvaluationTableColumn) => ColumnType<RowType>["render"] | undefined
     isSkeletonRow?: (record: RowType) => boolean
     renderSkeleton?: (context: SkeletonRenderContext<RowType>) => React.ReactNode

--- a/web/oss/src/components/EvalRunDetails/utils/buildPreviewColumns.tsx
+++ b/web/oss/src/components/EvalRunDetails/utils/buildPreviewColumns.tsx
@@ -1,5 +1,6 @@
 import React from "react"
 
+import type {MetricColumnDefinition} from "@agenta/entities/workflow"
 import {Tooltip} from "antd"
 import type {ColumnsType, ColumnType} from "antd/es/table"
 import clsx from "clsx"
@@ -7,11 +8,7 @@ import clsx from "clsx"
 import {ColumnVisibilityHeader} from "@/oss/components/InfiniteVirtualTable"
 import type {EvaluationRunKind} from "@/oss/lib/evaluations/utils/evaluationKind"
 
-import type {
-    EvaluationTableColumn,
-    EvaluationTableColumnGroup,
-    MetricColumnDefinition,
-} from "../atoms/table"
+import type {EvaluationTableColumn, EvaluationTableColumnGroup} from "../atoms/table"
 import PreviewEvaluationActionCell from "../components/TableCells/ActionCell"
 import PreviewEvaluationInputCell from "../components/TableCells/InputCell"
 import PreviewEvaluationInvocationCell from "../components/TableCells/InvocationCell"
@@ -19,6 +16,7 @@ import PreviewEvaluationMetricCell from "../components/TableCells/MetricCell"
 import StepGroupHeader from "../components/TableHeaders/StepGroupHeader"
 import {COLUMN_WIDTHS} from "../constants/table"
 
+import {selectStaticMetricColumnsForEvaluationType} from "./evaluationMetricColumns"
 import {humanizeStepKey, resolveGroupLabel} from "./labelHelpers"
 
 const TITLEIZE = (value: string) =>
@@ -210,11 +208,11 @@ export function buildPreviewColumns<RowType>({
     renderSkeleton,
 }: BuildPreviewColumnsArgs<RowType>): BuildPreviewColumnsResult<RowType> {
     const columnsMap = new Map(columns.map((column) => [column.id, column]))
-    // Online evaluations use auto metrics, human evaluations use human metrics
-    const metricsForType =
-        evaluationType === "auto" || evaluationType === "online"
-            ? staticMetricColumns.auto
-            : staticMetricColumns.human
+    // Auto, live, and SDK evaluations use auto metrics; human evaluations use human metrics.
+    const metricsForType = selectStaticMetricColumnsForEvaluationType(
+        staticMetricColumns,
+        evaluationType,
+    )
 
     const defaultSkeleton = () => (
         <div className="h-3 w-full rounded bg-neutral-200 animate-pulse" />

--- a/web/oss/src/components/EvalRunDetails/utils/buildSkeletonColumns.ts
+++ b/web/oss/src/components/EvalRunDetails/utils/buildSkeletonColumns.ts
@@ -1,3 +1,5 @@
+import type {EvaluationRunKind} from "@/oss/lib/evaluations/utils/evaluationKind"
+
 import type {
     EvaluationColumnKind,
     EvaluationTableColumn,
@@ -91,7 +93,7 @@ const createSkeletonGroupColumns = (
 }
 
 export const buildSkeletonColumnResult = (
-    evaluationType: "auto" | "human" | "online",
+    evaluationType: EvaluationRunKind,
 ): EvaluationTableColumnsResult => {
     const metaColumns = createMetaSkeletonColumns({
         includeTimestamp: evaluationType === "online",

--- a/web/oss/src/components/EvalRunDetails/utils/evaluationMetricColumns.test.ts
+++ b/web/oss/src/components/EvalRunDetails/utils/evaluationMetricColumns.test.ts
@@ -1,0 +1,41 @@
+import assert from "node:assert/strict"
+import {describe, it} from "node:test"
+
+import {selectStaticMetricColumnsForEvaluationType} from "./evaluationMetricColumns.ts"
+
+const metricColumns = {
+    auto: [
+        {
+            name: "auto metric",
+            kind: "metric" as const,
+            path: "metrics.auto",
+            stepKey: "auto",
+            metricType: "number",
+        },
+    ],
+    human: [
+        {
+            name: "human metric",
+            kind: "metric" as const,
+            path: "metrics.human",
+            stepKey: "human",
+            metricType: "number",
+        },
+    ],
+}
+
+describe("selectStaticMetricColumnsForEvaluationType", () => {
+    it("uses auto metrics for SDK/custom evaluations", () => {
+        assert.deepEqual(
+            selectStaticMetricColumnsForEvaluationType(metricColumns, "custom"),
+            metricColumns.auto,
+        )
+    })
+
+    it("uses human metrics only for human evaluations", () => {
+        assert.deepEqual(
+            selectStaticMetricColumnsForEvaluationType(metricColumns, "human"),
+            metricColumns.human,
+        )
+    })
+})

--- a/web/oss/src/components/EvalRunDetails/utils/evaluationMetricColumns.ts
+++ b/web/oss/src/components/EvalRunDetails/utils/evaluationMetricColumns.ts
@@ -1,0 +1,19 @@
+import type {MetricColumnDefinition} from "@agenta/entities/workflow"
+
+import type {EvaluationRunKind} from "@/oss/lib/evaluations/utils/evaluationKind"
+
+interface StaticMetricColumns {
+    auto: MetricColumnDefinition[]
+    human: MetricColumnDefinition[]
+}
+
+export const usesHumanMetricColumns = (evaluationType: EvaluationRunKind) =>
+    evaluationType === "human"
+
+export const usesAutoMetricColumns = (evaluationType: EvaluationRunKind) =>
+    !usesHumanMetricColumns(evaluationType)
+
+export const selectStaticMetricColumnsForEvaluationType = (
+    staticMetricColumns: StaticMetricColumns,
+    evaluationType: EvaluationRunKind,
+) => (usesHumanMetricColumns(evaluationType) ? staticMetricColumns.human : staticMetricColumns.auto)


### PR DESCRIPTION
## Summary
This is a follow-up to #4552 after the maintainer requested the repository template and visual proof.

This PR fixes the SDK/custom eval run details breadcrumb for #4549.

SDK eval result pages could fall back to the `Auto Evals` breadcrumb because the eval run details route normalized or omitted the `custom` run kind. The change preserves the shared evaluation run kind through the details page, maps `custom` to `SDK Evals`, and keeps SDK/custom runs on the non-human metric-column path while preserving human eval behavior.

Fixes #4549

## Testing

### Verified locally
- `npx --yes pnpm@11.1.2 exec tsx --tsconfig oss/tsconfig.json --test oss/src/components/EvalRunDetails/utils/evaluationMetricColumns.test.ts` - passed, 2 tests, 0 failures.
- `npx --yes pnpm@11.1.2 --filter @agenta/oss lint` - passed with Node 26 vs expected Node 24 and Next lint deprecation warnings.
- `npx --yes pnpm@11.1.2 exec prettier --check <changed files>` - passed during QA.
- `git diff --check origin/main...HEAD` - passed.

### Added or updated tests
- Added `oss/src/components/EvalRunDetails/utils/evaluationMetricColumns.test.ts` covering metric-column selection for SDK/custom and human evals.

### QA follow-up
- QA approved the branch as ready after branch, diff, identity, focused test, lint, and formatting checks.
- Full `npx --yes pnpm@11.1.2 --filter @agenta/oss types:check` still exits 1 on existing repository baseline diagnostics in this environment; no remaining focused diagnostic was tied to the SDK/custom metric helper path.

## Demo
- Local component-level proof GIF: https://gist.githubusercontent.com/Rajesh270712/bd10c47fd502a981c5db77d199963f91/raw/agenta-pr-4552-sdk-eval-breadcrumb-proof.gif

This proof shows the patched SDK/custom breadcrumb rendering as `SDK Evals` and linking back with `kind=custom`. It is local component-level proof because seeded local auth/API data was unavailable for a full product-session recording.

## Checklist
- [x] I have included a video or screen recording for UI changes, or marked Demo as N/A
- [x] Relevant tests pass locally
- [x] Relevant linting and formatting pass locally
- [x] I have signed the CLA, or I will sign it when the bot prompts me
