### PR TITLE
chore(api): proof migration on the EE-only chain

### DIFF
--- a/api/ee/databases/postgres/migrations/core_ee/versions/0ee000000002_ee_chain_proof.py
+++ b/api/ee/databases/postgres/migrations/core_ee/versions/0ee000000002_ee_chain_proof.py
@@ -1,0 +1,27 @@
+"""prove the EE-only chain advances independently of the shared chain
+
+Intentionally a no-op: its only observable effect is alembic_version_ee
+moving past the root in EE databases, while alembic_version_oss and the
+parked alembic_version are untouched. OSS databases never see this chain.
+
+Revision ID: 0ee000000002
+Revises: 0ee000000001
+Create Date: 2026-06-12 00:00:10.000000
+
+"""
+
+from typing import Sequence, Union
+
+# revision identifiers, used by Alembic.
+revision: str = "0ee000000002"
+down_revision: Union[str, None] = "0ee000000001"
+branch_labels: Union[str, Sequence[str], None] = None
+depends_on: Union[str, Sequence[str], None] = None
+
+
+def upgrade() -> None:
+    pass
+
+
+def downgrade() -> None:
+    pass


### PR DESCRIPTION
## Context

First real revision on the EE-only chain (see the chain-split PR). Intentionally a no-op.

## Changes

- `0ee000000002` on the EE chain: `alembic_version_ee` advances in EE databases; the shared and parked tables are untouched; OSS never sees this chain.

## What to QA

EE schema dump shows only the `alembic_version_ee` row changing; OSS dump is byte-identical before/after.

🤖 Generated with [Claude Code](https://claude.com/claude-code)