### PR TITLE
doc(docs): move test set annotation queue from planned to in progress

### DIFF
--- a/docs/src/data/roadmap.ts
+++ b/docs/src/data/roadmap.ts
@@ -525,9 +525,6 @@ export const inProgressFeatures: PlannedFeature[] = [
       },
     ],
   },
-];
-
-export const plannedFeatures: PlannedFeature[] = [
   {
     id: "annotation-queue-label-testsets",
     title: "Annotation Queue to Label Test Sets",
@@ -545,6 +542,9 @@ export const plannedFeatures: PlannedFeature[] = [
       },
     ],
   },
+];
+
+export const plannedFeatures: PlannedFeature[] = [
   {
     id: "trace-usage-limits",
     title: "Usage Limits for Traces (Hard and Soft Caps)",


### PR DESCRIPTION
## What

Moves **Annotation Queue to Label Test Sets** (#4010) from the **Planned** section to **In progress** in `docs/src/data/roadmap.ts`.

## Why

This capability has shipped but is not yet announced in the changelog, so it does not belong in *Planned*. Until it has a changelog entry to link from *Last Shipped*, *In progress* is the accurate status.

## Before / After

- **Before:** Listed under *Planned*, implying work has not started.
- **After:** Listed at the end of `inProgressFeatures`.

## Note

This is a separate, parallel PR to the one marking annotation queues / in-playground evaluation as shipped. Both touch `roadmap.ts`, so whichever merges second may need a trivial conflict resolution.