### PR TITLE
fix(hosting): guard against the web env-file footgun (F-037)

### DIFF
--- a/hosting/AGENTS.md
+++ b/hosting/AGENTS.md
@@ -41,3 +41,23 @@ COMPOSE_PROJECT_NAME=agenta-ee-dev-instance2 ./hosting/docker-compose/run.sh \
 
 This separation prevents Docker Compose conflicts between the main-branch and worktree
 instances.
+
+### Recreating only `web` — always pass the env file (F-037)
+
+`web` runs `next dev` and reads its env at container-create time, so an env or config change
+needs a **recreate**, not a `restart`. The footgun: recreating it by hand with a raw
+`docker compose ... up -d --no-deps web` and forgetting the env file. Compose then falls back to
+the committed default `${ENV_FILE:-./.env.<license>.dev}`, which has **port-80 / no-port URLs**,
+so the recreated web container 404s every `/api` call with no obvious cause (same class as F-020).
+
+Use the helper, which always passes the env file on both planes (the shell `ENV_FILE` var and the
+`--env-file` CLI flag) so the trap cannot recur:
+
+```bash
+hosting/docker-compose/recreate-web.sh                              # ee / dev / .env.ee.dev.local
+PROJECT=agenta-ee-dev-wp-b2-rendering hosting/docker-compose/recreate-web.sh
+```
+
+If you must run `docker compose` directly, pass `ENV_FILE=<file>` **and**
+`--env-file <path>` — both, every time. `run.sh` now also fails loud when its resolved env file
+is missing instead of silently using the port-80 default.

--- a/hosting/docker-compose/recreate-web.sh
+++ b/hosting/docker-compose/recreate-web.sh
@@ -1,0 +1,61 @@
+#!/bin/bash
+set -euo pipefail
+
+# Recreate ONLY the `web` container, always with the correct env file.
+#
+# F-037: `web` runs `next dev` and reads its env at container-create time, so a code/env change
+# needs a recreate (a `restart` is not enough). The recurring footgun is recreating it by hand:
+#
+#   docker compose -p <project> -f <file> up -d --no-deps --force-recreate web
+#
+# Without `ENV_FILE=...` AND `--env-file <path>`, Compose falls back to the committed default
+# `${ENV_FILE:-./.env.<license>.dev}` (port-80 / no-port URLs), so the recreated web container
+# 404s every `/api` call (same class as F-020) with no obvious cause. This script always passes
+# the env file on BOTH planes (the shell var that drives the in-file `${ENV_FILE}` default, and
+# the `--env-file` CLI flag that drives variable substitution), so the trap cannot recur.
+#
+# Usage:
+#   hosting/docker-compose/recreate-web.sh                      # ee / dev / .env.ee.dev.local
+#   LICENSE=ee STAGE=dev ENV_FILE=.env.ee.dev.local \
+#     PROJECT=agenta-ee-dev-wp-b2-rendering hosting/docker-compose/recreate-web.sh
+#
+# Env knobs (all optional; defaults match the documented dev stack):
+#   LICENSE  oss|ee                  (default: ee)
+#   STAGE    dev|gh|gh.local|...     (default: dev)
+#   ENV_FILE env file name or path   (default: .env.<license>.<stage>.local)
+#   PROJECT  compose project name    (default: agenta-<license>-<stage>)
+#   DOCKER_NETWORK_MODE              (default: bridge)
+
+LICENSE="${LICENSE:-ee}"
+STAGE="${STAGE:-dev}"
+ENV_FILE="${ENV_FILE:-.env.${LICENSE}.${STAGE}.local}"
+PROJECT="${PROJECT:-agenta-${LICENSE}-${STAGE}}"
+DOCKER_NETWORK_MODE="${DOCKER_NETWORK_MODE:-bridge}"
+
+SCRIPT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
+COMPOSE_FILE="${SCRIPT_DIR}/${LICENSE}/docker-compose.${STAGE}.yml"
+
+# Resolve ENV_FILE to a path the same way run.sh does: an explicit path is used as-is, a bare
+# name is taken relative to the license dir.
+if [[ "$ENV_FILE" = /* || "$ENV_FILE" == ./* || "$ENV_FILE" == ../* || "$ENV_FILE" == */* ]]; then
+    ENV_FILE_PATH="$ENV_FILE"
+else
+    ENV_FILE_PATH="${SCRIPT_DIR}/${LICENSE}/${ENV_FILE}"
+fi
+
+if [[ ! -f "$COMPOSE_FILE" ]]; then
+    echo "Error: compose file not found: $COMPOSE_FILE" >&2
+    exit 1
+fi
+if [[ ! -f "$ENV_FILE_PATH" ]]; then
+    echo "Error: env file not found: $ENV_FILE_PATH" >&2
+    echo "Refusing to recreate web: Compose would fall back to the port-80 default and the" >&2
+    echo "web container would 404 every '/api' call. Set ENV_FILE to an existing file." >&2
+    exit 1
+fi
+
+echo "Recreating 'web' for project '$PROJECT' with env file '$ENV_FILE_PATH'..."
+ENV_FILE="$ENV_FILE" DOCKER_NETWORK_MODE="$DOCKER_NETWORK_MODE" \
+    docker compose -p "$PROJECT" -f "$COMPOSE_FILE" --env-file "$ENV_FILE_PATH" \
+    --profile with-web up -d --no-deps --force-recreate web
+echo "✅ web recreated."

