### PR TITLE
docs(agent): agent-creation skills + custom-tools design note

### DIFF
--- a/docs/design/agent-workflows/projects/agent-creation-skills/README.md
+++ b/docs/design/agent-workflows/projects/agent-creation-skills/README.md
@@ -1,0 +1,254 @@
+# Agent-creation skills
+
+Skills that let a person, or an agent harness, create and run agents on Agenta from the
+outside: discover tools, learn the agent config schema, create and update a workflow, pick
+a harness, set secrets, and invoke. Plus self-hosting skills for running Agenta with and
+without the Claude subscription sidecar.
+
+This workspace holds the design, the draft skill files, and the custom-tools design note.
+The skills under `skills/` are drafts for review. When approved they move to
+`.agents/skills/<name>/` (symlinked into `.claude/skills/`), matching the repo convention.
+
+## Status
+
+Draft, opened for morning review. Every API call below was run against the live dev stack
+on 2026-06-26 (`http://localhost:8280`, project `hotel-agent`). The full create -> commit
+-> invoke loop returned a correct answer. Test workflows were archived after the run.
+
+## What "creating an agent" means in Agenta
+
+An agent is a **workflow**. A workflow is the Git-style triple Agenta uses for every
+versioned resource:
+
+- **Workflow (artifact)** — the named thing. "My Agent."
+- **Variant** — a branch of it. "main", "experiment-claude."
+- **Revision** — an immutable commit on a variant. Each revision carries the agent config.
+
+The agent config itself lives at `data.parameters.agent` inside a revision. Its catalog type
+is `agent_config` (the `x-ag-type-ref` the playground renders), but the **payload location is
+`parameters.agent`**, not `ag_config`. The builtin agent workflow is addressed by the URI
+`agenta:builtin:agent:v0`, stored in the revision's `data.uri` field.
+
+So creating an agent is four calls:
+
+1. `POST /api/workflows/` — create the artifact.
+2. `POST /api/workflows/variants/` — create a variant under it.
+3. `POST /api/workflows/revisions/commit` — commit a revision with the agent config.
+4. `POST /services/agent/v0/invoke` (or `/messages` to stream) — run it.
+
+Updating an agent is one more `commit` on the same variant; it appends a new revision
+(version increments). History is visible via `POST /api/workflows/revisions/log`.
+
+## Verified API calls
+
+All calls authenticate with `Authorization: ApiKey <key>` and carry `?project_id=<uuid>`
+(or OTel baggage). The agent runner is reached under `/services/`; the management API under
+`/api/`.
+
+### 1. Create the workflow artifact
+
+```
+POST /api/workflows/
+{
+  "workflow": {
+    "slug": "my-agent-<unique>",
+    "name": "My Agent",
+    "description": "Agent via API",
+    "flags": { "is_custom": false }
+  }
+}
+-> 200 { "workflow": { "id": "<workflow_id>", "slug": "...", ... } }
+```
+
+### 2. Create a variant
+
+Note the wrapper key is `workflow_variant` and the parent is `workflow_id` (the manual
+`.http` test files predate this rename and use `variant`/`artifact_id` — those 422 now).
+
+```
+POST /api/workflows/variants/
+{
+  "workflow_variant": {
+    "name": "main",
+    "slug": "main-<unique>",
+    "description": "main variant",
+    "workflow_id": "<workflow_id>"
+  }
+}
+-> 200 { "workflow_variant": { "id": "<variant_id>", ... } }
+```
+
+### 3. Commit a revision with the agent config
+
+The agent config goes in `data.parameters.agent`. The builtin URI goes in `data.uri` (use
+`uri`, not `url` — `url` is validated as an HTTP(S) URL and rejects the `agenta:` scheme).
+
+```
+POST /api/workflows/revisions/commit
+{
+  "workflow_revision": {
+    "message": "initial agent config",
+    "slug": "rev-<unique>",
+    "workflow_variant_id": "<variant_id>",
+    "data": {
+      "uri": "agenta:builtin:agent:v0",
+      "parameters": {
+        "agent": {
+          "agents_md": "You are a helpful research assistant. Answer concisely.",
+          "model": "openai/gpt-4o-mini",
+          "tools": [],
+          "harness": "pi_core",
+          "sandbox": "local",
+          "permission_policy": "auto"
+        }
+      }
+    }
+  }
+}
+-> 200 { "workflow_revision": { "id": "...", "version": "0", ... } }
+```
+
+### 4. Invoke
+
+```
+POST /services/agent/v0/invoke
+Accept: application/json
+{
+  "data": {
+    "inputs": { "messages": [ { "role": "user", "content": "What is the capital of France?" } ] },
+    "parameters": { "agent": { ...same agent config... } }
+  }
+}
+-> 200 { "data": { "outputs": { "role": "assistant", "content": "The capital of France is Paris." } } }
+```
+
+Stream the same body to `/services/agent/v0/messages` with `Accept: text/event-stream` and a
+Vercel `UIMessage`-shaped `data.messages` to get the playground's SSE stream.
+
+`/invoke` runs the config in the request directly. To run a *stored* revision, the playground
+resolves the revision first and passes its `parameters.agent`. The config in the request is
+the same object either way.
+
+## The agent config schema
+
+The schema is generated from `AgentConfigSchema` in
+`sdks/python/agenta/sdk/utils/types.py` and parsed at runtime by `AgentConfig` in
+`sdks/python/agenta/sdk/agents/dtos.py`. Fields (playground-facing names):
+
+| Field | Type | Default | Notes |
+|---|---|---|---|
+| `agents_md` | string | default AGENTS.md | The agent's standing instructions. (Runtime fallback key: `instructions`.) |
+| `model` | string or object | `"gpt-5.5"` | `"openai/gpt-4o-mini"` or `{provider, model, params, connection:{mode, slug}}`. |
+| `tools` | list | `[]` | Discriminated on `type`: `builtin`, `gateway`, `code`, `client`, `reference`. |
+| `mcp_servers` | list | `[]` | `{name, transport: stdio\|http, command/url, args, env, secrets, permission}`. |
+| `skills` | list | `[]` | Inline `SkillConfig` `{name, description, body, files}` or an `@ag.embed` reference. |
+| `harness` | string | `"pi_core"` | `pi_core`, `pi_agenta`, or `claude`. |
+| `sandbox` | string | `"local"` | `local` or `daytona`. |
+| `permission_policy` | enum | `"auto"` | `auto` or `deny`; how a permission-gating harness answers tool prompts headlessly. |
+| `sandbox_permission` | object | none | Layer-2 sandbox boundary (network egress, filesystem, enforcement). |
+| `harness_kwargs` | object | `{}` | Per-harness escape hatch keyed by harness name, e.g. `{"pi_core": {"append_system": "..."}}`. |
+
+### Harness selection and capabilities (from `/inspect`)
+
+`POST /services/agent/v0/inspect` returns `meta.harness_capabilities`, the source of truth
+for what each harness can do. Verified on the live stack:
+
+- `pi_core` (plain Pi) and `pi_agenta` (Pi + Agenta forced skills/persona/tools): providers
+  `openai, anthropic, gemini, mistral, groq, minimax, together_ai, openrouter`; connection
+  modes `agenta, self_managed`.
+- `claude` (Claude Code): provider `anthropic` only; deployments `direct, custom, bedrock,
+  vertex_ai, vertex`; models are aliases `default, sonnet, opus, haiku`.
+
+Pick a harness by setting `agent.harness` to one of those exact strings. A server-side
+capability check gates harness x provider x connection-mode x deployment before and after
+the vault resolve, so an invalid combination fails loud.
+
+## Tools: discovery, connections, resolution, calls
+
+Composio is the gateway provider. On the live stack: **1047 integrations**; GitHub alone
+exposes **846 actions**. Search is essential, hence the search-tools custom tool in the
+design note.
+
+- `GET /api/tools/catalog/providers/` — list providers (`composio`).
+- `GET /api/tools/catalog/providers/composio/integrations/?search=github&limit=20` — find an
+  integration (cursor-paginated; search suppresses the cursor).
+- `GET /api/tools/catalog/providers/composio/integrations/github/actions/?search=CREATE_ISSUE&limit=3`
+  — find an action (returns `count`, `total`, `cursor`, `actions[]`).
+- `POST /api/tools/connections/` — create a connection (initiates OAuth; open
+  `connection.data.redirect_url`). Body: `{connection: {slug, name, provider_key:"composio",
+  integration_key:"github"}}`.
+- `POST /api/tools/connections/query` — list connections.
+- `POST /api/tools/resolve` — expand a tool spec into the runner's view
+  (`{builtins, custom}`). Verified.
+- `POST /api/tools/call` — execute one tool. Body: `{data: {id, type:"function",
+  function: {name: "tools.composio.github.LIST_PULL_REQUESTS.<connection-slug>",
+  arguments: {...}}}}`.
+
+A gateway tool on the agent config references the connection by slug:
+
+```json
+{
+  "type": "gateway", "provider": "composio",
+  "integration": "github", "action": "GITHUB_CREATE_ISSUE",
+  "connection": "my-github-conn", "needs_approval": true
+}
+```
+
+## Secrets / vault
+
+Provider keys live in the project vault. The agent resolves the right one server-side from
+the caller's auth at invoke time; the client never sends the key.
+
+- `GET /api/vault/v1/secrets/` — list (verified; returns `provider_key` entries).
+- `POST /api/vault/v1/secrets/` — create. Verified create + delete round-trip:
+
+```
+POST /api/vault/v1/secrets/
+{
+  "header": { "name": "OpenAI", "description": "..." },
+  "secret": {
+    "kind": "provider_key",
+    "data": { "kind": "openai", "provider": { "key": "sk-..." } }
+  }
+}
+-> 200 { "id": "<secret_id>", ... }
+```
+
+- `PUT /api/vault/v1/secrets/{id}` — update. `DELETE /api/vault/v1/secrets/{id}` — delete.
+
+`secret.kind` is one of `provider_key`, `custom_provider`, `sso_provider`,
+`webhook_provider`. For a standard provider key, `data.kind` is the provider:
+`openai, anthropic, gemini, mistral, groq, cohere, together_ai, openrouter, perplexityai,
+deepinfra, anyscale, alephalpha, minimax`. `custom_provider` (`azure, bedrock, vertex_ai,
+sagemaker, custom, ...`) takes a `provider: {url, version, key}` and a `models` list.
+
+To pin a specific named secret on the agent config, set
+`model.connection = {"mode": "agenta", "slug": "<secret-name>"}`. With no slug, Agenta picks
+the project default for the model's provider. `mode: "self_managed"` injects nothing (the
+harness uses its own login, e.g. the Claude subscription sidecar).
+
+## Source map (load-bearing files)
+
+- Agent config schema generator + CATALOG_TYPES: `sdks/python/agenta/sdk/utils/types.py`
+- Runtime config parser + `HarnessType` + `SessionConfig`: `sdks/python/agenta/sdk/agents/dtos.py`
+- `/invoke` `/inspect` `/messages` handler: `services/oss/src/agent/app.py`
+- `/inspect` schema wrapper + default config: `services/oss/src/agent/schemas.py`
+- Model / connection DTOs: `sdks/python/agenta/sdk/agents/connections/models.py`
+- Tools / MCP / skills DTOs: `sdks/python/agenta/sdk/agents/{tools,mcp,skills}/models.py`
+- Workflows router + request models: `api/oss/src/apis/fastapi/workflows/{router.py,models.py}`
+- Revision data validation (`uri` vs `url`): `sdks/python/agenta/sdk/models/workflows.py`
+- Tools router: `api/oss/src/apis/fastapi/tools/router.py`
+- Vault router + secret DTOs: `api/oss/src/apis/fastapi/vault/router.py`, `api/oss/src/core/secrets/{dtos,enums}.py`
+- Manual API test recipes: `api/oss/tests/manual/{tools,workflows}/*.http`
+- Subscription sidecar recipe: `docs/design/agent-workflows/projects/subscription-sidecar/README.md`
+
+## Contents of this workspace
+
+- `README.md` — this design doc and verified API reference.
+- `skills/create-agenta-agent/SKILL.md` — the draft skill for creating an agent end to end.
+- `skills/self-host-agenta/SKILL.md` — the draft skill for self-hosting Agenta with and
+  without the Claude subscription sidecar.
+- `custom-tools-design.md` — the design note for the platform/gateway tools that let a
+  harness create agents (search-tools, create-workflow, invoke-workflow, update-own-workflow,
+  add-annotations, and more).
+- `build-notes.md` — decisions and judgment calls from this build.

