### PR TITLE
fix(frontend): label evaluator nodes in the playground by their entity name

### DIFF
--- a/web/packages/agenta-playground-ui/src/components/ExecutionItems/assets/ChatTurnView/index.tsx
+++ b/web/packages/agenta-playground-ui/src/components/ExecutionItems/assets/ChatTurnView/index.tsx
@@ -12,7 +12,6 @@ import {
 import {LoadingOutlined} from "@ant-design/icons"
 import {Popover, Tag} from "antd"
 import clsx from "clsx"
-import {atom} from "jotai"
 import {useAtomValue, useSetAtom} from "jotai"
 
 import {TurnMessageAdapter} from "@agenta/playground-ui/adapters"
@@ -21,6 +20,7 @@ import {usePlaygroundUIOptional} from "../../../../context/PlaygroundUIContext"
 import {useExecutionCell} from "../../../../hooks/useExecutionCell"
 import {EvaluatorFieldGrid} from "../../../shared/EvaluatorFieldGrid"
 import {extractDisplayEntries} from "../../../shared/EvaluatorFieldGrid/utils"
+import {usePlaygroundNodeLabels} from "../ExecutionRow/shared"
 import {ClickRunPlaceholder} from "../ResultPlaceholder"
 import TypingIndicator from "../TypingIndicator"
 
@@ -316,22 +316,7 @@ const ChatTurnView = ({
         | null
     const isChain = (nodes?.length ?? 0) > 1
 
-    const nodeNamesAtom = useMemo(
-        () =>
-            atom((get) => {
-                if (!nodes) return {} as Record<string, string>
-                const names: Record<string, string> = {}
-                for (const node of nodes) {
-                    const data = get(workflowMolecule.selectors.data(node.entityId))
-                    if (data?.name) {
-                        names[node.id] = data.name
-                    }
-                }
-                return names
-            }),
-        [nodes],
-    )
-    const nodeNames = useAtomValue(nodeNamesAtom)
+    const {nodeNames} = usePlaygroundNodeLabels(nodes)
 
     const downstreamNodes = useMemo(() => {
         if (!isChain || !nodes) return []

--- a/web/packages/agenta-playground-ui/src/components/ExecutionItems/assets/ExecutionRow/shared.tsx
+++ b/web/packages/agenta-playground-ui/src/components/ExecutionItems/assets/ExecutionRow/shared.tsx
@@ -17,6 +17,19 @@ export const usePlaygroundNodeLabels = (nodes: PlaygroundNode[] | null) => {
                 const names: Record<string, string> = {}
                 for (const node of nodes) {
                     const data = get(workflowMolecule.selectors.data(node.entityId))
+                    // Evaluators don't use variants: label them by the entity
+                    // (artifact) name. The revision's own `name` carries the
+                    // variant name ("default"). App nodes keep the revision
+                    // name, which is the variant label in comparison views.
+                    if (data?.flags?.is_evaluator) {
+                        const artifactName = get(
+                            workflowMolecule.selectors.artifactName(node.entityId),
+                        )
+                        if (artifactName) {
+                            names[node.id] = artifactName
+                            continue
+                        }
+                    }
                     if (data?.name) {
                         names[node.id] = data.name
                     }


### PR DESCRIPTION
## Context

Load an evaluator in the playground to grade an app (the app runs as the first step, the evaluator as the second) and run it. The result section labels the evaluator step "default" instead of the evaluator's name. Same name-family bug as #4662: the playground labels every node from the revision's `name`, and an evaluator revision's name is its variant name, which is always "default".

Before: app output followed by a result block titled "default".
After: the result block is titled with the evaluator's name, for example "CV Evaluator".

## Changes

`usePlaygroundNodeLabels` (the shared label source for execution rows in both single and comparison layouts) now picks the label by entity kind, per the rules in web/AGENTS.md: evaluator nodes resolve the workflow artifact's name through `workflowMolecule.selectors.artifactName`; app nodes keep the revision name, which is the variant label that comparison views rely on. If the artifact name has not loaded yet, the label falls back to the previous behavior instead of flashing empty.

`ChatTurnView` had its own inline copy of the same name lookup for chat-mode runs. It now reuses the shared hook, so chat turns get the fix without a second copy of the logic.

This is a point fix. The broader consolidation (a single `variantLabel` selector and scoped-store-safe queries) follows separately.

## Tests

- Package lint and `tsc --noEmit` clean on `agenta-playground-ui`.
- Verified on the dev deployment: opened the "CV Evaluator" code evaluator in the evaluator playground, attached the cv-screening app (revision v2), ran a test case. The app step returned its output and the evaluator result block is labeled "CV Evaluator" with its own status, not "default".

## What to QA

- Open any automatic evaluator created recently (its revisions are named "default") in the evaluator playground, attach an app, run. The evaluator's result block shows the evaluator's name.
- Same flow with a chat app to cover chat turns.
- Regression: open an app comparison in the normal playground. Variant columns are still labeled by variant, unchanged.
