### PR TITLE
[4244] fix(sdk): scope AWS credentials per request to stop Bedrock leak

### DIFF
--- a/sdks/python/agenta/sdk/engines/running/handlers.py
+++ b/sdks/python/agenta/sdk/engines/running/handlers.py
@@ -1040,12 +1040,11 @@ async def auto_ai_critique_v0(
         ) from e
 
     try:
-        with mockllm.user_aws_credentials_from(_coerce_credentials(provider_settings)):
-            response = await mockllm.acompletion(
-                messages=formatted_prompt_template,
-                response_format=response_format,
-                **provider_settings,
-            )
+        response = await mockllm.acompletion(
+            messages=formatted_prompt_template,
+            response_format=response_format,
+            **_normalize_aws_provider_settings(provider_settings),
+        )
 
         _outputs = response.choices[0].message.content.strip()  # type: ignore
 
@@ -1791,21 +1790,50 @@ class SinglePromptConfig(BaseModel):
     )
 
 
-def _coerce_credentials(provider_settings: Dict) -> Dict:
-    return {
-        "AWS_ACCESS_KEY_ID": provider_settings.get("AWS_ACCESS_KEY_ID")
-        or provider_settings.get("aws_access_key_id"),
-        "AWS_SECRET_ACCESS_KEY": provider_settings.get("AWS_SECRET_ACCESS_KEY")
-        or provider_settings.get("aws_secret_access_key"),
-        "AWS_SESSION_TOKEN": provider_settings.get("AWS_SESSION_TOKEN")
-        or provider_settings.get("aws_session_token"),
-        "AWS_REGION": provider_settings.get("AWS_REGION")
-        or provider_settings.get("aws_region")
-        or provider_settings.get("aws_region_name"),
-        "AWS_DEFAULT_REGION": provider_settings.get("AWS_DEFAULT_REGION")
-        or provider_settings.get("aws_default_region")
-        or provider_settings.get("aws_region_name"),
-    }
+# LiteLLM resolves Bedrock/Sagemaker auth from explicit ``aws_*`` call kwargs, which
+# keeps credentials request-scoped. Secret extras may store those credentials under
+# several spellings (env-style uppercase, ``aws_region`` vs ``aws_region_name``), so we
+# fold each alias into LiteLLM's canonical parameter name. Region aliases are ordered by
+# precedence.
+_AWS_PARAM_ALIASES: Dict[str, tuple] = {
+    "aws_access_key_id": ("aws_access_key_id", "AWS_ACCESS_KEY_ID"),
+    "aws_secret_access_key": ("aws_secret_access_key", "AWS_SECRET_ACCESS_KEY"),
+    "aws_session_token": ("aws_session_token", "AWS_SESSION_TOKEN"),
+    "aws_region_name": (
+        "aws_region_name",
+        "AWS_REGION_NAME",
+        "aws_region",
+        "AWS_REGION",
+        "aws_default_region",
+        "AWS_DEFAULT_REGION",
+    ),
+}
+
+
+def _normalize_aws_provider_settings(provider_settings: Dict) -> Dict:
+    """Fold AWS credential aliases into LiteLLM's canonical request-scoped params.
+
+    Passing the resolved credentials as ``aws_*`` call kwargs keeps them scoped to the
+    single request, instead of mutating process-global ``os.environ`` (which can leak
+    between concurrent calls in the same worker). Non-canonical alias keys are dropped so
+    they are not forwarded to LiteLLM as unrecognized kwargs. Non-AWS settings pass
+    through untouched.
+    """
+
+    settings = dict(provider_settings)
+    for canonical, aliases in _AWS_PARAM_ALIASES.items():
+        value = next(
+            (settings[alias] for alias in aliases if settings.get(alias) is not None),
+            None,
+        )
+        for alias in aliases:
+            if alias != canonical:
+                settings.pop(alias, None)
+        if value is not None:
+            settings[canonical] = value
+        else:
+            settings.pop(canonical, None)
+    return settings
 
 
 def _apply_responses_bridge_if_needed(
@@ -2034,13 +2062,10 @@ async def _run_prompt_llm_config_with_retry(
             if messages is not None:
                 openai_kwargs["messages"] = [*openai_kwargs["messages"], *messages]
 
-            with mockllm.user_aws_credentials_from(
-                _coerce_credentials(provider_settings)
-            ):
-                return await mockllm.acompletion(
-                    **{k: v for k, v in openai_kwargs.items() if k != "model"},
-                    **provider_settings,
-                )
+            return await mockllm.acompletion(
+                **{k: v for k, v in openai_kwargs.items() if k != "model"},
+                **_normalize_aws_provider_settings(provider_settings),
+            )
         except Exception as exc:
             last_error = exc
             if attempt >= attempts - 1 or not _should_retry(

--- a/sdks/python/agenta/sdk/litellm/mockllm.py
+++ b/sdks/python/agenta/sdk/litellm/mockllm.py
@@ -2,7 +2,6 @@ import asyncio
 import random
 from typing import Protocol, Any, Optional, Iterable
 from os import environ
-from contextlib import contextmanager
 from urllib.parse import urlparse
 
 from agenta.sdk.utils.logging import get_module_logger
@@ -14,58 +13,6 @@ from agenta.sdk.contexts.routing import RoutingContext
 AGENTA_LITELLM_MOCK = environ.get("AGENTA_LITELLM_MOCK") or None
 
 log = get_module_logger(__name__)
-
-
-ENV_KEYS_TO_CLEAR = [
-    # anything that could inject Lambda/ECS role creds
-    "AWS_SESSION_TOKEN",
-    "AWS_SECURITY_TOKEN",
-    "AWS_WEB_IDENTITY_TOKEN_FILE",
-    "AWS_ROLE_ARN",
-    "AWS_CONTAINER_CREDENTIALS_FULL_URI",
-    "AWS_CONTAINER_CREDENTIALS_RELATIVE_URI",
-    "AWS_ECS_CONTAINER_AUTHORIZATION_TOKEN",
-    "AWS_PROFILE",
-    "AWS_SHARED_CREDENTIALS_FILE",
-    "AWS_CONFIG_FILE",
-]
-
-ENV_KEYS_FROM_USER = [
-    "AWS_ACCESS_KEY_ID",
-    "AWS_SECRET_ACCESS_KEY",
-    "AWS_SESSION_TOKEN",
-    "AWS_REGION",
-    "AWS_DEFAULT_REGION",
-]
-
-
-@contextmanager
-def user_aws_credentials_from(ps: dict):
-    old = {}
-    try:
-        # Save original state of ALL keys we'll modify
-        for k in ENV_KEYS_TO_CLEAR + ENV_KEYS_FROM_USER:
-            if k in environ:
-                old[k] = environ[k]
-
-        # Clear AWS role credentials
-        for k in ENV_KEYS_TO_CLEAR:
-            environ.pop(k, None)
-
-        # Set user credentials
-        for k in ENV_KEYS_FROM_USER:
-            if ps.get(k.upper()) is None:
-                environ.pop(k, None)
-            else:
-                environ[k] = ps[k.upper()]
-        yield
-    finally:
-        # Restore all environment variables to original state
-        for k in ENV_KEYS_TO_CLEAR + ENV_KEYS_FROM_USER:
-            if k in old:
-                environ[k] = old[k]
-            else:
-                environ.pop(k, None)
 
 
 class LitellmProtocol(Protocol):

--- a/sdks/python/oss/tests/pytest/unit/test_auto_ai_critique_v0_runtime.py
+++ b/sdks/python/oss/tests/pytest/unit/test_auto_ai_critique_v0_runtime.py
@@ -11,7 +11,6 @@ Covers:
 - existing result normalization (numeric, boolean, dict, raw text) is unchanged.
 """
 
-from contextlib import contextmanager
 from types import SimpleNamespace
 from unittest.mock import AsyncMock, patch
 
@@ -36,11 +35,6 @@ def _fake_completion_response(content: str) -> SimpleNamespace:
     message = SimpleNamespace(content=content)
     choice = SimpleNamespace(message=message)
     return SimpleNamespace(choices=[choice])
-
-
-@contextmanager
-def _noop_aws_credentials(_provider_settings):
-    yield
 
 
 @pytest.fixture
@@ -71,21 +65,13 @@ def mocked_llm_call(initialized_sdk):
         content = captured.get("response_content", '{"score": 0.9}')
         return _fake_completion_response(content)
 
-    with (
-        patch.object(
-            critique_handlers.mockllm,
-            "acompletion",
-            side_effect=_fake_acompletion,
-        ) as mock_acompletion,
-        patch.object(
-            critique_handlers.mockllm,
-            "user_aws_credentials_from",
-            side_effect=_noop_aws_credentials,
-        ) as mock_creds,
-    ):
+    with patch.object(
+        critique_handlers.mockllm,
+        "acompletion",
+        side_effect=_fake_acompletion,
+    ) as mock_acompletion:
         yield SimpleNamespace(
             acompletion=mock_acompletion,
-            user_aws_credentials_from=mock_creds,
             captured=captured,
         )
 
@@ -192,6 +178,70 @@ async def test_resolves_custom_provider_model_settings(mocked_secrets, mocked_ll
     assert kwargs["aws_access_key_id"] == "AKIA..."
     assert kwargs["aws_region_name"] == "us-east-1"
     assert "temperature" not in kwargs
+
+
+async def test_aws_credential_aliases_normalized_to_litellm_params(
+    mocked_secrets, mocked_llm_call
+):
+    """AWS credential aliases are folded into LiteLLM's canonical request params.
+
+    Secret extras may store credentials env-style (uppercase) or with ``aws_region``
+    instead of ``aws_region_name``. These must be forwarded under LiteLLM's canonical
+    ``aws_*`` kwargs, and the non-canonical aliases must not leak through as
+    unrecognized kwargs.
+    """
+
+    mocked_secrets.get_settings.return_value = {
+        "model": "bedrock/anthropic.claude-3-5-sonnet",
+        "AWS_ACCESS_KEY_ID": "AKIA...",
+        "AWS_SECRET_ACCESS_KEY": "secret",
+        "AWS_SESSION_TOKEN": "token",
+        "aws_region": "eu-west-1",
+    }
+
+    await _auto_ai_critique_v0(
+        parameters=_base_parameters(model="my-self-hosted-claude"),
+        inputs={"question": "q", "expected": "e"},
+        outputs="o",
+    )
+
+    kwargs = mocked_llm_call.captured["kwargs"]
+    assert kwargs["aws_access_key_id"] == "AKIA..."
+    assert kwargs["aws_secret_access_key"] == "secret"
+    assert kwargs["aws_session_token"] == "token"
+    assert kwargs["aws_region_name"] == "eu-west-1"
+    # Non-canonical aliases are not forwarded to LiteLLM.
+    assert "AWS_ACCESS_KEY_ID" not in kwargs
+    assert "AWS_SECRET_ACCESS_KEY" not in kwargs
+    assert "AWS_SESSION_TOKEN" not in kwargs
+    assert "aws_region" not in kwargs
+
+
+async def test_aws_credentials_do_not_mutate_environ(mocked_secrets, mocked_llm_call):
+    """Resolving AWS credentials must not touch process-global ``os.environ``.
+
+    Mutating ``os.environ`` around an awaited call can leak credentials between
+    concurrent requests in the same worker (#4244).
+    """
+
+    import os
+
+    mocked_secrets.get_settings.return_value = {
+        "model": "bedrock/anthropic.claude-3-5-sonnet",
+        "aws_access_key_id": "AKIA...",
+        "aws_secret_access_key": "secret",
+        "aws_region_name": "us-east-1",
+    }
+
+    before = dict(os.environ)
+
+    await _auto_ai_critique_v0(
+        parameters=_base_parameters(model="my-self-hosted-claude"),
+        inputs={"question": "q", "expected": "e"},
+        outputs="o",
+    )
+
+    assert dict(os.environ) == before
 
 
 async def test_missing_provider_settings_raises_invalid_secrets(

--- a/sdks/python/oss/tests/pytest/unit/test_chat_v0_inputs.py
+++ b/sdks/python/oss/tests/pytest/unit/test_chat_v0_inputs.py
@@ -1,4 +1,3 @@
-from contextlib import nullcontext
 from types import SimpleNamespace
 
 import pytest
@@ -39,11 +38,6 @@ def fake_llm(monkeypatch):
         lambda model: {"model": model, "api_key": "test-key"},
     )
     monkeypatch.setattr(handlers.mockllm, "acompletion", acompletion)
-    monkeypatch.setattr(
-        handlers.mockllm,
-        "user_aws_credentials_from",
-        lambda _settings: nullcontext(),
-    )
 
     return captured
 

--- a/sdks/python/oss/tests/pytest/unit/test_prompt_template_extensions.py
+++ b/sdks/python/oss/tests/pytest/unit/test_prompt_template_extensions.py
@@ -1,5 +1,3 @@
-from contextlib import nullcontext
-
 import pytest
 
 from agenta.sdk.engines.running.handlers import (
@@ -333,10 +331,6 @@ async def test_retry_runner_retries_explicit_transient_provider_errors(monkeypat
         "agenta.sdk.engines.running.handlers.SecretsManager.get_provider_settings_from_workflow",
         lambda model: {"model": model},
     )
-    monkeypatch.setattr(
-        "agenta.sdk.engines.running.handlers.mockllm.user_aws_credentials_from",
-        lambda provider_settings: nullcontext(),
-    )
 
     async def fake_completion(**kwargs):
         calls.append(kwargs["model"])
@@ -553,10 +547,6 @@ async def test_retry_exhaustion_raises_after_max_attempts(monkeypatch):
     monkeypatch.setattr(
         "agenta.sdk.engines.running.handlers.SecretsManager.get_provider_settings_from_workflow",
         lambda model: {"model": model},
-    )
-    monkeypatch.setattr(
-        "agenta.sdk.engines.running.handlers.mockllm.user_aws_credentials_from",
-        lambda provider_settings: nullcontext(),
     )
 
     async def fake_completion(**kwargs):


### PR DESCRIPTION
## Summary

Concurrent Bedrock calls could leak AWS credentials between requests. Per-request credentials were installed by mutating process-global `os.environ` (`user_aws_credentials_from`) around an awaited `mockllm.acompletion(...)` call. Because the event loop can switch coroutines while those variables are set, overlapping requests in the same worker could observe each other's credentials — causing auth failures, billing against the wrong account, or signing requests against the wrong AWS account on ECS/Lambda.

Root cause: the env mutation was redundant. The resolved AWS credentials are **already** forwarded to LiteLLM as request-scoped `aws_*` kwargs via `**provider_settings` at both call sites. LiteLLM resolves Bedrock/Sagemaker auth from those explicit kwargs, so the only thing the `os.environ` mutation added was the cross-request leak.

This PR keeps credentials request-scoped without touching `os.environ`:

- Adds `_normalize_aws_provider_settings(...)`, which folds AWS credential/region aliases (env-style uppercase `AWS_ACCESS_KEY_ID`, and `aws_region` / `aws_default_region` vs `aws_region_name`) into LiteLLM's canonical `aws_*` params, and drops the non-canonical aliases so they aren't forwarded as unrecognized kwargs. This preserves the region/casing handling the old env path provided.
- Removes the `user_aws_credentials_from` context manager and its `ENV_KEYS_TO_CLEAR` / `ENV_KEYS_FROM_USER` lists from `mockllm.py`, and the now-unused `_coerce_credentials` helper.
- When a user supplies their own keys, LiteLLM builds a session from those static credentials and does not fall back to the container/instance role — so the previous "clear role creds" behavior is retained implicitly, per request.

Non-AWS providers are unaffected: settings without `aws_*` keys pass through untouched.

## Testing

### Verified locally

- `uv run pytest oss/tests/pytest/unit/` — **613 passed**.
- `uv run pytest oss/tests/pytest/unit/test_auto_ai_critique_v0_runtime.py oss/tests/pytest/unit/test_chat_v0_inputs.py oss/tests/pytest/unit/test_prompt_template_extensions.py` — the directly affected modules pass.
- `ruff format` and `ruff check` clean on all changed files.

### Added or updated tests

- `test_aws_credential_aliases_normalized_to_litellm_params` — env-style uppercase keys and `aws_region` are forwarded under LiteLLM's canonical `aws_*` params, and non-canonical aliases are not leaked as kwargs.
- `test_aws_credentials_do_not_mutate_environ` — resolving AWS credentials leaves `os.environ` untouched.
- Updated the three unit tests that mocked `user_aws_credentials_from` to drop the now-removed boundary.

### QA follow-up

I could not exercise live AWS paths locally. Please QA with user-provided credentials on an ECS/Lambda deployment with an attached IAM role to confirm no fallback to the instance/container role:

- Bedrock (legacy `invoke`), Bedrock Converse, Bedrock streaming, and Sagemaker.
- A concurrency check: two simultaneous requests with different credentials in one worker must not cross-contaminate.

## Demo

This is a backend/SDK change with no UI surface, so the demo is the regression suite that pins the fix. The two tests below encode the acceptance criteria from #4244 — credentials stay request-scoped (`aws_*` kwargs, no env mutation):

![Regression tests for the Bedrock credential leak passing](https://raw.githubusercontent.com/Koushik-Salammagari/agenta/demo-assets/demo/4244_credential_leak_tests.png)

```console
$ uv run pytest oss/tests/pytest/unit/test_auto_ai_critique_v0_runtime.py -v \
    -k "aws_credential_aliases or aws_credentials_do_not_mutate"

============================= test session starts ==============================
platform darwin -- Python 3.12.11, pytest-9.1.0, pluggy-1.6.0
collecting ... collected 42 items / 40 deselected / 2 selected

test_auto_ai_critique_v0_runtime.py::test_aws_credential_aliases_normalized_to_litellm_params PASSED [ 50%]
test_auto_ai_critique_v0_runtime.py::test_aws_credentials_do_not_mutate_environ            PASSED [100%]

======================= 2 passed, 40 deselected in 1.53s =======================
```

- `test_aws_credentials_do_not_mutate_environ` is the direct regression for the leak: it snapshots `os.environ` before the awaited call and asserts it is unchanged afterwards. On `main` (env-mutation path) this assertion fails; with this PR it passes.
- `test_aws_credential_aliases_normalized_to_litellm_params` proves the credentials still reach LiteLLM — now as request-scoped `aws_*` kwargs rather than via the environment.

## Checklist

- [x] I have included a demo (regression test run above); the change has no UI surface
- [x] Relevant tests pass locally
- [x] Relevant linting and formatting pass locally
- [x] I have signed the CLA

Closes #4244
