### PR TITLE
docs(agent): agent builder tools design (triggers, cron, find-triggers)

### DIFF
--- a/docs/design/agent-workflows/projects/agent-builder-capabilities/README.md
+++ b/docs/design/agent-workflows/projects/agent-builder-capabilities/README.md
@@ -1,448 +1,336 @@
-# Agent builder capabilities: tools and skills the build flow still needs
+# Design: agent builder tools (triggers, cron, and event discovery)
 
-A new agent on Agenta ships with skills and platform tools. The goal is that a user can chat
-with that agent and have it turn itself into a real application: wire the tools it needs,
-connect the integrations, edit its own instructions, set up a trigger or a cron job, and
-commit the result. This doc asks one question. What tools and skills are still missing for
-that to work, and what should each missing piece look like?
+A new agent on Agenta should turn itself into a real application by chatting with the user. It
+finds the tools it needs, connects the integrations, edits its own instructions, sets a trigger
+or a cron job, and commits the result. The agent becomes the app. The user never writes config by
+hand. They have a conversation.
 
-Grounded in code on branch `gitbutler/edit` over `big-agents`, 2026-06-28. Paths are absolute.
+This project owns the agent builder tools that make the trigger and cron half of that flow work,
+plus the one event-discovery endpoint the flow is missing. It does not own the skills that teach
+the flow (see `agent-skills`), the connection round-trip the flow depends on (see
+`agent-fe-roundtrip`), or how defaults reach a new agent (see `default-agent-config`). The map for
+all four is `agent-builds-an-app`.
 
-## Decisions locked in round 2
+Grounded in code on `gitbutler/edit` over `big-agents`, 2026-06-28. Paths are absolute.
 
-Mahmoud answered the four open questions. They are settled, and the design below assumes them:
+## 1. The goal and the gap
 
-1. **Self-modification only.** The agent becomes the app. It does not create other workflows.
-   No `create_workflow`, `create_variant`, or commit-to-another-variant tools now. The agent
-   that builds *other* agents is a separate future agent, out of scope here.
-2. **Triggers self-target.** A schedule or subscription points at the agent itself, with the
-   destination bound server-side from run context the way `commit_revision` binds the variant
-   id. The model never supplies a destination.
-3. **`find_triggers` with keyword search.** Build a small new backend that keyword-searches the
-   trigger event catalog and returns `find_capabilities`-shaped results. Not semantic. If the
-   event set turns out tiny, a hardcoded skill that enumerates events is an acceptable simpler
-   path; start with `find_triggers`.
-4. **The agent cannot create a connection or set a secret.** When a connection is missing, the
-   agent asks the frontend through the general client-tool round-trip (owned by the FE
-   round-trip design); when the frontend finishes, it tells the agent, which continues. Secrets
-   stay frontend-only. This doc references that mechanism and does not design it.
+The user wants the agent to run on a schedule or react to an outside event. "Triage every new
+GitHub issue." "Send me a digest each morning." Today the agent cannot set that up. It can edit
+its own instructions and wire action tools, but it has no way to schedule itself or subscribe
+itself to an event.
 
-A constraint that shapes every proposal: the team already decided (in
-`projects/agent-creation-skills/`, where a bespoke "create_workflow with logic" design was
-superseded on 2026-06-27) that platform tools are **thin wrappers over existing endpoints, with
-no new logic**, and that a **skill** composes the multi-step flow. Every tool below is one HTTP
-call to one endpoint that already ships. The one exception is `find_triggers`, which Mahmoud
-asked for as new backend; the doc says so plainly.
+The engine for triggers and cron already ships. Agenta has a full backend subsystem for event
+subscriptions, cron schedules, delivery logs, a provider event catalog, and a worker that fires
+the bound workflow. We do not build a scheduler. The gap is narrow and specific: there is no
+agent-facing tool layer over that engine, and there is no way to search the event catalog. This
+design fills both.
 
-## These tools all ship in a new agent's default config
+## 2. What already exists: the trigger and cron engine
 
-A consequence worth stating up front. The default-agent-config project freezes every platform op
-in the catalog into a new agent's default config at build time. So once the tools below land, a
-new agent ships with all of them: the three core ops (`find_capabilities`, `query_workflows`,
-`commit_revision`) plus the eight trigger and cron ops here. Several are approval-gated
-(`create_schedule`, `create_subscription`, `test_subscription`), and they all arrive with their
-catalog default permissions, which the user can edit. This is intended. The build flow needs it,
-because there is no picker to add a platform tool back: a tool that is not in the default can
-never reach the agent. So adding a tool to this catalog also changes what every new agent
-carries. See `../default-agent-config/design.md`.
+Everything below ships today under `api/oss/src/`. The agent only ever writes one row, a schedule
+or a subscription. The engine does the rest.
 
-## How to read this
-
-- Section 1: the end-to-end walkthrough, each step mapped to a tool or skill, marked EXISTS or
-  MISSING.
-- Section 2: the triggers and cron reality (the backend already exists).
-- Section 3: each missing tool, with the `design-interfaces` role analysis and motivations.
-- Section 4: **the agent-driven trigger and subscription flow, walked end to end.** This is the
-  part Mahmoud most wants explored: what the agent asks, what happens when a connection is
-  missing, and whether a subscription can be tested before a connection exists.
-- Section 5: the missing skills.
-- Section 6: the split between us (backend, SDK, runner) and Arda (frontend).
-- Section 7: the smaller questions that remain.
-
-## 1. The end-to-end walkthrough
-
-The agent is configuring itself. The columns: the step, the serving tool or skill, and whether
-that piece exists today.
-
-| # | Build step | Serving tool / skill | State |
-|---|---|---|---|
-| 0 | Understand the goal, plan the build | skill: **build-your-first-app** (orchestrator) | MISSING (skill) |
-| 1 | Find the right action tools | `find_capabilities` tool | EXISTS |
-| 2 | See what already exists in the project | `query_workflows` tool | EXISTS |
-| 3 | Connect an integration the tools need | FE connection round-trip (agent requests, cannot create) | MISSING (FE-owned) |
-| 3b | Check whether a connection is ready | `list_connections` tool | MISSING (tool) |
-| 4 | Set a provider key / secret | frontend-only, by design | OUT (FE-only) |
-| 5 | Attach tools + edit own AGENTS.md + own skills | `commit_revision` tool (self-target) | EXISTS |
-| 6 | Find the right event to trigger on | `find_triggers` tool (keyword) | MISSING (new backend) |
-| 7 | Set up a cron job on itself | `create_schedule` tool (self-target) | MISSING (tool); backend EXISTS |
-| 8 | Set up an event trigger on itself | `create_subscription` tool (self-target) | MISSING (tool); backend EXISTS |
-| 9 | List / inspect its own triggers | `list_schedules` / `list_subscriptions` tools | MISSING (tool); backend EXISTS |
-| 10 | Test the trigger end to end | `test_subscription` tool + `list_deliveries` | MISSING (tool); backend EXISTS |
-| 11 | Commit the finished agent | `commit_revision` (self-target) | EXISTS |
-| - | Teach the trigger + cron flow | skill: **set-up-triggers** | MISSING (skill) |
-| - | Teach the discover-and-wire flow | skill: **discover-and-wire-tools** | DRAFT, not yet a platform skill |
-| - | Teach the create/commit/invoke flow | skill: **create-agenta-agent** | DRAFT, not yet a platform skill |
-
-The gaps cluster in three places: trigger and cron tools (backend ready, no agent-facing tools),
-the connection dependency (the agent requests through the FE, never creates), and the build-flow
-skills (drafts exist, none loaded as platform skills yet). Self-modification of instructions,
-tools, and skills is already covered by `commit_revision`.
-
-## 2. The triggers and cron reality
-
-Agenta has a complete trigger subsystem already. We are not designing a scheduler. We are
-exposing what ships.
-
-What exists, in `api/oss/src/`:
-
-- **Schedules (cron).** `core/triggers/dtos.py` defines `TriggerSchedule`; the router
+- **Schedules (cron).** `core/triggers/dtos.py` defines `TriggerSchedule`. The router
   (`apis/fastapi/triggers/router.py`) exposes `POST /api/triggers/schedules/` plus list, query,
-  fetch, edit, delete, start, stop. A schedule carries a five-field cron expression
-  (`data.schedule`, UTC, one-minute floor, validated by `croniter`), an optional
+  fetch, edit, delete, start, and stop. A schedule carries a five-field cron expression in
+  `data.schedule` (UTC, one-minute floor, validated by `croniter`), an optional
   `[start_time, end_time)` window, an `inputs_fields` mapping template, and a
