### PR TITLE
fix(api): keep prompt input_keys when projecting evaluation inputs

### DIFF
--- a/api/oss/src/core/evaluations/runtime/adapters.py
+++ b/api/oss/src/core/evaluations/runtime/adapters.py
@@ -36,6 +36,37 @@ def _read_field(source: Any, field: str) -> Any:
     return getattr(source, field, None)
 
 
+def _collect_prompt_input_keys(parameters: Any) -> set:
+    """Collect every prompt ``input_keys`` declared anywhere in ``parameters``.
+
+    Prompt handlers (``completion_v0``/``chat_v0``) validate the runtime inputs
+    against ``prompt.input_keys`` at invoke time. For builtin prompt workflows
+    ``schemas.inputs.properties`` only declares the STRUCTURAL inputs (e.g.
+    ``messages`` for chat), not the template variables (e.g. ``context``) — those
+    live in ``input_keys``. Projection must keep these keys, otherwise a template
+    variable that has no matching schema property is dropped and the workflow is
+    invoked with empty inputs (``Invalid inputs: Expected ['context'] Got []``).
+
+    Walks the tree so it is robust to wrapping (``{"ag_config": {...}}``) and to
+    multiple prompt configs.
+    """
+    keys: set = set()
+
+    def _walk(node: Any) -> None:
+        if isinstance(node, dict):
+            input_keys = node.get("input_keys")
+            if isinstance(input_keys, list):
+                keys.update(key for key in input_keys if isinstance(key, str))
+            for value in node.values():
+                _walk(value)
+        elif isinstance(node, list):
+            for item in node:
+                _walk(item)
+
+    _walk(parameters)
+    return keys
+
+
 def _project_inputs(inputs: Any, data: Any) -> Any:
     """Project source inputs onto the revision's declared input schema.
 
@@ -43,7 +74,10 @@ def _project_inputs(inputs: Any, data: Any) -> Any:
     ground-truth/bookkeeping keys like ``correct_answer`` or ``testcase_id``.
     The invoked workflow should only receive the inputs its revision declares,
     so filter ``inputs`` down to the keys present in
-    ``data.schemas.inputs.properties``.
+    ``data.schemas.inputs.properties``, widened by the prompt's declared
+    ``input_keys`` so template variables absent from the schema (e.g. ``context``
+    for a builtin chat workflow, whose schema declares only ``messages``) are not
+    stripped.
 
     If the revision declares no input schema (no ``properties``), inputs pass
     through unchanged so untyped/legacy revisions are not broken.
@@ -59,7 +93,10 @@ def _project_inputs(inputs: Any, data: Any) -> Any:
     if not isinstance(properties, dict) or not properties:
         return inputs
 
-    return {key: value for key, value in inputs.items() if key in properties}
+    parameters = _read_field(data, "parameters") if data is not None else None
+    allowed = set(properties.keys()) | _collect_prompt_input_keys(parameters)
+
+    return {key: value for key, value in inputs.items() if key in allowed}
 
 
 def _dump_model(source: Any, **kwargs: Any) -> Any:

--- a/api/oss/tests/pytest/unit/evaluations/test_evaluation_inputs.py
+++ b/api/oss/tests/pytest/unit/evaluations/test_evaluation_inputs.py
@@ -1,0 +1,63 @@
+"""Regression tests for input projection in the evaluation runtime.
+
+`_project_inputs` filters a testcase row down to the inputs a workflow revision
+declares before invoking it. For builtin prompt workflows the declared input
+schema (`schemas.inputs.properties`) only carries STRUCTURAL inputs (e.g.
+`messages` for chat), not the prompt template variables (e.g. `context`), which
+live in `prompt.input_keys`. Dropping a template variable here invokes the
+workflow with empty inputs and fails with
+`Invalid inputs: Expected ['context'] Got []`.
+
+Verified end-to-end against the running stack (chat:v0 app whose schema declares
+only `messages`, prompt uses `{{context}}`): with this projection the app
+receives `{'context': ...}` instead of `{}`.
+"""
+
+from oss.src.core.evaluations.runtime.adapters import _project_inputs
+
+
+def _data(*, properties=None, parameters=None):
+    schemas = {"inputs": {"properties": properties}} if properties is not None else {}
+    return {"schemas": schemas, "parameters": parameters}
+
+
+def test_drops_bookkeeping_columns():
+    inputs = {"context": "x", "correct_answer": "y", "testcase_id": "1"}
+    data = _data(properties={"context": {}})
+
+    assert _project_inputs(inputs, data) == {"context": "x"}
+
+
+def test_passthrough_when_no_input_schema():
+    inputs = {"context": "x", "testcase_id": "1"}
+
+    assert _project_inputs(inputs, _data()) == inputs
+    assert _project_inputs(inputs, _data(properties={})) == inputs
+
+
+def test_keeps_template_var_absent_from_schema_chat_workflow():
+    """The real bug: a chat:v0 app's schema declares only `messages`, but the
+    prompt's template variable `context` lives in `input_keys`. Projection must
+    keep `context` (and drop ground-truth/bookkeeping columns)."""
+    inputs = {"context": "Nauru", "correct_answer": "...", "testcase_id": "1"}
+    data = _data(
+        properties={"messages": {"x-ag-type-ref": "messages"}},
+        parameters={"prompt": {"input_keys": ["context"]}},
+    )
+
+    assert _project_inputs(inputs, data) == {"context": "Nauru"}
+
+
+def test_keeps_input_keys_with_wrapped_ag_config():
+    inputs = {"context": "Nauru", "testcase_id": "1"}
+    data = _data(
+        properties={"messages": {}},
+        parameters={"ag_config": {"prompt": {"input_keys": ["context"]}}},
+    )
+
+    assert _project_inputs(inputs, data) == {"context": "Nauru"}
+
+
+def test_non_dict_inputs_pass_through():
+    assert _project_inputs(None, _data(properties={"context": {}})) is None
+    assert _project_inputs([], _data(properties={"context": {}})) == []


### PR DESCRIPTION
## Summary
  Running an evaluation against a testset fails on every row when the target is a
  builtin prompt/chat workflow whose template variable is not a declared structural
  input. The application step returns HTTP 400:
  
  `Invalid inputs:\nExpected '['context']'\nGot ('list') '[]'.`
  (type `v0:schemas:invalid-inputs`)
  
  **Root cause:** `_project_inputs` in
  `api/oss/src/core/evaluations/runtime/adapters.py` filters each testcase row down to
  the keys in `data.schemas.inputs.properties` before invoking the workflow (to drop
  bookkeeping columns like `correct_answer`/`testcase_id`). For builtin prompt
  workflows that schema declares only the **structural** inputs (e.g. `messages` for
  `chat:v0`), not the prompt template variables (e.g. `context`) — which live in
  `parameters.prompt.input_keys` and are what `completion_v0`/`chat_v0` actually
  validate against. So the projection strips `context`, the workflow is invoked with
  `{}`, and validation fails.

  **Fix:** widen the projection allow-list to the union of the schema's property keys
  and the prompt's declared `input_keys`, so a template variable absent from the schema
  is no longer dropped. Bookkeeping columns are still removed; the no-schema
  pass-through path is unchanged (untyped/legacy revisions unaffected).

  ## Testing
  ### Verified locally
  Reproduced on a self-hosted OSS stack: a `chat` app whose prompt uses `{{context}}`,
  evaluated against a testset with a `context` column. Before the change the
  application step fails with `Invalid inputs: Expected ['context'] Got []`; after the
  change `context` flows through and the app proceeds to the model call.

  ### Added or updated tests
  Added `api/oss/tests/pytest/unit/evaluations/test_project_inputs.py` covering the
  chat-app case (schema declares only `messages`, prompt needs `context`), the
  bookkeeping-column drop, and the no-schema pass-through. All pass.

  ### QA follow-up
  N/A

  ## Demo
Before the change
<img width="787" height="750" alt="Screenshot 2026-06-23 at 7 10 05 PM" src="https://github.com/user-attachments/assets/14427e84-5e5b-48bd-af88-21fa183e3bea" />

After the change
<img width="1459" height="765" alt="Screenshot 2026-06-23 at 7 09 01 PM" src="https://github.com/user-attachments/assets/01a2e2ca-04f7-4086-94a8-6ad7ae402906" />
  ## Checklist
  - [x] I have included a video or screen recording for UI changes, or marked Demo as N/A
  - [x] Relevant tests pass locally
  - [x] Relevant linting and formatting pass locally
  - [ ] I have signed the CLA, or I will sign it when the bot prompts me

<!-- GitButler Footer Boundary Top -->
---
This is **part 1 of 2 in a stack** made with GitButler:
- <kbd>&nbsp;2&nbsp;</kbd> #6608
- <kbd>&nbsp;1&nbsp;</kbd> #4807 👈 
<!-- GitButler Footer Boundary Bottom -->