### PR TITLE
[fix] Table header stays aligned during horizontal scroll in InfiniteVirtualTable

### DIFF
--- a/web/oss/src/components/InfiniteVirtualTable/components/InfiniteVirtualTableInner.tsx
+++ b/web/oss/src/components/InfiniteVirtualTable/components/InfiniteVirtualTableInner.tsx
@@ -446,6 +446,36 @@ const InfiniteVirtualTableInnerBase = <RecordType extends object>({
         tableHeaderHeight,
     ])
 
+    // Sync .ant-table-header scroll position with .ant-table-body on every horizontal scroll.
+    //
+    // AntD's virtual Table syncs header/body scroll internally, but it can lose sync after
+    // column visibility changes, resizes, or scroll-config updates that trigger a re-render.
+    // We attach our own passive scroll listener as a safety net: when it fires, the header is
+    // already correct (AntD's handler ran first), so this is a no-op in the happy path.
+    // When AntD's sync breaks, our listener corrects the header on the very next scroll tick.
+    useEffect(() => {
+        const container = containerRef.current
+        if (!container) return
+
+        const body = container.querySelector<HTMLElement>(".ant-table-body")
+        const header = container.querySelector<HTMLElement>(".ant-table-header")
+        if (!body || !header) return
+
+        const sync = () => {
+            if (header.scrollLeft !== body.scrollLeft) {
+                header.scrollLeft = body.scrollLeft
+            }
+        }
+
+        body.addEventListener("scroll", sync, {passive: true})
+        // Correct any drift that happened during the re-render that triggered this effect
+        sync()
+
+        return () => {
+            body.removeEventListener("scroll", sync)
+        }
+    }, [finalColumns, scrollConfig.x])
+
     // Memoize dependencies object to prevent unnecessary useEffect runs in useScrollContainer
     // Without memoization, a new object is created every render, causing infinite loops during scroll
     const scrollContainerDeps = useMemo(


### PR DESCRIPTION
## Summary
Fix table header columns becoming misaligned after horizontal scrolling in `InfiniteVirtualTable`.

**Root cause:** AntD's virtual table renders `.ant-table-header` (overflow: hidden) and `.ant-table-body` (overflow: auto) as separate DOM elements and syncs their scroll positions internally. However, after column visibility changes or `scroll.x` updates trigger a re-render, AntD's internal sync handler is re-registered and may not fire before the next scroll event, causing the header to drift relative to the body.

**Fix:** Add a passive `scroll` listener on `.ant-table-body` inside `InfiniteVirtualTableInner` that directly writes `body.scrollLeft → header.scrollLeft` on every scroll tick. The effect re-attaches whenever `finalColumns` or `scrollConfig.x` change — exactly the conditions that cause drift — and runs `sync()` once on mount to correct any drift that happened during the triggering re-render.

## Testing
### Verified locally
- Toggled column visibility via the column-picker while scrolled horizontally: header stays aligned.
- Resized columns while scrolled horizontally: header stays aligned.
- Normal horizontal scroll before any column changes: still works correctly.
- Checked that the passive listener has no measurable scroll performance impact.

### Added or updated tests
N/A — this is a DOM-sync side-effect that requires a rendered browser environment to test meaningfully. Manual verification covers the affected scenarios.

### QA follow-up
- Test with a large number of columns (10+) so the table is horizontally scrollable.
- Toggle column visibility while scrolled to the rightmost position and verify headers snap back into alignment.
- Verify on Safari (different scroll event timing) as well as Chrome.

## Demo
**Before:** After scrolling right and then toggling a column, the header row drifts and no longer aligns with the body columns.

**After:** Header stays perfectly aligned with body columns at all times, including after column visibility or width changes.

<img width="900" height="380" alt="demo-4633-before-after" src="https://github.com/user-attachments/assets/e1d2de9b-5347-4688-a3bd-d792cf044b84" />

## Checklist
- [x] I have included a video or screen recording for UI changes, or marked Demo as N/A
- [x] Relevant tests pass locally
- [x] Relevant linting and formatting pass locally
- [x] I have signed the CLA, or I will sign it when the bot prompts me

Closes #4633
