### PR TITLE
docs(agent): direct-call tools design (Workstream A)

### DIFF
--- a/docs/design/agent-workflows/projects/direct-call-tools/README.md
+++ b/docs/design/agent-workflows/projects/direct-call-tools/README.md
@@ -1,0 +1,23 @@
+# Direct-call tools (Workstream A)
+
+Make resolved agent tools carry their own call target, so the sidecar calls reference and
+platform tools directly and only gateway (Composio) tools route through the central
+`/tools/call`.
+
+## Files in this workspace
+
+- **`plan.md`** — the hand-off and the two-workstream split (A here, B on PRs #4860/#4877),
+  plus the Workstream A execution phases. This is the file the orchestrator was pointed at.
+- **`context.md`** — why this exists: the conversation, the decision, goals and non-goals.
+- **`research.md`** — the actual code seams with file:line, and the nuances that shape the
+  design (reference still needs the API; the args-placement wrinkle; the schema catalog).
+- **`design.md`** — the technical design: the `call` descriptor, the dispatch algorithm, the
+  per-tool-type table (config → resolved → dispatch), the platform-op catalog.
+- **`status.md`** — current state, what Workstream B is doing concurrently, open decisions,
+  next step. Source of truth for progress.
+
+## One-line state
+
+Planning. No code yet. Workstream B is active in parallel on the reference tool (PRs #4860 /
+#4877); the shared file `sdks/python/agenta/sdk/agents/tools/models.py` must be serialized.
+See `status.md`.

--- a/docs/design/agent-workflows/projects/direct-call-tools/context.md
+++ b/docs/design/agent-workflows/projects/direct-call-tools/context.md
@@ -1,0 +1,52 @@
+# Context
+
+## Where this came from
+
+In a design conversation, Mahmoud pushed on how agent tool calls route. Today every resolved
+callback tool POSTs to one endpoint, `/tools/call`, which re-parses a string `call_ref` and
+re-dispatches: `workflow.*` runs a referenced workflow, `tools.*` runs a Composio action. His
+objection, first raised as an inline comment on PR #4863 (`custom-tools-design.md` line 67):
+the proposed platform tools (create_workflow, annotate, ...) would have `/tools/call` make HTTP
+calls to other Agenta API endpoints. Calls between two API endpoints with no value. Those
+should be direct service calls.
+
+Generalized: a tool that points at another Agenta workflow ("reference") or runs an Agenta
+operation ("platform") is just an Agenta endpoint, and the sidecar already holds the caller's
+credential. So the `/tools/call` hop adds a step and no value for those two. Only gateway
+(Composio) tools need the server, because only the server can read the Composio secret from the
+vault.
+
+## The decision
+
+1. Resolved tools carry their own call target. The sidecar calls reference and platform tools
+   directly; gateway stays server-side through `/tools/call`.
+2. Drop the `@ag.reference` marker. A reference tool is just `type:"reference"` in the config
+   `tools` list. (This is Workstream B, on the existing reference PRs.)
+3. Keep `@ag.embed` (it inlines a value, a different feature). Hide it from the tool UI for now.
+4. A reference can point at an environment or a variant, each at latest or a pinned revision.
+   (Schema is Workstream B; resolution is Workstream A.)
+
+## Goals
+
+- Kill the endpoint-to-endpoint pattern for platform tools: they run as in-process service
+  calls behind one direct endpoint each, never `/tools/call` re-hitting `/api/...`.
+- Give the SDK the routing decision (each tool resolves to a concrete call target), and shrink
+  `/tools/call` to the gateway-only executor.
+- Keep the sidecar dumb and the Daytona sandbox unchanged (still name + args; the host runner
+  makes the direct call).
+- Keep one credential (the run's caller auth) and never let the model retarget a locked call.
+
+## Non-goals
+
+- Letting tools call non-Agenta hosts. Paths are relative; the sidecar joins its own Agenta
+  base. Off-Agenta targets are a deliberate later decision.
+- Changing gateway (Composio) execution. It keeps its server-side path.
+- Streaming a sub-agent's tokens into the parent model. A reference runs in batch; the model
+  gets the final output; the user sees the nested run through the trace.
+- Re-implementing the reference config schema (Workstream B owns it). A reuses it.
+
+## Why now
+
+The reference tool is already in review (PR #4860) with a frontend stacked on it (#4877). The
+custom-tools design note (#4863) is waiting on the execution model. Settling the routing now
+lets both land on the right shape instead of on `/tools/call` string-routing.

--- a/docs/design/agent-workflows/projects/direct-call-tools/context.md
+++ b/docs/design/agent-workflows/projects/direct-call-tools/context.md
@@ -50,3 +50,11 @@ vault.
 The reference tool is already in review (PR #4860) with a frontend stacked on it (#4877). The
 custom-tools design note (#4863) is waiting on the execution model. Settling the routing now
 lets both land on the right shape instead of on `/tools/call` string-routing.
+
+## Merge, review, and ownership
+
+Mahmoud reviewed this design and is aligned with all the decisions. His one standing requirement
+is the ability to review before anything merges. Merge order, commit organization, and how the
+work is split across PRs are the orchestrator's call, not design decisions captured here. So the
+"sequencing notes" in `plan.md` and `status.md` are guidance for the orchestrator, not approvals
+Mahmoud owes.

--- a/docs/design/agent-workflows/projects/direct-call-tools/design.md
+++ b/docs/design/agent-workflows/projects/direct-call-tools/design.md
@@ -11,7 +11,7 @@ endpoint directly. When absent, it falls back to the shared `/tools/call` (gatew
 ```
 call: {
   method: "POST" | "GET",
-  path: string,            // RELATIVE to the Agenta base, e.g. "/api/annotations/"
+  path: string,            // absolute path from the Agenta origin, e.g. "/api/annotations/"
   body?: object,           // server-fixed fields, baked at resolve time
   args_into?: string,      // dotted path where the model's args are placed; absent = root
 }
@@ -50,7 +50,7 @@ Rules the sidecar applies:
 | Stage | Shape |
 |---|---|
 | config | `{ type:"reference", ref_by:"variant"|"environment", slug, version?, name?, description?, input_schema? }` (Workstream B) |
-| resolved | `CallbackToolSpec` with `call`, no `callRef`. `input_schema` = the workflow's inputs. |
+| resolved | `CallbackToolSpec` with `call`, no `callRef`. `input_schema` = the referenced workflow's input contract (`revision.schemas.inputs`, read at resolve time). |
 | dispatch | sidecar → direct POST to the invoke endpoint; the revision is resolved by the service at resolve time and baked into `call.body` |
 
 Resolved example:
@@ -73,6 +73,23 @@ directly. The invoke endpoint loads and runs `rev_abc123` in **batch** and retur
 result is the sub-workflow's `data.outputs` plus `trace_id`. The sub-run nests in the trace; the
 model gets the final output.
 
+**Where the input schema comes from.** The reference tool's `input_schema` is the referenced
+workflow's own input contract, which the service reads at resolve time from the workflow's
+`/inspect` response (`revision.schemas.inputs`). For a chat workflow that contract carries
+`messages` (referenced via `x-ag-type-ref: "messages"`, the shared `Messages` type served at
+`/workflows/catalog/types`) plus any template input variables; for a prompt workflow it is the
+template variables. The model therefore sees exactly the inputs the workflow expects, with no
+hand-authored schema, and the runner places its args at `data.inputs` (`args_into`), where the
+invoke reads `messages` from `inputs.messages`.
+
+**Output schemas: deferred.** The referenced workflow also publishes an output contract
+(`revision.schemas.outputs`), and an output schema exists in a few places (MCP's optional
+`outputSchema`, Agenta's AI-services `ToolDefinition`). But the tool definitions the model
+actually sees — OpenAI/Anthropic function calling and the Pi/Claude/MCP registrations — are
+input-schema only; the model gets the tool's output as result text, not validated against a
+declared schema. So we put no tool `output_schema` on the wire now. The workflow's
+`schemas.outputs` stays available for a later structured-output pass; noted, not a Phase-1 item.
+
 Resolution detail (`ref_by` → references key): `variant` → `workflow_variant`, `environment` →
 `environment`; absent `version` = latest of that variant/environment, set = that revision. The
 service resolves this to a `workflow_revision` id up front, always, including for `environment`
@@ -83,7 +100,7 @@ only if a long-lived sidecar ever calls itself with no service in front.)
 The win over today: no call-time resolution detour and no `/tools/call` string-routing. The
 service already does the resolve-time API work for gateway/embed/secrets, so a reference is one
 more thing it resolves there. Removing the `workflow.*` branch from `/tools/call` is coupled to
-this and is an open decision (see `status.md`).
+this; when exactly it lands is the orchestrator's sequencing call (see `status.md`).
 
 ### Platform (an Agenta operation)
 
@@ -118,24 +135,53 @@ in-process service work. No `/tools/call`, and no endpoint calling another endpo
 
 `code` runs in the sandbox subprocess; `client` is browser-fulfilled. Neither uses `call`.
 
+## Permissions and approval (uniform across all tool types)
+
+Permission and approval are not part of the `call` path and are not special-cased per executor.
+Every tool type (gateway, reference, platform, code, client) carries `needs_approval` /
+`permission` on the shared `ToolSpecBase`, and the runner resolves the effective decision with the
+same `effective_permission()` precedence and enforces it BEFORE the call, regardless of where the
+call goes. Going direct changes the transport, not the gate, so HITL still works for direct tools.
+
+A later PR will refactor tool config into a typed shape (a `type` plus a per-type config block,
+including a dedicated permissions block) instead of today's flat fields. That hierarchy is out of
+scope here. The requirement this design holds is narrower: permission handling stays consistent
+across all tool types, so the refactor can lift it uniformly later.
+
 ## The platform-op catalog
 
-Mirror `platform_catalog.py`. A server-side `_PLATFORM_TOOLS` table keyed by `op`:
+Mirror the pattern Agenta already uses for a reserved, code-defined tool:
+`tools.agenta.find_capabilities` (PR #4884, `api/oss/src/core/tools/discovery.py`) — a reserved
+`tools.agenta.*` op with a `description` and an `input_schema`, backed by an endpoint
+(`POST /tools/discover`). The platform-op catalog generalizes that one reserved tool into a small
+code-defined table, shaped like the evaluators catalog (`resources/evaluators/evaluators.py`: a
+module-level list of `{key, description, settings_template, ...}` entries):
 
 ```
-op -> { method, path, input_schema_ref, default_permission, default_needs_approval }
+op -> { description, method, path, input_schema (or x-ag-type-ref), default_permission, default_needs_approval }
 ```
 
-- **Descriptions live in the SDK** (per Mahmoud), next to the op→endpoint table the resolver
-  uses. The author writes only `{ type:"platform", op }`.
-- **Input schemas come from the in-process schema catalog** (the `CATALOG_TYPES` /
-  `/workflows/catalog/types` mechanism, built from `model_json_schema()`), fetched at resolve
-  time. Not parsed from `/openapi.json`.
+- **Descriptions live in the SDK** (per Mahmoud), next to the op→endpoint table the resolver uses.
+  The author writes only `{ type:"platform", op }`.
+- **Input schemas reuse the in-process schema catalog** (the `CATALOG_TYPES` mechanism, built from
+  `model_json_schema()` and served at `/workflows/catalog/types`), referenced via `x-ag-type-ref`
+  — the same mechanism the agent `/inspect` schema already uses for `messages`. Not parsed from
+  `/openapi.json`.
 - Each op carries a sensible default permission; `needs_approval` / `permission` on the config
-  override per the existing `effective_permission()` precedence.
+  override per `effective_permission()` (see the permissions section above).
 
-`create_workflow` today is three calls (artifact, variant, revision). Add one convenience
-endpoint so the platform tool is a single direct call, atomic, with its own permission check.
+**`find_capabilities` is the first platform tool.** PR #4884 already built the server side
+(`POST /tools/discover` + the reserved op); Workstream A adds the SDK emission of it as a
+`CallbackToolSpec` with a `call` — exactly the general platform-tool path here. (STATUS.md tracks
+that emission as deferred-into-A.)
+
+Not `platform_catalog.py` wholesale: that catalog (reserved `_agenta.*` workflow slugs, versioned,
+deterministic UUIDs, a virtual revision provider) is current and correct for platform
+**workflows/skills**, but heavier than platform ops need. Mirror its "code-defined,
+reserved-namespace, validated-at-import" spirit, not its versioned-revision machinery.
+
+`create_workflow` today is three calls (artifact, variant, revision). Add one convenience endpoint
+so the platform tool is a single direct call, atomic, with its own permission check.
 
 ## Sidecar dispatch algorithm
 

--- a/docs/design/agent-workflows/projects/direct-call-tools/design.md
+++ b/docs/design/agent-workflows/projects/direct-call-tools/design.md
@@ -79,8 +79,8 @@ Resolved (Codex binding review):
   entries), and verify the stripped schema still satisfies the endpoint's real required contract
   (do not drop a field the endpoint needs that the model should still provide).
 - **`runContext` is its own field on the `/run` contract** (explicit run metadata, NOT inside
-  `TraceContext`), with the MCP-resource / context-file fallback for local backends that cannot
-  read it (see `run-context.md`).
+  `TraceContext`), refreshed per turn. It is consumed only by `bind`; the model does not read it
+  directly (see `run-context.md`).
 - **Merge hardening** as in the body-assembly rule above (path-conflict rejection, strict path
   parsing, prototype-pollution-safe deep-set, post-merge validation).
 
@@ -222,20 +222,19 @@ across all tool types, so the refactor can lift it uniformly later.
 ## Run context
 
 Some tools need the run's own context (the current trace, the running workflow/variant + draft
-state + latest revision, the session_id). The resolved direction (Codex rev-2):
+state + latest revision, the session_id). The decision:
 
-- Run context rides the **run contract** as a run-level `runContext` payload on `/run` — data, not
-  a callable tool, and not modeled as a `get_context` primitive.
-- **Protected self-identity** (the agent's own variant / trace) is **bound server-side** into the
-  `call.body` of self-targeting tools and hidden from the model, so the model cannot retarget
-  within the project. Endpoints also harden (revision-precondition on commit).
-- **Non-authority context the model needs to read** is delivered as an **MCP resource** (primary)
-  with a **context-file fallback** for harnesses without resource support.
-- **Refresh per turn** — `latest_revision` changes after a commit, so a once-at-start snapshot
-  goes stale.
+- Run context rides the **run/session** as a `runContext` payload on `/run`, **refreshed per
+  turn** — data, not a callable tool.
+- It is consumed **only by `bind`**: a tool definition binds a run-context value into a request
+  field, and the runner fills it server-side at dispatch, hidden from the model (see "Context
+  binding"). Self-targeting tools (own variant / own trace) bind their identity this way, so the
+  model supplies only the payload and cannot retarget within the project. Endpoints also harden
+  (revision-precondition on commit).
+- The model does **not** read run context directly — no MCP resource, no `get_context` tool, no
+  context file, no prompt injection. Those were considered and dropped.
 
-Full options, tradeoffs, and the one open decision (server-bind self-identity vs "own is
-convention"): `run-context.md`.
+The decision and the dropped options: `run-context.md`.
 
 ## The platform-op catalog
 

--- a/docs/design/agent-workflows/projects/direct-call-tools/design.md
+++ b/docs/design/agent-workflows/projects/direct-call-tools/design.md
@@ -25,6 +25,10 @@ Rules the sidecar applies:
   non-Agenta host. A run carrying any direct tool therefore also carries a `toolCallback` (it
   does whenever any callback tool is present). All direct targets, platform ops and the
   reference invoke, live under that one origin.
+- **Guardrail — the `call` is untrusted input.** The runner validates `method` against an
+  allowlist (`GET`/`POST`), `path` against a relative-path regex with an `/api/...` prefix, and
+  binds the origin as above. The sidecar is a constrained dispatcher, never an arbitrary HTTP
+  client, so the `call` descriptor adds no SSRF surface. (Per the Codex review.)
 - Auth is the run's single `toolCallback.authorization` (the caller credential), reused for
   every direct call. No per-tool auth.
 - Body assembly:
@@ -147,6 +151,15 @@ A later PR will refactor tool config into a typed shape (a `type` plus a per-typ
 including a dedicated permissions block) instead of today's flat fields. That hierarchy is out of
 scope here. The requirement this design holds is narrower: permission handling stays consistent
 across all tool types, so the refactor can lift it uniformly later.
+
+## Run context
+
+Some tools need the run's own context (the current trace, the running workflow/variant + draft
+state + latest revision, the session_id). The resolved direction (Codex-reviewed): run context
+rides the **run contract** as a run-level `runContext` payload on `/run`, and the runner/SDK
+**binds the protected fields server-side** into the call so the model cannot override them;
+endpoints also harden (own-variant + revision-precondition checks). It is NOT modeled as a tool
+argument or a static tool. Full options, tradeoffs, and the open A-vs-C decision: `run-context.md`.
 
 ## The platform-op catalog
 

--- a/docs/design/agent-workflows/projects/direct-call-tools/design.md
+++ b/docs/design/agent-workflows/projects/direct-call-tools/design.md
@@ -1,0 +1,162 @@
+# Design — direct-call tools
+
+The shape at each of the three stages (config, resolved spec, sidecar dispatch) for each tool
+type, then the platform-op catalog and the reference resolution.
+
+## The `call` descriptor (the one new field)
+
+A resolved callback tool gains an optional `call`. When present, the sidecar calls that
+endpoint directly. When absent, it falls back to the shared `/tools/call` (gateway).
+
+```
+call: {
+  method: "POST" | "GET",
+  path: string,            // RELATIVE to the Agenta base, e.g. "/api/annotations/"
+  body?: object,           // server-fixed fields, baked at resolve time
+  args_into?: string,      // dotted path where the model's args are placed; absent = root
+}
+```
+
+Rules the sidecar applies:
+
+- `path` is an absolute path from the Agenta ORIGIN, and the runner derives that origin from the
+  run's `toolCallback.endpoint` (the same Agenta the gateway callback uses; the origin is the
+  scheme/host/port of that URL). The resolver never emits a host, so a tool can never reach a
+  non-Agenta host. A run carrying any direct tool therefore also carries a `toolCallback` (it
+  does whenever any callback tool is present). All direct targets, platform ops and the
+  reference invoke, live under that one origin.
+- Auth is the run's single `toolCallback.authorization` (the caller credential), reused for
+  every direct call. No per-tool auth.
+- Body assembly:
+  - If `args_into` is set: deep-clone `body`, set the `args_into` path to the model's args,
+    POST it. (Reference: `args_into = "data.inputs"`.)
+  - Else: `POST { ...modelArgs, ...body }` so **fixed fields win**. This is what stops the
+    model from overriding a locked field (e.g. `update_own_workflow`'s owning variant id).
+
+`callRef` stays for gateway. A spec has either `call` (direct) or `callRef` (gateway), not both.
+
+## Per-tool-type table
+
+### Gateway (Composio) — unchanged
+
+| Stage | Shape |
+|---|---|
+| config | `{ type:"gateway", provider:"composio", integration, action, connection }` |
+| resolved | `CallbackToolSpec` with `callRef:"tools.composio...."`, no `call` |
+| dispatch | sidecar → shared `/tools/call` (server reads the Composio secret) |
+
+### Reference (a stored workflow as a tool)
+
+| Stage | Shape |
+|---|---|
+| config | `{ type:"reference", ref_by:"variant"|"environment", slug, version?, name?, description?, input_schema? }` (Workstream B) |
+| resolved | `CallbackToolSpec` with `call`, no `callRef`. `input_schema` = the workflow's inputs. |
+| dispatch | sidecar → direct POST to the invoke endpoint; the revision is resolved by the service at resolve time and baked into `call.body` |
+
+Resolved example:
+
+```json
+{ "name": "get_weather", "description": "Look up weather for a city",
+  "inputSchema": { "type":"object", "properties": { "city": {"type":"string"} } },
+  "call": {
+    "method": "POST",
+    "path": "/api/workflows/invoke",
+    "body": { "references": { "workflow_revision": { "id": "rev_abc123" } } },
+    "args_into": "data.inputs"
+  } }
+```
+
+The service resolved `ref_by:"variant", slug:"weather-agent", version:"3"` to the concrete
+revision `rev_abc123` at resolve time and baked it into `call.body`. At call time the model
+supplies `{ "city": "Paris" }`; the sidecar sets `body.data.inputs = {city:"Paris"}` and POSTs
+directly. The invoke endpoint loads and runs `rev_abc123` in **batch** and returns. The tool
+result is the sub-workflow's `data.outputs` plus `trace_id`. The sub-run nests in the trace; the
+model gets the final output.
+
+Resolution detail (`ref_by` → references key): `variant` → `workflow_variant`, `environment` →
+`environment`; absent `version` = latest of that variant/environment, set = that revision. The
+service resolves this to a `workflow_revision` id up front, always, including for `environment`
+references. The sidecar is always invoked fresh by the service, so the service re-resolves on
+each invoke and the baked revision stays current; there is no call-time env resolution. (Revisit
+only if a long-lived sidecar ever calls itself with no service in front.)
+
+The win over today: no call-time resolution detour and no `/tools/call` string-routing. The
+service already does the resolve-time API work for gateway/embed/secrets, so a reference is one
+more thing it resolves there. Removing the `workflow.*` branch from `/tools/call` is coupled to
+this and is an open decision (see `status.md`).
+
+### Platform (an Agenta operation)
+
+| Stage | Shape |
+|---|---|
+| config | `{ type:"platform", op:"create_workflow", needs_approval?, permission? }` |
+| resolved | `CallbackToolSpec` with `call`; `description` from the SDK catalog; `input_schema` fetched from the schema catalog at resolve time |
+| dispatch | sidecar → direct POST to that op's endpoint (a plain authenticated endpoint that does in-process service work) |
+
+Resolved examples:
+
+```json
+{ "name": "add_trace_annotation", "description": "Record a finding on a trace",
+  "inputSchema": { "...from catalog..." },
+  "call": { "method":"POST", "path":"/api/annotations/" } }
+```
+
+```json
+{ "name": "update_own_workflow", "description": "Commit a new revision to your own workflow",
+  "inputSchema": { "type":"object", "properties": { "agent_config":{}, "message":{} } },
+  "call": { "method":"POST", "path":"/api/workflows/revisions/commit",
+            "body": { "workflow_variant_id": "<the running agent's own variant>" } } }
+```
+
+For platform tools `args_into` is usually absent (the args are the body). The owning variant id
+is server-fixed in `body`, so the model cannot retarget another agent.
+
+This is the line-67 fix: each platform op is one direct call to an endpoint that does its own
+in-process service work. No `/tools/call`, and no endpoint calling another endpoint.
+
+### Code / client — unchanged
+
+`code` runs in the sandbox subprocess; `client` is browser-fulfilled. Neither uses `call`.
+
+## The platform-op catalog
+
+Mirror `platform_catalog.py`. A server-side `_PLATFORM_TOOLS` table keyed by `op`:
+
+```
+op -> { method, path, input_schema_ref, default_permission, default_needs_approval }
+```
+
+- **Descriptions live in the SDK** (per Mahmoud), next to the op→endpoint table the resolver
+  uses. The author writes only `{ type:"platform", op }`.
+- **Input schemas come from the in-process schema catalog** (the `CATALOG_TYPES` /
+  `/workflows/catalog/types` mechanism, built from `model_json_schema()`), fetched at resolve
+  time. Not parsed from `/openapi.json`.
+- Each op carries a sensible default permission; `needs_approval` / `permission` on the config
+  override per the existing `effective_permission()` precedence.
+
+`create_workflow` today is three calls (artifact, variant, revision). Add one convenience
+endpoint so the platform tool is a single direct call, atomic, with its own permission check.
+
+## Sidecar dispatch algorithm
+
+```ts
+// services/agent/src/tools/dispatch.ts, callback branch:
+if (spec.call) {
+  const body = assembleBody(spec.call, params);   // args_into deep-set, else fixed-wins merge
+  const url = joinBase(runnerAgentaBase, spec.call.path);   // relative path only
+  return callDirect(spec.call.method, url, opts.authorization, body, opts.signal);
+}
+if (opts.relayDir) return relayToolCall(...);     // gateway on Daytona
+return callAgentaTool(opts.endpoint, opts.authorization, spec.callRef, ...);  // gateway
+```
+
+Daytona: the same `if (spec.call)` branch lives in the host-side relay handler
+(`relay.ts executeRelayedTool`), which already holds the full spec. The sandbox still sends only
+name + args; the host makes the direct call. Permission / HITL gating is unchanged: it is a
+spec-level concern enforced before the call, independent of where the call goes.
+
+## What `/tools/call` becomes
+
+Gateway-only. The `workflow.*` branch and its `_call_workflow_tool` move out (reference goes
+direct). The endpoint's sole job is the one thing that needs the server: resolve the Composio
+connection from the vault and call Composio.

--- a/docs/design/agent-workflows/projects/direct-call-tools/design.md
+++ b/docs/design/agent-workflows/projects/direct-call-tools/design.md
@@ -35,7 +35,7 @@ Rules the sidecar applies:
   - If `args_into` is set: deep-clone `body`, set the `args_into` path to the model's args,
     POST it. (Reference: `args_into = "data.inputs"`.)
   - Else: `POST { ...modelArgs, ...body }` so **fixed fields win**. This is what stops the
-    model from overriding a locked field (e.g. `update_own_workflow`'s owning variant id).
+    model from overriding a locked field (e.g. a reference tool's baked `workflow_revision` id).
 
 `callRef` stays for gateway. A spec has either `call` (direct) or `callRef` (gateway), not both.
 
@@ -106,34 +106,47 @@ service already does the resolve-time API work for gateway/embed/secrets, so a r
 more thing it resolves there. Removing the `workflow.*` branch from `/tools/call` is coupled to
 this; when exactly it lands is the orchestrator's sequencing call (see `status.md`).
 
-### Platform (an Agenta operation)
+### Platform (an existing Agenta endpoint exposed to the harness)
+
+A platform tool is a **thin wrapper over an existing endpoint** — no new endpoint, no hidden
+logic, no "operation" abstraction. The config names which endpoint to expose; the resolver fills
+the description + input schema from the catalog and emits the `call`. The harness supplies the
+arguments (including its own run context — see "Run context"); the "how" of an operation is taught
+by a **skill**, not encoded in the tool.
 
 | Stage | Shape |
 |---|---|
-| config | `{ type:"platform", op:"create_workflow", needs_approval?, permission? }` |
-| resolved | `CallbackToolSpec` with `call`; `description` from the SDK catalog; `input_schema` fetched from the schema catalog at resolve time |
-| dispatch | sidecar → direct POST to that op's endpoint (a plain authenticated endpoint that does in-process service work) |
+| config | `{ type:"platform", op:"<exposed-endpoint-key>", needs_approval?, permission? }` |
+| resolved | `CallbackToolSpec` with `call`; `description` + `input_schema` from the catalog |
+| dispatch | sidecar → direct call to that existing endpoint with the caller credential |
 
-Resolved examples:
-
-```json
-{ "name": "add_trace_annotation", "description": "Record a finding on a trace",
-  "inputSchema": { "...from catalog..." },
-  "call": { "method":"POST", "path":"/api/annotations/" } }
-```
+Resolved example — expose the commit-revision endpoint as a tool:
 
 ```json
-{ "name": "update_own_workflow", "description": "Commit a new revision to your own workflow",
-  "inputSchema": { "type":"object", "properties": { "agent_config":{}, "message":{} } },
-  "call": { "method":"POST", "path":"/api/workflows/revisions/commit",
-            "body": { "workflow_variant_id": "<the running agent's own variant>" } } }
+{ "name": "commit_revision", "description": "Commit a new revision to a workflow variant",
+  "inputSchema": { "...the endpoint's request schema, from the catalog..." },
+  "call": { "method":"POST", "path":"/api/workflows/revisions/commit" } }
 ```
 
-For platform tools `args_into` is usually absent (the args are the body). The owning variant id
-is server-fixed in `body`, so the model cannot retarget another agent.
+The harness fills the body with the payload (the new config, the annotation content). There is
+**no** `update_own_workflow` or `add_trace_annotation` tool — those were the rejected logic-wrapping
+idea. "Annotate my trace" is just creating a new trace that links to the agent's own `trace_id`;
+"update myself" is just committing a revision to the agent's own variant. The raw endpoints are
+exposed; a skill teaches composition.
 
-This is the line-67 fix: each platform op is one direct call to an endpoint that does its own
-in-process service work. No `/tools/call`, and no endpoint calling another endpoint.
+For a **self-targeting** op, the agent's own identity (its variant / its trace) is **server-bound**
+into `call.body` at resolve time and omitted from the model-visible schema, so the model supplies
+only the payload and cannot retarget a different variant/trace within the project. This is the
+Codex finding (project-scoped auth does not stop within-project lateral movement) and it is still a
+thin wrapper — just a fixed field. General (non-self) endpoint wrappers leave the target to the
+model, bounded by the endpoint's own permission. See `run-context.md`.
+
+`body` / `args_into` on `call` are exactly the mechanism for those server-bound fields (and for the
+reference tool's baked revision id); a plain non-self endpoint wrapper needs neither — the model
+args are the request body.
+
+This is the line-67 fix: platform tools call existing endpoints directly, instead of `/tools/call`
+re-dispatching to other Agenta endpoints. We do not add new endpoints; we expose the ones we have.
 
 ### Code / client — unchanged
 
@@ -155,11 +168,20 @@ across all tool types, so the refactor can lift it uniformly later.
 ## Run context
 
 Some tools need the run's own context (the current trace, the running workflow/variant + draft
-state + latest revision, the session_id). The resolved direction (Codex-reviewed): run context
-rides the **run contract** as a run-level `runContext` payload on `/run`, and the runner/SDK
-**binds the protected fields server-side** into the call so the model cannot override them;
-endpoints also harden (own-variant + revision-precondition checks). It is NOT modeled as a tool
-argument or a static tool. Full options, tradeoffs, and the open A-vs-C decision: `run-context.md`.
+state + latest revision, the session_id). The resolved direction (Codex rev-2):
+
+- Run context rides the **run contract** as a run-level `runContext` payload on `/run` — data, not
+  a callable tool, and not modeled as a `get_context` primitive.
+- **Protected self-identity** (the agent's own variant / trace) is **bound server-side** into the
+  `call.body` of self-targeting tools and hidden from the model, so the model cannot retarget
+  within the project. Endpoints also harden (revision-precondition on commit).
+- **Non-authority context the model needs to read** is delivered as an **MCP resource** (primary)
+  with a **context-file fallback** for harnesses without resource support.
+- **Refresh per turn** — `latest_revision` changes after a commit, so a once-at-start snapshot
+  goes stale.
+
+Full options, tradeoffs, and the one open decision (server-bind self-identity vs "own is
+convention"): `run-context.md`.
 
 ## The platform-op catalog
 
@@ -193,8 +215,9 @@ deterministic UUIDs, a virtual revision provider) is current and correct for pla
 **workflows/skills**, but heavier than platform ops need. Mirror its "code-defined,
 reserved-namespace, validated-at-import" spirit, not its versioned-revision machinery.
 
-`create_workflow` today is three calls (artifact, variant, revision). Add one convenience endpoint
-so the platform tool is a single direct call, atomic, with its own permission check.
+Multi-step operations (e.g. create-then-commit) are composed by the harness across several
+endpoint-wrapper calls, guided by a skill — not collapsed into a new convenience endpoint. The
+thin-wrapper rule holds: we expose existing endpoints, we do not add new ones.
 
 ## Sidecar dispatch algorithm
 

--- a/docs/design/agent-workflows/projects/direct-call-tools/design.md
+++ b/docs/design/agent-workflows/projects/direct-call-tools/design.md
@@ -13,6 +13,7 @@ call: {
   method: "POST" | "GET",
   path: string,            // absolute path from the Agenta origin, e.g. "/api/annotations/"
   body?: object,           // server-fixed fields, baked at resolve time
+  context?: object,        // {body-path: "$ctx.<run-context-key>"} filled by the runner at dispatch
   args_into?: string,      // dotted path where the model's args are placed; absent = root
 }
 ```
@@ -31,13 +32,66 @@ Rules the sidecar applies:
   client, so the `call` descriptor adds no SSRF surface. (Per the Codex review.)
 - Auth is the run's single `toolCallback.authorization` (the caller credential), reused for
   every direct call. No per-tool auth.
-- Body assembly:
-  - If `args_into` is set: deep-clone `body`, set the `args_into` path to the model's args,
-    POST it. (Reference: `args_into = "data.inputs"`.)
-  - Else: `POST { ...modelArgs, ...body }` so **fixed fields win**. This is what stops the
-    model from overriding a locked field (e.g. a reference tool's baked `workflow_revision` id).
+- Body assembly (merge order: model args, then `body`, then `context` — later wins):
+  - Start from the model's args, placed at `args_into` if set (e.g. `data.inputs` for a
+    reference) else at the root.
+  - Overlay `body` (static server-fixed fields, e.g. a reference tool's baked `workflow_revision`
+    id).
+  - Overlay `context`: for each `body-path: "$ctx.<key>"`, resolve `<key>` against the run's
+    `runContext` blob (passed on `/run`, refreshed per turn) and deep-set it. Context is filled
+    LAST, so a model arg can never collide into a bound field.
+  - **Hardening (Codex): "context last" is necessary but not sufficient.** Reject at resolve time
+    any path overlap across `args_into` / `body` / `context` (including nested/prefix collisions);
+    parse dotted paths strictly; deep-set with prototype-pollution-safe assignment (reject
+    `__proto__` / `constructor` / `prototype`); validate the merged body against the endpoint
+    schema before POSTing.
 
 `callRef` stays for gateway. A spec has either `call` (direct) or `callRef` (gateway), not both.
+
+### Context binding (how a catalog entry fills a field from run context)
+
+This is the mechanism behind server-binding self-identity (see `run-context.md`). A platform-op
+catalog entry declares a `bind` map — endpoint field → run-context key — and that map is the
+entire "transformation"; the runner stays generic (it never knows what a "variant" is).
+
+- **Catalog entry:** `{ method, path, input_schema_ref, bind: { "<endpoint-field>": "$ctx.<key>" } }`.
+- **Resolve time (service):** delete every `bind` key from the model-visible `input_schema` (and
+  from `required`), and emit `call.context = bind` on the spec. The model never sees the bound
+  field.
+- **`/run` (service → runner):** carry a `runContext` blob — `{ workflow: { variant_id,
+  variant_name, revision_id, is_draft, latest_revision_id }, trace: { trace_id, span_id },
+  session_id }` — refreshed per turn so mutable values (trace, latest revision) never go stale.
+- **Dispatch (runner):** fill each `call.context` entry from `runContext`, deep-set it into the
+  body last in the merge order above, POST.
+
+Worked example (`update_self`): `bind: { "workflow_variant_id": "$ctx.workflow.variant_id" }` →
+the model schema drops `workflow_variant_id` → the model calls `update_self({ parameters, message })`
+→ the runner POSTs `{ workflow_variant_id: <own, from runContext>, parameters, message }`. The
+agent can only ever target itself.
+
+Resolved (Codex binding review):
+
+- **Binding resolution is hybrid.** Immutable identity (the running `variant_id`) is baked at
+  resolve time into `call.body`; mutable values (`trace_id`, `latest_revision_id`) are filled at
+  dispatch from the per-turn `runContext` via `call.context`. Dispatch-time-for-all is simpler but
+  still risks stale-within-a-turn, so commits should also carry a revision precondition.
+- **Schema stripping is path-aware.** Remove exactly the bound paths (and their `required`
+  entries), and verify the stripped schema still satisfies the endpoint's real required contract
+  (do not drop a field the endpoint needs that the model should still provide).
+- **`runContext` is its own field on the `/run` contract** (explicit run metadata, NOT inside
+  `TraceContext`), with the MCP-resource / context-file fallback for local backends that cannot
+  read it (see `run-context.md`).
+- **Merge hardening** as in the body-assembly rule above (path-conflict rejection, strict path
+  parsing, prototype-pollution-safe deep-set, post-merge validation).
+
+Implementation checklist (this PR is design-only; Codex confirmed none of it is built yet — that
+is the build plan, dispatched separately):
+1. Wire types: add `runContext` + the `call` descriptor (`method/path/body/context/args_into`) to
+   `protocol.ts` and the Python wire models; keep `callRef` as the gateway fallback.
+2. Platform-op resolver: the catalog + path-aware schema stripping + bind-path handling + required
+   pruning.
+3. Dispatch: context assembly with the conflict checks + safe deep-set, in BOTH the direct and the
+   Daytona-relay paths.
 
 ## Per-tool-type table
 

--- a/docs/design/agent-workflows/projects/direct-call-tools/interfaces.md
+++ b/docs/design/agent-workflows/projects/direct-call-tools/interfaces.md
@@ -1,0 +1,97 @@
+# Interface reference — direct-call tools
+
+The concrete interface delta, so review and implementation reference the same contract. Each entry
+is the exact shape plus the seam (file) it lands in. This is the spec; `design.md` is the rationale.
+
+## 1. Resolved tool spec — the `call` descriptor (cross-service wire)
+
+Add to `ResolvedToolSpec` (TS, `services/agent/src/protocol.ts`) and `CallbackToolSpec` (Python,
+`sdks/python/agenta/sdk/agents/tools/models.py`):
+
+```
+call?: {
+  method: "POST" | "GET",
+  path: string,                              // absolute path from the Agenta origin
+  body?: object,                             // static server-fixed fields (resolve time)
+  context?: { [bodyPath: string]: "$ctx.<key>" },   // runner fills from runContext at dispatch
+  args_into?: string                         // dotted path where the model's args are placed
+}
+```
+
+- Mirror in `wire.py`; update the golden `/run` fixtures and both wire-contract tests.
+- `callRef` stays for gateway; a spec carries `call` XOR `callRef`.
+- Seams: `protocol.ts`, `models.py`, `wire.py`, `golden/`.
+
+## 2. Run request — `runContext` (cross-service wire)
+
+Add `runContext` to `AgentRunRequest` (`protocol.ts`) and the Python wire model — its OWN field,
+NOT inside `TraceContext` — refreshed per turn:
+
+```
+runContext?: {
+  workflow?: { artifact_id, variant_id, variant_name, revision_id, version, is_draft, latest_revision_id },
+  trace?:    { trace_id, span_id },
+  session_id?: string
+}
+```
+
+- The service fills it in `services/oss/src/agent/app.py` (it already holds `RunningContext.revision`
+  + the request). Consumed only by `call.context` binding; the model never reads it.
+- Seams: `protocol.ts` (AgentRunRequest), `wire.py`, `app.py`.
+
+## 3. Tool config — `type:"platform"` (public-edge, agent config)
+
+Add a `PlatformToolConfig` arm to the `ToolConfig` union (`models.py`):
+
+```
+{ type: "platform", op: string, needs_approval?: bool, permission?: <Permission> }
+```
+
+- Surfaced in `AgentConfigSchema.tools`.
+- Seams: `models.py` (ToolConfig union), the agent-config schema (`schemas.py` / `agent_v0_interface`),
+  FE `AgentConfigControl` (later).
+
+## 4. Platform-op catalog entry (in-service; SDK)
+
+**Location (Codex catalog review):** a TYPED catalog model (not plain module-level dicts) in a new
+`sdks/python/agenta/sdk/agents/platform/op_catalog.py`, bridged in `platform/resolve.py`, with the
+config arm in `tools/models.py` wired through `tools/resolver.py`. Descriptions live in the SDK.
+Reuse `PlatformConnection` (the existing base-url/auth/headers seam) rather than new HTTP plumbing.
+
+A code-defined catalog mapping an `op` to:
+
+```
+op -> {
+  description: string,           // SDK-owned
+  method, path,                  // the EXISTING endpoint to expose
+  input_schema_ref: string,      // a CATALOG_TYPES key (x-ag-type-ref) — the endpoint's request schema
+  bind?: { [endpointField: string]: "$ctx.<key>" },   // self-targeting fields filled server-side
+  default_permission?, default_needs_approval?
+}
+```
+
+- Resolve: strip each `bind` field (path-aware) from the model-visible `input_schema` (+ `required`);
+  emit `call` (`method`/`path`/`context`=bind/`body`).
+- Seams: `platform/op_catalog.py` (new), `platform/resolve.py`, `tools/{models,resolver}.py`,
+  `CATALOG_TYPES`.
+
+## 5. Reference tool config (owned by Workstream B; referenced here)
+
+```
+{ type: "reference", ref_by: "variant"|"environment", slug, version?, name?, description?, input_schema? }
+```
+
+- Resolves to a `CallbackToolSpec` with `call` → the invoke endpoint; revision resolved at resolve
+  time (env follows the live deployment because the service re-resolves per invoke).
+- Seams: `models.py` (`ReferenceToolConfig`, B), the SDK workflow resolver.
+
+## 6. Dispatch — body assembly (runner)
+
+`services/agent/src/tools/dispatch.ts` + `relay.ts` (the Daytona host handler): for a `call` spec,
+assemble the body = model args (at `args_into` or root) → overlay static `body` → overlay `context`
+(resolve each `$ctx.*` against `runContext`, deep-set), **context last**. Hardening: path-conflict
+rejection, strict dotted-path parse, prototype-pollution-safe deep-set, post-merge schema
+validation. Guardrail: method allowlist (`GET`/`POST`), relative `/api/...` path, origin derived
+from `toolCallback.endpoint`.
+
+- Seams: `dispatch.ts`, `relay.ts`, a new direct-call helper (e.g. `tools/direct.ts`).

--- a/docs/design/agent-workflows/projects/direct-call-tools/plan.md
+++ b/docs/design/agent-workflows/projects/direct-call-tools/plan.md
@@ -1,0 +1,189 @@
+# Direct-call tools — plan and workstream split
+
+Date: 2026-06-27
+Owner of this doc: the agent in the design conversation with Mahmoud (Workstream A).
+
+This is the hand-off file. Point the orchestrator here instead of copy-pasting. It holds the
+decision, the two workstreams, the PRs each touches, the sequencing, and the open decisions.
+
+---
+
+## The decision (context)
+
+A resolved tool should carry where to call. The sidecar then calls reference and platform
+tools directly, and only gateway (Composio) tools route through `/tools/call`.
+
+Why, in one paragraph: today every callback tool POSTs to the single `/tools/call`, which
+re-parses a string and re-dispatches. For a **reference** (a stored workflow used as a tool)
+and a **platform** tool (an Agenta operation like create-workflow or annotate), the target is
+just an Agenta endpoint, and the sidecar already holds the caller's credential. So the
+`/tools/call` hop adds a step and no value. **Gateway** is the one real exception: only the
+server can read the Composio secret, so gateway stays server-side.
+
+Two more decisions made in the same conversation:
+
+- **Drop the `@ag.reference` marker.** A reference tool is just `type:"reference"` in the
+  config `tools` list. The marker was authoring sugar for symmetry with skills. Keep the tool
+  type; remove the marker machinery.
+- **Keep `@ag.embed`** (a different feature: it inlines a value). For now, do **not** show
+  embed in the tool-authoring UI.
+
+---
+
+## PR map
+
+| PR | State | Branch → base | Role |
+|----|-------|---------------|------|
+| **#4860** | open, not draft | `feat/agent-embedref-tools` → `big-agents` | Backend/SDK reference tool. Added `type:"reference"`, the `@ag.reference` marker, and the `workflow.*` routing in `/tools/call`. |
+| **#4877** | draft | `fe-feat/agent-embedref-tools-onbig` → **#4860** | Frontend, stacked on #4860. Authors a reference tool via the marker. |
+| **#4837** | open | `docs/agent-embedref-tools` → `big-agents` | Design doc for the two-syntax (embed/reference) plan. |
+| **#4863** | draft | `docs/agent-creation-skills` → `big-agents` | The custom-tools design note. Mahmoud's line-67 comment ("no calls between two API endpoints, use direct service calls") is the seed of this whole plan. |
+
+#4877 is stacked on #4860, so the two move together.
+
+---
+
+## Workstream B — drop the marker, rebuild the FE on the tool type
+
+**Route this to a subagent. Touches #4860 and #4877 (and a doc note on #4837). Self-contained;
+can start now. Does NOT need Workstream A.**
+
+### Context for the subagent
+
+A reference tool is `type:"reference"` in the config `tools` list. We are removing the
+`@ag.reference` marker but keeping the tool type and keeping reference tools working through
+the **existing** `/tools/call` `workflow.*` routing (do not remove that here — that removal
+belongs to Workstream A, and removing it now breaks reference execution). `@ag.embed` stays in
+the backend untouched; we only hide it from the tool UI.
+
+### Tasks on #4860 (backend/SDK)
+
+1. Remove the marker path: `AG_REFERENCE_MARKER` and `_coerce_reference_tool`
+   (`sdks/python/agenta/sdk/agents/tools/compat.py`), the `AG_REFERENCE_KEY` "leave it" guards
+   in `api/oss/src/core/embeds/utils.py`, and the generic-resolver logic that keeps the
+   marker node. Keep `ReferenceToolConfig` (`type:"reference"`), the resolver mapping to
+   `CallbackToolSpec`, and the `/tools/call` `workflow.*` routing.
+2. Leave `@ag.embed` fully intact.
+3. Add environment/variant targeting to `ReferenceToolConfig`. The author picks one axis, then
+   takes the latest or pins a revision. Suggested shape (implementer finalizes names):
+   - `ref_by: "variant" | "environment"`
+   - `slug: str` (the variant slug or the environment slug)
+   - `version: Optional[str]` (absent = latest; set = pin that revision)
+   - existing `name` / `description` / `input_schema`
+   Map these to the workflows service references (`workflow_variant` vs `environment`, slug +
+   version) — `resolve_references_with_info` already resolves by variant and by environment.
+   Wire them through `_call_workflow_tool` → `WorkflowServiceRequest.references` so env/variant
+   works end-to-end through the current routing.
+4. Update the tests that assert the marker (`test_utils.py`, `test_parsing.py`,
+   `test_models.py`, `test_resolver.py`, `test_workflow_resolver.py`) and the interface docs in
+   #4860 (`tool-models-and-resolution.md`, `agent-config-schema.md`, `tools.md`,
+   `runner-to-tool-callback.md`) to describe `type:"reference"` only.
+
+### Tasks on #4877 (frontend)
+
+1. Author a reference tool as `type:"reference"`, not the marker.
+2. Reference selector UI: choose environment or variant, then latest or a specific revision
+   (consume the schema from task B-3).
+3. Do not surface embed in the tool UI. Keep it in the backend/model; just hide it.
+4. Retitle the PR away from "@ag.reference".
+
+### Doc note
+
+Note the marker removal on #4837 (the design PR), since it describes the two-syntax plan.
+
+---
+
+## Workstream A — direct-call tools architecture
+
+**This agent owns it, via `/plan-feature`. New project under
+`docs/design/agent-workflows/projects/direct-call-tools/`. Supersedes the execution half of
+#4860 and answers #4863's line-67 comment.**
+
+Scope the plan will cover:
+
+1. **`call` descriptor on the resolved spec.** Add optional `call: { method, path, body }` to
+   `CallbackToolSpec` (SDK `tools/models.py`) and `ResolvedToolSpec` (`protocol.ts`). `path`
+   is **relative** (Agenta-only); the sidecar joins its own base from env, so a tool can never
+   target a non-Agenta host. `body` holds server-fixed fields.
+2. **Sidecar dispatch.** New `if (spec.call)` branch in `dispatch.ts`: join base + path, reuse
+   the run's authorization, merge `{...modelArgs, ...spec.call.body}` so fixed fields win and
+   the model cannot retarget. Daytona: the host-side relay handler makes the direct call; the
+   sandbox still sends only name + args.
+3. **Reference goes direct.** SDK resolver emits a `call` to the invoke endpoint (**batch,
+   not stream**), with env/variant/version baked into `body`. Tool result = `data.outputs` +
+   `trace_id`; the sub-run nests in the trace for the user, the model gets the final output.
+   Remove the `/tools/call` `workflow.*` routing. Move the recursion/budget guard to the
+   invoke endpoint.
+4. **Platform tools.** New `type:"platform"` config (`op` + permission/approval overrides). A
+   platform-op catalog where **descriptions live in the SDK** and **input schemas are fetched
+   at resolve time from `openapi.json`** for each op's endpoint. The SDK owns the
+   `op → {method, relative path}` table and emits the `call`. Add a `create_workflow`
+   convenience endpoint so it is one call, not three. Each op is gated by its endpoint's own
+   permission plus spec-level `needs_approval`.
+5. **Gateway unchanged**, and `/tools/call` shrinks to the gateway-only executor.
+6. **Stretch (flag out-of-scope unless cheap):** forward the trace context to the sub-workflow
+   on a reference invoke, so the child run links under the parent.
+7. Reply to the line-67 comment on #4863 and reconcile `custom-tools-design.md` with this
+   project doc.
+
+---
+
+## Sequencing and dependencies
+
+- **B lands first** and keeps reference working through the existing routing.
+- **A supersedes B's execution path:** moves reference to direct, removes the routing, adds
+  platform tools. A **reuses** B's env/variant schema; it does not re-add it.
+- The two are mostly disjoint planes while in flight: B is SDK config + API routing + FE; A is
+  the resolved-spec `call` descriptor + sidecar dispatch + platform catalog. The shared file to
+  coordinate is `sdks/python/agenta/sdk/agents/tools/models.py` (B edits `ReferenceToolConfig`,
+  A adds `call` to `CallbackToolSpec`) — different classes, but same file, so serialize commits.
+
+## Open decisions for Mahmoud
+
+1. **When to remove the `/tools/call` workflow routing.** It belongs to A (reference stops
+   executing the moment it is gone unless the direct path exists). Recommendation: keep it in
+   A. If removed in B instead, reference tools go dark until A lands.
+2. **Trace-context forwarding to the sub-workflow** (item A-6): nice to have, possibly out of
+   scope for the first cut. Mahmoud leaned "agree with invoke," unsure on this one.
+
+---
+
+## Execution phases (Workstream A)
+
+Detailed design is in `design.md`; code seams in `research.md`. Phases are ordered so the
+gateway path never breaks and the live stack stays green between milestones.
+
+- **Phase 1 — the `call` descriptor (plumbing, no behavior change).** Add optional `call` to
+  `CallbackToolSpec` (SDK `tools/models.py`) and `ResolvedToolSpec` (`protocol.ts`), mirror in
+  `wire.py`, update the golden `/run` fixtures + both contract tests. No resolver emits it and
+  no dispatch reads it yet, so behavior is unchanged. **Touches the shared `models.py` — gated
+  on B (see `status.md`); do the protocol.ts/wire/golden side first, fold the `models.py`
+  field after B commits.**
+- **Phase 2 — sidecar direct branch.** Add `if (spec.call)` to `dispatch.ts` and the host relay
+  handler (`relay.ts executeRelayedTool`), with `assembleBody` (the `args_into` deep-set vs the
+  fixed-wins merge). Unit-test with fake `call` specs. Live behavior still unchanged (nothing
+  emits `call`). Runner vitest green.
+- **Phase 3 — platform tools.** New `type:"platform"` config; the `_PLATFORM_TOOLS` catalog
+  (descriptions in the SDK, input schema via the in-process schema catalog); resolver emits
+  `call` for platform ops; `create_workflow` convenience endpoint. Start with a small set
+  (`search_tools`, `add_trace_annotation`, `create_workflow`, `update_own_workflow`,
+  `inspect_harnesses`). Largely independent of B. SDK + service tests + a live E2E.
+- **Phase 4 — reference goes direct (gated on B).** Resolver emits `call` for reference using
+  B's env/variant schema; confirm/clean the `/api/workflows/invoke`-style endpoint and move the
+  recursion/budget guard there; remove the `/tools/call` `workflow.*` routing. Tests + live E2E.
+  Depends on B landed and on decision 1 above.
+- **Phase 5 — gateway cleanup + docs.** `/tools/call` shrinks to gateway-only. `keep-docs-in-sync`:
+  the interface inventory, `tools.md`, `agent-config-schema.md`, and a reply on #4863 reconciling
+  `custom-tools-design.md`.
+- **Phase 6 — stretch.** Trace-context forwarding to the sub-workflow on a reference invoke.
+
+### Coordination and PRs
+
+- Phases 1-3 are mostly disjoint from B (platform tools do not touch the reference config). The
+  one shared surface is `models.py` in Phase 1 — serialize via first-committer-owns.
+- Likely two GitButler lanes on `big-agents`: (a) the direct-call core (`call` descriptor +
+  dispatch + platform tools, Phases 1-3); (b) reference-direct + routing-removal (Phases 4-5),
+  stacked after B lands. Do NOT merge to `big-agents` (the orchestrator folds back).
+- Test matrix per `implement-feature`: wire contract both sides, SDK unit, service unit, runner
+  vitest, then the live daytona / local-pi / claude x SDK / UI cells. `debug-local-deployment`
+  between milestones.

--- a/docs/design/agent-workflows/projects/direct-call-tools/plan.md
+++ b/docs/design/agent-workflows/projects/direct-call-tools/plan.md
@@ -114,15 +114,17 @@ Scope the plan will cover:
    `trace_id`; the sub-run nests in the trace for the user, the model gets the final output.
    Remove the `/tools/call` `workflow.*` routing. Move the recursion/budget guard to the
    invoke endpoint.
-4. **Platform tools.** New `type:"platform"` config (`op` + permission/approval overrides). A
-   platform-op catalog where **descriptions live in the SDK** and **input schemas reuse the
-   in-process schema catalog** (the `CATALOG_TYPES` mechanism, built from `model_json_schema()`,
-   referenced via `x-ag-type-ref`). The SDK owns the `op → {method, relative path}` table and
-   emits the `call`. Mirror the reserved-tool pattern from PR #4884
+4. **Platform tools (thin wrappers over EXISTING endpoints).** New `type:"platform"` config
+   (`op` = which existing endpoint to expose, + permission/approval overrides). A platform-op
+   catalog where **descriptions live in the SDK** and **input schemas reuse the in-process schema
+   catalog** (`CATALOG_TYPES`, via `x-ag-type-ref`). The SDK owns the `op → {method, relative
+   path}` table and emits the `call`. Mirror the reserved-tool pattern from PR #4884
    (`tools.agenta.find_capabilities`); `find_capabilities` is the first platform tool (its SDK
-   emission is the deferred item below). Add a `create_workflow` convenience endpoint so it is one
-   call, not three. Each op is gated by its endpoint's own permission plus spec-level
-   `needs_approval`.
+   emission is the deferred item below). **No new endpoints and no logic-wrapping tools** (no
+   `update_own_workflow` / `add_trace_annotation` — those are the rejected first version; the
+   harness calls raw endpoints and composes multi-step ops via a skill). Each op is gated by its
+   endpoint's own permission plus spec-level `needs_approval`. Depends on the run-context delivery
+   mechanism (see `run-context.md`) so the agent can supply its own trace/variant.
 5. **Gateway unchanged**, and `/tools/call` shrinks to the gateway-only executor.
 6. **Stretch (flag out-of-scope unless cheap):** forward the trace context to the sub-workflow
    on a reference invoke, so the child run links under the parent.
@@ -171,13 +173,14 @@ gateway path never breaks and the live stack stays green between milestones.
   handler (`relay.ts executeRelayedTool`), with `assembleBody` (the `args_into` deep-set vs the
   fixed-wins merge). Unit-test with fake `call` specs. Live behavior still unchanged (nothing
   emits `call`). Runner vitest green.
-- **Phase 3 — platform tools.** New `type:"platform"` config; the platform-op catalog
-  (descriptions in the SDK, input schema via the in-process `CATALOG_TYPES` catalog; mirrors the
-  reserved `tools.agenta.*` pattern from PR #4884); resolver emits `call` for platform ops;
-  `create_workflow` convenience endpoint. First op = `find_capabilities` (its SDK emission is the
-  Deferred item below, from PR #4884), then a small set (`add_trace_annotation`,
-  `create_workflow`, `update_own_workflow`, `inspect_harnesses`). Largely independent of B. SDK +
-  service tests + a live E2E.
+- **Phase 3 — platform tools (thin endpoint wrappers).** New `type:"platform"` config; the
+  platform-op catalog (descriptions in the SDK, input schema via the in-process `CATALOG_TYPES`
+  catalog; mirrors the reserved `tools.agenta.*` pattern from PR #4884); resolver emits `call` for
+  platform ops. First op = `find_capabilities` (its SDK emission is the Deferred item below, from
+  PR #4884), then a small set of EXISTING endpoints exposed as-is (e.g. commit-revision,
+  create-annotation-trace, workflow create/query, `/inspect`). No new endpoints, no logic-wrapping
+  tools. Includes the run-context delivery mechanism (see `run-context.md`) so the agent can pass
+  its own trace/variant. Largely independent of B. SDK + service tests + a live E2E.
 - **Phase 4 — reference goes direct (gated on B).** Resolver emits `call` for reference using
   B's env/variant schema; confirm/clean the `/api/workflows/invoke`-style endpoint and move the
   recursion/budget guard there; remove the `/tools/call` `workflow.*` routing. Tests + live E2E.

--- a/docs/design/agent-workflows/projects/direct-call-tools/plan.md
+++ b/docs/design/agent-workflows/projects/direct-call-tools/plan.md
@@ -124,7 +124,8 @@ Scope the plan will cover:
    `update_own_workflow` / `add_trace_annotation` — those are the rejected first version; the
    harness calls raw endpoints and composes multi-step ops via a skill). Each op is gated by its
    endpoint's own permission plus spec-level `needs_approval`. Depends on the run-context delivery
-   mechanism (see `run-context.md`) so the agent can supply its own trace/variant.
+   mechanism (`runContext` on `/run` + tool `bind`; see `run-context.md`) so tools can bind the
+   agent's own trace/variant server-side.
 5. **Gateway unchanged**, and `/tools/call` shrinks to the gateway-only executor.
 6. **Stretch (flag out-of-scope unless cheap):** forward the trace context to the sub-workflow
    on a reference invoke, so the child run links under the parent.
@@ -179,8 +180,9 @@ gateway path never breaks and the live stack stays green between milestones.
   platform ops. First op = `find_capabilities` (its SDK emission is the Deferred item below, from
   PR #4884), then a small set of EXISTING endpoints exposed as-is (e.g. commit-revision,
   create-annotation-trace, workflow create/query, `/inspect`). No new endpoints, no logic-wrapping
-  tools. Includes the run-context delivery mechanism (see `run-context.md`) so the agent can pass
-  its own trace/variant. Largely independent of B. SDK + service tests + a live E2E.
+  tools. Includes the run-context mechanism (`runContext` on `/run` + tool `bind`; see
+  `run-context.md`) so self-targeting tools bind the agent's own trace/variant server-side.
+  Largely independent of B. SDK + service tests + a live E2E.
 - **Phase 4 — reference goes direct (gated on B).** Resolver emits `call` for reference using
   B's env/variant schema; confirm/clean the `/api/workflows/invoke`-style endpoint and move the
   recursion/budget guard there; remove the `/tools/call` `workflow.*` routing. Tests + live E2E.

--- a/docs/design/agent-workflows/projects/direct-call-tools/plan.md
+++ b/docs/design/agent-workflows/projects/direct-call-tools/plan.md
@@ -115,11 +115,14 @@ Scope the plan will cover:
    Remove the `/tools/call` `workflow.*` routing. Move the recursion/budget guard to the
    invoke endpoint.
 4. **Platform tools.** New `type:"platform"` config (`op` + permission/approval overrides). A
-   platform-op catalog where **descriptions live in the SDK** and **input schemas are fetched
-   at resolve time from `openapi.json`** for each op's endpoint. The SDK owns the
-   `op → {method, relative path}` table and emits the `call`. Add a `create_workflow`
-   convenience endpoint so it is one call, not three. Each op is gated by its endpoint's own
-   permission plus spec-level `needs_approval`.
+   platform-op catalog where **descriptions live in the SDK** and **input schemas reuse the
+   in-process schema catalog** (the `CATALOG_TYPES` mechanism, built from `model_json_schema()`,
+   referenced via `x-ag-type-ref`). The SDK owns the `op → {method, relative path}` table and
+   emits the `call`. Mirror the reserved-tool pattern from PR #4884
+   (`tools.agenta.find_capabilities`); `find_capabilities` is the first platform tool (its SDK
+   emission is the deferred item below). Add a `create_workflow` convenience endpoint so it is one
+   call, not three. Each op is gated by its endpoint's own permission plus spec-level
+   `needs_approval`.
 5. **Gateway unchanged**, and `/tools/call` shrinks to the gateway-only executor.
 6. **Stretch (flag out-of-scope unless cheap):** forward the trace context to the sub-workflow
    on a reference invoke, so the child run links under the parent.
@@ -138,13 +141,18 @@ Scope the plan will cover:
   coordinate is `sdks/python/agenta/sdk/agents/tools/models.py` (B edits `ReferenceToolConfig`,
   A adds `call` to `CallbackToolSpec`) — different classes, but same file, so serialize commits.
 
-## Open decisions for Mahmoud
+## Sequencing notes (orchestrator's call)
+
+Mahmoud reviewed the design and is aligned with all the decisions. Per his note, merge order and
+commit organization are the orchestrator's to decide; the only standing requirement is the
+ability to review before merge. So the items below are sequencing notes, not decisions Mahmoud
+owes.
 
 1. **When to remove the `/tools/call` workflow routing.** It belongs to A (reference stops
-   executing the moment it is gone unless the direct path exists). Recommendation: keep it in
-   A. If removed in B instead, reference tools go dark until A lands.
-2. **Trace-context forwarding to the sub-workflow** (item A-6): nice to have, possibly out of
-   scope for the first cut. Mahmoud leaned "agree with invoke," unsure on this one.
+   executing the moment it is gone unless the direct path exists). Recommendation: keep it in A,
+   after B lands. If removed in B instead, reference tools go dark until A lands.
+2. **Trace-context forwarding to the sub-workflow** (item A-6): a Phase 6 stretch, likely
+   deferred past the first cut.
 
 ---
 
@@ -163,19 +171,51 @@ gateway path never breaks and the live stack stays green between milestones.
   handler (`relay.ts executeRelayedTool`), with `assembleBody` (the `args_into` deep-set vs the
   fixed-wins merge). Unit-test with fake `call` specs. Live behavior still unchanged (nothing
   emits `call`). Runner vitest green.
-- **Phase 3 — platform tools.** New `type:"platform"` config; the `_PLATFORM_TOOLS` catalog
-  (descriptions in the SDK, input schema via the in-process schema catalog); resolver emits
-  `call` for platform ops; `create_workflow` convenience endpoint. Start with a small set
-  (`search_tools`, `add_trace_annotation`, `create_workflow`, `update_own_workflow`,
-  `inspect_harnesses`). Largely independent of B. SDK + service tests + a live E2E.
+- **Phase 3 — platform tools.** New `type:"platform"` config; the platform-op catalog
+  (descriptions in the SDK, input schema via the in-process `CATALOG_TYPES` catalog; mirrors the
+  reserved `tools.agenta.*` pattern from PR #4884); resolver emits `call` for platform ops;
+  `create_workflow` convenience endpoint. First op = `find_capabilities` (its SDK emission is the
+  Deferred item below, from PR #4884), then a small set (`add_trace_annotation`,
+  `create_workflow`, `update_own_workflow`, `inspect_harnesses`). Largely independent of B. SDK +
+  service tests + a live E2E.
 - **Phase 4 — reference goes direct (gated on B).** Resolver emits `call` for reference using
   B's env/variant schema; confirm/clean the `/api/workflows/invoke`-style endpoint and move the
   recursion/budget guard there; remove the `/tools/call` `workflow.*` routing. Tests + live E2E.
-  Depends on B landed and on decision 1 above.
+  Depends on B landed and on the sequencing note above.
 - **Phase 5 — gateway cleanup + docs.** `/tools/call` shrinks to gateway-only. `keep-docs-in-sync`:
   the interface inventory, `tools.md`, `agent-config-schema.md`, and a reply on #4863 reconciling
   `custom-tools-design.md`.
 - **Phase 6 — stretch.** Trace-context forwarding to the sub-workflow on a reference invoke.
+
+---
+
+## Deferred items
+
+**Date recorded:** 2026-06-27
+**Provenance:** tool-discovery Phase 2, PR #4884
+
+**SDK-side reserved-tool emission for `find_capabilities` is not built.**
+
+The server accepts `tools.agenta.find_capabilities` (router `_call_agenta_tool` →
+`ToolsService.discover_capabilities`; the fixed spec lives in
+`api/oss/src/core/tools/discovery.py`: `FIND_CAPABILITIES_CALL_REF / _OP / _DESCRIPTION /
+_INPUT_SCHEMA`).
+
+What is missing: making `platform.resolve_tools` (SDK `agenta.sdk.agents` tools resolver) emit
+a `CallbackToolSpec` with `call_ref=tools.agenta.find_capabilities` plus the shared
+`ToolCallback`, so an agent config can carry the tool and the model can actually call it
+end-to-end. The runner needs no change — it forwards the call_ref opaquely (confirmed).
+
+This was deferred because it overlaps Workstream A's platform-op catalog mechanism (Phase 3
+above), which adds `CallbackToolSpec.call` and platform-op resolution to the same SDK
+`tools/models.py` / `resolver.py`. Building a parallel mechanism now would conflict.
+
+**Action:** implement this on the direct-call-tools / Workstream A seam (the `type:"platform"`
+catalog), treating find_capabilities as the first platform op. Until then, find_capabilities is
+API-callable but NOT agent-usable end-to-end, which blocks the end-to-end skills QA of the
+discover-and-wire-tools skill.
+
+---
 
 ### Coordination and PRs
 

--- a/docs/design/agent-workflows/projects/direct-call-tools/plan.md
+++ b/docs/design/agent-workflows/projects/direct-call-tools/plan.md
@@ -232,3 +232,72 @@ discover-and-wire-tools skill.
 - Test matrix per `implement-feature`: wire contract both sides, SDK unit, service unit, runner
   vitest, then the live daytona / local-pi / claude x SDK / UI cells. `debug-local-deployment`
   between milestones.
+
+---
+
+## Endpoints to expose as platform tools (the wrapper set)
+
+The candidate set, drawn from the older #4863 note, reframed as EXISTING endpoints exposed as-is
+(no new endpoints; the "how" lives in skills, not in tool logic). Each is a catalog entry (§4 of
+`interfaces.md`). Some have BOTH a plain form (the model supplies the target) and a self-targeting
+`bind` form (the runner binds the agent's own identity); **both are in scope**.
+
+**Discovery**
+- `find_capabilities` — the reserved `tools.agenta.find_capabilities` (PR #4884); its SDK emission
+  is the Deferred item above. The first platform tool.
+- search integrations / actions — `GET /api/tools/catalog/.../integrations?search=` +
+  `.../actions?search=`.
+
+**Workflows (the agent building / improving agents)**
+- create artifact — `POST /api/workflows/`
+- create variant — `POST /api/workflows/variants/`
+- commit revision — `POST /api/workflows/revisions/commit`
+  - **plain:** the model supplies `workflow_variant_id`.
+  - **self (bind):** "update myself" — `bind workflow_variant_id ← $ctx.workflow.variant_id`, plus a
+    revision precondition.
+- query workflows — `POST /api/workflows/query`; get workflow — `GET /api/workflows/{id}`
+- retrieve revision — `POST /api/workflows/revisions/retrieve`; revision log —
+  `POST /api/workflows/revisions/log`
+- fork variant — `POST /api/workflows/variants/fork`
+
+**Run / inspect**
+- invoke a workflow (sub-agent) — this is the **reference-tool** path, not a separate platform op
+  (Codex: do not duplicate `workflow.*` resolution); listed only for completeness.
+- inspect harnesses — `POST /services/agent/v0/inspect` (the agent **service** inspect endpoint,
+  returns `meta.harness_capabilities`; not an `/api/...` route).
+
+**Connections / secrets**
+- create / check a Composio connection — `POST /api/tools/connections/` (returns the OAuth
+  redirect; the tool cannot complete OAuth — a human approves).
+- create a vault secret — `POST /api/vault/v1/secrets/`.
+
+**Annotations (the "redundant pair" Mahmoud flagged)**
+- create an annotation — ONE mechanism: create a trace carrying the annotation that LINKS to a
+  target trace.
+  - **plain:** the model supplies the target `trace_id`.
+  - **self (bind):** "annotate my trace" — `bind <link.trace_id> ← $ctx.trace.trace_id`.
+
+Notes:
+- The plain vs self/bind variants are two catalog entries over the SAME endpoint; both ship.
+- Per-op default permission / `needs_approval` is set in the catalog (e.g. `set_secret`,
+  create-workflow, update-self default to approval; reads ungated). Confirm at implementation.
+- Which ops ship first vs later is the orchestrator's sequencing; the catalog makes adding one a
+  data change.
+
+### Catalog implementation (Codex catalog review, folded)
+
+- The catalog is a **typed model** in a new `sdks/python/agenta/sdk/agents/platform/op_catalog.py`,
+  bridged in `platform/resolve.py`, wired through `tools/{models,resolver}.py`. Descriptions live in
+  the SDK. Reuse `PlatformConnection` for the HTTP seam — do not invent new plumbing.
+- **Execution: direct (the decision), not `/tools/call`.** Codex leaned toward keeping platform ops
+  on the existing `/tools/call` `tools.agenta.*` dispatch (consistency with today's
+  `find_capabilities`). We go direct via the `call` descriptor per the decision (no valueless hop);
+  the SSRF guardrails (method allowlist, `/api/` prefix, origin binding) cover Codex's earlier
+  surface concern. `find_capabilities` migrates from the `/tools/call` route to a direct `call` to
+  `POST /api/tools/discover` as part of its SDK emission; the `tools.agenta.*` dispatch in
+  `/tools/call` is then removed alongside the `workflow.*` removal, leaving `/tools/call`
+  gateway-only.
+- **Traps (Codex):** keep the `tools.agenta.<slug>` namespace stable; set a per-op permission
+  default in the catalog (mutating ops default to approval); if any op stays server-mediated during
+  migration, extend `_call_agenta_tool` AND the discovery response path together to avoid
+  resolve/discovery drift.

--- a/docs/design/agent-workflows/projects/direct-call-tools/research.md
+++ b/docs/design/agent-workflows/projects/direct-call-tools/research.md
@@ -1,0 +1,99 @@
+# Research — the code seams
+
+All paths verified this session. Line numbers are approximate anchors, not exact contracts.
+
+## Tool config and resolved spec (SDK)
+
+- `sdks/python/agenta/sdk/agents/tools/models.py`
+  - `ToolConfig` union (`~127`), discriminated by `type`: `builtin`, `gateway`, `code`,
+    `client`, `reference`. **No `platform` type yet** (Workstream A adds it).
+  - `GatewayToolConfig` → `reference` property `tools.{provider}.{integration}.{action}.{connection}`.
+  - `ReferenceToolConfig` (`~92`): `slug` + optional `version` today; `call_ref` property
+    `workflow.{slug}[.{version}]`. **Workstream B adds env/variant here.**
+  - `CallbackToolSpec` (`~233`): the resolved spec. `kind:"callback"` + `call_ref`. Inherits
+    `ToolSpecBase` (`~155`): `name`, `description`, `input_schema`, `needs_approval`, `render`,
+    `read_only`, `permission`, `effective_permission()`, `to_wire()`. **Workstream A adds the
+    optional `call` field here.**
+  - `ToolSpec` union (`~252`): `CallbackToolSpec | CodeToolSpec | ClientToolSpec`.
+- `sdks/python/agenta/sdk/agents/tools/resolver.py` (`~172`): partitions configs; reference and
+  gateway both resolve to `CallbackToolSpec` + one shared `ToolCallback(endpoint=.../tools/call,
+  authorization)`. Reference resolves locally; gateway calls `/tools/resolve`.
+- `sdks/python/agenta/sdk/agents/platform/workflow.py` / `gateway.py`: the two resolvers. Both
+  return `ToolCallback(endpoint=f"{api_base}/tools/call", authorization=...)`.
+
+## Runner wire and dispatch (TypeScript)
+
+- `services/agent/src/protocol.ts`
+  - `ResolvedToolSpec` (`~63`): `name`, `description`, `inputSchema`, `callRef`,
+    `kind:"callback"|"code"|"client"`, `runtime`, `code`, `env`, `needsApproval`, `render`,
+    `readOnly`, `permission`. **Workstream A adds optional `call`.**
+  - `ToolCallbackContext` (`~87`): `{ endpoint, authorization }`, single, on
+    `AgentRunRequest.toolCallback` (`~340`). Stays for gateway.
+- `services/agent/src/tools/dispatch.ts` `runResolvedTool` (`~53`): branches on `spec.kind`:
+  `code` → `runCodeTool`; `client` → throw; default/`callback` → relay (Daytona) or
+  `callAgentaTool(endpoint, auth, callRef, ...)`. **Workstream A adds the `if (spec.call)`
+  direct branch before the gateway fallback.**
+- `services/agent/src/tools/relay.ts` `startToolRelay` (`~159`): the host-side relay loop holds
+  the FULL specs in `specsByName` (`~169`) and looks each up by name (`~177`).
+  `executeRelayedTool` (`~118`) currently branches code vs gateway-callback. **The host can
+  branch on `spec.call` here with the sandbox unchanged** (the sandbox still posts name + args).
+
+## The reference-invoke seam (important nuance)
+
+- `api/oss/src/apis/fastapi/tools/router.py` `_call_workflow_tool` (`~1086-1188`): parses
+  `workflow.{slug}[.{version}]`, builds
+  `WorkflowServiceRequest(references={"workflow": Reference(slug, version)}, data=WorkflowServiceRequestData(inputs=arguments))`,
+  and calls `workflows_service.invoke_workflow(...)`.
+- `api/oss/src/core/workflows/service.py` `invoke_workflow` resolves the references to a revision
+  + service URL, then `_post_service_json(url=f"{service_url}/invoke", credentials=Secret {token}, payload=...)` (`~1952`).
+- `WorkflowServiceRequest` = `WorkflowInvokeRequest` in `sdks/python/agenta/sdk/models/workflows.py`
+  (`~234-300`): `references` (`{workflow|workflow_variant|environment|...: Reference}`), `data`
+  (`inputs`, `parameters`, `revision`), `version`, `session_id`.
+- `resolve_references_with_info` (`core/workflows/service.py ~269-364`) resolves by workflow,
+  variant, **environment** (deployment slot), or revision. This is what makes env/variant
+  targeting work, and it resolves at CALL time.
+
+**Where resolution happens (corrected).** Resolving slug/env/variant → a concrete revision
+needs server-side access, but that server side is the **agent service at resolve time**, not
+the API at call time. The service already calls the API to resolve gateway tools
+(`/tools/resolve`), inline embeds (`/workflows/revisions/resolve`), and secrets while it builds
+the run's tool specs. A reference resolves the same way: the service turns the reference into a
+concrete revision id and bakes it into the tool's `call.body`. The sidecar then POSTs the
+resolved revision + inputs directly to the invoke endpoint. There is no call-time resolution
+hop. The only thing the invoke endpoint does at call time is load and run that revision (the
+execution), plus enforce the recursion/budget guard.
+
+Decision (2026-06-27): always bake the resolved revision at resolve time, including for
+`environment` references. The sidecar is always invoked fresh by the service, so the service
+re-resolves on every invoke and the baked revision stays current; no call-time env resolution is
+needed. Revisit only if a long-lived sidecar ever calls itself with no service in front.
+
+**Args-placement wrinkle.** The model's tool args must land at `body.data.inputs` for an invoke,
+but at the body root for most platform ops. A flat merge is not enough. The `call` descriptor
+needs an `args_into` path (see `design.md`).
+
+## Platform-op catalog precedent
+
+- `api/oss/src/core/workflows/platform_catalog.py`: `_PLATFORM_WORKFLOWS` (`~58`) keys reserved
+  `_agenta.*` slugs to `{ "current": "vN", "versions": { "vN": <payload> } }`; `get_revision`
+  (`~139`) resolves current-or-pinned; deterministic `uuid5` ids (`~68`). Mirror this as a
+  `_PLATFORM_TOOLS` catalog: `op → { description?, method, path, schema_ref, default_permission }`.
+
+## Schema source (refines the openapi idea)
+
+- `CATALOG_TYPES` in `sdks/python/agenta/sdk/utils/types.py` (`~1392`) is built at import from
+  `Model.model_json_schema()` (dereferenced), and served by `GET /workflows/catalog/types/{type}`
+  (`api/oss/src/apis/fastapi/workflows/router.py ~429`, impl `resources/workflows/catalog.py ~222`).
+- Recommendation: expose each platform op's input schema through this in-process catalog
+  mechanism (a small `/tools/catalog/...` or reuse the types catalog), NOT by parsing
+  `/openapi.json` over HTTP. In-process pydantic `model_json_schema()` is the repo's existing
+  pattern and avoids coupling to route structure. This is the "probably other places" Mahmoud
+  expected. Descriptions still live in the SDK catalog; only the input schema is fetched.
+
+## Auth (already established earlier this session)
+
+- The sidecar holds the run's caller credential (`toolCallback.authorization`, derived per
+  request from the tracing context, `platform/connection.py ~64`). Direct calls reuse it.
+- The API mints a short-lived `Secret` JWT internally when forwarding to a runner
+  (`api/oss/src/middlewares/auth.py ~727`, `sign_secret_token ~914`). That stays server-side.
+  (A scoped/attenuated token is a known future hardening, out of scope here.)

--- a/docs/design/agent-workflows/projects/direct-call-tools/research.md
+++ b/docs/design/agent-workflows/projects/direct-call-tools/research.md
@@ -85,10 +85,53 @@ needs an `args_into` path (see `design.md`).
   `Model.model_json_schema()` (dereferenced), and served by `GET /workflows/catalog/types/{type}`
   (`api/oss/src/apis/fastapi/workflows/router.py ~429`, impl `resources/workflows/catalog.py ~222`).
 - Recommendation: expose each platform op's input schema through this in-process catalog
-  mechanism (a small `/tools/catalog/...` or reuse the types catalog), NOT by parsing
+  mechanism (reuse the `CATALOG_TYPES` types catalog via `x-ag-type-ref`), NOT by parsing
   `/openapi.json` over HTTP. In-process pydantic `model_json_schema()` is the repo's existing
   pattern and avoids coupling to route structure. This is the "probably other places" Mahmoud
   expected. Descriptions still live in the SDK catalog; only the input schema is fetched.
+
+## Workflow input/messages contract + output schemas (round 2)
+
+For the reference tool's `input_schema` (Mahmoud's comment on design.md:60):
+
+- A workflow's input contract is `WorkflowRequestData.inputs` (a dict). For a CHAT workflow the
+  messages ride at `inputs.messages` — `services/oss/src/agent/app.py` reads
+  `to_messages(messages or (inputs or {}).get("messages") or [])`. So `args_into: "data.inputs"`
+  is correct: the model's `{messages, ...vars}` becomes `data.inputs`.
+- `Message` (ag_type `message`) and `Messages` (ag_type `messages`) live in `CATALOG_TYPES`
+  (`sdks/python/agenta/sdk/utils/types.py`), served at `/workflows/catalog/types`. Workflows
+  reference them via `x-ag-type-ref: "messages"` — e.g. `services/oss/src/agent/schemas.py`
+  `AGENT_INPUTS_SCHEMA` does exactly this for the agent's own inputs.
+- A referenced workflow publishes its schemas: `/inspect` → `WorkflowInspectResponse.revision`
+  → `WorkflowRevisionData.schemas` = `JsonSchemas {parameters, inputs, outputs}`
+  (`sdks/python/agenta/sdk/models/workflows.py`). So the SDK reads `revision.schemas.inputs` at
+  resolve time to build the reference tool's `input_schema`, with no hand-authoring.
+- Output schemas: `JsonSchemas` also carries `outputs`, so a referenced workflow DOES have an
+  output contract. But tool definitions are input-schema-only across the harnesses (`ToolSpecBase`
+  has no `output_schema`; OpenAI/Anthropic function calling = input only). The only `outputSchema`
+  in the repo is AI-services `ToolDefinition` (`api/oss/src/core/ai_services/dtos.py`) and MCP's
+  optional field. Decision: no tool `output_schema` on the wire now; keep `schemas.outputs`
+  available for a later structured-output pass.
+
+## Catalog patterns to mirror (round 2)
+
+For the platform-op catalog (Mahmoud's comment on design.md:123, "look at the catalogs we have"):
+
+- **`CATALOG_TYPES`** (`utils/types.py` → `/workflows/catalog/types`): the schema-serving pattern;
+  reuse it for input schemas via `x-ag-type-ref`.
+- **Evaluators catalog** (`api/oss/src/resources/evaluators/evaluators.py`): a module-level list of
+  `{key, name, description, settings_template, ...}` — the closest "code-defined named ops with
+  metadata + schema" shape. Mirror this shape for the op table.
+- **`tools.agenta.find_capabilities`** (PR #4884, `api/oss/src/core/tools/discovery.py`):
+  `FIND_CAPABILITIES_CALL_REF / _DESCRIPTION / _INPUT_SCHEMA` + `POST /tools/discover`. The most
+  direct precedent — a reserved Agenta tool with description + input schema + endpoint. The
+  platform-op catalog generalizes it; `find_capabilities` is the first entry (its SDK emission is
+  the Deferred item in `plan.md`).
+- **`platform_catalog.py`** (`PlatformWorkflowCatalog`): CONFIRMED current and active (merged
+  `91db4611c4`), NOT being removed — but it is for platform *workflows/skills* (reserved `_agenta.*`
+  slugs, versioned, deterministic UUIDs, a virtual revision provider), heavier than platform ops
+  need. Mirror its spirit (code-defined, reserved-namespace, validated-at-import), not its
+  versioned-revision machinery.
 
 ## Auth (already established earlier this session)
 

--- a/docs/design/agent-workflows/projects/direct-call-tools/run-context.md
+++ b/docs/design/agent-workflows/projects/direct-call-tools/run-context.md
@@ -1,140 +1,63 @@
-# Run context propagation — boundaries, options, tradeoffs
+# Run context propagation — decision and mechanics
 
-Date: 2026-06-27 (rev 2 — corrected framing)
-Status: options for review. Re-asked Codex with the corrected framing (see the bottom). Open
-question; Mahmoud is weighing options.
+Date: 2026-06-27 (rev 3 — DECIDED)
+Status: **decided** — this is the design to implement. Options weighed and dropped are at the end.
 
-## What platform tools actually are (correcting a misframe)
+## Decision
 
-Platform tools are a **thin wrapper** that exposes **existing** Agenta API endpoints to the
-harness. No new endpoints, no hidden logic, no "operation" abstraction. A platform tool = an
-existing endpoint (method + path) + a description of how/when to use it + its input schema. The
-harness calls it with arguments; the sidecar makes the HTTP call with the caller credential.
+1. **Run context is delivered as part of the run/session.** The service computes a `runContext`
+   blob — the running workflow/variant, whether it is a draft, the latest revision, the variant
+   name, the current trace, the session_id (all of which it already holds; no API calls) — and
+   sends it on the `/run` request, **refreshed per turn**.
+2. **Tool definitions may declare a `bind` map.** A platform tool's catalog entry can bind a
+   run-context value into a specific request field. The runner fills bound fields at dispatch from
+   `runContext`, **server-side and hidden from the model**. This is how tools that act on the run's
+   own context work: "update myself" binds the agent's own `variant_id`; "annotate my trace" binds
+   the agent's own `trace_id`. The model supplies only the payload, never the identity.
+3. **The model does not read run context directly.** No MCP resource, no `get_context` tool, no
+   context file, no system-prompt injection. Run context is consumed **only** by `bind`.
 
-There is **no `update_own_workflow` tool and no `add_trace_annotation` tool.** Those were the
-rejected first-version idea (tools that wrap business logic; see the superseded banner on #4863's
-`custom-tools-design.md`). The real operations are done by calling the RAW endpoints:
+This keeps the boundary clean: the service owns and refreshes the context, the runner applies a
+declarative `bind` against it, each tool stays a thin wrapper over an existing endpoint, and the
+model can only act on its own run because the protected fields are bound, not chosen.
 
-- **"Annotate my trace"** is the existing annotation mechanism: create a new trace that carries
-  the annotation and **links** to the target trace. To annotate its OWN trace, the harness must
-  know its own `trace_id` (it is the link target). The endpoint minting a new linking trace is
-  correct, not a gap.
-- **"Update myself"** is commit-a-new-revision. The harness must know which variant it is working
-  on (and the variant name if it publishes).
+## Why (thin-wrapper recap)
 
-The harness learns HOW to compose these calls from a **skill** ("to update yourself: know your
-variant, then call the commit-revision tool with it; to annotate your trace, create a trace
-linking to your own trace_id"). The skill is the logic; the tools are raw endpoints; the model
-orchestrates.
+Platform tools are a thin wrapper over EXISTING Agenta endpoints — no new endpoints, no
+logic-wrapping tools. "Annotate my trace" is creating a new trace that links to my own trace;
+"update myself" is committing a revision to my own variant. The one thing such a tool needs that
+the model must not choose is the run's own identity — and `bind` supplies exactly that.
 
-## The real problem
+## Mechanics (summary; full detail and the implementation checklist in `design.md`)
 
-Because the tools are raw endpoints and the model orchestrates, **the harness must know its run
-context** to make the right calls: its own `trace_id`, the variant/revision it is running, the
-`session_id`. The service already has all of this with no API calls. The only question is **how
-to get that context into the harness.**
+- **Catalog entry:** `{ method, path, input_schema_ref, bind: { "<endpoint-field>": "$ctx.<key>" } }`.
+- **Resolve time (service):** strip each bound field from the model-visible input schema (and
+  `required`); emit `call.context = bind` on the resolved spec.
+- **`/run`:** carry the `runContext` blob, refreshed per turn.
+- **Dispatch (runner):** fill `call.context` from `runContext` and deep-set it into the body LAST
+  (after the model args and the static `body`), with path-conflict rejection, strict path parsing,
+  prototype-pollution-safe deep-set, and post-merge schema validation. Immutable identity
+  (`variant_id`) may instead be baked at resolve time into `call.body` (hybrid); mutable values
+  (`trace_id`, `latest_revision_id`) are always dispatch-time, plus a revision precondition on
+  commit so a stale value fails loudly.
 
-Two consequences of the thin-wrapper model:
+See `design.md` → "The `call` descriptor" and "Context binding" for the full mechanics.
 
-- **The model must SEE the context** (it constructs the calls), so "inject it server-side so the
-  model can't supply it" does not apply here. The model supplies its own trace/variant.
-- **Security is the normal endpoint permission on the caller credential**, project-scoped. The
-  harness acts as the caller within their project. "Own" is a convention the skill teaches, not a
-  server-enforced constraint — a thin wrapper has nowhere to enforce it, and it doesn't need to
-  (the credential already bounds the blast radius to the project).
+## Considered but not used (do NOT implement — recorded so they are not re-proposed)
 
-## System boundaries (who does what)
+- **MCP resource for run context** — semantically clean (data, not an action) but
+  harness-dependent (Pi/Codex vary), and it adds a model-read path we do not need once context is
+  consumed only by `bind`.
+- **`get_context` static-return tool** — a tool that returns embedded JSON. Rejected as a
+  canonical primitive (data is not an action; it muddies the runner's `callback / code / client`
+  set) and unnecessary since the model does not read context directly.
+- **Context file in the run workspace** — out-of-band; not needed.
+- **System-prompt preamble** — static, cannot refresh per turn, bloats the prompt.
+- **AGENTS.md injection** — we do not mutate the user's AGENTS.md.
+- **"Own is a convention" (model supplies its own variant/trace)** — rejected: project-scoped auth
+  does not stop within-project lateral movement, so protected self-identity is bound server-side
+  instead.
 
-- **Service**: knows the run context; declares which endpoints to expose as platform tools (with
-  descriptions + schemas); delivers the context to the harness (the mechanism is the open
-  question below); ships the skill(s) that teach the harness how to compose the calls.
-- **Sidecar / runner**: materializes the tools, exposes the context, dispatches the endpoint
-  calls (direct, with the caller credential). Generic — a small canonical primitive set.
-- **SDK local backend** (claude / pi / codex in a folder, where we generate the MCPs): same, in
-  one process.
-- **API endpoints**: the existing endpoints, unchanged, enforcing their normal permissions.
-
-## Options for delivering the context to the harness
-
-1. **AGENTS.md injection** — rejected. We do not want to mutate the user's AGENTS.md.
-2. **`get_context` tool, hard-coded in the sidecar** — always present; the service flags it on
-   per session. Works, but "always there" bakes a specific tool into the generic runner and is
-   not generalizable.
-3. **`get_context` as a new "static-return" tool type** (Mahmoud's lean) — like a code tool, but
-   instead of running code it returns a pre-defined JSON. The service declares the tool and embeds
-   the run-context JSON; the sidecar materializes a tool that just returns it. The harness calls
-   `get_context`, reads its trace/variant/session, then calls the endpoint-wrapper tools. General
-   (a tool type the service declares per session); no specific logic baked into the runner.
-4. **Run context as an MCP *resource*** (not listed before) — MCP separates *resources*
-   (read-only data) from *tools* (actions). Run context is data, so a `run-context` MCP resource
-   is the semantically correct shape, and it fits the "we generate the MCPs" local-backend model.
-   Caveat: depends on the harness supporting MCP resources (Claude does; Pi/Codex vary).
-5. **A context file in the run workspace** (not listed before) — the sidecar/SDK writes
-   `.agenta/run-context.json` into the run cwd; the skill tells the harness to read it. No
-   protocol support needed; fits the folder-based local backend especially. Out-of-band (the model
-   has to be told to read it).
-6. **System-prompt preamble** — the service prepends the context to the agent's system prompt.
-   Universal, no round-trip, but static (a multi-turn `trace_id` can change) and bloats context.
-
-## Tradeoffs
-
-| | Universal across harnesses | New primitive | Refreshable per turn | local-backend fit | Boundary cleanliness |
-|---|---|---|---|---|---|
-| 2 hard-coded tool | yes | none (baked) | yes | medium | bakes a specific tool into the runner |
-| 3 static-return tool | yes | +1 (static) | yes (re-declared) | strong | clean (service declares it) |
-| 4 MCP resource | harness-dependent | uses MCP | yes | strong (we author the MCPs) | cleanest semantically |
-| 5 context file | yes | none | yes (rewrite) | strong (folders) | out-of-band |
-| 6 system prompt | yes | none | weak | medium | simple but static |
-
-## Recommendation (after the Codex rev-2 review)
-
-Codex reframed this usefully: **split run context by trust, and treat it as data, not a tool.**
-
-1. **Protected self-identity (the agent's own variant / own trace): server-bind it.** For a
-   self-targeting op — "update myself" (commit to my own variant), "annotate my trace" — the
-   identity is **locked into `call.body` at resolve time and omitted from the model-visible input
-   schema.** The model supplies only the payload (the new config / the annotation content), never
-   which variant or trace. Still a thin wrapper over the existing endpoint, just with the identity
-   fixed. This removes the real risk Codex flagged: project-scoped auth stops cross-project access
-   but NOT within-project lateral movement (a model retargeting a different variant/trace in the
-   same project). So we do **not** rely on "own is convention" for these fields; we bind them.
-2. **General model-readable context (what the model needs to reason/orchestrate): run-level data,
-   delivered as an MCP resource (primary) with a context-file fallback.** It rides the run
-   contract (service → runner metadata), not a tool. Codex is against making a `get_context`
-   static-return tool a canonical primitive — it is a tool-shaped escape hatch for data and
-   muddies the runner's `callback / code / client` set. Keep the static-return tool only as a
-   temporary per-harness compatibility shim if a harness supports neither resources nor a file.
-3. **Refresh semantics (Codex P3): refresh per turn.** `latest_revision` changes mid-run (after a
-   commit), so a once-at-start snapshot goes stale. Refresh the context each turn, or — better for
-   commits — have the commit endpoint take an expected-revision precondition so a stale value
-   fails loudly instead of clobbering.
-
-Net: the sensitive path needs no model-visible delivery at all (server-bound); the delivery
-question (resource vs file) only covers non-authority context the model reads, and we pick MCP
-resource + file fallback.
-
-### The one decision for Mahmoud
-
-You framed it as "the model supplies its own trace/variant; own is a convention." Codex and I
-land on **server-binding the self-identity fields** for the sensitive ops instead (locked in
-`call.body`, hidden from the model), because convention does not stop within-project lateral
-movement. It is still a thin wrapper. Confirm server-bind, or say why convention is enough.
-
-## Codex review (rev 2, xhigh)
-
-- **Verdict: pass with conditions.** The thin-wrapper framing is coherent; the risk is *where run
-  context is trusted and how that trust is enforced*, not the wrapper idea.
-- **P1 — reconcile the docs:** run-context.md presented an open matrix while design.md asserted a
-  direction. (Resolved: the recommendation above is the direction; design.md matches.)
-- **P1 — server-bind protected fields:** if a platform endpoint schema exposes
-  variant/trace/revision/session and they are not forced server-side, the model can retarget
-  effects within the project. Project auth limits blast radius, not within-project movement.
-- **P2 — a static-return tool is not a canonical primitive** (data, not action). Resource / file /
-  payload is the right shape; static tool only as a compat shim.
-- **P2 — if MCP resource, define a fallback** for harnesses without resource support (Pi/Codex
-  vary), or portability regresses.
-- **P3 — decide refresh semantics** for mutable context (`latest_revision` after a commit):
-  snapshot-at-start vs per-turn, documented; or an expected-revision precondition on commit.
-- **Q4 — design mostly right:** the `call` descriptor + allowlisted method/path + `args_into` +
-  the `/tools/call` shrink is the right factoring for the local backend; keep context provisioning
-  OUTSIDE primitive dispatch (a service→runner metadata path), not an executable tool.
+_Provenance: the within-project lateral-movement rationale and the merge-hardening list came from
+the Codex (xhigh) reviews; the delivery decision (run/session + `bind`, nothing else) is
+Mahmoud's._

--- a/docs/design/agent-workflows/projects/direct-call-tools/run-context.md
+++ b/docs/design/agent-workflows/projects/direct-call-tools/run-context.md
@@ -1,0 +1,198 @@
+# Run context propagation — boundaries, options, tradeoffs
+
+Date: 2026-06-27
+Status: Codex-reviewed. Revised recommendation: **Option C** (run-level context channel +
+server-side injection of protected fields). One decision left for Mahmoud (A vs C). See the
+bottom.
+
+## Problem
+
+Some tools need the run's own context:
+
+- `update_own_workflow` needs the running agent's variant — and the business state around it:
+  the current revision, whether it is a **draft**, and if so the **latest revision** and the
+  **variant name**, because an "update" appends a new revision to the last variant.
+- `add_trace_annotation` needs the **current trace_id** (and span).
+- Both (and others) may want the **session_id**.
+
+The service already has all of this from the inbound request and `RunningContext.revision` — no
+API calls needed. The question is not "how does the service get it" but **how it reaches the
+tool, and where the boundaries sit**. The tools take `trace_id` / `workflow_variant_id` as
+inputs; we just need to deliver the current run context to the place that fills them.
+
+## System boundaries (who does what)
+
+This is the part that matters most. Keep responsibilities clean:
+
+- **Service** (`services/oss/src/agent/`): owns business context. It computes the run-context
+  blob (it has revision, draft-state, latest variant/revision, variant name, session_id, trace).
+  It resolves tools. It hands **both** the resolved tools and the run context to the sidecar on
+  `/run`. All business logic lives here.
+- **Sidecar / runner** (`services/agent/`): generic. It materializes tools from config and
+  dispatches calls. It **holds** the run-context blob but does **not** compute or interpret it.
+  Its behavior reduces to a small set of canonical primitives (below).
+- **SDK local backend** (future: claude / pi / codex in a folder): plays **both** roles in one
+  process — computes the run context (it has `RunningContext`) and materializes/dispatches in a
+  working folder. Same boundaries, collapsed. The design must not assume a separate sidecar.
+- **API endpoints**: consume the context (trace_id to link an annotation, variant_id to commit a
+  revision) and enforce permissions on the caller credential.
+
+## The canonical sidecar primitives (the generality that matters)
+
+The sidecar's tool behavior should reduce to a **small, canonical set** of executors, so any
+backend is built by generating config that maps onto them — not by adding bespoke logic per
+backend. Today's set:
+
+1. **Callback** (`ToolCallback`): the call is POSTed back to Agenta — gateway via `/tools/call`,
+   or direct via `call.path`. The canonical "call back to the platform" primitive.
+2. **Code**: run code in the sandbox subprocess.
+3. **Client**: browser-fulfilled across a turn boundary.
+4. **MCP-delivered**: tools surfaced through an MCP server (stdio/http) the sidecar wires up.
+
+Run context forces a choice that is really about this set: **add one new canonical primitive (a
+"static" tool that returns embedded data), or extend the callback primitive with a
+context-injection step.** That choice, not the field list, is the real design decision, because
+the localBackend reuses whichever primitives exist.
+
+## The run-context payload (what the service computes)
+
+```
+RunContext {
+  session_id: str
+  trace: { trace_id, span_id }
+  workflow: {
+    artifact_id, variant_id, variant_name,
+    revision_id, version,
+    is_draft: bool,
+    latest_revision_id            // the revision an "update" would append onto
+  }
+}
+```
+
+`project_id` / `user_id` are not included — they ride the caller credential.
+
+## Options
+
+### Option A — `get_run_context` as a static-output tool (a new canonical primitive)
+
+The service computes the run context and embeds it in a `get_run_context` tool **definition**
+(a new tool type whose `output` is a pre-built JSON). The sidecar materializes a tool that just
+returns that JSON. The model calls `get_run_context`, reads `trace_id` / `variant_id`, and passes
+them as inputs to `update_own_workflow` / `add_trace_annotation`.
+
+- **Boundaries:** clean. Service computes + embeds; sidecar returns-constant; model forwards;
+  endpoint consumes + permission-checks.
+- **Generality:** adds exactly one new canonical primitive (static-return), simple and reusable.
+  Strong localBackend fit — the SDK materializes the same static tool in a folder.
+- **Security:** the model holds the context and re-supplies it as args, so it **could** pass a
+  different trace_id / variant_id. Mitigation: endpoints must enforce ownership/scoping on the
+  **caller credential**, not trust the arg (e.g. "you may only commit to variants you own").
+- **Cost:** one extra model round-trip (read context, then call the edit tool); the model sees
+  its own context (transparent, sometimes useful).
+
+### Option B — the runner injects context into the call body (extend the callback primitive)
+
+The service passes the run context as a `runContext` field on `/run`. Each direct tool's `call`
+gains a `context` map (`{ body-path -> run-context-key }`). The runner deep-sets those at
+dispatch from `runContext`. The model never sees or sets them.
+
+- **Boundaries:** service computes; runner injects; endpoint consumes.
+- **Generality:** no new primitive, but the callback primitive grows an injection step every
+  backend must implement.
+- **Security:** strong — injected values override model args, so the model cannot spoof its trace
+  or variant.
+- **Cost:** no extra round-trip; but the model cannot reference context it cannot see (fine for
+  the default-current case, limiting if a tool wants the model to choose).
+
+### Option C — hybrid
+
+Static `get_run_context` so the model **can** read context when it needs to reason, **plus**
+injection (Option B) for the security-sensitive defaults (own-variant, current-trace). Best
+coverage, most machinery.
+
+### Option D — standard propagation (traceparent header + baggage)
+
+The runner propagates `traceparent` (+ baggage) on outbound calls; endpoints derive trace/session
+server-side. Idiomatic for trace, but endpoint-specific and does **not** cover identity
+(variant/draft-state), so it is at best a complement, not a full answer.
+
+## Tradeoff summary
+
+| | Boundaries | New sidecar primitive | Spoof-resistance | Extra round-trip | localBackend fit |
+|---|---|---|---|---|---|
+| A static tool | cleanest | +1 (static) | weak (mitigate at endpoint) | yes | strong |
+| B inject | clean | none (callback grows) | strong | no | medium |
+| C hybrid | clean | +1 | strong | optional | strong |
+| D propagate | trace-only | none | n/a | no | partial |
+
+## Recommendation (revised after the Codex review)
+
+Lead with **Option C / B: run context is a run-level channel, and protected fields are bound
+server-side, not model-owned.** Codex pushed back hard on Option A as the lead, and the argument
+holds:
+
+- **A is a boundary category-error.** A static-return tool is a "what the model can see" channel,
+  not a tool-execution primitive. Run context belongs to the **`run` contract** — a run-level
+  `runContext` payload on `/run` (trace, workflow lineage, session_id) — not to tool behavior.
+  Modeling it as a tool drifts the boundary.
+- **Generality actually favors B/C, not A.** B/C add NO new canonical primitive: run context is a
+  run-level field plus an injection step inside the existing callback primitive. A would add a
+  whole new "static" primitive. So the "small canonical set" goal is *better* served by B/C — the
+  opposite of the original lean.
+- **Security:** with A, identity/trace become model-supplied args (spoofable). An endpoint check
+  is necessary but not sufficient (see the security section below).
+
+So: put `runContext` on the run request; the runner (or the SDK local backend) binds the
+protected fields (`trace_id`, `variant_id`, `latest_revision_id`) into the call server-side; the
+model cannot override them. Keep a `get_run_context` static disclosure ONLY if the product needs
+the model to *reason about* its context, and only for non-authority fields (`is_draft`,
+`variant_name`) — never as the trust anchor for a commit or annotation.
+
+**The decision for Mahmoud:** you leaned A (static tool) for boundary cleanliness; Codex and I
+land on **C** (run-level channel + injection) as both cleaner and safer. Confirm C, or say why A.
+
+## localBackend angle
+
+For a localBackend (claude / pi / codex running in a folder, with MCPs we generate), the run
+context must be produced by the in-process SDK and exposed through the **same** primitive as the
+sidecar uses — a static tool (Option A) or an injected callback (Option B). Whichever we pick
+becomes a primitive the localBackend materializer reuses verbatim, which is exactly why the
+"small canonical set" constraint drives the choice.
+
+## Security and guardrails (from the Codex review)
+
+These apply regardless of which option we pick, and several are net-new findings:
+
+- **Confused-deputy on the variant.** If the model can name `workflow_variant_id`, the commit
+  endpoint must verify it is the run-owned target. Today workflow-commit is gated by a
+  request-level permission (`EDIT_WORKFLOWS`), which does NOT encode "owned-variant" semantics. So
+  `update_own_workflow` must bind the owning variant server-side (run context), and/or the
+  endpoint must enforce ownership — not just the generic permission.
+- **Replay/race on `latest_revision_id`.** A model-supplied "latest revision" is staleness-prone.
+  The commit endpoint needs an expected-revision precondition (optimistic-lock / CAS), not a blind
+  append.
+- **Trace integrity.** Model-supplied trace IDs must be ignored/overridden by the server's run
+  context, or a model can redirect annotations onto another trace.
+- **`add_trace_annotation` has no backend today.** `/api/annotations/` currently always mints a
+  NEW trace link (`uuid4`) and does not consume a supplied trace id
+  (`api/oss/src/core/annotations/service.py`). So attaching to the *active* trace is a real
+  endpoint to build, not just a tool to wire.
+- **The `call` descriptor is an untrusted HTTP dispatcher.** Treat it as a transport guardrail:
+  enforce a method allowlist (`GET`/`POST`), a relative-path regex, an `/api/...` prefix check,
+  and origin binding to the single trusted Agenta host (already derived from
+  `toolCallback.endpoint`). This is now also noted in `design.md`.
+
+## Codex verdict (xhigh, gpt-5.3-codex-spark)
+
+- **Verdict:** do not ship Option A alone; recommended posture is **Option C** (bind
+  security-sensitive fields server-side; optional read-only visibility). The boundary direction
+  (service resolves + supplies the call; sidecar executes) is right.
+- **Architecture:** boundaries mostly correct; the `call` descriptor is the right seam if
+  implemented as untrusted-input parsing with strict validation. Direct-call support needs
+  synchronized changes in BOTH the direct and the relayed (Daytona) paths. Removing the
+  `workflow.*` parse from `/tools/call` must be a deliberate migration, not a silent change.
+- **Priorities:** (1) endpoint-side hardening for sensitive ops (bind run-owned ids; revision
+  precondition) — required regardless of option; (2) a run-level context channel for protected
+  injection; (3) a concrete `add_trace_annotation` backend that attaches to the active trace;
+  (4) a strict `call` parser/validator with malformed-input tests; (5) `get_run_context` only as
+  read-only metadata if the product needs model visibility.

--- a/docs/design/agent-workflows/projects/direct-call-tools/run-context.md
+++ b/docs/design/agent-workflows/projects/direct-call-tools/run-context.md
@@ -1,198 +1,140 @@
 # Run context propagation — boundaries, options, tradeoffs
 
-Date: 2026-06-27
-Status: Codex-reviewed. Revised recommendation: **Option C** (run-level context channel +
-server-side injection of protected fields). One decision left for Mahmoud (A vs C). See the
-bottom.
+Date: 2026-06-27 (rev 2 — corrected framing)
+Status: options for review. Re-asked Codex with the corrected framing (see the bottom). Open
+question; Mahmoud is weighing options.
 
-## Problem
+## What platform tools actually are (correcting a misframe)
 
-Some tools need the run's own context:
+Platform tools are a **thin wrapper** that exposes **existing** Agenta API endpoints to the
+harness. No new endpoints, no hidden logic, no "operation" abstraction. A platform tool = an
+existing endpoint (method + path) + a description of how/when to use it + its input schema. The
+harness calls it with arguments; the sidecar makes the HTTP call with the caller credential.
 
-- `update_own_workflow` needs the running agent's variant — and the business state around it:
-  the current revision, whether it is a **draft**, and if so the **latest revision** and the
-  **variant name**, because an "update" appends a new revision to the last variant.
-- `add_trace_annotation` needs the **current trace_id** (and span).
-- Both (and others) may want the **session_id**.
+There is **no `update_own_workflow` tool and no `add_trace_annotation` tool.** Those were the
+rejected first-version idea (tools that wrap business logic; see the superseded banner on #4863's
+`custom-tools-design.md`). The real operations are done by calling the RAW endpoints:
 
-The service already has all of this from the inbound request and `RunningContext.revision` — no
-API calls needed. The question is not "how does the service get it" but **how it reaches the
-tool, and where the boundaries sit**. The tools take `trace_id` / `workflow_variant_id` as
-inputs; we just need to deliver the current run context to the place that fills them.
+- **"Annotate my trace"** is the existing annotation mechanism: create a new trace that carries
+  the annotation and **links** to the target trace. To annotate its OWN trace, the harness must
+  know its own `trace_id` (it is the link target). The endpoint minting a new linking trace is
+  correct, not a gap.
+- **"Update myself"** is commit-a-new-revision. The harness must know which variant it is working
+  on (and the variant name if it publishes).
+
+The harness learns HOW to compose these calls from a **skill** ("to update yourself: know your
+variant, then call the commit-revision tool with it; to annotate your trace, create a trace
+linking to your own trace_id"). The skill is the logic; the tools are raw endpoints; the model
+orchestrates.
+
+## The real problem
+
+Because the tools are raw endpoints and the model orchestrates, **the harness must know its run
+context** to make the right calls: its own `trace_id`, the variant/revision it is running, the
+`session_id`. The service already has all of this with no API calls. The only question is **how
+to get that context into the harness.**
+
+Two consequences of the thin-wrapper model:
+
+- **The model must SEE the context** (it constructs the calls), so "inject it server-side so the
+  model can't supply it" does not apply here. The model supplies its own trace/variant.
+- **Security is the normal endpoint permission on the caller credential**, project-scoped. The
+  harness acts as the caller within their project. "Own" is a convention the skill teaches, not a
+  server-enforced constraint — a thin wrapper has nowhere to enforce it, and it doesn't need to
+  (the credential already bounds the blast radius to the project).
 
 ## System boundaries (who does what)
 
-This is the part that matters most. Keep responsibilities clean:
+- **Service**: knows the run context; declares which endpoints to expose as platform tools (with
+  descriptions + schemas); delivers the context to the harness (the mechanism is the open
+  question below); ships the skill(s) that teach the harness how to compose the calls.
+- **Sidecar / runner**: materializes the tools, exposes the context, dispatches the endpoint
+  calls (direct, with the caller credential). Generic — a small canonical primitive set.
+- **SDK local backend** (claude / pi / codex in a folder, where we generate the MCPs): same, in
+  one process.
+- **API endpoints**: the existing endpoints, unchanged, enforcing their normal permissions.
 
-- **Service** (`services/oss/src/agent/`): owns business context. It computes the run-context
-  blob (it has revision, draft-state, latest variant/revision, variant name, session_id, trace).
-  It resolves tools. It hands **both** the resolved tools and the run context to the sidecar on
-  `/run`. All business logic lives here.
-- **Sidecar / runner** (`services/agent/`): generic. It materializes tools from config and
-  dispatches calls. It **holds** the run-context blob but does **not** compute or interpret it.
-  Its behavior reduces to a small set of canonical primitives (below).
-- **SDK local backend** (future: claude / pi / codex in a folder): plays **both** roles in one
-  process — computes the run context (it has `RunningContext`) and materializes/dispatches in a
-  working folder. Same boundaries, collapsed. The design must not assume a separate sidecar.
-- **API endpoints**: consume the context (trace_id to link an annotation, variant_id to commit a
-  revision) and enforce permissions on the caller credential.
+## Options for delivering the context to the harness
 
-## The canonical sidecar primitives (the generality that matters)
+1. **AGENTS.md injection** — rejected. We do not want to mutate the user's AGENTS.md.
+2. **`get_context` tool, hard-coded in the sidecar** — always present; the service flags it on
+   per session. Works, but "always there" bakes a specific tool into the generic runner and is
+   not generalizable.
+3. **`get_context` as a new "static-return" tool type** (Mahmoud's lean) — like a code tool, but
+   instead of running code it returns a pre-defined JSON. The service declares the tool and embeds
+   the run-context JSON; the sidecar materializes a tool that just returns it. The harness calls
+   `get_context`, reads its trace/variant/session, then calls the endpoint-wrapper tools. General
+   (a tool type the service declares per session); no specific logic baked into the runner.
+4. **Run context as an MCP *resource*** (not listed before) — MCP separates *resources*
+   (read-only data) from *tools* (actions). Run context is data, so a `run-context` MCP resource
+   is the semantically correct shape, and it fits the "we generate the MCPs" local-backend model.
+   Caveat: depends on the harness supporting MCP resources (Claude does; Pi/Codex vary).
+5. **A context file in the run workspace** (not listed before) — the sidecar/SDK writes
+   `.agenta/run-context.json` into the run cwd; the skill tells the harness to read it. No
+   protocol support needed; fits the folder-based local backend especially. Out-of-band (the model
+   has to be told to read it).
+6. **System-prompt preamble** — the service prepends the context to the agent's system prompt.
+   Universal, no round-trip, but static (a multi-turn `trace_id` can change) and bloats context.
 
-The sidecar's tool behavior should reduce to a **small, canonical set** of executors, so any
-backend is built by generating config that maps onto them — not by adding bespoke logic per
-backend. Today's set:
+## Tradeoffs
 
-1. **Callback** (`ToolCallback`): the call is POSTed back to Agenta — gateway via `/tools/call`,
-   or direct via `call.path`. The canonical "call back to the platform" primitive.
-2. **Code**: run code in the sandbox subprocess.
-3. **Client**: browser-fulfilled across a turn boundary.
-4. **MCP-delivered**: tools surfaced through an MCP server (stdio/http) the sidecar wires up.
-
-Run context forces a choice that is really about this set: **add one new canonical primitive (a
-"static" tool that returns embedded data), or extend the callback primitive with a
-context-injection step.** That choice, not the field list, is the real design decision, because
-the localBackend reuses whichever primitives exist.
-
-## The run-context payload (what the service computes)
-
-```
-RunContext {
-  session_id: str
-  trace: { trace_id, span_id }
-  workflow: {
-    artifact_id, variant_id, variant_name,
-    revision_id, version,
-    is_draft: bool,
-    latest_revision_id            // the revision an "update" would append onto
-  }
-}
-```
-
-`project_id` / `user_id` are not included — they ride the caller credential.
-
-## Options
-
-### Option A — `get_run_context` as a static-output tool (a new canonical primitive)
-
-The service computes the run context and embeds it in a `get_run_context` tool **definition**
-(a new tool type whose `output` is a pre-built JSON). The sidecar materializes a tool that just
-returns that JSON. The model calls `get_run_context`, reads `trace_id` / `variant_id`, and passes
-them as inputs to `update_own_workflow` / `add_trace_annotation`.
-
-- **Boundaries:** clean. Service computes + embeds; sidecar returns-constant; model forwards;
-  endpoint consumes + permission-checks.
-- **Generality:** adds exactly one new canonical primitive (static-return), simple and reusable.
-  Strong localBackend fit — the SDK materializes the same static tool in a folder.
-- **Security:** the model holds the context and re-supplies it as args, so it **could** pass a
-  different trace_id / variant_id. Mitigation: endpoints must enforce ownership/scoping on the
-  **caller credential**, not trust the arg (e.g. "you may only commit to variants you own").
-- **Cost:** one extra model round-trip (read context, then call the edit tool); the model sees
-  its own context (transparent, sometimes useful).
-
-### Option B — the runner injects context into the call body (extend the callback primitive)
-
-The service passes the run context as a `runContext` field on `/run`. Each direct tool's `call`
-gains a `context` map (`{ body-path -> run-context-key }`). The runner deep-sets those at
-dispatch from `runContext`. The model never sees or sets them.
-
-- **Boundaries:** service computes; runner injects; endpoint consumes.
-- **Generality:** no new primitive, but the callback primitive grows an injection step every
-  backend must implement.
-- **Security:** strong — injected values override model args, so the model cannot spoof its trace
-  or variant.
-- **Cost:** no extra round-trip; but the model cannot reference context it cannot see (fine for
-  the default-current case, limiting if a tool wants the model to choose).
-
-### Option C — hybrid
-
-Static `get_run_context` so the model **can** read context when it needs to reason, **plus**
-injection (Option B) for the security-sensitive defaults (own-variant, current-trace). Best
-coverage, most machinery.
-
-### Option D — standard propagation (traceparent header + baggage)
-
-The runner propagates `traceparent` (+ baggage) on outbound calls; endpoints derive trace/session
-server-side. Idiomatic for trace, but endpoint-specific and does **not** cover identity
-(variant/draft-state), so it is at best a complement, not a full answer.
-
-## Tradeoff summary
-
-| | Boundaries | New sidecar primitive | Spoof-resistance | Extra round-trip | localBackend fit |
+| | Universal across harnesses | New primitive | Refreshable per turn | local-backend fit | Boundary cleanliness |
 |---|---|---|---|---|---|
-| A static tool | cleanest | +1 (static) | weak (mitigate at endpoint) | yes | strong |
-| B inject | clean | none (callback grows) | strong | no | medium |
-| C hybrid | clean | +1 | strong | optional | strong |
-| D propagate | trace-only | none | n/a | no | partial |
+| 2 hard-coded tool | yes | none (baked) | yes | medium | bakes a specific tool into the runner |
+| 3 static-return tool | yes | +1 (static) | yes (re-declared) | strong | clean (service declares it) |
+| 4 MCP resource | harness-dependent | uses MCP | yes | strong (we author the MCPs) | cleanest semantically |
+| 5 context file | yes | none | yes (rewrite) | strong (folders) | out-of-band |
+| 6 system prompt | yes | none | weak | medium | simple but static |
 
-## Recommendation (revised after the Codex review)
+## Recommendation (after the Codex rev-2 review)
 
-Lead with **Option C / B: run context is a run-level channel, and protected fields are bound
-server-side, not model-owned.** Codex pushed back hard on Option A as the lead, and the argument
-holds:
+Codex reframed this usefully: **split run context by trust, and treat it as data, not a tool.**
 
-- **A is a boundary category-error.** A static-return tool is a "what the model can see" channel,
-  not a tool-execution primitive. Run context belongs to the **`run` contract** — a run-level
-  `runContext` payload on `/run` (trace, workflow lineage, session_id) — not to tool behavior.
-  Modeling it as a tool drifts the boundary.
-- **Generality actually favors B/C, not A.** B/C add NO new canonical primitive: run context is a
-  run-level field plus an injection step inside the existing callback primitive. A would add a
-  whole new "static" primitive. So the "small canonical set" goal is *better* served by B/C — the
-  opposite of the original lean.
-- **Security:** with A, identity/trace become model-supplied args (spoofable). An endpoint check
-  is necessary but not sufficient (see the security section below).
+1. **Protected self-identity (the agent's own variant / own trace): server-bind it.** For a
+   self-targeting op — "update myself" (commit to my own variant), "annotate my trace" — the
+   identity is **locked into `call.body` at resolve time and omitted from the model-visible input
+   schema.** The model supplies only the payload (the new config / the annotation content), never
+   which variant or trace. Still a thin wrapper over the existing endpoint, just with the identity
+   fixed. This removes the real risk Codex flagged: project-scoped auth stops cross-project access
+   but NOT within-project lateral movement (a model retargeting a different variant/trace in the
+   same project). So we do **not** rely on "own is convention" for these fields; we bind them.
+2. **General model-readable context (what the model needs to reason/orchestrate): run-level data,
+   delivered as an MCP resource (primary) with a context-file fallback.** It rides the run
+   contract (service → runner metadata), not a tool. Codex is against making a `get_context`
+   static-return tool a canonical primitive — it is a tool-shaped escape hatch for data and
+   muddies the runner's `callback / code / client` set. Keep the static-return tool only as a
+   temporary per-harness compatibility shim if a harness supports neither resources nor a file.
+3. **Refresh semantics (Codex P3): refresh per turn.** `latest_revision` changes mid-run (after a
+   commit), so a once-at-start snapshot goes stale. Refresh the context each turn, or — better for
+   commits — have the commit endpoint take an expected-revision precondition so a stale value
+   fails loudly instead of clobbering.
 
-So: put `runContext` on the run request; the runner (or the SDK local backend) binds the
-protected fields (`trace_id`, `variant_id`, `latest_revision_id`) into the call server-side; the
-model cannot override them. Keep a `get_run_context` static disclosure ONLY if the product needs
-the model to *reason about* its context, and only for non-authority fields (`is_draft`,
-`variant_name`) — never as the trust anchor for a commit or annotation.
+Net: the sensitive path needs no model-visible delivery at all (server-bound); the delivery
+question (resource vs file) only covers non-authority context the model reads, and we pick MCP
+resource + file fallback.
 
-**The decision for Mahmoud:** you leaned A (static tool) for boundary cleanliness; Codex and I
-land on **C** (run-level channel + injection) as both cleaner and safer. Confirm C, or say why A.
+### The one decision for Mahmoud
 
-## localBackend angle
+You framed it as "the model supplies its own trace/variant; own is a convention." Codex and I
+land on **server-binding the self-identity fields** for the sensitive ops instead (locked in
+`call.body`, hidden from the model), because convention does not stop within-project lateral
+movement. It is still a thin wrapper. Confirm server-bind, or say why convention is enough.
 
-For a localBackend (claude / pi / codex running in a folder, with MCPs we generate), the run
-context must be produced by the in-process SDK and exposed through the **same** primitive as the
-sidecar uses — a static tool (Option A) or an injected callback (Option B). Whichever we pick
-becomes a primitive the localBackend materializer reuses verbatim, which is exactly why the
-"small canonical set" constraint drives the choice.
+## Codex review (rev 2, xhigh)
 
-## Security and guardrails (from the Codex review)
-
-These apply regardless of which option we pick, and several are net-new findings:
-
-- **Confused-deputy on the variant.** If the model can name `workflow_variant_id`, the commit
-  endpoint must verify it is the run-owned target. Today workflow-commit is gated by a
-  request-level permission (`EDIT_WORKFLOWS`), which does NOT encode "owned-variant" semantics. So
-  `update_own_workflow` must bind the owning variant server-side (run context), and/or the
-  endpoint must enforce ownership — not just the generic permission.
-- **Replay/race on `latest_revision_id`.** A model-supplied "latest revision" is staleness-prone.
-  The commit endpoint needs an expected-revision precondition (optimistic-lock / CAS), not a blind
-  append.
-- **Trace integrity.** Model-supplied trace IDs must be ignored/overridden by the server's run
-  context, or a model can redirect annotations onto another trace.
-- **`add_trace_annotation` has no backend today.** `/api/annotations/` currently always mints a
-  NEW trace link (`uuid4`) and does not consume a supplied trace id
-  (`api/oss/src/core/annotations/service.py`). So attaching to the *active* trace is a real
-  endpoint to build, not just a tool to wire.
-- **The `call` descriptor is an untrusted HTTP dispatcher.** Treat it as a transport guardrail:
-  enforce a method allowlist (`GET`/`POST`), a relative-path regex, an `/api/...` prefix check,
-  and origin binding to the single trusted Agenta host (already derived from
-  `toolCallback.endpoint`). This is now also noted in `design.md`.
-
-## Codex verdict (xhigh, gpt-5.3-codex-spark)
-
-- **Verdict:** do not ship Option A alone; recommended posture is **Option C** (bind
-  security-sensitive fields server-side; optional read-only visibility). The boundary direction
-  (service resolves + supplies the call; sidecar executes) is right.
-- **Architecture:** boundaries mostly correct; the `call` descriptor is the right seam if
-  implemented as untrusted-input parsing with strict validation. Direct-call support needs
-  synchronized changes in BOTH the direct and the relayed (Daytona) paths. Removing the
-  `workflow.*` parse from `/tools/call` must be a deliberate migration, not a silent change.
-- **Priorities:** (1) endpoint-side hardening for sensitive ops (bind run-owned ids; revision
-  precondition) — required regardless of option; (2) a run-level context channel for protected
-  injection; (3) a concrete `add_trace_annotation` backend that attaches to the active trace;
-  (4) a strict `call` parser/validator with malformed-input tests; (5) `get_run_context` only as
-  read-only metadata if the product needs model visibility.
+- **Verdict: pass with conditions.** The thin-wrapper framing is coherent; the risk is *where run
+  context is trusted and how that trust is enforced*, not the wrapper idea.
+- **P1 — reconcile the docs:** run-context.md presented an open matrix while design.md asserted a
+  direction. (Resolved: the recommendation above is the direction; design.md matches.)
+- **P1 — server-bind protected fields:** if a platform endpoint schema exposes
+  variant/trace/revision/session and they are not forced server-side, the model can retarget
+  effects within the project. Project auth limits blast radius, not within-project movement.
+- **P2 — a static-return tool is not a canonical primitive** (data, not action). Resource / file /
+  payload is the right shape; static tool only as a compat shim.
+- **P2 — if MCP resource, define a fallback** for harnesses without resource support (Pi/Codex
+  vary), or portability regresses.
+- **P3 — decide refresh semantics** for mutable context (`latest_revision` after a commit):
+  snapshot-at-start vs per-turn, documented; or an expected-revision precondition on commit.
+- **Q4 — design mostly right:** the `call` descriptor + allowlisted method/path + `args_into` +
+  the `/tools/call` shrink is the right factoring for the local backend; keep context provisioning
+  OUTSIDE primitive dispatch (a service→runner metadata path), not an executable tool.

--- a/docs/design/agent-workflows/projects/direct-call-tools/status.md
+++ b/docs/design/agent-workflows/projects/direct-call-tools/status.md
@@ -4,9 +4,8 @@ Last updated: 2026-06-27
 
 ## Where this is
 
-DESIGN deliverable on draft PR #4886 for Mahmoud's review. **Round-2 comments addressed (second
-version)** — the per-comment summary is in the PR comment. No code in this project; implementation
-is dispatched by the orchestrator once the design is approved.
+DESIGN deliverable on draft PR #4886. **Design is now complete — all decisions made, including
+run-context delivery.** No code in this project; implementation is dispatched by the orchestrator.
 
 `design.md` (the `call` descriptor, the per-tool-type table, the dispatch algorithm) and
 `plan.md` (the phases) are the spec the implementation subagent would follow. Phase 1's wire
@@ -27,6 +26,12 @@ rather than editing concurrently. Until then A does not touch models.py.
 
 ## Decided
 
+- **2026-06-27 (FINAL) — run-context delivery = run/session + tool `bind`.** The service sends a
+  `runContext` blob on `/run` (refreshed per turn); tool definitions declare a `bind` map and the
+  runner fills bound fields server-side at dispatch, hidden from the model. Self-targeting tools
+  bind their own variant/trace this way (settles server-bind vs "own is convention" → server-bind).
+  No MCP resource, no `get_context` tool, no context file, no prompt injection (all in "Considered
+  but not used" in `run-context.md`). **This closes the last open decision; the design is complete.**
 - **2026-06-27 — env resolution timing.** Always bake the resolved revision at resolve time,
   including `environment` references. The service is always in front of the sidecar and
   re-resolves on each invoke, so the baked revision stays current. No call-time env resolution.

--- a/docs/design/agent-workflows/projects/direct-call-tools/status.md
+++ b/docs/design/agent-workflows/projects/direct-call-tools/status.md
@@ -1,0 +1,53 @@
+# Status
+
+Last updated: 2026-06-27
+
+## Where this is
+
+DESIGN deliverable, complete: context, research, design, plan. A draft PR carries these docs for
+Mahmoud's review. No code in this project. Implementation is dispatched by the orchestrator to a
+subagent once the design is approved; it is not done here.
+
+`design.md` (the `call` descriptor, the per-tool-type table, the dispatch algorithm) and
+`plan.md` (the phases) are the spec the implementation subagent would follow. Phase 1's wire
+field lands on `CallbackToolSpec` in the shared `models.py` (B's active file), so implementation
+is sequenced after Workstream B.
+
+## Workstream B is active in parallel
+
+Mahmoud started a separate agent on Workstream B (drop the `@ag.reference` marker, keep
+`type:"reference"`, rebuild FE #4877 on the tool type, hide embed in the UI, add env/variant to
+the reference schema) on PRs #4860 / #4877.
+
+**Shared file: `sdks/python/agenta/sdk/agents/tools/models.py`.** B edits `ReferenceToolConfig`
+(adds env/variant) and removes `AG_REFERENCE_MARKER`. A adds the optional `call` field to
+`CallbackToolSpec`. Different classes, same file. Per the coordination contract (first-committer
+owns a shared file), A waits for B's models.py to commit, then adds `call` on top of B's version
+rather than editing concurrently. Until then A does not touch models.py.
+
+## Decided
+
+- **2026-06-27 — env resolution timing.** Always bake the resolved revision at resolve time,
+  including `environment` references. The service is always in front of the sidecar and
+  re-resolves on each invoke, so the baked revision stays current. No call-time env resolution.
+
+## Open decisions for Mahmoud
+
+1. **When to remove the `/tools/call` `workflow.*` routing.** It is coupled to "reference goes
+   direct" (Phase 4) and depends on B having landed. Recommendation: it lives in Workstream A,
+   after B. If removed earlier, reference tools stop executing until A lands. This should be
+   surfaced as a 🔸 Decision-needed comment on a PR.
+2. **Trace-context forwarding to the sub-workflow on a reference invoke** (Phase 6, stretch).
+   Nice to have; likely defer past the first cut.
+
+## Next step
+
+- Surface decision 1 on a PR (open a design-docs PR for this project if none exists).
+- Begin Phase 1 (the `call` descriptor) on the parts that do not touch the shared models.py,
+  and coordinate the models.py addition as a handoff after B commits.
+- Platform tools (Phases 2-3) are largely independent of B and can proceed first.
+
+## Board
+
+Row claimed on `scratch/agent-coordination.md` (2026-06-27, `direct-call-tools (A)`). No `but`
+write yet; BUT-LOCK left FREE; board/plan edits left unassigned.

--- a/docs/design/agent-workflows/projects/direct-call-tools/status.md
+++ b/docs/design/agent-workflows/projects/direct-call-tools/status.md
@@ -4,9 +4,9 @@ Last updated: 2026-06-27
 
 ## Where this is
 
-DESIGN deliverable, complete: context, research, design, plan. A draft PR carries these docs for
-Mahmoud's review. No code in this project. Implementation is dispatched by the orchestrator to a
-subagent once the design is approved; it is not done here.
+DESIGN deliverable on draft PR #4886 for Mahmoud's review. **Round-2 comments addressed (second
+version)** — the per-comment summary is in the PR comment. No code in this project; implementation
+is dispatched by the orchestrator once the design is approved.
 
 `design.md` (the `call` descriptor, the per-tool-type table, the dispatch algorithm) and
 `plan.md` (the phases) are the spec the implementation subagent would follow. Phase 1's wire
@@ -30,22 +30,35 @@ rather than editing concurrently. Until then A does not touch models.py.
 - **2026-06-27 — env resolution timing.** Always bake the resolved revision at resolve time,
   including `environment` references. The service is always in front of the sidecar and
   re-resolves on each invoke, so the baked revision stays current. No call-time env resolution.
+- **2026-06-27 (round 2) — Mahmoud aligned with all design decisions.** Merge order and commit
+  organization are the orchestrator's call; the only requirement is reviewability before merge.
+- **2026-06-27 (round 2) — schema sourcing.** Platform-tool input schemas come from the in-process
+  `CATALOG_TYPES` catalog (via `x-ag-type-ref`), not `/openapi.json` (fixed the doc inconsistency
+  CodeRabbit flagged).
+- **2026-06-27 (round 2) — reference input schema.** Taken from the referenced workflow's
+  `revision.schemas.inputs` (via `/inspect`); chat carries `messages` via `x-ag-type-ref`.
+- **2026-06-27 (round 2) — no tool output schema on the wire now.** Harness tool defs are
+  input-only; the workflow's `schemas.outputs` stays available for a later pass.
+- **2026-06-27 (round 2) — permissions uniform across all tool types** (not special-cased on the
+  `call` path); a typed permissions-config hierarchy is a future refactor, out of scope.
+- **2026-06-27 (round 2) — catalog to mirror.** The reserved `tools.agenta.*` pattern (PR #4884
+  `find_capabilities`) + the evaluators catalog shape, not `platform_catalog.py` wholesale.
 
-## Open decisions for Mahmoud
+## Sequencing (orchestrator's call)
 
-1. **When to remove the `/tools/call` `workflow.*` routing.** It is coupled to "reference goes
-   direct" (Phase 4) and depends on B having landed. Recommendation: it lives in Workstream A,
-   after B. If removed earlier, reference tools stop executing until A lands. This should be
-   surfaced as a 🔸 Decision-needed comment on a PR.
+Mahmoud is aligned with all design decisions; the items below are sequencing for the orchestrator,
+not decisions Mahmoud owes.
+
+1. **When to remove the `/tools/call` `workflow.*` routing.** Coupled to "reference goes direct"
+   (Phase 4) and depends on B having landed. Recommendation: in Workstream A, after B.
 2. **Trace-context forwarding to the sub-workflow on a reference invoke** (Phase 6, stretch).
-   Nice to have; likely defer past the first cut.
+   Likely deferred past the first cut.
 
 ## Next step
 
-- Surface decision 1 on a PR (open a design-docs PR for this project if none exists).
-- Begin Phase 1 (the `call` descriptor) on the parts that do not touch the shared models.py,
-  and coordinate the models.py addition as a handoff after B commits.
-- Platform tools (Phases 2-3) are largely independent of B and can proceed first.
+- Round-2 review addressed; second version on PR #4886 awaiting Mahmoud's skim.
+- After approval, the orchestrator dispatches the implementation per the phases in `plan.md`
+  (Phase 1's `call` field on `models.py` sequenced after Workstream B).
 
 ## Board
 


### PR DESCRIPTION
## What

Design docs (no code) for **direct-call tools**: make each resolved agent tool carry its own
call target so the sidecar calls **reference** and **platform** tools directly, and only
**gateway** (Composio) tools route through the central `/tools/call`.

Lives under `docs/design/agent-workflows/projects/direct-call-tools/`. This is the Workstream A
design, up for review. Implementation is dispatched separately (the workstream split is in
`plan.md`).

## Why

Today every callback tool POSTs to one endpoint, `/tools/call`, which re-parses a string and
re-dispatches. For a **reference** (a stored workflow used as a tool) or a **platform** tool (an
Agenta operation like create-workflow or annotate), the target is just an Agenta endpoint and the
sidecar already holds the caller credential, so the hop adds a step and no value. **Gateway** is
the one real exception: only the server can read the Composio secret. Seeded by the line-67
comment on #4863.

## What's in it

- `context.md` — the decision, goals, non-goals.
- `research.md` — the actual code seams (config/resolved/dispatch, the reference-invoke path,
  the platform-op catalog precedent, the in-process schema catalog) with file:line.
- `design.md` — the `call` descriptor, the per-tool-type table (config -> resolved -> dispatch),
  the platform-op catalog, the reference resolution.
- `plan.md` — the two-workstream split (this is A; B drops the `@ag.reference` marker and
  rebuilds the FE on `type:"reference"` on #4860 / #4877) plus the A execution phases.
- `status.md`, `README.md`.

## Decisions settled in the design

- Reference/platform tools call directly; gateway stays server-side.
- Drop the `@ag.reference` marker (keep `type:"reference"`); keep embed, hidden in the UI for
  now. [Workstream B]
- A reference can target an environment or a variant, latest or a pinned revision. [schema in B]
- The service resolves the reference revision at resolve time and bakes it in (the sidecar is
  always invoked fresh by the service, so it stays current).

## Decision needed from you

See the **🔸 Decision needed** comment: when to remove the `/tools/call` `workflow.*` routing
(my recommendation: in Workstream A, after B lands).

## How to review

This is a **design review, not a code review**. Read `design.md` first (the shape), then
`plan.md` (the split + phases). No code in this PR.

Related: #4860 / #4877 (the reference tool, Workstream B), #4837 (embedref design), #4863
(custom-tools note, where this started).

https://claude.ai/code/session_01YXbQbNQvPn6GU3P8TvLMEw
