### PR TITLE
fix(agent): land skill/error trace attrs under recognized ag.* namespaces (F-036)

### DIFF
--- a/services/agent/src/tracing/otel.ts
+++ b/services/agent/src/tracing/otel.ts
@@ -472,12 +472,14 @@ export function createAgentaOtel(
       agentSpan.setAttribute("openinference.span.kind", "AGENT");
       agentSpan.setAttribute("gen_ai.operation.name", "invoke_agent");
       agentSpan.setAttribute("gen_ai.agent.name", "pi");
-      // F-029: record which skills loaded (author + forced `_agenta.*`) on Pi's own agent span,
-      // so a local-Pi trace shows the surfaced skills, not just the author config echoed
-      // elsewhere. The set is passed from the runner via AGENTA_SKILLS_LOADED.
+      // F-029/F-036: record which skills loaded on Pi's own agent span under the recognized
+      // `ag.meta.*` namespace, so a local-Pi trace shows the surfaced skills (not just the author
+      // config echoed elsewhere) AND Agenta's OTel ingest keeps them in a first-class `ag.*` bucket
+      // rather than relocating an unrecognized `ag.agent.*` key to `ag.unsupported.*`. The set is
+      // passed from the runner via AGENTA_SKILLS_LOADED.
       if (config.skills && config.skills.length > 0) {
-        agentSpan.setAttribute("ag.agent.skills.loaded", config.skills);
-        agentSpan.setAttribute("ag.agent.skills.count", config.skills.length);
+        agentSpan.setAttribute("ag.meta.skills.loaded", config.skills);
+        agentSpan.setAttribute("ag.meta.skills.count", config.skills.length);
       }
       if (config.sessionId) {
         agentSpan.setAttribute("session.id", config.sessionId);
@@ -1014,11 +1016,14 @@ export function createSandboxAgentOtel(
     agentSpan.setAttribute("openinference.span.kind", "AGENT");
     agentSpan.setAttribute("gen_ai.operation.name", "invoke_agent");
     agentSpan.setAttribute("gen_ai.agent.name", init.harness ?? "agent");
-    // F-029: stamp the skills that actually materialized (author + forced `_agenta.*`) so a
-    // trace shows which skills loaded, not just the author config echoed on the workflow span.
+    // F-029/F-036: stamp the skills that actually materialized so a trace shows which skills
+    // loaded (not just the author config echoed on the workflow span), under the recognized
+    // `ag.meta.*` namespace. Agenta's OTel ingest strict-whitelists top-level `ag.*` keys and
+    // relocates unrecognized ones (an `ag.agent.*` key) to `ag.unsupported.*`; `ag.meta` is a
+    // free-form recognized bucket, the same place run/request metadata already lands.
     if (init.skills && init.skills.length > 0) {
-      agentSpan.setAttribute("ag.agent.skills.loaded", init.skills);
-      agentSpan.setAttribute("ag.agent.skills.count", init.skills.length);
+      agentSpan.setAttribute("ag.meta.skills.loaded", init.skills);
+      agentSpan.setAttribute("ag.meta.skills.count", init.skills.length);
     }
     const sessionId = input.sessionId ?? init.sessionId;
     if (sessionId) {
@@ -1171,10 +1176,13 @@ export function createSandboxAgentOtel(
   function recordError(message: string, errorProvider?: string): void {
     const text = message || "agent run failed";
     const stamp = (span: Span): void => {
-      span.setAttribute("ag.error.message", text);
+      // F-036: use the recognized `ag.exception.*` namespace (a free-form recognized bucket)
+      // rather than `ag.error.*`, which Agenta's OTel ingest relocates to `ag.unsupported.*`
+      // (unrecognized top-level `ag.*` key). `message` mirrors the OTel exception event below.
+      span.setAttribute("ag.exception.message", text);
       const failedProvider = errorProvider ?? provider;
       if (failedProvider)
-        span.setAttribute("ag.error.provider", failedProvider);
+        span.setAttribute("ag.exception.provider", failedProvider);
       span.recordException({ name: "AgentRunError", message: text });
       span.setStatus({ code: SpanStatusCode.ERROR, message: text });
     };

--- a/services/agent/tests/unit/otel-skills-error.test.ts
+++ b/services/agent/tests/unit/otel-skills-error.test.ts
@@ -1,14 +1,18 @@
 /**
  * Unit tests for the tracing additions in `tracing/otel.ts`:
  *
- *  - F-029: the loaded skills (author + forced `_agenta.*`) are stamped on the agent span via
- *    `ag.agent.skills.loaded` / `ag.agent.skills.count`, on BOTH the sandbox-agent ACP tracer
+ *  - F-029/F-036: the loaded skills (author + forced `_agenta.*`) are stamped on the agent span
+ *    via `ag.meta.skills.loaded` / `ag.meta.skills.count`, on BOTH the sandbox-agent ACP tracer
  *    (`createSandboxAgentOtel`, non-Pi / Daytona) and Pi's own extension tracer
- *    (`createAgentaOtel`, local Pi).
- *  - F-030: `recordError` stamps the user-facing error message + the provider that failed plus
- *    an exception event on the agent span, so an error run's trace carries the same diagnostic
- *    the HTTP response does. When the harness self-instruments (no owned span) it emits a
- *    standalone `agent_error` span so the failure still reaches the trace.
+ *    (`createAgentaOtel`, local Pi). The `ag.meta.*` namespace is a recognized `ag.*` bucket, so
+ *    Agenta's OTel ingest keeps the attributes there rather than relocating an unrecognized
+ *    `ag.agent.*` key into `ag.unsupported.*` (the F-036 namespace wrinkle).
+ *  - F-030/F-036: `recordError` stamps the user-facing error message + the provider that failed
+ *    plus an exception event on the agent span, so an error run's trace carries the same
+ *    diagnostic the HTTP response does. The attributes use the recognized `ag.exception.*`
+ *    namespace (not `ag.error.*`, which ingest would relocate to `ag.unsupported.*`). When the
+ *    harness self-instruments (no owned span) it emits a standalone `agent_error` span so the
+ *    failure still reaches the trace.
  *
  * Spans export over OTLP from a module-level provider, so we spy on the OTel API tracer and
  * capture the attributes/exceptions each span records, rather than wiring an in-memory exporter.
@@ -93,23 +97,53 @@ afterEach(() => {
 });
 
 describe("otel skills + error tracing", () => {
-  it("stamps loaded skills on the sandbox-agent agent span (F-029)", () => {
+  it("stamps loaded skills (author + builtins) on the sandbox-agent agent span (F-029/F-036)", () => {
     const spans = spyTracer();
     const otel = createSandboxAgentOtel({
       harness: "claude",
       model: "anthropic/claude-haiku",
       emitSpans: true,
+      // The runner stamps exactly the materialized list it is given: an author skill AND a
+      // forced `_agenta.*` platform skill both appear in `loaded` (F-036 builtins-in-loaded).
       skills: ["weather-oracle", "_agenta.agenta-getting-started"],
     });
     otel.start({ prompt: "hi" });
 
     const agentSpan = spans.find((s) => s.name === "invoke_agent");
     expect(agentSpan).toBeTruthy();
-    expect(agentSpan?.attributes["ag.agent.skills.loaded"]).toEqual([
+    expect(agentSpan?.attributes["ag.meta.skills.loaded"]).toEqual([
       "weather-oracle",
       "_agenta.agenta-getting-started",
     ]);
-    expect(agentSpan?.attributes["ag.agent.skills.count"]).toBe(2);
+    expect(agentSpan?.attributes["ag.meta.skills.count"]).toBe(2);
+  });
+
+  it("uses recognized ag.* namespaces, never ag.agent.* / ag.error.* (F-036)", () => {
+    // Agenta's OTel ingest strict-whitelists top-level `ag.*` keys against a known-attribute
+    // schema and relocates any unrecognized key (e.g. an `ag.agent.*` or `ag.error.*` key) into
+    // `ag.unsupported.*`. Pin that skills + error attributes use the recognized `ag.meta.*` and
+    // `ag.exception.*` buckets so they are never demoted to `ag.unsupported.*`.
+    const spans = spyTracer();
+    const otel = createSandboxAgentOtel({
+      harness: "claude",
+      model: "anthropic/claude-haiku",
+      emitSpans: true,
+      skills: ["weather-oracle"],
+    });
+    otel.start({ prompt: "hi" });
+    otel.recordError("model authentication failed", "anthropic");
+
+    const agentSpan = spans.find((s) => s.name === "invoke_agent");
+    const keys = Object.keys(agentSpan?.attributes ?? {});
+    // No demoted-to-unsupported namespaces.
+    expect(keys.some((k) => k.startsWith("ag.agent."))).toBe(false);
+    expect(keys.some((k) => k.startsWith("ag.error."))).toBe(false);
+    expect(keys.some((k) => k.startsWith("ag.unsupported."))).toBe(false);
+    // The recognized homes are present.
+    expect(agentSpan?.attributes["ag.meta.skills.loaded"]).toEqual([
+      "weather-oracle",
+    ]);
+    expect(agentSpan?.attributes["ag.exception.message"]).toBeDefined();
   });
 
   it("omits the skills attributes when no skills loaded", () => {
@@ -121,8 +155,8 @@ describe("otel skills + error tracing", () => {
     });
     otel.start({ prompt: "hi" });
     const agentSpan = spans.find((s) => s.name === "invoke_agent");
-    expect(agentSpan?.attributes["ag.agent.skills.loaded"]).toBeUndefined();
-    expect(agentSpan?.attributes["ag.agent.skills.count"]).toBeUndefined();
+    expect(agentSpan?.attributes["ag.meta.skills.loaded"]).toBeUndefined();
+    expect(agentSpan?.attributes["ag.meta.skills.count"]).toBeUndefined();
   });
 
   it("stamps loaded skills on Pi's own agent span (F-029, local Pi)", () => {
@@ -142,11 +176,11 @@ describe("otel skills + error tracing", () => {
       await handlers["before_agent_start"]?.({ prompt: "hi" });
       await handlers["agent_start"]?.({});
       const agentSpan = spans.find((s) => s.name === "invoke_agent");
-      expect(agentSpan?.attributes["ag.agent.skills.loaded"]).toEqual([
+      expect(agentSpan?.attributes["ag.meta.skills.loaded"]).toEqual([
         "weather-oracle",
         "_agenta.agenta-getting-started",
       ]);
-      expect(agentSpan?.attributes["ag.agent.skills.count"]).toBe(2);
+      expect(agentSpan?.attributes["ag.meta.skills.count"]).toBe(2);
     })();
   });
 
@@ -164,10 +198,10 @@ describe("otel skills + error tracing", () => {
     );
 
     const agentSpan = spans.find((s) => s.name === "invoke_agent");
-    expect(agentSpan?.attributes["ag.error.message"]).toContain(
+    expect(agentSpan?.attributes["ag.exception.message"]).toContain(
       "model authentication failed",
     );
-    expect(agentSpan?.attributes["ag.error.provider"]).toBe("anthropic");
+    expect(agentSpan?.attributes["ag.exception.provider"]).toBe("anthropic");
     expect(agentSpan?.exceptions.length).toBe(1);
     expect(agentSpan?.exceptions[0].message).toContain(
       "model authentication failed",
@@ -196,10 +230,10 @@ describe("otel skills + error tracing", () => {
 
     const errSpan = spans.find((s) => s.name === "agent_error");
     expect(errSpan).toBeTruthy();
-    expect(errSpan?.attributes["ag.error.message"]).toContain(
+    expect(errSpan?.attributes["ag.exception.message"]).toContain(
       "model authentication failed",
     );
-    expect(errSpan?.attributes["ag.error.provider"]).toBe("anthropic");
+    expect(errSpan?.attributes["ag.exception.provider"]).toBe("anthropic");
     expect(errSpan?.exceptions.length).toBe(1);
     expect(errSpan?.ended).toBe(true);
   });
@@ -214,6 +248,6 @@ describe("otel skills + error tracing", () => {
     otel.start({ prompt: "hi" });
     otel.recordError("some failure");
     const agentSpan = spans.find((s) => s.name === "invoke_agent");
-    expect(agentSpan?.attributes["ag.error.provider"]).toBe("anthropic");
+    expect(agentSpan?.attributes["ag.exception.provider"]).toBe("anthropic");
   });
 });


### PR DESCRIPTION
## Context

The Wave-1 agent tracing fix (PR #4855, F-029/F-030) added skill and error attributes to the agent span, but it stamped them as `ag.agent.skills.loaded` / `ag.agent.skills.count` and `ag.error.message` / `ag.error.provider`. Live QA (F-036) found these land under `ag.unsupported.*` in the trace viewer (e.g. `ag.unsupported.agent.skills.loaded`, `ag.unsupported.error.message`).

Root cause: Agenta's OTel ingest (`api/oss/src/core/tracing/utils/attributes.py` `initialize_ag_attributes`) strict-whitelists top-level `ag.*` keys against the `AgAttributes` pydantic model and relocates any unrecognized key into an `ag.unsupported.*` bucket. `agent` and `error` are not fields on that model, so both attribute groups were demoted. The data was correct and queryable, just mis-namespaced.

This change moves the attributes to existing recognized free-form `ag.*` buckets, so they land first-class with no api/SDK schema change:

- skills: `ag.agent.skills.{loaded,count}` -> `ag.meta.skills.{loaded,count}` (`ag.meta` is the recognized home for run/request metadata, the same place model/system/response info lands)
- error: `ag.error.{message,provider}` -> `ag.exception.{message,provider}` (`ag.exception` is the recognized error bucket; `message` mirrors the OTel exception event)

Both `ag.meta` and `ag.exception` pass ingest validation untouched (they are free-form `Meta` / `Data` dicts), so no api-side schema change is needed. Registering net-new `ag.agent.*` / `ag.error.*` namespaces would mean coordinated edits to the SDK pydantic model + the api validator + tests + back-compat — non-trivial for a pure-naming polish where the info is already present, so it was deliberately not done.

## Scope / risk

- Runner-only: `services/agent/src/tracing/otel.ts` (three attribute-name changes across the Pi extension tracer and the sandbox-agent ACP tracer) plus its unit test.
- No `/run` wire change (the golden wire contract is untouched; skill names ride an internal env var, errors are span-side only).
- No api, SDK, or FE change. No live runner restart.
- Behavior risk: a downstream trace query that hard-codes `ag.unsupported.agent.skills.*` or `ag.unsupported.error.*` would need to read the new keys. No such query exists in the repo (grep of code + interface inventory is clean; only QA scratch docs referenced the old names, now updated).

### Not fixed here (reported, out of scope): builtins-in-loaded

F-036 also noted the forced `_agenta.*` platform skill did not appear in the `loaded` list on a `pi_agenta` run (only the author skill). This is NOT a runner trace bug: the runner faithfully stamps exactly the materialized `request.skills` it receives. The platform default skill (`_agenta.agenta-getting-started`) is `@ag.embed`-ed only into the DEFAULT agent config template (`services/oss/src/agent/schemas.py`), so a custom config drops it and it never reaches the wire. The runner has no independent forced-skill installation and treats `pi_agenta` like `pi_core` for skills, so it cannot stamp a skill it never received. Force-injecting the platform skill for every `pi_agenta` run regardless of config is a server-side concern (the platform-skill seeding "separate workstream" noted in `harnesses.py` / `agenta_builtins.py`) and lives outside this lane's `otel.ts` boundary. Recorded as decision D-016.

## How to QA

Prerequisites: Node 24 on PATH; from `services/agent`.

1. Run the focused unit test:
   ```
   pnpm exec vitest run tests/unit/otel-skills-error.test.ts
   ```
   Expected: 7 passed. The new `uses recognized ag.* namespaces, never ag.agent.* / ag.error.* (F-036)` test asserts the agent span carries no `ag.agent.*`, `ag.error.*`, or `ag.unsupported.*` keys, and that `ag.meta.skills.loaded` + `ag.exception.message` are present.
2. Full suite + typecheck:
   ```
   pnpm test && pnpm run typecheck
   ```
   Expected: 268 passed, tsc clean.
3. Live (orchestrator, optional): run a `pi_agenta` skill cell and an error cell, fetch the trace via `GET /api/preview/tracing/traces/{trace_id}`, and grep span attributes — the loaded skills now appear under `ag.meta.skills.*` and the error under `ag.exception.*`, not under `ag.unsupported.*`.

Edge cases covered by tests: no skills -> attributes omitted; `recordError` provider falls back to the init model provider; local-Pi self-instrument path stamps Pi's own span (skills) and emits a standalone `agent_error` span (error).

https://claude.ai/code/session_01GYo3UEfvsZpncagqb28Mbc