### PR TITLE
docs(agent): reconcile agent-workflows docs with code + add config/run.sh/findings

### DIFF
--- a/docs/design/agent-workflows/documentation/adapters/agenta.md
+++ b/docs/design/agent-workflows/documentation/adapters/agenta.md
@@ -5,12 +5,12 @@ adapter](pi.md) and produces a Pi-shaped config, so it inherits everything Pi do
 tools, the system-prompt layers, tracing). What it adds is a fixed set of Agenta-shipped
 extras that the agent author cannot turn off:
 
-- **Forced tools** — always unioned into the agent's resolved tools. At minimum `read`
+- **Forced tools**: always unioned into the agent's resolved tools. At minimum `read`
   (Pi only renders the skills section when `read` is enabled) and `bash` (so skills can run
   their helper scripts).
-- **Forced skills** — Agenta-shipped Pi skills loaded on every run.
-- **A base AGENTS.md preamble** — the author's `instructions` are appended after it.
-- **A base persona** — forced onto Pi's `append_system`, with any author-supplied
+- **Forced skills**: Agenta-shipped Pi skills loaded on every run.
+- **A base AGENTS.md preamble**: the author's `instructions` are appended after it.
+- **A base persona**: forced onto Pi's `append_system`, with any author-supplied
   `append_system` appended after it.
 
 Read the [architecture](../architecture.md), [ports and adapters](../ports-and-adapters.md),
@@ -30,7 +30,16 @@ disk because they reference relative scripts and assets, so they cannot ride the
 text. The contract between the two halves is the skill **name**: `AGENTA_FORCED_SKILLS` lists
 names, and each must match a committed directory under the runner's skills root.
 
+Because the Agenta harness IS Pi, its tools are delivered the Pi-native way (through the
+extension on the ACP path, through `buildCustomTools` in process), never over MCP. The forced
+`read` and `bash` tools are Pi built-ins, so they ride the wire as built-in names, not resolved
+specs.
+
 ## How a skill reaches the model
+
+The flow below is for the in-process engine. The deployed path (sandbox-agent over ACP) reaches the
+same end state by a different mechanism, described in
+[On the sandbox-agent (ACP) path](#on-the-sandbox-agent-acp-path) below.
 
 1. `AgentaHarness._to_harness_config` puts the forced skill names on the `skills` field of
    the `/run` request (`AgentaAgentConfig.wire_tools`).
@@ -59,7 +68,7 @@ remains available for local/example contrast runs.
 ## On the sandbox-agent (ACP) path
 
 `SandboxAgentBackend` also lists `HarnessType.AGENTA` as supported, so `agenta` runs over ACP through
-the sandbox-agent daemon as well — this is what lets it use the Daytona sandbox. The Agenta harness is
+the sandbox-agent daemon as well. This is what lets it use the Daytona sandbox. The Agenta harness is
 Pi with an opinion, and the sandbox-agent daemon only knows real agents (`pi`, `claude`, …), so the
 runner maps `agenta` onto the `pi` ACP agent (`acpAgent` in `engines/sandbox_agent.ts`) and treats it
 as Pi for capabilities, model resolution, and tracing.
@@ -68,7 +77,7 @@ The forced *skills* cannot ride the `/run` wire as text (a skill is a directory 
 reference relative scripts and assets), so the wire carries only the skill **names** and the
 runner lays the bundled directories into the Pi **agent dir**'s `skills/` (user scope).
 `runSandboxAgent` resolves the names against the bundled `skills/` root (`engines/skills.ts`, shared
-with the in-process engine). The agent dir is deliberate — Pi auto-discovers and enables
+with the in-process engine). The agent dir is deliberate. Pi auto-discovers and enables
 user-scope skills (`<agentDir>/skills/`) on every run, whereas project skills
 (`<cwd>/.pi/skills/`) are trust-gated and would not load in this headless run.
 

--- a/docs/design/agent-workflows/documentation/adapters/claude-code.md
+++ b/docs/design/agent-workflows/documentation/adapters/claude-code.md
@@ -24,17 +24,28 @@ Anthropic key" rather than a stack trace.
 
 ## Tools over MCP
 
-Claude advertises the `mcpTools` capability, so the runner delivers tools to Claude the
-standard ACP way, over MCP. This is the branch that the [capability probe](../ports-and-adapters.md)
-chooses: deliver over MCP when the harness reports `mcpTools`, not when the harness name is
-something in particular.
+Claude reports the `mcpTools` capability, so the runner delivers tools to Claude the standard
+ACP way, over MCP. This is the branch that `buildSessionMcpServers`
+(`engines/sandbox_agent/mcp.ts`) chooses: deliver over MCP when the harness reports `mcpTools`,
+not when the harness name is something in particular. In practice the capability comes from the
+static per-harness fallback (`engines/sandbox_agent/capabilities.ts`): the daemon rarely fills
+a real `info.capabilities`, so the runner uses `mcpTools: true` for any non-Pi harness.
 
-The mechanism is a small stdio MCP server (`tools/mcp-server.ts`) that the daemon launches
-and attaches to the session. Its tool bodies POST back to Agenta's `/tools/call` with the
-same callback-tool envelope the Pi path uses. The resolved specs and the callback endpoint reach the
-MCP server through its environment, so nothing tool-specific is written to a file the agent
-can read. The safety property is identical to Pi's: the provider key and the connection auth
-stay server-side, and the agent only ever asks Agenta to run a named tool.
+The mechanism is a small stdio MCP server named `agenta-tools` (`tools/mcp-server.ts`, launched
+by `tools/mcp-bridge.ts`) that the daemon attaches to the session. This is an Agenta tool
+DELIVERY vehicle, not a user-declared MCP server: it carries the same gateway and code specs
+the Pi extension would register, just exposed over MCP because Claude cannot take a native
+tool. Its env carries only public metadata (names, descriptions, schemas) and a relay
+directory; the `call_ref`, the code, the scoped secrets, and the callback auth never reach it.
+When the model calls a tool, the server relays the request back to the runner over the file
+relay (`tools/relay.ts`), and the runner runs the private spec from memory and POSTs to
+`/tools/call`. The safety property is identical to Pi's: the provider key and the connection
+auth stay server-side, and the agent only ever asks Agenta to run a named tool.
+
+User-declared `mcp_servers` are a separate thing and effectively off today. They would reach
+Claude through `toAcpMcpServers` as additional ACP stdio servers, but only when
+`AGENTA_AGENT_ENABLE_MCP` is set (off by default), so in practice no user MCP server is
+attached. See [tools.md](../tools.md#status-and-known-gaps).
 
 ## Permissions
 

--- a/docs/design/agent-workflows/documentation/adapters/pi.md
+++ b/docs/design/agent-workflows/documentation/adapters/pi.md
@@ -33,9 +33,15 @@ variables, so the extension stays inert when none are set and is safe to install
 
 ## Tools, the Pi-native way
 
-Pi 0.79.4 does not support MCP. So we do not deliver tools over MCP to Pi. Instead the
-extension reads the resolved tool specs from `AGENTA_TOOL_SPECS` and registers each one with
-Pi directly through `pi.registerTool`. Pi then sees them as native tools and runs the loop.
+Pi 0.79.4 does not support MCP, and `pi-acp` does not forward MCP servers either. So we do not
+deliver anything over MCP to Pi: the runner's tool-delivery fork
+(`buildSessionMcpServers` in `engines/sandbox_agent/mcp.ts`) returns an empty MCP list for Pi,
+and tools come through the extension instead. The extension reads the resolved tool specs from
+`AGENTA_TOOL_PUBLIC_SPECS` (public metadata only: name, description, input schema) and
+registers each one with Pi directly through `pi.registerTool`. Pi then sees them as native
+tools and runs the loop. The private parts of each spec (the `call_ref`, the code, the scoped
+secrets, the callback auth) never reach the extension; they stay in runner memory and the
+extension relays every call back.
 
 Each registered tool's body does one thing: it POSTs the call back to Agenta's `/tools/call`
 with the tool's `callRef` (the callback-tool envelope). The model picks the tool and supplies the
@@ -158,9 +164,14 @@ And auth comes from the provider key in the sandbox env when present, or from an
 The in-process Pi engine (`engines/pi.ts`, selected by the `InProcessPiBackend`) skips sandbox-agent
 entirely. It drives Pi's `createAgentSession` directly, with everything in memory: AGENTS.md
 injected through the resource loader, the session and settings managers in memory, and a
-throwaway working directory. It registers the same tools as Pi `customTools` (the same
-POST-back-to-`/tools/call` body) and traces with the same extension logic, just wired in
-process rather than loaded from disk.
+throwaway working directory. It registers the same tools as Pi `customTools` through
+`buildCustomTools`, and traces with the same extension logic, just wired in process rather than
+loaded from disk. One difference from the ACP path: there is no file relay. Because the engine
+runs in the same process as the runner, each tool body executes directly through
+`runResolvedTool` (a gateway tool POSTs to `/tools/call`, a code tool spawns a local
+subprocess). The relay only exists on the ACP path, where a separate Pi process or a Daytona
+sandbox cannot reach Agenta or hold the private spec. The in-process engine also ignores
+`mcp_servers` entirely (`PI_CAPABILITIES.mcpTools` is false).
 
 It returns the same `/run` result as the sandbox-agent path, which is the whole point of the ports:
 the workflow author cannot tell which engine ran. It exists for the simplest local case and

--- a/docs/design/agent-workflows/documentation/agent-configuration.md
+++ b/docs/design/agent-workflows/documentation/agent-configuration.md
@@ -1,0 +1,249 @@
+# Agent Configuration
+
+This page documents how an agent workflow is configured today, end to end. It traces one
+config object from the playground form, through the catalog type and SDK interface, down to
+what the runtime actually reads. It marks what is enforced, what is loose, what is wired, and
+what is decorative.
+
+All file:line citations were verified against the code on 2026-06-23.
+
+## The one-sentence version
+
+The playground renders a single composite `agent_config` control. The field list for that
+control is not hardcoded in the frontend. It is fetched from the backend catalog type
+`agent_config`, which the SDK defines once as `AgentConfigSchema`. The runtime then re-parses
+the same payload into a permissive `AgentConfig` plus a `RunSelection`, resolves tools and
+secrets server-side, and hands a final wire request to the Node runner.
+
+## Three objects share the name "AgentConfig"
+
+Keep these separate. They look alike but do different jobs.
+
+| Object | File | Role |
+| --- | --- | --- |
+| `AgentConfigSchema` | `sdks/python/agenta/sdk/utils/types.py:1065` | Strict schema. Emits the JSON Schema that becomes the catalog type and drives the playground form. It describes the config. |
+| `AgentConfig` (neutral runtime) | `sdks/python/agenta/sdk/agents/dtos.py:308` | Runtime parser. Coerces the loose payload the playground sends. It consumes the config. |
+| `AgentConfig` (file-default dataclass) | `services/oss/src/agent/config.py:30` | Loose file-default loader. Holds the service's built-in defaults with `tools: List[Any]`. |
+
+## The full path
+
+```
+Playground form
+  → AgentConfigControl (FE)               reads schema.properties from the catalog type
+  → GET /workflows/catalog/types/agent_config   resolves x-ag-type-ref to the full schema
+  → AgentConfigSchema (SDK)               the strict schema, registered in CATALOG_TYPES
+  → AgentConfig.from_params + RunSelection (SDK runtime)   re-parse the saved payload
+  → SessionConfig                         tools + secrets resolved server-side
+  → AgentRunRequest (TS wire contract)    the final shape the Node runner receives
+```
+
+## Layer 1: the frontend playground form
+
+The form is fully schema-driven. There is no hand-built agent form. A single marker on the
+workflow's parameters schema mounts one composite control.
+
+The marker is `x-ag-type-ref: "agent_config"`. The schema renderer detects it at
+`web/packages/agenta-entity-ui/src/DrillInView/SchemaControls/SchemaPropertyRenderer.tsx:130`
+and dispatches to `AgentConfigControl` at the same file's `case "agent_config"` (around line
+430).
+
+`AgentConfigControl`
+(`web/packages/agenta-entity-ui/src/DrillInView/SchemaControls/AgentConfigControl.tsx`) does
+not invent widgets. It reads `schema.properties` (line 78) and renders each sub-field with an
+existing control:
+
+- `agents_md` renders as a multiline text input labeled "Instructions". It falls back to a
+  legacy `instructions` value when `agents_md` is missing.
+- `model` renders as a grouped choice control.
+- `tools` renders as a flat array. Each entry uses `ToolItemControl`, the same tool object
+  shape the prompt control uses.
+- `mcp_servers` renders as a flat array. Each entry uses `McpServerItemControl`, which is a
+  JSON editor for one server entry.
+- `harness`, `sandbox`, and `permission_policy` each render as an enum select.
+
+So the object the form produces is:
+
+```
+{ agents_md, model, tools[], mcp_servers[], harness, sandbox, permission_policy }
+```
+
+The field set comes from the backend at runtime. The frontend fetches the catalog type with
+`GET /workflows/catalog/types/{agType}`
+(`web/packages/agenta-entities/src/workflow/api/api.ts`, around line 1291) and merges its
+`properties` into the stored schema
+(`web/packages/agenta-entities/src/workflow/state/molecule.ts`, around line 520). If the
+backend schema changes, the form changes with no frontend edit.
+
+There is no `persona` control. The form never renders one. See the persona note below.
+
+## Layer 2: the catalog type and service schema
+
+`AgentConfigSchema` is the single source of the field list
+(`sdks/python/agenta/sdk/utils/types.py:1065`). It is a strict model with no `extra="allow"`.
+Its fields and defaults:
+
+| Field | Type | Default | Notes |
+| --- | --- | --- | --- |
+| `agents_md` | `str` | a hello-world prompt | `x-ag-type: textarea` |
+| `model` | `str` | `"gpt-5.5"` | `x-parameter: grouped_choice`, plain string |
+| `tools` | `List[ToolConfig]` | empty list | typed discriminated union |
+| `mcp_servers` | `List[MCPServerConfig]` | empty list | typed |
+| `harness` | `Literal["pi","claude","agenta"]` | `"pi"` | enum |
+| `sandbox` | `Literal["local","daytona"]` | `"local"` | enum |
+| `permission_policy` | `Literal["auto","deny"]` | `"auto"` | enum |
+
+The schema is registered in `CATALOG_TYPES` under the key `"agent_config"`
+(`sdks/python/agenta/sdk/utils/types.py:1132`). The API catalog imports `CATALOG_TYPES` from
+the SDK and re-serves it (`api/oss/src/resources/workflows/catalog.py:10`). The API does not
+define any agent fields itself. A grep for `AgentConfigSchema` across `api/` returns nothing.
+
+The agent workflow service advertises this type by reference, not by value. Its `/inspect`
+schema carries a thin pointer plus a pre-fill default
+(`services/oss/src/agent/schemas.py:55`):
+
+```python
+AGENT_CONFIG_SCHEMA = {
+    "type": "object",
+    "x-ag-type-ref": "agent_config",
+    "default": _DEFAULT_AGENT_CONFIG,
+}
+```
+
+The SDK builtin interface `agent_v0_interface` carries the same reference on its `agent`
+parameter (`sdks/python/agenta/sdk/engines/running/interfaces.py:527`).
+
+The schema's own docstring states the design split. The runtime config stays permissive
+because its job is to coerce sloppy input. This schema is strict because its job is to
+describe the shape (`sdks/python/agenta/sdk/utils/types.py:1065`).
+
+## Layer 3: the SDK runtime config
+
+The neutral runtime `AgentConfig` lives at
+`sdks/python/agenta/sdk/agents/dtos.py:308`. Its fields:
+
+```python
+class AgentConfig(BaseModel):
+    model_config = ConfigDict(populate_by_name=True)   # NOT extra="allow"
+    instructions: Optional[str] = None                 # becomes AGENTS.md
+    model: Optional[str] = None
+    tools: List[ToolConfig] = Field(default_factory=list)
+    mcp_servers: List[MCPServerConfig] = Field(default_factory=list)
+    harness_options: Dict[str, Dict[str, Any]] = Field(default_factory=dict)
+```
+
+One correction to a common belief. This model is not `extra="allow"`. Its looseness comes
+from before-validators that coerce messy input, not from accepting arbitrary keys:
+
+- `_coerce_tools` accepts strings, dicts, and legacy shapes.
+- `_coerce_mcp_servers` parses loose server shapes.
+- `from_params()` accepts three payload shapes: the `agent` element, a prompt-template
+  prompt, or a flat `{model, agents_md, tools}` object.
+
+The genuinely loose object is the file-default dataclass at
+`services/oss/src/agent/config.py:30`, which holds `tools: List[Any]`. That is the service's
+built-in default, not user input.
+
+Two fields the schema lists are not on this neutral config. `harness`, `sandbox`, and
+`permission_policy` live on a separate `RunSelection` object
+(`sdks/python/agenta/sdk/agents/dtos.py:364`). The SDK splits "what the agent is" from "where
+and how it runs." The composite schema flattens both into one control for the playground.
+
+Tool entries are strict even though the list is lenient. Each tool subclass is `extra="forbid"`
+(`sdks/python/agenta/sdk/agents/tools/models.py`). `MCPServerConfig` is also `extra="forbid"`
+with a transport validator (`sdks/python/agenta/sdk/agents/mcp/models.py`).
+
+There is no `ModelRef` type. `model` is a plain string everywhere. There is no provider field.
+The rich model picker is built only for the UI by `_model_catalog_type()`
+(`sdks/python/agenta/sdk/utils/types.py:1045`).
+
+## Layer 4: what the runtime actually reads
+
+The Python `/invoke` handler is at `services/oss/src/agent/app.py`. It parses the request
+into two objects (around line 72):
+
+```python
+agent_config = AgentConfig.from_params(params, defaults=_default_agent_config())
+selection    = RunSelection.from_params(params)
+```
+
+It then resolves tools, MCP servers, and secrets server-side (`app.py`, lines 78 to 83),
+bundles everything into a `SessionConfig` (`dtos.py:554`), picks a backend from the selection
+(`select_backend`, `app.py:49`), and runs one turn through a harness.
+
+`sandbox` is deliberately absent from `SessionConfig`. It is a backend concern. The handler
+passes it to `SandboxAgentBackend(sandbox=...)` instead (`app.py:56`).
+
+The final wire shape the Node runner receives is `AgentRunRequest` in
+`services/agent/src/protocol.ts` (around line 185). That is the true wired surface:
+`harness`, `sandbox`, `agentsMd`, `systemPrompt`/`appendSystemPrompt`, `model`, `tools`
+(builtin names), `skills`, `customTools`, `mcpServers`, `toolCallback`, `permissionPolicy`.
+
+## Field-by-field: enforced vs loose, wired vs decorative
+
+Legend: (a) catalog/schema, (b) SDK neutral config, (c) runtime.
+
+| Field | (a) schema | (b) SDK config | (c) runtime | Status |
+| --- | --- | --- | --- | --- |
+| model / provider | yes, `model: str` | yes, `Optional[str]` | wired to the runner | Loose string. No `ModelRef`, no provider enum. There is no separate provider field. |
+| tools | yes, strict list | yes, lenient coercion | wired, resolved to builtin names + tool specs | Entries strict, list lenient. |
+| mcp_servers | yes, strict list | yes | wired, resolved to runner mcp servers | Strict per entry. Gated by `AGENTA_AGENT_ENABLE_MCP` at the service. |
+| skills | no | no | wired but forced only | Not author-settable. Only the Agenta harness injects forced skills. See below. |
+| persona | no | no | wired but forced only | Not a config field. The Agenta harness hardcodes an append-system preamble. See below. |
+| agents_md | yes, `agents_md: str` | yes, as `instructions` | wired to `agentsMd` | The schema names it `agents_md`. The neutral config names it `instructions`. |
+| harness | yes, enum | no, on `RunSelection` | wired, picks the harness class | Enum-enforced. The runtime validates via `make_harness`. |
+| sandbox | yes, enum | no, on `RunSelection` | wired to the backend, absent from `SessionConfig` | Backend concern, not agent identity. |
+| permission_policy | yes, enum | no, on `RunSelection` | wired to `SessionConfig` | Only the Claude harness reads it. Pi ignores it, so it is decorative for pi and agenta. |
+
+## Notable gaps and quirks
+
+`skills` and `persona` are not author config. They are runtime injections of the Agenta
+harness only. `skills` is a `List[str]` on `AgentaAgentConfig`, force-populated from a fixed
+list. `persona` is a forced append-system string. Neither appears in any schema, neither
+appears on the neutral config, and the playground renders no control for either. Pi and
+Claude harnesses get no forced skills or persona.
+
+Per-harness divergence is real. `permission_policy` is wired only for Claude. Builtin tool
+names are dropped for Claude with a warning, because builtins are Pi-only. Skills and persona
+are Agenta-only. Pi's `system` and `append_system` overrides come through the
+`harness_options` escape hatch on the neutral config, which is itself absent from the schema.
+
+The schema is the only place where harness, sandbox, and permission policy sit next to the
+agent definition. The SDK keeps them apart. The composite schema re-flattens them so the
+playground can show one control.
+
+## A concrete example config
+
+This is what the playground saves and the runtime reads:
+
+```json
+{
+  "agents_md": "You are a helpful research assistant. Cite your sources.",
+  "model": "gpt-5.5",
+  "tools": [
+    { "type": "builtin", "name": "web_search" }
+  ],
+  "mcp_servers": [
+    {
+      "name": "github",
+      "transport": "stdio",
+      "command": "npx",
+      "args": ["-y", "@modelcontextprotocol/server-github"]
+    }
+  ],
+  "harness": "pi",
+  "sandbox": "local",
+  "permission_policy": "auto"
+}
+```
+
+With this config, the runtime reads `agents_md`, `model`, `tools`, and `mcp_servers` through
+the neutral `AgentConfig`, reads `harness`, `sandbox`, and `permission_policy` through
+`RunSelection`, resolves the tools and MCP servers server-side, and runs one turn on the Pi
+harness in a local sandbox. The `permission_policy` value is ignored because the harness is
+Pi, not Claude.
+
+## See also
+
+- `agent-template.md` for the intended long-term template shape and what is still missing.
+- `tools.md` for the tool taxonomy and resolution path.
+- `running-the-agent.md` for how the service and the runner sidecar are actually started.

--- a/docs/design/agent-workflows/documentation/agent-template.md
+++ b/docs/design/agent-workflows/documentation/agent-template.md
@@ -57,3 +57,9 @@ experimental and not a general template system.
 Hooks, assets, extra code snippets, and a generic permissions overlay are deferred. The POC
 should leave space for them without pretending they are supported.
 
+## See also
+
+For the live config contract today, from the playground form through the catalog type and
+SDK interface down to what the runtime reads, see `agent-configuration.md`. This page is the
+intended shape; that page is the current reality, field by field.
+

