### PR TITLE
fix(frontend): keep playground drafts when connecting a test set

### DIFF
--- a/docs/design/playground-keep-drafts-on-testset-connect/README.md
+++ b/docs/design/playground-keep-drafts-on-testset-connect/README.md
@@ -1,0 +1,32 @@
+# Keep playground draft rows when connecting a test set
+
+Planning workspace for fixing the UX where draft test cases in the playground
+(opened from a trace, or created manually) are silently destroyed when the user
+connects a test set.
+
+## Files
+
+- [context.md](context.md): why this work exists, the reported UX issue, goals
+  and non-goals.
+- [research.md](research.md): codebase findings. The full data flow from trace
+  to playground, the exact root cause of the silent data loss, the existing
+  building blocks we can reuse, and the caveats (chat mode, empty initial row,
+  column mismatches).
+- [plan.md](plan.md): proposed fix, UX flow, implementation phases, and test
+  plan.
+- [status.md](status.md): current progress and open decisions. Source of truth
+  for where the work stands.
+
+## TL;DR
+
+When the playground is in local mode (not connected to a test set) and holds
+draft rows, "Connect test set" replaces those rows with the selected test set
+with no warning. The guard modal that exists for "Change test set" never fires
+because (a) the not-connected menu path skips it and (b) the `hasLocalChanges`
+selector returns `false` by design when not connected.
+
+The fix: detect meaningful local draft rows at connect time, ask the user
+whether to keep them, and on "keep" connect to the test set then re-import the
+captured rows as unsaved additions. The existing `importRows` + `commitChanges`
+machinery already supports "unsaved rows on top of a connected test set, then
+sync back", so no new persistence logic is needed.

--- a/docs/design/playground-keep-drafts-on-testset-connect/context.md
+++ b/docs/design/playground-keep-drafts-on-testset-connect/context.md
@@ -1,0 +1,50 @@
+# Context
+
+## The reported UX issue
+
+Reported by Mahmoud on 2026-06-09.
+
+1. The user opens a trace in the playground (trace drawer > "Playground"
+   button). The playground is linked to the application, and the trace inputs
+   appear as a test case row. Functionally this is the same state as creating
+   test cases manually in the playground: local draft rows, no connected test
+   set.
+2. The user then connects ("syncs") a test set from the Test set dropdown.
+3. Expected: a modal asking whether to keep the playground test cases and add
+   them (as unsaved rows) to the loaded test set, so the user can review them
+   alongside the test set rows and later sync them back into the test set.
+4. Actual: the playground silently replaces the draft rows with the test set
+   rows. The trace-derived test case is lost with no warning.
+
+## Why this matters
+
+The trace-to-playground flow exists so users can take a real production input
+and iterate on it. A natural next step is "add this interesting case to my
+test set". Today that path destroys the case at the exact moment the user
+tries to combine it with the test set. There is no undo.
+
+## Goals
+
+- Never silently destroy meaningful draft rows on test set connect.
+- Offer "keep and add": connect the test set, append the previous draft rows
+  as unsaved additions, and let the user sync them back via the existing
+  "Sync changes" commit flow.
+- Offer "discard": today's replace behavior, but explicit.
+- Cover both trace-derived rows and manually created rows. The system does not
+  distinguish them (see research.md), and the expectation is the same.
+
+## Non-goals
+
+- Changing the existing connected-mode "Change test set" guard
+  (TestsetDisconnectConfirmModal). It already prompts with Save / Discard.
+  Unifying the two prompts can come later.
+- Changing the "Add to test set" drawer flow (trace > testset directly).
+- Persisting kept rows automatically. Kept rows stay unsaved until the user
+  syncs, by design ("temporarily added").
+- Chat playground multi-row support. Chat mode has a deliberate single-row
+  gate (see research.md); v1 keeps chat behavior as is.
+
+## Related memory
+
+The repo memory note "Recent Prompts green dots bug" is unrelated. No prior
+planning doc covers this area; `docs/design/` has no playground testset doc.

--- a/docs/design/playground-keep-drafts-on-testset-connect/plan.md
+++ b/docs/design/playground-keep-drafts-on-testset-connect/plan.md
@@ -1,0 +1,111 @@
+# Plan
+
+## Proposed UX
+
+User is in local mode with meaningful draft rows (from a trace or manual
+entry) and connects a test set:
+
+1. User opens Test set dropdown > "Connect test set", picks a test set and
+   test cases, clicks "Load Selected".
+2. New modal appears (only when meaningful draft rows exist):
+
+   - Title: `Keep your draft test cases?`
+   - Body: `Your playground has {n} draft test case{s} that are not part of
+     "{testsetName}". Keep them to add them to the loaded test set as unsaved
+     rows. You can review them and sync them to the test set afterwards.`
+   - Buttons:
+     - `Keep and add` (primary): connect, then append the captured draft rows
+       as unsaved additions.
+     - `Discard` (default, danger styling): today's replace behavior.
+     - `Cancel`: back to the playground unchanged (selection modal already
+       closed; acceptable for v1).
+
+3. After "Keep and add": the table shows the test set rows plus the draft
+   rows. `hasLocalChanges` is true, so the dropdown shows "Sync changes".
+   Committing creates a new test set revision that includes the kept rows.
+   This is the existing commit flow, unchanged.
+
+Copy is a draft. Final copy review against the writing-style guidelines (no
+em dashes, active voice, short sentences) before merge.
+
+## Implementation phases
+
+### Phase 1: state layer (packages)
+
+1. **`hasMeaningfulLocalRows` selector** in the loadable controller
+   (`web/packages/agenta-entities/src/loadable/controller.ts`), exposed via
+   `loadableController.selectors`. True when the loadable is in local mode and
+   at least one display row's data has a non-empty value (trim strings, skip
+   system fields). This intentionally stays separate from `hasLocalChanges`,
+   whose "false when not connected" contract other features depend on.
+2. **`connectToTestsetKeepingLocalRows` compound action** in
+   `playgroundController`
+   (`web/packages/agenta-playground/src/state/controllers/playgroundController.ts`):
+   - Capture current local rows: `displayRowIds` + `testcaseMolecule` data,
+     filtered to meaningful rows.
+   - Call existing `connectToTestsetAtom` with the selected test set rows.
+   - Call existing `importTestcasesAtom` with the captured rows.
+   - Chat mode: do not offer keep (the caller skips the prompt); the action
+     can still guard defensively by falling back to plain connect.
+   Orchestration lives in the package so it is unit-testable and the app layer
+   stays thin (per `agenta-package-practices`).
+
+### Phase 2: app layer (modal + wiring)
+
+3. **Keep/discard modal** in
+   `web/oss/src/components/Playground/Components/Modals/`. Either:
+   - extend `TestsetDisconnectConfirmModal` with a new intent
+     (`"keep-local-rows"`) and per-intent buttons, or
+   - add a sibling `KeepDraftRowsModal` using `EnhancedModal` from
+     `@agenta/ui`, with a small state atom like the disconnect modal's.
+   Recommendation: a sibling modal. The disconnect modal's Save/Discard
+   semantics differ enough that overloading it would muddy both.
+4. **Wire `handleLoadConfirm`** in
+   `web/oss/src/components/Playground/Components/TestsetDropdown/index.tsx`:
+   in the connect branch (not `importMode === "import"`), when
+   `hasMeaningfulLocalRows && !isChatPlayground`, stash the pending payload in
+   the modal atom and open the modal instead of connecting immediately.
+   Modal "Keep and add" calls `connectToTestsetKeepingLocalRows`; "Discard"
+   calls `connectToTestset` as today.
+5. **Wire `handleCreateAndLoad`** the same way (Create & Load currently wipes
+   draft rows into a brand-new empty test set, the worst case of this bug).
+
+### Phase 3: QA and polish
+
+6. Package unit tests (in `tests/unit/` per package practices):
+   - capture + connect + import leaves test set rows plus kept rows, kept rows
+     in `newEntityIdsAtom`, `hasLocalChanges` true.
+   - empty initial row does not count as meaningful.
+   - chat mode falls back to plain connect.
+7. Manual QA on the dev stack (debug-local-deployment skill):
+   - trace > playground > connect test set > keep > sync changes > verify the
+     new revision contains the trace row.
+   - same with manual rows; same with Discard; same with Create & Load.
+   - trace row whose input keys do not match the test set columns (expect
+     "(new)" column behavior, no crash).
+8. `pnpm lint-fix` in `web`, copy review.
+
+## Decisions (confirmed with Mahmoud, 2026-06-09)
+
+1. **Modal placement**: prompt after the selection modal confirm. Decided:
+   modal.
+2. **Chat mode**: show a warning modal ("Replace the current conversation?")
+   instead of the keep option, since the chat playground loads one test case
+   at a time. Decided: warning modal.
+3. **Connected-mode "Change test set"**: the existing Save/Discard guard
+   stays as is for v1.
+4. **UX and copy**: delegated. Final copy: title "Keep your draft test
+   cases?", buttons Cancel / "Discard drafts" (danger) / "Keep and load"
+   (primary). Chat variant: title "Replace the current conversation?",
+   buttons Cancel / "Load and replace" (primary, danger). "Keep and load" is
+   the emphasized button because it is the safe, non-destructive action.
+
+## Risks
+
+- `connectToSource` clears entity state; if capture happens after, data is
+  gone. The compound action owns the ordering, and a unit test pins it.
+- Imported rows with mismatched columns surface as "(new)" columns on commit.
+  Acceptable, but QA item 7 verifies it.
+- The selection modal's preselect logic in load mode assumes a clean slate;
+  importing afterwards does not touch selection drafts, so no conflict is
+  expected. Verify during QA.

