### PR TITLE
feat(sdk): advertise Vercel messages protocol headers

### DIFF
--- a/sdks/python/agenta/sdk/agents/adapters/vercel/__init__.py
+++ b/sdks/python/agenta/sdk/agents/adapters/vercel/__init__.py
@@ -12,9 +12,13 @@ from .messages import (
     vercel_ui_messages_to_messages,
 )
 from .routing import (
+    VERCEL_MESSAGE_PROTOCOL,
+    VERCEL_MESSAGE_PROTOCOL_HEADERS,
+    VERCEL_MESSAGE_PROTOCOL_VERSION,
     inject_stream_session_id,
     register_agent_message_routes,
     resolve_session_id,
+    set_vercel_message_protocol_headers,
 )
 from .sse import VERCEL_UI_MESSAGE_STREAM_HEADERS, vercel_sse_stream
 from .stream import agent_run_to_vercel_parts, ui_message_stream
@@ -27,6 +31,10 @@ __all__ = [
     "vercel_sse_stream",
     "resolve_session_id",
     "inject_stream_session_id",
+    "VERCEL_MESSAGE_PROTOCOL",
+    "VERCEL_MESSAGE_PROTOCOL_VERSION",
+    "VERCEL_MESSAGE_PROTOCOL_HEADERS",
+    "set_vercel_message_protocol_headers",
     "register_agent_message_routes",
     # Former flat-module names.
     "from_ui_messages",

--- a/sdks/python/agenta/sdk/agents/adapters/vercel/routing.py
+++ b/sdks/python/agenta/sdk/agents/adapters/vercel/routing.py
@@ -25,6 +25,20 @@ from .messages import message_to_vercel_ui_message, vercel_ui_messages_to_messag
 # An opaque, project-scoped session id (RFC §4.1): bounded length, restricted charset.
 _SESSION_ID_RE = re.compile(r"^[A-Za-z0-9._:-]{1,128}$")
 
+VERCEL_MESSAGE_PROTOCOL = "vercel"
+VERCEL_MESSAGE_PROTOCOL_VERSION = "v1"
+VERCEL_MESSAGE_PROTOCOL_HEADERS = {
+    "x-ag-messages-format": VERCEL_MESSAGE_PROTOCOL,
+    "x-ag-messages-version": VERCEL_MESSAGE_PROTOCOL_VERSION,
+}
+
+
+def set_vercel_message_protocol_headers(response: Response) -> Response:
+    """Stamp the default agent ``/messages`` protocol identity on an HTTP response."""
+    for key, value in VERCEL_MESSAGE_PROTOCOL_HEADERS.items():
+        response.headers.setdefault(key, value)
+    return response
+
 
 def resolve_session_id(session_id: Optional[str]) -> Optional[str]:
     """Mint a new id when absent, echo a valid one, or return ``None`` when invalid."""
@@ -69,9 +83,13 @@ def make_messages_endpoint(
 
         session_id = resolve_session_id(request.session_id)
         if session_id is None:
-            return JSONResponse(
-                status_code=400,
-                content={"detail": "session_id violates the allowed charset/length"},
+            return set_vercel_message_protocol_headers(
+                JSONResponse(
+                    status_code=400,
+                    content={
+                        "detail": "session_id violates the allowed charset/length"
+                    },
+                )
             )
 
         try:
@@ -104,22 +122,28 @@ def make_messages_endpoint(
                 and response.status.code is not None
                 and response.status.code >= 400
             ):
-                return make_json_response(response)
+                return set_vercel_message_protocol_headers(make_json_response(response))
 
             if want_stream:
                 if not isinstance(response, WorkflowStreamingResponse):
-                    return make_not_acceptable_response(str(requested), response)
+                    return set_vercel_message_protocol_headers(
+                        make_not_acceptable_response(str(requested), response)
+                    )
                 inject_stream_session_id(response, session_id)
-                return make_stream_response(response, "vercel")
+                return set_vercel_message_protocol_headers(
+                    make_stream_response(response, "vercel")
+                )
 
             if not isinstance(response, WorkflowBatchResponse):
-                return make_not_acceptable_response(
-                    requested or "application/json", response
+                return set_vercel_message_protocol_headers(
+                    make_not_acceptable_response(
+                        requested or "application/json", response
+                    )
                 )
-            return make_json_response(response)
+            return set_vercel_message_protocol_headers(make_json_response(response))
 
         except Exception as exception:
-            return await handle_failure(exception)
+            return set_vercel_message_protocol_headers(await handle_failure(exception))
 
     return messages_endpoint
 
@@ -140,8 +164,8 @@ def make_load_session_endpoint(
                 for idx, message in enumerate(messages, start=1)
             ],
         )
-        return JSONResponse(
-            content=response.model_dump(mode="json"),
+        return set_vercel_message_protocol_headers(
+            JSONResponse(content=response.model_dump(mode="json"))
         )
 
     return load_session_endpoint

--- a/sdks/python/oss/tests/pytest/utils/test_messages_endpoint.py
+++ b/sdks/python/oss/tests/pytest/utils/test_messages_endpoint.py
@@ -20,6 +20,8 @@ from fastapi.testclient import TestClient
 
 from agenta.sdk.agents import Message
 from agenta.sdk.agents.adapters.vercel.routing import (
+    VERCEL_MESSAGE_PROTOCOL,
+    VERCEL_MESSAGE_PROTOCOL_VERSION,
     inject_stream_session_id,
     make_load_session_endpoint,
     resolve_session_id,
@@ -67,6 +69,11 @@ async def test_inject_stream_session_id_stamps_first_start_part():
 _UI_MESSAGE = {"role": "user", "parts": [{"type": "text", "text": "hello"}]}
 
 
+def _assert_vercel_message_protocol(response):
+    assert response.headers["x-ag-messages-format"] == VERCEL_MESSAGE_PROTOCOL
+    assert response.headers["x-ag-messages-version"] == VERCEL_MESSAGE_PROTOCOL_VERSION
+
+
 def _build_client() -> TestClient:
     app = FastAPI()
 
@@ -78,7 +85,13 @@ def _build_client() -> TestClient:
         return await call_next(request)
 
     @route("/", app=app, flags={"is_agent": True})
-    async def agent(messages=None, inputs=None, parameters=None, stream=None):
+    async def agent(
+        messages=None,
+        inputs=None,
+        parameters=None,
+        stream=None,
+        session_id=None,
+    ):
         if stream:
 
             async def gen():
@@ -89,7 +102,12 @@ def _build_client() -> TestClient:
                 yield {"type": "finish"}
 
             return gen()
-        return {"role": "assistant", "content": "hi", "echoed": messages}
+        return {
+            "role": "assistant",
+            "content": "hi",
+            "echoed": messages,
+            "session_id": session_id,
+        }
 
     return TestClient(app)
 
@@ -145,9 +163,11 @@ def client():
 def test_messages_json_mints_session_and_folds_conversation(client):
     res = client.post("/messages", json={"data": {"messages": [_UI_MESSAGE]}})
     assert res.status_code == 200
+    _assert_vercel_message_protocol(res)
     body = res.json()
     assert body["session_id"].startswith("sess_")
     assert body["data"]["outputs"]["content"] == "hi"
+    assert body["data"]["outputs"]["session_id"] == body["session_id"]
     # The Vercel UIMessage was folded to a neutral {role, content} message for the handler.
     assert body["data"]["outputs"]["echoed"] == [{"role": "user", "content": "hello"}]
 
@@ -158,7 +178,9 @@ def test_messages_echoes_supplied_session_id(client):
         json={"session_id": "sess_keep", "data": {"messages": [_UI_MESSAGE]}},
     )
     assert res.status_code == 200
+    _assert_vercel_message_protocol(res)
     assert res.json()["session_id"] == "sess_keep"
+    assert res.json()["data"]["outputs"]["session_id"] == "sess_keep"
 
 
 def test_messages_sse_streams_with_done_and_session_in_start(client):
@@ -168,6 +190,7 @@ def test_messages_sse_streams_with_done_and_session_in_start(client):
         json={"session_id": "sess_abc", "data": {"messages": [_UI_MESSAGE]}},
     )
     assert res.status_code == 200
+    _assert_vercel_message_protocol(res)
     assert res.headers["x-vercel-ai-ui-message-stream"] == "v1"
     text = res.text
     assert '"sessionId": "sess_abc"' in text  # stamped onto the start part
@@ -208,6 +231,7 @@ def test_messages_sse_preserves_json_error_before_stream():
         )
 
     assert response.status_code == 500
+    _assert_vercel_message_protocol(response)
     assert response.headers["content-type"].startswith("application/json")
     assert "x-vercel-ai-ui-message-stream" not in response.headers
     body = response.json()
@@ -222,11 +246,13 @@ def test_messages_rejects_invalid_session_id(client):
         "/messages", json={"session_id": "bad id!", "data": {"messages": []}}
     )
     assert res.status_code == 400
+    _assert_vercel_message_protocol(res)
 
 
 def test_load_session_returns_stub_history(client):
     res = client.post("/load-session", json={"session_id": "sess_abc"})
     assert res.status_code == 200
+    _assert_vercel_message_protocol(res)
     assert res.json() == {"session_id": "sess_abc", "messages": []}
 
 
@@ -244,6 +270,8 @@ async def test_load_session_uses_session_store_port():
     response = await endpoint(None, LoadSessionRequest(session_id="sess_abc"))
 
     assert response.status_code == 200
+    assert response.headers["x-ag-messages-format"] == VERCEL_MESSAGE_PROTOCOL
+    assert response.headers["x-ag-messages-version"] == VERCEL_MESSAGE_PROTOCOL_VERSION
     assert json.loads(response.body) == {
         "session_id": "sess_abc",
         "messages": [


### PR DESCRIPTION
<!-- stack-nav:start -->
### This PR is part of a stack. Review bottom-up.

Each PR's diff is only its own delta. Merge from the bottom. This PR's base is #4768 (merge that first).

- #4758: Pi-backed agent workflow service, template, tracing
- #4759: runnable tools as agent configuration
- #4760: drive harnesses over ACP via rivet
- #4761: move the runtime into the SDK behind backend/harness ports
  - #4762: docker cleanups for the sidecar (side branch off #4761)
- #4763: typed SDK agent tool contracts
- #4764: resolve typed tools through the service
- #4765: deliver resolved tools through the runner
- #4766: remove Vercel adapter dead aliases
- #4767: propagate messages session ids to runner traces
- #4768: load-session via a no-op session store port
- **#4769: advertise Vercel messages protocol headers  <- you are here**
- #4770: agent-workflows ground truth + comment hygiene
<!-- stack-nav:end -->

## Context

The agent `/messages` endpoint speaks the Vercel UIMessage wire format, but the response never said so. A client had to assume the format and version out of band. This PR makes the server declare both on every response, so a client can read them and branch on what the server actually speaks.

Base branch: `feat/agent-load-session-store-port`. This is the Protocol Shell Hardening slice (#2) from `docs/design/agent-workflows/pr-stack.md`, which makes `/messages` reviewable as an HTTP contract.

## What this changes

The endpoint now stamps two response headers:

- `x-ag-messages-format: vercel`
- `x-ag-messages-version: v1`

A new helper, `set_vercel_message_protocol_headers`, applies both with `setdefault`, so it never clobbers a header a path already set. It wraps every response the adapter returns:

- `/messages` success JSON (batch response)
- `/messages` success SSE (Vercel stream)
- `/messages` `400` for an invalid `session_id`
- `/messages` upstream error JSON (status code at or above 400)
- `/messages` `406` not-acceptable, for both the stream and batch type mismatches
- `/messages` exception path (`handle_failure`)
- `/load-session` JSON

Before, a 400 looked like:

```
HTTP/1.1 400 Bad Request
content-type: application/json
```

After:

```
HTTP/1.1 400 Bad Request
content-type: application/json
x-ag-messages-format: vercel
x-ag-messages-version: v1
```

The header constants, the headers map, and the helper are also exported from `vercel/__init__.py` so callers and tests can reference them by name instead of hardcoding strings.

## Key architectural decision to review

The decision to scrutinize is versioning the wire protocol through response headers rather than the response body. The server names the format (`vercel`) and a version (`v1`) on the envelope, so a client can detect both before it parses anything. The body stays a pure payload.

The tradeoff is that header stamping is opt-in per return path. Nothing in FastAPI forces a `/messages` response through the helper. Each `return` must wrap its response by hand. `set_vercel_message_protocol_headers` lives in `routing.py` and the call sites are spread across `make_messages_endpoint` and `make_load_session_endpoint`. A middleware would stamp every response unconditionally, but it would also touch responses from other routes and would need to know which routes are agent message routes. The per-return approach keeps the blast radius to this adapter at the cost of a contributor remembering to wrap each new exit.

## How to review this PR

Read `sdks/python/agenta/sdk/agents/adapters/vercel/routing.py` first.

1. Check the constants and the helper at lines 28 to 40. Confirm `setdefault` is intentional, so a path that needs a different format or version can override it.
2. Walk every `return` in `make_messages_endpoint` (lines 84 to 146) and confirm each one passes through the helper. The 400, the upstream-error JSON, both not-acceptable branches, the stream, the success JSON, and the `except` all wrap.
3. Confirm `make_load_session_endpoint` (lines 167 to 169) wraps its only return.
4. Check the exports in `vercel/__init__.py`.

The likely regression is a new `/messages` return path that forgets the helper, so that one response ships without the headers and a client misreads the format. The not-acceptable and exception paths are the easiest to overlook, since they read like error plumbing rather than protocol surface.

## Tests / notes

`sdks/python/oss/tests/pytest/utils/test_messages_endpoint.py` adds a `_assert_vercel_message_protocol` check and asserts the headers on the success JSON, the echoed-session response, the SSE stream, the pre-stream 500, the invalid-session 400, and both `/load-session` paths (route and direct endpoint). The direct `/load-session` test asserts the literal header values, which pins the constants. No assertion yet covers the two not-acceptable (406) branches.