### PR TITLE
docs(agent): frontend round-trip design (client tools, commit refresh, connections)

### DIFF
--- a/docs/design/agent-workflows/projects/agent-fe-roundtrip/design.md
+++ b/docs/design/agent-workflows/projects/agent-fe-roundtrip/design.md
@@ -1,0 +1,648 @@
+# The interactive frontend round-trip
+
+Status: design draft, round 3, 2026-06-28. Owner: agent-workflows. Audience: Arda (most of
+the frontend work), us (SDK, runner, API). The decisions below are locked. Round 3 adds the
+detailed client-tool mechanism (Part 1b), grounded in the Vercel AI SDK.
+
+## The problem in one sentence
+
+An agent sometimes needs the human. It wants to change its own config, or it needs a
+connection that does not exist. In both cases the agent must pause, show the user something
+in the playground, wait for the user to act, and then continue with the result.
+
+Both cases are the same shape. This doc designs that shape once, then applies it twice.
+
+## Decisions (locked 2026-06-28)
+
+These were the four open questions; Mahmoud answered them. The rest of the doc is written
+around them.
+
+- **D1 — config-change approval is per-tool, not hardcoded.** Whether a commit needs
+  approval is the tool's own `needs_approval`, handled by the existing approval boundary. Do
+  not force "always approve." The new universal requirement is the **refresh**: after a commit
+  lands, the playground refreshes the config panel — whether a human approved it or the agent
+  committed directly. The refresh signal fires in **both** paths. Do not build a config diff
+  now; v1 ships a generic approval UI. But the frame must carry enough identity (tool name
+  plus a render hint) for the playground to dispatch a per-tool UI later.
+- **D2 — connection trigger is an explicit tool, skill-driven.** The agent learns from
+  discovery that a connection is missing and the skill teaches it to call `request_connection`.
+  Auto-interception is **out for v1**: the agent handles its own connection needs explicitly.
+  Runner auto-interception of a call-time failure stays only a noted future option.
+- **D3 — build the generic primitive, not a narrow one.** One client-tool round-trip carries
+  both config-approval and connection-request, and it retires the dead `client` executor.
+- **D4 — the result returns as a structured tool result (the "callback").** It is keyed to the
+  parked tool call and carries a **reference** (integration plus slug, or "connection ready"),
+  never the secret. The runner re-resolves the real credential from the vault on resume. The
+  "frontend auto-sends a follow-up message" framing maps to this structured result, not a
+  free-text user message.
+- **D5 — `request_connection` is a hard-coded platform tool with a client executor.** It lives
+  in the same platform catalog as `find_capabilities` and `commit_revision`
+  (`PLATFORM_OPS` in `op_catalog.py`), except it is client-executed instead of server-executed.
+  This resolves the earlier "client-executor tool versus platform tool" question: it is both —
+  a platform-catalog tool whose executor is `client`. Because it is a platform tool, it can
+  ship in the default embedded set; coordinate with the default-agent-config project on whether
+  a new agent gets it by default.
+
+The builder-capabilities project (triggers, subscriptions) rides this same primitive, so the
+contract stays general enough to serve those too.
+
+## What we already have (verified in code)
+
+We are not starting from zero. The human-in-the-loop approval flow already does a full
+round-trip, and it is the model for everything below.
+
+Today, when a tool needs approval:
+
+1. The runner raises a neutral `interaction_request` event with `kind: "permission"`
+   (`services/agent/src/protocol.ts`).
+2. The stream adapter projects that event to a Vercel `tool-approval-request` frame
+   (`sdks/python/agenta/sdk/agents/adapters/vercel/stream.py`).
+3. The run **parks**: the runner ends the turn with stop reason `paused`, disposes the
+   sandbox, and emits a clean `finish` frame (`services/agent/src/engines/sandbox_agent.ts`).
+4. The playground renders approve or deny in `ToolActivity` and, the moment the user
+   decides, auto-resends via `sendAutomaticallyWhen: agentShouldResumeAfterApproval`
+   (`web/oss/src/components/AgentChatSlice/`).
+5. The next turn carries the decision back as a `tool_result` block with an `{approved}`
+   envelope. The runner cold-replays the conversation and resolves the parked gate, keyed by
+   `approvalKey(toolName, args)` (`services/agent/src/responder.ts`).
+
+So the transport exists: out through the stream, park, render, wait, resume on the next
+message. The decision even rides home in the right place — a `tool_result` keyed to the tool
+call, not a free-floating field.
+
+Two more facts matter:
+
+- The neutral event already declares `kind: "permission" | "input" | "client_tool"`. Only
+  `permission` is wired. `client_tool` is the slot reserved for exactly this work, and the
+  `Responder` interface has no `onClientTool` yet.
+- The `client` executor exists as a tool model (`ClientToolConfig`, `ClientToolSpec`) but the
+  runner forbids executing it everywhere, on purpose. The rails are laid; nothing runs on
+  them.
+
+The gap is narrow and clear. We have a working round-trip for one fixed interaction
+(approve/deny). We need to generalize it so an arbitrary client-side tool can round-trip, and
+then point it at two concrete jobs.
+
+## Part 1 — the shared primitive: a client-executor tool that round-trips
+
+### The idea
+
+A client-executor tool is a tool the **playground** runs, not the sandbox. The agent calls
+it like any other tool. The runner does not execute it; instead it emits an interaction
+request, parks the run, and waits. The playground dispatches a widget, the user acts, and the
+result comes back on the next turn as a `tool_result` keyed to the same tool call. The agent
+reads the result and continues.
+
+This is the permission flow with two things generalized:
+
+- The **outbound** request carries an arbitrary tool call, not just a permission ask.
+- The **inbound** result carries an arbitrary `tool_result` output, not just `{approved}`.
+
+Everything between (park, cold-replay, resume, the auto-resend predicate) stays as is.
+
+### The contract (design-interfaces applied)
+
+The round-trip crosses two boundaries: runner to playground (the stream frame) and playground
+to runner (the next message). Each field below is classified by role, not by feature.
+
+**Outbound — the neutral `interaction_request` event (runner-internal, then projected to a
+stream frame).**
+
+```jsonc
+{
+  "type": "interaction_request",
+  "id": "acp-perm-123",          // protocol context: correlation id, per-call
+  "kind": "client_tool",         // routing: selects the playground dispatcher
+  "payload": {
+    "toolCallId": "call_abc",    // protocol context: ties the result back to the call
+    "toolCall": {                // data: what the tool asked (name + args), for the widget
+      "name": "request_connection",
+      "input": { "integration": "github" }
+    },
+    "render": { "kind": "connect", "...": "..." }  // metadata: a presentation hint
+  }
+}
+```
+
+Role classification:
+
+- `id`, `toolCallId` — **protocol context**. Correlation, per-call, platform-owned. Reuse the
+  existing names; do not invent a parallel id.
+- `kind` — **routing**. It picks which playground widget handles the request. Keep it a closed
+  enum at the boundary (`permission`, `input`, `client_tool`; later `connect` if we specialize
+  — see Q3). Routing chooses a destination; that is exactly what `kind` does here.
+- `toolCall.name` / `toolCall.input` — **data**. The tool and its arguments. The widget reads
+  these to know what to show. Caller-owned (the model produced them).
+- `render` — **metadata** (a presentation directive). It tells the playground how to draw the
+  request. It must never carry behavior or secrets; it is a hint, and the playground may
+  ignore it. This reuses the existing `data-render` channel.
+
+**Per-tool dispatch is the load-bearing extensibility (D1).** The contract must let the
+playground pick a tool-specific widget later without a protocol change. Two fields make that
+possible, and both are already in the frame above:
+
+- `toolCall.name` is the stable dispatch key. `commit_revision` can map to a config-diff
+  widget, `request_connection` to a connect widget, a future tool to its own widget.
+- `render.kind` is the explicit hint when name alone is too coarse (one tool, several
+  presentations).
+
+The dispatcher reads `render.kind` first, falls back to `toolCall.name`, and falls back again
+to a generic widget when it recognizes neither. So v1 ships only the generic widget, and every
+later per-tool UI is an added case in the dispatcher, not a new frame. The same rule applies to
+the approval frame: a `tool-approval-request` already carries `toolCallId`, and the playground
+can read the tool name and render hint off the matching tool part, so approvals dispatch
+per-tool by the identical mechanism.
+
+**Inbound — the result on the next turn's message history (a `tool_result` content block).**
+
+```jsonc
+{
+  "type": "tool_result",
+  "toolCallId": "call_abc",      // protocol context: matches the parked call
+  "toolName": "request_connection",
+  "output": { "connected": true, "integration": "github", "slug": "github-main" }
+}
+```
+
+Role classification:
+
+- `toolCallId` / `toolName` — **protocol context**. The cold-replay anchor. The runner already
+  re-keys by `approvalKey(name, args)`, so this is the existing match path.
+- `output` — **data**. The result of the interaction, owned by the playground (it ran the
+  tool). For approval today, `output` is `{approved}`. For a connection, it is a **reference**
+  (`integration`, `slug`), never the credential.
+
+The single most important interface rule here: **the result is a `tool_result` keyed to the
+tool call, and it carries a reference, never a secret.** The connection itself lives in the
+project vault, keyed `(project_id, provider_key, integration_key, slug)`. The runner
+re-resolves it server-side on the resumed turn. Putting the secret in the stream or the
+message would leak it into transcripts and traces for no benefit, because the runner has to
+re-resolve from the vault anyway.
+
+### Options for the substrate
+
+**Option A — one generic client-tool round-trip (chosen, D3).** Any tool with
+`executor: client` round-trips through the playground. `request_connection` is just the first
+instance; a config-diff approval, an elicitation form, or a "pick one of these" widget are
+later instances with no new transport. The runner gains one `onClientTool` responder that
+parks and resolves exactly like `onPermission`. The stream adapter projects `client_tool` to a
+generic client-tool frame. The playground gains one dispatcher that routes by tool name or
+`render.kind`.
+
+- Motivation: the cost is front-loaded once. Every future "ask the human something" feature
+  is then a tool plus a widget, not a protocol change. It matches the executor taxonomy we
+  already committed to (builtin / gateway / code / client) and finally makes `client` real.
+- Cost: more upfront design on the widget dispatcher, and a generic contract is easier to get
+  subtly wrong than a narrow one.
+
+**Option B — two narrow interaction kinds.** Keep `permission` as is and add a dedicated
+`connect` kind for Problem 2. No generic client executor yet. Each kind has a bespoke frame
+and a bespoke widget.
+
+- Motivation: smaller blast radius, ships Problem 2 fastest, every field is concrete.
+- Cost: the third interaction (and there will be a third) repeats the work. The `client`
+  executor stays a dead model. We pay the generalization later anyway, with two
+  special cases to retire.
+
+**Locked: Option A (D3).** Mahmoud chose the general solution. The second application
+(Problem 2) and the likely third (richer config approval, elicitation, and the
+builder-capabilities triggers/subscriptions) all want the same transport, and we already carry
+the `client_tool` slot and the `client` executor as debt. Building A pays both off. Option B is
+recorded only as the rejected narrow alternative.
+
+### What this part costs, split by owner
+
+- Runner (us, TypeScript): add `onClientTool` to `Responder`; park on an unresolved
+  client-tool call exactly as permission parks; resolve from the inbound `tool_result` on
+  resume. Generalize `extractApprovalDecisions` to also extract generic client-tool results,
+  keyed by `approvalKey(name, args)`.
+- SDK (us, Python): project `interaction_request kind="client_tool"` to a stream frame in
+  `vercel/stream.py`; parse the inbound `tool_result` for client tools in `vercel/messages.py`
+  (the approval parsing already exists; widen it). Define the client-tool spec shape.
+- Playground (Arda): the **client-tool dispatcher** — render a widget by tool name or
+  `render.kind`, and the **resume predicate** — generalize `agentShouldResumeAfterApproval` so
+  a settled client-tool part (not only an approval) triggers the auto-resend. This is the
+  biggest new frontend surface.
+
+## Part 1b — the client-tool mechanism in detail (grounded in the Vercel AI SDK)
+
+This part answers three questions in detail: how a client tool is registered end to end, where
+the dispatch logic lives and what fires in the playground, and the return path plus its UX.
+
+The headline: **we do not invent a transport. The Vercel AI SDK already ships both halves we
+need.** The HITL approval flow we run today uses one half. Client tools are the sibling half.
+
+- **The approval half (in use today).** `useChat`'s `addToolApprovalResponse` records the
+  decision, and `sendAutomaticallyWhen: lastAssistantMessageIsCompleteWithApprovalResponses`
+  auto-resends. Our `agentShouldResumeAfterApproval` wraps that predicate.
+- **The client-tool half (what we reuse here).** A tool with no server `execute` is
+  client-handled. The playground supplies the result through `onToolCall` and/or
+  `addToolOutput` (the API was `addToolResult`, now deprecated in favor of `addToolOutput`),
+  and `sendAutomaticallyWhen: lastAssistantMessageIsCompleteWithToolCalls` auto-resends. The
+  standard `providerExecuted` flag on a tool part says whether the server ran the tool, so the
+  playground can tell a server result from a client call.
+
+All symbols above are exported by the installed `ai@6` / `@ai-sdk/react@3` (verified). The work
+is to wire our runner and stream to the client-tool half and to add the per-tool widgets — not
+to build new streaming.
+
+### How it maps to our runner
+
+- **Server-executed tools** (builtin, gateway, code): the sandbox runs them; the runner streams
+  `tool-output-available`. The part arrives **settled**, with `providerExecuted` truthy. The
+  playground shows the result; there is nothing to handle.
+- **Client-executed tools** (`executor: client`): the runner does **not** execute them. It
+  streams the tool call (`tool-input-available`) with no output and **parks** (stop reason
+  `paused`), exactly as a permission gate parks. The part arrives **unsettled**, with
+  `providerExecuted` falsy, so the Vercel layer treats it as client-handled. The runner already
+  forbids executing client tools; we turn "forbid" into "emit and park."
+
+### 1. Registration — three layers, one flag
+
+Design-interfaces first: "this tool runs on the client" is a single config field on the
+execution-location axis of the executor taxonomy (builtin / gateway / code / client). It is
+platform-owned and long-lived. It must flow unchanged from the catalog to the wire to the
+playground. Do not scatter it across feature-named fields.
+
+**Layer A — the platform catalog (server, us).** `request_connection` is a hard-coded platform
+op in `PLATFORM_OPS` (`op_catalog.py`), beside `find_capabilities` and `commit_revision`,
+except it carries the client executor (D5). One source of truth for "client-handled" starts
+here.
+
+**Layer B — the spec and the wire (us).** The resolver emits the tool spec with the client
+marker (`ClientToolSpec` / `kind: "client"`). On the wire to the runner the spec carries that
+marker, so the runner knows to emit-and-park rather than dispatch to the sandbox. No new wire
+shape; the `client` spec already exists, unused.
+
+**Layer C — the playground (Arda).** The playground must know which streamed tool calls are
+its job. Two grounding facts make this robust:
+
+- *Implicit, from Vercel:* any tool call that arrives with no server output is client-handled —
+  `onToolCall` fires and the part stays unsettled until the playground supplies output.
+  `providerExecuted` is the standard field that marks a server-run tool, so client parts read
+  falsy. This seam is already in use (`agentApprovalResume.ts` filters `providerExecuted !==
+  true`).
+- *Explicit, so the playground never guesses:* the playground registers a handler per client
+  tool, keyed by `render.kind` then tool `name`. The dispatcher knows its closed set
+  (`request_connection` for v1; more later). A tool call whose name is **not** in the registry
+  and has **no** server output is an error surface — render a generic "this app cannot handle
+  that request" fallback, never a silent hang.
+
+The registration contract on the spec, by role:
+
+- `executor: "client"` (`kind: "client"`) — **config / routing**: the execution location.
+  Platform-owned, set in the catalog. The single source of truth for "client-handled."
+- `name` — **metadata / identity**: the playground dispatch key.
+- `input_schema` — **data**: the call-argument contract.
+- `render` (optional) — **metadata**: a presentation hint that refines dispatch.
+- `needs_approval` — **policy**, orthogonal: a client tool *may* also be approval-gated, but
+  `request_connection` is not (connecting is its own confirmation).
+
+The playground registry is a `Record<string, ClientToolHandler>` keyed by `render.kind` or
+`name`. v1 has one entry. Each later client tool is one added entry, not a protocol change.
+
+### 2. Dispatch location — what fires in the playground
+
+The AI SDK gives two entry points; we use the second for any tool that needs human action.
+
+- **`onToolCall({ toolCall })` on `useChat`** fires the instant a client tool call streams in.
+  It fits a **fully automatic** client tool that can compute and return (or call
+  `addToolOutput`) immediately. It is the wrong place for connect, whose result needs the user
+  for seconds to minutes. Note it as available; v1 does not use it.
+- **Render-from-parts plus `addToolOutput`** is the **interactive** pattern, and where dispatch
+  lives. The tool part sits in `input-available` (unsettled). The message-part renderer — the
+  same place `ToolActivity` renders approve and deny today — dispatches the per-tool widget by
+  `render.kind` then `name`, falling back to a generic widget. The widget drives the
+  interaction, then calls `addToolOutput({ tool, toolCallId, output })`. The part flips to
+  `output-available`, and `lastAssistantMessageIsCompleteWithToolCalls` makes
+  `sendAutomaticallyWhen` auto-resend.
+
+So dispatch lives in the message-part renderer, not in `onToolCall`, for interactive tools.
+
+Concretely, for `request_connection`:
+
+1. The stream delivers `tool-input-available` for `request_connection` (plus an optional
+   `data-render`). The part is unsettled.
+2. The runner parks; the turn finishes cleanly.
+3. The renderer sees an unsettled client tool part named `request_connection` and dispatches
+   the connect widget.
+4. The widget calls `POST /tools/connections/`, opens the returned `redirect_url` in a popup,
+   and listens for the callback `postMessage`.
+5. On completion it calls `addToolOutput({ tool: "request_connection", toolCallId, output: {
+   connected: true, integration, slug } })`.
+6. `lastAssistantMessageIsCompleteWithToolCalls` is now true, so `useChat` auto-resends.
+7. The runner cold-replays, resolves the parked call by `approvalKey(name, args)`, and the
+   agent continues.
+
+This needs one generalization of the resume predicate. Today `agentShouldResumeAfterApproval`
+wraps the approval predicate. It must also resume on a settled client-tool output — compose it
+with `lastAssistantMessageIsCompleteWithToolCalls`. The clean form is one predicate that
+returns true when every non-provider-executed tool part on the last assistant turn is settled
+(`output-available`, `output-error`, or `approval-responded`) and at least one was just
+resolved. That is a small superset of today's function. Arda owns it; we supply the contract.
+
+### 3. Return path and UI
+
+**The resume envelope (the callback).** The result is a tool output keyed to the parked call.
+`addToolOutput` carries it home as a `tool_result` block in the next message's history:
+
+```jsonc
+{
+  "type": "tool_result",
+  "toolCallId": "call_abc",          // protocol context: the cold-replay anchor
+  "toolName": "request_connection",
+  "output": { "connected": true, "integration": "github", "slug": "github-main" }
+}
+```
+
+- `toolCallId` / `toolName` — **protocol context**. The runner re-keys by
+  `approvalKey(name, args)` on resume.
+- `output` — **data**, and a **reference**, never the secret: `integration` plus `slug` (or as
+  little as `{ "connected": true }`). The runner re-resolves the real credential from the vault.
+- Failure and cancel must also settle the part. If the user closes the popup or OAuth fails, the
+  widget calls `addToolOutput` with `{ connected: false, reason }` (or the error form via
+  `errorText`). The agent then learns it failed and can re-ask. Never leave the part unsettled;
+  an unsettled part hangs the resume.
+
+**The UX of showing the result — Arda's call.** The wire envelope is identical either way; this
+is pure presentation.
+
+- **Option U1 — an inline status chip (lean).** The connect interaction renders as a compact
+  tool-activity row, the same visual language as the approve/deny row: "Connect GitHub" with a
+  button, collapsing on success to "GitHub connected" with a check. The raw tool result is not
+  shown as a chat bubble.
+  - Motivation: consistent with the existing HITL UI, low noise, and the result is plumbing the
+    user does not need to read. This matches Mahmoud's "hidden behind a status indicator."
+- **Option U2 — a plain chat message.** The result posts as a visible turn ("Connected GitHub")
+  in the transcript.
+  - Motivation: maximally legible; the conversation literally shows what happened. But it is
+    noisier, it can imply the user typed something they did not, and it duplicates what the
+    agent will restate on resume.
+
+Lean: **U1**, for consistency with the approval UI and lower noise. Move to U2 only if testing
+shows people miss that a connection happened.
+
+### The post-connection handoff
+
+The callback says only "the connection now exists." It does **not** add the tool to the agent.
+After the resume, the agent must re-resolve or re-run discovery to actually wire and use the
+tool:
+
+1. The resume turn arrives carrying the connect tool result.
+2. The agent re-runs `find_capabilities` (or re-resolves the gateway tool). The
+   `ConnectionRequirement` now reads `ready` with a `slug`.
+3. The agent adds the gateway tool to its config (or calls it) and proceeds.
+
+This loop is **teaching, not transport**. Our primitive delivers the "connection ready" signal;
+the **agent-skills / agent-creation-skills project owns the skill** that teaches the agent the
+full loop (discover, `request_connection`, re-discover, add the tool). Flag this as a
+cross-project dependency. Because connections are project-scoped, the re-resolve succeeds on the
+very next turn.
+
+## Part 2 — Problem 1: the agent changes its own config
+
+### What happens today
+
+`commit_revision` is a platform op with `default_needs_approval=True` and
+`default_permission="ask"`. The running variant id is server-bound from the run context, so
+the agent commits to its own default variant. The approval gate is therefore **already
+available** through the permission flow in Part 1's "what we have." When the agent calls
+`commit_revision`, the run parks on a permission gate; the user sees the request; on approve
+the commit runs server-side; on deny it does not.
+
+Two pieces follow from D1: the approval gate stays a per-tool choice (we do not hardcode it),
+and the refresh must fire whether or not a human approved.
+
+### Step 1 — the approval gate is per-tool (D1)
+
+There is no "always approve" decision to make here, and that is the point. Whether
+`commit_revision` parks for a human is the tool's own `needs_approval`, read by the existing
+approval boundary:
+
+- `commit_revision` ships with `default_needs_approval=True`, so by default the run parks and
+  the user approves before the commit takes effect (park-before-run semantics). This is a
+  sensible default for "the agent rewrote itself," but it is a default, not a hardcode.
+- An author (or a future "auto-commit" mode) can set `needs_approval=False` on the tool config.
+  The agent then commits directly, with no gate. The refresh in step 3 still runs.
+
+So Problem 1 needs no new gate logic. It needs the **refresh** (step 3), plus the
+**per-tool approval UI hook** the contract now carries.
+
+**The approval UI: generic now, per-tool later.** v1 renders the generic approval widget — it
+shows the tool input, which for `commit_revision` is the new config under
+`workflow_revision.data`. Do not build a config diff yet. But the frame carries the tool name
+and a `render` hint (Part 1, "per-tool dispatch"), so a later `render: { kind: "config-diff" }`
+on `commit_revision` lets the playground swap in a real before/after diff with no protocol
+change. Raw JSON is a weak approval surface for anything non-trivial, so the diff is the
+expected first per-tool widget — but it is a follow-up, not v1.
+
+### Step 2 — the new commit on the default variant
+
+No design choice here; the platform op already targets the running variant and appends a
+revision. Worth stating only so the refresh in step 3 knows what to listen for: a successful
+`commit_revision` produces a new revision id and version on the default variant.
+
+### Step 3 — refresh the config panel (the universal requirement, D1)
+
+This is the one piece D1 makes mandatory. Today the playground reads the latest revision per
+request via `workflowLatestRevisionQueryAtomFamily`. When the agent commits through
+`commit_revision` (server-side, not the playground's own commit modal), the playground has no
+signal that a new revision landed. It needs one, and it needs it **in both paths**: the gated
+path (a human approved, the commit runs on the resume turn) and the direct path
+(`needs_approval=False`, the commit runs inside the turn).
+
+The clean way to satisfy both: emit the refresh signal when `commit_revision` **succeeds**, not
+when it is approved. Success happens in both paths, so one emit point covers both.
+
+**Option R1 — a named "revision committed" data frame (locked).** On a successful
+`commit_revision`, the runner or SDK emits a one-way `data` event,
+`data-committed-revision`, with `{ variantId, revisionId, version }`. The playground listens
+and invalidates `workflowLatestRevisionQueryAtomFamily`, which refreshes the panel and the
+section drawers (#4881). Emitting on success (not on approval) is what makes it fire in both
+the gated and the direct path.
+
+- Motivation: this is the role-correct design. The signal's role is metadata — "the config
+  changed, here is the new reference." It belongs on the existing one-way `data-<name>`
+  channel, not piggybacked on a tool result. It is explicit, typed, and decoupled from any one
+  tool's output shape. The #4904 "committed revision reference" work is the natural home.
+
+**Option R2 — key off the `commit_revision` tool result (pragmatic).** The playground already
+sees the `tool-output-available` frame for `commit_revision`. Its output carries the new
+revision id. The playground invalidates the query when it sees that specific tool settle.
+
+- Motivation: no new frame; possibly works today with #4904 already in place. Fastest.
+- Cost: couples the playground to a platform tool name and its output shape. If the tool is
+  renamed or its output changes, the refresh silently breaks.
+
+**Option R3 — blind refetch on turn finish.** Refetch the latest revision whenever a turn
+finishes.
+
+- Motivation: trivial.
+- Cost: wasteful and racy; refetches on every turn whether or not anything changed, and can
+  race the commit's write.
+
+Locked: **R1**, emitted on commit success. It is the clean contract, it matches where #4904
+already points, and emitting on success is what gives us both paths for free. **R2** is an
+acceptable stopgap if #4904 already exposes the committed reference on the tool result and we
+want Problem 1 visibly working this week — but it must still trigger in both paths, so confirm
+the tool-output frame appears for a direct (un-gated) commit before relying on it. Avoid R3.
+
+### Problem 1 owner split
+
+- Approval gate: already wired and per-tool (D1); no new gate work for us.
+- Generic approval UI: the shared dispatcher's generic widget (Arda), built in Part 1.
+- Per-tool config-diff render (follow-up): SDK attaches `render: { kind: "config-diff" }` (us);
+  the diff widget is Arda.
+- Refresh signal (R1): emit `data-committed-revision` on commit success in both paths (us,
+  SDK/runner); listen and invalidate the query (Arda).
+
+## Part 3 — Problem 2: the agent needs a connection that does not exist
+
+### The end-to-end flow
+
+1. The agent learns it needs a connection from **discovery**: it calls `find_capabilities`
+   (the discovery platform op), which returns a `ConnectionRequirement` with `state`
+   (`ready` / `needs_auth` / `needs_input`) and a `connect` affordance. A skill teaches the
+   agent the discover-then-connect loop (D2).
+2. The agent calls `request_connection(integration)`. The runner raises a client-tool
+   interaction: "connect GitHub." The run parks.
+3. The playground dispatches a **connect widget**: it shows the integration, calls
+   `POST /tools/connections/`, and opens the returned `redirect_url` (the OAuth flow) in a
+   popup.
+4. The user finishes OAuth. The callback (`GET /tools/connections/callback`) activates the
+   connection in the project vault and posts a message to the opener window.
+5. The moment the connect widget hears that message, it writes the result back as a
+   `tool_result` (`{ connected: true, integration, slug }`) keyed to the parked tool call. The
+   resume predicate fires and the conversation auto-resends.
+6. The runner resumes, re-resolves the tool (the connection now exists in the vault), and the
+   agent proceeds.
+
+### Where the connection request comes from
+
+**Locked: an explicit `request_connection` tool, driven by discovery (D2).** The agent calls
+`find_capabilities`, sees a `ConnectionRequirement` that is not `ready`, and calls
+`request_connection(integration)`. A skill teaches that loop. The call round-trips through
+Part 1's primitive. The `connect` affordance (which endpoint to call, with what body) rides in
+the tool input or the render hint, so the playground speaks Agenta, never Composio.
+
+- Motivation: explicit and legible. The agent decides when to ask and can explain why in its
+  own words first. It reuses the client-tool primitive with zero new transport. Connection
+  state is reported by discovery, not guessed. This is the seam the builder-capabilities
+  project depends on for its trigger and subscription work.
+- Cost: the agent must know to call it, so the skill must teach the discover-then-connect loop.
+  That skill already exists in spirit (the tool-discovery setup skill).
+
+**Rejected as primary, kept as an optional later safety net: runner auto-interception.** This
+is the runner catching a missing-connection *failure at call time* — the gateway tool resolve
+raises `ConnectionNotFoundError` mid-run, and the runner raises a connect interaction itself,
+with no agent tool call. Mahmoud finds this murky and prefers the agent to act on discovery
+plus skill guidance. The control flow would be implicit and live in the runner, and the thing
+that parks would be a synthetic interaction rather than a real model tool call, so the
+cold-replay anchor (`approvalKey(name, args)`) would have to be synthesized carefully. We may
+add it later only as a fallback, so an agent that skips discovery degrades to a connect prompt
+instead of a raw error. It is not in scope for v1.
+
+### How the result comes back and resumes the agent
+
+Mahmoud described step 5 as "the frontend automatically sends a follow-up message with the
+result." There are two ways to send it, and the choice matters.
+
+**Option P1 — a `tool_result` keyed to the parked tool call (recommended).** The connect
+widget writes the result as the parked client tool's output. Because it is a settled tool
+part, the (generalized) resume predicate auto-resends, exactly like an approval today. The
+runner resolves the parked call and the agent reads "connected" as the tool's return value.
+
+- Motivation: it reuses the entire HITL machinery — park, cold-replay, the auto-resend
+  predicate, the `tool_result` envelope. The agent gets the answer in the right place: as the
+  return value of the tool it called. No fake turns, no transcript pollution. It is the same
+  envelope as approve/deny, so one code path covers both.
+
+**Option P2 — a fresh user message ("I connected GitHub").** The playground appends a normal
+user message and resends.
+
+- Motivation: conceptually simplest; it is just another user turn.
+- Cost: the parked tool call is never resolved, so the runner either re-raises it or the model
+  is left guessing. It pollutes the transcript with a message the user did not write. It does
+  not reuse the resume predicate. It is the worse fit on every axis.
+
+Locked: **P1 (D4).** It matches "send the result back and resume" while reusing the proven
+path. The "follow-up message" framing maps to this structured result, not a literal chat
+message; P2 is recorded only as the rejected alternative.
+
+What the result carries: a **reference**, never the secret.
+`{ connected: true, integration: "github", slug: "github-main" }`. The connection lives in the
+project vault; the runner re-resolves the real credential on resume. The connection is
+project-scoped, so it persists beyond the session, and a later run needs no re-prompt.
+
+### Problem 2 owner split
+
+- `request_connection` as a platform-catalog tool with a `client` executor, plus its
+  argument/output schema and render hint (D5): us (SDK / catalog), with the connect affordance
+  shaped server-side by discovery (already built).
+- The **connect widget** — show the integration, call `POST /tools/connections/`, open the
+  OAuth popup, listen for the callback `postMessage`, call `addToolOutput`: Arda. This is the
+  main new frontend surface for Problem 2.
+- Generalized resume predicate (a settled client-tool output triggers resend): Arda (the
+  `agentShouldResumeAfterApproval` seam, composed with
+  `lastAssistantMessageIsCompleteWithToolCalls`).
+- The **skill** that teaches the discover, `request_connection`, re-discover, add-tool loop:
+  the agent-creation-skills project (cross-project dependency; our primitive only delivers the
+  "connection ready" signal).
+- Default-set membership (does a new agent get `request_connection`?): the default-agent-config
+  project.
+- Optional later safety net (runner auto-interception): us (runner + API); out of v1 scope.
+
+## The frontend-versus-us split, at a glance
+
+Most of this is frontend, and most of the frontend is Arda's call.
+
+**Us (SDK, runner, API):**
+
+- Runner: `onClientTool` responder (emit + park + resume), built as the generic client-tool
+  path (D3); generalize result extraction beyond `{approved}` to any structured tool output,
+  keyed by `approvalKey(name, args)`.
+- SDK: project `interaction_request kind="client_tool"` to a stream frame; parse the inbound
+  client-tool `tool_result` (widen the approval parsing); define the `request_connection`
+  platform op with a `client` executor (D5); carry `toolCall.name` plus `render` on the frame so
+  the playground can dispatch per-tool UIs later (D1).
+- API/SDK: emit the `data-committed-revision` refresh frame on commit success, in both the
+  gated and direct paths (R1, D1).
+- Out of v1 scope: runner auto-interception of a missing-connection failure (the rejected
+  safety net, D2).
+
+**Arda (frontend), the decisions that are his:**
+
+- The client-tool **dispatcher**, living in the message-part renderer (sibling to today's
+  `ToolActivity` approval UI): which widget renders for which `render.kind` then tool `name`,
+  with a generic widget as the fallback and an explicit "cannot handle that" surface for an
+  unknown client tool. v1 ships only the generic widget; per-tool widgets are added cases later
+  (D1, D3). This is the central new surface and the main "is this how we want it to look and
+  behave" call.
+- The **connect widget**: the OAuth popup, the callback listener, and the reply via
+  `addToolOutput` (success and the failure/cancel case both settle the part).
+- The result **UX** (U1 inline status chip versus U2 chat message; lean U1).
+- The **config-panel refresh** on the new revision (R1), and later the per-tool **config-diff**
+  approval widget.
+- The generalized **resume predicate**: `agentShouldResumeAfterApproval` composed with
+  `lastAssistantMessageIsCompleteWithToolCalls`, so a settled client-tool output resumes, not
+  only an approval.
+
+## Residual open items (not blocking; for the consolidation PR)
+
+The headline decisions (D1-D5) are locked. These smaller choices fall out during implementation
+and do not need Mahmoud now:
+
+- The exact `render.kind` vocabulary (for example `connect`, `config-diff`). The dispatch
+  precedence is settled (`render.kind` then `name` then generic fallback); only the string
+  values remain, an implementation detail to settle with Arda.
+- The `request_connection` arguments and output schema (likely `{ integration }` in, `{
+  connected, integration, slug }` out) and its exact `render` hint.
+- Whether the resume predicate stays one function that covers both approvals and client-tool
+  outputs, or two composed predicates. Same behavior; Arda's call at the seam.
+- The `data-committed-revision` payload's exact fields beyond `{ variantId, revisionId,
+  version }` (for example a human-readable label), once the panel-refresh code names what it
+  needs.
+
+Resolved in round 3: `request_connection` is a platform-catalog tool with a `client` executor
+(D5), not an either/or; the default-agent-config project decides whether it ships in a new
+agent's default tool set.

--- a/docs/design/agent-workflows/projects/agent-fe-roundtrip/design.md
+++ b/docs/design/agent-workflows/projects/agent-fe-roundtrip/design.md
@@ -1,648 +1,481 @@
-# The interactive frontend round-trip
+# Frontend round-trip: a client tool that asks the human
 
-Status: design draft, round 3, 2026-06-28. Owner: agent-workflows. Audience: Arda (most of
-the frontend work), us (SDK, runner, API). The decisions below are locked. Round 3 adds the
-detailed client-tool mechanism (Part 1b), grounded in the Vercel AI SDK.
+Status: design, ready for review. Date: 2026-06-28. Owner: agent-workflows.
+Audience: Arda (most of the frontend), us (SDK, runner, API).
 
-## The problem in one sentence
+This doc owns one primitive: a tool call that leaves the agent, travels to the playground,
+shows the user something, waits for the user to act, and resumes the agent with the result.
+We design that primitive once, then point it at two jobs.
 
-An agent sometimes needs the human. It wants to change its own config, or it needs a
-connection that does not exist. In both cases the agent must pause, show the user something
-in the playground, wait for the user to act, and then continue with the result.
+## The problem
 
-Both cases are the same shape. This doc designs that shape once, then applies it twice.
+An agent sometimes needs the human in the middle of a run. Two cases drive this work, and they
+are the same shape.
+
+1. The agent edits its own config. It calls `commit_revision` to write a new revision of
+   itself. The user should usually approve that first, and the playground must then show the
+   new config.
+2. The agent needs a connection it does not have. It wants to call a GitHub tool, but no GitHub
+   connection exists. The user must finish an OAuth flow before the agent can continue.
+
+Both cases pause the run, surface something in the playground, wait, and resume the agent with
+a result. One primitive serves both. The builder-capabilities work (triggers, subscriptions)
+rides the same primitive, so we keep it general.
+
+## Approach in one paragraph
+
+We do not invent a transport. We already ship this round-trip: the human-in-the-loop (HITL)
+approval flow pauses a run, renders approve or deny, waits, and resumes. The Vercel AI SDK
+ships two matching halves, and we already use one. The approval half drives HITL today. The
+client-tool half is the sibling we reuse here: a tool with no server execute is fulfilled by
+the client, which supplies the result and triggers an automatic resend. The runner's current
+rule, "forbid client tools," becomes "emit the call and park." That is the whole idea. The rest
+of this doc is the contract, the two applications, and the work split.
+
+## Scope
+
+In v1:
+
+- One generic client-executor round-trip that any client tool can use.
+- `request_connection` as the first client tool, for the connection case.
+- `commit_revision` approval through the existing gate, plus a refresh of the config panel.
+- A reference-only resume envelope, with failure and cancel both settled.
+
+Out of v1, recorded so no one rebuilds them by accident:
+
+- A config diff. v1 ships a generic approval widget. A per-tool diff is a later widget, not a
+  new contract.
+- Runner auto-interception of a missing-connection failure. The agent asks for a connection
+  explicitly, taught by a skill. Auto-interception stays a future safety net (see Rejected
+  alternatives).
 
 ## Decisions (locked 2026-06-28)
 
-These were the four open questions; Mahmoud answered them. The rest of the doc is written
-around them.
+These were the open questions. Mahmoud answered them. The rest of the doc honors them.
 
-- **D1 — config-change approval is per-tool, not hardcoded.** Whether a commit needs
-  approval is the tool's own `needs_approval`, handled by the existing approval boundary. Do
-  not force "always approve." The new universal requirement is the **refresh**: after a commit
-  lands, the playground refreshes the config panel — whether a human approved it or the agent
-  committed directly. The refresh signal fires in **both** paths. Do not build a config diff
-  now; v1 ships a generic approval UI. But the frame must carry enough identity (tool name
-  plus a render hint) for the playground to dispatch a per-tool UI later.
-- **D2 — connection trigger is an explicit tool, skill-driven.** The agent learns from
-  discovery that a connection is missing and the skill teaches it to call `request_connection`.
-  Auto-interception is **out for v1**: the agent handles its own connection needs explicitly.
-  Runner auto-interception of a call-time failure stays only a noted future option.
-- **D3 — build the generic primitive, not a narrow one.** One client-tool round-trip carries
-  both config-approval and connection-request, and it retires the dead `client` executor.
-- **D4 — the result returns as a structured tool result (the "callback").** It is keyed to the
-  parked tool call and carries a **reference** (integration plus slug, or "connection ready"),
-  never the secret. The runner re-resolves the real credential from the vault on resume. The
-  "frontend auto-sends a follow-up message" framing maps to this structured result, not a
-  free-text user message.
-- **D5 — `request_connection` is a hard-coded platform tool with a client executor.** It lives
-  in the same platform catalog as `find_capabilities` and `commit_revision`
-  (`PLATFORM_OPS` in `op_catalog.py`), except it is client-executed instead of server-executed.
-  This resolves the earlier "client-executor tool versus platform tool" question: it is both —
-  a platform-catalog tool whose executor is `client`. Because it is a platform tool, it can
-  ship in the default embedded set; coordinate with the default-agent-config project on whether
-  a new agent gets it by default.
+| ID | Decision |
+| --- | --- |
+| D1 | Config-change approval is per-tool, not hardcoded. `needs_approval` stays the tool's own field, read by the existing approval gate. The new universal requirement is the refresh: after a commit lands, the playground refreshes the config panel, whether a human approved or the agent committed directly. The refresh fires in both paths. No config diff in v1, but the frame carries the tool name plus a render hint so a per-tool widget can be added later with no protocol change. |
+| D2 | The connection trigger is an explicit `request_connection` tool, driven by discovery and a skill. Runner auto-interception of a call-time failure is out of v1, kept only as a future option. |
+| D3 | Build the generic primitive, not a narrow connection flow. One client-tool round-trip carries both jobs and retires the dead `client` executor. |
+| D4 | The result returns as a structured tool result keyed to the parked call. It carries a reference (integration plus slug, or "connection ready"), never the secret. The runner re-resolves the credential from the vault on resume. Failure and cancel also settle the call so the run never hangs. |
+| D5 | `request_connection` is a hard-coded platform tool with a client executor. It sits in the same platform catalog as `find_capabilities` and `commit_revision`, except the runner does not execute it: the playground does. Because it is a platform tool, it is part of the injected build kit (see Build-kit alignment). |
 
-The builder-capabilities project (triggers, subscriptions) rides this same primitive, so the
-contract stays general enough to serve those too.
+## What exists today (verified in code)
 
-## What we already have (verified in code)
+We are not starting from zero. Three things are already built or already shipped by the SDK.
 
-We are not starting from zero. The human-in-the-loop approval flow already does a full
-round-trip, and it is the model for everything below.
+The HITL round-trip already works end to end. When a tool needs approval:
 
-Today, when a tool needs approval:
-
-1. The runner raises a neutral `interaction_request` event with `kind: "permission"`
+1. The runner raises a neutral `interaction_request` with `kind: "permission"`
    (`services/agent/src/protocol.ts`).
-2. The stream adapter projects that event to a Vercel `tool-approval-request` frame
+2. The SDK projects that event to a Vercel `tool-approval-request` frame
    (`sdks/python/agenta/sdk/agents/adapters/vercel/stream.py`).
-3. The run **parks**: the runner ends the turn with stop reason `paused`, disposes the
-   sandbox, and emits a clean `finish` frame (`services/agent/src/engines/sandbox_agent.ts`).
-4. The playground renders approve or deny in `ToolActivity` and, the moment the user
-   decides, auto-resends via `sendAutomaticallyWhen: agentShouldResumeAfterApproval`
+3. The run parks: the runner ends the turn with stop reason `paused`, disposes the sandbox,
+   and emits a clean finish frame (`services/agent/src/engines/sandbox_agent.ts`).
+4. The playground renders approve or deny in `ToolActivity` and, the moment the user decides,
+   auto-resends through `sendAutomaticallyWhen: agentShouldResumeAfterApproval`
    (`web/oss/src/components/AgentChatSlice/`).
 5. The next turn carries the decision back as a `tool_result` block with an `{approved}`
-   envelope. The runner cold-replays the conversation and resolves the parked gate, keyed by
-   `approvalKey(toolName, args)` (`services/agent/src/responder.ts`).
+   output. The runner cold-replays the conversation and resolves the parked gate, keyed by
+   `approvalKey(name, args)` (`services/agent/src/responder.ts`).
 
 So the transport exists: out through the stream, park, render, wait, resume on the next
-message. The decision even rides home in the right place — a `tool_result` keyed to the tool
-call, not a free-floating field.
+message. The decision even rides home in the right place, a `tool_result` keyed to the call.
 
-Two more facts matter:
+The rails for the generic case are laid but dormant. The neutral event already declares
+`kind: "permission" | "input" | "client_tool"`, and only `permission` is wired; `Responder`
+has `onPermission` but no `onClientTool`. The `client` executor exists as a model
+(`ClientToolSpec`, `kind: "client"` in `sdks/python/agenta/sdk/agents/tools/`), but the runner
+throws on any client tool on purpose (`services/agent/src/tools/dispatch.ts`). Nothing runs on
+the rails yet.
 
-- The neutral event already declares `kind: "permission" | "input" | "client_tool"`. Only
-  `permission` is wired. `client_tool` is the slot reserved for exactly this work, and the
-  `Responder` interface has no `onClientTool` yet.
-- The `client` executor exists as a tool model (`ClientToolConfig`, `ClientToolSpec`) but the
-  runner forbids executing it everywhere, on purpose. The rails are laid; nothing runs on
-  them.
+The AI SDK ships both halves we need (`ai@6` and `@ai-sdk/react@3`, currently on the beta
+channel; all symbols below verified present in `node_modules`).
 
-The gap is narrow and clear. We have a working round-trip for one fixed interaction
-(approve/deny). We need to generalize it so an arbitrary client-side tool can round-trip, and
-then point it at two concrete jobs.
-
-## Part 1 — the shared primitive: a client-executor tool that round-trips
-
-### The idea
-
-A client-executor tool is a tool the **playground** runs, not the sandbox. The agent calls
-it like any other tool. The runner does not execute it; instead it emits an interaction
-request, parks the run, and waits. The playground dispatches a widget, the user acts, and the
-result comes back on the next turn as a `tool_result` keyed to the same tool call. The agent
-reads the result and continues.
-
-This is the permission flow with two things generalized:
-
-- The **outbound** request carries an arbitrary tool call, not just a permission ask.
-- The **inbound** result carries an arbitrary `tool_result` output, not just `{approved}`.
-
-Everything between (park, cold-replay, resume, the auto-resend predicate) stays as is.
-
-### The contract (design-interfaces applied)
-
-The round-trip crosses two boundaries: runner to playground (the stream frame) and playground
-to runner (the next message). Each field below is classified by role, not by feature.
-
-**Outbound — the neutral `interaction_request` event (runner-internal, then projected to a
-stream frame).**
-
-```jsonc
-{
-  "type": "interaction_request",
-  "id": "acp-perm-123",          // protocol context: correlation id, per-call
-  "kind": "client_tool",         // routing: selects the playground dispatcher
-  "payload": {
-    "toolCallId": "call_abc",    // protocol context: ties the result back to the call
-    "toolCall": {                // data: what the tool asked (name + args), for the widget
-      "name": "request_connection",
-      "input": { "integration": "github" }
-    },
-    "render": { "kind": "connect", "...": "..." }  // metadata: a presentation hint
-  }
-}
-```
-
-Role classification:
-
-- `id`, `toolCallId` — **protocol context**. Correlation, per-call, platform-owned. Reuse the
-  existing names; do not invent a parallel id.
-- `kind` — **routing**. It picks which playground widget handles the request. Keep it a closed
-  enum at the boundary (`permission`, `input`, `client_tool`; later `connect` if we specialize
-  — see Q3). Routing chooses a destination; that is exactly what `kind` does here.
-- `toolCall.name` / `toolCall.input` — **data**. The tool and its arguments. The widget reads
-  these to know what to show. Caller-owned (the model produced them).
-- `render` — **metadata** (a presentation directive). It tells the playground how to draw the
-  request. It must never carry behavior or secrets; it is a hint, and the playground may
-  ignore it. This reuses the existing `data-render` channel.
-
-**Per-tool dispatch is the load-bearing extensibility (D1).** The contract must let the
-playground pick a tool-specific widget later without a protocol change. Two fields make that
-possible, and both are already in the frame above:
-
-- `toolCall.name` is the stable dispatch key. `commit_revision` can map to a config-diff
-  widget, `request_connection` to a connect widget, a future tool to its own widget.
-- `render.kind` is the explicit hint when name alone is too coarse (one tool, several
-  presentations).
-
-The dispatcher reads `render.kind` first, falls back to `toolCall.name`, and falls back again
-to a generic widget when it recognizes neither. So v1 ships only the generic widget, and every
-later per-tool UI is an added case in the dispatcher, not a new frame. The same rule applies to
-the approval frame: a `tool-approval-request` already carries `toolCallId`, and the playground
-can read the tool name and render hint off the matching tool part, so approvals dispatch
-per-tool by the identical mechanism.
-
-**Inbound — the result on the next turn's message history (a `tool_result` content block).**
-
-```jsonc
-{
-  "type": "tool_result",
-  "toolCallId": "call_abc",      // protocol context: matches the parked call
-  "toolName": "request_connection",
-  "output": { "connected": true, "integration": "github", "slug": "github-main" }
-}
-```
-
-Role classification:
-
-- `toolCallId` / `toolName` — **protocol context**. The cold-replay anchor. The runner already
-  re-keys by `approvalKey(name, args)`, so this is the existing match path.
-- `output` — **data**. The result of the interaction, owned by the playground (it ran the
-  tool). For approval today, `output` is `{approved}`. For a connection, it is a **reference**
-  (`integration`, `slug`), never the credential.
-
-The single most important interface rule here: **the result is a `tool_result` keyed to the
-tool call, and it carries a reference, never a secret.** The connection itself lives in the
-project vault, keyed `(project_id, provider_key, integration_key, slug)`. The runner
-re-resolves it server-side on the resumed turn. Putting the secret in the stream or the
-message would leak it into transcripts and traces for no benefit, because the runner has to
-re-resolve from the vault anyway.
-
-### Options for the substrate
-
-**Option A — one generic client-tool round-trip (chosen, D3).** Any tool with
-`executor: client` round-trips through the playground. `request_connection` is just the first
-instance; a config-diff approval, an elicitation form, or a "pick one of these" widget are
-later instances with no new transport. The runner gains one `onClientTool` responder that
-parks and resolves exactly like `onPermission`. The stream adapter projects `client_tool` to a
-generic client-tool frame. The playground gains one dispatcher that routes by tool name or
-`render.kind`.
-
-- Motivation: the cost is front-loaded once. Every future "ask the human something" feature
-  is then a tool plus a widget, not a protocol change. It matches the executor taxonomy we
-  already committed to (builtin / gateway / code / client) and finally makes `client` real.
-- Cost: more upfront design on the widget dispatcher, and a generic contract is easier to get
-  subtly wrong than a narrow one.
-
-**Option B — two narrow interaction kinds.** Keep `permission` as is and add a dedicated
-`connect` kind for Problem 2. No generic client executor yet. Each kind has a bespoke frame
-and a bespoke widget.
-
-- Motivation: smaller blast radius, ships Problem 2 fastest, every field is concrete.
-- Cost: the third interaction (and there will be a third) repeats the work. The `client`
-  executor stays a dead model. We pay the generalization later anyway, with two
-  special cases to retire.
-
-**Locked: Option A (D3).** Mahmoud chose the general solution. The second application
-(Problem 2) and the likely third (richer config approval, elicitation, and the
-builder-capabilities triggers/subscriptions) all want the same transport, and we already carry
-the `client_tool` slot and the `client` executor as debt. Building A pays both off. Option B is
-recorded only as the rejected narrow alternative.
-
-### What this part costs, split by owner
-
-- Runner (us, TypeScript): add `onClientTool` to `Responder`; park on an unresolved
-  client-tool call exactly as permission parks; resolve from the inbound `tool_result` on
-  resume. Generalize `extractApprovalDecisions` to also extract generic client-tool results,
-  keyed by `approvalKey(name, args)`.
-- SDK (us, Python): project `interaction_request kind="client_tool"` to a stream frame in
-  `vercel/stream.py`; parse the inbound `tool_result` for client tools in `vercel/messages.py`
-  (the approval parsing already exists; widen it). Define the client-tool spec shape.
-- Playground (Arda): the **client-tool dispatcher** — render a widget by tool name or
-  `render.kind`, and the **resume predicate** — generalize `agentShouldResumeAfterApproval` so
-  a settled client-tool part (not only an approval) triggers the auto-resend. This is the
-  biggest new frontend surface.
-
-## Part 1b — the client-tool mechanism in detail (grounded in the Vercel AI SDK)
-
-This part answers three questions in detail: how a client tool is registered end to end, where
-the dispatch logic lives and what fires in the playground, and the return path plus its UX.
-
-The headline: **we do not invent a transport. The Vercel AI SDK already ships both halves we
-need.** The HITL approval flow we run today uses one half. Client tools are the sibling half.
-
-- **The approval half (in use today).** `useChat`'s `addToolApprovalResponse` records the
-  decision, and `sendAutomaticallyWhen: lastAssistantMessageIsCompleteWithApprovalResponses`
-  auto-resends. Our `agentShouldResumeAfterApproval` wraps that predicate.
-- **The client-tool half (what we reuse here).** A tool with no server `execute` is
-  client-handled. The playground supplies the result through `onToolCall` and/or
-  `addToolOutput` (the API was `addToolResult`, now deprecated in favor of `addToolOutput`),
-  and `sendAutomaticallyWhen: lastAssistantMessageIsCompleteWithToolCalls` auto-resends. The
-  standard `providerExecuted` flag on a tool part says whether the server ran the tool, so the
+- The approval half, in use today: `addToolApprovalResponse` records the decision, and
+  `lastAssistantMessageIsCompleteWithApprovalResponses` drives the resend. Our
+  `agentShouldResumeAfterApproval` wraps it.
+- The client-tool half, which we reuse: a tool with no server execute is client-handled. The
+  playground supplies the result through `addToolOutput` (the older `addToolResult` is
+  deprecated), and `lastAssistantMessageIsCompleteWithToolCalls` drives the resend. The
+  `providerExecuted` flag on a tool part says whether the server ran the tool, so the
   playground can tell a server result from a client call.
 
-All symbols above are exported by the installed `ai@6` / `@ai-sdk/react@3` (verified). The work
-is to wire our runner and stream to the client-tool half and to add the per-tool widgets — not
-to build new streaming.
+The gap is narrow. We have a working round-trip for one fixed interaction. We generalize it so
+any client tool can round-trip, then point it at two jobs.
 
-### How it maps to our runner
+## The primitive: a generic client-tool round-trip
 
-- **Server-executed tools** (builtin, gateway, code): the sandbox runs them; the runner streams
-  `tool-output-available`. The part arrives **settled**, with `providerExecuted` truthy. The
-  playground shows the result; there is nothing to handle.
-- **Client-executed tools** (`executor: client`): the runner does **not** execute them. It
-  streams the tool call (`tool-input-available`) with no output and **parks** (stop reason
-  `paused`), exactly as a permission gate parks. The part arrives **unsettled**, with
-  `providerExecuted` falsy, so the Vercel layer treats it as client-handled. The runner already
-  forbids executing client tools; we turn "forbid" into "emit and park."
+### How it works
 
-### 1. Registration — three layers, one flag
+A client-executor tool is a tool the playground runs, not the sandbox. The agent calls it like
+any other tool. The runner does not execute it. Instead it streams the tool call, parks the
+run, and waits. The playground dispatches a widget, the user acts, and the result returns on
+the next turn as a `tool_result` keyed to the same call. The agent reads the result as the
+tool's return value and continues.
 
-Design-interfaces first: "this tool runs on the client" is a single config field on the
-execution-location axis of the executor taxonomy (builtin / gateway / code / client). It is
-platform-owned and long-lived. It must flow unchanged from the catalog to the wire to the
-playground. Do not scatter it across feature-named fields.
+This is the permission flow with two things generalized. The outbound side carries an arbitrary
+tool call, not just a permission ask. The inbound side carries an arbitrary tool output, not
+just `{approved}`. Everything between, the park, the cold-replay, and the resume, stays as it
+is.
 
-**Layer A — the platform catalog (server, us).** `request_connection` is a hard-coded platform
-op in `PLATFORM_OPS` (`op_catalog.py`), beside `find_capabilities` and `commit_revision`,
-except it carries the client executor (D5). One source of truth for "client-handled" starts
-here.
+### The contract, by role
 
-**Layer B — the spec and the wire (us).** The resolver emits the tool spec with the client
-marker (`ClientToolSpec` / `kind: "client"`). On the wire to the runner the spec carries that
-marker, so the runner knows to emit-and-park rather than dispatch to the sandbox. No new wire
-shape; the `client` spec already exists, unused.
+Two boundaries cross: runner to playground (outbound) and playground to runner (inbound). We
+classify each field by the role it plays, not the feature it touches.
 
-**Layer C — the playground (Arda).** The playground must know which streamed tool calls are
-its job. Two grounding facts make this robust:
+The outbound side needs no new Vercel frame. The permission flow projects a bespoke
+`tool-approval-request` frame because approval is a separate concern layered on top of the tool
+call. A client tool is different: the tool call itself is what the client fulfills. So the call
+rides as the standard unsettled tool part the runner already streams (`tool-input-available`,
+no output, `providerExecuted` falsy), and the optional presentation hint rides the existing
+one-way `data-render` channel (`data-<name>` in `stream.py`). The runner-internal
+`interaction_request kind="client_tool"` is what drives the park; it does not need its own
+wire frame.
 
-- *Implicit, from Vercel:* any tool call that arrives with no server output is client-handled —
-  `onToolCall` fires and the part stays unsettled until the playground supplies output.
-  `providerExecuted` is the standard field that marks a server-run tool, so client parts read
-  falsy. This seam is already in use (`agentApprovalResume.ts` filters `providerExecuted !==
-  true`).
-- *Explicit, so the playground never guesses:* the playground registers a handler per client
-  tool, keyed by `render.kind` then tool `name`. The dispatcher knows its closed set
-  (`request_connection` for v1; more later). A tool call whose name is **not** in the registry
-  and has **no** server output is an error surface — render a generic "this app cannot handle
-  that request" fallback, never a silent hang.
+What the playground reads to render the request:
 
-The registration contract on the spec, by role:
+```jsonc
+{
+  "toolCallId": "call_abc",        // protocol context: ties the result back to the call
+  "toolName": "request_connection",// data / identity: the dispatch key
+  "input": { "integration": "github" }, // data: the call arguments, owned by the model
+  "render": { "kind": "connect" }  // metadata: a presentation hint, on the data-render channel
+}
+```
 
-- `executor: "client"` (`kind: "client"`) — **config / routing**: the execution location.
-  Platform-owned, set in the catalog. The single source of truth for "client-handled."
-- `name` — **metadata / identity**: the playground dispatch key.
-- `input_schema` — **data**: the call-argument contract.
-- `render` (optional) — **metadata**: a presentation hint that refines dispatch.
-- `needs_approval` — **policy**, orthogonal: a client tool *may* also be approval-gated, but
-  `request_connection` is not (connecting is its own confirmation).
+- `toolCallId` is protocol context. Correlation, per call, platform-owned. We reuse the
+  existing id; we do not mint a parallel one.
+- `toolName` is data and the stable dispatch key. `request_connection` maps to a connect
+  widget, `commit_revision` to a config-diff widget later, a future tool to its own widget.
+- `input` is data. The tool arguments the model produced. The widget reads them to know what to
+  show.
+- `render` is metadata, a presentation directive. It refines dispatch when the name alone is
+  too coarse. It carries no behavior and no secret, and the playground may ignore it.
 
-The playground registry is a `Record<string, ClientToolHandler>` keyed by `render.kind` or
-`name`. v1 has one entry. Each later client tool is one added entry, not a protocol change.
-
-### 2. Dispatch location — what fires in the playground
-
-The AI SDK gives two entry points; we use the second for any tool that needs human action.
-
-- **`onToolCall({ toolCall })` on `useChat`** fires the instant a client tool call streams in.
-  It fits a **fully automatic** client tool that can compute and return (or call
-  `addToolOutput`) immediately. It is the wrong place for connect, whose result needs the user
-  for seconds to minutes. Note it as available; v1 does not use it.
-- **Render-from-parts plus `addToolOutput`** is the **interactive** pattern, and where dispatch
-  lives. The tool part sits in `input-available` (unsettled). The message-part renderer — the
-  same place `ToolActivity` renders approve and deny today — dispatches the per-tool widget by
-  `render.kind` then `name`, falling back to a generic widget. The widget drives the
-  interaction, then calls `addToolOutput({ tool, toolCallId, output })`. The part flips to
-  `output-available`, and `lastAssistantMessageIsCompleteWithToolCalls` makes
-  `sendAutomaticallyWhen` auto-resend.
-
-So dispatch lives in the message-part renderer, not in `onToolCall`, for interactive tools.
-
-Concretely, for `request_connection`:
-
-1. The stream delivers `tool-input-available` for `request_connection` (plus an optional
-   `data-render`). The part is unsettled.
-2. The runner parks; the turn finishes cleanly.
-3. The renderer sees an unsettled client tool part named `request_connection` and dispatches
-   the connect widget.
-4. The widget calls `POST /tools/connections/`, opens the returned `redirect_url` in a popup,
-   and listens for the callback `postMessage`.
-5. On completion it calls `addToolOutput({ tool: "request_connection", toolCallId, output: {
-   connected: true, integration, slug } })`.
-6. `lastAssistantMessageIsCompleteWithToolCalls` is now true, so `useChat` auto-resends.
-7. The runner cold-replays, resolves the parked call by `approvalKey(name, args)`, and the
-   agent continues.
-
-This needs one generalization of the resume predicate. Today `agentShouldResumeAfterApproval`
-wraps the approval predicate. It must also resume on a settled client-tool output — compose it
-with `lastAssistantMessageIsCompleteWithToolCalls`. The clean form is one predicate that
-returns true when every non-provider-executed tool part on the last assistant turn is settled
-(`output-available`, `output-error`, or `approval-responded`) and at least one was just
-resolved. That is a small superset of today's function. Arda owns it; we supply the contract.
-
-### 3. Return path and UI
-
-**The resume envelope (the callback).** The result is a tool output keyed to the parked call.
-`addToolOutput` carries it home as a `tool_result` block in the next message's history:
+What the playground sends back, on the next turn's message history:
 
 ```jsonc
 {
   "type": "tool_result",
-  "toolCallId": "call_abc",          // protocol context: the cold-replay anchor
+  "toolCallId": "call_abc",        // protocol context: the cold-replay anchor
   "toolName": "request_connection",
   "output": { "connected": true, "integration": "github", "slug": "github-main" }
 }
 ```
 
-- `toolCallId` / `toolName` — **protocol context**. The runner re-keys by
-  `approvalKey(name, args)` on resume.
-- `output` — **data**, and a **reference**, never the secret: `integration` plus `slug` (or as
-  little as `{ "connected": true }`). The runner re-resolves the real credential from the vault.
-- Failure and cancel must also settle the part. If the user closes the popup or OAuth fails, the
-  widget calls `addToolOutput` with `{ connected: false, reason }` (or the error form via
-  `errorText`). The agent then learns it failed and can re-ask. Never leave the part unsettled;
-  an unsettled part hangs the resume.
+- `toolCallId` and `toolName` are protocol context. The runner re-keys by
+  `approvalKey(name, args)` on resume, the existing match path.
+- `output` is data, and for a connection it is a reference, never the credential. The
+  connection lives in the project vault, keyed `(project_id, provider_key, integration_key,
+  slug)`. The runner re-resolves the real credential server-side on the resumed turn. Putting
+  the secret in the stream or the message would leak it into transcripts and traces for no
+  gain, since the runner re-resolves anyway.
 
-**The UX of showing the result — Arda's call.** The wire envelope is identical either way; this
-is pure presentation.
+The single most important rule: the result is a `tool_result` keyed to the call, and it carries
+a reference, not a secret.
 
-- **Option U1 — an inline status chip (lean).** The connect interaction renders as a compact
-  tool-activity row, the same visual language as the approve/deny row: "Connect GitHub" with a
-  button, collapsing on success to "GitHub connected" with a check. The raw tool result is not
-  shown as a chat bubble.
-  - Motivation: consistent with the existing HITL UI, low noise, and the result is plumbing the
-    user does not need to read. This matches Mahmoud's "hidden behind a status indicator."
-- **Option U2 — a plain chat message.** The result posts as a visible turn ("Connected GitHub")
-  in the transcript.
-  - Motivation: maximally legible; the conversation literally shows what happened. But it is
-    noisier, it can imply the user typed something they did not, and it duplicates what the
-    agent will restate on resume.
+### Registration: one flag, three layers
 
-Lean: **U1**, for consistency with the approval UI and lower noise. Move to U2 only if testing
+"This tool runs on the client" is one field on the execution-location axis of the executor
+taxonomy (builtin, gateway, code, client). It is platform-owned and long-lived. It must flow
+unchanged from the catalog to the wire to the playground. We do not scatter it across
+feature-named fields.
+
+Layer A, the platform catalog (us). `request_connection` is a hard-coded platform op beside
+`find_capabilities` and `commit_revision` (`sdks/python/agenta/sdk/agents/platform/`).
+One correction from the old draft: the platform op model has no `executor` field today, and
+every existing op is server-executed by an HTTP method and path. `request_connection` is the
+first op with `executor: "client"` and no method or path, because the playground runs it. So
+this is a small new shape in the catalog, not a reuse of an existing one.
+
+Layer B, the spec and the wire (us). The resolver maps a `client` platform op to a
+`ClientToolSpec` (`kind: "client"`), the model that already exists. The spec carries the client
+marker on the wire to the runner, so the runner knows to emit and park rather than dispatch to
+the sandbox. No new wire shape; the `client` spec exists, unused.
+
+Layer C, the playground (Arda). The playground must know which streamed tool calls are its job,
+and it must never guess. Two facts make this robust.
+
+- Implicit, from Vercel: any tool call that arrives with no server output is client-handled,
+  and `providerExecuted` reads falsy. This seam is already in use; `agentApprovalResume.ts`
+  filters `providerExecuted !== true`.
+- Explicit, so the playground never guesses: the playground keeps a registry of client-tool
+  handlers, keyed by `render.kind` first, then by `name`. A streamed tool call that is not in
+  the registry and has no server output is an error surface. The playground renders a generic
+  "this app cannot handle that request" widget. It never hangs silently.
+
+The registry is a `Record<string, ClientToolHandler>`. v1 has one entry, `request_connection`.
+Each later client tool is one added entry, not a protocol change.
+
+The spec fields, by role:
+
+- `executor: "client"` (`kind: "client"`) is config and routing: the execution location.
+  Platform-owned, set in the catalog. The single source of truth for "client-handled."
+- `name` is metadata and identity: the dispatch key.
+- `input_schema` is data: the argument contract.
+- `render` is metadata: the presentation hint that refines dispatch.
+- `needs_approval` is policy, and orthogonal. A client tool may also be approval-gated.
+  `request_connection` is not, because connecting is its own confirmation.
+
+### Where dispatch lives
+
+The AI SDK offers two entry points. We use the second for any tool that needs a human.
+
+- `onToolCall` fires the instant a client tool call streams in. It fits a fully automatic tool
+  that can compute and return at once. It is the wrong place for connect, which needs the user
+  for seconds to minutes. We note it as available; v1 does not use it.
+- The message-part renderer is the interactive pattern, and where dispatch lives. This is the
+  same place `ToolActivity` renders approve and deny today. The renderer sees an unsettled
+  client tool part, dispatches the widget by `render.kind` then `name`, and falls back to the
+  generic widget. The widget drives the interaction, then calls `addToolOutput`. The part flips
+  to settled, and `lastAssistantMessageIsCompleteWithToolCalls` makes `sendAutomaticallyWhen`
+  resend.
+
+This needs one generalization of the resume predicate. Today `agentShouldResumeAfterApproval`
+wraps the approval predicate. It must also resume on a settled client-tool output. The clean
+form is one predicate that returns true when every non-provider-executed tool part on the last
+assistant turn is settled (`output-available`, `output-error`, or `approval-responded`) and at
+least one was just resolved. That is a small superset of today's function. Whether it stays one
+predicate or composes two is Arda's call at the seam.
+
+### The resume envelope
+
+The result is a tool output keyed to the parked call. `addToolOutput` carries it home as the
+`tool_result` block shown above. The output is a reference, never the secret: `integration`
+plus `slug`, or as little as `{ "connected": true }`.
+
+Failure and cancel must also settle the part. If the user closes the popup or the OAuth flow
+fails, the widget calls `addToolOutput` with `{ connected: false, reason }` (or the error form
+via `errorText`). The agent then learns it failed and can re-ask. An unsettled part hangs the
+resume, so the widget settles the part on every path.
+
+### Showing the resume to the user
+
+The wire envelope is identical either way. This is pure presentation, and it is Arda's call.
+
+- Option U1, an inline status chip (lean). The connect interaction renders as a compact
+  tool-activity row, the same visual language as approve and deny: "Connect GitHub" with a
+  button, collapsing on success to "GitHub connected" with a check. The raw tool result never
+  shows as a chat bubble. This is consistent with the HITL UI, low noise, and treats the result
+  as plumbing the user does not need to read.
+- Option U2, a plain chat message. The result posts as a visible turn ("Connected GitHub") in
+  the transcript. This is maximally legible, but it is noisier, it can imply the user typed
+  something they did not, and it duplicates what the agent restates on resume.
+
+Lean: U1, for consistency with the approval UI and lower noise. Move to U2 only if testing
 shows people miss that a connection happened.
 
 ### The post-connection handoff
 
-The callback says only "the connection now exists." It does **not** add the tool to the agent.
-After the resume, the agent must re-resolve or re-run discovery to actually wire and use the
-tool:
+The callback says only that the connection now exists. It does not add the tool to the agent.
+After the resume, the agent re-runs discovery to wire the tool and use it:
 
 1. The resume turn arrives carrying the connect tool result.
-2. The agent re-runs `find_capabilities` (or re-resolves the gateway tool). The
-   `ConnectionRequirement` now reads `ready` with a `slug`.
-3. The agent adds the gateway tool to its config (or calls it) and proceeds.
+2. The agent re-runs `find_capabilities`. The `ConnectionRequirement` now reads `ready` with a
+   `slug`.
+3. The agent adds the gateway tool to its config or calls it, and proceeds.
 
-This loop is **teaching, not transport**. Our primitive delivers the "connection ready" signal;
-the **agent-skills / agent-creation-skills project owns the skill** that teaches the agent the
-full loop (discover, `request_connection`, re-discover, add the tool). Flag this as a
-cross-project dependency. Because connections are project-scoped, the re-resolve succeeds on the
-very next turn.
+This loop is teaching, not transport. Our primitive delivers the "connection ready" signal. The
+agent-skills project owns the skill that teaches the full loop (discover, `request_connection`,
+re-discover, add the tool). This is a cross-project dependency. Because connections are
+project-scoped, the re-resolve succeeds on the very next turn.
 
-## Part 2 — Problem 1: the agent changes its own config
-
-### What happens today
+## Application 1: the agent edits its own config
 
 `commit_revision` is a platform op with `default_needs_approval=True` and
-`default_permission="ask"`. The running variant id is server-bound from the run context, so
-the agent commits to its own default variant. The approval gate is therefore **already
-available** through the permission flow in Part 1's "what we have." When the agent calls
-`commit_revision`, the run parks on a permission gate; the user sees the request; on approve
-the commit runs server-side; on deny it does not.
+`default_permission="ask"`. The running variant id is bound server-side from run context, so
+the agent commits to its own default variant. The approval gate is therefore already available
+through the HITL flow above. When the agent calls `commit_revision`, the run parks on a
+permission gate, the user sees the request, and on approve the commit runs server-side.
 
-Two pieces follow from D1: the approval gate stays a per-tool choice (we do not hardcode it),
-and the refresh must fire whether or not a human approved.
+Two things follow from D1.
 
-### Step 1 — the approval gate is per-tool (D1)
+First, the gate stays per-tool. There is no "always approve" to decide, and that is the point.
+Whether `commit_revision` parks is the tool's own `needs_approval`. The default is `True`, a
+sensible default for "the agent rewrote itself," but it is a default, not a hardcode. An author
+or a future auto-commit mode can set it to `False`, and the agent then commits directly. The
+refresh below still runs.
 
-There is no "always approve" decision to make here, and that is the point. Whether
-`commit_revision` parks for a human is the tool's own `needs_approval`, read by the existing
-approval boundary:
+The approval widget is generic now and per-tool later. v1 renders the generic approval widget,
+which shows the tool input. For `commit_revision` that input is the new config. We do not build
+a config diff yet. The frame carries the tool name and a `render` hint, so a later
+`render: { kind: "config-diff" }` on `commit_revision` lets the playground swap in a real
+before-and-after diff with no protocol change. Raw JSON is a weak approval surface, so the diff
+is the expected first per-tool widget, but it is a follow-up.
 
-- `commit_revision` ships with `default_needs_approval=True`, so by default the run parks and
-  the user approves before the commit takes effect (park-before-run semantics). This is a
-  sensible default for "the agent rewrote itself," but it is a default, not a hardcode.
-- An author (or a future "auto-commit" mode) can set `needs_approval=False` on the tool config.
-  The agent then commits directly, with no gate. The refresh in step 3 still runs.
+Second, the refresh is the universal requirement. Today the playground reads the latest revision
+per request through `workflowLatestRevisionQueryAtomFamily`. When the agent commits through
+`commit_revision`, the playground has no signal that a new revision landed. It needs one, and it
+needs it in both paths: the gated path (a human approved, the commit runs on the resume turn)
+and the direct path (`needs_approval=False`, the commit runs inside the turn). The clean way to
+cover both is to emit the refresh when the commit succeeds, not when it is approved. Success
+happens in both paths, so one emit point covers both.
 
-So Problem 1 needs no new gate logic. It needs the **refresh** (step 3), plus the
-**per-tool approval UI hook** the contract now carries.
+Locked: a named refresh frame (R1). On a successful `commit_revision`, the runner or SDK emits
+a one-way `data` event, `data-committed-revision`, with `{ variantId, revisionId, version }`.
+The playground listens and invalidates `workflowLatestRevisionQueryAtomFamily`, which refreshes
+the panel and the section drawers. This is role-correct: the signal is metadata, "the config
+changed, here is the new reference," so it belongs on the one-way `data-<name>` channel, not on
+a tool result. (R2 and R3 are recorded under Rejected alternatives.)
 
-**The approval UI: generic now, per-tool later.** v1 renders the generic approval widget — it
-shows the tool input, which for `commit_revision` is the new config under
-`workflow_revision.data`. Do not build a config diff yet. But the frame carries the tool name
-and a `render` hint (Part 1, "per-tool dispatch"), so a later `render: { kind: "config-diff" }`
-on `commit_revision` lets the playground swap in a real before/after diff with no protocol
-change. Raw JSON is a weak approval surface for anything non-trivial, so the diff is the
-expected first per-tool widget — but it is a follow-up, not v1.
+## Application 2: the agent needs a connection
 
-### Step 2 — the new commit on the default variant
+The end-to-end flow:
 
-No design choice here; the platform op already targets the running variant and appends a
-revision. Worth stating only so the refresh in step 3 knows what to listen for: a successful
-`commit_revision` produces a new revision id and version on the default variant.
-
-### Step 3 — refresh the config panel (the universal requirement, D1)
-
-This is the one piece D1 makes mandatory. Today the playground reads the latest revision per
-request via `workflowLatestRevisionQueryAtomFamily`. When the agent commits through
-`commit_revision` (server-side, not the playground's own commit modal), the playground has no
-signal that a new revision landed. It needs one, and it needs it **in both paths**: the gated
-path (a human approved, the commit runs on the resume turn) and the direct path
-(`needs_approval=False`, the commit runs inside the turn).
-
-The clean way to satisfy both: emit the refresh signal when `commit_revision` **succeeds**, not
-when it is approved. Success happens in both paths, so one emit point covers both.
-
-**Option R1 — a named "revision committed" data frame (locked).** On a successful
-`commit_revision`, the runner or SDK emits a one-way `data` event,
-`data-committed-revision`, with `{ variantId, revisionId, version }`. The playground listens
-and invalidates `workflowLatestRevisionQueryAtomFamily`, which refreshes the panel and the
-section drawers (#4881). Emitting on success (not on approval) is what makes it fire in both
-the gated and the direct path.
-
-- Motivation: this is the role-correct design. The signal's role is metadata — "the config
-  changed, here is the new reference." It belongs on the existing one-way `data-<name>`
-  channel, not piggybacked on a tool result. It is explicit, typed, and decoupled from any one
-  tool's output shape. The #4904 "committed revision reference" work is the natural home.
-
-**Option R2 — key off the `commit_revision` tool result (pragmatic).** The playground already
-sees the `tool-output-available` frame for `commit_revision`. Its output carries the new
-revision id. The playground invalidates the query when it sees that specific tool settle.
-
-- Motivation: no new frame; possibly works today with #4904 already in place. Fastest.
-- Cost: couples the playground to a platform tool name and its output shape. If the tool is
-  renamed or its output changes, the refresh silently breaks.
-
-**Option R3 — blind refetch on turn finish.** Refetch the latest revision whenever a turn
-finishes.
-
-- Motivation: trivial.
-- Cost: wasteful and racy; refetches on every turn whether or not anything changed, and can
-  race the commit's write.
-
-Locked: **R1**, emitted on commit success. It is the clean contract, it matches where #4904
-already points, and emitting on success is what gives us both paths for free. **R2** is an
-acceptable stopgap if #4904 already exposes the committed reference on the tool result and we
-want Problem 1 visibly working this week — but it must still trigger in both paths, so confirm
-the tool-output frame appears for a direct (un-gated) commit before relying on it. Avoid R3.
-
-### Problem 1 owner split
-
-- Approval gate: already wired and per-tool (D1); no new gate work for us.
-- Generic approval UI: the shared dispatcher's generic widget (Arda), built in Part 1.
-- Per-tool config-diff render (follow-up): SDK attaches `render: { kind: "config-diff" }` (us);
-  the diff widget is Arda.
-- Refresh signal (R1): emit `data-committed-revision` on commit success in both paths (us,
-  SDK/runner); listen and invalidate the query (Arda).
-
-## Part 3 — Problem 2: the agent needs a connection that does not exist
-
-### The end-to-end flow
-
-1. The agent learns it needs a connection from **discovery**: it calls `find_capabilities`
-   (the discovery platform op), which returns a `ConnectionRequirement` with `state`
-   (`ready` / `needs_auth` / `needs_input`) and a `connect` affordance. A skill teaches the
-   agent the discover-then-connect loop (D2).
-2. The agent calls `request_connection(integration)`. The runner raises a client-tool
-   interaction: "connect GitHub." The run parks.
-3. The playground dispatches a **connect widget**: it shows the integration, calls
+1. The agent learns it needs a connection from discovery. It calls `find_capabilities`, which
+   returns a `ConnectionRequirement` with `state` (`ready`, `needs_auth`, or `needs_input`) and
+   a `connect` affordance. A skill teaches the discover-then-connect loop (D2).
+2. The agent calls `request_connection(integration)`. The runner streams the call and parks.
+3. The playground dispatches the connect widget. It shows the integration, calls
    `POST /tools/connections/`, and opens the returned `redirect_url` (the OAuth flow) in a
    popup.
-4. The user finishes OAuth. The callback (`GET /tools/connections/callback`) activates the
-   connection in the project vault and posts a message to the opener window.
-5. The moment the connect widget hears that message, it writes the result back as a
-   `tool_result` (`{ connected: true, integration, slug }`) keyed to the parked tool call. The
-   resume predicate fires and the conversation auto-resends.
-6. The runner resumes, re-resolves the tool (the connection now exists in the vault), and the
-   agent proceeds.
+4. The user finishes OAuth. The callback activates the connection in the project vault and posts
+   a message to the opener window.
+5. The widget hears that message and calls `addToolOutput` with
+   `{ connected: true, integration, slug }`, keyed to the parked call. The resume predicate
+   fires and the conversation auto-resends.
+6. The runner cold-replays, resolves the parked call by `approvalKey(name, args)`, re-resolves
+   the connection from the vault, and the agent proceeds.
 
-### Where the connection request comes from
+The connection request is an explicit tool, driven by discovery (D2). The agent calls
+`find_capabilities`, sees a requirement that is not `ready`, and calls
+`request_connection(integration)`. The `connect` affordance (which endpoint to call, with what
+body) rides in the tool input or the render hint, so the playground speaks Agenta, never
+Composio. The agent decides when to ask and can explain why in its own words first. This is the
+seam the builder-capabilities project depends on for triggers and subscriptions.
 
-**Locked: an explicit `request_connection` tool, driven by discovery (D2).** The agent calls
-`find_capabilities`, sees a `ConnectionRequirement` that is not `ready`, and calls
-`request_connection(integration)`. A skill teaches that loop. The call round-trips through
-Part 1's primitive. The `connect` affordance (which endpoint to call, with what body) rides in
-the tool input or the render hint, so the playground speaks Agenta, never Composio.
+The result carries a reference, never the secret:
+`{ connected: true, integration: "github", slug: "github-main" }`. The connection persists at
+project scope, so a later run needs no re-prompt.
 
-- Motivation: explicit and legible. The agent decides when to ask and can explain why in its
-  own words first. It reuses the client-tool primitive with zero new transport. Connection
-  state is reported by discovery, not guessed. This is the seam the builder-capabilities
-  project depends on for its trigger and subscription work.
-- Cost: the agent must know to call it, so the skill must teach the discover-then-connect loop.
-  That skill already exists in spirit (the tool-discovery setup skill).
+`request_connection` is a client-executed platform op (D5), built per the registration section
+above. Its argument and output schema is likely `{ integration }` in and
+`{ connected, integration, slug }` out, with a `render` hint of `{ kind: "connect" }`. The
+connect affordance is shaped server-side by discovery, which already exists.
 
-**Rejected as primary, kept as an optional later safety net: runner auto-interception.** This
-is the runner catching a missing-connection *failure at call time* — the gateway tool resolve
-raises `ConnectionNotFoundError` mid-run, and the runner raises a connect interaction itself,
-with no agent tool call. Mahmoud finds this murky and prefers the agent to act on discovery
-plus skill guidance. The control flow would be implicit and live in the runner, and the thing
-that parks would be a synthetic interaction rather than a real model tool call, so the
-cold-replay anchor (`approvalKey(name, args)`) would have to be synthesized carefully. We may
-add it later only as a fallback, so an agent that skips discovery degrades to a connect prompt
-instead of a raw error. It is not in scope for v1.
+## Build-kit alignment
 
-### How the result comes back and resumes the agent
+This section references the default-agent-config project (inject-not-commit) and does not
+redesign it.
 
-Mahmoud described step 5 as "the frontend automatically sends a follow-up message with the
-result." There are two ways to send it, and the choice matters.
+The default platform tools and the authoring skill are an injected, read-only playground build
+kit. They are not committed to the agent config. The backend exposes the kit as a read-only
+`build_kit` descriptor at `revision.data.build_kit` in the `/inspect` response, grouped into
+`skills`, `tools`, and `permissions`; each row carries `key`, `name`, and `description`, and
+permission rows add `status`. A per-run flag `flags.inject_build_kit` on the run request turns
+injection on or off, defaulting off server-side.
 
-**Option P1 — a `tool_result` keyed to the parked tool call (recommended).** The connect
-widget writes the result as the parked client tool's output. Because it is a settled tool
-part, the (generalized) resume predicate auto-resends, exactly like an approval today. The
-runner resolves the parked call and the agent reads "connected" as the tool's return value.
+Two consequences for this project.
 
-- Motivation: it reuses the entire HITL machinery — park, cold-replay, the auto-resend
-  predicate, the `tool_result` envelope. The agent gets the answer in the right place: as the
-  return value of the tool it called. No fake turns, no transcript pollution. It is the same
-  envelope as approve/deny, so one code path covers both.
+First, `request_connection` is a platform tool, so it is part of the injected build kit, not the
+committed config. It appears as a `tools` row in `build_kit` whenever the kit is injected.
+Whether a published agent keeps it after commit is the default-agent-config project's call, not
+ours.
 
-**Option P2 — a fresh user message ("I connected GitHub").** The playground appends a normal
-user message and resends.
+Second, the config refresh in Application 1 should also refresh the build-kit display. When a
+commit lands, the new revision can change which kit rows apply, so the same
+`data-committed-revision` signal that invalidates the config panel should also refresh the
+build-kit view. We reference the descriptor and the flag; we do not change their shape.
 
-- Motivation: conceptually simplest; it is just another user turn.
-- Cost: the parked tool call is never resolved, so the runner either re-raises it or the model
-  is left guessing. It pollutes the transcript with a message the user did not write. It does
-  not reuse the resume predicate. It is the worse fit on every axis.
-
-Locked: **P1 (D4).** It matches "send the result back and resume" while reusing the proven
-path. The "follow-up message" framing maps to this structured result, not a literal chat
-message; P2 is recorded only as the rejected alternative.
-
-What the result carries: a **reference**, never the secret.
-`{ connected: true, integration: "github", slug: "github-main" }`. The connection lives in the
-project vault; the runner re-resolves the real credential on resume. The connection is
-project-scoped, so it persists beyond the session, and a later run needs no re-prompt.
-
-### Problem 2 owner split
-
-- `request_connection` as a platform-catalog tool with a `client` executor, plus its
-  argument/output schema and render hint (D5): us (SDK / catalog), with the connect affordance
-  shaped server-side by discovery (already built).
-- The **connect widget** — show the integration, call `POST /tools/connections/`, open the
-  OAuth popup, listen for the callback `postMessage`, call `addToolOutput`: Arda. This is the
-  main new frontend surface for Problem 2.
-- Generalized resume predicate (a settled client-tool output triggers resend): Arda (the
-  `agentShouldResumeAfterApproval` seam, composed with
-  `lastAssistantMessageIsCompleteWithToolCalls`).
-- The **skill** that teaches the discover, `request_connection`, re-discover, add-tool loop:
-  the agent-creation-skills project (cross-project dependency; our primitive only delivers the
-  "connection ready" signal).
-- Default-set membership (does a new agent get `request_connection`?): the default-agent-config
-  project.
-- Optional later safety net (runner auto-interception): us (runner + API); out of v1 scope.
-
-## The frontend-versus-us split, at a glance
+## Work split
 
 Most of this is frontend, and most of the frontend is Arda's call.
 
-**Us (SDK, runner, API):**
+Us (SDK, runner, API):
 
-- Runner: `onClientTool` responder (emit + park + resume), built as the generic client-tool
-  path (D3); generalize result extraction beyond `{approved}` to any structured tool output,
-  keyed by `approvalKey(name, args)`.
-- SDK: project `interaction_request kind="client_tool"` to a stream frame; parse the inbound
-  client-tool `tool_result` (widen the approval parsing); define the `request_connection`
-  platform op with a `client` executor (D5); carry `toolCall.name` plus `render` on the frame so
-  the playground can dispatch per-tool UIs later (D1).
-- API/SDK: emit the `data-committed-revision` refresh frame on commit success, in both the
-  gated and direct paths (R1, D1).
-- Out of v1 scope: runner auto-interception of a missing-connection failure (the rejected
-  safety net, D2).
+- Runner: add `onClientTool` to `Responder`; emit the call and park on an unresolved client
+  tool exactly as permission parks; resolve from the inbound `tool_result` on resume.
+  Generalize the decision extraction beyond `{approved}` to any structured output, keyed by
+  `approvalKey(name, args)`.
+- SDK: surface a client tool as a standard unsettled tool part plus an optional `data-render`
+  hint (no new Vercel frame); widen the inbound `tool_result` parsing for client tools in
+  `vercel/messages.py`; add `request_connection` as a `client` platform op (the new
+  `executor: "client"`, no method or path) and map it to `ClientToolSpec`.
+- API or SDK: emit `data-committed-revision` on commit success, in both the gated and direct
+  paths (R1).
 
-**Arda (frontend), the decisions that are his:**
+Arda (frontend), the calls that are his:
 
-- The client-tool **dispatcher**, living in the message-part renderer (sibling to today's
-  `ToolActivity` approval UI): which widget renders for which `render.kind` then tool `name`,
-  with a generic widget as the fallback and an explicit "cannot handle that" surface for an
-  unknown client tool. v1 ships only the generic widget; per-tool widgets are added cases later
-  (D1, D3). This is the central new surface and the main "is this how we want it to look and
-  behave" call.
-- The **connect widget**: the OAuth popup, the callback listener, and the reply via
-  `addToolOutput` (success and the failure/cancel case both settle the part).
-- The result **UX** (U1 inline status chip versus U2 chat message; lean U1).
-- The **config-panel refresh** on the new revision (R1), and later the per-tool **config-diff**
-  approval widget.
-- The generalized **resume predicate**: `agentShouldResumeAfterApproval` composed with
-  `lastAssistantMessageIsCompleteWithToolCalls`, so a settled client-tool output resumes, not
-  only an approval.
+- The client-tool dispatcher in the message-part renderer (sibling to `ToolActivity`): which
+  widget renders for which `render.kind` then `name`, the generic widget as fallback, and an
+  explicit "cannot handle that" surface for an unknown client tool. v1 ships only the generic
+  widget. This is the central new surface.
+- The connect widget: the OAuth popup, the callback listener, and the reply through
+  `addToolOutput` (success and failure both settle the part).
+- The generalized resume predicate: `agentShouldResumeAfterApproval` extended so a settled
+  client-tool output resumes, not only an approval.
+- The result UX (U1 inline chip versus U2 chat message; lean U1).
+- The config-panel and build-kit refresh on `data-committed-revision`, and later the per-tool
+  config-diff widget.
 
-## Residual open items (not blocking; for the consolidation PR)
+Cross-project (coordinated, not ours to build):
 
-The headline decisions (D1-D5) are locked. These smaller choices fall out during implementation
-and do not need Mahmoud now:
+- The skill that teaches the discover, `request_connection`, re-discover, add-tool loop:
+  agent-skills.
+- Whether a new agent keeps `request_connection` after commit: default-agent-config.
 
-- The exact `render.kind` vocabulary (for example `connect`, `config-diff`). The dispatch
-  precedence is settled (`render.kind` then `name` then generic fallback); only the string
-  values remain, an implementation detail to settle with Arda.
-- The `request_connection` arguments and output schema (likely `{ integration }` in, `{
-  connected, integration, slug }` out) and its exact `render` hint.
-- Whether the resume predicate stays one function that covers both approvals and client-tool
-  outputs, or two composed predicates. Same behavior; Arda's call at the seam.
-- The `data-committed-revision` payload's exact fields beyond `{ variantId, revisionId,
-  version }` (for example a human-readable label), once the panel-refresh code names what it
-  needs.
+## Rejected alternatives
 
-Resolved in round 3: `request_connection` is a platform-catalog tool with a `client` executor
-(D5), not an either/or; the default-agent-config project decides whether it ships in a new
-agent's default tool set.
+- Two narrow interaction kinds. Keep `permission` and add a dedicated `connect` kind, each with
+  a bespoke frame and widget. Smaller blast radius, but the third interaction repeats the work,
+  the `client` executor stays dead, and we pay the generalization later with two special cases
+  to retire. D3 chose the generic primitive.
+- A fresh user message for the connection result ("I connected GitHub"). The parked call would
+  never resolve, so the runner would re-raise it or the model would guess. It pollutes the
+  transcript with text the user did not write and reuses none of the resume machinery. D4 chose
+  the `tool_result`.
+- Refresh off the `commit_revision` tool result (R2). The playground keys the panel refresh off
+  the tool's output frame. No new frame, possibly fastest, but it couples the playground to a
+  platform tool name and output shape, and it must still fire in the direct un-gated path.
+  Acceptable only as a short-lived stopgap. Avoid R3, a blind refetch on every turn finish,
+  which is wasteful and can race the write.
+- Runner auto-interception of a missing-connection failure. The gateway resolve raises
+  `ConnectionNotFoundError` mid-run and the runner raises a connect interaction itself, with no
+  agent tool call. The control flow is implicit and lives in the runner, and the parked thing is
+  a synthetic interaction rather than a real model tool call, so the cold-replay anchor must be
+  synthesized carefully. We may add it later as a fallback, so an agent that skips discovery
+  degrades to a connect prompt instead of a raw error. Out of v1 (D2).
+
+## Open questions (non-blocking)
+
+These settle during implementation, with Arda, and do not need Mahmoud now.
+
+- The `render.kind` vocabulary (for example `connect`, `config-diff`). The dispatch precedence
+  is settled (`render.kind`, then `name`, then generic fallback); only the string values remain.
+- The exact `request_connection` argument and output schema, and its `render` hint.
+- Whether the resume predicate stays one function or composes two. Same behavior either way.
+- The `data-committed-revision` payload beyond `{ variantId, revisionId, version }`, once the
+  refresh code names what it needs.
+
+## Cross-project dependencies
+
+- agent-skills owns the skill that teaches the discover-then-connect loop. Our primitive only
+  delivers the "connection ready" signal.
+- default-agent-config owns the `build_kit` descriptor and `flags.inject_build_kit`, and decides
+  whether `request_connection` ships in a published agent. We reference both.
+- agent-builder-capabilities rides this primitive for triggers and subscriptions, and gates a
+  live subscription test on a connection. We keep the contract general enough to serve it.
+
+## References
+
+Sibling docs (read to align, do not edit):
+`../default-agent-config/`, `../advanced-build-kit/`, `../agent-skills/`,
+`../agent-builder-capabilities/`, `../agent-builds-an-app/`.
+
+Code anchors (verified 2026-06-28):
+
+- Neutral event and responder: `services/agent/src/protocol.ts`,
+  `services/agent/src/responder.ts` (`approvalKey`, decision extraction).
+- Park and finish: `services/agent/src/engines/sandbox_agent.ts`.
+- Client-tool guard: `services/agent/src/tools/dispatch.ts`.
+- Stream and inbound parsing: `sdks/python/agenta/sdk/agents/adapters/vercel/stream.py`
+  (`tool-approval-request`, `data-<name>`), `.../vercel/messages.py`.
+- Tool models: `sdks/python/agenta/sdk/agents/tools/` (`ClientToolSpec`, `kind: "client"`).
+- Platform catalog: `sdks/python/agenta/sdk/agents/platform/op_catalog.py`
+  (`find_capabilities`, `commit_revision`; no `executor` field yet).
+- Frontend: `web/oss/src/components/AgentChatSlice/`,
+  `web/packages/agenta-playground/src/state/execution/agentApprovalResume.ts`.
+- Connections API: `api/oss/src/apis/fastapi/tools/router.py` (`/tools/discover`,
+  `/tools/connections/`, OAuth callback `postMessage`, `ConnectionNotFoundError` 404).

--- a/docs/design/agent-workflows/projects/agent-fe-roundtrip/design.md
+++ b/docs/design/agent-workflows/projects/agent-fe-roundtrip/design.md
@@ -1,124 +1,113 @@
-# Frontend round-trip: a client tool that asks the human
+# Frontend round-trip: client tools that ask the human
 
 Status: design, ready for review. Date: 2026-06-28. Owner: agent-workflows.
 Audience: Arda (most of the frontend), us (SDK, runner, API).
 
-This doc owns one primitive: a tool call that leaves the agent, travels to the playground,
-shows the user something, waits for the user to act, and resumes the agent with the result.
-We design that primitive once, then point it at two jobs.
+An agent sometimes needs the human in the middle of a run. This doc owns one primitive that
+serves that need: a tool call that leaves the agent, reaches the playground, shows the user
+something, waits, and resumes the agent with the result. We design the primitive once and point
+it at two jobs.
 
 ## The problem
 
-An agent sometimes needs the human in the middle of a run. Two cases drive this work, and they
-are the same shape.
+Two cases drive this work, and they share one shape.
 
 1. The agent edits its own config. It calls `commit_revision` to write a new revision of
-   itself. The user should usually approve that first, and the playground must then show the
-   new config.
-2. The agent needs a connection it does not have. It wants to call a GitHub tool, but no GitHub
-   connection exists. The user must finish an OAuth flow before the agent can continue.
+   itself. The user usually approves first, and the playground then shows the new config.
+2. The agent needs a connection it lacks. It wants a GitHub tool, but no GitHub connection
+   exists. The user must finish an OAuth flow before the agent can continue.
 
-Both cases pause the run, surface something in the playground, wait, and resume the agent with
-a result. One primitive serves both. The builder-capabilities work (triggers, subscriptions)
-rides the same primitive, so we keep it general.
+Both cases pause the run, surface something in the playground, wait for the user, and resume the
+agent with a result. One primitive carries both. The builder-capabilities work (triggers,
+subscriptions) rides the same primitive, so we keep it general.
 
-## Approach in one paragraph
+## The shape, in one paragraph
 
-We do not invent a transport. We already ship this round-trip: the human-in-the-loop (HITL)
-approval flow pauses a run, renders approve or deny, waits, and resumes. The Vercel AI SDK
-ships two matching halves, and we already use one. The approval half drives HITL today. The
-client-tool half is the sibling we reuse here: a tool with no server execute is fulfilled by
-the client, which supplies the result and triggers an automatic resend. The runner's current
-rule, "forbid client tools," becomes "emit the call and park." That is the whole idea. The rest
-of this doc is the contract, the two applications, and the work split.
+We reuse a transport we already ship. The human-in-the-loop (HITL) approval flow pauses a run,
+renders approve or deny, waits, and resumes on the next message. The Vercel AI SDK ships two
+matching halves; we use one today. The approval half drives HITL. The client-tool half is the
+sibling we reuse: a tool with no server execute is fulfilled by the client, which supplies the
+result and triggers an automatic resend. The runner's current rule, "forbid client tools,"
+becomes "emit the call and park." That is the whole idea. The rest of this doc is the contract,
+the two applications, and the work split.
 
 ## Scope
 
 In v1:
 
-- One generic client-executor round-trip that any client tool can use.
-- `request_connection` as the first client tool, for the connection case.
+- One generic client-tool round-trip that any browser-fulfilled tool can use.
+- `request_connection` as the first such tool, for the connection case.
 - `commit_revision` approval through the existing gate, plus a refresh of the config panel.
-- A reference-only resume envelope, with failure and cancel both settled.
+- A reference-only resume envelope, with success, failure, cancel, and abandon all settled.
 
-Out of v1, recorded so no one rebuilds them by accident:
+Out of v1, recorded so no one rebuilds them:
 
-- A config diff. v1 ships a generic approval widget. A per-tool diff is a later widget, not a
-  new contract.
+- A config diff widget. v1 ships a generic approval widget; a per-tool diff is a later widget,
+  not a new contract.
 - Runner auto-interception of a missing-connection failure. The agent asks for a connection
-  explicitly, taught by a skill. Auto-interception stays a future safety net (see Rejected
-  alternatives).
+  explicitly, taught by a skill. Auto-interception stays a future safety net (see Appendix).
 
 ## Decisions (locked 2026-06-28)
 
-These were the open questions. Mahmoud answered them. The rest of the doc honors them.
-
 | ID | Decision |
 | --- | --- |
-| D1 | Config-change approval is per-tool, not hardcoded. `needs_approval` stays the tool's own field, read by the existing approval gate. The new universal requirement is the refresh: after a commit lands, the playground refreshes the config panel, whether a human approved or the agent committed directly. The refresh fires in both paths. No config diff in v1, but the frame carries the tool name plus a render hint so a per-tool widget can be added later with no protocol change. |
-| D2 | The connection trigger is an explicit `request_connection` tool, driven by discovery and a skill. Runner auto-interception of a call-time failure is out of v1, kept only as a future option. |
-| D3 | Build the generic primitive, not a narrow connection flow. One client-tool round-trip carries both jobs and retires the dead `client` executor. |
-| D4 | The result returns as a structured tool result keyed to the parked call. It carries a reference (integration plus slug, or "connection ready"), never the secret. The runner re-resolves the credential from the vault on resume. Failure and cancel also settle the call so the run never hangs. |
-| D5 | `request_connection` is a hard-coded platform tool with a client executor. It sits in the same platform catalog as `find_capabilities` and `commit_revision`, except the runner does not execute it: the playground does. Because it is a platform tool, it is part of the injected build kit (see Build-kit alignment). |
+| D1 | Config-change approval is per-tool, not hardcoded. `needs_approval` stays the tool's own field, read by the existing approval gate. The universal requirement is the refresh: after a commit lands, the playground refreshes the config panel and the build-kit view, whether a human approved or the agent committed directly. The refresh fires in both paths. No config diff in v1; the frame carries the tool name plus a render hint so a per-tool widget can land later with no protocol change. |
+| D2 | The connection trigger is an explicit `request_connection` tool, driven by discovery and a skill. Runner auto-interception of a call-time failure is out of v1. |
+| D3 | Build the generic primitive, not a narrow connection flow. One client-tool round-trip carries both jobs and wires the declared-but-dormant `client_tool` interaction path. |
+| D4 | The result returns as a structured tool result keyed to the parked call. It carries a reference (integration plus slug, or "connection ready"), never the secret. The runner re-resolves the credential from the vault on resume. Success, failure, cancel, and abandon all settle the call so the run never hangs. |
+| D5 | `request_connection` is a non-runnable reference tool: a hard-coded platform workflow the build kit embeds with `@ag.embed`, the same way it embeds the authoring skill. It is not a platform op. The backend exposes the tool; the frontend handles the call. |
 
-## What exists today (verified in code)
+## What exists today (verified in code 2026-06-28)
 
-We are not starting from zero. Three things are already built or already shipped by the SDK.
+We start from a working round-trip, not from zero.
 
-The HITL round-trip already works end to end. When a tool needs approval:
+The HITL round-trip works end to end. When a tool needs approval:
 
 1. The runner raises a neutral `interaction_request` with `kind: "permission"`
    (`services/agent/src/protocol.ts`).
-2. The SDK projects that event to a Vercel `tool-approval-request` frame
+2. The SDK projects it to a Vercel `tool-approval-request` frame
    (`sdks/python/agenta/sdk/agents/adapters/vercel/stream.py`).
-3. The run parks: the runner ends the turn with stop reason `paused`, disposes the sandbox,
-   and emits a clean finish frame (`services/agent/src/engines/sandbox_agent.ts`).
+3. The run parks: the runner ends the turn with stop reason `paused`, disposes the sandbox, and
+   emits a clean finish frame (`services/agent/src/engines/sandbox_agent.ts`).
 4. The playground renders approve or deny in `ToolActivity` and, the moment the user decides,
    auto-resends through `sendAutomaticallyWhen: agentShouldResumeAfterApproval`
    (`web/oss/src/components/AgentChatSlice/`).
-5. The next turn carries the decision back as a `tool_result` block with an `{approved}`
-   output. The runner cold-replays the conversation and resolves the parked gate, keyed by
+5. The next turn carries the decision back as a `tool_result` block with an `{approved}` output.
+   The runner cold-replays the conversation and resolves the parked gate, keyed by
    `approvalKey(name, args)` (`services/agent/src/responder.ts`).
 
-So the transport exists: out through the stream, park, render, wait, resume on the next
-message. The decision even rides home in the right place, a `tool_result` keyed to the call.
-
 The rails for the generic case are laid but dormant. The neutral event already declares
-`kind: "permission" | "input" | "client_tool"`, and only `permission` is wired; `Responder`
-has `onPermission` but no `onClientTool`. The `client` executor exists as a model
-(`ClientToolSpec`, `kind: "client"` in `sdks/python/agenta/sdk/agents/tools/`), but the runner
-throws on any client tool on purpose (`services/agent/src/tools/dispatch.ts`). Nothing runs on
-the rails yet.
+`kind: "permission" | "input" | "client_tool"`, and only `permission` is wired; `Responder` has
+`onPermission` and no `onClientTool` (`services/agent/src/responder.ts`). A client tool is
+correctly refused in-sandbox: `dispatch.ts` throws because a client tool is browser-fulfilled and
+must never run in the sandbox (`services/agent/src/tools/dispatch.ts`). What is missing is the
+path that recognizes a client tool *before* dispatch and emits-and-parks it instead.
 
-The AI SDK ships both halves we need (`ai@6` and `@ai-sdk/react@3`, currently on the beta
-channel; all symbols below verified present in `node_modules`).
+The AI SDK ships both halves we need (`ai@6` and `@ai-sdk/react@3`, beta channel; all symbols
+below verified present in `node_modules`).
 
 - The approval half, in use today: `addToolApprovalResponse` records the decision, and
-  `lastAssistantMessageIsCompleteWithApprovalResponses` drives the resend. Our
+  `lastAssistantMessageIsCompleteWithApprovalResponses` drives the resend.
   `agentShouldResumeAfterApproval` wraps it.
 - The client-tool half, which we reuse: a tool with no server execute is client-handled. The
-  playground supplies the result through `addToolOutput` (the older `addToolResult` is
-  deprecated), and `lastAssistantMessageIsCompleteWithToolCalls` drives the resend. The
-  `providerExecuted` flag on a tool part says whether the server ran the tool, so the
-  playground can tell a server result from a client call.
-
-The gap is narrow. We have a working round-trip for one fixed interaction. We generalize it so
-any client tool can round-trip, then point it at two jobs.
+  playground supplies the result through `addToolOutput` (`addToolResult` is deprecated), and
+  `lastAssistantMessageIsCompleteWithToolCalls` drives the resend. The `providerExecuted` flag on
+  a tool part says whether the server ran the tool, so the playground tells a server result from a
+  client call.
 
 ## The primitive: a generic client-tool round-trip
 
 ### How it works
 
-A client-executor tool is a tool the playground runs, not the sandbox. The agent calls it like
-any other tool. The runner does not execute it. Instead it streams the tool call, parks the
-run, and waits. The playground dispatches a widget, the user acts, and the result returns on
-the next turn as a `tool_result` keyed to the same call. The agent reads the result as the
-tool's return value and continues.
+A client tool is a tool the playground runs, not the sandbox. The agent calls it like any other
+tool. The runner does not execute it. It streams the tool call, parks the run, and waits. The
+playground dispatches a widget, the user acts, and the result returns on the next turn as a
+`tool_result` keyed to the same call. The agent reads the result as the tool's return value and
+continues.
 
-This is the permission flow with two things generalized. The outbound side carries an arbitrary
-tool call, not just a permission ask. The inbound side carries an arbitrary tool output, not
-just `{approved}`. Everything between, the park, the cold-replay, and the resume, stays as it
-is.
+This is the permission flow with two parts generalized. The outbound side carries an arbitrary
+tool call, not just a permission ask. The inbound side carries an arbitrary tool output, not just
+`{approved}`. The park, the cold-replay, and the resume stay as they are.
 
 ### The contract, by role
 
@@ -126,258 +115,264 @@ Two boundaries cross: runner to playground (outbound) and playground to runner (
 classify each field by the role it plays, not the feature it touches.
 
 The outbound side needs no new Vercel frame. The permission flow projects a bespoke
-`tool-approval-request` frame because approval is a separate concern layered on top of the tool
-call. A client tool is different: the tool call itself is what the client fulfills. So the call
-rides as the standard unsettled tool part the runner already streams (`tool-input-available`,
-no output, `providerExecuted` falsy), and the optional presentation hint rides the existing
-one-way `data-render` channel (`data-<name>` in `stream.py`). The runner-internal
-`interaction_request kind="client_tool"` is what drives the park; it does not need its own
-wire frame.
+`tool-approval-request` frame because approval is a separate concern layered on the tool call. A
+client tool is different: the tool call itself is what the client fulfills. So the call rides as
+the standard unsettled tool part the runner already streams (`tool-input-available`, no output,
+`providerExecuted` falsy), and an optional presentation hint rides the existing one-way render
+channel (`data-<name>` in `stream.py`). The runner-internal `interaction_request kind="client_tool"`
+drives the park; it needs no wire frame of its own.
 
 What the playground reads to render the request:
 
 ```jsonc
 {
-  "toolCallId": "call_abc",        // protocol context: ties the result back to the call
-  "toolName": "request_connection",// data / identity: the dispatch key
-  "input": { "integration": "github" }, // data: the call arguments, owned by the model
-  "render": { "kind": "connect" }  // metadata: a presentation hint, on the data-render channel
+  "toolCallId": "call_abc",            // context: ties the result back to the call
+  "toolName": "request_connection",    // identity: the dispatch key
+  "input": { "integration": "github" },// data: the call arguments, owned by the model
+  "render": { "kind": "connect" }      // metadata: an optional presentation hint
 }
 ```
 
-- `toolCallId` is protocol context. Correlation, per call, platform-owned. We reuse the
-  existing id; we do not mint a parallel one.
-- `toolName` is data and the stable dispatch key. `request_connection` maps to a connect
-  widget, `commit_revision` to a config-diff widget later, a future tool to its own widget.
-- `input` is data. The tool arguments the model produced. The widget reads them to know what to
+- `toolCallId` is protocol context. Correlation, per call, platform-owned. We reuse the existing
+  id; we mint no parallel one.
+- `toolName` is identity and the stable dispatch key. `request_connection` maps to a connect
+  widget; a future tool maps to its own widget.
+- `input` is data, the tool arguments the model produced. The widget reads them to know what to
   show.
-- `render` is metadata, a presentation directive. It refines dispatch when the name alone is
-  too coarse. It carries no behavior and no secret, and the playground may ignore it.
+- `render` is metadata, an optional presentation hint on the one-way render channel. It refines
+  dispatch when the name alone is too coarse. It carries no behavior and no secret, and the
+  playground may ignore it. It lives on the stream, never in the committed config (see Build-kit
+  alignment).
 
 What the playground sends back, on the next turn's message history:
 
 ```jsonc
 {
   "type": "tool_result",
-  "toolCallId": "call_abc",        // protocol context: the cold-replay anchor
+  "toolCallId": "call_abc",            // context: the cold-replay anchor
   "toolName": "request_connection",
   "output": { "connected": true, "integration": "github", "slug": "github-main" }
 }
 ```
 
-- `toolCallId` and `toolName` are protocol context. The runner re-keys by
-  `approvalKey(name, args)` on resume, the existing match path.
-- `output` is data, and for a connection it is a reference, never the credential. The
-  connection lives in the project vault, keyed `(project_id, provider_key, integration_key,
-  slug)`. The runner re-resolves the real credential server-side on the resumed turn. Putting
-  the secret in the stream or the message would leak it into transcripts and traces for no
-  gain, since the runner re-resolves anyway.
+- `toolCallId` and `toolName` are protocol context. The runner re-keys by name and args on resume,
+  the existing match path.
+- `output` is data, and for a connection it is a reference, never the credential. The connection
+  lives in the project vault, keyed `(project_id, provider_key, integration_key, slug)`. The
+  runner re-resolves the real credential server-side on the resumed turn. Putting the secret in
+  the stream or the message would leak it into transcripts and traces for no gain.
 
-The single most important rule: the result is a `tool_result` keyed to the call, and it carries
-a reference, not a secret.
+The single most important rule: the result is a `tool_result` keyed to the call, and it carries a
+reference, not a secret.
 
-### Registration: one flag, three layers
+### Rename the cold-replay anchor to `parkedCallKey`
 
-"This tool runs on the client" is one field on the execution-location axis of the executor
-taxonomy (builtin, gateway, code, client). It is platform-owned and long-lived. It must flow
-unchanged from the catalog to the wire to the playground. We do not scatter it across
-feature-named fields.
-
-Layer A, the platform catalog (us). `request_connection` is a hard-coded platform op beside
-`find_capabilities` and `commit_revision` (`sdks/python/agenta/sdk/agents/platform/`).
-One correction from the old draft: the platform op model has no `executor` field today, and
-every existing op is server-executed by an HTTP method and path. `request_connection` is the
-first op with `executor: "client"` and no method or path, because the playground runs it. So
-this is a small new shape in the catalog, not a reuse of an existing one.
-
-Layer B, the spec and the wire (us). The resolver maps a `client` platform op to a
-`ClientToolSpec` (`kind: "client"`), the model that already exists. The spec carries the client
-marker on the wire to the runner, so the runner knows to emit and park rather than dispatch to
-the sandbox. No new wire shape; the `client` spec exists, unused.
-
-Layer C, the playground (Arda). The playground must know which streamed tool calls are its job,
-and it must never guess. Two facts make this robust.
-
-- Implicit, from Vercel: any tool call that arrives with no server output is client-handled,
-  and `providerExecuted` reads falsy. This seam is already in use; `agentApprovalResume.ts`
-  filters `providerExecuted !== true`.
-- Explicit, so the playground never guesses: the playground keeps a registry of client-tool
-  handlers, keyed by `render.kind` first, then by `name`. A streamed tool call that is not in
-  the registry and has no server output is an error surface. The playground renders a generic
-  "this app cannot handle that request" widget. It never hangs silently.
-
-The registry is a `Record<string, ClientToolHandler>`. v1 has one entry, `request_connection`.
-Each later client tool is one added entry, not a protocol change.
-
-The spec fields, by role:
-
-- `executor: "client"` (`kind: "client"`) is config and routing: the execution location.
-  Platform-owned, set in the catalog. The single source of truth for "client-handled."
-- `name` is metadata and identity: the dispatch key.
-- `input_schema` is data: the argument contract.
-- `render` is metadata: the presentation hint that refines dispatch.
-- `needs_approval` is policy, and orthogonal. A client tool may also be approval-gated.
-  `request_connection` is not, because connecting is its own confirmation.
+The runner resolves a parked call by `approvalKey(name, args)` (`services/agent/src/responder.ts`).
+A client tool is not an approval gate, so the approval-specific name is wrong for the generic
+mechanism. Rename the function to a neutral `parkedCallKey(name, args)`, which reads correctly for
+any parked interaction (permission, client tool, future input). If the rename costs more than it
+returns, the minimum is a note that the name is historical and covers all parked interactions.
 
 ### Where dispatch lives
 
 The AI SDK offers two entry points. We use the second for any tool that needs a human.
 
 - `onToolCall` fires the instant a client tool call streams in. It fits a fully automatic tool
-  that can compute and return at once. It is the wrong place for connect, which needs the user
-  for seconds to minutes. We note it as available; v1 does not use it.
-- The message-part renderer is the interactive pattern, and where dispatch lives. This is the
-  same place `ToolActivity` renders approve and deny today. The renderer sees an unsettled
-  client tool part, dispatches the widget by `render.kind` then `name`, and falls back to the
-  generic widget. The widget drives the interaction, then calls `addToolOutput`. The part flips
-  to settled, and `lastAssistantMessageIsCompleteWithToolCalls` makes `sendAutomaticallyWhen`
-  resend.
+  that computes and returns at once. It is the wrong place for connect, which needs the user for
+  seconds to minutes. We note it as available; v1 does not use it.
+- The message-part renderer is the interactive pattern, and where dispatch lives. This is where
+  `ToolActivity` renders approve and deny today. The renderer sees an unsettled client tool part,
+  dispatches the widget by `render.kind`, then `toolName`, then a generic fallback. The widget
+  drives the interaction, then calls `addToolOutput`. The part flips to settled, and
+  `lastAssistantMessageIsCompleteWithToolCalls` makes `sendAutomaticallyWhen` resend.
+
+The playground keeps a registry of client-tool handlers, keyed by `render.kind` first, then by
+`toolName`. A streamed client tool call that is not in the registry is an error surface: the
+playground renders a generic "this app cannot handle that request" widget and settles the part, so
+it never hangs silently. v1 ships one entry, `request_connection`, plus the generic fallback. Each
+later client tool is one added entry, not a protocol change.
 
 This needs one generalization of the resume predicate. Today `agentShouldResumeAfterApproval`
-wraps the approval predicate. It must also resume on a settled client-tool output. The clean
-form is one predicate that returns true when every non-provider-executed tool part on the last
+wraps the approval predicate. It must also resume on a settled client-tool output. The clean form
+is one predicate that returns true when every non-provider-executed tool part on the last
 assistant turn is settled (`output-available`, `output-error`, or `approval-responded`) and at
-least one was just resolved. That is a small superset of today's function. Whether it stays one
-predicate or composes two is Arda's call at the seam.
+least one was just resolved. Whether it stays one predicate or composes two is Arda's call at the
+seam.
 
-### The resume envelope
+### Settle on every path
 
-The result is a tool output keyed to the parked call. `addToolOutput` carries it home as the
-`tool_result` block shown above. The output is a reference, never the secret: `integration`
-plus `slug`, or as little as `{ "connected": true }`.
+An unsettled tool part hangs the resume, so the widget must settle the part on every terminal
+path, not only on success.
 
-Failure and cancel must also settle the part. If the user closes the popup or the OAuth flow
-fails, the widget calls `addToolOutput` with `{ connected: false, reason }` (or the error form
-via `errorText`). The agent then learns it failed and can re-ask. An unsettled part hangs the
-resume, so the widget settles the part on every path.
+- **Success.** The widget calls `addToolOutput` with the reference, for example
+  `{ connected: true, integration, slug }`.
+- **Explicit cancel.** The user dismisses the widget. The widget calls `addToolOutput` with
+  `{ connected: false, reason: "cancelled" }`.
+- **Failure.** The interaction errors. The widget calls `addToolOutput` with
+  `{ connected: false, reason }`, or the error form via `errorText`.
+- **Abandon.** The user starts but never finishes (closes the popup, walks away). The widget
+  detects the closed popup and settles `{ connected: false, reason: "cancelled" }`. A timeout
+  backstop settles `{ connected: false, reason: "timeout" }` if no terminal signal arrives within
+  a bound.
 
-### Showing the resume to the user
+On every path the agent receives a definite result, so it can re-ask or move on rather than wait
+forever. Application 2 covers the connect-specific UX of the incomplete state.
 
-The wire envelope is identical either way. This is pure presentation, and it is Arda's call.
+## `request_connection`: a non-runnable reference tool
 
-- Option U1, an inline status chip (lean). The connect interaction renders as a compact
-  tool-activity row, the same visual language as approve and deny: "Connect GitHub" with a
-  button, collapsing on success to "GitHub connected" with a check. The raw tool result never
-  shows as a chat bubble. This is consistent with the HITL UI, low noise, and treats the result
-  as plumbing the user does not need to read.
-- Option U2, a plain chat message. The result posts as a visible turn ("Connected GitHub") in
-  the transcript. This is maximally legible, but it is noisier, it can imply the user typed
-  something they did not, and it duplicates what the agent restates on resume.
+This is the corrected model, and it follows ownership rather than transport.
 
-Lean: U1, for consistency with the approval UI and lower noise. Move to U2 only if testing
-shows people miss that a connection happened.
+A normal reference tool (`type: "reference"`, `ReferenceToolConfig`) points at a workflow and is
+backend-runnable: when the model calls it, the runner routes the call to `POST /tools/call` and
+the Agenta service runs the workflow revision server-side. `request_connection` is not that. It
+has no API call for the runner to make. The browser does the work.
 
-### The post-connection handoff
+So we model `request_connection` as a non-runnable reference tool, the same idea as a platform
+skill. A platform skill is a hard-coded workflow the build kit embeds with `@ag.embed`.
+`request_connection` is a hard-coded workflow embedded the same way, and the embed resolver inlines
+it into a `client` tool config (the existing `@ag.embed`-of-a-tool path: an embedded tool resolves
+to a browser-fulfilled `client` tool, not a server callback). The runner then emits-and-parks it
+through the generic primitive above, and the playground fulfills it.
 
-The callback says only that the connection now exists. It does not add the tool to the agent.
-After the resume, the agent re-runs discovery to wire the tool and use it:
+Three points fall out of this model:
 
-1. The resume turn arrives carrying the connect tool result.
-2. The agent re-runs `find_capabilities`. The `ConnectionRequirement` now reads `ready` with a
-   `slug`.
-3. The agent adds the gateway tool to its config or calls it, and proceeds.
+- It is **not a platform op**. Platform ops (`find_capabilities`, `commit_revision`) always bind to
+  an HTTP method and path the runner calls. `request_connection` has neither, so it does not belong
+  in the platform-op catalog.
+- The build kit carries it **as an embed**, beside the authoring skill, not as a committed tool
+  (see Build-kit alignment). Its identity in the kit is the workflow it references.
+- On the wire it is a `ClientToolSpec` (`kind: "client"`), the model that already exists. The spec
+  carries `name` (the dispatch key), `input_schema` (the argument contract), and an optional render
+  hint. The runner reads the client marker, then emits and parks instead of dispatching to the
+  sandbox.
 
-This loop is teaching, not transport. Our primitive delivers the "connection ready" signal. The
-agent-skills project owns the skill that teaches the full loop (discover, `request_connection`,
-re-discover, add the tool). This is a cross-project dependency. Because connections are
-project-scoped, the re-resolve succeeds on the very next turn.
+`needs_approval` is policy and orthogonal. A client tool may also be approval-gated.
+`request_connection` is not, because connecting is its own confirmation.
+
+## Build-kit alignment
+
+This section references the default-agent-config project (`#4917`) and does not redesign it.
+
+The default platform tools and the authoring skill are an agent-template **overlay** the backend
+serves read-only. The backend attaches it to the inspect response at
+`additional_context.playground_build_kit.agent_template_overlay`, a partial `parameters.agent`. The frontend
+merges the overlay onto the current `parameters.agent` on a playground run and excludes it on
+commit. There is no run flag and no service-side injection; the agent service runs the
+`parameters.agent` it receives.
+
+Two consequences for this project.
+
+First, `request_connection` joins the overlay as a **reference-tool entry**, identity by its
+referenced workflow, beside the authoring skill's `@ag.embed`. It is never committed. The overlay
+is the kit's home; this project owns only the tool's definition and behavior.
+
+Second, the config refresh in Application 1 must also refresh the build-kit view. A commit can
+change which overlay rows apply, so the same `data-committed-revision` signal that invalidates the
+config panel also refreshes the build-kit display. We reference the overlay and the container; we
+change neither.
 
 ## Application 1: the agent edits its own config
 
 `commit_revision` is a platform op with `default_needs_approval=True` and
-`default_permission="ask"`. The running variant id is bound server-side from run context, so
-the agent commits to its own default variant. The approval gate is therefore already available
-through the HITL flow above. When the agent calls `commit_revision`, the run parks on a
-permission gate, the user sees the request, and on approve the commit runs server-side.
+`default_permission="ask"`. The running variant id is bound server-side from run context, so the
+agent commits to its own default variant. The approval gate is therefore already available through
+the HITL flow. When the agent calls `commit_revision`, the run parks on a permission gate, the user
+sees the request, and on approve the commit runs server-side.
 
-Two things follow from D1.
-
-First, the gate stays per-tool. There is no "always approve" to decide, and that is the point.
-Whether `commit_revision` parks is the tool's own `needs_approval`. The default is `True`, a
-sensible default for "the agent rewrote itself," but it is a default, not a hardcode. An author
-or a future auto-commit mode can set it to `False`, and the agent then commits directly. The
-refresh below still runs.
+The gate stays per-tool (D1). Whether `commit_revision` parks is the tool's own `needs_approval`.
+The default is `True`, a sensible default for "the agent rewrote itself," but it is a default, not
+a hardcode. An author or a future auto-commit mode can set it to `False`, and the agent then
+commits directly. The refresh below still runs.
 
 The approval widget is generic now and per-tool later. v1 renders the generic approval widget,
-which shows the tool input. For `commit_revision` that input is the new config. We do not build
-a config diff yet. The frame carries the tool name and a `render` hint, so a later
-`render: { kind: "config-diff" }` on `commit_revision` lets the playground swap in a real
-before-and-after diff with no protocol change. Raw JSON is a weak approval surface, so the diff
-is the expected first per-tool widget, but it is a follow-up.
+which shows the tool input. For `commit_revision` that input is the new config. A later
+`render: { kind: "config-diff" }` lets the playground swap in a real before-and-after diff with no
+protocol change. Raw JSON is a weak approval surface, so the diff is the expected first per-tool
+widget, but it is a follow-up.
 
-Second, the refresh is the universal requirement. Today the playground reads the latest revision
-per request through `workflowLatestRevisionQueryAtomFamily`. When the agent commits through
-`commit_revision`, the playground has no signal that a new revision landed. It needs one, and it
-needs it in both paths: the gated path (a human approved, the commit runs on the resume turn)
-and the direct path (`needs_approval=False`, the commit runs inside the turn). The clean way to
-cover both is to emit the refresh when the commit succeeds, not when it is approved. Success
+The refresh is the universal requirement. Today the playground reads the latest revision per
+request through `workflowLatestRevisionQueryAtomFamily`. When the agent commits, the playground has
+no signal that a new revision landed, and it needs one in both paths: the gated path (a human
+approved, the commit runs on the resume turn) and the direct path (`needs_approval=False`, the
+commit runs inside the turn). Fire the refresh on commit success, not on approval, because success
 happens in both paths, so one emit point covers both.
 
-Locked: a named refresh frame (R1). On a successful `commit_revision`, the runner or SDK emits
-a one-way `data` event, `data-committed-revision`, with `{ variantId, revisionId, version }`.
-The playground listens and invalidates `workflowLatestRevisionQueryAtomFamily`, which refreshes
-the panel and the section drawers. This is role-correct: the signal is metadata, "the config
-changed, here is the new reference," so it belongs on the one-way `data-<name>` channel, not on
-a tool result. (R2 and R3 are recorded under Rejected alternatives.)
+Locked: on a successful `commit_revision`, the runner or SDK emits a one-way `data` event,
+`data-committed-revision`, with `{ variantId, revisionId, version }`. The playground listens and
+invalidates `workflowLatestRevisionQueryAtomFamily`, which refreshes the config panel, the section
+drawers, and the build-kit view. The signal is metadata ("the config changed, here is the new
+reference"), so it rides the one-way `data-<name>` channel, not a tool result.
 
 ## Application 2: the agent needs a connection
 
 The end-to-end flow:
 
 1. The agent learns it needs a connection from discovery. It calls `find_capabilities`, which
-   returns a `ConnectionRequirement` with `state` (`ready`, `needs_auth`, or `needs_input`) and
-   a `connect` affordance. A skill teaches the discover-then-connect loop (D2).
+   returns a `ConnectionRequirement` with `state` (`ready`, `needs_auth`, or `needs_input`) and a
+   `connect` affordance. A skill teaches the discover-then-connect loop (D2).
 2. The agent calls `request_connection(integration)`. The runner streams the call and parks.
 3. The playground dispatches the connect widget. It shows the integration, calls
-   `POST /tools/connections/`, and opens the returned `redirect_url` (the OAuth flow) in a
-   popup.
-4. The user finishes OAuth. The callback activates the connection in the project vault and posts
-   a message to the opener window.
-5. The widget hears that message and calls `addToolOutput` with
-   `{ connected: true, integration, slug }`, keyed to the parked call. The resume predicate
-   fires and the conversation auto-resends.
-6. The runner cold-replays, resolves the parked call by `approvalKey(name, args)`, re-resolves
+   `POST /tools/connections/`, and opens the returned `redirect_url` (the OAuth flow) in a popup.
+4. The user finishes OAuth. The callback activates the connection in the project vault and posts a
+   message to the opener window.
+5. The widget validates the message origin (below), then calls `addToolOutput` with
+   `{ connected: true, integration, slug }`, keyed to the parked call. The resume predicate fires
+   and the conversation auto-resends.
+6. The runner cold-replays, resolves the parked call by `parkedCallKey(name, args)`, re-resolves
    the connection from the vault, and the agent proceeds.
 
-The connection request is an explicit tool, driven by discovery (D2). The agent calls
-`find_capabilities`, sees a requirement that is not `ready`, and calls
-`request_connection(integration)`. The `connect` affordance (which endpoint to call, with what
-body) rides in the tool input or the render hint, so the playground speaks Agenta, never
-Composio. The agent decides when to ask and can explain why in its own words first. This is the
-seam the builder-capabilities project depends on for triggers and subscriptions.
+The connect affordance (which endpoint to call, with what body) rides in the tool input or the
+render hint, so the playground speaks Agenta, never Composio. The agent decides when to ask and can
+explain why in its own words first. This is the seam the builder-capabilities project depends on
+for triggers and subscriptions. The connection persists at project scope, so a later run needs no
+re-prompt.
 
-The result carries a reference, never the secret:
-`{ connected: true, integration: "github", slug: "github-main" }`. The connection persists at
-project scope, so a later run needs no re-prompt.
+### Security: validate the popup message origin
 
-`request_connection` is a client-executed platform op (D5), built per the registration section
-above. Its argument and output schema is likely `{ integration }` in and
-`{ connected, integration, slug }` out, with a `render` hint of `{ kind: "connect" }`. The
-connect affordance is shaped server-side by discovery, which already exists.
+The connect widget opens `redirect_url` in a popup and listens for a `postMessage` from the OAuth
+callback. A `postMessage` listener trusts any sender by default, so a malicious page could spoof the
+callback signal. Before the widget trusts the message and calls `addToolOutput`, it MUST validate
+`event.origin` against the Agenta API origin and drop any message from another origin. This is a
+hard requirement, not a nicety. As defense in depth, the callback should also carry an expected
+shape and a state value bound to this connect attempt.
 
-## Build-kit alignment
+### The incomplete state (abandoned flow)
 
-This section references the default-agent-config project (inject-not-commit) and does not
-redesign it.
+A user can open the popup and never finish. The run must not hang, and the UI must show what
+happened.
 
-The default platform tools and the authoring skill are an injected, read-only playground build
-kit. They are not committed to the agent config. The backend exposes the kit as a read-only
-`build_kit` descriptor at `revision.data.build_kit` in the `/inspect` response, grouped into
-`skills`, `tools`, and `permissions`; each row carries `key`, `name`, and `description`, and
-permission rows add `status`. A per-run flag `flags.inject_build_kit` on the run request turns
-injection on or off, defaulting off server-side.
+- While the popup is open, the chip reads "Connecting GitHub…" with a Cancel action.
+- If the user closes the popup without success, the widget detects the closed window and settles
+  the part with `{ connected: false, reason: "cancelled" }`. A timeout backstop settles
+  `{ connected: false, reason: "timeout" }` if nothing arrives within a bound.
+- The chip then reads "Connection not completed" with a Retry action.
+- The agent receives the failure result on the resume turn, so it can re-ask ("I still need GitHub
+  access, want to try again?") or move on. It never waits on a call that will not return.
 
-Two consequences for this project.
+### The post-connection handoff
 
-First, `request_connection` is a platform tool, so it is part of the injected build kit, not the
-committed config. It appears as a `tools` row in `build_kit` whenever the kit is injected.
-Whether a published agent keeps it after commit is the default-agent-config project's call, not
-ours.
+The callback says only that the connection now exists. It does not add the tool to the agent. After
+the resume, the agent re-runs `find_capabilities`, sees the `ConnectionRequirement` now reads
+`ready` with a `slug`, and adds the gateway tool or calls it. This loop is teaching, not transport.
+Our primitive delivers the "connection ready" signal; the agent-skills project owns the skill that
+teaches the full loop. Connections are project-scoped, so the re-resolve succeeds on the very next
+turn.
 
-Second, the config refresh in Application 1 should also refresh the build-kit display. When a
-commit lands, the new revision can change which kit rows apply, so the same
-`data-committed-revision` signal that invalidates the config panel should also refresh the
-build-kit view. We reference the descriptor and the flag; we do not change their shape.
+## Displaying the result
+
+The wire envelope is identical either way. This is pure presentation, and Arda's call.
+
+- **U1, an inline status chip (lean).** The connect interaction renders as a compact tool-activity
+  row, the same visual language as approve and deny: "Connect GitHub" with a button, collapsing on
+  success to "GitHub connected" with a check, and on abandon to "Connection not completed" with
+  retry. The raw tool result never shows as a chat bubble. This matches the HITL UI, stays low
+  noise, and treats the result as plumbing the user need not read.
+- **U2, a plain chat message.** The result posts as a visible turn ("Connected GitHub"). This is
+  maximally legible but noisier, can imply the user typed something they did not, and duplicates
+  what the agent restates on resume.
+
+Lean: U1, for consistency with the approval UI and lower noise. Move to U2 only if testing shows
+people miss that a connection happened.
 
 ## Work split
 
@@ -385,27 +380,27 @@ Most of this is frontend, and most of the frontend is Arda's call.
 
 Us (SDK, runner, API):
 
-- Runner: add `onClientTool` to `Responder`; emit the call and park on an unresolved client
-  tool exactly as permission parks; resolve from the inbound `tool_result` on resume.
-  Generalize the decision extraction beyond `{approved}` to any structured output, keyed by
-  `approvalKey(name, args)`.
-- SDK: surface a client tool as a standard unsettled tool part plus an optional `data-render`
-  hint (no new Vercel frame); widen the inbound `tool_result` parsing for client tools in
-  `vercel/messages.py`; add `request_connection` as a `client` platform op (the new
-  `executor: "client"`, no method or path) and map it to `ClientToolSpec`.
-- API or SDK: emit `data-committed-revision` on commit success, in both the gated and direct
-  paths (R1).
+- Runner: add `onClientTool` to `Responder`; recognize a client tool before dispatch and emit-and-
+  park exactly as permission parks; resolve from the inbound `tool_result` on resume; generalize
+  decision extraction beyond `{approved}` to any structured output; rename `approvalKey` to
+  `parkedCallKey`.
+- SDK: surface a client tool as a standard unsettled tool part plus an optional render hint (no new
+  Vercel frame); widen inbound `tool_result` parsing for client tools in `vercel/messages.py`;
+  define `request_connection` as a hard-coded non-runnable workflow and resolve its `@ag.embed`
+  into a `ClientToolSpec`.
+- API or SDK: emit `data-committed-revision` on commit success, in both the gated and direct paths.
 
 Arda (frontend), the calls that are his:
 
-- The client-tool dispatcher in the message-part renderer (sibling to `ToolActivity`): which
-  widget renders for which `render.kind` then `name`, the generic widget as fallback, and an
-  explicit "cannot handle that" surface for an unknown client tool. v1 ships only the generic
-  widget. This is the central new surface.
-- The connect widget: the OAuth popup, the callback listener, and the reply through
-  `addToolOutput` (success and failure both settle the part).
-- The generalized resume predicate: `agentShouldResumeAfterApproval` extended so a settled
-  client-tool output resumes, not only an approval.
+- The client-tool dispatcher in the message-part renderer (sibling to `ToolActivity`): which widget
+  renders for which `render.kind`, then `toolName`, the generic widget as fallback, and an explicit
+  "cannot handle that" surface for an unknown client tool. v1 ships only the generic widget. This is
+  the central new surface.
+- The connect widget: the OAuth popup, the origin-validated callback listener, and the reply through
+  `addToolOutput` (success, cancel, failure, and abandon all settle the part), plus the incomplete-
+  state UX.
+- The generalized resume predicate: `agentShouldResumeAfterApproval` extended so a settled client-
+  tool output resumes, not only an approval.
 - The result UX (U1 inline chip versus U2 chat message; lean U1).
 - The config-panel and build-kit refresh on `data-committed-revision`, and later the per-tool
   config-diff widget.
@@ -414,49 +409,44 @@ Cross-project (coordinated, not ours to build):
 
 - The skill that teaches the discover, `request_connection`, re-discover, add-tool loop:
   agent-skills.
-- Whether a new agent keeps `request_connection` after commit: default-agent-config.
-
-## Rejected alternatives
-
-- Two narrow interaction kinds. Keep `permission` and add a dedicated `connect` kind, each with
-  a bespoke frame and widget. Smaller blast radius, but the third interaction repeats the work,
-  the `client` executor stays dead, and we pay the generalization later with two special cases
-  to retire. D3 chose the generic primitive.
-- A fresh user message for the connection result ("I connected GitHub"). The parked call would
-  never resolve, so the runner would re-raise it or the model would guess. It pollutes the
-  transcript with text the user did not write and reuses none of the resume machinery. D4 chose
-  the `tool_result`.
-- Refresh off the `commit_revision` tool result (R2). The playground keys the panel refresh off
-  the tool's output frame. No new frame, possibly fastest, but it couples the playground to a
-  platform tool name and output shape, and it must still fire in the direct un-gated path.
-  Acceptable only as a short-lived stopgap. Avoid R3, a blind refetch on every turn finish,
-  which is wasteful and can race the write.
-- Runner auto-interception of a missing-connection failure. The gateway resolve raises
-  `ConnectionNotFoundError` mid-run and the runner raises a connect interaction itself, with no
-  agent tool call. The control flow is implicit and lives in the runner, and the parked thing is
-  a synthetic interaction rather than a real model tool call, so the cold-replay anchor must be
-  synthesized carefully. We may add it later as a fallback, so an agent that skips discovery
-  degrades to a connect prompt instead of a raw error. Out of v1 (D2).
+- The build-kit overlay and whether a published agent keeps `request_connection`:
+  default-agent-config (`#4917`).
 
 ## Open questions (non-blocking)
 
-These settle during implementation, with Arda, and do not need Mahmoud now.
+These settle during implementation, with Arda.
 
-- The `render.kind` vocabulary (for example `connect`, `config-diff`). The dispatch precedence
-  is settled (`render.kind`, then `name`, then generic fallback); only the string values remain.
-- The exact `request_connection` argument and output schema, and its `render` hint.
+- The `render.kind` vocabulary (for example `connect`, `config-diff`). Dispatch precedence is
+  settled (`render.kind`, then `toolName`, then generic fallback); only the string values remain.
+- The exact `request_connection` argument and output schema, and its render hint.
 - Whether the resume predicate stays one function or composes two. Same behavior either way.
-- The `data-committed-revision` payload beyond `{ variantId, revisionId, version }`, once the
-  refresh code names what it needs.
+- The `data-committed-revision` payload beyond `{ variantId, revisionId, version }`.
+- The abandon timeout bound and whether popup-closed detection uses polling or a focus listener.
 
-## Cross-project dependencies
+## Appendix: prior approaches
 
-- agent-skills owns the skill that teaches the discover-then-connect loop. Our primitive only
-  delivers the "connection ready" signal.
-- default-agent-config owns the `build_kit` descriptor and `flags.inject_build_kit`, and decides
-  whether `request_connection` ships in a published agent. We reference both.
-- agent-builder-capabilities rides this primitive for triggers and subscriptions, and gates a
-  live subscription test on a connection. We keep the contract general enough to serve it.
+Recorded so no one rebuilds them.
+
+- Two narrow interaction kinds. Keep `permission` and add a dedicated `connect` kind, each with a
+  bespoke frame and widget. Smaller blast radius, but the third interaction repeats the work and
+  we pay the generalization later with special cases to retire. D3 chose the generic primitive.
+- A fresh user message for the connection result ("I connected GitHub"). The parked call would
+  never resolve, so the runner would re-raise it or the model would guess. It pollutes the
+  transcript and reuses none of the resume machinery. D4 chose the `tool_result`.
+- `request_connection` as a platform op with a client executor. A platform op binds to an HTTP
+  method and path the runner calls; this tool has neither. Modeling it as an op invented a new op
+  shape and put a non-runnable tool in the runnable catalog. It is a non-runnable reference tool
+  instead (D5).
+- Refresh off the `commit_revision` tool result, or a blind refetch on every turn finish. The
+  first couples the playground to a platform tool's output shape and still must fire in the direct
+  path; the second is wasteful and can race the write. The `data-committed-revision` signal avoids
+  both.
+- Runner auto-interception of a missing-connection failure. The gateway resolve raises
+  `ConnectionNotFoundError` mid-run and the runner raises a connect interaction itself, with no
+  agent tool call. The control flow is implicit, and the parked thing is a synthetic interaction
+  rather than a real model tool call, so the cold-replay anchor must be synthesized carefully. We
+  may add it later as a fallback, so an agent that skips discovery degrades to a connect prompt
+  instead of a raw error. Out of v1 (D2).
 
 ## References
 
@@ -467,15 +457,18 @@ Sibling docs (read to align, do not edit):
 Code anchors (verified 2026-06-28):
 
 - Neutral event and responder: `services/agent/src/protocol.ts`,
-  `services/agent/src/responder.ts` (`approvalKey`, decision extraction).
+  `services/agent/src/responder.ts` (`approvalKey`, the cold-replay anchor to rename).
 - Park and finish: `services/agent/src/engines/sandbox_agent.ts`.
-- Client-tool guard: `services/agent/src/tools/dispatch.ts`.
+- Client-tool in-sandbox guard: `services/agent/src/tools/dispatch.ts`.
 - Stream and inbound parsing: `sdks/python/agenta/sdk/agents/adapters/vercel/stream.py`
   (`tool-approval-request`, `data-<name>`), `.../vercel/messages.py`.
-- Tool models: `sdks/python/agenta/sdk/agents/tools/` (`ClientToolSpec`, `kind: "client"`).
+- Tool models: `sdks/python/agenta/sdk/agents/tools/models.py`
+  (`ClientToolConfig`, `ReferenceToolConfig`, `ClientToolSpec`).
+- Reference/workflow tool resolution: `sdks/python/agenta/sdk/agents/platform/workflow.py`.
+- Embed resolution (embed-of-tool to client): `api/oss/src/core/embeds/utils.py`.
 - Platform catalog: `sdks/python/agenta/sdk/agents/platform/op_catalog.py`
-  (`find_capabilities`, `commit_revision`; no `executor` field yet).
+  (`find_capabilities`, `commit_revision`).
 - Frontend: `web/oss/src/components/AgentChatSlice/`,
   `web/packages/agenta-playground/src/state/execution/agentApprovalResume.ts`.
-- Connections API: `api/oss/src/apis/fastapi/tools/router.py` (`/tools/discover`,
-  `/tools/connections/`, OAuth callback `postMessage`, `ConnectionNotFoundError` 404).
+- Connections API and OAuth callback `postMessage`: `api/oss/src/apis/fastapi/tools/router.py`
+  (`/tools/discover`, `/tools/connections/`, `ConnectionNotFoundError` 404).

--- a/docs/design/agent-workflows/projects/agent-fe-roundtrip/status.md
+++ b/docs/design/agent-workflows/projects/agent-fe-roundtrip/status.md
@@ -4,112 +4,109 @@ Source of truth for this project. Update as work proceeds.
 
 ## What this project is
 
-One shared primitive, two applications. A tool call that travels up to the playground,
-shows the user something, waits for the user to act, and resumes the agent with the result.
+One primitive, two applications. A tool call that travels to the playground, shows the user
+something, waits for the user to act, and resumes the agent with the result.
 
-- **Problem 1** — the agent changes its own config (`commit_revision`). Approval is per-tool
-  (not hardcoded); after a commit lands, the playground refreshes the config panel in both the
-  gated and the direct path.
-- **Problem 2** — the agent needs a connection that does not exist (for example GitHub).
-  Discovery reports it; the agent calls `request_connection`; the user finishes the OAuth flow
-  in the playground; the frontend auto-replies with a structured result and resumes the agent.
+- Application 1: the agent edits its own config (`commit_revision`). Approval stays per-tool,
+  not hardcoded. After a commit lands, the playground refreshes the config panel and the
+  build-kit view in both the gated and the direct path.
+- Application 2: the agent needs a connection it does not have (for example GitHub). Discovery
+  reports it, the agent calls `request_connection`, the user finishes the OAuth flow in the
+  playground, the frontend replies with a structured reference, and the agent resumes.
 
 The design doc is [`design.md`](./design.md).
 
-## Current state — 2026-06-28 (round 3)
+## Current state, 2026-06-28
 
-Research done; design at round 3. Round 3 adds the detailed client-tool mechanism (design.md
-"Part 1b") grounded in the Vercel AI SDK. Nothing built. Docs-first; the orchestrator
-consolidates the converged design docs into one draft PR for Mahmoud's review.
+Design ready for review. Nothing built yet. Docs-first.
 
-The key finding: the HITL permission flow we already ship **is** a client round-trip, and the
-Vercel AI SDK already ships the sibling half we need. The approval flow uses
-`addToolApprovalResponse` + `lastAssistantMessageIsCompleteWithApprovalResponses`. Client tools
-use `onToolCall` / `addToolOutput` (the renamed `addToolResult`) +
-`lastAssistantMessageIsCompleteWithToolCalls`, with `providerExecuted` distinguishing
-server-run from client-run tool parts. All verified present in `ai@6` / `@ai-sdk/react@3`. We
-wire our runner and stream to the client-tool half and add the widgets; we invent no transport.
+The headline finding: the HITL approval flow we already ship is a client round-trip, and the
+Vercel AI SDK ships the sibling half we need. The runner's "forbid client tools" becomes "emit
+the call and park." No new transport.
 
-## Decisions (locked 2026-06-28, relayed via the orchestrator)
+## Decisions (locked 2026-06-28)
 
-- **D1 — config-change approval is per-tool, not hardcoded.** `needs_approval` is the tool's
-  own config, handled by the existing approval boundary. The new universal requirement is the
-  refresh: fire `data-committed-revision` on commit **success**, so it covers both the gated
-  and the direct path. v1 ships a generic approval UI; the frame carries tool name plus a
-  `render` hint so per-tool UIs (a config diff for `commit_revision`) can be added later with
-  no protocol change.
-- **D2 — connection trigger is an explicit `request_connection` tool, skill-driven.** Discovery
-  reports the missing connection; the skill teaches the agent to call `request_connection`.
-  Runner auto-interception of a call-time failure is rejected as primary, kept only as an
-  optional later safety net (out of v1).
-- **D3 — build the generic client-tool round-trip**, not a narrow `connect` kind. It carries
-  both applications and retires the dead `client` executor.
-- **D4 — the result returns as a structured tool result (the "callback")** keyed to the parked
-  call, carrying a reference (integration plus slug), never the secret. The runner re-resolves
-  from the vault on resume. The "frontend auto-sends a follow-up message" framing maps to this,
-  not a free-text user message.
-- **D5 — `request_connection` is a hard-coded platform tool with a client executor.** Same
-  catalog as `find_capabilities` and `commit_revision`, but client-executed. Resolves the
-  earlier "client-executor tool vs platform tool" question (it is both). Because it is a
-  platform tool it can ship in the default embedded set — coordinate with the
-  default-agent-config project.
-
-Round 3 mechanism, in brief (design.md "Part 1b"):
-
-- **Registration:** one execution-location flag (`executor: "client"`) flows catalog -> spec ->
-  wire -> playground. The runner emits-and-parks instead of dispatching to the sandbox. The
-  playground registers a handler per tool keyed by `render.kind` then `name`; an unknown client
-  tool renders an explicit "cannot handle" surface, never a silent hang.
-- **Dispatch:** lives in the message-part renderer (sibling to `ToolActivity`), not in
-  `onToolCall` (that is for headless auto client tools). The widget calls `addToolOutput`;
-  `lastAssistantMessageIsCompleteWithToolCalls` auto-resends.
-- **Return + UX:** the envelope is a `tool_result` keyed to the call, reference-only. UX is
-  Arda's call: U1 inline status chip (lean) vs U2 chat message.
-- **Post-connection handoff:** the callback only says "connection ready." The agent must
-  re-discover and add the tool; the agent-creation-skills project owns that teaching.
-
-Residual non-blocking items (render-kind string values, the `request_connection` arg/output
-schema, one-vs-two resume predicates, the refresh payload fields) are in design.md and settle
-during implementation with Arda.
+- D1: config-change approval is per-tool. `needs_approval` stays the tool's own field. The new
+  universal requirement is the refresh, fired on commit success so it covers both the gated and
+  the direct path. v1 ships a generic approval widget; the frame carries the tool name and a
+  render hint for a later config-diff widget.
+- D2: the connection trigger is an explicit `request_connection` tool, driven by discovery and a
+  skill. Runner auto-interception is out of v1, kept only as a future option.
+- D3: build the generic client-tool round-trip, not a narrow connect kind. It carries both
+  applications and retires the dead `client` executor.
+- D4: the result returns as a structured tool result keyed to the parked call, carrying a
+  reference (integration plus slug), never the secret. The runner re-resolves from the vault on
+  resume. Failure and cancel also settle the call.
+- D5: `request_connection` is a hard-coded platform tool with a client executor, in the same
+  catalog as `find_capabilities` and `commit_revision`. Because it is a platform tool, it is
+  part of the injected build kit.
 
 ## Verified facts (grounded in code, do not relitigate)
 
-- Neutral event `interaction_request` already carries `kind: "permission" | "input" |
-  "client_tool"` (`services/agent/src/protocol.ts`). Only `permission` is wired. `Responder`
-  has only `onPermission`; `client_tool` and `input` are declared and unhandled.
-- The `client` executor exists as a model (`ClientToolConfig` type, `ClientToolSpec` kind)
-  but execution is forbidden in every runner path on purpose. The rails exist; the round-trip
-  does not.
-- Park/resume is fully built for permission. The runner parks (stop reason `paused`),
-  cold-replays on the next turn, and resolves a decision keyed by `approvalKey(name, args)`.
-  Decisions are read from inbound `tool_result` blocks carrying `{approved}`
+- The neutral event `interaction_request` already carries
+  `kind: "permission" | "input" | "client_tool"` (`services/agent/src/protocol.ts`). Only
+  `permission` is wired. `Responder` has `onPermission` only.
+- The `client` executor exists as a model (`ClientToolSpec`, `kind: "client"`), but the runner
+  throws on any client tool on purpose (`services/agent/src/tools/dispatch.ts`).
+- Park and resume is fully built for permission. The runner parks (stop reason `paused`),
+  cold-replays on the next turn, and resolves a decision keyed by `approvalKey(name, args)`,
+  read from inbound `tool_result` blocks carrying `{approved}`
   (`services/agent/src/responder.ts`).
-- The playground consumes the stream with `useChat`, renders approve/deny in `ToolActivity`,
-  and auto-resumes via `sendAutomaticallyWhen: agentShouldResumeAfterApproval`
-  (`web/oss/src/components/AgentChatSlice/`).
-- `commit_revision` is a platform op with `default_needs_approval=True`,
-  `default_permission="ask"`. The running variant id is server-bound. The approval gate is
-  already available (`sdks/python/agenta/sdk/agents/platform/op_catalog.py`).
+- The playground consumes the stream with `useChat`, renders approve and deny in `ToolActivity`,
+  and auto-resumes through `sendAutomaticallyWhen: agentShouldResumeAfterApproval`, which
+  filters `providerExecuted !== true`
+  (`web/oss/src/components/AgentChatSlice/`,
+  `web/packages/agenta-playground/src/state/execution/agentApprovalResume.ts`).
+- The AI SDK is on the beta channel (`ai@6.0.0-beta`, `@ai-sdk/react@3.0.0-beta`). All symbols
+  we rely on are present: `addToolApprovalResponse`,
+  `lastAssistantMessageIsCompleteWithApprovalResponses`, `onToolCall`, `addToolOutput`,
+  `lastAssistantMessageIsCompleteWithToolCalls`, and the `providerExecuted` flag.
+- `commit_revision` is a platform op with `default_needs_approval=True` and
+  `default_permission="ask"`. The running variant id is bound server-side
+  (`sdks/python/agenta/sdk/agents/platform/op_catalog.py`).
 - Config refresh today is imperative: the playground reads the latest revision per request
-  via `workflowLatestRevisionQueryAtomFamily`. No "a revision landed" frame exists yet for
+  through `workflowLatestRevisionQueryAtomFamily`. No "a revision landed" frame exists yet for
   the agent's own commit.
-- Connections: `POST /tools/discover` (`find_capabilities`, a platform op) returns
-  `ConnectionRequirement{integration, state: ready|needs_auth|needs_input, connect}`. A
-  missing connection on the resolve path raises `ConnectionNotFoundError` (HTTP 404).
-  `POST /tools/connections/` returns `status.redirect_url`; the OAuth callback activates the
-  connection and posts a message to the opener window. Connections live at project scope,
-  keyed `(project_id, provider_key, integration_key, slug)`.
+- Connections: `POST /tools/discover` (`find_capabilities`) returns
+  `ConnectionRequirement{integration, state, connect}`. `POST /tools/connections/` returns
+  `status.redirect_url`; the OAuth callback activates the connection and posts a message to the
+  opener. A missing connection at resolve time raises `ConnectionNotFoundError` (HTTP 404).
+  Connections live at project scope, keyed `(project_id, provider_key, integration_key, slug)`
+  (`api/oss/src/apis/fastapi/tools/router.py`).
+
+## Corrections folded into this round
+
+- `request_connection` does not exist yet. It is proposed by this doc and built as the first
+  client platform op.
+- The platform op model has no `executor` field, and every existing op is server-executed by an
+  HTTP method and path. `request_connection` is the first op with `executor: "client"` and no
+  method or path. This is a small new shape in the catalog.
+- A client tool needs no new Vercel frame. The call rides as the standard unsettled tool part,
+  and the optional render hint rides the existing `data-render` channel.
+
+## Build-kit alignment (reference, do not redesign)
+
+The default platform tools and the authoring skill are injected, not committed. The backend
+exposes them as a read-only `build_kit` descriptor at `revision.data.build_kit` in `/inspect`
+(grouped `skills`, `tools`, `permissions`; rows carry `key`, `name`, `description`; permission
+rows add `status`), with a per-run flag `flags.inject_build_kit` on the run request.
+`request_connection` is a `tools` row in that kit. The commit refresh (`data-committed-revision`)
+should also refresh the build-kit display. Owned by the default-agent-config project.
 
 ## Coordination
 
-- The "default tools and skills" project and the "missing builder tools" project are active.
-  The builder-capabilities work depends on this project's connection-request flow; that
-  dependency is designed here (Problem 2). Coordinate concrete tool names via the
-  orchestrator.
+- agent-skills owns the skill that teaches the discover-then-connect loop. Our primitive only
+  delivers the "connection ready" signal.
+- default-agent-config owns the build kit and decides whether a published agent keeps
+  `request_connection`.
+- agent-builder-capabilities rides this primitive for triggers and subscriptions, and gates a
+  live subscription test on a connection.
 
 ## Links
 
-- Tool discovery (the connection-state source for Problem 2):
+- Tool discovery (the connection-state source for Application 2):
   [`../tool-discovery/status.md`](../tool-discovery/status.md)
-- HITL park/resume (the primitive Problem 1 and 2 extend):
+- HITL park and resume (the primitive both applications extend):
   [`../hitl-fix`](../hitl-fix)
+- Default build kit (the inject-not-commit model and the `build_kit` descriptor):
+  [`../default-agent-config/`](../default-agent-config/)

--- a/docs/design/agent-workflows/projects/agent-fe-roundtrip/status.md
+++ b/docs/design/agent-workflows/projects/agent-fe-roundtrip/status.md
@@ -1,0 +1,115 @@
+# Status
+
+Source of truth for this project. Update as work proceeds.
+
+## What this project is
+
+One shared primitive, two applications. A tool call that travels up to the playground,
+shows the user something, waits for the user to act, and resumes the agent with the result.
+
+- **Problem 1** — the agent changes its own config (`commit_revision`). Approval is per-tool
+  (not hardcoded); after a commit lands, the playground refreshes the config panel in both the
+  gated and the direct path.
+- **Problem 2** — the agent needs a connection that does not exist (for example GitHub).
+  Discovery reports it; the agent calls `request_connection`; the user finishes the OAuth flow
+  in the playground; the frontend auto-replies with a structured result and resumes the agent.
+
+The design doc is [`design.md`](./design.md).
+
+## Current state — 2026-06-28 (round 3)
+
+Research done; design at round 3. Round 3 adds the detailed client-tool mechanism (design.md
+"Part 1b") grounded in the Vercel AI SDK. Nothing built. Docs-first; the orchestrator
+consolidates the converged design docs into one draft PR for Mahmoud's review.
+
+The key finding: the HITL permission flow we already ship **is** a client round-trip, and the
+Vercel AI SDK already ships the sibling half we need. The approval flow uses
+`addToolApprovalResponse` + `lastAssistantMessageIsCompleteWithApprovalResponses`. Client tools
+use `onToolCall` / `addToolOutput` (the renamed `addToolResult`) +
+`lastAssistantMessageIsCompleteWithToolCalls`, with `providerExecuted` distinguishing
+server-run from client-run tool parts. All verified present in `ai@6` / `@ai-sdk/react@3`. We
+wire our runner and stream to the client-tool half and add the widgets; we invent no transport.
+
+## Decisions (locked 2026-06-28, relayed via the orchestrator)
+
+- **D1 — config-change approval is per-tool, not hardcoded.** `needs_approval` is the tool's
+  own config, handled by the existing approval boundary. The new universal requirement is the
+  refresh: fire `data-committed-revision` on commit **success**, so it covers both the gated
+  and the direct path. v1 ships a generic approval UI; the frame carries tool name plus a
+  `render` hint so per-tool UIs (a config diff for `commit_revision`) can be added later with
+  no protocol change.
+- **D2 — connection trigger is an explicit `request_connection` tool, skill-driven.** Discovery
+  reports the missing connection; the skill teaches the agent to call `request_connection`.
+  Runner auto-interception of a call-time failure is rejected as primary, kept only as an
+  optional later safety net (out of v1).
+- **D3 — build the generic client-tool round-trip**, not a narrow `connect` kind. It carries
+  both applications and retires the dead `client` executor.
+- **D4 — the result returns as a structured tool result (the "callback")** keyed to the parked
+  call, carrying a reference (integration plus slug), never the secret. The runner re-resolves
+  from the vault on resume. The "frontend auto-sends a follow-up message" framing maps to this,
+  not a free-text user message.
+- **D5 — `request_connection` is a hard-coded platform tool with a client executor.** Same
+  catalog as `find_capabilities` and `commit_revision`, but client-executed. Resolves the
+  earlier "client-executor tool vs platform tool" question (it is both). Because it is a
+  platform tool it can ship in the default embedded set — coordinate with the
+  default-agent-config project.
+
+Round 3 mechanism, in brief (design.md "Part 1b"):
+
+- **Registration:** one execution-location flag (`executor: "client"`) flows catalog -> spec ->
+  wire -> playground. The runner emits-and-parks instead of dispatching to the sandbox. The
+  playground registers a handler per tool keyed by `render.kind` then `name`; an unknown client
+  tool renders an explicit "cannot handle" surface, never a silent hang.
+- **Dispatch:** lives in the message-part renderer (sibling to `ToolActivity`), not in
+  `onToolCall` (that is for headless auto client tools). The widget calls `addToolOutput`;
+  `lastAssistantMessageIsCompleteWithToolCalls` auto-resends.
+- **Return + UX:** the envelope is a `tool_result` keyed to the call, reference-only. UX is
+  Arda's call: U1 inline status chip (lean) vs U2 chat message.
+- **Post-connection handoff:** the callback only says "connection ready." The agent must
+  re-discover and add the tool; the agent-creation-skills project owns that teaching.
+
+Residual non-blocking items (render-kind string values, the `request_connection` arg/output
+schema, one-vs-two resume predicates, the refresh payload fields) are in design.md and settle
+during implementation with Arda.
+
+## Verified facts (grounded in code, do not relitigate)
+
+- Neutral event `interaction_request` already carries `kind: "permission" | "input" |
+  "client_tool"` (`services/agent/src/protocol.ts`). Only `permission` is wired. `Responder`
+  has only `onPermission`; `client_tool` and `input` are declared and unhandled.
+- The `client` executor exists as a model (`ClientToolConfig` type, `ClientToolSpec` kind)
+  but execution is forbidden in every runner path on purpose. The rails exist; the round-trip
+  does not.
+- Park/resume is fully built for permission. The runner parks (stop reason `paused`),
+  cold-replays on the next turn, and resolves a decision keyed by `approvalKey(name, args)`.
+  Decisions are read from inbound `tool_result` blocks carrying `{approved}`
+  (`services/agent/src/responder.ts`).
+- The playground consumes the stream with `useChat`, renders approve/deny in `ToolActivity`,
+  and auto-resumes via `sendAutomaticallyWhen: agentShouldResumeAfterApproval`
+  (`web/oss/src/components/AgentChatSlice/`).
+- `commit_revision` is a platform op with `default_needs_approval=True`,
+  `default_permission="ask"`. The running variant id is server-bound. The approval gate is
+  already available (`sdks/python/agenta/sdk/agents/platform/op_catalog.py`).
+- Config refresh today is imperative: the playground reads the latest revision per request
+  via `workflowLatestRevisionQueryAtomFamily`. No "a revision landed" frame exists yet for
+  the agent's own commit.
+- Connections: `POST /tools/discover` (`find_capabilities`, a platform op) returns
+  `ConnectionRequirement{integration, state: ready|needs_auth|needs_input, connect}`. A
+  missing connection on the resolve path raises `ConnectionNotFoundError` (HTTP 404).
+  `POST /tools/connections/` returns `status.redirect_url`; the OAuth callback activates the
+  connection and posts a message to the opener window. Connections live at project scope,
+  keyed `(project_id, provider_key, integration_key, slug)`.
+
+## Coordination
+
+- The "default tools and skills" project and the "missing builder tools" project are active.
+  The builder-capabilities work depends on this project's connection-request flow; that
+  dependency is designed here (Problem 2). Coordinate concrete tool names via the
+  orchestrator.
+
+## Links
+
+- Tool discovery (the connection-state source for Problem 2):
+  [`../tool-discovery/status.md`](../tool-discovery/status.md)
+- HITL park/resume (the primitive Problem 1 and 2 extend):
+  [`../hitl-fix`](../hitl-fix)

--- a/docs/design/agent-workflows/projects/agent-fe-roundtrip/status.md
+++ b/docs/design/agent-workflows/projects/agent-fe-roundtrip/status.md
@@ -4,15 +4,15 @@ Source of truth for this project. Update as work proceeds.
 
 ## What this project is
 
-One primitive, two applications. A tool call that travels to the playground, shows the user
-something, waits for the user to act, and resumes the agent with the result.
+One primitive, two applications. A tool call travels to the playground, shows the user something,
+waits for the user to act, and resumes the agent with the result.
 
-- Application 1: the agent edits its own config (`commit_revision`). Approval stays per-tool,
-  not hardcoded. After a commit lands, the playground refreshes the config panel and the
-  build-kit view in both the gated and the direct path.
-- Application 2: the agent needs a connection it does not have (for example GitHub). Discovery
-  reports it, the agent calls `request_connection`, the user finishes the OAuth flow in the
-  playground, the frontend replies with a structured reference, and the agent resumes.
+- Application 1: the agent edits its own config (`commit_revision`). Approval stays per-tool. After
+  a commit lands, the playground refreshes the config panel and the build-kit view in both the
+  gated and the direct path.
+- Application 2: the agent needs a connection it lacks (for example GitHub). Discovery reports it,
+  the agent calls `request_connection`, the user finishes OAuth in the playground, the frontend
+  replies with a structured reference, and the agent resumes.
 
 The design doc is [`design.md`](./design.md).
 
@@ -20,53 +20,60 @@ The design doc is [`design.md`](./design.md).
 
 Design ready for review. Nothing built yet. Docs-first.
 
-The headline finding: the HITL approval flow we already ship is a client round-trip, and the
-Vercel AI SDK ships the sibling half we need. The runner's "forbid client tools" becomes "emit
-the call and park." No new transport.
+The headline finding: the HITL approval flow we already ship is a client round-trip, and the Vercel
+AI SDK ships the sibling half. The runner's "forbid client tools" becomes "emit the call and park."
+No new transport.
 
 ## Decisions (locked 2026-06-28)
 
-- D1: config-change approval is per-tool. `needs_approval` stays the tool's own field. The new
-  universal requirement is the refresh, fired on commit success so it covers both the gated and
-  the direct path. v1 ships a generic approval widget; the frame carries the tool name and a
-  render hint for a later config-diff widget.
+- D1: config-change approval is per-tool. `needs_approval` stays the tool's own field. The universal
+  requirement is the refresh, fired on commit success so it covers both the gated and the direct
+  path. v1 ships a generic approval widget; the frame carries the tool name and a render hint for a
+  later config-diff widget.
 - D2: the connection trigger is an explicit `request_connection` tool, driven by discovery and a
-  skill. Runner auto-interception is out of v1, kept only as a future option.
+  skill. Runner auto-interception is out of v1.
 - D3: build the generic client-tool round-trip, not a narrow connect kind. It carries both
-  applications and retires the dead `client` executor.
-- D4: the result returns as a structured tool result keyed to the parked call, carrying a
-  reference (integration plus slug), never the secret. The runner re-resolves from the vault on
-  resume. Failure and cancel also settle the call.
-- D5: `request_connection` is a hard-coded platform tool with a client executor, in the same
-  catalog as `find_capabilities` and `commit_revision`. Because it is a platform tool, it is
-  part of the injected build kit.
+  applications and wires the declared-but-dormant `client_tool` interaction path.
+- D4: the result returns as a structured tool result keyed to the parked call, carrying a reference
+  (integration plus slug), never the secret. The runner re-resolves from the vault on resume.
+  Success, failure, cancel, and abandon all settle the call.
+- D5: `request_connection` is a non-runnable reference tool: a hard-coded platform workflow the
+  build kit embeds with `@ag.embed`, like the authoring skill. It is not a platform op. The backend
+  exposes the tool; the frontend handles the call.
 
 ## Verified facts (grounded in code, do not relitigate)
 
-- The neutral event `interaction_request` already carries
+- The neutral event `interaction_request` carries
   `kind: "permission" | "input" | "client_tool"` (`services/agent/src/protocol.ts`). Only
-  `permission` is wired. `Responder` has `onPermission` only.
-- The `client` executor exists as a model (`ClientToolSpec`, `kind: "client"`), but the runner
-  throws on any client tool on purpose (`services/agent/src/tools/dispatch.ts`).
+  `permission` is wired; `Responder` has `onPermission` only. `input` and `client_tool` are
+  forward-looking.
+- A client tool is correctly refused in-sandbox: `dispatch.ts` throws because it is browser-
+  fulfilled (`services/agent/src/tools/dispatch.ts`). Missing is the emit-and-park path that runs
+  before dispatch.
+- The cold-replay anchor is `approvalKey(name, args)` (`services/agent/src/responder.ts`). CodeRabbit
+  flagged the approval-specific name; rename it to `parkedCallKey`.
 - Park and resume is fully built for permission. The runner parks (stop reason `paused`),
-  cold-replays on the next turn, and resolves a decision keyed by `approvalKey(name, args)`,
-  read from inbound `tool_result` blocks carrying `{approved}`
-  (`services/agent/src/responder.ts`).
-- The playground consumes the stream with `useChat`, renders approve and deny in `ToolActivity`,
-  and auto-resumes through `sendAutomaticallyWhen: agentShouldResumeAfterApproval`, which
-  filters `providerExecuted !== true`
-  (`web/oss/src/components/AgentChatSlice/`,
+  cold-replays on the next turn, and resolves a decision read from inbound `tool_result` blocks
+  carrying `{approved}` (`services/agent/src/responder.ts`).
+- The playground consumes the stream with `useChat`, renders approve and deny in `ToolActivity`, and
+  auto-resumes through `sendAutomaticallyWhen: agentShouldResumeAfterApproval`, which filters
+  `providerExecuted !== true` (`web/oss/src/components/AgentChatSlice/`,
   `web/packages/agenta-playground/src/state/execution/agentApprovalResume.ts`).
-- The AI SDK is on the beta channel (`ai@6.0.0-beta`, `@ai-sdk/react@3.0.0-beta`). All symbols
-  we rely on are present: `addToolApprovalResponse`,
+- The AI SDK is on the beta channel (`ai@6.0.0-beta`, `@ai-sdk/react@3.0.0-beta`). All symbols we
+  rely on are present: `addToolApprovalResponse`,
   `lastAssistantMessageIsCompleteWithApprovalResponses`, `onToolCall`, `addToolOutput`,
   `lastAssistantMessageIsCompleteWithToolCalls`, and the `providerExecuted` flag.
+- Tool models: `ReferenceToolConfig` (`type: "reference"`) resolves to a server-side
+  `CallbackToolSpec` (`/tools/call`, backend-runnable). An `@ag.embed` of a workflow tool inlines to
+  a browser-fulfilled `ClientToolSpec` (`kind: "client"`). `request_connection` takes the second
+  path (`sdks/python/agenta/sdk/agents/tools/models.py`, `.../platform/workflow.py`,
+  `api/oss/src/core/embeds/utils.py`).
 - `commit_revision` is a platform op with `default_needs_approval=True` and
   `default_permission="ask"`. The running variant id is bound server-side
   (`sdks/python/agenta/sdk/agents/platform/op_catalog.py`).
-- Config refresh today is imperative: the playground reads the latest revision per request
-  through `workflowLatestRevisionQueryAtomFamily`. No "a revision landed" frame exists yet for
-  the agent's own commit.
+- Config refresh today is imperative: the playground reads the latest revision per request through
+  `workflowLatestRevisionQueryAtomFamily`. No "a revision landed" frame exists yet for the agent's
+  own commit.
 - Connections: `POST /tools/discover` (`find_capabilities`) returns
   `ConnectionRequirement{integration, state, connect}`. `POST /tools/connections/` returns
   `status.redirect_url`; the OAuth callback activates the connection and posts a message to the
@@ -74,33 +81,24 @@ the call and park." No new transport.
   Connections live at project scope, keyed `(project_id, provider_key, integration_key, slug)`
   (`api/oss/src/apis/fastapi/tools/router.py`).
 
-## Corrections folded into this round
+## Build-kit alignment (reference, do not redesign; #4917)
 
-- `request_connection` does not exist yet. It is proposed by this doc and built as the first
-  client platform op.
-- The platform op model has no `executor` field, and every existing op is server-executed by an
-  HTTP method and path. `request_connection` is the first op with `executor: "client"` and no
-  method or path. This is a small new shape in the catalog.
-- A client tool needs no new Vercel frame. The call rides as the standard unsettled tool part,
-  and the optional render hint rides the existing `data-render` channel.
-
-## Build-kit alignment (reference, do not redesign)
-
-The default platform tools and the authoring skill are injected, not committed. The backend
-exposes them as a read-only `build_kit` descriptor at `revision.data.build_kit` in `/inspect`
-(grouped `skills`, `tools`, `permissions`; rows carry `key`, `name`, `description`; permission
-rows add `status`), with a per-run flag `flags.inject_build_kit` on the run request.
-`request_connection` is a `tools` row in that kit. The commit refresh (`data-committed-revision`)
-should also refresh the build-kit display. Owned by the default-agent-config project.
+The default platform tools and the authoring skill are an agent-template overlay the backend serves
+read-only at `additional_context.playground_build_kit.agent_template_overlay` (a partial `parameters.agent`). The
+frontend merges the overlay onto `parameters.agent` on a playground run and excludes it on commit.
+There is no run flag and no service-side injection. `request_connection` joins the overlay as a
+reference-tool entry (identity by its referenced workflow), beside the authoring skill's `@ag.embed`.
+The commit refresh (`data-committed-revision`) also refreshes the build-kit view. Owned by the
+default-agent-config project.
 
 ## Coordination
 
 - agent-skills owns the skill that teaches the discover-then-connect loop. Our primitive only
   delivers the "connection ready" signal.
-- default-agent-config owns the build kit and decides whether a published agent keeps
-  `request_connection`.
-- agent-builder-capabilities rides this primitive for triggers and subscriptions, and gates a
-  live subscription test on a connection.
+- default-agent-config (`#4917`) owns the build-kit overlay and decides whether a published agent
+  keeps `request_connection`.
+- agent-builder-capabilities rides this primitive for triggers and subscriptions, and gates a live
+  subscription test on a connection.
 
 ## Links
 
@@ -108,5 +106,5 @@ should also refresh the build-kit display. Owned by the default-agent-config pro
   [`../tool-discovery/status.md`](../tool-discovery/status.md)
 - HITL park and resume (the primitive both applications extend):
   [`../hitl-fix`](../hitl-fix)
-- Default build kit (the inject-not-commit model and the `build_kit` descriptor):
+- Default build kit (the overlay model and the `additional_context` container):
   [`../default-agent-config/`](../default-agent-config/)


### PR DESCRIPTION
## Context

This is the Part 2 design for the agent frontend round-trip, written for Arda to review the
approach before any frontend work starts. It is docs only.

An agent sometimes needs the human in the middle of a run. It rewrites its own config and wants
approval first. Or it needs a GitHub connection that does not exist yet, and the user must finish an
OAuth flow before the agent can continue. Both cases pause the run, show something in the playground,
wait for the user, and resume the agent with the result.

The finding that drives the design: the HITL approval flow we already ship is one half of this
round-trip, and the Vercel AI SDK ships the matching half. The runner's rule "forbid client tools"
becomes "emit the call and park." No new transport.

## What the design proposes

**One generic client-tool round-trip.** A tool with no server execute is fulfilled by the browser.
The runner streams the call, parks the run, and waits. The playground renders a widget, the user
acts, and the result returns on the next turn as a `tool_result` keyed to the same call. This is the
permission flow generalized: the outbound side carries any tool call, the inbound side carries any
structured output. The park, the cold-replay, and the resume stay as they are.

**`request_connection` as a non-runnable reference tool.** The earlier draft modeled it as a
platform op. That was wrong. A platform op always binds to an HTTP method and path the runner calls,
and this tool has neither, because the browser does the work. The corrected model is a hard-coded
workflow the build kit embeds with `@ag.embed`, the same way it embeds the authoring skill. The embed
resolver inlines that embed into a browser-fulfilled `client` tool. So the round-trip needs no new
tool shape and no new flag.

**The abandon flow resolved.** An unsettled tool part hangs the resume, so the widget settles the
parked call on every terminal path, including abandon. It detects a closed popup and settles a
cancel result, with a timeout backstop if no terminal signal arrives within a bound. The chip then
reads "Connection not completed" with a Retry action, and the agent gets a definite failure result
so it can re-ask or move on. It never waits forever.

**Build-kit alignment with #4917.** `request_connection` joins the agent-template overlay as a
reference-tool entry, beside the authoring skill's `@ag.embed`, and is never committed. The doc now
uses the finalized container path `additional_context.playground_build_kit.agent_template_overlay`.
There is no run flag and no service-side injection.

**Two review fixes.** The cold-replay anchor is renamed from `approvalKey` to the neutral
`parkedCallKey`, since a client tool is not an approval gate. The connect widget must validate
`event.origin` against the Agenta API origin before it trusts the OAuth callback `postMessage`,
stated as a hard requirement, with a state binding as defense in depth.

## Scope / risk

Docs only. No code changes. The design reuses the existing HITL park-and-resume machinery rather
than adding a transport, so the runtime risk lands at implementation time, not here. Out of scope and
recorded in the doc: the per-tool config-diff widget, runner auto-interception of a missing
connection, and the skill that teaches the discover-then-connect loop (owned by agent-skills). The
build-kit overlay itself is owned by default-agent-config (#4917); this doc references it and changes
neither.

## How to QA

Read `docs/design/agent-workflows/projects/agent-fe-roundtrip/design.md` and `status.md`. Confirm the
approach reads correctly, in particular the `request_connection` reframe (the load-bearing claim that
an `@ag.embed` of a workflow tool already inlines to a browser-fulfilled client tool), the abandon
resolution, and the two review fixes. Inline focus-pointers mark the sections worth the most
attention.