### PR TITLE
feat(agent): restore the internal gateway-tool MCP channel for Claude

### DIFF
--- a/docs/design/agent-workflows/documentation/adapters/claude-code.md
+++ b/docs/design/agent-workflows/documentation/adapters/claude-code.md
@@ -31,16 +31,22 @@ not when the harness name is something in particular. In practice the capability
 static per-harness fallback (`engines/sandbox_agent/capabilities.ts`): the daemon rarely fills
 a real `info.capabilities`, so the runner uses `mcpTools: true` for any non-Pi harness.
 
-The mechanism is a small stdio MCP server named `agenta-tools` (`tools/mcp-server.ts`, launched
-by `tools/mcp-bridge.ts`) that the daemon attaches to the session. This is an Agenta tool
-DELIVERY vehicle, not a user-declared MCP server: it carries the same gateway and code specs
-the Pi extension would register, just exposed over MCP because Claude cannot take a native
-tool. Its env carries only public metadata (names, descriptions, schemas) and a relay
-directory; the `call_ref`, the code, the scoped secrets, and the callback auth never reach it.
-When the model calls a tool, the server relays the request back to the runner over the file
-relay (`tools/relay.ts`), and the runner runs the private spec from memory and POSTs to
-`/tools/call`. The safety property is identical to Pi's: the provider key and the connection
-auth stay server-side, and the agent only ever asks Agenta to run a named tool.
+The mechanism is a small MCP server named `agenta-tools` (`tools/tool-mcp-http.ts`, built by
+`tools/mcp-bridge.ts` `buildToolMcpServers`) that the runner serves on a loopback HTTP endpoint
+and attaches to the session as an ACP `type: "http"` MCP server. This is an Agenta tool DELIVERY
+vehicle, not a user-declared MCP server: it carries the same gateway and code specs the Pi
+extension would register, just exposed over MCP because Claude cannot take a native tool. It runs
+in the already-running runner process (no runner-host child) and is reachable only from loopback;
+it holds only public metadata (names, descriptions, schemas) and a relay directory; the
+`call_ref`, the code, the scoped secrets, and the callback auth never reach it. When the model
+calls a tool, the server relays the request back to the runner over the file relay
+(`tools/relay.ts`), and the runner runs the private spec from memory and POSTs to `/tools/call`.
+The safety property is identical to Pi's: the provider key and the connection auth stay
+server-side, and the agent only ever asks Agenta to run a named tool.
+
+(This internal channel was disabled as collateral with the user-stdio-MCP disable in PR #4831 and
+restored over loopback HTTP by the gateway-tool-mcp project. It is independent of the user MCP
+capability below — the two toggle separately.)
 
 User-declared `mcp_servers` are a separate thing and effectively off today. They would reach
 Claude through `toAcpMcpServers` as additional ACP stdio servers, but only when

--- a/docs/design/agent-workflows/documentation/ground-truth.md
+++ b/docs/design/agent-workflows/documentation/ground-truth.md
@@ -50,8 +50,10 @@ this page and the referenced code as the source of truth.
   tool secrets.
 - Callback tools route through `/tools/call`. On Daytona, Pi tool calls use the runner file
   relay.
-- MCP delivery exists for non-Pi harnesses through the stdio MCP bridge, but service-side
-  MCP resolution is feature-gated.
+- Gateway/code tool delivery to non-Pi harnesses (Claude) exists through the internal MCP
+  channel, served over a loopback HTTP MCP endpoint the runner stands up (no runner-host child
+  process). User-declared MCP resolution is feature-gated (`AGENTA_AGENT_ENABLE_MCP`, off by
+  default).
 
 ## Not Implemented
 
@@ -71,8 +73,10 @@ this page and the referenced code as the source of truth.
   per option (`HARNESS_IDENTITIES`); the stored/wire harness value stays the bare string.
 - Per-request model override is not honored on the Pi ACP path. pi-acp accepts only its
   default model and silently falls back (`projects/qa/findings.md`, F-007).
-- Remote (`http`) MCP servers are skipped by the runner path. Local stdio MCP is the path
-  represented by the bridge.
+- User-declared MCP transports split: remote (`http`) servers are delivered by the runner
+  (`toAcpMcpServers`, #4834); stdio servers are disabled (`USER_MCP_UNSUPPORTED_MESSAGE`) because
+  they launch a process on the runner host. The runner's own internal gateway-tool channel is a
+  separate thing and is delivered over loopback HTTP.
 - Trigger lifecycle, Compose.io trigger integration, and event-to-agent mapping are not
   implemented in the agent workflow code.
 - A persisted agent template object that separates `AGENTS.md`, skills, tools,

--- a/docs/design/agent-workflows/documentation/tools.md
+++ b/docs/design/agent-workflows/documentation/tools.md
@@ -176,8 +176,9 @@ network. So the call is relayed through files instead: the in-sandbox tool write
 file to a relay directory, the runner (which can reach Agenta) reads it, performs the same
 `/tools/call` POST, and writes the answer back (`relayToolCall` in `dispatch.ts`,
 `startToolRelay` in `tools/relay.ts`). Same callback, same envelope, different delivery. The
-non-Pi MCP bridge uses this same relay even on local runs, because the bridge runs in a
-separate process that the runner keeps blind to the private spec.
+non-Pi internal MCP channel (a loopback HTTP MCP server the runner serves) uses this same relay
+even on local runs, because the harness calling it is kept blind to the private spec — only
+public metadata crosses the channel, and execution relays back to the runner.
 
 ### Code tools: the runner runs them locally
 
@@ -304,7 +305,7 @@ declarative UI spec (`RenderHint` in `protocol.ts`).
 - The `render` hint is plumbed end to end on the runner side, but full frontend projection of
   every render kind is still in progress.
 - Gateway calls on Daytona depend on the file relay, because the sandbox cannot reach Agenta
-  directly. The relay is also used by the non-Pi MCP bridge on local runs.
+  directly. The relay is also used by the non-Pi internal MCP channel on local runs.
 - **Code tools are standard-library-only.** The image ships `python3` and `node`, but the
   child env has no package install and no module path to the runner's dependencies, so a tool
   cannot import third-party packages.

--- a/docs/design/agent-workflows/interfaces/cross-service/runner-to-mcp-server.md
+++ b/docs/design/agent-workflows/interfaces/cross-service/runner-to-mcp-server.md
@@ -1,11 +1,20 @@
 # Runner To MCP Server
 
-Pi takes its tools natively. Every other harness gets tools over MCP. The runner-owned stdio
-tool bridge (which exposed backend-resolved tools to non-Pi harnesses) is currently DISABLED —
-it launched a child process on the runner host, outside the sandbox boundary. User-declared
-MCP servers ride the same `/run` payload after the Python side resolves their secrets; of
-those, HTTP (remote) servers are delivered and stdio servers are disabled for the same reason.
-This page covers both: the runner-owned bridge and the user servers.
+Pi takes its tools natively. Every other harness gets tools over MCP. There are TWO independent
+MCP layers, and they toggle separately (do not merge their gates):
+
+1. **The internal gateway-tool channel** — the runner synthesizes it from the run's resolved
+   `customTools` so a non-Pi harness (Claude) can receive Agenta gateway/callback tools. It is
+   DELIVERED, over an internal loopback HTTP MCP endpoint the runner serves (no runner-host child
+   process).
+2. **User-declared MCP servers** — the user's own servers on the `/run` payload after the Python
+   side resolves their secrets. HTTP (remote) servers are delivered; stdio servers are DISABLED
+   (they launch an arbitrary process on the runner host, outside the sandbox boundary).
+
+PR #4831 once conflated these into a single `MCP_UNSUPPORTED_MESSAGE` switch, which disabled the
+internal channel as collateral with the (correct) user-stdio disable; the gateway-tool-mcp
+project split them again. The user-facing constant is now `USER_MCP_UNSUPPORTED_MESSAGE` and means
+ONLY "user MCP servers are unsupported"; the internal channel never borrows it.
 
 ## The contract
 
@@ -13,14 +22,21 @@ This page covers both: the runner-owned bridge and the user servers.
 probe reports `mcpTools: true`. Pi always returns an empty MCP set because it gets tools the
 native way.
 
-**The stdio bridge (disabled).** The runner-owned server spoke JSON-RPC 2.0 over stdio and
-answered three methods. It is disabled today (`MCP_UNSUPPORTED_MESSAGE`); the shape below is
-retained for when its runner-host execution is made sandbox-safe:
+**The internal gateway-tool channel (delivered, HTTP on loopback).** For a non-Pi harness with
+executable tool specs, `buildToolMcpServers` starts a tiny MCP server on `127.0.0.1:<ephemeral>`
+and returns one ACP `type: "http"` entry (`{name: "agenta-tools", url, headers: []}`). The
+server speaks JSON-RPC 2.0 over Streamable-HTTP (stateless JSON mode) and answers three methods:
 
 - `initialize`: returns protocol version and `capabilities.tools`.
 - `tools/list`: returns the resolved tool specs as MCP tools. Client-kind tools are filtered
   out here, because the browser fulfills those.
-- `tools/call`: runs the named tool with its arguments and returns `content`, or an error.
+- `tools/call`: runs the named tool through `runResolvedTool(..., { relayDir })` (the same relay
+  the Pi path uses) and returns `content`, or an error.
+
+It carries NO credential: the entry has empty `headers`, the server holds only public metadata +
+the relay dir, and it is bound to loopback. It launches no child process — it is served by the
+already-running runner — so it does not reintroduce the runner-host execution hole that #4831
+closed for user stdio MCP. The run end closes it (releases the port).
 
 **The file relay.** A resolved tool may need to run privately rather than inside the harness
 process. The relay moves the call across that boundary: the child writes a `<id>.req.json`
@@ -43,15 +59,17 @@ allowlist, and permission. Two transports, opposite states:
 - **Stdio (`transport: "stdio"` + `command`) is disabled.** A stdio server launches an
   arbitrary process on the runner host, outside the sandbox boundary, so the implementation is
   disabled (parity with the removed code execution) until its security is fixed. `run-plan.ts`
-  refuses any run carrying one (`MCP_UNSUPPORTED_MESSAGE`); `toAcpMcpServers` throws the same as
-  a defense-in-depth backstop. The wire shape is kept; only delivery is off.
+  refuses any run carrying one (`USER_MCP_UNSUPPORTED_MESSAGE`); `toAcpMcpServers` throws the same
+  as a defense-in-depth backstop. The wire shape is kept; only delivery is off.
 
 ## Owned by
 
 - `sdks/python/agenta/sdk/agents/mcp/`: the Python models and resolver.
-- `services/agent/src/engines/sandbox_agent/mcp.ts`: builds the session's MCP servers.
-- `services/agent/src/tools/mcp-bridge.ts`: the bridge.
-- `services/agent/src/tools/mcp-server.ts`: the stdio JSON-RPC server.
+- `services/agent/src/engines/sandbox_agent/mcp.ts`: builds the session's MCP servers (the two
+  layers; `USER_MCP_UNSUPPORTED_MESSAGE`).
+- `services/agent/src/tools/mcp-bridge.ts`: the internal gateway-tool channel builder.
+- `services/agent/src/tools/tool-mcp-http.ts`: the internal loopback HTTP MCP server.
+- `services/agent/src/tools/mcp-server.ts`: the removed stdio JSON-RPC server (refusing stub).
 - `services/agent/src/tools/relay.ts`: the file relay loop and hosts.
 
 ## Watch for when changing
