### PR TITLE
[#4620] fix(api): assign revision versions pre-insert under a variant lock to prevent duplicates

### DIFF
--- a/api/oss/src/apis/fastapi/git/exceptions.py
+++ b/api/oss/src/apis/fastapi/git/exceptions.py
@@ -22,6 +22,7 @@ from oss.src.core.git.types import (
     InitialRevisionConflict,
     RetrieveRefsInconsistent,
     RetrieveRefsInsufficient,
+    RevisionVersionConflict,
     VariantForkError,
 )
 
@@ -30,6 +31,14 @@ class InitialRevisionConflictException(HTTPException):
     def __init__(
         self,
         message: str = "An initial revision already exists for this variant.",
+    ):
+        super().__init__(status_code=409, detail=message)
+
+
+class RevisionVersionConflictException(HTTPException):
+    def __init__(
+        self,
+        message: str = "A revision with this version already exists for this variant.",
     ):
         super().__init__(status_code=409, detail=message)
 
@@ -63,6 +72,8 @@ def handle_git_exceptions():
                 return await func(*args, **kwargs)
             except InitialRevisionConflict as e:
                 raise InitialRevisionConflictException(message=e.message) from e
+            except RevisionVersionConflict as e:
+                raise RevisionVersionConflictException(message=e.message) from e
             except VariantForkError as e:
                 raise VariantForkErrorException(message=e.message) from e
             except RetrieveRefsInsufficient as e:

--- a/api/oss/src/core/git/types.py
+++ b/api/oss/src/core/git/types.py
@@ -78,9 +78,9 @@ applications) reject it at the boundary.
 Exception registry
 ==================
 
-`InitialRevisionConflict`, `VariantForkError`, `RetrieveRefsInsufficient`,
-and `RetrieveRefsInconsistent` are translated to HTTP responses by
-`@handle_git_exceptions()` in
+`InitialRevisionConflict`, `RevisionVersionConflict`, `VariantForkError`,
+`RetrieveRefsInsufficient`, and `RetrieveRefsInconsistent` are translated
+to HTTP responses by `@handle_git_exceptions()` in
 `api/oss/src/apis/fastapi/git/exceptions.py`. Any new git-domain
 exception added here must also be registered there.
 
@@ -127,6 +127,20 @@ class InitialRevisionConflict(GitError):
     The `initial=True` guard in the DAO raises this exception when a
     revision already exists for the variant, so routers can map it to
     HTTP 409 via `@handle_git_exceptions()` without inspecting None.
