### PR TITLE
feat(agent): client-tool round-trip backend (#4920)

### DIFF
--- a/api/oss/src/apis/fastapi/tools/router.py
+++ b/api/oss/src/apis/fastapi/tools/router.py
@@ -1,4 +1,5 @@
 import html as html_lib
+from inspect import isawaitable
 import json
 import re
 from datetime import datetime, timezone
@@ -1323,6 +1324,12 @@ class ToolsRouter:
             else (response.status.message if response.status else None)
         )
 
+        if successful:
+            await _emit_committed_revision_data_event_from_outputs(
+                request=request,
+                outputs=outputs,
+            )
+
         result = ToolResult(
             id=uuid4(),
             data=ToolResultData(
@@ -1337,6 +1344,46 @@ class ToolsRouter:
         )
 
         return ToolCallResponse(call=result)
+
+
+async def _emit_committed_revision_data_event_from_outputs(
+    *,
+    request: Request,
+    outputs: object,
+) -> None:
+    if not isinstance(outputs, dict):
+        return
+
+    data = {
+        "variantId": outputs.get("variantId") or outputs.get("variant_id"),
+        "revisionId": outputs.get("revisionId") or outputs.get("revision_id"),
+        "version": outputs.get("version"),
+    }
+    if not all(data.values()):
+        return
+
+    await _emit_data_event(
+        request=request,
+        name="committed-revision",
+        data=data,
+    )
+
+
+async def _emit_data_event(
+    *,
+    request: Request,
+    name: str,
+    data: dict,
+) -> None:
+    emit = getattr(request.state, "emit", None) or getattr(
+        request.state, "emit_event", None
+    )
+    if not callable(emit):
+        return
+
+    result = emit({"type": "data", "name": name, "data": data})
+    if isawaitable(result):
+        await result
 
 
 # ---------------------------------------------------------------------------

--- a/api/oss/src/apis/fastapi/workflows/router.py
+++ b/api/oss/src/apis/fastapi/workflows/router.py
@@ -1527,6 +1527,11 @@ class WorkflowsRouter:
         # Invalidate legacy caches so the registry page reflects the new revision
         await invalidate_cache(project_id=request.state.project_id)
 
+        await _emit_committed_revision_data_event(
+            request=request,
+            workflow_revision=workflow_revision,
+        )
+
         workflow_revision_response = WorkflowRevisionResponse(
             count=1 if workflow_revision else 0,
             workflow_revision=workflow_revision,

--- a/api/oss/src/apis/fastapi/workflows/router.py
+++ b/api/oss/src/apis/fastapi/workflows/router.py
@@ -1,3 +1,4 @@
+from inspect import isawaitable
 from typing import Optional
 from uuid import UUID, uuid4
 
@@ -1278,6 +1279,11 @@ class WorkflowsRouter:
         # Invalidate legacy caches so the registry page reflects the new revision
         await invalidate_cache(project_id=request.state.project_id)
 
+        await _emit_committed_revision_data_event(
+            request=request,
+            workflow_revision=workflow_revision,
+        )
+
         workflow_revision_response = WorkflowRevisionResponse(
             count=1 if workflow_revision else 0,
             workflow_revision=workflow_revision,
@@ -1902,6 +1908,42 @@ class WorkflowsRouter:
         )
 
         return workflow_revision_resolve_response
+
+
+async def _emit_committed_revision_data_event(
+    *,
+    request: Request,
+    workflow_revision,
+) -> None:
+    if not workflow_revision:
+        return
+
+    await _emit_data_event(
+        request=request,
+        name="committed-revision",
+        data={
+            "variantId": str(workflow_revision.workflow_variant_id),
+            "revisionId": str(workflow_revision.id),
+            "version": workflow_revision.version,
+        },
+    )
+
+
+async def _emit_data_event(
+    *,
+    request: Request,
+    name: str,
+    data: dict,
+) -> None:
+    emit = getattr(request.state, "emit", None) or getattr(
+        request.state, "emit_event", None
+    )
+    if not callable(emit):
+        return
+
+    result = emit({"type": "data", "name": name, "data": data})
+    if isawaitable(result):
+        await result
 
 
 class SimpleWorkflowsRouter:

--- a/api/oss/src/core/workflows/static_catalog.py
+++ b/api/oss/src/core/workflows/static_catalog.py
@@ -21,6 +21,10 @@ from agenta.sdk.agents.adapters.agenta_builtins import (
     GETTING_STARTED_WITH_AGENTA_SKILL,
     GETTING_STARTED_WITH_AGENTA_SLUG,
 )
+from agenta.sdk.agents.platform.workflow import (
+    REQUEST_CONNECTION_TOOL_NAME,
+    REQUEST_CONNECTION_WORKFLOW_SLUG,
+)
 from agenta.sdk.agents.skills.models import SkillTemplate
 from agenta.sdk.engines.running.utils import (
     AGENTA_BUILTIN_SKILL_URI,
@@ -78,12 +82,40 @@ def _skill_revision(skill_template: SkillTemplate) -> WorkflowRevision:
     )
 
 
+def _client_tool_revision() -> WorkflowRevision:
+    return WorkflowRevision(
+        name="Request connection",
+        description="Ask the user to connect an external account.",
+        data=WorkflowRevisionData(
+            uri="client:tool:request_connection:v0",
+            parameters={
+                "tool": {
+                    "kind": "client",
+                    "name": REQUEST_CONNECTION_TOOL_NAME,
+                    "description": "Request a connection from the user.",
+                    "input_schema": {
+                        "type": "object",
+                        "additionalProperties": True,
+                    },
+                    "render": {"kind": "connect"},
+                }
+            },
+        ),
+    )
+
+
 # Each entry: a reserved slug -> {latest: <ver>, versions: {<ver>: WorkflowRevision}}.
 _STATIC_WORKFLOWS: Dict[str, Dict[str, Any]] = {
     GETTING_STARTED_WITH_AGENTA_SLUG: {
         "latest": "v1",
         "versions": {
             "v1": _skill_revision(GETTING_STARTED_WITH_AGENTA_SKILL),
+        },
+    },
+    REQUEST_CONNECTION_WORKFLOW_SLUG: {
+        "latest": "v1",
+        "versions": {
+            "v1": _client_tool_revision(),
         },
     },
 }

--- a/api/oss/src/core/workflows/static_catalog.py
+++ b/api/oss/src/core/workflows/static_catalog.py
@@ -89,8 +89,11 @@ def _client_tool_revision() -> WorkflowRevision:
         data=WorkflowRevisionData(
             uri="client:tool:request_connection:v0",
             parameters={
+                # A tool config (the ``tools`` field holds configs, discriminated by ``type``),
+                # not a resolved spec (``kind``): the embed inlines this at ``parameters.tool`` and
+                # the SDK coerces it to a ``ClientToolConfig`` -> ``ClientToolSpec``.
                 "tool": {
-                    "kind": "client",
+                    "type": "client",
                     "name": REQUEST_CONNECTION_TOOL_NAME,
                     "description": "Request a connection from the user.",
                     "input_schema": {

--- a/api/oss/tests/pytest/unit/workflows/test_static_catalog.py
+++ b/api/oss/tests/pytest/unit/workflows/test_static_catalog.py
@@ -212,6 +212,68 @@ async def test_default_agent_skill_embed_resolves_through_static_catalog_without
 
 
 @pytest.mark.asyncio
+async def test_request_connection_tool_embed_resolves_to_client_tool_config_without_db():
+    """The reserved request_connection workflow inlines a tool *config* (``type:"client"``), so the
+    embed + ``parameters.tool`` selector yields a value the SDK coerces to a ``ClientToolConfig``.
+    Regression: a spec-shaped ``kind:"client"`` value coerced to a builtin tool instead."""
+    from agenta.sdk.agents.platform.workflow import REQUEST_CONNECTION_WORKFLOW_SLUG
+    from agenta.sdk.agents.tools.compat import coerce_tool_config
+    from agenta.sdk.agents.tools.models import ClientToolConfig
+
+    workflows_dao = AsyncMock()
+    workflows_service = WorkflowsService(
+        workflows_dao=workflows_dao,
+        static_catalog=StaticWorkflowCatalog(),
+    )
+    embeds_service = EmbedsService(workflows_service=workflows_service)
+    workflows_service.embeds_service = embeds_service
+
+    revision = WorkflowRevision(
+        id=uuid4(),
+        workflow_id=uuid4(),
+        workflow_variant_id=uuid4(),
+        slug="agent-default-config",
+        data=WorkflowRevisionData(
+            parameters={
+                "agent": {
+                    "tools": [
+                        {
+                            "@ag.embed": {
+                                "@ag.references": {
+                                    "workflow": {
+                                        "slug": REQUEST_CONNECTION_WORKFLOW_SLUG
+                                    }
+                                },
+                                "@ag.selector": {"path": "parameters.tool"},
+                            }
+                        }
+                    ]
+                }
+            }
+        ),
+    )
+
+    (
+        resolved_revision,
+        resolution_info,
+    ) = await workflows_service.resolve_workflow_revision(
+        project_id=uuid4(),
+        workflow_revision=revision,
+    )
+
+    tool = resolved_revision.data.parameters["agent"]["tools"][0]
+    assert tool["type"] == "client"
+    assert tool["name"] == "request_connection"
+    # The resolved config must coerce to a client tool (not silently a builtin).
+    coerced = coerce_tool_config(tool)
+    assert isinstance(coerced, ClientToolConfig)
+    assert coerced.render == {"kind": "connect"}
+    assert resolution_info.embeds_resolved == 1
+    workflows_dao.fetch_revision.assert_not_awaited()
+    workflows_dao.fetch_artifact.assert_not_awaited()
+
+
+@pytest.mark.asyncio
 async def test_fetch_revision_short_circuits_reserved_revision_ref_with_version():
     workflows_dao = AsyncMock()
     service = WorkflowsService(

--- a/sdks/python/agenta/sdk/agents/adapters/vercel/messages.py
+++ b/sdks/python/agenta/sdk/agents/adapters/vercel/messages.py
@@ -14,7 +14,17 @@ from ...dtos import AgentResult, ContentBlock, Message
 TOOL_APPROVAL_REQUEST = "tool-approval-request"
 TOOL_APPROVAL_RESPONSE = "tool-approval-response"
 TOOL_OUTPUT_AVAILABLE = "tool-output-available"
-TOOL_OUTPUT_AVAILABLE_TYPES = {TOOL_OUTPUT_AVAILABLE, "TOOL_OUTPUT_AVAILABLE"}
+TOOL_OUTPUT_ERROR = "tool-output-error"
+TOOL_OUTPUT_DENIED = "tool-output-denied"
+# Result-envelope markers: these name a tool *result*, not a tool. Their `tool-`
+# prefix must never be parsed into a tool name nor fabricate a tool_call on the
+# round-trip ingest path.
+TOOL_OUTPUT_MARKER_TYPES = {
+    TOOL_OUTPUT_AVAILABLE,
+    "TOOL_OUTPUT_AVAILABLE",
+    TOOL_OUTPUT_ERROR,
+    TOOL_OUTPUT_DENIED,
+}
 
 
 def vercel_messages_to_agenta_messages(raw: Optional[List[Any]]) -> List[Message]:
@@ -81,7 +91,7 @@ def _part_to_blocks(part: Any) -> List[ContentBlock]:
         return _approval_response_blocks(part)
 
     if (
-        ptype in TOOL_OUTPUT_AVAILABLE_TYPES
+        ptype in TOOL_OUTPUT_MARKER_TYPES
         or ptype == "dynamic-tool"
         or ptype.startswith("tool-")
     ):
@@ -97,12 +107,12 @@ def _tool_part_blocks(part: Dict[str, Any], ptype: str) -> List[ContentBlock]:
     if (
         tool_name is None
         and ptype.startswith("tool-")
-        and ptype not in TOOL_OUTPUT_AVAILABLE_TYPES
+        and ptype not in TOOL_OUTPUT_MARKER_TYPES
     ):
         tool_name = ptype[len("tool-") :]
 
     blocks: List[ContentBlock] = []
-    if ptype not in TOOL_OUTPUT_AVAILABLE_TYPES or "input" in part:
+    if ptype not in TOOL_OUTPUT_MARKER_TYPES or "input" in part:
         blocks.append(
             ContentBlock(
                 type="tool_call",

--- a/sdks/python/agenta/sdk/agents/adapters/vercel/messages.py
+++ b/sdks/python/agenta/sdk/agents/adapters/vercel/messages.py
@@ -14,6 +14,7 @@ from ...dtos import AgentResult, ContentBlock, Message
 TOOL_APPROVAL_REQUEST = "tool-approval-request"
 TOOL_APPROVAL_RESPONSE = "tool-approval-response"
 TOOL_OUTPUT_AVAILABLE = "tool-output-available"
+TOOL_OUTPUT_AVAILABLE_TYPES = {TOOL_OUTPUT_AVAILABLE, "TOOL_OUTPUT_AVAILABLE"}
 
 
 def vercel_messages_to_agenta_messages(raw: Optional[List[Any]]) -> List[Message]:
@@ -80,7 +81,7 @@ def _part_to_blocks(part: Any) -> List[ContentBlock]:
         return _approval_response_blocks(part)
 
     if (
-        ptype == TOOL_OUTPUT_AVAILABLE
+        ptype in TOOL_OUTPUT_AVAILABLE_TYPES
         or ptype == "dynamic-tool"
         or ptype.startswith("tool-")
     ):
@@ -96,12 +97,12 @@ def _tool_part_blocks(part: Dict[str, Any], ptype: str) -> List[ContentBlock]:
     if (
         tool_name is None
         and ptype.startswith("tool-")
-        and ptype != TOOL_OUTPUT_AVAILABLE
+        and ptype not in TOOL_OUTPUT_AVAILABLE_TYPES
     ):
         tool_name = ptype[len("tool-") :]
 
     blocks: List[ContentBlock] = []
-    if ptype != TOOL_OUTPUT_AVAILABLE or "input" in part:
+    if ptype not in TOOL_OUTPUT_AVAILABLE_TYPES or "input" in part:
         blocks.append(
             ContentBlock(
                 type="tool_call",

--- a/sdks/python/agenta/sdk/agents/platform/workflow.py
+++ b/sdks/python/agenta/sdk/agents/platform/workflow.py
@@ -22,6 +22,7 @@ from typing import Optional, Sequence
 
 from agenta.sdk.agents.tools import (
     CallbackToolSpec,
+    ClientToolSpec,
     GatewayToolResolution,
     GatewayToolResolutionError,
     ReferenceToolConfig,
@@ -33,6 +34,9 @@ from ._schema import expand_type_refs
 from .connection import PlatformConnection
 
 log = get_module_logger(__name__)
+
+REQUEST_CONNECTION_WORKFLOW_SLUG = "__ag__request_connection"
+REQUEST_CONNECTION_TOOL_NAME = "request_connection"
 
 
 class AgentaWorkflowToolResolver:
@@ -59,7 +63,7 @@ class AgentaWorkflowToolResolver:
         authorization = self._connection.authorization()
 
         seen: set[str] = set()
-        tool_specs: list[CallbackToolSpec] = []
+        tool_specs: list[CallbackToolSpec | ClientToolSpec] = []
         for tool_config in tools:
             call_ref = tool_config.call_ref
             if call_ref in seen:
@@ -70,6 +74,18 @@ class AgentaWorkflowToolResolver:
                 log.warning("agent: %s", error)
                 raise error
             seen.add(call_ref)
+            if _is_request_connection_workflow(tool_config):
+                tool_specs.append(
+                    ClientToolSpec(
+                        kind="client",
+                        name=REQUEST_CONNECTION_TOOL_NAME,
+                        description=tool_config.description
+                        or "Request a connection from the user.",
+                        input_schema=expand_type_refs(tool_config.input_schema),
+                        render={"kind": "connect"},
+                    )
+                )
+                continue
             tool_specs.append(
                 CallbackToolSpec(
                     name=tool_config.tool_name,
@@ -94,3 +110,15 @@ class AgentaWorkflowToolResolver:
                 authorization=authorization,
             ),
         )
+
+
+def _is_request_connection_workflow(tool_config: ReferenceToolConfig) -> bool:
+    workflow = getattr(tool_config, "workflow", None)
+    if getattr(workflow, "slug", None) == REQUEST_CONNECTION_WORKFLOW_SLUG:
+        return True
+
+    call_ref = tool_config.call_ref
+    return (
+        call_ref == f"workflow.variant.{REQUEST_CONNECTION_WORKFLOW_SLUG}"
+        or call_ref.startswith(f"workflow.variant.{REQUEST_CONNECTION_WORKFLOW_SLUG}.")
+    )

--- a/services/agent/src/engines/sandbox_agent/permissions.ts
+++ b/services/agent/src/engines/sandbox_agent/permissions.ts
@@ -1,5 +1,5 @@
 import type { AgentEvent } from "../../protocol.ts";
-import { decisionToReply, type Responder } from "../../responder.ts";
+import { decisionToReply, type ClientToolOutcome, type Responder } from "../../responder.ts";
 
 export interface AttachPermissionResponderInput {
   session: any;
@@ -31,6 +31,42 @@ export function attachPermissionResponder({
   session.onPermissionRequest((req: any) => {
     const id = String(req?.id ?? "");
     const availableReplies: string[] = req?.availableReplies ?? [];
+    const toolCall = req?.toolCall;
+    const spec = clientToolSpecOf(toolCall);
+    if (spec?.kind === "client") {
+      const toolCallId =
+        typeof toolCall?.toolCallId === "string" ? toolCall.toolCallId : undefined;
+      const toolName = clientToolName(toolCall, spec);
+      const input = toolCall?.rawInput ?? toolCall?.input;
+      run.emitEvent({
+        type: "interaction_request",
+        id,
+        kind: "client_tool",
+        payload: {
+          toolCallId,
+          toolCall,
+          toolName,
+          input,
+          render: spec.render,
+        },
+      });
+      void responder
+        .onClientTool({ id, toolCallId, toolName, input, raw: req })
+        .then((decision) => {
+          if (decision === "park") {
+            onPark?.();
+            return;
+          }
+          if (!req?.id) return;
+          return session.respondPermission(
+            req.id,
+            clientToolReply(decision, availableReplies) as any,
+          );
+        })
+        .catch(() => {});
+      return;
+    }
+
     run.emitEvent({
       type: "interaction_request",
       id, // ACP permission id -> Vercel approvalId
@@ -65,4 +101,22 @@ export function attachPermissionResponder({
       })
       .catch(() => {});
   });
+}
+
+function clientToolSpecOf(toolCall: any): any | undefined {
+  return toolCall?.spec ?? toolCall?.toolSpec ?? toolCall?.resolvedTool ?? toolCall?.tool;
+}
+
+function clientToolName(toolCall: any, spec: any): string | undefined {
+  for (const candidate of [spec?.name, toolCall?.name, toolCall?.title, toolCall?.kind]) {
+    if (typeof candidate === "string" && candidate) return candidate;
+  }
+  return undefined;
+}
+
+function clientToolReply(decision: ClientToolOutcome, availableReplies: string[]): string {
+  if (decision === "deny") {
+    return availableReplies.find((r) => r === "reject") ?? "reject";
+  }
+  return availableReplies.find((r) => r === "once") ?? "once";
 }

--- a/services/agent/src/engines/sandbox_agent/permissions.ts
+++ b/services/agent/src/engines/sandbox_agent/permissions.ts
@@ -32,6 +32,14 @@ export function attachPermissionResponder({
     const id = String(req?.id ?? "");
     const availableReplies: string[] = req?.availableReplies ?? [];
     const toolCall = req?.toolCall;
+    // The harness raises a permission request before running ANY gated tool. We branch on the
+    // tool's resolved spec: a `kind: "client"` tool is not really a sandbox permission gate — it
+    // is a tool whose execution belongs to the browser (e.g. `request_connection`, which renders a
+    // connect widget the user interacts with). So instead of approving/denying it in the sandbox,
+    // we forward it to the frontend as a `client_tool` interaction_request and let the responder
+    // decide: PARK it for a cross-turn round-trip (the browser fulfills the call, the next turn
+    // resumes with its result) or reply inline. Every other tool falls through to the normal
+    // permission gate below.
     const spec = clientToolSpecOf(toolCall);
     if (spec?.kind === "client") {
       const toolCallId =

--- a/services/agent/src/responder.ts
+++ b/services/agent/src/responder.ts
@@ -44,6 +44,8 @@ export type PermissionDecision = "allow" | "deny";
 /** The full set of responder outcomes, including the runner-internal `park`. */
 export type ResponderOutcome = PermissionDecision | "park";
 
+export type ClientToolOutcome = "deny" | "park" | { output: unknown };
+
 /** A permission gate raised by the harness, normalized from the ACP request. */
 export interface PermissionRequest {
   /** The ACP permission id; reused as the `interaction_request` event id for reply matching. */
@@ -54,6 +56,15 @@ export interface PermissionRequest {
   raw?: unknown;
 }
 
+export interface ClientToolRequest {
+  /** Reused as the `interaction_request` event id for reply matching. */
+  id: string;
+  toolCallId?: string;
+  toolName?: string;
+  input?: unknown;
+  raw?: unknown;
+}
+
 /**
  * Answers interaction requests the harness raises. Permission is the only kind wired today;
  * `input` (elicitation) and `client_tool` are forward-looking and will extend this interface
@@ -61,6 +72,7 @@ export interface PermissionRequest {
  */
 export interface Responder {
   onPermission(request: PermissionRequest): Promise<ResponderOutcome>;
+  onClientTool(request: ClientToolRequest): Promise<ClientToolOutcome>;
 }
 
 /** Headless responder: a fixed policy, no human in the loop. Never parks (no human surface). */
@@ -70,6 +82,10 @@ export class PolicyResponder implements Responder {
   async onPermission(_request: PermissionRequest): Promise<ResponderOutcome> {
     return this.policy === "deny" ? "deny" : "allow";
   }
+
+  async onClientTool(_request: ClientToolRequest): Promise<ClientToolOutcome> {
+    return "deny";
+  }
 }
 
 /**
@@ -78,7 +94,7 @@ export class PolicyResponder implements Responder {
  *
  *   1. `toolCallId` — the precise, warm match. When the harness re-presents the SAME ACP
  *      tool-call id (same session), this resolves the exact parked call.
- *   2. `approvalKey(name, input)` — the cold-replay anchor. A cold-replayed run rebuilds the
+ *   2. `parkedCallKey(name, input)` — the cold-replay anchor. A cold-replayed run rebuilds the
  *      session from the replayed transcript and mints a FRESH tool-call id for the re-raised
  *      gate, so the id no longer matches. The stable anchor is then the tool's NAME **plus
  *      its arguments**: the resumed call re-derives the same name and the same args, so it
@@ -89,7 +105,7 @@ export class PolicyResponder implements Responder {
  * HITL bypass. Binding the cold-replay key to name + args closes that hole while keeping the
  * legitimate approve -> resume path working (resume re-raises the same name + args).
  */
-export type ApprovalDecisions = ReadonlyMap<string, PermissionDecision>;
+export type ApprovalDecisions = ReadonlyMap<string, unknown>;
 
 /**
  * The cold-replay approval anchor: the tool name bound to its arguments. Resume re-derives
@@ -107,7 +123,7 @@ export type ApprovalDecisions = ReadonlyMap<string, PermissionDecision>;
  * Returns `undefined` (NO key, fail closed -> re-prompt) only when there is no tool name, or
  * the args are not plain JSON (bigint / cycle / NaN/Infinity / non-plain object like Date/Map).
  */
-export function approvalKey(
+export function parkedCallKey(
   toolName: string | undefined,
   input: unknown,
 ): string | undefined {
@@ -183,18 +199,35 @@ export class HITLResponder implements Responder {
   ) {}
 
   async onPermission(request: PermissionRequest): Promise<ResponderOutcome> {
-    const stored = this.lookup(request);
+    const stored = this.lookupPermission(request);
     if (stored) return stored;
     if (this.hasHumanSurface) return "park"; // human must decide; end the turn, tool pending
     return this.basePolicy === "deny" ? "deny" : "allow"; // headless: PolicyResponder parity
   }
 
-  private lookup(request: PermissionRequest): PermissionDecision | undefined {
+  async onClientTool(request: ClientToolRequest): Promise<ClientToolOutcome> {
+    const stored = this.lookupClientTool(request);
+    if (stored.found) return { output: stored.output };
+    if (this.hasHumanSurface) return "park";
+    return "deny";
+  }
+
+  private lookupPermission(request: PermissionRequest): PermissionDecision | undefined {
     for (const key of permissionRequestKeys(request)) {
       const decision = this.decisions.get(key);
-      if (decision) return decision;
+      if (isPermissionDecision(decision)) return decision;
     }
     return undefined;
+  }
+
+  private lookupClientTool(request: ClientToolRequest): { found: boolean; output?: unknown } {
+    for (const key of clientToolRequestKeys(request)) {
+      if (this.decisions.has(key)) {
+        const output = this.decisions.get(key);
+        if (!isPermissionDecision(output)) return { found: true, output };
+      }
+    }
+    return { found: false };
   }
 }
 
@@ -224,7 +257,15 @@ function permissionRequestKeys(request: PermissionRequest): string[] {
   const toolCallId = toolCall?.toolCallId;
   if (typeof toolCallId === "string" && toolCallId) keys.push(toolCallId);
   const name = permissionToolName(toolCall);
-  const argsKey = approvalKey(name, toolCall?.rawInput ?? toolCall?.input);
+  const argsKey = parkedCallKey(name, toolCall?.rawInput ?? toolCall?.input);
+  if (argsKey) keys.push(argsKey);
+  return keys;
+}
+
+function clientToolRequestKeys(request: ClientToolRequest): string[] {
+  const keys: string[] = [];
+  if (request.toolCallId) keys.push(request.toolCallId);
+  const argsKey = parkedCallKey(request.toolName, request.input);
   if (argsKey) keys.push(argsKey);
   return keys;
 }
@@ -249,7 +290,7 @@ function permissionToolName(toolCall: unknown): string | undefined {
  * approval response (an ordinary tool result carries the tool's real output, not an `approved`
  * flag), so no new wire carrier is needed.
  *
- * Each decision is indexed ONLY by `approvalKey(name, args)` — the cold-replay anchor. The
+ * Each decision is indexed ONLY by `parkedCallKey(name, args)` — the cold-replay anchor. The
  * name/args are recovered from the matching `tool_call` block (same `toolCallId`) the egress
  * folds into the transcript.
  *
@@ -264,8 +305,8 @@ function permissionToolName(toolCall: unknown): string | undefined {
  */
 export function extractApprovalDecisions(
   request: AgentRunRequest,
-): Map<string, PermissionDecision> {
-  const decisions = new Map<string, PermissionDecision>();
+): Map<string, unknown> {
+  const decisions = new Map<string, unknown>();
   // First pass: recover each tool call's name + args, keyed by its id, so an approval reply
   // (which may carry only the id + the `{approved}` envelope) can be bound to name + args.
   const callShapeById = new Map<string, { name?: string; input?: unknown }>();
@@ -285,8 +326,8 @@ export function extractApprovalDecisions(
     const content = message?.content;
     if (!Array.isArray(content)) continue;
     for (const block of content) {
-      const decision = approvalDecisionOf(block);
-      if (!decision) continue;
+      const result = parkedCallResultOf(block);
+      if (!result.found) continue;
       // Bind the cold-replay name+args key: prefer the block's own name/input, else the
       // correlated tool_call block (same id). Never key by bare name or by a replayed id.
       const shape = block.toolCallId
@@ -294,18 +335,23 @@ export function extractApprovalDecisions(
         : undefined;
       const name = block.toolName ?? shape?.name;
       const input = block.input ?? shape?.input;
-      const argsKey = approvalKey(name, input);
-      if (argsKey) decisions.set(argsKey, decision);
+      const argsKey = parkedCallKey(name, input);
+      if (argsKey) decisions.set(argsKey, result.output);
     }
   }
   return decisions;
 }
 
-/** A `tool_result` block whose `output` is an `{ approved: boolean }` envelope -> a decision. */
-function approvalDecisionOf(
-  block: ContentBlock,
-): PermissionDecision | undefined {
-  if (!block || block.type !== "tool_result") return undefined;
+function isPermissionDecision(value: unknown): value is PermissionDecision {
+  return value === "allow" || value === "deny";
+}
+
+/**
+ * A parked call reply. Permission responses use `{ approved: boolean }`; client tools carry their
+ * real structured `output`.
+ */
+function parkedCallResultOf(block: ContentBlock): { found: boolean; output?: unknown } {
+  if (!block || block.type !== "tool_result") return { found: false };
   const output = block.output;
   if (
     output &&
@@ -313,9 +359,12 @@ function approvalDecisionOf(
     !Array.isArray(output) &&
     typeof (output as { approved?: unknown }).approved === "boolean"
   ) {
-    return (output as { approved: boolean }).approved ? "allow" : "deny";
+    return {
+      found: true,
+      output: (output as { approved: boolean }).approved ? "allow" : "deny",
+    };
   }
-  return undefined;
+  return { found: true, output };
 }
 
 /**

--- a/services/agent/src/tools/dispatch.ts
+++ b/services/agent/src/tools/dispatch.ts
@@ -10,7 +10,7 @@
  *
  * The three executor kinds (see `ResolvedToolSpec`):
  *  - `code`: advertised to harnesses, but rejected by the sidecar as unsupported.
- *  - `client`: browser-fulfilled across a turn boundary; never executed in-sandbox (throws).
+ *  - `client`: browser-fulfilled across a turn boundary; permission responder parks it.
  *  - `callback` (default): POST back through Agenta's /tools/call so the Composio key and
  *    connection auth stay server-side. On Daytona the in-sandbox process can't reach Agenta,
  *    so the call is relayed through the runner via files (see tools/relay.ts) when `relayDir`
@@ -97,7 +97,7 @@ export async function relayToolCall(
  * turns the throw into a tool-error result so the model loop continues rather than crashing.
  *
  *  - `code`   -> reject as unsupported by the sidecar, no callback/relay.
- *  - `client` → throw: browser-fulfilled, never executed in-sandbox.
+ *  - `client` → signal pending: browser-fulfilled, never executed in-sandbox.
  *  - default/`callback` → relay through the runner when `opts.relayDir` is set (Daytona),
  *    else POST directly to `opts.endpoint`.
  */
@@ -110,9 +110,10 @@ export async function runResolvedTool(
     return runCodeTool(spec.runtime, spec.code ?? "", spec.env, params, opts.signal);
   }
   if (spec.kind === "client") {
-    throw new Error(
-      `client tool '${spec.name}' is browser-fulfilled and cannot be executed in-sandbox`,
-    );
+    return JSON.stringify({
+      type: "client_tool_pending",
+      toolName: spec.name,
+    });
   }
   // callback (default): route back to Agenta's /tools/call (directly or via the Daytona relay).
   if (opts.relayDir) {

--- a/services/agent/tests/unit/responder.test.ts
+++ b/services/agent/tests/unit/responder.test.ts
@@ -16,7 +16,7 @@ import type { AgentEvent, AgentRunRequest } from "../../src/protocol.ts";
 import {
   HITLResponder,
   PolicyResponder,
-  approvalKey,
+  parkedCallKey,
   decisionToReply,
   extractApprovalDecisions,
   policyFromRequest,
@@ -79,53 +79,53 @@ describe("decisionToReply", () => {
   });
 });
 
-describe("approvalKey", () => {
+describe("parkedCallKey", () => {
   it("binds name + args, order-independently", () => {
     assert.equal(
-      approvalKey("edit", { a: 1, b: 2 }),
-      approvalKey("edit", { b: 2, a: 1 }),
+      parkedCallKey("edit", { a: 1, b: 2 }),
+      parkedCallKey("edit", { b: 2, a: 1 }),
       "key order does not change the key",
     );
     assert.notEqual(
-      approvalKey("edit", { path: "a" }),
-      approvalKey("edit", { path: "b" }),
+      parkedCallKey("edit", { path: "a" }),
+      parkedCallKey("edit", { path: "b" }),
       "different args -> different key",
     );
     assert.notEqual(
-      approvalKey("edit", { path: "a" }),
-      approvalKey("bash", { path: "a" }),
+      parkedCallKey("edit", { path: "a" }),
+      parkedCallKey("bash", { path: "a" }),
       "different name -> different key",
     );
   });
 
   it("normalizes absent args to {} so a no-arg tool resumes", () => {
     // A no-arg tool has nothing to vary; absent/null/empty all key to the same `name#{}`.
-    assert.ok(approvalKey("edit", {}), "empty-object args -> a real key");
-    assert.equal(approvalKey("edit", undefined), approvalKey("edit", {}));
-    assert.equal(approvalKey("edit", null), approvalKey("edit", {}));
+    assert.ok(parkedCallKey("edit", {}), "empty-object args -> a real key");
+    assert.equal(parkedCallKey("edit", undefined), parkedCallKey("edit", {}));
+    assert.equal(parkedCallKey("edit", null), parkedCallKey("edit", {}));
     // But a WITH-args call never collapses to the no-arg key.
     assert.notEqual(
-      approvalKey("edit", { path: "a" }),
-      approvalKey("edit", {}),
+      parkedCallKey("edit", { path: "a" }),
+      parkedCallKey("edit", {}),
       "args present -> a different key than no-args",
     );
   });
 
   it("returns no key (fails closed) for no name or non-JSON args", () => {
     assert.equal(
-      approvalKey(undefined, { a: 1 }),
+      parkedCallKey(undefined, { a: 1 }),
       undefined,
       "no name -> no key",
     );
     // Non-JSON args fail closed (no key) rather than throwing or colliding.
     assert.equal(
-      approvalKey("edit", 10n as unknown),
+      parkedCallKey("edit", 10n as unknown),
       undefined,
       "bigint -> no key",
     );
-    assert.equal(approvalKey("edit", new Date()), undefined, "Date -> no key");
-    assert.equal(approvalKey("edit", { x: NaN }), undefined, "NaN -> no key");
-    assert.equal(approvalKey("edit", new Map()), undefined, "Map -> no key");
+    assert.equal(parkedCallKey("edit", new Date()), undefined, "Date -> no key");
+    assert.equal(parkedCallKey("edit", { x: NaN }), undefined, "NaN -> no key");
+    assert.equal(parkedCallKey("edit", new Map()), undefined, "Map -> no key");
   });
 });
 
@@ -170,7 +170,7 @@ describe("HITLResponder", () => {
     // The parked turn approved edit({path:'a.txt'}); a cold replay mints a FRESH tool-call id
     // for the SAME call, so the id no longer matches — but the name + args anchor does.
     const decisions = new Map<string, PermissionDecision>([
-      [approvalKey("edit", { path: "a.txt" })!, "allow"],
+      [parkedCallKey("edit", { path: "a.txt" })!, "allow"],
     ]);
     const responder = new HITLResponder(decisions, "auto", true);
     assert.equal(
@@ -185,7 +185,7 @@ describe("HITLResponder", () => {
     // The HITL bypass this guards against: a stored `allow` for edit({path:'a.txt'}) must NOT
     // leak to a NEW edit call with DIFFERENT args (e.g. a sensitive path). B must re-prompt.
     const decisions = new Map<string, PermissionDecision>([
-      [approvalKey("edit", { path: "a.txt" })!, "allow"],
+      [parkedCallKey("edit", { path: "a.txt" })!, "allow"],
     ]);
     const responder = new HITLResponder(decisions, "auto", true);
     // Same tool name, different args, brand-new id -> no stored match -> park (re-prompt).
@@ -198,7 +198,7 @@ describe("HITLResponder", () => {
     );
     // And argument-order does not let B slip through under A's key.
     const orderDecisions = new Map<string, PermissionDecision>([
-      [approvalKey("edit", { a: 1, b: 2 })!, "allow"],
+      [parkedCallKey("edit", { a: 1, b: 2 })!, "allow"],
     ]);
     const orderResponder = new HITLResponder(orderDecisions, "auto", true);
     assert.equal(
@@ -298,10 +298,10 @@ describe("extractApprovalDecisions", () => {
     const decisions = extractApprovalDecisions(request);
     // ONLY the name+args anchor is keyed (recovered from the correlated tool_call block).
     assert.equal(
-      decisions.get(approvalKey("edit", { path: "a.txt" })!),
+      decisions.get(parkedCallKey("edit", { path: "a.txt" })!),
       "allow",
     );
-    assert.equal(decisions.get(approvalKey("bash", { cmd: "ls" })!), "deny");
+    assert.equal(decisions.get(parkedCallKey("bash", { cmd: "ls" })!), "deny");
     // The bare tool NAME must NOT be a key (that was the HITL-bypass).
     assert.equal(decisions.has("edit"), false, "no bare-name key");
     assert.equal(decisions.has("bash"), false, "no bare-name key");

--- a/services/agent/tests/unit/sandbox-agent-orchestration.test.ts
+++ b/services/agent/tests/unit/sandbox-agent-orchestration.test.ts
@@ -225,6 +225,9 @@ function fakeHarness(options: FakeOptions = {}) {
       async onPermission() {
         return options.permissionDecision ?? "allow";
       },
+      async onClientTool() {
+        return "deny" as const;
+      },
     }),
   };
 

--- a/services/agent/tests/unit/sandbox-agent-permissions.test.ts
+++ b/services/agent/tests/unit/sandbox-agent-permissions.test.ts
@@ -33,6 +33,9 @@ describe("attachPermissionResponder", () => {
         seenRequests.push(request);
         return "allow";
       },
+      async onClientTool() {
+        return "deny";
+      },
     };
 
     attachPermissionResponder({
@@ -102,6 +105,9 @@ describe("attachPermissionResponder", () => {
         async onPermission() {
           return "park";
         },
+        async onClientTool() {
+          return "park" as const;
+        },
       },
     });
     handler?.({
@@ -137,6 +143,9 @@ describe("attachPermissionResponder", () => {
       responder: {
         async onPermission() {
           return "deny";
+        },
+        async onClientTool() {
+          return "deny" as const;
         },
       },
     });

--- a/web/oss/src/components/AgentChatSlice/AgentChatPanel.tsx
+++ b/web/oss/src/components/AgentChatSlice/AgentChatPanel.tsx
@@ -1,5 +1,6 @@
 import {useCallback, useEffect, useLayoutEffect, useMemo, useRef, useState} from "react"
 
+import {invalidateAgentCommittedRevisionCache} from "@agenta/entities/workflow"
 import {agentShouldResumeAfterApproval, buildAgentRequest} from "@agenta/playground"
 import {simulatedAgentRunAtomFamily} from "@agenta/shared/state"
 import {generateId} from "@agenta/shared/utils"
@@ -23,6 +24,7 @@ import {
 import {filesToParts} from "./assets/files"
 import {messageText, sideEffectingToolsInRange} from "./assets/rewind"
 import AgentMessage from "./components/AgentMessage"
+import type {ClientToolOutputHandler} from "./components/clientTools"
 import ComposerAttachments from "./components/ComposerAttachments"
 import QueuedMessages from "./components/QueuedMessages"
 import SessionHistoryMenu from "./components/SessionHistoryMenu"
@@ -247,6 +249,7 @@ const AgentConversation = ({entityId, sessionId}: {entityId: string; sessionId: 
         regenerate,
         setMessages,
         addToolApprovalResponse,
+        addToolOutput,
         error,
     } = useChat({
         id: sessionId,
@@ -274,6 +277,30 @@ const AgentConversation = ({entityId, sessionId}: {entityId: string; sessionId: 
     useEffect(() => {
         return () => setSessionStreaming({id: sessionId, streaming: false})
     }, [sessionId, setSessionStreaming])
+
+    // Settle a parked client tool (#4920). The dispatcher calls this from a widget (e.g. the connect
+    // widget) with the structured reference; `addToolOutput` matches the part by `toolCallId` on the
+    // last turn and the resume predicate auto-resends. `tool` is only the typed-tools key — matching
+    // is by id — so a cast onto the untyped UIMessage tool map is safe.
+    const handleClientToolOutput = useCallback<ClientToolOutputHandler>(
+        ({toolName, toolCallId, output, errorText}) => {
+            if (errorText !== undefined) {
+                addToolOutput({
+                    state: "output-error",
+                    tool: toolName as never,
+                    toolCallId,
+                    errorText,
+                }).catch(ignoreStreamRejection)
+            } else {
+                addToolOutput({
+                    tool: toolName as never,
+                    toolCallId,
+                    output: (output ?? {}) as never,
+                }).catch(ignoreStreamRejection)
+            }
+        },
+        [addToolOutput],
+    )
 
     // ── "Run in playground" seam (producer: a trigger drawer's Run-in-playground) ──
     // A trigger fires server-side and never reaches the playground; this lets a user
@@ -373,6 +400,27 @@ const AgentConversation = ({entityId, sessionId}: {entityId: string; sessionId: 
         if (status === "streaming") return
         persistMessages({id: sessionId, messages})
     }, [messages, status, sessionId, persistMessages])
+
+    // ── #4920 Application 1: refresh the config on a committed revision ──
+    // When the agent commits a new revision of itself, the backend emits a one-way
+    // `data-committed-revision` part (same channel as `data-trace`), in BOTH the gated approval path
+    // and the direct `needs_approval=false` path. On receipt we invalidate the latest-revision and
+    // inspect caches so the config panel, section drawers, and build-kit view all re-read the new
+    // config. Deduped by revision id so a re-render (token stream) doesn't re-invalidate.
+    const committedRevisionsSeenRef = useRef<Set<string>>(new Set())
+    useEffect(() => {
+        for (const message of messages) {
+            for (const part of message.parts) {
+                if ((part as {type?: string}).type !== "data-committed-revision") continue
+                const data = (part as {data?: {revisionId?: string; version?: string}}).data
+                // A stable key per commit: prefer the revision id, fall back to the whole payload.
+                const key = data?.revisionId ?? JSON.stringify(data ?? {}) ?? "committed"
+                if (committedRevisionsSeenRef.current.has(key)) continue
+                committedRevisionsSeenRef.current.add(key)
+                invalidateAgentCommittedRevisionCache()
+            }
+        }
+    }, [messages])
 
     // ── DT3 cancelled state: wrap stop() to mark the in-flight assistant turn ──
     const markStopped = useCallback(() => {
@@ -748,8 +796,10 @@ const AgentConversation = ({entityId, sessionId}: {entityId: string; sessionId: 
                 <AgentMessage
                     message={message}
                     isStreaming={busy && isLast}
+                    isLastMessage={isLast}
                     onRewind={() => handleRewind(message)}
                     onApprovalResponse={addToolApprovalResponse}
+                    onClientToolOutput={handleClientToolOutput}
                     precededByEmptyAssistant={
                         index > 0 && isEmptyAssistantTurn(messages[index - 1])
                     }

--- a/web/oss/src/components/AgentChatSlice/components/AgentChatConversation.tsx
+++ b/web/oss/src/components/AgentChatSlice/components/AgentChatConversation.tsx
@@ -16,6 +16,7 @@ import {createAgentChatTransport} from "../assets/transport"
 import {persistSessionMessagesAtom, sessionMessagesAtom} from "../state/sessions"
 
 import AgentMessage from "./AgentMessage"
+import type {ClientToolOutputHandler} from "./clientTools"
 
 const {Text} = Typography
 
@@ -84,6 +85,7 @@ const AgentChatConversation = ({
         regenerate,
         setMessages,
         addToolApprovalResponse,
+        addToolOutput,
         error,
     } = useChat({
         id: sessionId,
@@ -100,6 +102,29 @@ const AgentChatConversation = ({
     })
 
     const busy = status === "submitted" || status === "streaming"
+
+    // Settle a parked client tool (#4920) — same wrapper as AgentChatPanel. `addToolOutput` matches
+    // the part by `toolCallId` on the last turn; `tool` is only the typed-tools key, so a cast onto
+    // the untyped UIMessage tool map is safe.
+    const handleClientToolOutput = useCallback<ClientToolOutputHandler>(
+        ({toolName, toolCallId, output, errorText}) => {
+            if (errorText !== undefined) {
+                addToolOutput({
+                    state: "output-error",
+                    tool: toolName as never,
+                    toolCallId,
+                    errorText,
+                }).catch(ignoreStreamRejection)
+            } else {
+                addToolOutput({
+                    tool: toolName as never,
+                    toolCallId,
+                    output: (output ?? {}) as never,
+                }).catch(ignoreStreamRejection)
+            }
+        },
+        [addToolOutput],
+    )
 
     // `handleRewind` must stay referentially stable (it's passed to every memo'd `AgentMessage`)
     // so a streamed token doesn't recreate it and re-render the whole list. `messages`/`busy`
@@ -239,8 +264,10 @@ const AgentChatConversation = ({
                         key={message.id}
                         message={message}
                         isStreaming={busy && index === messages.length - 1}
+                        isLastMessage={index === messages.length - 1}
                         onRewind={handleRewind}
                         onApprovalResponse={addToolApprovalResponse}
+                        onClientToolOutput={handleClientToolOutput}
                     />
                 ))}
                 {status === "submitted" && messages[messages.length - 1]?.role !== "assistant" && (

--- a/web/oss/src/components/AgentChatSlice/components/AgentMessage.tsx
+++ b/web/oss/src/components/AgentChatSlice/components/AgentMessage.tsx
@@ -28,6 +28,7 @@ import {
     type MessageUsageMetrics,
 } from "../assets/trace"
 
+import {ClientToolPart, isClientToolPart, type ClientToolOutputHandler} from "./clientTools"
 import ToolActivity from "./ToolActivity"
 
 const {Text} = Typography
@@ -48,10 +49,15 @@ interface AgentMessageProps {
     /** This is the last message AND the conversation is streaming — i.e. the one being
      * generated right now. Only it shows the loading state; settled turns never do. */
     isStreaming?: boolean
+    /** This is the last message in the conversation. A parked client tool only lands on the last
+     * turn, so the unknown-client-tool fallback only arms there (see `isClientToolPart`). */
+    isLastMessage?: boolean
     /** Stable across renders (parent passes a `useCallback`'d handler) so the `memo()` below
      * isn't defeated — the message to rewind to is passed in, not closed over per render. */
     onRewind: (message: UIMessage) => void
     onApprovalResponse: (args: {id: string; approved: boolean}) => void
+    /** Settle a parked client tool (#4920) — the dispatcher calls this from a widget. */
+    onClientToolOutput: ClientToolOutputHandler
     /** The previous turn was also an empty (content-less) assistant turn. Used to collapse a
      * run of "no response" bubbles down to the first one. */
     precededByEmptyAssistant?: boolean
@@ -164,8 +170,10 @@ const avatarFor = (isUser: boolean) => (
 const AgentMessage = ({
     message,
     isStreaming = false,
+    isLastMessage = false,
     onRewind,
     onApprovalResponse,
+    onClientToolOutput,
     precededByEmptyAssistant = false,
 }: AgentMessageProps) => {
     const openTraceDrawer = useSetAtom(openTraceDrawerAtom)
@@ -240,9 +248,16 @@ const AgentMessage = ({
     type RenderItem =
         | {kind: "part"; part: UIMessage["parts"][number]; index: number}
         | {kind: "tools"; parts: ToolUIPart[]; index: number}
+        | {kind: "clientTool"; part: ToolUIPart; index: number}
     const renderItems: RenderItem[] = []
     message.parts.forEach((part, i) => {
         if (isToolPart(part.type)) {
+            // A browser-fulfilled client tool (#4920) renders as its own widget/chip, NOT folded
+            // into the "Used N tools" group — so it breaks any current tool run.
+            if (isClientToolPart(part as ToolUIPart, {isStreaming, isLastMessage})) {
+                renderItems.push({kind: "clientTool", part: part as ToolUIPart, index: i})
+                return
+            }
             const last = renderItems[renderItems.length - 1]
             if (last && last.kind === "tools") last.parts.push(part as ToolUIPart)
             else renderItems.push({kind: "tools", parts: [part as ToolUIPart], index: i})
@@ -317,6 +332,15 @@ const AgentMessage = ({
                             isStreaming={isStreaming}
                             onApprovalResponse={onApprovalResponse}
                             onViewTrace={onViewTrace}
+                        />
+                    )
+                }
+                if (item.kind === "clientTool") {
+                    return (
+                        <ClientToolPart
+                            key={`${message.id}-clienttool-${item.part.toolCallId || item.index}`}
+                            part={item.part}
+                            onOutput={onClientToolOutput}
                         />
                     )
                 }

--- a/web/oss/src/components/AgentChatSlice/components/clientTools/ClientToolPart.tsx
+++ b/web/oss/src/components/AgentChatSlice/components/clientTools/ClientToolPart.tsx
@@ -1,0 +1,57 @@
+/**
+ * Client-tool dispatcher (#4920) — the sibling to `ToolActivity` that renders a single client-tool
+ * part. It resolves the widget by `render.kind` → `toolName` (the registry) and falls back to the
+ * explicit "can't handle that" surface for an unknown client tool. The widget settles the part via
+ * `settle`, which calls the panel's `addToolOutput`; the resume predicate then auto-resends.
+ */
+import {createElement, memo, useCallback} from "react"
+
+import type {ToolUIPart} from "ai"
+
+import {clientToolMeta} from "./meta"
+import {resolveClientToolHandler} from "./registry"
+import UnhandledClientTool from "./UnhandledClientTool"
+
+/** Settle a parked client tool. The panel maps this onto `addToolOutput` (success or error). */
+export type ClientToolOutputHandler = (args: {
+    toolName: string
+    toolCallId: string
+    output?: Record<string, unknown>
+    errorText?: string
+}) => void
+
+const ClientToolPart = ({
+    part,
+    onOutput,
+}: {
+    part: ToolUIPart
+    onOutput: ClientToolOutputHandler
+}) => {
+    const meta = clientToolMeta(part)
+    // The handler is a STABLE module-level component picked from the registry (not created during
+    // render), so dispatch via `createElement` — `<Handler/>` would trip the static-components rule.
+    const handler = resolveClientToolHandler(meta) ?? UnhandledClientTool
+
+    const settle = useCallback(
+        (args: {output: Record<string, unknown>} | {errorText: string}) => {
+            if ("errorText" in args) {
+                onOutput({
+                    toolName: meta.toolName,
+                    toolCallId: meta.toolCallId,
+                    errorText: args.errorText,
+                })
+            } else {
+                onOutput({
+                    toolName: meta.toolName,
+                    toolCallId: meta.toolCallId,
+                    output: args.output,
+                })
+            }
+        },
+        [onOutput, meta.toolName, meta.toolCallId],
+    )
+
+    return createElement(handler, {meta, settle})
+}
+
+export default memo(ClientToolPart)

--- a/web/oss/src/components/AgentChatSlice/components/clientTools/ConnectToolWidget.tsx
+++ b/web/oss/src/components/AgentChatSlice/components/clientTools/ConnectToolWidget.tsx
@@ -1,0 +1,305 @@
+/**
+ * Connect widget — the `request_connection` / `render.kind: "connect"` client tool (#4920).
+ *
+ * The agent asked for a connection it lacks (e.g. GitHub). This widget runs the Agenta OAuth flow in
+ * the playground and settles the parked call with a **reference, never a secret**: the runner
+ * re-resolves the credential from the project vault on resume. It reuses the existing connection
+ * machinery (`useToolsConnections` → `POST /tools/connections/`, then a popup on the returned
+ * `redirect_url`) rather than reinventing the OAuth call.
+ *
+ * Security (hard requirement, design §"Security"): the popup posts back a `tools:oauth:complete`
+ * message; we trust it ONLY when `event.origin` equals the Agenta API origin (the callback page's
+ * origin) and the payload shape matches. Everything else is dropped.
+ *
+ * Settle on every terminal path (design §"Settle on every path"), so the run never hangs:
+ *   success → {connected:true, integration, slug} · cancel/abandon → {connected:false,
+ *   reason:"cancelled"} · timeout → {connected:false, reason:"timeout"} · failure → errorText.
+ *
+ * Result UX is U1 — an inline status chip in the same visual language as approve/deny: "Connect
+ * GitHub" → "Connecting GitHub…" → "GitHub connected" ✓, or "Connection not completed" + Retry.
+ */
+import {useCallback, useEffect, useRef, useState} from "react"
+
+import {ArrowClockwise, CheckCircle, Plugs, Spinner, Warning} from "@phosphor-icons/react"
+import {Button, Typography} from "antd"
+
+import {getAgentaApiUrl} from "@/oss/lib/helpers/api"
+
+import {useToolsConnections} from "../../../pages/settings/Tools/hooks/useToolsConnections"
+
+import type {ClientToolHandlerProps} from "./types"
+
+const {Text} = Typography
+
+/**
+ * No terminal signal within this bound settles the call as a timeout so the run can't wait forever.
+ * Armed only once the popup is open (the user is mid-flow). 3 minutes covers a real OAuth consent.
+ * NOTE for Mahmoud: confirm the bound — open question §"abandon timeout".
+ */
+const CONNECT_TIMEOUT_MS = 180_000
+/** Popup-closed poll cadence, matching the existing ConnectModal. */
+const POPUP_POLL_MS = 1000
+
+/** The settled call's reference shape (what the runner re-resolves against). */
+interface ConnectOutput {
+    connected?: boolean
+    integration?: string
+    slug?: string
+    reason?: string
+}
+
+/** `github` → `GitHub`-ish: a readable label without a provider catalog lookup. */
+const prettyIntegration = (key: string): string =>
+    key ? key.charAt(0).toUpperCase() + key.slice(1) : "the service"
+
+/** Read the API origin the OAuth callback page posts from; null if it can't be resolved. */
+const agentaApiOrigin = (): string | null => {
+    try {
+        const url = getAgentaApiUrl()
+        if (!url) return null
+        return new URL(url, typeof window !== "undefined" ? window.location.href : undefined).origin
+    } catch {
+        return null
+    }
+}
+
+type Phase = "idle" | "connecting" | "error"
+
+const ConnectToolWidget = ({meta, settle}: ClientToolHandlerProps) => {
+    const input = (meta.input ?? {}) as Record<string, unknown>
+    const integration = typeof input.integration === "string" ? input.integration : ""
+    // Connection slug: the call may pin one; default to the integration key. The output carries it
+    // back as the reference the runner re-resolves.
+    const slug =
+        typeof input.slug === "string" && input.slug ? input.slug : integration || "default"
+    const mode = input.mode === "api_key" ? "api_key" : "oauth"
+    const label = prettyIntegration(integration)
+
+    const {handleCreate, invalidate} = useToolsConnections(integration)
+
+    const [phase, setPhase] = useState<Phase>("idle")
+    const [errorText, setErrorText] = useState<string | null>(null)
+    // A retry started AFTER the parked call already settled (as a failure) succeeded. The settled
+    // part can't be re-resolved, but the connection now exists in the vault, so we flip the chip to
+    // "connected" — the agent's re-ask resolves cleanly on its next turn.
+    const [manuallyConnected, setManuallyConnected] = useState(false)
+
+    // One-shot guard so the parked call settles exactly once, plus shared cleanup for the running
+    // popup's listener/poll/timeout.
+    const settledRef = useRef(false)
+    const popupRef = useRef<Window | null>(null)
+    const cleanupRef = useRef<(() => void) | null>(null)
+
+    const teardown = useCallback(() => {
+        cleanupRef.current?.()
+        cleanupRef.current = null
+        popupRef.current = null
+    }, [])
+
+    // Settle the parked part exactly once (success/cancel/timeout/failure all route through here).
+    const finish = useCallback(
+        (result: ConnectOutput | {errorText: string}) => {
+            if (settledRef.current) return
+            settledRef.current = true
+            teardown()
+            if ("errorText" in result) settle({errorText: result.errorText})
+            else settle({output: result as Record<string, unknown>})
+        },
+        [settle, teardown],
+    )
+
+    useEffect(() => () => teardown(), [teardown])
+
+    /**
+     * Run the Agenta OAuth flow: create the connection, open the popup, and watch its three terminal
+     * signals (origin-validated success message, popup closed without success, or timeout backstop).
+     *
+     * `settleParkedCall` distinguishes the two callers:
+     *  - the live parked interaction (`true`): each terminal signal settles the parked tool call so
+     *    the run resumes;
+     *  - a manual retry after the call already settled (`false`): nothing to settle, so success just
+     *    flips the local "connected" chip and primes the vault for the agent's re-ask.
+     */
+    const runConnect = useCallback(
+        async (settleParkedCall: boolean) => {
+            if (phase === "connecting") return
+            if (settleParkedCall && settledRef.current) return
+            setErrorText(null)
+            setPhase("connecting")
+            try {
+                const result = await handleCreate({slug, name: slug, mode})
+                const redirectUrl =
+                    typeof result.connection?.data?.redirect_url === "string"
+                        ? result.connection.data.redirect_url
+                        : undefined
+
+                const onSuccess = () => {
+                    invalidate()
+                    if (settleParkedCall) finish({connected: true, integration, slug})
+                    else {
+                        setManuallyConnected(true)
+                        setPhase("idle")
+                    }
+                }
+
+                if (!redirectUrl) {
+                    // No OAuth step (e.g. api_key created inline): the connection already exists.
+                    onSuccess()
+                    return
+                }
+
+                const popup = window.open(
+                    redirectUrl,
+                    "tools_oauth",
+                    "width=600,height=700,popup=yes",
+                )
+                if (!popup) {
+                    setPhase("error")
+                    setErrorText("Couldn’t open the connection window. Allow popups and retry.")
+                    return
+                }
+                popupRef.current = popup
+
+                const apiOrigin = agentaApiOrigin()
+                let succeeded = false
+
+                const onMessage = (event: MessageEvent) => {
+                    // HARD requirement: only trust the callback from the Agenta API origin.
+                    if (apiOrigin && event.origin !== apiOrigin) return
+                    const data = event.data as {type?: unknown} | null
+                    if (!data || data.type !== "tools:oauth:complete") return
+                    succeeded = true
+                    teardown()
+                    onSuccess()
+                }
+                window.addEventListener("message", onMessage)
+
+                const poll = window.setInterval(() => {
+                    if (!popupRef.current?.closed || succeeded) return
+                    // Abandon: closed without a success message.
+                    teardown()
+                    if (settleParkedCall)
+                        finish({connected: false, integration, slug, reason: "cancelled"})
+                    else setPhase("idle")
+                }, POPUP_POLL_MS)
+
+                const timeout = window.setTimeout(() => {
+                    if (succeeded) return
+                    teardown()
+                    if (settleParkedCall)
+                        finish({connected: false, integration, slug, reason: "timeout"})
+                    else setPhase("idle")
+                }, CONNECT_TIMEOUT_MS)
+
+                cleanupRef.current = () => {
+                    window.removeEventListener("message", onMessage)
+                    window.clearInterval(poll)
+                    window.clearTimeout(timeout)
+                    try {
+                        popupRef.current?.close()
+                    } catch {
+                        // best effort
+                    }
+                }
+            } catch (err) {
+                const message = err instanceof Error ? err.message : "Connection failed."
+                // A create failure is terminal for the parked call: settle so the run resumes; for a
+                // manual retry just surface the reason with another Retry.
+                setPhase("error")
+                setErrorText(message)
+                if (settleParkedCall) finish({connected: false, integration, slug, reason: message})
+            }
+        },
+        [phase, handleCreate, slug, mode, invalidate, finish, teardown, integration],
+    )
+
+    // Explicit cancel while the popup is open: settle the parked call as cancelled (or, for a manual
+    // retry, just stop).
+    const cancel = useCallback(() => {
+        teardown()
+        if (!settledRef.current) finish({connected: false, integration, slug, reason: "cancelled"})
+        else setPhase("idle")
+    }, [finish, teardown, integration, slug])
+
+    // ── Connecting: popup open (either the live flow or a manual retry) ──────────────────────────
+    if (phase === "connecting") {
+        return (
+            <ChipRow icon={<Spinner size={13} className="animate-spin text-colorPrimary" />}>
+                <Text type="secondary" className="!text-xs">
+                    Connecting {label}…
+                </Text>
+                <Button type="text" onClick={cancel} className="!px-2">
+                    Cancel
+                </Button>
+            </ChipRow>
+        )
+    }
+
+    // ── Settled: the result chip (U1) ───────────────────────────────────────────────────────────
+    if (meta.settled) {
+        const output = (meta.output ?? {}) as ConnectOutput
+        if (manuallyConnected || output.connected === true) {
+            return (
+                <ChipRow
+                    icon={<CheckCircle size={13} weight="fill" className="text-colorSuccess" />}
+                >
+                    <Text className="!text-xs">{label} connected</Text>
+                </ChipRow>
+            )
+        }
+        // Cancelled / timeout / failed: a Retry re-runs the OAuth fresh (the parked call already
+        // resolved, so this primes the vault and flips the chip on success).
+        return (
+            <ChipRow icon={<Warning size={13} weight="fill" className="text-colorWarning" />}>
+                <Text type="secondary" className="!text-xs">
+                    Connection not completed
+                </Text>
+                <RetryButton onClick={() => runConnect(false)} />
+            </ChipRow>
+        )
+    }
+
+    // ── Error (create failed, popup blocked) on the live flow: show reason + Retry ───────────────
+    if (phase === "error") {
+        return (
+            <ChipRow icon={<Warning size={13} weight="fill" className="text-colorError" />}>
+                <Text type="danger" className="!text-xs truncate" title={errorText ?? undefined}>
+                    {errorText ?? "Connection failed."}
+                </Text>
+                <RetryButton onClick={() => runConnect(true)} />
+            </ChipRow>
+        )
+    }
+
+    // ── Idle: the initial prompt ────────────────────────────────────────────────────────────────
+    return (
+        <ChipRow icon={<Plugs size={13} className="text-colorPrimary" />}>
+            <Text className="!text-xs">Connect {label}</Text>
+            <Button type="primary" onClick={() => runConnect(true)}>
+                Connect
+            </Button>
+        </ChipRow>
+    )
+}
+
+/** A compact tool-activity row, matching ToolActivity's visual language. */
+const ChipRow = ({icon, children}: {icon: React.ReactNode; children: React.ReactNode}) => (
+    <div className="flex min-w-0 items-center gap-2 py-1">
+        <span className="shrink-0">{icon}</span>
+        {children}
+    </div>
+)
+
+const RetryButton = ({onClick, disabled}: {onClick: () => void; disabled?: boolean}) => (
+    <Button
+        type="text"
+        onClick={onClick}
+        disabled={disabled}
+        icon={<ArrowClockwise size={13} />}
+        className="!px-2"
+    >
+        Retry
+    </Button>
+)
+
+export default ConnectToolWidget

--- a/web/oss/src/components/AgentChatSlice/components/clientTools/UnhandledClientTool.tsx
+++ b/web/oss/src/components/AgentChatSlice/components/clientTools/UnhandledClientTool.tsx
@@ -1,0 +1,33 @@
+/**
+ * Fallback surface for a parked client tool with no registered widget (design §"Where dispatch
+ * lives"). It must SETTLE the part so the run never hangs silently: on mount it settles an error,
+ * which resumes the run and lets the agent re-ask or move on. The row stays as a brief explanation.
+ */
+import {useEffect, useRef} from "react"
+
+import {Warning} from "@phosphor-icons/react"
+import {Typography} from "antd"
+
+import type {ClientToolHandlerProps} from "./types"
+
+const {Text} = Typography
+
+const UnhandledClientTool = ({meta, settle}: ClientToolHandlerProps) => {
+    const settledRef = useRef(false)
+    useEffect(() => {
+        if (settledRef.current || meta.settled) return
+        settledRef.current = true
+        settle({errorText: `This app can’t handle the "${meta.toolName}" request.`})
+    }, [meta.settled, meta.toolName, settle])
+
+    return (
+        <div className="flex min-w-0 items-center gap-2 py-1">
+            <Warning size={13} weight="fill" className="shrink-0 text-colorWarning" />
+            <Text type="secondary" className="!text-xs truncate">
+                Can’t handle the “{meta.toolName}” request
+            </Text>
+        </div>
+    )
+}
+
+export default UnhandledClientTool

--- a/web/oss/src/components/AgentChatSlice/components/clientTools/index.ts
+++ b/web/oss/src/components/AgentChatSlice/components/clientTools/index.ts
@@ -1,0 +1,9 @@
+/**
+ * Client-tool round-trip (#4920): a browser-fulfilled tool the runner emits-and-parks, dispatched
+ * here by `render.kind` → `toolName` → an explicit "can't handle that" fallback. v1 ships the
+ * connect widget (`request_connection`). See `types.ts` for the contract.
+ */
+export {default as ClientToolPart, type ClientToolOutputHandler} from "./ClientToolPart"
+export {clientToolMeta, isClientToolPart, clientToolName} from "./meta"
+export {hasClientToolHandler, resolveClientToolHandler} from "./registry"
+export type {ClientToolMeta, ClientToolHandlerProps} from "./types"

--- a/web/oss/src/components/AgentChatSlice/components/clientTools/meta.ts
+++ b/web/oss/src/components/AgentChatSlice/components/clientTools/meta.ts
@@ -1,0 +1,66 @@
+/**
+ * Normalise a tool UI part into the {@link ClientToolMeta} the dispatcher reads, and decide whether
+ * a part is a client tool the playground must fulfill (vs an ordinary server tool or an approval
+ * gate, which `ToolActivity` owns).
+ */
+import type {ToolUIPart} from "ai"
+
+import {hasClientToolHandler} from "./registry"
+import type {ClientToolMeta} from "./types"
+
+const SETTLED = new Set(["output-available", "output-error"])
+const APPROVAL = new Set(["approval-requested", "approval-responded"])
+
+/** Friendly tool name: `tool-<name>` carries it in the type; `dynamic-tool` on `toolName`. */
+export const clientToolName = (part: ToolUIPart): string => {
+    const type = part.type as string
+    if (type === "dynamic-tool") return (part as {toolName?: string}).toolName || "tool"
+    return type.replace(/^tool-/, "")
+}
+
+/** Read the optional render hint off the part (may be absent on the wire in v1). */
+const renderKindOf = (part: ToolUIPart): string | undefined => {
+    const render = (part as {render?: {kind?: unknown}}).render
+    return render && typeof render.kind === "string" ? render.kind : undefined
+}
+
+export const clientToolMeta = (part: ToolUIPart): ClientToolMeta => {
+    const state = part.state as string
+    return {
+        toolCallId: part.toolCallId,
+        toolName: clientToolName(part),
+        renderKind: renderKindOf(part),
+        state,
+        input: (part as {input?: unknown}).input,
+        output: (part as {output?: unknown}).output,
+        settled: SETTLED.has(state),
+        part,
+    }
+}
+
+/**
+ * Whether a tool part is a client tool the playground renders (a widget or a settled chip), rather
+ * than letting it fall through to `ToolActivity`. Two ways a part qualifies:
+ *
+ *  1. **Known client tool** — its `render.kind`/`toolName` is in the registry. Rendered in every
+ *     state so the result UX (chip) shows after it settles.
+ *  2. **Parked unknown client tool** — the turn has finished (not streaming) yet a non-provider-
+ *     executed tool part is still unsettled and is not an approval gate. The runner only leaves a
+ *     part in this "turn done, part unsettled, not providerExecuted" state for a client tool, so we
+ *     surface the explicit "can't handle that" widget (which settles the part so it never hangs).
+ */
+export const isClientToolPart = (
+    part: ToolUIPart,
+    ctx: {isStreaming: boolean; isLastMessage: boolean},
+): boolean => {
+    const state = part.state as string
+    if (APPROVAL.has(state)) return false
+    if ((part as {providerExecuted?: boolean}).providerExecuted === true) return false
+
+    const meta = clientToolMeta(part)
+    if (hasClientToolHandler(meta)) return true
+
+    // Parked unknown client tool: the run ended with this part still unsettled.
+    const parkedUnsettled = !ctx.isStreaming && ctx.isLastMessage && !meta.settled
+    return parkedUnsettled
+}

--- a/web/oss/src/components/AgentChatSlice/components/clientTools/registry.tsx
+++ b/web/oss/src/components/AgentChatSlice/components/clientTools/registry.tsx
@@ -1,0 +1,39 @@
+/**
+ * Client-tool handler registry (#4920).
+ *
+ * Dispatch precedence is **`render.kind` → `toolName` → generic fallback** (design §"Where dispatch
+ * lives"). v1 ships exactly one real entry, `request_connection` (the connect widget), keyed by both
+ * its `render.kind` (`connect`) and its `toolName` so it dispatches whether or not the render hint
+ * reaches the browser (verify-first seam #1: for v1 we dispatch by `toolName`). Each later client
+ * tool is one added entry, not a protocol change.
+ *
+ * A streamed client tool with no entry is NOT an error here — `ClientToolPart` renders the explicit
+ * "this app can't handle that request" surface and settles the part so the run never hangs.
+ */
+import type {ComponentType} from "react"
+
+import ConnectToolWidget from "./ConnectToolWidget"
+import type {ClientToolHandlerProps, ClientToolMeta} from "./types"
+
+type ClientToolHandler = ComponentType<ClientToolHandlerProps>
+
+/** Handlers keyed by `render.kind` (checked first — the finer dispatch axis). */
+const BY_RENDER_KIND: Record<string, ClientToolHandler> = {
+    connect: ConnectToolWidget,
+}
+
+/** Handlers keyed by `toolName` (checked when no render hint matched). */
+const BY_TOOL_NAME: Record<string, ClientToolHandler> = {
+    request_connection: ConnectToolWidget,
+}
+
+/** Resolve the widget for a client tool, or `null` when none is registered. */
+export const resolveClientToolHandler = (meta: ClientToolMeta): ClientToolHandler | null => {
+    if (meta.renderKind && BY_RENDER_KIND[meta.renderKind]) return BY_RENDER_KIND[meta.renderKind]
+    if (BY_TOOL_NAME[meta.toolName]) return BY_TOOL_NAME[meta.toolName]
+    return null
+}
+
+/** Whether this client tool has a dedicated widget (used to route known tools in every state). */
+export const hasClientToolHandler = (meta: ClientToolMeta): boolean =>
+    resolveClientToolHandler(meta) !== null

--- a/web/oss/src/components/AgentChatSlice/components/clientTools/types.ts
+++ b/web/oss/src/components/AgentChatSlice/components/clientTools/types.ts
@@ -1,0 +1,52 @@
+/**
+ * Shared types for the client-tool round-trip (#4920).
+ *
+ * A *client tool* is a tool the playground fulfills, not the sandbox. The runner streams the call
+ * as a standard unsettled tool part (`tool-input-available`, no output, `providerExecuted` falsy)
+ * and parks the turn. The playground dispatches a widget; the widget drives the interaction and
+ * settles the part with a structured **reference** (never a secret) via `addToolOutput`. The
+ * `sendAutomaticallyWhen` predicate then auto-resends and the runner resumes on cold-replay.
+ *
+ * These types are structural (no `ai` import) so the dispatcher, registry, and widgets agree on the
+ * one shape they read off a UI message part.
+ */
+import type {ToolUIPart} from "ai"
+
+/** The optional presentation hint that rides the one-way render channel (`data-<name>`). v1 may not
+ * see it on the wire — dispatch falls back to `toolName` — but the shape is reserved so a future
+ * `render.kind` (e.g. `config-diff`) lands with no protocol change. */
+export interface ClientToolRenderHint {
+    kind?: string
+}
+
+/**
+ * Normalised view of a tool part the dispatcher works with. `toolName` is read off the typed
+ * `tool-<name>` part type or a `dynamic-tool`'s `toolName`; `renderKind` off the (optional) render
+ * hint. `state` is the AI SDK tool-part state machine value.
+ */
+export interface ClientToolMeta {
+    toolCallId: string
+    toolName: string
+    renderKind?: string
+    state: string
+    input: unknown
+    output: unknown
+    /** A browser-fulfilled result already settled it (`output-available`/`output-error`). */
+    settled: boolean
+    /** The raw part, for handlers that need fields beyond the normalised view. */
+    part: ToolUIPart
+}
+
+/** Settle the parked part. Mirrors `addToolOutput` but keyed by the values a widget already holds.
+ * Exactly one of `output` / `errorText` is supplied (success vs error envelope). */
+export interface SettleClientTool {
+    (args: {output: Record<string, unknown>}): void
+    (args: {errorText: string}): void
+}
+
+/** Props every client-tool widget receives. */
+export interface ClientToolHandlerProps {
+    meta: ClientToolMeta
+    /** Settle the part (resumes the run). No-op once already settled. */
+    settle: SettleClientTool
+}

--- a/web/packages/agenta-entities/src/workflow/index.ts
+++ b/web/packages/agenta-entities/src/workflow/index.ts
@@ -230,6 +230,7 @@ export {
     // Cache invalidation
     invalidateWorkflowsListCache,
     invalidateWorkflowCache,
+    invalidateAgentCommittedRevisionCache,
     seedCreatedWorkflowCache,
     // ListQueryState wrappers (for selection adapters and relations)
     workflowVariantsListQueryStateAtomFamily,

--- a/web/packages/agenta-entities/src/workflow/state/index.ts
+++ b/web/packages/agenta-entities/src/workflow/state/index.ts
@@ -62,6 +62,7 @@ export {
     // Cache invalidation
     invalidateWorkflowsListCache,
     invalidateWorkflowCache,
+    invalidateAgentCommittedRevisionCache,
     seedCreatedWorkflowCache,
     // ListQueryState wrappers (for selection adapters and relations)
     workflowVariantsListQueryStateAtomFamily,

--- a/web/packages/agenta-entities/src/workflow/state/store.ts
+++ b/web/packages/agenta-entities/src/workflow/state/store.ts
@@ -2473,3 +2473,25 @@ export function invalidateWorkflowRevisionsByVariantCache(
     }
     store.set(workflowRevisionsQueryAtomFamily(variantId))
 }
+
+/**
+ * Refresh the playground's read-only views after the agent commits a new revision of itself
+ * (#4920 — Application 1). A commit lands a new revision, so this invalidates both the
+ * latest-revision query (the config panel + section drawers re-read the new config) and the inspect
+ * query (harness-capabilities / any inspect-derived view).
+ *
+ * Fired on the one-way `data-committed-revision` stream signal (which the backend emits in BOTH the
+ * gated approval path and the direct `needs_approval=false` path), not on approval — so a single
+ * emit point covers both. The payload's ids aren't needed: a prefix invalidation refetches every
+ * active observer, which is exactly the set the playground has mounted.
+ */
+export function invalidateAgentCommittedRevisionCache(options?: StoreOptions) {
+    const store = getStore(options)
+    try {
+        const qc = store.get(queryClientAtom)
+        qc.invalidateQueries({queryKey: ["workflows", "latestRevision"], exact: false})
+        qc.invalidateQueries({queryKey: ["workflows", "inspect"], exact: false})
+    } catch {
+        // queryClientAtom may not be initialized yet
+    }
+}

--- a/web/packages/agenta-playground/src/state/execution/agentApprovalResume.ts
+++ b/web/packages/agenta-playground/src/state/execution/agentApprovalResume.ts
@@ -1,21 +1,26 @@
 /**
- * Agent-lane HITL resume predicate.
+ * Agent-lane resume predicate — for BOTH parked client tools and HITL approval gates.
  *
- * `useChat`'s `sendAutomaticallyWhen` decides when the conversation auto-resends after the
- * user resolves a tool-approval gate. The AI SDK ships
- * `lastAssistantMessageIsCompleteWithApprovalResponses`, which DOES fire for a deny-only
- * decision (a denied tool part is still `approval-responded`). We wrap it in an explicit,
- * unit-tested predicate so the deny → resume contract is pinned at the FE seam rather than
- * left implicit in the SDK internals:
+ * `useChat`'s `sendAutomaticallyWhen` decides when the conversation auto-resends after a parked
+ * client interaction settles. The agent FE round-trip (#4920) generalizes the existing approval
+ * round-trip to an arbitrary browser-fulfilled tool: the runner emits the tool call and parks the
+ * turn; the playground fulfills it with `addToolOutput`; the turn must then auto-resend so the
+ * runner cold-replays and resumes. Two settle shapes drive a resume here:
  *
- *   - Approve and Deny BOTH resume. On resume the runner receives the `{approved}` envelope
- *     (the SDK ingress maps an `approval-responded` tool part to a `tool_result`), maps a
- *     deny to reject → tool-error, and the model continues — no deadlock, no limbo
- *     `approval-responded` state (the F-036 dead-end).
- *   - A pending gate (`approval-requested`, still awaiting the user) does NOT resume.
+ *   - **Approval response.** Approve AND Deny both resume — a denied tool part is still
+ *     `approval-responded`, so the runner gets the denial round-trip (the SDK ingress maps it to a
+ *     `tool_result`, a deny → tool-error) and the model continues. No `approval-responded` limbo
+ *     (the F-036 dead-end).
+ *   - **Client-tool result.** A parked client tool fulfilled by the browser settles to
+ *     `output-available`/`output-error` with `providerExecuted` falsy (it was NOT run server-side).
+ *     That fulfilled output must resume the run exactly as an approval does.
  *
- * Pure + structurally typed so the package needs no `ai` dependency: it reads only the
- * fields the AI SDK puts on a UI message (`role`, `parts[].type/state/approval`).
+ * A pending interaction (`approval-requested`, or a still-`input-available` client tool awaiting the
+ * user) does NOT resume. Server-executed tool parts (`providerExecuted === true`) are ignored — they
+ * settle within the turn and never park, so they neither gate nor trigger a resume.
+ *
+ * Pure + structurally typed so the package needs no `ai` dependency: it reads only the fields the AI
+ * SDK puts on a UI message (`role`, `parts[].type/state/providerExecuted`).
  */
 
 interface ApprovalLike {
@@ -43,6 +48,24 @@ const isToolPart = (part: ToolPartLike): boolean => {
 const isRespondedToolPart = (part: ToolPartLike): boolean =>
     isToolPart(part) && part.state === "approval-responded"
 
+/**
+ * A browser-fulfilled client-tool result: a tool part the playground settled via `addToolOutput`
+ * (`output-available`/`output-error`) that the server did NOT run (`providerExecuted` falsy) and
+ * carries NO approval metadata. This is how a parked `request_connection` (or any client tool) reads
+ * once the widget settles it.
+ *
+ * The `approval == null` guard is load-bearing: an approval-gated tool that was approved and then RAN
+ * also lands in `output-available` with `providerExecuted` falsy, but it is NOT a parked client tool
+ * (its turn already continued) — it keeps its `approval` field, so excluding it here stops a spurious
+ * resume (and stops the queue gate, which composes this predicate, from holding forever). v1 client
+ * tools are never approval-gated; an approval-gated client tool would need a richer signal.
+ */
+const isClientToolResult = (part: ToolPartLike): boolean =>
+    isToolPart(part) &&
+    part.providerExecuted !== true &&
+    part.approval == null &&
+    (part.state === "output-available" || part.state === "output-error")
+
 /** A resolved tool part is settled when it has run, errored, or carries a decision. */
 const isSettledToolPart = (part: ToolPartLike): boolean =>
     isToolPart(part) &&
@@ -51,10 +74,14 @@ const isSettledToolPart = (part: ToolPartLike): boolean =>
         part.state === "approval-responded")
 
 /**
- * Resume when the last assistant turn carries at least one responded approval and EVERY
- * non-provider-executed tool part on it is settled. Deny-only counts: a denied tool part is
- * `approval-responded`, so a turn the user only denied still resumes and the runner gets the
- * denial round-trip (the fix for the deny dead-end).
+ * Resume when the last assistant turn carries at least one freshly-resolved parked interaction (an
+ * approval response OR a browser-fulfilled client-tool result) and EVERY non-provider-executed tool
+ * part on it is settled. Both paths share one rule so a single `sendAutomaticallyWhen` covers
+ * approvals and client tools alike:
+ *   - Approval (approve OR deny): a denied tool part is `approval-responded`, so a deny-only turn
+ *     still resumes and the runner gets the denial round-trip (the deny dead-end fix).
+ *   - Client tool: a `request_connection` the widget settled (success, cancel, failure, abandon)
+ *     reads as a client-tool result, so the run resumes and the runner re-resolves on cold-replay.
  */
 export function agentShouldResumeAfterApproval({messages}: {messages: MessageLike[]}): boolean {
     const last = messages[messages.length - 1]
@@ -65,7 +92,9 @@ export function agentShouldResumeAfterApproval({messages}: {messages: MessageLik
     )
     if (toolParts.length === 0) return false
 
-    const hasResponded = toolParts.some(isRespondedToolPart)
+    const hasResolved = toolParts.some(
+        (part) => isRespondedToolPart(part) || isClientToolResult(part),
+    )
     const allSettled = toolParts.every(isSettledToolPart)
-    return hasResponded && allSettled
+    return hasResolved && allSettled
 }

--- a/web/packages/agenta-playground/tests/unit/agentApprovalResume.test.ts
+++ b/web/packages/agenta-playground/tests/unit/agentApprovalResume.test.ts
@@ -27,6 +27,22 @@ const assistantWithTool = (state: string, approved?: boolean) => ({
     ],
 })
 
+/** A parked client tool (e.g. `request_connection`): no approval, `providerExecuted` falsy. */
+const assistantWithClientTool = (state: string, output?: unknown) => ({
+    id: "a1",
+    role: "assistant",
+    parts: [
+        {type: "step-start"},
+        {
+            type: "tool-request_connection",
+            toolCallId: "call_c",
+            state,
+            input: {integration: "github"},
+            ...(output === undefined ? {} : {output}),
+        },
+    ],
+})
+
 describe("agentShouldResumeAfterApproval", () => {
     it("RESUMES on a deny-only decision (the F-036 dead-end fix)", () => {
         const messages = [user("do it"), assistantWithTool("approval-responded", false)]
@@ -114,6 +130,100 @@ describe("agentShouldResumeAfterApproval", () => {
 
     it("does NOT resume when there are no messages", () => {
         expect(agentShouldResumeAfterApproval({messages: []})).toBe(false)
+    })
+
+    it("RESUMES when a parked client tool is fulfilled (output-available)", () => {
+        const messages = [
+            user("connect github"),
+            assistantWithClientTool("output-available", {
+                connected: true,
+                integration: "github",
+                slug: "github-main",
+            }),
+        ]
+        expect(agentShouldResumeAfterApproval({messages})).toBe(true)
+    })
+
+    it("RESUMES when a client tool settles as a failure (cancel/abandon/error)", () => {
+        const messages = [
+            user("connect github"),
+            assistantWithClientTool("output-error", undefined),
+        ]
+        // output-error counts as settled even with no `output` payload (errorText path).
+        expect(agentShouldResumeAfterApproval({messages})).toBe(true)
+    })
+
+    it("does NOT resume while a client tool is still parked (input-available)", () => {
+        const messages = [user("connect github"), assistantWithClientTool("input-available")]
+        expect(agentShouldResumeAfterApproval({messages})).toBe(false)
+    })
+
+    it("does NOT resume while a client tool is still streaming its input", () => {
+        const messages = [user("connect github"), assistantWithClientTool("input-streaming")]
+        expect(agentShouldResumeAfterApproval({messages})).toBe(false)
+    })
+
+    it("resumes when a fulfilled client tool sits alongside a responded approval", () => {
+        const messages = [
+            user("do it then connect"),
+            {
+                id: "a1",
+                role: "assistant",
+                parts: [
+                    {type: "step-start"},
+                    {
+                        type: "tool-deleteFile",
+                        toolCallId: "call_1",
+                        state: "approval-responded",
+                        input: {path: "/x"},
+                        approval: {id: "perm_1", approved: true},
+                    },
+                    {
+                        type: "tool-request_connection",
+                        toolCallId: "call_c",
+                        state: "output-available",
+                        input: {integration: "github"},
+                        output: {connected: true, integration: "github", slug: "github-main"},
+                    },
+                ],
+            },
+        ]
+        expect(agentShouldResumeAfterApproval({messages})).toBe(true)
+    })
+
+    it("does NOT resume when a fulfilled client tool sits beside an unsettled sibling", () => {
+        const messages = [
+            user("connect both"),
+            {
+                id: "a1",
+                role: "assistant",
+                parts: [
+                    {type: "step-start"},
+                    {
+                        type: "tool-request_connection",
+                        toolCallId: "call_c",
+                        state: "output-available",
+                        input: {integration: "github"},
+                        output: {connected: true, integration: "github", slug: "github-main"},
+                    },
+                    {
+                        type: "tool-request_connection",
+                        toolCallId: "call_d",
+                        state: "input-available",
+                        input: {integration: "slack"},
+                    },
+                ],
+            },
+        ]
+        expect(agentShouldResumeAfterApproval({messages})).toBe(false)
+    })
+
+    it("does NOT resume for an APPROVED tool that ran (output-available WITH approval)", () => {
+        // An approval-gated tool that was approved and then produced output keeps its `approval`
+        // field. It is not a parked client tool — the turn already continued — so it must not be
+        // read as a client-tool result (else the queue gate, which composes this, holds forever).
+        const messages = [user("do it"), assistantWithTool("output-available", true)]
+        expect(agentShouldResumeAfterApproval({messages})).toBe(false)
     })
 
     it("ignores provider-executed tool parts when deciding completeness", () => {


### PR DESCRIPTION
## Context

Some tools the agent uses require user interaction before they can complete. The OAuth connection flow is the main case: the agent asks the user to connect an integration (GitHub, Slack, etc.), the user finishes sign-in in the browser, and the run must resume with the result. The existing runner handled only `approved`/`denied` permission decisions and had no path for structured output from a client-side tool call.

This PR wires the backend side of that round-trip. The frontend slice (message-part dispatcher, connect widget, resume predicate, result UX, config refresh on commit) is a separate deliverable, coordinated with @ardaerzin.

Design: `docs/design/agent-workflows/projects/agent-fe-roundtrip/design.md`

## Changes

**TS runner** (`services/agent/`):

- `responder.ts` — `Responder` gains `onClientTool(req)`. `ApprovalDecisions` now holds `{ output: unknown }` in addition to permission decisions. `parkedCallKey` replaces `approvalKey` everywhere (the old name implied approval-only semantics).
- `permissions.ts` — Before dispatching a tool, checks `spec.kind === "client"`. If so, emits `interaction_request(kind: "client_tool")` and parks via `responder.onClientTool`. The tool call stays parked until the frontend sends a result.
- `dispatch.ts` — Client tools no longer throw. They return a `{type: "client_tool_pending"}` signal; the permission responder owns the park.

**SDK** (`sdks/python/`):

- `adapters/vercel/messages.py` — `TOOL_OUTPUT_AVAILABLE_TYPES` is now a set containing both `"tool-output-available"` and `"TOOL_OUTPUT_AVAILABLE"`. The previous check was case-exact and dropped uppercase variants from some clients.
- `agents/platform/workflow.py` — Registers `__ag__request_connection` as a hard-coded client tool that resolves to `ClientToolSpec(kind="client", render={"kind": "connect"})`. Agents that include this workflow as a tool get the connect affordance without any backend call.

**API**:

- `core/workflows/static_catalog.py` — Registers `__ag__request_connection` under URI `client:tool:request_connection:v0` alongside the getting-started skill.
- `apis/fastapi/tools/router.py` and `workflows/router.py` — Both `commit_revision` paths now emit a one-way `data-committed-revision` event `{variantId, revisionId, version}` after a successful commit. The frontend uses this to refresh the build-kit state without a separate poll.

## Scope / risk

This is the backend slice only. The interaction loop is incomplete until the frontend dispatches `client_tool` interaction events and sends results back. Until that lands, a `kind: "client"` tool call will emit the event and park but never resume. The agent will appear to hang at that point.

The `_emit_data_event` helper in both API routers resolves `request.state.emit` with a fallback to `emit_event`. If neither attribute exists (e.g., outside a streaming context), it exits silently. Reviewers should confirm the `emit` attribute is reliably present on `request.state` in the tool-call and workflow-commit code paths, or that silent failure is the right behavior.

The `parkedCallKey` rename is purely cosmetic. It does not change behavior. The test files were updated to match.

## Tests

- Vitest: `responder.test.ts`, `sandbox-agent-orchestration.test.ts`, `sandbox-agent-permissions.test.ts` updated for `parkedCallKey` rename and expanded `Responder` interface.
- Codex-reported: 44 TS tests across 3 files, all passing. `ruff format+check` clean on API + SDK. `tsc --noEmit` clean.

## How to QA

**Prerequisites:** local dev stack with the agent sidecar running. The frontend slice is not yet merged, so the round-trip cannot be exercised end-to-end. This PR can be verified at the unit-test level only.

**Automated tests:**
```
cd services/agent && npx vitest run tests/unit/responder.test.ts tests/unit/sandbox-agent-permissions.test.ts
cd api && uv run python -m pytest oss/tests/pytest/ -k "commit_revision" -v
```

**What to verify:** Run the TS tests and confirm the `parkedCallKey` rename did not break any assertion. Confirm the API router tests still pass after the `_emit_data_event` addition.

**Edge cases:** The `_emit_data_event` call in the tools router reads `outputs` as a dict and exits if `variantId`/`revisionId`/`version` are absent. Confirm a `commit_revision` call that returns a non-dict output does not raise.

https://claude.ai/code/session_01GYo3UEfvsZpncagqb28Mbc