### PR TITLE
refactor(frontend): split AgentTemplateControl into focused modules

### DIFF
--- a/docs/design/agent-config-section-drawers/design.md
+++ b/docs/design/agent-config-section-drawers/design.md
@@ -92,6 +92,15 @@ switch, mirroring the model warning. Tracked as the harness-gating follow-up.
 - Reference (`@ag.reference`) chips in the editor — they live on the embedref branch (#4877) and
   light up here when that merges.
 - Optional: model remap (instead of clear) when switching harness.
+- Tool draft validation depth — the per-kind `draftInvalid` only checks an inline function's name
+  today. Under the incoming `kind`-discriminated tool schema (`schema-driven-config-proposal.md`,
+  CHANGE-3) every entry must validate against its per-kind sub-schema. Tighten when that lands; the
+  registry's per-kind `draftInvalid`/`createSeed` get replaced wholesale (the current `tool.createSeed`
+  is an unused stub — creation seeds from the picker). Raised from PR #4923 review.
+- Named-connection slug on a provider change — intentionally kept today (the option list is
+  vault-secret async, so an eager clear would wipe a valid slug mid-load). When provider becomes
+  first-class via `ModelSpec` (`../agent-workflows/scratch/notes-model-auth.md`, R2), re-bind or clear the slug when the
+  derived provider changes. Raised from PR #4923 review.
 
 ## Verification
 

--- a/web/packages/agenta-entity-ui/src/DrillInView/SchemaControls/AgentTemplateControl.tsx
+++ b/web/packages/agenta-entity-ui/src/DrillInView/SchemaControls/AgentTemplateControl.tsx
@@ -93,10 +93,7 @@ export function AgentTemplateControl({
     }, [config])
 
     const [referenceSelectorOpen, setReferenceSelectorOpen] = useState(false)
