### PR TITLE
fix(agent): stop Daytona sandbox leak (credit-burner)

### DIFF
--- a/docs/design/agent-workflows/documentation/running-the-agent.md
+++ b/docs/design/agent-workflows/documentation/running-the-agent.md
@@ -169,6 +169,11 @@ These are the agent-relevant variables. The example file lists them commented ou
 - `SANDBOX_AGENT_PROVIDER`. `local` or `daytona`. Default `local`.
 - `SANDBOX_AGENT_DAYTONA_API_KEY`, `_API_URL`, `_TARGET`, `_SNAPSHOT`, `_IMAGE`,
   `_INSTALL_PI`. Daytona credentials the runner reads for the `daytona` sandbox provider.
+- `SANDBOX_AGENT_DAYTONA_AUTOSTOP_MINUTES`. Idle minutes before Daytona auto-stops a sandbox.
+  Default `15`. Leak backstop: the create object pairs `ephemeral` (auto-delete on stop) with
+  this non-zero auto-stop so a sandbox the runner leaks (a process KILL skips the per-run
+  teardown) self-reaps instead of burning credit. Values below `1` fall back to the default
+  (a `0` would re-disable auto-stop and reintroduce the leak).
 
 The `sandbox-agent` container deliberately has no `env_file`. The harness sandbox must not
 inherit the stack's secrets. The compose block comments explain this

