### PR TITLE
test(agent): guard /inspect x-ag-type-ref markers resolve in catalog

### DIFF
--- a/services/oss/tests/pytest/unit/agent/test_inspect_catalog_refs.py
+++ b/services/oss/tests/pytest/unit/agent/test_inspect_catalog_refs.py
@@ -1,0 +1,66 @@
+"""Every ``x-ag-type-ref`` the agent ``/inspect`` schema emits must resolve in the catalog.
+
+The agent self-describes its interface in ``AGENT_SCHEMAS`` (``services/oss/src/agent/schemas.py``)
+instead of registering a static SDK interface. Its input/output/parameter schemas carry
+``x-ag-type-ref`` markers (``messages``, ``message``, ``agent_config``) that the playground
+resolves against ``GET /workflows/catalog/types/{type}`` to pick a control. That endpoint
+resolves a marker via ``CATALOG_TYPES`` (``agenta.sdk.utils.types``): the router calls
+``get_workflow_catalog_type(ag_type=...)``, which is ``CATALOG_TYPES.get(ag_type)`` and 404s
+when the key is unknown (``oss.src.resources.workflows.catalog``).
+
+Nothing else asserts that link, so renaming a marker on either side (or dropping a catalog
+type) silently breaks the playground form: the control fails to resolve and renders nothing.
+This guard fails fast instead.
+"""
+
+from __future__ import annotations
+
+from typing import Any, Set
+
+from agenta.sdk.utils.types import CATALOG_TYPES
+
+from oss.src.agent.schemas import AGENT_SCHEMAS
+
+# Markers the agent /inspect schema is expected to emit. Pinned so that *dropping* a marker
+# (not just renaming it to something unresolvable) is caught too. Update this set
+# deliberately when the agent interface changes.
+EXPECTED_INSPECT_REFS = {"messages", "message", "agent_config"}
+
+
+def _collect_type_refs(node: Any, acc: Set[str]) -> Set[str]:
+    """Recursively gather every ``x-ag-type-ref`` string value reachable from ``node``."""
+    if isinstance(node, dict):
+        ref = node.get("x-ag-type-ref")
+        if isinstance(ref, str):
+            acc.add(ref)
+        for value in node.values():
+            _collect_type_refs(value, acc)
+    elif isinstance(node, list):
+        for value in node:
+            _collect_type_refs(value, acc)
+    return acc
+
+
+def test_inspect_schema_emits_the_expected_type_refs():
+    refs = _collect_type_refs(AGENT_SCHEMAS, set())
+
+    assert refs == EXPECTED_INSPECT_REFS, (
+        "The agent /inspect schema emits a different set of x-ag-type-ref markers than "
+        "expected. If this is intentional, update EXPECTED_INSPECT_REFS (and make sure each "
+        "new marker resolves in the workflow catalog)."
+    )
+
+
+def test_every_inspect_type_ref_resolves_in_the_catalog():
+    refs = _collect_type_refs(AGENT_SCHEMAS, set())
+
+    assert refs, "The agent /inspect schema emitted no x-ag-type-ref markers at all."
+
+    unresolved = sorted(ref for ref in refs if ref not in CATALOG_TYPES)
+
+    assert not unresolved, (
+        "These x-ag-type-ref markers from the agent /inspect schema do not resolve in the "
+        f"workflow catalog (GET /workflows/catalog/types/{{type}}): {unresolved}. "
+        f"Available catalog types: {sorted(CATALOG_TYPES)}. "
+        "Rename the marker to a catalog type, or add the type to CATALOG_TYPES."
+    )


### PR DESCRIPTION
## Context

The agent `/inspect` endpoint emits `x-ag-type-ref` markers in its JSON Schema. These markers tell the playground frontend which catalog type to load for a given field. Nothing checked that a marker emitted by `/inspect` actually resolves in the workflow catalog (`/workflows/catalog/types/{type}`). A renamed or dropped marker would break the playground form silently — the field would render as a plain text input instead of its specialized control.

This came out of the interface-inventory review (finding A9).

## Changes

Adds `services/oss/tests/pytest/unit/agent/test_inspect_catalog_refs.py`. The test recursively extracts every `x-ag-type-ref` from `AGENT_SCHEMAS` and asserts each resolves in `CATALOG_TYPES` (the exact dict the catalog endpoint wraps). It also pins the expected marker set, so a dropped marker is caught too. Placed in the services unit suite because the agent schema lives in the `services/` package.

## Scope / risk

Test-only change. No production code is touched. The test runs in the `services/oss` unit suite and has no runtime dependency on a running service. A false negative would only fire if `AGENT_SCHEMAS` or `CATALOG_TYPES` changed without a corresponding update to the pinned set in the test.

## Tests / notes

The agent `/inspect` emits exactly `messages`, `message`, `agent_config` — all three resolve today; no marker/catalog fix was needed. `2 passed`.

Not merged to big-agents — left for review.

## How to QA

**Prerequisites:** Python environment with the `services/oss` dependencies installed (`uv sync` or equivalent).

**Steps:**
1. Run the new test:
   ```bash
   cd services/oss && uv run python -m pytest tests/pytest/unit/agent/test_inspect_catalog_refs.py -n0 -v
   ```
2. Manually verify the claim — confirm the three markers appear in the `/inspect` response for any agent:
   ```bash
   curl http://localhost:8000/workflows/<slug>/inspect | \
     python3 -c "import sys,json; d=json.load(sys.stdin); print([v for v in str(d).split('x-ag-type-ref') if v[:5].strip()][:5])"
   ```

**Expected result:** Both test cases pass. The curl confirms `messages`, `message`, and `agent_config` appear as `x-ag-type-ref` values in the real `/inspect` response.

**Automated tests:**
```bash
cd services/oss && uv run python -m pytest tests/pytest/unit/agent/test_inspect_catalog_refs.py -n0 -v
```

**Edge cases:** If a future PR adds a new `x-ag-type-ref` to `AGENT_SCHEMAS` without adding it to `CATALOG_TYPES`, this test will fail. That is the intended behavior. Confirm the pinned set in the test matches the actual markers emitted.

Claude-Session: https://claude.ai/code/session_01GYo3UEfvsZpncagqb28Mbc
