### PR TITLE
chore(agent): make sandbox-agent runner first-class

### DIFF
--- a/docs/design/agent-workflows/sidecar-deployment-proposal/README.md
+++ b/docs/design/agent-workflows/sidecar-deployment-proposal/README.md
@@ -1,0 +1,9 @@
+# Agent Runner Deployment
+
+Planning workspace for making the agent runner a first-class `sandbox-agent` deployment
+component across Docker Compose, Helm, Railway, and self-host documentation.
+
+## Files
+
+- `proposal.md` - Reviewed deployment proposal and implementation direction.
+- `status.md` - Current implementation progress, decisions, blockers, and next steps.

--- a/docs/design/agent-workflows/sidecar-deployment-proposal/proposal.md
+++ b/docs/design/agent-workflows/sidecar-deployment-proposal/proposal.md
@@ -1,0 +1,519 @@
+# Agent runner deployment proposal
+
+Status: revised proposal for review. Updated 2026-06-20 after owner review.
+
+Goal: make `services/agent` a first-class `sandbox-agent` runner service across
+Agenta deployments. The service should be part of the normal OSS and EE deployment
+shape, like the API, services, web, and workers. Advanced operators can still point
+Agenta at an external runner, but the default self-host story should not require them
+to invent this component.
+
+This document is a deployment and naming plan. It includes the env-var handling changes
+needed to make the deployment contract real.
+
+---
+
+## 1. Decision summary
+
+1. **The deployable service is `sandbox-agent`.** Stop using the old service and env
+   names that tie the runner to Pi. The Compose service, Helm objects, Railway service,
+   docs, comments, and examples should all call it `sandbox-agent` or "agent runner".
+
+2. **The production runner is sandbox-agent-backed.** The direct in-process Pi runner was
+   useful as a POC and can remain as an internal/example path, but it should not be the
+   default production image or deployment story.
+
+3. **The Agenta service only needs a runner URL.** The services/API container should call a
+   stable HTTP runner contract. Runtime engine choice is not an Agenta deployment env var.
+   Harness choice belongs to agent/run configuration. Sandbox/provider details belong to
+   the runner service.
+
+4. **The default Compose stack includes the runner.** OSS and EE Docker Compose should ship
+   a default `sandbox-agent` service that backs the open-source agent workflow path. It can
+   be replaced by an external runner for advanced deployments, but the base stack should be
+   usable without an extra optional overlay.
+
+5. **Auth/provider selection is owned by the provider-model-auth design.** This proposal
+   should not design OAuth, account binding, or provider-key injection. It should link to
+   `provider-model-auth/` and keep the runner deployment contract compatible with
+   self-managed credentials.
+
+6. **Cloud and self-host sandbox images have different distribution rules.** Agenta Cloud
+   can maintain its own internal Daytona snapshot. Self-hosters get a build recipe and
+   container templates, not a redistributed snapshot that contains proprietary harnesses.
+
+---
+
+## 2. Current state to clean up
+
+The active stack has a TypeScript runner at `services/agent`. It exposes:
+
+- `GET /health`
+- `POST /run`
+- an NDJSON streaming form of the same run contract
+
+The Python services layer calls that runner over HTTP when a runner URL is configured, or
+spawns the local TypeScript CLI when running from a source checkout.
+
+Current deployment gaps:
+
+| Target | Current state | Target state |
+| --- | --- | --- |
+| EE dev Compose | Has a runner service, but with legacy Pi-specific naming and dev-only mounts. | Rename to `sandbox-agent`, keep dev conveniences isolated to dev. |
+| OSS dev Compose | No runner service. | Add the same first-class `sandbox-agent` service. |
+| OSS/EE production Compose | No runner service. | Add `sandbox-agent` to the default production Compose files. |
+| Helm | No runner Deployment or Service. | Add first-class runner templates and service URL wiring. |
+| Railway | `hosting/railway/oss/` exists for the core stack, but no runner service. | Add a Railway `sandbox-agent` service and configure the services URL. |
+| Docs | Self-host docs do not describe the runner or its env contract. | Add a runner guide and update configuration and architecture pages. |
+| CI images | Production Dockerfile exists, but no published runner image. | Publish a GHCR image for OSS and the corresponding private EE image if needed. |
+
+Current naming debt:
+
+- The runner service and URL env var still use Pi-specific names in code and Compose.
+- The ACP-backed engine still uses older library/product wording in comments, filenames,
+  env vars, and docs.
+- Several dev-only defaults are mixed into the sample runner block.
+
+Those names should be treated as migration debt. New documentation and new deployment
+surface should use the target vocabulary.
+
+---
+
+## 3. Target architecture
+
+Default containerized deployment:
+
+```text
+browser / playground
+    |
+    v
+services container
+    agent workflow handler
+    resolves config, provider access, tools, trace context
+    |
+    | POST /run to AGENTA_AGENT_RUNNER_URL
+    v
+sandbox-agent runner service
+    services/agent HTTP server on :8765
+    owns the agent loop and sandbox-agent daemon lifecycle
+    |
+    +-- local sandbox-agent provider
+    |
+    +-- Daytona sandbox-agent provider
+          |
+          +-- harness adapter: Pi, Claude Code, future Codex/OpenCode/etc.
+```
+
+Ownership boundary:
+
+| Layer | Owns | Must not own |
+| --- | --- | --- |
+| Agenta services/API | Workflow routing, agent config, provider-account resolution, tool resolution, trace context, run history. | Sandbox implementation details, harness installation, runner process lifecycle. |
+| `sandbox-agent` runner service | The `/run` protocol, harness launch, sandbox-agent daemon lifecycle, sandbox provider config, runner-side tracing export. | Agenta project vault, all stack secrets, browser-callable secret APIs. |
+| Sandbox image/snapshot | Harness binaries, adapter dependencies, OS packages, optional self-managed login volume. | Baked Agenta credentials or user secrets. |
+
+The direct in-process Pi runner should move out of the production path. Keep it only as:
+
+- a local development shortcut,
+- a unit-test/fake-engine helper, or
+- an example of how to build a custom runner.
+
+The published runner image should exercise the same sandbox-agent-backed path users deploy.
+
+---
+
+## 4. Configuration contract
+
+### 4a. Services/API container
+
+The Agenta services container should have a small deployment contract:
+
+| Var | Default | Meaning |
+| --- | --- | --- |
+| `AGENTA_AGENT_RUNNER_URL` | `http://sandbox-agent:8765` in Compose/Helm/Railway | HTTP URL for the runner service. |
+| `AGENTA_AGENT_RUNNER_TIMEOUT_SECONDS` | implementation default | Request timeout for a runner call. |
+| `AGENTA_AGENT_ENABLE_MCP` | `false` until the runtime support is complete | Feature gate for user-declared MCP server resolution. |
+
+Remove these concerns from the services env surface:
+
+- runtime engine choice,
+- default harness choice,
+- sandbox provider choice,
+- Daytona credentials,
+- harness-specific auth directories,
+- runner image or snapshot selection.
+
+Harness selection should come from the agent/run config. Sandbox defaults should be owned
+by the runner service and eventually by the persisted agent template, not by the services
+container env.
+
+The new env vars should be added to `api/oss/src/utils/env.py` or the services equivalent
+instead of being read through raw `os.getenv`.
+
+### 4b. `sandbox-agent` runner service
+
+The runner service should have a runner-scoped env contract:
+
+| Var | Default | Meaning |
+| --- | --- | --- |
+| `PORT` | `8765` | HTTP listen port. |
+| `SANDBOX_AGENT_PROVIDER` | `local` | Default sandbox provider for runs that do not request one. Supported values begin with `local` and `daytona`. |
+| `SANDBOX_AGENT_BIN` | bundled binary | Override path to the sandbox-agent daemon binary. |
+| `SANDBOX_AGENT_LOG_LEVEL` | `info` or implementation default | Runner and daemon log verbosity. |
+| `SANDBOX_AGENT_DAYTONA_API_KEY` | unset | Daytona API key, only needed when the Daytona provider is enabled. |
+| `SANDBOX_AGENT_DAYTONA_API_URL` | Daytona default | Daytona API endpoint. |
+| `SANDBOX_AGENT_DAYTONA_TARGET` | Daytona default | Daytona region/target. |
+| `SANDBOX_AGENT_DAYTONA_SNAPSHOT` | unset | Snapshot name for Daytona runs. |
+| `SANDBOX_AGENT_DAYTONA_IMAGE` | unset | Plain image override for Daytona runs when no snapshot is set. |
+
+Rules:
+
+- Do not use `env_file` for the runner in Compose. The runner must not inherit the full
+  Agenta stack secret set.
+- Do not expose provider API keys as a default runner env path. Managed provider access
+  comes from the service-side resolver described in `provider-model-auth/`.
+- Do not keep `AGENTA_HOST` or `AGENTA_API_KEY` as published runner defaults. Trace export
+  credentials should be supplied per run or through a narrowly scoped runner setting.
+- Keep harness-specific filesystem knobs out of the main table. They belong in templates for
+  users building their own runner image or self-managed auth setup.
+
+### 4c. Template-only harness config
+
+Some variables are valid for a custom image template but should not define the general
+runner contract:
+
+| Template var | Use |
+| --- | --- |
+| `CLAUDE_CONFIG_DIR` | Self-managed Claude Code login mounted by an individual self-hoster. |
+| `CLAUDE_CODE_OAUTH_TOKEN` | Self-managed Claude Code OAuth path when an operator explicitly opts into it. |
+| `PI_CODING_AGENT_DIR` | Pi login directory for a Pi-specific custom image or dev setup. |
+| provider API key env vars | Local-only or BYO-runner fallback, not the Agenta-managed multi-tenant path. |
+
+The docs should present these as custom-image recipes, not as the normal Agenta deployment
+contract. The account and credential model is in `provider-model-auth/design.md`.
+
+---
+
+## 5. Runner protocol and external runners
+
+"Bring your own runner" cannot mean "any container with two endpoints." The `/run`
+contract carries tools, trace context, model/provider access, permission policy, MCP
+configuration, skills, streaming events, and capability flags.
+
+Before we document external runners as supported, we need:
+
+1. A versioned runner protocol identifier.
+2. JSON schemas or generated types for request, event, and response payloads.
+3. Golden fixtures shared between Python and TypeScript.
+4. A conformance test that a custom runner image can run.
+5. Capability negotiation so the service can reject unsupported harness/tool combinations
+   before a run starts.
+
+Until that exists, the supported self-host path is:
+
+- run the Agenta-published `sandbox-agent` image, or
+- build a custom image from our template while preserving the same protocol.
+
+---
+
+## 6. Deployment plan
+
+### 6a. Docker Compose
+
+Add `sandbox-agent` as a first-class service to OSS and EE Compose files, including dev and
+production variants.
+
+Target shape:
+
+```yaml
+services:
+  services:
+    environment:
+      AGENTA_AGENT_RUNNER_URL: ${AGENTA_AGENT_RUNNER_URL:-http://sandbox-agent:8765}
+
+  sandbox-agent:
+    image: ghcr.io/agenta-ai/agenta-sandbox-agent:${AGENTA_VERSION}
+    restart: always
+    environment:
+      PORT: "8765"
+      SANDBOX_AGENT_PROVIDER: ${SANDBOX_AGENT_PROVIDER:-local}
+      SANDBOX_AGENT_DAYTONA_API_KEY: ${SANDBOX_AGENT_DAYTONA_API_KEY:-}
+      SANDBOX_AGENT_DAYTONA_API_URL: ${SANDBOX_AGENT_DAYTONA_API_URL:-}
+      SANDBOX_AGENT_DAYTONA_TARGET: ${SANDBOX_AGENT_DAYTONA_TARGET:-}
+      SANDBOX_AGENT_DAYTONA_SNAPSHOT: ${SANDBOX_AGENT_DAYTONA_SNAPSHOT:-}
+      SANDBOX_AGENT_DAYTONA_IMAGE: ${SANDBOX_AGENT_DAYTONA_IMAGE:-}
+    healthcheck:
+      test: ["CMD", "node", "-e", "fetch('http://127.0.0.1:8765/health').then(r=>process.exit(r.ok?0:1)).catch(()=>process.exit(1))"]
+    networks:
+      - agenta-network
+```
+
+Dev-only differences can stay in `docker-compose.dev.yml`:
+
+- local build from `services/agent/docker/Dockerfile.dev`,
+- source bind mounts,
+- watcher or extension rebuild commands,
+- local login mounts for a developer's machine.
+
+Published production Compose files should not include:
+
+- host-specific Agenta URLs,
+- user home-directory mounts,
+- dev-box IPs,
+- whole-stack `env_file` inheritance,
+- direct-Pi POC defaults.
+
+External runner path:
+
+- Set `AGENTA_AGENT_RUNNER_URL` to the external service URL.
+- Either omit the internal `sandbox-agent` service through a documented advanced override or
+  let it run unused if the deployment tool cannot conditionally remove it cleanly.
+
+### 6b. Helm
+
+Add a first-class runner Deployment and Service:
+
+- `templates/sandbox-agent-deployment.yaml`
+- `templates/sandbox-agent-service.yaml`
+- helper for the runner image
+- image pull secrets wired for EE/private registries
+- services-pod env injection for `AGENTA_AGENT_RUNNER_URL`
+
+Proposed values:
+
+```yaml
+agentRunner:
+  enabled: true
+  externalUrl: ""
+  image:
+    repository: ""
+    tag: ""
+    pullPolicy: IfNotPresent
+  sandbox:
+    provider: local
+    daytona:
+      apiKeySecret: ""
+      apiUrl: ""
+      target: ""
+      snapshot: ""
+      image: ""
+  env: {}
+  resources: {}
+```
+
+Rules:
+
+- If `agentRunner.enabled=true`, set `AGENTA_AGENT_RUNNER_URL` to the in-cluster Service.
+- If `agentRunner.externalUrl` is set, point services at that URL and do not require the
+  in-cluster runner.
+- Keep existing SDK code-sandbox Daytona values separate from runner Daytona values. They
+  are different consumers.
+
+### 6c. Railway
+
+Railway has an existing OSS deployment tree under `hosting/railway/oss/`. Add a
+`sandbox-agent` service there:
+
+- `hosting/railway/oss/sandbox-agent/Dockerfile` or image-backed deployment config.
+- Bootstrap/configure scripts create the Railway service.
+- The services Railway service gets `AGENTA_AGENT_RUNNER_URL` set to the private Railway URL
+  for `sandbox-agent`.
+- For Daytona runs, set the runner-scoped Daytona vars on the `sandbox-agent` Railway
+  service.
+
+Railway caveats:
+
+- Railway has no Docker socket or host volume in the normal template flow.
+- For self-managed OAuth/login mounts, prefer a custom self-host container environment
+  rather than Railway.
+- For remote sandbox execution, Daytona is the cleaner Railway path.
+
+---
+
+## 7. Image and sandbox strategy
+
+### 7a. Published runner image
+
+Add CI that builds `services/agent/docker/Dockerfile` and publishes:
+
+- OSS: `ghcr.io/agenta-ai/agenta-sandbox-agent`
+- EE/private, if required by the release process: matching private registry image
+
+The image should:
+
+- run the sandbox-agent-backed path by default,
+- listen on `$PORT`,
+- expose `/health` and `/run`,
+- bake no credentials,
+- avoid proprietary harness binaries unless redistribution is explicitly allowed,
+- include only the open-source dependencies and adapters needed for the default path.
+
+The image should not be a direct-Pi POC container.
+
+### 7b. Custom runner templates
+
+Provide templates for operators who need a customized runner:
+
+- add Claude Code from Anthropic at build or runtime,
+- add future Codex/OpenCode adapters,
+- install internal CA certificates,
+- preinstall MCP servers,
+- mount self-managed login directories,
+- pin harness versions.
+
+The template contract is still the same: listen on `$PORT`, implement the versioned runner
+protocol, and bake no credentials.
+
+### 7c. Daytona images and snapshots
+
+Separate the two cases:
+
+- **Agenta Cloud:** can maintain an internal Daytona snapshot for the cloud runner path,
+  including the harness binaries Agenta is licensed to use internally.
+- **Self-host:** ship a recipe that builds a snapshot in the operator's Daytona account.
+  Do not distribute the built snapshot.
+
+Move the snapshot builder out of historical scratch material into a supported path, for
+example:
+
+```text
+services/agent/sandbox-images/daytona/
+```
+
+That folder should include:
+
+- a build script,
+- a README explaining prerequisites,
+- provenance notes for each harness installed,
+- required runner env vars,
+- validation commands.
+
+---
+
+## 8. Provider, model, and auth boundary
+
+Do not solve provider/model/auth in this deployment proposal. The accepted design lives in:
+
+- `docs/design/agent-workflows/provider-model-auth/context.md`
+- `docs/design/agent-workflows/provider-model-auth/design.md`
+
+Deployment implications from that design:
+
+- The committed agent config carries model intent, not concrete credentials.
+- The run/environment chooses a provider account or self-managed runtime mode.
+- The service resolves a least-privilege credential plan.
+- The runner receives only the credential material required for that run.
+- Self-managed OAuth/login directories are a runtime-provided auth mode, not a vault-stored
+  mutable file.
+
+The runner deployment must preserve that boundary by avoiding broad env inheritance and by
+keeping credential-bearing env vars out of the default service config.
+
+---
+
+## 9. Documentation plan
+
+Docs live under `docs/docs/self-host/`.
+
+1. **New: `guides/07-deploy-the-agent-runner.mdx`**
+   - What the `sandbox-agent` runner is.
+   - How it fits into Compose, Helm, and Railway.
+   - Default deployment path.
+   - External runner URL path.
+   - Health checks and troubleshooting.
+
+2. **New: `guides/08-custom-agent-runner-images.mdx`**
+   - How to extend the runner image.
+   - Template-only harness config.
+   - Self-managed login mounts.
+   - Licensing and "no baked credentials" rules.
+
+3. **New: `guides/09-agent-daytona-sandboxes.mdx`**
+   - When to use Daytona.
+   - How to build the self-host snapshot recipe.
+   - How Cloud-owned snapshots differ from self-host recipes.
+
+4. **Edit: `02-configuration.mdx`**
+   - Add the services env vars.
+   - Add runner-scoped env vars.
+   - Avoid listing template-only OAuth/login vars as normal Agenta config.
+
+5. **Edit: `infrastructure/01-architecture.mdx`**
+   - Add the `sandbox-agent` runner service to the deployment diagram.
+   - Show `services -> sandbox-agent` over the runner URL.
+
+6. **Edit: `guides/04-deploy-on-railway.mdx`**
+   - Add the `sandbox-agent` Railway service.
+   - Explain private service URL wiring.
+
+7. **Edit existing agent-workflows design docs**
+   - Replace legacy runner names in current docs and comments.
+   - Keep archived `trash/` pages historical unless a current page links to them as active
+     design truth.
+
+---
+
+## 10. Implementation phases
+
+### Phase 0 - Terminology cleanup
+
+- Pick final names:
+  - service: `sandbox-agent`
+  - services env: `AGENTA_AGENT_RUNNER_URL`
+  - image: `agenta-sandbox-agent`
+  - Helm values root: `agentRunner`
+- Rename current docs and comments away from legacy runner wording.
+- Drop the old env names from current docs and examples. No compatibility note is needed
+  because this surface has not shipped.
+
+### Phase 1 - Runner URL and config cleanup
+
+- Add `AGENTA_AGENT_RUNNER_URL` to the env module.
+- Keep the old URL env as a temporary fallback with deprecation logging.
+- Remove deployment env defaults for runtime, harness, and sandbox from the services layer.
+- Move sandbox-provider defaults into runner service config.
+
+### Phase 2 - Production runner path
+
+- Make the sandbox-agent-backed engine the default runner path.
+- Move the direct Pi POC path out of the published image or gate it as dev/example only.
+- Ensure unit and wire-contract tests cover the production path.
+
+### Phase 3 - Compose
+
+- Add `sandbox-agent` to OSS and EE dev/prod Compose.
+- Wire `AGENTA_AGENT_RUNNER_URL` into services.
+- Remove dev-only defaults from published Compose files.
+- Add health checks.
+
+### Phase 4 - Images and CI
+
+- Publish the OSS runner image to GHCR.
+- Add any EE/private image publishing required by the release process.
+- Document image tags and release ownership.
+
+### Phase 5 - Helm and Railway
+
+- Add Helm templates, values, services env wiring, and private image pull support. 
+- Add `sandbox-agent` to `hosting/railway/oss/` scripts and docs.
+
+### Phase 6 - Docs and custom templates
+
+- Add self-host guides.
+- Move Daytona snapshot recipes into `services/agent/sandbox-images/daytona/`.
+- Add custom runner image templates and conformance checks.
+
+---
+
+## 11. Open decisions
+
+1. **Final env name:** this proposal recommends `AGENTA_AGENT_RUNNER_URL`.
+2. **Final image name:** this proposal recommends `agenta-sandbox-agent`.
+3. **Direct Pi POC destination:** move it to an example after the sandbox-agent path is
+   stable.
+4. **Helm default:** this proposal recommends `agentRunner.enabled=true` for first-class
+   behavior, with `externalUrl` and disable paths for advanced operators. 
+5. **Cloud Daytona snapshot ownership:** decide where the internal Cloud snapshot build and
+   release process lives.
+6. **External runner support level:** decide whether v1 supports only "custom image from our
+   template" or a broader protocol-compatible external runner after conformance tests exist.