--- a/docs/design/agent-workflows/projects/agent-creation-skills/build-notes.md
+++ b/docs/design/agent-workflows/projects/agent-creation-skills/build-notes.md
@@ -1,0 +1,81 @@
+# Build notes: agent-creation skills
+
+Overnight build, 2026-06-26. Session-authored decisions and judgment calls. The user was
+asleep and authorized child subagents for the research.
+
+## What was built
+
+- `README.md` — design doc + verified API reference for agent creation.
+- `skills/create-agenta-agent/` — SKILL.md + reference.md + runnable `create_agent.py`.
+- `skills/self-host-agenta/` — SKILL.md + reference.md.
+- `custom-tools-design.md` — design note for the agent-self-creation tools.
+
+The skills live under this project workspace as drafts. When approved they move to
+`.agents/skills/<name>/` (symlinked into `.claude/skills/`), matching the repo convention.
+They were NOT placed there yet, to keep the PR a reviewable proposal rather than a live
+behavior change.
+
+## Live verification (this is the load-bearing part)
+
+Everything in the skills was run against the live dev stack on 2026-06-26:
+
+- Host `http://localhost:8280`, project `hotel-agent`
+  (`019e8df5-635d-7261-85db-d40eb02a1f38`), API key from
+  `examples/python/hotel_agent/draft/.env`.
+- Full loop verified: create workflow -> create variant -> commit revision (agent config) ->
+  invoke. Returned "The capital of France is Paris." and "The capital of Japan is Tokyo."
+- Update verified: a second commit appended version `1`; revisions log showed both.
+- Secrets verified: list, create (fake anthropic key), delete (cleanup) round-trip.
+- Tools verified: catalog providers (1 = composio, 1047 integrations), github actions search
+  (846 total), `/tools/resolve`.
+- Harness capabilities pulled live from `/inspect` for all three harnesses.
+- The bundled `create_agent.py` ran end to end with `--archive` and cleaned up after itself.
+- All test workflows were archived. The fake secret was deleted.
+
+## Decisions and judgment calls
+
+1. **`parameters.agent`, not `ag_config`.** The brief and a memory note call the payload
+   `ag_config`. The code has no such key. The catalog *type* is `agent_config`; the payload
+   *location* is `data.parameters.agent`. The skills use the correct name and call this out
+   explicitly as a gotcha, since the wrong name is in circulation.
+
+2. **`data.uri`, not `data.url`.** The first commit attempt used `url` and got a 422 ("Invalid
+   URL format") because `url` is validated as an HTTP(S) URL. The builtin scheme
+   `agenta:builtin:agent:v0` only fits `uri`. Found by reading
+   `sdks/python/agenta/sdk/models/workflows.py`. Documented as a gotcha.
+
+3. **Variant request wrapper renamed.** The manual `.http` test files use `variant` /
+   `artifact_id`; the live API now wants `workflow_variant` / `workflow_id` and 422s
+   otherwise. The skills use the current shape and note the drift.
+
+4. **Did not test the Claude harness live.** The b2-rendering stack points at its own
+   API-key sidecar (`sandbox-agent:8765`), and the subscription sidecar (`:8790`) is a
+   separate, deliberately-unwired container. Repointing the running stack to test Claude
+   risked disrupting the live deployment, against the hygiene rule. Claude harness selection
+   and capabilities are documented from the verified `/inspect` output and the
+   subscription-sidecar README (which records its own 2026-06-25 verification) rather than
+   re-run. The create/commit/invoke loop is harness-agnostic, so the Pi verification covers
+   the mechanics; only the harness string and provider differ for Claude.
+
+5. **Cheap models only.** Used `gpt-4o-mini` for every live invoke, per hygiene.
+
+6. **Custom-tools note is design-only.** Per the brief. It maps each proposed tool to an
+   existing, verified endpoint and to the harness tool path, but proposes no implementation.
+
+7. **Skill structure follows Anthropic's published guidance** (researched live): short
+   SKILL.md (the procedure), heavy reference split into a bundled `reference.md` loaded on
+   demand, a runnable script for the deterministic path, and a description written in third
+   person packed with when-to-use triggers. `allowed-tools` + `user-invocable` match the
+   repo's existing skills.
+
+## Follow-ups (not done here)
+
+- Live-verify the Claude harness via the subscription sidecar on a throwaway stack (not the
+  running one), then pin a replay test with the `agent-replay-test` skill.
+- When the skills are approved, move them to `.agents/skills/` and add the symlinks.
+- The custom-tools note's open questions need a product call (reserved provider vs builtin
+  names; self-only vs general update; budget guard wiring; annotation auto-on; bundle vs
+  individual).
+- Consider a `fetch_config_schema` example that pulls the live `agent_config` JSON Schema
+  from `/api/workflows/catalog/types/agent_config` so a builder agent can self-describe the
+  config (endpoint exists; not exercised this session).

