### PR TITLE
[fix] Keep unused test set columns on playground rows through Run

### DIFF
--- a/web/packages/agenta-playground/src/state/controllers/playgroundController.ts
+++ b/web/packages/agenta-playground/src/state/controllers/playgroundController.ts
@@ -85,6 +85,7 @@ import {
 import {pruneDanglingConnections} from "../helpers/connectionGraph"
 import {
     collectDownstreamReferencedColumns,
+    collectTestcaseServerColumns,
     reconcileRowDataForEntity,
     resolveEntityInputContract,
 } from "../helpers/entityInputContract"
@@ -2226,8 +2227,15 @@ function pruneTestcaseRowsForEntity(get: Getter, set: Setter, entityId: string):
         const data = (row as {data?: Record<string, unknown>} | null)?.data
         if (!data || typeof data !== "object") continue
 
+        // Per-row: the synced test set's own columns are intentional data,
+        // not stale leftovers — keep them through the swap clean (#4647).
+        const serverColumns = collectTestcaseServerColumns(get, rowId)
+        const protectedKeys =
+            serverColumns.size > 0
+                ? new Set([...protectedColumns, ...serverColumns])
+                : protectedColumns
         const {dropped} = reconcileRowDataForEntity(get, entityId, data, {
-            protectedKeys: protectedColumns,
+            protectedKeys,
         })
         if (dropped.length === 0) continue
 

--- a/web/packages/agenta-playground/src/state/controllers/playgroundController.ts
+++ b/web/packages/agenta-playground/src/state/controllers/playgroundController.ts
@@ -2150,22 +2150,46 @@ function relinkLoadableSessions(
         set(executionStateAtomFamily(newLoadableId), nextExecState)
         set(executionStateAtomFamily(oldLoadableId), createInitialExecutionState())
 
-        // Also migrate row-level execution results stored on the loadable
-        // state itself. These render the per-row output cells; leaving them
-        // behind makes the just-committed revision look like it never ran.
+        // Also migrate state stored on the loadable itself:
+        //  - executionResults: per-row output cells; leaving them behind makes
+        //    the just-committed revision look like it never ran.
+        //  - the testset connection (connectedSource*, hiddenTestcaseIds,
+        //    activeRowId): the connection is keyed by loadableId, so an anchor
+        //    commit would strand it on the old key. The playground then
+        //    silently drops to local mode — the TestsetDropdown shows
+        //    unsynced and the connection-gated unused-columns footer
+        //    disappears — and the URL snapshot re-encodes the rows as a
+        //    local testset, losing the server link entirely.
         // `linkToRunnable` will overwrite linkedRunnable* immediately after
-        // this, so we don't touch those fields here — only the
-        // execution-output map needs to move.
+        // this, so we don't touch those fields here.
         const oldLoadableState = get(loadableStateAtomFamily(oldLoadableId))
-        if (Object.keys(oldLoadableState.executionResults).length > 0) {
+        const movesExecutionResults = Object.keys(oldLoadableState.executionResults).length > 0
+        const movesConnection = Boolean(oldLoadableState.connectedSourceId)
+        if (movesExecutionResults || movesConnection) {
             const newLoadableState = get(loadableStateAtomFamily(newLoadableId))
             set(loadableStateAtomFamily(newLoadableId), {
                 ...newLoadableState,
-                executionResults: oldLoadableState.executionResults,
+                ...(movesExecutionResults
+                    ? {executionResults: oldLoadableState.executionResults}
+                    : {}),
+                ...(movesConnection
+                    ? {
+                          connectedSourceId: oldLoadableState.connectedSourceId,
+                          connectedSourceName: oldLoadableState.connectedSourceName,
+                          connectedSourceType: oldLoadableState.connectedSourceType,
+                          hiddenTestcaseIds: oldLoadableState.hiddenTestcaseIds,
+                          activeRowId: oldLoadableState.activeRowId,
+                      }
+                    : {}),
             })
             set(loadableStateAtomFamily(oldLoadableId), {
                 ...oldLoadableState,
                 executionResults: {},
+                connectedSourceId: null,
+                connectedSourceName: null,
+                connectedSourceType: null,
+                hiddenTestcaseIds: new Set<string>(),
+                activeRowId: null,
             })
         }
     } else if (execRewrote) {

--- a/web/packages/agenta-playground/src/state/execution/webWorkerIntegration.ts
+++ b/web/packages/agenta-playground/src/state/execution/webWorkerIntegration.ts
@@ -21,6 +21,7 @@ import {entityIdsAtom, playgroundNodesAtom} from "../atoms/playground"
 import {clearSessionResponsesAtom, messageIdsAtomFamily, messagesByIdAtomFamily} from "../chat"
 import {
     collectDownstreamReferencedColumns,
+    collectTestcaseServerColumns,
     reconcileRowDataForEntity,
 } from "../helpers/entityInputContract"
 
@@ -336,8 +337,14 @@ export const triggerExecutionAtom = atom(
         // swaps. Columns a downstream evaluator references via `<input>_key`
         // settings (e.g. correct_answer_key → ground_truth) are protected so a
         // strict clean against the app contract doesn't drop intentional eval
-        // inputs.
+        // inputs. The synced test set's own columns are protected too (#4647):
+        // a column the prompt doesn't reference is intentional test set data,
+        // not a stale leftover, and deleting it here emptied the "unused
+        // testcase columns" footer on Run.
         const protectedColumns = collectDownstreamReferencedColumns(get, nodes)
+        for (const column of collectTestcaseServerColumns(get, testcaseRowId)) {
+            protectedColumns.add(column)
+        }
         const reconciledRow = reconcileRowDataForEntity(get, rootEntityId, rawTestcaseData, {
             protectedKeys: protectedColumns,
         })

--- a/web/packages/agenta-playground/src/state/helpers/entityInputContract.ts
+++ b/web/packages/agenta-playground/src/state/helpers/entityInputContract.ts
@@ -23,6 +23,7 @@ import {
     groupTemplateVariables,
     resolveTemplateFormat,
 } from "@agenta/entities/runnable"
+import {isSystemField, testcaseMolecule} from "@agenta/entities/testcase"
 import {workflowMolecule} from "@agenta/entities/workflow"
 import type {Getter} from "jotai"
 
@@ -238,6 +239,38 @@ export function collectDownstreamReferencedColumns(
         for (const column of collectPromptInputColumns(settings)) {
             columns.add(column)
         }
+    }
+    return columns
+}
+
+/**
+ * Collect the columns a synced test set row carries in its SERVER snapshot.
+ *
+ * These are intentional test set data, not stale leftovers, so the strict
+ * row clean must keep them even when the primary app's prompt doesn't
+ * reference them (they render under the "unused testcase columns" footer,
+ * which would otherwise empty on Run — #4647). Keys a previous primary wrote
+ * to the row locally (the #4525 stale-key case) are absent from the server
+ * snapshot, so they still get cleaned. Local/unsaved rows have no server
+ * snapshot and get no protection.
+ *
+ * `CHAT_TRANSPORT_KEYS` are excluded even when the test set stores them: a
+ * chat-formatted test set connected to a completion app must still get the
+ * chat-transport strip, and chat apps keep `messages` through `allowedKeys`
+ * without needing protection.
+ */
+export function collectTestcaseServerColumns(
+    get: Getter,
+    testcaseRowId: string | null | undefined,
+): Set<string> {
+    if (!testcaseRowId) return new Set()
+    const server = get(testcaseMolecule.selectors.serverData(testcaseRowId)) as {
+        data?: Record<string, unknown> | null
+    } | null
+    if (!server?.data || typeof server.data !== "object") return new Set()
+    const columns = new Set(Object.keys(server.data).filter((key) => !isSystemField(key)))
+    for (const key of CHAT_TRANSPORT_KEYS) {
+        columns.delete(key)
     }
     return columns
 }

--- a/web/packages/agenta-playground/tests/unit/anchorSwapConnectionMigration.test.ts
+++ b/web/packages/agenta-playground/tests/unit/anchorSwapConnectionMigration.test.ts
@@ -1,0 +1,92 @@
+/**
+ * Unit tests for the testset-connection migration on anchor swaps.
+ *
+ * Committing a playground draft replaces the anchor entity id (old revision
+ * → new revision), which changes the derived loadable id
+ * (`testset:workflow:<revisionId>`). `relinkLoadableSessions` already moved
+ * chat history and execution results to the new loadable id (AGE-3785), but
+ * left the testset connection behind on the old key. The playground then
+ * silently dropped to local mode after every commit: the TestsetDropdown
+ * showed unsynced and the connection-gated unused-columns footer vanished.
+ *
+ * These tests drive the real controller through the same path a commit
+ * takes (`setEntityIds` with a positional anchor swap) and assert the
+ * connection follows the rename.
+ *
+ * Each test uses a fresh createStore() and unique entity ids for isolation
+ * (the loadable anchor in `derivedLoadableIdAtom` is module-level state).
+ */
+
+import {loadableController} from "@agenta/entities/loadable"
+import {createStore} from "jotai"
+import {describe, expect, it} from "vitest"
+
+import {playgroundController} from "../../src/state/controllers/playgroundController"
+
+const REVISION_ID = "11111111-1111-4111-8111-111111111111"
+const TESTCASE_ID = "22222222-2222-4222-8222-222222222222"
+
+function connectPayload(loadableId: string) {
+    return {
+        loadableId,
+        revisionId: REVISION_ID,
+        testcases: [{id: TESTCASE_ID, country: "Spain"}],
+        testsetName: "Countries",
+        testsetId: "ts-1",
+        revisionVersion: 1,
+    }
+}
+
+/** Seed the playground with a connected primary entity. */
+function setupConnected(store: ReturnType<typeof createStore>, entityId: string) {
+    const loadableId = `testset:workflow:${entityId}`
+    // Connect before selecting the entity: with no nodes, isChatModeAtom
+    // resolves undefined → non-chat (same approach as the
+    // connectToTestsetKeepingLocalRows tests).
+    store.set(playgroundController.actions.connectToTestset, connectPayload(loadableId))
+    store.set(playgroundController.actions.setEntityIds, [entityId])
+    return loadableId
+}
+
+describe("anchor swap testset connection migration", () => {
+    it("moves the connection to the new loadable id on commit-style swaps", () => {
+        const store = createStore()
+        const oldLoadableId = setupConnected(store, "rev-a1")
+
+        // Commit-style anchor swap: rev-a1 is replaced in place by rev-a2.
+        store.set(playgroundController.actions.setEntityIds, ["rev-a2"])
+
+        const migrated = store.get(
+            loadableController.selectors.connectedSource("testset:workflow:rev-a2"),
+        )
+        expect(migrated?.id).toBe(REVISION_ID)
+        expect(migrated?.name).toBe("Countries (v1)")
+
+        const stranded = store.get(loadableController.selectors.connectedSource(oldLoadableId))
+        expect(stranded?.id).toBeNull()
+    })
+
+    it("keeps testcase rows visible through the swap", () => {
+        const store = createStore()
+        setupConnected(store, "rev-b1")
+
+        store.set(playgroundController.actions.setEntityIds, ["rev-b2"])
+
+        const rowIds = store.get(
+            loadableController.selectors.displayRowIds("testset:workflow:rev-b2"),
+        )
+        expect(rowIds).toEqual([TESTCASE_ID])
+    })
+
+    it("does not invent a connection when the old loadable had none", () => {
+        const store = createStore()
+        store.set(playgroundController.actions.setEntityIds, ["rev-c1"])
+
+        store.set(playgroundController.actions.setEntityIds, ["rev-c2"])
+
+        const source = store.get(
+            loadableController.selectors.connectedSource("testset:workflow:rev-c2"),
+        )
+        expect(source?.id).toBeNull()
+    })
+})

--- a/web/packages/agenta-playground/tests/unit/entityInputContract.test.ts
+++ b/web/packages/agenta-playground/tests/unit/entityInputContract.test.ts
@@ -1,37 +1,86 @@
 /**
- * Unit tests for `collectDownstreamReferencedColumns`.
+ * Unit tests for the entity input contract helpers.
  *
- * Regression (#4525): the primary app's strict row clean dropped a testcase
- * column an LLM-as-a-judge referenced only through its prompt template (e.g.
- * `{{guidelines.rubric}}`), because the protected-column collector looked only
- * at `<input>_key` settings. The evaluator then ran without `guidelines`.
+ * `collectDownstreamReferencedColumns` regression (#4525): the primary app's
+ * strict row clean dropped a testcase column an LLM-as-a-judge referenced only
+ * through its prompt template (e.g. `{{guidelines.rubric}}`), because the
+ * protected-column collector looked only at `<input>_key` settings. The
+ * evaluator then ran without `guidelines`.
  *
- * The config source (the workflow molecule) is mocked so the test stays a pure
- * function check. The template-variable extraction is the real implementation.
+ * `collectTestcaseServerColumns` regression (#4647): the strict row clean
+ * deleted a synced test set's columns the prompt didn't reference, emptying
+ * the "unused testcase columns" footer on Run. The server snapshot's columns
+ * are intentional data and must survive the clean.
+ *
+ * The atom sources (workflow + testcase molecules) are mocked so the tests
+ * stay pure function checks: each selector returns a token the fake getter
+ * resolves against fixtures. The template-variable extraction is the real
+ * implementation.
  */
 import {describe, expect, it, vi} from "vitest"
 
-// `configuration(entityId)` returns a token the fake getter resolves to a
-// config. This avoids standing up a jotai store with a hydrated workflow.
 vi.mock("@agenta/entities/workflow", () => ({
     workflowMolecule: {
         selectors: {
             configuration: (entityId: string) => ({__configFor: entityId}),
+            data: (entityId: string) => ({__dataFor: entityId}),
+            executionMode: (entityId: string) => ({__modeFor: entityId}),
+            inputPorts: (entityId: string) => ({__portsFor: entityId}),
+            requestPayload: (entityId: string) => ({__payloadFor: entityId}),
         },
     },
 }))
 
-import {collectDownstreamReferencedColumns} from "../../src/state/helpers/entityInputContract"
+// Keep the real module (other packages in the import graph use
+// `testcaseMolecule.atoms`); only `serverData` returns a token the fake
+// getter resolves against fixtures. `isSystemField` stays the real one.
+vi.mock("@agenta/entities/testcase", async (importOriginal) => {
+    const actual = await importOriginal<typeof import("@agenta/entities/testcase")>()
+    return {
+        ...actual,
+        testcaseMolecule: {
+            ...actual.testcaseMolecule,
+            selectors: {
+                ...actual.testcaseMolecule.selectors,
+                serverData: (rowId: string) => ({__serverDataFor: rowId}),
+            },
+        },
+    }
+})
+
+import {
+    collectDownstreamReferencedColumns,
+    collectTestcaseServerColumns,
+    reconcileRowDataForEntity,
+} from "../../src/state/helpers/entityInputContract"
 
 interface TestNode {
     depth: number
     entityId: string
 }
 
-function makeGet(configByEntity: Record<string, Record<string, unknown> | null>) {
+interface GetterFixtures {
+    serverDataByRow?: Record<string, {data?: Record<string, unknown> | null} | null>
+    entityById?: Record<string, unknown>
+    modeById?: Record<string, "chat" | "completion">
+    portsById?: Record<string, {key?: string}[]>
+    payloadById?: Record<string, unknown>
+}
+
+function makeGet(
+    configByEntity: Record<string, Record<string, unknown> | null>,
+    fixtures: GetterFixtures = {},
+) {
     return ((token: unknown) => {
-        const entityId = (token as {__configFor?: string} | null)?.__configFor
-        return entityId ? (configByEntity[entityId] ?? null) : null
+        const t = token as Record<string, string | undefined> | null
+        if (!t) return null
+        if (t.__configFor) return configByEntity[t.__configFor] ?? null
+        if (t.__serverDataFor) return fixtures.serverDataByRow?.[t.__serverDataFor] ?? null
+        if (t.__dataFor) return fixtures.entityById?.[t.__dataFor] ?? null
+        if (t.__modeFor) return fixtures.modeById?.[t.__modeFor]
+        if (t.__portsFor) return fixtures.portsById?.[t.__portsFor] ?? []
+        if (t.__payloadFor) return fixtures.payloadById?.[t.__payloadFor] ?? null
+        return null
     }) as Parameters<typeof collectDownstreamReferencedColumns>[0]
 }
 
@@ -158,5 +207,127 @@ describe("collectDownstreamReferencedColumns", () => {
         const columns = collectDownstreamReferencedColumns(get, nodes)
 
         expect(columns.size).toBe(0)
+    })
+})
+
+describe("collectTestcaseServerColumns", () => {
+    it("returns the connected test set's non-system columns", () => {
+        const get = makeGet(
+            {},
+            {
+                serverDataByRow: {
+                    tc1: {
+                        data: {
+                            country: "France",
+                            capital: "Paris",
+                            id: "tc1",
+                            testset_id: "ts1",
+                            created_at: "2026-06-01",
+                        },
+                    },
+                },
+            },
+        )
+
+        const columns = collectTestcaseServerColumns(get, "tc1")
+
+        expect([...columns].sort()).toEqual(["capital", "country"])
+    })
+
+    it("excludes chat transport keys so the chat-to-completion strip is preserved", () => {
+        const get = makeGet(
+            {},
+            {
+                serverDataByRow: {
+                    tc1: {data: {messages: [{role: "user", content: "hi"}], country: "France"}},
+                },
+            },
+        )
+
+        const columns = collectTestcaseServerColumns(get, "tc1")
+
+        expect(columns.has("messages")).toBe(false)
+        expect(columns.has("country")).toBe(true)
+    })
+
+    it("returns an empty set when the row has no server data (local row)", () => {
+        const get = makeGet({}, {serverDataByRow: {tc1: null}})
+
+        expect(collectTestcaseServerColumns(get, "tc1").size).toBe(0)
+    })
+
+    it("returns an empty set for a missing row id", () => {
+        const get = makeGet({})
+
+        expect(collectTestcaseServerColumns(get, undefined).size).toBe(0)
+        expect(collectTestcaseServerColumns(get, null).size).toBe(0)
+    })
+})
+
+describe("reconcileRowDataForEntity with protected server columns", () => {
+    const completionAppFixtures: GetterFixtures = {
+        entityById: {app: {flags: {}}},
+        modeById: {app: "completion" as const},
+        portsById: {app: [{key: "country"}]},
+    }
+
+    it("keeps protected server columns and still drops stale local keys", () => {
+        const get = makeGet(
+            {},
+            {
+                ...completionAppFixtures,
+                serverDataByRow: {tc1: {data: {country: "France", capital: "Paris"}}},
+            },
+        )
+        const serverColumns = collectTestcaseServerColumns(get, "tc1")
+
+        const result = reconcileRowDataForEntity(
+            get,
+            "app",
+            {
+                country: "France",
+                capital: "Paris",
+                // Stale local key from a previously selected chat app — not in
+                // the server snapshot, so it must still be cleaned (#4525).
+                messages: [{role: "user", content: "hi"}],
+            },
+            {protectedKeys: serverColumns},
+        )
+
+        expect(result.strategy).toBe("strict")
+        expect(result.dropped).toEqual(["messages"])
+        expect(result.data).toEqual({country: "France", capital: "Paris"})
+    })
+
+    it("drops unreferenced columns when the row has no server snapshot", () => {
+        const get = makeGet({}, completionAppFixtures)
+        const serverColumns = collectTestcaseServerColumns(get, "local-1")
+
+        const result = reconcileRowDataForEntity(
+            get,
+            "app",
+            {country: "France", capital: "Paris"},
+            {protectedKeys: serverColumns},
+        )
+
+        expect(result.dropped).toEqual(["capital"])
+    })
+
+    it("keeps messages for a chat app through allowedKeys, not protection", () => {
+        const get = makeGet(
+            {},
+            {
+                entityById: {app: {flags: {}}},
+                modeById: {app: "chat" as const},
+                portsById: {app: [{key: "country"}]},
+            },
+        )
+
+        const result = reconcileRowDataForEntity(get, "app", {
+            country: "France",
+            messages: [{role: "user", content: "hi"}],
+        })
+
+        expect(result.dropped).toEqual([])
     })
 })


### PR DESCRIPTION
## Context

In the playground, columns of a synced test set that the prompt does not reference show under a collapsed "unused testcase columns" footer. The moment you clicked Run, they disappeared. The deletion was real, not just visual: the run removed the columns from the testcase row state, so committing the rows back could lose them from the test set.

The pre-run strict row clean from #4525 caused this. It reconciles the shared testcase row against the app's input contract and persists the deletion of every key the app does not declare. It could not tell a stale leftover key (chat `messages` after swapping a chat app to a completion app, the #4525 case) apart from a genuine test set column the prompt just does not use.

Fixes #4647

## Changes

A new helper, `collectTestcaseServerColumns`, reads the testcase's server snapshot (`testcaseMolecule.selectors.serverData`) and returns its non-system columns. Both persisting cleans (the run-time reconcile in `webWorkerIntegration.ts` and the app-swap prune in `playgroundController.ts`) add these columns to the protected set.

This draws the line where it belongs: keys in the server snapshot are intentional test set data and survive the clean; keys that only exist locally were written by a previous app and still get dropped. Local, unsaved rows have no server snapshot and keep the old behavior.

`messages` is never protected, even when the test set stores it. Chat apps already keep it through `allowedKeys`, and for completion apps the #4525 chat-transport strip must keep firing.

Before: clicking Run deleted `capital` and `notes` from a row synced from a test set with columns `country`, `capital`, `notes` when the prompt only used `{{country}}`.
After: the footer keeps showing them with their values; the run request still sends only `{"country": ...}`.

## Tests

- 7 new unit tests in `entityInputContract.test.ts` (server-column collection, system-field filtering, `messages` exclusion, strict reconcile with protected columns). `pnpm --filter @agenta/playground test`: 79 passed.
- Verified on the dev deployment: synced `completion_testset` to the Completion app, ran two rows. The unused `guidelines` column stayed visible with its value, and the `/services/completion/v0/invoke` body contained only `country`.
- Rows that already lost columns under the old behavior keep their pruned drafts. Reconnecting the test set restores them.

## What to QA

- Playground: connect a test set that has more columns than the prompt uses, expand the unused-columns footer, click Run. The columns stay, values intact.
- Same check after swapping the primary app in the evaluator configuration screen: unused test set columns survive the swap on all rows.
- Regression (#4525): run a chat app so `messages` lands on the shared row, swap to a completion app, Run. The request body has no `messages` and no stale chat keys reappear.
