### PR TITLE
fix(agent): deliver Claude gateway tools on Daytona via an in-sandbox stdio MCP relay shim (F-042)

### DIFF
--- a/docs/design/agent-workflows/projects/claude-daytona-gateway/README.md
+++ b/docs/design/agent-workflows/projects/claude-daytona-gateway/README.md
@@ -1,0 +1,161 @@
+# Claude gateway/callback tools on Daytona (F-042)
+
+**Status:** designed + draft impl landed on a lane (DRAFT PR, do NOT merge; no live Daytona test
+run yet — that is the one remaining gate before "done"). Codex-reviewed (xhigh), findings folded
+in. 284 runner unit tests + typecheck green; the bundle builds (5.3 kB, network-free) and answers
+`initialize` over stdio.
+**Owner:** agent-workflows.
+**Base:** big-agents tip `80b2748f56` (workspace tip `407635ca01`).
+**Source finding:** [`projects/qa/findings.md` F-042](../qa/findings.md) (Daytona E3 sweep,
+2026-06-26). This is also the proven answer to gateway-tool-mcp
+[open question 3](../gateway-tool-mcp/status.md).
+
+## The one-line problem
+
+On the **Claude** harness running in a **Daytona** sandbox, an Agenta gateway/callback tool is
+never surfaced to the model. The same tool works on Claude+LOCAL and on Pi+Daytona. Only the
+Claude x Daytona cell drops it.
+
+## Root cause
+
+There are two separate things a tool needs: **advertisement** (the model is told the tool
+exists, with its name/description/schema) and **execution** (when the model calls it, something
+runs the resolved spec server-side and returns the result). F-042 is an advertisement gap, not
+an execution gap.
+
+How each environment x harness advertises gateway/callback tools today:
+
+| Cell | Advertisement channel | Execution channel | Works? |
+| --- | --- | --- | --- |
+| Pi, local | Pi extension `registerTool` (in-process) | direct `/tools/call` POST | yes |
+| Pi, Daytona | Pi extension `registerTool` (in-sandbox, uploaded) | **file relay** (`tools/relay.ts`) | yes |
+| Claude, local | runner **loopback HTTP MCP** server (`tool-mcp-http.ts`), advertised via `sessionInit.mcpServers` | dispatch in the MCP handler -> relay/POST | yes |
+| **Claude, Daytona** | **NONE** | file relay loop is started, ready, idle | **no (F-042)** |
+
+The #4853 fix is correct: on Daytona the runner skips the loopback HTTP MCP server, because its
+URL is `127.0.0.1:<port>` which, from inside the remote sandbox, is the **sandbox's** loopback,
+not the runner's host. Advertising it would hand the in-sandbox Claude an unreachable URL.
+(`engines/sandbox_agent/mcp.ts` `buildSessionMcpServers`, `isDaytona` branch.)
+
+But skipping the loopback removes Claude's ONLY advertisement channel on Daytona, and nothing
+replaces it. The "file relay" (`tools/relay.ts` `startToolRelay`) is purely the **execution**
+transport: the runner polls the sandbox filesystem for `<id>.req.json` files and POSTs the
+resolved callback to `/tools/call`, writing `<id>.res.json` back. **Writing those req files (and
+advertising the tool to the model) is done by an in-sandbox process** — for Pi, the bundled
+extension (`extensions/agenta.ts` `registerTools` -> `runResolvedTool` -> `relayToolCall`).
+Claude has no such in-sandbox shim, so on Daytona `sessionInit.mcpServers` is empty for Claude,
+the model is never told the tool exists, and the relay loop sits idle waiting for req files that
+never get written. The runner's `daytona: N gateway tool(s) delivered via the file relay` log
+line is the runner's INTENT, not a Claude-reachable delivery.
+
+### Proven by contrast (F-042 live repro)
+
+Same synthetic `callback` tool (`get_weather` -> echo server returning an unguessable token),
+posted to the runner `/run`:
+
+- Claude + Daytona -> `ok:true`, model says "I don't have access to a `get_weather` tool". Echo
+  server never called. -> tool NOT delivered.
+- Claude + LOCAL -> reply is exactly the token; echo server called. -> loopback MCP works.
+- Pi + Daytona -> reply is exactly the token; echo server called. -> Pi extension delivers on
+  Daytona.
+
+So the failure is specifically the missing **in-sandbox advertisement shim for a non-Pi harness
+on Daytona**. The relay execution side already works; only the advertisement is missing.
+
+## Why the loopback can't just be "made reachable"
+
+The obvious alternative — keep the HTTP MCP server and make the sandbox reach it — was
+considered and rejected as the smallest fix:
+
+- **Daytona preview/port-forward.** The Daytona SDK exposes `getPreviewLink(port)` /
+  `getSignedPreviewUrl(port)`, but that forwards a port **out of** the sandbox (sandbox -> public
+  URL), not the runner's host port **into** the sandbox. There is no reverse tunnel.
+- **Bind the MCP server to a sandbox-reachable address.** The runner host and the Daytona sandbox
+  are on different networks with no shared routable address; the runner has no inbound URL the
+  sandbox can dial without a tunnel.
+- **The sandbox-agent handle doesn't expose preview/port APIs anyway.** Our `sandbox` object
+  (sandbox-agent `0.4.2`) exposes `runProcess`, `readFsFile`, `writeFsFile`, `mkdirFs`,
+  `createSession`, `destroySession`, `destroySandbox` — the filesystem + process surface the file
+  relay already uses. It does NOT surface `getPreviewLink`. Reaching it would mean dropping below
+  the sandbox-agent wrapper into the raw Daytona SDK, a much bigger change.
+
+The file relay already crosses the boundary (the runner reads/writes the sandbox FS over the
+daemon API), and it already works for Pi on Daytona. The right move is to give Claude the same
+in-sandbox relay shim Pi has, not to invent a new network path.
+
+## Recommended design: an in-sandbox stdio MCP relay shim for Claude on Daytona
+
+Give a non-Pi harness on Daytona the Daytona equivalent of the Pi extension: a tiny,
+self-contained **stdio MCP server** that runs **inside** the sandbox, advertises the run's
+resolved gateway/callback tools, and on `tools/call` writes a relay `<id>.req.json` and polls
+`<id>.res.json` — exactly the file protocol the existing runner-side relay loop
+(`startToolRelay`) already implements and the Pi extension already speaks (`relayToolCall` in
+`tools/dispatch.ts`).
+
+Why stdio and not HTTP:
+
+- ACP's `McpServer` union includes a **stdio** variant (`McpServerStdio` = `{name, command,
+  args, env}`). `sessionInit.mcpServers` is forwarded verbatim into the in-sandbox `newSession`
+  (sandbox-agent `normalizeSessionInit` deep-clones it through), so the in-sandbox Claude
+  launches the stdio command **inside the sandbox**. That is the correct side of the boundary —
+  the same place the Pi extension runs.
+- The #4831 security concern about stdio MCP is about a stdio child on the **runner host**
+  (outside the sandbox). Here the child runs **inside** the Daytona sandbox, under the sandbox's
+  own confinement, and carries only public tool metadata + the relay dir (no callRef, no code, no
+  callback auth, no secrets). Every credentialed action still happens server-side in runner
+  memory via the existing relay -> `/tools/call`. So this does NOT reopen #4831's hole. (The
+  user-declared stdio MCP gate in `run-plan.ts` / `toAcpMcpServers` is a SEPARATE layer and stays
+  disabled; this internal channel is synthesized by the runner, never user-declared — same
+  two-layers rule as gateway-tool-mcp.)
+- Local stays HTTP-on-loopback (already works); Daytona uses the stdio shim. Same split as
+  #4844: HTTP advertisement for local, file relay for Daytona — now with a real advertiser on the
+  Daytona side.
+
+### Shape of the shim
+
+A new standalone script `src/tools/relay-mcp-stdio.ts`, esbuild-bundled to
+`dist/tools/relay-mcp-stdio.js` (same pattern as the Pi extension's
+`scripts/build-extension.mjs`), reading everything from env:
+
+- `AGENTA_TOOL_PUBLIC_SPECS` — JSON `[{name, description, inputSchema}]` (public only; reuse
+  `publicToolSpecs`).
+- `AGENTA_TOOL_RELAY_DIR` — the in-sandbox relay dir (`plan.relayDir`, nested under the cwd).
+
+It speaks MCP **stdio** JSON-RPC: `initialize`, `tools/list` (from the public specs), and
+`tools/call` (write `<id>.req.json` `{toolName, toolCallId, args}`, poll `<id>.res.json`
+`{ok, text|error}`, mirroring `relayToolCall`). It launches no network and holds no secret.
+
+### Wiring (Daytona, non-Pi only)
+
+1. **Upload** the bundled `relay-mcp-stdio.js` into the sandbox (best-effort, like
+   `uploadPiExtensionToSandbox`), when `isDaytona && !isPi && executableToolSpecs.length > 0`.
+2. **Advertise** it: in `buildSessionMcpServers`, when `isDaytona && !isPi && capabilities.mcpTools`
+   and there are executable specs, return an `McpServerStdio` entry
+   `{name: "agenta-tools", command: "node", args: [<sandbox path to the shim>], env: [{AGENTA_TOOL_PUBLIC_SPECS}, {AGENTA_TOOL_RELAY_DIR}]}`
+   instead of the empty list. (Local non-Pi keeps the loopback HTTP server; Pi keeps `[]`.)
+3. **Execute** unchanged: `plan.useToolRelay` already starts `startToolRelay` with the
+   `sandboxRelayHost` on Daytona. It already polls the sandbox FS and runs the resolved spec.
+   No change to the relay loop, callback dispatch, permissions (Layer 3 still enforced in the
+   relay loop), or tracing.
+
+Net: one new bundled script + one new upload helper + a non-Pi/Daytona branch in
+`buildSessionMcpServers`. The execution path, the security model, and the local path are all
+unchanged.
+
+See [`plan.md`](./plan.md) for the file-by-file change list, the security argument in full, the
+test plan, and the open questions.
+
+## Smallest correct option (why this one)
+
+| Option | Cost | Verdict |
+| --- | --- | --- |
+| In-sandbox stdio MCP relay shim (recommended) | one bundled script + upload + a session branch; reuses the entire relay execution path; no new network path | **chosen** — smallest change that actually advertises tools to a non-Pi harness on Daytona |
+| Sandbox-reachable HTTP MCP (tunnel/preview into the sandbox) | needs an inbound path the SDK doesn't expose; drop below sandbox-agent into the raw Daytona SDK; new network surface | rejected — bigger, new attack surface, no reverse tunnel exists |
+| Make Claude a "Pi-extension-like" via the Claude SDK MCP config files | Claude-specific config plumbing; still needs an in-sandbox process to write relay reqs | rejected — converges on the same shim but harness-coupled |
+
+## Verification status
+
+- Code-path analysis: complete (this doc + plan).
+- Live Daytona run: **NOT done** (per task; no Daytona tonight). The fix must be verified with a
+  real Claude + Daytona + callback-tool `/run` before it can be called done — repro recipe is in
+  F-042 and in [`plan.md`](./plan.md).

--- a/docs/design/agent-workflows/projects/claude-daytona-gateway/plan.md
+++ b/docs/design/agent-workflows/projects/claude-daytona-gateway/plan.md
@@ -1,0 +1,202 @@
+# Plan: in-sandbox stdio MCP relay shim for Claude on Daytona (F-042)
+
+Goal: deliver Agenta gateway/callback tools to a non-Pi harness (Claude) running in a Daytona
+sandbox, by giving it the Daytona equivalent of the Pi extension — a tiny in-sandbox stdio MCP
+server that advertises the tools and writes relay request files. Reuse the existing relay
+execution path unchanged.
+
+Read [`README.md`](./README.md) first for the root cause and the option comparison.
+
+## Invariants this must preserve
+
+1. **Two MCP layers stay separate** (the #4831 / gateway-tool-mcp rule): the INTERNAL
+   gateway-tool channel (synthesized by the runner from `customTools`) and the USER MCP
+   capability (user-declared servers) toggle independently. This change touches only the internal
+   channel; user stdio MCP stays disabled, user http MCP unchanged.
+2. **No secret crosses the boundary.** The shim env carries only `AGENTA_TOOL_PUBLIC_SPECS`
+   (public name/description/inputSchema) and `AGENTA_TOOL_RELAY_DIR`. The callRef, code, scoped
+   env, callback endpoint, and callback auth stay in runner memory; the relay loop applies them
+   server-side. Same guarantee as the loopback HTTP server and the Pi extension.
+3. **#4831 stays closed.** The stdio child runs INSIDE the Daytona sandbox (the harness's own
+   confinement), not on the runner host. The runner-host stdio hole #4831 closed is a different
+   place; this does not reintroduce it.
+4. **Local path unchanged.** Local non-Pi keeps the loopback HTTP MCP server; Pi keeps `[]`
+   everywhere; the only new behavior is `isDaytona && !isPi && executable specs`.
+5. **Layer 3 permissions unchanged.** `ask`/`deny`/`allow` are still enforced in `startToolRelay`
+   (`resolvePermission`) on the runner side, harness-agnostic. The shim never sees a permission.
+6. **Fail loud, not silent (A7 / F-032).** If the shim cannot be delivered, the run must error,
+   not return an `ok:true` empty turn. Today `assertRequiredCapabilities` already refuses a non-Pi
+   run that carries tools when the probe lacks `mcpTools`/`toolCalls`. Keep that gate; the new
+   branch only changes WHICH server entry is delivered, not whether tools are required.
+
+## Files to change
+
+### New: `services/agent/src/tools/relay-mcp-stdio.ts`
+
+A standalone stdio MCP server. No imports from the harness SDK. Reads:
+
+- `AGENTA_TOOL_PUBLIC_SPECS` — JSON `[{name, description, inputSchema}]`.
+- `AGENTA_TOOL_RELAY_DIR` — relay dir (in-sandbox path).
+
+Speaks MCP JSON-RPC over stdin/stdout (newline-delimited or LSP-style framing — match what the
+in-sandbox Claude ACP -> Claude SDK MCP stdio client expects; see Open question 1):
+
+- `initialize` -> `{protocolVersion, capabilities:{tools:{}}, serverInfo:{name:"agenta-tools"}}`.
+- `notifications/initialized` -> no response.
+- `tools/list` -> the public specs (`name`, `description`, `inputSchema`).
+- `tools/call` -> write `<relayDir>/<sanitizeRelayId(id)>.req.json`
+  `{toolName, toolCallId, args}`; poll `<relayDir>/<id>.res.json` until `{ok:true,text}` (return
+  as MCP `content:[{type:"text",text}]`) or `{ok:false,error}` (return `isError:true`); time out
+  via `RELAY_TIMEOUT_MS`. This is exactly `relayToolCall` in `tools/dispatch.ts` — factor the
+  shared poll/write into a helper both call, or copy it (the shim is bundled standalone, so a
+  shared import must bundle cleanly).
+
+Reuse `sanitizeRelayId`, `RELAY_REQ_SUFFIX`, `RELAY_RES_SUFFIX`, `RELAY_POLL_MS`,
+`RELAY_TIMEOUT_MS` from `tools/relay.ts`, and the `tools/list` filtering/handler shape from
+`tool-mcp-http.ts` `handle` (initialize/tools-list/tools-call), so the framing logic has one
+source of truth where possible.
+
+### New bundle step: `scripts/build-extension.mjs` (extend) or a sibling script
+
+Add a second esbuild entry that emits `dist/tools/relay-mcp-stdio.js` (ESM, node target,
+self-contained, `external: []` — it has no harness-SDK dep). Same banner shim as the extension if
+any CJS dep sneaks in. The Daytona snapshot already bundles `dist/` (it carries the Pi extension
+the same way), so no snapshot rebuild is needed beyond shipping the new file. Confirm the
+sandbox-image build copies `dist/tools/` too (Open question 3).
+
+### `services/agent/src/engines/sandbox_agent/pi-assets.ts` (or a new `relay-shim.ts`)
+
+Add `uploadRelayShimToSandbox(sandbox, destDir, log)` mirroring `uploadPiExtensionToSandbox`:
+`mkdirFs` + `writeFsFile` the bundled `relay-mcp-stdio.js` into a known in-sandbox path (e.g.
+`<cwd>/.agenta-tools/relay-mcp-stdio.js`, alongside the relay dir, or `/home/sandbox/.agenta`).
+Best-effort with a log on failure. Resolve the bundle path the way `EXTENSION_BUNDLE` is resolved
+(env override + `PKG_ROOT/dist/...`).
+
+### `services/agent/src/engines/sandbox_agent/mcp.ts` — `buildSessionMcpServers`
+
+Today (Daytona branch): `const internal = isDaytona ? {servers: [], close} : await buildToolMcpServers(...)`.
+
+Change: when `isDaytona && !isPi && capabilities.mcpTools` and `toolSpecs` has executable specs,
+build an `McpServerStdio` entry instead of `[]`:
+
+```
+{
+  name: "agenta-tools",
+  command: "node",
+  args: [<in-sandbox path to relay-mcp-stdio.js>],
+  env: [
+    { name: "AGENTA_TOOL_PUBLIC_SPECS", value: JSON.stringify(publicToolSpecs(executable)) },
+    { name: "AGENTA_TOOL_RELAY_DIR", value: relayDir },
+  ],
+}
+```
+
+Keep the existing `daytona: N gateway tool(s) delivered via the file relay` log, but make it
+TRUE now (the shim is the deliverer). Local non-Pi unchanged (loopback HTTP). Pi unchanged (`[]`).
+The new branch needs the in-sandbox shim path; pass it into `buildSessionMcpServers` (a new input
+field) or compute it from `relayDir`.
+
+The `McpServerEntry` union (`mcp.ts`) must gain the stdio variant for the internal channel
+(`McpServerStdio` already exists in `mcp-bridge.ts`; the internal channel currently only emits
+`McpServerHttp`). Add `McpServerStdio` to the returned union for this branch.
+
+### `services/agent/src/engines/sandbox_agent.ts`
+
+Where Daytona assets are pushed (`if (plan.isDaytona) await prepareDaytonaPiAssets(...)`), also
+upload the relay shim when `!plan.isPi && plan.executableToolSpecs.length > 0`. (Today
+`prepareDaytonaPiAssets` early-returns for non-Pi; add a non-Pi relay-shim upload either there or
+inline in the engine.) Pass the in-sandbox shim path into `buildSessionMcpServers`.
+
+No change to: the relay loop start (`plan.useToolRelay` -> `startToolRelay` with
+`sandboxRelayHost`), `resolveRunUsage`, tracing, the permission responder, or the result shape.
+
+### `services/agent/src/protocol.ts` / `wire.py`
+
+**No wire change.** This is entirely runner-internal (the shim is synthesized from `customTools`,
+which already cross the wire). Do not touch the golden fixtures.
+
+## Tests (vitest, `services/agent/tests/unit/`)
+
+1. **`relay-mcp-stdio` unit** — drive the shim's `handle`/dispatch directly (export a pure
+   handler like `tool-mcp-http.ts` does): `tools/list` returns the public specs (no callRef/code/
+   auth leak — assert the serialized output contains none of the private fields); `tools/call`
+   writes a `.req.json` with `{toolName, toolCallId, args}` and resolves from a `.res.json` you
+   write; `{ok:false}` maps to an MCP `isError` result; an unknown tool errors.
+2. **`buildSessionMcpServers` Daytona non-Pi branch** — `isDaytona:true, isPi:false,
+   capabilities.mcpTools:true`, executable specs -> returns ONE `type:"stdio"` (or stdio-shaped)
+   `agenta-tools` entry whose env carries `AGENTA_TOOL_PUBLIC_SPECS` + `AGENTA_TOOL_RELAY_DIR` and
+   NO secret. Local non-Pi still returns the http loopback entry; Pi still returns `[]`; Daytona
+   non-Pi with NO executable specs returns `[]`.
+3. **Upload helper** — `uploadRelayShimToSandbox` calls `mkdirFs` + `writeFsFile` with the bundled
+   contents at the expected path (fake sandbox, like the pi-assets test).
+4. **Wire-contract test** — unchanged; assert it still passes (no wire change).
+
+## Live verification (REQUIRED before "done" — not run tonight)
+
+Repro from F-042: a `callback` tool `get_weather` (callRef `composio.weather.GET_WEATHER`) routed
+to a local echo server returning an unguessable token. Recreate `:8280` sandbox-agent with the
+full Daytona `.env.ee.dev.local`, force `sandbox:daytona`, harness `claude` (haiku), inject an
+`ANTHROPIC_API_KEY` via `secrets`. Expect:
+
+- The model calls `get_weather` and replies with the token (today it says "I don't have access to
+  a get_weather tool").
+- The echo server is hit (`fn=composio.weather.GET_WEATHER`).
+- The runner log shows the stdio shim launched in-sandbox + the relay req/res cycle.
+- Hygiene: 0 leaked sandboxes (the per-run `finally` still deletes; allow ~5s for the async
+  Daytona delete).
+
+Contrast cells that must still pass: Claude+LOCAL (loopback), Pi+Daytona (extension), Pi+LOCAL.
+
+When green, capture the run with the `agent-replay-test` skill to pin it, and update F-042 to
+RESOLVED + the matrix scoreboard in `projects/qa/`.
+
+## Codex review (xhigh, 2026-06-26) — folded in
+
+Verdict: "the in-sandbox stdio MCP relay shim is the smallest correct architecture for F-042"
+(the runner-host loopback cannot serve Daytona Claude; the relay loop cannot advertise; the Claude
+ACP adapter has no serverless tool-advertisement path). Acted on its priority points in the draft:
+
+- **Fail loud, not best-effort.** `uploadRelayShimToSandbox` now THROWS
+  (`RELAY_SHIM_UNAVAILABLE_MESSAGE`) on a missing bundle / failed upload, on the path that requires
+  the shim (Daytona + non-Pi + executable tools), so F-042 cannot become another silent tool drop.
+- **Layering.** Moved the shim bundle constant + upload helper OUT of the already-stretched
+  `pi-assets.ts` into a dedicated `engines/sandbox_agent/relay-shim.ts`; `mcp.ts` stays pure (it
+  builds the session entry, it does not touch files).
+- **Dependency seam.** Factored the file-relay CLIENT out of `tools/dispatch.ts` into
+  `tools/relay-client.ts`, so the in-sandbox bundle carries ONLY file-relay code — NOT the direct
+  callback (`/tools/call` POST) or code executor `dispatch.ts` also imports. Verified: the bundle
+  is 5.3 kB with 0 network calls (vs the 1.3 MB Pi extension).
+- **Hardening.** `randomUUID()` for the relay call id; concurrent stdio request handling (a
+  `tools/call` no longer blocks the read loop); nonzero exit on missing required env.
+- **Security caveat (documented, not a leak).** The relay dir is an in-sandbox capability: any
+  sandbox process that can write a valid `.req.json` can invoke an ALLOWED tool during the run.
+  That is not a secret leak (no credential crosses the boundary) and matches the Pi relay
+  precedent; the guard is the runner-side Layer-3 permission enforcement in `startToolRelay`
+  (`resolvePermission`), which is unchanged. The same exposure already exists for Pi on Daytona.
+- **Framing confirmed.** Codex independently confirmed the Claude Code bundled MCP transport is
+  newline-delimited JSON-RPC (`cli.js`: reads to a newline, writes `JSON.stringify(...) + "\n"`),
+  matching the shim. Open question 1 is closed.
+
+## Open questions (answer before/while implementing)
+
+1. **Claude's in-sandbox stdio MCP framing — RESOLVED (code-read).** Confirmed against the
+   installed adapter `node_modules/@zed-industries/claude-agent-acp/dist/acp-agent.js` (~L899-921):
+   the adapter maps each ACP `sessionInit.mcpServers` entry to a Claude SDK MCP config. An entry
+   WITH a `type` field becomes an http/sse server; an entry with NO `type` (exactly the
+   `McpServerStdio` shape: `name`/`command`/`args`/`env`) becomes `{type:"stdio", command, args,
+   env}`. The Claude Agent SDK then launches it via the standard MCP stdio transport
+   (`@modelcontextprotocol/sdk` `StdioClientTransport`), which is **newline-delimited JSON-RPC**
+   (one JSON object per line on stdin/stdout). So the shim must: read NDJSON from stdin, write one
+   JSON-RPC object per line to stdout, keep stdout clean (logs to stderr only). The adapter runs
+   INSIDE the Daytona sandbox, so the `command` is spawned in-sandbox — the design holds. The
+   internal channel entry must therefore be the type-less stdio shape (do NOT set `type` on it).
+2. **Does the in-sandbox Daytona image have `node` on PATH?** The stdio `command` is `node`. The
+   Daytona snapshot installs Pi via `npm` (`installPiInSandbox`), so node exists; confirm it is on
+   PATH for the ACP-launched stdio child, or use an absolute path.
+3. **Snapshot/image packaging of `dist/tools/`.** Confirm `sandbox-images/daytona/build_snapshot.py`
+   and the sidecar Docker image carry `dist/tools/relay-mcp-stdio.js` (the extension is shipped via
+   `dist/extensions/`; mirror that). If the runner uploads the shim from its own `dist/` over the
+   FS API (recommended, like the Pi extension upload), the snapshot need not bake it.
+4. **Codex/other non-Pi harnesses on Daytona.** This fix is harness-agnostic (any non-Pi,
+   mcpTools-capable harness on Daytona gets the stdio shim). Codex on Daytona is untested; the
+   design covers it but only Claude is the verified target.

--- a/services/agent/scripts/build-extension.mjs
+++ b/services/agent/scripts/build-extension.mjs
@@ -1,9 +1,15 @@
 /**
- * Bundle the Agenta Pi extension into one self-contained file so its OpenTelemetry deps
- * resolve wherever Pi loads it (host, docker sidecar, Daytona snapshot). Pi only accepts
- * `.ts`/`.js` extension files, so we emit `.js` (ESM) with a default export.
+ * Bundle the Agenta in-sandbox harness assets into self-contained files so their deps resolve
+ * wherever they are loaded (host, docker sidecar, Daytona snapshot):
  *
- * Run: pnpm run build:extension  ->  dist/extensions/agenta.js
+ *   dist/extensions/agenta.js     the Pi extension (tracing + tools). Pi loads it on every run;
+ *                                 Pi only accepts `.ts`/`.js` extension files, so ESM `.js` with
+ *                                 a default export.
+ *   dist/tools/relay-mcp-stdio.js the in-sandbox stdio MCP relay shim (F-042): the Daytona tool
+ *                                 advertiser for a non-Pi harness (Claude), which has no bundled
+ *                                 extension. The harness launches it as `node relay-mcp-stdio.js`.
+ *
+ * Run: pnpm run build:extension
  */
 import { build } from "esbuild";
 import { dirname, join } from "node:path";
@@ -28,3 +34,16 @@ await build({
 });
 
 process.stderr.write("[build-extension] wrote dist/extensions/agenta.js\n");
+
+await build({
+  entryPoints: [join(root, "src/tools/relay-mcp-stdio.ts")],
+  outfile: join(root, "dist/tools/relay-mcp-stdio.js"),
+  bundle: true,
+  platform: "node",
+  format: "esm",
+  target: "node20",
+  // No harness SDK dep; only sibling tools/* modules, which bundle in.
+  logLevel: "info",
+});
+
+process.stderr.write("[build-extension] wrote dist/tools/relay-mcp-stdio.js\n");

--- a/services/agent/src/engines/sandbox_agent.ts
+++ b/services/agent/src/engines/sandbox_agent.ts
@@ -65,6 +65,7 @@ import {
   buildPiExtensionEnv,
   prepareLocalPiAssets,
 } from "./sandbox_agent/pi-assets.ts";
+import { uploadRelayShimToSandbox } from "./sandbox_agent/relay-shim.ts";
 import { attachPermissionResponder } from "./sandbox_agent/permissions.ts";
 import { buildSandboxProvider } from "./sandbox_agent/provider.ts";
 import {
@@ -188,6 +189,7 @@ export interface SandboxAgentDeps extends BuildRunPlanDeps {
   startToolRelay?: typeof startToolRelay;
   localRelayHost?: typeof localRelayHost;
   sandboxRelayHost?: typeof sandboxRelayHost;
+  uploadRelayShimToSandbox?: typeof uploadRelayShimToSandbox;
   responderFactory?: (permissionPolicy: string | undefined) => Responder;
   log?: Log;
 }
@@ -299,8 +301,18 @@ export async function runSandboxAgent(
     // On Daytona, push the harness login, the extension, and AGENTS.md into the remote
     // sandbox via the filesystem API (nothing secret is baked into the image). Locally
     // these use the host filesystem and the harness's own login (PI_CODING_AGENT_DIR).
+    // The in-sandbox stdio MCP relay shim path, set only on the Daytona + non-Pi + has-tools path
+    // (F-042): a non-Pi harness in the sandbox cannot reach the loopback HTTP channel, so it gets
+    // the uploaded shim as a stdio MCP server instead. Pi delivers via its extension; local non-Pi
+    // uses the loopback HTTP channel — neither needs this.
+    let relayShimPath: string | undefined;
     if (plan.isDaytona) {
       await prepareDaytonaPiAssets({ sandbox, plan, log: logger });
+      if (!plan.isPi && plan.executableToolSpecs.length > 0) {
+        relayShimPath = await (
+          deps.uploadRelayShimToSandbox ?? uploadRelayShimToSandbox
+        )(sandbox, plan.relayDir, logger);
+      }
     }
     workspace = await (deps.prepareWorkspace ?? prepareWorkspace)({
       sandbox,
@@ -348,6 +360,9 @@ export async function runSandboxAgent(
       toolSpecs: plan.toolSpecs,
       userMcpServers: request.mcpServers,
       relayDir: plan.relayDir,
+      // The uploaded in-sandbox stdio MCP relay shim, set only on Daytona + non-Pi + has-tools
+      // (F-042); advertises the gateway tools the loopback channel cannot reach in the sandbox.
+      relayShimPath,
       log: logger,
     });
     // Close the internal gateway-tool MCP server (if one started) when the run ends.

--- a/services/agent/src/engines/sandbox_agent/mcp.ts
+++ b/services/agent/src/engines/sandbox_agent/mcp.ts
@@ -8,6 +8,7 @@ import {
   USER_MCP_UNSUPPORTED_MESSAGE,
   type McpServerStdio,
 } from "../../tools/mcp-bridge.ts";
+import { publicToolSpecs } from "../../tools/public-spec.ts";
 
 type Log = (message: string) => void;
 
@@ -171,6 +172,13 @@ export interface BuildSessionMcpServersInput {
   toolSpecs: ResolvedToolSpec[];
   userMcpServers?: McpServerConfig[];
   relayDir: string;
+  /**
+   * The in-sandbox path to the uploaded stdio MCP relay shim (`relay-mcp-stdio.js`), set ONLY on
+   * the Daytona + non-Pi path so the internal gateway-tool channel is advertised as a stdio MCP
+   * server the in-sandbox harness launches (F-042). `undefined` everywhere else: local uses the
+   * loopback HTTP channel and Pi uses its bundled extension, neither of which needs this.
+   */
+  relayShimPath?: string;
   log?: Log;
 }
 
@@ -201,6 +209,37 @@ export interface SessionMcpServers {
  * Returns a `close()` the caller MUST run when the session ends, to release the internal server's
  * loopback port (a no-op on Daytona, where no internal server starts).
  */
+/**
+ * Build the INTERNAL gateway-tool channel as an ACP stdio MCP server (F-042): the Daytona-side
+ * equivalent of the loopback HTTP channel, for a non-Pi harness that runs in the sandbox. The
+ * entry advertises the run's executable tools via the uploaded `relay-mcp-stdio.js` shim, which
+ * the in-sandbox harness launches (`node relay-mcp-stdio.js`); on a call the shim writes a relay
+ * request file the runner-side relay loop executes. Carries ONLY public metadata + the relay dir
+ * in `env` — no secret crosses the boundary (the shim never sees callRef/code/auth). An empty /
+ * all-`client` spec list is a no-op (no channel).
+ */
+function buildStdioToolMcpServer(
+  toolSpecs: ResolvedToolSpec[],
+  relayShimPath: string,
+  relayDir: string,
+): McpServerStdio[] {
+  const specs = publicToolSpecs(toolSpecs);
+  if (specs.length === 0) return [];
+  return [
+    {
+      // The harness keys MCP servers by name; "agenta-tools" matches the loopback HTTP channel.
+      name: "agenta-tools",
+      command: "node",
+      args: [relayShimPath],
+      // The shim reads only these two from env: public specs + the relay dir. No credential.
+      env: [
+        { name: "AGENTA_TOOL_PUBLIC_SPECS", value: JSON.stringify(specs) },
+        { name: "AGENTA_TOOL_RELAY_DIR", value: relayDir },
+      ],
+    },
+  ];
+}
+
 export async function buildSessionMcpServers({
   isPi,
   capabilities,
@@ -209,6 +248,7 @@ export async function buildSessionMcpServers({
   toolSpecs,
   userMcpServers,
   relayDir,
+  relayShimPath,
   log = () => {},
 }: BuildSessionMcpServersInput): Promise<SessionMcpServers> {
   const userMcpCount = userMcpServers?.length ?? 0;
@@ -222,18 +262,33 @@ export async function buildSessionMcpServers({
     return { servers: [], close: async () => {} };
   }
 
-  // Layer 1: INTERNAL gateway-tool channel (do not merge with the user gate below). LOCAL ONLY:
-  // its advertised URL is a runner loopback (`127.0.0.1`), unreachable from a remote Daytona
-  // sandbox where the harness runs. On Daytona, skip the loopback HTTP advertisement and let the
-  // file relay deliver the tools (the relay loop polls the sandbox filesystem; see the Daytona
-  // tool relay in `engines/sandbox_agent.ts`).
-  const internal = isDaytona
-    ? { servers: [], close: async () => {} }
-    : await buildToolMcpServers(toolSpecs, relayDir, log);
+  // Layer 1: INTERNAL gateway-tool channel (do not merge with the user gate below). Transport
+  // depends on where the harness runs:
+  //  - LOCAL: a runner loopback (`127.0.0.1`) HTTP MCP server the harness dials from the host.
+  //  - DAYTONA: the loopback is unreachable from the in-sandbox harness (its `127.0.0.1` is the
+  //    sandbox's), so advertise a STDIO MCP server instead — the uploaded `relay-mcp-stdio.js`
+  //    shim the in-sandbox harness launches (F-042). On a call the shim writes a relay request
+  //    the runner-side relay loop executes (the loop already polls the sandbox FS; see the Daytona
+  //    tool relay in `engines/sandbox_agent.ts`). This is the in-sandbox advertiser a non-Pi
+  //    harness lacked on Daytona; with no uploaded shim path it falls back to no channel.
+  let internal: SessionMcpServers;
+  if (!isDaytona) {
+    internal = await buildToolMcpServers(toolSpecs, relayDir, log);
+  } else if (relayShimPath) {
+    internal = {
+      servers: buildStdioToolMcpServer(toolSpecs, relayShimPath, relayDir),
+      close: async () => {},
+    };
+  } else {
+    internal = { servers: [], close: async () => {} };
+  }
   if (isDaytona && toolSpecs.length > 0) {
     log(
-      `daytona: ${toolSpecs.length} gateway tool(s) delivered via the file relay, not a ` +
-        `loopback MCP URL (unreachable from the sandbox)`,
+      relayShimPath
+        ? `daytona: ${toolSpecs.length} gateway tool(s) advertised via the in-sandbox stdio ` +
+            `MCP relay shim (the loopback MCP URL is unreachable from the sandbox)`
+        : `daytona: ${toolSpecs.length} gateway tool(s) NOT advertised (no in-sandbox relay ` +
+            `shim path; non-Pi harness tools will not surface)`,
     );
   }
   // Layer 2: USER MCP capability (stdio disabled, http delivered; do not merge with Layer 1).

--- a/services/agent/src/engines/sandbox_agent/relay-shim.ts
+++ b/services/agent/src/engines/sandbox_agent/relay-shim.ts
@@ -1,0 +1,69 @@
+/**
+ * In-sandbox stdio MCP relay shim asset (F-042).
+ *
+ * The non-Pi harness (Claude) on Daytona has no bundled extension to advertise gateway/callback
+ * tools, and the runner loopback HTTP MCP server is unreachable from inside the sandbox. So the
+ * runner uploads a tiny standalone stdio MCP server — `tools/relay-mcp-stdio.ts`, esbuild-bundled
+ * to `dist/tools/relay-mcp-stdio.js` like the Pi extension — into the sandbox and advertises it as
+ * an ACP stdio MCP server the in-sandbox harness launches. This module owns the bundle location +
+ * the upload; `mcp.ts` stays pure (it only builds the session entry, it does not touch files).
+ *
+ * FAIL LOUD (A7 / F-032): on the Daytona + non-Pi + has-executable-tools path the engine REQUIRES
+ * this shim — without it the tools silently never surface (exactly the F-042 bug). So a missing
+ * bundle or a failed upload THROWS (with a named message), and the engine catch turns it into
+ * `{ ok: false, error }` rather than proceeding with an empty tool channel.
+ */
+import { existsSync, readFileSync } from "node:fs";
+import { join } from "node:path";
+
+import { PKG_ROOT } from "./daemon.ts";
+
+type Log = (message: string) => void;
+
+/**
+ * The bundled shim path. Built by `pnpm run build:extension` alongside the Pi extension. Resolved
+ * lazily (a function, not a module-level const) so `SANDBOX_AGENT_RELAY_MCP_BUNDLE` is honored at
+ * call time — the runner sets it after module load, and tests point it at a fixture.
+ */
+export function relayMcpBundlePath(): string {
+  return (
+    process.env.SANDBOX_AGENT_RELAY_MCP_BUNDLE ??
+    join(PKG_ROOT, "dist", "tools", "relay-mcp-stdio.js")
+  );
+}
+
+/** Thrown when the shim cannot be delivered on a path that REQUIRES it (Daytona non-Pi + tools). */
+export const RELAY_SHIM_UNAVAILABLE_MESSAGE =
+  "the in-sandbox tool relay shim could not be delivered to the Daytona sandbox, so the run's " +
+  "gateway/callback tools cannot be advertised to the harness; run build:extension and retry, or " +
+  "run on the local sandbox / the Pi harness.";
+
+/**
+ * Upload the bundled stdio MCP relay shim into a Daytona sandbox and return the in-sandbox path.
+ * Throws `RELAY_SHIM_UNAVAILABLE_MESSAGE` when the bundle is missing or the upload fails — the
+ * caller only invokes this on the path that REQUIRES the shim, so a failure must fail the run
+ * loudly rather than silently drop the tools. Carries no secret (only the script itself).
+ */
+export async function uploadRelayShimToSandbox(
+  sandbox: any,
+  destDir: string,
+  log: Log = () => {},
+): Promise<string> {
+  const bundle = relayMcpBundlePath();
+  if (!existsSync(bundle)) {
+    log(`relay MCP shim bundle missing at ${bundle} (run build:extension)`);
+    throw new Error(RELAY_SHIM_UNAVAILABLE_MESSAGE);
+  }
+  const destPath = `${destDir}/relay-mcp-stdio.js`;
+  try {
+    await sandbox.mkdirFs({ path: destDir });
+    await sandbox.writeFsFile(
+      { path: destPath },
+      readFileSync(bundle, "utf-8"),
+    );
+    return destPath;
+  } catch (err) {
+    log(`relay MCP shim upload failed: ${(err as Error).message}`);
+    throw new Error(RELAY_SHIM_UNAVAILABLE_MESSAGE);
+  }
+}

--- a/services/agent/src/tools/dispatch.ts
+++ b/services/agent/src/tools/dispatch.ts
@@ -16,23 +16,16 @@
  *    so the call is relayed through the runner via files (see tools/relay.ts) when `relayDir`
  *    is set; otherwise it POSTs directly.
  *
- * `relayToolCall` lives here (not in extensions/agenta.ts) so this module is the single
- * dispatch home with no import cycle back into a call site.
+ * The file-relay CLIENT (`relayToolCall`) lives in `tools/relay-client.ts` so the standalone
+ * in-sandbox shim can bundle it WITHOUT this module's direct callback/code executors; it is
+ * re-exported here so existing callers are unchanged.
  */
-import { existsSync, mkdirSync, readFileSync, unlinkSync, writeFileSync } from "node:fs";
-
 import type { ResolvedToolSpec } from "../protocol.ts";
 import { callAgentaTool } from "./callback.ts";
 import { runCodeTool } from "./code.ts";
-import {
-  RELAY_POLL_MS,
-  RELAY_REQ_SUFFIX,
-  RELAY_RES_SUFFIX,
-  RELAY_TIMEOUT_MS,
-  sanitizeRelayId,
-  sleep,
-  type RelayResponse,
-} from "./relay.ts";
+import { relayToolCall } from "./relay-client.ts";
+
+export { relayToolCall } from "./relay-client.ts";
 
 /** Options for executing a resolved tool. `endpoint`/`authorization`/`relayDir` only matter for callbacks. */
 export interface RunResolvedToolOpts {
@@ -46,50 +39,6 @@ export interface RunResolvedToolOpts {
   relayDir?: string;
   /** Caller cancellation, combined with the per-tool timeout. */
   signal?: AbortSignal;
-}
-
-/**
- * Daytona tool call: the in-sandbox process can't reach Agenta, so write the request to a
- * file the runner watches and poll for the response it writes back (see tools/relay.ts).
- */
-export async function relayToolCall(
-  dir: string,
-  toolName: string,
-  toolCallId: string,
-  params: unknown,
-  signal?: AbortSignal,
-): Promise<string> {
-  const id = sanitizeRelayId(toolCallId);
-  const reqPath = `${dir}/${id}${RELAY_REQ_SUFFIX}`;
-  const resPath = `${dir}/${id}${RELAY_RES_SUFFIX}`;
-  try {
-    mkdirSync(dir, { recursive: true });
-  } catch {
-    // The runner also creates it; a race here is harmless.
-  }
-  writeFileSync(reqPath, JSON.stringify({ toolName, toolCallId, args: params ?? {} }), "utf-8");
-
-  const deadline = Date.now() + RELAY_TIMEOUT_MS;
-  while (Date.now() < deadline) {
-    if (signal?.aborted) throw new Error("aborted");
-    if (existsSync(resPath)) {
-      const res = JSON.parse(readFileSync(resPath, "utf-8")) as RelayResponse;
-      try {
-        unlinkSync(reqPath);
-      } catch {
-        /* best-effort cleanup */
-      }
-      try {
-        unlinkSync(resPath);
-      } catch {
-        /* best-effort cleanup */
-      }
-      if (res.ok) return res.text ?? "";
-      throw new Error(res.error || `tool relay failed for ${toolName}`);
-    }
-    await sleep(RELAY_POLL_MS);
-  }
-  throw new Error(`tool relay timed out for ${toolName}`);
 }
 
 /**
@@ -107,7 +56,13 @@ export async function runResolvedTool(
   opts: RunResolvedToolOpts,
 ): Promise<string> {
   if (spec.kind === "code") {
-    return runCodeTool(spec.runtime, spec.code ?? "", spec.env, params, opts.signal);
+    return runCodeTool(
+      spec.runtime,
+      spec.code ?? "",
+      spec.env,
+      params,
+      opts.signal,
+    );
   }
   if (spec.kind === "client") {
     throw new Error(
@@ -116,7 +71,13 @@ export async function runResolvedTool(
   }
   // callback (default): route back to Agenta's /tools/call (directly or via the Daytona relay).
   if (opts.relayDir) {
-    return relayToolCall(opts.relayDir, spec.name, opts.toolCallId, params, opts.signal);
+    return relayToolCall(
+      opts.relayDir,
+      spec.name,
+      opts.toolCallId,
+      params,
+      opts.signal,
+    );
   }
   return callAgentaTool(
     opts.endpoint ?? "",

--- a/services/agent/src/tools/relay-client.ts
+++ b/services/agent/src/tools/relay-client.ts
@@ -1,0 +1,77 @@
+/**
+ * File-relay CLIENT — the in-sandbox half of the Daytona tool relay.
+ *
+ * The runner-side relay loop (`tools/relay.ts` `startToolRelay`) executes resolved tool specs and
+ * answers via files in a sandbox dir. This module is the other end: an in-sandbox process writes a
+ * `<id>.req.json` request and polls for the `<id>.res.json` the runner writes back. It is split
+ * out of `tools/dispatch.ts` so the standalone in-sandbox shim (`tools/relay-mcp-stdio.ts`) can
+ * bundle ONLY the file-relay code — NOT the direct callback/code executors `dispatch.ts` also
+ * imports (a credentialed `/tools/call` POST and the code runner have no business in a sandbox
+ * child). `dispatch.ts` re-exports `relayToolCall` from here so its callers are unchanged.
+ */
+import {
+  existsSync,
+  mkdirSync,
+  readFileSync,
+  unlinkSync,
+  writeFileSync,
+} from "node:fs";
+
+import {
+  RELAY_POLL_MS,
+  RELAY_REQ_SUFFIX,
+  RELAY_RES_SUFFIX,
+  RELAY_TIMEOUT_MS,
+  sanitizeRelayId,
+  sleep,
+  type RelayResponse,
+} from "./relay.ts";
+
+/**
+ * Daytona tool call from inside the sandbox: the in-sandbox process can't reach Agenta, so write
+ * the request to a file the runner watches and poll for the response it writes back (see
+ * `tools/relay.ts`). Returns the result text; throws on a relay error or timeout.
+ */
+export async function relayToolCall(
+  dir: string,
+  toolName: string,
+  toolCallId: string,
+  params: unknown,
+  signal?: AbortSignal,
+): Promise<string> {
+  const id = sanitizeRelayId(toolCallId);
+  const reqPath = `${dir}/${id}${RELAY_REQ_SUFFIX}`;
+  const resPath = `${dir}/${id}${RELAY_RES_SUFFIX}`;
+  try {
+    mkdirSync(dir, { recursive: true });
+  } catch {
+    // The runner also creates it; a race here is harmless.
+  }
+  writeFileSync(
+    reqPath,
+    JSON.stringify({ toolName, toolCallId, args: params ?? {} }),
+    "utf-8",
+  );
+
+  const deadline = Date.now() + RELAY_TIMEOUT_MS;
+  while (Date.now() < deadline) {
+    if (signal?.aborted) throw new Error("aborted");
+    if (existsSync(resPath)) {
+      const res = JSON.parse(readFileSync(resPath, "utf-8")) as RelayResponse;
+      try {
+        unlinkSync(reqPath);
+      } catch {
+        /* best-effort cleanup */
+      }
+      try {
+        unlinkSync(resPath);
+      } catch {
+        /* best-effort cleanup */
+      }
+      if (res.ok) return res.text ?? "";
+      throw new Error(res.error || `tool relay failed for ${toolName}`);
+    }
+    await sleep(RELAY_POLL_MS);
+  }
+  throw new Error(`tool relay timed out for ${toolName}`);
+}

--- a/services/agent/src/tools/relay-mcp-stdio.ts
+++ b/services/agent/src/tools/relay-mcp-stdio.ts
@@ -1,0 +1,229 @@
+/**
+ * In-sandbox stdio MCP relay shim — the INTERNAL gateway-tool delivery channel for a non-Pi
+ * harness on Daytona (F-042).
+ *
+ * Background. A non-Pi harness (Claude) takes tools over MCP. On LOCAL the runner advertises
+ * them over a loopback HTTP MCP server (`tools/tool-mcp-http.ts`), which Claude — running on the
+ * runner host — dials. On DAYTONA the harness runs IN the remote sandbox, where that loopback
+ * (`127.0.0.1`) is the sandbox's, not the runner's, so the loopback channel is skipped
+ * (`engines/sandbox_agent/mcp.ts`). That left a non-Pi harness on Daytona with no in-sandbox tool
+ * advertiser at all (Pi has its bundled extension; Claude had nothing), so the model never saw
+ * the tool — the F-042 gap.
+ *
+ * This shim is the Daytona equivalent of the Pi extension's `registerTools`, but packaged as a
+ * standalone stdio MCP server the in-sandbox harness launches. It is advertised to the harness as
+ * an ACP `McpServerStdio` entry (`{name, command, args, env}`, NO `type` field) in
+ * `sessionInit.mcpServers`; the sandbox-agent SDK forwards that verbatim into the in-sandbox
+ * `newSession`, and the Claude ACP adapter (`@zed-industries/claude-agent-acp`) maps a type-less
+ * entry to a Claude SDK `{type:"stdio", command, args, env}` MCP server. The Claude Agent SDK
+ * launches it over the standard MCP stdio transport, which is NEWLINE-DELIMITED JSON-RPC: one
+ * JSON object per line on stdin, one JSON object per line on stdout. stdout is reserved for
+ * JSON-RPC; all logging goes to stderr.
+ *
+ * Security (does NOT reopen the #4831 runner-host-stdio hole): this child runs INSIDE the Daytona
+ * sandbox, under the sandbox's own confinement — not on the runner host. It reads ONLY public
+ * tool metadata + the relay dir from its env:
+ *   AGENTA_TOOL_PUBLIC_SPECS   JSON [{ name, description, inputSchema }] (no callRef/code/auth)
+ *   AGENTA_TOOL_RELAY_DIR      the in-sandbox relay dir to write request files into
+ * It launches no network and holds no credential. On `tools/call` it writes a relay request file
+ * the runner-side relay loop (`tools/relay.ts` `startToolRelay`) already polls and executes; the
+ * private spec + callback auth are applied server-side in runner memory. Same guarantee as the
+ * loopback HTTP server and the Pi extension; the user-declared stdio MCP gate (`run-plan.ts` /
+ * `toAcpMcpServers`) is a SEPARATE layer and stays disabled — this internal channel is
+ * synthesized by the runner from `customTools`, never user-declared.
+ *
+ * Bundled self-contained (esbuild -> `dist/tools/relay-mcp-stdio.js`, like the Pi extension) so it
+ * runs wherever it is uploaded. It imports ONLY from sibling `tools/*` modules that bundle cleanly
+ * (no harness SDK).
+ */
+import { randomUUID } from "node:crypto";
+import { createInterface } from "node:readline";
+import { argv } from "node:process";
+import { fileURLToPath } from "node:url";
+
+import type { PublicToolSpec } from "./public-spec.ts";
+// Import the file-relay CLIENT directly (NOT dispatch.ts) so the bundle carries only file-relay
+// code — no direct callback (`/tools/call` POST) or code executor reaches a sandbox child.
+import { relayToolCall } from "./relay-client.ts";
+
+const DEFAULT_PROTOCOL = "2025-06-18";
+
+function log(message: string): void {
+  // stderr only: stdout is the JSON-RPC channel.
+  process.stderr.write(`[agenta-relay-mcp] ${message}\n`);
+}
+
+/** Parse the public specs from env; [] on absent/malformed (the shim then advertises nothing). */
+function parsePublicSpecs(raw: string | undefined): PublicToolSpec[] {
+  if (!raw) return [];
+  try {
+    const parsed = JSON.parse(raw);
+    return Array.isArray(parsed) ? (parsed as PublicToolSpec[]) : [];
+  } catch (err) {
+    log(`bad AGENTA_TOOL_PUBLIC_SPECS: ${(err as Error).message}`);
+    return [];
+  }
+}
+
+const EMPTY_OBJECT_SCHEMA = {
+  type: "object",
+  properties: {},
+  additionalProperties: true,
+};
+
+/**
+ * Handle one MCP JSON-RPC message. Returns the response object, or `undefined` for a
+ * notification (no `id`). Mirrors `tools/tool-mcp-http.ts` `handle`, but `tools/call` writes a
+ * relay request file (`relayToolCall`) rather than dispatching in-process — the runner executes.
+ */
+export async function handleRelayMcpMessage(
+  message: any,
+  specs: PublicToolSpec[],
+  relayDir: string,
+): Promise<unknown | undefined> {
+  const { id, method, params } = message ?? {};
+
+  // Notifications (no id, e.g. notifications/initialized) need no response.
+  if (id === undefined || id === null) return undefined;
+
+  if (method === "initialize") {
+    return {
+      jsonrpc: "2.0",
+      id,
+      result: {
+        protocolVersion: params?.protocolVersion ?? DEFAULT_PROTOCOL,
+        capabilities: { tools: {} },
+        serverInfo: { name: "agenta-tools", version: "0.1.0" },
+      },
+    };
+  }
+
+  if (method === "tools/list") {
+    return {
+      jsonrpc: "2.0",
+      id,
+      result: {
+        // Only public metadata crosses to the harness — never callRef, code, scoped env, or
+        // callback auth (those never reach this process; it only has the public specs).
+        tools: specs.map((s) => ({
+          name: s.name,
+          description: s.description ?? s.name,
+          inputSchema:
+            (s.inputSchema as Record<string, unknown>) ?? EMPTY_OBJECT_SCHEMA,
+        })),
+      },
+    };
+  }
+
+  if (method === "tools/call") {
+    const name = params?.name;
+    if (!specs.some((s) => s.name === name)) {
+      return {
+        jsonrpc: "2.0",
+        id,
+        error: { code: -32602, message: `unknown tool: ${name}` },
+      };
+    }
+    try {
+      // Write the relay request + poll the response; the runner-side loop executes the private
+      // spec server-side. A fresh uuid per call keeps parallel calls from colliding on the
+      // relay filename.
+      const text = await relayToolCall(
+        relayDir,
+        name,
+        randomUUID(),
+        params?.arguments,
+      );
+      return {
+        jsonrpc: "2.0",
+        id,
+        result: { content: [{ type: "text", text }] },
+      };
+    } catch (err) {
+      // Surface as an MCP tool error (isError) so the model can recover, not a crash.
+      return {
+        jsonrpc: "2.0",
+        id,
+        result: {
+          content: [
+            {
+              type: "text",
+              text: err instanceof Error ? err.message : String(err),
+            },
+          ],
+          isError: true,
+        },
+      };
+    }
+  }
+
+  return {
+    jsonrpc: "2.0",
+    id,
+    error: { code: -32601, message: `method not found: ${method}` },
+  };
+}
+
+/**
+ * Run the stdio JSON-RPC loop: one JSON object per line in, one per line out. Exposed so a test
+ * can drive it with fake streams; `main()` wires the real stdin/stdout.
+ */
+export async function runRelayMcpStdio(
+  specs: PublicToolSpec[],
+  relayDir: string,
+  input: NodeJS.ReadableStream = process.stdin,
+  output: NodeJS.WritableStream = process.stdout,
+): Promise<void> {
+  log(`serving ${specs.length} tool(s) -> relay ${relayDir}`);
+  const rl = createInterface({ input, crlfDelay: Infinity });
+  const inflight: Promise<void>[] = [];
+  for await (const line of rl) {
+    const trimmed = line.trim();
+    if (!trimmed) continue;
+    let message: any;
+    try {
+      message = JSON.parse(trimmed);
+    } catch (err) {
+      log(`parse error: ${(err as Error).message}`);
+      continue;
+    }
+    // Handle each message concurrently: a `tools/call` blocks on the relay round-trip, and we
+    // must keep reading stdin (the client may pipeline `tools/list` + several calls). Each write
+    // is a single atomic line, so interleaved responses stay valid JSON-RPC.
+    inflight.push(
+      handleRelayMcpMessage(message, specs, relayDir).then((response) => {
+        if (response !== undefined)
+          output.write(`${JSON.stringify(response)}\n`);
+      }),
+    );
+  }
+  await Promise.allSettled(inflight);
+}
+
+async function main(): Promise<void> {
+  const relayDir = process.env.AGENTA_TOOL_RELAY_DIR ?? "";
+  if (!relayDir) {
+    // The harness launched the shim without its required env: fail loud (nonzero exit) so the
+    // MCP client surfaces a server start failure rather than a silently inert tool advertiser.
+    log("AGENTA_TOOL_RELAY_DIR is unset; cannot relay tool calls");
+    process.exitCode = 1;
+    return;
+  }
+  const specs = parsePublicSpecs(process.env.AGENTA_TOOL_PUBLIC_SPECS);
+  await runRelayMcpStdio(specs, relayDir);
+}
+
+// Run when executed directly (the harness launches `node relay-mcp-stdio.js`); stay inert on
+// import (so the unit test can import the handler without starting the stdin loop).
+function isDirectRun(): boolean {
+  const entry = argv[1];
+  if (!entry) return false;
+  try {
+    return fileURLToPath(import.meta.url) === entry;
+  } catch {
+    return import.meta.url.endsWith(entry);
+  }
+}
+if (isDirectRun()) {
+  void main();
+}

