### PR TITLE
[docs] Add agent workflow interface inventory

### DIFF
--- a/docs/design/agent-workflows/README.md
+++ b/docs/design/agent-workflows/README.md
@@ -1,13 +1,15 @@
 # Agent Workflows
 
 This workspace documents the agent-workflows feature: running a coding harness as an
-Agenta workflow. It is organized into four layers so the living design docs stay separate
+Agenta workflow. It is organized into five layers so the living design docs stay separate
 from in-flight project notes and historical archaeology.
 
 ## Layout
 
 - **[documentation/](documentation/)** — the living design docs, kept current with the
   code. Start here.
+- **[interfaces/](interfaces/)** - interface inventory for reviews: public edge
+  contracts, cross-service contracts, and in-service ports/DTOs.
 - **[projects/](projects/)** — active, self-contained workstreams. Each has its own
   `README.md`/`status.md`. These graduate into `documentation/` or fold into the code as
   they land.

--- a/docs/design/agent-workflows/documentation/ports-and-adapters.md
+++ b/docs/design/agent-workflows/documentation/ports-and-adapters.md
@@ -3,6 +3,10 @@
 The agent runtime uses the same hexagonal vocabulary as the rest of Agenta. The SDK owns
 the neutral ports and data contracts. The service and runner plug adapters into them.
 
+For the per-seam review lens (which boundary a diff touches and what it can break), see the
+[in-service interfaces](../interfaces/in-service/) inventory. This page owns the layering
+narrative.
+
 ## Runtime Package
 
 The SDK runtime lives under `sdks/python/agenta/sdk/agents/`.
@@ -29,7 +33,7 @@ sessions. It does not know how Pi or Claude wants tools shaped.
 Current backends:
 
 - `SandboxAgentBackend`: implemented, supports `pi`, `claude`, and `agenta`, local or Daytona.
-  This is the backend the deployed service always uses (`services/oss/src/agent/app.py:49`).
+  This is the backend the deployed service always uses (`services/oss/src/agent/app.py`).
 - `LocalBackend`: planned, public class exists, methods raise.
 
 The sidecar's in-process `pi` engine (`engines/pi.ts`) is still reachable with `backend: "pi"`,

--- a/docs/design/agent-workflows/documentation/protocol.md
+++ b/docs/design/agent-workflows/documentation/protocol.md
@@ -119,6 +119,11 @@ create-session call.
 `sdks/python/agenta/sdk/agents/utils/wire.py`. The TypeScript side mirrors it in
 `services/agent/src/protocol.ts`.
 
+The review lens for this boundary, including the full request and result shapes and what can
+break when a field moves, is in the interface inventory's
+[Service to agent runner](../interfaces/cross-service/service-to-agent-runner.md). This page
+owns the field-by-field narrative.
+
 Request fields include:
 
 | Field | Meaning |
@@ -129,7 +134,7 @@ Request fields include:
 | `sessionId` | External conversation id. The runtime is cold and receives history in `messages`. |
 | `agentsMd` | Instructions that become `AGENTS.md`. |
 | `systemPrompt`, `appendSystemPrompt` | Pi prompt overrides. Delivered on both the in-process Pi path and the sandbox-agent Pi path (the sandbox-agent engine writes `SYSTEM.md` / `APPEND_SYSTEM.md` into the per-run Pi agent dir, local and Daytona). |
