### PR TITLE
doc(docs): mark annotation queues and in-playground evaluation as shipped on the roadmap

### DIFF
--- a/docs/src/data/roadmap.ts
+++ b/docs/src/data/roadmap.ts
@@ -27,6 +27,42 @@ export const shippedFeatures: ShippedFeature[] = [
   // Integration: FFA500
   // Security: 000000
   {
+    id: "playground-evaluation-workbench",
+    title: "Evaluate While You Iterate in the Playground",
+    description:
+      "Attach evaluators to playground sessions and see scores inline as you iterate on prompts. Connect test sets to keep prompt iteration and data curation in one loop.",
+    changelogPath: "/docs/changelog/playground-evaluation-workbench",
+    shippedAt: "2026-06-09",
+    labels: [
+      {
+        name: "Playground",
+        color: "BCFF78",
+      },
+      {
+        name: "Evaluation",
+        color: "86B7FF",
+      },
+    ],
+  },
+  {
+    id: "annotation-queues",
+    title: "Annotation Queues",
+    description:
+      "Build a review queue from traces or test set rows, attach a scoring schema, and route it to reviewers. Export finished queues as labeled test sets that feed straight into your evaluators.",
+    changelogPath: "/docs/changelog/annotation-queues",
+    shippedAt: "2026-05-18",
+    labels: [
+      {
+        name: "Observability",
+        color: "DE74FF",
+      },
+      {
+        name: "Evaluation",
+        color: "86B7FF",
+      },
+    ],
+  },
+  {
     id: "deployment-webhooks",
     title: "Webhooks and GitHub Automations for Prompt Deployments",
     description:
@@ -462,36 +498,6 @@ export const inProgressFeatures: PlannedFeature[] = [
         name: "Playground",
         color: "BCFF78",
       },
-      {
-        name: "Observability",
-        color: "DE74FF",
-      },
-    ],
-  },
-  {
-    id: "evaluators-in-playground",
-    title: "Running Evaluators in the Playground",
-    description:
-      "Run evaluators directly in the playground to get immediate quality feedback on prompt changes. Evaluate outputs inline as you iterate on prompts. Scores, pass/fail results, and evaluator reasoning appear right next to the LLM response.",
-    githubUrl: "https://github.com/Agenta-AI/agenta/discussions/3702",
-    labels: [
-      {
-        name: "Playground",
-        color: "BCFF78",
-      },
-      {
-        name: "Evaluation",
-        color: "86B7FF",
-      },
-    ],
-  },
-  {
-    id: "annotation-queues-traces",
-    title: "Annotation Queues for Traces",
-    description:
-      "Annotation queues let you define a set of traces to review, assign them to team members, and track annotation progress — all from within Agenta.",
-    githubUrl: "https://github.com/Agenta-AI/agenta/discussions/4009",
-    labels: [
       {
         name: "Observability",
         color: "DE74FF",


### PR DESCRIPTION
## What

The roadmap's "Last Shipped" list (`docs/src/data/roadmap.ts`) was stuck at the **Webhooks and GitHub Automations** entry from 3/11/2026, even though two of the features still listed under **In progress** had already shipped and been announced in the changelog.

This moves them to **Last Shipped**:

| Feature | Changelog | Shipped |
|---|---|---|
| Annotation Queues | `/changelog/annotation-queues` | 2026-05-18 |
| Evaluate While You Iterate in the Playground | `/changelog/playground-evaluation-workbench` | 2026-06-09 |

## Before / After

- **Before:** "Annotation Queues for Traces" (#4009) and "Running Evaluators in the Playground" (#3702) sat in *In progress*, telling visitors these were still being built. The roadmap's newest shipped item was from March.
- **After:** Both are removed from *In progress* and added to the top of `shippedFeatures`, each linking to its published changelog entry.

## Notes

- Dark Mode (6/5) and the Unified Invoke API (4/14) were also shipped in this window but are intentionally left off per request.
- "Updates to the Evaluator Playground" (#4011) stays in progress; it is framed as a separate richer-editing effort from the workbench.