--- a/services/agent/tests/unit/relay-mcp-stdio.test.ts
+++ b/services/agent/tests/unit/relay-mcp-stdio.test.ts
@@ -1,0 +1,194 @@
+/**
+ * Unit tests for the in-sandbox stdio MCP relay shim (F-042): the Daytona tool advertiser for a
+ * non-Pi harness (Claude). The shim speaks newline-delimited MCP JSON-RPC over stdio and, on
+ * `tools/call`, writes a relay request file the runner-side relay loop executes.
+ *
+ * These drive the pure handler `handleRelayMcpMessage` directly (no real harness, no real stdio):
+ *  - `initialize` answers with serverInfo + tools capability.
+ *  - `tools/list` advertises ONLY public metadata (name/description/inputSchema) — never a
+ *    callRef/code/auth (the shim only ever receives public specs, so this is structural).
+ *  - `tools/call` writes a `<id>.req.json` and resolves from a `<id>.res.json`; ok -> text
+ *    content, not-ok -> isError; unknown tool -> JSON-RPC error.
+ *
+ * Run: pnpm exec vitest run tests/unit/relay-mcp-stdio.test.ts
+ */
+import { afterEach, describe, it } from "vitest";
+import assert from "node:assert/strict";
+import {
+  mkdtempSync,
+  readdirSync,
+  readFileSync,
+  rmSync,
+  writeFileSync,
+} from "node:fs";
+import { tmpdir } from "node:os";
+import { join } from "node:path";
+
+import { handleRelayMcpMessage } from "../../src/tools/relay-mcp-stdio.ts";
+import type { PublicToolSpec } from "../../src/tools/public-spec.ts";
+import {
+  RELAY_REQ_SUFFIX,
+  RELAY_RES_SUFFIX,
+  sanitizeRelayId,
+} from "../../src/tools/relay.ts";
+
+const specs: PublicToolSpec[] = [
+  {
+    name: "get_weather",
+    description: "Get the weather",
+    inputSchema: { type: "object", properties: { city: { type: "string" } } },
+  },
+];
+
+const dirs: string[] = [];
+function relayDir(): string {
+  const d = mkdtempSync(join(tmpdir(), "agenta-relay-mcp-stdio-"));
+  dirs.push(d);
+  return d;
+}
+afterEach(() => {
+  for (const d of dirs) rmSync(d, { recursive: true, force: true });
+  dirs.length = 0;
+});
+
+describe("relay-mcp-stdio handler", () => {
+  it("initialize -> serverInfo + tools capability", async () => {
+    const res: any = await handleRelayMcpMessage(
+      { jsonrpc: "2.0", id: 1, method: "initialize", params: {} },
+      specs,
+      relayDir(),
+    );
+    assert.equal(res.id, 1);
+    assert.equal(res.result.serverInfo.name, "agenta-tools");
+    assert.ok(res.result.capabilities.tools);
+  });
+
+  it("a notification (no id) returns undefined (no response written)", async () => {
+    const res = await handleRelayMcpMessage(
+      { jsonrpc: "2.0", method: "notifications/initialized" },
+      specs,
+      relayDir(),
+    );
+    assert.equal(res, undefined);
+  });
+
+  it("tools/list advertises only public metadata", async () => {
+    const res: any = await handleRelayMcpMessage(
+      { jsonrpc: "2.0", id: 2, method: "tools/list" },
+      specs,
+      relayDir(),
+    );
+    assert.deepEqual(
+      res.result.tools.map((t: any) => t.name),
+      ["get_weather"],
+    );
+    const serialized = JSON.stringify(res);
+    // Structural: the shim never has a callRef/code/auth to leak; assert the advertisement shape.
+    assert.ok(!serialized.includes("callRef"));
+    assert.ok(!serialized.includes("authorization"));
+    assert.ok(res.result.tools[0].inputSchema.properties.city);
+  });
+
+  it("tools/call writes a relay req and resolves from the runner's res (ok -> text)", async () => {
+    const dir = relayDir();
+    const callId = "get_weather-9-123";
+    // Simulate the runner's relay loop: watch for the req, write a res.
+    const pending = handleRelayMcpMessage(
+      {
+        jsonrpc: "2.0",
+        id: 9,
+        method: "tools/call",
+        params: { name: "get_weather", arguments: { city: "Berlin" } },
+      },
+      specs,
+      dir,
+    );
+
+    // Poll for the request file the shim writes, then answer it.
+    await waitFor(() =>
+      readdirSync(dir).some((f) => f.endsWith(RELAY_REQ_SUFFIX)),
+    );
+    const reqName = readdirSync(dir).find((f) => f.endsWith(RELAY_REQ_SUFFIX))!;
+    const req = JSON.parse(readFileSync(join(dir, reqName), "utf-8"));
+    assert.equal(req.toolName, "get_weather");
+    assert.deepEqual(req.args, { city: "Berlin" });
+    const id = reqName.slice(0, -RELAY_REQ_SUFFIX.length);
+    writeFileSync(
+      join(dir, `${id}${RELAY_RES_SUFFIX}`),
+      JSON.stringify({ ok: true, text: "RELAY-OK city=Berlin" }),
+      "utf-8",
+    );
+
+    const res: any = await pending;
+    assert.equal(res.id, 9);
+    assert.equal(res.result.content[0].text, "RELAY-OK city=Berlin");
+    assert.ok(!res.result.isError);
+    // Use callId only to keep the lint happy about the documented stable-id intent.
+    assert.ok(sanitizeRelayId(callId).length > 0);
+  });
+
+  it("tools/call maps a not-ok relay result to an MCP isError result", async () => {
+    const dir = relayDir();
+    const pending = handleRelayMcpMessage(
+      {
+        jsonrpc: "2.0",
+        id: 10,
+        method: "tools/call",
+        params: { name: "get_weather", arguments: {} },
+      },
+      specs,
+      dir,
+    );
+    await waitFor(() =>
+      readdirSync(dir).some((f) => f.endsWith(RELAY_REQ_SUFFIX)),
+    );
+    const reqName = readdirSync(dir).find((f) => f.endsWith(RELAY_REQ_SUFFIX))!;
+    const id = reqName.slice(0, -RELAY_REQ_SUFFIX.length);
+    writeFileSync(
+      join(dir, `${id}${RELAY_RES_SUFFIX}`),
+      JSON.stringify({ ok: false, error: "upstream 500" }),
+      "utf-8",
+    );
+    const res: any = await pending;
+    assert.equal(res.result.isError, true);
+    assert.match(res.result.content[0].text, /upstream 500/);
+  });
+
+  it("tools/call for an unknown tool -> JSON-RPC error (never writes a req)", async () => {
+    const dir = relayDir();
+    const res: any = await handleRelayMcpMessage(
+      {
+        jsonrpc: "2.0",
+        id: 11,
+        method: "tools/call",
+        params: { name: "nope", arguments: {} },
+      },
+      specs,
+      dir,
+    );
+    assert.equal(res.error.code, -32602);
+    assert.equal(
+      readdirSync(dir).length,
+      0,
+      "no relay req written for an unknown tool",
+    );
+  });
+
+  it("an unknown method -> method-not-found error", async () => {
+    const res: any = await handleRelayMcpMessage(
+      { jsonrpc: "2.0", id: 12, method: "tools/frobnicate" },
+      specs,
+      relayDir(),
+    );
+    assert.equal(res.error.code, -32601);
+  });
+});
+
+async function waitFor(pred: () => boolean, timeoutMs = 3000): Promise<void> {
+  const deadline = Date.now() + timeoutMs;
+  while (Date.now() < deadline) {
+    if (pred()) return;
+    await new Promise((r) => setTimeout(r, 20));
+  }
+  throw new Error("waitFor timed out");
+}

