### PR TITLE
[feat] All-harness self-hostable agent sidecar (Claude Code + Pi)

### DIFF
--- a/docs/design/agent-workflows/projects/sidecar-deployment-proposal/status.md
+++ b/docs/design/agent-workflows/projects/sidecar-deployment-proposal/status.md
@@ -20,6 +20,13 @@ the first-class deployable runner service reached through `AGENTA_AGENT_RUNNER_U
 - Added self-hosting docs for deploying the runner, building custom runner images, and
   using Daytona-backed sandboxes.
 - Swept active docs and deployment references for stale runner names and old env vars.
+- Added the **all-harness self-host sidecar** image recipe
+  (`services/agent/docker/Dockerfile.sidecar` + `sidecar-entrypoint.sh`): one image that
+  hosts every harness (`pi_core`, `pi_agenta`, `claude`) on `:8765` with no compose CMD
+  override — it bakes the Pi provisioning (writable `/pi-agent`) and optionally Claude Code
+  (self-host licensing boundary documented). This is the single-`docker run` self-host shape.
+  Verified in isolation: a subscription-OAuth `claude` run and a `pi_core` run both pass on a
+  test container with no `/pi-agent` EACCES. Documented in `services/agent/docker/README.md`.
 
 ## Decisions
 

--- a/docs/design/agent-workflows/projects/subscription-sidecar/README.md
+++ b/docs/design/agent-workflows/projects/subscription-sidecar/README.md
@@ -5,6 +5,13 @@ Claude Code with a **Claude subscription (OAuth)** instead of an `ANTHROPIC_API_
 own Claude login is mounted **read-only** into the container; Claude Code is installed at runtime
 and authenticates entirely off that mounted login. No API key is set anywhere.
 
