### PR TITLE
fix(frontend): show the evaluator name instead of 'default' in tables

### DIFF
--- a/web/oss/src/components/Evaluators/Drawers/HumanEvaluatorDrawer/index.tsx
+++ b/web/oss/src/components/Evaluators/Drawers/HumanEvaluatorDrawer/index.tsx
@@ -10,7 +10,7 @@
  */
 import {memo, useCallback, useMemo} from "react"
 
-import {workflowMolecule} from "@agenta/entities/workflow"
+import {workflowArtifactQueryAtomFamily, workflowMolecule} from "@agenta/entities/workflow"
 import {getDefaultStore} from "jotai"
 import {useAtomValue, useSetAtom} from "jotai"
 import dynamic from "next/dynamic"
@@ -39,12 +39,26 @@ const HumanEvaluatorDrawer = () => {
     // Read full entity data through the molecule using the revision ID
     // passed directly by the caller (table row). No extra fetch needed.
     const entityData = useAtomValue(workflowMolecule.selectors.data(revisionId ?? ""))
+    // Identity fields must come from the ARTIFACT: the revision's `name` is
+    // the variant name ("default"), and the form writes the prefilled name
+    // back to the artifact via PUT /workflows/{id} on save — prefilling from
+    // the revision would permanently rename the evaluator to "default".
+    const artifactQuery = useAtomValue(
+        workflowArtifactQueryAtomFamily(workflowId ?? entityData?.workflow_id ?? ""),
+    )
+    const artifact = artifactQuery.data
     // Override `id` with the workflow ID — the entity data is keyed by
     // revision ID, but CreateEvaluator uses `evaluator.id` for the
     // update API call which expects a workflow ID.
     const evaluatorWorkflow =
         mode === "edit" && revisionId && entityData
-            ? {...entityData, id: workflowId ?? entityData.workflow_id ?? entityData.id}
+            ? {
+                  ...entityData,
+                  id: workflowId ?? entityData.workflow_id ?? entityData.id,
+                  name: artifact?.name ?? entityData.name,
+                  slug: artifact?.slug ?? entityData.slug,
+                  description: artifact?.description ?? entityData.description,
+              }
             : null
     const closeDrawer = useSetAtom(closeHumanEvaluatorDrawerAtom)
 

--- a/web/oss/src/components/Evaluators/Table/assets/evaluatorColumns.tsx
+++ b/web/oss/src/components/Evaluators/Table/assets/evaluatorColumns.tsx
@@ -38,9 +38,11 @@ import type {EvaluatorTableRow} from "../../store/evaluatorsPaginatedStore"
 // unnecessary re-renders and avoiding max-update-depth from object churn.
 // ============================================================================
 
-/** Workflow name — string | null */
+/** Entity display name from the workflow artifact — string | null.
+ *  Revision `name` carries the variant name ("default"), so both parent rows
+ *  (workflow id) and revision rows (revision id) resolve the artifact name. */
 const workflowNameAtomFamily = atomFamily((id: string) =>
-    atom<string | null>((get) => get(workflowMolecule.selectors.name(id))),
+    atom<string | null>((get) => get(workflowMolecule.selectors.artifactName(id))),
 )
 /** Workflow slug — string | null */
 const workflowSlugAtomFamily = atomFamily((id: string) =>

--- a/web/oss/src/components/Evaluators/components/ConfigureEvaluator/EvaluatorPlaygroundHeader.tsx
+++ b/web/oss/src/components/Evaluators/components/ConfigureEvaluator/EvaluatorPlaygroundHeader.tsx
@@ -34,22 +34,20 @@ const EvaluatorPlaygroundHeader: React.FC = () => {
         useMemo(() => workflowMolecule.selectors.data(evaluatorEntityId), [evaluatorEntityId]),
     )
 
-    // Read the workflow-level name (not the revision name, which may be a variant name).
-    // The workflow entity is seeded by the evaluator list page. For direct URL navigation
-    // where the workflow entity may not be seeded, fall back to the revision's own name.
+    // The entity display name lives on the workflow artifact; the revision's
+    // own `name` carries the variant name ("default").
     const workflowId = evaluatorData?.workflow_id ?? evaluatorEntityId
-    const workflowName = useAtomValue(
-        useMemo(() => workflowMolecule.selectors.name(workflowId), [workflowId]),
+    const artifactName = useAtomValue(
+        useMemo(
+            () => workflowMolecule.selectors.artifactName(evaluatorEntityId),
+            [evaluatorEntityId],
+        ),
     )
     const workflowSlug = useAtomValue(
         useMemo(() => workflowMolecule.selectors.slug(workflowId), [workflowId]),
     )
     const evaluatorName =
-        workflowName?.trim() ||
-        workflowSlug?.trim() ||
-        evaluatorData?.name?.trim() ||
-        evaluatorData?.slug?.trim() ||
-        "Evaluator"
+        artifactName?.trim() || workflowSlug?.trim() || evaluatorData?.slug?.trim() || "Evaluator"
 
     return (
         <div className="flex items-center justify-between gap-4 px-2.5 py-2 bg-[var(--ag-rgba-000-02)] border-0 border-b border-solid border-[var(--ag-rgba-051729-06)]">

--- a/web/oss/src/components/Evaluators/store/evaluatorsPaginatedStore.ts
+++ b/web/oss/src/components/Evaluators/store/evaluatorsPaginatedStore.ts
@@ -21,6 +21,7 @@ import {
     fetchWorkflowsBatch,
     workflowMolecule,
     onEvaluatorMutation,
+    primeWorkflowArtifactCacheImperative,
 } from "@agenta/entities/workflow"
 import {queryClient} from "@agenta/shared/api"
 import {projectIdAtom} from "@agenta/shared/state"
@@ -224,6 +225,10 @@ async function ensureEvaluatorWorkflowCache({
     for (const w of workflows) {
         workflowMolecule.set.seedEntity(w.id, w)
     }
+
+    // Prime the artifact cache so name cells resolve the entity display name
+    // (from the artifact, not the revision) without extra requests.
+    primeWorkflowArtifactCacheImperative(workflows)
 
     // Fetch latest revision for each workflow to classify by category.
     // Workflow-level flags only have is_evaluator — type-specific flags

--- a/web/oss/src/components/pages/evaluations/NewEvaluation/Components/CreateEvaluatorDrawer/index.tsx
+++ b/web/oss/src/components/pages/evaluations/NewEvaluation/Components/CreateEvaluatorDrawer/index.tsx
@@ -55,7 +55,13 @@ const DrawerHeader = ({entityId, onClose}: {entityId: string; onClose: () => voi
     const entityData = useAtomValue(
         useMemo(() => workflowMolecule.selectors.data(entityId), [entityId]),
     )
-    const name = entityData?.name?.trim() || entityData?.slug?.trim() || "New Evaluator"
+    // Entity display name lives on the artifact; the revision's own `name`
+    // carries the variant name ("default"). Falls back to the entity name
+    // for ephemeral drafts that have no artifact yet.
+    const artifactName = useAtomValue(
+        useMemo(() => workflowMolecule.selectors.artifactName(entityId), [entityId]),
+    )
+    const name = artifactName?.trim() || entityData?.slug?.trim() || "New Evaluator"
 
     return (
         <div className="flex items-center justify-between px-4 py-3 border-0 border-b border-solid border-[var(--ag-rgba-051729-06)]">

--- a/web/packages/agenta-annotation-ui/src/components/AnnotationQueuesView/cells/EvaluatorNamesCell.tsx
+++ b/web/packages/agenta-annotation-ui/src/components/AnnotationQueuesView/cells/EvaluatorNamesCell.tsx
@@ -118,7 +118,7 @@ const EvaluatorNameTag = memo(function EvaluatorNameTag({
     fallbackSlug: string | null
 }) {
     const lookupId = evaluatorRevisionId ?? evaluatorId ?? ""
-    const name = useAtomValue(workflowMolecule.selectors.name(lookupId))
+    const name = useAtomValue(workflowMolecule.selectors.artifactName(lookupId))
     const slug = useAtomValue(workflowMolecule.selectors.slug(lookupId))
     const fallbackId = evaluatorId ?? lookupId
 
@@ -136,7 +136,7 @@ const EvaluatorNameSpan = memo(function EvaluatorNameSpan({
     fallbackSlug: string | null
 }) {
     const lookupId = evaluatorRevisionId ?? evaluatorId ?? ""
-    const name = useAtomValue(workflowMolecule.selectors.name(lookupId))
+    const name = useAtomValue(workflowMolecule.selectors.artifactName(lookupId))
     const slug = useAtomValue(workflowMolecule.selectors.slug(lookupId))
     const fallbackId = evaluatorId ?? lookupId
 

--- a/web/packages/agenta-annotation-ui/src/components/AnnotationSession/ConfigurationView.tsx
+++ b/web/packages/agenta-annotation-ui/src/components/AnnotationSession/ConfigurationView.tsx
@@ -246,8 +246,11 @@ const EvaluatorCard = memo(function EvaluatorCard({evaluatorId}: {evaluatorId: s
 
     const query = useAtomValue(workflowMolecule.selectors.query(evaluatorId))
     const evaluator = useAtomValue(workflowMolecule.selectors.data(evaluatorId))
+    // Entity display name lives on the artifact; the revision's own `name`
+    // carries the variant name ("default").
+    const artifactName = useAtomValue(workflowMolecule.selectors.artifactName(evaluatorId))
 
-    const displayName = evaluator?.name || evaluator?.slug || evaluatorId.slice(0, 8)
+    const displayName = artifactName || evaluator?.slug || evaluatorId.slice(0, 8)
     const isHuman = evaluator?.flags?.is_feedback ?? false
     const isCustom = evaluator?.flags?.is_custom ?? false
     const version = evaluator?.version

--- a/web/packages/agenta-annotation-ui/src/components/AnnotationSession/ScenarioListView.tsx
+++ b/web/packages/agenta-annotation-ui/src/components/AnnotationSession/ScenarioListView.tsx
@@ -398,7 +398,7 @@ const AnnotationColumnHeader = memo(function AnnotationColumnHeader({
     def: AnnotationColumnDef
 }) {
     const evaluatorLookupId = def.evaluatorRevisionId ?? def.evaluatorId ?? ""
-    const name = useAtomValue(workflowMolecule.selectors.name(evaluatorLookupId))
+    const name = useAtomValue(workflowMolecule.selectors.artifactName(evaluatorLookupId))
     const slug = useAtomValue(workflowMolecule.selectors.slug(evaluatorLookupId))
     const displaySlug = def.evaluatorSlug || slug
     const displayName = name || displaySlug || def.columnName || def.stepKey
@@ -426,7 +426,7 @@ const AnnotationGroupHeader = memo(function AnnotationGroupHeader({
     onToggle: () => void
 }) {
     const evaluatorLookupId = def.evaluatorRevisionId ?? def.evaluatorId ?? ""
-    const name = useAtomValue(workflowMolecule.selectors.name(evaluatorLookupId))
+    const name = useAtomValue(workflowMolecule.selectors.artifactName(evaluatorLookupId))
     const slug = useAtomValue(workflowMolecule.selectors.slug(evaluatorLookupId))
     const displaySlug = def.evaluatorSlug || slug
     const displayName = name || displaySlug || def.columnName || def.stepKey
@@ -1172,7 +1172,7 @@ function resolveExportColumnLabel(
             const annotationDef = def.annotationDef
             const evaluatorLookupId = annotationDef.evaluatorRevisionId ?? annotationDef.evaluatorId
             const name = evaluatorLookupId
-                ? store.get(workflowMolecule.selectors.name(evaluatorLookupId))
+                ? store.get(workflowMolecule.selectors.artifactName(evaluatorLookupId))
                 : null
             const slug = evaluatorLookupId
                 ? store.get(workflowMolecule.selectors.slug(evaluatorLookupId))

--- a/web/packages/agenta-entities/src/workflow/index.ts
+++ b/web/packages/agenta-entities/src/workflow/index.ts
@@ -240,6 +240,9 @@ export {
     workflowLatestRevisionIdAtomFamily,
     workflowAppTypeAtomFamily,
     workflowLatestRevisionQueryAtomFamily,
+    // Artifact (workflow-level container — entity display name)
+    workflowArtifactQueryAtomFamily,
+    primeWorkflowArtifactCacheImperative,
     // Commit / Archive
     commitWorkflowRevisionAtom,
     commitWorkflowRevision,

--- a/web/packages/agenta-entities/src/workflow/state/index.ts
+++ b/web/packages/agenta-entities/src/workflow/state/index.ts
@@ -69,6 +69,9 @@ export {
     workflowLatestRevisionIdAtomFamily,
     workflowAppTypeAtomFamily,
     workflowLatestRevisionQueryAtomFamily,
+    // Artifact (workflow-level container — entity display name)
+    workflowArtifactQueryAtomFamily,
+    primeWorkflowArtifactCacheImperative,
 } from "./store"
 
 // Union atoms (app + evaluator combined)

--- a/web/packages/agenta-entities/src/workflow/state/molecule.ts
+++ b/web/packages/agenta-entities/src/workflow/state/molecule.ts
@@ -88,6 +88,7 @@ import {
     workflowAppSchemaAtomFamily,
     workflowInterfaceSchemasAtomFamily,
     workflowDraftAtomFamily,
+    workflowArtifactQueryAtomFamily,
     workflowBaseEntityAtomFamily,
     workflowEntityAtomFamily,
     workflowLocalServerDataAtomFamily,
@@ -428,6 +429,24 @@ const nameAtomFamily = atomFamily((workflowId: string) =>
     atom<string | null>((get) => {
         const entity = get(workflowBaseEntityAtomFamily(workflowId))
         return entity?.name ?? null
+    }),
+)
+
+/**
+ * Entity display name resolved from the workflow ARTIFACT.
+ *
+ * Revision `name` carries the variant name ("default"), not the entity name,
+ * so surfaces that label the entity (evaluator tables, annotation cells, page
+ * headers) must read the artifact's name. Accepts a revision id or a workflow
+ * id; falls back to the entity's own name for local drafts without an artifact.
+ */
+const artifactNameAtomFamily = atomFamily((entityId: string) =>
+    atom<string | null>((get) => {
+        if (!entityId) return null
+        const entity = get(workflowBaseEntityAtomFamily(entityId))
+        const artifactId = entity?.workflow_id ?? entityId
+        const artifactQuery = get(workflowArtifactQueryAtomFamily(artifactId))
+        return artifactQuery.data?.name ?? entity?.name ?? null
     }),
 )
 
@@ -1316,6 +1335,8 @@ export const workflowMolecule = {
         outputSchema: outputSchemaAtomFamily,
         /** Workflow name */
         name: nameAtomFamily,
+        /** Entity display name from the workflow artifact (revision names carry the variant name) */
+        artifactName: artifactNameAtomFamily,
         /** Workflow slug */
         slug: slugAtomFamily,
 
@@ -1461,6 +1482,8 @@ export const workflowMolecule = {
             getStore(options).get(parametersAtomFamily(workflowId)),
         name: (workflowId: string, options?: StoreOptions) =>
             getStore(options).get(nameAtomFamily(workflowId)),
+        artifactName: (entityId: string, options?: StoreOptions) =>
+            getStore(options).get(artifactNameAtomFamily(entityId)),
         // Raw flags
         flags: (workflowId: string, options?: StoreOptions) =>
             getStore(options).get(flagsAtomFamily(workflowId)),

--- a/web/packages/agenta-entities/src/workflow/state/store.ts
+++ b/web/packages/agenta-entities/src/workflow/state/store.ts
@@ -866,43 +866,27 @@ const workflowArtifactBatchFetcher = createBatchFetcher<WorkflowArtifactRequest,
     serializeKey: (req) => `${req.projectId}:${req.workflowId}`,
     batchFn: async (requests, serializedKeys) => {
         const results = new Map<string, Workflow | null>()
-        const byProject = new Map<string, {workflowIds: string[]; keys: string[]}>()
+        serializedKeys.forEach((key) => results.set(key, null))
 
-        requests.forEach((req, index) => {
-            const key = serializedKeys[index]
-            if (!req.projectId || !req.workflowId) {
-                results.set(key, null)
-                return
-            }
+        // Exactly one project is in scope at a time in the web app.
+        const projectId = requests[0]?.projectId
+        if (!projectId) return results
+        if (requests.some((req) => req.projectId !== projectId)) {
+            throw new Error("workflowArtifactBatchFetcher: requests span multiple projects")
+        }
 
-            const existing = byProject.get(req.projectId)
-            if (existing) {
-                existing.workflowIds.push(req.workflowId)
-                existing.keys.push(key)
-            } else {
-                byProject.set(req.projectId, {workflowIds: [req.workflowId], keys: [key]})
-            }
+        const workflowIds = [...new Set(requests.map((req) => req.workflowId).filter(Boolean))]
+        if (workflowIds.length === 0) return results
+
+        const response = await queryWorkflows({
+            projectId,
+            workflowRefs: workflowIds.map((id) => ({id})),
+            includeArchived: true,
         })
-
-        await Promise.all(
-            Array.from(byProject.entries()).map(async ([projectId, group]) => {
-                try {
-                    const response = await queryWorkflows({
-                        projectId,
-                        workflowRefs: group.workflowIds.map((id) => ({id})),
-                        includeArchived: true,
-                    })
-                    const byId = new Map(
-                        (response.workflows ?? []).map((workflow) => [workflow.id, workflow]),
-                    )
-                    group.workflowIds.forEach((workflowId, index) => {
-                        results.set(group.keys[index], byId.get(workflowId) ?? null)
-                    })
-                } catch {
-                    group.keys.forEach((key) => results.set(key, null))
-                }
-            }),
-        )
+        const byId = new Map((response.workflows ?? []).map((workflow) => [workflow.id, workflow]))
+        requests.forEach((req, index) => {
+            results.set(serializedKeys[index], byId.get(req.workflowId) ?? null)
+        })
 
         return results
     },

--- a/web/packages/agenta-entities/src/workflow/state/store.ts
+++ b/web/packages/agenta-entities/src/workflow/state/store.ts
@@ -852,6 +852,115 @@ export const workflowAppTypeAtomFamily = atomFamily((workflowId: string) =>
 )
 
 // ============================================================================
+// ARTIFACT QUERY (workflow-level container — entity name/description)
+// ============================================================================
+
+interface WorkflowArtifactRequest {
+    projectId: string
+    workflowId: string
+}
+
+const workflowArtifactBatchFetcher = createBatchFetcher<WorkflowArtifactRequest, Workflow | null>({
+    maxBatchSize: 50,
+    flushDelay: 10,
+    serializeKey: (req) => `${req.projectId}:${req.workflowId}`,
+    batchFn: async (requests, serializedKeys) => {
+        const results = new Map<string, Workflow | null>()
+        const byProject = new Map<string, {workflowIds: string[]; keys: string[]}>()
+
+        requests.forEach((req, index) => {
+            const key = serializedKeys[index]
+            if (!req.projectId || !req.workflowId) {
+                results.set(key, null)
+                return
+            }
+
+            const existing = byProject.get(req.projectId)
+            if (existing) {
+                existing.workflowIds.push(req.workflowId)
+                existing.keys.push(key)
+            } else {
+                byProject.set(req.projectId, {workflowIds: [req.workflowId], keys: [key]})
+            }
+        })
+
+        await Promise.all(
+            Array.from(byProject.entries()).map(async ([projectId, group]) => {
+                try {
+                    const response = await queryWorkflows({
+                        projectId,
+                        workflowRefs: group.workflowIds.map((id) => ({id})),
+                        includeArchived: true,
+                    })
+                    const byId = new Map(
+                        (response.workflows ?? []).map((workflow) => [workflow.id, workflow]),
+                    )
+                    group.workflowIds.forEach((workflowId, index) => {
+                        results.set(group.keys[index], byId.get(workflowId) ?? null)
+                    })
+                } catch {
+                    group.keys.forEach((key) => results.set(key, null))
+                }
+            }),
+        )
+
+        return results
+    },
+})
+
+/**
+ * Query atom family for the workflow ARTIFACT (the workflow-level container).
+ *
+ * Deliberately keyed apart from the revision caches: `workflowQueryAtomFamily`
+ * and the latest-revision query both resolve revisions, so the artifact would
+ * otherwise compete with a revision for the same cache slot. The artifact is
+ * the source of truth for the entity's display name — revision `name` carries
+ * the variant name ("default"), not the entity name.
+ */
+export const workflowArtifactQueryAtomFamily = atomFamily((workflowId: string) =>
+    atomWithQuery((get) => {
+        const projectId = get(workflowProjectIdAtom)
+        return {
+            queryKey: ["workflows", "artifact", workflowId, projectId],
+            queryFn: async (): Promise<Workflow | null> => {
+                if (!projectId || !workflowId) return null
+                return workflowArtifactBatchFetcher({projectId, workflowId})
+            },
+            enabled:
+                get(sessionAtom) &&
+                !!projectId &&
+                !!workflowId &&
+                !isLocalDraftId(workflowId) &&
+                !isPlaceholderId(workflowId),
+            staleTime: 60_000,
+        }
+    }),
+)
+
+/**
+ * Prime the artifact query cache from an already-fetched workflows list
+ * (e.g. a page-level `queryWorkflows` call) so artifact-name lookups
+ * resolve without extra requests.
+ */
+export function primeWorkflowArtifactCacheImperative(
+    workflows: (Workflow | null | undefined)[],
+    options?: StoreOptions,
+): void {
+    const store = getStore(options)
+    const projectId = store.get(workflowProjectIdAtom)
+    if (!projectId) return
+    try {
+        const queryClient = store.get(queryClientAtom)
+        for (const workflow of workflows) {
+            if (!workflow?.id) continue
+            queryClient.setQueryData(["workflows", "artifact", workflow.id, projectId], workflow)
+        }
+    } catch {
+        // queryClientAtom may not be initialized yet (rare)
+    }
+}
+
+// ============================================================================
 // SINGLE ENTITY QUERY
 // ============================================================================
 
@@ -2118,6 +2227,8 @@ export function invalidateWorkflowsListCache(options?: StoreOptions) {
     try {
         const qc = store.get(queryClientAtom)
         qc.invalidateQueries({queryKey: ["workflows", "apps"], exact: false})
+        // Artifact-level metadata (name/description) may have changed too
+        qc.invalidateQueries({queryKey: ["workflows", "artifact"], exact: false})
     } catch {
         // queryClientAtom may not be initialized yet
     }
@@ -2216,6 +2327,7 @@ export function invalidateWorkflowCache(workflowId: string, options?: StoreOptio
     try {
         const qc = store.get(queryClientAtom)
         qc.invalidateQueries({queryKey: ["workflows", "revision", workflowId], exact: false})
+        qc.invalidateQueries({queryKey: ["workflows", "artifact", workflowId], exact: false})
     } catch {
         // queryClientAtom may not be initialized yet
     }


### PR DESCRIPTION
## Context

Save an evaluator from the UI and every list shows it as "default" instead of the name you typed. The evaluators table, the evaluator configure header, and the annotation views were all affected. The name itself was never lost: the backend stored it correctly the whole time. The bug was about which name the UI read.

A workflow is stored in three levels, like git: the workflow itself (think repo), its variants (branches), and its revisions (commits). Both the workflow and each revision carry a `name` column. The workflow's name holds the real name, "Exact Match". Since #4341 the frontend names every revision after its variant, which for evaluators is always "default". That change was deliberate: evaluation tables label applications by their variant, and revisions named after the app made those chips show the app name instead of "default". But the evaluator surfaces use the revision's name as the entity label, so every evaluator created since then displays "default". Edits compound it: the commit flow copies the current entity name into each new revision, so v2 and v3 inherit "default" forever.

Before: an evaluator saved as "Exact Match" lists as "default v1".
After: it lists as "Exact Match v1".

## The fix

Reverting the revision naming would re-break the variant chips, so revision names stay as they are. Instead, the entity label now comes from the workflow row, which always had the right name.

One obstacle made this more than a field swap. The workflow molecule keys every entity by a single id, and its query always resolves a revision: a revision id fetches that revision, and a workflow id fetches that workflow's latest revision. There was no way to hold the workflow row itself. The workflow and its latest revision competed for the same cache slot, and the revision always won. The configure header already tried to read the workflow-level name and lost to exactly this collision.

So the workflow row gets its own slot:

- `workflowArtifactQueryAtomFamily` fetches the workflow row through the existing `POST /workflows/query`, batched, under its own cache key (`["workflows", "artifact", ...]`). A revision can never overwrite it. ("Artifact" is the backend's name for the workflow-level container; see `workflow_artifacts`.)
- `workflowMolecule.selectors.artifactName(id)` accepts either a revision id or a workflow id. It resolves the entity, follows `entity.workflow_id` up to the workflow, and returns the workflow's name. Local drafts that have no workflow yet fall back to their own name. The existing `selectors.name` keeps its meaning, so the app-create drawer rename flow is untouched.
- The evaluators table name cells, the configure header, and the annotation queue/scenario cells now read `artifactName`. The evaluators page already fetches the workflow list, so it primes the new cache and the table resolves every name without extra requests.
- `invalidateWorkflowsListCache` and `invalidateWorkflowCache` also clear artifact entries, so a rename shows up immediately.

No API changes and no migration. Evaluators created while the bug was live display correctly again, because their workflow name was always right. The "default" strings left on their revisions no longer matter to any reader.

## Tests

- `tsc --noEmit` clean on `agenta-entities` and `agenta-annotation-ui`; eslint clean on all touched files; all 656 `agenta-entities` unit tests pass.
- Verified on the dev deployment: evaluators created during the broken window ("Exact Matchasfa", "Code Evaluation", "LLM-as-a-judge") show their names with version tags. The configure drawer header shows the name while its variant selector still shows "default v2", as intended.
- The annotation views previously resolved names only when revisions were loaded. They now issue one small batched artifact fetch, which fixes "default" there too.

## What to QA

Full checklist in the [QA comment](https://github.com/Agenta-AI/agenta/pull/4634#issuecomment-4678961840). The short version:

- Create an evaluator (automatic and human), name it, save. The table shows your name with v1, not "default".
- Edit and commit. The name stays, the version bumps.
- Regression: run a new evaluation. The application/variant chips still say "default", not the app name. That is the #4341 behavior this PR must not undo.