--- a/docs/design/agent-workflows/sidecar-deployment-proposal/status.md
+++ b/docs/design/agent-workflows/sidecar-deployment-proposal/status.md
@@ -1,0 +1,48 @@
+# Status
+
+## Current State
+
+Implementation complete for the repo surfaces covered by the proposal. The flat proposal
+has been moved into this folder as `proposal.md`, and Agenta now treats `sandbox-agent` as
+the first-class deployable runner service reached through `AGENTA_AGENT_RUNNER_URL`.
+
+## Progress Log
+
+- Moved the flat proposal file into this folder as
+  `docs/design/agent-workflows/sidecar-deployment-proposal/proposal.md`.
+- Added this `status.md` and a folder `README.md`.
+- Updated the services/API handler to route through the TypeScript runner URL and removed
+  the deploy-time harness/sandbox/runtime env selection.
+- Renamed the SDK and runner adapter surfaces from upstream-specific names to
+  `sandbox-agent` names while keeping the direct Pi engine as an explicit local/dev path.
+- Wired the `sandbox-agent` service through OSS and EE Docker Compose variants, Helm,
+  Railway scripts, and the image build workflow.
+- Added self-hosting docs for deploying the runner, building custom runner images, and
+  using Daytona-backed sandboxes.
+- Swept active docs and deployment references for stale runner names and old env vars.
+
+## Decisions
+
+- Use `sandbox-agent` for the deployable service name.
+- Use `AGENTA_AGENT_RUNNER_URL` for the services/API container URL to the runner.
+- Move the direct in-process Pi path toward an example/dev path, not the production default.
+- No compatibility note for old env names is required because this surface has not shipped.
+- Keep runner-provider defaults runner-side under `SANDBOX_AGENT_*`.
+- Keep the Daytona snapshot recipe under `services/agent/sandbox-images/daytona/`.
+- Use `agenta-sandbox-pi` as the default Daytona snapshot name.
+
+## Blockers
+
+- None.
+
+## Open Questions
+
+- EE private runner image publishing still needs to be verified in the release pipeline.
+- A full self-host smoke deploy should run after the `agenta-sandbox-agent` image is
+  published by CI.
+
+## Next Steps
+
+1. Run an OSS Compose smoke deploy from published images.
+2. Run a Helm install smoke deploy with the default `agentRunner.enabled=true` path.
+3. Verify the Railway preview path creates and wires the `sandbox-agent` service.

--- a/docs/docs/self-host/02-configuration.mdx
+++ b/docs/docs/self-host/02-configuration.mdx
@@ -115,6 +115,26 @@ for how they behave. The plan and role variables are Enterprise-only; see
 | `AGENTA_SERVICES_HOOK_ALLOW_INSECURE` | `agenta.services.hook.allow_insecure` | `agenta.services.hook.allowInsecure` |
 | `AGENTA_SERVICES_MIDDLEWARE_CACHING_ENABLED` | `agenta.services.middleware.caching_enabled` | `agenta.services.middleware.cachingEnabled` |
 
+## Agent runner
+
+These variables configure agent workflows. `AGENTA_AGENT_*` variables are read by the
+Services API. `SANDBOX_AGENT_*` variables are read by the separate `sandbox-agent` runner
+service. See [Deploy the agent runner](/self-host/guides/deploy-the-agent-runner).
+
+| Env var | Component | values.yaml path |
+|---|---|---|
+| `AGENTA_AGENT_RUNNER_URL` | Services API | `agentRunner.externalUrl` or generated from `agentRunner.enabled` |
+| `AGENTA_AGENT_RUNNER_TIMEOUT_SECONDS` | Services API / SDK | n/a |
+| `AGENTA_AGENT_ENABLE_MCP` | Services API | `agentRunner.enableMcp` |
+| `SANDBOX_AGENT_PROVIDER` | `sandbox-agent` | `agentRunner.provider` |
+| `SANDBOX_AGENT_LOG_LEVEL` | `sandbox-agent` | `agentRunner.logLevel` |
+| `SANDBOX_AGENT_DAYTONA_API_KEY` | `sandbox-agent` | `agentRunner.daytona.apiKey` |
+| `SANDBOX_AGENT_DAYTONA_API_URL` | `sandbox-agent` | `agentRunner.daytona.apiUrl` |
+| `SANDBOX_AGENT_DAYTONA_TARGET` | `sandbox-agent` | `agentRunner.daytona.target` |
+| `SANDBOX_AGENT_DAYTONA_SNAPSHOT` | `sandbox-agent` | `agentRunner.daytona.snapshot` |
+| `SANDBOX_AGENT_DAYTONA_IMAGE` | `sandbox-agent` | `agentRunner.daytona.image` |
+| `SANDBOX_AGENT_DAYTONA_INSTALL_PI` | `sandbox-agent` | `agentRunner.daytona.installPi` |
+
 ## Agenta — webhooks
 
 | Env var | env.py path | values.yaml path |

--- a/docs/docs/self-host/guides/07-deploy-the-agent-runner.mdx
+++ b/docs/docs/self-host/guides/07-deploy-the-agent-runner.mdx
@@ -1,0 +1,65 @@
+---
+title: Deploy the Agent Runner
+sidebar_label: Deploy Agent Runner
+description: Configure the sandbox-agent runner service for self-hosted agent workflows
+---
+
+Agenta agent workflows run through a separate `sandbox-agent` runner service. The Services
+API sends agent runs to this service through `AGENTA_AGENT_RUNNER_URL`.
+
+The runner owns the harness process, the sandbox-agent daemon lifecycle, and runner-scoped
+sandbox provider settings. It should not inherit the full stack environment file.
+
+## Docker Compose
+
+The bundled Compose files include `sandbox-agent` by default. The Services API points to it
+inside the Compose network:
+
+```bash
+AGENTA_AGENT_RUNNER_URL=http://sandbox-agent:8765
+```
+
+Use these variables when you need to override the image or default sandbox provider:
+
+```bash
+AGENTA_SANDBOX_AGENT_IMAGE_NAME=agenta-sandbox-agent
+AGENTA_SANDBOX_AGENT_IMAGE_TAG=latest
+SANDBOX_AGENT_PROVIDER=local
+```
+
+## Helm
+
+The Helm chart enables the runner by default:
+
+```yaml
+agentRunner:
+  enabled: true
+  port: 8765
+  provider: local
+```
+
+When `agentRunner.enabled=true`, the chart creates a `sandbox-agent` Deployment and Service
+and injects the in-cluster URL into the Services pod as `AGENTA_AGENT_RUNNER_URL`.
+
+To use an external runner instead:
+
+```yaml
+agentRunner:
+  enabled: false
+  externalUrl: https://runner.example.com
+```
+
+## Railway
+
+The Railway scripts create a `sandbox-agent` service and configure the Services API with the
+runner's private Railway URL. For image-based deploys, provide the runner image with the
+other Agenta images:
+
+```bash
+export AGENTA_SANDBOX_AGENT_IMAGE="ghcr.io/agenta-ai/agenta-sandbox-agent:latest"
+```
+
+## Related
+
+- [Custom agent runner images](/self-host/guides/custom-agent-runner-images)
+- [Agent Daytona sandboxes](/self-host/guides/agent-daytona-sandboxes)

--- a/docs/docs/self-host/guides/09-agent-daytona-sandboxes.mdx
+++ b/docs/docs/self-host/guides/09-agent-daytona-sandboxes.mdx
@@ -1,0 +1,59 @@
+---
+title: Agent Daytona Sandboxes
+sidebar_label: Agent Daytona Sandboxes
+description: Configure Daytona as the sandbox provider for self-hosted agent workflows
+---
+
+The agent runner can create Daytona sandboxes for agent runs. Configure Daytona on the
+`sandbox-agent` runner service, not on every Agenta container.
+
+## Configure the runner
+
+```bash
+SANDBOX_AGENT_PROVIDER=daytona
+SANDBOX_AGENT_DAYTONA_API_KEY=<daytona-api-key>
+SANDBOX_AGENT_DAYTONA_API_URL=https://app.daytona.io/api
+SANDBOX_AGENT_DAYTONA_TARGET=eu
+```
+
+For Helm:
+
+```yaml
+agentRunner:
+  provider: daytona
+  daytona:
+    apiKey: <daytona-api-key>
+    apiUrl: https://app.daytona.io/api
+    target: eu
+```
+
+## Optional snapshot
+
+Daytona runs start faster from a prepared snapshot. Agenta ships the recipe, not a
+prebuilt snapshot:
+
+```bash
+cd services/agent/sandbox-images/daytona
+uv run build_snapshot.py --force
+```
+
+Then configure the snapshot name:
+
+```bash
+SANDBOX_AGENT_DAYTONA_SNAPSHOT=agenta-sandbox-pi
+SANDBOX_AGENT_DAYTONA_INSTALL_PI=false
+```
+
+For Helm:
+
+```yaml
+agentRunner:
+  daytona:
+    snapshot: agenta-sandbox-pi
+    installPi: false
+```
+
+## Related
+
+- [Deploy the agent runner](/self-host/guides/deploy-the-agent-runner)
+- [Custom agent runner images](/self-host/guides/custom-agent-runner-images)

