### PR TITLE
fix(evaluator): look in advanced_config for *_key settings when build…

### DIFF
--- a/web/packages/agenta-entities/src/runnable/utils.ts
+++ b/web/packages/agenta-entities/src/runnable/utils.ts
@@ -1120,6 +1120,29 @@ export function buildEvaluatorExecutionInputs(ctx: EvaluatorInputContext): Recor
 }
 
 /**
+ * Resolve a `{key}_key` setting value from the settings object.
+ *
+ * `nestEvaluatorConfiguration` moves `correct_answer_key` and `threshold` into
+ * `advanced_config` for LLM evaluators so the UI can group them under an
+ * "Advanced Configuration" section. At execution time the nested config is
+ * passed as `settings`, so we must look in both the top level AND inside
+ * `advanced_config` to find these mappings.
+ */
+function resolveKeySettingValue(
+    settings: Record<string, unknown>,
+    keySettingName: string,
+): string | undefined {
+    const topLevel = settings[keySettingName]
+    if (typeof topLevel === "string" && topLevel) return topLevel
+
+    const advancedConfig = settings.advanced_config as Record<string, unknown> | undefined
+    const nested = advancedConfig?.[keySettingName]
+    if (typeof nested === "string" && nested) return nested
+
+    return undefined
+}
+
+/**
  * Schema-driven input construction.
  * Iterates schema properties and resolves each input from settings, upstream output, or testcase data.
  */
@@ -1136,8 +1159,10 @@ function buildFromSchema(ctx: {
     for (const key of Object.keys(schemaProperties)) {
         // 1. Check for a corresponding _key setting that maps to a testcase column
         //    e.g., input "correct_answer" ← setting "correct_answer_key" → testcase column
+        //    The setting may live at the top level or inside advanced_config (LLM evaluators
+        //    have it nested there after nestEvaluatorConfiguration).
         const keySettingName = `${key}_key`
-        const keySettingValue = settings[keySettingName]
+        const keySettingValue = resolveKeySettingValue(settings, keySettingName)
 
         if (typeof keySettingValue === "string" && keySettingValue) {
             const columnName = keySettingValue.startsWith("testcase.")
@@ -1198,7 +1223,9 @@ function buildLegacy(ctx: {
 }): Record<string, unknown> {
     const {testcaseData, upstreamOutput, settings} = ctx
 
-    const correctAnswerKey = settings.correct_answer_key
+    // Look in both top-level and advanced_config — nestEvaluatorConfiguration
+    // moves correct_answer_key into advanced_config for LLM evaluators.
+    const correctAnswerKey = resolveKeySettingValue(settings, "correct_answer_key")
     const groundTruthKey =
         typeof correctAnswerKey === "string" && correctAnswerKey.startsWith("testcase.")
             ? correctAnswerKey.split(".")[1]
@@ -1278,9 +1305,11 @@ export function validateEvaluatorInputs(ctx: EvaluatorInputContext): EvaluatorIn
             continue
         }
 
-        // Check for a corresponding _key setting that maps to a testcase column
+        // Check for a corresponding _key setting that maps to a testcase column.
+        // Also look inside advanced_config — nestEvaluatorConfiguration moves
+        // correct_answer_key there for LLM evaluators.
         const keySettingName = `${key}_key`
-        const keySettingValue = settings[keySettingName]
+        const keySettingValue = resolveKeySettingValue(settings, keySettingName)
 
         if (typeof keySettingValue === "string" && keySettingValue) {
             // Setting exists — check if the mapped column exists in testcase data


### PR DESCRIPTION
…ing evaluator inputs

nestEvaluatorConfiguration nests correct_answer_key (and threshold) inside advanced_config for LLM evaluators so the UI can render them under an "Advanced Configuration" section. buildEvaluatorExecutionInputs, buildLegacy, and validateEvaluatorInputs all did a top-level-only lookup (settings["correct_answer_key"]), so the key→testcase-column mapping was silently missed, causing:

  - "Missing input: At 'correct_answer'" errors when the evaluator ran
  - correct_answer visually clearing from the testcase editor after a run

Adds resolveKeySettingValue() which checks both settings[keySettingName] and settings.advanced_config[keySettingName], and uses it in all three call sites.

## Summary
<!-- What changed? -->
<!-- Why was this change needed? -->
<!-- What problem does it solve? -->
<!-- For fixes, explain how the change addresses the root cause. -->

## Testing
### Verified locally
<!-- What did you run or verify locally? Be specific. -->

### Added or updated tests
<!-- What tests did you add or update? Include unit, integration, and end-to-end coverage when relevant. Write N/A if none. -->

### QA follow-up
<!-- What still needs QA? List flows, browsers, environments, edge cases, or data conditions to validate. Write N/A if none. -->

## Demo
<!-- Required for UI changes. Add screenshots, GIFs, or a short video. -->
<!-- If this is not a UI change, write N/A. -->

## Checklist
- [ ] I have included a video or screen recording for UI changes, or marked Demo as N/A
- [ ] Relevant tests pass locally
- [ ] Relevant linting and formatting pass locally
- [ ] I have signed the CLA, or I will sign it when the bot prompts me

## Contributor Resources
- [Contributing guide](https://agenta.ai/docs/contributing/overview)
- [Creating your first PR](https://agenta.ai/docs/contributing/first-pr)
- [Development mode](https://agenta.ai/docs/contributing/guides/development-mode)
- [Testing](https://agenta.ai/docs/contributing/guides/testing)
- [Formatting and linting](https://agenta.ai/docs/contributing/guides/formatting-and-linting)
- [Slack support](https://join.slack.com/t/agenta-hq/shared_invite/zt-37pnbp5s6-mbBrPL863d_oLB61GSNFjw)
