### PR TITLE
feat(agent): route load-session through a no-op session store port

### DIFF
--- a/sdks/python/agenta/sdk/agents/__init__.py
+++ b/sdks/python/agenta/sdk/agents/__init__.py
@@ -49,7 +49,15 @@ from .dtos import (
     to_messages,
 )
 from .errors import ToolResolutionError, UnsupportedHarnessError
-from .interfaces import Backend, Environment, Harness, Sandbox, Session
+from .interfaces import (
+    Backend,
+    Environment,
+    Harness,
+    NoopSessionStore,
+    Sandbox,
+    Session,
+    SessionStore,
+)
 from .mcp import (
     MCPConfigurationError,
     MCPError,
@@ -157,6 +165,8 @@ __all__ = [
     "Backend",
     "Sandbox",
     "Session",
+    "SessionStore",
+    "NoopSessionStore",
     "Environment",
     "Harness",
     # Errors

--- a/sdks/python/agenta/sdk/agents/adapters/vercel/routing.py
+++ b/sdks/python/agenta/sdk/agents/adapters/vercel/routing.py
@@ -12,13 +12,15 @@ from fastapi.responses import JSONResponse, Response
 from agenta.sdk.contexts.tracing import tracing_context_manager
 from agenta.sdk.models.workflows import (
     LoadSessionRequest,
+    LoadSessionResponse,
     WorkflowBatchResponse,
     WorkflowInvokeRequest,
     WorkflowRequestData,
     WorkflowStreamingResponse,
 )
 
-from .messages import vercel_ui_messages_to_messages
+from ...interfaces import NoopSessionStore, SessionStore
+from .messages import message_to_vercel_ui_message, vercel_ui_messages_to_messages
 
 # An opaque, project-scoped session id (RFC §4.1): bounded length, restricted charset.
 _SESSION_ID_RE = re.compile(r"^[A-Za-z0-9._:-]{1,128}$")
@@ -122,12 +124,24 @@ def make_messages_endpoint(
     return messages_endpoint
 
 
-def make_load_session_endpoint():
-    """Build the v1 ``POST /load-session`` stub endpoint."""
+def make_load_session_endpoint(
+    *,
+    session_store: Optional[SessionStore] = None,
+):
+    """Build the v1 ``POST /load-session`` endpoint over the session-store port."""
+    store = session_store or NoopSessionStore()
 
     async def load_session_endpoint(req: Request, request: LoadSessionRequest):
+        messages = await store.load(request.session_id)
+        response = LoadSessionResponse(
+            session_id=request.session_id,
+            messages=[
+                message_to_vercel_ui_message(message, message_id=f"msg-{idx}")
+                for idx, message in enumerate(messages, start=1)
+            ],
+        )
         return JSONResponse(
-            content={"session_id": request.session_id, "messages": []},
+            content=response.model_dump(mode="json"),
         )
 
     return load_session_endpoint
@@ -146,6 +160,7 @@ def register_agent_message_routes(
     make_not_acceptable_response: Callable[[str, Any], Response],
     make_stream_response: Callable[[WorkflowStreamingResponse, str], Response],
     handle_failure: Callable[[Exception], Any],
+    session_store: Optional[SessionStore] = None,
 ) -> None:
     """Register ``/messages`` and ``/load-session`` on a FastAPI app/router target."""
     target.add_api_route(
@@ -165,6 +180,6 @@ def register_agent_message_routes(
     )
     target.add_api_route(
         prefix + "/load-session",
-        make_load_session_endpoint(),
+        make_load_session_endpoint(session_store=session_store),
         methods=["POST"],
     )

--- a/sdks/python/agenta/sdk/agents/interfaces.py
+++ b/sdks/python/agenta/sdk/agents/interfaces.py
@@ -86,6 +86,44 @@ class Session(ABC):
         return None
 
 
+class SessionStore(ABC):
+    """Durable conversation history behind the agent session id.
+
+    The cold runtime still receives the full message history on every turn. This port is the
+    place a platform-backed or file-backed store attaches when the server owns that history.
+    """
+
+    @abstractmethod
+    async def load(self, session_id: str) -> Sequence[Message]:
+        """Return the neutral message history for ``session_id``."""
+
+    @abstractmethod
+    async def save_turn(
+        self,
+        session_id: str,
+        *,
+        messages: Sequence[Message],
+        result: Optional[AgentResult] = None,
+    ) -> None:
+        """Persist one completed cold turn."""
+
+
+class NoopSessionStore(SessionStore):
+    """Session store adapter used until server-owned history persistence lands."""
+
+    async def load(self, session_id: str) -> Sequence[Message]:
+        return ()
+
+    async def save_turn(
+        self,
+        session_id: str,
+        *,
+        messages: Sequence[Message],
+        result: Optional[AgentResult] = None,
+    ) -> None:
+        return None
+
+
 # ---------------------------------------------------------------------------
 # Backend (the engine)
 # ---------------------------------------------------------------------------

--- a/sdks/python/oss/tests/pytest/utils/test_messages_endpoint.py
+++ b/sdks/python/oss/tests/pytest/utils/test_messages_endpoint.py
@@ -11,18 +11,22 @@ Two layers:
   without ``ag.init()``.
 """
 
+import json
 from unittest.mock import MagicMock, patch
 
 import pytest
 from fastapi import FastAPI
 from fastapi.testclient import TestClient
 
+from agenta.sdk.agents import Message
 from agenta.sdk.agents.adapters.vercel.routing import (
     inject_stream_session_id,
+    make_load_session_endpoint,
     resolve_session_id,
 )
 from agenta.sdk.decorators.routing import route
 from agenta.sdk.models.workflows import (
+    LoadSessionRequest,
     WorkflowBatchResponse,
     WorkflowServiceStatus,
     WorkflowStreamingResponse,
@@ -224,3 +228,29 @@ def test_load_session_returns_stub_history(client):
     res = client.post("/load-session", json={"session_id": "sess_abc"})
     assert res.status_code == 200
     assert res.json() == {"session_id": "sess_abc", "messages": []}
+
+
+@pytest.mark.asyncio
+async def test_load_session_uses_session_store_port():
+    class _Store:
+        async def load(self, session_id):
+            assert session_id == "sess_abc"
+            return [Message(role="user", content="hello")]
+
+        async def save_turn(self, session_id, *, messages, result=None):
+            raise AssertionError("load-session should only load")
+
+    endpoint = make_load_session_endpoint(session_store=_Store())
+    response = await endpoint(None, LoadSessionRequest(session_id="sess_abc"))
+
+    assert response.status_code == 200
+    assert json.loads(response.body) == {
+        "session_id": "sess_abc",
+        "messages": [
+            {
+                "id": "msg-1",
+                "role": "user",
+                "parts": [{"type": "text", "text": "hello"}],
+            }
+        ],
+    }


### PR DESCRIPTION
<!-- stack-nav:start -->
### This PR is part of a stack. Review bottom-up.

Each PR's diff is only its own delta. Merge from the bottom. This PR's base is #4767 (merge that first).

- #4758: Pi-backed agent workflow service, template, tracing
- #4759: runnable tools as agent configuration
- #4760: drive harnesses over ACP via rivet
- #4761: move the runtime into the SDK behind backend/harness ports
  - #4762: docker cleanups for the sidecar (side branch off #4761)
- #4763: typed SDK agent tool contracts
- #4764: resolve typed tools through the service
- #4765: deliver resolved tools through the runner
- #4766: remove Vercel adapter dead aliases
- #4767: propagate messages session ids to runner traces
- **#4768: load-session via a no-op session store port  <- you are here**
- #4769: advertise Vercel messages protocol headers
- #4770: agent-workflows ground truth + comment hygiene
<!-- stack-nav:end -->

## Context

This PR routes the agent `POST /load-session` endpoint through a new `SessionStore` port instead of returning a hardcoded empty stub. It sits on `fix/agent-session-id-tracing` and is slice #5 (cold session persistence) in `docs/design/agent-workflows/pr-stack.md`: the port-only seam.

The cold runtime still receives the full message history on every turn. This PR does not change that. It adds the seam where a server-owned history store will later attach, and it locks the load-session response shape before any storage lands.

## What this changes

`make_load_session_endpoint` used to build a fixed response. It now takes an optional `session_store` and calls `store.load(session_id)`, then converts each neutral `Message` back into a Vercel `UIMessage` at the adapter boundary.

The default store is `NoopSessionStore`. Its `load` returns `()` and its `save_turn` discards. So with no real adapter wired, the response is identical to before:

Before (hardcoded stub):
```json
{"session_id": "sess_abc", "messages": []}
```

After (NoopSessionStore, same output):
```json
{"session_id": "sess_abc", "messages": []}
```

With a real store that returns one user `Message`, the same path now produces:
```json
{"session_id": "sess_abc", "messages": [
  {"id": "msg-1", "role": "user", "parts": [{"type": "text", "text": "hello"}]}
]}
```

## Key architectural decision to review

Land the persistence seam now with no real adapter. `SessionStore` and `NoopSessionStore` live in `sdks/python/agenta/sdk/agents/interfaces.py`. The tradeoff: the API shape of `/load-session` and the `load` / `save_turn` contract get pinned and exported now, while actual storage ships in a later slice. The runtime keeps sending full history every turn, so nothing depends on the store for correctness yet. The risk is over-fitting the port to a store that does not exist. Check that `load` returning a `Sequence[Message]` and `save_turn` taking `messages` plus an optional `AgentResult` will fit a real platform-backed or file-backed adapter without a signature break.

The second thing to scrutinize is the conversion direction at the boundary in `routing.py`. Loaded neutral `Message` objects flow back out through `message_to_vercel_ui_message`, which is the inverse of the inbound `vercel_ui_messages_to_messages` on `/messages`. The store speaks neutral messages; the wire speaks Vercel `UIMessage`. Confirm those two directions stay symmetric so a saved turn round-trips.

## How to review this PR

1. Start with `sdks/python/agenta/sdk/agents/interfaces.py`. Read the `SessionStore` ABC and `NoopSessionStore`. Check the method signatures are the contract you want frozen.
2. Then `sdks/python/agenta/sdk/agents/adapters/vercel/routing.py`, `make_load_session_endpoint`. Confirm the `session_store or NoopSessionStore()` default preserves old behavior, and that `register_agent_message_routes` threads the optional `session_store` through.
3. Then `__init__.py` exports for `SessionStore` and `NoopSessionStore`.
4. Likely regression: a store that returns messages but the endpoint mislabels indices or roles. The `msg-{idx}` ids start at 1 per response, so they are not stable across calls. Check that no consumer treats them as durable.

## Tests / notes

`test_load_session_uses_session_store_port` injects a fake store, asserts `load` is called with the session id, and asserts the response renders one user message as a Vercel `UIMessage`. The existing `test_load_session_returns_stub_history` still passes against the default `NoopSessionStore`, which proves the no-op path is unchanged.