### PR TITLE
fix(frontend): send committed revision reference only on clean agent runs

### DIFF
--- a/web/packages/agenta-playground/src/state/execution/agentRequest.ts
+++ b/web/packages/agenta-playground/src/state/execution/agentRequest.ts
@@ -302,7 +302,25 @@ export async function buildAgentRequest(
         | RevisionLike
         | null
         | undefined
-    const references = buildAgentReferences(entity)
+
+    // Whether the run may CLAIM its committed identity. The service derives draft-ness purely
+    // from a resolved committed-revision reference — `services/oss/src/agent/tracing.py`
+    // `_run_context_workflow`: `is_draft = revision is None` — and a self-targeting "update myself"
+    // tool binds the revision/variant that reference resolves to. So the run may forward the
+    // reference family ONLY when it is actually running that committed revision unchanged:
+    //  - dirty (unsaved left-panel edits): the run is an inline-config draft; forwarding the
+    //    revision would wrongly mark it non-draft and bind a tool to a revision whose config
+    //    differs from what's running. The resolver also re-resolves a bare variant ref to its
+    //    latest revision, so the variant must be dropped too — send no references at all.
+    //  - uncommitted local draft (no real revision UUID): same inline-config-draft case.
+    // This matches the service's documented contract: "a playground run of an unsaved inline
+    // config carries no revision reference, so is_draft is True". App scoping rides the
+    // `application_id` URL query (derived below), so a draft run stays associated with its app.
+    const fullReferences = buildAgentReferences(entity)
+    const isDirty = store.get(workflowMolecule.selectors.isDirty(entityId)) as boolean
+    const isCommittedRevisionRun =
+        !isDirty && typeof fullReferences?.application_revision?.id === "string"
+    const references = isCommittedRevisionRun ? fullReferences : null
 
     const headersFactory = store.get(executionHeadersAtom)
     // Negotiation 1 (transport): the Accept header picks the response channel `/invoke`
@@ -322,7 +340,9 @@ export async function buildAgentRequest(
     }
 
     const projectId = store.get(projectIdAtom) || undefined
-    const appId = references?.application?.id
+    // App scoping rides the URL even for a draft run (where `references` is null), so the run
+    // stays associated with its app — read it from the full identity, not the gated `references`.
+    const appId = fullReferences?.application?.id
     const url = withQuery(invocationUrl, {
         application_id: appId,
         // Mirror executionItems.ts: project_id only travels alongside auth.

--- a/web/packages/agenta-playground/tests/unit/agentRequest.test.ts
+++ b/web/packages/agenta-playground/tests/unit/agentRequest.test.ts
@@ -34,6 +34,7 @@ vi.mock("@agenta/entities/workflow", async (importOriginal) => {
                 invocationUrl: mk<string | null>(null),
                 configuration: mk<Record<string, unknown> | null>(null),
                 data: mk<Record<string, unknown> | null>(null),
+                isDirty: mk<boolean>(false),
             },
         },
     }
@@ -42,8 +43,8 @@ vi.mock("@agenta/entities/workflow", async (importOriginal) => {
 import {workflowMolecule} from "@agenta/entities/workflow"
 import {projectIdAtom} from "@agenta/shared/state"
 
-import {agentChannelModeAtom} from "../../src/state/execution/channelMode"
 import {buildAgentRequest, buildAgentReferences} from "../../src/state/execution/agentRequest"
+import {agentChannelModeAtom} from "../../src/state/execution/channelMode"
 import {executionHeadersAtom} from "../../src/state/execution/webWorkerIntegration"
 
 const REAL_APP = "11111111-1111-4111-8111-111111111111"
@@ -56,7 +57,12 @@ const set = (store: any, sel: any, id: string, value: unknown) =>
 function seed(
     store: ReturnType<typeof createStore>,
     id: string,
-    over: {url?: string | null; config?: Record<string, unknown> | null; data?: any},
+    over: {
+        url?: string | null
+        config?: Record<string, unknown> | null
+        data?: any
+        isDirty?: boolean
+    },
 ) {
     set(
         store,
@@ -66,6 +72,7 @@ function seed(
     )
     set(store, workflowMolecule.selectors.configuration, id, over.config ?? {temperature: 0.7})
     set(store, workflowMolecule.selectors.data, id, over.data ?? null)
+    set(store, workflowMolecule.selectors.isDirty, id, over.isDirty ?? false)
 }
 
 describe("buildAgentReferences (draft-id stripping)", () => {
@@ -187,8 +194,11 @@ describe("buildAgentRequest", () => {
         expect(parameters.agent).toMatchObject({model: "gpt-5.5", harness: "pi_core"})
     })
 
-    it("INCLUDES references built from the entity identity", async () => {
+    it("INCLUDES references for a CLEAN committed revision run (marks it non-draft)", async () => {
+        // A run of an unmodified committed revision claims its identity: the service marks it
+        // non-draft from the resolved revision reference and a self-targeting tool binds it.
         seed(store, "e", {
+            isDirty: false,
             data: {
                 id: REAL_REV,
                 version: 3,
@@ -203,16 +213,34 @@ describe("buildAgentRequest", () => {
         expect(refs.application_revision).toMatchObject({id: REAL_REV, version: "3"})
     })
 
-    it("STRIPS local-draft (non-UUID) ids from references", async () => {
+    it("OMITS references for a DIRTY committed revision (inline-config draft), keeping app scoping", async () => {
+        // Unsaved left-panel edits make this an inline-config draft. Forwarding the committed
+        // revision would wrongly mark it non-draft and bind a self-targeting tool to a revision
+        // whose config differs from what's running, so references are dropped entirely. The app
+        // still scopes the run via the URL query.
         seed(store, "e", {
-            data: {id: "draft-local-xyz", workflow_id: REAL_APP, version: 1},
+            isDirty: true,
+            data: {
+                id: REAL_REV,
+                version: 3,
+                workflow_id: REAL_APP,
+                workflow_variant_id: REAL_VARIANT,
+            },
         })
         const req = await buildAgentRequest("e", [], {sessionId: "s1", store})
-        const refs = req!.requestBody.references as any
-        // real app id survives; the draft revision id is dropped (version still rides)
-        expect(refs.application.id).toBe(REAL_APP)
-        expect(refs.application_revision?.id).toBeUndefined()
-        expect(refs.application_revision?.version).toBe("1")
+        expect(req!.requestBody.references).toBeNull()
+        expect(req!.invocationUrl).toContain(`application_id=${REAL_APP}`)
+    })
+
+    it("OMITS references for an UNCOMMITTED local draft (no real revision id), keeping app scoping", async () => {
+        // A never-committed local draft has no committed revision UUID, so it is an inline-config
+        // draft too — send no references, but keep the app scoping in the URL.
+        seed(store, "e", {
+            data: {id: "draft-local-xyz", workflow_id: REAL_APP, workflow_variant_id: REAL_VARIANT},
+        })
+        const req = await buildAgentRequest("e", [], {sessionId: "s1", store})
+        expect(req!.requestBody.references).toBeNull()
+        expect(req!.invocationUrl).toContain(`application_id=${REAL_APP}`)
     })
 
     it("puts project_id + application_id in the URL QUERY, never the body", async () => {


### PR DESCRIPTION
## Context

Follow-up to the run-context plumbing in #4892, per Mahmoud's coordination note on direct-call tools: when a variant is **committed**, the playground should send the committed revision reference with the run request (not just the inline config) so the service can mark the run **non-draft** and let a self-targeting tool bind its own revision/variant via `runContext`.

## Problem

The canonical playground run builder (`buildAgentRequest`, used by `AgentChatPanel`) forwarded the full reference family — `application` + `application_variant` + `application_revision` — on **every** run whenever the entity carried a UUID, ignoring whether the left-panel config had unsaved edits.

The agent service derives draft-ness purely from a resolved committed-revision reference (`services/oss/src/agent/tracing.py` → `_run_context_workflow`: `is_draft = revision is None`), and the SDK resolver (`/applications/revisions/retrieve` with `resolve: True`) re-resolves a bare variant ref to its *latest* revision. So a **dirty** (edited) run still got marked **non-draft**, and a self-targeting tool would bind a revision whose config differs from what is actually running.

## What changed

`web/packages/agenta-playground/src/state/execution/agentRequest.ts` — forward the reference family **only** when the run targets a committed, unmodified revision:

```ts
const isCommittedRevisionRun =
    !isDirty && typeof fullReferences?.application_revision?.id === "string"
const references = isCommittedRevisionRun ? fullReferences : null
```

- **Clean committed revision** → full references → service marks the run non-draft; a self-targeting tool binds the exact revision/variant.
- **Dirty (unsaved edits)** or **uncommitted local draft** → `references: null` — the service's documented "unsaved inline config carries no revision reference, so `is_draft` is True" case.
- `application_id` URL query is derived independently from the full identity, so a draft run stays associated with its app.

## Tests

`web/packages/agenta-playground/tests/unit/agentRequest.test.ts` — added clean→refs, dirty→null, and uncommitted-local-draft→null coverage (replacing the old partial-ref local-draft case). **24 tests pass**, `tsc --noEmit` clean, source lint clean.

## Note / coordination item

Dropping all references for draft runs assumes draft-run traces still surface via `application_id`/OTel rather than body references. Expressing "draft run *bound to a variant*" (variant bound but still draft) would need a backend change — an explicit `is_draft` flag, or not auto-resolving variant → latest revision. This PR is the FE half and is forward-compatible either way.