+    """
+
+
+class RevisionVersionConflict(GitError):
+    """Raised when the version computed for a new revision already exists
+    on the variant.
+
+    Version assignment in the DAO is collision-free for rows it writes
+    (serialized per variant, strictly above every existing numeric
+    version), so this fires only when an out-of-band writer — a data
+    migration or manual DB operation — left a conflicting version behind.
+    Raised before the insert, so the commit rolls back instead of silently
+    storing a duplicate. Routers map it to HTTP 409 via
+    `@handle_git_exceptions()`.
     """
 
 

--- a/api/oss/src/dbs/postgres/git/dao.py
+++ b/api/oss/src/dbs/postgres/git/dao.py
@@ -2,13 +2,18 @@ from typing import Optional, List, TypeVar, Type
 from uuid import UUID
 from datetime import datetime, timezone
 
-from sqlalchemy import or_, select, func, update
+from sqlalchemy import or_, select, func, update, case, cast, Integer
+from sqlalchemy.ext.asyncio import AsyncSession
 from sqlalchemy.orm import selectinload
 
 from oss.src.utils.logging import get_module_logger
 
 from oss.src.core.shared.exceptions import EntityCreationConflict
-from oss.src.core.git.types import is_identifying, InitialRevisionConflict
+from oss.src.core.git.types import (
+    is_identifying,
+    InitialRevisionConflict,
+    RevisionVersionConflict,
+)
 from oss.src.core.shared.dtos import Reference, Windowing
 from oss.src.core.git.interfaces import GitDAOInterface
 from oss.src.core.git.types import VariantForkError
@@ -1002,7 +1007,7 @@ class GitDAO(GitDAOInterface):
 
     # ─ revisions ──────────────────────────────────────────────────────────────
 
-    @suppress_exceptions(exclude=[EntityCreationConflict])
+    @suppress_exceptions(exclude=[EntityCreationConflict, RevisionVersionConflict])
     async def create_revision(
         self,
         *,
@@ -1043,6 +1048,14 @@ class GitDAO(GitDAOInterface):
 
         try:
             async with self.engine.session() as session:
+                version = await self._assign_next_version(
+                    session=session,
+                    project_id=project_id,
+                    variant_id=revision_create.variant_id,
+                )
+
+                revision_dbe.version = version  # type: ignore
+
                 session.add(revision_dbe)
 
                 await session.commit()
@@ -1053,18 +1066,6 @@ class GitDAO(GitDAOInterface):
                 revision = map_dbe_to_dto(
                     DTO=Revision,
                     dbe=revision_dbe,  # type: ignore
-                )
-
-                revision.version = await self._get_version(
-                    project_id=project_id,
-                    variant_id=revision.variant_id,  # type: ignore
-                    revision_id=revision.id,  # type: ignore
-                )
-
-                await self._set_version(
-                    project_id=project_id,
-                    revision_id=revision.id,  # type: ignore
-                    version=revision.version,
                 )
 
                 return revision
@@ -1559,7 +1560,7 @@ class GitDAO(GitDAOInterface):
 
     # --------------------------------------------------------------------------
 
-    @suppress_exceptions(exclude=[InitialRevisionConflict])
+    @suppress_exceptions(exclude=[InitialRevisionConflict, RevisionVersionConflict])
     async def commit_revision(
         self,
         *,
@@ -1603,30 +1604,20 @@ class GitDAO(GitDAOInterface):
 
         try:
             async with self.engine.session() as session:
-                if initial and revision_commit.variant_id:
-                    # Lock the variant row so concurrent initial commits queue up rather
-                    # than racing through the count check below.
-                    await session.execute(
-                        select(self.VariantDBE)  # type: ignore
-                        .where(
-                            self.VariantDBE.project_id == project_id,  # type: ignore
-                            self.VariantDBE.id == revision_commit.variant_id,  # type: ignore
-                        )
-                        .with_for_update()
+                version = await self._assign_next_version(
+                    session=session,
+                    project_id=project_id,
+                    variant_id=revision_commit.variant_id,
+                )
+
+                # The computed version is "0" iff the variant has no revisions
+                # (the variant row is locked, so this cannot race another commit).
+                if initial and revision_commit.variant_id and version != "0":
+                    raise InitialRevisionConflict(
+                        "An initial revision already exists for this variant."
                     )
-                    guard_stmt = (
-                        select(func.count())  # pylint: disable=not-callable
-                        .select_from(self.RevisionDBE)  # type: ignore
-                        .where(
-                            self.RevisionDBE.project_id == project_id,  # type: ignore
-                            self.RevisionDBE.variant_id == revision_commit.variant_id,  # type: ignore
-                        )
-                    )
-                    guard_result = await session.execute(guard_stmt)
-                    if guard_result.scalar_one() > 0:
-                        raise InitialRevisionConflict(
-                            "An initial revision already exists for this variant."
-                        )
+
+                revision_dbe.version = version  # type: ignore
 
                 session.add(revision_dbe)
                 await session.commit()
@@ -1649,18 +1640,6 @@ class GitDAO(GitDAOInterface):
                 )
                 revision.variant_slug = (
                     revision_dbe.variant.slug if revision_dbe.variant else None
-                )
-
-                revision.version = await self._get_version(
-                    project_id=project_id,
-                    variant_id=revision.variant_id,  # type: ignore
-                    revision_id=revision.id,  # type: ignore
-                )
-
-                await self._set_version(
-                    project_id=project_id,
-                    revision_id=revision.id,  # type: ignore
-                    version=revision.version,
                 )
 
                 if revision.version == "0":
@@ -1797,49 +1776,86 @@ class GitDAO(GitDAOInterface):
 
     # ─ helpers ────────────────────────────────────────────────────────────────
 
-    async def _get_version(
+    async def _assign_next_version(
         self,
         *,
+        session: AsyncSession,
         project_id: UUID,
-        variant_id: UUID,
-        revision_id: UUID,
+        variant_id: Optional[UUID],
     ) -> str:
-        async with self.engine.session() as session:
-            stmt = (
-                select(func.count())  # pylint: disable=not-callable
-                .select_from(self.RevisionDBE)  # type: ignore
+        """Compute the version for a new revision, pre-insert, on the caller's session.
+
+        Locks the variant row so commits to one variant serialize, then returns
+        `GREATEST(count, max + 1)` over the variant's existing revisions
+        (archived included). The count term reproduces the legacy positional
+        numbering on healthy data; the max term keeps the version strictly above
+        every existing numeric version even when earlier rows were hard-removed
+        out of band (data migrations, manual DB ops) — the case that used to
+        silently produce duplicate versions. Non-numeric versions (out-of-band
+        writes) are ignored by the max term instead of failing the cast.
+
+        Raises `RevisionVersionConflict` when a live revision already carries
+        the computed version (only possible via out-of-band writers); raised
+        before the insert, so the caller's transaction rolls back cleanly.
+        """
+        if variant_id is not None:
+            await session.execute(
+                select(self.VariantDBE)  # type: ignore
                 .where(
-                    self.RevisionDBE.project_id == project_id,  # type: ignore
-                    self.RevisionDBE.variant_id == variant_id,  # type: ignore
-                    self.RevisionDBE.id < revision_id,  # type: ignore
+                    self.VariantDBE.project_id == project_id,  # type: ignore
+                    self.VariantDBE.id == variant_id,  # type: ignore
+                )
+                .with_for_update()
+            )
+
+        numeric_version = case(
+            (
+                self.RevisionDBE.version.op("~")(r"^\d+$"),  # type: ignore
+                cast(self.RevisionDBE.version, Integer),  # type: ignore
+            )
+        )
+
+        stmt = (
+            select(
+                func.greatest(
+                    func.count(),  # pylint: disable=not-callable
+                    func.coalesce(func.max(numeric_version) + 1, 0),
                 )
             )
-
-            result = await session.execute(stmt)
-
-            position = result.scalar_one()
-
-            return str(position)
-
-    async def _set_version(
-        self,
-        *,
-        project_id: UUID,
-        revision_id: UUID,
-        version: str,
-    ) -> None:
-        async with self.engine.session() as session:
-            stmt = update(self.RevisionDBE).filter(
+            .select_from(self.RevisionDBE)  # type: ignore
+            .where(
                 self.RevisionDBE.project_id == project_id,  # type: ignore
+                self.RevisionDBE.variant_id == variant_id,  # type: ignore
+            )
+        )
+
+        result = await session.execute(stmt)
+
+        version = str(result.scalar_one())
+
+        guard_stmt = (
+            select(func.count())  # pylint: disable=not-callable
+            .select_from(self.RevisionDBE)  # type: ignore
+            .where(
+                self.RevisionDBE.project_id == project_id,  # type: ignore
+                self.RevisionDBE.variant_id == variant_id,  # type: ignore
+                self.RevisionDBE.version == version,  # type: ignore
+                self.RevisionDBE.deleted_at.is_(None),  # type: ignore
+            )
+        )
+
+        guard_result = await session.execute(guard_stmt)
+
+        if guard_result.scalar_one() > 0:
+            log.error(
+                f"Revision version conflict: computed version {version} already "
+                f"exists for variant {variant_id} in project {project_id}"
+            )
+            raise RevisionVersionConflict(
+                f"A revision with version {version} already exists for this variant."
             )
 
-            stmt = stmt.filter(self.RevisionDBE.id == revision_id)  # type: ignore
-
-            stmt = stmt.values(version=version)  # type: ignore
-
-            await session.execute(stmt)
-
-            await session.commit()
+        return version
 
     async def _null_revision_fields(
         self,

--- a/api/oss/tests/pytest/acceptance/test_revision_version_sequence.py
+++ b/api/oss/tests/pytest/acceptance/test_revision_version_sequence.py
@@ -1,0 +1,160 @@
+"""Revision version assignment is collision-free and strictly increasing.
+
+Versions used to be assigned post-insert as a positional count of earlier rows
+in the variant. When an earlier revision was hard-removed out of band (a data
+migration or manual DB operation), the count regressed and the next commit
+silently reused an existing version — two revisions both labeled v2 in one
+variant. Versions are now computed pre-insert as GREATEST(count, max + 1)
+under a per-variant row lock, so they stay unique on damaged variants and
+under concurrent commits, while healthy variants keep the exact same numbers.
+"""
+
+import os
+from concurrent.futures import ThreadPoolExecutor
+from uuid import uuid4
+
+import pytest
+
+
+# helpers ----------------------------------------------------------------------
+
+
+def _create_workflow_with_variant(authed_api):
+    slug = f"wf-{uuid4().hex[:8]}"
+    response = authed_api(
+        "POST",
+        "/workflows/",
+        json={"workflow": {"slug": slug, "name": slug}},
+    )
+    assert response.status_code == 200, response.text
+    workflow = response.json()["workflow"]
+
+    variant_slug = f"{slug}-v"
+    response = authed_api(
+        "POST",
+        "/workflows/variants/",
+        json={
+            "workflow_variant": {
+                "slug": variant_slug,
+                "name": variant_slug,
+                "workflow_id": workflow["id"],
+            }
+        },
+    )
+    assert response.status_code == 200, response.text
+    return workflow, response.json()["workflow_variant"]
+
+
+def _commit_revision(authed_api, workflow_id: str, variant_id: str, message: str):
+    return authed_api(
+        "POST",
+        "/workflows/revisions/commit",
+        json={
+            "workflow_revision": {
+                "slug": uuid4().hex[-12:],
+                "workflow_id": workflow_id,
+                "workflow_variant_id": variant_id,
+                "message": message,
+            }
+        },
+    )
+
+
+def _list_revisions(authed_api, workflow_id: str):
+    response = authed_api(
+        "POST",
+        "/workflows/revisions/query",
+        json={"workflow_refs": [{"id": workflow_id}]},
+    )
+    assert response.status_code == 200, response.text
+    return response.json()["workflow_revisions"]
+
+
+def _db_execute(statement: str, **params) -> None:
+    """Run one SQL statement against the deployment DB (out-of-band writer)."""
+    sqlalchemy = pytest.importorskip("sqlalchemy")
+    pytest.importorskip("asyncpg")
+    import asyncio
+
+    from sqlalchemy.ext.asyncio import create_async_engine
+
+    uri = os.environ["AGENTA_POSTGRES_URI"]
+    if uri.startswith("postgresql://"):
+        uri = uri.replace("postgresql://", "postgresql+asyncpg://", 1)
+
+    async def _run():
+        engine = create_async_engine(uri)
+        try:
+            async with engine.begin() as connection:
+                await connection.execute(sqlalchemy.text(statement), params)
+        finally:
+            await engine.dispose()
+
+    asyncio.run(_run())
+
+
+# tests ------------------------------------------------------------------------
+
+
+def test_versions_are_gapless_for_healthy_sequential_commits(authed_api):
+    workflow, variant = _create_workflow_with_variant(authed_api)
+
+    for i in range(3):
+        response = _commit_revision(authed_api, workflow["id"], variant["id"], f"c{i}")
+        assert response.status_code == 200, response.text
+
+    revisions = _list_revisions(authed_api, workflow["id"])
+    versions = sorted(int(revision["version"]) for revision in revisions)
+    assert versions == [0, 1, 2]
+
+    seed = next(r for r in revisions if int(r["version"]) == 0)
+    assert not seed.get("data")
+
+
+@pytest.mark.skipif(
+    not os.getenv("AGENTA_POSTGRES_URI"),
+    reason="needs AGENTA_POSTGRES_URI for direct DB access",
+)
+def test_hard_deleted_revision_does_not_cause_version_reuse(authed_api):
+    """The customer scenario: an out-of-band hard delete used to make the
+    positional count regress, so the next commit reused an existing version."""
+    workflow, variant = _create_workflow_with_variant(authed_api)
+
+    for i in range(4):
+        response = _commit_revision(authed_api, workflow["id"], variant["id"], f"c{i}")
+        assert response.status_code == 200, response.text
+
+    revisions = _list_revisions(authed_api, workflow["id"])
+    victim = next(r for r in revisions if int(r["version"]) == 2)
+    _db_execute(
+        "DELETE FROM workflow_revisions WHERE id = :revision_id",
+        revision_id=victim["id"],
+    )
+
+    response = _commit_revision(authed_api, workflow["id"], variant["id"], "after-del")
+    assert response.status_code == 200, response.text
+    assert response.json()["workflow_revision"]["version"] == "4"
+
+    versions = [r["version"] for r in _list_revisions(authed_api, workflow["id"])]
+    assert len(versions) == len(set(versions)), versions
+
+
+def test_concurrent_commits_get_distinct_versions(authed_api):
+    workflow, variant = _create_workflow_with_variant(authed_api)
+
+    # Seed the variant so the concurrent burst exercises the non-initial path.
+    response = _commit_revision(authed_api, workflow["id"], variant["id"], "seed")
+    assert response.status_code == 200, response.text
+
+    def commit(i: int):
+        return _commit_revision(authed_api, workflow["id"], variant["id"], f"r{i}")
+
+    with ThreadPoolExecutor(max_workers=12) as pool:
+        responses = list(pool.map(commit, range(12)))
+
+    versions = []
+    for response in responses:
+        assert response.status_code == 200, response.text
+        versions.append(response.json()["workflow_revision"]["version"])
+
+    assert len(versions) == len(set(versions)), versions


### PR DESCRIPTION
## What was wrong

A variant could end up with two revisions carrying the **same version number** — the registry showed two rows both labeled `v2` for one prompt, and it was impossible to tell which one was deployed where. Confirmed in production data: a variant held `v1`, `v2` (committed months earlier), and a second `v2` (committed recently).

## Cause

`GitDAO` assigned versions **after** the insert, as a positional count, across three separate transactions:

```python
# insert + commit, then in a new transaction:
version = str(COUNT(revisions WHERE variant_id = Y AND id < new_revision_id))
# then in a third transaction: UPDATE ... SET version = ...
```

The count is only correct while the set of earlier rows never shrinks. The app only soft-deletes (archive), which the count includes — but an out-of-band **hard delete** (data migration, manual DB op) makes the count regress, so the next commit silently reuses an existing version. There is no uniqueness constraint on `(project_id, variant_id, version)`, so nothing rejected the duplicate. UI actions cannot trigger it (verified: sequential commits, archive-then-commit, fork, and 12 concurrent commits all stay distinct).

## Fix

Version assignment moves **before the insert, into the same transaction**, serialized per variant by the `SELECT ... FOR UPDATE` row lock that already existed for the `initial=True` path:

- `version = GREATEST(COUNT(*), COALESCE(MAX(version::int) + 1, 0))` over the variant's existing revisions (archived included; non-numeric versions ignored by the max term so legacy data can't brick a variant). Healthy variants keep the exact same numbers as before; damaged variants get `max + 1` instead of a reused version; an empty variant still yields `"0"`, so the seed-revision nulling is unchanged.
- A creation-time guard checks that no live revision already carries the computed version and raises the new `RevisionVersionConflict` → **HTTP 409** via `@handle_git_exceptions()` (all six git routers pick it up). It fires pre-insert, so the transaction rolls back — no orphan row. It is only reachable via out-of-band writers, exactly the class that created the bug.
- **No DB constraint added** on purpose: existing production data already contains duplicates and must keep working. The guard is application-level, at creation time only.
- The insert→count→update dance (3 transactions) collapses into one transaction; `_get_version`/`_set_version` are removed. The `initial` seed conflict check reuses the computed version (`version != "0"` ⟺ a revision exists) under the same lock.

`GitDAO` is shared, so this covers workflows, applications/evaluators, testsets, queries, and environments. No frontend changes: the client never sends or predicts versions, tolerates gaps, and surfaces a 409 as a toast.

## Before / After (verified live)

| Scenario | Before | After |
|---|---|---|
| Sequential commits | 0,1,2,… | 0,1,2,… (unchanged) |
| Hard-delete an earlier row, then commit | **reuses an existing version (silent duplicate)** | `max+1`, no duplicate |
| 12 concurrent commits on a damaged variant | could collide | all distinct |
| Fresh variant (seed flow) | v0 (data nulled) + v1 | identical |

## Tests

New `api/oss/tests/pytest/acceptance/test_revision_version_sequence.py`:
- healthy sequential commits stay gapless with the seed revision's data nulled,
- hard-delete-then-commit yields `max+1` instead of a duplicate (env-gated on `AGENTA_POSTGRES_URI`),
- 12 concurrent commits get distinct versions.

All three pass against a live deployment, plus the existing commit/retrieve acceptance suites (81 tests) as a regression net. `ruff format`/`check` clean.

Existing rows with duplicate versions are untouched by this change and need a separate one-off cleanup.

Closes #4620
