### PR TITLE
refactor(agent): collapse run-selection into AgentConfig, rename harness_kwargs

### DIFF
--- a/docs/design/agent-workflows/documentation/adapters/agenta.md
+++ b/docs/design/agent-workflows/documentation/adapters/agenta.md
@@ -55,7 +55,7 @@ This follows Pi's own split (see `PiAgentConfig`): the **persona** ("who the age
 belongs in `append_system`, and **project conventions** belong in `AGENTS.md`. So the Agenta
 persona is a forced `append_system`, while the Agenta base preamble plus the author's
 instructions are the `AGENTS.md`. An author's own `system` / `append_system` (via
-`AgentConfig.harness_options["pi_core"]`) still apply, layered after the forced persona.
+`AgentConfig.harness_kwargs["pi_core"]`) still apply, layered after the forced persona.
 
 ## Selecting it
 

--- a/docs/design/agent-workflows/documentation/adapters/pi.md
+++ b/docs/design/agent-workflows/documentation/adapters/pi.md
@@ -71,13 +71,13 @@ layer, and `SYSTEM` / `APPEND_SYSTEM` only change Pi's base persona. For almost 
 ### How to set them
 
 `SYSTEM` and `APPEND_SYSTEM` are Pi-specific, so they ride the neutral config's per-harness
-escape hatch, `AgentConfig.harness_options`. It is a bag keyed by harness name; each Harness
+escape hatch, `AgentConfig.harness_kwargs`. It is a bag keyed by harness name; each Harness
 adapter reads only its own slice:
 
 ```python
 AgentConfig(
     instructions="Project: a SQL analytics tool. Run `make lint` before finishing.",  # AGENTS.md
-    harness_options={
+    harness_kwargs={
         "pi_core": {
             "system": "You are a SQL expert. Only answer with queries.",  # replaces base prompt
             "append_system": "Always explain each query in one line.",     # adds to base prompt

--- a/docs/design/agent-workflows/documentation/agent-configuration.md
+++ b/docs/design/agent-workflows/documentation/agent-configuration.md
@@ -12,8 +12,9 @@ All file:line citations were verified against the code on 2026-06-23.
 The playground renders a single composite `agent_config` control. The field list for that
 control is not hardcoded in the frontend. It is fetched from the backend catalog type
 `agent_config`, which the SDK defines once as `AgentConfigSchema`. The runtime then re-parses
-the same payload into a permissive `AgentConfig` plus a `RunSelection`, resolves tools and
-secrets server-side, and hands a final wire request to the Node runner.
+the same payload into one permissive `AgentConfig` (the run-selection fields `harness`,
+`sandbox`, and `permission_policy` live on it), resolves tools and secrets server-side, and
+hands a final wire request to the Node runner.
 
 ## Three objects share the name "AgentConfig"
 
@@ -32,7 +33,7 @@ Playground form
   → AgentConfigControl (FE)               reads schema.properties from the catalog type
   → GET /workflows/catalog/types/agent_config   resolves x-ag-type-ref to the full schema
   → AgentConfigSchema (SDK)               the strict schema, registered in CATALOG_TYPES
-  → AgentConfig.from_params + RunSelection (SDK runtime)   re-parse the saved payload
+  → AgentConfig.from_params (SDK runtime)   re-parse the saved payload (one config)
   → SessionConfig                         tools + secrets resolved server-side
   → AgentRunRequest (TS wire contract)    the final shape the Node runner receives
 ```
@@ -137,7 +138,11 @@ class AgentConfig(BaseModel):
     model: Optional[str] = None
     tools: List[ToolConfig] = Field(default_factory=list)
     mcp_servers: List[MCPServerConfig] = Field(default_factory=list)
-    harness_options: Dict[str, Dict[str, Any]] = Field(default_factory=dict)
+    harness_kwargs: Dict[str, Dict[str, Any]] = Field(default_factory=dict)
+    # the run-selection fields
+    harness: str = "pi_core"
+    sandbox: str = "local"
+    permission_policy: PermissionPolicy = "auto"
 ```
 
 One correction to a common belief. This model is not `extra="allow"`. Its looseness comes
@@ -152,10 +157,12 @@ The genuinely loose object is the file-default dataclass at
 `services/oss/src/agent/config.py:30`, which holds `tools: List[Any]`. That is the service's
 built-in default, not user input.
 
-Two fields the schema lists are not on this neutral config. `harness`, `sandbox`, and
-`permission_policy` live on a separate `RunSelection` object
-(`sdks/python/agenta/sdk/agents/dtos.py:364`). The SDK splits "what the agent is" from "where
-and how it runs." The composite schema flattens both into one control for the playground.
+The run-selection fields are on this neutral config too. `harness`, `sandbox`, and
+`permission_policy` are plain fields on `AgentConfig` (in
+`sdks/python/agenta/sdk/agents/dtos.py`). They used to live on a separate `RunSelection`
+object; that object is retired, because there is one agent definition, not an agent plus a
+sidecar selection. The composite schema and the neutral config now agree: both keep these
+fields next to the rest of the agent.
 
 Tool entries are strict even though the list is lenient. Each tool subclass is `extra="forbid"`
 (`sdks/python/agenta/sdk/agents/tools/models.py`). `MCPServerConfig` is also `extra="forbid"`
@@ -168,19 +175,20 @@ The rich model picker is built only for the UI by `_model_catalog_type()`
 ## Layer 4: what the runtime actually reads
 
 The Python `/invoke` handler is at `services/oss/src/agent/app.py`. It parses the request
-into two objects (around line 72):
+into one object:
 
 ```python
 agent_config = AgentConfig.from_params(params, defaults=_default_agent_config())
-selection    = RunSelection.from_params(params)
 ```
 
-It then resolves tools, MCP servers, and secrets server-side (`app.py`, lines 78 to 83),
-bundles everything into a `SessionConfig` (`dtos.py:554`), picks a backend from the selection
-(`select_backend`, `app.py:49`), and runs one turn through a harness.
+That single parse covers everything, including the run-selection fields. The handler then
+resolves tools, MCP servers, and secrets server-side, bundles everything into a
+`SessionConfig`, picks a backend from `agent_config.sandbox` (`select_backend`,
+`services/oss/src/agent/app.py`), and runs one turn through a harness chosen from
+`agent_config.harness`.
 
 `sandbox` is deliberately absent from `SessionConfig`. It is a backend concern. The handler
-passes it to `SandboxAgentBackend(sandbox=...)` instead (`app.py:56`).
+reads `agent_config.sandbox` and passes it to `SandboxAgentBackend(sandbox=...)` instead.
 
 The final wire shape the Node runner receives is `AgentRunRequest` in
 `services/agent/src/protocol.ts` (around line 185). That is the true wired surface:
@@ -199,9 +207,9 @@ Legend: (a) catalog/schema, (b) SDK neutral config, (c) runtime.
 | skills | no | no | wired but forced only | Not author-settable. Only the Agenta harness injects forced skills. See below. |
 | persona | no | no | wired but forced only | Not a config field. The Agenta harness hardcodes an append-system preamble. See below. |
 | agents_md | yes, `agents_md: str` | yes, as `instructions` | wired to `agentsMd` | The schema names it `agents_md`. The neutral config names it `instructions`. |
-| harness | yes, enum | no, on `RunSelection` | wired, picks the harness class | Enum-enforced. The runtime validates via `make_harness`. |
-| sandbox | yes, enum | no, on `RunSelection` | wired to the backend, absent from `SessionConfig` | Backend concern, not agent identity. |
-| permission_policy | yes, enum | no, on `RunSelection` | wired to `SessionConfig` | Only the Claude harness reads it. Pi ignores it, so it is decorative for `pi_core` and `pi_agenta`. |
+| harness | yes, enum | yes, on `AgentConfig` | wired, picks the harness class | Enum-enforced. The runtime validates via `make_harness`. |
+| sandbox | yes, enum | yes, on `AgentConfig` | wired to the backend, absent from `SessionConfig` | Backend concern, not agent identity. |
+| permission_policy | yes, enum | yes, on `AgentConfig` | wired to `SessionConfig` | Only the Claude harness reads it. Pi ignores it, so it is decorative for `pi_core` and `pi_agenta`. |
 
 ## Notable gaps and quirks
 
@@ -214,11 +222,10 @@ Claude harnesses get no forced skills or persona.
 Per-harness divergence is real. `permission_policy` is wired only for Claude. Builtin tool
 names are dropped for Claude with a warning, because builtins are Pi-only. Skills and persona
 are Agenta-only. Pi's `system` and `append_system` overrides come through the
-`harness_options` escape hatch on the neutral config, which is itself absent from the schema.
+`harness_kwargs` escape hatch on the neutral config, which is itself absent from the schema.
 
-The schema is the only place where harness, sandbox, and permission policy sit next to the
-agent definition. The SDK keeps them apart. The composite schema re-flattens them so the
-playground can show one control.
+Harness, sandbox, and permission policy sit next to the agent definition in both the schema
+and the neutral `AgentConfig`. The two agree on one control.
 
 ## A concrete example config
 
@@ -245,9 +252,9 @@ This is what the playground saves and the runtime reads:
 }
 ```
 
-With this config, the runtime reads `agents_md`, `model`, `tools`, and `mcp_servers` through
-the neutral `AgentConfig`, reads `harness`, `sandbox`, and `permission_policy` through
-`RunSelection`, resolves the tools and MCP servers server-side, and runs one turn on the Pi
+With this config, the runtime reads `agents_md`, `model`, `tools`, `mcp_servers`, and the
+run-selection fields `harness`, `sandbox`, and `permission_policy` through the one neutral
+`AgentConfig`, resolves the tools and MCP servers server-side, and runs one turn on the Pi
 harness in a local sandbox. The `permission_policy` value is ignored because the harness is
 Pi, not Claude.
 

--- a/docs/design/agent-workflows/documentation/agent-template.md
+++ b/docs/design/agent-workflows/documentation/agent-template.md
@@ -21,7 +21,7 @@ wire shape JSON-friendly. File bytes can be base64 encoded when plain text is no
 | --- | --- | --- |
 | Generic agent identity | `AGENTS.md`, skills, tool references, template metadata | Intended long-term template surface. Partly represented today by `agents_md` and tool config. |
 | Harness-specific config | Harness id, model, harness option bags, permission policy | Present today. Permissions are not generic yet. |
-| Runtime infrastructure | Local versus Daytona, runner sidecar URL, filesystem isolation, secret channels | Present as a POC selection in `RunSelection`, but should not become durable agent identity by default. |
+| Runtime infrastructure | Local versus Daytona, runner sidecar URL, filesystem isolation, secret channels | Present today as run-selection fields on `AgentConfig` (one agent config), but should not become durable agent identity by default. |
 
 The current code still accepts `sandbox` in request config. That is useful for the POC and
 tests, but the long-term template should not require users to encode where the platform is

--- a/docs/design/agent-workflows/documentation/architecture.md
+++ b/docs/design/agent-workflows/documentation/architecture.md
@@ -9,8 +9,8 @@ Agenta already runs prompt workflows that call a model once and return one answe
 workflow runs a coding harness instead. The harness reads instructions, calls a model, calls
 tools, observes the results, and loops until it has an answer.
 
