### PR TITLE
fix(agent): close LOW-severity backend findings (LOW-5/6/7, F-028)

### DIFF
--- a/docs/design/agent-workflows/interfaces/cross-service/service-to-agent-runner.md
+++ b/docs/design/agent-workflows/interfaces/cross-service/service-to-agent-runner.md
@@ -49,8 +49,7 @@ group by job:
   "secrets":        { "OPENAI_API_KEY": "..." },   // the only vault-key channel on the wire
 
   // turn
-  "prompt":   "...",                     // explicit latest turn; falls back to last user msg
-  "messages": [ /* neutral ChatMessage[] */ ],
+  "messages": [ /* neutral ChatMessage[] */ ],  // the only turn channel; the runner derives the latest user turn (no separate `prompt` field on the wire)
 
   // tools + skills (see runner-to-tool-callback.md, runner-to-mcp-server.md)
   "tools":        [ "read", "edit" ],    // built-in tool names

--- a/docs/design/agent-workflows/interfaces/in-service/sandbox-permission.md
+++ b/docs/design/agent-workflows/interfaces/in-service/sandbox-permission.md
@@ -16,14 +16,18 @@ a run from passing to failing, so the matrix is the contract.
     "allowlist": []                // CIDR ranges; honored when mode is "allowlist"
   },
   "filesystem": null,              // "on" | "readonly" | "off"; declared, enforced nowhere
