### PR TITLE
fix: show evaluation run errors in ETL output columns

### DIFF
--- a/web/oss/src/components/EvalRunDetails/etl/cells/EtlResolvedCell.tsx
+++ b/web/oss/src/components/EvalRunDetails/etl/cells/EtlResolvedCell.tsx
@@ -39,6 +39,7 @@ import {useQuery, useQueryClient} from "@tanstack/react-query"
 import {Tag} from "antd"
 import clsx from "clsx"
 import {useAtomValue} from "jotai"
+import {AlertCircle} from "lucide-react"
 
 import {isTerminalStatus} from "../../atoms/compare"
 import {scenarioRowHeightAtom, type ScenarioRowHeight} from "../../state/rowHeight"
@@ -250,6 +251,27 @@ const EtlResolvedCell = ({
 
     const hasValue = !!resolved && resolved.source !== "missing"
 
+    // Extract step error from the results cache when the step that this
+    // column maps to has a failure status and an error payload (e.g.
+    // missing API key, LLM invocation failure). Without this check cells
+    // for failed steps render "—" which is indistinguishable from a step
+    // that just produced no value.
+    const stepError = useMemo<{message: string} | null>(() => {
+        if (!resolved || !resultsFetched) return null
+        const results = (resultsQ.data ??
+            evaluationResultMolecule.get.byScenario({projectId, runId, scenarioId}) ??
+            []) as HydratedScenarioRow["results"]
+        for (const r of results) {
+            if (r.step_key === resolved.stepKey && r.status === "failure" && r.error) {
+                return {
+                    message:
+                        typeof r.error.message === "string" ? r.error.message : String(r.error),
+                }
+            }
+        }
+        return null
+    }, [resolved, resultsFetched, projectId, runId, scenarioId, hydrationVersion, resultsQ.data])
+
     // Is a slice this cell needs still in flight? Distinguishes
     // "slice-not-hydrated" (skeleton) from "genuinely missing" ("—") for
     // a terminal scenario. A slice that the materializer marked failed is
@@ -318,7 +340,19 @@ const EtlResolvedCell = ({
     const isTerminal = isTerminalStatus(scenarioStatus)
 
     let content: React.ReactNode
-    if (hasValue) {
+    if (stepError && isTerminal) {
+        content = (
+            <div className="flex flex-col gap-1">
+                <div className="flex items-center gap-1.5 text-red-500">
+                    <AlertCircle size={14} className="flex-shrink-0" />
+                    <span className="text-xs font-medium">Error</span>
+                </div>
+                <span className="scenario-table-text whitespace-pre-wrap text-red-600 text-xs">
+                    {stepError.message}
+                </span>
+            </div>
+        )
+    } else if (hasValue) {
         content = (
             <div
                 className="scenario-table-text w-full"


### PR DESCRIPTION
## Summary

Fixes #4660

When an evaluation step fails (e.g. missing OpenAI API key), the ETL-resolved cells in the evaluation results table were showing `"—"` (empty placeholder) instead of the error message. This made it impossible to distinguish between a step that produced no value and one that failed.

## Changes

- `web/oss/src/components/EvalRunDetails/etl/cells/EtlResolvedCell.tsx`: Check the evaluation results cache for the step mapped to each column. When the result has `status: "failure"` with an error payload, render a red error label with the error message instead of the empty placeholder.

## Verification

- TypeScript check: no errors in the changed file
- ESLint: no warnings or errors
- Prettier: passes format check

## Screenshots

Before: the output column shows `"—"` for failed steps, indistinguishable from a step that produced no value.

After: a red error indicator with the error message is displayed. The styling matches the existing error pattern used in `MetricCell` and `InvocationCell` (AlertCircle icon + red text).