### PR TITLE
fix(frontend): resolve evaluation names for SDK-created apps and new evaluators

### DIFF
--- a/web/oss/src/components/EvalRunDetails/atoms/table/evaluators.ts
+++ b/web/oss/src/components/EvalRunDetails/atoms/table/evaluators.ts
@@ -3,6 +3,7 @@ import {
     fetchWorkflowRevisionById,
     extractEvaluatorRef,
     deduplicateRefs,
+    queryWorkflows,
     toEvaluatorDefinitionFromWorkflow,
     toEvaluatorDefinitionFromRaw,
     type EvaluatorDefinition,
@@ -47,6 +48,31 @@ const evaluatorRevisionQueryAtomFamily = atomFamily(
                         return null
                     }
                 }
+            },
+            enabled: !!projectId && !!id,
+            staleTime: 5 * 60_000,
+            refetchOnWindowFocus: false,
+        })),
+    (a, b) => a.projectId === b.projectId && a.id === b.id,
+)
+
+/**
+ * Self-contained query for the workflow ARTIFACT (the workflow-level
+ * container). The entity display name lives there; the revision's own `name`
+ * carries the variant name ("default"). Defined locally (like the revision
+ * query above) so it runs in the evaluations scoped store.
+ */
+const evaluatorArtifactQueryAtomFamily = atomFamily(
+    ({projectId, id}: {projectId: string; id: string}) =>
+        atomWithQuery(() => ({
+            queryKey: ["eval-run", "evaluator-artifact", projectId, id],
+            queryFn: async () => {
+                const response = await queryWorkflows({
+                    projectId,
+                    workflowRefs: [{id}],
+                    includeArchived: true,
+                })
+                return response.workflows?.[0] ?? null
             },
             enabled: !!projectId && !!id,
             staleTime: 5 * 60_000,
@@ -139,6 +165,15 @@ export const evaluationEvaluatorsByRunQueryAtomFamily = atomFamily((runId: strin
                 const lookupId = ref.artifactId ?? ref.revisionId ?? refId
                 if (lookupId && definition.id !== lookupId) {
                     definition.id = lookupId
+                }
+                // The entity display name lives on the workflow artifact; the
+                // revision's own `name` carries the variant name ("default").
+                const artifactId = ref.artifactId ?? workflow.workflow_id ?? null
+                if (artifactId) {
+                    const artifactName = get(
+                        evaluatorArtifactQueryAtomFamily({projectId, id: artifactId}),
+                    ).data?.name
+                    if (artifactName) definition.name = artifactName
                 }
                 definitions.push(definition)
             } else if (!anyPending) {

--- a/web/oss/src/components/EvalRunDetails/components/views/OverviewView/utils/evaluatorMetrics.ts
+++ b/web/oss/src/components/EvalRunDetails/components/views/OverviewView/utils/evaluatorMetrics.ts
@@ -140,11 +140,17 @@ export const buildEvaluatorMetricEntries = (
                 })
             }
 
+            // Match by id OR slug (same as EvaluatorMetricsChart): refs may
+            // carry the revision id while definitions are keyed by artifact id.
+            const definition = evaluatorDefinitions?.find?.(
+                (def) =>
+                    (evaluatorRef?.id && def.id === evaluatorRef.id) ||
+                    (evaluatorRef?.slug && def.slug === evaluatorRef.slug),
+            )
+
             return {
                 stepKey,
-                label:
-                    evaluatorDefinitions?.find?.((def) => def.id === evaluatorRef?.id)?.name ??
-                    label,
+                label: definition?.name ?? label,
                 evaluatorRef,
                 metrics: Array.from(unique.values()),
             }

--- a/web/oss/src/components/References/ReferenceLabels.tsx
+++ b/web/oss/src/components/References/ReferenceLabels.tsx
@@ -1,6 +1,10 @@
 import {memo, useMemo} from "react"
 
-import {getWorkflowTypeColor, workflowMolecule} from "@agenta/entities/workflow"
+import {
+    getWorkflowTypeColor,
+    workflowMolecule,
+    workflowVariantsListQueryStateAtomFamily,
+} from "@agenta/entities/workflow"
 import {Skeleton, Typography} from "antd"
 import type {TooltipPlacement} from "antd/es/tooltip"
 import clsx from "clsx"
@@ -473,6 +477,18 @@ export const VariantRevisionLabel = memo(
         const data = useAtomValue(dataAtom)
         const query = useAtomValue(queryAtom)
 
+        // Resolve the VARIANT's own name (then slug): SDK-created variants and
+        // revisions may carry no `name`, and the revision slug is an opaque hex.
+        const variantsAtom = useMemo(
+            () => workflowVariantsListQueryStateAtomFamily(data?.workflow_id ?? ""),
+            [data?.workflow_id],
+        )
+        const variantsState = useAtomValue(variantsAtom)
+        const resolvedVariantId = data?.workflow_variant_id ?? data?.variant_id ?? variantId
+        const variant = resolvedVariantId
+            ? (variantsState.data ?? []).find((v) => v.id === resolvedVariantId)
+            : undefined
+
         if (!variantId && !revisionId) {
             return <Text type="secondary">—</Text>
         }
@@ -481,9 +497,15 @@ export const VariantRevisionLabel = memo(
             return <Skeleton.Input active size="small" style={{width: 140}} />
         }
 
-        // Get variant name from workflow data or fallback
+        // Get variant name from the variant entity, workflow data, or fallback
         // Prefer `name` over `slug` — slug can be an opaque ID on older revisions
-        const variantName = data?.name ?? data?.slug ?? fallbackVariantName ?? null
+        const variantName =
+            variant?.name ??
+            variant?.slug ??
+            data?.name ??
+            data?.slug ??
+            fallbackVariantName ??
+            null
 
         // Get revision number from workflow data or fallback
         const revision = data?.version ?? fallbackRevision ?? null

--- a/web/oss/src/components/References/atoms/entityReferences.ts
+++ b/web/oss/src/components/References/atoms/entityReferences.ts
@@ -7,6 +7,7 @@ import {
     fetchWorkflow,
     fetchWorkflowRevisionById,
     parseWorkflowKeyFromUri,
+    queryWorkflows,
     resolveOutputSchemaProperties,
     workflowMolecule,
     workflowsListQueryStateAtom,
@@ -302,6 +303,30 @@ export const evaluatorWorkflowQueryAtomFamily = atomFamily(
 )
 
 /**
+ * Self-contained query for the workflow ARTIFACT (the workflow-level
+ * container). The entity display name lives there; the revision's own
+ * `name` carries the variant name ("default").
+ */
+const workflowArtifactReferenceQueryAtomFamily = atomFamily(
+    ({projectId, id}: {projectId: string; id: string}) =>
+        atomWithQuery(() => ({
+            queryKey: ["evaluator-reference", "artifact", projectId, id],
+            queryFn: async () => {
+                const response = await queryWorkflows({
+                    projectId,
+                    workflowRefs: [{id}],
+                    includeArchived: true,
+                })
+                return response.workflows?.[0] ?? null
+            },
+            enabled: !!projectId && !!id,
+            staleTime: 5 * 60_000,
+            refetchOnWindowFocus: false,
+        })),
+    (a, b) => a.projectId === b.projectId && a.id === b.id,
+)
+
+/**
  * Resolves evaluator reference (name, slug, metrics) from the workflow
  * entity system. Uses a self-contained query that works in any Jotai
  * store — no dependency on shared projectIdAtom/sessionAtom.
@@ -332,11 +357,23 @@ export const evaluatorReferenceAtomFamily = atomFamily(
                 }
                 const workflow = query.data
                 if (workflow) {
+                    const artifactId = workflow.workflow_id ?? null
+                    const artifactName = artifactId
+                        ? (get(
+                              workflowArtifactReferenceQueryAtomFamily({projectId, id: artifactId}),
+                          ).data?.name ?? null)
+                        : null
                     return {
                         data: {
                             id: workflow.workflow_id ?? workflow.id ?? id,
                             slug: workflow.slug ?? slug ?? null,
-                            name: workflow.name ?? workflow.slug ?? slug ?? id ?? null,
+                            name:
+                                artifactName ??
+                                workflow.name ??
+                                workflow.slug ??
+                                slug ??
+                                id ??
+                                null,
                             workflowKey: parseWorkflowKeyFromUri(workflow.data?.uri ?? null),
                             metrics: extractMetricsFromWorkflow(workflow),
                         },

--- a/web/oss/src/components/References/hooks/usePreviewVariantConfig.ts
+++ b/web/oss/src/components/References/hooks/usePreviewVariantConfig.ts
@@ -53,7 +53,9 @@ const usePreviewVariantConfig = (
         const variantId = data?.workflow_variant_id
         if (!variantId) return null
         const match = (variantsState.data ?? []).find((v) => v.id === variantId)
-        return match?.name ?? null
+        // SDK-created variants may carry no name; the slug ("default") is
+        // still the right label.
+        return match?.name ?? match?.slug ?? null
     }, [data?.workflow_variant_id, variantsState.data])
 
     const config: VariantConfig | null =

--- a/web/oss/src/components/pages/evaluations/NewEvaluation/Components/NewEvaluationModalContent.tsx
+++ b/web/oss/src/components/pages/evaluations/NewEvaluation/Components/NewEvaluationModalContent.tsx
@@ -1,12 +1,12 @@
 import {type FC, memo, useCallback, useMemo} from "react"
 
-import {workflowMolecule} from "@agenta/entities/workflow"
+import {workflowMolecule, workflowVariantsListQueryStateAtomFamily} from "@agenta/entities/workflow"
 import {createEvaluatorFromTemplate} from "@agenta/entities/workflow"
 import {message} from "@agenta/ui/app-message"
 import {CloseCircleOutlined} from "@ant-design/icons"
 import {Input, Tabs, Tag, Typography} from "antd"
 import clsx from "clsx"
-import {useSetAtom} from "jotai"
+import {useAtomValue, useSetAtom} from "jotai"
 import dynamic from "next/dynamic"
 
 import {openHumanEvaluatorDrawerAtom} from "@/oss/components/Evaluators/Drawers/HumanEvaluatorDrawer/store"
@@ -43,6 +43,39 @@ const SelectVariantSection = dynamic(() => import("./SelectVariantSection"), {
 const AdvancedSettings = dynamic(() => import("./AdvancedSettings"), {
     ssr: false,
 })
+
+interface SelectedRevisionLike {
+    workflow_variant_id?: string | null
+    variant_id?: string | null
+    name?: string | null
+    version?: number | null
+}
+
+/**
+ * Variant tag label. The display name lives on the VARIANT (fall back to its
+ * slug): SDK-created variants and revisions may carry no `name` at all, and
+ * UI-created revisions are named after the variant.
+ */
+const RevisionTagLabel = memo(
+    ({revision, workflowId}: {revision: SelectedRevisionLike; workflowId: string}) => {
+        const variantsState = useAtomValue(workflowVariantsListQueryStateAtomFamily(workflowId))
+        const variantId = revision.workflow_variant_id ?? revision.variant_id
+        const variant = (variantsState.data ?? []).find((v) => v.id === variantId)
+        const label = variant?.name ?? variant?.slug ?? revision.name ?? "-"
+        return <>{`${label} - v${revision.version ?? 0}`}</>
+    },
+)
+
+/**
+ * Evaluator tag label. The entity display name lives on the workflow artifact;
+ * the revision's own `name` carries the variant name ("default").
+ */
+const EvaluatorTagLabel = memo(
+    ({cfg}: {cfg: {id: string; name?: string | null; version?: number | null}}) => {
+        const artifactName = useAtomValue(workflowMolecule.selectors.artifactName(cfg.id))
+        return <>{`${artifactName ?? cfg.name ?? "-"} - v${cfg.version ?? 0}`}</>
+    },
+)
 
 const NewEvaluationModalContent: FC<NewEvaluationModalContentProps> = ({
     onSuccess,
@@ -115,12 +148,18 @@ const NewEvaluationModalContent: FC<NewEvaluationModalContentProps> = ({
     )
 
     const selectedVariants = useMemo(
-        () => selectedVariantRevisionIds.map((id) => workflowMolecule.get.data(id)).filter(Boolean),
+        () =>
+            selectedVariantRevisionIds
+                .map((id) => workflowMolecule.get.data(id))
+                .filter((w): w is NonNullable<typeof w> => Boolean(w)),
         [selectedVariantRevisionIds],
     )
 
     const selectedEvalConfig = useMemo(
-        () => selectedEvalConfigs.map((id) => workflowMolecule.get.data(id)).filter(Boolean),
+        () =>
+            selectedEvalConfigs
+                .map((id) => workflowMolecule.get.data(id))
+                .filter((w): w is NonNullable<typeof w> => Boolean(w)),
         [selectedEvalConfigs],
     )
 
@@ -178,7 +217,7 @@ const NewEvaluationModalContent: FC<NewEvaluationModalContentProps> = ({
                                     )
                                 }}
                             >
-                                {`${v.name || "-"} - v${v.version ?? 0}`}
+                                <RevisionTagLabel revision={v} workflowId={selectedAppId || ""} />
                             </Tag>
                         ))}
                     </TabLabel>
@@ -255,7 +294,7 @@ const NewEvaluationModalContent: FC<NewEvaluationModalContentProps> = ({
                                         )
                                     }}
                                 >
-                                    {`${cfg.name || "-"} - v${cfg.version ?? 0}`}
+                                    <EvaluatorTagLabel cfg={cfg} />
                                 </Tag>
                             )
                         })}