-    // The item-config drawer (tools / MCP servers / skills). Edits happen on a local `draft`; they
-    // only apply to the config on Save, so creating an item never pollutes the config until
-    // confirmed, and editing an existing item can be cancelled cleanly (Cancel/X discards the
-    // draft). The shared machine writes to each kind's array via the ITEM_KINDS registry.
+    // Shared draft-then-save drawer for tools, MCP servers, and skills (writes via ITEM_KINDS).
     const {
         editing,
         draft,
@@ -113,8 +110,7 @@ export function AgentTemplateControl({
         draftInvalid,
     } = useConfigItemDrawer({config, onChange})
 
-    // Instructions file editor. The section is modelled as a file list (one AGENTS.md today, more
-    // soon), so each file opens here. Draft + Save mirrors the item drawer: edits apply on Save.
+    // Instructions file editor (a file list — one AGENTS.md today). Draft + Save like the item drawer.
     const [editingInstruction, setEditingInstruction] = useState<{filename: string} | null>(null)
     const [instructionDraft, setInstructionDraft] = useState("")
     const openInstruction = useCallback((filename: string, content: string) => {
@@ -122,9 +118,8 @@ export function AgentTemplateControl({
         setEditingInstruction({filename})
     }, [])
 
-    // Section drawers (Model & harness, Advanced): the accordion header opens these instead of
-    // expanding inline. Edits apply live through the existing handlers; a full-config snapshot taken
-    // on open is restored on Cancel, giving the same draft-then-save feel as the item drawers.
+    // Section drawers (Model & harness, Advanced). Edits apply live; a config snapshot taken on open
+    // is restored on Cancel, giving the same draft-then-save feel as the item drawers.
     const [openSection, setOpenSection] = useState<null | "model-harness" | "advanced">(null)
     const sectionSnapshot = useRef<Record<string, unknown> | null>(null)
     const openSectionDrawer = useCallback(
@@ -140,16 +135,12 @@ export function AgentTemplateControl({
     }, [onChange])
     const saveSection = useCallback(() => setOpenSection(null), [])
 
-    // How the config sections are laid out: stacked accordion (default), tabs, or cards.
-    // Layout is a global, persisted preference set from the variant header menu (see
-    // agentTemplateLayout); the panel only reads it.
+    // Layout (accordion / tabs / cards) is a global persisted preference; the panel only reads it.
     const layout = useAtomValue(agentTemplateLayoutAtom)
 
-    // `config` IS the agent template (the `parameters.agent` value), exactly as the prompt control's
-    // value is the prompt template. `schema` is the `agent-template` catalog type and decides which
-    // sections exist: the portable definition's fields (instructions / llm / tools / mcps / skills)
-    // are FLAT on it; the execution parts (harness / runner / sandbox) are nested sub-objects, read
-    // by the Model & harness + Advanced sections (see useModelHarness).
+    // `config` IS the agent template (`parameters.agent`); `schema` is the `agent-template` type and
+    // decides which sections exist. Portable fields (instructions / llm / tools / mcps / skills) are
+    // FLAT; execution parts (harness / runner / sandbox) are nested sub-objects (see useModelHarness).
     const props = (schema?.properties ?? {}) as Record<string, SchemaProperty>
 
     // Set one flat field of the agent definition (instructions / tools / mcps / skills).
@@ -170,9 +161,7 @@ export function AgentTemplateControl({
     // feeds both sections), so they live in their own hook that returns the summaries + bodies.
     const mh = useModelHarness({schema, config, onChange, revisionId, disabled, withTooltip})
 
-    // Tools live as a flat array on the agent definition (the same tool-object shape the prompt
-    // control uses). The add/remove flows differ per kind (inline function, builtin, gateway,
-    // workflow reference), so that logic lives in its own hook; the orchestrator just wires it in.
+    // Tool add/remove (inline function, builtin, gateway, workflow reference) lives in its own hook.
     const {
         tools,
         handleAddTool,
@@ -183,9 +172,7 @@ export function AgentTemplateControl({
         referenceableWorkflows,
     } = useAgentTools({config, onChange, configRef, openCreate, workflowReference})
 
-    // MCP servers are a sibling of tools: a flat array on the agent config. Each entry is the
-    // open McpServer shape (name + stdio command/args/env or remote url, secret names), edited
-    // as JSON the backend resolver parses identically to `tools`.
+    // MCP servers: a flat array of McpServer shapes (stdio command/args/env or remote url + secrets).
     const mcpServers = useMemo(
         () => (Array.isArray(config.mcps) ? (config.mcps as unknown[]) : []),
         [config.mcps],
@@ -195,9 +182,7 @@ export function AgentTemplateControl({
         [openCreate],
     )
 
-    // Skills are a sibling of tools/MCP: a flat array on the agent config. Each entry is an inline
-    // SKILL.md package (name + description + body + files + flags) or an `@ag.embed` reference the
-    // backend inlines — the `skill-template` catalog type (SkillTemplateSchema in the SDK).
+    // Skills: a flat array of inline SKILL.md packages or `@ag.embed` references the backend inlines.
     const skills = useMemo(
         () => (Array.isArray(config.skills) ? (config.skills as unknown[]) : []),
         [config.skills],
@@ -234,9 +219,7 @@ export function AgentTemplateControl({
             : undefined,
     }
 
-    // A compact "+" affordance for a section header, so an item can be added without first
-    // expanding the section. Rendered in the header's `extra` slot (which stops propagation, so it
-    // never toggles the section).
+    // Compact "+" for a section header's `extra` slot (stops propagation, so it never toggles open).
     const headerAddButton = (label: string, onClick: () => void) => (
         <Tooltip title={label}>
             <Button type="text" icon={<Plus size={16} />} onClick={onClick} aria-label={label} />
@@ -412,11 +395,8 @@ export function AgentTemplateControl({
                     No agent configuration fields are available for this schema.
                 </Typography.Text>
             ) : layout === "tabs" ? (
-                // Tabs is the non-default "see-everything" layout: it renders each section's body
-                // inline (no `onOpen` drawer), so edits are live (edit → dirty → commit) like the
-                // rest of the playground. The drawer sections (Model & harness, Advanced) supply a
-                // trimmed `inlineContent` here so the tab shows just their controls — not the wide
-                // two-panel drawer body, whose side panel reads as out-of-place chrome inline.
+                // Tabs renders each section's body inline (no drawer), so edits are live. Drawer
+                // sections supply a trimmed `inlineContent` so the tab shows just their controls.
                 <Tabs
                     items={sections.map((s) => ({
                         key: s.key,
@@ -427,10 +407,8 @@ export function AgentTemplateControl({
                             </span>
                         ),
                         children: (
-                            // Render the section's `extra` (the add-action, e.g. Add trigger)
-                            // here too — the accordion/cards layouts surface it via `extra`, and
-                            // dropping it leaves tab-layout users unable to add items. The body is
-                            // the trimmed `inlineContent` (drawer sections) or `content` otherwise.
+                            // Render `extra` (the add-action) here too, else tab users can't add
+                            // items. Body is the trimmed `inlineContent` or `content`.
                             <div className="flex flex-col gap-3 pt-1">
                                 {s.extra ? <div className="flex justify-end">{s.extra}</div> : null}
                                 {s.inlineContent ?? s.content}

--- a/web/packages/agenta-entity-ui/src/DrillInView/SchemaControls/AgentTemplateControl.tsx
+++ b/web/packages/agenta-entity-ui/src/DrillInView/SchemaControls/AgentTemplateControl.tsx
@@ -53,23 +53,16 @@ import {useAtomValue} from "jotai"
 import {useOptionalDrillIn} from "../components/MoleculeDrillInContext"
 
 import {AddTextLink} from "./AddTextLink"
-import {countSummary, cloneItem, enumLabel} from "./agentTemplate/agentTemplateUtils"
-import {
-    describeMcp,
-    describeSkill,
-    describeTool,
-    isBuiltinPayloadMatch,
-    isEmbedRefSkill,
-    isFunctionTool,
-    isStaticSkill,
-    toolName,
-    toolReferenceSlug,
-} from "./agentTemplate/itemDescriptors"
-import {InstructionsFileRow, ItemRow} from "./agentTemplate/ItemRow"
+import {countSummary, enumLabel} from "./agentTemplate/agentTemplateUtils"
+import {ConfigItemList} from "./agentTemplate/ConfigItemList"
+import {isBuiltinPayloadMatch, toolName, toolReferenceSlug} from "./agentTemplate/itemDescriptors"
+import {ITEM_KINDS} from "./agentTemplate/itemKinds"
+import {InstructionsFileRow} from "./agentTemplate/ItemRow"
+import {useConfigItemDrawer} from "./agentTemplate/useConfigItemDrawer"
 import {agentTemplateLayoutAtom} from "./agentTemplateLayout"
 import {ClaudePermissionsControl} from "./ClaudePermissionsControl"
 import {CodeEditor} from "./CodeEditor"
-import {ConfigItemDrawer, type ConfigItemView} from "./ConfigItemDrawer"
+import {ConfigItemDrawer} from "./ConfigItemDrawer"
 import {
     allowedConnectionModes,
     buildModelOptionGroups,
@@ -87,11 +80,8 @@ import {GroupedChoiceControl} from "./GroupedChoiceControl"
 import {HarnessSelectControl} from "./HarnessSelectControl"
 import {InstructionsDrawer} from "./InstructionsDrawer"
 import {JsonObjectEditor} from "./JsonObjectEditor"
-import {McpServerFormView} from "./McpServerFormView"
 import {SandboxPermissionControl} from "./SandboxPermissionControl"
 import {SectionDrawer} from "./SectionDrawer"
-import {SkillFormView} from "./SkillFormView"
-import {ToolFormView} from "./ToolFormView"
 import {ToolSelectorPopover, type ToolSelectionMeta} from "./ToolSelectorPopover"
 import {type ToolObj} from "./toolUtils"
 import {
@@ -129,34 +119,26 @@ export function AgentTemplateControl({
         configRef.current = config
     }, [config])
 
-    // The item-config drawer (tools / MCP servers). Edits happen on a local `draft`; they only
-    // apply to the config on Save. So creating an item never pollutes the config until confirmed,
-    // and editing an existing item can be cancelled cleanly (Cancel/X discards the draft).
-    const [editing, setEditing] = useState<{
-        kind: "tool" | "mcp" | "skill"
-        mode: "create" | "edit"
-        index: number
-    } | null>(null)
-    const [draft, setDraft] = useState<Record<string, unknown>>({})
-    const [drawerView, setDrawerView] = useState<ConfigItemView>("form")
     const [referenceSelectorOpen, setReferenceSelectorOpen] = useState(false)
-    const openCreate = useCallback(
-        (kind: "tool" | "mcp" | "skill", seed: Record<string, unknown>, view: ConfigItemView) => {
-            setDraft(seed)
-            setDrawerView(view)
-            setEditing({kind, mode: "create", index: -1})
-        },
-        [],
-    )
-    const openEdit = useCallback(
-        (kind: "tool" | "mcp" | "skill", index: number, item: unknown, view: ConfigItemView) => {
-            setDraft(cloneItem(item))
-            setDrawerView(view)
-            setEditing({kind, mode: "edit", index})
-        },
-        [],
-    )
-    const closeEditor = useCallback(() => setEditing(null), [])
+    // The item-config drawer (tools / MCP servers / skills). Edits happen on a local `draft`; they
+    // only apply to the config on Save, so creating an item never pollutes the config until
+    // confirmed, and editing an existing item can be cancelled cleanly (Cancel/X discards the
+    // draft). The shared machine writes to each kind's array via the ITEM_KINDS registry.
+    const {
+        editing,
+        draft,
+        setDraft,
+        drawerView,
+        setDrawerView,
+        jsonInvalid,
+        setJsonInvalid,
+        openCreate,
+        openEdit,
+        closeEditor,
+        commitDraft,
+        removeItem,
+        draftInvalid,
+    } = useConfigItemDrawer({config, onChange})
 
     // Instructions file editor. The section is modelled as a file list (one AGENTS.md today, more
     // soon), so each file opens here. Draft + Save mirrors the item drawer: edits apply on Save.
@@ -458,11 +440,6 @@ export function AgentTemplateControl({
         [workflowReference, onChange],
     )
 
-    const handleToolDelete = useCallback(
-        (index: number) => setTools(tools.filter((_, i) => i !== index)),
-        [tools, setTools],
-    )
-
     const handleRemoveToolByName = useCallback(
         (name: string) => setTools(tools.filter((tool) => toolName(tool) !== name)),
         [tools, setTools],
@@ -494,16 +471,9 @@ export function AgentTemplateControl({
         () => (Array.isArray(config.mcps) ? (config.mcps as unknown[]) : []),
         [config.mcps],
     )
-    const setMcpServers = useCallback(
-        (next: unknown[]) => setAgentField("mcps", next),
-        [setAgentField],
-    )
-    const handleAddMcpServer = useCallback(() => {
-        openCreate("mcp", {name: "", transport: "stdio", command: "", args: []}, "form")
-    }, [openCreate])
-    const handleMcpServerDelete = useCallback(
-        (index: number) => setMcpServers(mcpServers.filter((_, i) => i !== index)),
-        [mcpServers, setMcpServers],
+    const handleAddMcpServer = useCallback(
+        () => openCreate("mcp", ITEM_KINDS.mcp.createSeed(), "form"),
+        [openCreate],
     )
 
     // Skills are a sibling of tools/MCP: a flat array on the agent config. Each entry is an inline
@@ -513,69 +483,10 @@ export function AgentTemplateControl({
         () => (Array.isArray(config.skills) ? (config.skills as unknown[]) : []),
         [config.skills],
     )
-    const setSkills = useCallback(
-        (next: unknown[]) => setAgentField("skills", next),
-        [setAgentField],
+    const handleAddSkill = useCallback(
+        () => openCreate("skill", ITEM_KINDS.skill.createSeed(), "form"),
+        [openCreate],
     )
-    const handleAddSkill = useCallback(() => {
-        openCreate("skill", {name: "", description: "", body: ""}, "form")
-    }, [openCreate])
-    const handleSkillDelete = useCallback(
-        (index: number) => setSkills(skills.filter((_, i) => i !== index)),
-        [skills, setSkills],
-    )
-
-    // Apply the drawer's draft to the config: append (create) or replace at index (edit).
-    const commitDraft = useCallback(() => {
-        if (!editing) return
-        if (editing.kind === "tool") {
-            const next = [...tools]
-            if (editing.mode === "create") next.push(draft)
-            else next[editing.index] = draft
-            setTools(next)
-        } else if (editing.kind === "mcp") {
-            const next = [...mcpServers]
-            if (editing.mode === "create") next.push(draft)
-            else next[editing.index] = draft
-            setMcpServers(next)
-        } else {
-            const next = [...skills]
-            if (editing.mode === "create") next.push(draft)
-            else next[editing.index] = draft
-            setSkills(next)
-        }
-        setEditing(null)
-    }, [editing, draft, tools, mcpServers, skills, setTools, setMcpServers, setSkills])
-
-    // Block Save until the draft has the minimum it needs to be a valid item (a name). `@ag.embed`
-    // skill references carry no name and are always valid (they round-trip as-is).
-    // JSON-view parse validity from the open drawer's JsonObjectEditor; blocks Save while the
-    // raw JSON is invalid. The editor keeps invalid text local and stops emitting onChange, so
-    // without this Save would silently commit the last valid draft.
-    const [jsonInvalid, setJsonInvalid] = useState(false)
-    // Reset when the open item changes — each editor is keyed/remounts and starts valid.
-    useEffect(() => {
-        setJsonInvalid(false)
-    }, [editing])
-
-    const draftInvalid = useMemo(() => {
-        if (!editing) return true
-        if (editing.kind === "mcp") {
-            // A server needs a launch target too, not just a name: stdio → command, http → url.
-            const name = String(draft.name ?? "").trim()
-            const transport = draft.transport === "http" ? "http" : "stdio"
-            const target =
-                transport === "http"
-                    ? String(draft.url ?? "").trim()
-                    : String(draft.command ?? "").trim()
-            return !name || !target
-        }
-        if (editing.kind === "skill")
-            return !isEmbedRefSkill(draft) && !String(draft.name ?? "").trim()
-        const fn = draft.function as Record<string, unknown> | undefined
-        if (fn && typeof fn === "object") return !String(fn.name ?? "").trim()
-        return false
-    }, [editing, draft])
 
     // ``instructions.agents_md`` is the one instruction document (flat on the template).
     const instructions =
@@ -1239,40 +1150,23 @@ export function AgentTemplateControl({
                 />
             ) : undefined,
             defaultOpen: true,
-            content:
-                tools.length > 0 ? (
-                    <div className="flex flex-col gap-2">
-                        {tools.map((tool, index) => (
-                            <ItemRow
-                                key={`tool-${index}`}
-                                descriptor={describeTool(tool)}
-                                onEdit={() =>
-                                    openEdit(
-                                        "tool",
-                                        index,
-                                        tool,
-                                        isFunctionTool(tool) ? "form" : "json",
-                                    )
-                                }
-                                onRemove={() => {
-                                    handleToolDelete(index)
-                                    closeEditor()
-                                }}
-                                disabled={disabled}
-                            />
-                        ))}
-                    </div>
-                ) : !disabled ? (
-                    // Empty: a muted line whose action is a borderless text link (the header + adds
-                    // once there are items). The link is the ToolSelectorPopover trigger.
-                    <span className="text-xs text-[var(--ag-c-97A4B0,#97a4b0)]">
-                        No tools yet —{" "}
+            content: (
+                <ConfigItemList
+                    kind="tool"
+                    items={tools}
+                    openEdit={openEdit}
+                    removeItem={removeItem}
+                    closeEditor={closeEditor}
+                    disabled={disabled}
+                    // The empty-state add is the same popover as the header +.
+                    emptyAdd={
                         <ToolSelectorPopover
                             {...toolSelectorProps}
                             trigger={<AddTextLink label="add a tool" />}
                         />
-                    </span>
-                ) : null,
+                    }
+                />
+            ),
         },
         hasMcp && {
             key: "mcp",
@@ -1281,28 +1175,17 @@ export function AgentTemplateControl({
             summary: countSummary(mcpServers.length, "server"),
             extra: !disabled ? headerAddButton("Add MCP server", handleAddMcpServer) : undefined,
             defaultOpen: mcpServers.length > 0,
-            content:
-                mcpServers.length > 0 ? (
-                    <div className="flex flex-col gap-2">
-                        {mcpServers.map((server, index) => (
-                            <ItemRow
-                                key={`mcp-${index}`}
-                                descriptor={describeMcp(server)}
-                                onEdit={() => openEdit("mcp", index, server, "form")}
-                                onRemove={() => {
-                                    handleMcpServerDelete(index)
-                                    closeEditor()
-                                }}
-                                disabled={disabled}
-                            />
-                        ))}
-                    </div>
-                ) : !disabled ? (
-                    <span className="text-xs text-[var(--ag-c-97A4B0,#97a4b0)]">
-                        No MCP servers yet —{" "}
-                        <AddTextLink label="add a server" onClick={handleAddMcpServer} />
-                    </span>
-                ) : null,
+            content: (
+                <ConfigItemList
+                    kind="mcp"
+                    items={mcpServers}
+                    openEdit={openEdit}
+                    removeItem={removeItem}
+                    closeEditor={closeEditor}
+                    disabled={disabled}
+                    emptyAdd={<AddTextLink label="add a server" onClick={handleAddMcpServer} />}
+                />
+            ),
         },
         hasSkills && {
             key: "skills",
@@ -1311,36 +1194,17 @@ export function AgentTemplateControl({
             summary: countSummary(skills.length, "skill"),
             extra: !disabled ? headerAddButton("Add skill", handleAddSkill) : undefined,
             defaultOpen: skills.length > 0,
-            content:
-                skills.length > 0 ? (
-                    <div className="flex flex-col gap-2">
-                        {skills.map((skill, index) => (
-                            <ItemRow
-                                key={`skill-${index}`}
-                                descriptor={describeSkill(skill)}
-                                onEdit={() =>
-                                    openEdit(
-                                        "skill",
-                                        index,
-                                        skill,
-                                        isEmbedRefSkill(skill) ? "json" : "form",
-                                    )
-                                }
-                                onRemove={() => {
-                                    handleSkillDelete(index)
-                                    closeEditor()
-                                }}
-                                // Static skills (`__ag__*`) are read-only: no remove, and
-                                // the drawer opens disabled (see the skill drawer below).
-                                disabled={disabled || isStaticSkill(skill)}
-                            />
-                        ))}
-                    </div>
-                ) : !disabled ? (
-                    <span className="text-xs text-[var(--ag-c-97A4B0,#97a4b0)]">
-                        No skills yet — <AddTextLink label="add a skill" onClick={handleAddSkill} />
-                    </span>
-                ) : null,
+            content: (
+                <ConfigItemList
+                    kind="skill"
+                    items={skills}
+                    openEdit={openEdit}
+                    removeItem={removeItem}
+                    closeEditor={closeEditor}
+                    disabled={disabled}
+                    emptyAdd={<AddTextLink label="add a skill" onClick={handleAddSkill} />}
+                />
+            ),
         },
         {
             key: "triggers",
@@ -1452,132 +1316,53 @@ export function AgentTemplateControl({
                 ))
             )}
 
-            {editing && editing.kind === "tool" && (
-                <ConfigItemDrawer
-                    open
-                    mode={editing.mode}
-                    icon={<Wrench size={16} />}
-                    title={
-                        describeTool(draft).name && describeTool(draft).name !== "Tool"
-                            ? describeTool(draft).name
-                            : "New tool"
-                    }
-                    badge={{
-                        text: describeTool(draft).typeLabel,
-                        color: describeTool(draft).typeColor,
-                    }}
-                    subtitle={describeTool(draft).subtitle}
-                    footerNote="Changes apply to this agent configuration"
-                    view={drawerView}
-                    onViewChange={setDrawerView}
-                    onCancel={closeEditor}
-                    onSave={commitDraft}
-                    saveDisabled={draftInvalid || (drawerView === "json" && jsonInvalid)}
-                    jsonOnly={!isFunctionTool(draft)}
-                    disabled={disabled}
-                    form={
-                        <ToolFormView
-                            key={`tool-form-${editing.mode}-${editing.index}`}
-                            value={draft}
-                            onChange={(v) => setDraft(v as Record<string, unknown>)}
-                            disabled={disabled}
-                        />
-                    }
-                    json={
-                        <JsonObjectEditor
-                            key={`tool-json-${editing.mode}-${editing.index}`}
-                            value={draft}
-                            onChange={(v) => setDraft(v as Record<string, unknown>)}
-                            onValidityChange={(valid) => setJsonInvalid(!valid)}
-                            disabled={disabled}
-                        />
-                    }
-                />
-            )}
-
-            {editing && editing.kind === "mcp" && (
-                <ConfigItemDrawer
-                    open
-                    mode={editing.mode}
-                    icon={<Plugs size={16} />}
-                    title={String(draft.name ?? "").trim() || "New MCP server"}
-                    badge={{
-                        text: describeMcp(draft).typeLabel,
-                        color: describeMcp(draft).typeColor,
-                    }}
-                    subtitle={describeMcp(draft).subtitle}
-                    footerNote="Changes apply to this agent configuration"
-                    view={drawerView}
-                    onViewChange={setDrawerView}
-                    onCancel={closeEditor}
-                    onSave={commitDraft}
-                    saveDisabled={draftInvalid || (drawerView === "json" && jsonInvalid)}
-                    disabled={disabled}
-                    form={
-                        <McpServerFormView
-                            key={`mcp-form-${editing.mode}-${editing.index}`}
-                            value={draft}
-                            onChange={(v) => setDraft(v)}
-                            disabled={disabled}
-                        />
-                    }
-                    json={
-                        <JsonObjectEditor
-                            key={`mcp-json-${editing.mode}-${editing.index}`}
-                            value={draft}
-                            onChange={(v) => setDraft(v as Record<string, unknown>)}
-                            onValidityChange={(valid) => setJsonInvalid(!valid)}
-                            disabled={disabled}
-                        />
-                    }
-                />
-            )}
-
-            {editing && editing.kind === "skill" && (
-                <ConfigItemDrawer
-                    open
-                    mode={editing.mode}
-                    icon={<GraduationCap size={16} />}
-                    title={
-                        isEmbedRefSkill(draft)
-                            ? "Skill reference"
-                            : String(draft.name ?? "").trim() || "New skill"
-                    }
-                    badge={{
-                        text: describeSkill(draft).typeLabel,
-                        color: describeSkill(draft).typeColor,
-                    }}
-                    subtitle={describeSkill(draft).subtitle}
-                    footerNote="Changes apply to this agent configuration"
-                    // Wider than the default 600 — the skill drawer is two-pane (Files + editor).
-                    width={760}
-                    view={drawerView}
-                    onViewChange={setDrawerView}
-                    onCancel={closeEditor}
-                    onSave={commitDraft}
-                    saveDisabled={draftInvalid || (drawerView === "json" && jsonInvalid)}
-                    jsonOnly={isEmbedRefSkill(draft)}
-                    // Static skills (`__ag__*`) are read-only — view their JSON but can't edit.
-                    disabled={disabled || isStaticSkill(draft)}
-                    form={
-                        <SkillFormView
-                            key={`skill-form-${editing.mode}-${editing.index}`}
-                            value={draft}
-                            onChange={(v) => setDraft(v)}
-                            disabled={disabled || isStaticSkill(draft)}
-                        />
-                    }
-                    json={
-                        <JsonObjectEditor
-                            key={`skill-json-${editing.mode}-${editing.index}`}
-                            value={draft}
-                            onChange={(v) => setDraft(v as Record<string, unknown>)}
-                            onValidityChange={(valid) => setJsonInvalid(!valid)}
-                            disabled={disabled || isStaticSkill(draft)}
-                        />
-                    }
-                />
-            )}
+            {editing
+                ? (() => {
+                      // One drawer for all three kinds — the per-kind icon/title/form/view rules
+                      // come from the ITEM_KINDS registry (replaces three near-identical blocks).
+                      const def = ITEM_KINDS[editing.kind]
+                      const desc = def.describe(draft)
+                      const readOnly = disabled || def.isReadOnly(draft)
+                      const Form = def.FormView
+                      const itemKey = `${editing.kind}-${editing.mode}-${editing.index}`
+                      return (
+                          <ConfigItemDrawer
+                              open
+                              mode={editing.mode}
+                              icon={def.icon}
+                              title={def.drawerTitle(draft)}
+                              badge={{text: desc.typeLabel, color: desc.typeColor}}
+                              subtitle={desc.subtitle}
+                              footerNote="Changes apply to this agent configuration"
+                              width={def.drawerWidth}
+                              view={drawerView}
+                              onViewChange={setDrawerView}
+                              onCancel={closeEditor}
+                              onSave={commitDraft}
+                              saveDisabled={draftInvalid || (drawerView === "json" && jsonInvalid)}
+                              jsonOnly={def.jsonOnly(draft)}
+                              disabled={readOnly}
+                              form={
+                                  <Form
+                                      key={`form-${itemKey}`}
+                                      value={draft}
+                                      onChange={(v) => setDraft(v)}
+                                      disabled={readOnly}
+                                  />
+                              }
+                              json={
+                                  <JsonObjectEditor
+                                      key={`json-${itemKey}`}
+                                      value={draft}
+                                      onChange={(v) => setDraft(v as Record<string, unknown>)}
+                                      onValidityChange={(valid) => setJsonInvalid(!valid)}
+                                      disabled={readOnly}
+                                  />
+                              }
+                          />
+                      )
+                  })()
+                : null}
 
             {editingInstruction && (
                 <InstructionsDrawer

--- a/web/packages/agenta-entity-ui/src/DrillInView/SchemaControls/AgentTemplateControl.tsx
+++ b/web/packages/agenta-entity-ui/src/DrillInView/SchemaControls/AgentTemplateControl.tsx
@@ -25,7 +25,7 @@ import {useCallback, useEffect, useMemo, useRef, useState} from "react"
 
 import type {SchemaProperty} from "@agenta/entities/shared"
 import {ConfigAccordionSection} from "@agenta/ui/components/presentational"
-import {useDrillInUI, type WorkflowReferencePayload} from "@agenta/ui/drill-in"
+import {useDrillInUI} from "@agenta/ui/drill-in"
 import {cn} from "@agenta/ui/styles"
 import {
     Cpu,
@@ -45,9 +45,9 @@ import {useOptionalDrillIn} from "../components/MoleculeDrillInContext"
 import {AddTextLink} from "./AddTextLink"
 import {countSummary} from "./agentTemplate/agentTemplateUtils"
 import {ConfigItemList} from "./agentTemplate/ConfigItemList"
-import {isBuiltinPayloadMatch, toolName, toolReferenceSlug} from "./agentTemplate/itemDescriptors"
 import {ITEM_KINDS} from "./agentTemplate/itemKinds"
 import {InstructionsFileRow} from "./agentTemplate/ItemRow"
+import {useAgentTools} from "./agentTemplate/useAgentTools"
 import {useConfigItemDrawer} from "./agentTemplate/useConfigItemDrawer"
 import {useModelHarness} from "./agentTemplate/useModelHarness"
 import {agentTemplateLayoutAtom} from "./agentTemplateLayout"
@@ -55,7 +55,7 @@ import {ConfigItemDrawer} from "./ConfigItemDrawer"
 import {InstructionsDrawer} from "./InstructionsDrawer"
 import {JsonObjectEditor} from "./JsonObjectEditor"
 import {SectionDrawer} from "./SectionDrawer"
-import {ToolSelectorPopover, type ToolSelectionMeta} from "./ToolSelectorPopover"
+import {ToolSelectorPopover} from "./ToolSelectorPopover"
 import {type ToolObj} from "./toolUtils"
 import {
     AddTriggerDropdown,
@@ -170,100 +170,18 @@ export function AgentTemplateControl({
     // feeds both sections), so they live in their own hook that returns the summaries + bodies.
     const mh = useModelHarness({schema, config, onChange, revisionId, disabled, withTooltip})
 
-    // Tools live as a flat array on the agent definition (the same tool-object shape the
-    // prompt control uses, so the backend resolver parses them identically).
-    const tools = useMemo(
-        () => (Array.isArray(config.tools) ? (config.tools as unknown[]) : []),
-        [config.tools],
-    )
-    const setTools = useCallback((next: unknown[]) => setAgentField("tools", next), [setAgentField])
-
-    const handleAddTool = useCallback(
-        (tool: ToolObj, meta?: ToolSelectionMeta) => {
-            const next =
-                meta && tool && typeof tool === "object" && !Array.isArray(tool)
-                    ? {
-                          ...(tool as Record<string, unknown>),
-                          agenta_metadata: {
-                              ...(((tool as Record<string, unknown>).agenta_metadata as
-                                  | Record<string, unknown>
-                                  | undefined) ?? {}),
-                              ...meta,
-                          },
-                      }
-                    : tool
-            // A custom (inline function) tool starts blank — edit it in a create drawer and only
-            // append on Save, so a half-filled tool never lands in the config. Builtin/gateway
-            // tools arrive complete (and gateway is multi-select), so add those straight away.
-            if (meta?.source === "custom") {
-                openCreate("tool", next as Record<string, unknown>, "form")
-                return
-            }
-            setTools([...tools, next])
-        },
-        [tools, setTools, openCreate],
-    )
-
-    // Append a `type:"reference"` tool for a workflow chosen in the reference drawer (#4860),
-    // auto-deriving its model-facing input schema from the workflow's latest revision. The axis
-    // (variant/environment), pinned version, and environment come from the drawer's payload.
-    const handleAddWorkflowReference = useCallback(
-        async (payload: WorkflowReferencePayload) => {
-            const wf = workflowReference?.workflows.find((w) => w.slug === payload.slug)
-            let inputSchema: Record<string, unknown> | null = null
-            try {
-                inputSchema = wf
-                    ? ((await workflowReference?.resolveInputSchema(wf)) ?? null)
-                    : null
-            } catch {
-                inputSchema = null
-            }
-            // Read the freshest tools after the async lookup so a concurrent add/remove isn't clobbered.
-            const latest = configRef.current
-            const latestTools = Array.isArray(latest.tools) ? (latest.tools as unknown[]) : []
-            if (latestTools.some((t) => toolReferenceSlug(t) === payload.slug)) return
-            const referenceTool: Record<string, unknown> = {
-                type: "reference",
-                ref_by: payload.refBy,
-                slug: payload.slug,
-                ...(payload.refBy === "variant" && payload.version
-                    ? {version: payload.version}
-                    : {}),
-                ...(payload.refBy === "environment" && payload.environment
-                    ? {environment: payload.environment}
-                    : {}),
-                name: wf?.name || payload.slug,
-                description: wf?.description ?? wf?.name ?? "",
-                input_schema: inputSchema ?? {type: "object", properties: {}},
-            }
-            onChange({...latest, tools: [...latestTools, referenceTool]})
-        },
-        [workflowReference, onChange],
-    )
-
-    const handleRemoveToolByName = useCallback(
-        (name: string) => setTools(tools.filter((tool) => toolName(tool) !== name)),
-        [tools, setTools],
-    )
-
-    const handleRemoveBuiltinTool = useCallback(
-        (toolToRemove: ToolObj) => {
-            let removed = false
-            const updated = tools.filter((tool) => {
-                if (removed) return true
-                if (!isBuiltinPayloadMatch(tool, toolToRemove)) return true
-                removed = true
-                return false
-            })
-            if (removed) setTools(updated)
-        },
-        [tools, setTools],
-    )
-
-    const selectedToolNames = useMemo(
-        () => new Set(tools.map(toolName).filter((n): n is string => Boolean(n))),
-        [tools],
-    )
+    // Tools live as a flat array on the agent definition (the same tool-object shape the prompt
+    // control uses). The add/remove flows differ per kind (inline function, builtin, gateway,
+    // workflow reference), so that logic lives in its own hook; the orchestrator just wires it in.
+    const {
+        tools,
+        handleAddTool,
+        handleAddWorkflowReference,
+        handleRemoveToolByName,
+        handleRemoveBuiltinTool,
+        selectedToolNames,
+        referenceableWorkflows,
+    } = useAgentTools({config, onChange, configRef, openCreate, workflowReference})
 
     // MCP servers are a sibling of tools: a flat array on the agent config. Each entry is the
     // open McpServer shape (name + stdio command/args/env or remote url, secret names), edited
@@ -315,14 +233,6 @@ export function AgentTemplateControl({
             ? () => setReferenceSelectorOpen(true)
             : undefined,
     }
-
-    // Workflows not yet referenced as a tool — the pool the selector drawer offers.
-    const referenceableWorkflows = useMemo(() => {
-        const referenced = new Set(
-            tools.map((t) => toolReferenceSlug(t)).filter((s): s is string => Boolean(s)),
-        )
-        return (workflowReference?.workflows ?? []).filter((w) => !referenced.has(w.slug))
-    }, [tools, workflowReference])
 
     // A compact "+" affordance for a section header, so an item can be added without first
     // expanding the section. Rendered in the header's `extra` slot (which stops propagation, so it

--- a/web/packages/agenta-entity-ui/src/DrillInView/SchemaControls/AgentTemplateControl.tsx
+++ b/web/packages/agenta-entity-ui/src/DrillInView/SchemaControls/AgentTemplateControl.tsx
@@ -31,14 +31,12 @@ import {useDrillInUI, type WorkflowReferencePayload} from "@agenta/ui/drill-in"
 import {SelectLLMProviderBase} from "@agenta/ui/select-llm-provider"
 import {cn} from "@agenta/ui/styles"
 import {
-    CaretRight,
     Check,
     Cpu,
     Cube,
     EyeSlash,
     FileText,
     GraduationCap,
-    GraphIcon,
     Key,
     Lightbulb,
     Lightning,
@@ -46,7 +44,6 @@ import {
     Plus,
     ShieldCheck,
     SlidersHorizontal,
-    Trash,
     Warning,
     Wrench,
 } from "@phosphor-icons/react"
@@ -56,6 +53,19 @@ import {useAtomValue} from "jotai"
 import {useOptionalDrillIn} from "../components/MoleculeDrillInContext"
 
 import {AddTextLink} from "./AddTextLink"
+import {countSummary, cloneItem, enumLabel} from "./agentTemplate/agentTemplateUtils"
+import {
+    describeMcp,
+    describeSkill,
+    describeTool,
+    isBuiltinPayloadMatch,
+    isEmbedRefSkill,
+    isFunctionTool,
+    isStaticSkill,
+    toolName,
+    toolReferenceSlug,
+} from "./agentTemplate/itemDescriptors"
+import {InstructionsFileRow, ItemRow} from "./agentTemplate/ItemRow"
 import {agentTemplateLayoutAtom} from "./agentTemplateLayout"
 import {ClaudePermissionsControl} from "./ClaudePermissionsControl"
 import {CodeEditor} from "./CodeEditor"
@@ -83,7 +93,7 @@ import {SectionDrawer} from "./SectionDrawer"
 import {SkillFormView} from "./SkillFormView"
 import {ToolFormView} from "./ToolFormView"
 import {ToolSelectorPopover, type ToolSelectionMeta} from "./ToolSelectorPopover"
-import {parseGatewayFunctionName, type ToolObj} from "./toolUtils"
+import {type ToolObj} from "./toolUtils"
 import {
     AddTriggerDropdown,
     TriggerManagementSection,
@@ -100,448 +110,6 @@ export interface AgentTemplateControlProps {
     withTooltip?: boolean
     disabled?: boolean
     className?: string
-}
-
-/** Read the function name of a tool object (the gateway slug for Composio tools). */
-function toolName(tool: unknown): string | undefined {
-    if (!tool || typeof tool !== "object") return undefined
-    const fn = (tool as Record<string, unknown>).function
-    if (!fn || typeof fn !== "object") return undefined
-    const name = (fn as Record<string, unknown>).name
-    return typeof name === "string" ? name : undefined
-}
-
-/** Slug a `type:"reference"` tool targets (undefined for any other tool). Dedupes referenced
- * workflows; ignores gateway function names so a same-named gateway tool can't shadow a workflow. */
-function toolReferenceSlug(tool: unknown): string | undefined {
-    if (!tool || typeof tool !== "object") return undefined
-    const t = tool as Record<string, unknown>
-    if (t.type !== "reference") return undefined
-    return typeof t.slug === "string" ? (t.slug as string) : undefined
-}
-
-function isBuiltinPayloadMatch(tool: unknown, payload: ToolObj): boolean {
-    if (!tool || typeof tool !== "object" || Array.isArray(tool)) return false
-    if (!payload || typeof payload !== "object" || Array.isArray(payload)) return false
-
-    const toolObj = tool as Record<string, unknown>
-    const payloadObj = payload as Record<string, unknown>
-
-    if (typeof payloadObj.type === "string" && toolObj.type === payloadObj.type) return true
-    if (typeof payloadObj.name === "string" && toolObj.name === payloadObj.name) return true
-
-    const payloadKeys = Object.keys(payloadObj)
-    return (
-        payloadKeys.length === 1 &&
-        payloadKeys[0] !== "type" &&
-        payloadKeys[0] !== "name" &&
-        payloadKeys[0] in toolObj
-    )
-}
-
-/**
- * Best-effort display label for an enum value, used in collapsed section summaries.
- * Reads `x-model-metadata` titles and `anyOf`/`oneOf` const titles, falling back to the
- * raw value so a summary is always shown.
- */
-function enumLabel(schema: SchemaProperty | undefined, value: unknown): string | null {
-    if (value == null || value === "") return null
-    const v = String(value)
-    const s = schema as Record<string, unknown> | undefined
-    const meta = s?.["x-model-metadata"] as Record<string, {name?: string}> | undefined
-    if (meta?.[v]?.name) return meta[v]!.name as string
-    const variants = (s?.anyOf ?? s?.oneOf) as {const?: unknown; title?: string}[] | undefined
-    const hit = variants?.find((o) => o?.const === value)
-    if (hit?.title) return hit.title
-    return v
-}
-
-const countSummary = (n: number, noun: string): string =>
-    n > 0 ? `${n} ${noun}${n === 1 ? "" : "s"}` : "None"
-
-/** Whether a tool has an editable OpenAI-style `function` (vs a bare builtin `type`). */
-function isFunctionTool(tool: unknown): boolean {
-    if (!tool || typeof tool !== "object") return false
-    const fn = (tool as Record<string, unknown>).function
-    return Boolean(fn && typeof fn === "object")
-}
-
-/** How a config-item row presents itself: avatar, name + description, and type tags. */
-interface ItemDescriptor {
-    /** Primary label (rendered monospace). */
-    name: string
-    /** Secondary description line. */
-    description?: string
-    /** Avatar monogram, used when no `icon` is given. */
-    mono: string
-    /** Avatar background colour. */
-    color: string
-    /** Avatar icon (overrides the monogram). */
-    icon?: React.ReactNode
-    /** Type tags shown on the right of a row (e.g. "built-in", "definition", "gmail"). */
-    tags: string[]
-    /** Type label for the drawer header badge (e.g. "definition", "MCP server"). */
-    typeLabel: string
-    /** antd Tag colour for the header badge. */
-    typeColor?: string
-    /** One-line type description shown as the drawer subtitle. */
-    subtitle: string
-}
-
-/** Two-char monogram, title-cased ("gmail" -> "Gm", "zendesk" -> "Ze"). */
-function monogram(value: string): string {
-    return (value.charAt(0).toUpperCase() + (value.charAt(1) ?? "")).trim() || "?"
-}
-
-/** Deep-clone a config item so drawer edits don't alias the committed config object. */
-function cloneItem(item: unknown): Record<string, unknown> {
-    if (!item || typeof item !== "object") return {}
-    return JSON.parse(JSON.stringify(item)) as Record<string, unknown>
-}
-
-/** Classify a tool into its row avatar / name / description / type tags. */
-function describeTool(tool: unknown): ItemDescriptor {
-    const t = (tool ?? {}) as Record<string, unknown>
-    const fn = t.function as Record<string, unknown> | undefined
-    const fnName = typeof fn?.name === "string" ? (fn.name as string) : undefined
-    const description = typeof fn?.description === "string" ? (fn.description as string) : undefined
-
-    // Workflow reference tool (type:"reference", #4860): a referenced workflow the backend runs
-    // server-side as a callback tool. Detected by the discriminator BEFORE the builtin fallback
-    // (which would otherwise misclassify it as built-in).
-    if (t.type === "reference") {
-        const slug = typeof t.slug === "string" ? (t.slug as string) : undefined
-        const refName = typeof t.name === "string" ? (t.name as string) : undefined
-        const target =
-            t.ref_by === "environment" && typeof t.environment === "string"
-                ? `${slug ?? ""} @ ${t.environment as string}`
-                : typeof t.version === "string"
-                  ? `${slug ?? ""} v${t.version as string}`
-                  : slug
-        return {
-            name: refName ?? slug ?? "Workflow tool",
-            description: typeof t.description === "string" ? (t.description as string) : undefined,
-            mono: "",
-            color: "#0d9488",
-            icon: <GraphIcon size={15} weight="fill" />,
-            tags: ["workflow"],
-            typeLabel: "workflow",
-            typeColor: "geekblue",
-            subtitle: target ? `Referenced workflow · ${target}` : "Referenced workflow",
-        }
-    }
-
-    // Third-party / gateway tool: tools__provider__integration__action__connection.
-    const gateway = fnName ? parseGatewayFunctionName(fnName) : null
-    if (gateway) {
-        return {
-            name: gateway.action,
-            description,
-            mono: monogram(gateway.integration),
-            color: "#1c2c3d",
-            tags: [gateway.integration],
-            typeLabel: "third-party",
-            subtitle: `Connected app tool · ${gateway.integration}`,
-        }
-    }
-
-    // Built-in / provider tool: a bare `type` with no editable `function`.
-    if (!fn || typeof fn !== "object") {
-        const typeValue =
-            typeof t.type === "string" && t.type !== "function"
-                ? (t.type as string)
-                : Object.keys(t).find((k) => k !== "type" && k !== "function")
-        return {
-            name: typeValue ?? "Built-in tool",
-            mono: "io",
-            color: "#0d9488",
-            tags: ["built-in"],
-            typeLabel: "built-in",
-            typeColor: "cyan",
-            subtitle: "Provider built-in tool",
-        }
-    }
-
-    // Function definition (custom inline tool).
-    return {
-        name: fnName ?? "Tool",
-        description,
-        mono: "{}",
-        color: "#7c3aed",
-        tags: ["definition"],
-        typeLabel: "definition",
-        typeColor: "purple",
-        subtitle: "Schema-only · executed by your app",
-    }
-}
-
-/** Classify an MCP server into its row avatar / name / description / tags. */
-function describeMcp(server: unknown): ItemDescriptor {
-    const s = (server ?? {}) as Record<string, unknown>
-    const transport = s.transport === "http" ? "http" : "stdio"
-    const name = typeof s.name === "string" && s.name ? (s.name as string) : "MCP server"
-    const detailField = transport === "http" ? s.url : s.command
-    return {
-        name,
-        description: typeof detailField === "string" ? detailField : undefined,
-        mono: "",
-        color: "#2563eb",
-        icon: <Plugs size={15} weight="fill" />,
-        tags: [transport],
-        typeLabel: "MCP server",
-        typeColor: "cyan",
-        subtitle: "Model Context Protocol server",
-    }
-}
-
-/**
- * A skills entry is either an inline SKILL.md package or an `@ag.embed` reference (which the
- * backend inlines). Embed refs carry the marker at the top level and must round-trip intact, so
- * they're edited JSON-only rather than through the structured form.
- */
-function isEmbedRefSkill(skill: unknown): boolean {
-    return Boolean(
-        skill && typeof skill === "object" && "@ag.embed" in (skill as Record<string, unknown>),
-    )
-}
-
-/** Classify a skill into its row avatar / name / description / type tags. */
-function asObj(value: unknown): Record<string, unknown> | undefined {
-    return value && typeof value === "object" && !Array.isArray(value)
-        ? (value as Record<string, unknown>)
-        : undefined
-}
-
-/** The reserved slug namespace for static (Agenta-owned) skills (mirrors the backend `__ag__*`). */
-const STATIC_SKILL_SLUG_PREFIX = "__ag__"
-
-/** The slug an `@ag.embed` entry points at (a `workflow` or pinned `workflow_revision` reference). */
-function staticEmbedSlug(skill: Record<string, unknown>): string | undefined {
-    const refs = asObj(asObj(skill["@ag.embed"])?.["@ag.references"])
-    if (!refs) return undefined
-    const slug = asObj(refs.workflow)?.slug ?? asObj(refs.workflow_revision)?.slug
-    return typeof slug === "string" ? slug : undefined
-}
-
-/** A pinned revision's version, when the embed references a `workflow_revision`. */
-function embedRevisionVersion(skill: Record<string, unknown>): string | undefined {
-    const refs = asObj(asObj(skill["@ag.embed"])?.["@ag.references"])
-    const version = asObj(refs?.workflow_revision)?.version
-    return typeof version === "string" ? version : undefined
-}
-
-/**
- * Whether a skill entry is static (Agenta-owned) and so read-only for the author. The reliable client-side
- * signal is the reserved `__ag__` slug prefix on the embed's referenced workflow (or pinned
- * revision); a resolved object carrying `flags.is_static === true` counts too.
- */
-function isStaticSkill(skill: unknown): boolean {
-    const s = asObj(skill)
-    if (!s) return false
-    const slug = staticEmbedSlug(s)
-    if (slug && slug.startsWith(STATIC_SKILL_SLUG_PREFIX)) return true
-    return asObj(s.flags)?.is_static === true
-}
-
-function describeSkill(skill: unknown): ItemDescriptor {
-    const s = (skill ?? {}) as Record<string, unknown>
-    if (isStaticSkill(s)) {
-        const slug = staticEmbedSlug(s)
-        const version = embedRevisionVersion(s)
-        return {
-            name: slug ?? "Static skill",
-            mono: "sk",
-            color: "#6b7280",
-            tags: version ? ["static", `v${version}`] : ["static"],
-            typeLabel: "static skill",
-            subtitle: "Provided by Agenta — read-only",
-        }
-    }
-    if (isEmbedRefSkill(s)) {
-        return {
-            name: "Skill reference",
-            mono: "sk",
-            color: "#b45309",
-            tags: ["@ag.embed"],
-            typeLabel: "@ag.embed",
-            typeColor: "blue",
-            subtitle: "Referenced skill — inlined by the backend",
-        }
-    }
-    return {
-        name: typeof s.name === "string" && s.name ? (s.name as string) : "Skill",
-        description: typeof s.description === "string" ? (s.description as string) : undefined,
-        mono: "sk",
-        color: "#b45309",
-        tags: ["skill"],
-        typeLabel: "skill",
-        typeColor: "gold",
-        subtitle: "Inline SKILL.md package",
-    }
-}
-
-/** Strip Markdown syntax to a short single-line preview for an instructions file row. */
-function mdPreview(md: string): string {
-    return (md ?? "")
-        .replace(/```[\s\S]*?```/g, " ") // fenced code blocks
-        .replace(/^#{1,6}\s+/gm, "") // heading markers
-        .replace(/^\s*[-*+]\s+/gm, "") // bullet list markers (so "- Greet…" reads as prose)
-        .replace(/^\s*\d+\.\s+/gm, "") // numbered list markers
-        .replace(/!?\[([^\]]*)\]\([^)]*\)/g, "$1") // links/images → their text
-        .replace(/[*_`>#]/g, "") // inline emphasis / quote chars
-        .replace(/\s+/g, " ") // collapse newlines + runs of whitespace
-        .trim()
-        .slice(0, 140)
-}
-
-/** Row descriptor for an instructions markdown file (e.g. AGENTS.md). */
-function describeInstruction(filename: string, content: string): ItemDescriptor {
-    return {
-        name: filename,
-        description: mdPreview(content) || "Empty file",
-        mono: "md",
-        color: "#0f766e",
-        icon: <FileText size={14} />,
-        tags: [],
-        typeLabel: "instructions",
-        subtitle: "Markdown instructions for the agent",
-    }
-}
-
-/** Colored avatar square (icon or monogram) at the start of a config-item row. */
-function ItemAvatar({descriptor}: {descriptor: ItemDescriptor}) {
-    return (
-        <span
-            className="flex h-7 w-7 shrink-0 items-center justify-center rounded text-white"
-            style={{background: descriptor.color, fontSize: 10, fontWeight: 600, lineHeight: 1}}
-        >
-            {descriptor.icon ?? descriptor.mono}
-        </span>
-    )
-}
-
-/**
- * A config-item row (a tool or MCP server): type avatar, name + description, type tags, and a
- * chevron. The whole row opens the item drawer; remove appears on hover.
- */
-function ItemRow({
-    descriptor,
-    onEdit,
-    onRemove,
-    disabled,
-}: {
-    descriptor: ItemDescriptor
-    onEdit: () => void
-    onRemove?: () => void
-    disabled?: boolean
-}) {
-    return (
-        <div
-            role="button"
-            tabIndex={0}
-            onClick={onEdit}
-            onKeyDown={(e) => {
-                if (e.key === "Enter" || e.key === " ") {
-                    e.preventDefault()
-                    onEdit()
-                }
-            }}
-            className="group flex cursor-pointer items-center gap-2.5 rounded border border-solid border-[var(--ag-c-EAEFF5,#eaeff5)] px-3 py-2 transition-colors hover:border-[var(--ag-c-97A4B0,#97a4b0)]"
-        >
-            <ItemAvatar descriptor={descriptor} />
-            <div className="min-w-0 flex-1">
-                <div className="truncate font-mono text-xs font-medium">{descriptor.name}</div>
-                {descriptor.description ? (
-                    <Typography.Text
-                        type="secondary"
-                        className="block truncate text-xs leading-tight"
-                    >
-                        {descriptor.description}
-                    </Typography.Text>
-                ) : null}
-            </div>
-            <div className="flex shrink-0 items-center gap-1.5">
-                {descriptor.tags.map((tag) => (
-                    <Tag key={tag} className="m-0 text-[11px]">
-                        {tag}
-                    </Tag>
-                ))}
-                {onRemove && !disabled ? (
-                    <button
-                        type="button"
-                        aria-label="Remove"
-                        onClick={(e) => {
-                            e.stopPropagation()
-                            onRemove()
-                        }}
-                        className="flex cursor-pointer items-center border-0 bg-transparent p-0 text-[var(--ag-c-97A4B0,#97a4b0)] opacity-0 transition-opacity hover:text-[var(--ag-c-FF4D4F,#ff4d4f)] group-hover:opacity-100"
-                    >
-                        <Trash size={14} />
-                    </button>
-                ) : null}
-                <CaretRight size={14} className="text-[var(--ag-c-97A4B0,#97a4b0)]" />
-            </div>
-        </div>
-    )
-}
-
-/**
- * An instructions markdown file row. Avatar + filename + a 2-line preview of the (markdown-stripped)
- * content, clamped with an ellipsis. The whole row opens the editor drawer for the full content —
- * there is no inline expand, so it reads the same as the tool / MCP rows.
- */
-function InstructionsFileRow({
-    filename,
-    content,
-    onOpen,
-}: {
-    filename: string
-    content: string
-    onOpen: () => void
-}) {
-    const descriptor = describeInstruction(filename, content)
-    const wordCount = content.trim().split(/\s+/).filter(Boolean).length
-    const meta =
-        wordCount > 0
-            ? `Markdown · ${wordCount} word${wordCount === 1 ? "" : "s"}`
-            : "Markdown · empty"
-    return (
-        <div
-            role="button"
-            tabIndex={0}
-            onClick={onOpen}
-            onKeyDown={(e) => {
-                if (e.key === "Enter" || e.key === " ") {
-                    e.preventDefault()
-                    onOpen()
-                }
-            }}
-            className="group flex cursor-pointer items-start gap-3 rounded-lg border border-solid border-[var(--ag-c-EAEFF5,#eaeff5)] px-3 py-2.5 transition-colors hover:border-[var(--ag-c-97A4B0,#97a4b0)]"
-        >
-            <ItemAvatar descriptor={descriptor} />
-            <div className="min-w-0 flex-1">
-                {/* Identity row: filename (color inherits → theme-correct) + a muted meta, so the
-                    name/type/size reads separately from the content preview below. */}
-                <div className="flex items-baseline gap-2">
-                    <span className="truncate font-mono text-[13px] font-medium leading-tight">
-                        {filename}
-                    </span>
-                    <Typography.Text type="secondary" className="shrink-0 text-[11px]">
-                        {meta}
-                    </Typography.Text>
-                </div>
-                {/* `descriptor.description` is the stripped-markdown preview (or "Empty file");
-                    clamp to 2 lines so long instructions get a real "…" rather than a hard cut. */}
-                <Typography.Text
-                    type="secondary"
-                    className="mt-1 line-clamp-2 text-xs leading-snug"
-                >
-                    {descriptor.description}
-                </Typography.Text>
-            </div>
-            <CaretRight size={15} className="mt-1 shrink-0 text-[var(--ag-c-97A4B0,#97a4b0)]" />
-        </div>
-    )
 }
 
 export function AgentTemplateControl({

--- a/web/packages/agenta-entity-ui/src/DrillInView/SchemaControls/AgentTemplateControl.tsx
+++ b/web/packages/agenta-entity-ui/src/DrillInView/SchemaControls/AgentTemplateControl.tsx
@@ -23,64 +23,37 @@
  */
 import {useCallback, useEffect, useMemo, useRef, useState} from "react"
 
-import {vaultSecretsQueryAtom} from "@agenta/entities/secret"
 import type {SchemaProperty} from "@agenta/entities/shared"
-import {harnessCapabilitiesAtomFamily} from "@agenta/entities/workflow"
-import {ConfigAccordionSection, LabeledField} from "@agenta/ui/components/presentational"
+import {ConfigAccordionSection} from "@agenta/ui/components/presentational"
 import {useDrillInUI, type WorkflowReferencePayload} from "@agenta/ui/drill-in"
-import {SelectLLMProviderBase} from "@agenta/ui/select-llm-provider"
 import {cn} from "@agenta/ui/styles"
 import {
-    Check,
     Cpu,
-    Cube,
-    EyeSlash,
     FileText,
     GraduationCap,
-    Key,
-    Lightbulb,
     Lightning,
     Plugs,
     Plus,
-    ShieldCheck,
     SlidersHorizontal,
-    Warning,
     Wrench,
 } from "@phosphor-icons/react"
-import {Button, Select, Switch, Tabs, Tag, Tooltip, Typography} from "antd"
+import {Button, Tabs, Tag, Tooltip, Typography} from "antd"
 import {useAtomValue} from "jotai"
 
 import {useOptionalDrillIn} from "../components/MoleculeDrillInContext"
 
 import {AddTextLink} from "./AddTextLink"
-import {countSummary, enumLabel} from "./agentTemplate/agentTemplateUtils"
+import {countSummary} from "./agentTemplate/agentTemplateUtils"
 import {ConfigItemList} from "./agentTemplate/ConfigItemList"
 import {isBuiltinPayloadMatch, toolName, toolReferenceSlug} from "./agentTemplate/itemDescriptors"
 import {ITEM_KINDS} from "./agentTemplate/itemKinds"
 import {InstructionsFileRow} from "./agentTemplate/ItemRow"
 import {useConfigItemDrawer} from "./agentTemplate/useConfigItemDrawer"
+import {useModelHarness} from "./agentTemplate/useModelHarness"
 import {agentTemplateLayoutAtom} from "./agentTemplateLayout"
-import {ClaudePermissionsControl} from "./ClaudePermissionsControl"
-import {CodeEditor} from "./CodeEditor"
 import {ConfigItemDrawer} from "./ConfigItemDrawer"
-import {
-    allowedConnectionModes,
-    buildModelOptionGroups,
-    composeModelValue,
-    connectionFromConfig,
-    harnessAllowsModel,
-    modelIdFromConfig,
-    namedConnectionOptions,
-    providerForModel,
-    type ConnectionMode,
-    type VaultConnectionEntry,
-} from "./connectionUtils"
-import {EnumSelectControl} from "./EnumSelectControl"
-import {GroupedChoiceControl} from "./GroupedChoiceControl"
-import {HarnessSelectControl} from "./HarnessSelectControl"
 import {InstructionsDrawer} from "./InstructionsDrawer"
 import {JsonObjectEditor} from "./JsonObjectEditor"
-import {SandboxPermissionControl} from "./SandboxPermissionControl"
 import {SectionDrawer} from "./SectionDrawer"
 import {ToolSelectorPopover, type ToolSelectionMeta} from "./ToolSelectorPopover"
 import {type ToolObj} from "./toolUtils"
@@ -173,201 +146,29 @@ export function AgentTemplateControl({
     const layout = useAtomValue(agentTemplateLayoutAtom)
 
     // `config` IS the agent template (the `parameters.agent` value), exactly as the prompt control's
-    // value is the prompt template. `schema` is the `agent-template` catalog type: the portable
-    // definition's fields (instructions/llm/tools/mcps/skills) are FLAT on it; the execution parts
-    // (harness/runner/sandbox) are nested sub-objects, each with its own `.properties`.
+    // value is the prompt template. `schema` is the `agent-template` catalog type and decides which
+    // sections exist: the portable definition's fields (instructions / llm / tools / mcps / skills)
+    // are FLAT on it; the execution parts (harness / runner / sandbox) are nested sub-objects, read
+    // by the Model & harness + Advanced sections (see useModelHarness).
     const props = (schema?.properties ?? {}) as Record<string, SchemaProperty>
-    const subProps = useCallback(
-        (section: string): Record<string, SchemaProperty> =>
-            (props[section]?.properties as Record<string, SchemaProperty>) ?? {},
-        [props],
-    )
-    const harnessProps = subProps("harness")
-    const runnerProps = subProps("runner")
-    const sandboxProps = subProps("sandbox")
 
-    const asObject = useCallback(
-        (key: string): Record<string, unknown> =>
-            config[key] && typeof config[key] === "object" && !Array.isArray(config[key])
-                ? (config[key] as Record<string, unknown>)
-                : {},
-        [config],
-    )
-    const harness = asObject("harness")
-    const runner = asObject("runner")
-    const sandbox = asObject("sandbox")
-
-    // The runner's headless interaction default (was the flat `permission_policy`).
-    const runnerInteractions =
-        runner.interactions && typeof runner.interactions === "object"
-            ? (runner.interactions as Record<string, unknown>)
-            : {}
-    const headlessValue = (runnerInteractions.headless as string | null | undefined) ?? null
-    const headlessSchema = (
-        runnerProps.interactions?.properties as Record<string, SchemaProperty> | undefined
-    )?.headless
-
-    // Replace one nested execution section (harness / runner / sandbox), leaving the rest intact.
-    const setSection = useCallback(
-        (key: string, sectionValue: unknown) => onChange({...config, [key]: sectionValue}),
-        [config, onChange],
-    )
-    // Set one flat field of the agent definition (instructions / llm / tools / mcps / skills).
+    // Set one flat field of the agent definition (instructions / tools / mcps / skills).
     const setAgentField = useCallback(
         (key: string, fieldValue: unknown) => onChange({...config, [key]: fieldValue}),
         [config, onChange],
     )
 
-    // Model + credential connection (`llm`). It is ALWAYS a structured object (the harness-filtered
-    // picker only ever produces one); a legacy bare string is read for display. composeModelValue
-    // carries through extra keys (e.g. `extras`) so a form edit never silently drops them. The picker
-    // is harness-filtered: selecting a model sets BOTH the model id and its provider, fed by the
-    // `/inspect` capability map below.
-    const harnessValue = typeof harness.kind === "string" ? (harness.kind as string) : null
-    // Pi (`pi_core`/`pi_agenta`) never gates tool use (`permissions: false`); a permission
-    // policy is meaningless for it, so the field is hidden for Pi. Only Claude honors it.
-    const isPiHarness = harnessValue === "pi_core" || harnessValue === "pi_agenta"
-    const llm = config.llm
-    const modelId = useMemo(() => modelIdFromConfig(llm), [llm])
-    const connection = useMemo(() => connectionFromConfig(llm), [llm])
-
-    // Per-harness capability map from the `/inspect` response meta, keyed by the open revision.
-    // Null when inspect hasn't resolved or the agent didn't publish it (older agents / standalone),
-    // in which case the connectionUtils helpers fall back permissively.
+    // The open revision id (from drill-in context): harness-capability inspection (inside
+    // useModelHarness) and bound-trigger scoping both key off it.
     const drillIn = useOptionalDrillIn<unknown>()
     const revisionId = drillIn?.entityId ?? null
-    // Triggers bound to this agent (for the section count badge). The section body and
-    // the header add-dropdown derive scoping from the same hook.
+    // Triggers bound to this agent (for the section count badge). The section body and the header
+    // add-dropdown derive scoping from the same hook.
     const {count: triggerCount} = useAgentTriggers(revisionId)
-    const capabilities = useAtomValue(
-        useMemo(() => harnessCapabilitiesAtomFamily(revisionId ?? ""), [revisionId]),
-    )
 
-    // The project's stored connections (read-only) for the connection picker. The transformed vault
-    // list surfaces custom-provider connections as {type, name, provider}; the resolver matches a
-    // named connection by that name (the slug).
-    const vaultQuery = useAtomValue(vaultSecretsQueryAtom)
-    const vaultSecrets = useMemo(
-        () => (Array.isArray(vaultQuery.data) ? (vaultQuery.data as VaultConnectionEntry[]) : []),
-        [vaultQuery.data],
-    )
-
-    const modeOptions = useMemo(
-        () => allowedConnectionModes(capabilities, harnessValue),
-        [capabilities, harnessValue],
-    )
-
-    // Harness-filtered model options, built straight from inspect meta. Empty when the harness
-    // publishes none (older agent / standalone) — fall back to the schema's full catalog picker.
-    const modelGroups = useMemo(
-        () => buildModelOptionGroups(capabilities, harnessValue),
-        [capabilities, harnessValue],
-    )
-    const hasInspectModels = modelGroups.length > 0
-
-    // Compose the new `config.llm` ModelRef from the current fields, overriding some. Picking a
-    // model derives its provider from the harness's published groups (sets both).
-    const writeModel = useCallback(
-        (patch: {
-            modelId?: string | null
-            provider?: string | null
-            mode?: ConnectionMode
-            slug?: string | null
-        }) => {
-            const nextModelId = patch.modelId !== undefined ? patch.modelId : modelId
-            // When the model changes, derive the provider from the picked model; otherwise keep it.
-            let nextProvider: string | null
-            if (patch.provider !== undefined) {
-                nextProvider = patch.provider
-            } else if (patch.modelId !== undefined) {
-                nextProvider =
-                    providerForModel(capabilities, harnessValue, nextModelId) ?? connection.provider
-            } else {
-                nextProvider = connection.provider
-            }
-            setAgentField(
-                "llm",
-                composeModelValue({
-                    modelId: nextModelId,
-                    provider: nextProvider,
-                    mode: patch.mode !== undefined ? patch.mode : connection.mode,
-                    slug: patch.slug !== undefined ? patch.slug : connection.slug,
-                    existing: llm,
-                }),
-            )
-        },
-        [setAgentField, modelId, connection, llm, capabilities, harnessValue],
-    )
-
-    // NB: we deliberately do NOT clear the model when switching to a harness that can't reach it
-    // (Arda's call). The model is kept and the compatibility panel flags it as not reachable so the
-    // user can pick a new one — keeping their choice over silently wiping it. (Save can persist an
-    // unreachable model that errors at run time; that's the accepted trade-off.)
-
-    // Reset a connection mode the new harness no longer allows. Guarded on a non-empty
-    // option set so a harness that publishes no modes stays permissive (and we never loop).
-    // Slug validity is intentionally NOT normalized here: connectionOptions is vault-secret
-    // async, so an empty set during load would wrongly clear a valid slug.
-    useEffect(() => {
-        if (modeOptions.length > 0 && !modeOptions.includes(connection.mode)) {
-            writeModel({mode: modeOptions[0], slug: null})
-        }
-    }, [connection.mode, modeOptions, writeModel])
-
-    // Named connections selectable for the chosen provider under this harness (Agenta-managed).
-    const connectionOptions = useMemo(
-        () => namedConnectionOptions(vaultSecrets, capabilities, harnessValue, connection.provider),
-        [vaultSecrets, capabilities, harnessValue, connection.provider],
-    )
-
-    // Raw-JSON escape hatch for the whole `agent.llm` value (collapsed by default).
-    const [showModelJson, setShowModelJson] = useState(false)
-    const [modelJsonText, setModelJsonText] = useState(() => JSON.stringify(llm ?? "", null, 2))
-    const handleModelJsonChange = useCallback(
-        (text: string) => {
-            setModelJsonText(text)
-            try {
-                setAgentField("llm", text ? JSON.parse(text) : "")
-            } catch {
-                // Keep the invalid text in the editor; don't propagate until it parses.
-            }
-        },
-        [setAgentField],
-    )
-    const handleToggleModelJson = useCallback(
-        (next: boolean) => {
-            if (next) setModelJsonText(JSON.stringify(llm ?? "", null, 2))
-            setShowModelJson(next)
-        },
-        [llm],
-    )
-    // Keep the open JSON buffer in sync when `agent.llm` changes from OUTSIDE the editor
-    // (the model picker or the authentication cards). Guard with a structural compare so we
-    // only resync on external changes — when the buffer already represents `agent.llm`
-    // (the user is typing here) we skip, so we never reformat mid-edit or fight the cursor.
-    useEffect(() => {
-        if (!showModelJson) return
-        let bufferValue: unknown
-        try {
-            bufferValue = modelJsonText ? JSON.parse(modelJsonText) : ""
-        } catch {
-            return // invalid in-progress JSON — leave the user's text untouched
-        }
-        if (JSON.stringify(bufferValue) !== JSON.stringify(llm ?? "")) {
-            setModelJsonText(JSON.stringify(llm ?? "", null, 2))
-        }
-    }, [llm, showModelJson, modelJsonText])
-
-    // Claude permissions (Layer 1, Claude-only): the Claude harness's own permission knobs, the
-    // first-class `harness.permissions` slice. Shown in Advanced only for the Claude harness.
-    const claudePermissions = useMemo(() => {
-        const perms = harness.permissions
-        return perms && typeof perms === "object" ? (perms as Record<string, unknown>) : null
-    }, [harness])
-    const setClaudePermissions = useCallback(
-        (next: Record<string, unknown>) => setSection("harness", {...harness, permissions: next}),
-        [harness, setSection],
-    )
+    // Model & harness + Advanced own a lot of coupled, stateful logic (the model/connection state
+    // feeds both sections), so they live in their own hook that returns the summaries + bodies.
+    const mh = useModelHarness({schema, config, onChange, revisionId, disabled, withTooltip})
 
     // Tools live as a flat array on the agent definition (the same tool-object shape the
     // prompt control uses, so the backend resolver parses them identically).
@@ -495,24 +296,10 @@ export function AgentTemplateControl({
             : {}
     const agentsMd = (instructions.agents_md as string | null | undefined) ?? null
 
-    const modelSummary =
-        [enumLabel(harnessProps.kind, harness.kind), enumLabel(props.llm, modelId)]
-            .filter(Boolean)
-            .join(" · ") || undefined
-
     const hasInstructions = Boolean(props.instructions)
-    const hasModelOrHarness = Boolean(props.llm || harnessProps.kind)
     const hasTools = Boolean(props.tools)
     const hasMcp = Boolean(props.mcps)
     const hasSkills = Boolean(props.skills)
-    const hasClaudePermissions = harnessValue === "claude"
-    const hasAdvanced = Boolean(
-        props.llm || // Authentication lives in Advanced now
-        sandboxProps.kind ||
-        sandboxProps.permissions ||
-        runnerProps.interactions ||
-        hasClaudePermissions,
-    )
 
     // Shared props for the tool picker, so the in-body popover and the header quick-add trigger
     // drive the same add flow.
@@ -546,558 +333,18 @@ export function AgentTemplateControl({
         </Tooltip>
     )
 
-    // The Model picker (inspect-filtered when available, else the schema catalog).
-    const modelPicker = props.llm ? (
-        hasInspectModels ? (
-            <LabeledField
-                label="Model"
-                description="Filtered to the models this harness can reach. Selecting a model also sets its provider."
-                withTooltip={withTooltip}
-            >
-                <SelectLLMProviderBase
-                    showGroup
-                    options={modelGroups}
-                    value={modelId ?? undefined}
-                    onChange={(v) => writeModel({modelId: (v as string) ?? null})}
-                    disabled={disabled}
-                    placeholder="Select a model…"
-                    className="w-full"
-                />
-            </LabeledField>
-        ) : (
-            <GroupedChoiceControl
-                schema={
-                    (props.llm?.properties as Record<string, SchemaProperty> | undefined)?.model ??
-                    props.llm
-                }
-                label="Model"
-                value={modelId}
-                onChange={(v) => writeModel({modelId: v})}
-                withTooltip={withTooltip}
-                disabled={disabled}
-            />
-        )
-    ) : null
-
-    // Shared version-history placeholder for the section drawers (real revision diffs are deferred).
-    const versionHistorySkeleton = (
-        <div>
-            <div className="mb-2 flex items-center gap-1.5">
-                <span className="text-[11px] uppercase tracking-wide text-[var(--ag-c-97A4B0,#97a4b0)]">
-                    Version history
-                </span>
-                <span className="rounded-full border border-solid border-[var(--ag-c-EAEFF5,#eaeff5)] px-1.5 text-[10px] text-[var(--ag-c-97A4B0,#97a4b0)]">
-                    soon
-                </span>
-            </div>
-            <div className="flex flex-col gap-2.5 opacity-50">
-                {["w-[42%]", "w-[32%]", "w-[38%]"].map((widthClass, i) => (
-                    <div key={i} className="flex items-center gap-2">
-                        <span className="h-1.5 w-1.5 shrink-0 rounded-full bg-[var(--ag-c-EAEFF5,#eaeff5)]" />
-                        <span
-                            className={cn(
-                                "h-2 rounded bg-[var(--ag-c-EAEFF5,#eaeff5)]",
-                                widthClass,
-                            )}
-                        />
-                    </div>
-                ))}
-            </div>
-        </div>
-    )
-
-    // Harness list + per-harness detail come from the inspect capabilities map. Compatibility is
-    // real (provider/model reachability + connection mode), all derived from that same data.
-    //
-    // GAP (intentional, tracked): `harness_capabilities` only covers providers / connection modes /
-    // models / hosting — NOT which tools, skills, or MCP servers a harness supports. So the
-    // compatibility panel and the per-card keeps/clears status reason only about the MODEL + auth,
-    // never about tools/skills/MCP. Switching harness can silently leave unsupported tools, and we
-    // don't warn/gate them. When the backend extends harness_capabilities with tool/skill/MCP
-    // support, extend the compatibility panel to warn (and optionally lock those sections), mirroring
-    // the model warning. See docs/design/agent-config-section-drawers/design.md ("Known gap").
-    const harnessList = capabilities ? Object.keys(capabilities) : []
-    const modelReachable =
-        !modelId ||
-        !capabilities ||
-        !harnessValue ||
-        harnessAllowsModel(capabilities, harnessValue, modelId)
-    const authSupported = modeOptions.length === 0 || modeOptions.includes(connection.mode)
-
-    const harnessCards = (
-        <div className="flex flex-col gap-2">
-            {harnessList.map((h) => {
-                const caps = capabilities?.[h]
-                const selected = harnessValue === h
-                const providers = caps?.providers ?? []
-                const deployments = caps?.deployments ?? []
-                const modelCount = caps
-                    ? Object.values(caps.models ?? {}).reduce(
-                          (n, arr) => n + (Array.isArray(arr) ? arr.length : 0),
-                          0,
-                      )
-                    : 0
-                const keepsModel = !modelId || harnessAllowsModel(capabilities, h, modelId)
-                return (
-                    <button
-                        key={h}
-                        type="button"
-                        disabled={disabled}
-                        onClick={() => setSection("harness", {...harness, kind: h})}
-                        className={cn(
-                            "flex w-full flex-col gap-1.5 rounded-lg border border-solid p-2.5 text-left transition-colors",
-                            disabled ? "cursor-not-allowed opacity-60" : "cursor-pointer",
-                            selected
-                                ? "border-[var(--ant-color-primary)] bg-[var(--ant-color-fill-secondary)]"
-                                : "border-[var(--ant-color-border)] bg-[var(--ant-color-fill-quaternary)] hover:border-[var(--ant-color-text-quaternary)] hover:bg-[var(--ant-color-fill-tertiary)]",
-                        )}
-                    >
-                        <div className="flex items-center gap-2">
-                            <span
-                                className={cn(
-                                    "flex h-3.5 w-3.5 shrink-0 items-center justify-center rounded-full border border-solid",
-                                    selected
-                                        ? "border-[var(--ant-color-primary)]"
-                                        : "border-[var(--ag-c-97A4B0,#97a4b0)]",
-                                )}
-                            >
-                                {selected && (
-                                    <span className="h-1.5 w-1.5 rounded-full bg-[var(--ant-color-primary)]" />
-                                )}
-                            </span>
-                            <span className="text-xs font-medium">
-                                {enumLabel(harnessProps.kind, h) || h}
-                            </span>
-                            {selected ? (
-                                <span className="ml-auto rounded-full bg-[var(--ant-color-fill-secondary)] px-2 text-[10px] text-[var(--ant-color-primary-text)]">
-                                    Current
-                                </span>
-                            ) : modelId ? (
-                                <span
-                                    className={cn(
-                                        "ml-auto inline-flex items-center gap-1 text-[10.5px]",
-                                        keepsModel
-                                            ? "text-[var(--ant-color-success)]"
-                                            : "text-[var(--ant-color-warning)]",
-                                    )}
-                                >
-                                    {keepsModel ? <Check size={11} /> : <Warning size={11} />}
-                                    {keepsModel ? "supports your model" : "model not available"}
-                                </span>
-                            ) : null}
-                        </div>
-                        {providers.length > 0 || modelCount > 0 ? (
-                            <div className="pl-[22px] text-[11px] text-[var(--ag-c-97A4B0,#97a4b0)]">
-                                {providers.slice(0, 4).join(", ")}
-                                {providers.length > 4 ? ` +${providers.length - 4}` : ""}
-                                {modelCount ? ` · ${modelCount} models` : ""}
-                            </div>
-                        ) : null}
-                        {deployments.length > 0 ? (
-                            <div className="pl-[22px] text-[11px] text-[var(--ag-c-97A4B0,#97a4b0)]">
-                                Hosting: {deployments.join(" · ")}
-                            </div>
-                        ) : null}
-                    </button>
-                )
-            })}
-        </div>
-    )
-
-    const compatibilityPanel =
-        capabilities && harnessValue ? (
-            <div className="flex flex-col gap-4">
-                <div>
-                    <div className="mb-2 text-[11px] uppercase tracking-wide text-[var(--ag-c-97A4B0,#97a4b0)]">
-                        Current setup
-                    </div>
-                    <div className="flex flex-col gap-2 text-xs">
-                        {modelId ? (
-                            <div
-                                className={cn(
-                                    "flex items-start gap-1.5",
-                                    modelReachable
-                                        ? "text-[var(--ant-color-success)]"
-                                        : "text-[var(--ant-color-warning)]",
-                                )}
-                            >
-                                {modelReachable ? (
-                                    <Check size={14} className="mt-px shrink-0" />
-                                ) : (
-                                    <Warning size={14} className="mt-px shrink-0" />
-                                )}
-                                <span>
-                                    <span className="font-mono">{modelId}</span>{" "}
-                                    {modelReachable ? "is reachable." : "is not reachable here."}
-                                </span>
-                            </div>
-                        ) : (
-                            <span className="text-[var(--ag-c-97A4B0,#97a4b0)]">
-                                No model selected.
-                            </span>
-                        )}
-                        {props.llm ? (
-                            <div
-                                className={cn(
-                                    "flex items-start gap-1.5",
-                                    authSupported
-                                        ? "text-[var(--ant-color-success)]"
-                                        : "text-[var(--ant-color-warning)]",
-                                )}
-                            >
-                                {authSupported ? (
-                                    <Check size={14} className="mt-px shrink-0" />
-                                ) : (
-                                    <Warning size={14} className="mt-px shrink-0" />
-                                )}
-                                <span>
-                                    {connection.mode === "agenta"
-                                        ? "Agenta-managed"
-                                        : "Self-managed"}{" "}
-                                    auth{" "}
-                                    {authSupported ? "is supported." : "is not supported here."}
-                                </span>
-                            </div>
-                        ) : null}
-                    </div>
-                </div>
-
-                {modelId && harnessList.some((h) => h !== harnessValue) ? (
-                    <div>
-                        <div className="mb-2 text-[11px] uppercase tracking-wide text-[var(--ag-c-97A4B0,#97a4b0)]">
-                            If you switch
-                        </div>
-                        <div className="flex flex-col gap-2 text-xs">
-                            {harnessList
-                                .filter((h) => h !== harnessValue)
-                                .map((h) => {
-                                    const keeps = harnessAllowsModel(capabilities, h, modelId)
-                                    return (
-                                        <div key={h} className="flex items-start gap-1.5">
-                                            {keeps ? (
-                                                <Check
-                                                    size={14}
-                                                    className="mt-px shrink-0 text-[var(--ant-color-success)]"
-                                                />
-                                            ) : (
-                                                <Warning
-                                                    size={14}
-                                                    className="mt-px shrink-0 text-[var(--ant-color-warning)]"
-                                                />
-                                            )}
-                                            <span className="text-[var(--ag-c-586673,#586673)]">
-                                                <span className="text-[var(--ag-c-1C2C3D,#1c2c3d)]">
-                                                    {enumLabel(harnessProps.kind, h) || h}
-                                                </span>{" "}
-                                                {keeps
-                                                    ? "supports your model."
-                                                    : "doesn't support your model — pick a new one."}
-                                            </span>
-                                        </div>
-                                    )
-                                })}
-                        </div>
-                    </div>
-                ) : null}
-
-                {versionHistorySkeleton}
-            </div>
-        ) : null
-
-    // Model & harness drawer body. With inspect capabilities: harness cards + model picker on the
-    // left, a real compatibility panel on the right. Without them: the plain harness select.
-    // Shared Model & harness controls — rendered by both the wide drawer body (with the
-    // compatibility side panel) and the trimmed tabs-inline body (single column, no chrome).
-    const modelHarnessControls = capabilities ? (
-        <>
-            <div className="flex gap-2 rounded-md bg-[var(--ant-color-fill-quaternary)] p-2.5">
-                <Lightbulb size={15} className="mt-px shrink-0 text-[var(--ag-c-586673,#586673)]" />
-                <span className="text-[11.5px] leading-snug text-[var(--ag-c-586673,#586673)]">
-                    The harness is the runtime that executes your agent. It decides which providers,
-                    hosting and connection options you can use.
-                </span>
-            </div>
-            <div>
-                <div className="mb-2 text-[11px] uppercase tracking-wide text-[var(--ag-c-97A4B0,#97a4b0)]">
-                    Harness
-                </div>
-                {harnessCards}
-            </div>
-            {modelPicker}
-        </>
-    ) : (
-        <>
-            {harnessProps.kind && (
-                <HarnessSelectControl
-                    schema={harnessProps.kind}
-                    label="Harness"
-                    value={(harness.kind as string | null) ?? null}
-                    onChange={(v) => setSection("harness", {...harness, kind: v})}
-                    withTooltip={withTooltip}
-                    disabled={disabled}
-                />
-            )}
-            {modelPicker}
-        </>
-    )
-
-    const modelHarnessDrawerBody = capabilities ? (
-        <div className="flex h-full min-h-0 gap-6">
-            <div className="flex min-w-0 flex-1 flex-col gap-4 overflow-y-auto pr-1">
-                {modelHarnessControls}
-            </div>
-            <div className="w-[240px] shrink-0 overflow-y-auto">{compatibilityPanel}</div>
-        </div>
-    ) : (
-        <div className="flex h-full flex-col gap-3 overflow-y-auto">{modelHarnessControls}</div>
-    )
-
-    // Trimmed body for the tabs layout: the same controls in one column, without the drawer's
-    // two-panel split or side panel (which read as out-of-place chrome inside a tab).
-    const modelHarnessInline = <div className="flex flex-col gap-4">{modelHarnessControls}</div>
-
-    // Authentication (credential source) — moved out of Model & harness into Advanced.
-    const authControls = props.llm ? (
-        <div className="flex flex-col gap-2">
-            {modeOptions.map((m) => {
-                const selected = connection.mode === m
-                const title = m === "agenta" ? "Agenta-managed" : "Self-managed"
-                const desc =
-                    m === "agenta"
-                        ? "Agenta supplies the credential from this project's vault — the default provider key, or a named connection you pick below."
-                        : "The harness signs in itself (an environment variable or a prior OAuth login). Agenta injects no credential."
-                return (
-                    <button
-                        key={m}
-                        type="button"
-                        role="radio"
-                        aria-checked={selected}
-                        disabled={disabled}
-                        onClick={() => writeModel({mode: m})}
-                        className={cn(
-                            "flex w-full items-start gap-2.5 rounded-lg border border-solid p-2.5 text-left transition-colors",
-                            disabled ? "cursor-not-allowed opacity-60" : "cursor-pointer",
-                            selected
-                                ? "border-[var(--ant-color-primary)] bg-[var(--ant-color-fill-secondary)]"
-                                : "border-[var(--ant-color-border)] bg-[var(--ant-color-fill-quaternary)] hover:border-[var(--ant-color-text-quaternary)] hover:bg-[var(--ant-color-fill-tertiary)]",
-                        )}
-                    >
-                        <span
-                            className={cn(
-                                "mt-0.5 flex h-4 w-4 shrink-0 items-center justify-center rounded-full border border-solid",
-                                selected
-                                    ? "border-[var(--ant-color-primary)]"
-                                    : "border-[var(--ant-color-text-tertiary)]",
-                            )}
-                        >
-                            {selected && (
-                                <span className="h-2 w-2 rounded-full bg-[var(--ant-color-primary)]" />
-                            )}
-                        </span>
-                        <span className="flex flex-col gap-0.5">
-                            <Typography.Text
-                                className={cn(
-                                    "text-xs font-medium leading-none",
-                                    selected && "!text-[var(--ant-color-primary-text)]",
-                                )}
-                            >
-                                {title}
-                            </Typography.Text>
-                            <Typography.Text type="secondary" className="text-[11px] leading-snug">
-                                {desc}
-                            </Typography.Text>
-                        </span>
-                    </button>
-                )
-            })}
-            {connection.mode === "agenta" && (
-                <LabeledField
-                    label="Connection"
-                    description="Which stored connection supplies the credential. Project default uses the project's provider key."
-                    withTooltip={withTooltip}
-                >
-                    <Select<string>
-                        value={connection.slug ?? "__default__"}
-                        onChange={(v) =>
-                            writeModel({slug: v === "__default__" ? null : (v ?? null)})
-                        }
-                        options={[
-                            {value: "__default__", label: "Project default"},
-                            ...connectionOptions.map((o) => ({value: o.value, label: o.label})),
-                        ]}
-                        disabled={disabled}
-                        className="w-full"
-                        showSearch
-                        optionFilterProp="label"
-                    />
-                </LabeledField>
-            )}
-
-            {/* Raw-JSON escape hatch for the whole `agent.llm` value (model + connection),
-                collapsed by default. */}
-            <div className="flex items-center gap-2">
-                <Switch
-                    checked={showModelJson}
-                    onChange={handleToggleModelJson}
-                    disabled={disabled}
-                />
-                <Typography.Text className="text-xs">Edit as JSON</Typography.Text>
-            </div>
-            {showModelJson && (
-                <CodeEditor
-                    value={modelJsonText}
-                    onChange={handleModelJsonChange}
-                    language="json"
-                    disabled={disabled}
-                />
-            )}
-        </div>
-    ) : null
-
-    // Advanced header summary: auth mode + sandbox, so the collapsed header still conveys state.
-    const advancedSummary =
-        [
-            props.llm ? (connection.mode === "agenta" ? "Agenta-managed" : "Self-managed") : null,
-            sandbox.kind ? `Sandbox: ${String(sandbox.kind)}` : null,
-        ]
-            .filter(Boolean)
-            .join(" · ") || undefined
-
-    // Advanced drawer body — two panels (consistent with Model & harness): grouped, explained
-    // settings on the left; version history on the right. Authentication moved here.
-    const hasExecutionGroup = Boolean(sandboxProps.kind || sandboxProps.permissions)
-    const hasPermissionsGroup = Boolean(headlessSchema || hasClaudePermissions)
-    // Shared Advanced controls (Authentication / Execution / Permissions groups), rendered by
-    // both the wide drawer body (with the version-history side panel) and the tabs-inline body.
-    const advancedControls = (
-        <>
-            {authControls ? (
-                <div>
-                    <div className="mb-0.5 flex items-center gap-1.5">
-                        <Key size={15} className="text-[var(--ag-c-586673,#586673)]" />
-                        <span className="text-[13px] font-medium">Authentication</span>
-                    </div>
-                    <p className="mb-2.5 ml-[22px] text-[11.5px] leading-snug text-[var(--ag-c-97A4B0,#97a4b0)]">
-                        Where the model credential comes from when this agent runs.
-                    </p>
-                    <div className="ml-[22px]">{authControls}</div>
-                </div>
-            ) : null}
-
-            {hasExecutionGroup ? (
-                <div className="border-0 border-t border-solid border-[var(--ag-c-EAEFF5,#eaeff5)] pt-4">
-                    <div className="mb-0.5 flex items-center gap-1.5">
-                        <Cube size={15} className="text-[var(--ag-c-586673,#586673)]" />
-                        <span className="text-[13px] font-medium">Execution environment</span>
-                    </div>
-                    <p className="mb-2.5 ml-[22px] text-[11.5px] leading-snug text-[var(--ag-c-97A4B0,#97a4b0)]">
-                        Where the agent&apos;s tools and code run, and what that sandbox may touch.
-                    </p>
-                    <div className="ml-[22px] flex flex-col gap-2.5">
-                        {sandboxProps.kind && (
-                            <EnumSelectControl
-                                schema={sandboxProps.kind}
-                                label="Sandbox"
-                                value={(sandbox.kind as string | null) ?? null}
-                                onChange={(v) => setSection("sandbox", {...sandbox, kind: v})}
-                                withTooltip={withTooltip}
-                                disabled={disabled}
-                            />
-                        )}
-                        {sandboxProps.permissions ? (
-                            <SandboxPermissionControl
-                                value={
-                                    (sandbox.permissions as Record<string, unknown> | null) ?? null
-                                }
-                                onChange={(v) =>
-                                    setSection("sandbox", {...sandbox, permissions: v})
-                                }
-                                disabled={disabled}
-                            />
-                        ) : null}
-                    </div>
-                </div>
-            ) : null}
-
-            {hasPermissionsGroup ? (
-                <div className="border-0 border-t border-solid border-[var(--ag-c-EAEFF5,#eaeff5)] pt-4">
-                    <div className="mb-0.5 flex items-center gap-1.5">
-                        <ShieldCheck size={15} className="text-[var(--ag-c-586673,#586673)]" />
-                        <span className="text-[13px] font-medium">Permissions</span>
-                    </div>
-                    <p className="mb-2.5 ml-[22px] text-[11.5px] leading-snug text-[var(--ag-c-97A4B0,#97a4b0)]">
-                        What the agent may do on its own before it must ask.
-                    </p>
-                    <div className="ml-[22px] flex flex-col gap-2.5">
-                        {headlessSchema ? (
-                            isPiHarness ? (
-                                <div className="flex items-center gap-1.5 text-[11px] text-[var(--ag-c-97A4B0,#97a4b0)]">
-                                    <EyeSlash size={13} />
-                                    Permission policy isn&apos;t used by the Pi harness.
-                                </div>
-                            ) : (
-                                <EnumSelectControl
-                                    schema={headlessSchema}
-                                    label="Permission policy"
-                                    value={headlessValue}
-                                    onChange={(v) =>
-                                        setSection("runner", {
-                                            ...runner,
-                                            interactions: {...runnerInteractions, headless: v},
-                                        })
-                                    }
-                                    withTooltip={withTooltip}
-                                    disabled={disabled}
-                                />
-                            )
-                        ) : null}
-                        {hasClaudePermissions ? (
-                            <div className="flex flex-col gap-1.5">
-                                <div className="flex items-center gap-1.5">
-                                    <Typography.Text className="text-xs font-medium">
-                                        Claude permissions
-                                    </Typography.Text>
-                                    <span className="rounded-full bg-[var(--ant-color-fill-secondary)] px-2 text-[10px] text-[var(--ant-color-primary-text)]">
-                                        Claude harness
-                                    </span>
-                                </div>
-                                <ClaudePermissionsControl
-                                    value={claudePermissions}
-                                    onChange={setClaudePermissions}
-                                    disabled={disabled}
-                                />
-                            </div>
-                        ) : null}
-                    </div>
-                </div>
-            ) : null}
-        </>
-    )
-
-    const advancedDrawerBody = (
-        <div className="flex h-full min-h-0 gap-6">
-            <div className="flex min-w-0 flex-1 flex-col gap-4 overflow-y-auto pr-1">
-                {advancedControls}
-            </div>
-            <div className="w-[240px] shrink-0 overflow-y-auto">{versionHistorySkeleton}</div>
-        </div>
-    )
-
-    // Trimmed body for the tabs layout: the grouped controls in one column, no side panel.
-    const advancedInline = <div className="flex flex-col gap-4">{advancedControls}</div>
-
     // Each config section as a descriptor, so it can be rendered in any layout (accordion /
     // tabs / cards) without duplicating the content. Schema-gated, like before.
     const sections = [
-        hasModelOrHarness && {
+        mh.hasModelOrHarness && {
             key: "model-harness",
             icon: <Cpu size={16} />,
             title: "Model & harness",
-            summary: modelSummary,
+            summary: mh.modelSummary,
             defaultOpen: true,
             onOpen: () => openSectionDrawer("model-harness"),
-            content: modelHarnessDrawerBody,
-            inlineContent: modelHarnessInline,
+            content: mh.modelHarnessDrawerBody,
+            inlineContent: mh.modelHarnessInline,
         },
         hasInstructions && {
             key: "instructions",
@@ -1224,15 +471,15 @@ export function AgentTemplateControl({
             defaultOpen: triggerCount > 0,
             content: <TriggerManagementSection entityId={revisionId} disabled={disabled} />,
         },
-        hasAdvanced && {
+        mh.hasAdvanced && {
             key: "advanced",
             icon: <SlidersHorizontal size={16} />,
             title: "Advanced",
             defaultOpen: false,
-            summary: advancedSummary,
+            summary: mh.advancedSummary,
             onOpen: () => openSectionDrawer("advanced"),
-            content: advancedDrawerBody,
-            inlineContent: advancedInline,
+            content: mh.advancedDrawerBody,
+            inlineContent: mh.advancedInline,
         },
     ].filter(Boolean) as {
         key: string
@@ -1389,9 +636,9 @@ export function AgentTemplateControl({
                 onCancel={cancelSection}
                 onSave={saveSection}
                 disabled={disabled}
-                width={capabilities ? 880 : 560}
+                width={mh.modelHarnessDrawerWidth}
             >
-                {modelHarnessDrawerBody}
+                {mh.modelHarnessDrawerBody}
             </SectionDrawer>
 
             <SectionDrawer
@@ -1403,7 +650,7 @@ export function AgentTemplateControl({
                 disabled={disabled}
                 width={880}
             >
-                {advancedDrawerBody}
+                {mh.advancedDrawerBody}
             </SectionDrawer>
 
             {workflowReference?.enabled && (

--- a/web/packages/agenta-entity-ui/src/DrillInView/SchemaControls/agentTemplate/ConfigItemList.tsx
+++ b/web/packages/agenta-entity-ui/src/DrillInView/SchemaControls/agentTemplate/ConfigItemList.tsx
@@ -1,8 +1,6 @@
 /**
- * The list body for a tool / MCP / skill config section: a column of {@link ItemRow}s, or a muted
- * empty-state line whose action is the caller-supplied add trigger. All per-kind behavior (how an
- * item is classified, its default edit view, whether it's read-only) comes from {@link ITEM_KINDS},
- * so the three sections share one render instead of three copies.
+ * List body for a tool / MCP / skill section: a column of {@link ItemRow}s or a muted empty state.
+ * Per-kind behavior comes from {@link ITEM_KINDS}, so the three sections share one render.
  */
 import type {ReactNode} from "react"
 

--- a/web/packages/agenta-entity-ui/src/DrillInView/SchemaControls/agentTemplate/ConfigItemList.tsx
+++ b/web/packages/agenta-entity-ui/src/DrillInView/SchemaControls/agentTemplate/ConfigItemList.tsx
@@ -1,0 +1,58 @@
+/**
+ * The list body for a tool / MCP / skill config section: a column of {@link ItemRow}s, or a muted
+ * empty-state line whose action is the caller-supplied add trigger. All per-kind behavior (how an
+ * item is classified, its default edit view, whether it's read-only) comes from {@link ITEM_KINDS},
+ * so the three sections share one render instead of three copies.
+ */
+import type {ReactNode} from "react"
+
+import type {ConfigItemView} from "../ConfigItemDrawer"
+
+import {ITEM_KINDS, type ItemKind} from "./itemKinds"
+import {ItemRow} from "./ItemRow"
+
+export function ConfigItemList({
+    kind,
+    items,
+    openEdit,
+    removeItem,
+    closeEditor,
+    disabled,
+    emptyAdd,
+}: {
+    kind: ItemKind
+    items: unknown[]
+    openEdit: (kind: ItemKind, index: number, item: unknown, view: ConfigItemView) => void
+    removeItem: (kind: ItemKind, index: number) => void
+    closeEditor: () => void
+    disabled?: boolean
+    /** The add trigger shown in the empty state (a popover for tools, a text link otherwise). */
+    emptyAdd: ReactNode
+}) {
+    const def = ITEM_KINDS[kind]
+    if (items.length > 0) {
+        return (
+            <div className="flex flex-col gap-2">
+                {items.map((item, index) => (
+                    <ItemRow
+                        key={`${kind}-${index}`}
+                        descriptor={def.describe(item)}
+                        onEdit={() => openEdit(kind, index, item, def.editView(item))}
+                        onRemove={() => {
+                            removeItem(kind, index)
+                            closeEditor()
+                        }}
+                        // Read-only items (static `__ag__*` skills) can't be removed and open disabled.
+                        disabled={disabled || def.isReadOnly(item)}
+                    />
+                ))}
+            </div>
+        )
+    }
+    if (disabled) return null
+    return (
+        <span className="text-xs text-[var(--ag-c-97A4B0,#97a4b0)]">
+            {def.emptyLabel} — {emptyAdd}
+        </span>
+    )
+}

--- a/web/packages/agenta-entity-ui/src/DrillInView/SchemaControls/agentTemplate/ItemRow.tsx
+++ b/web/packages/agenta-entity-ui/src/DrillInView/SchemaControls/agentTemplate/ItemRow.tsx
@@ -1,0 +1,145 @@
+/**
+ * The presentational rows for the agent-template config sections: a colored avatar, the generic
+ * tool/MCP/skill row, and the richer instructions-file row. All are dumb — they render an
+ * {@link ItemDescriptor} and call back on open/remove; the section owners hold the state.
+ */
+import {CaretRight, Trash} from "@phosphor-icons/react"
+import {Tag, Typography} from "antd"
+
+import {describeInstruction, type ItemDescriptor} from "./itemDescriptors"
+
+/** Colored avatar square (icon or monogram) at the start of a config-item row. */
+export function ItemAvatar({descriptor}: {descriptor: ItemDescriptor}) {
+    return (
+        <span
+            className="flex h-7 w-7 shrink-0 items-center justify-center rounded text-white"
+            style={{background: descriptor.color, fontSize: 10, fontWeight: 600, lineHeight: 1}}
+        >
+            {descriptor.icon ?? descriptor.mono}
+        </span>
+    )
+}
+
+/**
+ * A config-item row (a tool or MCP server): type avatar, name + description, type tags, and a
+ * chevron. The whole row opens the item drawer; remove appears on hover.
+ */
+export function ItemRow({
+    descriptor,
+    onEdit,
+    onRemove,
+    disabled,
+}: {
+    descriptor: ItemDescriptor
+    onEdit: () => void
+    onRemove?: () => void
+    disabled?: boolean
+}) {
+    return (
+        <div
+            role="button"
+            tabIndex={0}
+            onClick={onEdit}
+            onKeyDown={(e) => {
+                if (e.key === "Enter" || e.key === " ") {
+                    e.preventDefault()
+                    onEdit()
+                }
+            }}
+            className="group flex cursor-pointer items-center gap-2.5 rounded border border-solid border-[var(--ag-c-EAEFF5,#eaeff5)] px-3 py-2 transition-colors hover:border-[var(--ag-c-97A4B0,#97a4b0)]"
+        >
+            <ItemAvatar descriptor={descriptor} />
+            <div className="min-w-0 flex-1">
+                <div className="truncate font-mono text-xs font-medium">{descriptor.name}</div>
+                {descriptor.description ? (
+                    <Typography.Text
+                        type="secondary"
+                        className="block truncate text-xs leading-tight"
+                    >
+                        {descriptor.description}
+                    </Typography.Text>
+                ) : null}
+            </div>
+            <div className="flex shrink-0 items-center gap-1.5">
+                {descriptor.tags.map((tag) => (
+                    <Tag key={tag} className="m-0 text-[11px]">
+                        {tag}
+                    </Tag>
+                ))}
+                {onRemove && !disabled ? (
+                    <button
+                        type="button"
+                        aria-label="Remove"
+                        onClick={(e) => {
+                            e.stopPropagation()
+                            onRemove()
+                        }}
+                        className="flex cursor-pointer items-center border-0 bg-transparent p-0 text-[var(--ag-c-97A4B0,#97a4b0)] opacity-0 transition-opacity hover:text-[var(--ag-c-FF4D4F,#ff4d4f)] group-hover:opacity-100"
+                    >
+                        <Trash size={14} />
+                    </button>
+                ) : null}
+                <CaretRight size={14} className="text-[var(--ag-c-97A4B0,#97a4b0)]" />
+            </div>
+        </div>
+    )
+}
+
+/**
+ * An instructions markdown file row. Avatar + filename + a 2-line preview of the (markdown-stripped)
+ * content, clamped with an ellipsis. The whole row opens the editor drawer for the full content —
+ * there is no inline expand, so it reads the same as the tool / MCP rows.
+ */
+export function InstructionsFileRow({
+    filename,
+    content,
+    onOpen,
+}: {
+    filename: string
+    content: string
+    onOpen: () => void
+}) {
+    const descriptor = describeInstruction(filename, content)
+    const wordCount = content.trim().split(/\s+/).filter(Boolean).length
+    const meta =
+        wordCount > 0
+            ? `Markdown · ${wordCount} word${wordCount === 1 ? "" : "s"}`
+            : "Markdown · empty"
+    return (
+        <div
+            role="button"
+            tabIndex={0}
+            onClick={onOpen}
+            onKeyDown={(e) => {
+                if (e.key === "Enter" || e.key === " ") {
+                    e.preventDefault()
+                    onOpen()
+                }
+            }}
+            className="group flex cursor-pointer items-start gap-3 rounded-lg border border-solid border-[var(--ag-c-EAEFF5,#eaeff5)] px-3 py-2.5 transition-colors hover:border-[var(--ag-c-97A4B0,#97a4b0)]"
+        >
+            <ItemAvatar descriptor={descriptor} />
+            <div className="min-w-0 flex-1">
+                {/* Identity row: filename (color inherits → theme-correct) + a muted meta, so the
+                    name/type/size reads separately from the content preview below. */}
+                <div className="flex items-baseline gap-2">
+                    <span className="truncate font-mono text-[13px] font-medium leading-tight">
+                        {filename}
+                    </span>
+                    <Typography.Text type="secondary" className="shrink-0 text-[11px]">
+                        {meta}
+                    </Typography.Text>
+                </div>
+                {/* `descriptor.description` is the stripped-markdown preview (or "Empty file");
+                    clamp to 2 lines so long instructions get a real "…" rather than a hard cut. */}
+                <Typography.Text
+                    type="secondary"
+                    className="mt-1 line-clamp-2 text-xs leading-snug"
+                >
+                    {descriptor.description}
+                </Typography.Text>
+            </div>
+            <CaretRight size={15} className="mt-1 shrink-0 text-[var(--ag-c-97A4B0,#97a4b0)]" />
+        </div>
+    )
+}

--- a/web/packages/agenta-entity-ui/src/DrillInView/SchemaControls/agentTemplate/ItemRow.tsx
+++ b/web/packages/agenta-entity-ui/src/DrillInView/SchemaControls/agentTemplate/ItemRow.tsx
@@ -12,8 +12,8 @@ import {describeInstruction, type ItemDescriptor} from "./itemDescriptors"
 export function ItemAvatar({descriptor}: {descriptor: ItemDescriptor}) {
     return (
         <span
-            className="flex h-7 w-7 shrink-0 items-center justify-center rounded text-white"
-            style={{background: descriptor.color, fontSize: 10, fontWeight: 600, lineHeight: 1}}
+            className="flex h-7 w-7 shrink-0 items-center justify-center rounded text-[10px] font-semibold leading-none text-white"
+            style={{background: descriptor.color}}
         >
             {descriptor.icon ?? descriptor.mono}
         </span>

--- a/web/packages/agenta-entity-ui/src/DrillInView/SchemaControls/agentTemplate/agentTemplateUtils.ts
+++ b/web/packages/agenta-entity-ui/src/DrillInView/SchemaControls/agentTemplate/agentTemplateUtils.ts
@@ -1,0 +1,32 @@
+/**
+ * Small, pure helpers shared across the agent-template config sections. No React, no state — kept
+ * separate so the section components and the orchestrator can reuse them (and so they're testable).
+ */
+import type {SchemaProperty} from "@agenta/entities/shared"
+
+/**
+ * Best-effort display label for an enum value, used in collapsed section summaries.
+ * Reads `x-model-metadata` titles and `anyOf`/`oneOf` const titles, falling back to the
+ * raw value so a summary is always shown.
+ */
+export function enumLabel(schema: SchemaProperty | undefined, value: unknown): string | null {
+    if (value == null || value === "") return null
+    const v = String(value)
+    const s = schema as Record<string, unknown> | undefined
+    const meta = s?.["x-model-metadata"] as Record<string, {name?: string}> | undefined
+    if (meta?.[v]?.name) return meta[v]!.name as string
+    const variants = (s?.anyOf ?? s?.oneOf) as {const?: unknown; title?: string}[] | undefined
+    const hit = variants?.find((o) => o?.const === value)
+    if (hit?.title) return hit.title
+    return v
+}
+
+/** "3 tools" / "1 server" / "None" — the count line shown in a collapsed section header. */
+export const countSummary = (n: number, noun: string): string =>
+    n > 0 ? `${n} ${noun}${n === 1 ? "" : "s"}` : "None"
+
+/** Deep-clone a config item so drawer edits don't alias the committed config object. */
+export function cloneItem(item: unknown): Record<string, unknown> {
+    if (!item || typeof item !== "object") return {}
+    return JSON.parse(JSON.stringify(item)) as Record<string, unknown>
+}

--- a/web/packages/agenta-entity-ui/src/DrillInView/SchemaControls/agentTemplate/itemDescriptors.tsx
+++ b/web/packages/agenta-entity-ui/src/DrillInView/SchemaControls/agentTemplate/itemDescriptors.tsx
@@ -1,10 +1,7 @@
 /**
- * Per-item presentation classifiers for the agent-template config sections.
- *
- * Each `describe*` maps a raw config item (a tool / MCP server / skill / instructions file) to an
- * {@link ItemDescriptor} — the avatar, name, description, and type tags a row and its drawer header
- * render. Kept beside the small classifier predicates they rely on (e.g. `isFunctionTool`,
- * `isStaticSkill`) so the registry, the rows, and the drawers all share one source of truth.
+ * Per-item presentation classifiers: each `describe*` maps a raw config item (tool / MCP / skill /
+ * instructions file) to an {@link ItemDescriptor} (avatar, name, description, tags). Kept beside the
+ * predicates they rely on (`isFunctionTool`, `isStaticSkill`) so registry, rows, and drawers agree.
  */
 import {FileText, GraphIcon, Plugs} from "@phosphor-icons/react"
 

--- a/web/packages/agenta-entity-ui/src/DrillInView/SchemaControls/agentTemplate/itemDescriptors.tsx
+++ b/web/packages/agenta-entity-ui/src/DrillInView/SchemaControls/agentTemplate/itemDescriptors.tsx
@@ -1,0 +1,291 @@
+/**
+ * Per-item presentation classifiers for the agent-template config sections.
+ *
+ * Each `describe*` maps a raw config item (a tool / MCP server / skill / instructions file) to an
+ * {@link ItemDescriptor} — the avatar, name, description, and type tags a row and its drawer header
+ * render. Kept beside the small classifier predicates they rely on (e.g. `isFunctionTool`,
+ * `isStaticSkill`) so the registry, the rows, and the drawers all share one source of truth.
+ */
+import {FileText, GraphIcon, Plugs} from "@phosphor-icons/react"
+
+import {parseGatewayFunctionName, type ToolObj} from "../toolUtils"
+
+/** How a config-item row presents itself: avatar, name + description, and type tags. */
+export interface ItemDescriptor {
+    /** Primary label (rendered monospace). */
+    name: string
+    /** Secondary description line. */
+    description?: string
+    /** Avatar monogram, used when no `icon` is given. */
+    mono: string
+    /** Avatar background colour. */
+    color: string
+    /** Avatar icon (overrides the monogram). */
+    icon?: React.ReactNode
+    /** Type tags shown on the right of a row (e.g. "built-in", "definition", "gmail"). */
+    tags: string[]
+    /** Type label for the drawer header badge (e.g. "definition", "MCP server"). */
+    typeLabel: string
+    /** antd Tag colour for the header badge. */
+    typeColor?: string
+    /** One-line type description shown as the drawer subtitle. */
+    subtitle: string
+}
+
+/** Read the function name of a tool object (the gateway slug for Composio tools). */
+export function toolName(tool: unknown): string | undefined {
+    if (!tool || typeof tool !== "object") return undefined
+    const fn = (tool as Record<string, unknown>).function
+    if (!fn || typeof fn !== "object") return undefined
+    const name = (fn as Record<string, unknown>).name
+    return typeof name === "string" ? name : undefined
+}
+
+/** Slug a `type:"reference"` tool targets (undefined for any other tool). Dedupes referenced
+ * workflows; ignores gateway function names so a same-named gateway tool can't shadow a workflow. */
+export function toolReferenceSlug(tool: unknown): string | undefined {
+    if (!tool || typeof tool !== "object") return undefined
+    const t = tool as Record<string, unknown>
+    if (t.type !== "reference") return undefined
+    return typeof t.slug === "string" ? (t.slug as string) : undefined
+}
+
+export function isBuiltinPayloadMatch(tool: unknown, payload: ToolObj): boolean {
+    if (!tool || typeof tool !== "object" || Array.isArray(tool)) return false
+    if (!payload || typeof payload !== "object" || Array.isArray(payload)) return false
+
+    const toolObj = tool as Record<string, unknown>
+    const payloadObj = payload as Record<string, unknown>
+
+    if (typeof payloadObj.type === "string" && toolObj.type === payloadObj.type) return true
+    if (typeof payloadObj.name === "string" && toolObj.name === payloadObj.name) return true
+
+    const payloadKeys = Object.keys(payloadObj)
+    return (
+        payloadKeys.length === 1 &&
+        payloadKeys[0] !== "type" &&
+        payloadKeys[0] !== "name" &&
+        payloadKeys[0] in toolObj
+    )
+}
+
+/** Whether a tool has an editable OpenAI-style `function` (vs a bare builtin `type`). */
+export function isFunctionTool(tool: unknown): boolean {
+    if (!tool || typeof tool !== "object") return false
+    const fn = (tool as Record<string, unknown>).function
+    return Boolean(fn && typeof fn === "object")
+}
+
+/** Two-char monogram, title-cased ("gmail" -> "Gm", "zendesk" -> "Ze"). */
+export function monogram(value: string): string {
+    return (value.charAt(0).toUpperCase() + (value.charAt(1) ?? "")).trim() || "?"
+}
+
+/** Classify a tool into its row avatar / name / description / type tags. */
+export function describeTool(tool: unknown): ItemDescriptor {
+    const t = (tool ?? {}) as Record<string, unknown>
+    const fn = t.function as Record<string, unknown> | undefined
+    const fnName = typeof fn?.name === "string" ? (fn.name as string) : undefined
+    const description = typeof fn?.description === "string" ? (fn.description as string) : undefined
+
+    // Workflow reference tool (type:"reference", #4860): a referenced workflow the backend runs
+    // server-side as a callback tool. Detected by the discriminator BEFORE the builtin fallback
+    // (which would otherwise misclassify it as built-in).
+    if (t.type === "reference") {
+        const slug = typeof t.slug === "string" ? (t.slug as string) : undefined
+        const refName = typeof t.name === "string" ? (t.name as string) : undefined
+        const target =
+            t.ref_by === "environment" && typeof t.environment === "string"
+                ? `${slug ?? ""} @ ${t.environment as string}`
+                : typeof t.version === "string"
+                  ? `${slug ?? ""} v${t.version as string}`
+                  : slug
+        return {
+            name: refName ?? slug ?? "Workflow tool",
+            description: typeof t.description === "string" ? (t.description as string) : undefined,
+            mono: "",
+            color: "#0d9488",
+            icon: <GraphIcon size={15} weight="fill" />,
+            tags: ["workflow"],
+            typeLabel: "workflow",
+            typeColor: "geekblue",
+            subtitle: target ? `Referenced workflow · ${target}` : "Referenced workflow",
+        }
+    }
+
+    // Third-party / gateway tool: tools__provider__integration__action__connection.
+    const gateway = fnName ? parseGatewayFunctionName(fnName) : null
+    if (gateway) {
+        return {
+            name: gateway.action,
+            description,
+            mono: monogram(gateway.integration),
+            color: "#1c2c3d",
+            tags: [gateway.integration],
+            typeLabel: "third-party",
+            subtitle: `Connected app tool · ${gateway.integration}`,
+        }
+    }
+
+    // Built-in / provider tool: a bare `type` with no editable `function`.
+    if (!fn || typeof fn !== "object") {
+        const typeValue =
+            typeof t.type === "string" && t.type !== "function"
+                ? (t.type as string)
+                : Object.keys(t).find((k) => k !== "type" && k !== "function")
+        return {
+            name: typeValue ?? "Built-in tool",
+            mono: "io",
+            color: "#0d9488",
+            tags: ["built-in"],
+            typeLabel: "built-in",
+            typeColor: "cyan",
+            subtitle: "Provider built-in tool",
+        }
+    }
+
+    // Function definition (custom inline tool).
+    return {
+        name: fnName ?? "Tool",
+        description,
+        mono: "{}",
+        color: "#7c3aed",
+        tags: ["definition"],
+        typeLabel: "definition",
+        typeColor: "purple",
+        subtitle: "Schema-only · executed by your app",
+    }
+}
+
+/** Classify an MCP server into its row avatar / name / description / tags. */
+export function describeMcp(server: unknown): ItemDescriptor {
+    const s = (server ?? {}) as Record<string, unknown>
+    const transport = s.transport === "http" ? "http" : "stdio"
+    const name = typeof s.name === "string" && s.name ? (s.name as string) : "MCP server"
+    const detailField = transport === "http" ? s.url : s.command
+    return {
+        name,
+        description: typeof detailField === "string" ? detailField : undefined,
+        mono: "",
+        color: "#2563eb",
+        icon: <Plugs size={15} weight="fill" />,
+        tags: [transport],
+        typeLabel: "MCP server",
+        typeColor: "cyan",
+        subtitle: "Model Context Protocol server",
+    }
+}
+
+function asObj(value: unknown): Record<string, unknown> | undefined {
+    return value && typeof value === "object" && !Array.isArray(value)
+        ? (value as Record<string, unknown>)
+        : undefined
+}
+
+/**
+ * A skills entry is either an inline SKILL.md package or an `@ag.embed` reference (which the
+ * backend inlines). Embed refs carry the marker at the top level and must round-trip intact, so
+ * they're edited JSON-only rather than through the structured form.
+ */
+export function isEmbedRefSkill(skill: unknown): boolean {
+    return Boolean(
+        skill && typeof skill === "object" && "@ag.embed" in (skill as Record<string, unknown>),
+    )
+}
+
+/** The reserved slug namespace for static (Agenta-owned) skills (mirrors the backend `__ag__*`). */
+const STATIC_SKILL_SLUG_PREFIX = "__ag__"
+
+/** The slug an `@ag.embed` entry points at (a `workflow` or pinned `workflow_revision` reference). */
+function staticEmbedSlug(skill: Record<string, unknown>): string | undefined {
+    const refs = asObj(asObj(skill["@ag.embed"])?.["@ag.references"])
+    if (!refs) return undefined
+    const slug = asObj(refs.workflow)?.slug ?? asObj(refs.workflow_revision)?.slug
+    return typeof slug === "string" ? slug : undefined
+}
+
+/** A pinned revision's version, when the embed references a `workflow_revision`. */
+function embedRevisionVersion(skill: Record<string, unknown>): string | undefined {
+    const refs = asObj(asObj(skill["@ag.embed"])?.["@ag.references"])
+    const version = asObj(refs?.workflow_revision)?.version
+    return typeof version === "string" ? version : undefined
+}
+
+/**
+ * Whether a skill entry is static (Agenta-owned) and so read-only for the author. The reliable client-side
+ * signal is the reserved `__ag__` slug prefix on the embed's referenced workflow (or pinned
+ * revision); a resolved object carrying `flags.is_static === true` counts too.
+ */
+export function isStaticSkill(skill: unknown): boolean {
+    const s = asObj(skill)
+    if (!s) return false
+    const slug = staticEmbedSlug(s)
+    if (slug && slug.startsWith(STATIC_SKILL_SLUG_PREFIX)) return true
+    return asObj(s.flags)?.is_static === true
+}
+
+/** Classify a skill into its row avatar / name / description / type tags. */
+export function describeSkill(skill: unknown): ItemDescriptor {
+    const s = (skill ?? {}) as Record<string, unknown>
+    if (isStaticSkill(s)) {
+        const slug = staticEmbedSlug(s)
+        const version = embedRevisionVersion(s)
+        return {
+            name: slug ?? "Static skill",
+            mono: "sk",
+            color: "#6b7280",
+            tags: version ? ["static", `v${version}`] : ["static"],
+            typeLabel: "static skill",
+            subtitle: "Provided by Agenta — read-only",
+        }
+    }
+    if (isEmbedRefSkill(s)) {
+        return {
+            name: "Skill reference",
+            mono: "sk",
+            color: "#b45309",
+            tags: ["@ag.embed"],
+            typeLabel: "@ag.embed",
+            typeColor: "blue",
+            subtitle: "Referenced skill — inlined by the backend",
+        }
+    }
+    return {
+        name: typeof s.name === "string" && s.name ? (s.name as string) : "Skill",
+        description: typeof s.description === "string" ? (s.description as string) : undefined,
+        mono: "sk",
+        color: "#b45309",
+        tags: ["skill"],
+        typeLabel: "skill",
+        typeColor: "gold",
+        subtitle: "Inline SKILL.md package",
+    }
+}
+
+/** Strip Markdown syntax to a short single-line preview for an instructions file row. */
+export function mdPreview(md: string): string {
+    return (md ?? "")
+        .replace(/```[\s\S]*?```/g, " ") // fenced code blocks
+        .replace(/^#{1,6}\s+/gm, "") // heading markers
+        .replace(/^\s*[-*+]\s+/gm, "") // bullet list markers (so "- Greet…" reads as prose)
+        .replace(/^\s*\d+\.\s+/gm, "") // numbered list markers
+        .replace(/!?\[([^\]]*)\]\([^)]*\)/g, "$1") // links/images → their text
+        .replace(/[*_`>#]/g, "") // inline emphasis / quote chars
+        .replace(/\s+/g, " ") // collapse newlines + runs of whitespace
+        .trim()
+        .slice(0, 140)
+}
+
+/** Row descriptor for an instructions markdown file (e.g. AGENTS.md). */
+export function describeInstruction(filename: string, content: string): ItemDescriptor {
+    return {
+        name: filename,
+        description: mdPreview(content) || "Empty file",
+        mono: "md",
+        color: "#0f766e",
+        icon: <FileText size={14} />,
+        tags: [],
+        typeLabel: "instructions",
+        subtitle: "Markdown instructions for the agent",
+    }
+}

--- a/web/packages/agenta-entity-ui/src/DrillInView/SchemaControls/agentTemplate/itemKinds.tsx
+++ b/web/packages/agenta-entity-ui/src/DrillInView/SchemaControls/agentTemplate/itemKinds.tsx
@@ -1,12 +1,7 @@
 /**
- * The per-kind registry for the agent-template list sections (tools / MCP servers / skills).
- *
- * Tools, MCP servers and skills are edited through the same machinery — a list of {@link ItemRow}s
- * plus a draft-then-save {@link ConfigItemDrawer} — and differ only in this data: which config array
- * they live on, how an item is classified, which form view edits it, and the small per-kind rules
- * (default Form/JSON view, JSON-only, read-only, create seed, draft validity). Centralizing those
- * lets `useConfigItemDrawer`, the section bodies, and the single drawer render share one code path
- * instead of three near-identical copies.
+ * Per-kind registry for the tool / MCP / skill list sections. They share one machinery (an
+ * {@link ItemRow} list + a draft-then-save {@link ConfigItemDrawer}) and differ only in this data —
+ * config array, classifier, form view, per-kind rules — so all three run through one code path.
  */
 import type {ComponentType, ReactNode} from "react"
 

--- a/web/packages/agenta-entity-ui/src/DrillInView/SchemaControls/agentTemplate/itemKinds.tsx
+++ b/web/packages/agenta-entity-ui/src/DrillInView/SchemaControls/agentTemplate/itemKinds.tsx
@@ -77,6 +77,7 @@ export const ITEM_KINDS: Record<ItemKind, ItemKindDef> = {
         editView: (item) => (isFunctionTool(item) ? "form" : "json"),
         jsonOnly: (draft) => !isFunctionTool(draft),
         isReadOnly: () => false,
+        // Unused for tools: creation seeds from the picker (buildInlineFunctionTool), not this.
         createSeed: () => ({}),
         draftInvalid: (draft) => {
             const fn = draft.function as Record<string, unknown> | undefined

--- a/web/packages/agenta-entity-ui/src/DrillInView/SchemaControls/agentTemplate/itemKinds.tsx
+++ b/web/packages/agenta-entity-ui/src/DrillInView/SchemaControls/agentTemplate/itemKinds.tsx
@@ -1,0 +1,137 @@
+/**
+ * The per-kind registry for the agent-template list sections (tools / MCP servers / skills).
+ *
+ * Tools, MCP servers and skills are edited through the same machinery — a list of {@link ItemRow}s
+ * plus a draft-then-save {@link ConfigItemDrawer} — and differ only in this data: which config array
+ * they live on, how an item is classified, which form view edits it, and the small per-kind rules
+ * (default Form/JSON view, JSON-only, read-only, create seed, draft validity). Centralizing those
+ * lets `useConfigItemDrawer`, the section bodies, and the single drawer render share one code path
+ * instead of three near-identical copies.
+ */
+import type {ComponentType, ReactNode} from "react"
+
+import {GraduationCap, Plugs, Wrench} from "@phosphor-icons/react"
+
+import type {ConfigItemView} from "../ConfigItemDrawer"
+import {McpServerFormView} from "../McpServerFormView"
+import {SkillFormView} from "../SkillFormView"
+import {ToolFormView} from "../ToolFormView"
+
+import {
+    describeMcp,
+    describeSkill,
+    describeTool,
+    isEmbedRefSkill,
+    isFunctionTool,
+    isStaticSkill,
+    type ItemDescriptor,
+} from "./itemDescriptors"
+
+export type ItemKind = "tool" | "mcp" | "skill"
+
+/** The structured form view for a kind — Tool/Mcp/Skill all share this prop shape. */
+type ItemFormView = ComponentType<{
+    value: Record<string, unknown>
+    onChange: (next: Record<string, unknown>) => void
+    disabled?: boolean
+}>
+
+export interface ItemKindDef {
+    kind: ItemKind
+    /** The flat config array this kind lives on. */
+    field: "tools" | "mcps" | "skills"
+    /** Drawer (and section) icon. */
+    icon: ReactNode
+    /** Noun for the collapsed-header count ("3 tools"). */
+    noun: string
+    /** Empty-state lead ("No tools yet"). */
+    emptyLabel: string
+    /** Classify an item into its row/drawer descriptor. */
+    describe: (item: unknown) => ItemDescriptor
+    /** Structured editor for this kind. */
+    FormView: ItemFormView
+    /** Drawer header title for the current draft. */
+    drawerTitle: (draft: Record<string, unknown>) => string
+    /** Wider drawer for kinds that need it (skills are two-pane). */
+    drawerWidth?: number
+    /** Default Form/JSON view when opening an existing item. */
+    editView: (item: unknown) => ConfigItemView
+    /** Items with no structured form open JSON-only (no Form/JSON toggle). */
+    jsonOnly: (item: Record<string, unknown>) => boolean
+    /** Read-only items (e.g. static `__ag__*` skills) — viewable but not editable. */
+    isReadOnly: (item: unknown) => boolean
+    /** Seed for a fresh "create" draft. */
+    createSeed: () => Record<string, unknown>
+    /** Whether the draft is missing the minimum it needs to save. */
+    draftInvalid: (draft: Record<string, unknown>) => boolean
+}
+
+export const ITEM_KINDS: Record<ItemKind, ItemKindDef> = {
+    tool: {
+        kind: "tool",
+        field: "tools",
+        icon: <Wrench size={16} />,
+        noun: "tool",
+        emptyLabel: "No tools yet",
+        describe: describeTool,
+        FormView: ToolFormView,
+        drawerTitle: (draft) => {
+            const name = describeTool(draft).name
+            return name && name !== "Tool" ? name : "New tool"
+        },
+        editView: (item) => (isFunctionTool(item) ? "form" : "json"),
+        jsonOnly: (draft) => !isFunctionTool(draft),
+        isReadOnly: () => false,
+        createSeed: () => ({}),
+        draftInvalid: (draft) => {
+            const fn = draft.function as Record<string, unknown> | undefined
+            if (fn && typeof fn === "object") return !String(fn.name ?? "").trim()
+            return false
+        },
+    },
+    mcp: {
+        kind: "mcp",
+        field: "mcps",
+        icon: <Plugs size={16} />,
+        noun: "server",
+        emptyLabel: "No MCP servers yet",
+        describe: describeMcp,
+        FormView: McpServerFormView,
+        drawerTitle: (draft) => String(draft.name ?? "").trim() || "New MCP server",
+        editView: () => "form",
+        jsonOnly: () => false,
+        isReadOnly: () => false,
+        createSeed: () => ({name: "", transport: "stdio", command: "", args: []}),
+        draftInvalid: (draft) => {
+            // A server needs a launch target too, not just a name: stdio → command, http → url.
+            const name = String(draft.name ?? "").trim()
+            const transport = draft.transport === "http" ? "http" : "stdio"
+            const target =
+                transport === "http"
+                    ? String(draft.url ?? "").trim()
+                    : String(draft.command ?? "").trim()
+            return !name || !target
+        },
+    },
+    skill: {
+        kind: "skill",
+        field: "skills",
+        icon: <GraduationCap size={16} />,
+        noun: "skill",
+        emptyLabel: "No skills yet",
+        describe: describeSkill,
+        FormView: SkillFormView,
+        // Wider than the default 600 — the skill drawer is two-pane (Files + editor).
+        drawerWidth: 760,
+        drawerTitle: (draft) =>
+            isEmbedRefSkill(draft)
+                ? "Skill reference"
+                : String(draft.name ?? "").trim() || "New skill",
+        editView: (item) => (isEmbedRefSkill(item) ? "json" : "form"),
+        jsonOnly: (draft) => isEmbedRefSkill(draft),
+        isReadOnly: (item) => isStaticSkill(item),
+        createSeed: () => ({name: "", description: "", body: ""}),
+        // `@ag.embed` skill references carry no name and are always valid (they round-trip as-is).
+        draftInvalid: (draft) => !isEmbedRefSkill(draft) && !String(draft.name ?? "").trim(),
+    },
+}

--- a/web/packages/agenta-entity-ui/src/DrillInView/SchemaControls/agentTemplate/useAgentTools.ts
+++ b/web/packages/agenta-entity-ui/src/DrillInView/SchemaControls/agentTemplate/useAgentTools.ts
@@ -1,0 +1,149 @@
+/**
+ * Tool-list management for the agent-template Tools section. The `tools` array mixes four kinds that
+ * each add differently: inline function tools (edited in a create drawer before they land), builtin
+ * and gateway tools (arrive complete, added straight away), and `type:"reference"` workflow tools
+ * (#4860, whose input schema is derived asynchronously from the workflow's latest revision). This
+ * hook owns that logic plus the derived sets the Tools section needs, so the orchestrator only wires
+ * the handlers into the picker and renders.
+ */
+import {useCallback, useMemo, type MutableRefObject} from "react"
+
+import type {WorkflowReferenceBridge, WorkflowReferencePayload} from "@agenta/ui/drill-in"
+
+import type {ToolSelectionMeta} from "../ToolSelectorPopover"
+import type {ToolObj} from "../toolUtils"
+
+import {isBuiltinPayloadMatch, toolName, toolReferenceSlug} from "./itemDescriptors"
+import type {ItemKind} from "./itemKinds"
+
+export function useAgentTools({
+    config,
+    onChange,
+    configRef,
+    openCreate,
+    workflowReference,
+}: {
+    config: Record<string, unknown>
+    onChange: (next: Record<string, unknown>) => void
+    /** Latest config, so an async reference add doesn't clobber a concurrent edit. */
+    configRef: MutableRefObject<Record<string, unknown>>
+    /** Opens the shared item-config drawer in "create" mode (for inline function tools). */
+    openCreate: (kind: ItemKind, seed: Record<string, unknown>, view: "form" | "json") => void
+    workflowReference?: WorkflowReferenceBridge
+}) {
+    // Tools live as a flat array on the agent definition (the same tool-object shape the
+    // prompt control uses, so the backend resolver parses them identically).
+    const tools = useMemo(
+        () => (Array.isArray(config.tools) ? (config.tools as unknown[]) : []),
+        [config.tools],
+    )
+    const setTools = useCallback(
+        (next: unknown[]) => onChange({...config, tools: next}),
+        [config, onChange],
+    )
+
+    const handleAddTool = useCallback(
+        (tool: ToolObj, meta?: ToolSelectionMeta) => {
+            const next =
+                meta && tool && typeof tool === "object" && !Array.isArray(tool)
+                    ? {
+                          ...(tool as Record<string, unknown>),
+                          agenta_metadata: {
+                              ...(((tool as Record<string, unknown>).agenta_metadata as
+                                  | Record<string, unknown>
+                                  | undefined) ?? {}),
+                              ...meta,
+                          },
+                      }
+                    : tool
+            // A custom (inline function) tool starts blank — edit it in a create drawer and only
+            // append on Save, so a half-filled tool never lands in the config. Builtin/gateway
+            // tools arrive complete (and gateway is multi-select), so add those straight away.
+            if (meta?.source === "custom") {
+                openCreate("tool", next as Record<string, unknown>, "form")
+                return
+            }
+            setTools([...tools, next])
+        },
+        [tools, setTools, openCreate],
+    )
+
+    // Append a `type:"reference"` tool for a workflow chosen in the reference drawer (#4860),
+    // auto-deriving its model-facing input schema from the workflow's latest revision. The axis
+    // (variant/environment), pinned version, and environment come from the drawer's payload.
+    const handleAddWorkflowReference = useCallback(
+        async (payload: WorkflowReferencePayload) => {
+            const wf = workflowReference?.workflows.find((w) => w.slug === payload.slug)
+            let inputSchema: Record<string, unknown> | null = null
+            try {
+                inputSchema = wf
+                    ? ((await workflowReference?.resolveInputSchema(wf)) ?? null)
+                    : null
+            } catch {
+                inputSchema = null
+            }
+            // Read the freshest tools after the async lookup so a concurrent add/remove isn't clobbered.
+            const latest = configRef.current
+            const latestTools = Array.isArray(latest.tools) ? (latest.tools as unknown[]) : []
+            if (latestTools.some((t) => toolReferenceSlug(t) === payload.slug)) return
+            const referenceTool: Record<string, unknown> = {
+                type: "reference",
+                ref_by: payload.refBy,
+                slug: payload.slug,
+                ...(payload.refBy === "variant" && payload.version
+                    ? {version: payload.version}
+                    : {}),
+                ...(payload.refBy === "environment" && payload.environment
+                    ? {environment: payload.environment}
+                    : {}),
+                name: wf?.name || payload.slug,
+                description: wf?.description ?? wf?.name ?? "",
+                input_schema: inputSchema ?? {type: "object", properties: {}},
+            }
+            onChange({...latest, tools: [...latestTools, referenceTool]})
+        },
+        [workflowReference, onChange, configRef],
+    )
+
+    const handleRemoveToolByName = useCallback(
+        (name: string) => setTools(tools.filter((tool) => toolName(tool) !== name)),
+        [tools, setTools],
+    )
+
+    const handleRemoveBuiltinTool = useCallback(
+        (toolToRemove: ToolObj) => {
+            let removed = false
+            const updated = tools.filter((tool) => {
+                if (removed) return true
+                if (!isBuiltinPayloadMatch(tool, toolToRemove)) return true
+                removed = true
+                return false
+            })
+            if (removed) setTools(updated)
+        },
+        [tools, setTools],
+    )
+
+    const selectedToolNames = useMemo(
+        () => new Set(tools.map(toolName).filter((n): n is string => Boolean(n))),
+        [tools],
+    )
+
+    // Workflows not yet referenced as a tool — the pool the selector drawer offers.
+    const referenceableWorkflows = useMemo(() => {
+        const referenced = new Set(
+            tools.map((t) => toolReferenceSlug(t)).filter((s): s is string => Boolean(s)),
+        )
+        return (workflowReference?.workflows ?? []).filter((w) => !referenced.has(w.slug))
+    }, [tools, workflowReference])
+
+    return {
+        tools,
+        handleAddTool,
+        handleAddWorkflowReference,
+        handleRemoveToolByName,
+        handleRemoveBuiltinTool,
+        selectedToolNames,
+        referenceableWorkflows,
+    }
+}

--- a/web/packages/agenta-entity-ui/src/DrillInView/SchemaControls/agentTemplate/useAgentTools.ts
+++ b/web/packages/agenta-entity-ui/src/DrillInView/SchemaControls/agentTemplate/useAgentTools.ts
@@ -1,10 +1,7 @@
 /**
- * Tool-list management for the agent-template Tools section. The `tools` array mixes four kinds that
- * each add differently: inline function tools (edited in a create drawer before they land), builtin
- * and gateway tools (arrive complete, added straight away), and `type:"reference"` workflow tools
- * (#4860, whose input schema is derived asynchronously from the workflow's latest revision). This
- * hook owns that logic plus the derived sets the Tools section needs, so the orchestrator only wires
- * the handlers into the picker and renders.
+ * Tool-list management for the Tools section. The `tools` array mixes inline function, builtin,
+ * gateway, and `type:"reference"` workflow tools (#4860; the last derives its input schema async).
+ * This hook owns those add/remove flows plus the derived sets the section needs.
  */
 import {useCallback, useMemo, type MutableRefObject} from "react"
 

--- a/web/packages/agenta-entity-ui/src/DrillInView/SchemaControls/agentTemplate/useConfigItemDrawer.ts
+++ b/web/packages/agenta-entity-ui/src/DrillInView/SchemaControls/agentTemplate/useConfigItemDrawer.ts
@@ -1,9 +1,6 @@
 /**
- * The shared draft-then-save state machine for the agent-template list sections (tools / MCP /
- * skills). Edits happen on a local `draft`; they only apply to the config on Save, so creating an
- * item never pollutes the config until confirmed and editing can be cancelled cleanly. Which config
- * array a kind writes to, and what counts as a valid draft, come from {@link ITEM_KINDS} — so all
- * three kinds run through one path instead of three copies.
+ * Shared draft-then-save state machine for the tool / MCP / skill sections. Edits live on a local
+ * `draft` and apply only on Save; the target array and draft validity come from {@link ITEM_KINDS}.
  */
 import {useCallback, useEffect, useMemo, useState} from "react"
 

--- a/web/packages/agenta-entity-ui/src/DrillInView/SchemaControls/agentTemplate/useConfigItemDrawer.ts
+++ b/web/packages/agenta-entity-ui/src/DrillInView/SchemaControls/agentTemplate/useConfigItemDrawer.ts
@@ -1,0 +1,104 @@
+/**
+ * The shared draft-then-save state machine for the agent-template list sections (tools / MCP /
+ * skills). Edits happen on a local `draft`; they only apply to the config on Save, so creating an
+ * item never pollutes the config until confirmed and editing can be cancelled cleanly. Which config
+ * array a kind writes to, and what counts as a valid draft, come from {@link ITEM_KINDS} — so all
+ * three kinds run through one path instead of three copies.
+ */
+import {useCallback, useEffect, useMemo, useState} from "react"
+
+import type {ConfigItemView} from "../ConfigItemDrawer"
+
+import {cloneItem} from "./agentTemplateUtils"
+import {ITEM_KINDS, type ItemKind, type ItemKindDef} from "./itemKinds"
+
+export interface EditingState {
+    kind: ItemKind
+    mode: "create" | "edit"
+    index: number
+}
+
+export function useConfigItemDrawer({
+    config,
+    onChange,
+}: {
+    config: Record<string, unknown>
+    onChange: (next: Record<string, unknown>) => void
+}) {
+    const [editing, setEditing] = useState<EditingState | null>(null)
+    const [draft, setDraft] = useState<Record<string, unknown>>({})
+    const [drawerView, setDrawerView] = useState<ConfigItemView>("form")
+    // JSON-view parse validity from the open drawer's JsonObjectEditor; blocks Save while the raw
+    // JSON is invalid. Reset when the open item changes — each editor is keyed/remounts and starts
+    // valid.
+    const [jsonInvalid, setJsonInvalid] = useState(false)
+    useEffect(() => {
+        setJsonInvalid(false)
+    }, [editing])
+
+    const openCreate = useCallback(
+        (kind: ItemKind, seed: Record<string, unknown>, view: ConfigItemView) => {
+            setDraft(seed)
+            setDrawerView(view)
+            setEditing({kind, mode: "create", index: -1})
+        },
+        [],
+    )
+    const openEdit = useCallback(
+        (kind: ItemKind, index: number, item: unknown, view: ConfigItemView) => {
+            setDraft(cloneItem(item))
+            setDrawerView(view)
+            setEditing({kind, mode: "edit", index})
+        },
+        [],
+    )
+    const closeEditor = useCallback(() => setEditing(null), [])
+
+    const fieldArray = useCallback(
+        (field: ItemKindDef["field"]): unknown[] =>
+            Array.isArray(config[field]) ? (config[field] as unknown[]) : [],
+        [config],
+    )
+
+    // Apply the drawer's draft to the config: append (create) or replace at index (edit).
+    const commitDraft = useCallback(() => {
+        if (!editing) return
+        const {field} = ITEM_KINDS[editing.kind]
+        const next = [...fieldArray(field)]
+        if (editing.mode === "create") next.push(draft)
+        else next[editing.index] = draft
+        onChange({...config, [field]: next})
+        setEditing(null)
+    }, [editing, draft, config, onChange, fieldArray])
+
+    /** Drop one item by index from its kind's array. */
+    const removeItem = useCallback(
+        (kind: ItemKind, index: number) => {
+            const {field} = ITEM_KINDS[kind]
+            onChange({...config, [field]: fieldArray(field).filter((_, i) => i !== index)})
+        },
+        [config, onChange, fieldArray],
+    )
+
+    // Block Save until the draft has the minimum it needs to be a valid item.
+    const draftInvalid = useMemo(
+        () => (editing ? ITEM_KINDS[editing.kind].draftInvalid(draft) : true),
+        [editing, draft],
+    )
+
+    return {
+        editing,
+        draft,
+        setDraft,
+        drawerView,
+        setDrawerView,
+        jsonInvalid,
+        setJsonInvalid,
+        openCreate,
+        openEdit,
+        closeEditor,
+        commitDraft,
+        removeItem,
+        draftInvalid,
+    }
+}

--- a/web/packages/agenta-entity-ui/src/DrillInView/SchemaControls/agentTemplate/useModelHarness.tsx
+++ b/web/packages/agenta-entity-ui/src/DrillInView/SchemaControls/agentTemplate/useModelHarness.tsx
@@ -1,13 +1,6 @@
 /**
- * useModelHarness
- *
- * Owns the agent template's Model & harness + Advanced concern — the most stateful part of the
- * config panel — and returns the section summaries and (drawer + tabs-inline) bodies the orchestrator
- * places. It lives together because the model/connection state feeds BOTH sections: the harness cards
- * + model picker + compatibility panel on one side, and the Advanced "Authentication" controls on the
- * other (auth mode, the connection picker, and the raw-JSON escape hatch all edit `agent.llm`).
- *
- * Pulled out of AgentTemplateControl verbatim — same hooks, same render order, same dependencies.
+ * useModelHarness — the Model & harness + Advanced sections (the panel's most stateful part). One
+ * hook because the model/connection state feeds both; returns each section's summary + bodies.
  */
 import {useCallback, useEffect, useMemo, useState} from "react"
 
@@ -175,15 +168,12 @@ export function useModelHarness({
         [setAgentField, modelId, connection, llm, capabilities, harnessValue],
     )
 
-    // NB: we deliberately do NOT clear the model when switching to a harness that can't reach it
-    // (Arda's call). The model is kept and the compatibility panel flags it as not reachable so the
-    // user can pick a new one — keeping their choice over silently wiping it. (Save can persist an
-    // unreachable model that errors at run time; that's the accepted trade-off.)
+    // Model is deliberately NOT cleared on a harness switch that can't reach it: the compatibility
+    // panel flags it instead, so the user's choice survives (Arda's call; may error at run time).
 
-    // Reset a connection mode the new harness no longer allows. Guarded on a non-empty
-    // option set so a harness that publishes no modes stays permissive (and we never loop).
-    // Slug validity is intentionally NOT normalized here: connectionOptions is vault-secret
-    // async, so an empty set during load would wrongly clear a valid slug.
+    // Reset a connection mode the new harness disallows; guarded on a non-empty option set so a
+    // harness publishing no modes stays permissive. Slug is NOT normalized here (connectionOptions
+    // is vault-async; an empty set mid-load would wrongly clear a valid slug).
     useEffect(() => {
         if (modeOptions.length > 0 && !modeOptions.includes(connection.mode)) {
             writeModel({mode: modeOptions[0], slug: null})
@@ -320,16 +310,10 @@ export function useModelHarness({
         </div>
     )
 
-    // Harness list + per-harness detail come from the inspect capabilities map. Compatibility is
-    // real (provider/model reachability + connection mode), all derived from that same data.
-    //
-    // GAP (intentional, tracked): `harness_capabilities` only covers providers / connection modes /
-    // models / hosting — NOT which tools, skills, or MCP servers a harness supports. So the
-    // compatibility panel and the per-card keeps/clears status reason only about the MODEL + auth,
-    // never about tools/skills/MCP. Switching harness can silently leave unsupported tools, and we
-    // don't warn/gate them. When the backend extends harness_capabilities with tool/skill/MCP
-    // support, extend the compatibility panel to warn (and optionally lock those sections), mirroring
-    // the model warning. See docs/design/agent-config-section-drawers/design.md ("Known gap").
+    // Harness list + compatibility (provider/model reachability + connection mode) derive from the
+    // inspect capabilities map. GAP (tracked): harness_capabilities covers model/provider/mode/hosting
+    // only — NOT tools/skills/MCP — so switching harness can silently leave unsupported tools
+    // unwarned. Extend the panel when the backend adds that. See design.md ("Known gap").
     const harnessList = capabilities ? Object.keys(capabilities) : []
     const modelReachable =
         !modelId ||
@@ -647,8 +631,7 @@ export function useModelHarness({
                 </LabeledField>
             )}
 
-            {/* Raw-JSON escape hatch for the whole `agent.llm` value (model + connection),
-                collapsed by default. */}
+            {/* Raw-JSON escape hatch for the whole `agent.llm` value, collapsed by default. */}
             <div className="flex items-center gap-2">
                 <Switch
                     checked={showModelJson}
@@ -677,12 +660,10 @@ export function useModelHarness({
             .filter(Boolean)
             .join(" · ") || undefined
 
-    // Advanced drawer body — two panels (consistent with Model & harness): grouped, explained
-    // settings on the left; version history on the right. Authentication moved here.
+    // Advanced drawer body: two panels like Model & harness (settings left, version history right).
     const hasExecutionGroup = Boolean(sandboxProps.kind || sandboxProps.permissions)
     const hasPermissionsGroup = Boolean(headlessSchema || hasClaudePermissions)
-    // Shared Advanced controls (Authentication / Execution / Permissions groups), rendered by
-    // both the wide drawer body (with the version-history side panel) and the tabs-inline body.
+    // Shared Advanced controls, rendered by both the wide drawer body and the tabs-inline body.
     const advancedControls = (
         <>
             {authControls ? (

--- a/web/packages/agenta-entity-ui/src/DrillInView/SchemaControls/agentTemplate/useModelHarness.tsx
+++ b/web/packages/agenta-entity-ui/src/DrillInView/SchemaControls/agentTemplate/useModelHarness.tsx
@@ -1,0 +1,815 @@
+/**
+ * useModelHarness
+ *
+ * Owns the agent template's Model & harness + Advanced concern — the most stateful part of the
+ * config panel — and returns the section summaries and (drawer + tabs-inline) bodies the orchestrator
+ * places. It lives together because the model/connection state feeds BOTH sections: the harness cards
+ * + model picker + compatibility panel on one side, and the Advanced "Authentication" controls on the
+ * other (auth mode, the connection picker, and the raw-JSON escape hatch all edit `agent.llm`).
+ *
+ * Pulled out of AgentTemplateControl verbatim — same hooks, same render order, same dependencies.
+ */
+import {useCallback, useEffect, useMemo, useState} from "react"
+
+import {vaultSecretsQueryAtom} from "@agenta/entities/secret"
+import type {SchemaProperty} from "@agenta/entities/shared"
+import {harnessCapabilitiesAtomFamily} from "@agenta/entities/workflow"
+import {LabeledField} from "@agenta/ui/components/presentational"
+import {SelectLLMProviderBase} from "@agenta/ui/select-llm-provider"
+import {cn} from "@agenta/ui/styles"
+import {Check, Cube, EyeSlash, Key, Lightbulb, ShieldCheck, Warning} from "@phosphor-icons/react"
+import {Select, Switch, Typography} from "antd"
+import {useAtomValue} from "jotai"
+
+import {ClaudePermissionsControl} from "../ClaudePermissionsControl"
+import {CodeEditor} from "../CodeEditor"
+import {
+    allowedConnectionModes,
+    buildModelOptionGroups,
+    composeModelValue,
+    connectionFromConfig,
+    harnessAllowsModel,
+    modelIdFromConfig,
+    namedConnectionOptions,
+    providerForModel,
+    type ConnectionMode,
+    type VaultConnectionEntry,
+} from "../connectionUtils"
+import {EnumSelectControl} from "../EnumSelectControl"
+import {GroupedChoiceControl} from "../GroupedChoiceControl"
+import {HarnessSelectControl} from "../HarnessSelectControl"
+import {SandboxPermissionControl} from "../SandboxPermissionControl"
+
+import {enumLabel} from "./agentTemplateUtils"
+
+export function useModelHarness({
+    schema,
+    config,
+    onChange,
+    revisionId,
+    disabled,
+    withTooltip,
+}: {
+    schema?: SchemaProperty | null
+    config: Record<string, unknown>
+    onChange: (next: Record<string, unknown>) => void
+    revisionId: string | null
+    disabled?: boolean
+    withTooltip?: boolean
+}) {
+    const props = (schema?.properties ?? {}) as Record<string, SchemaProperty>
+    const subProps = useCallback(
+        (section: string): Record<string, SchemaProperty> =>
+            (props[section]?.properties as Record<string, SchemaProperty>) ?? {},
+        [props],
+    )
+    const harnessProps = subProps("harness")
+    const runnerProps = subProps("runner")
+    const sandboxProps = subProps("sandbox")
+
+    const asObject = useCallback(
+        (key: string): Record<string, unknown> =>
+            config[key] && typeof config[key] === "object" && !Array.isArray(config[key])
+                ? (config[key] as Record<string, unknown>)
+                : {},
+        [config],
+    )
+    const harness = asObject("harness")
+    const runner = asObject("runner")
+    const sandbox = asObject("sandbox")
+
+    // The runner's headless interaction default (was the flat `permission_policy`).
+    const runnerInteractions =
+        runner.interactions && typeof runner.interactions === "object"
+            ? (runner.interactions as Record<string, unknown>)
+            : {}
+    const headlessValue = (runnerInteractions.headless as string | null | undefined) ?? null
+    const headlessSchema = (
+        runnerProps.interactions?.properties as Record<string, SchemaProperty> | undefined
+    )?.headless
+
+    // Replace one nested execution section (harness / runner / sandbox), leaving the rest intact.
+    const setSection = useCallback(
+        (key: string, sectionValue: unknown) => onChange({...config, [key]: sectionValue}),
+        [config, onChange],
+    )
+    // Set one flat field of the agent definition (here only `llm`).
+    const setAgentField = useCallback(
+        (key: string, fieldValue: unknown) => onChange({...config, [key]: fieldValue}),
+        [config, onChange],
+    )
+
+    // Model + credential connection (`llm`). It is ALWAYS a structured object (the harness-filtered
+    // picker only ever produces one); a legacy bare string is read for display. composeModelValue
+    // carries through extra keys (e.g. `extras`) so a form edit never silently drops them. The picker
+    // is harness-filtered: selecting a model sets BOTH the model id and its provider, fed by the
+    // `/inspect` capability map below.
+    const harnessValue = typeof harness.kind === "string" ? (harness.kind as string) : null
+    // Pi (`pi_core`/`pi_agenta`) never gates tool use (`permissions: false`); a permission
+    // policy is meaningless for it, so the field is hidden for Pi. Only Claude honors it.
+    const isPiHarness = harnessValue === "pi_core" || harnessValue === "pi_agenta"
+    const llm = config.llm
+    const modelId = useMemo(() => modelIdFromConfig(llm), [llm])
+    const connection = useMemo(() => connectionFromConfig(llm), [llm])
+
+    // Per-harness capability map from the `/inspect` response meta, keyed by the open revision.
+    // Null when inspect hasn't resolved or the agent didn't publish it (older agents / standalone),
+    // in which case the connectionUtils helpers fall back permissively.
+    const capabilities = useAtomValue(
+        useMemo(() => harnessCapabilitiesAtomFamily(revisionId ?? ""), [revisionId]),
+    )
+
+    // The project's stored connections (read-only) for the connection picker. The transformed vault
+    // list surfaces custom-provider connections as {type, name, provider}; the resolver matches a
+    // named connection by that name (the slug).
+    const vaultQuery = useAtomValue(vaultSecretsQueryAtom)
+    const vaultSecrets = useMemo(
+        () => (Array.isArray(vaultQuery.data) ? (vaultQuery.data as VaultConnectionEntry[]) : []),
+        [vaultQuery.data],
+    )
+
+    const modeOptions = useMemo(
+        () => allowedConnectionModes(capabilities, harnessValue),
+        [capabilities, harnessValue],
+    )
+
+    // Harness-filtered model options, built straight from inspect meta. Empty when the harness
+    // publishes none (older agent / standalone) — fall back to the schema's full catalog picker.
+    const modelGroups = useMemo(
+        () => buildModelOptionGroups(capabilities, harnessValue),
+        [capabilities, harnessValue],
+    )
+    const hasInspectModels = modelGroups.length > 0
+
+    // Compose the new `config.llm` ModelRef from the current fields, overriding some. Picking a
+    // model derives its provider from the harness's published groups (sets both).
+    const writeModel = useCallback(
+        (patch: {
+            modelId?: string | null
+            provider?: string | null
+            mode?: ConnectionMode
+            slug?: string | null
+        }) => {
+            const nextModelId = patch.modelId !== undefined ? patch.modelId : modelId
+            // When the model changes, derive the provider from the picked model; otherwise keep it.
+            let nextProvider: string | null
+            if (patch.provider !== undefined) {
+                nextProvider = patch.provider
+            } else if (patch.modelId !== undefined) {
+                nextProvider =
+                    providerForModel(capabilities, harnessValue, nextModelId) ?? connection.provider
+            } else {
+                nextProvider = connection.provider
+            }
+            setAgentField(
+                "llm",
+                composeModelValue({
+                    modelId: nextModelId,
+                    provider: nextProvider,
+                    mode: patch.mode !== undefined ? patch.mode : connection.mode,
+                    slug: patch.slug !== undefined ? patch.slug : connection.slug,
+                    existing: llm,
+                }),
+            )
+        },
+        [setAgentField, modelId, connection, llm, capabilities, harnessValue],
+    )
+
+    // NB: we deliberately do NOT clear the model when switching to a harness that can't reach it
+    // (Arda's call). The model is kept and the compatibility panel flags it as not reachable so the
+    // user can pick a new one — keeping their choice over silently wiping it. (Save can persist an
+    // unreachable model that errors at run time; that's the accepted trade-off.)
+
+    // Reset a connection mode the new harness no longer allows. Guarded on a non-empty
+    // option set so a harness that publishes no modes stays permissive (and we never loop).
+    // Slug validity is intentionally NOT normalized here: connectionOptions is vault-secret
+    // async, so an empty set during load would wrongly clear a valid slug.
+    useEffect(() => {
+        if (modeOptions.length > 0 && !modeOptions.includes(connection.mode)) {
+            writeModel({mode: modeOptions[0], slug: null})
+        }
+    }, [connection.mode, modeOptions, writeModel])
+
+    // Named connections selectable for the chosen provider under this harness (Agenta-managed).
+    const connectionOptions = useMemo(
+        () => namedConnectionOptions(vaultSecrets, capabilities, harnessValue, connection.provider),
+        [vaultSecrets, capabilities, harnessValue, connection.provider],
+    )
+
+    // Raw-JSON escape hatch for the whole `agent.llm` value (collapsed by default).
+    const [showModelJson, setShowModelJson] = useState(false)
+    const [modelJsonText, setModelJsonText] = useState(() => JSON.stringify(llm ?? "", null, 2))
+    const handleModelJsonChange = useCallback(
+        (text: string) => {
+            setModelJsonText(text)
+            try {
+                setAgentField("llm", text ? JSON.parse(text) : "")
+            } catch {
+                // Keep the invalid text in the editor; don't propagate until it parses.
+            }
+        },
+        [setAgentField],
+    )
+    const handleToggleModelJson = useCallback(
+        (next: boolean) => {
+            if (next) setModelJsonText(JSON.stringify(llm ?? "", null, 2))
+            setShowModelJson(next)
+        },
+        [llm],
+    )
+    // Keep the open JSON buffer in sync when `agent.llm` changes from OUTSIDE the editor
+    // (the model picker or the authentication cards). Guard with a structural compare so we
+    // only resync on external changes — when the buffer already represents `agent.llm`
+    // (the user is typing here) we skip, so we never reformat mid-edit or fight the cursor.
+    useEffect(() => {
+        if (!showModelJson) return
+        let bufferValue: unknown
+        try {
+            bufferValue = modelJsonText ? JSON.parse(modelJsonText) : ""
+        } catch {
+            return // invalid in-progress JSON — leave the user's text untouched
+        }
+        if (JSON.stringify(bufferValue) !== JSON.stringify(llm ?? "")) {
+            setModelJsonText(JSON.stringify(llm ?? "", null, 2))
+        }
+    }, [llm, showModelJson, modelJsonText])
+
+    // Claude permissions (Layer 1, Claude-only): the Claude harness's own permission knobs, the
+    // first-class `harness.permissions` slice. Shown in Advanced only for the Claude harness.
+    const claudePermissions = useMemo(() => {
+        const perms = harness.permissions
+        return perms && typeof perms === "object" ? (perms as Record<string, unknown>) : null
+    }, [harness])
+    const setClaudePermissions = useCallback(
+        (next: Record<string, unknown>) => setSection("harness", {...harness, permissions: next}),
+        [harness, setSection],
+    )
+
+    const modelSummary =
+        [enumLabel(harnessProps.kind, harness.kind), enumLabel(props.llm, modelId)]
+            .filter(Boolean)
+            .join(" · ") || undefined
+
+    const hasModelOrHarness = Boolean(props.llm || harnessProps.kind)
+    const hasClaudePermissions = harnessValue === "claude"
+    const hasAdvanced = Boolean(
+        props.llm || // Authentication lives in Advanced now
+        sandboxProps.kind ||
+        sandboxProps.permissions ||
+        runnerProps.interactions ||
+        hasClaudePermissions,
+    )
+
+    // The Model picker (inspect-filtered when available, else the schema catalog).
+    const modelPicker = props.llm ? (
+        hasInspectModels ? (
+            <LabeledField
+                label="Model"
+                description="Filtered to the models this harness can reach. Selecting a model also sets its provider."
+                withTooltip={withTooltip}
+            >
+                <SelectLLMProviderBase
+                    showGroup
+                    options={modelGroups}
+                    value={modelId ?? undefined}
+                    onChange={(v) => writeModel({modelId: (v as string) ?? null})}
+                    disabled={disabled}
+                    placeholder="Select a model…"
+                    className="w-full"
+                />
+            </LabeledField>
+        ) : (
+            <GroupedChoiceControl
+                schema={
+                    (props.llm?.properties as Record<string, SchemaProperty> | undefined)?.model ??
+                    props.llm
+                }
+                label="Model"
+                value={modelId}
+                onChange={(v) => writeModel({modelId: v})}
+                withTooltip={withTooltip}
+                disabled={disabled}
+            />
+        )
+    ) : null
+
+    // Shared version-history placeholder for the section drawers (real revision diffs are deferred).
+    const versionHistorySkeleton = (
+        <div>
+            <div className="mb-2 flex items-center gap-1.5">
+                <span className="text-[11px] uppercase tracking-wide text-[var(--ag-c-97A4B0,#97a4b0)]">
+                    Version history
+                </span>
+                <span className="rounded-full border border-solid border-[var(--ag-c-EAEFF5,#eaeff5)] px-1.5 text-[10px] text-[var(--ag-c-97A4B0,#97a4b0)]">
+                    soon
+                </span>
+            </div>
+            <div className="flex flex-col gap-2.5 opacity-50">
+                {["w-[42%]", "w-[32%]", "w-[38%]"].map((widthClass, i) => (
+                    <div key={i} className="flex items-center gap-2">
+                        <span className="h-1.5 w-1.5 shrink-0 rounded-full bg-[var(--ag-c-EAEFF5,#eaeff5)]" />
+                        <span
+                            className={cn(
+                                "h-2 rounded bg-[var(--ag-c-EAEFF5,#eaeff5)]",
+                                widthClass,
+                            )}
+                        />
+                    </div>
+                ))}
+            </div>
+        </div>
+    )
+
+    // Harness list + per-harness detail come from the inspect capabilities map. Compatibility is
+    // real (provider/model reachability + connection mode), all derived from that same data.
+    //
+    // GAP (intentional, tracked): `harness_capabilities` only covers providers / connection modes /
+    // models / hosting — NOT which tools, skills, or MCP servers a harness supports. So the
+    // compatibility panel and the per-card keeps/clears status reason only about the MODEL + auth,
+    // never about tools/skills/MCP. Switching harness can silently leave unsupported tools, and we
+    // don't warn/gate them. When the backend extends harness_capabilities with tool/skill/MCP
+    // support, extend the compatibility panel to warn (and optionally lock those sections), mirroring
+    // the model warning. See docs/design/agent-config-section-drawers/design.md ("Known gap").
+    const harnessList = capabilities ? Object.keys(capabilities) : []
+    const modelReachable =
+        !modelId ||
+        !capabilities ||
+        !harnessValue ||
+        harnessAllowsModel(capabilities, harnessValue, modelId)
+    const authSupported = modeOptions.length === 0 || modeOptions.includes(connection.mode)
+
+    const harnessCards = (
+        <div className="flex flex-col gap-2">
+            {harnessList.map((h) => {
+                const caps = capabilities?.[h]
+                const selected = harnessValue === h
+                const providers = caps?.providers ?? []
+                const deployments = caps?.deployments ?? []
+                const modelCount = caps
+                    ? Object.values(caps.models ?? {}).reduce(
+                          (n, arr) => n + (Array.isArray(arr) ? arr.length : 0),
+                          0,
+                      )
+                    : 0
+                const keepsModel = !modelId || harnessAllowsModel(capabilities, h, modelId)
+                return (
+                    <button
+                        key={h}
+                        type="button"
+                        disabled={disabled}
+                        onClick={() => setSection("harness", {...harness, kind: h})}
+                        className={cn(
+                            "flex w-full flex-col gap-1.5 rounded-lg border border-solid p-2.5 text-left transition-colors",
+                            disabled ? "cursor-not-allowed opacity-60" : "cursor-pointer",
+                            selected
+                                ? "border-[var(--ant-color-primary)] bg-[var(--ant-color-fill-secondary)]"
+                                : "border-[var(--ant-color-border)] bg-[var(--ant-color-fill-quaternary)] hover:border-[var(--ant-color-text-quaternary)] hover:bg-[var(--ant-color-fill-tertiary)]",
+                        )}
+                    >
+                        <div className="flex items-center gap-2">
+                            <span
+                                className={cn(
+                                    "flex h-3.5 w-3.5 shrink-0 items-center justify-center rounded-full border border-solid",
+                                    selected
+                                        ? "border-[var(--ant-color-primary)]"
+                                        : "border-[var(--ag-c-97A4B0,#97a4b0)]",
+                                )}
+                            >
+                                {selected && (
+                                    <span className="h-1.5 w-1.5 rounded-full bg-[var(--ant-color-primary)]" />
+                                )}
+                            </span>
+                            <span className="text-xs font-medium">
+                                {enumLabel(harnessProps.kind, h) || h}
+                            </span>
+                            {selected ? (
+                                <span className="ml-auto rounded-full bg-[var(--ant-color-fill-secondary)] px-2 text-[10px] text-[var(--ant-color-primary-text)]">
+                                    Current
+                                </span>
+                            ) : modelId ? (
+                                <span
+                                    className={cn(
+                                        "ml-auto inline-flex items-center gap-1 text-[10.5px]",
+                                        keepsModel
+                                            ? "text-[var(--ant-color-success)]"
+                                            : "text-[var(--ant-color-warning)]",
+                                    )}
+                                >
+                                    {keepsModel ? <Check size={11} /> : <Warning size={11} />}
+                                    {keepsModel ? "supports your model" : "model not available"}
+                                </span>
+                            ) : null}
+                        </div>
+                        {providers.length > 0 || modelCount > 0 ? (
+                            <div className="pl-[22px] text-[11px] text-[var(--ag-c-97A4B0,#97a4b0)]">
+                                {providers.slice(0, 4).join(", ")}
+                                {providers.length > 4 ? ` +${providers.length - 4}` : ""}
+                                {modelCount ? ` · ${modelCount} models` : ""}
+                            </div>
+                        ) : null}
+                        {deployments.length > 0 ? (
+                            <div className="pl-[22px] text-[11px] text-[var(--ag-c-97A4B0,#97a4b0)]">
+                                Hosting: {deployments.join(" · ")}
+                            </div>
+                        ) : null}
+                    </button>
+                )
+            })}
+        </div>
+    )
+
+    const compatibilityPanel =
+        capabilities && harnessValue ? (
+            <div className="flex flex-col gap-4">
+                <div>
+                    <div className="mb-2 text-[11px] uppercase tracking-wide text-[var(--ag-c-97A4B0,#97a4b0)]">
+                        Current setup
+                    </div>
+                    <div className="flex flex-col gap-2 text-xs">
+                        {modelId ? (
+                            <div
+                                className={cn(
+                                    "flex items-start gap-1.5",
+                                    modelReachable
+                                        ? "text-[var(--ant-color-success)]"
+                                        : "text-[var(--ant-color-warning)]",
+                                )}
+                            >
+                                {modelReachable ? (
+                                    <Check size={14} className="mt-px shrink-0" />
+                                ) : (
+                                    <Warning size={14} className="mt-px shrink-0" />
+                                )}
+                                <span>
+                                    <span className="font-mono">{modelId}</span>{" "}
+                                    {modelReachable ? "is reachable." : "is not reachable here."}
+                                </span>
+                            </div>
+                        ) : (
+                            <span className="text-[var(--ag-c-97A4B0,#97a4b0)]">
+                                No model selected.
+                            </span>
+                        )}
+                        {props.llm ? (
+                            <div
+                                className={cn(
+                                    "flex items-start gap-1.5",
+                                    authSupported
+                                        ? "text-[var(--ant-color-success)]"
+                                        : "text-[var(--ant-color-warning)]",
+                                )}
+                            >
+                                {authSupported ? (
+                                    <Check size={14} className="mt-px shrink-0" />
+                                ) : (
+                                    <Warning size={14} className="mt-px shrink-0" />
+                                )}
+                                <span>
+                                    {connection.mode === "agenta"
+                                        ? "Agenta-managed"
+                                        : "Self-managed"}{" "}
+                                    auth{" "}
+                                    {authSupported ? "is supported." : "is not supported here."}
+                                </span>
+                            </div>
+                        ) : null}
+                    </div>
+                </div>
+
+                {modelId && harnessList.some((h) => h !== harnessValue) ? (
+                    <div>
+                        <div className="mb-2 text-[11px] uppercase tracking-wide text-[var(--ag-c-97A4B0,#97a4b0)]">
+                            If you switch
+                        </div>
+                        <div className="flex flex-col gap-2 text-xs">
+                            {harnessList
+                                .filter((h) => h !== harnessValue)
+                                .map((h) => {
+                                    const keeps = harnessAllowsModel(capabilities, h, modelId)
+                                    return (
+                                        <div key={h} className="flex items-start gap-1.5">
+                                            {keeps ? (
+                                                <Check
+                                                    size={14}
+                                                    className="mt-px shrink-0 text-[var(--ant-color-success)]"
+                                                />
+                                            ) : (
+                                                <Warning
+                                                    size={14}
+                                                    className="mt-px shrink-0 text-[var(--ant-color-warning)]"
+                                                />
+                                            )}
+                                            <span className="text-[var(--ag-c-586673,#586673)]">
+                                                <span className="text-[var(--ag-c-1C2C3D,#1c2c3d)]">
+                                                    {enumLabel(harnessProps.kind, h) || h}
+                                                </span>{" "}
+                                                {keeps
+                                                    ? "supports your model."
+                                                    : "doesn't support your model — pick a new one."}
+                                            </span>
+                                        </div>
+                                    )
+                                })}
+                        </div>
+                    </div>
+                ) : null}
+
+                {versionHistorySkeleton}
+            </div>
+        ) : null
+
+    // Model & harness drawer body. With inspect capabilities: harness cards + model picker on the
+    // left, a real compatibility panel on the right. Without them: the plain harness select.
+    // Shared Model & harness controls — rendered by both the wide drawer body (with the
+    // compatibility side panel) and the trimmed tabs-inline body (single column, no chrome).
+    const modelHarnessControls = capabilities ? (
+        <>
+            <div className="flex gap-2 rounded-md bg-[var(--ant-color-fill-quaternary)] p-2.5">
+                <Lightbulb size={15} className="mt-px shrink-0 text-[var(--ag-c-586673,#586673)]" />
+                <span className="text-[11.5px] leading-snug text-[var(--ag-c-586673,#586673)]">
+                    The harness is the runtime that executes your agent. It decides which providers,
+                    hosting and connection options you can use.
+                </span>
+            </div>
+            <div>
+                <div className="mb-2 text-[11px] uppercase tracking-wide text-[var(--ag-c-97A4B0,#97a4b0)]">
+                    Harness
+                </div>
+                {harnessCards}
+            </div>
+            {modelPicker}
+        </>
+    ) : (
+        <>
+            {harnessProps.kind && (
+                <HarnessSelectControl
+                    schema={harnessProps.kind}
+                    label="Harness"
+                    value={(harness.kind as string | null) ?? null}
+                    onChange={(v) => setSection("harness", {...harness, kind: v})}
+                    withTooltip={withTooltip}
+                    disabled={disabled}
+                />
+            )}
+            {modelPicker}
+        </>
+    )
+
+    const modelHarnessDrawerBody = capabilities ? (
+        <div className="flex h-full min-h-0 gap-6">
+            <div className="flex min-w-0 flex-1 flex-col gap-4 overflow-y-auto pr-1">
+                {modelHarnessControls}
+            </div>
+            <div className="w-[240px] shrink-0 overflow-y-auto">{compatibilityPanel}</div>
+        </div>
+    ) : (
+        <div className="flex h-full flex-col gap-3 overflow-y-auto">{modelHarnessControls}</div>
+    )
+
+    // Trimmed body for the tabs layout: the same controls in one column, without the drawer's
+    // two-panel split or side panel (which read as out-of-place chrome inside a tab).
+    const modelHarnessInline = <div className="flex flex-col gap-4">{modelHarnessControls}</div>
+
+    // Authentication (credential source) — moved out of Model & harness into Advanced.
+    const authControls = props.llm ? (
+        <div className="flex flex-col gap-2">
+            {modeOptions.map((m) => {
+                const selected = connection.mode === m
+                const title = m === "agenta" ? "Agenta-managed" : "Self-managed"
+                const desc =
+                    m === "agenta"
+                        ? "Agenta supplies the credential from this project's vault — the default provider key, or a named connection you pick below."
+                        : "The harness signs in itself (an environment variable or a prior OAuth login). Agenta injects no credential."
+                return (
+                    <button
+                        key={m}
+                        type="button"
+                        role="radio"
+                        aria-checked={selected}
+                        disabled={disabled}
+                        onClick={() => writeModel({mode: m})}
+                        className={cn(
+                            "flex w-full items-start gap-2.5 rounded-lg border border-solid p-2.5 text-left transition-colors",
+                            disabled ? "cursor-not-allowed opacity-60" : "cursor-pointer",
+                            selected
+                                ? "border-[var(--ant-color-primary)] bg-[var(--ant-color-fill-secondary)]"
+                                : "border-[var(--ant-color-border)] bg-[var(--ant-color-fill-quaternary)] hover:border-[var(--ant-color-text-quaternary)] hover:bg-[var(--ant-color-fill-tertiary)]",
+                        )}
+                    >
+                        <span
+                            className={cn(
+                                "mt-0.5 flex h-4 w-4 shrink-0 items-center justify-center rounded-full border border-solid",
+                                selected
+                                    ? "border-[var(--ant-color-primary)]"
+                                    : "border-[var(--ant-color-text-tertiary)]",
+                            )}
+                        >
+                            {selected && (
+                                <span className="h-2 w-2 rounded-full bg-[var(--ant-color-primary)]" />
+                            )}
+                        </span>
+                        <span className="flex flex-col gap-0.5">
+                            <Typography.Text
+                                className={cn(
+                                    "text-xs font-medium leading-none",
+                                    selected && "!text-[var(--ant-color-primary-text)]",
+                                )}
+                            >
+                                {title}
+                            </Typography.Text>
+                            <Typography.Text type="secondary" className="text-[11px] leading-snug">
+                                {desc}
+                            </Typography.Text>
+                        </span>
+                    </button>
+                )
+            })}
+            {connection.mode === "agenta" && (
+                <LabeledField
+                    label="Connection"
+                    description="Which stored connection supplies the credential. Project default uses the project's provider key."
+                    withTooltip={withTooltip}
+                >
+                    <Select<string>
+                        value={connection.slug ?? "__default__"}
+                        onChange={(v) =>
+                            writeModel({slug: v === "__default__" ? null : (v ?? null)})
+                        }
+                        options={[
+                            {value: "__default__", label: "Project default"},
+                            ...connectionOptions.map((o) => ({value: o.value, label: o.label})),
+                        ]}
+                        disabled={disabled}
+                        className="w-full"
+                        showSearch
+                        optionFilterProp="label"
+                    />
+                </LabeledField>
+            )}
+
+            {/* Raw-JSON escape hatch for the whole `agent.llm` value (model + connection),
+                collapsed by default. */}
+            <div className="flex items-center gap-2">
+                <Switch
+                    checked={showModelJson}
+                    onChange={handleToggleModelJson}
+                    disabled={disabled}
+                />
+                <Typography.Text className="text-xs">Edit as JSON</Typography.Text>
+            </div>
+            {showModelJson && (
+                <CodeEditor
+                    value={modelJsonText}
+                    onChange={handleModelJsonChange}
+                    language="json"
+                    disabled={disabled}
+                />
+            )}
+        </div>
+    ) : null
+
+    // Advanced header summary: auth mode + sandbox, so the collapsed header still conveys state.
+    const advancedSummary =
+        [
+            props.llm ? (connection.mode === "agenta" ? "Agenta-managed" : "Self-managed") : null,
+            sandbox.kind ? `Sandbox: ${String(sandbox.kind)}` : null,
+        ]
+            .filter(Boolean)
+            .join(" · ") || undefined
+
+    // Advanced drawer body — two panels (consistent with Model & harness): grouped, explained
+    // settings on the left; version history on the right. Authentication moved here.
+    const hasExecutionGroup = Boolean(sandboxProps.kind || sandboxProps.permissions)
+    const hasPermissionsGroup = Boolean(headlessSchema || hasClaudePermissions)
+    // Shared Advanced controls (Authentication / Execution / Permissions groups), rendered by
+    // both the wide drawer body (with the version-history side panel) and the tabs-inline body.
+    const advancedControls = (
+        <>
+            {authControls ? (
+                <div>
+                    <div className="mb-0.5 flex items-center gap-1.5">
+                        <Key size={15} className="text-[var(--ag-c-586673,#586673)]" />
+                        <span className="text-[13px] font-medium">Authentication</span>
+                    </div>
+                    <p className="mb-2.5 ml-[22px] text-[11.5px] leading-snug text-[var(--ag-c-97A4B0,#97a4b0)]">
+                        Where the model credential comes from when this agent runs.
+                    </p>
+                    <div className="ml-[22px]">{authControls}</div>
+                </div>
+            ) : null}
+
+            {hasExecutionGroup ? (
+                <div className="border-0 border-t border-solid border-[var(--ag-c-EAEFF5,#eaeff5)] pt-4">
+                    <div className="mb-0.5 flex items-center gap-1.5">
+                        <Cube size={15} className="text-[var(--ag-c-586673,#586673)]" />
+                        <span className="text-[13px] font-medium">Execution environment</span>
+                    </div>
+                    <p className="mb-2.5 ml-[22px] text-[11.5px] leading-snug text-[var(--ag-c-97A4B0,#97a4b0)]">
+                        Where the agent&apos;s tools and code run, and what that sandbox may touch.
+                    </p>
+                    <div className="ml-[22px] flex flex-col gap-2.5">
+                        {sandboxProps.kind && (
+                            <EnumSelectControl
+                                schema={sandboxProps.kind}
+                                label="Sandbox"
+                                value={(sandbox.kind as string | null) ?? null}
+                                onChange={(v) => setSection("sandbox", {...sandbox, kind: v})}
+                                withTooltip={withTooltip}
+                                disabled={disabled}
+                            />
+                        )}
+                        {sandboxProps.permissions ? (
+                            <SandboxPermissionControl
+                                value={
+                                    (sandbox.permissions as Record<string, unknown> | null) ?? null
+                                }
+                                onChange={(v) =>
+                                    setSection("sandbox", {...sandbox, permissions: v})
+                                }
+                                disabled={disabled}
+                            />
+                        ) : null}
+                    </div>
+                </div>
+            ) : null}
+
+            {hasPermissionsGroup ? (
+                <div className="border-0 border-t border-solid border-[var(--ag-c-EAEFF5,#eaeff5)] pt-4">
+                    <div className="mb-0.5 flex items-center gap-1.5">
+                        <ShieldCheck size={15} className="text-[var(--ag-c-586673,#586673)]" />
+                        <span className="text-[13px] font-medium">Permissions</span>
+                    </div>
+                    <p className="mb-2.5 ml-[22px] text-[11.5px] leading-snug text-[var(--ag-c-97A4B0,#97a4b0)]">
+                        What the agent may do on its own before it must ask.
+                    </p>
+                    <div className="ml-[22px] flex flex-col gap-2.5">
+                        {headlessSchema ? (
+                            isPiHarness ? (
+                                <div className="flex items-center gap-1.5 text-[11px] text-[var(--ag-c-97A4B0,#97a4b0)]">
+                                    <EyeSlash size={13} />
+                                    Permission policy isn&apos;t used by the Pi harness.
+                                </div>
+                            ) : (
+                                <EnumSelectControl
+                                    schema={headlessSchema}
+                                    label="Permission policy"
+                                    value={headlessValue}
+                                    onChange={(v) =>
+                                        setSection("runner", {
+                                            ...runner,
+                                            interactions: {...runnerInteractions, headless: v},
+                                        })
+                                    }
+                                    withTooltip={withTooltip}
+                                    disabled={disabled}
+                                />
+                            )
+                        ) : null}
+                        {hasClaudePermissions ? (
+                            <div className="flex flex-col gap-1.5">
+                                <div className="flex items-center gap-1.5">
+                                    <Typography.Text className="text-xs font-medium">
+                                        Claude permissions
+                                    </Typography.Text>
+                                    <span className="rounded-full bg-[var(--ant-color-fill-secondary)] px-2 text-[10px] text-[var(--ant-color-primary-text)]">
+                                        Claude harness
+                                    </span>
+                                </div>
+                                <ClaudePermissionsControl
+                                    value={claudePermissions}
+                                    onChange={setClaudePermissions}
+                                    disabled={disabled}
+                                />
+                            </div>
+                        ) : null}
+                    </div>
+                </div>
+            ) : null}
+        </>
+    )
+
+    const advancedDrawerBody = (
+        <div className="flex h-full min-h-0 gap-6">
+            <div className="flex min-w-0 flex-1 flex-col gap-4 overflow-y-auto pr-1">
+                {advancedControls}
+            </div>
+            <div className="w-[240px] shrink-0 overflow-y-auto">{versionHistorySkeleton}</div>
+        </div>
+    )
+
+    // Trimmed body for the tabs layout: the grouped controls in one column, no side panel.
+    const advancedInline = <div className="flex flex-col gap-4">{advancedControls}</div>
+
+    return {
+        hasModelOrHarness,
+        modelSummary,
+        modelHarnessDrawerBody,
+        modelHarnessInline,
+        // The capability-aware (two-panel) drawer is wider than the plain one.
+        modelHarnessDrawerWidth: capabilities ? 880 : 560,
+        hasAdvanced,
+        advancedSummary,
+        advancedDrawerBody,
+        advancedInline,
+    }
+}


### PR DESCRIPTION
## Context

`AgentTemplateControl.tsx` had grown to ~2,070 lines. It held the whole agent-template config panel in one file: the model/connection/harness/sandbox state machine, the tool/MCP/skill list logic, three near-identical item-drawer code paths, the section descriptors, and the render for all three layouts. That made it hard to read and hard to touch without scrolling past unrelated concerns.

This is a behavior-preserving refactor. No feature or UX change. The public `AgentTemplateControl` export is unchanged; only its internals moved into focused modules.

## Changes

Split the orchestrator into a small set of co-located modules under a new `agentTemplate/` folder. The orchestrator now just assembles the schema-gated `sections` array and renders it; everything else lives in a hook or a registry.

**Before:** one 2,070-line file.
**After:** a 580-line orchestrator + 8 focused modules.

| Module | Lines | Responsibility |
|---|---|---|
| `AgentTemplateControl.tsx` | 580 | Orchestrator: assembles sections, renders accordion / tabs / cards + drawers |
| `useModelHarness.tsx` | 815 | Model/connection/harness/sandbox state + the Model & harness and Advanced section bodies |
| `itemDescriptors.tsx` | 291 | Tool/MCP/skill classifiers + describe functions |
| `useAgentTools.ts` | 149 | Tool-list add/remove (function / builtin / gateway / workflow-reference) + derived sets |
| `ItemRow.tsx` | 145 | Presentational rows (avatar, item row, instructions-file row) |
| `itemKinds.tsx` | 137 | `ITEM_KINDS` registry: the per-kind config that collapses 3 near-identical paths into 1 |
| `useConfigItemDrawer.ts` | 104 | Shared draft-then-save state machine for all three list kinds |
| `ConfigItemList.tsx` | 58 | Shared list / empty-state body |
| `agentTemplateUtils.ts` | 32 | Pure helpers (`enumLabel`, `countSummary`, `cloneItem`) |

The two real code-sharing wins: tools, MCP servers, and skills now run through one `ITEM_KINDS` registry and one `useConfigItemDrawer` state machine instead of three copies, and the Model & harness + Advanced sections share one `useModelHarness` hook (their state is coupled, so they belong together).

## Tests / notes

- `@agenta/entity-ui` `types:check` clean; eslint clean across the orchestrator and all `agentTemplate/` files.
- OSS `tsc` holds exactly at the pre-existing baseline (593 errors, unchanged) — no errors leaked into consumers.
- Verified live on the playground against the dev server for this branch. No console errors. Exercised: all sections in the default accordion layout (correct summaries + the AGENTS.md preview row); the Model & harness section drawer (harness cards, model picker, capabilities panel, version-history skeleton); the tool selector popover; the MCP item create drawer (form renders, Create correctly disabled until valid); and both the Tabs and Cards layouts.

## What to QA

- Open an agent variant in the playground. The config panel shows the same sections as before: Model & harness, Instructions, Tools, MCP servers, Skills, Triggers, Advanced, each with its summary.
- Open the Model & harness section. The drawer shows the harness cards, model picker, the right-hand capabilities panel, and version history.
- Add a tool (custom function), an MCP server, and a skill. Each opens its drawer; Save is blocked until the draft is valid; the item appears in the list after Save and can be removed.
- Switch layout from the panel's gear menu between Accordion, Tabs, and Cards. All three render the same sections.
- Regression to watch: the workflow-reference tool flow (add a workflow as a tool) and the instructions-file editor drawer, since both moved.