--- a/docs/docs/self-host/infrastructure/01-architecture.mdx
+++ b/docs/docs/self-host/infrastructure/01-architecture.mdx
@@ -122,6 +122,17 @@ Agenta follows a modern microservices architecture with clear separation of conc
 - **Error Handling**: Robust error handling for LLM API failures
 - **Endpoint Groups**: Includes `/services/completion/*` and `/services/chat/*`
 
+### sandbox-agent Runner
+- **Technology**: Node.js TypeScript runner plus sandbox-agent daemon
+- **Port**: 8765 (internal)
+- **Purpose**: Executes agent workflows for the Services API
+
+**Key Responsibilities**:
+- **Agent Runs**: Receives `/run` requests from the Services API through `AGENTA_AGENT_RUNNER_URL`
+- **Harness Launch**: Starts Pi, Claude Code, or other supported harness adapters over ACP
+- **Sandbox Provider**: Runs local sandboxes or creates Daytona sandboxes using runner-scoped `SANDBOX_AGENT_*` configuration
+- **Tool Relay**: Relays server-side tools back to the Services API without exposing the full stack environment to the harness process
+
 ## Infrastructure Services
 
 ### PostgreSQL (Database)
@@ -175,6 +186,11 @@ API Service depends on:
 ├── Redis (task queue, caching, sessions)
 ├── SuperTokens (authentication)
 └── Worker pool (async task execution)
+
+Services API depends on:
+├── PostgreSQL (agent and service state)
+├── LLM providers (model calls)
+└── sandbox-agent runner (agent workflow execution)
 ```
 
 ### Worker Dependencies

--- a/hosting/docker-compose/ee/docker-compose.dev.yml
+++ b/hosting/docker-compose/ee/docker-compose.dev.yml
@@ -418,7 +418,7 @@ services:
             - ${ENV_FILE:-./.env.ee.dev}
         environment:
             DOCKER_NETWORK_MODE: ${DOCKER_NETWORK_MODE:-bridge}
-            AGENTA_AGENT_RUNNER_URL: http://sandbox-agent:8765
+            AGENTA_AGENT_RUNNER_URL: ${AGENTA_AGENT_RUNNER_URL:-http://sandbox-agent:8765}
             AGENTA_AGENT_ENABLE_MCP: ${AGENTA_AGENT_ENABLE_MCP:-false}
         # === NETWORK ============================================== #
         networks:

--- a/hosting/docker-compose/ee/docker-compose.gh.local.yml
+++ b/hosting/docker-compose/ee/docker-compose.gh.local.yml
@@ -299,11 +299,17 @@ services:
             - ${ENV_FILE:-./.env.ee.gh}
         environment:
             - SCRIPT_NAME=/services
+            - AGENTA_AGENT_RUNNER_URL=${AGENTA_AGENT_RUNNER_URL:-http://sandbox-agent:8765}
+            - AGENTA_AGENT_ENABLE_MCP=${AGENTA_AGENT_ENABLE_MCP:-false}
         # === NETWORK ============================================== #
         networks:
             - agenta-ee-gh-network
         extra_hosts:
             - "host.docker.internal:host-gateway"
+        # === ORCHESTRATION ======================================== #
+        depends_on:
+            sandbox-agent:
+                condition: service_healthy
         # === LABELS =============================================== #
         labels:
             - "traefik.http.routers.services.rule=PathPrefix(`/services/`)"
@@ -315,6 +321,38 @@ services:
             - "traefik.http.routers.services.service=services"
         # === LIFECYCLE ============================================ #
         restart: always
+
+    sandbox-agent:
+        # === IMAGE ================================================ #
+        build:
+            context: ../../../services/agent
+            dockerfile: docker/Dockerfile
+        # === CONFIGURATION ======================================== #
+        environment:
+            PORT: "8765"
+            AGENTA_HOST: ${AGENTA_HOST:-}
+            AGENTA_API_KEY: ${AGENTA_API_KEY:-}
+            SANDBOX_AGENT_PROVIDER: ${SANDBOX_AGENT_PROVIDER:-local}
+            SANDBOX_AGENT_DAYTONA_API_KEY: ${SANDBOX_AGENT_DAYTONA_API_KEY:-}
+            SANDBOX_AGENT_DAYTONA_API_URL: ${SANDBOX_AGENT_DAYTONA_API_URL:-}
+            SANDBOX_AGENT_DAYTONA_TARGET: ${SANDBOX_AGENT_DAYTONA_TARGET:-}
+            SANDBOX_AGENT_DAYTONA_SNAPSHOT: ${SANDBOX_AGENT_DAYTONA_SNAPSHOT:-}
+            SANDBOX_AGENT_DAYTONA_IMAGE: ${SANDBOX_AGENT_DAYTONA_IMAGE:-}
+            SANDBOX_AGENT_DAYTONA_INSTALL_PI: ${SANDBOX_AGENT_DAYTONA_INSTALL_PI:-false}
+        # === NETWORK ============================================== #
+        networks:
+            - agenta-ee-gh-network
+        # === LABELS =============================================== #
+        labels:
+            - "traefik.enable=false"
+        # === LIFECYCLE ============================================ #
+        restart: always
+        healthcheck:
+            test: ["CMD", "node", "-e", "fetch('http://127.0.0.1:8765/health').then(r=>process.exit(r.ok?0:1)).catch(()=>process.exit(1))"]
+            interval: 10s
+            timeout: 5s
+            retries: 12
+            start_period: 20s
 
     postgres:
         # === IMAGE ================================================ #

--- a/hosting/docker-compose/ee/env.ee.dev.example
+++ b/hosting/docker-compose/ee/env.ee.dev.example
@@ -114,12 +114,16 @@ AGENTA_CRYPT_KEY=replace-me
 # CRISP_WEBSITE_ID=
 
 # ================================================================== #
-# daytona
+# sandbox-agent
 # ================================================================== #
-# DAYTONA_API_KEY=
-# DAYTONA_API_URL=https://app.daytona.io/api
-# DAYTONA_SNAPSHOT=daytona-small
-# DAYTONA_TARGET=eu
+# AGENTA_AGENT_RUNNER_URL=http://sandbox-agent:8765
+# AGENTA_AGENT_ENABLE_MCP=false
+# SANDBOX_AGENT_PROVIDER=local
+# SANDBOX_AGENT_DAYTONA_API_KEY=
+# SANDBOX_AGENT_DAYTONA_API_URL=https://app.daytona.io/api
+# SANDBOX_AGENT_DAYTONA_TARGET=eu
+# SANDBOX_AGENT_DAYTONA_SNAPSHOT=agenta-sandbox-pi
+# SANDBOX_AGENT_DAYTONA_IMAGE=
 
 # ================================================================== #
 # docker

--- a/hosting/docker-compose/oss/docker-compose.dev.yml
+++ b/hosting/docker-compose/oss/docker-compose.dev.yml
@@ -31,6 +31,15 @@ services:
         # === EXECUTION ============================================ #
         command: ["true"]
 
+    .sandbox-agent:
+        # === IMAGE ================================================ #
+        image: agenta-oss-dev-sandbox-agent:latest
+        build:
+            context: ../../../services/agent
+            dockerfile: docker/Dockerfile.dev
+        # === EXECUTION ============================================ #
+        command: ["true"]
+
     web:
         # === ACTIVATION =========================================== #
         profiles:
@@ -398,11 +407,17 @@ services:
             - ${ENV_FILE:-./.env.oss.dev}
         environment:
             DOCKER_NETWORK_MODE: ${DOCKER_NETWORK_MODE:-bridge}
+            AGENTA_AGENT_RUNNER_URL: ${AGENTA_AGENT_RUNNER_URL:-http://sandbox-agent:8765}
+            AGENTA_AGENT_ENABLE_MCP: ${AGENTA_AGENT_ENABLE_MCP:-false}
         # === NETWORK ============================================== #
         networks:
             - agenta-network
         extra_hosts:
             - "host.docker.internal:host-gateway"
+        # === ORCHESTRATION ======================================== #
+        depends_on:
+            sandbox-agent:
+                condition: service_healthy
         # === LABELS =============================================== #
         labels:
             - "traefik.http.routers.services.rule=PathPrefix(`/services/`)"
@@ -414,6 +429,47 @@ services:
             - "traefik.http.routers.services.service=services"
         # === LIFECYCLE ============================================ #
         restart: always
+
+    sandbox-agent:
+        # === IMAGE ================================================ #
+        image: agenta-oss-dev-sandbox-agent:latest
+        # === EXECUTION ============================================ #
+        command: >
+            sh -c "mkdir -p /pi-agent && cp -a /pi-agent-ro/. /pi-agent/ 2>/dev/null || true;
+            node scripts/build-extension.mjs &&
+            exec node_modules/.bin/tsx watch src/server.ts"
+        # === CONFIGURATION ======================================== #
+        # Deliberately no env_file: harness processes must not inherit the full stack
+        # secret set. Tools run server-side through /tools/call; the runner only needs
+        # its own port plus optional runner-scoped provider credentials.
+        environment:
+            PORT: "8765"
+            PI_CODING_AGENT_DIR: /pi-agent
+            AGENTA_HOST: ${AGENTA_HOST:-}
+            AGENTA_API_KEY: ${AGENTA_API_KEY:-}
+            SANDBOX_AGENT_PROVIDER: ${SANDBOX_AGENT_PROVIDER:-local}
+            SANDBOX_AGENT_DAYTONA_API_KEY: ${SANDBOX_AGENT_DAYTONA_API_KEY:-}
+            SANDBOX_AGENT_DAYTONA_API_URL: ${SANDBOX_AGENT_DAYTONA_API_URL:-}
+            SANDBOX_AGENT_DAYTONA_TARGET: ${SANDBOX_AGENT_DAYTONA_TARGET:-}
+            SANDBOX_AGENT_DAYTONA_SNAPSHOT: ${SANDBOX_AGENT_DAYTONA_SNAPSHOT:-agenta-sandbox-pi}
+            SANDBOX_AGENT_DAYTONA_IMAGE: ${SANDBOX_AGENT_DAYTONA_IMAGE:-}
+            SANDBOX_AGENT_DAYTONA_INSTALL_PI: ${SANDBOX_AGENT_DAYTONA_INSTALL_PI:-false}
+        # === STORAGE ============================================== #
+        volumes:
+            - ../../../services/agent/src:/app/src
+            - ../../../services/agent/skills:/app/skills
+            - ${HOME}/.pi/agent:/pi-agent-ro:ro
+        # === NETWORK ============================================== #
+        networks:
+            - agenta-network
+        # === LIFECYCLE ============================================ #
+        restart: always
+        healthcheck:
+            test: ["CMD", "node", "-e", "fetch('http://127.0.0.1:8765/health').then(r=>process.exit(r.ok?0:1)).catch(()=>process.exit(1))"]
+            interval: 10s
+            timeout: 5s
+            retries: 12
+            start_period: 20s
 
     postgres:
         # === IMAGE ================================================ #

--- a/hosting/docker-compose/oss/docker-compose.gh.local.yml
+++ b/hosting/docker-compose/oss/docker-compose.gh.local.yml
@@ -297,11 +297,17 @@ services:
             - ${ENV_FILE:-./.env.oss.gh}
         environment:
             - SCRIPT_NAME=/services
+            - AGENTA_AGENT_RUNNER_URL=${AGENTA_AGENT_RUNNER_URL:-http://sandbox-agent:8765}
+            - AGENTA_AGENT_ENABLE_MCP=${AGENTA_AGENT_ENABLE_MCP:-false}
         # === NETWORK ============================================== #
         networks:
             - agenta-oss-gh-network
         extra_hosts:
             - "host.docker.internal:host-gateway"
+        # === ORCHESTRATION ======================================== #
+        depends_on:
+            sandbox-agent:
+                condition: service_healthy
         # === LABELS =============================================== #
         labels:
             - "traefik.http.routers.services.rule=PathPrefix(`/services/`)"
@@ -313,6 +319,38 @@ services:
             - "traefik.http.routers.services.service=services"
         # === LIFECYCLE ============================================ #
         restart: always
+
+    sandbox-agent:
+        # === IMAGE ================================================ #
+        build:
+            context: ../../../services/agent
+            dockerfile: docker/Dockerfile
+        # === CONFIGURATION ======================================== #
+        environment:
+            PORT: "8765"
+            AGENTA_HOST: ${AGENTA_HOST:-}
+            AGENTA_API_KEY: ${AGENTA_API_KEY:-}
+            SANDBOX_AGENT_PROVIDER: ${SANDBOX_AGENT_PROVIDER:-local}
+            SANDBOX_AGENT_DAYTONA_API_KEY: ${SANDBOX_AGENT_DAYTONA_API_KEY:-}
+            SANDBOX_AGENT_DAYTONA_API_URL: ${SANDBOX_AGENT_DAYTONA_API_URL:-}
+            SANDBOX_AGENT_DAYTONA_TARGET: ${SANDBOX_AGENT_DAYTONA_TARGET:-}
+            SANDBOX_AGENT_DAYTONA_SNAPSHOT: ${SANDBOX_AGENT_DAYTONA_SNAPSHOT:-}
+            SANDBOX_AGENT_DAYTONA_IMAGE: ${SANDBOX_AGENT_DAYTONA_IMAGE:-}
+            SANDBOX_AGENT_DAYTONA_INSTALL_PI: ${SANDBOX_AGENT_DAYTONA_INSTALL_PI:-false}
+        # === NETWORK ============================================== #
+        networks:
+            - agenta-oss-gh-network
+        # === LABELS =============================================== #
+        labels:
+            - "traefik.enable=false"
+        # === LIFECYCLE ============================================ #
+        restart: always
+        healthcheck:
+            test: ["CMD", "node", "-e", "fetch('http://127.0.0.1:8765/health').then(r=>process.exit(r.ok?0:1)).catch(()=>process.exit(1))"]
+            interval: 10s
+            timeout: 5s
+            retries: 12
+            start_period: 20s
 
     postgres:
         # === IMAGE ================================================ #

--- a/hosting/docker-compose/oss/docker-compose.gh.ssl.yml
+++ b/hosting/docker-compose/oss/docker-compose.gh.ssl.yml
@@ -316,11 +316,17 @@ services:
             - ${ENV_FILE:-./.env.oss.gh}
         environment:
             - SCRIPT_NAME=/services
+            - AGENTA_AGENT_RUNNER_URL=${AGENTA_AGENT_RUNNER_URL:-http://sandbox-agent:8765}
+            - AGENTA_AGENT_ENABLE_MCP=${AGENTA_AGENT_ENABLE_MCP:-false}
         # === NETWORK ============================================== #
         networks:
             - agenta-gh-ssl-network
         extra_hosts:
             - "host.docker.internal:host-gateway"
+        # === ORCHESTRATION ======================================== #
+        depends_on:
+            sandbox-agent:
+                condition: service_healthy
         # === LABELS =============================================== #
         labels:
             - "traefik.http.routers.services.rule=Host(`${TRAEFIK_DOMAIN}`) && PathPrefix(`/services/`)"
@@ -334,6 +340,38 @@ services:
             - "traefik.http.routers.services.tls.certresolver=myResolver"
         # === LIFECYCLE ============================================ #
         restart: always
+
+    sandbox-agent:
+        # === IMAGE ================================================ #
+        build:
+            context: ../../../services/agent
+            dockerfile: docker/Dockerfile
+        # === CONFIGURATION ======================================== #
+        environment:
+            PORT: "8765"
+            AGENTA_HOST: ${AGENTA_HOST:-}
+            AGENTA_API_KEY: ${AGENTA_API_KEY:-}
+            SANDBOX_AGENT_PROVIDER: ${SANDBOX_AGENT_PROVIDER:-local}
+            SANDBOX_AGENT_DAYTONA_API_KEY: ${SANDBOX_AGENT_DAYTONA_API_KEY:-}
+            SANDBOX_AGENT_DAYTONA_API_URL: ${SANDBOX_AGENT_DAYTONA_API_URL:-}
+            SANDBOX_AGENT_DAYTONA_TARGET: ${SANDBOX_AGENT_DAYTONA_TARGET:-}
+            SANDBOX_AGENT_DAYTONA_SNAPSHOT: ${SANDBOX_AGENT_DAYTONA_SNAPSHOT:-}
+            SANDBOX_AGENT_DAYTONA_IMAGE: ${SANDBOX_AGENT_DAYTONA_IMAGE:-}
+            SANDBOX_AGENT_DAYTONA_INSTALL_PI: ${SANDBOX_AGENT_DAYTONA_INSTALL_PI:-false}
+        # === NETWORK ============================================== #
+        networks:
+            - agenta-gh-ssl-network
+        # === LABELS =============================================== #
+        labels:
+            - "traefik.enable=false"
+        # === LIFECYCLE ============================================ #
+        restart: always
+        healthcheck:
+            test: ["CMD", "node", "-e", "fetch('http://127.0.0.1:8765/health').then(r=>process.exit(r.ok?0:1)).catch(()=>process.exit(1))"]
+            interval: 10s
+            timeout: 5s
+            retries: 12
+            start_period: 20s
 
     postgres:
         # === IMAGE ================================================ #

--- a/hosting/docker-compose/oss/env.oss.dev.example
+++ b/hosting/docker-compose/oss/env.oss.dev.example
@@ -114,12 +114,16 @@ AGENTA_CRYPT_KEY=replace-me
 # CRISP_WEBSITE_ID=
 
 # ================================================================== #
-# daytona
+# sandbox-agent
 # ================================================================== #
-# DAYTONA_API_KEY=
-# DAYTONA_API_URL=https://app.daytona.io/api
-# DAYTONA_SNAPSHOT=daytona-small
-# DAYTONA_TARGET=eu
+# AGENTA_AGENT_RUNNER_URL=http://sandbox-agent:8765
+# AGENTA_AGENT_ENABLE_MCP=false
+# SANDBOX_AGENT_PROVIDER=local
+# SANDBOX_AGENT_DAYTONA_API_KEY=
+# SANDBOX_AGENT_DAYTONA_API_URL=https://app.daytona.io/api
+# SANDBOX_AGENT_DAYTONA_TARGET=eu
+# SANDBOX_AGENT_DAYTONA_SNAPSHOT=agenta-sandbox-pi
+# SANDBOX_AGENT_DAYTONA_IMAGE=
 
 # ================================================================== #
 # docker

--- a/services/agent/AGENTS.md
+++ b/services/agent/AGENTS.md
@@ -1,0 +1,62 @@
+# Agent runner (TypeScript) conventions
+
+Scope: everything under `services/agent/`. This is the Node "agent runner" sidecar. It runs
+the agent loop and serves one contract: a JSON `/run` request in, a structured result out.
+The Python agent service (`services/oss/src/agent/`) decides *what* to run; this package
+*runs* it. It lives in Node because the harnesses (Pi, Claude Code, and the `sandbox-agent` package)
+are Node libraries with no Python SDK. The repo-wide rules live in `/AGENTS.md`; the
+architecture overview is this folder's `README.md`.
+
+## This is a standalone pnpm package
+
+Not part of the `web/` pnpm workspace. It has its OWN `pnpm-lock.yaml`, builds its own Docker
+image, and pins Node 24 / pnpm 10.30 / ESM (`"type": "module"`). It runs through `tsx` (no
+app compile step); the only build is `pnpm run build:extension` (esbuild-bundles the Pi
+extension into `dist/`). Keep it standalone so the sidecar image stays decoupled from the web
+dependency graph.
+
+## Commands
+
+```bash
+pnpm install              # from services/agent, with Node 24 on PATH
+pnpm run serve            # HTTP sidecar on :8765 (GET /health, POST /run)
+pnpm run run:cli          # one JSON request on stdin -> one result on stdout
+pnpm test                 # vitest: all unit tests
+pnpm run test:watch       # vitest watch
+pnpm run test:coverage    # vitest + v8 coverage
+pnpm run typecheck        # tsc --noEmit (src + tests + vitest.config)
+```
+
+## Where code and tests go
+
+- Runtime code: `src/` — `engines/` (one engine per file: `pi`, `sandbox_agent`), `tools/`,
+  `tracing/`, `extensions/`. Entrypoints: `cli.ts`, `server.ts`. The `/run` wire contract is
+  `protocol.ts`.
+- Tests: `tests/unit/**/*.test.ts` (vitest, `node:assert` is fine inside `it`). Shared test
+  helpers and fixtures live in `tests/utils/`. This mirrors `web/packages/*` and the repo
+  testing.structure spec. Do not add tests back under a flat `test/` directory.
+- Build/test artifacts (`test-results/`, `coverage/`, `dist/`) are git-ignored from the ROOT
+  `.gitignore` — a nested `services/agent/.gitignore` does NOT take effect (the repo-wide
+  `.*` rule ignores all nested `.gitignore` files).
+
+## The wire contract is mirrored — change both sides
+
+`src/protocol.ts` is the source of the `/run` types. The Python side hand-mirrors them in
+`sdks/python/agenta/sdk/agents/utils/wire.py`, and the contract is pinned by shared golden
+fixtures in `sdks/python/oss/tests/pytest/unit/agents/golden/`. Both sides assert those
+fixtures: Python in `test_wire_contract.py`, TypeScript in `tests/unit/wire-contract.test.ts`.
+If you add, rename, or remove a wire field, update the golden, then `protocol.ts` AND
+`wire.py` AND both contract tests, deliberately. The TS test has a compile-time key guard, so
+a drifted `protocol.ts` fails `tsc`.
+
+## Testing seams
+
+`server.ts` and `cli.ts` export `createAgentServer(run)` / `runCli(raw, {run})` so the HTTP
+and CLI behavior can be tested with a fake engine (no live Pi/Claude/sandbox-agent). Prefer testing
+through those seams over importing the real engines. Engine-internal logic that is pure
+(`tracing/otel.ts` state machine, `tools/*`, `engines/skills.ts`) is unit-tested directly.
+
+## Before committing
+
+There is no eslint here yet (deferred); `tsc --strict` + the repo-wide prettier hook are the
+floor. Run `pnpm test` and `pnpm run typecheck` before pushing.

--- a/services/agent/CLAUDE.md
+++ b/services/agent/CLAUDE.md
@@ -1,0 +1,1 @@
+AGENTS.md

--- a/services/agent/src/engines/skills.ts
+++ b/services/agent/src/engines/skills.ts
@@ -1,0 +1,50 @@
+/**
+ * Bundled-skill resolution, shared by both engines.
+ *
+ * The Agenta harness ships a fixed set of skills (see the SDK's `agenta_builtins`). They
+ * cannot ride the `/run` wire as text because each skill is a directory that may reference
+ * relative scripts and assets, so the wire carries only the skill *names* and each engine
+ * resolves them here against the runner's bundled `skills/` root:
+ *
+ *  - the in-process Pi engine (`engines/pi.ts`) feeds the resolved dirs to Pi's resource
+ *    loader as `additionalSkillPaths`;
+ *  - the sandbox-agent engine (`engines/sandbox_agent.ts`) lays the resolved dirs into the Pi agent dir's
+ *    `skills/` (user scope), where Pi auto-discovers them on every run.
+ */
+import { existsSync, statSync } from "node:fs";
+import { dirname, isAbsolute, join } from "node:path";
+import { fileURLToPath } from "node:url";
+
+// services/agent/src/engines/skills.ts -> services/agent. Bundled skills (the Agenta
+// harness's forced skills) live under services/agent/skills/<name>/. Overridable for
+// non-default layouts (e.g. a relocated sidecar).
+const PKG_ROOT = dirname(dirname(dirname(fileURLToPath(import.meta.url))));
+export const SKILLS_ROOT = process.env.AGENTA_AGENT_SKILLS_DIR || join(PKG_ROOT, "skills");
+
+/**
+ * Resolve the requested skill names to bundled skill directories under SKILLS_ROOT. Each name
+ * must be a committed dir holding a SKILL.md (Pi loads it and surfaces it in the system
+ * prompt). Absolute paths are honored as-is; unknown or non-directory entries are skipped with
+ * a warning so a stale name never fails the run. `log` defaults to a no-op so callers without a
+ * logger stay quiet.
+ */
+export function resolveSkillDirs(
+  names: string[] | undefined,
+  log: (message: string) => void = () => {},
+): string[] {
+  const dirs: string[] = [];
+  for (const name of names ?? []) {
+    if (!name) continue;
+    const path = isAbsolute(name) ? name : join(SKILLS_ROOT, name);
+    try {
+      if (existsSync(path) && statSync(path).isDirectory()) {
+        dirs.push(path);
+      } else {
+        log(`skipping unknown skill "${name}" (no directory at ${path})`);
+      }
+    } catch {
+      log(`skipping skill "${name}": cannot stat ${path}`);
+    }
+  }
+  return dirs;
+}

