### PR TITLE
fix(frontend): keep test set columns on locally-joined playground rows

### DIFF
--- a/.all-contributorsrc
+++ b/.all-contributorsrc
@@ -624,6 +624,15 @@
         "code",
         "platform"
       ]
+    },
+    {
+      "login": "NamHT4Devlop",
+      "name": "Hồ Trung Nam",
+      "avatar_url": "https://avatars.githubusercontent.com/u/122743792?v=4",
+      "profile": "https://github.com/NamHT4Devlop",
+      "contributions": [
+        "code"
+      ]
     }
   ],
   "contributorsPerLine": 7,

--- a/README.md
+++ b/README.md
@@ -191,7 +191,7 @@ We welcome contributions of all kinds, from filing issues and sharing ideas to i
 ## Contributors ✨
 
 <!-- ALL-CONTRIBUTORS-BADGE:START - Do not remove or modify this section -->
-[![All Contributors](https://img.shields.io/badge/all_contributors-66-orange.svg?style=flat-square)](#contributors-)
+[![All Contributors](https://img.shields.io/badge/all_contributors-67-orange.svg?style=flat-square)](#contributors-)
 <!-- ALL-CONTRIBUTORS-BADGE:END -->
 
 Thanks goes to these wonderful people ([emoji key](https://allcontributors.org/docs/en/emoji-key)):
@@ -286,6 +286,7 @@ Thanks goes to these wonderful people ([emoji key](https://allcontributors.org/d
       <td align="center" valign="top" width="14.28%"><a href="https://github.com/Sanket2329"><img src="https://avatars.githubusercontent.com/u/196506711?v=4?s=100" width="100px;" alt="Sanket Shakya"/><br /><sub><b>Sanket Shakya</b></sub></a><br /><a href="https://github.com/Agenta-AI/agenta/commits?author=Sanket2329" title="Code">💻</a></td>
       <td align="center" valign="top" width="14.28%"><a href="https://github.com/unfitcoder101"><img src="https://avatars.githubusercontent.com/u/175036458?v=4?s=100" width="100px;" alt="unfitcoder101"/><br /><sub><b>unfitcoder101</b></sub></a><br /><a href="https://github.com/Agenta-AI/agenta/issues?q=author%3Aunfitcoder101" title="Bug reports">🐛</a></td>
       <td align="center" valign="top" width="14.28%"><a href="https://github.com/Shunmuka"><img src="https://avatars.githubusercontent.com/u/137101604?v=4?s=100" width="100px;" alt="Shunmuka Valsa"/><br /><sub><b>Shunmuka Valsa</b></sub></a><br /><a href="https://github.com/Agenta-AI/agenta/commits?author=Shunmuka" title="Code">💻</a> <a href="#platform-Shunmuka" title="Packaging/porting to new platform">📦</a></td>
+      <td align="center" valign="top" width="14.28%"><a href="https://github.com/NamHT4Devlop"><img src="https://avatars.githubusercontent.com/u/122743792?v=4?s=100" width="100px;" alt="Hồ Trung Nam"/><br /><sub><b>Hồ Trung Nam</b></sub></a><br /><a href="https://github.com/Agenta-AI/agenta/commits?author=NamHT4Devlop" title="Code">💻</a></td>
     </tr>
   </tbody>
 </table>

--- a/docs/src/data/roadmap.ts
+++ b/docs/src/data/roadmap.ts
@@ -27,6 +27,42 @@ export const shippedFeatures: ShippedFeature[] = [
   // Integration: FFA500
   // Security: 000000
   {
+    id: "playground-evaluation-workbench",
+    title: "Evaluate While You Iterate in the Playground",
+    description:
+      "Attach evaluators to playground sessions and see scores inline as you iterate on prompts. Connect test sets to keep prompt iteration and data curation in one loop.",
+    changelogPath: "/docs/changelog/playground-evaluation-workbench",
+    shippedAt: "2026-06-09",
+    labels: [
+      {
+        name: "Playground",
+        color: "BCFF78",
+      },
+      {
+        name: "Evaluation",
+        color: "86B7FF",
+      },
+    ],
+  },
+  {
+    id: "annotation-queues",
+    title: "Annotation Queues",
+    description:
+      "Build a review queue from traces or test set rows, attach a scoring schema, and route it to reviewers. Export finished queues as labeled test sets that feed straight into your evaluators.",
+    changelogPath: "/docs/changelog/annotation-queues",
+    shippedAt: "2026-05-18",
+    labels: [
+      {
+        name: "Observability",
+        color: "DE74FF",
+      },
+      {
+        name: "Evaluation",
+        color: "86B7FF",
+      },
+    ],
+  },
+  {
     id: "deployment-webhooks",
     title: "Webhooks and GitHub Automations for Prompt Deployments",
     description:
@@ -462,36 +498,6 @@ export const inProgressFeatures: PlannedFeature[] = [
         name: "Playground",
         color: "BCFF78",
       },
-      {
-        name: "Observability",
-        color: "DE74FF",
-      },
-    ],
-  },
-  {
-    id: "evaluators-in-playground",
-    title: "Running Evaluators in the Playground",
-    description:
-      "Run evaluators directly in the playground to get immediate quality feedback on prompt changes. Evaluate outputs inline as you iterate on prompts. Scores, pass/fail results, and evaluator reasoning appear right next to the LLM response.",
-    githubUrl: "https://github.com/Agenta-AI/agenta/discussions/3702",
-    labels: [
-      {
-        name: "Playground",
-        color: "BCFF78",
-      },
-      {
-        name: "Evaluation",
-        color: "86B7FF",
-      },
-    ],
-  },
-  {
-    id: "annotation-queues-traces",
-    title: "Annotation Queues for Traces",
-    description:
-      "Annotation queues let you define a set of traces to review, assign them to team members, and track annotation progress — all from within Agenta.",
-    githubUrl: "https://github.com/Agenta-AI/agenta/discussions/4009",
-    labels: [
       {
         name: "Observability",
         color: "DE74FF",

--- a/docs/src/data/roadmap.ts
+++ b/docs/src/data/roadmap.ts
@@ -525,9 +525,6 @@ export const inProgressFeatures: PlannedFeature[] = [
       },
     ],
   },
-];
-
-export const plannedFeatures: PlannedFeature[] = [
   {
     id: "annotation-queue-label-testsets",
     title: "Annotation Queue to Label Test Sets",
@@ -545,6 +542,9 @@ export const plannedFeatures: PlannedFeature[] = [
       },
     ],
   },
+];
+
+export const plannedFeatures: PlannedFeature[] = [
   {
     id: "trace-usage-limits",
     title: "Usage Limits for Traces (Hard and Soft Caps)",

--- a/web/packages/agenta-playground/src/state/controllers/playgroundController.ts
+++ b/web/packages/agenta-playground/src/state/controllers/playgroundController.ts
@@ -85,7 +85,7 @@ import {
 import {pruneDanglingConnections} from "../helpers/connectionGraph"
 import {
     collectDownstreamReferencedColumns,
-    collectTestcaseServerColumns,
+    collectTestsetServerColumns,
     reconcileRowDataForEntity,
     resolveEntityInputContract,
 } from "../helpers/entityInputContract"
@@ -2218,6 +2218,13 @@ function pruneTestcaseRowsForEntity(get: Getter, set: Setter, entityId: string):
     if (!Array.isArray(displayRowIds) || displayRowIds.length === 0) return "noop"
 
     const protectedColumns = collectDownstreamReferencedColumns(get, get(playgroundNodesAtom))
+    // The synced test set's own columns are intentional data, not stale
+    // leftovers — keep them through the swap clean (#4647). Test-set-scoped
+    // (union across all server rows), so rows that joined the test set
+    // locally are covered too; same value for every row, hence hoisted.
+    for (const column of collectTestsetServerColumns(get)) {
+        protectedColumns.add(column)
+    }
 
     const updates: {id: string; updates: {data: Record<string, unknown>}}[] = []
 
@@ -2226,15 +2233,8 @@ function pruneTestcaseRowsForEntity(get: Getter, set: Setter, entityId: string):
         const data = (row as {data?: Record<string, unknown>} | null)?.data
         if (!data || typeof data !== "object") continue
 
-        // Per-row: the synced test set's own columns are intentional data,
-        // not stale leftovers — keep them through the swap clean (#4647).
-        const serverColumns = collectTestcaseServerColumns(get, rowId)
-        const protectedKeys =
-            serverColumns.size > 0
-                ? new Set([...protectedColumns, ...serverColumns])
-                : protectedColumns
         const {dropped} = reconcileRowDataForEntity(get, entityId, data, {
-            protectedKeys,
+            protectedKeys: protectedColumns,
         })
         if (dropped.length === 0) continue
 

--- a/web/packages/agenta-playground/src/state/execution/selectors.ts
+++ b/web/packages/agenta-playground/src/state/execution/selectors.ts
@@ -543,7 +543,33 @@ export const playgroundInputsAtomFamily = atomFamily(
                 testcaseData[key] = value
             }
 
-            return splitInputsVisibility({referencedKeys, draftKeys, testcaseData})
+            // In connected mode, surface the test set's columns even when
+            // this row doesn't carry them yet — a draft kept through "Keep
+            // and load" or a row added while connected starts with only its
+            // own keys. The drawer already offers these via the registry
+            // merge in `rowVariableKeysAtomFamily`; without the same merge
+            // here the grid hides exactly those fields. Same system/chat
+            // strips as `testcaseData` above.
+            let testsetColumnKeys: string[] | undefined
+            const loadableId = get(derivedLoadableIdAtom)
+            const mode = loadableId ? get(loadableController.selectors.mode(loadableId)) : null
+            if (mode === "connected") {
+                const registry = get(testcaseMolecule.atoms.columns) as {key: string}[] | null
+                testsetColumnKeys = (registry ?? [])
+                    .map((column) => column.key)
+                    .filter(
+                        (key) =>
+                            !isSystemField(key) &&
+                            !(isChat && (key === "messages" || key === "outputs")),
+                    )
+            }
+
+            return splitInputsVisibility({
+                referencedKeys,
+                draftKeys,
+                testcaseData,
+                testsetColumnKeys,
+            })
         }),
     (a, b) => a.testcaseId === b.testcaseId && (a.downstreamKey ?? "") === (b.downstreamKey ?? ""),
 )

--- a/web/packages/agenta-playground/src/state/execution/visibility.ts
+++ b/web/packages/agenta-playground/src/state/execution/visibility.ts
@@ -45,6 +45,12 @@ export interface SplitInputsVisibilityArgs {
     draftKeys?: string[]
     /** Current testcase row data. */
     testcaseData: Record<string, unknown>
+    /** Column keys of the connected test set. Keys the row doesn't carry yet
+     *  are appended to `unreferencedColumns` with an `undefined` value, so a
+     *  row that joined the test set locally (a kept draft, a row added while
+     *  connected) shows the same empty fields a server row would. Callers
+     *  pre-filter system/chat-transport keys, same as for `testcaseData`. */
+    testsetColumnKeys?: string[]
 }
 
 /**
@@ -57,6 +63,7 @@ export function splitInputsVisibility({
     referencedKeys,
     draftKeys = [],
     testcaseData,
+    testsetColumnKeys = [],
 }: SplitInputsVisibilityArgs): InputsVisibility {
     const refsSet = new Set(referencedKeys)
     const draftSet = new Set(draftKeys)
@@ -70,6 +77,15 @@ export function splitInputsVisibility({
     for (const [name, value] of Object.entries(testcaseData)) {
         if (refsSet.has(name)) continue
         unreferencedColumns.push({name, value})
+    }
+
+    // Test set columns missing from this row render as empty fields after
+    // the row's own columns. Referenced keys already surface in `inputs`
+    // (with `undefined` when absent), so only unreferenced ones land here.
+    for (const name of testsetColumnKeys) {
+        if (refsSet.has(name)) continue
+        if (name in testcaseData) continue
+        unreferencedColumns.push({name, value: undefined})
     }
 
     return {inputs, unreferencedColumns}

--- a/web/packages/agenta-playground/src/state/execution/webWorkerIntegration.ts
+++ b/web/packages/agenta-playground/src/state/execution/webWorkerIntegration.ts
@@ -21,7 +21,7 @@ import {entityIdsAtom, playgroundNodesAtom} from "../atoms/playground"
 import {clearSessionResponsesAtom, messageIdsAtomFamily, messagesByIdAtomFamily} from "../chat"
 import {
     collectDownstreamReferencedColumns,
-    collectTestcaseServerColumns,
+    collectTestsetServerColumns,
     reconcileRowDataForEntity,
 } from "../helpers/entityInputContract"
 
@@ -340,9 +340,12 @@ export const triggerExecutionAtom = atom(
         // inputs. The synced test set's own columns are protected too (#4647):
         // a column the prompt doesn't reference is intentional test set data,
         // not a stale leftover, and deleting it here emptied the "unused
-        // testcase columns" footer on Run.
+        // testcase columns" footer on Run. The protection is test-set-scoped
+        // (union across all server rows), not per-row, so rows that joined
+        // the test set locally — kept drafts, rows added while connected —
+        // keep their filled test set columns too.
         const protectedColumns = collectDownstreamReferencedColumns(get, nodes)
-        for (const column of collectTestcaseServerColumns(get, testcaseRowId)) {
+        for (const column of collectTestsetServerColumns(get)) {
             protectedColumns.add(column)
         }
         const reconciledRow = reconcileRowDataForEntity(get, rootEntityId, rawTestcaseData, {

--- a/web/packages/agenta-playground/src/state/helpers/entityInputContract.ts
+++ b/web/packages/agenta-playground/src/state/helpers/entityInputContract.ts
@@ -244,31 +244,43 @@ export function collectDownstreamReferencedColumns(
 }
 
 /**
- * Collect the columns a synced test set row carries in its SERVER snapshot.
+ * Collect the columns the connected test set carries in its SERVER
+ * snapshots, unioned across ALL of its rows.
  *
  * These are intentional test set data, not stale leftovers, so the strict
  * row clean must keep them even when the primary app's prompt doesn't
  * reference them (they render under the "unused testcase columns" footer,
- * which would otherwise empty on Run — #4647). Keys a previous primary wrote
- * to the row locally (the #4525 stale-key case) are absent from the server
- * snapshot, so they still get cleaned. Local/unsaved rows have no server
- * snapshot and get no protection.
+ * which would otherwise empty on Run — #4647). The union is test-set-scoped
+ * rather than per-row on purpose: a row that joined the test set locally —
+ * a draft kept through "Keep and load", or a row added while connected —
+ * has no server snapshot of its own, yet the test set's columns are just as
+ * intentional for it. Per-row protection silently excluded those rows, so a
+ * value filled into e.g. `expected_output` was wiped by the pre-run clean.
+ *
+ * The #4525 guarantee is preserved: keys a previous primary wrote to a row
+ * locally exist only in local row data, never in any server snapshot, so
+ * they still get cleaned. In local mode `testcaseMolecule.ids` is empty by
+ * invariant (server ids only exist while connected), so no protection
+ * applies there.
  *
  * `CHAT_TRANSPORT_KEYS` are excluded even when the test set stores them: a
  * chat-formatted test set connected to a completion app must still get the
  * chat-transport strip, and chat apps keep `messages` through `allowedKeys`
  * without needing protection.
  */
-export function collectTestcaseServerColumns(
-    get: Getter,
-    testcaseRowId: string | null | undefined,
-): Set<string> {
-    if (!testcaseRowId) return new Set()
-    const server = get(testcaseMolecule.selectors.serverData(testcaseRowId)) as {
-        data?: Record<string, unknown> | null
-    } | null
-    if (!server?.data || typeof server.data !== "object") return new Set()
-    const columns = new Set(Object.keys(server.data).filter((key) => !isSystemField(key)))
+export function collectTestsetServerColumns(get: Getter): Set<string> {
+    const ids = get(testcaseMolecule.ids) as string[] | null | undefined
+    const columns = new Set<string>()
+    if (!Array.isArray(ids)) return columns
+    for (const id of ids) {
+        const server = get(testcaseMolecule.selectors.serverData(id)) as {
+            data?: Record<string, unknown> | null
+        } | null
+        if (!server?.data || typeof server.data !== "object") continue
+        for (const key of Object.keys(server.data)) {
+            if (!isSystemField(key)) columns.add(key)
+        }
+    }
     for (const key of CHAT_TRANSPORT_KEYS) {
         columns.delete(key)
     }

--- a/web/packages/agenta-playground/tests/unit/entityInputContract.test.ts
+++ b/web/packages/agenta-playground/tests/unit/entityInputContract.test.ts
@@ -7,10 +7,14 @@
  * protected-column collector looked only at `<input>_key` settings. The
  * evaluator then ran without `guidelines`.
  *
- * `collectTestcaseServerColumns` regression (#4647): the strict row clean
+ * `collectTestsetServerColumns` regression (#4647): the strict row clean
  * deleted a synced test set's columns the prompt didn't reference, emptying
- * the "unused testcase columns" footer on Run. The server snapshot's columns
- * are intentional data and must survive the clean.
+ * the "unused testcase columns" footer on Run. The server snapshots' columns
+ * are intentional data and must survive the clean. The collection is
+ * test-set-scoped (union across all server rows) so rows that joined the
+ * test set locally — a draft kept through "Keep and load", a row added while
+ * connected — are protected too; per-row protection wiped their filled
+ * test set columns on Run.
  *
  * The atom sources (workflow + testcase molecules) are mocked so the tests
  * stay pure function checks: each selector returns a token the fake getter
@@ -32,7 +36,7 @@ vi.mock("@agenta/entities/workflow", () => ({
 }))
 
 // Keep the real module (other packages in the import graph use
-// `testcaseMolecule.atoms`); only `serverData` returns a token the fake
+// `testcaseMolecule.atoms`); `serverData` and `ids` return tokens the fake
 // getter resolves against fixtures. `isSystemField` stays the real one.
 vi.mock("@agenta/entities/testcase", async (importOriginal) => {
     const actual = await importOriginal<typeof import("@agenta/entities/testcase")>()
@@ -40,6 +44,7 @@ vi.mock("@agenta/entities/testcase", async (importOriginal) => {
         ...actual,
         testcaseMolecule: {
             ...actual.testcaseMolecule,
+            ids: {__testcaseIds: "ids"},
             selectors: {
                 ...actual.testcaseMolecule.selectors,
                 serverData: (rowId: string) => ({__serverDataFor: rowId}),
@@ -50,7 +55,7 @@ vi.mock("@agenta/entities/testcase", async (importOriginal) => {
 
 import {
     collectDownstreamReferencedColumns,
-    collectTestcaseServerColumns,
+    collectTestsetServerColumns,
     reconcileRowDataForEntity,
 } from "../../src/state/helpers/entityInputContract"
 
@@ -60,6 +65,8 @@ interface TestNode {
 }
 
 interface GetterFixtures {
+    /** Connected test set's server row ids — resolved for `testcaseMolecule.ids`. */
+    testcaseIds?: string[]
     serverDataByRow?: Record<string, {data?: Record<string, unknown> | null} | null>
     entityById?: Record<string, unknown>
     modeById?: Record<string, "chat" | "completion">
@@ -75,6 +82,7 @@ function makeGet(
         const t = token as Record<string, string | undefined> | null
         if (!t) return null
         if (t.__configFor) return configByEntity[t.__configFor] ?? null
+        if (t.__testcaseIds) return fixtures.testcaseIds ?? []
         if (t.__serverDataFor) return fixtures.serverDataByRow?.[t.__serverDataFor] ?? null
         if (t.__dataFor) return fixtures.entityById?.[t.__dataFor] ?? null
         if (t.__modeFor) return fixtures.modeById?.[t.__modeFor]
@@ -210,11 +218,12 @@ describe("collectDownstreamReferencedColumns", () => {
     })
 })
 
-describe("collectTestcaseServerColumns", () => {
+describe("collectTestsetServerColumns", () => {
     it("returns the connected test set's non-system columns", () => {
         const get = makeGet(
             {},
             {
+                testcaseIds: ["tc1"],
                 serverDataByRow: {
                     tc1: {
                         data: {
@@ -229,38 +238,61 @@ describe("collectTestcaseServerColumns", () => {
             },
         )
 
-        const columns = collectTestcaseServerColumns(get, "tc1")
+        const columns = collectTestsetServerColumns(get)
 
         expect([...columns].sort()).toEqual(["capital", "country"])
+    })
+
+    it("unions columns across all server rows of the test set", () => {
+        const get = makeGet(
+            {},
+            {
+                testcaseIds: ["tc1", "tc2"],
+                serverDataByRow: {
+                    tc1: {data: {country: "France"}},
+                    tc2: {data: {country: "Spain", expected_output: "Madrid"}},
+                },
+            },
+        )
+
+        const columns = collectTestsetServerColumns(get)
+
+        expect([...columns].sort()).toEqual(["country", "expected_output"])
     })
 
     it("excludes chat transport keys so the chat-to-completion strip is preserved", () => {
         const get = makeGet(
             {},
             {
+                testcaseIds: ["tc1"],
                 serverDataByRow: {
                     tc1: {data: {messages: [{role: "user", content: "hi"}], country: "France"}},
                 },
             },
         )
 
-        const columns = collectTestcaseServerColumns(get, "tc1")
+        const columns = collectTestsetServerColumns(get)
 
         expect(columns.has("messages")).toBe(false)
         expect(columns.has("country")).toBe(true)
     })
 
-    it("returns an empty set when the row has no server data (local row)", () => {
-        const get = makeGet({}, {serverDataByRow: {tc1: null}})
+    it("returns an empty set in local mode (no server ids)", () => {
+        const get = makeGet({}, {testcaseIds: []})
 
-        expect(collectTestcaseServerColumns(get, "tc1").size).toBe(0)
+        expect(collectTestsetServerColumns(get).size).toBe(0)
     })
 
-    it("returns an empty set for a missing row id", () => {
-        const get = makeGet({})
+    it("skips rows whose server snapshot is missing", () => {
+        const get = makeGet(
+            {},
+            {
+                testcaseIds: ["tc1", "tc2"],
+                serverDataByRow: {tc1: null, tc2: {data: {country: "Spain"}}},
+            },
+        )
 
-        expect(collectTestcaseServerColumns(get, undefined).size).toBe(0)
-        expect(collectTestcaseServerColumns(get, null).size).toBe(0)
+        expect([...collectTestsetServerColumns(get)]).toEqual(["country"])
     })
 })
 
@@ -276,10 +308,11 @@ describe("reconcileRowDataForEntity with protected server columns", () => {
             {},
             {
                 ...completionAppFixtures,
+                testcaseIds: ["tc1"],
                 serverDataByRow: {tc1: {data: {country: "France", capital: "Paris"}}},
             },
         )
-        const serverColumns = collectTestcaseServerColumns(get, "tc1")
+        const serverColumns = collectTestsetServerColumns(get)
 
         const result = reconcileRowDataForEntity(
             get,
@@ -288,7 +321,7 @@ describe("reconcileRowDataForEntity with protected server columns", () => {
                 country: "France",
                 capital: "Paris",
                 // Stale local key from a previously selected chat app — not in
-                // the server snapshot, so it must still be cleaned (#4525).
+                // any server snapshot, so it must still be cleaned (#4525).
                 messages: [{role: "user", content: "hi"}],
             },
             {protectedKeys: serverColumns},
@@ -299,9 +332,35 @@ describe("reconcileRowDataForEntity with protected server columns", () => {
         expect(result.data).toEqual({country: "France", capital: "Paris"})
     })
 
-    it("drops unreferenced columns when the row has no server snapshot", () => {
-        const get = makeGet({}, completionAppFixtures)
-        const serverColumns = collectTestcaseServerColumns(get, "local-1")
+    it("keeps a test set column filled on a row that joined the test set locally", () => {
+        // A draft kept through "Keep and load" has no server snapshot of its
+        // own, but the test set's columns (here `capital`, carried by tc1's
+        // snapshot) are intentional data for it too — the clean must not wipe
+        // the value the user just filled.
+        const get = makeGet(
+            {},
+            {
+                ...completionAppFixtures,
+                testcaseIds: ["tc1"],
+                serverDataByRow: {tc1: {data: {country: "France", capital: "Paris"}}},
+            },
+        )
+        const serverColumns = collectTestsetServerColumns(get)
+
+        const result = reconcileRowDataForEntity(
+            get,
+            "app",
+            {country: "Spain", capital: "Madrid"},
+            {protectedKeys: serverColumns},
+        )
+
+        expect(result.dropped).toEqual([])
+        expect(result.data).toEqual({country: "Spain", capital: "Madrid"})
+    })
+
+    it("drops unreferenced columns in local mode (no connected test set)", () => {
+        const get = makeGet({}, {...completionAppFixtures, testcaseIds: []})
+        const serverColumns = collectTestsetServerColumns(get)
 
         const result = reconcileRowDataForEntity(
             get,

--- a/web/packages/agenta-playground/tests/unit/visibility.test.ts
+++ b/web/packages/agenta-playground/tests/unit/visibility.test.ts
@@ -224,4 +224,41 @@ describe("splitInputsVisibility", () => {
             ).toEqual([{name: "expected", value: "world"}])
         })
     })
+
+    describe("test set columns missing from the row", () => {
+        it("appends missing test set columns as empty fields after the row's own", () => {
+            // A draft row kept through "Keep and load" carries only its own
+            // keys; the test set's extra columns must still render so the
+            // user can fill them in the grid, not just the drawer.
+            const {unreferencedColumns} = splitInputsVisibility({
+                referencedKeys: ["prompt"],
+                testcaseData: {prompt: "hello", notes: "draft"},
+                testsetColumnKeys: ["expected_output", "context"],
+            })
+            expect(unreferencedColumns).toEqual([
+                {name: "notes", value: "draft"},
+                {name: "expected_output", value: undefined},
+                {name: "context", value: undefined},
+            ])
+        })
+
+        it("does not duplicate columns the row already carries", () => {
+            const {unreferencedColumns} = splitInputsVisibility({
+                referencedKeys: [],
+                testcaseData: {expected_output: "42"},
+                testsetColumnKeys: ["expected_output"],
+            })
+            expect(unreferencedColumns).toEqual([{name: "expected_output", value: "42"}])
+        })
+
+        it("leaves referenced test set columns to the inputs cards", () => {
+            const {inputs, unreferencedColumns} = splitInputsVisibility({
+                referencedKeys: ["country"],
+                testcaseData: {},
+                testsetColumnKeys: ["country", "expected_output"],
+            })
+            expect(inputs).toEqual([{name: "country", value: undefined}])
+            expect(unreferencedColumns).toEqual([{name: "expected_output", value: undefined}])
+        })
+    })
 })


### PR DESCRIPTION
## Context

In the playground, a row that joins a connected test set *locally* carries only the prompt's own columns, not the test set's extra columns (like `expected_output`). You hit this two ways: keep a draft test case through "Keep and load" when connecting a test set, or click "Test case" to add a row while already connected. Two bugs followed. The grid hid the extra columns while the test case drawer showed them, and filling one then clicking Run dropped the value (gone from the request, and gone from the drawer after the run).

Root cause: the #4647 protection that keeps a test set's columns through the pre-run strict clean (#4525) was scoped per row, reading each row's own server snapshot. A locally-joined row has no server snapshot, so the clean wiped its test set columns at run-start, and the grid only derived columns from the row's own data.

## Changes

Scope the protection to the test set, not the row. `collectTestcaseServerColumns(get, rowId)` becomes `collectTestsetServerColumns(get)`, which unions the server-snapshot columns across every connected row. A locally-joined row is now covered by the same set as every other row. The #4525 cleanup still works: stale keys from a previously selected app live only in local row data, never in a server snapshot, and chat transport keys are still stripped.

The grid's visibility split now also merges the test set's column registry in connected mode, mirroring what the drawer already did. Locally-joined rows render the extra columns as empty editable fields.

The app request is unchanged. It still sends only the prompt's declared inputs. The extra columns are test set reference data, so they ride along on the testcase row, not in the LLM request.

```
Before (locally-joined row): grid shows only `cv`; Run wipes any filled extra column.
After  (locally-joined row): grid shows `cv` + the test set's extra columns; filled values survive Run.
```

## Tests

- Updated and added unit tests. `entityInputContract.test.ts`: union across rows, a locally-joined row keeps a filled column through the clean, local mode still drops unreferenced keys. `visibility.test.ts`: missing test set columns appended as empty fields, no duplication, referenced keys stay in the input cards. Full `@agenta/playground` suite passes (94 tests).
- Verified on the live dev stack. A completion app connected to a test set with 3 extra columns: a locally-added row shows all 3, a typed value survives a real Run (HTTP 200), and the invoke body still carries only the declared input.

## What to QA

Completion prompt:

- Open a completion playground whose prompt references fewer fields than a test set has. Type a value in the test case, connect that test set, and choose "Keep and load". The kept row's grid shows the test set's extra columns (collapsed under "N unused testcase columns"), same as rows loaded from the server.
- While connected, click "Test case" to add a row. It shows the same extra columns.
- Fill one extra column on that row and click Run. After the run finishes the value is still there. Open the drawer to confirm.
- Regression: the app request still sends only the prompt's variables. The extra columns should not appear in the invoke payload, and rows loaded straight from the server should behave exactly as before.

Chat prompt (this change touches the `messages` / `outputs` strip and the column protection, so chat is the main regression surface):

- Open a chat playground and connect a chat-formatted test set (one that stores a `messages` conversation). The conversation loads into the chat thread, and `messages` does NOT show up as an "unused testcase column" in the footer. A leaked `messages` column is the regression to watch.
- If the chat test set also has reference columns (for example `ground_truth` or `expected_output`), those should show under "unused testcase columns" and survive a Run. `messages` should still not show.
- Run the conversation. The messages persist through the run (the thread is not wiped), and the request carries the conversation, not the reference columns.
- Cross-mode: connect a chat-formatted test set to a completion app. `messages` should not be sent in the request and should not stick as a column on the row. Then connect a plain completion test set to a chat app and confirm it still runs normally.
