### PR TITLE
fix: display exception message in trace output column when outputs is nullfix: display exception message in trace output column when outputs is…

### DIFF
--- a/web/oss/src/components/pages/observability/assets/getObservabilityColumns.tsx
+++ b/web/oss/src/components/pages/observability/assets/getObservabilityColumns.tsx
@@ -121,18 +121,36 @@ export const getObservabilityColumns = ({evaluatorSlugs}: ObservabilityColumnsPr
             width: 400,
             maxWidth: 400,
             render: (_, record) => {
-                const outputs = getTraceOutputs(record)
-                const {data: sanitizedOutputs} = sanitizeDataWithBlobUrls(outputs)
-                return (
-                    <SmartCellContent
-                        value={sanitizedOutputs}
-                        keyPrefix={`trace-output-${record.span_id}`}
-                        maxLines={4}
-                        chatPreference="output"
-                        className="h-[112px] overflow-hidden"
-                    />
-                )
-            },
+    const outputs = getTraceOutputs(record)
+    const exception = record.events?.find((event) => event.name === "exception")
+    const {data: sanitizedOutputs} = sanitizeDataWithBlobUrls(outputs)
+
+    if (!outputs && exception) {
+        const exceptionMessage =
+    (exception.attributes?.["exception.message"] as string) ||
+    (exception.attributes?.["exception.type"] as string) ||
+    "Exception"
+        return (
+            <SmartCellContent
+                value={exceptionMessage}
+                keyPrefix={`trace-output-${record.span_id}`}
+                maxLines={4}
+                chatPreference="output"
+                className="h-[112px] overflow-hidden text-red-500"
+            />
+        )
+    }
+
+    return (
+        <SmartCellContent
+            value={sanitizedOutputs}
+            keyPrefix={`trace-output-${record.span_id}`}
+            maxLines={4}
+            chatPreference="output"
+            className="h-[112px] overflow-hidden"
+        />
+    )
+},
         },
         ...(evaluatorSlugs.length > 0
             ? [


### PR DESCRIPTION
## Summary
Display exception message in the trace output column when outputs are null.

Previously, when a trace span had an exception event but no outputs, 
the output column showed an em dash (—). Now it shows the exception 
message/type in red so users can immediately see what failed without 
opening the trace detail view.

## Changes
- Modified `getObservabilityColumns.tsx` to check `record.events` for exception events when outputs are null
- Display `exception.message` or `exception.type` as fallback text
- Exception styled in red for visual distinction


## Demo
<img width="1470" height="956" alt="Screenshot 2026-06-19 at 2 44 29 AM" src="https://github.com/user-attachments/assets/cb0341f9-290a-4050-868e-83db317cebb2" />                                                                      <img width="1470" height="956" alt="Screenshot 2026-06-19 at 2 44 35 AM" src="https://github.com/user-attachments/assets/42e8e74d-f7b4-4890-aa13-b2d0a2993bfa" />

## Issue
Fixes #4731           