### PR TITLE
feat(frontend): decouple playground chat behavior from the app is_chat flag

### DIFF
--- a/docs/design/playground-mode-switch/README.md
+++ b/docs/design/playground-mode-switch/README.md
@@ -1,0 +1,39 @@
+# Playground mode switch (chat ⇄ completion)
+
+Working docs for letting users switch a chat app's playground between chat
+mode (multi-turn conversation) and completion mode (single-turn, N test
+cases) at runtime, without losing data in either direction.
+
+Design source: the handoff bundle at `design_handoff_playground_mode_switch/`
+in the repo root (open `Mode Switch Exploration.html` for the boards; its
+`README.md` is the visual spec). Where this plan deviates from the handoff,
+[context.md](context.md) records the deviation and the reason.
+
+## Files
+
+| File | Purpose |
+|---|---|
+| [context.md](context.md) | What we build and why, scope decisions, product rules (the invariants) |
+| [research.md](research.md) | Codebase map: mode derivation and its consumers, the chat working copy and its adapter, sync state, reusable UI |
+| [plan.md](plan.md) | The PR stack with tasks and test strategy |
+| [status.md](status.md) | Progress, decisions, next steps. Read this first in a new session |
+
+## TL;DR
+
+- `is_chat` does two jobs today: it says the app accepts a messages input
+  (a capability) and it picks the playground UI (a behavior). We split
+  them. The behavior becomes a playground-level override atom, persisted
+  per app, never versioned. Scope: chat apps only, so every run stays an
+  ordinary chat request and the backend never changes.
+- The conversation already lives in the test case row's `messages` column;
+  a bidirectional adapter keeps it in sync with the chat UI in real time.
+  We reuse that column as the frozen history. No new `history` column.
+- Chat → completion: move the last assistant reply from `messages` into
+  the row's result slot; runs then regenerate that reply per row.
+  Completion → chat: `messages` plus the latest result become the
+  conversation again (picker when several rows are loaded; tabs come in a
+  later PR).
+- A sync gate blocks switching while test cases have unsynced changes
+  (with a quiet "Switch without syncing" escape hatch). The toggle is
+  disabled in compare mode and stays behind a flag until both directions
+  work (end of PR3).

--- a/docs/design/playground-mode-switch/context.md
+++ b/docs/design/playground-mode-switch/context.md
@@ -1,0 +1,113 @@
+# Context
+
+## Background
+
+The playground ships two separate surfaces today:
+
+- **Chat playground**: multi-turn. One loaded conversation. Each Run appends
+  an assistant turn. Hard-gated to a single test case row.
+- **Completion playground**: single turn. N test cases loaded from a test
+  set. Each Run regenerates one output per row.
+
+Which surface you get is decided by the app, not the user. The workflow
+entity's `flags.is_chat` flag (with a schema fallback) picks the surface.
+That flag does two jobs at once: it states a capability (this app accepts a
+messages input) and it dictates a behavior (render the chat playground).
+Users cannot run a chat app against a table of test cases without recreating
+the app.
+
+## What we build
+
+One playground, one toggle. A segmented `Chat | Completion` control in the
+generations panel header switches the playground of a **chat app** between
+the two behaviors:
+
+- **Chat → Completion**: the conversation freezes into the test case row.
+  The last assistant reply moves out of the row's `messages` column and into
+  the row's output slot. Each Run then regenerates only that final reply.
+  The user can load and run multiple test cases.
+- **Completion → Chat**: a test case's `messages` column plus its latest
+  output become the conversation again. The user picks one test case when
+  several are loaded; the rest stay in the test set.
+
+Capability and behavior become two separate pieces of state. The capability
+stays derived from the app. The behavior is a playground-level override that
+defaults to the capability and is never committed or versioned.
+
+## Scope decisions
+
+1. **Chat apps only.** The toggle appears only when the app is
+   chat-capable. A chat app in completion mode still sends ordinary chat
+   requests (history in, one reply out), so the feature needs no backend
+   changes. Giving completion apps a chat mode would require backend
+   support for conversations and is a separate feature.
+2. **Reuse the `messages` column.** The handoff design froze the
+   conversation into a new `history` column. The conversation already lives
+   in the row's `messages` column, kept in sync by an existing
+   bidirectional adapter (research.md, section 3). We reuse it. Banner and
+   dialog copy say `messages` instead of `history`.
+3. **Picker before tabs.** Chat stays single-conversation for now.
+   Switching completion → chat with several rows asks the user to pick one.
+   Test-case tabs (handoff board 3C) remain the end state and land in the
+   last PR, after the chat working copy is re-keyed per row. The handoff
+   rejected pickers as the end state; we use one only as staging.
+4. **Sync gate keeps the escape hatch.** The gate's footer keeps the quiet,
+   left-aligned red "Switch without syncing" text button next to Cancel and
+   the primary "Sync & switch".
+5. **Compare mode disables the toggle.** In comparison view (more than one
+   variant displayed) the segmented control is disabled with a tooltip.
+   This avoids inventing a "focused variant" concept for deciding whose
+   replies freeze into the row.
+6. **Toggle hidden until both directions work.** The control ships behind a
+   flag in PR2 and becomes visible at the end of PR3, together with the
+   sync gate.
+
+## Product rules (the contract)
+
+From the design's state-mapping table and edge-case matrix, adjusted for the
+`messages` column decision. These are the invariants the implementation must
+keep:
+
+- The prompt template (system message + `{{vars}}`) belongs to the variant.
+  It never moves between modes and is never written into the row's
+  `messages` column.
+- Round-trip with no edits is identity: no duplicated system message, no
+  lost turns.
+- A switch never deletes data. Everything is recoverable from the test set.
+- Run metadata (latency, cost, trace links) on turns that freeze into the
+  row is dropped. The `messages` column is plain editable data.
+- Only the **latest** output becomes a turn on completion → chat. Earlier
+  runs stay in run history / observability.
+- Mode is playground/local state. It is not part of the variant config and
+  is never committed or versioned.
+
+## Goals
+
+- Switch modes in place, instantly after dialogs, no page reload.
+- Both directions reversible and lossless (via the sync gate).
+- Completion mode for chat apps: N test cases, each with its own frozen
+  conversation, runs that regenerate one reply per row.
+- The switch transform is pure and unit-tested.
+- No backend or API changes.
+
+## Non-goals
+
+- No chat mode for completion apps (needs backend work; separate feature).
+- No multi-conversation chat until the final PR (tabs and the per-row
+  re-keying that enables them).
+- No change to how apps declare `is_chat`. The flag stays the default mode.
+- No per-variant mode. One global control.
+- No redesign of existing message cards, variable cards, output cards, Run
+  buttons, or modals. The new chrome (segmented control, dialogs, banner,
+  later the tab strip) is the only new UI.
+- No new animations beyond existing conventions. An optional 0.2s opacity
+  crossfade on the generations body is acceptable.
+
+## Design fidelity note
+
+The handoff mocks follow the Agenta design system, but the production
+playground defines the canonical styling for message cards, variable cards,
+and outputs. Where mock and app disagree on those, the app wins. The new
+chrome must match the spec precisely (exact paddings, colors, and copy are
+in the handoff README, sections "Screens / Views" and "Design Tokens"),
+except where the scope decisions above change the copy.

