### PR TITLE
[feat] Add triggers catalog browse and connections UI

### DIFF
--- a/web/oss/src/components/Sidebar/SettingsSidebar.tsx
+++ b/web/oss/src/components/Sidebar/SettingsSidebar.tsx
@@ -5,6 +5,7 @@ import {
     Buildings,
     ClockCounterClockwise,
     Key,
+    Lightning,
     Link,
     Receipt,
     Sparkle,
@@ -46,6 +47,7 @@ const SettingsSidebar: FC<SettingsSidebarProps> = ({lastPath}) => {
     const canShowUsageBilling = isEE() && isOwner
     const billingEnabled = isBillingEnabled()
     const canShowTools = isToolsEnabled()
+    const canShowTriggers = isToolsEnabled()
     // Audit Log is an EE feature. Within EE the tab is gated by `view_events`;
     // the page content is gated separately by the `Flag.AUDIT` entitlement.
     const canShowAuditLog = isEE() && canViewEvents
@@ -57,6 +59,7 @@ const SettingsSidebar: FC<SettingsSidebarProps> = ({lastPath}) => {
             (requestedTab === "organization" && !canShowOrganization) ||
             (requestedTab === "billing" && !canShowUsageBilling) ||
             (requestedTab === "tools" && !canShowTools) ||
+            (requestedTab === "triggers" && !canShowTriggers) ||
             (requestedTab === "apiKeys" && !canViewApiKeys) ||
             (requestedTab === "auditLog" && !canShowAuditLog) ||
             (requestedTab === "account" && !canShowAccount)
@@ -69,6 +72,7 @@ const SettingsSidebar: FC<SettingsSidebarProps> = ({lastPath}) => {
         canShowUsageBilling,
         canShowOrganization,
         canShowTools,
+        canShowTriggers,
         canViewApiKeys,
         canShowAuditLog,
         canShowAccount,
@@ -104,6 +108,15 @@ const SettingsSidebar: FC<SettingsSidebarProps> = ({lastPath}) => {
                           key: "tools",
                           title: "Tools",
                           icon: <Wrench size={16} className="mt-0.5" />,
+                      },
+                  ]
+                : []),
+            ...(canShowTriggers
+                ? [
+                      {
+                          key: "triggers",
+                          title: "Triggers",
+                          icon: <Lightning size={16} className="mt-0.5" />,
                       },
                   ]
                 : []),
@@ -156,6 +169,7 @@ const SettingsSidebar: FC<SettingsSidebarProps> = ({lastPath}) => {
         billingEnabled,
         canShowOrganization,
         canShowTools,
+        canShowTriggers,
         canViewApiKeys,
         canShowAuditLog,
         canShowAccount,

--- a/web/oss/src/components/pages/settings/Triggers/Triggers.tsx
+++ b/web/oss/src/components/pages/settings/Triggers/Triggers.tsx
@@ -1,0 +1,9 @@
+import GatewayTriggersSection from "./components/GatewayTriggersSection"
+
+export default function Triggers() {
+    return (
+        <div className="flex flex-col gap-6">
+            <GatewayTriggersSection />
+        </div>
+    )
+}

--- a/web/oss/src/components/pages/settings/Triggers/components/GatewayTriggersSection.tsx
+++ b/web/oss/src/components/pages/settings/Triggers/components/GatewayTriggersSection.tsx
@@ -1,0 +1,134 @@
+import {useCallback, useMemo} from "react"
+
+import {
+    eventsDrawerAtom,
+    useTriggerConnectionsQuery,
+    type TriggerConnection,
+} from "@agenta/entities/gatewayTrigger"
+import {ConnectionStatusBadge} from "@agenta/entity-ui/gatewayTool"
+import {TriggerEventsDrawer} from "@agenta/entity-ui/gatewayTrigger"
+import {Lightning} from "@phosphor-icons/react"
+import {Button, Empty, Table, Tag, Tooltip, Typography} from "antd"
+import type {ColumnsType} from "antd/es/table"
+import {useSetAtom} from "jotai"
+
+import {formatDay} from "@/oss/lib/helpers/dateTimeHelper"
+
+const DEFAULT_PROVIDER = "composio"
+
+export default function GatewayTriggersSection() {
+    const {connections, isLoading} = useTriggerConnectionsQuery()
+    const setEventsDrawer = useSetAtom(eventsDrawerAtom)
+
+    const openEvents = useCallback(
+        (record: TriggerConnection) => {
+            setEventsDrawer({
+                providerKey: record.provider_key ?? DEFAULT_PROVIDER,
+                integrationKey: record.integration_key,
+                integrationName: record.name ?? record.slug ?? record.integration_key,
+                connectionId: record.id ?? undefined,
+            })
+        },
+        [setEventsDrawer],
+    )
+
+    const columns: ColumnsType<TriggerConnection> = useMemo(
+        () => [
+            {
+                title: "Integration",
+                key: "integration",
+                onHeaderCell: () => ({style: {minWidth: 160}}),
+                render: (_, record) => (
+                    <Tag
+                        bordered={false}
+                        color="default"
+                        className="bg-[var(--ag-c-0517290F)] px-2 py-[1px]"
+                    >
+                        {record.integration_key}
+                    </Tag>
+                ),
+            },
+            {
+                title: "Name",
+                key: "name",
+                onHeaderCell: () => ({style: {minWidth: 160}}),
+                render: (_, record) => (
+                    <Typography.Text>{record.name || record.slug}</Typography.Text>
+                ),
+            },
+            {
+                title: "Status",
+                key: "status",
+                onHeaderCell: () => ({style: {minWidth: 120}}),
+                render: (_, record) => <ConnectionStatusBadge connection={record} />,
+            },
+            {
+                title: "Created at",
+                dataIndex: "created_at",
+                key: "created_at",
+                onHeaderCell: () => ({style: {minWidth: 160}}),
+                render: (value: string) =>
+                    value ? formatDay({date: value, outputFormat: "YYYY-MM-DD HH:mm"}) : "-",
+            },
+            {
+                title: "",
+                key: "actions",
+                width: 120,
+                fixed: "right",
+                align: "right",
+                render: (_, record) => (
+                    <Button
+                        size="small"
+                        icon={<Lightning size={14} />}
+                        onClick={(e) => {
+                            e.stopPropagation()
+                            openEvents(record)
+                        }}
+                    >
+                        Events
+                    </Button>
+                ),
+            },
+        ],
+        [openEvents],
+    )
+
+    return (
+        <>
+            <section className="flex flex-col gap-2">
+                <div className="flex items-center gap-2">
+                    <Typography.Text className="text-sm font-medium">
+                        Trigger integrations
+                    </Typography.Text>
+                    <Tooltip title="Browse the events of a connected integration">
+                        <Lightning size={14} />
+                    </Tooltip>
+                </div>
+
+                <Typography.Text type="secondary" className="text-xs">
+                    Triggers reuse the same connections as tools. Connect an integration under
+                    Tools, then browse its events here.
+                </Typography.Text>
+
+                <Table<TriggerConnection>
+                    className="ph-no-capture"
+                    columns={columns}
+                    dataSource={connections}
+                    rowKey={(record) => record.id ?? record.slug ?? record.integration_key}
+                    bordered
+                    pagination={false}
+                    loading={isLoading}
+                    locale={{
+                        emptyText: <Empty description="No connected integrations yet" />,
+                    }}
+                    onRow={(record) => ({
+                        onClick: () => openEvents(record),
+                        className: "cursor-pointer",
+                    })}
+                />
+            </section>
+
+            <TriggerEventsDrawer />
+        </>
+    )
+}

--- a/web/oss/src/pages/w/[workspace_id]/p/[project_id]/settings/index.tsx
+++ b/web/oss/src/pages/w/[workspace_id]/p/[project_id]/settings/index.tsx
@@ -39,6 +39,10 @@ const Tools = dynamic(() => import("@/oss/components/pages/settings/Tools/Tools"
     ssr: false,
 })
 
+const Triggers = dynamic(() => import("@/oss/components/pages/settings/Triggers/Triggers"), {
+    ssr: false,
+})
+
 const Organization = dynamic(() => import("@/oss/components/pages/settings/Organization"), {
     ssr: false,
 })
@@ -71,12 +75,14 @@ export const Settings: React.FC<SettingsProps> = ({AuditLogComponent}) => {
     const canShowBilling = isEE() && isOwner
     const billingEnabled = isBillingEnabled()
     const canShowTools = isToolsEnabled()
+    const canShowTriggers = isToolsEnabled()
     const canShowAuditLog = isEE() && canViewEvents
     const canShowAccount = isEE()
     const resolvedTab =
         (tab === "organization" && !canShowOrganization) ||
         (tab === "billing" && !canShowBilling) ||
         (tab === "tools" && !canShowTools) ||
+        (tab === "triggers" && !canShowTriggers) ||
         (tab === "apiKeys" && !canViewApiKeys) ||
         (tab === "auditLog" && !canShowAuditLog) ||
         (tab === "account" && !canShowAccount)
@@ -124,6 +130,8 @@ export const Settings: React.FC<SettingsProps> = ({AuditLogComponent}) => {
                             return "Providers & Models"
                         case "tools":
                             return "Tools"
+                        case "triggers":
+                            return "Triggers"
                         case "apiKeys":
                             return "API Keys"
                         case "automations":
@@ -177,6 +185,8 @@ export const Settings: React.FC<SettingsProps> = ({AuditLogComponent}) => {
                 return {content: <Secrets />, title: "Providers & Models"}
             case "tools":
                 return {content: <Tools />, title: "Tools"}
+            case "triggers":
+                return {content: <Triggers />, title: "Triggers"}
             case "apiKeys":
                 return {content: <APIKeys />, title: "API Keys"}
             case "billing":

--- a/web/packages/agenta-entities/package.json
+++ b/web/packages/agenta-entities/package.json
@@ -50,6 +50,7 @@
         "./event/state": "./src/event/state/index.ts",
         "./secret": "./src/secret/index.ts",
         "./gatewayTool": "./src/gatewayTool/index.ts",
+        "./gatewayTrigger": "./src/gatewayTrigger/index.ts",
         "./environment": "./src/environment/index.ts",
         "./simpleQueue": "./src/simpleQueue/index.ts",
         "./simpleQueue/etl": "./src/simpleQueue/etl/index.ts",

--- a/web/packages/agenta-entities/src/gatewayTrigger/api/api.ts
+++ b/web/packages/agenta-entities/src/gatewayTrigger/api/api.ts
@@ -1,0 +1,119 @@
+/**
+ * Gateway-trigger API functions.
+ *
+ * Catalog browse + connection list over the `/triggers/*` endpoints. Each
+ * response is validated against the frozen zod schema at the boundary
+ * (`safeParseWithLogging`), so a backend drift surfaces as a logged parse
+ * failure rather than a downstream crash.
+ *
+ * `/triggers/connections/query` reads the same shared `gateway_connections`
+ * rows as `/tools/connections/query` (WP0); the connection shape is reused
+ * from gatewayTool so the two lists stay byte-compatible (F2).
+ */
+
+import {safeParseWithLogging} from "../../shared"
+import {
+    triggerCatalogEventResponseSchema,
+    triggerCatalogEventsResponseSchema,
+    triggerCatalogProviderResponseSchema,
+    triggerCatalogProvidersResponseSchema,
+    triggerConnectionsResponseSchema,
+    type TriggerCatalogEventResponse,
+    type TriggerCatalogEventsResponse,
+    type TriggerCatalogProviderResponse,
+    type TriggerCatalogProvidersResponse,
+    type TriggerConnectionsResponse,
+} from "../core/types"
+
+import {axios, projectScopedParams, triggersBaseUrl} from "./client"
+
+// --- Catalog browse ---
+
+export const fetchTriggerProviders = async (): Promise<TriggerCatalogProvidersResponse> => {
+    const {data} = await axios.get(`${triggersBaseUrl()}/catalog/providers/`, projectScopedParams())
+    return (
+        safeParseWithLogging(
+            triggerCatalogProvidersResponseSchema,
+            data,
+            "[fetchTriggerProviders]",
+        ) ?? {count: 0, providers: []}
+    )
+}
+
+export const fetchTriggerProvider = async (
+    providerKey: string,
+): Promise<TriggerCatalogProviderResponse> => {
+    const {data} = await axios.get(
+        `${triggersBaseUrl()}/catalog/providers/${providerKey}`,
+        projectScopedParams(),
+    )
+    return (
+        safeParseWithLogging(
+            triggerCatalogProviderResponseSchema,
+            data,
+            "[fetchTriggerProvider]",
+        ) ?? {count: 0, provider: null}
+    )
+}
+
+export const fetchTriggerEvents = async (
+    providerKey: string,
+    integrationKey: string,
+    params?: {query?: string; limit?: number; cursor?: string},
+): Promise<TriggerCatalogEventsResponse> => {
+    const {data} = await axios.get(
+        `${triggersBaseUrl()}/catalog/providers/${providerKey}/integrations/${integrationKey}/events/`,
+        projectScopedParams({
+            query: params?.query,
+            limit: params?.limit,
+            cursor: params?.cursor,
+        }),
+    )
+    return (
+        safeParseWithLogging(triggerCatalogEventsResponseSchema, data, "[fetchTriggerEvents]") ?? {
+            count: 0,
+            total: 0,
+            cursor: null,
+            events: [],
+        }
+    )
+}
+
+export const fetchTriggerEvent = async (
+    providerKey: string,
+    integrationKey: string,
+    eventKey: string,
+): Promise<TriggerCatalogEventResponse> => {
+    const {data} = await axios.get(
+        `${triggersBaseUrl()}/catalog/providers/${providerKey}/integrations/${integrationKey}/events/${eventKey}`,
+        projectScopedParams(),
+    )
+    return (
+        safeParseWithLogging(triggerCatalogEventResponseSchema, data, "[fetchTriggerEvent]") ?? {
+            count: 0,
+            event: null,
+        }
+    )
+}
+
+// --- Connections (shared rows, WP0 view; F2) ---
+
+export const queryTriggerConnections = async (params?: {
+    provider_key?: string
+    integration_key?: string
+}): Promise<TriggerConnectionsResponse> => {
+    const {data} = await axios.post(
+        `${triggersBaseUrl()}/connections/query`,
+        {
+            provider_key: params?.provider_key,
+            integration_key: params?.integration_key,
+        },
+        projectScopedParams(),
+    )
+    const validated = safeParseWithLogging(
+        triggerConnectionsResponseSchema,
+        data,
+        "[queryTriggerConnections]",
+    )
+    return (validated as TriggerConnectionsResponse | null) ?? {count: 0, connections: []}
+}

--- a/web/packages/agenta-entities/src/gatewayTrigger/api/client.ts
+++ b/web/packages/agenta-entities/src/gatewayTrigger/api/client.ts
@@ -1,0 +1,30 @@
+import {axios, getAgentaApiUrl} from "@agenta/shared/api"
+import {projectIdAtom} from "@agenta/shared/state"
+import {getDefaultStore} from "jotai"
+
+/**
+ * HTTP client for the `/triggers/*` API.
+ *
+ * The triggers catalog isn't in the Fern client yet (WP1 hasn't been
+ * regenerated into `@agentaai/api-client`), so we use the shared axios
+ * instance. Once the client gains a `triggers` resource this module collapses
+ * onto `getAgentaSdkClient().triggers` like `gatewayTool/api/client.ts`.
+ */
+export const triggersBaseUrl = () => `${getAgentaApiUrl()}/triggers`
+
+/**
+ * Scope a request to the current project. The shared axios interceptor does
+ * not inject `project_id`, so we mirror `gatewayTool`'s `projectScopedRequest`
+ * and read it from the shared atom.
+ */
+export function projectScopedParams(extra?: Record<string, unknown>) {
+    const projectId = getDefaultStore().get(projectIdAtom)
+    return {
+        params: {
+            ...(projectId ? {project_id: projectId} : {}),
+            ...(extra ?? {}),
+        },
+    }
+}
+
+export {axios}

--- a/web/packages/agenta-entities/src/gatewayTrigger/api/index.ts
+++ b/web/packages/agenta-entities/src/gatewayTrigger/api/index.ts
@@ -1,0 +1,8 @@
+export {
+    fetchTriggerEvent,
+    fetchTriggerEvents,
+    fetchTriggerProvider,
+    fetchTriggerProviders,
+    queryTriggerConnections,
+} from "./api"
+export {triggersBaseUrl, projectScopedParams} from "./client"

--- a/web/packages/agenta-entities/src/gatewayTrigger/core/index.ts
+++ b/web/packages/agenta-entities/src/gatewayTrigger/core/index.ts
@@ -1,0 +1,1 @@
+export * from "./types"

--- a/web/packages/agenta-entities/src/gatewayTrigger/core/types.ts
+++ b/web/packages/agenta-entities/src/gatewayTrigger/core/types.ts
@@ -1,0 +1,131 @@
+/**
+ * Gateway-trigger domain types.
+ *
+ * The triggers catalog API (WP1) is not yet in the Fern-generated client, so
+ * the wire shapes are declared here as zod schemas mirroring the frozen
+ * backend DTOs (`api/oss/src/core/triggers/dtos.py`,
+ * `api/oss/src/apis/fastapi/triggers/models.py`). Validation runs at the API
+ * boundary, exactly as `web/AGENTS.md` prescribes for the Fern path. When the
+ * client is regenerated with a `triggers` resource these aliases swap to
+ * `AgentaApi.*` mechanically.
+ *
+ * Connections are shared rows (WP0): the same `gateway_connections` surface
+ * both `/tools/connections` and `/triggers/connections`. We reuse the
+ * gatewayTool connection type so the two lists are byte-compatible (F2).
+ */
+
+import {z} from "zod"
+
+import type {ToolConnection, ToolConnectionsResponse} from "../../gatewayTool/core/types"
+
+// ---------------------------------------------------------------------------
+// Catalog
+// ---------------------------------------------------------------------------
+
+export const triggerProviderKindSchema = z.enum(["composio"])
+export type TriggerProviderKind = z.infer<typeof triggerProviderKindSchema>
+
+export const triggerCatalogProviderSchema = z
+    .object({
+        key: triggerProviderKindSchema,
+        name: z.string(),
+        description: z.string().nullish(),
+    })
+    .passthrough()
+export type TriggerCatalogProvider = z.infer<typeof triggerCatalogProviderSchema>
+
+export const triggerCatalogEventSchema = z
+    .object({
+        key: z.string(),
+        name: z.string(),
+        description: z.string().nullish(),
+        provider: z.string().nullish(),
+        integration: z.string().nullish(),
+        categories: z.array(z.string()).default([]),
+        logo: z.string().nullish(),
+    })
+    .passthrough()
+export type TriggerCatalogEvent = z.infer<typeof triggerCatalogEventSchema>
+
+export const triggerCatalogEventDetailsSchema = triggerCatalogEventSchema.extend({
+    trigger_config: z.record(z.string(), z.unknown()).nullish(),
+    payload: z.record(z.string(), z.unknown()).nullish(),
+})
+export type TriggerCatalogEventDetails = z.infer<typeof triggerCatalogEventDetailsSchema>
+
+export const triggerCatalogProvidersResponseSchema = z
+    .object({
+        count: z.number().default(0),
+        providers: z.array(triggerCatalogProviderSchema).default([]),
+    })
+    .passthrough()
+export type TriggerCatalogProvidersResponse = z.infer<typeof triggerCatalogProvidersResponseSchema>
+
+export const triggerCatalogProviderResponseSchema = z
+    .object({
+        count: z.number().default(0),
+        provider: triggerCatalogProviderSchema.nullish(),
+    })
+    .passthrough()
+export type TriggerCatalogProviderResponse = z.infer<typeof triggerCatalogProviderResponseSchema>
+
+export const triggerCatalogEventsResponseSchema = z
+    .object({
+        count: z.number().default(0),
+        total: z.number().default(0),
+        cursor: z.string().nullish(),
+        events: z.array(triggerCatalogEventSchema).default([]),
+    })
+    .passthrough()
+export type TriggerCatalogEventsResponse = z.infer<typeof triggerCatalogEventsResponseSchema>
+
+export const triggerCatalogEventResponseSchema = z
+    .object({
+        count: z.number().default(0),
+        event: triggerCatalogEventDetailsSchema.nullish(),
+    })
+    .passthrough()
+export type TriggerCatalogEventResponse = z.infer<typeof triggerCatalogEventResponseSchema>
+
+// ---------------------------------------------------------------------------
+// Connections — shared `gateway_connections` rows (WP0). Same shape as
+// `/tools/connections`; the FE treats both lists as the same rows (F2). The TS
+// type aliases the gatewayTool Fern type so the two lists are byte-compatible;
+// the schema validates the axios boundary (the triggers client isn't Fern yet).
+// ---------------------------------------------------------------------------
+
+const jsonRecordSchema = z.record(z.string(), z.unknown()).nullish()
+
+export const triggerConnectionSchema = z
+    .object({
+        flags: jsonRecordSchema,
+        tags: jsonRecordSchema,
+        meta: jsonRecordSchema,
+        created_at: z.string().nullish(),
+        updated_at: z.string().nullish(),
+        deleted_at: z.string().nullish(),
+        created_by_id: z.string().nullish(),
+        updated_by_id: z.string().nullish(),
+        deleted_by_id: z.string().nullish(),
+        name: z.string().nullish(),
+        description: z.string().nullish(),
+        slug: z.string().nullish(),
+        id: z.string().nullish(),
+        provider_key: z.string(),
+        integration_key: z.string(),
+        data: jsonRecordSchema,
+        status: z.unknown().nullish(),
+    })
+    .passthrough()
+
+export const triggerConnectionsResponseSchema = z
+    .object({
+        count: z.number().default(0),
+        connections: z.array(triggerConnectionSchema).default([]),
+    })
+    .passthrough()
+
+export type TriggerConnection = ToolConnection
+export type TriggerConnectionsResponse = ToolConnectionsResponse
+
+export {isConnectionActive, isConnectionValid} from "../../gatewayTool/core/types"

--- a/web/packages/agenta-entities/src/gatewayTrigger/hooks/index.ts
+++ b/web/packages/agenta-entities/src/gatewayTrigger/hooks/index.ts
@@ -1,0 +1,8 @@
+export {catalogEventsInfiniteFamily, eventsSearchAtom, useCatalogEvents} from "./useCatalogEvents"
+export {triggerEventDetailQueryFamily, useTriggerEvent} from "./useTriggerEvent"
+export {
+    triggerConnectionsQueryAtom,
+    triggerIntegrationConnectionsAtomFamily,
+    useTriggerConnectionsQuery,
+    useTriggerIntegrationConnections,
+} from "./useTriggerConnections"

--- a/web/packages/agenta-entities/src/gatewayTrigger/hooks/useCatalogEvents.ts
+++ b/web/packages/agenta-entities/src/gatewayTrigger/hooks/useCatalogEvents.ts
@@ -1,0 +1,84 @@
+import {useCallback, useEffect, useMemo, useRef, useState} from "react"
+
+import {atom, useAtomValue, useSetAtom} from "jotai"
+import {atomFamily} from "jotai/utils"
+import {atomWithInfiniteQuery} from "jotai-tanstack-query"
+
+import {fetchTriggerEvents} from "../api"
+import type {TriggerCatalogEvent, TriggerCatalogEventsResponse} from "../core/types"
+
+const DEFAULT_PROVIDER = "composio"
+const CHUNK_SIZE = 10
+const PREFETCH = 2
+
+// Server-side search atom — set by the drawer, drives the query
+export const eventsSearchAtom = atom("")
+
+export const catalogEventsInfiniteFamily = atomFamily((integrationKey: string) =>
+    atomWithInfiniteQuery<TriggerCatalogEventsResponse>((get) => {
+        const search = get(eventsSearchAtom)
+
+        return {
+            queryKey: ["triggers", "catalog", "events", DEFAULT_PROVIDER, integrationKey, search],
+            queryFn: async ({pageParam}) =>
+                fetchTriggerEvents(DEFAULT_PROVIDER, integrationKey, {
+                    query: search || undefined,
+                    limit: CHUNK_SIZE,
+                    cursor: (pageParam as string) || undefined,
+                }),
+            initialPageParam: "",
+            getNextPageParam: (lastPage) => lastPage.cursor ?? undefined,
+            staleTime: 5 * 60_000,
+            refetchOnWindowFocus: false,
+            enabled: !!integrationKey,
+        }
+    }),
+)
+
+export const useCatalogEvents = (integrationKey: string) => {
+    const query = useAtomValue(catalogEventsInfiniteFamily(integrationKey))
+    const setSearch = useSetAtom(eventsSearchAtom)
+
+    const events = useMemo<TriggerCatalogEvent[]>(() => {
+        const pages = query.data?.pages ?? []
+        return pages.flatMap((p) => p.events ?? [])
+    }, [query.data?.pages])
+
+    const total = useMemo(() => {
+        const pages = query.data?.pages ?? []
+        return pages.length > 0 ? (pages[0].total ?? 0) : 0
+    }, [query.data?.pages])
+
+    const [targetPages, setTargetPages] = useState(1 + PREFETCH)
+    const loadedPages = query.data?.pages?.length ?? 0
+
+    const prevLoadedRef = useRef(loadedPages)
+    useEffect(() => {
+        if (loadedPages === 0 && prevLoadedRef.current > 0) {
+            setTargetPages(1 + PREFETCH)
+        }
+        prevLoadedRef.current = loadedPages
+    }, [loadedPages])
+
+    const requestMore = useCallback(() => {
+        setTargetPages((t) => t + PREFETCH)
+    }, [])
+
+    useEffect(() => {
+        if (loadedPages < targetPages && query.hasNextPage && !query.isFetchingNextPage) {
+            query.fetchNextPage()
+        }
+    }, [loadedPages, targetPages, query.hasNextPage, query.isFetchingNextPage, query.fetchNextPage])
+
+    return {
+        events,
+        total,
+        prefetchThreshold: PREFETCH * CHUNK_SIZE,
+        isLoading: query.isPending,
+        isFetchingNextPage: query.isFetchingNextPage,
+        hasNextPage: query.hasNextPage ?? false,
+        error: query.error,
+        requestMore,
+        setSearch,
+    }
+}

--- a/web/packages/agenta-entities/src/gatewayTrigger/hooks/useTriggerConnections.ts
+++ b/web/packages/agenta-entities/src/gatewayTrigger/hooks/useTriggerConnections.ts
@@ -1,0 +1,66 @@
+import {useMemo} from "react"
+
+import {useAtomValue} from "jotai"
+import {atomFamily} from "jotai/utils"
+import {atomWithQuery} from "jotai-tanstack-query"
+
+import {queryTriggerConnections} from "../api"
+import type {TriggerConnection, TriggerConnectionsResponse} from "../core/types"
+
+const DEFAULT_PROVIDER = "composio"
+
+// Full list of trigger connections (shared `gateway_connections` rows, F2).
+export const triggerConnectionsQueryAtom = atomWithQuery<TriggerConnectionsResponse>(() => ({
+    queryKey: ["triggers", "connections"],
+    queryFn: () => queryTriggerConnections(),
+    staleTime: 30_000,
+    refetchOnWindowFocus: false,
+}))
+
+export const useTriggerConnectionsQuery = () => {
+    const query = useAtomValue(triggerConnectionsQueryAtom)
+
+    const connections = useMemo<TriggerConnection[]>(
+        () => query.data?.connections ?? [],
+        [query.data?.connections],
+    )
+
+    return {
+        connections,
+        count: query.data?.count ?? 0,
+        isLoading: query.isPending,
+        error: query.error,
+        refetch: query.refetch,
+    }
+}
+
+// Connections scoped to a single integration.
+export const triggerIntegrationConnectionsAtomFamily = atomFamily((integrationKey: string) =>
+    atomWithQuery<TriggerConnectionsResponse>(() => ({
+        queryKey: ["triggers", "connections", DEFAULT_PROVIDER, integrationKey],
+        queryFn: () =>
+            queryTriggerConnections({
+                provider_key: DEFAULT_PROVIDER,
+                integration_key: integrationKey,
+            }),
+        staleTime: 30_000,
+        refetchOnWindowFocus: false,
+        enabled: !!integrationKey,
+    })),
+)
+
+export const useTriggerIntegrationConnections = (integrationKey: string) => {
+    const query = useAtomValue(triggerIntegrationConnectionsAtomFamily(integrationKey))
+
+    const connections = useMemo<TriggerConnection[]>(
+        () => query.data?.connections ?? [],
+        [query.data?.connections],
+    )
+
+    return {
+        connections,
+        count: query.data?.count ?? 0,
+        isLoading: query.isPending,
+        error: query.error,
+    }
+}

--- a/web/packages/agenta-entities/src/gatewayTrigger/hooks/useTriggerEvent.ts
+++ b/web/packages/agenta-entities/src/gatewayTrigger/hooks/useTriggerEvent.ts
@@ -1,0 +1,37 @@
+import {useAtomValue} from "jotai"
+import {atomFamily} from "jotai/utils"
+import {atomWithQuery} from "jotai-tanstack-query"
+
+import {fetchTriggerEvent} from "../api"
+import type {TriggerCatalogEventResponse} from "../core/types"
+
+const DEFAULT_PROVIDER = "composio"
+
+export const triggerEventDetailQueryFamily = atomFamily(
+    ({integrationKey, eventKey}: {integrationKey: string; eventKey: string}) =>
+        atomWithQuery<TriggerCatalogEventResponse>(() => ({
+            queryKey: [
+                "triggers",
+                "catalog",
+                "eventDetail",
+                DEFAULT_PROVIDER,
+                integrationKey,
+                eventKey,
+            ],
+            queryFn: () => fetchTriggerEvent(DEFAULT_PROVIDER, integrationKey, eventKey),
+            staleTime: 5 * 60_000,
+            refetchOnWindowFocus: false,
+            enabled: !!integrationKey && !!eventKey,
+        })),
+    (a, b) => a.integrationKey === b.integrationKey && a.eventKey === b.eventKey,
+)
+
+export const useTriggerEvent = (integrationKey: string, eventKey: string) => {
+    const query = useAtomValue(triggerEventDetailQueryFamily({integrationKey, eventKey}))
+
+    return {
+        event: query.data?.event ?? null,
+        isLoading: query.isPending,
+        error: query.error,
+    }
+}

--- a/web/packages/agenta-entities/src/gatewayTrigger/index.ts
+++ b/web/packages/agenta-entities/src/gatewayTrigger/index.ts
@@ -1,0 +1,64 @@
+/**
+ * Gateway-trigger entity module.
+ *
+ * Browser-side state and queries for the `/triggers/*` endpoint family:
+ * the read-only events catalog (WP1) and the shared connection list (WP0).
+ *
+ * Mirrors `gatewayTool`. The catalog isn't in the Fern client yet, so the API
+ * layer uses the shared axios instance with zod validation at the boundary
+ * (see `api/api.ts`); it collapses onto the Fern `triggers` resource once the
+ * client is regenerated.
+ */
+
+// ---------------------------------------------------------------------------
+// CORE — domain types
+// ---------------------------------------------------------------------------
+
+export type {
+    TriggerCatalogEvent,
+    TriggerCatalogEventDetails,
+    TriggerCatalogEventResponse,
+    TriggerCatalogEventsResponse,
+    TriggerCatalogProvider,
+    TriggerCatalogProviderResponse,
+    TriggerCatalogProvidersResponse,
+    TriggerConnection,
+    TriggerConnectionsResponse,
+    TriggerProviderKind,
+} from "./core"
+export {isConnectionActive, isConnectionValid} from "./core"
+
+// ---------------------------------------------------------------------------
+// API — HTTP wrappers (axios + zod boundary validation)
+// ---------------------------------------------------------------------------
+
+export {
+    fetchTriggerEvent,
+    fetchTriggerEvents,
+    fetchTriggerProvider,
+    fetchTriggerProviders,
+    queryTriggerConnections,
+} from "./api"
+
+// ---------------------------------------------------------------------------
+// STATE — drawer + selection atoms
+// ---------------------------------------------------------------------------
+
+export {eventsDrawerAtom, eventSearchAtom, selectedCatalogEventAtom} from "./state"
+export type {EventsDrawerState} from "./state"
+
+// ---------------------------------------------------------------------------
+// HOOKS — query hooks for React consumers
+// ---------------------------------------------------------------------------
+
+export {
+    catalogEventsInfiniteFamily,
+    eventsSearchAtom,
+    triggerConnectionsQueryAtom,
+    triggerEventDetailQueryFamily,
+    triggerIntegrationConnectionsAtomFamily,
+    useCatalogEvents,
+    useTriggerConnectionsQuery,
+    useTriggerEvent,
+    useTriggerIntegrationConnections,
+} from "./hooks"

--- a/web/packages/agenta-entities/src/gatewayTrigger/state/atoms.ts
+++ b/web/packages/agenta-entities/src/gatewayTrigger/state/atoms.ts
@@ -1,0 +1,17 @@
+import {atom} from "jotai"
+
+// ---------------------------------------------------------------------------
+// Events drawer state — opened against a connected integration
+// ---------------------------------------------------------------------------
+
+export interface EventsDrawerState {
+    providerKey: string
+    integrationKey: string
+    integrationName?: string
+    connectionId?: string
+}
+export const eventsDrawerAtom = atom<EventsDrawerState | null>(null)
+
+// Drawer-local browsing state (reset on close)
+export const eventSearchAtom = atom("")
+export const selectedCatalogEventAtom = atom<string | null>(null)

--- a/web/packages/agenta-entities/src/gatewayTrigger/state/index.ts
+++ b/web/packages/agenta-entities/src/gatewayTrigger/state/index.ts
@@ -1,0 +1,2 @@
+export {eventsDrawerAtom, eventSearchAtom, selectedCatalogEventAtom} from "./atoms"
+export type {EventsDrawerState} from "./atoms"

--- a/web/packages/agenta-entities/tests/unit/gatewayTriggerApi.test.ts
+++ b/web/packages/agenta-entities/tests/unit/gatewayTriggerApi.test.ts
@@ -1,0 +1,173 @@
+/**
+ * Unit tests for the gateway-trigger API layer.
+ *
+ * The triggers catalog isn't in the Fern client yet, so these functions call
+ * the shared axios instance and validate the response against the frozen zod
+ * schema at the boundary. Tests stub `@agenta/shared/api` (axios + URL) and the
+ * project store so we can introspect the request shape and confirm boundary
+ * validation without hitting the network.
+ *
+ * AC coverage:
+ *  - Catalog browse: events are fetched against the WP1 API shape.
+ *  - F2: `/triggers/connections/query` reads the same shared connection rows
+ *    that `/tools/connections/query` returns, with no second connect.
+ */
+
+import {beforeEach, describe, expect, it, vi} from "vitest"
+
+const {get, post} = vi.hoisted(() => ({get: vi.fn(), post: vi.fn()}))
+
+vi.mock("@agenta/shared/api", () => ({
+    axios: {get, post},
+    getAgentaApiUrl: () => "https://api.test",
+}))
+
+vi.mock("@agenta/shared/state", () => ({
+    projectIdAtom: {__type: "projectIdAtom"},
+}))
+
+vi.mock("jotai", async (importOriginal) => {
+    const actual = await importOriginal<typeof import("jotai")>()
+    return {...actual, getDefaultStore: () => ({get: () => "proj-42"})}
+})
+
+import {
+    fetchTriggerEvent,
+    fetchTriggerEvents,
+    fetchTriggerProviders,
+    queryTriggerConnections,
+} from "../../src/gatewayTrigger/api/api"
+
+beforeEach(() => {
+    get.mockReset()
+    post.mockReset()
+})
+
+describe("catalog browse", () => {
+    it("lists providers and scopes the request to the project", async () => {
+        get.mockResolvedValueOnce({
+            data: {count: 1, providers: [{key: "composio", name: "Composio"}]},
+        })
+
+        const res = await fetchTriggerProviders()
+
+        const [url, opts] = get.mock.calls[0]
+        expect(url).toBe("https://api.test/triggers/catalog/providers/")
+        expect(opts.params).toMatchObject({project_id: "proj-42"})
+        expect(res.providers[0].key).toBe("composio")
+    })
+
+    it("fetches an integration's events against the WP1 path with cursor params", async () => {
+        get.mockResolvedValueOnce({
+            data: {
+                count: 1,
+                total: 1,
+                cursor: "next",
+                events: [{key: "github_star", name: "Repo starred", categories: []}],
+            },
+        })
+
+        const res = await fetchTriggerEvents("composio", "github", {
+            query: "star",
+            limit: 10,
+            cursor: "c1",
+        })
+
+        const [url, opts] = get.mock.calls[0]
+        expect(url).toBe(
+            "https://api.test/triggers/catalog/providers/composio/integrations/github/events/",
+        )
+        expect(opts.params).toMatchObject({
+            project_id: "proj-42",
+            query: "star",
+            limit: 10,
+            cursor: "c1",
+        })
+        expect(res.events).toHaveLength(1)
+        expect(res.cursor).toBe("next")
+    })
+
+    it("returns an event's trigger_config schema", async () => {
+        const triggerConfig = {
+            type: "object",
+            properties: {owner: {type: "string"}, repo: {type: "string"}},
+            required: ["owner", "repo"],
+        }
+        get.mockResolvedValueOnce({
+            data: {
+                count: 1,
+                event: {
+                    key: "github_star",
+                    name: "Repo starred",
+                    categories: [],
+                    trigger_config: triggerConfig,
+                },
+            },
+        })
+
+        const res = await fetchTriggerEvent("composio", "github", "github_star")
+
+        const [url] = get.mock.calls[0]
+        expect(url).toBe(
+            "https://api.test/triggers/catalog/providers/composio/integrations/github/events/github_star",
+        )
+        expect(res.event?.trigger_config).toEqual(triggerConfig)
+    })
+
+    it("falls back to an empty response when the payload fails validation", async () => {
+        get.mockResolvedValueOnce({data: {events: "not-an-array"}})
+
+        const res = await fetchTriggerEvents("composio", "github")
+
+        expect(res).toEqual({count: 0, total: 0, cursor: null, events: []})
+    })
+})
+
+describe("connections (F2 — shared rows)", () => {
+    it("queries the same shared connection rows surfaced by /tools/connections", async () => {
+        // A row created via /tools/connections; it appears verbatim under
+        // /triggers/connections without a second connect.
+        const sharedRow = {
+            id: "conn-1",
+            slug: "github-prod",
+            name: "GitHub prod",
+            provider_key: "composio",
+            integration_key: "github",
+            flags: {is_active: true, is_valid: true},
+        }
+        post.mockResolvedValueOnce({data: {count: 1, connections: [sharedRow]}})
+
+        const res = await queryTriggerConnections({
+            provider_key: "composio",
+            integration_key: "github",
+        })
+
+        const [url, body, opts] = post.mock.calls[0]
+        expect(url).toBe("https://api.test/triggers/connections/query")
+        expect(body).toEqual({provider_key: "composio", integration_key: "github"})
+        expect(opts.params).toMatchObject({project_id: "proj-42"})
+        expect(res.connections[0]).toMatchObject({id: "conn-1", integration_key: "github"})
+    })
+
+    it("tolerates a connection with no flags (no crash, no second connect path)", async () => {
+        post.mockResolvedValueOnce({
+            data: {
+                count: 1,
+                connections: [{id: "conn-2", provider_key: "composio", integration_key: "slack"}],
+            },
+        })
+
+        const res = await queryTriggerConnections()
+
+        expect(res.connections).toHaveLength(1)
+        expect(res.connections[0].integration_key).toBe("slack")
+    })
+
+    it("falls back to an empty list when the payload fails validation", async () => {
+        post.mockResolvedValueOnce({data: {connections: 42}})
+
+        const res = await queryTriggerConnections()
+
+        expect(res).toEqual({count: 0, connections: []})
+    })
+})

--- a/web/packages/agenta-entity-ui/package.json
+++ b/web/packages/agenta-entity-ui/package.json
@@ -18,6 +18,7 @@
         "./adapters": "./src/adapters/index.ts",
         "./drill-in": "./src/DrillInView/index.ts",
         "./gatewayTool": "./src/gatewayTool/index.ts",
+        "./gatewayTrigger": "./src/gatewayTrigger/index.ts",
         "./modals": "./src/modals/index.ts",
         "./selection": "./src/selection/index.ts",
         "./template-format": "./src/template-format/index.ts",

--- a/web/packages/agenta-entity-ui/src/gatewayTrigger/drawers/TriggerEventsDrawer.tsx
+++ b/web/packages/agenta-entity-ui/src/gatewayTrigger/drawers/TriggerEventsDrawer.tsx
@@ -1,0 +1,250 @@
+import React, {useCallback, useMemo, useRef, useState} from "react"
+
+import {
+    eventsDrawerAtom,
+    eventsSearchAtom,
+    useCatalogEvents,
+    useTriggerEvent,
+    type TriggerCatalogEvent,
+} from "@agenta/entities/gatewayTrigger"
+import {useDebouncedAtomSearch} from "@agenta/shared/hooks"
+import {ScrollSentinel, ScrollToTopButton} from "@agenta/ui"
+import {ArrowLeft, MagnifyingGlass} from "@phosphor-icons/react"
+import {Card, Divider, Drawer, Empty, Form, Input, Spin, Tag, Typography} from "antd"
+import {useAtom, useSetAtom} from "jotai"
+
+import SchemaForm from "../../gatewayTool/components/SchemaForm"
+
+// ---------------------------------------------------------------------------
+// TriggerEventsDrawer (root) — opened against a connected integration
+// ---------------------------------------------------------------------------
+
+export default function TriggerEventsDrawer() {
+    const [state, setState] = useAtom(eventsDrawerAtom)
+    const [selectedEvent, setSelectedEvent] = useState<TriggerCatalogEvent | null>(null)
+    const setEventsSearch = useSetAtom(eventsSearchAtom)
+
+    const open = !!state
+
+    const handleClose = useCallback(() => {
+        setState(null)
+        setSelectedEvent(null)
+        setEventsSearch("")
+    }, [setState, setEventsSearch])
+
+    const handleBack = useCallback(() => {
+        setSelectedEvent(null)
+    }, [])
+
+    return (
+        <Drawer
+            open={open}
+            onClose={handleClose}
+            title={
+                selectedEvent
+                    ? "Event"
+                    : `Events${state?.integrationName ? ` · ${state.integrationName}` : ""}`
+            }
+            size="large"
+            destroyOnClose
+            styles={{
+                body: {
+                    padding: 0,
+                    display: "flex",
+                    flexDirection: "column",
+                    overflow: "hidden",
+                },
+            }}
+        >
+            {state &&
+                (selectedEvent ? (
+                    <EventDetailView
+                        integrationKey={state.integrationKey}
+                        event={selectedEvent}
+                        onBack={handleBack}
+                    />
+                ) : (
+                    <EventsView integrationKey={state.integrationKey} onSelect={setSelectedEvent} />
+                ))}
+        </Drawer>
+    )
+}
+
+// ---------------------------------------------------------------------------
+// Events view (sticky header + scrollable content)
+// ---------------------------------------------------------------------------
+
+function EventsView({
+    integrationKey,
+    onSelect,
+}: {
+    integrationKey: string
+    onSelect: (event: TriggerCatalogEvent) => void
+}) {
+    const setAtom = useSetAtom(eventsSearchAtom)
+    const search = useDebouncedAtomSearch(setAtom)
+    const scrollRef = useRef<HTMLDivElement>(null)
+
+    const {
+        events,
+        total,
+        prefetchThreshold,
+        isLoading,
+        hasNextPage,
+        isFetchingNextPage,
+        requestMore,
+    } = useCatalogEvents(integrationKey)
+
+    const sentinelIndex = useMemo(
+        () => Math.max(0, events.length - prefetchThreshold),
+        [events.length, prefetchThreshold],
+    )
+
+    return (
+        <div className="flex flex-col h-full overflow-hidden">
+            <div className="flex flex-col gap-3 px-6 pt-4 pb-3 shrink-0">
+                <Input
+                    placeholder="Search events…"
+                    prefix={<MagnifyingGlass size={16} />}
+                    value={search.value}
+                    onChange={(e) => search.onChange(e.target.value)}
+                    allowClear
+                    onClear={() => search.onChange("")}
+                />
+                <Typography.Text type="secondary" className="text-xs">
+                    {total} event{total !== 1 ? "s" : ""}
+                </Typography.Text>
+            </div>
+
+            <Divider className="!m-0" />
+
+            <div
+                ref={scrollRef}
+                className="flex-1 overflow-y-auto overscroll-contain px-6 py-3 relative"
+            >
+                {isLoading && events.length === 0 ? (
+                    <div className="flex items-center justify-center py-8">
+                        <Spin />
+                    </div>
+                ) : events.length === 0 ? (
+                    <Empty description="No events found" />
+                ) : (
+                    <div className="flex flex-col gap-2">
+                        {events.map((event, i) => (
+                            <React.Fragment key={event.key}>
+                                {i === sentinelIndex && (
+                                    <ScrollSentinel
+                                        onVisible={requestMore}
+                                        hasMore={hasNextPage}
+                                        isFetching={isFetchingNextPage}
+                                    />
+                                )}
+                                <Card
+                                    hoverable
+                                    onClick={() => onSelect(event)}
+                                    className="cursor-pointer"
+                                    size="small"
+                                >
+                                    <div className="flex flex-col gap-0.5">
+                                        <div className="flex items-center gap-2">
+                                            <Typography.Text strong className="truncate">
+                                                {event.name}
+                                            </Typography.Text>
+                                            {event.categories?.slice(0, 2).map((c) => (
+                                                <Tag key={c} className="text-xs">
+                                                    {c}
+                                                </Tag>
+                                            ))}
+                                        </div>
+                                        {event.description && (
+                                            <Typography.Text type="secondary" className="text-xs">
+                                                {event.description}
+                                            </Typography.Text>
+                                        )}
+                                    </div>
+                                </Card>
+                            </React.Fragment>
+                        ))}
+
+                        <ScrollSentinel
+                            onVisible={requestMore}
+                            hasMore={hasNextPage}
+                            isFetching={isFetchingNextPage}
+                        />
+
+                        {isFetchingNextPage && (
+                            <div className="flex items-center justify-center py-4">
+                                <Spin size="small" />
+                            </div>
+                        )}
+                    </div>
+                )}
+
+                <ScrollToTopButton scrollRef={scrollRef} />
+            </div>
+        </div>
+    )
+}
+
+// ---------------------------------------------------------------------------
+// Event detail — read-only `trigger_config` schema
+// ---------------------------------------------------------------------------
+
+function EventDetailView({
+    integrationKey,
+    event,
+    onBack,
+}: {
+    integrationKey: string
+    event: TriggerCatalogEvent
+    onBack: () => void
+}) {
+    const [form] = Form.useForm()
+    const {event: detail, isLoading} = useTriggerEvent(integrationKey, event.key)
+
+    const schema = (detail?.trigger_config ?? null) as Record<string, unknown> | null
+
+    return (
+        <div className="flex flex-col h-full overflow-hidden">
+            <div className="flex flex-col gap-2 px-6 pt-4 pb-3 shrink-0">
+                <div className="flex items-center gap-3">
+                    <button
+                        type="button"
+                        aria-label="Go back"
+                        onClick={onBack}
+                        className="shrink-0 cursor-pointer bg-transparent border-0 p-0 inline-flex items-center"
+                    >
+                        <ArrowLeft size={16} />
+                    </button>
+                    <Typography.Text strong className="truncate flex-1">
+                        {event.name}
+                    </Typography.Text>
+                </div>
+                {event.description && (
+                    <Typography.Paragraph type="secondary" className="!text-xs !mb-0">
+                        {event.description}
+                    </Typography.Paragraph>
+                )}
+            </div>
+
+            <Divider className="!m-0" />
+
+            <div className="flex-1 overflow-y-auto overscroll-contain px-6 py-4">
+                <Typography.Text className="text-sm font-medium">
+                    Trigger configuration
+                </Typography.Text>
+                <div className="mt-3">
+                    {isLoading ? (
+                        <div className="flex items-center justify-center py-8">
+                            <Spin />
+                        </div>
+                    ) : schema && Object.keys(schema).length > 0 ? (
+                        <SchemaForm schema={schema} form={form} disabled />
+                    ) : (
+                        <Empty description="This event has no configuration" />
+                    )}
+                </div>
+            </div>
+        </div>
+    )
+}

--- a/web/packages/agenta-entity-ui/src/gatewayTrigger/index.ts
+++ b/web/packages/agenta-entity-ui/src/gatewayTrigger/index.ts
@@ -1,0 +1,10 @@
+/**
+ * Gateway-trigger entity UI.
+ *
+ * Atom-driven drawer for browsing a connected integration's events and viewing
+ * each event's `trigger_config` schema. State and data come from
+ * `@agenta/entities/gatewayTrigger`; this layer is purely the UI. Mirrors
+ * `gatewayTool`.
+ */
+
+export {default as TriggerEventsDrawer} from "./drawers/TriggerEventsDrawer"


### PR DESCRIPTION
## Context
The triggers backend (catalog plus connections) had no UI. This lane adds the browse half of the frontend: a Triggers surface where you pick a connected integration, browse its events, and see each event's config schema, plus the connection list. It is the visual dual of the existing Tools settings surface.

## Changes
Adds a Triggers settings surface mirroring the Tools UI:

- On a connected integration you browse its events (from the catalog API) and view each event's `trigger_config` schema read-only, reusing the existing `SchemaForm`.
- Connections are read via `/triggers/connections`. The same shared `gateway_connections` row appears under both Tools and Triggers with no second connect. The two lists use distinct React Query keys so the shared rows never collide in cache, and the connection type is aliased to the tools type so the lists stay byte-compatible.
- New `gatewayTrigger` modules in `@agenta/entities` (API client, hooks, state) and `@agenta/entity-ui` (the events drawer), plus the OSS settings page and sidebar entry.

The API client is built on the shared axios instance with zod validation at the boundary, because the catalog API is not yet in the generated Fern client and regenerating it needs the backend OpenAPI (out of scope for a web-only lane). The local zod schemas mirror the backend DTOs and collapse onto the generated client once it is regenerated.

The Triggers tab is gated by the same Composio gate as Tools (`isToolsEnabled()`); no separate frontend flag.

## Tests / notes
- `@agenta/entities` unit suite passes, including a new `gatewayTriggerApi` test covering catalog browse, the shared-row reads, and boundary-validation fallbacks.
- Type-check and lint pass on `@agenta/entities` and `@agenta/entity-ui`.

## What to QA
- Open Settings on a project with a connected Composio integration. A Triggers tab should appear next to Tools.
- In Triggers, pick the connected integration and browse its events. Each event should show its `trigger_config` schema. Confirm the connection that appears under Tools also appears under Triggers without prompting a second connect.
- Regression to watch: the Tools connection list must still render and behave exactly as before.
