### PR TITLE
docs(agent): default config as a build-kit overlay (inspect_context)

### DIFF
--- a/docs/design/agent-workflows/projects/default-agent-config/README.md
+++ b/docs/design/agent-workflows/projects/default-agent-config/README.md
@@ -11,7 +11,7 @@ the user's own config.
 
 - `design.md`: the design. The overlay model (the frontend merges, the backend serves, the
   service runs as-is), the overlay shape (a partial `parameters.agent`, skills as `@ag.embed`),
-  where it lives on the inspect response (`inspect_context.build_kit.agent_template_overlay`), the
+  where it lives on the inspect response (`additional_context.playground_build_kit.agent_template_overlay`), the
   merge semantics, the frontend run-and-commit behavior, the advanced-drawer UI, what the backend
   does not do, the interface notes, and the change set.
 - `research.md`: the code trace behind the design. Where the default comes from, how platform

--- a/docs/design/agent-workflows/projects/default-agent-config/README.md
+++ b/docs/design/agent-workflows/projects/default-agent-config/README.md
@@ -1,20 +1,22 @@
-# Default agent config
+# Default agent config (playground build kit)
 
-Make a new agent start useful. Pre-load its config with all the platform tools and the
-default Agenta skill, present by default and removable. Workflow (reference) tools are left
-as they are.
+The platform tools and the Agenta authoring skill are a Playground build kit. The backend
+injects them into the playground session so the agent can build and improve itself. They are
+shown read-only, toggled as a whole, and never committed to the published agent. The user's
+agent ships with only the user's own config.
 
 ## Files
 
-- `design.md` — the design. Problem, the injection-point finding, the locked decisions, the
-  change set by layer, and the resolved ownership question.
+- `design.md` — the design. The inject-not-commit model, the three questions answered, the
+  `build_kit` descriptor contract the drawer reads, the per-run flag, and the change set.
 - `research.md` — the code trace behind the design. Where the default comes from, how
-  platform tools and skills are shaped, and why no disable flag exists today.
-- `status.md` — current state, decisions, coordination, and out-of-scope items.
+  platform tools and skills are shaped, and the run-prep path. Code facts still valid; the
+  approach pivoted (see status).
+- `status.md` — the pivot, the fixed contract, open questions, and coordination.
 
 ## In one line
 
-The new-agent draft reads its values from the catalog template, which is backed by a bare
-SDK default. Point the catalog template at the enriched default (frozen platform tools plus
-the getting-started skill embed), keep the SDK builtin bare, so the defaults reach the draft
-and stay removable.
+Inject the build kit (platform tools, authoring skill, build permissions) into the
+playground session for display and for the run, strip it on commit, keep the published
+default bare. The drawer reads a read-only `build_kit` descriptor from `/inspect` and toggles
+it with one per-run flag.

--- a/docs/design/agent-workflows/projects/default-agent-config/README.md
+++ b/docs/design/agent-workflows/projects/default-agent-config/README.md
@@ -1,26 +1,26 @@
 # Default agent config (playground build kit)
 
-The platform tools, the Agenta authoring skill, and the build permissions are a Playground
-build kit. The frontend injects them into the run when the user works in the playground, so
-the agent can build and improve itself. The backend only exposes the kit's information through
-`/inspect`. The agent service stays dumb: it runs the agent template it receives. The kit is
-shown read-only, toggled as a whole, and never committed. The published agent ships with only
+The platform tools, the Agenta authoring skill, and the build permissions are a playground build
+kit, modeled as an **agent-template overlay**: a partial agent template the platform serves
+read-only on the inspect response. The frontend merges the overlay onto `parameters.agent` on a
+playground run so the assistant can build and improve the agent, and leaves it out on commit. The
+agent service stays dumb: it runs the template it receives. The published agent ships with only
 the user's own config.
 
 ## Files
 
-- `design.md`: the design. The corrected model (the frontend injects, the backend informs,
-  the service stays dumb), the `/inspect` `build_kit` descriptor and how the frontend reads and
-  injects it, the frontend run-and-commit logic, the advanced-drawer UI folded in, what the
-  backend explicitly does not do, the interface notes, and the change set.
+- `design.md`: the design. The overlay model (the frontend merges, the backend serves, the
+  service runs as-is), the overlay shape (a partial `parameters.agent`, skills as `@ag.embed`),
+  where it lives on the inspect response (`inspect_context.build_kit.agent_template_overlay`), the
+  merge semantics, the frontend run-and-commit behavior, the advanced-drawer UI, what the backend
+  does not do, the interface notes, and the change set.
 - `research.md`: the code trace behind the design. Where the default comes from, how platform
-  tools and skills are shaped, the run path, and the commit path. Code facts still valid; the
-  approach pivoted (see status).
-- `status.md`: the pivot from the rejected backend-injection model, the fixed contract, open
-  questions, and coordination.
+  tools and skills are shaped, the run path, and the commit path.
+- `status.md`: where the design stands, the contract for the frontend, open questions, and
+  coordination.
 
 ## In one line
 
-The frontend reads a read-only `build_kit` descriptor from `/inspect`, injects its skills,
-tools, and permissions into `parameters.agent` on a kit-on run, and leaves them out on commit.
-The backend only describes the kit. The service never knows it exists.
+The frontend reads a read-only `agent_template_overlay` from the inspect response, merges its
+tools, skill, and sandbox permissions onto `parameters.agent` on a kit-on run, and leaves them out
+on commit. The backend only serves the overlay. The service never knows it exists.

--- a/docs/design/agent-workflows/projects/default-agent-config/README.md
+++ b/docs/design/agent-workflows/projects/default-agent-config/README.md
@@ -1,0 +1,20 @@
+# Default agent config
+
+Make a new agent start useful. Pre-load its config with all the platform tools and the
+default Agenta skill, present by default and removable. Workflow (reference) tools are left
+as they are.
+
+## Files
+
+- `design.md` — the design. Problem, the injection-point finding, the locked decisions, the
+  change set by layer, and the resolved ownership question.
+- `research.md` — the code trace behind the design. Where the default comes from, how
+  platform tools and skills are shaped, and why no disable flag exists today.
+- `status.md` — current state, decisions, coordination, and out-of-scope items.
+
+## In one line
+
+The new-agent draft reads its values from the catalog template, which is backed by a bare
+SDK default. Point the catalog template at the enriched default (frozen platform tools plus
+the getting-started skill embed), keep the SDK builtin bare, so the defaults reach the draft
+and stay removable.

--- a/docs/design/agent-workflows/projects/default-agent-config/README.md
+++ b/docs/design/agent-workflows/projects/default-agent-config/README.md
@@ -1,22 +1,26 @@
 # Default agent config (playground build kit)
 
-The platform tools and the Agenta authoring skill are a Playground build kit. The backend
-injects them into the playground session so the agent can build and improve itself. They are
-shown read-only, toggled as a whole, and never committed to the published agent. The user's
-agent ships with only the user's own config.
+The platform tools, the Agenta authoring skill, and the build permissions are a Playground
+build kit. The frontend injects them into the run when the user works in the playground, so
+the agent can build and improve itself. The backend only exposes the kit's information through
+`/inspect`. The agent service stays dumb: it runs the agent template it receives. The kit is
+shown read-only, toggled as a whole, and never committed. The published agent ships with only
+the user's own config.
 
 ## Files
 
-- `design.md` — the design. The inject-not-commit model, the three questions answered, the
-  `build_kit` descriptor contract the drawer reads, the per-run flag, and the change set.
-- `research.md` — the code trace behind the design. Where the default comes from, how
-  platform tools and skills are shaped, and the run-prep path. Code facts still valid; the
+- `design.md`: the design. The corrected model (the frontend injects, the backend informs,
+  the service stays dumb), the `/inspect` `build_kit` descriptor and how the frontend reads and
+  injects it, the frontend run-and-commit logic, the advanced-drawer UI folded in, what the
+  backend explicitly does not do, the interface notes, and the change set.
+- `research.md`: the code trace behind the design. Where the default comes from, how platform
+  tools and skills are shaped, the run path, and the commit path. Code facts still valid; the
   approach pivoted (see status).
-- `status.md` — the pivot, the fixed contract, open questions, and coordination.
+- `status.md`: the pivot from the rejected backend-injection model, the fixed contract, open
+  questions, and coordination.
 
 ## In one line
 
-Inject the build kit (platform tools, authoring skill, build permissions) into the
-playground session for display and for the run, strip it on commit, keep the published
-default bare. The drawer reads a read-only `build_kit` descriptor from `/inspect` and toggles
-it with one per-run flag.
+The frontend reads a read-only `build_kit` descriptor from `/inspect`, injects its skills,
+tools, and permissions into `parameters.agent` on a kit-on run, and leaves them out on commit.
+The backend only describes the kit. The service never knows it exists.

--- a/docs/design/agent-workflows/projects/default-agent-config/design.md
+++ b/docs/design/agent-workflows/projects/default-agent-config/design.md
@@ -66,8 +66,8 @@ Today's overlay:
       { "type": "platform", "op": "find_capabilities" },
       { "type": "platform", "op": "query_workflows" },
       { "type": "platform", "op": "commit_revision" },
-      // a client/embed tool: a non-runnable reference to a reserved-slug workflow the frontend handles (#4920)
-      { "type": "reference", "slug": "__ag__request_connection" }
+      // a client tool the embed resolver inlines: an @ag.embed of a reserved-slug workflow, the same shape as a skill embed (#4920)
+      { "@ag.embed": { "@ag.references": { "workflow": { "slug": "__ag__request_connection" } } } }
     ],
     "skills": [
       { "@ag.embed": { "@ag.references": { "workflow": { "slug": "__ag__getting_started_with_agenta" } } } }
@@ -85,11 +85,12 @@ already owns. It iterates `PLATFORM_OPS`
 platform ops, so a new op added by the builder-tools project joins the kit with no edit here. It
 also enumerates the reserved-slug platform workflows from the static workflow catalog
 (`StaticWorkflowCatalog` over `_STATIC_WORKFLOWS` at
-`/home/mahmoud/code/agenta/api/oss/src/core/workflows/static_catalog.py`) and adds each as a
-reference (workflow-as-tool) entry. These reserved workflows are the same `__ag__*` family as the
-platform skills, so a client tool like `__ag__request_connection` (the non-runnable connection
-tool the frontend handles, owned by `#4920`) rides the kit beside the platform ops with no bespoke
-path. The two iterations are symmetric: one walks the op catalog, the other walks the static
+`/home/mahmoud/code/agenta/api/oss/src/core/workflows/static_catalog.py`) and adds each as an
+`@ag.embed` reference, the same embed shape a skill uses, only the slug differs. These reserved
+workflows are the same `__ag__*` family as the platform skills, so a client tool like
+`__ag__request_connection` (a non-runnable tool the embed resolver inlines into a `client` tool the
+frontend handles, owned by `#4920`) rides the kit beside the platform ops with no bespoke path. The
+two iterations are symmetric: one walks the op catalog, the other walks the static
 workflow catalog. `skills` is the `@ag.embed` reference to the authoring skill's reserved slug;
 `sandbox` is the build-permission elevation. Each entry is an ordinary agent-template fragment, so
 the dumb service resolves it the way it resolves any tool, skill, or sandbox setting, and a kit-on
@@ -141,13 +142,15 @@ on.
 
 A kit-on run produces a derived run config by merging the overlay onto a copy of the current
 `parameters.agent`. The merge is an override overlay: the overlay adds entries the config lacks
-and overrides entries it already holds.
+and overrides entries it already holds. When the overlay overrides a user setting, the drawer
+flags it on that user's own control (see the override hint in the drawer UI), so the user can see
+what the kit changed and how to match the published agent.
 
 - **Object fields** (`sandbox`, `runner`, `harness`, `llm`, `instructions`) deep-merge, and the
   overlay wins on a conflict. So `sandbox.permissions.write_files: "allow"` elevates the run's
   sandbox without discarding the user's other sandbox settings.
 - **List fields** (`tools`, `skills`, `mcps`) merge by item identity. A tool's identity is its
-  `op` for a platform tool, the referenced workflow for a reference (non-runnable workflow) tool,
+  `op` for a platform tool, the referenced workflow slug for an `@ag.embed` tool,
   otherwise its `name`; a skill's identity is the slug its `@ag.embed` references; an MCP server's
   identity is its `name`. On an identity match the overlay entry
   overrides; otherwise it appends. So the kit's three platform ops and one authoring skill add to
@@ -226,8 +229,8 @@ panel already uses, so the groups stop rendering as one long scroll.
 - Summaries reuse state already present: Authentication shows `Agenta-managed`, Execution
   environment shows `Sandbox: Local`, Permissions shows `Auto`.
 
-This change carries no contract and no commit logic. It is drawer polish on the existing groups
-and can ship on its own (open question 4).
+This change carries no contract and no commit logic. It is drawer polish on the existing groups,
+so it ships as a separate, independent change, not part of the build-kit core.
 
 ### Change 2: add the "Playground build kit" section
 
@@ -254,10 +257,11 @@ illustrative.
 
 ### The toggle wiring
 
-The toggle does not set a run flag. It is `buildKitEnabled`, session state, default on. The
-frontend reads it when it builds the run request and applies the overlay when it is on (frontend
-behavior, step 2). The drawer writes nothing into the config and never echoes the overlay. The
-toggle is a playground preference, not a field on the revision.
+The toggle does not set a run flag. It is `buildKitEnabled`, ephemeral session state that resets
+to on each session, default on. The frontend reads it when it builds the run request and applies
+the overlay when it is on (frontend behavior, step 2). The drawer writes nothing into the config
+and never echoes the overlay. The toggle is a playground preference, not a field on the revision
+and not a stored preference in v1.
 
 ### Keep two permission ideas distinct
 
@@ -274,6 +278,16 @@ Permissions group stays an editable, committed control elsewhere. Review this wi
 because the two ideas sit close together and a user who conflates them could believe the agent
 ships with write-files and execute-code permission.
 
+### Show an override hint on an overridden user control
+
+When the kit is on and the overlay overrides one of the user's own settings, the drawer control
+for that user setting shows a hint or tooltip: the value is overridden in the playground by the
+build kit, and to make the playground match the published agent the user toggles the build kit off.
+The load-bearing case is a permission. If the user disables execute-code in their own config but
+the kit re-enables it for the playground run, the Permissions control tells the user why the
+playground behaves differently from the published agent and how to match it (toggle the kit off).
+The hint appears only on a control the overlay actually overrides, and only while the kit is on.
+
 ## Published default stays bare
 
 A new agent's stored config is bare: no platform tools, no authoring skill, no elevated sandbox.
@@ -284,15 +298,9 @@ boundary (`build_agent_v0_default(skill_slug=..., include_sandbox_permission=Tru
 `/home/mahmoud/code/agenta/services/oss/src/agent/schemas.py`). Revert that enrichment so the
 inspect schema default and the catalog template both carry the bare default, the same value the
 SDK builtin carries. The skill and the sandbox elevation reach a run only through the overlay, by
-the frontend's merge.
-
-The authoring skill also stops reaching runs through the harness force. Today the `pi_agenta`
-harness unions `AGENTA_FORCED_SKILLS` into every run, always on and not toggleable
-(`/home/mahmoud/code/agenta/sdks/python/agenta/sdk/agents/adapters/agenta_builtins.py:104`,
-`harnesses.py:140`). A forced skill cannot be toggled, which contradicts the kit's toggle. So the
-authoring skill comes from the overlay, not the force. Set `AGENTA_FORCED_SKILLS = []`, keeping
-`force_skills` for a future genuinely-forced item. This touches the skills project's surface, so
-confirm it with them (open question 2).
+the frontend's merge. The overlay delivers the authoring skill on its own, through its own
+`@ag.embed` reference, so the published default carries no skill of its own. Reverting the
+`schemas.py` enrichment is the only backend change this needs.
 
 ## What the backend explicitly does NOT do
 
@@ -344,21 +352,18 @@ The model rests on role splits, not feature splits.
 3. **Published default goes bare (backend).** Revert the `schemas.py` enrichment so the schema
    default is bare. Move the authoring skill and the sandbox elevation into the overlay.
 
-4. **Stop force-injecting the skill (SDK).** Set `AGENTA_FORCED_SKILLS = []`
-   (`agenta_builtins.py:104`). Coordinate with the skills project.
-
-5. **Frontend read and render (web).** Read `additional_context.playground_build_kit.agent_template_overlay`
+4. **Frontend read and render (web).** Read `additional_context.playground_build_kit.agent_template_overlay`
    into session state. Render the "Playground build kit" section, reusing the existing config-item
-   controls, and make the advanced sections collapsible.
+   controls.
 
-6. **Frontend overlay applier (web).** Add an explicit applier (deep-merge objects, identity-merge
+5. **Frontend overlay applier (web).** Add an explicit applier (deep-merge objects, identity-merge
    lists) and call it in `buildAgentRequest` when the toggle is on, on the throwaway run copy
    only.
 
-7. **Frontend exclude on commit (web).** No change beyond confirming the overlay is never written
+6. **Frontend exclude on commit (web).** No change beyond confirming the overlay is never written
    into `entity.data.parameters`, so `prepareCommitParameters` excludes it for free.
 
-8. **Tests.** Backend: the builder lists the platform ops, the authoring skill, and the build
+7. **Tests.** Backend: the builder lists the platform ops, the authoring skill, and the build
    permissions as one overlay; the inspect response carries `additional_context.playground_build_kit`; the
    published default is bare across the builtin, the inspect schema, and the catalog (update
    `/home/mahmoud/code/agenta/services/oss/tests/pytest/unit/agent/test_default_agent_template.py`).
@@ -390,28 +395,31 @@ The model rests on role splits, not feature splits.
   references the skill by its reserved slug.
 - The builder-tools project (`#4919`) adds more platform ops. The builder reads `PLATFORM_OPS` at
   assembly time, so new ops join the overlay automatically.
-- A client tool such as `request_connection` is not a platform op. It is a non-runnable
-  workflow (reference) tool: the backend exposes it and the frontend handles the call, the same
-  reference-tool concept the platform already has. The kit carries it as a reference-tool entry,
-  embedded from its reserved `__ag__*` slug (identity by its referenced workflow), beside the
-  platform ops. Its primary definition is owned by `#4920`.
+- A client tool such as `request_connection` is not a platform op. The kit carries it as an
+  `@ag.embed` reference to its reserved `__ag__*` slug, the same embed shape a skill uses, only the
+  slug differs; the embed resolver inlines it into a `client` tool the frontend handles (identity
+  by its referenced workflow slug), beside the platform ops. Its primary definition is owned by
+  `#4920`.
 - Per-item edit or delete of kit items, and a picker to add platform tools to the published agent,
   are out of scope. The kit is whole-toggle and read-only in v1.
 - The overlay model carries through to `#4918`, `#4919`, and `#4920`. They are not edited here; the
   orchestrator propagates it after Mahmoud approves this design.
 
+## Decisions
+
+- **Toggle persistence.** Ephemeral per playground session, resetting to on. Not a stored
+  preference in v1.
+- **Merge precedence on a conflict.** The overlay wins on an identity match: it is an override
+  overlay. When it overrides a user setting, the drawer flags it on that user's own control with an
+  override hint (toggle the kit off to match the published agent).
+- **Change 1 (collapsible sections).** Ships as a separate, independent change, not part of the
+  build-kit core.
+
 ## Open questions for Mahmoud
 
-1. **Toggle persistence.** Ephemeral per playground session (resets to on), or a stored playground
-   preference per user and agent. I lean ephemeral for v1.
-2. **Confirm the published default goes fully bare**, dropping the authoring skill and the sandbox
-   boundary from the schema default into the overlay, and setting `AGENTA_FORCED_SKILLS = []`. This
-   touches the skills project's surface, so it needs their nod.
-3. **Merge precedence on a conflict.** The overlay overrides on an identity match (it is an
-   override overlay). Confirm the kit should win over a user entry of the same identity, rather
-   than yield to it.
-4. **Ship Change 1 (collapsible sections) with the kit, or separately?** It is independent UI
-   polish with no contract and no logic. I lean separate.
+1. **Confirm the published default goes bare**, dropping the authoring skill and the sandbox
+   boundary from the schema default into the overlay. This touches the skills project's surface, so
+   it needs their nod.
 
 ## Appendix: prior approaches
 

--- a/docs/design/agent-workflows/projects/default-agent-config/design.md
+++ b/docs/design/agent-workflows/projects/default-agent-config/design.md
@@ -1,240 +1,278 @@
-# Design: default agent config (platform tools and the default skill)
+# Design: the playground build kit (inject, do not commit)
 
 Status: draft for Mahmoud's review. Grounded in code on `gitbutler/edit` over
-`big-agents`, 2026-06-28. See `research.md` for the full code trace.
+`big-agents`, 2026-06-28. See `research.md` for the code trace. This rewrite replaces an
+earlier approach (materialize the defaults into the catalog template). That approach is
+dropped. See "What changed and why".
 
 ## Problem and goal
 
-When a user creates a new agent, the config arrives almost empty: no tools, no skills. We
-want a new agent to start useful. The config should arrive pre-loaded with:
+A new agent arrives almost empty. We want the playground to give the agent the tools and
+skills it needs to build and improve itself, without writing those tools and skills into the
+published agent.
 
-1. All the platform tools. Today that is the three core ops (`find_capabilities`,
-   `query_workflows`, `commit_revision`). Once the builder project ships its tools, the default
-   grows to carry every platform op the catalog holds: the three core ops plus the eight trigger
-   and cron ops (`create_schedule`, `create_subscription`, `list_schedules`,
-   `list_subscriptions`, `list_deliveries`, `list_connections`, `test_subscription`,
-   `find_triggers`). Several of these are approval-gated. They all ship with their catalog
-   default permissions, and the user can edit those permissions. This is intended (see decision 3
-   and the risks section).
-2. The default Agenta skill (`agenta-getting-started`), referenced by embed.
+The platform tools and the Agenta authoring skill are a build aid, not part of the user's
+agent. The user is shipping their agent. The platform ops (find capabilities, query
+workflows, commit a revision) and the authoring skill exist so the agent can scaffold and
+edit itself while the user works on it in the playground. Once the agent ships, it should
+not carry Agenta's authoring tools unless the user added their own.
 
-Workflow (reference) tools are user-added and stay exactly as they are. This design does
-not touch them.
+So the model is inject, not commit. The backend injects the kit into the playground
+session, for display and for the run. The commit writes only the user's real config.
 
-The defaults are opt-out. The user can remove any default item. Disable-but-keep is a
-later addition, not part of this design (see decision 2).
+## What changed and why
 
-Out of scope: the debug-mode UX issue where defaults are not shown, and any "add platform
-tool" picker. We cover making the defaults present and removable, nothing more on UX.
+The earlier draft made the platform tools and the skill embed part of the agent config and
+baked them into the catalog template, so a new agent committed them. Mahmoud reviewed that
+and rejected it. The defaults should not be committed to the agent. They are a playground
+overlay. The designer handoff (`design_handoff_advanced_build_kit`) names this exactly: a
+"Playground build kit" that is "Removed on commit" and "None of this is part of the
+published agent".
 
-## What ships today
+Two consequences. The published-config default stays bare. The build kit becomes a separate
+backend concept that the playground injects and the commit strips.
 
-- One builder is the source of the default agent config:
-  `build_agent_v0_default(...)` at
-  `/home/mahmoud/code/agenta/sdks/python/agenta/sdk/utils/types.py:1399`. It returns
-  `tools: []` and, only when asked, one skill embed. It already accepts `skill_slug=` and
-  `include_sandbox_permission=`.
-- Platform tools are catalog ops. Three exist today (`find_capabilities`, `query_workflows`,
-  `commit_revision`); the builder project adds eight more. A config entry is just
-  `{"type": "platform", "op": "<name>"}`. There is no wildcard.
-- The default skill is one placeholder, `agenta-getting-started`, served read-only from
-  code by the static catalog under the reserved slug `__ag__getting_started_with_agenta`.
-- Today the skill reaches a run two ways, and neither is what we want:
-  - The service `/inspect` schema default embeds it (passes `skill_slug`), but that path
-    does not reach the new-agent draft (see the injection-point finding below).
-  - The `pi_agenta` harness force-injects it via `AGENTA_FORCED_SKILLS`. Forced means the
-    user can never remove it. That is the opposite of opt-out.
-- No `enabled`/`disabled` flag exists on tools or skills. Items are present or absent.
+This is also simpler. Nothing about the kit is persisted into the agent, so there is no
+merge, no per-item delete marker, and no list of suppressed defaults in the stored config.
 
-## The injection point (the finding)
+## The model
 
-Mahmoud's instinct was right: the defaults must reach the temporary playground (the draft
-of a not-yet-created agent). I traced exactly where that draft gets its values.
+The build kit is a backend-defined set of three things:
 