--- a/services/agent/src/entry.ts
+++ b/services/agent/src/entry.ts
@@ -1,0 +1,17 @@
+/**
+ * True when `moduleUrl` is the process entry point, so an entrypoint module runs its `main()`
+ * under `tsx src/x.ts` but stays inert when imported by a test. Compares the resolved real
+ * paths of `process.argv[1]` and the module's own file.
+ */
+import { argv } from "node:process";
+import { realpathSync } from "node:fs";
+import { fileURLToPath } from "node:url";
+
+export function isEntrypoint(moduleUrl: string): boolean {
+  if (!argv[1]) return false;
+  try {
+    return realpathSync(argv[1]) === realpathSync(fileURLToPath(moduleUrl));
+  } catch {
+    return false;
+  }
+}

--- a/services/agent/src/version.ts
+++ b/services/agent/src/version.ts
@@ -1,0 +1,35 @@
+/**
+ * Runner identity, surfaced on `GET /health` so a client can detect an incompatible runner
+ * before the first run (the version-skew guard).
+ *
+ * `PROTOCOL_VERSION` is the MAJOR of the `/run` wire contract in `protocol.ts`. Bump it only
+ * for a change that is not backward compatible; a client that probes `/health` can then
+ * refuse a runner whose protocol major it does not support. `RUNNER_VERSION` is the package
+ * version (the build), distinct from the protocol.
+ */
+import pkg from "../package.json";
+
+export const PROTOCOL_VERSION = 1;
+export const RUNNER_VERSION: string = pkg.version;
+export const ENGINES = ["pi", "sandbox-agent"] as const;
+export const HARNESSES = ["pi", "claude", "agenta"] as const;
+
+export interface RunnerInfo {
+  status: "ok";
+  /** Package build version (e.g. "0.1.0"). */
+  runner: string;
+  /** Wire-contract major. A client refuses a major it does not understand. */
+  protocol: number;
+  engines: readonly string[];
+  harnesses: readonly string[];
+}
+
+export function runnerInfo(): RunnerInfo {
+  return {
+    status: "ok",
+    runner: RUNNER_VERSION,
+    protocol: PROTOCOL_VERSION,
+    engines: ENGINES,
+    harnesses: HARNESSES,
+  };
+}

--- a/services/agent/tests/unit/cli.test.ts
+++ b/services/agent/tests/unit/cli.test.ts
@@ -1,0 +1,66 @@
+/**
+ * Unit tests for the stdin/stdout CLI transport via the `runCli(raw, stream, io)` seam.
+ *
+ * Injects a FAKE engine and a collecting `write`, so no stdin/stdout/process.exit mocking is
+ * needed. Covers the one-shot happy path, invalid JSON, a failing result, and the streaming
+ * order (event lines then exactly one terminal result line). No harness, no process exit.
+ *
+ * Run: pnpm test (or: pnpm exec vitest run tests/unit/cli.test.ts)
+ */
+import { describe, it } from "vitest";
+import assert from "node:assert/strict";
+
+import { runCli, type RunAgent } from "../../src/cli.ts";
+
+const okRun: RunAgent = async () => ({ ok: true, output: "hi" });
+
+function collector() {
+  const chunks: string[] = [];
+  return { chunks, write: (s: string) => chunks.push(s), text: () => chunks.join("") };
+}
+
+describe("runCli", () => {
+  it("one-shot: writes the result JSON and returns exit 0", async () => {
+    const out = collector();
+    const code = await runCli(JSON.stringify({ backend: "pi" }), false, { run: okRun, write: out.write });
+    assert.equal(code, 0);
+    assert.deepEqual(JSON.parse(out.text()), { ok: true, output: "hi" });
+  });
+
+  it("invalid JSON: returns exit 1 with an error result", async () => {
+    const out = collector();
+    const code = await runCli("{not json", false, { run: okRun, write: out.write });
+    assert.equal(code, 1);
+    const res = JSON.parse(out.text()) as { ok: boolean; error: string };
+    assert.equal(res.ok, false);
+    assert.match(res.error, /Invalid JSON on stdin/);
+  });
+
+  it("a failing result returns exit 1", async () => {
+    const out = collector();
+    const code = await runCli("{}", false, {
+      run: async () => ({ ok: false, error: "boom" }),
+      write: out.write,
+    });
+    assert.equal(code, 1);
+    assert.equal((JSON.parse(out.text()) as { error: string }).error, "boom");
+  });
+
+  it("stream: event lines then exactly one terminal result line", async () => {
+    const out = collector();
+    const streamRun: RunAgent = async (_req, emit) => {
+      emit?.({ type: "message", text: "a" });
+      emit?.({ type: "message", text: "b" });
+      return { ok: true, output: "ab", events: [{ type: "message", text: "a" }] };
+    };
+    const code = await runCli("{}", true, { run: streamRun, write: out.write });
+    assert.equal(code, 0);
+    const records = out
+      .text()
+      .trim()
+      .split("\n")
+      .map((line) => JSON.parse(line) as { kind: string; result?: { events: unknown[] } });
+    assert.deepEqual(records.map((r) => r.kind), ["event", "event", "result"]);
+    assert.deepEqual(records[2].result!.events, [], "terminal result does not echo events");
+  });
+});

