### PR TITLE
fix(agent): Claude carries skills for project-local materialization

### DIFF
--- a/sdks/python/agenta/sdk/agents/dtos.py
+++ b/sdks/python/agenta/sdk/agents/dtos.py
@@ -697,12 +697,6 @@ class ClaudeAgentConfig(HarnessAgentConfig):
             "permissionPolicy": self.permission_policy,
         }
 
-    def wire_skills(self) -> Dict[str, Any]:
-        """Claude's headless SDK cannot load inline skill packages, so the Claude config
-        drops any authored skills (graceful degrade) and emits no ``skills`` on the wire.
-        Pi and Agenta override this differently via the inherited base seam."""
-        return {}
-
     def wire_harness_files(self) -> Dict[str, Any]:
         """Render the Claude harness's permission settings into a ``.claude/settings.json`` file
         the runner drops in the cwd. This is the claude adapter (Layer 1 translation), done in

--- a/services/oss/tests/pytest/unit/agent/test_invoke_handler.py
+++ b/services/oss/tests/pytest/unit/agent/test_invoke_handler.py
@@ -180,11 +180,12 @@ async def test_invoke_cross_harness_same_body_divergent_configs(
     assert agenta_wire["permissionPolicy"] == "auto"
     assert "skills" not in agenta_wire
 
-    # Skills ride the dedicated `wire_skills` seam. Pi and Agenta load them; Claude's SDK path
-    # cannot, so it logs-and-drops (graceful degrade), emitting no skills.
+    # Skills ride the dedicated `wire_skills` seam. All three harnesses carry the resolved
+    # inline package: Pi/Agenta load it into the resource loader, and the runner materializes
+    # it for Claude under `.claude/skills/<name>` (project-local skill layout).
     assert pi_cfg.wire_skills()["skills"][0]["name"] == "release-notes"
     assert agenta_cfg.wire_skills()["skills"][0]["name"] == "release-notes"
-    assert claude_cfg.wire_skills() == {}
+    assert claude_cfg.wire_skills()["skills"][0]["name"] == "release-notes"
 
     # The configs genuinely differ at the boundary; the body's sameness is not a tautology.
     assert pi_wire != claude_wire


### PR DESCRIPTION
## Symptom

After #4824 merged, **run-sdk-unit-tests** failed: `test_claude_carries_skills_for_project_local_materialization` got `KeyError: 'skills'` from `claude_cfg.wire_skills()`.

## Root cause

#4824 restored a `ClaudeAgentConfig.wire_skills` override returning `{}` (graceful degrade). That assumption is stale: commit `08212c6dca` (*fix(agent): materialize skills for Claude harness*, already on big-agents) made the runner materialize skills under `.claude/skills/<name>`, so Claude **does** carry them on the wire. The override fixed the stale services-test assertion but broke the authoritative SDK test.

The `main` → `big-agents` merge left the two tests contradicting each other; #4824 picked the wrong side.

## Fix

- Remove the `ClaudeAgentConfig.wire_skills` override; Claude inherits the base seam and carries resolved inline skill packages.
- Update the stale `test_invoke_handler` assertion to expect Claude carries the skill (aligned with the SDK test and the runner materializer).

## Verification

- SDK `oss/tests/pytest/unit/agents`: 319 passed.
- Services `test_invoke_handler.py`: 13 passed.

https://claude.ai/code/session_01DEZYALzKjh9ocjkscaBWRT