### PR TITLE
fix(agent): propagate messages session ids to runner traces

### DIFF
--- a/sdks/python/agenta/sdk/middlewares/running/normalizer.py
+++ b/sdks/python/agenta/sdk/middlewares/running/normalizer.py
@@ -66,8 +66,10 @@ class NormalizerMiddleware:
         1. If parameter name is 'request': passes the entire WorkflowServiceRequest
         2. If parameter name matches DATA_FIELDS (like 'inputs', 'outputs', 'parameters'):
            extracts that field from request.data
-        3. If parameter is **kwargs: includes all unconsumed DATA_FIELDS
-        4. Otherwise: looks up the parameter name in request.data.inputs dict
+        3. If parameter name is a supported top-level request field like 'session_id':
+           extracts that field from the request envelope
+        4. If parameter is **kwargs: includes all unconsumed DATA_FIELDS
+        5. Otherwise: looks up the parameter name in request.data.inputs dict
 
         Args:
             request: The workflow service request containing inputs and data
@@ -93,6 +95,10 @@ class NormalizerMiddleware:
                 normalized[name] = (
                     getattr(request.data, name, None) if request.data else None
                 )
+                consumed.add(name)
+
+            elif name == "session_id":
+                normalized[name] = request.session_id
                 consumed.add(name)
 
             elif param.kind == inspect.Parameter.VAR_KEYWORD:

--- a/sdks/python/oss/tests/pytest/unit/test_normalizer_passthrough.py
+++ b/sdks/python/oss/tests/pytest/unit/test_normalizer_passthrough.py
@@ -79,6 +79,36 @@ class TestRequestNormalization:
 
         assert kwargs["parameters"] == {"correct_answer_key": "answer"}
 
+    @pytest.mark.asyncio
+    async def test_session_id_is_passed_to_explicit_handler_argument(self):
+        def handler(session_id):
+            return session_id
+
+        request = WorkflowServiceRequest(
+            session_id="sess_request",
+            data=WorkflowRequestData(),
+        )
+
+        mw = NormalizerMiddleware()
+        kwargs = await mw._normalize_request(request, handler)
+
+        assert kwargs["session_id"] == "sess_request"
+
+    @pytest.mark.asyncio
+    async def test_session_id_is_not_added_to_var_kwargs(self):
+        def handler(**kwargs):
+            return kwargs
+
+        request = WorkflowServiceRequest(
+            session_id="sess_request",
+            data=WorkflowRequestData(inputs={"prompt": "hi"}),
+        )
+
+        mw = NormalizerMiddleware()
+        kwargs = await mw._normalize_request(request, handler)
+
+        assert "session_id" not in kwargs
+
 
 class TestAsyncGenerator:
     @pytest.mark.asyncio

--- a/services/agent/src/engines/pi.ts
+++ b/services/agent/src/engines/pi.ts
@@ -41,6 +41,7 @@ import {
   type HarnessCapabilities,
   type ResolvedToolSpec,
   type ToolCallbackContext,
+  resolveRunSessionId,
   resolvePromptText,
 } from "../protocol.ts";
 import { EMPTY_OBJECT_SCHEMA } from "../tools/callback.ts";
@@ -299,7 +300,8 @@ export async function runPi(
       }));
 
       // Hand the session id + model to the extension so spans carry them.
-      otel.config.sessionId = session.sessionId;
+      const sessionId = resolveRunSessionId(request, session.sessionId);
+      otel.config.sessionId = sessionId;
       otel.config.provider = model.provider;
       otel.config.requestModel = model.id;
 
@@ -329,7 +331,6 @@ export async function runPi(
       await session.prompt(prompt);
 
       const output = streamed.trim() || extractAssistantText(session.messages);
-      const sessionId = session.sessionId;
       const stopReason = lastStopReason(session.messages);
       const usage = otel.usage();
 

--- a/services/agent/src/engines/rivet.ts
+++ b/services/agent/src/engines/rivet.ts
@@ -65,6 +65,7 @@ import {
   type ToolCallbackContext,
   messageText,
   resolvePromptText,
+  resolveRunSessionId,
 } from "../protocol.ts";
 
 const require = createRequire(import.meta.url);
@@ -817,6 +818,7 @@ export async function runRivet(
       cwd,
       sessionInit: { cwd, mcpServers },
     });
+    const sessionId = resolveRunSessionId(request, session.id);
 
     // Resolve the model first: when the harness rejects the requested id and keeps its
     // own default (e.g. Claude ignores "gpt-5.5"), `model` is undefined and the chat span
