### PR TITLE
fix(agent): fail loud when MCP is disabled but the request sent mcp_servers (F-039)

### DIFF
--- a/sdks/python/agenta/sdk/agents/__init__.py
+++ b/sdks/python/agenta/sdk/agents/__init__.py
@@ -88,6 +88,7 @@ from .interfaces import (
 )
 from .mcp import (
     MCPConfigurationError,
+    MCPDisabledError,
     MCPError,
     MCPResolver,
     MCPServerConfig,
@@ -199,6 +200,7 @@ __all__ = [
     "MCPResolver",
     "MCPError",
     "MCPConfigurationError",
+    "MCPDisabledError",
     "MissingMCPSecretError",
     # Skills are a sibling subsystem
     "SkillConfig",

--- a/sdks/python/agenta/sdk/agents/mcp/__init__.py
+++ b/sdks/python/agenta/sdk/agents/mcp/__init__.py
@@ -1,6 +1,11 @@
 """Public MCP configuration and resolution API."""
 
-from .errors import MCPConfigurationError, MCPError, MissingMCPSecretError
+from .errors import (
+    MCPConfigurationError,
+    MCPDisabledError,
+    MCPError,
+    MissingMCPSecretError,
+)
 from .interfaces import MCPSecretProvider
 from .models import MCPServerConfig, ResolvedMCPServer
 from .parsing import parse_mcp_server_config, parse_mcp_server_configs
@@ -18,5 +23,6 @@ __all__ = [
     "mcp_servers_to_wire",
     "MCPError",
     "MCPConfigurationError",
+    "MCPDisabledError",
     "MissingMCPSecretError",
 ]

--- a/sdks/python/agenta/sdk/agents/mcp/errors.py
+++ b/sdks/python/agenta/sdk/agents/mcp/errors.py
@@ -22,6 +22,26 @@ class MCPConfigurationError(MCPError):
         self.value = value
 
 
+class MCPDisabledError(MCPError):
+    """The deployment disabled MCP, but the request still declared ``mcp_servers``.
+
+    Raised instead of silently dropping the servers, so the user learns their MCP config was
+    ignored rather than wondering why the run behaved as if it had no servers. The fail-loud
+    MCP guards in the runner never see these servers (resolution strips them before the wire),
+    so this is the boundary that must surface the disabled state.
+    """
+
+    def __init__(self, *, server_names: Sequence[str]) -> None:
+        names = tuple(server_names)
+        listed = ", ".join(names) if names else "(unnamed)"
+        super().__init__(
+            "MCP servers are disabled on this deployment "
+            "(set AGENTA_AGENT_ENABLE_MCP to enable them), but the request declared "
+            f"{len(names)} MCP server(s): {listed}. Remove them or enable MCP."
+        )
+        self.server_names = names
+
+
 class MissingMCPSecretError(MCPError):
     def __init__(self, *, server_name: str, secret_names: Sequence[str]) -> None:
         names = tuple(secret_names)

--- a/services/oss/src/agent/tools/resolver.py
+++ b/services/oss/src/agent/tools/resolver.py
@@ -11,7 +11,8 @@ from __future__ import annotations
 import os
 from typing import Any, List, Optional, Sequence
 
-from agenta.sdk.agents.mcp import ResolvedMCPServer
+from agenta.sdk.agents.mcp import MCPDisabledError, ResolvedMCPServer
+from agenta.sdk.agents.mcp.parsing import parse_mcp_server_configs
 from agenta.sdk.agents.platform import resolve_mcp, resolve_tools
 from agenta.sdk.agents.tools.interfaces import ToolSecretProvider
 from agenta.sdk.utils.constants import TRUTHY
@@ -30,8 +31,16 @@ async def resolve_mcp_servers(
 ) -> List[ResolvedMCPServer]:
     """Resolve MCP servers, gated by ``AGENTA_AGENT_ENABLE_MCP`` (off by default).
 
-    Returns the resolved servers when enabled, an empty list when not.
+    When MCP is enabled, returns the resolved servers. When it is disabled and the request
+    declared NO servers, returns an empty list (the common case, unchanged). When it is disabled
+    but the request DID declare servers, raises :class:`MCPDisabledError` instead of silently
+    stripping them — silent-stripping made the runner's fail-loud MCP guards unreachable via
+    ``/invoke`` and ``/messages``, so the user got a run that quietly ignored their MCP config.
     """
     if not _mcp_enabled():
-        return []
+        if not mcp_servers:
+            return []
+        # Parse only to surface the server names in the error; do not resolve secrets (disabled).
+        names = [config.name for config in parse_mcp_server_configs(mcp_servers)]
+        raise MCPDisabledError(server_names=names)
     return await resolve_mcp(mcp_servers, secret_provider=secret_provider)

--- a/services/oss/tests/pytest/unit/agent/tools/test_resolution.py
+++ b/services/oss/tests/pytest/unit/agent/tools/test_resolution.py
@@ -6,6 +6,7 @@ import pytest
 
 from agenta.sdk.agents import (
     CodeToolSpec,
+    MCPDisabledError,
     MissingMCPSecretError,
     MissingToolSecretError,
 )
@@ -70,9 +71,29 @@ async def test_missing_tool_secret_is_not_silently_omitted():
         )
 
 
-async def test_mcp_is_disabled_at_service_composition_by_default(monkeypatch):
+async def test_mcp_disabled_with_no_servers_is_an_empty_list(monkeypatch):
+    # The common case (MCP off, no servers declared): still a clean empty list, unchanged.
     monkeypatch.delenv("AGENTA_AGENT_ENABLE_MCP", raising=False)
-    assert await resolve_mcp_servers([{"name": "github", "command": "npx"}]) == []
+    assert await resolve_mcp_servers([]) == []
+
+
+async def test_mcp_disabled_with_servers_fails_loud_instead_of_silent_strip(
+    monkeypatch,
+):
+    # F-039: disabling MCP must NOT silently drop user-declared servers. The user gets a clear
+    # "MCP servers are disabled" error naming the servers, not a run that quietly ignored them.
+    monkeypatch.delenv("AGENTA_AGENT_ENABLE_MCP", raising=False)
+    with pytest.raises(MCPDisabledError) as excinfo:
+        await resolve_mcp_servers(
+            [
+                {"name": "github", "command": "npx"},
+                {"name": "filesystem", "command": "npx"},
+            ]
+        )
+    assert excinfo.value.server_names == ("github", "filesystem")
+    message = str(excinfo.value)
+    assert "disabled" in message
+    assert "github" in message and "filesystem" in message
 
 
 async def test_missing_mcp_secret_is_explicit_when_enabled(monkeypatch):


### PR DESCRIPTION
## Symptom

When `AGENTA_AGENT_ENABLE_MCP` is false (the deployed default), the service silently stripped **all** user `mcp_servers`. The runner's fail-loud MCP guards therefore never fired via `/invoke` or `/messages`, and the user got a run that quietly ignored their MCP config — no error, no hint.

## Fix

`resolve_mcp_servers` now raises a new `MCPDisabledError` (naming the declared servers) when MCP is disabled **and** the request declared servers. An empty list (the common case) is unchanged. The error surfaces on both the batch and stream paths before backend setup, exactly like the existing `MissingMCPSecretError`.

- New `MCPDisabledError` in `sdks/python/agenta/sdk/agents/mcp/errors.py`, exported from `mcp/__init__.py` and `agents/__init__.py`.
- `services/oss/src/agent/tools/resolver.py` parses the server names (no secret resolution while disabled) to list them in the message.

## Before / after

- Before: MCP off + request with `mcp_servers` → servers silently dropped, run proceeds as if none were sent.
- After: → `MCP servers are disabled on this deployment (set AGENTA_AGENT_ENABLE_MCP to enable them), but the request declared 1 MCP server(s): github. Remove them or enable MCP.`

## Tests

`services/oss/tests/pytest/unit/agent/tools/test_resolution.py`: replaced the old silent-strip assertion — empty list stays empty; servers-while-disabled raises `MCPDisabledError` naming the servers. Service agent suite: 42 passed; SDK agents: 392 passed. ruff clean.

## Review ask

Confirm fail-loud is the desired behavior for the deployed default (MCP off). The alternative is to keep stripping but log a warning; I chose fail-loud because the silent path made the runner's own MCP guards unreachable and surprised users.

https://claude.ai/code/session_01GYo3UEfvsZpncagqb28Mbc