--- a/docs/design/agent-workflows/documentation/architecture.md
+++ b/docs/design/agent-workflows/documentation/architecture.md
@@ -1,144 +1,223 @@
 # Architecture
 
-This page explains how the active-stack agent workflow runs. It describes the code carried
-by the sibling implementation PRs, not only the docs PR commit and not the older
-work-package plans in [trash/](trash/).
+This page explains how an agent workflow runs today. It describes the code on disk, verified
+against the files cited. Where the doc states a future intent, it says so plainly.
 
 ## The Model
 
-Agenta already runs prompt workflows that call a model once and return one answer. An
-agent workflow runs a coding harness instead. The harness reads instructions, calls a
-model, calls tools, observes the results, and loops until it has an answer.
+Agenta already runs prompt workflows that call a model once and return one answer. An agent
+workflow runs a coding harness instead. The harness reads instructions, calls a model, calls
+tools, observes the results, and loops until it has an answer.
 
-The implementation keeps two choices configurable:
+The runtime keeps two run choices configurable
+(`sdks/python/agenta/sdk/agents/dtos.py:364`, `RunSelection`):
 
 - **Harness:** which agent runs. Supported values are `pi`, `claude`, and experimental
-  `agenta`.
-- **Sandbox:** where the run happens. Supported values are `local` and `daytona` on the
-  sandbox-agent path. The in-process Pi path is local only.
+  `agenta`. Default `pi`.
+- **Sandbox:** where the run happens. Supported values are `local` and `daytona`. Default
+  `local`.
 
-The platform still exposes the agent through normal workflow routing. `/invoke` remains the
-batch contract. Agent routes also register `/messages` and `/load-session` for the browser
-chat protocol.
+The platform exposes the agent through normal workflow routing. `/invoke` is the batch
+contract. Agent routes also register `/messages` and `/load-session` for the browser chat
+protocol.
 
 ## Runtime Shape
 
-The deployed local stack uses two containers.
+The deployed stack uses two containers: the Python services container and the Node agent
+runner sidecar.
 
 ```
 browser / playground
     |
     | POST /invoke or POST /messages
     v
-services container
-    Python workflow handler
+services container (Python)
+    agent workflow handler
     services/oss/src/agent/app.py
     |
-    | POST /run, or spawn the runner CLI in local checkout mode
+    | POST /run over HTTP (AGENTA_AGENT_RUNNER_URL set)
+    | or spawn the runner CLI in a source checkout
     v
-agent runner sidecar
+agent runner sidecar (Node)
     compose service: sandbox-agent
-    Node HTTP server
+    HTTP server on :8765
     services/agent/src/server.ts
     |
-    +-- in-process Pi engine
+    +-- pi engine (in-process Pi)
     |   services/agent/src/engines/pi.ts
     |
-    +-- sandbox-agent engine
+    +-- sandbox-agent engine (default)
         services/agent/src/engines/sandbox_agent.ts
         |
         +-- sandbox-agent daemon
             |
-            +-- ACP adapter: pi-acp or claude-agent-acp
+            +-- ACP adapter: pi or claude
                 |
-                +-- harness CLI: pi or claude
+                +-- harness CLI: Pi or Claude Code
 ```
 
-The `services` container owns Agenta concerns: workflow routing, config parsing, provider
-secret resolution, tool resolution, and trace context. The agent runner sidecar owns the
-agent run: it drives Pi directly or drives a harness over ACP through sandbox-agent. In Docker
-Compose this service is still named `sandbox-agent`, and the service reaches it through
-`AGENTA_AGENT_RUNNER_URL`.
+The services container owns Agenta concerns: workflow routing, config parsing, provider
+secret resolution, tool resolution, and trace context. The sidecar owns the agent run. It
+drives Pi in-process or drives a harness over ACP through the sandbox-agent daemon. In Docker
+Compose the sidecar is named `sandbox-agent`, and the service reaches it through
+`AGENTA_AGENT_RUNNER_URL` (`services/oss/src/agent/config.py:46`).
 
-The sidecar deliberately does not inherit the full stack environment. Provider keys and
-tool credentials are resolved by the service and passed only in the scoped run payloads
-that need them.
+The sidecar does not inherit the full stack environment. The service resolves provider keys
+and tool credentials and passes them only in the scoped `/run` payloads that need them.
+
+## What The Deployed Service Actually Runs
+
+The deployed handler always uses `SandboxAgentBackend`. `select_backend` in
+`services/oss/src/agent/app.py:49` constructs `SandboxAgentBackend` for every run, regardless
+of harness. So `pi`, `claude`, and `agenta` all run through the sandbox-agent daemon over ACP
+on the deployed path.
+
+`InProcessPiBackend` exists and works, but the service never selects it. It is the simplest
+backend and the reference to read when writing a new one. It is also the engine the `pi`
+engine file (`services/agent/src/engines/pi.ts`) drives directly. The sidecar still has a `pi`
+engine: a `/run` request with `backend: "pi"` runs Pi in-process inside the sidecar without
+the daemon. The deployed Python service does not send that; standalone SDK scripts and tests
+can.
+
+This split matters when reading the code. There are two `pi` paths:
+
+- The `pi` engine in the sidecar (`engines/pi.ts`), reached only with `backend: "pi"`.
+- The `pi` harness over the sandbox-agent daemon (`engines/sandbox_agent.ts` with `harness:
+  "pi"`), which is what the deployed service sends.
 
 ## Backends
 
-The SDK runtime models engines as `Backend` adapters.
+The SDK runtime models engines as `Backend` adapters
+(`sdks/python/agenta/sdk/agents/interfaces.py:133`).
 
 | Backend | Status | Harnesses | Sandbox support | Notes |
 | --- | --- | --- | --- | --- |
-| `InProcessPiBackend` | Implemented | `pi`, `agenta` | `local` only | Drives `services/agent/src/engines/pi.ts`. This is the simple local Pi path. |
-| `SandboxAgentBackend` | Implemented | `pi`, `claude` | `local`, `daytona` | Drives `services/agent/src/engines/sandbox_agent.ts`, which starts `sandbox-agent` and an ACP adapter. |
-| `LocalBackend` | Not implemented | Intended: `pi`, `claude` | Local machine | Public class exists, but `create_sandbox` and `create_session` raise `NotImplementedError`. |
-
-`services/oss/src/agent/app.py` uses `SandboxAgentBackend` for the deployed service path.
-`AGENTA_AGENT_RUNNER_URL` selects the HTTP runner transport when set; otherwise a source
-checkout uses the local TypeScript runner CLI. `InProcessPiBackend` remains a local/example
-contrast path.
+| `SandboxAgentBackend` | Implemented | `pi`, `claude`, `agenta` | `local`, `daytona` | The deployed path. Drives `engines/sandbox_agent.ts`: starts the sandbox-agent daemon and an ACP adapter. `supported_harnesses` is `{pi, claude, agenta}` (`adapters/sandbox_agent.py:121`). |
+| `InProcessPiBackend` | Implemented | `pi`, `agenta` | `local` only | Drives `engines/pi.ts` (in-process Pi). Not selected by the deployed service; used by standalone scripts and tests (`adapters/in_process.py:119`). |
+| `LocalBackend` | Not implemented | Intended: `pi`, `claude` | Local machine | Public class exists; `create_sandbox` and `create_session` raise `NotImplementedError` (`adapters/local.py:34`). |
 
 ## Harnesses
 
-The SDK runtime models agent-specific behavior as `Harness` adapters.
+The SDK runtime models agent-specific behavior as `Harness` adapters
+(`sdks/python/agenta/sdk/agents/adapters/harnesses.py`).
 
-| Harness | Status | Backend path | Notes |
+| Harness | Status | Where it runs | Notes |
 | --- | --- | --- | --- |
-| `PiHarness` | Implemented | In-process Pi or sandbox-agent | Native Pi tools, Pi prompt overrides, Pi tracing extension. |
-| `ClaudeHarness` | Implemented | sandbox-agent only | MCP tools, permission policy, runner-built tracing. |
-| `AgentaHarness` | Experimental | In-process Pi only | Pi with forced tools, forced skill names, and placeholder Agenta prompt layers. |
+| `PiHarness` | Implemented | sandbox-agent (deployed) or in-process Pi | Native Pi tools, Pi prompt overrides, Pi tracing extension. |
+| `ClaudeHarness` | Implemented | sandbox-agent only | MCP-delivered tools, permission policy, runner-built tracing. No Pi built-in tools. |
+| `AgentaHarness` | Experimental | sandbox-agent (`local` and `daytona`) or in-process Pi | Pi with forced tools, forced skills, a base AGENTS.md preamble, and a persona. The harness maps to the `pi` ACP agent plus forced extras. Content is still placeholder. |
 
-`AgentaHarness` with `daytona` or any sandbox-agent path is intentionally unsupported today. It
-raises through the normal harness/backend compatibility check instead of silently running
-without its forced skills.
+The `agenta` harness runs on the sandbox-agent path. The runner treats it as the `pi` ACP
+agent and layers the forced skills and prompt extras on top
+(`services/agent/src/engines/sandbox_agent/run-plan.ts:78`). The QA matrix verified it on
+sandbox-agent local and Daytona (`projects/qa/findings.md`, F-002). An earlier claim that
+`agenta` was in-process-only was stale.
 
 ## Request Flow
 
 Batch `/invoke` follows this path:
 
-1. The workflow route calls `_agent` in `services/oss/src/agent/app.py`.
+1. The workflow route calls `_agent` in `services/oss/src/agent/app.py:63`.
 2. `_agent` parses `AgentConfig` and `RunSelection` from request parameters.
-3. The service resolves provider keys, tools, and MCP servers. MCP resolution is gated by
-   `AGENTA_AGENT_ENABLE_MCP`.
-4. The service builds `SessionConfig` and creates a harness over an environment and backend.
-5. The harness opens a cold session, sends one `/run` request to the TypeScript runner, and
-   destroys the session.
+3. The service resolves three things independently: tools, MCP servers, and provider-key
+   secrets. MCP resolution is gated by `AGENTA_AGENT_ENABLE_MCP`
+   (`services/oss/src/agent/tools/resolver.py:23`, off by default).
+4. The service builds `SessionConfig` and constructs a harness over an `Environment` and
+   `SandboxAgentBackend`.
+5. The harness opens a cold session, sends one `/run` request to the sidecar, and tears the
+   session down.
 6. The service records usage on the workflow span and returns one assistant message.
 
 Agent `/messages` follows the same runtime path after a browser-protocol adapter step:
 
-1. `sdks/python/agenta/sdk/agents/adapters/vercel/routing.py` validates or mints
-   `session_id`.
+1. `sdks/python/agenta/sdk/agents/adapters/vercel/routing.py` validates or mints `session_id`.
 2. It converts Vercel `UIMessage` parts into neutral agent `Message` objects.
 3. It sets `data.stream` from the `Accept` header.
-4. `_agent` either returns a batch message or streams an `AgentRun`.
-5. The Vercel adapter converts live `AgentEvent` objects into Vercel UI Message Stream
-   parts and the routing layer frames them as SSE.
+4. `_agent` returns a batch message or streams an `AgentRun`.
+5. The Vercel adapter converts live `AgentEvent` objects into Vercel UI Message Stream parts
+   and the routing layer frames them as SSE.
 
-`/load-session` is registered for agent routes, but the default store is
-`NoopSessionStore`. It returns an empty message list unless a real `SessionStore` is
-injected.
+`/load-session` is registered for agent routes, but no durable store is wired. It returns an
+empty message list. See [Sessions](sessions.md).
 
 ## Lifecycle
 
-The runtime is still cold. Each turn creates a fresh session and tears it down after the
-turn. Multi-turn context comes from replaying message history, not from a warm daemon or a
-persisted model session.
+The runtime is cold. Each turn creates a fresh session and tears it down after the turn.
+Multi-turn context comes from replaying message history, not from a warm daemon or a persisted
+model session. The sandbox-agent engine does keep an in-process `InMemorySessionPersistDriver`
+(`services/agent/src/engines/sandbox_agent.ts:150`), but it lives only for the duration of one
+`/run` process, so it does not survive across turns.
 
-This cold model keeps isolation simple and makes `/invoke` and `/messages` share the same
-runtime. It also means durable server-owned history and warm `session/load` are still future
-work.
+This cold model keeps isolation simple and lets `/invoke` and `/messages` share one runtime.
+It also means durable server-owned history and warm session reload are still future work. See
+[Sessions](sessions.md).
 
-## Active-Stack Gaps
+## The Sidecar
+
+The sidecar is a standalone Node package under `services/agent/`. It is not part of the `web/`
+pnpm workspace. It builds its own Docker image and runs through `tsx` with no app compile step.
+The only build is the Pi extension bundle.
+
+The sidecar serves one contract on two entrypoints (`services/agent/README.md`):
+
+- `src/server.ts`: a long-lived HTTP server on `:8765` with `GET /health` and `POST /run`.
+  This is the dockerized sidecar the service calls over HTTP.
+- `src/cli.ts`: one JSON request on stdin, one result on stdout. The SDK adapters use this
+  subprocess transport when `AGENTA_AGENT_RUNNER_URL` is unset (a source checkout).
+
+Both route to an engine by the request's `backend` field. The default is `sandbox-agent`
+(`services/agent/src/server.ts:38`).
+
+### Licensing and images
+
+Two image files live under `services/agent/docker/`
+(`services/agent/docker/README.md`):
+
+- `Dockerfile`: production. Source baked in, no watcher.
+- `Dockerfile.dev`: dev. `tsx watch`, source bind-mounted, hot reload.
+
+The rule that shapes every image: ship build recipes, not Claude-containing images, and never
+bake a credential into any image.
+
+- Pi (`@earendil-works/pi-coding-agent`, MIT) is baked via npm dependencies.
+- Claude Code is proprietary. It is never baked into an image Agenta builds and distributes.
+  The sandbox-agent daemon installs it from Anthropic at runtime over HTTPS, which is why the
+  image installs `ca-certificates`.
+- No credential is baked. Provider keys arrive as request secrets or `ANTHROPIC_API_KEY` /
+  `OPENAI_API_KEY`. OAuth subscription login is a self-host, mount-only opt-in, never for
+  multi-tenant serving.
+
+The production image also installs `python3`, because `code` tools with `runtime: "python"`
+run in the sidecar by spawning `python3` (`services/agent/docker/Dockerfile:27`).
+
+### Daytona sandbox
+
+For the `daytona` sandbox, the runner starts a remote Daytona VM and pushes the harness login,
+the Pi extension, AGENTS.md, skills, and any system-prompt files into it over the Daytona
+filesystem API (`services/agent/src/engines/sandbox_agent/daytona.ts`). Agenta ships a build
+recipe, not a built snapshot. The operator runs it in their own Daytona account
+(`services/agent/sandbox-images/daytona/`). The runner reads `SANDBOX_AGENT_PROVIDER` and the
+`SANDBOX_AGENT_DAYTONA_*` env vars to find the snapshot.
+
+## Tracing
+
+When the `/run` request carries a `trace` block, the run is exported to Agenta as
+OpenTelemetry spans nested under the caller's `/invoke` span. The Pi path self-instruments via
+the bundled Agenta extension. Other harnesses are traced by the runner from the ACP event
+stream (`services/agent/src/tracing/otel.ts`). The Python `tracing` module
+(`services/oss/src/agent/tracing.py`) fills the `trace` block from the live workflow span and
+rolls run usage back onto it.
+
+## Gaps
 
 - `LocalBackend` is a public adapter shape but does not run anything yet.
-- `/load-session` has the route contract but no default persistent store and no write path
-  from completed turns.
+- No durable session store is wired. `/load-session` returns empty history and completed turns
+  are not persisted. See [Sessions](sessions.md).
 - `AgentaHarness` uses placeholder preamble, persona, and skill content.
-- `AgentaHarness` is local in-process only.
-- Pi system prompt overrides are not delivered on the sandbox-agent ACP path.
-- The agent is still registered as a custom workflow handler, not as a first-class builtin
-  URI such as `agenta:builtin:agent:v0`.
-- Historical work-package labels remain in several sibling code comments. They should be
-  cleaned in a documentation and comment hygiene PR.
+- The agent is registered as a custom workflow handler, not as a first-class builtin URI such
+  as `agenta:builtin:agent:v0`. The builtin interface exists in the SDK, but the handler is
+  still bound directly (`services/oss/src/agent/app.py:138`).
+- Per-request model override is not honored on the Pi-over-sandbox-agent ACP path; pi-acp
+  accepts only its default model (`projects/qa/findings.md`, F-007).
+- For the full reconciliation of what is wired and what is missing, see
+  [Ground Truth](ground-truth.md).

--- a/docs/design/agent-workflows/documentation/ground-truth.md
+++ b/docs/design/agent-workflows/documentation/ground-truth.md
@@ -1,15 +1,14 @@
 # Ground Truth
 
-This page maps the active agent-workflows PR stack. It describes the code after the
-sibling code PRs are considered together. The docs PR commit itself is docs-only and does
-not contain every file listed below. If another design page disagrees with this page,
-treat this page and the referenced code as the source of truth.
+This page maps what the agent-workflows code does, what is wired, and what is missing. It is
+verified against the files it cites. If another design page disagrees with this page, treat
+this page and the referenced code as the source of truth.
 
 ## Code Surface
 
 | Area | Files | Active-stack role |
 | --- | --- | --- |
-| Agent service handler | `services/oss/src/agent/app.py` | Parses agent config, resolves secrets and tools, chooses a backend, runs batch or streaming turns. |
+| Agent service handler | `services/oss/src/agent/app.py` | Parses agent config, resolves secrets and tools, builds `SandboxAgentBackend`, runs batch or streaming turns. |
 | Agent route wiring | `sdks/python/agenta/sdk/decorators/routing.py` | Registers `/invoke`, `/inspect`, and agent-only `/messages` plus `/load-session`. |
 | Browser protocol adapter | `sdks/python/agenta/sdk/agents/adapters/vercel/` | Converts Vercel `UIMessage` input and emits Vercel UI Message Stream parts. |
 | SDK runtime DTOs | `sdks/python/agenta/sdk/agents/dtos.py` | Defines `AgentConfig`, `RunSelection`, `SessionConfig`, messages, events, capabilities, and harness configs. |
@@ -33,9 +32,16 @@ treat this page and the referenced code as the source of truth.
   runtime messages, and supports JSON or Vercel SSE based on `Accept`.
 - Streaming runs over a runner NDJSON stream internally. The browser edge projects those
   events into Vercel UI Message Stream parts and appends `[DONE]`.
-- `InProcessPiBackend` supports `pi` and `agenta` on local.
-- `SandboxAgentBackend` supports `pi` and `claude` on local or Daytona.
+- The deployed service always uses `SandboxAgentBackend` (`services/oss/src/agent/app.py:49`).
+  It does not select a backend per harness.
+- `SandboxAgentBackend` supports `pi`, `claude`, and `agenta` on local or Daytona.
+- `InProcessPiBackend` supports `pi` and `agenta` on local. It is the reference backend and is
+  not selected by the deployed service.
 - `PiHarness`, `ClaudeHarness`, and `AgentaHarness` exist and validate backend support.
+- Pi `systemPrompt` and `appendSystemPrompt` overrides are delivered on both the in-process Pi
+  path and the sandbox-agent Pi path. The sandbox-agent engine writes `SYSTEM.md` /
+  `APPEND_SYSTEM.md` into the per-run Pi agent dir, local and Daytona
+  (`services/agent/src/engines/sandbox_agent/pi-assets.ts`).
 - The tool resolver package exists in the SDK. The service composes SDK tool and MCP
   resolvers with service-owned gateway and vault adapters.
 - Code tools execute in a subprocess with a minimal allowlisted environment plus scoped
@@ -54,12 +60,13 @@ treat this page and the referenced code as the source of truth.
 - Harness session snapshots, such as sandbox-agent/ACP state save/load around cleanup/setup, are
   not represented by a production port yet.
 - Warm daemon sessions, ACP `session/load`, and session fork are not wired.
-- `AgentaHarness` ships placeholder Agenta preamble, persona, and skill set. (It does run on
-  sandbox-agent local and Daytona, verified by the QA matrix; the earlier "does not run on sandbox-agent" note
-  was stale.)
-- The agent is not registered as a first-class built-in workflow type.
-- Pi `systemPrompt` and `appendSystemPrompt` are not delivered on the sandbox-agent ACP path.
-- Remote MCP servers are skipped by the active-stack runner path. Local stdio MCP is the path
+- `AgentaHarness` ships placeholder Agenta preamble, persona, and skill set. It does run on
+  sandbox-agent local and Daytona, verified by the QA matrix (`projects/qa/findings.md`, F-002).
+- The agent is not registered as a first-class built-in workflow type. The builtin interface
+  exists in the SDK, but the handler is still bound directly (`services/oss/src/agent/app.py:138`).
+- Per-request model override is not honored on the Pi-over-sandbox-agent ACP path. pi-acp
+  accepts only its default model and silently falls back (`projects/qa/findings.md`, F-007).
+- Remote (`http`) MCP servers are skipped by the runner path. Local stdio MCP is the path
   represented by the bridge.
 - Trigger lifecycle, Compose.io trigger integration, and event-to-agent mapping are not
   implemented in the agent workflow code.
@@ -68,16 +75,16 @@ treat this page and the referenced code as the source of truth.
 
 ## Planned Or Blocked Work
 
-- [SDK Local Tools](sdk-local-tools/) is a planned and partly implemented workspace for
-  standalone SDK tool resolution. It remains blocked on `LocalBackend`.
+- [SDK Local Tools](../projects/sdk-local-tools/) is a planned and partly implemented
+  workspace for standalone SDK tool resolution. It remains blocked on `LocalBackend`.
 - Durable server-owned sessions need a real `SessionStore`, a write path from completed
   turns, ownership checks, and a decision on platform versus local storage.
 - Stateful session resume needs research into sandbox-agent/ACP session representation and a
   future save/load snapshot interface separate from chat history.
 - Trigger integration needs a provider port, a Compose.io adapter, Agenta-owned trigger
   state, and event-to-agent mapping.
-- The old streaming RFCs are archived in [trash/old-rfcs/](trash/old-rfcs/). They explain
-  why the protocol exists but no longer describe the exact active-stack state.
+- The old streaming RFCs are archived in [../archive/old-rfcs/](../archive/old-rfcs/). They
+  explain why the protocol exists but no longer describe the exact current state.
 
 ## Verification Pointers
 
@@ -85,4 +92,4 @@ treat this page and the referenced code as the source of truth.
   `sdks/python/oss/tests/pytest/utils/test_messages_endpoint.py`.
 - Agent service handler tests live in `services/oss/tests/pytest/unit/agent/`.
 - Wire-contract tests live in `sdks/python/oss/tests/pytest/unit/agents/test_wire_contract.py`.