--- a/hosting/docker-compose/run.sh
+++ b/hosting/docker-compose/run.sh
@@ -315,6 +315,16 @@ else
     ENV_FILE_PATH="./hosting/docker-compose/$LICENSE/$ENV_FILE"
 fi
 
+# F-037 guard: fail loud when the resolved env file is missing instead of letting Compose
+# silently fall back to its `${ENV_FILE:-./.env.<license>.<stage>}` default. The committed
+# default holds port-80 / no-port URLs, so a typo'd or absent env file produces a stack whose
+# web container 404s every `/api` call (same class as F-020) with no obvious cause. Catch it here.
+if [[ ! -f "$ENV_FILE_PATH" ]]; then
+    error_exit "Env file not found: $ENV_FILE_PATH
+Refusing to start: Docker Compose would silently fall back to its built-in default
+(port-80 / no-port URLs), which makes every web '/api' call 404 with no obvious cause.
+Pass an existing --env-file (e.g. --env-file .env.$LICENSE.$STAGE.local) or create the file."
+fi
 
 # Export the ENV_FILE to the environment
 export ENV_FILE="$ENV_FILE"


### PR DESCRIPTION
## Symptom

Recreating the `web` container without `ENV_FILE=./.env.<license>.dev.local` makes Docker Compose fall back to its committed default (`${ENV_FILE:-./.env.<license>.dev}`), which has **port-80 / no-port URLs**. The recreated web container then 404s **every** `/api` call with no obvious cause (same class as F-020, and it recurs).

## Why not just change the compose default

`.env.*.local` is git-ignored and machine-specific (absent in fresh checkouts), so pointing the compose default at it would break clean checkouts. This change makes the **smallest safe** fix instead: a guard + a helper + a doc note, with no risky stack-wide compose-default change.

## Fix

- `run.sh`: fail loud when the resolved env file is missing, instead of silently using the port-80 default.
- `recreate-web.sh` (new): recreate **only** `web`, always passing the env file on both planes (the shell `ENV_FILE` var that drives the in-file `${ENV_FILE}` default **and** the `--env-file` CLI flag that drives variable substitution), so the trap cannot recur.
- `hosting/AGENTS.md`: document the footgun and the helper.

## Usage

```bash
hosting/docker-compose/recreate-web.sh                              # ee / dev / .env.ee.dev.local
PROJECT=agenta-ee-dev-wp-b2-rendering hosting/docker-compose/recreate-web.sh
```

## Tests

Both scripts pass `bash -n`. The guard was verified against real files (existing `.env.ee.dev.local` passes; an absent file would `error_exit`). No app code touched.

## Review ask

Check the `recreate-web.sh` defaults (`LICENSE=ee`, `STAGE=dev`, `PROJECT=agenta-ee-dev`) match how the team actually recreates web, and whether you'd prefer this as a `run.sh` subcommand instead of a sibling script.

https://claude.ai/code/session_01GYo3UEfvsZpncagqb28Mbc