### PR TITLE
[#4592] fix(frontend): deployment "Last modified" shows the deployed revision date

### DIFF
--- a/web/packages/agenta-entities/src/environment/state/appDeployments.ts
+++ b/web/packages/agenta-entities/src/environment/state/appDeployments.ts
@@ -10,6 +10,7 @@ import {atom, getDefaultStore} from "jotai"
 import {selectAtom} from "jotai/utils"
 import {atomFamily} from "jotai-family"
 
+import type {Workflow} from "../../workflow/core"
 import {workflowMolecule} from "../../workflow/state/molecule"
 import {workflowVariantsListDataAtomFamily} from "../../workflow/state/store"
 import type {Environment, Reference} from "../core"
@@ -76,7 +77,38 @@ function extractAppDeployment(env: Environment, appId: string): AppDeploymentInf
     return null
 }
 
-function toAppEnvironmentDeployment(env: Environment, appId: string): AppEnvironmentDeployment {
+/**
+ * Resolve the "last modified" date shown for a deployment.
+ *
+ * Prefers the deployed revision's own date, then falls back to the environment record's
+ * timestamp only when no revision date is available.
+ *
+ * On the revision side, `created_at` is preferred over `updated_at`: a revision is an
+ * immutable commit whose `created_at` is the commit/deploy moment, and the backend leaves
+ * `updated_at` NULL on commit. On the fallback side, the environment's
+ * `updated_at`/`created_at` track the environment artifact and do not change when a new
+ * revision is deployed, so they are a misleading "last modified" and used only as a last
+ * resort.
+ */
+export function resolveDeploymentLastModified(
+    revision: Pick<Workflow, "created_at" | "updated_at"> | null | undefined,
+    env: Pick<Environment, "updated_at" | "created_at">,
+): string | null {
+    return revision?.created_at ?? revision?.updated_at ?? env.updated_at ?? env.created_at ?? null
+}
+
+/**
+ * Build the flat deployment shape for one environment.
+ *
+ * `revisionData` is the deployed revision's workflow entity, resolved reactively by the
+ * caller (see {@link appEnvironmentsQueryAtomFamily}). It is the raw revision query data,
+ * used to backfill incomplete reference data and to source the deployment's date.
+ */
+function toAppEnvironmentDeployment(
+    env: Environment,
+    appId: string,
+    revisionData: Workflow | null,
+): AppEnvironmentDeployment {
     const dep = extractAppDeployment(env, appId)
     const appSlug = dep?.application?.slug
 
@@ -84,25 +116,19 @@ function toAppEnvironmentDeployment(env: Environment, appId: string): AppEnviron
     let revision = dep?.applicationRevision?.version ?? null
 
     // Fallback: resolve from workflow entity stores when reference data is incomplete
-    // (handles deployments made before slug/version were populated in references)
-    if ((!variantName || !revision) && dep?.applicationRevision?.id) {
-        const revisionId = dep.applicationRevision.id
-        const store = getDefaultStore()
-        const workflowData = workflowMolecule.get.data(revisionId)
-        if (workflowData) {
-            if (!revision && workflowData.version != null) {
-                revision = String(workflowData.version)
-            }
-            if (!variantName) {
-                const variantId = dep?.applicationVariant?.id
-                const workflowId = workflowData.workflow_id || appId
-                const variants = workflowId
-                    ? store.get(workflowVariantsListDataAtomFamily(workflowId))
-                    : []
-                const variantEntity = variants.find((v) => v.id === variantId)
-                variantName =
-                    variantEntity?.name || variantEntity?.slug || workflowData.slug || null
-            }
+    // (handles deployments made before slug/version were populated in references).
+    if ((!variantName || !revision) && revisionData) {
+        if (!revision && revisionData.version != null) {
+            revision = String(revisionData.version)
+        }
+        if (!variantName) {
+            const variantId = dep?.applicationVariant?.id
+            const workflowId = revisionData.workflow_id || appId
+            const variants = workflowId
+                ? getDefaultStore().get(workflowVariantsListDataAtomFamily(workflowId))
+                : []
+            const variantEntity = variants.find((v) => v.id === variantId)
+            variantName = variantEntity?.name || variantEntity?.slug || revisionData.slug || null
         }
     }
 
@@ -113,7 +139,9 @@ function toAppEnvironmentDeployment(env: Environment, appId: string): AppEnviron
         deployedVariantId: dep?.applicationVariant?.id ?? null,
         deployedRevisionId: dep?.applicationRevision?.id ?? null,
         revision,
-        updatedAt: env.updated_at ?? env.created_at ?? null,
+        // "Last modified" reflects the deployed revision's commit date, not the environment
+        // record's own timestamp (see resolveDeploymentLastModified for the rationale).
+        updatedAt: resolveDeploymentLastModified(revisionData, env),
     }
 }
 
@@ -150,7 +178,17 @@ export const appEnvironmentsQueryAtomFamily = atomFamily((appId: string) =>
 
         const environments = listQuery.data?.environments ?? []
         const data = appId
-            ? environments.map((env) => toAppEnvironmentDeployment(env, appId))
+            ? environments.map((env) => {
+                  // Reactively resolve the deployed revision's entity so the deployment's
+                  // "last modified" date (and any reference backfill) re-derives when it
+                  // loads, instead of reading a stale imperative snapshot.
+                  const revisionId =
+                      extractAppDeployment(env, appId)?.applicationRevision?.id ?? null
+                  const revisionData = revisionId
+                      ? (get(workflowMolecule.atoms.query(revisionId)).data ?? null)
+                      : null
+                  return toAppEnvironmentDeployment(env, appId, revisionData)
+              })
             : ([] as AppEnvironmentDeployment[])
 
         return {

--- a/web/packages/agenta-entities/tests/unit/app-deployments.test.ts
+++ b/web/packages/agenta-entities/tests/unit/app-deployments.test.ts
@@ -1,0 +1,53 @@
+/**
+ * Unit tests for the deployment "last modified" date resolution.
+ *
+ * Regression guard for the bug where the Deployment card showed the environment record's
+ * own timestamp (which never changes on deploy) instead of the deployed revision's date.
+ *
+ * The helper encodes the precedence
+ * revision.created_at > revision.updated_at > env.updated_at > env.created_at. A revision
+ * is an immutable commit whose `created_at` is the commit/deploy moment, so it wins over
+ * both the revision's own `updated_at` (NULL on commit) and the env artifact's timestamps.
+ */
+
+import {describe, it, expect} from "vitest"
+
+import {resolveDeploymentLastModified} from "../../src/environment/state/appDeployments"
+
+describe("resolveDeploymentLastModified", () => {
+    it("uses the deployed revision's commit date over the environment timestamp", () => {
+        const env = {created_at: "2025-08-18T06:16:49Z", updated_at: "2025-08-18T06:16:49Z"}
+        const revision = {created_at: "2025-08-25T13:16:00Z", updated_at: null}
+        expect(resolveDeploymentLastModified(revision, env)).toBe("2025-08-25T13:16:00Z")
+    })
+
+    it("prefers the revision's created_at over its updated_at", () => {
+        const env = {created_at: "2025-08-18T06:16:49Z", updated_at: "2025-08-18T06:16:49Z"}
+        const revision = {created_at: "2025-08-25T13:16:00Z", updated_at: "2025-08-30T09:00:00Z"}
+        expect(resolveDeploymentLastModified(revision, env)).toBe("2025-08-25T13:16:00Z")
+    })
+
+    it("falls back to the revision's updated_at when created_at is missing", () => {
+        const env = {created_at: "2025-08-18T06:16:49Z", updated_at: "2025-08-18T06:16:49Z"}
+        const revision = {created_at: null, updated_at: "2025-08-30T09:00:00Z"}
+        expect(resolveDeploymentLastModified(revision, env)).toBe("2025-08-30T09:00:00Z")
+    })
+
+    it("falls back to env.updated_at when the revision is unavailable", () => {
+        const env = {created_at: "2025-08-18T06:16:49Z", updated_at: "2025-09-01T10:00:00Z"}
+        expect(resolveDeploymentLastModified(null, env)).toBe("2025-09-01T10:00:00Z")
+        expect(resolveDeploymentLastModified(undefined, env)).toBe("2025-09-01T10:00:00Z")
+        expect(resolveDeploymentLastModified({created_at: null, updated_at: null}, env)).toBe(
+            "2025-09-01T10:00:00Z",
+        )
+    })
+
+    it("falls back to env.created_at when revision date and env.updated_at are missing", () => {
+        const env = {created_at: "2025-08-18T06:16:49Z", updated_at: null}
+        expect(resolveDeploymentLastModified(null, env)).toBe("2025-08-18T06:16:49Z")
+    })
+
+    it("returns null when no date is available", () => {
+        expect(resolveDeploymentLastModified(null, {created_at: null, updated_at: null})).toBeNull()
+    })
+})


### PR DESCRIPTION
## What was wrong

On the prompt **Overview → Deployment** card, **Last modified** showed the wrong date, usually far in the past, so you could not tell when a prompt was actually deployed. A project whose environments were all created on one day showed that same creation date for every environment's deployment, no matter when each revision was actually deployed.

## Cause

The date came from the environment record's own timestamp:

```ts
updatedAt: env.updated_at ?? env.created_at ?? null
```

A simple-environment's `updated_at`/`created_at` track the environment artifact. They do not change when a new revision is deployed, so the displayed date was unrelated to the deploy (usually the environment's creation date).

## Fix

`appEnvironmentsQueryAtomFamily` now resolves the deployed revision **reactively** from the raw revision query (`workflowMolecule.atoms.query(revisionId).data`, the same source the Registry "Created on" column uses) and "Last modified" uses that revision's commit date.

Precedence (in `resolveDeploymentLastModified`): `revision.created_at` → `revision.updated_at` → `env.updated_at` → `env.created_at`.

Two details that matter:
- We read the **raw revision query**, not `workflowMolecule.get.data()`. The latter returns a merged server+draft object whose `created_at` is the artifact's creation date, not the revision's commit date.
- The read is reactive (`get(...)` inside the derived atom), so the date re-derives when the revision loads instead of reading a stale imperative snapshot.

## Before / After

| | Before | After |
|---|---|---|
| Deployment card "Last modified" | environment record timestamp (wrong, static) | deployed revision's commit date |

## Verification

- Unit test for the precedence (`resolveDeploymentLastModified`), 6 cases.
- `tsc --noEmit` and `eslint` clean on the changed files.
- Verified live: the card shows the deployed revision's date, stable across reloads, with no regression to the environment status dot.

Scope: `@agenta/entities` only (two files).

Closes #4592
