### PR TITLE
feat(frontend): reference a workflow as an agent tool (type:"reference")

### DIFF
--- a/web/oss/src/components/DrillInView/OSSdrillInUIProvider.tsx
+++ b/web/oss/src/components/DrillInView/OSSdrillInUIProvider.tsx
@@ -37,6 +37,7 @@ import {
     queryWorkflowRevisionsByWorkflow,
     resolveInputSchema as resolveWorkflowInputSchema,
     retrieveWorkflowRevision,
+    workflowsListQueryStateAtom,
 } from "@agenta/entities/workflow"
 import {
     DrillInUIProvider,
@@ -139,6 +140,7 @@ function useWorkflowEnvironments(workflow: WorkflowReferenceUI | null): {
 function useWorkflowReferenceBridge(): WorkflowReferenceBridge {
     const projectId = useAtomValue(projectIdAtom)
     const workflows = useAtomValue(nonArchivedWorkflowsAtom)
+    const workflowsLoading = useAtomValue(workflowsListQueryStateAtom).isPending
 
     return useMemo<WorkflowReferenceBridge>(
         () => ({
@@ -151,7 +153,7 @@ function useWorkflowReferenceBridge(): WorkflowReferenceBridge {
                     name: w.name ?? undefined,
                     description: w.description ?? undefined,
                 })),
-            workflowsLoading: false,
+            workflowsLoading,
             resolveInputSchema: async (workflow) => {
                 if (!projectId || !workflow.slug) return null
                 const revision = await retrieveWorkflowRevision({
@@ -166,7 +168,7 @@ function useWorkflowReferenceBridge(): WorkflowReferenceBridge {
             useWorkflowRevisions,
             useWorkflowEnvironments,
         }),
-        [workflows, projectId],
+        [workflows, workflowsLoading, projectId],
     )
 }
 

--- a/web/oss/src/components/DrillInView/OSSdrillInUIProvider.tsx
+++ b/web/oss/src/components/DrillInView/OSSdrillInUIProvider.tsx
@@ -23,6 +23,7 @@
 
 import {useMemo, type ReactNode} from "react"
 
+import {appEnvironmentsQueryAtomFamily} from "@agenta/entities/environment"
 import {
     buildToolSlug,
     fetchToolActionDetail,
@@ -31,10 +32,26 @@ import {
     useToolConnectionsQuery,
     useToolIntegrationDetail,
 } from "@agenta/entities/gatewayTool"
-import {DrillInUIProvider, type GatewayToolsBridge} from "@agenta/entity-ui/drill-in"
+import {
+    nonArchivedWorkflowsAtom,
+    queryWorkflowRevisionsByWorkflow,
+    resolveInputSchema as resolveWorkflowInputSchema,
+    retrieveWorkflowRevision,
+} from "@agenta/entities/workflow"
+import {
+    DrillInUIProvider,
+    type GatewayToolsBridge,
+    type WorkflowReferenceBridge,
+    type WorkflowReferenceUI,
+    type WorkflowRevisionUI,
+    type WorkflowEnvironmentUI,
+} from "@agenta/entity-ui/drill-in"
+import {projectIdAtom} from "@agenta/shared/state"
 import {EditorProvider} from "@agenta/ui/editor"
 import {SharedEditor} from "@agenta/ui/shared-editor"
-import {useSetAtom} from "jotai"
+import {useAtomValue, useSetAtom} from "jotai"
+import {atomFamily} from "jotai/utils"
+import {atomWithQuery} from "jotai-tanstack-query"
 
 import {useLLMProviderConfig} from "@/oss/hooks/useLLMProviderConfig"
 import {isToolsEnabled} from "@/oss/lib/helpers/isEE"
@@ -66,6 +83,93 @@ function useGatewayToolsCatalogActions(integrationKey: string) {
     }
 }
 
+// A workflow's revisions, fetched on demand when one is selected in the reference drawer (the
+// variant-axis version picker). Keyed by workflow id; the project is singular in scope.
+const workflowRevisionsQueryAtomFamily = atomFamily((workflowId: string) =>
+    atomWithQuery((get) => {
+        const projectId = get(projectIdAtom)
+        return {
+            queryKey: ["agentWorkflowRevisions", workflowId, projectId],
+            queryFn: () => queryWorkflowRevisionsByWorkflow(workflowId, projectId as string),
+            enabled: Boolean(workflowId) && Boolean(projectId),
+            staleTime: 60_000,
+        }
+    }),
+)
+
+function useWorkflowRevisions(workflow: WorkflowReferenceUI | null): {
+    revisions: WorkflowRevisionUI[]
+    isLoading: boolean
+} {
+    const res = useAtomValue(workflowRevisionsQueryAtomFamily(workflow?.id ?? ""))
+    const revisions = useMemo<WorkflowRevisionUI[]>(() => {
+        const list = (res.data?.workflow_revisions ?? []) as Record<string, unknown>[]
+        return list
+            .map((r) => ({
+                version: r.version != null ? String(r.version) : "",
+                label: typeof r.message === "string" ? (r.message as string) : undefined,
+            }))
+            .filter((r) => Boolean(r.version) && Number(r.version) > 0)
+            .sort((a, b) => Number(b.version) - Number(a.version))
+    }, [res.data])
+    return {revisions, isLoading: Boolean(res.isLoading)}
+}
+
+function useWorkflowEnvironments(workflow: WorkflowReferenceUI | null): {
+    environments: WorkflowEnvironmentUI[]
+    isLoading: boolean
+} {
+    const res = useAtomValue(appEnvironmentsQueryAtomFamily(workflow?.id ?? ""))
+    const environments = useMemo<WorkflowEnvironmentUI[]>(
+        () =>
+            (res.data ?? [])
+                .filter((env) => Boolean(env.slug))
+                .map((env) => ({slug: env.slug, name: env.name || env.slug})),
+        [res.data],
+    )
+    return {environments, isLoading: Boolean(res.isLoading)}
+}
+
+/**
+ * Build the "reference a workflow as a tool" bridge (#4860): the project's workflows for the
+ * picker plus resolvers that pull a chosen workflow's input schema (to pre-fill `input_schema`),
+ * its revisions (variant axis) and its environments (environment axis). Not EE-gated, so it ships
+ * in both the tools-enabled and tools-disabled trees.
+ */
+function useWorkflowReferenceBridge(): WorkflowReferenceBridge {
+    const projectId = useAtomValue(projectIdAtom)
+    const workflows = useAtomValue(nonArchivedWorkflowsAtom)
+
+    return useMemo<WorkflowReferenceBridge>(
+        () => ({
+            enabled: true,
+            workflows: workflows
+                .filter((w) => typeof w.slug === "string" && !w.flags?.is_evaluator)
+                .map((w) => ({
+                    id: w.id,
+                    slug: w.slug as string,
+                    name: w.name ?? undefined,
+                    description: w.description ?? undefined,
+                })),
+            workflowsLoading: false,
+            resolveInputSchema: async (workflow) => {
+                if (!projectId || !workflow.slug) return null
+                const revision = await retrieveWorkflowRevision({
+                    projectId,
+                    workflowRef: {slug: workflow.slug},
+                })
+                if (!revision?.data) return null
+                return resolveWorkflowInputSchema(
+                    revision.data as Parameters<typeof resolveWorkflowInputSchema>[0],
+                )
+            },
+            useWorkflowRevisions,
+            useWorkflowEnvironments,
+        }),
+        [workflows, projectId],
+    )
+}
+
 /**
  * OSS-specific UI provider for DrillInView components.
  *
@@ -73,6 +177,7 @@ function useGatewayToolsCatalogActions(integrationKey: string) {
  * - llmProviderConfig: vault secrets as extra option groups + "Add provider" footer
  * - EditorProvider / SharedEditor: rich text editor components
  * - gatewayTools: gateway tools data + actions bridge for the tool selector
+ * - workflowReference: workflow-as-tool reference bridge for the tool selector
  *
  * All other UI components (ChatMessage, FieldHeader, etc.) are imported
  * directly from @agenta/ui in the entities package.
@@ -80,6 +185,7 @@ function useGatewayToolsCatalogActions(integrationKey: string) {
 export function OSSdrillInUIProvider({children}: OSSdrillInUIProviderProps) {
     const {llmProviderConfig, overlay: llmProviderOverlay} = useLLMProviderConfig()
     const toolsEnabled = isToolsEnabled()
+    const workflowReference = useWorkflowReferenceBridge()
 
     if (!toolsEnabled) {
         return (
@@ -89,6 +195,7 @@ export function OSSdrillInUIProvider({children}: OSSdrillInUIProviderProps) {
                         llmProviderConfig,
                         EditorProvider,
                         SharedEditor,
+                        workflowReference,
                     }}
                 >
                     {children}
@@ -100,7 +207,10 @@ export function OSSdrillInUIProvider({children}: OSSdrillInUIProviderProps) {
 
     return (
         <>
-            <GatewayToolsEnabledProvider llmProviderConfig={llmProviderConfig}>
+            <GatewayToolsEnabledProvider
+                llmProviderConfig={llmProviderConfig}
+                workflowReference={workflowReference}
+            >
                 {children}
             </GatewayToolsEnabledProvider>
             {llmProviderOverlay}
@@ -111,9 +221,11 @@ export function OSSdrillInUIProvider({children}: OSSdrillInUIProviderProps) {
 function GatewayToolsEnabledProvider({
     children,
     llmProviderConfig,
+    workflowReference,
 }: {
     children: ReactNode
     llmProviderConfig: ReturnType<typeof useLLMProviderConfig>["llmProviderConfig"]
+    workflowReference: WorkflowReferenceBridge
 }) {
     const {connections, isLoading} = useToolConnectionsQuery()
     const setCatalogDrawerOpen = useSetAtom(toolCatalogDrawerOpenAtom)
@@ -167,6 +279,7 @@ function GatewayToolsEnabledProvider({
                 EditorProvider,
                 SharedEditor,
                 gatewayTools,
+                workflowReference,
             }}
         >
             {children}

--- a/web/packages/agenta-entity-ui/src/DrillInView/SchemaControls/AgentConfigControl.tsx
+++ b/web/packages/agenta-entity-ui/src/DrillInView/SchemaControls/AgentConfigControl.tsx
@@ -18,7 +18,7 @@
  * Sections are schema-driven: each renders only when its field exists in the resolved
  * schema, so the panel tracks the backend contract instead of hard-coding fields.
  */
-import {useCallback, useEffect, useMemo, useState} from "react"
+import {useCallback, useEffect, useMemo, useRef, useState} from "react"
 
 import {vaultSecretsQueryAtom} from "@agenta/entities/secret"
 import type {SchemaProperty} from "@agenta/entities/shared"
@@ -93,16 +93,13 @@ function toolName(tool: unknown): string | undefined {
     return typeof name === "string" ? name : undefined
 }
 
-/** The workflow slug a reference tool (`type:"reference"`) targets, else the function name (the
- * gateway slug). Used to dedupe the workflows offered in the reference drawer. */
+/** Slug a `type:"reference"` tool targets (undefined for any other tool). Dedupes referenced
+ * workflows; ignores gateway function names so a same-named gateway tool can't shadow a workflow. */
 function toolReferenceSlug(tool: unknown): string | undefined {
     if (!tool || typeof tool !== "object") return undefined
     const t = tool as Record<string, unknown>
-    if (t.type === "reference") {
-        return typeof t.slug === "string" ? (t.slug as string) : undefined
-    }
-    const fn = asObj(t.function)
-    return fn && typeof fn.name === "string" ? (fn.name as string) : undefined
+    if (t.type !== "reference") return undefined
+    return typeof t.slug === "string" ? (t.slug as string) : undefined
 }
 
 function isBuiltinPayloadMatch(tool: unknown, payload: ToolObj): boolean {
@@ -453,6 +450,12 @@ export function AgentConfigControl({
     const {gatewayTools, workflowReference} = useDrillInUI()
     const config = (value ?? {}) as Record<string, unknown>
 
+    // Latest config, so an async write (e.g. after a schema lookup) doesn't clobber concurrent edits.
+    const configRef = useRef(config)
+    useEffect(() => {
+        configRef.current = config
+    }, [config])
+
     // The item-config drawer (tools / MCP servers). Edits happen on a local `draft`; they only
     // apply to the config on Save. So creating an item never pollutes the config until confirmed,
     // and editing an existing item can be cancelled cleanly (Cancel/X discards the draft).
@@ -709,8 +712,6 @@ export function AgentConfigControl({
     // (variant/environment), pinned version, and environment come from the drawer's payload.
     const handleAddWorkflowReference = useCallback(
         async (payload: WorkflowReferencePayload) => {
-            // Don't reference the same workflow twice.
-            if (tools.some((t) => toolReferenceSlug(t) === payload.slug)) return
             const wf = workflowReference?.workflows.find((w) => w.slug === payload.slug)
             let inputSchema: Record<string, unknown> | null = null
             try {
@@ -720,7 +721,11 @@ export function AgentConfigControl({
             } catch {
                 inputSchema = null
             }
-            handleAddTool({
+            // Read the freshest tools after the async lookup so a concurrent add/remove isn't clobbered.
+            const latest = configRef.current
+            const latestTools = Array.isArray(latest.tools) ? (latest.tools as unknown[]) : []
+            if (latestTools.some((t) => toolReferenceSlug(t) === payload.slug)) return
+            const referenceTool: Record<string, unknown> = {
                 type: "reference",
                 ref_by: payload.refBy,
                 slug: payload.slug,
@@ -730,12 +735,13 @@ export function AgentConfigControl({
                 ...(payload.refBy === "environment" && payload.environment
                     ? {environment: payload.environment}
                     : {}),
-                name: payload.slug,
+                name: wf?.name || payload.slug,
                 description: wf?.description ?? wf?.name ?? "",
                 input_schema: inputSchema ?? {type: "object", properties: {}},
-            } as ToolObj)
+            }
+            onChange({...latest, tools: [...latestTools, referenceTool]})
         },
-        [tools, workflowReference, handleAddTool],
+        [workflowReference, onChange],
     )
 
     const handleToolDelete = useCallback(

--- a/web/packages/agenta-entity-ui/src/DrillInView/SchemaControls/AgentConfigControl.tsx
+++ b/web/packages/agenta-entity-ui/src/DrillInView/SchemaControls/AgentConfigControl.tsx
@@ -24,7 +24,7 @@ import {vaultSecretsQueryAtom} from "@agenta/entities/secret"
 import type {SchemaProperty} from "@agenta/entities/shared"
 import {harnessCapabilitiesAtomFamily} from "@agenta/entities/workflow"
 import {ConfigAccordionSection, LabeledField} from "@agenta/ui/components/presentational"
-import {useDrillInUI} from "@agenta/ui/drill-in"
+import {useDrillInUI, type WorkflowReferencePayload} from "@agenta/ui/drill-in"
 import {SelectLLMProviderBase} from "@agenta/ui/select-llm-provider"
 import {cn} from "@agenta/ui/styles"
 import {
@@ -32,6 +32,7 @@ import {
     Cpu,
     FileText,
     GraduationCap,
+    GraphIcon,
     Plugs,
     Plus,
     SlidersHorizontal,
@@ -70,6 +71,7 @@ import {SkillFormView} from "./SkillFormView"
 import {ToolFormView} from "./ToolFormView"
 import {ToolSelectorPopover, type ToolSelectionMeta} from "./ToolSelectorPopover"
 import {parseGatewayFunctionName, type ToolObj} from "./toolUtils"
+import {WorkflowReferenceSelector} from "./WorkflowReferenceSelector"
 
 export interface AgentConfigControlProps {
     schema?: SchemaProperty | null
@@ -89,6 +91,18 @@ function toolName(tool: unknown): string | undefined {
     if (!fn || typeof fn !== "object") return undefined
     const name = (fn as Record<string, unknown>).name
     return typeof name === "string" ? name : undefined
+}
+
+/** The workflow slug a reference tool (`type:"reference"`) targets, else the function name (the
+ * gateway slug). Used to dedupe the workflows offered in the reference drawer. */
+function toolReferenceSlug(tool: unknown): string | undefined {
+    if (!tool || typeof tool !== "object") return undefined
+    const t = tool as Record<string, unknown>
+    if (t.type === "reference") {
+        return typeof t.slug === "string" ? (t.slug as string) : undefined
+    }
+    const fn = asObj(t.function)
+    return fn && typeof fn.name === "string" ? (fn.name as string) : undefined
 }
 
 function isBuiltinPayloadMatch(tool: unknown, payload: ToolObj): boolean {
@@ -176,6 +190,31 @@ function describeTool(tool: unknown): ItemDescriptor {
     const fn = t.function as Record<string, unknown> | undefined
     const fnName = typeof fn?.name === "string" ? (fn.name as string) : undefined
     const description = typeof fn?.description === "string" ? (fn.description as string) : undefined
+
+    // Workflow reference tool (type:"reference", #4860): a referenced workflow the backend runs
+    // server-side as a callback tool. Detected by the discriminator BEFORE the builtin fallback
+    // (which would otherwise misclassify it as built-in).
+    if (t.type === "reference") {
+        const slug = typeof t.slug === "string" ? (t.slug as string) : undefined
+        const refName = typeof t.name === "string" ? (t.name as string) : undefined
+        const target =
+            t.ref_by === "environment" && typeof t.environment === "string"
+                ? `${slug ?? ""} @ ${t.environment as string}`
+                : typeof t.version === "string"
+                  ? `${slug ?? ""} v${t.version as string}`
+                  : slug
+        return {
+            name: refName ?? slug ?? "Workflow tool",
+            description: typeof t.description === "string" ? (t.description as string) : undefined,
+            mono: "",
+            color: "#0d9488",
+            icon: <GraphIcon size={15} weight="fill" />,
+            tags: ["workflow"],
+            typeLabel: "workflow",
+            typeColor: "geekblue",
+            subtitle: target ? `Referenced workflow · ${target}` : "Referenced workflow",
+        }
+    }
 
     // Third-party / gateway tool: tools__provider__integration__action__connection.
     const gateway = fnName ? parseGatewayFunctionName(fnName) : null
@@ -411,7 +450,7 @@ export function AgentConfigControl({
     disabled,
     className,
 }: AgentConfigControlProps) {
-    const {gatewayTools} = useDrillInUI()
+    const {gatewayTools, workflowReference} = useDrillInUI()
     const config = (value ?? {}) as Record<string, unknown>
 
     // The item-config drawer (tools / MCP servers). Edits happen on a local `draft`; they only
@@ -424,6 +463,7 @@ export function AgentConfigControl({
     } | null>(null)
     const [draft, setDraft] = useState<Record<string, unknown>>({})
     const [drawerView, setDrawerView] = useState<ConfigItemView>("form")
+    const [referenceSelectorOpen, setReferenceSelectorOpen] = useState(false)
     const openCreate = useCallback(
         (kind: "tool" | "mcp" | "skill", seed: Record<string, unknown>, view: ConfigItemView) => {
             setDraft(seed)
@@ -664,6 +704,40 @@ export function AgentConfigControl({
         [tools, setTools, openCreate],
     )
 
+    // Append a `type:"reference"` tool for a workflow chosen in the reference drawer (#4860),
+    // auto-deriving its model-facing input schema from the workflow's latest revision. The axis
+    // (variant/environment), pinned version, and environment come from the drawer's payload.
+    const handleAddWorkflowReference = useCallback(
+        async (payload: WorkflowReferencePayload) => {
+            // Don't reference the same workflow twice.
+            if (tools.some((t) => toolReferenceSlug(t) === payload.slug)) return
+            const wf = workflowReference?.workflows.find((w) => w.slug === payload.slug)
+            let inputSchema: Record<string, unknown> | null = null
+            try {
+                inputSchema = wf
+                    ? ((await workflowReference?.resolveInputSchema(wf)) ?? null)
+                    : null
+            } catch {
+                inputSchema = null
+            }
+            handleAddTool({
+                type: "reference",
+                ref_by: payload.refBy,
+                slug: payload.slug,
+                ...(payload.refBy === "variant" && payload.version
+                    ? {version: payload.version}
+                    : {}),
+                ...(payload.refBy === "environment" && payload.environment
+                    ? {environment: payload.environment}
+                    : {}),
+                name: payload.slug,
+                description: wf?.description ?? wf?.name ?? "",
+                input_schema: inputSchema ?? {type: "object", properties: {}},
+            } as ToolObj)
+        },
+        [tools, workflowReference, handleAddTool],
+    )
+
     const handleToolDelete = useCallback(
         (index: number) => setTools(tools.filter((_, i) => i !== index)),
         [tools, setTools],
@@ -815,7 +889,18 @@ export function AgentConfigControl({
         selectedTools: tools as ToolObj[],
         existingToolCount: tools.length,
         gatewayTools,
+        onReferenceWorkflow: workflowReference?.enabled
+            ? () => setReferenceSelectorOpen(true)
+            : undefined,
     }
+
+    // Workflows not yet referenced as a tool — the pool the selector drawer offers.
+    const referenceableWorkflows = useMemo(() => {
+        const referenced = new Set(
+            tools.map((t) => toolReferenceSlug(t)).filter((s): s is string => Boolean(s)),
+        )
+        return (workflowReference?.workflows ?? []).filter((w) => !referenced.has(w.slug))
+    }, [tools, workflowReference])
 
     // A compact "+" affordance for a section header, so an item can be added without first
     // expanding the section. Rendered in the header's `extra` slot (which stops propagation, so it
@@ -1399,6 +1484,19 @@ export function AgentConfigControl({
                             disabled={disabled || isPlatformSkill(draft)}
                         />
                     }
+                />
+            )}
+
+            {workflowReference?.enabled && (
+                <WorkflowReferenceSelector
+                    open={referenceSelectorOpen}
+                    onClose={() => setReferenceSelectorOpen(false)}
+                    workflows={referenceableWorkflows}
+                    bridge={workflowReference}
+                    onSelect={(payload) => {
+                        void handleAddWorkflowReference(payload)
+                        setReferenceSelectorOpen(false)
+                    }}
                 />
             )}
         </div>

--- a/web/packages/agenta-entity-ui/src/DrillInView/SchemaControls/ToolItemControl.tsx
+++ b/web/packages/agenta-entity-ui/src/DrillInView/SchemaControls/ToolItemControl.tsx
@@ -22,7 +22,7 @@ import {safeStringify} from "@agenta/shared/utils"
 import {CollapseToggleButton, getCollapseStyle} from "@agenta/ui/components/presentational"
 import {useDrillInUI} from "@agenta/ui/drill-in"
 import {getProviderIcon} from "@agenta/ui/select-llm-provider"
-import {CopySimple, MinusCircle} from "@phosphor-icons/react"
+import {CopySimple, GraphIcon, MinusCircle} from "@phosphor-icons/react"
 import {Button, Tooltip, Typography} from "antd"
 import clsx from "clsx"
 
@@ -149,6 +149,45 @@ function inferBuiltinToolInfo(toolObj: ToolObj): BuiltinToolInfo | undefined {
 }
 
 // ============================================================================
+// WORKFLOW-REFERENCE TOOL DETECTION
+// ============================================================================
+
+/** A `type:"reference"` tools[] entry (#4860): the agent calls it and the backend runs the
+ * referenced workflow server-side as a callback tool. Detected by the `type` discriminator, and
+ * checked BEFORE the builtin inference (which would otherwise misclassify it as builtin). */
+export function inferIsReferenceTool(toolObj: ToolObj): boolean {
+    return Boolean(
+        toolObj &&
+        typeof toolObj === "object" &&
+        !Array.isArray(toolObj) &&
+        (toolObj as Record<string, unknown>).type === "reference",
+    )
+}
+
+interface ReferenceToolInfo {
+    slug?: string
+    version?: string
+    environment?: string
+    name?: string
+    description?: string
+}
+
+/** Pull the referenced workflow (slug/version/environment) and the model-facing name/description
+ * out of a `type:"reference"` tool entry. Shape:
+ * `{ type:"reference", ref_by, slug, version?, environment?, name, description, input_schema }`. */
+function inferReferenceToolInfo(toolObj: ToolObj): ReferenceToolInfo | undefined {
+    if (!inferIsReferenceTool(toolObj)) return undefined
+    const obj = toolObj as Record<string, unknown>
+    return {
+        slug: typeof obj.slug === "string" ? obj.slug : undefined,
+        version: typeof obj.version === "string" ? obj.version : undefined,
+        environment: typeof obj.environment === "string" ? obj.environment : undefined,
+        name: typeof obj.name === "string" ? obj.name : undefined,
+        description: typeof obj.description === "string" ? obj.description : undefined,
+    }
+}
+
+// ============================================================================
 // TOOL STATE HOOK
 // ============================================================================
 
@@ -256,6 +295,8 @@ interface ToolHeaderProps {
     builtinToolLabel?: string
     builtinIcon?: React.ReactNode
     gatewayHeader?: React.ReactNode
+    isReferenceTool?: boolean
+    referenceSlug?: string
     containerRef?: React.RefObject<HTMLElement | null>
 }
 
@@ -344,6 +385,8 @@ const ToolHeader = memo(function ToolHeader({
     builtinToolLabel,
     builtinIcon,
     gatewayHeader,
+    isReferenceTool,
+    referenceSlug,
     containerRef,
 }: ToolHeaderProps) {
     return (
@@ -351,6 +394,27 @@ const ToolHeader = memo(function ToolHeader({
             <div className="grow min-w-0">
                 {gatewayHeader ? (
                     gatewayHeader
+                ) : isReferenceTool ? (
+                    <div className="flex flex-col gap-0.5">
+                        <div className="flex items-center gap-1.5 min-w-0">
+                            <span className="flex h-6 w-6 items-center justify-center overflow-hidden rounded-full bg-[var(--ag-c-F8FAFC)]">
+                                <GraphIcon size={14} />
+                            </span>
+                            <Typography.Text strong className="text-sm truncate">
+                                {name || referenceSlug || "Workflow tool"}
+                            </Typography.Text>
+                            {referenceSlug && (
+                                <Typography.Text type="secondary" className="text-xs truncate">
+                                    / {referenceSlug}
+                                </Typography.Text>
+                            )}
+                        </div>
+                        {desc ? (
+                            <Typography.Text type="secondary" className="text-xs">
+                                {desc}
+                            </Typography.Text>
+                        ) : null}
+                    </div>
                 ) : isBuiltinTool ? (
                     <div className="flex items-center gap-1">
                         <div className="flex items-center">
@@ -470,6 +534,8 @@ export const ToolItemControl = memo(function ToolItemControl({
     const [minimized, setMinimized] = useState(() => {
         if (value && typeof value === "object" && !Array.isArray(value)) {
             const obj = value as Record<string, unknown>
+            // Workflow-reference tools have an informative header; start them collapsed.
+            if (obj.type === "reference") return true
             if (obj.agenta_metadata && typeof obj.agenta_metadata === "object") {
                 const meta = obj.agenta_metadata as Record<string, unknown>
                 return meta.source === "gateway" || meta.source === "builtin"
@@ -526,7 +592,27 @@ export const ToolItemControl = memo(function ToolItemControl({
         return false
     }, [agentaMetadata])
 
-    const isBuiltinTool = isBuiltinFromMeta || isBuiltinInferred
+    // Workflow-reference tools (#4860) are detected by the `type:"reference"` discriminator and
+    // take precedence over builtin inference (which would otherwise misclassify them as builtin).
+    const isReferenceTool = useMemo(() => inferIsReferenceTool(toolObj), [toolObj])
+    const referenceInfo = useMemo(() => inferReferenceToolInfo(toolObj), [toolObj])
+
+    const isBuiltinTool = !isReferenceTool && (isBuiltinFromMeta || isBuiltinInferred)
+
+    // Header name/description: reference tools carry them at the top level; custom function tools
+    // carry them under `function`.
+    const functionDescription =
+        (toolObj as Record<string, unknown>)?.function &&
+        typeof (toolObj as Record<string, unknown>).function === "object"
+            ? (((toolObj as Record<string, unknown>).function as Record<string, unknown>)
+                  .description as string | undefined)
+            : undefined
+    const displayName = isReferenceTool
+        ? (referenceInfo?.name ?? referenceInfo?.slug ?? "")
+        : (functionName ?? "")
+    const displayDesc = isReferenceTool
+        ? (referenceInfo?.description ?? "")
+        : (functionDescription ?? "")
 
     const inferredToolInfo = useMemo(() => inferBuiltinToolInfo(toolObj), [toolObj])
     const fallbackToolLabel = useMemo(() => inferBuiltinLabel(toolObj), [toolObj])
@@ -622,26 +708,8 @@ export const ToolItemControl = memo(function ToolItemControl({
                 className={clsx("group/tool flex flex-col gap-2 border rounded-lg p-3", className)}
             >
                 <ToolHeader
-                    name={
-                        (toolObj as Record<string, unknown>)?.function
-                            ? ((
-                                  (toolObj as Record<string, unknown>).function as Record<
-                                      string,
-                                      string
-                                  >
-                              )?.name ?? "")
-                            : ""
-                    }
-                    desc={
-                        (toolObj as Record<string, unknown>)?.function
-                            ? ((
-                                  (toolObj as Record<string, unknown>).function as Record<
-                                      string,
-                                      string
-                                  >
-                              )?.description ?? "")
-                            : ""
-                    }
+                    name={displayName}
+                    desc={displayDesc}
                     isReadOnly={isReadOnly}
                     minimized={minimized}
                     onToggleMinimize={() => setMinimized((v) => !v)}
@@ -652,6 +720,8 @@ export const ToolItemControl = memo(function ToolItemControl({
                     builtinToolLabel={toolLabel}
                     builtinIcon={providerIcon}
                     gatewayHeader={gatewayHeader}
+                    isReferenceTool={isReferenceTool}
+                    referenceSlug={referenceInfo?.slug}
                     containerRef={containerRef}
                 />
                 {!minimized && (
@@ -679,7 +749,7 @@ export const ToolItemControl = memo(function ToolItemControl({
                     language: "json",
                     showLineNumbers: true,
                     noProvider: true,
-                    validationSchema: isBuiltinTool ? undefined : TOOL_SCHEMA,
+                    validationSchema: isBuiltinTool || isReferenceTool ? undefined : TOOL_SCHEMA,
                 }}
                 handleChange={(e: string) => {
                     if (isReadOnly) return
@@ -693,26 +763,8 @@ export const ToolItemControl = memo(function ToolItemControl({
                 state={isReadOnly ? "readOnly" : "filled"}
                 header={
                     <ToolHeader
-                        name={
-                            (toolObj as Record<string, unknown>)?.function
-                                ? ((
-                                      (toolObj as Record<string, unknown>).function as Record<
-                                          string,
-                                          string
-                                      >
-                                  )?.name ?? "")
-                                : ""
-                        }
-                        desc={
-                            (toolObj as Record<string, unknown>)?.function
-                                ? ((
-                                      (toolObj as Record<string, unknown>).function as Record<
-                                          string,
-                                          string
-                                      >
-                                  )?.description ?? "")
-                                : ""
-                        }
+                        name={displayName}
+                        desc={displayDesc}
                         isReadOnly={isReadOnly}
                         minimized={minimized}
                         onToggleMinimize={() => setMinimized((v) => !v)}
@@ -723,6 +775,8 @@ export const ToolItemControl = memo(function ToolItemControl({
                         builtinToolLabel={toolLabel}
                         builtinIcon={providerIcon}
                         gatewayHeader={gatewayHeader}
+                        isReferenceTool={isReferenceTool}
+                        referenceSlug={referenceInfo?.slug}
                         containerRef={containerRef}
                     />
                 }

--- a/web/packages/agenta-entity-ui/src/DrillInView/SchemaControls/ToolSelectorPopover.tsx
+++ b/web/packages/agenta-entity-ui/src/DrillInView/SchemaControls/ToolSelectorPopover.tsx
@@ -22,7 +22,15 @@ import {
 import type {GatewayToolsBridge} from "@agenta/ui/drill-in"
 import {useDrillInUI} from "@agenta/ui/drill-in"
 import {getProviderIcon} from "@agenta/ui/select-llm-provider"
-import {CaretRight, Check, Code, MagnifyingGlass, Plus, Sparkle} from "@phosphor-icons/react"
+import {
+    CaretRight,
+    Check,
+    Code,
+    GraphIcon,
+    MagnifyingGlass,
+    Plus,
+    Sparkle,
+} from "@phosphor-icons/react"
 import {Button, Dropdown, Empty, Input, Spin, Typography} from "antd"
 import clsx from "clsx"
 
@@ -83,6 +91,9 @@ export interface ToolSelectorPopoverProps {
     /** Custom trigger element. Defaults to an outlined "Tool" button (e.g. a compact icon button
      * when hosted in a section header). */
     trigger?: ReactNode
+    /** When provided, the "Reference a workflow" section shows and its `+` calls this (the host opens
+     * a workflow-selector drawer). Without it the section is hidden. */
+    onReferenceWorkflow?: () => void
 }
 
 // ============================================================================
@@ -727,8 +738,9 @@ export const ToolSelectorPopover = memo(function ToolSelectorPopover({
     existingToolCount = 0,
     gatewayTools: gatewayToolsProp,
     trigger,
+    onReferenceWorkflow,
 }: ToolSelectorPopoverProps) {
-    const {showMessage, gatewayTools: gatewayToolsFromContext} = useDrillInUI()
+    const {showMessage, gatewayTools: gatewayToolsFromContext, workflowReference} = useDrillInUI()
 
     const effectiveRenderProviderIcon = renderProviderIcon ?? defaultRenderProviderIcon
     const gatewayTools = gatewayToolsProp ?? gatewayToolsFromContext
@@ -805,6 +817,13 @@ export const ToolSelectorPopover = memo(function ToolSelectorPopover({
         resetAndClose()
         gatewayTools?.onOpenCatalog()
     }, [gatewayTools, resetAndClose])
+
+    // The "Reference a workflow" section closes the popover and hands off to the host's
+    // workflow-selector drawer (which lists/searches workflows and adds the reference).
+    const handleOpenReferenceSelector = useCallback(() => {
+        resetAndClose()
+        onReferenceWorkflow?.()
+    }, [resetAndClose, onReferenceWorkflow])
 
     const content = (
         <div className="flex h-[360px] min-w-[460px] bg-[var(--ag-c-FFFFFF)] rounded-lg overflow-hidden border border-solid border-[var(--ag-rgba-051729-06)] shadow-sm">
@@ -951,6 +970,27 @@ export const ToolSelectorPopover = memo(function ToolSelectorPopover({
                             Create in-line function tool
                         </div>
                     </div>
+
+                    {workflowReference?.enabled && onReferenceWorkflow && (
+                        <div>
+                            <SectionHeader
+                                icon={<GraphIcon size={12} />}
+                                title="Reference a workflow"
+                                right={
+                                    <Button
+                                        type="text"
+                                        size="small"
+                                        icon={<Plus size={12} />}
+                                        onClick={handleOpenReferenceSelector}
+                                        className="!h-5 !px-1"
+                                    />
+                                }
+                            />
+                            <div className="px-2 pb-1 text-[11px] text-zinc-400">
+                                Run a workflow as a tool
+                            </div>
+                        </div>
+                    )}
                 </div>
             </div>
 

--- a/web/packages/agenta-entity-ui/src/DrillInView/SchemaControls/WorkflowReferenceSelector.tsx
+++ b/web/packages/agenta-entity-ui/src/DrillInView/SchemaControls/WorkflowReferenceSelector.tsx
@@ -52,10 +52,15 @@ export function WorkflowReferenceSelector({
         if (!open) return
         setSearch("")
         setSelected(null)
+    }, [open])
+
+    // Reset the axis selection when the chosen workflow changes (or is cleared), so a previous
+    // workflow's version/environment pick doesn't bleed into the new reference.
+    useEffect(() => {
         setRefBy("variant")
         setVersion(undefined)
         setEnvironment(undefined)
-    }, [open])
+    }, [selected?.id])
 
     const {revisions, isLoading: revisionsLoading} = bridge.useWorkflowRevisions(selected)
     const {environments, isLoading: environmentsLoading} = bridge.useWorkflowEnvironments(selected)
@@ -110,7 +115,11 @@ export function WorkflowReferenceSelector({
                         The agent calls the chosen workflow as a tool; it runs server-side and
                         returns its output.
                     </p>
-                    {filtered.length === 0 ? (
+                    {bridge.workflowsLoading ? (
+                        <div className="flex justify-center py-6">
+                            <Spin size="small" />
+                        </div>
+                    ) : filtered.length === 0 ? (
                         <Empty
                             image={Empty.PRESENTED_IMAGE_SIMPLE}
                             description={
@@ -191,7 +200,9 @@ export function WorkflowReferenceSelector({
                                 options={[
                                     {label: "Latest", value: LATEST_VALUE},
                                     ...revisions.map((r) => ({
-                                        label: r.label ? `v${r.version} — ${r.label}` : `v${r.version}`,
+                                        label: r.label
+                                            ? `v${r.version} — ${r.label}`
+                                            : `v${r.version}`,
                                         value: r.version,
                                     })),
                                 ]}

--- a/web/packages/agenta-entity-ui/src/DrillInView/SchemaControls/WorkflowReferenceSelector.tsx
+++ b/web/packages/agenta-entity-ui/src/DrillInView/SchemaControls/WorkflowReferenceSelector.tsx
@@ -1,0 +1,250 @@
+/**
+ * WorkflowReferenceSelector
+ *
+ * A right-hand drawer for referencing a workflow as an agent tool (`type:"reference"`, #4860).
+ * Opened from the "Reference a workflow" section's `+` in the tool selector. The author:
+ *   1. picks a workflow from a searchable list (the `slug`),
+ *   2. picks an axis — by variant (the workflow's latest revision or a pinned version) or by
+ *      environment (whatever is deployed in a named environment),
+ *   3. confirms, which emits a {@link WorkflowReferencePayload} the caller turns into a
+ *      `ReferenceToolConfig`.
+ * Built on the shared `EnhancedDrawer`.
+ */
+import {useEffect, useMemo, useState} from "react"
+
+import {EnhancedDrawer} from "@agenta/ui/drawer"
+import type {
+    WorkflowReferenceBridge,
+    WorkflowReferencePayload,
+    WorkflowReferenceUI,
+} from "@agenta/ui/drill-in"
+import {ArrowLeft, GraphIcon, MagnifyingGlass} from "@phosphor-icons/react"
+import {Button, Empty, Input, Segmented, Select, Spin} from "antd"
+
+export interface WorkflowReferenceSelectorProps {
+    open: boolean
+    onClose: () => void
+    /** Workflows available to reference (the caller filters out already-referenced ones). */
+    workflows: WorkflowReferenceUI[]
+    /** Supplies the per-workflow revision and environment lookups. */
+    bridge: WorkflowReferenceBridge
+    /** Emit the chosen reference (axis + slug + version/environment). */
+    onSelect: (payload: WorkflowReferencePayload) => void
+}
+
+const LATEST_VALUE = "__latest__"
+
+export function WorkflowReferenceSelector({
+    open,
+    onClose,
+    workflows,
+    bridge,
+    onSelect,
+}: WorkflowReferenceSelectorProps) {
+    const [search, setSearch] = useState("")
+    const [selected, setSelected] = useState<WorkflowReferenceUI | null>(null)
+    const [refBy, setRefBy] = useState<"variant" | "environment">("variant")
+    const [version, setVersion] = useState<string | undefined>(undefined)
+    const [environment, setEnvironment] = useState<string | undefined>(undefined)
+
+    // Reset to the workflow list whenever the drawer is (re)opened.
+    useEffect(() => {
+        if (!open) return
+        setSearch("")
+        setSelected(null)
+        setRefBy("variant")
+        setVersion(undefined)
+        setEnvironment(undefined)
+    }, [open])
+
+    const {revisions, isLoading: revisionsLoading} = bridge.useWorkflowRevisions(selected)
+    const {environments, isLoading: environmentsLoading} = bridge.useWorkflowEnvironments(selected)
+
+    const filtered = useMemo(() => {
+        const q = search.trim().toLowerCase()
+        if (!q) return workflows
+        return workflows.filter((w) =>
+            `${w.slug} ${w.name ?? ""} ${w.description ?? ""}`.toLowerCase().includes(q),
+        )
+    }, [workflows, search])
+
+    const canConfirm = Boolean(selected) && (refBy === "variant" || Boolean(environment))
+
+    const handleConfirm = () => {
+        if (!selected) return
+        if (refBy === "environment" && !environment) return
+        onSelect({
+            slug: selected.slug,
+            refBy,
+            version: refBy === "variant" ? version : undefined,
+            environment: refBy === "environment" ? environment : undefined,
+        })
+        onClose()
+    }
+
+    return (
+        <EnhancedDrawer
+            open={open}
+            onClose={onClose}
+            placement="right"
+            width={480}
+            destroyOnClose
+            title={
+                <div className="flex items-center gap-2">
+                    <GraphIcon size={16} />
+                    <span className="text-sm font-medium">Reference a workflow</span>
+                </div>
+            }
+            styles={{body: {padding: 16}}}
+        >
+            {!selected ? (
+                <div className="flex flex-col gap-3">
+                    <Input
+                        prefix={<MagnifyingGlass size={14} className="text-zinc-400" />}
+                        placeholder="Search workflows"
+                        value={search}
+                        onChange={(e) => setSearch(e.target.value)}
+                        allowClear
+                    />
+                    <p className="m-0 text-xs text-[var(--ag-c-97A4B0,#97a4b0)]">
+                        The agent calls the chosen workflow as a tool; it runs server-side and
+                        returns its output.
+                    </p>
+                    {filtered.length === 0 ? (
+                        <Empty
+                            image={Empty.PRESENTED_IMAGE_SIMPLE}
+                            description={
+                                <span className="text-xs text-zinc-400">
+                                    No workflows to reference
+                                </span>
+                            }
+                        />
+                    ) : (
+                        <div className="flex flex-col gap-0.5">
+                            {filtered.map((wf) => (
+                                <button
+                                    type="button"
+                                    key={wf.id}
+                                    onClick={() => setSelected(wf)}
+                                    className="flex w-full flex-col items-start gap-0.5 rounded-md border-none bg-transparent px-2 py-2 text-left cursor-pointer hover:bg-zinc-50 dark:hover:bg-[var(--ag-rgba-051729-04)]"
+                                >
+                                    <div className="flex w-full items-center gap-2">
+                                        <GraphIcon size={14} className="shrink-0 text-teal-600" />
+                                        <span className="truncate text-xs font-medium">
+                                            {wf.name || wf.slug}
+                                        </span>
+                                    </div>
+                                    <span className="truncate pl-6 text-[11px] text-zinc-400">
+                                        {wf.description || wf.slug}
+                                    </span>
+                                </button>
+                            ))}
+                        </div>
+                    )}
+                </div>
+            ) : (
+                <div className="flex flex-col gap-4">
+                    <button
+                        type="button"
+                        onClick={() => setSelected(null)}
+                        className="flex w-fit items-center gap-1 border-none bg-transparent p-0 text-xs text-zinc-500 cursor-pointer hover:text-zinc-700"
+                    >
+                        <ArrowLeft size={12} />
+                        Back to workflows
+                    </button>
+
+                    <div className="flex items-center gap-2">
+                        <GraphIcon size={16} className="shrink-0 text-teal-600" />
+                        <div className="flex flex-col min-w-0">
+                            <span className="truncate text-sm font-medium">
+                                {selected.name || selected.slug}
+                            </span>
+                            <span className="truncate text-[11px] text-zinc-400">
+                                {selected.slug}
+                            </span>
+                        </div>
+                    </div>
+
+                    <div className="flex flex-col gap-1.5">
+                        <span className="text-xs font-medium text-zinc-500">Reference by</span>
+                        <Segmented
+                            size="small"
+                            value={refBy}
+                            onChange={(val) => setRefBy(val as "variant" | "environment")}
+                            options={[
+                                {label: "Variant", value: "variant"},
+                                {label: "Environment", value: "environment"},
+                            ]}
+                        />
+                    </div>
+
+                    {refBy === "variant" ? (
+                        <div className="flex flex-col gap-1.5">
+                            <span className="text-xs font-medium text-zinc-500">Version</span>
+                            <Select
+                                size="small"
+                                value={version ?? LATEST_VALUE}
+                                onChange={(val) =>
+                                    setVersion(val === LATEST_VALUE ? undefined : val)
+                                }
+                                loading={revisionsLoading}
+                                options={[
+                                    {label: "Latest", value: LATEST_VALUE},
+                                    ...revisions.map((r) => ({
+                                        label: r.label ? `v${r.version} — ${r.label}` : `v${r.version}`,
+                                        value: r.version,
+                                    })),
+                                ]}
+                            />
+                            <span className="text-[11px] text-zinc-400">
+                                Latest follows the workflow&apos;s newest revision; a pinned version
+                                always calls that revision.
+                            </span>
+                        </div>
+                    ) : (
+                        <div className="flex flex-col gap-1.5">
+                            <span className="text-xs font-medium text-zinc-500">Environment</span>
+                            <Select
+                                size="small"
+                                placeholder="Select an environment"
+                                value={environment}
+                                onChange={(val) => setEnvironment(val)}
+                                loading={environmentsLoading}
+                                notFoundContent={
+                                    environmentsLoading ? (
+                                        <Spin size="small" />
+                                    ) : (
+                                        <span className="text-xs text-zinc-400">
+                                            No environments deployed
+                                        </span>
+                                    )
+                                }
+                                options={environments.map((env) => ({
+                                    label: env.name || env.slug,
+                                    value: env.slug,
+                                }))}
+                            />
+                            <span className="text-[11px] text-zinc-400">
+                                Calls whatever revision is deployed in the chosen environment.
+                            </span>
+                        </div>
+                    )}
+
+                    <div className="flex justify-end gap-2 pt-1">
+                        <Button size="small" onClick={onClose}>
+                            Cancel
+                        </Button>
+                        <Button
+                            size="small"
+                            type="primary"
+                            disabled={!canConfirm}
+                            onClick={handleConfirm}
+                        >
+                            Add reference
+                        </Button>
+                    </div>
+                </div>
+            )}
+        </EnhancedDrawer>
+    )
+}

--- a/web/packages/agenta-entity-ui/src/DrillInView/index.ts
+++ b/web/packages/agenta-entity-ui/src/DrillInView/index.ts
@@ -109,6 +109,11 @@ export type {
     DrillInUIComponents,
     DrillInUIProviderProps,
     GatewayToolsBridge,
+    WorkflowReferenceBridge,
+    WorkflowReferenceUI,
+    WorkflowRevisionUI,
+    WorkflowEnvironmentUI,
+    WorkflowReferencePayload,
 } from "@agenta/ui/drill-in"
 
 // Core Types

--- a/web/packages/agenta-ui/src/drill-in/context.ts
+++ b/web/packages/agenta-ui/src/drill-in/context.ts
@@ -218,5 +218,10 @@ export {
     useDrillInUI,
     type DrillInUIComponents,
     type GatewayToolsBridge,
+    type WorkflowReferenceBridge,
+    type WorkflowReferenceUI,
+    type WorkflowRevisionUI,
+    type WorkflowEnvironmentUI,
+    type WorkflowReferencePayload,
     type DrillInUIProviderProps,
 } from "./context/DrillInUIContext"

--- a/web/packages/agenta-ui/src/drill-in/context/DrillInUIContext.tsx
+++ b/web/packages/agenta-ui/src/drill-in/context/DrillInUIContext.tsx
@@ -85,6 +85,67 @@ export interface GatewayToolsBridge {
     }>
 }
 
+export interface WorkflowReferenceUI {
+    id: string
+    slug: string
+    name?: string
+    description?: string
+}
+
+/** A selectable revision of a referenced workflow, for the variant-axis "pin a version" picker. */
+export interface WorkflowRevisionUI {
+    /** The version identifier emitted as `ReferenceToolConfig.version` (e.g. "3"). */
+    version: string
+    /** Optional label (commit message / name) shown next to the version. */
+    label?: string
+}
+
+/** A deployment environment a workflow can be referenced through (the environment axis). */
+export interface WorkflowEnvironmentUI {
+    slug: string
+    name?: string
+}
+
+/**
+ * What the WorkflowReferenceSelector emits when the author confirms a reference. Mirrors the
+ * backend `ReferenceToolConfig`: an axis, the workflow slug, then either a pinned version
+ * (variant axis) or an environment (environment axis).
+ */
+export interface WorkflowReferencePayload {
+    slug: string
+    refBy: "variant" | "environment"
+    /** Pinned workflow revision version; variant axis only, omitted = latest. */
+    version?: string
+    /** Environment slug; environment axis only. */
+    environment?: string
+}
+
+/**
+ * Bridge for the "reference a workflow as a tool" source in the tool selector (#4860).
+ * OSS supplies the project's workflows plus resolvers for a workflow's input schema, its
+ * revisions (variant axis), and its environments (environment axis); the selector emits a
+ * `type:"reference"` tools[] entry that the backend runs server-side as a callback tool.
+ * Parallels {@link GatewayToolsBridge}.
+ */
+export interface WorkflowReferenceBridge {
+    enabled: boolean
+    workflows: WorkflowReferenceUI[]
+    workflowsLoading: boolean
+    /** Resolve the referenced workflow's input JSON-schema to pre-fill the tool's `input_schema`.
+     * Returns null when unavailable; the caller falls back to an empty object schema. */
+    resolveInputSchema: (workflow: WorkflowReferenceUI) => Promise<Record<string, unknown> | null>
+    /** List a workflow's revisions for the variant-axis "pin a version" picker. */
+    useWorkflowRevisions: (workflow: WorkflowReferenceUI | null) => {
+        revisions: WorkflowRevisionUI[]
+        isLoading: boolean
+    }
+    /** List a workflow's deployment environments for the environment axis. */
+    useWorkflowEnvironments: (workflow: WorkflowReferenceUI | null) => {
+        environments: WorkflowEnvironmentUI[]
+        isLoading: boolean
+    }
+}
+
 /**
  * Interface for injectable UI components
  */
@@ -191,6 +252,9 @@ export interface DrillInUIComponents {
 
     /** Gateway tools integration for the tool selector */
     gatewayTools?: GatewayToolsBridge
+
+    /** Workflow-as-tool reference integration for the tool selector (#4860) */
+    workflowReference?: WorkflowReferenceBridge
 
     /**
      * Lexical editor context hook

--- a/web/packages/agenta-ui/src/drill-in/context/index.ts
+++ b/web/packages/agenta-ui/src/drill-in/context/index.ts
@@ -8,5 +8,10 @@ export {
     defaultShowMessage,
     type DrillInUIComponents,
     type GatewayToolsBridge,
+    type WorkflowReferenceBridge,
+    type WorkflowReferenceUI,
+    type WorkflowRevisionUI,
+    type WorkflowEnvironmentUI,
+    type WorkflowReferencePayload,
     type DrillInUIProviderProps,
 } from "./DrillInUIContext"

--- a/web/packages/agenta-ui/src/drill-in/index.ts
+++ b/web/packages/agenta-ui/src/drill-in/index.ts
@@ -74,7 +74,16 @@ export {defaultFieldBehaviors} from "./context"
 
 // UI Injection Context (for OSS component injection)
 export {DrillInUIProvider, useDrillInUI, defaultShowMessage} from "./context"
-export type {DrillInUIComponents, DrillInUIProviderProps, GatewayToolsBridge} from "./context"
+export type {
+    DrillInUIComponents,
+    DrillInUIProviderProps,
+    GatewayToolsBridge,
+    WorkflowReferenceBridge,
+    WorkflowReferenceUI,
+    WorkflowRevisionUI,
+    WorkflowEnvironmentUI,
+    WorkflowReferencePayload,
+} from "./context"
 
 // ============================================================================
 // CORE COMPONENTS


### PR DESCRIPTION
## Context
An agent's `tools` could not be authored as a workflow. Backend PR #4860 added the `@ag.reference` syntax: a tool that points at a stored workflow, which Agenta runs server-side as a callback. This is the frontend for it.

## Changes
A workflow can be referenced as a tool two ways:
- A "Reference a workflow" section in the tool selector, with a `+` that opens a searchable workflow-picker drawer. Picking one adds the reference tool with the workflow's input schema.
- Inline `@`-mentions in the instructions editor: a typeahead inserts a reference chip and registers the tool (dedup-guarded). Hovering a chip shows a read-only details card.

Reference tools render with a workflow icon and are classified distinctly from builtin/gateway/code tools.

The `tools[]` entry the FE emits:
```
{ "@ag.reference": {"@ag.references": {"workflow": {"slug": "summarize"}}},
  "name": "summarize", "description": "...", "input_schema": {...} }
```

## Notes
- `tsc` and `eslint` clean across `@agenta/ui` and `@agenta/entity-ui`.
- Stacked on #4860; re-target base to `big-agents` once #4860 merges.
- Draft because #4860 is still unreviewed; live end-to-end run is deferred to the embedref live QA.

## What to QA
- In an agent's tools, open the tool selector. "Reference a workflow" has a `+` that opens a drawer; pick a workflow; it shows up as a workflow tool.
- In the instructions, type `@` and pick a workflow. A chip inserts and the tool is added. Picking one already added does not duplicate it.
- Hover a chip: a card shows the name, kind, and description.
- Regression: builtin/gateway/code tools still add and render as before.