@@ -838,7 +840,7 @@ export async function runRivet(
 
     run.start({
       prompt,
-      sessionId: session.id,
+      sessionId,
       messages: [...priorMessages(request), { role: "user", content: prompt }],
     });
 
@@ -922,7 +924,7 @@ export async function runRivet(
       // `streamingDeltas` advertises end-to-end live deltas, which is only true when a live
       // sink is wired. The one-shot path reports false even when the harness produces deltas.
       capabilities: { ...capabilities, streamingDeltas: !!emit && capabilities.streamingDeltas },
-      sessionId: session.id,
+      sessionId,
       model: model ?? request.model,
       traceId: run.traceId(),
     };

--- a/services/agent/src/protocol.ts
+++ b/services/agent/src/protocol.ts
@@ -189,7 +189,7 @@ export interface AgentRunRequest {
   harness?: string;
   /** Sandbox for the rivet backend ("local" / "daytona"). */
   sandbox?: string;
-  /** Continue a prior run by replaying its history. */
+  /** External conversation id. The cold runtime still receives history in `messages`. */
   sessionId?: string;
   /** Provider API keys as env vars ({OPENAI_API_KEY,...}), resolved from the vault. */
   secrets?: Record<string, string>;
@@ -287,4 +287,9 @@ export function resolvePromptText(request: AgentRunRequest): string {
     }
   }
   return "";
+}
+
+/** Prefer the platform conversation id, falling back to the harness's ephemeral id. */
+export function resolveRunSessionId(request: AgentRunRequest, fallback: string): string {
+  return request.sessionId && request.sessionId.trim() ? request.sessionId : fallback;
 }

--- a/services/agent/test/continuation.test.ts
+++ b/services/agent/test/continuation.test.ts
@@ -11,7 +11,11 @@
 import assert from "node:assert/strict";
 
 import { messageTranscript, buildTurnText } from "../src/engines/rivet.ts";
-import type { AgentRunRequest, ContentBlock } from "../src/protocol.ts";
+import {
+  resolveRunSessionId,
+  type AgentRunRequest,
+  type ContentBlock,
+} from "../src/protocol.ts";
 
 // --- messageTranscript -------------------------------------------------------
 assert.equal(messageTranscript("hello"), "hello");
@@ -28,6 +32,13 @@ assert.equal(
   messageTranscript([{ type: "tool_result", toolName: "send", output: "boom", isError: true }]),
   "[send error: boom]",
 );
