### PR TITLE
feat(api): Enforce AGENTA_ACCESS_* domain and email controls in OSS

### DIFF
--- a/api/oss/src/core/auth/helper.py
+++ b/api/oss/src/core/auth/helper.py
@@ -3,7 +3,6 @@ from typing import Any, Optional, Set
 
 from oss.src.utils.exceptions import UnauthorizedException
 from oss.src.utils.caching import get_cache, set_cache
-from oss.src.utils.common import is_ee
 from oss.src.utils.env import env
 from oss.src.utils.lazy import _load_posthog
 from oss.src.utils.logging import get_module_logger
@@ -134,9 +133,6 @@ def matches_exact_or_subdomain(
 
 
 async def is_auth_info_blocked(auth_info: AuthInfo) -> bool:
-    if not is_ee():
-        return False
-
     if auth_info.email in await get_blocked_emails():
         return True
 

--- a/api/oss/tests/pytest/unit/auth/test_helper.py
+++ b/api/oss/tests/pytest/unit/auth/test_helper.py
@@ -13,7 +13,6 @@ from supertokens_python.recipe.thirdparty.interfaces import SignInUpNotAllowed
 async def test_ensure_auth_info_not_blocked_rejects_explicitly_blocked_email(
     monkeypatch,
 ):
-    monkeypatch.setattr(auth_helper, "is_ee", lambda: True)
     monkeypatch.setattr(
         auth_helper,
         "get_blocked_emails",
@@ -38,7 +37,6 @@ async def test_ensure_auth_info_not_blocked_rejects_explicitly_blocked_email(
 
 @pytest.mark.asyncio
 async def test_ensure_auth_info_not_blocked_rejects_disallowed_domain(monkeypatch):
-    monkeypatch.setattr(auth_helper, "is_ee", lambda: True)
     monkeypatch.setattr(
         auth_helper,
         "get_blocked_emails",


### PR DESCRIPTION
## Context

OSS already parses all four access env vars (`AGENTA_ACCESS_ALLOWED_DOMAINS`, `AGENTA_ACCESS_ALLOWED_OWNER_EMAILS`, `AGENTA_ACCESS_BLOCKED_DOMAINS`, `AGENTA_ACCESS_BLOCKED_EMAILS`) through the shared `AccessConfig`, but never enforces them: `is_auth_info_blocked()` early-returns `False` when not running EE. Sequencing step 3 of the convergence plan (`docs/designs/oss-ee-convergence/assessment-a-oss-multi-org.md`).

## Changes

Deletes the `if not is_ee(): return False` gate in `is_auth_info_blocked()` (`oss/src/core/auth/helper.py`). That is the whole change: parsing, normalization, and the exact-or-subdomain matcher are already shared, so OSS now gets identical blocklist/allowlist semantics on every auth path that calls `ensure_auth_info_not_blocked`.

`AGENTA_ACCESS_ALLOWED_OWNER_EMAILS` is enforced by `can_create_organization`, which moves into OSS with the org-creation PR (#4673); nothing more is needed here.

## Tests / notes

- `ruff format` and `ruff check` pass.
- Unit tests in `oss/tests/pytest/unit/auth/test_helper.py` updated: they stubbed the now-deleted `is_ee` import (which would raise AttributeError) and now exercise the enforcement path both editions share.
- Note for OSS deployments with PostHog enabled: when `AGENTA_ACCESS_BLOCKED_EMAILS`/`BLOCKED_DOMAINS` are unset, the PostHog-backed fallback blocklists now also apply (same as EE).
- Shippable independently of the multi-org work.

## What to QA

- OSS with `AGENTA_ACCESS_BLOCKED_EMAILS=bad@x.com`: signup/signin as that email is denied with "Access Denied."
- OSS with `AGENTA_ACCESS_ALLOWED_DOMAINS=mycorp.com`: a `@mycorp.com` (or subdomain) email signs in; any other domain is denied.
- Regression: OSS with none of the vars set behaves as before (everyone allowed).

🤖 Generated with [Claude Code](https://claude.com/claude-code)


