### PR TITLE
chore(hosting): wire the agent runner sidecar into compose

### DIFF
--- a/hosting/docker-compose/ee/docker-compose.dev.yml
+++ b/hosting/docker-compose/ee/docker-compose.dev.yml
@@ -411,8 +411,10 @@ services:
             DOCKER_NETWORK_MODE: ${DOCKER_NETWORK_MODE:-bridge}
             # Agent workflow: reach the agent runner sidecar in-network.
             AGENTA_AGENT_PI_URL: http://agent-pi:8765
-            # Agent runtime (WP-8): drive the harness over ACP via a rivet daemon.
+            # Agent runtime: drive the harness over ACP via a rivet daemon.
             # Harness (pi/claude) and sandbox (local/daytona) are independent axes.
+            # The agent-pi sidecar files are introduced by PR #4778, so this compose
+            # wiring must land after #4778 or be reviewed with that branch applied.
             AGENTA_AGENT_RUNTIME: ${AGENTA_AGENT_RUNTIME:-rivet}
             AGENTA_AGENT_HARNESS: ${AGENTA_AGENT_HARNESS:-pi}
             AGENTA_AGENT_SANDBOX: ${AGENTA_AGENT_SANDBOX:-local}
@@ -437,6 +439,7 @@ services:
         # === IMAGE ================================================ #
         # Agent runner sidecar. The services container
         # calls it in-network at http://agent-pi:8765 (AGENTA_AGENT_PI_URL).
+        # The build context and Dockerfile come from PR #4778.
         build:
             context: ../../../services/agent
             dockerfile: docker/Dockerfile.dev
@@ -451,8 +454,8 @@ services:
         # Deliberately NO env_file: the Pi sandbox must not inherit the stack's
         # secrets (COMPOSIO_API_KEY, STRIPE/POSTHOG/GOOGLE keys, ...). Tools run
         # server-side via /tools/call, so the sandbox only needs its own port, the Pi
-        # login (mounted below), the OTLP export fallback, and — for the rivet `daytona`
-        # sandbox axis (WP-8) — the Daytona credentials the SDK reads to create sandboxes.
+        # login (mounted below), the OTLP export fallback, and the Daytona credentials
+        # the SDK reads for the rivet `daytona` sandbox axis.
         environment:
             PORT: "8765"
             PI_CODING_AGENT_DIR: /pi-agent

--- a/hosting/docker-compose/ee/docker-compose.dev.yml
+++ b/hosting/docker-compose/ee/docker-compose.dev.yml
@@ -409,6 +409,13 @@ services:
             - ${ENV_FILE:-./.env.ee.dev}
         environment:
             DOCKER_NETWORK_MODE: ${DOCKER_NETWORK_MODE:-bridge}
+            # Agent workflow: reach the agent runner sidecar in-network.
+            AGENTA_AGENT_PI_URL: http://agent-pi:8765
+            # Agent runtime (WP-8): drive the harness over ACP via a rivet daemon.
+            # Harness (pi/claude) and sandbox (local/daytona) are independent axes.
+            AGENTA_AGENT_RUNTIME: ${AGENTA_AGENT_RUNTIME:-rivet}
+            AGENTA_AGENT_HARNESS: ${AGENTA_AGENT_HARNESS:-pi}
+            AGENTA_AGENT_SANDBOX: ${AGENTA_AGENT_SANDBOX:-local}
         # === NETWORK ============================================== #
         networks:
             - agenta-network
@@ -423,6 +430,55 @@ services:
             - "traefik.http.routers.services.middlewares=services-strip"
             - "traefik.http.services.services.loadbalancer.server.port=8080"
             - "traefik.http.routers.services.service=services"