--- a/docs/design/playground-keep-drafts-on-testset-connect/research.md
+++ b/docs/design/playground-keep-drafts-on-testset-connect/research.md
@@ -1,0 +1,200 @@
+# Research
+
+All paths relative to repo root. Line numbers as of 2026-06-09 on
+`gitbutler/workspace`.
+
+## 1. How a trace becomes playground rows
+
+Entry point: the "Playground" button in the trace drawer.
+
+- `web/oss/src/components/SharedDrawers/TraceDrawer/components/TraceContent/components/TraceTypeHeader/index.tsx`
+  - Button at lines 220-231, handler `handleOpenInPlayground` at 130-189.
+  - Writes `openTraceInPlaygroundAtom`
+    (`web/oss/src/components/SharedDrawers/TraceDrawer/store/openInPlayground.ts:18-23`),
+    which delegates to `playgroundController.actions.openFromTrace`.
+  - If the trace resolves to an app revision, navigates to
+    `/app/{appId}/playground?revisions={entityId}`.
+
+Transformation: `openFromTraceAtom` in
+`web/packages/agenta-playground/src/state/controllers/playgroundController.ts:1114-1651`.
+
+- Extracts inputs/outputs/parameters from the span, resolves app or evaluator
+  references, then inserts the row via
+  `loadableController.actions.setRows(loadableId, [{id: "trace-input-0", data}])`
+  (lines 1310, 1360, 1405, 1563 for the four span variants).
+
+Important detail: `setRowsAtom`
+(`web/packages/agenta-entities/src/loadable/controller.ts:747-768`) **ignores
+the passed row id**. It deletes existing molecule entities and calls
+`testcaseMolecule.actions.add({data})`, which assigns a fresh local id
+(`new-...`). So trace-derived rows are plain local testcase entities,
+indistinguishable from manually created rows. There is no "from trace" marker
+in state. This matches the user's framing: the fix must treat trace rows and
+manual rows identically.
+
+After this flow the playground loadable is in **local mode**:
+`loadableState.connectedSourceId == null`, `connectedTestsetAtom` holds
+`{id: null, name: "<generated local name>"}`.
+
+## 2. How "Connect test set" works and where rows get destroyed
+
+UI: `web/oss/src/components/Playground/Components/TestsetDropdown/index.tsx`.
+
+Menu when **not connected** (lines 457-474):
+
+```ts
+{key: "connect", label: "Connect test set", onClick: () => setSelectionModalMode("load")}
+```
+
+No guard of any kind. Compare the **connected** menu's "Change test set"
+(`handleChangeTestset`, lines 367-385), which checks `hasLocalChanges` and
+routes through `TestsetDisconnectConfirmModal` (Save & load / Discard & load /
+Cancel) before opening the selection modal.
+
+Selection modal: `TestsetSelectionModal` in
+`web/packages/agenta-playground-ui/src/components/TestsetSelectionModal/`
+("load" mode). On confirm, `handleLoadConfirm` (TestsetDropdown lines 245-277)
+runs:
+
+- `importMode === "import"` (only set in edit mode for a different revision):
+  `playgroundController.actions.importTestcases` adds rows without touching
+  the connection.
+- Otherwise (the connect path): `playgroundController.actions.connectToTestset`.
+
+`connectToTestsetAtom`
+(`web/packages/agenta-playground/src/state/controllers/playgroundController.ts:535-597`)
+normalizes rows, applies the chat single-row gate, then calls
+`loadableController.actions.connectToSource`.
+
+**The destruction happens here.** `connectToSourceAtom`
+(`web/packages/agenta-entities/src/loadable/controller.ts:935-986`):
+
+```ts
+// Clear local entities before connecting to a new source
+// This ensures Replace mode fully replaces existing data
+set(clearNewEntityIdsAtom)
+set(clearDeletedIdsAtom)
+set(resetTestcaseIdsAtom)
+```
+
+Local draft rows (trace-derived or manual) are cleared, then the test set rows
+are written into the query cache and draft atoms. Nothing captures the old
+rows first.
+
+## 3. Why the existing guard never fires
+
+`hasLocalChanges` resolves to `connectedHasLocalChangesAtomFamily`
+(`web/packages/agenta-entities/src/loadable/controller.ts:441-476`):
+
+```ts
+// Not connected - no "local changes" concept
+if (!state.connectedSourceId) {
+    return false
+}
+```
+
+So in local mode the selector is `false` **by design**, regardless of how many
+draft rows exist. Even if the not-connected menu item routed through
+`handleChangeTestset`, the guard would not trigger. Two independent gaps:
+
+1. The not-connected "Connect test set" path has no guard wiring.
+2. The dirty-detection selector excludes local mode.
+
+## 4. Building blocks that already implement the desired end state
+
+The user's expected flow ("test set loaded, playground rows added on top as
+temporary rows, then sync back") is already expressible with existing actions:
+
+- `importRowsAtom`
+  (`web/packages/agenta-entities/src/loadable/controller.ts:671-742`): adds
+  testcases as **new local entities without changing the connection**. New
+  entities land in `newEntityIdsAtom`.
+- Once connected, any entries in `newEntityIdsAtom` make
+  `hasLocalChanges === true` (controller.ts:451-455), which enables the
+  "Sync changes" menu item (TestsetDropdown line 478-482).
+- "Sync changes" opens `EntityCommitModal` and calls `commitChangesAtom`
+  (controller.ts:1087-1177), which commits via `saveTestsetAtom`, creates a
+  new revision including the new rows, and reconnects to it.
+
+So `connect, then import the captured rows` produces exactly: test set rows +
+previous playground rows as unsaved additions + working "Sync changes" path.
+No new persistence logic is needed.
+
+Playground-level wrapper: `importTestcasesAtom`
+(`web/packages/agenta-playground/src/state/controllers/playgroundController.ts:608-632`)
+adds the chat-message seeding on top of `importRows`. Reuse it rather than
+calling the loadable action directly.
+
+Capture before connect: row data is readable via
+`loadableController.selectors.displayRowIds(loadableId)` plus
+`testcaseMolecule.get.data(id)` (the same pattern `handleLoadConfirm` already
+uses for the selected test set rows). Capture must happen **before**
+`connectToSource` runs, because it clears the entities.
+
+Existing modal to model after (or extend):
+`web/oss/src/components/Playground/Components/Modals/TestsetDisconnectConfirmModal/index.tsx`
+with its state atom at `.../store/state.ts` (intents: "disconnect",
+"change-testset").
+
+## 5. Caveats and edge cases
+
+### a. Fresh playgrounds seed one empty row
+
+`addPrimaryNodeAtom`
+(`web/packages/agenta-playground/src/state/controllers/playgroundController.ts:186-238`)
+links the loadable and creates an initial empty row (unless
+`skipInitialRow`). A naive "any local rows exist" check would prompt every
+first-time connect. The detection must be "at least one local row whose data
+contains a non-empty value" (trim strings, ignore system fields). Call this
+`hasMeaningfulLocalRows` below.
+
+### b. Chat mode single-row gate
+
+`connectToTestsetAtom` (lines 553-568) and `importTestcasesAtom` (lines
+613-617) both slice to one row in chat mode, deliberately (QA decision
+2026-06-01, documented in the code). "Keep and add" in chat mode would either
+exceed the gate or silently drop rows. v1 decision: skip the prompt in chat
+mode and keep today's replace behavior there.
+
+### c. Column mismatch between draft rows and the test set
+
+A trace row's input keys may differ from the test set's columns. Imported
+rows keep their own keys; the connected view filters columns at the view layer
+(`connectedRowsAtomFamily`, see comment at controller.ts:922-924) and
+`newColumnKeysAtomFamily` (controller.ts:486-520) marks columns "(new)". The
+selection modal already surfaces compatibility warnings
+(`SelectionSummary.tsx`). Behavior is acceptable for v1: mismatched keys show
+as new columns and commit as such. Worth one manual QA pass with a trace whose
+inputs do not match the test set schema.
+
+### d. Where the prompt can hook in
+
+`handleLoadConfirm` (TestsetDropdown lines 245-277) is the single funnel for
+the connect decision in load mode. The "Create & Load" path
+(`handleCreateAndLoad`, lines 309-348) also calls `connectToTestset` and
+clears rows the same way; it creates an **empty** test set, so "keep" arguably
+matters even more there (otherwise Create & Load from a trace produces an
+empty playground). Include it.
+
+### e. `TestsetSelectionPayload.importMode === "import"`
+
+The import branch in `handleLoadConfirm` does not destroy rows, so the prompt
+must only wrap the connect branch.
+
+## 6. Reference: file map
+
+| Concern | File | Lines |
+|---|---|---|
+| Trace drawer button | `web/oss/src/components/SharedDrawers/TraceDrawer/components/TraceContent/components/TraceTypeHeader/index.tsx` | 130-189, 220-231 |
+| Trace transform | `web/packages/agenta-playground/src/state/controllers/playgroundController.ts` | 1114-1651 |
+| Row clearing on connect | `web/packages/agenta-entities/src/loadable/controller.ts` | 935-986 |
+| setRows (id not preserved) | `web/packages/agenta-entities/src/loadable/controller.ts` | 747-768 |
+| Dirty detection (local mode excluded) | `web/packages/agenta-entities/src/loadable/controller.ts` | 441-476 |
+| importRows | `web/packages/agenta-entities/src/loadable/controller.ts` | 671-742 |
+| commitChanges (sync back) | `web/packages/agenta-entities/src/loadable/controller.ts` | 1087-1177 |
+| connectToTestset + chat gate | `web/packages/agenta-playground/src/state/controllers/playgroundController.ts` | 535-597 |
+| importTestcases wrapper | `web/packages/agenta-playground/src/state/controllers/playgroundController.ts` | 608-632 |
+| Initial empty row | `web/packages/agenta-playground/src/state/controllers/playgroundController.ts` | 186-238 |
+| Dropdown + confirm funnel | `web/oss/src/components/Playground/Components/TestsetDropdown/index.tsx` | 245-348, 367-385, 457-474 |
+| Existing guard modal | `web/oss/src/components/Playground/Components/Modals/TestsetDisconnectConfirmModal/index.tsx` | all |
+| Selection modal | `web/packages/agenta-playground-ui/src/components/TestsetSelectionModal/` | all |