--- a/docs/design/agent-workflows/projects/agent-creation-skills/custom-tools-design.md
+++ b/docs/design/agent-workflows/projects/agent-creation-skills/custom-tools-design.md
@@ -1,0 +1,186 @@
+# Custom tools for agent self-creation: design note
+
+Design only. These are the Agenta-default tools a harness would get so it can create, run,
+and improve agents from inside a run, the same way a person does through the API. The skills
+in this workspace teach a model to do this with raw HTTP; these tools make it a first-class,
+typed, permissioned capability that composes with any harness.
+
+Companion to the verified API research in `README.md`. Implementation is out of scope here.
+
+## Why these tools
+
+An agent that can build agents needs the same primitives a person uses, but shaped as tools:
+
+- It must **find** the right tool out of ~100k Composio actions across ~1000 integrations.
+  Listing is hopeless; search is the only workable interface.
+- It must **create** and **update** a workflow, and **run** one to test it.
+- It must **improve itself**: update its own workflow's config and leave a trace of what it
+  tried.
+- It must **record** findings on traces so a later run (or a person) can search them.
+
+These map to the API surface that already exists and was verified live. The tools are thin,
+permissioned wrappers over those endpoints, exposed through the gateway so every harness
+(Pi, Claude, Agenta) gets them identically.
+
+## How they compose with the harnesses
+
+These are **gateway / builtin** tools on the agent config, not harness-specific. A harness
+sees them as normal tool calls; the runner routes each call to the Agenta API using the run's
+caller auth (the same per-request credential the run already carries, so a created agent
+inherits no more access than the caller). Because they ride the existing tool path:
+
+- They work on `pi_core`, `pi_agenta`, and `claude` with no per-harness code.
+- Each carries `needs_approval` / `permission` like any tool, so a deployment can require a
+  human to approve `create_workflow` while letting `search_tools` run freely.
+- They are listed in the agent config's `tools`, so an "agent-builder" agent is just a normal
+  agent with these tools enabled and an `agents_md` that explains the workflow.
+
+A natural packaging: a single reserved bundle (e.g. `_agenta.agent_builder`) that enables the
+set below, plus a forced skill that documents the create -> commit -> invoke loop (the
+`create-agenta-agent` skill content). Enabling the bundle turns any agent into one that can
+build agents.
+
+## The proposed tools
+
+Priority order. The first five are the must-haves from the brief; the rest are the obvious
+companions.
+
+### 1. `search_tools` (must-have)
+
+Find a Composio integration and action by intent. The single most important tool: without it
+the catalog is unusable from inside a run.
+
+- Inputs: `query` (free text), optional `integration`, `limit`, `read_only` filter.
+- Behavior: searches integrations and actions, returns ranked `{integration, action_key,
+  name, description, input_schema_summary}`. Two-stage (integration then action) mirrors the
+  catalog endpoints.
+- Backs onto: `GET /api/tools/catalog/.../integrations/?search=` and `.../actions/?search=`.
+- Permission: read-only, safe to leave un-gated.
+
+### 2. `create_workflow` (must-have)
+
+Create an agent: the artifact, a variant, and an initial revision with the agent config, in
+one call (so the model does not have to chain three).
+
+- Inputs: `name`, `slug?`, `agent_config` (the `parameters.agent` object), `variant_slug?`,
+  `message?`.
+- Behavior: `POST /api/workflows/` -> `POST /api/workflows/variants/` ->
+  `POST /api/workflows/revisions/commit` with `data.uri = agenta:builtin:agent:v0`. Returns
+  the ids and the version.
+- Permission: default `needs_approval` in shared projects; it creates a durable resource.
+
+### 3. `invoke_workflow` (must-have)
+
+Run a workflow (by id/slug, or an inline config) and get the output. Lets a builder agent
+test what it created.
+
+- Inputs: `workflow_ref` (id or slug) or inline `agent_config`, plus `messages` / `inputs`,
+  optional `stream`.
+- Behavior: resolve the revision if a ref is given, then `POST /services/agent/v0/invoke`.
+  Returns the assistant output and the `trace_id`.
+- Guardrail: depth/recursion limit so a builder agent cannot fork-bomb itself; a per-run
+  budget cap. Cheap-model default for self-tests.
+- Permission: gateable; read-ish but it spends model budget.
+
+### 4. `update_own_workflow` (must-have)
+
+Let an agent improve itself: commit a new revision to its *own* workflow variant. Scoped to
+the running agent's own workflow so it cannot rewrite arbitrary agents.
+
+- Inputs: `agent_config` (the new config), `message`.
+- Behavior: resolve the running agent's own `workflow_variant_id` from the run context, then
+  `POST /api/workflows/revisions/commit`. Appends a version; never overwrites.
+- Guardrail: the runner injects the owning variant id; the tool does not accept an arbitrary
+  target. A general `update_workflow` (any target) is a separate, more-privileged tool.
+- Permission: default `needs_approval`; self-modification should be visible.
+
+### 5. `add_trace_annotation` (must-have)
+
+Record a finding on the current (or a referenced) trace so it is searchable later. This is
+how a builder agent leaves notes a future run or a person can query: "what did the agent try,
+and what worked?"
+
+- Inputs: `trace_id?` (defaults to the current run), `name`, `data` (structured), `note?`.
+- Behavior: write an annotation linked to the trace via the annotations API. Annotations are
+  queryable, so later runs can search prior attempts and outcomes.
+- Backs onto: the annotations/tracing API (see `api/oss/src/apis/fastapi/annotations/`).
+- Permission: write, but low-risk; safe to leave un-gated within the caller's project.
+
+### 6. `manage_connection` (companion)
+
+Create and check a Composio connection from inside a run, so a builder agent can wire a tool
+end to end.
+
+- Inputs: `action` (`create`/`status`/`list`), `integration`, `slug?`.
+- Behavior: `POST /api/tools/connections/` returns the OAuth `redirect_url` for a human to
+  finish; `status` polls. The tool cannot complete OAuth itself (by design: a human approves
+  the grant), so it surfaces the redirect and the pending state.
+- Permission: gateable; it initiates an external auth grant.
+
+### 7. `set_secret` (companion)
+
+Store a provider key or named secret in the project vault.
+
+- Inputs: `name`, `kind` (`provider_key`/`custom_provider`), `provider`, `key` (write-only).
+- Behavior: `POST /api/vault/v1/secrets/`. The value is never echoed back.
+- Permission: default `needs_approval`; it writes a credential. Many deployments will keep
+  this human-only.
+
+### 8. `inspect_harnesses` (companion)
+
+Return the live `meta.harness_capabilities` so a builder agent picks a valid harness x
+provider x model combination before committing a config (instead of guessing and hitting the
+server-side gate).
+
+- Inputs: none.
+- Behavior: `POST /services/agent/v0/inspect`. Returns providers, models, connection modes,
+  and deployments per harness.
+- Permission: read-only.
+
+### 9. `list_my_workflows` / `get_workflow` (companion)
+
+Discover and read existing agents in the project, so a builder agent can fork or update one
+rather than starting blank.
+
+- Behavior: `POST /api/workflows/query`, `GET /api/workflows/{id}`,
+  `POST /api/workflows/revisions/retrieve`, `POST /api/workflows/revisions/log`.
+- Permission: read-only within the caller's project.
+
+### 10. `fork_workflow` (companion)
+
+Branch an existing agent into a new variant to experiment without touching the original.
+
+- Behavior: `POST /api/workflows/variants/fork`.
+- Permission: gateable; it creates a durable resource.
+
+## Cross-cutting design choices
+
+- **One auth, per request.** Every tool uses the run's caller credential. A created or
+  modified agent never escalates beyond the caller. No global service key.
+- **Permission per tool, not per bundle.** Each tool carries `needs_approval` / `permission`
+  so a deployment tunes the risk surface (e.g. `search_tools` free, `set_secret` human-only).
+- **Self-scope by default.** `update_own_workflow` targets only the running agent's own
+  variant; arbitrary-target editing is a separate, higher-privilege tool. This bounds the
+  blast radius of a self-improving agent.
+- **Recursion and budget guards on `invoke_workflow`.** Depth limit plus a per-run model
+  budget, cheap-model default for self-tests, so a builder agent cannot spend unboundedly or
+  recurse forever.
+- **Annotations as the memory substrate.** `add_trace_annotation` plus searchable traces give
+  a builder agent (and a person) a durable, queryable record of what was tried. This is the
+  feedback loop that makes self-improvement more than one-shot.
+- **Gateway-shaped, harness-agnostic.** Exposing them through the existing gateway/tool path
+  means zero per-harness work and identical behavior across Pi, Agenta, and Claude.
+
+## Open questions for review
+
+- Should the builder tools be a reserved gateway provider (`tools.agenta.*`) or builtin tool
+  names? Reserved provider keeps them out of the Composio namespace and lets the resolver own
+  routing.
+- `update_workflow` (any target) vs `update_own_workflow` (self only): ship self-only first,
+  add the general one behind a stronger permission later?
+- How does `invoke_workflow`'s budget guard interact with the existing per-project metering?
+  Reuse the meter or add a per-run cap?
+- Should `add_trace_annotation` be auto-on for every builder agent (so the record always
+  exists), or an explicit tool the model chooses to call?
+- Packaging: one `_agenta.agent_builder` bundle + forced skill, or individually selectable
+  tools? A bundle is the simplest "make this agent able to build agents" switch.