--- a/services/agent/tests/unit/relay-shim.test.ts
+++ b/services/agent/tests/unit/relay-shim.test.ts
@@ -1,0 +1,101 @@
+/**
+ * Unit tests for the in-sandbox stdio MCP relay shim asset upload (F-042).
+ *
+ * The upload is FAIL-LOUD on the path that requires it: a missing bundle or a failed upload throws
+ * `RELAY_SHIM_UNAVAILABLE_MESSAGE` (the engine turns it into `{ok:false,error}`), rather than
+ * silently dropping the run's tools — exactly the silent drop F-042 was.
+ *
+ * Run: pnpm exec vitest run tests/unit/relay-shim.test.ts
+ */
+import { afterEach, describe, it } from "vitest";
+import assert from "node:assert/strict";
+import { mkdtempSync, rmSync, writeFileSync } from "node:fs";
+import { tmpdir } from "node:os";
+import { join } from "node:path";
+
+import {
+  RELAY_SHIM_UNAVAILABLE_MESSAGE,
+  uploadRelayShimToSandbox,
+} from "../../src/engines/sandbox_agent/relay-shim.ts";
+
+const dirs: string[] = [];
+const prevBundle = process.env.SANDBOX_AGENT_RELAY_MCP_BUNDLE;
+
+afterEach(() => {
+  for (const d of dirs.splice(0)) rmSync(d, { recursive: true, force: true });
+  if (prevBundle === undefined)
+    delete process.env.SANDBOX_AGENT_RELAY_MCP_BUNDLE;
+  else process.env.SANDBOX_AGENT_RELAY_MCP_BUNDLE = prevBundle;
+});
+
+describe("uploadRelayShimToSandbox", () => {
+  it("uploads the bundle and returns the in-sandbox path", async () => {
+    const bundleDir = mkdtempSync(join(tmpdir(), "agenta-relay-shim-bundle-"));
+    dirs.push(bundleDir);
+    const bundlePath = join(bundleDir, "relay-mcp-stdio.js");
+    writeFileSync(bundlePath, "// shim bundle", "utf-8");
+    process.env.SANDBOX_AGENT_RELAY_MCP_BUNDLE = bundlePath;
+
+    const calls: Array<{ op: string; path: string; body?: string }> = [];
+    const sandbox = {
+      mkdirFs: async ({ path }: { path: string }) =>
+        calls.push({ op: "mkdir", path }),
+      writeFsFile: async ({ path }: { path: string }, body: string) =>
+        calls.push({ op: "write", path, body }),
+    };
+
+    const dest = await uploadRelayShimToSandbox(
+      sandbox,
+      "/home/sandbox/agenta-x/.agenta-tools",
+    );
+    assert.equal(
+      dest,
+      "/home/sandbox/agenta-x/.agenta-tools/relay-mcp-stdio.js",
+    );
+    assert.deepEqual(calls, [
+      { op: "mkdir", path: "/home/sandbox/agenta-x/.agenta-tools" },
+      {
+        op: "write",
+        path: "/home/sandbox/agenta-x/.agenta-tools/relay-mcp-stdio.js",
+        body: "// shim bundle",
+      },
+    ]);
+  });
+
+  it("throws (fail loud) when the bundle is missing — never silently drops tools", async () => {
+    process.env.SANDBOX_AGENT_RELAY_MCP_BUNDLE = join(
+      tmpdir(),
+      "definitely-missing-relay-shim-bundle.js",
+    );
+    const sandbox = {
+      mkdirFs: async () => {
+        throw new Error("should not be called");
+      },
+      writeFsFile: async () => {
+        throw new Error("should not be called");
+      },
+    };
+    await assert.rejects(
+      () => uploadRelayShimToSandbox(sandbox, "/home/sandbox/x"),
+      new RegExp(RELAY_SHIM_UNAVAILABLE_MESSAGE),
+    );
+  });
+
+  it("throws when the upload itself fails", async () => {
+    const bundleDir = mkdtempSync(join(tmpdir(), "agenta-relay-shim-bundle-"));
+    dirs.push(bundleDir);
+    const bundlePath = join(bundleDir, "relay-mcp-stdio.js");
+    writeFileSync(bundlePath, "// shim bundle", "utf-8");
+    process.env.SANDBOX_AGENT_RELAY_MCP_BUNDLE = bundlePath;
+    const sandbox = {
+      mkdirFs: async () => {},
+      writeFsFile: async () => {
+        throw new Error("sandbox FS write failed");
+      },
+    };
+    await assert.rejects(
+      () => uploadRelayShimToSandbox(sandbox, "/home/sandbox/x"),
+      new RegExp(RELAY_SHIM_UNAVAILABLE_MESSAGE),
+    );
+  });
+});

