### PR TITLE
fix(agent): force the _agenta platform skill on every pi_agenta run (D-016)

### DIFF
--- a/api/oss/src/core/workflows/platform_catalog.py
+++ b/api/oss/src/core/workflows/platform_catalog.py
@@ -17,6 +17,10 @@ user cannot author or shadow it, and resolution never falls through to Postgres.
 from typing import Any, Dict, Optional, Tuple
 from uuid import UUID, uuid5
 
+from agenta.sdk.agents.adapters.agenta_builtins import (
+    AGENTA_GETTING_STARTED_SKILL,
+    AGENTA_GETTING_STARTED_SLUG,
+)
 from agenta.sdk.agents.skills.models import SkillConfig
 
 from oss.src.core.workflows.dtos import (
@@ -43,50 +47,19 @@ _PLATFORM_NAMESPACE_UUID = UUID("a6e6b3f2-2c4a-5f3a-9b6f-0a1b2c3d4e5f")
 
 
 # ---------------------------------------------------------------------------
-# Platform skill content (single source of the body text)
-# ---------------------------------------------------------------------------
-
-_GETTING_STARTED_BODY = (
-    "# Getting started with Agenta agents\n"
-    "\n"
-    "This skill orients an agent running on the Agenta platform.\n"
-    "\n"
-    "## When to use it\n"
-    "\n"
-    "Use it at the start of a task to recall how Agenta agents are expected to behave: be "
-    "concise, ask for missing inputs, and prefer the tools and skills the agent was given over "
-    "guessing.\n"
-    "\n"
-    "## Conventions\n"
-    "\n"
-    "- Greet the user once, then get to work.\n"
-    "- State assumptions briefly when a request is ambiguous.\n"
-    "- When a skill or tool references a relative path, resolve it against the skill directory "
-    "(the parent of SKILL.md) before running it.\n"
-    "- Keep answers short unless the user asks for depth.\n"
-)
-
-
-# ---------------------------------------------------------------------------
 # Catalogue definition
 # ---------------------------------------------------------------------------
 #
 # Each entry maps a reserved slug to a `current` version pointer and a map of immutable versions.
-# A version payload is a SkillConfig dict, validated at module import (see _validate_catalog).
+# A version payload is a SkillConfig dict, validated at module import (see _validate_catalog). The
+# skill content is canonical in the SDK (agenta_builtins.AGENTA_GETTING_STARTED_SKILL), imported
+# here so the embed path (this catalogue) and the forced path (AgentaHarness) stay one source.
 
 _PLATFORM_WORKFLOWS: Dict[str, Dict[str, Any]] = {
-    "_agenta.agenta-getting-started": {
+    AGENTA_GETTING_STARTED_SLUG: {
         "current": "v1",
         "versions": {
-            "v1": {
-                "name": "agenta-getting-started",
-                "description": (
-                    "Getting started on the Agenta platform: how an Agenta agent should behave, "
-                    "ask for missing inputs, and use its tools and skills. Use at the start of a "
-                    "task."
-                ),
-                "body": _GETTING_STARTED_BODY,
-            },
+            "v1": AGENTA_GETTING_STARTED_SKILL.model_dump(mode="json"),
         },
     },
 }

--- a/sdks/python/agenta/sdk/agents/adapters/agenta_builtins.py
+++ b/sdks/python/agenta/sdk/agents/adapters/agenta_builtins.py
@@ -5,14 +5,17 @@ every run carries a fixed set of Agenta-shipped extras the author cannot turn of
 
 - a base **persona** appended to Pi's system prompt (``AGENTA_FORCED_APPEND_SYSTEM``),
 - a base **AGENTS.md preamble** the author's instructions are appended to (``AGENTA_PREAMBLE``),
-- a set of **forced tools** (``AGENTA_FORCED_TOOLS``).
+- a set of **forced tools** (``AGENTA_FORCED_TOOLS``),
+- a set of **forced platform skills** (``AGENTA_FORCED_SKILLS``).
 
-Forced skills are *not* a constant here. They are platform default skills served from a
-code-defined ``PlatformWorkflowCatalog`` under the reserved ``_agenta.*`` slug namespace and
-embedded into the agent config (resolved server-side into concrete
-:class:`~agenta.sdk.agents.skills.SkillConfig` packages before the runner). By the time this
-harness runs, those defaults already ride ``AgentConfig.skills``, so the adapter needs no name
-list. The catalogue is a separate workstream (see the skills-config proposal).
+The forced platform skills are the actually-forced part of "forced skills". The default agent
+config template embeds the platform default skill by reserved ``_agenta.*`` slug, but that embed
+only rides the *default* template: a custom ``pi_agenta`` config that drops the embed would
+otherwise lose the platform skill entirely. To make "forced" mean forced, ``AgentaHarness``
+unions ``AGENTA_FORCED_SKILLS`` into every run's skills via :func:`force_skills`, regardless of
+what the author's config carries. The canonical skill content lives here (in the SDK, the lowest
+layer); the server-side ``PlatformWorkflowCatalog`` imports the same constant so the embed path
+and the forced path stay one source of truth.
 
 Two layers, kept distinct on purpose (matching Pi's own split, see :class:`PiAgentConfig`):
 the *persona* is an ``append_system`` (changes Pi's base prompt), while *project conventions*
@@ -23,6 +26,8 @@ is the persona layer.
 from __future__ import annotations
 
 from typing import List, Optional
+
+from ..skills import SkillConfig
 
 # The base AGENTS.md preamble. The author's own ``instructions`` are appended after this, so
 # the final AGENTS.md is ``AGENTA_PREAMBLE`` + the author's project conventions.
@@ -56,6 +61,48 @@ fabricate results."""
 # works via Pi defaults today).
 AGENTA_FORCED_TOOLS: List[str] = ["read", "bash"]
 
+# Reserved slug of the platform default skill. The default agent config template embeds the
+# skill by this slug; the server-side PlatformWorkflowCatalog resolves the slug to the
+# SkillConfig below. Kept here so the catalogue and the forced path share one slug constant.
+AGENTA_GETTING_STARTED_SLUG = "_agenta.agenta-getting-started"
+
+# Canonical SKILL.md body for the platform "getting started" skill. Single source of the body
+# text: the server-side PlatformWorkflowCatalog imports this constant rather than redeclaring it.
+_GETTING_STARTED_BODY = (
+    "# Getting started with Agenta agents\n"
+    "\n"
+    "This skill orients an agent running on the Agenta platform.\n"
+    "\n"
+    "## When to use it\n"
+    "\n"
+    "Use it at the start of a task to recall how Agenta agents are expected to behave: be "
+    "concise, ask for missing inputs, and prefer the tools and skills the agent was given over "
+    "guessing.\n"
+    "\n"
+    "## Conventions\n"
+    "\n"
+    "- Greet the user once, then get to work.\n"
+    "- State assumptions briefly when a request is ambiguous.\n"
+    "- When a skill or tool references a relative path, resolve it against the skill directory "
+    "(the parent of SKILL.md) before running it.\n"
+    "- Keep answers short unless the user asks for depth.\n"
+)
+
+# The platform default skill as a concrete inline package. This is the canonical content; the
+# server-side catalogue serves the same SkillConfig for the reserved slug above.
+AGENTA_GETTING_STARTED_SKILL = SkillConfig(
+    name="agenta-getting-started",
+    description=(
+        "Getting started on the Agenta platform: how an Agenta agent should behave, ask for "
+        "missing inputs, and use its tools and skills. Use at the start of a task."
+    ),
+    body=_GETTING_STARTED_BODY,
+)
+
+# Platform skills every pi_agenta run carries, regardless of the author's config. These are the
+# actually-forced skills (see module docstring); unioned in by `force_skills`.
+AGENTA_FORCED_SKILLS: List[SkillConfig] = [AGENTA_GETTING_STARTED_SKILL]
+
 
 def _join(*parts: Optional[str]) -> Optional[str]:
     """Join the non-empty parts with a blank line, or ``None`` when nothing remains."""
@@ -86,4 +133,20 @@ def force_tools(builtin_tools: List[str]) -> List[str]:
         if name and name not in seen:
             seen.add(name)
             out.append(name)
+    return out
+
+
+def force_skills(skills: List[SkillConfig]) -> List[SkillConfig]:
+    """Union the author's skills with the forced platform skills, de-duplicated by name.
+
+    The author's skills come first and win on a name clash (a config that already carries the
+    resolved platform skill — e.g. via the default template's embed — is not doubled), then any
+    forced platform skill not already present is appended. This is what makes the ``_agenta``
+    platform skill actually forced on a custom ``pi_agenta`` config that drops the embed."""
+    seen = {skill.name for skill in skills}
+    out: List[SkillConfig] = list(skills)
+    for forced in AGENTA_FORCED_SKILLS:
+        if forced.name not in seen:
+            seen.add(forced.name)
+            out.append(forced)
     return out

--- a/sdks/python/agenta/sdk/agents/adapters/harnesses.py
+++ b/sdks/python/agenta/sdk/agents/adapters/harnesses.py
@@ -35,6 +35,7 @@ from ..tools.models import ToolSpec, coerce_tool_spec
 from .agenta_builtins import (
     compose_append_system,
     compose_instructions,
+    force_skills,
     force_tools,
 )
 
@@ -118,8 +119,9 @@ class AgentaHarness(Harness):
     forced Agenta extras (see :mod:`.agenta_builtins`): a base AGENTS.md preamble the author's
     instructions are appended to, a forced persona ``append_system``, and forced tools. The
     author's own Pi ``harness_kwargs`` (``system`` / ``append_system``) still apply, layered
-    after the forced bits. Skills come from the neutral config as resolved inline packages;
-    seeding platform default skills is a separate project-creation workstream."""
+    after the forced bits. The author's resolved inline skills ride the neutral config, and the
+    forced platform skill(s) are unioned in (de-duped by name) so a custom config that drops the
+    default template's ``_agenta`` embed still carries the platform skill."""
 
     harness_type = HarnessType.AGENTA
 
@@ -135,7 +137,9 @@ class AgentaHarness(Harness):
             tool_specs=list(config.tool_specs),
             tool_callback=config.tool_callback,
             mcp_servers=list(config.mcp_servers),
-            skills=list(config.agent.skills),
+            # Force the platform skill(s) into every run, de-duped by name. A custom config that
+            # drops the default template's `_agenta` embed still gets the platform skill.
+            skills=force_skills(list(config.agent.skills)),
             sandbox_permission=config.agent.sandbox_permission,
             harness_kwargs=config.agent.harness_kwargs,
             system=_opt_str(pi_options.get("system")),

--- a/sdks/python/oss/tests/pytest/unit/agents/test_harness_adapters.py
+++ b/sdks/python/oss/tests/pytest/unit/agents/test_harness_adapters.py
@@ -2,8 +2,8 @@
 
 Pi and Claude genuinely differ (Pi takes built-ins and never gates tool use; Claude has no
 built-ins, delivers tools over MCP, and gates on a permission policy). Agenta is Pi with a
-fixed opinion: a forced preamble, persona, and tools. Skills ride the neutral config as
-resolved inline packages (seeding platform default skills is a separate workstream). These
+fixed opinion: a forced preamble, persona, tools, and platform skills. The author's resolved
+inline skills ride the neutral config and the forced platform skill(s) are unioned in. These
 tests lock that the translation honors those differences and that ``make_harness`` validates
 support.
 """
@@ -30,8 +30,11 @@ from agenta.sdk.agents import (
 from agenta.sdk.agents.adapters import harnesses
 from agenta.sdk.agents.adapters.agenta_builtins import (
     AGENTA_FORCED_APPEND_SYSTEM,
+    AGENTA_FORCED_SKILLS,
     AGENTA_FORCED_TOOLS,
+    AGENTA_GETTING_STARTED_SKILL,
     AGENTA_PREAMBLE,
+    force_skills,
 )
 from agenta.sdk.agents.adapters.harnesses import _normalize_tool_specs, _opt_str
 
@@ -128,14 +131,60 @@ def test_agenta_forces_tools_preamble_and_persona_and_carries_skills(make_env):
         assert forced in result.builtin_tools
     assert "web_search" in result.builtin_tools
     assert "read" in result.builtin_tools
-    # The author's resolved inline skills ride the config and reach the wire on their own seam.
-    assert [s.name for s in result.skills] == ["release-notes"]
+    # The author's resolved inline skills ride the config, plus the forced platform skill(s) the
+    # harness always injects. The author's skill comes first; the platform skill is appended.
+    skill_names = [s.name for s in result.skills]
+    assert skill_names[0] == "release-notes"
+    assert AGENTA_GETTING_STARTED_SKILL.name in skill_names
     assert "skills" not in result.wire_tools()
     assert result.wire_skills()["skills"][0]["name"] == "release-notes"
     # The persona is forced onto append_system; custom tools and callback pass through.
     assert result.append_system.startswith(AGENTA_FORCED_APPEND_SYSTEM)
     assert result.custom_tools[0]["name"] == "t"
     assert result.tool_callback is _CALLBACK
+
+
+def test_agenta_forces_platform_skill_on_a_skill_less_config(make_env):
+    # The actually-forced behavior: a custom pi_agenta config with NO skills (the default
+    # template's `_agenta` embed dropped) still carries the platform skill on every run.
+    harness = AgentaHarness(make_env(supported=[HarnessType.AGENTA]))
+    config = _session_config(
+        agent=AgentConfig(instructions="My project rules.", model="m", skills=[])
+    )
+
+    result = harness._to_harness_config(config)
+
+    assert [s.name for s in result.skills] == [AGENTA_GETTING_STARTED_SKILL.name]
+
+
+def test_agenta_does_not_duplicate_an_already_present_platform_skill(make_env):
+    # A config that already carries the resolved platform skill (e.g. via the default template's
+    # embed) is not doubled: the author's copy wins on the name clash.
+    harness = AgentaHarness(make_env(supported=[HarnessType.AGENTA]))
+    existing = AGENTA_GETTING_STARTED_SKILL.model_dump(mode="json")
+    config = _session_config(
+        agent=AgentConfig(instructions="hi", model="m", skills=[existing])
+    )
+
+    result = harness._to_harness_config(config)
+
+    names = [s.name for s in result.skills]
+    assert names.count(AGENTA_GETTING_STARTED_SKILL.name) == 1
+
+
+def test_force_skills_unions_forced_after_author_skills():
+    from agenta.sdk.agents.skills import SkillConfig
+
+    author = SkillConfig(
+        name="release-notes", description="Draft notes.", body="Do it."
+    )
+
+    out = force_skills([author])
+
+    assert out[0] is author
+    assert {s.name for s in out} == {"release-notes"} | {
+        s.name for s in AGENTA_FORCED_SKILLS
+    }
 
 
 def test_agenta_forces_tools_without_duplicates(make_env):


### PR DESCRIPTION
## Problem

The AgentaHarness platform skill (`_agenta.agenta-getting-started`) was only embedded in the **default** agent config template via an `@ag.embed`. A **custom** `pi_agenta` config that did not carry that embed dropped the skill entirely, so the supposedly forced platform skill was never actually forced. (This is QA decision D-016 / the F-036 'builtins-in-loaded' remainder.)

## Fix

- Add `AGENTA_FORCED_SKILLS` and `force_skills()` to `agenta_builtins.py`. The canonical getting-started `SkillConfig` content now lives in the SDK (the lowest layer).
- `AgentaHarness._to_harness_config` now unions the forced platform skill(s) into every run via `force_skills(...)`, de-duped by name (the author's skills come first and win on a name clash, so a default config that already carries the resolved skill is not doubled).
- The server-side `PlatformWorkflowCatalog` imports the same SDK constant for the reserved slug, so the embed path and the forced path stay one source of truth.

## Test

- SDK agents unit suite (397) green, including 3 new tests: forced skill on a skill-less custom config, no duplication when already present, `force_skills` union order.
- API platform-catalog test (29) green; live import+resolve verified (stable revision id, `is_platform=True`, body intact).
- Service default-agent-config test (5) green.
- `ruff format` + `ruff check`: clean.

## Remainder

The runner trace's `skills.loaded` is stamped from the wire skills, so this fix also makes the forced `_agenta` skill show up there for custom configs. No other remainder.

https://claude.ai/code/session_01GYo3UEfvsZpncagqb28Mbc