### PR TITLE
fix(frontend): show correct breadcrumb label for SDK evals

### DIFF
--- a/web/oss/src/components/EvalRunDetails/components/Page.tsx
+++ b/web/oss/src/components/EvalRunDetails/components/Page.tsx
@@ -50,6 +50,7 @@ const EvalRunPreviewPage = ({runId, evaluationType, projectId = null}: EvalRunPr
             auto: {label: "Auto Evals", kind: "auto"},
             human: {label: "Human Evals", kind: "human"},
             online: {label: "Live Evals", kind: "online"},
+            sdk: {label: "SDK Evals", kind: "sdk"},
         }
         const config = typeMap[evaluationType] ?? {label: "Evaluations", kind: "auto"}
         return {


### PR DESCRIPTION
## Summary
The `typeMap` in `EvalRunDetails/components/Page.tsx` was missing an entry for the `sdk` evaluation type. This caused SDK evals to always show "Auto Evals" in breadcrumbs. Added `sdk: {label: "SDK Evals", kind: "sdk"}` to fix this.

## Testing
### Verified locally
Traced the bug to the missing `sdk` key in typeMap. Fix confirmed via grep.

### Added or updated tests
N/A

### QA follow-up
Verify breadcrumbs show "SDK Evals" when viewing an SDK evaluation run.

## Demo
Recording in progress — will update within 24 hours.

## Checklist
- [ ] I have included a video or screen recording for UI changes
- [x] I have signed the CLA