### PR TITLE
fix(agent): scope HITL approval to the specific call + enable approve/deny promptly

### DIFF
--- a/services/agent/src/responder.ts
+++ b/services/agent/src/responder.ts
@@ -73,20 +73,97 @@ export class PolicyResponder implements Responder {
 }
 
 /**
- * A lookup of approval decisions the user already made on a prior turn, keyed by the
- * identifier carried on the permission request. Both the tool-call id and the tool name are
- * indexed because a cold-replayed run mints fresh ACP permission/tool-call ids each turn, so
- * the stable cross-turn anchor is whichever the harness re-presents. `toolCallId` is the
- * precise match; `toolName` is the fallback when the id was not preserved across the boundary.
+ * A lookup of approval decisions the user already made on a prior turn, keyed by an
+ * identifier carried on the permission request. Two keys are indexed per decision:
+ *
+ *   1. `toolCallId` — the precise, warm match. When the harness re-presents the SAME ACP
+ *      tool-call id (same session), this resolves the exact parked call.
+ *   2. `approvalKey(name, input)` — the cold-replay anchor. A cold-replayed run rebuilds the
+ *      session from the replayed transcript and mints a FRESH tool-call id for the re-raised
+ *      gate, so the id no longer matches. The stable anchor is then the tool's NAME **plus
+ *      its arguments**: the resumed call re-derives the same name and the same args, so it
+ *      resolves; a DIFFERENT call to the same tool (different args) does NOT, so it re-prompts.
+ *
+ * Keying by the bare tool NAME alone (the prior behavior) over-authorized: an `allow` on call
+ * A auto-approved any later call B to the same tool, even with different/sensitive args — a
+ * HITL bypass. Binding the cold-replay key to name + args closes that hole while keeping the
+ * legitimate approve -> resume path working (resume re-raises the same name + args).
  */
 export type ApprovalDecisions = ReadonlyMap<string, PermissionDecision>;
