### PR TITLE
[feat] Restructure the trace/telemetry interface by semantic role

### DIFF
--- a/docs/design/agent-workflows/interfaces/cross-service/service-and-runner-trace-export.md
+++ b/docs/design/agent-workflows/interfaces/cross-service/service-and-runner-trace-export.md
@@ -7,17 +7,35 @@ turn attached to the rest of the request and what carries usage back for account
 
 ## The contract
 
-**Context in.** The `/run` request carries a `trace` block:
+**Context in.** The `/run` request carries the run's tracing inputs in two role-separated blocks —
+`context` (per-call propagation) and `telemetry` (operator-owned exporter config + capture policy):
 
 ```jsonc
 {
-  "traceparent":    "00-<traceId>-<spanId>-01",  // W3C; makes the run a child span
-  "baggage":        "...",                         // W3C baggage, carried for future use
-  "endpoint":       "https://.../api/otlp/v1/traces",  // OTLP target; falls back to env
-  "authorization":  "ApiKey ...",                  // export auth; falls back to env
-  "captureContent": true                           // false drops prompt/completion/tool I/O
+  "context": {
+    "propagation": {
+      "traceparent": "00-<traceId>-<spanId>-01",  // W3C; makes the run a child span
+      "baggage":     "..."                         // W3C baggage, carried for future use
+    }
+  },
+  "telemetry": {
+    "capture":   { "content": { "enabled": true } },  // false drops prompt/completion/tool I/O
+    "exporters": {
+      "otlp": {
+        "endpoint": "https://.../api/otlp/v1/traces",         // OTLP target; falls back to env
+        "headers":  { "authorization": "ApiKey ..." }         // export credential; falls back to env
+      }
+    }
+  }
 }
 ```
+
+Both blocks come from one service-side capture (`trace_context()`) and are both `null` when the run
+has no trace context (the standalone case). They split four roles that previously shared one `trace`
+bucket: per-call propagation context (`context.propagation`), exporter config
+(`telemetry.exporters.otlp.endpoint`), exporter credential
+(`telemetry.exporters.otlp.headers.authorization`), and capture policy
+(`telemetry.capture.content.enabled`).
 
 **Spans back out.** The runner builds a span tree per run and exports it parent-first to the
 target carried for that trace id, so Agenta can attach it under the caller's span:
@@ -46,12 +64,14 @@ way it has to be stamped before the span closes.
 
 ## Watch for when changing
 
-- **Context propagation.** `traceparent` is what makes the run a child. Drop it and the trace
-  detaches.
-- **OTLP endpoint and auth.** Per-trace target first, env fallback second. Both paths have to
-  keep working.
+- **Context propagation.** `context.propagation.traceparent` is what makes the run a child. Drop it
+  and the trace detaches.
+- **OTLP endpoint and auth.** `telemetry.exporters.otlp.endpoint` and its
+  `headers.authorization`: per-trace target first, env fallback second. Both paths have to keep
+  working.
 - **Span names and semantic attributes.** Agenta's trace UI reads these; renames ripple into
   it.
-- **`captureContent`.** When false, prompts, completions, and tool I/O must not be exported.
+- **`telemetry.capture.content.enabled`.** When false, prompts, completions, and tool I/O must not
+  be exported.
 - **Usage accounting.** Usage has to be stamped before flush, or exported traces carry zero
   totals.

--- a/docs/design/agent-workflows/interfaces/cross-service/service-to-agent-runner.md
+++ b/docs/design/agent-workflows/interfaces/cross-service/service-to-agent-runner.md
@@ -63,8 +63,12 @@ group by job:
   "sandboxPermission": { /* Layer 2 boundary; network enforced on Daytona, see sandbox-permission.md */ },
   "harnessFiles":      [ { "path": ".claude/settings.json", "content": "..." } ],
 
