### PR TITLE
feat(frontend): offer Agent type in the Prompts page create menu

### DIFF
--- a/web/oss/src/components/pages/prompts/components/PromptsBreadcrumb.tsx
+++ b/web/oss/src/components/pages/prompts/components/PromptsBreadcrumb.tsx
@@ -148,6 +148,16 @@ const PromptsBreadcrumb = ({
                         ),
                         onClick: () => onNewPrompt?.("completion"),
                     },
+                    {
+                        key: "new_prompt_agent",
+                        label: (
+                            <span className="inline-flex items-center gap-2">
+                                {getAppTypeIcon("agent")}
+                                <span>Agent</span>
+                            </span>
+                        ),
+                        onClick: () => onNewPrompt?.("agent"),
+                    },
                 ],
             },
             {

--- a/web/oss/src/components/pages/prompts/components/PromptsTableSection.tsx
+++ b/web/oss/src/components/pages/prompts/components/PromptsTableSection.tsx
@@ -92,6 +92,23 @@ export const PromptsTableSection = ({
                             onOpenNewPrompt("completion")
                         },
                     },
+                    {
+                        key: "new_prompt_agent",
+                        label: (
+                            <span className="inline-flex items-center gap-2">
+                                {getAppTypeIcon("agent")}
+                                <span>Agent</span>
+                            </span>
+                        ),
+                        onClick: ({
+                            domEvent,
+                        }: {
+                            domEvent: React.MouseEvent | React.KeyboardEvent
+                        }) => {
+                            domEvent.stopPropagation()
+                            onOpenNewPrompt("agent")
+                        },
+                    },
                 ],
             },
             {


### PR DESCRIPTION
> Stacked on #4850 (agent config panel); it needs the agent create drawer from that PR. Base is `fe-feat/agent-config-panel-onbig` so the diff is just this feature, and it retargets/rebases onto `big-agents` once #4850 merges.

## Context

Agents can be created from the Home page (the create modal offers Chat / Completion / Agent), but the **Prompts page** "Create new" menu (and the breadcrumb create menu) only listed Chat and Completion, so agent workflows couldn't be created there.

## Changes

Added an **Agent** item to both create menus, wired exactly like Chat/Completion:
- [PromptsTableSection](web/oss/src/components/pages/prompts/components/PromptsTableSection.tsx) ("Create new" → New prompt submenu)
- [PromptsBreadcrumb](web/oss/src/components/pages/prompts/components/PromptsBreadcrumb.tsx) (breadcrumb create menu)

No new logic was needed. The create handler was already type-agnostic: `onOpenNewPrompt: (type: AppType)` → `handleOpenNewPromptModal` → `createEphemeralAppFromTemplate({type})` → open the agent create drawer. `getAppTypeIcon` already had the agent (robot) icon. Only the two menu entries were missing.

## For the agent service (Mahmoud / agents)

Pure FE menu wiring. No new backend or create-flow code. It reuses the exact `createEphemeralAppFromTemplate({type: "agent"})` path the Home modal already uses.

## Tests / notes

- tsc + eslint clean on both files.
- The create path is identical to the Home "Agent" option, which is confirmed working (Home → Agent → the agent create drawer opens with the config panel + chat).
- The live submenu render was not screenshotted: the "Create new" menu opens, but antd's nested "New prompt" submenu does not expand under browser automation.

## What to QA

- Prompts page → Create new → New prompt → Agent. The agent create drawer opens with the agent config panel + chat (same as creating an agent from Home).
- Regression: Chat and Completion still create their respective apps.
