### PR TITLE
ci: exempt private org members from PR contribution check

### DIFF
--- a/.github/workflows/13-check-pr-contribution.yml
+++ b/.github/workflows/13-check-pr-contribution.yml
@@ -51,6 +51,19 @@ jobs:
             const LABEL = 'incomplete-pr';
             const INTERNAL = ['OWNER', 'MEMBER', 'COLLABORATOR'];
 
+            // author_association reports MEMBER only for *public* org members. Private
+            // members fall back to CONTRIBUTOR because this workflow's GITHUB_TOKEN
+            // cannot see private membership, so list internal handles explicitly here.
+            // Add a handle whenever a teammate with private org membership joins.
+            const ALLOWLIST = [
+              'mmabrouk',
+              'jp-agenta',
+              'ardaerzin',
+              'ashrafchowdury',
+              'bekossy',
+              'junaway',
+            ].map((h) => h.toLowerCase());
+
             // Files that are non-functional. A PR touching only these may skip the demo.
             const EXEMPT = [
               /(^|\/)tests?\//i,
@@ -100,8 +113,13 @@ jobs:
               return;
             }
 
-            // Exempt internal contributors (org members) and bots.
-            if (!forceExternal && (pr.user.type === 'Bot' || INTERNAL.includes(pr.author_association))) {
+            // Exempt internal contributors and bots. Check both the GitHub-reported
+            // association (covers public org members) and the explicit allowlist
+            // (covers private org members the token cannot see as MEMBER).
+            const isInternal =
+              INTERNAL.includes(pr.author_association) ||
+              ALLOWLIST.includes(pr.user.login.toLowerCase());
+            if (!forceExternal && (pr.user.type === 'Bot' || isInternal)) {
               core.info(`PR #${number} by ${pr.user.login} (${pr.author_association}) is internal, skipping.`);
               return;
             }


### PR DESCRIPTION
## Summary
Follow-up to #4579. While testing that bot in dry-run against real PRs, it flagged a PR by `ashrafchowdury` (a core team member) as external and would have closed it.

Root cause: `author_association` only reports `MEMBER` for **public** org members. Arda, Ashraf, and other teammates have **private** org membership, which this workflow's `GITHUB_TOKEN` cannot see, so it received `CONTRIBUTOR` and treated them as external.

Fix: add an explicit allowlist of internal GitHub handles, checked alongside `author_association`. Public members stay auto-covered by the association; private-member teammates are covered by the allowlist. A comment explains why the list exists and when to add to it.

The workflow is currently **disabled on `main`** (I disabled it after finding this). Re-enable it once this merges.

## Testing
### Verified locally
- YAML parses.
- `git diff origin/main` shows only the allowlist delta.
- The four dry-run cases from #4579 are unaffected (template + demo detection unchanged). I will re-run the dispatch matrix after this merges, including a member PR with `force_external=false` to confirm the exemption now skips it.

### Added or updated tests
N/A. CI workflow.

### QA follow-up
After merge: re-enable the workflow, then dispatch `13 - check PR contribution` (`dry_run=true`) against a member's PR to confirm `internal, skipping`, and against an external non-compliant PR to confirm it still flags.

## Demo
N/A. Touches only `.github/**`.

## Checklist
- [x] I have included a video or screen recording for UI changes, or marked Demo as N/A
- [x] Relevant tests pass locally
- [x] Relevant linting and formatting pass locally
- [x] I have signed the CLA, or I will sign it when the bot prompts me