-  // tracing (see service-and-runner-trace-export.md)
-  "trace": { "traceparent": "...", "endpoint": "...", "authorization": "...", "captureContent": true },
+  // tracing, grouped by role (see service-and-runner-trace-export.md)
+  "context":   { "propagation": { "traceparent": "...", "baggage": null } },  // per-call W3C trace-context propagation
+  "telemetry": {                                                               // operator-owned exporter config + capture policy
+    "capture":   { "content": { "enabled": true } },                          // capture policy (default on)
+    "exporters": { "otlp": { "endpoint": "...", "headers": { "authorization": "..." } } }  // destination + credential
+  },
 
   // run context — the run's own identity, refreshed per turn (direct-call tools, Phase 3a)
   "runContext": {                          // omitted when the run has no own identity to bind
@@ -90,6 +94,17 @@ inner keys are deliberately snake_case — they are the binding namespace a `cal
 (`"$ctx.<dotted.path>"`, e.g. `"$ctx.workflow.variant.id"`) addresses, not the wire's usual
 camelCase. Omitted when there is no identity to bind, so a run that needs no binding stays
 byte-identical.
+
+The run's tracing inputs ride the wire grouped by role rather than in one `trace` bucket (they
+mixed four roles: per-call propagation, exporter config, exporter credential, and capture policy).
+`context.propagation` carries the per-call W3C trace-context headers (`traceparent` / `baggage`, kept
+verbatim) that nest the run under the caller's `/invoke` span. `telemetry` carries the
+operator-owned config: `capture.content.enabled` is the capture policy, and `exporters.otlp` is the
+OTLP destination with the credential nested under the standard `authorization` header. Both come
+from one service-side capture (`trace_context()` in `tracing.py`) and are both `null` when the run
+has no trace context. Note `context` (telemetry propagation, consumed by the runner's OTLP exporter)
+is distinct from `runContext` (the run's own resource identity, consumed by tool `call.context`
+binding); they are different roles with different consumers and are kept separate.
 
 Two splits matter for back-compat. `provider` and `connection` appear only when the model
 arrives as a structured `model_ref`; a plain string like `"gpt-5.5"` leaves them off so the

--- a/sdks/python/agenta/sdk/agents/dtos.py
+++ b/sdks/python/agenta/sdk/agents/dtos.py
@@ -356,9 +356,22 @@ EventSink = Callable[[Event], None]
 
 
 class TraceContext(BaseModel):
-    """Agenta trace context threaded into a harness run, so it nests under the caller's
-    workflow span. All fields optional; with none set the run traces standalone (or not at
-    all), the standalone-SDK case."""
+    """The run's tracing inputs, captured once per turn and serialized into TWO role-separated wire
+    objects (this is one capture, not one wire field).
+
+    The fields below are the flat capture (what the service reads off the active span and env), but
+    they play three different roles, so they ride the wire grouped by role rather than in one
+    ``trace`` bucket (see the trace/telemetry interface restructure):
+
+    - ``traceparent`` / ``baggage`` are per-call protocol CONTEXT (the W3C trace-context propagation
+      headers, kept verbatim). They ride ``context.propagation`` via :meth:`context_to_wire`.
+    - ``endpoint`` / ``authorization`` / ``capture_content`` are operator-owned telemetry CONFIG +
+      POLICY + CREDENTIAL: where spans export, what is captured, and the exporter auth. They ride
+      ``telemetry`` via :meth:`telemetry_to_wire`, with the credential nested under the exporter's
+      ``headers`` rather than as a free-floating field.
+
+    All fields optional; with none set the run traces standalone (or not at all), the
+    standalone-SDK case."""
 
     traceparent: Optional[str] = None
     baggage: Optional[str] = None
@@ -366,13 +379,28 @@ class TraceContext(BaseModel):
     authorization: Optional[str] = None  # full Authorization header value
     capture_content: bool = True
 
-    def to_wire(self) -> Dict[str, Any]:
+    def context_to_wire(self) -> Dict[str, Any]:
+        """The per-call propagation CONTEXT (W3C ``traceparent`` / ``baggage``), grouped under
+        ``context.propagation`` so it reads as protocol context, not config."""
         return {
-            "traceparent": self.traceparent,
-            "baggage": self.baggage,
-            "endpoint": self.endpoint,
-            "authorization": self.authorization,
-            "captureContent": self.capture_content,
+            "propagation": {
+                "traceparent": self.traceparent,
+                "baggage": self.baggage,
+            }
+        }
+
+    def telemetry_to_wire(self) -> Dict[str, Any]:
+        """The telemetry CONFIG: the capture POLICY (``capture.content.enabled``) and the OTLP
+        exporter destination (``exporters.otlp.endpoint``) with the CREDENTIAL nested under the
+        exporter's standard ``authorization`` header."""
+        return {
+            "capture": {"content": {"enabled": self.capture_content}},
+            "exporters": {
+                "otlp": {
+                    "endpoint": self.endpoint,
+                    "headers": {"authorization": self.authorization},
+                }
+            },
         }
 
 

--- a/sdks/python/agenta/sdk/agents/utils/wire.py
+++ b/sdks/python/agenta/sdk/agents/utils/wire.py
@@ -117,7 +117,13 @@ def request_to_wire(
         "model": config.model,
         "messages": [message.to_wire() for message in messages],
         "secrets": dict(secrets or {}),
-        "trace": trace.to_wire() if trace else None,
+        # The run's tracing inputs ride the wire grouped by role (see the trace/telemetry interface
+        # restructure): `context.propagation` carries the per-call W3C trace-context headers, and
+        # `telemetry` carries the operator-owned exporter config + capture policy. Both come from the
+        # single `trace` capture; both are null when the run has no trace context (the standalone
+        # case), matching the prior single-`trace`-null behavior.
+        "context": trace.context_to_wire() if trace else None,
+        "telemetry": trace.telemetry_to_wire() if trace else None,
         **config.wire_tools(),
         **config.wire_prompt(),
         **config.wire_mcp(),

--- a/sdks/python/agenta/sdk/agents/wire_models.py
+++ b/sdks/python/agenta/sdk/agents/wire_models.py
@@ -105,14 +105,60 @@ class WireChatMessage(_WireModel):
     content: Union[str, List[WireContentBlock]] = ""
 
 
-class WireTraceContext(_WireModel):
-    """Agenta trace context threaded into a run (mirrors ``TraceContext.to_wire``)."""
+class WirePropagation(_WireModel):
+    """The W3C trace-context propagation headers inside ``context`` (mirrors
+    ``TraceContext.context_to_wire``). Kept verbatim as the standard ``traceparent`` / ``baggage``
+    names."""
 
     traceparent: Optional[str] = None
     baggage: Optional[str] = None
+
+
+class WireRequestContext(_WireModel):
+    """The run's per-call protocol context (``context`` on the request). Carries the W3C trace
+    propagation today; a role bucket distinct from the operator-owned ``telemetry`` config and from
+    ``runContext`` (the run's own resource identity)."""
+
+    propagation: Optional[WirePropagation] = None
+
+
+class WireCaptureContent(_WireModel):
+    """The content-capture policy inside ``telemetry.capture`` — whether message and tool content is
+    captured on the exported spans (default on)."""
+
+    enabled: bool = True
+
+
+class WireCapture(_WireModel):
+    """The telemetry capture policy (``telemetry.capture``)."""
+
+    content: Optional[WireCaptureContent] = None
+
+
+class WireOtlpExporter(_WireModel):
+    """The OTLP exporter destination inside ``telemetry.exporters`` — the traces ``endpoint`` plus
+    the credential nested under the standard ``authorization`` header, so the secret lives under the
+    thing it authenticates."""
+
     endpoint: Optional[str] = None
-    authorization: Optional[str] = None
-    capture_content: bool = Field(default=True, alias="captureContent")
+    headers: Optional[Dict[str, str]] = None
+
+
+class WireExporters(_WireModel):
+    """The telemetry exporters (``telemetry.exporters``). Only OTLP today; a plural map so a second
+    exporter can be added without reshaping the contract."""
+
+    otlp: Optional[WireOtlpExporter] = None
+
+
+class WireTelemetry(_WireModel):
+    """The run's telemetry config (``telemetry`` on the request; mirrors
+    ``TraceContext.telemetry_to_wire``). Operator/policy-owned: where this run's spans export
+    (``exporters.otlp``) and the content-capture policy (``capture.content.enabled``). Distinct from
+    the per-call propagation ``context``."""
+
+    capture: Optional[WireCapture] = None
+    exporters: Optional[WireExporters] = None
 
 
 class WireToolCallback(_WireModel):
@@ -355,7 +401,11 @@ class WireRunRequest(_WireModel):
     messages: Optional[List[WireChatMessage]] = None
     # Secrets injected as harness env (provider keys); never written to the agent filesystem.
     secrets: Optional[Dict[str, str]] = None
-    trace: Optional[WireTraceContext] = None
+    # Tracing inputs, grouped by role (see the trace/telemetry interface restructure): ``context``
+    # carries the per-call W3C trace-context propagation, ``telemetry`` the operator-owned exporter
+    # config + capture policy. Both come from the single service-side trace capture.
+    context: Optional[WireRequestContext] = None
+    telemetry: Optional[WireTelemetry] = None
     # The run's own context (trace + variant identity), refreshed per turn; consumed only by a
     # tool's ``call.context`` binding at dispatch (direct-call tools, Phase 3a). Omitted when unset.
     run_context: Optional[WireRunContext] = Field(default=None, alias="runContext")

--- a/sdks/python/oss/tests/pytest/unit/agents/golden/run_request.claude.json
+++ b/sdks/python/oss/tests/pytest/unit/agents/golden/run_request.claude.json
@@ -8,7 +8,8 @@
     {"role": "user", "content": "hi"}
   ],
   "secrets": {"ANTHROPIC_API_KEY": "sk-ant"},
-  "trace": null,
+  "context": null,
+  "telemetry": null,
   "tools": [],
   "customTools": [
     {

--- a/sdks/python/oss/tests/pytest/unit/agents/golden/run_request.pi_core.json
+++ b/sdks/python/oss/tests/pytest/unit/agents/golden/run_request.pi_core.json
@@ -8,12 +8,26 @@
     {"role": "user", "content": "hi"}
   ],
   "secrets": {"OPENAI_API_KEY": "sk-test"},
-  "trace": {
-    "traceparent": "00-0af7651916cd43dd8448eb211c80319c-b7ad6b7169203331-01",
-    "baggage": null,
-    "endpoint": "https://otlp.example/v1/traces",
-    "authorization": "Access tok-123",
-    "captureContent": true
+  "context": {
+    "propagation": {
+      "traceparent": "00-0af7651916cd43dd8448eb211c80319c-b7ad6b7169203331-01",
+      "baggage": null
+    }
+  },
+  "telemetry": {
+    "capture": {
+      "content": {
+        "enabled": true
+      }
+    },
+    "exporters": {
+      "otlp": {
+        "endpoint": "https://otlp.example/v1/traces",
+        "headers": {
+          "authorization": "Access tok-123"
+        }
+      }
+    }
   },
   "runContext": {
     "workflow": {

--- a/sdks/python/oss/tests/pytest/unit/agents/test_dtos_capabilities_events.py
+++ b/sdks/python/oss/tests/pytest/unit/agents/test_dtos_capabilities_events.py
@@ -55,14 +55,18 @@ def test_agent_event_keeps_full_payload_in_data():
     assert event.data == {"type": "tool_call", "name": "search", "input": {"q": "x"}}
 
 
-def test_trace_context_to_wire_emits_all_keys_camelcase():
-    wire = TraceContext(traceparent="tp", endpoint="ep").to_wire()
-    assert wire == {
-        "traceparent": "tp",
-        "baggage": None,
-        "endpoint": "ep",
-        "authorization": None,
-        "captureContent": True,  # defaults on, camelCase
+def test_trace_context_serializes_into_role_separated_wire_objects():
+    # The single trace capture rides the wire as two role-separated objects (trace/telemetry
+    # restructure): the per-call W3C propagation under `context.propagation`, and the operator-owned
+    # exporter config + capture policy under `telemetry` (the credential nested under the OTLP
+    # exporter's standard `authorization` header). Unset fields stay null, as before.
+    trace = TraceContext(traceparent="tp", endpoint="ep")
+    assert trace.context_to_wire() == {
+        "propagation": {"traceparent": "tp", "baggage": None}
+    }
+    assert trace.telemetry_to_wire() == {
+        "capture": {"content": {"enabled": True}},  # defaults on
+        "exporters": {"otlp": {"endpoint": "ep", "headers": {"authorization": None}}},
     }
 
 

--- a/sdks/python/oss/tests/pytest/unit/agents/test_wire_contract.py
+++ b/sdks/python/oss/tests/pytest/unit/agents/test_wire_contract.py
@@ -58,7 +58,8 @@ KNOWN_REQUEST_KEYS = {
     "credentialMode",
     "messages",
     "secrets",
-    "trace",
+    "context",
+    "telemetry",
     "runContext",
     "tools",
     "customTools",
@@ -271,6 +272,26 @@ def test_request_to_wire_pi_matches_golden(golden):
         },
     }
     assert "session_id" not in payload["runContext"]
+    # The run's tracing inputs ride the wire grouped by role (trace/telemetry restructure): the
+    # per-call W3C propagation under `context.propagation`, and the operator-owned exporter config +
+    # capture policy under `telemetry` (the credential nested under the OTLP exporter's standard
+    # `authorization` header). No single `trace` bucket mixes the four roles anymore.
+    assert payload["context"] == {
+        "propagation": {
+            "traceparent": "00-0af7651916cd43dd8448eb211c80319c-b7ad6b7169203331-01",
+            "baggage": None,
+        }
+    }
+    assert payload["telemetry"] == {
+        "capture": {"content": {"enabled": True}},
+        "exporters": {
+            "otlp": {
+                "endpoint": "https://otlp.example/v1/traces",
+                "headers": {"authorization": "Access tok-123"},
+            }
+        },
+    }
+    assert "trace" not in payload
     # The declared sandbox boundary rides the wire as nested camelCase `sandboxPermission`;
     # the unset `filesystem` is dropped (declared, not enforced) so it never appears.
     assert payload["sandboxPermission"] == {
@@ -311,6 +332,11 @@ def test_request_to_wire_claude_matches_golden(golden):
     assert payload == golden("run_request.claude.json")
     # The claude payload threads no run context, so `runContext` is absent (the golden has none).
     assert "runContext" not in payload
+    # No trace context threaded on this config: both role-separated keys are null (matching the
+    # prior single `trace: null`), and the legacy `trace` key is gone.
+    assert payload["context"] is None
+    assert payload["telemetry"] is None
+    assert "trace" not in payload
     # No explicit author permission + read_only=True -> derived `allow` rides the wire.
     assert payload["customTools"][0]["permission"] == "allow"
     # Claude-specific invariants the golden encodes, asserted explicitly so a failure reads clearly.

--- a/services/agent/src/engines/sandbox_agent.ts
+++ b/services/agent/src/engines/sandbox_agent.ts
@@ -376,11 +376,11 @@ export async function runSandboxAgent(
       // The names of every skill that materialized for this run (author + forced `_agenta.*`),
       // stamped on the agent span so the trace shows which skills loaded (F-029).
       skills: plan.skillDirs.map((s) => s.name),
-      traceparent: request.trace?.traceparent,
-      baggage: request.trace?.baggage,
-      endpoint: request.trace?.endpoint,
-      authorization: request.trace?.authorization,
-      captureContent: request.trace?.captureContent,
+      traceparent: request.context?.propagation?.traceparent,
+      baggage: request.context?.propagation?.baggage,
+      endpoint: request.telemetry?.exporters?.otlp?.endpoint,
+      authorization: request.telemetry?.exporters?.otlp?.headers?.authorization,
+      captureContent: request.telemetry?.capture?.content?.enabled,
       emitSpans: !plan.isPi || plan.isDaytona,
       emit,
     });

--- a/services/agent/src/engines/sandbox_agent/pi-assets.ts
+++ b/services/agent/src/engines/sandbox_agent/pi-assets.ts
@@ -36,17 +36,19 @@ export function buildPiExtensionEnv(
   opts: { relayDir?: string; usageOutPath?: string; skills?: string[] } = {},
 ): Record<string, string> {
   const env: Record<string, string> = {};
-  const trace = tracing ? request.trace : undefined;
-  if (trace?.traceparent) env.TRACEPARENT = trace.traceparent;
-  if (trace?.endpoint) env.OTEL_EXPORTER_OTLP_TRACES_ENDPOINT = trace.endpoint;
-  if (trace?.authorization)
-    env.OTEL_EXPORTER_OTLP_HEADERS = `Authorization=${trace.authorization}`;
-  if (trace && trace.captureContent === false)
+  const propagation = tracing ? request.context?.propagation : undefined;
+  const telemetry = tracing ? request.telemetry : undefined;
+  const otlp = telemetry?.exporters?.otlp;
+  if (propagation?.traceparent) env.TRACEPARENT = propagation.traceparent;
+  if (otlp?.endpoint) env.OTEL_EXPORTER_OTLP_TRACES_ENDPOINT = otlp.endpoint;
+  if (otlp?.headers?.authorization)
+    env.OTEL_EXPORTER_OTLP_HEADERS = `Authorization=${otlp.headers.authorization}`;
+  if (telemetry?.capture?.content?.enabled === false)
     env.AGENTA_AGENT_CONTENT_CAPTURE_ENABLED = "false";
   // The skills that materialized for this run (author + forced `_agenta.*`), so Pi's own agent
   // span records which skills loaded (F-029). Only set under tracing (the extension's only span
   // consumer); a JSON array string the extension parses.
-  if (trace && opts.skills && opts.skills.length > 0)
+  if (telemetry && opts.skills && opts.skills.length > 0)
     env.AGENTA_AGENT_SKILLS_LOADED = JSON.stringify(opts.skills);
 
   const specs = publicToolSpecs(

--- a/services/agent/src/protocol.ts
+++ b/services/agent/src/protocol.ts
@@ -33,16 +33,42 @@ export interface ChatMessage {
 }
 
 /**
- * Trace context threaded in from the Agenta service so the agent run joins the caller's
- * /invoke trace instead of starting its own. All fields optional; with none set the run is
- * traced standalone (or not at all) using env config.
+ * W3C trace-context propagation threaded in from the Agenta service so the agent run joins the
+ * caller's /invoke trace instead of starting its own. `traceparent` / `baggage` are the standard
+ * W3C propagation headers, kept verbatim. This is per-call protocol CONTEXT (it changes every
+ * turn) — distinct from the operator-owned `telemetry` config (where spans export, what is
+ * captured) and from `runContext` (the run's own resource identity, bound into tool requests).
+ * All fields optional; with none set the run is traced standalone (or not at all) using env config.
  */
-export interface TraceContext {
+export interface Propagation {
   traceparent?: string;
   baggage?: string;
+}
+
+export interface RequestContext {
+  propagation?: Propagation;
+}
+
+/**
+ * How this run's telemetry behaves: where spans are exported and what may be captured. This is
+ * operator/policy-owned CONFIG, distinct from the per-call propagation `context` above.
+ *
+ *  - `capture.content.enabled` is the capture POLICY: default on; `false` strips message and tool
+ *    content from the exported spans.
+ *  - `exporters.otlp` is the OTLP destination: `endpoint` is the traces URL, and `headers` carries
+ *    the exporter CREDENTIAL under the standard `authorization` header (kept verbatim), so the
+ *    secret lives under the thing it authenticates rather than as a free-floating field.
+ *
+ * All fields optional; an absent endpoint/headers falls back to the runner's env config.
+ */
+export interface OtlpExporter {
   endpoint?: string;
-  authorization?: string;
-  captureContent?: boolean;
+  headers?: Record<string, string>;
+}
+
+export interface Telemetry {
+  capture?: { content?: { enabled?: boolean } };
+  exporters?: { otlp?: OtlpExporter };
 }
 
 /**
@@ -415,8 +441,17 @@ export interface AgentRunRequest {
    * first-party wire field plus runner-side translation.
    */
   harnessFiles?: Array<{ path: string; content: string }>;
-  /** Tracing: thread the Agenta trace context across the boundary. */
-  trace?: TraceContext;
+  /**
+   * W3C trace-context propagation: nests the run under the caller's /invoke span so the agent's
+   * work joins the same trace (see `service-and-runner-trace-export.md`). Per-call context; the
+   * run's own resource identity rides `runContext`, and the exporter config rides `telemetry`.
+   */
+  context?: RequestContext;
+  /**
+   * Telemetry config: where this run's spans export (`exporters.otlp`) and the content-capture
+   * policy (`capture.content.enabled`). Operator/policy-owned; falls back to the runner's env.
+   */
+  telemetry?: Telemetry;
   /**
    * The run's own context (trace + variant identity), refreshed per turn (direct-call tools,
    * Phase 3a). Consumed only by a tool's `call.context` binding at dispatch — the runner fills the

--- a/services/agent/tests/unit/sandbox-agent-pi-assets.test.ts
+++ b/services/agent/tests/unit/sandbox-agent-pi-assets.test.ts
@@ -41,11 +41,19 @@ afterEach(() => {
 describe("buildPiExtensionEnv", () => {
   it("exposes tracing, usage, and public tool metadata only", () => {
     const request = {
-      trace: {
-        traceparent: "00-aaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa-bbbbbbbbbbbbbbbb-01",
-        endpoint: "https://otlp.example.test/v1/traces",
-        authorization: "Bearer trace-token",
-        captureContent: false,
+      context: {
+        propagation: {
+          traceparent: "00-aaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa-bbbbbbbbbbbbbbbb-01",
+        },
+      },
+      telemetry: {
+        capture: { content: { enabled: false } },
+        exporters: {
+          otlp: {
+            endpoint: "https://otlp.example.test/v1/traces",
+            headers: { authorization: "Bearer trace-token" },
+          },
+        },
       },
       customTools: [
         {
@@ -72,11 +80,14 @@ describe("buildPiExtensionEnv", () => {
       usageOutPath: "/tmp/usage.json",
     });
 
-    assert.equal(env.TRACEPARENT, request.trace?.traceparent);
-    assert.equal(env.OTEL_EXPORTER_OTLP_TRACES_ENDPOINT, request.trace?.endpoint);
+    assert.equal(env.TRACEPARENT, request.context?.propagation?.traceparent);
+    assert.equal(
+      env.OTEL_EXPORTER_OTLP_TRACES_ENDPOINT,
+      request.telemetry?.exporters?.otlp?.endpoint,
+    );
     assert.equal(
       env.OTEL_EXPORTER_OTLP_HEADERS,
-      `Authorization=${request.trace?.authorization}`,
+      `Authorization=${request.telemetry?.exporters?.otlp?.headers?.authorization}`,
     );
     assert.equal(env.AGENTA_AGENT_CONTENT_CAPTURE_ENABLED, "false");
     assert.equal(env.AGENTA_AGENT_TOOLS_RELAY_DIR, "/tmp/relay");
@@ -97,10 +108,13 @@ describe("buildPiExtensionEnv", () => {
   it("omits trace and tool env when tracing and relay are disabled", () => {
     const env = buildPiExtensionEnv(
       {
-        trace: {
-          traceparent:
-            "00-aaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa-bbbbbbbbbbbbbbbb-01",
+        context: {
+          propagation: {
+            traceparent:
+              "00-aaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa-bbbbbbbbbbbbbbbb-01",
+          },
         },
+        telemetry: { capture: { content: { enabled: true } } },
         customTools: [{ name: "safe_tool", kind: "callback" }],
       } as AgentRunRequest,
       false,
@@ -113,9 +127,12 @@ describe("buildPiExtensionEnv", () => {
 
   it("carries the loaded skill names under tracing (F-029)", () => {
     const request = {
-      trace: {
-        traceparent: "00-aaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa-bbbbbbbbbbbbbbbb-01",
+      context: {
+        propagation: {
+          traceparent: "00-aaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa-bbbbbbbbbbbbbbbb-01",
+        },
       },
+      telemetry: { capture: { content: { enabled: true } } },
     } as AgentRunRequest;
 
     const env = buildPiExtensionEnv(request, true, {
@@ -130,9 +147,12 @@ describe("buildPiExtensionEnv", () => {
 
   it("omits the loaded skills env when there are none or tracing is off", () => {
     const request = {
-      trace: {
-        traceparent: "00-aaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa-bbbbbbbbbbbbbbbb-01",
+      context: {
+        propagation: {
+          traceparent: "00-aaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa-bbbbbbbbbbbbbbbb-01",
+        },
       },
+      telemetry: { capture: { content: { enabled: true } } },
     } as AgentRunRequest;
 
     assert.equal(

--- a/services/agent/tests/unit/wire-contract.test.ts
+++ b/services/agent/tests/unit/wire-contract.test.ts
@@ -44,7 +44,8 @@ const KNOWN_REQUEST_KEYS = [
   "credentialMode",
   "messages",
   "secrets",
-  "trace",
+  "context",
+  "telemetry",
   "runContext",
   "tools",
   "customTools",
@@ -121,6 +122,24 @@ describe("wire contract: requests (vs Python golden)", () => {
     // The conversation id is NOT duplicated in run context; it rides the top-level `sessionId`.
     assert.equal((req.runContext as Record<string, unknown>).session_id, undefined);
     assert.equal(req.sessionId, "sess-1");
+    // The run's tracing inputs reach the runner grouped by role (trace/telemetry restructure): the
+    // per-call W3C propagation under `context.propagation`, and the operator-owned exporter config +
+    // capture policy under `telemetry` (the OTLP credential under the standard `authorization`
+    // header). No single `trace` bucket mixes the four roles anymore.
+    assert.equal(
+      req.context!.propagation!.traceparent,
+      "00-0af7651916cd43dd8448eb211c80319c-b7ad6b7169203331-01",
+    );
+    assert.equal(req.telemetry!.capture!.content!.enabled, true);
+    assert.equal(
+      req.telemetry!.exporters!.otlp!.endpoint,
+      "https://otlp.example/v1/traces",
+    );
+    assert.equal(
+      req.telemetry!.exporters!.otlp!.headers!.authorization,
+      "Access tok-123",
+    );
+    assert.equal((req as Record<string, unknown>).trace, undefined);
     // Pi exposes the prompt overrides.
     assert.equal(req.systemPrompt, "You are Pi.");
     assert.equal(req.appendSystemPrompt, "Be terse.");

--- a/services/oss/src/agent/tracing.py
+++ b/services/oss/src/agent/tracing.py
@@ -153,16 +153,24 @@ def run_context() -> Optional[RunContext]:
     dispatch, server-side and hidden from the model (see
     ``projects/direct-call-tools/run-context.md``). The conversation id is not part of this blob —
     it rides the top-level ``sessionId`` field. Best-effort: any failure (or an entirely empty
-    context) returns ``None`` so the run proceeds and the ``runContext`` key is simply omitted."""
+    context) returns ``None`` so the run proceeds and the ``runContext`` key is simply omitted.
+
+    The workflow and the trace are captured as INDEPENDENT failure domains: a failure reading the
+    workflow references must not drop an otherwise-valid ``trace`` (and vice versa), so a trace-only
+    run still ships ``runContext.trace``."""
+    workflow = None
     try:
         workflow = _run_context_workflow()
-        trace = _run_context_trace()
-        if workflow is None and trace is None:
-            return None
-        return RunContext(workflow=workflow, trace=trace)
     except Exception:  # pylint: disable=broad-except
-        log.warning("agent: failed to capture run context", exc_info=True)
+        log.warning("agent: failed to capture run-context workflow", exc_info=True)
+    trace = None
+    try:
+        trace = _run_context_trace()
+    except Exception:  # pylint: disable=broad-except
+        log.warning("agent: failed to capture run-context trace", exc_info=True)
+    if workflow is None and trace is None:
         return None
+    return RunContext(workflow=workflow, trace=trace)
 
 
 def record_usage(usage: Optional[Dict[str, Any]]) -> None:

--- a/services/oss/tests/pytest/unit/agent/test_tracing.py
+++ b/services/oss/tests/pytest/unit/agent/test_tracing.py
@@ -1,0 +1,55 @@
+"""Unit tests for the agent service's tracing glue (`oss.src.agent.tracing`).
+
+Covers `run_context()`'s independent-failure-domain contract: the workflow identity and the trace
+identity are captured separately, so a failure reading one must not drop the other.
+"""
+
+from __future__ import annotations
+
+from agenta.sdk.agents import RunContextTrace, RunContextWorkflow
+
+from oss.src.agent import tracing
+
+
+def test_run_context_keeps_trace_when_workflow_capture_fails(monkeypatch):
+    # A failure reading the workflow references must not drop an otherwise-valid trace: a
+    # trace-only run still ships `runContext.trace`.
+    def boom():
+        raise RuntimeError("tracing references unavailable")
+
+    monkeypatch.setattr(tracing, "_run_context_workflow", boom)
+    monkeypatch.setattr(
+        tracing,
+        "_run_context_trace",
+        lambda: RunContextTrace(trace_id="t", span_id="s"),
+    )
+
+    ctx = tracing.run_context()
+    assert ctx is not None
+    assert ctx.workflow is None
+    assert ctx.trace == RunContextTrace(trace_id="t", span_id="s")
+
+
+def test_run_context_keeps_workflow_when_trace_capture_fails(monkeypatch):
+    # The reverse domain: a failure reading the active span must not drop a valid workflow identity.
+    def boom():
+        raise RuntimeError("span context unavailable")
+
+    monkeypatch.setattr(
+        tracing,
+        "_run_context_workflow",
+        lambda: RunContextWorkflow(is_draft=True),
+    )
+    monkeypatch.setattr(tracing, "_run_context_trace", boom)
+
+    ctx = tracing.run_context()
+    assert ctx is not None
+    assert ctx.trace is None
+    assert ctx.workflow == RunContextWorkflow(is_draft=True)
+
+
+def test_run_context_none_when_both_empty(monkeypatch):
+    # No workflow identity and no trace -> no run context at all (the key is omitted on the wire).
+    monkeypatch.setattr(tracing, "_run_context_workflow", lambda: None)
+    monkeypatch.setattr(tracing, "_run_context_trace", lambda: None)
+    assert tracing.run_context() is None


### PR DESCRIPTION
## Context

The `/run` request carries a `trace` block on **every** agent run. It mixed four different roles under one bucket — the classic interface-design failure the `design-interfaces` skill is built around:

```jsonc
"trace": {
  "traceparent": "...",     // per-call propagation CONTEXT
  "baggage": null,          // per-call propagation CONTEXT
  "endpoint": "...",        // exporter CONFIG (the destination)
  "authorization": "...",   // exporter CREDENTIAL
  "captureContent": true    // capture POLICY
}
```

Four roles, one feature label. This is the deferred "Fork A" from #4892 — the proposed shape was posted on that thread and Mahmoud greenlit it ("yes please create another pr to target this"). This PR is **shape-only**: behavior is identical.

## What changed

Split the block by semantic role into `context` (per-call protocol context) and `telemetry` (operator-owned config + policy + credential):

```jsonc
"context": {
  "propagation": { "traceparent": "...", "baggage": null }
},
"telemetry": {
  "capture":   { "content": { "enabled": true } },
  "exporters": { "otlp": { "endpoint": "...", "headers": { "authorization": "..." } } }
}
```

Both keys come from one service-side capture (`trace_context()`); both are `null` when the run has no trace context (the prior single `trace: null`). The keys are updated in lockstep across the wire and **both** OTLP readers:

- **Wire (TS):** `protocol.ts` — `TraceContext` replaced by `Propagation` / `RequestContext` / `Telemetry` / `OtlpExporter`; `AgentRunRequest.trace` → `context` + `telemetry`.
- **Wire (Python):** `dtos.py` (`TraceContext.context_to_wire()` / `telemetry_to_wire()`), `utils/wire.py` (`request_to_wire`), `wire_models.py` (`WirePropagation` / `WireRequestContext` / `WireCapture` / `WireOtlpExporter` / `WireExporters` / `WireTelemetry`).
- **The two live OTLP readers:** `engines/sandbox_agent.ts` (the tracer init) and `engines/sandbox_agent/pi-assets.ts` (the Pi extension OTLP env).
- **Golden + contract tests:** both golden fixtures, both wire-contract tests, and the DTO unit test, with explicit role-shape assertions.

The internal tracer (`tracing/otel.ts`) and its `captureContent` field are **not** touched — that is downstream of the readers and not part of the wire.

### CodeRabbit follow-up (from #4892)

`run_context()` in `services/oss/src/agent/tracing.py` treated workflow and trace capture as one failure domain — a failure reading the workflow references would drop an otherwise-valid `runContext.trace`. They are now captured as **independent failure domains**, so a trace-only run still ships `runContext.trace`. Added `test_tracing.py` covering both directions.

## Interface reference (old → new)

| Role | Old (`trace.*`) | New |
| --- | --- | --- |
| per-call propagation context | `traceparent`, `baggage` | `context.propagation.{traceparent,baggage}` |
| capture policy | `captureContent` | `telemetry.capture.content.enabled` |
| exporter config (destination) | `endpoint` | `telemetry.exporters.otlp.endpoint` |
| exporter credential | `authorization` | `telemetry.exporters.otlp.headers.authorization` |

### design-interfaces rationale

Each field now lives under a parent that answers the same question it does: standard W3C names (`traceparent`/`baggage`) kept verbatim under `context.propagation`; the credential nested under the exporter's `headers` (under the thing it authenticates) rather than free-floating; the capture policy expressed as an allowlist-style `enabled` flag, not a sibling of the data; `exporters` plural so a second exporter can be added without reshaping. `context` (telemetry propagation, read by the runner's OTLP exporter) is intentionally kept distinct from `runContext` (the run's own resource identity, read by tool `call.context` binding) — different roles, different consumers.

## Scope / risk

- **Shape-only.** No behavior change. The `captureContent`-default-on semantics (`!== false`) and the OTLP env wiring are preserved exactly. Standalone runs still serialize `context: null, telemetry: null`.
- **Single-DTO threading kept.** The Python plumbing still threads one `TraceContext` object through `SessionConfig` → `Backend.create_session` → `request_to_wire`; only the serialization (the wire) is role-split. This keeps the change to the contract, not the call graph.
- **Deferred (out of scope):** `projects/runner-interface/README.md` shows the old shape but is already stale (it still has the removed `backend` field and an old golden filename); a DTO rename (`TraceContext` is now slightly misnamed) is left as optional cleanup. Flagged, not done, to keep the diff a clean shape change.

## How to QA

```bash
# Python wire contract + models + DTO + the run_context fix
cd sdks/python && uv run ruff check agenta/sdk/agents/ \
  && uv run --no-sync python -m pytest oss/tests/pytest/unit/agents/ -n0
cd ../services && uv run --no-sync python -m pytest oss/tests/pytest/unit/agent/ -n0

# TS typecheck + the OTLP/telemetry + wire-contract tests
cd ../services/agent && pnpm run typecheck && pnpm test
```

Expected (verified locally): SDK agents 441 passed; service agent 45 passed (3 new in `test_tracing.py`); TS typecheck clean, 309 vitest passed (incl. `wire-contract.test.ts`, `sandbox-agent-pi-assets.test.ts`, `tool-direct.test.ts`). The contract tests pin both sides of the new shape and that the legacy `trace` key is gone; the pi-assets test confirms telemetry still flows to the OTLP env (`TRACEPARENT`, `OTEL_EXPORTER_OTLP_TRACES_ENDPOINT`, `OTEL_EXPORTER_OTLP_HEADERS`).

Do not merge.

https://claude.ai/code/session_01GYo3UEfvsZpncagqb28Mbc