### PR TITLE
feat(frontend): agent config playground controls

### DIFF
--- a/web/oss/src/components/pages/app-management/components/CreateAppDropdown/index.tsx
+++ b/web/oss/src/components/pages/app-management/components/CreateAppDropdown/index.tsx
@@ -34,6 +34,12 @@ const ITEMS: CreateAppDropdownItem[] = [
         description: "Single-shot prompt completion.",
         testId: "create-app-dropdown-completion",
     },
+    {
+        type: "agent",
+        label: "Agent",
+        description: "Agent that uses tools over multiple turns.",
+        testId: "create-app-dropdown-agent",
+    },
 ]
 
 interface CreateAppDropdownProps {

--- a/web/oss/src/components/pages/app-management/components/CreateAppDropdown/index.tsx
+++ b/web/oss/src/components/pages/app-management/components/CreateAppDropdown/index.tsx
@@ -34,12 +34,6 @@ const ITEMS: CreateAppDropdownItem[] = [
         description: "Single-shot prompt completion.",
         testId: "create-app-dropdown-completion",
     },
-    {
-        type: "agent",
-        label: "Agent",
-        description: "Agent that uses tools over multiple turns.",
-        testId: "create-app-dropdown-agent",
-    },
 ]
 
 interface CreateAppDropdownProps {

--- a/web/oss/src/components/pages/app-management/modals/CreateAppTypeModal/index.tsx
+++ b/web/oss/src/components/pages/app-management/modals/CreateAppTypeModal/index.tsx
@@ -51,6 +51,12 @@ const OPTIONS: CreateAppTypeOption[] = [
         description: "Single-shot prompt completion.",
         testId: "create-app-type-modal-completion",
     },
+    {
+        type: "agent",
+        label: "Agent",
+        description: "Agent that uses tools over multiple turns.",
+        testId: "create-app-type-modal-agent",
+    },
 ]
 
 interface CreateAppTypeModalProps {

--- a/web/oss/src/components/pages/app-management/modals/CreateAppTypeModal/index.tsx
+++ b/web/oss/src/components/pages/app-management/modals/CreateAppTypeModal/index.tsx
@@ -51,12 +51,6 @@ const OPTIONS: CreateAppTypeOption[] = [
         description: "Single-shot prompt completion.",
         testId: "create-app-type-modal-completion",
     },
-    {
-        type: "agent",
-        label: "Agent",
-        description: "Agent that uses tools over multiple turns.",
-        testId: "create-app-type-modal-agent",
-    },
 ]
 
 interface CreateAppTypeModalProps {

--- a/web/oss/src/components/pages/prompts/assets/iconHelpers.tsx
+++ b/web/oss/src/components/pages/prompts/assets/iconHelpers.tsx
@@ -1,6 +1,6 @@
 import React from "react"
 
-import {ChatDotsIcon, NoteIcon} from "@phosphor-icons/react"
+import {ChatDotsIcon, NoteIcon, RobotIcon} from "@phosphor-icons/react"
 
 import CompletionAppIcon from "../components/CompletionAppIcon"
 import SetupWorkflowIcon from "../components/SetupWorkflowIcon"
@@ -8,6 +8,8 @@ import SetupWorkflowIcon from "../components/SetupWorkflowIcon"
 export const getAppTypeIcon = (appType?: string) => {
     const normalizedType = appType?.toLowerCase()
 
+    if (normalizedType?.includes("agent"))
+        return <RobotIcon size={16} className="text-zinc-9 dark:text-white" />
     if (normalizedType?.includes("chat"))
         return <ChatDotsIcon size={16} className="text-zinc-9 dark:text-white" />
     if (normalizedType?.includes("completion"))

--- a/web/packages/agenta-entities/src/workflow/state/appUtils.ts
+++ b/web/packages/agenta-entities/src/workflow/state/appUtils.ts
@@ -64,7 +64,7 @@ export const appTemplatesDataAtom = atom<WorkflowCatalogTemplate[]>((get) => {
  * App types supported by the drawer flow. "custom" routes through the
  * existing CustomWorkflowModal and does NOT use this factory.
  */
-export type AppType = "chat" | "completion"
+export type AppType = "chat" | "completion" | "agent"
 
 export interface CreateEphemeralAppFromTemplateParams {
     type: AppType
@@ -206,7 +206,9 @@ export async function createEphemeralAppFromTemplate({
             is_code: false,
             is_match: false,
             is_feedback: false,
-            is_chat: type === "chat",
+            // Agent takes messages-in / returns a final message, so it runs in
+            // chat mode like `chat` (backend infers is_chat from messages-in too).
+            is_chat: type === "chat" || type === "agent",
             has_url: false,
             has_script: false,
             has_handler: false,

--- a/web/packages/agenta-entity-ui/src/DrillInView/SchemaControls/AgentConfigControl.tsx
+++ b/web/packages/agenta-entity-ui/src/DrillInView/SchemaControls/AgentConfigControl.tsx
@@ -1,0 +1,324 @@
+/**
+ * AgentConfigControl
+ *
+ * One composite control for the whole agent config, dispatched from
+ * `x-ag-type: "agent_config"` / `x-ag-type-ref: "agent_config"` (see SchemaPropertyRenderer).
+ * It reuses the existing controls rather than inventing new ones: the model selector
+ * (GroupedChoiceControl), the tool picker (ToolSelectorPopover + ToolItemControl), the MCP
+ * server editor (McpServerItemControl), enum selects (harness, sandbox, permission policy),
+ * and a textarea (agents_md). The field shape is the `agent_config` catalog type generated
+ * from the SDK model (AgentConfigSchema in agenta.sdk.utils.types); the agent service ships a
+ * thin `x-ag-type-ref` the playground resolves and reads back (services/oss/src/agent).
+ */
+import {useCallback, useMemo} from "react"
+
+import type {SchemaProperty} from "@agenta/entities/shared"
+import {useDrillInUI} from "@agenta/ui/drill-in"
+import {cn} from "@agenta/ui/styles"
+import {Plus} from "@phosphor-icons/react"
+import {Button, Typography} from "antd"
+
+import {EnumSelectControl} from "./EnumSelectControl"
+import {GroupedChoiceControl} from "./GroupedChoiceControl"
+import {McpServerItemControl} from "./McpServerItemControl"
+import {TextInputControl} from "./TextInputControl"
+import {ToolItemControl} from "./ToolItemControl"
+import {ToolSelectorPopover, type ToolSelectionMeta} from "./ToolSelectorPopover"
+import {type ToolObj} from "./toolUtils"
+
+export interface AgentConfigControlProps {
+    schema?: SchemaProperty | null
+    label?: string
+    value?: Record<string, unknown> | null
+    onChange: (value: Record<string, unknown>) => void
+    description?: string
+    withTooltip?: boolean
+    disabled?: boolean
+    className?: string
+}
+
+/** Read the function name of a tool object (the gateway slug for Composio tools). */
+function toolName(tool: unknown): string | undefined {
+    if (!tool || typeof tool !== "object") return undefined
+    const fn = (tool as Record<string, unknown>).function
+    if (!fn || typeof fn !== "object") return undefined
+    const name = (fn as Record<string, unknown>).name
+    return typeof name === "string" ? name : undefined
+}
+
+function isBuiltinPayloadMatch(tool: unknown, payload: ToolObj): boolean {
+    if (!tool || typeof tool !== "object" || Array.isArray(tool)) return false
+    if (!payload || typeof payload !== "object" || Array.isArray(payload)) return false
+
+    const toolObj = tool as Record<string, unknown>
+    const payloadObj = payload as Record<string, unknown>
+
+    if (typeof payloadObj.type === "string" && toolObj.type === payloadObj.type) return true
+    if (typeof payloadObj.name === "string" && toolObj.name === payloadObj.name) return true
+
+    const payloadKeys = Object.keys(payloadObj)
+    return (
+        payloadKeys.length === 1 &&
+        payloadKeys[0] !== "type" &&
+        payloadKeys[0] !== "name" &&
+        payloadKeys[0] in toolObj
+    )
+}
+
+export function AgentConfigControl({
+    schema,
+    value,
+    onChange,
+    withTooltip,
+    disabled,
+    className,
+}: AgentConfigControlProps) {
+    const {EditorProvider} = useDrillInUI()
+    const config = (value ?? {}) as Record<string, unknown>
+    const props = (schema?.properties ?? {}) as Record<string, SchemaProperty>
+
+    // Update a single field of the agent config, leaving the rest intact.
+    const setField = useCallback(
+        (key: string, fieldValue: unknown) => onChange({...config, [key]: fieldValue}),
+        [config, onChange],
+    )
+
+    // Tools live as a flat array on the agent config (the same tool-object shape the
+    // prompt control uses, so the backend resolver parses them identically).
+    const tools = useMemo(
+        () => (Array.isArray(config.tools) ? (config.tools as unknown[]) : []),
+        [config.tools],
+    )
+    const setTools = useCallback((next: unknown[]) => setField("tools", next), [setField])
+
+    const handleAddTool = useCallback(
+        (tool: ToolObj, meta?: ToolSelectionMeta) => {
+            const next =
+                meta && tool && typeof tool === "object" && !Array.isArray(tool)
+                    ? {
+                          ...(tool as Record<string, unknown>),
+                          agenta_metadata: {
+                              ...(((tool as Record<string, unknown>).agenta_metadata as
+                                  | Record<string, unknown>
+                                  | undefined) ?? {}),
+                              ...meta,
+                          },
+                      }
+                    : tool
+            setTools([...tools, next])
+        },
+        [tools, setTools],
+    )
+
+    const handleToolChange = useCallback(
+        (index: number, next: ToolObj) => {
+            const updated = [...tools]
+            updated[index] = next
+            setTools(updated)
+        },
+        [tools, setTools],
+    )
+
+    const handleToolDelete = useCallback(
+        (index: number) => setTools(tools.filter((_, i) => i !== index)),
+        [tools, setTools],
+    )
+
+    const handleRemoveToolByName = useCallback(
+        (name: string) => setTools(tools.filter((tool) => toolName(tool) !== name)),
+        [tools, setTools],
+    )
+
+    const handleRemoveBuiltinTool = useCallback(
+        (toolToRemove: ToolObj) => {
+            let removed = false
+            const updated = tools.filter((tool) => {
+                if (removed) return true
+                if (!isBuiltinPayloadMatch(tool, toolToRemove)) return true
+                removed = true
+                return false
+            })
+            if (removed) setTools(updated)
+        },
+        [tools, setTools],
+    )
+
+    const selectedToolNames = useMemo(
+        () => new Set(tools.map(toolName).filter((n): n is string => Boolean(n))),
+        [tools],
+    )
+
+    // MCP servers are a sibling of tools: a flat array on the agent config. Each entry is the
+    // open McpServer shape (name + stdio command/args/env or remote url, secret names), edited
+    // as JSON the backend resolver parses identically to `tools`.
+    const mcpServers = useMemo(
+        () => (Array.isArray(config.mcp_servers) ? (config.mcp_servers as unknown[]) : []),
+        [config.mcp_servers],
+    )
+    const setMcpServers = useCallback(
+        (next: unknown[]) => setField("mcp_servers", next),
+        [setField],
+    )
+    const handleAddMcpServer = useCallback(
+        () => setMcpServers([...mcpServers, {name: "", transport: "stdio", command: "", args: []}]),
+        [mcpServers, setMcpServers],
+    )
+    const handleMcpServerChange = useCallback(
+        (index: number, next: Record<string, unknown>) => {
+            const updated = [...mcpServers]
+            updated[index] = next
+            setMcpServers(updated)
+        },
+        [mcpServers, setMcpServers],
+    )
+    const handleMcpServerDelete = useCallback(
+        (index: number) => setMcpServers(mcpServers.filter((_, i) => i !== index)),
+        [mcpServers, setMcpServers],
+    )
+
+    // ``agents_md`` is the catalog-schema field; ``instructions`` is read as a fallback so an
+    // already-stored agent config (the legacy key) still populates the editor.
+    const agentsMd =
+        (config.agents_md as string | null | undefined) ??
+        (config.instructions as string | null | undefined) ??
+        null
+
+    return (
+        <div className={cn("flex flex-col gap-3", className)}>
+            <TextInputControl
+                schema={props.agents_md}
+                label="Instructions"
+                value={agentsMd}
+                onChange={(v) => setField("agents_md", v)}
+                description={props.agents_md?.description as string | undefined}
+                withTooltip={withTooltip}
+                disabled={disabled}
+                multiline
+            />
+
+            <GroupedChoiceControl
+                schema={props.model}
+                label="Model"
+                value={(config.model as string | null) ?? null}
+                onChange={(v) => setField("model", v)}
+                withTooltip={withTooltip}
+                disabled={disabled}
+            />
+
+            {/* Tools */}
+            <div className="flex flex-col gap-2">
+                {tools.length > 0 && (
+                    <div className="flex flex-col gap-2">
+                        {tools.map((tool, index) => {
+                            const control = (
+                                <ToolItemControl
+                                    key={`tool-${index}`}
+                                    value={tool}
+                                    onChange={(v) => handleToolChange(index, v)}
+                                    onDelete={disabled ? undefined : () => handleToolDelete(index)}
+                                    disabled={disabled}
+                                />
+                            )
+                            return EditorProvider ? (
+                                <EditorProvider
+                                    key={`tool-editor-${index}`}
+                                    codeOnly
+                                    language="json"
+                                    showToolbar={false}
+                                    enableTokens={false}
+                                    id={`agent-tool-editor-${index}`}
+                                >
+                                    {control}
+                                </EditorProvider>
+                            ) : (
+                                control
+                            )
+                        })}
+                    </div>
+                )}
+                {!disabled && (
+                    <div>
+                        <ToolSelectorPopover
+                            onAddTool={handleAddTool}
+                            onRemoveTool={handleRemoveToolByName}
+                            onRemoveBuiltinTool={handleRemoveBuiltinTool}
+                            selectedToolNames={selectedToolNames}
+                            selectedTools={tools as ToolObj[]}
+                            existingToolCount={tools.length}
+                        />
+                    </div>
+                )}
+            </div>
+
+            {/* MCP servers */}
+            <div className="flex flex-col gap-2">
+                <Typography.Text className="text-sm font-medium">MCP servers</Typography.Text>
+                {mcpServers.length > 0 && (
+                    <div className="flex flex-col gap-2">
+                        {mcpServers.map((server, index) => {
+                            const control = (
+                                <McpServerItemControl
+                                    key={`mcp-${index}`}
+                                    value={server}
+                                    onChange={(v) => handleMcpServerChange(index, v)}
+                                    onDelete={
+                                        disabled ? undefined : () => handleMcpServerDelete(index)
+                                    }
+                                    disabled={disabled}
+                                />
+                            )
+                            return EditorProvider ? (
+                                <EditorProvider
+                                    key={`mcp-editor-${index}`}
+                                    codeOnly
+                                    language="json"
+                                    showToolbar={false}
+                                    enableTokens={false}
+                                    id={`agent-mcp-editor-${index}`}
+                                >
+                                    {control}
+                                </EditorProvider>
+                            ) : (
+                                control
+                            )
+                        })}
+                    </div>
+                )}
+                {!disabled && (
+                    <div>
+                        <Button size="small" icon={<Plus size={14} />} onClick={handleAddMcpServer}>
+                            Add MCP server
+                        </Button>
+                    </div>
+                )}
+            </div>
+
+            <EnumSelectControl
+                schema={props.harness}
+                label="Harness"
+                value={(config.harness as string | null) ?? null}
+                onChange={(v) => setField("harness", v)}
+                withTooltip={withTooltip}
+                disabled={disabled}
+            />
+
+            <EnumSelectControl
+                schema={props.sandbox}
+                label="Sandbox"
+                value={(config.sandbox as string | null) ?? null}
+                onChange={(v) => setField("sandbox", v)}
+                withTooltip={withTooltip}
+                disabled={disabled}
+            />
+
+            <EnumSelectControl
+                schema={props.permission_policy}
+                label="Permission policy"
+                value={(config.permission_policy as string | null) ?? null}
+                onChange={(v) => setField("permission_policy", v)}
+                withTooltip={withTooltip}
+                disabled={disabled}
+            />
+        </div>
+    )
+}

--- a/web/packages/agenta-entity-ui/src/DrillInView/SchemaControls/McpServerItemControl.tsx
+++ b/web/packages/agenta-entity-ui/src/DrillInView/SchemaControls/McpServerItemControl.tsx
@@ -11,7 +11,7 @@
  */
 import {memo, useCallback, useEffect, useRef, useState} from "react"
 
-import {safeStringify} from "@agenta/shared/utils"
+import {isPlainObject, safeStringify} from "@agenta/shared/utils"
 import {useDrillInUI} from "@agenta/ui/drill-in"
 import {MinusCircle} from "@phosphor-icons/react"
 import {Button, Tooltip, Typography} from "antd"
@@ -32,10 +32,11 @@ export interface McpServerItemControlProps {
 
 function toServerObj(value: unknown): Record<string, unknown> {
     try {
-        if (typeof value === "string")
-            return value ? (JSON.parse(value) as Record<string, unknown>) : {}
-        if (value && typeof value === "object" && !Array.isArray(value))
-            return value as Record<string, unknown>
+        if (typeof value === "string") {
+            const parsed = value ? JSON.parse(value) : {}
+            return isPlainObject(parsed) ? parsed : {}
+        }
+        if (isPlainObject(value)) return value
     } catch {
         // fall through to empty object
     }
@@ -71,7 +72,8 @@ export const McpServerItemControl = memo(function McpServerItemControl({
             if (disabled) return
             setEditorText(text)
             try {
-                const parsed = text ? (JSON.parse(text) as Record<string, unknown>) : {}
+                const parsed = text ? JSON.parse(text) : {}
+                if (!isPlainObject(parsed)) return
                 lastExternalRef.current = safeStringify(parsed)
                 onChange?.(parsed)
             } catch {

--- a/web/packages/agenta-entity-ui/src/DrillInView/SchemaControls/McpServerItemControl.tsx
+++ b/web/packages/agenta-entity-ui/src/DrillInView/SchemaControls/McpServerItemControl.tsx
@@ -1,0 +1,137 @@
+/**
+ * McpServerItemControl
+ *
+ * Schema-driven control for one declared MCP server on the agent config. MCP servers are a
+ * sibling of `tools` (not a tool variant): a server names a transport (stdio command/args/env
+ * or a remote url), an optional tool allowlist, and the vault secret names the backend resolves
+ * into its env at run time. The shape is open enough that a JSON editor is the pragmatic v1 —
+ * the same approach ToolItemControl takes for tool definitions — with a name header and a delete
+ * control. The typed shape lives in the `agent_config` catalog type (AgentConfigSchema /
+ * McpServer in the SDK); this control just edits one entry of the `mcp_servers` array.
+ */
+import {memo, useCallback, useEffect, useRef, useState} from "react"
+
+import {safeStringify} from "@agenta/shared/utils"
+import {useDrillInUI} from "@agenta/ui/drill-in"
+import {MinusCircle} from "@phosphor-icons/react"
+import {Button, Tooltip, Typography} from "antd"
+import clsx from "clsx"
+
+export interface McpServerItemControlProps {
+    /** MCP server value (object or JSON string) */
+    value: unknown
+    /** Called when the server value changes (only on valid JSON) */
+    onChange?: (value: Record<string, unknown>) => void
+    /** Called when the server should be removed */
+    onDelete?: () => void
+    /** Whether the control is read-only */
+    disabled?: boolean
+    /** Additional CSS classes */
+    className?: string
+}
+
+function toServerObj(value: unknown): Record<string, unknown> {
+    try {
+        if (typeof value === "string")
+            return value ? (JSON.parse(value) as Record<string, unknown>) : {}
+        if (value && typeof value === "object" && !Array.isArray(value))
+            return value as Record<string, unknown>
+    } catch {
+        // fall through to empty object
+    }
+    return {}
+}
+
+export const McpServerItemControl = memo(function McpServerItemControl({
+    value,
+    onChange,
+    onDelete,
+    disabled = false,
+    className,
+}: McpServerItemControlProps) {
+    const {SharedEditor} = useDrillInUI()
+    const serverObj = toServerObj(value)
+    const name =
+        typeof serverObj.name === "string" && serverObj.name ? serverObj.name : "MCP server"
+
+    const [editorText, setEditorText] = useState<string>(() => safeStringify(serverObj ?? {}))
+
+    // Reset the editor text when the value changes from outside (add/remove/reorder).
+    const lastExternalRef = useRef<string>(safeStringify(serverObj ?? {}))
+    useEffect(() => {
+        const next = safeStringify(toServerObj(value) ?? {})
+        if (next !== lastExternalRef.current) {
+            lastExternalRef.current = next
+            setEditorText(next)
+        }
+    }, [value])
+
+    const handleEditorChange = useCallback(
+        (text: string) => {
+            if (disabled) return
+            setEditorText(text)
+            try {
+                const parsed = text ? (JSON.parse(text) as Record<string, unknown>) : {}
+                lastExternalRef.current = safeStringify(parsed)
+                onChange?.(parsed)
+            } catch {
+                // Keep the invalid text in the editor; don't propagate until it parses.
+            }
+        },
+        [disabled, onChange],
+    )
+
+    const header = (
+        <div className="w-full flex items-center justify-between py-1">
+            <Typography.Text strong className="text-sm truncate">
+                {name}
+            </Typography.Text>
+            {!disabled && onDelete && (
+                <Tooltip title="Remove">
+                    <Button
+                        icon={<MinusCircle size={14} />}
+                        type="text"
+                        size="small"
+                        onClick={onDelete}
+                        className="invisible group-hover/mcp:visible shrink-0"
+                    />
+                </Tooltip>
+            )}
+        </div>
+    )
+
+    if (!SharedEditor) {
+        return (
+            <div className={clsx("group/mcp flex flex-col gap-2 border rounded-lg p-3", className)}>
+                {header}
+                <textarea
+                    className="font-mono text-xs p-2 border rounded min-h-[120px] resize-y w-full"
+                    value={editorText}
+                    onChange={(e) => handleEditorChange(e.target.value)}
+                    readOnly={disabled}
+                />
+            </div>
+        )
+    }
+
+    return (
+        <div className={clsx("group/mcp flex flex-col w-full max-w-full", className)}>
+            <SharedEditor
+                initialValue={editorText}
+                editorProps={{
+                    codeOnly: true,
+                    language: "json",
+                    showLineNumbers: true,
+                    noProvider: true,
+                }}
+                handleChange={handleEditorChange}
+                noProvider
+                disableDebounce
+                syncWithInitialValueChanges
+                editorType="border"
+                state={disabled ? "readOnly" : "filled"}
+                header={header}
+            />
+        </div>
+    )
+})

--- a/web/packages/agenta-entity-ui/src/DrillInView/SchemaControls/SchemaPropertyRenderer.tsx
+++ b/web/packages/agenta-entity-ui/src/DrillInView/SchemaControls/SchemaPropertyRenderer.tsx
@@ -19,6 +19,7 @@ import {formatLabel} from "@agenta/ui/drill-in"
 import {Typography} from "antd"
 import clsx from "clsx"
 
+import {AgentConfigControl} from "./AgentConfigControl"
 import {BooleanToggleControl} from "./BooleanToggleControl"
 import {CodeEditorControl} from "./CodeEditorControl"
 import {EnumSelectControl} from "./EnumSelectControl"
@@ -95,6 +96,7 @@ function getControlType(
     | "grouped_choice"
     | "feedback_config"
     | "fields_tags_editor"
+    | "agent_config"
     | "hidden"
     | "unknown" {
     if (forceType) return forceType
@@ -124,6 +126,9 @@ function getControlType(
     }
     if (xAgTypeRef === "code" || xAgType === "code") {
         return "code"
+    }
+    if (xAgTypeRef === "agent_config" || xAgType === "agent_config") {
+        return "agent_config"
     }
 
     // When schema is null, fall back to value-based detection
@@ -417,6 +422,22 @@ export const SchemaPropertyRenderer = memo(function SchemaPropertyRenderer({
                     value={value as unknown[] | null}
                     onChange={(v) => onChange(v)}
                     description={tooltipDesc}
+                    disabled={disabled}
+                    className={className}
+                />
+            )
+
+        case "agent_config":
+            // Render the whole agent config (instructions, model, tools, runtime) as one
+            // composite control that reuses the model selector, tool picker, and enums.
+            return (
+                <AgentConfigControl
+                    schema={resolvedSchema}
+                    label={displayLabel}
+                    value={value as Record<string, unknown> | null}
+                    onChange={(v) => onChange(v)}
+                    description={tooltipDesc}
+                    withTooltip={withTooltip}
                     disabled={disabled}
                     className={className}
                 />

--- a/web/packages/agenta-entity-ui/src/DrillInView/SchemaControls/index.ts
+++ b/web/packages/agenta-entity-ui/src/DrillInView/SchemaControls/index.ts
@@ -61,6 +61,12 @@ export type {ToolSelectorPopoverProps} from "./ToolSelectorPopover"
 export {TOOL_PROVIDERS_META, TOOL_SPECS} from "./toolUtils"
 export type {ToolObj, ToolFunction} from "./toolUtils"
 
+export {McpServerItemControl} from "./McpServerItemControl"
+export type {McpServerItemControlProps} from "./McpServerItemControl"
+
+export {AgentConfigControl} from "./AgentConfigControl"
+export type {AgentConfigControlProps} from "./AgentConfigControl"
+
 // ============================================================================
 // COMPOSITE CONTROLS
 // ============================================================================


### PR DESCRIPTION
<!-- stack-nav:start -->
### Agent-workflows: functional PR set

Sliced by functional area, final code only (no intermediate churn). Most PRs are independent off `main`; two pairs are stacked. This PR's base is `main`.

- #4771: SDK agent runtime: ports, adapters, tools, messages protocol
  - #4772: Agent service + tool-resolution API
- #4773: Runner wire contract + tool execution
  - #4774: Runner engines, server, tracing
- **#4775: Playground agent config UI  <- you are here**
- #4776: Hosting compose wiring
- #4777: Docs: design + ground truth
<!-- stack-nav:end -->

## Context

The playground needs to edit a typed agent config: instructions, model, tools, MCP servers, and runtime settings (harness, sandbox, permission policy). The backend already exposes an `agent_config` catalog type generated from the SDK model, and ships a thin `x-ag-type-ref: "agent_config"` marker on the field. This PR is the frontend that resolves that marker and renders the form. It branches from `main` and is one functional slice of the agent-workflows feature, showing the final code for the playground controls.

## What this changes

The schema renderer now recognizes the `agent_config` marker and dispatches the whole config object to one composite control, `AgentConfigControl`. That control does not invent new widgets. It reuses the model selector, the tool picker, the enum selects, and a textarea, and adds one new piece: `McpServerItemControl`, a JSON editor for a single MCP server entry. The create-app dropdown and the create-app type modal both gain an "Agent" option with a robot icon. An agent app runs in chat mode: `is_chat` is now true for type `chat` or `agent`.

## Key architectural decision to review

The form is driven by the catalog type, not hand-built. The backend marks the field with `x-ag-type-ref`, and the frontend dispatches on that marker (`SchemaPropertyRenderer.tsx:130`). The control then reads each sub-field's schema off `schema.properties` and renders it with an existing control. This keeps the form in sync with the typed schema as long as the property names match: `agents_md`, `model`, `tools`, `mcp_servers`, `harness`, `sandbox`, `permission_policy`. The tradeoff is the coupling lives in property-name string keys, not in types. If the SDK renames a field, the control silently drops it rather than failing the build. Scrutinize whether that contract is documented and tested well enough to survive a backend rename, and whether the two read-back fallbacks (`agents_md` falling back to `instructions`) are the right place for legacy compatibility.

The second decision worth a look: `tools` and `mcp_servers` are both flat arrays on the config, edited as raw JSON, because the backend resolver parses them. The MCP editor only propagates `onChange` when the text parses as JSON, and keeps invalid text local until it does. That matches how `ToolItemControl` already works, so it is consistent, but it means a half-typed server entry is held outside the form value.

## How to review this PR

Read `AgentConfigControl.tsx` first. Check that every sub-control receives the matching `props.<field>` schema and that `setField` merges rather than replaces the config object. Confirm the tool helpers (`handleAddTool`, `handleRemoveToolByName`, `selectedToolNames`) all key off `toolName`, which reads `function.name`. A tool object missing that path would be invisible to the selected-set and the remove-by-name path, which is the likely regression.

Then read `McpServerItemControl.tsx`. The `lastExternalRef` guard resets the editor text only on external value changes (add, remove, reorder) and not on the user's own keystrokes. Check that the parse-then-propagate path does not clobber in-progress edits, and that an empty string maps to `{}` rather than throwing.

Then `appUtils.ts:211` for the `is_chat` change, and the two create-app menus plus `iconHelpers.tsx` for the Agent option and robot icon.

## Tests / notes

No automated tests ship with this slice. Watch the schema-name contract: the control depends on the SDK field names staying stable, and a rename surfaces as a missing sub-control rather than a type error.