### PR TITLE
fix(frontend): union day-of-month and day-of-week in cron next-runs preview

### DIFF
--- a/web/packages/agenta-entities/src/gatewayTrigger/core/cron.ts
+++ b/web/packages/agenta-entities/src/gatewayTrigger/core/cron.ts
@@ -125,15 +125,24 @@ export function nextCronRuns(expression: string, count = 3, from: Date = new Dat
     cursor.setUTCSeconds(0, 0)
     cursor.setUTCMinutes(cursor.getUTCMinutes() + 1)
 
+    // POSIX cron treats day-of-month and day-of-week as a *union* when BOTH are
+    // restricted: `0 0 1 * 1` fires on the 1st OR on Mondays (matching the
+    // backend croniter), not only on Mondays that fall on the 1st. When either
+    // field is `*` it is always-true, so the result collapses to a plain AND.
+    const domRestricted = dom !== "*"
+    const dowRestricted = dow !== "*"
+
     // Cap the scan at one year of minutes to avoid an unbounded loop.
     const MAX_STEPS = 366 * 24 * 60
     for (let step = 0; step < MAX_STEPS && runs.length < count; step++) {
+        const domHit = matchField(cursor.getUTCDate(), dom, FIELD_BOUNDS[2])
+        const dowHit = matchField(cursor.getUTCDay(), dow, FIELD_BOUNDS[4])
+        const dayHit = domRestricted && dowRestricted ? domHit || dowHit : domHit && dowHit
         if (
             matchField(cursor.getUTCMinutes(), minute, FIELD_BOUNDS[0]) &&
             matchField(cursor.getUTCHours(), hour, FIELD_BOUNDS[1]) &&
-            matchField(cursor.getUTCDate(), dom, FIELD_BOUNDS[2]) &&
             matchField(cursor.getUTCMonth() + 1, month, FIELD_BOUNDS[3]) &&
-            matchField(cursor.getUTCDay(), dow, FIELD_BOUNDS[4])
+            dayHit
         ) {
             runs.push(new Date(cursor))
         }

--- a/web/packages/agenta-entities/tests/unit/gatewayTriggerCron.test.ts
+++ b/web/packages/agenta-entities/tests/unit/gatewayTriggerCron.test.ts
@@ -82,4 +82,33 @@ describe("nextCronRuns", () => {
     it("returns an empty list for an invalid expression", () => {
         expect(nextCronRuns("nope", 3)).toEqual([])
     })
+
+    it("unions day-of-month and day-of-week when both are restricted", () => {
+        // `0 0 1 * 1` = midnight on the 1st OR on any Monday (POSIX cron / the
+        // backend croniter). 2026-06-22 is a Monday, so the next fires are the
+        // following Monday, then the 1st, then the next Monday — NOT the rare
+        // 1st-of-month-that-is-also-a-Monday (which would be 2027-02-01).
+        const from = new Date("2026-06-22T08:00:00Z")
+        const runs = nextCronRuns("0 0 1 * 1", 3, from)
+
+        expect(runs.map((r) => r.toISOString())).toEqual([
+            "2026-06-29T00:00:00.000Z", // Monday
+            "2026-07-01T00:00:00.000Z", // 1st of the month
+            "2026-07-06T00:00:00.000Z", // Monday
+        ])
+    })
+
+    it("keeps plain AND semantics when only one day field is restricted", () => {
+        const from = new Date("2026-06-22T08:00:00Z")
+        // Only day-of-month restricted: every 1st of the month.
+        expect(nextCronRuns("0 0 1 * *", 2, from).map((r) => r.toISOString())).toEqual([
+            "2026-07-01T00:00:00.000Z",
+            "2026-08-01T00:00:00.000Z",
+        ])
+        // Only day-of-week restricted: every Monday.
+        expect(nextCronRuns("0 0 * * 1", 2, from).map((r) => r.toISOString())).toEqual([
+            "2026-06-29T00:00:00.000Z",
+            "2026-07-06T00:00:00.000Z",
+        ])
+    })
 })


### PR DESCRIPTION
Stacked on #4749 (`gateway-triggers-all`). solves a bug in the schedule drawer's cron preview.

## Problem

The schedule "next runs" preview ANDs the **day-of-month** and **day-of-week** cron fields. POSIX cron — and the backend `croniter` that actually fires the schedule — treat them as a **union** when both are restricted.

So `0 0 1 * 1` ("1st of the month **or** any Monday") previewed its next run as **2027-02-01** (the next 1st-of-month that also happens to be a Monday, ~7 months out) instead of the coming Monday. The preview disagreed with what the schedule would actually do

## Before / After

For `0 0 1 * 1`, evaluated 2026-06-22 (a Monday):

| | Next runs |
|---|---|
| Before | 2027-02-01, 2027-03-01, … |
| After | 2026-06-29 (Mon), 2026-07-01 (1st), 2026-07-06 (Mon), … |

## Change

`nextCronRuns` now matches **either** day field when both are restricted, and keeps plain AND when only one is (a `*` field is always-true). Pure client-side preview helper — the backend remains the source of truth; this only makes the hint agree with it.

Added unit coverage for the union case and the single-restricted-field AND case (`gatewayTriggerCron.test.ts`, 13 passing).

## Verified

- `vitest run gatewayTriggerCron.test.ts` — 13/13 pass
- prettier + eslint clean on changed files