### PR TITLE
test(agent): align acceptance/integration tests with agent refactors

### DIFF
--- a/sdks/python/oss/tests/pytest/acceptance/workflows/test_new_uri_handlers.py
+++ b/sdks/python/oss/tests/pytest/acceptance/workflows/test_new_uri_handlers.py
@@ -502,6 +502,10 @@ class TestLlmV0Acceptance:
         assert retrieve_handler("agenta:builtin:prompt:v0") is None
         assert retrieve_interface("agenta:builtin:prompt:v0") is None
 
-    def test_agent_alias_is_not_registered(self):
+    def test_agent_interface_is_registered_without_handler(self):
+        # The agent builtin ships an interface (schemas) but no in-process handler:
+        # the agent runs in the sidecar, not via a registered SDK callable.
         assert retrieve_handler("agenta:builtin:agent:v0") is None
-        assert retrieve_interface("agenta:builtin:agent:v0") is None
+        revision = retrieve_interface("agenta:builtin:agent:v0")
+        assert isinstance(revision, WorkflowRevisionData)
+        assert revision.uri == "agenta:builtin:agent:v0"

--- a/services/oss/tests/pytest/integration/agent/conftest.py
+++ b/services/oss/tests/pytest/integration/agent/conftest.py
@@ -1,9 +1,10 @@
 """Integration fixtures: a fake httpx client for the tool/secret resolvers.
 
 These tests wire the real resolver code against a mocked HTTP boundary (no live backend, no
-respx/pytest-httpx dependency). ``install_http`` patches, in a given resolver module, the two
-``client`` helpers (``agenta_api_base`` / ``request_authorization``) plus ``httpx.AsyncClient``,
-and returns a ``capture`` dict the test can assert the outgoing request against.
+respx/pytest-httpx dependency). ``install_http`` patches the two ``PlatformConnection`` helpers
+(``_derive_base_url`` / ``_derive_authorization`` in the SDK platform connection module) plus
+``httpx.AsyncClient`` in the given SDK platform module that performs the HTTP, and returns a
+``capture`` dict the test can assert the outgoing request against.
 """
 
 from __future__ import annotations
@@ -12,6 +13,8 @@ import json
 from typing import Any, Dict, Optional
 
 import pytest
+
+from agenta.sdk.agents.platform import connection as platform_connection
 
 
 class _FakeResponse:
@@ -63,8 +66,10 @@ def install_http(monkeypatch):
         authorization: Optional[str] = "Access tok",
     ) -> Dict[str, Any]:
         capture: Dict[str, Any] = {}