--- a/services/agent/src/engines/sandbox_agent.ts
+++ b/services/agent/src/engines/sandbox_agent.ts
@@ -87,6 +87,37 @@ function log(message: string): void {
 
 type Log = (message: string) => void;
 
+// In-flight sandbox handles, by run. The per-run `finally` deletes the sandbox on every normal /
+// error / client-disconnect path, but a process KILL (docker stop / SIGTERM / OOM mid-run) skips
+// the `finally` entirely — so a shutdown signal handler (see `server.ts`) drains this set to
+// best-effort delete any still-running sandbox before exit. Remote (Daytona) sandboxes also carry
+// the auto-stop backstop in `provider.ts` for the cases a signal can never reach (SIGKILL/OOM).
+const inFlightSandboxes = new Set<{
+  destroySandbox?: () => Promise<unknown>;
+}>();
+
+/**
+ * Best-effort delete every sandbox currently mid-run, bounded so it can never hang shutdown.
+ * Called from the process signal handler so `docker stop` reaps remote sandboxes instead of
+ * leaking them. Each delete is independent and its own failure is swallowed; the whole sweep is
+ * raced against `timeoutMs` so a slow Daytona API call cannot block the exit.
+ */
+export async function destroyInFlightSandboxes(
+  timeoutMs = 5000,
+): Promise<void> {
+  const pending = [...inFlightSandboxes];
+  if (pending.length === 0) return;
+  const sweep = Promise.allSettled(
+    pending.map((sandbox) =>
+      Promise.resolve(sandbox.destroySandbox?.()).catch(() => {}),
+    ),
+  );
+  await Promise.race([
+    sweep,
+    new Promise<void>((resolve) => setTimeout(resolve, timeoutMs)),
+  ]);
+}
+
 const CLAUDE_STRICT_DEPLOYMENTS = new Set([
   "custom",
   "bedrock",
@@ -250,6 +281,10 @@ export async function runSandboxAgent(
         ? (deps.createCookieFetch ?? createCookieFetch)()
         : (deps.createAcpFetch ?? createAcpFetch)(),
     });
+    // Track the live handle so a shutdown signal handler can delete it if the `finally` below is
+    // skipped by a process KILL (docker stop / SIGTERM / OOM); removed in the `finally` on every
+    // normal exit so it is never double-deleted.
+    if (sandbox) inFlightSandboxes.add(sandbox);
 
     // On Daytona, push the harness login, the extension, and AGENTS.md into the remote
     // sandbox via the filesystem API (nothing secret is baked into the image). Locally
@@ -475,6 +510,7 @@ export async function runSandboxAgent(
       error,
     };
   } finally {
+    if (sandbox) inFlightSandboxes.delete(sandbox);
     await toolRelay?.stop().catch(() => {});
     await closeToolMcp?.().catch(() => {});
     await sandbox?.destroySandbox().catch(() => {});

--- a/services/agent/src/engines/sandbox_agent/provider.ts
+++ b/services/agent/src/engines/sandbox_agent/provider.ts
@@ -31,6 +31,75 @@ export function daytonaNetworkFields(
 }
 
 /**
+ * Default Daytona auto-stop backstop (minutes of idle before the runner stops the sandbox).
+ *
+ * 15 minutes is the Daytona SDK's own documented default and sits comfortably beyond a normal
+ * run (an actively prompting sandbox is BUSY, not idle, so this measures leaked-and-idle time,
+ * not total run time). Override with `SANDBOX_AGENT_DAYTONA_AUTOSTOP_MINUTES` if runs idle
+ * longer (e.g. long parked HITL turns).
+ */
+export const DEFAULT_DAYTONA_AUTOSTOP_MINUTES = 15;
+
+/**
+ * The auto-stop backstop, in minutes, that self-reaps a LEAKED Daytona sandbox.
+ *
+ * THE LEAK: the per-run teardown (`finally` in `sandbox_agent.ts`) deletes the sandbox on every
+ * normal / error / client-disconnect path, but a process KILL (docker stop / SIGTERM / SIGKILL
+ * / OOM mid-run) skips the `finally`, so the sandbox leaks. The Daytona create object pairs
+ * `ephemeral: true` (auto-DELETE on stop) with a non-zero auto-stop interval here: the upstream
+ * sandbox-agent wrapper hardcodes `autoStopInterval: 0` (auto-stop OFF) BUT spreads our create
+ * object AFTER it, so this value wins. With auto-stop > 0 an idle leaked sandbox stops on its
+ * own, which then fires the ephemeral auto-delete — so it self-reaps instead of burning credit.
+ *
+ * Returns a positive integer minute count, clamped to >= 1 (0 would re-disable auto-stop and
+ * reintroduce the leak). Invalid / non-positive env values fall back to the default.
+ */
+export function daytonaAutoStopMinutes(
+  rawValue: string | undefined = process.env
+    .SANDBOX_AGENT_DAYTONA_AUTOSTOP_MINUTES,
+): number {
+  const parsed = Number(rawValue);
+  if (!Number.isFinite(parsed) || parsed < 1) {
+    return DEFAULT_DAYTONA_AUTOSTOP_MINUTES;
+  }
+  return Math.floor(parsed);
+}
+
+/**
+ * Build the Daytona `create` object from the runner's env + the resolved run inputs.
+ *
+ * Pulled out as a pure function because the real `daytona()` provider closes over this object
+ * and constructs a Daytona client (needs API-key env), so the create fields cannot be inspected
+ * through `buildSandboxProvider`. Testing this directly is the only way to pin that the create
+ * object carries the auto-stop leak backstop (and `ephemeral`).
+ */
+export function buildDaytonaCreate(
+  piExtEnv: Record<string, string>,
+  secrets: Record<string, string>,
+  sandboxPermission: SandboxPermission | undefined,
+): Record<string, unknown> {
+  const snapshot = process.env.SANDBOX_AGENT_DAYTONA_SNAPSHOT;
+  const target = process.env.SANDBOX_AGENT_DAYTONA_TARGET;
+  return {
+    // The sandbox-agent provider always sets a default `image`, which Daytona turns into a
+    // build entry that conflicts with `snapshot`. Spreading image:undefined last
+    // suppresses that so the snapshot is used as-is.
+    ...(snapshot ? { snapshot, image: undefined } : {}),
+    ...(target ? { target } : {}),
+    ...daytonaNetworkFields(sandboxPermission),
+    envVars: daytonaEnvVars(piExtEnv, secrets),
+    // Server-side leak backstop: `ephemeral` only auto-DELETES a sandbox when it STOPS, and the
+    // sandbox-agent wrapper hardcodes `autoStopInterval: 0` (auto-stop OFF) — the two cancel out,
+    // so a sandbox the runner leaks (a process KILL skips the per-run teardown `finally`) never
+    // self-reaps and burns credit forever. Setting a non-zero auto-stop here (our create object
+    // is spread AFTER the wrapper's hardcode, so this wins) makes an idle leaked sandbox stop on
+    // its own, which then triggers the ephemeral auto-delete.
+    autoStopInterval: daytonaAutoStopMinutes(),
+    ephemeral: true,
+  };
+}
+
+/**
  * Build the sandbox-agent provider for the requested axis.
  *
  * Daytona needs an image or snapshot that carries the daemon and harness CLI. The
@@ -50,21 +119,10 @@ export function buildSandboxProvider(
 ) {
   if (sandboxId === "daytona") {
     applyDaytonaClientEnv();
-    const snapshot = process.env.SANDBOX_AGENT_DAYTONA_SNAPSHOT;
     const image = process.env.SANDBOX_AGENT_DAYTONA_IMAGE;
-    const target = process.env.SANDBOX_AGENT_DAYTONA_TARGET;
     return daytona({
       ...(image ? { image } : {}),
-      create: {
-        // The sandbox-agent provider always sets a default `image`, which Daytona turns into a
-        // build entry that conflicts with `snapshot`. Spreading image:undefined last
-        // suppresses that so the snapshot is used as-is.
-        ...(snapshot ? { snapshot, image: undefined } : {}),
-        ...(target ? { target } : {}),
-        ...daytonaNetworkFields(sandboxPermission),
-        envVars: daytonaEnvVars(piExtEnv, secrets),
-        ephemeral: true,
-      } as any,
+      create: buildDaytonaCreate(piExtEnv, secrets, sandboxPermission) as any,
     });
   }
 

--- a/services/agent/src/server.ts
+++ b/services/agent/src/server.ts
@@ -26,7 +26,10 @@ import type {
   EmitEvent,
   StreamRecord,
 } from "./protocol.ts";
-import { runSandboxAgent } from "./engines/sandbox_agent.ts";
+import {
+  destroyInFlightSandboxes,
+  runSandboxAgent,
+} from "./engines/sandbox_agent.ts";
 import { runnerInfo } from "./version.ts";
 import { isEntrypoint } from "./entry.ts";
 
@@ -202,6 +205,43 @@ export function createAgentServer(run: RunAgent = runAgent): Server {
   return createServer(createRequestListener(run));
 }
 
+/**
+ * Register a shutdown handler that best-effort deletes any in-flight sandbox(es) before exit.
+ *
+ * Without this, `docker stop` (SIGTERM) kills the process while the per-run `finally` in
+ * `runSandboxAgent` is still waiting on the harness — so the sandbox it created is never deleted
+ * and leaks (a Daytona credit-burner). The handler drains the in-flight registry, then exits.
+ *
+ * It is timeout-bounded so it can NEVER hang shutdown: `destroyInFlightSandboxes` races the
+ * deletes against its own timeout, and if the SIGTERM grace period elapses the orchestrator's
+ * SIGKILL ends the process anyway (the Daytona auto-stop backstop in `provider.ts` covers that
+ * unreachable case). The handler installs once and is idempotent against a repeated signal.
+ *
+ * Injectable (`onCleanup` / `exit`) so a test can drive it without killing the test process.
+ */
+export function registerShutdownHandler({
+  onCleanup = destroyInFlightSandboxes,
+  exit = (code: number) => process.exit(code),
+  signals = ["SIGTERM", "SIGINT"] as const,
+}: {
+  onCleanup?: (timeoutMs?: number) => Promise<void>;
+  exit?: (code: number) => void;
+  signals?: readonly NodeJS.Signals[];
+} = {}): void {
+  let shuttingDown = false;
+  const handle = (signal: NodeJS.Signals): void => {
+    if (shuttingDown) return; // a second signal must not race a second cleanup
+    shuttingDown = true;
+    process.stderr.write(
+      `[sandbox-agent] received ${signal}, cleaning up in-flight sandboxes\n`,
+    );
+    void onCleanup()
+      .catch(() => {})
+      .finally(() => exit(0));
+  };
+  for (const signal of signals) process.on(signal, handle);
+}
+
 // Only run as a server when this file is the process entry (`tsx src/server.ts`); importing
 // it (e.g. from a test) is inert.
 if (isEntrypoint(import.meta.url)) {
@@ -220,6 +260,11 @@ if (isEntrypoint(import.meta.url)) {
       `[sandbox-agent] uncaughtException: ${err.stack ?? err.message}\n`,
     );
   });
+
+  // On `docker stop` (SIGTERM) / Ctrl-C (SIGINT), delete any sandbox a run created before the
+  // process exits, so a kill mid-run does not leak the sandbox (the per-run `finally` never
+  // runs when the process is killed).
+  registerShutdownHandler();
 
   createAgentServer().listen(PORT, HOST, () => {
     process.stderr.write(

--- a/services/agent/tests/unit/sandbox-agent-provider.test.ts
+++ b/services/agent/tests/unit/sandbox-agent-provider.test.ts
@@ -8,10 +8,23 @@
  *
  * Run: pnpm test (or: pnpm exec vitest run tests/unit/sandbox-agent-provider.test.ts)
  */
-import { describe, it } from "vitest";
+import { afterEach, describe, it } from "vitest";
 import assert from "node:assert/strict";
 
-import { daytonaNetworkFields } from "../../src/engines/sandbox_agent/provider.ts";
+import {
+  DEFAULT_DAYTONA_AUTOSTOP_MINUTES,
+  buildDaytonaCreate,
+  daytonaAutoStopMinutes,
+  daytonaNetworkFields,
+} from "../../src/engines/sandbox_agent/provider.ts";
+
+const AUTOSTOP_ENV = "SANDBOX_AGENT_DAYTONA_AUTOSTOP_MINUTES";
+const previousAutoStop = process.env[AUTOSTOP_ENV];
+
+afterEach(() => {
+  if (previousAutoStop === undefined) delete process.env[AUTOSTOP_ENV];
+  else process.env[AUTOSTOP_ENV] = previousAutoStop;
+});
 
 describe("daytonaNetworkFields", () => {
   it("blocks all egress for network:off", () => {
@@ -50,5 +63,66 @@ describe("daytonaNetworkFields", () => {
 
   it("leaves the sandbox default-open when no policy is set", () => {
     assert.deepEqual(daytonaNetworkFields(undefined), {});
+  });
+});
+
+describe("daytonaAutoStopMinutes (leak backstop)", () => {
+  it("uses the env value when it is a positive integer", () => {
+    assert.equal(daytonaAutoStopMinutes("30"), 30);
+  });
+
+  it("floors a fractional env value to whole minutes", () => {
+    assert.equal(daytonaAutoStopMinutes("12.9"), 12);
+  });
+
+  it("falls back to the default when the env is unset", () => {
+    assert.equal(
+      daytonaAutoStopMinutes(undefined),
+      DEFAULT_DAYTONA_AUTOSTOP_MINUTES,
+    );
+  });
+
+  it("falls back to the default for a non-numeric env value", () => {
+    assert.equal(
+      daytonaAutoStopMinutes("soon"),
+      DEFAULT_DAYTONA_AUTOSTOP_MINUTES,
+    );
+  });
+
+  it("clamps 0 to the default so auto-stop is never re-disabled (the leak)", () => {
+    // 0 would mean auto-stop OFF, which pairs with ephemeral to leak forever — exactly the bug.
+    assert.equal(daytonaAutoStopMinutes("0"), DEFAULT_DAYTONA_AUTOSTOP_MINUTES);
+  });
+
+  it("clamps a negative env value to the default", () => {
+    assert.equal(
+      daytonaAutoStopMinutes("-5"),
+      DEFAULT_DAYTONA_AUTOSTOP_MINUTES,
+    );
+  });
+
+  it("the default is a positive backstop (auto-stop stays ON)", () => {
+    assert.ok(DEFAULT_DAYTONA_AUTOSTOP_MINUTES >= 1);
+  });
+});
+
+describe("buildDaytonaCreate (leak backstop on the create object)", () => {
+  it("carries a positive auto-stop interval + ephemeral by default (self-reaps a leak)", () => {
+    delete process.env[AUTOSTOP_ENV];
+    const create = buildDaytonaCreate({}, {}, undefined);
+    // ephemeral auto-deletes ON STOP; a non-zero auto-stop is what makes a leaked sandbox stop.
+    assert.equal(create.ephemeral, true);
+    assert.equal(create.autoStopInterval, DEFAULT_DAYTONA_AUTOSTOP_MINUTES);
+    assert.ok(
+      (create.autoStopInterval as number) > 0,
+      "auto-stop must be > 0 or the ephemeral auto-delete never fires (the leak)",
+    );
+  });
+
+  it("carries the env-configured auto-stop interval", () => {
+    process.env[AUTOSTOP_ENV] = "42";
+    const create = buildDaytonaCreate({}, {}, undefined);
+    assert.equal(create.autoStopInterval, 42);
+    assert.equal(create.ephemeral, true);
   });
 });

--- a/services/agent/tests/unit/server.test.ts
+++ b/services/agent/tests/unit/server.test.ts
@@ -11,7 +11,11 @@ import { afterEach, describe, it } from "vitest";
 import assert from "node:assert/strict";
 import type { AddressInfo } from "node:net";
 
-import { createAgentServer, type RunAgent } from "../../src/server.ts";
+import {
+  createAgentServer,
+  registerShutdownHandler,
+  type RunAgent,
+} from "../../src/server.ts";
 
 const TOKEN_ENV = "AGENTA_AGENT_RUNNER_TOKEN";
 const previousToken = process.env[TOKEN_ENV];
@@ -223,5 +227,85 @@ describe("createAgentServer", () => {
     } finally {
       await s.close();
     }
+  });
+});
+
+describe("registerShutdownHandler (sandbox-leak backstop on docker stop)", () => {
+  // Register on real, but harmless, signals so we can drive process.emit without touching SIGTERM
+  // (which would kill the test runner). The injected exit() makes the handler a no-op on exit.
+  const TEST_SIGNALS = ["SIGUSR2"] as const;
+  const registered: NodeJS.Signals[] = [];
+
+  afterEach(() => {
+    for (const signal of registered.splice(0))
+      process.removeAllListeners(signal);
+  });
+
+  function register(opts: Parameters<typeof registerShutdownHandler>[0]) {
+    registerShutdownHandler({ signals: TEST_SIGNALS, ...opts });
+    registered.push(...TEST_SIGNALS);
+  }
+
+  it("registers a listener for each shutdown signal", () => {
+    register({ onCleanup: async () => {}, exit: () => {} });
+    for (const signal of TEST_SIGNALS) {
+      assert.ok(
+        process.listenerCount(signal) >= 1,
+        `expected a listener on ${signal}`,
+      );
+    }
+  });
+
+  it("runs cleanup then exits when a signal fires", async () => {
+    let cleaned = false;
+    let exitCode: number | undefined;
+    register({
+      onCleanup: async () => {
+        cleaned = true;
+      },
+      exit: (code) => {
+        exitCode = code;
+      },
+    });
+
+    process.emit("SIGUSR2", "SIGUSR2");
+    // The handler awaits cleanup before exiting; let the microtasks settle.
+    await new Promise((resolve) => setImmediate(resolve));
+
+    assert.equal(cleaned, true, "cleanup ran");
+    assert.equal(exitCode, 0, "process exited 0 after cleanup");
+  });
+
+  it("still exits when cleanup rejects (cleanup must never block shutdown)", async () => {
+    let exitCode: number | undefined;
+    register({
+      onCleanup: async () => {
+        throw new Error("daytona delete failed");
+      },
+      exit: (code) => {
+        exitCode = code;
+      },
+    });
+
+    process.emit("SIGUSR2", "SIGUSR2");
+    await new Promise((resolve) => setImmediate(resolve));
+
+    assert.equal(exitCode, 0, "a failing cleanup does not prevent exit");
+  });
+
+  it("cleans up only once even if the signal fires repeatedly", async () => {
+    let cleanups = 0;
+    register({
+      onCleanup: async () => {
+        cleanups += 1;
+      },
+      exit: () => {},
+    });
+
+    process.emit("SIGUSR2", "SIGUSR2");
+    process.emit("SIGUSR2", "SIGUSR2");
+    await new Promise((resolve) => setImmediate(resolve));
+
+    assert.equal(cleanups, 1, "a repeated signal does not re-run cleanup");
   });
 });


### PR DESCRIPTION
## The leak

Daytona sandboxes the runner created were leaking and burning credit. 10 were found alive long after their runs ended.

The per-run teardown (`finally` in `runSandboxAgent`) deletes the sandbox on every normal / error / client-disconnect path — that part works. But a process **KILL** (`docker stop` / SIGTERM / SIGKILL / OOM mid-run) skips the `finally` entirely, so the sandbox is never deleted.

There was also no server-side backstop. The `sandbox-agent` SDK wrapper hardcodes `autoStopInterval: 0` (auto-stop **OFF**), while `ephemeral: true` only auto-deletes a sandbox **ON STOP**. Those two cancel out: a sandbox that never stops is never auto-deleted, so a leaked one self-reaps **never**.

## The fix (runner-only, two-part backstop)

**1. Server-side TTL backstop — `provider.ts`.** The Daytona create object now sets a non-zero `autoStopInterval` alongside the existing `ephemeral: true`. The wrapper spreads our create object *after* its `autoStopInterval: 0` hardcode, so our value wins. With auto-stop > 0, an idle leaked sandbox stops on its own, which then triggers the ephemeral auto-delete — it self-reaps. Configurable via a new `SANDBOX_AGENT_DAYTONA_AUTOSTOP_MINUTES` (default `15` min — the Daytona SDK's own documented default; clamped to `>= 1` so a `0` cannot re-disable auto-stop and reintroduce the leak). `autoStopInterval` measures **idle** time and an actively prompting sandbox is busy, so this does not cut live runs short. Extracted `buildDaytonaCreate` so the create object is unit-testable (the real `daytona()` provider closes over it).

**2. Shutdown signal handler — `server.ts`.** `registerShutdownHandler` deletes any in-flight sandbox(es) on SIGTERM / SIGINT before exit, so a graceful `docker stop` cleans up immediately instead of waiting on the auto-stop. It drains a new in-flight registry in `sandbox_agent.ts` (`destroyInFlightSandboxes`; sandboxes register after `startSandboxAgent`, deregister in the `finally`). The handler is timeout-bounded (5 s race) and idempotent against a repeated signal, so it can never hang shutdown — and the auto-stop backstop covers the SIGKILL/OOM cases a signal can never reach.

Resources (cpu/mem/disk) are left untouched — they are snapshot-baked in `build_snapshot.py`. **No `/run` wire change.**

## Tests

- `daytonaAutoStopMinutes` env parsing: env value, fractional floor, unset/non-numeric/`0`/negative fall back to the default.
- `buildDaytonaCreate` carries a positive `autoStopInterval` + `ephemeral` (default and env-configured).
- `registerShutdownHandler`: registers a listener per signal, runs cleanup then exits, still exits when cleanup rejects, and cleans up only once on a repeated signal.
- Full runner suite green: 265 tests + `tsc`.

https://claude.ai/code/session_01GYo3UEfvsZpncagqb28Mbc