### PR TITLE
fix(frontend): pass prompt-referenced testset columns to playground evaluators

### DIFF
--- a/web/packages/agenta-entities/src/runnable/index.ts
+++ b/web/packages/agenta-entities/src/runnable/index.ts
@@ -135,6 +135,7 @@ export {
     extractVariablesFromConfig,
     extractSectionOpenersFromConfig,
     extractVariablesFromEnhancedPrompts,
+    resolveTemplateFormat,
     syncPromptInputKeysInParameters,
 } from "./utils"
 export type {ExecuteRunnableOptions} from "./utils"

--- a/web/packages/agenta-playground/src/state/helpers/entityInputContract.ts
+++ b/web/packages/agenta-playground/src/state/helpers/entityInputContract.ts
@@ -17,6 +17,12 @@
  * build the request `variables`, so filtering against it is guaranteed
  * consistent with what actually gets sent.
  */
+import {
+    extractSectionOpenersFromConfig,
+    extractVariablesFromConfig,
+    groupTemplateVariables,
+    resolveTemplateFormat,
+} from "@agenta/entities/runnable"
 import {workflowMolecule} from "@agenta/entities/workflow"
 import type {Getter} from "jotai"
 
@@ -186,16 +192,23 @@ export function reconcileRowDataForEntity(
 }
 
 /**
- * Collect testcase column names that downstream evaluator nodes reference via
- * their `<input>_key` settings (e.g. `correct_answer_key → ground_truth`).
+ * Collect testcase column names that downstream evaluator nodes consume.
+ *
+ * An evaluator pulls a testcase column in two ways, and the primary app's
+ * strict row clean must protect both (pass the result as
+ * `reconcileRowDataForEntity`'s `protectedKeys`):
+ *
+ *  1. A `<input>_key` setting whose value names the column (e.g.
+ *     `correct_answer_key → ground_truth`). Mirrors the `<key>_key` resolution
+ *     in `buildEvaluatorExecutionInputs` (`@agenta/entities/runnable`): a string
+ *     value naming a column, optionally prefixed `testcase.`.
+ *  2. A template variable in the evaluator's own prompt — an LLM-as-a-judge
+ *     referencing `{{guidelines.rubric}}` consumes the `guidelines` column. The
+ *     primary app never declares it, so without this the strict clean drops it
+ *     from the shared row before the evaluator runs (#4525 regression).
  *
  * These columns are intentional evaluation inputs the primary app doesn't
- * declare, so a strict row clean against the app contract must protect them
- * (pass the result as `reconcileRowDataForEntity`'s `protectedKeys`).
- *
- * Mirrors the `<key>_key` resolution in `buildEvaluatorExecutionInputs`
- * (`@agenta/entities/runnable`): a setting named `<input>_key` whose string
- * value names a column, optionally prefixed `testcase.`.
+ * declare, so a strict clean against the app contract must keep them.
  */
 export function collectDownstreamReferencedColumns(
     get: Getter,
@@ -209,12 +222,88 @@ export function collectDownstreamReferencedColumns(
             | null
             | undefined
         if (!settings || typeof settings !== "object") continue
+
+        // 1. `<input>_key` settings that map a column by name.
         for (const [key, value] of Object.entries(settings)) {
             if (!key.endsWith("_key")) continue
             if (typeof value !== "string" || value.length === 0) continue
             const column = value.startsWith("testcase.") ? value.split(".")[1] : value
             if (column) columns.add(column)
         }
+
+        // 2. Columns the evaluator's own prompt references as template
+        //    variables. Evaluators surface the `{inputs, outputs}` envelope as
+        //    their input ports, so these prompt references never appear in
+        //    `inputPorts` — we extract them here directly from the config.
+        for (const column of collectPromptInputColumns(settings)) {
+            columns.add(column)
+        }
     }
+    return columns
+}
+
+/**
+ * Evaluator input names that are injected at runtime, never sourced from a
+ * testcase column: `prediction`/`outputs` carry the upstream output, `inputs` is
+ * the whole testcase object, and `messages` is chat transport. A prompt
+ * referencing one of these must not protect a same-named row key from the
+ * reconcile clean — `buildEvaluatorExecutionInputs` supplies them at run time,
+ * and protecting `messages` would defeat the chat-transport strip (#4525).
+ */
+const RESERVED_EVALUATOR_INPUT_KEYS = new Set<string>([
+    "prediction",
+    "outputs",
+    "inputs",
+    ...CHAT_TRANSPORT_KEYS,
+])
+
+/**
+ * Memoizes the prompt parse per config object. `configuration(entityId)` returns
+ * a stable reference across the rows of a run (it only changes when the config
+ * is edited), so this keeps the per-row reconcile from re-parsing every
+ * evaluator prompt on every row.
+ */
+const promptInputColumnsCache = new WeakMap<Record<string, unknown>, string[]>()
+
+/**
+ * Extract the testcase input columns an entity's prompt references as template
+ * variables. Mirrors the input-port derivation in the workflow molecule: pull
+ * every template variable from the config, group them, and keep the `inputs`-
+ * envelope keys that name a real testcase column. Runtime-resolved references
+ * (`{{$.outputs.score}}`, plus the reserved names above) are excluded.
+ *
+ * Template format defaults to `curly` when unset, matching both
+ * `extractVariablesFromConfig` (which extracts each prompt with a curly default)
+ * and the evaluator picker's curly fallback for legacy judges. So a curly dotted
+ * reference like `{{guidelines.rubric}}` groups to the literal column
+ * `guidelines.rubric` (the backend curly resolver's literal-key lookup) instead
+ * of being mis-split to `guidelines`.
+ */
+function collectPromptInputColumns(config: Record<string, unknown>): string[] {
+    const cached = promptInputColumnsCache.get(config)
+    if (cached) return cached
+
+    const vars = extractVariablesFromConfig(config)
+    const sectionOpeners = extractSectionOpenersFromConfig(config)
+    const promptObj = config.prompt as Record<string, unknown> | undefined
+    const rawTemplateFormat =
+        (promptObj?.template_format as string | undefined) ??
+        (config.template_format as string | undefined)
+    const templateFormat = resolveTemplateFormat(rawTemplateFormat) ?? "curly"
+
+    const columns =
+        vars.length === 0
+            ? []
+            : groupTemplateVariables(vars, {sectionOpeners, templateFormat})
+                  .filter((group) => group.envelope === "inputs")
+                  .map((group) => group.key)
+                  .filter(
+                      (key): key is string =>
+                          typeof key === "string" &&
+                          key.length > 0 &&
+                          !RESERVED_EVALUATOR_INPUT_KEYS.has(key),
+                  )
+
+    promptInputColumnsCache.set(config, columns)
     return columns
 }

