### PR TITLE
[fix] Claude: disable Tool-Search so agenta tools receive their input schema

### DIFF
--- a/services/agent/src/engines/sandbox_agent.ts
+++ b/services/agent/src/engines/sandbox_agent.ts
@@ -133,6 +133,16 @@ function applyClaudeConnectionEnv(
 ): boolean {
   if (acpAgent !== "claude") return false;
 
+  // Disable the Claude Agent SDK's Tool-Search feature for every Claude run. The bundled
+  // SDK defaults Tool-Search ON, which makes Claude DEFER the `agenta-tools` MCP tools and
+  // call them before their `inputSchema` is loaded — so it emits an empty `input: {}` and
+  // tools-with-args (reference workflows, commit_revision) never receive their arguments.
+  // Our tool count is small, so deferral buys nothing and only strips the schema. The SDK
+  // treats only `false`/`0`/`no`/`off` as off, so the string must be "false" (not "0"/"100").
+  // This is applied after `buildDaemonEnv`'s clear and is not in `KNOWN_PROVIDER_ENV_VARS`,
+  // so it is never stripped, and it reaches the Daytona sandbox like `ANTHROPIC_BASE_URL`.
+  env.ENABLE_TOOL_SEARCH = "false";
+
   const deployment = request.deployment;
   const selectedModel = request.model;
   const baseUrl = request.endpoint?.baseUrl;

--- a/services/agent/tests/unit/sandbox-agent-orchestration.test.ts
+++ b/services/agent/tests/unit/sandbox-agent-orchestration.test.ts
@@ -566,6 +566,29 @@ describe("runSandboxAgent orchestration", () => {
     assert.equal(env.ANTHROPIC_API_KEY, "resolved");
     assert.equal(env.ANTHROPIC_BASE_URL, "https://claude-gw.example/v1");
     assert.equal(env.ANTHROPIC_MODEL, undefined);
+    // Tool-Search is disabled for every claude run so the agenta-tools MCP tools keep their
+    // inputSchema (deferral would strip it -> empty tool input). The SDK only treats the exact
+    // string "false"/"0"/"no"/"off" as off, so it must be the string "false".
+    assert.equal(env.ENABLE_TOOL_SEARCH, "false");
+  });
+
+  it("does not set ENABLE_TOOL_SEARCH for a non-claude (pi) run", async () => {
+    const { calls, deps } = fakeHarness();
+
+    const result = await runSandboxAgent(
+      {
+        harness: "pi_core",
+        messages: [{ role: "user", content: "hello" }],
+      } as AgentRunRequest,
+      undefined,
+      undefined,
+      deps,
+    );
+
+    assert.equal(result.ok, true);
+    const env = calls.providerArgs[1] as Record<string, string>;
+    // The Tool-Search toggle is Claude-specific: a Pi run must not carry it.
+    assert.equal(env.ENABLE_TOOL_SEARCH, undefined);
   });
 
   it("sets Claude Bedrock env and strict selected model pass-through", async () => {


### PR DESCRIPTION
## Context

The runner never sets `ENABLE_TOOL_SEARCH`, so the bundled Claude Agent SDK runs with
Tool-Search **on** (its default). With Tool-Search on, Claude **defers** the `agenta-tools`
MCP tools: instead of getting each tool's `inputSchema` up front, Claude must first call a
`ToolSearch` meta-tool to load the schema, then call the real tool. When Claude calls a
deferred tool before that schema is loaded it sends an empty `input: {}`, so a tool that
needs arguments (a reference workflow, `commit_revision`) receives nothing. A reference
workflow with no arguments returns `null`.

The fix disables Tool-Search for every Claude run. The agent's tool count is small, so
deferral buys nothing — it only strips the schema and adds a round-trip.

## The change

One line in `applyClaudeConnectionEnv` (`services/agent/src/engines/sandbox_agent.ts`),
right after the `acpAgent !== "claude"` guard:

```ts
env.ENABLE_TOOL_SEARCH = "false";
```

- The value must be the string `"false"` — the SDK treats only `false`/`0`/`no`/`off` as off.
- This `env` map is the same one that already carries `ANTHROPIC_BASE_URL`; it is applied
  after `buildDaemonEnv`'s clear and is not in `KNOWN_PROVIDER_ENV_VARS`, so it is never
  stripped, and it reaches both the local daemon and the Daytona sandbox.
- It is set only for `claude`; Pi runs never carry it.

## Interface reference

| Var | Set when | Value | Seam |
|---|---|---|---|
| `ENABLE_TOOL_SEARCH` | `acpAgent === "claude"` (every Claude run) | `"false"` | `services/agent/src/engines/sandbox_agent.ts` → `applyClaudeConnectionEnv` |

This is a runner-internal harness env var. It is not a wire field, not in `protocol.ts`,
and not part of the `/run` contract, so no `wire.py` / golden / SDK change is needed. The
same `sandbox_agent.ts` source is built into both the runner image and the subscription
sidecar, so both pick the fix up.

## Scope / risk

- Touches only the Claude env branch in the runner. Pi runs are unchanged (asserted by a
  test). No wire/schema/API change.
- Low risk: it removes a harness feature that only adds a deferral round-trip for a small,
  fixed tool set. The worst case is more tokens for tool definitions up front, which is
  negligible at this tool count.

## How to QA

Prerequisites: a Claude run path (the subscription sidecar at `:8790`, OAuth, model `haiku`,
`sandbox=local`) and a project with a runnable workflow exposed as a reference tool
(`completion-0o1r` in `pi-agents`, which needs a `country` arg).

1. Unit tests (the contract for this change):
   ```
   cd services/agent && pnpm test && pnpm run typecheck
   ```
   `runSandboxAgent orchestration` asserts `ENABLE_TOOL_SEARCH=false` for a Claude run and
   `undefined` for a Pi run.
2. Live: stream a Claude `/invoke` run that calls a reference tool needing args, against the
   sub-sidecar (which builds from this source). Expected with the fix: Claude calls the tool
   **directly** (no `ToolSearch` meta-tool round-trip in the SSE) and the workflow returns a
   real result (`"The capital of France is Paris."`), not `null`.

Edge cases checked: the workflow returns `null` / `STATUS_CODE_ERROR` when called with `{}`
(empty input), and a real result when called with `{"country": "France"}` — confirming empty
input is what produces `null`.

---

🤖 _The AI agent says:_ See my review comment below for the full live-verification result and an
important caveat about what this fix does and does not prove.
