### PR TITLE
fix(frontend): show boolean evaluator metrics as True/False, not a mean

### DIFF
--- a/.all-contributorsrc
+++ b/.all-contributorsrc
@@ -605,6 +605,15 @@
       "contributions": [
         "code"
       ]
+    },
+    {
+      "login": "unfitcoder101",
+      "name": "unfitcoder101",
+      "avatar_url": "https://avatars.githubusercontent.com/u/175036458?v=4",
+      "profile": "https://github.com/unfitcoder101",
+      "contributions": [
+        "bug"
+      ]
     }
   ],
   "contributorsPerLine": 7,

--- a/README.md
+++ b/README.md
@@ -191,7 +191,7 @@ We welcome contributions of all kinds, from filing issues and sharing ideas to i
 ## Contributors ✨
 
 <!-- ALL-CONTRIBUTORS-BADGE:START - Do not remove or modify this section -->
-[![All Contributors](https://img.shields.io/badge/all_contributors-64-orange.svg?style=flat-square)](#contributors-)
+[![All Contributors](https://img.shields.io/badge/all_contributors-65-orange.svg?style=flat-square)](#contributors-)
 <!-- ALL-CONTRIBUTORS-BADGE:END -->
 
 Thanks goes to these wonderful people ([emoji key](https://allcontributors.org/docs/en/emoji-key)):
@@ -284,6 +284,7 @@ Thanks goes to these wonderful people ([emoji key](https://allcontributors.org/d
     </tr>
     <tr>
       <td align="center" valign="top" width="14.28%"><a href="https://github.com/Sanket2329"><img src="https://avatars.githubusercontent.com/u/196506711?v=4?s=100" width="100px;" alt="Sanket Shakya"/><br /><sub><b>Sanket Shakya</b></sub></a><br /><a href="https://github.com/Agenta-AI/agenta/commits?author=Sanket2329" title="Code">💻</a></td>
+      <td align="center" valign="top" width="14.28%"><a href="https://github.com/unfitcoder101"><img src="https://avatars.githubusercontent.com/u/175036458?v=4?s=100" width="100px;" alt="unfitcoder101"/><br /><sub><b>unfitcoder101</b></sub></a><br /><a href="https://github.com/Agenta-AI/agenta/issues?q=author%3Aunfitcoder101" title="Bug reports">🐛</a></td>
     </tr>
   </tbody>
 </table>

--- a/web/oss/src/components/CustomUIs/LabelValuePill.tsx
+++ b/web/oss/src/components/CustomUIs/LabelValuePill.tsx
@@ -8,9 +8,10 @@ interface LabelValuePillProps {
     label: string
     value: string
     className?: string
+    valueClassName?: string
 }
 
-const LabelValuePill = ({label, value, className}: LabelValuePillProps) => {
+const LabelValuePill = ({label, value, className, valueClassName}: LabelValuePillProps) => {
     return (
         <div
             className={clsx(
@@ -27,7 +28,7 @@ const LabelValuePill = ({label, value, className}: LabelValuePillProps) => {
             )}
         >
             <div>{label}</div>
-            <div>{getStringOrJson(value)}</div>
+            <div className={valueClassName}>{getStringOrJson(value)}</div>
         </div>
     )
 }

--- a/web/oss/src/components/DrillInView/PrettyJsonView.tsx
+++ b/web/oss/src/components/DrillInView/PrettyJsonView.tsx
@@ -13,6 +13,8 @@ import {
     DEFAULT_ROLE_COLOR_CLASS,
 } from "@agenta/ui/cell-renderers"
 
+import {booleanValueColorClass} from "@/oss/lib/helpers/colors"
+
 /**
  * "Pretty JSON" view.
  *
@@ -484,9 +486,7 @@ const ScalarValue = ({value}: {value: unknown}) => {
     }
     if (typeof value === "boolean") {
         return (
-            <span
-                className={`font-mono text-[12.5px] ${value ? "text-green-7 dark:text-[var(--ant-green-7)]" : "text-orange-6"}`}
-            >
+            <span className={`font-mono text-[12.5px] ${booleanValueColorClass(value)}`}>
                 {String(value)}
             </span>
         )

--- a/web/oss/src/components/SharedDrawers/TraceDrawer/components/TraceSidePanel/TraceAnnotations/index.tsx
+++ b/web/oss/src/components/SharedDrawers/TraceDrawer/components/TraceSidePanel/TraceAnnotations/index.tsx
@@ -9,6 +9,7 @@ import {useAtomValue} from "jotai"
 
 import CustomAntdTag from "@/oss/components/CustomUIs/CustomAntdTag"
 import EvaluatorDetailsPopover from "@/oss/components/SharedDrawers/TraceDrawer/components/EvaluatorDetailsPopover"
+import {booleanValueColorClass} from "@/oss/lib/helpers/colors"
 import {getStringOrJson} from "@/oss/lib/helpers/utils"
 import {groupAnnotationsByReferenceId} from "@/oss/lib/hooks/useAnnotations/assets/helpers"
 import {AnnotationDto} from "@/oss/lib/hooks/useAnnotations/types"
@@ -27,6 +28,7 @@ type AnnotationCategory = "metric" | "note" | "extra"
 interface AnnotationChipEntry {
     annotations: {value: any; user: string}[]
     average?: number
+    latest?: boolean
     category: AnnotationCategory
 }
 
@@ -62,6 +64,7 @@ const TraceAnnotations = ({annotations = []}: TraceAnnotationsProps) => {
                 metricsBucket[metricName] = {
                     annotations: (metricValue.annotations || []) as {value: any; user: string}[],
                     average: metricValue.average,
+                    latest: metricValue.latest,
                     category: "metric",
                 }
             }
@@ -128,6 +131,9 @@ const TraceAnnotations = ({annotations = []}: TraceAnnotationsProps) => {
 
     const getSummaryValue = (metric: AnnotationChipEntry) => {
         if (metric.category === "metric") {
+            if (metric.latest !== undefined) {
+                return metric.latest ? "True" : "False"
+            }
             if (metric.average !== undefined) {
                 return `μ ${metric.average}`
             }
@@ -175,13 +181,29 @@ const TraceAnnotations = ({annotations = []}: TraceAnnotationsProps) => {
 
                         {filteredMetrics.map(([key, metric]) => {
                             const summaryValue = getSummaryValue(metric)
+                            const booleanColorClass =
+                                metric.latest !== undefined
+                                    ? booleanValueColorClass(metric.latest)
+                                    : undefined
                             const popoverTitle =
-                                metric.category === "metric" && metric.average !== undefined ? (
+                                metric.category === "metric" &&
+                                (metric.average !== undefined || metric.latest !== undefined) ? (
                                     <div className="flex items-center justify-between">
                                         <Space className="truncate overflow-hidden">
-                                            <Typography.Text>Total mean:</Typography.Text>
+                                            <Typography.Text>
+                                                {metric.latest !== undefined
+                                                    ? "Value:"
+                                                    : "Total mean:"}
+                                            </Typography.Text>
                                             <CustomAntdTag
-                                                value={`μ ${metric.average}`}
+                                                value={
+                                                    metric.latest !== undefined
+                                                        ? metric.latest
+                                                            ? "True"
+                                                            : "False"
+                                                        : `μ ${metric.average}`
+                                                }
+                                                className={booleanColorClass}
                                                 bordered={false}
                                             />
                                         </Space>
@@ -261,8 +283,13 @@ const TraceAnnotations = ({annotations = []}: TraceAnnotationsProps) => {
                                             </Typography.Text>
                                             {summaryValue ? (
                                                 <Typography.Text
-                                                    type="secondary"
-                                                    className="truncate overflow-hidden text-ellipsis"
+                                                    type={
+                                                        booleanColorClass ? undefined : "secondary"
+                                                    }
+                                                    className={clsx(
+                                                        "truncate overflow-hidden text-ellipsis",
+                                                        booleanColorClass,
+                                                    )}
                                                 >
                                                     {summaryValue}
                                                 </Typography.Text>

--- a/web/oss/src/components/pages/observability/components/EvaluatorMetricsCell.tsx
+++ b/web/oss/src/components/pages/observability/components/EvaluatorMetricsCell.tsx
@@ -5,6 +5,7 @@ import {useAtomValue} from "jotai"
 
 import LabelValuePill from "@/oss/components/CustomUIs/LabelValuePill"
 import useEvaluatorReference from "@/oss/components/References/hooks/useEvaluatorReference"
+import {booleanValueColorClass} from "@/oss/lib/helpers/colors"
 import {traceAnnotationInfoAtomFamily} from "@/oss/state/newObservability"
 import {useProjectData} from "@/oss/state/project"
 
@@ -39,12 +40,19 @@ const EvaluatorMetricsCell = memo(({invocationKey, evaluatorSlug}: Props) => {
             </div>
             <div className="flex items-center gap-2 max-w-[450px] overflow-x-auto [&::-webkit-scrollbar]:!w-0">
                 {Object.entries(metrics).map(([metricName, rawData]) => {
-                    const data = rawData as {average?: number}
+                    const data = rawData as {average?: number; latest?: boolean}
+                    const isBoolean = data.latest !== undefined
+                    const value = isBoolean ? (data.latest ? "True" : "False") : `μ ${data.average}`
                     return (
                         <LabelValuePill
                             key={metricName}
                             label={metricName}
-                            value={`μ ${data.average}`}
+                            value={value}
+                            valueClassName={
+                                isBoolean
+                                    ? booleanValueColorClass(data.latest as boolean)
+                                    : undefined
+                            }
                             className="!min-w-fit"
                         />
                     )

--- a/web/oss/src/lib/helpers/colors.ts
+++ b/web/oss/src/lib/helpers/colors.ts
@@ -71,6 +71,13 @@ export const fadeColor = (hex: string, opacity: number) => {
     return `rgba(${r}, ${g}, ${b}, ${opacity})`
 }
 
+/**
+ * Tailwind classes for a boolean value, kept identical to the pretty JSON view
+ * (PrettyJsonView) so True/False read the same wherever they appear.
+ */
+export const booleanValueColorClass = (value: boolean): string =>
+    value ? "text-green-7 dark:text-[var(--ant-green-7)]" : "text-orange-6"
+
 export const getTagColors = () => [...tagColors]
 
 export const getRandomColors = () => colorPairs.map((color) => color.textColor)

--- a/web/oss/src/lib/hooks/useAnnotations/assets/helpers.ts
+++ b/web/oss/src/lib/hooks/useAnnotations/assets/helpers.ts
@@ -119,19 +119,32 @@ export const groupAnnotationsByReferenceId = (
             const allNumbers = values.every((v) => typeof v.value === "number")
             const allBooleans = values.every((v) => typeof v.value === "boolean")
 
-            if (allNumbers || allBooleans) {
-                // Handle both numbers and booleans the same way
-                const total = values.reduce(
-                    (sum, v) => sum + (typeof v.value === "boolean" ? (v.value ? 1 : 0) : v.value),
-                    0,
-                )
+            if (allBooleans) {
+                if (values.length === 1) {
+                    // A single boolean feedback is shown as True/False (color-coded by
+                    // the UI). Averaging one boolean would only produce a meaningless
+                    // "mean 0/1".
+                    result[evaluatorSlot][metricName] = {
+                        latest: values[0].value as boolean,
+                        annotations: values,
+                    }
+                } else {
+                    // Multiple boolean feedbacks fall back to the share that are true.
+                    const total = values.reduce((sum, v) => sum + (v.value ? 1 : 0), 0)
+                    result[evaluatorSlot][metricName] = {
+                        average: parseFloat((total / values.length).toFixed(2)),
+                        annotations: values,
+                    }
+                }
+            } else if (allNumbers) {
+                const total = values.reduce((sum, v) => sum + (v.value as number), 0)
                 const average = total / values.length
                 result[evaluatorSlot][metricName] = {
                     average: parseFloat(average.toFixed(2)),
                     annotations: values,
                 }
             } else {
-                // mixed or unsupported types — skip or log
+                // mixed or unsupported types — skip
                 continue
             }
         }


### PR DESCRIPTION
Closes #4666

## Context

In Observability, boolean evaluator metrics were averaged and shown as a meaningless chip like `μ 0`, both in the table evaluator column and in the trace drawer. A boolean is not a quantity, so the mean tells you nothing. It also hid the metric's type: because `tech_match` looked numeric (`μ 0`), it was easy to build a numeric filter (`≥ 0`) that never matches a boolean and returns empty.

## Changes

`groupAnnotationsByReferenceId` no longer averages booleans. It keeps the latest boolean value, and the UI renders it as `True` / `False`.

Before (boolean metric in the evaluator column / drawer):

```
tech_match  μ 0
```

After:

```
tech_match  False
```

Numeric metrics are unchanged. They still show `μ <average>` with a `Total mean:` popover.

`True` / `False` use the same green/orange the pretty JSON view uses for booleans. That color moved into `booleanValueColorClass` (`lib/helpers/colors.ts`), and `PrettyJsonView` now reads it from there too, so there is one source of truth.

## Tests / notes

- Lint and typecheck are clean on the changed files.
- Verified on the dev box (CV-screening project, boolean evaluator `cv-evaluator-bekq`): the table evaluator column and the trace drawer show `True` / `False` in green/orange, the metric popover reads `Value: True` instead of `Total mean: μ X`, and no `μ 0` / `μ 1` remains. Numeric means still render (verified in code; that project has no numeric metric to show live).

## What to QA

- Open Observability in a project with a boolean evaluator metric. The evaluator-column chip shows `True` / `False` (green/orange), not `μ 0`.
- Open a trace drawer. The annotations panel shows the boolean as `True` / `False`, and its popover title reads `Value: True` / `Value: False`.
- Regression: a numeric evaluator metric still shows `μ <number>` with a `Total mean:` popover, and the pretty JSON view still colors booleans the same green/orange.
