### PR TITLE
refactor(agent): remove Vercel adapter dead aliases

### DIFF
--- a/sdks/python/agenta/sdk/agents/adapters/vercel/routing.py
+++ b/sdks/python/agenta/sdk/agents/adapters/vercel/routing.py
@@ -168,8 +168,3 @@ def register_agent_message_routes(
         make_load_session_endpoint(),
         methods=["POST"],
     )
-
-
-# Back-compat aliases for the former routing-private helper names.
-_resolve_session_id = resolve_session_id
-_inject_stream_session_id = inject_stream_session_id

--- a/sdks/python/agenta/sdk/agents/adapters/vercel/sse.py
+++ b/sdks/python/agenta/sdk/agents/adapters/vercel/sse.py
@@ -23,8 +23,3 @@ def vercel_sse_stream(aiter: AsyncGenerator[Any, None]):
         yield "data: [DONE]\n\n"
 
     return gen()
-
-
-# Back-compat aliases for the former routing-private names.
-_VERCEL_UI_MESSAGE_STREAM_HEADERS = VERCEL_UI_MESSAGE_STREAM_HEADERS
-_vercel_sse_stream = vercel_sse_stream

--- a/sdks/python/agenta/sdk/agents/ui_messages.py
+++ b/sdks/python/agenta/sdk/agents/ui_messages.py
@@ -6,18 +6,12 @@ New code should import from :mod:`agenta.sdk.agents.adapters.vercel`.
 from __future__ import annotations
 
 from .adapters.vercel import (
-    agent_run_to_vercel_parts,
     from_ui_messages,
-    message_to_vercel_ui_message,
     to_ui_message,
     ui_message_stream,
-    vercel_ui_messages_to_messages,
 )
 
 __all__ = [
-    "vercel_ui_messages_to_messages",
-    "message_to_vercel_ui_message",
-    "agent_run_to_vercel_parts",
     "from_ui_messages",
     "to_ui_message",
     "ui_message_stream",

--- a/sdks/python/agenta/sdk/decorators/routing.py
+++ b/sdks/python/agenta/sdk/decorators/routing.py
@@ -20,11 +20,7 @@ from agenta.sdk.models.workflows import (
     WorkflowBaseResponse,
     WorkflowServiceResponseData,
 )
-from agenta.sdk.agents.adapters.vercel.routing import (
-    inject_stream_session_id,
-    register_agent_message_routes,
-    resolve_session_id,
-)
+from agenta.sdk.agents.adapters.vercel.routing import register_agent_message_routes
 from agenta.sdk.agents.adapters.vercel.sse import (
     VERCEL_UI_MESSAGE_STREAM_HEADERS as _VERCEL_UI_MESSAGE_STREAM_HEADERS,
     vercel_sse_stream as _vercel_sse_stream,
@@ -36,19 +32,6 @@ from agenta.sdk.middlewares.running.vault import invalidate_secrets_cache
 from agenta.sdk.contexts.tracing import TracingContext, tracing_context_manager
 from agenta.sdk.decorators.running import auto_workflow, inspect_workflow, Workflow
 from agenta.sdk.engines.running.errors import ErrorStatus
-
-
-def _resolve_session_id(session_id: Optional[str]) -> Optional[str]:
-    """Compatibility wrapper for the Vercel adapter helper."""
-    return resolve_session_id(session_id)
-
-
-def _inject_stream_session_id(
-    response: WorkflowStreamingResponse,
-    session_id: str,
-) -> None:
-    """Compatibility wrapper for the Vercel adapter helper."""
-    inject_stream_session_id(response, session_id)
 
 
 # ---------------------------------------------------------------------------


### PR DESCRIPTION
<!-- stack-nav:start -->
### This PR is part of a stack. Review bottom-up.

Each PR's diff is only its own delta. Merge from the bottom. This PR's base is #4765 (merge that first).

- #4758: Pi-backed agent workflow service, template, tracing
- #4759: runnable tools as agent configuration
- #4760: drive harnesses over ACP via rivet
- #4761: move the runtime into the SDK behind backend/harness ports
  - #4762: docker cleanups for the sidecar (side branch off #4761)
- #4763: typed SDK agent tool contracts
- #4764: resolve typed tools through the service
- #4765: deliver resolved tools through the runner
- **#4766: remove Vercel adapter dead aliases  <- you are here**
- #4767: propagate messages session ids to runner traces
- #4768: load-session via a no-op session store port
- #4769: advertise Vercel messages protocol headers
- #4770: agent-workflows ground truth + comment hygiene
<!-- stack-nav:end -->

## Context

The Vercel adapter moved into its own package (`agents/adapters/vercel/`). That move left behind a set of compatibility shims: underscore-prefixed aliases and re-exports that pointed back at the new canonical names. Nothing reads them anymore. This PR base is `feat/sdk-local-tools-runner-docs`. It is slice #2 (protocol shell hardening) of `docs/design/agent-workflows/pr-stack.md`, the dead-code removal step.

## What this changes

This deletes the leftover aliases. The canonical functions stay exactly where they are. No call site changes, no behavior changes. The diff is one trimmed import plus the removed shim lines.

## Key architectural decision to review

The only thing to confirm is that the removed names have no live callers. Here is what was removed and where it lived:

- `_resolve_session_id` and `_inject_stream_session_id`: compatibility wrappers in `sdks/python/agenta/sdk/decorators/routing.py`. The real helpers are `resolve_session_id` and `inject_stream_session_id` in the Vercel adapter.
- `_VERCEL_UI_MESSAGE_STREAM_HEADERS` and `_vercel_sse_stream`: self-aliases at the bottom of `sdks/python/agenta/sdk/agents/adapters/vercel/sse.py`. The canonical names `VERCEL_UI_MESSAGE_STREAM_HEADERS` and `vercel_sse_stream` are untouched.
- `vercel_ui_messages_to_messages`, `message_to_vercel_ui_message`, and `agent_run_to_vercel_parts`: re-exports trimmed from `sdks/python/agenta/sdk/agents/ui_messages.py`. These names still live in the adapter package and are imported directly from there.

One subtlety worth a second look: `decorators/routing.py` imports the canonical `sse.py` names and locally re-aliases them with `as _VERCEL_UI_MESSAGE_STREAM_HEADERS` and `as _vercel_sse_stream`. That local alias is separate from the deleted self-aliases inside `sse.py`, so it keeps working.

## How to review this PR

Grep the codebase for each removed name and confirm zero live callers, then approve. The removed underscore wrappers have no callers. The trimmed `ui_messages.py` re-exports have no importers that go through `ui_messages`; every caller imports the canonical names directly from `agents.adapters.vercel`. This is safe to approve quickly.