### PR TITLE
chore(api): proof migration on the shared post-alignment chain

### DIFF
--- a/api/oss/databases/postgres/migrations/core_oss/versions/0a5500000002_oss_chain_proof.py
+++ b/api/oss/databases/postgres/migrations/core_oss/versions/0a5500000002_oss_chain_proof.py
@@ -1,0 +1,26 @@
+"""prove the shared chain advances independently of the parked legacy chain
+
+Intentionally a no-op: its only observable effect is alembic_version_oss
+moving from the root to this revision in both editions.
+
+Revision ID: 0a5500000002
+Revises: 0a5500000001
+Create Date: 2026-06-12 00:00:09.000000
+
+"""
+
+from typing import Sequence, Union
+
+# revision identifiers, used by Alembic.
+revision: str = "0a5500000002"
+down_revision: Union[str, None] = "0a5500000001"
+branch_labels: Union[str, Sequence[str], None] = None
+depends_on: Union[str, Sequence[str], None] = None
+
+
+def upgrade() -> None:
+    pass
+
+
+def downgrade() -> None:
+    pass


### PR DESCRIPTION
## Context

First real revision on the shared post-alignment chain (see the chain-split PR). Intentionally a no-op.

## Changes

- `0a5500000002` on the shared chain: replaying either edition moves `alembic_version_oss` past the root while the parked `alembic_version` stays at the align revision.

## What to QA

Schema dumps before/after show only the `alembic_version_oss` row changing, identically in OSS and EE.

🤖 Generated with [Claude Code](https://claude.com/claude-code)