--- a/docs/design/agent-workflows/projects/agent-creation-skills/custom-tools-design.md
+++ b/docs/design/agent-workflows/projects/agent-creation-skills/custom-tools-design.md
@@ -1,5 +1,14 @@
 # Custom tools for agent self-creation: design note
 
+> **⚠️ SUPERSEDED (2026-06-27).** The framing below — bespoke tools that wrap business logic
+> (`create_workflow`, `update_own_workflow`, `invoke_workflow`, `add_trace_annotation`, …) — was
+> the **first version** and is **not** what we are building. The decision: **platform tools are a
+> thin wrapper that exposes EXISTING Agenta endpoints to the harness** — no new endpoints, no
+> hidden logic. The harness calls raw endpoints and composes multi-step operations via a skill,
+> using its own run context (its trace_id / variant). See
+> `../direct-call-tools/` (`design.md` + `run-context.md`) for the current design. Treat the named
+> "tools" below as illustrative endpoint targets, not as logic-wrapping tools to build.
+
 Design only. These are the Agenta-default tools a harness would get so it can create, run,
 and improve agents from inside a run, the same way a person does through the API. The skills
 in this workspace teach a model to do this with raw HTTP; these tools make it a first-class,

--- a/docs/design/agent-workflows/projects/agent-creation-skills/skills/create-agenta-agent/SKILL.md
+++ b/docs/design/agent-workflows/projects/agent-creation-skills/skills/create-agenta-agent/SKILL.md
@@ -1,0 +1,212 @@
+---
+name: create-agenta-agent
+description: Create, configure, update, and run an agent on Agenta through the HTTP API. Use when the user wants to build an Agenta agent, create an agent workflow, set its instructions or model or tools, pick a harness (Pi or Claude), connect Composio tools, set a provider key, or invoke an agent over the API. Covers discovering tools, the agent config schema, the create/commit/invoke calls, and updating an existing agent.
+allowed-tools: Read, Bash, Write, Grep, Glob
+user-invocable: true
+---
+
+# Create an Agenta agent
+
+Build an agent on Agenta from the outside, over the HTTP API. An agent is a versioned
+**workflow**; its config lives in a **revision**. Creating one is four calls, updating it is
+one more. This skill gives the exact payloads, verified against a live stack.
+
+Read `reference.md` in this folder for the full field tables, the tools catalog, the secrets
+schema, and the harness capability map. This file is the procedure.
+
+## Mental model
+
+An agent is the Git-style triple Agenta uses for every versioned thing:
+
+- **Workflow (artifact)** — the named agent.
+- **Variant** — a branch of it (`main`, `experiment-claude`).
+- **Revision** — an immutable commit on a variant. The agent config rides here.
+
+The agent config sits at `data.parameters.agent` in a revision. Its catalog type is
+`agent_config`, but the payload key is **`agent`**, never `ag_config`. The builtin agent
+workflow is addressed by the URI `agenta:builtin:agent:v0` in the revision's `data.uri`.
+
+## Setup
+
+You need three things:
+
+1. The host, e.g. `http://localhost:8280` (dev) or your cloud host.
+2. An API key. Header: `Authorization: ApiKey <key>`.
+3. A `project_id`. List projects with `GET /api/projects/`. Pass it as `?project_id=<uuid>`
+   on every call.
+
+The management API is under `/api/`. The agent runner is under `/services/`.
+
+## Step 0 (optional): discover what's available
+
+- Harnesses, providers, and models: `POST /services/agent/v0/inspect` with `{}`. Read
+  `meta.harness_capabilities`. `claude` only supports the `anthropic` provider with aliases
+  `default/sonnet/opus/haiku`; `pi_core` and `pi_agenta` support eight providers.
+- Tools: search the Composio catalog. There are ~1000 integrations and hundreds of actions
+  each, so always search, never list blind.
+  - `GET /api/tools/catalog/providers/composio/integrations/?search=github&limit=20`
+  - `GET /api/tools/catalog/providers/composio/integrations/github/actions/?search=create_issue&limit=10`
+- Existing secrets: `GET /api/vault/v1/secrets/`.
+
+## Step 1: create the workflow artifact
+
+```bash
+curl -sS -X POST "$HOST/api/workflows/?project_id=$PROJECT" \
+  -H "Authorization: ApiKey $KEY" -H 'Content-Type: application/json' \
+  -d '{ "workflow": { "slug": "my-agent-001", "name": "My Agent",
+        "description": "Agent via API", "flags": { "is_custom": false } } }'
+# -> 200, save .workflow.id
+```
+
+## Step 2: create a variant
+
+The wrapper key is `workflow_variant` and the parent is `workflow_id`. (Old `.http` test
+files use `variant`/`artifact_id`; those now 422.)
+
+```bash
+curl -sS -X POST "$HOST/api/workflows/variants/?project_id=$PROJECT" \
+  -H "Authorization: ApiKey $KEY" -H 'Content-Type: application/json' \
+  -d '{ "workflow_variant": { "name": "main", "slug": "main-001",
+        "description": "main variant", "workflow_id": "<workflow_id>" } }'
+# -> 200, save .workflow_variant.id
+```
+
+## Step 3: commit a revision with the agent config
+
+The config goes in `data.parameters.agent`. The builtin URI goes in `data.uri` (use `uri`,
+not `url`; `url` is validated as HTTP(S) and rejects the `agenta:` scheme).
+
+```bash
+curl -sS -X POST "$HOST/api/workflows/revisions/commit?project_id=$PROJECT" \
+  -H "Authorization: ApiKey $KEY" -H 'Content-Type: application/json' \
+  -d '{
+    "workflow_revision": {
+      "message": "initial agent config", "slug": "rev-001",
+      "workflow_variant_id": "<variant_id>",
+      "data": {
+        "uri": "agenta:builtin:agent:v0",
+        "parameters": { "agent": {
+          "agents_md": "You are a helpful research assistant. Answer concisely.",
+          "model": "openai/gpt-4o-mini",
+          "tools": [], "harness": "pi_core", "sandbox": "local",
+          "permission_policy": "auto"
+        } }
+      }
+    } }'
+# -> 200, .workflow_revision.version == "0"
+```
+
+### Minimal vs full config
+
+The minimum is `agents_md` and `model`. Everything else has a default. The fields:
+
+- `agents_md` (string) — the agent's instructions.
+- `model` (string or object) — `"openai/gpt-4o-mini"`, or
+  `{"provider":"anthropic","model":"claude-opus-4-8","connection":{"mode":"agenta","slug":"anthropic-prod"}}`.
+- `harness` — `pi_core` (plain Pi), `pi_agenta` (Pi + Agenta skills), `claude` (Claude Code).
+- `sandbox` — `local` or `daytona`.
+- `tools`, `mcp_servers`, `skills` — see `reference.md` for the shapes.
+- `permission_policy` — `auto` or `deny`.
+
+To add a Composio tool, first create a connection (Step 5b), then put a gateway tool in
+`tools`:
+
+```json
+{ "type": "gateway", "provider": "composio", "integration": "github",
+  "action": "GITHUB_CREATE_ISSUE", "connection": "my-github-conn", "needs_approval": true }
+```
+
+## Step 4: invoke
+
+```bash
+curl -sS -X POST "$HOST/services/agent/v0/invoke?project_id=$PROJECT" \
+  -H "Authorization: ApiKey $KEY" -H 'Content-Type: application/json' -H 'Accept: application/json' \
+  -d '{ "data": {
+        "inputs": { "messages": [ { "role": "user", "content": "What is the capital of France?" } ] },
+        "parameters": { "agent": { "agents_md": "Answer in one short sentence.",
+                                    "model": "openai/gpt-4o-mini", "harness": "pi_core" } } } }'
+# -> { "data": { "outputs": { "role": "assistant", "content": "The capital of France is Paris." } } }
+```
+
+`/invoke` runs the config in the request directly. To stream as the playground does, POST the
+same body (with `data.messages` in Vercel `UIMessage` shape) to `/services/agent/v0/messages`
+with `Accept: text/event-stream`.
+
+To run a *stored* revision instead of an inline config, fetch it first
+(`POST /api/workflows/revisions/retrieve`) and pass its `parameters.agent` as the config.
+
+## Step 5: the supporting tasks
+
+### 5a. Set a provider key (secret)
+
+The client never sends the key at invoke time. Store it once in the vault; the agent resolves
+it server-side from your auth.
+
+```bash
+curl -sS -X POST "$HOST/api/vault/v1/secrets/?project_id=$PROJECT" \
+  -H "Authorization: ApiKey $KEY" -H 'Content-Type: application/json' \
+  -d '{ "header": { "name": "OpenAI" },
+        "secret": { "kind": "provider_key",
+                    "data": { "kind": "openai", "provider": { "key": "sk-..." } } } }'
+```
+
+`data.kind` is the provider (`openai`, `anthropic`, `gemini`, ...). For Azure/Bedrock/Vertex
+use `secret.kind: "custom_provider"` (see `reference.md`).
+
+### 5b. Connect a Composio tool
+
+```bash
+curl -sS -X POST "$HOST/api/tools/connections/?project_id=$PROJECT" \
+  -H "Authorization: ApiKey $KEY" -H 'Content-Type: application/json' \
+  -d '{ "connection": { "slug": "my-github-conn", "name": "My GitHub",
+        "provider_key": "composio", "integration_key": "github" } }'
+# Open .connection.data.redirect_url in a browser to finish OAuth, then poll
+# GET /api/tools/connections/<id> until it is connected.
+```
+
+Then reference the connection slug in a gateway tool on the agent config (Step 3).
+
+### 5c. Pick the harness
+
+Set `agent.harness`. Confirm the harness supports your model and provider with
+`/inspect` first. `claude` needs an `anthropic` provider key (or a self-managed login such
+as the subscription sidecar; see the `self-host-agenta` skill). Pi harnesses work with any
+of their eight providers.
+
+## Updating an agent
+
+Commit another revision on the same variant. It appends a new version; nothing is
+overwritten.
+
+```bash
+curl -sS -X POST "$HOST/api/workflows/revisions/commit?project_id=$PROJECT" \
+  -H "Authorization: ApiKey $KEY" -H 'Content-Type: application/json' \
+  -d '{ "workflow_revision": { "message": "tighten persona", "slug": "rev-002",
+        "workflow_variant_id": "<variant_id>",
+        "data": { "uri": "agenta:builtin:agent:v0",
+                  "parameters": { "agent": { "agents_md": "You are terse. One word answers.",
+                                             "model": "openai/gpt-4o-mini", "harness": "pi_core" } } } } }'
+```
+
+See history: `POST /api/workflows/revisions/log` with
+`{ "workflow_revisions": { "workflow_variant_id": "<variant_id>", "depth": 10 } }`.
+
+## Gotchas
+
+- **`parameters.agent`, not `ag_config`.** The catalog *type name* is `agent_config`; the
+  payload *key* is `agent`.
+- **`data.uri`, not `data.url`.** `url` is validated as an HTTP(S) URL. The builtin scheme
+  `agenta:builtin:agent:v0` only fits `uri`.
+- **Variant wrapper renamed.** Use `workflow_variant` + `workflow_id`, not `variant` +
+  `artifact_id`.
+- **Harness x provider gating is server-side.** A bad combo (e.g. `harness: claude` with an
+  `openai` model) fails loud. Check `/inspect` first.
+- **Keys are resolved server-side.** Do not send provider keys in the invoke body; store them
+  in the vault. Use `model.connection.slug` to pin a specific named secret.
+- **Use cheap models when testing** (`gpt-4o-mini`, `claude haiku`).
+
+## Verify with the bundled script
+
+`create_agent.py` in this folder runs the whole loop (create -> variant -> commit -> invoke)
+and prints each response. Run it with `uv run create_agent.py --host ... --key ... --project ...`.
+It uses inline `# /// script` deps, so no install step.

