### PR TITLE
[fix] Resolve broken `references` in Playground

### DIFF
--- a/.all-contributorsrc
+++ b/.all-contributorsrc
@@ -605,6 +605,15 @@
       "contributions": [
         "code"
       ]
+    },
+    {
+      "login": "unfitcoder101",
+      "name": "unfitcoder101",
+      "avatar_url": "https://avatars.githubusercontent.com/u/175036458?v=4",
+      "profile": "https://github.com/unfitcoder101",
+      "contributions": [
+        "bug"
+      ]
     }
   ],
   "contributorsPerLine": 7,

--- a/README.md
+++ b/README.md
@@ -191,7 +191,7 @@ We welcome contributions of all kinds, from filing issues and sharing ideas to i
 ## Contributors ✨
 
 <!-- ALL-CONTRIBUTORS-BADGE:START - Do not remove or modify this section -->
-[![All Contributors](https://img.shields.io/badge/all_contributors-64-orange.svg?style=flat-square)](#contributors-)
+[![All Contributors](https://img.shields.io/badge/all_contributors-65-orange.svg?style=flat-square)](#contributors-)
 <!-- ALL-CONTRIBUTORS-BADGE:END -->
 
 Thanks goes to these wonderful people ([emoji key](https://allcontributors.org/docs/en/emoji-key)):
@@ -284,6 +284,7 @@ Thanks goes to these wonderful people ([emoji key](https://allcontributors.org/d
     </tr>
     <tr>
       <td align="center" valign="top" width="14.28%"><a href="https://github.com/Sanket2329"><img src="https://avatars.githubusercontent.com/u/196506711?v=4?s=100" width="100px;" alt="Sanket Shakya"/><br /><sub><b>Sanket Shakya</b></sub></a><br /><a href="https://github.com/Agenta-AI/agenta/commits?author=Sanket2329" title="Code">💻</a></td>
+      <td align="center" valign="top" width="14.28%"><a href="https://github.com/unfitcoder101"><img src="https://avatars.githubusercontent.com/u/175036458?v=4?s=100" width="100px;" alt="unfitcoder101"/><br /><sub><b>unfitcoder101</b></sub></a><br /><a href="https://github.com/Agenta-AI/agenta/issues?q=author%3Aunfitcoder101" title="Bug reports">🐛</a></td>
     </tr>
   </tbody>
 </table>

--- a/api/oss/src/core/workflows/service.py
+++ b/api/oss/src/core/workflows/service.py
@@ -395,6 +395,52 @@ class WorkflowsService:
         )
 
     @staticmethod
+    def _validate_execution_reference_families(
+        *,
+        request: WorkflowServiceRequest,
+    ) -> tuple[Optional[Reference], Optional[Reference], Optional[Reference]]:
+        refs = request.references or {}
+
+        families = {
+            "workflow": (
+                refs.get("workflow"),
+                refs.get("workflow_variant"),
+                refs.get("workflow_revision"),
+            ),
+            "application": (
+                refs.get("application"),
+                refs.get("application_variant"),
+                refs.get("application_revision"),
+            ),
+            "evaluator": (
+                refs.get("evaluator"),
+                refs.get("evaluator_variant"),
+                refs.get("evaluator_revision"),
+            ),
+        }
+
+        populated = [
+            (name, artifact_ref, variant_ref, revision_ref)
+            for name, (artifact_ref, variant_ref, revision_ref) in families.items()
+            if any(ref is not None for ref in (artifact_ref, variant_ref, revision_ref))
+        ]
+
+        if len(populated) > 1:
+            names = ", ".join(name for name, *_ in populated)
+            error = ValueError(
+                "Workflow execution accepts exactly one of the workflow, "
+                f"application, or evaluator reference families. Received: {names}."
+            )
+            error.status_code = 400  # type: ignore[attr-defined]
+            raise error
+
+        if not populated:
+            return None, None, None
+
+        _, artifact_ref, variant_ref, revision_ref = populated[0]
+        return artifact_ref, variant_ref, revision_ref
+
+    @staticmethod
     def _get_revision_data(
         *,
         request: WorkflowServiceRequest,
@@ -524,11 +570,20 @@ class WorkflowsService:
             return
 
         refs = request.references
-        workflow_ref = refs.get("workflow")
+        (
+            workflow_ref,
+            workflow_variant_ref,
+            workflow_revision_ref,
+        ) = self._validate_execution_reference_families(request=request)
         workflow_revision = None
+        selector_key = (
+            request.selector.get("key")
+            if isinstance(request.selector, dict)
+            else getattr(request.selector, "key", None)
+        )
 
         if "environment" in refs:
-            key = (
+            key = selector_key or (
                 f"{workflow_ref.slug}.revision"
                 if workflow_ref and workflow_ref.slug
                 else None
@@ -539,12 +594,12 @@ class WorkflowsService:
                 key=key,
             )
 
-        elif "workflow_revision" in refs or "workflow" in refs:
+        elif workflow_revision_ref or workflow_variant_ref or workflow_ref:
             workflow_revision, _, _ = await self.retrieve_workflow_revision(
                 project_id=project_id,
                 workflow_ref=workflow_ref,
-                workflow_variant_ref=refs.get("workflow_variant"),
-                workflow_revision_ref=refs.get("workflow_revision"),
+                workflow_variant_ref=workflow_variant_ref,
+                workflow_revision_ref=workflow_revision_ref,
             )
 
         if workflow_revision and workflow_revision.data:

--- a/sdks/python/agenta/sdk/middlewares/running/resolver.py
+++ b/sdks/python/agenta/sdk/middlewares/running/resolver.py
@@ -32,6 +32,19 @@ def _raise_bad_request(message: str) -> None:
     raise error
 
 
+def _has_reference_identity(ref: Any) -> bool:
+    if ref is None:
+        return False
+
+    if hasattr(ref, "model_dump"):
+        return bool(ref.model_dump(mode="json", exclude_none=True))
+
+    if isinstance(ref, dict):
+        return any(value is not None for value in ref.values())
+
+    return True
+
+
 def _validate_executable_reference_families(refs: Dict[str, Any]) -> None:
     families = {
         "workflow": (
@@ -54,7 +67,7 @@ def _validate_executable_reference_families(refs: Dict[str, Any]) -> None:
     populated = [
         family_name
         for family_name, family_keys in families.items()
-        if any(key in refs for key in family_keys)
+        if any(_has_reference_identity(refs.get(key)) for key in family_keys)
     ]
 
     if len(populated) > 1:

--- a/sdks/python/agenta/sdk/middlewares/running/resolver.py
+++ b/sdks/python/agenta/sdk/middlewares/running/resolver.py
@@ -26,6 +26,45 @@ _EMBEDS_ERROR_POLICY = "exception"
 _AG_EMBED_MARKER = "@ag.embed"
 
 
+def _raise_bad_request(message: str) -> None:
+    error = ValueError(message)
+    error.status_code = 400  # type: ignore[attr-defined]
+    raise error
+
+
+def _validate_executable_reference_families(refs: Dict[str, Any]) -> None:
+    families = {
+        "workflow": (
+            "workflow",
+            "workflow_variant",
+            "workflow_revision",
+        ),
+        "application": (
+            "application",
+            "application_variant",
+            "application_revision",
+        ),
+        "evaluator": (
+            "evaluator",
+            "evaluator_variant",
+            "evaluator_revision",
+        ),
+    }
+
+    populated = [
+        family_name
+        for family_name, family_keys in families.items()
+        if any(key in refs for key in family_keys)
+    ]
+
+    if len(populated) > 1:
+        _raise_bad_request(
+            "Competing execution target references are not allowed. "
+            "Provide exactly one of workflow, application, or evaluator "
+            f"references; got {', '.join(populated)}."
+        )
+
+
 def _has_embed_markers(config: Any, _depth: int = 0) -> bool:
     """Check if a configuration contains any @ag.embed markers.
 
@@ -170,6 +209,8 @@ async def resolve_references_with_info(
     """
     if not request.references:
         return None, None, None
+
+    _validate_executable_reference_families(request.references)
 
     try:
         if not ag.async_api:

--- a/sdks/python/oss/tests/pytest/utils/test_resolver_middleware.py
+++ b/sdks/python/oss/tests/pytest/utils/test_resolver_middleware.py
@@ -11,7 +11,10 @@ import pytest
 from unittest.mock import AsyncMock, MagicMock, patch
 
 from agenta.sdk.contexts.tracing import TracingContext, tracing_context_manager
-from agenta.sdk.middlewares.running.resolver import _has_embed_markers
+from agenta.sdk.middlewares.running.resolver import (
+    _has_embed_markers,
+    resolve_references_with_info,
+)
 
 
 class TestHasEmbedMarkers:
@@ -418,6 +421,24 @@ class TestResolverMiddlewareEmbedGate:
             assert TracingContext.get().selector is None
         finally:
             TracingContext.reset(token)
+
+
+class TestResolverReferenceValidation:
+    @pytest.mark.asyncio
+    async def test_rejects_competing_application_and_evaluator_refs(self):
+        from agenta.sdk.models.workflows import WorkflowInvokeRequest
+
+        request = WorkflowInvokeRequest(
+            references={
+                "application": {"slug": "my-app"},
+                "evaluator": {"slug": "my-eval"},
+            }
+        )
+
+        with pytest.raises(ValueError, match="Competing execution target references"):
+            await resolve_references_with_info(
+                request=request, credentials="test-creds"
+            )
 
 
 class TestResolverMiddlewareTracingParameters:

--- a/sdks/python/oss/tests/pytest/utils/test_resolver_middleware.py
+++ b/sdks/python/oss/tests/pytest/utils/test_resolver_middleware.py
@@ -8,11 +8,13 @@ Tests cover:
 """
 
 import pytest
+import agenta as ag
 from unittest.mock import AsyncMock, MagicMock, patch
 
 from agenta.sdk.contexts.tracing import TracingContext, tracing_context_manager
 from agenta.sdk.middlewares.running.resolver import (
     _has_embed_markers,
+    _validate_executable_reference_families,
     resolve_references_with_info,
 )
 
@@ -432,13 +434,39 @@ class TestResolverReferenceValidation:
             references={
                 "application": {"slug": "my-app"},
                 "evaluator": {"slug": "my-eval"},
-            }
+            },
         )
 
         with pytest.raises(ValueError, match="Competing execution target references"):
             await resolve_references_with_info(
-                request=request, credentials="test-creds"
+                request=request,
+                credentials="test-creds",
             )
+
+    @pytest.mark.asyncio
+    async def test_ignores_empty_reference_objects(self):
+        from agenta.sdk.models.workflows import WorkflowInvokeRequest
+
+        request = WorkflowInvokeRequest(
+            references={
+                "application": {},
+                "evaluator": {"slug": "my-eval"},
+            },
+        )
+
+        with patch.object(ag, "async_api", None):
+            assert await resolve_references_with_info(
+                request=request,
+                credentials="test-creds",
+            ) == (None, None, None)
+
+    def test_ignores_none_reference_values(self):
+        _validate_executable_reference_families(
+            {
+                "application": None,
+                "evaluator": {"slug": "my-eval"},
+            },
+        )
 
 
 class TestResolverMiddlewareTracingParameters:

--- a/web/packages/agenta-playground/src/state/execution/executionRunner.ts
+++ b/web/packages/agenta-playground/src/state/execution/executionRunner.ts
@@ -107,6 +107,50 @@ function normalizeApplicationReferences(
     return Object.keys(normalized).length > 0 ? normalized : undefined
 }
 
+function normalizeEvaluatorReferences(
+    references: RequestPayloadData["references"],
+): TraceReferenceMap | undefined {
+    if (!references) return undefined
+
+    const evaluatorRef = asRecord(references.evaluator)
+    const evaluatorVariantRef = asRecord(references.evaluator_variant)
+    const evaluatorRevisionRef = asRecord(references.evaluator_revision)
+    const normalized: TraceReferenceMap = {}
+
+    const evaluatorId = readString(evaluatorRef?.id)
+    const evaluatorSlug = readString(evaluatorRef?.slug)
+    if (evaluatorId || evaluatorSlug) {
+        normalized.evaluator = {
+            ...(evaluatorId ? {id: evaluatorId} : {}),
+            ...(evaluatorSlug ? {slug: evaluatorSlug} : {}),
+        }
+    }
+
+    const evaluatorVariantId =
+        readString(evaluatorVariantRef?.id) || readString(evaluatorRef?.variant_id)
+    const evaluatorVariantSlug = readString(evaluatorVariantRef?.slug)
+    if (evaluatorVariantId || evaluatorVariantSlug) {
+        normalized.evaluator_variant = {
+            ...(evaluatorVariantId ? {id: evaluatorVariantId} : {}),
+            ...(evaluatorVariantSlug ? {slug: evaluatorVariantSlug} : {}),
+        }
+    }
+
+    const evaluatorRevisionId =
+        readString(evaluatorRevisionRef?.id) || readString(evaluatorRef?.revision_id)
+    const evaluatorRevisionSlug = readString(evaluatorRevisionRef?.slug)
+    const evaluatorRevisionVersion = readString(evaluatorRevisionRef?.version)
+    if (evaluatorRevisionId || evaluatorRevisionSlug || evaluatorRevisionVersion) {
+        normalized.evaluator_revision = {
+            ...(evaluatorRevisionId ? {id: evaluatorRevisionId} : {}),
+            ...(evaluatorRevisionSlug ? {slug: evaluatorRevisionSlug} : {}),
+            ...(evaluatorRevisionVersion ? {version: evaluatorRevisionVersion} : {}),
+        }
+    }
+
+    return Object.keys(normalized).length > 0 ? normalized : undefined
+}
+
 function toRunnableNode(node: PlaygroundNode): RunnableNode {
     return {
         id: node.id,
@@ -161,7 +205,65 @@ function buildUpstreamReferences(params: {
         workflowMolecule.selectors.requestPayload(sourceNode.entity.id),
     ) as RequestPayloadData | null
 
-    return normalizeApplicationReferences(sourcePayload?.references)
+    return (
+        normalizeApplicationReferences(sourcePayload?.references) ??
+        buildApplicationSelfReferences({
+            get: params.get,
+            revisionId: sourceNode.entity.id,
+        })
+    )
+}
+
+function buildApplicationSelfReferences(params: {
+    get: Getter
+    revisionId: string
+}): TraceReferenceMap | undefined {
+    const revision = params.get(workflowMolecule.selectors.data(params.revisionId)) as
+        | (Record<string, unknown> & {flags?: Record<string, unknown> | null})
+        | null
+    if (!revision || revision.flags?.is_evaluator === true) return undefined
+
+    const realId = (value: unknown): string | undefined => {
+        const s = readString(value)
+        return s && !isLocalDraftId(s) ? s : undefined
+    }
+
+    const refs: TraceReferenceMap = {}
+
+    const workflowId = realId(revision.workflow_id) ?? realId(revision.artifact_id)
+    const workflowSlug = readString(revision.workflow_slug) ?? readString(revision.artifact_slug)
+    if (workflowId || workflowSlug) {
+        refs.application = {
+            ...(workflowId ? {id: workflowId} : {}),
+            ...(workflowSlug ? {slug: workflowSlug} : {}),
+        }
+    }
+
+    const variantId = realId(revision.workflow_variant_id) ?? realId(revision.variant_id)
+    const variantSlug =
+        readString(revision.workflow_variant_slug) ?? readString(revision.variant_slug)
+    if (variantId || variantSlug) {
+        refs.application_variant = {
+            ...(variantId ? {id: variantId} : {}),
+            ...(variantSlug ? {slug: variantSlug} : {}),
+        }
+    }
+
+    const revisionId = realId(revision.id) ?? realId(params.revisionId)
+    const revisionSlug = readString(revision.slug)
+    const revisionVersion =
+        typeof revision.version === "number"
+            ? String(revision.version)
+            : readString(revision.version)
+    if (revisionId || revisionSlug || revisionVersion) {
+        refs.application_revision = {
+            ...(revisionId ? {id: revisionId} : {}),
+            ...(revisionSlug ? {slug: revisionSlug} : {}),
+            ...(revisionVersion ? {version: revisionVersion} : {}),
+        }
+    }
+
+    return Object.keys(refs).length > 0 ? refs : undefined
 }
 
 /**
@@ -192,6 +294,12 @@ function buildEvaluatorSelfReferences(params: {
     get: Getter
     revisionId: string
 }): TraceReferenceMap | undefined {
+    const requestPayload = params.get(
+        workflowMolecule.selectors.requestPayload(params.revisionId),
+    ) as RequestPayloadData | null
+    const requestRefs = normalizeEvaluatorReferences(requestPayload?.references)
+    if (requestRefs) return requestRefs
+
     const revision = params.get(workflowMolecule.selectors.data(params.revisionId)) as
         | (Record<string, unknown> & {flags?: Record<string, unknown> | null})
         | null
@@ -610,24 +718,18 @@ export async function executeStepForSessionWithExecutionItems(
                             : undefined
                     const stageReferences = (() => {
                         if (node.depth === 0) return undefined
-                        const upstream = buildUpstreamReferences({
+                        const selfEval = buildEvaluatorSelfReferences({
+                            get,
+                            revisionId: node.entity.id as string,
+                        })
+                        if (selfEval) return selfEval
+                        return buildUpstreamReferences({
                             get,
                             incomingConnection: allConnections.find(
                                 (connection) => connection.targetNodeId === nodeId,
                             ),
                             runnableNodes,
                         })
-                        // For evaluator stages, also attach the evaluator's
-                        // own identity so the emitted trace can be found via
-                        // `references.evaluator.slug` on the evaluator's
-                        // /apps/<evalId>/traces page. Merges with upstream
-                        // application refs (the app being scored).
-                        const selfEval = buildEvaluatorSelfReferences({
-                            get,
-                            revisionId: node.entity.id as string,
-                        })
-                        if (!upstream && !selfEval) return undefined
-                        return {...(upstream ?? {}), ...(selfEval ?? {})}
                     })()
 
                     const stageExecutionItem = stageHandle.run({


### PR DESCRIPTION
## What happened

Evaluator playground runs were sending both `evaluator*` and upstream `application*` references to the evaluator `/invoke` request. The application trace link is valid under `links.application`, but the evaluator request references should identify only the evaluator being invoked.

## What changed

- Updated playground chain execution to use evaluator self references for evaluator stages instead of merging upstream application references.
- Normalized evaluator and application reference families before attaching them to stage invoke payloads.
- Added API/SDK validation to reject competing runnable reference families.