### PR TITLE
fix(api): only drop is_platform query filter when False, not True

### DIFF
--- a/api/oss/src/core/workflows/service.py
+++ b/api/oss/src/core/workflows/service.py
@@ -181,6 +181,21 @@ class WorkflowsService:
             if key not in cls.SERVER_OWNED_FLAG_KEYS
         }
 
+    @classmethod
+    def _drop_default_server_owned_query_flags(cls, flags: dict) -> dict:
+        """For query filters: drop a server-owned flag only when it is False (its default).
+
+        A caller re-posting a workflow's serialized flags carries ``is_platform=False``;
+        filtering on it would match nothing, since the key is scrubbed on write and is never
+        stored. An explicit ``is_platform=True`` is a deliberate platform-catalogue filter and
+        is preserved.
+        """
+        return {
+            key: value
+            for key, value in flags.items()
+            if not (key in cls.SERVER_OWNED_FLAG_KEYS and value is False)
+        }
+
     async def _get_cached_workflow(
         self,
         *,
@@ -794,7 +809,7 @@ class WorkflowsService:
                     exclude_none=True,
                     exclude={"flags"},
                 ),
-                flags=self._scrub_server_owned_flags(
+                flags=self._drop_default_server_owned_query_flags(
                     self._dump_flags(
                         self._artifact_query_flags_from_any(workflow_query.flags)
                     )
@@ -1631,7 +1646,7 @@ class WorkflowsService:
                     exclude_none=True,
                     exclude={"flags"},
                 ),
-                flags=self._scrub_server_owned_flags(
+                flags=self._drop_default_server_owned_query_flags(
                     self._dump_flags(
                         self._revision_query_flags_from_any(
                             workflow_revision_query.flags,


### PR DESCRIPTION
## Symptom

After #4827 merged, `run-api-unit-tests` failed: `test_query_with_explicit_is_platform_filters_on_it` got `None` instead of `{"is_platform": True}`.

## Root cause

#4827 fixed the real `/workflows/query` bug (an echoed `is_platform: false` matched zero rows) by scrubbing `is_platform` from query filters — but did it **unconditionally**, so an explicit `is_platform: true` (a deliberate platform-catalogue filter) was also stripped.

## Fix

Add a query-specific scrub that drops a server-owned flag **only when its value is False** (the echoed default that matches nothing, since the key is scrubbed on write). An explicit `True` is preserved. The write path keeps its unconditional scrub.

## Verification

- `test_platform_catalog.py` + `test_flag_ownership.py`: 42 passed.
- Round-trip repro: `is_platform:false` echo → filter matches stored workflow; `is_platform:true` → filter preserved.

https://claude.ai/code/session_01DEZYALzKjh9ocjkscaBWRT