### PR TITLE
fix(entities): keep evaluator parameter schema flat at entity layer

### DIFF
--- a/web/packages/agenta-entities/src/workflow/state/commit.ts
+++ b/web/packages/agenta-entities/src/workflow/state/commit.ts
@@ -86,19 +86,13 @@ function prepareCommitParameters(
 
 /**
  * Prepare schemas for the commit API.
- * Commits the edited `data.schemas` so input/output schema edits persist.
- * For evaluators the `parameters` subkey carries a display-only nesting transform
- * with no flatten inverse, so it is restored from the flat server schema.
+ * Commits the edited `data.schemas` so input/output AND parameters schema
+ * edits persist. Evaluator schemas are kept flat at the entity layer (see
+ * #4808), so no special-casing or restoration from the flat server schema
+ * is needed here anymore — the edited schema commits as-is.
  */
-function prepareCommitSchemas(
-    entity: Workflow,
-    flatSchemas: WorkflowData["schemas"] | null,
-): WorkflowData["schemas"] | undefined {
-    const edited = entity.data?.schemas
-    if (!entity.flags?.is_evaluator || !edited) {
-        return edited
-    }
-    return {...edited, parameters: flatSchemas?.parameters ?? edited.parameters}
+function prepareCommitSchemas(entity: Workflow): WorkflowData["schemas"] | undefined {
+    return entity.data?.schemas
 }
 
 // ============================================================================
@@ -260,7 +254,6 @@ export const commitWorkflowRevisionAtom = atom(
             const flatSource = getFlatSourceData(get, revisionId)
             const flatParams =
                 (flatSource?.data?.parameters as Record<string, unknown> | null) ?? null
-            const flatSchemas = flatSource?.data?.schemas ?? null
 
             // 2. Call the revision commit endpoint directly.
             // We do NOT use `updateWorkflow` here — that function also fires a
@@ -288,7 +281,7 @@ export const commitWorkflowRevisionAtom = atom(
                     script: entity.data.script,
                     runtime: entity.data.runtime,
                     parameters: prepareCommitParameters(entity, flatParams),
-                    schemas: prepareCommitSchemas(entity, flatSchemas),
+                    schemas: prepareCommitSchemas(entity),
                 },
             })
 
@@ -419,7 +412,6 @@ export const createWorkflowVariantAtom = atom(
             const flatSource = getFlatSourceData(get, baseRevisionId)
             const flatParams =
                 (flatSource?.data?.parameters as Record<string, unknown> | null) ?? null
-            const flatSchemas = flatSource?.data?.schemas ?? null
 
             const workflowId = entity.workflow_id ?? entity.id
             if (!entity.data) {
@@ -470,7 +462,7 @@ export const createWorkflowVariantAtom = atom(
                     script: entity.data.script,
                     runtime: entity.data.runtime,
                     parameters: prepareCommitParameters(entity, flatParams),
-                    schemas: prepareCommitSchemas(entity, flatSchemas),
+                    schemas: prepareCommitSchemas(entity),
                 },
             })
 
@@ -578,7 +570,6 @@ export const createWorkflowFromEphemeralAtom = atom(
             const flatSource = getFlatSourceData(get, revisionId)
             const flatParams =
                 (flatSource?.data?.parameters as Record<string, unknown> | null) ?? null
-            const flatSchemas = flatSource?.data?.schemas ?? null
 
             // 2. Generate a unique slug (never use the template key)
             const workflowName = name || entity.name || "Workflow"
@@ -600,7 +591,7 @@ export const createWorkflowFromEphemeralAtom = atom(
                     ? {
                           uri: entity.data.uri,
                           parameters: prepareCommitParameters(entity, flatParams),
-                          schemas: prepareCommitSchemas(entity, flatSchemas),
+                          schemas: prepareCommitSchemas(entity),
                       }
                     : undefined,
             })

--- a/web/packages/agenta-entities/src/workflow/state/store.ts
+++ b/web/packages/agenta-entities/src/workflow/state/store.ts
@@ -19,7 +19,7 @@ import {getDefaultStore} from "jotai/vanilla"
 import {atomFamily} from "jotai-family"
 import {atomWithQuery, queryClientAtom} from "jotai-tanstack-query"
 
-import {nestEvaluatorConfiguration, nestEvaluatorSchema} from "../../runnable/evaluatorTransforms"
+import {nestEvaluatorConfiguration} from "../../runnable/evaluatorTransforms"
 import {syncPromptInputKeysInParameters} from "../../runnable/utils"
 import type {StoreOptions, ListQueryState} from "../../shared"
 import {generateLocalId, isLocalDraftId, isPlaceholderId} from "../../shared"
@@ -1264,22 +1264,13 @@ export const workflowBaseEntityAtomFamily = atomFamily((workflowId: string) =>
                 const nestedParams = flatParams
                     ? nestEvaluatorConfiguration(flatParams, flatSchema)
                     : undefined
-                const nestedSchema = flatSchema ? nestEvaluatorSchema(flatSchema) : undefined
 
-                if (nestedParams || nestedSchema) {
+                if (nestedParams) {
                     localData = {
                         ...localData,
                         data: {
                             ...localData.data,
                             ...(nestedParams ? {parameters: nestedParams} : {}),
-                            ...(nestedSchema
-                                ? {
-                                      schemas: {
-                                          ...localData.data?.schemas,
-                                          parameters: nestedSchema,
-                                      },
-                                  }
-                                : {}),
                         },
                     } as Workflow
                 }
@@ -1313,14 +1304,6 @@ export const workflowBaseEntityAtomFamily = atomFamily((workflowId: string) =>
                         data: {
                             ...localMerged.data,
                             parameters: nestEvaluatorConfiguration(draftParams, reNestSchema),
-                            ...(reNestSchema
-                                ? {
-                                      schemas: {
-                                          ...localMerged.data?.schemas,
-                                          parameters: nestEvaluatorSchema(reNestSchema),
-                                      },
-                                  }
-                                : {}),
                         },
                     } as Workflow
                 }
@@ -1350,22 +1333,13 @@ export const workflowBaseEntityAtomFamily = atomFamily((workflowId: string) =>
             const nestedParams = flatParams
                 ? nestEvaluatorConfiguration(flatParams, flatSchema)
                 : undefined
-            const nestedSchema = flatSchema ? nestEvaluatorSchema(flatSchema) : undefined
 
-            if (nestedParams || nestedSchema) {
+            if (nestedParams) {
                 merged = {
                     ...merged,
                     data: {
                         ...merged.data,
                         ...(nestedParams ? {parameters: nestedParams} : {}),
-                        ...(nestedSchema
-                            ? {
-                                  schemas: {
-                                      ...merged.data?.schemas,
-                                      parameters: nestedSchema,
-                                  },
-                              }
-                            : {}),
                     },
                 } as Workflow
             }
@@ -1397,14 +1371,6 @@ export const workflowBaseEntityAtomFamily = atomFamily((workflowId: string) =>
                     data: {
                         ...finalMerged.data,
                         parameters: nestEvaluatorConfiguration(draftParams, reNestSchema),
-                        ...(reNestSchema
-                            ? {
-                                  schemas: {
-                                      ...finalMerged.data?.schemas,
-                                      parameters: nestEvaluatorSchema(reNestSchema),
-                                  },
-                              }
-                            : {}),
                     },
                 } as Workflow
             }
@@ -1452,22 +1418,13 @@ export const workflowEntityAtomFamily = atomFamily((workflowId: string) =>
                 const nestedParams = flatParams
                     ? nestEvaluatorConfiguration(flatParams, flatSchema)
                     : undefined
-                const nestedSchema = flatSchema ? nestEvaluatorSchema(flatSchema) : undefined
 
-                if (nestedParams || nestedSchema) {
+                if (nestedParams) {
                     localData = {
                         ...localData,
                         data: {
                             ...localData.data,
                             ...(nestedParams ? {parameters: nestedParams} : {}),
-                            ...(nestedSchema
-                                ? {
-                                      schemas: {
-                                          ...localData.data?.schemas,
-                                          parameters: nestedSchema,
-                                      },
-                                  }
-                                : {}),
                         },
                     } as Workflow
                 }
@@ -1501,14 +1458,6 @@ export const workflowEntityAtomFamily = atomFamily((workflowId: string) =>
                         data: {
                             ...localMerged.data,
                             parameters: nestEvaluatorConfiguration(draftParams, reNestSchema),
-                            ...(reNestSchema
-                                ? {
-                                      schemas: {
-                                          ...localMerged.data?.schemas,
-                                          parameters: nestEvaluatorSchema(reNestSchema),
-                                      },
-                                  }
-                                : {}),
                         },
                     } as Workflow
                 }
@@ -1651,22 +1600,13 @@ export const workflowEntityAtomFamily = atomFamily((workflowId: string) =>
             const nestedParams = flatParams
                 ? nestEvaluatorConfiguration(flatParams, flatSchema)
                 : undefined
-            const nestedSchema = flatSchema ? nestEvaluatorSchema(flatSchema) : undefined
 
-            if (nestedParams || nestedSchema) {
+            if (nestedParams) {
                 merged = {
                     ...merged,
                     data: {
                         ...merged.data,
                         ...(nestedParams ? {parameters: nestedParams} : {}),
-                        ...(nestedSchema
-                            ? {
-                                  schemas: {
-                                      ...merged.data?.schemas,
-                                      parameters: nestedSchema,
-                                  },
-                              }
-                            : {}),
                     },
                 } as Workflow
             }
@@ -1698,14 +1638,6 @@ export const workflowEntityAtomFamily = atomFamily((workflowId: string) =>
                     data: {
                         ...finalMerged.data,
                         parameters: nestEvaluatorConfiguration(draftParams, reNestSchema),
-                        ...(reNestSchema
-                            ? {
-                                  schemas: {
-                                      ...finalMerged.data?.schemas,
-                                      parameters: nestEvaluatorSchema(reNestSchema),
-                                  },
-                              }
-                            : {}),
                     },
                 } as Workflow
             }
@@ -1825,19 +1757,10 @@ export const workflowIsDirtyAtomFamily = atomFamily((workflowId: string) =>
             return sortObjectKeys(normalized)
         }
 
-        // Server schemas.parameters stays flat for evaluators while the entity
-        // side is nested (nestEvaluatorSchema in workflowBaseEntityAtomFamily).
-        // Nest the server schema too so the whole-data diff is like-for-like.
-        const rawServerSchemaParams = serverData.data?.schemas?.parameters as
-            | Record<string, unknown>
-            | undefined
-        const serverSchemas =
-            rawServerSchemaParams && serverData.flags?.is_evaluator
-                ? {
-                      ...serverData.data?.schemas,
-                      parameters: nestEvaluatorSchema(rawServerSchemaParams),
-                  }
-                : serverData.data?.schemas
+        // Both entity and server schemas.parameters are now flat for evaluators
+        // (schema nesting was removed from the entity layer — see #4808),
+        // so no re-nesting is needed for a like-for-like comparison.
+        const serverSchemas = serverData.data?.schemas
 
         // Compare the whole data object (so code/hook fields register as dirty),
         // keeping parameters and schemas normalized to avoid false positives.


### PR DESCRIPTION
## Summary
Fixes evaluator parameter-schema edits being silently dropped on commit.

For evaluator-flagged workflows (hook/code/LLM-as-judge), edits to the 
`parameters` schema in the config editor don't persist — input/output 
schema edits save fine, but parameter schema edits get discarded.

Root cause: `nestEvaluatorSchema` was called at the entity-merge boundary 
in `store.ts`, so every consumer (editor, dirty-check, commit) only ever 
saw the nested/display version of the schema. Since nesting has no 
inverse, `prepareCommitSchemas` in `commit.ts` had to discard any edits 
and restore the original flat schema from the server to avoid corrupting it.

**Fix:**
- Removed all `nestEvaluatorSchema` calls from the entity layer in 
  `store.ts` (8 call sites across `workflowBaseEntityAtomFamily` and 
  `workflowEntityAtomFamily`). The entity's `data.schemas.parameters` 
  now stays flat end-to-end, matching how `parameters` itself is 
  already handled.
- Simplified `workflowIsDirtyAtomFamily`'s comparison logic — no longer 
  needs to re-nest the server schema for a like-for-like diff, since 
  both sides are flat now.
- Simplified `prepareCommitSchemas` in `commit.ts` to commit the edited 
  schema as-is — no more lossy round-trip or evaluator special-casing.

This matches the approach validated by @ardaerzin in the issue thread: 
move nesting out of the entity/store layer entirely and keep it 
display-only (params nesting via `nestEvaluatorConfiguration` is 
untouched and still works correctly).

## Testing
### Verified locally
TypeScript compiles clean on both changed files (`tsc --noEmit`), no new 
errors introduced.

### Added or updated tests
N/A — no existing test coverage for this transform; happy to add if requested.

### QA follow-up
Manual UI repro of the exact DrillIn parameter-schema editor flow is 
still in progress on my end — will follow up with a demo, or appreciate 
a pointer to the exact editor view if a reviewer can share one.

## Demo
N/A for now — this is primarily a data-layer fix. Will add a UI demo 
once I confirm the exact repro flow.

## Checklist
- [ ] I have included a video or screen recording for UI changes, or marked Demo as N/A
- [x] Relevant tests pass locally
- [x] Relevant linting and formatting pass locally
- [ ] I have signed the CLA, or I will sign it when the bot prompts me

Branched off `add-code-hook-workflow-config` per @ardaerzin's guidance, 
since that's where the schema editor and `prepareCommitSchemas` currently live.

Fixes #4808