### PR TITLE
fix(docs): remove broken custom-agent-runner-images links

### DIFF
--- a/docs/docs/self-host/guides/07-deploy-the-agent-runner.mdx
+++ b/docs/docs/self-host/guides/07-deploy-the-agent-runner.mdx
@@ -61,5 +61,4 @@ export AGENTA_SANDBOX_AGENT_IMAGE="ghcr.io/agenta-ai/agenta-sandbox-agent:latest
 
 ## Related
 
-- [Custom agent runner images](/self-host/guides/custom-agent-runner-images)
 - [Agent Daytona sandboxes](/self-host/guides/agent-daytona-sandboxes)

--- a/docs/docs/self-host/guides/09-agent-daytona-sandboxes.mdx
+++ b/docs/docs/self-host/guides/09-agent-daytona-sandboxes.mdx
@@ -56,4 +56,3 @@ agentRunner:
 ## Related
 
 - [Deploy the agent runner](/self-host/guides/deploy-the-agent-runner)
-- [Custom agent runner images](/self-host/guides/custom-agent-runner-images)


### PR DESCRIPTION
## What

Two self-host guides linked to `/self-host/guides/custom-agent-runner-images`, a page that was never created. Docusaurus treats a dangling internal link as a hard build error, so the docs deploy on `big-agents` failed:

```
[ERROR] Docusaurus found broken links!
- Broken link on source page path = /docs/self-host/guides/agent-daytona-sandboxes:
   -> linking to /docs/self-host/guides/custom-agent-runner-images
- Broken link on source page path = /docs/self-host/guides/deploy-the-agent-runner:
   -> linking to /docs/self-host/guides/custom-agent-runner-images
```

## Change

Removed the two dead "Related" links from:
- `docs/docs/self-host/guides/07-deploy-the-agent-runner.mdx`
- `docs/docs/self-host/guides/09-agent-daytona-sandboxes.mdx`

## Verification

`pnpm run build` in `docs/` now completes: `[SUCCESS] Generated static files in "build"`.