--- a/docs/design/agent-workflows/projects/agent-creation-skills/skills/create-agenta-agent/create_agent.py
+++ b/docs/design/agent-workflows/projects/agent-creation-skills/skills/create-agenta-agent/create_agent.py
@@ -1,0 +1,162 @@
+# /// script
+# requires-python = ">=3.10"
+# dependencies = ["httpx"]
+# ///
+"""Create an Agenta agent end to end and invoke it.
+
+Runs the full loop: create workflow -> create variant -> commit a revision with the agent
+config -> invoke. Prints each response. Use cheap models when testing.
+
+Usage:
+    uv run create_agent.py \
+        --host http://localhost:8280 \
+        --key  <AGENTA_API_KEY> \
+        --project <PROJECT_ID> \
+        [--model openai/gpt-4o-mini] [--harness pi_core] \
+        [--prompt "You are a terse geography bot."] \
+        [--question "What is the capital of France?"] \
+        [--archive]   # archive the test workflow when done
+
+Verified against the live dev stack on 2026-06-26. The whole loop is four HTTP calls; the
+config object is identical for the stored revision and the invoke.
+"""
+
+import argparse
+import json
+import sys
+import uuid
+
+import httpx
+
+
+def main() -> int:
+    ap = argparse.ArgumentParser(description=__doc__)
+    ap.add_argument("--host", required=True, help="e.g. http://localhost:8280")
+    ap.add_argument("--key", required=True, help="Agenta API key (ApiKey auth)")
+    ap.add_argument("--project", required=True, help="project_id (UUID)")
+    ap.add_argument("--model", default="openai/gpt-4o-mini")
+    ap.add_argument(
+        "--harness", default="pi_core", choices=["pi_core", "pi_agenta", "claude"]
+    )
+    ap.add_argument(
+        "--prompt",
+        default="You are a helpful research assistant. Answer in one short sentence.",
+    )
+    ap.add_argument("--question", default="What is the capital of France?")
+    ap.add_argument(
+        "--archive", action="store_true", help="archive the created workflow at the end"
+    )
+    args = ap.parse_args()
+
+    g = uuid.uuid4().hex[:8]
+    auth = {"Authorization": f"ApiKey {args.key}", "Content-Type": "application/json"}
+    client = httpx.Client(
+        base_url=args.host,
+        headers=auth,
+        timeout=120,
+        params={"project_id": args.project},
+    )
+
+    agent_config = {
+        "agents_md": args.prompt,
+        "model": args.model,
+        "tools": [],
+        "harness": args.harness,
+        "sandbox": "local",
+        "permission_policy": "auto",
+    }
+
+    def call(label: str, r: httpx.Response) -> dict:
+        print(f"\n### {label}: {r.status_code}")
+        try:
+            body = r.json()
+            print(json.dumps(body, indent=2)[:900])
+        except Exception:
+            print(r.text[:600])
+            body = {}
+        if r.status_code >= 300:
+            sys.exit(f"{label} failed")
+        return body
+
+    # 1. create workflow artifact
+    wf = call(
+        "1. CREATE WORKFLOW",
+        client.post(
+            "/api/workflows/",
+            json={
+                "workflow": {
+                    "slug": f"my-agent-{g}",
+                    "name": f"My Agent {g}",
+                    "description": "Agent created by create_agent.py",
+                    "flags": {"is_custom": False},
+                }
+            },
+        ),
+    )["workflow"]
+
+    # 2. create variant
+    var = call(
+        "2. CREATE VARIANT",
+        client.post(
+            "/api/workflows/variants/",
+            json={
+                "workflow_variant": {
+                    "name": f"main-{g}",
+                    "slug": f"main-{g}",
+                    "description": "main variant",
+                    "workflow_id": wf["id"],
+                }
+            },
+        ),
+    )["workflow_variant"]
+
+    # 3. commit a revision carrying the agent config
+    call(
+        "3. COMMIT REVISION (agent config)",
+        client.post(
+            "/api/workflows/revisions/commit",
+            json={
+                "workflow_revision": {
+                    "message": "initial agent config",
+                    "slug": f"rev-{g}",
+                    "workflow_variant_id": var["id"],
+                    "data": {
+                        "uri": "agenta:builtin:agent:v0",
+                        "parameters": {"agent": agent_config},
+                    },
+                }
+            },
+        ),
+    )
+
+    # 4. invoke the agent
+    out = call(
+        "4. INVOKE AGENT",
+        client.post(
+            "/services/agent/v0/invoke",
+            headers={**auth, "Accept": "application/json"},
+            json={
+                "data": {
+                    "inputs": {
+                        "messages": [{"role": "user", "content": args.question}]
+                    },
+                    "parameters": {"agent": agent_config},
+                }
+            },
+        ),
+    )
+    answer = out.get("data", {}).get("outputs", {}).get("content")
+    print(f"\n>>> answer: {answer}")
+
+    if args.archive:
+        call(
+            "5. ARCHIVE WORKFLOW (cleanup)",
+            client.post(f"/api/workflows/{wf['id']}/archive"),
+        )
+
+    print(f"\nworkflow_id={wf['id']} variant_id={var['id']}")
+    return 0
+
+
+if __name__ == "__main__":
+    raise SystemExit(main())

