### PR TITLE
refactor(frontend): consolidate workflow name resolution into two molecule selectors

### DIFF
--- a/web/oss/src/components/EvalRunDetails/atoms/table/evaluators.ts
+++ b/web/oss/src/components/EvalRunDetails/atoms/table/evaluators.ts
@@ -3,7 +3,7 @@ import {
     fetchWorkflowRevisionById,
     extractEvaluatorRef,
     deduplicateRefs,
-    queryWorkflows,
+    workflowArtifactScopedQueryAtomFamily,
     toEvaluatorDefinitionFromWorkflow,
     toEvaluatorDefinitionFromRaw,
     type EvaluatorDefinition,
@@ -48,31 +48,6 @@ const evaluatorRevisionQueryAtomFamily = atomFamily(
                         return null
                     }
                 }
-            },
-            enabled: !!projectId && !!id,
-            staleTime: 5 * 60_000,
-            refetchOnWindowFocus: false,
-        })),
-    (a, b) => a.projectId === b.projectId && a.id === b.id,
-)
-
-/**
- * Self-contained query for the workflow ARTIFACT (the workflow-level
- * container). The entity display name lives there; the revision's own `name`
- * carries the variant name ("default"). Defined locally (like the revision
- * query above) so it runs in the evaluations scoped store.
- */
-const evaluatorArtifactQueryAtomFamily = atomFamily(
-    ({projectId, id}: {projectId: string; id: string}) =>
-        atomWithQuery(() => ({
-            queryKey: ["eval-run", "evaluator-artifact", projectId, id],
-            queryFn: async () => {
-                const response = await queryWorkflows({
-                    projectId,
-                    workflowRefs: [{id}],
-                    includeArchived: true,
-                })
-                return response.workflows?.[0] ?? null
             },
             enabled: !!projectId && !!id,
             staleTime: 5 * 60_000,
@@ -171,7 +146,7 @@ export const evaluationEvaluatorsByRunQueryAtomFamily = atomFamily((runId: strin
                 const artifactId = ref.artifactId ?? workflow.workflow_id ?? null
                 if (artifactId) {
                     const artifactName = get(
-                        evaluatorArtifactQueryAtomFamily({projectId, id: artifactId}),
+                        workflowArtifactScopedQueryAtomFamily({projectId, workflowId: artifactId}),
                     ).data?.name
                     if (artifactName) definition.name = artifactName
                 }

--- a/web/oss/src/components/References/ReferenceLabels.tsx
+++ b/web/oss/src/components/References/ReferenceLabels.tsx
@@ -1,10 +1,6 @@
 import {memo, useMemo} from "react"
 
-import {
-    getWorkflowTypeColor,
-    workflowMolecule,
-    workflowVariantsListQueryStateAtomFamily,
-} from "@agenta/entities/workflow"
+import {getWorkflowTypeColor, workflowMolecule} from "@agenta/entities/workflow"
 import {Skeleton, Typography} from "antd"
 import type {TooltipPlacement} from "antd/es/tooltip"
 import clsx from "clsx"
@@ -477,17 +473,12 @@ export const VariantRevisionLabel = memo(
         const data = useAtomValue(dataAtom)
         const query = useAtomValue(queryAtom)
 
-        // Resolve the VARIANT's own name (then slug): SDK-created variants and
-        // revisions may carry no `name`, and the revision slug is an opaque hex.
-        const variantsAtom = useMemo(
-            () => workflowVariantsListQueryStateAtomFamily(data?.workflow_id ?? ""),
-            [data?.workflow_id],
+        // Resolve the VARIANT's own label (name, then slug): SDK-created
+        // variants and revisions may carry no `name`, and the revision slug
+        // is an opaque hex.
+        const variantLabel = useAtomValue(
+            useMemo(() => workflowMolecule.selectors.variantLabel(revisionId ?? ""), [revisionId]),
         )
-        const variantsState = useAtomValue(variantsAtom)
-        const resolvedVariantId = data?.workflow_variant_id ?? data?.variant_id ?? variantId
-        const variant = resolvedVariantId
-            ? (variantsState.data ?? []).find((v) => v.id === resolvedVariantId)
-            : undefined
 
         if (!variantId && !revisionId) {
             return <Text type="secondary">—</Text>
@@ -499,13 +490,7 @@ export const VariantRevisionLabel = memo(
 
         // Get variant name from the variant entity, workflow data, or fallback
         // Prefer `name` over `slug` — slug can be an opaque ID on older revisions
-        const variantName =
-            variant?.name ??
-            variant?.slug ??
-            data?.name ??
-            data?.slug ??
-            fallbackVariantName ??
-            null
+        const variantName = variantLabel ?? data?.name ?? data?.slug ?? fallbackVariantName ?? null
 
         // Get revision number from workflow data or fallback
         const revision = data?.version ?? fallbackRevision ?? null

--- a/web/oss/src/components/References/atoms/entityReferences.ts
+++ b/web/oss/src/components/References/atoms/entityReferences.ts
@@ -7,7 +7,7 @@ import {
     fetchWorkflow,
     fetchWorkflowRevisionById,
     parseWorkflowKeyFromUri,
-    queryWorkflows,
+    workflowArtifactScopedQueryAtomFamily,
     resolveOutputSchemaProperties,
     workflowMolecule,
     workflowsListQueryStateAtom,
@@ -303,30 +303,6 @@ export const evaluatorWorkflowQueryAtomFamily = atomFamily(
 )
 
 /**
- * Self-contained query for the workflow ARTIFACT (the workflow-level
- * container). The entity display name lives there; the revision's own
- * `name` carries the variant name ("default").
- */
-const workflowArtifactReferenceQueryAtomFamily = atomFamily(
-    ({projectId, id}: {projectId: string; id: string}) =>
-        atomWithQuery(() => ({
-            queryKey: ["evaluator-reference", "artifact", projectId, id],
-            queryFn: async () => {
-                const response = await queryWorkflows({
-                    projectId,
-                    workflowRefs: [{id}],
-                    includeArchived: true,
-                })
-                return response.workflows?.[0] ?? null
-            },
-            enabled: !!projectId && !!id,
-            staleTime: 5 * 60_000,
-            refetchOnWindowFocus: false,
-        })),
-    (a, b) => a.projectId === b.projectId && a.id === b.id,
-)
-
-/**
  * Resolves evaluator reference (name, slug, metrics) from the workflow
  * entity system. Uses a self-contained query that works in any Jotai
  * store — no dependency on shared projectIdAtom/sessionAtom.
@@ -360,7 +336,10 @@ export const evaluatorReferenceAtomFamily = atomFamily(
                     const artifactId = workflow.workflow_id ?? null
                     const artifactName = artifactId
                         ? (get(
-                              workflowArtifactReferenceQueryAtomFamily({projectId, id: artifactId}),
+                              workflowArtifactScopedQueryAtomFamily({
+                                  projectId,
+                                  workflowId: artifactId,
+                              }),
                           ).data?.name ?? null)
                         : null
                     return {

--- a/web/oss/src/components/References/hooks/usePreviewVariantConfig.ts
+++ b/web/oss/src/components/References/hooks/usePreviewVariantConfig.ts
@@ -1,6 +1,6 @@
 import {useMemo} from "react"
 
-import {workflowMolecule, workflowVariantsListQueryStateAtomFamily} from "@agenta/entities/workflow"
+import {workflowMolecule} from "@agenta/entities/workflow"
 import {getDefaultStore, useAtomValue} from "jotai"
 
 interface VariantConfig {
@@ -40,23 +40,15 @@ const usePreviewVariantConfig = (
     const data = useAtomValue(dataAtom, {store: defaultStore})
     const query = useAtomValue(queryAtom, {store: defaultStore})
 
-    // Resolve the VARIANT name, not the revision name. The default variant's
+    // Resolve the VARIANT label, not the revision name. The default variant's
     // revisions are historically named after the app ("completion-1"), so using
     // the revision name renders the default variant as the app name instead of
-    // "default". Look the variant up by the revision's workflow_variant_id.
-    const variantsAtom = useMemo(
-        () => workflowVariantsListQueryStateAtomFamily(data?.workflow_id ?? ""),
-        [data?.workflow_id],
+    // "default".
+    const variantLabelAtom = useMemo(
+        () => workflowMolecule.selectors.variantLabel(effectiveRevisionId),
+        [effectiveRevisionId],
     )
-    const variantsState = useAtomValue(variantsAtom, {store: defaultStore})
-    const variantName = useMemo(() => {
-        const variantId = data?.workflow_variant_id
-        if (!variantId) return null
-        const match = (variantsState.data ?? []).find((v) => v.id === variantId)
-        // SDK-created variants may carry no name; the slug ("default") is
-        // still the right label.
-        return match?.name ?? match?.slug ?? null
-    }, [data?.workflow_variant_id, variantsState.data])
+    const variantName = useAtomValue(variantLabelAtom, {store: defaultStore})
 
     const config: VariantConfig | null =
         enabled && revisionId && data

--- a/web/oss/src/components/pages/evaluations/NewEvaluation/Components/NewEvaluationModalContent.tsx
+++ b/web/oss/src/components/pages/evaluations/NewEvaluation/Components/NewEvaluationModalContent.tsx
@@ -1,6 +1,6 @@
 import {type FC, memo, useCallback, useMemo} from "react"
 
-import {workflowMolecule, workflowVariantsListQueryStateAtomFamily} from "@agenta/entities/workflow"
+import {workflowMolecule} from "@agenta/entities/workflow"
 import {createEvaluatorFromTemplate} from "@agenta/entities/workflow"
 import {message} from "@agenta/ui/app-message"
 import {CloseCircleOutlined} from "@ant-design/icons"
@@ -45,8 +45,7 @@ const AdvancedSettings = dynamic(() => import("./AdvancedSettings"), {
 })
 
 interface SelectedRevisionLike {
-    workflow_variant_id?: string | null
-    variant_id?: string | null
+    id?: string | null
     name?: string | null
     version?: number | null
 }
@@ -56,15 +55,11 @@ interface SelectedRevisionLike {
  * slug): SDK-created variants and revisions may carry no `name` at all, and
  * UI-created revisions are named after the variant.
  */
-const RevisionTagLabel = memo(
-    ({revision, workflowId}: {revision: SelectedRevisionLike; workflowId: string}) => {
-        const variantsState = useAtomValue(workflowVariantsListQueryStateAtomFamily(workflowId))
-        const variantId = revision.workflow_variant_id ?? revision.variant_id
-        const variant = (variantsState.data ?? []).find((v) => v.id === variantId)
-        const label = variant?.name ?? variant?.slug ?? revision.name ?? "-"
-        return <>{`${label} - v${revision.version ?? 0}`}</>
-    },
-)
+const RevisionTagLabel = memo(({revision}: {revision: SelectedRevisionLike}) => {
+    const variantLabel = useAtomValue(workflowMolecule.selectors.variantLabel(revision.id ?? ""))
+    const label = variantLabel ?? revision.name ?? "-"
+    return <>{`${label} - v${revision.version ?? 0}`}</>
+})
 
 /**
  * Evaluator tag label. The entity display name lives on the workflow artifact;
@@ -217,7 +212,7 @@ const NewEvaluationModalContent: FC<NewEvaluationModalContentProps> = ({
                                     )
                                 }}
                             >
-                                <RevisionTagLabel revision={v} workflowId={selectedAppId || ""} />
+                                <RevisionTagLabel revision={v} />
                             </Tag>
                         ))}
                     </TabLabel>

--- a/web/oss/src/components/pages/evaluations/NewEvaluation/Components/NewEvaluationModalInner.tsx
+++ b/web/oss/src/components/pages/evaluations/NewEvaluation/Components/NewEvaluationModalInner.tsx
@@ -5,7 +5,6 @@ import {extractSourceIdFromDraft, isLocalDraftId, isValidUUID} from "@agenta/ent
 import {
     workflowMolecule,
     workflowRevisionsByWorkflowListDataAtomFamily,
-    workflowVariantsListQueryStateAtomFamily,
 } from "@agenta/entities/workflow"
 import {
     evaluatorConfigsListDataAtom,
@@ -378,10 +377,12 @@ const NewEvaluationModalInner = ({
     // Variant display names live on the VARIANT (name, then slug): SDK-created
     // variants and revisions may carry no `name` at all, and UI-created
     // revisions are named after the variant.
-    const appVariantsState = useAtomValue(
+    const selectedSingleRevisionId =
+        selectedVariantRevisionIds.length === 1 ? selectedVariantRevisionIds[0] : ""
+    const selectedVariantLabel = useAtomValue(
         useMemo(
-            () => workflowVariantsListQueryStateAtomFamily(selectedAppId || ""),
-            [selectedAppId],
+            () => workflowMolecule.selectors.variantLabel(selectedSingleRevisionId),
+            [selectedSingleRevisionId],
         ),
     )
 
@@ -393,11 +394,9 @@ const NewEvaluationModalInner = ({
         }
         const revision = filteredVariants?.find((v) => selectedVariantRevisionIds.includes(v.id))
         if (!revision) return ""
-        const variantId = revision.workflow_variant_id ?? revision.variant_id
-        const variant = (appVariantsState.data ?? []).find((v) => v.id === variantId)
-        const label = variant?.name ?? variant?.slug ?? revision.name ?? "-"
+        const label = selectedVariantLabel ?? revision.name ?? "-"
         return `${label}-v${revision.version ?? 0}-${selectedTestsetName}`
-    }, [selectedVariantRevisionIds, selectedTestsetName, filteredVariants, appVariantsState.data])
+    }, [selectedVariantRevisionIds, selectedTestsetName, filteredVariants, selectedVariantLabel])
 
     // Auto-generate / update evaluation name intelligently to avoid loops
     const lastAutoNameRef = useRef<string>("")

--- a/web/packages/agenta-entities/src/workflow/index.ts
+++ b/web/packages/agenta-entities/src/workflow/index.ts
@@ -242,6 +242,8 @@ export {
     workflowLatestRevisionQueryAtomFamily,
     // Artifact (workflow-level container — entity display name)
     workflowArtifactQueryAtomFamily,
+    workflowArtifactScopedQueryAtomFamily,
+    workflowVariantsScopedQueryAtomFamily,
     primeWorkflowArtifactCacheImperative,
     // Commit / Archive
     commitWorkflowRevisionAtom,

--- a/web/packages/agenta-entities/src/workflow/state/index.ts
+++ b/web/packages/agenta-entities/src/workflow/state/index.ts
@@ -71,6 +71,8 @@ export {
     workflowLatestRevisionQueryAtomFamily,
     // Artifact (workflow-level container — entity display name)
     workflowArtifactQueryAtomFamily,
+    workflowArtifactScopedQueryAtomFamily,
+    workflowVariantsScopedQueryAtomFamily,
     primeWorkflowArtifactCacheImperative,
 } from "./store"
 

--- a/web/packages/agenta-entities/src/workflow/state/molecule.ts
+++ b/web/packages/agenta-entities/src/workflow/state/molecule.ts
@@ -89,6 +89,7 @@ import {
     workflowInterfaceSchemasAtomFamily,
     workflowDraftAtomFamily,
     workflowArtifactQueryAtomFamily,
+    workflowVariantsQueryAtomFamily,
     workflowBaseEntityAtomFamily,
     workflowEntityAtomFamily,
     workflowLocalServerDataAtomFamily,
@@ -447,6 +448,30 @@ const artifactNameAtomFamily = atomFamily((entityId: string) =>
         const artifactId = entity?.workflow_id ?? entityId
         const artifactQuery = get(workflowArtifactQueryAtomFamily(artifactId))
         return artifactQuery.data?.name ?? entity?.name ?? null
+    }),
+)
+
+/**
+ * Variant label resolved from the VARIANT entity.
+ *
+ * The label is `variant.name`, then `variant.slug` (SDK-created variants
+ * carry no name; their slug is "default"). Never labels from revision
+ * fields: a revision's `name` is unreliable and its slug is an opaque hex.
+ * Accepts a revision id or a workflow id; for a workflow id the latest
+ * revision's variant label is returned.
+ */
+const variantLabelAtomFamily = atomFamily((entityId: string) =>
+    atom<string | null>((get) => {
+        if (!entityId) return null
+        const entity = get(workflowBaseEntityAtomFamily(entityId))
+        const workflowId = entity?.workflow_id ?? null
+        const variantId = entity?.workflow_variant_id ?? entity?.variant_id ?? null
+        if (!workflowId || !variantId) return null
+        const variantsQuery = get(workflowVariantsQueryAtomFamily(workflowId))
+        const variant = (variantsQuery.data?.workflow_variants ?? []).find(
+            (v) => v.id === variantId,
+        )
+        return variant?.name ?? variant?.slug ?? null
     }),
 )
 
@@ -1337,6 +1362,8 @@ export const workflowMolecule = {
         name: nameAtomFamily,
         /** Entity display name from the workflow artifact (revision names carry the variant name) */
         artifactName: artifactNameAtomFamily,
+        /** Variant label from the variant entity (name, then slug) */
+        variantLabel: variantLabelAtomFamily,
         /** Workflow slug */
         slug: slugAtomFamily,
 
@@ -1484,6 +1511,8 @@ export const workflowMolecule = {
             getStore(options).get(nameAtomFamily(workflowId)),
         artifactName: (entityId: string, options?: StoreOptions) =>
             getStore(options).get(artifactNameAtomFamily(entityId)),
+        variantLabel: (entityId: string, options?: StoreOptions) =>
+            getStore(options).get(variantLabelAtomFamily(entityId)),
         // Raw flags
         flags: (workflowId: string, options?: StoreOptions) =>
             getStore(options).get(flagsAtomFamily(workflowId)),

--- a/web/packages/agenta-entities/src/workflow/state/store.ts
+++ b/web/packages/agenta-entities/src/workflow/state/store.ts
@@ -463,21 +463,41 @@ export const nonArchivedAppWorkflowsAtom = atom<Workflow[]>((get) => {
 // ============================================================================
 
 /**
- * Query atom family for fetching variants of a workflow.
- * Used in the Workflow → Variant → Revision selection hierarchy.
+ * Variants query keyed by explicit projectId. This is the canonical query;
+ * the explicit key lets it run inside isolated Jotai stores (e.g. the
+ * evaluation tables) where the global projectIdAtom is not hydrated.
  */
-export const workflowVariantsQueryAtomFamily = atomFamily((workflowId: string) =>
-    atomWithQuery((get) => {
-        const projectId = get(workflowProjectIdAtom)
-        return {
+export const workflowVariantsScopedQueryAtomFamily = atomFamily(
+    ({projectId, workflowId}: {projectId: string; workflowId: string}) =>
+        atomWithQuery(() => ({
             queryKey: ["workflows", "variants", workflowId, projectId],
             queryFn: async (): Promise<WorkflowVariantsResponse> => {
                 if (!projectId || !workflowId) return {count: 0, workflow_variants: []}
                 return queryWorkflowVariants(workflowId, projectId)
             },
-            enabled: get(sessionAtom) && !!projectId && !!workflowId,
+            enabled: !!projectId && !!workflowId,
             staleTime: 30_000,
+        })),
+    (a, b) => a.projectId === b.projectId && a.workflowId === b.workflowId,
+)
+
+/**
+ * Query atom family for fetching variants of a workflow.
+ * Used in the Workflow → Variant → Revision selection hierarchy.
+ * Default-store wrapper around the scoped query above.
+ */
+export const workflowVariantsQueryAtomFamily = atomFamily((workflowId: string) =>
+    atom((get) => {
+        const projectId = get(workflowProjectIdAtom)
+        if (!projectId || !workflowId || !get(sessionAtom)) {
+            return {
+                data: undefined as WorkflowVariantsResponse | undefined,
+                isPending: Boolean(workflowId),
+                isError: false,
+                error: null,
+            }
         }
+        return get(workflowVariantsScopedQueryAtomFamily({projectId, workflowId}))
     }),
 )
 
@@ -893,7 +913,9 @@ const workflowArtifactBatchFetcher = createBatchFetcher<WorkflowArtifactRequest,
 })
 
 /**
- * Query atom family for the workflow ARTIFACT (the workflow-level container).
+ * Artifact query keyed by explicit projectId. This is the canonical query;
+ * the explicit key lets it run inside isolated Jotai stores (e.g. the
+ * evaluation tables) where the global projectIdAtom is not hydrated.
  *
  * Deliberately keyed apart from the revision caches: `workflowQueryAtomFamily`
  * and the latest-revision query both resolve revisions, so the artifact would
@@ -901,23 +923,40 @@ const workflowArtifactBatchFetcher = createBatchFetcher<WorkflowArtifactRequest,
  * the source of truth for the entity's display name — revision `name` carries
  * the variant name ("default"), not the entity name.
  */
-export const workflowArtifactQueryAtomFamily = atomFamily((workflowId: string) =>
-    atomWithQuery((get) => {
-        const projectId = get(workflowProjectIdAtom)
-        return {
+export const workflowArtifactScopedQueryAtomFamily = atomFamily(
+    ({projectId, workflowId}: WorkflowArtifactRequest) =>
+        atomWithQuery(() => ({
             queryKey: ["workflows", "artifact", workflowId, projectId],
             queryFn: async (): Promise<Workflow | null> => {
                 if (!projectId || !workflowId) return null
                 return workflowArtifactBatchFetcher({projectId, workflowId})
             },
             enabled:
-                get(sessionAtom) &&
                 !!projectId &&
                 !!workflowId &&
                 !isLocalDraftId(workflowId) &&
                 !isPlaceholderId(workflowId),
             staleTime: 60_000,
+        })),
+    (a, b) => a.projectId === b.projectId && a.workflowId === b.workflowId,
+)
+
+/**
+ * Default-store wrapper around the scoped artifact query: fills projectId
+ * from the global atom and gates on the session.
+ */
+export const workflowArtifactQueryAtomFamily = atomFamily((workflowId: string) =>
+    atom((get) => {
+        const projectId = get(workflowProjectIdAtom)
+        if (!projectId || !workflowId || !get(sessionAtom)) {
+            return {
+                data: null as Workflow | null,
+                isPending: Boolean(workflowId),
+                isError: false,
+                error: null,
+            }
         }
+        return get(workflowArtifactScopedQueryAtomFamily({projectId, workflowId}))
     }),
 )
 
@@ -2333,7 +2372,12 @@ export function invalidateWorkflowVariantsCache(workflowId: string, options?: St
     } catch {
         // queryClientAtom may not be initialized yet
     }
-    store.set(workflowVariantsQueryAtomFamily(workflowId))
+    // The query-key invalidation above refetches every active observer; the
+    // wrapper atom is read-only so there is no per-atom refetch trigger.
+    const projectId = store.get(workflowProjectIdAtom)
+    if (projectId && workflowId) {
+        store.set(workflowVariantsScopedQueryAtomFamily({projectId, workflowId}))
+    }
 }
 
 /**

--- a/web/packages/agenta-playground-ui/src/components/ExecutionItemComparisonView/assets/GenerationComparisonOutputHeader/index.tsx
+++ b/web/packages/agenta-playground-ui/src/components/ExecutionItemComparisonView/assets/GenerationComparisonOutputHeader/index.tsx
@@ -16,6 +16,11 @@ const GenerationComparisonOutputHeader: React.FC<GenerationComparisonOutputHeade
     entityId,
 }) => {
     const data = useAtomValue(useMemo(() => workflowMolecule.selectors.data(entityId), [entityId]))
+    // Comparison columns are labeled by VARIANT. The revision's own `name`
+    // is only a fallback for drafts the variants list does not know yet.
+    const variantLabel = useAtomValue(
+        useMemo(() => workflowMolecule.selectors.variantLabel(entityId), [entityId]),
+    )
 
     const version = data?.version as number | undefined
     const label = isLocalDraftId(entityId) ? formatLocalDraftLabel(null) : getVersionLabel(version)
@@ -27,7 +32,7 @@ const GenerationComparisonOutputHeader: React.FC<GenerationComparisonOutputHeade
                 className,
             )}
         >
-            <Typography>{data?.name ?? null}</Typography>
+            <Typography>{variantLabel ?? data?.name ?? null}</Typography>
             <Tag color="default" variant="filled" className="bg-[var(--ag-rgba-051729-06)]">
                 {label}
             </Tag>


### PR DESCRIPTION
## Context

The "default" / "--" naming bugs (#4662, fixed across #4634, #4661, #4668) kept resurfacing because workflow name resolution is not one mechanism. The molecule has selectors, but pages like the evaluation run details mount their tables inside isolated Jotai stores where the global `projectIdAtom` is never hydrated, so the molecule's queries silently stay disabled there. Each file worked around that with its own self-contained query, which left four separate fetch-and-cache implementations for the same workflow artifact, and every new surface picked one (or invented a fifth) and got the fallback chain slightly wrong.

This PR makes the two display rules from web/AGENTS.md ("Entity display names") mechanically easy to follow: one sanctioned selector per rule, working in every store.

## Changes

The canonical artifact and variants queries in `@agenta/entities/workflow` are now keyed by explicit `{projectId, workflowId}` (`workflowArtifactScopedQueryAtomFamily`, `workflowVariantsScopedQueryAtomFamily`). An explicit key is what the per-file copies already did; promoting it to the package makes the canonical query usable inside isolated stores. The old single-key families remain as thin default-store wrappers that fill `projectId` from the global atom and gate on the session, so the ergonomic API and the query cache keys are unchanged.

On top of that sits the second sanctioned selector: `workflowMolecule.selectors.variantLabel(entityId)` resolves the variant through `workflow_variant_id` and labels it `variant.name`, then `variant.slug`. Together with the existing `selectors.artifactName`, every display surface now has exactly two ways to label a workflow, matching the AGENTS.md rules.

Consumers then collapse onto these:

- The self-contained artifact query copies in `References/atoms/entityReferences.ts` and `EvalRunDetails/atoms/table/evaluators.ts` are deleted; both import the scoped package family. One cache instead of three for the same artifact.
- The four hand-rolled variant lookups from #4661 (`usePreviewVariantConfig`, `VariantRevisionLabel`, the new-evaluation modal tag, the auto-generated run name) become `selectors.variantLabel` reads.
- `GenerationComparisonOutputHeader` (playground comparison columns) now prefers the variant label over the revision name, which also fixes SDK-created apps whose revisions carry no name at all.

Net behavior change: none intended. The diff is +133/−126; the deletions are the duplicated query plumbing.

## Tests

- All 656 `agenta-entities` unit tests pass; `tsc --noEmit` clean on `agenta-entities` and `agenta-playground-ui`; package lints clean; the touched `web/oss` files carry the same 8 pre-existing tsc errors as their baseline, none new.
- A medium-effort review pass traced every consumer of the re-keyed families for writes or fields the wrapper lacks; the two candidates it raised were refuted (one call is guarded, one consumer sees an identical shape before and after).
- Verified on the dev deployment: the evaluation run overview (the isolated-store path, riskiest) renders "Code Evaluation" in the summary rows and "default v2" in the Variant chip through the new scoped queries.

## What to QA

Regression-only sweep, no behavior should change:

- Evaluation run overview: evaluator names and the Variant row read correctly.
- New evaluation modal: the Revision tab tag and the suggested run name show the variant label ("default - v2" for SDK-created apps).
- Playground comparison view: columns are still labeled by variant; evaluator second-step results still show the evaluator name.
- Registry and deployments pages load with correct variant names.