--- a/web/oss/src/components/pages/evaluations/NewEvaluation/Components/NewEvaluationModalInner.tsx
+++ b/web/oss/src/components/pages/evaluations/NewEvaluation/Components/NewEvaluationModalInner.tsx
@@ -5,6 +5,7 @@ import {extractSourceIdFromDraft, isLocalDraftId, isValidUUID} from "@agenta/ent
 import {
     workflowMolecule,
     workflowRevisionsByWorkflowListDataAtomFamily,
+    workflowVariantsListQueryStateAtomFamily,
 } from "@agenta/entities/workflow"
 import {
     evaluatorConfigsListDataAtom,
@@ -374,16 +375,29 @@ const NewEvaluationModalInner = ({
         }
     }, [])
 
+    // Variant display names live on the VARIANT (name, then slug): SDK-created
+    // variants and revisions may carry no `name` at all, and UI-created
+    // revisions are named after the variant.
+    const appVariantsState = useAtomValue(
+        useMemo(
+            () => workflowVariantsListQueryStateAtomFamily(selectedAppId || ""),
+            [selectedAppId],
+        ),
+    )
+
     // Memoised base (deterministic) part of generated name (without random suffix)
     const generatedNameBase = useMemo(() => {
         if (!selectedVariantRevisionIds.length || !selectedTestsetName) return ""
         if (selectedVariantRevisionIds.length > 1) {
             return `${selectedVariantRevisionIds.length}-variants-${selectedTestsetName}`
         }
-        const variant = filteredVariants?.find((v) => selectedVariantRevisionIds.includes(v.id))
-        if (!variant) return ""
-        return `${variant.name || "-"}-v${variant.version ?? 0}-${selectedTestsetName}`
-    }, [selectedVariantRevisionIds, selectedTestsetName, filteredVariants])
+        const revision = filteredVariants?.find((v) => selectedVariantRevisionIds.includes(v.id))
+        if (!revision) return ""
+        const variantId = revision.workflow_variant_id ?? revision.variant_id
+        const variant = (appVariantsState.data ?? []).find((v) => v.id === variantId)
+        const label = variant?.name ?? variant?.slug ?? revision.name ?? "-"
+        return `${label}-v${revision.version ?? 0}-${selectedTestsetName}`
+    }, [selectedVariantRevisionIds, selectedTestsetName, filteredVariants, appVariantsState.data])
 
     // Auto-generate / update evaluation name intelligently to avoid loops
     const lastAutoNameRef = useRef<string>("")