-- Runner tool tests live in `services/agent/test/`.
+- Runner tests live in `services/agent/tests/unit/`.

--- a/docs/design/agent-workflows/documentation/ports-and-adapters.md
+++ b/docs/design/agent-workflows/documentation/ports-and-adapters.md
@@ -28,8 +28,10 @@ sessions. It does not know how Pi or Claude wants tools shaped.
 
 Current backends:
 
-- `InProcessPiBackend`: implemented, supports `pi` and `agenta`, local only.
-- `SandboxAgentBackend`: implemented, supports `pi` and `claude`, local or Daytona.
+- `SandboxAgentBackend`: implemented, supports `pi`, `claude`, and `agenta`, local or Daytona.
+  This is the backend the deployed service always uses (`services/oss/src/agent/app.py:49`).
+- `InProcessPiBackend`: implemented, supports `pi` and `agenta`, local only. The reference
+  backend; not selected by the deployed service.
 - `LocalBackend`: planned, public class exists, methods raise.
 
 ### Environment
@@ -45,11 +47,13 @@ turn.
 
 Current harnesses:
 
-- `PiHarness` keeps built-in tool names, resolved tool specs, Pi prompt overrides, and Pi
-  native tool delivery.
+- `PiHarness` keeps built-in tool names, resolved tool specs, Pi prompt overrides (`system`
+  and `append_system` from `harness_options.pi`), and Pi native tool delivery.
 - `ClaudeHarness` drops Pi built-ins, carries MCP-delivered specs, and carries the
   permission policy.
-- `AgentaHarness` is Pi with forced Agenta policy layered on top.
+- `AgentaHarness` is Pi with forced Agenta policy layered on top: a base AGENTS.md preamble,
+  a forced persona, forced tools, and forced skills (`adapters/agenta_builtins.py`). It runs
+  on both `SandboxAgentBackend` and `InProcessPiBackend`.
 
 ### Session
 
@@ -104,8 +108,10 @@ tools, resolved MCP servers, trace context, and the session id.
 2. Resolve provider secrets.
 3. Resolve tools and, when enabled, MCP servers.
 4. Build `SessionConfig`.
-5. Choose a backend.
-6. Build the harness.
+5. Build the backend. The service always builds `SandboxAgentBackend`, passing the run's
+   sandbox (`local` or `daytona`) and the runner transport. It does not branch on harness.
+6. Build the harness over an `Environment` wrapping that backend. The harness validates that
+   the backend supports it.
 7. Run `prompt` or `stream`.
 
 Tool and MCP resolution are split cleanly:
@@ -147,7 +153,6 @@ result fields should update both sides and the wire tests in the same PR.
 - `SessionStore` has no production adapter and the current runtime does not call
   `save_turn` after completed `/messages` turns.
 - `AgentaHarness` policy content is placeholder product copy.
-- `AgentaHarness` cannot run on sandbox-agent or Daytona.
 - MCP server resolution is disabled unless `AGENTA_AGENT_ENABLE_MCP` is truthy.
-- The code still has historical WP labels in comments. Those labels should not guide new
+- The code still has historical WP labels in some comments. Those labels should not guide new
   design decisions.

--- a/docs/design/agent-workflows/documentation/protocol.md
+++ b/docs/design/agent-workflows/documentation/protocol.md
@@ -123,13 +123,14 @@ Request fields include:
 
 | Field | Meaning |
 | --- | --- |
-| `backend` | Runner engine: `pi` or `sandbox-agent`. |
-| `harness` | Harness id: `pi`, `claude`, or `agenta` depending on backend support. |
+| `backend` | Runner engine: `sandbox-agent` (default) or `pi` (in-process). The deployed service always sends `sandbox-agent`. |
+| `harness` | Harness id: `pi`, `claude`, or `agenta`. On the sandbox-agent path `agenta` maps to the `pi` ACP agent plus forced skills and prompt extras. |
 | `sandbox` | Sandbox id, usually `local` or `daytona`. |
-| `sessionId` | External conversation id. The runtime is still cold and receives history in `messages`. |
+| `sessionId` | External conversation id. The runtime is cold and receives history in `messages`. |
 | `agentsMd` | Instructions that become `AGENTS.md`. |
-| `systemPrompt`, `appendSystemPrompt` | Pi prompt overrides. Not delivered on the sandbox-agent Pi path yet. |
-| `model` | Requested model id. |
+| `systemPrompt`, `appendSystemPrompt` | Pi prompt overrides. Delivered on both the in-process Pi path and the sandbox-agent Pi path (the sandbox-agent engine writes `SYSTEM.md` / `APPEND_SYSTEM.md` into the per-run Pi agent dir, local and Daytona). |
+| `skills` | Bundled skill directory names to force-load (the `agenta` harness, Pi only). |
+| `model` | Requested model id. Not honored on the Pi-over-sandbox-agent path; pi-acp accepts only its default model (see Ground Truth). |
 | `messages` | Conversation history and current turn. |
 | `secrets` | Provider env vars resolved by the service. |
 | `tools`, `customTools`, `toolCallback`, `mcpServers` | Resolved tool delivery. |

--- a/docs/design/agent-workflows/documentation/running-the-agent.md
+++ b/docs/design/agent-workflows/documentation/running-the-agent.md
@@ -1,0 +1,205 @@
+# Running the Agent
+
+This page explains how the agent workflow runs in practice. There is no agent-specific
+`run.sh`. The agent runs as a normal service in the Agenta stack, started by the shared
+`hosting/docker-compose/run.sh`. This page covers that script, the agent pieces it starts,
+the ports, the env vars, and the two ways to run the Node runner outside Docker.
+
+All file:line citations were verified against the code on 2026-06-23.
+
+## There are two agent processes
+
+The agent workflow is split across two services. Know which is which.
+
+1. The Python agent service. It lives in `services/oss/src/agent/`. It runs inside the shared
+   `services` container as a normal Agenta workflow. It decides what to run. It exposes
+   `/invoke` and `/inspect`, parses the config, resolves tools and secrets server-side, and
+   then calls the runner (`services/oss/src/agent/app.py`).
+
+2. The Node runner sidecar. It lives in `services/agent/`. Its compose service name is
+   `sandbox-agent`. It runs the agent loop with the real harnesses (Pi, Claude, the
+   `sandbox-agent` package). It listens on `:8765` and serves `GET /health` and `POST /run`
+   (`services/agent/src/server.ts`). The Python service calls it over HTTP.
+
+The Python service finds the runner through `AGENTA_AGENT_RUNNER_URL`, which defaults to
+`http://sandbox-agent:8765` in every compose stage (for example
+`hosting/docker-compose/ee/docker-compose.dev.yml:421`).
+
+## The script: hosting/docker-compose/run.sh
+
+`run.sh` is the single entrypoint for the whole stack. It picks the right compose file,
+profiles, and env file, then builds or pulls images and runs `docker compose up -d`. The
+agent comes up with everything else. You do not start it separately.
+
+Note: the `run-sh` skill describes an older flag set (`--stage`, `--gh`, `--ssl`,
+`--web-domain`). The current script uses different flags. The accurate flag set is below,
+read straight from `hosting/docker-compose/run.sh`.
+
+### Stage selection
+
+The script derives a stage from the image mode and a few flags:
+
+- `--dev` selects the `dev` stage. Code is bind-mounted and reloads live.
+- `--gh` (the default) selects the `gh` stage. It uses prebuilt registry images.
+- `--local` with `--gh` selects `gh.local`, which builds from local source but in gh layout.
+- `--ssl` with `--gh` selects `gh.ssl`.
+
+The compose file resolves to
+`hosting/docker-compose/<license>/docker-compose.<stage>.yml`. If that file is missing, the
+script exits with an error.
+
+### Key flags
+
+- `--oss` or `--ee` or `--license <oss|ee>`. Default is `oss`.
+- `--dev` or `--gh` or `--image <gh|dev>`. Default is `gh`.
+- `--local`. Build from local gh source. Requires `--gh`.
+- `--build`. Build images before up.
+- `--no-cache`. Build with no cache. Requires `--build`.
+- `--pull` or `--no-pull`. Default is pull on gh, no pull on dev.
+- `--no-web` or `--web-local` or `--web-mode <docker|local|none>`. Default is docker.
+- `--web-url <URL>`. Override `AGENTA_WEB_URL`.
+- `-e` or `--env` or `--env-file <path>`. Use an explicit env file. Otherwise the stage
+  default applies.
+- `--nuke`. Remove related volumes on shutdown.
+- `--down`. Stop containers and exit, no up.
+- `--ssl`. Use the SSL proxy stage. Requires `--gh`.
+- `--nginx`. Use the nginx proxy instead of Traefik.
+- `--help`. Print usage.
+
+### What it does, in order
+
+1. Parse and validate flags. Conflicting flags error out.
+2. Pick the compose file from license and stage.
+3. Resolve the env file. The default is `.env.<license>.<stage>` under
+   `hosting/docker-compose/<license>/`. `gh.local` reuses the `gh` env file.
+4. Add profiles. `with-web` unless web mode is none. Then `with-traefik` or `with-nginx`.
+5. Build, or build with no cache, or pull, depending on the flags and stage.
+6. Run `docker compose down` to clear the old stack. Add `--volumes` when `--nuke`.
+7. Run `docker compose up -d` with `AGENTA_WEB_URL` set.
+8. If web mode is local, install web deps and run the web dev server on the host.
+
+The agent runs in step 7 like any other service. No agent flag exists.
+
+## The standard agent dev command
+
+From the main checked-out branch:
+
+```bash
+./hosting/docker-compose/run.sh --build --license ee --dev --env-file .env.ee.dev.local
+```
+
+This is the dev default from `hosting/CLAUDE.md`. It brings up the full EE stack in dev mode,
+including the `services` container (which hosts the Python agent service) and the
+`sandbox-agent` container (the Node runner).
+
+From a git worktree, prefix a distinct project name and use a per-worktree env file so the
+two stacks do not collide:
+
+```bash
+COMPOSE_PROJECT_NAME=agenta-ee-dev-instance2 ./hosting/docker-compose/run.sh \
+  --license ee --dev --env-file .env.ee.dev.instance2
+```
+
+To stop the stack without removing volumes:
+
+```bash
+./hosting/docker-compose/run.sh --license ee --dev --down
+```
+
+## What run.sh starts for the agent
+
+In the EE dev compose, the relevant services are:
+
+- `services`. Runs uvicorn on port `8080` inside the container
+  (`hosting/docker-compose/ee/docker-compose.dev.yml:383`). It hosts the Python agent
+  service. Traefik routes `/services/` to it. It sets `AGENTA_AGENT_RUNNER_URL` to
+  `http://sandbox-agent:8765` and `AGENTA_AGENT_ENABLE_MCP` to `false` by default (lines 421
+  to 422). It depends on `sandbox-agent` being healthy (line 430).
+
+- `sandbox-agent`. The Node runner (lines 444 onward). In dev it runs
+  `tsx src/server.ts` after rebuilding the Pi extension. It listens on `8765`. Its health
+  check hits `http://127.0.0.1:8765/health` (line 492). It is not behind a compose profile,
+  so it always comes up.
+
+The `sandbox-agent` service ships in every stage. It is present in dev, gh, and gh.ssl for
+both oss and ee. For example the gh stage defines it at
+`hosting/docker-compose/ee/docker-compose.gh.yml:317` and
+`hosting/docker-compose/oss/docker-compose.gh.yml:344`. In gh it uses a prebuilt ghcr image
+instead of building from source.
+
+### The dev sandbox-agent command, explained
+
+The dev compose overrides the image CMD with a shell command (around line 455):
+
+```sh
+mkdir -p /pi-agent && cp -a /pi-agent-ro/. /pi-agent/ 2>/dev/null || true;
+node scripts/build-extension.mjs &&
+exec node_modules/.bin/tsx src/server.ts
+```
+
+It does three things. It copies the read-only mounted Pi login into a writable path so OAuth
+refresh stays in the container. It rebuilds the Pi extension from the mounted `src`, because
+`dist/` is not bind-mounted and a restart would otherwise keep a stale bundle and silently
+drop custom tools. It then starts the server with `tsx`.
+
+## Ports
+
+- `8765`. The Node runner sidecar. `GET /health` and `POST /run`. Internal to the stack.
+- `8080`. The Python `services` container's uvicorn. Internal. Traefik routes `/services/`
+  to it.
+- Traefik. In dev the EE stack exposes Traefik on the host. The default mapping is
+  `8080:8080` in the example compose, but the live local env file
+  (`hosting/docker-compose/ee/.env.ee.dev.local`) sets `TRAEFIK_PORT=8280`, so the local box
+  serves the whole stack on `:8280`.
+
+The frontend talks to the agent through the gateway, not the runner. For example the local
+env file points the chat slice at
+`http://144.76.237.122:8280/services/agent/v0/messages`
+(`NEXT_PUBLIC_AGENT_CHAT_API` in `.env.ee.dev.local`).
+
+## Agent env vars
+
+These are the agent-relevant variables. The example file lists them commented out
+(`hosting/docker-compose/ee/env.ee.dev.example`, lines 119 onward).
+
+- `AGENTA_AGENT_RUNNER_URL`. Where the Python service finds the runner. Default
+  `http://sandbox-agent:8765`. When unset, the Python service spawns the runner CLI locally
+  instead (see `runner_url` and `select_backend` in `services/oss/src/agent/`).
+- `AGENTA_AGENT_ENABLE_MCP`. Gates MCP server resolution. Default `false`.
+- `SANDBOX_AGENT_PROVIDER`. `local` or `daytona`. Default `local`.
+- `SANDBOX_AGENT_DAYTONA_API_KEY`, `_API_URL`, `_TARGET`, `_SNAPSHOT`, `_IMAGE`,
+  `_INSTALL_PI`. Daytona credentials the runner reads for the `daytona` sandbox provider.
+
+The `sandbox-agent` container deliberately has no `env_file`. The harness sandbox must not
+inherit the stack's secrets. The compose block comments explain this
+(`hosting/docker-compose/ee/docker-compose.dev.yml`, around line 459). Tools run server-side
+in the Python service, so the sandbox only needs its own port, the Pi login, an OTLP export
+fallback, and the Daytona credentials.
+
+## Running the Node runner outside Docker
+
+You can run the runner directly. From `services/agent/`, with Node 24 on PATH
+(`services/agent/AGENTS.md`):
+
+```bash
+pnpm install
+pnpm run serve     # HTTP sidecar on :8765, GET /health and POST /run
+pnpm run run:cli   # one JSON request on stdin, one result on stdout
+```
+
+This is a standalone pnpm package. It is not part of the web workspace. It runs through `tsx`
+with no compile step. The only build is `pnpm run build:extension`, which bundles the Pi
+extension into `dist/`.
+
+When the Python service runs in a source checkout with `AGENTA_AGENT_RUNNER_URL` unset, it
+spawns this runner through the CLI path instead of calling it over HTTP. See `select_backend`
+in `services/oss/src/agent/app.py:49` and `runner_url` in `services/oss/src/agent/config.py`.
+
+## See also
+
+- The `run-sh` skill at `.claude/skills/run-sh/SKILL.md`. It is a useful overview but its
+  flag list is stale. Trust `hosting/docker-compose/run.sh` and `docs/packs/hosting.md` for
+  the current flags.
+- `hosting/CLAUDE.md` for the worktree project-name pattern.
+- `agent-configuration.md` for what the config payload contains.
+- `architecture.md` and `ports-and-adapters.md` for the service split rationale.

--- a/docs/design/agent-workflows/documentation/sessions.md
+++ b/docs/design/agent-workflows/documentation/sessions.md
@@ -1,33 +1,40 @@
 # Sessions
 
-The agent runtime has session ids today. It does not have durable server-owned session
-history yet.
+This page describes how sessions behave today, then how they would behave with a real session
+store. The two parts are kept separate on purpose.
 
-## Today: Cold Replay
+## Today
 
-Each turn is cold:
+### Every turn is cold
+
+The runtime has session ids but no durable server-owned history. Each turn is cold:
 
 1. The service creates a harness session.
-2. The backend sends one `/run` request to the TypeScript runner.
-3. The runner starts the needed process tree.
+2. The backend sends one `/run` request to the sidecar.
+3. The runner starts the process tree (the sandbox-agent daemon and an ACP harness, or
+   in-process Pi).
 4. The harness completes one turn.
 5. The session is destroyed.
 
-Nothing warm is kept between turns. The model sees prior conversation only because the
-client sends message history again.
+Nothing warm is kept between turns. The model sees prior conversation only because the client
+sends message history again on every turn.
 
-On `/invoke`, that history is read from `data.inputs.messages`.
+- On `/invoke`, history is read from `data.inputs.messages`.
+- On `/messages`, history is read from `data.messages` in Vercel `UIMessage` shape, then
+  converted to neutral runtime messages before the same handler runs.
 
-On `/messages`, that history is read from `data.messages` in Vercel `UIMessage` shape, then
-converted to neutral runtime messages before the same handler runs.
+The sandbox-agent engine creates an `InMemorySessionPersistDriver`
+(`services/agent/src/engines/sandbox_agent.ts:150`), but it exists only for the one `/run`
+process. It does not survive across turns, so it does not make the runtime warm.
 
-## What The Session Id Does
+### What the session id does
 
 `session_id` is an opaque conversation id. `/messages` accepts it at the top level. If the
-client omits it, the route mints one with a `sess_` prefix. If the client sends one, the
-route validates the charset and length and echoes it.
+client omits it, the route mints one with a `sess_` prefix
+(`sdks/python/agenta/sdk/agents/adapters/vercel/routing.py:43`). If the client sends one, the
+route validates it against `^[A-Za-z0-9._:-]{1,128}$` and echoes it; an invalid id is a 400.
 
-The id flows into:
+The id flows through the run:
 
 - `WorkflowInvokeRequest.session_id`
 - `_agent(..., session_id=...)`
@@ -37,58 +44,59 @@ The id flows into:
 - the Vercel stream `start.messageMetadata.sessionId`
 - the batch `WorkflowBatchResponse.session_id`
 
-The id groups turns, but it does not make the server authoritative for context yet. The
-message history on the request is still what the model sees.
+The id groups turns. It does not make the server authoritative for context. The message
+history on the request is still what the model sees.
 
-## Intended Id Semantics
+### Streaming
 
-The intended behavior is create-or-resume:
+Streaming is implemented without changing the cold lifecycle. The runner emits live NDJSON
+records internally: one `{"kind":"event"}` record per event, then one `{"kind":"result"}`
+terminal record. The Python `AgentRun` turns those records into live `AgentEvent` objects. The
+Vercel adapter projects each event into Vercel UI Message Stream parts, and the route frames
+them as SSE.
 
-- If the client omits `session_id`, the server creates one and returns it.
-- If the client supplies a known `session_id`, the server resumes that session.
-- If the client supplies an unknown but valid `session_id`, the server creates a session
-  using that id.
+So the browser can see text, reasoning, tool calls, tool results, data parts, files, errors,
+and finish metadata as they happen. This is live delivery, not a warm or persisted session.
 
-The current implementation only validates and propagates the id. Because there is no
-durable store, it cannot distinguish known from unknown ids yet.
+### `/load-session`
 
-There should not be a required `create-session` endpoint for the normal chat path. The same
-implicit creation pattern should cover pre-message operations too. For example, a file
-upload before the first typed message can create a session and return the id that later
-chat turns use.
-
-If a client already knows a session id and needs to render history, it should call
-`/load-session` before sending the first message.
-
-## Streaming
-
-Streaming is implemented without changing the cold lifecycle.
-
-The runner emits live NDJSON records internally. The Python `AgentRun` turns those records
-into live `AgentEvent` objects. The Vercel adapter projects each event into Vercel UI
-Message Stream parts and the route frames them as SSE.
-
-This means the browser can see text, reasoning, tool calls, tool results, data parts, files,
-errors, and finish metadata as they happen. It does not mean the session is warm or
-persisted.
-
-## `/load-session`
-
-The route exists and calls a `SessionStore` port. The default store is `NoopSessionStore`.
-It returns an empty list:
+The route exists and calls a `SessionStore` port. The default store is `NoopSessionStore`
+(`sdks/python/agenta/sdk/agents/interfaces.py:112`), and the route registration passes no
+other store (`sdks/python/agenta/sdk/decorators/routing.py:515`). So it always returns an
+empty list:
 
 ```json
 { "session_id": "sess_abc", "messages": [] }
 ```
 
-That makes the protocol testable, but it does not restore history. A production store still
-needs to be selected and wired.
+That makes the protocol testable. It does not restore history.
 
-## Missing Durable History
+## Intended (not implemented)
+
+### Create-or-resume
+
+The intended id behavior is create-or-resume:
+
+- If the client omits `session_id`, the server creates one and returns it.
+- If the client supplies a known `session_id`, the server resumes that session.
+- If the client supplies an unknown but valid `session_id`, the server creates a session using
+  that id.
+
+The current code only validates and propagates the id. With no durable store, it cannot tell a
+known id from an unknown one. So create-or-resume is intent, not behavior.
+
+There should not be a required `create-session` endpoint for the normal chat path. The same
+implicit creation should cover pre-message operations too. For example, a file upload before
+the first typed message can create a session and return the id later chat turns use.
+
+A client that already knows a session id and needs to render history should call
+`/load-session` before the first message.
+
+### A real session store
 
 To make sessions real, the platform needs:
 
-- A production `SessionStore` implementation.
+- A production `SessionStore` implementation, injected where `NoopSessionStore` is today.
 - A call to `save_turn` after each completed `/messages` turn.
 - Ownership checks keyed by project and caller.
 - A load path that returns persisted Vercel `UIMessage` history.
@@ -96,34 +104,31 @@ To make sessions real, the platform needs:
 
 Until that lands, clients must keep sending full history.
 
-## Missing Session Snapshots
+### Harness session snapshots
 
-Durable chat history is only the MVP path. Stateful harnesses may also need their own
-session state saved before teardown and loaded during setup. This is separate from storing
-Vercel `UIMessage` history.
+Durable chat history is the MVP. Stateful harnesses may also need their own session state saved
+before teardown and loaded during setup. This is separate from storing `UIMessage` history.
 
 Examples of state that may not be recoverable from messages alone:
 
-- sandbox-agent or ACP session blobs.
+- A sandbox-agent or ACP session blob.
 - Tool or harness state created during setup.
-- Filesystem or process metadata needed to resume a warm-ish session after a cold restart.
+- Filesystem or process metadata needed to resume a warm session after a cold restart.
 