-        monkeypatch.setattr(module, "agenta_api_base", lambda: api_base)
-        monkeypatch.setattr(module, "request_authorization", lambda: authorization)
+        monkeypatch.setattr(platform_connection, "_derive_base_url", lambda: api_base)
+        monkeypatch.setattr(
+            platform_connection, "_derive_authorization", lambda: authorization
+        )
         response = _FakeResponse(status, payload, text)
         monkeypatch.setattr(
             module.httpx,

--- a/services/oss/tests/pytest/integration/agent/test_resolve_secrets_http.py
+++ b/services/oss/tests/pytest/integration/agent/test_resolve_secrets_http.py
@@ -8,20 +8,20 @@ from __future__ import annotations
 
 import pytest
 
-from oss.src.agent import secrets
 from oss.src.agent.secrets import resolve_harness_secrets
+from agenta.sdk.agents.platform import secrets as platform_secrets
 
 pytestmark = pytest.mark.integration
 
 
 async def test_no_api_base_returns_empty(install_http):
-    install_http(secrets, api_base=None)
+    install_http(platform_secrets, api_base=None)
     assert await resolve_harness_secrets() == {}
 
 
 async def test_maps_only_provider_keys_with_dedupe(install_http):
     install_http(
-        secrets,
+        platform_secrets,
         status=200,
         payload=[
             {
@@ -55,10 +55,10 @@ async def test_maps_only_provider_keys_with_dedupe(install_http):
 
 
 async def test_http_error_returns_empty(install_http):
-    install_http(secrets, status=400)
+    install_http(platform_secrets, status=400)
     assert await resolve_harness_secrets() == {}
 
 
 async def test_network_exception_returns_empty(install_http):
-    install_http(secrets, raises=RuntimeError("network down"))
+    install_http(platform_secrets, raises=RuntimeError("network down"))
     assert await resolve_harness_secrets() == {}

--- a/services/oss/tests/pytest/integration/agent/tools/test_gateway_http.py
+++ b/services/oss/tests/pytest/integration/agent/tools/test_gateway_http.py
@@ -9,7 +9,7 @@ from agenta.sdk.agents import (
 )
 
 from oss.src.agent.tools import resolve_tools
-from oss.src.agent.tools import gateway
+from agenta.sdk.agents.platform import gateway
 
 pytestmark = pytest.mark.integration
 

--- a/services/oss/tests/pytest/integration/agent/tools/test_secrets_http.py
+++ b/services/oss/tests/pytest/integration/agent/tools/test_secrets_http.py
@@ -3,13 +3,14 @@ from __future__ import annotations
 import pytest
 
 from oss.src.agent.tools import secrets
+from agenta.sdk.agents.platform import secrets as platform_secrets
 
 pytestmark = pytest.mark.integration
 
 
 async def test_named_secrets_are_resolved_by_tools_adapter(install_http):
     capture = install_http(
-        secrets,
+        platform_secrets,
         payload={"secrets": {"TOKEN": "value", "EMPTY": None}},
     )
 
@@ -28,12 +29,12 @@ async def test_named_secrets_are_resolved_by_tools_adapter(install_http):
 
 
 async def test_named_secrets_without_api_base_return_empty(install_http):
-    install_http(secrets, api_base=None)
+    install_http(platform_secrets, api_base=None)
 
     assert await secrets.resolve_named_secrets(["TOKEN"]) == {}
 
 
 async def test_named_secret_http_failure_returns_empty(install_http):
-    install_http(secrets, status=500)
+    install_http(platform_secrets, status=500)
 
     assert await secrets.resolve_named_secrets(["TOKEN"]) == {}


### PR DESCRIPTION
## Symptom

The acceptance + integration test suites were **skipped** on #4791 while the agenta-web build was broken. Once #4822 fixed the build, they ran and surfaced pre-existing drift on big-agents:

- **run-sdk-tests (acceptance)**: `test_agent_alias_is_not_registered` failed — the agent builtin now ships a registered *interface*.
- **run-services-tests (integration)**: 15 failures — `AttributeError: ... has no attribute 'agenta_api_base'`.

## Root cause

Two agent refactors already on big-agents weren't reflected in these tests:

1. The agent builtin (`agenta:builtin:agent:v0`) registers an **interface** (schemas) but no in-process handler — it runs in the sidecar. The old test asserted it was fully unregistered.
2. Gateway/secret resolution **moved into the SDK platform package** (#4772). `oss/src/agent/tools/{gateway,secrets}.py` and `oss/src/agent/secrets.py` are now thin re-export shims, so the module-level `agenta_api_base` / `request_authorization` / `httpx` / `log` the tests patched no longer exist on them.

## Fix (tests only)

- Rename + correct the sdk test to assert the agent **interface is registered** and the handler is absent.
- Repoint the integration conftest to patch `PlatformConnection`'s `_derive_base_url` / `_derive_authorization` helpers, and patch `httpx`/`log` on the SDK platform `gateway`/`secrets` modules (where the resolvers actually run). Test intent preserved; no tests deleted.

## Verification

- sdk `test_new_uri_handlers.py`: 27 passed.
- services `integration/agent`: 15 passed.

https://claude.ai/code/session_01DEZYALzKjh9ocjkscaBWRT