--- a/docs/design/playground-keep-drafts-on-testset-connect/status.md
+++ b/docs/design/playground-keep-drafts-on-testset-connect/status.md
@@ -1,12 +1,28 @@
 # Status
 
-Last updated: 2026-06-09
+Last updated: 2026-06-10
 
 ## Current state
 
-**Implemented, unit-tested, lint and package builds green.** Committed on
-`fix/playground-keep-drafts-on-testset-connect`, PR stacked on
-`release/v0.103.0` (the v0.103.0 release PR, #4584). Manual QA pending.
+**Implemented, unit-tested, QA-round-1 bugs fixed and re-verified on the dev
+stack.** Committed on `fix/playground-keep-drafts-on-testset-connect`, PR
+#4604 stacked on `release/v0.103.0` (the v0.103.0 release PR, #4584).
+
+## QA round 1 (2026-06-10)
+
+QA reported three bugs against the first commit: Cancel still loaded the
+test set, the modal fired with an inflated draft count, and the picked test
+set rows rendered behind the modal. All three shared one root cause: the
+selection modal committed the picked ids into the global testcase ids atom
+(`commitSelectionDraft`) before the keep/discard decision. Fixed in two
+layers: `LoadModeContent` load mode now discards the draft instead of
+committing it (the connect populates ids itself), and `TestsetDropdown`
+clears stale ids in local mode before measuring drafts. A follow-up review
+also found and fixed: `meaningfulLocalRows` counted rows the user had
+removed (`hiddenTestcaseIds`), which would have resurrected deleted rows on
+keep; and a guard against confirming the selection modal with no real test
+set picked (the `"local"` sentinel). All three QA scenarios plus the
+no-draft and keep paths re-verified in Chrome against the dev stack.
 
 ## Done
 

--- a/docs/design/playground-keep-drafts-on-testset-connect/status.md
+++ b/docs/design/playground-keep-drafts-on-testset-connect/status.md
@@ -1,0 +1,71 @@
+# Status
+
+Last updated: 2026-06-09
+
+## Current state
+
+**Implemented, unit-tested, lint and package builds green.** Committed on
+`fix/playground-keep-drafts-on-testset-connect`, PR stacked on
+`release/v0.103.0` (the v0.103.0 release PR, #4584). Manual QA pending.
+
+## Done
+
+- Research and root cause analysis ([research.md](research.md)).
+- Decisions confirmed with Mahmoud ([plan.md](plan.md) Decisions section):
+  post-confirm modal; chat gets a warning modal; connected-mode change-testset
+  guard untouched; copy delegated.
+- Implementation:
+  - `meaningfulLocalRows` selector in
+    `web/packages/agenta-entities/src/loadable/controller.ts` (local-mode rows
+    with user-entered data; blank seeded rows and blank chat message shells
+    excluded; returns [] when connected).
+  - `connectToTestsetKeepingLocalRows` compound action in
+    `web/packages/agenta-playground/src/state/controllers/playgroundController.ts`
+    (capture before connect, then re-import as unsaved additions; plain
+    connect fallback in chat mode). `ConnectToTestsetPayload` is now exported
+    from `@agenta/playground`.
+  - `KeepDraftRowsModal` in
+    `web/oss/src/components/Playground/Components/Modals/KeepDraftRowsModal/`
+    with variants `keep` and `chat-replace`.
+  - Wiring in
+    `web/oss/src/components/Playground/Components/TestsetDropdown/index.tsx`:
+    `handleLoadConfirm` opens the modal when meaningful drafts exist;
+    `handleCreateAndLoad` keeps drafts unconditionally (the created test set
+    is empty, so they become the first unsaved rows).
+- Tests (all passing):
+  - `web/packages/agenta-entities/tests/unit/loadable-meaningful-local-rows.test.ts`
+    (7 tests).
+  - `web/packages/agenta-playground/tests/unit/connectToTestsetKeepingLocalRows.test.ts`
+    (3 tests).
+- `pnpm turbo run build --filter=@agenta/entities --filter=@agenta/playground`
+  and `pnpm lint-fix` pass. OSS `types:check` reports no errors in the
+  changed files (the suite has many pre-existing failures elsewhere).
+
+## Next steps
+
+1. Manual QA on the dev stack (see plan.md Phase 3, item 7): trace > connect
+   test set > keep > sync changes; discard path; Create & Load with drafts;
+   chat warning; trace row with mismatched columns.
+2. Commit and open a PR.
+
+## Known limitations (accepted for v1)
+
+- Chat mode: drafts cannot be kept (single-testcase gate); the modal only
+  warns. Create & Load in chat still replaces the conversation silently,
+  matching previous behavior.
+- Kept rows with columns missing from the test set surface as "(new)" columns
+  on commit (existing view-layer behavior).
+- Chat-mode coverage is manual only: `isChatModeAtom` is derived from the
+  workflow molecule, which the unit harness does not stand up.
+
+## Decisions log
+
+- 2026-06-09: scope v1 to the local-mode connect path (and Create & Load);
+  leave the connected-mode change-testset guard unchanged. Confirmed.
+- 2026-06-09: treat trace-derived and manual rows identically. The state
+  layer cannot distinguish them anyway (`setRows` discards the
+  `trace-input-0` id), and the user expectation is the same.
+- 2026-06-09: chat mode shows a replace warning instead of a keep option.
+  Confirmed by Mahmoud.
+- 2026-06-09: Create & Load keeps drafts without prompting; the alternative
+  silently wipes them into an empty test set.

--- a/web/oss/src/components/Playground/Components/Modals/KeepDraftRowsModal/index.tsx
+++ b/web/oss/src/components/Playground/Components/Modals/KeepDraftRowsModal/index.tsx
@@ -1,0 +1,92 @@
+import {playgroundController} from "@agenta/playground"
+import {EnhancedModal, ModalContent} from "@agenta/ui"
+import {Button, Typography} from "antd"
+import {useAtomValue, useSetAtom} from "jotai"
+
+import {initialKeepDraftRowsState, keepDraftRowsModalAtom} from "./store/state"
+
+/**
+ * Shown when connecting a test set would clear local draft rows (created
+ * manually or by opening a trace in the playground). Lets the user keep the
+ * drafts as unsaved additions to the loaded test set, or discard them.
+ *
+ * In chat mode only one testcase can load at a time, so the modal degrades
+ * to a warning that loading replaces the drafted conversation.
+ */
+const KeepDraftRowsModal = () => {
+    const {open, variant, draftCount, targetTestsetName, pendingPayload} =
+        useAtomValue(keepDraftRowsModalAtom)
+    const setModalState = useSetAtom(keepDraftRowsModalAtom)
+    const connectToTestset = useSetAtom(playgroundController.actions.connectToTestset)
+    const connectKeepingDrafts = useSetAtom(
+        playgroundController.actions.connectToTestsetKeepingLocalRows,
+    )
+
+    const testsetLabel = targetTestsetName?.trim() || "the test set"
+    const isChatVariant = variant === "chat-replace"
+
+    const title = isChatVariant
+        ? "Replace the current conversation?"
+        : "Keep your draft test cases?"
+
+    const descriptionLine1 = isChatVariant
+        ? `Loading ${testsetLabel} replaces the conversation in the playground.`
+        : draftCount === 1
+          ? "You have 1 draft test case in the playground."
+          : `You have ${draftCount} draft test cases in the playground.`
+
+    const descriptionLine2 = isChatVariant
+        ? "The chat playground loads one test case at a time, so the conversation cannot be kept."
+        : `You can keep ${draftCount === 1 ? "it" : "them"} and load ${testsetLabel} alongside. Kept test cases stay unsaved until you sync changes back to the test set.`
+
+    const handleClose = () => {
+        setModalState(initialKeepDraftRowsState)
+    }
+
+    const handleDiscardAndLoad = () => {
+        if (pendingPayload) connectToTestset(pendingPayload)
+        handleClose()
+    }
+
+    const handleKeepAndLoad = () => {
+        if (pendingPayload) connectKeepingDrafts(pendingPayload)
+        handleClose()
+    }
+
+    return (
+        <EnhancedModal
+            open={open}
+            onCancel={handleClose}
+            footer={
+                <div className="flex items-center justify-end gap-2 pt-2">
+                    <Button type="text" onClick={handleClose}>
+                        Cancel
+                    </Button>
+                    {isChatVariant ? (
+                        <Button type="primary" danger onClick={handleDiscardAndLoad}>
+                            Load and replace
+                        </Button>
+                    ) : (
+                        <>
+                            <Button danger onClick={handleDiscardAndLoad}>
+                                Discard drafts
+                            </Button>
+                            <Button type="primary" onClick={handleKeepAndLoad}>
+                                Keep and load
+                            </Button>
+                        </>
+                    )}
+                </div>
+            }
+            title={title}
+            width={500}
+        >
+            <ModalContent gap="small">
+                <Typography.Text>{descriptionLine1}</Typography.Text>
+                <Typography.Text>{descriptionLine2}</Typography.Text>
+            </ModalContent>
+        </EnhancedModal>
+    )
+}
+
+export default KeepDraftRowsModal

--- a/web/oss/src/components/Playground/Components/Modals/KeepDraftRowsModal/store/state.ts
+++ b/web/oss/src/components/Playground/Components/Modals/KeepDraftRowsModal/store/state.ts
@@ -1,0 +1,33 @@
+import type {ConnectToTestsetPayload} from "@agenta/playground"
+import {atom} from "jotai"
+
+/**
+ * "keep": completion playground with local draft rows. Offers keeping the
+ * drafts as unsaved additions to the loaded test set, or discarding them.
+ *
+ * "chat-replace": chat playground with a drafted conversation. The chat
+ * playground loads one testcase at a time, so drafts cannot be kept; the
+ * modal only warns that loading replaces the conversation.
+ */
+export type KeepDraftRowsVariant = "keep" | "chat-replace"
+
+interface KeepDraftRowsModalState {
+    open: boolean
+    variant: KeepDraftRowsVariant
+    /** Number of meaningful draft rows, for the modal copy */
+    draftCount: number
+    /** Name of the test set the user picked, for the modal copy */
+    targetTestsetName: string | null
+    /** The connect payload to run once the user decides */
+    pendingPayload: ConnectToTestsetPayload | null
+}
+
+export const initialKeepDraftRowsState: KeepDraftRowsModalState = {
+    open: false,
+    variant: "keep",
+    draftCount: 0,
+    targetTestsetName: null,
+    pendingPayload: null,
+}
+
+export const keepDraftRowsModalAtom = atom<KeepDraftRowsModalState>(initialKeepDraftRowsState)

--- a/web/oss/src/components/Playground/Components/TestsetDropdown/index.tsx
+++ b/web/oss/src/components/Playground/Components/TestsetDropdown/index.tsx
@@ -48,6 +48,8 @@ import {toTestsetTraceReference, type TestsetTraceReference} from "@/oss/lib/tra
 import {saveNewTestsetAtom} from "@/oss/state/entities/testset/mutations"
 import {projectIdAtom} from "@/oss/state/project/selectors/project"
 
+import KeepDraftRowsModal from "../Modals/KeepDraftRowsModal"
+import {keepDraftRowsModalAtom} from "../Modals/KeepDraftRowsModal/store/state"
 import TestsetDisconnectConfirmModal from "../Modals/TestsetDisconnectConfirmModal"
 import {testsetDisconnectConfirmModalAtom} from "../Modals/TestsetDisconnectConfirmModal/store/state"
 
@@ -125,6 +127,9 @@ export function TestsetDropdown() {
 
     // ── Actions ────────────────────────────────────────────────────────────
     const connectToTestset = useSetAtom(playgroundController.actions.connectToTestset)
+    const connectKeepingDrafts = useSetAtom(
+        playgroundController.actions.connectToTestsetKeepingLocalRows,
+    )
     const importTestcases = useSetAtom(playgroundController.actions.importTestcases)
     const disconnectAndReset = useSetAtom(playgroundController.actions.disconnectAndResetToLocal)
     const updateTestcaseSelection = useSetAtom(loadableController.actions.updateTestcaseSelection)
@@ -134,6 +139,7 @@ export function TestsetDropdown() {
     const initSelectionDraft = useSetAtom(testcaseMolecule.actions.initSelectionDraft)
     const saveNewTestset = useSetAtom(saveNewTestsetAtom)
     const setDisconnectConfirmModalState = useSetAtom(testsetDisconnectConfirmModalAtom)
+    const setKeepDraftRowsModalState = useSetAtom(keepDraftRowsModalAtom)
     const store = useStore()
     const {canExportData} = useProjectPermissions()
 
@@ -261,19 +267,46 @@ export function TestsetDropdown() {
                     const data = testcaseMolecule.get.data(id)
                     return data ? {...(data as Record<string, unknown>)} : {id}
                 })
-                connectToTestset({
+                const connectPayload = {
                     loadableId,
                     revisionId: payload.revisionId,
                     testcases,
                     testsetName: payload.testsetName ?? "",
                     testsetId: payload.testsetId ?? null,
                     revisionVersion: payload.revisionVersion ?? null,
-                })
+                }
+
+                // Connecting clears local rows. If the playground holds draft
+                // test cases (typed manually or opened from a trace), ask the
+                // user first instead of silently discarding them.
+                const draftRows = store.get(
+                    loadableController.selectors.meaningfulLocalRows(loadableId),
+                )
+                if (draftRows.length > 0) {
+                    setKeepDraftRowsModalState({
+                        open: true,
+                        variant: isChatPlayground ? "chat-replace" : "keep",
+                        draftCount: draftRows.length,
+                        targetTestsetName: payload.testsetName ?? null,
+                        pendingPayload: connectPayload,
+                    })
+                    setSelectionModalMode(null)
+                    return
+                }
+
+                connectToTestset(connectPayload)
             }
 
             setSelectionModalMode(null)
         },
-        [loadableId, connectToTestset, importTestcases],
+        [
+            loadableId,
+            connectToTestset,
+            importTestcases,
+            store,
+            isChatPlayground,
+            setKeepDraftRowsModalState,
+        ],
     )
 
     // ── Edit mode: update visible rows without changing connection ─────────
