### PR TITLE
[docs] Sandbox runtime metering — scoped-resource design

### DIFF
--- a/docs/designs/sandbox-runtime-metering/proposal.md
+++ b/docs/designs/sandbox-runtime-metering/proposal.md
@@ -1,0 +1,233 @@
+# Sandbox Runtime Metering — Design Proposal
+
+Meter the wall-clock minutes an agent-runner **sandbox** (Daytona VM) is alive,
+record it as a billable usage dimension, enforce per-plan limits, and report it
+to Stripe as a usage-based price.
+
+We pay Daytona per-minute of ephemeral VM lifetime; this puts that cost into the
+product's pricing surface as a first-class meter, with guardrails.
+
+> Status: proposal. Builds directly on the `extend-meters` work
+> ([../extend-meters/proposal.md](../extend-meters/proposal.md)), which already
+> reshaped `meters` around a deterministic `meter_id` with flexible scope/period
+> and made "add a billable counter" a well-worn path.
+
+## Locked decisions
+
+1. **Unit & rounding.** Whole minutes, **rounded up per run** (`ceil`). Each
+   sandbox lifetime is one run; a 12s run counts as 1 minute, a 61s run as 2.
+2. **What we meter.** Only the **agent-runner (rivet) sandbox** — the new path.
+   We do **not** retrofit the legacy code-evaluator Daytona runner
+   (`sdks/python/agenta/sdk/engines/running/runners/daytona.py`). The design is
+   provider-neutral so the same meter can later cover other sandboxes without a
+   schema change.
+3. **Outcome.** Both **limits** (per-plan monthly minute quota, enforced) and
+   **billing** (reported to Stripe as usage).
+
+## The one idea that makes this clean
+
+The rivet runner already emits an OTel span tree and exports it OTLP/HTTP to
+`{AGENTA_HOST}/api/otlp/v1/traces` — the **same** ingest pipeline that today
+charges `TRACES_INGESTED`. Trace ingestion already:
+
+- resolves the **organization** per trace (attribution is solved), and
+- charges `check_entitlements(...)` per-org, batched, in the background worker
+  `api/oss/src/tasks/asyncio/tracing/worker.py` (≈ line 268).
+
+So runtime minutes become **a span attribute** on the agent's root span, and the
+worker that already counts root spans gains a few lines to *also* sum that
+attribute and charge a second counter. No new tenant-propagation, no new
+transport, no synchronous coupling to the runner.
+
+```
+client ─▶ api gateway ─▶ workflow invoke ─▶ agent service ─▶ rivet runner ─▶ Daytona VM
+                                                  │                              │
+   (A) pre-run soft gate (429 if over) ◀──────────┘        (B) bracket start→destroy,
+                                                                 stamp sandbox.runtime_ms
+                                                                 on the root span
+        OTLP spans ─────────────────────────────────────────────────────┘
+            │
+            ▼
+   api/otlp ingest ─▶ tracing worker  ──(C) per-org: charge TRACES_INGESTED (today)
+                                       └─(C') per-org: Σ ceil(ms/60000) ⇒ charge SANDBOX_RUNTIME_MINUTES (new)
+                                                  │
+                                                  ▼
+                            meters table ─▶ report cron ─▶ Stripe MeterEvent (billing)
+                                          └▶ /billing/usage (display + limit)
+```
+
+Three insertion points: **(B)** capture in the runner, **(C')** charge in the
+worker, **(A)** gate before the run. Everything else is config.
+
+## Naming
+
+New dimension slug: **`sandbox_runtime_minutes`** (enum `SANDBOX_RUNTIME_MINUTES`).
+Provider-neutral on purpose — the meter measures *sandbox wall-time we pay for*,
+not "Daytona" specifically, so swapping providers or adding the evaluator
+sandbox later reuses the same meter. Span attribute: **`sandbox.runtime_ms`**
+(raw milliseconds, for fidelity/observability); the per-run `ceil`-to-minutes
+rounding is applied once, in the worker, so the policy lives in exactly one place.
+
+## (B) Capture — agent runner
+
+`services/agent/src/engines/rivet.ts::runRivet()` brackets the exact billable VM
+lifetime in a single function:
+
+- `t0 = performance.now()` immediately before `SandboxAgent.start()` (≈ L883).
+- in the `finally`, after `destroySandbox()` (≈ L1079):
+  `runtimeMs = Math.round(performance.now() - t0)`.
+
+This deliberately includes provisioning **and** the `npm install` warmup (up to
+~180s) — that VM time is real Daytona spend and should be billed.
+
+Surface it two ways (they converge):
+
+1. **On the result** — add `sandboxRuntimeMs` to `AgentRunResult`
+   (`services/agent/src/protocol.ts`, alongside `usage`). The Python adapter
+   `sdks/python/agenta/sdk/agents/adapters/rivet.py` already threads the result
+   back; `services/oss/src/agent/app.py` (≈ L127) → `record_usage()`
+   (`services/oss/src/agent/tracing.py` ≈ L62) is where `gen_ai.usage.*` is
+   stamped on the workflow span — stamp `sandbox.runtime_ms` there too.
+2. The span then flows through OTLP ingest like any other usage attribute.
+
+Only the agent's **root span** carries the attribute (one run = one sandbox =
+one root span), which is what the worker keys on. Non-Daytona backends (local
+runner) simply don't set it ⇒ they meter zero, no special-casing.
+
+## (C') Charge — tracing worker (EE path, per-org, batched)
+
+The worker already groups root spans by org and calls
+`check_entitlements(key=Counter.TRACES_INGESTED, delta=<root span count>, ...)`.
+Extend the same loop:
+
+```python
+# per org, over the batch's root spans:
+minutes = sum(
+    math.ceil(span.attributes["sandbox.runtime_ms"] / 60_000)
+    for span in root_spans
+    if span.attributes.get("sandbox.runtime_ms")          # per-run ceil
+)
+if minutes:
+    allowed, _, _ = await check_entitlements(
+        key=Counter.SANDBOX_RUNTIME_MINUTES,
+        delta=minutes,
+        scope=scope_from(organization_id=org_id),          # worker has no ambient ctx
+    )
+    # post-paid: we charge what already ran; `allowed=False` just means the
+    # org is now over and the *next* run's pre-gate will reject. Do not drop.
+```
+
+`check_entitlements` is the single chokepoint that records usage and enforces
+quota in one atomic upsert (`api/ee/.../entitlements/service.py` ≈ L272 →
+`MetersDAO.adjust` ≈ `dao.py:376`). It fails open on any infra glitch, so a
+metering hiccup never blocks ingestion.
+
+**Post-paid semantics.** Unlike pre-paid counters, minutes are only known after
+the run. We therefore *charge after* (here) and *gate before* (A). A run already
+in flight is always allowed to finish and is billed; enforcement bites on the
+*next* run. This matches how cloud usage billing normally behaves.
+
+## (A) Gate — agent invocation edge (EE, soft pre-check)
+
+Before dispatching an agent run, soft-check the meter at the HTTP boundary
+(mirroring the OTLP soft-check at `api/oss/.../otlp/router.py` ≈ L224):
+
+```python
+allowed, _, _ = await check_entitlements(
+    key=Counter.SANDBOX_RUNTIME_MINUTES,
+    delta=0,                # read-only: "are we already at/over?"
+    cache=True,             # Redis-cached, never writes
+)
+if not allowed:
+    raise HTTPException(429, "You have reached your agent runtime minutes quota for this period.")
+```
+
+`delta=0` + `strict` quota means "reject once `value >= limit`". This is a cheap
+Redis read on the hot path; it fails open.
+
+## Config — registry changes (EE)
+
+All in `api/ee/src/core/access/entitlements/types.py` unless noted:
+
+1. **`Counter`**: add `SANDBOX_RUNTIME_MINUTES = "sandbox_runtime_minutes"`.
+2. **`Meters`** (`api/ee/src/core/meters/types.py`): mirror
+   `SANDBOX_RUNTIME_MINUTES = Counter.SANDBOX_RUNTIME_MINUTES.value` (required —
+   DAO/cache cross-reference by name).
+3. **`DEFAULT_ENTITLEMENTS`** — add a `Quota` under `Tracker.COUNTERS` for every
+   plan:
+   - Hobby: `Quota(free=<F>, limit=<F>, strict=True, period=Period.MONTHLY)` — a
+     real cap (this is the cost-control plan).
+   - Pro/Business: `Quota(free=<P>, limit=<P or None>, strict=True, period=Period.MONTHLY)`
+     — included allotment, optionally uncapped with overage billed.
+   - Enterprise/Agenta-internal: `Quota(period=Period.MONTHLY)` (unlimited).
+
+   `scope=None` ⇒ organization-scoped, which is what we want (Daytona spend is an
+   org-level cost). `period=Period.MONTHLY` is the *reset window* — the quantity
+   is minutes; there is **no** need for a per-minute `Period` granularity.
+4. **`CONSTRAINTS[Constraint.READ_ONLY][Tracker.COUNTERS]`**: include the new
+   counter so a blocked/over org can't keep burning sandbox time.
+5. **`REPORTS`**: add `Counter.SANDBOX_RUNTIME_MINUTES.value: "sandbox_runtime_minutes"`
+   (internal slug → Stripe meter slot). Membership here is exactly "is billed to
+   Stripe".
+6. **`DEFAULT_CATALOG`** (display): add a feature/price line so the pricing modal
+   shows the allotment + overage.
+
+## Billing — Stripe
+
+The report cron (`api/ee/src/crons/meters.sh` → `POST /admin/billing/usage/report`
+→ `MetersService.report()` at `api/ee/src/core/meters/service.py` ≈ L75) already
+pages unsynced meter rows and, for any counter in `REPORTS`, calls
+`stripe.billing.MeterEvent.create(event_name="sandbox_runtime_minutes",
+payload={delta = value - synced}, identifier=...)` with deterministic
+idempotency. So once the slug is in `REPORTS`, reporting is automatic.
+
+Stripe-side, two non-code steps + one config:
+
+- Create a Stripe **Meter** named `sandbox_runtime_minutes`.
+- Create a usage-based **Price** per plan bound to that meter (e.g. N minutes
+  included, $X per minute overage).
+- Add the price slot to `AGENTA_BILLING_PRICING` (env `BillingConfig`,
+  `api/oss/src/utils/env.py` ≈ L214); `get_stripe_meter_price()`
+  (`api/ee/src/core/subscriptions/settings.py` ≈ L453) resolves it per plan.
+
+## Database migration
+
+One Alembic revision adding `SANDBOX_RUNTIME_MINUTES` to the `meters_type`
+Postgres enum. Copy the self-contained template at
+`api/ee/databases/postgres/migrations/core/versions/b2c3d4e5f7a8_add_events_ingested_meter.py`
+(create temp type / alter column / drop / rename; downgrade deletes new-key rows
+first). No table/DAO/`compute_meter_id` changes — the metering core is generic
+over the enum.
+
+## Read & display
+
+`/billing/usage` (`api/ee/.../billing/router.py` ≈ L932) iterates the plan's
+counters and emits one row per quota automatically — the new meter appears with
+`value/limit/free/period/scope` once the `Quota` is declared. Frontend: add the
+label/descriptor to the usage card (`web/ee/src/services/billing/types.d.ts` +
+the card renderer) and the pricing catalog line.
+
+## What this is NOT
+
+- Not metering the legacy evaluator sandbox (explicitly out — no retrofit). The
+  generic naming leaves the door open later.
+- Not a per-minute *rate* limit (that's the separate throttle/token-bucket path).
+  This is a *quantity* of minutes over a monthly window.
+- Not changing `compute_meter_id` or the meters schema shape.
+
+## Risks & edges
+
+- **Re-ingested traces would double-charge.** Same property the existing
+  `TRACES_INGESTED` charge has; if it matters, dedupe by root-span id. Parity
+  with today's behavior is the default.
+- **Warmup dominates short runs.** Cold sandbox + `npm install` (~up to 180s)
+  means even trivial prompts cost ≥ a few minutes. That's real spend; surface it
+  in docs so customers aren't surprised, and it's an argument for sandbox pooling
+  later (separate work).
+- **Post-paid overshoot.** One run can cross the limit before the gate trips on
+  the next. Acceptable; strict quota keeps it to a single run's overage.
+- **Fail-open everywhere.** A metering outage neither blocks runs nor charges —
+  we under-bill rather than break the product. Intentional.
+
+See [tasks.md](./tasks.md) for the implementation checklist and
+[research.md](./research.md) for the grounding in current code.

--- a/docs/designs/sandbox-runtime-metering/proposal.md
+++ b/docs/designs/sandbox-runtime-metering/proposal.md
@@ -1,149 +1,222 @@
 # Sandbox Runtime Metering — Design Proposal
 
 Meter the wall-clock minutes an agent-runner **sandbox** (Daytona VM) is alive,
-record it as a billable usage dimension, enforce per-plan limits, and report it
-to Stripe as a usage-based price.
+model it as a **configurable, scoped resource** that callers must be entitled to
+consume, **gate** each run against that resource before it starts, and **bill**
+the consumed minutes to Stripe.
 
-We pay Daytona per-minute of ephemeral VM lifetime; this puts that cost into the
-product's pricing surface as a first-class meter, with guardrails.
+We pay Daytona per-minute of ephemeral VM lifetime. Today that cost never reaches
+the pricing surface: no meter, no per-plan limit, nothing reported to Stripe.
+This design closes that gap and, in doing so, lays the first rail for a general
+"limit usage per project / agent / user" capability.
 
-> Status: proposal. Builds directly on the `extend-meters` work
-> ([../extend-meters/proposal.md](../extend-meters/proposal.md)), which already
-> reshaped `meters` around a deterministic `meter_id` with flexible scope/period
-> and made "add a billable counter" a well-worn path.
+> Status: proposal. Builds on the `extend-meters` work
+> ([../extend-meters/proposal.md](../extend-meters/proposal.md)), which reshaped
+> `meters` around a deterministic `meter_id` with flexible scope/period and made
+> "add a billable counter" a well-worn path.
 
-## Locked decisions
+## The resource model (the frame)
 
-1. **Unit & rounding.** Whole minutes, **rounded up per run** (`ceil`). Each
-   sandbox lifetime is one run; a 12s run counts as 1 minute, a 61s run as 2.
-2. **What we meter.** Only the **agent-runner (rivet) sandbox** — the new path.
-   We do **not** retrofit the legacy code-evaluator Daytona runner
-   (`sdks/python/agenta/sdk/engines/running/runners/daytona.py`). The design is
-   provider-neutral so the same meter can later cover other sandboxes without a
-   schema change.
-3. **Outcome.** Both **limits** (per-plan monthly minute quota, enforced) and
-   **billing** (reported to Stripe as usage).
+Think of a **resource** as a named, configurable **entitlement with a quota**,
+attached to a scope. A request declares which resource it is about to consume;
+the system checks — at the same cached point where it already checks
+authentication — whether the caller is *entitled to run*, and only then proceeds.
+After the work runs, the consumed amount is booked against that resource.
 
-## The one idea that makes this clean
+This is not a new subsystem: it is exactly what the EE **entitlements** layer
+already does (`check_entitlements`, `Quota`, `Scope`, `meters`). We are giving it
+one new dimension (sandbox runtime minutes) and using it the way it was built to
+be used — as a budget you check before acting and debit after.
 
-The rivet runner already emits an OTel span tree and exports it OTLP/HTTP to
-`{AGENTA_HOST}/api/otlp/v1/traces` — the **same** ingest pipeline that today
-charges `TRACES_INGESTED`. Trace ingestion already:
+**Scope ladder.** The entitlement `Scope` today is `ORGANIZATION | PROJECT | USER`.
+We ship the resource **project-scoped by default** — every run in a project draws
+from that project's runtime budget — because that matches "a team has a sandbox
+budget." The same key can later be instanced at:
 
-- resolves the **organization** per trace (attribution is solved), and
-- charges `check_entitlements(...)` per-org, batched, in the background worker
-  `api/oss/src/tasks/asyncio/tracing/worker.py` (≈ line 268).
+- **USER** scope ("this user can't spend more than X") — available today, no new code.
+- **AGENT** scope ("this agent can't spend more than X") — a *future* rung; needs a
+  new `Scope.AGENT` and a way for the request to name which resource instance it
+  draws from. Explicitly phase 2.
 
-So runtime minutes become **a span attribute** on the agent's root span, and the
-worker that already counts root spans gains a few lines to *also* sum that
-attribute and charge a second counter. No new tenant-propagation, no new
-transport, no synchronous coupling to the runner.
+Org-wide budgets remain expressible (`Scope.ORGANIZATION`) for customers who want a
+single cap. The point is that the *grain is configuration*, not a rewrite — start
+with one project-scoped resource, grow into per-agent / per-user / multi-resource
+without touching the metering core.
+
+## Why measurement comes from the runner, not from Daytona
+
+The tempting design is "tag sandboxes, let a cron pull usage from Daytona, never
+touch the run path." We verified Daytona's API against this and it does **not**
+hold for our workload (sources in [research.md](./research.md#daytona-api-reality)):
+
+- **No per-sandbox usage/cost API.** CPU-seconds, GB-seconds, disk, and price exist
+  **only in the Daytona dashboard "Spending" view**. No REST endpoint or SDK method
+  exports them.
+- **The one `/organizations/:id/usage` endpoint is the wrong data and unreachable.**
+  It returns live *quota-vs-allocation snapshots* (cores/GB in use now), org/region
+  scoped — no cost, no time-integration, never per-sandbox. It also currently
+  requires an interactive **JWT, not an API key** (open request:
+  daytonaio/daytona#4643), so a server cron can't call it cleanly.
+- **Up to 48h billing lag**, documented.
+- **Our sandboxes are ephemeral.** The rivet runner creates a **cold sandbox per
+  prompt turn** and destroys it in a `finally` — lifetime is seconds to a few
+  minutes, entirely inside one run. A periodic `list()` cron would find them
+  already deleted (and deleted-sandbox retention in `list` is undocumented). The
+  sandbox object also has **no `startedAt`/`stoppedAt`** — only `createdAt` /
+  `lastActivityAt` / `state` — so even catching a live one wouldn't give an exact
+  billable lifetime.
+
+The runner, by contrast, already brackets the *exact* billable window
+(`start()` → `destroy()`) for free. So **the runner is the measurement source**,
+and Daytona **labels** are repurposed for what they *can* do reliably:
+attribution-audit, orphan/leak detection, and a manual cross-check against the
+48h-lagged dashboard. Labels are not the billing path.
+
+## Data flow
 
 ```
-client ─▶ api gateway ─▶ workflow invoke ─▶ agent service ─▶ rivet runner ─▶ Daytona VM
-                                                  │                              │
-   (A) pre-run soft gate (429 if over) ◀──────────┘        (B) bracket start→destroy,
-                                                                 stamp sandbox.runtime_ms
-                                                                 on the root span
-        OTLP spans ─────────────────────────────────────────────────────┘
-            │
-            ▼
-   api/otlp ingest ─▶ tracing worker  ──(C) per-org: charge TRACES_INGESTED (today)
-                                       └─(C') per-org: Σ ceil(ms/60000) ⇒ charge SANDBOX_RUNTIME_MINUTES (new)
-                                                  │
-                                                  ▼
-                            meters table ─▶ report cron ─▶ Stripe MeterEvent (billing)
-                                          └▶ /billing/usage (display + limit)
+                       (A) GATE — soft check_entitlements(resource, cache=True),
+                            folded into the cached /access/permissions check;
+                            429 if the project is already over its minute budget
+                                  │ records  run → resolved scope
+client ─▶ api gateway ─▶ agent invocation (EE) ───────────────┐
+                                  │                            ▼
+                                  ▼                      (run record / Redis stash)
+                            agent service ─▶ rivet runner ─▶ Daytona VM
+                                  │              │   labels: org / project / [agent,user]
+                                  │              │   (B) MEASURE: t0 before start()…
+                                  │              ▼        destroy() in finally
+                                  │        runtimeMs ⇒ ceil → minutes
+                                  ▼
+   (C) ACCOUNT — trusted report (run_id, sandbox_id, minutes)
+        ─▶ internal metering endpoint (api, EE), authed as the agent service
+           (NOT the admin key); idempotent on sandbox_id
+        ─▶ join run_id → recorded scope  (attribution from the run record,
+           never from the report payload — a report can only attach minutes
+           to a run the auth layer already scoped)
+        ─▶ check_entitlements(resource, delta=minutes)   ← books the meter
+                                  │
+                                  ▼
+        meters table ─▶ report cron ─▶ Stripe MeterEvent (billing, per org)
+                     └▶ /billing/usage (display + the cached value the gate reads)
+
+   Daytona labels ─▶ reconciliation cron (AUDIT ONLY): list non-deleted sandboxes
+        by label, flag orphans/leaks, sanity-check against the dashboard.
+        Not a billing source — usage/cost is dashboard-only and 48h-lagged.
 ```
 
-Three insertion points: **(B)** capture in the runner, **(C')** charge in the
-worker, **(A)** gate before the run. Everything else is config.
+Three insertion points — **(A)** gate, **(B)** measure, **(C)** account — plus a
+non-billing reconciliation cron. Everything else is registry/config.
 
 ## Naming
 
-New dimension slug: **`sandbox_runtime_minutes`** (enum `SANDBOX_RUNTIME_MINUTES`).
-Provider-neutral on purpose — the meter measures *sandbox wall-time we pay for*,
-not "Daytona" specifically, so swapping providers or adding the evaluator
-sandbox later reuses the same meter. Span attribute: **`sandbox.runtime_ms`**
-(raw milliseconds, for fidelity/observability); the per-run `ceil`-to-minutes
-rounding is applied once, in the worker, so the policy lives in exactly one place.
+Dimension slug: **`sandbox_runtime_minutes`** (enum `SANDBOX_RUNTIME_MINUTES`).
+Provider-neutral on purpose — it measures *sandbox wall-time we pay for*, not
+"Daytona" — so swapping providers or adding the legacy evaluator sandbox later
+reuses the same resource. Rounding policy (per-run `ceil` to whole minutes) is
+applied **once**, at the accounting step, so it lives in exactly one place.
 
-## (B) Capture — agent runner
+## (A) Gate — folded into the cached auth check
 
-`services/agent/src/engines/rivet.ts::runRivet()` brackets the exact billable VM
-lifetime in a single function:
+Your "the service calls me before doing the thing" is a **soft entitlement check**
+at the point that already runs on every invocation. `check_entitlements` already
+supports this exact mode — `cache=True` is a "Redis-cached read, never writes"
+soft-check (`api/ee/.../entitlements/service.py:272`, the same pattern the OTLP
+edge uses at `api/oss/.../otlp/router.py:224`):
+
+```python
+allowed, _, _ = await check_entitlements(
+    key=Counter.SANDBOX_RUNTIME_MINUTES,
+    delta=0,                # read-only: "are we already at/over budget?"
+    cache=True,             # Redis-cached, never writes; fails open
+    scope=scope_from(project_id=project_id),   # project-scoped resource (default)
+)
+if not allowed:
+    raise HTTPException(429, "Agent runtime minutes quota reached for this period.")
+```
+
+This extends the cached permissions/auth resolution from "are you authenticated?"
+to "are you authenticated **and** entitled to run this?" It is a cheap Redis read
+on the hot path and **fails open**. Because consumption is booked post-run
+(below), the gate reads the *last-booked* value — see "Limit semantics".
+
+At the same point, record **`run_id → resolved scope`** (org/project/[user]) so the
+post-run report can be attributed without trusting the report payload. The run
+already has a server-side record; stashing the scope there (or in a short-TTL Redis
+key) is the join target for (C). *(Exact join key + store — run record vs Redis —
+is an implementation detail to finalize; see tasks.)*
+
+## (B) Measure — agent runner
+
+`services/agent/src/engines/rivet.ts::runRivet()` already brackets the exact
+billable VM lifetime:
 
 - `t0 = performance.now()` immediately before `SandboxAgent.start()` (≈ L883).
 - in the `finally`, after `destroySandbox()` (≈ L1079):
   `runtimeMs = Math.round(performance.now() - t0)`.
 
-This deliberately includes provisioning **and** the `npm install` warmup (up to
-~180s) — that VM time is real Daytona spend and should be billed.
+This intentionally includes provisioning **and** the `npm install` warmup (up to
+~180s) — that VM time is real Daytona spend and must be billed. At sandbox
+creation, also set **`labels`** = `{ org, project, [agent, user], run_id }`
+(`labels` is a create-param, `Record<string,string>`; see research) so the
+reconciliation cron can attribute and detect leaks.
 
-Surface it two ways (they converge):
+## (C) Account — trusted report joined to the recorded scope
 
-1. **On the result** — add `sandboxRuntimeMs` to `AgentRunResult`
-   (`services/agent/src/protocol.ts`, alongside `usage`). The Python adapter
-   `sdks/python/agenta/sdk/agents/adapters/rivet.py` already threads the result
-   back; `services/oss/src/agent/app.py` (≈ L127) → `record_usage()`
-   (`services/oss/src/agent/tracing.py` ≈ L62) is where `gen_ai.usage.*` is
-   stamped on the workflow span — stamp `sandbox.runtime_ms` there too.
-2. The span then flows through OTLP ingest like any other usage attribute.
-
-Only the agent's **root span** carries the attribute (one run = one sandbox =
-one root span), which is what the worker keys on. Non-Daytona backends (local
-runner) simply don't set it ⇒ they meter zero, no special-casing.
-
-## (C') Charge — tracing worker (EE path, per-org, batched)
-
-The worker already groups root spans by org and calls
-`check_entitlements(key=Counter.TRACES_INGESTED, delta=<root span count>, ...)`.
-Extend the same loop:
+The runner reports the measured minutes out-of-band to an **internal metering
+endpoint** in `api/` (EE), authenticated as the **agent service's existing
+credential** — *not* the admin `AGENTA_AUTH_KEY`. The report carries
+`(run_id, sandbox_id, minutes)` and **never names a tenant**:
 
 ```python
-# per org, over the batch's root spans:
-minutes = sum(
-    math.ceil(span.attributes["sandbox.runtime_ms"] / 60_000)
-    for span in root_spans
-    if span.attributes.get("sandbox.runtime_ms")          # per-run ceil
-)
-if minutes:
-    allowed, _, _ = await check_entitlements(
-        key=Counter.SANDBOX_RUNTIME_MINUTES,
-        delta=minutes,
-        scope=scope_from(organization_id=org_id),          # worker has no ambient ctx
-    )
-    # post-paid: we charge what already ran; `allowed=False` just means the
-    # org is now over and the *next* run's pre-gate will reject. Do not drop.
-```
-
-`check_entitlements` is the single chokepoint that records usage and enforces
-quota in one atomic upsert (`api/ee/.../entitlements/service.py` ≈ L272 →
-`MetersDAO.adjust` ≈ `dao.py:376`). It fails open on any infra glitch, so a
-metering hiccup never blocks ingestion.
-
-**Post-paid semantics.** Unlike pre-paid counters, minutes are only known after
-the run. We therefore *charge after* (here) and *gate before* (A). A run already
-in flight is always allowed to finish and is billed; enforcement bites on the
-*next* run. This matches how cloud usage billing normally behaves.
-
-## (A) Gate — agent invocation edge (EE, soft pre-check)
-
-Before dispatching an agent run, soft-check the meter at the HTTP boundary
-(mirroring the OTLP soft-check at `api/oss/.../otlp/router.py` ≈ L224):
-
-```python
-allowed, _, _ = await check_entitlements(
+# internal endpoint, EE
+scope = load_scope_for_run(run_id)        # from the run record stashed at the gate
+minutes = ceil_minutes(report.runtime_ms) # per-run ceil, applied here, once
+await check_entitlements(
     key=Counter.SANDBOX_RUNTIME_MINUTES,
-    delta=0,                # read-only: "are we already at/over?"
-    cache=True,             # Redis-cached, never writes
+    delta=minutes,
+    scope=scope,                          # attribution from the run record
+    idempotency_key=report.sandbox_id,    # at-least-once safe; one charge per sandbox
 )
-if not allowed:
-    raise HTTPException(429, "You have reached your agent runtime minutes quota for this period.")
 ```
 
-`delta=0` + `strict` quota means "reject once `value >= limit`". This is a cheap
-Redis read on the hot path; it fails open.
+Why this shape:
+
+- **No new secret, no god-key.** It reuses the credential the agent service
+  already holds. The admin key never leaves the cron host.
+- **Not spoofable into cross-tenant billing.** Attribution comes from the
+  server-side run record, not the request body. A compromised reporter could only
+  mis-state minutes for runs that already exist and are already scoped — bounded
+  blast radius — and can never bill a different tenant. This is the property the
+  customer-emitted OTLP-span approach lacked.
+- **Idempotent.** Keyed on `sandbox_id` (stable, unique, returned by Daytona), so
+  retries/at-least-once delivery never double-charge. Multi-turn sessions create
+  one sandbox per turn ⇒ one charge per turn, naturally.
+
+`check_entitlements` is the single chokepoint that records usage and enforces quota
+in one atomic upsert (`dao.py:376`), and **fails open** — a metering hiccup never
+blocks a run.
+
+> **Lighter alternative (rejected as primary).** The runner already exports OTel
+> spans to `/api/otlp/v1/traces`; we could stamp `sandbox.runtime_ms` on the root
+> span and sum it in the tracing worker. It is simpler, but spans on that ingest
+> are customer-influenceable, so it is spoofable to *under-bill* and is lossy on
+> dropped traces. Acceptable for a v0 internal rollout; not the billing source of
+> record. Kept here as a fallback, not the plan.
+
+## Limit semantics (state this plainly)
+
+Minutes are only known **after** a run, so this is a **post-paid** meter with a
+**soft, slightly-lagged** gate:
+
+- A run already in flight always finishes and is billed.
+- The gate reads the last-booked value, so a project can cross its budget on one
+  run before the *next* run is blocked. `strict` quota keeps the overshoot to a
+  single run's worth.
+
+This is a **budget guardrail, not a hard real-time cap** — the right model for
+spend control, and consistent with how cloud usage billing behaves. Do not design
+UX that promises a hard cutoff at exactly N minutes.
 
 ## Config — registry changes (EE)
 
@@ -154,80 +227,107 @@ All in `api/ee/src/core/access/entitlements/types.py` unless noted:
    `SANDBOX_RUNTIME_MINUTES = Counter.SANDBOX_RUNTIME_MINUTES.value` (required —
    DAO/cache cross-reference by name).
 3. **`DEFAULT_ENTITLEMENTS`** — add a `Quota` under `Tracker.COUNTERS` for every
-   plan:
-   - Hobby: `Quota(free=<F>, limit=<F>, strict=True, period=Period.MONTHLY)` — a
-     real cap (this is the cost-control plan).
-   - Pro/Business: `Quota(free=<P>, limit=<P or None>, strict=True, period=Period.MONTHLY)`
-     — included allotment, optionally uncapped with overage billed.
-   - Enterprise/Agenta-internal: `Quota(period=Period.MONTHLY)` (unlimited).
+   plan, **`scope=Scope.PROJECT`** (the default resource grain), `period=Period.MONTHLY`,
+   `strict=True`:
+   - Hobby: a real cap (the cost-control plan).
+   - Pro/Business: included allotment, optionally uncapped with overage billed.
+   - Enterprise/Agenta-internal: unlimited.
 
-   `scope=None` ⇒ organization-scoped, which is what we want (Daytona spend is an
-   org-level cost). `period=Period.MONTHLY` is the *reset window* — the quantity
-   is minutes; there is **no** need for a per-minute `Period` granularity.
+   `period=Period.MONTHLY` is the **reset window**, not the unit; the quantity is
+   minutes. Project-scoped rows still carry `organization_id`, so Stripe billing
+   still aggregates per org (below).
 4. **`CONSTRAINTS[Constraint.READ_ONLY][Tracker.COUNTERS]`**: include the new
-   counter so a blocked/over org can't keep burning sandbox time.
-5. **`REPORTS`**: add `Counter.SANDBOX_RUNTIME_MINUTES.value: "sandbox_runtime_minutes"`
-   (internal slug → Stripe meter slot). Membership here is exactly "is billed to
-   Stripe".
-6. **`DEFAULT_CATALOG`** (display): add a feature/price line so the pricing modal
-   shows the allotment + overage.
+   counter so a blocked/over project can't keep burning sandbox time.
+5. **`REPORTS`**: add
+   `Counter.SANDBOX_RUNTIME_MINUTES.value: "sandbox_runtime_minutes"` (internal slug
+   → Stripe meter slot). Membership here *is* "is billed to Stripe".
+6. **`DEFAULT_CATALOG`** (display): a feature/price line so the pricing modal shows
+   allotment + overage.
 
 ## Billing — Stripe
 
 The report cron (`api/ee/src/crons/meters.sh` → `POST /admin/billing/usage/report`
-→ `MetersService.report()` at `api/ee/src/core/meters/service.py` ≈ L75) already
-pages unsynced meter rows and, for any counter in `REPORTS`, calls
+→ `MetersService.report()` at `api/ee/src/core/meters/service.py:75`) already pages
+unsynced meter rows and, for any counter in `REPORTS`, calls
 `stripe.billing.MeterEvent.create(event_name="sandbox_runtime_minutes",
-payload={delta = value - synced}, identifier=...)` with deterministic
-idempotency. So once the slug is in `REPORTS`, reporting is automatic.
+payload={delta = value - synced, customer_id=<org's customer>}, identifier=...)`
+with deterministic idempotency. Because every row carries `organization_id`,
+project-scoped rows roll up to the org's Stripe customer automatically. Once the
+slug is in `REPORTS`, reporting is automatic.
 
-Stripe-side, two non-code steps + one config:
+Two non-code steps + one config:
 
-- Create a Stripe **Meter** named `sandbox_runtime_minutes`.
-- Create a usage-based **Price** per plan bound to that meter (e.g. N minutes
-  included, $X per minute overage).
-- Add the price slot to `AGENTA_BILLING_PRICING` (env `BillingConfig`,
-  `api/oss/src/utils/env.py` ≈ L214); `get_stripe_meter_price()`
-  (`api/ee/src/core/subscriptions/settings.py` ≈ L453) resolves it per plan.
+- Create a Stripe **Meter** `sandbox_runtime_minutes`.
+- Create a usage-based **Price** per plan bound to it (N minutes included, $X/min
+  overage).
+- Add the price slot to `AGENTA_BILLING_PRICING` (`api/oss/src/utils/env.py:214`);
+  `get_stripe_meter_price()` (`api/ee/.../subscriptions/settings.py:453`) resolves
+  it per plan.
+
+## Reconciliation cron (audit only — new, optional)
+
+A sibling of `meters.sh` (e.g. `daytona_reconcile.sh` → internal endpoint, Redis
+lock, same shape) that does **not** bill. It uses the Daytona SDK with the existing
+API key to `list()` non-deleted sandboxes filtered by our `labels`, and:
+
+- flags **orphans/leaks** — sandboxes alive longer than a turn should be (a runner
+  crash that skipped `destroy()`), which is real money walking; optionally stop them.
+- cross-checks the accounted minutes against the dashboard's 48h-lagged figures as a
+  **manual** drift sanity-check.
+
+It is a safety net and observability aid, not a source of billing truth. (If
+Daytona later ships an API-key-callable per-sandbox usage endpoint — see #4643 — we
+can promote this to a true reconciliation/correction step.)
 
 ## Database migration
 
-One Alembic revision adding `SANDBOX_RUNTIME_MINUTES` to the `meters_type`
-Postgres enum. Copy the self-contained template at
+One Alembic revision adding `SANDBOX_RUNTIME_MINUTES` to the `meters_type` Postgres
+enum. Copy the self-contained template at
 `api/ee/databases/postgres/migrations/core/versions/b2c3d4e5f7a8_add_events_ingested_meter.py`
 (create temp type / alter column / drop / rename; downgrade deletes new-key rows
-first). No table/DAO/`compute_meter_id` changes — the metering core is generic
-over the enum.
+first). No table/DAO/`compute_meter_id` changes — the metering core is generic over
+the enum.
 
 ## Read & display
 
-`/billing/usage` (`api/ee/.../billing/router.py` ≈ L932) iterates the plan's
-counters and emits one row per quota automatically — the new meter appears with
+`/billing/usage` (`api/ee/.../billing/router.py` ≈ L932) emits one row per quota,
+projected to the caller's scope/period — the new resource appears with
 `value/limit/free/period/scope` once the `Quota` is declared. Frontend: add the
-label/descriptor to the usage card (`web/ee/src/services/billing/types.d.ts` +
-the card renderer) and the pricing catalog line.
+label/descriptor to the usage card (`web/ee/src/services/billing/types.d.ts` + the
+card renderer) and the pricing catalog line. Because the default scope is PROJECT,
+the card shows the **project's** runtime budget.
 
 ## What this is NOT
 
-- Not metering the legacy evaluator sandbox (explicitly out — no retrofit). The
-  generic naming leaves the door open later.
-- Not a per-minute *rate* limit (that's the separate throttle/token-bucket path).
-  This is a *quantity* of minutes over a monthly window.
-- Not changing `compute_meter_id` or the meters schema shape.
+- **Not** a Daytona-usage-pull pipeline — verified infeasible for ephemeral
+  sandboxes (no per-sandbox cost API, JWT-only `/usage`, 48h lag, sandbox gone
+  before a cron sees it). Labels are for audit/reconciliation only.
+- **Not** metering the legacy evaluator sandbox
+  (`sdks/python/agenta/sdk/engines/running/runners/daytona.py`) — no retrofit. The
+  provider-neutral name leaves the door open later.
+- **Not** a per-minute *rate* limit (that's the separate throttle/token-bucket
+  path) — this is a *quantity* of minutes over a monthly window.
+- **Not** a hard real-time cutoff — it's a post-paid budget with a lagged soft gate.
+- **Not** per-agent yet — that's the phase-2 `Scope.AGENT` rung.
 
 ## Risks & edges
 
-- **Re-ingested traces would double-charge.** Same property the existing
-  `TRACES_INGESTED` charge has; if it matters, dedupe by root-span id. Parity
-  with today's behavior is the default.
-- **Warmup dominates short runs.** Cold sandbox + `npm install` (~up to 180s)
-  means even trivial prompts cost ≥ a few minutes. That's real spend; surface it
-  in docs so customers aren't surprised, and it's an argument for sandbox pooling
-  later (separate work).
-- **Post-paid overshoot.** One run can cross the limit before the gate trips on
-  the next. Acceptable; strict quota keeps it to a single run's overage.
-- **Fail-open everywhere.** A metering outage neither blocks runs nor charges —
-  we under-bill rather than break the product. Intentional.
+- **Post-paid overshoot.** One run can cross the budget before the next is gated.
+  Bounded to a single run by `strict`. Intentional.
+- **Warmup dominates short runs.** Cold sandbox + `npm install` (~up to 180s) means
+  even trivial prompts cost a few minutes of real spend. Surface in docs; it's the
+  argument for sandbox pooling later (separate work).
+- **Orphaned sandboxes.** A runner crash that skips `destroy()` keeps a VM (and the
+  meter) running; the reconciliation cron is the backstop — flag and optionally
+  reap by label.
+- **Report delivery loss.** If the trusted post-run report is dropped, that run goes
+  unbilled (fail-open under-bills rather than breaking). At-least-once delivery +
+  `sandbox_id` idempotency keeps retries safe; the reconciliation cron catches gross
+  drift.
+- **Join-key correctness.** (C) is only as good as the `run_id → scope` record from
+  (A); get that stash/lookup right (durability, TTL) or minutes attach to the wrong
+  (or no) project.
 
 See [tasks.md](./tasks.md) for the implementation checklist and
-[research.md](./research.md) for the grounding in current code.
+[research.md](./research.md) for the grounding in current code and the Daytona API
+findings.

--- a/docs/designs/sandbox-runtime-metering/research.md
+++ b/docs/designs/sandbox-runtime-metering/research.md
@@ -1,0 +1,99 @@
+# Sandbox Runtime Metering — Research
+
+Grounding for [proposal.md](./proposal.md): how metering, billing, and the agent
+sandbox actually work in the tree today. File:line refs are approximate anchors.
+
+## Metering subsystem (EE)
+
+The whole metering subsystem lives in `api/ee/`; OSS only *calls into* it via
+`check_entitlements`, guarded by `is_ee()`. There is no "usage event" table —
+metering is pre-aggregated counter/gauge rows updated atomically in place.
+
+- **Dimensions today** — `api/ee/src/core/access/entitlements/types.py`:
+  `Counter = {EVALUATIONS_RUN, TRACES_INGESTED, TRACES_RETRIEVED, CREDITS_CONSUMED, EVENTS_INGESTED}`,
+  `Gauge = {USERS}`. Mirrored to `Meters` in `api/ee/src/core/meters/types.py:23`
+  (member **name** binds the DB enum; `Counter` carries the lowercase **value** —
+  cross with `Meters[counter.name]`).
+- **Table** — `meters` (`api/ee/src/dbs/postgres/meters/{dbes,dbas,dao}.py`). PK
+  `meter_id` (deterministic UUIDv5 via `compute_meter_id`), nullable scope
+  (`organization_id/workspace_id/project_id/user_id`) and period
+  (`year/month/day`), `key meters_type`, `value`, `synced` (last value pushed to
+  Stripe).
+- **Write/enforce chokepoint** — `check_entitlements(key, delta, cache, scope, period)`
+  at `api/ee/src/core/access/entitlements/service.py:272`. Soft mode
+  (`cache=True`) = Redis read, never writes; hard mode = atomic upsert
+  `INSERT ... ON CONFLICT (meter_id) DO UPDATE SET value = greatest(value+delta,0)
+  WHERE <quota predicate> RETURNING value` (`dao.py:376`). Strict predicate:
+  `greatest(value+delta,0) <= limit`. **Fails open** on non-`EntitlementsException`.
+- **Existing write call-sites** — `TRACES_INGESTED`: soft-check at OTLP edge
+  (`api/oss/src/apis/fastapi/otlp/router.py:224`), hard charge per-org in
+  `api/oss/src/tasks/asyncio/tracing/worker.py:268`. `EVALUATIONS_RUN`: sync in
+  `apis/fastapi/evaluations/router.py` with refund-on-failure.
+- **Read** — `/billing/usage` (`api/ee/src/apis/fastapi/billing/router.py` ≈ 932)
+  emits one row per plan quota, projected to the caller's scope/period.
+- **Adding a counter** — add to `Counter` → mirror in `Meters` → `Quota` per plan
+  in `DEFAULT_ENTITLEMENTS` → enum migration (template
+  `…/versions/b2c3d4e5f7a8_add_events_ingested_meter.py`) → optional `REPORTS` /
+  `CONSTRAINTS` → call `check_entitlements` at the usage site. DAO, reader, and
+  `compute_meter_id` are generic and need no change.
+
+## Billing / plans / Stripe (EE)
+
+- **Plans** — `DefaultPlan` (`types.py:6`): hobby / pro / business /
+  agenta-internal / self-hosted-enterprise. Grants in `DEFAULT_ENTITLEMENTS`
+  (`types.py:332-670`), display in `DEFAULT_CATALOG` (`types.py:189-330`).
+  Env-overridable via `AGENTA_ACCESS_PLANS` / `AGENTA_ACCESS_DEFAULT_PLAN_OVERLAY`.
+- **`Quota`** (`types.py:90`): `free, limit, strict, retention, scope, period`,
+  all optional. `period ∈ {DAILY, MONTHLY, YEARLY}` is the **reset window**, not
+  the unit. `scope=None ⇒ organization`.
+- **Stripe** — billing router `api/ee/src/apis/fastapi/billing/router.py`
+  (webhooks, checkouts, portals, `/usage`, `/catalog`, admin report). Lazy-loaded;
+  no-ops without `STRIPE_API_KEY`. Usage push: `MetersService.report()`
+  (`api/ee/src/core/meters/service.py:75`) → counters via
+  `stripe.billing.MeterEvent.create(delta=value-synced)`, gauges via
+  `Subscription.modify`. Reportable set = `REPORTS` dict (`types.py:677`). Price
+  IDs from `AGENTA_BILLING_PRICING` (`api/oss/src/utils/env.py:214`), resolved by
+  `get_stripe_meter_price()` (`api/ee/src/core/subscriptions/settings.py:453`).
+  Cron: `api/ee/src/crons/meters.{sh,txt}` → `POST /admin/billing/usage/report`.
+- **Enforcement on exceed** varies by call-site: OSS routers raise `429`; EE
+  routers return `NOT_ENTITLED_RESPONSE` (403 + upgrade copy); workers drop the
+  batch. Rate limits are a *separate* path — `throttling_middleware`
+  (`api/ee/src/middlewares/throttling.py`), token-bucket per `Category`.
+
+## Agent sandbox runtime
+
+Two distinct Daytona systems — **do not conflate**:
+
+| | Code-evaluator (shipped, OSS) | **Agent runner (rivet, target)** |
+|---|---|---|
+| Runs | user evaluator code | a coding agent over ACP |
+| Core | `sdks/python/agenta/sdk/engines/running/runners/daytona.py` | `services/agent/src/engines/rivet.ts` |
+| Lifetime | one sandbox per `run()` | one **cold** sandbox per prompt turn |
+
+- **Lifetime bracket (target)** — `runRivet()` (`rivet.ts` ≈ L782): VM lives from
+  `SandboxAgent.start()` (≈ L883) to `destroySandbox()` (≈ L1079, in `finally`).
+  Includes provisioning + `installPiInSandbox()` warmup (up to ~180s). No pooling,
+  no reuse — conversation continuity is by replaying history into a fresh VM. So
+  **billable minutes = Σ per-turn lifetimes**.
+- **Duration today** — **not captured**. No `elapsed/duration/perf_counter` for
+  either sandbox. `AgentUsage` (`services/agent/src/protocol.ts:178`) tracks
+  tokens + LLM cost only.
+- **Entry point** — agent app `/invoke` & `/messages`
+  (`services/oss/src/agent/app.py:76`); `record_usage(result.usage)` (≈ L127)
+  stamps `gen_ai.usage.*` on the workflow span via
+  `services/oss/src/agent/tracing.py:62`. **This is where a
+  `sandbox.runtime_ms` attribute slots in.**
+- **Attribution** — only `project_id` (OTel baggage) + credentials reach the
+  runner; org/workspace/user are **not** propagated there. ⇒ resolve org at trace
+  ingestion (the worker already does) rather than in the runner.
+- **Telemetry** — TS runner exports OTel spans OTLP/HTTP to
+  `{AGENTA_HOST}/api/otlp/v1/traces` (`services/agent/src/tracing/otel.ts`). No
+  separate metrics pipeline — duration is a **span attribute**, not a metric.
+
+## Consequence for the design
+
+Because the runner already feeds the OTLP ingest that charges `TRACES_INGESTED`
+per-org in a worker, the runtime-minutes charge piggybacks on that exact path:
+stamp `sandbox.runtime_ms` on the root span (B), extend the worker to sum
+`ceil(ms/60000)` per org and charge `SANDBOX_RUNTIME_MINUTES` (C'), and soft-gate
+at the invocation edge (A). No new attribution or transport.

--- a/docs/designs/sandbox-runtime-metering/research.md
+++ b/docs/designs/sandbox-runtime-metering/research.md
@@ -1,7 +1,8 @@
 # Sandbox Runtime Metering — Research
 
 Grounding for [proposal.md](./proposal.md): how metering, billing, and the agent
-sandbox actually work in the tree today. File:line refs are approximate anchors.
+sandbox actually work today, plus what Daytona's API does and does not expose.
+File:line refs are approximate anchors.
 
 ## Metering subsystem (EE)
 
@@ -14,50 +15,64 @@ metering is pre-aggregated counter/gauge rows updated atomically in place.
   `Gauge = {USERS}`. Mirrored to `Meters` in `api/ee/src/core/meters/types.py:23`
   (member **name** binds the DB enum; `Counter` carries the lowercase **value** —
   cross with `Meters[counter.name]`).
+- **Scope** — `Scope` enum (`types.py:83`): `ORGANIZATION | PROJECT | USER`. There
+  is **no `AGENT` scope** today; per-agent budgets are a future addition. `Quota`
+  with `scope=None` defaults to organization.
 - **Table** — `meters` (`api/ee/src/dbs/postgres/meters/{dbes,dbas,dao}.py`). PK
   `meter_id` (deterministic UUIDv5 via `compute_meter_id`), nullable scope
-  (`organization_id/workspace_id/project_id/user_id`) and period
-  (`year/month/day`), `key meters_type`, `value`, `synced` (last value pushed to
-  Stripe).
+  (`organization_id/workspace_id/project_id/user_id`) and period (`year/month/day`),
+  `key meters_type`, `value`, `synced` (last value pushed to Stripe). A
+  project-scoped row still carries `organization_id`, so Stripe billing can roll up
+  per org.
 - **Write/enforce chokepoint** — `check_entitlements(key, delta, cache, scope, period)`
-  at `api/ee/src/core/access/entitlements/service.py:272`. Soft mode
-  (`cache=True`) = Redis read, never writes; hard mode = atomic upsert
+  at `api/ee/src/core/access/entitlements/service.py:272`. Soft mode (`cache=True`)
+  = Redis read, **never writes** (`service.py:276`) — this is the pre-run *gate*.
+  Hard mode = atomic upsert
   `INSERT ... ON CONFLICT (meter_id) DO UPDATE SET value = greatest(value+delta,0)
   WHERE <quota predicate> RETURNING value` (`dao.py:376`). Strict predicate:
   `greatest(value+delta,0) <= limit`. **Fails open** on non-`EntitlementsException`.
 - **Existing write call-sites** — `TRACES_INGESTED`: soft-check at OTLP edge
-  (`api/oss/src/apis/fastapi/otlp/router.py:224`), hard charge per-org in
-  `api/oss/src/tasks/asyncio/tracing/worker.py:268`. `EVALUATIONS_RUN`: sync in
-  `apis/fastapi/evaluations/router.py` with refund-on-failure.
-- **Read** — `/billing/usage` (`api/ee/src/apis/fastapi/billing/router.py` ≈ 932)
-  emits one row per plan quota, projected to the caller's scope/period.
-- **Adding a counter** — add to `Counter` → mirror in `Meters` → `Quota` per plan
-  in `DEFAULT_ENTITLEMENTS` → enum migration (template
+  (`api/oss/.../otlp/router.py:224`), hard charge per-org in the tracing worker
+  (`api/oss/.../tracing/worker.py:268`). `EVALUATIONS_RUN`: sync in
+  `apis/fastapi/evaluations/router.py` with refund-on-failure. These show both the
+  soft-gate-then-hard-charge shape and per-scope charging from a background job.
+- **Read** — `/billing/usage` (`api/ee/.../billing/router.py` ≈ 932) emits one row
+  per plan quota, projected to the caller's scope/period.
+- **Adding a counter** — add to `Counter` → mirror in `Meters` → `Quota` per plan in
+  `DEFAULT_ENTITLEMENTS` → enum migration (template
   `…/versions/b2c3d4e5f7a8_add_events_ingested_meter.py`) → optional `REPORTS` /
   `CONSTRAINTS` → call `check_entitlements` at the usage site. DAO, reader, and
   `compute_meter_id` are generic and need no change.
 
-## Billing / plans / Stripe (EE)
+## Billing / plans / Stripe + the report cron (EE)
 
-- **Plans** — `DefaultPlan` (`types.py:6`): hobby / pro / business /
-  agenta-internal / self-hosted-enterprise. Grants in `DEFAULT_ENTITLEMENTS`
-  (`types.py:332-670`), display in `DEFAULT_CATALOG` (`types.py:189-330`).
-  Env-overridable via `AGENTA_ACCESS_PLANS` / `AGENTA_ACCESS_DEFAULT_PLAN_OVERLAY`.
-- **`Quota`** (`types.py:90`): `free, limit, strict, retention, scope, period`,
-  all optional. `period ∈ {DAILY, MONTHLY, YEARLY}` is the **reset window**, not
-  the unit. `scope=None ⇒ organization`.
-- **Stripe** — billing router `api/ee/src/apis/fastapi/billing/router.py`
-  (webhooks, checkouts, portals, `/usage`, `/catalog`, admin report). Lazy-loaded;
-  no-ops without `STRIPE_API_KEY`. Usage push: `MetersService.report()`
-  (`api/ee/src/core/meters/service.py:75`) → counters via
-  `stripe.billing.MeterEvent.create(delta=value-synced)`, gauges via
-  `Subscription.modify`. Reportable set = `REPORTS` dict (`types.py:677`). Price
-  IDs from `AGENTA_BILLING_PRICING` (`api/oss/src/utils/env.py:214`), resolved by
-  `get_stripe_meter_price()` (`api/ee/src/core/subscriptions/settings.py:453`).
-  Cron: `api/ee/src/crons/meters.{sh,txt}` → `POST /admin/billing/usage/report`.
-- **Enforcement on exceed** varies by call-site: OSS routers raise `429`; EE
-  routers return `NOT_ENTITLED_RESPONSE` (403 + upgrade copy); workers drop the
-  batch. Rate limits are a *separate* path — `throttling_middleware`
+- **Plans** — `DefaultPlan` (`types.py:6`): hobby / pro / business / agenta-internal
+  / self-hosted-enterprise. Grants in `DEFAULT_ENTITLEMENTS` (`types.py:332-670`),
+  display in `DEFAULT_CATALOG` (`types.py:189-330`). Env-overridable via
+  `AGENTA_ACCESS_PLANS` / `AGENTA_ACCESS_DEFAULT_PLAN_OVERLAY`.
+- **`Quota`** (`types.py:90`): `free, limit, strict, retention, scope, period`, all
+  optional. `period ∈ {DAILY, MONTHLY, YEARLY}` is the **reset window**, not the
+  unit. `scope=None ⇒ organization`.
+- **Stripe push** — `MetersService.report()` (`api/ee/src/core/meters/service.py:75`):
+  `dump()` selects rows where `synced != value`, batched; for each meter whose key is
+  in `REPORTS`, counters → `stripe.billing.MeterEvent.create(delta = value - synced,
+  customer_id, identifier=…)` (Stripe dedupes by identifier), gauges →
+  `Subscription.modify`; then `bump()` sets `synced = value`. Reportable set =
+  `REPORTS` dict (`types.py:677`). Price IDs from `AGENTA_BILLING_PRICING`
+  (`api/oss/src/utils/env.py:214`), resolved by `get_stripe_meter_price()`
+  (`api/ee/.../subscriptions/settings.py:453`).
+- **The report cron is a push/sync job, not a pull.** `api/ee/src/crons/meters.txt`
+  runs `meters.sh` at `:15` and `:45` (every 30 min). `meters.sh` is a thin wrapper:
+  one `curl -X POST http://api:8000/admin/billing/usage/report` with
+  `Authorization: Access ${AGENTA_AUTH_KEY}` (admin key), 15-min timeout. The
+  endpoint (`billing/router.py:1051`, schema-hidden `/admin/billing`) takes a Redis
+  lock (`namespace="meters:report"`, ~1h TTL; `/usage/report/unlock` force-releases)
+  then calls `report()`. It reads the **local `meters` table** and flushes deltas
+  **out to Stripe** — it never pulls usage from anywhere. Siblings `events.sh`,
+  `spans.sh` follow the identical pattern; a new metering/reconcile cron would too.
+- **Enforcement on exceed** varies by call-site: OSS routers raise `429`; EE routers
+  return `NOT_ENTITLED_RESPONSE` (403 + upgrade copy); workers drop the batch. Rate
+  limits are a *separate* path — `throttling_middleware`
   (`api/ee/src/middlewares/throttling.py`), token-bucket per `Category`.
 
 ## Agent sandbox runtime
@@ -74,26 +89,79 @@ Two distinct Daytona systems — **do not conflate**:
   `SandboxAgent.start()` (≈ L883) to `destroySandbox()` (≈ L1079, in `finally`).
   Includes provisioning + `installPiInSandbox()` warmup (up to ~180s). No pooling,
   no reuse — conversation continuity is by replaying history into a fresh VM. So
-  **billable minutes = Σ per-turn lifetimes**.
+  **billable minutes = Σ per-turn lifetimes**, and the runner is the only component
+  that observes a complete lifetime.
 - **Duration today** — **not captured**. No `elapsed/duration/perf_counter` for
-  either sandbox. `AgentUsage` (`services/agent/src/protocol.ts:178`) tracks
-  tokens + LLM cost only.
+  either sandbox. `AgentUsage` (`services/agent/src/protocol.ts:178`) tracks tokens
+  + LLM cost only.
 - **Entry point** — agent app `/invoke` & `/messages`
-  (`services/oss/src/agent/app.py:76`); `record_usage(result.usage)` (≈ L127)
-  stamps `gen_ai.usage.*` on the workflow span via
-  `services/oss/src/agent/tracing.py:62`. **This is where a
-  `sandbox.runtime_ms` attribute slots in.**
-- **Attribution** — only `project_id` (OTel baggage) + credentials reach the
-  runner; org/workspace/user are **not** propagated there. ⇒ resolve org at trace
-  ingestion (the worker already does) rather than in the runner.
-- **Telemetry** — TS runner exports OTel spans OTLP/HTTP to
-  `{AGENTA_HOST}/api/otlp/v1/traces` (`services/agent/src/tracing/otel.ts`). No
-  separate metrics pipeline — duration is a **span attribute**, not a metric.
+  (`services/oss/src/agent/app.py:76`); `record_usage(result.usage)` (≈ L127) stamps
+  `gen_ai.usage.*` on the workflow span via `services/oss/src/agent/tracing.py:62`.
+- **Attribution** — only `project_id` (OTel baggage) + credentials reach the runner;
+  org/workspace/user are **not** propagated there. The EE invocation edge, however,
+  has org+project+user resolved — which is where the gate and the `run_id → scope`
+  record live.
+- **Telemetry** — the TS runner exports OTel spans OTLP/HTTP to
+  `{AGENTA_HOST}/api/otlp/v1/traces` (`services/agent/src/tracing/otel.ts`). Usable
+  as a *fallback* duration channel (span attribute) but customer-influenceable on
+  that ingest, so not the billing source of record.
+
+## Daytona API reality
+
+Findings verified against Daytona's official docs and SDK references (June 2026).
+**Bottom line: you cannot pull per-sandbox runtime or cost from Daytona via API
+today.** Build metering around the runner; use labels for audit only.
+
+- **No per-sandbox usage/cost API.** CPU-seconds, RAM GB-seconds, disk GB-seconds,
+  and total price exist **only in the dashboard "Spending" view** — no REST endpoint
+  or SDK method exports them. ([Billing](https://www.daytona.io/docs/en/billing/))
+- **`GET /organizations/:id/usage` is the wrong data and unreachable from a cron.**
+  Returns live quota-vs-allocation snapshots (cores/GB in use now), org/region
+  scoped — no cost, no time-integration, never per-sandbox. Currently **JWT-only
+  (~1h expiry), not API-key callable**; API-key support + a `READ_ORGANIZATION_USAGE`
+  permission is an **open, unimplemented request**
+  ([daytonaio/daytona#4643](https://github.com/daytonaio/daytona/issues/4643)).
+- **Billing lag up to 48h**, documented.
+- **Lifecycle data that *does* exist** (on `list()`/`get()`, the metering-viable
+  path, but see caveats): `id` (stable, unique, the idempotency key), `labels`,
+  `createdAt`, `updatedAt`, `lastActivityAt`, `state`
+  (`Started/Stopped/Archived/Deleted/…`), and auto-lifecycle fields
+  `autoStopInterval` (default 15 min), `autoArchiveInterval` (default 7 days),
+  `autoDeleteInterval` (default never). **No `startedAt`/`stoppedAt`** — exact
+  runtime would require tracking state transitions yourself.
+  ([TS Sandbox object](https://www.daytona.io/docs/en/typescript-sdk/sandbox/),
+  [Sandboxes](https://www.daytona.io/docs/en/sandboxes/))
+- **Why list-polling still fails for us:** our sandboxes are ephemeral (created and
+  destroyed inside one run, seconds–minutes), so a periodic cron finds them already
+  deleted, and **deleted-sandbox retention in `list` is undocumented**. Snapshot
+  final state before delete if you ever rely on it.
+- **Labels** — field `labels: Record<string,string>`; settable at creation
+  (`CreateSandboxFromSnapshotParams`/`...BaseParams`), updatable later (set
+  **replaces** the full set), filterable in `list({ labels: {…} })`. Count/length/
+  charset constraints undocumented. ([TS Daytona class](https://www.daytona.io/docs/en/typescript-sdk/daytona/),
+  [Python Daytona class](https://www.daytona.io/docs/python-sdk/sync/daytona/))
+- **Auth** — API key as `Authorization: Bearer <KEY>` + `X-Daytona-Organization-ID`;
+  keys are org-scoped with granular permissions (sandbox create/delete, etc.). No
+  "read usage" permission exists. SDK sandbox ops (create/list/get/stop/delete) work
+  with an API key. ([API Keys](https://www.daytona.io/docs/en/api-keys/))
+- **SDKs** — Python `daytona` (formerly `daytona_sdk`), TS `@daytonaio/sdk`:
+  `create(params, labels=…)`, `list(query with labels filter)`, `get(id_or_name)`,
+  `start/stop/delete`. **No usage-related SDK methods.**
 
 ## Consequence for the design
 
-Because the runner already feeds the OTLP ingest that charges `TRACES_INGESTED`
-per-org in a worker, the runtime-minutes charge piggybacks on that exact path:
-stamp `sandbox.runtime_ms` on the root span (B), extend the worker to sum
-`ceil(ms/60000)` per org and charge `SANDBOX_RUNTIME_MINUTES` (C'), and soft-gate
-at the invocation edge (A). No new attribution or transport.
+- **Measurement source = the runner** (only component that observes the full
+  ephemeral lifetime; Daytona exposes no usable per-sandbox usage/cost API).
+- **Attribution + gate = the entitlements layer** — soft `check_entitlements`
+  (`cache=True`) at the cached auth/invocation edge (the *gate*), `run_id → scope`
+  recorded there, hard `check_entitlements(delta=minutes)` from a **trusted post-run
+  report** keyed/idempotent on `sandbox_id`, attributed from the recorded scope
+  (never the report payload).
+- **Default scope = PROJECT** (the configurable "resource"); USER available today,
+  AGENT is phase 2.
+- **Daytona labels = audit/reconciliation/leak-detection only**, never the billing
+  source. A reconciliation cron can `list()` non-deleted sandboxes by label to catch
+  orphans and sanity-check the 48h-lagged dashboard. If #4643 ships an API-key usage
+  endpoint, this can become a true correction step.
+- **Stripe** = the existing report cron flushes the new counter once it is in
+  `REPORTS`; project-scoped rows roll up per org via `organization_id`.

--- a/docs/designs/sandbox-runtime-metering/tasks.md
+++ b/docs/designs/sandbox-runtime-metering/tasks.md
@@ -1,85 +1,108 @@
 # Sandbox Runtime Metering — Implementation Checklist
 
-Ordered so each step is independently reviewable. See
-[proposal.md](./proposal.md) for rationale.
+Ordered so each step is independently reviewable. See [proposal.md](./proposal.md)
+for rationale and [research.md](./research.md) for code/API grounding.
 
-## 1. Capture in the runner (TS) — point (B)
+## 1. Measure in the runner (TS) — point (B)
 
 - [ ] `services/agent/src/engines/rivet.ts::runRivet()`: `t0 = performance.now()`
       before `SandboxAgent.start()`; in the `finally` after `destroySandbox()`,
       `runtimeMs = Math.round(performance.now() - t0)`.
-- [ ] `services/agent/src/protocol.ts`: add `sandboxRuntimeMs?: number` to
-      `AgentRunResult` (next to `usage`). Populate it from `runRivet`. Local /
-      non-Daytona backends leave it unset.
-- [ ] (optional) also set it on the runner's `invoke_agent` root span attribute
-      directly in `services/agent/src/tracing/otel.ts` for runner-side traces.
+- [ ] At sandbox creation, set `labels = { org, project, run_id, [agent, user] }`
+      (Daytona `labels` create-param) for reconciliation/leak-detection.
+- [ ] Carry `runtimeMs` (+ `sandbox.id`, `run_id`) back to where the post-run report
+      is sent. Local / non-Daytona backends leave it unset ⇒ they meter zero.
 
-## 2. Propagate + stamp the span (Python) — bridge to OTLP
+## 2. Gate — fold into the cached auth check (EE) — point (A)
 
-- [ ] `sdks/python/agenta/sdk/agents/adapters/rivet.py`: surface
-      `sandboxRuntimeMs` from the runner result onto the Python result object.
-- [ ] `services/oss/src/agent/tracing.py::record_usage()` (and its call in
-      `app.py` ≈ L127): stamp `sandbox.runtime_ms` on the workflow/root span
-      alongside `gen_ai.usage.*`. Only the root span.
+- [ ] At the agent invocation edge (where org/project/user are resolved): soft
+      `check_entitlements(key=Counter.SANDBOX_RUNTIME_MINUTES, delta=0, cache=True,
+      scope=scope_from(project_id=...))`; raise `HTTPException(429, "…agent runtime
+      minutes quota…")` when not allowed. Fail-open on error.
+- [ ] Record `run_id → resolved scope` (org/project/[user]) for the post-run join.
+      **Decide the store**: durable run record vs short-TTL Redis key. (Load-bearing
+      for correct attribution — pick the durable option unless there's a reason not
+      to.)
 
-## 3. Registry / config (EE)
+## 3. Account — trusted post-run report (EE) — point (C)
+
+- [ ] New **internal** metering endpoint in `api/` (EE), authenticated as the agent
+      service's **existing** credential (NOT the admin `AGENTA_AUTH_KEY`). Accepts
+      `(run_id, sandbox_id, runtime_ms)`.
+- [ ] Handler: load scope via `run_id` (from step 2), `minutes = ceil(runtime_ms /
+      60_000)` (per-run ceil, applied here once), then
+      `check_entitlements(key=Counter.SANDBOX_RUNTIME_MINUTES, delta=minutes,
+      scope=<loaded>, idempotency_key=sandbox_id)`. Never read tenant from the
+      payload. Post-paid: do not reject on `allowed=False`.
+- [ ] Runner/agent-service: send the report after `destroy()` (at-least-once;
+      `sandbox_id` makes retries idempotent). Failure to send ⇒ unbilled (fail-open),
+      caught later by reconciliation.
+
+## 4. Registry / config (EE)
 
 - [ ] `api/ee/src/core/access/entitlements/types.py`:
   - [ ] `Counter.SANDBOX_RUNTIME_MINUTES = "sandbox_runtime_minutes"`.
-  - [ ] `DEFAULT_ENTITLEMENTS`: add a `Quota(... period=Period.MONTHLY, strict=True)`
-        under `Tracker.COUNTERS` for **every** plan (real `limit` on Hobby/Pro,
-        `None` on Business/Enterprise/Agenta). Numbers TBD by product.
+  - [ ] `DEFAULT_ENTITLEMENTS`: add `Quota(scope=Scope.PROJECT, period=Period.MONTHLY,
+        strict=True, ...)` under `Tracker.COUNTERS` for **every** plan (real `limit`
+        on Hobby/Pro, `None` on Business/Enterprise/Agenta). Numbers TBD by product.
   - [ ] `CONSTRAINTS[Constraint.READ_ONLY][Tracker.COUNTERS]`: include it.
   - [ ] `REPORTS`: `Counter.SANDBOX_RUNTIME_MINUTES.value: "sandbox_runtime_minutes"`.
   - [ ] `DEFAULT_CATALOG`: display line (allotment + overage).
 - [ ] `api/ee/src/core/meters/types.py`: mirror
       `SANDBOX_RUNTIME_MINUTES = Counter.SANDBOX_RUNTIME_MINUTES.value` in `Meters`.
 
-## 4. Database migration (EE)
+## 5. Database migration (EE)
 
 - [ ] New Alembic revision adding `SANDBOX_RUNTIME_MINUTES` to the `meters_type`
       enum — copy `…/core/versions/b2c3d4e5f7a8_add_events_ingested_meter.py`
       (type-swap up; downgrade deletes new-key rows first).
 
-## 5. Charge in the worker (EE) — point (C')
-
-- [ ] `api/oss/src/tasks/asyncio/tracing/worker.py` (≈ L268): in the existing
-      per-org loop, sum `ceil(span.attributes["sandbox.runtime_ms"] / 60_000)`
-      over root spans and `await check_entitlements(key=Counter.SANDBOX_RUNTIME_MINUTES,
-      delta=minutes, scope=scope_from(organization_id=org_id))` when `> 0`.
-      Do not drop the batch on `allowed=False` (post-paid).
-
-## 6. Gate before the run (EE) — point (A)
-
-- [ ] At the agent invocation entry (gateway/invoke handler): soft
-      `check_entitlements(key=Counter.SANDBOX_RUNTIME_MINUTES, delta=0, cache=True)`;
-      raise `HTTPException(429, "…agent runtime minutes quota…")` when not allowed.
-
-## 7. Stripe (config, not code)
+## 6. Stripe (config, not code)
 
 - [ ] Create Stripe Meter `sandbox_runtime_minutes`.
 - [ ] Create usage-based Price per plan bound to it (included minutes + overage).
-- [ ] Add the price slot to `AGENTA_BILLING_PRICING` env so
-      `get_stripe_meter_price()` resolves it.
+- [ ] Add the price slot to `AGENTA_BILLING_PRICING` env so `get_stripe_meter_price()`
+      resolves it. (Existing report cron then flushes it automatically; project rows
+      roll up per org via `organization_id`.)
+
+## 7. Reconciliation cron (EE) — audit only, optional but recommended
+
+- [ ] Sibling of `meters.sh` (`daytona_reconcile.{sh,txt}`) → internal endpoint,
+      Redis-locked, same shape. Does **not** bill.
+- [ ] Handler: Daytona SDK `list({labels})` over non-deleted sandboxes; flag
+      orphans/leaks (alive longer than a turn ⇒ skipped `destroy()`), optionally reap;
+      log drift vs the dashboard's 48h-lagged figures for manual sanity-check.
 
 ## 8. Frontend
 
-- [ ] `web/ee/src/services/billing/types.d.ts` + usage card: render the new
-      counter (label, unit = "minutes").
+- [ ] `web/ee/src/services/billing/types.d.ts` + usage card: render the new counter
+      (label, unit = "minutes"); it's the **project's** budget by default.
 - [ ] Pricing modal: surface the catalog line.
 
 ## 9. Tests / verification
 
-- [ ] Unit: `ceil` rounding (12s→1, 60s→1, 61s→2, 0→0); attribute-missing ⇒ 0.
-- [ ] Worker: per-org sum + charge with a synthetic batch of root spans.
-- [ ] Gate: 429 once `value >= limit`; fail-open when metering errors.
-- [ ] `/billing/usage` shows the counter with correct value/limit/period.
-- [ ] Manual: run an agent on the Daytona backend, confirm minutes accrue and
-      report to a Stripe test meter.
+- [ ] Unit: `ceil` rounding (12s→1, 60s→1, 61s→2, 0→0); missing runtime ⇒ 0.
+- [ ] Account endpoint: attribution comes from the `run_id` record, not the payload;
+      duplicate `sandbox_id` charges once (idempotency); fail-open on metering error.
+- [ ] Gate: 429 once `value >= limit` for the project scope; fail-open when metering
+      errors.
+- [ ] `/billing/usage` shows the counter with correct value/limit/period at PROJECT
+      scope.
+- [ ] Reconciliation: a synthetic orphaned sandbox (matching labels, long-lived) is
+      flagged.
+- [ ] Manual: run an agent on the Daytona backend; confirm minutes accrue against the
+      project budget and report to a Stripe test meter.
 
-## Open product inputs (need numbers/decisions)
+## Open inputs / decisions
 
-- Per-plan minute allotments + limits (Hobby cap, Pro/Business included + overage).
-- Overage price per minute.
-- Whether to dedupe re-ingested traces (double-charge guard) now or accept
-  parity with `TRACES_INGESTED`.
+- **Product numbers:** per-plan minute allotments + limits (Hobby cap, Pro/Business
+  included + overage), overage price per minute.
+- **Join key + store** (step 2): durable run record vs Redis stash, and the exact
+  `run_id`/session identifier shared by gate and runner.
+- **Internal report auth:** confirm the exact existing agent-service credential /
+  internal auth mechanism for the metering endpoint (must not be the admin key).
+- **Daytona usage API:** track daytonaio/daytona#4643 — if an API-key-callable
+  per-sandbox usage endpoint ships, promote the reconciliation cron to a true
+  correction step. (We have team access; ask Daytona to confirm/prioritize.)
+- **Phase 2:** `Scope.AGENT` + request-addressable resource selection (per-agent
+  budgets, multiple resources per project).

--- a/docs/designs/sandbox-runtime-metering/tasks.md
+++ b/docs/designs/sandbox-runtime-metering/tasks.md
@@ -1,0 +1,85 @@
+# Sandbox Runtime Metering — Implementation Checklist
+
+Ordered so each step is independently reviewable. See
+[proposal.md](./proposal.md) for rationale.
+
+## 1. Capture in the runner (TS) — point (B)
+
+- [ ] `services/agent/src/engines/rivet.ts::runRivet()`: `t0 = performance.now()`
+      before `SandboxAgent.start()`; in the `finally` after `destroySandbox()`,
+      `runtimeMs = Math.round(performance.now() - t0)`.
+- [ ] `services/agent/src/protocol.ts`: add `sandboxRuntimeMs?: number` to
+      `AgentRunResult` (next to `usage`). Populate it from `runRivet`. Local /
+      non-Daytona backends leave it unset.
+- [ ] (optional) also set it on the runner's `invoke_agent` root span attribute
+      directly in `services/agent/src/tracing/otel.ts` for runner-side traces.
+
+## 2. Propagate + stamp the span (Python) — bridge to OTLP
+
+- [ ] `sdks/python/agenta/sdk/agents/adapters/rivet.py`: surface
+      `sandboxRuntimeMs` from the runner result onto the Python result object.
+- [ ] `services/oss/src/agent/tracing.py::record_usage()` (and its call in
+      `app.py` ≈ L127): stamp `sandbox.runtime_ms` on the workflow/root span
+      alongside `gen_ai.usage.*`. Only the root span.
+
+## 3. Registry / config (EE)
+
+- [ ] `api/ee/src/core/access/entitlements/types.py`:
+  - [ ] `Counter.SANDBOX_RUNTIME_MINUTES = "sandbox_runtime_minutes"`.
+  - [ ] `DEFAULT_ENTITLEMENTS`: add a `Quota(... period=Period.MONTHLY, strict=True)`
+        under `Tracker.COUNTERS` for **every** plan (real `limit` on Hobby/Pro,
+        `None` on Business/Enterprise/Agenta). Numbers TBD by product.
+  - [ ] `CONSTRAINTS[Constraint.READ_ONLY][Tracker.COUNTERS]`: include it.
+  - [ ] `REPORTS`: `Counter.SANDBOX_RUNTIME_MINUTES.value: "sandbox_runtime_minutes"`.
+  - [ ] `DEFAULT_CATALOG`: display line (allotment + overage).
+- [ ] `api/ee/src/core/meters/types.py`: mirror
+      `SANDBOX_RUNTIME_MINUTES = Counter.SANDBOX_RUNTIME_MINUTES.value` in `Meters`.
+
+## 4. Database migration (EE)
+
+- [ ] New Alembic revision adding `SANDBOX_RUNTIME_MINUTES` to the `meters_type`
+      enum — copy `…/core/versions/b2c3d4e5f7a8_add_events_ingested_meter.py`
+      (type-swap up; downgrade deletes new-key rows first).
+
+## 5. Charge in the worker (EE) — point (C')
+
+- [ ] `api/oss/src/tasks/asyncio/tracing/worker.py` (≈ L268): in the existing
+      per-org loop, sum `ceil(span.attributes["sandbox.runtime_ms"] / 60_000)`
+      over root spans and `await check_entitlements(key=Counter.SANDBOX_RUNTIME_MINUTES,
+      delta=minutes, scope=scope_from(organization_id=org_id))` when `> 0`.
+      Do not drop the batch on `allowed=False` (post-paid).
+
+## 6. Gate before the run (EE) — point (A)
+
+- [ ] At the agent invocation entry (gateway/invoke handler): soft
+      `check_entitlements(key=Counter.SANDBOX_RUNTIME_MINUTES, delta=0, cache=True)`;
+      raise `HTTPException(429, "…agent runtime minutes quota…")` when not allowed.
+
+## 7. Stripe (config, not code)
+
+- [ ] Create Stripe Meter `sandbox_runtime_minutes`.
+- [ ] Create usage-based Price per plan bound to it (included minutes + overage).
+- [ ] Add the price slot to `AGENTA_BILLING_PRICING` env so
+      `get_stripe_meter_price()` resolves it.
+
+## 8. Frontend
+
+- [ ] `web/ee/src/services/billing/types.d.ts` + usage card: render the new
+      counter (label, unit = "minutes").
+- [ ] Pricing modal: surface the catalog line.
+
+## 9. Tests / verification
+
+- [ ] Unit: `ceil` rounding (12s→1, 60s→1, 61s→2, 0→0); attribute-missing ⇒ 0.
+- [ ] Worker: per-org sum + charge with a synthetic batch of root spans.
+- [ ] Gate: 429 once `value >= limit`; fail-open when metering errors.
+- [ ] `/billing/usage` shows the counter with correct value/limit/period.
+- [ ] Manual: run an agent on the Daytona backend, confirm minutes accrue and
+      report to a Stripe test meter.
+
+## Open product inputs (need numbers/decisions)
+
+- Per-plan minute allotments + limits (Hobby cap, Pro/Business included + overage).
+- Overage price per minute.
+- Whether to dedupe re-ingested traces (double-charge guard) now or accept
+  parity with `TRACES_INGESTED`.


### PR DESCRIPTION
## Context

We pay Daytona by the minute for the ephemeral VM that runs an agent, but that runtime never reaches our pricing surface — no meter, no per-plan limit, nothing reported to Stripe. This design adds sandbox wall-time as a first-class billable dimension, modeled as a **configurable, scoped resource** so it also lays the first rail for "limit usage per project / agent / user."

Documentation only. Adds a design under `docs/designs/sandbox-runtime-metering/` (proposal, research, tasks). No code or schema changes.

## The model

A **resource** is a named, scoped **entitlement with a quota** — exactly what the EE `check_entitlements` / `Quota` / `Scope` / `meters` layer already provides. A request declares the resource it's about to consume; the system checks entitlement at the same cached point it already checks auth, and only then runs; the consumed minutes are booked after. Shipped **project-scoped by default** (`Scope.PROJECT`), with `USER` available today and a new `AGENT` scope as an explicit phase 2.

## What changed since the first draft (and why)

The first draft pulled runtime out of the OTel trace pipeline. We then explored "tag sandboxes, let a cron pull usage from Daytona, never touch the run path." **Verifying Daytona's API killed that approach for our workload:**

- **No per-sandbox usage/cost API** — CPU-seconds / GB-seconds / price are **dashboard-only**.
- The one `/organizations/:id/usage` endpoint is **live quota snapshots, not cost**, org/region-scoped, and currently **JWT-only — not API-key callable** (open issue [daytonaio/daytona#4643](https://github.com/daytonaio/daytona/issues/4643)).
- **Up to 48h billing lag**, documented.
- Our sandboxes are **ephemeral** (cold VM per prompt turn, destroyed in a `finally`), so a `list()` cron finds them already gone, and there's **no `startedAt`/`stoppedAt`** to reconstruct runtime from.

So **measurement stays in the runner** (the only component that observes a full lifetime), and Daytona **labels** are repurposed for **audit / leak-detection / reconciliation**, not billing.

## Design (three insertion points + an audit cron)

- **(A) Gate** — a soft `check_entitlements(resource, cache=True)` folded into the cached auth check: "authenticated **and** entitled to run?" Returns 429 once the project is over its monthly minute budget. Records `run_id → resolved scope` for attribution.
- **(B) Measure** — `services/agent/src/engines/rivet.ts::runRivet()` already brackets `SandboxAgent.start()`→`destroySandbox()` (warmup included); capture `runtimeMs` and tag the sandbox with `labels`.
- **(C) Account** — the runner sends a **trusted post-run report** `(run_id, sandbox_id, minutes)` to an internal endpoint authed as the agent service's **existing** credential (not the admin key). Attribution comes from the run record (never the payload), so it can't bill arbitrary tenants and adds no new secret; idempotent on `sandbox_id`; charges via the same atomic, fail-open `check_entitlements` every meter uses.
- **Reconciliation cron** (audit only) — `list()` non-deleted sandboxes by label to flag orphaned/leaked VMs and sanity-check the 48h-lagged dashboard. Not a billing source.

Everything else is the well-worn "add a counter" path (`extend-meters`): one enum member, a `Quota(scope=PROJECT, period=MONTHLY, strict=True)` per plan, one Alembic enum migration (template exists), add the slug to `REPORTS` so the existing meters→Stripe cron flushes it (project rows roll up per org via `organization_id`), and `/billing/usage` surfaces it.

## Semantics worth flagging

Post-paid: a run already in flight finishes and is billed; the gate reads the last-booked value, so this is a **soft, slightly-lagged budget guardrail, not a hard real-time cutoff** (`strict` bounds overshoot to one run).

## Files

- `proposal.md` — the resource model, the Daytona verdict, the gate/measure/account flow, registry/Stripe/DB steps, reconciliation cron, risks.
- `research.md` — grounding in current metering/billing/sandbox code (file:line) **and** the cited Daytona API findings.
- `tasks.md` — ordered checklist + open inputs (per-plan numbers, join-key/store, internal report auth, #4643 tracking, phase-2 `Scope.AGENT`).

## Notes

- Still a draft on the product side: per-plan minute allotments and overage price are open.
- Open implementation decisions called out in `tasks.md`: the `run_id → scope` join store (durable vs Redis) and the exact existing internal credential for the report endpoint.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01MdaZVVA8e9LHk2ZrsEJEBj

---
_Generated by [Claude Code](https://claude.ai/code/session_01MdaZVVA8e9LHk2ZrsEJEBj)_