-| `skills` | Bundled skill directory names to force-load (the `agenta` harness, Pi only). |
+| `skills` | Resolved inline skill packages (full `SKILL.md` content, with `@ag.embed` references inlined server-side), declared in the agent config. All three harnesses wire them; the runner materializes each into a skill dir (Pi/Agenta through Pi's agent-dir scope, Claude under project-local `.claude/skills`). Omitted when none are declared. |
 | `model` | Requested model id. Not honored on the Pi-over-sandbox-agent path; pi-acp accepts only its default model (see Ground Truth). |
 | `messages` | Conversation history and current turn. |
 | `secrets` | Provider env vars resolved by the service. |

--- a/docs/design/agent-workflows/interfaces/README.md
+++ b/docs/design/agent-workflows/interfaces/README.md
@@ -32,6 +32,43 @@ Every page follows the same shape so you can scan it fast:
 - The files that own it.
 - What to check when you change it, including the tests that move with it.
 
+## The interfaces at a glance
+
+One row per interface, so a reviewer can find the boundary a diff touches before opening a
+page. `Status` is read from each page's prose: **stable** (wired and unlikely to move),
+**evolving** (wired but actively changing or only partly enforced), **declared-not-wired**
+(the shape exists but nothing applies it yet).
+
+| Interface | Blast radius | Owner file(s) | Status | Tests |
+|---|---|---|---|---|
+| [`/invoke`](public-edge/workflow-invoke.md) | public | `decorators/routing.py`, `models/workflows.py`, `agent/app.py` | stable | `unit/agent/`, `utils/test_messages_endpoint.py` |
+| [`/inspect`](public-edge/workflow-inspect.md) | public | `agent/schemas.py`, `models/workflows.py`, `decorators/routing.py` | stable | `unit/agents/test_dtos_agent_config.py` |
+| [`/messages`](public-edge/agent-messages.md) | public | `adapters/vercel/{routing,messages,stream}.py`, `agentRequest.ts` | evolving (create-or-resume not observable until storage lands) | `utils/test_messages_endpoint.py`, `unit/agents/test_ui_messages.py` |
+| [Agent config schema](public-edge/agent-config-schema.md) | public | `agent/schemas.py`, `sdk/utils/types.py`, `agents/dtos.py` | stable | `unit/agents/test_dtos_agent_config.py` |
+| [`/run`](cross-service/service-to-agent-runner.md) | cross-service (the spine) | `protocol.ts`, `utils/wire.py`, `utils/ts_runner.py`, `server.ts`/`cli.ts` | stable (pinned by golden) | `unit/agents/test_wire_contract.py` + `golden/`, `services/agent/tests/unit/wire-contract.test.ts` |
+| [Runner to harness](cross-service/runner-to-harness.md) | cross-service (ACP) | `engines/sandbox_agent.ts` + `sandbox_agent/{run-plan,capabilities,permissions}.ts`, `engines/pi.ts` | evolving | `services/agent/tests/unit/sandbox-agent-*.test.ts` |
+| [Runner to MCP server](cross-service/runner-to-mcp-server.md) | cross-service | `agents/mcp/`, `engines/sandbox_agent/mcp.ts`, `tools/{mcp-bridge,mcp-server,relay}.ts` | evolving (stdio wired; remote deferred) | `services/agent/tests/unit/mcp-servers.test.ts` |
+| [Runner to tool callback](cross-service/runner-to-tool-callback.md) | cross-service | `tools/{callback,dispatch}.ts`, `apis/fastapi/tools/router.py`, `agent/tools/resolver.py` | stable | `services/agent/tests/unit/{code-tool,extension-tools}.test.ts` |
+| [Service and runner trace export](cross-service/service-and-runner-trace-export.md) | cross-service | `agent/tracing.py`, `tracing/otel.ts`, `extensions/agenta.ts` | stable | `services/agent/tests/unit/` |
+| [Service to vault and tool providers](cross-service/service-to-vault-and-tool-providers.md) | cross-service (external) | `agent/app.py`, `platform/{resolve,connections}.py`, `agents/capabilities.py`, `tools/router.py` | stable | `unit/agents/connections/`, `unit/agents/platform/`, `unit/agents/tools/` |
+| [Agent service handler](in-service/agent-service-handler.md) | in-service | `services/oss/src/agent/app.py` | stable | `services/oss/tests/pytest/unit/agent/` |
+| [Neutral runtime DTOs](in-service/neutral-runtime-dtos.md) | in-service | `agents/dtos.py` | stable | `unit/agents/test_dtos_*.py` |
+| [Runtime ports](in-service/runtime-ports.md) | in-service | `agents/interfaces.py` | evolving (`SessionStore` noop, `LocalBackend` stub) | `unit/agents/test_environment_lifecycle.py`, `test_harness_adapters.py` |
+| [Backend adapter](in-service/backend-adapter.md) | in-service | `agents/adapters/sandbox_agent.py` | stable | `unit/agents/test_runner_adapter_config.py`, `test_environment_lifecycle.py` |
+| [Harness adapters](in-service/harness-adapters.md) | in-service | `agents/adapters/harnesses.py`, `agents/dtos.py` | stable | `unit/agents/test_harness_adapters.py`, `test_dtos_harness_configs.py` |
+| [Browser protocol adapter](in-service/browser-protocol-adapter.md) | in-service | `agents/adapters/vercel/{routing,messages,stream,sse}.py` | stable | `unit/agents/test_ui_messages.py`, `utils/test_messages_endpoint.py` |
+| [Tool models and resolution](in-service/tool-models-and-resolution.md) | in-service | `agents/tools/models.py`, `platform/gateway.py`, `agent/tools/resolver.py` | stable | `unit/agents/tools/` |
+| [MCP models and resolution](in-service/mcp-models-and-resolution.md) | in-service | `agents/mcp/{models,resolver,wire}.py` | evolving (stdio wired; remote deferred; resolution feature-gated) | `unit/agents/mcp/` |
+| [Model connection resolution](in-service/model-connection-resolution.md) | in-service | `agent/app.py`, `agents/connections/`, `platform/{resolve,connections}.py`, `agents/capabilities.py` | stable | `unit/agents/connections/` |
+| [Runner engine internals](in-service/runner-engine-internals.md) | in-service (runner) | `server.ts`, `cli.ts`, `engines/{sandbox_agent,pi}.ts` | stable | `services/agent/tests/unit/{server,cli}.test.ts` |
+| [Permission responder](in-service/permission-responder.md) | in-service (runner) | `responder.ts`, `engines/sandbox_agent/permissions.ts` | stable | `services/agent/tests/unit/{responder,sandbox-agent-permissions}.test.ts` |
+| [Sandbox permission](in-service/sandbox-permission.md) | in-service (runner) | `agents/dtos.py`, `protocol.ts`, `engines/sandbox_agent/{provider,run-plan}.ts` | evolving (network enforced on Daytona only; local rejected; filesystem nowhere) | `services/agent/tests/unit/{sandbox-agent-provider,sandbox-agent-run-plan}.test.ts` |
+
+Paths are relative to the owner package (`sdks/python/agenta/sdk/`, `services/agent/src/`,
+`services/oss/src/`, `api/oss/src/`); test paths are relative to each package's pytest root
+unless prefixed. The `/load-session` shell endpoint is intentionally omitted: it is being
+removed in a sibling change, so it is not listed here.
+
 ## Source of truth
 
 When a field changes, update the owner file, the tests, and the matching page here in the

--- a/docs/design/agent-workflows/interfaces/README.md
+++ b/docs/design/agent-workflows/interfaces/README.md
@@ -1,0 +1,39 @@
+# Agent Workflow Interfaces
+
+The agent workflow stack spans a Python service, a Node runner, a sandboxed harness, a
+browser client, the vault, and the trace pipeline. A change in one of these places often
+breaks a contract that lives in another. This folder names those contracts so a reviewer
+can tell, before reading the diff, which boundary a change touches and what it can break.
+
+Read it as review context, not as a tutorial. The code is still the source of truth. Each
+page points at the files that own the contract and says what to check when it moves.
+
+## How the inventory is organized
+
+The split is by blast radius, because blast radius is what decides how careful a review
+has to be.
+
+- **[Public edge](public-edge/)** holds the contracts that browser and workflow clients
+  depend on. Break one and you break callers you do not control, so these change most
+  conservatively.
+- **[Cross-service](cross-service/)** holds contracts that cross a process, container, or
+  external service boundary. Each side deploys and fails on its own, so a field can change
+  on one side and reach an older version on the other.
+- **[In-service](in-service/)** holds contracts that stay inside one process or package.
+  They are still contracts. They break adapters, tests, and extension points even when no
+  wire field changes.
+
+## How to read each page
+
+Every page follows the same shape so you can scan it fast:
+
+- One short statement of what crosses the boundary and why it matters.
+- The concrete contract: the real types, fields, and shapes, not a list of names.
+- The files that own it.
+- What to check when you change it, including the tests that move with it.
+
+## Source of truth
+
+When a field changes, update the owner file, the tests, and the matching page here in the
+same PR. A page that has drifted from the code is worse than no page. It reads as
+authoritative while it is wrong.

--- a/docs/design/agent-workflows/interfaces/cross-service/README.md
+++ b/docs/design/agent-workflows/interfaces/cross-service/README.md
@@ -1,0 +1,25 @@
+# Cross-Service Interfaces
+
+These contracts cross a process, container, or external service boundary. The Python
+service talks to the Node runner; the runner talks to the harness, the tool endpoint, and
+MCP servers; the service talks to the vault; and traces flow back to Agenta. Each side
+deploys on its own schedule and fails on its own, so a field added on one side can reach an
+older version on the other.
+
+That independence is what makes these the contracts to change carefully. The `/run`
+contract in particular is pinned by golden fixtures and hand-mirrored between Python and
+TypeScript, so any field change has to move both sides and their tests at once.
+
+## Interfaces
+
+- [Service to agent runner](service-to-agent-runner.md): the `/run` contract, the spine of
+  the stack.
+- [Runner to harness](runner-to-harness.md): how the runner drives Pi or Claude over ACP.
+- [Runner to tool callback](runner-to-tool-callback.md): how runner tools call back into
+  Agenta so secrets stay server-side.
+- [Runner to MCP server](runner-to-mcp-server.md): the stdio bridge and file relay for
+  non-Pi tool delivery.
+- [Service to vault and tool providers](service-to-vault-and-tool-providers.md): credential
+  and tool resolution before the run.
+- [Service and runner trace export](service-and-runner-trace-export.md): trace context in,
+  spans back out.

--- a/docs/design/agent-workflows/interfaces/cross-service/runner-to-harness.md
+++ b/docs/design/agent-workflows/interfaces/cross-service/runner-to-harness.md
@@ -1,0 +1,66 @@
+# Runner To Harness
+
+Once the runner has a `/run` request, it has to drive an actual coding agent. It does this
+one of two ways: the legacy in-process Pi engine, or the `sandbox-agent` path that talks to
+Pi or Claude over ACP (the Agent Client Protocol). The deployed service sends
+`backend: sandbox-agent`, so the ACP path is the one that runs in production. This boundary
+is where a neutral request becomes a harness-specific session, so it owns harness selection,
+capability detection, and event mapping.
+
+## The contract
+
+**Harness selection.** The `harness` field picks the agent. `"agenta"` maps to the ACP
+agent `"pi"` (Pi with Agenta's forced opinion), and other values map to their own ACP agent.
+The `sandbox` field picks `local` or `daytona`.
+
+**The run plan.** `run-plan.ts` turns the request into a `RunPlan`, the resolved shape the
+engine actually runs. It holds the resolved turn text, the working directory and tool relay
+directory, the materialized skill dirs, the secrets and the legacy provider key var, the
+sandbox permission boundary, and the harness files. It also carries `credentialMode`, which
+decides whether the runner clears inherited provider env before applying `secrets`.
+
+**The capability probe.** `capabilities.ts` asks the sandbox what the harness supports and
+returns `HarnessCapabilities`:
+
+```jsonc
+{ "textMessages": true, "images": false, "fileAttachments": false, "mcpTools": false,
+  "toolCalls": false, "reasoning": false, "planMode": false, "permissions": false,
+  "usage": false, "streamingDeltas": false, "sessionLifecycle": false }
+```
+
+The probe gates real behavior. Tools only go over MCP when `mcpTools` is true, for example.
+If the probe fails, the runner falls back to a static capability policy.
+
+**The ACP event stream.** The harness emits ACP updates that the runner maps to neutral
+events:
+
+| ACP update | Becomes |
+|---|---|
+| `agent_message_chunk` | assistant text (Pi sends pure deltas, Claude cumulative) |
+| `agent_thought_chunk` | reasoning |
+| `tool_call` | a tool call with id, title, and raw input |
+| `tool_call_update` | tool completion or failure with output |
+| `usage_update` | token and cost roll-up |
+| permission request | a permission interaction (see [Permission responder](../in-service/permission-responder.md)) |
+
+**Abort.** HTTP streaming passes an `AbortSignal` into the sandbox start; a client disconnect
+tears the sandbox down in the `finally` path.
+
+## Owned by
+
+- `services/agent/src/engines/sandbox_agent.ts`: the ACP driver.
+- `services/agent/src/engines/sandbox_agent/run-plan.ts`: the resolved run plan.
+- `services/agent/src/engines/sandbox_agent/capabilities.ts`: the capability probe.
+- `services/agent/src/engines/sandbox_agent/permissions.ts`: permission wiring.
+- `services/agent/src/engines/pi.ts`: the legacy in-process path.
+
+## Watch for when changing
+
+- **Harness selection and the `agenta` to `pi` remap.** New harnesses thread through here.
+- **The capability probe.** It gates tool delivery, permissions, and streaming. A wrong flag
+  silently changes behavior rather than erroring.
+- **ACP event mapping.** A missed or mis-mapped update drops content from the stream.
+- **Pi versus ACP divergence.** Pi takes tools natively and can self-instrument traces; the
+  ACP path delivers tools over MCP and the runner builds the spans.
+- **Daytona behavior.** The sandbox provider changes the working directory and the file
+  relay host. Test both `local` and `daytona`.

--- a/docs/design/agent-workflows/interfaces/cross-service/runner-to-mcp-server.md
+++ b/docs/design/agent-workflows/interfaces/cross-service/runner-to-mcp-server.md
@@ -1,0 +1,51 @@
+# Runner To MCP Server
+
+Pi takes its tools natively. Every other harness gets tools over MCP. So for non-Pi
+harnesses the runner stands up its own stdio MCP server, exposes the backend-resolved tools
+through it, and lets the harness call them like any MCP tool. User-declared MCP servers ride
+the same `/run` payload after the Python side resolves their secrets. This page covers both:
+the runner-owned bridge and the user servers.
+
+## The contract
+
+**Gating.** The runner builds MCP servers only when the harness is not Pi and the capability
+probe reports `mcpTools: true`. Pi always returns an empty MCP set because it gets tools the
+native way.
+
+**The stdio bridge.** The runner-owned server speaks JSON-RPC 2.0 over stdio and answers
+three methods:
+
+- `initialize`: returns protocol version and `capabilities.tools`.
+- `tools/list`: returns the resolved tool specs as MCP tools. Client-kind tools are filtered
+  out here, because the browser fulfills those.
+- `tools/call`: runs the named tool with its arguments and returns `content`, or an error.
+
+**The file relay.** A resolved tool may need to run privately rather than inside the harness
+process. The relay moves the call across that boundary: the child writes a `<id>.req.json`
+request into the relay directory, the runner polls (every ~300ms), executes the tool through
+the `RelayHost` (local `node:fs` or the Daytona sandbox filesystem), and writes a
+`<id>.res.json` response. A tool slower than the relay timeout surfaces as a tool error.
+
+**User-declared servers.** `mcpServers` in `/run` carries each user server with its
+transport, command or url, args, env (secrets already injected by the Python resolver), tool
+allowlist, and permission. Stdio servers are wired today; remote servers are modeled but
+deferred.
+
+## Owned by
+
+- `sdks/python/agenta/sdk/agents/mcp/`: the Python models and resolver.
+- `services/agent/src/engines/sandbox_agent/mcp.ts`: builds the session's MCP servers.
+- `services/agent/src/tools/mcp-bridge.ts`: the bridge.
+- `services/agent/src/tools/mcp-server.ts`: the stdio JSON-RPC server.
+- `services/agent/src/tools/relay.ts`: the file relay loop and hosts.
+
+## Watch for when changing
+
+- **The gate.** MCP delivery depends on harness type and the `mcpTools` capability, not on a
+  single env flag. Changing either changes which tools reach the harness.
+- **The MCP server config shape.** It is part of the `/run` contract and the wire serializer.
+- **The stdio methods.** `initialize`, `tools/list`, `tools/call`, and the client-tool filter.
+- **The relay.** Polling interval, timeout, and the local-versus-Daytona host. A slow tool
+  must fail cleanly.
+- **Remote MCP support.** It is modeled but not wired. Enabling it is a real contract change.
+- **Per-server permission and allowlist behavior.**

--- a/docs/design/agent-workflows/interfaces/cross-service/runner-to-tool-callback.md
+++ b/docs/design/agent-workflows/interfaces/cross-service/runner-to-tool-callback.md
@@ -1,0 +1,59 @@
+# Runner To Tool Callback
+
+Gateway and callback tools run their real work inside Agenta, not inside the sandbox. When
+the harness calls such a tool, the runner posts the call back to Agenta's tool endpoint,
+Agenta executes it with the provider key it holds, and the result comes back. This is how
+provider keys and connection auth stay server-side: the sandbox never sees them.
+
+## The contract
+
+The runner posts an OpenAI-style function-call envelope to `POST /tools/call`:
+
+```jsonc
+{
+  "data": {
+    "id":       "call_zEoV...",            // the LLM tool_call_id, echoed back for correlation
+    "type":     "function",
+    "function": {
+      "name":      "tools.composio.github.create_issue.my_conn",  // resolved tool slug
+      "arguments": { "title": "..." }      // sent as an object, not a JSON string
+    }
+  }
+}
+```
+
+The endpoint returns a `ToolCallResponse`. The execution result is already serialized as a
+JSON string in `call.data.content`, so the runner hands it to the model verbatim:
+
+```jsonc
+{
+  "call": {
+    "id": "uuid",
+    "status": { "code": "STATUS_CODE_OK", "message": "..." },
+    "data":   { "role": "tool", "tool_call_id": "call_zEoV...", "content": "{\"...\":\"...\"}" }
+  }
+}
+```
+
+Two details bite. The LLM cannot put dots in a function name, so the slug travels with `__`
+separators and the router normalizes them back to dots. And `arguments` may arrive as a JSON
+string (from the model) or an object; the router normalizes to a dict before executing.
+
+## Owned by
+
+- `services/agent/src/tools/callback.ts`: the runner caller (sends the envelope, reads `content`).
+- `services/agent/src/tools/dispatch.ts`: runner-side dispatch.
+- `api/oss/src/apis/fastapi/tools/router.py`: the endpoint that parses, executes, and serializes.
+- `services/oss/src/agent/tools/resolver.py`: re-exports the SDK resolver; no service-layer logic.
+
+## Watch for when changing
+
+- **The tool slug format.** The `tools.{provider}.{integration}.{action}.{connection}`
+  reference and the `__`/`.` normalization are a paired contract across runner and router.
+- **Tool result content.** `call.data.content` is a JSON string already; do not double-encode
+  it on the way out.
+- **Argument normalization.** Keep accepting both string and object arguments.
+- **Timeout and error mapping.** The runner pairs a tool-call timeout with the caller signal.
+  A timeout has to surface as a tool error, not a hung turn.
+- **Gateway provider execution.** Provider keys must stay server-side. Nothing here may push
+  a key onto the wire to the sandbox.

--- a/docs/design/agent-workflows/interfaces/cross-service/service-and-runner-trace-export.md
+++ b/docs/design/agent-workflows/interfaces/cross-service/service-and-runner-trace-export.md
@@ -1,0 +1,57 @@
+# Service And Runner Trace Export
+
+An agent run should show up as one nested trace, not two disconnected ones. So the service
+passes trace context into the runner, the runner nests its spans under the caller's workflow
+span, and those spans export back to Agenta over OTLP. This boundary is what keeps the agent
+turn attached to the rest of the request and what carries usage back for accounting.
+
+## The contract
+
+**Context in.** The `/run` request carries a `trace` block:
+
+```jsonc
+{
+  "traceparent":    "00-<traceId>-<spanId>-01",  // W3C; makes the run a child span
+  "baggage":        "...",                         // W3C baggage, carried for future use
+  "endpoint":       "https://.../api/otlp/v1/traces",  // OTLP target; falls back to env
+  "authorization":  "ApiKey ...",                  // export auth; falls back to env
+  "captureContent": true                           // false drops prompt/completion/tool I/O
+}
+```
+
+**Spans back out.** The runner builds a span tree per run and exports it parent-first to the
+target carried for that trace id, so Agenta can attach it under the caller's span:
+
+```
+invoke_agent (AGENT)
+  └─ turn N (CHAIN)
+       ├─ chat <model> (LLM)    [input/output messages, usage]
+       └─ execute_tool <name> (TOOL)   [one per tool call]
+```
+
+When a `traceparent` is supplied, `invoke_agent` becomes a child and the result's `traceId`
+echoes the W3C trace id. A standalone run mints a fresh one. If no spans are emitted,
+`traceId` is absent.
+
+**Usage roll-up.** The run accumulates token and cost usage and stamps it on the
+`invoke_agent` span before flush, so the exported trace carries final totals. In-process Pi
+reads usage from its own message stream; the ACP path pulls it from `usage_update`. Either
+way it has to be stamped before the span closes.
+
+## Owned by
+
+- `services/oss/src/agent/tracing.py`: builds the trace context the service sends.
+- `services/agent/src/tracing/otel.ts`: the runner's span building and OTLP export.
+- `services/agent/src/extensions/agenta.ts`: the Pi extension that self-instruments.
+
+## Watch for when changing
+
+- **Context propagation.** `traceparent` is what makes the run a child. Drop it and the trace
+  detaches.
+- **OTLP endpoint and auth.** Per-trace target first, env fallback second. Both paths have to
+  keep working.
+- **Span names and semantic attributes.** Agenta's trace UI reads these; renames ripple into
+  it.
+- **`captureContent`.** When false, prompts, completions, and tool I/O must not be exported.
+- **Usage accounting.** Usage has to be stamped before flush, or exported traces carry zero
+  totals.

--- a/docs/design/agent-workflows/interfaces/cross-service/service-to-agent-runner.md
+++ b/docs/design/agent-workflows/interfaces/cross-service/service-to-agent-runner.md
@@ -68,8 +68,9 @@ group by job:
 
 Two splits matter for back-compat. `provider` and `connection` appear only when the model
 arrives as a structured `model_ref`; a plain string like `"gpt-5.5"` leaves them off so the
-wire stays byte-identical to the old shape. And `secrets` plus `endpoint.env` are the only
-channels that carry vault keys. `ResolvedConnection.to_wire()` never emits `env`.
+wire stays byte-identical to the old shape. And `secrets` is the only vault-key channel on
+the runner wire. `endpoint` carries non-secret connection config, and
+`ResolvedConnection.to_wire()` never emits `env`.
 
 ## The result
 

--- a/docs/design/agent-workflows/interfaces/cross-service/service-to-agent-runner.md
+++ b/docs/design/agent-workflows/interfaces/cross-service/service-to-agent-runner.md
@@ -1,0 +1,132 @@
+# Service To Agent Runner
+
+The `/run` contract is the spine of the agent stack. The Python service builds a request,
+the Node runner executes a turn, and the runner returns a result or a stream of events.
+Everything else in this folder hangs off this contract. It is also the most pinned one: the
+TypeScript types in `protocol.ts` are mirrored by hand in `wire.py`, and shared golden
+fixtures byte-check the serialization. A field cannot move on one side alone.
+
+In deployed containers the transport is HTTP to the sidecar. In local source checkouts it
+can be a CLI subprocess that takes the same JSON on stdin. Both transports carry the same
+payload, so the request shape is the contract and the transport is an implementation detail.
+
+## Transports
+
+- HTTP: `POST /run` on the sidecar, JSON body.
+- HTTP streaming: same route with `Accept: application/x-ndjson`.
+- CLI: JSON request on stdin, JSON result on stdout.
+- CLI streaming: the `--stream` flag, NDJSON on stdout.
+
+## The request
+
+`AgentRunRequest` is built by `request_to_wire(...)` in `wire.py` and typed in
+`protocol.ts`. Every field is optional on the wire; the runner fills defaults. The fields
+group by job:
+
+```jsonc
+{
+  // engine + placement
+  "backend":  "sandbox-agent",          // or "pi" (legacy in-process); routed by server/cli
+  "harness":  "pi",                      // "pi" | "claude" | "agenta"
+  "sandbox":  "local",                   // "local" | "daytona"
+  "sessionId": "sess_ab12...",           // external id; cold runtime still gets full history
+
+  // instructions
+  "agentsMd":           "...",           // AGENTS.md text, injected as instructions
+  "systemPrompt":       "...",           // Pi only: replace the base prompt
+  "appendSystemPrompt": "...",           // Pi only: append without replacing
+
+  // model + connection (see service-to-vault-and-tool-providers.md)
+  "model":          "openai/gpt-5.5",
+  "provider":       "openai",            // present only for a structured model_ref
+  "connection":     { "mode": "agenta", "slug": "..." },
+  "deployment":     "direct",            // direct | azure | bedrock | vertex | custom
+  "endpoint":       { "baseUrl": "...", "apiVersion": "...", "region": "...", "headers": {} },
+  "credentialMode": "env",               // env | runtime_provided | none
+  "secrets":        { "OPENAI_API_KEY": "..." },   // the only vault-key channel on the wire
+
+  // turn
+  "prompt":   "...",                     // explicit latest turn; falls back to last user msg
+  "messages": [ /* neutral ChatMessage[] */ ],
+
+  // tools + skills (see runner-to-tool-callback.md, runner-to-mcp-server.md)
+  "tools":        [ "read", "edit" ],    // built-in tool names
+  "customTools":  [ /* ResolvedToolSpec[] */ ],
+  "toolCallback": { "endpoint": "...", "authorization": "..." },  // required if customTools set
+  "mcpServers":   [ /* McpServerConfig[] */ ],
+  "skills":       [ /* inline skill packages */ ],
+
+  // policy + files
+  "permissionPolicy":  "auto",           // "auto" | "deny"
+  "sandboxPermission": { /* Layer 2 boundary; declared, not yet enforced */ },
+  "harnessFiles":      [ { "path": ".claude/settings.json", "content": "..." } ],
+
+  // tracing (see service-and-runner-trace-export.md)
+  "trace": { "traceparent": "...", "endpoint": "...", "authorization": "...", "captureContent": true }
+}
+```
+
+Two splits matter for back-compat. `provider` and `connection` appear only when the model
+arrives as a structured `model_ref`; a plain string like `"gpt-5.5"` leaves them off so the
+wire stays byte-identical to the old shape. And `secrets` plus `endpoint.env` are the only
+channels that carry vault keys. `ResolvedConnection.to_wire()` never emits `env`.
+
+## The result
+
+`AgentRunResult`, parsed by `result_from_wire(...)`. `ok: false` raises in Python.
+
+```jsonc
+{
+  "ok":           true,
+  "output":       "final assistant text",     // what the playground renders
+  "messages":     [ /* structured assistant messages */ ],
+  "events":       [ /* event log; empty on the streaming path */ ],
+  "usage":        { "input": 0, "output": 0, "total": 0, "cost": 0 },
+  "stopReason":   "end_turn",
+  "capabilities": { /* HarnessCapabilities, probed */ },
+  "sessionId":    "sess_...",                  // carried forward to the next turn
+  "model":        "openai/gpt-5.5",
+  "traceId":      "hex...",                     // present when a traceparent was passed
+  "error":        null                          // set when ok is false
+}
+```
+
+## Streaming
+
+The streaming transports emit one JSON object per line. Each event is flushed as it is
+built; the run ends with exactly one terminal `result` record.
+
+```jsonc
+{ "kind": "event",  "event":  { "type": "message_delta", "id": "m1", "delta": "Hi" } }
+{ "kind": "result", "result": { "ok": true, "output": "Hi" } }
+```
+
+On the streaming path the terminal result's `events` array is empty, because the events
+already went out live. A consumer that reads events off the result will get nothing on this
+path; it must read them from the stream. A stream that ends without a `result` record is an
+error.
+
+## Owned by
+
+- `services/agent/src/protocol.ts`: the TypeScript request, result, and event types.
+- `sdks/python/agenta/sdk/agents/utils/wire.py`: the Python serializer that mirrors them.
+- `sdks/python/agenta/sdk/agents/utils/ts_runner.py`: HTTP and subprocess transport.
+- `services/agent/src/server.ts` and `cli.ts`: the runner-side HTTP and CLI entrypoints.
+
+## Watch for when changing
+
+- **Any wire field, event kind, capability flag, tool field, or stream record.** Change one
+  and you change the contract.
+- **The byte-for-byte back-compat splits.** A plain string `model` must keep `provider` and
+  `connection` off the wire, or the golden fixtures break.
+- **Streaming versus batch divergence.** Events ride the stream live and never echo in the
+  terminal result.
+- **Error and cancellation behavior.** HTTP maps `>= 400` to a runtime error; the CLI uses
+  exit codes. HTTP streaming wires an `AbortSignal` to client disconnect; the CLI has none.
+
+## Required test updates
+
+- Python wire contract tests under `sdks/python/oss/tests/pytest/unit/agents/`.
+- TypeScript wire contract tests under `services/agent/tests/unit/`.
+- Golden fixtures under `sdks/python/oss/tests/pytest/unit/agents/golden/`. These pin the
+  exact bytes, so regenerate and review the diff deliberately.

--- a/docs/design/agent-workflows/interfaces/cross-service/service-to-agent-runner.md
+++ b/docs/design/agent-workflows/interfaces/cross-service/service-to-agent-runner.md
@@ -10,6 +10,10 @@ In deployed containers the transport is HTTP to the sidecar. In local source che
 can be a CLI subprocess that takes the same JSON on stdin. Both transports carry the same
 payload, so the request shape is the contract and the transport is an implementation detail.
 
+The field-by-field narrative of `/run` (and the public `/invoke` and `/messages` surfaces it
+serves) lives in [Protocol](../../documentation/protocol.md). This page owns the review lens:
+what crosses the boundary, what can break, and what to check when a field moves.
+
 ## Transports
 
 - HTTP: `POST /run` on the sidecar, JSON body.
@@ -58,7 +62,7 @@ group by job:
 
   // policy + files
   "permissionPolicy":  "auto",           // "auto" | "deny"
-  "sandboxPermission": { /* Layer 2 boundary; declared, not yet enforced */ },
+  "sandboxPermission": { /* Layer 2 boundary; network enforced on Daytona, see sandbox-permission.md */ },
   "harnessFiles":      [ { "path": ".claude/settings.json", "content": "..." } ],
 
   // tracing (see service-and-runner-trace-export.md)

--- a/docs/design/agent-workflows/interfaces/cross-service/service-to-vault-and-tool-providers.md
+++ b/docs/design/agent-workflows/interfaces/cross-service/service-to-vault-and-tool-providers.md
@@ -1,0 +1,55 @@
+# Service To Vault And Tool Providers
+
+Before the service can call the runner, it has to turn the editable agent config into
+concrete, least-privilege inputs: one model connection, the resolved tool specs, and the MCP
+server secrets. This is where vault keys enter the picture and where they are kept from
+leaking. The run gets exactly the one connection it needs, with its secret in a dedicated
+channel, and nothing more.
+
+## The contract
+
+The service resolves several types, each with a clear job:
+
+- **`RuntimeAuthContext`**: the caller's `project_id` (taken from request state, never the
+  body), plus the `harness` and `backend` so resolution can apply capability gates.
+- **`ModelRef`**: what the config asked for. `provider`, `model`, neutral `params`, and a
+  `Connection` of `mode` (`agenta` or `self_managed`) and optional `slug`.
+- **`ResolvedConnection`**: what the run gets. `provider`, `model`, `deployment`,
+  `credential_mode`, the secret `env` (the only secret channel, `repr=False`), and a
+  non-secret `endpoint` (base url, api version, region, public headers).
+- **`ToolConfig` and `ToolSpec`**: the editable tool config and its resolved runnable form.
+  See [Tool models and resolution](../in-service/tool-models-and-resolution.md).
+- **`ResolvedMCPServer`**: a user MCP server with its named secrets injected into `env`.
+
+**Least privilege.** `resolve_connection(...)` builds a candidate pool from the vault
+(`provider_key` and `custom_provider` secrets), filters by model then provider, picks exactly
+one connection deterministically, and fails loud on ambiguity. The run never receives the
+whole vault.
+
+**Capability gating.** A per-harness table decides which providers, deployments, and
+connection modes a harness can reach. Pi reaches eight direct providers; Claude reaches
+Anthropic across direct, custom, bedrock, and vertex. The service checks provider and mode
+before resolution and deployment after, and rejects unreachable choices server-side. The
+same table ships on `/inspect` so the form can filter ahead of time.
+
+## Owned by
+
+- `services/oss/src/agent/app.py`: orchestrates resolution for a run.
+- `sdks/python/agenta/sdk/agents/platform/resolve.py`: the resolver entrypoints.
+- `sdks/python/agenta/sdk/agents/platform/connections.py`: the vault candidate logic.
+- `sdks/python/agenta/sdk/agents/capabilities.py`: the harness capability table and gates.
+- `services/oss/src/agent/tools/resolver.py` and `api/oss/src/apis/fastapi/tools/router.py`:
+  tool resolution and execution.
+
+## Watch for when changing
+
+- **The secret channel.** Keys ride `env` (and the `/run` `secrets` field) and nowhere else.
+  `endpoint` is non-secret by design. Do not widen the channel.
+- **Single-connection selection.** Keep it deterministic and fail-loud. Silent fallback to
+  the wrong key is the failure to avoid.
+- **Provider env var mapping.** The provider-to-env-var map (`openai` to `OPENAI_API_KEY`,
+  and so on) is what the harness reads.
+- **The capability table.** It gates runs server-side and feeds the form. Drift between the
+  two offers choices the run will reject.
+- **Connection slug semantics.** The slug is a portable name, not a database id, so it
+  survives project export and import.

--- a/docs/design/agent-workflows/interfaces/in-service/README.md
+++ b/docs/design/agent-workflows/interfaces/in-service/README.md
@@ -22,4 +22,5 @@ resolvers that turn config into concrete inputs.
 - [Model connection resolution](model-connection-resolution.md): config to one connection.
 - [Runner engine internals](runner-engine-internals.md): the runner's shared engine seam.
 - [Permission responder](permission-responder.md): headless policy and human approval.
-- [Sandbox permission](sandbox-permission.md): the declared network and filesystem boundary.
+- [Sandbox permission](sandbox-permission.md): the network and filesystem boundary, and where
+  each part is actually enforced.

--- a/docs/design/agent-workflows/interfaces/in-service/README.md
+++ b/docs/design/agent-workflows/interfaces/in-service/README.md
@@ -1,0 +1,25 @@
+# In-Service Interfaces
+
+These contracts stay inside one process or package. No HTTP field changes when they move,
+which is exactly why they are easy to break by accident. They are the ports, DTOs, and
+adapters that the service composes to turn a request into a run. Break one and you break
+adapters, tests, or a future extension point, with no wire diff to warn you.
+
+Read them when you touch the Python runtime: the handler that orchestrates a run, the
+neutral DTOs that everything speaks, the ports that let backends and harnesses swap, and the
+resolvers that turn config into concrete inputs.
+
+## Interfaces
+
+- [Agent service handler](agent-service-handler.md): the orchestration entrypoint.
+- [Neutral runtime DTOs](neutral-runtime-dtos.md): the semantic vocabulary of the runtime.
+- [Runtime ports](runtime-ports.md): the abstract seams backends and harnesses plug into.
+- [Backend adapter](backend-adapter.md): the one backend wired today.
+- [Harness adapters](harness-adapters.md): how Pi, Claude, and Agenta differ.
+- [Browser protocol adapter](browser-protocol-adapter.md): the Vercel translation layer.
+- [Tool models and resolution](tool-models-and-resolution.md): tool config to runnable spec.
+- [MCP models and resolution](mcp-models-and-resolution.md): MCP config to resolved server.
+- [Model connection resolution](model-connection-resolution.md): config to one connection.
+- [Runner engine internals](runner-engine-internals.md): the runner's shared engine seam.
+- [Permission responder](permission-responder.md): headless policy and human approval.
+- [Sandbox permission](sandbox-permission.md): the declared network and filesystem boundary.

--- a/docs/design/agent-workflows/interfaces/in-service/agent-service-handler.md
+++ b/docs/design/agent-workflows/interfaces/in-service/agent-service-handler.md
@@ -1,0 +1,49 @@
+# Agent Service Handler
+
+The handler is where a generic workflow request becomes an agent run. It sits between the
+workflow route and the neutral runtime, and it owns the order in which a run is assembled:
+parse the config, resolve everything the run needs, build one `SessionConfig`, pick a
+backend and harness, and execute. Most run-level behavior changes pass through this file, so
+the order it runs in is itself a contract.
+
+## What it reads
+
+The handler (`_agent` in `app.py`) takes the workflow envelope's pieces:
+
+- `parameters`: carries the agent config under `agent` and the run selection (`harness`,
+  `sandbox`, `permission_policy`) in the same object.
+- `messages` or `inputs.messages`: the turn history (it checks `messages` first).
+- `stream`: batch versus streaming.
+- `session_id`: the external conversation id.
+
+## What it does, in order
+
+1. Parse config and selection: `AgentConfig.from_params(params, defaults=...)` and
+   `RunSelection.from_params(params)`.
+2. Convert the request messages to neutral `Message[]`.
+3. Resolve tools into builtin names, runnable specs, and a tool callback.
+4. Resolve MCP servers.
+5. Resolve the model connection and its scoped secrets. The capability check runs in two
+   halves: provider and mode before resolution, deployment after. Unnamed default
+   connections degrade tolerantly to an empty `env` rather than failing the run.
+6. Build one `SessionConfig` carrying all of the above plus trace context and session id.
+7. Select the backend (`SandboxAgentBackend`) and make the harness, which validates that the
+   harness is supported.
+8. Run: stream Vercel parts, or await one batch turn that returns
+   `{"role": "assistant", "content": result.output}`.
+9. Record usage.
+
+## Owned by
+
+- `services/oss/src/agent/app.py`
+
+## Watch for when changing
+
+- **Where config lives.** Agent config and run selection share `parameters`. Moving either
+  breaks the form and the playground request builder.
+- **Default application.** The handler merges request params over a default agent config.
+  Changing the merge changes what an empty form runs.
+- **Resolution order.** Provider and mode gate before resolution; deployment gates after.
+  The tolerant default path is deliberate. Reordering can turn a clean reject into a leak or
+  a hard failure.
+- **Batch versus streaming.** Two execution paths return two shapes. Keep them in sync.

--- a/docs/design/agent-workflows/interfaces/in-service/backend-adapter.md
+++ b/docs/design/agent-workflows/interfaces/in-service/backend-adapter.md
@@ -1,0 +1,53 @@
+# Backend Adapter
+
+`SandboxAgentBackend` is the one backend wired in production. It implements the
+[`Backend`](runtime-ports.md) port for the `sandbox-agent` engine: it creates sessions, holds
+the sandbox selection, serializes the `/run` payload, and delivers it over HTTP or CLI. When
+you change how the service talks to the runner, you change this adapter.
+
+## The contract
+
+It supports `pi`, `claude`, and `agenta`, and holds a `local` or `daytona` sandbox. Its
+engine id is the hard-coded `"sandbox-agent"`. The constructor resolves the runner: a `url`
+selects HTTP delivery, otherwise a resolved `command` selects a CLI subprocess.
+
+```python
+SandboxAgentBackend(
+    sandbox="local",                  # "local" | "daytona"
+    url=None,                         # HTTP runner URL; when set, HTTP transport
+    command=None,                     # CLI command; used when url is None
+    cwd=None,
+    timeout=float(os.getenv("AGENTA_AGENT_RUNNER_TIMEOUT_SECONDS", "180")),
+)
+```
+
+The session it creates builds the wire payload with `request_to_wire(engine="sandbox-agent",
+...)` (see [Service to agent runner](../cross-service/service-to-agent-runner.md)) and
+delivers it:
+
+```python
+# batch
+data = await self._backend._deliver(self._wire_payload(messages))   # HTTP or subprocess
+result = result_from_wire(data); self._absorb_result(result)        # parse + carry session id
+
+# stream
+records = self._backend._deliver_stream(self._wire_payload(messages))
+return AgentRun(records).on_result(self._absorb_result)
+```
+
+`_absorb_result` carries the returned `sessionId` forward to the next turn. The Python side
+holds that id; the runner stays stateless.
+
+## Owned by
+
+- `sdks/python/agenta/sdk/agents/adapters/sandbox_agent.py`
+
+## Watch for when changing
+
+- **The supported harness set.** Adding a harness here is a real capability change.
+- **Runner resolution.** URL versus command selection and the timeout env var decide the
+  transport.
+- **Streaming transport.** Batch returns one JSON; streaming returns an `AgentRun` over NDJSON
+  records.
+- **Result parsing and session carry-forward.** `result_from_wire` plus `_absorb_result` are
+  how a multi-turn conversation keeps its id.

--- a/docs/design/agent-workflows/interfaces/in-service/backend-adapter.md
+++ b/docs/design/agent-workflows/interfaces/in-service/backend-adapter.md
@@ -5,6 +5,10 @@
 the sandbox selection, serializes the `/run` payload, and delivers it over HTTP or CLI. When
 you change how the service talks to the runner, you change this adapter.
 
+Its place in the hexagonal layering, alongside the planned `LocalBackend`, is narrated in
+[Ports and adapters](../../documentation/ports-and-adapters.md#backend). This page owns the
+review lens: what this adapter does and what to check when it moves.
+
 ## The contract
 
 It supports `pi`, `claude`, and `agenta`, and holds a `local` or `daytona` sandbox. Its

--- a/docs/design/agent-workflows/interfaces/in-service/browser-protocol-adapter.md
+++ b/docs/design/agent-workflows/interfaces/in-service/browser-protocol-adapter.md
@@ -7,6 +7,12 @@ Message Stream parts on the way out. It owns the public [`/messages`](../public-
 and [`/load-session`](../public-edge/agent-load-session.md) contracts, so a change here is
 usually a change a browser will notice.
 
+The adapter's place in the layering is narrated in
+[Ports and adapters](../../documentation/ports-and-adapters.md#browser-protocol-adapter), and
+the event-to-stream-part table in [Protocol](../../documentation/protocol.md#vercel-stream-parts).
+This page owns the review lens: what crosses the boundary, what can break, and what to check
+when the mapping moves.
+
 ## The contract
 
 **Inbound (`messages.py`).** Each Vercel part maps to a neutral content block:

--- a/docs/design/agent-workflows/interfaces/in-service/browser-protocol-adapter.md
+++ b/docs/design/agent-workflows/interfaces/in-service/browser-protocol-adapter.md
@@ -1,0 +1,116 @@
+# Browser Protocol Adapter
+
+The Vercel adapter is the translation layer between the browser's protocol and the neutral
+runtime. It exists so Vercel names stay out of the runtime DTOs: the adapter converts
+`UIMessage[]` to neutral `Message[]` on the way in, and neutral `AgentEvent`s to Vercel UI
+Message Stream parts on the way out. It owns the public [`/messages`](../public-edge/agent-messages.md)
+and [`/load-session`](../public-edge/agent-load-session.md) contracts, so a change here is
+usually a change a browser will notice.
+
+## The contract
+
+**Inbound (`messages.py`).** Each Vercel part maps to a neutral content block:
+
+| Vercel part | Neutral block |
+|---|---|
+| `text` | `ContentBlock(type="text")` |
+| `file` | `ContentBlock(type="image"` or `"resource")` with uri and mime |
+| `tool-{name}` state `input-available` | `ContentBlock(type="tool_call")` |
+| `tool-{name}` state `output-available`/`output-error` | `ContentBlock(type="tool_result")` |
+| `tool-approval-response` | `tool_result` carrying `{approved}` |
+| `tool-approval-request` | dropped (it is permission state, not history) |
+
+**Outbound (`stream.py`).** Each neutral event becomes one or more strict Vercel parts:
+
+| Neutral event | Vercel parts |
+|---|---|
+| `message` / `message_*` | `text-start` / `text-delta` / `text-end` |
+| `thought` / `reasoning_*` | `reasoning-start/delta/end` |
+| `tool_call` | `tool-input-start`, `tool-input-available` (+ optional `data-render`) |
+| `tool_result` | `tool-output-available` / `-error` / `-denied` |
+| `interaction_request` (permission) | `tool-approval-request` (strict `{type, approvalId, toolCallId}`) |
+| `interaction_request` (input) | `data-input-request` |
+| `usage`, `done` | collected, stamped on `finish` |
+
+**Finish.** Stop reasons map to the AI SDK enum (`end_turn` to `stop`, `max_tokens` to
+`length`, `tool_use` to `tool-calls`, and so on; unmapped falls back to `unknown`). The final
+`finish` part carries `usage` and `traceId` in `messageMetadata`.
+
+**SSE framing (`sse.py`).** Headers include `x-vercel-ai-ui-message-stream: v1`,
+`cache-control: no-cache`, and `x-accel-buffering: no` to stop proxies buffering the stream.
+The stream ends with `data: [DONE]`.
+
+## Appendix: the Vercel UIMessage, all cases
+
+A `UIMessage` is `{id, role, parts}`, where `parts` is a typed list. The mapping above is the
+summary; this is the exact shape of each part, in both directions. These are the
+history-message parts that `messages.py` converts. The live SSE stream uses a related but
+distinct set of streaming parts (`text-delta`, `tool-input-available`, and so on), covered in
+the outbound table above.
+
+```jsonc
+{ "id": "msg-1", "role": "user", "parts": [ /* Part[] */ ] }
+```
+
+**Inbound parts (browser to neutral), handled by `_part_to_blocks`:**
+
+```jsonc
+// text -> text block
+{ "type": "text", "text": "hello" }
+
+// file -> image block when mediaType starts with "image/", else resource
+{ "type": "file", "mediaType": "image/png", "url": "https://...", "data": "<base64>" }
+
+// any "tool-<name>" / "dynamic-tool" / "tool-output-available" -> tool_call and/or tool_result
+{ "type": "tool-search", "toolCallId": "call_1", "state": "input-available",
+  "input": { "q": "..." } }
+{ "type": "tool-search", "toolCallId": "call_1", "state": "output-available",
+  "output": { "...": "..." } }
+{ "type": "tool-search", "toolCallId": "call_1", "state": "output-error",
+  "errorText": "..." }
+
+// tool-approval-response -> a tool_result keyed by toolCallId (or approvalId)
+{ "type": "tool-approval-response", "toolCallId": "call_1", "approved": true, "reason": "..." }
+
+// tool-approval-request -> dropped (permission state, not history)
+{ "type": "tool-approval-request", "toolCallId": "call_1" }
+```
+
+When a tool part has no `toolName`, the adapter recovers it from the `tool-<name>` type
+suffix. An approval response with no explicit `output` becomes `{"approved": <bool>}`, or the
+`reason` string.
+
+**Outbound parts (neutral to browser), handled by `_block_to_parts`:** a batch
+`message_to_vercel_ui_message` renders an `AgentResult` as a single text part, and a neutral
+`Message` block by block:
+
+```jsonc
+{ "type": "text", "text": "..." }                       // from a text block
+{ "type": "file", "url": "...", "mediaType": "...", "data": "<base64>" }   // image/resource
+{ "type": "tool-search", "toolCallId": "call_1", "state": "input-available",
+  "input": { "...": "..." } }                            // from a tool_call block
+{ "type": "tool-search", "toolCallId": "call_1",
+  "state": "output-available", "output": { "...": "..." } }   // tool_result (or "output-error")
+```
+
+The neutral side of this mapping is in
+[Neutral runtime DTOs](neutral-runtime-dtos.md#appendix-the-message-representation-all-cases).
+
+## Owned by
+
+- `sdks/python/agenta/sdk/agents/adapters/vercel/routing.py`: routes, validation, negotiation.
+- `sdks/python/agenta/sdk/agents/adapters/vercel/messages.py`: message conversion both ways.
+- `sdks/python/agenta/sdk/agents/adapters/vercel/stream.py`: event-to-part projection.
+- `sdks/python/agenta/sdk/agents/adapters/vercel/sse.py`: SSE framing and headers.
+
+## Watch for when changing
+
+- **Part shape is strict.** The browser validates every part. A `render` field cannot ride a
+  tool part inline; it rides a sibling `data-render`. A malformed part throws in `useChat`.
+- **Tool approval round trips.** The request-drop and response-to-`tool_result` mapping are
+  what make cross-turn approval work.
+- **Finish reason mapping.** An unmapped reason becomes `unknown`, not an error, so a missing
+  mapping is easy to miss.
+- **Usage and trace metadata.** Both ride the `finish` part only, not earlier parts.
+- **Keep Vercel names out of the runtime.** The whole point of this layer is that the DTOs
+  stay neutral.

--- a/docs/design/agent-workflows/interfaces/in-service/harness-adapters.md
+++ b/docs/design/agent-workflows/interfaces/in-service/harness-adapters.md
@@ -1,0 +1,49 @@
+# Harness Adapters
+
+The three harnesses look the same from the outside and behave differently inside. The harness
+adapters are where that difference lives: each turns a neutral `SessionConfig` into a
+harness-specific config and decides how tools, prompts, and policy reach the agent. When a
+behavior should differ by harness, it differs here.
+
+## The contract
+
+Each adapter implements `_to_harness_config(...)` and emits a different `/run` wire shape:
+
+- **`PiHarness`** delivers built-in tool names and native custom tools, supports Pi prompt
+  overrides (`system`, `append_system`), and drops `permission_policy` because Pi never gates
+  tool use.
+- **`ClaudeHarness`** delivers tools over MCP, not natively, and has no Pi built-ins (it warns
+  if any are set). It carries `permission_policy` and renders `.claude/settings.json` from
+  `harness_options` and the sandbox permission, shipped as `harnessFiles`. It cannot load
+  inline skill packages, so its `wire_skills()` returns `{}`.
+- **`AgentaHarness`** runs on the same Pi engine but forces Agenta's opinion: it composes the
+  base instructions over the author's, forces the Agenta tool set, and layers the Agenta
+  persona into `append_system`.
+
+The wire shapes, side by side:
+
+| | Pi | Claude | Agenta |
+|---|---|---|---|
+| built-in tools | yes | no | forced set |
+| custom tools | native | over MCP | native |
+| prompt overrides | `system`/`append_system` | none (reads `harness_options`) | forced `append_system` + author `system` |
+| permission policy | dropped | carried | dropped |
+| inline skills | yes | no (`{}`) | yes |
+| harness files | none | `.claude/settings.json` | none |
+
+## Owned by
+
+- `sdks/python/agenta/sdk/agents/adapters/harnesses.py`: the three adapters.
+- `sdks/python/agenta/sdk/agents/dtos.py`: the `PiAgentConfig`/`ClaudeAgentConfig`/
+  `AgentaAgentConfig` wire emitters.
+
+## Watch for when changing
+
+- **Tool delivery per harness.** Native versus MCP is the load-bearing difference. Pi takes
+  tools natively; everyone else gets them over the MCP bridge.
+- **Prompt override behavior.** Pi replaces or appends; Claude reads options; Agenta composes.
+- **Forced Agenta behavior.** Instruction composition and the forced tool set are deliberate.
+- **The Claude skills override.** `wire_skills()` must stay `{}`. It was lost in a merge once
+  and regressed a cross-harness test.
+- **Harness options.** The `harness_options` bag is keyed by harness; each adapter reads only
+  its own slice.

--- a/docs/design/agent-workflows/interfaces/in-service/harness-adapters.md
+++ b/docs/design/agent-workflows/interfaces/in-service/harness-adapters.md
@@ -5,6 +5,10 @@ adapters are where that difference lives: each turns a neutral `SessionConfig` i
 harness-specific config and decides how tools, prompts, and policy reach the agent. When a
 behavior should differ by harness, it differs here.
 
+The `Harness` port and the per-harness roles are narrated in
+[Ports and adapters](../../documentation/ports-and-adapters.md#harness). This page owns the
+review lens: the wire-shape differences and what to check when one moves.
+
 ## The contract
 
 Each adapter implements `_to_harness_config(...)` and emits a different `/run` wire shape:
@@ -14,8 +18,9 @@ Each adapter implements `_to_harness_config(...)` and emits a different `/run` w
   tool use.
 - **`ClaudeHarness`** delivers tools over MCP, not natively, and has no Pi built-ins (it warns
   if any are set). It carries `permission_policy` and renders `.claude/settings.json` from
-  `harness_options` and the sandbox permission, shipped as `harnessFiles`. It cannot load
-  inline skill packages, so its `wire_skills()` returns `{}`.
+  `harness_options` and the sandbox permission, shipped as `harnessFiles`. It carries inline
+  skill packages on the wire like the others; the runner materializes them under
+  `.claude/skills` in the session cwd, matching Claude's project-local skill layout.
 - **`AgentaHarness`** runs on the same Pi engine but forces Agenta's opinion: it composes the
   base instructions over the author's, forces the Agenta tool set, and layers the Agenta
   persona into `append_system`.
@@ -28,7 +33,7 @@ The wire shapes, side by side:
 | custom tools | native | over MCP | native |
 | prompt overrides | `system`/`append_system` | none (reads `harness_options`) | forced `append_system` + author `system` |
 | permission policy | dropped | carried | dropped |
-| inline skills | yes | no (`{}`) | yes |
+| inline skills | yes (agent-dir scope) | yes (materialized to `.claude/skills`) | yes (agent-dir scope) |
 | harness files | none | `.claude/settings.json` | none |
 
 ## Owned by
@@ -43,7 +48,9 @@ The wire shapes, side by side:
   tools natively; everyone else gets them over the MCP bridge.
 - **Prompt override behavior.** Pi replaces or appends; Claude reads options; Agenta composes.
 - **Forced Agenta behavior.** Instruction composition and the forced tool set are deliberate.
-- **The Claude skills override.** `wire_skills()` must stay `{}`. It was lost in a merge once
-  and regressed a cross-harness test.
+- **Claude skill delivery.** Claude wires inline skills like the other harnesses; the runner
+  materializes them under `.claude/skills`. (An earlier revision suppressed Claude's
+  `wire_skills()` to `{}`; that override is gone, and `test_claude_carries_skills_for_project_local_materialization`
+  now pins the carry-on-wire behavior.)
 - **Harness options.** The `harness_options` bag is keyed by harness; each adapter reads only
   its own slice.

--- a/docs/design/agent-workflows/interfaces/in-service/mcp-models-and-resolution.md
+++ b/docs/design/agent-workflows/interfaces/in-service/mcp-models-and-resolution.md
@@ -1,0 +1,47 @@
+# MCP Models And Resolution
+
+MCP config is parsed and resolved on its own path, separate from tools. The author declares a
+server with the secrets it needs by name; the resolver fetches those secrets from the vault
+and injects them into the server's env before the runner ever sees it. So the config holds
+secret names, and the resolved server holds secret values. Tokens never live in the config.
+
+## The contract
+
+**Declared (`MCPServerConfig`).** What the author writes:
+
+```jsonc
+{
+  "name": "files",
+  "transport": "stdio",            // "stdio" (needs command) | "http" (needs url)
+  "command": "npx",
+  "args": ["-y", "server-filesystem"],
+  "env": {},                       // non-secret env
+  "url": null,                     // http transport only
+  "secrets": { "TOKEN_ENV": "vault-secret-name" },  // {env var: vault secret name}
+  "tools": [],                     // allowlist; empty means all
+  "permission": null               // "allow" | "ask" | "deny"
+}
+```
+
+**Resolved (`ResolvedMCPServer`).** Same shape, minus `secrets`, with the named secrets merged
+into `env`. The `to_wire()` emits only the keys that are set, so an empty `args`, `env`,
+`url`, or `tools` is omitted from the `/run` payload.
+
+**Resolution.** The resolver collects every named secret across all servers, fetches them in
+one call, and injects each into its server's `env`. A missing secret raises under the error
+policy. Stdio servers run today; remote (`http`) servers are modeled but deferred.
+
+## Owned by
+
+- `sdks/python/agenta/sdk/agents/mcp/models.py`: the declared and resolved models.
+- `sdks/python/agenta/sdk/agents/mcp/resolver.py`: the batch secret resolution.
+- `sdks/python/agenta/sdk/agents/mcp/wire.py`: wire serialization.
+
+## Watch for when changing
+
+- **Stdio versus remote.** Only stdio is wired. Enabling remote is a real change.
+- **Secret env resolution.** Secrets are named in config, fetched once, and injected into
+  `env`. The config never holds a token.
+- **Tool allowlists and the permission model.** Per-server gating flows to the runner.
+- **Wire serialization.** Empty fields are omitted; that omission is part of the `/run`
+  contract.

--- a/docs/design/agent-workflows/interfaces/in-service/model-connection-resolution.md
+++ b/docs/design/agent-workflows/interfaces/in-service/model-connection-resolution.md
@@ -1,0 +1,58 @@
+# Model Connection Resolution
+
+The agent config says which model to run. This contract turns that into one least-privilege
+connection: the run gets exactly the credential it needs and nothing else. It is also where
+harness capability gating lives, so an unreachable provider or deployment is rejected before
+the run starts. The cross-service view is in
+[Service to vault and tool providers](../cross-service/service-to-vault-and-tool-providers.md);
+this page is the in-service model side.
+
+## The contract
+
+**`ModelRef`** is what the config asked for: `provider`, `model`, neutral `params`, and a
+`Connection` of `mode` (`agenta` or `self_managed`) and optional `slug`. A plain string model
+parses into a `ModelRef` with no connection; a structured `{provider, model, connection}`
+parses into a full one.
+
+**`ResolvedConnection`** is what the run gets:
+
+```jsonc
+{
+  "provider": "openai",
+  "model": "gpt-5.5",              // possibly rewritten for the deployment
+  "deployment": "direct",          // direct | azure | bedrock | vertex_ai | custom
+  "credential_mode": "env",        // env | runtime_provided | none
+  "env": { "OPENAI_API_KEY": "..." },   // the only secret channel (repr=False)
+  "endpoint": {                    // non-secret connection config
+    "base_url": null, "api_version": null, "region": null, "headers": {}
+  }
+}
+```
+
+**Resolution** builds a candidate pool from the vault (`provider_key` and `custom_provider`
+secrets), filters by exact model then by provider family, and picks one connection: by slug
+if named, else the single candidate, else one named `default`, else it raises on ambiguity.
+The run receives only that candidate's `env` and `endpoint`. It never receives the whole
+vault.
+
+**Capability gating** runs in two halves around resolution. Provider and connection mode are
+checked before; deployment is checked after (the resolved connection is what carries it).
+Each harness publishes what it can reach: Pi reaches eight direct providers; Claude reaches
+Anthropic across direct, custom, bedrock, and vertex. Unnamed default connections degrade
+tolerantly to an empty `env` rather than failing the run.
+
+## Owned by
+
+- `services/oss/src/agent/app.py`: orchestrates resolution and the capability checks.
+- `sdks/python/agenta/sdk/agents/connections/`: `ModelRef`, `Connection`, `ResolvedConnection`.
+- `sdks/python/agenta/sdk/agents/platform/resolve.py` and `platform/connections.py`: the
+  resolver and the vault candidate logic.
+- `sdks/python/agenta/sdk/agents/capabilities.py`: the harness capability table and gates.
+
+## Watch for when changing
+
+- **Provider and deployment support per harness.** The table gates runs and feeds the form.
+- **Single-connection selection.** Keep it deterministic and fail-loud on ambiguity.
+- **The tolerant default path.** Unnamed `agenta`/`self_managed` connections degrade to empty
+  `env`; that is deliberate, so do not turn it into a hard failure by accident.
+- **The secret channel.** `env` carries the key; `endpoint` is non-secret. Do not mix them.

--- a/docs/design/agent-workflows/interfaces/in-service/neutral-runtime-dtos.md
+++ b/docs/design/agent-workflows/interfaces/in-service/neutral-runtime-dtos.md
@@ -1,0 +1,95 @@
+# Neutral Runtime DTOs
+
+These are the vocabulary the Python runtime speaks. They are neutral on purpose: no Vercel
+names, no harness names, no wire quirks. Adapters translate into and out of them at the
+edges, so the rest of the runtime stays decoupled from any one protocol or harness. Change a
+field here and you change the meaning everywhere at once, which is why these models earn
+their own page.
+
+The message representation is the most load-bearing of them, so it gets a full appendix at
+the end.
+
+## The types
+
+All in `dtos.py`. The ones that carry the most weight:
+
+- **`AgentConfig`**: the parsed editable config. `instructions`, `model`/`model_ref`,
+  `tools`, `mcp_servers`, `skills`, `sandbox_permission`, and a `harness_options` bag keyed
+  by harness name. Built by `from_params(...)`. The editable schema is
+  [Agent config schema](../public-edge/agent-config-schema.md).
+- **`RunSelection`**: `harness` (default `pi`), `sandbox` (default `local`),
+  `permission_policy` (`auto` | `deny`).
+- **`SessionConfig`**: everything one run needs, assembled by the handler: the agent config,
+  secrets, resolved connection, permission policy, trace, session id, and the resolved tool
+  and MCP inputs.
+- **`Message` and `ContentBlock`**: the neutral conversation shape. See the appendix.
+- **`AgentEvent`**: a `type` plus a free `data` dict. The streamed event vocabulary
+  (`message`, `thought`, `tool_call`, `tool_result`, `usage`, `error`, `done`).
+- **`AgentResult`**: the parsed run result (output, messages, events, usage, stop reason,
+  capabilities, session id, model, trace id).
+- **`HarnessCapabilities`**: the boolean feature flags a harness reports.
+- **`TraceContext`**: the trace block sent to the runner.
+- **`PiAgentConfig`, `ClaudeAgentConfig`, `AgentaAgentConfig`**: harness-specific configs
+  that subclass a common base and each emit their own `/run` wire fields. They are the bridge
+  from neutral config to harness behavior; see [Harness adapters](harness-adapters.md).
+
+## Appendix: the message representation, all cases
+
+A `Message` is `{role, content}`, where `content` is a plain string or a list of
+`ContentBlock`. A bare string normalizes to one `text` block; a list of all-text blocks
+collapses back to a string. The Python model is snake_case, the wire (`to_wire`) is
+camelCase, and `from_raw` accepts either, so inbound coercion is forgiving.
+
+```python
+class Message:
+    role: str
+    content: str | list[ContentBlock]   # "" by default
+```
+
+A `ContentBlock` is one piece of a message, discriminated by `type`. It carries only the
+fields its type uses, and `to_wire` emits just the ones that are set.
+
+| `type` | Fields used | Meaning |
+|---|---|---|
+| `text` | `text` | a span of text (the only kind callers send today) |
+| `image` | `data` (base64), `mime_type`, `uri` | an image for an image-capable harness |
+| `resource` | `data`, `mime_type`, `uri` | a non-image attachment |
+| `tool_call` | `tool_call_id`, `tool_name`, `input` | a resolved tool call, for structured continuation |
+| `tool_result` | `tool_call_id`, `tool_name`, `output`, `is_error` | that call's result |
+
+The wire shape of each (camelCase, only set fields emitted):
+
+```jsonc
+{ "type": "text", "text": "hello" }
+{ "type": "image", "data": "<base64>", "mimeType": "image/png", "uri": "https://..." }
+{ "type": "resource", "data": "<base64>", "mimeType": "application/pdf", "uri": "..." }
+{ "type": "tool_call", "toolCallId": "call_1", "toolName": "search", "input": { "q": "..." } }
+{ "type": "tool_result", "toolCallId": "call_1", "toolName": "search",
+  "output": { "...": "..." }, "isError": false }
+```
+
+The `tool_call` and `tool_result` carriers exist so a cross-turn approval round trip replays
+as a real tool call plus its result: the [`/messages`](../public-edge/agent-messages.md)
+egress folds inbound Vercel tool and approval parts into these blocks, and the model resumes
+from the result instead of re-asking. The Vercel side of that mapping is in
+[Browser protocol adapter](browser-protocol-adapter.md). This neutral model mirrors
+`ContentBlock` in `services/agent/src/protocol.ts`.
+
+Note that this `Message` is the agent runtime's type, deliberately not re-exported as
+`agenta.Message`. A different `Message` (the prompt-template one) lives in
+`agenta.sdk.utils.types`; the two never appear in the same call.
+
+## Owned by
+
+- `sdks/python/agenta/sdk/agents/dtos.py`
+
+## Watch for when changing
+
+- **Message content shape.** `ContentBlock` is how tool calls, results, images, and approvals
+  travel through the runtime. The `from_raw`/`to_wire` pair coerces and camelCases; keep both
+  in step with the TypeScript mirror.
+- **Event names and data.** The browser adapter maps these to strict Vercel parts. A rename
+  ripples outward.
+- **Capability names.** They gate behavior across the runner and the form.
+- **Harness-specific config fields.** Each subclass owns a slice of the `/run` wire. Adding a
+  field here usually means adding a wire field and a golden fixture.

--- a/docs/design/agent-workflows/interfaces/in-service/neutral-runtime-dtos.md
+++ b/docs/design/agent-workflows/interfaces/in-service/neutral-runtime-dtos.md
@@ -9,6 +9,10 @@ their own page.
 The message representation is the most load-bearing of them, so it gets a full appendix at
 the end.
 
+How these DTOs sit in the SDK runtime layering, and which adapters translate at the edges, is
+narrated in [Ports and adapters](../../documentation/ports-and-adapters.md#runtime-package).
+This page owns the review lens: the field meanings and what to check when one moves.
+
 ## The types
 
 All in `dtos.py`. The ones that carry the most weight:

--- a/docs/design/agent-workflows/interfaces/in-service/permission-responder.md
+++ b/docs/design/agent-workflows/interfaces/in-service/permission-responder.md
@@ -1,0 +1,44 @@
+# Permission Responder
+
+When a harness asks to use a tool, something has to answer. The responder is that something.
+It abstracts two modes behind one interface: a headless policy that auto-approves or denies,
+and a human-in-the-loop flow that parks the request for browser approval and resumes it on a
+later turn. Because the browser approval spans two turns, the matching logic here is subtle,
+and worth reading before you touch it.
+
+## The contract
+
+```typescript
+interface Responder {
+  onPermission(request: PermissionRequest): Promise<PermissionDecision>;  // "allow" | "deny"
+}
+```
+
+- **`PolicyResponder`** is headless. It returns `deny` when the policy is `deny`, else `allow`.
+- **`HITLResponder`** handles human approval across turns. It holds the approval decisions
+  extracted from the message history, a base policy, and whether a human surface exists:
+  1. look the request up in the decisions map (by tool-call id, then by tool name),
+  2. if found, apply it (the resume path),
+  3. if not found and a human can answer, return `deny` to park it (the browser will be asked),
+  4. if not found and no human surface, fall back to the base policy (fully headless).
+
+**Decision extraction.** `extractApprovalDecisions(request)` scans the message history for
+`tool_result` blocks whose output is `{approved: boolean}`, and indexes each by both its
+`toolCallId` and its `toolName`. The tool name is the fallback because a cold replay can mint
+a fresh permission id each turn, so the stable anchor is the name.
+
+**Policy precedence.** `deny` from the request wins, then the
+`SANDBOX_AGENT_DENY_PERMISSIONS` env override, else `auto`.
+
+## Owned by
+
+- `services/agent/src/responder.ts`: the responders and decision extraction.
+- `services/agent/src/engines/sandbox_agent/permissions.ts`: how they wire into the ACP run.
+
+## Watch for when changing
+
+- **Policy precedence.** Request, env override, default. Reordering changes who can approve.
+- **Cross-turn matching.** Tool-call id first, tool name as the fallback for cold replays.
+  Breaking the fallback breaks approval after a replay.
+- **Parking behavior.** Whether a session has a human surface decides park-versus-headless.
+  An interactive run parks unapproved tools; a headless `/invoke` applies the base policy.

--- a/docs/design/agent-workflows/interfaces/in-service/runner-engine-internals.md
+++ b/docs/design/agent-workflows/interfaces/in-service/runner-engine-internals.md
@@ -1,0 +1,52 @@
+# Runner Engine Internals
+
+Inside the Node runner, the HTTP server and the CLI share one engine seam. Both entrypoints
+parse a request, pick an engine by `backend`, and call it with the same signature. This page
+is the runner-internal contract that keeps HTTP and CLI behaving identically. The wire shape
+they exchange is [Service to agent runner](../cross-service/service-to-agent-runner.md); this
+page is the function seam behind it.
+
+## The contract
+
+```typescript
+type RunAgent = (
+  request: AgentRunRequest,
+  emit?: EmitEvent,            // live event sink; drives the stream
+  signal?: AbortSignal,        // HTTP streaming only; the CLI has none
+) => Promise<AgentRunResult>;
+
+type EmitEvent = (event: AgentEvent) => void;
+```
+
+Both entrypoints route the same way:
+
+```typescript
+const backend = (request.backend ?? DEFAULT_BACKEND).toLowerCase();
+return backend === "pi"
+  ? runPi(request, emit)                      // in-process Pi; no signal
+  : runSandboxAgent(request, emit, signal);   // ACP path; signal optional
+```
+
+The HTTP server detects streaming from `Accept: application/x-ndjson`, wires an
+`AbortController` to the response close, and writes NDJSON or a single JSON response. The CLI
+reads the request from stdin, detects streaming from `--stream`, writes NDJSON or single JSON
+to stdout, and exits `0` on `ok: true`, `1` otherwise.
+
+## Owned by
+
+- `services/agent/src/server.ts`: the HTTP entrypoint.
+- `services/agent/src/cli.ts`: the CLI entrypoint.
+- `services/agent/src/engines/sandbox_agent.ts`: the ACP engine.
+- `services/agent/src/engines/pi.ts`: the in-process Pi engine.
+
+## Watch for when changing
+
+- **Engine selection.** The `backend` routing is the fork. A new engine plugs in here.
+- **Event emission timing.** `emit` drives the live stream; when an engine calls it changes
+  what the client sees and when.
+- **Error conversion.** HTTP maps failures to status codes; the CLI maps them to exit codes.
+  Keep the two consistent.
+- **Abort propagation.** Only HTTP streaming has a signal. The CLI cannot be cancelled mid-run
+  the same way.
+- **The terminal result.** Streaming ends with exactly one result record; both entrypoints
+  must guarantee it.

--- a/docs/design/agent-workflows/interfaces/in-service/runtime-ports.md
+++ b/docs/design/agent-workflows/interfaces/in-service/runtime-ports.md
@@ -5,6 +5,11 @@ without touching the orchestration. They are Python ABCs in one file. The servic
 them; the adapters implement them. Read this page to understand the lifecycle a run moves
 through, from backend to sandbox to session to harness.
 
+The port-by-port narrative, with the hexagonal layering and the current implementation
+status of each, is in
+[Ports and adapters](../../documentation/ports-and-adapters.md). This page owns the review
+lens: which seam a change touches and what it can break.
+
 ## The ports
 
 All in `interfaces.py`. Each has a narrow job:
@@ -52,3 +57,10 @@ All in `interfaces.py`. Each has a narrow job:
 - **Durable history.** Wiring a real `SessionStore` changes the `/load-session` contract.
 - **Harness responsibilities.** `_to_harness_config` is the single point a new harness has to
   implement.
+
+## Required test updates
+
+- `sdks/python/oss/tests/pytest/unit/agents/test_environment_lifecycle.py`: backend, sandbox,
+  and environment lifecycle.
+- `sdks/python/oss/tests/pytest/unit/agents/test_harness_adapters.py`: the `Harness` seam and
+  `_to_harness_config` per adapter.

--- a/docs/design/agent-workflows/interfaces/in-service/runtime-ports.md
+++ b/docs/design/agent-workflows/interfaces/in-service/runtime-ports.md
@@ -1,0 +1,54 @@
+# Runtime Ports
+
+The runtime ports are the abstract seams that let the service swap backends and harnesses
+without touching the orchestration. They are Python ABCs in one file. The service composes
+them; the adapters implement them. Read this page to understand the lifecycle a run moves
+through, from backend to sandbox to session to harness.
+
+## The ports
+
+All in `interfaces.py`. Each has a narrow job:
+
+- **`Backend`**: the engine abstraction. Declares `supported_harnesses`, and creates
+  sandboxes and sessions.
+
+  ```python
+  async def create_sandbox(self) -> Sandbox: ...
+  async def create_session(self, sandbox, config, *, harness,
+                           secrets=None, trace=None, session_id=None) -> Session: ...
+  ```
+
+- **`Sandbox`**: provisioning and teardown. `add_files(files)` and `destroy()`.
+- **`Session`**: one conversation. The core port:
+
+  ```python
+  @property
+  def id(self) -> Optional[str]: ...
+  async def prompt(self, messages, *, on_event=None) -> AgentResult: ...
+  def stream(self, messages) -> AgentRun: ...
+  ```
+
+- **`Environment`**: owns sandbox policy over a backend. `sandbox_per_session` decides whether
+  each session gets a fresh sandbox. Its `create_session(...)` is what the harness calls.
+- **`Harness`**: maps a neutral `SessionConfig` to a harness-specific config and runs turns.
+  The one abstract method is `_to_harness_config(config) -> HarnessAgentConfig`; the base
+  supplies `prompt`, `stream`, and `create_session`.
+- **`SessionStore`**: durable message history. `load(session_id)` and
+  `save_turn(session_id, *, messages, result)`. Only `NoopSessionStore` is wired today, so
+  history is not persisted yet (see [Agent load session](../public-edge/agent-load-session.md)).
+
+## Owned by
+
+- `sdks/python/agenta/sdk/agents/interfaces.py`
+
+## Watch for when changing
+
+- **Backend lifecycle.** `setup`/`shutdown` and sandbox creation define when resources spin
+  up and tear down.
+- **Cold versus warm sessions.** `sandbox_per_session` and the cold-runtime assumption
+  (full history every turn) hang off these ports.
+- **Session teardown.** `destroy()` defaults to a no-op; an implementation that holds
+  resources has to override it.
+- **Durable history.** Wiring a real `SessionStore` changes the `/load-session` contract.
+- **Harness responsibilities.** `_to_harness_config` is the single point a new harness has to
+  implement.

--- a/docs/design/agent-workflows/interfaces/in-service/sandbox-permission.md
+++ b/docs/design/agent-workflows/interfaces/in-service/sandbox-permission.md
@@ -1,0 +1,40 @@
+# Sandbox Permission
+
+`SandboxPermission` is the declared security boundary an agent runs inside: outbound network
+egress and filesystem access. It is Layer 2 of the model, modeled in Python and serialized to
+the runner. The important caveat for a reviewer is that it is declared, not yet enforced. The
+config travels and is versioned; the runner does not apply it on the sandbox provider yet.
+
+## The contract
+
+```jsonc
+{
+  "network": {
+    "mode": "on",                  // "on" (allow all egress) | "off" (block) | "allowlist"
+    "allowlist": []                // CIDR ranges; used when mode is "allowlist"
+  },
+  "filesystem": null,              // "on" | "readonly" | "off"; declared, not enforced
+  "enforcement": "strict"          // "strict" (fail if it cannot be applied) | "best_effort"
+}
+```
+
+It is optional on `AgentConfig`. An unset value never reaches the wire, so existing configs
+are unaffected. The default config the form pre-fills sets `network.mode: "on"` and
+`enforcement: "strict"`. The wire form is the nested camelCase `sandboxPermission` object on
+the `/run` payload.
+
+## Owned by
+
+- `sdks/python/agenta/sdk/agents/dtos.py`: `SandboxPermission` and `NetworkEgress`.
+- `services/agent/src/protocol.ts`: the wire type.
+- `services/agent/src/engines/sandbox_agent/run-plan.ts`: where the runner reads it.
+
+## Watch for when changing
+
+- **Declared versus enforced.** This is the headline. The moment the runner starts enforcing,
+  the `enforcement: "strict"` path can start failing runs that used to pass.
+- **Strict failure conditions.** Decide what counts as unenforceable before flipping
+  enforcement on.
+- **Local versus Daytona.** The two sandbox providers will enforce differently; test both.
+- **Interaction with tools and MCP servers.** Network egress and filesystem policy can block a
+  tool or an MCP server that reaches out.

--- a/docs/design/agent-workflows/interfaces/in-service/sandbox-permission.md
+++ b/docs/design/agent-workflows/interfaces/in-service/sandbox-permission.md
@@ -2,18 +2,20 @@
 
 `SandboxPermission` is the declared security boundary an agent runs inside: outbound network
 egress and filesystem access. It is Layer 2 of the model, modeled in Python and serialized to
-the runner. The important caveat for a reviewer is that it is declared, not yet enforced. The
-config travels and is versioned; the runner does not apply it on the sandbox provider yet.
+the runner. What a reviewer most needs to get right is the enforcement matrix, because it is
+uneven: network egress is a real hard boundary on Daytona, it is unenforceable on the local
+sandbox, and the filesystem boundary is declared but enforced nowhere. A change here can flip
+a run from passing to failing, so the matrix is the contract.
 
 ## The contract
 
 ```jsonc
 {
   "network": {
-    "mode": "on",                  // "on" (allow all egress) | "off" (block) | "allowlist"
-    "allowlist": []                // CIDR ranges; used when mode is "allowlist"
+    "mode": "on",                  // "on" (allow all egress) | "off" (block all) | "allowlist"
+    "allowlist": []                // CIDR ranges; honored when mode is "allowlist"
   },
-  "filesystem": null,              // "on" | "readonly" | "off"; declared, not enforced
+  "filesystem": null,              // "on" | "readonly" | "off"; declared, enforced nowhere
   "enforcement": "strict"          // "strict" (fail if it cannot be applied) | "best_effort"
 }
 ```
@@ -23,18 +25,79 @@ are unaffected. The default config the form pre-fills sets `network.mode: "on"` 
 `enforcement: "strict"`. The wire form is the nested camelCase `sandboxPermission` object on
 the `/run` payload.
 
+The field-by-field narrative of these shapes lives in
+[Agent config schema](../public-edge/agent-config-schema.md#sandbox_permission). This page
+owns the review lens: what actually enforces, where it cannot, and what to check before you
+flip the matrix.
+
+## The enforcement matrix
+
+Network egress is the only part with teeth, and only on Daytona.
+
+| Boundary | Local sandbox | Daytona | Enforced by |
+|---|---|---|---|
+| `network.mode: "off"` | not enforceable | `networkBlockAll: true` | `daytonaNetworkFields` |
+| `network.mode: "allowlist"` (non-empty) | not enforceable | `networkAllowList` (comma-joined CIDRs) | `daytonaNetworkFields` |
+| `network.mode: "allowlist"` (empty list) | not enforceable | `networkBlockAll: true` (block-all, not open) | `daytonaNetworkFields` |
+| `network.mode: "on"` / no policy | default-open | default-open (both fields unset) | n/a |
+| `filesystem` | declared only | declared only | nothing |
+
+**Network on Daytona is a hard boundary.** `daytonaNetworkFields` in
+`services/agent/src/engines/sandbox_agent/provider.ts` translates the network policy into
+Daytona create fields and `buildSandboxProvider` applies them when the sandbox provider is
+built. `mode: "off"` and an empty allowlist both map to `networkBlockAll: true`: "allow these
+zero ranges" is read faithfully as "allow nothing", so an empty allowlist locks down rather
+than opening up.
+
+**Network on local is not enforceable.** The local sidecar runs on the runner host with no
+egress control. `buildRunPlan` in `run-plan.ts` rejects a restricted network policy
+(`mode !== "on"`) on local with `enforcement: "strict"` before any work starts, and tells the
+caller to set `enforcement: "best_effort"` or move to Daytona. `best_effort` lets the run
+proceed without the guarantee.
+
+**Even on Daytona, some work runs outside the boundary.** Code tools, gateway (callback)
+tools, and stdio MCP servers do not run inside the sandbox. The tool relay
+(`services/agent/src/tools/relay.ts`) executes code and callback tools in the runner process,
+and the stdio MCP bridge (`services/agent/src/tools/mcp-bridge.ts`) launches an arbitrary
+host process. All of these sit on the runner host, so a network-blocked sandbox does not
+confine them. `buildRunPlan` knows this: under `strict` it rejects a restricted-network run on
+Daytona too when the request carries executable tool specs or a stdio MCP server, again
+pointing at `best_effort`.
+
+**Filesystem is declared, enforced nowhere.** `filesystem` (`on` / `readonly` / `off`)
+travels on the wire and is versioned with the config, but no provider applies it. See
+`protocol.ts:158`.
+
 ## Owned by
 
 - `sdks/python/agenta/sdk/agents/dtos.py`: `SandboxPermission` and `NetworkEgress`.
 - `services/agent/src/protocol.ts`: the wire type.
-- `services/agent/src/engines/sandbox_agent/run-plan.ts`: where the runner reads it.
+- `services/agent/src/engines/sandbox_agent/provider.ts`: `daytonaNetworkFields` and
+  `buildSandboxProvider`, where the network boundary is applied on Daytona.
+- `services/agent/src/engines/sandbox_agent/run-plan.ts`: `buildRunPlan`, where a restricted
+  policy is rejected when it cannot be a hard guarantee.
 
 ## Watch for when changing
 
-- **Declared versus enforced.** This is the headline. The moment the runner starts enforcing,
-  the `enforcement: "strict"` path can start failing runs that used to pass.
-- **Strict failure conditions.** Decide what counts as unenforceable before flipping
-  enforcement on.
-- **Local versus Daytona.** The two sandbox providers will enforce differently; test both.
-- **Interaction with tools and MCP servers.** Network egress and filesystem policy can block a
-  tool or an MCP server that reaches out.
+- **The enforcement matrix.** Network egress enforces on Daytona, not on local, and the
+  filesystem boundary enforces nowhere. Do not describe or treat the whole object as "declared
+  only"; only the filesystem part is.
+- **The strict-versus-best_effort gate.** `strict` rejects an unenforceable boundary;
+  `best_effort` accepts the boundary may not hold. Changing what counts as unenforceable
+  changes which runs get rejected.
+- **Runner-host bypass.** Code and gateway tools and stdio MCP servers run on the runner host
+  and escape the sandbox boundary even on Daytona. Adding a new host-side executor needs the
+  same `buildRunPlan` guard, or strict mode silently stops being strict.
+- **Local versus Daytona.** Test both. A policy that is a hard boundary on Daytona is a no-op
+  on local; the only thing protecting local is the strict-mode reject.
+- **The empty-allowlist semantics.** An empty allowlist means block-all, not open. Keep
+  `daytonaNetworkFields` and `buildRunPlan` agreeing on that, or the two disagree on whether a
+  run is restricted.
+
+## Required test updates
+
+- Runner unit tests for `daytonaNetworkFields` and `buildRunPlan` under
+  `services/agent/tests/unit/`.
+- Python wire tests for `SandboxPermission` serialization under
+  `sdks/python/oss/tests/pytest/unit/agents/`; the golden fixtures pin the camelCase
+  `sandboxPermission` shape.

--- a/docs/design/agent-workflows/interfaces/in-service/tool-models-and-resolution.md
+++ b/docs/design/agent-workflows/interfaces/in-service/tool-models-and-resolution.md
@@ -1,0 +1,72 @@
+# Tool Models And Resolution
+
+A tool starts as editable config and ends as a resolved spec that the runner can run. This
+page covers that in-service contract: the four config types the author writes, the three
+resolved spec types they become, and the permission derivation that runs in between. The
+resolved specs become `/run` fields, so a change here usually reaches the wire (see
+[Runner to tool callback](../cross-service/runner-to-tool-callback.md) and
+[Runner to MCP server](../cross-service/runner-to-mcp-server.md)).
+
+## Config types (what the author writes)
+
+All share a base of `needs_approval` (default `false`), `permission` (`allow`/`ask`/`deny`,
+optional), and `render` (optional), discriminated by `type`:
+
+```jsonc
+{ "type": "builtin", "name": "read" }
+
+{ "type": "gateway", "provider": "composio", "integration": "github",
+  "action": "create_issue", "connection": "my-gh", "name": null }
+
+{ "type": "code", "name": "fx", "runtime": "python",   // "python" | "node"
+  "script": "...", "input_schema": {}, "secrets": ["API_KEY"] }
+
+{ "type": "client", "name": "pick_file", "description": "...", "input_schema": {} }
+```
+
+## Resolved spec types (what the runner gets)
+
+```jsonc
+// callback: a gateway tool; runs in Agenta via /tools/call
+{ "kind": "callback", "name": "...", "description": "...", "input_schema": {},
+  "call_ref": "tools.composio.github.create_issue.my-gh" }
+
+// code: sandboxed code with its named secrets injected into env
+{ "kind": "code", "name": "...", "runtime": "python", "code": "...", "env": { "API_KEY": "..." } }
+
+// client: browser-fulfilled; filtered out of the runner's MCP tools/list
+{ "kind": "client", "name": "..." }
+```
+
+Each resolved spec also carries `needs_approval`, `read_only`, `permission`, and `render`.
+
+## Permission derivation
+
+When a tool's `permission` is unset, it is derived by precedence:
+
+1. an explicit `permission` wins,
+2. else `needs_approval: true` to `"ask"`,
+3. else `read_only`: `true` to `"allow"`, `false` to `"ask"`,
+4. else `None`, and the runner falls back to the global policy.
+
+## Secret injection
+
+Code tools name their secrets (`secrets: ["API_KEY"]`). The resolver fetches the named
+secrets once and merges them into the resolved spec's `env`. Gateway tools never carry a
+secret; their provider key stays server-side and the call routes back through `/tools/call`.
+
+## Owned by
+
+- `sdks/python/agenta/sdk/agents/tools/models.py`: the config and spec models and the
+  permission derivation.
+- `sdks/python/agenta/sdk/agents/platform/gateway.py`: gateway resolution to a `call_ref`.
+- `services/oss/src/agent/tools/resolver.py`: the service entrypoint (re-exports the SDK).
+
+## Watch for when changing
+
+- **Permission defaults and the derivation order.** It decides what gets gated.
+- **Read-only and render hints.** They flow through to the runner and the browser.
+- **The tool input schema.** It is what the harness sees as the tool's parameters.
+- **Secret injection for code tools.** Secrets ride `env` and are resolved once at parse time.
+- **Gateway call references.** The `call_ref` format is a paired contract with the tool
+  endpoint.

--- a/docs/design/agent-workflows/interfaces/public-edge/README.md
+++ b/docs/design/agent-workflows/interfaces/public-edge/README.md
@@ -1,0 +1,20 @@
+# Public Edge Interfaces
+
+These are the contracts the agent service exposes to callers it does not control: the
+browser playground, the embedded chat slice, and any client that drives a workflow over
+HTTP. They sit at the edge of the service and decide what those callers can rely on.
+
+A change here reaches code that ships on a different schedule than the service. Treat every
+field as load-bearing. Add before you remove, and keep older shapes working unless you have
+a reason not to.
+
+## Interfaces
+
+- [Agent messages](agent-messages.md): the streaming browser chat contract.
+- [Agent load session](agent-load-session.md): the history-resume contract, not yet wired
+  to durable storage.
+- [Workflow invoke](workflow-invoke.md): the generic batch invocation envelope.
+- [Workflow inspect](workflow-inspect.md): the schema the playground reads to build the
+  config form.
+- [Agent config schema](agent-config-schema.md): the full editable config that ships out on
+  inspect and comes back in on every run.

--- a/docs/design/agent-workflows/interfaces/public-edge/agent-config-schema.md
+++ b/docs/design/agent-workflows/interfaces/public-edge/agent-config-schema.md
@@ -1,0 +1,183 @@
+# Agent Config Schema
+
+The agent config schema is the editable shape a caller sends and the playground renders. It
+ships out through [`/inspect`](workflow-inspect.md) as the `agent_config` catalog type, comes
+back in on [`/messages`](agent-messages.md) and [`/invoke`](workflow-invoke.md) under
+`data.parameters.agent`, and the handler parses it with `AgentConfig.from_params(...)`. That
+round trip is why it sits at the public edge: a field added here has to be understood by the
+form, the request builder, and the parser at once.
+
+There are two models behind one schema. `AgentConfigSchema` (in `utils/types.py`) is strict
+and exists to *describe* the config, so the playground gets typed editors. The runtime
+`AgentConfig` (in `dtos.py`) is permissive (`List[Any]`) and exists to *coerce* whatever the
+form emits. Keep that split in mind: the schema is the contract; the parser is forgiving on
+purpose.
+
+The fields and the full schema follow.
+
+## Fields
+
+| Field | Type | Default | Meaning |
+|---|---|---|---|
+| `agents_md` | string (textarea) | hello-world prompt | The agent's system prompt, its AGENTS.md. |
+| `model` | string (`grouped_choice`) | `"gpt-5.5"` | Model the agent runs on. A plain id (`"gpt-5.5"`) or a structured `{provider, connection}` ref. See [Model connection resolution](../in-service/model-connection-resolution.md). |
+| `tools` | `ToolConfig[]` | `[]` | Runnable tools: `builtin`, `gateway`, `code`, or `client`. See [Tool models and resolution](../in-service/tool-models-and-resolution.md). |
+| `mcp_servers` | `MCPServerConfig[]` | `[]` | Declared MCP servers; secret env resolved from the vault at run time. See [MCP models and resolution](../in-service/mcp-models-and-resolution.md). |
+| `harness` | `"pi" \| "claude" \| "agenta"` | `"pi"` | The coding agent to drive. |
+| `sandbox` | `"local" \| "daytona"` | `"local"` | Where it runs. |
+| `permission_policy` | `"auto" \| "deny"` | `"auto"` | How a gating harness (Claude Code) handles tool-use prompts in a headless run. |
+| `sandbox_permission` | `SandboxPermission \| null` | `null` (form pre-fills one) | The declared network and filesystem boundary. See [Sandbox permission](../in-service/sandbox-permission.md). |
+| `skills` | `(SkillConfig \| EmbedRef)[]` | one embedded default skill | Inline SKILL.md packages, or `@ag.embed` references the backend inlines before the runner sees them. |
+
+Note that `harness`, `sandbox`, and `permission_policy` are the run selection. The handler
+reads them from the same `parameters` object via `RunSelection.from_params(...)`, not just
+from `AgentConfig`.
+
+## The default config
+
+`/inspect` ships this as the value the form starts from. It is the canonical example of
+every field in its default state:
+
+```jsonc
+{
+  "agents_md": "You are a friendly hello-world agent running on the Agenta agent service.\n\n- Greet the user warmly.\n- Answer the user's message in one or two short sentences.",
+  "model": "gpt-5.5",
+  "tools": [],
+  "mcp_servers": [],
+  "harness": "pi",
+  "sandbox": "local",
+  "permission_policy": "auto",
+  "sandbox_permission": {
+    "network": { "mode": "on", "allowlist": [] },
+    "enforcement": "strict"
+  },
+  "skills": [
+    {
+      "@ag.embed": {
+        "@ag.references": { "workflow": { "slug": "_agenta.agenta-getting-started" } },
+        "@ag.selector": { "path": "parameters.skill" }
+      }
+    }
+  ]
+}
+```
+
+The default skill is referenced by the reserved `_agenta.` slug, served from code by the
+platform catalog, never the database. The embed must reference the artifact (`workflow.slug`),
+which resolves to the latest revision; a bare revision slug with no version returns 500.
+
+## Appendix: the full schema, all cases
+
+The nested shapes the playground renders and the parser accepts.
+
+### `model`
+
+Either form is valid:
+
+```jsonc
+"gpt-5.5"                                              // plain id
+// or
+{ "provider": "openai", "model": "gpt-5.5",
+  "connection": { "mode": "agenta", "slug": "my-openai" } }   // structured ref
+```
+
+### `tools[]` (one of four variants, discriminated by `type`)
+
+```jsonc
+// builtin: a harness built-in by name
+{ "type": "builtin", "name": "read", "needs_approval": false, "permission": null, "render": null }
+
+// gateway: a server-side action (e.g. Composio); runs in Agenta, key stays server-side
+{ "type": "gateway", "provider": "composio", "integration": "github",
+  "action": "create_issue", "connection": "my-gh", "name": null,
+  "needs_approval": false, "permission": null, "render": null }
+
+// code: sandboxed code with named secrets injected at resolve time
+{ "type": "code", "name": "fx", "runtime": "python", "script": "...",
+  "input_schema": {}, "secrets": ["API_KEY"],
+  "needs_approval": false, "permission": null, "render": null }
+
+// client: fulfilled by the browser; filtered out of the runner's MCP tools/list
+{ "type": "client", "name": "pick_file", "description": "...", "input_schema": {},
+  "needs_approval": false, "permission": null, "render": null }
+```
+
+`permission` is `"allow" | "ask" | "deny"`. When unset, it is derived: explicit value wins,
+then `needs_approval` to `"ask"`, then `read_only` (`true` to `"allow"`, `false` to `"ask"`),
+else the global policy applies. See [Tool models and
+resolution](../in-service/tool-models-and-resolution.md).
+
+### `mcp_servers[]`
+
+```jsonc
+{
+  "name": "files",
+  "transport": "stdio",            // "stdio" (needs command) | "http" (needs url; deferred)
+  "command": "npx", "args": ["-y", "server-filesystem"],
+  "env": {},                       // non-secret env
+  "url": null,                     // http transport only
+  "secrets": { "TOKEN_ENV": "vault-secret-name" },  // {env var: vault secret name}
+  "tools": [],                     // allowlist; empty = all
+  "permission": null               // "allow" | "ask" | "deny"
+}
+```
+
+### `sandbox_permission`
+
+```jsonc
+{
+  "network": {
+    "mode": "on",                  // "on" (allow all) | "off" (block) | "allowlist"
+    "allowlist": []                // CIDR ranges; used when mode is "allowlist"
+  },
+  "filesystem": null,              // "on" | "readonly" | "off"; declared, not enforced yet
+  "enforcement": "strict"          // "strict" (fail if unenforceable) | "best_effort"
+}
+```
+
+This is Layer 2 of the security model. It is declared config; the runner does not enforce it
+on the sandbox provider yet. An unset value never reaches the wire.
+
+### `skills[]` (inline package or embed reference)
+
+```jsonc
+// inline SKILL.md package
+{
+  "name": "my-skill",              // ^[a-z0-9]+(-[a-z0-9]+)*$, <= 64 chars
+  "description": "trigger the model matches",   // <= 1024 chars
+  "body": "Markdown after the frontmatter",     // <= 50000 chars
+  "files": [                       // bundled files laid beside SKILL.md
+    { "path": "scripts/foo.py", "content": "...", "executable": false }
+  ],
+  "disable_model_invocation": false,   // hide from prompt; invoke only via /skill:name
+  "allow_executable_files": false      // default deny; sandbox policy must also allow
+}
+
+// embed reference: the backend inlines it into the shape above before the runner sees it
+{ "@ag.embed": { "@ag.references": { "workflow": { "slug": "_agenta.some-skill" } },
+                 "@ag.selector": { "path": "parameters.skill" } } }
+```
+
+A bundled file `path` must be relative: no leading `/`, no backslashes, no `..` segment, and
+not `SKILL.md` itself.
+
+## Owned by
+
+- `services/oss/src/agent/schemas.py`: the `/inspect` schema and the default config.
+- `sdks/python/agenta/sdk/utils/types.py`: `AgentConfigSchema` and the nested catalog types.
+- `sdks/python/agenta/sdk/agents/dtos.py`: the permissive runtime `AgentConfig` parser and
+  `SandboxPermission`.
+
+## Watch for when changing
+
+- **Two models, one contract.** Update the strict `AgentConfigSchema` and the permissive
+  runtime `AgentConfig` together, or the form and the parser drift.
+- **The catalog type.** `agent_config` binds this schema to `AgentConfigControl`. Renaming it
+  without updating the catalog breaks the form silently.
+- **The default config.** It is shipped on `/inspect` and is what an untouched form runs.
+  Keep every field's default in sync with the runtime.
+- **Nested shapes.** `tools`, `mcp_servers`, `skills`, and `sandbox_permission` each have
+  their own page and their own wire fields. A change here usually means a change there and a
+  golden fixture.
+- **Embed references.** Skills can arrive as `@ag.embed`. The schema must keep accepting that
+  form, or a valid default fails validation.

--- a/docs/design/agent-workflows/interfaces/public-edge/agent-config-schema.md
+++ b/docs/design/agent-workflows/interfaces/public-edge/agent-config-schema.md
@@ -135,8 +135,11 @@ resolution](../in-service/tool-models-and-resolution.md).
 }
 ```
 
-This is Layer 2 of the security model. It is declared config; the runner does not enforce it
-on the sandbox provider yet. An unset value never reaches the wire.
+This is Layer 2 of the security model. Enforcement is uneven: network egress is a hard
+boundary on Daytona, is unenforceable on the local sandbox (a strict restricted policy is
+rejected before the run), and the filesystem boundary is declared but enforced nowhere. The
+full matrix is in [Sandbox permission](../in-service/sandbox-permission.md#the-enforcement-matrix).
+An unset value never reaches the wire.
 
 ### `skills[]` (inline package or embed reference)
 

--- a/docs/design/agent-workflows/interfaces/public-edge/agent-load-session.md
+++ b/docs/design/agent-workflows/interfaces/public-edge/agent-load-session.md
@@ -1,0 +1,39 @@
+# Agent Load Session
+
+`POST {agent route}/load-session` is the contract a client calls to resume an earlier
+conversation from the server. The route exists and validates input, but it is not wired to
+durable storage yet. Knowing that gap is the point of this page: a reviewer should not
+assume server-side history works.
+
+## The contract
+
+```jsonc
+// request
+{ "session_id": "sess_abc" }
+
+// response
+{ "session_id": "sess_abc", "messages": [ /* Vercel UIMessage[] */ ] }
+```
+
+The default store is `NoopSessionStore`, and its `load()` returns an empty list. So today
+the response always carries `messages: []`. The browser owns conversation state through
+`useChat`; nothing server-side rehydrates it. The `session_id` is validated against the
+same `^[A-Za-z0-9._:-]{1,128}$` rule as `/messages`, and an invalid id returns `400`.
+
+The contract is shaped for the day a real `SessionStore` lands. Until then, treat a
+non-empty response as a signal that durable history has been wired, and check the rest of
+the resume path with it.
+
+## Owned by
+
+- `sdks/python/agenta/sdk/agents/adapters/vercel/routing.py`: the route and validation.
+- `sdks/python/agenta/sdk/agents/interfaces.py`: the `SessionStore` port and the no-op default.
+
+## Watch for when changing
+
+- **Wiring a real store.** The first non-no-op `SessionStore` makes this contract live.
+  Confirm the conversation rehydrates and that resumed turns carry their tool and approval
+  state, not just text.
+- **Session id validation.** Keep it identical to `/messages`. The two routes share the id.
+- **Server-owned resume.** Decide what the server is allowed to return for a session that
+  belongs to another project or user before history becomes real.

--- a/docs/design/agent-workflows/interfaces/public-edge/agent-messages.md
+++ b/docs/design/agent-workflows/interfaces/public-edge/agent-messages.md
@@ -5,6 +5,10 @@ the embedded chat slice send a turn here and render the streamed reply. It is th
 visible interface in the stack, and the one most likely to break a user-facing screen when
 its shape moves.
 
+The request, response modes, and the Vercel stream-part mapping are narrated field by field
+in [Protocol](../../documentation/protocol.md#messages). This page owns the review lens: what
+crosses the boundary, what can break, and what to check when the shape moves.
+
 ## The contract
 
 The request reuses the generic workflow envelope and carries the chat-specific payload in

--- a/docs/design/agent-workflows/interfaces/public-edge/agent-messages.md
+++ b/docs/design/agent-workflows/interfaces/public-edge/agent-messages.md
@@ -21,8 +21,7 @@ The request reuses the generic workflow envelope and carries the chat-specific p
   "data": {
     "messages":   [ /* Vercel UIMessage[] */ ],
     "parameters": { "agent": { /* draft-aware agent config */ },
-                    "harness": "pi", "sandbox": "local" },
-    "stream":     true                    // set by the route from Accept; not a caller field
+                    "harness": "pi", "sandbox": "local" }
   }
 }
 ```
@@ -31,6 +30,9 @@ The route negotiates transport from the `Accept` header. `text/event-stream` ret
 Vercel UI Message Stream framed as SSE. Anything else returns a `WorkflowBatchResponse`
 with one assistant message in `data.outputs`. The browser always sends
 `Accept: text/event-stream`.
+
+`stream` is not a caller field. The route sets `request.data.stream` from the negotiated
+transport before it invokes the shared agent handler.
 
 The `session_id` is validated against `^[A-Za-z0-9._:-]{1,128}$`. An invalid id returns
 `400`. A valid stream stamps the id onto the first SSE part's

--- a/docs/design/agent-workflows/interfaces/public-edge/agent-messages.md
+++ b/docs/design/agent-workflows/interfaces/public-edge/agent-messages.md
@@ -1,0 +1,64 @@
+# Agent Messages
+
+`POST {agent route}/messages` is the chat contract the browser drives. The playground and
+the embedded chat slice send a turn here and render the streamed reply. It is the most
+visible interface in the stack, and the one most likely to break a user-facing screen when
+its shape moves.
+
+## The contract
+
+The request reuses the generic workflow envelope and carries the chat-specific payload in
+`data`:
+
+```jsonc
+{
+  "session_id": "sess_ab12...",          // optional; the route mints sess_<uuid> when absent
+  "references": {                         // real artifact UUIDs only; local drafts dropped
+    "application":          { "id": "..." },
+    "application_variant":  { "id": "..." },
+    "application_revision": { "id": "...", "version": 3 }
+  },
+  "data": {
+    "messages":   [ /* Vercel UIMessage[] */ ],
+    "parameters": { "agent": { /* draft-aware agent config */ },
+                    "harness": "pi", "sandbox": "local" },
+    "stream":     true                    // set by the route from Accept; not a caller field
+  }
+}
+```
+
+The route negotiates transport from the `Accept` header. `text/event-stream` returns a
+Vercel UI Message Stream framed as SSE. Anything else returns a `WorkflowBatchResponse`
+with one assistant message in `data.outputs`. The browser always sends
+`Accept: text/event-stream`.
+
+The `session_id` is validated against `^[A-Za-z0-9._:-]{1,128}$`. An invalid id returns
+`400`. A valid stream stamps the id onto the first SSE part's
+`messageMetadata.sessionId` so the client can keep using it. Responses carry
+`x-ag-messages-format: vercel` and `x-ag-messages-version: v1`.
+
+The stream parts and their mapping live in [Browser protocol
+adapter](../in-service/browser-protocol-adapter.md). This page covers the edge contract;
+that page covers the translation.
+
+## Owned by
+
+- `web/packages/agenta-playground/src/state/execution/agentRequest.ts`: builds the request.
+- `web/oss/src/components/AgentChatSlice/AgentChatPanel.tsx`: drives `useChat`.
+- `sdks/python/agenta/sdk/agents/adapters/vercel/routing.py`: routes, validates, negotiates.
+- `sdks/python/agenta/sdk/agents/adapters/vercel/messages.py`: converts message history.
+- `sdks/python/agenta/sdk/agents/adapters/vercel/stream.py`: projects the event stream.
+
+## Watch for when changing
+
+- **Stream part names and shape.** The browser validates parts strictly. A renamed or
+  malformed part throws in `useChat` rather than degrading.
+- **Session id behavior.** Minting, validation bounds, and where the id lands in metadata.
+  Clients reuse the id across turns, so the runtime stays stateless.
+- **Where config lives.** Draft config rides `data.parameters`, so unsaved playground edits
+  drive the run. Do not move it into `inputs`.
+- **History shape.** The browser owns conversation state. Blank assistant turns must be
+  pruned client-side or they cascade into empty replies. Incomplete MCP or skill entries
+  must be pruned or the backend rejects the request.
+- **Approval, tool, file, data, usage, and trace parts.** Each maps to a strict Vercel part;
+  changing one ripples into the adapter and the client at once.

--- a/docs/design/agent-workflows/interfaces/public-edge/workflow-inspect.md
+++ b/docs/design/agent-workflows/interfaces/public-edge/workflow-inspect.md
@@ -7,14 +7,27 @@ schema. Change what this returns and you change what the playground renders.
 
 ## The contract
 
-The response carries the three schemas plus harness metadata:
+The raw response is an inspect envelope. The schemas and default config sit under
+`data.revision.data`; top-level `meta` carries harness metadata when the registered agent
+workflow provides it:
 
 ```jsonc
 {
-  "inputs":     { /* messages, marked x-ag-type-ref: "messages" */ },
-  "parameters": { "properties": { "agent": { /* x-ag-type-ref: "agent_config" */ } } },
-  "outputs":    { /* assistant message schema */ },
-  "meta":       { "harness_capabilities": { /* per-harness provider/deployment limits */ } }
+  "version": "2025.07.14",
+  "meta": { "harness_capabilities": { /* per-harness provider/deployment limits */ } },
+  "data": {
+    "revision": {
+      "data": {
+        "uri": "agenta:builtin:agent:v0",
+        "schemas": {
+          "inputs":     { /* messages, marked x-ag-type-ref: "messages" */ },
+          "parameters": { "properties": { "agent": { /* x-ag-type-ref: "agent_config" */ } } },
+          "outputs":    { /* assistant message schema */ }
+        },
+        "parameters": { /* default agent config */ }
+      }
+    }
+  }
 }
 ```
 
@@ -23,7 +36,7 @@ chat workflow. `x-ag-type-ref: "agent_config"` tells it to render the agent conf
 Each marker resolves through `/workflows/catalog/types/{type}` to the full JSON Schema, so
 the form and the schema stay in one place. The `meta.harness_capabilities` block is the same
 table the service uses server-side to reject unreachable provider and deployment choices, so
-the form can filter stored connections before the user submits.
+the form can filter stored connections before the user submits when that metadata is present.
 
 The shape of the config itself lives in [Agent config
 schema](agent-config-schema.md). This page covers what `/inspect` returns; that page covers

--- a/docs/design/agent-workflows/interfaces/public-edge/workflow-inspect.md
+++ b/docs/design/agent-workflows/interfaces/public-edge/workflow-inspect.md
@@ -1,0 +1,45 @@
+# Workflow Inspect
+
+`POST {route}/inspect` returns the workflow's interface description. The playground reads it
+to build the config form and to know what the workflow accepts and returns. For the agent
+service it returns the chat input schema, the output schema, and the editable agent config
+schema. Change what this returns and you change what the playground renders.
+
+## The contract
+
+The response carries the three schemas plus harness metadata:
+
+```jsonc
+{
+  "inputs":     { /* messages, marked x-ag-type-ref: "messages" */ },
+  "parameters": { "properties": { "agent": { /* x-ag-type-ref: "agent_config" */ } } },
+  "outputs":    { /* assistant message schema */ },
+  "meta":       { "harness_capabilities": { /* per-harness provider/deployment limits */ } }
+}
+```
+
+Two markers do the heavy lifting. `x-ag-type-ref: "messages"` tells the playground this is a
+chat workflow. `x-ag-type-ref: "agent_config"` tells it to render the agent config control.
+Each marker resolves through `/workflows/catalog/types/{type}` to the full JSON Schema, so
+the form and the schema stay in one place. The `meta.harness_capabilities` block is the same
+table the service uses server-side to reject unreachable provider and deployment choices, so
+the form can filter stored connections before the user submits.
+
+The shape of the config itself lives in [Agent config
+schema](agent-config-schema.md). This page covers what `/inspect` returns; that page covers
+the fields.
+
+## Owned by
+
+- `services/oss/src/agent/schemas.py`: builds the input, parameter, and output schemas.
+- `sdks/python/agenta/sdk/models/workflows.py`: the inspect response model.
+- `sdks/python/agenta/sdk/decorators/routing.py`: the generic inspect route.
+
+## Watch for when changing
+
+- **Catalog type markers.** `agent_config` and `messages` bind the schema to a playground
+  control. Renaming a marker without updating the catalog breaks the form silently.
+- **The config default.** `/inspect` ships the default agent config the form starts from.
+  Keep it in sync with what the runtime actually accepts.
+- **Harness capability metadata.** The form filters connections from this block. If it drifts
+  from the server-side table, the form offers choices the run will reject.

--- a/docs/design/agent-workflows/interfaces/public-edge/workflow-invoke.md
+++ b/docs/design/agent-workflows/interfaces/public-edge/workflow-invoke.md
@@ -5,6 +5,10 @@ every workflow type answers it. Agent workflows use it for batch calls, the non-
 path that returns a single assistant message. A change here touches every workflow, so the
 agent service has to fit the envelope rather than reshape it.
 
+The agent handler's read of this envelope is narrated in
+[Protocol](../../documentation/protocol.md#invoke). This page owns the review lens: what
+crosses the boundary, what can break, and what to check when the shape moves.
+
 ## The contract
 
 The request is the shared `WorkflowInvokeRequest` envelope. The agent handler reads three

--- a/docs/design/agent-workflows/interfaces/public-edge/workflow-invoke.md
+++ b/docs/design/agent-workflows/interfaces/public-edge/workflow-invoke.md
@@ -1,0 +1,52 @@
+# Workflow Invoke
+
+`POST {route}/invoke` is the generic workflow invocation contract. It is not agent-specific;
+every workflow type answers it. Agent workflows use it for batch calls, the non-streaming
+path that returns a single assistant message. A change here touches every workflow, so the
+agent service has to fit the envelope rather than reshape it.
+
+## The contract
+
+The request is the shared `WorkflowInvokeRequest` envelope. The agent handler reads three
+things out of it:
+
+- the turn history from `data.inputs.messages` (or `data.messages`),
+- the agent config and run selection from `data.parameters`,
+- the trace and reference context from the envelope itself.
+
+```jsonc
+{
+  "references": { /* application / variant / revision */ },
+  "data": {
+    "inputs":     { "messages": [ /* chat history */ ] },
+    "parameters": { "agent": { /* config */ }, "harness": "pi", "sandbox": "local" }
+  }
+}
+```
+
+The response is the generic workflow response. For agents, `data` carries one assistant
+message:
+
+```jsonc
+{ "data": { "role": "assistant", "content": "..." } }
+```
+
+`parameters` carries both the agent config (under `agent`) and the run selection (`harness`,
+`sandbox`, `permission_policy`) in the same object. The handler reads the history from
+`data.messages` first, then falls back to `inputs.messages`. The streaming version of this
+work is [Agent messages](agent-messages.md); this contract is the batch path.
+
+## Owned by
+
+- `sdks/python/agenta/sdk/models/workflows.py`: the envelope models.
+- `sdks/python/agenta/sdk/decorators/routing.py`: the generic route and Accept negotiation.
+- `services/oss/src/agent/app.py`: the agent handler that reads the envelope.
+
+## Watch for when changing
+
+- **The generic envelope.** Request and response models are shared across workflow types.
+  A change ripples beyond agents.
+- **Batch agent behavior.** Confirm the single assistant message still lands in `data` in
+  the shape callers expect.
+- **Accept negotiation.** The decorator decides batch versus stream. Non-Vercel stream
+  consumers depend on that negotiation staying stable.

--- a/docs/design/agent-workflows/interfaces/public-edge/workflow-invoke.md
+++ b/docs/design/agent-workflows/interfaces/public-edge/workflow-invoke.md
@@ -24,11 +24,11 @@ things out of it:
 }
 ```
 
-The response is the generic workflow response. For agents, `data` carries one assistant
-message:
+The response is the generic workflow response. For agents, `data.outputs` carries one
+assistant message:
 
 ```jsonc
-{ "data": { "role": "assistant", "content": "..." } }
+{ "data": { "outputs": { "role": "assistant", "content": "..." } } }
 ```
 
 `parameters` carries both the agent config (under `agent`) and the run selection (`harness`,
@@ -46,7 +46,7 @@ work is [Agent messages](agent-messages.md); this contract is the batch path.
 
 - **The generic envelope.** Request and response models are shared across workflow types.
   A change ripples beyond agents.
-- **Batch agent behavior.** Confirm the single assistant message still lands in `data` in
-  the shape callers expect.
+- **Batch agent behavior.** Confirm the single assistant message still lands in
+  `data.outputs` in the shape callers expect.
 - **Accept negotiation.** The decorator decides batch versus stream. Non-Vercel stream
   consumers depend on that negotiation staying stable.


### PR DESCRIPTION
## Context
Agent workflow review work currently has to jump between protocol, architecture, runner, and adapter docs to understand which interface a change touches. We need a lightweight map that names those boundaries and points reviewers to the owning files.

## Changes
Adds `docs/design/agent-workflows/interfaces/` as a review-oriented inventory, organized by blast radius:

- public edge interfaces for browser and workflow-client contracts
- cross-service interfaces for service, sidecar, harness, tools, MCP, vault, and trace boundaries
- in-service interfaces for SDK ports, DTOs, adapters, config, permissions, and model resolution

Each category has its own folder, with one file per interface or closely related interface group.

## Scope / risk
Docs-only change. No code, no tests, no migrations. The only thing that could regress is a broken cross-reference, and those were checked during authoring.

## Tests / notes
Verified the new links and scanned the new docs for banned docs-style terms and em dashes.

## How to QA

**Prerequisites:** No stack needed. A browser or a Markdown reader is enough.

**Steps:**
1. Open `docs/design/agent-workflows/interfaces/README.md` and verify the three category sections (Public edge, Cross-service, In-service) each link to a populated subfolder.
2. Click through three or four of the linked files and confirm the interface name, owning file path, and description make sense for a reviewer who doesn't know the PR.
3. Check that no file contains a broken relative link (GitHub renders these as 404 text in the preview).

**Expected result:** Every linked file opens and describes a real boundary in the codebase. No 404 links.

**Automated tests:** None. This is docs-only; there are no automated tests to run.

**Edge cases:** Confirm the `agent-load-session.md` file exists (it is referenced from `public-edge/README.md`); it will be deleted in the follow-on chore PR (#4828).