@@ -59,7 +77,9 @@ allowlist, and permission. Two transports, opposite states:
 - **The gate.** MCP delivery depends on harness type and the `mcpTools` capability, not on a
   single env flag. Changing either changes which tools reach the harness.
 - **The MCP server config shape.** It is part of the `/run` contract and the wire serializer.
-- **The stdio methods.** `initialize`, `tools/list`, `tools/call`, and the client-tool filter.
+- **The internal channel's MCP methods.** `initialize`, `tools/list`, `tools/call`, and the
+  client-tool filter, served over loopback HTTP. The framing (stateless JSON Streamable-HTTP) is
+  pinned to the MCP client the installed Claude harness uses; re-verify it if that version moves.
 - **The relay.** Polling interval, timeout, and the local-versus-Daytona host. A slow tool
   must fail cleanly.
 - **HTTP MCP delivery.** `toAcpMcpServers` routes the resolved secret from `env` into a

--- a/docs/design/agent-workflows/interfaces/in-service/mcp-models-and-resolution.md
+++ b/docs/design/agent-workflows/interfaces/in-service/mcp-models-and-resolution.md
@@ -36,8 +36,10 @@ the runner (`toAcpMcpServers`) reads each resolved `env` entry and emits it as a
 header (so `secrets: {"Authorization": "vault-name"}` becomes an `Authorization` header on the
 remote call). Stdio (`transport: "stdio"` + `command`) servers are disabled in the sidecar — a
 stdio server runs an arbitrary process on the runner host, outside the sandbox boundary — so a
-run carrying one is refused (`MCP_UNSUPPORTED_MESSAGE`). The SDK models, resolver, and wire are
-transport-agnostic; the enable/disable split lives entirely in the runner.
+run carrying one is refused (`USER_MCP_UNSUPPORTED_MESSAGE`). This is the USER MCP capability and
+is distinct from the runner's internal gateway-tool MCP channel (delivered over loopback HTTP;
+see `runner-to-mcp-server.md`). The SDK models, resolver, and wire are transport-agnostic; the
+enable/disable split lives entirely in the runner.
 
 ## Owned by
 

--- a/docs/design/agent-workflows/projects/sidecar-trust-and-sandbox-enforcement/README.md
+++ b/docs/design/agent-workflows/projects/sidecar-trust-and-sandbox-enforcement/README.md
@@ -26,8 +26,15 @@ not new wire fields). See [`status.md`](./status.md) for the landed summary.
 
 Composio, the tool gateway (gateway/callback tools), and named connections are referenced only
 as things that already exist; this work changes none of them. **The one exception is MCP:** the
-stdio MCP-server implementation in the sidecar is now disabled (parity with the removed code
-execution) until its security issues are fixed.
+**user-declared stdio** MCP-server implementation in the sidecar is now disabled (parity with the
+removed code execution) until its security issues are fixed.
+
+> Follow-up correction (gateway-tool-mcp project, 2026-06-25): this disable was originally wired
+> through a single shared constant that ALSO killed the runner's INTERNAL gateway-tool MCP channel
+> (the one that delivers Agenta gateway/callback tools to Claude), hard-failing Claude + gateway
+> tools. That collateral damage was reverted: the internal channel is restored over a loopback
+> HTTP MCP endpoint (no runner-host process), and the user-facing constant was renamed
+> `USER_MCP_UNSUPPORTED_MESSAGE`. Only **user stdio** MCP stays disabled.
 
 ## Files
 

