### PR TITLE
fix(frontend): repair SessionsTable JSX from botched merge

### DIFF
--- a/web/oss/src/components/pages/observability/components/SessionsTable/index.tsx
+++ b/web/oss/src/components/pages/observability/components/SessionsTable/index.tsx
@@ -120,46 +120,25 @@ const SessionsTable: React.FC = () => {
     const isEmptyState = sessionIds.length === 0 && !isLoading
 
     return (
-        <div className="flex flex-col h-full gap-2 min-h-0">
-            <ObservabilityHeader
-                columns={columns}
-                componentType="sessions"
-                isLoading={isLoading}
-                onRefresh={handleRefresh}
-                realtimeMode={realtimeMode}
-                setRealtimeMode={setRealtimeMode}
-                autoRefresh={autoRefresh}
-                setAutoRefresh={setAutoRefresh}
-                refreshTrigger={refreshTrigger}
-            />
-
-            {isEmptyState ? (
-                <EmptySessions showOnboarding={showOnboarding} />
-            ) : (
-                <InfiniteVirtualTableFeatureShell<SessionRow>
-                    store={store}
-                    tableScope={tableScope}
+        <SessionStoreProvider>
+            <div className="flex h-full min-h-0 flex-col gap-2">
+                <ObservabilityHeader
                     columns={columns}
-                    rowKey="session_id"
-                    pagination={pagination}
-                    resizableColumns
-                    enableExport={false}
-                    useSettingsDropdown={false}
-                    className="[&_.ant-table-tbody_.ant-table-cell]:align-top"
-                    tableProps={{
-                        bordered: true,
-                        loading: isLoading && sessionIds.length === 0,
-                        onRow: (record) => ({
-                            onClick: () => openDrawer({sessionId: record.session_id}),
-                            style: {cursor: "pointer"},
-                        }),
-                    }}
+                    componentType="sessions"
+                    isLoading={isLoading}
+                    onRefresh={handleRefresh}
+                    realtimeMode={realtimeMode}
+                    setRealtimeMode={setRealtimeMode}
+                    autoRefresh={autoRefresh}
+                    setAutoRefresh={setAutoRefresh}
+                    refreshTrigger={refreshTrigger}
                 />
 
                 {isEmptyState ? (
                     <EmptySessions showOnboarding={showOnboarding} />
                 ) : (
                     <InfiniteVirtualTableFeatureShell<SessionRow>
+                        store={store}
                         tableScope={tableScope}
                         columns={columns}
                         rowKey="session_id"

--- a/web/packages/agenta-entities/src/workflow/state/appUtils.ts
+++ b/web/packages/agenta-entities/src/workflow/state/appUtils.ts
@@ -209,6 +209,7 @@ export async function createEphemeralAppFromTemplate({
             // Agent takes messages-in / returns a final message, so it runs in
             // chat mode like `chat` (backend infers is_chat from messages-in too).
             is_chat: type === "chat" || type === "agent",
+            is_agent: type === "agent",
             has_url: false,
             has_script: false,
             has_handler: false,

--- a/web/packages/agenta-entity-ui/src/DrillInView/SchemaControls/AgentConfigControl.tsx
+++ b/web/packages/agenta-entity-ui/src/DrillInView/SchemaControls/AgentConfigControl.tsx
@@ -40,7 +40,6 @@ import {ToolSelectorPopover, type ToolSelectionMeta} from "./ToolSelectorPopover
 import {type ToolObj} from "./toolUtils"
 
 const CONNECTION_MODE_LABELS: Record<ConnectionMode, string> = {
-    default: "Project default",
     self_managed: "Self-managed",
     agenta: "Agenta connection",
 }

--- a/web/packages/agenta-playground/src/state/execution/agentRequest.ts
+++ b/web/packages/agenta-playground/src/state/execution/agentRequest.ts
@@ -234,7 +234,7 @@ export async function buildAgentRequest(
     // SSE stream `useChat` consumes. Without it the endpoint negotiates down to a
     // batch JSON response (Accept defaults to `*/*`; the AI-SDK transport sets no
     // Accept), which `useChat` can't render — the run succeeds but nothing appears.
-    const headers = {
+    const headers: Record<string, string> = {
         Accept: "text/event-stream",
         ...(headersFactory ? await headersFactory() : {}),
     }


### PR DESCRIPTION
## Symptom

The `main` → `big-agents` merge (in #4791) broke frontend CI two ways:

1. **TypeScript format / lint**: `SessionsTable/index.tsx` had a duplicate `{isEmptyState ? ...}` ternary and a mismatched `<div>` … `</SessionStoreProvider>` wrapper (a hard JSX syntax error).
2. **agenta-web build (amd64 + arm64)**: `@agenta/entities` failed to type-check — `appUtils.ts` built its ephemeral-workflow `flags` without the newly-added (defaulted) `is_agent` flag, so the `as Workflow` cast failed bidirectional overlap (TS2352). `next lint` does not catch this; the build's `tsc` does.

## Fix

1. Unite both merge sides of `SessionsTable`: wrap in `<SessionStoreProvider>`, keep one table retaining `store={store}` and the `flex-1` layout class.
2. Set `is_agent: type === 'agent'` in the constructed flags.

## Verification

- `prettier --check` + `eslint` on SessionsTable: pass.
- `@agenta/entities` `pnpm run types:check`: exit 0.

https://claude.ai/code/session_01DEZYALzKjh9ocjkscaBWRT