--- a/docs/design/agent-workflows/projects/agent-creation-skills/skills/create-agenta-agent/reference.md
+++ b/docs/design/agent-workflows/projects/agent-creation-skills/skills/create-agenta-agent/reference.md
@@ -1,0 +1,187 @@
+# create-agenta-agent: reference
+
+Full field tables, the tools catalog, the secrets schema, and the harness capability map.
+Loaded on demand by the `create-agenta-agent` skill. Every fact here was verified against a
+live stack on 2026-06-26.
+
+## The agent config schema
+
+Generated from `AgentConfigSchema` (`sdks/python/agenta/sdk/utils/types.py`), parsed at
+runtime by `AgentConfig` (`sdks/python/agenta/sdk/agents/dtos.py`). Goes at
+`data.parameters.agent`.
+
+| Field | Type | Required | Default | Notes |
+|---|---|---|---|---|
+| `agents_md` | string | no | default AGENTS.md | Standing instructions. Runtime fallback key: `instructions`. |
+| `model` | string or object | no | `"gpt-5.5"` | See "Model" below. |
+| `tools` | list | no | `[]` | Discriminated on `type`. See "Tools". |
+| `mcp_servers` | list | no | `[]` | See "MCP servers". |
+| `skills` | list | no | `[]` | Inline `SkillConfig` or `@ag.embed` ref. See "Skills". |
+| `harness` | string | no | `"pi_core"` | `pi_core`, `pi_agenta`, `claude`. |
+| `sandbox` | string | no | `"local"` | `local`, `daytona`. |
+| `permission_policy` | enum | no | `"auto"` | `auto`, `deny`. How a permission-gating harness answers tool prompts headlessly. |
+| `sandbox_permission` | object | no | none | Layer-2 boundary: network egress, filesystem, enforcement. Omit for no boundary. |
+| `harness_kwargs` | object | no | `{}` | Per-harness escape hatch keyed by harness name. E.g. `{"pi_core":{"append_system":"..."}}`. Both Pi harnesses read the `pi_core` slice. |
+
+### Model
+
+A plain string or a structured object.
+
+- String: `"gpt-4o-mini"` (provider inferred) or `"openai/gpt-4o-mini"` (explicit).
+- Object (`ModelRef`):
+
+```json
+{ "provider": "anthropic", "model": "claude-opus-4-8",
+  "params": { "reasoning_effort": "high" },
+  "connection": { "mode": "agenta", "slug": "anthropic-prod" } }
+```
+
+`connection.mode` is `agenta` (Agenta injects a vault key) or `self_managed` (Agenta injects
+nothing; the harness uses its own login). For `agenta`, `slug` names a specific secret; omit
+it to take the project default for the provider. A `self_managed` connection must not carry a
+`slug`.
+
+### Tools
+
+Discriminated union on `type`. Shared base: `needs_approval` (bool, default false),
+`permission` (`allow`/`ask`/`deny`), `render` (object).
+
+```json
+// builtin: a harness-native tool (read, write, bash, ...)
+{ "type": "builtin", "name": "read" }
+
+// gateway: a Composio action through the Agenta gateway
+{ "type": "gateway", "provider": "composio", "integration": "github",
+  "action": "GITHUB_CREATE_ISSUE", "connection": "my-github-conn", "needs_approval": true }
+
+// code: an inline function the runner executes
+{ "type": "code", "name": "add", "runtime": "python",
+  "script": "def run(a, b):\n    return a + b",
+  "input_schema": { "type": "object", "properties": { "a": {"type":"number"}, "b": {"type":"number"} } },
+  "secrets": [] }
+
+// client: a tool the calling client fulfills (HITL / app-side)
+{ "type": "client", "name": "ask_user", "input_schema": { "type": "object", "properties": {} } }
+
+// reference: another Agenta workflow used as a tool
+{ "type": "reference", "slug": "my-other-workflow", "version": 3 }
+```
+
+A bare string or `{ "name": "read" }` coerces to a `builtin`.
+
+### MCP servers
+
+```json
+{ "name": "filesystem", "transport": "stdio",
+  "command": "npx", "args": ["-y", "@modelcontextprotocol/server-filesystem", "/workspace"],
+  "env": {}, "secrets": {}, "tools": [], "permission": "ask" }
+// or transport "http" with "url": "https://..."
+```
+
+MCP is flag-gated; on this dev stack `AGENTA_AGENT_ENABLE_MCP=false`. Confirm it is enabled
+before relying on it.
+
+### Skills
+
+Inline `SkillConfig`:
+
+```json
+{ "name": "release-notes",
+  "description": "Use when asked to draft release notes from a changelog.",
+  "body": "# Release notes\nSummarize the changelog into user-facing bullets.",
+  "files": [], "disable_model_invocation": false, "allow_executable_files": false }
+```
+
+`name` matches `^[a-z0-9]+(-[a-z0-9]+)*$`, <= 64 chars. `description` <= 1024. `body` <=
+50000. Or reference a workflow-backed skill with an `@ag.embed` block.
+
+## Harness capabilities (live `/inspect` output)
+
+`POST /services/agent/v0/inspect` with `{}` returns `meta.harness_capabilities`:
+
+| Harness | Providers | Connection modes | Deployments | Model selection |
+|---|---|---|---|---|
+| `pi_core` | openai, anthropic, gemini, mistral, groq, minimax, together_ai, openrouter | agenta, self_managed | direct | `provider/id` |
+| `pi_agenta` | (same eight) | agenta, self_managed | direct | `provider/id` |
+| `claude` | anthropic | agenta, self_managed | direct, custom, bedrock, vertex_ai, vertex | aliases: `default`, `sonnet`, `opus`, `haiku` |
+
+The capability check runs server-side before and after the vault resolve. An invalid
+combination (e.g. `claude` with an `openai` model) fails loud with a clear error.
+
+## Tools catalog (Composio)
+
+On the live stack: 1 provider (`composio`), 1047 integrations. GitHub alone exposes 846
+actions. Always search.
+
+- `GET /api/tools/catalog/providers/` -> `{count, providers[]}`.
+- `GET /api/tools/catalog/providers/composio` -> one provider.
+- `GET /api/tools/catalog/providers/composio/integrations/?limit=20&cursor=<next>` -> page of
+  integrations. `?search=<term>` filters (and suppresses the cursor).
+- `GET /api/tools/catalog/providers/composio/integrations/<integration>` -> one integration.
+- `GET /api/tools/catalog/providers/composio/integrations/<integration>/actions/?search=<term>&limit=20`
+  -> `{count, total, cursor, actions[]}`. Each action has `key`, `name`, `description`,
+  `categories`, `read_only`.
+- `GET /api/tools/catalog/providers/composio/integrations/<integration>/actions/<action_key>`
+  -> one action (with its input schema).
+
+### Connections
+
+- `POST /api/tools/connections/` body `{connection: {slug, name, description?, provider_key:"composio", integration_key:"github"}}`.
+  Returns `connection.data.redirect_url`; open it to finish OAuth.
+- `GET /api/tools/connections/<id>` -> poll status after OAuth.
+- `POST /api/tools/connections/query` -> list (filterable by `provider_key`, `integration_key`).
+- `POST /api/tools/connections/<id>/refresh`, `/revoke`; `DELETE /api/tools/connections/<id>`.
+
+### Resolve and call
+
+- `POST /api/tools/resolve` body `{tools: [...]}` -> `{count, builtins, custom}`. Expands a
+  tool spec into the runner's view; useful to validate a config before committing.
+- `POST /api/tools/call` body
+  `{data: {id, type:"function", function: {name:"tools.composio.github.LIST_PULL_REQUESTS.<connection-slug>", arguments:{...}}}}`.
+  The slug pattern is `tools.{provider}.{integration}.{ACTION}.{connection-slug}`.
+
+## Secrets / vault
+
+- `GET /api/vault/v1/secrets/` -> list.
+- `POST /api/vault/v1/secrets/` -> create.
+- `GET|PUT|DELETE /api/vault/v1/secrets/<id>` -> read / update / delete.
+
+`secret.kind` is one of `provider_key`, `custom_provider`, `sso_provider`,
+`webhook_provider`.
+
+Standard provider key:
+
+```json
+{ "header": { "name": "OpenAI", "description": "..." },
+  "secret": { "kind": "provider_key",
+              "data": { "kind": "openai", "provider": { "key": "sk-..." } } } }
+```
+
+`data.kind` (standard providers): `openai, cohere, anyscale, deepinfra, alephalpha, groq,
+minimax, mistral, anthropic, perplexityai, together_ai, openrouter, gemini`.
+
+Custom provider (Azure, Bedrock, Vertex, self-hosted):
+
+```json
+{ "header": { "name": "MyAzure" },
+  "secret": { "kind": "custom_provider",
+              "data": { "kind": "azure",
+                        "provider": { "url": "https://...", "version": "2024-02-01", "key": "..." },
+                        "models": [ { "slug": "gpt-4o" } ] } } }
+```
+
+`custom_provider` kinds: `custom, azure, bedrock, sagemaker, vertex_ai, openai, cohere,
+anyscale, deepinfra, alephalpha, groq, minimax, mistral, anthropic, perplexityai,
+together_ai, openrouter, gemini`.
+
+## Auth and routing
+
+- Auth header: `Authorization: ApiKey <key>` (or a SuperTokens cookie in the browser).
+- `project_id`: query param `?project_id=<uuid>` or OTel baggage.
+- Management API: `/api/...` (the `api` container).
+- Agent runner: `/services/agent/v0/{invoke,inspect,messages}` (the `services` container).
+- Both behind the same traefik host (dev: `:8280`).
+
+The provider key is resolved server-side from the project vault using the caller's auth. The
+run never gets more access than the caller. A named connection (`mode:agenta` + slug) selects
+a specific secret; the project default is used when no slug is given.

