### PR TITLE
[feat][UX/UI] Hide mapping and preview until a test set is selected

### DIFF
--- a/web/oss/src/components/SharedDrawers/AddToTestsetDrawer/TestsetDrawer.tsx
+++ b/web/oss/src/components/SharedDrawers/AddToTestsetDrawer/TestsetDrawer.tsx
@@ -151,51 +151,56 @@ const TestsetDrawer = ({open, spanIds, onClose, initialPath = "ag.data"}: Testse
                             elementWidth={elementWidth}
                         />
 
-                        <DataPreviewEditor
-                            traceData={drawer.traceData}
-                            rowDataPreview={drawer.rowDataPreview}
-                            setRowDataPreview={drawer.setRowDataPreview}
-                            setUpdatedTraceData={drawer.setUpdatedTraceData}
-                            editorFormat={drawer.editorFormat}
-                            formatDataPreview={drawer.formatDataPreview}
-                            selectedTraceData={drawer.selectedTraceData}
-                            onRemoveTraceData={drawer.onRemoveTraceData}
-                            onSaveEditedTrace={drawer.onSaveEditedTrace}
-                            onRevertEditedTrace={drawer.onRevertEditedTrace}
-                            columnOptions={drawer.columnOptions}
-                            onMapToColumn={drawer.onMapToColumnFromDrillIn}
-                            onUnmap={drawer.onUnmapFromDrillIn}
-                            mappedPaths={drawer.mappedPaths}
-                            focusPath={focusPath}
-                            onFocusPathHandled={handleFocusPathHandled}
-                            onPropertyClick={handleFocusPath}
-                            initialPath={initialPath}
-                        />
+                        {/* Steps 2-4: only shown after a test set is selected or a new one is being created */}
+                        {(!!drawer.selectedRevisionId || drawer.isNewTestset) && (
+                            <>
+                                <DataPreviewEditor
+                                    traceData={drawer.traceData}
+                                    rowDataPreview={drawer.rowDataPreview}
+                                    setRowDataPreview={drawer.setRowDataPreview}
+                                    setUpdatedTraceData={drawer.setUpdatedTraceData}
+                                    editorFormat={drawer.editorFormat}
+                                    formatDataPreview={drawer.formatDataPreview}
+                                    selectedTraceData={drawer.selectedTraceData}
+                                    onRemoveTraceData={drawer.onRemoveTraceData}
+                                    onSaveEditedTrace={drawer.onSaveEditedTrace}
+                                    onRevertEditedTrace={drawer.onRevertEditedTrace}
+                                    columnOptions={drawer.columnOptions}
+                                    onMapToColumn={drawer.onMapToColumnFromDrillIn}
+                                    onUnmap={drawer.onUnmapFromDrillIn}
+                                    mappedPaths={drawer.mappedPaths}
+                                    focusPath={focusPath}
+                                    onFocusPathHandled={handleFocusPathHandled}
+                                    onPropertyClick={handleFocusPath}
+                                    initialPath={initialPath}
+                                />
 
-                        <MappingSection
-                            mappingData={drawer.mappingData}
-                            setMappingData={drawer.setMappingData}
-                            onMappingOptionChange={drawer.onMappingOptionChange}
-                            onRemoveMapping={drawer.onRemoveMapping}
-                            onNewColumnBlur={drawer.onNewColumnBlur}
-                            allAvailablePaths={drawer.allAvailablePaths}
-                            columnOptions={drawer.columnOptions}
-                            customSelectOptions={drawer.customSelectOptions}
-                            selectedRevisionId={drawer.selectedRevisionId}
-                            hasDuplicateColumns={drawer.hasDuplicateColumns}
-                            testsetId={drawer.testset.id}
-                            selectedTestsetColumns={drawer.selectedTestsetColumns}
-                            elementWidth={elementWidth}
-                            isNewTestset={drawer.isNewTestset}
-                            onFocusPath={handleFocusPath}
-                        />
+                                <MappingSection
+                                    mappingData={drawer.mappingData}
+                                    setMappingData={drawer.setMappingData}
+                                    onMappingOptionChange={drawer.onMappingOptionChange}
+                                    onRemoveMapping={drawer.onRemoveMapping}
+                                    onNewColumnBlur={drawer.onNewColumnBlur}
+                                    allAvailablePaths={drawer.allAvailablePaths}
+                                    columnOptions={drawer.columnOptions}
+                                    customSelectOptions={drawer.customSelectOptions}
+                                    selectedRevisionId={drawer.selectedRevisionId}
+                                    hasDuplicateColumns={drawer.hasDuplicateColumns}
+                                    testsetId={drawer.testset.id}
+                                    selectedTestsetColumns={drawer.selectedTestsetColumns}
+                                    elementWidth={elementWidth}
+                                    isNewTestset={drawer.isNewTestset}
+                                    onFocusPath={handleFocusPath}
+                                />
 
-                        <PreviewSection
-                            selectedRevisionId={drawer.selectedRevisionId}
-                            isMapColumnExist={drawer.isMapColumnExist}
-                            isNewTestset={drawer.isNewTestset}
-                            testcaseCount={drawer.traceData.length}
-                        />
+                                <PreviewSection
+                                    selectedRevisionId={drawer.selectedRevisionId}
+                                    isMapColumnExist={drawer.isMapColumnExist}
+                                    isNewTestset={drawer.isNewTestset}
+                                    testcaseCount={drawer.traceData.length}
+                                />
+                            </>
+                        )}
 
                         <ConfirmSaveModal
                             isConfirmSave={drawer.isConfirmSave}


### PR DESCRIPTION
## Summary

Closes #4616

Steps 2–4 of the **Add to test set** drawer (`DataPreviewEditor`, `MappingSection`, `PreviewSection`) are now hidden until the user either:
- selects an existing test set revision (`selectedRevisionId` is truthy), or
- switches to creating a new test set (`isNewTestset === true`).

Before this change all three sections rendered immediately on drawer open, showing mapping controls that had no effect until a test set was chosen — which was confusing.

## Changes

`web/oss/src/components/SharedDrawers/AddToTestsetDrawer/TestsetDrawer.tsx`

Wrapped the three lower sections in a single conditional:

```tsx
{(!!drawer.selectedRevisionId || drawer.isNewTestset) && (
    <>
        <DataPreviewEditor ... />
        <MappingSection ... />
        <PreviewSection ... />
    </>
)}
```

## Demo

**Before** — Steps 2–4 (data preview, column mapping, row preview) are always visible even with no test set selected, showing empty/unusable controls:

**After** — Only Step 1 (test set selector) is shown initially. Steps 2–4 appear only once a test set revision is selected or a new test set is being created:

![Before vs After: drawer steps hidden until test set selected](https://github.com/NamHT4Devlop/agenta/releases/download/untagged-669baf9edff6d855a815/agenta_before_after.png)

## How to test

1. Open the **Add to test set** drawer from a trace span.
2. Confirm only the `TestsetSelector` (step 1) is visible initially.
3. Select an existing test set — steps 2–4 should appear.
4. Clear the selection — steps 2–4 should hide again.
5. Choose **+ New test set** — steps 2–4 should appear.

## Type checks

`pnpm run types:check` in `web/oss/` — no new errors introduced (all pre-existing).