### PR TITLE
fix(agent): drop skills on Claude wire (restore lost override)

### DIFF
--- a/sdks/python/agenta/sdk/agents/dtos.py
+++ b/sdks/python/agenta/sdk/agents/dtos.py
@@ -697,6 +697,12 @@ class ClaudeAgentConfig(HarnessAgentConfig):
             "permissionPolicy": self.permission_policy,
         }
 
+    def wire_skills(self) -> Dict[str, Any]:
+        """Claude's headless SDK cannot load inline skill packages, so the Claude config
+        drops any authored skills (graceful degrade) and emits no ``skills`` on the wire.
+        Pi and Agenta override this differently via the inherited base seam."""
+        return {}
+
     def wire_harness_files(self) -> Dict[str, Any]:
         """Render the Claude harness's permission settings into a ``.claude/settings.json`` file
         the runner drops in the cwd. This is the claude adapter (Layer 1 translation), done in


### PR DESCRIPTION
## Symptom

**Application services Unit Test Results** (and the aggregated CodeQL check) failed on #4791:
`test_invoke_cross_harness_same_body_divergent_configs` asserts `claude_cfg.wire_skills() == {}` but got a populated `skills` dict.

## Root cause

`ClaudeAgentConfig` must override `wire_skills()` to return `{}` — Claude's headless SDK cannot load inline skill packages, so it logs-and-drops them (graceful degrade). That override was dropped in the `main` → `big-agents` merge, so the class fell back to the base `wire_skills`, which wires the skills.

## Fix

Re-add the `wire_skills` override on `ClaudeAgentConfig` returning `{}`.

## Verification

- Target test: `1 passed`.
- Full file: `13 passed`.

https://claude.ai/code/session_01DEZYALzKjh9ocjkscaBWRT