--- a/web/packages/agenta-playground-ui/src/components/ExecutionItems/assets/ChatTurnView/index.tsx
+++ b/web/packages/agenta-playground-ui/src/components/ExecutionItems/assets/ChatTurnView/index.tsx
@@ -12,7 +12,6 @@ import {
 import {LoadingOutlined} from "@ant-design/icons"
 import {Popover, Tag} from "antd"
 import clsx from "clsx"
-import {atom} from "jotai"
 import {useAtomValue, useSetAtom} from "jotai"
 
 import {TurnMessageAdapter} from "@agenta/playground-ui/adapters"
@@ -21,6 +20,7 @@ import {usePlaygroundUIOptional} from "../../../../context/PlaygroundUIContext"
 import {useExecutionCell} from "../../../../hooks/useExecutionCell"
 import {EvaluatorFieldGrid} from "../../../shared/EvaluatorFieldGrid"
 import {extractDisplayEntries} from "../../../shared/EvaluatorFieldGrid/utils"
+import {usePlaygroundNodeLabels} from "../ExecutionRow/shared"
 import {ClickRunPlaceholder} from "../ResultPlaceholder"
 import TypingIndicator from "../TypingIndicator"
 
@@ -316,22 +316,7 @@ const ChatTurnView = ({
         | null
     const isChain = (nodes?.length ?? 0) > 1
 
-    const nodeNamesAtom = useMemo(
-        () =>
-            atom((get) => {
-                if (!nodes) return {} as Record<string, string>
-                const names: Record<string, string> = {}
-                for (const node of nodes) {
-                    const data = get(workflowMolecule.selectors.data(node.entityId))
-                    if (data?.name) {
-                        names[node.id] = data.name
-                    }
-                }
-                return names
-            }),
-        [nodes],
-    )
-    const nodeNames = useAtomValue(nodeNamesAtom)
+    const {nodeNames} = usePlaygroundNodeLabels(nodes)
 
     const downstreamNodes = useMemo(() => {
         if (!isChain || !nodes) return []

--- a/web/packages/agenta-playground-ui/src/components/ExecutionItems/assets/ExecutionRow/shared.tsx
+++ b/web/packages/agenta-playground-ui/src/components/ExecutionItems/assets/ExecutionRow/shared.tsx
@@ -17,6 +17,19 @@ export const usePlaygroundNodeLabels = (nodes: PlaygroundNode[] | null) => {
                 const names: Record<string, string> = {}
                 for (const node of nodes) {
                     const data = get(workflowMolecule.selectors.data(node.entityId))
+                    // Evaluators don't use variants: label them by the entity
+                    // (artifact) name. The revision's own `name` carries the
+                    // variant name ("default"). App nodes keep the revision
+                    // name, which is the variant label in comparison views.
+                    if (data?.flags?.is_evaluator) {
+                        const artifactName = get(
+                            workflowMolecule.selectors.artifactName(node.entityId),
+                        )
+                        if (artifactName) {
+                            names[node.id] = artifactName
+                            continue
+                        }
+                    }
                     if (data?.name) {
                         names[node.id] = data.name
                     }


### PR DESCRIPTION
## Context

Two QA findings from the cv-screening project, both in the same family as #4634: a surface labels an entity with the revision's own `name`, which is not the entity's name.

The cv-screening app was created through the SDK, and that path sets no `name` at all: its variant and revisions carry `name: null` (the variant's slug is "default"). The new evaluation modal labeled the selected revision from the revision's name, so the sidebar tag showed "-- v2" instead of "default - v2", and the auto-generated run name came out as `--v2-CV Screening - IT Manager-m23zb`. The same gap made the run overview's Variant chip show the revision's opaque hex slug ("987ae9d16b60") instead of "default".

Separately, the run overview labeled evaluators from the evaluator's revision name. Since #4341, UI-created evaluator revisions are named "default", so a freshly created code evaluator showed as "default" in the Evaluator Scores summary even though its workflow is named "Code Evaluation".

Before: sidebar tag "-- v2", run named "--v2-CV Screening - IT Manager-…", overview summary rows "default", Variant chip "987ae9d16b60".
After: "default - v2", "default-v2-CV Screening - IT Manager-…", "Code Evaluation", "default".

## Changes

Two rules, applied at every broken read site:

- A variant label comes from the VARIANT: its `name`, then its `slug`. The revision's name or slug is only a last resort. Applied to the modal's selected-revision tag, the auto-generated name (`NewEvaluationModalInner`), and `VariantRevisionLabel` / `usePreviewVariantConfig` (the chips on run pages and tables).
- An evaluator label comes from the workflow ARTIFACT, same as #4634. Applied to the run-details evaluator definitions (`atoms/table/evaluators.ts`), the evaluator reference resolver (`entityReferences.ts`), and the overview metric entries, whose definition lookup now matches by id or slug like the chart already did.

The run-details atoms run in a scoped Jotai store where the shared `projectIdAtom` is not populated, so the artifact lookups there follow the file's existing self-contained query pattern (explicit projectId) rather than the molecule's artifact query.

Existing runs heal on display: the stored run names ("--v2-…") stay as they are, but every label resolved at render time is correct, including for runs created while the bug was live.

## Tests

- eslint clean on all seven touched files; tsc error count in the touched files went from 17 (pre-existing on main) to 8, no new errors.
- Verified on the dev deployment against the cv-screening project: modal revision tag shows "default - v3", the run overview shows "Code Evaluation" in summary rows and charts, the Variant chip shows "default v2", and the evaluations table Application column shows "default v2" instead of the hex slug.

## What to QA

Use an SDK-created app (cv-screening in the demo project) plus a freshly UI-created evaluator:

- Open New Evaluation, select the app and a revision. The Revision tab tag reads "default - v2" and the auto-generated name starts with "default-v2-", not "--v2-".
- Run the evaluation and open its overview. The evaluator appears with its real name ("Code Evaluation") in the summary rows and charts, and the Variant row shows "default", not a hex string.
- Regression: do the same with a UI-created app (variants and revisions have names). All labels should be unchanged.

Closes #4662
