### PR TITLE
feat(sdk): add display name params to AppManager and VariantManager

### DIFF
--- a/sdks/python/agenta/sdk/managers/apps.py
+++ b/sdks/python/agenta/sdk/managers/apps.py
@@ -22,10 +22,13 @@ def _build_simple_application_payload(
     app_slug: str,
     app_type: Optional[AppType],
     app_id: Optional[str] = None,
+    app_name: Optional[str] = None,
 ) -> dict:
     payload = {
         "slug": app_slug,
-        "name": app_slug,
+        # Use the explicit display name when provided; fall back to the slug
+        # so that SDK-created apps get a readable label in the UI (fixes #4663).
+        "name": app_name or app_slug,
     }
 
     if app_id:
@@ -52,6 +55,7 @@ class AppManager:
         cls,
         *,
         app_slug: str,
+        app_name: Optional[str] = None,
         template_key: Optional[AppType] = None,
         app_type: Optional[AppType] = DEFAULT_APP_TYPE,
     ) -> ReferencesResponse:
@@ -60,6 +64,7 @@ class AppManager:
             endpoint="/simple/applications/",
             json=_build_simple_application_payload(
                 app_slug=app_slug,
+                app_name=app_name,
                 app_type=template_key or app_type,
             ),
         )
@@ -73,6 +78,7 @@ class AppManager:
         cls,
         *,
         app_slug: str,
+        app_name: Optional[str] = None,
         template_key: Optional[AppType] = None,
         app_type: Optional[AppType] = DEFAULT_APP_TYPE,
     ) -> ReferencesResponse:
@@ -81,6 +87,7 @@ class AppManager:
             endpoint="/simple/applications/",
             json=_build_simple_application_payload(
                 app_slug=app_slug,
+                app_name=app_name,
                 app_type=template_key or app_type,
             ),
         )
@@ -120,12 +127,19 @@ class AppManager:
 
     @classmethod
     @handle_exceptions()
-    def update(cls, *, app_id: str, app_slug: str) -> ReferencesResponse:
+    def update(
+        cls,
+        *,
+        app_id: str,
+        app_slug: str,
+        app_name: Optional[str] = None,
+    ) -> ReferencesResponse:
         response = authed_api()(
             method="PUT",
             endpoint=f"/simple/applications/{app_id}",
             json=_build_simple_application_payload(
                 app_slug=app_slug,
+                app_name=app_name,
                 app_type=None,
                 app_id=app_id,
             ),
@@ -136,12 +150,19 @@ class AppManager:
 
     @classmethod
     @handle_exceptions()
-    async def aupdate(cls, *, app_id: str, app_slug: str) -> ReferencesResponse:
+    async def aupdate(
+        cls,
+        *,
+        app_id: str,
+        app_slug: str,
+        app_name: Optional[str] = None,
+    ) -> ReferencesResponse:
         response = await authed_async_api()(
             method="PUT",
             endpoint=f"/simple/applications/{app_id}",
             json=_build_simple_application_payload(
                 app_slug=app_slug,
+                app_name=app_name,
                 app_type=None,
                 app_id=app_id,
             ),

--- a/sdks/python/agenta/sdk/managers/shared.py
+++ b/sdks/python/agenta/sdk/managers/shared.py
@@ -748,21 +748,26 @@ class SharedManager:
         cls,
         *,
         variant_slug: str,
+        variant_name: Optional[str] = None,
         #
         app_id: Optional[str] = None,
         app_slug: Optional[str] = None,
     ):
         application = cls._query_simple_application(app_id=app_id, app_slug=app_slug)
 
+        variant_payload: Dict[str, Any] = {
+            "application_id": application.get("id"),
+            "slug": variant_slug,
+        }
+        # Include a human-readable display name when the caller provides one
+        # so that SDK-created variants are not shown as NULL in the UI (#4663).
+        if variant_name is not None:
+            variant_payload["name"] = variant_name
+
         response = authed_api()(
             method="POST",
             endpoint="/applications/variants/",
-            json={
-                "application_variant": {
-                    "application_id": application.get("id"),
-                    "slug": variant_slug,
-                }
-            },
+            json={"application_variant": variant_payload},
         )
         _raise_for_status(response)
         variant = response.json().get("application_variant")
@@ -777,6 +782,7 @@ class SharedManager:
         cls,
         *,
         variant_slug: str,
+        variant_name: Optional[str] = None,
         #
         app_id: Optional[str] = None,
         app_slug: Optional[str] = None,
@@ -786,15 +792,17 @@ class SharedManager:
             app_slug=app_slug,
         )
 
