### PR TITLE
fix(api): default variant name to its slug when not provided

### DIFF
--- a/api/oss/src/dbs/postgres/git/dao.py
+++ b/api/oss/src/dbs/postgres/git/dao.py
@@ -449,7 +449,9 @@ class GitDAO(GitDAOInterface):
             tags=variant_create.tags,
             meta=variant_create.meta,
             #
-            name=variant_create.name,
+            # Temporary default until the SDK can send variant display names;
+            # without it SDK-created variants surface as NULL and break entity labels.
+            name=variant_create.name or variant_create.slug,
             description=variant_create.description,
         )
 


### PR DESCRIPTION
## Context

The Python SDK creates variants with only a slug. There is no name parameter. The backend stored NULL for those names, and every UI label that resolves a variant name showed "--" or an opaque hex slug (see the evaluation surfaces bug, GitHub issue #4662).

## Changes

When a variant is created without a name, the shared git DAO now defaults `name` to the variant's `slug` instead of storing NULL:

```python
name=variant_create.name or variant_create.slug,
```

`create_variant` in `api/oss/src/dbs/postgres/git/dao.py` is the single choke point where the `Variant` DTO is built. `fork_variant` also routes through it. Every domain that uses the git DAO (workflows, applications, evaluators, testsets) gets the default for free.

**This is a temporary backstop; the proper fix is letting the SDK send display names, tracked in the SDK feature issue.**

Existing rows with NULL names are not migrated. The frontend keeps its slug fallback for them.

## Tests

- `ruff format` and `ruff check --fix` in `api/`: clean.
- `pytest oss/tests/pytest/unit/workflows/test_flag_ownership.py`: 12 passed. It is the only unit test touching `create_variant`; it mocks the DAO, so it confirms nothing regressed at the interface level. No test exercises the git DAO directly.

Refs #4663 (the SDK feature that makes this default unnecessary for new SDK versions)
