### PR TITLE
docs(docs): replace intro cover image with platform walkthrough video

### DIFF
--- a/docs/docs/getting-started/01-introduction.mdx
+++ b/docs/docs/getting-started/01-introduction.mdx
@@ -6,18 +6,26 @@ id: introduction
 sidebar_position: 0
 ---
 
-import Image from "@theme/IdealImage";
 
-<Image
-  style={{ display: "block", margin: "0 auto" }}
-  img={require("/images/agenta-cover.png")}
-  alt="Screenshots of Agenta LLMOPS platform"
-  loading="lazy"
-/>
-Agenta is an **open-source LLMOps platform** that helps **developers** and **product teams** build reliable LLM applications.
-
+Agenta is an **open-source LLMOps platform** that helps **AI engineers** and **subject matter experts** build reliable AI applications.
 
 Agenta covers the entire LLM development lifecycle: **prompt management**, **evaluation**, and **observability**.
+
+Learn how a typical workflow in Agenta looks like in this 5 minute walkthrough:
+
+
+<iframe
+  width="100%"
+  height="450"
+  style={{ display: "block", margin: "0 auto", borderRadius: "8px" }}
+  src="https://www.youtube.com/embed/zZJfqkc608M"
+  title="Agenta platform walkthrough"
+  frameBorder="0"
+  allow="accelerometer; autoplay; clipboard-write; encrypted-media; gyroscope; picture-in-picture; web-share"
+  allowFullScreen
+></iframe>
+
+
 
 ## Features
 
@@ -62,4 +70,3 @@ Agenta is open-source and MIT licensed, so you can self-host it, modify it, and 
 ### Works with any LLM app workflow
 
 Agenta enables prompt engineering and evaluation on any LLM app architecture, such as **Chain of Prompts**, **RAG**, or **LLM agents**. It is compatible with any framework like **Langchain** or **LlamaIndex**, and works with any model provider, such as **OpenAI**, **Cohere**, or **local models**.
-


### PR DESCRIPTION
## Summary

The docs landing page (What is Agenta?) opened with a static cover screenshot (`agenta-cover.png`). This replaces it with the embedded platform walkthrough video, the same walkthrough added to the README in #4698 (`https://www.youtube.com/watch?v=zZJfqkc608M`).

A short video lets new readers see the platform in action right away instead of a still image.

**Before:** static `agenta-cover.png` rendered via `@theme/IdealImage`.
**After:** responsive YouTube `<iframe>` embed of the walkthrough.

The embed follows the same pattern already used on the Quick Start pages. The now-unused `@theme/IdealImage` import is removed from the page.

## Testing
### Verified locally
Reviewed the rendered MDX change. The iframe matches the embed pattern in `docs/docs/getting-started/02-quick-start.mdx`.

### Added or updated tests
N/A — docs-only change.

### QA follow-up
Confirm the video renders and is full-width on the docs landing page after deploy.

## Demo
N/A — see the linked walkthrough video.

## Checklist
- [x] I have included a video or screen recording for UI changes, or marked Demo as N/A
- [x] Relevant tests pass locally
- [x] Relevant linting and formatting pass locally
- [x] I have signed the CLA, or I will sign it when the bot prompts me