--- a/docs/design/playground-mode-switch/plan.md
+++ b/docs/design/playground-mode-switch/plan.md
@@ -1,0 +1,144 @@
+# Plan
+
+Four stacked PRs. Each lands green on its own. Nothing is user-visible until
+the end of PR3, when both switch directions and the sync gate work together.
+File references and gaps: see [research.md](research.md). Scope decisions and
+their reasons: see [context.md](context.md), "V1 scope decisions".
+
+## PR1: split capability from behavior
+
+Goal: `is_chat` stops doing two jobs. Zero visible change.
+
+1. Add a mode override atom in `@agenta/playground` state:
+   `"chat" | "completion" | null` (null = follow the app's capability).
+   Persist per app via `atomWithStorage` (key `agenta:playground:mode`, one
+   record keyed by app id, derived scoped atom; web/CLAUDE.md pattern).
+   Only meaningful when the app is chat-capable; ignore it otherwise.
+2. Rewire `isChatModeAtom` and `appTypeAtom`
+   (`agenta-playground/src/state/execution/selectors.ts:1106-1125`) to
+   return `override ?? capability`. Leave `executionModeAtomFamily`
+   (entities layer) untouched.
+3. Audit every consumer in the research table (section 2). Confirm each one
+   reads mode through the rewired selectors rather than through
+   `workflowMolecule.selectors.executionMode` directly. `buildRequestBody`
+   takes mode as a parameter, so trace each caller.
+4. Reset rule: clear the override when the app changes or when the stored
+   value equals the capability default.
+
+Tests: unit test the effective-mode selector (`tests/unit/`). Manual smoke
+of both app types with the override forced from devtools.
+
+## PR2: chat → completion (behind a flag)
+
+Goal: a chat app runs as a completion playground over the same rows.
+
+1. **Switch transform** (pure, unit-tested, in `@agenta/playground`
+   helpers): given the working copy, write the frozen conversation to the
+   row's `messages` column and surface the last assistant reply as the
+   row's latest run result. Strip run metadata; never include the variant's
+   template system message. Write the reverse transform here too
+   (conversation = `messages` + latest result) so round-trip identity tests
+   exist from day one, even though PR3 wires it.
+2. **Verify the system-message rule** (research risk 2): confirm the
+   working copy and serializer exclude the variant's template system
+   message. Fix if not.
+3. **Load path**: keep the `messages` field when loading test sets in
+   completion mode for chat apps (`MESSAGE_FIELD_KEYS` filter in
+   `loadTestsetNormalizedMutation.ts`).
+4. **Messages column card**: render the row's `messages` column inside the
+   completion generation rows as an editable conversation card. Compose
+   from `ChatMessageList` + `TypeChip` (drill-in `MessagesField` precedent).
+5. **Run semantics**: per-row runs pass the row's `messages` as the
+   explicit `runParams.chatHistory` (`executionItems.ts:640`); the reply
+   lands in the run result slot, not the column. Run all covers every row.
+   Multiple loaded test cases work (the single-row gates apply only when
+   the behavior mode is chat).
+6. **Chrome**: `ModeSwitcher` segmented control in `@agenta/playground-ui`
+   (Ant `Segmented`, Phosphor `ChatCircle` / `Rows`, specs in the handoff
+   README section 1; precedent `ThemeSwitcher.tsx`). It replaces the
+   `ExecutionHeader` title; collapse-all relocates to an icon-only quiet
+   button with tooltip "Collapse all test cases". Behind a feature flag.
+7. **Dialogs**: confirm dialog (`EnhancedModal`, width 480, "Switch to
+   Completion?", two lines, Cancel / Switch). Skip it when the chat has
+   zero turns. Post-switch dismissible info banner; copy references the
+   `messages` column.
+8. Compare mode: the toggle renders disabled in comparison view, with a
+   tooltip ("Switching modes is available outside compare view"). Decided;
+   no "focused variant" concept gets built.
+
+Deliverable: with the flag on, the section 2 storyboard works end to end
+for a single variant, with copy adjusted for `messages`.
+
+## PR3: completion → chat, sync gate, expose the toggle
+
+Goal: the way back, made safe, then shipped.
+
+1. **Reverse switch**: the chosen row's `messages` plus its latest run
+   result become the conversation (latest output only; earlier runs stay in
+   observability). A variables-only row opens an empty conversation with
+   its columns loaded. The existing extract path
+   (`extractAndLoadChatMessages`) does most of the work.
+2. **Picker**: when several rows are loaded, a dialog asks which one to
+   load as the conversation. Default to the last-run or last-edited row.
+   The others stay in the test set. (Tabs replace this in PR4.)
+3. **Sync gate** (both directions, shown before any other dialog):
+   `EnhancedModal`, width 500, warning icon, "Sync your test cases first".
+   Body lists the actual unsynced case names and the connected test set
+   name (`meaningfulLocalRows`, per-row `testcaseMolecule.isDirty`,
+   `connectedSource`). Footer: left-aligned quiet red text button "Switch
+   without syncing" (the escape hatch stays; decided), spacer, Cancel,
+   primary "Sync & switch" (`commitChanges`, then proceed). When no test
+   set is connected, the primary becomes "Save as test set" with a name
+   input (`setName` + `saveAsNewTestset`), reusing the TestsetDropdown
+   save-new config where possible.
+4. **Expose the toggle**: remove the flag once both directions and the gate
+   pass QA.
+5. Align the TestsetDropdown `"chat-replace"` behavior with the new
+   reality where useful; do not expand its scope.
+
+Deliverable: boards 3 (with picker instead of tabs) and 4.1 work; switching
+with dirty rows always routes through the gate; round trips are identity.
+
+## PR4 (later): per-row conversations and tabs
+
+Goal: the design's end state. Chat holds N conversations, one visible.
+
+1. Spike first: re-key the chat working copy from `loadableId` to
+   `(loadableId, rowId)`, or add a conversation-id indirection. Check run,
+   streaming, compare-mode sessions, and Clear. Fix the write-back fan-out
+   (`syncChatMessagesToEntity.ts:125-131`) to target one row.
+2. Tab strip above the variable cards (handoff section 2 specs): active tab
+   = existing testcase chip style; `+` creates and activates an empty test
+   case; hidden with one test case; overflow past ~6 tabs into a "+N more"
+   dropdown.
+3. Run appends to the active conversation only; Run all runs each loaded
+   conversation's next turn.
+4. Delete the PR3 picker. Remove the chat single-row gates
+   (`playgroundController.ts:567-568, 616-631, 651-653`,
+   `webWorkerIntegration.ts:317-319`).
+5. This also gives chat-native apps multiple conversations, independent of
+   mode switching.
+
+## Edge cases to test (from the handoff matrix, board 4.3)
+
+- Empty chat or no output yet: skip the confirm dialog; a typed-but-unrun
+  user turn still freezes into the row; the output slot starts empty.
+- No system message duplication on any round trip.
+- Edited `messages` after a switch is the conversation now; trace links on
+  edited turns are dropped (the column is plain data).
+- Only the latest output becomes a turn when switching back.
+- Compare mode: the toggle is disabled in comparison view and re-enables
+  when the view drops back to one variant.
+
+## QA
+
+1. Unit: switch transforms (round-trip identity, metadata stripping,
+   system-message exclusion), effective-mode selector, sync-gate row
+   listing.
+2. E2E (Playwright, see docs/designs/testing): chat → completion → run →
+   edit `messages` → switch back; completion → chat with three rows through
+   the picker; sync gate on both paths (sync, and switch-without-syncing).
+3. Manual pass against the design boards for the new chrome.
+4. `pnpm lint-fix` in `web/`; package builds for `@agenta/playground` and
+   `@agenta/playground-ui`.
+5. Changelog entry when the toggle becomes visible (end of PR3).

--- a/docs/design/playground-mode-switch/research.md
+++ b/docs/design/playground-mode-switch/research.md
@@ -1,0 +1,228 @@
+# Research
+
+Codebase findings as of 2026-06-10 (branch `gitbutler/workspace`). All paths
+relative to repo root. Line numbers are approximate and will drift.
+
+## 1. Where mode comes from today
+
+Mode is derived from the workflow entity, per workflow, in the entities
+layer:
+
+- `web/packages/agenta-entities/src/workflow/state/runnableSetup.ts:185-203`
+  `executionModeAtomFamily(workflowId)` returns `"chat" | "completion"`.
+  It checks `entity.flags?.is_chat` first, then falls back to the input
+  schema having `properties.messages`.
+
+The playground reads it through two selectors:
+
+- `web/packages/agenta-playground/src/state/execution/selectors.ts:1106-1125`
+  `isChatModeAtom` reads the **primary node** (first depth-0 node in
+  `playgroundNodesAtom`) and returns `boolean | undefined`.
+  `appTypeAtom` maps that to `"chat" | "completion" | undefined`.
+
+This is the seam for the feature. Today one value means both "the app
+accepts a messages input" (capability) and "use chat behavior" (behavior).
+An override atom consulted inside `isChatModeAtom` and `appTypeAtom` splits
+the two: capability stays in `executionModeAtomFamily` (untouched, still
+used by other surfaces), behavior becomes `override ?? capability`.
+
+## 2. Every consumer of the mode (must respect the override)
+
+| Code path | Location | What it does |
+|---|---|---|
+| UI branch chat vs completion | `web/packages/agenta-playground-ui/src/components/ExecutionItems/index.tsx:31-86` | `PlaygroundGenerations` renders `<ChatMode/>` or `<CompletionMode/>` |
+| Request body | `web/packages/agenta-playground/src/state/execution/executionItems.ts:1018-1121` | `buildRequestBody(mode, ...)`: completion sends `inputRow`, chat sends `chatHistory` |
+| Per-run history source | `executionItems.ts:638-666` | chat builds `chatHistory` from `runParams.chatHistory` **if provided**, else from the message atoms. The explicit parameter is the hook for per-row history in completion mode |
+| Input dedup | `executionItems.ts:621-626` | chat deletes `messages` from input variables so the payload never duplicates the conversation |
+| Worker run shaping | `web/packages/agenta-playground/src/state/execution/webWorkerIntegration.ts:233-271, 317-319` | reads `isChatModeAtom`, clears previous responses, gates chat to the first display row |
+| Testcase load gate | `web/packages/agenta-playground/src/state/controllers/playgroundController.ts:567-568, 616-631` | chat slices loaded test cases to one (`.slice(0, 1)`) |
+| Keep-drafts fallback | `playgroundController.ts:651-653` | `connectToTestsetKeepingLocalRows` falls back to plain connect in chat mode |
+| Message extraction on load | `playgroundController.ts:590-596` → `helpers/extractAndLoadChatMessages.ts` | populates the chat working copy from a row's `messages` column |
+| Variable filtering | `selectors.ts:325-345` | chat hides `messages` and `outputs` keys from variable cards |
+| Testset loading | `helpers/loadTestsetNormalizedMutation.ts:24-90` | completion strips message-like fields from rows (`MESSAGE_FIELD_KEYS` at lines 10-18 includes `messages`); chat loads one row and extracts history. Completion mode for a chat app must keep `messages` |
+| Header label | `web/packages/agenta-playground-ui/src/components/ExecutionHeader/index.tsx:117-151` | panel title is "Chat" or "Generations" |
+| Compare output | `web/packages/agenta-playground-ui/src/components/ExecutionItemComparisonView/index.tsx:10-47` | chat vs completion comparison renderers |
+| TestsetDropdown variant | `web/oss/src/components/Playground/Components/TestsetDropdown/index.tsx:126, 298-299` | chat gets `"chat-replace"` connect behavior |
+
+Audit result (PR1, 2026-06-10): every behavior consumer reads
+`isChatModeAtom` directly or via `executionController.selectors.isChatMode`
+(`executionController.ts:205`), so rewiring that one atom covers them all.
+Two reads intentionally stay on the capability, because request shapes
+follow what the app accepts, not the UI behavior:
+
+- `entityInputContract.ts:82` (input contract: variables + `messages`).
+- `executionItems.ts:539-542` (request mode for `buildRequestBody`).
+
+PR2 note: with completion behavior on a chat app, the worker dispatch
+(`webWorkerIntegration.ts:233`, behavior-driven) and `executionItems.ts:540`
+(capability-driven) will disagree. PR2 reconciles them: per-row execution
+items that send chat-shaped requests with an explicit `runParams.chatHistory`
+from the row's `messages` column.
+
+A second, unrelated `executionModeAtomFamily` exists in the playground
+package (`execution/atoms.ts:76`, keyed by loadableId): it is execution-state
+machinery set from session mode (`reducer.ts:85`), which originates from the
+behavior-driven worker dispatch. Do not confuse the two.
+
+## 3. Chat state model: a working copy with a bidirectional adapter
+
+The test case row is the canonical store in **both** modes. Chat keeps a
+working copy of the conversation in separate atoms, and an adapter keeps the
+two in sync in real time:
+
+- **Working copy**:
+  `web/packages/agenta-playground/src/state/chat/messageAtoms.ts:22-85`
+  flat message list keyed by **loadableId** (one per playground):
+  `messageIdsAtomFamily`, `messagesByIdAtomFamily`,
+  `orderedMessagesAtomFamily`.
+  `chat/messageTypes.ts:40-156`: `ChatMessage` extends the OpenAI shape with
+  `sessionId` (per-variant session; user/system messages use
+  `SHARED_SESSION_ID`) and `parentId` (threading). Turns are derived at
+  render time.
+- **Read direction (row → working copy)**:
+  `helpers/extractAndLoadChatMessages.ts` parses the row's `messages` column
+  into the atoms when a test case loads.
+- **Write direction (working copy → row)**:
+  `helpers/syncChatMessagesToEntity.ts` serializes the conversation and
+  writes it to the row via `testcaseMolecule.actions.update(rowId, {data:
+  {messages}})`. The message reducer calls it after every mutation (add,
+  update, remove, truncate): `chat/messageReducer.ts:88, 130, 151, 192`.
+  Its header states the intent: "This follows the same real-time pattern
+  that completion mode uses."
+
+Serialization rules (`syncChatMessagesToEntity.ts:32-105`): strip internal
+metadata (`sessionId`, `parentId`, `id`); include all shared user/system
+messages; for per-variant replies, keep only the first (canonical) session;
+skip the trailing blank input placeholder.
+
+Why the working copy exists at all (a plain `messages` array cannot express
+these): per-variant sessions in compare mode (one conversation, N assistant
+replies per turn), streaming and run status, and threading.
+
+Two structural limits, relevant later:
+
+- The working copy is keyed per playground, not per row. Multi-conversation
+  chat (tabs) needs re-keying to `(loadableId, rowId)` or equivalent.
+- The write-back loops over **all** display rows and writes the same
+  conversation to each (`syncChatMessagesToEntity.ts:125-131`). Correct
+  today only because chat holds one row.
+
+## 4. Test cases, sync state, and save actions
+
+The loadable layer already has everything the sync gate needs:
+
+- Mode (connected vs local): `loadableController.selectors.mode(loadableId)`;
+  connected test set: `loadableController.selectors.connectedSource(loadableId)`
+  returns `{id, name}`.
+- Unsynced detection:
+  `loadableController.selectors.hasLocalChanges(loadableId)`;
+  `meaningfulLocalRowsAtomFamily(loadableId)`
+  (`web/packages/agenta-entities/src/loadable/controller.ts:510-537`) lists
+  rows with real user data, filtering blank/seeded rows;
+  per-row dirty: `testcaseMolecule.isDirty(rowId)`
+  (`web/packages/agenta-entities/src/testcase/state/molecule.ts:179-182`).
+  New rows are prefixed `new-` / `local-`.
+- Save actions: `loadableController.actions.commitChanges(loadableId, msg)`
+  (`loadable/controller.ts:1148-1238`) and
+  `loadableController.actions.saveAsNewTestset(loadableId, {...})`
+  (needs `setName` first). After commit, rows reconnect with server ids.
+- Existing UI to reuse: `TestsetDropdown`
+  (`web/oss/src/components/Playground/Components/TestsetDropdown/index.tsx:84-349`,
+  wires all four actions, has `EntityCommitModal` from `@agenta/entity-ui`),
+  `KeepDraftRowsModal`, `TestsetDisconnectConfirmModal` (both under
+  `web/oss/src/components/Playground/Components/Modals/`).
+- Sync badge: `PlaygroundSyncStateTag` in
+  `web/oss/src/components/Playground/Playground.tsx:29-53`.
+
+## 5. Messages-column UI building blocks
+
+Completion mode for a chat app must render the row's `messages` column as an
+editable conversation card. What exists:
+
+- **Editable**: `ChatMessageList` from `@agenta/ui/chat-message`. Already
+  used for config system messages in chat mode and by the drill-in messages
+  form: `web/packages/agenta-ui/src/drill-in/FieldRenderers/MessagesField.tsx`
+  (renders `ChatMessageList`, supports edit and stringify-back).
+  `TestcaseDataEditor`
+  (`web/packages/agenta-entity-ui/src/testcase/TestcaseDataEditor.tsx:39-56`)
+  already treats `dataType === "messages"` specially, with Form / JSON /
+  YAML view options and a `TypeChip`.
+- **Read-only**: `ChatMessagesCellContent`
+  (`web/packages/agenta-ui/src/CellRenderers/ChatMessagesCellContent.tsx:170-232`),
+  dispatched by `SmartCellContent` when the preview renderer is `chat`.
+- **Gap**: no inline messages-column card inside the completion generation
+  rows. We compose one from `ChatMessageList` + `TypeChip`. The purple
+  dashed `messages` tag styling from the mock does not exist in code (no
+  `#722ed1`/`#b37feb` hits); match whatever `TypeChip` does, per the "real
+  app wins" fidelity rule.
+
+## 6. Compare mode and the "focused variant"
+
+- `isComparisonViewAtom`:
+  `web/packages/agenta-playground/src/state/execution/displayedEntities.ts:171-175`
+  (true when more than one displayed entity).
+- Displayed entities: `entityIdsAtom` in
+  `web/packages/agenta-playground/src/state/atoms/playground.ts`; there is
+  also a `selectedNodeIdAtom`.
+- No "focused variant" concept exists, and we do not introduce one: the
+  toggle is disabled in comparison view (scope decision 5 in context.md).
+  If that ever changes, note that the write-back serializer already picks
+  the first non-shared session as canonical when freezing
+  (`syncChatMessagesToEntity.ts:63-72`).
+
+## 7. Header and chrome
+
+"Chrome" here means the framing UI around the content (header controls,
+dialogs, banner, later the tab strip), as opposed to the message and output
+cards themselves.
+
+- `ExecutionHeader`
+  (`web/packages/agenta-playground-ui/src/components/ExecutionHeader/index.tsx:44-187`):
+  collapsible label ("Chat" / "Generations"), collapse-all via
+  `executionItemController.selectors.allRowsCollapsed`, Clear and Run all
+  buttons. The segmented control replaces the label; collapse-all relocates
+  to an icon-only button right of the spacer.
+- Ant `Segmented` precedent with Phosphor icons:
+  `web/oss/src/components/Layout/assets/ThemeSwitcher.tsx:10-45`.
+- Icons: Phosphor (`@phosphor-icons/react`) is the standard. No Lucide.
+  Suggested: chat = `ChatCircle`, completion = `Rows`, sync/swap =
+  `ArrowsClockwise` / `Swap`.
+- Modals: use `EnhancedModal` from `@agenta/ui`, not raw antd `Modal`
+  (web/CLAUDE.md rule).
+
+## 8. Conventions that constrain the implementation
+
+- Package layering: `shared ← ui ← entities ← entity-ui ← playground ←
+  playground-ui`. The mode override atom and switch transforms belong in
+  `@agenta/playground` (state); the visual chrome belongs in
+  `@agenta/playground-ui`; app-level dialogs that touch testset flows can
+  live next to the existing modals in
+  `web/oss/src/components/Playground/Components/Modals/`.
+- Persisted state: the mode override survives reloads via localStorage,
+  using Jotai's `atomWithStorage` with an `agenta:` key. The repo pattern
+  keeps one stored record mapping app id → value, with a derived atom that
+  exposes only the current app's entry (web/CLAUDE.md, "Persisted state").
+- Package unit tests live in `tests/unit/`, not `src/`.
+- Verify packages with `pnpm turbo run build --filter=@agenta/<package>`
+  and `pnpm lint-fix` in `web/` before committing.
+
+## 9. Remaining gaps and risks
+
+1. **Completion-mode load strips `messages`.** `MESSAGE_FIELD_KEYS` in
+   `loadTestsetNormalizedMutation.ts:10-18` removes the `messages` field
+   when loading test sets in completion mode. Chat apps in completion mode
+   need that column kept (PR2).
+2. **Template system message round-trip.** The variant's system message must
+   never end up in the row's `messages` column. Verify what the working
+   copy holds and what the serializer writes before relying on round-trip
+   identity (PR2 task).
+3. **Result slot vs column.** In chat mode the assistant reply lands in the
+   working copy (and so in the column). In completion mode it must land in
+   the run result slot instead, with the column frozen. The switch transform
+   and the run path share this rule (PR2).
+4. **Multi-conversation chat.** Working copy keyed per playground; write-back
+   fans out to all rows. Only blocking for tabs (PR4).
+
+There is no backend risk: scoping to chat apps means every run is an
+ordinary chat request, and per-row history is already supported via the
+explicit `runParams.chatHistory` parameter (`executionItems.ts:640`).

--- a/docs/design/playground-mode-switch/status.md
+++ b/docs/design/playground-mode-switch/status.md
@@ -1,0 +1,47 @@
+# Status
+
+**Stage: PR1 implemented and verified; ready to push. Next: PR2.**
+Last updated: 2026-06-10.
+
+New session? Read [context.md](context.md) for scope and invariants,
+[research.md](research.md) for the codebase map, [plan.md](plan.md) for the
+PR stack. All product decisions are made; nothing is blocked on input.
+
+## Decisions
+
+| Decision | Choice | Why |
+|---|---|---|
+| Capability vs behavior | Two atoms: `is_chat` stays the capability; a playground-level override picks the behavior, consulted inside `isChatModeAtom` / `appTypeAtom` | One flag was doing two jobs; those selectors are the single seam all playground consumers already read |
+| Scope | Chat apps only | A chat app in completion mode still sends ordinary chat requests; no backend changes. Chat mode for completion apps needs backend support and is a separate feature |
+| Frozen conversation storage | Reuse the existing `messages` column, no new `history` column | The bidirectional adapter already reads/writes it; the switch becomes a small transform (last reply ↔ result slot) |
+| Completion → chat with N rows | Picker dialog, user chooses one row | Chat working copy is keyed per playground; re-keying per row is only needed for tabs and lives in PR4. Tabs stay the end state |
+| Sync gate escape hatch | Keep it: quiet, left-aligned red "Switch without syncing" | Avoids dead ends when a test set is not wanted; per design default |
+| Compare mode | Toggle disabled in comparison view, tooltip explains | Simpler; avoids inventing a "focused variant" concept |
+| Rollout | Toggle behind a flag until the end of PR3 | Both directions plus the sync gate must work before anyone can switch |
+| Persistence | `atomWithStorage`, per-app record, key `agenta:playground:mode` | Repo pattern; survives reloads; never versioned |
+| Transforms | Pure functions in `@agenta/playground` helpers, both directions written in PR2, unit tests in `tests/unit/` | Round-trip identity tests must exist from day one |
+
+## Engineering verifications pending
+
+- **Template system message round-trip** (PR2, before relying on round-trip
+  identity): confirm the chat working copy and
+  `syncChatMessagesToEntity.ts` never write the variant's system message
+  into the row's `messages` column.
+
+## Worklog
+
+- 2026-06-09: planning workspace created from the design handoff
+  (`design_handoff_playground_mode_switch/`).
+- 2026-06-10: research corrected (the chat ↔ row adapter is bidirectional
+  and real-time, not one-way). Scope agreed with Mahmoud; plan restructured
+  into four stacked PRs; all product questions decided.
+- 2026-06-10: PR1 done. `playgroundModeOverrideAtom` +
+  `playgroundCapabilityModeAtom` + `playgroundIsChatBehaviorAtom` in
+  `web/packages/agenta-playground/src/state/atoms/modeOverride.ts`;
+  `isChatModeAtom` delegates to the behavior atom. Consumer audit recorded
+  in research.md section 2. 7 new unit tests
+  (`tests/unit/modeOverride.test.ts`), full package suite 73/73, build and
+  lint green. Verified on the dev deployment: chat and completion
+  playgrounds unchanged by default; a `completion` localStorage override
+  flips the Chat app to the completion playground and back; a `chat`
+  override on the Completion app is correctly ignored.

--- a/web/packages/agenta-playground/src/state/atoms/index.ts
+++ b/web/packages/agenta-playground/src/state/atoms/index.ts
@@ -7,3 +7,4 @@
 export * from "./playground"
 export * from "./connections"
 export * from "./entitySelector"
+export * from "./modeOverride"

--- a/web/packages/agenta-playground/src/state/atoms/modeOverride.ts
+++ b/web/packages/agenta-playground/src/state/atoms/modeOverride.ts
@@ -1,0 +1,105 @@
+/**
+ * Playground mode override (chat ⇄ completion behavior).
+ *
+ * `is_chat` on the workflow entity is a capability: the app accepts a
+ * `messages` input. Which behavior the playground uses (multi-turn chat vs
+ * single-turn completion over N test cases) is a user choice, scoped to the
+ * playground, persisted per app, and never committed or versioned.
+ *
+ * The override only has an effect for chat-capable apps. Completion apps
+ * cannot run conversations, so `isChatModeAtom` ignores the override for
+ * them. Request shapes always follow the capability, not the behavior:
+ * a chat app running with completion behavior still sends chat-shaped
+ * requests (history in, one reply out).
+ *
+ * Design doc: docs/design/playground-mode-switch/
+ */
+
+import {workflowMolecule} from "@agenta/entities/workflow"
+import {atom} from "jotai"
+import {atomWithStorage} from "jotai/utils"
+
+import {playgroundNodesAtom} from "./playground"
+
+export type PlaygroundMode = "chat" | "completion"
+
+/**
+ * Persisted overrides, one entry per app. Keyed by the root workflow id so
+ * the choice survives reloads and revision switches. Entries equal to the
+ * app's capability default are never stored (see the setter below).
+ */
+const modeOverridesByAppStorageAtom = atomWithStorage<Record<string, PlaygroundMode>>(
+    "agenta:playground:mode",
+    {},
+)
+
+/**
+ * The app's capability-derived mode: what the workflow can do, regardless
+ * of any user override. `undefined` while the playground has no root node.
+ */
+export const playgroundCapabilityModeAtom = atom<PlaygroundMode | undefined>((get) => {
+    const rootNode = get(playgroundNodesAtom).find((n) => n.depth === 0)
+    if (!rootNode) return undefined
+    return get(workflowMolecule.selectors.executionMode(rootNode.entityId))
+})
+
+/**
+ * Stable per-app key for the override record. The playground's root node
+ * holds a revision id; the revision's `workflow_id` is the app. Falls back
+ * to the entity id itself for local drafts that have no parent workflow yet.
+ */
+const playgroundModeScopeKeyAtom = atom<string | null>((get) => {
+    const rootNode = get(playgroundNodesAtom).find((n) => n.depth === 0)
+    if (!rootNode) return null
+    const entity = get(workflowMolecule.selectors.data(rootNode.entityId)) as
+        | {workflow_id?: string | null}
+        | null
+        | undefined
+    return entity?.workflow_id || rootNode.entityId
+})
+
+/**
+ * The user's mode override for the current app, or `null` to follow the
+ * capability default.
+ *
+ * Writing the capability value (or `null`) removes the stored entry, so the
+ * record only ever holds real deviations from the default.
+ */
+export const playgroundModeOverrideAtom = atom(
+    (get) => {
+        const key = get(playgroundModeScopeKeyAtom)
+        if (!key) return null
+        return get(modeOverridesByAppStorageAtom)[key] ?? null
+    },
+    (get, set, next: PlaygroundMode | null) => {
+        const key = get(playgroundModeScopeKeyAtom)
+        if (!key) return
+        const overrides = get(modeOverridesByAppStorageAtom)
+        const capability = get(playgroundCapabilityModeAtom)
+        const normalized = next === capability ? null : next
+        if (normalized === null) {
+            if (!(key in overrides)) return
+            const {[key]: _removed, ...rest} = overrides
+            set(modeOverridesByAppStorageAtom, rest)
+            return
+        }
+        if (overrides[key] === normalized) return
+        set(modeOverridesByAppStorageAtom, {...overrides, [key]: normalized})
+    },
+)
+
+/**
+ * Effective playground behavior: capability combined with the override.
+ *
+ * `true` for chat behavior, `false` for completion behavior, `undefined`
+ * while the playground has no root node. Completion apps always get
+ * completion behavior; the override cannot make them chat.
+ *
+ * Exposed to consumers as `isChatModeAtom` (execution selectors).
+ */
+export const playgroundIsChatBehaviorAtom = atom<boolean | undefined>((get) => {
+    const capability = get(playgroundCapabilityModeAtom)
+    if (capability === undefined) return undefined
+    if (capability !== "chat") return false
+    return get(playgroundModeOverrideAtom) !== "completion"
+})

--- a/web/packages/agenta-playground/src/state/execution/selectors.ts
+++ b/web/packages/agenta-playground/src/state/execution/selectors.ts
@@ -16,6 +16,7 @@ import {selectAtom} from "jotai/utils"
 import {getDefaultStore} from "jotai/vanilla"
 import {atomFamily} from "jotai-family"
 
+import {playgroundIsChatBehaviorAtom} from "../atoms/modeOverride"
 import {entityIdsAtom, playgroundNodesAtom} from "../atoms/playground"
 import {addUserMessageAtom} from "../chat"
 import {sharedMessageIdsAtomFamily} from "../chat/messageSelectors"
@@ -1097,18 +1098,19 @@ export const outputPortSchemaMapAtom = atom<
 // ============================================================================
 
 /**
- * App-level chat mode detection.
+ * Playground-level chat behavior.
  *
- * Derives from the primary node's entity ID via `workflowMolecule.selectors.executionMode`.
- * Returns `true` for chat apps, `false` for completion apps, `undefined` while loading.
+ * Combines the app's capability (the primary node's
+ * `workflowMolecule.selectors.executionMode`) with the user's playground
+ * mode override (`playgroundModeOverrideAtom`). Completion apps cannot run
+ * conversations, so the override only applies to chat-capable apps.
+ * Returns `true` for chat behavior, `false` for completion behavior,
+ * `undefined` while the playground has no root node.
  *
+ * Request shapes follow the capability, not this atom (see
+ * docs/design/playground-mode-switch/).
  */
-export const isChatModeAtom = atom<boolean | undefined>((get) => {
-    const rootNode = get(playgroundNodesAtom).find((n) => n.depth === 0)
-    if (!rootNode) return undefined
-    const mode = get(workflowMolecule.selectors.executionMode(rootNode.entityId))
-    return mode === "chat"
-})
+export const isChatModeAtom = atom<boolean | undefined>((get) => get(playgroundIsChatBehaviorAtom))
 
 /**
  * App-level type derived from chat mode.

--- a/web/packages/agenta-playground/src/state/index.ts
+++ b/web/packages/agenta-playground/src/state/index.ts
@@ -412,11 +412,16 @@ export {
     // Connection atoms
     outputConnectionsAtom,
     playgroundDispatchAtom,
+    // Mode override atoms (chat ⇄ completion behavior; see
+    // docs/design/playground-mode-switch/)
+    playgroundCapabilityModeAtom,
+    playgroundModeOverrideAtom,
     playgroundNodesAtom,
     primaryEntityIdAtom,
     primaryNodeAtom,
     selectedNodeIdAtom,
     testsetModalOpenAtom,
+    type PlaygroundMode,
 } from "./atoms"
 
 // ============================================================================

--- a/web/packages/agenta-playground/tests/unit/modeOverride.test.ts
+++ b/web/packages/agenta-playground/tests/unit/modeOverride.test.ts
@@ -1,0 +1,173 @@
+/**
+ * Unit tests for the playground mode override atoms.
+ *
+ * The override decouples the app's capability (`is_chat`: the workflow
+ * accepts a `messages` input) from the playground's behavior (chat vs
+ * completion UI and run semantics). Contract under test:
+ *
+ * - completion apps always get completion behavior; the override is inert
+ * - chat apps default to chat behavior and can be overridden to completion
+ * - writing the capability default (or null) removes the stored entry
+ * - the override is scoped per app (`workflow_id`), not per revision
+ *
+ * Design doc: docs/design/playground-mode-switch/
+ *
+ * The workflow molecule is mocked with writable data atoms; `executionMode`
+ * derives from `flags.is_chat` exactly like the real selector's first check.
+ */
+import {createStore, type PrimitiveAtom} from "jotai"
+import {describe, expect, it, beforeEach} from "vitest"
+import {vi} from "vitest"
+
+vi.mock("@agenta/entities/workflow", async () => {
+    const {atom} = await import("jotai")
+    const dataAtoms = new Map<string, unknown>()
+    const dataFor = (id: string) => {
+        if (!dataAtoms.has(id)) {
+            dataAtoms.set(id, atom<Record<string, unknown> | null>(null))
+        }
+        return dataAtoms.get(id)
+    }
+    return {
+        workflowMolecule: {
+            selectors: {
+                data: dataFor,
+                executionMode: (id: string) =>
+                    atom((get) => {
+                        const entity = get(
+                            dataFor(id) as PrimitiveAtom<{
+                                flags?: {is_chat?: boolean}
+                            } | null>,
+                        )
+                        return entity?.flags?.is_chat ? "chat" : "completion"
+                    }),
+            },
+        },
+    }
+})
+
+import {workflowMolecule} from "@agenta/entities/workflow"
+
+import {
+    playgroundCapabilityModeAtom,
+    playgroundIsChatBehaviorAtom,
+    playgroundModeOverrideAtom,
+} from "../../src/state/atoms/modeOverride"
+import {playgroundNodesAtom} from "../../src/state/atoms/playground"
+import type {PlaygroundNode} from "../../src/state/types"
+
+type EntityData = {flags?: {is_chat?: boolean}; workflow_id?: string | null} | null
+
+function seedEntity(store: ReturnType<typeof createStore>, entityId: string, data: EntityData) {
+    store.set(workflowMolecule.selectors.data(entityId) as PrimitiveAtom<EntityData>, data)
+}
+
+function setRootNode(store: ReturnType<typeof createStore>, entityId: string) {
+    const node: PlaygroundNode = {
+        id: `node-${entityId}`,
+        entityType: "workflow" as PlaygroundNode["entityType"],
+        entityId,
+        depth: 0,
+    }
+    store.set(playgroundNodesAtom, [node])
+}
+
+describe("playground mode override", () => {
+    let store: ReturnType<typeof createStore>
+
+    beforeEach(() => {
+        store = createStore()
+        // The storage atom is module-level; clear leftovers between tests by
+        // resetting through the public setter once a scope exists.
+    })
+
+    it("is undefined with no root node, and the setter is a no-op", () => {
+        expect(store.get(playgroundCapabilityModeAtom)).toBeUndefined()
+        expect(store.get(playgroundIsChatBehaviorAtom)).toBeUndefined()
+        expect(store.get(playgroundModeOverrideAtom)).toBeNull()
+
+        store.set(playgroundModeOverrideAtom, "completion")
+        expect(store.get(playgroundModeOverrideAtom)).toBeNull()
+    })
+
+    it("completion apps get completion behavior and the override is inert", () => {
+        seedEntity(store, "rev-comp", {flags: {is_chat: false}, workflow_id: "app-comp"})
+        setRootNode(store, "rev-comp")
+
+        expect(store.get(playgroundCapabilityModeAtom)).toBe("completion")
+        expect(store.get(playgroundIsChatBehaviorAtom)).toBe(false)
+
+        store.set(playgroundModeOverrideAtom, "chat")
+        expect(store.get(playgroundIsChatBehaviorAtom)).toBe(false)
+
+        store.set(playgroundModeOverrideAtom, null)
+    })
+
+    it("chat apps default to chat behavior", () => {
+        seedEntity(store, "rev-chat", {flags: {is_chat: true}, workflow_id: "app-chat"})
+        setRootNode(store, "rev-chat")
+
+        expect(store.get(playgroundCapabilityModeAtom)).toBe("chat")
+        expect(store.get(playgroundModeOverrideAtom)).toBeNull()
+        expect(store.get(playgroundIsChatBehaviorAtom)).toBe(true)
+    })
+
+    it("a completion override flips a chat app to completion behavior, and clears", () => {
+        seedEntity(store, "rev-chat2", {flags: {is_chat: true}, workflow_id: "app-chat2"})
+        setRootNode(store, "rev-chat2")
+
+        store.set(playgroundModeOverrideAtom, "completion")
+        expect(store.get(playgroundModeOverrideAtom)).toBe("completion")
+        expect(store.get(playgroundIsChatBehaviorAtom)).toBe(false)
+
+        store.set(playgroundModeOverrideAtom, null)
+        expect(store.get(playgroundModeOverrideAtom)).toBeNull()
+        expect(store.get(playgroundIsChatBehaviorAtom)).toBe(true)
+    })
+
+    it("writing the capability default removes the stored entry", () => {
+        seedEntity(store, "rev-chat3", {flags: {is_chat: true}, workflow_id: "app-chat3"})
+        setRootNode(store, "rev-chat3")
+
+        store.set(playgroundModeOverrideAtom, "completion")
+        expect(store.get(playgroundModeOverrideAtom)).toBe("completion")
+
+        // "chat" is this app's capability default: normalized to removal.
+        store.set(playgroundModeOverrideAtom, "chat")
+        expect(store.get(playgroundModeOverrideAtom)).toBeNull()
+        expect(store.get(playgroundIsChatBehaviorAtom)).toBe(true)
+    })
+
+    it("scopes the override per app, surviving revision switches", () => {
+        seedEntity(store, "rev-a1", {flags: {is_chat: true}, workflow_id: "app-a"})
+        seedEntity(store, "rev-a2", {flags: {is_chat: true}, workflow_id: "app-a"})
+        seedEntity(store, "rev-b", {flags: {is_chat: true}, workflow_id: "app-b"})
+
+        setRootNode(store, "rev-a1")
+        store.set(playgroundModeOverrideAtom, "completion")
+        expect(store.get(playgroundIsChatBehaviorAtom)).toBe(false)
+
+        // Another app is unaffected.
+        setRootNode(store, "rev-b")
+        expect(store.get(playgroundModeOverrideAtom)).toBeNull()
+        expect(store.get(playgroundIsChatBehaviorAtom)).toBe(true)
+
+        // A different revision of the same app keeps the override.
+        setRootNode(store, "rev-a2")
+        expect(store.get(playgroundModeOverrideAtom)).toBe("completion")
+        expect(store.get(playgroundIsChatBehaviorAtom)).toBe(false)
+
+        store.set(playgroundModeOverrideAtom, null)
+    })
+
+    it("falls back to the entity id as scope key when workflow_id is missing", () => {
+        seedEntity(store, "local-draft", {flags: {is_chat: true}, workflow_id: null})
+        setRootNode(store, "local-draft")
+
+        store.set(playgroundModeOverrideAtom, "completion")
+        expect(store.get(playgroundModeOverrideAtom)).toBe("completion")
+        expect(store.get(playgroundIsChatBehaviorAtom)).toBe(false)
+
+        store.set(playgroundModeOverrideAtom, null)
+    })
+})


### PR DESCRIPTION
## Context

The playground decides chat vs completion from the app's `is_chat` flag. That one value does two jobs: it says the app accepts a `messages` input (a capability) and it picks the playground UI and run semantics (a behavior). The upcoming mode switch needs them separated, so a chat app can also run as a single-turn completion playground. Design workspace: `docs/design/playground-mode-switch/` (added in this PR).

This is PR 1 of 4. It is invisible by design: nothing writes the override yet. The segmented `Chat | Completion` control comes in the next PR.

## Changes

New `web/packages/agenta-playground/src/state/atoms/modeOverride.ts` with three atoms: the capability (`playgroundCapabilityModeAtom`), the user's override (`playgroundModeOverrideAtom`, persisted per app in localStorage under `agenta:playground:mode`, keyed by the root revision's `workflow_id` so it survives revision switches), and the effective behavior (`playgroundIsChatBehaviorAtom`).

Before:
```ts
isChatModeAtom = executionMode(rootNode.entityId) === "chat"
```

After:
```ts
isChatModeAtom = capability !== "chat" ? false : override !== "completion"
```

Every playground consumer already reads mode through `isChatModeAtom` (directly or via `executionController.selectors.isChatMode`), so the override flips the whole playground at once. Completion apps ignore the override; they cannot run conversations. Two reads intentionally stay on the capability (`entityInputContract.ts:82`, `executionItems.ts:540`): request shapes follow what the app accepts, not the UI behavior. Writing the capability default removes the stored entry, so storage only holds real deviations.

## Tests / notes

- 7 unit tests in `tests/unit/modeOverride.test.ts`: capability gate, override flip and clear, normalization to the default, per-app scoping across revisions, entity-id fallback for local drafts.
- Full `@agenta/playground` suite passes (73/73); package build and lint green.
- Verified on the dev deployment: both playground types render unchanged by default. Forcing `{"<appId>": "completion"}` in localStorage flips a chat app to the completion playground and back; a `chat` override on a completion app is ignored.
- Known and intentional: with the override forced via console, Run in completion behavior is not correct yet. The run-path reconciliation is PR 2 (noted in research.md, section 2).