### PR TITLE
[fix] Correct the env-var name in the MCP-disabled error (AGENTA_AGENT_MCP_SERVERS_ENABLED)

### DIFF
--- a/sdks/python/agenta/sdk/agents/mcp/errors.py
+++ b/sdks/python/agenta/sdk/agents/mcp/errors.py
@@ -36,7 +36,7 @@ class MCPDisabledError(MCPError):
         listed = ", ".join(names) if names else "(unnamed)"
         super().__init__(
             "MCP servers are disabled on this deployment "
-            "(set AGENTA_AGENT_ENABLE_MCP to enable them), but the request declared "
+            "(set AGENTA_AGENT_MCP_SERVERS_ENABLED to enable them), but the request declared "
             f"{len(names)} MCP server(s): {listed}. Remove them or enable MCP."
         )
         self.server_names = names

--- a/services/agent/src/engines/sandbox_agent/mcp.ts
+++ b/services/agent/src/engines/sandbox_agent/mcp.ts
@@ -33,7 +33,7 @@ export type McpServerEntry = McpServerStdio | McpServerHttp;
  * SSRF guard for a user HTTP MCP `url`. The runner emits the run's Agenta-resolved named secrets
  * as request headers to this author-supplied URL, so an attacker-controlled config could point it
  * at an internal/metadata endpoint and exfiltrate a credential (a classic server-side request
- * forgery). The capability is flag-gated (`AGENTA_AGENT_ENABLE_MCP`, off by default) and
+ * forgery). The capability is flag-gated (`AGENTA_AGENT_MCP_SERVERS_ENABLED`, off by default) and
  * config-trust, so a scheme + host guard is enough rather than full DNS-resolution pinning:
  *
  *  - require `https` (the secret rides in a header; `http` would send it in clear text). Opt out


### PR DESCRIPTION
🤖 _The AI agent says:_ I opened this PR on Mahmoud's behalf to preserve the F-047 fix found during agent-workflows QA.

## Context

The MCP-disabled error and a runner SSRF-guard comment named the wrong env var. Both told users to set `AGENTA_AGENT_ENABLE_MCP` to turn MCP servers on. The runner does not read that variable. It gates MCP on `AGENTA_AGENT_MCP_SERVERS_ENABLED` (`services/oss/src/agent/tools/resolver.py:24`). A user who followed the remediation set a no-op variable, and MCP stayed off. QA flagged this as F-047.

## Scope / risk

Text only, two files:

- `sdks/python/agenta/sdk/agents/mcp/errors.py` — the `MCPDisabledError` message.
- `services/agent/src/engines/sandbox_agent/mcp.ts` — the SSRF-guard comment.

No code path, gate, or default changes. The gate (`AGENTA_AGENT_MCP_SERVERS_ENABLED`, off by default) is untouched. Nothing reads the corrected string at runtime, so there is no behavior change.

## Interface reference

This aligns user-facing remediation text with the real config gate. No interface field changes.

- Real gate (unchanged): `AGENTA_AGENT_MCP_SERVERS_ENABLED`, read at `services/oss/src/agent/tools/resolver.py:24`; declared in the compose files (e.g. `hosting/docker-compose/oss/docker-compose.dev.yml:456`), default `false`.
- Before: the message and comment named `AGENTA_AGENT_ENABLE_MCP` (no code reads this name).
- After: both name `AGENTA_AGENT_MCP_SERVERS_ENABLED`.

## How to QA

Prereqs: the SDK MCP resolver; MCP disabled.

1. Leave `AGENTA_AGENT_MCP_SERVERS_ENABLED` unset (or falsey).
2. Resolve a request that declares one or more `mcp_servers`.
3. Expect `MCPDisabledError`. Its message now reads "...set AGENTA_AGENT_MCP_SERVERS_ENABLED to enable them...".

Test command:

```
cd services && uv run python -m pytest oss/tests/pytest/unit/agent/tools/test_resolution.py -k mcp_disabled
```

Edge cases: the existing test (`services/oss/tests/pytest/unit/agent/tools/test_resolution.py:80`) asserts only that the message contains "disabled" and the server names, so it stays green. It does not assert the var name. A one-line assertion (`assert "AGENTA_AGENT_MCP_SERVERS_ENABLED" in message`) would lock this fix against regression; left out here to keep the commit to the two user-facing files.

Out of scope: a QA helper at `docs/design/agent-workflows/projects/qa/scripts/run_matrix.py:227` still mentions the old var in a comment string. Left for a separate change to keep this PR to the two user-facing files.

https://claude.ai/code/session_01GYo3UEfvsZpncagqb28Mbc