-The runtime keeps two run choices configurable
-(`sdks/python/agenta/sdk/agents/dtos.py:364`, `RunSelection`):
+The runtime keeps two run choices configurable as fields on `AgentConfig`
+(`sdks/python/agenta/sdk/agents/dtos.py`):
 
 - **Harness:** which agent runs. Supported values are `pi_core`, `claude`, and experimental
   `pi_agenta`. Default `pi_core`. `pi_core` and `pi_agenta` both drive the `pi` ACP agent;
@@ -107,8 +107,9 @@ sandbox-agent local and Daytona (`projects/qa/findings.md`, F-002).
 
 Batch `/invoke` follows this path:
 
-1. The workflow route calls `_agent` in `services/oss/src/agent/app.py:63`.
-2. `_agent` parses `AgentConfig` and `RunSelection` from request parameters.
+1. The workflow route calls `_agent` in `services/oss/src/agent/app.py`.
+2. `_agent` parses one `AgentConfig` from request parameters; it carries the run-selection
+   fields `harness`, `sandbox`, and `permission_policy`.
 3. The service resolves three things independently: tools, MCP servers, and provider-key
    secrets. MCP resolution is gated by `AGENTA_AGENT_ENABLE_MCP`
    (`services/oss/src/agent/tools/resolver.py:23`, off by default).

--- a/docs/design/agent-workflows/documentation/ground-truth.md
+++ b/docs/design/agent-workflows/documentation/ground-truth.md
@@ -11,7 +11,7 @@ this page and the referenced code as the source of truth.
 | Agent service handler | `services/oss/src/agent/app.py` | Parses agent config, resolves secrets and tools, builds `SandboxAgentBackend`, runs batch or streaming turns. |
 | Agent route wiring | `sdks/python/agenta/sdk/decorators/routing.py` | Registers `/invoke`, `/inspect`, and agent-only `/messages`. |
 | Browser protocol adapter | `sdks/python/agenta/sdk/agents/adapters/vercel/` | Converts Vercel `UIMessage` input and emits Vercel UI Message Stream parts. |
-| SDK runtime DTOs | `sdks/python/agenta/sdk/agents/dtos.py` | Defines `AgentConfig`, `RunSelection`, `SessionConfig`, messages, events, capabilities, and harness configs. |
+| SDK runtime DTOs | `sdks/python/agenta/sdk/agents/dtos.py` | Defines `AgentConfig` (incl. the run-selection fields), `SessionConfig`, messages, events, capabilities, and harness configs. |
 | SDK runtime ports | `sdks/python/agenta/sdk/agents/interfaces.py` | Defines `Backend`, `Environment`, `Sandbox`, `Session`, and `Harness`. |
 | Backend adapters | `sdks/python/agenta/sdk/agents/adapters/sandbox_agent.py`, `local.py` | Implement the sandbox-agent backend. `LocalBackend` is a stub. |
 | Harness adapters | `sdks/python/agenta/sdk/agents/adapters/harnesses.py` | Maps neutral session config into Pi, Claude, and Agenta harness-specific config. |

--- a/docs/design/agent-workflows/documentation/ports-and-adapters.md
+++ b/docs/design/agent-workflows/documentation/ports-and-adapters.md
@@ -13,7 +13,7 @@ The SDK runtime lives under `sdks/python/agenta/sdk/agents/`.
 
 | Layer | Files | Role |
 | --- | --- | --- |
-| DTOs | `dtos.py` | `AgentConfig`, `RunSelection`, `SessionConfig`, messages, events, capabilities, and harness-specific config models. |
+| DTOs | `dtos.py` | `AgentConfig` (incl. the run-selection fields), `SessionConfig`, messages, events, capabilities, and harness-specific config models. |
 | Ports | `interfaces.py` | `Backend`, `Environment`, `Sandbox`, `Session`, `Harness`. |
 | Backend adapters | `adapters/sandbox_agent.py`, `adapters/local.py` | Engines that can run a harness. |
 | Harness adapters | `adapters/harnesses.py` | Per-harness mapping from neutral session config to harness-specific config. |
@@ -54,7 +54,7 @@ turn.
 Current harnesses:
 
 - `PiHarness` keeps built-in tool names, resolved tool specs, Pi prompt overrides (`system`
-  and `append_system` from `harness_options.pi`), and Pi native tool delivery.
+  and `append_system` from the `pi_core` key of `harness_kwargs`), and Pi native tool delivery.
 - `ClaudeHarness` drops Pi built-ins, carries MCP-delivered specs, and carries the
   permission policy.
 - `AgentaHarness` (harness value `pi_agenta`) is Pi with forced Agenta policy layered on top:
@@ -86,9 +86,10 @@ session representation and storage size.
 ## Config Ownership
 
 `AgentConfig` describes the agent itself: instructions, model, tool references, MCP server
-config, and per-harness option bags. It does not choose a backend.
-
-`RunSelection` describes runtime choices: harness, sandbox, and permission policy.
+config, and per-harness option bags. It also carries the run-selection fields `harness`,
+`sandbox`, and `permission_policy`; there is one agent config, not a config plus a separate
+`RunSelection` object. The handler reads `sandbox` to choose a backend, but the backend choice
+itself is not stored on the config.
 
 This is the current POC shape. The long-term split should be stricter:
 
@@ -98,9 +99,9 @@ This is the current POC shape. The long-term split should be stricter:
 - Runtime infrastructure: local versus Daytona, runner sidecar URL, filesystem isolation,
   and secret channels.
 
-Sandbox is currently selectable through `RunSelection` so the POC can exercise local and
-Daytona paths. It should not become durable agent template identity unless product
-requirements explicitly need portable per-template runtime selection.
+Sandbox is currently selectable through the `sandbox` field on `AgentConfig` so the POC can
+exercise local and Daytona paths. It should not become durable agent template identity unless
+product requirements explicitly need portable per-template runtime selection.
 
 `SessionConfig` describes one run: the neutral agent config plus resolved secrets, resolved
 tools, resolved MCP servers, trace context, and the session id.
@@ -109,7 +110,7 @@ tools, resolved MCP servers, trace context, and the session id.
 
 `services/oss/src/agent/app.py` is a thin consumer of the SDK ports:
 
-1. Parse `AgentConfig` and `RunSelection`.
+1. Parse one `AgentConfig` (it carries the run-selection fields too).
 2. Resolve provider secrets.
 3. Resolve tools and, when enabled, MCP servers.
 4. Build `SessionConfig`.

--- a/docs/design/agent-workflows/interfaces/in-service/agent-service-handler.md
+++ b/docs/design/agent-workflows/interfaces/in-service/agent-service-handler.md
@@ -10,16 +10,16 @@ the order it runs in is itself a contract.
 
 The handler (`_agent` in `app.py`) takes the workflow envelope's pieces:
 
-- `parameters`: carries the agent config under `agent` and the run selection (`harness`,
-  `sandbox`, `permission_policy`) in the same object.
+- `parameters`: carries the agent config under `agent`. The run-selection fields (`harness`,
+  `sandbox`, `permission_policy`) live on that same `agent` object.
 - `messages` or `inputs.messages`: the turn history (it checks `messages` first).
 - `stream`: batch versus streaming.
 - `session_id`: the external conversation id.
 
 ## What it does, in order
 
-1. Parse config and selection: `AgentConfig.from_params(params, defaults=...)` and
-   `RunSelection.from_params(params)`.
+1. Parse the config: `AgentConfig.from_params(params, defaults=...)`. One parse covers
+   everything, including the run-selection fields (`harness`, `sandbox`, `permission_policy`).
 2. Convert the request messages to neutral `Message[]`.
 3. Resolve tools into builtin names, runnable specs, and a tool callback.
 4. Resolve MCP servers.