--- a/services/agent/tests/unit/session-mcp-layering.test.ts
+++ b/services/agent/tests/unit/session-mcp-layering.test.ts
@@ -211,6 +211,99 @@ describe("buildSessionMcpServers layering (do-not-merge regression guard)", () =
     );
   });
 
+  it("(Daytona, non-Pi, relayShimPath) gateway tools -> stdio MCP relay shim, no loopback (F-042)", async () => {
+    // The F-042 fix: a non-Pi harness on Daytona gets the internal channel as a STDIO MCP server
+    // (the uploaded relay-mcp-stdio.js shim), since the loopback HTTP URL is unreachable in the
+    // sandbox. The entry carries the public specs + relay dir in env, NO credential, NO loopback.
+    const shimPath =
+      "/home/sandbox/agenta-abc/.agenta-tools/relay-mcp-stdio.js";
+    const { servers } = await build({
+      isPi: false,
+      isDaytona: true,
+      capabilities: mcpCapable,
+      harness: "claude",
+      toolSpecs: [gatewayTool],
+      relayDir,
+      relayShimPath: shimPath,
+    });
+    const internal = servers.find((s) => s.name === "agenta-tools");
+    assert.ok(internal, "the internal channel is advertised as a stdio server");
+    assert.ok(
+      !("type" in internal),
+      "a stdio MCP entry has no `type` field (so Claude's ACP adapter maps it to a stdio server)",
+    );
+    const stdio = internal as {
+      command: string;
+      args: string[];
+      env: Array<{ name: string; value: string }>;
+    };
+    assert.equal(stdio.command, "node");
+    assert.deepEqual(stdio.args, [shimPath]);
+    const envNames = stdio.env.map((e) => e.name).sort();
+    assert.deepEqual(envNames, [
+      "AGENTA_TOOL_PUBLIC_SPECS",
+      "AGENTA_TOOL_RELAY_DIR",
+    ]);
+    assert.ok(
+      !JSON.stringify(internal).includes("composio.search"),
+      "the private callRef never reaches the stdio advertisement",
+    );
+    assert.ok(
+      !JSON.stringify(servers).includes("127.0.0.1"),
+      "no unreachable loopback url on the Daytona session",
+    );
+  });
+
+  it("(Daytona, non-Pi, NO relayShimPath) gateway tools -> no channel (shim upload failed)", async () => {
+    // Without an uploaded shim path the channel cannot be advertised (fall back to no channel,
+    // the pre-F-042 behavior). The capability gate + fail-loud in the engine still apply upstream.
+    const { servers } = await build({
+      isPi: false,
+      isDaytona: true,
+      capabilities: mcpCapable,
+      harness: "claude",
+      toolSpecs: [gatewayTool],
+      relayDir,
+      relayShimPath: undefined,
+    });
+    assert.deepEqual(servers, [], "no internal channel without a shim path");
+  });
+
+  it("(Daytona, Pi, relayShimPath) still gets [] (Pi delivers via its extension, never the shim)", async () => {
+    const { servers } = await build({
+      isPi: true,
+      isDaytona: true,
+      capabilities: mcpCapable,
+      harness: "pi_agenta",
+      toolSpecs: [gatewayTool],
+      relayDir,
+      relayShimPath: "/home/sandbox/x/relay-mcp-stdio.js",
+    });
+    assert.deepEqual(servers, [], "Pi never uses the stdio shim");
+  });
+
+  it("(Daytona, non-Pi, relayShimPath, only client tools) -> no channel (nothing executable)", async () => {
+    const clientTool: ResolvedToolSpec = {
+      name: "pick_date",
+      kind: "client",
+      description: "browser-fulfilled",
+    };
+    const { servers } = await build({
+      isPi: false,
+      isDaytona: true,
+      capabilities: mcpCapable,
+      harness: "claude",
+      toolSpecs: [clientTool],
+      relayDir,
+      relayShimPath: "/home/sandbox/x/relay-mcp-stdio.js",
+    });
+    assert.deepEqual(
+      servers,
+      [],
+      "a client-only spec list advertises no stdio channel",
+    );
+  });
+
   it("(Daytona) a user http MCP is STILL delivered (remote url, not a runner loopback)", async () => {
     // The Daytona guard is scoped to the INTERNAL loopback channel only. A user http MCP is a
     // remote url the harness dials directly, so it stays reachable from the sandbox and must be


### PR DESCRIPTION
## Symptom (QA F-042)

On the **Claude** harness in a **Daytona** sandbox, an Agenta gateway/callback tool is never surfaced to the model. The same tool works on **Claude + LOCAL** and on **Pi + Daytona**. Only the Claude x Daytona cell drops it. Live repro (from F-042): a synthetic `get_weather` callback tool — Claude+Daytona replies "I don't have access to a `get_weather` tool", the echo server is never hit; Claude+LOCAL and Pi+Daytona both return the tool's token.

## Root cause: an advertisement gap (not an execution gap)

| Cell | Advertisement | Execution |
| --- | --- | --- |
| Pi, local/Daytona | bundled Pi extension `registerTool` (in-process / in-sandbox) | direct POST / file relay |
| Claude, local | runner **loopback HTTP MCP** server in `sessionInit.mcpServers` | relay/POST |
| **Claude, Daytona** | **NONE** | file relay loop running, idle |

#4853 correctly skips the loopback HTTP MCP on Daytona (its `127.0.0.1` is the *sandbox's* loopback, unreachable from the runner). But skipping it removed Claude's only advertisement channel on Daytona, and nothing replaced it. The file relay is the *execution* transport; the in-sandbox process that *advertises* the tool and writes relay request files is the Pi extension — which Claude does not have.

## Fix

A tiny self-contained **stdio MCP server** (`tools/relay-mcp-stdio.ts`), esbuild-bundled like the Pi extension, uploaded into the sandbox and advertised to Claude as an ACP `McpServerStdio` entry (typeless `{name,command,args,env}`). The sandbox-agent SDK forwards `sessionInit.mcpServers` verbatim into the in-sandbox `newSession`; the Claude ACP adapter maps a typeless entry to a Claude SDK `{type:"stdio",...}` server, launched **inside** the sandbox. On `tools/call` the shim writes the same relay request the existing runner-side relay loop already executes. The execution path, security model, and local path are all unchanged.

- `src/tools/relay-mcp-stdio.ts` — the shim (newline-delimited MCP JSON-RPC over stdio).
- `src/tools/relay-client.ts` — file-relay client factored out of `dispatch.ts` so the bundle carries only file-relay code (no callback/code executor): **5.3 kB, 0 network calls**.
- `src/engines/sandbox_agent/relay-shim.ts` — bundle path + **fail-loud** upload helper.
- `src/engines/sandbox_agent/mcp.ts` — Daytona non-Pi branch builds the stdio entry.
- `src/engines/sandbox_agent.ts` — upload the shim + pass the path on Daytona + non-Pi + tools.
- `scripts/build-extension.mjs` — also bundle `dist/tools/relay-mcp-stdio.js`.

## Security

The stdio child runs **inside** the Daytona sandbox (not the runner host — so it does NOT reopen the #4831 runner-host-stdio hole). It carries only public specs + the relay dir (no secret); every credentialed action stays server-side via the relay; Layer-3 permission enforcement in `startToolRelay` is unchanged. Caveat (documented): the relay dir is an in-sandbox capability — any sandbox process that can write a valid request file can invoke an already-allowed tool during the run. Not a secret leak; same exposure already exists for Pi on Daytona.

## Tests / status

- 284 runner unit tests + `tsc` green (was 268; +16 covering the shim handler, the stdio session entry, the fail-loud upload, and the no-shim/Pi/client-only branches).
- Bundle builds (5.3 kB, network-free) and answers `initialize` over stdio.
- Codex-reviewed (xhigh); findings folded in (fail-loud, layering, dependency seam, hardening, framing confirmed against the bundled Claude Code transport).
- **DRAFT — NOT live-verified on Daytona yet.** The one remaining gate is a real Claude + Daytona + callback-tool `/run`; repro recipe is in the design plan. Do not merge until that is green.

Design: `docs/design/agent-workflows/projects/claude-daytona-gateway/`

https://claude.ai/code/session_01GYo3UEfvsZpncagqb28Mbc