+
+// --- session id metadata ------------------------------------------------------
+assert.equal(
+  resolveRunSessionId({ sessionId: "sess_platform" }, "runner-ephemeral"),
+  "sess_platform",
+);
+assert.equal(resolveRunSessionId({}, "runner-ephemeral"), "runner-ephemeral");
 
 // --- buildTurnText keeps a resolved tool turn in the replay ------------------
 {

--- a/services/oss/src/agent/app.py
+++ b/services/oss/src/agent/app.py
@@ -77,6 +77,7 @@ async def _agent(
     messages: Optional[List[Any]] = None,
     parameters: Optional[Dict] = None,
     stream: Optional[bool] = None,
+    session_id: Optional[str] = None,
 ):
     params = parameters or {}
 
@@ -98,6 +99,7 @@ async def _agent(
         secrets=await resolve_harness_secrets(),
         permission_policy=selection.permission_policy,
         trace=trace_context(),
+        session_id=session_id,
         builtin_names=resources.tools.builtin_names,
         tool_specs=resources.tools.tool_specs,
         tool_callback=resources.tools.tool_callback,

--- a/services/oss/tests/pytest/unit/agent/conftest.py
+++ b/services/oss/tests/pytest/unit/agent/conftest.py
@@ -85,6 +85,7 @@ class FakeBackend(Backend):
         self.shutdown_calls = 0
         # Every harness-shaped config that reached the backend boundary, in call order.
         self.created_configs: list = []
+        self.created_session_ids: list[Optional[str]] = []
 
     async def setup(self) -> None:
         self.setup_calls += 1
@@ -99,6 +100,7 @@ class FakeBackend(Backend):
         self, sandbox, config, *, harness, secrets=None, trace=None, session_id=None
     ) -> _FakeSession:
         self.created_configs.append(config)
+        self.created_session_ids.append(session_id)
         return _FakeSession(self._result)
 
 

--- a/services/oss/tests/pytest/unit/agent/test_invoke_handler.py
+++ b/services/oss/tests/pytest/unit/agent/test_invoke_handler.py
@@ -85,6 +85,18 @@ async def test_invoke_runs_backend_lifecycle(patched):
     assert backend.shutdown_calls == 1  # cleanup() tears the backend down
 
 
+async def test_messages_session_id_reaches_session_config(patched):
+    backend, _ = patched
+
+    await app._agent(
+        messages=[{"role": "user", "content": "hi"}],
+        parameters={"agent": {"harness": "pi"}},
+        session_id="sess_request",
+    )
+
+    assert backend.created_session_ids == ["sess_request"]
+
+
 async def test_invoke_cross_harness_same_body_divergent_configs(
     monkeypatch, fake_backend
 ):


### PR DESCRIPTION
<!-- stack-nav:start -->
### This PR is part of a stack. Review bottom-up.

Each PR's diff is only its own delta. Merge from the bottom. This PR's base is #4766 (merge that first).

- #4758: Pi-backed agent workflow service, template, tracing
- #4759: runnable tools as agent configuration
- #4760: drive harnesses over ACP via rivet
- #4761: move the runtime into the SDK behind backend/harness ports
  - #4762: docker cleanups for the sidecar (side branch off #4761)
- #4763: typed SDK agent tool contracts
- #4764: resolve typed tools through the service
- #4765: deliver resolved tools through the runner
- #4766: remove Vercel adapter dead aliases
- **#4767: propagate messages session ids to runner traces  <- you are here**
- #4768: load-session via a no-op session store port
- #4769: advertise Vercel messages protocol headers
- #4770: agent-workflows ground truth + comment hygiene
<!-- stack-nav:end -->

## Context

The `/messages` endpoint already carries a `session_id` on the request envelope, and the response already echoes it back. But the id stopped at the route. It never reached the agent runner, so Pi and Rivet traces and run metadata were stamped with the harness's own ephemeral session id instead of the platform conversation id. That broke correlation: a multi-turn conversation produced a fresh, unrelated id on every span.

This PR threads the platform `session_id` from the request envelope down to the runner so traces carry it. Base branch: `refactor/vercel-adapter-cleanup`. This is the session-id seam from slice #2 (protocol) in `docs/design/agent-workflows/pr-stack.md`, reaching toward slice #5.

## What this changes

Before, the runner used whatever id the harness minted for itself. Each turn looked like a new conversation in the traces.

After, the runner prefers the platform id when the request supplies one, and falls back to the harness id only when it does not.

The id now travels the full path:

- `services/oss/src/agent/app.py`: the `_agent` handler accepts `session_id` and passes it into `SessionConfig`.
- `normalizer.py`: the middleware recognizes `session_id` as a top-level request field (sitting next to `inputs` and `parameters`) and binds it to a handler argument of the same name.
- `protocol.ts`: `resolveRunSessionId(request, fallback)` returns `request.sessionId` when it is non-empty, else the harness fallback.
- `pi.ts` and `rivet.ts`: both engines call `resolveRunSessionId` and stamp the resolved id onto OTel config, `run.start`, and the returned run metadata.

## Key architectural decision to review

`session_id` is modeled as a request-envelope primitive, like a trace id or a span id, not as an HTTP header or an inputs field. See `normalizer.py:100-102`. The middleware already special-cases `request` and the `DATA_FIELDS` (inputs/outputs/parameters); this adds `session_id` as a third class of binding: a recognized top-level envelope field, extracted from `request.session_id` rather than from `request.data.inputs`.

The tradeoff to scrutinize: this hard-codes one field name in the middleware. A future second envelope field would need the same treatment, so if more arrive, this wants a small allowlist set rather than a chain of `elif name == ...` branches. The test `test_session_id_is_not_added_to_var_kwargs` pins the deliberate boundary: `session_id` binds only to an explicit handler argument, never to `**kwargs`, so it does not leak into handlers that did not ask for it.

The id is for correlation, not for state. The cold runtime still receives the full conversation in `messages`, so the runner does not load history from the id. The doc-comment edit on `AgentRunRequest.sessionId` in `protocol.ts:192` makes that contract explicit: read it and confirm no engine is treating the id as a key to replay history from.

## How to review this PR

1. Start with `protocol.ts`: read `resolveRunSessionId` (the whole behavior is here) and the `sessionId` doc comment.
2. Then `normalizer.py:100-102`: confirm the new branch sits before the `**kwargs` branch, so an explicit `session_id` argument wins over kwargs capture.
3. Then `pi.ts` and `rivet.ts`: confirm every place that previously used `session.sessionId` / `session.id` for tracing or returned metadata now uses the resolved id. In `pi.ts`, note the local `sessionId` moved up so OTel config gets the resolved value.
4. Then `app.py`: confirm `session_id` reaches `SessionConfig`.

Likely regression: a request with no `session_id` (plain `/invoke`, or the first turn of a server-minted session) must still get the harness id. `resolveRunSessionId({}, fallback)` returning the fallback covers this; the test on that line guards it.

## Tests / notes

- `test_normalizer_passthrough.py`: explicit-arg binding plus the `**kwargs` exclusion.
- `test_invoke_handler.py`: `session_id="sess_request"` reaches the backend `SessionConfig` (asserted via the fake backend's `created_session_ids`).
- `continuation.test.ts`: `resolveRunSessionId` prefers the platform id and falls back when absent.