### PR TITLE
fix(frontend): keep the test set synced across playground commits

### DIFF
--- a/web/packages/agenta-playground/src/state/controllers/playgroundController.ts
+++ b/web/packages/agenta-playground/src/state/controllers/playgroundController.ts
@@ -2150,22 +2150,46 @@ function relinkLoadableSessions(
         set(executionStateAtomFamily(newLoadableId), nextExecState)
         set(executionStateAtomFamily(oldLoadableId), createInitialExecutionState())
 
-        // Also migrate row-level execution results stored on the loadable
-        // state itself. These render the per-row output cells; leaving them
-        // behind makes the just-committed revision look like it never ran.
+        // Also migrate state stored on the loadable itself:
+        //  - executionResults: per-row output cells; leaving them behind makes
+        //    the just-committed revision look like it never ran.
+        //  - the testset connection (connectedSource*, hiddenTestcaseIds,
+        //    activeRowId): the connection is keyed by loadableId, so an anchor
+        //    commit would strand it on the old key. The playground then
+        //    silently drops to local mode — the TestsetDropdown shows
+        //    unsynced and the connection-gated unused-columns footer
+        //    disappears — and the URL snapshot re-encodes the rows as a
+        //    local testset, losing the server link entirely.
         // `linkToRunnable` will overwrite linkedRunnable* immediately after
-        // this, so we don't touch those fields here — only the
-        // execution-output map needs to move.
+        // this, so we don't touch those fields here.
         const oldLoadableState = get(loadableStateAtomFamily(oldLoadableId))
-        if (Object.keys(oldLoadableState.executionResults).length > 0) {
+        const movesExecutionResults = Object.keys(oldLoadableState.executionResults).length > 0
+        const movesConnection = Boolean(oldLoadableState.connectedSourceId)
+        if (movesExecutionResults || movesConnection) {
             const newLoadableState = get(loadableStateAtomFamily(newLoadableId))
             set(loadableStateAtomFamily(newLoadableId), {
                 ...newLoadableState,
-                executionResults: oldLoadableState.executionResults,
+                ...(movesExecutionResults
+                    ? {executionResults: oldLoadableState.executionResults}
+                    : {}),
+                ...(movesConnection
+                    ? {
+                          connectedSourceId: oldLoadableState.connectedSourceId,
+                          connectedSourceName: oldLoadableState.connectedSourceName,
+                          connectedSourceType: oldLoadableState.connectedSourceType,
+                          hiddenTestcaseIds: oldLoadableState.hiddenTestcaseIds,
+                          activeRowId: oldLoadableState.activeRowId,
+                      }
+                    : {}),
             })
             set(loadableStateAtomFamily(oldLoadableId), {
                 ...oldLoadableState,
                 executionResults: {},
+                connectedSourceId: null,
+                connectedSourceName: null,
+                connectedSourceType: null,
+                hiddenTestcaseIds: new Set<string>(),
+                activeRowId: null,
             })
         }
     } else if (execRewrote) {

--- a/web/packages/agenta-playground/tests/unit/anchorSwapConnectionMigration.test.ts
+++ b/web/packages/agenta-playground/tests/unit/anchorSwapConnectionMigration.test.ts
@@ -1,0 +1,92 @@
+/**
+ * Unit tests for the testset-connection migration on anchor swaps.
+ *
+ * Committing a playground draft replaces the anchor entity id (old revision
+ * → new revision), which changes the derived loadable id
+ * (`testset:workflow:<revisionId>`). `relinkLoadableSessions` already moved
+ * chat history and execution results to the new loadable id (AGE-3785), but
+ * left the testset connection behind on the old key. The playground then
+ * silently dropped to local mode after every commit: the TestsetDropdown
+ * showed unsynced and the connection-gated unused-columns footer vanished.
+ *
+ * These tests drive the real controller through the same path a commit
+ * takes (`setEntityIds` with a positional anchor swap) and assert the
+ * connection follows the rename.
+ *
+ * Each test uses a fresh createStore() and unique entity ids for isolation
+ * (the loadable anchor in `derivedLoadableIdAtom` is module-level state).
+ */
+
+import {loadableController} from "@agenta/entities/loadable"
+import {createStore} from "jotai"
+import {describe, expect, it} from "vitest"
+
+import {playgroundController} from "../../src/state/controllers/playgroundController"
+
+const REVISION_ID = "11111111-1111-4111-8111-111111111111"
+const TESTCASE_ID = "22222222-2222-4222-8222-222222222222"
+
+function connectPayload(loadableId: string) {
+    return {
+        loadableId,
+        revisionId: REVISION_ID,
+        testcases: [{id: TESTCASE_ID, country: "Spain"}],
+        testsetName: "Countries",
+        testsetId: "ts-1",
+        revisionVersion: 1,
+    }
+}
+
+/** Seed the playground with a connected primary entity. */
+function setupConnected(store: ReturnType<typeof createStore>, entityId: string) {
+    const loadableId = `testset:workflow:${entityId}`
+    // Connect before selecting the entity: with no nodes, isChatModeAtom
+    // resolves undefined → non-chat (same approach as the
+    // connectToTestsetKeepingLocalRows tests).
+    store.set(playgroundController.actions.connectToTestset, connectPayload(loadableId))
+    store.set(playgroundController.actions.setEntityIds, [entityId])
+    return loadableId
+}
+
+describe("anchor swap testset connection migration", () => {
+    it("moves the connection to the new loadable id on commit-style swaps", () => {
+        const store = createStore()
+        const oldLoadableId = setupConnected(store, "rev-a1")
+
+        // Commit-style anchor swap: rev-a1 is replaced in place by rev-a2.
+        store.set(playgroundController.actions.setEntityIds, ["rev-a2"])
+
+        const migrated = store.get(
+            loadableController.selectors.connectedSource("testset:workflow:rev-a2"),
+        )
+        expect(migrated?.id).toBe(REVISION_ID)
+        expect(migrated?.name).toBe("Countries (v1)")
+
+        const stranded = store.get(loadableController.selectors.connectedSource(oldLoadableId))
+        expect(stranded?.id).toBeNull()
+    })
+
+    it("keeps testcase rows visible through the swap", () => {
+        const store = createStore()
+        setupConnected(store, "rev-b1")
+
+        store.set(playgroundController.actions.setEntityIds, ["rev-b2"])
+
+        const rowIds = store.get(
+            loadableController.selectors.displayRowIds("testset:workflow:rev-b2"),
+        )
+        expect(rowIds).toEqual([TESTCASE_ID])
+    })
+
+    it("does not invent a connection when the old loadable had none", () => {
+        const store = createStore()
+        store.set(playgroundController.actions.setEntityIds, ["rev-c1"])
+
+        store.set(playgroundController.actions.setEntityIds, ["rev-c2"])
+
+        const source = store.get(
+            loadableController.selectors.connectedSource("testset:workflow:rev-c2"),
+        )
+        expect(source?.id).toBeNull()
+    })
+})


### PR DESCRIPTION
## Context

Committing a prompt in the playground silently disconnected the synced test set. The header dropdown flipped back to "Test set", the "N unused testcase columns hidden" footer disappeared from every row, and the URL snapshot then saved the rows as a local test set instead of a connection. Creating an app from a draft prompt hits the same path (it is the first commit), which is how this was reported: sync a test set, create the app, the hidden columns vanish.

Root cause: the connection lives in loadable state keyed by `testset:workflow:<revisionId>`. A commit produces a new revision id, so the key changes. The relink step that already carries chat history and execution results across that rename (Agenta-AI/agenta#4457) never carried the connection, so it stayed stranded on the old key.

This also undermined Agenta-AI/agenta#4647/Agenta-AI/agenta#4649: once the snapshot downgrades the rows to a local test set, they lose their server snapshot, and the next Run deletes the unused columns again.

## Changes

`relinkLoadableSessions` now migrates `connectedSourceId`, `connectedSourceName`, `connectedSourceType`, `hiddenTestcaseIds`, and `activeRowId` to the new loadable id in the same pass that already moves `executionResults`, and clears them on the old key.

Before: commit v1 to v2, the dropdown shows "Test set" and the unused-column footers are gone.  <br>After: commit v1 to v2, the dropdown still shows "completion_testset (v2)", footers and values stay, and a reload keeps the connection (the snapshot encodes it again).

## Tests

* 3 new unit tests (`anchorSwapConnectionMigration.test.ts`) drive the real controller through a commit-style anchor swap with a real Jotai store. Package suite passes 89/89; `tsc --noEmit` and `pnpm lint-fix` clean.
* QA on the dev deployment passed all four flows: create-from-draft keeps the sync, plain commit keeps it, reload keeps it, and Run still preserves the unused column values (the Agenta-AI/agenta#4649 regression check).
* Adversarial subagent review found no blockers. Two pre-existing positional-swap flaws now also affect the connection and are left as follow-ups: opening the revision drawer over a stale playground selection mis-moves loadable state (it already mis-moved chat and results before this PR), and in compare mode the index-0 anchor detection can disagree with the real loadable anchor after a column reorder. Fixing both means reworking the Agenta-AI/agenta#4457 anchor detection, out of scope here.

## What to QA

* Prompts > Create new > New prompt, connect a test set that has columns the prompt does not use, click Create. On the new app's playground the test set still shows as synced and every row keeps its "unused testcase column hidden" footer.
* Edit the prompt and Commit as a new version. The sync, footers, and values survive.
* Reload the page. Still synced.
* Run a row. The unused column and its value are still there after the run.
* Regression: disconnect the test set from the dropdown after a commit. It should disconnect cleanly and fall back to a local test set.

Stacked on Agenta-AI/agenta#4649 (`wip/playground-testcase-server-columns`).

Closes Agenta-AI/agenta#4655.