### PR TITLE
[fix] Expand x-ag-type-ref in reference-tool input schemas so harnesses can invoke them

### DIFF
--- a/sdks/python/agenta/sdk/agents/platform/_schema.py
+++ b/sdks/python/agenta/sdk/agents/platform/_schema.py
@@ -30,13 +30,19 @@ from agenta.sdk.utils.types import CATALOG_TYPES
 # in for the catalog type ``<key>``.
 _TYPE_REF_KEY = "x-ag-type-ref"
 
-# JSON Schema keywords that describe the *shape* of a value. When a node is expanded these come
-# from the catalog entry — supplying the concrete structure the author elided behind the pointer
-# is the whole point of the expansion. Every other key on the author's node (``description``,
-# ``title``, ``examples``, ``default``, ...) is an annotation the author chose, so it is preserved
-# and wins over the catalog's.
+# JSON Schema keywords the catalog owns for a referenced type. They split in two:
+#
+#   - shape keywords describe the *structure* of a value (``type``, ``items``, ``properties``, ...);
+#   - validation keywords *constrain* that value (``minItems``, ``pattern``, ``minimum``, ...).
+#
+# Both are canonical to the catalog type. When a node is expanded these come from the catalog
+# entry, so an author annotation cannot loosen or tighten the catalog's shape — that would let the
+# emitted schema drift from the type's required form. Every other key on the author's node
+# (``description``, ``title``, ``examples``, ``default``, ...) is an annotation the author chose,
+# so it is preserved and wins over the catalog's.
 _STRUCTURAL_KEYS = frozenset(
     {
+        # shape
         "type",
         "items",
         "prefixItems",
@@ -55,6 +61,20 @@ _STRUCTURAL_KEYS = frozenset(
         "definitions",
         "discriminator",
         "format",
+        # validation constraints
+        "minItems",
+        "maxItems",
+        "uniqueItems",
+        "minLength",
+        "maxLength",
+        "pattern",
+        "minimum",
+        "maximum",
+        "exclusiveMinimum",
+        "exclusiveMaximum",
+        "multipleOf",
+        "minProperties",
+        "maxProperties",
     }
 )
 
@@ -69,10 +89,11 @@ def expand_type_refs(
     ``<key>`` is a key in ``catalog``, the node is replaced by a merge of the catalog entry and
     the author's node:
 
-    - the catalog entry supplies the concrete structure (``type``, ``items``, ``properties``, ...);
+    - the catalog entry supplies the concrete structure (``type``, ``items``, ``properties``, ...)
+      and its validation constraints (``minItems``, ``pattern``, ``minimum``, ...);
     - the author's annotations (``description``, ``title``, ...) are preserved and override the
-      catalog's, EXCEPT structural keywords the catalog already defines, which always come from the
-      catalog;
+      catalog's, EXCEPT the catalog-owned shape and constraint keywords the catalog already
+      defines, which always come from the catalog;
     - the ``x-ag-type-ref`` marker itself is dropped (it has been resolved).
 
     An unknown ``<key>`` (not in ``catalog``) is left exactly as it is — the marker stays and

--- a/sdks/python/agenta/sdk/agents/platform/_schema.py
+++ b/sdks/python/agenta/sdk/agents/platform/_schema.py
@@ -1,0 +1,107 @@
+"""Expand Agenta catalog type-references in a JSON Schema into concrete JSON Schema.
+
+A ``type:"reference"`` workflow tool carries the referenced workflow's input schema, and that
+schema can use Agenta's catalog shorthand: a node marked ``{"x-ag-type-ref": "<key>"}`` stands
+in for a named catalog type (``messages``, ``model``, ...) instead of spelling the shape out
+inline. That marker is an Agenta-internal pointer, not standard JSON Schema. When such a schema
+reaches a harness (Claude, an MCP client), the harness sees, for example, an ``array`` with no
+``items`` and cannot construct a valid call, so it returns ``null``.
+
+:func:`expand_type_refs` resolves those pointers against the in-process catalog
+(:data:`agenta.sdk.utils.types.CATALOG_TYPES`) BEFORE the tool spec is built, so the emitted
+``inputSchema`` is concrete, standard JSON Schema the harness can actually use. This changes only
+the CONTENT of the schema (it gains the structure the pointer elided), never the wire shape.
+
+Lives under ``platform/`` rather than ``tools/`` on purpose: importing ``CATALOG_TYPES`` from a
+``tools`` module is circular (``CATALOG_TYPES`` is defined in ``utils.types``, which imports
+``agents.tools``), whereas the platform package is imported lazily and sits below that cycle.
+
+Pure function, no I/O: the catalog is an in-memory dict shipped with the SDK.
+"""
+
+from __future__ import annotations
+
+from copy import deepcopy
+from typing import Any, Dict, Mapping
+
+from agenta.sdk.utils.types import CATALOG_TYPES
+
+# The Agenta-internal marker: a JSON Schema node carrying ``{"x-ag-type-ref": "<key>"}`` stands
+# in for the catalog type ``<key>``.
+_TYPE_REF_KEY = "x-ag-type-ref"
+
+# JSON Schema keywords that describe the *shape* of a value. When a node is expanded these come
+# from the catalog entry — supplying the concrete structure the author elided behind the pointer
+# is the whole point of the expansion. Every other key on the author's node (``description``,
+# ``title``, ``examples``, ``default``, ...) is an annotation the author chose, so it is preserved
+# and wins over the catalog's.
+_STRUCTURAL_KEYS = frozenset(
+    {
+        "type",
+        "items",
+        "prefixItems",
+        "properties",
+        "patternProperties",
+        "additionalProperties",
+        "required",
+        "enum",
+        "const",
+        "anyOf",
+        "oneOf",
+        "allOf",
+        "not",
+        "$ref",
+        "$defs",
+        "definitions",
+        "discriminator",
+        "format",
+    }
+)
+
+
+def expand_type_refs(
+    schema: Any,
+    catalog: Mapping[str, Dict[str, Any]] = CATALOG_TYPES,
+) -> Any:
+    """Return ``schema`` with every ``x-ag-type-ref`` pointer expanded to concrete JSON Schema.
+
+    Walks ``schema`` recursively. For any node carrying ``{"x-ag-type-ref": "<key>"}`` where
+    ``<key>`` is a key in ``catalog``, the node is replaced by a merge of the catalog entry and
+    the author's node:
+
+    - the catalog entry supplies the concrete structure (``type``, ``items``, ``properties``, ...);
+    - the author's annotations (``description``, ``title``, ...) are preserved and override the
+      catalog's, EXCEPT structural keywords the catalog already defines, which always come from the
+      catalog;
+    - the ``x-ag-type-ref`` marker itself is dropped (it has been resolved).
+
+    An unknown ``<key>`` (not in ``catalog``) is left exactly as it is — the marker stays and
+    nothing crashes. Nested and transitively-referenced types expand too (e.g. an ``llm`` whose
+    ``model`` field is itself an ``x-ag-type-ref``). The input is never mutated; a fresh structure
+    is returned.
+    """
+    return _expand(schema, catalog)
+
+
+def _expand(node: Any, catalog: Mapping[str, Dict[str, Any]]) -> Any:
+    if isinstance(node, list):
+        return [_expand(item, catalog) for item in node]
+    if not isinstance(node, dict):
+        return node
+
+    ref = node.get(_TYPE_REF_KEY)
+    if isinstance(ref, str) and ref in catalog:
+        merged: Dict[str, Any] = deepcopy(dict(catalog[ref]))
+        for key, value in node.items():
+            if key == _TYPE_REF_KEY:
+                continue  # the marker has been resolved; drop it
+            if key in _STRUCTURAL_KEYS and key in merged:
+                continue  # the concrete shape always comes from the catalog
+            merged[key] = value  # preserve the author's annotation
+        # Recurse so a catalog type that itself references another type, and any nested author
+        # refs, also expand. The current catalog types are acyclic, so this terminates.
+        return {key: _expand(value, catalog) for key, value in merged.items()}
+
+    # No resolvable ref here. Rebuild the node so nested refs inside it expand; an unknown ref key
+    # falls through to here and is left untouched (its scalar marker value is returned as-is).
+    return {key: _expand(value, catalog) for key, value in node.items()}

--- a/sdks/python/agenta/sdk/agents/platform/workflow.py
+++ b/sdks/python/agenta/sdk/agents/platform/workflow.py
@@ -29,6 +29,7 @@ from agenta.sdk.agents.tools import (
 )
 from agenta.sdk.utils.logging import get_module_logger
 
+from ._schema import expand_type_refs
 from .connection import PlatformConnection
 
 log = get_module_logger(__name__)
@@ -73,7 +74,12 @@ class AgentaWorkflowToolResolver:
                 CallbackToolSpec(
                     name=tool_config.tool_name,
                     description=tool_config.description or tool_config.tool_name,
-                    input_schema=tool_config.input_schema,
+                    # Expand Agenta catalog pointers (``x-ag-type-ref``, e.g. ``messages``) into
+                    # concrete JSON Schema so the harness sees a real shape (an array WITH items,
+                    # not a bare ``x-ag-type-ref``) and can construct the call. Reference tools are
+                    # the only tool kind whose schema comes from a workflow's inputs and so can
+                    # carry these pointers; code/client tools author plain JSON Schema.
+                    input_schema=expand_type_refs(tool_config.input_schema),
                     call_ref=call_ref,
                     needs_approval=tool_config.needs_approval,
                     render=tool_config.render,

--- a/sdks/python/oss/tests/pytest/unit/agents/platform/test_schema_expand.py
+++ b/sdks/python/oss/tests/pytest/unit/agents/platform/test_schema_expand.py
@@ -121,6 +121,31 @@ def test_custom_catalog_merge_policy():
     )
 
 
+def test_author_constraints_do_not_override_catalog():
+    """Catalog-authoritative: an author-supplied validation constraint on a ref node cannot loosen
+    or tighten the catalog's canonical constraint; only true annotations survive."""
+    result = expand_type_refs(
+        {
+            "x-ag-type-ref": "foo",
+            "minItems": 1,  # author tries to loosen the catalog's minItems
+            "pattern": "author",  # author tries to override the catalog's pattern
+            "description": "kept",  # a true annotation
+        },
+        catalog={
+            "foo": {
+                "type": "array",
+                "items": {"type": "string"},
+                "minItems": 5,
+                "pattern": "catalog",
+            }
+        },
+    )
+
+    assert result["minItems"] == 5  # catalog constraint wins, not the author's 1
+    assert result["pattern"] == "catalog"  # catalog constraint wins, not the author's
+    assert result["description"] == "kept"  # author annotation preserved
+
+
 def test_input_is_not_mutated():
     schema = {"type": "array", "x-ag-type-ref": "messages", "description": "hist"}
     before = copy.deepcopy(schema)

--- a/sdks/python/oss/tests/pytest/unit/agents/platform/test_schema_expand.py
+++ b/sdks/python/oss/tests/pytest/unit/agents/platform/test_schema_expand.py
@@ -1,0 +1,153 @@
+"""Tests for ``expand_type_refs``: turning Agenta ``x-ag-type-ref`` catalog pointers in a
+reference tool's input schema into concrete JSON Schema a harness can use.
+
+The bug this guards: a reference tool ships ``messages`` as ``{"type":"array","x-ag-type-ref":
+"messages"}`` — an array with no ``items``. ``x-ag-type-ref`` is an Agenta-internal pointer, not
+standard JSON Schema, so Claude / an MCP client cannot build a valid call and returns ``null``.
+"""
+
+from __future__ import annotations
+
+import copy
+
+from agenta.sdk.agents.platform import AgentaWorkflowToolResolver
+from agenta.sdk.agents.platform._schema import expand_type_refs
+from agenta.sdk.agents.tools import ReferenceToolConfig
+
+
+def _remaining_refs(node) -> list:
+    """Every ``x-ag-type-ref`` value still present anywhere in ``node`` (should be empty after a
+    full expansion of catalog-known refs)."""
+    found = []
+    if isinstance(node, dict):
+        if "x-ag-type-ref" in node:
+            found.append(node["x-ag-type-ref"])
+        for value in node.values():
+            found += _remaining_refs(value)
+    elif isinstance(node, list):
+        for item in node:
+            found += _remaining_refs(item)
+    return found
+
+
+def test_messages_ref_expands_to_array_with_items():
+    """The core bug: a ``messages`` ref becomes a concrete array WITH items (role + content)."""
+    result = expand_type_refs(
+        {"type": "array", "x-ag-type-ref": "messages"},
+    )
+
+    assert result["type"] == "array"
+    assert "items" in result  # the shape the bare pointer was missing
+    assert "x-ag-type-ref" not in result  # the marker is resolved away
+    item = result["items"]
+    assert "role" in item["properties"]
+    assert "content" in item["properties"]
+
+
+def test_author_description_is_preserved():
+    """The author's annotations survive the expansion; the structure comes from the catalog."""
+    result = expand_type_refs(
+        {
+            "type": "array",
+            "x-ag-type-ref": "messages",
+            "description": "The conversation so far",
+            "title": "Chat history",
+        },
+    )
+
+    assert result["description"] == "The conversation so far"
+    assert (
+        result["title"] == "Chat history"
+    )  # author annotation overrides the catalog title
+    assert "items" in result
+
+
+def test_schema_without_ref_is_unchanged():
+    schema = {
+        "type": "object",
+        "properties": {"text": {"type": "string", "description": "free text"}},
+        "required": ["text"],
+    }
+
+    assert expand_type_refs(schema) == schema
+
+
+def test_unknown_ref_is_left_as_is():
+    """An unknown catalog key does not crash and is left exactly as authored."""
+    node = {"type": "array", "x-ag-type-ref": "not-a-real-catalog-type"}
+
+    assert expand_type_refs(node) == node
+
+
+def test_nested_ref_inside_properties_expands():
+    schema = {
+        "type": "object",
+        "properties": {
+            "messages": {"type": "array", "x-ag-type-ref": "messages"},
+            "limit": {"type": "integer"},
+        },
+        "required": ["messages"],
+    }
+
+    result = expand_type_refs(schema)
+
+    messages = result["properties"]["messages"]
+    assert "items" in messages
+    assert "x-ag-type-ref" not in messages
+    assert result["properties"]["limit"] == {"type": "integer"}  # untouched neighbor
+
+
+def test_transitive_ref_expands():
+    """A catalog type whose own field is an ``x-ag-type-ref`` (``llm`` -> ``model``) expands fully."""
+    result = expand_type_refs({"x-ag-type-ref": "llm"})
+
+    assert _remaining_refs(result) == []
+
+
+def test_custom_catalog_merge_policy():
+    """Structure comes from the catalog; the author's own keys are kept; the marker is dropped."""
+    result = expand_type_refs(
+        {"x-ag-type-ref": "foo", "type": "string", "description": "authored"},
+        catalog={"foo": {"type": "number", "title": "Foo"}},
+    )
+
+    assert (
+        result
+        == {
+            "type": "number",  # structural -> catalog wins over the author's redundant "string"
+            "title": "Foo",  # catalog annotation surfaces when the author has none
+            "description": "authored",  # author annotation preserved
+        }
+    )
+
+
+def test_input_is_not_mutated():
+    schema = {"type": "array", "x-ag-type-ref": "messages", "description": "hist"}
+    before = copy.deepcopy(schema)
+
+    expand_type_refs(schema)
+
+    assert schema == before  # the original schema is untouched (pure function)
+
+
+async def test_resolver_emits_expanded_input_schema(connection):
+    """End-to-end at the call site: the resolved spec carries a concrete, item-bearing array."""
+    resolver = AgentaWorkflowToolResolver(connection=connection)
+    resolution = await resolver.resolve(
+        [
+            ReferenceToolConfig(
+                slug="summarize",
+                input_schema={
+                    "type": "object",
+                    "properties": {
+                        "messages": {"type": "array", "x-ag-type-ref": "messages"},
+                    },
+                    "required": ["messages"],
+                },
+            )
+        ]
+    )
+
+    messages = resolution.tool_specs[0].input_schema["properties"]["messages"]
+    assert "items" in messages
+    assert "x-ag-type-ref" not in messages


### PR DESCRIPTION
## Context

A `type:"reference"` workflow tool ships its `messages` input as
`{"type":"array","x-ag-type-ref":"messages"}` — an array with no `items`. `x-ag-type-ref` is an
Agenta-internal catalog pointer, not standard JSON Schema. The harness (Claude, an MCP client)
sees an array with no item shape, cannot build a valid call, and returns null. Mahmoud hit this: a
Claude agent with a reference tool could not invoke the referenced workflow.

## The fix

Expand the pointers into concrete JSON Schema at the reference resolver, before the spec is built.

- New pure helper `expand_type_refs` (`sdks/python/agenta/sdk/agents/platform/_schema.py`) walks
  the schema and resolves each `x-ag-type-ref` against the in-process `CATALOG_TYPES`.
- `AgentaWorkflowToolResolver.resolve` (`platform/workflow.py`) wraps the reference's
  `input_schema` through it.

Merge policy: the catalog supplies the structure (`type`, `items`, ...); the author's annotations
(`description`, `title`, ...) are preserved; the `x-ag-type-ref` marker is dropped. An unknown key
is left exactly as authored, with no crash. Nested and transitive pointers expand too.

The helper lives under `platform/` on purpose. `CATALOG_TYPES` is defined in `utils.types`, which
imports `agents.tools`, so importing the catalog from a `tools` module is circular. The platform
package is imported lazily and sits below that cycle.

## Scope / risk

- SDK reference-resolver only. Reference tools are the one tool kind whose schema comes from a
  workflow's inputs, so they are the only kind that can carry these pointers. `code` and `client`
  tools author plain JSON Schema and are unaffected.
- Content-only. This changes the content of the emitted `inputSchema` (concrete now), not the wire
  shape. No golden fixture carries a reference tool with `x-ag-type-ref`, so there is no golden
  update and the wire-contract tests stay green.
- A ref-free schema returns unchanged. An unknown ref key is left as-is. The input is never
  mutated.

## How to QA

Prerequisites: the SDK virtualenv (`cd sdks/python && uv sync`).

Unit:

1. `cd sdks/python`
2. `uv run --no-sync python -m pytest oss/tests/pytest/unit/agents/platform/test_schema_expand.py oss/tests/pytest/unit/agents/platform/test_workflow_resolver.py oss/tests/pytest/unit/agents/test_wire_contract.py -n0 -q`
3. Expected: all pass. The new test asserts a `messages` ref expands to an array **with** items
   (role + content), the author's `description` survives, a ref-free schema is unchanged, an
   unknown key is left as-is, and a nested ref expands.

Edge cases covered: unknown catalog key (left as-is, no crash), transitive ref (`llm` -> `model`),
purity (input not mutated), structural-vs-annotation precedence (catalog wins for `type`/`items`,
author wins for `description`/`title`).

Live (needs an SDK redeploy): a Claude agent with a reference tool can now invoke the referenced
workflow instead of returning null. The orchestrator will redeploy the SDK and re-run this cell.

## Interface reference

- Helper: `expand_type_refs(schema, catalog=CATALOG_TYPES)` at
  `sdks/python/agenta/sdk/agents/platform/_schema.py`.
- Call site: `sdks/python/agenta/sdk/agents/platform/workflow.py`,
  `AgentaWorkflowToolResolver.resolve` — `input_schema=expand_type_refs(tool_config.input_schema)`.
- Catalog: `CATALOG_TYPES` at `sdks/python/agenta/sdk/utils/types.py`. `CATALOG_TYPES["messages"]`
  is `{"type":"array","items":{...role/content...},"title":"Messages","x-ag-type":"messages"}`.
- No wire field changed; `inputSchema` content only.

## Docs

The reference-tool schema-delivery docs (the "Reference" bullet in `documentation/tools.md` and
`interfaces/in-service/tool-models-and-resolution.md`) should note that `x-ag-type-ref` is now
expanded at the reference resolver. Those files are owned and committed by the tool-discovery lane
(#4884), so the note is left out of this PR to avoid a cross-lane ownership conflict; it should be
folded into that lane or applied after it merges.

https://claude.ai/code/session_01GYo3UEfvsZpncagqb28Mbc
