### PR TITLE
docs(agent): plan the HITL approval fix (F-024)

### DIFF
--- a/docs/design/agent-workflows/projects/hitl-fix/README.md
+++ b/docs/design/agent-workflows/projects/hitl-fix/README.md
@@ -1,0 +1,42 @@
+# HITL approval fix (QA finding F-024)
+
+Human-in-the-loop (HITL) tool approval is the headline interactive feature of the agent
+playground: when a tool needs a human yes/no, the run should pause, the playground should
+show an inline **Run this tool? Approve / Deny** prompt, and the user's answer should resume
+the run. Today that round-trip is broken end to end. The Claude permission gate fires, but
+the playground never shows the prompt; the tool resolves straight to an ERROR
+("User refused permission to run tool") and the run is auto-denied. Pi cannot do HITL at all,
+because its only permission options are `auto` and `deny` — there is no `ask`.
+
+This is a design-only workspace. It analyzes the full HITL path across the runner, the
+protocol/stream egress, the frontend, and the Pi permission model, then proposes the
+smallest-correct fix and a test plan.
+
+## Files
+
+- [context.md](context.md) — why this work exists, the symptom, scope, goals/non-goals.
+- [research.md](research.md) — the read-only trace of all four layers, with the exact
+  root cause and file/line citations.
+- [plan.md](plan.md) — the proposed fix, layer by layer, with the smallest change and a
+  test plan (FE + SDK + runner).
+- [status.md](status.md) — current state and the open decision(s) for the user.
+
+## TL;DR
+
+- **Root cause (runner):** when an `ask` rule matches, the runner emits the
+  `interaction_request` event AND immediately replies `reject` to the harness to "park" the
+  turn. Claude turns that `reject` into a **failed tool call** ("User refused permission"),
+  which the egress projects as `tool-output-error`. That error part overwrites the
+  `approval-requested` part on the same `toolCallId`, so the FE shows ERROR instead of
+  Approve/Deny. The park reply (`reject`) and the surface signal (`approval-requested`) are
+  in conflict on the wire.
+- **Fix (runner):** park WITHOUT poisoning the tool. End the turn on the parked permission
+  without sending `reject` to the harness for that gate (or suppress the resulting failed
+  `tool_result` so it never reaches the egress), so the last word on that `toolCallId` is the
+  `approval-requested` part. Then the existing FE + egress + cross-turn resume machinery
+  (already built and unit-tested) works as designed.
+- **Pi HITL:** Pi declares `permissions: false` and never raises an ACP permission gate, so
+  there is no `ask` to expose. Decide whether to (a) keep Pi HITL out of scope and grey out
+  `ask` for Pi in the form (honest), or (b) enforce `ask` runner-side for Pi's resolved
+  tools via the relay (a real but larger build, tracked separately in open-issues S5.2).
+  Recommendation: (a) now, (b) as a tracked follow-up.