--- a/services/agent/src/engines/sandbox_agent.ts
+++ b/services/agent/src/engines/sandbox_agent.ts
@@ -205,6 +205,9 @@ export async function runSandboxAgent(
   let otel: ReturnType<typeof createSandboxAgentOtel> | undefined;
   // Daytona tool relay loop (started once the session exists, stopped after the prompt).
   let toolRelay: { stop: () => Promise<void> } | undefined;
+  // Internal gateway-tool MCP server closer (set when an internal channel is built for a non-Pi
+  // harness with executable tools; a no-op otherwise). Released in the `finally`.
+  let closeToolMcp: (() => Promise<void>) | undefined;
   let workspace: { cleanup: () => Promise<void> } | undefined = plan.isDaytona
     ? undefined
     : {
@@ -281,21 +284,22 @@ export async function runSandboxAgent(
       log: logger,
     });
 
-    const mcpServers = buildSessionMcpServers({
+    const sessionMcp = await buildSessionMcpServers({
       isPi: plan.isPi,
       capabilities,
       harness: plan.harness,
       toolSpecs: plan.toolSpecs,
       userMcpServers: request.mcpServers,
-      toolCallback: request.toolCallback as ToolCallbackContext | undefined,
       relayDir: plan.relayDir,
       log: logger,
     });
+    // Close the internal gateway-tool MCP server (if one started) when the run ends.
+    closeToolMcp = sessionMcp.close;
 
     const session = await sandbox.createSession({
       agent: plan.acpAgent,
       cwd: plan.cwd,
-      sessionInit: { cwd: plan.cwd, mcpServers },
+      sessionInit: { cwd: plan.cwd, mcpServers: sessionMcp.servers },
     });
     const sessionId = resolveRunSessionId(request, session.id);
 
@@ -412,7 +416,11 @@ export async function runSandboxAgent(
       if (piError) {
         return {
           ok: false,
-          error: conciseError(new Error(piError), plan.harness, request.provider),
+          error: conciseError(
+            new Error(piError),
+            plan.harness,
+            request.provider,
+          ),
         };
       }
     }
@@ -439,9 +447,13 @@ export async function runSandboxAgent(
   } catch (err) {
     otel?.finish();
     await otel?.flush().catch(() => {});
-    return { ok: false, error: conciseError(err, plan.harness, request.provider) };
+    return {
+      ok: false,
+      error: conciseError(err, plan.harness, request.provider),
+    };
   } finally {
     await toolRelay?.stop().catch(() => {});
+    await closeToolMcp?.().catch(() => {});
     await sandbox?.destroySandbox().catch(() => {});
     await sandbox?.dispose().catch(() => {});
     await workspace?.cleanup().catch(() => {});

--- a/services/agent/src/engines/sandbox_agent/mcp.ts
+++ b/services/agent/src/engines/sandbox_agent/mcp.ts
@@ -2,11 +2,10 @@ import type {
   HarnessCapabilities,
   McpServerConfig,
   ResolvedToolSpec,
-  ToolCallbackContext,
 } from "../../protocol.ts";
 import {
   buildToolMcpServers,
-  MCP_UNSUPPORTED_MESSAGE,
+  USER_MCP_UNSUPPORTED_MESSAGE,
   type McpServerStdio,
 } from "../../tools/mcp-bridge.ts";
 
@@ -31,7 +30,8 @@ export interface McpServerHttp {
 export type McpServerEntry = McpServerStdio | McpServerHttp;
 
 /**
- * Convert user-declared MCP servers into ACP entries.
+ * Convert USER-declared MCP servers into ACP entries. (This is the USER MCP capability layer —
+ * distinct from the INTERNAL gateway-tool channel below; see `buildSessionMcpServers`.)
  *
  * - HTTP (`transport: "http"` + `url`) is ENABLED. A remote server has no child process on the
  *   runner host: the harness connects to the URL and the named secret rides in a request header,
@@ -42,9 +42,9 @@ export type McpServerEntry = McpServerStdio | McpServerHttp;
  *   the header via the secret-map key, exactly as a stdio server names its env var.
  * - STDIO (`transport: "stdio"` + `command`) is DISABLED. A stdio MCP server launches an
  *   arbitrary process on the runner host, outside the sandbox boundary, so the implementation is
- *   disabled (parity with the removed code execution; see `tools/mcp-bridge.ts`) until its
- *   security is fixed. The wire shape (`McpServerConfig`) is kept, but a stdio server throws
- *   `MCP_UNSUPPORTED_MESSAGE` rather than being delivered.
+ *   disabled (parity with the removed code execution) until its security is fixed. The wire shape
+ *   (`McpServerConfig`) is kept, but a stdio server throws `USER_MCP_UNSUPPORTED_MESSAGE` rather
+ *   than being delivered.
  * - A server that is neither a valid http (no `url`) nor a valid stdio (no `command`) is skipped
  *   with a log — it was never deliverable.
  */
@@ -79,7 +79,7 @@ export function toAcpMcpServers(
       log(`skipping stdio MCP server '${s?.name ?? "?"}' (no command)`);
       continue;
     }
-    throw new Error(MCP_UNSUPPORTED_MESSAGE);
+    throw new Error(USER_MCP_UNSUPPORTED_MESSAGE);
   }
   return out;
 }
@@ -90,22 +90,40 @@ export interface BuildSessionMcpServersInput {
   harness: string;
   toolSpecs: ResolvedToolSpec[];
   userMcpServers?: McpServerConfig[];
-  toolCallback?: ToolCallbackContext;
   relayDir: string;
   log?: Log;
 }
 
-/** Build the ACP MCP server list for this session, gated by harness capabilities. */
-export function buildSessionMcpServers({
+/** The session MCP list plus a closer for any internal server started for it. */
+export interface SessionMcpServers {
+  servers: McpServerEntry[];
+  /** Stop the internal gateway-tool server (no-op when none started). Run in the engine `finally`. */
+  close: () => Promise<void>;
+}
+
+/**
+ * Build the ACP MCP server list for this session, gated by harness capabilities.
+ *
+ * TWO INDEPENDENT LAYERS — do not merge their gates (the #4831 regression this fixed conflated
+ * them into one switch; project gateway-tool-mcp):
+ *  1. INTERNAL gateway-tool channel (`buildToolMcpServers`): the runner-synthesized loopback HTTP
+ *     MCP server that delivers the run's resolved gateway/callback tools to the harness. Carries
+ *     only public metadata; execution relays server-side. RESTORED.
+ *  2. USER MCP capability (`toAcpMcpServers`): the user's own declared servers — stdio DISABLED,
+ *     http delivered (#4834). UNCHANGED.
+ *
+ * Returns a `close()` the caller MUST run when the session ends, to release the internal server's
+ * loopback port.
+ */
+export async function buildSessionMcpServers({
   isPi,
   capabilities,
   harness,
   toolSpecs,
   userMcpServers,
-  toolCallback,
   relayDir,
   log = () => {},
-}: BuildSessionMcpServersInput): McpServerEntry[] {
+}: BuildSessionMcpServersInput): Promise<SessionMcpServers> {
   const userMcpCount = userMcpServers?.length ?? 0;
   if (isPi || !capabilities.mcpTools) {
     if (!isPi && (toolSpecs.length > 0 || userMcpCount > 0)) {
@@ -114,11 +132,16 @@ export function buildSessionMcpServers({
           `${userMcpCount} user MCP server(s) not delivered`,
       );
     }
-    return [];
+    return { servers: [], close: async () => {} };
   }
 
-  return [
-    ...buildToolMcpServers(toolSpecs, toolCallback, relayDir),
-    ...toAcpMcpServers(userMcpServers, log),
-  ];
+  // Layer 1: INTERNAL gateway-tool channel (do not merge with the user gate below).
+  const internal = await buildToolMcpServers(toolSpecs, relayDir, log);
+  // Layer 2: USER MCP capability (stdio disabled, http delivered; do not merge with Layer 1).
+  const user = toAcpMcpServers(userMcpServers, log);
+
+  return {
+    servers: [...internal.servers, ...user],
+    close: internal.close,
+  };
 }

--- a/services/agent/src/engines/sandbox_agent/run-plan.ts
+++ b/services/agent/src/engines/sandbox_agent/run-plan.ts
@@ -11,7 +11,7 @@ import {
   resolvePromptText,
 } from "../../protocol.ts";
 import { executableToolSpecs } from "../../tools/public-spec.ts";
-import { MCP_UNSUPPORTED_MESSAGE } from "../../tools/mcp-bridge.ts";
+import { USER_MCP_UNSUPPORTED_MESSAGE } from "../../tools/mcp-bridge.ts";
 import {
   type MaterializedSkill,
   resolveSkillDirs as defaultResolveSkillDirs,
@@ -197,7 +197,7 @@ export function buildRunPlan(
   // code execution) until its security is fixed. Refuse any run carrying one, the way code
   // tools are gated — keep the wire shape, but the delivery is not supported.
   if (hasStdioMcpServer(request.mcpServers)) {
-    return { ok: false, error: MCP_UNSUPPORTED_MESSAGE };
+    return { ok: false, error: USER_MCP_UNSUPPORTED_MESSAGE };
   }
 
   // Layer 2: even on Daytona, code/gateway tools run on the RUNNER HOST via the relay, not

--- a/services/agent/src/tools/mcp-bridge.ts
+++ b/services/agent/src/tools/mcp-bridge.ts
@@ -1,25 +1,41 @@
 /**
- * Stdio MCP bridge — DISABLED in the sidecar.
+ * Tool MCP bridge — the INTERNAL gateway-tool delivery channel for non-Pi harnesses.
  *
- * This module used to expose resolved runnable tools (WP-7) to non-Pi harnesses (e.g. Claude)
- * by launching a stdio MCP child process (mcp-server.ts) on the runner host. That process runs
- * OUTSIDE the sandbox boundary, so a network-blocked sandbox does not confine it — the same
- * runner-host execution bypass that had code execution removed. Until the security issues are
- * fixed, the stdio MCP implementation is disabled the same way: the interface/types remain, but
- * any attempt to deliver a stdio MCP server throws a single named-constant message
- * (`MCP_UNSUPPORTED_MESSAGE`), mirroring `tools/code.ts` (`CODE_TOOL_UNSUPPORTED_MESSAGE`).
+ * Harnesses that accept tools over MCP only (Claude Code) cannot receive Agenta gateway/callback
+ * tools the way Pi does (Pi loads them through the bundled extension). So the runner advertises
+ * the run's resolved tools to the harness as an internal MCP server. Each tool call relays back
+ * to the runner, where the private spec / callback auth are applied server-side — the sandbox and
+ * harness never see a credential.
  *
- * The run plan (`engines/sandbox_agent/run-plan.ts`) refuses any run carrying a stdio MCP
- * server up front, so this throw is a defense-in-depth backstop, not the primary gate.
+ * Transport: an internal loopback HTTP MCP endpoint the runner serves (`tool-mcp-http.ts`). This
+ * REPLACES the pre-#4831 stdio bridge, which spawned a child process on the runner host outside
+ * the sandbox boundary — the same execution hole PR #4831 closed for USER stdio MCP servers. The
+ * loopback HTTP endpoint launches no process; it is served by the already-running runner. This
+ * is why restoring delivery here does NOT reopen #4831's hole (see project gateway-tool-mcp).
+ *
+ * IMPORTANT — this is NOT the user MCP capability:
+ *  - USER stdio MCP servers stay DISABLED (`engines/sandbox_agent/mcp.ts` `toAcpMcpServers` +
+ *    `run-plan.ts` `hasStdioMcpServer`, fail with `USER_MCP_UNSUPPORTED_MESSAGE`).
+ *  - USER http MCP servers are delivered unchanged (#4834).
+ *  - THIS internal channel is synthesized by the runner from `customTools`; the user never
+ *    declares it. The two layers toggle independently — do not merge their gates.
  */
-import type { ResolvedToolSpec, ToolCallbackContext } from "../protocol.ts";
+import type { ResolvedToolSpec } from "../protocol.ts";
+import type { McpServerHttp } from "../engines/sandbox_agent/mcp.ts";
+import { startInternalToolMcpServer } from "./tool-mcp-http.ts";
 
 export type { ResolvedToolSpec, ToolCallbackContext } from "../protocol.ts";
 
-export const MCP_UNSUPPORTED_MESSAGE =
+/**
+ * USER-facing MCP refusal. Means ONLY "user-declared MCP servers are not supported" — used by
+ * the user stdio gate (`run-plan.ts` `hasStdioMcpServer`) and the user stdio branch
+ * (`toAcpMcpServers`). The INTERNAL gateway-tool channel below must NEVER borrow this constant:
+ * conflating the two is exactly the #4831 regression this project fixed.
+ */
+export const USER_MCP_UNSUPPORTED_MESSAGE =
   "MCP servers are not supported by the sidecar.";
 
-/** ACP McpServerStdio entry: env is a list of {name, value}. */
+/** ACP McpServerStdio entry: env is a list of {name, value}. Kept for the disabled user path. */
 interface EnvVariable {
   name: string;
   value: string;
@@ -32,20 +48,50 @@ export interface McpServerStdio {
   env: EnvVariable[];
 }
 
+type Log = (message: string) => void;
+
+/** Result of building the internal channel: the server entries plus a closer for the run end. */
+export interface ToolMcpServersResult {
+  servers: McpServerHttp[];
+  /** Stop the internal server (no-op when none was started). Call in the engine `finally`. */
+  close: () => Promise<void>;
+}
+
+const NO_OP_CLOSE = async (): Promise<void> => {};
+
 /**
- * Disabled: building a tool MCP bridge would launch an unconfined stdio child process on the
- * runner host. Throws `MCP_UNSUPPORTED_MESSAGE` whenever there is something to deliver; an
- * empty/all-`client` spec list is a no-op (returns []) so the no-tools path is untouched.
+ * Build the INTERNAL gateway-tool MCP channel: start a loopback HTTP MCP server advertising the
+ * run's executable tools and return a `type: "http"` server entry pointing at it. An empty /
+ * all-`client` spec list is a no-op (`{ servers: [], close }`), so the no-tools path is untouched.
+ *
+ * The returned `close()` MUST be called when the run ends (the engine does this in its `finally`)
+ * to release the bound port. The channel carries no secret: the HTTP entry has empty `headers`,
+ * the server holds only public specs + the relay dir, and it is bound to loopback.
  */
-export function buildToolMcpServers(
+export async function buildToolMcpServers(
   specs: ResolvedToolSpec[],
-  _callbackOrRelayDir?: ToolCallbackContext | string,
-  _relayDir?: string,
-): McpServerStdio[] {
-  if (!specs || specs.length === 0) return [];
-  // `client` tools are browser-fulfilled and never go through the bridge; only an executable
-  // (`code`/`callback`) spec would have launched the stdio child, which is what we now refuse.
-  const executable = specs.filter((s) => s.kind !== "client");
-  if (executable.length === 0) return [];
-  throw new Error(MCP_UNSUPPORTED_MESSAGE);
+  relayDir: string,
+  log: Log = () => {},
+): Promise<ToolMcpServersResult> {
+  if (!specs || specs.length === 0) return { servers: [], close: NO_OP_CLOSE };
+  // `client` tools are browser-fulfilled and never go through this channel; only an executable
+  // (`code`/`callback`) spec needs delivering to the harness.
+  const executable = specs.filter((s) => (s.kind ?? "callback") !== "client");
+  if (executable.length === 0) return { servers: [], close: NO_OP_CLOSE };
+
+  const server = await startInternalToolMcpServer(executable, relayDir, log);
+  return {
+    servers: [
+      {
+        type: "http",
+        // The harness keys MCP servers by name; "agenta-tools" matches the pre-#4831 name.
+        name: "agenta-tools",
+        url: server.url,
+        // No credential on the wire: the channel is unauthenticated on loopback and carries
+        // only public metadata. Every credentialed action happens server-side via the relay.
+        headers: [],
+      },
+    ],
+    close: server.close,
+  };
 }

--- a/services/agent/src/tools/mcp-server.ts
+++ b/services/agent/src/tools/mcp-server.ts
@@ -6,13 +6,12 @@
  * HOST, outside the sandbox boundary, so a network-blocked sandbox did not confine it — the
  * same runner-host execution bypass that had code execution removed (`tools/code.ts`).
  *
- * The implementation is removed and stdio MCP delivery is disabled in the sidecar until the
- * security issues are fixed. Nothing launches this server anymore (`tools/mcp-bridge.ts`
- * `buildToolMcpServers` throws `MCP_UNSUPPORTED_MESSAGE` instead of spawning it, and
- * `run-plan.ts` refuses any run carrying a stdio MCP server). If invoked directly it refuses
- * loudly rather than serving.
+ * The stdio implementation is removed. The internal gateway-tool channel was RESTORED over an
+ * internal loopback HTTP MCP endpoint instead (`tools/tool-mcp-http.ts`), which launches no
+ * runner-host process — so it does not reintroduce this hole (project gateway-tool-mcp).
+ * Nothing launches this file anymore. If invoked directly it refuses loudly rather than serving.
  */
-import { MCP_UNSUPPORTED_MESSAGE } from "./mcp-bridge.ts";
+import { USER_MCP_UNSUPPORTED_MESSAGE } from "./mcp-bridge.ts";
 
-process.stderr.write(`[tool-bridge] ${MCP_UNSUPPORTED_MESSAGE}\n`);
+process.stderr.write(`[tool-bridge] ${USER_MCP_UNSUPPORTED_MESSAGE}\n`);
 process.exit(1);

--- a/services/agent/src/tools/tool-mcp-http.ts
+++ b/services/agent/src/tools/tool-mcp-http.ts
@@ -1,0 +1,283 @@
+/**
+ * Internal gateway-tool MCP server (loopback HTTP).
+ *
+ * THIS IS THE INTERNAL DELIVERY CHANNEL — not a user MCP capability. Harnesses that accept
+ * tools over MCP only (Claude Code) cannot receive Agenta gateway/callback tools natively the
+ * way Pi does (Pi loads them through the bundled extension). So the runner stands up this tiny
+ * MCP endpoint, synthesized from the run's already-resolved `customTools`, and advertises it to
+ * the harness as a `type: "http"` MCP server. On `tools/call` it runs the resolved tool through
+ * the SAME dispatch the Pi path uses (`runResolvedTool` → relay → `/tools/call`), so every
+ * credentialed action still happens server-side in runner memory.
+ *
+ * Why HTTP-on-loopback and not the old stdio bridge:
+ *  - No runner-host child process. The old `mcp-server.ts` spawned `tsx mcp-server.ts` on the
+ *    runner host, outside the sandbox boundary — the same execution hole PR #4831 closed for
+ *    USER stdio MCP servers. This endpoint launches nothing; it is served by the already-running
+ *    runner process and is reachable only from loopback.
+ *  - Reuses #4834's proven transport. Claude consumes a `type: "http"` MCP server natively (the
+ *    bundled `@zed-industries/claude-agent-acp` maps it to the Claude SDK's HTTP MCP client).
+ *
+ * This server is INDEPENDENT of the user MCP capability (`engines/sandbox_agent/mcp.ts`
+ * `toAcpMcpServers`): user stdio MCP stays disabled, user HTTP MCP is unchanged, and this
+ * internal channel is its own thing. Do not merge their gates (see project gateway-tool-mcp).
+ *
+ * Transport: MCP Streamable HTTP in stateless JSON mode. The MCP client (`@modelcontextprotocol/sdk`
+ * `StreamableHTTPClientTransport`) POSTs JSON-RPC with `Accept: application/json, text/event-stream`;
+ * we always answer a request with a single `application/json` JSON-RPC response (no SSE), `202` for
+ * a notification (no body), and `405` for the `GET`/`DELETE` stream-management verbs the client
+ * tolerates. No session id, no streaming — the simplest conformant server. Pin against the MCP SDK
+ * version bundled with the installed Claude harness if the framing ever drifts.
+ */
+import { randomUUID } from "node:crypto";
+import {
+  createServer,
+  type IncomingMessage,
+  type Server,
+  type ServerResponse,
+} from "node:http";
+import type { AddressInfo } from "node:net";
+
+import type { ResolvedToolSpec } from "../protocol.ts";
+import { EMPTY_OBJECT_SCHEMA } from "./callback.ts";
+import { runResolvedTool } from "./dispatch.ts";
+
+type Log = (message: string) => void;
+
+const DEFAULT_PROTOCOL = "2025-06-18";
+/** Loopback only: never reachable off-host, carries no credentials. */
+const HOST = "127.0.0.1";
+/** Bound the request body so a malformed/oversized POST cannot exhaust runner memory. */
+const MAX_BODY_BYTES = 1_000_000;
+
+export interface InternalToolMcpServer {
+  /** The loopback URL to advertise to the harness as a `type: "http"` MCP server. */
+  url: string;
+  /** Stop the server and release the port. Idempotent; safe in the engine `finally`. */
+  close: () => Promise<void>;
+}
+
+/**
+ * Handle one MCP JSON-RPC message. Returns the JSON-RPC response object, or `undefined` for a
+ * notification (no `id`). Mirrors the pre-#4831 stdio bridge handler, but takes the specs and
+ * relay dir in-process rather than from env, and dispatches `tools/call` to `runResolvedTool`.
+ */
+async function handle(
+  message: any,
+  specByName: Map<string, ResolvedToolSpec>,
+  specs: ResolvedToolSpec[],
+  relayDir: string,
+  log: Log,
+): Promise<unknown | undefined> {
+  const { id, method, params } = message ?? {};
+
+  // Notifications (no id, e.g. notifications/initialized) need no response.
+  if (id === undefined || id === null) return undefined;
+
+  if (method === "initialize") {
+    return {
+      jsonrpc: "2.0",
+      id,
+      result: {
+        protocolVersion: params?.protocolVersion ?? DEFAULT_PROTOCOL,
+        capabilities: { tools: {} },
+        serverInfo: { name: "agenta-tools", version: "0.1.0" },
+      },
+    };
+  }
+
+  if (method === "tools/list") {
+    return {
+      jsonrpc: "2.0",
+      id,
+      result: {
+        // `client` tools are browser-fulfilled, so this channel never advertises them. Only
+        // public metadata (name/description/inputSchema) crosses to the harness — never the
+        // callRef, code, scoped env, or callback auth, which stay in runner memory.
+        tools: specs
+          .filter((s) => (s.kind ?? "callback") !== "client")
+          .map((s) => ({
+            name: s.name,
+            description: s.description ?? s.name,
+            inputSchema:
+              (s.inputSchema as Record<string, unknown>) ?? EMPTY_OBJECT_SCHEMA,
+          })),
+      },
+    };
+  }
+
+  if (method === "tools/call") {
+    const name = params?.name;
+    const spec = specByName.get(name);
+    if (!spec) {
+      return {
+        jsonrpc: "2.0",
+        id,
+        error: { code: -32602, message: `unknown tool: ${name}` },
+      };
+    }
+    try {
+      // The channel holds only public metadata; execution relays to the runner via the relay
+      // dir, where the private spec + callback auth are applied server-side. A unique id per
+      // call keeps parallel calls from colliding.
+      const text = await runResolvedTool(spec, params?.arguments, {
+        toolCallId: randomUUID(),
+        relayDir,
+      });
+      return {
+        jsonrpc: "2.0",
+        id,
+        result: { content: [{ type: "text", text }] },
+      };
+    } catch (err) {
+      // Surface as an MCP tool error (isError) so the model can recover, not a crash.
+      return {
+        jsonrpc: "2.0",
+        id,
+        result: {
+          content: [
+            {
+              type: "text",
+              text: err instanceof Error ? err.message : String(err),
+            },
+          ],
+          isError: true,
+        },
+      };
+    }
+  }
+
+  log(`unknown method: ${method}`);
+  return {
+    jsonrpc: "2.0",
+    id,
+    error: { code: -32601, message: `method not found: ${method}` },
+  };
+}
+
+/** Read the full request body, rejecting anything over the size cap. */
+function readBody(req: IncomingMessage): Promise<string> {
+  return new Promise((resolve, reject) => {
+    let size = 0;
+    const chunks: Buffer[] = [];
+    req.on("data", (chunk: Buffer) => {
+      size += chunk.length;
+      if (size > MAX_BODY_BYTES) {
+        reject(new Error("request body too large"));
+        req.destroy();
+        return;
+      }
+      chunks.push(chunk);
+    });
+    req.on("end", () => resolve(Buffer.concat(chunks).toString("utf-8")));
+    req.on("error", reject);
+  });
+}
+
+/**
+ * Start the internal gateway-tool MCP server on loopback. Returns the URL to advertise and a
+ * `close()`. The caller decides whether to start it (only when there are executable specs); this
+ * function does not filter — it serves whatever specs it is given.
+ */
+export function startInternalToolMcpServer(
+  specs: ResolvedToolSpec[],
+  relayDir: string,
+  log: Log = () => {},
+): Promise<InternalToolMcpServer> {
+  const specByName = new Map(specs.map((s) => [s.name, s]));
+
+  const requestListener = (req: IncomingMessage, res: ServerResponse): void => {
+    // The MCP Streamable-HTTP client opens a GET SSE stream and sends a DELETE on close; this
+    // stateless server offers neither, so it returns 405 (the client tolerates 405 for both).
+    if (req.method !== "POST") {
+      res.writeHead(405, { "content-type": "application/json", allow: "POST" });
+      res.end(JSON.stringify({ error: "method not allowed" }));
+      return;
+    }
+
+    readBody(req)
+      .then(async (raw) => {
+        let parsed: any;
+        try {
+          parsed = JSON.parse(raw);
+        } catch {
+          res.writeHead(400, { "content-type": "application/json" });
+          res.end(
+            JSON.stringify({
+              jsonrpc: "2.0",
+              id: null,
+              error: { code: -32700, message: "parse error" },
+            }),
+          );
+          return;
+        }
+        // A batch is an array; handle each and answer with an array of the responses that have
+        // an id (notifications produce none).
+        if (Array.isArray(parsed)) {
+          const responses = (
+            await Promise.all(
+              parsed.map((m) => handle(m, specByName, specs, relayDir, log)),
+            )
+          ).filter((r) => r !== undefined);
+          if (responses.length === 0) {
+            res.writeHead(202);
+            res.end();
+            return;
+          }
+          res.writeHead(200, { "content-type": "application/json" });
+          res.end(JSON.stringify(responses));
+          return;
+        }
+
+        const response = await handle(parsed, specByName, specs, relayDir, log);
+        if (response === undefined) {
+          // Notification: no body. 202 Accepted is the streamable-HTTP convention.
+          res.writeHead(202);
+          res.end();
+          return;
+        }
+        res.writeHead(200, { "content-type": "application/json" });
+        res.end(JSON.stringify(response));
+      })
+      .catch((err) => {
+        log(
+          `request error: ${err instanceof Error ? err.message : String(err)}`,
+        );
+        if (!res.headersSent) {
+          res.writeHead(500, { "content-type": "application/json" });
+          res.end(
+            JSON.stringify({
+              jsonrpc: "2.0",
+              id: null,
+              error: { code: -32603, message: "internal error" },
+            }),
+          );
+        }
+      });
+  };
+
+  const server: Server = createServer(requestListener);
+
+  return new Promise((resolve, reject) => {
+    server.on("error", reject);
+    // Port 0 -> the OS assigns an ephemeral free port, read back from address().
+    server.listen(0, HOST, () => {
+      const address = server.address() as AddressInfo | null;
+      if (!address || typeof address === "string") {
+        server.close();
+        reject(new Error("internal tool MCP server has no bound port"));
+        return;
+      }
+      const url = `http://${HOST}:${address.port}/mcp`;
+      log(`internal tool MCP server on ${url} serving ${specs.length} tool(s)`);
+      resolve({
+        url,
+        close: () =>
+          new Promise<void>((done) => {
+            server.close(() => done());
+            // Drop keep-alive sockets so close() resolves promptly even if a client lingers.
+            server.closeAllConnections?.();
+          }),
+      });
+    });
+  });
+}

--- a/services/agent/tests/unit/mcp-servers.test.ts
+++ b/services/agent/tests/unit/mcp-servers.test.ts
@@ -9,7 +9,7 @@
  *   server's `env` map (the SDK resolver merges named secrets into `env` regardless of transport,
  *   and the wire has no separate `headers` field), so each `env` entry becomes an HTTP header.
  * - STDIO is DISABLED: a stdio server runs an arbitrary process on the RUNNER HOST, outside the
- *   sandbox boundary, so it throws `MCP_UNSUPPORTED_MESSAGE` (parity with the removed code
+ *   sandbox boundary, so it throws `USER_MCP_UNSUPPORTED_MESSAGE` (parity with the removed code
  *   execution) until its security is fixed.
  * - A command-less stdio server or a url-less http server was never deliverable and is skipped.
  *
@@ -20,7 +20,7 @@ import assert from "node:assert/strict";
 
 import { toAcpMcpServers } from "../../src/engines/sandbox_agent.ts";
 import type { McpServerHttp } from "../../src/engines/sandbox_agent/mcp.ts";
-import { MCP_UNSUPPORTED_MESSAGE } from "../../src/tools/mcp-bridge.ts";
+import { USER_MCP_UNSUPPORTED_MESSAGE } from "../../src/tools/mcp-bridge.ts";
 import type { McpServerConfig } from "../../src/protocol.ts";
 
 describe("toAcpMcpServers (http enabled, stdio disabled)", () => {
@@ -41,7 +41,7 @@ describe("toAcpMcpServers (http enabled, stdio disabled)", () => {
     ];
     assert.throws(
       () => toAcpMcpServers(servers),
-      new RegExp(MCP_UNSUPPORTED_MESSAGE),
+      new RegExp(USER_MCP_UNSUPPORTED_MESSAGE),
     );
   });
 

--- a/services/agent/tests/unit/sandbox-agent-orchestration.test.ts
+++ b/services/agent/tests/unit/sandbox-agent-orchestration.test.ts
@@ -327,18 +327,64 @@ describe("runSandboxAgent orchestration", () => {
     );
   });
 
-  it("fails a non-Pi run carrying custom tools because the MCP bridge is disabled", async () => {
-    // Claude takes tools only over MCP, and the sidecar's stdio MCP bridge is disabled until
-    // its security is fixed (parity with the removed code execution). So a Claude run with a
-    // custom tool now surfaces the not-supported error instead of silently dropping or
-    // unconfined-executing the tool.
-    const { deps } = fakeHarness();
+  it("delivers a non-Pi run's gateway tools over the internal HTTP MCP channel", async () => {
+    // Claude takes tools only over MCP. The INTERNAL gateway-tool channel (distinct from the
+    // disabled USER stdio MCP path) is restored over a loopback HTTP MCP server the runner
+    // serves, so a Claude run with a gateway tool now SUCCEEDS and the tool is advertised to the
+    // harness. This is the #4831 regression fix (project gateway-tool-mcp): the run no longer
+    // hard-fails with the user-facing MCP-unsupported error.
+    const { calls, deps } = fakeHarness();
 
     const result = await runSandboxAgent(
       {
         harness: "claude",
         prompt: "use the tool",
         customTools: [{ name: "server_tool", kind: "callback" }],
+      } as AgentRunRequest,
+      undefined,
+      undefined,
+      deps,
+    );
+
+    assert.equal(
+      result.ok,
+      true,
+      "the run succeeds; gateway tools reach Claude",
+    );
+    const mcpServers =
+      calls.createSessionOptions?.sessionInit?.mcpServers ?? [];
+    assert.equal(
+      mcpServers.length,
+      1,
+      "one internal MCP server delivered to the session",
+    );
+    assert.equal(mcpServers[0].name, "agenta-tools");
+    assert.equal(
+      mcpServers[0].type,
+      "http",
+      "delivered over http, not a stdio child process",
+    );
+    assert.match(
+      mcpServers[0].url,
+      /^http:\/\/127\.0\.0\.1:\d+\/mcp$/,
+      "loopback url",
+    );
+    assert.deepEqual(mcpServers[0].headers, [], "no credential on the channel");
+    // The internal server is opened then released, so its port does not leak past the run.
+    assert.equal(calls.sandboxDestroyed, 1, "sandbox disposed in finally");
+  });
+
+  it("still refuses a run carrying a USER stdio MCP server (user gate untouched)", async () => {
+    // The user-facing stdio MCP path stays disabled (parity with removed code execution); only
+    // the internal gateway-tool channel was restored. A user-declared stdio MCP server is still
+    // rejected up front with the user-facing message.
+    const { deps } = fakeHarness();
+
+    const result = await runSandboxAgent(
+      {
+        harness: "claude",
+        prompt: "go",
+        mcpServers: [{ name: "github", transport: "stdio", command: "npx" }],
       } as AgentRunRequest,
       undefined,
       undefined,

--- a/services/agent/tests/unit/session-mcp-layering.test.ts
+++ b/services/agent/tests/unit/session-mcp-layering.test.ts
@@ -1,0 +1,182 @@
+/**
+ * Layering regression guard for buildSessionMcpServers — the test that FAILS if the internal
+ * gateway-tool channel and the user MCP capability are ever re-merged into one gate.
+ *
+ * PR #4831 conflated two independent things into a single `MCP_UNSUPPORTED_MESSAGE` switch, which
+ * disabled gateway-tool delivery to Claude as collateral with the (correct) user stdio MCP
+ * disable. The fix (project gateway-tool-mcp) split them into:
+ *   1. INTERNAL gateway-tool channel — restored over loopback HTTP MCP; toggles on executable tools.
+ *   2. USER MCP capability — stdio DISABLED, http delivered (#4834).
+ *
+ * These three cases pin that the two layers toggle independently:
+ *   (a) gateway tools + NO user MCP        -> internal channel present, no throw
+ *   (b) user stdio MCP + NO gateway tools  -> refused (user gate)
+ *   (c) gateway tools + user http MCP      -> BOTH delivered; user stdio still refused
+ *
+ * Plus: Pi gets [] (native delivery), and the channel never carries a credential.
+ *
+ * Run: pnpm test (or: pnpm exec vitest run tests/unit/session-mcp-layering.test.ts)
+ */
+import { afterEach, describe, it } from "vitest";
+import assert from "node:assert/strict";
+
+import {
+  buildSessionMcpServers,
+  type SessionMcpServers,
+} from "../../src/engines/sandbox_agent/mcp.ts";
+import { USER_MCP_UNSUPPORTED_MESSAGE } from "../../src/tools/mcp-bridge.ts";
+import type {
+  HarnessCapabilities,
+  McpServerConfig,
+  ResolvedToolSpec,
+} from "../../src/protocol.ts";
+
+const relayDir = "/tmp/agenta-tools-layering";
+const mcpCapable: HarnessCapabilities = { mcpTools: true, toolCalls: true };
+
+const gatewayTool: ResolvedToolSpec = {
+  name: "search",
+  kind: "callback",
+  callRef: "composio.search",
+  description: "Search",
+};
+
+/** Always release the internal server's port after each case. */
+const built: SessionMcpServers[] = [];
+async function build(input: Parameters<typeof buildSessionMcpServers>[0]) {
+  const result = await buildSessionMcpServers(input);
+  built.push(result);
+  return result;
+}
+afterEach(async () => {
+  await Promise.all(built.map((b) => b.close()));
+  built.length = 0;
+});
+
+describe("buildSessionMcpServers layering (do-not-merge regression guard)", () => {
+  it("(a) gateway tools + no user MCP -> internal channel present, no throw", async () => {
+    const { servers } = await build({
+      isPi: false,
+      capabilities: mcpCapable,
+      harness: "claude",
+      toolSpecs: [gatewayTool],
+      userMcpServers: undefined,
+      relayDir,
+    });
+    assert.equal(
+      servers.length,
+      1,
+      "the internal gateway-tool server is delivered",
+    );
+    assert.equal(servers[0].name, "agenta-tools");
+    assert.ok(
+      "type" in servers[0] && servers[0].type === "http",
+      "http transport",
+    );
+  });
+
+  it("(b) user stdio MCP + no gateway tools -> refused (user gate untouched)", async () => {
+    const userMcpServers: McpServerConfig[] = [
+      { name: "github", transport: "stdio", command: "npx", args: ["x"] },
+    ];
+    await assert.rejects(
+      () =>
+        buildSessionMcpServers({
+          isPi: false,
+          capabilities: mcpCapable,
+          harness: "claude",
+          toolSpecs: [],
+          userMcpServers,
+          relayDir,
+        }),
+      new RegExp(USER_MCP_UNSUPPORTED_MESSAGE),
+      "a user stdio MCP server is still refused",
+    );
+  });
+
+  it("(c) gateway tools + user http MCP -> BOTH delivered; user stdio still refused", async () => {
+    const { servers } = await build({
+      isPi: false,
+      capabilities: mcpCapable,
+      harness: "claude",
+      toolSpecs: [gatewayTool],
+      userMcpServers: [
+        {
+          name: "linear",
+          transport: "http",
+          url: "https://mcp.linear.app/sse",
+          env: { Authorization: "Bearer x" },
+        },
+      ],
+      relayDir,
+    });
+    assert.equal(
+      servers.length,
+      2,
+      "internal channel AND the user http server",
+    );
+    const names = servers.map((s) => s.name).sort();
+    assert.deepEqual(names, ["agenta-tools", "linear"]);
+
+    // The user stdio path is still refused even alongside a gateway tool.
+    await assert.rejects(
+      () =>
+        buildSessionMcpServers({
+          isPi: false,
+          capabilities: mcpCapable,
+          harness: "claude",
+          toolSpecs: [gatewayTool],
+          userMcpServers: [{ name: "evil", transport: "stdio", command: "rm" }],
+          relayDir,
+        }),
+      new RegExp(USER_MCP_UNSUPPORTED_MESSAGE),
+    );
+  });
+
+  it("Pi gets [] (native delivery, no MCP channel) even with gateway tools", async () => {
+    const { servers } = await build({
+      isPi: true,
+      capabilities: mcpCapable,
+      harness: "pi_agenta",
+      toolSpecs: [gatewayTool],
+      relayDir,
+    });
+    assert.deepEqual(
+      servers,
+      [],
+      "Pi receives tools via the bundled extension, not MCP",
+    );
+  });
+
+  it("a non-MCP harness gets [] (capability gate), no internal server started", async () => {
+    const { servers } = await build({
+      isPi: false,
+      capabilities: { mcpTools: false, toolCalls: false },
+      harness: "no-mcp",
+      toolSpecs: [gatewayTool],
+      relayDir,
+    });
+    assert.deepEqual(servers, []);
+  });
+
+  it("the internal channel advertisement carries no credential (server-side invariant)", async () => {
+    const { servers } = await build({
+      isPi: false,
+      capabilities: mcpCapable,
+      harness: "claude",
+      toolSpecs: [gatewayTool],
+      relayDir,
+    });
+    const internal = servers.find((s) => s.name === "agenta-tools");
+    assert.ok(internal);
+    assert.deepEqual(
+      (internal as { headers: unknown }).headers,
+      [],
+      "no auth header on the internal channel",
+    );
+    assert.ok(
+      !JSON.stringify(internal).includes("composio.search"),
+      "the private callRef never reaches the advertisement",
+    );
+  });
+});

--- a/services/agent/tests/unit/tool-bridge.test.ts
+++ b/services/agent/tests/unit/tool-bridge.test.ts
@@ -1,120 +1,135 @@
 /**
- * Unit tests for buildToolMcpServers — the stdio tool MCP bridge, now DISABLED in the sidecar.
+ * Unit tests for buildToolMcpServers — the INTERNAL gateway-tool MCP channel, RESTORED over an
+ * internal loopback HTTP MCP server.
  *
- * The bridge used to launch a stdio MCP child process on the runner host to expose resolved
- * tools to non-Pi harnesses. That process ran outside the sandbox boundary (the same
- * runner-host execution bypass that had code execution removed), so the implementation is
- * disabled until its security is fixed. The interface/types remain, but delivering any
- * executable spec now throws `MCP_UNSUPPORTED_MESSAGE`. The no-tools path (empty or
- * client-only specs) stays a no-op so non-tool runs are untouched.
+ * PR #4831 disabled this channel as collateral with the USER stdio MCP disable, hard-failing
+ * Claude + gateway tools. This restores it: the runner stands up a loopback HTTP MCP endpoint
+ * (no runner-host child process) advertising the run's executable tools, and returns a
+ * `type: "http"` MCP server entry pointing at it. Execution relays back to the runner where the
+ * private spec / callback auth are applied — the channel itself carries only public metadata.
+ *
+ * These tests assert: an executable run yields one internal http server (no secrets in the
+ * advertisement), the no-tools / client-only path stays a no-op, and the served MCP endpoint
+ * advertises the public spec and routes a `tools/call` through the relay dir.
  *
  * Run: pnpm test (or: pnpm exec vitest run tests/unit/tool-bridge.test.ts)
  */
-import { describe, it } from "vitest";
+import { afterEach, describe, it } from "vitest";
 import assert from "node:assert/strict";
+import {
+  mkdtempSync,
+  readdirSync,
+  readFileSync,
+  rmSync,
+  writeFileSync,
+} from "node:fs";
+import { tmpdir } from "node:os";
+import { join } from "node:path";
 
 import {
   buildToolMcpServers,
-  MCP_UNSUPPORTED_MESSAGE,
+  type ToolMcpServersResult,
 } from "../../src/tools/mcp-bridge.ts";
+import { RELAY_REQ_SUFFIX, RELAY_RES_SUFFIX } from "../../src/tools/relay.ts";
 import type { ResolvedToolSpec } from "../../src/protocol.ts";
 
 const relayDir = "/tmp/agenta-tools";
 
-describe("buildToolMcpServers (disabled)", () => {
-  it("throws the unsupported error for a code-only run", () => {
+/** Track every started server so we always release its port. */
+const started: ToolMcpServersResult[] = [];
+async function build(...args: Parameters<typeof buildToolMcpServers>) {
+  const result = await buildToolMcpServers(...args);
+  started.push(result);
+  return result;
+}
+
+afterEach(async () => {
+  await Promise.all(started.map((s) => s.close()));
+  started.length = 0;
+});
+
+/** One JSON-RPC POST to the internal MCP server, returning the parsed JSON response. */
+async function rpc(url: string, body: unknown): Promise<any> {
+  const res = await fetch(url, {
+    method: "POST",
+    headers: {
+      "content-type": "application/json",
+      accept: "application/json, text/event-stream",
+    },
+    body: JSON.stringify(body),
+  });
+  if (res.status === 202) return undefined;
+  return res.json();
+}
+
+describe("buildToolMcpServers (internal gateway-tool channel)", () => {
+  it("starts one internal http server for an executable callback run, with NO credentials", async () => {
+    const specs: ResolvedToolSpec[] = [
+      {
+        name: "search",
+        kind: "callback",
+        callRef: "composio.search",
+        description: "Search the web",
+      },
+    ];
+    const { servers } = await build(specs, relayDir);
+
+    assert.equal(servers.length, 1, "one internal server");
+    const server = servers[0];
+    assert.equal(
+      server.type,
+      "http",
+      "delivered over the http transport (no host process)",
+    );
+    assert.equal(server.name, "agenta-tools");
+    assert.match(
+      server.url,
+      /^http:\/\/127\.0\.0\.1:\d+\/mcp$/,
+      "loopback url",
+    );
+    assert.deepEqual(
+      server.headers,
+      [],
+      "no secret header — the channel carries no credential",
+    );
+    // The advertisement must not leak the private callRef anywhere.
+    assert.ok(
+      !JSON.stringify(server).includes("composio.search"),
+      "the server entry never carries the private callRef",
+    );
+  });
+
+  it("starts the server for a code run too (executable)", async () => {
     const specs: ResolvedToolSpec[] = [
       {
         name: "adder",
-        description: "Add numbers",
         kind: "code",
         runtime: "python",
         code: "def main(**k): return 1",
         env: { PRIVATE: "secret" },
       },
     ];
-    assert.throws(
-      () => buildToolMcpServers(specs, relayDir),
-      new RegExp(MCP_UNSUPPORTED_MESSAGE),
+    const { servers } = await build(specs, relayDir);
+    assert.equal(servers.length, 1);
+    assert.equal(servers[0].type, "http");
+    assert.ok(
+      !JSON.stringify(servers[0]).includes("secret"),
+      "scoped env never crosses to the advertisement",
     );
   });
 
-  it("throws the unsupported error for a callback run", () => {
-    const specs: ResolvedToolSpec[] = [
-      { name: "search", kind: "callback", callRef: "composio.search" },
-    ];
-    assert.throws(
-      () =>
-        buildToolMcpServers(
-          specs,
-          {
-            endpoint: "https://agenta.example/tools/call",
-            authorization: "Bearer tok",
-          },
-          relayDir,
-        ),
-      new RegExp(MCP_UNSUPPORTED_MESSAGE),
-    );
+  it("returns [] for empty specs (no-tools path untouched)", async () => {
+    const { servers } = await build([], relayDir);
+    assert.deepEqual(servers, [], "empty specs -> []");
   });
 
-  it("throws for an absent-kind (back-compat callback) run", () => {
-    const specs: ResolvedToolSpec[] = [
-      { name: "legacy", callRef: "composio.legacy" },
-    ];
-    assert.throws(
-      () =>
-        buildToolMcpServers(
-          specs,
-          { endpoint: "https://agenta.example/tools/call" },
-          relayDir,
-        ),
-      new RegExp(MCP_UNSUPPORTED_MESSAGE),
-    );
-  });
-
-  it("throws for a mixed code+callback run", () => {
-    const specs: ResolvedToolSpec[] = [
-      {
-        name: "adder",
-        kind: "code",
-        runtime: "python",
-        code: "def main(**k): return 1",
-      },
-      { name: "search", kind: "callback", callRef: "composio.search" },
-    ];
-    assert.throws(
-      () => buildToolMcpServers(specs, relayDir),
-      new RegExp(MCP_UNSUPPORTED_MESSAGE),
-    );
-  });
-
-  it("returns [] for empty specs (no-tools path untouched)", () => {
-    assert.deepEqual(
-      buildToolMcpServers([], undefined),
-      [],
-      "empty specs -> []",
-    );
-  });
-
-  it("returns [] for client-only specs (nothing executable, never goes through the bridge)", () => {
+  it("returns [] for client-only specs (nothing executable goes through the channel)", async () => {
     const specs: ResolvedToolSpec[] = [{ name: "confirm", kind: "client" }];
-    assert.deepEqual(
-      buildToolMcpServers(specs, undefined),
-      [],
-      "client-only -> [] (nothing executable here)",
-    );
-    assert.deepEqual(
-      buildToolMcpServers(
-        specs,
-        { endpoint: "https://agenta.example/tools/call" },
-        relayDir,
-      ),
-      [],
-      "client-only -> [] even with an endpoint",
-    );
+    const { servers } = await build(specs, relayDir);
+    assert.deepEqual(servers, [], "client-only -> []");
   });
 
-  it("throws when an executable spec sits beside a client spec", () => {
+  it("starts the server when an executable spec sits beside a client spec", async () => {
     const specs: ResolvedToolSpec[] = [
       { name: "confirm", kind: "client" },
       {
@@ -124,9 +139,142 @@ describe("buildToolMcpServers (disabled)", () => {
         code: "def main(**k): return 1",
       },
     ];
-    assert.throws(
-      () => buildToolMcpServers(specs, relayDir),
-      new RegExp(MCP_UNSUPPORTED_MESSAGE),
-    );
+    const { servers } = await build(specs, relayDir);
+    assert.equal(servers.length, 1, "one server for the executable spec");
+  });
+
+  describe("the served MCP endpoint", () => {
+    it("answers initialize / tools/list (public spec only, client filtered)", async () => {
+      const specs: ResolvedToolSpec[] = [
+        {
+          name: "search",
+          kind: "callback",
+          callRef: "composio.search",
+          description: "Search the web",
+          inputSchema: {
+            type: "object",
+            properties: { q: { type: "string" } },
+          },
+        },
+        { name: "confirm", kind: "client" },
+      ];
+      const { servers } = await build(specs, relayDir);
+      const url = servers[0].url;
+
+      const init = await rpc(url, {
+        jsonrpc: "2.0",
+        id: 1,
+        method: "initialize",
+        params: { protocolVersion: "2025-06-18" },
+      });
+      assert.equal(init.result.serverInfo.name, "agenta-tools");
+      assert.ok(init.result.capabilities.tools, "advertises tools capability");
+
+      const list = await rpc(url, {
+        jsonrpc: "2.0",
+        id: 2,
+        method: "tools/list",
+      });
+      const tools = list.result.tools;
+      assert.equal(
+        tools.length,
+        1,
+        "the client tool is filtered out of the advertisement",
+      );
+      assert.equal(tools[0].name, "search");
+      assert.equal(tools[0].description, "Search the web");
+      assert.deepEqual(tools[0].inputSchema, {
+        type: "object",
+        properties: { q: { type: "string" } },
+      });
+      // The public advertisement never carries the private callRef.
+      assert.ok(
+        !JSON.stringify(tools).includes("composio.search"),
+        "no callRef in tools/list",
+      );
+    });
+
+    it("routes tools/call through the relay dir (server-side execution)", async () => {
+      const dir = mkdtempSync(join(tmpdir(), "agenta-tool-relay-"));
+      try {
+        const specs: ResolvedToolSpec[] = [
+          { name: "search", kind: "callback", callRef: "composio.search" },
+        ];
+        const { servers } = await build(specs, dir);
+        const url = servers[0].url;
+
+        // Stand in for the runner relay loop: as soon as the request file appears, write the
+        // response file the dispatcher polls for. This is the same file protocol the real
+        // `startToolRelay` serves, so a green call proves the channel feeds the relay.
+        const token = "relay-proof-marker";
+        const watcher = (async () => {
+          for (let i = 0; i < 200; i++) {
+            const reqFile = readdirSync(dir).find((f) =>
+              f.endsWith(RELAY_REQ_SUFFIX),
+            );
+            if (reqFile) {
+              const req = JSON.parse(readFileSync(join(dir, reqFile), "utf-8"));
+              // The relay only ever receives the public tool name + args, never the callRef.
+              assert.equal(req.toolName, "search");
+              assert.deepEqual(req.args, { q: "hi" });
+              const id = reqFile.slice(0, -RELAY_REQ_SUFFIX.length);
+              writeFileSync(
+                join(dir, `${id}${RELAY_RES_SUFFIX}`),
+                JSON.stringify({ ok: true, text: token }),
+                "utf-8",
+              );
+              return;
+            }
+            await new Promise((r) => setTimeout(r, 25));
+          }
+          throw new Error("relay request file never appeared");
+        })();
+
+        const call = await rpc(url, {
+          jsonrpc: "2.0",
+          id: 3,
+          method: "tools/call",
+          params: { name: "search", arguments: { q: "hi" } },
+        });
+        await watcher;
+
+        assert.equal(call.result.isError, undefined, "successful call");
+        assert.equal(call.result.content[0].type, "text");
+        assert.equal(
+          call.result.content[0].text,
+          token,
+          "the relay's response text reaches the caller",
+        );
+      } finally {
+        rmSync(dir, { recursive: true, force: true });
+      }
+    });
+
+    it("returns an MCP error for an unknown tool", async () => {
+      const specs: ResolvedToolSpec[] = [
+        { name: "search", kind: "callback", callRef: "composio.search" },
+      ];
+      const { servers } = await build(specs, relayDir);
+      const out = await rpc(servers[0].url, {
+        jsonrpc: "2.0",
+        id: 4,
+        method: "tools/call",
+        params: { name: "nope", arguments: {} },
+      });
+      assert.equal(out.error.code, -32602);
+      assert.match(out.error.message, /unknown tool/);
+    });
+
+    it("accepts a notification with no response (202)", async () => {
+      const specs: ResolvedToolSpec[] = [
+        { name: "search", kind: "callback", callRef: "composio.search" },
+      ];
+      const { servers } = await build(specs, relayDir);
+      const out = await rpc(servers[0].url, {
+        jsonrpc: "2.0",
+        method: "notifications/initialized",
+      });
+      assert.equal(out, undefined, "notification -> 202, no body");
+    });
   });
 });


### PR DESCRIPTION
## Context

A Claude agent run carrying gateway (Composio) tools hard-failed at delivery with "MCP servers are not supported by the sidecar.", even though the harness capability gate said Claude accepts tools.

Root cause: PR #4831 disabled user-declared stdio MCP for security, but it routed two different things through one shared `MCP_UNSUPPORTED_MESSAGE` gate: the user's own MCP servers AND the runner's internal gateway-tool channel (how Claude receives Composio/gateway tools). The later fail-loud capability work then turned that shared gate into a hard error for any Claude run with gateway tools.

## Changes

Split the two layers and restore only the internal channel. User-declared stdio MCP stays disabled; user HTTP MCP is unchanged.

- New `tools/tool-mcp-http.ts`: a loopback HTTP MCP server (stateless JSON Streamable-HTTP) the runner serves in-process. There is no runner-host child process, so this does not reopen the hole #4831 closed. It serves `initialize` / `tools/list` / `tools/call`; each `tools/call` dispatches through `runResolvedTool(..., {relayDir})`, the same server-side relay the Pi path already uses. It carries only public tool metadata.
- `mcp-bridge.ts`: `buildToolMcpServers` is re-enabled. It starts that loopback server for executable specs and returns one ACP `type: "http"` entry (name `agenta-tools`, empty headers). An empty or client-only spec stays a no-op. The user-facing constant is renamed to `USER_MCP_UNSUPPORTED_MESSAGE` so the internal channel can never borrow it.
- `mcp.ts`: `buildSessionMcpServers` is now async and returns `{servers, close}`, with the two independent layers (internal gateway-tool vs user MCP) documented inline.
- `sandbox_agent.ts`: threads `close()` into the run `finally` so the loopback port is released.

No wire, protocol, SDK, or golden-fixture change. The channel is synthesized from `customTools` already on the `/run` request.

## Scope / risk

This restores only the internal gateway-tool channel. User-declared stdio MCP remains refused (the security fix from #4831 stands), and user HTTP MCP is untouched. The loopback server binds in-process and is closed at the end of each run. The only behavior change a reviewer can observe is that a Claude run with gateway tools now succeeds instead of erroring.

This PR is stacked on #4838 (`feat/agent-capability-fail-loud`). Review and merge that first.

## Tests / notes

- A live HTTP round-trip test against the loopback server, including a relay `tools/call` proof.
- A new `session-mcp-layering` regression guard that locks the two-layer split.
- The orchestration test is re-targeted: a Claude + gateway run now succeeds, and a user stdio MCP run is still refused.
- 220 vitest + typecheck green in `services/agent`.

## How to QA

**Prerequisites:** the EE dev stack with the `sandbox-agent` sidecar running, and a project with a Composio (gateway) connection plus an Anthropic key in the vault. The runner CMD is overridden in compose, so make sure the sidecar image carries the current bundle.

**Steps:**
1. In the playground, open an agent config with `harness: claude`.
2. Add a gateway tool (a Composio tool resolved through the tool gateway).
3. Send a chat turn that makes the model call that tool.

**Expected result:** the tool call resolves through the gateway and the model answers. The run no longer fails with "MCP servers are not supported by the sidecar."

**Automated tests:**
```
cd services/agent && pnpm test -- --run session-mcp-layering tool-bridge sandbox-agent-orchestration mcp-servers
```

**Edge cases:** confirm a run that declares a user **stdio** MCP server is still refused with `USER_MCP_UNSUPPORTED_MESSAGE`. The split must not have reopened user stdio MCP. Also check a Pi run with gateway tools still works (Pi delivers tools over its native extension, not this channel).

Refs #4844 (plan).
