### PR TITLE
fix(api): scrub server-owned flags from workflow query filters

### DIFF
--- a/api/oss/src/core/workflows/service.py
+++ b/api/oss/src/core/workflows/service.py
@@ -794,8 +794,10 @@ class WorkflowsService:
                     exclude_none=True,
                     exclude={"flags"},
                 ),
-                flags=self._dump_flags(
-                    self._artifact_query_flags_from_any(workflow_query.flags)
+                flags=self._scrub_server_owned_flags(
+                    self._dump_flags(
+                        self._artifact_query_flags_from_any(workflow_query.flags)
+                    )
                 )
                 or None,
             )
@@ -1629,9 +1631,11 @@ class WorkflowsService:
                     exclude_none=True,
                     exclude={"flags"},
                 ),
-                flags=self._dump_flags(
-                    self._revision_query_flags_from_any(
-                        workflow_revision_query.flags,
+                flags=self._scrub_server_owned_flags(
+                    self._dump_flags(
+                        self._revision_query_flags_from_any(
+                            workflow_revision_query.flags,
+                        )
                     )
                 )
                 or None,


### PR DESCRIPTION
## Symptom

`run-api-tests (acceptance)` failed on #4791 once the build was fixed and the suite stopped being skipped: `test_query_workflows_by_flags` got `count == 0` instead of `1`.

## Root cause (real backend bug)

The write path scrubs the **server-owned `is_platform` flag** before persisting (`_scrub_server_owned_flags`), so stored flags never contain that key. The **query path did not scrub**, so a `/workflows/query` carrying `is_platform` (the test re-posts a workflow's own echoed-back flags, which include `is_platform: false`) built a JSONB `@>` containment filter for a key that is never stored — matching zero rows.

This affects any client that round-trips an echoed workflow's flags into a query, not just the test.

## Fix

Apply `_scrub_server_owned_flags` to the dumped flags on **both** the artifact and revision query builders, symmetric with the write path. Platform-catalogue workflows are served from the code catalog (not the DB), so `is_platform` must never gate a DB containment query.

## Verification

- `ruff format`/`ruff check`: clean.
- `test_flag_ownership.py` unit suite: 13 passed.
- Acceptance test validated by CI on this PR (needs Postgres).

https://claude.ai/code/session_01DEZYALzKjh9ocjkscaBWRT