### PR TITLE
fix(agent): surface the runner's actionable error on the batch path (F-038)

### DIFF
--- a/sdks/python/agenta/sdk/agents/utils/ts_runner.py
+++ b/sdks/python/agenta/sdk/agents/utils/ts_runner.py
@@ -56,15 +56,42 @@ async def deliver_http(
     url = base_url.rstrip("/") + "/run"
     async with httpx.AsyncClient(timeout=timeout) as client:
         response = await client.post(url, json=payload, headers=_runner_auth_headers())
-    # Any non-2xx is a transport failure; 4xx left to fall through surfaces as an opaque
-    # JSON parse error instead of a clear runner failure. The response body can carry internal
-    # detail, so it is logged, not surfaced.
+    # A run failure comes back as HTTP 500 with a runner *result* body (``{"ok": false,
+    # "error": <concise message>}``; see ``server.ts``). That ``error`` is the actionable,
+    # already-sanitized provider message (e.g. "insufficient credit — add the project's
+    # Anthropic key"), and it is the SAME body the streaming path surfaces. Returning it lets
+    # ``result_from_wire`` raise with that message, so the batch path (``/invoke`` + the
+    # ``/messages`` JSON path) matches SSE instead of collapsing to a generic "HTTP 500".
+    body = _runner_result_body(response)
+    if body is not None:
+        return body
+    # Anything else at >=400 is a genuine transport failure (proxy error, auth gate, non-result
+    # body). The response text can carry internal detail, so it is logged, not surfaced.
     if response.status_code >= 400:
         raise _transport_error(
             f"Agent runner HTTP {response.status_code}",
             detail=response.text[:1000],
         )
     return response.json()
+
+
+def _runner_result_body(response: Any) -> Optional[Dict[str, Any]]:
+    """The runner result JSON when ``response`` carries one, else ``None``.
+
+    A successful 2xx is always a result. A run-failure 500 carries the same result shape
+    (``{"ok": ..., "error": ...}``); recognizing it here keeps the actionable ``error`` instead
+    of discarding it as an opaque transport failure. A non-result error body (no ``ok`` key)
+    returns ``None`` so the caller falls through to the generic transport error.
+    """
+    if response.status_code < 400:
+        return response.json()
+    try:
+        data = response.json()
+    except Exception:  # pylint: disable=broad-except
+        return None
+    if isinstance(data, dict) and "ok" in data:
+        return data
+    return None
 
 
 async def deliver_subprocess(

--- a/sdks/python/oss/tests/pytest/unit/agents/test_runner_batch_error_fidelity.py
+++ b/sdks/python/oss/tests/pytest/unit/agents/test_runner_batch_error_fidelity.py
@@ -1,0 +1,142 @@
+"""The batch HTTP transport surfaces the runner's actionable error, not a generic HTTP 500.
+
+F-038: a run failure comes back from the runner as HTTP 500 with a *result* body
+(``{"ok": false, "error": <concise message>}``; see ``services/agent/src/server.ts``). That
+``error`` is the actionable, already-sanitized provider message and is the SAME body the
+streaming path surfaces. The batch path (``/invoke`` + the ``/messages`` JSON path) used to
+discard the body and raise a generic "Agent runner HTTP 500", losing the actionable text.
+
+These tests pin that ``deliver_http`` now returns a runner result body (success OR failure) so
+``result_from_wire`` raises with the concise message, while a genuine non-result error body
+(no ``ok`` key, e.g. a proxy error) still falls through to the generic transport error.
+"""
+
+from __future__ import annotations
+
+import json
+from typing import Any
+
+import httpx
+import pytest
+
+from agenta.sdk.agents.utils.ts_runner import deliver_http
+from agenta.sdk.agents.utils.wire import result_from_wire
+
+
+class _FakeResponse:
+    def __init__(self, status_code: int, payload: Any, *, text: Any = None) -> None:
+        self.status_code = status_code
+        self._payload = payload
+        self.text = text if text is not None else json.dumps(payload)
+
+    def json(self) -> Any:
+        if isinstance(self._payload, Exception):
+            raise self._payload
+        return self._payload
+
+
+def _fake_client(*, response: _FakeResponse):
+    class _Client:
+        def __init__(self, *args, **kwargs) -> None:
+            pass
+
+        async def __aenter__(self):
+            return self
+
+        async def __aexit__(self, *args):
+            return False
+
+        async def post(self, url, json=None, headers=None):
+            return response
+
+    return _Client
+
+
+CONCISE = (
+    "pi_core: the model provider account has insufficient credit "
+    "(check the project's Anthropic key)."
+)
+
+
+async def test_failure_500_returns_result_body_with_concise_error(monkeypatch):
+    monkeypatch.delenv("AGENTA_AGENT_RUNNER_TOKEN", raising=False)
+    monkeypatch.setattr(
+        httpx,
+        "AsyncClient",
+        _fake_client(response=_FakeResponse(500, {"ok": False, "error": CONCISE})),
+    )
+
+    body = await deliver_http("http://runner:8765", {"harness": "pi_core"})
+
+    # The body survives the >=400 status instead of being swallowed as a transport failure.
+    assert body == {"ok": False, "error": CONCISE}
+
+
+async def test_failure_500_surfaces_concise_error_through_result_from_wire(monkeypatch):
+    # End-to-end of the batch boundary: the concise provider message reaches the caller,
+    # matching what SSE already surfaces, not a generic "HTTP 500".
+    monkeypatch.delenv("AGENTA_AGENT_RUNNER_TOKEN", raising=False)
+    monkeypatch.setattr(
+        httpx,
+        "AsyncClient",
+        _fake_client(response=_FakeResponse(500, {"ok": False, "error": CONCISE})),
+    )
+
+    body = await deliver_http("http://runner:8765", {"harness": "pi_core"})
+    with pytest.raises(RuntimeError) as excinfo:
+        result_from_wire(body)
+
+    message = str(excinfo.value)
+    assert "insufficient credit" in message
+    assert "Anthropic key" in message
+    assert "HTTP 500" not in message
+
+
+async def test_success_2xx_still_returns_body(monkeypatch):
+    monkeypatch.delenv("AGENTA_AGENT_RUNNER_TOKEN", raising=False)
+    monkeypatch.setattr(
+        httpx,
+        "AsyncClient",
+        _fake_client(response=_FakeResponse(200, {"ok": True, "output": "hi"})),
+    )
+
+    body = await deliver_http("http://runner:8765", {"harness": "pi_core"})
+
+    assert body == {"ok": True, "output": "hi"}
+
+
+async def test_non_result_error_body_falls_through_to_transport_error(monkeypatch):
+    # A genuine transport failure (no ``ok`` key, e.g. a proxy/gateway error page) stays a
+    # generic transport error; we do not mistake an arbitrary 4xx/5xx body for a run result.
+    monkeypatch.delenv("AGENTA_AGENT_RUNNER_TOKEN", raising=False)
+    monkeypatch.setattr(
+        httpx,
+        "AsyncClient",
+        _fake_client(
+            response=_FakeResponse(502, {"detail": "bad gateway"}, text="bad gateway")
+        ),
+    )
+
+    with pytest.raises(RuntimeError) as excinfo:
+        await deliver_http("http://runner:8765", {"harness": "pi_core"})
+
+    assert "Agent runner HTTP 502" in str(excinfo.value)
+
+
+async def test_non_json_error_body_falls_through_to_transport_error(monkeypatch):
+    # A 500 whose body is not JSON at all (e.g. an HTML error page) is a transport failure.
+    monkeypatch.delenv("AGENTA_AGENT_RUNNER_TOKEN", raising=False)
+    monkeypatch.setattr(
+        httpx,
+        "AsyncClient",
+        _fake_client(
+            response=_FakeResponse(
+                500, ValueError("not json"), text="<html>boom</html>"
+            )
+        ),
+    )
+
+    with pytest.raises(RuntimeError) as excinfo:
+        await deliver_http("http://runner:8765", {"harness": "pi_core"})
+
+    assert "Agent runner HTTP 500" in str(excinfo.value)


### PR DESCRIPTION
## Symptom

The batch path (`/invoke` + the `/messages` JSON path) collapsed **every** runner `ok:false` to a generic `Agent runner HTTP 500`. Only the SSE path surfaced the actionable, provider-named message (e.g. *"insufficient credit — add the project's Anthropic key"*). The trace had the real message; the batch caller did not.

## Root cause

The runner returns a run failure as **HTTP 500 with a result body** (`{"ok":false,"error":<concise msg>}`; see `services/agent/src/server.ts`). The SDK transport `deliver_http` rejected any `>=400` *before* parsing the body, throwing `_transport_error("Agent runner HTTP 500")` and discarding the actionable `error`. The subprocess/CLI path was already correct (the CLI writes the full result to stdout on failure).

## Fix

`deliver_http` now recognizes a runner **result** body (a dict with an `ok` key) at any status and returns it, so `result_from_wire` raises with the already-sanitized concise message — matching what SSE surfaces. A non-result error body (no `ok` key) or a non-JSON body still falls through to the generic transport error. The existing error-sanitize boundary is unchanged (no internals leaked).

## Before / after

- Before: `/invoke` on an out-of-credit key → `Agent run failed: Agent runner HTTP 500`.
- After: `/invoke` → `Agent run failed: pi_core: the model provider account has insufficient credit (check the project's Anthropic key).`

## Tests

New `sdks/python/oss/tests/pytest/unit/agents/test_runner_batch_error_fidelity.py` (5 tests): 500-result returns body, end-to-end concise message via `result_from_wire`, 2xx still returns, non-result 502 and non-JSON 500 still fall through to a transport error. Full SDK agents suite: 392 passed. ruff clean.

## Review ask

Please sanity-check the `_runner_result_body` heuristic ("a dict with an `ok` key is a runner result"): is keying on the presence of `ok` the right discriminator, or should it also require the body to be a known result shape? This is the only judgment call.

https://claude.ai/code/session_01GYo3UEfvsZpncagqb28Mbc