--- a/docs/design/agent-workflows/projects/agent-creation-skills/skills/self-host-agenta/SKILL.md
+++ b/docs/design/agent-workflows/projects/agent-creation-skills/skills/self-host-agenta/SKILL.md
@@ -1,0 +1,153 @@
+---
+name: self-host-agenta
+description: Run a self-hosted Agenta stack and wire up agents. Use when the user wants to self-host Agenta, start the local dev stack, run Agenta with or without the agent runner sidecar, enable Claude with an API key or a Claude subscription (OAuth) login, or configure provider keys, MCP, and the Daytona sandbox for self-hosted agents. Covers the docker-compose stack, the sandbox-agent runner, the subscription sidecar recipe, and the env that controls each.
+allowed-tools: Read, Bash, Write, Grep, Glob
+user-invocable: true
+---
+
+# Self-host Agenta
+
+Stand up a self-hosted Agenta stack and run agents on it, with or without the agent runner
+sidecar, with an API key or a Claude subscription login. This file is the procedure. Read
+`reference.md` in this folder for the full env table and the trust model.
+
+## The pieces
+
+A running Agenta stack is one traefik fronting several containers. The ones that matter for
+agents:
+
+- `web` — the Next.js frontend.
+- `api` — the management API (`/api/...`): workflows, vault, tools, projects.
+- `services` — the workflow runner, including the builtin agent at
+  `/services/agent/v0/...`. It drives the agent.
+- `sandbox-agent` (optional) — the TypeScript runner sidecar. It is the thing that actually
+  spawns the harness (Pi, Claude) over ACP. `services` talks to it over the compose network.
+
+The agent works **without** the sidecar (the runner can spawn the harness CLI from a local
+checkout) and **with** it (the deployed path, where `services` calls the sidecar over HTTP).
+Which path runs is set by one env var, `AGENTA_AGENT_RUNNER_URL`.
+
+## Run the stack (no agents, baseline)
+
+From the repo root, on the main branch:
+
+```bash
+./hosting/docker-compose/run.sh --build --license ee --dev --env-file .env.ee.dev.local
+```
+
+- `--license ee` for the EE stack, `--license oss` for OSS.
+- `--dev` mounts source for hot reload. Drop it for a production-style run.
+- From a git worktree, prefix a distinct project name so compose does not collide:
+  `COMPOSE_PROJECT_NAME=agenta-ee-dev-instance2 ... --env-file .env.ee.dev.instance2`.
+
+The web app is on the traefik port (dev default `:8280`). Health: `curl $HOST/api/health`
+-> `{"status":"ok"}`.
+
+After it is up, set a provider key in the vault and create an agent with the
+`create-agenta-agent` skill.
+
+## Run agents WITHOUT the sidecar
+
+The agent runner can spawn the harness CLI directly from a local source checkout. Leave
+`AGENTA_AGENT_RUNNER_URL` unset and point `AGENTA_AGENT_RUNNER_DIR` at the runner source.
+`services` then runs the TS runner as a subprocess. This is the lightest setup: no extra
+container, but `services` needs Node and the runner deps available.
+
+Use this for local development of the runner itself. For anything shared or deployed, use the
+sidecar.
+
+## Run agents WITH the sidecar (the deployed path)
+
+The dev compose already defines the `sandbox-agent` service and wires it:
+
+```
+AGENTA_AGENT_RUNNER_URL=http://sandbox-agent:8765   # services -> sidecar over the compose net
+```
+
+When this is set, `services` POSTs each run to the sidecar's `/run`. The sidecar holds the
+harness binaries (Pi is baked; Claude Code is installed at runtime). This is what runs on the
+dev box today (compose project `agenta-ee-dev-wp-b2-rendering`).
+
+Sidecar health: from the host, `curl http://<sidecar>:8765/health` ->
+`{"status":"ok","engines":["sandbox-agent"],"harnesses":["pi_core","claude","pi_agenta"]}`.
+
+The sidecar must stay loopback-only or on the private compose network. It receives resolved
+provider keys in `/run` bodies, so it must never be exposed off-host. See `reference.md` for
+the trust model.
+
+## Claude: API key vs subscription (OAuth)
+
+Claude Code (the `claude` harness) authenticates two ways.
+
+### A. API key (managed)
+
+Store an `anthropic` provider key in the project vault (see the `create-agenta-agent` skill,
+"Set a provider key"). At invoke time Agenta resolves it server-side and injects
+`ANTHROPIC_API_KEY` into the harness env. Use `harness: "claude"`, `model: "sonnet"` (or
+`opus`/`haiku`/`default`). This is the normal self-host path.
+
+### B. Subscription / OAuth (self-managed)
+
+Drive Claude Code off a Claude **subscription** login (Max/Pro) instead of an API key. No key
+is stored anywhere; the harness uses a mounted OAuth login. On the agent config set
+`model.connection = {"mode": "self_managed"}` so Agenta injects nothing and the harness uses
+its own login.
+
+The reproducible recipe stands up a **second** sidecar that mounts the host's
+`~/.claude` (read-only) and serves the existing runner image with no API key:
+
+```bash
+REPO=/path/to/agenta
+IMAGE=agenta-ee-dev-sandbox-agent:latest
+HOST_PORT=8790    # distinct, loopback-only
+
+docker rm -f agenta-claude-sub-sidecar 2>/dev/null || true
+docker run -d --name agenta-claude-sub-sidecar \
+  --user "$(id -u):$(id -g)" \
+  -p 127.0.0.1:${HOST_PORT}:8765 \
+  -e PORT=8765 -e AGENTA_AGENT_RUNNER_HOST=0.0.0.0 -e NODE_ENV=development \
+  -e HOME=/home/agent -e PI_CODING_AGENT_DIR=/pi-agent -e SANDBOX_AGENT_PROVIDER=local \
+  --tmpfs /home/agent:exec,uid=$(id -u),gid=$(id -g) \
+  -v "$REPO/services/agent/src":/app/src:ro \
+  -v "$REPO/services/agent/skills":/app/skills:ro \
+  -v "$HOME/.claude":/home/agent/.claude:ro \
+  "$IMAGE" node_modules/.bin/tsx src/server.ts
+
+curl -s http://127.0.0.1:${HOST_PORT}/health
+```
+
+Before mounting, confirm the host login is a subscription (OAuth), not an API key:
+`~/.claude/.credentials.json` should have a `claudeAiOauth` block with `subscriptionType`
+`max`/`pro` and an `sk-ant-oat01-...` access token (`sk-ant-api...` is an API key). The full
+recipe, including the OAuth check and why each docker flag is there, is in
+`docs/design/agent-workflows/projects/subscription-sidecar/README.md`.
+
+This second sidecar is a DEV/TEST target by default. To make `services` send Claude runs to
+it instead of the API-key sidecar, point `AGENTA_AGENT_RUNNER_URL` at it (or wire it via the
+playground's composite sidecar URI). Keep it loopback-only.
+
+## Daytona cloud sandbox (optional)
+
+To run an agent in a Daytona cloud VM instead of locally, set `agent.sandbox = "daytona"` on
+the config. The sidecar reads `SANDBOX_AGENT_DAYTONA_*` (API key, URL, target, snapshot) to
+create the VM. The default snapshot is `agenta-sandbox-pi`. These are distinct from the api's
+`DAYTONA_*` vars. ALWAYS tear a Daytona sandbox down after use and verify it is gone; never
+leave a cloud sandbox open.
+
+## Quick verification
+
+After the stack is up and a provider key is set, run the `create-agenta-agent` skill's
+bundled `create_agent.py` against your host. It creates, invokes, and (with `--archive`)
+cleans up. A correct one-line answer proves the whole path: api -> services -> sidecar ->
+harness -> provider.
+
+## Gotchas
+
+- The sidecar must never be reachable off-host. It carries resolved secrets in run bodies.
+- The subscription sidecar needs a writable `HOME` (tmpfs) with the credential mounted
+  read-only *into* it; run as the host user so it can read the mounted `~/.claude`.
+- MCP is flag-gated. `AGENTA_AGENT_ENABLE_MCP` defaults to `false` in dev compose.
+- New Python deps in `sdks/pyproject.toml` crash-loop the dev `api` container on hot reload;
+  rebuild (`run.sh --build`) rather than relying on reload.
+- A non-secure HTTP dev host disables `crypto.randomUUID` and other secure-context Web APIs;
+  the frontend can crash silently. Use HTTPS for anything beyond local poking.

--- a/docs/design/agent-workflows/projects/agent-creation-skills/skills/self-host-agenta/reference.md
+++ b/docs/design/agent-workflows/projects/agent-creation-skills/skills/self-host-agenta/reference.md
@@ -1,0 +1,93 @@
+# self-host-agenta: reference
+
+The env that controls the agent runtime, and the trust model. Loaded on demand by the
+`self-host-agenta` skill.
+
+## Topology
+
+One traefik fronts the stack. The agent path:
+
+```
+client -> traefik -> api        (/api/...)        management: workflows, vault, tools
+                  -> services   (/services/...)   the builtin agent /services/agent/v0/*
+services -> sandbox-agent (8765) the runner sidecar that spawns the harness over ACP
+sandbox-agent -> Pi | Claude Code  the harness
+harness -> provider (OpenAI, Anthropic, ...) using the resolved key or the harness login
+```
+
+`api` is reached at `/api/...`, `services` at `/services/...`, both behind the same traefik
+host (dev `:8280`).
+
+## Env that controls the agent runtime
+
+Set on the `services` container (it owns backend selection) unless noted.
+
+| Var | Where | Default | Effect |
+|---|---|---|---|
+| `AGENTA_AGENT_RUNNER_URL` | services | unset (dev compose sets `http://sandbox-agent:8765`) | Set -> POST runs to the sidecar's `/run` (deployed path). Unset -> spawn the runner CLI locally. |
+| `AGENTA_AGENT_RUNNER_DIR` | services | runner source dir | Where to find the TS runner when spawning locally. |
+| `AGENTA_AGENT_RUNNER_TIMEOUT_SECONDS` | services | 180 | Run timeout for the HTTP/subprocess call. |
+| `AGENTA_AGENT_ENABLE_MCP` | services | `false` | Gate MCP servers on the agent config. |
+| `SANDBOX_AGENT_PROVIDER` | sidecar | `local` | `local` daemon vs cloud sandbox provider. |
+| `SANDBOX_AGENT_DAYTONA_API_KEY` | sidecar | empty | Daytona API key (for `sandbox: "daytona"` runs). |
+| `SANDBOX_AGENT_DAYTONA_API_URL` | sidecar | empty | Daytona API URL. |
+| `SANDBOX_AGENT_DAYTONA_TARGET` | sidecar | empty | Daytona region, e.g. `eu`. |
+| `SANDBOX_AGENT_DAYTONA_SNAPSHOT` | sidecar | `agenta-sandbox-pi` | Daytona snapshot to boot. |
+| `ANTHROPIC_API_KEY` | sidecar | unset | Inherited only on a managed run; the subscription path sets none. |
+| `PORT` | sidecar | 8765 | Sidecar listen port. |
+| `AGENTA_AGENT_RUNNER_HOST` | sidecar | `0.0.0.0` | Bind host inside the container. |
+
+The per-request `sandbox` axis (`local` vs `daytona`) is on the agent config, not env. The
+backend is always the sandbox-agent backend; only the transport (`RUNNER_URL`) and the
+sandbox axis vary.
+
+## Two backend paths
+
+- **Sidecar path** (deployed): `AGENTA_AGENT_RUNNER_URL` set. `services` POSTs to the
+  sidecar over the compose network. The sidecar holds the harness binaries. This is the
+  default on the dev box.
+- **Local-spawn path** (runner dev): `AGENTA_AGENT_RUNNER_URL` unset,
+  `AGENTA_AGENT_RUNNER_DIR` points at the runner checkout. `services` runs the TS runner as a
+  subprocess. No sidecar container; `services` needs Node and the runner deps.
+
+## Claude auth paths
+
+| Path | Connection mode | Key storage | How the harness authenticates |
+|---|---|---|---|
+| API key (managed) | `agenta` (default) | `anthropic` provider key in the project vault | Agenta resolves the key server-side and injects `ANTHROPIC_API_KEY`. |
+| Subscription (self-managed) | `self_managed` | none | The harness reads a mounted Claude OAuth login (`~/.claude/.credentials.json`); Agenta injects nothing. |
+
+On a managed run, the runner clears ambient provider creds then injects the resolved key. On
+a non-managed (`self_managed`) run, it keeps the inherited environment and the harness's own
+login. That is why the subscription sidecar works with no code change: it just adds the
+mounted login as infrastructure.
+
+## Trust model (why the sidecar stays loopback-only)
+
+The runner ships **resolved secrets in `/run` request bodies** (the injected provider key, code-tool and
+MCP secrets). Anyone who can reach the sidecar can submit a run and observe its environment.
+So the sidecar must be loopback-only (`127.0.0.1`) or confined to the private compose
+network, never exposed off-host or to the public internet. The subscription sidecar binds
+`127.0.0.1:8790` for exactly this reason.
+
+The provider-key resolve uses the **caller's** auth (the `Authorization` on the invoke, else
+the process `AGENTA_API_KEY`). A run never gets more access than the caller. A named
+connection (`mode: agenta` + slug) selects one specific secret; the project default is used
+when no slug is given; `self_managed` injects nothing.
+
+## Port hygiene
+
+When running multiple stacks or sidecars on one host, pick distinct host ports. Known users
+on the dev box: `:8280/:8281` and `:8380/:8381` (web stacks via traefik), `:8480` (another
+web stack), `:8790` (subscription sidecar), `5432/5434/5435` (Postgres). Sidecars bind their
+host port to the container's `8765`.
+
+## Source map
+
+- Backend selection + invoke handler: `services/oss/src/agent/app.py`
+- Runner config / env: `services/oss/src/agent/config.py`
+- Compose definition + env wiring: `hosting/docker-compose/ee/docker-compose.dev.yml`
+- Run command and worktree notes: `hosting/AGENTS.md`
+- Sidecar Docker + OAuth notes: `services/agent/docker/README.md`
+- Subscription sidecar recipe: `docs/design/agent-workflows/projects/subscription-sidecar/README.md`
+- Sidecar deployment proposal (k8s/Helm/Railway plan): `docs/design/agent-workflows/projects/sidecar-deployment-proposal/`


