### PR TITLE
fix(frontend): clear playground draft test cases when switching applications

### DIFF
--- a/web/oss/src/state/url/playground.ts
+++ b/web/oss/src/state/url/playground.ts
@@ -1,6 +1,7 @@
 // Import workflow to ensure the snapshot adapter is registered
 import "@agenta/entities/workflow"
 
+import {loadableController} from "@agenta/entities/loadable"
 import {
     workflowMolecule,
     workflowRevisionsByWorkflowListDataAtomFamily,
@@ -930,6 +931,12 @@ playgroundSyncAtom.onMount = (set) => {
 
         if (isPlaygroundRoute) {
             if (appChanged) {
+                // The testcase row store is global (shared across loadables),
+                // so the previous app's draft rows would otherwise appear in
+                // the new app's playground. Reset it before clearing the
+                // selection; the new app's linkToRunnable seeds a fresh empty
+                // row once the store is empty.
+                store.set(loadableController.actions.resetRowsForAppSwitch)
                 store.set(playgroundController.actions.setEntityIds, [])
                 currentSelected = []
             }

--- a/web/packages/agenta-entities/src/loadable/controller.ts
+++ b/web/packages/agenta-entities/src/loadable/controller.ts
@@ -903,6 +903,32 @@ const resetRowsForPlaygroundClearAtom = atom(null, (get, set, loadableId: string
     })
 })
 
+/**
+ * Thin global row-store reset for app→app navigation.
+ *
+ * The testcase row store is a global singleton shared across loadables, so
+ * rows drafted in one app's playground would otherwise leak into the next
+ * app's playground. Unlike `resetRowsForPlaygroundClear` this ignores the
+ * connected-mode branch (a previous app's connection must not preserve its
+ * server rows), adds no initial row (the next `linkToRunnable` seeds it once
+ * the store is empty), and touches no per-loadable state.
+ *
+ * `currentRevisionId` is cleared too: the paginated testcase query falls back
+ * to it, and leaving it set would let a mounted subscriber re-append the
+ * previous app's connected-testset rows right after this reset.
+ */
+const resetRowsForAppSwitchAtom = atom(null, (get, set) => {
+    const existingIds = get(testcaseMolecule.atoms.displayRowIds)
+    for (const id of existingIds) {
+        set(testcaseMolecule.actions.delete, id)
+    }
+
+    set(resetTestcaseIdsAtom)
+    set(clearNewEntityIdsAtom)
+    set(clearDeletedIdsAtom)
+    set(setCurrentRevisionIdAtom, null)
+})
+
 // ============================================================================
 // COLUMN ACTIONS
 // ============================================================================
@@ -2550,6 +2576,9 @@ export const testsetLoadable = {
         /** Reset rows for the playground Clear action */
         resetRowsForPlaygroundClear: resetRowsForPlaygroundClearAtom,
 
+        /** Reset the global row store on playground app→app navigation */
+        resetRowsForAppSwitch: resetRowsForAppSwitchAtom,
+
         /** Set columns */
         setColumns: setColumnsAtom,
 
@@ -2757,6 +2786,7 @@ const unifiedActions = {
     importRows: testsetLoadable.actions.importRows,
     clearRows: testsetLoadable.actions.clearRows,
     resetRowsForPlaygroundClear: testsetLoadable.actions.resetRowsForPlaygroundClear,
+    resetRowsForAppSwitch: testsetLoadable.actions.resetRowsForAppSwitch,
 
     // Column actions
     setColumns: testsetLoadable.actions.setColumns,

--- a/web/packages/agenta-entities/tests/unit/loadable-reset-rows-for-app-switch.test.ts
+++ b/web/packages/agenta-entities/tests/unit/loadable-reset-rows-for-app-switch.test.ts
@@ -1,0 +1,121 @@
+/**
+ * Unit tests for loadableController.actions.resetRowsForAppSwitch.
+ *
+ * The testcase row store is a global singleton shared across loadables.
+ * When the playground navigates app→app, rows drafted for the previous app
+ * must be cleared from the global store; otherwise they appear in the next
+ * app's playground (rows are not keyed per loadable or per app). The reset
+ * is intentionally thin: it clears only the global row store, leaving the
+ * previous loadable's per-id state untouched, and seeds no row itself — the
+ * next linkToRunnable does that once the store is empty.
+ *
+ * Each test uses a fresh createStore() for isolation.
+ */
+
+import {createStore} from "jotai"
+import {describe, it, expect} from "vitest"
+
+import {loadableController} from "../../src/loadable/controller"
+import {testcaseMolecule} from "../../src/testcase/state/molecule"
+import {
+    currentRevisionIdAtom,
+    deletedEntityIdsAtom,
+    markDeletedAtom,
+    testcaseIdsAtom,
+} from "../../src/testcase/state/store"
+
+const OLD_LOADABLE_ID = "testset:workflow:old-entity"
+const NEW_LOADABLE_ID = "testset:workflow:new-entity"
+const REVISION_ID = "11111111-1111-4111-8111-111111111111"
+const SERVER_ROW_ID = "22222222-2222-4222-8222-222222222222"
+
+function freshStore() {
+    return createStore()
+}
+
+/** Seed the global store as if app A's playground was in active use:
+ *  connected to a testset (server row + revision id), one local draft row,
+ *  and one server row marked deleted. */
+function seedAppAState(store: ReturnType<typeof freshStore>) {
+    store.set(loadableController.actions.connectToSource, OLD_LOADABLE_ID, REVISION_ID, "TS v1", [
+        {id: SERVER_ROW_ID, data: {country: "Spain"}},
+    ])
+    store.set(testcaseMolecule.actions.add, {data: {country: "France"}})
+    store.set(markDeletedAtom, SERVER_ROW_ID)
+}
+
+describe("resetRowsForAppSwitch", () => {
+    it("clears local rows, server ids, deleted set, and the current revision id", () => {
+        const store = freshStore()
+        seedAppAState(store)
+
+        // Sanity: the seeded state is dirty in every dimension the reset targets
+        expect(store.get(testcaseMolecule.newIds)).toHaveLength(1)
+        expect(store.get(testcaseIdsAtom)).toEqual([SERVER_ROW_ID])
+        expect(store.get(deletedEntityIdsAtom).size).toBe(1)
+        expect(store.get(currentRevisionIdAtom)).toBe(REVISION_ID)
+
+        store.set(loadableController.actions.resetRowsForAppSwitch)
+
+        expect(store.get(testcaseMolecule.atoms.displayRowIds)).toEqual([])
+        expect(store.get(testcaseMolecule.newIds)).toEqual([])
+        expect(store.get(testcaseIdsAtom)).toEqual([])
+        expect(store.get(deletedEntityIdsAtom).size).toBe(0)
+        expect(store.get(currentRevisionIdAtom)).toBeNull()
+    })
+
+    it("does not seed a replacement row itself", () => {
+        const store = freshStore()
+        store.set(testcaseMolecule.actions.add, {data: {country: "France"}})
+
+        store.set(loadableController.actions.resetRowsForAppSwitch)
+
+        expect(store.get(testcaseMolecule.atoms.displayRowIds)).toEqual([])
+    })
+
+    it("leaves the previous loadable's connection state untouched (thin scope)", () => {
+        const store = freshStore()
+        seedAppAState(store)
+
+        store.set(loadableController.actions.resetRowsForAppSwitch)
+
+        const source = store.get(loadableController.selectors.connectedSource(OLD_LOADABLE_ID))
+        expect(source?.id).toBe(REVISION_ID)
+    })
+
+    it("lets the next app's linkToRunnable seed exactly one fresh empty row", () => {
+        const store = freshStore()
+        seedAppAState(store)
+
+        store.set(loadableController.actions.resetRowsForAppSwitch)
+        store.set(
+            loadableController.actions.linkToRunnable,
+            NEW_LOADABLE_ID,
+            "workflow",
+            "new-entity",
+        )
+
+        const rowIds = store.get(testcaseMolecule.atoms.displayRowIds)
+        expect(rowIds).toHaveLength(1)
+        expect(rowIds[0].startsWith("new-")).toBe(true)
+        expect(store.get(testcaseMolecule.data(rowIds[0]))?.data).toEqual({})
+    })
+
+    it("without the reset, the previous app's rows leak into the next loadable (the bug being guarded)", () => {
+        const store = freshStore()
+        seedAppAState(store)
+
+        store.set(
+            loadableController.actions.linkToRunnable,
+            NEW_LOADABLE_ID,
+            "workflow",
+            "new-entity",
+        )
+
+        // linkToRunnable sees a non-empty global store and seeds nothing,
+        // so app A's rows remain visible in app B's playground.
+        const rowIds = store.get(testcaseMolecule.atoms.displayRowIds)
+        expect(rowIds.length).toBeGreaterThan(0)
+        expect(rowIds.some((id: string) => id.startsWith("new-"))).toBe(true)
+    })
+})


### PR DESCRIPTION

## Context

Moving between two applications carried the previous app's draft test case rows into the next app's playground. Open app A, type a few rows, switch to app B: app B rendered app A's rows verbatim, including rows loaded from a connected test set.

Playground loadables are keyed per anchor revision, but the rows themselves live in global singleton atoms in the testcase molecule (`testcaseIdsAtom`, `newEntityIdsBaseAtom`, `deletedEntityIdsBaseAtom`), shared by every loadable. On app change, `bindRevisionsReady` only cleared the node selection and never the row store. `linkToRunnable` then skipped seeding a fresh empty row because the store was not empty. The leak dates to the playground's move to the loadable architecture in February 2026.

## Changes

The `appChanged` branch in `bindRevisionsReady` now dispatches a new thin reset action, `loadableController.actions.resetRowsForAppSwitch`, before clearing the selection. The action deletes every row, resets the server/new/deleted id atoms, and nulls the global `currentRevisionId`. Nulling that last atom matters: the paginated testcase query falls back to it and would otherwise re-append the previous app's connected test set rows right after the reset. With the store empty, the next app's `linkToRunnable` seeds the canonical single empty row.

Before: switching from a Completion app (rows `country = France`, `country = Japan`) to a Chat app showed those two rows in the Chat playground.
After: the Chat playground opens with one empty row holding only its own `context` variable.

Returning to the same app's playground does not hit the `appChanged` guard, so drafts still survive playground to registry to playground navigation within one app.

The reset is intentionally thin. It does not touch the previous app's per-loadable state (connection metadata, hidden rows); the existing `resetRowsForPlaygroundClear` was not reusable because its connected-mode branch preserves server rows, which is exactly what must not survive an app switch.

## Tests

- Five new unit tests in `loadable-reset-rows-for-app-switch.test.ts`: full clear of all four global atoms, no self-seeded row, the old loadable's connection state untouched, `linkToRunnable` seeding exactly one fresh row after the reset, and a regression guard documenting the leak when the reset is skipped. Full `@agenta/entities` suite green (616 tests).
- Verified in Chrome against the dev stack: Completion to Chat and Chat to Completion each open with a single fresh row, same-app re-entry keeps drafts, no console errors.