+        # === LIFECYCLE ============================================ #
+        restart: always
+
+    agent-pi:
+        # === IMAGE ================================================ #
+        # Agent runner sidecar. The services container
+        # calls it in-network at http://agent-pi:8765 (AGENTA_AGENT_PI_URL).
+        build:
+            context: ../../../services/agent
+            dockerfile: docker/Dockerfile.dev
+        # === EXECUTION ============================================ #
+        # No file watcher (the box's inotify limit is shared across stacks). Copy the
+        # read-only mounted Pi login into a writable path so OAuth refresh stays
+        # in-container.
+        command: >
+            sh -c "mkdir -p /pi-agent && cp -a /pi-agent-ro/. /pi-agent/ 2>/dev/null || true;
+            exec node_modules/.bin/tsx src/server.ts"
+        # === CONFIGURATION ======================================== #
+        # Deliberately NO env_file: the Pi sandbox must not inherit the stack's
+        # secrets (COMPOSIO_API_KEY, STRIPE/POSTHOG/GOOGLE keys, ...). Tools run
+        # server-side via /tools/call, so the sandbox only needs its own port, the Pi
+        # login (mounted below), the OTLP export fallback, and — for the rivet `daytona`
+        # sandbox axis (WP-8) — the Daytona credentials the SDK reads to create sandboxes.
+        environment:
+            PORT: "8765"
+            PI_CODING_AGENT_DIR: /pi-agent
+            # Tracing export fallback (used when a request carries no usable OTLP
+            # credential). Must be reachable from this container.
+            AGENTA_HOST: ${AGENTA_HOST:-http://144.76.237.122:8280}
+            AGENTA_API_KEY: ${AGENTA_API_KEY:-}
+            # Daytona sandbox axis: the rivet daytona provider's `new Daytona()` reads
+            # these. Scoped to Daytona only (not the full stack secret set).
+            DAYTONA_API_KEY: ${DAYTONA_API_KEY:-}
+            DAYTONA_API_URL: ${DAYTONA_API_URL:-}
+            DAYTONA_TARGET: ${DAYTONA_TARGET:-}
+            # Pre-baked snapshot (rivet daemon + Pi + certs; Claude inherited from rivet's
+            # -full base) so Daytona runs skip the ~150s per-invoke `npm install pi`. We
+            # ship the builder (poc/build_rivet_snapshot.py), not the snapshot itself: each
+            # operator builds their own, so we never distribute a Claude-containing image.
+            # See services/agent/docker/README.md for the licensing posture.
+            AGENTA_RIVET_DAYTONA_SNAPSHOT: ${AGENTA_RIVET_DAYTONA_SNAPSHOT:-agenta-rivet-pi}
+            AGENTA_RIVET_DAYTONA_INSTALL_PI: ${AGENTA_RIVET_DAYTONA_INSTALL_PI:-false}
+        # === STORAGE ============================================== #
+        volumes:
+            - ../../../services/agent/src:/app/src
+            - ${HOME}/.pi/agent:/pi-agent-ro:ro
+        # === NETWORK ============================================== #
+        networks:
+            - agenta-network
         # === LIFECYCLE ============================================ #
         restart: always
 

--- a/hosting/docker-compose/ee/docker-compose.dev.yml
+++ b/hosting/docker-compose/ee/docker-compose.dev.yml
@@ -31,6 +31,15 @@ services:
         # === EXECUTION ============================================ #
         command: ["true"]
 
+    .sandbox-agent:
+        # === IMAGE ================================================ #
+        image: agenta-ee-dev-sandbox-agent:latest
+        build:
+            context: ../../../services/agent
+            dockerfile: docker/Dockerfile.dev
+        # === EXECUTION ============================================ #
+        command: ["true"]
+
     web:
         # === ACTIVATION =========================================== #
         profiles:
@@ -409,22 +418,17 @@ services:
             - ${ENV_FILE:-./.env.ee.dev}
         environment:
             DOCKER_NETWORK_MODE: ${DOCKER_NETWORK_MODE:-bridge}
-            # Agent workflow: reach the agent runner sidecar in-network.
-            AGENTA_AGENT_PI_URL: http://agent-pi:8765
-            # Agent runtime: drive the harness over ACP via a rivet daemon.
-            # Harness (pi/claude) and sandbox (local/daytona) are independent axes.
-            # The agent-pi sidecar files are introduced by PR #4778, so this compose
-            # wiring must land after #4778 or be reviewed with that branch applied.
-            AGENTA_AGENT_RUNTIME: ${AGENTA_AGENT_RUNTIME:-rivet}
-            AGENTA_AGENT_HARNESS: ${AGENTA_AGENT_HARNESS:-pi}
-            AGENTA_AGENT_SANDBOX: ${AGENTA_AGENT_SANDBOX:-local}
-            # Gate user-declared MCP servers (resolve_mcp_servers). Off by default.
+            AGENTA_AGENT_RUNNER_URL: http://sandbox-agent:8765
             AGENTA_AGENT_ENABLE_MCP: ${AGENTA_AGENT_ENABLE_MCP:-false}
         # === NETWORK ============================================== #
         networks:
             - agenta-network
         extra_hosts:
             - "host.docker.internal:host-gateway"
+        # === ORCHESTRATION ======================================== #
+        depends_on:
+            sandbox-agent:
+                condition: service_healthy
         # === LABELS =============================================== #
         labels:
             - "traefik.http.routers.services.rule=PathPrefix(`/services/`)"
@@ -437,32 +441,27 @@ services:
         # === LIFECYCLE ============================================ #
         restart: always
 
-    agent-pi:
+    sandbox-agent:
         # === IMAGE ================================================ #
-        # Agent runner sidecar. The services container
-        # calls it in-network at http://agent-pi:8765 (AGENTA_AGENT_PI_URL).
-        # The build context and Dockerfile come from PR #4778.
-        build:
-            context: ../../../services/agent
-            dockerfile: docker/Dockerfile.dev
+        image: agenta-ee-dev-sandbox-agent:latest
         # === EXECUTION ============================================ #
         # No file watcher (the box's inotify limit is shared across stacks). Copy the
         # read-only mounted Pi login into a writable path so OAuth refresh stays
         # in-container. This command replaces the image CMD, so the Pi extension rebuild
         # has to live here too: dist/ is not bind-mounted and src/extensions/agenta.ts is,
         # so without this a restart keeps a stale bundle and custom tools silently stop
-        # being delivered on the Rivet path (QA finding F-005). Rebuild from the mounted
+        # being delivered on the sandbox-agent path. Rebuild from the mounted
         # src on start; fail loud if it cannot build rather than run a stale bundle.
         command: >
             sh -c "mkdir -p /pi-agent && cp -a /pi-agent-ro/. /pi-agent/ 2>/dev/null || true;
             node scripts/build-extension.mjs &&
             exec node_modules/.bin/tsx src/server.ts"
         # === CONFIGURATION ======================================== #
-        # Deliberately NO env_file: the Pi sandbox must not inherit the stack's
+        # Deliberately no env_file: the harness sandbox must not inherit the stack's
         # secrets (COMPOSIO_API_KEY, STRIPE/POSTHOG/GOOGLE keys, ...). Tools run
         # server-side via /tools/call, so the sandbox only needs its own port, the Pi
         # login (mounted below), the OTLP export fallback, and the Daytona credentials
-        # the SDK reads for the rivet `daytona` sandbox axis.
+        # the runner reads for the `daytona` sandbox provider.
         environment:
             PORT: "8765"
             PI_CODING_AGENT_DIR: /pi-agent
@@ -470,27 +469,32 @@ services:
             # credential). Must be reachable from this container.
             AGENTA_HOST: ${AGENTA_HOST:-http://144.76.237.122:8280}
             AGENTA_API_KEY: ${AGENTA_API_KEY:-}
-            # Daytona sandbox axis: the rivet daytona provider's `new Daytona()` reads
-            # these. Scoped to Daytona only (not the full stack secret set).
-            DAYTONA_API_KEY: ${DAYTONA_API_KEY:-}
-            DAYTONA_API_URL: ${DAYTONA_API_URL:-}
-            DAYTONA_TARGET: ${DAYTONA_TARGET:-}
-            # Pre-baked snapshot (rivet daemon + Pi + certs; Claude inherited from rivet's
-            # -full base) so Daytona runs skip the ~150s per-invoke `npm install pi`. We
-            # ship the builder (poc/build_rivet_snapshot.py), not the snapshot itself: each
-            # operator builds their own, so we never distribute a Claude-containing image.
-            # See services/agent/docker/README.md for the licensing posture.
-            AGENTA_RIVET_DAYTONA_SNAPSHOT: ${AGENTA_RIVET_DAYTONA_SNAPSHOT:-agenta-rivet-pi}
-            AGENTA_RIVET_DAYTONA_INSTALL_PI: ${AGENTA_RIVET_DAYTONA_INSTALL_PI:-false}
+            SANDBOX_AGENT_PROVIDER: ${SANDBOX_AGENT_PROVIDER:-local}
+            SANDBOX_AGENT_DAYTONA_API_KEY: ${SANDBOX_AGENT_DAYTONA_API_KEY:-}
+            SANDBOX_AGENT_DAYTONA_API_URL: ${SANDBOX_AGENT_DAYTONA_API_URL:-}
+            SANDBOX_AGENT_DAYTONA_TARGET: ${SANDBOX_AGENT_DAYTONA_TARGET:-}
+            SANDBOX_AGENT_DAYTONA_SNAPSHOT: ${SANDBOX_AGENT_DAYTONA_SNAPSHOT:-agenta-sandbox-pi}
+            SANDBOX_AGENT_DAYTONA_IMAGE: ${SANDBOX_AGENT_DAYTONA_IMAGE:-}
+            SANDBOX_AGENT_DAYTONA_INSTALL_PI: ${SANDBOX_AGENT_DAYTONA_INSTALL_PI:-false}
         # === STORAGE ============================================== #
         volumes:
             - ../../../services/agent/src:/app/src
+            # The Agenta harness's forced skills are real files the runner lays into the
+            # sandbox per run (resolved from /app/skills). Bind-mounted like src so edits are
+            # live; the prod image bakes them with `COPY skills ./skills`.
+            - ../../../services/agent/skills:/app/skills
             - ${HOME}/.pi/agent:/pi-agent-ro:ro
         # === NETWORK ============================================== #
         networks:
             - agenta-network
         # === LIFECYCLE ============================================ #
         restart: always
+        healthcheck:
+            test: ["CMD", "node", "-e", "fetch('http://127.0.0.1:8765/health').then(r=>process.exit(r.ok?0:1)).catch(()=>process.exit(1))"]
+            interval: 10s
+            timeout: 5s
+            retries: 12
+            start_period: 20s
 
     postgres:
         # === IMAGE ================================================ #

--- a/hosting/docker-compose/ee/docker-compose.dev.yml
+++ b/hosting/docker-compose/ee/docker-compose.dev.yml
@@ -418,6 +418,8 @@ services:
             AGENTA_AGENT_RUNTIME: ${AGENTA_AGENT_RUNTIME:-rivet}
             AGENTA_AGENT_HARNESS: ${AGENTA_AGENT_HARNESS:-pi}
             AGENTA_AGENT_SANDBOX: ${AGENTA_AGENT_SANDBOX:-local}
+            # Gate user-declared MCP servers (resolve_mcp_servers). Off by default.
+            AGENTA_AGENT_ENABLE_MCP: ${AGENTA_AGENT_ENABLE_MCP:-false}
         # === NETWORK ============================================== #
         networks:
             - agenta-network
@@ -446,9 +448,14 @@ services:
         # === EXECUTION ============================================ #
         # No file watcher (the box's inotify limit is shared across stacks). Copy the
         # read-only mounted Pi login into a writable path so OAuth refresh stays
-        # in-container.
+        # in-container. This command replaces the image CMD, so the Pi extension rebuild
+        # has to live here too: dist/ is not bind-mounted and src/extensions/agenta.ts is,
+        # so without this a restart keeps a stale bundle and custom tools silently stop
+        # being delivered on the Rivet path (QA finding F-005). Rebuild from the mounted
+        # src on start; fail loud if it cannot build rather than run a stale bundle.
         command: >
             sh -c "mkdir -p /pi-agent && cp -a /pi-agent-ro/. /pi-agent/ 2>/dev/null || true;
+            node scripts/build-extension.mjs &&
             exec node_modules/.bin/tsx src/server.ts"
         # === CONFIGURATION ======================================== #
         # Deliberately NO env_file: the Pi sandbox must not inherit the stack's


### PR DESCRIPTION
<!-- stack-nav:start -->
### Agent-workflows: functional PR set

Sliced by functional area, final code only (no intermediate churn). Most PRs are independent off `main`; two pairs are stacked. This PR's base is `main`.

- #4771: SDK agent runtime: ports, adapters, tools, messages protocol
  - #4772: Agent service + tool-resolution API
- #4773: Runner wire contract + tool execution
  - #4774: Runner engines, server, tracing
- #4775: Playground agent config UI
- **#4776: Hosting compose wiring  <- you are here**
- #4777: Docs: design + ground truth
<!-- stack-nav:end -->

## Context

The agent runner needs a place to live in the dev stack. The Python service in `api/` decides per run whether to call a Pi process in its own checkout or an in-network sidecar. Until now the EE dev compose had no sidecar to call. This PR adds one. It branches off `main` and is the only hosting change in the agent-workflows slice: the runner stack, nothing else.

## What this changes

It adds an `agent-pi` service to `hosting/docker-compose/ee/docker-compose.dev.yml`. The service builds from `services/agent` (the `sandbox-agent server` runtime) and listens on port `8765`.

It also wires the `services` container to reach the sidecar. Four env vars carry the routing and the run defaults:

- `AGENTA_AGENT_PI_URL=http://agent-pi:8765` routes calls to the sidecar over the compose network.
- `AGENTA_AGENT_RUNTIME` picks the runtime (default `rivet`).
- `AGENTA_AGENT_HARNESS` picks the harness (default `pi`).
- `AGENTA_AGENT_SANDBOX` picks the sandbox (default `local`).

The `agent-pi` service runs with no `env_file` on purpose. The Pi sandbox must not inherit the stack secrets. It gets only its port, the mounted Pi login, an OTLP export fallback, and the Daytona credentials the SDK reads when the sandbox axis is `daytona`.

## Key architectural decision to review

Confirm the in-network URL wiring lines up with the runner. The service reads `AGENTA_AGENT_PI_URL` to choose HTTP-to-sidecar over a local subprocess (`services/oss/src/agent/app.py:63`). The compose value `http://agent-pi:8765` (line 398) is the Docker DNS name of the `agent-pi` service (line 421), so the names must stay in sync.

Confirm the two axes are independent. Harness (`pi`/`claude`) and sandbox (`local`/`daytona`) are separate choices the Python service sends per run, not a fixed pairing (line 400).

Confirm the licensing note. The comment at line 456 says we ship the snapshot builder, not the snapshot, so we never distribute a Claude-containing image. That matches the posture in `services/agent/docker/README.md`: Pi (MIT) is baked freely, Claude Code is installed from Anthropic at runtime and never repackaged.

## How to review this PR

Read the `agent-pi` block top to bottom and check the four points above: the matching service name and URL, the empty `env_file`, the scoped Daytona credentials, and the licensing comment.

The regression to watch: a stack that does not mount the sidecar. If a deploy omits `agent-pi` but the `services` container still has `AGENTA_AGENT_PI_URL` set, every agent run hits an unresolved host. The URL and the service must land together or not at all.