### PR TITLE
fix(api): split PydanticAI agent span messages at the latest user turn

### DIFF
--- a/api/oss/src/apis/fastapi/otlp/extractors/adapters/logfire_adapter.py
+++ b/api/oss/src/apis/fastapi/otlp/extractors/adapters/logfire_adapter.py
@@ -103,6 +103,48 @@ def _normalize_pydantic_messages(messages: list) -> list:
     return normalized
 
 
+def _split_agent_messages(
+    normalized: List[Dict[str, Any]],
+) -> Tuple[List[Dict[str, Any]], List[Dict[str, Any]]]:
+    """Split an agent run's conversation into (input prompt, output completion).
+
+    An agent run span carries the *whole* conversation in
+    ``pydantic_ai.all_messages`` — prior turns plus everything this run produced.
+    The split point is the agent's latest ``user`` message: everything up to and
+    including it is the input (prior turns + the question that triggered the run),
+    and the trailing assistant/tool messages are this run's output.
+
+    We deliberately do not split by role. Assistant, user, and tool messages
+    interleave across turns, so a role filter scatters the conversation and loses
+    which turn produced what (it would route every prior assistant reply into the
+    output and every prior user/tool message into the input).
+
+    ``pydantic_ai.new_message_index`` is intentionally not used: it indexes
+    PydanticAI's internal request/response messages, which do not line up with
+    this flattened, per-role message list (a single request bundling the system
+    prompt and the user prompt expands to two entries here, and a request
+    bundling parallel tool results expands to several).
+
+    Tool results normalize to ``role == "tool"``, so they never count as the
+    user boundary.
+    """
+    last_user_idx = next(
+        (
+            i
+            for i in range(len(normalized) - 1, -1, -1)
+            if isinstance(normalized[i], dict) and normalized[i].get("role") == "user"
+        ),
+        None,
+    )
+
+    if last_user_idx is None:
+        # No user turn (e.g. a tool-only or system-only run): treat the whole
+        # conversation as output and let the caller fall back to final_result.
+        return [], normalized
+
+    return normalized[: last_user_idx + 1], normalized[last_user_idx + 1 :]
+
+
 GENAI_SEMCONV_ATTRIBUTES_EXACT: List[Tuple[str, str]] = [
     # Core Data
     ("gen_ai.request.model", "ag.meta.request.model"),
@@ -335,16 +377,7 @@ class LogfireAdapter(BaseAdapter):
             if isinstance(all_messages, list):
                 normalized = _normalize_pydantic_messages(all_messages)
                 if normalized:
-                    input_msgs = [
-                        m
-                        for m in normalized
-                        if isinstance(m, dict) and m.get("role") != "assistant"
-                    ]
-                    output_msgs = [
-                        m
-                        for m in normalized
-                        if isinstance(m, dict) and m.get("role") == "assistant"
-                    ]
+                    input_msgs, output_msgs = _split_agent_messages(normalized)
                     if input_msgs:
                         features.data["inputs"] = {"prompt": input_msgs}
                     if output_msgs:

--- a/api/oss/tests/pytest/unit/otlp/test_logfire_adapter.py
+++ b/api/oss/tests/pytest/unit/otlp/test_logfire_adapter.py
@@ -343,7 +343,15 @@ class TestAgentSpanData:
         assert features.data["outputs"]["completion"] == "Some response"
         assert "inputs" not in features.data
 
-    def test_agent_extracts_last_assistant_as_output(self, adapter):
+    def test_agent_splits_at_latest_user_turn(self, adapter):
+        """A multi-turn conversation splits at the *latest* user message.
+
+        Everything up to and including the last user turn is the input (prior
+        turns + the question that triggered this run); the trailing assistant
+        message is the output. The split must preserve conversation order — it
+        must NOT scatter every assistant reply into the output and every user
+        message into the input.
+        """
         all_messages = [
             {"role": "user", "parts": [{"type": "text", "content": "hello"}]},
             {"role": "assistant", "parts": [{"type": "text", "content": "first"}]},
@@ -362,12 +370,97 @@ class TestAgentSpanData:
 
         assert features.data["inputs"]["prompt"] == [
             {"role": "user", "content": "hello"},
+            {"role": "assistant", "content": "first"},
             {"role": "user", "content": "again"},
         ]
         assert features.data["outputs"]["completion"] == [
-            {"role": "assistant", "content": "first"},
             {"role": "assistant", "content": "second"},
         ]
+
+    def test_agent_run_with_tool_calls_keeps_full_turn_as_output(self, adapter):
+        """The output of a run is its whole trailing turn: tool calls + answer.
+
+        Mirrors a real PydanticAI ``agent run`` span where the latest user
+        message kicks off a tool-calling loop. Everything after that user
+        message (assistant tool calls, tool results, and the final answer) is
+        the output; everything up to and including it is the input.
+        """
+        all_messages = [
+            {"role": "system", "parts": [{"type": "text", "content": "You help."}]},
+            {"role": "user", "parts": [{"type": "text", "content": "hi"}]},
+            {"role": "assistant", "parts": [{"type": "text", "content": "Hello!"}]},
+            {"role": "user", "parts": [{"type": "text", "content": "find me a room"}]},
+            {
+                "role": "assistant",
+                "parts": [
+                    {
+                        "type": "tool_call",
+                        "id": "call_1",
+                        "name": "search",
+                        "arguments": {"q": "room"},
+                    }
+                ],
+            },
+            {
+                "role": "user",
+                "parts": [
+                    {
+                        "type": "tool_call_response",
+                        "id": "call_1",
+                        "name": "search",
+                        "result": [{"room": "STD"}],
+                    }
+                ],
+            },
+            {
+                "role": "assistant",
+                "parts": [{"type": "text", "content": "Found a Standard room."}],
+                "finish_reason": "stop",
+            },
+        ]
+        bag = _make_bag(
+            {
+                "gen_ai.operation.name": "invoke_agent",
+                "pydantic_ai.all_messages": dumps(all_messages),
+                "final_result": "Found a Standard room.",
+                "agent_name": "agent",
+            }
+        )
+        features = SpanFeatures()
+        adapter.process(bag, features)
+
+        prompt = features.data["inputs"]["prompt"]
+        assert [m["role"] for m in prompt] == ["system", "user", "assistant", "user"]
+        assert prompt[-1]["content"] == "find me a room"
+
+        completion = features.data["outputs"]["completion"]
+        # tool-call assistant message, the normalized tool result, final answer
+        assert [m["role"] for m in completion] == ["assistant", "tool", "assistant"]
+        assert completion[0]["tool_calls"][0]["function"]["name"] == "search"
+        assert completion[-1]["content"] == "Found a Standard room."
+
+    def test_agent_run_ending_on_user_falls_back_to_final_result(self, adapter):
+        """If nothing trails the last user turn, output falls back to final_result."""
+        all_messages = [
+            {"role": "system", "parts": [{"type": "text", "content": "You help."}]},
+            {"role": "user", "parts": [{"type": "text", "content": "anything there?"}]},
+        ]
+        bag = _make_bag(
+            {
+                "gen_ai.operation.name": "invoke_agent",
+                "pydantic_ai.all_messages": dumps(all_messages),
+                "final_result": "Yes.",
+                "agent_name": "agent",
+            }
+        )
+        features = SpanFeatures()
+        adapter.process(bag, features)
+
+        assert [m["role"] for m in features.data["inputs"]["prompt"]] == [
+            "system",
+            "user",
+        ]
+        assert features.data["outputs"]["completion"] == "Yes."
 
     def test_agent_with_unknown_message_format_falls_back(self, adapter):
         """Messages that don't match {role, parts} format are stored raw."""
@@ -808,17 +901,20 @@ class TestRealisticSpans:
         features = SpanFeatures()
         adapter.process(bag, features)
 
+        # The run was triggered by "I wanted to know your name"; the input is the
+        # conversation up to and including it (prior turn intact), and the output
+        # is only the answer to it — not every assistant message in the history.
         assert features.data["inputs"]["prompt"] == [
             {"role": "system", "content": "You are the concierge agent..."},
             {"role": "user", "content": "hi"},
-            {"role": "user", "content": "I wanted to know your name"},
-        ]
-        assert features.data["outputs"]["completion"] == [
             {
                 "role": "assistant",
                 "content": "Hello, Sarah! How can I assist you today?",
                 "finish_reason": "stop",
             },
+            {"role": "user", "content": "I wanted to know your name"},
+        ]
+        assert features.data["outputs"]["completion"] == [
             {
                 "role": "assistant",
                 "content": "I'm your concierge agent here at The Agenta Grand Hotel.",


### PR DESCRIPTION
## Problem

A PydanticAI agent-run span carries the whole conversation in `pydantic_ai.all_messages`: prior turns plus everything this run produced. The Logfire OTLP adapter split that conversation into inputs and outputs **by role**: every `assistant` message became output, everything else became input.

Across a multi-turn run that scrambles the trace. Prior assistant replies get routed into this run's output, and prior user and tool messages get routed into its input. The trace's inputs and outputs no longer reflect what the run actually received and produced.

## Fix

Split at the agent's **latest `user` message** instead:

- Input: everything up to and including the last user message (prior turns plus the question that triggered this run).
- Output: the trailing assistant and tool messages this run produced.

Details:

- Tool results normalize to `role == "tool"`, so they never count as the user boundary.
- A run with no user turn (tool-only or system-only) falls back to treating the whole conversation as output, so the caller can use `final_result`.
- `pydantic_ai.new_message_index` is intentionally not used: it indexes PydanticAI's internal request/response messages, which do not line up with this flattened, per-role message list.

## Before / after

Before: a two-turn run shows the first turn's answer mixed into the second turn's input, and vice versa.
After: each run's input is the conversation up to its question, and its output is only what that run generated.

## Tests

Adds unit tests in `test_logfire_adapter.py`:

- `test_agent_splits_at_latest_user_turn`
- `test_agent_run_with_tool_calls_keeps_full_turn_as_output`
- `test_agent_run_ending_on_user_falls_back_to_final_result`

All green (`pytest oss/tests/pytest/unit/otlp/test_logfire_adapter.py`).

## Scope

Follow-up to #4357 (`[AGE-3763]` PydanticAI v2+ Logfire span mapping). Touches only the Logfire adapter and its test.