-When the user creates a new agent, the frontend builds a local draft in
-`createEphemeralAppFromTemplate`
-(`/home/mahmoud/code/agenta/web/packages/agenta-entities/src/workflow/state/appUtils.ts:118`).
-It fills the draft from two different sources:
+- Tools: the platform ops, sourced from the catalog (`PLATFORM_OPS`).
+- Skills: the Agenta authoring skill.
+- Permissions: the sandbox elevation the agent needs to build, write files and execute code.
 
-- The editable parameter values come from the catalog template, `template.data.parameters`
-  (appUtils.ts:189). This is what the user sees and edits.
-- The schemas (the shape used to render controls) come from `/inspect`, best effort
-  (appUtils.ts:171-185). Only the schema shape. Not the parameter values.
+The kit has one source of truth in the backend. It flows three ways.
 
-So the draft's actual values come from the catalog, not from `/inspect`.
+- Display. The backend exposes the kit so the Advanced drawer renders it as a read-only
+  group the user can toggle on or off. The drawer owns that UX, not this design.
+- Run. When the playground runs the agent with the kit on, the backend injects the kit into
+  the effective config for that run, before tool and skill resolution. The agent runs with
+  the platform tools, the authoring skill, and the build permissions.
+- Commit. The commit writes only the user's config. The kit is never in the stored config,
+  so there is nothing to strip. It is absent by construction.
 