--- a/web/packages/agenta-playground/tests/unit/entityInputContract.test.ts
+++ b/web/packages/agenta-playground/tests/unit/entityInputContract.test.ts
@@ -1,0 +1,162 @@
+/**
+ * Unit tests for `collectDownstreamReferencedColumns`.
+ *
+ * Regression (#4525): the primary app's strict row clean dropped a testcase
+ * column an LLM-as-a-judge referenced only through its prompt template (e.g.
+ * `{{guidelines.rubric}}`), because the protected-column collector looked only
+ * at `<input>_key` settings. The evaluator then ran without `guidelines`.
+ *
+ * The config source (the workflow molecule) is mocked so the test stays a pure
+ * function check. The template-variable extraction is the real implementation.
+ */
+import {describe, expect, it, vi} from "vitest"
+
+// `configuration(entityId)` returns a token the fake getter resolves to a
+// config. This avoids standing up a jotai store with a hydrated workflow.
+vi.mock("@agenta/entities/workflow", () => ({
+    workflowMolecule: {
+        selectors: {
+            configuration: (entityId: string) => ({__configFor: entityId}),
+        },
+    },
+}))
+
+import {collectDownstreamReferencedColumns} from "../../src/state/helpers/entityInputContract"
+
+interface TestNode {
+    depth: number
+    entityId: string
+}
+
+function makeGet(configByEntity: Record<string, Record<string, unknown> | null>) {
+    return ((token: unknown) => {
+        const entityId = (token as {__configFor?: string} | null)?.__configFor
+        return entityId ? (configByEntity[entityId] ?? null) : null
+    }) as Parameters<typeof collectDownstreamReferencedColumns>[0]
+}
+
+/**
+ * An LLM-as-a-judge config in the nested shape `nestEvaluatorConfiguration`
+ * produces: the prompt lives under `prompt.messages` with its own
+ * `template_format`.
+ */
+function llmJudgeConfig(
+    promptText: string,
+    extra: Record<string, unknown> = {},
+    templateFormat = "mustache",
+): Record<string, unknown> {
+    return {
+        prompt: {
+            messages: [{role: "user", content: promptText}],
+            template_format: templateFormat,
+            llm_config: {model: "gpt-4o"},
+        },
+        feedback_config: {type: "json_schema"},
+        ...extra,
+    }
+}
+
+describe("collectDownstreamReferencedColumns", () => {
+    it("protects a column the evaluator references only through its prompt", () => {
+        const nodes: TestNode[] = [
+            {depth: 0, entityId: "app"},
+            {depth: 1, entityId: "judge"},
+        ]
+        const get = makeGet({
+            judge: llmJudgeConfig("Score the answer using {{guidelines.rubric}}."),
+        })
+
+        const columns = collectDownstreamReferencedColumns(get, nodes)
+
+        // Root column, not the dotted path — the testcase column is `guidelines`.
+        expect(columns.has("guidelines")).toBe(true)
+        expect(columns.has("guidelines.rubric")).toBe(false)
+    })
+
+    it("still protects columns mapped through `<input>_key` settings", () => {
+        const nodes: TestNode[] = [{depth: 1, entityId: "judge"}]
+        const get = makeGet({
+            judge: llmJudgeConfig("Compare to the reference.", {
+                correct_answer_key: "ground_truth",
+            }),
+        })
+
+        const columns = collectDownstreamReferencedColumns(get, nodes)
+
+        expect(columns.has("ground_truth")).toBe(true)
+    })
+
+    it("strips the `testcase.` prefix on `<input>_key` values", () => {
+        const nodes: TestNode[] = [{depth: 1, entityId: "judge"}]
+        const get = makeGet({
+            judge: llmJudgeConfig("Compare to the reference.", {
+                correct_answer_key: "testcase.expected",
+            }),
+        })
+
+        const columns = collectDownstreamReferencedColumns(get, nodes)
+
+        expect(columns.has("expected")).toBe(true)
+    })
+
+    it("collects both prompt-referenced and `_key`-mapped columns together", () => {
+        const nodes: TestNode[] = [{depth: 1, entityId: "judge"}]
+        const get = makeGet({
+            judge: llmJudgeConfig("Use {{guidelines.rubric}} and {{context}}.", {
+                correct_answer_key: "ground_truth",
+            }),
+        })
+
+        const columns = collectDownstreamReferencedColumns(get, nodes)
+
+        expect([...columns].sort()).toEqual(["context", "ground_truth", "guidelines"])
+    })
+
+    it("does not protect runtime-injected reserved names", () => {
+        const nodes: TestNode[] = [{depth: 1, entityId: "judge"}]
+        const get = makeGet({
+            judge: llmJudgeConfig(
+                "Judge {{prediction}} vs {{outputs}}, given {{inputs}} and {{messages}}.",
+            ),
+        })
+
+        const columns = collectDownstreamReferencedColumns(get, nodes)
+
+        // prediction/outputs are the upstream output, inputs is the testcase
+        // object, messages is chat transport — none is a testcase column.
+        expect(columns.size).toBe(0)
+    })
+
+    it("keeps a curly dotted reference as the literal column name", () => {
+        const nodes: TestNode[] = [{depth: 1, entityId: "judge"}]
+        const get = makeGet({
+            // Legacy curly judge: `{{guidelines.rubric}}` names a literal column.
+            judge: llmJudgeConfig("Score with {{guidelines.rubric}}.", {}, "curly"),
+        })
+
+        const columns = collectDownstreamReferencedColumns(get, nodes)
+
+        expect(columns.has("guidelines.rubric")).toBe(true)
+        expect(columns.has("guidelines")).toBe(false)
+    })
+
+    it("ignores the depth-0 primary node", () => {
+        const nodes: TestNode[] = [{depth: 0, entityId: "app"}]
+        const get = makeGet({
+            app: llmJudgeConfig("{{guidelines.rubric}}"),
+        })
+
+        const columns = collectDownstreamReferencedColumns(get, nodes)
+
+        expect(columns.size).toBe(0)
+    })
+
+    it("returns an empty set when a node has no config", () => {
+        const nodes: TestNode[] = [{depth: 1, entityId: "judge"}]
+        const get = makeGet({judge: null})
+
+        const columns = collectDownstreamReferencedColumns(get, nodes)
+
+        expect(columns.size).toBe(0)
+    })
+})


