### PR TITLE
chore(agent): docker cleanups for the sandbox-agent sidecar

### DIFF
--- a/docs/design/agent-workflows/scratch/wp-8-rivet-acp-runtime/poc/build_rivet_snapshot.py
+++ b/docs/design/agent-workflows/scratch/wp-8-rivet-acp-runtime/poc/build_rivet_snapshot.py
@@ -2,7 +2,7 @@
 # requires-python = ">=3.11"
 # dependencies = ["daytona"]
 # ///
-"""Build a Daytona snapshot for the WP-8 rivet agent runtime.
+"""Build a Daytona snapshot for the WP-8 sandbox-agent runtime.
 
 Bakes the `pi` CLI into rivet's `-full` image (which already ships the sandbox-agent
 daemon, the Claude CLI, and CA certs) so Daytona runs don't pay a ~150s per-invoke
@@ -12,6 +12,20 @@ daemon, the Claude CLI, and CA certs) so Daytona runs don't pay a ~150s per-invo
     AGENTA_RIVET_DAYTONA_INSTALL_PI=false
 
 Run: DAYTONA_API_KEY=... DAYTONA_TARGET=eu uv run build_rivet_snapshot.py [--force]
+
+Licensing (see services/agent/docker/README.md):
+    This script is the build recipe we ship, NOT a snapshot we distribute. Whoever
+    runs it builds the snapshot in their own Daytona account: Agenta Cloud builds
+    its own for internal use; self-hosters build their own. We never hand anyone a
+    Claude-containing image, so this is compliant even though the `-full` base bundles
+    Claude (Anthropic's Commercial Terms forbid us *distributing* Claude Code, not
+    building/using it).
+
+    Cleaner-provenance follow-up (needs a live Daytona build to verify): base on a
+    daemon-only rivet image and install Claude from Anthropic at build (npm
+    `@anthropic-ai/claude-code` or `claude.ai/install.sh`), so the snapshot's Claude
+    comes straight from Anthropic instead of from a third party's bundled image. Pin
+    that only after confirming the daemon-only tag also ships the ACP adapters.
 """
 
 import sys

--- a/hosting/docker-compose/ee/docker-compose.dev.yml
+++ b/hosting/docker-compose/ee/docker-compose.dev.yml
@@ -450,8 +450,11 @@ services:
             DAYTONA_API_KEY: ${DAYTONA_API_KEY:-}
             DAYTONA_API_URL: ${DAYTONA_API_URL:-}
             DAYTONA_TARGET: ${DAYTONA_TARGET:-}
-            # Pre-baked snapshot (rivet daemon + Pi + Claude + certs) so Daytona runs skip
-            # the ~150s per-invoke `npm install pi`. Built by poc/build_rivet_snapshot.py.
+            # Pre-baked snapshot (rivet daemon + Pi + certs; Claude inherited from rivet's
+            # -full base) so Daytona runs skip the ~150s per-invoke `npm install pi`. We
+            # ship the builder (poc/build_rivet_snapshot.py), not the snapshot itself: each
+            # operator builds their own, so we never distribute a Claude-containing image.
+            # See services/agent/docker/README.md for the licensing posture.
             AGENTA_RIVET_DAYTONA_SNAPSHOT: ${AGENTA_RIVET_DAYTONA_SNAPSHOT:-agenta-rivet-pi}
             AGENTA_RIVET_DAYTONA_INSTALL_PI: ${AGENTA_RIVET_DAYTONA_INSTALL_PI:-false}
         # === STORAGE ============================================== #

--- a/services/agent/docker/Dockerfile
+++ b/services/agent/docker/Dockerfile
@@ -1,0 +1,55 @@
+# Agent runner sidecar (sandbox-agent server), production image.
+#
+# Runs the TypeScript runner (src/server.ts) as a long-lived HTTP server on :8765.
+# The Python agent service calls it in-network. Unlike Dockerfile.dev there is no
+# `tsx watch` and no bind mount: the source is baked in.
+#
+# Licensing posture (see docker/README.md):
+#   - Pi (@earendil-works/pi-coding-agent, MIT) is baked via the npm dependencies.
+#   - Claude Code is proprietary (Anthropic Commercial Terms). It is NEVER baked into
+#     this image. The sandbox-agent daemon installs it at runtime from Anthropic over
+#     HTTPS (the reason ca-certificates is installed). That keeps Anthropic as the
+#     distributor, the only compliant path for an image we build and ship.
+#   - No credential is baked: no API key, no OAuth login. Auth is injected at runtime
+#     (ANTHROPIC_API_KEY / request secrets; OAuth self-host is a mounted opt-in only).
+
+FROM node:24-slim
+
+WORKDIR /app
+
+# CA certificates: the sandbox-agent daemon (Rust) downloads harness CLIs (e.g. Claude
+# Code) over HTTPS using the system trust store, which node:*-slim omits — without this
+# the daemon's `install-agent claude` fails TLS verification. git lets npm/installers
+# fetch git deps.
+RUN apt-get update \
+    && apt-get install -y --no-install-recommends ca-certificates git \
+    && rm -rf /var/lib/apt/lists/*
+
+RUN corepack enable
+
+# Install deps as a cached layer (manifest + lockfile only). The full dependency set is
+# installed (not --prod): the runtime uses `tsx` and the extension build uses `esbuild`,
+# both devDependencies.
+COPY package.json pnpm-lock.yaml ./
+RUN pnpm install --frozen-lockfile
+
+# Bake the source (no bind mount in production).
+COPY tsconfig.json ./
+COPY scripts ./scripts
+COPY src ./src
+COPY config ./config
+COPY skills ./skills
+
+# Bundle the Agenta Pi extension (tracing + tools) into dist/. runSandboxAgent installs
+# this baked copy into Pi's agent dir on every run. Rebuild the image after editing
+# src/extensions/agenta.ts or the tracer.
+RUN pnpm run build:extension
+
+ENV NODE_ENV=production \
+    PORT=8765
+
+EXPOSE 8765
+
+# Call the local tsx binary directly to avoid pnpm/corepack HOME writes when the
+# container runs as a non-root host uid.
+CMD ["node_modules/.bin/tsx", "src/server.ts"]

--- a/services/agent/docker/README.md
+++ b/services/agent/docker/README.md
@@ -1,0 +1,66 @@
+# Agent sidecar images
+
+Images for the agent runner sidecar (the `sandbox-agent server` runtime in
+`services/agent/src/server.ts`). The Python service calls it in-network at
+`:8765`.
+
+- `Dockerfile.dev` — dev image. `tsx watch`, source bind-mounted, hot reload.
+- `Dockerfile` — production image. Source baked in, no watcher.
+
+## Licensing posture (read before changing any image or build recipe)
+
+The rule that shapes every image here:
+
+> **We ship build recipes, not Claude-containing images, and we never bake a
+> credential into any image.**
+
+Why:
+
+- **Pi** (`@earendil-works/pi-coding-agent`) is MIT. We bake it freely via the npm
+  dependencies, in every image and snapshot.
+- **Claude Code** is proprietary (© Anthropic PBC, governed by Anthropic's
+  [Commercial Terms](https://www.anthropic.com/legal/commercial-terms);
+  [legal & compliance](https://code.claude.com/docs/en/legal-and-compliance)). The
+  Commercial Terms grant a usage license only. They do not grant any right to
+  redistribute, resell, sublicense, or repackage the Services. So an image **we
+  build and distribute must not contain Claude Code.**
+- Claude Code is installed **from Anthropic** (`npm install -g
+  @anthropic-ai/claude-code`, `https://claude.ai/install.sh`, or the daemon's
+  `install-agent claude`). That keeps Anthropic as the distributor, which is the
+  permitted path. The production sidecar does this at runtime; a snapshot we build
+  for our own use does it at build time.
+
+## Authentication
+
+Auth is injected at runtime, never baked into a layer.
+
+- **API key (default, and the only option for cloud / multi-tenant).** Set
+  `ANTHROPIC_API_KEY` (or pass provider keys as request secrets from the vault).
+  Anthropic directs products and services that interact with Claude to use API key
+  auth, so this is the path for any Agenta-orchestrated run that serves users.
+- **OAuth subscription (self-host opt-in only).** An individual operator may mount
+  their own Claude login (e.g. `~/.claude`) into the container and run with their
+  own subscription. This is for personal, individual use of Claude Code, never for
+  serving other users, and it is the operator's responsibility. Anthropic restricts
+  Free/Pro/Max OAuth to first-party use and forbids third parties routing requests
+  through it (enforced since 2026-03). Cloud and multi-tenant deployments must stay
+  API-key only.
+
+We never bake an OAuth login or an API key into an image.
+
+## Build recipes (two paths)
+
+- **Cloud / Daytona (API key).** The Daytona snapshot recipe bakes Pi. Agenta Cloud
+  builds and uses its own snapshot internally; self-hosters run the same recipe
+  against their own Daytona account. We ship the build script (the recipe), not the
+  built snapshot, so we never distribute a Claude-containing artifact. Snapshot
+  builder: `docs/design/agent-workflows/scratch/wp-8-rivet-acp-runtime/poc/build_rivet_snapshot.py`.
+  Today it bases on rivet's `-full` image, which already bundles Claude. That is
+  compliant under the recipe-not-image model. **Cleaner-provenance follow-up
+  (needs a live Daytona build to verify):** base on a daemon-only rivet image and
+  install Claude from Anthropic at build, so the snapshot's Claude comes straight
+  from Anthropic rather than from a third party's bundled image. Relocation of the
+  builder into this folder is a follow-up.
+- **Self-host (API key, OAuth optional).** Build the production `Dockerfile` (it
+  bakes neither Claude nor a credential), then supply auth at runtime: an
+  `ANTHROPIC_API_KEY` env var, or, for individual use, a mounted OAuth login dir.


### PR DESCRIPTION
<!-- stack-nav:start -->
### This PR is part of a stack. Review bottom-up.

Each PR's diff is only its own delta. Merge from the bottom. This PR's base is #4761 (merge that first).

- #4758: Pi-backed agent workflow service, template, tracing
- #4759: runnable tools as agent configuration
- #4760: drive harnesses over ACP via rivet
- #4761: move the runtime into the SDK behind backend/harness ports
  - **#4762: docker cleanups for the sidecar (side branch off #4761)  <- you are here**
- #4763: typed SDK agent tool contracts
- #4764: resolve typed tools through the service
- #4765: deliver resolved tools through the runner
- #4766: remove Vercel adapter dead aliases
- #4767: propagate messages session ids to runner traces
- #4768: load-session via a no-op session store port
- #4769: advertise Vercel messages protocol headers
- #4770: agent-workflows ground truth + comment hygiene
<!-- stack-nav:end -->

## Context

The agent runner sidecar (the `sandbox-agent server` runtime in `services/agent/src/server.ts`) had a dev Dockerfile but no production image and no written rules for what an image may contain. This PR adds the production image and the licensing posture that governs every agent image. It branches off `feat/agent-harness-port` as the infra-chore side slice in `docs/design/agent-workflows/pr-stack.md`.

## What this changes

This PR adds three things and clarifies one comment:

- A production `Dockerfile` for the sidecar. It bakes the TypeScript runner source, runs `pnpm run build:extension`, and serves on `:8765` with `tsx`. No `tsx watch` and no bind mount, unlike the dev image.
- A `README.md` that states the rule for agent images: we ship build recipes, never Claude-containing images, and never a baked credential.
- A licensing note in the WP-8 Daytona snapshot builder explaining why the recipe-not-image model is compliant.
- The dev compose comment now says the snapshot bakes Pi and certs, with Claude inherited from rivet's `-full` base, not baked by us.

No binary, snapshot, or Claude artifact is committed. The repo ships the builder script, so each operator builds their own image in their own account.

## Key architectural decision to review

The decision to scrutinize is the licensing posture in `services/agent/docker/README.md` and the Dockerfile header. Claude Code is proprietary under Anthropic's Commercial Terms, which grant a usage license but no right to redistribute. Pi is MIT, so we bake it freely.

The tradeoff: we never produce an image that contains Claude Code. The production Dockerfile installs nothing from Anthropic at build time. Instead the sandbox-agent daemon installs Claude at runtime from Anthropic over HTTPS, which is why `ca-certificates` is installed (`Dockerfile:25`). That keeps Anthropic as the distributor. The Daytona snapshot is the one place this gets subtle: today the builder bases on rivet's `-full` image, which already bundles Claude. That stays compliant only because we ship the builder script, not the built snapshot, so each operator builds the Claude-containing image in their own account and we distribute nothing. The README records a cleaner-provenance follow-up: base on a daemon-only rivet image and install Claude from Anthropic at build, pending a live Daytona check that the daemon-only tag ships the ACP adapters.

Verify the rule holds end to end: nothing in this PR commits a Claude binary or a prebuilt snapshot, and no image baked here contains Claude or a credential.

## How to review this PR

1. Read `services/agent/docker/README.md` first. It is the contract the other files implement.
2. Read `services/agent/docker/Dockerfile`. Confirm it bakes only Pi (via npm deps) and source, installs no Anthropic package, and bakes no key or login. Check that `ca-certificates` exists because the daemon fetches Claude over TLS at runtime.
3. Skim the compose comment and the `build_rivet_snapshot.py` docstring. These are doc-only and restate the same posture.
4. Skip the runner source and the snapshot builder logic. This PR only edits the docstring there, not behavior.

## Tests / notes

Doc and Dockerfile only, no code paths change. The production image is not built in CI by this PR. The cleaner-provenance snapshot follow-up is parked because it needs a live Daytona build to confirm the daemon-only rivet tag ships the ACP adapters.