-The catalog builds `template.data.parameters` by reading the `default` off the parameters
-schema (`_extract_schema_parameter_defaults` in
-`/home/mahmoud/code/agenta/api/oss/src/resources/workflows/catalog.py:27`). That schema
-comes from the SDK interface registry, not from the service. The agent interface there is
-bare:
+The kit is off by default for any plain run of the agent. The playground turns it on. A
+production run of a published agent never injects it. This matters: the kit lets the agent
+rewrite itself and run code, which is a build-time power, not a shipped one.
+
+## The three questions
+
+### 1. How do we do this smartly, without too much complexity?
+
+Never commit the kit. That single rule removes the hard parts. There is no base-plus-patch
+merge in the stored config, no tombstone to record a deleted default, and no suppressed-list
+field. The stored config holds only the user's items, exactly as it does today.
+
+The kit is one backend definition. The run path injects it into the in-memory effective
+config at the existing run-prep step, then reuses the tool, skill, and permission resolution
+that already runs. The display path reads the same definition. The commit path does nothing
+new, because the kit was never in the config it serializes.
+
+The published-config default does not change. It stays bare. We do not touch the catalog
+template or the new-config seed. We add one concept (the kit) and one run flag (inject the
+kit for this session), and we move the authoring skill out of the published default and into
+the kit.
+
+### 2. Can we avoid hardcoding this in the frontend?
+
+Yes. The kit's contents come entirely from the backend. The backend names the tools, the
+skill, and the permissions, with labels for the drawer. The frontend renders the groups it
+receives and owns only the on or off toggle. It never lists a platform op or a skill name in
+its own code. The designer handoff says the same: "confirm the real set with the backend",
+and "the build-kit contents come from whatever Agenta already injects".
+
+### 3. Where does the injection happen, and how do we keep it out of the frontend?
+
+Two injection points, one backend source.
+
+- Display: the backend serves a build-kit descriptor. The drawer reads it. The set is
+  decided server-side.
+- Run: the agent service injects the kit into the effective config at run-prep, in `_agent`
+  (`/home/mahmoud/code/agenta/services/oss/src/agent/app.py:207`), before
+  `resolve_tools(agent_template.tools)` at line 227. Gated by the run flag. The injection is
+  harness-agnostic, so it works on `pi_core` as well as `pi_agenta`.
+
+The frontend never decides the set. It reads it for display and sends the toggle for the
+run.
+
+## Does `/inspect` already carry enough, or do we add a signal?
+
+`/inspect` is the right channel. The frontend already fetches it per workflow, so the drawer
+reads it with no new call. But the value `/inspect` carries today does not suffice. It
+carries the published-config schema default at
+`revision.data.schemas.parameters.properties.agent.default`
+(`/home/mahmoud/code/agenta/services/oss/src/agent/schemas.py:52`). That value's role is the
+seed for the user's persisted config. The build kit's role is an ephemeral overlay that the
+run injects and the commit excludes. Those are two different roles. Overloading the schema
+default to also mean "the kit to inject and strip" is the exact role confusion that caused
+the original gap, where the skill embed sat in a default the draft never read.
+
+So deliver a dedicated descriptor in the `/inspect` response, as a new read-only sibling of
+`schemas`, not inside the schema default. After this, `/inspect` carries two distinct things
+with two distinct roles: the bare schema default (the seed for the user's config) and the
+`build_kit` descriptor (the platform overlay). The exact descriptor shape is the contract
+below.
+
+Cleaning up the schema default is part of this. Today `schemas.py` enriches the published
+default with the skill embed and the sandbox boundary. Under this model those belong to the
+kit, not the published default. Move them. The published default returns to bare, the same
+value the SDK builtin already carries.
+
+## The build-kit contract (the drawer reads this)
+
+The advanced-build-kit drawer renders this exact shape and never invents its own. Field
+names are part of the contract.
+
+Delivered in the `/inspect` response at `revision.data.build_kit`, a read-only sibling of
+`revision.data.schemas`. It is platform-owned. The frontend reads it, renders it, and never
+writes, merges, or echoes it back.
 
 ```
-# interfaces.py:537
-default=build_agent_v0_default()   # no skill, no tools
+build_kit:
+  skills:      [ { key, name, description } ]                  # key = the skill slug
+  tools:       [ { key, name, description } ]                  # key = the platform op
+  permissions: [ { key, name, description, status } ]          # status only on permissions
 ```
 
-The comment on that line is explicit: "The minimal builtin default: no platform skill, no
-sandbox_permission. The agent service adds both via the same builder (see schemas.py)."
+- Grouped by kind: `skills`, `tools`, `permissions`. The drawer renders one read-only group
+  per kind, in that order.
+- Every row carries `key` (a stable identifier), `name` (the display name), and
+  `description` (the one-line purpose). `key` is the slug for a skill, the op for a tool, and
+  the permission key for a permission. The kind is the array the row sits in, so a row needs
+  no kind tag.
+- `permissions` rows additionally carry `status` (for example `on`), which the drawer shows
+  as the green status pill. Skills and tools rows have no `status`.
+- The source: `tools` from `PLATFORM_OPS` (the catalog owns the name, description, and per-op
+  permission), `skills` from the authoring skill (its slug, name, description), `permissions`
+  from the build permission set (write files, execute code). One backend builder produces all
+  three groups, and the same builder feeds the run-time injection, so the displayed kit and
+  the injected kit are the same set.
 
-So there are two separate defaults for the agent:
+The per-run flag the drawer toggle controls:
 
-- The SDK interface default (bare). Feeds the catalog, which feeds the new-agent draft.
-- The service `/inspect` default (enriched with the skill embed and the sandbox boundary).
-  Feeds `/inspect`, which the draft reads for schemas only, never for values.
+- `flags.inject_build_kit` (boolean), on the run request, request-scoped. The drawer's
+  enable or disable toggle sets it. When the kit is off the drawer sends `false`, the run
+  skips injection, and the agent runs with the user's config only. It defaults to off
+  server-side, so a request that omits it (any non-playground caller) never injects the kit.
+  The drawer defaults the toggle on, so a normal playground run sends `true`.
 
-That is the gap. The service enriches the default the draft never reads, and the draft
-reads the bare default the SDK interface declares. The skill embed the service adds, and
-the platform tools we want to add, do not reach a new agent.
+The two names intentionally pair: `build_kit` is the read-only catalog of what the toggle
+controls, and `inject_build_kit` is the toggle. They live in different messages (the inspect
+response versus the run request), so they never appear together.
 
-### Why the skill embed did not reach the draft
+## Change set, by layer
 
-The getting-started skill is already embedded in the default, but only on the service
-`/inspect` default. The catalog template, which is the surface the draft actually reads,
-still uses the bare builder. So the embed sits on a default no one reads for values. The
-fix is not to make the draft read `/inspect`. The fix is to put the enriched default (the
-platform tools plus the skill embed) into the catalog template path. Then it reaches the
-draft, and `/inspect` is not used for values at all.
+1. Build-kit definition. One backend builder returns the kit (tools from `PLATFORM_OPS`,
+   the authoring skill, the build permissions), with identifiers and labels. Single source.
+   The tool set is read from the catalog at call time, so a new op added by the builder-tools
+   project (`#4919`) joins the kit with no edit here. Likely home: the agent service or a
+   shared SDK helper that both the service and the API import.
 
-## The four decisions (locked by Mahmoud)
+2. Display signal. Serve the `build_kit` descriptor (the contract above) in the `/inspect`
+   response at `revision.data.build_kit`, a read-only sibling of `schemas`. The API inspect
+   proxy
+   (`/home/mahmoud/code/agenta/api/oss/src/apis/fastapi/applications/router.py:473`)
+   forwards the new sibling alongside `schemas`; confirm it passes `revision.data` through
+   rather than allow-listing fields. The same backend builder that produces the descriptor
+   feeds the run injection.
 
-1. The default skill is embedded, not forced. The default config carries an `@ag.embed`
-   of `__ag__getting_started_with_agenta`, present by default and removable. Stop
-   force-injecting it through the `pi_agenta` harness. Keep the `force_skills` mechanism in
-   the code for a future skill that carries real functionality.
-2. Delete-only for v1. No `is_active` flag now. Disable-but-keep comes later.
-3. Platform tools are a frozen, explicit list. Read all ops from the catalog at build
-   time, then store the result as a concrete list. No wildcard, no run-time resolution of
-   "all".
-4. The defaults must surface where the new-agent draft reads them, so the temporary
-   playground shows them.
+3. Run injection. In `_agent`
+   (`/home/mahmoud/code/agenta/services/oss/src/agent/app.py:207`), when
+   `flags.inject_build_kit` is true, merge the kit's tools into `agent_template.tools`, its
+   skill into `agent_template.skills`, and its permissions into the sandbox permission, before
+   the existing `resolve_tools` / `resolve_mcp_servers` calls. Reuse all existing resolution.
+   The flag rides `WorkflowInvokeRequestFlags` (`app.py:214`), defaults off server-side, and
+   the playground sends it on.
 
-## Proposed change set, by layer
+4. Published default stays bare. Revert the `schemas.py` enrichment so the `/inspect` schema
+   default and the catalog template both carry the bare default (no skill, no tools). The
+   skill embed and the sandbox boundary move into the kit. File:
+   `/home/mahmoud/code/agenta/services/oss/src/agent/schemas.py:52`. The catalog
+   (`/home/mahmoud/code/agenta/api/oss/src/resources/workflows/catalog.py`) needs no change;
+   the earlier materialize edit is dropped.
 
-The fix points the catalog template at the enriched default. The catalog is the surface
-the draft reads. Today it sources the agent default from the bare SDK builtin interface. It
-will instead source the enriched default: the same builder output the service already uses,
-plus the frozen platform-tools list. The SDK builtin interface stays bare. `/inspect` is
-not used for the draft's values.
+5. Stop force-injecting the skill. Set `AGENTA_FORCED_SKILLS = []`
+   (`/home/mahmoud/code/agenta/sdks/python/agenta/sdk/agents/adapters/agenta_builtins.py:104`).
+   The authoring skill now reaches a playground run through the kit injector, not through the
+   `pi_agenta` harness force. Keep `force_skills`, `force_tools`, and the skill constant for a
+   future genuinely-forced item.
 
-1. SDK builder. Extend `build_agent_v0_default` with one option that adds the platform
-   tools, sourced from `PLATFORM_OPS.keys()` at build time and frozen into a concrete list
-   of `{"type": "platform", "op": "<name>"}` entries (decision 3). The skill embed already
-   has `skill_slug=`. The builder gains the ability to emit these; its own no-arg default
-   does not change, so the bare builtin stays bare. File:
-   `/home/mahmoud/code/agenta/sdks/python/agenta/sdk/utils/types.py:1399`.
-
-2. Catalog template (the load-bearing fix for the draft). Source the agent template entry's
-   parameter default from the enriched default
-   (`build_agent_v0_default(skill_slug=__ag__getting_started_with_agenta,
-   include_sandbox_permission=True, include_platform_tools=True)`) rather than the bare
-   builtin the interface registry carries. The existing extraction and normalization
-   pipeline then moves the object default into `data.parameters` as it already does, so
-   `template.data.parameters.agent` carries the platform tools and the skill embed. This is
-   the larger interface-registry wiring change: the catalog stops inheriting the bare
-   interface default for the agent entry. File:
-   `/home/mahmoud/code/agenta/api/oss/src/resources/workflows/catalog.py` (the
-   `_enrich_entry` / `_build_template_data` path for the agent entry). The enriched default
-   imports cleanly from the SDK (`build_agent_v0_default`, `PLATFORM_OPS`, and the slug
-   constant `GETTING_STARTED_WITH_AGENTA_SLUG`), so no new shared module is needed.
-
-3. Service `/inspect`. Already passes `skill_slug` and `include_sandbox_permission`. Add the
-   platform-tools option so its default and the catalog template share one enriched value
-   and cannot drift. This keeps `/inspect` consistent and keeps the runtime fallback (which
-   uses the service default) consistent. The frontend still does not read values from
-   `/inspect`. File:
-   `/home/mahmoud/code/agenta/services/oss/src/agent/schemas.py:52`.
-
-4. Stop force-injecting the skill. Set `AGENTA_FORCED_SKILLS = []`. Keep `force_skills`,
-   `GETTING_STARTED_WITH_AGENTA_SKILL`, the slug constant, and the static catalog. The
-   getting-started skill now reaches agents through the embedded default config, where the
-   user can remove it. File:
-   `/home/mahmoud/code/agenta/sdks/python/agenta/sdk/agents/adapters/agenta_builtins.py:104`.
-   Leave `AGENTA_FORCED_TOOLS = ["read", "bash"]` alone; those are Pi builtins for skill
-   rendering, unrelated to the platform-op tools.
-
-5. Frontend, removable defaults. The skill control currently renders a `__ag__` static
-   skill as read-only and non-removable ("cannot be edited or removed"). Opt-out needs the
-   reference removable. Split the two ideas: the skill's content stays read-only (it is
-   Agenta's skill), but the embed in my config can be deleted. Verify the tools control
-   renders `{"type":"platform","op":...}` entries and allows deleting them; if it does
-   not, add that. Files:
-   `/home/mahmoud/code/agenta/web/packages/agenta-entity-ui/src/DrillInView/SchemaControls/SkillTemplateControl.tsx`
-   and the tools control in the same folder. Adding or picking new platform tools is out
-   of scope; only delete must work.
-
-6. Tests. The agent-template default test asserts three sources today
-   (`/home/mahmoud/code/agenta/services/oss/tests/pytest/unit/agent/test_default_agent_template.py`):
-   builtin equals the bare builder, and the service equals bare plus extras. Keep
-   builtin-equals-bare. Update the service test so the extras now include the frozen
-   platform tools. Add a catalog test (in the API suite) that asserts the agent template's
-   `data.parameters.agent` carries the platform tools and the skill embed, which is the
-   real guarantee that the draft gets the defaults.
-
-The defaults bake into the stored revision at create or commit time. Existing agents are
-not touched. A new platform tool added to the catalog later appears only in agents created
-after that, which is the correct behavior for opt-out defaults.
-
-## Coordination
-
-A separate skills subagent owns the getting-started skill content and any naming updates.
-This design does not write skill content. It owns embed-by-default: the getting-started
-skill arrives as an embedded default config item, referenced by `@ag.embed` to its stable
-slug, present by default and removable. See the agent-creation-skills and skills-config
-projects for the skill content and the static catalog.
+6. Tests. The default-template test
+   (`/home/mahmoud/code/agenta/services/oss/tests/pytest/unit/agent/test_default_agent_template.py`)
+   asserts the service default equals bare plus the skill and sandbox extras. Update it: the
+   published default is now bare across the builtin, `/inspect`, and the catalog. Add a test
+   that the build-kit descriptor lists the platform ops and the authoring skill, and a
+   run-prep test that an inject-kit run resolves the platform tools while a kit-off run does
+   not.
 
 ## Interface design notes
 
-This design adds no new wire field and no new contract surface. That is deliberate and
-worth stating.
+The model rests on three clean separations. Each is a semantic-role split, not a feature
+split.
 
-- The platform tool entries reuse the existing `platform` tool shape
-  (`{"type": "platform", "op": "<name>"}`). The `op` is a stable identifier into the
-  catalog. Role: config that selects behavior, plus a routing key (`op`) the resolver maps
-  to a platform endpoint. No new field.
-- The skill entry reuses the existing `@ag.embed` shape, referencing a server-owned skill
-  by stable slug. Role: config plus a routing key (the slug). No new field.
-- Decision 2 (no `is_active`) means we do not add a disable field. Delete is the existing
-  present/absent semantics.
-- Decision 3 (frozen list) means we store concrete enumerated entries, not a new wildcard
-  token in the contract.
+- Inject versus commit. The kit is injected at session time, for display and for the run. It
+  is never written to the stored revision. The revision holds only user data. Role of the
+  kit: platform-owned policy applied at runtime. Role of the stored config: user-owned data.
+- Default versus override. The kit is the platform's default capability set, managed by
+  Agenta and not edited per item in v1. The user's config is the user layer. There is no
+  per-item override of a kit item, so there is no merge and no precedence rule to define yet.
+- Display versus persisted. The kit is display and session ephemeral. The agent config is
+  persisted. The toggle is a playground preference. It is not part of the persisted agent
+  config. If we persist the toggle at all, it is a playground or UI preference keyed to the
+  user and agent, never a field on the revision.
 
-So the only real interface question was ownership: which layer owns the enriched default.
-The answer, decided by Mahmoud, is the catalog template (with `/inspect` kept in sync), not
-the portable SDK interface. The skill embed and the platform tools both resolve server-side
-(the static catalog for the skill, the platform resolver and credentials for the tools). A
-bare SDK interface that ran standalone could not resolve them. Keeping them at the catalog
-and service layer respects the existing split and avoids breaking standalone SDK use of the
-builtin agent.
+Where each new field sits, by role:
+
+- The `build_kit` descriptor is platform-owned and read-only. It is a sibling of the config
+  in the `/inspect` response (`revision.data.build_kit`), never a member of `parameters.agent`.
+  The frontend reads it, never writes it. Role: a platform-declared capability catalog for
+  display and runtime, not user data.
+- The `inject_build_kit` flag is request-scoped policy. It rides the run request flags, not
+  the config. It defaults to the safe value, off, so a raw `/invoke` never grants the agent
+  authoring tools or execute-code by accident. Role: a per-run mode the playground sets.
+
+The design adds no field to the stored agent config. The `build_kit` descriptor lives in the
+inspect response, and the `inject_build_kit` flag lives on the run request. The stored
+contract (`parameters.agent`) is unchanged.
 
 ## Risks and edge cases
 
-- Several seeded tools are approval-gated by default in the catalog: `commit_revision` today,
-  and `create_schedule`, `create_subscription`, and `test_subscription` once the builder ships.
-  Seeding them does not change that. A new agent asks before it commits, schedules, subscribes,
-  or runs a live trigger test. The seeded tools keep their catalog default permissions, and the
-  user can edit them. This is intended; it is worth a line in the user-facing docs.
-- The skill content is a placeholder today. That is fine. Real content lands separately; it
-  is not this design's job.
-- The catalog and `/inspect` defaults must stay in sync. Sourcing both from one builder
-  call removes the drift that caused this gap in the first place.
-- Frontend delete of a static-skill embed must remove only my reference, not affect the
-  shared static skill. The slug points at a read-only catalog entry; deleting the embed
-  just drops the list item.
+- Safety. The kit grants self-commit and execute-code. It must never inject on a production
+  run. The flag defaults off server-side and only the playground turns it on. State this in
+  the docs and assert it in a test.
+- The toggle off path. Turning the kit off must produce a run with the user's config only, so
+  the user tests the agent as users will see it. That is the no-inject path, which is the
+  default, so it is the simple case.
+- Existing agents. They gain the kit in the playground with no migration, because the kit is
+  injected, not stored. Nothing is baked, so nothing goes stale.
+- Permissions overlap. The agent's own sandbox permission is a real committed field. The
+  kit's build permissions are a separate, session-only elevation. The drawer shows the kit's
+  permissions as a read-only status, distinct from the agent's own sandbox config. Keep the
+  two clearly separated so a kit-off run uses the agent's own permissions.
 
-## Out of scope and follow-ups
+## Out of scope and coordination
 
-- Disable-but-keep (an `is_active` or equivalent), with the resolver and wire drop step.
-- The debug-mode UX where defaults are not shown by default.
-- A picker to add platform tools or skills back after deleting them.
-- Real getting-started skill content.
+- The Advanced drawer UX (collapsible sections, the build-kit toggle, the read-only dimmed
+  rows) is owned by the advanced-build-kit project and the designer handoff. This design
+  feeds it the backend descriptor. It does not design the drawer.
+- The authoring skill content and naming are owned by the skills project (`#4918`). This
+  design references the skill by its stable slug. It does not write skill content.
+- Per-item edit or delete of kit items, and a picker to add platform tools to the published
+  agent, are out of scope. The kit is whole-toggle and read-only in v1.
 
-## Resolved: where the enriched default lives
+## Settled while drafting
 
-Decided by Mahmoud. The catalog template carries the enriched default (the frozen
-platform-tools list plus the getting-started skill embed). The bare SDK builtin interface
-stays bare. Server-resolved Agenta defaults do not go into the portable SDK default.
-`/inspect` is not used for the draft's values; if it is not in `/inspect`, we do not rely on
-`/inspect`, we use the catalog template. The catalog-templates path now sources the agent
-default from the enriched default rather than the bare builtin, and the tests that assert
-"builtin equals bare" and "service equals bare plus extras" are updated accordingly.
+- Where the descriptor lives. In the `/inspect` response, at `revision.data.build_kit`, a
+  read-only sibling of `schemas`. The drawer project depends on this exact channel, so it is
+  fixed, not open.
+
+## Open questions for Mahmoud
+
+1. The toggle's persistence. Ephemeral per playground session (resets to on), or a stored
+   playground preference per user and agent. I lean ephemeral for v1. It is the smaller
+   surface and the kit defaults on.
+2. Confirm the published default goes fully bare, including dropping the skill embed and the
+   sandbox boundary from the `/inspect` schema default, with both moving into the kit. This
+   touches the skills project's surface, so it needs their nod too.

--- a/docs/design/agent-workflows/projects/default-agent-config/design.md
+++ b/docs/design/agent-workflows/projects/default-agent-config/design.md
@@ -65,7 +65,9 @@ Today's overlay:
     "tools": [
       { "type": "platform", "op": "find_capabilities" },
       { "type": "platform", "op": "query_workflows" },
-      { "type": "platform", "op": "commit_revision" }
+      { "type": "platform", "op": "commit_revision" },
+      // a client/embed tool: a non-runnable reference to a reserved-slug workflow the frontend handles (#4920)
+      { "type": "reference", "slug": "__ag__request_connection" }
     ],
     "skills": [
       { "@ag.embed": { "@ag.references": { "workflow": { "slug": "__ag__getting_started_with_agenta" } } } }
@@ -77,13 +79,21 @@ Today's overlay:
 }
 ```
 
-The backend assembles this from sources the SDK already owns: `tools` by iterating
-`PLATFORM_OPS` (`/home/mahmoud/code/agenta/sdks/python/agenta/sdk/agents/platform/op_catalog.py`),
-so a new op added by the builder-tools project joins the kit with no edit here; `skills` as the
-`@ag.embed` reference to the authoring skill's reserved slug; `sandbox` as the build-permission
-elevation. Each entry is an ordinary agent-template fragment, so the dumb service already knows
-how to run it and a kit-on run is indistinguishable on the wire from a config the user authored
-by hand with the same items.
+The backend assembles `tools` from two parallel iterations, both over sources the platform
+already owns. It iterates `PLATFORM_OPS`
+(`/home/mahmoud/code/agenta/sdks/python/agenta/sdk/agents/platform/op_catalog.py`) for the
+platform ops, so a new op added by the builder-tools project joins the kit with no edit here. It
+also enumerates the reserved-slug platform workflows from the static workflow catalog
+(`StaticWorkflowCatalog` over `_STATIC_WORKFLOWS` at
+`/home/mahmoud/code/agenta/api/oss/src/core/workflows/static_catalog.py`) and adds each as a
+reference (workflow-as-tool) entry. These reserved workflows are the same `__ag__*` family as the
+platform skills, so a client tool like `__ag__request_connection` (the non-runnable connection
+tool the frontend handles, owned by `#4920`) rides the kit beside the platform ops with no bespoke
+path. The two iterations are symmetric: one walks the op catalog, the other walks the static
+workflow catalog. `skills` is the `@ag.embed` reference to the authoring skill's reserved slug;
+`sandbox` is the build-permission elevation. Each entry is an ordinary agent-template fragment, so
+the dumb service resolves it the way it resolves any tool, skill, or sandbox setting, and a kit-on
+run is indistinguishable on the wire from a config the user authored by hand with the same items.
 
 ## Where the overlay lives in the inspect response
 
@@ -95,20 +105,20 @@ read-only container on the inspect response envelope.
 {
   "count": 1,
   "application": { /* ... the agent, including data.parameters (the user's config) ... */ },
-  "inspect_context": {
-    "build_kit": {
+  "additional_context": {
+    "playground_build_kit": {
       "agent_template_overlay": { /* the partial parameters.agent above */ }
     }
   }
 }
 ```
 
-- `inspect_context` is a new optional field on `SimpleApplicationResponse`
+- `additional_context` is a new optional field on `SimpleApplicationResponse`
   (`/home/mahmoud/code/agenta/api/oss/src/apis/fastapi/applications/models.py`), a sibling of
   `application`. It holds platform-supplied, read-only information derived for this response. The
   build kit is its first member; future read-only hints or pointers add new members beside
-  `build_kit` rather than overloading user-owned fields.
-- `build_kit` holds the kit's payload. Today that is one field, `agent_template_overlay`.
+  `playground_build_kit` rather than overloading user-owned fields.
+- `playground_build_kit` holds the kit's payload. Today that is one field, `agent_template_overlay`.
 - `agent_template_overlay` is the partial agent template the frontend merges. The name says
   exactly what it is and how it is used, and it cannot be mistaken for the saved template.
 
@@ -118,7 +128,7 @@ This placement is the load-bearing decision, and it follows ownership and lifecy
   `application.data.parameters`.
 - User metadata that round-trips through create, edit, and commit lives in `application.meta`.
 - Platform information that the backend derives read-only for one inspect response lives in
-  `inspect_context`.
+  `additional_context`.
 
 The overlay must not sit in `revision.data`. That object is the user's schema-constrained config,
 it is `extra="forbid"`
@@ -155,7 +165,7 @@ path.
 The frontend owns three behaviors. All read the same overlay; none change the run wire.
 
 1. **Read.** On loading the workflow, the frontend reads
-   `inspect_context.build_kit.agent_template_overlay` from the inspect response and keeps it in
+   `additional_context.playground_build_kit.agent_template_overlay` from the inspect response and keeps it in
    session-scoped state, keyed like the existing inspect cache (per service), separate from the
    persisted `data`. It renders the overlay in the drawer. It hardcodes no item list and no
    labels.
@@ -303,7 +313,7 @@ State the negatives so no implementer re-adds them.
 
 The model rests on role splits, not feature splits.
 
-- **Platform-derived information versus user-owned data.** `inspect_context` is platform-supplied,
+- **Platform-derived information versus user-owned data.** `additional_context` is platform-supplied,
   read-only, and derived per response. `application.data.parameters` is user config the revision
   persists; `application.meta` is user metadata that round-trips. Three owners, three lifecycles,
   three homes. This split is why the overlay needs no strip step and cannot leak into a commit.
@@ -320,14 +330,15 @@ The model rests on role splits, not feature splits.
 
 ## Change set, by layer
 
-1. **Inspect-context container (backend, new).** Add `inspect_context` to
-   `SimpleApplicationResponse` with a typed `build_kit.agent_template_overlay`
+1. **Additional-context container (backend, new).** Add `additional_context` to
+   `SimpleApplicationResponse` with a typed `playground_build_kit.agent_template_overlay`
    (`/home/mahmoud/code/agenta/api/oss/src/apis/fastapi/applications/models.py`). Populate it only
    in the read path (`fetch_simple_application`), never in create, edit, or commit.
 
-2. **Overlay builder (backend, new).** One builder assembles the overlay: `tools` from
-   `PLATFORM_OPS`, `skills` as the `@ag.embed` reference to the authoring slug, `sandbox` as the
-   build-permission elevation. It reads SDK-owned sources and is not referenced by the service run
+2. **Overlay builder (backend, new).** One builder assembles the overlay: `tools` from both
+   `PLATFORM_OPS` and the reserved-slug platform workflows in the static workflow catalog, `skills`
+   as the `@ag.embed` reference to the authoring slug, `sandbox` as the build-permission
+   elevation. It reads platform-owned sources and is not referenced by the service run
    path.
 
 3. **Published default goes bare (backend).** Revert the `schemas.py` enrichment so the schema
@@ -336,7 +347,7 @@ The model rests on role splits, not feature splits.
 4. **Stop force-injecting the skill (SDK).** Set `AGENTA_FORCED_SKILLS = []`
    (`agenta_builtins.py:104`). Coordinate with the skills project.
 
-5. **Frontend read and render (web).** Read `inspect_context.build_kit.agent_template_overlay`
+5. **Frontend read and render (web).** Read `additional_context.playground_build_kit.agent_template_overlay`
    into session state. Render the "Playground build kit" section, reusing the existing config-item
    controls, and make the advanced sections collapsible.
 
@@ -348,7 +359,7 @@ The model rests on role splits, not feature splits.
    into `entity.data.parameters`, so `prepareCommitParameters` excludes it for free.
 
 8. **Tests.** Backend: the builder lists the platform ops, the authoring skill, and the build
-   permissions as one overlay; the inspect response carries `inspect_context.build_kit`; the
+   permissions as one overlay; the inspect response carries `additional_context.playground_build_kit`; the
    published default is bare across the builtin, the inspect schema, and the catalog (update
    `/home/mahmoud/code/agenta/services/oss/tests/pytest/unit/agent/test_default_agent_template.py`).
    Frontend: a kit-on run merges the overlay into `parameters.agent` (deep-merge and identity-merge
@@ -381,9 +392,9 @@ The model rests on role splits, not feature splits.
   assembly time, so new ops join the overlay automatically.
 - A client tool such as `request_connection` is not a platform op. It is a non-runnable
   workflow (reference) tool: the backend exposes it and the frontend handles the call, the same
-  reference-tool concept the platform already has. If the kit later carries such a tool, it joins
-  the overlay as a reference-tool entry (identity by its referenced workflow), not a platform op.
-  Its primary definition is owned by `#4920`.
+  reference-tool concept the platform already has. The kit carries it as a reference-tool entry,
+  embedded from its reserved `__ag__*` slug (identity by its referenced workflow), beside the
+  platform ops. Its primary definition is owned by `#4920`.
 - Per-item edit or delete of kit items, and a picker to add platform tools to the published agent,
   are out of scope. The kit is whole-toggle and read-only in v1.
 - The overlay model carries through to `#4918`, `#4919`, and `#4920`. They are not edited here; the

--- a/docs/design/agent-workflows/projects/default-agent-config/design.md
+++ b/docs/design/agent-workflows/projects/default-agent-config/design.md
@@ -1,278 +1,208 @@
-# Design: the playground build kit (the frontend injects, the backend informs)
+# Design: the playground build kit (an agent-template overlay)
 
-Status: draft for Mahmoud's review. Grounded in code on `gitbutler/edit` over
-`big-agents`, 2026-06-28. Paths are absolute. See `research.md` for the code trace.
-
-This is the second rewrite. Mahmoud rejected the first rewrite's core model: it made the
-backend agent service inject the kit at run time, behind a run flag. That is gone. The
-corrected model moves the injection to the frontend and leaves the backend with one job,
-to inform. The section "What changed and why" records the pivot.
+Status: draft for Mahmoud's review. Grounded in code on `gitbutler/edit` over `big-agents`,
+2026-06-28. Paths are absolute. See `research.md` for the code trace.
 
 ## Problem and goal
 
-A new agent arrives almost bare. The playground still needs to give that agent the tools,
-the skill, and the permissions it takes to build and improve itself, while the user works on
-it. None of that authoring scaffolding belongs in the agent the user ships.
+A new agent arrives near-bare. While the user builds it in the playground, the assistant needs
+authoring scaffolding: the platform tools (find capabilities, query workflows, commit a
+revision), the Agenta authoring skill, and elevated sandbox permissions (write files, execute
+code). That scaffolding is a build aid, not the user's agent. The shipped agent must carry only
+what the user authored.
 
-The platform tools (find capabilities, query workflows, commit a revision), the Agenta
-authoring skill, and the build permissions (write files, execute code) are a build aid. They
-are not the user's agent. They exist so the assistant can scaffold and edit the agent in the
-playground. Once the agent ships, it should carry only what the user authored.
+So the build kit is shown and used in the playground, never committed, and never reaches a
+deployed run. This design decides who shows it, who applies it, and who keeps it out of the
+commit.
 
-So the kit is shown and used in the playground, but never committed. The goal of this design
-is to decide who shows it, who uses it, and who keeps it out of the commit.
+## The model: a build-kit overlay
 
-## What changed and why
+The build kit is an **agent-template overlay**: a partial agent template, the same shape as
+`parameters.agent`. The platform owns it. The backend serves it read-only on the inspect
+response. The frontend applies it to a playground run and leaves it out of a commit.
 
-The first rewrite put the injection in the backend. The agent service merged the kit into
-the effective config at a run-prep step, gated by a `flags.inject_build_kit` run flag.
-Mahmoud rejected that. His direction, verbatim in the PR review:
+Three actors, three jobs:
 
-> It should not be the agent service that injects the kit. This should be a front-end
-> matter. The front-end injects the kit when used in the playground as part of the
-> parameters of the agent template. The service itself should not know about it.
+- **The agent service runs the template it receives.** It reads `parameters.agent` and runs it.
+  It does not know the build kit exists. There is no run-prep merge and no run flag. The
+  platform tools, the authoring skill, and the build permissions reach a run only because they
+  are already inside the `parameters.agent` the service was handed, and the service resolves
+  them the way it resolves any tool, skill, or sandbox setting.
+- **The backend serves the overlay.** It assembles the overlay once and attaches it to the
+  inspect response. It never applies the overlay and never acts on it.
+- **The frontend applies the overlay.** It reads the overlay from the inspect response and
+  renders it read-only in the drawer. On a kit-on run, it merges the overlay onto the current
+  `parameters.agent` and sends the result. On commit, it does not merge, so the committed
+  config holds only the user's own template.
 
-> The frontend should own the business logic for setting these. The only thing the backend
-> should do is give information and inspect what this build kit is: which skills, which
-> tools, which permissions.
+"Shown but not committed" follows from where the overlay lives and when the frontend applies it.
+The overlay never enters `parameters.agent`, the tree the playground edits and commits. It lives
+in the read-only inspect response and, on a kit-on run, in a throwaway merged copy that feeds the
+run payload. A deployed agent runs its stored config, which has no overlay, so authoring power
+cannot reach a published run.
 
-So the model flips. The service stops injecting. The backend stops gating. The frontend owns
-the injection, and the backend's only build-kit job is to expose the kit's information
-through `/inspect`. The rest of this document follows from that one change.
+## The overlay shape
 
-## The corrected model
+The overlay is a partial `parameters.agent`. It can carry any agent-template field: tools,
+embedded skills, sandbox or permission overrides, a model choice, instructions, or anything the
+template defines later. One mechanism covers every kind. There are no per-kind groups and no
+display fields to invent, because the overlay reuses the agent-template shape the platform
+already defines and the playground already renders.
 
-Three actors, three clear jobs.
+Skills in the overlay are ordinary `@ag.embed` references, full stop. An embed reference (the
+slug, plus a version when pinned) is the platform's existing mechanism for embedding a variant,
+and it already identifies the skill, which carries its own name and description. The overlay adds
+no parallel `key`, `name`, or `description` for a skill. The authoring skill is the reserved
+static skill `__ag__getting_started_with_agenta`
+(`/home/mahmoud/code/agenta/sdks/python/agenta/sdk/agents/adapters/agenta_builtins.py`), served
+read-only under the reserved `__ag__*` namespace.
 
-- **The agent service stays dumb.** It receives an agent template at `parameters.agent` and
-  runs exactly that. It does not know the build kit exists. There is no run-prep injection
-  and no `inject_build_kit` run flag. If the platform tools, the authoring skill, and the
-  build permissions reach a run, they reach it because they are already inside the
-  `parameters.agent` the service was handed. The service resolves them the same way it
-  resolves any tool or skill.
-- **The backend informs.** Its only build-kit job is to expose the kit's information through
-  `/inspect`: which skills, which tools, which permissions the kit holds, and, for each, the
-  exact agent-template entry that item would contribute. This is read-only information. The
-  backend assembles it and never acts on it.
-- **The frontend owns the logic.** It reads the kit's information from `/inspect`. It shows
-  the kit in the advanced drawer with an enable or disable toggle. When the kit is on, the
-  frontend injects the kit's skills, tools, and permissions into `parameters.agent` in the
-  run request it sends. On commit, the frontend leaves the kit out, so the committed config
-  holds only the user's own config.
-
-The "shown but not committed" property now belongs to the frontend. The frontend includes
-the kit in the run payload and excludes it from the commit payload. Nothing in the backend
-adds or strips the kit.
-
-This is also where the property gets cheap. The kit never enters `parameters.agent`, the
-config tree the playground edits and commits. It lives only in the read-only descriptor and,
-on a kit-on run, in the outbound run payload. There is no strip step on commit, because the
-kit was never in the tree the commit serializes. There is no run flag, because a kit-on run
-is just a run whose `parameters.agent` already carries the extra items.
-
-A deployed agent therefore can never run with the kit. The kit is not in its stored config,
-and the backend never adds it. The only place the kit exists is the descriptor (information)
-and a live playground run payload (the frontend's doing). That is a stronger safety
-guarantee than a server flag: there is no path that injects authoring power into a published
-run, because nothing persists the kit and nothing on the run path adds it.
-
-## The `/inspect` build-kit descriptor (the central question)
-
-Mahmoud's central question: how do we put the build-kit information in `/inspect`, so the
-frontend can act on it? This section answers it, organized by role per the `design-interfaces`
-skill.
-
-### Where it sits
-
-Deliver the descriptor in the `/inspect` response at `revision.data.build_kit`, a read-only
-sibling of `revision.data.schemas`. The frontend already fetches `/inspect` per workflow, so
-the drawer reads the descriptor with no new request. The descriptor is platform-owned. The
-frontend reads it, renders it, and injects from it. It never writes it, merges it back, or
-echoes it to the backend.
-
-The descriptor is a sibling of the config, never a member of `parameters.agent`. That
-placement is the load-bearing decision. The kit is display-and-inject information that the
-platform owns and the session scopes. The agent config is user-owned data that the revision
-persists. They answer different questions, so they do not share a contract.
-
-### The shape
-
-Grouped by kind. Each kind renders as one read-only group in the drawer and routes to one
-destination in `parameters.agent`.
+Today's overlay:
 
 ```jsonc
 {
-  "build_kit": {
-    "skills": [
-      {
-        "key": "__ag__getting_started_with_agenta", // the skill slug (identity)
-        "name": "agenta-authoring",                  // display label
-        "description": "Scaffold and edit this agent's tools, skills, and config.",
-        "config": { "@ag.embed": { "slug": "__ag__getting_started_with_agenta" } }
-      }
-    ],
+  "agent_template_overlay": {
     "tools": [
-      {
-        "key": "find_capabilities",                  // the platform op (identity)
-        "name": "Find capabilities",
-        "description": "Discover the tools and workflows available to this agent.",
-        "config": { "type": "platform", "op": "find_capabilities" }
-      }
+      { "type": "platform", "op": "find_capabilities" },
+      { "type": "platform", "op": "query_workflows" },
+      { "type": "platform", "op": "commit_revision" }
     ],
-    "permissions": [
-      {
-        "key": "write_files",
-        "name": "Write files",
-        "description": "Filesystem read and write while building.",
-        "status": "on",                              // read-only policy state, the green pill
-        "config": { "sandbox": { "permissions": { "write_files": "allow" } } }
-      }
-    ]
+    "skills": [
+      { "@ag.embed": { "@ag.references": { "workflow": { "slug": "__ag__getting_started_with_agenta" } } } }
+    ],
+    "sandbox": {
+      "permissions": { "write_files": "allow", "execute_code": "allow" }
+    }
   }
 }
 ```
 
-### Why each row carries `config`
+The backend assembles this from sources the SDK already owns: `tools` by iterating
+`PLATFORM_OPS` (`/home/mahmoud/code/agenta/sdks/python/agenta/sdk/agents/platform/op_catalog.py`),
+so a new op added by the builder-tools project joins the kit with no edit here; `skills` as the
+`@ag.embed` reference to the authoring skill's reserved slug; `sandbox` as the build-permission
+elevation. Each entry is an ordinary agent-template fragment, so the dumb service already knows
+how to run it and a kit-on run is indistinguishable on the wire from a config the user authored
+by hand with the same items.
 
-This is the pivot from the rejected model, so it is worth stating plainly.
+## Where the overlay lives in the inspect response
 
-In the rejected model the backend injected the kit, so the descriptor only needed display
-fields: `key`, `name`, `description`, and a permission `status`. The frontend rendered those
-labels and flipped a flag; the backend turned `find_capabilities` into the real platform tool
-config server-side.
+The overlay is platform-owned, read-only, and derived per response. It is not user config and
+not user metadata, so it does not belong in either of those contracts. It rides a dedicated
+read-only container on the inspect response envelope.
 
-In the corrected model the frontend injects the kit. So each row must also carry the exact
-agent-template entry it contributes, because the frontend, not the backend, now writes that
-entry into `parameters.agent`. The `config` field is that entry: a platform tool config for a
-tool row, an `@ag.embed` reference for a skill row, a sandbox-permission fragment for a
-permission row.
+```jsonc
+{
+  "count": 1,
+  "application": { /* ... the agent, including data.parameters (the user's config) ... */ },
+  "inspect_context": {
+    "build_kit": {
+      "agent_template_overlay": { /* the partial parameters.agent above */ }
+    }
+  }
+}
+```
 
-Carrying `config` keeps the contents fully backend-owned. The frontend does a pure structural
-merge. It appends `skills[].config` to `parameters.agent.skills`, appends `tools[].config` to
-`parameters.agent.tools`, and merges `permissions[].config` into the agent's sandbox section.
-It never builds a tool's wire shape, never knows the authoring skill's slug, and never decides
-which permission to elevate. It owns the business logic (when to inject, where each kind goes,
-run versus commit). The backend owns the data (which items, and the exact form of each).
+- `inspect_context` is a new optional field on `SimpleApplicationResponse`
+  (`/home/mahmoud/code/agenta/api/oss/src/apis/fastapi/applications/models.py`), a sibling of
+  `application`. It holds platform-supplied, read-only information derived for this response. The
+  build kit is its first member; future read-only hints or pointers add new members beside
+  `build_kit` rather than overloading user-owned fields.
+- `build_kit` holds the kit's payload. Today that is one field, `agent_template_overlay`.
+- `agent_template_overlay` is the partial agent template the frontend merges. The name says
+  exactly what it is and how it is used, and it cannot be mistaken for the saved template.
 
-Because each `config` is an ordinary `parameters.agent` entry, the dumb service already knows
-how to run it. A kit-on run is indistinguishable on the wire from a config the user authored
-by hand with those same tools. That is what lets the service stay dumb.
+This placement is the load-bearing decision, and it follows ownership and lifecycle:
 
-I considered the leaner alternative: keep only `key`, `name`, `description`, and `status`, and
-have the frontend derive each injected entry from `key` plus kind. I rejected it. It pushes
-the platform tool wire shape and the skill embed shape into the frontend, and it cannot
-express a permission setting from a key alone. Open question 4 revisits this if we want the
-leaner shape after all.
+- User config that the revision persists and the deployment runs lives in
+  `application.data.parameters`.
+- User metadata that round-trips through create, edit, and commit lives in `application.meta`.
+- Platform information that the backend derives read-only for one inspect response lives in
+  `inspect_context`.
 
-### The role of each field
+The overlay must not sit in `revision.data`. That object is the user's schema-constrained config,
+it is `extra="forbid"`
+(`/home/mahmoud/code/agenta/sdks/python/agenta/sdk/models/workflows.py`), and it flows into the
+commit and edit paths. The overlay must not sit in `application.meta` either, because that field
+is user-owned and persisted. Both would blur the ownership line the rest of this design depends
+on.
 
-Run through `design-interfaces`, field by field:
+## Applying the overlay
 
-- The descriptor as a whole is platform-owned, session-scoped information. It is a sibling of
-  the config, never part of `parameters.agent`.
-- `skills` / `tools` / `permissions` are routing. The kind picks both the drawer group and the
-  destination list in `parameters.agent`. The three kinds differ in exactly one visible way: a
-  permission row carries a status the others do not.
-- `key` is a stable, platform-owned identity (the skill slug, the platform op, the permission
-  key). The drawer keys rows on it. It is not the visible label.
-- `name` and `description` are display metadata: the row's label and its one-line purpose.
-- `status` (permission rows only) is read-only policy state (`on` or `off`). It reflects what
-  the kit grants for authoring. The drawer renders it as the green `On` pill. Skill and tool
-  rows carry no status.
-- `config` is the agent-template fragment the row contributes. It is data the frontend writes
-  into the run payload. Despite the generic word, it has one exact meaning here: the
-  `parameters.agent` entry for this one item.
+A kit-on run produces a derived run config by merging the overlay onto a copy of the current
+`parameters.agent`. The merge is an override overlay: the overlay adds entries the config lacks
+and overrides entries it already holds.
 
-No field plays two roles. The kind tag is implicit in the array a row sits in. The labels and
-the injectable form are the backend's to own.
+- **Object fields** (`sandbox`, `runner`, `harness`, `llm`, `instructions`) deep-merge, and the
+  overlay wins on a conflict. So `sandbox.permissions.write_files: "allow"` elevates the run's
+  sandbox without discarding the user's other sandbox settings.
+- **List fields** (`tools`, `skills`, `mcps`) merge by item identity. A tool's identity is its
+  `op` for a platform tool, the referenced workflow for a reference (non-runnable workflow) tool,
+  otherwise its `name`; a skill's identity is the slug its `@ag.embed` references; an MCP server's
+  identity is its `name`. On an identity match the overlay entry
+  overrides; otherwise it appends. So the kit's three platform ops and one authoring skill add to
+  whatever the user authored, and re-adding an op the user already has is a no-op rather than a
+  duplicate.
 
-### How the backend assembles it
+The merge runs on a throwaway copy in the run-build path only. It never mutates the draft or the
+committed tree. A separate, explicit applier owns this, because the frontend's general config
+merge is shallow and array-replacing; a naive spread would clobber the user's `tools` or `skills`
+arrays. The applier lives beside the run builder (next section), not in the shared config-merge
+path.
 
-One backend builder produces all three groups, in the inspect layer, reading sources that the
-SDK already owns:
+## Frontend behavior
 
-- `tools` from `PLATFORM_OPS`
-  (`/home/mahmoud/code/agenta/sdks/python/agenta/sdk/agents/platform/op_catalog.py`). Each op
-  becomes a row: `key` is the op, `name` and `description` come from the catalog, and `config`
-  is `{ "type": "platform", "op": <op> }`. Reading the catalog at assembly time means a new op
-  added by the builder-tools project (`#4919`) joins the kit with no edit here.
-- `skills` from the authoring skill, the SDK constant `GETTING_STARTED_WITH_AGENTA`
-  (`/home/mahmoud/code/agenta/sdks/python/agenta/sdk/agents/adapters/agenta_builtins.py`),
-  served read-only under the reserved `__ag__*` slug. The row's `key` is the slug, `name` and
-  `description` come from the skill, and `config` is the `@ag.embed` reference to that slug.
-- `permissions` from the build-permission set (write files, execute code). Each becomes a row
-  with `status: "on"` and a `config` that is the sandbox-permission fragment the frontend
-  merges into the agent's sandbox section.
+The frontend owns three behaviors. All read the same overlay; none change the run wire.
 
-The builder lives in the backend inspect layer and reads SDK-owned constants. The agent
-service's run path never references it. That keeps the run path, and therefore the service,
-kit-unaware.
+1. **Read.** On loading the workflow, the frontend reads
+   `inspect_context.build_kit.agent_template_overlay` from the inspect response and keeps it in
+   session-scoped state, keyed like the existing inspect cache (per service), separate from the
+   persisted `data`. It renders the overlay in the drawer. It hardcodes no item list and no
+   labels.
 
-### How the backend serves it
-
-The `/inspect` response already carries `revision.data.schemas`, forwarded from the service's
-schema declaration through the API inspect proxy
-(`/home/mahmoud/code/agenta/api/oss/src/apis/fastapi/applications/router.py`). The inspect
-layer attaches `revision.data.build_kit` alongside `schemas`, assembled by the builder above.
-Confirm the proxy passes `revision.data` through rather than allow-listing fields, so the new
-sibling reaches the frontend.
-
-## The frontend logic
-
-The frontend owns three behaviors. All three read the same descriptor; none touch the
-backend's run wire.
-
-1. **Read.** On loading the workflow, the frontend reads `revision.data.build_kit` from the
-   `/inspect` response. It renders the three groups in the drawer (next section). It hardcodes
-   no item list, no label, and no wire shape.
-
-2. **Toggle and inject on run.** The drawer holds one piece of session state,
-   `buildKitEnabled`, default on. When the frontend builds a run request, it injects the kit
-   if the toggle is on. The injection point is `buildAgentRequest`
+2. **Apply on a kit-on run.** The drawer holds one piece of session state, `buildKitEnabled`,
+   default on. When the frontend builds a run request, it applies the overlay if the toggle is
+   on. The build point is `buildAgentRequest`
    (`/home/mahmoud/code/agenta/web/packages/agenta-playground/src/state/execution/agentRequest.ts`),
    which composes the `/invoke` body's `data.parameters` from the draft-aware config. With the
-   kit on, the builder appends `build_kit.skills[].config` and `build_kit.tools[].config` to
-   the run copy's `parameters.agent` lists and merges `build_kit.permissions[].config` into its
-   sandbox section, then sends that. With the kit off, it sends the user's config unchanged,
-   so the user previews the agent as users will see it. The builder already transforms
-   `parameters` before sending (it drops half-filled entries and normalizes tool shapes), so a
-   kit merge is the same kind of pre-send step, on a throwaway copy.
+   kit on, the applier merges the overlay into the run copy's `parameters.agent` (object fields
+   deep-merged, list fields identity-merged) and sends that. With the kit off, it sends the
+   user's config unchanged, so the user previews the agent as users will see it. The builder
+   already transforms `parameters` on a throwaway copy before sending (it drops half-filled
+   entries and normalizes tool shapes), so the overlay merge is the same kind of pre-send step.
 
-3. **Exclude on commit.** The commit path reads the user's config from `entity.data.parameters`
-   through `prepareCommitParameters`
-   (`/home/mahmoud/code/agenta/web/packages/agenta-entities/src/workflow/state/commit.ts:68`).
-   The kit was never written into `entity.data.parameters`, so the commit excludes it with no
-   strip step. The descriptor and the kit-on run payload are the only places the kit ever
-   appears.
+3. **Exclude on commit.** The commit path reads the user's config from
+   `entity.data.parameters` through `prepareCommitParameters`
+   (`/home/mahmoud/code/agenta/web/packages/agenta-entities/src/workflow/state/commit.ts`). The
+   overlay was never written into `entity.data.parameters`, so the commit excludes it with no
+   strip step. The inspect response and the kit-on run payload are the only places the overlay
+   ever appears.
 
 The run wire stays byte-compatible. The backend cannot tell a kit-on run from a hand-authored
 config with the same items, and it does not need to.
 
-## The UI drawer (folded in)
+## The drawer UI
 
-Mahmoud asked for this design to cover both the inspect information and the drawer UI he
-designed, in one document, not split into a separate PR. So the drawer design lives here. It
-recomposes existing drawer parts; nothing below is novel UI. The designer handoff
-(`/home/mahmoud/code/agenta/design_handoff_advanced_build_kit/README.md`) is the
-high-fidelity spec; the `.dc.html` is a visual reference, not code, and `support.js` is mock
-runtime to ignore.
+This design covers both the inspect contract and the advanced-drawer UI, in one document. The UI
+recomposes existing drawer parts. The designer handoff
+(`/home/mahmoud/code/agenta/design_handoff_advanced_build_kit/README.md`) is the high-fidelity
+spec; the `.dc.html` is a visual reference, not code, and `support.js` is mock runtime to ignore.
 
 ### The drawer today
 
 Verified on this branch, so the changes land on real structure.
 
 - The advanced drawer is `AgentTemplateControl.tsx`
-  (`/home/mahmoud/code/agenta/web/packages/agenta-entity-ui/src/DrillInView/SchemaControls/AgentTemplateControl.tsx`).
-  It renders inside the `SectionDrawer` shell (icon, title, scroll body, Cancel and Save).
-- The advanced body already stacks three groups, separated by top borders, not yet
-  collapsible: Authentication (`:1517`), Execution environment (`:1530`), and Permissions
-  (`:1565`). These configure the committed agent.
-- The collapsed-header summary the drawer already computes (`advancedSummary`, `:1501`) reads
-  values such as `Agenta-managed` and `Sandbox: Local` from existing state. The per-section
-  summaries reuse those values.
-- `SkillTemplateControl.tsx:205` already renders an Agenta-owned skill read-only: "Provided by
-  Agenta. This skill cannot be edited or removed," with no editor and no delete. This is the
-  read-only pattern the kit reuses, lifted from the per-item list into the kit section.
+  (`/home/mahmoud/code/agenta/web/packages/agenta-entity-ui/src/DrillInView/SchemaControls/AgentTemplateControl.tsx`),
+  rendered inside the `SectionDrawer` shell (icon, title, scroll body, Cancel and Save).
+- The advanced body stacks three groups, separated by top borders, not yet collapsible:
+  Authentication (`:1517`), Execution environment (`:1530`), and Permissions (`:1565`). These
+  configure the committed agent.
+- The collapsed-header summary the drawer computes (`advancedSummary`, `:1501`) reads values such
+  as `Agenta-managed` and `Sandbox: Local` from existing state.
+- `SkillTemplateControl.tsx:205` already renders an Agenta-owned skill read-only ("Provided by
+  Agenta. This skill cannot be edited or removed"), with no editor and no delete. This is the
+  read-only pattern the kit reuses.
 
 ### Change 1: make the advanced sections collapsible
 
@@ -282,14 +212,12 @@ panel already uses, so the groups stop rendering as one long scroll.
 - Default state is collapsed. Several sections can be open at once; it is not single-open.
 - The header row shows the section icon, the title, a one-line summary on the right, then a
   chevron that rotates when open.
-- The body mounts only when expanded. Its content is the section's existing controls,
-  unchanged.
+- The body mounts only when expanded. Its content is the section's existing controls, unchanged.
 - Summaries reuse state already present: Authentication shows `Agenta-managed`, Execution
-  environment shows `Sandbox: Local`, Permissions shows `Auto`. The build kit shows no text
-  summary; its toggle sits in the header instead.
+  environment shows `Sandbox: Local`, Permissions shows `Auto`.
 
-This change carries no contract and no commit logic. It is drawer polish on the existing
-groups, and it can ship on its own (open question 5).
+This change carries no contract and no commit logic. It is drawer polish on the existing groups
+and can ship on its own (open question 4).
 
 ### Change 2: add the "Playground build kit" section
 
@@ -302,192 +230,184 @@ background (`#fcfcfa`) so it reads as a distinct playground-only layer.
   section.
 - **Body, when expanded**: an intro paragraph that ends with "None of this is part of the
   published agent." When the kit is off, an info note that the assistant can no longer create
-  files, run code, or edit the agent here. Then the three groups.
-- **The three groups**, rendered straight from `build_kit`, one labelled group per kind, in
-  order: skills, tools, permissions. Every row is dimmed and locked, reusing the read-only
-  pattern from `SkillTemplateControl.tsx:205`. Permission rows additionally render the green
-  `On` pill from each row's `status`. The drawer hardcodes no item list; it renders whatever
-  the descriptor carries. The designer's sample rows (`agenta_authoring`, `commit_version`,
-  `Write files`) are illustrative.
+  files, run code, or edit the agent here. Then the overlay, rendered read-only.
 
-### The toggle wiring (the corrected part)
+The drawer renders the overlay by reusing the playground's existing config-item controls, the
+same way it renders the committed config. An `@ag.embed` skill renders as an embedded skill
+(read-only, the pattern from `SkillTemplateControl.tsx:205`); a platform tool renders as a
+platform tool; the `sandbox.permissions` fragment renders in a permissions group. The drawer
+derives the handoff's three labelled groups from the overlay's own `skills`, `tools`, and
+`sandbox.permissions`. A permission's green `On` pill reflects its value in the overlay (`allow`),
+so the overlay needs no separate status field. Every row is dimmed and locked. The drawer
+hardcodes no item list; it renders whatever the overlay carries. The designer's sample rows are
+illustrative.
 
-This is where the drawer differs from the rejected model. The toggle does not set a run flag.
-The toggle is `buildKitEnabled`, session state, default on. The frontend reads it when it
-builds the run request and injects the kit's `config` entries into `parameters.agent` when it
-is on (frontend logic, step 2). The drawer writes nothing into the config and never echoes the
-descriptor. The toggle is a playground preference, not a field on the revision.
+### The toggle wiring
+
+The toggle does not set a run flag. It is `buildKitEnabled`, session state, default on. The
+frontend reads it when it builds the run request and applies the overlay when it is on (frontend
+behavior, step 2). The drawer writes nothing into the config and never echoes the overlay. The
+toggle is a playground preference, not a field on the revision.
 
 ### Keep two permission ideas distinct
 
-The drawer now holds two things that both say "permissions," and they must not read as one
-setting.
+The drawer holds two things that both say "permissions," and they must not read as one setting.
 
-- The committed Permissions group, and the Execution environment group, configure the agent's
-  own permissions and sandbox. The user edits them, they commit, they ship.
-- The build kit's PERMISSIONS group is a read-only reflection of the permissions the kit grants
-  for authoring. It is dimmed, locked, tagged removed on commit, and never committed.
+- The committed Permissions group and the Execution environment group configure the agent's own
+  permissions and sandbox. The user edits them, they commit, they ship.
+- The build kit's permissions are a read-only reflection of the sandbox elevation the overlay
+  carries. They are dimmed, locked, tagged removed on commit, and never committed.
 
 The structure does the heavy lifting: the kit's permissions live inside the kit section, behind
 the same dimming, lock, and removed-on-commit tag as the rest of the kit, while the agent's own
-Permissions group stays an editable, committed control elsewhere. The intro paragraph and the
-tag carry the distinction in words. This is worth a deliberate review with the designer, because
-the two ideas sit close together and a user who conflates them could believe the agent ships
-with write-files and execute-code permission.
-
-## What the backend explicitly does NOT do
-
-This section exists because the rejected model lived in the backend. State the negatives so no
-implementer re-adds them.
-
-- **No service-side injection.** The agent service does not merge the kit into the config at
-  run-prep. There is no kit merge in `_agent`
-  (`/home/mahmoud/code/agenta/services/oss/src/agent/app.py`). The service runs
-  `parameters.agent` as received.
-- **No run flag.** There is no `flags.inject_build_kit` on the run request and none on
-  `WorkflowInvokeRequestFlags`. The toggle is client session state. The run wire gains no
-  field.
-- **The service does not read `build_kit`.** The descriptor is assembled by the inspect layer
-  and consumed by the frontend. The service's run path never references it. The service does
-  not know the kit exists.
-- **No backend strip on commit.** The backend does not remove kit items from a committed
-  config, because the kit never enters the committed config. The frontend simply does not put
-  it there.
+Permissions group stays an editable, committed control elsewhere. Review this with the designer,
+because the two ideas sit close together and a user who conflates them could believe the agent
+ships with write-files and execute-code permission.
 
 ## Published default stays bare
 
-The published-config default does not carry the kit. A new agent's stored config is bare: no
-platform tools, no authoring skill, no elevated sandbox.
+A new agent's stored config is bare: no platform tools, no authoring skill, no elevated sandbox.
+Those three belong to the overlay now, not to the published default.
 
 Today `schemas.py` enriches the published default with the authoring skill and the sandbox
 boundary (`build_agent_v0_default(skill_slug=..., include_sandbox_permission=True)` at
-`/home/mahmoud/code/agenta/services/oss/src/agent/schemas.py:52`). Under this model those two
-belong to the kit, not the published default. Revert the enrichment so the `/inspect` schema
-default and the catalog template both carry the bare default, the same value the SDK builtin
-carries. The skill and the sandbox elevation reach a run only through the kit, by the
-frontend's injection.
+`/home/mahmoud/code/agenta/services/oss/src/agent/schemas.py`). Revert that enrichment so the
+inspect schema default and the catalog template both carry the bare default, the same value the
+SDK builtin carries. The skill and the sandbox elevation reach a run only through the overlay, by
+the frontend's merge.
 
-That keeps two distinct things in `/inspect` with two distinct roles: the bare schema default
-(the seed for the user's persisted config) and the `build_kit` descriptor (the platform's
-session overlay). Overloading the schema default to also mean "the kit" was the exact role
-confusion this design avoids.
+The authoring skill also stops reaching runs through the harness force. Today the `pi_agenta`
+harness unions `AGENTA_FORCED_SKILLS` into every run, always on and not toggleable
+(`/home/mahmoud/code/agenta/sdks/python/agenta/sdk/agents/adapters/agenta_builtins.py:104`,
+`harnesses.py:140`). A forced skill cannot be toggled, which contradicts the kit's toggle. So the
+authoring skill comes from the overlay, not the force. Set `AGENTA_FORCED_SKILLS = []`, keeping
+`force_skills` for a future genuinely-forced item. This touches the skills project's surface, so
+confirm it with them (open question 2).
 
-The authoring skill stops reaching runs through the harness force as well. Today the
-`pi_agenta` harness unions `AGENTA_FORCED_SKILLS` into every run, always on and not toggleable
-(`/home/mahmoud/code/agenta/sdks/python/agenta/sdk/agents/adapters/agenta_builtins.py:104`).
-A forced skill cannot be toggled, which contradicts the kit's toggle. So the authoring skill
-must come from the kit (frontend injection), not the force. Set `AGENTA_FORCED_SKILLS = []`,
-keeping `force_skills` for a future genuinely-forced item. This touches the skills project's
-surface, so confirm it with them (open question 2).
+## What the backend explicitly does NOT do
+
+State the negatives so no implementer re-adds them.
+
+- **No service-side merge.** The agent service does not merge the overlay into the config at
+  run-prep. There is no overlay merge in the agent app
+  (`/home/mahmoud/code/agenta/services/oss/src/agent/app.py`). The service runs `parameters.agent`
+  as received.
+- **No run flag.** There is no inject flag on the run request and none on
+  `WorkflowInvokeRequestFlags`. The toggle is client session state. The run wire gains no field.
+- **The service does not read the overlay.** The overlay is assembled by the inspect layer and
+  consumed by the frontend. The service's run path never references it.
+- **No backend strip on commit.** The backend does not remove kit items from a committed config,
+  because the kit never enters the committed config.
 
 ## Interface notes (design-interfaces)
 
 The model rests on role splits, not feature splits.
 
-- **Information versus action.** The backend's `build_kit` is pure information: platform-owned,
-  read-only, session-scoped. The frontend acts on it. The split keeps the backend free of the
-  business logic and the frontend free of the data. It is the heart of the corrected model.
-- **Sibling versus member.** The descriptor is a sibling of the config in the `/inspect`
-  response (`revision.data.build_kit`), never a member of `parameters.agent`. Display-and-inject
-  information stays out of the persisted, user-owned config. That placement earns "shown but not
-  committed" with no strip step.
-- **Display versus inject, per row.** Each row carries display fields (`name`, `description`,
-  `status`) and one inject field (`config`). The two faces are different fields, never one
-  overloaded field. The frontend reads display fields to render and the inject field to merge.
-- **Session preference versus persisted config.** The toggle is a playground preference in
-  client session state. It is not a field on the revision and not a flag on the run. If we ever
-  persist it, it is a UI preference keyed to user and agent, never config on the agent.
-- **No new field on the stored config.** The stored contract (`parameters.agent`) is unchanged.
-  The descriptor lives in the inspect response; the toggle lives in the client. The run payload
-  carries ordinary `parameters.agent` entries the service already understands.
+- **Platform-derived information versus user-owned data.** `inspect_context` is platform-supplied,
+  read-only, and derived per response. `application.data.parameters` is user config the revision
+  persists; `application.meta` is user metadata that round-trips. Three owners, three lifecycles,
+  three homes. This split is why the overlay needs no strip step and cannot leak into a commit.
+- **One overlay, not three typed groups.** The kit is a partial agent template, so it reuses the
+  agent-template shape the platform already defines and the playground already renders. The kind
+  of each item (tool, skill, permission) is implicit in where it sits in the template, not in a
+  bespoke descriptor field.
+- **A skill is its embed reference.** An `@ag.embed` reference already identifies a skill and
+  carries its name and description. The overlay adds no parallel display fields for it.
+- **A permission's status is its value.** A sandbox permission set to `allow` in the overlay is
+  the status the drawer renders. No separate status field.
+- **Session preference versus persisted config.** The toggle is a playground preference in client
+  session state, not a field on the revision and not a flag on the run.
 
 ## Change set, by layer
 
-1. **Build-kit builder (backend, new).** One builder in the inspect layer assembles the
-   descriptor: `tools` from `PLATFORM_OPS`, `skills` from the authoring skill, `permissions`
-   from the build-permission set, each row with `key`, `name`, `description`, `config`, and
-   `status` on permissions. Reads SDK-owned sources. Not referenced by the service run path.
+1. **Inspect-context container (backend, new).** Add `inspect_context` to
+   `SimpleApplicationResponse` with a typed `build_kit.agent_template_overlay`
+   (`/home/mahmoud/code/agenta/api/oss/src/apis/fastapi/applications/models.py`). Populate it only
+   in the read path (`fetch_simple_application`), never in create, edit, or commit.
 
-2. **Inspect response (backend).** Attach `revision.data.build_kit` alongside
-   `revision.data.schemas` in the `/inspect` response. Confirm the API inspect proxy
-   (`/home/mahmoud/code/agenta/api/oss/src/apis/fastapi/applications/router.py`) passes
-   `revision.data` through.
+2. **Overlay builder (backend, new).** One builder assembles the overlay: `tools` from
+   `PLATFORM_OPS`, `skills` as the `@ag.embed` reference to the authoring slug, `sandbox` as the
+   build-permission elevation. It reads SDK-owned sources and is not referenced by the service run
+   path.
 
 3. **Published default goes bare (backend).** Revert the `schemas.py` enrichment so the schema
-   default is bare. Move the authoring skill and the sandbox elevation into the kit. Catalog
-   needs no change.
+   default is bare. Move the authoring skill and the sandbox elevation into the overlay.
 
 4. **Stop force-injecting the skill (SDK).** Set `AGENTA_FORCED_SKILLS = []`
-   (`agenta_builtins.py:104`). The authoring skill reaches a run through the kit's frontend
-   injection, not the harness force. Coordinate with the skills project.
+   (`agenta_builtins.py:104`). Coordinate with the skills project.
 
-5. **Frontend read and render (web).** Read `revision.data.build_kit` from `/inspect`. Render
-   the drawer's "Playground build kit" section and make the advanced sections collapsible
-   (drawer changes above).
+5. **Frontend read and render (web).** Read `inspect_context.build_kit.agent_template_overlay`
+   into session state. Render the "Playground build kit" section, reusing the existing config-item
+   controls, and make the advanced sections collapsible.
 
-6. **Frontend inject on run (web).** In `buildAgentRequest` (`agentRequest.ts`), when the
-   toggle is on, merge the descriptor's `config` entries into the run copy's `parameters.agent`
-   (skills and tools appended, permissions merged into the sandbox). Off sends the bare config.
+6. **Frontend overlay applier (web).** Add an explicit applier (deep-merge objects, identity-merge
+   lists) and call it in `buildAgentRequest` when the toggle is on, on the throwaway run copy
+   only.
 
-7. **Frontend exclude on commit (web).** No change needed beyond confirming the kit is never
-   written into `entity.data.parameters`, so `prepareCommitParameters` (`commit.ts:68`) excludes
-   it for free.
+7. **Frontend exclude on commit (web).** No change beyond confirming the overlay is never written
+   into `entity.data.parameters`, so `prepareCommitParameters` excludes it for free.
 
 8. **Tests.** Backend: the builder lists the platform ops, the authoring skill, and the build
-   permissions, each with a `config`; the `/inspect` response carries `build_kit` beside
-   `schemas`; the published default is bare across the builtin, `/inspect`, and the catalog.
-   Frontend: a kit-on run request carries the platform tools, the authoring skill, and the
-   elevated sandbox in `parameters.agent`; a kit-off run carries the bare config; a commit
-   excludes the kit either way. Update the default-template test
-   (`/home/mahmoud/code/agenta/services/oss/tests/pytest/unit/agent/test_default_agent_template.py`)
-   to assert the bare default.
+   permissions as one overlay; the inspect response carries `inspect_context.build_kit`; the
+   published default is bare across the builtin, the inspect schema, and the catalog (update
+   `/home/mahmoud/code/agenta/services/oss/tests/pytest/unit/agent/test_default_agent_template.py`).
+   Frontend: a kit-on run merges the overlay into `parameters.agent` (deep-merge and identity-merge
+   verified); a kit-off run sends the bare config; a commit excludes the kit either way; the
+   applier never mutates the draft or committed tree.
 
 ## Risks and edge cases
 
-- **Safety.** The kit grants self-commit, write files, and execute code. It must never reach a
-  production run. It cannot, because nothing persists it and the run path never adds it. A
-  deployed agent runs its stored config, which has no kit. State this and assert it in a test
-  (a published agent's resolved config never contains the platform ops or the elevated sandbox).
+- **Safety.** The kit grants self-commit, write files, and execute code. It cannot reach a
+  production run: nothing persists it and the run path never adds it. A deployed agent runs its
+  stored config, which has no overlay. Assert it (a published agent's resolved config never
+  contains the platform ops or the elevated sandbox).
 - **No new attack surface.** The run API already accepts and resolves whatever tools and
-  permissions a config carries. A hand-authored config with the platform ops already runs them
-  today. The kit grants the frontend no capability the run API did not already accept; it only
-  saves the user from authoring those entries by hand.
-- **Kit off.** Turning the kit off produces a run with the user's config only, so the user
-  tests the agent as users will see it. This is the no-inject path, the simple default.
+  permissions a config carries; a hand-authored config with the platform ops already runs them
+  today. The overlay grants the frontend no new capability; it only saves the user from authoring
+  those entries by hand.
+- **Merge precedence.** The applier must deep-merge objects and identity-merge lists, not spread.
+  A shallow spread would replace the user's `tools` or `skills` arrays. This is the one place a
+  naive implementation breaks the feature.
+- **Kit off.** A kit-off run uses the user's config only, so the user tests the agent as users
+  will see it.
 - **Existing agents.** They gain the kit in the playground with no migration, because the
-  frontend injects it from the descriptor at run time. Nothing is baked, so nothing goes stale.
-- **Permission overlap.** The agent's own sandbox is a committed field. The kit's build
-  permissions are a session-only elevation the frontend merges on a kit-on run. Keep them
-  separate so a kit-off run uses the agent's own permissions.
+  frontend merges it from the overlay at run time. Nothing is baked, so nothing goes stale.
 
 ## Out of scope and coordination
 
-- The authoring skill's content and naming are owned by the skills project (`#4918`). This
-  design references the skill by its stable slug. It does not write skill content.
-- The builder-tools project (`#4919`) adds more platform ops. The builder reads `PLATFORM_OPS`
-  at assembly time, so new ops join the kit automatically.
-- Per-item edit or delete of kit items, and a picker to add platform tools to the published
-  agent, are out of scope. The kit is whole-toggle and read-only in v1.
-- The model change in this rewrite ripples to `#4918`, `#4919`, `#4920`, which still reference
-  the rejected backend-injection model. They are not edited here; the orchestrator propagates
-  the corrected model after Mahmoud approves it.
+- The authoring skill's content and naming are owned by the skills project (`#4918`). This design
+  references the skill by its reserved slug.
+- The builder-tools project (`#4919`) adds more platform ops. The builder reads `PLATFORM_OPS` at
+  assembly time, so new ops join the overlay automatically.
+- A client tool such as `request_connection` is not a platform op. It is a non-runnable
+  workflow (reference) tool: the backend exposes it and the frontend handles the call, the same
+  reference-tool concept the platform already has. If the kit later carries such a tool, it joins
+  the overlay as a reference-tool entry (identity by its referenced workflow), not a platform op.
+  Its primary definition is owned by `#4920`.
+- Per-item edit or delete of kit items, and a picker to add platform tools to the published agent,
+  are out of scope. The kit is whole-toggle and read-only in v1.
+- The overlay model carries through to `#4918`, `#4919`, and `#4920`. They are not edited here; the
+  orchestrator propagates it after Mahmoud approves this design.
 
 ## Open questions for Mahmoud
 
-1. **Toggle persistence.** Ephemeral per playground session (resets to on), or a stored
-   playground preference per user and agent. I lean ephemeral for v1: smaller surface, and the
-   kit defaults on.
-2. **Confirm the published default goes fully bare**, dropping the authoring skill and the
-   sandbox boundary from the schema default into the kit, and setting `AGENTA_FORCED_SKILLS =
-   []`. This touches the skills project's surface, so it needs their nod.
-3. **Permissions group: read-only, or independently flippable?** The kit's PERMISSIONS group
-   reflects what the kit grants. Purely read-only under the single kit toggle (this design), or
-   should the user flip the build permissions off while keeping the rest of the kit on? I lean
-   read-only.
-4. **Carry `config` per row, or derive it from `key`?** This design carries `config` so the
-   frontend does a pure merge and owns no wire shapes. The leaner alternative drops `config`
-   and rebuilds each entry from `key` plus kind, which pushes the platform tool and skill shapes
-   into the frontend and cannot express a permission setting from a key. I lean carry `config`.
-5. **Ship Change 1 (collapsible sections) with the kit, or separately?** It is independent UI
-   polish with no contract and no logic. I lean separate, since it de-risks the larger change
-   and unblocks nothing.
+1. **Toggle persistence.** Ephemeral per playground session (resets to on), or a stored playground
+   preference per user and agent. I lean ephemeral for v1.
+2. **Confirm the published default goes fully bare**, dropping the authoring skill and the sandbox
+   boundary from the schema default into the overlay, and setting `AGENTA_FORCED_SKILLS = []`. This
+   touches the skills project's surface, so it needs their nod.
+3. **Merge precedence on a conflict.** The overlay overrides on an identity match (it is an
+   override overlay). Confirm the kit should win over a user entry of the same identity, rather
+   than yield to it.
+4. **Ship Change 1 (collapsible sections) with the kit, or separately?** It is independent UI
+   polish with no contract and no logic. I lean separate.
+
+## Appendix: prior approaches
+
+Two earlier models were considered and dropped. The first had the agent service merge the kit at
+run time behind a run flag; it put business logic in the service and a kit-injecting path on every
+run. The second kept the merge on the frontend but modeled the kit as a bespoke descriptor with
+three typed groups, each row carrying `key`, `name`, `description`, and a per-row `config`; it
+reinvented display fields the agent-template shape and the embed reference already provide. The
+current overlay model supersedes both: the service stays dumb, and the kit is one partial agent
+template the frontend merges.

--- a/docs/design/agent-workflows/projects/default-agent-config/design.md
+++ b/docs/design/agent-workflows/projects/default-agent-config/design.md
@@ -1,278 +1,493 @@
-# Design: the playground build kit (inject, do not commit)
+# Design: the playground build kit (the frontend injects, the backend informs)
 
 Status: draft for Mahmoud's review. Grounded in code on `gitbutler/edit` over
-`big-agents`, 2026-06-28. See `research.md` for the code trace. This rewrite replaces an
-earlier approach (materialize the defaults into the catalog template). That approach is
-dropped. See "What changed and why".
+`big-agents`, 2026-06-28. Paths are absolute. See `research.md` for the code trace.
+
+This is the second rewrite. Mahmoud rejected the first rewrite's core model: it made the
+backend agent service inject the kit at run time, behind a run flag. That is gone. The
+corrected model moves the injection to the frontend and leaves the backend with one job,
+to inform. The section "What changed and why" records the pivot.
 
 ## Problem and goal
 
-A new agent arrives almost empty. We want the playground to give the agent the tools and
-skills it needs to build and improve itself, without writing those tools and skills into the
-published agent.
+A new agent arrives almost bare. The playground still needs to give that agent the tools,
+the skill, and the permissions it takes to build and improve itself, while the user works on
+it. None of that authoring scaffolding belongs in the agent the user ships.
 
-The platform tools and the Agenta authoring skill are a build aid, not part of the user's
-agent. The user is shipping their agent. The platform ops (find capabilities, query
-workflows, commit a revision) and the authoring skill exist so the agent can scaffold and
-edit itself while the user works on it in the playground. Once the agent ships, it should
-not carry Agenta's authoring tools unless the user added their own.
+The platform tools (find capabilities, query workflows, commit a revision), the Agenta
+authoring skill, and the build permissions (write files, execute code) are a build aid. They
+are not the user's agent. They exist so the assistant can scaffold and edit the agent in the
+playground. Once the agent ships, it should carry only what the user authored.
 
-So the model is inject, not commit. The backend injects the kit into the playground
-session, for display and for the run. The commit writes only the user's real config.
+So the kit is shown and used in the playground, but never committed. The goal of this design
+is to decide who shows it, who uses it, and who keeps it out of the commit.
 
 ## What changed and why
 
-The earlier draft made the platform tools and the skill embed part of the agent config and
-baked them into the catalog template, so a new agent committed them. Mahmoud reviewed that
-and rejected it. The defaults should not be committed to the agent. They are a playground
-overlay. The designer handoff (`design_handoff_advanced_build_kit`) names this exactly: a
-"Playground build kit" that is "Removed on commit" and "None of this is part of the
-published agent".
+The first rewrite put the injection in the backend. The agent service merged the kit into
+the effective config at a run-prep step, gated by a `flags.inject_build_kit` run flag.
+Mahmoud rejected that. His direction, verbatim in the PR review:
 
-Two consequences. The published-config default stays bare. The build kit becomes a separate
-backend concept that the playground injects and the commit strips.
+> It should not be the agent service that injects the kit. This should be a front-end
+> matter. The front-end injects the kit when used in the playground as part of the
+> parameters of the agent template. The service itself should not know about it.
 
-This is also simpler. Nothing about the kit is persisted into the agent, so there is no
-merge, no per-item delete marker, and no list of suppressed defaults in the stored config.
+> The frontend should own the business logic for setting these. The only thing the backend
+> should do is give information and inspect what this build kit is: which skills, which
+> tools, which permissions.
 
-## The model
+So the model flips. The service stops injecting. The backend stops gating. The frontend owns
+the injection, and the backend's only build-kit job is to expose the kit's information
+through `/inspect`. The rest of this document follows from that one change.
 
-The build kit is a backend-defined set of three things:
+## The corrected model
 
-- Tools: the platform ops, sourced from the catalog (`PLATFORM_OPS`).
-- Skills: the Agenta authoring skill.
-- Permissions: the sandbox elevation the agent needs to build, write files and execute code.
+Three actors, three clear jobs.
 
-The kit has one source of truth in the backend. It flows three ways.
+- **The agent service stays dumb.** It receives an agent template at `parameters.agent` and
+  runs exactly that. It does not know the build kit exists. There is no run-prep injection
+  and no `inject_build_kit` run flag. If the platform tools, the authoring skill, and the
+  build permissions reach a run, they reach it because they are already inside the
+  `parameters.agent` the service was handed. The service resolves them the same way it
+  resolves any tool or skill.
+- **The backend informs.** Its only build-kit job is to expose the kit's information through
+  `/inspect`: which skills, which tools, which permissions the kit holds, and, for each, the
+  exact agent-template entry that item would contribute. This is read-only information. The
+  backend assembles it and never acts on it.
+- **The frontend owns the logic.** It reads the kit's information from `/inspect`. It shows
+  the kit in the advanced drawer with an enable or disable toggle. When the kit is on, the
+  frontend injects the kit's skills, tools, and permissions into `parameters.agent` in the
+  run request it sends. On commit, the frontend leaves the kit out, so the committed config
+  holds only the user's own config.
 
-- Display. The backend exposes the kit so the Advanced drawer renders it as a read-only
-  group the user can toggle on or off. The drawer owns that UX, not this design.
-- Run. When the playground runs the agent with the kit on, the backend injects the kit into
-  the effective config for that run, before tool and skill resolution. The agent runs with
-  the platform tools, the authoring skill, and the build permissions.
-- Commit. The commit writes only the user's config. The kit is never in the stored config,
-  so there is nothing to strip. It is absent by construction.
+The "shown but not committed" property now belongs to the frontend. The frontend includes
+the kit in the run payload and excludes it from the commit payload. Nothing in the backend
+adds or strips the kit.
 
-The kit is off by default for any plain run of the agent. The playground turns it on. A
-production run of a published agent never injects it. This matters: the kit lets the agent
-rewrite itself and run code, which is a build-time power, not a shipped one.
+This is also where the property gets cheap. The kit never enters `parameters.agent`, the
+config tree the playground edits and commits. It lives only in the read-only descriptor and,
+on a kit-on run, in the outbound run payload. There is no strip step on commit, because the
+kit was never in the tree the commit serializes. There is no run flag, because a kit-on run
+is just a run whose `parameters.agent` already carries the extra items.
 
-## The three questions
+A deployed agent therefore can never run with the kit. The kit is not in its stored config,
+and the backend never adds it. The only place the kit exists is the descriptor (information)
+and a live playground run payload (the frontend's doing). That is a stronger safety
+guarantee than a server flag: there is no path that injects authoring power into a published
+run, because nothing persists the kit and nothing on the run path adds it.
 
-### 1. How do we do this smartly, without too much complexity?
+## The `/inspect` build-kit descriptor (the central question)
 
-Never commit the kit. That single rule removes the hard parts. There is no base-plus-patch
-merge in the stored config, no tombstone to record a deleted default, and no suppressed-list
-field. The stored config holds only the user's items, exactly as it does today.
+Mahmoud's central question: how do we put the build-kit information in `/inspect`, so the
+frontend can act on it? This section answers it, organized by role per the `design-interfaces`
+skill.
 
-The kit is one backend definition. The run path injects it into the in-memory effective
-config at the existing run-prep step, then reuses the tool, skill, and permission resolution
-that already runs. The display path reads the same definition. The commit path does nothing
-new, because the kit was never in the config it serializes.
+### Where it sits
 
-The published-config default does not change. It stays bare. We do not touch the catalog
-template or the new-config seed. We add one concept (the kit) and one run flag (inject the
-kit for this session), and we move the authoring skill out of the published default and into
-the kit.
+Deliver the descriptor in the `/inspect` response at `revision.data.build_kit`, a read-only
+sibling of `revision.data.schemas`. The frontend already fetches `/inspect` per workflow, so
+the drawer reads the descriptor with no new request. The descriptor is platform-owned. The
+frontend reads it, renders it, and injects from it. It never writes it, merges it back, or
+echoes it to the backend.
 
-### 2. Can we avoid hardcoding this in the frontend?
+The descriptor is a sibling of the config, never a member of `parameters.agent`. That
+placement is the load-bearing decision. The kit is display-and-inject information that the
+platform owns and the session scopes. The agent config is user-owned data that the revision
+persists. They answer different questions, so they do not share a contract.
 
-Yes. The kit's contents come entirely from the backend. The backend names the tools, the
-skill, and the permissions, with labels for the drawer. The frontend renders the groups it
-receives and owns only the on or off toggle. It never lists a platform op or a skill name in
-its own code. The designer handoff says the same: "confirm the real set with the backend",
-and "the build-kit contents come from whatever Agenta already injects".
+### The shape
 
-### 3. Where does the injection happen, and how do we keep it out of the frontend?
+Grouped by kind. Each kind renders as one read-only group in the drawer and routes to one
+destination in `parameters.agent`.
 
-Two injection points, one backend source.
-
-- Display: the backend serves a build-kit descriptor. The drawer reads it. The set is
-  decided server-side.
-- Run: the agent service injects the kit into the effective config at run-prep, in `_agent`
-  (`/home/mahmoud/code/agenta/services/oss/src/agent/app.py:207`), before
-  `resolve_tools(agent_template.tools)` at line 227. Gated by the run flag. The injection is
-  harness-agnostic, so it works on `pi_core` as well as `pi_agenta`.
-
-The frontend never decides the set. It reads it for display and sends the toggle for the
-run.
-
-## Does `/inspect` already carry enough, or do we add a signal?
-
-`/inspect` is the right channel. The frontend already fetches it per workflow, so the drawer
-reads it with no new call. But the value `/inspect` carries today does not suffice. It
-carries the published-config schema default at
-`revision.data.schemas.parameters.properties.agent.default`
-(`/home/mahmoud/code/agenta/services/oss/src/agent/schemas.py:52`). That value's role is the
-seed for the user's persisted config. The build kit's role is an ephemeral overlay that the
-run injects and the commit excludes. Those are two different roles. Overloading the schema
-default to also mean "the kit to inject and strip" is the exact role confusion that caused
-the original gap, where the skill embed sat in a default the draft never read.
-
-So deliver a dedicated descriptor in the `/inspect` response, as a new read-only sibling of
-`schemas`, not inside the schema default. After this, `/inspect` carries two distinct things
-with two distinct roles: the bare schema default (the seed for the user's config) and the
-`build_kit` descriptor (the platform overlay). The exact descriptor shape is the contract
-below.
-
-Cleaning up the schema default is part of this. Today `schemas.py` enriches the published
-default with the skill embed and the sandbox boundary. Under this model those belong to the
-kit, not the published default. Move them. The published default returns to bare, the same
-value the SDK builtin already carries.
-
-## The build-kit contract (the drawer reads this)
-
-The advanced-build-kit drawer renders this exact shape and never invents its own. Field
-names are part of the contract.
-
-Delivered in the `/inspect` response at `revision.data.build_kit`, a read-only sibling of
-`revision.data.schemas`. It is platform-owned. The frontend reads it, renders it, and never
-writes, merges, or echoes it back.
-
-```
-build_kit:
-  skills:      [ { key, name, description } ]                  # key = the skill slug
-  tools:       [ { key, name, description } ]                  # key = the platform op
-  permissions: [ { key, name, description, status } ]          # status only on permissions
+```jsonc
+{
+  "build_kit": {
+    "skills": [
+      {
+        "key": "__ag__getting_started_with_agenta", // the skill slug (identity)
+        "name": "agenta-authoring",                  // display label
+        "description": "Scaffold and edit this agent's tools, skills, and config.",
+        "config": { "@ag.embed": { "slug": "__ag__getting_started_with_agenta" } }
+      }
+    ],
+    "tools": [
+      {
+        "key": "find_capabilities",                  // the platform op (identity)
+        "name": "Find capabilities",
+        "description": "Discover the tools and workflows available to this agent.",
+        "config": { "type": "platform", "op": "find_capabilities" }
+      }
+    ],
+    "permissions": [
+      {
+        "key": "write_files",
+        "name": "Write files",
+        "description": "Filesystem read and write while building.",
+        "status": "on",                              // read-only policy state, the green pill
+        "config": { "sandbox": { "permissions": { "write_files": "allow" } } }
+      }
+    ]
+  }
+}
 ```
 
-- Grouped by kind: `skills`, `tools`, `permissions`. The drawer renders one read-only group
-  per kind, in that order.
-- Every row carries `key` (a stable identifier), `name` (the display name), and
-  `description` (the one-line purpose). `key` is the slug for a skill, the op for a tool, and
-  the permission key for a permission. The kind is the array the row sits in, so a row needs
-  no kind tag.
-- `permissions` rows additionally carry `status` (for example `on`), which the drawer shows
-  as the green status pill. Skills and tools rows have no `status`.
-- The source: `tools` from `PLATFORM_OPS` (the catalog owns the name, description, and per-op
-  permission), `skills` from the authoring skill (its slug, name, description), `permissions`
-  from the build permission set (write files, execute code). One backend builder produces all
-  three groups, and the same builder feeds the run-time injection, so the displayed kit and
-  the injected kit are the same set.
+### Why each row carries `config`
 
-The per-run flag the drawer toggle controls:
+This is the pivot from the rejected model, so it is worth stating plainly.
 
-- `flags.inject_build_kit` (boolean), on the run request, request-scoped. The drawer's
-  enable or disable toggle sets it. When the kit is off the drawer sends `false`, the run
-  skips injection, and the agent runs with the user's config only. It defaults to off
-  server-side, so a request that omits it (any non-playground caller) never injects the kit.
-  The drawer defaults the toggle on, so a normal playground run sends `true`.
+In the rejected model the backend injected the kit, so the descriptor only needed display
+fields: `key`, `name`, `description`, and a permission `status`. The frontend rendered those
+labels and flipped a flag; the backend turned `find_capabilities` into the real platform tool
+config server-side.
 
-The two names intentionally pair: `build_kit` is the read-only catalog of what the toggle
-controls, and `inject_build_kit` is the toggle. They live in different messages (the inspect
-response versus the run request), so they never appear together.
+In the corrected model the frontend injects the kit. So each row must also carry the exact
+agent-template entry it contributes, because the frontend, not the backend, now writes that
+entry into `parameters.agent`. The `config` field is that entry: a platform tool config for a
+tool row, an `@ag.embed` reference for a skill row, a sandbox-permission fragment for a
+permission row.
+
+Carrying `config` keeps the contents fully backend-owned. The frontend does a pure structural
+merge. It appends `skills[].config` to `parameters.agent.skills`, appends `tools[].config` to
+`parameters.agent.tools`, and merges `permissions[].config` into the agent's sandbox section.
+It never builds a tool's wire shape, never knows the authoring skill's slug, and never decides
+which permission to elevate. It owns the business logic (when to inject, where each kind goes,
+run versus commit). The backend owns the data (which items, and the exact form of each).
+
+Because each `config` is an ordinary `parameters.agent` entry, the dumb service already knows
+how to run it. A kit-on run is indistinguishable on the wire from a config the user authored
+by hand with those same tools. That is what lets the service stay dumb.
+
+I considered the leaner alternative: keep only `key`, `name`, `description`, and `status`, and
+have the frontend derive each injected entry from `key` plus kind. I rejected it. It pushes
+the platform tool wire shape and the skill embed shape into the frontend, and it cannot
+express a permission setting from a key alone. Open question 4 revisits this if we want the
+leaner shape after all.
+
+### The role of each field
+
+Run through `design-interfaces`, field by field:
+
+- The descriptor as a whole is platform-owned, session-scoped information. It is a sibling of
+  the config, never part of `parameters.agent`.
+- `skills` / `tools` / `permissions` are routing. The kind picks both the drawer group and the
+  destination list in `parameters.agent`. The three kinds differ in exactly one visible way: a
+  permission row carries a status the others do not.
+- `key` is a stable, platform-owned identity (the skill slug, the platform op, the permission
+  key). The drawer keys rows on it. It is not the visible label.
+- `name` and `description` are display metadata: the row's label and its one-line purpose.
+- `status` (permission rows only) is read-only policy state (`on` or `off`). It reflects what
+  the kit grants for authoring. The drawer renders it as the green `On` pill. Skill and tool
+  rows carry no status.
+- `config` is the agent-template fragment the row contributes. It is data the frontend writes
+  into the run payload. Despite the generic word, it has one exact meaning here: the
+  `parameters.agent` entry for this one item.
+
+No field plays two roles. The kind tag is implicit in the array a row sits in. The labels and
+the injectable form are the backend's to own.
+
+### How the backend assembles it
+
+One backend builder produces all three groups, in the inspect layer, reading sources that the
+SDK already owns:
+
+- `tools` from `PLATFORM_OPS`
+  (`/home/mahmoud/code/agenta/sdks/python/agenta/sdk/agents/platform/op_catalog.py`). Each op
+  becomes a row: `key` is the op, `name` and `description` come from the catalog, and `config`
+  is `{ "type": "platform", "op": <op> }`. Reading the catalog at assembly time means a new op
+  added by the builder-tools project (`#4919`) joins the kit with no edit here.
+- `skills` from the authoring skill, the SDK constant `GETTING_STARTED_WITH_AGENTA`
+  (`/home/mahmoud/code/agenta/sdks/python/agenta/sdk/agents/adapters/agenta_builtins.py`),
+  served read-only under the reserved `__ag__*` slug. The row's `key` is the slug, `name` and
+  `description` come from the skill, and `config` is the `@ag.embed` reference to that slug.
+- `permissions` from the build-permission set (write files, execute code). Each becomes a row
+  with `status: "on"` and a `config` that is the sandbox-permission fragment the frontend
+  merges into the agent's sandbox section.
+
+The builder lives in the backend inspect layer and reads SDK-owned constants. The agent
+service's run path never references it. That keeps the run path, and therefore the service,
+kit-unaware.
+
+### How the backend serves it
+
+The `/inspect` response already carries `revision.data.schemas`, forwarded from the service's
+schema declaration through the API inspect proxy
+(`/home/mahmoud/code/agenta/api/oss/src/apis/fastapi/applications/router.py`). The inspect
+layer attaches `revision.data.build_kit` alongside `schemas`, assembled by the builder above.
+Confirm the proxy passes `revision.data` through rather than allow-listing fields, so the new
+sibling reaches the frontend.
+
+## The frontend logic
+
+The frontend owns three behaviors. All three read the same descriptor; none touch the
+backend's run wire.
+
+1. **Read.** On loading the workflow, the frontend reads `revision.data.build_kit` from the
+   `/inspect` response. It renders the three groups in the drawer (next section). It hardcodes
+   no item list, no label, and no wire shape.
+
+2. **Toggle and inject on run.** The drawer holds one piece of session state,
+   `buildKitEnabled`, default on. When the frontend builds a run request, it injects the kit
+   if the toggle is on. The injection point is `buildAgentRequest`
+   (`/home/mahmoud/code/agenta/web/packages/agenta-playground/src/state/execution/agentRequest.ts`),
+   which composes the `/invoke` body's `data.parameters` from the draft-aware config. With the
+   kit on, the builder appends `build_kit.skills[].config` and `build_kit.tools[].config` to
+   the run copy's `parameters.agent` lists and merges `build_kit.permissions[].config` into its
+   sandbox section, then sends that. With the kit off, it sends the user's config unchanged,
+   so the user previews the agent as users will see it. The builder already transforms
+   `parameters` before sending (it drops half-filled entries and normalizes tool shapes), so a
+   kit merge is the same kind of pre-send step, on a throwaway copy.
+
+3. **Exclude on commit.** The commit path reads the user's config from `entity.data.parameters`
+   through `prepareCommitParameters`
+   (`/home/mahmoud/code/agenta/web/packages/agenta-entities/src/workflow/state/commit.ts:68`).
+   The kit was never written into `entity.data.parameters`, so the commit excludes it with no
+   strip step. The descriptor and the kit-on run payload are the only places the kit ever
+   appears.
+
+The run wire stays byte-compatible. The backend cannot tell a kit-on run from a hand-authored
+config with the same items, and it does not need to.
+
+## The UI drawer (folded in)
+
+Mahmoud asked for this design to cover both the inspect information and the drawer UI he
+designed, in one document, not split into a separate PR. So the drawer design lives here. It
+recomposes existing drawer parts; nothing below is novel UI. The designer handoff
+(`/home/mahmoud/code/agenta/design_handoff_advanced_build_kit/README.md`) is the
+high-fidelity spec; the `.dc.html` is a visual reference, not code, and `support.js` is mock
+runtime to ignore.
+
+### The drawer today
+
+Verified on this branch, so the changes land on real structure.
+
+- The advanced drawer is `AgentTemplateControl.tsx`
+  (`/home/mahmoud/code/agenta/web/packages/agenta-entity-ui/src/DrillInView/SchemaControls/AgentTemplateControl.tsx`).
+  It renders inside the `SectionDrawer` shell (icon, title, scroll body, Cancel and Save).
+- The advanced body already stacks three groups, separated by top borders, not yet
+  collapsible: Authentication (`:1517`), Execution environment (`:1530`), and Permissions
+  (`:1565`). These configure the committed agent.
+- The collapsed-header summary the drawer already computes (`advancedSummary`, `:1501`) reads
+  values such as `Agenta-managed` and `Sandbox: Local` from existing state. The per-section
+  summaries reuse those values.
+- `SkillTemplateControl.tsx:205` already renders an Agenta-owned skill read-only: "Provided by
+  Agenta. This skill cannot be edited or removed," with no editor and no delete. This is the
+  read-only pattern the kit reuses, lifted from the per-item list into the kit section.
+
+### Change 1: make the advanced sections collapsible
+
+Each advanced group becomes a collapsible accordion item, the behavior the playground's left
+panel already uses, so the groups stop rendering as one long scroll.
+
+- Default state is collapsed. Several sections can be open at once; it is not single-open.
+- The header row shows the section icon, the title, a one-line summary on the right, then a
+  chevron that rotates when open.
+- The body mounts only when expanded. Its content is the section's existing controls,
+  unchanged.
+- Summaries reuse state already present: Authentication shows `Agenta-managed`, Execution
+  environment shows `Sandbox: Local`, Permissions shows `Auto`. The build kit shows no text
+  summary; its toggle sits in the header instead.
+
+This change carries no contract and no commit logic. It is drawer polish on the existing
+groups, and it can ship on its own (open question 5).
+
+### Change 2: add the "Playground build kit" section
+
+A new collapsible section at the top of the drawer, above Authentication, with a subtly warmer
+background (`#fcfcfa`) so it reads as a distinct playground-only layer.
+
+- **Header**: a wrench icon, the title `Playground build kit`, a restrained `Removed on commit`
+  tag (a small amber dot plus text, no pill, no banner), an enable or disable toggle, and the
+  chevron. The toggle's click stops propagation, so flipping the kit does not also expand the
+  section.
+- **Body, when expanded**: an intro paragraph that ends with "None of this is part of the
+  published agent." When the kit is off, an info note that the assistant can no longer create
+  files, run code, or edit the agent here. Then the three groups.
+- **The three groups**, rendered straight from `build_kit`, one labelled group per kind, in
+  order: skills, tools, permissions. Every row is dimmed and locked, reusing the read-only
+  pattern from `SkillTemplateControl.tsx:205`. Permission rows additionally render the green
+  `On` pill from each row's `status`. The drawer hardcodes no item list; it renders whatever
+  the descriptor carries. The designer's sample rows (`agenta_authoring`, `commit_version`,
+  `Write files`) are illustrative.
+
+### The toggle wiring (the corrected part)
+
+This is where the drawer differs from the rejected model. The toggle does not set a run flag.
+The toggle is `buildKitEnabled`, session state, default on. The frontend reads it when it
+builds the run request and injects the kit's `config` entries into `parameters.agent` when it
+is on (frontend logic, step 2). The drawer writes nothing into the config and never echoes the
+descriptor. The toggle is a playground preference, not a field on the revision.
+
+### Keep two permission ideas distinct
+
+The drawer now holds two things that both say "permissions," and they must not read as one
+setting.
+
+- The committed Permissions group, and the Execution environment group, configure the agent's
+  own permissions and sandbox. The user edits them, they commit, they ship.
+- The build kit's PERMISSIONS group is a read-only reflection of the permissions the kit grants
+  for authoring. It is dimmed, locked, tagged removed on commit, and never committed.
+
+The structure does the heavy lifting: the kit's permissions live inside the kit section, behind
+the same dimming, lock, and removed-on-commit tag as the rest of the kit, while the agent's own
+Permissions group stays an editable, committed control elsewhere. The intro paragraph and the
+tag carry the distinction in words. This is worth a deliberate review with the designer, because
+the two ideas sit close together and a user who conflates them could believe the agent ships
+with write-files and execute-code permission.
+
+## What the backend explicitly does NOT do
+
+This section exists because the rejected model lived in the backend. State the negatives so no
+implementer re-adds them.
+
+- **No service-side injection.** The agent service does not merge the kit into the config at
+  run-prep. There is no kit merge in `_agent`
+  (`/home/mahmoud/code/agenta/services/oss/src/agent/app.py`). The service runs
+  `parameters.agent` as received.
+- **No run flag.** There is no `flags.inject_build_kit` on the run request and none on
+  `WorkflowInvokeRequestFlags`. The toggle is client session state. The run wire gains no
+  field.
+- **The service does not read `build_kit`.** The descriptor is assembled by the inspect layer
+  and consumed by the frontend. The service's run path never references it. The service does
+  not know the kit exists.
+- **No backend strip on commit.** The backend does not remove kit items from a committed
+  config, because the kit never enters the committed config. The frontend simply does not put
+  it there.
+
+## Published default stays bare
+
+The published-config default does not carry the kit. A new agent's stored config is bare: no
+platform tools, no authoring skill, no elevated sandbox.
+
+Today `schemas.py` enriches the published default with the authoring skill and the sandbox
+boundary (`build_agent_v0_default(skill_slug=..., include_sandbox_permission=True)` at
+`/home/mahmoud/code/agenta/services/oss/src/agent/schemas.py:52`). Under this model those two
+belong to the kit, not the published default. Revert the enrichment so the `/inspect` schema
+default and the catalog template both carry the bare default, the same value the SDK builtin
+carries. The skill and the sandbox elevation reach a run only through the kit, by the
+frontend's injection.
+
+That keeps two distinct things in `/inspect` with two distinct roles: the bare schema default
+(the seed for the user's persisted config) and the `build_kit` descriptor (the platform's
+session overlay). Overloading the schema default to also mean "the kit" was the exact role
+confusion this design avoids.
+
+The authoring skill stops reaching runs through the harness force as well. Today the
+`pi_agenta` harness unions `AGENTA_FORCED_SKILLS` into every run, always on and not toggleable
+(`/home/mahmoud/code/agenta/sdks/python/agenta/sdk/agents/adapters/agenta_builtins.py:104`).
+A forced skill cannot be toggled, which contradicts the kit's toggle. So the authoring skill
+must come from the kit (frontend injection), not the force. Set `AGENTA_FORCED_SKILLS = []`,
+keeping `force_skills` for a future genuinely-forced item. This touches the skills project's
+surface, so confirm it with them (open question 2).
+
+## Interface notes (design-interfaces)
+
+The model rests on role splits, not feature splits.
+
+- **Information versus action.** The backend's `build_kit` is pure information: platform-owned,
+  read-only, session-scoped. The frontend acts on it. The split keeps the backend free of the
+  business logic and the frontend free of the data. It is the heart of the corrected model.
+- **Sibling versus member.** The descriptor is a sibling of the config in the `/inspect`
+  response (`revision.data.build_kit`), never a member of `parameters.agent`. Display-and-inject
+  information stays out of the persisted, user-owned config. That placement earns "shown but not
+  committed" with no strip step.
+- **Display versus inject, per row.** Each row carries display fields (`name`, `description`,
+  `status`) and one inject field (`config`). The two faces are different fields, never one
+  overloaded field. The frontend reads display fields to render and the inject field to merge.
+- **Session preference versus persisted config.** The toggle is a playground preference in
+  client session state. It is not a field on the revision and not a flag on the run. If we ever
+  persist it, it is a UI preference keyed to user and agent, never config on the agent.
+- **No new field on the stored config.** The stored contract (`parameters.agent`) is unchanged.
+  The descriptor lives in the inspect response; the toggle lives in the client. The run payload
+  carries ordinary `parameters.agent` entries the service already understands.
 
 ## Change set, by layer
 
-1. Build-kit definition. One backend builder returns the kit (tools from `PLATFORM_OPS`,
-   the authoring skill, the build permissions), with identifiers and labels. Single source.
-   The tool set is read from the catalog at call time, so a new op added by the builder-tools
-   project (`#4919`) joins the kit with no edit here. Likely home: the agent service or a
-   shared SDK helper that both the service and the API import.
+1. **Build-kit builder (backend, new).** One builder in the inspect layer assembles the
+   descriptor: `tools` from `PLATFORM_OPS`, `skills` from the authoring skill, `permissions`
+   from the build-permission set, each row with `key`, `name`, `description`, `config`, and
+   `status` on permissions. Reads SDK-owned sources. Not referenced by the service run path.
 
-2. Display signal. Serve the `build_kit` descriptor (the contract above) in the `/inspect`
-   response at `revision.data.build_kit`, a read-only sibling of `schemas`. The API inspect
-   proxy
-   (`/home/mahmoud/code/agenta/api/oss/src/apis/fastapi/applications/router.py:473`)
-   forwards the new sibling alongside `schemas`; confirm it passes `revision.data` through
-   rather than allow-listing fields. The same backend builder that produces the descriptor
-   feeds the run injection.
+2. **Inspect response (backend).** Attach `revision.data.build_kit` alongside
+   `revision.data.schemas` in the `/inspect` response. Confirm the API inspect proxy
+   (`/home/mahmoud/code/agenta/api/oss/src/apis/fastapi/applications/router.py`) passes
+   `revision.data` through.
 
-3. Run injection. In `_agent`
-   (`/home/mahmoud/code/agenta/services/oss/src/agent/app.py:207`), when
-   `flags.inject_build_kit` is true, merge the kit's tools into `agent_template.tools`, its
-   skill into `agent_template.skills`, and its permissions into the sandbox permission, before
-   the existing `resolve_tools` / `resolve_mcp_servers` calls. Reuse all existing resolution.
-   The flag rides `WorkflowInvokeRequestFlags` (`app.py:214`), defaults off server-side, and
-   the playground sends it on.
+3. **Published default goes bare (backend).** Revert the `schemas.py` enrichment so the schema
+   default is bare. Move the authoring skill and the sandbox elevation into the kit. Catalog
+   needs no change.
 
-4. Published default stays bare. Revert the `schemas.py` enrichment so the `/inspect` schema
-   default and the catalog template both carry the bare default (no skill, no tools). The
-   skill embed and the sandbox boundary move into the kit. File:
-   `/home/mahmoud/code/agenta/services/oss/src/agent/schemas.py:52`. The catalog
-   (`/home/mahmoud/code/agenta/api/oss/src/resources/workflows/catalog.py`) needs no change;
-   the earlier materialize edit is dropped.
+4. **Stop force-injecting the skill (SDK).** Set `AGENTA_FORCED_SKILLS = []`
+   (`agenta_builtins.py:104`). The authoring skill reaches a run through the kit's frontend
+   injection, not the harness force. Coordinate with the skills project.
 
-5. Stop force-injecting the skill. Set `AGENTA_FORCED_SKILLS = []`
-   (`/home/mahmoud/code/agenta/sdks/python/agenta/sdk/agents/adapters/agenta_builtins.py:104`).
-   The authoring skill now reaches a playground run through the kit injector, not through the
-   `pi_agenta` harness force. Keep `force_skills`, `force_tools`, and the skill constant for a
-   future genuinely-forced item.
+5. **Frontend read and render (web).** Read `revision.data.build_kit` from `/inspect`. Render
+   the drawer's "Playground build kit" section and make the advanced sections collapsible
+   (drawer changes above).
 
-6. Tests. The default-template test
+6. **Frontend inject on run (web).** In `buildAgentRequest` (`agentRequest.ts`), when the
+   toggle is on, merge the descriptor's `config` entries into the run copy's `parameters.agent`
+   (skills and tools appended, permissions merged into the sandbox). Off sends the bare config.
+
+7. **Frontend exclude on commit (web).** No change needed beyond confirming the kit is never
+   written into `entity.data.parameters`, so `prepareCommitParameters` (`commit.ts:68`) excludes
+   it for free.
+
+8. **Tests.** Backend: the builder lists the platform ops, the authoring skill, and the build
+   permissions, each with a `config`; the `/inspect` response carries `build_kit` beside
+   `schemas`; the published default is bare across the builtin, `/inspect`, and the catalog.
+   Frontend: a kit-on run request carries the platform tools, the authoring skill, and the
+   elevated sandbox in `parameters.agent`; a kit-off run carries the bare config; a commit
+   excludes the kit either way. Update the default-template test
    (`/home/mahmoud/code/agenta/services/oss/tests/pytest/unit/agent/test_default_agent_template.py`)
-   asserts the service default equals bare plus the skill and sandbox extras. Update it: the
-   published default is now bare across the builtin, `/inspect`, and the catalog. Add a test
-   that the build-kit descriptor lists the platform ops and the authoring skill, and a
-   run-prep test that an inject-kit run resolves the platform tools while a kit-off run does
-   not.
-
-## Interface design notes
-
-The model rests on three clean separations. Each is a semantic-role split, not a feature
-split.
-
-- Inject versus commit. The kit is injected at session time, for display and for the run. It
-  is never written to the stored revision. The revision holds only user data. Role of the
-  kit: platform-owned policy applied at runtime. Role of the stored config: user-owned data.
-- Default versus override. The kit is the platform's default capability set, managed by
-  Agenta and not edited per item in v1. The user's config is the user layer. There is no
-  per-item override of a kit item, so there is no merge and no precedence rule to define yet.
-- Display versus persisted. The kit is display and session ephemeral. The agent config is
-  persisted. The toggle is a playground preference. It is not part of the persisted agent
-  config. If we persist the toggle at all, it is a playground or UI preference keyed to the
-  user and agent, never a field on the revision.
-
-Where each new field sits, by role:
-
-- The `build_kit` descriptor is platform-owned and read-only. It is a sibling of the config
-  in the `/inspect` response (`revision.data.build_kit`), never a member of `parameters.agent`.
-  The frontend reads it, never writes it. Role: a platform-declared capability catalog for
-  display and runtime, not user data.
-- The `inject_build_kit` flag is request-scoped policy. It rides the run request flags, not
-  the config. It defaults to the safe value, off, so a raw `/invoke` never grants the agent
-  authoring tools or execute-code by accident. Role: a per-run mode the playground sets.
-
-The design adds no field to the stored agent config. The `build_kit` descriptor lives in the
-inspect response, and the `inject_build_kit` flag lives on the run request. The stored
-contract (`parameters.agent`) is unchanged.
+   to assert the bare default.
 
 ## Risks and edge cases
 
-- Safety. The kit grants self-commit and execute-code. It must never inject on a production
-  run. The flag defaults off server-side and only the playground turns it on. State this in
-  the docs and assert it in a test.
-- The toggle off path. Turning the kit off must produce a run with the user's config only, so
-  the user tests the agent as users will see it. That is the no-inject path, which is the
-  default, so it is the simple case.
-- Existing agents. They gain the kit in the playground with no migration, because the kit is
-  injected, not stored. Nothing is baked, so nothing goes stale.
-- Permissions overlap. The agent's own sandbox permission is a real committed field. The
-  kit's build permissions are a separate, session-only elevation. The drawer shows the kit's
-  permissions as a read-only status, distinct from the agent's own sandbox config. Keep the
-  two clearly separated so a kit-off run uses the agent's own permissions.
+- **Safety.** The kit grants self-commit, write files, and execute code. It must never reach a
+  production run. It cannot, because nothing persists it and the run path never adds it. A
+  deployed agent runs its stored config, which has no kit. State this and assert it in a test
+  (a published agent's resolved config never contains the platform ops or the elevated sandbox).
+- **No new attack surface.** The run API already accepts and resolves whatever tools and
+  permissions a config carries. A hand-authored config with the platform ops already runs them
+  today. The kit grants the frontend no capability the run API did not already accept; it only
+  saves the user from authoring those entries by hand.
+- **Kit off.** Turning the kit off produces a run with the user's config only, so the user
+  tests the agent as users will see it. This is the no-inject path, the simple default.
+- **Existing agents.** They gain the kit in the playground with no migration, because the
+  frontend injects it from the descriptor at run time. Nothing is baked, so nothing goes stale.
+- **Permission overlap.** The agent's own sandbox is a committed field. The kit's build
+  permissions are a session-only elevation the frontend merges on a kit-on run. Keep them
+  separate so a kit-off run uses the agent's own permissions.
 
 ## Out of scope and coordination
 
-- The Advanced drawer UX (collapsible sections, the build-kit toggle, the read-only dimmed
-  rows) is owned by the advanced-build-kit project and the designer handoff. This design
-  feeds it the backend descriptor. It does not design the drawer.
-- The authoring skill content and naming are owned by the skills project (`#4918`). This
+- The authoring skill's content and naming are owned by the skills project (`#4918`). This
   design references the skill by its stable slug. It does not write skill content.
+- The builder-tools project (`#4919`) adds more platform ops. The builder reads `PLATFORM_OPS`
+  at assembly time, so new ops join the kit automatically.
 - Per-item edit or delete of kit items, and a picker to add platform tools to the published
   agent, are out of scope. The kit is whole-toggle and read-only in v1.
-
-## Settled while drafting
-
-- Where the descriptor lives. In the `/inspect` response, at `revision.data.build_kit`, a
-  read-only sibling of `schemas`. The drawer project depends on this exact channel, so it is
-  fixed, not open.
+- The model change in this rewrite ripples to `#4918`, `#4919`, `#4920`, which still reference
+  the rejected backend-injection model. They are not edited here; the orchestrator propagates
+  the corrected model after Mahmoud approves it.
 
 ## Open questions for Mahmoud
 
-1. The toggle's persistence. Ephemeral per playground session (resets to on), or a stored
-   playground preference per user and agent. I lean ephemeral for v1. It is the smaller
-   surface and the kit defaults on.
-2. Confirm the published default goes fully bare, including dropping the skill embed and the
-   sandbox boundary from the `/inspect` schema default, with both moving into the kit. This
-   touches the skills project's surface, so it needs their nod too.
+1. **Toggle persistence.** Ephemeral per playground session (resets to on), or a stored
+   playground preference per user and agent. I lean ephemeral for v1: smaller surface, and the
+   kit defaults on.
+2. **Confirm the published default goes fully bare**, dropping the authoring skill and the
+   sandbox boundary from the schema default into the kit, and setting `AGENTA_FORCED_SKILLS =
+   []`. This touches the skills project's surface, so it needs their nod.
+3. **Permissions group: read-only, or independently flippable?** The kit's PERMISSIONS group
+   reflects what the kit grants. Purely read-only under the single kit toggle (this design), or
+   should the user flip the build permissions off while keeping the rest of the kit on? I lean
+   read-only.
+4. **Carry `config` per row, or derive it from `key`?** This design carries `config` so the
+   frontend does a pure merge and owns no wire shapes. The leaner alternative drops `config`
+   and rebuilds each entry from `key` plus kind, which pushes the platform tool and skill shapes
+   into the frontend and cannot express a permission setting from a key. I lean carry `config`.
+5. **Ship Change 1 (collapsible sections) with the kit, or separately?** It is independent UI
+   polish with no contract and no logic. I lean separate, since it de-risks the larger change
+   and unblocks nothing.

--- a/docs/design/agent-workflows/projects/default-agent-config/design.md
+++ b/docs/design/agent-workflows/projects/default-agent-config/design.md
@@ -1,0 +1,240 @@
+# Design: default agent config (platform tools and the default skill)
+
+Status: draft for Mahmoud's review. Grounded in code on `gitbutler/edit` over
+`big-agents`, 2026-06-28. See `research.md` for the full code trace.
+
+## Problem and goal
+
+When a user creates a new agent, the config arrives almost empty: no tools, no skills. We
+want a new agent to start useful. The config should arrive pre-loaded with:
+
+1. All the platform tools. Today that is the three core ops (`find_capabilities`,
+   `query_workflows`, `commit_revision`). Once the builder project ships its tools, the default
+   grows to carry every platform op the catalog holds: the three core ops plus the eight trigger
+   and cron ops (`create_schedule`, `create_subscription`, `list_schedules`,
+   `list_subscriptions`, `list_deliveries`, `list_connections`, `test_subscription`,
+   `find_triggers`). Several of these are approval-gated. They all ship with their catalog
+   default permissions, and the user can edit those permissions. This is intended (see decision 3
+   and the risks section).
+2. The default Agenta skill (`agenta-getting-started`), referenced by embed.
+
+Workflow (reference) tools are user-added and stay exactly as they are. This design does
+not touch them.
+
+The defaults are opt-out. The user can remove any default item. Disable-but-keep is a
+later addition, not part of this design (see decision 2).
+
+Out of scope: the debug-mode UX issue where defaults are not shown, and any "add platform
+tool" picker. We cover making the defaults present and removable, nothing more on UX.
+
+## What ships today
+
+- One builder is the source of the default agent config:
+  `build_agent_v0_default(...)` at
+  `/home/mahmoud/code/agenta/sdks/python/agenta/sdk/utils/types.py:1399`. It returns
+  `tools: []` and, only when asked, one skill embed. It already accepts `skill_slug=` and
+  `include_sandbox_permission=`.
+- Platform tools are catalog ops. Three exist today (`find_capabilities`, `query_workflows`,
+  `commit_revision`); the builder project adds eight more. A config entry is just
+  `{"type": "platform", "op": "<name>"}`. There is no wildcard.
+- The default skill is one placeholder, `agenta-getting-started`, served read-only from
+  code by the static catalog under the reserved slug `__ag__getting_started_with_agenta`.
+- Today the skill reaches a run two ways, and neither is what we want:
+  - The service `/inspect` schema default embeds it (passes `skill_slug`), but that path
+    does not reach the new-agent draft (see the injection-point finding below).
+  - The `pi_agenta` harness force-injects it via `AGENTA_FORCED_SKILLS`. Forced means the
+    user can never remove it. That is the opposite of opt-out.
+- No `enabled`/`disabled` flag exists on tools or skills. Items are present or absent.
+
+## The injection point (the finding)
+
+Mahmoud's instinct was right: the defaults must reach the temporary playground (the draft
+of a not-yet-created agent). I traced exactly where that draft gets its values.
+
+When the user creates a new agent, the frontend builds a local draft in
+`createEphemeralAppFromTemplate`
+(`/home/mahmoud/code/agenta/web/packages/agenta-entities/src/workflow/state/appUtils.ts:118`).
+It fills the draft from two different sources:
+
+- The editable parameter values come from the catalog template, `template.data.parameters`
+  (appUtils.ts:189). This is what the user sees and edits.
+- The schemas (the shape used to render controls) come from `/inspect`, best effort
+  (appUtils.ts:171-185). Only the schema shape. Not the parameter values.
+
+So the draft's actual values come from the catalog, not from `/inspect`.
+
+The catalog builds `template.data.parameters` by reading the `default` off the parameters
+schema (`_extract_schema_parameter_defaults` in
+`/home/mahmoud/code/agenta/api/oss/src/resources/workflows/catalog.py:27`). That schema
+comes from the SDK interface registry, not from the service. The agent interface there is
+bare:
+
+```
+# interfaces.py:537
+default=build_agent_v0_default()   # no skill, no tools
+```
+
+The comment on that line is explicit: "The minimal builtin default: no platform skill, no
+sandbox_permission. The agent service adds both via the same builder (see schemas.py)."
+
+So there are two separate defaults for the agent:
+
+- The SDK interface default (bare). Feeds the catalog, which feeds the new-agent draft.
+- The service `/inspect` default (enriched with the skill embed and the sandbox boundary).
+  Feeds `/inspect`, which the draft reads for schemas only, never for values.
+
+That is the gap. The service enriches the default the draft never reads, and the draft
+reads the bare default the SDK interface declares. The skill embed the service adds, and
+the platform tools we want to add, do not reach a new agent.
+
+### Why the skill embed did not reach the draft
+
+The getting-started skill is already embedded in the default, but only on the service
+`/inspect` default. The catalog template, which is the surface the draft actually reads,
+still uses the bare builder. So the embed sits on a default no one reads for values. The
+fix is not to make the draft read `/inspect`. The fix is to put the enriched default (the
+platform tools plus the skill embed) into the catalog template path. Then it reaches the
+draft, and `/inspect` is not used for values at all.
+
+## The four decisions (locked by Mahmoud)
+
+1. The default skill is embedded, not forced. The default config carries an `@ag.embed`
+   of `__ag__getting_started_with_agenta`, present by default and removable. Stop
+   force-injecting it through the `pi_agenta` harness. Keep the `force_skills` mechanism in
+   the code for a future skill that carries real functionality.
+2. Delete-only for v1. No `is_active` flag now. Disable-but-keep comes later.
+3. Platform tools are a frozen, explicit list. Read all ops from the catalog at build
+   time, then store the result as a concrete list. No wildcard, no run-time resolution of
+   "all".
+4. The defaults must surface where the new-agent draft reads them, so the temporary
+   playground shows them.
+
+## Proposed change set, by layer
+
+The fix points the catalog template at the enriched default. The catalog is the surface
+the draft reads. Today it sources the agent default from the bare SDK builtin interface. It
+will instead source the enriched default: the same builder output the service already uses,
+plus the frozen platform-tools list. The SDK builtin interface stays bare. `/inspect` is
+not used for the draft's values.
+
+1. SDK builder. Extend `build_agent_v0_default` with one option that adds the platform
+   tools, sourced from `PLATFORM_OPS.keys()` at build time and frozen into a concrete list
+   of `{"type": "platform", "op": "<name>"}` entries (decision 3). The skill embed already
+   has `skill_slug=`. The builder gains the ability to emit these; its own no-arg default
+   does not change, so the bare builtin stays bare. File:
+   `/home/mahmoud/code/agenta/sdks/python/agenta/sdk/utils/types.py:1399`.
+
+2. Catalog template (the load-bearing fix for the draft). Source the agent template entry's
+   parameter default from the enriched default
+   (`build_agent_v0_default(skill_slug=__ag__getting_started_with_agenta,
+   include_sandbox_permission=True, include_platform_tools=True)`) rather than the bare
+   builtin the interface registry carries. The existing extraction and normalization
+   pipeline then moves the object default into `data.parameters` as it already does, so
+   `template.data.parameters.agent` carries the platform tools and the skill embed. This is
+   the larger interface-registry wiring change: the catalog stops inheriting the bare
+   interface default for the agent entry. File:
+   `/home/mahmoud/code/agenta/api/oss/src/resources/workflows/catalog.py` (the
+   `_enrich_entry` / `_build_template_data` path for the agent entry). The enriched default
+   imports cleanly from the SDK (`build_agent_v0_default`, `PLATFORM_OPS`, and the slug
+   constant `GETTING_STARTED_WITH_AGENTA_SLUG`), so no new shared module is needed.
+
+3. Service `/inspect`. Already passes `skill_slug` and `include_sandbox_permission`. Add the
+   platform-tools option so its default and the catalog template share one enriched value
+   and cannot drift. This keeps `/inspect` consistent and keeps the runtime fallback (which
+   uses the service default) consistent. The frontend still does not read values from
+   `/inspect`. File:
+   `/home/mahmoud/code/agenta/services/oss/src/agent/schemas.py:52`.
+
+4. Stop force-injecting the skill. Set `AGENTA_FORCED_SKILLS = []`. Keep `force_skills`,
+   `GETTING_STARTED_WITH_AGENTA_SKILL`, the slug constant, and the static catalog. The
+   getting-started skill now reaches agents through the embedded default config, where the
+   user can remove it. File:
+   `/home/mahmoud/code/agenta/sdks/python/agenta/sdk/agents/adapters/agenta_builtins.py:104`.
+   Leave `AGENTA_FORCED_TOOLS = ["read", "bash"]` alone; those are Pi builtins for skill
+   rendering, unrelated to the platform-op tools.
+
+5. Frontend, removable defaults. The skill control currently renders a `__ag__` static
+   skill as read-only and non-removable ("cannot be edited or removed"). Opt-out needs the
+   reference removable. Split the two ideas: the skill's content stays read-only (it is
+   Agenta's skill), but the embed in my config can be deleted. Verify the tools control
+   renders `{"type":"platform","op":...}` entries and allows deleting them; if it does
+   not, add that. Files:
+   `/home/mahmoud/code/agenta/web/packages/agenta-entity-ui/src/DrillInView/SchemaControls/SkillTemplateControl.tsx`
+   and the tools control in the same folder. Adding or picking new platform tools is out
+   of scope; only delete must work.
+
+6. Tests. The agent-template default test asserts three sources today
+   (`/home/mahmoud/code/agenta/services/oss/tests/pytest/unit/agent/test_default_agent_template.py`):
+   builtin equals the bare builder, and the service equals bare plus extras. Keep
+   builtin-equals-bare. Update the service test so the extras now include the frozen
+   platform tools. Add a catalog test (in the API suite) that asserts the agent template's
+   `data.parameters.agent` carries the platform tools and the skill embed, which is the
+   real guarantee that the draft gets the defaults.
+
+The defaults bake into the stored revision at create or commit time. Existing agents are
+not touched. A new platform tool added to the catalog later appears only in agents created
+after that, which is the correct behavior for opt-out defaults.
+
+## Coordination
+
+A separate skills subagent owns the getting-started skill content and any naming updates.
+This design does not write skill content. It owns embed-by-default: the getting-started
+skill arrives as an embedded default config item, referenced by `@ag.embed` to its stable
+slug, present by default and removable. See the agent-creation-skills and skills-config
+projects for the skill content and the static catalog.
+
+## Interface design notes
+
+This design adds no new wire field and no new contract surface. That is deliberate and
+worth stating.
+
+- The platform tool entries reuse the existing `platform` tool shape
+  (`{"type": "platform", "op": "<name>"}`). The `op` is a stable identifier into the
+  catalog. Role: config that selects behavior, plus a routing key (`op`) the resolver maps
+  to a platform endpoint. No new field.
+- The skill entry reuses the existing `@ag.embed` shape, referencing a server-owned skill
+  by stable slug. Role: config plus a routing key (the slug). No new field.
+- Decision 2 (no `is_active`) means we do not add a disable field. Delete is the existing
+  present/absent semantics.
+- Decision 3 (frozen list) means we store concrete enumerated entries, not a new wildcard
+  token in the contract.
+
+So the only real interface question was ownership: which layer owns the enriched default.
+The answer, decided by Mahmoud, is the catalog template (with `/inspect` kept in sync), not
+the portable SDK interface. The skill embed and the platform tools both resolve server-side
+(the static catalog for the skill, the platform resolver and credentials for the tools). A
+bare SDK interface that ran standalone could not resolve them. Keeping them at the catalog
+and service layer respects the existing split and avoids breaking standalone SDK use of the
+builtin agent.
+
+## Risks and edge cases
+
+- Several seeded tools are approval-gated by default in the catalog: `commit_revision` today,
+  and `create_schedule`, `create_subscription`, and `test_subscription` once the builder ships.
+  Seeding them does not change that. A new agent asks before it commits, schedules, subscribes,
+  or runs a live trigger test. The seeded tools keep their catalog default permissions, and the
+  user can edit them. This is intended; it is worth a line in the user-facing docs.
+- The skill content is a placeholder today. That is fine. Real content lands separately; it
+  is not this design's job.
+- The catalog and `/inspect` defaults must stay in sync. Sourcing both from one builder
+  call removes the drift that caused this gap in the first place.
+- Frontend delete of a static-skill embed must remove only my reference, not affect the
+  shared static skill. The slug points at a read-only catalog entry; deleting the embed
+  just drops the list item.
+
+## Out of scope and follow-ups
+
+- Disable-but-keep (an `is_active` or equivalent), with the resolver and wire drop step.
+- The debug-mode UX where defaults are not shown by default.
+- A picker to add platform tools or skills back after deleting them.
+- Real getting-started skill content.
+
+## Resolved: where the enriched default lives
+
+Decided by Mahmoud. The catalog template carries the enriched default (the frozen
+platform-tools list plus the getting-started skill embed). The bare SDK builtin interface
+stays bare. Server-resolved Agenta defaults do not go into the portable SDK default.
+`/inspect` is not used for the draft's values; if it is not in `/inspect`, we do not rely on
+`/inspect`, we use the catalog template. The catalog-templates path now sources the agent
+default from the enriched default rather than the bare builtin, and the tests that assert
+"builtin equals bare" and "service equals bare plus extras" are updated accordingly.

--- a/docs/design/agent-workflows/projects/default-agent-config/research.md
+++ b/docs/design/agent-workflows/projects/default-agent-config/research.md
@@ -1,0 +1,159 @@
+# Research: default agent config (tools + skills loaded by default, opt-out)
+
+Grounded in code on branch `gitbutler/edit` (over `big-agents`), 2026-06-28. File paths are
+absolute.
+
+## The goal
+
+When a user creates a new agent, the config should arrive pre-loaded with the platform
+tools and the default Agenta skills. Workflow (reference) tools stay as they are. The user
+can disable each default item, and ideally delete it. This is opt-out, not opt-in. UX and
+debug-mode polish are out of scope for this design.
+
+## 1. Where a new agent's default config comes from
+
+There is one source of truth: `build_agent_v0_default(...)` in the SDK at
+`/home/mahmoud/code/agenta/sdks/python/agenta/sdk/utils/types.py:1399`. Everything else
+re-derives the seed from it. The default is concrete config baked into the stored revision
+at create or commit time. It is not resolved by reference at run time.
+
+What the builder returns today:
+
+```python
+{
+  "instructions": {"agents_md": _DEFAULT_AGENTS_MD},   # friendly hello-world
+  "llm": {"model": "gpt-5.5"},
+  "tools": [],
+  "mcps": [],
+  "harness": {"kind": "pi_core"},
+  "runner": {"kind": "sidecar", "interactions": {"headless": "auto"}},
+  "sandbox": {"kind": "local"},
+}
+```
+
+The builder takes an optional `skill_slug=` that adds one `@ag.embed` skill reference. No
+caller passes it today, so a new agent gets `skills: []` and `tools: []`.
+
+How the seed flows to every surface:
+
+- SDK builder -> schema default at
+  `/home/mahmoud/code/agenta/services/oss/src/agent/schemas.py:52`
+  (`_DEFAULT_AGENT_TEMPLATE = build_agent_v0_default(...)`, attached as the
+  `agent-template` schema `default`).
+- Schema default -> catalog template parameters at
+  `/home/mahmoud/code/agenta/api/oss/src/resources/workflows/catalog.py:107`
+  (`_extract_schema_parameter_defaults` reads
+  `parameters_schema.properties.agent.default` into `data.parameters`).
+- Catalog template -> frontend pre-fill at
+  `/home/mahmoud/code/agenta/web/packages/agenta-entities/src/workflow/state/appUtils.ts:189`
+  (`createEphemeralAppFromTemplate` seeds `parameters` from `template.data.parameters`).
+  There is no hardcoded default config in the frontend.
+- New variant fork copies the base entity's `parameters` at
+  `/home/mahmoud/code/agenta/web/packages/agenta-entities/src/workflow/state/commit.ts`.
+
+Implication: adding defaults to `build_agent_v0_default` puts them on every new-agent
+surface at once. It does not touch existing agents (correct for opt-out defaults).
+
+The run-time fallback noted in the morning report is separate and thinner. When `/invoke`
+runs by reference with no inline parameters, the API resolves the stored revision and uses
+its baked `parameters` (`/home/mahmoud/code/agenta/api/oss/src/core/workflows/service.py`,
+`_ensure_request_revision`). Only when `parameters.agent` is entirely absent does the
+service fall back to file/class field defaults
+(`/home/mahmoud/code/agenta/services/oss/src/agent/app.py:67`,
+`AgentTemplate.from_params`). So by-reference invocation resolves a baked config; it does
+not synthesize the platform tools or skills.
+
+## 2. Platform tools in config
+
+Catalog: `/home/mahmoud/code/agenta/sdks/python/agenta/sdk/agents/platform/op_catalog.py`,
+`PLATFORM_OPS`. Exactly three reserved ops today:
+
+| op | reads/mutates | default permission / approval |
+| --- | --- | --- |
+| `find_capabilities` | read | allow, no approval |
+| `query_workflows` | read | allow, no approval |
+| `commit_revision` | mutates (self only) | ask, approval required |
+
+Tool list lives at `parameters.agent.tools`. The discriminator is `type`, with values
+`builtin`, `gateway`, `code`, `client`, `reference`, `platform`. A platform entry is just:
+
+```json
+{ "type": "platform", "op": "find_capabilities" }
+```
+
+The catalog owns the description, endpoint, input schema, context bindings, and the per-op
+permission and approval default. `PlatformToolConfig.needs_approval` is `Optional[bool] =
+None`, so an unset entry keeps the catalog default (commit_revision stays approval-gated).
+
+There is no wildcard or "all platform tools" today. To seed all of them you enumerate the
+three entries, or have the builder iterate `PLATFORM_OPS.keys()`. Resolution turns a
+platform entry into a direct `call` descriptor via
+`/home/mahmoud/code/agenta/sdks/python/agenta/sdk/agents/platform/platform_tools.py`.
+
+## 3. Skills in config and the default skills that exist
+
+Skill model is `SkillTemplate` at
+`/home/mahmoud/code/agenta/sdks/python/agenta/sdk/agents/skills/models.py`. One shape: an
+inline SKILL.md package (`name`, `description`, `body`, `files`, `disable_model_invocation`,
+`allow_executable_files`). A skill stored elsewhere is referenced by `@ag.embed` and
+resolved server-side into the same shape.
+
+Skills list lives at `parameters.agent.skills`, sibling to `tools`. An item is either an
+inline `SkillTemplate` or a bare `{"@ag.embed": {...}}` reference.
+
+Code-defined platform skills today: exactly one. Slug
+`__ag__getting_started_with_agenta`, name `agenta-getting-started`. Source of truth is the
+SDK constant `GETTING_STARTED_WITH_AGENTA_SKILL` in
+`/home/mahmoud/code/agenta/sdks/python/agenta/sdk/agents/adapters/agenta_builtins.py`. It
+is served read-only through `StaticWorkflowCatalog`
+(`/home/mahmoud/code/agenta/api/oss/src/core/workflows/static_catalog.py`) under the
+reserved `__ag__*` namespace (no DB, no per-project seed). The content is a placeholder.
+
+Important nuance about how this skill reaches a run today:
+
+- It is NOT seeded into stored config. `build_agent_v0_default` can add it via `skill_slug`
+  but no caller does.
+- It reaches runs through the harness, not config. The `pi_agenta` harness
+  (`AgentaHarness`) unions `AGENTA_FORCED_SKILLS` into every run via `force_skills`
+  (`/home/mahmoud/code/agenta/sdks/python/agenta/sdk/agents/adapters/harnesses.py:140`).
+  This is always-on and cannot be disabled by the user.
+- The default new-agent harness is `pi_core`, not `pi_agenta`. So a default new agent does
+  not even get the getting-started skill today.
+
+Forced skills (`force_skills`) and opt-out defaults are opposite intents. Forced means the
+user can never remove it. The feature here wants present-by-default but removable. So this
+feature cannot use `force_skills`; it must bake skills into the config.
+
+FE control: `SkillTemplateControl` at
+`/home/mahmoud/code/agenta/web/packages/agenta-entity-ui/src/DrillInView/SchemaControls/SkillTemplateControl.tsx`.
+It renders `__ag__*` (static) skills read-only ("cannot be edited or removed").
+
+## 4. Present-but-disabled vs removed: the model today
+
+No `enabled` or `disabled` flag exists on tools, skills, or MCP servers. The model is
+strictly present or absent. Top-level config is `AgentTemplate` at
+`/home/mahmoud/code/agenta/sdks/python/agenta/sdk/agents/dtos.py:525` with `tools`,
+`mcp_servers`, `skills` lists.
+
+Nearby fields that are NOT a disable flag:
+
+- `permission: "allow"|"ask"|"deny"` on tools and MCP. `deny` means present but never runs.
+  It does not hide the tool from the model and does not exist on skills.
+- `disable_model_invocation` on skills hides the skill from the model's auto-discovery but
+  still loads it (invokable via `/skill:name`). Not a present-but-off switch.
+
+Filtering before the runner is type-based only. `ToolResolver.resolve`
+(`/home/mahmoud/code/agenta/sdks/python/agenta/sdk/agents/tools/resolver.py:115`) resolves
+every tool present. `wire_skills` and `wire_mcp` emit every entry present. There is no
+skip-disabled branch anywhere. So today the only way to turn an item off is to remove it.
+
+Precedent for present-but-disabled elsewhere in agenta: the convention is `is_active: bool =
+True` at the entity/row level (webhooks, triggers, gateway connections). Not used inside a
+config list yet.
+
+## Rename context (verified current)
+
+Config nests under `parameters.agent`. The catalog type-ref is `agent-template` in code
+(the doc `agent-config-schema.md` is stale and still says `agent_config`). `ModelRef.params`
+is now `extras`. `permission_policy` rides `runner.interactions.headless`. The `/run` wire
+is byte-identical; only the authoring shape changed.

--- a/docs/design/agent-workflows/projects/default-agent-config/status.md
+++ b/docs/design/agent-workflows/projects/default-agent-config/status.md
@@ -2,65 +2,63 @@
 
 ## Where we are
 
-Second rewrite. The first rewrite's core model was rejected and the design is rewritten in
-`design.md`. The corrected model: the frontend owns the injection, the backend only informs,
-and the agent service stays dumb. The advanced-drawer UI is folded into this design (Mahmoud
-asked for one document covering both the inspect information and the UI). Five open questions
-remain for Mahmoud.
+The design is in `design.md`. The build kit is an agent-template overlay: a partial agent template
+the platform serves read-only on the inspect response, the frontend merges onto `parameters.agent`
+on a playground run, and excludes on commit. The agent service stays dumb. The advanced-drawer UI
+is folded into this design. Four open questions remain for Mahmoud.
 
-## The pivot
+## The model
 
-The first rewrite put the injection in the backend agent service: a run-prep merge gated by a
-`flags.inject_build_kit` run flag. Mahmoud rejected it on the PR. His direction: the frontend
-injects the kit into `parameters.agent` in the playground; the service must not know the kit
-exists; the backend's only job is to expose the kit's information through `/inspect` so the
-frontend can act on it.
-
-So the model flipped:
-
-- The agent service stays dumb. No run-prep injection. No `inject_build_kit` flag. It runs the
-  agent template it receives.
-- The backend informs. It assembles a read-only `build_kit` descriptor and serves it on
-  `/inspect`. Nothing more.
-- The frontend owns the logic. It reads the descriptor, shows the drawer and toggle, injects the
-  kit into the run payload when on, and excludes it on commit.
-
-`research.md` still holds the code trace; the code facts there are valid, only the approach
-changed.
+- **The agent service runs the template it receives.** No run-prep merge, no run flag. It runs
+  `parameters.agent` as handed to it.
+- **The backend serves the overlay.** It assembles the overlay once and attaches it to the inspect
+  response. It never applies it.
+- **The frontend applies the overlay.** It reads the overlay, renders it read-only in the drawer,
+  merges it onto `parameters.agent` on a kit-on run, and leaves it out on commit.
 
 ## The contract for the frontend
 
-- Read-only `build_kit` descriptor in the `/inspect` response at `revision.data.build_kit`, a
-  sibling of `schemas`. Grouped by kind (`skills`, `tools`, `permissions`). Each row: `key`,
-  `name`, `description`, and `config` (the exact `parameters.agent` entry the frontend injects);
-  permission rows also `status` (the green pill). Platform-owned, read-only end to end.
-- The new bit versus the prior shape: each row now carries `config`, because the frontend, not
-  the backend, injects. The frontend does a pure structural merge and owns no wire shapes.
+- The overlay rides a new read-only container on the inspect response:
+  `inspect_context.build_kit.agent_template_overlay`, a sibling of `application` on
+  `SimpleApplicationResponse`. It is not in `revision.data` (user config, `extra="forbid"`, flows
+  into commit) and not in `application.meta` (user metadata, persisted). It is platform-owned,
+  read-only, derived per response. Future read-only hints add members beside `build_kit`.
+- The overlay is a partial `parameters.agent`. Today: the three platform ops in `tools`, the
+  authoring skill as an `@ag.embed` reference in `skills`, and the build-permission elevation in
+  `sandbox`. Skills are ordinary embed references with no parallel display fields; a permission's
+  status is its value in the overlay.
+- The frontend applies the overlay with a dedicated applier: deep-merge object fields, identity-
+  merge list fields, on a throwaway run copy only. It never mutates the draft or committed tree.
 - No run flag. The toggle is client session state, default on. A kit-on run is just a run whose
-  `parameters.agent` already carries the extra items. The run wire is unchanged.
+  `parameters.agent` already carries the merged items. The run wire is unchanged.
+
+(The naming and placement of `inspect_context` follow a Codex review of the whole inspect response
+schema, chosen over `meta` to avoid the user-owned artifact `meta` and to keep the platform-derived
+container extensible.)
 
 ## Open questions for Mahmoud
 
 1. Toggle persistence: ephemeral per session (lean) or a stored playground preference.
-2. Confirm the published default goes fully bare (drop the authoring skill and the sandbox
-   boundary from the schema default into the kit; set `AGENTA_FORCED_SKILLS = []`). Touches the
-   skills project.
-3. Kit PERMISSIONS group: read-only under the single toggle (lean) or independently flippable.
-4. Carry `config` per row (lean) or derive each injected entry from `key` plus kind.
-5. Ship Change 1 (collapsible sections) with the kit, or separately (lean separate).
+2. Confirm the published default goes fully bare (drop the authoring skill and the sandbox boundary
+   from the schema default into the overlay; set `AGENTA_FORCED_SKILLS = []`). Touches the skills
+   project.
+3. Merge precedence on a conflict: the overlay overrides on an identity match (lean), or yields to
+   a user entry of the same identity.
+4. Ship Change 1 (collapsible sections) with the kit, or separately (lean separate).
 
 ## Coordination
 
-- Advanced-drawer UI is folded into this design, not a separate PR (Mahmoud's instruction).
-- Authoring skill content and naming: skills project (`#4918`). We reference the slug only.
-- Builder tools (`#4919`) add more platform ops; the builder reads `PLATFORM_OPS` at assembly
-  time, so new ops join automatically.
-- The model change ripples to `#4918`, `#4919`, `#4920`, which still reference the rejected
-  backend-injection model. Do not edit them here; the orchestrator propagates the fix after
-  Mahmoud approves this model.
+- The advanced-drawer UI is folded into this design, not a separate PR.
+- Authoring skill content and naming: skills project (`#4918`). We reference the reserved slug only.
+- Builder tools (`#4919`) add more platform ops; the builder reads `PLATFORM_OPS` at assembly time,
+  so new ops join automatically.
+- A client tool such as `request_connection` is a non-runnable workflow (reference) tool, not a
+  platform op; its primary definition is owned by `#4920`. If the kit carries one, it joins the
+  overlay as a reference-tool entry.
+- The overlay model carries through to `#4918`, `#4919`, and `#4920`. Do not edit them here; the
+  orchestrator propagates the design after Mahmoud approves it.
 
 ## Out of scope
 
-- Per-item edit or delete of kit items (kit is whole-toggle, read-only in v1).
+- Per-item edit or delete of kit items (the kit is whole-toggle, read-only in v1).
 - A picker to add platform tools to the published agent.
-- Disable-but-keep for the user's own config.

--- a/docs/design/agent-workflows/projects/default-agent-config/status.md
+++ b/docs/design/agent-workflows/projects/default-agent-config/status.md
@@ -19,11 +19,12 @@ is folded into this design. Four open questions remain for Mahmoud.
 ## The contract for the frontend
 
 - The overlay rides a new read-only container on the inspect response:
-  `inspect_context.build_kit.agent_template_overlay`, a sibling of `application` on
+  `additional_context.playground_build_kit.agent_template_overlay`, a sibling of `application` on
   `SimpleApplicationResponse`. It is not in `revision.data` (user config, `extra="forbid"`, flows
   into commit) and not in `application.meta` (user metadata, persisted). It is platform-owned,
-  read-only, derived per response. Future read-only hints add members beside `build_kit`.
-- The overlay is a partial `parameters.agent`. Today: the three platform ops in `tools`, the
+  read-only, derived per response. Future read-only hints add members beside `playground_build_kit`.
+- The overlay is a partial `parameters.agent`. Today: the three platform ops plus a reference
+  (workflow-as-tool) entry for the client tool `__ag__request_connection` in `tools`, the
   authoring skill as an `@ag.embed` reference in `skills`, and the build-permission elevation in
   `sandbox`. Skills are ordinary embed references with no parallel display fields; a permission's
   status is its value in the overlay.
@@ -32,7 +33,7 @@ is folded into this design. Four open questions remain for Mahmoud.
 - No run flag. The toggle is client session state, default on. A kit-on run is just a run whose
   `parameters.agent` already carries the merged items. The run wire is unchanged.
 
-(The naming and placement of `inspect_context` follow a Codex review of the whole inspect response
+(The naming and placement of `additional_context` follow a Codex review of the whole inspect response
 schema, chosen over `meta` to avoid the user-owned artifact `meta` and to keep the platform-derived
 container extensible.)
 
@@ -51,10 +52,12 @@ container extensible.)
 - The advanced-drawer UI is folded into this design, not a separate PR.
 - Authoring skill content and naming: skills project (`#4918`). We reference the reserved slug only.
 - Builder tools (`#4919`) add more platform ops; the builder reads `PLATFORM_OPS` at assembly time,
-  so new ops join automatically.
+  so new ops join automatically. The builder also enumerates the reserved-slug platform workflows
+  in the static workflow catalog and adds each as a reference-tool entry, parallel to iterating
+  `PLATFORM_OPS`.
 - A client tool such as `request_connection` is a non-runnable workflow (reference) tool, not a
-  platform op; its primary definition is owned by `#4920`. If the kit carries one, it joins the
-  overlay as a reference-tool entry.
+  platform op; its primary definition is owned by `#4920`. The kit carries it as a reference-tool
+  entry embedded from its reserved `__ag__*` slug.
 - The overlay model carries through to `#4918`, `#4919`, and `#4920`. Do not edit them here; the
   orchestrator propagates the design after Mahmoud approves it.
 

--- a/docs/design/agent-workflows/projects/default-agent-config/status.md
+++ b/docs/design/agent-workflows/projects/default-agent-config/status.md
@@ -1,0 +1,40 @@
+# Status: default agent config
+
+## Where we are
+
+Research done (`research.md`). Injection point confirmed in code and decided. Design final
+in `design.md`, all decisions locked. Ready for the consolidated design-docs PR.
+
+## Decisions settled (by Mahmoud)
+
+1. Default skill is embedded, not forced. Stop force-injecting getting-started; keep the
+   `force_skills` mechanism for later.
+2. Delete-only for v1. No `is_active` flag now.
+3. Platform tools are a frozen, explicit list, read from the catalog at build time.
+4. Defaults must surface where the new-agent draft reads them.
+5. Injection point: the catalog template carries the enriched default. The bare SDK builtin
+   interface stays bare. `/inspect` is not used for the draft's values; it is kept in sync
+   only so the service default and the runtime fallback do not drift.
+
+## Injection point (confirmed and decided)
+
+The new-agent draft reads its editable values from the catalog
+(`template.data.parameters`), not from `/inspect` (the draft uses `/inspect` for schemas
+only). The catalog default comes from the bare SDK interface today
+(`build_agent_v0_default()` with no skill, no tools). The service `/inspect` enriches a
+default the draft never reads. That split was the gap. Fix: point the catalog template at
+the enriched default (platform tools plus the skill embed), keep the SDK builtin bare, keep
+`/inspect` in sync.
+
+## Coordination
+
+A separate skills subagent owns the getting-started skill content and naming. This project
+owns embed-by-default (the skill arrives as a removable embedded default config item). Do
+not write skill content here.
+
+## Out of scope (noted)
+
+- Disable-but-keep (`is_active` + resolver/wire drop).
+- Debug-mode UX where defaults are not shown.
+- A picker to add platform tools or skills back after deleting.
+- Real getting-started skill content.

--- a/docs/design/agent-workflows/projects/default-agent-config/status.md
+++ b/docs/design/agent-workflows/projects/default-agent-config/status.md
@@ -2,49 +2,62 @@
 
 ## Where we are
 
-Model pivoted to inject-not-commit and the design is rewritten in `design.md`. The platform
-tools and the Agenta authoring skill are a Playground build kit: injected for the playground
-session, shown read-only, toggled as a whole, and never committed to the published agent.
-The descriptor contract for the drawer project is fixed. Two open questions remain for
-Mahmoud.
+Second rewrite. The first rewrite's core model was rejected and the design is rewritten in
+`design.md`. The corrected model: the frontend owns the injection, the backend only informs,
+and the agent service stays dumb. The advanced-drawer UI is folded into this design (Mahmoud
+asked for one document covering both the inspect information and the UI). Five open questions
+remain for Mahmoud.
 
 ## The pivot
 
-The earlier approach (materialize the defaults into the catalog template so a new agent
-commits them) was reviewed by Mahmoud and dropped. Defaults are not committed. They are a
-playground overlay. The designer handoff (`design_handoff_advanced_build_kit`) names the
-same thing: a "Playground build kit", "Removed on commit", "None of this is part of the
-published agent". `research.md` still holds the code trace; the code facts there are valid,
-only the approach changed.
+The first rewrite put the injection in the backend agent service: a run-prep merge gated by a
+`flags.inject_build_kit` run flag. Mahmoud rejected it on the PR. His direction: the frontend
+injects the kit into `parameters.agent` in the playground; the service must not know the kit
+exists; the backend's only job is to expose the kit's information through `/inspect` so the
+frontend can act on it.
 
-## The model
+So the model flipped:
 
-- Build kit = backend-defined set of platform tools (`PLATFORM_OPS`) + the authoring skill +
-  build permissions (write files, execute code).
-- Inject for display and for the run. Strip on commit (it was never in the config).
-- The published-config default stays bare. The kit is a separate backend concept.
+- The agent service stays dumb. No run-prep injection. No `inject_build_kit` flag. It runs the
+  agent template it receives.
+- The backend informs. It assembles a read-only `build_kit` descriptor and serves it on
+  `/inspect`. Nothing more.
+- The frontend owns the logic. It reads the descriptor, shows the drawer and toggle, injects the
+  kit into the run payload when on, and excludes it on commit.
 
-## Contract fixed for the drawer project
+`research.md` still holds the code trace; the code facts there are valid, only the approach
+changed.
 
-- Read-only `build_kit` descriptor in the `/inspect` response at `revision.data.build_kit`,
-  a sibling of `schemas`. Grouped by kind (`skills`, `tools`, `permissions`). Each row:
-  `key`, `name`, `description`; permission rows also `status`. Platform-owned, never echoed
-  back.
-- One per-run flag `flags.inject_build_kit` (boolean), set by the drawer toggle, default off
-  server-side. Kit off skips injection.
+## The contract for the frontend
+
+- Read-only `build_kit` descriptor in the `/inspect` response at `revision.data.build_kit`, a
+  sibling of `schemas`. Grouped by kind (`skills`, `tools`, `permissions`). Each row: `key`,
+  `name`, `description`, and `config` (the exact `parameters.agent` entry the frontend injects);
+  permission rows also `status` (the green pill). Platform-owned, read-only end to end.
+- The new bit versus the prior shape: each row now carries `config`, because the frontend, not
+  the backend, injects. The frontend does a pure structural merge and owns no wire shapes.
+- No run flag. The toggle is client session state, default on. A kit-on run is just a run whose
+  `parameters.agent` already carries the extra items. The run wire is unchanged.
 
 ## Open questions for Mahmoud
 
 1. Toggle persistence: ephemeral per session (lean) or a stored playground preference.
-2. Confirm the published default goes fully bare (drop the skill embed and the sandbox
-   boundary from the `/inspect` schema default into the kit). Touches the skills project.
+2. Confirm the published default goes fully bare (drop the authoring skill and the sandbox
+   boundary from the schema default into the kit; set `AGENTA_FORCED_SKILLS = []`). Touches the
+   skills project.
+3. Kit PERMISSIONS group: read-only under the single toggle (lean) or independently flippable.
+4. Carry `config` per row (lean) or derive each injected entry from `key` plus kind.
+5. Ship Change 1 (collapsible sections) with the kit, or separately (lean separate).
 
 ## Coordination
 
-- Drawer UX: advanced-build-kit project + the designer handoff. We feed it the descriptor.
+- Advanced-drawer UI is folded into this design, not a separate PR (Mahmoud's instruction).
 - Authoring skill content and naming: skills project (`#4918`). We reference the slug only.
-- Builder tools (`#4919`) add more platform ops; the kit reads `PLATFORM_OPS` at call time,
-  so new ops join automatically.
+- Builder tools (`#4919`) add more platform ops; the builder reads `PLATFORM_OPS` at assembly
+  time, so new ops join automatically.
+- The model change ripples to `#4918`, `#4919`, `#4920`, which still reference the rejected
+  backend-injection model. Do not edit them here; the orchestrator propagates the fix after
+  Mahmoud approves this model.
 
 ## Out of scope
 

--- a/docs/design/agent-workflows/projects/default-agent-config/status.md
+++ b/docs/design/agent-workflows/projects/default-agent-config/status.md
@@ -5,7 +5,7 @@
 The design is in `design.md`. The build kit is an agent-template overlay: a partial agent template
 the platform serves read-only on the inspect response, the frontend merges onto `parameters.agent`
 on a playground run, and excludes on commit. The agent service stays dumb. The advanced-drawer UI
-is folded into this design. Four open questions remain for Mahmoud.
+is folded into this design. One open question remains for Mahmoud.
 
 ## The model
 
@@ -23,11 +23,11 @@ is folded into this design. Four open questions remain for Mahmoud.
   `SimpleApplicationResponse`. It is not in `revision.data` (user config, `extra="forbid"`, flows
   into commit) and not in `application.meta` (user metadata, persisted). It is platform-owned,
   read-only, derived per response. Future read-only hints add members beside `playground_build_kit`.
-- The overlay is a partial `parameters.agent`. Today: the three platform ops plus a reference
-  (workflow-as-tool) entry for the client tool `__ag__request_connection` in `tools`, the
-  authoring skill as an `@ag.embed` reference in `skills`, and the build-permission elevation in
-  `sandbox`. Skills are ordinary embed references with no parallel display fields; a permission's
-  status is its value in the overlay.
+- The overlay is a partial `parameters.agent`. Today: the three platform ops plus an `@ag.embed`
+  reference to the client tool `__ag__request_connection` in `tools` (the same embed shape a skill
+  uses, only the slug differs), the authoring skill as an `@ag.embed` reference in `skills`, and the
+  build-permission elevation in `sandbox`. Skills and the client tool are ordinary embed references
+  with no parallel display fields; a permission's status is its value in the overlay.
 - The frontend applies the overlay with a dedicated applier: deep-merge object fields, identity-
   merge list fields, on a throwaway run copy only. It never mutates the draft or committed tree.
 - No run flag. The toggle is client session state, default on. A kit-on run is just a run whose
@@ -37,15 +37,19 @@ is folded into this design. Four open questions remain for Mahmoud.
 schema, chosen over `meta` to avoid the user-owned artifact `meta` and to keep the platform-derived
 container extensible.)
 
+## Decided
+
+- Toggle persistence: ephemeral per session, resets to on. Not a stored preference in v1.
+- Merge precedence: the overlay wins on an identity match. When it overrides a user setting, the
+  drawer flags it on that user's own control with an override hint (toggle the kit off to match the
+  published agent).
+- Change 1 (collapsible sections): ships as a separate, independent change, not part of the
+  build-kit core.
+
 ## Open questions for Mahmoud
 
-1. Toggle persistence: ephemeral per session (lean) or a stored playground preference.
-2. Confirm the published default goes fully bare (drop the authoring skill and the sandbox boundary
-   from the schema default into the overlay; set `AGENTA_FORCED_SKILLS = []`). Touches the skills
-   project.
-3. Merge precedence on a conflict: the overlay overrides on an identity match (lean), or yields to
-   a user entry of the same identity.
-4. Ship Change 1 (collapsible sections) with the kit, or separately (lean separate).
+1. Confirm the published default goes bare (drop the authoring skill and the sandbox boundary from
+   the schema default into the overlay). Touches the skills project.
 
 ## Coordination
 
@@ -53,11 +57,11 @@ container extensible.)
 - Authoring skill content and naming: skills project (`#4918`). We reference the reserved slug only.
 - Builder tools (`#4919`) add more platform ops; the builder reads `PLATFORM_OPS` at assembly time,
   so new ops join automatically. The builder also enumerates the reserved-slug platform workflows
-  in the static workflow catalog and adds each as a reference-tool entry, parallel to iterating
+  in the static workflow catalog and adds each as an `@ag.embed` reference, parallel to iterating
   `PLATFORM_OPS`.
-- A client tool such as `request_connection` is a non-runnable workflow (reference) tool, not a
-  platform op; its primary definition is owned by `#4920`. The kit carries it as a reference-tool
-  entry embedded from its reserved `__ag__*` slug.
+- A client tool such as `request_connection` is not a platform op; its primary definition is owned
+  by `#4920`. The kit carries it as an `@ag.embed` reference to its reserved `__ag__*` slug, the
+  same embed shape a skill uses, only the slug differs.
 - The overlay model carries through to `#4918`, `#4919`, and `#4920`. Do not edit them here; the
   orchestrator propagates the design after Mahmoud approves it.
 

--- a/docs/design/agent-workflows/projects/default-agent-config/status.md
+++ b/docs/design/agent-workflows/projects/default-agent-config/status.md
@@ -1,40 +1,53 @@
-# Status: default agent config
+# Status: default agent config (playground build kit)
 
 ## Where we are
 
-Research done (`research.md`). Injection point confirmed in code and decided. Design final
-in `design.md`, all decisions locked. Ready for the consolidated design-docs PR.
+Model pivoted to inject-not-commit and the design is rewritten in `design.md`. The platform
+tools and the Agenta authoring skill are a Playground build kit: injected for the playground
+session, shown read-only, toggled as a whole, and never committed to the published agent.
+The descriptor contract for the drawer project is fixed. Two open questions remain for
+Mahmoud.
 
-## Decisions settled (by Mahmoud)
+## The pivot
 
-1. Default skill is embedded, not forced. Stop force-injecting getting-started; keep the
-   `force_skills` mechanism for later.
-2. Delete-only for v1. No `is_active` flag now.
-3. Platform tools are a frozen, explicit list, read from the catalog at build time.
-4. Defaults must surface where the new-agent draft reads them.
-5. Injection point: the catalog template carries the enriched default. The bare SDK builtin
-   interface stays bare. `/inspect` is not used for the draft's values; it is kept in sync
-   only so the service default and the runtime fallback do not drift.
+The earlier approach (materialize the defaults into the catalog template so a new agent
+commits them) was reviewed by Mahmoud and dropped. Defaults are not committed. They are a
+playground overlay. The designer handoff (`design_handoff_advanced_build_kit`) names the
+same thing: a "Playground build kit", "Removed on commit", "None of this is part of the
+published agent". `research.md` still holds the code trace; the code facts there are valid,
+only the approach changed.
 
-## Injection point (confirmed and decided)
+## The model
 
-The new-agent draft reads its editable values from the catalog
-(`template.data.parameters`), not from `/inspect` (the draft uses `/inspect` for schemas
-only). The catalog default comes from the bare SDK interface today
-(`build_agent_v0_default()` with no skill, no tools). The service `/inspect` enriches a
-default the draft never reads. That split was the gap. Fix: point the catalog template at
-the enriched default (platform tools plus the skill embed), keep the SDK builtin bare, keep
-`/inspect` in sync.
+- Build kit = backend-defined set of platform tools (`PLATFORM_OPS`) + the authoring skill +
+  build permissions (write files, execute code).
+- Inject for display and for the run. Strip on commit (it was never in the config).
+- The published-config default stays bare. The kit is a separate backend concept.
+
+## Contract fixed for the drawer project
+
+- Read-only `build_kit` descriptor in the `/inspect` response at `revision.data.build_kit`,
+  a sibling of `schemas`. Grouped by kind (`skills`, `tools`, `permissions`). Each row:
+  `key`, `name`, `description`; permission rows also `status`. Platform-owned, never echoed
+  back.
+- One per-run flag `flags.inject_build_kit` (boolean), set by the drawer toggle, default off
+  server-side. Kit off skips injection.
+
+## Open questions for Mahmoud
+
+1. Toggle persistence: ephemeral per session (lean) or a stored playground preference.
+2. Confirm the published default goes fully bare (drop the skill embed and the sandbox
+   boundary from the `/inspect` schema default into the kit). Touches the skills project.
 
 ## Coordination
 
-A separate skills subagent owns the getting-started skill content and naming. This project
-owns embed-by-default (the skill arrives as a removable embedded default config item). Do
-not write skill content here.
+- Drawer UX: advanced-build-kit project + the designer handoff. We feed it the descriptor.
+- Authoring skill content and naming: skills project (`#4918`). We reference the slug only.
+- Builder tools (`#4919`) add more platform ops; the kit reads `PLATFORM_OPS` at call time,
+  so new ops join automatically.
 
-## Out of scope (noted)
+## Out of scope
 
-- Disable-but-keep (`is_active` + resolver/wire drop).
-- Debug-mode UX where defaults are not shown.
-- A picker to add platform tools or skills back after deleting.
-- Real getting-started skill content.
+- Per-item edit or delete of kit items (kit is whole-toggle, read-only in v1).
+- A picker to add platform tools to the published agent.
+- Disable-but-keep for the user's own config.


### PR DESCRIPTION
## What this designs

A new agent on Agenta arrives near-bare. While the user builds it in the playground, the assistant needs authoring scaffolding: the platform tools (find capabilities, query workflows, commit a revision), the Agenta authoring skill, and elevated sandbox permissions (write files, execute code). That scaffolding is a build aid, not the user's agent. So it is shown and used in the playground, never committed, and never reaches a deployed run.

This doc decides who shows that scaffolding, who applies it, and who keeps it out of the commit.

## Iteration 3: re-derived from first principles as an overlay

This is the third pass. The first had the agent service inject the kit at run time behind a run flag. The second moved the logic to the frontend but modeled the kit as a bespoke descriptor with typed groups and per-row display fields. This pass re-derives the whole thing from scratch as a single overlay, the model Mahmoud asked for in review.

## The model: a build-kit overlay

The build kit is an agent-template overlay. It is a partial agent template, the same shape as `parameters.agent`. Three actors, three jobs:

- **The agent service stays dumb.** It runs the `parameters.agent` it receives and does not know the overlay exists. There is no run-prep merge and no run flag. The platform tools, the skill, and the build permissions reach a run only because the frontend already merged them into the template the service was handed.
- **The backend serves the overlay.** It assembles the overlay once and attaches it read-only to the inspect response. It never applies it.
- **The frontend applies the overlay.** It renders the overlay read-only in the drawer. On a kit-on run, it deep-merges objects and identity-merges lists onto a throwaway copy of `parameters.agent`. On commit, it does not merge, so the committed config holds only the user's own template.

"Shown but not committed" follows from this. The overlay never enters `parameters.agent`, the tree the playground edits and commits, so there is no strip step and a deployed agent can never run with it.

## Where the overlay lives in the inspect response

The overlay rides a dedicated read-only container, `additional_context`, a sibling of `application` on the inspect envelope:

```jsonc
{
  "application": { /* the agent, including data.parameters (user config) */ },
  "additional_context": {
    "playground_build_kit": {
      "agent_template_overlay": { /* the partial parameters.agent */ }
    }
  }
}
```

The placement follows ownership and lifecycle. User config the revision persists lives in `application.data.parameters`. User metadata that round-trips lives in `application.meta`. Platform information the backend derives read-only for one response lives in `additional_context`. The overlay is rejected from `revision.data` (it is `extra="forbid"` and flows into commit) and from `application.meta` (user-owned and persisted). This placement was chosen after consulting Codex on the whole inspect schema, so future read-only hints add members beside `playground_build_kit` rather than overloading a user-owned field.

## Skills and the client tool are embed references

A skill in the overlay is an ordinary `@ag.embed` reference, the platform's existing mechanism for embedding a variant. The reference (the slug, plus a version when pinned) already identifies the skill, which carries its own name and description. The overlay adds no parallel `key`, `name`, or `description`. The hard-coded client tool `__ag__request_connection` embeds the same way, through the identical `@ag.embed` shape (only the slug differs); the embed resolver inlines it into a `client` tool the frontend handles. The drawer renders each item with the existing config-item controls.

## The drawer UI, folded in

The inspect contract and the advanced-drawer design live in one doc. The drawer recomposes existing parts:

- Make the advanced sections collapsible accordions, the pattern the left panel already uses. This ships as a separate, independent change, not part of the build-kit core.
- Add a "Playground build kit" section at the top, rendered straight from the overlay, with a `Removed on commit` tag, an enable toggle, and read-only rows that reuse the existing read-only skill pattern.

The toggle is session state (`buildKitEnabled`, default on). It sets no run flag and writes nothing into the config. The doc flags the one real UI risk: the drawer now holds two ideas that both say "permissions" (the committed agent permissions and the kit's read-only build permissions), and they must not read as one setting. When the kit is on and overrides one of the user's own settings, the user's own control shows an override hint: the value is overridden in the playground by the build kit, and toggling the kit off makes the playground match the published agent. The load-bearing case is a permission the user disabled in their config that the kit re-enables for the playground run.

## Scope and risk

Doc only, no code. The authoring skill content is owned by the skills project (#4918). The builder-tools project (#4919) adds more platform ops, which the overlay builder picks up from `PLATFORM_OPS` automatically. Out of scope: per-item edit or delete of kit items, and a picker to add platform tools to the published agent.

The body is current-state only. The two earlier models are recorded in a short appendix, not in the design narrative. The overlay model ripples to the sibling docs (#4918, #4919, #4920); the orchestrator propagates it after this design is approved.

## Decided this round

- Toggle persistence: ephemeral per playground session, resets to on. Not a stored preference in v1.
- Merge precedence: the overlay wins on an identity match. When it overrides a user setting, the drawer flags it on that user's own control with an override hint (toggle the kit off to match the published agent).
- Collapsible sections: ship as a separate, independent change, not part of the build-kit core.

## Open questions for Mahmoud

1. Confirm the published default goes bare, dropping the authoring skill and the sandbox boundary from the schema default into the overlay. This touches the skills project's surface.

## Related PRs

Part of the "agent builds an app" initiative. Read the map first: #4921.

- Overview (the map): #4921
- Platform skills: #4918
- Builder tools: #4919
- Frontend round-trip: #4920

https://claude.ai/code/session_01GYo3UEfvsZpncagqb28Mbc