-  `references`/`selector` naming the workflow to run.
-- **Subscriptions (event-driven).** Same router exposes `POST /api/triggers/subscriptions/` and
-  the full lifecycle. A subscription watches one provider event (Composio today), keyed by a
-  `connection_id` and an `event_key`, with the same `inputs_fields` and `references`/`selector`.
-  An `is_test` flag puts it in capture-and-skip mode: events are recorded as test deliveries
-  with full context, and the workflow is never invoked.
-- **Test (one-shot).** `POST /api/triggers/subscriptions/test` creates a temporary test
-  subscription, long-polls for the first captured provider event, records it as a delivery, then
-  tears the temporary subscription down (`core/triggers/service.py`, `test_subscription`). It
-  needs a working connection, because it waits for a real event from the provider.
-- **Catalog.** `GET /api/triggers/catalog/providers/.../integrations/.../events/` browses the
-  events you can subscribe to. The leaf is an *event*, the trigger analogue of a tools *action*;
-  the event detail carries a `trigger_config` JSON Schema and an optional sample `payload`.
+  `references`/`selector` pair naming the workflow to run.
+- **Subscriptions (events).** The same router exposes `POST /api/triggers/subscriptions/` and the
+  full lifecycle. A subscription watches one provider event, keyed by a top-level `connection_id`
+  and a `data.event_key`, with the same `inputs_fields` and `references`/`selector`. An `is_test`
+  flag puts it in capture-and-skip mode: matching events are recorded as test deliveries with full
+  context, and the workflow is never invoked. Capture-and-skip needs no bound workflow.
+- **One-shot test.** `POST /api/triggers/subscriptions/test` creates a temporary test
+  subscription, long-polls the provider for the first real event (60-second deadline), records it
+  as a delivery, then always tears the temporary subscription down
+  (`core/triggers/service.py:624`). It requires a connection, because it waits for a real event
+  from the provider (`_require_connection`, `service.py:380`).
+- **Event catalog.** `GET /api/triggers/catalog/providers/.../integrations/.../events/` browses
+  the events you can subscribe to. The leaf is an *event*, the trigger analogue of a tool *action*.
+  Each event detail carries a `trigger_config` JSON Schema (the event's parameters) and an
+  optional sample `payload` (`core/triggers/dtos.py:73`).
 - **Deliveries.** `GET /api/triggers/deliveries` and `/query` are the audit log: one row per
-  fire, with inputs, result, error, and a test marker. This is how the agent confirms a trigger
-  fired and reads a captured sample event.
-- **The machinery.** A per-minute cron tick (`crons/triggers.sh`) POSTs an admin
-  `schedules/refresh`; due schedules are enqueued onto Taskiq + Redis Streams; a worker
-  (`entrypoints/worker_triggers.py`) dispatches each to the bound workflow. The agent never
-  touches any of this. It only writes the schedule or subscription row.
+  fire, recording the resolved `inputs`, the `result`, any `error`, and an `is_test` marker. This
+  is how the agent confirms a fire and reads a captured sample event.
+- **Connections.** A subscription's connection is a shared `gateway_connections` row. Triggers
+  exposes `/api/triggers/connections/*` over the same connection service that the tools subsystem
+  uses, so a connection made from either side is visible from both (`triggers/models.py:69`). The
+  agent never creates one; it only reads connection state.
+- **The machinery.** A per-minute external tick calls the admin endpoint
+  `POST /api/admin/triggers/schedules/refresh`. Due schedules and arriving events are enqueued onto
+  Taskiq and Redis Streams; a worker (`tasks/taskiq/triggers/worker.py`) dispatches each to the
+  bound workflow and records the delivery. The agent touches none of this.
 
-What does not exist: any agent-facing tool over these endpoints, and any search over events. The
-gap is the tool layer and the discovery story, not the engine.
+What is missing: any agent-facing tool over these endpoints, and any search over events. There is
+no `POST /api/triggers/discover` today. The gap is the tool layer and the discovery story, not the
+engine.
 
-How a trigger binds to the agent (decision 2): the destination is `data.references` plus
-`data.selector`. For self-targeting, the runner binds those to the running agent's own workflow
-from run context, stripped from the model-visible schema, exactly as `commit_revision` binds and
-strips the variant id. The model never names a destination, so it can only ever schedule or
-subscribe *itself*.
+## 3. Decisions this design honors
 
-## 3. The missing tools
+These are settled across the initiative (`agent-builds-an-app`). The design assumes them.
 
-Each tool is a platform-op catalog entry in
-`sdks/python/agenta/sdk/agents/platform/op_catalog.py`: a thin wrapper over one existing
-endpoint. The catalog owns the model-facing description, the method and path, the curated input
-schema, the run-context bindings, and the default permission and approval. Adding one is a data
-change to that catalog. `find_triggers` (3.4) is the lone exception that needs new backend.
+- **The agent becomes the app.** Self-modification only. A schedule or subscription targets the
+  running agent itself. No tool creates another workflow in this round.
+- **Triggers self-target by context binding.** The destination is bound server-side from run
+  context and stripped from the model-visible schema, the same way `commit_revision` binds the
+  variant id. The model never names a destination, so it can only schedule or subscribe itself.
+- **The agent cannot create connections or set secrets.** When a connection is missing, the agent
+  requests one through the frontend round-trip and waits. It holds only a connection reference, never
+  the secret. The round-trip is owned by `agent-fe-roundtrip`; this design consumes it.
+- **Builder tools are injected, not committed.** They are platform operations, a build-time aid.
+  They reach a playground run through the injected build kit and never enter the user's stored
+  config (section 6). The default-config model is owned by `default-agent-config`.
+- **Mutating tools default to approval.** `create_schedule`, `create_subscription`, and
+  `test_subscription` each pause for the user before they act.
 
-The `design-interfaces` rule applied throughout: classify each field by the role it plays (data,
-config, policy, credentials, routing, context, metadata), bind context server-side rather than
-trusting the model, and gate dangerous behavior behind approval rather than a blanket allow.
+## 4. The tool set
 
-### 3.1 `create_schedule` — set up a cron job on itself (backend exists)
+Every builder tool is a `PlatformOp`: one entry in
+`sdks/python/agenta/sdk/agents/platform/op_catalog.py`, one HTTP call to one endpoint that already
+ships. The catalog entry owns the model-facing description, the method and path, a curated input
+schema, the run-context bindings, and the default permission and approval. Adding a tool is a data
+change to that catalog. `find_triggers` (4.6) is the one exception that needs new backend.
 
-One call to `POST /api/triggers/schedules/`; the model's arguments land at `args_into:
-"schedule"`. The destination is bound, not supplied.
+Each tool's contract is laid out by the role each field plays: **input** (the data the model
+provides), **config** (how the trigger behaves), **routing** (where it points), **credentials**
+(how the source authenticates), **metadata** (labels), and **policy** (what is allowed). Two role
+rules run through the whole set. The destination is routing, and it is bound from context, never
+trusted from the model. The connection is a credential reference, an id only, never a secret.
+
+| Tool | Endpoint | Kind | Default permission |
+|---|---|---|---|
+| `find_triggers` | `POST /api/triggers/discover` (new) | read | allow |
+| `create_schedule` | `POST /api/triggers/schedules/` | mutate | ask, approval |
+| `create_subscription` | `POST /api/triggers/subscriptions/` | mutate | ask, approval |
+| `test_subscription` | `POST /api/triggers/subscriptions/test` | probe | ask, approval |
+| `list_schedules` | `GET /api/triggers/schedules/` | read | allow |
+| `list_subscriptions` | `GET /api/triggers/subscriptions/` | read | allow |
+| `list_deliveries` | `GET /api/triggers/deliveries` | read | allow |
+| `list_connections` | `POST /api/triggers/connections/query` | read | allow |
+
+### 4.1 `create_schedule`: run myself on a clock
+
+One call to `POST /api/triggers/schedules/`. The model's arguments land under `args_into:
+"schedule"`, matching the `{ "schedule": { ... } }` request body.
 
 | Field | Role | Owner | Notes |
 |---|---|---|---|
 | `name` | metadata | model | A human label for the schedule. |
-| `data.schedule` | config (period) | model | Five-field cron, UTC. The skill teaches the syntax. |
-| `data.start_time` / `data.end_time` | config (window) | model | Optional `[start, end)` bounds. |
-| `data.inputs_fields` | data (mapping) | model | Template that fills the run's inputs. |
-| `data.event_key` | metadata | model | A label for the fire; reused on deliveries. |
-| `data.references` + `data.selector` | routing (destination) | **context-bound** | The running agent's own workflow, from `$ctx`. Stripped from the model schema. |
+| `data.schedule` | config (cadence) | model | Five-field cron, UTC, one-minute floor. The skill teaches the syntax. |
+| `data.start_time` / `data.end_time` | config (active window) | model | Optional `[start, end)` bounds. |
+| `data.inputs_fields` | input (mapping) | model | Template that fills the run's inputs each fire. |
+| `data.event_key` | metadata | model | A label recorded on each delivery. |
+| `data.references` + `data.selector` | routing (destination) | context-bound | The running workflow, from `$ctx`. Stripped from the model schema. |
 
-Default permission and approval: **`ask`, approval required.** This is the load-bearing safety
-call. A schedule makes the agent run on its own, unattended, possibly costing money or taking
-real-world actions. That is exactly the dangerous behavior `design-interfaces` says to gate
-behind an explicit allow, never a default-on. It mirrors `commit_revision`.
+Default permission: **ask, approval required.** This is the load-bearing safety choice. A schedule
+makes the agent run unattended, on its own clock, possibly costing money or taking real actions.
+Approval gates exactly that. It mirrors `commit_revision`.
 
-The destination binding needs one implementation check: confirm the runner can express
-`data.references` as a `$ctx` binding to the running workflow (the key name and the dotted path
-the trigger's `/retrieve` resolver expects). `commit_revision` already binds
-`workflow_revision.workflow_variant_id` to `$ctx.workflow.variant.id`, so the mechanism exists;
-the exact reference key for triggers is the thing to verify.
-
-### 3.2 `create_subscription` — trigger itself on an external event (backend exists)
+### 4.2 `create_subscription`: react to an outside event
 
 One call to `POST /api/triggers/subscriptions/`, `args_into: "subscription"`. Same shape as a
-schedule, plus the connection.
+schedule, plus the connection that authenticates the event source.
 
 | Field | Role | Owner | Notes |
 |---|---|---|---|
-| `name` | metadata | model | Label. |
-| `connection_id` | routing / credentials | model, **value from the FE round-trip** | Identifies and authenticates the event source. The agent never creates it (decision 4); it passes the id it learned from the connection round-trip or from `list_connections`. |
-| `data.event_key` | config | model | The provider event to watch, from `find_triggers`. |
-| `data.trigger_config` | config | model | The event's parameters, shaped by the event's `trigger_config` schema. |
-| `data.inputs_fields` | data (mapping) | model | Fills the run's inputs from event context. |
-| `data.references` + `data.selector` | routing (destination) | **context-bound** | Self, same as 3.1. |
+| `name` | metadata | model | A human label. |
+| `connection_id` | credentials (reference) | model, value from the round-trip | Identifies and authenticates the event source. A top-level id, never a secret. The agent learns it from the connection round-trip or `list_connections`; it never creates the connection. |
+| `data.event_key` | config (which event) | model | The provider event to watch, from `find_triggers`. |
+| `data.trigger_config` | config (event parameters) | model | The event's parameters, shaped by the event's `trigger_config` schema (for example, the repository). |
+| `data.inputs_fields` | input (mapping) | model | Fills the run's inputs from event context. |
+| `data.references` + `data.selector` | routing (destination) | context-bound | Self, the same as 4.1. |
 
-Default permission and approval: **`ask`, approval required.** Same motivation as 3.1, stronger
-if anything, because the trigger fires on the provider's schedule, not the user's.
+Default permission: **ask, approval required.** Stronger than a schedule if anything, because the
+trigger fires on the provider's timing, not the user's. The connection branch is the crux of the
+build flow (section 5).
 
-The connection dependency is the crux of section 4. The agent holds only a *reference* to a
-connection (an id or slug); it never holds the secret and never creates the connection.
+### 4.3 The read tools
 
-### 3.3 The read and test tools
+Four thin reads, default permission **allow**, matching `find_capabilities` and `query_workflows`.
+The agent reads its own state before changing it and reads the log to confirm a fire.
 
-Thin reads, default permission **`allow`, no approval**, matching `find_capabilities` and
-`query_workflows`. The agent needs to see its own triggers before adding more, and to read the
-delivery log to confirm a fire.
+- `list_schedules` and `list_subscriptions` show the agent what it has already set up.
+- `list_deliveries` is the audit log. The agent reads a captured sample event here and confirms a
+  fire produced a result.
+- `list_connections` reads connection state, so the agent can check whether an integration is ready
+  before it subscribes. Because triggers and tools share the same connection rows, one read covers
+  both sides of the build.
 
-- `list_schedules` — `GET /api/triggers/schedules/`.
-- `list_subscriptions` — `GET /api/triggers/subscriptions/`.
-- `list_deliveries` — `GET /api/triggers/deliveries` (and `/query` for filters). The agent reads
-  a captured sample event here.
-- `list_connections` — `POST /api/tools/connections/query`. The agent checks whether a
-  connection is `ready` before it tries to subscribe.
+### 4.4 `test_subscription`: prove the live wiring
 
-`test_subscription` — `POST /api/triggers/subscriptions/test`. This one *does* something
-(creates a temporary test subscription and long-polls for a real event), but it invokes no
-workflow and leaves nothing behind. Default **`ask`** is the conservative choice, since it
-opens a real watch on the provider and blocks for up to a minute; `allow` is defensible because
-it is non-destructive. Lean `ask`. It requires a `connection_id`, so it cannot run before a
-connection exists (see section 4).
+`POST /api/triggers/subscriptions/test`. This one does something: it opens a temporary watch on the
+provider and blocks for up to a minute waiting for a real event. It invokes no workflow and leaves
+no row behind. It requires a `connection_id`, so it cannot run before a connection exists.
 
-### 3.4 `find_triggers` — keyword event discovery (new backend, decision 3)
+Default permission: **ask, approval required.** The tool opens a real provider watch and blocks, so
+it warrants a confirm even though it is non-destructive. Treating it as a mutating tool keeps the
+gate consistent with the two create tools. (Section 8 keeps `allow` as the alternative.)
+
+### 4.5 `find_triggers`: keyword event discovery (new backend)
 
 `find_capabilities` searches *actions* and returns ready-to-attach tool configs with connection
-state. There is no equivalent for *events*. Mahmoud chose to build a small one.
+state. There is no equivalent for *events*. This is the one new backend piece.
 
-- Endpoint: a new `POST /api/triggers/discover`, mirroring `POST /api/tools/discover`.
-- Search: **keyword**, not semantic, over the trigger event catalog.
-- Input roles: `use_cases` (data, the keyword fragments, e.g. "new github issue"), `provider`
-  (config, default `composio`), `limit_alternatives` (config). Identical in shape to
-  `find_capabilities`.
-- Output, `find_capabilities`-shaped per use case: the best-match event (its `event_key`,
-  integration, `trigger_config` schema, and sample `payload` if the catalog has one), the
-  connection state for that integration (`ready` / `needs_auth` / `needs_input`), alternatives,
-  and guidance. The connection state is what lets the agent decide whether to route to the FE
-  connection round-trip.
-- Platform tool: a thin wrapper over the new endpoint, default **`allow`** (read).
+- **Endpoint.** A new `POST /api/triggers/discover`, mirroring `POST /api/tools/discover`. It
+  joins a keyword match over the event catalog with the shared connection state, so the agent
+  learns the event and whether it can subscribe to it in one call. The catalog browse endpoints
+  return neither a search nor connection state, which is why this is new code, not a thin wrapper.
+- **Search.** Keyword, not semantic. The event set is small, so keyword matching is enough and far
+  cheaper than the semantic engine `find_capabilities` leans on.
 
-Motivation for keyword over semantic: the event set is small, so keyword matching is enough and
-far cheaper to build than the semantic engine `find_capabilities` leans on. The simpler fallback
-Mahmoud named (a hardcoded skill that just lists the common events) stays in reserve if even the
-keyword endpoint proves to be more than the small set warrants. Start with `find_triggers`.
+Input, the same shape as `find_capabilities`:
 
-## 4. The agent-driven trigger flow, end to end
+| Field | Role | Owner | Notes |
+|---|---|---|---|
+| `use_cases` | input (data) | model | One short fragment per event, for example "new github issue opened". |
+| `provider` | config | model | Provider to search. Default `composio`. |
+| `limit_alternatives` | config | model | Max alternatives per use case. Default 3. |
 
-This is the section Mahmoud most wants. Take a concrete ask: *"Run yourself every time a new
-GitHub issue is opened in `acme/app`, and triage it."* The agent is configuring itself. Walk it.
+Output, `find_capabilities`-shaped, per use case: the best-match event (its `event_key`,
+integration, `trigger_config` schema, and sample `payload` if the catalog has one), the connection
+state for that integration (`ready` / `needs_auth` / `needs_input`) and how to connect it,
+alternatives, and short guidance. The connection state is what lets the agent decide whether to
+route the user to the connection round-trip.
 
-### 4.1 The flow, step by step
+Default permission: **allow.** It only reads.
 
-1. **Clarify intent.** The agent asks what it needs to pin the event: which provider and event
-   ("a new issue is opened"), the scope ("which repo"), and what to do on each fire ("triage:
-   label it and post a summary"). Plain conversation, no tools yet.
+## 5. The build flow, end to end
 
-2. **Discover the event.** The agent calls `find_triggers(["new github issue opened"])`. It gets
-   back the `event_key`, the `trigger_config` schema (so it knows it must supply the repo), a
-   sample `payload` if available, and the **connection state** for GitHub.
+This is the heart of the design. Take a concrete request: *"Run yourself every time a new GitHub
+issue is opened in `acme/app`, and triage it."* The agent is configuring itself. Here is the walk.
 
-3. **Branch on connection state.** This is the fork that decides everything after.
-   - **Connection ready.** Continue to step 4.
-   - **Connection missing (`needs_auth` or `needs_input`).** The agent cannot create it
-     (decision 4). It emits a connection-request through the general client-tool round-trip: "I
-     need access to your GitHub to watch for new issues. I'll ask the app to connect it." The run
-     **pauses**. The user connects GitHub in the frontend (OAuth, or a key for `needs_input`).
-     The frontend signals the agent that the connection is ready and hands back its id or slug.
-     The agent resumes at step 4. This pause/resume is the FE round-trip design's mechanism; we
-     only consume it.
+1. **Clarify the intent.** The agent asks what it needs to pin the event: the provider and event
+   (a new issue opens), the scope (which repository), and what to do on each fire (triage: label
+   it, post a summary). Plain conversation, no tools yet.
+2. **Discover the event.** The agent calls `find_triggers(["new github issue opened"])`. Back come
+   the `event_key`, the `trigger_config` schema (so it knows it must supply the repository), a
+   sample `payload` if the catalog has one, and the connection state for GitHub.
+3. **Branch on the connection.** This fork decides everything after it.
+   - *Connection ready.* Continue to step 4.
+   - *Connection missing* (`needs_auth` or `needs_input`). The agent cannot create it. It requests
+     a connection through the frontend round-trip: "I need access to your GitHub to watch for new
+     issues. I will ask the app to connect it." The run pauses. The user connects GitHub in the
+     playground. The frontend resumes the agent with the connection reference. The agent continues
+     at step 4. This pause and resume belongs to `agent-fe-roundtrip`; the agent only consumes it.
+4. **Build the input mapping.** The agent must turn a GitHub-issue event into its own input. It
+   needs a sample event to show the user the shape. The sample can come from the catalog `payload`
+   (no connection needed) or from a real captured event (needs the connection). The agent explains
+   the mapping in plain terms: "When an issue opens, I receive its title, body, and labels. I will
+   treat the issue as my task, like this." The user adjusts, and the agent settles `inputs_fields`.
+5. **Test before going live.** Two modes, covered in 5.1.
+6. **Go live.** The agent calls `create_subscription`: self-targeted, `is_test` off, watching
+   `event_key` on the connection, with the confirmed `inputs_fields`. This is approval-gated: "From
+   now on I will run on every new issue in `acme/app`. Approve?" On approval the subscription is
+   created and active.
+7. **Confirm.** The agent reports what is now live with `list_subscriptions` and tells the user
+   where to manage it. The playground surface that shows standing subscriptions and their delivery
+   history is a product decision owned by the frontend.
 
-4. **Build and confirm the input mapping.** The agent must translate a GitHub-issue event into
-   its own input message. It needs a *sample event* to show the user what that looks like. Two
-   sources, and they differ in whether a connection is required (see 4.2):
-   - the sample `payload` from the catalog (no connection needed), or
-   - a real captured event via the test path (needs the connection).
-   The agent shows the user the mapping in plain terms: "When an issue opens, I receive its
-   title, body, and labels. I'll treat the issue as my task, like this." The user adjusts; the
-   agent settles `inputs_fields`.
+### 5.1 The key finding: a dry test needs no connection, a live test does
 
-5. **Test before going live.** Two modes, depending on what the user wants to prove (4.3):
-   - **Dry test** runs the agent once against a sample event, in the chat, so the user sees the
-     response. No live event, and if the sample comes from the catalog payload, no connection.
-   - **Live test** calls `test_subscription`, which watches the provider for a real event. The
-     user opens a throwaway issue; the agent reads the captured delivery and shows how it mapped
-     and would respond. This proves the real wiring, and it needs the connection.
+The order of operations turns on one fact. A test can run against a real provider event or against
+a sample event, and only the first needs a connection.
 
-6. **Go live.** The agent calls `create_subscription`: self-targeted (bound to its own workflow),
-   `is_test` off, watching `event_key` on the connection, with the confirmed `inputs_fields`.
-   This is **approval-gated**: "From now on I'll run automatically on every new issue in
-   `acme/app`. Approve?" On approval the subscription is created and active.
+- **A live test needs the connection.** `test_subscription` long-polls the provider for a real
+  captured event. With no connection there is no event source and nothing to capture. So a live
+  test, and going live, both sit behind the connection round-trip.
+- **A dry test can skip the connection.** When the catalog event carries a sample `payload`, the
+  agent maps that sample and runs itself on it with no connection at all. When the catalog has no
+  sample, the agent fabricates a representative payload from the `trigger_config` schema and says
+  so.
 
-7. **Confirm and hand off.** The agent reports what is now live (`list_subscriptions`) and tells
-   the user where to manage it. The frontend shows the standing subscriptions and their delivery
-   history (a product surface Arda owns).
+This split changes the build order, so the skill should make it explicit. The agent can answer "do
+I handle this event shape sensibly?" early and offline with a dry test, and defer "is the live
+wiring correct?" to a live test after the connection exists.
 
-A cron job (`create_schedule`) is the same flow without steps 2 and 3: no event, no connection.
-The only test available is a dry run of the agent itself, which runs into the test gap (4.4).
+**Recommendation: sample-first.** Build and dry-test the mapping against the catalog sample with no
+connection. Show the user the agent working. Then ask for the connection and go live, with one live
+test as the prove-it follow-up. The user sees the agent behave before authorizing anything, and the
+human round-trip stays off the critical path until the agent has already earned it.
 
-### 4.2 Can a subscription be tested before a connection exists?
+### 5.2 The cron variant
 
-Short answer: **a live test cannot; a dry test can.**
+A cron job is the same flow without steps 2 and 3: no event to discover, no connection to branch
+on. The agent clarifies the cadence, maps the inputs, and calls `create_schedule`, approval-gated.
+The only test available is a dry run of the agent against synthesized inputs, which runs into the
+gap below.
 
-- **Live test needs a connection.** `test_subscription` long-polls the provider for a real
-  captured event. With no connection there is no event source and nothing to capture. So the
-  connection round-trip (step 3) is a hard gate before any live test or any go-live.
-- **Dry test can skip the connection** *if* there is a sample event to run against. The catalog
-  event detail can carry a sample `payload`; when it does, the agent can map that sample and run
-  itself on it with no connection at all. When the catalog has no sample, the agent can fabricate
-  a representative payload from the `trigger_config` schema and say so.
-
-This split is worth making explicit in the skill, because it changes the order of operations.
-The agent can validate "do I handle this event shape sensibly?" early and offline (dry test),
-and defer "is the live wiring correct?" until after the connection exists (live test). It keeps
-the human round-trip off the critical path until the user has already seen the agent behave.
-
-### 4.3 The manual UI idea, translated to the agent
-
-The current manual idea is: "test connection" creates a (test) subscription; the user then picks
-a captured sample event, builds a message from it, and adds it to the chat to test, in a new or
-the same session. Two ways the agent can express that:
-
-- **Option A, capture-then-promote (closest to the manual flow).** The agent creates an
-  `is_test` subscription (or runs `test_subscription`), waits for a real event, captures it as a
-  delivery, builds the message from the captured event, dry-runs itself, then on approval
-  promotes to a live subscription. Motivation: it mirrors what users already do, and it tests
-  against a real provider payload. Cost: it needs the connection up front, so the round-trip
-  lands before the user has seen anything work, and it leans on real events arriving.
-- **Option B, sample-first (offline first).** The agent uses the catalog sample payload to build
-  and dry-test the mapping with no connection, shows the user the behavior, and only then asks
-  for the connection and goes live (optionally with one live test at the end). Motivation: the
-  user sees the agent work before being asked to authorize anything, which is a gentler first-run
-  experience, and the connection round-trip moves off the critical path. Cost: the early test
-  uses a sample, not a real event, so a final live test is still worth doing.
-
-Recommendation: **Option B as the default path in the skill, Option A as the "prove it live"
-follow-up.** It fits the locked decisions (the agent asks for the connection only when it must)
-and gives the smoothest first build.
-
-A second UX choice inside the test step: **same session or new session.** Running the dry test
-as the next turn of the current chat needs no new machinery (the agent just continues the
-conversation with the synthesized message) but mixes test output into the build conversation. A
-clean new session isolates the test but needs a way to invoke the agent fresh, which is the test
-gap below. Lean: same-session dry test for v1, new-session as a later nicety.
-
-### 4.4 The test gap
+### 5.3 The test gap
 
 Steps 5 and the cron case both want to "run the agent once to show the user." There is no clean
-public endpoint for that: invocation goes through the agent sidecar
-(`/services/agent/v0/invoke`) or the internal workflows service, and a platform-op path is
-confined to the `/api` mount. So a *new-session* dry test and a cron dry run have no thin-wrapper
-home today. Same-session dry tests dodge this (the agent simply continues the chat). Options, to
-decide later: expose a public `/api` invoke wrapper (new surface), keep dry tests same-session
-only, or accept that the user runs the final check in the playground. Flagging, not solving.
+public endpoint for that today. Invocation goes through the agent sidecar or the internal workflows
+service, and a platform operation is confined to the `/api` mount. So a dry run in a fresh session
+has no thin-wrapper home. A same-session dry test dodges this, because the agent simply continues
+the chat with the synthesized message. The options, to settle in implementation: keep dry tests
+same-session only, expose a public `/api` invoke wrapper, or let the user run the final check in
+the playground. Section 8 carries the recommendation.
 
-## 5. The missing skills
+## 6. How these tools reach the agent
 
-Skills are code-defined platform skills under the reserved `__ag__*` namespace, served read-only
-through `StaticWorkflowCatalog` (`api/oss/src/core/workflows/static_catalog.py`), authored as
-`SkillTemplate` constants next to
-`sdks/python/agenta/sdk/agents/adapters/agenta_builtins.py`, with the SKILL.md files under
-`services/agent/skills/<name>/`. Only one exists today (`agenta-getting-started`, a placeholder).
-A skill teaches the model which tools to use and in what order; it adds no behavior.
+The builder tools are platform operations, a build-time aid, not part of the user's shipped agent.
+So they follow the inject-not-commit model that `default-agent-config` owns. The agent uses them
+to build itself, but they never enter the stored config.
 
-### 5.1 `build-your-first-app` — the orchestrator skill (new)
+The mechanics are already in place. The build kit reads `PLATFORM_OPS` at call time and injects the
+platform tools into the playground run, before tool resolution. Adding the builder tools to
+`PLATFORM_OPS` is therefore the whole integration: the new tools join the kit with no extra wiring.
+The Advanced drawer shows them as a read-only group; the user toggles the whole kit on or off but
+does not edit a tool. A normal production run of the published agent never injects the kit, so it
+never carries these tools. When the agent commits, the commit writes only the user's config; the
+builder tools are absent by construction.
 
-The top-level skill that drives the whole self-build. What it teaches:
+One consequence is worth stating plainly. After this project lands, a new agent's build kit will
+carry around a dozen platform tools, several of them approval-gated. That is intended. The build
+flow has no picker, so the agent cannot add a platform tool to itself mid-run; the tools must be
+present from the start. `default-agent-config` confirms the same seam.
 
-1. Clarify the goal (what should the agent do, on what trigger, with what tools).
-2. Discover action tools with `find_capabilities`; discover events with `find_triggers`; check
-   what exists with `query_workflows` and `list_connections`.
-3. When a connection is missing, request it through the FE round-trip and wait. Never try to
-   create it.
-4. Configure itself with `commit_revision`: instructions, tools, skills.
-5. Set up the trigger or cron via the **set-up-triggers** skill, self-targeted.
-6. Test (sample-first dry test, then a live test once connected) and confirm.
-7. Commit and tell the user what it became and what is now scheduled or subscribed.
+The per-tool approval lives on the catalog entry, not in the drawer. `create_schedule`,
+`create_subscription`, and `test_subscription` each carry `default_needs_approval=True`, so they
+pause for the user wherever the kit is injected.
 
-It names the stop points: connection requests, schedules, subscriptions, and commits all pause
-for the human. Motivation: the model needs the sequence and the approval gates, and a single
-orchestration skill is where that lives. It turns "build me an app" into a guided flow instead
-of the model guessing the order of a dozen calls.
+## 7. Dependencies, ownership, and the work split
 
-### 5.2 `set-up-triggers` — the trigger and cron skill (new)
+This project owns the tools. It depends on two sibling projects and shares one seam with a third.
 
-The focused skill for steps 6 to 10. What it teaches:
+- **The connection round-trip** (`agent-fe-roundtrip`) is the pause-connect-resume mechanism in
+  step 3. Hard dependency. The connection branch of the build flow does not work without it.
+- **The skills** (`agent-skills`) teach the order of these tool calls and the stop points. The
+  `set-up-triggers` and `build-your-first-app` skills name the tools below and assume they are
+  present. This project ships the tools; that project ships the prose.
+- **The build kit** (`default-agent-config`) is the seam in section 6. This project adds ops to
+  `PLATFORM_OPS`; that project injects them.
 
-- Schedule (cron, our own tick, no connection) versus subscription (external event, needs a
-  connection).
-- Cron syntax, UTC, the one-minute floor, the optional window.
-- Finding an event with `find_triggers`, and reading its `trigger_config` schema.
-- Mapping event or time context into the run's inputs via `inputs_fields`.
-- That the destination is the agent itself and is set automatically; the model supplies no
-  destination.
-- The test split from section 4: dry test against a sample payload (no connection), live test
-  via `test_subscription` (needs the connection), and the capture-then-promote versus
-  sample-first orders.
-- Confirming a fire with `list_deliveries`.
+**What we build (backend, SDK):**
 
-Motivation: triggers carry real footguns (timezone, cron syntax, the connection prerequisite,
-the inputs mapping, the test ordering). A skill turns those into a checklist the model follows.
+- Add the eight builder tools to `PLATFORM_OPS`: `create_schedule`, `create_subscription` (both
+  self-targeted, approval-gated), `test_subscription`, the four reads, and `find_triggers`.
+- Build the `find_triggers` backend: the new `POST /api/triggers/discover` endpoint that joins a
+  keyword catalog match with shared connection state.
+- Verify the self-target binding. Confirm the trigger resolver accepts a `references`/`selector`
+  bound from `$ctx` to the running workflow, and find the exact reference key it expects.
+  `commit_revision` already binds `workflow_revision.workflow_variant_id` to
+  `$ctx.workflow.variant.id`, so the mechanism exists; the trigger reference key is the one thing to
+  confirm.
 
-### 5.3 Promote the two draft skills to platform skills
+**What the frontend owns (Arda):**
 
-Two skills already exist as drafts and should become `__ag__*` platform skills so the builder
-agent carries them:
+- The connection round-trip and connection entry (the secret never reaches the model).
+- The approval prompts for the three mutating tools.
+- The playground surface that shows standing schedules and subscriptions with their delivery
+  history.
 
-- `discover-and-wire-tools` (in `projects/tool-discovery/skills/`) — the discover,
-  resolve-connections, create, test loop around `find_capabilities`. It already flags trigger use
-  cases as out of its scope; with `find_triggers` and `set-up-triggers` landing, update that note
-  to hand off to the trigger skill instead of dead-ending.
-- `create-agenta-agent` (in `projects/agent-creation-skills/skills/`) — the create, commit,
-  invoke loop and the config schema. For self-modification, the load-bearing half is the commit
-  and the config schema; trim the create-a-new-workflow half to match decision 1.
+## 8. Open questions
 
-Both drafts predate JP's config rename. Before they ship, update the field names: config nests
-under `parameters.agent`, the type-ref is `agent-template` (not `agent_config`),
-`ModelRef.params` is now `extras`, and `permission_policy` rides `runner.interactions.headless`.
+The big decisions are settled (section 3). These are finer and non-blocking; each settles during
+implementation. Recommendations included.
 
-## 6. The split: us versus Arda (frontend)
-
-**Us (backend, SDK, runner):**
-
-- Add the trigger tools to the platform-op catalog: `create_schedule`, `create_subscription`
-  (both self-targeted, approval-gated), `list_schedules`, `list_subscriptions`,
-  `list_deliveries`, `list_connections`, `test_subscription` (sections 3.1 to 3.3).
-- Build `find_triggers`: the new `POST /api/triggers/discover` keyword endpoint plus its thin
-  platform tool (3.4).
-- Verify the self-target binding for triggers: that `data.references` can be bound from `$ctx`
-  to the running workflow, and find the reference key the trigger `/retrieve` resolver expects.
-- Author the two new skills (`build-your-first-app`, `set-up-triggers`) and promote the two draft
-  skills, all as `__ag__*` platform skills, updated to the current config field names.
-- Decide the test gap (4.4): same-session dry test only, or a public invoke wrapper.
-
-**Arda (frontend):**
-
-- The connection round-trip: the general client-tool mechanism by which the agent asks for a
-  connection, the run pauses, the user connects in the UI, and the frontend resumes the agent
-  with the connection reference. This is the other research subagent's design; we consume it.
-- Secret entry: collect provider keys directly into the vault, never through the model.
-- The config-change and action approval UI (the `projects/hitl-fix/` work): the approval prompts
-  for `commit_revision`, `create_schedule`, `create_subscription`, and `test_subscription` land
-  here.
-- The triggers surface: where standing schedules and subscriptions, and their delivery history,
-  show up in the playground so the user can see and manage what the agent set up. A product
-  decision for Arda.
-- The new-session test experience, if we want one (tied to the test gap, 4.4).
-
-## 7. The smaller questions that remain
-
-The four big questions are settled (top of this doc). What is left is finer:
-
-1. **Test order in the skill (4.3).** Confirm sample-first (Option B) as the default, with a live
-   test as the "prove it" follow-up. This is a skill-authoring choice, low risk to change later.
-2. **Same-session versus new-session dry test (4.3 / 4.4).** Lean same-session for v1 to avoid a
-   new invoke surface. Worth a yes from Mahmoud before we write the skill that way.
-3. **`test_subscription` permission (3.3).** `ask` (it opens a real provider watch and blocks) or
-   `allow` (it is non-destructive)? Lean `ask`.
-4. **`find_triggers` scope (3.4).** Build the keyword endpoint now, or start with the hardcoded
-   enumeration skill and add the endpoint only if the event set grows? Mahmoud said start with
-   `find_triggers`; confirm we want the endpoint in this round rather than the skill-only stand-in.
-5. **The test gap (4.4).** Do we want a public `/api` invoke wrapper in this round, or is
-   same-session dry testing plus the playground enough for v1?
+1. **Test order in the skill.** Sample-first as the default, with a live test as the prove-it
+   follow-up (5.1). A skill-authoring choice, low risk to change later. Recommend sample-first.
+2. **Same-session or new-session dry test.** Same-session for v1 avoids a new invoke surface
+   (5.3). Recommend same-session.
+3. **`test_subscription` permission.** `ask` (it opens a real provider watch and blocks) or `allow`
+   (it is non-destructive)? Recommend `ask`.
+4. **The test gap.** A public `/api` invoke wrapper now, or same-session dry testing plus the
+   playground for v1 (5.3)? Recommend deferring the wrapper.

--- a/docs/design/agent-workflows/projects/agent-builder-capabilities/README.md
+++ b/docs/design/agent-workflows/projects/agent-builder-capabilities/README.md
@@ -1,0 +1,448 @@
+# Agent builder capabilities: tools and skills the build flow still needs
+
+A new agent on Agenta ships with skills and platform tools. The goal is that a user can chat
+with that agent and have it turn itself into a real application: wire the tools it needs,
+connect the integrations, edit its own instructions, set up a trigger or a cron job, and
+commit the result. This doc asks one question. What tools and skills are still missing for
+that to work, and what should each missing piece look like?
+
+Grounded in code on branch `gitbutler/edit` over `big-agents`, 2026-06-28. Paths are absolute.
+
+## Decisions locked in round 2
+
+Mahmoud answered the four open questions. They are settled, and the design below assumes them:
+
+1. **Self-modification only.** The agent becomes the app. It does not create other workflows.
+   No `create_workflow`, `create_variant`, or commit-to-another-variant tools now. The agent
+   that builds *other* agents is a separate future agent, out of scope here.
+2. **Triggers self-target.** A schedule or subscription points at the agent itself, with the
+   destination bound server-side from run context the way `commit_revision` binds the variant
+   id. The model never supplies a destination.
+3. **`find_triggers` with keyword search.** Build a small new backend that keyword-searches the
+   trigger event catalog and returns `find_capabilities`-shaped results. Not semantic. If the
+   event set turns out tiny, a hardcoded skill that enumerates events is an acceptable simpler
+   path; start with `find_triggers`.
+4. **The agent cannot create a connection or set a secret.** When a connection is missing, the
+   agent asks the frontend through the general client-tool round-trip (owned by the FE
+   round-trip design); when the frontend finishes, it tells the agent, which continues. Secrets
+   stay frontend-only. This doc references that mechanism and does not design it.
+
+A constraint that shapes every proposal: the team already decided (in
+`projects/agent-creation-skills/`, where a bespoke "create_workflow with logic" design was
+superseded on 2026-06-27) that platform tools are **thin wrappers over existing endpoints, with
+no new logic**, and that a **skill** composes the multi-step flow. Every tool below is one HTTP
+call to one endpoint that already ships. The one exception is `find_triggers`, which Mahmoud
+asked for as new backend; the doc says so plainly.
+
+## These tools all ship in a new agent's default config
+
+A consequence worth stating up front. The default-agent-config project freezes every platform op
+in the catalog into a new agent's default config at build time. So once the tools below land, a
+new agent ships with all of them: the three core ops (`find_capabilities`, `query_workflows`,
+`commit_revision`) plus the eight trigger and cron ops here. Several are approval-gated
+(`create_schedule`, `create_subscription`, `test_subscription`), and they all arrive with their
+catalog default permissions, which the user can edit. This is intended. The build flow needs it,
+because there is no picker to add a platform tool back: a tool that is not in the default can
+never reach the agent. So adding a tool to this catalog also changes what every new agent
+carries. See `../default-agent-config/design.md`.
+
+## How to read this
+
+- Section 1: the end-to-end walkthrough, each step mapped to a tool or skill, marked EXISTS or
+  MISSING.
+- Section 2: the triggers and cron reality (the backend already exists).
+- Section 3: each missing tool, with the `design-interfaces` role analysis and motivations.
+- Section 4: **the agent-driven trigger and subscription flow, walked end to end.** This is the
+  part Mahmoud most wants explored: what the agent asks, what happens when a connection is
+  missing, and whether a subscription can be tested before a connection exists.
+- Section 5: the missing skills.
+- Section 6: the split between us (backend, SDK, runner) and Arda (frontend).
+- Section 7: the smaller questions that remain.
+
+## 1. The end-to-end walkthrough
+
+The agent is configuring itself. The columns: the step, the serving tool or skill, and whether
+that piece exists today.
+
+| # | Build step | Serving tool / skill | State |
+|---|---|---|---|
+| 0 | Understand the goal, plan the build | skill: **build-your-first-app** (orchestrator) | MISSING (skill) |
+| 1 | Find the right action tools | `find_capabilities` tool | EXISTS |
+| 2 | See what already exists in the project | `query_workflows` tool | EXISTS |
+| 3 | Connect an integration the tools need | FE connection round-trip (agent requests, cannot create) | MISSING (FE-owned) |
+| 3b | Check whether a connection is ready | `list_connections` tool | MISSING (tool) |
+| 4 | Set a provider key / secret | frontend-only, by design | OUT (FE-only) |
+| 5 | Attach tools + edit own AGENTS.md + own skills | `commit_revision` tool (self-target) | EXISTS |
+| 6 | Find the right event to trigger on | `find_triggers` tool (keyword) | MISSING (new backend) |
+| 7 | Set up a cron job on itself | `create_schedule` tool (self-target) | MISSING (tool); backend EXISTS |
+| 8 | Set up an event trigger on itself | `create_subscription` tool (self-target) | MISSING (tool); backend EXISTS |
+| 9 | List / inspect its own triggers | `list_schedules` / `list_subscriptions` tools | MISSING (tool); backend EXISTS |
+| 10 | Test the trigger end to end | `test_subscription` tool + `list_deliveries` | MISSING (tool); backend EXISTS |
+| 11 | Commit the finished agent | `commit_revision` (self-target) | EXISTS |
+| - | Teach the trigger + cron flow | skill: **set-up-triggers** | MISSING (skill) |
+| - | Teach the discover-and-wire flow | skill: **discover-and-wire-tools** | DRAFT, not yet a platform skill |
+| - | Teach the create/commit/invoke flow | skill: **create-agenta-agent** | DRAFT, not yet a platform skill |
+
+The gaps cluster in three places: trigger and cron tools (backend ready, no agent-facing tools),
+the connection dependency (the agent requests through the FE, never creates), and the build-flow
+skills (drafts exist, none loaded as platform skills yet). Self-modification of instructions,
+tools, and skills is already covered by `commit_revision`.
+
+## 2. The triggers and cron reality
+
+Agenta has a complete trigger subsystem already. We are not designing a scheduler. We are
+exposing what ships.
+
+What exists, in `api/oss/src/`:
+
+- **Schedules (cron).** `core/triggers/dtos.py` defines `TriggerSchedule`; the router
+  (`apis/fastapi/triggers/router.py`) exposes `POST /api/triggers/schedules/` plus list, query,
+  fetch, edit, delete, start, stop. A schedule carries a five-field cron expression
+  (`data.schedule`, UTC, one-minute floor, validated by `croniter`), an optional
+  `[start_time, end_time)` window, an `inputs_fields` mapping template, and a
+  `references`/`selector` naming the workflow to run.
+- **Subscriptions (event-driven).** Same router exposes `POST /api/triggers/subscriptions/` and
+  the full lifecycle. A subscription watches one provider event (Composio today), keyed by a
+  `connection_id` and an `event_key`, with the same `inputs_fields` and `references`/`selector`.
+  An `is_test` flag puts it in capture-and-skip mode: events are recorded as test deliveries
+  with full context, and the workflow is never invoked.
+- **Test (one-shot).** `POST /api/triggers/subscriptions/test` creates a temporary test
+  subscription, long-polls for the first captured provider event, records it as a delivery, then
+  tears the temporary subscription down (`core/triggers/service.py`, `test_subscription`). It
+  needs a working connection, because it waits for a real event from the provider.
+- **Catalog.** `GET /api/triggers/catalog/providers/.../integrations/.../events/` browses the
+  events you can subscribe to. The leaf is an *event*, the trigger analogue of a tools *action*;
+  the event detail carries a `trigger_config` JSON Schema and an optional sample `payload`.
+- **Deliveries.** `GET /api/triggers/deliveries` and `/query` are the audit log: one row per
+  fire, with inputs, result, error, and a test marker. This is how the agent confirms a trigger
+  fired and reads a captured sample event.
+- **The machinery.** A per-minute cron tick (`crons/triggers.sh`) POSTs an admin
+  `schedules/refresh`; due schedules are enqueued onto Taskiq + Redis Streams; a worker
+  (`entrypoints/worker_triggers.py`) dispatches each to the bound workflow. The agent never
+  touches any of this. It only writes the schedule or subscription row.
+
+What does not exist: any agent-facing tool over these endpoints, and any search over events. The
+gap is the tool layer and the discovery story, not the engine.
+
+How a trigger binds to the agent (decision 2): the destination is `data.references` plus
+`data.selector`. For self-targeting, the runner binds those to the running agent's own workflow
+from run context, stripped from the model-visible schema, exactly as `commit_revision` binds and
+strips the variant id. The model never names a destination, so it can only ever schedule or
+subscribe *itself*.
+
+## 3. The missing tools
+
+Each tool is a platform-op catalog entry in
+`sdks/python/agenta/sdk/agents/platform/op_catalog.py`: a thin wrapper over one existing
+endpoint. The catalog owns the model-facing description, the method and path, the curated input
+schema, the run-context bindings, and the default permission and approval. Adding one is a data
+change to that catalog. `find_triggers` (3.4) is the lone exception that needs new backend.
+
+The `design-interfaces` rule applied throughout: classify each field by the role it plays (data,
+config, policy, credentials, routing, context, metadata), bind context server-side rather than
+trusting the model, and gate dangerous behavior behind approval rather than a blanket allow.
+
+### 3.1 `create_schedule` — set up a cron job on itself (backend exists)
+
+One call to `POST /api/triggers/schedules/`; the model's arguments land at `args_into:
+"schedule"`. The destination is bound, not supplied.
+
+| Field | Role | Owner | Notes |
+|---|---|---|---|
+| `name` | metadata | model | A human label for the schedule. |
+| `data.schedule` | config (period) | model | Five-field cron, UTC. The skill teaches the syntax. |
+| `data.start_time` / `data.end_time` | config (window) | model | Optional `[start, end)` bounds. |
+| `data.inputs_fields` | data (mapping) | model | Template that fills the run's inputs. |
+| `data.event_key` | metadata | model | A label for the fire; reused on deliveries. |
+| `data.references` + `data.selector` | routing (destination) | **context-bound** | The running agent's own workflow, from `$ctx`. Stripped from the model schema. |
+
+Default permission and approval: **`ask`, approval required.** This is the load-bearing safety
+call. A schedule makes the agent run on its own, unattended, possibly costing money or taking
+real-world actions. That is exactly the dangerous behavior `design-interfaces` says to gate
+behind an explicit allow, never a default-on. It mirrors `commit_revision`.
+
+The destination binding needs one implementation check: confirm the runner can express
+`data.references` as a `$ctx` binding to the running workflow (the key name and the dotted path
+the trigger's `/retrieve` resolver expects). `commit_revision` already binds
+`workflow_revision.workflow_variant_id` to `$ctx.workflow.variant.id`, so the mechanism exists;
+the exact reference key for triggers is the thing to verify.
+
+### 3.2 `create_subscription` — trigger itself on an external event (backend exists)
+
+One call to `POST /api/triggers/subscriptions/`, `args_into: "subscription"`. Same shape as a
+schedule, plus the connection.
+
+| Field | Role | Owner | Notes |
+|---|---|---|---|
+| `name` | metadata | model | Label. |
+| `connection_id` | routing / credentials | model, **value from the FE round-trip** | Identifies and authenticates the event source. The agent never creates it (decision 4); it passes the id it learned from the connection round-trip or from `list_connections`. |
+| `data.event_key` | config | model | The provider event to watch, from `find_triggers`. |
+| `data.trigger_config` | config | model | The event's parameters, shaped by the event's `trigger_config` schema. |
+| `data.inputs_fields` | data (mapping) | model | Fills the run's inputs from event context. |
+| `data.references` + `data.selector` | routing (destination) | **context-bound** | Self, same as 3.1. |
+
+Default permission and approval: **`ask`, approval required.** Same motivation as 3.1, stronger
+if anything, because the trigger fires on the provider's schedule, not the user's.
+
+The connection dependency is the crux of section 4. The agent holds only a *reference* to a
+connection (an id or slug); it never holds the secret and never creates the connection.
+
+### 3.3 The read and test tools
+
+Thin reads, default permission **`allow`, no approval**, matching `find_capabilities` and
+`query_workflows`. The agent needs to see its own triggers before adding more, and to read the
+delivery log to confirm a fire.
+
+- `list_schedules` — `GET /api/triggers/schedules/`.
+- `list_subscriptions` — `GET /api/triggers/subscriptions/`.
+- `list_deliveries` — `GET /api/triggers/deliveries` (and `/query` for filters). The agent reads
+  a captured sample event here.
+- `list_connections` — `POST /api/tools/connections/query`. The agent checks whether a
+  connection is `ready` before it tries to subscribe.
+
+`test_subscription` — `POST /api/triggers/subscriptions/test`. This one *does* something
+(creates a temporary test subscription and long-polls for a real event), but it invokes no
+workflow and leaves nothing behind. Default **`ask`** is the conservative choice, since it
+opens a real watch on the provider and blocks for up to a minute; `allow` is defensible because
+it is non-destructive. Lean `ask`. It requires a `connection_id`, so it cannot run before a
+connection exists (see section 4).
+
+### 3.4 `find_triggers` — keyword event discovery (new backend, decision 3)
+
+`find_capabilities` searches *actions* and returns ready-to-attach tool configs with connection
+state. There is no equivalent for *events*. Mahmoud chose to build a small one.
+
+- Endpoint: a new `POST /api/triggers/discover`, mirroring `POST /api/tools/discover`.
+- Search: **keyword**, not semantic, over the trigger event catalog.
+- Input roles: `use_cases` (data, the keyword fragments, e.g. "new github issue"), `provider`
+  (config, default `composio`), `limit_alternatives` (config). Identical in shape to
+  `find_capabilities`.
+- Output, `find_capabilities`-shaped per use case: the best-match event (its `event_key`,
+  integration, `trigger_config` schema, and sample `payload` if the catalog has one), the
+  connection state for that integration (`ready` / `needs_auth` / `needs_input`), alternatives,
+  and guidance. The connection state is what lets the agent decide whether to route to the FE
+  connection round-trip.
+- Platform tool: a thin wrapper over the new endpoint, default **`allow`** (read).
+
+Motivation for keyword over semantic: the event set is small, so keyword matching is enough and
+far cheaper to build than the semantic engine `find_capabilities` leans on. The simpler fallback
+Mahmoud named (a hardcoded skill that just lists the common events) stays in reserve if even the
+keyword endpoint proves to be more than the small set warrants. Start with `find_triggers`.
+
+## 4. The agent-driven trigger flow, end to end
+
+This is the section Mahmoud most wants. Take a concrete ask: *"Run yourself every time a new
+GitHub issue is opened in `acme/app`, and triage it."* The agent is configuring itself. Walk it.
+
+### 4.1 The flow, step by step
+
+1. **Clarify intent.** The agent asks what it needs to pin the event: which provider and event
+   ("a new issue is opened"), the scope ("which repo"), and what to do on each fire ("triage:
+   label it and post a summary"). Plain conversation, no tools yet.
+
+2. **Discover the event.** The agent calls `find_triggers(["new github issue opened"])`. It gets
+   back the `event_key`, the `trigger_config` schema (so it knows it must supply the repo), a
+   sample `payload` if available, and the **connection state** for GitHub.
+
+3. **Branch on connection state.** This is the fork that decides everything after.
+   - **Connection ready.** Continue to step 4.
+   - **Connection missing (`needs_auth` or `needs_input`).** The agent cannot create it
+     (decision 4). It emits a connection-request through the general client-tool round-trip: "I
+     need access to your GitHub to watch for new issues. I'll ask the app to connect it." The run
+     **pauses**. The user connects GitHub in the frontend (OAuth, or a key for `needs_input`).
+     The frontend signals the agent that the connection is ready and hands back its id or slug.
+     The agent resumes at step 4. This pause/resume is the FE round-trip design's mechanism; we
+     only consume it.
+
+4. **Build and confirm the input mapping.** The agent must translate a GitHub-issue event into
+   its own input message. It needs a *sample event* to show the user what that looks like. Two
+   sources, and they differ in whether a connection is required (see 4.2):
+   - the sample `payload` from the catalog (no connection needed), or
+   - a real captured event via the test path (needs the connection).
+   The agent shows the user the mapping in plain terms: "When an issue opens, I receive its
+   title, body, and labels. I'll treat the issue as my task, like this." The user adjusts; the
+   agent settles `inputs_fields`.
+
+5. **Test before going live.** Two modes, depending on what the user wants to prove (4.3):
+   - **Dry test** runs the agent once against a sample event, in the chat, so the user sees the
+     response. No live event, and if the sample comes from the catalog payload, no connection.
+   - **Live test** calls `test_subscription`, which watches the provider for a real event. The
+     user opens a throwaway issue; the agent reads the captured delivery and shows how it mapped
+     and would respond. This proves the real wiring, and it needs the connection.
+
+6. **Go live.** The agent calls `create_subscription`: self-targeted (bound to its own workflow),
+   `is_test` off, watching `event_key` on the connection, with the confirmed `inputs_fields`.
+   This is **approval-gated**: "From now on I'll run automatically on every new issue in
+   `acme/app`. Approve?" On approval the subscription is created and active.
+
+7. **Confirm and hand off.** The agent reports what is now live (`list_subscriptions`) and tells
+   the user where to manage it. The frontend shows the standing subscriptions and their delivery
+   history (a product surface Arda owns).
+
+A cron job (`create_schedule`) is the same flow without steps 2 and 3: no event, no connection.
+The only test available is a dry run of the agent itself, which runs into the test gap (4.4).
+
+### 4.2 Can a subscription be tested before a connection exists?
+
+Short answer: **a live test cannot; a dry test can.**
+
+- **Live test needs a connection.** `test_subscription` long-polls the provider for a real
+  captured event. With no connection there is no event source and nothing to capture. So the
+  connection round-trip (step 3) is a hard gate before any live test or any go-live.
+- **Dry test can skip the connection** *if* there is a sample event to run against. The catalog
+  event detail can carry a sample `payload`; when it does, the agent can map that sample and run
+  itself on it with no connection at all. When the catalog has no sample, the agent can fabricate
+  a representative payload from the `trigger_config` schema and say so.
+
+This split is worth making explicit in the skill, because it changes the order of operations.
+The agent can validate "do I handle this event shape sensibly?" early and offline (dry test),
+and defer "is the live wiring correct?" until after the connection exists (live test). It keeps
+the human round-trip off the critical path until the user has already seen the agent behave.
+
+### 4.3 The manual UI idea, translated to the agent
+
+The current manual idea is: "test connection" creates a (test) subscription; the user then picks
+a captured sample event, builds a message from it, and adds it to the chat to test, in a new or
+the same session. Two ways the agent can express that:
+
+- **Option A, capture-then-promote (closest to the manual flow).** The agent creates an
+  `is_test` subscription (or runs `test_subscription`), waits for a real event, captures it as a
+  delivery, builds the message from the captured event, dry-runs itself, then on approval
+  promotes to a live subscription. Motivation: it mirrors what users already do, and it tests
+  against a real provider payload. Cost: it needs the connection up front, so the round-trip
+  lands before the user has seen anything work, and it leans on real events arriving.
+- **Option B, sample-first (offline first).** The agent uses the catalog sample payload to build
+  and dry-test the mapping with no connection, shows the user the behavior, and only then asks
+  for the connection and goes live (optionally with one live test at the end). Motivation: the
+  user sees the agent work before being asked to authorize anything, which is a gentler first-run
+  experience, and the connection round-trip moves off the critical path. Cost: the early test
+  uses a sample, not a real event, so a final live test is still worth doing.
+
+Recommendation: **Option B as the default path in the skill, Option A as the "prove it live"
+follow-up.** It fits the locked decisions (the agent asks for the connection only when it must)
+and gives the smoothest first build.
+
+A second UX choice inside the test step: **same session or new session.** Running the dry test
+as the next turn of the current chat needs no new machinery (the agent just continues the
+conversation with the synthesized message) but mixes test output into the build conversation. A
+clean new session isolates the test but needs a way to invoke the agent fresh, which is the test
+gap below. Lean: same-session dry test for v1, new-session as a later nicety.
+
+### 4.4 The test gap
+
+Steps 5 and the cron case both want to "run the agent once to show the user." There is no clean
+public endpoint for that: invocation goes through the agent sidecar
+(`/services/agent/v0/invoke`) or the internal workflows service, and a platform-op path is
+confined to the `/api` mount. So a *new-session* dry test and a cron dry run have no thin-wrapper
+home today. Same-session dry tests dodge this (the agent simply continues the chat). Options, to
+decide later: expose a public `/api` invoke wrapper (new surface), keep dry tests same-session
+only, or accept that the user runs the final check in the playground. Flagging, not solving.
+
+## 5. The missing skills
+
+Skills are code-defined platform skills under the reserved `__ag__*` namespace, served read-only
+through `StaticWorkflowCatalog` (`api/oss/src/core/workflows/static_catalog.py`), authored as
+`SkillTemplate` constants next to
+`sdks/python/agenta/sdk/agents/adapters/agenta_builtins.py`, with the SKILL.md files under
+`services/agent/skills/<name>/`. Only one exists today (`agenta-getting-started`, a placeholder).
+A skill teaches the model which tools to use and in what order; it adds no behavior.
+
+### 5.1 `build-your-first-app` — the orchestrator skill (new)
+
+The top-level skill that drives the whole self-build. What it teaches:
+
+1. Clarify the goal (what should the agent do, on what trigger, with what tools).
+2. Discover action tools with `find_capabilities`; discover events with `find_triggers`; check
+   what exists with `query_workflows` and `list_connections`.
+3. When a connection is missing, request it through the FE round-trip and wait. Never try to
+   create it.
+4. Configure itself with `commit_revision`: instructions, tools, skills.
+5. Set up the trigger or cron via the **set-up-triggers** skill, self-targeted.
+6. Test (sample-first dry test, then a live test once connected) and confirm.
+7. Commit and tell the user what it became and what is now scheduled or subscribed.
+
+It names the stop points: connection requests, schedules, subscriptions, and commits all pause
+for the human. Motivation: the model needs the sequence and the approval gates, and a single
+orchestration skill is where that lives. It turns "build me an app" into a guided flow instead
+of the model guessing the order of a dozen calls.
+
+### 5.2 `set-up-triggers` — the trigger and cron skill (new)
+
+The focused skill for steps 6 to 10. What it teaches:
+
+- Schedule (cron, our own tick, no connection) versus subscription (external event, needs a
+  connection).
+- Cron syntax, UTC, the one-minute floor, the optional window.
+- Finding an event with `find_triggers`, and reading its `trigger_config` schema.
+- Mapping event or time context into the run's inputs via `inputs_fields`.
+- That the destination is the agent itself and is set automatically; the model supplies no
+  destination.
+- The test split from section 4: dry test against a sample payload (no connection), live test
+  via `test_subscription` (needs the connection), and the capture-then-promote versus
+  sample-first orders.
+- Confirming a fire with `list_deliveries`.
+
+Motivation: triggers carry real footguns (timezone, cron syntax, the connection prerequisite,
+the inputs mapping, the test ordering). A skill turns those into a checklist the model follows.
+
+### 5.3 Promote the two draft skills to platform skills
+
+Two skills already exist as drafts and should become `__ag__*` platform skills so the builder
+agent carries them:
+
+- `discover-and-wire-tools` (in `projects/tool-discovery/skills/`) — the discover,
+  resolve-connections, create, test loop around `find_capabilities`. It already flags trigger use
+  cases as out of its scope; with `find_triggers` and `set-up-triggers` landing, update that note
+  to hand off to the trigger skill instead of dead-ending.
+- `create-agenta-agent` (in `projects/agent-creation-skills/skills/`) — the create, commit,
+  invoke loop and the config schema. For self-modification, the load-bearing half is the commit
+  and the config schema; trim the create-a-new-workflow half to match decision 1.
+
+Both drafts predate JP's config rename. Before they ship, update the field names: config nests
+under `parameters.agent`, the type-ref is `agent-template` (not `agent_config`),
+`ModelRef.params` is now `extras`, and `permission_policy` rides `runner.interactions.headless`.
+
+## 6. The split: us versus Arda (frontend)
+
+**Us (backend, SDK, runner):**
+
+- Add the trigger tools to the platform-op catalog: `create_schedule`, `create_subscription`
+  (both self-targeted, approval-gated), `list_schedules`, `list_subscriptions`,
+  `list_deliveries`, `list_connections`, `test_subscription` (sections 3.1 to 3.3).
+- Build `find_triggers`: the new `POST /api/triggers/discover` keyword endpoint plus its thin
+  platform tool (3.4).
+- Verify the self-target binding for triggers: that `data.references` can be bound from `$ctx`
+  to the running workflow, and find the reference key the trigger `/retrieve` resolver expects.
+- Author the two new skills (`build-your-first-app`, `set-up-triggers`) and promote the two draft
+  skills, all as `__ag__*` platform skills, updated to the current config field names.
+- Decide the test gap (4.4): same-session dry test only, or a public invoke wrapper.
+
+**Arda (frontend):**
+
+- The connection round-trip: the general client-tool mechanism by which the agent asks for a
+  connection, the run pauses, the user connects in the UI, and the frontend resumes the agent
+  with the connection reference. This is the other research subagent's design; we consume it.
+- Secret entry: collect provider keys directly into the vault, never through the model.
+- The config-change and action approval UI (the `projects/hitl-fix/` work): the approval prompts
+  for `commit_revision`, `create_schedule`, `create_subscription`, and `test_subscription` land
+  here.
+- The triggers surface: where standing schedules and subscriptions, and their delivery history,
+  show up in the playground so the user can see and manage what the agent set up. A product
+  decision for Arda.
+- The new-session test experience, if we want one (tied to the test gap, 4.4).
+
+## 7. The smaller questions that remain
+
+The four big questions are settled (top of this doc). What is left is finer:
+
+1. **Test order in the skill (4.3).** Confirm sample-first (Option B) as the default, with a live
+   test as the "prove it" follow-up. This is a skill-authoring choice, low risk to change later.
+2. **Same-session versus new-session dry test (4.3 / 4.4).** Lean same-session for v1 to avoid a
+   new invoke surface. Worth a yes from Mahmoud before we write the skill that way.
+3. **`test_subscription` permission (3.3).** `ask` (it opens a real provider watch and blocks) or
+   `allow` (it is non-destructive)? Lean `ask`.
+4. **`find_triggers` scope (3.4).** Build the keyword endpoint now, or start with the hardcoded
+   enumeration skill and add the endpoint only if the event set grows? Mahmoud said start with
+   `find_triggers`; confirm we want the endpoint in this round rather than the skill-only stand-in.
+5. **The test gap (4.4).** Do we want a public `/api` invoke wrapper in this round, or is
+   same-session dry testing plus the playground enough for v1?

--- a/docs/design/agent-workflows/projects/agent-builder-capabilities/README.md
+++ b/docs/design/agent-workflows/projects/agent-builder-capabilities/README.md
@@ -78,10 +78,13 @@ These are settled across the initiative (`agent-builds-an-app`). The design assu
   variant id. The model never names a destination, so it can only schedule or subscribe itself.
 - **The agent cannot create connections or set secrets.** When a connection is missing, the agent
   requests one through the frontend round-trip and waits. It holds only a connection reference, never
-  the secret. The round-trip is owned by `agent-fe-roundtrip`; this design consumes it.
-- **Builder tools are injected, not committed.** They are platform operations, a build-time aid.
-  They reach a playground run through the injected build kit and never enter the user's stored
-  config (section 6). The default-config model is owned by `default-agent-config`.
+  the secret. The request itself rides `request_connection`, a non-runnable reference tool the
+  overlay embeds via `@ag.embed`, not one of the platform ops in this set. The round-trip is owned
+  by `agent-fe-roundtrip` (#4920); this design consumes it.
+- **Builder tools ride the build-kit overlay, not the committed config.** They are platform
+  operations, a build-time aid. They reach a playground run through the build-kit overlay the
+  frontend applies, and never enter the user's stored config (section 6). The overlay model is
+  owned by `default-agent-config`.
 - **Mutating tools default to approval.** `create_schedule`, `create_subscription`, and
   `test_subscription` each pause for the user before they act.
 
@@ -91,7 +94,7 @@ Every builder tool is a `PlatformOp`: one entry in
 `sdks/python/agenta/sdk/agents/platform/op_catalog.py`, one HTTP call to one endpoint that already
 ships. The catalog entry owns the model-facing description, the method and path, a curated input
 schema, the run-context bindings, and the default permission and approval. Adding a tool is a data
-change to that catalog. `find_triggers` (4.6) is the one exception that needs new backend.
+change to that catalog. `find_triggers` (4.5) is the one exception that needs new backend.
 
 Each tool's contract is laid out by the role each field plays: **input** (the data the model
 provides), **config** (how the trigger behaves), **routing** (where it points), **credentials**
@@ -105,6 +108,10 @@ trusted from the model. The connection is a credential reference, an id only, ne
 | `create_schedule` | `POST /api/triggers/schedules/` | mutate | ask, approval |
 | `create_subscription` | `POST /api/triggers/subscriptions/` | mutate | ask, approval |
 | `test_subscription` | `POST /api/triggers/subscriptions/test` | probe | ask, approval |
+| `remove_schedule` | `DELETE /api/triggers/schedules/{id}` | mutate | ask, approval |
+| `remove_subscription` | `DELETE /api/triggers/subscriptions/{id}` | mutate | ask, approval |
+| `pause_schedule` / `resume_schedule` | `POST /api/triggers/schedules/{id}/stop` / `/start` | mutate | ask, approval |
+| `pause_subscription` / `resume_subscription` | `POST /api/triggers/subscriptions/{id}/stop` / `/start` | mutate | ask, approval |
 | `list_schedules` | `GET /api/triggers/schedules/` | read | allow |
 | `list_subscriptions` | `GET /api/triggers/subscriptions/` | read | allow |
 | `list_deliveries` | `GET /api/triggers/deliveries` | read | allow |
@@ -166,7 +173,7 @@ no row behind. It requires a `connection_id`, so it cannot run before a connecti
 
 Default permission: **ask, approval required.** The tool opens a real provider watch and blocks, so
 it warrants a confirm even though it is non-destructive. Treating it as a mutating tool keeps the
-gate consistent with the two create tools. (Section 8 keeps `allow` as the alternative.)
+gate consistent with the two create tools. (Decided as `ask`; see section 8.)
 
 ### 4.5 `find_triggers`: keyword event discovery (new backend)
 
@@ -195,6 +202,26 @@ alternatives, and short guidance. The connection state is what lets the agent de
 route the user to the connection round-trip.
 
 Default permission: **allow.** It only reads.
+
+### 4.6 Undo: remove, pause, and resume
+
+The agent set the schedule or subscription up, so it can also take it back down. These tools target
+the same self-bound destination as the create tools and map one-to-one onto delete and lifecycle
+endpoints that already ship (section 2). Each is mutating and approval-gated.
+
+- `remove_schedule` and `remove_subscription` delete a trigger the agent created, by id, over
+  `DELETE /api/triggers/schedules/{id}` and `DELETE /api/triggers/subscriptions/{id}`.
+- `pause_schedule` / `resume_schedule` and `pause_subscription` / `resume_subscription` stop or
+  start a trigger without deleting it, over the existing `/{id}/stop` and `/{id}/start` endpoints.
+  Pause leaves the row in place so the agent can resume it later.
+
+| Field | Role | Owner | Notes |
+|---|---|---|---|
+| `id` | routing (target) | model, from `list_schedules` / `list_subscriptions` | The schedule or subscription to act on. The agent reads it from its own trigger list first. |
+
+Default permission: **ask, approval required.** Removing or pausing a live trigger changes what the
+agent does unattended, so it gates the same way the create tools do. The agent reads its current
+triggers with `list_schedules` / `list_subscriptions` before it removes or pauses one.
 
 ## 5. The build flow, end to end
 
@@ -263,32 +290,34 @@ Steps 5 and the cron case both want to "run the agent once to show the user." Th
 public endpoint for that today. Invocation goes through the agent sidecar or the internal workflows
 service, and a platform operation is confined to the `/api` mount. So a dry run in a fresh session
 has no thin-wrapper home. A same-session dry test dodges this, because the agent simply continues
-the chat with the synthesized message. The options, to settle in implementation: keep dry tests
-same-session only, expose a public `/api` invoke wrapper, or let the user run the final check in
-the playground. Section 8 carries the recommendation.
+the chat with the synthesized message. That is the decision for v1 (section 8): keep dry tests
+same-session only and defer the public `/api` invoke wrapper.
 
 ## 6. How these tools reach the agent
 
 The builder tools are platform operations, a build-time aid, not part of the user's shipped agent.
-So they follow the inject-not-commit model that `default-agent-config` owns. The agent uses them
-to build itself, but they never enter the stored config.
+So they ride the build-kit overlay that `default-agent-config` owns. The agent uses them to build
+itself, but they never enter the stored config.
 
-The mechanics are already in place. The build kit reads `PLATFORM_OPS` at call time and injects the
-platform tools into the playground run, before tool resolution. Adding the builder tools to
-`PLATFORM_OPS` is therefore the whole integration: the new tools join the kit with no extra wiring.
-The Advanced drawer shows them as a read-only group; the user toggles the whole kit on or off but
-does not edit a tool. A normal production run of the published agent never injects the kit, so it
-never carries these tools. When the agent commits, the commit writes only the user's config; the
-builder tools are absent by construction.
+The mechanics are already in place. The backend assembles the overlay by iterating `PLATFORM_OPS`,
+adding each op to the overlay's `tools` list as a `{ "type": "platform", "op": ... }` entry. Adding
+the builder tools to `PLATFORM_OPS` is therefore the whole integration: the new tools join the
+overlay with no extra wiring. The backend serves the overlay read-only on the inspect response at
+`additional_context.playground_build_kit.agent_template_overlay`; the frontend applies it on a
+kit-on playground run and excludes it on commit. There is no backend injection and no run flag. The
+Advanced drawer shows the tools as a read-only group; the user toggles the whole kit on or off but
+does not edit a tool. A production run of the published agent has no overlay, so it never carries
+these tools. When the agent commits, the commit writes only the user's config; the builder tools
+are absent by construction.
 
-One consequence is worth stating plainly. After this project lands, a new agent's build kit will
+One consequence is worth stating plainly. After this project lands, a new agent's overlay will
 carry around a dozen platform tools, several of them approval-gated. That is intended. The build
 flow has no picker, so the agent cannot add a platform tool to itself mid-run; the tools must be
 present from the start. `default-agent-config` confirms the same seam.
 
 The per-tool approval lives on the catalog entry, not in the drawer. `create_schedule`,
-`create_subscription`, and `test_subscription` each carry `default_needs_approval=True`, so they
-pause for the user wherever the kit is injected.
+`create_subscription`, `test_subscription`, the remove tools, and the pause and resume tools each
+carry `default_needs_approval=True`, so they pause for the user wherever the overlay applies.
 
 ## 7. Dependencies, ownership, and the work split
 
@@ -299,13 +328,14 @@ This project owns the tools. It depends on two sibling projects and shares one s
 - **The skills** (`agent-skills`) teach the order of these tool calls and the stop points. The
   `set-up-triggers` and `build-your-first-app` skills name the tools below and assume they are
   present. This project ships the tools; that project ships the prose.
-- **The build kit** (`default-agent-config`) is the seam in section 6. This project adds ops to
-  `PLATFORM_OPS`; that project injects them.
+- **The build-kit overlay** (`default-agent-config`) is the seam in section 6. This project adds ops
+  to `PLATFORM_OPS`; that project assembles them into the overlay the frontend applies.
 
 **What we build (backend, SDK):**
 
-- Add the eight builder tools to `PLATFORM_OPS`: `create_schedule`, `create_subscription` (both
-  self-targeted, approval-gated), `test_subscription`, the four reads, and `find_triggers`.
+- Add the builder tools to `PLATFORM_OPS`: `create_schedule`, `create_subscription` (both
+  self-targeted, approval-gated), `test_subscription`, `remove_schedule`, `remove_subscription`,
+  the pause and resume pair for each, the four reads, and `find_triggers`.
 - Build the `find_triggers` backend: the new `POST /api/triggers/discover` endpoint that joins a
   keyword catalog match with shared connection state.
 - Verify the self-target binding. Confirm the trigger resolver accepts a `references`/`selector`
@@ -317,20 +347,25 @@ This project owns the tools. It depends on two sibling projects and shares one s
 **What the frontend owns (Arda):**
 
 - The connection round-trip and connection entry (the secret never reaches the model).
-- The approval prompts for the three mutating tools.
+- The approval prompts for the mutating tools.
 - The playground surface that shows standing schedules and subscriptions with their delivery
   history.
 
-## 8. Open questions
+## 8. Decided
 
-The big decisions are settled (section 3). These are finer and non-blocking; each settles during
-implementation. Recommendations included.
+These settled during the review. They are recorded here so they are not reopened.
+
+- **Dry test is same-session for v1.** A same-session dry test continues the chat with the
+  synthesized message, so it needs no new invoke surface (5.3).
+- **`test_subscription` permission is `ask`.** It opens a real provider watch and blocks, so it
+  warrants a confirm even though it is non-destructive (4.4).
+- **Defer the public invoke wrapper.** The test gap (5.3) is real, but a same-session dry test
+  dodges it, so the public `/api` invoke wrapper waits.
+
+## 9. Open questions
+
+The big decisions are settled (section 3 and section 8). This one is finer and non-blocking; it
+settles during implementation. Recommendation included.
 
 1. **Test order in the skill.** Sample-first as the default, with a live test as the prove-it
    follow-up (5.1). A skill-authoring choice, low risk to change later. Recommend sample-first.
-2. **Same-session or new-session dry test.** Same-session for v1 avoids a new invoke surface
-   (5.3). Recommend same-session.
-3. **`test_subscription` permission.** `ask` (it opens a real provider watch and blocks) or `allow`
-   (it is non-destructive)? Recommend `ask`.
-4. **The test gap.** A public `/api` invoke wrapper now, or same-session dry testing plus the
-   playground for v1 (5.3)? Recommend deferring the wrapper.

--- a/docs/design/agent-workflows/projects/agent-builder-capabilities/status.md
+++ b/docs/design/agent-workflows/projects/agent-builder-capabilities/status.md
@@ -6,9 +6,9 @@ first.
 
 ## What this project owns
 
-The agent-facing tools that let an Agenta agent set up triggers and cron jobs on itself, discover
-the events it can react to, and read its own trigger state. Eight platform tools, one of which
-(`find_triggers`) needs a small new backend endpoint.
+The agent-facing tools that let an Agenta agent set up triggers and cron jobs on itself, take them
+back down, discover the events it can react to, and read its own trigger state. A set of platform
+tools, one of which (`find_triggers`) needs a small new backend endpoint.
 
 ## What it does NOT own
 
@@ -17,7 +17,7 @@ the events it can react to, and read its own trigger state. Eight platform tools
 - The connection round-trip (pause, connect in the playground, resume). Owned by
   `agent-fe-roundtrip`. The connection branch of the build flow depends on it.
 - How defaults reach a new agent. Owned by `default-agent-config`. The builder tools join
-  `PLATFORM_OPS` and ride the injected build kit; they are never committed to config.
+  `PLATFORM_OPS` and ride the build-kit overlay; they are never committed to config.
 
 ## Headline finding
 
@@ -29,9 +29,11 @@ plus one new endpoint (`find_triggers`) for keyword event discovery.
 ## The tool set
 
 `find_triggers` (new backend), `create_schedule`, `create_subscription`, `test_subscription`,
-`list_schedules`, `list_subscriptions`, `list_deliveries`, `list_connections`. The three mutating
-tools default to approval. Self-targeting binds the destination from run context, the way
-`commit_revision` binds the variant id. See `README.md` section 4 for each contract.
+`remove_schedule`, `remove_subscription`, the pause and resume pair for each, the four `list_*`
+reads. The mutating tools default to approval. Self-targeting binds the destination from run
+context, the way `commit_revision` binds the variant id. See `README.md` section 4 for each
+contract. The remove, pause, and resume tools map onto the delete and start/stop endpoints that
+already ship, so the agent can undo a schedule or subscription it set up.
 
 ## The key UX finding
 
@@ -46,19 +48,24 @@ any authorization. See section 5.1.
 2. Triggers self-target via run-context binding.
 3. `find_triggers` is a small new keyword endpoint, `find_capabilities`-shaped.
 4. The agent cannot create connections or set secrets; it holds a reference and asks the frontend.
-5. Builder tools are injected through the build kit, never committed to config.
+5. Builder tools ride the build-kit overlay, never committed to config.
 6. Mutating tools default to approval.
+
+## Decided (see `README.md` section 8)
+
+Dry test is same-session for v1, `test_subscription` permission is `ask`, and the public invoke
+wrapper is deferred.
 
 ## Open questions (non-blocking)
 
-See `README.md` section 8: test order (sample-first), same-session vs new-session dry test,
-`test_subscription` permission (`ask`), and the test gap (defer the public invoke wrapper).
+See `README.md` section 9: test order in the skill (sample-first).
 
 ## State
 
 - [x] Research: triggers/cron engine, catalog, deliveries, connections, `commit_revision` binding.
-- [x] Tool set and per-tool contracts (design-interfaces role analysis).
+- [x] Tool set and per-tool contracts (design-interfaces role analysis), including the remove,
+  pause, and resume undo tools.
 - [x] The agent-driven build flow walked end to end, with the dry-vs-live test finding.
-- [x] Inject-not-commit alignment with `default-agent-config`.
+- [x] Build-kit overlay alignment with `default-agent-config`.
 - [ ] Orchestrator folds this into the consolidated review.
 - [ ] Convert the tool set into per-tool implementation slices.

--- a/docs/design/agent-workflows/projects/agent-builder-capabilities/status.md
+++ b/docs/design/agent-workflows/projects/agent-builder-capabilities/status.md
@@ -1,0 +1,59 @@
+# Status: agent-builder-capabilities
+
+Design only. No code, no PR. Grounded in code on branch `gitbutler/edit` (over `big-agents`),
+2026-06-28. File paths are absolute.
+
+## What this project owns
+
+The tools and skills an Agenta agent needs so it can build an app end to end by chatting with
+a user: wire tools and connections, edit its own instructions, set up a trigger or a cron job,
+and commit the result. This is the "agent builds an agent" use case.
+
+## What it does NOT own
+
+- Which defaults get loaded into a NEW agent at create time. That is
+  `projects/default-agent-config/` (read it, do not edit it).
+- The interactive frontend round-trip (config-change approval, connection-request client
+  tool, OAuth redirect pause/resume). That is the separate FE round-trip design. This doc
+  names the dependency and defers the mechanism.
+
+## State
+
+- [x] Research: triggers/cron, skills, config shape, existing endpoints, sibling docs.
+- [x] Round 1 draft: walkthrough, missing tools, missing skills, FE split, open questions.
+- [x] Round 2: Mahmoud's four decisions locked in; agent-driven trigger UX walked end to end.
+- [ ] Orchestrator folds this into the consolidated draft PR for review.
+- [ ] Convert decisions into per-tool and per-skill implementation slices.
+
+## Headline finding
+
+Triggers and cron already exist as a full backend subsystem (`api/oss/src/.../triggers/`):
+event subscriptions, cron schedules, deliveries, a Composio catalog, a worker, and a cron
+tick. We do not build a scheduler. We expose thin platform tools over endpoints that already
+ship, plus the skills that teach the build flow. The one new backend piece is `find_triggers`
+(a keyword event-discovery endpoint).
+
+## Decisions locked (round 2)
+
+1. **Self-modification only.** The agent becomes the app; no create-other-workflow tools.
+2. **Triggers self-target** via run-context binding (like `commit_revision`).
+3. **`find_triggers`** = small new keyword-search backend, `find_capabilities`-shaped.
+4. **Agent cannot create connections or set secrets.** It requests a connection through the FE
+   round-trip; secrets stay FE-only.
+
+## Tools to add (all thin platform-op wrappers except find_triggers)
+
+`create_schedule`, `create_subscription` (self-targeted, approval-gated), `list_schedules`,
+`list_subscriptions`, `list_deliveries`, `list_connections`, `test_subscription`, and the new
+`find_triggers` endpoint + tool.
+
+## Skills to add
+
+`build-your-first-app` (orchestrator), `set-up-triggers`; promote the `discover-and-wire-tools`
+and `create-agenta-agent` drafts to `__ag__*` platform skills (update to the renamed config
+fields first).
+
+## Smaller questions still open
+
+See `README.md` section 7: test order (sample-first), same-session vs new-session dry test,
+`test_subscription` permission, `find_triggers` endpoint vs skill-only, and the test gap.

--- a/docs/design/agent-workflows/projects/agent-builder-capabilities/status.md
+++ b/docs/design/agent-workflows/projects/agent-builder-capabilities/status.md
@@ -1,59 +1,64 @@
 # Status: agent-builder-capabilities
 
-Design only. No code, no PR. Grounded in code on branch `gitbutler/edit` (over `big-agents`),
-2026-06-28. File paths are absolute.
+Design only. No code. Grounded in code on `gitbutler/edit` over `big-agents`, 2026-06-28. Paths
+are absolute. Part of the `agent-builds-an-app` initiative; read `agent-builds-an-app/README.md`
+first.
 
 ## What this project owns
 
-The tools and skills an Agenta agent needs so it can build an app end to end by chatting with
-a user: wire tools and connections, edit its own instructions, set up a trigger or a cron job,
-and commit the result. This is the "agent builds an agent" use case.
+The agent-facing tools that let an Agenta agent set up triggers and cron jobs on itself, discover
+the events it can react to, and read its own trigger state. Eight platform tools, one of which
+(`find_triggers`) needs a small new backend endpoint.
 
 ## What it does NOT own
 
-- Which defaults get loaded into a NEW agent at create time. That is
-  `projects/default-agent-config/` (read it, do not edit it).
-- The interactive frontend round-trip (config-change approval, connection-request client
-  tool, OAuth redirect pause/resume). That is the separate FE round-trip design. This doc
-  names the dependency and defers the mechanism.
-
-## State
-
-- [x] Research: triggers/cron, skills, config shape, existing endpoints, sibling docs.
-- [x] Round 1 draft: walkthrough, missing tools, missing skills, FE split, open questions.
-- [x] Round 2: Mahmoud's four decisions locked in; agent-driven trigger UX walked end to end.
-- [ ] Orchestrator folds this into the consolidated draft PR for review.
-- [ ] Convert decisions into per-tool and per-skill implementation slices.
+- The skills that teach the build flow. Owned by `agent-skills`. This project ships the tools; that
+  project ships the prose that drives them.
+- The connection round-trip (pause, connect in the playground, resume). Owned by
+  `agent-fe-roundtrip`. The connection branch of the build flow depends on it.
+- How defaults reach a new agent. Owned by `default-agent-config`. The builder tools join
+  `PLATFORM_OPS` and ride the injected build kit; they are never committed to config.
 
 ## Headline finding
 
-Triggers and cron already exist as a full backend subsystem (`api/oss/src/.../triggers/`):
-event subscriptions, cron schedules, deliveries, a Composio catalog, a worker, and a cron
-tick. We do not build a scheduler. We expose thin platform tools over endpoints that already
-ship, plus the skills that teach the build flow. The one new backend piece is `find_triggers`
-(a keyword event-discovery endpoint).
+The trigger and cron engine already ships as a full backend (`api/oss/src/.../triggers/`): event
+subscriptions, cron schedules, deliveries, a Composio event catalog, a worker, and a per-minute
+tick. We do not build a scheduler. We add thin platform tools over endpoints that already ship,
+plus one new endpoint (`find_triggers`) for keyword event discovery.
 
-## Decisions locked (round 2)
+## The tool set
 
-1. **Self-modification only.** The agent becomes the app; no create-other-workflow tools.
-2. **Triggers self-target** via run-context binding (like `commit_revision`).
-3. **`find_triggers`** = small new keyword-search backend, `find_capabilities`-shaped.
-4. **Agent cannot create connections or set secrets.** It requests a connection through the FE
-   round-trip; secrets stay FE-only.
+`find_triggers` (new backend), `create_schedule`, `create_subscription`, `test_subscription`,
+`list_schedules`, `list_subscriptions`, `list_deliveries`, `list_connections`. The three mutating
+tools default to approval. Self-targeting binds the destination from run context, the way
+`commit_revision` binds the variant id. See `README.md` section 4 for each contract.
 
-## Tools to add (all thin platform-op wrappers except find_triggers)
+## The key UX finding
 
-`create_schedule`, `create_subscription` (self-targeted, approval-gated), `list_schedules`,
-`list_subscriptions`, `list_deliveries`, `list_connections`, `test_subscription`, and the new
-`find_triggers` endpoint + tool.
+A live test (`test_subscription`) needs the connection, because it long-polls the provider for a
+real event. A dry test does not: the agent runs against the catalog's sample payload. So the
+default build order is sample-first. The agent shows the user the agent working before asking for
+any authorization. See section 5.1.
 
-## Skills to add
+## Decisions honored (from the initiative)
 
-`build-your-first-app` (orchestrator), `set-up-triggers`; promote the `discover-and-wire-tools`
-and `create-agenta-agent` drafts to `__ag__*` platform skills (update to the renamed config
-fields first).
+1. The agent becomes the app. Self-modification only.
+2. Triggers self-target via run-context binding.
+3. `find_triggers` is a small new keyword endpoint, `find_capabilities`-shaped.
+4. The agent cannot create connections or set secrets; it holds a reference and asks the frontend.
+5. Builder tools are injected through the build kit, never committed to config.
+6. Mutating tools default to approval.
 
-## Smaller questions still open
+## Open questions (non-blocking)
 
-See `README.md` section 7: test order (sample-first), same-session vs new-session dry test,
-`test_subscription` permission, `find_triggers` endpoint vs skill-only, and the test gap.
+See `README.md` section 8: test order (sample-first), same-session vs new-session dry test,
+`test_subscription` permission (`ask`), and the test gap (defer the public invoke wrapper).
+
+## State
+
+- [x] Research: triggers/cron engine, catalog, deliveries, connections, `commit_revision` binding.
+- [x] Tool set and per-tool contracts (design-interfaces role analysis).
+- [x] The agent-driven build flow walked end to end, with the dry-vs-live test finding.
+- [x] Inject-not-commit alignment with `default-agent-config`.
+- [ ] Orchestrator folds this into the consolidated review.
+- [ ] Convert the tool set into per-tool implementation slices.


### PR DESCRIPTION
## What this designs

A new agent on Agenta should turn itself into a real app by chatting with the user: discover the tools it needs, connect the integrations, edit its own instructions, set a trigger or a cron job, and commit. This doc designs the trigger-and-cron half of that flow: the agent-facing builder tools, plus the one event-discovery endpoint the flow is missing.

> Aligned to the approved #4917 build-kit overlay model: the builder tools join `PLATFORM_OPS`, ride the overlay the backend serves read-only on the inspect response, and are applied by the frontend on a playground run and excluded on commit. The agent service stays dumb (no run flag, no service-side merge). Every tool carries a design-interfaces role analysis.

## The finding

The trigger and cron engine already ships as a full backend: event subscriptions, cron schedules, delivery logs, a Composio event catalog, a worker, and a per-minute tick. We do not build a scheduler. The gap is narrow. There is no agent-facing tool layer over that engine, and there is no way to search the event catalog. This design fills both.

## What it adds

Builder tools over endpoints that already ship, plus one new backend piece.

- `create_schedule` and `create_subscription`: mutating, self-targeted, approval-gated.
- `test_subscription`: a probe that opens a real provider watch and blocks; approval-gated.
- `remove_schedule` and `remove_subscription`, plus a pause and resume pair for each (over the existing delete and start/stop endpoints): the agent can take back down a schedule or subscription it set up. Mutating, approval-gated. **New in this pass.**
- `list_schedules`, `list_subscriptions`, `list_deliveries`, `list_connections`: reads, default allow.
- `find_triggers`: the one new backend piece. A keyword search over the event catalog at `POST /api/triggers/discover`, shaped like `find_capabilities`. It joins the catalog match with shared connection state, so the agent learns the event and whether it can subscribe to it in one call.

Two role rules run through the whole set. The destination is routing, and it is bound server-side from run context the way `commit_revision` binds the variant id, so the model can only target the running agent itself. The connection is a credential reference (an id, never a secret). The agent holds the reference and asks the frontend to make the connection through `request_connection`, a non-runnable reference tool the overlay embeds via `@ag.embed` (owned by #4920), not one of the platform ops in this set.

## The part to read closely

Section 5 walks the agent-driven build flow end to end on a concrete ask: run yourself on every new GitHub issue in `acme/app`, and triage it. The key finding is the dry-vs-live test split. A live test (`test_subscription`) needs the connection, because it long-polls the provider for a real event. A dry test does not: the agent runs itself against the catalog's sample payload with no connection. That split sets the build order. The recommendation is sample-first: build and dry-test the mapping offline, show the user the agent working, then ask for the connection and go live with one live test as the prove-it follow-up.

## Decided this pass

The finer questions are settled and recorded in section 8: dry test is same-session for v1, `test_subscription` permission is `ask`, and the public invoke wrapper is deferred. One open question remains (section 9): test order in the build skill (lean sample-first).

## Scope / risk

Doc only, no code. The builder tools reach a run through the build-kit overlay the frontend applies and never enter stored config, so a published production agent never carries them (section 6). This design depends on the connection round-trip (owned by the frontend round-trip PR) and the skills that teach the flow (owned by the platform skills PR).

## Related PRs

Part of the "agent builds an app" initiative. Read the map first: #4921.

- Overview (the map): #4921
- Default agent config: #4917
- Platform skills: #4918
- Frontend round-trip: #4920

https://claude.ai/code/session_01GYo3UEfvsZpncagqb28Mbc