@@ -56,8 +56,8 @@ the instrumented handler and merges the registered interface (the passed `schema
 
 ## Watch for when changing
 
-- **Where config lives.** Agent config and run selection share `parameters`. Moving either
-  breaks the form and the playground request builder.
+- **Where config lives.** The agent config, including its run-selection fields, rides
+  `parameters.agent`. Moving it breaks the form and the playground request builder.
 - **Default application.** The handler merges request params over a default agent config.
   Changing the merge changes what an empty form runs.
 - **Resolution order.** Provider and mode gate before resolution; deployment gates after.

--- a/docs/design/agent-workflows/interfaces/in-service/harness-adapters.md
+++ b/docs/design/agent-workflows/interfaces/in-service/harness-adapters.md
@@ -18,7 +18,7 @@ Each adapter implements `_to_harness_config(...)` and emits a different `/run` w
   tool use.
 - **`ClaudeHarness`** delivers tools over MCP, not natively, and has no Pi built-ins (it warns
   if any are set). It carries `permission_policy` and renders `.claude/settings.json` from
-  `harness_options` and the sandbox permission, shipped as `harnessFiles`. It carries inline
+  `harness_kwargs` and the sandbox permission, shipped as `harnessFiles`. It carries inline
   skill packages on the wire like the others; the runner materializes them under
   `.claude/skills` in the session cwd, matching Claude's project-local skill layout.
 - **`AgentaHarness`** runs on the same Pi engine but forces Agenta's opinion: it composes the
@@ -31,7 +31,7 @@ The wire shapes, side by side:
 |---|---|---|---|
 | built-in tools | yes | no | forced set |
 | custom tools | native | over MCP | native |
-| prompt overrides | `system`/`append_system` | none (reads `harness_options`) | forced `append_system` + author `system` |
+| prompt overrides | `system`/`append_system` | none (reads `harness_kwargs`) | forced `append_system` + author `system` |
 | permission policy | dropped | carried | dropped |
 | inline skills | yes (agent-dir scope) | yes (materialized to `.claude/skills`) | yes (agent-dir scope) |
 | harness files | none | `.claude/settings.json` | none |
@@ -52,5 +52,5 @@ The wire shapes, side by side:
   materializes them under `.claude/skills`. (An earlier revision suppressed Claude's
   `wire_skills()` to `{}`; that override is gone, and `test_claude_carries_skills_for_project_local_materialization`
   now pins the carry-on-wire behavior.)
-- **Harness options.** The `harness_options` bag is keyed by harness; each adapter reads only
+- **Harness options.** The `harness_kwargs` bag is keyed by harness; each adapter reads only
   its own slice.

--- a/docs/design/agent-workflows/interfaces/in-service/neutral-runtime-dtos.md
+++ b/docs/design/agent-workflows/interfaces/in-service/neutral-runtime-dtos.md
@@ -18,11 +18,12 @@ This page owns the review lens: the field meanings and what to check when one mo
 All in `dtos.py`. The ones that carry the most weight:
 
 - **`AgentConfig`**: the parsed editable config. `instructions`, `model`/`model_ref`,
-  `tools`, `mcp_servers`, `skills`, `sandbox_permission`, and a `harness_options` bag keyed
-  by harness name. Built by `from_params(...)`. The editable schema is
-  [Agent config schema](../public-edge/agent-config-schema.md).
-- **`RunSelection`**: `harness` (default `pi_core`), `sandbox` (default `local`),
-  `permission_policy` (`auto` | `deny`). The `harness` value is the bare `HarnessType` string.
+  `tools`, `mcp_servers`, `skills`, `sandbox_permission`, a `harness_kwargs` bag keyed
+  by harness name, and the run-selection fields `harness` (default `pi_core`), `sandbox`
+  (default `local`), and `permission_policy` (`auto` | `deny`). The `harness` value is the
+  bare `HarnessType` string. There is one agent config; run selection used to live on a
+  separate `RunSelection` object and now folds in here. Built by `from_params(...)`. The
+  editable schema is [Agent config schema](../public-edge/agent-config-schema.md).
 - **`HarnessType` and `HARNESS_IDENTITIES`**: the closed harness enum plus the single source for
   each harness's interface identity — a versioned slug (`agenta:harness:<value>:v0`, the repo's
   slug grammar) and a display name. The agent_config schema builds its harness `oneOf` from

--- a/docs/design/agent-workflows/interfaces/public-edge/agent-config-schema.md
+++ b/docs/design/agent-workflows/interfaces/public-edge/agent-config-schema.md
@@ -29,9 +29,10 @@ The fields and the full schema follow.
 | `sandbox_permission` | `SandboxPermission \| null` | `null` (form pre-fills one) | The declared network and filesystem boundary. See [Sandbox permission](../in-service/sandbox-permission.md). |
 | `skills` | `(SkillConfig \| EmbedRef)[]` | one embedded default skill | Inline SKILL.md packages, or `@ag.embed` references the backend inlines before the runner sees them. |
 
-Note that `harness`, `sandbox`, and `permission_policy` are the run selection. The handler
-reads them from the same `parameters` object via `RunSelection.from_params(...)`, not just
-from `AgentConfig`.
+Note that `harness`, `sandbox`, and `permission_policy` are the run-selection fields. They
+live on `AgentConfig` itself, under `data.parameters.agent`, and the handler reads them in the
+one `AgentConfig.from_params(...)` parse along with the rest of the config. There is one agent
+config, not a config plus a separate selection object.
 
 ### Harness as a slug + display name
 

--- a/docs/design/agent-workflows/interfaces/public-edge/agent-messages.md
+++ b/docs/design/agent-workflows/interfaces/public-edge/agent-messages.md
@@ -24,8 +24,8 @@ The request reuses the generic workflow envelope and carries the chat-specific p
   },
   "data": {
     "messages":   [ /* Vercel UIMessage[] */ ],
-    "parameters": { "agent": { /* draft-aware agent config */ },
-                    "harness": "pi_core", "sandbox": "local" }
+    "parameters": { "agent": { /* draft-aware agent config, incl.
+                                  harness, sandbox, permission_policy */ } }
   }
 }
 ```

--- a/docs/design/agent-workflows/interfaces/public-edge/workflow-invoke.md
+++ b/docs/design/agent-workflows/interfaces/public-edge/workflow-invoke.md
@@ -15,7 +15,7 @@ The request is the shared `WorkflowInvokeRequest` envelope. The agent handler re
 things out of it:
 
 - the turn history from `data.inputs.messages` (or `data.messages`),
-- the agent config and run selection from `data.parameters`,
+- the agent config, including its run-selection fields, from `data.parameters.agent`,
 - the trace and reference context from the envelope itself.
 
 ```jsonc
@@ -23,7 +23,7 @@ things out of it:
   "references": { /* application / variant / revision */ },
   "data": {
     "inputs":     { "messages": [ /* chat history */ ] },
-    "parameters": { "agent": { /* config */ }, "harness": "pi_core", "sandbox": "local" }
+    "parameters": { "agent": { /* config, incl. harness, sandbox, permission_policy */ } }
   }
 }
 ```
@@ -35,10 +35,10 @@ assistant message:
 { "data": { "outputs": { "role": "assistant", "content": "..." } } }
 ```
 
-`parameters` carries both the agent config (under `agent`) and the run selection (`harness`,
-`sandbox`, `permission_policy`) in the same object. The handler reads the history from
-`data.messages` first, then falls back to `inputs.messages`. The streaming version of this
-work is [Agent messages](agent-messages.md); this contract is the batch path.
+`parameters` carries the agent config under `agent`, and the run-selection fields (`harness`,
+`sandbox`, `permission_policy`) live inside that same `agent` object. The handler reads the
+history from `data.messages` first, then falls back to `inputs.messages`. The streaming
+version of this work is [Agent messages](agent-messages.md); this contract is the batch path.
 
 ## Owned by
 

--- a/docs/design/agent-workflows/projects/agent-config-structure-cleanup/status.md
+++ b/docs/design/agent-workflows/projects/agent-config-structure-cleanup/status.md
@@ -1,0 +1,47 @@
+# Agent-config structure cleanup — status
+
+Source: PR #4821 review comments 2 / 7 / 8 (approved).
+
+## What
+
+1. Collapse the run-selection fields (`harness`, `sandbox`, `permission_policy`) from the
+   separate `RunSelection` DTO INTO `AgentConfig`. They live under `data.parameters.agent`,
+   not as siblings of `agent`. Retire `RunSelection`.
+2. Rename the per-harness options bag `harness_options` -> `harness_kwargs` (a dict keyed by
+   harness name; `permission_policy` stays the sidecar action-permission, now inside AgentConfig).
+
+POC: no back-compat, no deprecation shims. Change shapes cleanly.
+
+## Wire impact
+
+NONE. The `/run` payload keeps `harness`, `sandbox`, `permissionPolicy` exactly as today:
+`harness`/`sandbox` are passed to `request_to_wire(harness=, sandbox=)` by the harness adapter
+(from `make_harness` + `select_backend`); `permissionPolicy` rides `wire_tools()` on the
+per-harness config. This is an envelope/config-placement + parsing change, not a wire change.
+Golden fixtures unchanged.
+
+## Coordination
+
+- Stacked on `feat/agent-model-picker` (#4839), the config/FE tip.
+- Did NOT touch `services/agent/**` (sibling HTTP-MCP impl active there).
+- `sandbox` stays (sibling sidecar-uri-config replaces it with `uri` AFTER this); structure
+  left easy for that. Did NOT edit the sidecar-uri-config project workspace.
+
+## Test results
+
+- SDK agents: 342 passed (`-n0`).
+- service-agent: 38 passed.
+- FE playground: 121 passed (agentRequest 19, incl. new nested-under-agent test); entity-ui: 126.
+- entity-ui + playground typecheck (turbo build) green; oss touched files (transport.ts) typecheck
+  clean (pre-existing unrelated baseline errors only). ruff + prettier + eslint clean.
+- Codex (xhigh) reviewed: runtime sound, `/run` wire unchanged; flagged the `SessionConfig`
+  docstring "sandbox absent" claim (now reworded, since `sandbox` rides on `agent` but is read
+  before the session is built and no adapter consumes it).
+
+## Deferred
+
+- `services/agent/src/protocol.ts:354` still has a `harness_options` doc comment (describes the
+  Python-side bag). In the runner dir (sibling HTTP-MCP impl active there) so NOT touched here;
+  rename to `harness_kwargs` in a runner-owned change.
+
+## State: LANDED (pending PR)

--- a/sdks/python/agenta/__init__.py
+++ b/sdks/python/agenta/__init__.py
@@ -63,7 +63,6 @@ from .sdk.agents import (  # noqa: F401
     LocalBackend,
     PiHarness,
     SandboxAgentBackend,
-    RunSelection,
     SessionConfig,
     make_harness,
 )

--- a/sdks/python/agenta/sdk/agents/__init__.py
+++ b/sdks/python/agenta/sdk/agents/__init__.py
@@ -67,7 +67,6 @@ from .dtos import (
     NetworkEgress,
     PermissionPolicy,
     PiAgentConfig,
-    RunSelection,
     SandboxPermission,
     SessionConfig,
     ToolCallback,
@@ -142,7 +141,6 @@ from .adapters.vercel import (
 __all__ = [
     # DTOs
     "AgentConfig",
-    "RunSelection",
     "SessionConfig",
     "HarnessAgentConfig",
     "PiAgentConfig",

--- a/sdks/python/agenta/sdk/agents/adapters/claude_settings.py
+++ b/sdks/python/agenta/sdk/agents/adapters/claude_settings.py
@@ -8,7 +8,7 @@ whatever ``harnessFiles`` the adapter produced into the session cwd. The Claude 
 file is the only clean Claude-config path because the sandbox-agent daemon strips ACP ``_meta``.
 
 Three rule sources merge here:
- - the AUTHOR's options (Layer 1), read from the generic ``harness_options["claude"]["permissions"]``
+ - the AUTHOR's options (Layer 1), read from the generic ``harness_kwargs["claude"]["permissions"]``
    slice: ``default_mode`` + per-tool ``allow``/``deny``/``ask`` strings. This is the only place the
    claude-specific shape of that slice is known.
  - rules DERIVED from ``sandbox_permission`` (Layer 2): baseline reinforcement of the sandbox
@@ -43,7 +43,7 @@ def _string_list(value: Any) -> List[str]:
 
 
 def _parse_author_permissions(slice_: Any) -> Dict[str, Any]:
-    """Parse the untyped author block from ``harness_options["claude"]["permissions"]``.
+    """Parse the untyped author block from ``harness_kwargs["claude"]["permissions"]``.
 
     ``default_mode`` (also accepted as ``defaultMode``) survives only when it is one of the four
     valid modes; ``allow``/``deny``/``ask`` become string lists. This is where the claude-specific
@@ -138,13 +138,13 @@ def _get(obj: Any, key: str) -> Any:
 
 
 def build_claude_settings_files(
-    harness_options: Optional[Dict[str, Any]],
+    harness_kwargs: Optional[Dict[str, Any]],
     sandbox_permission: Any = None,
     mcp_servers: Any = None,
 ) -> List[Dict[str, str]]:
     """Build the Claude ``settings.json`` as a generic ``harnessFiles`` entry, or ``[]`` if none.
 
-    Reads the author's Layer-1 options from ``harness_options["claude"]["permissions"]``, merges
+    Reads the author's Layer-1 options from ``harness_kwargs["claude"]["permissions"]``, merges
     them with the Layer-2-derived rules (from ``sandbox_permission``) and the Layer-3-derived MCP
     rules (from ``mcp_servers``), dedupes each list, and emits the smallest valid file:
     ``permissions.defaultMode`` is set only when authored (and valid), and each allow/deny/ask list
@@ -153,7 +153,7 @@ def build_claude_settings_files(
 
     Returns ``[{"path": ".claude/settings.json", "content": <json str>}]`` or ``[]``.
     """
-    author = _parse_author_permissions(_claude_permissions_slice(harness_options))
+    author = _parse_author_permissions(_claude_permissions_slice(harness_kwargs))
 
     # Merge order: author rules first, then derived rules (Layer 2, then Layer 3). ``_dedupe``
     # keeps first-seen order, so an author rule wins its position and derived rules append.
@@ -184,11 +184,11 @@ def build_claude_settings_files(
     return [{"path": SETTINGS_PATH, "content": content}]
 
 
-def _claude_permissions_slice(harness_options: Optional[Dict[str, Any]]) -> Any:
+def _claude_permissions_slice(harness_kwargs: Optional[Dict[str, Any]]) -> Any:
     """Pull the ``claude.permissions`` slice from the generic per-harness options map."""
-    if not isinstance(harness_options, dict):
+    if not isinstance(harness_kwargs, dict):
         return None
-    claude = harness_options.get("claude")
+    claude = harness_kwargs.get("claude")
     if not isinstance(claude, dict):
         return None
     return claude.get("permissions")

--- a/sdks/python/agenta/sdk/agents/adapters/harnesses.py
+++ b/sdks/python/agenta/sdk/agents/adapters/harnesses.py
@@ -60,10 +60,10 @@ class PiHarness(Harness):
     def _to_harness_config(self, config: SessionConfig) -> PiAgentConfig:
         # Pi delivers tools natively: built-in names plus resolved specs registered through
         # the Pi extension. Pi does not gate tool use, so the permission policy is dropped.
-        # Pi reads its own slice of the neutral harness_options bag (the `pi_core` key, shared
+        # Pi reads its own slice of the neutral harness_kwargs bag (the `pi_core` key, shared
         # by both Pi-family harnesses): `system` replaces Pi's base prompt, `append_system`
         # extends it (both leave AGENTS.md untouched).
-        pi_options = config.agent.harness_options.get(HarnessType.PI.value, {})
+        pi_options = config.agent.harness_kwargs.get(HarnessType.PI.value, {})
         return PiAgentConfig(
             agents_md=config.agent.instructions,
             model=config.agent.model,
@@ -74,7 +74,7 @@ class PiHarness(Harness):
             mcp_servers=list(config.mcp_servers),
             skills=list(config.agent.skills),
             sandbox_permission=config.agent.sandbox_permission,
-            harness_options=config.agent.harness_options,
+            harness_kwargs=config.agent.harness_kwargs,
             system=_opt_str(pi_options.get("system")),
             append_system=_opt_str(pi_options.get("append_system")),
         )
@@ -94,7 +94,7 @@ class ClaudeHarness(Harness):
             )
         # Skills stay on the harness config; the runner materializes them under `.claude/skills`
         # in the session cwd so Claude ACP can load the same resolved inline packages.
-        # The whole neutral harness_options bag (plus sandbox_permission + mcp_servers) is threaded
+        # The whole neutral harness_kwargs bag (plus sandbox_permission + mcp_servers) is threaded
         # onto the ClaudeAgentConfig; the config's `wire_harness_files` (the Python claude adapter)
         # parses the `claude.permissions` slice and renders `.claude/settings.json` as a generic
         # `harnessFiles` entry. No claude-specific parsing happens here; the runner just writes the
@@ -108,7 +108,7 @@ class ClaudeHarness(Harness):
             mcp_servers=list(config.mcp_servers),
             skills=list(config.agent.skills),
             sandbox_permission=config.agent.sandbox_permission,
-            harness_options=config.agent.harness_options,
+            harness_kwargs=config.agent.harness_kwargs,
             permission_policy=config.permission_policy,
         )
 
@@ -117,7 +117,7 @@ class AgentaHarness(Harness):
     """Pi with an Agenta opinion. Same engine as :class:`PiHarness`, but every run carries the
     forced Agenta extras (see :mod:`.agenta_builtins`): a base AGENTS.md preamble the author's
     instructions are appended to, a forced persona ``append_system``, and forced tools. The
-    author's own Pi ``harness_options`` (``system`` / ``append_system``) still apply, layered
+    author's own Pi ``harness_kwargs`` (``system`` / ``append_system``) still apply, layered
     after the forced bits. Skills come from the neutral config as resolved inline packages;
     seeding platform default skills is a separate project-creation workstream."""
 
@@ -126,7 +126,7 @@ class AgentaHarness(Harness):
     def _to_harness_config(self, config: SessionConfig) -> AgentaAgentConfig:
         # The author's Pi options still apply; the pi_agenta harness reads the same `pi_core`
         # slice as PiHarness (it drives Pi) and layers its forced extras on top.
-        pi_options = config.agent.harness_options.get(HarnessType.PI.value, {})
+        pi_options = config.agent.harness_kwargs.get(HarnessType.PI.value, {})
         return AgentaAgentConfig(
             agents_md=compose_instructions(config.agent.instructions),
             model=config.agent.model,
@@ -137,7 +137,7 @@ class AgentaHarness(Harness):
             mcp_servers=list(config.mcp_servers),
             skills=list(config.agent.skills),
             sandbox_permission=config.agent.sandbox_permission,
-            harness_options=config.agent.harness_options,
+            harness_kwargs=config.agent.harness_kwargs,
             system=_opt_str(pi_options.get("system")),
             append_system=compose_append_system(
                 _opt_str(pi_options.get("append_system"))

--- a/sdks/python/agenta/sdk/agents/dtos.py
+++ b/sdks/python/agenta/sdk/agents/dtos.py
@@ -403,12 +403,19 @@ class AgentResult(BaseModel):
 
 
 class AgentConfig(BaseModel):
-    """What an agent IS, independent of where or how it runs. ``instructions`` becomes
+    """What an agent is and how it runs — the single agent definition. ``instructions`` becomes
     ``AGENTS.md``. ``tools`` are provider-agnostic references; resolving them into runnable
     specs is the caller's job (the Agenta service does it server-side).
 
-    ``harness_options`` is the neutral config's one escape hatch: a map keyed by harness
-    name (``"pi_core"``, ``"claude"``) whose value is a free-form bag of knobs only that harness
+    ``harness`` / ``sandbox`` / ``permission_policy`` are the run-selection fields: which
+    coding agent to drive, where it runs, and how a permission-gating harness answers tool-use
+    prompts in a headless run. They live on ``AgentConfig`` (under ``data.parameters.agent``)
+    rather than a separate object — there is one agent definition, not an agent plus a sidecar
+    selection. ``sandbox`` is a backend/environment concern the caller reads to pick a backend;
+    it never enters ``SessionConfig`` or the neutral run.
+
+    ``harness_kwargs`` is the per-harness escape hatch: a map keyed by harness name
+    (``"pi_core"``, ``"claude"``) whose value is a free-form bag of knobs only that harness
     understands, for example Pi's ``system`` / ``append_system`` prompt overrides. The
     config stays harness-agnostic because each Harness adapter reads only its own slice and
     ignores the rest; a key for a harness that is not running is simply never looked at. Both
@@ -428,8 +435,15 @@ class AgentConfig(BaseModel):
     tools: List[ToolConfig] = Field(default_factory=list)
     mcp_servers: List[MCPServerConfig] = Field(default_factory=list)
     skills: List[SkillConfig] = Field(default_factory=list)
-    harness_options: Dict[str, Dict[str, Any]] = Field(default_factory=dict)
+    harness_kwargs: Dict[str, Dict[str, Any]] = Field(default_factory=dict)
     sandbox_permission: Optional[SandboxPermission] = None
+    # The run-selection fields (formerly the separate ``RunSelection``): the coding agent to
+    # drive, where it runs, and the headless permission policy. The caller reads ``harness`` /
+    # ``sandbox`` to pick a harness class and backend; ``permission_policy`` is the sidecar
+    # action-permission a gating harness (Claude) consults.
+    harness: str = "pi_core"
+    sandbox: str = "local"
+    permission_policy: PermissionPolicy = "auto"
 
     @model_validator(mode="before")
     @classmethod
@@ -463,45 +477,24 @@ class AgentConfig(BaseModel):
         Accepts three shapes, in priority order: the dedicated ``agent`` element, the
         playground ``prompt`` prompt-template (system message -> instructions, ``llm_config``
         -> model + tools), and a flat ``{model, agents_md, tools}``. Unset fields fall back
-        to ``defaults``. ``harness_options`` is read from the ``agent`` element (or the flat
-        request) when present.
+        to ``defaults``. ``harness_kwargs`` and the run-selection fields
+        (``harness`` / ``sandbox`` / ``permission_policy``) are read from the ``agent`` element
+        (or the flat request) when present.
         """
         base = defaults or cls()
         instructions, model, tools = _parse_agent_fields(params, base)
+        harness, sandbox, permission_policy = _parse_run_selection(params, base)
         return cls(
             instructions=instructions,
             model=model,
             tools=_as_list(tools),
             mcp_servers=_parse_mcp_servers_raw(params, base),
             skills=_parse_skills_raw(params, base),
-            harness_options=_parse_harness_options(params, base),
+            harness_kwargs=_parse_harness_kwargs(params, base),
             sandbox_permission=_parse_sandbox_permission(params, base),
-        )
-
-
-class RunSelection(BaseModel):
-    """The run-time choices stored next to the agent config: which harness, which sandbox,
-    the permission policy. Read by the caller to pick a backend and harness class;
-    deliberately not part of the neutral :class:`AgentConfig`."""
-
-    harness: str = "pi_core"
-    sandbox: str = "local"
-    permission_policy: PermissionPolicy = "auto"
-
-    @classmethod
-    def from_params(
-        cls,
-        params: Dict[str, Any],
-        *,
-        default_harness: str = "pi_core",
-        default_sandbox: str = "local",
-    ) -> "RunSelection":
-        agent = params.get("agent")
-        source = agent if isinstance(agent, dict) else params
-        return cls(
-            harness=str(source.get("harness") or default_harness).lower(),
-            sandbox=str(source.get("sandbox") or default_sandbox).lower(),
-            permission_policy=str(source.get("permission_policy") or "auto").lower(),
+            harness=harness,
+            sandbox=sandbox,
+            permission_policy=permission_policy,
         )
 
 
@@ -543,10 +536,10 @@ class HarnessAgentConfig(BaseModel):
     skills: List[SkillConfig] = Field(default_factory=list)
     sandbox_permission: Optional[SandboxPermission] = None
     # The neutral per-harness options bag (a map keyed by harness name), carried verbatim from
-    # ``AgentConfig.harness_options`` by the harness adapter. The active harness's CONFIG translates
+    # ``AgentConfig.harness_kwargs`` by the harness adapter. The active harness's CONFIG translates
     # its own slice into rendered files for the wire (see :meth:`wire_harness_files`); the raw bag
     # itself does not ride the wire anymore.
-    harness_options: Dict[str, Dict[str, Any]] = Field(default_factory=dict)
+    harness_kwargs: Dict[str, Dict[str, Any]] = Field(default_factory=dict)
 
     @model_validator(mode="before")
     @classmethod
@@ -609,7 +602,7 @@ class HarnessAgentConfig(BaseModel):
         renders to drop in the session cwd before the session starts. Empty by default (Pi/Agenta
         render none), so a config that produces no files is unchanged (the golden wire contract).
 
-        This is where the per-harness translation of the generic ``harness_options`` bag happens in
+        This is where the per-harness translation of the generic ``harness_kwargs`` bag happens in
         Python (it used to happen in the TS runner). A harness that turns its own options slice into
         a config file overrides this; the runner is then a dumb writer that materializes each
         ``{path, content}`` entry into the cwd (``path`` relative to cwd) and has no harness
@@ -752,7 +745,7 @@ class ClaudeAgentConfig(HarnessAgentConfig):
     def wire_harness_files(self) -> Dict[str, Any]:
         """Render the Claude harness's permission settings into a ``.claude/settings.json`` file
         the runner drops in the cwd. This is the claude adapter (Layer 1 translation), done in
-        Python: parse the author's ``harness_options["claude"]["permissions"]`` slice, merge the
+        Python: parse the author's ``harness_kwargs["claude"]["permissions"]`` slice, merge the
         Layer-2 ``sandbox_permission`` derivation and the per-MCP-server Layer-3 permissions, and
         emit one ``harnessFiles`` entry. Omitted when Claude has nothing to write (no author options
         and no derived rules), so a boundary-free Claude run is byte-identical to before."""
@@ -762,7 +755,7 @@ class ClaudeAgentConfig(HarnessAgentConfig):
         from .adapters.claude_settings import build_claude_settings_files
 
         files = build_claude_settings_files(
-            self.harness_options, self.sandbox_permission, self.mcp_servers
+            self.harness_kwargs, self.sandbox_permission, self.mcp_servers
         )
         if not files:
             return {}
@@ -785,11 +778,12 @@ class AgentaAgentConfig(PiAgentConfig):
 class SessionConfig(BaseModel):
     """Everything one run needs except where it runs.
 
-    ``agent`` is the neutral definition. ``secrets`` are provider keys injected as harness
+    ``agent`` is the agent definition. ``secrets`` are provider keys injected as harness
     env, never written to the agent filesystem. The ``builtin_tools`` / ``custom_tools`` /
     ``tool_callback`` triple is the resolved tool delivery (Agenta produces it server-side;
-    empty for a bare standalone run). Sandbox is intentionally absent: it is a
-    backend/environment concern."""
+    empty for a bare standalone run). The agent config's ``sandbox`` field is a
+    backend/environment concern: the caller reads it to pick a backend BEFORE the session is
+    built, and the run itself never consumes it (no adapter reads ``agent.sandbox``)."""
 
     model_config = ConfigDict(populate_by_name=True)
 
@@ -912,26 +906,45 @@ def _parse_skills_raw(
     return _as_list(raw)
 
 
-def _parse_harness_options(
+def _parse_harness_kwargs(
     params: Dict[str, Any],
     defaults: AgentConfig,
 ) -> Dict[str, Dict[str, Any]]:
     """Pull the per-harness options bag from a request/config dict, falling back to defaults.
 
-    Reads ``harness_options`` from the ``agent`` element when present, else from the flat
+    Reads ``harness_kwargs`` from the ``agent`` element when present, else from the flat
     request. Keeps only well-formed entries (a harness name mapping to an options dict) and
     lower-cases the harness key so it matches :class:`HarnessType` values.
     """
     agent = params.get("agent")
     source = agent if isinstance(agent, dict) else params
-    raw = source.get("harness_options")
+    raw = source.get("harness_kwargs")
     if not isinstance(raw, dict):
-        return dict(defaults.harness_options)
+        return dict(defaults.harness_kwargs)
     options: Dict[str, Dict[str, Any]] = {}
     for name, opts in raw.items():
         if isinstance(opts, dict):
             options[str(name).lower()] = dict(opts)
-    return options or dict(defaults.harness_options)
+    return options or dict(defaults.harness_kwargs)
+
+
+def _parse_run_selection(
+    params: Dict[str, Any],
+    defaults: AgentConfig,
+) -> Tuple[str, str, "PermissionPolicy"]:
+    """Pull the run-selection trio (harness / sandbox / permission_policy) from a request dict.
+
+    Reads from the ``agent`` element when present, else the flat request, falling back to
+    ``defaults``. Each value is lower-cased so a playground-supplied ``"Claude"`` / ``"Daytona"``
+    matches the bare :class:`HarnessType` / sandbox values the caller selects on."""
+    agent = params.get("agent")
+    source = agent if isinstance(agent, dict) else params
+    harness = str(source.get("harness") or defaults.harness).lower()
+    sandbox = str(source.get("sandbox") or defaults.sandbox).lower()
+    permission_policy = str(
+        source.get("permission_policy") or defaults.permission_policy
+    ).lower()
+    return harness, sandbox, permission_policy
 
 
 def _parse_sandbox_permission(

--- a/sdks/python/agenta/sdk/agents/dtos.py
+++ b/sdks/python/agenta/sdk/agents/dtos.py
@@ -921,11 +921,14 @@ def _parse_harness_kwargs(
     raw = source.get("harness_kwargs")
     if not isinstance(raw, dict):
         return dict(defaults.harness_kwargs)
+    # An explicit empty dict clears inherited per-harness options; only an
+    # *absent* key (caught above) falls back to defaults. Distinguishing the two
+    # lets a caller remove an inherited prompt/permission override by sending {}.
     options: Dict[str, Dict[str, Any]] = {}
     for name, opts in raw.items():
         if isinstance(opts, dict):
             options[str(name).lower()] = dict(opts)
-    return options or dict(defaults.harness_kwargs)
+    return options
 
 
 def _parse_run_selection(

--- a/sdks/python/agenta/sdk/agents/utils/wire.py
+++ b/sdks/python/agenta/sdk/agents/utils/wire.py
@@ -61,7 +61,7 @@ def request_to_wire(
     and ``wire_model_ref``'s ``provider`` (its ``env`` never reaches the wire; the secret rides
     ``secrets``).
     ``config.wire_harness_files()`` adds the generic ``harnessFiles`` array: files the active
-    harness's config rendered from its own ``harness_options`` slice, to materialize in the session
+    harness's config rendered from its own ``harness_kwargs`` slice, to materialize in the session
     cwd before the session starts (``path`` relative to cwd, ``content`` the file text). Omitted
     unless the config produced any files. This is where the per-harness translation happens in
     Python (e.g. the claude config renders ``.claude/settings.json``); the runner is a dumb writer

--- a/sdks/python/agenta/sdk/utils/types.py
+++ b/sdks/python/agenta/sdk/utils/types.py
@@ -1102,12 +1102,12 @@ class AgentConfigSchema(AgSchemaMixin):
     This is the schema-generation counterpart to the runtime :class:`agenta.sdk.agents.AgentConfig`
     parser: it exists only to emit a rich JSON Schema for the ``agent_config`` control, so the
     field shapes live in Pydantic (single source of truth) instead of a hand-written literal.
-    It deliberately composes the editable fields the control surfaces — the neutral config
-    (``agents_md``/``model``/``tools``/``mcp_servers``) plus the run selection
-    (``harness``/``sandbox``/``permission_policy``) — and types ``tools``/``mcp_servers`` with the
-    real tool-def models so the playground gets typed editors. The runtime ``AgentConfig`` stays
-    permissive (``List[Any]``) because its job is to coerce the loose shapes the playground emits;
-    this model is strict because its job is to describe them.
+    It composes every editable field the control surfaces — the definition
+    (``agents_md``/``model``/``tools``/``mcp_servers``) and the run-selection fields
+    (``harness``/``sandbox``/``permission_policy``), all one config — and types
+    ``tools``/``mcp_servers`` with the real tool-def models so the playground gets typed editors.
+    The runtime ``AgentConfig`` stays permissive (``List[Any]``) because its job is to coerce the
+    loose shapes the playground emits; this model is strict because its job is to describe them.
     """
 
     __ag_type__ = "agent_config"

--- a/sdks/python/oss/tests/pytest/unit/agents/adapters/test_claude_settings.py
+++ b/sdks/python/oss/tests/pytest/unit/agents/adapters/test_claude_settings.py
@@ -2,7 +2,7 @@
 
 This is the translation that used to live in the TS runner's ``claude-settings.ts``. It merges
 three rule sources into one ``.claude/settings.json``: the author's
-``harness_options["claude"]["permissions"]`` slice, the Layer-2 sandbox-boundary derivation, and
+``harness_kwargs["claude"]["permissions"]`` slice, the Layer-2 sandbox-boundary derivation, and
 the per-MCP-server Layer-3 permissions. The runner is now a dumb writer of the rendered
 ``harnessFiles`` entry this produces.
 """

--- a/sdks/python/oss/tests/pytest/unit/agents/test_dtos_agent_config.py
+++ b/sdks/python/oss/tests/pytest/unit/agents/test_dtos_agent_config.py
@@ -1,8 +1,9 @@
-"""``AgentConfig.from_params`` (the three request shapes) and ``RunSelection.from_params``.
+"""``AgentConfig.from_params`` (the three request shapes), including the run-selection fields.
 
-The handler parses whatever the playground or a stored config sends into a neutral
-``AgentConfig`` plus a ``RunSelection``. This file locks the three accepted shapes, the
-defaults fall-through, the ``harness_options`` escape hatch, and the run-selection parsing.
+The handler parses whatever the playground or a stored config sends into one ``AgentConfig``.
+This file locks the three accepted shapes, the defaults fall-through, the ``harness_kwargs``
+escape hatch, and the run-selection parsing (``harness`` / ``sandbox`` / ``permission_policy``,
+which now live on ``AgentConfig`` rather than a separate ``RunSelection``).
 """
 
 from __future__ import annotations
@@ -10,7 +11,6 @@ from __future__ import annotations
 from agenta.sdk.agents import (
     AgentConfig,
     BuiltinToolConfig,
-    RunSelection,
 )
 
 _DEFAULTS = AgentConfig(instructions="default-md", model="default-model", tools=["d"])
@@ -26,7 +26,7 @@ def test_from_params_agent_element_shape():
                 "instructions": "I",
                 "model": "M",
                 "tools": [{"type": "builtin", "name": "read"}],
-                "harness_options": {"pi_core": {"system": "S"}},
+                "harness_kwargs": {"pi_core": {"system": "S"}},
             }
         },
         defaults=_DEFAULTS,
@@ -34,7 +34,7 @@ def test_from_params_agent_element_shape():
     assert config.instructions == "I"
     assert config.model == "M"
     assert config.tools == [BuiltinToolConfig(name="read")]
-    assert config.harness_options == {"pi_core": {"system": "S"}}
+    assert config.harness_kwargs == {"pi_core": {"system": "S"}}
 
 
 def test_from_params_prompt_template_shape():
@@ -149,34 +149,34 @@ def test_from_params_skills_falls_back_to_defaults_when_absent():
     assert [s.name for s in config.skills] == ["release-notes"]
 
 
-def test_harness_options_drops_malformed_and_lowercases_keys():
+def test_harness_kwargs_drops_malformed_and_lowercases_keys():
     config = AgentConfig.from_params(
         {
             "agent": {
-                "harness_options": {
+                "harness_kwargs": {
                     "PI_CORE": {"system": "S"},  # key lower-cased
                     "claude": "not a dict",  # dropped
                 }
             }
         }
     )
-    assert config.harness_options == {"pi_core": {"system": "S"}}
+    assert config.harness_kwargs == {"pi_core": {"system": "S"}}
 
 
-def test_harness_options_falls_back_to_defaults_when_absent():
-    defaults = AgentConfig(harness_options={"pi_core": {"system": "D"}})
+def test_harness_kwargs_falls_back_to_defaults_when_absent():
+    defaults = AgentConfig(harness_kwargs={"pi_core": {"system": "D"}})
     config = AgentConfig.from_params(
         {"agent": {"instructions": "I"}}, defaults=defaults
     )
-    assert config.harness_options == {"pi_core": {"system": "D"}}
+    assert config.harness_kwargs == {"pi_core": {"system": "D"}}
 
 
-# -------------------------------------------------------------- RunSelection
+# ---------------------------------------------------- run-selection fields
 
 
 def test_run_selection_defaults():
-    sel = RunSelection.from_params({})
-    assert (sel.harness, sel.sandbox, sel.permission_policy) == (
+    config = AgentConfig.from_params({})
+    assert (config.harness, config.sandbox, config.permission_policy) == (
         "pi_core",
         "local",
         "auto",
@@ -184,7 +184,7 @@ def test_run_selection_defaults():
 
 
 def test_run_selection_reads_agent_subdict_and_lowercases():
-    sel = RunSelection.from_params(
+    config = AgentConfig.from_params(
         {
             "agent": {
                 "harness": "Claude",
@@ -193,21 +193,20 @@ def test_run_selection_reads_agent_subdict_and_lowercases():
             }
         }
     )
-    assert (sel.harness, sel.sandbox, sel.permission_policy) == (
+    assert (config.harness, config.sandbox, config.permission_policy) == (
         "claude",
         "daytona",
         "deny",
     )
 
 
-def test_run_selection_honors_custom_defaults():
-    sel = RunSelection.from_params(
-        {}, default_harness="claude", default_sandbox="daytona"
-    )
-    assert sel.harness == "claude"
-    assert sel.sandbox == "daytona"
+def test_run_selection_honors_defaults():
+    defaults = AgentConfig(harness="claude", sandbox="daytona")
+    config = AgentConfig.from_params({}, defaults=defaults)
+    assert config.harness == "claude"
+    assert config.sandbox == "daytona"
 
 
 def test_run_selection_reads_flat_request():
-    sel = RunSelection.from_params({"harness": "claude"})
-    assert sel.harness == "claude"
+    config = AgentConfig.from_params({"harness": "claude"})
+    assert config.harness == "claude"

--- a/sdks/python/oss/tests/pytest/unit/agents/test_dtos_agent_config.py
+++ b/sdks/python/oss/tests/pytest/unit/agents/test_dtos_agent_config.py
@@ -171,6 +171,16 @@ def test_harness_kwargs_falls_back_to_defaults_when_absent():
     assert config.harness_kwargs == {"pi_core": {"system": "D"}}
 
 
+def test_harness_kwargs_explicit_empty_clears_defaults():
+    # An explicit empty dict clears inherited per-harness options; only an absent
+    # key falls back to defaults.
+    defaults = AgentConfig(harness_kwargs={"pi_core": {"system": "D"}})
+    config = AgentConfig.from_params(
+        {"agent": {"harness_kwargs": {}}}, defaults=defaults
+    )
+    assert config.harness_kwargs == {}
+
+
 # ---------------------------------------------------- run-selection fields
 
 

--- a/sdks/python/oss/tests/pytest/unit/agents/test_harness_adapters.py
+++ b/sdks/python/oss/tests/pytest/unit/agents/test_harness_adapters.py
@@ -64,11 +64,11 @@ def test_pi_keeps_builtins_and_native_tools(make_env):
     assert result.model == "m"
 
 
-def test_pi_reads_its_harness_options_slice(make_env):
+def test_pi_reads_its_harness_kwargs_slice(make_env):
     harness = PiHarness(make_env(supported=[HarnessType.PI]))
     agent = AgentConfig(
         instructions="hi",
-        harness_options={
+        harness_kwargs={
             "pi_core": {"system": "You are Pi.", "append_system": "Be terse."},
             "claude": {"system": "ignored for Pi"},
         },
@@ -86,11 +86,11 @@ def test_pi_reads_its_harness_options_slice(make_env):
     }
 
 
-def test_pi_drops_blank_harness_options(make_env):
+def test_pi_drops_blank_harness_kwargs(make_env):
     harness = PiHarness(make_env(supported=[HarnessType.PI]))
     agent = AgentConfig(
         instructions="hi",
-        harness_options={"pi_core": {"system": "   ", "append_system": ""}},
+        harness_kwargs={"pi_core": {"system": "   ", "append_system": ""}},
     )
 
     result = harness._to_harness_config(_session_config(agent=agent))
@@ -152,7 +152,7 @@ def test_agenta_passes_through_user_pi_options(make_env):
     harness = AgentaHarness(make_env(supported=[HarnessType.AGENTA]))
     agent = AgentConfig(
         instructions="hi",
-        harness_options={
+        harness_kwargs={
             "pi_core": {"system": "You are Pi.", "append_system": "Be terse."}
         },
     )
@@ -247,13 +247,13 @@ def test_claude_threads_options_and_renders_settings_file(make_env):
         },
         "pi_core": {"system": "ignored for Claude"},
     }
-    agent = AgentConfig(instructions="hi", model="m", harness_options=options)
+    agent = AgentConfig(instructions="hi", model="m", harness_kwargs=options)
 
     result = harness._to_harness_config(_session_config(agent=agent))
 
     # The whole map is threaded onto the config; the claude config's `wire_harness_files` (the
     # Python claude adapter) translates its own `claude.permissions` slice into a rendered file.
-    assert result.harness_options == options
+    assert result.harness_kwargs == options
     wire = result.wire_harness_files()
     assert wire["harnessFiles"][0]["path"] == ".claude/settings.json"
     assert json.loads(wire["harnessFiles"][0]["content"]) == {
@@ -265,12 +265,12 @@ def test_claude_threads_options_and_renders_settings_file(make_env):
     }
 
 
-def test_claude_without_harness_options_renders_no_files(make_env):
+def test_claude_without_harness_kwargs_renders_no_files(make_env):
     harness = ClaudeHarness(make_env(supported=[HarnessType.CLAUDE]))
 
     result = harness._to_harness_config(_session_config())
 
-    assert result.harness_options == {}
+    assert result.harness_kwargs == {}
     assert result.wire_harness_files() == {}
 
 

--- a/sdks/python/oss/tests/pytest/unit/agents/test_wire_contract.py
+++ b/sdks/python/oss/tests/pytest/unit/agents/test_wire_contract.py
@@ -123,7 +123,7 @@ def _claude_payload():
         custom_tools=[dict(_CUSTOM_TOOL)],
         tool_callback=_CALLBACK,
         permission_policy="deny",
-        harness_options={
+        harness_kwargs={
             "claude": {
                 "permissions": {
                     "default_mode": "acceptEdits",
@@ -466,7 +466,7 @@ def test_request_to_wire_pi_renders_no_harness_files_from_its_options():
     # config carrying options (even a `claude` slice that is never its concern) emits no
     # `harnessFiles`. The raw options map no longer rides the wire.
     config = PiAgentConfig(
-        harness_options={
+        harness_kwargs={
             "pi": {"system": "You are Pi."},
             "claude": {"permissions": {"default_mode": "plan"}},
         }
@@ -489,7 +489,7 @@ def test_request_to_wire_claude_renders_settings_from_options_and_boundaries():
     # `mcp__<server>` ask. The author's deny keeps its position; derived rules append (deduped).
     config = ClaudeAgentConfig(
         sandbox_permission=SandboxPermission(network={"mode": "off"}),
-        harness_options={"claude": {"permissions": {"default_mode": "plan"}}},
+        harness_kwargs={"claude": {"permissions": {"default_mode": "plan"}}},
         mcp_servers=[
             {
                 "name": "github",

--- a/services/oss/src/agent/app.py
+++ b/services/oss/src/agent/app.py
@@ -2,14 +2,14 @@
 
 Mirrors the chat/completion services: an Agenta app exposing ``/invoke`` and ``/inspect``
 through ``ag.create_app`` + ``ag.workflow`` + ``ag.route``. The handler parses the request
-into a neutral ``AgentConfig`` + ``RunSelection`` (``agenta.sdk.agents``), resolves tools
-(``tools``) and one least-privilege model connection (``resolve_connection``) server-side,
-threads the trace context (``tracing``), then runs one turn through a :class:`Harness` over a
-backend it picks from the selection, and records the run's usage.
+into one neutral ``AgentConfig`` (``agenta.sdk.agents``), resolves tools (``tools``) and one
+least-privilege model connection (``resolve_connection``) server-side, threads the trace
+context (``tracing``), then runs one turn through a :class:`Harness` over a backend it picks
+from the config's run-selection fields, and records the run's usage.
 
 The sandbox-agent-backed backend is the production path. The transport is a deployment
 choice: HTTP to `AGENTA_AGENT_RUNNER_URL`, or a local runner CLI in a source checkout.
-The harness, sandbox, and permission policy are editable playground config.
+The harness, sandbox, and permission policy are editable fields on the agent config.
 """
 
 from typing import Any, Dict, List, Optional
@@ -25,7 +25,6 @@ from agenta.sdk.agents import (
     ResolvedConnection,
     RuntimeAuthContext,
     SandboxAgentBackend,
-    RunSelection,
     SessionConfig,
     make_harness,
     to_messages,
@@ -184,15 +183,16 @@ async def _resolve_session_connection(
     return resolved
 
 
-def select_backend(selection: RunSelection) -> Backend:
-    """Pick the backend for a run.
+def select_backend(agent_config: AgentConfig) -> Backend:
+    """Pick the backend for a run from the agent config's run-selection fields.
 
     The service always uses the sandbox-agent-backed runner. `AGENTA_AGENT_RUNNER_URL`
     selects HTTP transport in deployed containers. When it is unset, local development
-    spawns the TypeScript runner CLI from the runner dir.
+    spawns the TypeScript runner CLI from the runner dir. Only ``sandbox`` is read here;
+    it is a backend/environment concern that never enters ``SessionConfig``.
     """
     return SandboxAgentBackend(
-        sandbox=selection.sandbox,
+        sandbox=agent_config.sandbox,
         url=runner_url(),
         cwd=str(runner_dir()),
     )
@@ -208,7 +208,6 @@ async def _agent(
     params = parameters or {}
 
     agent_config = AgentConfig.from_params(params, defaults=_default_agent_config())
-    selection = RunSelection.from_params(params)
 
     msgs = to_messages(messages or (inputs or {}).get("messages") or [])
     # Three independent resolutions (tools, MCP, the model's one connection), not one aggregate:
@@ -224,7 +223,9 @@ async def _agent(
     resolved_connection: Optional[ResolvedConnection] = None
     secrets: Dict[str, str] = {}
     if model_ref is not None:
-        ctx = RuntimeAuthContext(harness=selection.harness, backend=selection.sandbox)
+        ctx = RuntimeAuthContext(
+            harness=agent_config.harness, backend=agent_config.sandbox
+        )
         resolved_connection = await _resolve_session_connection(model_ref, ctx)
         secrets = resolved_connection.env
 
@@ -232,7 +233,7 @@ async def _agent(
         agent=agent_config,
         secrets=secrets,  # the env compat alias the wire still reads
         resolved_connection=resolved_connection,
-        permission_policy=selection.permission_policy,
+        permission_policy=agent_config.permission_policy,
         trace=trace_context(),
         session_id=session_id,
         builtin_names=resolved_tools.builtin_names,
@@ -245,7 +246,9 @@ async def _agent(
     # here instead of silently changing runtime behavior. The sandbox-agent backend supports all
     # three harnesses (pi_core, pi_agenta, claude). setup/cleanup own the backend lifecycle;
     # prompt/stream run one cold turn.
-    harness = make_harness(selection.harness, Environment(select_backend(selection)))
+    harness = make_harness(
+        agent_config.harness, Environment(select_backend(agent_config))
+    )
 
     # Both paths hand off to a helper that owns the environment lifecycle (setup/cleanup).
     # They differ only in shape, as they must: the `/messages` SSE path (`stream` set) returns

--- a/services/oss/tests/pytest/unit/agent/test_default_agent_config.py
+++ b/services/oss/tests/pytest/unit/agent/test_default_agent_config.py
@@ -8,7 +8,7 @@ and that the `/inspect` default the playground pre-fills is the same value the r
 
 from __future__ import annotations
 
-from agenta.sdk.agents import AgentConfig, RunSelection
+from agenta.sdk.agents import AgentConfig
 from agenta.sdk.engines.running.interfaces import agent_v0_interface
 from agenta.sdk.utils.types import AgentConfigSchema, build_agent_v0_default
 
@@ -41,24 +41,23 @@ def test_service_default_is_the_builder_plus_service_only_choices():
 
 def test_inspect_default_parses_into_the_runtime_selection():
     # The default the playground pre-fills on `/inspect` must parse cleanly into the same runtime
-    # values `AgentConfig.from_params` / `RunSelection.from_params` produce, so what the user sees
-    # is what the agent runs. The `@ag.embed` skill resolves server-side before this parse, so the
-    # config-level round-trip is asserted on the non-skill fields plus the run selection.
+    # values `AgentConfig.from_params` produces, so what the user sees is what the agent runs. The
+    # `@ag.embed` skill resolves server-side before this parse, so the config-level round-trip is
+    # asserted on the non-skill fields plus the run-selection fields (now on `AgentConfig`).
     inspect_default = _inspect_agent_default()
     no_skill = {k: v for k, v in inspect_default.items() if k != "skills"}
     params = {"agent": no_skill}
 
     config = AgentConfig.from_params(params)
-    selection = RunSelection.from_params(params)
 
     assert config.model == inspect_default["model"]
     assert config.instructions == inspect_default["agents_md"]
     assert (
         config.sandbox_permission is not None
     )  # the service boundary survives the parse
-    assert selection.harness == "pi_core"
-    assert selection.sandbox == "local"
-    assert selection.permission_policy == "auto"
+    assert config.harness == "pi_core"
+    assert config.sandbox == "local"
+    assert config.permission_policy == "auto"
 
 
 def test_service_only_extras_present_in_inspect_absent_from_builtin():

--- a/services/oss/tests/pytest/unit/agent/test_select_backend.py
+++ b/services/oss/tests/pytest/unit/agent/test_select_backend.py
@@ -7,9 +7,9 @@ from pathlib import Path
 import pytest
 
 from agenta.sdk.agents import (
+    AgentConfig,
     AgentRunnerConfigurationError,
     SandboxAgentBackend,
-    RunSelection,
 )
 
 from oss.src.agent.app import select_backend
@@ -31,7 +31,7 @@ def _clean_env(monkeypatch, runner_wrapper: Path):
 
 
 def _sel(harness="pi_core", sandbox="local"):
-    return RunSelection(harness=harness, sandbox=sandbox)
+    return AgentConfig(harness=harness, sandbox=sandbox)
 
 
 @pytest.mark.parametrize("harness", ["pi_core", "pi_agenta", "claude"])

--- a/web/oss/src/components/AgentChatSlice/assets/transport.ts
+++ b/web/oss/src/components/AgentChatSlice/assets/transport.ts
@@ -52,16 +52,27 @@ const stubConfig = () => ({
 /**
  * Real config from the app's latest revision when `appId` is set and loaded; else the stub.
  * Returns `{parameters, references}`: `parameters` is the agent config the backend reads as
- * `data.parameters`. `harness`/`sandbox` (agent-specific, not part of a stored workflow
- * config) are defaulted but never override values the resolved config already carries.
+ * `data.parameters`. `harness`/`sandbox` are run-selection fields on the AGENT CONFIG
+ * (`parameters.agent`); they are defaulted there but never override values the resolved
+ * config already carries.
  */
 const configFor = (appId?: string | null) => {
     const resolved = resolveAppAgConfig(appId)
     if (!resolved) return stubConfig()
-    return {
-        parameters: {harness: "pi_core", sandbox: "local", ...resolved.ag_config},
-        references: resolved.references,
-    }
+    const agConfig = resolved.ag_config as Record<string, unknown>
+    const agent = agConfig.agent
+    const parameters =
+        agent && typeof agent === "object"
+            ? {
+                  ...agConfig,
+                  agent: {
+                      harness: "pi_core",
+                      sandbox: "local",
+                      ...(agent as Record<string, unknown>),
+                  },
+              }
+            : {harness: "pi_core", sandbox: "local", ...agConfig}
+    return {parameters, references: resolved.references}
 }
 
 const withQuery = (url: string, params: Record<string, string | undefined>): string => {

--- a/web/oss/src/components/AgentChatSlice/assets/transport.ts
+++ b/web/oss/src/components/AgentChatSlice/assets/transport.ts
@@ -56,22 +56,30 @@ const stubConfig = () => ({
  * (`parameters.agent`); they are defaulted there but never override values the resolved
  * config already carries.
  */
+// Legacy pre-migration run-selection keys that now live inside `agent`. Stripped from the
+// top level when `agent` is present so we never emit both wire shapes for one config.
+const LEGACY_RUN_SELECTION_KEYS = ["harness", "sandbox", "permission_policy"] as const
+
 const configFor = (appId?: string | null) => {
     const resolved = resolveAppAgConfig(appId)
     if (!resolved) return stubConfig()
     const agConfig = resolved.ag_config as Record<string, unknown>
     const agent = agConfig.agent
-    const parameters =
-        agent && typeof agent === "object"
-            ? {
-                  ...agConfig,
-                  agent: {
-                      harness: "pi_core",
-                      sandbox: "local",
-                      ...(agent as Record<string, unknown>),
-                  },
-              }
-            : {harness: "pi_core", sandbox: "local", ...agConfig}
+    let parameters: Record<string, unknown>
+    if (agent && typeof agent === "object") {
+        const rest = {...agConfig}
+        for (const key of LEGACY_RUN_SELECTION_KEYS) delete rest[key]
+        parameters = {
+            ...rest,
+            agent: {
+                harness: "pi_core",
+                sandbox: "local",
+                ...(agent as Record<string, unknown>),
+            },
+        }
+    } else {
+        parameters = {harness: "pi_core", sandbox: "local", ...agConfig}
+    }
     return {parameters, references: resolved.references}
 }
 

--- a/web/packages/agenta-entity-ui/src/DrillInView/SchemaControls/AgentConfigControl.tsx
+++ b/web/packages/agenta-entity-ui/src/DrillInView/SchemaControls/AgentConfigControl.tsx
@@ -348,34 +348,34 @@ export function AgentConfigControl({
     )
 
     // Layer 1 (Claude-only): the Claude harness's own permission knobs, persisted into the neutral
-    // `harness_options.claude.permissions` bag. Hidden when the harness is not Claude.
-    const harnessOptions = useMemo(
+    // `harness_kwargs.claude.permissions` bag. Hidden when the harness is not Claude.
+    const harnessKwargs = useMemo(
         () =>
-            config.harness_options && typeof config.harness_options === "object"
-                ? (config.harness_options as Record<string, unknown>)
+            config.harness_kwargs && typeof config.harness_kwargs === "object"
+                ? (config.harness_kwargs as Record<string, unknown>)
                 : {},
-        [config.harness_options],
+        [config.harness_kwargs],
     )
     const claudePermissions = useMemo(() => {
-        const claude = harnessOptions.claude
+        const claude = harnessKwargs.claude
         const claudeObj =
             claude && typeof claude === "object" ? (claude as Record<string, unknown>) : undefined
         const perms = claudeObj?.permissions
         return perms && typeof perms === "object" ? (perms as Record<string, unknown>) : null
-    }, [harnessOptions])
-    // Write `harness_options.claude.permissions`, preserving any other harness_options slices.
+    }, [harnessKwargs])
+    // Write `harness_kwargs.claude.permissions`, preserving any other harness_kwargs slices.
     const setClaudePermissions = useCallback(
         (next: Record<string, unknown>) => {
             const claude =
-                harnessOptions.claude && typeof harnessOptions.claude === "object"
-                    ? (harnessOptions.claude as Record<string, unknown>)
+                harnessKwargs.claude && typeof harnessKwargs.claude === "object"
+                    ? (harnessKwargs.claude as Record<string, unknown>)
                     : {}
-            setField("harness_options", {
-                ...harnessOptions,
+            setField("harness_kwargs", {
+                ...harnessKwargs,
                 claude: {...claude, permissions: next},
             })
         },
-        [harnessOptions, setField],
+        [harnessKwargs, setField],
     )
     const [showClaudeAdvanced, setShowClaudeAdvanced] = useState(false)
 

--- a/web/packages/agenta-entity-ui/src/DrillInView/SchemaControls/ClaudePermissionsControl.tsx
+++ b/web/packages/agenta-entity-ui/src/DrillInView/SchemaControls/ClaudePermissionsControl.tsx
@@ -3,14 +3,14 @@
  *
  * Layer 1 of the agent capability config, Claude-only: the Claude harness's own permission knobs.
  * These map 1:1 to Claude Code's `permissions` settings block and persist into the neutral
- * `harness_options.claude.permissions` bag on the agent config (the SDK's `ClaudePermissions`,
+ * `harness_kwargs.claude.permissions` bag on the agent config (the SDK's `ClaudePermissions`,
  * agenta.sdk.agents.dtos). The shape:
  *   { default_mode?: "default"|"acceptEdits"|"plan"|"bypassPermissions",
  *     allow: string[], deny: string[], ask: string[] }
  *
  * It is rendered as a collapsed "advanced" section by AgentConfigControl and is hidden when the
  * harness is not Claude (nothing here applies to Pi, which never gates tool use). Non-destructive:
- * an author who touches nothing leaves `harness_options` untouched.
+ * an author who touches nothing leaves `harness_kwargs` untouched.
  */
 import {memo, useCallback, useMemo} from "react"
 
@@ -28,7 +28,7 @@ interface ClaudePermissionsValue {
 }
 
 export interface ClaudePermissionsControlProps {
-    /** The `harness_options.claude.permissions` value (object or null/undefined). */
+    /** The `harness_kwargs.claude.permissions` value (object or null/undefined). */
     value?: Record<string, unknown> | null
     /** Called with the next permissions object. */
     onChange: (value: Record<string, unknown>) => void

--- a/web/packages/agenta-playground/src/state/execution/agentRequest.ts
+++ b/web/packages/agenta-playground/src/state/execution/agentRequest.ts
@@ -181,11 +181,17 @@ const hasAnswer = (message: unknown): boolean => {
  * always wins; the schema nests the config under `agent`, but a flat config (no `agent` key)
  * is still defaulted at the top level so a non-schema config keeps working.
  */
+// Legacy pre-migration run-selection keys that now live inside `agent`. Stripped from the
+// top level when `agent` is present so we never emit both wire shapes for one config.
+const LEGACY_RUN_SELECTION_KEYS = ["harness", "sandbox", "permission_policy"] as const
+
 const withAgentRunDefaults = (config: Record<string, unknown>): Record<string, unknown> => {
     const agent = config.agent
     if (agent && typeof agent === "object") {
+        const rest = {...config}
+        for (const key of LEGACY_RUN_SELECTION_KEYS) delete rest[key]
         return {
-            ...config,
+            ...rest,
             agent: {harness: "pi_core", sandbox: "local", ...(agent as Record<string, unknown>)},
         }
     }

--- a/web/packages/agenta-playground/src/state/execution/agentRequest.ts
+++ b/web/packages/agenta-playground/src/state/execution/agentRequest.ts
@@ -19,8 +19,8 @@
  *   { session_id, references, data: { messages, parameters } }
  *  - `parameters` is the DRAFT-AWARE config (`workflowMolecule.selectors.configuration`,
  *    merged draft + server) so unsaved left-panel edits apply to the agent run.
- *  - `harness`/`sandbox` are agent-runtime hints, defaulted but never overriding
- *    a value the resolved config already carries.
+ *  - `harness`/`sandbox` live on the agent config (`parameters.agent`), defaulted but
+ *    never overriding a value the resolved config already carries.
  *  - `project_id` / `application_id` ride the URL QUERY (never the body), and
  *    `project_id` only travels alongside auth — mirroring `executionItems.ts`.
  */
@@ -174,6 +174,24 @@ const hasAnswer = (message: unknown): boolean => {
     return Array.isArray(msg.parts) && msg.parts.some(isAnswerPart)
 }
 
+/**
+ * Default the agent run-selection fields (`harness`/`sandbox`) onto the AGENT CONFIG
+ * (`parameters.agent`), not as top-level params siblings. They are part of one `AgentConfig`
+ * now, so they belong inside the `agent` block. A value the resolved config already carries
+ * always wins; the schema nests the config under `agent`, but a flat config (no `agent` key)
+ * is still defaulted at the top level so a non-schema config keeps working.
+ */
+const withAgentRunDefaults = (config: Record<string, unknown>): Record<string, unknown> => {
+    const agent = config.agent
+    if (agent && typeof agent === "object") {
+        return {
+            ...config,
+            agent: {harness: "pi_core", sandbox: "local", ...(agent as Record<string, unknown>)},
+        }
+    }
+    return {harness: "pi_core", sandbox: "local", ...config}
+}
+
 const withQuery = (url: string, params: Record<string, string | undefined>): string => {
     const qs = new URLSearchParams()
     for (const [key, value] of Object.entries(params)) {
@@ -217,11 +235,13 @@ export async function buildAgentRequest(
         | Record<string, unknown>
         | null
         | undefined
-    const parameters = pruneBlankEntries({
-        harness: "pi_core",
-        sandbox: "local",
-        ...(config ?? {}),
-    }) as Record<string, unknown>
+    // `harness`/`sandbox` are run-selection fields on the AGENT CONFIG (`parameters.agent`), not
+    // top-level params siblings. Default them inside the `agent` block, never overriding values
+    // the resolved config already carries.
+    const parameters = pruneBlankEntries(withAgentRunDefaults(config ?? {})) as Record<
+        string,
+        unknown
+    >
 
     const entity = store.get(workflowMolecule.selectors.data(entityId)) as
         | RevisionLike

--- a/web/packages/agenta-playground/tests/unit/agentRequest.test.ts
+++ b/web/packages/agenta-playground/tests/unit/agentRequest.test.ts
@@ -148,12 +148,23 @@ describe("buildAgentRequest", () => {
         expect(req!.requestBody.session_id).toBe("s1")
         const data = req!.requestBody.data as any
         expect(data.messages).toEqual([{role: "user"}])
-        // draft-aware config flows through, harness/sandbox defaulted
+        // draft-aware config flows through; a flat config (no `agent` key) is defaulted at top level
         expect(data.parameters).toMatchObject({
             temperature: 0.9,
             prompt: {x: 1},
             harness: "pi_core",
         })
+    })
+
+    it("defaults harness/sandbox INSIDE the agent block when the config nests under `agent`", async () => {
+        // The schema places the run-selection fields on the agent config (`parameters.agent`),
+        // not as top-level params siblings. Defaults land there; an explicit value wins.
+        seed(store, "e", {config: {agent: {model: "gpt-5.5", sandbox: "daytona"}}})
+        const req = await buildAgentRequest("e", [], {sessionId: "s1", store})
+        const agent = (req!.requestBody.data as any).parameters.agent
+        expect(agent).toMatchObject({model: "gpt-5.5", harness: "pi_core", sandbox: "daytona"})
+        // not duplicated at the top level
+        expect((req!.requestBody.data as any).parameters.harness).toBeUndefined()
     })
 
     it("INCLUDES references built from the entity identity", async () => {

--- a/web/packages/agenta-playground/tests/unit/agentRequest.test.ts
+++ b/web/packages/agenta-playground/tests/unit/agentRequest.test.ts
@@ -167,6 +167,25 @@ describe("buildAgentRequest", () => {
         expect((req!.requestBody.data as any).parameters.harness).toBeUndefined()
     })
 
+    it("STRIPS legacy top-level run-selection keys when a nested agent is present", async () => {
+        // A partially-migrated config carrying BOTH the nested `agent` and legacy top-level
+        // run-selection keys must emit only the nested shape, never both at once.
+        seed(store, "e", {
+            config: {
+                harness: "claude",
+                sandbox: "local",
+                permission_policy: "deny",
+                agent: {model: "gpt-5.5"},
+            },
+        })
+        const req = await buildAgentRequest("e", [], {sessionId: "s1", store})
+        const parameters = (req!.requestBody.data as any).parameters
+        expect(parameters.harness).toBeUndefined()
+        expect(parameters.sandbox).toBeUndefined()
+        expect(parameters.permission_policy).toBeUndefined()
+        expect(parameters.agent).toMatchObject({model: "gpt-5.5", harness: "pi_core"})
+    })
+
     it("INCLUDES references built from the entity identity", async () => {
         seed(store, "e", {
             data: {


### PR DESCRIPTION
## What and why

PR #4821 review (comments 2 / 7 / 8) asked for one thing: there should be a single agent config, not an `AgentConfig` plus a separate sidecar `RunSelection`. The run-selection fields were split off into their own DTO and parsed separately, so "what the agent is" and "how it runs" lived in two places that both rode `data.parameters`.

This collapses them. `harness`, `sandbox`, and `permission_policy` are now plain fields on `AgentConfig`, parsed by the one `AgentConfig.from_params(...)`. `RunSelection` is retired. The per-harness options bag `harness_options` is renamed to `harness_kwargs` (comment 8): a map keyed by harness name where the author sets per-harness knobs, e.g. Pi's `system`/`append_system` under `pi_core`, Claude's `permissions` under `claude`. `permission_policy` stays the sidecar action-permission, now inside `AgentConfig`.

POC: no back-compat, no deprecation shims. Shapes change cleanly.

## Public-edge envelope change

The run-selection fields move from siblings of `agent` to inside it. They live under `data.parameters.agent.{harness,sandbox,permission_policy}`, not `data.parameters.{harness,sandbox,permission_policy}`.

Before:
```jsonc
"parameters": {
  "agent": { "agents_md": "...", "model": "..." },
  "harness": "pi_core",
  "sandbox": "local"
}
```

After:
```jsonc
"parameters": {
  "agent": { "agents_md": "...", "model": "...", "harness": "pi_core", "sandbox": "local", "permission_policy": "auto" }
}
```

The playground schema (`AgentConfigSchema`) and `build_agent_v0_default` already placed these inside `agent`, so the schema and default did not change. The FE request builders (`agentRequest.ts`, `AgentChatSlice/transport.ts`) stopped injecting top-level `harness`/`sandbox` and now default them inside the `agent` block.

## The `/run` wire did NOT change

`harness`/`sandbox` ride the wire as explicit args to `request_to_wire(harness=, sandbox=)` (the harness adapter passes them from `make_harness(agent_config.harness, ...)` + `select_backend(agent_config).sandbox`); `permissionPolicy` rides `wire_tools()`. There are no new wire fields and the golden fixtures are untouched. This is an envelope/config-placement + parsing change, not a contract change. `sandbox` stays a backend/environment concern read before the session is built; no adapter consumes it.

## Decisions

- **Retire `RunSelection`.** Nothing else needed it; one agent definition is the whole point of the comment. Removed its export from `agenta.sdk.agents` and the top-level `agenta` package.
- **`harness_options` -> `harness_kwargs`.** Today's bag already was the general per-harness map the comment described, so this is a reconcile-rename, not a new field.
- **`sandbox` left in place** (not removed). The sibling sidecar-uri-config work will replace `sandbox` with an optional `uri` next; this PR moves `sandbox` cleanly into `AgentConfig` so that follow-up is a small field swap.

## Tests

- SDK agents: 342 passed. service-agent: 38 passed.
- FE playground: 121 (agentRequest 19, incl. a new test asserting the defaults land inside `agent`). entity-ui: 126.
- entity-ui + playground typecheck green; ruff + prettier + eslint clean.
- Codex (xhigh) reviewed: runtime sound, wire unchanged.

## Docs

Updated the interface inventory pages (agent-config-schema, agent-messages, workflow-invoke, agent-service-handler, neutral-runtime-dtos) and the affected documentation pages (agent-configuration, ground-truth, ports-and-adapters, architecture, harness-adapters, adapters/pi, adapters/agenta, agent-template) to the "everything under AgentConfig" shape and the `harness_kwargs` name.

## Deferred

- `services/agent/src/protocol.ts:354` has a `harness_options` doc comment (describes the Python-side bag). It is in the runner dir (sibling HTTP-MCP impl active there), so untouched; rename in a runner-owned change.

https://claude.ai/code/session_01GYo3UEfvsZpncagqb28Mbc