-  "enforcement": "strict"          // "strict" (fail if it cannot be applied) | "best_effort"
+  "enforcement": "strict"          // "strict" (fail if it cannot be applied) | "best_effort"; omitted defaults to "strict"
 }
 ```
 
 It is optional on `AgentConfig`. An unset value never reaches the wire, so existing configs
 are unaffected. The default config the form pre-fills sets `network.mode: "on"` and
 `enforcement: "strict"`. The wire form is the nested camelCase `sandboxPermission` object on
-the `/run` payload.
+the `/run` payload. The Python schema (`WireSandboxPermission.enforcement`) defaults
+`enforcement` to `"strict"`, and the runner now matches: `buildRunPlan` treats an omitted
+`enforcement` as strict (`enforcement !== "best_effort"`), so only an explicit `"best_effort"`
+opts out of the hard-guarantee check (Codex LOW-6). The live service always fills `"strict"`;
+this only aligns a direct runner caller.
 
 The field-by-field narrative of these shapes lives in
 [Agent config schema](../public-edge/agent-config-schema.md#sandbox_permission). This page

--- a/docs/design/agent-workflows/projects/qa/matrix.md
+++ b/docs/design/agent-workflows/projects/qa/matrix.md
@@ -7,7 +7,16 @@ each one and what a pass looks like. See `README.md` for how to configure and ru
 ## Legend
 
 Environments: `E1` service / in-process Pi, `E2` service / sandbox-agent local, `E3` service / sandbox-agent
-Daytona, `E4` local SDK backend.
+Daytona, `E4` SDK-direct over the local Node runner CLI (`SandboxAgentBackend(cwd=services/agent)`).
+
+> **E4 is NOT in-process Pi.** The in-process SDK backend was renamed `InProcessPiBackend` ->
+> `LocalBackend` and is currently a stub (`create_sandbox` / `create_session` raise
+> `NotImplementedError`; in-process Pi and Claude are a later phase — see F-018 in
+> `findings.md`). The only working SDK-direct path is `SandboxAgentBackend` driving the
+> TypeScript runner CLI as a subprocess. So an "E4" cell exercises the same wire and runner as
+> E2, just invoked from a host script instead of the service. The older "E1 in-process Pi
+> contrast" notes refer to a direct-Pi batch run outside the SDK; that contrast is now blocked
+> on `LocalBackend` from the SDK.
 
 Harnesses: `pi`, `agenta`, `claude`.
 
@@ -23,23 +32,29 @@ Cell codes:
 These come from the code and the prior `feature-matrix-test.md` run. They are the reason
 the full product is much smaller than it looks.
 
-1. **In-process Pi does not support Claude.** `InProcessPiBackend.supported_harnesses` is
-   `{pi, agenta}`. So every `claude` cell on E1 is `n/a`. Claude only runs on sandbox-agent (E2, E3)
-   or on E4 when the script uses `SandboxAgentBackend`.
+1. **In-process Pi does not support Claude.** The in-process Pi path is harness `{pi, agenta}`
+   only; Claude only runs on sandbox-agent (E2, E3). So every `claude` cell on E1 is `n/a`.
+   E4 (SDK-direct) runs through `SandboxAgentBackend`, which does support Claude, so a `claude`
+   E4 cell is valid (modulo the Anthropic-key precondition). The in-process SDK backend that the
+   old E1 contrast used (`InProcessPiBackend`) was renamed `LocalBackend` and is now a stub, so
+   it cannot be the E4 backend (F-018).
 2. **Claude is blocked on an Anthropic key.** The harness is wired but returns HTTP 500
    `claude: model authentication failed` with no Anthropic key in the project vault. Every
    `claude` cell is `blocked:anthropic-key` until a key is added.
 3. **Builtin tools are a Pi concept.** `pi` and `agenta` deliver Pi builtins (`bash`,
    `read`, `write`, `edit`). Claude has no Pi builtins; it gets tools over MCP only. So
    builtin-tool cells on `claude` are `n/a`.
-4. **Skills are an Agenta-harness feature.** The SDK only wires the `skills` field for
-   `AgentaAgentConfig`. A plain `pi` run does not load skills, and Claude has no skill
-   concept here. So skill cells are `valid` on `agenta` and `n/a` on `pi` and `claude`.
-   Confirm this during the run: if a plain `pi` run can be made to load a skill, that is a
-   finding, not an assumption. As of 2026-06-24 the `skills` field carries an author-supplied
-   `SkillConfig` (inline or `@ag.embed`), so F-003 is unblocked: skills are no longer
-   forced-only. On Claude the runner drops them by design (it materializes skills for Pi only)
-   and now logs a warning when it does (F-015, resolved 2026-06-24).
+4. **Skills load on either Pi harness, not just `agenta`.** As of 2026-06-24 the `skills`
+   field carries an author-supplied `SkillConfig` (inline or `@ag.embed`) on any Pi-family
+   harness, so F-003 is unblocked: skills are no longer forced-only and are no longer an
+   `agenta`-only feature. The `pi_agenta` harness additionally *forces* `read`+`bash` (which is
+   what makes Pi surface a skill), but a plain `pi_core` run that supplies the same forced
+   tools loads and invokes author skills too — verified live 2026-06-25 on `pi_core` (F-028).
+   So skill cells are `valid` on both `pi` and `agenta` (the runner materializes skills for the
+   `pi` ACP agent that both drive). On Claude the runner drops them by design (it materializes
+   skills for Pi only) and logs a warning when it does (F-015, resolved 2026-06-24), so Claude
+   skill cells stay `n/a`/`dropped`. The remaining `agenta`-vs-`pi` difference is the forced
+   tool set, not skill support.
 5. **MCP is delivered to non-Pi harnesses only, and is flag-gated.** Per `ground-truth.md`
    MCP delivery exists through the stdio bridge for non-Pi harnesses, and in-process Pi
    reports `mcpTools: false`. So MCP is `valid` on `claude` (sandbox-agent) and `n/a` or
@@ -75,14 +90,14 @@ this QA program must drive. `?` means status unknown until run.
 | code tools | valid | valid | blocked:anthropic-key |
 | gateway tools (Composio) | blocked:composio-connection | blocked:composio-connection | blocked:composio-connection + anthropic-key |
 | MCP (stdio) | n/a? verify | n/a? verify | blocked:mcp-flag + stdio-server + anthropic-key |
-| skills without code | n/a | valid (forced) | n/a |
-| skills with code | n/a | valid | n/a |
-| skill invocation (author config) | n/a | valid (inline + embed) | dropped by design (warns; F-015 resolved) |
+| skills without code | valid | valid (forced) | n/a |
+| skills with code | valid | valid | n/a |
+| skill invocation (author config) | valid (with forced read+bash; F-028) | valid (inline + embed) | dropped by design (warns; F-015 resolved) |
 | client tools | n/a on /invoke | n/a on /invoke | n/a on /invoke |
 
 ### Valid cell x environment (where each valid capability should run)
 
-| Capability / harness | E1 in-proc Pi | E2 sandbox-agent local | E3 sandbox-agent Daytona | E4 local SDK |
+| Capability / harness | E1 in-proc Pi | E2 sandbox-agent local | E3 sandbox-agent Daytona | E4 SDK-direct (SandboxAgentBackend CLI) |
 | --- | --- | --- | --- | --- |
 | code tool / pi | valid | valid | valid | valid |
 | code tool / agenta | valid | valid | valid | valid |
@@ -383,6 +398,12 @@ clean contrast that confirms F-001 is sandbox-agent-specific: in-process Pi hono
 (reply ended with the injected `ZK-9-END`), the ACP path drops it (`sandbox_agent.ts:875`). Code tools
 also pass natively in-process (python3 is present in that path).
 
+> This contrast batch ran Pi in-process directly, not through the SDK backend. The SDK's
+> in-process backend (`InProcessPiBackend`, now renamed `LocalBackend`) is a stub today
+> (`NotImplementedError`), so this exact contrast can no longer be driven from the SDK — only
+> the `SandboxAgentBackend` SDK-direct path is live (F-018). Reproduce the contrast outside the
+> SDK if you need it again.
+
 | Capability / harness | E1 in-process Pi |
 | --- | --- |
 | chat / pi, agenta | pass |
@@ -417,3 +438,424 @@ environment precondition, like `blocked:anthropic-key`, not a skills defect). Sk
 correct up to that boundary: the skill materializes into the Daytona sandbox; only the model
 turn cannot run. For Claude the drop is by design (the SDK path can't load `SKILL.md`); the
 silent-drop observability gap is F-015.
+
+## Live run results — SDK / API surface (2026-06-25)
+
+Run against `localhost:8280` (compose project `agenta-ee-dev-wp-b2-rendering`, `services` →
+`AGENTA_AGENT_RUNNER_URL=http://sandbox-agent:8765`, so the service path is E2 sandbox-agent
+local), commit `51e4c9e8e7`. The `examples/python/hotel_agent/draft/.env` API key
+(`N1twS5YQ`) is bound to the **hotel-agent** project (`019e8df5-635d-…`, OpenAI key only) — NOT
+the Default project, as the 2026-06-25 re-run corrected (see F-019). The `?project_id` on
+`/invoke` routes the call but credential/connection resolution always reads the bound project's
+vault. Model `openai/gpt-4o-mini`. Captures in
+`qa/runs/E2__*.json`. **Wire-value change since the prior run:** the harness values are now
+`pi_core` / `pi_agenta` / `claude` (the old `pi`/`agenta` return `not a valid HarnessType`),
+and a bare `model: "gpt-4o-mini"` no longer resolves a key — the model must carry a provider
+(`openai/gpt-4o-mini` or the structured `{provider, model}`) or no credential is injected
+(F-017). `append_system`/`system` moved from `harness_options.pi.*` to
+`harness_kwargs.pi_core.*` (both Pi-family harnesses read the `pi_core` slice).
+
+| Cell (capability / harness) | E2 service /invoke | E4 SDK-direct | Triage | Notes |
+| --- | --- | --- | --- | --- |
+| chat+instructions / pi_core | pass | pass | — | `PONG`; E4 `E4-PONG` via `SandboxAgentBackend` over the local CLI |
+| chat+instructions / pi_agenta | pass | n/t | — | `PONG` |
+| instructions obeyed / pi_agenta | pass | n/t | — | agents_md forced reply `INSTR-OBEYED-88` |
+| model override (structured ModelRef) / pi_core | pass | n/t | — | `{provider:openai, model:gpt-4o-mini}` → `STRUCT-OK`; key resolves |
+| auth: Agenta-managed OpenAI / pi_core, pi_agenta | pass | pass | — | connection→key resolution injects the OpenAI key (provider-qualified model) |
+| builtin bash / pi_core | pass | n/t | — | `QA-BASH-x86_64` (unguessable `uname -m`) |
+| builtin bash (forced) / pi_agenta | pass | n/t | — | `QA-BASH-x86_64`; bash forced for the agenta harness |
+| append_system / pi_core | pass | pass | — | `ZK-9-END` / `E4-ZK-9`; **F-001 fix confirmed live** on sandbox-agent |
+| system (replace base prompt) / pi_core | pass | n/t | — | `SYS-REPLACED-77` |
+| code tool (python) / pi_core, pi_agenta | **fail** | **fail** | escalate | `Code tools are not supported by the sidecar.` returned as a 200 tool result; by-design gate (F-016) |
+| auth: Agenta-managed Anthropic / pi_core | blocked | n/t | env | 500 `model authentication failed`; **the QA key is bound to hotel-agent (only OpenAI), NOT Default** (F-019 re-run) |
+| chat / claude | blocked | n/t | env | same: needs a Default- or pi-agents-scoped key; both have a real Anthropic vault key (F-019 re-run) |
+| gateway tool (Composio) / pi_core, claude | blocked | n/t | env | 500 `Gateway tool resolution failed (HTTP 404)`; `github-w9g` is in Default, the hotel-agent key can't see it (F-019 re-run) |
+| MCP (stdio) / claude | blocked | n/t | env | `AGENTA_AGENT_ENABLE_MCP=false` + Claude credential-blocked (F-019) |
+| HITL approval round-trip (park→approve→resume) | blocked + SAME break as F-024 | n/t | env + architectural | `/invoke` is headless (no gate); `/messages` emits `tool-approval-request` but answers the gate inline with a `reject` → tool error, not a true suspend (F-019 re-run; characterized statically, feeds HITL design) |
+
+`n/t` = not tested (equivalent cell already covered; E4 sampled chat + append_system to prove
+the SDK-direct path, which uses the same wire and runner). The `/messages` SSE path was
+verified working on Pi (Vercel `start`/`text-delta`/`finish`/`[DONE]` chunks) — the transport
+the HITL round-trip rides — but the gate-raising harness (Claude) is unavailable.
+
+**Green (proven end-to-end with an unguessable token):** chat, instructions, structured model
+override, Agenta-managed OpenAI auth (connection→key injection), builtin bash (real `uname -m`),
+`append_system` (F-001 regression now green on sandbox-agent), `system` replace, and the
+`/messages` SSE transport — on both `pi_core` and `pi_agenta`, on E2 and (sampled) E4.
+
+**New findings this pass:** F-016 (code-tool sidecar gate, escalate), F-017 (bare model string
+→ no credential, defer), F-018 (E4 `LocalBackend` is a stub; SDK-direct works via
+`SandboxAgentBackend`, fix-now doc), F-019 (Claude/Anthropic/gateway/MCP/HITL all blocked on
+per-project credential access, environmental).
+
+## Live run results — SDK / API surface re-run (2026-06-25, second pass)
+
+Run against `localhost:8280` via the box IP (`http://144.76.237.122:8280`), compose project
+`agenta-ee-dev-wp-b2-rendering`, commit `2389401ac3` (the `f8cfee3908` sidecar-uri commit on top).
+E2 sandbox-agent local. Key: the hotel-agent `.env` API key (OpenAI-only vault, project
+`019e8df5-635d-…`). Model `openai/gpt-4o-mini` (cheap). Both entrypoints exercised. Captures:
+`runs/E2_2026-06-25__*`.
+
+**Wire-contract changes since the prior pass:** (1) the `sandbox` per-run field is GONE — the
+sidecar provider (local/daytona) is configured by the sidecar's OWN env; an optional `uri` routes
+to a sidecar, allowlist-gated by `AGENTA_AGENT_RUNNER_URI_ALLOWLIST` (default empty = off; E2 just
+uses the env-var `AGENTA_AGENT_RUNNER_URL` fallback). (2) the `code` tool wire field is `script`
+(+`input_schema`), NOT `code`/`parameters` — the old shape 500s at config validation. (3) http MCP
+is now ENABLED and stdio DISABLED-fail-loud — but ONLY on the Claude branch (F-032).
+
+| Cell (capability / harness) | /invoke (batch) | /messages (SSE) | Triage | Notes |
+| --- | --- | --- | --- | --- |
+| chat+instructions / pi_core | pass | pass | — | `PONG`; SSE emits start/text-delta(P,ONG)/finish/[DONE] + `sessionId` |
+| chat+instructions / pi_agenta | pass | n/t | — | `PONG` |
+| instructions obeyed / pi_agenta | pass | pass | — | `INSTR-OBEYED-7K2Q` / `MSG-INSTR-5T8` |
+| model override (structured ModelRef) / pi_core | pass | n/t | — | `{provider:openai, model:gpt-4o-mini}` → `STRUCT-OK-9X4` |
+| model resolution matches config | pass | pass | — | LLM span `gen_ai.system=openai`, `request.model=gpt-4o-mini`; cost confirms (F-031) |
+| append_system / pi_core | pass | n/t | — | `ZK-9-END3`; F-001 stays green; the text is echoed in the trace |
+| system (replace) / pi_core | pass | n/t | — | `SYS-REPLACED-77Q` |
+| builtin bash / pi_core, pi_agenta | pass | pass | — | `QA-BASH-x86_64` (real `uname -m`); SSE shows tool-input/tool-output parts |
+| code tool (python) / pi_core | **fail-loud 500** | **error part** | verify+docs | `Code tools are not supported by the sidecar.` — NO LONGER a silent 200 (F-027, F-016 improved) |
+| bare model string (no provider) / pi_core | fail-loud 500 | n/t | — | `needs a provider prefix` — F-017 resolved, confirmed |
+| skills (inline author SkillConfig) / pi_agenta | pass | n/t | — | `SKILL-LOADED-7Q42-OK`; runner log `skills: weather-oracle` |
+| skills (inline author SkillConfig) / **pi_core** | **pass** | n/t | matrix-fix | token present on PLAIN pi_core — matrix rule 4 says n/a (F-028) |
+| skills negative control / pi_agenta | pass | n/t | — | no skills → no token |
+| skills with code (bundled script) / pi_agenta | **fail** | n/t | open | script materializes but model can't resolve `scripts/code.py` relative path (F-008 still live) |
+| right-provider-on-error / pi_core, claude | pass | pass | — | `pi_core:`/`claude: model authentication failed — … Anthropic key` (F-031) |
+| Agenta-managed Anthropic / pi_core, claude | blocked (env) | blocked | env | hotel-agent vault has no Anthropic key (F-019); resolution wiring correct |
+| gateway tool (Composio) / pi_core | blocked (500) | n/t | env | `Gateway tool resolution failed (HTTP 404)` — github-tvn is pi-agents', not hotel-agent (F-019) |
+| user MCP (stdio) / pi_core | **silent-drop 200** | n/t | defer | dropped with no log, no error on the Pi family (F-032); stdio-fail-loud is Claude-only |
+| user MCP (http) / pi_core | **silent-drop 200** | n/t | defer | same; http-MCP-enabled is Claude-only and credential-blocked (F-032, F-019) |
+| internal gateway-tool MCP / claude | blocked (env) | n/t | env | Claude credential-blocked; on Pi gateway rides the Pi extension, not MCP |
+| HITL approval / claude | blocked (env) | n/t | env | Claude credential-blocked; `/invoke` headless anyway (F-019) |
+
+**/invoke vs /messages — they agree.** Both entrypoints return the same assistant content for the
+same cell. `/messages` default (Accept: application/json) returns the SAME batch JSON as `/invoke`
+PLUS a `session_id`. `/messages` with `Accept: text/event-stream` returns the true AI SDK v6 Vercel
+UI Message Stream: `start`(+sessionId)→`start-step`→`text-start`→`text-delta`…→`text-end`→
+`finish-step`→`finish`(usage+traceId)→`[DONE]`, with tool runs adding
+`tool-input-start`/`tool-input-available`/`tool-output-available` parts. Errors differ correctly by
+contract: `/invoke` returns HTTP 500 with the message in the envelope; `/messages` SSE returns HTTP
+200 with an `error` stream part (`errorText: "Agent run failed: <same message>"`) then `[DONE]`.
+
+**TRACING (verified via `GET /api/preview/tracing/traces/{trace_id}`).** Traces ARE generated for
+every run and carry a rich nested tree: `_agent` (workflow) → `invoke_agent` (AGENT) → `turn N`
+(CHAIN) → `chat <model>` (LLM) + `execute_tool <name>` (TOOL). The runner's separate OTLP batch
+lands under the workflow trace via traceparent. **Present:** provider+model on the LLM span
+(`gen_ai.system=openai`, `request.model`/`response.model=gpt-4o-mini`, `response.id`,
+`finish_reasons`); the full config echo on `_agent` (`agent.model`, `agent.harness`,
+`harness_kwargs.pi_core.append_system` TEXT, `agent.tools`, `agent.skills` config); per-tool spans
+(`gen_ai.tool.name=bash`, `tool.call.id`); token+cost roll-up at every level (incl.
+`cache_read_input_tokens`). **Missing (findings):** (a) no skill-USED/loaded signal and no
+forced/platform `_agenta` skills in the trace — only the author skill CONFIG echo (F-029); (b)
+error runs carry only `ag.metrics.errors.cumulative=1` with NO message/provider/exception event and
+NO nested spans — the diagnostic text lives only in the HTTP body / SSE error part (F-030).
+
+**New findings this pass:** F-027 (code tools now fail-loud, F-016 silent-200 fixed), F-028
+(author skills load on plain pi_core; matrix rule 4 wrong), F-029 (skills invisible in traces
+beyond config echo), F-030 (error runs trace only a count, no message), F-031 (right-provider +
+model-resolution confirmed; Claude alias now needs a provider prefix as an F-017 side-effect),
+F-032 (Pi-family user MCP dropped silently, no log/error). Still blocked on credentials (F-019):
+Agenta-managed Anthropic/Claude, Composio gateway, http-MCP-on-Claude, stdio-fail-loud-on-Claude,
+HITL — all need a Default/pi-agents-scoped API key (not minted this read-only pass). Self-managed
+Anthropic stays untested by design: it has no per-request channel (must be baked into the sidecar
+env), and this pass did not bake the user-provided raw key — limitation documented, not forced.
+
+---
+
+## Model-authentication axis
+
+A fourth axis, orthogonal to environment, harness, and capability. It tests that the right
+credential reaches the right harness — no more, no less — and that the model that ran is the
+one that was asked for.
+
+**Use cheap models for all model-auth QA.** Use `gpt-4o-mini` or `o4-mini` for the Pi/OpenAI
+cells and `claude-haiku-4-5-20251001` (or the alias `haiku`) for the Claude/Anthropic cells.
+Never use GPT-4o, Sonnet, or Opus for routine QA runs.
+
+### Terminology
+
+- **Agenta-managed** (`connection.mode = agenta`): the credential lives in the project vault;
+  Agenta resolves it and injects it. The user stores the key once; the agent config references
+  it by slug or takes the project default.
+- **Self-managed** (`connection.mode = self_managed`): Agenta injects nothing. The harness
+  uses its own OAuth login, a baked env key in the sidecar, or a key the user supplies out of
+  band. The QA runner will have no explicit key; whether the run still succeeds tells you which
+  ambient credential was used.
+- **Provider**: the logical credential family — `openai`, `anthropic`, or a custom-provider
+  slug stored in the vault as a `custom_provider` secret (a custom base-URL endpoint).
+- **Deployment variant**: direct (the provider's public endpoint), or a cloud wrapper — Bedrock,
+  Vertex, or a custom endpoint. For v1, Bedrock and Vertex on Claude and on Pi are declared
+  but not wired (fail-loud); custom endpoint (Pi only) is staged with the model-config sibling.
+  The QA cells for those variants are therefore `blocked:not-wired-v1` and exist only to
+  confirm the fail-loud behavior.
+
+### Validity rules
+
+1. **Pi reaches OpenAI and Anthropic (and six other providers) via direct api-key.** The full
+   vault-mapped Pi provider list is in `harness-provider-matrix.md`. For auth QA, OpenAI and
+   Anthropic are the representative pair; a custom-provider test covers the base-URL path.
+2. **Claude reaches Anthropic only**, three ways: direct key, custom gateway (ANTHROPIC_BASE_URL),
+   or Bedrock/Vertex (v1: declared, not wired — fail-loud). No OpenAI cell is valid for Claude.
+3. **Self-managed cells require an ambient credential.** In the QA environment these require a
+   baked-in sidecar env key or an OAuth login. If neither is present, the cell is
+   `blocked:no-ambient-cred`.
+4. **In-process Pi (E1) does not run Claude** (rule 1 from the main validity rules). Every
+   Claude auth cell on E1 is `n/a`.
+5. **Custom provider on Claude is only via `ANTHROPIC_BASE_URL`** (a custom Anthropic-protocol
+   gateway). A custom OpenAI-protocol endpoint on Claude is `n/a`.
+6. **Bedrock/Vertex are not wired in v1.** Cells exist to assert fail-loud (HTTP 422
+   `UnsupportedDeployment`), not to run a model turn.
+7. **E3 (Daytona) inherits from E2** for auth: if the key is not wired into the Daytona ACP
+   daemon, the run fails regardless of what the vault holds. Flag as
+   `blocked:daytona-model-auth` rather than `blocked:key-missing`.
+
+### Model-auth validity matrix
+
+Rows = provider + auth mode + deployment. Columns = harness (pi, agenta, claude) at the
+representative environments E2 (and E1 where relevant).
+
+| Provider / mode / deployment | pi (E2) | agenta (E2) | claude (E2) |
+| --- | --- | --- | --- |
+| OpenAI — Agenta-managed — direct | valid | valid | n/a (Claude is Anthropic-only) |
+| OpenAI — self-managed — direct | valid (if ambient key) | valid (if ambient key) | n/a |
+| Anthropic — Agenta-managed — direct | valid | valid | valid |
+| Anthropic — self-managed — direct | valid (if ambient key) | valid (if ambient key) | valid (if ambient cred) |
+| Custom provider (OpenAI-compat endpoint) — Agenta-managed | blocked:not-wired-v1 (Pi custom-endpoint stages with model-config) | blocked:not-wired-v1 | n/a |
+| Custom provider (Anthropic-compat gateway) — Agenta-managed | n/a | n/a | valid (ANTHROPIC_BASE_URL) |
+| Anthropic — Agenta-managed — Bedrock | blocked:not-wired-v1 (fail-loud expected) | blocked:not-wired-v1 | blocked:not-wired-v1 |
+| Anthropic — Agenta-managed — Vertex | blocked:not-wired-v1 (fail-loud expected) | blocked:not-wired-v1 | blocked:not-wired-v1 |
+
+Notes on blocked cells:
+- `blocked:not-wired-v1` cells should still be run — the expected result is a fail-loud HTTP
+  422 `UnsupportedDeployment`. If they return 200, that is a finding (a silently-mis-credentialed
+  run is worse than an error).
+- Pi custom-endpoint/cloud consumption stages with the `model-config` sibling project as a
+  prerequisite. Until that lands, Pi cells for custom endpoint and cloud deployments remain
+  blocked.
+
+### Credential-isolation sub-scenarios (run in parallel with the scenarios above)
+
+These exist to catch the whole-vault dump (current-code risk R1 from `notes-model-auth.md`):
+once the redesign lands, each run should have access to exactly one provider's key.
+
+| Sub-scenario | Expected behavior | How to verify |
+| --- | --- | --- |
+| Project has OpenAI key only; run targets OpenAI model | pass | reply arrives; trace shows `openai` provider |
+| Project has OpenAI key only; run targets Anthropic model | fail-loud: no Anthropic key | HTTP 4xx or runner error before model turn |
+| Project has both OpenAI and Anthropic keys; run targets OpenAI model | pass; Anthropic key NOT injected | `ANTHROPIC_API_KEY` absent from sandbox env (verify via a code tool `leak_probe` that prints `os.environ.get("ANTHROPIC_API_KEY","none")`) |
+| Project has both OpenAI and Anthropic keys; run targets Anthropic model | pass; OpenAI key NOT injected | `OPENAI_API_KEY` absent via `leak_probe` |
+| Self-managed; project vault is empty | pass (harness uses own ambient cred) OR blocked:no-ambient-cred | no vault error; observe which cred ran (trace provider label) |
+
+**Current behavior caveat.** The whole-vault dump (risk R1) is the current code's posture:
+all provider keys for the project are injected into every run regardless of model. The
+isolation sub-scenarios will FAIL on the current code for the "key NOT injected" assertions.
+These sub-scenarios become meaningful regression tests only after the `provider-model-auth`
+redesign lands. Until then, run them to document the current state and capture the baseline
+captures in `qa/runs/`.
+
+### Model-auth scenario: Agenta-managed OpenAI (gpt-4o-mini), harness pi
+
+```gherkin
+Scenario Outline: pi harness uses a vault-managed OpenAI key
+  Given a project with exactly one provider_key secret for openai (e.g. slug "openai-qa")
+    And no other provider keys in the vault
+    And an agent with harness pi, model "gpt-4o-mini", connection {mode: agenta}
+    And agents_md "Reply with exactly the word PONG and nothing else."
+  When I POST /invoke on environment <env>
+  Then the reply is exactly "PONG"
+    And the trace span carries provider "openai" and model "gpt-4o-mini"
+    And no Anthropic or other-provider key appears in the sandbox env (leak_probe)
+
+  Examples:
+    | env |
+    | E1  |
+    | E2  |
+```
+
+### Model-auth scenario: Agenta-managed Anthropic (claude-haiku), harness pi
+
+```gherkin
+Scenario Outline: pi harness uses a vault-managed Anthropic key
+  Given a project with exactly one provider_key secret for anthropic
+    And an agent with harness pi, model "claude-haiku-4-5-20251001",
+        connection {mode: agenta}
+    And agents_md "Reply with exactly the word PONG and nothing else."
+  When I POST /invoke on environment <env>
+  Then the reply is exactly "PONG"
+    And the trace span carries provider "anthropic"
+    And no OpenAI or other-provider key appears in the sandbox env (leak_probe)
+
+  Examples:
+    | env |
+    | E2  |
+# E1 (in-process Pi) is also valid for Anthropic via Pi, but the whole-vault dump means
+# cross-key isolation cannot be asserted there today.
+```
+
+### Model-auth scenario: Agenta-managed Anthropic (claude-haiku), harness claude
+
+```gherkin
+Scenario Outline: claude harness uses a vault-managed Anthropic key
+  Given a project with a provider_key secret for anthropic (the pi-agents project has one)
+    And an agent with harness claude, model "haiku" (alias accepted by applyModel),
+        connection {mode: agenta}
+    And agents_md "Reply with exactly the word PONG and nothing else."
+  When I POST /invoke on environment <env>
+  Then the reply is exactly "PONG"
+    And the trace span carries provider "anthropic"
+    And the runner log does not contain "model authentication failed"
+
+  Examples:
+    | env |
+    | E2  |
+# Use the pi-agents project's own API key. Cross-project keys silently resolve the wrong
+# vault (finding F-004 lesson). Alias "haiku" is required; a full id like
+# "claude-haiku-4-5-20251001" falls back to default (Sonnet) and burns credit (F-007).
+```
+
+### Model-auth scenario: Custom provider (OpenAI-compatible endpoint), harness pi
+
+```gherkin
+Scenario: pi harness routes through a custom OpenAI-compat base URL
+  Given a custom_provider vault secret with a base_url pointing to an OpenAI-compat endpoint
+    And an agent with harness pi, model "<provider-slug>/gpt-4o-mini",
+        connection {mode: agenta, slug: "<provider-slug>"}
+  When I POST /invoke on environment E2
+  Then the run returns HTTP 422 with code "UnsupportedDeployment"
+    (because Pi custom-endpoint consumption is blocked:not-wired-v1)
+# When the model-config sibling lands, this cell flips to valid and the expected result
+# becomes "reply arrives with a model turn using the custom endpoint."
+# Verify then by checking the outbound request host in the sandbox (network intercept or
+# provider-side log) matches the custom base_url, not api.openai.com.
+```
+
+### Model-auth scenario: Custom Anthropic gateway, harness claude
+
+```gherkin
+Scenario: claude harness routes through a custom Anthropic base URL
+  Given a custom_provider vault secret for anthropic with base_url set to a proxy endpoint
+    And the proxy echoes requests and returns a valid Claude response
+    And an agent with harness claude, model "haiku",
+        connection {mode: agenta, slug: "<custom-anthropic-slug>"}
+  When I POST /invoke on environment E2
+  Then the reply arrives (via the proxy)
+    And the proxy log shows an inbound request from the runner
+    And ANTHROPIC_BASE_URL in the sandbox env equals the custom base_url
+# This is the ANTHROPIC_BASE_URL path. The custom_provider secret's base_url is projected
+# into ANTHROPIC_BASE_URL by the harness adapter. Verify isolation: ANTHROPIC_API_KEY should
+# be the proxy's key, not the direct anthropic key from the vault.
+```
+
+### Model-auth scenario: Bedrock / Vertex fail-loud (v1 blocked)
+
+```gherkin
+Scenario Outline: a cloud deployment variant is rejected before the model turn
+  Given an agent with harness <harness>, model <model>,
+        connection {mode: agenta, deployment: <deployment>}
+  When I POST /invoke on environment E2
+  Then the response is HTTP 422 with code "UnsupportedDeployment"
+    And no model turn runs (no LLM call, zero spend)
+
+  Examples:
+    | harness | model               | deployment |
+    | claude  | haiku               | bedrock    |
+    | claude  | haiku               | vertex     |
+    | pi      | claude-haiku-..     | bedrock    |
+    | pi      | claude-haiku-..     | vertex     |
+# These are the fail-loud guards. A 200 here is a finding (mis-credentialed silent run).
+# When v1 wiring lands, remove these rows and replace with real cloud-cred tests.
+```
+
+### Model-auth scenario: self-managed, no vault key injected
+
+```gherkin
+Scenario Outline: self-managed connection injects nothing from the vault
+  Given an agent with harness <harness>, model <model>,
+        connection {mode: self_managed}
+  When I POST /invoke on environment E2
+  Then the vault resolve step is skipped (no HTTP call to /vault/connections/resolve in logs)
+    And either: the run succeeds using the harness's own ambient credential
+        or: the run fails fast with "no credential available" (not a vault error)
+    And no provider key from the project vault appears in the sandbox env (leak_probe)
+
+  Examples:
+    | harness | model       |
+    | pi      | gpt-4o-mini |
+    | claude  | haiku       |
+# If the sidecar has no baked ambient key and no OAuth login, both cells are
+# blocked:no-ambient-cred. Run them anyway; the expected result changes from "success" to
+# "clean no-cred error." Either outcome is acceptable; a vault-key leak is not.
+```
+
+### How to set up and verify model-auth runs
+
+**Playground setup (per-request override, fastest for E2):**
+
+```bash
+KEY=<pi-agents-project-API-key>
+PROJ=<pi-agents-project-id>
+curl -s -X POST \
+  -H "Authorization: ApiKey $KEY" -H "content-type: application/json" \
+  "http://localhost:8280/services/agent/v0/invoke?project_id=$PROJ" \
+  -d '{
+    "data": {
+      "inputs": {"messages": [{"role": "user", "content": "ping"}]},
+      "parameters": {
+        "agent": {
+          "harness": "claude",
+          "model": "haiku",
+          "agents_md": "Reply with exactly the word PONG and nothing else.",
+          "connection": {"mode": "agenta"}
+        }
+      }
+    }
+  }'
+```
+
+**Verifying the right credential ran:**
+
+1. Check the trace span: `span.attributes["ag.model.provider"]` must match the intended provider.
+2. Check the runner logs for `"model authentication failed"` (absence is required on a pass).
+3. For isolation: add a `leak_probe` code tool (python, `print(os.environ.get("ANTHROPIC_API_KEY","none"))`)
+   and confirm the output is `"none"` when running an OpenAI model, and vice versa. Note that
+   on current code (pre-redesign) this probe WILL print the key — capture that as baseline.
+4. For self-managed: check runner logs for the vault-resolve HTTP call; it must be absent on a
+   `self_managed` run.
+5. For fail-loud cells: the HTTP status must be 422 with a structured error body containing
+   `"UnsupportedDeployment"` and no inference spend.
+
+**Which project to use:**
+
+Use the `pi-agents` project for all Anthropic/Claude cells — it has the Anthropic provider
+key. Use a separate QA project for the OpenAI isolation test to avoid vault-key cross-contamination.
+Always use that project's own API key (F-004 lesson: a cross-project API key silently resolves
+the wrong vault).
+
+**Model aliases for Claude:**
+
+Use alias `haiku` (not the full id `claude-haiku-4-5-20251001`) until F-007 is fixed. A full
+id falls back silently to the default model (Sonnet), which is expensive.
+
+**Cost guard:**
+
+- OpenAI cells: `gpt-4o-mini`. Do NOT use `gpt-4o`, `gpt-5.5`, or any Sonnet-tier model.
+- Anthropic cells: `haiku` alias or `claude-haiku-4-5-20251001` once F-007 is fixed.
+- Fail-loud cells (blocked:not-wired-v1): no model turn runs; zero spend. Still send them.
+- Daytona (E3): E3 inherits E2 for auth; unless specifically testing Daytona-specific model-auth
+  wiring, skip E3 auth cells to save Daytona spin-up cost and re-run time.
+
+### Live run results — model-auth (not yet run)
+
+This section will be filled in when the first model-auth pass runs. Expected cells to complete
+on current code (pre-redesign):
+
+| Cell | Expected on current code | Status |
+| --- | --- | --- |
+| OpenAI Agenta-managed / pi / E2 | pass (whole-vault dump delivers the key) | not yet run |
+| Anthropic Agenta-managed / pi / E2 | pass (same) | not yet run |
+| Anthropic Agenta-managed / claude / E2 | pass (F-004 corrected; pi-agents project key required) | not yet run |
+| Custom gateway / claude / E2 | not yet run | not yet run |
+| Bedrock fail-loud / claude / E2 | expect 422 | not yet run |
+| Vertex fail-loud / claude / E2 | expect 422 | not yet run |
+| Self-managed / pi / E2 | depends on ambient cred | not yet run |
+| Isolation: two keys, OpenAI model / pi / E2 | FAIL on current code (Anthropic key leaks) | not yet run; baseline capture |
+| Isolation: two keys, Anthropic model / pi / E2 | FAIL on current code (OpenAI key leaks) | not yet run; baseline capture |

