### PR TITLE
[fix] Explicit service selection and graceful no-deployment on Railway redeploy

### DIFF
--- a/hosting/railway/oss/scripts/deploy-from-images.sh
+++ b/hosting/railway/oss/scripts/deploy-from-images.sh
@@ -43,9 +43,27 @@ fi
 
 redeploy_service_if_exists() {
     local service="$1"
+    local exit_code=0
+    local err
 
-    if railway_call service "$service" >/dev/null 2>&1; then
-        railway_call redeploy --yes >/dev/null
+    if ! railway_call service "$service" >/dev/null 2>&1; then
+        return 0
+    fi
+
+    # Redeploy so the service picks up freshly configured credentials. On a
+    # brand-new preview environment the managed service (e.g. Postgres) has no
+    # prior deployment record yet; Railway will start it via the template in
+    # that case, so "No deployment found" is non-fatal — skip and continue.
+    err="$(railway_call redeploy --service "$service" --environment "$ENV_NAME" --yes 2>&1 >/dev/null)" \
+        || exit_code=$?
+
+    if [ "$exit_code" -ne 0 ]; then
+        if printf '%s' "$err" | grep -qiE "no deployment found"; then
+            printf "No prior deployment for '%s'; skipping redeploy (fresh env).\n" "$service" >&2
+            return 0
+        fi
+        printf '%s\n' "$err" >&2
+        return "$exit_code"
     fi
 }
 

--- a/hosting/railway/oss/scripts/deploy-services.sh
+++ b/hosting/railway/oss/scripts/deploy-services.sh
@@ -17,7 +17,7 @@ fi
 railway link --project "$PROJECT_NAME" --environment "$ENV_NAME" --json >/dev/null
 
 # Bring stateful infra up first so credentials/volumes are applied.
-railway service "$POSTGRES_SERVICE" >/dev/null && railway redeploy --yes
+railway service "$POSTGRES_SERVICE" >/dev/null && railway redeploy --service "$POSTGRES_SERVICE" --environment "$ENV_NAME" --yes
 if railway service "$REDIS_SERVICE" >/dev/null 2>&1; then
     railway up hosting/railway/oss/redis --path-as-root --service "$REDIS_SERVICE" --detach
 fi

--- a/hosting/railway/oss/scripts/smoke.sh
+++ b/hosting/railway/oss/scripts/smoke.sh
@@ -92,16 +92,16 @@ repair_path() {
 
     case "$path" in
         "/w")
-            railway service web >/dev/null && railway redeploy --yes >/dev/null
-            railway service gateway >/dev/null && railway redeploy --yes >/dev/null
+            railway service web >/dev/null && railway redeploy --service web --environment "$ENV_NAME" --yes >/dev/null
+            railway service gateway >/dev/null && railway redeploy --service gateway --environment "$ENV_NAME" --yes >/dev/null
             ;;
         "/api/health")
-            railway service api >/dev/null && railway redeploy --yes >/dev/null
-            railway service gateway >/dev/null && railway redeploy --yes >/dev/null
+            railway service api >/dev/null && railway redeploy --service api --environment "$ENV_NAME" --yes >/dev/null
+            railway service gateway >/dev/null && railway redeploy --service gateway --environment "$ENV_NAME" --yes >/dev/null
             ;;
         "/services/health")
-            railway service services >/dev/null && railway redeploy --yes >/dev/null
-            railway service gateway >/dev/null && railway redeploy --yes >/dev/null
+            railway service services >/dev/null && railway redeploy --service services --environment "$ENV_NAME" --yes >/dev/null
+            railway service gateway >/dev/null && railway redeploy --service gateway --environment "$ENV_NAME" --yes >/dev/null
             ;;
         *)
             return 1


### PR DESCRIPTION
## Context

Railway preview deploys were failing with **No deployment found for service** at the `redeploy_service_if_exists` step. There are two compounding root causes:

1. `railway redeploy --yes` (no explicit `--service` flag) targets whatever service the CLI has implicitly linked at that point in the script, which is not necessarily Postgres. The current Railway CLI treats implicit service selection as deprecated.

2. Even with the correct service targeted, **brand-new PR preview environments** have the Postgres managed service created by the template but no prior deployment record. `railway redeploy` requires an existing deployment to rebase from, so it always fails with "No deployment found" on the first run of a fresh preview.

PR #4725 addressed root cause 1 but was reverted because previews were still failing (root cause 2 was still live). This PR re-applies the explicit flag fix and adds the missing no-deployment guard.

## Changes

Every `railway redeploy --yes` call now passes `--service <name> --environment "$ENV_NAME"` so the CLI always targets the intended service.

In `redeploy_service_if_exists` (`deploy-from-images.sh`), the redeploy failure is now classified before propagating:

Before:
```bash
if railway_call service "$service" >/dev/null 2>&1; then
    railway_call redeploy --yes >/dev/null   # fails on fresh env; exits the whole deploy
fi
```

After:
```bash
err="$(railway_call redeploy --service "$service" --environment "$ENV_NAME" --yes 2>&1 >/dev/null)" \
    || exit_code=$?

if [ "$exit_code" -ne 0 ]; then
    if printf '%s' "$err" | grep -qiE "no deployment found"; then
        printf "No prior deployment for '%s'; skipping redeploy (fresh env).\n" "$service" >&2
        return 0   # non-fatal; Railway starts the service via the template
    fi
    printf '%s\n' "$err" >&2
    return "$exit_code"   # real failures still propagate
fi
```

`deploy-services.sh` and `smoke.sh`'s `repair_path` get the same explicit `--service`/`--environment` flags. Neither needs the no-deployment guard since they operate against established environments that always have prior deployments.

## Tests / notes

- Verified locally with `bash -n` on all three scripts.
- `git diff --check -- hosting/railway/oss/scripts/` passes.
- The "No deployment found" guard only fires for that exact Railway error message; all other failures still propagate and fail the deploy as before.
- Follow-up: watch the next preview deploy run to confirm the Alembic errors (duplicate key on `ux_evaluation_queues_default_per_run`) clear up now that Postgres initialization is no longer being interrupted mid-sequence.