### PR TITLE
fix(frontend): use generateId() instead of crypto.randomUUID in AgentChatSlice

### DIFF
--- a/web/oss/src/components/AgentChatSlice/state/sessions.ts
+++ b/web/oss/src/components/AgentChatSlice/state/sessions.ts
@@ -1,3 +1,4 @@
+import {generateId} from "@agenta/shared/utils"
 import type {UIMessage} from "ai"
 import {atom, type Getter} from "jotai"
 import {atomFamily, atomWithStorage, selectAtom} from "jotai/utils"
@@ -117,7 +118,7 @@ export const openSessionIdsAtom = atom((get) => new Set(get(openIdsAtom)))
 /** Create a session and make it the active open tab. Returns the new id. */
 export const addSessionAtom = atom(null, (get, set) => {
     const key = get(appKeyAtom)
-    const id = crypto.randomUUID()
+    const id = generateId()
     // Read open ids BEFORE mutating history, else the fallback would re-count the new id.
     const open = currentOpenIds(get, key)
     const all = get(sessionsByAppAtom)


### PR DESCRIPTION
## Context
On plain-HTTP deployments (dev boxes, internal staging without TLS), creating a new agent session in the playground appeared to get stuck. No new chat tab opened; the error boundary swallowed the real cause. The root cause was a call to `crypto.randomUUID()` in `addSessionAtom`, which is `undefined` in non-secure contexts (the Web Crypto API only exposes it over HTTPS or `localhost`).

## Changes
Replace `crypto.randomUUID()` with `generateId()` from `@agenta/shared/utils` in `web/oss/src/components/AgentChatSlice/state/sessions.ts`.

`generateId()` is a uuid v4 helper that works in all contexts; it is already the standard across the rest of `web/oss`. The import was also added at the top of the file.

Before:
```ts
const id = crypto.randomUUID()
```

After:
```ts
import {generateId} from "@agenta/shared/utils"
// ...
const id = generateId()
```

## Scope / risk
One-line change in `sessions.ts`. No other component is touched. The uuid format is identical (v4), so session IDs generated before and after this change are indistinguishable. The only regression risk is that `generateId` produces a malformed ID on some edge-case platform; the existing usages in the codebase confirm it does not.

## Tests / notes
- `pnpm lint-fix` in `web/`: 11/11 tasks pass, no warnings.
- TypeScript errors in the affected file: none. (Pre-existing unrelated errors in Automations and AppGlobalWrappers are unchanged.)
- The real fix for all three classes of this problem is HTTPS. `crypto.randomUUID` is only defined on secure contexts; the two other call sites in the codebase (PlaygroundConfigSection.tsx and the annotation one) are already guarded — this was the last unguarded call in the agent slice.

## How to QA

**Prerequisites:** A plain-HTTP deployment (dev box at `http://144.76.237.122:<port>`, or local dev stack served over HTTP on a non-localhost origin). The agent playground feature must be enabled.

**Steps:**
1. Open an agent app in the playground over HTTP (not HTTPS and not localhost).
2. Click "New chat" (or the session creation button) in the AgentChatSlice panel.
3. Observe whether a new chat tab opens immediately.

**Expected result:** A new chat session tab appears without any error. No `TypeError: crypto.randomUUID is not a function` in the browser console.

**Regression check (HTTPS / localhost):**
4. On a localhost or HTTPS deployment, repeat steps 1-3. Confirm creating a session still works normally — `generateId()` must behave identically to `crypto.randomUUID()` in secure contexts.

**Automated tests:** No automated tests cover this specific call site. Verify manually.

**Edge cases:** If the user opens the playground before the JS bundle fully loads on a slow connection, the session atom may be initialized before `generateId` is available. Confirm there is no race condition by hard-refreshing on a throttled connection (DevTools Network > Slow 3G) and clicking "New chat" immediately.

https://claude.ai/code/session_01GYo3UEfvsZpncagqb28Mbc