--- a/services/agent/tests/unit/code-tool.test.ts
+++ b/services/agent/tests/unit/code-tool.test.ts
@@ -1,0 +1,89 @@
+/**
+ * Unit test for the code-tool executor (runCodeTool).
+ *
+ * Exercises both runtimes end-to-end through real subprocesses: a python tool, node tools
+ * written as a bare top-level `function main` (the F2 regression) and as an explicit
+ * `module.exports.main`, an async node `main`, the F3 env-isolation guarantee (provider keys
+ * do NOT leak in; declared scoped secrets DO), and the non-zero-exit reject path.
+ *
+ * Needs `python3` and `node` on PATH (both present locally and on ubuntu CI runners).
+ *
+ * Run: pnpm test (or: pnpm exec vitest run tests/unit/code-tool.test.ts)
+ */
+import { describe, it } from "vitest";
+import assert from "node:assert/strict";
+
+import { runCodeTool } from "../../src/tools/code.ts";
+
+describe("runCodeTool", () => {
+  it("runs a python bare `def main(**kw)`", async () => {
+    const code = 'def main(**kw):\n    return {"sum": kw.get("a", 0) + kw.get("b", 0)}\n';
+    const out = await runCodeTool("python", code, undefined, { a: 2, b: 3 });
+    assert.deepEqual(JSON.parse(out), { sum: 5 }, "python bare main returns the right JSON");
+  });
+
+  it("runs a node bare top-level `function main` (F2 regression)", async () => {
+    const code = "function main(inputs) { return { got: inputs }; }";
+    const out = await runCodeTool("node", code, undefined, { hello: "world" });
+    assert.deepEqual(
+      JSON.parse(out),
+      { got: { hello: "world" } },
+      "node bare function main executes and echoes the input",
+    );
+  });
+
+  it("runs a node explicit `module.exports.main`", async () => {
+    const code = "module.exports.main = function (inputs) { return { via: 'exports', got: inputs }; };";
+    const out = await runCodeTool("node", code, undefined, { x: 1 });
+    assert.deepEqual(
+      JSON.parse(out),
+      { via: "exports", got: { x: 1 } },
+      "node module.exports.main works",
+    );
+  });
+
+  it("runs an async node `main` returning a Promise", async () => {
+    const code =
+      "async function main(inputs) { await new Promise((r) => setTimeout(r, 5)); return { doubled: inputs.n * 2 }; }";
+    const out = await runCodeTool("node", code, undefined, { n: 21 });
+    assert.deepEqual(JSON.parse(out), { doubled: 42 }, "node async main resolves");
+  });
+
+  it("F3: provider keys do NOT leak; scoped secrets DO", async () => {
+    const hadKey = "OPENAI_API_KEY" in process.env;
+    const prevKey = process.env.OPENAI_API_KEY;
+    process.env.OPENAI_API_KEY = "leak-me-xyz";
+    try {
+      // The provider key sits in process.env but must not reach the snippet.
+      const leakCode = "function main() { return { key: process.env.OPENAI_API_KEY ?? 'absent' }; }";
+      const leakOut = await runCodeTool("node", leakCode, undefined, {});
+      assert.deepEqual(
+        JSON.parse(leakOut),
+        { key: "absent" },
+        "F3: OPENAI_API_KEY did NOT leak into the snippet env",
+      );
+
+      // A secret declared on the tool (passed via the scoped `env` arg) must be visible.
+      const scopedCode =
+        "function main() { return { secret: process.env.MY_TOOL_SECRET ?? 'absent' }; }";
+      const scopedOut = await runCodeTool("node", scopedCode, { MY_TOOL_SECRET: "ok" }, {});
+      assert.deepEqual(
+        JSON.parse(scopedOut),
+        { secret: "ok" },
+        "F3: scoped MY_TOOL_SECRET IS visible to the snippet",
+      );
+    } finally {
+      if (hadKey) process.env.OPENAI_API_KEY = prevKey;
+      else delete process.env.OPENAI_API_KEY;
+    }
+  });
+
+  it("rejects when the snippet throws / exits non-zero", async () => {
+    const code = "function main() { throw new Error('boom'); }";
+    await assert.rejects(
+      () => runCodeTool("node", code, undefined, {}),
+      /boom|exited/,
+      "a throwing snippet rejects",
+    );
+  });
+});

--- a/services/agent/tests/unit/continuation.test.ts
+++ b/services/agent/tests/unit/continuation.test.ts
@@ -1,0 +1,72 @@
+/**
+ * Unit tests for the cross-turn HITL continuation substrate.
+ *
+ * Under the cold model the harness rebuilds context from the replayed transcript, and ACP
+ * prompt content blocks cannot carry tool calls/results. So a resolved interaction (an
+ * approved tool that ran, a client-fulfilled tool) must survive into the replay as text.
+ * `messageTranscript` encodes tool turns; `buildTurnText` keeps them in the replayed history.
+ *
+ * Run: pnpm test (or: pnpm exec vitest run tests/unit/continuation.test.ts)
+ */
+import { describe, it } from "vitest";
+import assert from "node:assert/strict";
+
+import { messageTranscript, buildTurnText } from "../../src/engines/sandbox_agent.ts";
+import {
+  resolveRunSessionId,
+  type AgentRunRequest,
+  type ContentBlock,
+} from "../../src/protocol.ts";
+
+describe("messageTranscript", () => {
+  it("encodes plain text, content blocks, and tool turns", () => {
+    assert.equal(messageTranscript("hello"), "hello");
+    assert.equal(messageTranscript([{ type: "text", text: "a" }, { type: "text", text: "b" }]), "a\nb");
+    assert.equal(
+      messageTranscript([{ type: "tool_call", toolName: "getWeather", input: { city: "Paris" } }]),
+      '[called getWeather({"city":"Paris"})]',
+    );
+    assert.equal(
+      messageTranscript([{ type: "tool_result", toolName: "getWeather", output: { temp: 24 } }]),
+      '[getWeather returned: {"temp":24}]',
+    );
+    assert.equal(
+      messageTranscript([{ type: "tool_result", toolName: "send", output: "boom", isError: true }]),
+      "[send error: boom]",
+    );
+  });
+});
+
+describe("resolveRunSessionId", () => {
+  it("prefers the platform session id, falling back to the ephemeral one", () => {
+    assert.equal(
+      resolveRunSessionId({ sessionId: "sess_platform" }, "runner-ephemeral"),
+      "sess_platform",
+    );
+    assert.equal(resolveRunSessionId({}, "runner-ephemeral"), "runner-ephemeral");
+  });
+});
+
+describe("buildTurnText", () => {
+  it("keeps a resolved tool turn in the replay", () => {
+    const req: AgentRunRequest = {
+      messages: [
+        { role: "user", content: "weather in Paris?" },
+        {
+          role: "assistant",
+          content: [{ type: "tool_call", toolName: "getWeather", input: { city: "Paris" } } as ContentBlock],
+        },
+        {
+          role: "tool",
+          content: [{ type: "tool_result", toolName: "getWeather", output: { temp: 24 } } as ContentBlock],
+        },
+        { role: "user", content: "and tomorrow?" },
+      ],
+    };
+    const text = buildTurnText(req);
+    assert.ok(text.includes("called getWeather"), "tool call survives replay");
+    assert.ok(text.includes("getWeather returned"), "tool result survives replay");
+    assert.ok(text.includes("and tomorrow?"), "latest user prompt is the live turn");
+    assert.ok(text.startsWith("Conversation so far:"), "transcript header present");
+  });
+});

--- a/services/agent/tests/unit/extension-tools.test.ts
+++ b/services/agent/tests/unit/extension-tools.test.ts
@@ -1,0 +1,108 @@
+/**
+ * Regression: the Agenta Pi extension registers custom tools from AGENTA_TOOL_PUBLIC_SPECS.
+ *
+ * Guards QA finding F-005 (docs/design/agent-workflows/qa/findings.md): a build where the
+ * extension stopped reading AGENTA_TOOL_PUBLIC_SPECS shipped custom tools that the model never
+ * saw, so it improvised with bash and failed. This pins the contract at the source: given the
+ * public-spec env the runner sets (buildPiExtensionEnv in engines/sandbox_agent.ts), the extension
+ * factory calls pi.registerTool once per spec, passes the JSON Schema through, and gives each
+ * tool an execute() that relays to the runner. It is also inert when the env is absent.
+ *
+ * Run: pnpm test (or: pnpm exec vitest run tests/unit/extension-tools.test.ts)
+ */
+import { afterEach, describe, it } from "vitest";
+import assert from "node:assert/strict";
+
+import factory from "../../src/extensions/agenta.ts";
+
+const TOOL_ENV = [
+  "AGENTA_TOOL_PUBLIC_SPECS",
+  "AGENTA_TOOL_RELAY_DIR",
+  "AGENTA_TRACEPARENT",
+  "AGENTA_OTLP_ENDPOINT",
+  "AGENTA_USAGE_OUT",
+  "AGENTA_CAPTURE_CONTENT",
+];
+
+function fakePi() {
+  const registered: any[] = [];
+  return {
+    registered,
+    registerTool(spec: any) {
+      registered.push(spec);
+    },
+    on() {},
+  };
+}
+
+function clearEnv() {
+  for (const key of TOOL_ENV) delete process.env[key];
+}
+
+afterEach(clearEnv);
+
+describe("agenta extension tool registration", () => {
+  it("registers one tool per public spec, schema passed through", () => {
+    clearEnv();
+    process.env.AGENTA_TOOL_PUBLIC_SPECS = JSON.stringify([
+      {
+        name: "secret_math",
+        description: "qa math",
+        inputSchema: {
+          type: "object",
+          properties: { x: { type: "integer" } },
+          required: ["x"],
+        },
+      },
+      { name: "no_schema_tool", description: "no schema" },
+    ]);
+    process.env.AGENTA_TOOL_RELAY_DIR = "/tmp/agenta-relay-test";
+
+    const pi = fakePi();
+    factory(pi as any);
+
+    assert.equal(pi.registered.length, 2, "registers one tool per public spec");
+    assert.deepEqual(
+      pi.registered.map((t) => t.name),
+      ["secret_math", "no_schema_tool"],
+      "registers each spec by name",
+    );
+
+    const math = pi.registered[0];
+    assert.equal(math.description, "qa math", "carries the description");
+    assert.ok(
+      math.parameters && math.parameters.properties && math.parameters.properties.x,
+      "passes the JSON Schema through to Pi",
+    );
+    assert.equal(typeof math.execute, "function", "each tool has an execute() that relays");
+
+    const noSchema = pi.registered[1];
+    assert.ok(
+      noSchema.parameters,
+      "a spec without inputSchema falls back to a schema, never undefined",
+    );
+  });
+
+  it("is inert without the tool env (the F-005 bug shape: never delivered)", () => {
+    clearEnv();
+    const pi = fakePi();
+    factory(pi as any);
+    assert.equal(
+      pi.registered.length,
+      0,
+      "no tool env => registers nothing (no silent partial state)",
+    );
+  });
+
+  it("does not register when specs are present but the relay dir is missing", () => {
+    clearEnv();
+    process.env.AGENTA_TOOL_PUBLIC_SPECS = JSON.stringify([{ name: "x" }]);
+    const pi = fakePi();
+    factory(pi as any);
+    assert.equal(
+      pi.registered.length,
+      0,
+      "specs without a relay dir do not register (incomplete wiring is not honored)",
+    );
+  });
+});

--- a/services/agent/tests/unit/mcp-servers.test.ts
+++ b/services/agent/tests/unit/mcp-servers.test.ts
@@ -1,0 +1,58 @@
+/**
+ * Unit tests for the user-declared MCP server conversion (Agent B's Slice 4, wired in sandbox-agent).
+ *
+ * Agent B's `resolve_mcp_servers` emits the McpServerConfig wire shape
+ * ({name,transport,command,args,env,url?,tools?}, env as a Record), pinned in the Python
+ * test_wire_contract. This covers the TS half: converting that to the ACP stdio entry the
+ * session consumes (env as a {name,value} list), skipping remote/http, and not enforcing the
+ * per-server tools allowlist over ACP in v1.
+ *
+ * Run: pnpm test (or: pnpm exec vitest run tests/unit/mcp-servers.test.ts)
+ */
+import { describe, it } from "vitest";
+import assert from "node:assert/strict";
+
+import { toAcpMcpServers } from "../../src/engines/sandbox_agent.ts";
+import type { McpServerConfig } from "../../src/protocol.ts";
+
+describe("toAcpMcpServers", () => {
+  it("maps empty input to []", () => {
+    assert.deepEqual(toAcpMcpServers(undefined), [], "undefined -> []");
+    assert.deepEqual(toAcpMcpServers([]), [], "[] -> []");
+  });
+
+  it("converts a stdio server's env Record to an ACP {name,value} list", () => {
+    const servers: McpServerConfig[] = [
+      {
+        name: "github",
+        transport: "stdio",
+        command: "npx",
+        args: ["-y", "@modelcontextprotocol/server-github"],
+        env: { GITHUB_PERSONAL_ACCESS_TOKEN: "ghp_x", LOG_LEVEL: "info" },
+        tools: ["create_issue"], // allowlist not enforced over ACP v1 (logged), server still delivered
+      },
+    ];
+    const out = toAcpMcpServers(servers);
+    assert.equal(out.length, 1);
+    assert.equal(out[0].name, "github");
+    assert.equal(out[0].command, "npx");
+    assert.deepEqual(out[0].args, ["-y", "@modelcontextprotocol/server-github"]);
+    assert.deepEqual(out[0].env, [
+      { name: "GITHUB_PERSONAL_ACCESS_TOKEN", value: "ghp_x" },
+      { name: "LOG_LEVEL", value: "info" },
+    ]);
+  });
+
+  it("skips remote/http and command-less stdio servers", () => {
+    const out = toAcpMcpServers([
+      { name: "remote", transport: "http", url: "https://example.com/mcp" },
+      { name: "broken", transport: "stdio" }, // no command
+    ]);
+    assert.deepEqual(out, [], "http + command-less stdio both skipped");
+  });
+
+  it("defaults missing env / args to empty", () => {
+    const out = toAcpMcpServers([{ name: "fs", transport: "stdio", command: "mcp-fs" }]);
+    assert.deepEqual(out, [{ name: "fs", command: "mcp-fs", args: [], env: [] }]);
+  });
+});