### PR DESCRIPTION
## Context

In the LLM-as-a-judge playground: load a testset with columns `input`, `context`,
`guidelines`; use a prompt that references only `{{input}}` and `{{context}}`; add an
evaluator whose prompt references `{{guidelines.rubric}}`. On Run, the prompt invoke
correctly includes `input` and `context`, but the evaluator invoke is missing
`guidelines`.

Root cause: before each run the shared testset row is reconciled against the **primary
app's** input contract (#4525, shipped in v0.102.0). The reconcile drops every column the
primary app doesn't declare, keeping only the columns a downstream evaluator maps through
an `<input>_key` setting. A column an evaluator references **only in its prompt**
(`{{guidelines.rubric}}`) was not in that protected list, so it was stripped from the
shared row before the evaluator ran. This worked in v0.100 / v0.101.

## Changes

`collectDownstreamReferencedColumns` now also collects the testset columns each downstream
evaluator references in its own prompt, not just the ones mapped through `<input>_key`
settings.

Before, the protected set came only from `<input>_key` settings:

```
correct_answer_key: "ground_truth"       -> protects "ground_truth"
prompt: "...{{guidelines.rubric}}..."    -> nothing (guidelines dropped)
```

After, prompt-referenced input columns are protected too:

```
prompt: "...{{guidelines.rubric}}..."    -> protects "guidelines"
```

A new `collectPromptInputColumns` helper reuses the same extraction the workflow molecule
uses to derive an app's input ports (`extractVariablesFromConfig` + `groupTemplateVariables`,
keeping only `inputs`-envelope keys). It also:

- excludes reserved runtime names (`prediction`, `outputs`, `inputs`, `messages`) that the
  evaluator machinery injects and that are not testset columns, so a bare `{{prediction}}`
  or `{{messages}}` never re-protects chat transport the #4525 strip removes,
- defaults the template format to `curly` to match how variables are extracted, so a legacy
  curly judge's `{{a.b}}` maps to the literal column `a.b` instead of being mis-split,
- memoizes the parse per config object, since the reconcile runs once per row.

`resolveTemplateFormat` is re-exported from `@agenta/entities/runnable` for the helper.

## Tests / notes

- New unit test `entityInputContract.test.ts` (8 cases): prompt-only column protected,
  `<input>_key` still protected, `testcase.` prefix stripped, reserved names excluded,
  curly dotted column kept literally, both sources combined, depth-0 primary ignored,
  missing config safe.
- Full `@agenta/playground` unit suite green (63). `@agenta/playground` and
  `@agenta/entities` typecheck and lint clean.
- Frontend-only. No backend or API change.