+        variant_payload: Dict[str, Any] = {
+            "application_id": application.get("id"),
+            "slug": variant_slug,
+        }
+        if variant_name is not None:
+            variant_payload["name"] = variant_name
+
         response = await authed_async_api()(
             method="POST",
             endpoint="/applications/variants/",
-            json={
-                "application_variant": {
-                    "application_id": application.get("id"),
-                    "slug": variant_slug,
-                }
-            },
+            json={"application_variant": variant_payload},
         )
         _raise_for_status(response)
         variant = response.json().get("application_variant")
@@ -1083,6 +1091,7 @@ class SharedManager:
         *,
         parameters: dict,
         variant_slug: str,
+        revision_name: Optional[str] = None,
         #
         app_id: Optional[str] = None,
         app_slug: Optional[str] = None,
@@ -1093,19 +1102,23 @@ class SharedManager:
             variant_slug=variant_slug,
         )
 
+        revision_payload: Dict[str, Any] = {
+            "application_id": variant.get("application_id")
+            or variant.get("artifact_id"),
+            "application_variant_id": variant.get("application_variant_id")
+            or variant.get("id"),
+            "slug": uuid4().hex[:12],
+            "data": {"parameters": parameters},
+        }
+        # Attach a human-readable revision name when the caller supplies one
+        # so that committed revisions don't surface as NULL in the UI (#4663).
+        if revision_name is not None:
+            revision_payload["name"] = revision_name
+
         response = authed_api()(
             method="POST",
             endpoint="/applications/revisions/commit",
-            json={
-                "application_revision": {
-                    "application_id": variant.get("application_id")
-                    or variant.get("artifact_id"),
-                    "application_variant_id": variant.get("application_variant_id")
-                    or variant.get("id"),
-                    "slug": uuid4().hex[:12],
-                    "data": {"parameters": parameters},
-                }
-            },
+            json={"application_revision": revision_payload},
         )
         _raise_for_status(response)
 
@@ -1128,6 +1141,7 @@ class SharedManager:
         *,
         parameters: dict,
         variant_slug: str,
+        revision_name: Optional[str] = None,
         #
         app_id: Optional[str] = None,
         app_slug: Optional[str] = None,
@@ -1138,19 +1152,21 @@ class SharedManager:
             variant_slug=variant_slug,
         )
 
+        revision_payload: Dict[str, Any] = {
+            "application_id": variant.get("application_id")
+            or variant.get("artifact_id"),
+            "application_variant_id": variant.get("application_variant_id")
+            or variant.get("id"),
+            "slug": uuid4().hex[:12],
+            "data": {"parameters": parameters},
+        }
+        if revision_name is not None:
+            revision_payload["name"] = revision_name
+
         response = await authed_async_api()(
             method="POST",
             endpoint="/applications/revisions/commit",
-            json={
-                "application_revision": {
-                    "application_id": variant.get("application_id")
-                    or variant.get("artifact_id"),
-                    "application_variant_id": variant.get("application_variant_id")
-                    or variant.get("id"),
-                    "slug": uuid4().hex[:12],
-                    "data": {"parameters": parameters},
-                }
-            },
+            json={"application_revision": revision_payload},
         )
         _raise_for_status(response)
 

--- a/sdks/python/agenta/sdk/managers/variant.py
+++ b/sdks/python/agenta/sdk/managers/variant.py
@@ -10,6 +10,8 @@ class VariantManager(SharedManager):
         *,
         parameters: dict,
         variant_slug: str,
+        variant_name: Optional[str] = None,
+        revision_name: Optional[str] = None,
         #
         app_id: Optional[str] = None,
         app_slug: Optional[str] = None,
@@ -18,6 +20,7 @@ class VariantManager(SharedManager):
             app_id=app_id,
             app_slug=app_slug,
             variant_slug=variant_slug,