@@ -323,9 +356,11 @@ export function TestsetDropdown() {
             })
 
             if (result.success && result.revisionId && result.testsetId) {
-                // Connect the newly created testset
+                // Connect the newly created testset. The new test set is empty,
+                // so keep any draft rows instead of wiping them: they become
+                // unsaved additions the user can sync as the first commit.
                 const testcases = result.testcases ?? []
-                connectToTestset({
+                connectKeepingDrafts({
                     loadableId,
                     revisionId: result.revisionId,
                     testcases,
@@ -344,7 +379,7 @@ export function TestsetDropdown() {
             message.error(result.error?.message ?? "Failed to create test set")
             return {success: false as const}
         },
-        [loadableId, store, saveNewTestset, connectToTestset],
+        [loadableId, store, saveNewTestset, connectKeepingDrafts],
     )
 
     // ── Disconnect ─────────────────────────────────────────────────────────
@@ -595,6 +630,9 @@ export function TestsetDropdown() {
 
             {/* Disconnect with unsaved changes modal */}
             <TestsetDisconnectConfirmModal />
+
+            {/* Keep or discard local draft rows when connecting a test set */}
+            <KeepDraftRowsModal />
 
             {/* Add to testset drawer — mounted only when open to avoid isDrawerOpenAtom conflicts */}
             {addToTestsetOpen && (

--- a/web/oss/src/components/Playground/Components/TestsetDropdown/index.tsx
+++ b/web/oss/src/components/Playground/Components/TestsetDropdown/index.tsx
@@ -262,6 +262,15 @@ export function TestsetDropdown() {
                     testcases: payload.testcases ?? [],
                 })
             } else {
+                // No real testset picked: the modal falls back to the "local"
+                // sentinel as draft key, and the selection then mirrors the
+                // playground's own rows. Connecting to it would bind the
+                // loadable to a bogus source and duplicate the draft rows.
+                if (!payload.revisionId || payload.revisionId === "local") {
+                    setSelectionModalMode(null)
+                    return
+                }
+
                 // Replace mode: connect and sync selected testcases from entity layer
                 const testcases = payload.selectedTestcaseIds.map((id) => {
                     const data = testcaseMolecule.get.data(id)
@@ -274,6 +283,15 @@ export function TestsetDropdown() {
                     testsetName: payload.testsetName ?? "",
                     testsetId: payload.testsetId ?? null,
                     revisionVersion: payload.revisionVersion ?? null,
+                }
+
+                // Invariant: in local mode the global testcase ids atom must be
+                // empty — server ids only exist while connected. Stale ids here
+                // would count as draft rows below and render as phantom rows if
+                // the user cancels the keep/discard modal, so clear them before
+                // measuring. A real connect repopulates them via connectToSource.
+                if (!isConnected) {
+                    store.set(testcaseMolecule.ids, [])
                 }
 
                 // Connecting clears local rows. If the playground holds draft
@@ -305,6 +323,7 @@ export function TestsetDropdown() {
             importTestcases,
             store,
             isChatPlayground,
+            isConnected,
             setKeepDraftRowsModalState,
         ],
     )
@@ -359,6 +378,8 @@ export function TestsetDropdown() {
                 // Connect the newly created testset. The new test set is empty,
                 // so keep any draft rows instead of wiping them: they become
                 // unsaved additions the user can sync as the first commit.
+                // (Chat mode is the exception: the single-testcase gate inside
+                // the action falls back to a plain connect there.)
                 const testcases = result.testcases ?? []
                 connectKeepingDrafts({
                     loadableId,

--- a/web/packages/agenta-entities/src/loadable/controller.ts
+++ b/web/packages/agenta-entities/src/loadable/controller.ts
@@ -514,7 +514,10 @@ const meaningfulLocalRowsAtomFamily = atomFamily((loadableId: string) =>
             return []
         }
 
-        const displayRowIds = get(testcaseMolecule.atoms.displayRowIds)
+        // Use the loadable-filtered row ids (not the raw molecule list) so rows
+        // the user removed in the playground (hiddenTestcaseIds) don't count as
+        // drafts and can't be resurrected by a keep-and-connect flow.
+        const displayRowIds = get(displayRowIdsAtomFamily(loadableId))
         const rows: TestsetRow[] = []
         for (const id of displayRowIds) {
             const entity = get(testcaseMolecule.data(id))

--- a/web/packages/agenta-entities/src/loadable/controller.ts
+++ b/web/packages/agenta-entities/src/loadable/controller.ts
@@ -476,6 +476,67 @@ const connectedHasLocalChangesAtomFamily = atomFamily((loadableId: string) =>
 )
 
 /**
+ * Whether a row value carries user-entered content.
+ *
+ * Chat message shells ({role, content}) always carry a role string, so only
+ * their content decides meaningfulness — otherwise the blank seeded chat row
+ * would count as a draft.
+ */
+const hasMeaningfulValue = (value: unknown): boolean => {
+    if (value == null) return false
+    if (typeof value === "string") return value.trim().length > 0
+    if (typeof value === "number" || typeof value === "boolean") return true
+    if (Array.isArray(value)) return value.some(hasMeaningfulValue)
+    if (isRecord(value)) {
+        if (typeof value.role === "string" && "content" in value) {
+            return hasMeaningfulValue(value.content)
+        }
+        return Object.values(value).some(hasMeaningfulValue)
+    }
+    return false
+}
+
+/**
+ * Local-mode draft rows that contain meaningful (user-entered) data.
+ *
+ * Returns [] when connected to a source: connected loadables track edits via
+ * hasLocalChanges, whose "false when not connected" contract this selector
+ * deliberately leaves untouched. Used to warn before connectToSource clears
+ * local entities (e.g. rows created manually or from a trace).
+ *
+ * The initial empty row every fresh playground seeds is excluded, so a clean
+ * playground connecting its first test set is not treated as having drafts.
+ */
+const meaningfulLocalRowsAtomFamily = atomFamily((loadableId: string) =>
+    atom<TestsetRow[]>((get) => {
+        const state = get(loadableStateAtomFamily(loadableId))
+        if (state.connectedSourceId) {
+            return []
+        }
+
+        const displayRowIds = get(testcaseMolecule.atoms.displayRowIds)
+        const rows: TestsetRow[] = []
+        for (const id of displayRowIds) {
+            const entity = get(testcaseMolecule.data(id))
+            const entityData = (entity?.data ?? {}) as Record<string, unknown>
+
+            const data: Record<string, unknown> = {}
+            let meaningful = false
+            for (const [key, value] of Object.entries(entityData)) {
+                if (SYSTEM_FIELDS.has(key)) continue
+                data[key] = value
+                if (hasMeaningfulValue(value)) meaningful = true
+            }
+
+            if (meaningful) {
+                rows.push({id, data} as TestsetRow)
+            }
+        }
+        return rows
+    }),
+)
+
+/**
  * Returns the list of column keys that are new (added from runnable but not in original testcase data).
  * Used to indicate "(new)" in the UI for provided columns.
  *
@@ -2372,6 +2433,9 @@ export const testsetLoadable = {
         /** Has local changes for a loadable */
         hasLocalChanges: (loadableId: string) => connectedHasLocalChangesAtomFamily(loadableId),
 
+        /** Local-mode draft rows with meaningful data (empty when connected) */
+        meaningfulLocalRows: (loadableId: string) => meaningfulLocalRowsAtomFamily(loadableId),
+
         /** Column keys that are new (added from runnable but not in original testcase data) */
         newColumnKeys: (loadableId: string) => newColumnKeysAtomFamily(loadableId),
 
@@ -2612,6 +2676,10 @@ const unifiedSelectors = {
 
     /** Has local changes for a loadable */
     hasLocalChanges: (loadableId: string) => testsetLoadable.selectors.hasLocalChanges(loadableId),
+
+    /** Local-mode draft rows with meaningful data (empty when connected) */
+    meaningfulLocalRows: (loadableId: string) =>
+        testsetLoadable.selectors.meaningfulLocalRows(loadableId),
 
     /** Column keys that are new (added but not in original data) */
     newColumnKeys: (loadableId: string) => testsetLoadable.selectors.newColumnKeys(loadableId),

--- a/web/packages/agenta-entities/tests/unit/loadable-meaningful-local-rows.test.ts
+++ b/web/packages/agenta-entities/tests/unit/loadable-meaningful-local-rows.test.ts
@@ -63,6 +63,18 @@ describe("meaningfulLocalRows", () => {
         expect(meaningfulRows(store)).toHaveLength(1)
     })
 
+    it("excludes rows the user removed from the playground (hiddenTestcaseIds)", () => {
+        const store = freshStore()
+        const kept = store.set(testcaseMolecule.actions.add, {data: {country: "France"}})
+        const removed = store.set(testcaseMolecule.actions.add, {data: {country: "Spain"}})
+
+        // Playground row delete hides local rows via the loadable removeRow path
+        store.set(loadableController.actions.removeRow, LOADABLE_ID, removed!.id)
+
+        const rows = meaningfulRows(store)
+        expect(rows.map((r) => r.id)).toEqual([kept!.id])
+    })
+
     it("returns [] once the loadable is connected", () => {
         const store = freshStore()
         store.set(testcaseMolecule.actions.add, {data: {country: "France"}})

--- a/web/packages/agenta-entities/tests/unit/loadable-meaningful-local-rows.test.ts
+++ b/web/packages/agenta-entities/tests/unit/loadable-meaningful-local-rows.test.ts
@@ -1,0 +1,123 @@
+/**
+ * Unit tests for loadableController.selectors.meaningfulLocalRows and the
+ * keep-drafts connect sequence (capture → connectToSource → importRows).
+ *
+ * meaningfulLocalRows backs the playground's "Keep your draft test cases?"
+ * modal: it must surface local rows that hold user-entered data, while
+ * ignoring the blank row every fresh playground seeds, and it must return []
+ * once a loadable is connected (connected loadables use hasLocalChanges).
+ *
+ * Each test uses a fresh createStore() for isolation.
+ */
+
+import {createStore} from "jotai"
+import {describe, it, expect} from "vitest"
+
+import {loadableController} from "../../src/loadable/controller"
+import {testcaseMolecule} from "../../src/testcase/state/molecule"
+
+const LOADABLE_ID = "testset:workflow:test-entity"
+const REVISION_ID = "11111111-1111-4111-8111-111111111111"
+const TESTCASE_ID = "22222222-2222-4222-8222-222222222222"
+
+function freshStore() {
+    return createStore()
+}
+
+function meaningfulRows(store: ReturnType<typeof freshStore>) {
+    return store.get(loadableController.selectors.meaningfulLocalRows(LOADABLE_ID))
+}
+
+describe("meaningfulLocalRows", () => {
+    it("returns [] when no rows exist", () => {
+        const store = freshStore()
+        expect(meaningfulRows(store)).toEqual([])
+    })
+
+    it("ignores the seeded empty row", () => {
+        const store = freshStore()
+        store.set(testcaseMolecule.actions.add, {data: {country: "", capital: "  "}})
+        expect(meaningfulRows(store)).toEqual([])
+    })
+
+    it("includes rows with user-entered data", () => {
+        const store = freshStore()
+        store.set(testcaseMolecule.actions.add, {data: {country: "France"}})
+        store.set(testcaseMolecule.actions.add, {data: {country: ""}})
+
+        const rows = meaningfulRows(store)
+        expect(rows).toHaveLength(1)
+        expect(rows[0].data).toMatchObject({country: "France"})
+    })
+
+    it("treats blank chat message shells as empty", () => {
+        const store = freshStore()
+        store.set(testcaseMolecule.actions.add, {
+            data: {messages: [{role: "user", content: ""}]},
+        })
+        expect(meaningfulRows(store)).toEqual([])
+
+        store.set(testcaseMolecule.actions.add, {
+            data: {messages: [{role: "user", content: "hello"}]},
+        })
+        expect(meaningfulRows(store)).toHaveLength(1)
+    })
+
+    it("returns [] once the loadable is connected", () => {
+        const store = freshStore()
+        store.set(testcaseMolecule.actions.add, {data: {country: "France"}})
+
+        store.set(loadableController.actions.connectToSource, LOADABLE_ID, REVISION_ID, "TS v1", [
+            {id: TESTCASE_ID, data: {country: "Spain"}},
+        ])
+
+        expect(meaningfulRows(store)).toEqual([])
+    })
+})
+
+describe("keep-drafts connect sequence", () => {
+    it("connectToSource alone destroys local drafts (the bug being guarded)", () => {
+        const store = freshStore()
+        store.set(testcaseMolecule.actions.add, {data: {country: "France"}})
+
+        store.set(loadableController.actions.connectToSource, LOADABLE_ID, REVISION_ID, "TS v1", [
+            {id: TESTCASE_ID, data: {country: "Spain"}},
+        ])
+
+        const rowIds = store.get(loadableController.selectors.displayRowIds(LOADABLE_ID))
+        expect(rowIds).toEqual([TESTCASE_ID])
+        expect(store.get(testcaseMolecule.newIds)).toEqual([])
+        expect(store.get(loadableController.selectors.hasLocalChanges(LOADABLE_ID))).toBe(false)
+    })
+
+    it("capture → connect → importRows keeps drafts as unsaved additions", () => {
+        const store = freshStore()
+        store.set(testcaseMolecule.actions.add, {data: {country: "France"}})
+        store.set(testcaseMolecule.actions.add, {data: {country: ""}})
+
+        // Capture BEFORE connecting - connectToSource clears local entities
+        const captured = meaningfulRows(store)
+        expect(captured).toHaveLength(1)
+
+        store.set(loadableController.actions.connectToSource, LOADABLE_ID, REVISION_ID, "TS v1", [
+            {id: TESTCASE_ID, data: {country: "Spain"}},
+        ])
+        store.set(
+            loadableController.actions.importRows,
+            LOADABLE_ID,
+            captured.map((row) => ({...row.data})),
+        )
+
+        const rowIds = store.get(loadableController.selectors.displayRowIds(LOADABLE_ID))
+        expect(rowIds).toHaveLength(2)
+        expect(rowIds).toContain(TESTCASE_ID)
+
+        const keptId = rowIds.find((id: string) => id !== TESTCASE_ID) as string
+        expect(keptId.startsWith("new-")).toBe(true)
+        const kept = store.get(testcaseMolecule.data(keptId))
+        expect(kept?.data).toMatchObject({country: "France"})
+
+        // The kept row counts as an unsaved change, enabling "Sync changes"
+        expect(store.get(loadableController.selectors.hasLocalChanges(LOADABLE_ID))).toBe(true)
+    })
+})

--- a/web/packages/agenta-playground-ui/src/components/TestsetSelectionModal/components/LoadModeContent.tsx
+++ b/web/packages/agenta-playground-ui/src/components/TestsetSelectionModal/components/LoadModeContent.tsx
@@ -130,7 +130,6 @@ export function LoadModeContent({
 
     // ===================== Selection State =====================
     const setSelectionDraft = useSetAtom(testcase.actions.setSelectionDraft)
-    const commitSelectionDraft = useSetAtom(testcase.actions.commitSelectionDraft)
     const discardSelectionDraft = useSetAtom(testcase.actions.discardSelectionDraft)
 
     const draftKey = selectedRevisionId ?? "local"
@@ -213,8 +212,15 @@ export function LoadModeContent({
 
             onConfirm(payload)
         } else {
-            // Load mode: commit draft and build payload with metadata
-            commitSelectionDraft(draftKey)
+            // Load mode: hand the selection to the consumer via the payload and
+            // discard the draft WITHOUT committing it. Committing would write
+            // the picked ids into the global testcase ids atom before the
+            // consumer decides to connect — the consumer may defer behind a
+            // confirmation (keep-drafts modal) or abort, and a real connect
+            // populates the ids itself via connectToSource. Pre-committing
+            // rendered the picked testset rows in the playground background
+            // and made them count as local draft rows.
+            discardSelectionDraft(draftKey)
 
             const payload: TestsetSelectionPayload = {
                 revisionId: selectedRevisionId ?? "local",
@@ -237,7 +243,6 @@ export function LoadModeContent({
         currentSelection,
         isViewingConnected,
         discardSelectionDraft,
-        commitSelectionDraft,
         selectedRevisionId,
         onConfirm,
         onCancel,

--- a/web/packages/agenta-playground/src/index.ts
+++ b/web/packages/agenta-playground/src/index.ts
@@ -80,7 +80,7 @@ export type {PlaygroundEntityProviders} from "./state"
 export type {PlaygroundTestResult, PlaygroundNode} from "./state"
 export type {ChatMessage, SimpleChatMessage, MessageTarget} from "./state"
 export type {ChainExecutionResult, ChainNodeInfo} from "./state"
-export type {OpenFromTraceResult} from "./state"
+export type {ConnectToTestsetPayload, OpenFromTraceResult} from "./state"
 
 // ============================================================================
 // TRACE REFERENCE RESOLUTION (shared with OSS trace drawer UI gate)

--- a/web/packages/agenta-playground/src/state/controllers/index.ts
+++ b/web/packages/agenta-playground/src/state/controllers/index.ts
@@ -9,7 +9,7 @@ export {
     setOnSelectionChangeCallback,
     getOnSelectionChangeCallback,
 } from "./playgroundController"
-export type {OpenFromTraceResult} from "./playgroundController"
+export type {ConnectToTestsetPayload, OpenFromTraceResult} from "./playgroundController"
 export {outputConnectionController} from "./outputConnectionController"
 export {entitySelectorController} from "./entitySelectorController"
 export {executionController} from "./executionController"

--- a/web/packages/agenta-playground/src/state/controllers/playgroundController.ts
+++ b/web/packages/agenta-playground/src/state/controllers/playgroundController.ts
@@ -104,7 +104,7 @@ import {getRunnableTypeResolver} from "./urlSnapshotController"
 /**
  * Payload for connecting to a testset (load mode)
  */
-interface ConnectToTestsetPayload {
+export interface ConnectToTestsetPayload {
     loadableId: string
     revisionId: string
     testcases: ({id?: string} & Record<string, unknown>)[]
@@ -630,6 +630,41 @@ const importTestcasesAtom = atom(null, (get, set, payload: ImportTestcasesPayloa
         })
     }
 })
+
+/**
+ * Connect to a testset while keeping the current local draft rows.
+ *
+ * `connectToSource` clears all local entities, so rows created manually or
+ * from a trace are destroyed by a plain connect. This action captures the
+ * meaningful local rows first, connects, then re-imports the captured rows
+ * as unsaved additions (`newEntityIdsAtom`), which turns on hasLocalChanges
+ * and lets the user sync them into the test set via the commit flow.
+ *
+ * Chat playgrounds load a single testcase (see the gate in
+ * `connectToTestsetAtom`), so kept rows cannot be appended there; this
+ * action falls back to a plain connect in chat mode. Callers should warn
+ * instead of offering "keep" for chat.
+ */
+const connectToTestsetKeepingLocalRowsAtom = atom(
+    null,
+    (get, set, payload: ConnectToTestsetPayload) => {
+        const isChat = get(isChatModeAtom) ?? false
+        const captured = isChat
+            ? []
+            : get(loadableController.selectors.meaningfulLocalRows(payload.loadableId))
+
+        set(connectToTestsetAtom, payload)
+
+        if (captured.length > 0) {
+            // Strip the old local IDs so importRows creates fresh entities
+            // instead of dedup-checking against IDs the connect just cleared.
+            set(importTestcasesAtom, {
+                loadableId: payload.loadableId,
+                testcases: captured.map(({data}) => ({...data})),
+            })
+        }
+    },
+)
 
 // ============================================================================
 // WP2: ROW WITH INIT COMPOUND ACTION
@@ -2381,6 +2416,9 @@ export const playgroundController = {
 
         /** Import testcases (import mode - no connection) */
         importTestcases: importTestcasesAtom,
+
+        /** Connect to a testset, re-importing local draft rows as unsaved additions */
+        connectToTestsetKeepingLocalRows: connectToTestsetKeepingLocalRowsAtom,
 
         // WP2: Row with init action
         /** Add a row with local testset initialization */

--- a/web/packages/agenta-playground/src/state/index.ts
+++ b/web/packages/agenta-playground/src/state/index.ts
@@ -352,6 +352,7 @@ export {
 
 export type {
     BuildEncodedSnapshotResult,
+    ConnectToTestsetPayload,
     CreateSnapshotResult,
     HydrateFromUrlResult,
     HydrateSnapshotResult,

--- a/web/packages/agenta-playground/tests/unit/connectToTestsetKeepingLocalRows.test.ts
+++ b/web/packages/agenta-playground/tests/unit/connectToTestsetKeepingLocalRows.test.ts
@@ -1,0 +1,87 @@
+/**
+ * Unit tests for playgroundController.actions.connectToTestsetKeepingLocalRows.
+ *
+ * The action backs the "Keep and load" choice in the playground's keep-drafts
+ * modal: it captures meaningful local rows before connectToSource clears
+ * them, connects to the test set, then re-imports the captured rows as
+ * unsaved additions so the user can sync them into the test set later.
+ *
+ * Chat mode is not exercised here: isChatModeAtom derives from the primary
+ * node's workflow molecule, which needs the full entity stack. With no nodes
+ * it resolves undefined → non-chat, which is the path under test.
+ *
+ * Each test uses a fresh createStore() for isolation.
+ */
+
+import {loadableController} from "@agenta/entities/loadable"
+import {testcaseMolecule} from "@agenta/entities/testcase"
+import {createStore} from "jotai"
+import {describe, it, expect} from "vitest"
+
+import {playgroundController} from "../../src/state/controllers/playgroundController"
+
+const LOADABLE_ID = "testset:workflow:test-entity"
+const REVISION_ID = "11111111-1111-4111-8111-111111111111"
+const TESTCASE_ID = "22222222-2222-4222-8222-222222222222"
+
+function freshStore() {
+    return createStore()
+}
+
+function connectPayload() {
+    return {
+        loadableId: LOADABLE_ID,
+        revisionId: REVISION_ID,
+        testcases: [{id: TESTCASE_ID, country: "Spain"}],
+        testsetName: "Countries",
+        testsetId: "ts-1",
+        revisionVersion: 1,
+    }
+}
+
+describe("connectToTestsetKeepingLocalRows", () => {
+    it("re-imports meaningful drafts as unsaved additions after connecting", () => {
+        const store = freshStore()
+        store.set(testcaseMolecule.actions.add, {data: {country: "France"}})
+        store.set(testcaseMolecule.actions.add, {data: {country: ""}})
+
+        store.set(playgroundController.actions.connectToTestsetKeepingLocalRows, connectPayload())
+
+        const rowIds = store.get(loadableController.selectors.displayRowIds(LOADABLE_ID))
+        expect(rowIds).toHaveLength(2)
+        expect(rowIds).toContain(TESTCASE_ID)
+
+        const keptId = rowIds.find((id: string) => id !== TESTCASE_ID) as string
+        expect(keptId.startsWith("new-")).toBe(true)
+        expect(store.get(testcaseMolecule.data(keptId))?.data).toMatchObject({country: "France"})
+
+        // Connection established + kept row pending sync
+        const source = store.get(loadableController.selectors.connectedSource(LOADABLE_ID))
+        expect(source?.id).toBe(REVISION_ID)
+        expect(store.get(loadableController.selectors.hasLocalChanges(LOADABLE_ID))).toBe(true)
+    })
+
+    it("connects without importing when no meaningful drafts exist", () => {
+        const store = freshStore()
+        store.set(testcaseMolecule.actions.add, {data: {country: ""}})
+
+        store.set(playgroundController.actions.connectToTestsetKeepingLocalRows, connectPayload())
+
+        expect(store.get(loadableController.selectors.displayRowIds(LOADABLE_ID))).toEqual([
+            TESTCASE_ID,
+        ])
+        expect(store.get(loadableController.selectors.hasLocalChanges(LOADABLE_ID))).toBe(false)
+    })
+
+    it("plain connectToTestset still replaces drafts (modal's Discard path)", () => {
+        const store = freshStore()
+        store.set(testcaseMolecule.actions.add, {data: {country: "France"}})
+
+        store.set(playgroundController.actions.connectToTestset, connectPayload())
+
+        expect(store.get(loadableController.selectors.displayRowIds(LOADABLE_ID))).toEqual([
+            TESTCASE_ID,
+        ])
+        expect(store.get(testcaseMolecule.newIds)).toEqual([])
+    })
+})


### PR DESCRIPTION
> Stacked on #4584 (`release/v0.103.0`).

## Context

Opening a trace in the playground (or typing test cases manually) creates local draft rows. Connecting a test set afterwards silently destroyed them: `connectToSource` clears all local entities before loading the test set rows, the not-connected "Connect test set" menu item has no unsaved-changes guard, and `hasLocalChanges` is false by design in local mode. So the exact case the trace-to-playground flow exists for ("take this production input and add it to my test set") lost the input at the moment of connecting, with no undo.

## Changes

Connecting now asks before clearing.

Before: Connect test set > pick rows > Load Selected. The playground shows only the test set rows; the trace-derived draft is gone.

After: the same flow opens a modal when drafts exist: "Keep your draft test cases?" with **Keep and load** (primary), **Discard drafts**, and Cancel. Keep and load connects, then re-imports the drafts as unsaved rows on top of the test set rows. They count as local changes, so the existing **Sync changes** flow commits them into the test set as a new revision.

Details:

- New `loadableController.selectors.meaningfulLocalRows`: local-mode rows whose data holds user-entered content. The blank row every fresh playground seeds and blank chat message shells do not count, so a clean playground's first connect never prompts. Returns `[]` when connected, leaving the `hasLocalChanges` contract untouched.
- New `playgroundController.actions.connectToTestsetKeepingLocalRows`: captures drafts before `connectToSource` clears them, connects, then re-imports via the existing `importTestcases`.
- Chat playgrounds load one testcase at a time (the single-row gate), so drafts cannot be kept there. The modal degrades to a warning: "Replace the current conversation?".
- Create & Load keeps drafts without prompting. The newly created test set is empty, so the old behavior wiped the drafts into nothing.
- The connected-mode "Change test set" Save/Discard guard is unchanged.

Research notes and decisions: `docs/design/playground-keep-drafts-on-testset-connect/`.

## Tests

- 7 new unit tests in `agenta-entities` (selector semantics, capture/connect/import ordering) and 3 in `agenta-playground` (compound action, no-drafts pass-through, discard path). All pass.
- `turbo build` for both packages and `pnpm lint-fix` pass.
- The chat warning needs a manual check: `isChatModeAtom` derives from the workflow molecule, which the unit harness does not stand up.

## QA round 1 fixes (second commit)

QA reported three bugs: Cancel still loaded the test set, the modal fired with an inflated draft count, and the picked rows rendered behind the modal. All three came from the selection modal committing the picked ids into the global testcase ids atom before the keep/discard decision. The second commit makes load-mode confirm discard the draft instead (a real connect populates the ids itself), clears stale ids in local mode before measuring drafts, ignores confirms with no real test set picked, and excludes rows the user removed from the playground from the draft count (they used to resurrect on "Keep and load"). All three scenarios plus the no-draft and keep paths were re-verified in Chrome against the dev stack; an eighth unit test covers the hidden-rows case.

## How to QA

In order of risk:

1. **Keep path (core).** In an app playground, type values into the generation row (or open a trace via trace drawer > Playground). Test set > Connect test set, pick a test set and a few rows, Load Selected. The "Keep your draft test cases?" modal must appear with the right draft count. Click **Keep and load**: the table shows the test set rows plus your draft rows, and the dropdown shows **Sync changes** enabled. Commit and verify the new revision contains the draft rows.
2. **Cancel path.** Same setup, click **Cancel** in the modal. The playground must stay exactly as before: draft rows only, still disconnected, and no rows from the test set you picked. This was QA bug 1; the selection modal no longer commits the picked ids before the decision.
3. **Discard path.** Same setup, **Discard drafts**: only test set rows remain, Sync changes stays disabled.
4. **No-prompt cases.** A fresh playground (only the seeded empty row) connecting a test set must NOT prompt. An already-connected playground switching test sets must show the existing Save/Discard modal, not the new one.
5. **Create & Load with drafts.** With draft rows, use Create test set ("Build in UI") > Create & Load. The drafts must survive into the new empty test set as unsaved rows.
6. **Chat playground.** Connect a test set while a conversation is drafted: the warning variant ("Replace the current conversation?") must show instead of the keep option, and the chat must still load exactly one testcase.
7. **Column mismatch.** Keep a trace-derived row whose input keys do not match the test set columns: the row keeps its data, extra columns show as "(new)", commit does not crash.

https://github.com/user-attachments/assets/92509b20-9430-40b0-a093-f78c1425a64c