--- a/docs/design/agent-workflows/projects/sidecar-trust-and-sandbox-enforcement/README.md
+++ b/docs/design/agent-workflows/projects/sidecar-trust-and-sandbox-enforcement/README.md
@@ -183,6 +183,11 @@ hardening](#later--deferred-hardening) subsection below — it is NOT part of th
    exposure. **IMPLEMENTED:** when `AGENTA_AGENT_RUNNER_TOKEN` is set, `server.ts` requires it
    on `/run` (`Authorization: Bearer <token>` or `X-Agenta-Runner-Token: <token>`,
    constant-time compare) and returns 401 otherwise; `/health` stays open for liveness probes.
+   **Both sides now read the same env var** (Codex LOW-5): the SDK transport
+   (`sdks/.../utils/ts_runner.py` `_runner_auth_headers`) reads `AGENTA_AGENT_RUNNER_TOKEN`
+   and presents `Authorization: Bearer <token>` on the HTTP `/run` POST + NDJSON stream when
+   set, so turning the gate on no longer locks the Python service out; unset = no header
+   (loopback default unchanged).
 
 Rationale: steps 1–2 are config-only, make the implicit assumption real and auditable, and
 need no wire-contract change or cert/key machinery. They are the whole near-term ask.

--- a/sdks/python/agenta/sdk/agents/utils/ts_runner.py
+++ b/sdks/python/agenta/sdk/agents/utils/ts_runner.py
@@ -18,6 +18,20 @@ _DEFAULT_TIMEOUT = float(os.getenv("AGENTA_AGENT_RUNNER_TIMEOUT_SECONDS", "180")
 log = get_module_logger(__name__)
 
 
+def _runner_auth_headers() -> Dict[str, str]:
+    """The ``Authorization`` header for the runner's optional shared-token gate, if configured.
+
+    The runner enables a ``/run`` token check only when ``AGENTA_AGENT_RUNNER_TOKEN`` is set on
+    its side (default OFF; see ``server.ts``). When the gate is on, an un-tokened POST is rejected
+    with 401, which would lock the co-located Python service out. Set the SAME env var here and we
+    present it as ``Authorization: Bearer <token>`` (the runner also accepts this header). Unset =
+    no header, matching the runner's default-off behavior, so loopback deployments are unaffected.
+    Read per-call (not cached) so a test or runtime env change takes effect without a re-import.
+    """
+    token = os.getenv("AGENTA_AGENT_RUNNER_TOKEN")
+    return {"Authorization": f"Bearer {token}"} if token else {}
+
+
 def _transport_error(user_message: str, *, detail: str) -> RuntimeError:
     """A transport RuntimeError whose surfaced text is clean; the raw detail is logged only.
 
@@ -41,7 +55,7 @@ async def deliver_http(
 
     url = base_url.rstrip("/") + "/run"
     async with httpx.AsyncClient(timeout=timeout) as client:
-        response = await client.post(url, json=payload)
+        response = await client.post(url, json=payload, headers=_runner_auth_headers())
     # Any non-2xx is a transport failure; 4xx left to fall through surfaces as an opaque
     # JSON parse error instead of a clear runner failure. The response body can carry internal
     # detail, so it is logged, not surfaced.
@@ -122,7 +136,7 @@ async def deliver_http_stream(
     import httpx  # local import: only the HTTP transport needs it
 
     url = base_url.rstrip("/") + "/run"
-    headers = {"Accept": "application/x-ndjson"}
+    headers = {"Accept": "application/x-ndjson", **_runner_auth_headers()}
     saw_result = False
     async with httpx.AsyncClient(timeout=timeout) as client:
         async with client.stream(

--- a/sdks/python/oss/tests/pytest/unit/agents/test_runner_transport_auth.py
+++ b/sdks/python/oss/tests/pytest/unit/agents/test_runner_transport_auth.py
@@ -1,0 +1,173 @@
+"""The runner HTTP transport sends the optional shared-token header (Codex LOW-5).
+
+The runner's ``/run`` endpoint has an opt-in shared-token gate (``AGENTA_AGENT_RUNNER_TOKEN``,
+default OFF; see ``services/agent/src/server.ts``). When the operator turns it on, an un-tokened
+POST from the co-located Python service is rejected with 401. These tests pin the Python side of
+that contract: ``deliver_http`` / ``deliver_http_stream`` attach ``Authorization: Bearer
+<token>`` when the same env var is set, and send no auth header when it is not (loopback default).
+"""
+
+from __future__ import annotations
+
+import json
+from typing import Any, Dict, List
+
+import httpx
+
+from agenta.sdk.agents.utils.ts_runner import (
+    _runner_auth_headers,
+    deliver_http,
+    deliver_http_stream,
+)
+
+
+class _FakeResponse:
+    def __init__(self, status_code: int, payload: Any) -> None:
+        self.status_code = status_code
+        self._payload = payload
+        self.text = json.dumps(payload)
+
+    def json(self) -> Any:
+        return self._payload
+
+
+def _fake_post_client(capture: Dict[str, Any], *, payload: Any):
+    class _Client:
+        def __init__(self, *args, **kwargs) -> None:
+            pass
+
+        async def __aenter__(self):
+            return self
+
+        async def __aexit__(self, *args):
+            return False
+
+        async def post(self, url, json=None, headers=None):
+            capture.update(url=url, json=json, headers=headers or {})
+            return _FakeResponse(200, payload)
+
+    return _Client
+
+
+def _fake_stream_client(capture: Dict[str, Any], *, lines: List[str]):
+    class _Stream:
+        def __init__(self) -> None:
+            self.status_code = 200
+
+        async def __aenter__(self):
+            return self
+
+        async def __aexit__(self, *args):
+            return False
+
+        async def aiter_lines(self):
+            for line in lines:
+                yield line
+
+        async def aread(self) -> bytes:
+            return b""
+
+    class _Client:
+        def __init__(self, *args, **kwargs) -> None:
+            pass
+
+        async def __aenter__(self):
+            return self
+
+        async def __aexit__(self, *args):
+            return False
+
+        def stream(self, method, url, json=None, headers=None):
+            capture.update(method=method, url=url, json=json, headers=headers or {})
+            return _Stream()
+
+    return _Client
+
+
+# --- _runner_auth_headers (pure, env-driven) -------------------------------
+
+
+def test_auth_headers_absent_by_default(monkeypatch):
+    monkeypatch.delenv("AGENTA_AGENT_RUNNER_TOKEN", raising=False)
+    assert _runner_auth_headers() == {}
+
+
+def test_auth_headers_present_when_token_set(monkeypatch):
+    monkeypatch.setenv("AGENTA_AGENT_RUNNER_TOKEN", "s3cr3t")
+    assert _runner_auth_headers() == {"Authorization": "Bearer s3cr3t"}
+
+
+def test_auth_headers_read_per_call(monkeypatch):
+    # Read fresh each call (not cached at import), so a runtime env flip takes effect.
+    monkeypatch.delenv("AGENTA_AGENT_RUNNER_TOKEN", raising=False)
+    assert _runner_auth_headers() == {}
+    monkeypatch.setenv("AGENTA_AGENT_RUNNER_TOKEN", "later")
+    assert _runner_auth_headers() == {"Authorization": "Bearer later"}
+
+
+# --- deliver_http (one-shot) -----------------------------------------------
+
+
+async def test_deliver_http_sends_bearer_when_token_set(monkeypatch):
+    monkeypatch.setenv("AGENTA_AGENT_RUNNER_TOKEN", "tok-123")
+    capture: Dict[str, Any] = {}
+    monkeypatch.setattr(
+        httpx, "AsyncClient", _fake_post_client(capture, payload={"ok": True})
+    )
+
+    result = await deliver_http("http://runner:8765", {"harness": "pi_core"})
+
+    assert result == {"ok": True}
+    assert capture["headers"].get("Authorization") == "Bearer tok-123"
+    assert capture["url"] == "http://runner:8765/run"
+
+
+async def test_deliver_http_no_auth_header_when_unset(monkeypatch):
+    monkeypatch.delenv("AGENTA_AGENT_RUNNER_TOKEN", raising=False)
+    capture: Dict[str, Any] = {}
+    monkeypatch.setattr(
+        httpx, "AsyncClient", _fake_post_client(capture, payload={"ok": True})
+    )
+
+    await deliver_http("http://runner:8765", {"harness": "pi_core"})
+
+    assert "Authorization" not in capture["headers"]
+
+
+# --- deliver_http_stream (NDJSON) ------------------------------------------
+
+
+async def test_deliver_http_stream_sends_bearer_and_keeps_accept(monkeypatch):
+    monkeypatch.setenv("AGENTA_AGENT_RUNNER_TOKEN", "tok-stream")
+    capture: Dict[str, Any] = {}
+    lines = [json.dumps({"kind": "result", "result": {"ok": True}})]
+    monkeypatch.setattr(httpx, "AsyncClient", _fake_stream_client(capture, lines=lines))
+
+    records = [
+        record
+        async for record in deliver_http_stream(
+            "http://runner:8765", {"harness": "pi_core"}
+        )
+    ]
+
+    assert records == [{"kind": "result", "result": {"ok": True}}]
+    # The auth header rides alongside the NDJSON Accept header, neither clobbers the other.
+    assert capture["headers"].get("Authorization") == "Bearer tok-stream"
+    assert capture["headers"].get("Accept") == "application/x-ndjson"
+
+
+async def test_deliver_http_stream_no_auth_header_when_unset(monkeypatch):
+    monkeypatch.delenv("AGENTA_AGENT_RUNNER_TOKEN", raising=False)
+    capture: Dict[str, Any] = {}
+    lines = [json.dumps({"kind": "result", "result": {"ok": True}})]
+    monkeypatch.setattr(httpx, "AsyncClient", _fake_stream_client(capture, lines=lines))
+
+    _ = [
+        record
+        async for record in deliver_http_stream(
+            "http://runner:8765", {"harness": "pi_core"}
+        )
+    ]
+
+    assert "Authorization" not in capture["headers"]
+    assert capture["headers"].get("Accept") == "application/x-ndjson"

--- a/services/agent/src/engines/sandbox_agent/run-plan.ts
+++ b/services/agent/src/engines/sandbox_agent/run-plan.ts
@@ -237,7 +237,11 @@ export function buildRunPlan(
   // inside the sandbox, so they bypass the sandbox network boundary. Under `strict` + a
   // restricted network, refuse them; `best_effort` is the opt-out that accepts the boundary is
   // not a hard guarantee.
-  const strict = request.sandboxPermission?.enforcement === "strict";
+  // Default to strict when `enforcement` is omitted, matching the documented wire schema
+  // (`WireSandboxPermission.enforcement` defaults to "strict"). The Python service always fills
+  // "strict", so the live path is unchanged; this aligns a DIRECT runner caller (and the
+  // omit-when-default goldens) so only an explicit "best_effort" opts out of the hard guarantee.
+  const strict = request.sandboxPermission?.enforcement !== "best_effort";
   if (networkRestricted && isDaytona && strict) {
     const mode = network?.mode ?? "on";
     if (executableToolSpecsForRun.length > 0) {

--- a/services/agent/src/protocol.ts
+++ b/services/agent/src/protocol.ts
@@ -158,6 +158,7 @@ export interface SandboxPermission {
   };
   /** Declared, NOT enforced today. */
   filesystem?: "on" | "readonly" | "off";
+  /** Omitted defaults to `strict` (matches the wire schema); only `best_effort` opts out. */
   enforcement?: "strict" | "best_effort";
 }
 
@@ -321,8 +322,6 @@ export interface AgentRunRequest {
    * connection; see the provider-model-auth design (Concern 3).
    */
   credentialMode?: string;
-  /** Explicit latest turn. Falls back to the last user message in `messages`. */
-  prompt?: string;
   /** The conversation so far; the runner picks the latest turn and replays the rest. */
   messages?: ChatMessage[];
   /** Built-in tools to enable. */
@@ -407,9 +406,8 @@ export function messageText(
     .join("");
 }
 
-/** The latest user turn: explicit prompt, else last user message content. */
+/** The latest user turn: the last user message's text (the wire carries no standalone prompt). */
 export function resolvePromptText(request: AgentRunRequest): string {
-  if (request.prompt && request.prompt.trim()) return request.prompt;
   const messages = request.messages ?? [];
   for (let i = messages.length - 1; i >= 0; i--) {
     if (messages[i].role === "user") {

--- a/services/agent/tests/unit/responder.test.ts
+++ b/services/agent/tests/unit/responder.test.ts
@@ -82,18 +82,18 @@ describe("decisionToReply", () => {
 describe("approvalKey", () => {
   it("binds name + args, order-independently", () => {
     assert.equal(
-      approvalKey("edit", {a: 1, b: 2}),
-      approvalKey("edit", {b: 2, a: 1}),
+      approvalKey("edit", { a: 1, b: 2 }),
+      approvalKey("edit", { b: 2, a: 1 }),
       "key order does not change the key",
     );
     assert.notEqual(
-      approvalKey("edit", {path: "a"}),
-      approvalKey("edit", {path: "b"}),
+      approvalKey("edit", { path: "a" }),
+      approvalKey("edit", { path: "b" }),
       "different args -> different key",
     );
     assert.notEqual(
-      approvalKey("edit", {path: "a"}),
-      approvalKey("bash", {path: "a"}),
+      approvalKey("edit", { path: "a" }),
+      approvalKey("bash", { path: "a" }),
       "different name -> different key",
     );
   });
@@ -105,18 +105,26 @@ describe("approvalKey", () => {
     assert.equal(approvalKey("edit", null), approvalKey("edit", {}));
     // But a WITH-args call never collapses to the no-arg key.
     assert.notEqual(
-      approvalKey("edit", {path: "a"}),
+      approvalKey("edit", { path: "a" }),
       approvalKey("edit", {}),
       "args present -> a different key than no-args",
     );
   });
 
   it("returns no key (fails closed) for no name or non-JSON args", () => {
-    assert.equal(approvalKey(undefined, {a: 1}), undefined, "no name -> no key");
+    assert.equal(
+      approvalKey(undefined, { a: 1 }),
+      undefined,
+      "no name -> no key",
+    );
     // Non-JSON args fail closed (no key) rather than throwing or colliding.
-    assert.equal(approvalKey("edit", 10n as unknown), undefined, "bigint -> no key");
+    assert.equal(
+      approvalKey("edit", 10n as unknown),
+      undefined,
+      "bigint -> no key",
+    );
     assert.equal(approvalKey("edit", new Date()), undefined, "Date -> no key");
-    assert.equal(approvalKey("edit", {x: NaN}), undefined, "NaN -> no key");
+    assert.equal(approvalKey("edit", { x: NaN }), undefined, "NaN -> no key");
     assert.equal(approvalKey("edit", new Map()), undefined, "Map -> no key");
   });
 });
@@ -166,7 +174,9 @@ describe("HITLResponder", () => {
     ]);
     const responder = new HITLResponder(decisions, "auto", true);
     assert.equal(
-      await responder.onPermission(permReq("fresh-id", "edit", { path: "a.txt" })),
+      await responder.onPermission(
+        permReq("fresh-id", "edit", { path: "a.txt" }),
+      ),
       "allow",
     );
   });
@@ -192,7 +202,9 @@ describe("HITLResponder", () => {
     ]);
     const orderResponder = new HITLResponder(orderDecisions, "auto", true);
     assert.equal(
-      await orderResponder.onPermission(permReq("call-c", "edit", { b: 2, a: 1 })),
+      await orderResponder.onPermission(
+        permReq("call-c", "edit", { b: 2, a: 1 }),
+      ),
       "allow",
       "the same args in a different key order is the same call (resumes)",
     );
@@ -204,7 +216,9 @@ describe("HITLResponder", () => {
     const decisions = new Map<string, PermissionDecision>([["edit", "allow"]]);
     const responder = new HITLResponder(decisions, "auto", true);
     assert.equal(
-      await responder.onPermission(permReq("fresh-id", "edit", { path: "a.txt" })),
+      await responder.onPermission(
+        permReq("fresh-id", "edit", { path: "a.txt" }),
+      ),
       "park",
       "a bare-name entry must not auto-approve a real call",
     );
@@ -283,7 +297,10 @@ describe("extractApprovalDecisions", () => {
 
     const decisions = extractApprovalDecisions(request);
     // ONLY the name+args anchor is keyed (recovered from the correlated tool_call block).
-    assert.equal(decisions.get(approvalKey("edit", { path: "a.txt" })!), "allow");
+    assert.equal(
+      decisions.get(approvalKey("edit", { path: "a.txt" })!),
+      "allow",
+    );
     assert.equal(decisions.get(approvalKey("bash", { cmd: "ls" })!), "deny");
     // The bare tool NAME must NOT be a key (that was the HITL-bypass).
     assert.equal(decisions.has("edit"), false, "no bare-name key");
@@ -320,7 +337,9 @@ describe("extractApprovalDecisions", () => {
   });
 
   it("returns an empty lookup when there are no structured messages (headless /invoke)", () => {
-    const request: AgentRunRequest = { prompt: "just a single turn" };
+    const request: AgentRunRequest = {
+      messages: [{ role: "user", content: "just a single turn" }],
+    };
     assert.equal(extractApprovalDecisions(request).size, 0);
   });
 
@@ -392,7 +411,9 @@ describe("extractApprovalDecisions", () => {
     );
     // Fresh id this turn, but same name + args -> resolves (resume works).
     assert.equal(
-      await responder.onPermission(permReq("fresh-id", "edit", { path: "a.txt" })),
+      await responder.onPermission(
+        permReq("fresh-id", "edit", { path: "a.txt" }),
+      ),
       "allow",
       "the parked call resumes under a fresh id via the name+args anchor",
     );

--- a/services/agent/tests/unit/sandbox-agent-orchestration.test.ts
+++ b/services/agent/tests/unit/sandbox-agent-orchestration.test.ts
@@ -211,7 +211,11 @@ describe("runSandboxAgent orchestration", () => {
     const { calls, deps } = fakeHarness();
 
     const result = await runSandboxAgent(
-      { harness: "claude", prompt: "hello", model: "requested-model" },
+      {
+        harness: "claude",
+        messages: [{ role: "user", content: "hello" }],
+        model: "requested-model",
+      },
       undefined,
       undefined,
       deps,
@@ -253,7 +257,7 @@ describe("runSandboxAgent orchestration", () => {
     const streamed: AgentEvent[] = [];
 
     const result = await runSandboxAgent(
-      { harness: "claude", prompt: "hello" },
+      { harness: "claude", messages: [{ role: "user", content: "hello" }] },
       (event) => streamed.push(event),
       undefined,
       deps,
@@ -270,7 +274,10 @@ describe("runSandboxAgent orchestration", () => {
     const { calls, deps } = fakeHarness({ emitPermission: true });
 
     const result = await runSandboxAgent(
-      { harness: "claude", prompt: "edit the file" },
+      {
+        harness: "claude",
+        messages: [{ role: "user", content: "edit the file" }],
+      },
       undefined,
       undefined,
       deps,
@@ -310,7 +317,7 @@ describe("runSandboxAgent orchestration", () => {
     const result = await runSandboxAgent(
       {
         harness: "pi_core",
-        prompt: "use the tool",
+        messages: [{ role: "user", content: "use the tool" }],
         customTools: [{ name: "server_tool", kind: "callback" }],
       } as AgentRunRequest,
       undefined,
@@ -346,7 +353,7 @@ describe("runSandboxAgent orchestration", () => {
     const result = await runSandboxAgent(
       {
         harness: "claude",
-        prompt: "use the tool",
+        messages: [{ role: "user", content: "use the tool" }],
         customTools: [{ name: "server_tool", kind: "callback" }],
       } as AgentRunRequest,
       undefined,
@@ -391,7 +398,7 @@ describe("runSandboxAgent orchestration", () => {
     const result = await runSandboxAgent(
       {
         harness: "claude",
-        prompt: "go",
+        messages: [{ role: "user", content: "go" }],
         mcpServers: [{ name: "github", transport: "stdio", command: "npx" }],
       } as AgentRunRequest,
       undefined,
@@ -415,7 +422,7 @@ describe("runSandboxAgent orchestration", () => {
     const result = await runSandboxAgent(
       {
         harness: "claude",
-        prompt: "use the tool",
+        messages: [{ role: "user", content: "use the tool" }],
         customTools: [{ name: "server_tool", kind: "callback" }],
       } as AgentRunRequest,
       undefined,
@@ -441,7 +448,7 @@ describe("runSandboxAgent orchestration", () => {
     const result = await runSandboxAgent(
       {
         harness: "pi_core",
-        prompt: "use the tool",
+        messages: [{ role: "user", content: "use the tool" }],
         customTools: [{ name: "server_tool", kind: "callback" }],
       } as AgentRunRequest,
       undefined,
@@ -457,7 +464,7 @@ describe("runSandboxAgent orchestration", () => {
     const { calls, deps } = fakeHarness({ promptError: new Error("boom") });
 
     const result = await runSandboxAgent(
-      { harness: "claude", prompt: "explode" },
+      { harness: "claude", messages: [{ role: "user", content: "explode" }] },
       undefined,
       undefined,
       deps,
@@ -482,7 +489,7 @@ describe("runSandboxAgent orchestration", () => {
       {
         harness: "claude",
         sandbox: "daytona",
-        prompt: "hello",
+        messages: [{ role: "user", content: "hello" }],
         sandboxPermission,
       },
       undefined,
@@ -500,7 +507,7 @@ describe("runSandboxAgent orchestration", () => {
     const controller = new AbortController();
 
     const result = await runSandboxAgent(
-      { harness: "claude", prompt: "hello" },
+      { harness: "claude", messages: [{ role: "user", content: "hello" }] },
       undefined,
       controller.signal,
       deps,
@@ -516,7 +523,7 @@ describe("runSandboxAgent orchestration", () => {
     const result = await runSandboxAgent(
       {
         harness: "claude",
-        prompt: "hello",
+        messages: [{ role: "user", content: "hello" }],
         credentialMode: "env",
         secrets: { ANTHROPIC_API_KEY: "resolved" },
         endpoint: { baseUrl: "https://claude-gw.example/v1" },
@@ -542,7 +549,7 @@ describe("runSandboxAgent orchestration", () => {
     const result = await runSandboxAgent(
       {
         harness: "claude",
-        prompt: "hello",
+        messages: [{ role: "user", content: "hello" }],
         model: "anthropic.claude-x",
         deployment: "bedrock",
         credentialMode: "env",
@@ -573,7 +580,7 @@ describe("runSandboxAgent orchestration", () => {
     const result = await runSandboxAgent(
       {
         harness: "claude",
-        prompt: "hello",
+        messages: [{ role: "user", content: "hello" }],
         model: "claude-sonnet-4",
         deployment: "vertex_ai",
         credentialMode: "env",
@@ -600,7 +607,7 @@ describe("runSandboxAgent orchestration", () => {
     const result = await runSandboxAgent(
       {
         harness: "claude",
-        prompt: "hello",
+        messages: [{ role: "user", content: "hello" }],
         credentialMode: "runtime_provided",
       } as AgentRunRequest,
       undefined,
@@ -630,7 +637,10 @@ describe("runSandboxAgent default HITL responder wiring", () => {
     const { calls, deps } = depsWithDefaultResponder();
 
     const result = await runSandboxAgent(
-      { harness: "claude", prompt: "edit the file" },
+      {
+        harness: "claude",
+        messages: [{ role: "user", content: "edit the file" }],
+      },
       undefined,
       undefined,
       deps,

--- a/services/agent/tests/unit/sandbox-agent-run-plan.test.ts
+++ b/services/agent/tests/unit/sandbox-agent-run-plan.test.ts
@@ -46,7 +46,7 @@ describe("buildRunPlan", () => {
     const result = buildRunPlan(
       {
         harness: "pi_agenta",
-        prompt: " ship it ",
+        messages: [{ role: "user", content: " ship it " }],
         agentsMd: " instructions ",
         systemPrompt: " system ",
         appendSystemPrompt: " append ",
@@ -103,7 +103,7 @@ describe("buildRunPlan", () => {
       {
         harness: "claude",
         sandbox: "daytona",
-        prompt: "hello",
+        messages: [{ role: "user", content: "hello" }],
         sandboxPermission: {
           network: { mode: "on", allowlist: [] },
           enforcement: "strict",
@@ -122,7 +122,11 @@ describe("buildRunPlan", () => {
 
   it("treats an absent sandbox permission as unrestricted", () => {
     const result = buildRunPlan(
-      { harness: "claude", sandbox: "daytona", prompt: "hello" },
+      {
+        harness: "claude",
+        sandbox: "daytona",
+        messages: [{ role: "user", content: "hello" }],
+      },
       { createDaytonaCwd: () => "/home/sandbox/agenta-fixed" },
     );
 
@@ -138,7 +142,7 @@ describe("buildRunPlan", () => {
       {
         harness: "claude",
         sandbox: "local",
-        prompt: "hello",
+        messages: [{ role: "user", content: "hello" }],
         sandboxPermission: {
           network: { mode: "off" },
           enforcement: "strict",
@@ -159,7 +163,7 @@ describe("buildRunPlan", () => {
       {
         harness: "claude",
         sandbox: "local",
-        prompt: "hello",
+        messages: [{ role: "user", content: "hello" }],
         sandboxPermission: {
           network: { mode: "off" },
           enforcement: "best_effort",
@@ -178,7 +182,7 @@ describe("buildRunPlan", () => {
       {
         harness: "claude",
         sandbox: "local",
-        prompt: "hello",
+        messages: [{ role: "user", content: "hello" }],
         sandboxPermission: {
           network: { mode: "on" },
           enforcement: "strict",
@@ -198,7 +202,7 @@ describe("buildRunPlan", () => {
         {
           harness: "claude",
           sandbox: "daytona",
-          prompt: "hello",
+          messages: [{ role: "user", content: "hello" }],
           sandboxPermission: { filesystem: "readonly", enforcement },
         } as AgentRunRequest,
         { createDaytonaCwd: () => "/home/sandbox/agenta-fixed" },
@@ -218,7 +222,7 @@ describe("buildRunPlan", () => {
       {
         harness: "claude",
         sandbox: "daytona",
-        prompt: "hello",
+        messages: [{ role: "user", content: "hello" }],
         customTools: [{ name: "server_tool", kind: "callback" }],
         sandboxPermission: {
           network: { mode: "allowlist", allowlist: ["10.0.0.0/8"] },
@@ -234,6 +238,50 @@ describe("buildRunPlan", () => {
     assert.match(result.error, /network:allowlist/);
   });
 
+  it("treats an OMITTED enforcement as strict (LOW-6: wire-schema default is strict)", () => {
+    // The Python service always fills enforcement="strict", but a DIRECT runner caller may omit
+    // it. The wire schema defaults it to "strict", so an omitted value must rebuff a runner-host
+    // tool on a restricted-network Daytona run the same as an explicit "strict" — only an
+    // explicit "best_effort" opts out.
+    const result = buildRunPlan(
+      {
+        harness: "claude",
+        sandbox: "daytona",
+        messages: [{ role: "user", content: "hello" }],
+        customTools: [{ name: "server_tool", kind: "callback" }],
+        sandboxPermission: {
+          network: { mode: "allowlist", allowlist: ["10.0.0.0/8"] },
+          // enforcement omitted on purpose
+        },
+      } as AgentRunRequest,
+      { createDaytonaCwd: () => "/home/sandbox/agenta-fixed" },
+    );
+
+    assert.equal(result.ok, false);
+    if (result.ok) return;
+    assert.match(result.error, /run on the runner host and would bypass/);
+  });
+
+  it("lets best_effort opt out of the runner-host-tool guard (LOW-6 contrast)", () => {
+    // The explicit opt-out: best_effort accepts that the network boundary is not a hard
+    // guarantee, so the same restricted-network Daytona run with a host tool is allowed.
+    const result = buildRunPlan(
+      {
+        harness: "claude",
+        sandbox: "daytona",
+        messages: [{ role: "user", content: "hello" }],
+        customTools: [{ name: "server_tool", kind: "callback" }],
+        sandboxPermission: {
+          network: { mode: "allowlist", allowlist: ["10.0.0.0/8"] },
+          enforcement: "best_effort",
+        },
+      } as AgentRunRequest,
+      { createDaytonaCwd: () => "/home/sandbox/agenta-fixed" },
+    );
+
+    assert.equal(result.ok, true);
+  });
+
   it("errors on any run carrying a stdio MCP server (MCP disabled)", () => {
     // The stdio MCP implementation is disabled in the sidecar; a stdio server errors the
     // not-implemented way regardless of sandbox/enforcement, even with no network policy.
@@ -241,7 +289,7 @@ describe("buildRunPlan", () => {
       {
         harness: "claude",
         sandbox: "daytona",
-        prompt: "hello",
+        messages: [{ role: "user", content: "hello" }],
         mcpServers: [{ name: "fs", transport: "stdio", command: "mcp-fs" }],
       } as AgentRunRequest,
       { createDaytonaCwd: () => "/home/sandbox/agenta-fixed" },
@@ -257,7 +305,7 @@ describe("buildRunPlan", () => {
       {
         harness: "claude",
         sandbox: "local",
-        prompt: "hello",
+        messages: [{ role: "user", content: "hello" }],
         mcpServers: [{ name: "fs", transport: "stdio", command: "mcp-fs" }],
       } as AgentRunRequest,
       { createLocalCwd: () => "/tmp/local-cwd" },
@@ -276,7 +324,7 @@ describe("buildRunPlan", () => {
       {
         harness: "pi_core",
         sandbox: "local",
-        prompt: "hello",
+        messages: [{ role: "user", content: "hello" }],
         mcpServers: [{ name: "fs", transport: "stdio", command: "mcp-fs" }],
       } as AgentRunRequest,
       { createLocalCwd: () => "/tmp/local-cwd" },
@@ -296,7 +344,7 @@ describe("buildRunPlan", () => {
       {
         harness: "pi_agenta",
         sandbox: "daytona",
-        prompt: "hello",
+        messages: [{ role: "user", content: "hello" }],
         mcpServers: [
           {
             name: "linear",
@@ -328,7 +376,7 @@ describe("buildRunPlan", () => {
       {
         harness: "claude",
         sandbox: "local",
-        prompt: "hello",
+        messages: [{ role: "user", content: "hello" }],
         mcpServers: [
           {
             name: "linear",
@@ -352,7 +400,7 @@ describe("buildRunPlan", () => {
       {
         harness: "pi_core",
         sandbox: "local",
-        prompt: "compute it",
+        messages: [{ role: "user", content: "compute it" }],
         customTools: [
           {
             name: "secret_math",
@@ -382,7 +430,7 @@ describe("buildRunPlan", () => {
       {
         harness: "pi_core",
         sandbox: "local",
-        prompt: "do it",
+        messages: [{ role: "user", content: "do it" }],
         customTools: [{ name: "server_tool", kind: "callback" }],
       } as AgentRunRequest,
       { createLocalCwd: () => "/tmp/local-cwd" },
@@ -396,7 +444,7 @@ describe("buildRunPlan", () => {
       {
         harness: "claude",
         sandbox: "daytona",
-        prompt: "hello",
+        messages: [{ role: "user", content: "hello" }],
         mcpServers: [
           { name: "remote", transport: "http", url: "https://mcp.example" },
         ],
@@ -416,7 +464,7 @@ describe("buildRunPlan", () => {
       {
         harness: "claude",
         sandbox: "daytona",
-        prompt: "hello",
+        messages: [{ role: "user", content: "hello" }],
         customTools: [{ name: "server_tool", kind: "callback" }],
         sandboxPermission: {
           network: { mode: "off" },
@@ -434,7 +482,7 @@ describe("buildRunPlan", () => {
       {
         harness: "claude",
         sandbox: "daytona",
-        prompt: "hello",
+        messages: [{ role: "user", content: "hello" }],
         sandboxPermission: {
           network: { mode: "off" },
           enforcement: "strict",
@@ -452,7 +500,7 @@ describe("buildRunPlan", () => {
       {
         harness: "claude",
         sandbox: "daytona",
-        prompt: "hello",
+        messages: [{ role: "user", content: "hello" }],
         skills: [
           { name: "alpha", description: "Alpha skill.", body: "Do alpha." },
           { name: "beta", description: "Beta skill.", body: "Do beta." },
@@ -487,7 +535,11 @@ describe("buildRunPlan", () => {
     // No skills on the wire: materialization is a no-op and must not warn.
     const logs: string[] = [];
     const result = buildRunPlan(
-      { harness: "claude", sandbox: "daytona", prompt: "hello" },
+      {
+        harness: "claude",
+        sandbox: "daytona",
+        messages: [{ role: "user", content: "hello" }],
+      },
       {
         createDaytonaCwd: () => "/home/sandbox/agenta-fixed",
         log: (message) => logs.push(message),
@@ -506,7 +558,7 @@ describe("buildRunPlan", () => {
       {
         harness: "claude",
         sandbox: "daytona",
-        prompt: "hello",
+        messages: [{ role: "user", content: "hello" }],
         secrets: { ANTHROPIC_API_KEY: "anthropic" },
         credentialMode: "env",
         systemPrompt: "ignored for non-pi",


### PR DESCRIPTION
## What

Closes four LOW-severity backend findings from the Codex review + QA sweep. All four are footguns or doc drift, not live-path bugs — the deployed service was already safe on each. Backend + docs only; no frontend, no live-runner restart.

### LOW-5 — runner HTTP transport had no auth header

The runner's `/run` endpoint has an opt-in shared-token gate (`AGENTA_AGENT_RUNNER_TOKEN`, default OFF in `server.ts`). The Python transport POSTed with no `Authorization` header, so turning the gate on would 401 the co-located Python service — a one-sided footgun.

`ts_runner.py` now reads the **same** env var and sends `Authorization: Bearer <token>` on both HTTP transports (`deliver_http`, `deliver_http_stream`) when it is set; unset = no header, so loopback deployments are unchanged.

### LOW-6 — enforcement default mismatch

The Python wire schema defaults `sandboxPermission.enforcement` to `"strict"`, but the runner treated only the literal `"strict"` as strict — an **omitted** value silently degraded to best_effort for a direct runner caller.

`buildRunPlan` now treats omitted as strict (`enforcement !== "best_effort"`). The live service always fills `"strict"`, so this only aligns direct callers with the documented default.

### LOW-7 — dead `prompt` wire field

The TS `AgentRunRequest` declared a `prompt` field the Python producer never emits (`WireRunRequest` lacks it; a `test_wire_contract.py` test asserts `"prompt" not in payload`; it was absent from `KNOWN_REQUEST_KEYS` and the goldens on both sides).

Removed `prompt` from `protocol.ts` and dropped its branch in `resolvePromptText` (now derives the latest turn from `messages` only). `resolvePromptText` stays — transcript/run-plan use it as the messages-derived helper. The golden fixtures and both wire-contract tests are unchanged.

### F-028 — QA matrix doc

The matrix said skills are `n/a` on `pi`, but author skills load+invoke on plain `pi_core` (verified live; both Pi-family harnesses drive the same `pi` ACP agent). Corrected validity rule 4 and the capability×harness rows so skill cells are `valid` on both `pi` and `agenta`. The real `agenta`-vs-`pi` difference is the forced `read`+`bash` set, not skill support.

## Tests

- **Golden wire contract intact** — fixtures unchanged vs `big-agents`; `test_wire_contract.py` (Python) + `wire-contract.test.ts` (TS) green.
- SDK agents **366** unit + **7 new** transport-auth tests (`test_runner_transport_auth.py`, LOW-5) + transport roundtrip **4** — green; ruff clean.
- Runner **268** vitest (incl. **2 new** LOW-6 run-plan tests) + `tsc --strict` — green. ~38 runner test fixtures migrated from the dead `prompt:` convenience to `messages:` (the otel `start({prompt})` calls use a separate inline type and were left untouched).

## Docs kept in sync

- `interfaces/cross-service/service-to-agent-runner.md` — dropped the `prompt` wire row (LOW-7).
- `interfaces/in-service/sandbox-permission.md` — documented omitted-enforcement-defaults-to-strict (LOW-6).
- `projects/sidecar-trust-and-sandbox-enforcement/README.md` — both sides now read `AGENTA_AGENT_RUNNER_TOKEN` (LOW-5).
- `projects/qa/matrix.md` — F-028 wording.

Decisions logged in `qa/final-sweep-decisions.md` (D-018..D-021), left unassigned per the QA-scratch convention.

## Review ask

Please sanity-check the three contract-adjacent changes: (1) LOW-7 — confirm removing `prompt` from `protocol.ts` is acceptable given it was already dead on the wire and the golden is untouched; (2) LOW-6 — confirm flipping the omitted-enforcement default to strict is the desired alignment; (3) LOW-5 — confirm reusing the runner's `AGENTA_AGENT_RUNNER_TOKEN` env name on the client side is the right single-knob design.

https://claude.ai/code/session_01GYo3UEfvsZpncagqb28Mbc