--- a/services/agent/tests/unit/responder.test.ts
+++ b/services/agent/tests/unit/responder.test.ts
@@ -1,0 +1,92 @@
+/**
+ * Unit tests for the interaction responder seam and the otel `emitEvent` hook.
+ *
+ * Covers the behavior parity of the responder (it replaces the old inline auto-approve in
+ * sandbox_agent.ts) and that an out-of-stream event (an `interaction_request`) routed through
+ * `emitEvent` lands in both the live sink and the batch `events()` log. No harness, no
+ * network.
+ *
+ * Run: pnpm test (or: pnpm exec vitest run tests/unit/responder.test.ts)
+ */
+import { afterEach, describe, it } from "vitest";
+import assert from "node:assert/strict";
+
+import { createSandboxAgentOtel } from "../../src/tracing/otel.ts";
+import type { AgentEvent } from "../../src/protocol.ts";
+import {
+  PolicyResponder,
+  decisionToReply,
+  policyFromRequest,
+} from "../../src/responder.ts";
+
+// Defensive cleanup: policyFromRequest reads this env var; never let it leak past a test
+// (e.g. if an assertion throws mid-test, before the inline delete runs).
+afterEach(() => {
+  delete process.env.SANDBOX_AGENT_DENY_PERMISSIONS;
+});
+
+describe("policyFromRequest", () => {
+  it("honors the arg and the env override", () => {
+    delete process.env.SANDBOX_AGENT_DENY_PERMISSIONS;
+    assert.equal(policyFromRequest(undefined), "auto");
+    assert.equal(policyFromRequest("auto"), "auto");
+    assert.equal(policyFromRequest("deny"), "deny");
+
+    process.env.SANDBOX_AGENT_DENY_PERMISSIONS = "true";
+    assert.equal(policyFromRequest(undefined), "deny", "env forces deny");
+    assert.equal(policyFromRequest("auto"), "deny", "env overrides auto");
+    delete process.env.SANDBOX_AGENT_DENY_PERMISSIONS;
+  });
+});
+
+describe("decisionToReply (parity with the old inline mapping)", () => {
+  it("maps allow/deny onto the available replies", () => {
+    assert.equal(decisionToReply("allow", ["always", "once", "reject"]), "always");
+    assert.equal(decisionToReply("allow", ["once", "reject"]), "once");
+    assert.equal(decisionToReply("allow", []), "once", "allow falls back to once");
+    assert.equal(decisionToReply("deny", ["always", "once", "reject"]), "reject");
+    assert.equal(decisionToReply("deny", []), "reject", "deny falls back to reject");
+  });
+});
+
+describe("PolicyResponder", () => {
+  it("auto allows and deny denies", async () => {
+    const auto = new PolicyResponder("auto");
+    const deny = new PolicyResponder("deny");
+    const req = { id: "p1", availableReplies: ["once", "reject"] };
+    assert.equal(await auto.onPermission(req), "allow");
+    assert.equal(await deny.onPermission(req), "deny");
+  });
+});
+
+describe("emitEvent", () => {
+  it("streaming path: flushes to the live sink and the batch log", () => {
+    const emitted: AgentEvent[] = [];
+    const run = createSandboxAgentOtel({ harness: "claude", model: "anthropic/x", emit: (e) => emitted.push(e) });
+    run.start({ prompt: "hi" });
+    const interaction: AgentEvent = {
+      type: "interaction_request",
+      id: "p1",
+      kind: "permission",
+      payload: { availableReplies: ["once", "reject"] },
+    };
+    run.emitEvent(interaction);
+
+    const live = emitted.find((e) => e.type === "interaction_request");
+    assert.ok(live, "interaction_request flushed to the live sink");
+    assert.equal((live as any).id, "p1");
+    assert.ok(
+      run.events().some((e) => e.type === "interaction_request"),
+      "interaction_request also recorded in the batch log",
+    );
+  });
+
+  it("one-shot path: records in the batch log only", () => {
+    const run = createSandboxAgentOtel({ harness: "claude", model: "anthropic/x" });
+    run.start({ prompt: "hi" });
+    run.emitEvent({ type: "data", name: "weather", data: { temp: 24 } });
+    const ev = run.events().find((e) => e.type === "data");
+    assert.ok(ev, "data event recorded with no live sink");
+    assert.equal((ev as any).name, "weather");
+  });
+});

--- a/services/agent/tests/unit/server.test.ts
+++ b/services/agent/tests/unit/server.test.ts
@@ -1,0 +1,109 @@
+/**
+ * Unit tests for the HTTP transport via the `createAgentServer(run)` seam.
+ *
+ * Starts a real server on an ephemeral port with a FAKE engine (no Pi/Claude/sandbox-agent) and makes
+ * real requests. Covers /health, the /run happy path, invalid JSON (400), a failing result
+ * (500), and the NDJSON streaming order (events first, then exactly one terminal result).
+ *
+ * Run: pnpm test (or: pnpm exec vitest run tests/unit/server.test.ts)
+ */
+import { describe, it } from "vitest";
+import assert from "node:assert/strict";
+import type { AddressInfo } from "node:net";
+
+import { createAgentServer, type RunAgent } from "../../src/server.ts";
+
+async function listen(run: RunAgent): Promise<{ url: string; close: () => Promise<void> }> {
+  const server = createAgentServer(run);
+  await new Promise<void>((resolve) => server.listen(0, "127.0.0.1", resolve));
+  const { port } = server.address() as AddressInfo;
+  return {
+    url: `http://127.0.0.1:${port}`,
+    close: () => new Promise<void>((resolve) => server.close(() => resolve())),
+  };
+}
+
+const okRun: RunAgent = async () => ({ ok: true, output: "hi", events: [] });
+
+describe("createAgentServer", () => {
+  it("GET /health returns runner identity", async () => {
+    const s = await listen(okRun);
+    try {
+      const res = await fetch(`${s.url}/health`);
+      assert.equal(res.status, 200);
+      const body = (await res.json()) as Record<string, unknown>;
+      assert.equal(body.status, "ok");
+      assert.equal(typeof body.runner, "string");
+      assert.equal(typeof body.protocol, "number");
+      assert.ok(Array.isArray(body.engines) && (body.engines as unknown[]).includes("pi"));
+      assert.ok(Array.isArray(body.harnesses));
+    } finally {
+      await s.close();
+    }
+  });
+
+  it("POST /run returns the engine result (200)", async () => {
+    const s = await listen(okRun);
+    try {
+      const res = await fetch(`${s.url}/run`, { method: "POST", body: JSON.stringify({ backend: "pi" }) });
+      assert.equal(res.status, 200);
+      const body = (await res.json()) as { ok: boolean; output: string };
+      assert.equal(body.ok, true);
+      assert.equal(body.output, "hi");
+    } finally {
+      await s.close();
+    }
+  });
+
+  it("POST /run with invalid JSON returns 400", async () => {
+    const s = await listen(okRun);
+    try {
+      const res = await fetch(`${s.url}/run`, { method: "POST", body: "{not json" });
+      assert.equal(res.status, 400);
+      const body = (await res.json()) as { ok: boolean; error: string };
+      assert.equal(body.ok, false);
+      assert.match(body.error, /Invalid JSON/);
+    } finally {
+      await s.close();
+    }
+  });
+
+  it("a failing result returns 500", async () => {
+    const failRun: RunAgent = async () => ({ ok: false, error: "boom" });
+    const s = await listen(failRun);
+    try {
+      const res = await fetch(`${s.url}/run`, { method: "POST", body: "{}" });
+      assert.equal(res.status, 500);
+      const body = (await res.json()) as { ok: boolean; error: string };
+      assert.equal(body.ok, false);
+      assert.equal(body.error, "boom");
+    } finally {
+      await s.close();
+    }
+  });
+
+  it("NDJSON stream: events first, then exactly one terminal result with no echoed events", async () => {
+    const streamRun: RunAgent = async (_req, emit) => {
+      emit?.({ type: "message", text: "a" });
+      emit?.({ type: "message", text: "b" });
+      return { ok: true, output: "ab", events: [{ type: "message", text: "a" }] };
+    };
+    const s = await listen(streamRun);
+    try {
+      const res = await fetch(`${s.url}/run`, {
+        method: "POST",
+        headers: { accept: "application/x-ndjson" },
+        body: "{}",
+      });
+      assert.equal(res.status, 200);
+      const records = (await res.text())
+        .trim()
+        .split("\n")
+        .map((line) => JSON.parse(line) as { kind: string; result?: { events: unknown[] } });
+      assert.deepEqual(records.map((r) => r.kind), ["event", "event", "result"]);
+      assert.deepEqual(records[2].result!.events, [], "terminal result does not echo events");
+    } finally {
+      await s.close();
+    }
+  });
+});

--- a/services/agent/tests/unit/skills.test.ts
+++ b/services/agent/tests/unit/skills.test.ts
@@ -1,0 +1,65 @@
+/**
+ * Unit tests for bundled-skill resolution (`engines/skills.ts`), the shared helper both
+ * engines use to turn the Agenta harness's forced skill *names* into directories on disk.
+ *
+ * No harness, no network: just disk resolution against a temp SKILLS_ROOT and absolute paths.
+ *
+ * Run: pnpm test (or: pnpm exec vitest run tests/unit/skills.test.ts)
+ */
+import { afterAll, describe, it } from "vitest";
+import assert from "node:assert/strict";
+import { mkdirSync, mkdtempSync, rmSync, writeFileSync } from "node:fs";
+import { tmpdir } from "node:os";
+import { join } from "node:path";
+
+// A throwaway skills root with one real skill dir and one bare file (not a skill dir).
+const root = mkdtempSync(join(tmpdir(), "agenta-skills-test-"));
+mkdirSync(join(root, "alpha"));
+writeFileSync(join(root, "alpha", "SKILL.md"), "---\nname: alpha\n---\n");
+writeFileSync(join(root, "loose.md"), "not a dir");
+
+// skills.ts reads AGENTA_AGENT_SKILLS_DIR at import time, so set it before importing.
+const prevSkillsDir = process.env.AGENTA_AGENT_SKILLS_DIR;
+process.env.AGENTA_AGENT_SKILLS_DIR = root;
+const { resolveSkillDirs, SKILLS_ROOT } = await import("../../src/engines/skills.ts");
+
+afterAll(() => {
+  // Restore the env var so this file does not leak it to others sharing the worker.
+  if (prevSkillsDir === undefined) delete process.env.AGENTA_AGENT_SKILLS_DIR;
+  else process.env.AGENTA_AGENT_SKILLS_DIR = prevSkillsDir;
+  rmSync(root, { recursive: true, force: true });
+});
+
+describe("resolveSkillDirs", () => {
+  it("SKILLS_ROOT honors the override", () => {
+    assert.equal(SKILLS_ROOT, root, "SKILLS_ROOT reads AGENTA_AGENT_SKILLS_DIR");
+  });
+
+  it("resolves a known name to its directory under the root", () => {
+    assert.deepEqual(resolveSkillDirs(["alpha"]), [join(root, "alpha")]);
+  });
+
+  it("skips unknown names and non-directories, logging each", () => {
+    const logs: string[] = [];
+    assert.deepEqual(resolveSkillDirs(["nope", "loose.md"], (m) => logs.push(m)), []);
+    assert.equal(logs.length, 2, "one log line per skipped entry");
+    assert.ok(
+      logs.every((m) => /skipping/.test(m)),
+      "skips are surfaced through the logger",
+    );
+  });
+
+  it("honors absolute paths as-is (the in-process loader path)", () => {
+    assert.deepEqual(resolveSkillDirs([join(root, "alpha")]), [join(root, "alpha")]);
+  });
+
+  it("treats empty / undefined input as a no-op", () => {
+    assert.deepEqual(resolveSkillDirs(undefined), []);
+    assert.deepEqual(resolveSkillDirs([]), []);
+    assert.deepEqual(resolveSkillDirs([""]), [], "blank names are dropped");
+  });
+
+  it("uses a silent no-op default logger (no throw without a logger)", () => {
+    assert.deepEqual(resolveSkillDirs(["nope"]), [], "missing skill is skipped, not thrown");
+  });
+});