--- a/docs/design/agent-workflows/projects/hitl-fix/context.md
+++ b/docs/design/agent-workflows/projects/hitl-fix/context.md
@@ -1,0 +1,84 @@
+# Context
+
+## Why this work exists
+
+Human-in-the-loop tool approval is the interactive contract of the agent playground. A run
+that wants to call a sensitive tool should pause and ask the human, not silently run it and
+not silently refuse it. The whole stack was built for this:
+
+- The frontend renderer (`ToolPart.tsx`) has an `approval-requested` state with **Approve /
+  Deny** buttons and an "Awaiting approval" chip.
+- The chat panel wires the AI SDK v6 approval round-trip (`addToolApprovalResponse`,
+  `sendAutomaticallyWhen: lastAssistantMessageIsCompleteWithApprovalResponses`).
+- The SDK egress maps the runner's protocol-neutral `interaction_request` event to the AI SDK
+  `tool-approval-request` stream part, and maps the inbound `tool-approval-response` back into
+  an `{ approved: boolean }` tool-result block.
+- The runner has a cross-turn responder (`HITLResponder`) that parks an undecided permission
+  on turn N and resolves it from the stored reply on turn N+1.
+
+Each piece exists and is unit-tested. But end to end, in the live playground, the round-trip
+does not work.
+
+## The symptom (F-024)
+
+Repro: Claude harness + `haiku` + the GitHub gateway tool delivered over MCP. In "Advanced:
+Claude permissions" set an **Ask** rule matching the tool (`mcp__*`, the tool name, or
+`mcp__composio__*`). Prompt: "Use the GET_THE_AUTHENTICATED_USER github tool now ... then
+reply with HITL-DONE."
+
+What happens:
+
+- The Claude permission gate **does** fire (proof the `ask` rule is honored end to end —
+  the Claude `.claude/settings.json` is rendered correctly and the harness raises the gate).
+- The playground shows **no** "Run this tool?" Approve/Deny prompt and **no** "Awaiting
+  approval" chip.
+- The tool-call card resolves straight to **ERROR: "User refused permission to run tool."**
+  The run auto-denies without ever pausing for the human.
+
+Second defect: the Pi **Permission policy** field offers only `auto` / `deny` — no `ask` — so
+HITL is not configurable for Pi at all from the form.
+
+## Why it matters
+
+Without this, the playground cannot demonstrate the agent feature's most important safety
+property. "Ask before running" is the difference between a demoable governed agent and an
+ungoverned one. The renderer and the cross-turn resume are already paid for; the run just
+never reaches them.
+
+## Scope
+
+In scope:
+
+- The runner permission-gate handling for the Claude harness (the `interaction_request` ↔
+  responder reply ↔ resulting tool-result on the wire).
+- The protocol/stream egress mapping of the parked gate (verify it survives to the FE).
+- The frontend approval surface (verify it renders and resumes once the wire is correct).
+- The Pi permission model: expose `ask` honestly, or document precisely what Pi needs.
+- A test plan that covers FE + SDK + runner, including the cross-turn resume.
+
+Out of scope (tracked elsewhere):
+
+- Relay-tool HITL for resolved `code`/gateway tools (open-issues "Relay-tool HITL: resolved
+  code/gateway tools cannot park/emit/resume (S5.2)"). Note: in the F-024 repro the gateway
+  tool is delivered to Claude **over MCP**, so the gate that fires is the **harness** gate,
+  not the relay — this fix targets the harness path, which is the one F-024 exercises.
+- A real Pi interactive permission protocol (Pi has no ACP permission capability today).
+
+## Goals
+
+1. When an `ask` rule fires on the Claude harness, the playground shows the inline
+   Approve/Deny prompt and pauses (no auto-deny, no ERROR card).
+2. Approve resumes the run and the tool actually executes; Deny leaves it un-run and the model
+   continues without it.
+3. Pi `ask` is either honestly exposed (with runner enforcement) or honestly hidden, with the
+   decision and the follow-up tracked.
+4. The fix is the smallest change that makes the existing FE + egress + resume machinery work,
+   with regression tests at each layer.
+
+## Non-goals
+
+- Re-architecting the responder or the cross-turn model (it is already built and unit-tested;
+  the bug is one conflicting reply on the wire).
+- Building relay-tool park/resume (S5.2) in this fix.
+- A new wire field if the existing `interaction_request` / `tool-approval-request` carriers
+  suffice (they do).

--- a/docs/design/agent-workflows/projects/hitl-fix/plan.md
+++ b/docs/design/agent-workflows/projects/hitl-fix/plan.md
@@ -1,0 +1,175 @@
+# Plan: smallest-correct HITL fix
+
+The renderer, the egress, and the cross-turn resume are already correct (see research.md). The
+fix is to stop the runner from poisoning the wire when it parks an `ask` gate. Below is the
+layer-by-layer change, smallest first, plus the Pi decision and the test plan.
+
+## The core fix (runner): park without poisoning the tool
+
+When `HITLResponder` decides to PARK (human surface, no stored decision), the runner must end
+the turn WITHOUT producing a failed `tool_result` for that `toolCallId`, so the
+`approval-requested` part is the last word on that tool call.
+
+Today park = reply `reject` to the harness, which makes Claude emit a failed tool call. Two
+viable approaches; the design recommends Approach A and keeps B as the fallback if A proves
+harness-fragile.
+
+### Approach A (recommended): a distinct PARK decision; do not reply `reject` on park
+
+Introduce a third responder outcome alongside `allow` / `deny`: `park`. On `park`,
+`attachPermissionResponder` does NOT call `session.respondPermission(...)` for that gate at all
+(or replies with a cancel/no-op the harness treats as "end turn pending", per the ACP
+capability). The turn ends with the gated tool un-run and no failed `tool_result` emitted. The
+`interaction_request` event (already emitted before the decision) is the final state for that
+`toolCallId`, so the egress's `tool-approval-request` survives to the FE.
+
+Files:
+
+- `services/agent/src/responder.ts`
+  - Widen `PermissionDecision` to `"allow" | "deny" | "park"` (or add a sibling return type so
+    `decisionToReply` only ever sees `allow`/`deny`). `HITLResponder` returns `"park"` in the
+    branch that today returns `"deny"` for the human surface (`:90`). `PolicyResponder` and the
+    headless branch are unchanged (still `allow`/`deny`), so `/invoke` is byte-identical.
+  - `extractApprovalDecisions` / the resume path is unchanged: a stored `allow`/`deny` still
+    short-circuits before park.
+- `services/agent/src/engines/sandbox_agent/permissions.ts`
+  - On `park`, skip `respondPermission` (the turn ends with the tool pending) — or, if the
+    harness requires an answer to unblock the turn, reply with the ACP "cancel"/"defer" reply
+    when offered, NEVER `reject`. Add a comment citing this finding so it is not "simplified"
+    back to `reject`.
+- `services/agent/src/responder.ts` `decisionToReply` stays `allow`/`deny` only (park never
+  reaches it).
+
+Open verification (empirical, needs the live harness): confirm that ending the turn without a
+`reject` reply does not leave Claude blocked awaiting a permission answer. If the ACP session
+requires a terminal answer per request, use the harness's cancel/abort reply on park rather
+than no reply. This is the one harness-behavior unknown; the test plan's live step pins it.
+
+### Approach B (fallback): suppress the park-induced failed tool_result in the event layer
+
+Keep park = `reject` to the harness, but teach the runner to drop the resulting failed
+`tool_result` for a `toolCallId` that has an outstanding parked `interaction_request`. The
+responder records the parked `toolCallId`s; `maybeCloseTool`
+(`services/agent/src/tracing/otel.ts:1040-1054`) checks that set and, when a `failed` update is
+the "User refused permission" refusal for a parked call, records nothing (or records a neutral
+`approval-pending` marker) instead of `tool_result {isError:true}`.
+
+Downsides vs A: it pattern-matches the refusal text/timing, couples the otel layer to the
+responder, and leaves a `reject` going to the harness (which may also abort the turn in a way
+that breaks resume). Prefer A; keep B only if A cannot end the turn cleanly.
+
+## Egress (Layer 2): no change expected
+
+`stream.py` already emits `tool-approval-request` for `interaction_request` kind `permission`,
+and already has `tool-output-denied` for an explicit deny. Once the runner stops emitting the
+clobbering `tool-output-error` on park, the existing egress is correct. One guard to ADD:
+ensure that when a turn ends with an outstanding approval request and no resolution, the egress
+does NOT emit a `finish` that the FE would read as "tool failed" — verify the parked turn's
+`finish` carries a benign `finishReason` (e.g. `tool-calls`/`unknown`, never `error`). This is
+assertion-only unless the trace shows otherwise.
+
+## Frontend (Layer 3): no change expected for F-024
+
+`ToolPart.tsx` already renders Approve/Deny for `approval-requested` and `AgentChatPanel`
+already auto-resumes. No change is required to fix the Claude path once the wire is correct.
+
+Two adjacent FE items to fold in as small follow-ups (NOT required for the core fix, but cheap
+and in the same area):
+
+- Confirm the auto-resume path (`sendAutomaticallyWhen`) re-sends the conversation with the
+  `tool-approval-response` part so `/messages` + `extractApprovalDecisions` resolves it. This is
+  wired; the test plan exercises it live.
+- F-025 (duplicate React keys) is a separate finding in the same component tree; out of scope
+  here, noted so the two are not conflated.
+
+## Pi HITL (Layer 4): the decision
+
+Pi has no permission gate (`permissions: false`; `permissionPolicy` hardcoded `auto`). The
+form offering `ask` for Pi would be a lie unless the runner enforces it. Two honest options:
+
+- **Option Pi-1 (recommended now): hide `ask` for Pi.** Keep `PermissionPolicy` as
+  `auto`/`deny` for the harness gate, and in `AgentConfigControl.tsx` grey out / omit the
+  policy field (or the `ask` option) when the harness is Pi, with helper text "Pi runs tools
+  without prompting; use per-tool permission for gating" once relay HITL exists. Truthful,
+  tiny, ships with the Claude fix.
+- **Option Pi-2 (follow-up, larger): enforce `ask` for Pi via the relay.** Build relay-tool
+  park/emit/resume (open-issues S5.2): when a resolved `code`/gateway tool has `permission:
+  "ask"`, the relay emits an `interaction_request` keyed by the tool-call id, ends the turn
+  without writing the relay response file, and resumes from the stored decision on the next
+  turn. This is the only way Pi can do HITL (Pi gates nothing itself; only the relay sits
+  between Pi and a resolved tool). It needs a turn-boundary model in the relay and is tracked
+  as its own slice.
+
+Recommendation: ship Pi-1 with the Claude fix; track Pi-2 as the real Pi HITL path. Note the
+per-tool `permission: "allow" | "ask" | "deny"` field already exists on `ResolvedToolSpec`
+(`protocol.ts:83`) and on MCP servers, so Pi-2 is "enforce the field at the relay", not "add a
+field".
+
+## Test plan (FE + SDK + runner)
+
+### Runner unit (vitest, `services/agent/tests/unit`)
+
+1. `responder.test.ts`: `HITLResponder` with a human surface and no stored decision returns
+   `park` (not `deny`); with a stored `allow`/`deny` returns it; headless (no surface) returns
+   the base policy. (Updates the existing park test to the new outcome.)
+2. `permissions.test.ts`: on a `park` decision, `attachPermissionResponder` emits the
+   `interaction_request` event and does NOT call `respondPermission` with `reject` (assert the
+   fake session's `respondPermission` is not called with `reject`, or is not called at all).
+3. New regression guard: drive a fake ACP session that, on a parked gate, would emit a
+   `failed` `tool_call_update`; assert the runner does NOT emit a `tool_result {isError}` for a
+   parked `toolCallId` (Approach A makes this vacuous because no reject is sent; under B it
+   asserts the suppression).
+
+### SDK contract / egress (pytest, `sdks/python/oss/tests/pytest/unit/agents`)
+
+4. `stream.py` egress test: a run whose events are `[tool_call, interaction_request(permission),
+   done]` (NO error tool_result) produces a stream containing exactly one
+   `tool-approval-request` for that `toolCallId` and NO `tool-output-error` for it. (Locks the
+   "park does not clobber" contract at the egress.)
+5. `messages.py` ingest test (already covered, assert it stays green): an inbound
+   `tool-approval-response {approved:true}` becomes a `tool_result` block with
+   `output:{approved:true}`, and `extractApprovalDecisions` resolves it to `allow`.
+
+### Golden wire (if any wire field changes)
+
+6. If `PermissionDecision`/`park` stays runner-internal (recommended), NO golden/`wire.py`
+   change. Confirm `protocol.ts` `AgentEvent` is unchanged so the golden fixtures and
+   `test_wire_contract.py` / `wire-contract.test.ts` stay green without edits. (Park is a
+   runner-internal decision, not a wire value.)
+
+### Live end-to-end (the empirical proof, via the agent sidecar)
+
+Run against a live sidecar (EE-dev compose `:8280`; see `agent-workflows-qa` /
+`debug-local-deployment`), Claude harness, a model with credit, an `ask` rule matching a tool.
+This pins the one harness-behavior unknown (does park end the turn cleanly).
+
+7. POST `/messages` (session S) forcing the gated tool. Assert the stream contains
+   `tool-approval-request` and NO `tool-output-error`/`tool-output-available` for that tool
+   (it did not run). In the playground, assert the inline Approve/Deny prompt renders.
+8. Approve: the FE auto-resume re-POSTs `/messages` (same S) with the
+   `tool-approval-response {approved:true}`. Assert turn 2 re-raises the gate, the stored
+   decision resolves it to `allow`, the tool runs (a real `tool-output-available` appears), and
+   the final reply is the agent's (e.g. `HITL-DONE`).
+9. Deny in a fresh session: assert the tool stays un-run and the model continues without it
+   (`tool-output-denied` or no tool output, no ERROR card).
+
+If step 8's turn 2 does NOT re-raise the gate after a cold replay (the model may not re-issue
+the identical call), fall back to the runner replaying the approved tool's result directly into
+the transcript rather than relying on the harness to re-ask. This is the open question already
+logged in open-issues ("Live multi-turn HITL round-trip is unverified"); this plan's live test
+is exactly the experiment that settles it. Capture the result in status.md either way.
+
+### Pin a replay regression
+
+10. Once step 8 is green, capture the `/run` pair and write an `agent-replay-test` so the
+    park→approve→resume round-trip replays forever without a live LLM (locks SDK + runner
+    behavior).
+
+## Smallest-change summary
+
+- Runner: add a `park` outcome; on park, do not send `reject` (Approach A). ~1 file of real
+  logic (`responder.ts`) + the `permissions.ts` wiring + comments.
+- Egress: no change (assertion-only test additions).
+- FE: no change for F-024 (assertion via the live test).
+- Pi: hide `ask` for Pi in the form (Option Pi-1); track relay enforcement (Pi-2).
+- Tests: 1 updated + ~4 new unit/contract tests + 3 live cells + 1 replay pin.

--- a/docs/design/agent-workflows/projects/hitl-fix/research.md
+++ b/docs/design/agent-workflows/projects/hitl-fix/research.md
@@ -1,0 +1,198 @@
+# Research: the full HITL path, read-only trace
+
+All citations are to the tree at `gitbutler/workspace` (v0.104.2). The HITL round-trip
+crosses four layers. The renderer, the egress, and the cross-turn resume are correct. The
+break is a single conflicting reply in the **runner**, which poisons the wire so the
+correct egress part is overwritten by a tool error.
+
+## Layer 1 — Runner: how the gate is handled (THE BUG)
+
+### The wiring
+
+`services/agent/src/engines/sandbox_agent.ts:350-361` builds the responder per run:
+
+```ts
+const hasHumanSurface = !!(request.sessionId && request.sessionId.trim());
+attachPermissionResponder({
+  session,
+  run,
+  responder:
+    deps.responderFactory?.(request.permissionPolicy) ??
+    new HITLResponder(
+      extractApprovalDecisions(request),
+      policyFromRequest(request.permissionPolicy),
+      hasHumanSurface,
+    ),
+});
+```
+
+`hasHumanSurface` is true on the `/messages` (playground) path because that endpoint stamps a
+`sessionId` on every turn; it is false on headless `/invoke`. Correct.
+
+`services/agent/src/engines/sandbox_agent/permissions.ts:21-44` is `attachPermissionResponder`.
+On every ACP permission request it does TWO things:
+
+1. Emits the protocol-neutral event (correct — this is what the FE needs):
+
+```ts
+run.emitEvent({
+  type: "interaction_request",
+  id,                       // ACP permission id -> Vercel approvalId
+  kind: "permission",
+  payload: { toolCallId: req?.toolCall?.toolCallId, toolCall: req?.toolCall, availableReplies, options },
+});
+```
+
+2. Asks the responder for a decision and **replies to the harness with it**:
+
+```ts
+void responder.onPermission({ id, availableReplies, raw: req })
+  .then((decision) => session.respondPermission(req.id, decisionToReply(decision, availableReplies)))
+  .catch(() => {});
+```
+
+### The park decision
+
+`HITLResponder.onPermission` (`services/agent/src/responder.ts:87-92`):
+
+```ts
+async onPermission(request) {
+  const stored = this.lookup(request);
+  if (stored) return stored;                 // resume path: a prior turn decided
+  if (this.hasHumanSurface) return "deny";   // PARK: do not run the unapproved tool this turn
+  return this.basePolicy === "deny" ? "deny" : "allow"; // headless parity
+}
+```
+
+On the playground first turn there is no stored decision and `hasHumanSurface` is true, so it
+returns `"deny"` to "park". The comment says denying "just declines to run the unapproved tool
+this turn; the turn ends safely". That reasoning is the bug.
+
+### Why park-by-reject poisons the wire
+
+`decisionToReply("deny", ...)` (`responder.ts:177-189`) maps `deny` to the ACP `reject`
+reply. So `attachPermissionResponder` calls `session.respondPermission(req.id, "reject")`.
+
+For the **Claude** harness, replying `reject` to a permission request is not a no-op — Claude
+treats it as the user refusing, and produces a **failed tool call**: a `tool_call_update`
+with `status: "failed"` whose content is "User refused permission to run tool".
+
+The runner's event state machine turns that into a tool-error event.
+`services/agent/src/tracing/otel.ts:1040-1054` (`maybeCloseTool`):
+
+```ts
+const status = update?.status;
+if (status !== "completed" && status !== "failed") return;
+const out = acpToolContentText(update.content) || acpToolContentText(update.rawOutput);
+...
+record({ type: "tool_result", id, output: out, isError: status === "failed" });
+```
+
+So for the SAME `toolCallId` the runner emits, in order on one turn:
+
+1. `tool_call` (the input) — possibly,
+2. `interaction_request` (kind `permission`) — the part the FE needs,
+3. `tool_result` with `isError: true`, output "User refused permission to run tool".
+
+### The net effect
+
+The egress (Layer 2) faithfully turns (2) into `tool-approval-request` and (3) into
+`tool-output-error`, both keyed to the same `toolCallId`. The AI SDK merges parts by
+`toolCallId`, so the later `output-error` **clobbers** the `approval-requested` state. The FE
+renders the final state: ERROR "User refused permission to run tool" — exactly the symptom.
+The gate fired, the approval part WAS emitted, but the runner's own `reject` reply destroyed it
+on the same turn.
+
+This is why F-024 reads "the gate fires but no prompt": the prompt is emitted and immediately
+overwritten by the refusal the runner itself triggered.
+
+## Layer 2 — Protocol / stream egress (CORRECT)
+
+The protocol-neutral IR has the HITL event:
+`services/agent/src/protocol.ts:231-236` defines
+`{ type: "interaction_request"; id; kind: "permission" | "input" | "client_tool"; payload? }`.
+
+The Vercel egress maps it correctly:
+`sdks/python/agenta/sdk/agents/adapters/vercel/stream.py:149-151` routes
+`interaction_request` to `_interaction_parts`, and `:201-242` emits, for `kind == "permission"`:
+
+- a synthesized `tool-input-start` / `tool-input-available` if no tool call preceded it
+  (so the approval has a tool part to attach to), then
+- `{ "type": "tool-approval-request", "approvalId": <event id>, "toolCallId": <id> }`.
+
+`TOOL_APPROVAL_REQUEST = "tool-approval-request"`
+(`sdks/python/agenta/sdk/agents/adapters/vercel/messages.py:14`).
+
+The inbound direction is also correct. The approval reply rides back as a
+`tool-approval-response` UIMessage part; `messages.py:79-80,139-148` (`_approval_response_blocks`)
+converts it to a `tool_result` block whose `output` is `{ "approved": boolean }`. The runner's
+`extractApprovalDecisions` (`responder.ts:127-159`) reads exactly that envelope to build the
+cross-turn decision map. The two sides agree on the wire.
+
+Conclusion: the egress already emits `tool-approval-request` when the gate fires. The problem
+is purely that the runner ALSO emits a clobbering `tool-output-error` on the same turn.
+
+## Layer 3 — Frontend (CORRECT)
+
+`web/oss/src/components/AgentChatSlice/components/ToolPart.tsx`:
+
+- `STATE_META` includes `"approval-requested": {label: "Awaiting approval", color: "warning"}`
+  (`:47`) and `"output-error"`, `"output-denied"` states.
+- When `state === "approval-requested" && approval?.id`, it renders "Run this tool?" with
+  Approve and Deny buttons (`:153-176`) calling
+  `onApprovalResponse({id: approval.id, approved: true|false})`.
+
+`web/oss/src/components/AgentChatSlice/AgentChatPanel.tsx:93,99,243`:
+
+- destructures `addToolApprovalResponse` from `useChat`,
+- sets `sendAutomaticallyWhen: lastAssistantMessageIsCompleteWithApprovalResponses` (auto-resume),
+- passes `onApprovalResponse={addToolApprovalResponse}` down to the tool part.
+
+The outbound transport carries the decision: `assets/transport.ts` + `assets/toAgentaMessage.ts`
+fold the approval into the request (Track A sends UIMessage parts verbatim; Track B surfaces it
+in a `tool_approvals` side field). The `/messages` egress + `extractApprovalDecisions` consume it.
+
+Conclusion: the FE renders Approve/Deny and resumes correctly IF it receives a surviving
+`approval-requested` part. It does not, only because the runner overwrites it.
+
+## Layer 4 — Pi permission model (NOT WIRED BY DESIGN)
+
+Pi never raises a permission gate:
+
+- `services/agent/src/engines/sandbox_agent/capabilities.ts:111` static fallback sets
+  `permissions: !isPiHarness` — Pi reports `permissions: false`.
+- `sdks/python/agenta/sdk/agents/dtos.py:662-709` (`PiAgentConfig`) hardcodes
+  `"permissionPolicy": "auto"  # Pi never gates tool use` and carries no permission policy at
+  all; the docstring says "Pi does not gate tool use, so no permission policy applies".
+- `PermissionPolicy = Literal["auto", "deny"]` (`dtos.py:110`) — there is no `ask` value, and
+  the policy is Claude-only in effect.
+
+The FE "Permission policy" field (`AgentConfigControl.tsx:675-678`) is schema-driven from
+`props.permission_policy`, whose enum is the SDK `PermissionPolicy` (`auto`/`deny`). So Pi (and
+the policy field generally) cannot express `ask`. There is no Pi code path that would surface an
+`interaction_request`, so even if the form offered `ask` for Pi, nothing would honor it on the
+harness path.
+
+The only way to gate a Pi tool is the runner-side **relay** for resolved `code`/gateway tools,
+and that path explicitly degrades `ask` to the headless policy and returns a refusal string —
+it cannot park/emit/resume. This is the separately-tracked open issue "Relay-tool HITL:
+resolved code/gateway tools cannot park/emit/resume (S5.2)"
+(`docs/design/agent-workflows/scratch/open-issues.md`), with `TODO(S5)` markers at
+`services/agent/src/tools/relay.ts:65` and `:128`.
+
+## Cross-check: SDK QA
+
+A parallel SDK QA pass is checking whether the SDK HITL path has the same break. From this
+code trace, the SDK egress/ingest (Layer 2) is correct in both directions: it emits
+`tool-approval-request` and ingests `tool-approval-response` into the `{approved}` envelope.
+So the SDK HITL helpers are not the cause; the same runner `reject`-clobber would surface to an
+SDK consumer too (the run stream would carry the approval part followed by the error part).
+Fold the SDK QA result in when available; the expectation is that fixing the runner fixes both
+surfaces, because they share the egress and the runner.
+
+## The one-line root cause
+
+The runner parks an `ask` gate by replying `reject` to the harness AND emitting the
+approval-request event. For Claude, `reject` produces a failed tool call ("User refused
+permission") that the egress projects as `tool-output-error` on the same `toolCallId`,
+overwriting the `approval-requested` part. Park and surface contradict each other on the wire.

--- a/docs/design/agent-workflows/projects/hitl-fix/status.md
+++ b/docs/design/agent-workflows/projects/hitl-fix/status.md
@@ -1,0 +1,44 @@
+# Status
+
+**State:** DESIGN ONLY. Not implemented, not merged. Awaiting the decision below.
+
+**Date:** 2026-06-25
+
+## What is done
+
+- Full read-only trace of the HITL path across all four layers (runner, egress, FE, Pi).
+- Root cause isolated to a single conflicting runner reply (see research.md).
+- Smallest-correct fix designed with two approaches (A recommended, B fallback) and a
+  test plan covering runner + SDK + FE + live e2e + a replay pin (see plan.md).
+
+## Root cause (one line)
+
+The runner parks an `ask` gate by replying `reject` to the harness AND emitting the
+approval-request event; for Claude, `reject` produces a failed tool call ("User refused
+permission") that the egress projects as `tool-output-error` on the same `toolCallId`,
+overwriting the `approval-requested` part the FE needs.
+
+## Decisions needed from the user
+
+1. **Park mechanism (Approach A vs B).** A = add a runner-internal `park` outcome and do NOT
+   send `reject` on park (clean, no wire change). B = keep `reject` and suppress the resulting
+   failed `tool_result` in the otel layer (pattern-matchy). Recommendation: A.
+2. **Pi HITL (Option Pi-1 vs Pi-2).** Pi-1 = hide `ask` for Pi now (honest, tiny, ships with
+   the Claude fix). Pi-2 = build relay-tool park/resume so Pi can actually gate resolved tools
+   (larger, tracked as open-issues S5.2). Recommendation: Pi-1 now, Pi-2 as a follow-up.
+
+## Known empirical unknown (settled by the live test)
+
+Whether ending the parked turn without a `reject` leaves Claude cleanly stopped, and whether a
+cold-replayed turn 2 re-raises the gate so the stored decision applies. The plan's live steps
+7-9 are the experiment; if turn 2 does not re-raise, the resume falls back to the runner
+replaying the approved tool result into the transcript. Capture the outcome here when run.
+
+## Cross-references
+
+- QA finding: `docs/design/agent-workflows/projects/qa/findings.md` (F-024).
+- Related open issues: `docs/design/agent-workflows/scratch/open-issues.md`
+  ("Relay-tool HITL: resolved code/gateway tools cannot park/emit/resume (S5.2)" and
+  "Live multi-turn HITL round-trip is unverified").
+- Capability-config project (where `HITLResponder` was built):
+  `docs/design/agent-workflows/projects/capability-config/`.


### PR DESCRIPTION
## What

Design-only workspace for fixing the broken human-in-the-loop (HITL) tool approval flow, QA finding **F-024**. No code change.

Adds `docs/design/agent-workflows/projects/hitl-fix/` (README, context, research, plan, status).

## The bug (F-024)

Claude harness + an **Ask** permission rule + a gateway tool: the permission gate fires, but the playground shows **no** "Run this tool? Approve / Deny" prompt. The tool-call card resolves straight to **ERROR: "User refused permission to run tool"** and the run auto-denies. Park → approve → resume never triggers. Separately, Pi's "Permission policy" field offers only `auto`/`deny` — no `ask` — so HITL is not configurable for Pi at all.

## Root cause (across layers)

The renderer (`ToolPart.tsx`), the AI-SDK egress (`stream.py` emits `tool-approval-request`), and the cross-turn resume (`HITLResponder` + `extractApprovalDecisions`) are all **correct**. The break is one conflicting reply in the **runner**:

- On an `ask` gate with a human surface, `HITLResponder.onPermission` returns `deny` to "park", and `attachPermissionResponder` maps that to `session.respondPermission(id, "reject")`.
- For Claude, `reject` produces a **failed tool call** ("User refused permission to run tool"), which `maybeCloseTool` (`tracing/otel.ts`) records as a `tool_result {isError:true}`.
- The egress projects that as `tool-output-error` on the **same `toolCallId`** as the `approval-requested` part, so the AI SDK merges and the error **overwrites** the approval prompt.

Park (the surface signal) and `reject` (the harness reply) contradict each other on the wire.

## Proposed fix (smallest-correct)

- **Runner:** add a runner-internal `park` outcome; on park, do **not** send `reject` (end the turn with the tool pending), so the `approval-requested` part is the last word. No wire change. (Fallback B: suppress the park-induced failed `tool_result` in the otel layer.)
- **Egress / FE:** no change for the Claude path once the runner stops poisoning the wire (assertion-only tests).
- **Pi:** hide `ask` for Pi in the form now (honest, tiny); track real Pi HITL via relay enforcement (open-issues S5.2) as a follow-up.

Test plan covers runner unit + SDK egress/ingest contract + golden wire (unchanged) + live FE e2e (park → approve → resume) + a replay-test pin.

## Decisions needed

See the pinned "Decision needed" comment.

https://claude.ai/code/session_01GYo3UEfvsZpncagqb28Mbc