### PR TITLE
fix(frontend): guard agent-chat run-error against crypto.randomUUID on plain HTTP

### DIFF
--- a/web/oss/src/components/AgentChatSlice/AgentChatPanel.tsx
+++ b/web/oss/src/components/AgentChatSlice/AgentChatPanel.tsx
@@ -1,6 +1,7 @@
 import {useCallback, useEffect, useMemo, useRef, useState} from "react"
 
 import {agentShouldResumeAfterApproval, buildAgentRequest} from "@agenta/playground"
+import {generateId} from "@agenta/shared/utils"
 import {useChat} from "@ai-sdk/react"
 import {Attachments, Bubble, Sender} from "@ant-design/x"
 import {ArrowDown, Paperclip} from "@phosphor-icons/react"
@@ -186,7 +187,7 @@ const AgentConversation = ({entityId, sessionId}: {entityId: string; sessionId: 
             return [
                 ...prev,
                 {
-                    id: `run-error-${crypto.randomUUID()}`,
+                    id: `run-error-${generateId()}`,
                     role: "assistant",
                     parts: [],
                     metadata: {runError: parsed},


### PR DESCRIPTION
## Symptom

On the plain-HTTP dev box (a non-secure browsing context), `crypto.randomUUID` is `undefined`. When an agent run errors, `AgentChatPanel` builds a fallback carrier message with `id: `run-error-${crypto.randomUUID()}`` and crashes the render, so the error is swallowed by the error boundary and the panel looks stuck.

## Fix

Use the existing `generateId()` helper from `@agenta/shared/utils` (uuid v4, no secure-context dependency) instead of `crypto.randomUUID`. This is the #4842 approach.

A sweep of the whole `AgentChatSlice` found only this one `crypto.randomUUID`. The other secure-context-adjacent API (`navigator.clipboard.writeText` in `AgentMessage.tsx`) is a user-gesture click handler, not a render path, so it is out of scope here.

## Test

- `pnpm lint-fix`: clean.
- OSS `types:check`: zero errors in `AgentChatSlice` (the repo's pre-existing `tsc` backlog is unrelated).

https://claude.ai/code/session_01GYo3UEfvsZpncagqb28Mbc