--- a/services/agent/tests/unit/stream-events.test.ts
+++ b/services/agent/tests/unit/stream-events.test.ts
@@ -1,0 +1,146 @@
+/**
+ * Unit test for the createSandboxAgentOtel delta/lifecycle state machine.
+ *
+ * Drives `handleUpdate` with a hand-built ACP `session/update` sequence (Claude-style
+ * cumulative text snapshots, a tool call between two text runs, a reasoning run) and asserts
+ * the streaming and one-shot event shapes. No harness, no network: spans are built offline
+ * and never flushed.
+ *
+ * Run: pnpm test (or: pnpm exec vitest run tests/unit/stream-events.test.ts)
+ */
+import { describe, it } from "vitest";
+import assert from "node:assert/strict";
+
+import { createSandboxAgentOtel } from "../../src/tracing/otel.ts";
+import type { AgentEvent } from "../../src/protocol.ts";
+
+const textChunk = (text: string) => ({
+  sessionUpdate: "agent_message_chunk",
+  content: { type: "text", text },
+});
+const thoughtChunk = (text: string) => ({
+  sessionUpdate: "agent_thought_chunk",
+  content: { type: "text", text },
+});
+const toolCall = (id: string, title: string, rawInput: unknown) => ({
+  sessionUpdate: "tool_call",
+  toolCallId: id,
+  title,
+  rawInput,
+});
+const toolDone = (id: string, text: string) => ({
+  sessionUpdate: "tool_call_update",
+  toolCallId: id,
+  status: "completed",
+  content: [{ content: { type: "text", text } }],
+});
+const usage = () => ({ sessionUpdate: "usage_update", used: 100, cost: { amount: 0.01 } });
+
+// The same ACP sequence drives both modes: two text runs around a tool call, then reasoning.
+function drive(run: ReturnType<typeof createSandboxAgentOtel>): void {
+  run.start({ prompt: "weather in Paris?" });
+  run.handleUpdate(textChunk("Hello ")); // pure delta
+  run.handleUpdate(textChunk("Hello world")); // cumulative snapshot (Claude-style)
+  run.handleUpdate(toolCall("call_1", "getWeather", { city: "Paris" }));
+  run.handleUpdate(toolDone("call_1", "sunny"));
+  run.handleUpdate(textChunk("Hello world It is sunny.")); // resumes after the tool
+  run.handleUpdate(thoughtChunk("thinking..."));
+  run.handleUpdate(usage());
+}
+
+const types = (events: AgentEvent[]) => events.map((e) => e.type);
+const ofType = <T extends AgentEvent["type"]>(events: AgentEvent[], t: T) =>
+  events.filter((e) => e.type === t) as Extract<AgentEvent, { type: T }>[];
+
+describe("createSandboxAgentOtel state machine", () => {
+  it("scenario 1: streaming (emit set) yields pure deltas and balanced lifecycle", () => {
+    const emitted: AgentEvent[] = [];
+    const run = createSandboxAgentOtel({ harness: "claude", model: "anthropic/x", emit: (e) => emitted.push(e) });
+    drive(run);
+    const finalText = run.finish();
+
+    // No coalesced text events on the streaming path.
+    assert.equal(ofType(emitted, "message").length, 0, "no coalesced message when streaming");
+    assert.equal(ofType(emitted, "thought").length, 0, "no coalesced thought when streaming");
+
+    // Exactly one terminal done.
+    assert.equal(ofType(emitted, "done").length, 1, "exactly one done");
+
+    // Two text blocks (split by the tool call), one reasoning block, balanced start/end.
+    const mStart = ofType(emitted, "message_start");
+    const mEnd = ofType(emitted, "message_end");
+    assert.equal(mStart.length, 2, "two message_start");
+    assert.equal(mEnd.length, 2, "two message_end");
+    assert.deepEqual(mStart.map((e) => e.id), ["msg-0", "msg-1"], "stable monotonic text ids");
+    const rStart = ofType(emitted, "reasoning_start");
+    const rEnd = ofType(emitted, "reasoning_end");
+    assert.equal(rStart.length, 1, "one reasoning_start");
+    assert.equal(rEnd.length, 1, "one reasoning_end");
+
+    // Deltas are pure and reconstruct the full text, with no overlap/repeat.
+    const text = ofType(emitted, "message_delta").map((e) => e.delta).join("");
+    assert.equal(text, "Hello world It is sunny.", "concatenated deltas == full text");
+    assert.equal(text, finalText, "deltas match finish() output");
+    const reasoning = ofType(emitted, "reasoning_delta").map((e) => e.delta).join("");
+    assert.equal(reasoning, "thinking...", "concatenated reasoning deltas");
+
+    // Ordering invariant: each block's start precedes its deltas precede its end; tool result
+    // lands before the second text block opens.
+    const seq = types(emitted);
+    assert.ok(seq.indexOf("message_end") < seq.indexOf("tool_call"), "first text block closes before the tool call");
+    assert.ok(seq.indexOf("tool_result") < seq.lastIndexOf("message_start"), "tool result precedes the second text block");
+    for (const id of ["msg-0", "msg-1", "reason-2"]) {
+      const idxs = emitted
+        .map((e, i) => ((e as any).id === id ? { i, t: e.type } : null))
+        .filter(Boolean) as { i: number; t: string }[];
+      assert.ok(idxs[0].t.endsWith("_start"), `${id} starts with *_start`);
+      assert.ok(idxs[idxs.length - 1].t.endsWith("_end"), `${id} ends with *_end`);
+    }
+  });
+
+  it("scenario 2: one-shot (no emit) coalesces text/thought and keeps structured events", () => {
+    const run = createSandboxAgentOtel({ harness: "claude", model: "anthropic/x" });
+    drive(run);
+    const finalText = run.finish();
+    const events = run.events();
+
+    // Coalesced text/thought, no delta lifecycle events.
+    const messages = ofType(events, "message");
+    assert.equal(messages.length, 1, "one coalesced message");
+    assert.equal(messages[0].text, "Hello world It is sunny.", "coalesced text == final");
+    assert.equal(messages[0].text, finalText);
+    assert.equal(ofType(events, "thought").length, 1, "one coalesced thought");
+    for (const t of ["message_start", "message_delta", "message_end", "reasoning_start", "reasoning_delta", "reasoning_end"]) {
+      assert.equal(events.filter((e) => e.type === t).length, 0, `no ${t} on the one-shot path`);
+    }
+
+    // The structured tool/usage events are still present, with exactly one done.
+    assert.equal(ofType(events, "tool_call").length, 1, "tool_call present");
+    assert.equal(ofType(events, "tool_result").length, 1, "tool_result present");
+    assert.equal(ofType(events, "usage").length, 1, "usage present");
+    assert.equal(ofType(events, "done").length, 1, "exactly one done");
+  });
+
+  it("scenario 3: span-less mode still records ACP events and final usage", () => {
+    const run = createSandboxAgentOtel({ harness: "pi", model: "openai-codex/x", emitSpans: false });
+    drive(run);
+    run.setUsage({ input: 4, output: 6, total: 10, cost: 0.02 });
+    const finalText = run.finish();
+    const events = run.events();
+
+    assert.equal(finalText, "Hello world It is sunny.");
+    assert.equal(ofType(events, "message").length, 1, "message present without spans");
+    assert.equal(ofType(events, "thought").length, 1, "thought present without spans");
+    assert.equal(ofType(events, "tool_call").length, 1, "tool_call present without spans");
+    assert.equal(ofType(events, "tool_result").length, 1, "tool_result present without spans");
+    const usageEvents = ofType(events, "usage");
+    assert.equal(usageEvents.length, 1, "usage present without spans");
+    assert.deepEqual(
+      usageEvents[0],
+      { type: "usage", input: 4, output: 6, total: 10, cost: 0.02 },
+      "final usage replaces stream-only usage before done",
+    );
+    assert.equal(ofType(events, "done").length, 1, "exactly one done without spans");
+    assert.ok(types(events).indexOf("usage") < types(events).indexOf("done"), "usage precedes done");
+  });
+});

--- a/services/agent/tests/unit/tool-bridge.test.ts
+++ b/services/agent/tests/unit/tool-bridge.test.ts
@@ -1,0 +1,157 @@
+/**
+ * Unit tests for buildToolMcpServers (the tool MCP bridge attachment decision).
+ *
+ * Regression cover for F4: attachment must be decided per tool kind, not on the callback
+ * endpoint alone. A `code` tool runs locally in mcp-server.ts and needs no endpoint, so a run
+ * whose tools are all `code` must still attach the `agenta-tools` server. Only `callback`-kind
+ * tools require AGENTA_TOOL_CALLBACK_ENDPOINT; missing it must degrade those tools, not drop the
+ * whole server. `client` tools are browser-fulfilled and never justify attaching the bridge.
+ *
+ * Run: pnpm test (or: pnpm exec vitest run tests/unit/tool-bridge.test.ts)
+ */
+import { describe, it } from "vitest";
+import assert from "node:assert/strict";
+
+import { buildToolMcpServers } from "../../src/tools/mcp-bridge.ts";
+import type { ResolvedToolSpec, ToolCallbackContext } from "../../src/protocol.ts";
+
+/** Look up an env var value by name in the ACP {name,value} list (undefined if absent). */
+function envValue(
+  env: { name: string; value: string }[],
+  name: string,
+): string | undefined {
+  return env.find((e) => e.name === name)?.value;
+}
+
+const relayDir = "/tmp/agenta-tools";
+
+describe("buildToolMcpServers", () => {
+  it("attaches the server for a code-only run, with public specs and relay dir", () => {
+    const specs: ResolvedToolSpec[] = [
+      {
+        name: "adder",
+        description: "Add numbers",
+        kind: "code",
+        runtime: "python",
+        code: "def main(**k): return 1",
+        env: { PRIVATE: "secret" },
+      },
+    ];
+    const out = buildToolMcpServers(specs, relayDir);
+    assert.equal(out.length, 1, "code-only run still attaches the server");
+    assert.equal(out[0].name, "agenta-tools");
+    assert.ok(
+      envValue(out[0].env, "AGENTA_TOOL_PUBLIC_SPECS") !== undefined,
+      "AGENTA_TOOL_PUBLIC_SPECS is set",
+    );
+    assert.equal(
+      envValue(out[0].env, "AGENTA_TOOL_CALLBACK_ENDPOINT"),
+      undefined,
+      "no endpoint env for code-only run",
+    );
+    assert.equal(envValue(out[0].env, "AGENTA_TOOL_RELAY_DIR"), relayDir);
+    assert.equal(envValue(out[0].env, "AGENTA_TOOL_CALLBACK_AUTH"), undefined);
+    assert.equal(envValue(out[0].env, "AGENTA_TOOL_SPECS"), undefined);
+    // Only public metadata round-trips; private executor fields stay runner-side.
+    assert.deepEqual(JSON.parse(envValue(out[0].env, "AGENTA_TOOL_PUBLIC_SPECS")!), [
+      { name: "adder", description: "Add numbers" },
+    ]);
+  });
+
+  it("never exposes endpoint/auth env to the bridge child (callback + full callback)", () => {
+    const specs: ResolvedToolSpec[] = [
+      { name: "search", kind: "callback", callRef: "composio.search" },
+    ];
+    const callback: ToolCallbackContext = {
+      endpoint: "https://agenta.example/tools/call",
+      authorization: "Bearer tok",
+    };
+    const out = buildToolMcpServers(specs, callback, relayDir);
+    assert.equal(out.length, 1);
+    assert.equal(
+      envValue(out[0].env, "AGENTA_TOOL_CALLBACK_ENDPOINT"),
+      undefined,
+      "endpoint env is never exposed to the bridge",
+    );
+    assert.equal(
+      envValue(out[0].env, "AGENTA_TOOL_CALLBACK_AUTH"),
+      undefined,
+      "auth env is never exposed to the bridge",
+    );
+    assert.equal(envValue(out[0].env, "AGENTA_TOOL_RELAY_DIR"), relayDir);
+  });
+
+  it("omits AUTH env when authorization is absent (endpoint but no auth)", () => {
+    const specs: ResolvedToolSpec[] = [
+      { name: "search", kind: "callback", callRef: "composio.search" },
+    ];
+    const out = buildToolMcpServers(specs, { endpoint: "https://agenta.example/tools/call" }, relayDir);
+    assert.equal(out.length, 1);
+    assert.equal(envValue(out[0].env, "AGENTA_TOOL_CALLBACK_ENDPOINT"), undefined);
+    assert.equal(
+      envValue(out[0].env, "AGENTA_TOOL_CALLBACK_AUTH"),
+      undefined,
+      "no AUTH env when authorization absent",
+    );
+  });
+
+  it("treats an absent kind as callback (back-compat)", () => {
+    const specs: ResolvedToolSpec[] = [{ name: "legacy", callRef: "composio.legacy" }];
+    const out = buildToolMcpServers(specs, { endpoint: "https://agenta.example/tools/call" }, relayDir);
+    assert.equal(out.length, 1, "back-compat (no kind) attaches as a callback tool");
+    assert.equal(envValue(out[0].env, "AGENTA_TOOL_CALLBACK_ENDPOINT"), undefined);
+  });
+
+  it("attaches one server for a mixed code+callback run with no endpoint", () => {
+    const specs: ResolvedToolSpec[] = [
+      { name: "adder", kind: "code", runtime: "python", code: "def main(**k): return 1" },
+      { name: "search", kind: "callback", callRef: "composio.search" },
+    ];
+    const out = buildToolMcpServers(specs, relayDir);
+    assert.notDeepEqual(out, [], "mixed run with no endpoint must not return []");
+    assert.equal(out.length, 1, "still attaches the server so the code tool works");
+    assert.equal(
+      envValue(out[0].env, "AGENTA_TOOL_CALLBACK_ENDPOINT"),
+      undefined,
+      "endpoint env omitted when missing",
+    );
+    // Both executable specs are advertised, but only as public metadata.
+    assert.deepEqual(JSON.parse(envValue(out[0].env, "AGENTA_TOOL_PUBLIC_SPECS")!), [
+      { name: "adder" },
+      { name: "search" },
+    ]);
+  });
+
+  it("returns [] for empty specs", () => {
+    assert.deepEqual(buildToolMcpServers([], undefined), [], "empty specs -> []");
+  });
+
+  it("returns [] for client-only specs (nothing executable, even with an endpoint)", () => {
+    const specs: ResolvedToolSpec[] = [{ name: "confirm", kind: "client" }];
+    assert.deepEqual(
+      buildToolMcpServers(specs, undefined),
+      [],
+      "client-only -> [] (nothing executable here)",
+    );
+    assert.deepEqual(
+      buildToolMcpServers(specs, { endpoint: "https://agenta.example/tools/call" }, relayDir),
+      [],
+      "client-only -> [] even with an endpoint",
+    );
+  });
+
+  it("drops client tools from the advertised list but still attaches for an executable sibling", () => {
+    const specs: ResolvedToolSpec[] = [
+      { name: "confirm", kind: "client" },
+      { name: "adder", kind: "code", runtime: "python", code: "def main(**k): return 1" },
+    ];
+    const out = buildToolMcpServers(specs, relayDir);
+    assert.equal(out.length, 1, "executable spec attaches the server");
+    const passed: ResolvedToolSpec[] = JSON.parse(envValue(out[0].env, "AGENTA_TOOL_PUBLIC_SPECS")!);
+    assert.deepEqual(
+      passed.map((s) => s.name),
+      ["adder"],
+      "client spec excluded from the executable list passed to the bridge",
+    );
+  });
+});

