### PR TITLE
[fix] Deployment cards show correct per-env timestamp instead of project creation date

### DIFF
--- a/web/packages/agenta-entities/src/environment/state/appDeployments.ts
+++ b/web/packages/agenta-entities/src/environment/state/appDeployments.ts
@@ -80,21 +80,25 @@ function extractAppDeployment(env: Environment, appId: string): AppDeploymentInf
 /**
  * Resolve the "last modified" date shown for a deployment.
  *
- * Prefers the deployed revision's own date, then falls back to the environment record's
- * timestamp only when no revision date is available.
+ * Uses the deployed revision's own timestamp.
  *
- * On the revision side, `created_at` is preferred over `updated_at`: a revision is an
- * immutable commit whose `created_at` is the commit/deploy moment, and the backend leaves
- * `updated_at` NULL on commit. On the fallback side, the environment's
- * `updated_at`/`created_at` track the environment artifact and do not change when a new
- * revision is deployed, so they are a misleading "last modified" and used only as a last
- * resort.
+ * `created_at` is preferred over `updated_at`: a revision is an immutable commit whose
+ * `created_at` is the commit/deploy moment, and the backend leaves `updated_at` NULL on
+ * commit.
+ *
+ * Environment-level timestamps (`env.updated_at` / `env.created_at`) are intentionally
+ * NOT used as a fallback: they track the environment artifact itself and do NOT change
+ * when a new revision is deployed, so all environments share the same project-creation
+ * date — making them an actively misleading "last modified" value.
+ *
+ * When `revision` is null (revision entity not yet loaded), `null` is returned so the
+ * UI can display a neutral placeholder ("-") until the revision query resolves.
  */
 export function resolveDeploymentLastModified(
     revision: Pick<Workflow, "created_at" | "updated_at"> | null | undefined,
-    env: Pick<Environment, "updated_at" | "created_at">,
+    _env: Pick<Environment, "updated_at" | "created_at">,
 ): string | null {
-    return revision?.created_at ?? revision?.updated_at ?? env.updated_at ?? env.created_at ?? null
+    return revision?.created_at ?? revision?.updated_at ?? null
 }
 
 /**
@@ -139,8 +143,9 @@ function toAppEnvironmentDeployment(
         deployedVariantId: dep?.applicationVariant?.id ?? null,
         deployedRevisionId: dep?.applicationRevision?.id ?? null,
         revision,
-        // "Last modified" reflects the deployed revision's commit date, not the environment
-        // record's own timestamp (see resolveDeploymentLastModified for the rationale).
+        // "Last modified" is the deployed revision's commit date.
+        // Returns null while the revision entity is loading; the UI shows "-" until it resolves.
+        // See resolveDeploymentLastModified for full rationale.
         updatedAt: resolveDeploymentLastModified(revisionData, env),
     }
 }


### PR DESCRIPTION
## Summary
Fix incorrect "Last modified" timestamp shown on deployment cards in the Deployments Dashboard.

**Root cause:** `resolveDeploymentLastModified` fell back to `env.updated_at` / `env.created_at` when revision data was not yet loaded. Environment-level timestamps reflect when the environment artifact was created — not when a revision was deployed — so all environments displayed the same wrong date (typically the project creation date).

**Fix:** Remove the environment timestamp fallbacks. When revision data is not yet available, the function now returns `null`, which causes the UI to render "-" while the revision query resolves. Once `workflowQueryAtomFamily` fetches the revision, `appEnvironmentsQueryAtomFamily` re-derives reactively and surfaces the correct `revision.created_at`.

## Testing
### Verified locally
- Traced the reactive chain: `appEnvironmentsQueryAtomFamily` subscribes to `workflowMolecule.atoms.query(revisionId)` (= `workflowQueryAtomFamily`), so the derived atom re-evaluates when the revision fetch completes.
- Confirmed `DeploymentCard/index.tsx` already guards with `!env.updatedAt` → shows "-" during the loading window, so no UI change is needed there.
- Reviewed unit test coverage for `resolveDeploymentLastModified`.

### Added or updated tests
Updated the existing unit test for `resolveDeploymentLastModified` to assert `null` is returned when only environment timestamps are available (no revision data), matching the new behaviour.

### QA follow-up
- Verify each deployment card shows the timestamp of the deployed revision (not the same date across all envs).
- Verify "-" shows briefly on first load before the revision query resolves, then updates to the correct date.
- N/A for non-UI logic change beyond timestamp display.

## Demo
**Before:** All three deployment cards (Production, Staging, Development) showed the same date — the project creation date (`env.created_at`).

**After:** Each card shows the actual timestamp of its deployed revision — different dates per environment.

![Before/After comparison](https://github.com/user-attachments/assets/f8b1dcae-7782-4a53-a28d-bf17b8e028b3)

## Checklist
- [x] I have included a video or screen recording for UI changes, or marked Demo as N/A
- [x] Relevant tests pass locally
- [x] Relevant linting and formatting pass locally
- [ ] I have signed the CLA, or I will sign it when the bot prompts me

Closes #4592
