### PR TITLE
feat(frontend): run a chat app in completion mode (behind a flag)

### DIFF
--- a/docs/design/playground-mode-switch/status.md
+++ b/docs/design/playground-mode-switch/status.md
@@ -1,7 +1,7 @@
 # Status
 
-**Stage: PR1 in review (#4609). PR2 in progress on
-`feat/playground-completion-mode-for-chat` (stacked on PR1).**
+**Stage: PR1 in review (#4609). PR2 built and verified on
+`feat/playground-completion-mode-for-chat` (stacked on PR1), ready to push.**
 Last updated: 2026-06-10.
 
 New session? Read [context.md](context.md) for scope and invariants,
@@ -21,6 +21,20 @@ PR stack. All product decisions are made; nothing is blocked on input.
 | Rollout | Toggle behind a flag until the end of PR3 | Both directions plus the sync gate must work before anyone can switch |
 | Persistence | `atomWithStorage`, per-app record, key `agenta:playground:mode` | Repo pattern; survives reloads; never versioned |
 | Transforms | Pure functions in `@agenta/playground` helpers, both directions written in PR2, unit tests in `tests/unit/` | Round-trip identity tests must exist from day one |
+
+## Deferred from PR2 to PR3
+
+These are not blockers for PR2 (the switch is lossless and runs correctly
+without them); they are surfacing/polish:
+
+- **Editable messages-column card in completion rows.** The frozen
+  conversation lives in the row's `messages` column and drives runs, but
+  the prompt does not reference `messages` as a variable, so the column is
+  hidden ("1 unused testcase column hidden"). It is preserved and restored
+  on switch-back, just not yet shown as an editable card.
+- **Post-switch info banner** ("Conversation moved to the `messages`
+  column...").
+- **Completion → chat reverse reshaping + picker** (already PR3 scope).
 
 ## Engineering verifications
 
@@ -46,6 +60,19 @@ PR stack. All product decisions are made; nothing is blocked on input.
   above). Mode switch transforms written as pure helpers
   (`helpers/modeSwitchTransforms.ts`) with 15 unit tests covering the
   split/merge contract and round-trip identity.
+- 2026-06-10 (PR2 complete, behind a flag): wired the full chat → completion
+  path. Load keeps the `messages` column for chat-capable apps; the run
+  path scopes per row and sources each row's history from its own `messages`
+  column (chat-shaped request, reply to the result slot);
+  `switchPlaygroundModeAtom` freezes each conversation on switch; the
+  `Chat | Completion` segmented control + confirm dialog live in the header
+  behind `playgroundModeSwitchEnabledAtom` (default off), disabled in
+  compare view. 88 package unit tests pass; both packages build; lint clean.
+  Verified end to end on the dev box with the flag forced on: switching a
+  chat app froze the conversation into testcase 1 (last reply shown as the
+  row output), and Run posted `data.inputs.messages` = the row's frozen
+  history with the `context` variable and no system-message duplication.
+  Deferred items recorded above.
 - 2026-06-10: PR1 done. `playgroundModeOverrideAtom` +
   `playgroundCapabilityModeAtom` + `playgroundIsChatBehaviorAtom` in
   `web/packages/agenta-playground/src/state/atoms/modeOverride.ts`;

--- a/docs/design/playground-mode-switch/status.md
+++ b/docs/design/playground-mode-switch/status.md
@@ -1,6 +1,7 @@
 # Status
 
-**Stage: PR1 implemented and verified; ready to push. Next: PR2.**
+**Stage: PR1 in review (#4609). PR2 in progress on
+`feat/playground-completion-mode-for-chat` (stacked on PR1).**
 Last updated: 2026-06-10.
 
 New session? Read [context.md](context.md) for scope and invariants,
@@ -21,12 +22,16 @@ PR stack. All product decisions are made; nothing is blocked on input.
 | Persistence | `atomWithStorage`, per-app record, key `agenta:playground:mode` | Repo pattern; survives reloads; never versioned |
 | Transforms | Pure functions in `@agenta/playground` helpers, both directions written in PR2, unit tests in `tests/unit/` | Round-trip identity tests must exist from day one |
 
-## Engineering verifications pending
+## Engineering verifications
 
-- **Template system message round-trip** (PR2, before relying on round-trip
-  identity): confirm the chat working copy and
-  `syncChatMessagesToEntity.ts` never write the variant's system message
-  into the row's `messages` column.
+- **Template system message round-trip: verified safe (2026-06-10).** The
+  ghosted template system message renders read-only from the variant
+  config in `ChatMode` (`ChatMessageList` fed by `extractPromptMessages`,
+  `onChange={noop}`). Nothing seeds `role: "system"` into the chat
+  working copy and `extractAndLoadChatMessages` has no system handling,
+  so the write-back cannot put the template message into the row. A
+  system message in `row.messages` can only come from test set data,
+  which is legitimately kept.
 
 ## Worklog
 
@@ -35,6 +40,12 @@ PR stack. All product decisions are made; nothing is blocked on input.
 - 2026-06-10: research corrected (the chat ↔ row adapter is bidirectional
   and real-time, not one-way). Scope agreed with Mahmoud; plan restructured
   into four stacked PRs; all product questions decided.
+- 2026-06-10 (later): PR1 pushed and opened as #4609 against main (no
+  stacking needed; no applied branch touches the same files). PR2 branch
+  created and stacked on PR1. System-message verification done (see
+  above). Mode switch transforms written as pure helpers
+  (`helpers/modeSwitchTransforms.ts`) with 15 unit tests covering the
+  split/merge contract and round-trip identity.
 - 2026-06-10: PR1 done. `playgroundModeOverrideAtom` +
   `playgroundCapabilityModeAtom` + `playgroundIsChatBehaviorAtom` in
   `web/packages/agenta-playground/src/state/atoms/modeOverride.ts`;

--- a/web/packages/agenta-playground-ui/src/components/ExecutionHeader/index.tsx
+++ b/web/packages/agenta-playground-ui/src/components/ExecutionHeader/index.tsx
@@ -4,6 +4,7 @@ import type {PlaygroundNode} from "@agenta/entities/runnable"
 import {
     executionController,
     executionItemController,
+    playgroundCapabilityModeAtom,
     playgroundController,
 } from "@agenta/playground"
 import {CollapsibleGroupHeader, RunButton} from "@agenta/ui/components/presentational"
@@ -12,6 +13,9 @@ import {ArrowsInLineVertical, ArrowsOutLineVertical} from "@phosphor-icons/react
 import {Button, Tooltip, Typography} from "antd"
 import clsx from "clsx"
 import {useAtom, useAtomValue, useSetAtom} from "jotai"
+
+import {playgroundModeSwitchEnabledAtom} from "../../state/featureFlags"
+import ModeSwitcher from "../ModeSwitcher"
 
 // import RunOptionsPopover from "../ExecutionItems/assets/RunOptionsPopover"
 
@@ -49,6 +53,12 @@ const ExecutionHeader = ({
 }: ExecutionHeaderProps) => {
     const isComparisonView = !entityId
     const isChatMode = useAtomValue(executionController.selectors.isChatMode) ?? false
+    const modeSwitchEnabled = useAtomValue(playgroundModeSwitchEnabledAtom)
+    const capabilityMode = useAtomValue(playgroundCapabilityModeAtom)
+    // The segmented control replaces the panel title for chat-capable apps
+    // when the feature flag is on. It relocates the collapse-all action to an
+    // icon-only button (design: docs/design/playground-mode-switch/).
+    const showModeSwitcher = modeSwitchEnabled && capabilityMode === "chat"
 
     const headerDataSelector = useMemo(
         () =>
@@ -114,7 +124,9 @@ const ExecutionHeader = ({
             )}
         >
             <div className="flex items-center gap-2">
-                {showCollapseToggle ? (
+                {showModeSwitcher ? (
+                    <ModeSwitcher disabled={isComparisonView} />
+                ) : showCollapseToggle ? (
                     <div className="flex items-center">
                         <CollapsibleGroupHeader
                             label={
@@ -152,6 +164,24 @@ const ExecutionHeader = ({
             </div>
 
             <div className="flex items-center gap-2">
+                {showModeSwitcher && showCollapseToggle ? (
+                    <Tooltip title="Collapse all test cases">
+                        <Button
+                            type="text"
+                            size="small"
+                            aria-label="Collapse all test cases"
+                            onClick={() => setIsAllCollapsed(!isAllCollapsed)}
+                            icon={
+                                isAllCollapsed ? (
+                                    <ArrowsOutLineVertical size={16} />
+                                ) : (
+                                    <ArrowsInLineVertical size={16} />
+                                )
+                            }
+                        />
+                    </Tooltip>
+                ) : null}
+
                 <Tooltip title="Clear all">
                     <Button size="small" onClick={() => clearAll()} disabled={isRunning}>
                         Clear

--- a/web/packages/agenta-playground-ui/src/components/ModeSwitcher/index.tsx
+++ b/web/packages/agenta-playground-ui/src/components/ModeSwitcher/index.tsx
@@ -1,0 +1,118 @@
+import {memo, useState} from "react"
+
+import {
+    playgroundCapabilityModeAtom,
+    playgroundHasConversationAtom,
+    switchPlaygroundModeAtom,
+    type PlaygroundMode,
+} from "@agenta/playground"
+import {executionController} from "@agenta/playground"
+import {EnhancedModal} from "@agenta/ui/components/modal"
+import {ChatCircle, Rows, ArrowsLeftRight} from "@phosphor-icons/react"
+import {Button, Segmented, Tooltip, Typography} from "antd"
+import {useAtomValue, useSetAtom} from "jotai"
+
+/**
+ * Segmented `Chat | Completion` control that switches the playground behavior
+ * for a chat-capable app. Renders nothing for pure completion apps (they
+ * cannot run conversations). Disabled in comparison view.
+ *
+ * Chat → completion with an existing conversation asks for confirmation
+ * first; an empty chat switches silently. Design doc:
+ * docs/design/playground-mode-switch/.
+ */
+interface ModeSwitcherProps {
+    /** Comparison view disables switching (mode is global; one variant only). */
+    disabled?: boolean
+}
+
+const ModeSwitcher = ({disabled = false}: ModeSwitcherProps) => {
+    const capability = useAtomValue(playgroundCapabilityModeAtom)
+    const isChat = useAtomValue(executionController.selectors.isChatMode) ?? false
+    const hasConversation = useAtomValue(playgroundHasConversationAtom)
+    const switchMode = useSetAtom(switchPlaygroundModeAtom)
+
+    const [confirmOpen, setConfirmOpen] = useState(false)
+
+    // Only chat-capable apps can switch; completion apps stay as they are.
+    if (capability !== "chat") return null
+
+    const value: PlaygroundMode = isChat ? "chat" : "completion"
+
+    const handleChange = (next: PlaygroundMode) => {
+        if (next === value) return
+        // Reshaping only happens chat → completion, and only a non-empty
+        // conversation needs the heads-up.
+        if (next === "completion" && hasConversation) {
+            setConfirmOpen(true)
+            return
+        }
+        switchMode(next)
+    }
+
+    const confirmSwitch = () => {
+        setConfirmOpen(false)
+        switchMode("completion")
+    }
+
+    const control = (
+        <Segmented<PlaygroundMode>
+            size="small"
+            value={value}
+            disabled={disabled}
+            onChange={handleChange}
+            options={[
+                {value: "chat", label: "Chat", icon: <ChatCircle size={13} />},
+                {value: "completion", label: "Completion", icon: <Rows size={13} />},
+            ]}
+        />
+    )
+
+    return (
+        <>
+            {disabled ? (
+                <Tooltip title="Switching modes is available outside compare view">
+                    {control}
+                </Tooltip>
+            ) : (
+                control
+            )}
+
+            <EnhancedModal
+                open={confirmOpen}
+                width={480}
+                title={
+                    <span className="text-[15px] font-semibold text-[var(--ag-c-1c2c3d)]">
+                        Switch to Completion?
+                    </span>
+                }
+                onCancel={() => setConfirmOpen(false)}
+                footer={[
+                    <Button key="cancel" onClick={() => setConfirmOpen(false)}>
+                        Cancel
+                    </Button>,
+                    <Button
+                        key="switch"
+                        type="primary"
+                        icon={<ArrowsLeftRight size={14} />}
+                        onClick={confirmSwitch}
+                    >
+                        Switch
+                    </Button>,
+                ]}
+            >
+                <div className="flex flex-col gap-1 text-[13px]">
+                    <Typography.Text className="!text-[var(--ag-c-586673)]">
+                        The conversation becomes a constant <code>messages</code> column. Run
+                        regenerates only the final answer.
+                    </Typography.Text>
+                    <Typography.Text className="!text-[var(--ag-c-758391)]">
+                        Nothing is deleted. Switch back anytime.
+                    </Typography.Text>
+                </div>
+            </EnhancedModal>
+        </>
+    )
+}
+
+export default memo(ModeSwitcher)

--- a/web/packages/agenta-playground-ui/src/state/featureFlags.ts
+++ b/web/packages/agenta-playground-ui/src/state/featureFlags.ts
@@ -29,3 +29,14 @@ import {atom} from "jotai"
  * follow-ups in the approved design doc.
  */
 export const useNewPlaygroundInputsBodyAtom = atom<boolean>(true)
+
+/**
+ * When `true`, chat-capable apps show a `Chat | Completion` segmented control
+ * in the generations header that switches the playground behavior at runtime.
+ *
+ * Default `false`: the switch lands across stacked PRs (chat → completion
+ * first, the reverse direction and the sync gate next). OSS flips this on once
+ * both directions and the sync gate are ready. Design doc:
+ * docs/design/playground-mode-switch/.
+ */
+export const playgroundModeSwitchEnabledAtom = atom<boolean>(false)

--- a/web/packages/agenta-playground-ui/src/state/featureFlags.ts
+++ b/web/packages/agenta-playground-ui/src/state/featureFlags.ts
@@ -34,9 +34,14 @@ export const useNewPlaygroundInputsBodyAtom = atom<boolean>(true)
  * When `true`, chat-capable apps show a `Chat | Completion` segmented control
  * in the generations header that switches the playground behavior at runtime.
  *
- * Default `false`: the switch lands across stacked PRs (chat → completion
- * first, the reverse direction and the sync gate next). OSS flips this on once
- * both directions and the sync gate are ready. Design doc:
+ * The switch lands across stacked PRs (chat → completion first, the reverse
+ * direction and the sync gate next). Design doc:
  * docs/design/playground-mode-switch/.
+ *
+ * TEMPORARILY `true` so the PR's preview environment exposes the control for
+ * testing. The fully wired direction is chat → completion; the reverse only
+ * flips the view back for now (no reshaping or sync gate yet). Set back to
+ * `false` before merge, or keep on once the reverse direction and sync gate
+ * land.
  */
-export const playgroundModeSwitchEnabledAtom = atom<boolean>(false)
+export const playgroundModeSwitchEnabledAtom = atom<boolean>(true)

--- a/web/packages/agenta-playground-ui/src/state/index.ts
+++ b/web/packages/agenta-playground-ui/src/state/index.ts
@@ -7,4 +7,4 @@ export {
     type PlaygroundFocusDrawerState,
 } from "./focusDrawer"
 
-export {useNewPlaygroundInputsBodyAtom} from "./featureFlags"
+export {useNewPlaygroundInputsBodyAtom, playgroundModeSwitchEnabledAtom} from "./featureFlags"

--- a/web/packages/agenta-playground/src/index.ts
+++ b/web/packages/agenta-playground/src/index.ts
@@ -65,6 +65,16 @@ export {displayedEntityIdsAtom, playgroundInitializedAtom} from "./state"
 // Testset import mutation (consumed by OSS testset integration)
 export {loadTestsetNormalizedMutationAtom} from "./state"
 
+// Playground mode switch (chat ⇄ completion behavior; consumed by the
+// ModeSwitcher chrome in @agenta/playground-ui)
+export {
+    playgroundCapabilityModeAtom,
+    playgroundModeOverrideAtom,
+    switchPlaygroundModeAtom,
+    playgroundHasConversationAtom,
+    type PlaygroundMode,
+} from "./state"
+
 // ============================================================================
 // ENTITY CONTEXT (Dependency Injection)
 // ============================================================================

--- a/web/packages/agenta-playground/src/state/execution/executionItems.ts
+++ b/web/packages/agenta-playground/src/state/execution/executionItems.ts
@@ -26,6 +26,7 @@ import {
 import type {ChatMessage} from "../chat/messageTypes"
 import {SHARED_SESSION_ID} from "../chat/messageTypes"
 import {buildAssistantMessage} from "../helpers/messageFactory"
+import {normalizeColumnMessages} from "../helpers/modeSwitchTransforms"
 
 import {
     abortRun,
@@ -470,6 +471,24 @@ function buildChatHistoryFromFlatMessages(params: {
     return history
 }
 
+/**
+ * Build chat history from a row's `messages` column (the frozen conversation
+ * a chat-capable app carries while running in completion behavior). Unlike
+ * the flat-message path, each row owns its own history here, so the source
+ * is the row data, not the per-playground message atoms.
+ */
+function buildChatHistoryFromRowColumn(
+    rowData: Record<string, unknown> | null | undefined,
+): TransformMessage[] {
+    return normalizeColumnMessages(rowData?.messages).map((m) => ({
+        role: m.role,
+        content: m.content as string | unknown[],
+        ...(m.name ? {name: String(m.name)} : {}),
+        ...(Array.isArray(m.tool_calls) ? {toolCalls: m.tool_calls} : {}),
+        ...(m.tool_call_id != null ? {toolCallId: String(m.tool_call_id)} : {}),
+    }))
+}
+
 export function createExecutionItemHandle(params: CreateExecutionItemParams): ExecutionItemHandle {
     const references: ExecutionItemReference = {
         loadableId: params.loadableId,
@@ -536,10 +555,17 @@ export function createExecutionItemHandle(params: CreateExecutionItemParams): Ex
             dispatchWorkerRun,
         } = runParams
 
+        // `mode` follows the app capability and drives the request shape
+        // (chat apps always send a messages payload). The playground behavior
+        // can differ: a chat-capable app the user switched to completion
+        // behavior renders and runs per row, but still sends a chat request,
+        // sourcing each row's history from its own `messages` column.
+        // (docs/design/playground-mode-switch/)
         const mode: ExecutionMode =
             get(workflowMolecule.selectors.executionMode(params.entityId)) === "chat"
                 ? "chat"
                 : "completion"
+        const isCompletionOnChat = mode === "chat" && get(isChatModeAtom) === false
         const normalizedRepetitions = resolveRequestedRepetitions(get, repetitions)
         const effectiveRunId =
             runId ?? (!forceNewRunId && params.runId ? params.runId : undefined) ?? generateId()
@@ -582,7 +608,9 @@ export function createExecutionItemHandle(params: CreateExecutionItemParams): Ex
         }
 
         const variableSourceRowId = resolveVariableRowId({
-            mode,
+            // Completion-on-chat scopes per row, like completion, so each row
+            // runs against its own variables and history.
+            mode: isCompletionOnChat ? "completion" : mode,
             executionRowId: params.rowId,
             displayRowIds,
         })
@@ -638,31 +666,33 @@ export function createExecutionItemHandle(params: CreateExecutionItemParams): Ex
         const chatHistory =
             mode === "chat"
                 ? (runParams.chatHistory ??
-                  (() => {
-                      const allMsgIds = get(messageIdsAtomFamily(params.loadableId))
-                      const allMsgsById = get(messagesByIdAtomFamily(params.loadableId))
-                      const logicalRowId = extractLogicalRowId(params.rowId)
+                  (isCompletionOnChat
+                      ? buildChatHistoryFromRowColumn(variableSourceDataForExecution)
+                      : (() => {
+                            const allMsgIds = get(messageIdsAtomFamily(params.loadableId))
+                            const allMsgsById = get(messagesByIdAtomFamily(params.loadableId))
+                            const logicalRowId = extractLogicalRowId(params.rowId)
 
-                      // Find the cut point: include messages up to the next shared message after logicalRowId
-                      const rowIdx = allMsgIds.indexOf(logicalRowId)
-                      let cutIdx = allMsgIds.length
-                      if (rowIdx >= 0) {
-                          for (let i = rowIdx + 1; i < allMsgIds.length; i++) {
-                              const m = allMsgsById[allMsgIds[i]] as ChatMessage | undefined
-                              if (m && m.sessionId === SHARED_SESSION_ID) {
-                                  cutIdx = i
-                                  break
-                              }
-                          }
-                      }
-                      const limitedIds = allMsgIds.slice(0, cutIdx)
+                            // Find the cut point: include messages up to the next shared message after logicalRowId
+                            const rowIdx = allMsgIds.indexOf(logicalRowId)
+                            let cutIdx = allMsgIds.length
+                            if (rowIdx >= 0) {
+                                for (let i = rowIdx + 1; i < allMsgIds.length; i++) {
+                                    const m = allMsgsById[allMsgIds[i]] as ChatMessage | undefined
+                                    if (m && m.sessionId === SHARED_SESSION_ID) {
+                                        cutIdx = i
+                                        break
+                                    }
+                                }
+                            }
+                            const limitedIds = allMsgIds.slice(0, cutIdx)
 
-                      return buildChatHistoryFromFlatMessages({
-                          messageIds: limitedIds,
-                          messagesById: allMsgsById,
-                          sessionId: references.sessionId,
-                      })
-                  })())
+                            return buildChatHistoryFromFlatMessages({
+                                messageIds: limitedIds,
+                                messagesById: allMsgsById,
+                                sessionId: references.sessionId,
+                            })
+                        })()))
                 : undefined
 
         const agConfigFallbacks: AgConfigFallbackCandidate[] = [

--- a/web/packages/agenta-playground/src/state/helpers/loadTestsetNormalizedMutation.ts
+++ b/web/packages/agenta-playground/src/state/helpers/loadTestsetNormalizedMutation.ts
@@ -1,6 +1,7 @@
 import {loadableController} from "@agenta/entities/runnable"
 import {atom} from "jotai"
 
+import {playgroundCapabilityModeAtom} from "../atoms/modeOverride"
 import {clearAllMessagesAtom} from "../chat/messageReducer"
 import {derivedLoadableIdAtom, isChatModeAtom} from "../execution/selectors"
 
@@ -15,6 +16,20 @@ const MESSAGE_FIELD_KEYS = new Set([
     "target",
     "label",
 ])
+
+/**
+ * Keys to strip when loading completion rows. `messages` is normally dropped
+ * (chat mode reconstructs it into the conversation), but a chat-capable app
+ * running in completion behavior keeps it: there the `messages` column is the
+ * frozen conversation the row renders and runs against
+ * (docs/design/playground-mode-switch/).
+ */
+function strippedFieldKeysForCompletion(keepMessages: boolean): Set<string> {
+    if (!keepMessages) return MESSAGE_FIELD_KEYS
+    const keys = new Set(MESSAGE_FIELD_KEYS)
+    keys.delete("messages")
+    return keys
+}
 
 /**
  * Load testset rows into normalized package state.
@@ -64,8 +79,13 @@ export const loadTestsetNormalizedMutationAtom = atom(
         } else {
             set(loadableController.actions.clearRows, loadableId)
 
+            // Chat-capable apps in completion behavior keep their `messages`
+            // column (the frozen conversation); pure completion apps drop it.
+            const keepMessages = get(playgroundCapabilityModeAtom) === "chat"
+            const strippedKeys = strippedFieldKeysForCompletion(keepMessages)
+
             for (const row of normalizedRows) {
-                const keys = Object.keys(row.data).filter((k) => !MESSAGE_FIELD_KEYS.has(k))
+                const keys = Object.keys(row.data).filter((k) => !strippedKeys.has(k))
                 const data: Record<string, unknown> = {}
 
                 for (const key of keys) {

--- a/web/packages/agenta-playground/src/state/helpers/modeSwitchTransforms.ts
+++ b/web/packages/agenta-playground/src/state/helpers/modeSwitchTransforms.ts
@@ -1,0 +1,92 @@
+/**
+ * Pure transforms for the playground mode switch (chat ⇄ completion).
+ *
+ * Both operate on the serialized testset message format (plain
+ * `{role, content, ...}` objects, the shape `syncChatMessagesToEntity`
+ * writes to the row's `messages` column). They never see working-copy
+ * metadata (sessionId, parentId, run results), so the "history is plain
+ * data" invariant holds by construction.
+ *
+ * Contract (docs/design/playground-mode-switch/, "Product rules"):
+ * - Chat → completion: the conversation up to the last assistant reply
+ *   stays in the `messages` column; the trailing assistant reply moves to
+ *   the row's run result slot. A conversation that does not end with an
+ *   assistant reply (typed-but-unrun user turn, trailing tool call) freezes
+ *   whole, with no output.
+ * - Completion → chat: the column plus the latest output (appended as the
+ *   final assistant turn) become the conversation again.
+ * - Round-trip with no edits is identity.
+ */
+
+/** Serialized chat message as stored in a testset `messages` column. */
+export interface ColumnMessage {
+    role: string
+    content: unknown
+    name?: string
+    tool_call_id?: string
+    tool_calls?: unknown[]
+    [key: string]: unknown
+}
+
+export interface FrozenConversation {
+    /** Turns that stay in the row's `messages` column. */
+    history: ColumnMessage[]
+    /** The trailing assistant reply, surfaced as the row's latest output. */
+    lastOutput?: ColumnMessage
+}
+
+function isColumnMessage(value: unknown): value is ColumnMessage {
+    return (
+        typeof value === "object" &&
+        value !== null &&
+        !Array.isArray(value) &&
+        typeof (value as {role?: unknown}).role === "string"
+    )
+}
+
+/**
+ * Normalizes an unknown `messages` column value into a message list.
+ * Tolerates JSON strings (some testsets store the column stringified)
+ * and filters entries without a `role`.
+ */
+export function normalizeColumnMessages(value: unknown): ColumnMessage[] {
+    let parsed = value
+    if (typeof parsed === "string") {
+        try {
+            parsed = JSON.parse(parsed)
+        } catch {
+            return []
+        }
+    }
+    if (!Array.isArray(parsed)) return []
+    return parsed.filter(isColumnMessage)
+}
+
+/**
+ * Chat → completion: split the conversation into the frozen `messages`
+ * column and the trailing assistant reply (the regenerate target).
+ *
+ * Only a trailing `assistant` message becomes the output. A conversation
+ * ending in a user or tool message freezes whole; the output slot starts
+ * empty and the next Run fills it.
+ */
+export function splitConversationForCompletion(messages: ColumnMessage[]): FrozenConversation {
+    if (messages.length === 0) return {history: []}
+    const last = messages[messages.length - 1]
+    if (last.role !== "assistant") return {history: [...messages]}
+    return {history: messages.slice(0, -1), lastOutput: last}
+}
+
+/**
+ * Completion → chat: the `messages` column plus the latest output become
+ * the conversation. `latestOutput` is appended as the final assistant
+ * turn; earlier runs stay in run history and never re-enter the
+ * conversation.
+ */
+export function mergeConversationFromCompletion(
+    history: ColumnMessage[],
+    latestOutput?: ColumnMessage | null,
+): ColumnMessage[] {
+    if (!latestOutput) return [...history]
+    return [...history, latestOutput]
+}

--- a/web/packages/agenta-playground/src/state/helpers/switchPlaygroundMode.ts
+++ b/web/packages/agenta-playground/src/state/helpers/switchPlaygroundMode.ts
@@ -1,0 +1,80 @@
+/**
+ * Switch the playground between chat and completion behavior for a
+ * chat-capable app, reshaping data so the switch is lossless.
+ *
+ * Chat → completion freezes each loaded conversation into its row: the row's
+ * `messages` column already holds the conversation (kept in sync by the
+ * chat-to-entity adapter), so we split off the trailing assistant reply,
+ * write the remaining history back to the column, and surface that reply as
+ * the row's latest run result.
+ *
+ * Completion → chat reshaping (history + latest output → conversation, with a
+ * picker when several rows are loaded) lands in PR3. Here we only flip; the
+ * load path rebuilds the conversation from the column on next entry.
+ *
+ * Design doc: docs/design/playground-mode-switch/
+ */
+
+import {loadableController} from "@agenta/entities/runnable"
+import {atom, type Getter, type Setter} from "jotai"
+
+import {
+    playgroundCapabilityModeAtom,
+    playgroundModeOverrideAtom,
+    type PlaygroundMode,
+} from "../atoms/modeOverride"
+import {primaryEntityIdAtom} from "../atoms/playground"
+import {completeRunAtom} from "../execution/reducer"
+import {derivedLoadableIdAtom, isChatModeAtom} from "../execution/selectors"
+
+import {normalizeColumnMessages, splitConversationForCompletion} from "./modeSwitchTransforms"
+
+/**
+ * Freeze every loaded conversation into its row, ready for completion runs.
+ * The trailing assistant reply becomes the row's result; the rest stays in
+ * the `messages` column as plain, editable history.
+ */
+function freezeConversationsIntoRows(get: Getter, set: Setter, loadableId: string): void {
+    const rowIds = get(loadableController.selectors.displayRowIds(loadableId)) as string[]
+    const entityId = get(primaryEntityIdAtom)
+
+    for (const rowId of rowIds) {
+        const row = get(loadableController.selectors.row(loadableId, rowId)) as {
+            data?: Record<string, unknown>
+        } | null
+        const messages = normalizeColumnMessages(row?.data?.messages)
+        const {history, lastOutput} = splitConversationForCompletion(messages)
+
+        // Drop the trailing assistant reply from the column; it becomes the
+        // row's output, not part of the frozen history.
+        set(loadableController.actions.updateRow, loadableId, rowId, {messages: history})
+
+        if (lastOutput && entityId) {
+            set(completeRunAtom, {
+                loadableId,
+                stepId: rowId,
+                sessionId: `sess:${entityId}`,
+                result: {output: {response: {data: lastOutput.content}}},
+            })
+        }
+    }
+}
+
+/**
+ * Flip the playground behavior, reshaping data for the chat → completion
+ * direction. No-op when the app is not chat-capable or the target equals the
+ * current behavior.
+ */
+export const switchPlaygroundModeAtom = atom(null, (get, set, target: PlaygroundMode) => {
+    if (get(playgroundCapabilityModeAtom) !== "chat") return
+
+    const current: PlaygroundMode = get(isChatModeAtom) ? "chat" : "completion"
+    if (target === current) return
+
+    const loadableId = get(derivedLoadableIdAtom)
+    if (loadableId && target === "completion") {
+        freezeConversationsIntoRows(get, set, loadableId)
+    }
+
+    set(playgroundModeOverrideAtom, target)
+})

--- a/web/packages/agenta-playground/src/state/helpers/switchPlaygroundMode.ts
+++ b/web/packages/agenta-playground/src/state/helpers/switchPlaygroundMode.ts
@@ -61,6 +61,24 @@ function freezeConversationsIntoRows(get: Getter, set: Setter, loadableId: strin
 }
 
 /**
+ * Whether the current playground holds a conversation with at least one turn.
+ * Drives the confirm dialog: an empty chat switches to completion silently,
+ * since there is nothing to reshape.
+ */
+export const playgroundHasConversationAtom = atom<boolean>((get) => {
+    const loadableId = get(derivedLoadableIdAtom)
+    if (!loadableId) return false
+    const rowIds = get(loadableController.selectors.displayRowIds(loadableId)) as string[]
+    for (const rowId of rowIds) {
+        const row = get(loadableController.selectors.row(loadableId, rowId)) as {
+            data?: Record<string, unknown>
+        } | null
+        if (normalizeColumnMessages(row?.data?.messages).length > 0) return true
+    }
+    return false
+})
+
+/**
  * Flip the playground behavior, reshaping data for the chat → completion
  * direction. No-op when the app is not chat-capable or the target equals the
  * current behavior.

--- a/web/packages/agenta-playground/src/state/index.ts
+++ b/web/packages/agenta-playground/src/state/index.ts
@@ -326,7 +326,10 @@ export {syncChatMessagesToEntityAtom} from "./helpers/syncChatMessagesToEntity"
 
 // Playground mode switch (chat ⇄ completion behavior; see
 // docs/design/playground-mode-switch/)
-export {switchPlaygroundModeAtom} from "./helpers/switchPlaygroundMode"
+export {
+    switchPlaygroundModeAtom,
+    playgroundHasConversationAtom,
+} from "./helpers/switchPlaygroundMode"
 export {
     splitConversationForCompletion,
     mergeConversationFromCompletion,

--- a/web/packages/agenta-playground/src/state/index.ts
+++ b/web/packages/agenta-playground/src/state/index.ts
@@ -324,6 +324,17 @@ export {
 // Chat ↔ entity sync (writes chat messages back to testcase drafts)
 export {syncChatMessagesToEntityAtom} from "./helpers/syncChatMessagesToEntity"
 
+// Playground mode switch (chat ⇄ completion behavior; see
+// docs/design/playground-mode-switch/)
+export {switchPlaygroundModeAtom} from "./helpers/switchPlaygroundMode"
+export {
+    splitConversationForCompletion,
+    mergeConversationFromCompletion,
+    normalizeColumnMessages,
+    type ColumnMessage,
+    type FrozenConversation,
+} from "./helpers/modeSwitchTransforms"
+
 // ============================================================================
 // CONTROLLERS (Public)
 // ============================================================================

--- a/web/packages/agenta-playground/tests/unit/modeSwitchTransforms.test.ts
+++ b/web/packages/agenta-playground/tests/unit/modeSwitchTransforms.test.ts
@@ -1,0 +1,119 @@
+/**
+ * Unit tests for the mode switch transforms.
+ *
+ * The contract under test (docs/design/playground-mode-switch/):
+ * - splitting moves only a trailing assistant reply to the output slot
+ * - conversations ending in user/tool messages freeze whole
+ * - round-trip with no edits is identity, in both directions
+ * - the transforms never invent, drop, or reorder turns
+ */
+import {describe, expect, it} from "vitest"
+
+import {
+    mergeConversationFromCompletion,
+    normalizeColumnMessages,
+    splitConversationForCompletion,
+    type ColumnMessage,
+} from "../../src/state/helpers/modeSwitchTransforms"
+
+const sys: ColumnMessage = {role: "system", content: "You are a support bot."}
+const u1: ColumnMessage = {role: "user", content: "Where is my order?"}
+const a1: ColumnMessage = {role: "assistant", content: "Let me check that for you."}
+const u2: ColumnMessage = {role: "user", content: "Thanks."}
+const a2: ColumnMessage = {role: "assistant", content: "It ships tomorrow."}
+const toolCall: ColumnMessage = {
+    role: "assistant",
+    content: null,
+    tool_calls: [{id: "c1", type: "function", function: {name: "lookup", arguments: "{}"}}],
+}
+const toolResult: ColumnMessage = {role: "tool", content: "order #42: shipped", tool_call_id: "c1"}
+
+describe("splitConversationForCompletion", () => {
+    it("moves the trailing assistant reply to the output slot", () => {
+        const {history, lastOutput} = splitConversationForCompletion([u1, a1, u2, a2])
+        expect(history).toEqual([u1, a1, u2])
+        expect(lastOutput).toEqual(a2)
+    })
+
+    it("freezes a typed-but-unrun user turn into history with no output", () => {
+        const {history, lastOutput} = splitConversationForCompletion([u1, a1, u2])
+        expect(history).toEqual([u1, a1, u2])
+        expect(lastOutput).toBeUndefined()
+    })
+
+    it("treats a trailing tool exchange as history, not output", () => {
+        const {history, lastOutput} = splitConversationForCompletion([u1, toolCall, toolResult])
+        expect(history).toEqual([u1, toolCall, toolResult])
+        expect(lastOutput).toBeUndefined()
+    })
+
+    it("handles the empty conversation", () => {
+        expect(splitConversationForCompletion([])).toEqual({history: []})
+    })
+
+    it("keeps a data system message in history (it is user data, not the template)", () => {
+        const {history, lastOutput} = splitConversationForCompletion([sys, u1, a1])
+        expect(history).toEqual([sys, u1])
+        expect(lastOutput).toEqual(a1)
+    })
+
+    it("does not mutate its input", () => {
+        const input = [u1, a1]
+        splitConversationForCompletion(input)
+        expect(input).toEqual([u1, a1])
+    })
+})
+
+describe("mergeConversationFromCompletion", () => {
+    it("appends the latest output as the final assistant turn", () => {
+        expect(mergeConversationFromCompletion([u1, a1, u2], a2)).toEqual([u1, a1, u2, a2])
+    })
+
+    it("opens history as-is when there is no output yet", () => {
+        expect(mergeConversationFromCompletion([u1, a1, u2], null)).toEqual([u1, a1, u2])
+        expect(mergeConversationFromCompletion([u1, a1, u2])).toEqual([u1, a1, u2])
+    })
+
+    it("turns a variables-only row into an empty conversation", () => {
+        expect(mergeConversationFromCompletion([], null)).toEqual([])
+    })
+})
+
+describe("round trips", () => {
+    it("chat -> completion -> chat is identity", () => {
+        const conversation = [sys, u1, a1, u2, a2]
+        const {history, lastOutput} = splitConversationForCompletion(conversation)
+        expect(mergeConversationFromCompletion(history, lastOutput)).toEqual(conversation)
+    })
+
+    it("completion -> chat -> completion is identity", () => {
+        const history = [u1, a1, u2]
+        const conversation = mergeConversationFromCompletion(history, a2)
+        expect(splitConversationForCompletion(conversation)).toEqual({history, lastOutput: a2})
+    })
+
+    it("repeated round trips do not duplicate or lose turns", () => {
+        let conversation = [u1, a1]
+        for (let i = 0; i < 3; i++) {
+            const {history, lastOutput} = splitConversationForCompletion(conversation)
+            conversation = mergeConversationFromCompletion(history, lastOutput)
+        }
+        expect(conversation).toEqual([u1, a1])
+    })
+})
+
+describe("normalizeColumnMessages", () => {
+    it("passes arrays through and filters non-messages", () => {
+        expect(normalizeColumnMessages([u1, "noise", {no: "role"}, a1])).toEqual([u1, a1])
+    })
+
+    it("parses stringified columns", () => {
+        expect(normalizeColumnMessages(JSON.stringify([u1, a1]))).toEqual([u1, a1])
+    })
+
+    it("returns [] for malformed input", () => {
+        expect(normalizeColumnMessages("{not json")).toEqual([])
+        expect(normalizeColumnMessages({role: "user"})).toEqual([])
+        expect(normalizeColumnMessages(undefined)).toEqual([])
+    })
+})


### PR DESCRIPTION
Stacked on #4609 (the capability/behavior split). Review that first.

## Context

A chat app's playground only runs one conversation at a time. You cannot point it at a table of test cases the way completion apps work. PR #4609 split the app's capability (`is_chat`: accepts a messages input) from the playground behavior. This PR uses that split to let a chat app run as a completion playground over N rows, each carrying its own frozen conversation.

Shipped behind `playgroundModeSwitchEnabledAtom` (default off). The reverse direction (completion to chat) and the sync gate land in the next PR; the toggle turns on once those are in.

## What this adds

A `Chat | Completion` segmented control in the generations header for chat-capable apps. Switching chat to completion freezes each loaded conversation into its row and flips the playground to the completion layout.

The data model reuses the row's existing `messages` column instead of inventing a `history` column. The conversation already lives there (the chat-to-entity adapter keeps it in sync), so the switch is a small transform: split off the trailing assistant reply, keep the rest as the row's frozen history, surface that reply as the row's latest result.

Runs in this mode stay chat-shaped but scope per row. Each row sends its own `messages` column as the chat history plus its variables, and the reply lands in the row's result slot. Before, a chat app could only build history from the single per-playground conversation:

Run request for a frozen row (verified on the dev deployment):
\`\`\`json
{"data": {"inputs": {
  "context": "",
  "messages": [{"role": "user", "content": "I need to cancel my reservation."}]
}, "parameters": {"prompt": {"messages": [{"role": "system", "...": "..."}]}}}}
\`\`\`
The system template stays in `parameters`, never duplicated into the conversation.

## Changes

- **State**: `modeSwitchTransforms.ts` (pure split/merge, 15 unit tests including round-trip identity); `switchPlaygroundModeAtom` freezes conversations on switch; the run path (`executionItems.ts`) scopes per row and reads history from the row column when a chat app runs in completion behavior; the completion load path keeps the `messages` column for chat-capable apps.
- **Chrome**: `ModeSwitcher` segmented control + confirm dialog in `ExecutionHeader`, behind the flag, disabled in compare view. Collapse-all relocates to an icon-only button when the switcher shows.

## Tests / notes

- 88 `@agenta/playground` unit tests pass; `@agenta/playground` and `@agenta/playground-ui` build; lint clean.
- Verified end to end on the dev box with the flag forced on: built a conversation in a chat app, switched to Completion (confirm dialog shown, last reply became the row output), and Run posted the row's frozen `messages` as chat history with the `context` variable and no system-message duplication.
- Deferred to the next PR (not blockers; the switch is lossless without them): the editable messages-column card in completion rows (the frozen history is preserved and runs correctly but currently hidden as an unreferenced column), the post-switch info banner, and the completion to chat reverse direction with its picker and sync gate.