### PR DESCRIPTION
## What

DRAFT for morning review. A new workspace of skills that let a person, or an agent harness, **create agents on Agenta over the API**, plus a design note for the gateway tools that would let a harness build agents itself.

Lives under `docs/design/agent-workflows/projects/agent-creation-skills/`. The skill files are drafts under `skills/`; when approved they move to `.agents/skills/<name>/` (symlinked into `.claude/skills/`), per repo convention. Nothing wired into runtime behavior.

## Why

We want users (and harnesses) to be able to build agents on Agenta without reverse-engineering the API. These skills capture the create -> commit -> invoke loop, the agent config schema, tool discovery, harness selection, and secrets, all verified against the live stack.

## Contents

- **`skills/create-agenta-agent/`** — SKILL.md (the procedure) + reference.md (full field tables, tools catalog, secrets schema, harness capability map) + `create_agent.py` (a runnable `uv run` script that does the whole loop with `--archive` cleanup).
- **`skills/self-host-agenta/`** — SKILL.md + reference.md: run the stack with/without the `sandbox-agent` sidecar, Claude via API key vs subscription (OAuth) login, the Daytona sandbox, and the trust model.
- **`custom-tools-design.md`** — design note for the agent-self-creation tools: `search_tools` (Composio has ~1000 integrations, search is essential), `create_workflow`, `invoke_workflow`, `update_own_workflow`, `add_trace_annotation`, plus companions. Design only; each maps to a verified endpoint.
- **`README.md`** — the verified API reference. **`build-notes.md`** — decisions and judgment calls.

## Verified live

Every API call was run against the dev stack on 2026-06-26 (project `hotel-agent`, cheap models). The full create workflow -> create variant -> commit revision (`parameters.agent`) -> invoke loop returned correct answers ("...Paris.", "...Tokyo."); update appended a version; secrets create/delete and tools search/resolve confirmed. The bundled script ran end to end and cleaned up after itself. Test workflows archived; fake secret deleted.

Key corrections to circulating lore, documented as gotchas: the config payload key is **`parameters.agent`** (not `ag_config`); the builtin URI goes in **`data.uri`** (not `data.url`, which validates as HTTP); the variant request wrapper is **`workflow_variant`/`workflow_id`** (the old `.http` files use `variant`/`artifact_id` and now 422).

## Review asks

- Is the custom-tools set the right shape, especially `update_own_workflow` (self-scoped) vs a general `update_workflow`, and the `invoke_workflow` recursion/budget guard? See the "Open questions for review" in the design note.
- Should the skills move to `.agents/skills/` now, or stay drafts until the custom tools land?

Design only / docs only. Not for merge yet.

https://claude.ai/code/session_01GYo3UEfvsZpncagqb28Mbc