### PR TITLE
docs(docs): add Playground evaluation workbench changelog entry

### DIFF
--- a/docs/blog/announcement-assets/playground-evaluation-workbench.md
+++ b/docs/blog/announcement-assets/playground-evaluation-workbench.md
@@ -1,0 +1,52 @@
+# Playground Evaluation Workbench Announcement Copy
+
+Changelog: https://agenta.ai/docs/changelog/playground-evaluation-workbench
+
+Video: https://youtu.be/VGYOH1k15rE
+
+## LinkedIn
+
+We rebuilt the Agenta Playground from scratch. It is now the main workspace for your AI applications.
+
+Two major additions came with it.
+
+You can attach evaluators to the Playground and score outputs as you edit. Change the prompt, run again, and the scores update next to each output.
+
+You can also load test sets into the Playground. This lets you work on your evals and add test cases directly from the Playground.
+
+Watch the video: https://youtu.be/VGYOH1k15rE
+
+Read the changelog: https://agenta.ai/docs/changelog/playground-evaluation-workbench
+
+## X / Twitter
+
+### Single Post
+
+We rebuilt the Agenta Playground from scratch. It is now the main workspace for your AI apps.
+
+Attach evaluators to score outputs as you edit, and load test sets to work on your evals and add test cases without leaving the Playground.
+
+https://agenta.ai/docs/changelog/playground-evaluation-workbench
+
+### Thread
+
+1/ We rebuilt the Agenta Playground from scratch. It is now the main workspace for your AI applications.
+
+2/ You can attach evaluators to the Playground and score outputs as you edit. Change the prompt, run again, and the scores update.
+
+3/ You can also load test sets. Work on your evals and add test cases directly from the Playground.
+
+https://agenta.ai/docs/changelog/playground-evaluation-workbench
+
+## Slack
+
+We rebuilt the Playground from scratch. It is now the main workspace for your AI applications.
+
+Two things you can do now:
+
+- Attach evaluators to score outputs as you edit.
+- Load test sets to work on your evals and add test cases directly from the Playground.
+
+Changelog: https://agenta.ai/docs/changelog/playground-evaluation-workbench
+
+Video: https://youtu.be/VGYOH1k15rE

--- a/docs/blog/entries/playground-evaluation-workbench.mdx
+++ b/docs/blog/entries/playground-evaluation-workbench.mdx
@@ -1,0 +1,62 @@
+---
+title: "Evaluate While You Iterate in the Playground"
+slug: playground-evaluation-workbench
+date: 2026-06-09
+tags: [v0.103.0]
+description: "Attach evaluators to Playground sessions, see scores inline, and use connected test sets to keep prompt iteration and data curation in one loop."
+---
+
+<div style={{display: "flex", justifyContent: "center", marginTop: "20px", marginBottom: "20px", flexDirection: "column", alignItems: "center"}}>
+  <iframe
+    width="100%"
+    height="500"
+    src="https://www.youtube.com/embed/VGYOH1k15rE"
+    title="Evaluate While You Iterate in the Playground"
+    frameBorder="0"
+    allow="accelerometer; autoplay; clipboard-write; encrypted-media; gyroscope; picture-in-picture; web-share"
+    allowFullScreen
+  ></iframe>
+</div>
+
+## The workflow this is for
+
+Improving an LLM app is an evaluation loop. You run the prompt, see where it fails, adjust the prompt or evaluator, and run it again against the examples that matter.
+
+That loop used to be split across surfaces. The Playground is where you iterated on prompts, while evaluations and test set curation happened elsewhere.
+
+The Playground is now an evaluation workbench. You can attach evaluators to a Playground session, see evaluator results next to each output, and keep test data connected while you debug.
+
+## What changed
+
+### Inline evaluators
+
+You can now attach evaluators directly in the Playground. When you run a prompt, evaluator results appear inline next to the generated output, so you can see whether a change improved the answer while the prompt is still in front of you.
+
+This is different from starting a full evaluation run. The evaluation button creates a persisted evaluation run over a test set. Inline evaluators are playground-scoped. They are for fast feedback while you are editing.
+
+### Connected test sets
+
+You can load a test set into the Playground in connected mode. Rows stay tied to the source test set, so edits you make while debugging can be synced back instead of copied by hand.
+
+Local mode is still available when you want scratch examples. Connected mode is for the cases where your iteration should improve the dataset you already use for evaluation.
+
+## The loop
+
+1. Open a prompt in the Playground.
+2. Load a connected test set or add local examples.
+3. Attach one or more evaluators.
+4. Run the prompt and inspect the inline scores.
+5. Edit the prompt, evaluator, or examples.
+6. Run again until the output and the score line up.
+
+This keeps prompt changes, evaluator feedback, and test data curation in one place.
+
+## Why it matters
+
+Teams usually lose time moving between prompt editing, evaluation setup, and data cleanup. That makes it harder to understand whether a failure came from the prompt, the evaluator, or the examples.
+
+Inline evaluators and connected test sets make that feedback loop shorter. Subject matter experts can stay in the Playground, inspect failures, adjust the data, and rerun the same cases without switching context.
+
+## Getting started
+
+Open the Playground, load a test set, and attach an evaluator from the evaluator control. Run the prompt to see evaluator results next to each output.

--- a/docs/blog/main.mdx
+++ b/docs/blog/main.mdx
@@ -10,6 +10,34 @@ import Image from "@theme/IdealImage";
 
 <section class="changelog">
 
+### [Evaluate While You Iterate in the Playground](/changelog/playground-evaluation-workbench)
+
+_9 June 2026_
+
+**v0.103.0**
+
+<div style={{display: "flex", justifyContent: "center", marginTop: "20px", marginBottom: "20px", flexDirection: "column", alignItems: "center"}}>
+  <iframe
+    width="100%"
+    height="420"
+    src="https://www.youtube.com/embed/VGYOH1k15rE"
+    title="Evaluate While You Iterate in the Playground"
+    frameBorder="0"
+    allow="accelerometer; autoplay; clipboard-write; encrypted-media; gyroscope; picture-in-picture; web-share"
+    allowFullScreen
+  ></iframe>
+</div>
+
+We have rebuilt the playground from scratch to be the main workspace for your AI applications. 
+
+We have added two major features:
+
+1. You can attach evaluators to the playground to score outputs as you edit.
+
+2. You can load test sets. This allows you to work on your evals and add test cases directly from the playground.
+
+---
+
 ### [Annotation Queues](/changelog/annotation-queues)
 
 _18 May 2026_


### PR DESCRIPTION
Adds the changelog entry for the Playground rebuild shipped in v0.103.0: you can attach evaluators to score outputs as you edit, and load test sets to work on evals and add test cases from the Playground.

## What's in here

- `docs/blog/main.mdx` — summary entry on the changelog index, with the launch video embedded (https://youtu.be/VGYOH1k15rE).
- `docs/blog/entries/playground-evaluation-workbench.mdx` — the full changelog entry, with the same video and version tag `v0.103.0`.
- `docs/blog/announcement-assets/playground-evaluation-workbench.md` — LinkedIn, X, and Slack copy for the announcement (not published from the docs build; reference copy for the launch).

## Notes

- Version is `v0.103.0` across both the summary and the entry. The earlier draft carried `v0.96.0`, which had already been used by the April Unified Invoke API entry; corrected to match the current release.
- The sidebar announcement card (`SidebarBanners/data/changelog.json`) and the roadmap update are not included here. Say the word and I'll add them in a follow-up.