### PR TITLE
fix(railway): re-create preview project when a stale link fails

### DIFF
--- a/hosting/railway/oss/scripts/bootstrap.sh
+++ b/hosting/railway/oss/scripts/bootstrap.sh
@@ -72,9 +72,24 @@ ensure_project_linked() {
             | head -n 1 || true)"
     fi
 
-    if [ -n "$existing_project" ]; then
-        railway_call link --project "$PROJECT_NAME" --json >/dev/null
-    else
+    if [ -z "$existing_project" ]; then
+        railway_call init --name "$PROJECT_NAME" --json >/dev/null
+        return
+    fi
+
+    # `project list` and `link --project` can disagree. `project list`
+    # enumerates projects across every workspace the token can see and can lag
+    # behind a just-deleted project, while `link --project` only resolves
+    # within the single workspace it selects. So a project the list still
+    # reports as existing may not actually be linkable — most visibly right
+    # after a preview is destroyed (PR converted to draft) and then rebuilt (PR
+    # marked ready for review). Treat a link failure as "needs to be
+    # (re)created" and fall back to init, instead of aborting the whole setup.
+    local link_status=0
+    railway_call link --project "$PROJECT_NAME" --json >/dev/null || link_status=$?
+    if [ "$link_status" -ne 0 ]; then
+        printf "railway link could not resolve existing project '%s'; recreating it.\n" \
+            "$PROJECT_NAME" >&2
         railway_call init --name "$PROJECT_NAME" --json >/dev/null
     fi
 }


### PR DESCRIPTION
## What

When a PR preview is destroyed and later rebuilt, the **setup** job aborted instead of bringing the preview back. Seen on [PR #4341's run](https://github.com/Agenta-AI/agenta/actions/runs/27152091229/job/80145742111):

```
> Select a workspace Agenta
Project "agenta-oss-pr-4341" not found in workspace "Agenta".
Available: agenta-oss-pr-4586, agenta-oss-pr-4583, ...
[railway][FAIL] command failed (exit 1)
    at ensure_project_linked (hosting/railway/oss/scripts/bootstrap.sh:76)
```

## Why it happens

This is the destroy → draft → ready lifecycle: `45-railway-cleanup` destroys the project on `converted_to_draft`, and `14-check-pr-preview` rebuilds it on `ready_for_review`.

In `ensure_project_linked`, `railway project list` still reported the deleted project (it enumerates projects across every workspace and lags behind a just-deleted one), so the function took the `link` branch. `railway link --project` then failed because the project no longer exists in the workspace it resolves. The list and `link` disagree, and the script hard-failed the whole setup job rather than recovering.

## The fix

Treat a `link` failure on a "listed" project as needs-recreate: fall back to `railway init` so the preview comes back.

- **Before:** list says project exists → `link` → fails → setup job dies.
- **After:** list says project exists → `link` → if it fails, `init` (re-create) → setup continues.

The happy path is unchanged: when `link` succeeds, no extra `init` runs. A genuinely missing project still goes straight to `init` as before.

## Testing

Unit-tested the three branches of `ensure_project_linked` with a mocked `railway_call`:

- listed + link OK → `link` only (no duplicate `init`)
- listed + link fails → `link` then `init` (the fix)
- not listed → `init` only

`bash -n` passes.