+> **Productized form:** the all-harness self-host sidecar image
+> (`services/agent/docker/Dockerfile.sidecar`) bakes this provisioning — a writable
+> `/pi-agent` so Pi also works, plus the optional Claude Code install — into a single
+> `docker build` + `docker run`. This page is the manual, no-rebuild recipe; the Dockerfile
+> is its productized version. See
+> [`services/agent/docker/README.md` → The all-harness self-host sidecar](../../../../../services/agent/docker/README.md#the-all-harness-self-host-sidecar).
+
 This is a **standalone DEV/TEST target**. It is intentionally **not wired into the app**: it does
 not change the main stack, the compose files, or any app config. Its purpose is to be an easy
 target for testing **self-managed (subscription) Claude authentication** — later reachable through

--- a/services/agent/docker/Dockerfile.sidecar
+++ b/services/agent/docker/Dockerfile.sidecar
@@ -1,0 +1,132 @@
+# All-harness, self-hostable agent sidecar (Claude Code + Pi) — SELF-HOST RECIPE.
+#
+# One image that serves EVERY harness the runner supports — `pi_core`, `pi_agenta`, and
+# `claude` — on the runner port (:8765), with NO compose CMD override. It layers the Pi
+# provisioning that the dev compose CMD does inline today onto the production runner
+# image, and (optionally) bakes Claude Code for fast cold starts.
+#
+# Why this exists: the production `Dockerfile` IS the Pi-capable runner, but it relies on
+# an external orchestrator to make Pi usable. The dev compose service overrides the image
+# CMD to run as root and `mkdir -p /pi-agent` + copy the Pi login + rebuild the extension
+# before serving. A self-hoster running a bare `docker run` of that image as a non-root
+# user instead hits `EACCES: mkdir '/pi-agent/extensions'`, because the runner daemon
+# tries to lay the Agenta Pi extension into an unwritable PI_CODING_AGENT_DIR. (That is
+# exactly why `agenta-claude-sub-sidecar` — the same image, plain entrypoint, non-root,
+# no Pi prep — can host `claude` but not Pi.) This image bakes that provisioning in so a
+# single `docker build` + `docker run` hosts all three harnesses.
+#
+# ─────────────────────────────────────────────────────────────────────────────
+# LICENSING BOUNDARY — READ BEFORE BUILDING OR PUBLISHING
+# ─────────────────────────────────────────────────────────────────────────────
+# This is a build RECIPE for self-hosters, NOT an image Agenta publishes. See
+# docker/README.md ("We ship build recipes, not Claude-containing images").
+#   - Pi (@earendil-works/pi-coding-agent, MIT) is baked via the runner image. Fine.
+#   - Claude Code is proprietary (Anthropic Commercial Terms): a usage license, no
+#     redistribution right. With INSTALL_CLAUDE_CODE=true this recipe installs Claude
+#     Code FROM ANTHROPIC at build (`npm i -g @anthropic-ai/claude-code`), so the
+#     self-hoster who runs `docker build` is the one pulling it from Anthropic for their
+#     own individual use. The resulting image MUST NOT be published, pushed to a shared
+#     registry, or otherwise distributed by Agenta — that would make Agenta a Claude Code
+#     redistributor, which the Commercial Terms forbid.
+#   - Set --build-arg INSTALL_CLAUDE_CODE=false for a redistribution-safe base: it bakes
+#     NO Claude Code; the runner daemon installs it from Anthropic at runtime on the
+#     first `claude` run instead (the production path). Pi still works either way.
+#   - No credential is ever baked: no API key, no OAuth login. Auth is supplied at
+#     runtime (ANTHROPIC_API_KEY / request secrets, or the read-only ~/.claude OAuth
+#     mount documented below).
+#
+# ─────────────────────────────────────────────────────────────────────────────
+# BUILD (two steps — reuses the production runner build, does not fork it)
+# ─────────────────────────────────────────────────────────────────────────────
+#   # 1. Build the production runner image (Pi baked, extension bundled):
+#   docker build -t agenta-sandbox-agent:latest \
+#     -f services/agent/docker/Dockerfile services/agent
+#
+#   # 2. Build this all-harness sidecar on top of it:
+#   docker build -t agenta-allharness-sidecar:latest \
+#     -f services/agent/docker/Dockerfile.sidecar services/agent
+#
+#   # To reuse an already-built runner image instead of rebuilding step 1, pass e.g.
+#   #   --build-arg RUNNER_IMAGE=agenta-ee-dev-sandbox-agent:latest
+#   # To build a redistribution-safe base (no Claude Code baked):
+#   #   --build-arg INSTALL_CLAUDE_CODE=false
+#
+# ─────────────────────────────────────────────────────────────────────────────
+# RUN
+# ─────────────────────────────────────────────────────────────────────────────
+#   # Subscription OAuth (individual self-host use only):
+#   docker run -d --name agenta-allharness-sidecar \
+#     -p 127.0.0.1:8790:8765 \
+#     -v "$HOME/.claude":/home/node/.claude:ro \
+#     agenta-allharness-sidecar:latest
+#
+#   # API-key auth instead of the OAuth mount (the cloud / multi-tenant safe path):
+#   docker run -d --name agenta-allharness-sidecar \
+#     -p 127.0.0.1:8790:8765 \
+#     -e ANTHROPIC_API_KEY=sk-ant-... \
+#     agenta-allharness-sidecar:latest
+#
+#   # Optional: seed a Pi subscription login (so Pi can authenticate off your Pi OAuth):
+#   #   -v "$HOME/.pi/agent":/pi-agent-ro:ro
+#
+# Bind the host port to 127.0.0.1: /run bodies can carry resolved secrets, so the runner
+# must never be exposed off-host. Subscription OAuth is individual-use only and must never
+# serve other users (Anthropic restricts Free/Pro/Max OAuth to first-party use); cloud /
+# multi-tenant deployments must stay API-key only. Daytona is NOT used here — this sidecar
+# is local-only by design (Claude Code's IP is banned on Daytona). See docker/README.md.
+
+# The production runner image: Pi baked, extension bundled into dist/, ca-certificates /
+# git / python3 installed, USER node. Reused as-is; this image only layers provisioning on
+# top of it (it does not re-run the build).
+ARG RUNNER_IMAGE=agenta-sandbox-agent:latest
+FROM ${RUNNER_IMAGE}
+
+# Re-declare after FROM so the ARG is in scope for the RUN below.
+ARG INSTALL_CLAUDE_CODE=true
+
+# Provisioning runs as root, then we drop back to the unprivileged runtime user to serve.
+USER root
+
+# Pi provisioning. On every Pi run the runner daemon installs the Agenta Pi extension into
+# PI_CODING_AGENT_DIR (installPiExtensionLocal -> mkdir `$PI_CODING_AGENT_DIR/extensions`).
+# The dev compose CMD created /pi-agent as root before serving; here we create it at build,
+# owned by the runtime user (node), so a non-root `docker run` can write it — no compose
+# CMD override, no EACCES. The extension *bundle* is already in dist/ from the runner
+# image's `pnpm run build:extension`, so no runtime rebuild is needed (unlike dev compose,
+# whose bundle had to be rebuilt because src/ was bind-mounted over the baked dist/).
+RUN mkdir -p /pi-agent && chown -R node:node /pi-agent
+
+# Claude Code (self-host recipe; see LICENSING BOUNDARY above). Installed FROM Anthropic at
+# build only when opted in; the resulting image must not be redistributed by Agenta. When
+# false, the runner daemon installs Claude Code from Anthropic at runtime on the first
+# `claude` run (the production path), so Claude still works — just with a one-time cold
+# start. Pi is unaffected either way.
+RUN if [ "$INSTALL_CLAUDE_CODE" = "true" ]; then \
+        npm install -g @anthropic-ai/claude-code \
+        && echo "Baked Claude Code from Anthropic (self-host recipe — DO NOT redistribute this image)"; \
+    else \
+        echo "INSTALL_CLAUDE_CODE=false — Claude Code will be installed from Anthropic at runtime"; \
+    fi
+
+# Entrypoint: seed an optional read-only Pi login, ensure the agent dir, then serve.
+COPY docker/sidecar-entrypoint.sh /usr/local/bin/sidecar-entrypoint.sh
+RUN chmod +x /usr/local/bin/sidecar-entrypoint.sh
+
+# Serve on all interfaces (a co-located service container reaches it over the network),
+# point Pi at the writable agent dir created above, give Claude Code a writable HOME for
+# its OAuth login + session state, and keep the sandbox local (no Daytona).
+ENV AGENTA_AGENT_RUNNER_HOST=0.0.0.0 \
+    AGENTA_AGENT_RUNNER_PORT=8765 \
+    PI_CODING_AGENT_DIR=/pi-agent \
+    SANDBOX_AGENT_PROVIDER=local \
+    HOME=/home/node
+
+EXPOSE 8765
+
+# Drop privileges: serve as the unprivileged runtime user. Claude Code reads its OAuth
+# login from $HOME/.claude (mount ~/.claude:/home/node/.claude:ro) and writes session
+# state under the writable $HOME (/home/node).
+USER node
+
+ENTRYPOINT ["/usr/local/bin/sidecar-entrypoint.sh"]
+CMD ["node_modules/.bin/tsx", "src/server.ts"]

--- a/services/agent/docker/README.md
+++ b/services/agent/docker/README.md
@@ -6,6 +6,12 @@ Images for the agent runner (the `sandbox-agent server` runtime in
 
 - `Dockerfile.dev` — dev image. `tsx watch`, source bind-mounted, hot reload.
 - `Dockerfile` — production image. Source baked in, no watcher.
+- `Dockerfile.sidecar` — **all-harness, self-host sidecar recipe.** Builds on the
+  production image and bakes the Pi provisioning the dev compose CMD does inline today,
+  so a single `docker run` (no compose CMD override) hosts every harness — `pi_core`,
+  `pi_agenta`, and `claude`. Optionally bakes Claude Code from Anthropic for fast cold
+  starts. See [The all-harness self-host sidecar](#the-all-harness-self-host-sidecar)
+  below. `sidecar-entrypoint.sh` is its entrypoint.
 
 ## Licensing posture (read before changing any image or build recipe)
 
@@ -64,3 +70,81 @@ We never bake an OAuth login or an API key into an image.
 - **Self-host (API key, OAuth optional).** Build the production `Dockerfile` (it
   bakes neither Claude nor a credential), then supply auth at runtime: an
   `ANTHROPIC_API_KEY` env var, or, for individual use, a mounted OAuth login dir.
+
+## The all-harness self-host sidecar
+
+`Dockerfile.sidecar` is the **self-host shape**: one image that serves every harness
+(`pi_core`, `pi_agenta`, `claude`) on `:8765` with no compose CMD override. It exists
+because the production `Dockerfile` is the Pi-capable runner but relies on an external
+orchestrator to make Pi usable. The dev compose service overrides the image CMD to run as
+root, `mkdir -p /pi-agent`, copy the Pi login, and rebuild the extension before serving. A
+self-hoster running a bare `docker run` of that image as a non-root user instead hits
+`EACCES: mkdir '/pi-agent/extensions'`, because the runner daemon tries to lay the Agenta
+Pi extension into an unwritable `PI_CODING_AGENT_DIR`. (That is exactly why
+`agenta-claude-sub-sidecar` — the same image with a plain entrypoint, non-root, no Pi prep
+— can host `claude` but not Pi.)
+
+`Dockerfile.sidecar` bakes that provisioning in:
+
+- creates `/pi-agent` at build owned by the runtime user (`node`), so a non-root run can
+  write it — no compose CMD, no `EACCES`. `PI_CODING_AGENT_DIR=/pi-agent` is set;
+- `sidecar-entrypoint.sh` ensures the dir and, if `~/.pi/agent` is mounted read-only at
+  `/pi-agent-ro`, copies it in (the same Pi-login seed the compose CMD does);
+- the Agenta Pi extension bundle is already in `dist/` from the runner image's
+  `pnpm run build:extension`, so there is no runtime rebuild;
+- sets a writable `HOME=/home/node` and serves on `0.0.0.0:8765`.
+
+### Licensing boundary (same rule as above)
+
+This is a build **recipe**, not an image Agenta publishes. With the default
+`INSTALL_CLAUDE_CODE=true` it installs Claude Code **from Anthropic** at build, so the
+self-hoster who runs `docker build` is the one pulling it for their own individual use.
+**The resulting image must not be published, pushed to a shared registry, or distributed by
+Agenta** — that would make Agenta a Claude Code redistributor, which the Commercial Terms
+forbid. Build with `--build-arg INSTALL_CLAUDE_CODE=false` for a redistribution-safe base
+that bakes no Claude Code and installs it from Anthropic at runtime instead (Pi works either
+way). No credential is ever baked.
+
+### Build (reuses the production build, two steps)
+
+```bash
+# 1. Production runner image (Pi baked, extension bundled):
+docker build -t agenta-sandbox-agent:latest \
+  -f services/agent/docker/Dockerfile services/agent
+
+# 2. All-harness sidecar on top of it:
+docker build -t agenta-allharness-sidecar:latest \
+  -f services/agent/docker/Dockerfile.sidecar services/agent
+```
+
+Reuse an already-built runner image with `--build-arg RUNNER_IMAGE=<image>` instead of
+rebuilding step 1.
+
+### Run
+
+```bash
+# Subscription OAuth (individual self-host use only): mount the host Claude login read-only.
+docker run -d --name agenta-allharness-sidecar \
+  -p 127.0.0.1:8790:8765 \
+  -v "$HOME/.claude":/home/node/.claude:ro \
+  agenta-allharness-sidecar:latest
+
+# Or API-key auth (the cloud / multi-tenant safe path):
+docker run -d --name agenta-allharness-sidecar \
+  -p 127.0.0.1:8790:8765 \
+  -e ANTHROPIC_API_KEY=sk-ant-... \
+  agenta-allharness-sidecar:latest
+```
+
+Bind the host port to `127.0.0.1`: `/run` bodies can carry resolved secrets, so the runner
+must never be exposed off-host. Subscription OAuth is individual-use only and must never
+serve other users; cloud / multi-tenant deployments must stay API-key only. The runtime
+user is `node` (uid 1000), so on a host whose uid is not 1000 the read-only `~/.claude`
+mount may be unreadable — either run on a uid-1000 host or mount a writable copy of
+`~/.claude`. Daytona is **not** used here — this sidecar is local-only by design (Claude
+Code's IP is banned on Daytona).
+
+The manual, no-rebuild version of this (mount the existing runner image's source and run as
+the host user) is documented in
+`docs/design/agent-workflows/projects/subscription-sidecar/README.md`; this Dockerfile is
+its productized, single-`docker run` form.

--- a/services/agent/docker/sidecar-entrypoint.sh
+++ b/services/agent/docker/sidecar-entrypoint.sh
@@ -1,0 +1,32 @@
+#!/bin/sh
+# Entrypoint for the all-harness self-host sidecar (services/agent/docker/Dockerfile.sidecar).
+#
+# Reproduces the Pi provisioning the dev compose CMD does inline, but baked into the image
+# so no compose CMD override is needed:
+#   - ensure PI_CODING_AGENT_DIR exists and is writable (the image pre-creates /pi-agent
+#     owned by the runtime user; this is the idempotent belt-and-suspenders that also
+#     covers a custom PI_CODING_AGENT_DIR),
+#   - optionally seed a Pi login mounted read-only at /pi-agent-ro into it, exactly like
+#     the compose `cp -a /pi-agent-ro/.` (so Pi subscription auth + sessions stay writable
+#     in-container rather than failing against a read-only mount),
+#   - then exec the server (the image CMD).
+#
+# The Agenta Pi extension bundle is already built into dist/ at image build
+# (`pnpm run build:extension` in the runner image), so — unlike the dev compose CMD —
+# there is no runtime rebuild: the baked bundle matches the baked src.
+set -eu
+
+PI_DIR="${PI_CODING_AGENT_DIR:-/pi-agent}"
+
+# Idempotent: /pi-agent is pre-created and owned by the runtime user at image build. This
+# only matters if PI_CODING_AGENT_DIR was overridden to a fresh, writable path.
+mkdir -p "$PI_DIR" 2>/dev/null || true
+
+# Optional Pi login seed. A read-only mount of a host Pi agent dir (~/.pi/agent) at
+# /pi-agent-ro is copied into the writable PI_CODING_AGENT_DIR so Pi can both read its
+# login and write its extensions/sessions. Best-effort: API-key Pi runs need no login.
+if [ -d /pi-agent-ro ]; then
+    cp -a /pi-agent-ro/. "$PI_DIR"/ 2>/dev/null || true
+fi
+
+exec "$@"


### PR DESCRIPTION
## Context

We run a second agent-runner sidecar (`agenta-claude-sub-sidecar`) that authenticates Claude Code with a **subscription OAuth** (a read-only `~/.claude` mount) instead of an API key. It is the *same* runner image as the main `sandbox-agent`, but started with the plain default entrypoint, as a non-root user, with no Pi provisioning. The result: it can host `claude`, but every Pi run crashes with `EACCES: mkdir '/pi-agent/extensions'`.

Why: the main runner only hosts Pi because the **dev compose service overrides the image CMD** — it runs as root, does `mkdir -p /pi-agent` + copies the Pi login + rebuilds the extension, then serves. A bare `docker run` of that image as a non-root user has no writable `PI_CODING_AGENT_DIR`, so the runner daemon cannot lay the Agenta Pi extension and fails. There was no single image a self-hoster could `docker build` + `docker run` that serves *every* harness.

This PR adds that image: a self-host recipe that bakes the Pi provisioning into the image (no compose CMD), keeps the `~/.claude` OAuth mount working, and serves all three harnesses (`pi_core`, `pi_agenta`, `claude`).

## What changed

- **`services/agent/docker/Dockerfile.sidecar`** (new) — `FROM` the production runner image (reuses that build, does not fork it). As root it creates `/pi-agent` owned by the runtime user (`node`) and, behind `ARG INSTALL_CLAUDE_CODE=true`, installs Claude Code **from Anthropic**; then sets `PI_CODING_AGENT_DIR=/pi-agent`, a writable `HOME=/home/node`, `AGENTA_AGENT_RUNNER_HOST=0.0.0.0`, `SANDBOX_AGENT_PROVIDER=local`, drops to `USER node`, and serves.
- **`services/agent/docker/sidecar-entrypoint.sh`** (new) — ensures `PI_CODING_AGENT_DIR` and seeds an optional read-only Pi login mounted at `/pi-agent-ro` (the same `cp -a /pi-agent-ro/.` the compose CMD does), then execs the server. The Pi extension bundle is already in `dist/` from the runner image's `build:extension`, so there is no runtime rebuild.
- **Docs** — `services/agent/docker/README.md` gains an "all-harness self-host sidecar" section (build + run + licensing boundary); the `subscription-sidecar` project README cross-links it as the productized form; the `sidecar-deployment-proposal` status logs it.

### Provisioning vs the old compose CMD

| Compose CMD (runtime, root) | This image (baked) |
| --- | --- |
| `mkdir -p /pi-agent` as root | `/pi-agent` created at build, owned by `node` (works non-root, no `EACCES`) |
| `cp -a /pi-agent-ro/.` (Pi login seed) | entrypoint copies `/pi-agent-ro` if mounted |
| `node scripts/build-extension.mjs` (rebuild, src bind-mounted) | bundle already baked in `dist/` (src is baked, no rebuild) |
| `exec tsx src/server.ts` | `ENTRYPOINT` + `CMD` serve as `node` |

## Scope / risk

- **Additive.** New files only (one Dockerfile, one entrypoint, doc edits). The existing `services/agent/docker/Dockerfile` and `Dockerfile.dev`, the compose stack, and the live `agenta-claude-sub-sidecar` are untouched. Nothing wires this image into the app.
- **Licensing boundary (the thing to review).** This is a build **recipe**, not an image Agenta publishes. With the default `INSTALL_CLAUDE_CODE=true` it installs Claude Code from Anthropic at build, so the self-hoster who runs `docker build` is the one pulling it for their own individual use. The resulting image **must not be published/distributed by Agenta** — that would make Agenta a Claude Code redistributor, which Anthropic's Commercial Terms forbid. `--build-arg INSTALL_CLAUDE_CODE=false` gives a redistribution-safe base that installs Claude at runtime instead. No credential is ever baked.
- **Local-only by design.** No Daytona (Claude Code's IP is banned on Daytona). Subscription OAuth is individual-use only and must never serve other users; cloud/multi-tenant must stay API-key only. Host port bound to `127.0.0.1` (the runner trusts its caller with resolved secrets).
- **uid caveat:** the runtime user is `node` (uid 1000); on a host whose uid is not 1000 the read-only `~/.claude` mount may be unreadable — documented.

## How to QA

Prerequisites: Docker; a Claude subscription OAuth at `~/.claude/.credentials.json` (token prefix `sk-ant-oat01-`) on a uid-1000 host, OR an `ANTHROPIC_API_KEY`.

1. Build the base runner image, then the sidecar:
   ```bash
   docker build -t agenta-sandbox-agent:latest -f services/agent/docker/Dockerfile services/agent
   docker build -t agenta-allharness-sidecar:test -f services/agent/docker/Dockerfile.sidecar services/agent
   ```
2. Run an isolated test container (distinct name + loopback port, does not touch any live sidecar):
   ```bash
   docker run -d --name allharness-test -p 127.0.0.1:8791:8765 \
     -v "$HOME/.claude":/home/node/.claude:ro agenta-allharness-sidecar:test
   curl -s http://127.0.0.1:8791/health
   ```
   Expected: `{"status":"ok",...,"harnesses":["pi_core","claude","pi_agenta"]}`.
3. Claude via subscription OAuth (no API key):
   ```bash
   curl -s -X POST http://127.0.0.1:8791/run -H 'content-type: application/json' \
     -d '{"harness":"claude","sandbox":"local","model":"haiku","credentialMode":"runtime_provided",
          "messages":[{"role":"user","content":"Reply with exactly: hi. Nothing else."}]}'
   ```
   Expected: `{"ok":true,...}`.
4. Pi (key via resolved secrets), and confirm no `EACCES`:
   ```bash
   curl -s -X POST http://127.0.0.1:8791/run -H 'content-type: application/json' \
     -d '{"harness":"pi_core","sandbox":"local","model":"claude-haiku-4-5","provider":"anthropic",
          "credentialMode":"env","secrets":{"ANTHROPIC_API_KEY":"sk-ant-..."},
          "messages":[{"role":"user","content":"Reply with exactly: hi from pi. Nothing else."}]}'
   docker exec allharness-test ls -la /pi-agent/extensions   # agenta.js present, no EACCES
   ```
   Expected: `{"ok":true,"output":"hi from pi",...}`.
5. Clean up: `docker rm -f allharness-test && docker rmi agenta-allharness-sidecar:test`.

Edge cases worth a look: `--build-arg INSTALL_CLAUDE_CODE=false` (Claude installs at runtime on first run, ~10s); seeding a Pi login via `-v "$HOME/.pi/agent":/pi-agent-ro:ro`.

### Verified in isolation (this PR)

Built both images, ran a test container on `:8791` with the `~/.claude` mount (the live `:8790` sidecar and the `:8280` stack untouched). Both harnesses passed: a `claude`+`haiku` subscription-OAuth run returned `ok:true` in ~4.3s (no install delay -> baked Claude Code used), and a `pi_core`+`claude-haiku-4-5` run returned `ok:true` with **no `/pi-agent` EACCES** and `/pi-agent/extensions/agenta.js` installed. Test container and images removed afterward.

https://claude.ai/code/session_01GYo3UEfvsZpncagqb28Mbc
