### PR TITLE
style(examples): ruff format RAG_QA_chatbot scripts

### DIFF
--- a/examples/python/RAG_QA_chatbot/backend/agent_loop.py
+++ b/examples/python/RAG_QA_chatbot/backend/agent_loop.py
@@ -217,7 +217,9 @@ async def _stream_step(
             yield _sse({"type": "text-delta", "id": text_id, "delta": content})
 
         for tc in getattr(delta, "tool_calls", None) or []:
-            acc = tool_acc.setdefault(tc.index, {"id": "", "name": "", "args": "", "started": ""})
+            acc = tool_acc.setdefault(
+                tc.index, {"id": "", "name": "", "args": "", "started": ""}
+            )
             if tc.id:
                 acc["id"] = tc.id
             fn = getattr(tc, "function", None)
@@ -230,7 +232,11 @@ async def _stream_step(
             if not acc["started"] and acc["id"] and acc["name"]:
                 acc["started"] = "1"
                 yield _sse(
-                    {"type": "tool-input-start", "toolCallId": acc["id"], "toolName": acc["name"]}
+                    {
+                        "type": "tool-input-start",
+                        "toolCallId": acc["id"],
+                        "toolName": acc["name"],
+                    }
                 )
                 if acc["args"]:  # flush args that arrived before the name
                     yield _sse(

--- a/examples/python/RAG_QA_chatbot/ingest/fix_urls.py
+++ b/examples/python/RAG_QA_chatbot/ingest/fix_urls.py
@@ -20,10 +20,14 @@ from .loaders import load_mdx
 
 
 def main():
-    parser = argparse.ArgumentParser(description="Backfill corrected doc URLs in Qdrant")
+    parser = argparse.ArgumentParser(
+        description="Backfill corrected doc URLs in Qdrant"
+    )
     parser.add_argument("--source", required=True, help="Path to docs directory")
     parser.add_argument("--base-url", required=True, help="Base URL for doc links")
-    parser.add_argument("--collection", default=None, help="Collection (default: from env)")
+    parser.add_argument(
+        "--collection", default=None, help="Collection (default: from env)"
+    )
     args = parser.parse_args()
 
     load_dotenv()
@@ -32,9 +36,13 @@ def main():
     url_by_path = {d.file_path: d.url for d in load_mdx(args.source, args.base_url)}
     print(f"Re-derived {len(url_by_path)} URLs from {args.source}")
 
-    client = QdrantClient(url=os.getenv("QDRANT_URL"), api_key=os.getenv("QDRANT_API_KEY"))
+    client = QdrantClient(
+        url=os.getenv("QDRANT_URL"), api_key=os.getenv("QDRANT_API_KEY")
+    )
 
-    pending: dict[str, list] = defaultdict(list)  # correct_url -> [point ids needing it]
+    pending: dict[str, list] = defaultdict(
+        list
+    )  # correct_url -> [point ids needing it]
     scanned = 0
     offset = None
     while True:


### PR DESCRIPTION
## Symptom

**Python format** CI failed on #4791: `ruff format --check` wanted to reformat two files.

## Fix

Ran `ruff format` on:
- `examples/python/RAG_QA_chatbot/backend/agent_loop.py`
- `examples/python/RAG_QA_chatbot/ingest/fix_urls.py`

## Verification

`ruff format --check` on both: `2 files already formatted`.

https://claude.ai/code/session_01DEZYALzKjh9ocjkscaBWRT