--- a/services/agent/tests/unit/tool-dispatch.test.ts
+++ b/services/agent/tests/unit/tool-dispatch.test.ts
@@ -1,0 +1,123 @@
+/**
+ * Unit tests for the shared tool-dispatch module (tools/dispatch.ts) and its routing.
+ *
+ * The kind-dispatch ("branch on spec.kind to execute a resolved tool") used to be duplicated
+ * across engines/pi.ts, extensions/agenta.ts, and tools/mcp-server.ts. It now lives once in
+ * `runResolvedTool`. These tests cover both the routing into that function and the call-site
+ * advertising behavior that stays per-site:
+ *  - buildCustomTools (pi.ts) skips `client` specs, builds a tool per `code`/`callback` spec,
+ *    and skips a `callback` spec with no callback endpoint.
+ *  - runResolvedTool runs a real `code` snippet end-to-end (python) and throws for `client`.
+ *
+ * No network and no harness: the `code` path shells out to python3 (available locally); the
+ * `callback`/relay paths are not exercised here (they need a live /tools/call or a relay dir).
+ *
+ * Run: pnpm test (or: pnpm exec vitest run tests/unit/tool-dispatch.test.ts)
+ */
+import { describe, it } from "vitest";
+import assert from "node:assert/strict";
+import { mkdtempSync, rmSync, writeFileSync } from "node:fs";
+import { tmpdir } from "node:os";
+import { join } from "node:path";
+
+import { buildCustomTools } from "../../src/engines/pi.ts";
+import { relayToolCall, runResolvedTool } from "../../src/tools/dispatch.ts";
+import { RELAY_RES_SUFFIX, sanitizeRelayId } from "../../src/tools/relay.ts";
+import type { ResolvedToolSpec, ToolCallbackContext } from "../../src/protocol.ts";
+
+const callback: ToolCallbackContext = { endpoint: "https://agenta.test/tools/call" };
+
+const clientSpec: ResolvedToolSpec = { name: "client_tool", kind: "client" };
+const codeSpec: ResolvedToolSpec = {
+  name: "code_tool",
+  kind: "code",
+  runtime: "python",
+  code: 'def main(**kw):\n    return {"echo": kw}\n',
+};
+const callbackSpec: ResolvedToolSpec = {
+  name: "callback_tool",
+  kind: "callback",
+  callRef: "composio.SOME_ACTION",
+};
+
+describe("buildCustomTools routing", () => {
+  it("skips client specs and builds one tool per code/callback spec", () => {
+    const tools = buildCustomTools([clientSpec, codeSpec, callbackSpec], callback);
+    const names = tools.map((t) => t.name);
+
+    // `client` is browser-fulfilled, so it is never registered in-process.
+    assert.ok(!names.includes("client_tool"), "client spec is skipped");
+    // `code` and `callback` each produce exactly one tool with the spec's name.
+    assert.ok(names.includes("code_tool"), "code spec produces a tool");
+    assert.ok(names.includes("callback_tool"), "callback spec produces a tool");
+    assert.equal(tools.length, 2, "only the two executable specs produce tools");
+  });
+
+  it("skips a callback spec with no endpoint but keeps a sibling code spec", () => {
+    const tools = buildCustomTools([codeSpec, callbackSpec], undefined);
+    const names = tools.map((t) => t.name);
+    assert.ok(names.includes("code_tool"), "code spec still registers without an endpoint");
+    assert.ok(
+      !names.includes("callback_tool"),
+      "callback spec is skipped when no callback endpoint",
+    );
+    assert.equal(tools.length, 1, "only the code spec registers without an endpoint");
+  });
+});
+
+describe("runResolvedTool", () => {
+  it("runs a code spec end-to-end (python)", async () => {
+    const text = await runResolvedTool(codeSpec, { greeting: "hi", n: 3 }, {
+      toolCallId: "call-1",
+    });
+    const parsed = JSON.parse(text);
+    assert.deepEqual(
+      parsed,
+      { echo: { greeting: "hi", n: 3 } },
+      "code tool runs the snippet and returns its JSON output containing the input",
+    );
+  });
+
+  it("throws for a client spec (never executed in-sandbox)", async () => {
+    await assert.rejects(
+      () => runResolvedTool(clientSpec, {}, { toolCallId: "call-2" }),
+      /browser-fulfilled/,
+      "client tool throws (never executed in-sandbox)",
+    );
+  });
+});
+
+// Directly exercises the Daytona file-relay path (the code site of the fixed `callRef` bug):
+// pre-write the response file the runner watches for, then call relayToolCall and read it back.
+describe("relayToolCall (Daytona file relay)", () => {
+  it("returns the relayed text when the response is ok", async () => {
+    const dir = mkdtempSync(join(tmpdir(), "agenta-relay-test-"));
+    try {
+      const toolCallId = "call-ok";
+      const resPath = join(dir, sanitizeRelayId(toolCallId) + RELAY_RES_SUFFIX);
+      writeFileSync(resPath, JSON.stringify({ ok: true, text: "relayed-ok" }));
+      const out = await relayToolCall(dir, "myTool", toolCallId, { a: 1 });
+      assert.equal(out, "relayed-ok");
+    } finally {
+      rmSync(dir, { recursive: true, force: true });
+    }
+  });
+
+  it("reports the tool name on an empty relay error (regression for the callRef bug)", async () => {
+    const dir = mkdtempSync(join(tmpdir(), "agenta-relay-test-"));
+    try {
+      const toolCallId = "call-err";
+      const resPath = join(dir, sanitizeRelayId(toolCallId) + RELAY_RES_SUFFIX);
+      // ok:false with an empty error string forces the fallback message, which referenced the
+      // undefined `callRef` before the fix and would have thrown a ReferenceError instead.
+      writeFileSync(resPath, JSON.stringify({ ok: false, error: "" }));
+      await assert.rejects(
+        () => relayToolCall(dir, "myTool", toolCallId, {}),
+        /tool relay failed for myTool/,
+        "the error message uses toolName, not an undefined callRef",
+      );
+    } finally {
+      rmSync(dir, { recursive: true, force: true });
+    }
+  });
+});

--- a/services/agent/tests/unit/wire-contract.test.ts
+++ b/services/agent/tests/unit/wire-contract.test.ts
@@ -1,0 +1,163 @@
+/**
+ * The `/run` wire contract, asserted from the TypeScript (consumer) side against the shared
+ * golden fixtures. The Python (producer) side asserts the same files in
+ * `sdks/python/oss/tests/pytest/unit/agents/test_wire_contract.py`; this is the other half it
+ * names ("the TS side asserts the same files").
+ *
+ * Two layers, because `protocol.ts` is types only (erased at runtime):
+ *  - COMPILE-TIME: a key list mirrored from the Python `KNOWN_REQUEST_KEYS`, assigned to
+ *    `(keyof AgentRunRequest)[]`. If `protocol.ts` renames or drops a field the wire still
+ *    emits, this fails `tsc`.
+ *  - RUNTIME: load each golden file and assert its real shape, exercising the runner's own
+ *    helpers (`resolvePromptText`, `resolveRunSessionId`, `messageText`).
+ *
+ * If a field is added/renamed/removed on the wire, update the golden, then `protocol.ts` and
+ * the key lists here, deliberately.
+ *
+ * Run: pnpm test (or: pnpm exec vitest run tests/unit/wire-contract.test.ts)
+ */
+import { describe, it } from "vitest";
+import assert from "node:assert/strict";
+
+import { loadGolden } from "../utils/golden.ts";
+import {
+  type AgentRunRequest,
+  type AgentRunResult,
+  type HarnessCapabilities,
+  messageText,
+  resolvePromptText,
+  resolveRunSessionId,
+} from "../../src/protocol.ts";
+
+// Mirror of KNOWN_REQUEST_KEYS in the Python test: the full set of top-level keys the wire
+// may emit. AgentRunRequest must declare every one.
+const KNOWN_REQUEST_KEYS = [
+  "backend",
+  "harness",
+  "sandbox",
+  "sessionId",
+  "agentsMd",
+  "model",
+  "messages",
+  "secrets",
+  "trace",
+  "tools",
+  "customTools",
+  "mcpServers",
+  "toolCallback",
+  "permissionPolicy",
+  "systemPrompt",
+  "appendSystemPrompt",
+  "skills",
+] as const;
+
+// COMPILE-TIME drift guard: every wire key must be a field of AgentRunRequest. Drop or rename
+// a field in protocol.ts and this assignment stops typechecking.
+const _requestKeysExistOnType: readonly (keyof AgentRunRequest)[] = KNOWN_REQUEST_KEYS;
+void _requestKeysExistOnType;
+
+describe("wire contract: requests (vs Python golden)", () => {
+  for (const name of ["run_request.pi.json", "run_request.claude.json"]) {
+    it(`${name}: every top-level key is known to AgentRunRequest`, () => {
+      const req = loadGolden(name) as Record<string, unknown>;
+      for (const key of Object.keys(req)) {
+        assert.ok(
+          (KNOWN_REQUEST_KEYS as readonly string[]).includes(key),
+          `golden request key '${key}' is not in KNOWN_REQUEST_KEYS / AgentRunRequest`,
+        );
+      }
+    });
+  }
+
+  it("pi request: shape, tool axes, and the runner helpers", () => {
+    const req = loadGolden("run_request.pi.json") as AgentRunRequest;
+    assert.equal(req.backend, "pi");
+    assert.equal(req.harness, "pi");
+    assert.ok(Array.isArray(req.messages));
+    // The serializer emits `messages` only; the runner derives the latest turn.
+    assert.equal(resolvePromptText(req), "hi");
+    assert.equal(messageText(req.messages![0].content), "hi");
+    // The platform session id wins over the runner fallback.
+    assert.equal(resolveRunSessionId(req, "runner-ephemeral"), "sess-1");
+    // The custom-tool axes reach the runner intact.
+    const tool = req.customTools![0];
+    assert.equal(tool.kind, "callback");
+    assert.ok(tool.callRef && tool.callRef.length > 0, "callback tool carries its callRef");
+    // Pi exposes the prompt overrides.
+    assert.equal(req.systemPrompt, "You are Pi.");
+    assert.equal(req.appendSystemPrompt, "Be terse.");
+  });
+
+  it("claude request: gates tool use, no prompt overrides, null session id", () => {
+    const req = loadGolden("run_request.claude.json") as AgentRunRequest;
+    assert.equal(req.backend, "sandbox-agent");
+    assert.equal(req.harness, "claude");
+    assert.deepEqual(req.tools, []); // Claude has no Pi built-ins
+    assert.equal(req.permissionPolicy, "deny"); // Claude gates tool use
+    assert.equal(req.systemPrompt, undefined); // Claude exposes no prompt overrides
+    assert.equal(req.appendSystemPrompt, undefined);
+    // sessionId is null on the wire, so the runner falls back to its ephemeral id.
+    assert.equal(resolveRunSessionId(req, "runner-ephemeral"), "runner-ephemeral");
+  });
+});
+
+// Mirror of the result capability flags: every camelCase key the wire returns must be a field
+// of HarnessCapabilities. Compile-time guard, same idea as the request keys.
+const CAPABILITY_KEYS = [
+  "textMessages",
+  "images",
+  "fileAttachments",
+  "mcpTools",
+  "toolCalls",
+  "reasoning",
+  "planMode",
+  "permissions",
+  "usage",
+  "streamingDeltas",
+  "sessionLifecycle",
+] as const;
+const _capabilityKeysExistOnType: readonly (keyof HarnessCapabilities)[] = CAPABILITY_KEYS;
+void _capabilityKeysExistOnType;
+
+describe("wire contract: results (vs Python golden)", () => {
+  it("ok result: shape, events, and camelCase capabilities", () => {
+    const res = loadGolden("run_result.ok.json") as AgentRunResult & {
+      capabilities: Record<string, unknown>;
+    };
+    assert.equal(res.ok, true);
+    assert.equal(res.output, "Hello!");
+    assert.deepEqual(res.messages!.map((m) => m.role), ["assistant"]);
+    // The wire carries a trailing event with no `type`; the Python consumer drops it on
+    // parse, so the TS contract must tolerate it (three typed events survive).
+    const typed = res.events!.filter((e) => typeof (e as { type?: unknown }).type === "string");
+    assert.deepEqual(typed.map((e) => e.type), ["message", "usage", "done"]);
+    assert.deepEqual(res.usage, { input: 10, output: 5, total: 15, cost: 0.001 });
+    assert.equal(res.stopReason, "end_turn");
+    assert.equal(res.sessionId, "sess-42");
+    assert.equal(res.model, "gpt-5.5");
+    assert.equal(res.traceId, "trace-abc");
+    // Capabilities come back camelCase; every key must be known to HarnessCapabilities.
+    for (const key of Object.keys(res.capabilities)) {
+      assert.ok(
+        (CAPABILITY_KEYS as readonly string[]).includes(key),
+        `golden capability key '${key}' is not in HarnessCapabilities`,
+      );
+    }
+    assert.equal(res.capabilities.mcpTools, true);
+    assert.equal(res.capabilities.images, false);
+    assert.equal(res.capabilities.textMessages, true);
+  });
+
+  it("error result: ok=false carries the error message", () => {
+    const res = loadGolden("run_result.error.json") as AgentRunResult;
+    assert.equal(res.ok, false);
+    assert.equal(res.error, "model exploded");
+  });
+
+  it("minimal ok result: bare success is valid", () => {
+    const res = { ok: true } as AgentRunResult;
+    assert.equal(res.ok, true);
+    assert.equal(res.output, undefined);
+    assert.equal(res.capabilities, undefined);
+  });
+});

--- a/services/agent/tests/utils/golden.ts
+++ b/services/agent/tests/utils/golden.ts
@@ -1,0 +1,22 @@
+/**
+ * Load the shared cross-language wire fixtures.
+ *
+ * These JSON files are the single anchor for the `/run` contract. The Python producer asserts
+ * them in `sdks/python/oss/tests/pytest/unit/agents/test_wire_contract.py`; the TS consumer
+ * asserts the same files here. Read in place via `node:fs` (no copy, no bundler import) so the
+ * two sides can never drift against different copies.
+ */
+import { readFileSync } from "node:fs";
+import { fileURLToPath } from "node:url";
+import { dirname, join } from "node:path";
+
+const here = dirname(fileURLToPath(import.meta.url));
+// services/agent/tests/utils -> repo root -> the shared Python golden fixtures.
+export const GOLDEN_DIR = join(
+  here,
+  "../../../../sdks/python/oss/tests/pytest/unit/agents/golden",
+);
+
+export function loadGolden(name: string): unknown {
+  return JSON.parse(readFileSync(join(GOLDEN_DIR, name), "utf-8"));
+}

--- a/services/agent/vitest.config.ts
+++ b/services/agent/vitest.config.ts
@@ -1,0 +1,20 @@
+import { defineConfig } from "vitest/config";
+
+// Mirrors the web/packages/* convention: node env, junit for CI publishing, v8 coverage
+// over src/. Unit tests live in tests/unit/**; the runner code stays in src/.
+export default defineConfig({
+  test: {
+    include: ["tests/unit/**/*.test.ts"],
+    environment: "node",
+    reporters: ["default", "junit"],
+    outputFile: {
+      junit: "./test-results/junit.xml",
+    },
+    coverage: {
+      provider: "v8",
+      include: ["src/**/*.ts"],
+      reporter: ["text", "lcov", "json-summary"],
+      reportsDirectory: "./coverage",
+    },
+  },
+});


### PR DESCRIPTION
## Context
The agent runtime POC still refers to the runner sidecar through older names and scattered self-host docs. Review needs a deployment-oriented core slice that documents the sandbox-agent service and wires the local/dev compose surfaces without taking Railway, Kubernetes, or image-build CI.

This PR is intentionally part of the existing agent-workflows POC stack. Review it with #4771, #4772, #4776, #4778, and #4779; it is not meant to merge alone.

## Changes
Moves the sidecar deployment proposal into a project folder with status tracking, adds self-host docs for the agent runner and Daytona sandboxes, and updates OSS/EE local compose/env examples to expose the `sandbox-agent` service shape. It also adds runner docs and test scaffolding for the first-class sandbox-agent name.

Child PRs:
- Railway: #4787
- Kubernetes: #4788
- Images and CI: #4789

## Tests / notes
- Previously verified as part of the working tree with `pnpm run typecheck` and `pnpm test` in `services/agent`, relevant Python unit tests, compose config checks, and Helm template renders.
- Does not include Railway, Kubernetes, published image builds, or CI changes. Those are split into child PRs.
- There are still unrelated unassigned changes in the GitButler workspace from other POC work; they were not included here.

## What to QA
- In the local OSS and EE compose examples, confirm the API service can point at `sandbox-agent` through the documented env variables.
- Read the self-host runner docs and confirm Railway, Kubernetes, and custom image references point to the follow-up PRs rather than this core slice.