+            variant_name=variant_name,
         )
 
         if variant:
@@ -26,6 +29,7 @@ class VariantManager(SharedManager):
                 app_id=app_id,
                 app_slug=app_slug,
                 variant_slug=variant_slug,
+                revision_name=revision_name,
             )
 
         return variant
@@ -36,6 +40,8 @@ class VariantManager(SharedManager):
         *,
         parameters: dict,
         variant_slug: str,
+        variant_name: Optional[str] = None,
+        revision_name: Optional[str] = None,
         #
         app_id: Optional[str] = None,
         app_slug: Optional[str] = None,
@@ -44,6 +50,7 @@ class VariantManager(SharedManager):
             app_id=app_id,
             app_slug=app_slug,
             variant_slug=variant_slug,
+            variant_name=variant_name,
         )
         if variant:
             variant = await SharedManager.acommit(
@@ -51,6 +58,7 @@ class VariantManager(SharedManager):
                 app_id=app_id,
                 app_slug=app_slug,
                 variant_slug=variant_slug,
+                revision_name=revision_name,
             )
 
         return variant
@@ -61,6 +69,7 @@ class VariantManager(SharedManager):
         *,
         parameters: dict,
         variant_slug: str,
+        revision_name: Optional[str] = None,
         #
         app_id: Optional[str] = None,
         app_slug: Optional[str] = None,
@@ -70,6 +79,7 @@ class VariantManager(SharedManager):
             app_id=app_id,
             app_slug=app_slug,
             variant_slug=variant_slug,
+            revision_name=revision_name,
         )
         return variant
 
@@ -79,6 +89,7 @@ class VariantManager(SharedManager):
         *,
         parameters: dict,
         variant_slug: str,
+        revision_name: Optional[str] = None,
         #
         app_id: Optional[str] = None,
         app_slug: Optional[str] = None,
@@ -88,6 +99,7 @@ class VariantManager(SharedManager):
             app_id=app_id,
             app_slug=app_slug,
             variant_slug=variant_slug,
+            revision_name=revision_name,
         )
         return variant
 


### PR DESCRIPTION
## Summary

Closes #4663

SDK-created apps always had their display name forced to the slug (e.g. `cv-screening` instead of `CV Screening`), and SDK-created variants / revisions always got `name: NULL`, so the UI shows `--` or hex labels instead of real names.

This PR adds optional `app_name`, `variant_name`, and `revision_name` parameters to the relevant SDK managers so callers can pass a human-readable label at creation time.

---

## Changes

### `sdks/python/agenta/sdk/managers/apps.py`
- `_build_simple_application_payload`: added `app_name: Optional[str] = None`; uses `app_name or app_slug` so a readable label is always sent.
- `AppManager.create` / `acreate`: new optional `app_name` parameter.
- `AppManager.update` / `aupdate`: new optional `app_name` parameter.

### `sdks/python/agenta/sdk/managers/shared.py`
- `SharedManager.add` / `aadd`: new optional `variant_name`; conditionally included in the variant creation payload.
- `SharedManager.commit` / `acommit`: new optional `revision_name`; conditionally included in the revision commit payload.

### `sdks/python/agenta/sdk/managers/variant.py`
- `VariantManager.create` / `acreate`: added `variant_name` and `revision_name`; threaded through to `SharedManager`.
- `VariantManager.commit` / `acommit`: added `revision_name`; threaded through to `SharedManager.commit`.

---

## Backward Compatibility

All new parameters default to `None`. No existing call sites are affected - the SDK behaves identically unless the caller explicitly passes a name.

## Usage Example

`python
# App with a readable display name
app = AppManager.create(app_slug="cv-screening", app_name="CV Screening")

# Variant with a readable display name
variant = VariantManager.create(
    app_slug="cv-screening",
    variant_slug="default",
    variant_name="Default Variant",
    revision_name="Initial configuration",
    parameters={...},
)
`

## Testing

- [x] Python `ast.parse` validates all three modified files with zero syntax errors.
- [ ] Manual end-to-end: create app + variant via SDK, verify UI shows the display name instead of `--`.