### PR TITLE
[fix] HITL: restore real tool args on approval so parked tools execute with their input

### DIFF
--- a/sdks/python/agenta/sdk/agents/adapters/vercel/stream.py
+++ b/sdks/python/agenta/sdk/agents/adapters/vercel/stream.py
@@ -376,26 +376,37 @@ def _interaction_parts(
     if kind == "permission":
         tool_call_id = _approval_tool_call_id(payload)
         tool_call = payload.get("toolCall")
-        if (
-            tool_call_id is not None
-            and tool_call_id not in seen_tool_calls
-            and isinstance(tool_call, dict)
-        ):
-            seen_tool_calls.add(tool_call_id)
+        if tool_call_id is not None and isinstance(tool_call, dict):
             tool_name = (
                 tool_call.get("name") or tool_call.get("title") or tool_call.get("kind")
             )
-            yield {
-                "type": "tool-input-start",
-                "toolCallId": tool_call_id,
-                "toolName": tool_name,
-            }
-            yield {
-                "type": "tool-input-available",
-                "toolCallId": tool_call_id,
-                "toolName": tool_name,
-                "input": tool_call.get("rawInput") or tool_call.get("input"),
-            }
+            real_input = tool_call.get("rawInput") or tool_call.get("input")
+            if tool_call_id not in seen_tool_calls:
+                # The runner parked without first surfacing the tool call, so
+                # synthesize a tool part for the approval to render against.
+                seen_tool_calls.add(tool_call_id)
+                yield {
+                    "type": "tool-input-start",
+                    "toolCallId": tool_call_id,
+                    "toolName": tool_name,
+                }
+                yield {
+                    "type": "tool-input-available",
+                    "toolCallId": tool_call_id,
+                    "toolName": tool_name,
+                    "input": real_input,
+                }
+            elif real_input:
+                # The tool call was already surfaced, often with empty input on a
+                # cold-replay resume. The approval request carries the real args, so
+                # re-emit `tool-input-available` to refresh the parked call's input
+                # instead of persisting `{}` (HITL approve-empty-input bug).
+                yield {
+                    "type": "tool-input-available",
+                    "toolCallId": tool_call_id,
+                    "toolName": tool_name,
+                    "input": real_input,
+                }
         yield {
             "type": TOOL_APPROVAL_REQUEST,
             "approvalId": data.get("id"),

--- a/sdks/python/oss/tests/pytest/unit/agents/adapters/test_vercel_stream_park.py
+++ b/sdks/python/oss/tests/pytest/unit/agents/adapters/test_vercel_stream_park.py
@@ -82,3 +82,74 @@ async def test_parked_run_emits_approval_then_finish() -> None:
     # a model completion `stop`, not `unknown`).
     finish = parts[-1]
     assert finish["finishReason"] == "other"
+
+
+def _parked_run_with_real_args() -> AgentStream:
+    """A parked turn where the runner first surfaced the tool call with EMPTY input, then the
+    approval request carries the REAL args on ``payload.toolCall.rawInput`` (the cold-replay
+    resume shape of the HITL approve-empty-input bug)."""
+    return AgentStream(
+        _records(
+            [
+                {
+                    "kind": "event",
+                    "event": {
+                        "type": "tool_call",
+                        "id": "tool-1",
+                        "name": "commit_revision",
+                        "input": {},
+                    },
+                },
+                {
+                    "kind": "event",
+                    "event": {
+                        "type": "interaction_request",
+                        "id": "perm-1",
+                        "kind": "permission",
+                        "payload": {
+                            "toolCallId": "tool-1",
+                            "toolCall": {
+                                "id": "tool-1",
+                                "name": "commit_revision",
+                                "rawInput": {"message": "ship it"},
+                            },
+                        },
+                    },
+                },
+                {"kind": "event", "event": {"type": "done", "stopReason": "paused"}},
+                {
+                    "kind": "result",
+                    "result": {
+                        "ok": True,
+                        "output": "",
+                        "stopReason": "paused",
+                        "sessionId": "conv-1",
+                        "traceId": "trace-1",
+                    },
+                },
+            ]
+        )
+    )
+
+
+@pytest.mark.asyncio
+async def test_parked_tool_call_refreshes_real_args_on_approval() -> None:
+    """The approval request must refresh the parked tool call's input with the real args even
+    when the tool-call id was already surfaced with empty input. Otherwise the FE persists the
+    call with ``{}`` and a self-update tool (e.g. commit_revision) fires with no arguments."""
+    parts = [
+        part async for part in agent_run_to_vercel_parts(_parked_run_with_real_args())
+    ]
+
+    inputs = [p for p in parts if p.get("type") == "tool-input-available"]
+    # The empty first emit from the `tool_call` event, then a refreshing emit from the approval
+    # request carrying the real args.
+    assert len(inputs) == 2
+    assert inputs[0]["input"] == {}
+    assert inputs[-1]["toolCallId"] == "tool-1"
+    assert inputs[-1]["input"] == {"message": "ship it"}
+
+    # The approval still attaches to the same tool-call id and the stream drains cleanly.
+    approval = next(p for p in parts if p["type"] == "tool-approval-request")
+    assert approval["toolCallId"] == "tool-1"
+    assert parts[-1]["type"] == "finish"


### PR DESCRIPTION
## Context

A parked human-in-the-loop (HITL) tool lost its arguments on approval. When a `needs_approval` tool parks, the runner surfaces the tool call first (often with empty input on a cold-replay resume), then sends a permission request whose `toolCall.rawInput` carries the real arguments. The Vercel egress adapter (`_interaction_parts`) skipped re-emitting `tool-input-available` whenever the tool-call id was already seen. So the real args on the permission request were dropped, the frontend persisted `{}`, and the approved tool ran with no arguments.

This is a pre-existing HITL bug. It surfaced through WS-A's `commit_revision` self-update platform tool: approving it committed an empty revision instead of the model's intended config. This fix unblocks that tool.

- **Before:** the parked tool shows `{}`; approve runs the tool with `{}`.
- **After:** the parked tool shows its real args; approve runs the tool with those args.

## What changed

`sdks/python/agenta/sdk/agents/adapters/vercel/stream.py` — `_interaction_parts`. When a `permission` request's `toolCall` carries a non-empty `rawInput`/`input`, emit a refreshing `tool-input-available` with those args even if the tool-call id was already surfaced. The first-emit path (synthesizing a tool part when the runner never surfaced the call) is unchanged.

## Interface reference

One egress seam; no wire, schema, or endpoint change.

- File: `sdks/python/agenta/sdk/agents/adapters/vercel/stream.py`, `_interaction_parts` (the `permission` branch).
- Reads: the neutral `interaction_request` event with `kind == "permission"`, then `payload.toolCall.rawInput` (fallback `payload.toolCall.input`).
- Emits: an extra AI SDK `tool-input-available` chunk `{type, toolCallId, toolName, input}` with the real args, ahead of the existing `tool-approval-request` chunk.
- The `/run` wire contract, the golden fixtures, and every endpoint are untouched.

## Scope / risk

- Scope is the Vercel stream adapter only. No runner, service, schema, or endpoint change.
- The extra `tool-input-available` fires only when the permission request carries non-empty args, so arg-less and non-parked tools are unaffected.
- Known limitation (pre-existing, not introduced here): on approval the frontend cold-replays the conversation, which relies on the model re-emitting identical args. If the model re-emits different args or re-parks, the tool can park again. In practice it executes on the first try.

## How to QA

Prerequisites: an EE dev stack with the Claude subscription sidecar as the agent runner, `sandbox=local`, and a Claude agent (harness Claude Code, self-managed, `haiku`) with a tool whose Permission is set to "Ask".

Unit test:

```
cd sdks/python && uv run --no-sync python -m pytest oss/tests/pytest/unit/agents/adapters/test_vercel_stream_park.py -n0 -q
```

Expected: 2 passed. The new `test_parked_tool_call_refreshes_real_args_on_approval` asserts that a parked tool-call whose approval carries real args emits a `tool-input-available` with those args, not `{}`.

Playground:

1. Open a Claude agent in the playground. Add a tool that takes arguments and set its Permission to "Ask".
2. Ask the agent to call the tool with a specific argument (for example, "list channels with limit 3").
3. The run parks. The approval prompt shows the real input (for example `{"limit": 3}`), not `{}`.
4. Approve. The tool runs with the real input and returns a real result.
5. On a second run, Deny. The run ends gracefully: the tool reports blocked and the agent recovers.

Verified live on the EE dev stack (subscription sidecar, `sandbox=local`, `haiku`): the parked tool showed `{"limit": 3}`, approve ran it and returned the real Slack result on the first try, and deny was graceful. Zero Daytona sandboxes.

https://claude.ai/code/session_01GYo3UEfvsZpncagqb28Mbc
