### PR TITLE
[4645] fix(frontend): wrap API key inside the create-key modal

### DIFF
--- a/web/oss/src/components/pages/settings/APIKeys/APIKeys.tsx
+++ b/web/oss/src/components/pages/settings/APIKeys/APIKeys.tsx
@@ -100,8 +100,9 @@ const APIKeys: React.FC = () => {
                                     Make sure to copy your API Key now. You won’t be able to see it
                                     again!
                                 </div>
-                                <div className="mt-[0.5rem] flex items-center gap-2">
+                                <div className="mt-[0.5rem] flex items-start gap-2">
                                     <span
+                                        className="min-w-0 break-all"
                                         style={{
                                             ...monospaceKeyStyle,
                                             color: token.colorTextSecondary,
@@ -110,7 +111,7 @@ const APIKeys: React.FC = () => {
                                     >
                                         {data}
                                     </span>
-                                    <span>
+                                    <span className="shrink-0">
                                         <Tooltip title="Copy">
                                             <CopyOutlined
                                                 onClick={() => copyToClipboard(data)}


### PR DESCRIPTION
## Summary
The API-key **creation success** popup (`modal.success` via `AlertPopup`) rendered the full key in a `flex` row with no break rule. A real key is an 8-character prefix plus a 64-character hex secret joined by a single `.` (`{prefix}.{secrets.token_hex(32)}`), so the unbreakable hex tail kept the flex item at its full intrinsic width and the key overflowed past the modal edge — the end of the key and the copy icon were clipped out of view.

Root cause: the key `<span>` was a flex item with the default `min-width: auto`, so it could not shrink below its content, and it had no `word-break`, so the long token never wrapped.

Fix (in `web/oss/src/components/pages/settings/APIKeys/APIKeys.tsx`):
- key span → `min-w-0 break-all` so the flex item can shrink and the token can break mid-string within the available width
- copy-icon span → `shrink-0` so it is never squeezed out
- row → `items-start` so the copy icon aligns to the first line when the key wraps

No behavior change beyond layout; the same key string and copy action are preserved.

## Testing
### Verified locally
- Reproduced the layout with a faithful key (`{8-char prefix}.{64 hex chars}`) at the real `modal.success` width (650px). Before: the key is clipped at the modal's right edge and the copy icon is pushed out of view. After: the key wraps onto a second line, fully visible, with the copy icon beside the first line.
- `pnpm lint-fix` in `web/` — passes with no ESLint warnings or errors.

### Added or updated tests
N/A — CSS/layout-only change to a single presentational block; there is no existing test harness around this modal.

### QA follow-up
Confirm wrapping on the live create-key flow across light/dark themes and narrow viewports. No data conditions involved.

## Demo
Before / after — the created API key now wraps inside the success modal instead of overflowing past its right edge:

![Before and after: API key overflowing the modal vs. wrapping inside it](https://raw.githubusercontent.com/Koushik-Salammagari/agenta/pr-assets/docs/pr-4645-before-after.png)

## Checklist
- [x] I have included a video or screen recording for UI changes, or marked Demo as N/A
- [x] Relevant tests pass locally
- [x] Relevant linting and formatting pass locally
- [ ] I have signed the CLA, or I will sign it when the bot prompts me