+
+/**
+ * The cold-replay approval anchor: the tool name bound to its arguments. Resume re-derives
+ * the same name + args (matches); a different call to the same tool has different args (no
+ * match -> re-prompts).
+ *
+ * Absent args (null/undefined) normalize to `{}` so a genuine NO-ARG tool still gets a stable
+ * key and resumes (its calls have nothing to vary, so sharing a key is the same call). This is
+ * a deliberate trade-off over fail-closed: the ACP wire reliably carries `rawInput` and the
+ * stored side carries the tool_call `input`, so a tool that takes args reports them on both
+ * sides (a different-args call gets a different key). The residual is only if a with-args tool
+ * reports empty on BOTH sides — then two such calls collide, which the reliable arg capture
+ * makes a non-issue.
+ *
+ * Returns `undefined` (NO key, fail closed -> re-prompt) only when there is no tool name, or
+ * the args are not plain JSON (bigint / cycle / NaN/Infinity / non-plain object like Date/Map).
+ */
+export function approvalKey(
+  toolName: string | undefined,
+  input: unknown,
+): string | undefined {
+  if (!toolName) return undefined;
+  const args = input === null || input === undefined ? {} : input;
+  const hash = stableArgsHash(args);
+  if (hash === undefined) return undefined; // non-JSON args -> fail closed (no key, re-prompt)
+  return `${toolName}#${hash}`;
+}
+
+/**
+ * Order-independent, stable serialization of tool args so the same call hashes the same.
+ * Returns `undefined` for any value that is not plain JSON (bigint, cycles, NaN/Infinity, or
+ * a non-plain object like Date/Map) so the caller can fail closed rather than collide. Tool
+ * args arrive as JSON over the wire, so this only triggers on a malformed/hostile payload.
+ */
+function stableArgsHash(input: unknown): string | undefined {
+  try {
+    return canonicalJson(input);
+  } catch {
+    return undefined;
+  }
+}
+
+function canonicalJson(value: unknown): string {
+  if (value === null) return "null";
+  if (value === undefined) throw new Error("undefined is not JSON");
+  if (typeof value === "bigint") throw new Error("bigint is not JSON");
+  if (typeof value === "number") {
+    if (!Number.isFinite(value)) throw new Error("non-finite number is not JSON");
+    return JSON.stringify(value);
+  }
+  if (typeof value !== "object") return JSON.stringify(value);
+  if (Array.isArray(value)) {
+    return `[${value.map(canonicalJson).join(",")}]`;
+  }
+  // Only plain objects are stable JSON; reject Date/Map/Set/etc. so they don't collapse to {}.
+  const proto = Object.getPrototypeOf(value);
+  if (proto !== Object.prototype && proto !== null) {
+    throw new Error("non-plain object is not JSON");
+  }
+  const entries = Object.entries(value as Record<string, unknown>)
+    .filter(([, v]) => v !== undefined)
+    .sort(([a], [b]) => (a < b ? -1 : a > b ? 1 : 0));
+  return `{${entries.map(([k, v]) => `${JSON.stringify(k)}:${canonicalJson(v)}`).join(",")}}`;
+}
 
 /**
  * The cross-turn human-in-the-loop responder for the `/messages` path.
  *
  * It answers a permission gate three ways, in order:
- *   1. The user already decided (a stored `decisions` entry for this tool-call id or tool
- *      name) -> apply it. THIS IS THE RESUME PATH: turn N parks, turn N+1 carries the reply.
+ *   1. The user already decided (a stored `decisions` entry for this exact tool-call id, or
+ *      for this tool's name + args) -> apply it. THIS IS THE RESUME PATH: turn N parks, turn
+ *      N+1 carries the reply. The match is scoped to the SPECIFIC call (id, or name + args),
+ *      never to all future calls of the tool by name, so an `allow` cannot leak to a later
+ *      call with different args.
  *   2. No stored decision and there is a human surface (`hasHumanSurface`) -> `park`. The
  *      `interaction_request` was already emitted upstream (the FE prompts), so the turn ends
  *      with this tool PENDING and NO harness reply (the adapter skips `respondPermission`).
@@ -121,42 +198,104 @@ export class HITLResponder implements Responder {
   }
 }
 
-/** The identifiers a stored decision may be keyed by: the gated tool-call id, then its name. */
+/**
+ * The identifiers a stored decision may be keyed by: the gated tool-call id (precise/warm),
+ * then the tool name bound to its args (the cold-replay anchor). NOTE: bare name is NOT a key
+ * — that would auto-approve any later call to the same tool regardless of args (a HITL
+ * bypass). The name is read off the ACP `ToolCallUpdate`, which carries `title`/`kind` (no
+ * `name` field on the live wire); the args come from `rawInput` (falling back to `input` for
+ * non-ACP shapes / tests).
+ */
 function permissionRequestKeys(request: PermissionRequest): string[] {
   const keys: string[] = [];
   const raw = request.raw as
-    | { toolCall?: { toolCallId?: unknown; name?: unknown } }
+    | {
+        toolCall?: {
+          toolCallId?: unknown;
+          name?: unknown;
+          title?: unknown;
+          kind?: unknown;
+          rawInput?: unknown;
+          input?: unknown;
+        };
+      }
     | undefined;
-  const toolCallId = raw?.toolCall?.toolCallId;
+  const toolCall = raw?.toolCall;
+  const toolCallId = toolCall?.toolCallId;
   if (typeof toolCallId === "string" && toolCallId) keys.push(toolCallId);
-  const name = raw?.toolCall?.name;
-  if (typeof name === "string" && name) keys.push(name);
+  const name = permissionToolName(toolCall);
+  const argsKey = approvalKey(name, toolCall?.rawInput ?? toolCall?.input);
+  if (argsKey) keys.push(argsKey);
   return keys;
+}
+
+/** Resolve the gated tool's name the same way the egress does: name, then title, then kind. */
+function permissionToolName(toolCall: unknown): string | undefined {
+  const tc = toolCall as
+    | { name?: unknown; title?: unknown; kind?: unknown }
+    | undefined;
+  for (const candidate of [tc?.name, tc?.title, tc?.kind]) {
+    if (typeof candidate === "string" && candidate) return candidate;
+  }
+  return undefined;
 }
 
 /**
  * Build the approval-decision lookup from the inbound run request's message history.
  *
  * The signal is the converted approval reply that the Vercel adapter
- * (`_approval_response_blocks`) already produces: a `tool_result` content block keyed by
- * `toolCallId` whose `output` is an `{ approved: boolean }` envelope. That envelope shape is
- * unique to an approval response (an ordinary tool result carries the tool's real output, not
- * an `approved` flag), so no new wire carrier is needed. We index each decision by its
- * `toolCallId` and, when the block also names a tool, by `toolName` (the cross-turn fallback
- * when a cold replay did not preserve the id).
+ * (`_approval_response_blocks`) produces: a `tool_result` content block keyed by `toolCallId`
+ * whose `output` is an `{ approved: boolean }` envelope. That envelope shape is unique to an
+ * approval response (an ordinary tool result carries the tool's real output, not an `approved`
+ * flag), so no new wire carrier is needed.
+ *
+ * Each decision is indexed ONLY by `approvalKey(name, args)` — the cold-replay anchor. The
+ * name/args are recovered from the matching `tool_call` block (same `toolCallId`) the egress
+ * folds into the transcript.
+ *
+ * Two keys deliberately do NOT appear:
+ *   - The bare tool NAME — keying by name alone let an `allow` on one call auto-approve every
+ *     later call to that tool, even with different args (the HITL bypass this fix closes).
+ *   - The historical `toolCallId` — the `/messages` path is always cold-replay (a fresh
+ *     session per turn, prior calls replayed as text), so the harness mints a NEW id for the
+ *     re-raised gate and a stored historical id can never LEGITIMATELY match it. Keeping it
+ *     would only add an args-blind match risk if a fresh id ever collided with a historical
+ *     one. So we drop it: the cross-turn match is name + args, never a replayed id.
  */
 export function extractApprovalDecisions(
   request: AgentRunRequest,
 ): Map<string, PermissionDecision> {
   const decisions = new Map<string, PermissionDecision>();
+  // First pass: recover each tool call's name + args, keyed by its id, so an approval reply
+  // (which may carry only the id + the `{approved}` envelope) can be bound to name + args.
+  const callShapeById = new Map<string, { name?: string; input?: unknown }>();
+  for (const message of request.messages ?? []) {
+    const content = message?.content;
+    if (!Array.isArray(content)) continue;
+    for (const block of content) {
+      if (block?.type === "tool_call" && block.toolCallId) {
+        callShapeById.set(block.toolCallId, {
+          name: block.toolName,
+          input: block.input,
+        });
+      }
+    }
+  }
   for (const message of request.messages ?? []) {
     const content = message?.content;
     if (!Array.isArray(content)) continue;
     for (const block of content) {
       const decision = approvalDecisionOf(block);
       if (!decision) continue;
-      if (block.toolCallId) decisions.set(block.toolCallId, decision);
-      if (block.toolName) decisions.set(block.toolName, decision);
+      // Bind the cold-replay name+args key: prefer the block's own name/input, else the
+      // correlated tool_call block (same id). Never key by bare name or by a replayed id.
+      const shape = block.toolCallId
+        ? callShapeById.get(block.toolCallId)
+        : undefined;
+      const name = block.toolName ?? shape?.name;
+      const input = block.input ?? shape?.input;
+      const argsKey = approvalKey(name, input);
+      if (argsKey) decisions.set(argsKey, decision);
     }
   }
   return decisions;
@@ -194,7 +333,16 @@ export function policyFromRequest(permissionPolicy?: string): PermissionPolicy {
   return "auto";
 }
 
-/** Map an allow/deny decision onto the harness's available ACP replies. */
+/**
+ * Map an allow/deny decision onto the harness's available ACP replies.
+ *
+ * An `allow` maps to `"once"` (grant THIS call only), NOT `"always"`. `"always"` tells the
+ * harness to allow the tool broadly for the rest of the turn WITHOUT re-raising the gate, so a
+ * single approval of call A would silently authorize later calls to the same tool without
+ * rechecking name + args — re-opening the over-authorization hole this module closes. Every
+ * call must be gated individually; the headless auto-allow policy already returns `allow` per
+ * call, so `"once"` per call is equivalent for it and strictly safer for HITL.
+ */
 export function decisionToReply(
   decision: PermissionDecision,
   availableReplies: string[],
@@ -202,9 +350,5 @@ export function decisionToReply(
   if (decision === "deny") {
     return availableReplies.find((r) => r === "reject") ?? "reject";
   }
-  return (
-    availableReplies.find((r) => r === "always") ??
-    availableReplies.find((r) => r === "once") ??
-    "once"
-  );
+  return availableReplies.find((r) => r === "once") ?? "once";
 }

--- a/services/agent/tests/unit/responder.test.ts
+++ b/services/agent/tests/unit/responder.test.ts
@@ -16,6 +16,7 @@ import type { AgentEvent, AgentRunRequest } from "../../src/protocol.ts";
 import {
   HITLResponder,
   PolicyResponder,
+  approvalKey,
   decisionToReply,
   extractApprovalDecisions,
   policyFromRequest,
@@ -43,11 +44,14 @@ describe("policyFromRequest", () => {
   });
 });
 
-describe("decisionToReply (parity with the old inline mapping)", () => {
-  it("maps allow/deny onto the available replies", () => {
+describe("decisionToReply", () => {
+  it("maps allow to ONCE (never always) so an approval grants only this call", () => {
+    // SECURITY: `always` would let the harness allow the tool broadly for the rest of the
+    // turn without re-gating, re-opening the over-authorization hole. allow -> once, always.
     assert.equal(
       decisionToReply("allow", ["always", "once", "reject"]),
-      "always",
+      "once",
+      "allow must NOT map to always even when always is offered",
     );
     assert.equal(decisionToReply("allow", ["once", "reject"]), "once");
     assert.equal(
@@ -55,6 +59,14 @@ describe("decisionToReply (parity with the old inline mapping)", () => {
       "once",
       "allow falls back to once",
     );
+    assert.equal(
+      decisionToReply("allow", ["always"]),
+      "once",
+      "with only always offered, still fall back to once (never broaden)",
+    );
+  });
+
+  it("maps deny onto reject", () => {
     assert.equal(
       decisionToReply("deny", ["always", "once", "reject"]),
       "reject",
@@ -64,6 +76,48 @@ describe("decisionToReply (parity with the old inline mapping)", () => {
       "reject",
       "deny falls back to reject",
     );
+  });
+});
+
+describe("approvalKey", () => {
+  it("binds name + args, order-independently", () => {
+    assert.equal(
+      approvalKey("edit", {a: 1, b: 2}),
+      approvalKey("edit", {b: 2, a: 1}),
+      "key order does not change the key",
+    );
+    assert.notEqual(
+      approvalKey("edit", {path: "a"}),
+      approvalKey("edit", {path: "b"}),
+      "different args -> different key",
+    );
+    assert.notEqual(
+      approvalKey("edit", {path: "a"}),
+      approvalKey("bash", {path: "a"}),
+      "different name -> different key",
+    );
+  });
+
+  it("normalizes absent args to {} so a no-arg tool resumes", () => {
+    // A no-arg tool has nothing to vary; absent/null/empty all key to the same `name#{}`.
+    assert.ok(approvalKey("edit", {}), "empty-object args -> a real key");
+    assert.equal(approvalKey("edit", undefined), approvalKey("edit", {}));
+    assert.equal(approvalKey("edit", null), approvalKey("edit", {}));
+    // But a WITH-args call never collapses to the no-arg key.
+    assert.notEqual(
+      approvalKey("edit", {path: "a"}),
+      approvalKey("edit", {}),
+      "args present -> a different key than no-args",
+    );
+  });
+
+  it("returns no key (fails closed) for no name or non-JSON args", () => {
+    assert.equal(approvalKey(undefined, {a: 1}), undefined, "no name -> no key");
+    // Non-JSON args fail closed (no key) rather than throwing or colliding.
+    assert.equal(approvalKey("edit", 10n as unknown), undefined, "bigint -> no key");
+    assert.equal(approvalKey("edit", new Date()), undefined, "Date -> no key");
+    assert.equal(approvalKey("edit", {x: NaN}), undefined, "NaN -> no key");
+    assert.equal(approvalKey("edit", new Map()), undefined, "Map -> no key");
   });
 });
 
@@ -78,12 +132,18 @@ describe("PolicyResponder", () => {
 });
 
 // A permission request as the harness adapter shapes it: `raw.toolCall` carries the gated
-// tool's id + name, which is what the responder keys a stored decision by.
-function permReq(toolCallId?: string, name?: string): PermissionRequest {
+// tool's id, name, and args (`rawInput`), which is what the responder keys a stored decision
+// by. `name` is optional so a test can simulate the live ACP wire (which carries `title`/
+// `kind`, not `name`).
+function permReq(
+  toolCallId?: string,
+  name?: string,
+  rawInput?: unknown,
+): PermissionRequest {
   return {
     id: "perm-1",
     availableReplies: ["once", "always", "reject"],
-    raw: { id: "perm-1", toolCall: { toolCallId, name } },
+    raw: { id: "perm-1", toolCall: { toolCallId, name, rawInput } },
   };
 }
 
@@ -98,13 +158,55 @@ describe("HITLResponder", () => {
     assert.equal(await deny.onPermission(permReq("tc-2", "edit")), "deny");
   });
 
-  it("matches a stored decision by tool name when the id was not preserved", async () => {
+  it("matches a stored decision by tool name + args when the id was not preserved (cold replay)", async () => {
+    // The parked turn approved edit({path:'a.txt'}); a cold replay mints a FRESH tool-call id
+    // for the SAME call, so the id no longer matches — but the name + args anchor does.
+    const decisions = new Map<string, PermissionDecision>([
+      [approvalKey("edit", { path: "a.txt" })!, "allow"],
+    ]);
+    const responder = new HITLResponder(decisions, "auto", true);
+    assert.equal(
+      await responder.onPermission(permReq("fresh-id", "edit", { path: "a.txt" })),
+      "allow",
+    );
+  });
+
+  it("SECURITY: approving call A does NOT auto-approve a later call B to the same tool with different args", async () => {
+    // The HITL bypass this guards against: a stored `allow` for edit({path:'a.txt'}) must NOT
+    // leak to a NEW edit call with DIFFERENT args (e.g. a sensitive path). B must re-prompt.
+    const decisions = new Map<string, PermissionDecision>([
+      [approvalKey("edit", { path: "a.txt" })!, "allow"],
+    ]);
+    const responder = new HITLResponder(decisions, "auto", true);
+    // Same tool name, different args, brand-new id -> no stored match -> park (re-prompt).
+    assert.equal(
+      await responder.onPermission(
+        permReq("call-b", "edit", { path: "/etc/shadow" }),
+      ),
+      "park",
+      "a different-args call to the same tool must re-prompt, not auto-approve",
+    );
+    // And argument-order does not let B slip through under A's key.
+    const orderDecisions = new Map<string, PermissionDecision>([
+      [approvalKey("edit", { a: 1, b: 2 })!, "allow"],
+    ]);
+    const orderResponder = new HITLResponder(orderDecisions, "auto", true);
+    assert.equal(
+      await orderResponder.onPermission(permReq("call-c", "edit", { b: 2, a: 1 })),
+      "allow",
+      "the same args in a different key order is the same call (resumes)",
+    );
+  });
+
+  it("SECURITY: bare tool NAME is not a key — a stored bare-name entry never auto-approves", async () => {
+    // Defense in depth: even if a bare tool name somehow lands in the map, the responder must
+    // not honor it (it only consults the id key and the name+args key).
     const decisions = new Map<string, PermissionDecision>([["edit", "allow"]]);
     const responder = new HITLResponder(decisions, "auto", true);
-    // Fresh tool-call id this turn, but the name still matches the recorded decision.
     assert.equal(
-      await responder.onPermission(permReq("fresh-id", "edit")),
-      "allow",
+      await responder.onPermission(permReq("fresh-id", "edit", { path: "a.txt" })),
+      "park",
+      "a bare-name entry must not auto-approve a real call",
     );
   });
 
@@ -141,7 +243,7 @@ describe("HITLResponder", () => {
 });
 
 describe("extractApprovalDecisions", () => {
-  it("builds the lookup from approval tool_result blocks, keyed by id and name", () => {
+  it("builds the lookup from approval tool_result blocks, keyed by id and by name+args (not bare name)", () => {
     const request: AgentRunRequest = {
       sessionId: "s-1",
       messages: [
@@ -153,7 +255,7 @@ describe("extractApprovalDecisions", () => {
               type: "tool_call",
               toolCallId: "tc-1",
               toolName: "edit",
-              input: {},
+              input: { path: "a.txt" },
             },
           ],
         },
@@ -171,6 +273,7 @@ describe("extractApprovalDecisions", () => {
               type: "tool_result",
               toolCallId: "tc-2",
               toolName: "bash",
+              input: { cmd: "ls" },
               output: { approved: false },
             },
           ],
@@ -179,10 +282,16 @@ describe("extractApprovalDecisions", () => {
     };
 
     const decisions = extractApprovalDecisions(request);
-    assert.equal(decisions.get("tc-1"), "allow");
-    assert.equal(decisions.get("edit"), "allow");
-    assert.equal(decisions.get("tc-2"), "deny");
-    assert.equal(decisions.get("bash"), "deny");
+    // ONLY the name+args anchor is keyed (recovered from the correlated tool_call block).
+    assert.equal(decisions.get(approvalKey("edit", { path: "a.txt" })!), "allow");
+    assert.equal(decisions.get(approvalKey("bash", { cmd: "ls" })!), "deny");
+    // The bare tool NAME must NOT be a key (that was the HITL-bypass).
+    assert.equal(decisions.has("edit"), false, "no bare-name key");
+    assert.equal(decisions.has("bash"), false, "no bare-name key");
+    // The historical replayed tool-call id must NOT be a key (cold replay mints fresh ids;
+    // a stored historical id could only ever match a fresh one by collision -> args-blind).
+    assert.equal(decisions.has("tc-1"), false, "no replayed-id key");
+    assert.equal(decisions.has("tc-2"), false, "no replayed-id key");
   });
 
   it("ignores ordinary tool results that are not approval envelopes", () => {
@@ -215,7 +324,7 @@ describe("extractApprovalDecisions", () => {
     assert.equal(extractApprovalDecisions(request).size, 0);
   });
 
-  it("end-to-end: an extracted decision resumes a parked permission", async () => {
+  it("end-to-end: an extracted decision resumes via name+args when the approval block names the tool", async () => {
     const request: AgentRunRequest = {
       sessionId: "s-2",
       messages: [
@@ -226,6 +335,7 @@ describe("extractApprovalDecisions", () => {
               type: "tool_result",
               toolCallId: "tc-1",
               toolName: "edit",
+              input: { path: "a.txt" },
               output: { approved: true },
             },
           ],
@@ -237,9 +347,62 @@ describe("extractApprovalDecisions", () => {
       "auto",
       true, // human surface present, but the stored decision wins over the park
     );
+    // Resolves on the name+args anchor (the replayed id is NOT a key).
     assert.equal(
-      await responder.onPermission(permReq("tc-1", "edit")),
+      await responder.onPermission(permReq("tc-1", "edit", { path: "a.txt" })),
       "allow",
+    );
+  });
+
+  it("end-to-end: a cold replay (FRESH id) resumes the parked call by name+args", async () => {
+    // The parked call: edit({path:'a.txt'}) approved. A cold replay rebuilds the session and
+    // mints a fresh tool-call id; the id no longer matches, but the name + args anchor does.
+    const request: AgentRunRequest = {
+      sessionId: "s-3",
+      messages: [
+        {
+          role: "assistant",
+          content: [
+            {
+              type: "tool_call",
+              toolCallId: "tc-1",
+              toolName: "edit",
+              input: { path: "a.txt" },
+            },
+          ],
+        },
+        {
+          role: "tool",
+          content: [
+            // The approval reply may carry only the id + the {approved} envelope; the name +
+            // args are recovered from the correlated tool_call block above.
+            {
+              type: "tool_result",
+              toolCallId: "tc-1",
+              output: { approved: true },
+            },
+          ],
+        },
+      ],
+    };
+    const responder = new HITLResponder(
+      extractApprovalDecisions(request),
+      "auto",
+      true,
+    );
+    // Fresh id this turn, but same name + args -> resolves (resume works).
+    assert.equal(
+      await responder.onPermission(permReq("fresh-id", "edit", { path: "a.txt" })),
+      "allow",
+      "the parked call resumes under a fresh id via the name+args anchor",
+    );
+    // SECURITY end-to-end: a different-args call to the same tool re-prompts (no leak).
+    assert.equal(
+      await responder.onPermission(
+        permReq("other-id", "edit", { path: "/etc/passwd" }),
+      ),
+      "park",
+      "a different-args call must NOT inherit the earlier approval",
     );
   });
 });

--- a/services/agent/tests/unit/sandbox-agent-orchestration.test.ts
+++ b/services/agent/tests/unit/sandbox-agent-orchestration.test.ts
@@ -288,8 +288,9 @@ describe("runSandboxAgent orchestration", () => {
         },
       ],
     );
+    // allow -> once (per-call grant), never always: a turn-wide grant would skip re-gating.
     assert.deepEqual(calls.permissionReplies, [
-      { id: "perm-1", reply: "always" },
+      { id: "perm-1", reply: "once" },
     ]);
   });
 
@@ -630,9 +631,10 @@ describe("runSandboxAgent default HITL responder wiring", () => {
     await flushPromises();
 
     assert.equal(result.ok, true);
-    // Old PolicyResponder("auto") would have replied "always"; the default must match.
+    // Headless auto-allow gates each call individually, so once (this call) is equivalent to
+    // the old always and strictly safer — no turn-wide grant that skips re-gating.
     assert.deepEqual(calls.permissionReplies, [
-      { id: "perm-1", reply: "always" },
+      { id: "perm-1", reply: "once" },
     ]);
   });
 
@@ -668,7 +670,7 @@ describe("runSandboxAgent default HITL responder wiring", () => {
     assert.deepEqual(calls.permissionReplies, []);
   });
 
-  it("human surface with a stored approval resumes the tool (always)", async () => {
+  it("human surface with a stored approval resumes the tool (once)", async () => {
     const { calls, deps } = depsWithDefaultResponder();
 
     const result = await runSandboxAgent(
@@ -678,8 +680,8 @@ describe("runSandboxAgent default HITL responder wiring", () => {
         messages: [
           { role: "user", content: "edit the file" },
           {
-            // The cross-turn approval reply, keyed by the gated tool's name (cold replay
-            // mints a fresh tool-call id "tool-1" each turn, so the name is the anchor).
+            // The cross-turn approval reply. Cold replay mints a fresh tool-call id "tool-1"
+            // each turn, so the anchor is the tool's name + args (here a no-arg edit -> {}).
             role: "tool",
             content: [
               {
@@ -700,8 +702,9 @@ describe("runSandboxAgent default HITL responder wiring", () => {
     await flushPromises();
 
     assert.equal(result.ok, true);
+    // Resumes via the name+args anchor, then grants ONCE (per call), not always.
     assert.deepEqual(calls.permissionReplies, [
-      { id: "perm-1", reply: "always" },
+      { id: "perm-1", reply: "once" },
     ]);
   });
 });

--- a/services/agent/tests/unit/sandbox-agent-permissions.test.ts
+++ b/services/agent/tests/unit/sandbox-agent-permissions.test.ts
@@ -73,7 +73,9 @@ describe("attachPermissionResponder", () => {
         },
       },
     ]);
-    assert.deepEqual(replies, [{ id: "perm-1", reply: "always" }]);
+    // allow maps to ONCE, not always: a per-call approval must not broaden into a
+    // turn-wide grant that skips re-gating later calls (the over-authorization hole).
+    assert.deepEqual(replies, [{ id: "perm-1", reply: "once" }]);
   });
 
   it("parks: emits the interaction_request but sends NO harness reply (F-024 regression)", async () => {

--- a/web/oss/src/components/AgentChatSlice/AgentChatPanel.tsx
+++ b/web/oss/src/components/AgentChatSlice/AgentChatPanel.tsx
@@ -237,7 +237,6 @@ const AgentConversation = ({entityId, sessionId}: {entityId: string; sessionId: 
                         <div key={message.id} className="flex flex-col gap-1">
                             <AgentMessage
                                 message={message}
-                                busy={busy}
                                 isStreaming={busy && index === messages.length - 1}
                                 onRewind={() => handleRewind(message)}
                                 onApprovalResponse={addToolApprovalResponse}

--- a/web/oss/src/components/AgentChatSlice/components/AgentChatConversation.tsx
+++ b/web/oss/src/components/AgentChatSlice/components/AgentChatConversation.tsx
@@ -203,7 +203,6 @@ const AgentChatConversation = ({
                     <AgentMessage
                         key={message.id}
                         message={message}
-                        busy={busy}
                         isStreaming={busy && index === messages.length - 1}
                         onRewind={() => handleRewind(message)}
                         onApprovalResponse={addToolApprovalResponse}

--- a/web/oss/src/components/AgentChatSlice/components/AgentMessage.tsx
+++ b/web/oss/src/components/AgentChatSlice/components/AgentMessage.tsx
@@ -40,7 +40,6 @@ const TraceMetrics = ({traceId, usage}: {traceId: string; usage?: MessageUsageMe
 
 interface AgentMessageProps {
     message: UIMessage
-    busy: boolean
     /** This is the last message AND the conversation is streaming — i.e. the one being
      * generated right now. Only it shows the loading state; settled turns never do. */
     isStreaming?: boolean
@@ -112,7 +111,6 @@ const avatarFor = (isUser: boolean) => (
  */
 const AgentMessage = ({
     message,
-    busy,
     isStreaming = false,
     onRewind,
     onApprovalResponse,
@@ -201,7 +199,6 @@ const AgentMessage = ({
                             key={partKey}
                             part={part as ToolUIPart}
                             onApprovalResponse={onApprovalResponse}
-                            disabled={busy}
                         />
                     )
                 }

--- a/web/oss/src/components/AgentChatSlice/components/ToolPart.tsx
+++ b/web/oss/src/components/AgentChatSlice/components/ToolPart.tsx
@@ -65,7 +65,6 @@ interface ToolPartProps {
     part: ToolUIPart
     /** Resolve a pending approval. `id` is the approvalId. */
     onApprovalResponse: (args: {id: string; approved: boolean}) => void
-    disabled?: boolean
 }
 
 /**
@@ -73,13 +72,28 @@ interface ToolPartProps {
  * human-in-the-loop approval round-trip. The FE renders tool calls; it never executes
  * them. Approve/Deny call `addToolApprovalResponse`; the auto-resume (configured on
  * `useChat`) re-sends the conversation and the service streams the tool output.
+ *
+ * Approve/Deny are clickable AS SOON AS the prompt renders — they are NOT gated on the
+ * conversation being idle (F-026). An approval request can only appear while the stream is
+ * still in flight (that's how the event arrives), so gating on `busy` left the buttons
+ * disabled for the whole turn (~70-140s), reading as a hang. `addToolApprovalResponse`
+ * records the decision immediately and the SDK defers the resume until the stream settles
+ * (it re-sends only when status is not streaming/submitted), so clicking mid-stream is safe.
  */
-const ToolPart = ({part, onApprovalResponse, disabled}: ToolPartProps) => {
+const ToolPart = ({part, onApprovalResponse}: ToolPartProps) => {
     const toolName = part.type.replace(/^tool-/, "")
     const state = part.state as string
     const meta = STATE_META[state] ?? {label: state, color: "default"}
     const approval = (part as {approval?: {id: string; approved?: boolean; reason?: string}})
         .approval
+    // Guard against a double-submit between the click and the SDK flipping the part to
+    // `approval-responded` (which removes the buttons). Not tied to the conversation `busy`.
+    const [responding, setResponding] = useState(false)
+    const respond = (approved: boolean) => {
+        if (responding || !approval?.id) return
+        setResponding(true)
+        onApprovalResponse({id: approval.id, approved})
+    }
 
     // Collapsible body. A pending approval is force-expanded so the buttons stay reachable.
     const [open, setOpen] = useState(true)
@@ -156,19 +170,15 @@ const ToolPart = ({part, onApprovalResponse, disabled}: ToolPartProps) => {
                             <Button
                                 size="small"
                                 type="primary"
-                                disabled={disabled}
-                                onClick={() =>
-                                    onApprovalResponse({id: approval.id, approved: true})
-                                }
+                                loading={responding}
+                                onClick={() => respond(true)}
                             >
                                 Approve
                             </Button>
                             <Button
                                 size="small"
-                                disabled={disabled}
-                                onClick={() =>
-                                    onApprovalResponse({id: approval.id, approved: false})
-                                }
+                                disabled={responding}
+                                onClick={() => respond(false)}
                             >
                                 Deny
                             </Button>


### PR DESCRIPTION
## What and why

Two HITL findings from the final agent QA sweep, both in the tool-approval path.

### Finding 1 (HIGH, Codex) — approval over-authorized by tool NAME

A stored approval decision was indexed by BOTH the ACP `toolCallId` AND the bare tool
NAME. The bare-name key was a HITL bypass: approving call A auto-approved any later call B
to the **same tool** with **different args**.

- **Before:** approve `edit({path:"a.txt"})` → a later `edit({path:"/etc/shadow"})` (fresh
  tool-call id) falls through to the `edit` name key and silently auto-runs.
- **After:** the cold-replay anchor is `approvalKey(name, args)` — the tool name bound to a
  canonical (key-sorted) hash of its args — not the bare name. The same call (same name +
  args) resumes; a different call to the same tool re-prompts.

The name fallback exists because `/messages` is cold-replay: each turn rebuilds the session
from the replayed transcript, so the harness mints a **fresh** ACP tool-call id for the
re-raised gate and the precise `toolCallId` no longer matches across turns. Binding the
fallback to name + args keeps the resume working while closing the hole — precision and
resume coexist (no escalation).

### Finding 2 (F-026) — Approve/Deny disabled ~70-140s, reads as a hang

The buttons were gated on the conversation-level `busy` (`status === submitted/streaming`).
But an approval request can only appear **while the stream is in flight** — so `busy` is
necessarily true when the prompt first shows, leaving the buttons disabled for the whole
turn. The AI SDK is built for mid-stream answers: `addToolApprovalResponse` records the
decision immediately and only auto-resends once the stream settles. So the gate was wrong,
not a backend-park latency.

Fix: enable Approve/Deny as soon as the `approval-requested` part renders; guard only
against a double-submit. Drops the now-dead `busy` prop on `AgentMessage` and its two
callers.

## Files

- `services/agent/src/responder.ts` — `approvalKey(name,args)` + `canonicalJson`; rework
  `permissionRequestKeys` (live) and `extractApprovalDecisions` (stored) to drop bare-name.
- `services/agent/tests/unit/responder.test.ts` — adds the two required tests (different-args
  call re-prompts; parked call resumes under a fresh id via name+args) + a bare-name-not-a-key
  guard; updates the existing lookups to name+args.
- `web/oss/src/components/AgentChatSlice/{components/ToolPart,components/AgentMessage,components/AgentChatConversation,AgentChatPanel}.tsx`
  — enable Approve/Deny promptly; remove the dead `busy` prop.

## Tests

- Runner: `responder.test.ts` 16/16 green; typecheck clean for these files (a pre-existing
  `otel.ts` error from a sibling lane is unrelated).
- FE: eslint clean on the 4 changed files; no typecheck errors in the changed files.

## Not done here (in-scope of sibling lanes)

The SDK ingress (`adapters/vercel/messages.py`) does not currently emit the `{approved}`
envelope for a verbatim `approval-responded` tool part; live resume depends on whatever
decision shape reaches `extractApprovalDecisions`. The responder is correct + precise
regardless, and the resume property is pinned at the responder layer by unit tests. Logged
as D-007 in the QA decisions log.

https://claude.ai/code/session_01GYo3UEfvsZpncagqb28Mbc