-The interface is not designed yet. It likely needs explicit `save_session` and
-`load_session` semantics around harness cleanup/setup, plus a storage decision after we
-understand the size and shape of sandbox-agent/ACP session data. Small JSON blobs may fit in
-Postgres. Large opaque blobs may need object storage.
+This interface is not designed yet. The `SessionStore` port covers message history only; a
+snapshot port would be a separate addition. It likely needs explicit `save_session` and
+`load_session` semantics around cleanup and setup, plus a storage decision after we measure the
+size and shape of sandbox-agent/ACP session data. Small JSON blobs may fit in Postgres. Large
+opaque blobs may need object storage. Retention should be short by default, measured in days.
 
-Retention should be short by default, measured in days. Traces may have a different
-retention policy.
-
-## Later: Warm Sessions
+### Warm sessions
 
 Warm sessions are separate from durable cold history. A warm model would keep the daemon or
 harness state alive and use ACP `session/load` or equivalent state restoration. That can
 recover state a transcript cannot, but it also needs a filesystem jail, per-session secret
 channels, and clear multi-tenant isolation.
 
-The likely order remains:
+The likely order:
 
 1. Add server-owned history while keeping cold replay.
 2. Add warm daemon sessions only if long-running stateful agents need them.

--- a/docs/design/agent-workflows/documentation/tools.md
+++ b/docs/design/agent-workflows/documentation/tools.md
@@ -72,22 +72,31 @@ names, the list of specs, and one `ToolCallback` (the endpoint callback tools po
 
 ## How tools get resolved (the service side)
 
-Resolution is the service's job. The composition point is `resolve_agent_resources` in
-`services/oss/src/agent/tools/resolver.py`. It hands the declared configs to the SDK's
-`ToolResolver` (`sdks/python/agenta/sdk/agents/tools/resolver.py`), wired with two Agenta
-adapters: a `VaultToolSecretProvider` for secrets and an `AgentaGatewayToolResolver` for
-gateway tools. The SDK owns the generic algorithm; the service plugs in the Agenta-specific
-HTTP calls. The SDK never imports the service.
+Resolution is the service's job, but most of it now lives in the SDK. The service calls two
+entrypoints in `services/oss/src/agent/app.py` (`_agent`): `resolve_tools(agent_config.tools)`
+and `resolve_mcp_servers(agent_config.mcp_servers)`. Both are thin re-exports. The service
+files under `services/oss/src/agent/tools/` are shims:
+`resolver.py` re-exports the SDK's `resolve_tools` and adds the MCP gate; `gateway.py` and
+`secrets.py` re-export the SDK platform adapters. The real composition is
+`resolve_tools` in `sdks/python/agenta/sdk/agents/platform/resolve.py`, which builds a
+`ToolResolver` (`sdks/python/agenta/sdk/agents/tools/resolver.py`) wired with two
+Agenta-platform adapters: `AgentaNamedSecretProvider` for secrets and
+`AgentaGatewayToolResolver` for gateway tools (both in
+`sdks/python/agenta/sdk/agents/platform/`). The SDK owns the generic algorithm; the platform
+adapters plug in the Agenta-specific HTTP calls. The SDK never imports the service.
 
 Resolution runs per type:
 
 - **Builtin** passes straight through. The name lands in `builtin_names`. No network call.
-- **Code** has its declared `secrets` looked up by name. The service resolves them through
-  `POST /secrets/resolve` (the named-secret vault path in `services/oss/src/agent/tools/secrets.py`)
-  and injects the values into the spec's `env`. The script itself is not run here.
+- **Code** has its declared `secrets` looked up by name. The named-secret provider resolves
+  them through `POST /secrets/resolve` (the platform adapter in
+  `sdks/python/agenta/sdk/agents/platform/secrets.py`, re-exported by
+  `services/oss/src/agent/tools/secrets.py`) and injects the values into the spec's `env`. The
+  script itself is not run here.
 - **Client** passes through to a `ClientToolSpec`. There is nothing to resolve server-side.
 - **Gateway** is the involved one. `AgentaGatewayToolResolver`
-  (`services/oss/src/agent/tools/gateway.py`) posts the references to the API's
+  (`sdks/python/agenta/sdk/agents/platform/gateway.py`, re-exported by
+  `services/oss/src/agent/tools/gateway.py`) posts the references to the API's
   `POST /tools/resolve`. The API (`api/oss/src/core/tools/service.py`, `resolve_agent_tools`)
   validates that the named connection exists, is active, and is authenticated, then enriches
   the tool from the Composio catalog with its real description and input schema. It returns a
@@ -102,8 +111,13 @@ name, a schema, and an opaque slug. The Composio key and the connection's auth n
 service.
 
 MCP servers resolve on the same path but only when `AGENTA_AGENT_ENABLE_MCP` is truthy. The
+gate lives in `resolve_mcp_servers` (`services/oss/src/agent/tools/resolver.py`): when the
+flag is off it returns an empty list before the SDK `MCPResolver` ever runs. When on, the
 `MCPResolver` injects each server's named secrets into its `env`, the same way code tools get
-theirs. By default this is off, so MCP is currently opt-in.
+theirs. By default this is off, so `mcp_servers` is dropped at the service and `mcpServers` is
+omitted from the wire. See the [status](#status-and-known-gaps) section: even with the flag on,
+user MCP reaches Claude only, not the default Pi harness, so the field is a no-op in the common
+case.
 
 The whole resolved bundle then rides the `/run` wire: built-in names in `tools`, resolved
 specs in `customTools`, the callback in `toolCallback`, and resolved MCP servers in
@@ -112,22 +126,28 @@ specs in `customTools`, the callback in `toolCallback`, and resolved MCP servers
 ## How tools get delivered (the harness fork)
 
 The runner has to hand resolved tools to a harness, and harnesses do not accept tools the same
-way. The runner branches on a capability, `mcpTools`, not on the harness name. A harness that
+way. The runner branches on a capability, `mcpTools`, not on the harness name (the branch is
+`buildSessionMcpServers` in `services/agent/src/engines/sandbox_agent/mcp.ts`). A harness that
 reports it can take tools over MCP gets them that way; a harness that cannot gets them
 natively. Today that splits cleanly into two paths.
 
 - **Pi takes native tools.** Pi has an extension API, so the runner registers each resolved
   spec as a Pi tool directly. In-process this is `buildCustomTools` in
   `services/agent/src/engines/pi.ts`; over ACP it is the bundled Pi extension
-  (`services/agent/src/extensions/agenta.ts`), which does the same registration from inside
-  Pi. Either way Pi runs the tool body the runner gives it.
+  (`services/agent/src/extensions/agenta.ts`), which reads the public specs from
+  `AGENTA_TOOL_PUBLIC_SPECS` and does the same registration from inside Pi. Either way Pi runs
+  the tool body the runner gives it. Pi gets no MCP server at all here: `buildSessionMcpServers`
+  returns an empty list for Pi, so neither the synthetic `agenta-tools` server nor any user
+  MCP server is attached.
 - **Claude and other ACP harnesses take MCP.** They cannot accept a native tool, so the runner
   exposes the same resolved specs as a small synthetic MCP server named `agenta-tools`
   (`services/agent/src/tools/mcp-bridge.ts` launches `services/agent/src/tools/mcp-server.ts`).
   This bridge is given only public metadata (names, descriptions, schemas) and a relay
   directory. It never receives the `call_ref`, the code, the scoped secrets, or the callback
   auth. When the model calls a tool, the bridge relays the request back to the runner, and the
-  runner runs the private spec from memory.
+  runner runs the private spec from memory. This `agenta-tools` server is a tool DELIVERY
+  vehicle, not a user MCP server: it carries gateway and code tools, and it exists only on the
+  Claude path.
 
 Both paths funnel execution through one function, `runResolvedTool` in
 `services/agent/src/tools/dispatch.ts`. It is the single place that branches on `kind`, so how
@@ -176,6 +196,14 @@ in `code.ts`). The snippet defines a `main` function; Python is called as `main(
 Node as `main(inputs)`. A non-zero exit or a timeout becomes a tool error so the model loop
 continues rather than crashing the run.
 
+The production image ships the interpreters: the runner Dockerfile installs `python3`
+(`services/agent/docker/Dockerfile`), and `node` is already present. An earlier missing
+`python3` made Python code tools fail with `spawn python3 ENOENT`; that is fixed. One real
+constraint remains: the child only has the interpreter and the tool's own secrets, with no
+package-install step and no `NODE_PATH` to the runner's modules. So a code tool is limited to
+the language standard library. Glue code works; anything that needs a third-party package does
+not, until a provisioning story exists.
+
 ### Client tools: the browser fulfils them across a turn boundary
 
 Execution happens in the browser, not in the runner at all. A client tool is never run
@@ -198,11 +226,20 @@ they are not delivered to non-Pi harnesses over ACP, which bring their own nativ
 
 Execution happens in a separate server process. A declared MCP server is resolved server-side
 (secrets injected into its `env`) and, for MCP-capable harnesses, passed to the ACP daemon as a
-stdio server (`toAcpMcpServers` in `services/agent/src/engines/sandbox_agent.ts`). The daemon
-launches the server's `command` with the resolved `env`, and the harness talks to it over the
-MCP protocol. Two limits apply today: MCP is gated behind `AGENTA_AGENT_ENABLE_MCP`, and Pi's
-ACP adapter does not forward user MCP servers, so MCP currently reaches Claude-style harnesses
-only.
+stdio server (`toAcpMcpServers` in `services/agent/src/engines/sandbox_agent/mcp.ts`). The
+daemon launches the server's `command` with the resolved `env`, and the harness talks to it
+over the MCP protocol.
+
+In practice user MCP is dead on the default path, and for two reasons that stack. First,
+resolution is gated behind `AGENTA_AGENT_ENABLE_MCP`, which is off by default, so the servers
+never reach the wire. Second, even with the flag on, `buildSessionMcpServers` drops user MCP
+for Pi (Pi's ACP adapter does not forward them), so it would reach Claude only. Pi and Agenta
+are the default harnesses, so the `mcp_servers` field is accepted and then silently ignored in
+the common case. This is the silent-drop that the
+[harness-capabilities project](../../projects/harness-capabilities/proposal.md) is built to fix
+(fail loud, or deliver MCP on Pi through the extension). The
+[removal-and-capability notes](../../scratch/notes-tools-mcp-capabilities.md) lay out the two
+options.
 
 ## Approval and rendering
 
@@ -239,23 +276,29 @@ declarative UI spec (`RenderHint` in `protocol.ts`).
 | Resolved tool specs | `sdks/python/agenta/sdk/agents/tools/models.py` (`ResolvedToolSet`) |
 | MCP config | `sdks/python/agenta/sdk/agents/mcp/models.py` |
 | SDK resolution algorithm | `sdks/python/agenta/sdk/agents/tools/resolver.py` |
-| Service resolution composition | `services/oss/src/agent/tools/resolver.py` |
-| Gateway resolver (calls `/tools/resolve`) | `services/oss/src/agent/tools/gateway.py` |
-| Named-secret resolution (`/secrets/resolve`) | `services/oss/src/agent/tools/secrets.py` |
+| SDK platform composition (`resolve_tools`/`resolve_mcp`) | `sdks/python/agenta/sdk/agents/platform/resolve.py` |
+| Service entrypoints (shims + MCP gate) | `services/oss/src/agent/tools/resolver.py`, `__init__.py` |
+| Gateway resolver (calls `/tools/resolve`) | `sdks/python/agenta/sdk/agents/platform/gateway.py` (shim: `services/oss/src/agent/tools/gateway.py`) |
+| Named-secret resolution (`/secrets/resolve`) | `sdks/python/agenta/sdk/agents/platform/secrets.py` (shim: `services/oss/src/agent/tools/secrets.py`) |
 | API resolve + execute | `api/oss/src/core/tools/service.py`, `api/oss/src/apis/fastapi/tools/router.py` |
 | Wire contract | `services/agent/src/protocol.ts`, `sdks/python/agenta/sdk/agents/utils/wire.py` |
+| Tool-delivery fork (branch on `mcpTools`) | `services/agent/src/engines/sandbox_agent/mcp.ts` |
 | Runtime dispatch (branch on `kind`) | `services/agent/src/tools/dispatch.ts` |
 | Callback transport | `services/agent/src/tools/callback.ts` |
 | Code execution | `services/agent/src/tools/code.ts` |
+| Daytona/non-Pi relay | `services/agent/src/tools/relay.ts` |
 | Pi native delivery | `services/agent/src/engines/pi.ts`, `services/agent/src/extensions/agenta.ts` |
-| MCP bridge for non-Pi harnesses | `services/agent/src/tools/mcp-bridge.ts`, `services/agent/src/tools/mcp-server.ts` |
+| `agenta-tools` server for non-Pi harnesses | `services/agent/src/tools/mcp-bridge.ts`, `services/agent/src/tools/mcp-server.ts` |
+| Capability probe | `services/agent/src/engines/sandbox_agent/capabilities.ts` |
 | Permission policy | `services/agent/src/responder.ts` |
 
 ## Status and known gaps
 
-- MCP server resolution is off unless `AGENTA_AGENT_ENABLE_MCP` is truthy, so MCP is opt-in.
-- Pi's ACP adapter does not forward user-declared MCP servers; MCP reaches Claude-style
-  harnesses only.
+- **User MCP is effectively dead on the default path.** Resolution is off unless
+  `AGENTA_AGENT_ENABLE_MCP` is truthy, and even on, the runner drops user MCP for Pi. Pi and
+  Agenta are the default harnesses, so `mcp_servers` is a silent no-op for most runs. It would
+  reach Claude only. Do not confuse this with the `agenta-tools` server, which is an internal
+  tool-delivery vehicle for Claude, not a user MCP server.
 - `needs_approval` is honored only by permission-gating harnesses (Claude over ACP). It is a
   no-op on Pi.
 - Gateway tools support only the `composio` provider today; other providers raise.
@@ -263,5 +306,15 @@ declarative UI spec (`RenderHint` in `protocol.ts`).
   every render kind is still in progress.
 - Gateway calls on Daytona depend on the file relay, because the sandbox cannot reach Agenta
   directly. The relay is also used by the non-Pi MCP bridge on local runs.
+- **Code tools are standard-library-only.** The image ships `python3` and `node`, but the
+  child env has no package install and no module path to the runner's dependencies, so a tool
+  cannot import third-party packages.
+- **Harness capabilities are probed but not consumed.** The runner probes `HarnessCapabilities`
+  per run (`engines/sandbox_agent/capabilities.ts`), uses them only for the internal `mcpTools`
+  delivery branch, and returns them on the `/run` result. The result field is parsed into
+  `AgentResult.capabilities` and then read by nobody: no `/inspect` surface, no frontend gate,
+  no service check. `/health` advertises `engines` and `harnesses` but no capabilities. The
+  [harness-capabilities proposal](../../projects/harness-capabilities/proposal.md) is the plan
+  to make this a real, consumed contract.
 </content>
 </invoke>

--- a/docs/design/agent-workflows/scratch/capability-architecture.md
+++ b/docs/design/agent-workflows/scratch/capability-architecture.md
@@ -1,0 +1,201 @@
+# Capability configuration: architecture sketch (scratch)
+
+Scratch thinking for how to expose web / execute / read / write (and network) as a single
+author-facing configuration that enforces correctly across harnesses (`pi`, `claude`) and
+backends (sandbox-agent local, sandbox-agent Daytona, and the not-yet-built local SDK
+`LocalBackend`). Pairs with `capability-map.md` (the current-state research). This is a
+proposal to argue with, not a decision.
+
+## The core problem in one sentence
+
+One neutral, author-facing capability declaration must fan out to enforcement that lives in
+**two different architectural planes** (the harness's tools and the sandbox's isolation), and
+must **degrade honestly** when a backend cannot enforce a given plane.
+
+That is the whole difficulty. Everything below is about drawing those two planes cleanly and
+deciding who owns what.
+
+## The two enforcement planes
+
+A capability is only real if enforced. There are exactly two places enforcement can happen,
+and they are not interchangeable:
+
+1. **The tool plane (harness-owned).** Decide which tools the model is even given. "Web off"
+   here means: do not hand Claude `WebFetch`/`WebSearch`; for Pi, drop nothing useful because
+   Pi has no web tool, but it can still `curl` from `bash`. "Read-only" here means: give Pi
+   `read`/`grep`/`find`/`ls` but not `write`/`edit`/`bash`; give Claude `Read`/`Glob`/`Grep`
+   and disallow `Write`/`Edit`/`Bash`. This is **intent and UX**, expressed in the harness's
+   own tool vocabulary.
+
+2. **The sandbox plane (backend-owned).** Decide what the running process can physically do,
+   regardless of which tools it holds. "Web off" here means: block network egress at the
+   sandbox boundary (Daytona `networkBlockAll`). "No writes outside cwd" means: filesystem
+   confinement. This is the **security boundary**.
+
+The critical asymmetry: **for network and filesystem, only the sandbox plane is a real
+boundary.** Pi can always `curl` from `bash`, so "web off" enforced only in the tool plane is
+advisory, not safe. A capability that must be a guarantee (no exfiltration, no writes to the
+host) has to be enforced in the sandbox plane. The tool plane is the UX layer on top.
+
+Consequence: the same author toggle ("web: off") means *defense in depth* when both planes
+can act (Daytona: hide the web tools AND block egress), and means *best-effort only* when only
+the tool plane can act (local: hide the tools, but the process can still reach the network).
+The architecture must make that difference explicit, not hidden.
+
+## Who owns what (the boundary map)
+
+Mapping onto the existing ports (`interfaces.py`, `dtos.py`, `adapters/harnesses.py`, the TS
+runner). The principle: **each layer already owns a kind of knowledge; attach the matching
+slice of capability to the layer that already owns that kind.**
+
+| Layer | Already owns | Capability responsibility |
+| --- | --- | --- |
+| `AgentConfig` (author-facing) | neutral intent (instructions, model, tools, mcp) | **declare** the neutral capability profile. No enforcement. |
+| `SessionConfig` (neutral runtime) | the neutral run bag (builtin_names, permission_policy, secrets) | **carry** the capability profile unchanged to the harness + backend. |
+| `Harness` adapter (`PiHarness`/`ClaudeHarness`) | per-harness tool knowledge ("Claude has no Pi builtins") | **translate** capability -> harness tool controls (the tool plane). The only place that knows "web = WebFetch+WebSearch on Claude, curl-in-bash on Pi". |
+| `Backend` / `Environment` / `Sandbox` | sandbox lifecycle + policy (`sandbox_per_session`) | **translate** capability -> sandbox provisioning (network/fs isolation; the sandbox plane). Declare what it can enforce. |
+| TS runner (`sandbox_agent.ts`) | applying a harness-shaped config to an ACP session + provider | **apply** what it is told: set the session's allowed tools/permission mode; pass network params to the provider. It decides nothing. |
+
+The clean rule: **policy is decided in the SDK (harness adapter + backend), the runner only
+applies.** Today the runner accidentally owns policy by omission (it drops `builtin_names`,
+never sets Claude tool controls, never sets network). That is the inversion to correct.
+
+## What the author-facing config should look like
+
+Goal: a few legible toggles, not a tool-by-tool checklist. The four capabilities the product
+owner named map to coarse axes. A first shape on `AgentConfig`:
+
+```
+capabilities:
+  filesystem: none | read_only | read_write   # read + write collapsed to one axis
+  code_execution: bool                          # shell / run code
+  network: off | on | { allow: [cidr|host, ...] }  # web; allowlist is Daytona-only
+```
+
+Open questions on the shape (for review):
+
+- **Booleans vs presets.** Presets ("Researcher: read-only, no exec, web on"; "Coder:
+  read-write, exec, web on"; "Sandboxed analyst: read-write, exec, no web") may be better UX
+  than four independent switches, with an "advanced" expander for the raw axes. Presets also
+  dodge nonsensical combinations.
+- **Granularity.** Is `filesystem: read_only` worth it, or is the honest set just
+  `code_execution` + `network` (the two with real security weight), leaving read/write always
+  on? Read-only is hard to make a true boundary anyway (Pi `read` vs `write` is tool-plane
+  only; real fs confinement is sandbox-plane and neither backend does it yet).
+- **Where it sits.** A nested `capabilities` object on `AgentConfig`, parallel to `tools`, vs.
+  flattening onto the existing run-selection (`harness`/`sandbox`/`permission_policy`). I lean
+  nested object: it is a coherent concept and the schema/inspect/table machinery from
+  `proposal.md` Part 2 wants one keyed block.
+- **Relationship to `permission_policy`.** `permission_policy` (auto/deny) is a *third* plane
+  (gate a call the model already made). It overlaps "code_execution: off" partially (deny
+  blocks Bash too) but is coarser (all-or-nothing, Claude-only). I think capabilities should
+  *subsume* the intent and `permission_policy` stays as the runtime HITL knob, not a capability
+  axis. Worth a Codex opinion.
+
+## How it flows end to end (Daytona example, `web: off`)
+
+1. Author sets `capabilities.network: off` in the playground. Stored on the agent config.
+2. SDK parses it onto `AgentConfig.capabilities`, copied onto `SessionConfig`.
+3. `ClaudeHarness._to_harness_config` reads it and emits `disallowed_tools: [WebFetch,
+   WebSearch]` (tool plane). `PiHarness` emits nothing for the tool plane (no web tool to drop)
+   but records the intent.
+4. The backend (`SandboxAgentBackend` for Daytona) reads `capabilities.network: off` and, at
+   `create_sandbox`, sets the provider's `networkBlockAll: true` (sandbox plane).
+5. The TS runner applies both: Claude session created with the disallowed tools; the Daytona
+   provider `create` object carries `networkBlockAll`.
+6. Result: Claude has no web tools AND the VM has no egress. Pi has its tools but the VM has no
+   egress, so its `curl` fails closed. Defense in depth, both harnesses safe.
+
+Same config on **local sidecar**: step 3 still works (Claude loses the web tools). Step 4
+cannot: the local provider is the host, no `networkBlockAll`. So the backend must declare it
+**cannot enforce `network`** and the config must fail loud (or require an explicit
+`allow_unsafe_local: true`), per the static capability table + fail-loud rule in
+`proposal.md`. This is the honest-degradation requirement.
+
+## How it works for the unimplemented local SDK backend
+
+This is the portability test, and the model passes it cleanly *if* policy lives in the SDK:
+
+- **Tool plane is backend-independent.** It is owned by the `Harness` adapter, which is the
+  same object regardless of backend. So `capabilities -> Pi --tools / Claude allowedTools` is
+  computed once in Python and works for `LocalBackend` (Pi-via-bundled-JS, Claude-via-
+  `claude-agent-sdk`) exactly as for sandbox-agent. For the Claude-via-`claude-agent-sdk` path
+  this is *especially* clean: `allowedTools`/`disallowedTools`/`permissionMode` are native
+  options of that SDK, so the local Claude path enforces the tool plane in-process with no
+  runner at all.
+- **Sandbox plane degrades the same way as local sidecar.** `LocalBackend` has no sandbox, so
+  it declares it cannot enforce `network`/fs isolation, and the same fail-loud rule fires. A
+  `LocalBackend` user who wants a true network boundary is told to use a sandboxed backend.
+
+So the SAME `capabilities` block is portable across all backends. What varies is only the set
+of guarantees a backend can honor, and that variance is declared in one capability/enforcement
+table, not discovered at runtime.
+
+## Port-shape change this forces (the one real structural cost)
+
+`Backend.create_sandbox()` currently takes **no arguments** (`interfaces.py:155`) and
+`Environment._sandbox()` calls it parameterless. But network/fs isolation is a *per-config*
+decision (set at Daytona create time), not a per-environment one. So either:
+
+- `create_sandbox(policy: SandboxPolicy)` gains a typed sandbox-policy argument threaded from
+  the config through `Environment.create_session` -> `_sandbox()` -> `create_sandbox`, or
+- a `SandboxPolicy` is attached to the `Environment` at construction (cleaner if sandbox policy
+  is environment-scoped, worse if two configs in one environment want different network).
+
+I lean toward threading a `SandboxPolicy` through `create_sandbox`, because the capability is
+authored per-agent-config, and one environment may serve several configs. This is the only
+load-bearing port change; everything else is additive fields.
+
+## Defense-in-depth: which plane is authoritative?
+
+My position: **enforce in both planes where possible, and treat the sandbox plane as the
+source of truth for any capability with security weight (network, fs).** The tool plane exists
+to (a) shape what the model attempts (better behavior, fewer wasted denied calls) and (b)
+cover backends with no sandbox plane, as best-effort. Never advertise a tool-plane restriction
+as a guarantee when the sandbox plane is absent. This is the single most important correctness
+rule in the whole design, because it is where "we told the user web was off" can be a lie.
+
+## Strawman capability x (harness, backend) enforcement table
+
+What each pairing can actually guarantee, which the static table should encode:
+
+| Capability | Pi tool plane | Claude tool plane | Daytona sandbox plane | Local sidecar / LocalBackend sandbox plane |
+| --- | --- | --- | --- | --- |
+| network off | n/a (no web tool; curl remains) | drop WebFetch/WebSearch | **enforce** (networkBlockAll) | **cannot** (host network) -> fail loud |
+| network allowlist | n/a | n/a (no per-host tool gate) | **enforce** (networkAllowList CIDR) | **cannot** -> fail loud |
+| code_execution off | drop `bash` (and tool-relay code tools?) | disallow Bash/KillShell + permissionMode | partial (cannot un-install interpreters) | tool plane only |
+| read_only | drop write/edit/bash | disallow Write/Edit + Bash | no fs confinement today | no fs confinement |
+
+The "n/a" cells are the honest gaps: Pi's lack of a web tool means its web access is purely a
+sandbox-plane concern, and Claude's tools have no per-host web gate, so a network *allowlist*
+is sandbox-plane only for both. This table is why network must be sandbox-plane to be real.
+
+## My recommendation (to be challenged)
+
+1. Add a neutral `capabilities` object to `AgentConfig` with `code_execution` (bool) and
+   `network` (off/on/allowlist) as the two axes with real weight; treat `filesystem` as a
+   later, mostly-tool-plane nicety. Offer presets in the UI over the raw axes.
+2. Enforce in two planes, policy decided in the SDK: `Harness` adapters own the tool plane,
+   `Backend` owns the sandbox plane. The runner only applies.
+3. Make the sandbox plane authoritative for network/fs; the tool plane is UX + best-effort.
+4. Declare per-backend enforceability in the static capability table (`proposal.md` Part 2)
+   and fail loud when a config asks for a guarantee a backend cannot honor (with an explicit
+   unsafe-opt-out for local dev).
+5. Thread a `SandboxPolicy` through `create_sandbox`; accept that as the one structural port
+   change.
+6. Prerequisite cleanup (already latent bugs): the runner must actually honor Pi
+   `builtin_names` on the sandbox-agent path (it is dropped today) and must set Claude
+   `allowedTools`/`permissionMode` on session creation (never set today). Without these the
+   tool plane does not exist.
+
+## Questions for Codex
+
+1. Are two planes the right decomposition, or is there a cleaner single seam I am missing?
+2. Capability config shape: booleans vs presets vs per-tool; is collapsing read/write right?
+3. Is the sandbox-plane-authoritative + tool-plane-as-UX rule the correct stance, or should we
+   refuse configs whose guarantee cannot be met rather than offer best-effort?
+4. The `create_sandbox(policy)` port change: thread per-call, or attach to `Environment`?
+5. Does putting tool-plane policy in the `Harness` adapter and sandbox-plane policy in the
+   `Backend` keep the "backend is pure plumbing" invariant, or does sandbox-plane policy
+   actually belong in `Environment` (which already owns sandbox policy)?
+6. Anything that breaks the portability claim for the in-process `claude-agent-sdk` local path?

--- a/docs/design/agent-workflows/scratch/capability-map.md
+++ b/docs/design/agent-workflows/scratch/capability-map.md
@@ -1,0 +1,241 @@
+# Harness capability map: web, execute, read, write
+
+What can the `pi` and `claude` harnesses actually do (access the web, execute code, read
+files, write files), what is on by default, what can we configure, and how the sandbox
+backend (Daytona vs local sidecar) changes the answer.
+
+Scope: the **sandbox-agent** runner only (`services/agent/src/engines/sandbox_agent.ts`,
+environments E2 local and E3 Daytona). The in-process Pi POC engine (`engines/pi.ts`) is out
+of scope, as requested. Note the `pi` *harness* running on sandbox-agent is in scope; only the
+separate in-process Pi engine is not. All claims cite code or the installed package source.
+
+## The one thing to understand first: three independent layers
+
+A capability like "can run code" is not a single switch. It is the AND of three layers, and
+they live in three different places:
+
+1. **The harness's built-in toolset.** Each coding agent ships its own tools. Pi gives the
+   model `read`, `write`, `edit`, `bash` by default
+   (`node_modules/@earendil-works/pi-coding-agent/README.md:96`). Claude (the Claude Agent
+   SDK) ships `Read`, `Write`, `Edit`, `Bash`, `Glob`, `Grep`, `NotebookEdit`, `WebFetch`,
+   `WebSearch`, `Task`, `TodoWrite`, `KillShell`
+   (`node_modules/.pnpm/@anthropic-ai+claude-agent-sdk@0.2.83.../sdk-tools.d.ts`). This layer
+   decides *which tools the model can call at all*.
+
+2. **The permission gate.** When a tool wants to run, the harness may raise an ACP permission
+   request. Our runner answers it with a fixed policy responder
+   (`responder.ts:44`, `permissions.ts:21`). Default is auto-allow; `permissionPolicy: "deny"`
+   or `SANDBOX_AGENT_DENY_PERMISSIONS=true` flips it to deny-everything
+   (`responder.ts:57-62`). This layer decides *whether a call the model made is allowed to
+   execute*. It is all-or-nothing, not per-tool.
+
+3. **The sandbox environment.** The tool runs *somewhere*. `bash` can only `curl` the web if
+   the sandbox has network. `python script.py` only runs if python is installed. The "sandbox"
+   is the Daytona VM (E3) or the local sidecar host itself (E2). This layer decides *what the
+   tool's execution can actually reach and do*.
+
+Capability = (harness ships the tool) AND (permission policy allows it) AND (the environment
+can carry it out). Most of the surprises below come from confusing these three.
+
+## Per-harness default capabilities
+
+### `pi` harness (and `agenta`, which is `pi` with forced extras)
+
+| Capability | Default | Mechanism |
+| --- | --- | --- |
+| Read files | **Yes** | built-in `read` tool (`README.md:96`) |
+| Write files | **Yes** | built-in `write` + `edit` tools |
+| Execute code / shell | **Yes** | built-in `bash` tool |
+| Access the web | **No dedicated tool** | Pi has no `WebFetch`/`WebSearch`. The only web path is `bash` running `curl`/`wget`, which needs network in the sandbox |
+
+Pi has **no permission gating by design** ("It intentionally does not include ... permission
+popups", `docs/usage.md:303`; the probe reports `permissions: false` for pi,
+`capabilities.ts:24-35`). So on Pi the permission policy layer is a no-op: `bash` and `write`
+run without ever asking, and `permissionPolicy: "deny"` does **not** stop them, because Pi
+never raises the request the responder would answer.
+
+`agenta` is the same engine. It additionally **forces** `read` + `bash` on
+(`agenta_builtins.py:52`) and forces a skill, but it cannot remove the default write/edit.
+
+### `claude` harness
+
+| Capability | Default | Mechanism |
+| --- | --- | --- |
+| Read files | **Yes** | `Read`, `Glob`, `Grep` |
+| Write files | **Yes** | `Write`, `Edit`, `NotebookEdit` |
+| Execute code / shell | **Yes** | `Bash`, `KillShell` |
+| Access the web | **Yes** | `WebFetch` **and** `WebSearch` are built in |
+
+Claude is the richer harness: it has first-class web tools Pi lacks. Claude **does** gate tool
+use (probe reports `permissions: true`, `capabilities.ts:24`), and our runner auto-approves
+every gate by default (`responder.ts:48`). So with the default policy, Claude behaves as
+"all tools on." With `permissionPolicy: "deny"`, every Claude tool call is rejected (a blunt
+kill switch, not a selective one).
+
+The QA run confirms the live behavior: `pi` builtin `bash` passes on E2/E3; `claude` chat +
+code-tool + web-capable run passes once an Anthropic key is present
+(`../qa/matrix.md:308-320`).
+
+## What you can configure through our interfaces today
+
+This is the blunt part. Very little of the per-capability surface is actually wired on the
+sandbox-agent path.
+
+- **Turn individual tools on/off (web off, exec off, read-only, ...):** **Not possible today.**
+  - The config has a `builtin_names` / `tools` field meant to select Pi built-ins
+    (`dtos.py:457`, wire field `protocol.ts:216`). But the sandbox-agent runner **never reads
+    `request.tools`**. Only the out-of-scope in-process `pi.ts:281` honors it. On sandbox-agent,
+    Pi always launches with its default four tools regardless of what you set. So even Pi's own
+    tool-selection knob is silently dropped here.
+  - Claude built-in selection is dropped one layer earlier: `ClaudeHarness` discards
+    `builtin_names` entirely because built-ins are a Pi concept (`harnesses.py:83-87`). The
+    Claude Agent SDK *does* support `allowedTools` / `disallowedTools` / `permissionMode`
+    (present in `sdk.d.ts`), but our runner sets **none** of them. It creates the session with
+    only `cwd` and `mcpServers` (`sandbox_agent.ts:195-199`). So there is currently no path to
+    say "Claude without WebSearch" or "Claude read-only."
+- **Block all tool execution:** **Yes, but only for Claude.** `permissionPolicy: "deny"` (per
+  run) or `SANDBOX_AGENT_DENY_PERMISSIONS=true` (per deployment) rejects every gated call
+  (`responder.ts:57`). On Pi it does nothing (Pi does not gate).
+- **Add tools (gateway, code, MCP):** Yes, this is the wired direction. Resolved custom tools
+  reach Pi natively through the bundled extension (`extensions/agenta.ts`) and reach Claude
+  over an MCP stdio bridge (`mcp.ts:50-75`), gated on the probed `mcpTools` capability. MCP
+  user-servers are delivered to Claude, dropped for Pi (`mcp.ts:61-67`), and remote/http MCP
+  is skipped (`mcp.ts:21`).
+- **Pick the model:** partially. Aliases work; a full model id often silently falls back to the
+  harness default (F-007, `../qa/matrix.md:321`, `model.ts:46-70`).
+
+Net: today the product exposes **add tools** and **deny-all (Claude)**. It does **not** expose
+"disable web," "disable code execution," "read-only," or even Pi's own built-in selection on
+the sandbox-agent path. The capability descriptors the daemon reports
+(`commandExecution`, `fileChanges`, `mcpTools`, `permissions`, ... in `AgentCapabilities`,
+`sandbox-agent/dist/index.d.ts:30-49`) are **descriptive** (what the harness can do), not
+**controls** (they do not turn anything off). The runner reads them only to branch tool
+delivery, not to restrict the harness.
+
+## The backend dimension: Daytona vs local sidecar
+
+The harness toolset is identical across backends (same Pi, same Claude). What changes is the
+**environment layer**: isolation, network reach, and what is installed to execute code.
+
+### Local sidecar (E2): the "sandbox" is the host
+
+The local provider spawns `sandbox-agent server` as a **child process on the sidecar host**,
+inheriting `process.env` and binding `127.0.0.1`
+(`sandbox-agent/dist/providers/local.js`, `provider.ts:42`). There is **no isolation**:
+
+- **Read/write** happen on the host filesystem, in a throwaway temp cwd
+  (`run-plan.ts:54-56`, cleaned up in the `finally`, `sandbox_agent.ts:296`). But `bash` is not
+  jailed to that cwd; the agent runs with the sidecar process's privileges and can read/write
+  what that user can.
+- **Web/network** = whatever the host has. No allowlist, no block. If the sidecar can reach the
+  internet, so can the agent's `curl`.
+- **Code execution** = whatever interpreters are installed in the sidecar image. (This is
+  exactly where F-006 bit: `python3` was missing from the image, so python code tools failed
+  with ENOENT until it was added.)
+- There is **no per-run network or filesystem control knob** for local. The only lever is the
+  deny-all permission policy (Claude only).
+
+So local is fast and simple, but it trades away the sandbox. Treat E2 as "the agent runs
+inside our sidecar," not "the agent runs in a sandbox."
+
+### Daytona (E3): a real isolated VM, with controls we do not yet use
+
+Daytona provisions a separate ephemeral sandbox per run
+(`provider.ts:21-37`, `ephemeral: true`). Read/write/exec happen **inside that VM**, not on our
+host. Code execution depends on what the snapshot bakes: our `agenta-sandbox-pi` snapshot is
+`rivetdev/sandbox-agent:...-full` (daemon + Claude + CA certs) plus the `pi` CLI
+(`sandbox-images/daytona/build_snapshot.py:42-73`), sized cpu=2/mem=4/disk=8.
+
+Crucially, **Daytona exposes network and resource controls that our runner does not surface.**
+The provider passes a `create` overrides object straight to the Daytona SDK
+(`provider.ts:26-37`, sandbox-agent `daytona({ create })`), and the SDK's create params include
+(`@daytonaio/sdk/cjs/Daytona.d.ts:115-160`):
+
+- `networkBlockAll?: boolean` - block **all** network access for the sandbox.
+- `networkAllowList?: string` - comma-separated **CIDR allowlist** (egress only to named
+  ranges).
+- `resources` / `memory` / `disk` / `gpuType` - compute envelope.
+- `volumes`, `autoStopInterval`, `user`, `language`, etc.
+
+Today `buildSandboxProvider` sets only `snapshot`/`image`/`target`/`envVars`/`ephemeral`. It
+passes **no** network params, so a Daytona run has **full egress by default**. We *could* make
+web access a real per-config control on Daytona by threading `networkBlockAll` /
+`networkAllowList` into that `create` object. That lever exists at the backend and is unused.
+
+This is the sharp asymmetry: **Daytona can enforce "no web" or "web only to these hosts" at
+the sandbox boundary; local cannot enforce anything** (it is the host). If "configurable web
+access" is a product goal, Daytona is the backend that can deliver it cleanly, and the change
+is in the runner's provider wiring, not in the harness.
+
+### The daemon's own primitives (a separate plane, not wired to the harness)
+
+Independently of the harness's tools, the sandbox-agent daemon exposes its own HTTP API over
+the sandbox: `/v1/fs/*` (read, write, list, delete, move, upload), `/v1/process/*` (run a
+command, stream logs), and `/v1/desktop/*` (full computer-use: mouse, keyboard, screenshot,
+recording) (`sandbox-agent/dist/index.d.ts`). We use this control plane only for provisioning
+(upload the extension, install pi, write AGENTS.md, run the usage readback). It is **not**
+exposed to the model as tools. So "computer use" is available at the substrate but unused by
+our agents today. Worth noting as a latent capability, not a current one.
+
+## Summary table
+
+| Question | `pi` (on sandbox-agent) | `claude` (on sandbox-agent) |
+| --- | --- | --- |
+| Read files (default) | yes (`read`) | yes (`Read`/`Glob`/`Grep`) |
+| Write files (default) | yes (`write`/`edit`) | yes (`Write`/`Edit`) |
+| Execute code (default) | yes (`bash`) | yes (`Bash`) |
+| Web access (default) | only via `bash`+curl (no web tool) | yes (`WebFetch`+`WebSearch`) |
+| Permission gating | none (Pi never gates) | yes; runner auto-approves |
+| Selectively disable a tool | no interface today | no interface today |
+| Block all tool exec | no (Pi ignores deny) | yes (`permissionPolicy: deny`) |
+| Add tools (code/gateway/MCP) | yes (native) | yes (over MCP bridge) |
+
+| Backend | Isolation | Web by default | Web configurable? | Exec depends on |
+| --- | --- | --- | --- | --- |
+| Local sidecar (E2) | none (runs on host) | yes (host network) | no knob | sidecar image |
+| Daytona (E3) | per-run ephemeral VM | yes (full egress) | **yes, but unused** (`networkBlockAll`/`networkAllowList` exist) | snapshot image |
+
+## Gaps and opportunities (if we want capabilities to be real controls)
+
+1. **No per-capability control exists on the sandbox-agent path.** "Disable web," "disable
+   exec," "read-only" are not configurable for either harness today. Adding them means wiring
+   the harness's own knobs: Pi's `--tools` / `--no-builtin-tools` (and actually honoring
+   `request.tools`, which the runner drops), and Claude's `allowedTools` / `disallowedTools` /
+   `permissionMode` on session creation.
+2. **Web access is the cleanest thing to make configurable, via Daytona network params.**
+   `networkBlockAll` / `networkAllowList` are already accepted by the provider's `create`
+   object; the runner just needs to pass them from config. This gates web at the sandbox
+   boundary regardless of which tools the harness ships, so it works for both Pi (curl) and
+   Claude (WebFetch).
+3. **Local cannot be made safe by config.** Because the local provider is the host, no
+   per-run network or filesystem confinement is possible there. If untrusted configs ever run,
+   they should run on Daytona, not local.
+4. **Pi's missing web tool vs Claude's web tools** is a real product difference to surface: a
+   "give the agent web access" toggle means different things per harness (curl-in-bash for Pi,
+   first-class WebFetch/WebSearch for Claude).
+5. The capability **descriptors** the daemon already reports (`AgentCapabilities`) are the
+   natural place to *display* what a harness can do, and the static capability table proposed
+   in `proposal.md` is the natural place to declare what we *let* the user configure. This doc
+   is the web/exec/read/write cut of that same framework.
+
+## Sources
+
+- Runner: `services/agent/src/engines/sandbox_agent.ts` (session create `:195-199`, permission
+  wiring `:232-238`, no tool allowlist), `engines/sandbox_agent/provider.ts` (Daytona create
+  overrides), `engines/sandbox_agent/daemon.ts` (local daemon env), `responder.ts` (permission
+  policy), `engines/sandbox_agent/capabilities.ts` (probe), `engines/sandbox_agent/mcp.ts`
+  (tool/MCP delivery gate), `engines/sandbox_agent/run-plan.ts` (cwd, `request.tools` unused).
+- Harness toolsets: `node_modules/@earendil-works/pi-coding-agent/README.md:96`,
+  `docs/usage.md:303` (Pi built-ins, no MCP/permissions);
+  `node_modules/.pnpm/@anthropic-ai+claude-agent-sdk@0.2.83.../sdk-tools.d.ts` (Claude tools);
+  `@zed-industries/claude-agent-acp` README (ACP adapter, "tool calls with permission
+  requests").
+- SDK adapters: `sdks/python/agenta/sdk/agents/adapters/harnesses.py` (Claude drops
+  `builtin_names`), `adapters/agenta_builtins.py` (forced `read`+`bash`), `dtos.py:457`
+  (`builtin_names` field).
+- Daytona controls: `node_modules/.pnpm/@daytonaio+sdk@0.187.0.../cjs/Daytona.d.ts:115-160`
+  (`networkBlockAll`, `networkAllowList`, resources); snapshot recipe
+  `services/agent/sandbox-images/daytona/build_snapshot.py`.
+- Daemon API: `node_modules/sandbox-agent/dist/index.d.ts` (`/v1/fs`, `/v1/process`,
+  `/v1/desktop`, `AgentCapabilities`).
+- Live behavior: `../qa/matrix.md:299-344` (E2/E3 run results).

--- a/docs/design/agent-workflows/scratch/dead-code-report.md
+++ b/docs/design/agent-workflows/scratch/dead-code-report.md
@@ -1,0 +1,270 @@
+# Agent-workflows dead-code report
+
+Date: 2026-06-23. Read-only investigation. No code changed.
+
+## What "the code is not really doing anything" means here
+
+The premise is partly true and partly false. The live runtime path is wired and
+reached. The service (`services/oss/src/agent/app.py`) always selects
+`SandboxAgentBackend` + the `pi` harness, resolves tools/MCP/secrets through the SDK
+`platform` package, and streams through the vercel adapter. That whole spine is alive.
+
+What is genuinely dead is the scaffolding left around the spine: leftover re-export shims
+from the PR #4772 refactor, compat wrappers that duplicate a canonical name, two backend
+adapters that only tests or nothing reach, and one broken module that cannot even import.
+The breadth of files (31 TS, ~40 SDK) makes it look like a large system. Most of those
+files are live; a focused minority is dead.
+
+## Counts
+
+- High confidence (delete): 7 findings.
+- Medium confidence (reachable only via a non-default flag, tests, or unimplemented): 6 findings.
+- Low confidence (cosmetic / public-surface-only orphans): 3 findings.
+
+## How I checked (shared method)
+
+For each symbol I ran `git grep -n "<symbol>"` across `services/`, `sdks/`, `api/`, `web/`
+excluding `.pyc`, then classified the hits: only-definition, only-`__init__`-re-export,
+only-tests, or live caller. For files I grepped inbound imports of the basename. The live
+entry points are `app.py` (service), `cli.ts`/`server.ts` (runner), and the public SDK
+surface `agenta/__init__.py`.
+
+---
+
+## SERVICE - `services/oss/src/agent/`
+
+### DEAD (high): `client.py` whole file
+
+- File: `services/oss/src/agent/client.py` (`agenta_api_base`, `request_authorization`,
+  `TOOLS_TIMEOUT`).
+- Verdict: dead. Zero importers anywhere.
+- How I checked: `git grep -n "agent.client\|agenta_api_base\|request_authorization"` over
+  `services/oss/src/` returns only the definitions in this file. `app.py` imports
+  `config`, `schemas`, `tools`, `tracing` only. The backend base-URL and authorization
+  logic now lives in `agenta.sdk.agents.platform.connection` (`PlatformConnection`,
+  `DEFAULT_TOOLS_TIMEOUT`). The conftest references to `agenta_api_base` /
+  `request_authorization` patch the SDK platform module passed into `_install`, not this
+  file.
+- Action: delete.
+
+### DEAD (medium): `secrets.py` and `tools/secrets.py` and `tools/gateway.py` shims (tests-only)
+
+- Files: `services/oss/src/agent/secrets.py` (`resolve_harness_secrets`,
+  `_PROVIDER_ENV_VARS`), `services/oss/src/agent/tools/secrets.py`
+  (`VaultToolSecretProvider`, `resolve_named_secrets`), `services/oss/src/agent/tools/gateway.py`
+  (`AgentaGatewayToolResolver`, `_to_gateway_reference`, `_normalize_reference`).
+- Verdict: thin re-export shims of the SDK `platform` package. No LIVE importer. `app.py`
+  imports none of them. The only non-shim importers are tests.
+- How I checked: `git grep -n` for each symbol. `resolve_harness_secrets` and
+  `_PROVIDER_ENV_VARS`: only `secrets.py` + two test files. `VaultToolSecretProvider`:
+  only the shim + `tools/__init__.py` re-export, never constructed (`VaultToolSecretProvider(`
+  returns nothing). `_to_gateway_reference`/`AgentaGatewayToolResolver` via
+  `tools/__init__`: only `test_gateway_mapping.py`. `app.py` resolves via
+  `agenta.sdk.agents.platform` (`resolve_secrets`) and `oss.src.agent.tools`
+  (`resolve_tools`/`resolve_mcp_servers`), which themselves call the SDK platform, not
+  these shims.
+- Nuance: `tools/__init__.py` re-exports `AgentaGatewayToolResolver` and
+  `VaultToolSecretProvider` in `__all__`, but nothing imports those names from it at
+  runtime. `_gateway_ref = _to_gateway_reference` in `tools/__init__.py:7` is assigned and
+  never read.
+- Action: needs-human-decision. These keep test imports green and preserve a
+  backward-compatible import path. If the tests are repointed at
+  `agenta.sdk.agents.platform`, all four shim files plus the `__init__` re-exports can go.
+  `resolver.py` and the `resolve_tools`/`resolve_mcp_servers` it exposes are LIVE; keep them.
+
+### NOT DEAD (checked): `config.py`, `schemas.py`, `tracing.py`, `tools/resolver.py`
+
+- `config.py`: all three `AgentConfig` fields (`agents_md`, `model`, `tools`) are read by
+  `app.py` `_default_agent_config`. No decorative config.
+- `schemas.py`: `AGENT_SCHEMAS` consumed by `app.py:144`; harness default is `"pi"`
+  (`schemas.py:50`), matching the live selection.
+- `tracing.py`: `record_usage`, `trace_context` imported by `app.py:36`.
+- `tools/resolver.py`: `resolve_tools`, `resolve_mcp_servers` imported by `app.py:35`. The
+  MCP gate `AGENTA_AGENT_ENABLE_MCP` defaults off, so MCP resolution is gated-but-reachable,
+  not dead.
+
+---
+
+## RUNNER - `services/agent/src/` (TypeScript sandbox-agent)
+
+Entry points confirmed via `package.json`: `cli.ts` (`run:cli`) and `server.ts` (`serve`).
+Engine dispatch is `backend === "pi" ? runPi(...) : runSandboxAgent(...)` at
+`server.ts:47-50` and `cli.ts:31-34`, default `sandbox-agent`. Both engines are live: the
+SDK `InProcessPiBackend` sets `AGENT_BACKEND=pi`, `SandboxAgentBackend` sets
+`sandbox-agent`. Keep both engines, both tool executors, all of `tools/`, `protocol.ts`,
+`responder.ts`.
+
+### DEAD (high): `shutdownTracing`
+
+- File: `services/agent/src/tracing/otel.ts:179`, function `shutdownTracing`.
+- Verdict: dead. Zero callers in `src`, `tests`, or the Python side.
+- How I checked: `grep -rn "shutdownTracing" services/agent` returns only the definition.
+  The runner flushes per-run via `flushTrace` (`otel.ts:583,1020`); there is no
+  process-level shutdown-flush path. The only other repo hit is an archived POC under
+  `docs/.../archive/wp-1-pi-tracing/poc/`, a different file.
+- Action: delete.
+
+### DEAD (medium): test-only re-export aliases on the engine surface
+
+- File: `services/agent/src/engines/sandbox_agent.ts:74-75`. Re-exports `buildTurnText`,
+  `messageTranscript` (from `./sandbox_agent/transcript.ts`) and `toAcpMcpServers` (from
+  `./sandbox_agent/mcp.ts`).
+- Verdict: the underlying functions are LIVE (production imports them directly from their
+  defining modules). The re-export aliases on the engine are consumed only by
+  `tests/unit/continuation.test.ts` and `tests/unit/mcp-servers.test.ts`.
+- How I checked: grep for each name scoped to `sandbox_agent.ts` import source; only the
+  two test files import through the engine.
+- Action: needs-human-decision. Either delete the three re-exports and repoint the two
+  tests at the defining modules, or keep them as an intentional "test through the engine's
+  public surface" seam. Not runtime-dead.
+
+### NOT DEAD (checked, do not re-investigate)
+
+- `tools/mcp-server.ts`: looks orphaned (no static import) but is spawned as a `tsx`
+  subprocess by `mcp-bridge.ts:26`. Live.
+- `extensions/agenta.ts`: no static import, but esbuild-bundled to
+  `dist/extensions/agenta.js` and loaded by Pi at runtime (`pi-assets.ts:24`, Dockerfiles
+  run `build:extension`). Live.
+- `engines/sandbox_agent.ts` (file) is NOT superseded by `engines/sandbox_agent/` (folder).
+  The file is the orchestrator that imports the folder modules.
+- `version.ts` (`PROTOCOL_VERSION`/`RUNNER_VERSION`/`ENGINES`/`HARNESSES`): served by
+  `/health` via `runnerInfo()`.
+- `provider.ts`, `transcript.ts`, `usage.ts`, `model.ts`, `daytona.ts`, `pi-assets.ts`,
+  `public-spec.ts`, `workspace.ts`: all reached through their orchestrators.
+
+---
+
+## SDK - `sdks/python/agenta/sdk/agents/` and `sdk/engines/running/`
+
+### DEAD (high): broken `engines/running/registry.py`
+
+- File: `sdks/python/agenta/sdk/engines/running/registry.py` (only symbol
+  `exact_match_v1`).
+- Verdict: dead and unimportable. Line 5 does
+  `from agenta.sdk.engines.running.types import Data`, but `running/types.py` does not
+  exist, so importing the module raises `ModuleNotFoundError`.
+- How I checked: `ls running/types.py` (no such file). `git grep "running.registry\|from .registry import exact_match_v1"`
+  finds no importer of THIS module. The `exact_match_v1` hits elsewhere are an unrelated
+  function in `sdk.workflows.handlers` and in manual test scripts. Note: `running/` is the
+  OLDER workflow-engine subsystem, separate from the agent path; the agent code never
+  imports `engines.running`.
+- Action: delete file.
+
+### DEAD (high): `is_import_safe`
+
+- File: `sdks/python/agenta/sdk/engines/running/sandbox.py:9`, function `is_import_safe`.
+- Verdict: dead. Zero callers.
+- How I checked: `git grep "is_import_safe"` returns only the definition. The live member
+  in that file is `execute_code_safely` (called from `handlers.py`).
+- Action: delete function.
+
+### DEAD (high): `tool_spec_to_wire` and `tool_specs_to_wire`
+
+- File: `sdks/python/agenta/sdk/agents/tools/wire.py:10,14`.
+- Verdict: dead standalone functions. The live serialization path uses the
+  `ToolSpec.to_wire()` METHOD (`dtos.py:479,484`), not these module functions.
+- How I checked: `git grep "tool_specs\?_to_wire"` returns only the defs plus their
+  re-export in `tools/__init__.py:38,65-66`. No real caller.
+- Action: delete the functions and the `__init__` re-exports.
+
+### DEAD (high): `ui_messages.py` whole module
+
+- File: `sdks/python/agenta/sdk/agents/ui_messages.py`.
+- Verdict: dead compat shim re-exporting `from_ui_messages`/`to_ui_message`/
+  `ui_message_stream` from `adapters.vercel`. Zero importers of the module.
+- How I checked: `git grep "agents.ui_messages\|from .ui_messages\|from agenta.sdk.agents.ui_messages"`
+  returns nothing. The live service imports the canonical `agent_run_to_vercel_parts`
+  directly (`app.py:29`).
+- Action: delete file. The flat aliases `from_ui_messages`, `to_ui_message`,
+  `ui_message_stream = agent_run_to_vercel_parts` in `adapters/vercel/messages.py:218-219`
+  and `adapters/vercel/stream.py:216` have no real callers either and can go with it.
+
+### DEAD (high): `parse_tool_configs` (plural-of-the-wrong-name)
+
+- File: `sdks/python/agenta/sdk/agents/tools/parsing.py`.
+- Verdict: dead. Zero references anywhere, not even tests.
+- How I checked: `git grep "parse_tool_configs"` finds only the def. The live parse path
+  uses `coerce_tool_configs` (`dtos.py:331`, `platform/resolve.py:52`,
+  `api/oss/.../tools/models.py:113`).
+- Action: delete. Note the siblings `coerce_tool_config` (singular) and `parse_tool_config`
+  (singular) are tests-only plus internal `compat.py` use; keep for now or fold into test
+  fixtures (medium, human call).
+
+### DEAD-ish (medium): `InProcessPiBackend` (tests-only, but a public export)
+
+- File: `sdks/python/agenta/sdk/agents/adapters/in_process.py`, class `InProcessPiBackend`.
+- Verdict: never selected by the service. Constructed only in tests
+  (`test_transport_roundtrip.py`, `test_harness_adapters.py`, `test_runner_adapter_config.py`).
+  It is a near-duplicate of `SandboxAgentBackend`.
+- How I checked: `git grep "InProcessPiBackend\|InProcessPi"` excluding tests finds only
+  its definition plus public-API re-exports in `agenta/__init__.py:63` and
+  `agents/__init__.py`. `select_backend` in `app.py` always returns `SandboxAgentBackend`.
+- Action: needs-human-decision. It is exported as public SDK API ("the reference backend")
+  but only tests and explicit non-default callers reach it. Keep as a documented reference
+  backend or demote to a test fixture.
+
+### DEAD (medium): `LocalBackend` (never instantiated, unimplemented)
+
+- File: `sdks/python/agenta/sdk/agents/adapters/local.py`, class `LocalBackend`.
+- Verdict: never instantiated anywhere; every method raises `NotImplementedError`.
+- How I checked: `git grep "LocalBackend("` finds only the class definition. Methods at
+  `local.py:35,50` raise `NotImplementedError`.
+- Action: keep-but-wire (a tracked Phase 3/4 stub) or delete if no longer planned. Dead
+  today by design.
+
+### REACHABLE-BUT-NEVER-DEFAULT (medium): `ClaudeHarness`, `AgentaHarness` (+ `agenta_builtins.py`)
+
+- File: `sdks/python/agenta/sdk/agents/adapters/harnesses.py:77,105`, plus the forced
+  tools/skills machinery in `adapters/agenta_builtins.py`.
+- Verdict: registered in the harness registry (`harnesses.py:127-129`) and listed in
+  `SandboxAgentBackend.supported_harnesses` (`sandbox_agent.py:121-122`), so they ARE
+  reachable if a user sets `harness: "claude"` or `harness: "agenta"` in playground config.
+  The default everywhere is `"pi"` (`schemas.py:50`, `dtos.py:369,378`). Outside explicit
+  config they run only in unit tests.
+- Action: keep (config-gated feature). Flag that AGENTA/CLAUDE are exercised only via tests
+  plus explicit non-default config, so they are easy to break unnoticed.
+
+### LOW / cosmetic
+
+- `mcp_server_to_wire` (singular) in `mcp/wire.py`: no non-test, non-`__init__` caller
+  (live path uses plural `mcp_servers_to_wire`, `dtos.py:439`). Delete singular helper.
+- `MCPSecretProvider` in `mcp/interfaces.py`: Protocol/typing surface, no constructor.
+  Keep.
+- `MessageContent` type alias `dtos.py:179`: used only in-file, not in `__all__`. Cosmetic.
+- `ToolConfigDiagnostic` / `ToolConfigParseResult` / `coerce_tool_configs(on_error="collect")`
+  in `tools/compat.py:20,27`: the diagnostics/collect branch is tests-only (live callers
+  use the default `on_error="raise"`). Public structured-error surface; human call.
+
+### NOT DEAD (checked, do not re-investigate)
+
+- `platform.resolve` does NOT supersede `tools.resolver` / `mcp.resolver`. It WRAPS them:
+  `platform/resolve.py:48,62` constructs `ToolResolver(...)` and `MCPResolver(...)`. One
+  resolution stack, not two. All of `tools/resolver.py`, `mcp/resolver.py`,
+  `platform/{gateway,secrets,connection}.py` are live.
+- `engines/running/` is a separate, OLDER workflow/evaluator engine
+  (`completion_v0`/`chat_v0`/`echo_v0`, code runners, catalog, templates). The agent path
+  never imports it. It is heavily used by `api/`, the completion/chat services, SDK
+  decorators, and DB migrations. Out of scope for agent-workflows but mostly live; the only
+  dead spots inside it are `registry.py` and `is_import_safe` above. `DaytonaRunner`
+  (`runners/daytona.py`) is env-gated (`AGENTA_SERVICES_CODE_SANDBOX_RUNNER=daytona`), not
+  dead; `LocalRunner` is the default.
+- `dtos.py`, `interfaces.py`, `streaming.py` (`AgentRun`), `_runner_config.py`,
+  `utils/ts_runner.py` (all `deliver_*`), `utils/wire.py`: all have live callers in the
+  service or adapters.
+- vercel adapter `routing.py`/`sse.py`/`stream.py`/`messages.py`: reached via
+  `decorators/routing.py:518` (`register_agent_message_routes`), gated by the `is_agent`
+  flag that `app.py:146` sets. The FE `AgentChatSlice` consumes `/messages` through
+  `NEXT_PUBLIC_AGENT_CHAT_API`.
+
+---
+
+## Suggested cleanup order (lowest risk first)
+
+1. `shutdownTracing` (otel.ts), `is_import_safe` (sandbox.py), `running/registry.py`,
+   `tool_spec(s)_to_wire`, `parse_tool_configs`, `ui_messages.py` + flat vercel aliases,
+   `mcp_server_to_wire` singular. All zero-caller, high confidence.
+2. Service shims (`client.py` then, after repointing tests, `secrets.py`,
+   `tools/secrets.py`, `tools/gateway.py` + `__init__` re-exports).
+3. The runner test-only re-exports (`sandbox_agent.ts:74-75`) once tests are repointed.
+4. Human decisions: `InProcessPiBackend`, `LocalBackend`, `ClaudeHarness`/`AgentaHarness`,
+   the `coerce_tool_configs` diagnostics surface.

--- a/docs/design/agent-workflows/scratch/notes-architecture.md
+++ b/docs/design/agent-workflows/scratch/notes-architecture.md
@@ -1,0 +1,86 @@
+# Architecture doc notes (open questions and follow-ups)
+
+These are items I could not fully close while reconciling the architecture / sidecar /
+sessions / protocol / ground-truth docs against the code on 2026-06-23. Each is written so you
+can act on it cold. File:line citations are from the working tree at that date.
+
+## Corrections I made (so you can spot-check)
+
+- The deployed service ALWAYS uses `SandboxAgentBackend`. `select_backend`
+  (`services/oss/src/agent/app.py:49`) hard-codes it and does not branch on harness. The old
+  docs implied the service picks between `InProcessPiBackend` and `SandboxAgentBackend`. It
+  does not. `InProcessPiBackend` is reference-only and is exercised by tests / standalone
+  scripts, not the running service. Confirmed by `services/oss/tests/pytest/unit/agent/test_select_backend.py`.
+- `SandboxAgentBackend.supported_harnesses` is `{pi, claude, agenta}`
+  (`sdks/python/agenta/sdk/agents/adapters/sandbox_agent.py:121`). Old architecture/ports docs
+  said `{pi, claude}` and claimed `agenta` was in-process-only or unsupported on sandbox-agent.
+  Stale. `agenta` maps to the `pi` ACP agent (`engines/sandbox_agent/run-plan.ts:78`).
+- Pi `systemPrompt` / `appendSystemPrompt` ARE delivered on the sandbox-agent path now
+  (`engines/sandbox_agent/pi-assets.ts:71-107`, called from `prepareLocalPiAssets` line 181 and
+  the Daytona path in `daytona.ts`). The old docs and QA matrix said "dropped on sandbox-agent
+  (F-001)". `projects/qa/findings.md` F-001 is marked **resolved** and the code confirms it.
+  NOTE: `projects/qa/matrix.md` still shows `append_system / pi` as `known-fail (F-001)` /
+  `fail (F-001)` and references `sandbox_agent.ts:875`. That matrix is STALE relative to the
+  code and findings.md. The matrix is owned by the QA project, not by me, so I did not edit it.
+  RECOMMEND: have the QA owner flip those matrix cells to pass and drop the `:875` line ref
+  (the monolithic `sandbox_agent.ts` was split into `engines/sandbox_agent/*`, so old line
+  numbers like `:875`, `:933-949`, `:961` in findings.md and matrix.md no longer resolve).
+
+## Stale line numbers across QA docs (not mine to edit)
+
+`projects/qa/findings.md` and `projects/qa/matrix.md` cite line numbers in a now-split file:
+- `sandbox_agent.ts:875` (F-001, append_system) - file was refactored into
+  `services/agent/src/engines/sandbox_agent/` (run-plan, pi-assets, model, mcp, etc.).
+- `sandbox_agent.ts:961` (F-007, applyModel) - now `engines/sandbox_agent/model.ts` +
+  `applyModel`.
+- `sandbox_agent.ts:933-949` (F-009, MCP) - now `engines/sandbox_agent/mcp.ts`.
+These still point at the right concepts but the wrong locations. A QA-owner pass should refresh
+them. I cite the new files in the docs I own.
+
+## Open question: is `agenta` harness genuinely first-class on sandbox-agent, or pi-with-extras?
+
+The runner maps `harness: "agenta"` to `acpAgent = "pi"` and layers forced skills + prompt
+extras (`run-plan.ts:78`). So on sandbox-agent, `agenta` is "pi ACP agent + Agenta forced
+config", not a distinct ACP agent. I described it that way. Confirm this is the intended
+long-term model (vs. a real `agenta` ACP agent) before the agent-template doc hardens it.
+
+## Open question: model override on sandbox-agent Pi
+
+QA F-007 says pi-acp accepts only `default` for the model category, so a real model id is
+silently dropped on the Pi-over-sandbox-agent path. I documented this as a current gap in
+architecture.md and ground-truth.md. I did NOT independently re-verify against pi-acp source
+(it lives in the `sandbox-agent` npm package, not this repo). If you can confirm whether pi-acp
+exposes any non-default model channel, that resolves whether F-007 is "wire it" or "fail loud".
+
+## Open question: sidecar.md vs folding into architecture.md
+
+I folded the sidecar story into `architecture.md` (sections "The Sidecar", "Licensing and
+images", "Daytona sandbox") rather than creating `documentation/sidecar.md`. Reason: `README.md`
+(not mine to edit) lists the doc reading order and has no `sidecar.md` entry; a new unreferenced
+file would be a dangling doc. If you prefer a dedicated `sidecar.md`, move those three sections
+out and add a README link. The content is self-contained enough to lift cleanly.
+
+## Open question: `LocalBackend` plan path
+
+`sdks/python/agenta/sdk/agents/adapters/local.py:16` points readers to
+`docs/design/agent-workflows/scratch/sdk-local-backend/plan.md`. After the restructure that
+content is at `docs/design/agent-workflows/archive/sdk-local-backend/` (and the active
+workstream is `projects/sdk-local-tools/`). The code comment's doc path is now wrong. That is a
+code comment, not a doc I own, so I left it. RECOMMEND a one-line fix in `local.py` to the new
+path, or to `projects/sdk-local-tools/`.
+
+## Not verified live
+
+I did not run the stack. All claims about runtime behavior are read from code plus the existing
+QA captures (`projects/qa/findings.md`, `projects/qa/matrix.md`,
+`scratch/feature-matrix-test.md`). The most load-bearing un-rerun claims:
+- system-prompt delivery on Daytona (read from `daytona.ts` + `pi-assets.ts`; QA F-001 verified
+  local and Daytona on 2026-06-20).
+- `InMemorySessionPersistDriver` not surviving across turns (read from the cold per-`/run`
+  lifecycle in `engines/sandbox_agent.ts`; no cross-process store is constructed).
+
+## Minor: SDK `interfaces.py` docstring lists only Pi/Claude harnesses
+
+`sdks/python/agenta/sdk/agents/interfaces.py:14-15` names `PiHarness` / `ClaudeHarness` but not
+`AgentaHarness`. Cosmetic staleness in a code docstring (not a doc I own). Worth a one-word fix
+when someone touches that file.

--- a/docs/design/agent-workflows/scratch/notes-config-runsh.md
+++ b/docs/design/agent-workflows/scratch/notes-config-runsh.md
@@ -1,0 +1,84 @@
+# Scratch notes: agent configuration and run.sh
+
+Working notes from documenting agent configuration and run.sh on 2026-06-23. Open questions,
+things I could not verify, and the search for the "morning research."
+
+## The morning research on run.sh: NOT FOUND
+
+I could not find the lost run.sh research from "this morning." Here is what I checked and
+ruled out:
+
+- Searched all scratchpad dirs under `/tmp/claude-1000/`. Only reorg artifacts there
+  (`reorg_paths.txt`, `reorg-pr-body.md`), nothing about run.sh.
+- Searched `~/.claude/` and `~/.codex/memories/`. Nothing run.sh specific.
+- Searched the agent-workflows docs tree for `run.sh`. Only incidental hits in archive WP
+  docs (for example `archive/wp-2-agent-service/implementation-plan.md:230` mentions
+  `./hosting/docker-compose/run.sh --oss --dev --build`). No dedicated run.sh research doc.
+- Checked the worktree `.claude/worktrees/agent-a438aa3a2fe3880c0/`. Its `run.sh` is
+  byte-identical to main. It does have edits to `hosting/AGENTS.md`, `hosting/CLAUDE.md`, and
+  `docs/packs/hosting.md`, but those are about run.sh usage, not a research doc, and they
+  match what is already on the main checkout.
+- `git log` shows no recent commit titled like run.sh research.
+
+Conclusion: if the morning research exists, it is in a session transcript or an
+unsaved buffer, not on disk in this repo or the scratchpads I can read. I wrote
+`running-the-agent.md` from the actual scripts instead. If the research turns up, fold it in
+and reconcile against that doc.
+
+## The run-sh skill is stale
+
+`.claude/skills/run-sh/SKILL.md` documents an older flag set. It mentions `--stage`, `--gh`
+as a stage alias, `--ssl`, and `--web-domain`. The current `hosting/docker-compose/run.sh`
+uses `--image gh|dev`, `--local`, `--down`, `--web-mode`, `--web-url`, and derives the stage
+internally. The skill's "Defaults" and "Options" sections do not match the script. I noted
+this in `running-the-agent.md` and pointed readers at the script and `docs/packs/hosting.md`.
+
+Open question: should someone update the run-sh skill to match the current script? Out of
+scope for this task (skill files are not mine to edit here), but worth a follow-up.
+
+## There is no agent-specific run.sh
+
+Confirmed. The only `run.sh` scripts in the repo are
+`hosting/docker-compose/run.sh` and `hosting/kubernetes/run.sh` (plus the worktree copies).
+The agent runs as the `sandbox-agent` compose service, started by the docker-compose run.sh
+with everything else. The Node runner's own entrypoints are `pnpm run serve` and
+`pnpm run run:cli`, not a shell script.
+
+## Config: things I am confident about
+
+- Three distinct `AgentConfig`-named objects. Schema (`AgentConfigSchema`, types.py:1065),
+  neutral runtime (`dtos.py:308`), file-default dataclass (`config.py:30`). All verified.
+- The "loose runtime" belief needs a caveat. The neutral `AgentConfig` is NOT `extra="allow"`.
+  Its `model_config` is `populate_by_name=True`. The looseness is in before-validators and
+  `from_params` multi-shape coercion, plus the file-default dataclass `tools: List[Any]`. I
+  documented it this way. If the memory note meant "permissive about input shapes," that is
+  right. If it meant "open Pydantic model," that is wrong.
+- `skills` and `persona` are not author config. They are forced injections of the Agenta
+  harness only. No schema field, no neutral-config field, no playground control.
+- `permission_policy` is only read by the Claude harness. Decorative for pi and agenta.
+
+## Config: open questions and unverified items
+
+- I relied on a subagent for the exact FE line numbers in `AgentConfigControl.tsx`,
+  `SchemaPropertyRenderer.tsx`, and the molecule/store/api enrichment chain. The file paths
+  are confirmed to exist, but I cite the FE line numbers as "around line N" because I did not
+  open every FE file myself. If precise FE line numbers matter, re-verify
+  `web/packages/agenta-entity-ui/src/DrillInView/SchemaControls/`.
+- `_DEFAULT_AGENT_MODEL` is `"gpt-5.5"` per the subagent (types.py:1057). I did not open that
+  exact line. Low risk, but flag it.
+- The `harness_options` escape hatch (Pi `system`/`append_system`) is on the neutral config
+  but absent from `AgentConfigSchema`. So the playground cannot set it through the standard
+  form. I documented this as a quirk. Worth confirming whether any UI path sets it at all, or
+  whether it is API-only today.
+- `AGENTA_AGENT_ENABLE_MCP` defaults to `false`. So MCP servers in the config are accepted by
+  the schema and form but not resolved unless the flag is on. This is a wired-but-gated case.
+  I mentioned it in both docs. Confirm the exact gate location in
+  `services/oss/src/agent/tools/` if precise behavior matters.
+
+## Cross-references the new docs assume
+
+- `agent-template.md` already documents the request surface fields and the missing-work list.
+  My `agent-configuration.md` complements it with the live FE-to-runtime path. No overlap
+  edits needed; I left `agent-template.md` unchanged because it was already accurate.
+- `tools.md`, `architecture.md`, `ports-and-adapters.md`, `sessions.md` are owned by other
+  agents. I only reference them, I did not edit them.

--- a/docs/design/agent-workflows/scratch/notes-model-auth.md
+++ b/docs/design/agent-workflows/scratch/notes-model-auth.md
@@ -1,0 +1,295 @@
+# Notes: current model / provider / auth code (agent-workflows)
+
+Review date: 2026-06-23. Reviewer: subagent, read-only.
+Scope: is the model/provider/auth code that exists RIGHT NOW correct? Findings cite real
+`file:line`. "Current reality" is what the code does today. "Proposed" is the
+`provider-model-auth/` redesign (not yet built).
+
+## Overall verdict
+
+The current path **works for the happy case** (one provider key per project, the chosen
+model's provider key present in the vault) but is **not correct as a security or
+multi-account design**. Two real problems stand out:
+
+1. It injects the **entire project vault** of provider keys into the harness on every run,
+   not the one key the chosen model needs. (over-broad credential exposure)
+2. There is **no provider concept** anywhere. The model is a bare string. Key selection is
+   "dump them all and hope the harness picks the right one." No provider routing, no
+   account selection, no custom endpoint.
+
+Per-user/per-request scoping is **correct** (authorization is resolved per request, never
+cached globally). Model override is **mostly correct** (it is applied and verified, with a
+labelled fallback), not silently dropped. So the redesign is justified, but the current code
+is not catastrophically broken; it is the loose, single-account MVP the redesign tightens.
+
+---
+
+## How the model is chosen and passed (Q1)
+
+**Current reality: a bare string, no provider concept, applied post-hoc with fallback.**
+
+- Config default `model` is a plain string, e.g. `"gpt-5.5"`
+  (`services/oss/src/agent/config.py:21`, `:70-76`). `AgentConfig.model: Optional[str]`
+  (`sdks/python/agenta/sdk/agents/dtos.py:323`). No `provider` field anywhere in the agent
+  config or DTOs (grep for `ModelSpec`/`provider` in `sdk/agents/*.py` finds only tool
+  providers and the `provider_key` vault kind, never a model provider).
+- The string flows: request `parameters.agent.model`
+  (`dtos.py:687` `_parse_agent_fields`) -> `AgentConfig.model` -> harness adapter copies it
+  verbatim into `PiAgentConfig.model` / `ClaudeAgentConfig.model`
+  (`adapters/harnesses.py:65`, `:90`, `:114`) -> wire field `"model"`
+  (`utils/wire.py:50`) -> TS `request.model` (`services/agent/src/protocol.ts:210-211`).
+- The runner applies it AFTER the session exists with `applyModel`
+  (`services/agent/src/engines/sandbox_agent.ts:205`,
+  `engines/sandbox_agent/model.ts:46-70`): it calls `session.setModel(wanted)`, and on
+  failure parses the harness's allowed-values error and tries a suffix match
+  (`model.ts:7-16`). If nothing matches, it logs and returns `undefined`, and **the harness
+  keeps its own default model** (`model.ts:67-69`).
+
+**Is there any provider concept? No.** The only place "provider" enters model routing is an
+implicit harness->key-var guess in the runner: `harnessKeyVar = acpAgent === "claude" ?
+"ANTHROPIC_API_KEY" : "OPENAI_API_KEY"` (`engines/sandbox_agent/run-plan.ts:91`). That guess
+is used only to compute `hasApiKey` (whether to upload Pi's OAuth fallback), not to select
+which key to inject. So a Pi run targeting a Gemini or Anthropic model still gets every key
+dumped and relies on the harness to pick.
+
+Verdict: **correct enough for single-provider use, structurally wrong for routing.** The
+model is "provider-blind." A model like `claude-opus-4-8` selected under the Pi harness has
+no path that says "this needs the Anthropic key"; it works only because the Anthropic key is
+in the dumped env anyway.
+
+---
+
+## How credentials are resolved and injected (Q2)
+
+**Current reality: whole-vault dump. Over-broad. Confirmed end-to-end.**
+
+Resolution (Python, service side):
+
+- `app.py:83` calls `resolve_secrets()` with no arguments.
+- `resolve_secrets` == `resolve_provider_keys`
+  (`sdks/python/agenta/sdk/agents/platform/resolve.py:35`,
+  `platform/secrets.py:105-141`).
+- It does `GET /secrets/` (`platform/secrets.py:121`), iterates **every** secret in the
+  response, and for each `kind == "provider_key"` maps the provider kind to an env var via
+  `_PROVIDER_ENV_VARS` and collects `{ENV_VAR: key}` (`secrets.py:132-141`). The chosen
+  `model` is **never passed in and never consulted**. There is no model or provider filter.
+- Dedup is "first wins": `env.setdefault(env_var, key)` (`secrets.py:140`). So two OpenAI
+  keys -> the second is silently dropped (matches the redesign's "duplicate-key landmine,"
+  though the line moved from the old `agent/secrets.py:71` into `platform/secrets.py:140`).
+
+Backend side, what `GET /secrets/` returns:
+
+- `list_secrets` (`api/oss/src/apis/fastapi/vault/router.py:101-141`) returns the **entire
+  project vault** as `List[SecretResponseDTO]`, scoped only by
+  `request.state.project_id`, cached per project. No model/provider filter parameter exists.
+- The values are **decrypted**: `VaultService.list_secrets` runs under
+  `set_data_encryption_key(...)` (`api/oss/src/core/secrets/services.py:52-59`) and the DTO
+  carries the plaintext `provider.key` (`api/oss/src/core/secrets/dtos.py:17-23`,
+  `StandardProviderSettingsDTO.key: str`). So the agent service pulls every plaintext
+  provider key for the project on every run.
+
+Injection into the harness (TS runner):
+
+- The full `secrets` map rides the `/run` wire as `secrets: Record<string,string>`
+  (`utils/wire.py:52`, `protocol.ts:194-195`).
+- sandbox-agent backend: `Object.assign(env, plan.secrets)` puts **all** keys into the local
+  daemon env (`services/agent/src/engines/sandbox_agent.ts:119`). For Daytona, the same map
+  is spread into the sandbox env vars (`engines/sandbox_agent/daytona.ts:33-39`,
+  `buildSandboxProvider` passes `plan.secrets` at `provider.ts:34`). The harness process
+  therefore sees OpenAI + Anthropic + Gemini + ... keys regardless of the model it runs.
+
+**Severity: HIGH.** A run for an OpenAI model still has the project's Anthropic, Gemini,
+Groq, OpenRouter, etc. keys in its environment. A compromised or prompt-injected harness, a
+custom code-tool subprocess, or a misbehaving MCP server can read all of them. This is the
+single most important current-correctness/security issue. Evidence:
+`platform/secrets.py:132-141`, `sandbox_agent.ts:119`, `daytona.ts:33-39`,
+`vault/router.py:130`.
+
+**One thing that IS correctly scoped:** code-tool and MCP env get only their **named**
+secrets via `resolve_named_secrets` (`POST /secrets/resolve`,
+`platform/secrets.py:29-78`), restricted to the requested set (`secrets.py:72-78`). That
+path is least-privilege. The over-broad behavior is specifically the **provider-key**
+(model auth) path, not the tool-secret path.
+
+---
+
+## Per-user vs global auth (Q3)
+
+**Current reality: correct. Per-request, never global.**
+
+- The backend credential is resolved per request: `PlatformConnection.authorization()`
+  resolves lazily on each call, never caches (`platform/connection.py:108-110`, `:131-133`),
+  and reads `inject({}).get("Authorization")` (`connection.py:86-93`).
+- `inject` reads `TracingContext.get()` (`sdks/python/agenta/sdk/engines/tracing/
+  propagation.py:74`, `:94-96`), which is a request-scoped context (ContextVar), so one
+  caller's Authorization does not bleed into another's run. The fallback to the process
+  `AGENTA_API_KEY` (`connection.py:95-97`) is the standalone-SDK case (the env key is the
+  user's own).
+- The backend enforces project scope from `request.state.project_id`, not from the body
+  (`vault/router.py:130-132`). EE adds an explicit `VIEW_SECRET` permission check
+  (`vault/router.py:103-115`). So a caller only ever reads their own project's vault.
+
+The `list_secrets` cache is keyed by `project_id` (`vault/router.py:117-139`), which is a
+project-scoped cache, not a cross-user leak.
+
+**Caveat (runner-side, not backend-side):** the in-process Pi engine mutates
+**process-global** `process.env` to inject keys, but it serializes runs and restores prior
+env in a `finally` (`services/agent/src/engines/pi.ts:69-99`), so request A's vault keys do
+not leak into request B. That is correct as written. The risk there is the inherited
+baked-in dev key (see Q5, finding 3), not cross-request vault leakage.
+
+Verdict: **per-user/per-request auth is implemented correctly.** This is a current behavior
+to PRESERVE.
+
+---
+
+## Claude vs Pi auth differences (Q4)
+
+**Current reality: API-key first, OAuth/login fallback. Mostly correct, some sharp edges.**
+
+- The runner copies a fixed allowlist of provider auth from the sidecar process env into the
+  daemon env: `OPENAI_API_KEY`, `ANTHROPIC_API_KEY`, `ANTHROPIC_AUTH_TOKEN`,
+  `CLAUDE_CODE_OAUTH_TOKEN`, `CLAUDE_CONFIG_DIR`, `GEMINI_API_KEY`
+  (`services/agent/src/engines/sandbox_agent/daemon.ts:78-88`). Vault keys are then overlaid
+  on top (`sandbox_agent.ts:119`). So Claude can authenticate via `ANTHROPIC_API_KEY` (vault
+  or baked) or a subscription token (`CLAUDE_CODE_OAUTH_TOKEN`/`ANTHROPIC_AUTH_TOKEN`) baked
+  into the sidecar.
+- Pi auth: if no provider key is available for the harness's key var
+  (`hasApiKey = !!secrets[harnessKeyVar]`, `run-plan.ts:113`), the Daytona path uploads the
+  dev's local Pi OAuth login (`auth.json` + `settings.json`) into the sandbox
+  (`engines/sandbox_agent/daytona.ts:88-105`, `:127`). Local runs use the host's
+  `PI_CODING_AGENT_DIR` login (`daemon.ts:71-74`).
+- **File-based auth that rotates:** the redesign's research is right that Pi/Claude rotate
+  their OAuth credential files. Today the code uploads a **snapshot** of `auth.json`
+  (`daytona.ts:90-101`). For a short-lived Daytona run this is fine, but it is a frozen
+  copy; it is never written back, and if the token has expired it is stale. This is a known
+  limitation, not a crash. Severity: LOW-MEDIUM (only the self-managed-OAuth-in-sandbox
+  case).
+
+Verdict: **functionally correct for API-key auth.** The OAuth-file-snapshot upload is the
+weak spot the redesign's `source: runtime` / "never store the rotating file" addresses.
+
+---
+
+## Concrete current-correctness risks (Q5), prioritized
+
+### R1 - Whole-vault provider-key dump (over-broad exposure). Severity: HIGH.
+Every project provider key is decrypted and injected into the harness env on every run,
+regardless of the chosen model.
+Evidence: `platform/secrets.py:132-141` (no model filter, returns all provider_key envs),
+`sandbox_agent.ts:119` / `daytona.ts:33-39` (all keys into the run env),
+`vault/router.py:130` (`GET /secrets/` returns the whole project vault, decrypted via
+`core/secrets/services.py:52-59`).
+Fix in redesign: `ResolvedModelAccess.env` carries one provider's vars only; service-side
+`POST /vault/model-access/resolve` replaces the dump.
+
+### R2 - No provider concept / provider-blind model routing. Severity: MEDIUM-HIGH.
+The model is a bare string with no provider. Nothing maps "model X needs provider Y's key."
+It works only because R1 dumps every key. Selecting a non-default-provider model under a
+harness has no first-class routing; it depends on the harness's own resolution plus the
+dumped env.
+Evidence: `AgentConfig.model: Optional[str]` (`dtos.py:323`); the only provider inference is
+the harness-name guess `run-plan.ts:91`; `applyModel` is a post-hoc `setModel` with a string
+suffix match (`model.ts:7-16`, `:46-70`).
+Fix in redesign: `ModelSpec { provider, model, params }` committed in the config; provider is
+first-class and the resolver matches account provider to model provider.
+
+### R3 - Inherited provider env is not cleared before applying the plan. Severity: MEDIUM.
+On the sandbox-agent path the daemon env starts with the sidecar's baked provider keys
+(`daemon.ts:78-88`), and vault keys are overlaid (`sandbox_agent.ts:119`). A baked dev key
+for a provider the vault does NOT have stays visible to the run. There is no clear-then-apply
+step on this path. (The in-process Pi engine DOES restore/delete per run at `pi.ts:80-92`,
+but only for the keys present in `secrets`; a baked key absent from `secrets` is untouched.)
+Evidence: `daemon.ts:78-88`, `sandbox_agent.ts:119`, contrast `pi.ts:69-99`.
+Fix in redesign: security non-negotiable #5, "clear inherited provider env before applying."
+
+### R4 - Duplicate keys for one provider: first silently wins (no forced choice). Severity: LOW-MEDIUM.
+`env.setdefault(env_var, key)` means a project with two OpenAI keys silently uses the first
+encountered. The completion path does the opposite (last wins,
+`sdks/python/agenta/sdk/managers/secrets.py` provider loop), so the two paths disagree.
+Evidence: `platform/secrets.py:140`.
+Fix in redesign: multi-account by slug; error (do not guess) when multiple accounts and no
+default/binding.
+
+### R5 - Silent model fallback can mislead (degraded, not data-incorrect). Severity: LOW.
+When `setModel` cannot honor the requested model, the run proceeds on the harness's default
+model. This is intentional and is handled honestly for tracing: `applyModel` returns
+`undefined` and the chat span is labelled generically rather than claiming the requested
+model (`sandbox_agent.ts:202-205`, `:209`; `model.ts:67-69`). So it is NOT a silent
+mislabel. But the user still gets a different model than asked, with only a stderr log
+(`model.ts:67`). Not surfaced to the caller. This is a UX/observability gap, not a
+correctness bug. Note: this is the opposite of "silently-dropped model override claimed as
+applied"; the code is careful here.
+
+### R6 - `AGENTA_CRYPT_KEY` defaults to `"replace-me"`. Severity: HIGH if shipped, but PRE-EXISTING / OUT OF SCOPE.
+`api/oss/src/utils/env.py:410`. The vault data-encryption key has a weak default. Not
+introduced by the agent feature; flagged by the redesign too (security non-negotiable #8).
+Call out for a separate security follow-up.
+
+---
+
+## What is already CORRECT and should be preserved
+
+- **Per-request, per-user authorization** (Q3). Lazy, never cached, request-scoped context,
+  project scope from `request.state`, EE permission check. `connection.py:108-133`,
+  `propagation.py:74/94`, `vault/router.py:103-132`.
+- **Named tool/MCP secret resolution is already least-privilege** (only requested names,
+  restricted to the requested set). `platform/secrets.py:29-78`. The model-auth path should
+  move to this same shape.
+- **Honest model labelling on fallback** (R5): the trace does not claim a model the harness
+  did not run. `sandbox_agent.ts:202-205`, `model.ts:67-69`. Preserve this.
+- **In-process Pi env restore discipline**: serialized runs + `finally` restore prevent
+  cross-request vault-key leakage. `pi.ts:69-99`. The redesign should keep this and extend
+  it to clear-then-apply.
+- **Best-effort optionality**: an empty vault is valid (the harness falls back to its own
+  login); a vault outage returns empty rather than failing the run.
+  `platform/secrets.py:109-130`. Keep this for the self-managed (`source: runtime`) case.
+- **The three-way split already exists in the ports** (agent identity / harness config /
+  runtime). `RunSelection` is deliberately not part of the neutral `AgentConfig`
+  (`dtos.py:364-387`). The redesign's `ModelSpec` (committed) vs `ModelAccessBinding` (on the
+  run) lands cleanly on this existing seam.
+
+---
+
+## How the redesign maps to the current problems
+
+| Current problem (this doc) | Redesign fix |
+| --- | --- |
+| R1 whole-vault dump | `ResolvedModelAccess.env` = one provider's vars; `POST /vault/model-access/resolve` replaces `resolve_provider_keys` |
+| R2 provider-blind model string | `ModelSpec { provider, model, params }` committed; provider first-class; provider-match security rule |
+| R3 inherited env not cleared | security non-negotiable #5: clear-then-apply on the runner |
+| R4 first-wins dedup | multi-account by slug; error on ambiguity, no guessing |
+| R5 silent model fallback | `getModel(provider, id)` exact match, no silent fallback (Pi/Codex/Claude table) |
+| R6 weak crypt key default | explicitly flagged, OUT OF SCOPE (same call as this doc) |
+| OAuth file snapshot (Q4) | `source: runtime` self-managed; never store the rotating file |
+
+Behaviors the redesign explicitly preserves (and so should NOT regress): per-request auth,
+the additive nature (prompts/completions untouched), best-effort optionality, the
+agent-config-vs-run split.
+
+---
+
+## Doc-vs-code drift to be aware of (for whoever implements)
+
+The redesign's `status.md` / `design.md` cite OLDER line numbers, because the code was
+refactored after those docs were written:
+- "`services/oss/src/agent/secrets.py:71`" (first-wins dedup) is now
+  `sdks/python/agenta/sdk/agents/platform/secrets.py:140`. The service `secrets.py` is now a
+  thin re-export (`services/oss/src/agent/secrets.py:1-12`).
+- "`services/agent/src/engines/sandbox_agent.ts:309` / `:530`" (env copy / Daytona spread)
+  are now split into `engines/sandbox_agent/daemon.ts:78-88` (process-env copy),
+  `sandbox_agent.ts:119` (vault overlay), and `engines/sandbox_agent/daytona.ts:33-39`
+  (Daytona spread).
+- "`services/oss/src/agent/secrets.py:26-35`" (provider->env map, "incomplete and partly
+  dead") is now `_PROVIDER_ENV_VARS` at `platform/secrets.py:93-102`.
+The substance of every claim still holds against the current code; only the locations moved.
+
+## Open questions for the user
+
+1. Is the whole-vault dump (R1) acceptable as a stopgap until the resolver lands, or should
+   a quick model-scoped filter be patched in first? A minimal fix is feasible without the
+   full redesign: filter `resolve_provider_keys` to the chosen model's provider env var.
+2. R3 (clear inherited env) and R6 (`replace-me` crypt key) are security items independent of
+   the resolver redesign. Should they be split into their own fix now?
+3. Is the OAuth-file snapshot upload (`daytona.ts`) used in any shipping path, or only the
+   dev Daytona POC? If only POC, R4/OAuth concerns are lower urgency.

--- a/docs/design/agent-workflows/scratch/notes-tools-mcp-capabilities.md
+++ b/docs/design/agent-workflows/scratch/notes-tools-mcp-capabilities.md
@@ -1,0 +1,309 @@
+# Notes: tools, MCP, code tools, sandbox capabilities
+
+Scratch findings + recommendations. Investigation date 2026-06-23. Everything below is cited
+to `file:line` against the working tree. Marks: VERIFIED (read the code), STALE (memory hint
+that no longer holds), DEAD (code exists but nothing reaches it).
+
+## TL;DR verdict
+
+- **Builtin tools**: live. Pi-only. A bare name added to the session allowlist.
+- **Gateway (callback) tools**: live on every path (in-process Pi, Pi-over-ACP, Claude-over-MCP,
+  local + Daytona). This is the real, exercised tool path.
+- **Code tools**: live and reachable. `python3` IS in the prod image now (the old ENOENT is
+  fixed). Caveat: the child env is a tight allowlist, so a code tool that imports a third-party
+  package will fail (no pip/venv, no inherited env).
+- **Client tools**: plumbed end to end on the runner side (throws in-sandbox, emitted as
+  `interaction_request`), but full browser fulfillment is a frontend-egress concern, not
+  verified here as working UI.
+- **User MCP servers** (`mcp_servers` config): effectively dead on the deployed path.
+  Gated OFF by `AGENTA_AGENT_ENABLE_MCP` (default false) at the service, AND gated off for Pi
+  in the runner. So today it reaches nobody by default, and even with the flag on it reaches
+  Claude only. Pi/agenta is the default harness, so in practice user MCP is dead.
+- **Sandbox-side MCP machinery** (`mcp-server.ts` + the `agenta-tools` synthetic server in
+  `mcp-bridge.ts`): only used to deliver GATEWAY/CODE tools to a non-Pi (Claude) harness that
+  reports `mcpTools`. It is NOT used for user `mcp_servers`. It is reachable only on the Claude
+  path. On the default Pi path it is never launched.
+- **Capability advertisement**: `HarnessCapabilities` exists in the wire, is probed in the
+  runner, gates tool delivery internally, and is returned on the `/run` result. But it is a
+  DEAD read on the consume side: parsed into `AgentResult.capabilities` (`dtos.py:297`,
+  `wire.py:87`) and then never read by the service, `/inspect`, or the frontend. `/health`
+  advertises `engines`/`harnesses` but NOT capabilities.
+
+## End-to-end trace (deployed = sandbox-agent path)
+
+Config -> service resolution -> wire -> runner -> harness.
+
+### 1. Config (SDK)
+
+`AgentConfig.tools` is a list of 4 discriminated configs: `builtin` / `gateway` / `code` /
+`client` (`sdks/python/agenta/sdk/agents/tools/models.py:22-77`). `AgentConfig.mcp_servers`
+is a SIBLING field, not a tool type (`sdks/python/agenta/sdk/agents/mcp/models.py`).
+
+Three orthogonal axes per tool: `type`/`kind` (executor), `needs_approval`, `render`
+(`models.py:22-29` ToolConfigBase; `protocol.ts:52-76`).
+
+"4 executors" = `builtin` (a name, not a spec) + 3 spec kinds: `callback` / `code` / `client`
+(`models.py:131-153`). NOTE: the resolved `kind` for a gateway tool is **`callback`**, not
+`gateway`. There is no `gateway` kind on the wire. The config `type` `gateway` -> resolved
+`kind` `callback` (`resolver.py:162-167`, `models.py:131-137`).
+
+### 2. Service resolution
+
+`services/oss/src/agent/app.py:78-80`:
+```
+resolved_tools = await resolve_tools(agent_config.tools)
+resolved_mcp   = await resolve_mcp_servers(agent_config.mcp_servers)
+```
+Both are thin re-exports of SDK platform entrypoints. The service files are now shims:
+- `services/oss/src/agent/tools/resolver.py` re-exports `resolve_tools` and adds the MCP gate.
+- `gateway.py`, `secrets.py`, `__init__.py` are re-export shims to
+  `agenta.sdk.agents.platform.*`.
+
+Real resolution: `sdks/python/agenta/sdk/agents/platform/resolve.py:40-65` ->
+`ToolResolver.resolve` (`sdks/python/agenta/sdk/agents/tools/resolver.py:102-177`).
+
+Per type:
+- `builtin` -> name lands in `builtin_names`, no network (`resolver.py:103-107`).
+- `code` -> declared `secrets` resolved by name via the named-secret provider, injected into
+  spec `env` (`resolver.py:124-154`). Script not run here.
+- `client` -> pass-through to `ClientToolSpec` (`resolver.py:156-159`).
+- `gateway` -> `AgentaGatewayToolResolver` posts to API `/tools/resolve`, gets a `call_ref`
+  slug, wraps in `CallbackToolSpec` + one `ToolCallback` -> `/tools/call`
+  (`resolver.py:161-167`; gateway impl now in `platform/gateway.py`).
+
+MCP gate (THE key gate): `services/oss/src/agent/tools/resolver.py:22-37`. If
+`AGENTA_AGENT_ENABLE_MCP` not truthy -> returns `[]`. Default off. So `resolved_mcp` is empty
+by default and `mcpServers` is omitted from the wire.
+
+### 3. Wire
+
+`request_to_wire` -> `mcpServers` only when non-empty (`utils/wire.py:54-56`, gated by
+`config.wire_mcp()`). `customTools` = resolved specs, `toolCallback` = the callback,
+`tools` = builtin names. Wire contract: `protocol.ts` (TS) mirrored by `utils/wire.py`.
+
+### 4. Runner delivery (the fork)
+
+Engine selected by `server.ts:38-49`: default `sandbox-agent`, request `backend:"pi"` picks
+the in-process engine. Deployed = `sandbox-agent` (`runSandboxAgent`).
+
+Delivery decision in `engines/sandbox_agent/mcp.ts:50-75` (`buildSessionMcpServers`):
+- If `isPi` OR `!capabilities.mcpTools` -> return `[]` (no MCP servers attached). For Pi this
+  means NO MCP at all (neither agenta-tools nor user servers). Tools for Pi are delivered the
+  Pi-native way via the extension, NOT through this function.
+- Else (Claude, `mcpTools` true) -> attach `buildToolMcpServers(...)` (the synthetic
+  `agenta-tools` server carrying gateway/code specs) + `toAcpMcpServers(userMcpServers)`.
+
+So:
+- **Pi-native delivery**: the bundled extension (`extensions/agenta.ts:38-75`) reads
+  `AGENTA_TOOL_PUBLIC_SPECS` + `AGENTA_TOOL_RELAY_DIR` and calls `pi.registerTool` per spec.
+  Execution goes through `runResolvedTool` (`tools/dispatch.ts:104`) -> relay file ->
+  runner-side `startToolRelay` (`tools/relay.ts:121`) -> `/tools/call` (gateway) or local
+  `python3`/`node` (code). The extension env carries PUBLIC metadata only; private specs/auth
+  stay in runner memory (`pi-assets.ts:31-50`).
+- **Claude MCP delivery**: `mcp-bridge.ts:63` builds the `agenta-tools` ACP stdio server;
+  `mcp-server.ts` is the bridge process; it relays calls back via `runResolvedTool` with a
+  `relayDir`. User `mcp_servers` (if the flag were on) would be ADDITIONAL ACP stdio servers
+  via `toAcpMcpServers` (`mcp.ts:15-36`), but pi-acp does not forward those and they are
+  gated off for Pi.
+
+### 5. In-process engine (reference only)
+
+`engines/pi.ts:150-198` (`buildCustomTools`) branches on kind directly: code -> local
+subprocess, callback -> `/tools/call`, client -> skipped. Ignores `request.mcpServers`
+ENTIRELY (`PI_CAPABILITIES.mcpTools = false`, `pi.ts:60`). Not the deployed path.
+
+## What is live / gated / dead, with evidence
+
+| Thing | State | Evidence |
+| --- | --- | --- |
+| Builtin tools (Pi) | LIVE | `resolver.py:103-107`; allowlist `pi.ts:280-283` |
+| Gateway/callback tools | LIVE all paths | `callback.ts:32`; relay `relay.ts:103-112`; Pi ext `agenta.ts:60-71` |
+| Code tools | LIVE; `python3` in image | `code.ts:115`; `Dockerfile:27` installs `python3` |
+| Client tools | PLUMBED (runner); FE unverified | throws `dispatch.ts:112-115`; filtered `mcp-server.ts:63`, `public-spec.ts:17` |
+| User `mcp_servers` | GATED OFF (default) + Pi-dead | service gate `resolver.py:22-37`; runner gate `mcp.ts:61` |
+| `agenta-tools` synthetic MCP server | LIVE only on Claude path | `mcp-bridge.ts:63`, `mcp-server.ts`; never built for Pi `mcp.ts:61` |
+| `HarnessCapabilities` probe | LIVE in runner, gates delivery | `capabilities.ts:42-52`, used `sandbox_agent.ts:183-193` |
+| `result.capabilities` consume | DEAD | parsed `wire.py:87`/`dtos.py:297`, read by nobody downstream |
+| `needs_approval` | Claude-only honored | responder `responder.ts`; Pi no-op |
+| `render` | runner copies hint; FE projection partial | `protocol.ts:133-136`, copied onto events |
+
+## STALE memory hints, corrected
+
+- "missing python3 in the agent image (python code tools ENOENT)" -> STALE/FIXED. The prod
+  Dockerfile installs `python3` (`services/agent/docker/Dockerfile:26-28`) with a comment that
+  names exactly this failure mode. Code tools with `runtime: python` work in the prod image.
+  (Caveat below: only the interpreter, no third-party packages.)
+- "stale Pi extension bundle (custom tools silently undelivered on rivet)" -> partially
+  current as a CLASS of risk. The extension is a baked esbuild bundle
+  (`pi-assets.ts:24-25`, `Dockerfile:48`). If the image is built without `build:extension`,
+  or `SANDBOX_AGENT_EXTENSION_BUNDLE` points at a stale file, tools silently do not register
+  (`installPiExtensionLocal` logs and returns, `pi-assets.ts:53-65`). The prod Dockerfile does
+  run `build:extension`, so the prod image is fine; the risk is dev/compose images that
+  override CMD or skip the build step. This is a build-hygiene risk, not a code bug.
+- "MCP gated behind AGENTA_AGENT_ENABLE_MCP, claude-only" -> VERIFIED, still true.
+
+## Real, current gaps and oddities (the "does not make sense" list)
+
+1. **User MCP is dead by default and Pi-impossible.** `AGENTA_AGENT_ENABLE_MCP` defaults off.
+   Even on, `buildSessionMcpServers` drops user MCP for Pi (`mcp.ts:61`), and Pi is the default
+   harness. So the entire `mcp_servers` config field is a silent no-op for the common case. The
+   field is accepted, serialized only when the flag is on, then dropped at the runner. This is
+   the silent-drop F-009 the harness-capabilities project is about.
+
+2. **Two MCP machineries that do different things share the word "MCP".** (a) The synthetic
+   `agenta-tools` server (`mcp-bridge.ts` + `mcp-server.ts`) is an internal TOOL DELIVERY
+   vehicle for Claude - it has nothing to do with user-declared MCP. (b) `toAcpMcpServers`
+   delivers user `mcp_servers`. Both live under "MCP" and both are off on the default path.
+   This conflation is most of the confusion.
+
+3. **`HarnessCapabilities` is half a feature.** The runner probes it and gates on it, which is
+   good, but the probe almost always falls back to the STATIC per-harness guess
+   (`capabilities.ts:24-39`) because `sandbox.getAgent(...).capabilities` is usually absent. And
+   the result it returns is read by nobody. So we pay for a probe whose only real effect is the
+   internal `mcpTools` branch, which a static `harness === "pi"` check would do identically.
+
+4. **Code tools cannot import packages.** `buildChildEnv` (`code.ts:99-108`) gives the child
+   only PATH/HOME/locale/temp + the tool's own secrets. The image has `python3` and `node` but
+   no `pip install`/`npm install` of arbitrary deps at tool time, and no `NODE_PATH` to the
+   runner's `node_modules`. So a code tool is limited to the stdlib. Fine for glue, surprising
+   for anything real. Worth documenting as a constraint, not necessarily removing.
+
+## Removal proposal: take user-MCP out of the sandbox
+
+User said: "the way we implement it does not make sense; remove it at least from the sandbox."
+Reading: remove the user-declared MCP plumbing from the sandbox-agent runner (NOT the
+gateway/code tool delivery, which happens to also use an MCP server for Claude). Below is a
+precise, code-free plan (other sessions own the code; this is a plan).
+
+### What is safe to remove (sandbox/runner side)
+
+The user-MCP path is small and isolated:
+
+- `services/agent/src/engines/sandbox_agent/mcp.ts`: `toAcpMcpServers` (the user-MCP -> ACP
+  stdio converter) and its call inside `buildSessionMcpServers` (the `...toAcpMcpServers(...)`
+  spread, `mcp.ts:73`). Keep `buildToolMcpServers` (that is the Claude tool-delivery vehicle).
+- The `userMcpServers` parameter threaded into `buildSessionMcpServers`
+  (`sandbox_agent.ts:189`, `mcp.ts:43,60,62`).
+- `McpServerConfig` on the wire (`protocol.ts:89-97`) and `mcpServers` on `AgentRunRequest`
+  (`protocol.ts:227`) - ONLY if we also drop the field service-side; otherwise leave the wire
+  field but stop consuming it.
+
+### What depends on it / what breaks
+
+- Nothing in the deployed path breaks, because it is already gated off
+  (`AGENTA_AGENT_ENABLE_MCP` default false). Removing it changes behavior only for someone who
+  set the flag AND used Claude AND declared `mcp_servers`. That is a near-empty set.
+- The golden wire-contract fixtures pin `mcpServers` (`services/agent/CLAUDE.md` wire rules).
+  Removing the field means updating `protocol.ts` + `utils/wire.py` + both golden fixtures +
+  both contract tests, deliberately, together. This is the only real cost.
+- `toAcpMcpServers` is re-exported (`sandbox_agent.ts:75`) and has unit tests; those go too.
+
+### Recommended shape (simplest honest end state)
+
+Two clean options. Prefer **A** if we want to keep the door open, **B** if we want it gone.
+
+**Option A - keep the field, stop pretending it works on the default path; make the drop loud.**
+Leave `mcp_servers` in config and on the wire, but:
+- Delete `toAcpMcpServers` user-MCP delivery from the runner (it only ever reached Claude, off
+  by default). 
+- Make the SERVICE reject a non-empty `mcp_servers` for a harness that cannot honor it (fail
+  loud, per the harness-capabilities proposal slice 1), instead of silently dropping at the
+  runner. This is the smallest change that removes the silent no-op.
+- Result: the sandbox no longer carries user-MCP code; the boundary tells the user "this
+  harness does not support MCP" up front.
+
+**Option B - remove user MCP entirely (config + wire + runner).**
+- Drop `AgentConfig.mcp_servers`, the `MCPResolver`, `resolve_mcp_servers`,
+  `AGENTA_AGENT_ENABLE_MCP`, the `mcpServers` wire field, `toAcpMcpServers`, and the
+  `agenta.sdk.agents.mcp` package's user-server half.
+- Keep `buildToolMcpServers`/`mcp-server.ts` (Claude tool delivery) untouched - it is not user
+  MCP.
+- Update the golden wire fixtures + contract tests in the same change.
+- Result: the only "MCP" left in the tree is the internal Claude tool-delivery server, which
+  could even be renamed away from "MCP" (e.g. `tool-bridge`) to kill the conflation.
+
+### What NOT to remove
+
+- `mcp-server.ts` / `mcp-bridge.ts` `buildToolMcpServers` / the relay: these deliver GATEWAY
+  and CODE tools to Claude. Removing them breaks tools on the Claude harness. They are
+  mislabeled (they are a tool bridge that happens to speak MCP), not dead.
+- The Pi extension tool path: that is the main tool delivery for the default harness.
+
+### My recommendation
+
+Option A now (cheap, removes the silent failure, shrinks the sandbox), Option B later if the
+product decides user-MCP is not a near-term feature. If Part 1 of the harness-capabilities
+proposal (MCP on Pi via the extension) is actually wanted, that is the OPPOSITE of removal and
+the two should not both be in flight - decide first.
+
+## Capability advertisement proposal
+
+### Current state (verified)
+
+- `/health` returns `{ status, runner, protocol, engines, harnesses }`
+  (`version.ts:27-35`). No capabilities. `HARNESSES = ["pi","claude","agenta"]` is a flat list.
+- `HarnessCapabilities` is probed per RUN inside the runner (`capabilities.ts`), used only to
+  gate tool delivery (`sandbox_agent.ts:183`), and returned on the result. The probe is mostly
+  the static fallback because the daemon rarely fills `info.capabilities`.
+- The consume side is dead: `AgentResult.capabilities` is parsed and dropped. No `/inspect`
+  surface, no FE gate, no service gate.
+- There is a substantial design already: `projects/harness-capabilities/proposal.md` argues for
+  a static per-harness capability table in `sdks/python/agenta/sdk/agents/capabilities.py`, with
+  the runtime probe as a narrowing Layer 2, surfaced via `/inspect` as a `harness_capabilities`
+  map, and a fail-loud backend reject. `capability-map.md` documents the actual web/exec/read/
+  write matrix per harness x sandbox.
+
+### What the runner SHOULD advertise (and how)
+
+Two grains, both worth having:
+
+1. **Static, run-independent, on `/health`** (the version-skew sibling). Extend `runnerInfo()`
+   so `harnesses` is not a flat list but a map: per harness, the static capability set the
+   runner believes it can drive (`mcpTools`, `permissions`, `images`, `planMode`, plus a
+   `toolDelivery` tag: `pi_native` | `acp_mcp`). This is the "what MAY run" contract a schema
+   and a form can read before any run. It is the runner half of the harness-capabilities
+   static table; pin it against the SDK table with a golden contract test (same discipline as
+   the wire contract).
+
+2. **Dynamic, per-run, on the `/run` result** (already exists as `capabilities`). Keep it, but
+   make it CONSUMED: the service should (a) compare probed vs static and log drift, (b)
+   optionally fold a small subset into the `/invoke` response or a span attribute so the
+   product can see what actually ran. Today this field is wasted.
+
+### How the service consumes it
+
+- At schema/`inspect` time: read the static map (from the SDK table, mirrored from `/health`)
+  and emit a `harness_capabilities` document so the FE can show/hide `mcp_servers`,
+  `permission_policy`, and gate `model`. This is proposal Part 2 slice 2.
+- At invoke time (fail loud): before starting the runner, reject a non-empty config field the
+  selected harness cannot honor (`mcp_servers` on pi/agenta; an unsettable `model`). This is
+  proposal Part 2 slice 1 and the single highest-value change - it converts the silent drop
+  into an honest error. It does not need the runner change to land; the SDK static table is
+  enough.
+- At result time: intersection check. If the probe reports LESS than the static table for a
+  capability the user asked for, fail or warn loudly; if MORE, log drift.
+
+### Minimal first step
+
+Land the SDK static capability table + the backend fail-loud reject (proposal slice 1). It
+needs no runner change, kills the worst silent failures (user MCP on Pi, model on sandbox-agent),
+and gives the FE something to read. The `/health` capability map and the consume-the-probe work
+are good follow-ups but not the bottleneck.
+
+## Open questions (for the user)
+
+1. Is user-declared `mcp_servers` a real near-term product feature, or scratch? If scratch,
+   Option B (remove entirely) is cleanest. If real, the right move is the harness-capabilities
+   Part 1 (MCP on Pi via extension), which is the opposite of removal. These conflict - pick one.
+2. Should the internal Claude tool-delivery server keep the name "MCP"? Renaming it (e.g.
+   `tool-bridge`) would end the conflation that makes all of this confusing. It speaks MCP on
+   the wire to the harness, but it is an Agenta tool relay, not a user MCP server.
+3. Do we want `result.capabilities` consumed at all, or should it be removed too? It is dead
+   today. Either wire it into `/inspect`/the FE (per the proposal) or drop it from the result.
+4. Code tools are stdlib-only (no package install). Is that the intended contract, or do we
+   want a provisioning story (a base image with common libs, or a per-tool deps manifest)?
+5. The capability probe is mostly the static fallback. Is it worth keeping the probe at all
+   before the daemon actually fills `info.capabilities`, or should we ship the static table now
+   and add the probe when there is real data to probe?
+</content>
+</invoke>


### PR DESCRIPTION
## What

Reconciles the agent-workflows living design docs with the actual code, and fills the
documentation gaps the old flat folder left open. Builds on the restructure (#4805).

## Living-doc corrections (all verified against code, with file:line in the prose)

- **Deployment reality:** the deployed service always runs over the sandbox-agent runner.
  The in-process Pi backend is test/reference only. The old docs implied the service picks
  between them.
- **Harness coverage:** the sandbox-agent path supports `agenta` too (`pi`, `claude`,
  `agenta`), and Pi `system` / `append_system` prompts are delivered on that path now. The
  old docs said otherwise.
- **Tools / MCP:** gateway and code tools are live on all paths; user `mcp_servers` is gated
  off (`AGENTA_AGENT_ENABLE_MCP`) and is a dead no-op for Pi (the default harness); the
  internal `agenta-tools` server is a tool-delivery vehicle for Claude, not user MCP. tools.md
  and the three adapter pages now say this plainly.
- **Sessions:** rewritten to lead with how sessions behave today (cold replay, session ids,
  `/load-session` shape with no durable store) and to separate the future session-store design.

## New living docs

- `documentation/agent-configuration.md` - the full config contract: FE playground form ->
  catalog type / service schema -> SDK interface -> runtime, with what is enforced vs loose
  and wired vs decorative per field.
- `documentation/running-the-agent.md` - how the agent service and the sandbox-agent runner
  are actually run (compose, ports, env, standalone runner).

## Findings parked in scratch/ (for review, not yet acted on)

- `dead-code-report.md` - dead/unwired code in the service, runner, and SDK (7 high-confidence).
- `notes-model-auth.md` - correctness review of the current model/provider/auth path
  (whole-vault key dump and provider-blind routing are the main risks; per-request auth
  scoping is correct).
- `notes-tools-mcp-capabilities.md` + `capability-map.md` + `capability-architecture.md` -
  what is live vs gated vs dead for tools/MCP, a concrete plan to remove the dead user-MCP
  path from the sandbox, and a proposal for the sandbox to advertise its capabilities.
- `notes-architecture.md`, `notes-config-runsh.md` - per-topic open questions.

## Notes

- Docs and findings only. No code changes.
- Stacked on `big-agents` after the restructure merge.

https://claude.ai/code/session_01K1B1nizzup79YAnc2wF77L
