### PR TITLE
feat(agent): playground build kit (default agent config)

### DIFF
--- a/api/oss/src/apis/fastapi/applications/models.py
+++ b/api/oss/src/apis/fastapi/applications/models.py
@@ -1,4 +1,4 @@
-from typing import Optional, List
+from typing import Any, Dict, Optional, List
 
 from pydantic import BaseModel, Field
 
@@ -599,6 +599,49 @@ class SimpleApplicationQueryRequest(BaseModel):
     )
 
 
+class AgentTemplateOverlay(BaseModel):
+    """A documented subset of the `parameters.agent` authoring shape.
+
+    Carries the platform-owned tools, authoring skills, and sandbox elevation the playground
+    layers on top of the draft for the build kit. Entries are intentionally open (platform-op
+    configs and `@ag.embed` references), so they are typed loosely: the full `parameters.agent`
+    authoring template has no shared Pydantic model today (it rides as free-form
+    `data.parameters`), and the SDK's runtime `AgentTemplate` is the flattened parse with
+    different field names, so neither can be reused 1:1 to type this overlay.
+    """
+
+    tools: List[Dict[str, Any]] = Field(
+        default_factory=list,
+        description="Platform tool configs and `@ag.embed` tool references.",
+    )
+    skills: List[Dict[str, Any]] = Field(
+        default_factory=list,
+        description="`@ag.embed` references to authoring skills.",
+    )
+    sandbox: Optional[Dict[str, Any]] = Field(
+        default=None,
+        description="Sandbox section overlay, e.g. `{permissions: {...}}`.",
+    )
+
+
+class PlaygroundBuildKitContext(BaseModel):
+    """Read-only playground build-kit context for one inspect/fetch response."""
+
+    agent_template_overlay: Optional[AgentTemplateOverlay] = Field(
+        default=None,
+        description="Partial `parameters.agent` overlay applied by the playground only.",
+    )
+
+
+class SimpleApplicationAdditionalContext(BaseModel):
+    """Platform-supplied read-only context for a simple-application response."""
+
+    playground_build_kit: Optional[PlaygroundBuildKitContext] = Field(
+        default=None,
+        description="Playground-only build kit data that is never persisted on the app.",
+    )
+
+
 class SimpleApplicationResponse(BaseModel):
     """Simple-application single-row response envelope."""
 
@@ -612,6 +655,10 @@ class SimpleApplicationResponse(BaseModel):
             "The application with `variant_id`, `revision_id`, and the "
             "revision's `data` merged. `data.url` is the invocation URL."
         ),
+    )
+    additional_context: Optional[SimpleApplicationAdditionalContext] = Field(
+        default=None,
+        description="Read-only platform context derived for this response.",
     )
 
 

--- a/api/oss/src/apis/fastapi/applications/overlay.py
+++ b/api/oss/src/apis/fastapi/applications/overlay.py
@@ -1,0 +1,92 @@
+"""Read-only overlays attached to application inspect/fetch responses."""
+
+from typing import Any, Dict, List, Optional
+
+from agenta.sdk.agents.adapters.agenta_builtins import GETTING_STARTED_WITH_AGENTA_SLUG
+from agenta.sdk.agents.platform.op_catalog import PLATFORM_OPS
+
+from oss.src.core.workflows.static_catalog import (
+    STATIC_SLUG_PREFIX,
+    StaticWorkflowCatalog,
+    _STATIC_WORKFLOWS,
+)
+
+
+def _workflow_embed(
+    slug: str,
+    *,
+    name: Optional[str],
+    selector_path: str,
+) -> Dict[str, Any]:
+    # The selector is load-bearing: without it the embed resolves to the whole revision.data
+    # (``{uri, parameters: {skill|tool: ...}}``), which neither the SDK skill parser nor the tool
+    # coercer accepts. ``parameters.skill`` / ``parameters.tool`` extracts the flat inline value
+    # the agent template expects (see test_skill_template_catalog canonical embed shape).
+    embed: Dict[str, Any] = {
+        "@ag.embed": {
+            "@ag.references": {"workflow": {"slug": slug}},
+            "@ag.selector": {"path": selector_path},
+        }
+    }
+    # The display name rides alongside the embed so the playground shows the workflow's name, not
+    # the raw ``__ag__*`` slug. Resolution replaces the whole entry, so this sibling is discarded
+    # before the tool/skill parser ever sees it.
+    if name:
+        embed["name"] = name
+    return embed
+
+
+def _reserved_static_tool_embeds(
+    catalog: StaticWorkflowCatalog,
+) -> List[Dict[str, Any]]:
+    """Tool embeds for the reserved static workflows that are tools (not skills).
+
+    Only confirmed non-skill static workflows with a resolvable revision are included; a missing
+    revision or missing flags is skipped so an invalid tool embed can't leak into the playground.
+    """
+    embeds: List[Dict[str, Any]] = []
+    for slug in _STATIC_WORKFLOWS:
+        if not slug.startswith(STATIC_SLUG_PREFIX):
+            continue
+        revision = catalog.retrieve_revision(slug=slug)
+        if not revision or not revision.flags or revision.flags.is_skill:
+            continue
+        embeds.append(
+            _workflow_embed(
+                slug,
+                name=revision.name,
+                selector_path="parameters.tool",
+            )
+        )
+    return embeds
+
+
+def build_agent_template_overlay() -> Dict[str, Any]:
+    """Build the playground-only agent-template overlay from platform-owned sources."""
+
+    catalog = StaticWorkflowCatalog()
+
+    skills: List[Dict[str, Any]] = []
+    authoring_skill = catalog.retrieve_revision(slug=GETTING_STARTED_WITH_AGENTA_SLUG)
+    if authoring_skill:
+        skills.append(
+            _workflow_embed(
+                GETTING_STARTED_WITH_AGENTA_SLUG,
+                name=authoring_skill.name,
+                selector_path="parameters.skill",
+            )
+        )
+
+    return {
+        "tools": [
+            *[{"type": "platform", "op": op_name} for op_name in PLATFORM_OPS],
+            *_reserved_static_tool_embeds(catalog),
+        ],
+        "skills": skills,
+        "sandbox": {
+            "permissions": {
+                "write_files": "allow",
+                "execute_code": "allow",
+            }
+        },
+    }

--- a/api/oss/src/apis/fastapi/applications/router.py
+++ b/api/oss/src/apis/fastapi/applications/router.py
@@ -66,9 +66,12 @@ from oss.src.apis.fastapi.applications.models import (
     SimpleApplicationCreateRequest,
     SimpleApplicationEditRequest,
     SimpleApplicationQueryRequest,
+    SimpleApplicationAdditionalContext,
     SimpleApplicationResponse,
     SimpleApplicationsResponse,
+    PlaygroundBuildKitContext,
 )
+from oss.src.apis.fastapi.applications.overlay import build_agent_template_overlay
 from oss.src.apis.fastapi.applications.utils import (
     parse_application_variant_query_request_from_params,
     parse_application_variant_query_request_from_body,
@@ -1902,9 +1905,28 @@ class SimpleApplicationsRouter:
             application_id=application_id,
         )
 
+        # Build the read-only playground overlay defensively: this handler returns a controlled
+        # default on error (``@suppress_exceptions``), so letting overlay synthesis raise would
+        # blank the whole fetched application instead of just dropping the optional context.
+        additional_context = None
+        if simple_application:
+            try:
+                additional_context = SimpleApplicationAdditionalContext(
+                    playground_build_kit=PlaygroundBuildKitContext(
+                        agent_template_overlay=build_agent_template_overlay(),
+                    ),
+                )
+            except Exception:  # noqa: BLE001 - overlay is best-effort; never blank the response
+                log.warning(
+                    "Failed to build playground build-kit overlay for application %s",
+                    application_id,
+                    exc_info=True,
+                )
+
         simple_application_response = SimpleApplicationResponse(
             count=1 if simple_application else 0,
             application=simple_application,
+            additional_context=additional_context,
         )
 
         return simple_application_response

--- a/api/oss/tests/pytest/unit/applications/test_build_kit_overlay.py
+++ b/api/oss/tests/pytest/unit/applications/test_build_kit_overlay.py
@@ -1,0 +1,192 @@
+from types import SimpleNamespace
+from unittest.mock import AsyncMock
+from uuid import uuid4
+
+import pytest
+
+from agenta.sdk.agents.adapters.agenta_builtins import GETTING_STARTED_WITH_AGENTA_SLUG
+from agenta.sdk.agents.dtos import AgentTemplate
+from agenta.sdk.agents.platform.op_catalog import PLATFORM_OPS
+from agenta.sdk.agents.tools.models import ClientToolConfig, PlatformToolConfig
+
+from oss.src.apis.fastapi.applications import router as applications_router_module
+from oss.src.apis.fastapi.applications.overlay import build_agent_template_overlay
+from oss.src.apis.fastapi.applications.router import SimpleApplicationsRouter
+from oss.src.core.applications.dtos import SimpleApplication
+from oss.src.core.embeds.service import EmbedsService
+from oss.src.core.workflows.dtos import WorkflowRevision, WorkflowRevisionData
+from oss.src.core.workflows.service import WorkflowsService
+from oss.src.core.workflows.static_catalog import (
+    STATIC_SLUG_PREFIX,
+    StaticWorkflowCatalog,
+    _STATIC_WORKFLOWS,
+)
+
+
+def _embed_slug(entry: dict) -> str | None:
+    refs = entry.get("@ag.embed", {}).get("@ag.references", {})
+    workflow = refs.get("workflow") or refs.get("workflow_revision") or {}
+    return workflow.get("slug")
+
+
+def test_agent_template_overlay_contains_platform_ops_authoring_skill_and_permissions():
+    overlay = build_agent_template_overlay()
+
+    platform_tools = [
+        tool
+        for tool in overlay["tools"]
+        if isinstance(tool, dict) and tool.get("type") == "platform"
+    ]
+    assert platform_tools == [
+        {"type": "platform", "op": op_name} for op_name in PLATFORM_OPS
+    ]
+
+    authoring_skill = StaticWorkflowCatalog().retrieve_revision(
+        slug=GETTING_STARTED_WITH_AGENTA_SLUG
+    )
+    assert overlay["skills"] == [
+        {
+            "name": authoring_skill.name,
+            "@ag.embed": {
+                "@ag.references": {
+                    "workflow": {"slug": GETTING_STARTED_WITH_AGENTA_SLUG}
+                },
+                "@ag.selector": {"path": "parameters.skill"},
+            },
+        }
+    ]
+    assert overlay["sandbox"] == {
+        "permissions": {"write_files": "allow", "execute_code": "allow"}
+    }
+
+
+def test_agent_template_overlay_includes_reserved_static_workflow_tool_embeds():
+    overlay = build_agent_template_overlay()
+    tool_embeds = [
+        tool
+        for tool in overlay["tools"]
+        if isinstance(tool, dict) and "@ag.embed" in tool
+    ]
+    tool_embed_slugs = {_embed_slug(tool) for tool in tool_embeds}
+    # Each tool embed must carry the canonical ``parameters.tool`` selector so it resolves to the
+    # flat inline tool config the SDK coercer accepts (regression: missing selector -> HTTP 500
+    # "Unsupported tool configuration shape").
+    assert all(
+        tool["@ag.embed"].get("@ag.selector") == {"path": "parameters.tool"}
+        for tool in tool_embeds
+    )
+    catalog = StaticWorkflowCatalog()
+
+    # Each tool embed carries the workflow's display name so the playground renders that instead of
+    # the raw ``__ag__*`` slug.
+    for tool in tool_embeds:
+        revision = catalog.retrieve_revision(slug=_embed_slug(tool))
+        assert tool.get("name") == revision.name
+
+    expected_slugs = set()
+    for slug in _STATIC_WORKFLOWS:
+        revision = catalog.retrieve_revision(slug=slug)
+        if (
+            slug.startswith(STATIC_SLUG_PREFIX)
+            and revision
+            and revision.flags
+            and not revision.flags.is_skill
+        ):
+            expected_slugs.add(slug)
+
+    assert tool_embed_slugs == expected_slugs
+
+
+@pytest.mark.asyncio
+async def test_fetch_simple_application_includes_build_kit_context(monkeypatch):
+    project_id = uuid4()
+    user_id = uuid4()
+    application_id = uuid4()
+
+    class DummySimpleApplicationsService:
+        applications_service = object()
+
+        async def fetch(self, **kwargs):
+            assert kwargs["project_id"] == project_id
+            assert kwargs["application_id"] == application_id
+            return SimpleApplication(id=application_id, slug="agent")
+
+    monkeypatch.setattr(
+        applications_router_module,
+        "check_action_access",
+        AsyncMock(return_value=True),
+        raising=False,
+    )
+
+    router = SimpleApplicationsRouter(
+        simple_applications_service=DummySimpleApplicationsService()
+    )
+    request = SimpleNamespace(
+        state=SimpleNamespace(project_id=str(project_id), user_id=str(user_id))
+    )
+
+    response = await router.fetch_simple_application(
+        request,
+        application_id=application_id,
+    )
+
+    overlay = (
+        response.additional_context.playground_build_kit.agent_template_overlay
+        if response.additional_context
+        and response.additional_context.playground_build_kit
+        else None
+    )
+    assert response.application is not None
+    # The overlay is now a typed `AgentTemplateOverlay`; its JSON projection is the wire payload and
+    # must match the platform-built overlay dict byte for byte.
+    assert overlay is not None
+    assert overlay.model_dump(mode="json") == build_agent_template_overlay()
+
+
+@pytest.mark.asyncio
+async def test_resolved_build_kit_overlay_parses_through_from_params():
+    """The overlay must survive embed resolution and parse with no error.
+
+    Regression: each ``@ag.embed`` reference dropped its ``@ag.selector``, so the resolver inlined
+    the whole ``revision.data`` and ``AgentTemplate.from_params`` raised HTTP 500
+    ``Unsupported tool configuration shape``. Exercises overlay -> embed resolution (static
+    catalogue, no DB) -> ``from_params`` end to end.
+    """
+    workflows_dao = AsyncMock()
+    workflows_service = WorkflowsService(
+        workflows_dao=workflows_dao,
+        static_catalog=StaticWorkflowCatalog(),
+    )
+    workflows_service.embeds_service = EmbedsService(
+        workflows_service=workflows_service
+    )
+
+    revision = WorkflowRevision(
+        id=uuid4(),
+        workflow_id=uuid4(),
+        workflow_variant_id=uuid4(),
+        slug="agent-default-config",
+        data=WorkflowRevisionData(parameters={"agent": build_agent_template_overlay()}),
+    )
+
+    resolved, _ = await workflows_service.resolve_workflow_revision(
+        project_id=uuid4(),
+        workflow_revision=revision,
+    )
+    # No reserved embed may touch Postgres.
+    workflows_dao.fetch_revision.assert_not_awaited()
+    workflows_dao.fetch_artifact.assert_not_awaited()
+
+    template = AgentTemplate.from_params({"agent": resolved.data.parameters["agent"]})
+
+    platform_ops = [
+        tool for tool in template.tools if isinstance(tool, PlatformToolConfig)
+    ]
+    client_tools = [
+        tool for tool in template.tools if isinstance(tool, ClientToolConfig)
+    ]
+    assert any(tool.op == "find_capabilities" for tool in platform_ops)
+    # The request_connection embed must coerce to a client tool, not a builtin.
+    assert [tool.name for tool in client_tools] == ["request_connection"]
+    assert client_tools[0].render == {"kind": "connect"}
+    assert [skill.name for skill in template.skills] == ["agenta-getting-started"]

--- a/services/oss/src/agent/schemas.py
+++ b/services/oss/src/agent/schemas.py
@@ -8,7 +8,6 @@ Kept in its own module so it composes into the workflow registration with a one-
 change and stays out of the handler logic.
 """
 
-from agenta.sdk.agents.adapters.agenta_builtins import GETTING_STARTED_WITH_AGENTA_SLUG
 from agenta.sdk.utils.types import build_agent_v0_default
 
 _SCHEMA = "https://json-schema.org/draft/2020-12/schema"
@@ -37,22 +36,9 @@ AGENT_INPUTS_SCHEMA = {
 # catalog type keeps the typed tools/mcps shape in one place; this schema only carries the default the
 # playground pre-fills. The agent handler passes `parameters` verbatim to `AgentTemplate.from_params`,
 # which reads the template at `parameters.agent` (so a tool is at `parameters.agent.tools`).
-# Reserved slug of the static default skill, served from code by the StaticWorkflowCatalog
-# (api/oss/src/core/workflows/static_catalog.py), never the database. The default config
-# references it by stable slug through an @ag.embed; the embed resolver inlines the catalogue's
-# SkillTemplate (at the canonical parameters.skill selector) before the runner sees it. The
-# `__ag__` prefix is reserved: a user cannot author or shadow it. This replaces both
-# AGENTA_FORCED_SKILLS and the old per-project skill seeder. Single source: the SDK constant.
-_DEFAULT_SKILL_SLUG = GETTING_STARTED_WITH_AGENTA_SLUG
-
-# The service default = the shared builder (single source, in the SDK) plus the two service-only
-# choices: the static default skill (inlined from the reserved slug) and the declared Layer-2
-# sandbox boundary the playground pre-fills. The SDK builtin interface uses the same builder
-# without these, so a new default field changes one place.
-_DEFAULT_AGENT_TEMPLATE = build_agent_v0_default(
-    skill_slug=_DEFAULT_SKILL_SLUG,
-    include_sandbox_permission=True,
-)
+# The published default stays bare. The playground build kit is served as read-only inspect/fetch
+# context and applied only to playground runs; it is not part of the committed agent template.
+_DEFAULT_AGENT_TEMPLATE = build_agent_v0_default()
 
 AGENT_TEMPLATE_SCHEMA = {
     "type": "object",

--- a/services/oss/tests/pytest/unit/agent/test_default_agent_template.py
+++ b/services/oss/tests/pytest/unit/agent/test_default_agent_template.py
@@ -16,7 +16,7 @@ from agenta.sdk.agents import AgentTemplate
 from agenta.sdk.engines.running.interfaces import agent_v0_interface
 from agenta.sdk.utils.types import build_agent_v0_default
 
-from oss.src.agent.schemas import AGENT_SCHEMAS, _DEFAULT_SKILL_SLUG
+from oss.src.agent.schemas import AGENT_SCHEMAS
 
 
 def _inspect_agent_default() -> dict:
@@ -35,50 +35,40 @@ def test_builtin_default_is_the_bare_builder():
     assert _builtin_agent_default() == build_agent_v0_default()
 
 
-def test_service_default_is_the_builder_plus_service_only_choices():
-    # The service default is the same builder plus the two service-only choices, passed as
-    # named args (not a second copy): the platform default skill and the declared sandbox boundary.
-    assert _inspect_agent_default() == build_agent_v0_default(
-        skill_slug=_DEFAULT_SKILL_SLUG,
-        include_sandbox_permission=True,
-    )
+def test_service_default_is_the_bare_builder():
+    # The playground build kit carries authoring extras; the published default stays bare.
+    assert _inspect_agent_default() == build_agent_v0_default()
 
 
 def test_inspect_default_parses_into_the_runtime_selection():
     # The default the playground pre-fills on `/inspect` must parse cleanly into the same runtime
-    # values `AgentTemplate.from_params` produces, so what the user sees is what the agent runs. The
-    # `@ag.embed` skill resolves server-side before this parse, so the config-level round-trip is
-    # asserted on the non-skill fields plus the execution selectors.
+    # values `AgentTemplate.from_params` produces, so what the user sees is what the agent runs.
     inspect_default = _inspect_agent_default()
-    no_skill = {k: v for k, v in inspect_default.items() if k != "skills"}
-    params = {"agent": no_skill}
+    params = {"agent": inspect_default}
 
     config = AgentTemplate.from_params(params)
 
     assert config.model == inspect_default["llm"]["model"]
     assert config.instructions == inspect_default["instructions"]["agents_md"]
-    assert (
-        config.sandbox_permission is not None
-    )  # the service boundary survives the parse
+    assert config.sandbox_permission is None
     assert config.harness == "pi_core"
     assert config.sandbox == "local"
     assert config.permission_policy == "auto"
 
 
-def test_service_only_extras_present_in_inspect_absent_from_builtin():
-    # The platform default skill and the sandbox boundary ride the SERVICE default (the playground
-    # pre-fill + the runtime fallback) and are intentionally ABSENT from the SDK builtin, which is
-    # the minimal harness-agnostic shape with no platform opinion. They are in both inspect and
-    # runtime via the SAME service default object, so they cannot drift between the two.
+def test_authoring_extras_absent_from_every_published_default():
+    # Platform tools, the authoring skill, and elevated sandbox permissions belong to the
+    # playground build-kit overlay, not to the published default template.
     inspect_default = _inspect_agent_default()
     builtin_default = _builtin_agent_default()
 
-    assert "permissions" in inspect_default["sandbox"]
-    assert (
-        inspect_default["skills"][0]["@ag.embed"]["@ag.references"]["workflow"]["slug"]
-        == _DEFAULT_SKILL_SLUG
-    )
+    assert inspect_default["tools"] == []
+    assert "skills" not in inspect_default
+    assert "permissions" not in inspect_default["sandbox"]
+    assert "execute_code" not in inspect_default["sandbox"]
+    assert "write_files" not in inspect_default["sandbox"]
 
+    assert builtin_default["tools"] == []
     assert "permissions" not in builtin_default["sandbox"]
     assert "skills" not in builtin_default
 

--- a/web/packages/agenta-entities/src/workflow/api/api.ts
+++ b/web/packages/agenta-entities/src/workflow/api/api.ts
@@ -17,6 +17,7 @@
 import {getAgentaSdkClient} from "@agenta/sdk"
 import {getAgentaApiUrl, axios} from "@agenta/shared/api"
 import {dereferenceSchema, generateId} from "@agenta/shared/utils"
+import {z} from "zod"
 
 import {parseRevisionUri, safeParseWithLogging} from "../../shared"
 import {extractAllEndpointSchemas, type OpenAPISpec} from "../../shared/openapi"
@@ -484,6 +485,82 @@ export async function inspectWorkflow(
     )
 
     return response.data ?? {}
+}
+
+// ============================================================================
+// SIMPLE APPLICATION FETCH (carries the read-only playground build-kit overlay)
+// ============================================================================
+
+/**
+ * Response shape from `GET /simple/applications/{application_id}`.
+ *
+ * The playground build kit's `agent_template_overlay` rides here, on
+ * `additional_context` — the backend's read-only, platform-derived container on
+ * `SimpleApplicationResponse`. The agent-service `/inspect` response carries no
+ * behavior-changing meta, so the overlay is read from this app fetch instead.
+ */
+export interface SimpleApplicationFetchResponse {
+    count?: number
+    application?: Record<string, unknown> | null
+    additional_context?: {
+        playground_build_kit?: {
+            agent_template_overlay?: Record<string, unknown> | null
+        } | null
+    } | null
+}
+
+// Boundary validation for the inspect/fetch overlay. Kept permissive — the overlay is a free-form
+// `parameters.agent` subset (platform ops + `@ag.embed` refs) — but it gates the shape that reaches
+// `workflowAgentTemplateOverlayAtomFamily`, so a non-object overlay is rejected here, not downstream.
+const simpleApplicationFetchResponseSchema = z.object({
+    count: z.number().optional(),
+    application: z.record(z.string(), z.unknown()).nullable().optional(),
+    additional_context: z
+        .object({
+            playground_build_kit: z
+                .object({
+                    agent_template_overlay: z.record(z.string(), z.unknown()).nullable().optional(),
+                })
+                .nullable()
+                .optional(),
+        })
+        .nullable()
+        .optional(),
+})
+
+/**
+ * Fetch a single simple application by id.
+ *
+ * Endpoint: `GET /simple/applications/{application_id}`. Returns the app with
+ * its current variant/revision `data` merged, plus `additional_context` holding
+ * the playground-only build-kit overlay.
+ *
+ * @param applicationId - The application (workflow artifact) id
+ * @param projectId - Project ID
+ */
+export async function fetchSimpleApplication(
+    applicationId: string,
+    projectId: string,
+): Promise<SimpleApplicationFetchResponse | null> {
+    if (!projectId || !applicationId) return null
+
+    // Fern-generated client (single source of truth for the request/response
+    // shape). Its types under-declare the backend's `extra="allow"`
+    // `additional_context`, so it is read defensively below.
+    const client = getAgentaSdkClient({host: getAgentaApiUrl()})
+    const data = await client.applications.fetchSimpleApplication(
+        {application_id: applicationId},
+        {queryParams: {project_id: projectId}},
+    )
+
+    // Validate at the boundary before the overlay reaches the atom family. Fern under-declares the
+    // backend's `extra="allow"` `additional_context`, so the local schema is the drift check.
+    const validated = safeParseWithLogging(
+        simpleApplicationFetchResponseSchema,
+        data,
+        "[fetchSimpleApplication]",
+    )
+    return (validated ?? null) as SimpleApplicationFetchResponse | null
 }
 
 // ============================================================================

--- a/web/packages/agenta-entities/src/workflow/api/index.ts
+++ b/web/packages/agenta-entities/src/workflow/api/index.ts
@@ -19,6 +19,9 @@ export {
     // Inspect (resolve full schema including inputs)
     inspectWorkflow,
     type InspectWorkflowResponse,
+    // Simple application fetch (carries the playground build-kit overlay)
+    fetchSimpleApplication,
+    type SimpleApplicationFetchResponse,
     // Interface schemas fetch (builtin workflow fallback)
     fetchInterfaceSchemas,
     type InterfaceSchemasResponse,

--- a/web/packages/agenta-entities/src/workflow/index.ts
+++ b/web/packages/agenta-entities/src/workflow/index.ts
@@ -53,6 +53,12 @@ export {
     type HarnessCapabilitiesMap,
 } from "./state/inspectMeta"
 
+export {
+    workflowAgentTemplateOverlayAtomFamily,
+    workflowBuildKitEnabledAtomFamily,
+    type AgentTemplate,
+} from "./state"
+
 // ============================================================================
 // SCHEMAS & TYPES
 // ============================================================================

--- a/web/packages/agenta-entities/src/workflow/state/commit.ts
+++ b/web/packages/agenta-entities/src/workflow/state/commit.ts
@@ -69,6 +69,8 @@ function prepareCommitParameters(
     entity: Workflow,
     flatParams: Record<string, unknown> | null,
 ): Record<string, unknown> | undefined {
+    // The playground build-kit overlay lives in read-only additional_context/session atoms. Commit
+    // reads only the user-owned revision config here, so platform ops and sandbox elevation stay out.
     const rawParams = stripAgentaMetadataDeep(entity.data?.parameters) as
         | Record<string, unknown>
         | undefined

--- a/web/packages/agenta-entities/src/workflow/state/index.ts
+++ b/web/packages/agenta-entities/src/workflow/state/index.ts
@@ -56,6 +56,9 @@ export {
     workflowEntityAtomFamily,
     workflowIsDirtyAtomFamily,
     workflowIsEphemeralAtomFamily,
+    workflowAgentTemplateOverlayAtomFamily,
+    workflowBuildKitEnabledAtomFamily,
+    type AgentTemplate,
     // Mutations
     updateWorkflowDraftAtom,
     discardWorkflowDraftAtom,

--- a/web/packages/agenta-entities/src/workflow/state/store.ts
+++ b/web/packages/agenta-entities/src/workflow/state/store.ts
@@ -23,11 +23,17 @@ import {nestEvaluatorConfiguration, nestEvaluatorSchema} from "../../runnable/ev
 import {syncPromptInputKeysInParameters} from "../../runnable/utils"
 import type {StoreOptions, ListQueryState} from "../../shared"
 import {generateLocalId, isLocalDraftId, isPlaceholderId} from "../../shared"
-import type {InspectWorkflowResponse, InterfaceSchemasResponse, AppOpenApiSchemas} from "../api"
+import type {
+    InspectWorkflowResponse,
+    InterfaceSchemasResponse,
+    AppOpenApiSchemas,
+    SimpleApplicationFetchResponse,
+} from "../api"
 import {
     extractDefaultsFromSchema,
     fetchWorkflowRevisionsByIdsBatch,
     inspectWorkflow,
+    fetchSimpleApplication,
     fetchWorkflowAppOpenApiSchema,
     fetchAgTypeSchema,
     fetchWorkflowsBatch,
@@ -1095,6 +1101,59 @@ export const workflowInspectAtomFamily = atomFamily((revisionId: string) =>
             staleTime: 60_000,
         }
     }),
+)
+
+// ============================================================================
+// PLAYGROUND BUILD KIT SESSION STATE
+// ============================================================================
+
+export type AgentTemplate = Record<string, unknown>
+
+/**
+ * Fetch the simple-application envelope for one app id.
+ *
+ * The playground build-kit overlay rides on this response's
+ * `additional_context`, not on the agent-service `/inspect` response (which
+ * carries no behavior-changing meta by design).
+ */
+export const simpleApplicationQueryAtomFamily = atomFamily((applicationId: string) =>
+    atomWithQuery((get) => {
+        const projectId = get(workflowProjectIdAtom)
+        return {
+            queryKey: ["simpleApplication", applicationId, projectId],
+            queryFn: async (): Promise<SimpleApplicationFetchResponse | null> => {
+                if (!projectId || !applicationId) return null
+                return fetchSimpleApplication(applicationId, projectId)
+            },
+            enabled: get(sessionAtom) && !!projectId && !!applicationId,
+            staleTime: 60_000,
+            refetchOnWindowFocus: false,
+        }
+    }),
+)
+
+export const workflowAgentTemplateOverlayAtomFamily = atomFamily((revisionId: string) =>
+    atom<AgentTemplate | null>((get) => {
+        // The app id (workflow artifact id) the revision belongs to. Server data
+        // wins; fall back to the local base entity so a draft agent still resolves.
+        const revisionData = get(workflowQueryAtomFamily(revisionId)).data ?? null
+        const applicationId =
+            revisionData?.workflow_id ??
+            get(workflowBaseEntityAtomFamily(revisionId))?.workflow_id ??
+            null
+        if (!applicationId) return null
+
+        const appData = get(simpleApplicationQueryAtomFamily(applicationId)).data ?? null
+        const overlay =
+            appData?.additional_context?.playground_build_kit?.agent_template_overlay ?? null
+        return overlay && typeof overlay === "object" && !Array.isArray(overlay)
+            ? (overlay as AgentTemplate)
+            : null
+    }),
+)
+
+export const workflowBuildKitEnabledAtomFamily = atomFamily((_revisionId: string) =>
+    atom<boolean>(true),
 )
 
 // ============================================================================

--- a/web/packages/agenta-entity-ui/src/DrillInView/SchemaControls/agentTemplate/itemDescriptors.tsx
+++ b/web/packages/agenta-entity-ui/src/DrillInView/SchemaControls/agentTemplate/itemDescriptors.tsx
@@ -173,7 +173,7 @@ export function describeMcp(server: unknown): ItemDescriptor {
     }
 }
 
-function asObj(value: unknown): Record<string, unknown> | undefined {
+export function asObj(value: unknown): Record<string, unknown> | undefined {
     return value && typeof value === "object" && !Array.isArray(value)
         ? (value as Record<string, unknown>)
         : undefined
@@ -194,7 +194,7 @@ export function isEmbedRefSkill(skill: unknown): boolean {
 const STATIC_SKILL_SLUG_PREFIX = "__ag__"
 
 /** The slug an `@ag.embed` entry points at (a `workflow` or pinned `workflow_revision` reference). */
-function staticEmbedSlug(skill: Record<string, unknown>): string | undefined {
+export function staticEmbedSlug(skill: Record<string, unknown>): string | undefined {
     const refs = asObj(asObj(skill["@ag.embed"])?.["@ag.references"])
     if (!refs) return undefined
     const slug = asObj(refs.workflow)?.slug ?? asObj(refs.workflow_revision)?.slug

--- a/web/packages/agenta-entity-ui/src/DrillInView/SchemaControls/agentTemplate/useBuildKit.tsx
+++ b/web/packages/agenta-entity-ui/src/DrillInView/SchemaControls/agentTemplate/useBuildKit.tsx
@@ -1,0 +1,312 @@
+/**
+ * useBuildKit — the playground-only "build kit" overlay shown in the Advanced section.
+ *
+ * The default agent config carries a server-side overlay of playground-only tools, skills, and
+ * sandbox permissions that help the assistant build and revise the agent. None of it is part of the
+ * published agent (the backend strips it on commit). This hook reads that overlay (keyed by the open
+ * revision) plus the user's build-kit on/off toggle, and returns:
+ *   - `hasBuildKitOverlay`: whether to render the build-kit block / extend the Advanced section,
+ *   - `buildKitSection`: the read-only drawer block (platform tools, embedded tools/skills, sandbox
+ *     permissions) with the enable/disable switch,
+ *   - `permissionOverrideHint`: the inline warning to show above SandboxPermissionControl when the
+ *     build kit overrides one of the user's permission values.
+ *
+ * Kept beside useModelHarness (which owns the Advanced section) so the overlay and the user's own
+ * sandbox/permission controls render together.
+ */
+import {useMemo, useState} from "react"
+
+import {
+    workflowAgentTemplateOverlayAtomFamily,
+    workflowBuildKitEnabledAtomFamily,
+} from "@agenta/entities/workflow"
+import {cn} from "@agenta/ui/styles"
+import {CaretRight, Warning, Wrench} from "@phosphor-icons/react"
+import {Switch, Tag, Tooltip, Typography} from "antd"
+import {useAtom, useAtomValue} from "jotai"
+
+import {asObj, staticEmbedSlug, type ItemDescriptor} from "./itemDescriptors"
+import {ItemAvatar} from "./ItemRow"
+
+/** Display name for an `@ag.embed` row: the overlay's sibling `name`, else the referenced
+ * workflow's `name`, else undefined (callers fall back to the slug). */
+function embedDisplayName(entry: Record<string, unknown>): string | undefined {
+    if (typeof entry.name === "string" && entry.name) return entry.name
+    const refs = asObj(asObj(entry["@ag.embed"])?.["@ag.references"])
+    const wfName = asObj(refs?.workflow)?.name ?? asObj(refs?.workflow_revision)?.name
+    return typeof wfName === "string" && wfName ? wfName : undefined
+}
+
+function ReadOnlyItemRow({descriptor}: {descriptor: ItemDescriptor}) {
+    return (
+        <div className="flex items-center gap-2.5 rounded border border-solid border-[var(--ag-c-EAEFF5,#eaeff5)] bg-[var(--ant-color-fill-quaternary)] px-3 py-2 opacity-70">
+            <ItemAvatar descriptor={descriptor} />
+            <div className="min-w-0 flex-1">
+                <div className="truncate font-mono text-xs font-medium">{descriptor.name}</div>
+                {descriptor.description ? (
+                    <Typography.Text
+                        type="secondary"
+                        className="block truncate text-xs leading-tight"
+                    >
+                        {descriptor.description}
+                    </Typography.Text>
+                ) : null}
+            </div>
+            <div className="flex shrink-0 items-center gap-1.5">
+                {descriptor.tags.map((tag) => (
+                    <Tag key={tag} className="m-0 text-[11px]">
+                        {tag}
+                    </Tag>
+                ))}
+                <Tag className="m-0 text-[11px]">Locked</Tag>
+            </div>
+        </div>
+    )
+}
+
+function isEmbedRefEntry(entry: unknown): entry is Record<string, unknown> {
+    return Boolean(
+        entry && typeof entry === "object" && "@ag.embed" in (entry as Record<string, unknown>),
+    )
+}
+
+function describeBuildKitPlatformTool(tool: Record<string, unknown>): ItemDescriptor {
+    const op = typeof tool.op === "string" ? tool.op : "platform tool"
+    return {
+        name: op,
+        description: "Platform-owned playground tool",
+        mono: "",
+        color: "#0d9488",
+        icon: <Wrench size={15} weight="fill" />,
+        tags: ["platform"],
+        typeLabel: "platform",
+        typeColor: "cyan",
+        subtitle: "Platform tool",
+    }
+}
+
+function describeBuildKitEmbed(
+    entry: Record<string, unknown>,
+    kind: "tool" | "skill",
+): ItemDescriptor {
+    const slug = staticEmbedSlug(entry)
+    return {
+        name: embedDisplayName(entry) ?? slug ?? `${kind} reference`,
+        description: "Provided by Agenta. This item cannot be edited or removed.",
+        mono: kind === "tool" ? "wf" : "sk",
+        color: kind === "tool" ? "#0d9488" : "#6b7280",
+        tags: ["@ag.embed"],
+        typeLabel: "@ag.embed",
+        typeColor: "blue",
+        subtitle: "Agenta-owned reference",
+    }
+}
+
+function formatPermissionValue(value: unknown): string {
+    if (typeof value === "string") return value
+    if (typeof value === "number" || typeof value === "boolean") return String(value)
+    if (value == null) return "null"
+    try {
+        return JSON.stringify(value)
+    } catch {
+        return String(value)
+    }
+}
+
+function stableString(value: unknown): string {
+    try {
+        return JSON.stringify(value)
+    } catch {
+        return String(value)
+    }
+}
+
+function overriddenPermissionKeys(
+    userPermissions: Record<string, unknown> | null | undefined,
+    overlayPermissions: Record<string, unknown> | null | undefined,
+): string[] {
+    if (!userPermissions || !overlayPermissions) return []
+    return Object.entries(overlayPermissions)
+        .filter(([key, overlayValue]) => {
+            if (!(key in userPermissions)) return false
+            return stableString(userPermissions[key]) !== stableString(overlayValue)
+        })
+        .map(([key]) => key)
+}
+
+export function useBuildKit({
+    revisionId,
+    sandboxPermissions,
+    disabled,
+}: {
+    revisionId: string | null
+    sandboxPermissions: Record<string, unknown> | null
+    disabled?: boolean
+}) {
+    const agentTemplateOverlay = useAtomValue(
+        useMemo(() => workflowAgentTemplateOverlayAtomFamily(revisionId ?? ""), [revisionId]),
+    )
+    const [buildKitEnabled, setBuildKitEnabled] = useAtom(
+        useMemo(() => workflowBuildKitEnabledAtomFamily(revisionId ?? ""), [revisionId]),
+    )
+    const [buildKitExpanded, setBuildKitExpanded] = useState(true)
+
+    const overlayTools = useMemo(
+        () => (Array.isArray(agentTemplateOverlay?.tools) ? agentTemplateOverlay.tools : []),
+        [agentTemplateOverlay],
+    )
+    const overlaySkills = useMemo(
+        () => (Array.isArray(agentTemplateOverlay?.skills) ? agentTemplateOverlay.skills : []),
+        [agentTemplateOverlay],
+    )
+    const overlaySandbox = useMemo(
+        () => asObj(agentTemplateOverlay?.sandbox),
+        [agentTemplateOverlay],
+    )
+    const overlayPermissions = useMemo(() => asObj(overlaySandbox?.permissions), [overlaySandbox])
+    const platformOverlayTools = useMemo(
+        () =>
+            overlayTools.filter((tool): tool is Record<string, unknown> =>
+                Boolean(asObj(tool)?.type === "platform"),
+            ),
+        [overlayTools],
+    )
+    const embeddedOverlayTools = useMemo(() => overlayTools.filter(isEmbedRefEntry), [overlayTools])
+    const embeddedOverlaySkills = useMemo(
+        () => overlaySkills.filter(isEmbedRefEntry),
+        [overlaySkills],
+    )
+    const hasBuildKitOverlay = Boolean(
+        agentTemplateOverlay &&
+        (platformOverlayTools.length > 0 ||
+            embeddedOverlayTools.length > 0 ||
+            embeddedOverlaySkills.length > 0 ||
+            Object.keys(overlayPermissions ?? {}).length > 0),
+    )
+    const sandboxPermissionOverrideKeys = useMemo(
+        () =>
+            buildKitEnabled ? overriddenPermissionKeys(sandboxPermissions, overlayPermissions) : [],
+        [buildKitEnabled, sandboxPermissions, overlayPermissions],
+    )
+
+    const buildKitSection = hasBuildKitOverlay ? (
+        <div className="rounded border border-solid border-[var(--ag-c-EAEFF5,#eaeff5)] bg-[#fcfcfa]">
+            <button
+                type="button"
+                onClick={() => setBuildKitExpanded((open) => !open)}
+                className="flex w-full cursor-pointer items-center gap-2 border-0 bg-transparent px-3 py-2.5 text-left"
+            >
+                <Wrench size={15} className="text-[var(--ag-c-586673,#586673)]" />
+                <span className="text-[13px] font-medium">Playground build kit</span>
+                <span className="ml-auto inline-flex items-center gap-1.5 text-[11px] text-[var(--ag-c-586673,#586673)]">
+                    <span className="h-1.5 w-1.5 rounded-full bg-[#d97706]" />
+                    Removed on commit
+                </span>
+                <span onClick={(e) => e.stopPropagation()} className="inline-flex items-center">
+                    <Switch
+                        size="small"
+                        checked={buildKitEnabled}
+                        onChange={setBuildKitEnabled}
+                        disabled={disabled}
+                    />
+                </span>
+                <CaretRight
+                    size={14}
+                    className={cn(
+                        "text-[var(--ag-c-97A4B0,#97a4b0)] transition-transform",
+                        buildKitExpanded && "rotate-90",
+                    )}
+                />
+            </button>
+            {buildKitExpanded ? (
+                <div className="flex flex-col gap-3 border-0 border-t border-solid border-[var(--ag-c-EAEFF5,#eaeff5)] px-3 pb-3 pt-2.5">
+                    <p className="m-0 text-[11.5px] leading-snug text-[var(--ag-c-586673,#586673)]">
+                        These playground-only tools, skills, and permissions help the assistant
+                        build and revise this agent. None of this is part of the published agent.
+                    </p>
+                    {!buildKitEnabled ? (
+                        <div className="rounded border border-solid border-[var(--ant-color-info-border)] bg-[var(--ant-color-info-bg)] px-2.5 py-2 text-[11.5px] leading-snug text-[var(--ant-color-info-text)]">
+                            The assistant can no longer create files, run code, or edit the agent
+                            here.
+                        </div>
+                    ) : null}
+                    {platformOverlayTools.length > 0 ? (
+                        <div className="flex flex-col gap-1.5">
+                            <Typography.Text className="text-xs font-medium">
+                                Platform tools
+                            </Typography.Text>
+                            {platformOverlayTools.map((tool, index) => (
+                                <ReadOnlyItemRow
+                                    key={`build-kit-platform-tool-${index}`}
+                                    descriptor={describeBuildKitPlatformTool(tool)}
+                                />
+                            ))}
+                        </div>
+                    ) : null}
+                    {embeddedOverlayTools.length > 0 ? (
+                        <div className="flex flex-col gap-1.5">
+                            <Typography.Text className="text-xs font-medium">
+                                Embedded tools
+                            </Typography.Text>
+                            {embeddedOverlayTools.map((tool, index) => (
+                                <ReadOnlyItemRow
+                                    key={`build-kit-embedded-tool-${index}`}
+                                    descriptor={describeBuildKitEmbed(tool, "tool")}
+                                />
+                            ))}
+                        </div>
+                    ) : null}
+                    {embeddedOverlaySkills.length > 0 ? (
+                        <div className="flex flex-col gap-1.5">
+                            <Typography.Text className="text-xs font-medium">
+                                Embedded skills
+                            </Typography.Text>
+                            {embeddedOverlaySkills.map((skill, index) => (
+                                <ReadOnlyItemRow
+                                    key={`build-kit-embedded-skill-${index}`}
+                                    descriptor={describeBuildKitEmbed(skill, "skill")}
+                                />
+                            ))}
+                        </div>
+                    ) : null}
+                    {overlayPermissions && Object.keys(overlayPermissions).length > 0 ? (
+                        <div className="flex flex-col gap-1.5">
+                            <Typography.Text className="text-xs font-medium">
+                                Sandbox permissions
+                            </Typography.Text>
+                            <div className="flex flex-col gap-1.5 opacity-70">
+                                {Object.entries(overlayPermissions).map(([key, value]) => (
+                                    <div
+                                        key={key}
+                                        className="flex items-center justify-between gap-3 rounded border border-solid border-[var(--ag-c-EAEFF5,#eaeff5)] bg-[var(--ant-color-fill-quaternary)] px-3 py-2 text-xs"
+                                    >
+                                        <span className="font-mono">{key}</span>
+                                        <Tag className="m-0 font-mono text-[11px]">
+                                            {formatPermissionValue(value)}
+                                        </Tag>
+                                    </div>
+                                ))}
+                            </div>
+                        </div>
+                    ) : null}
+                </div>
+            ) : null}
+        </div>
+    ) : null
+
+    const permissionOverrideHint =
+        sandboxPermissionOverrideKeys.length > 0 ? (
+            <Tooltip title="This value is overridden by the build kit in playground. Turn the build kit off to match the published agent.">
+                <div className="inline-flex w-fit items-center gap-1.5 rounded bg-[var(--ant-color-warning-bg)] px-2 py-1 text-[11px] text-[var(--ant-color-warning-text)]">
+                    <Warning size={12} />
+                    Build kit overrides {sandboxPermissionOverrideKeys.join(", ")}
+                </div>
+            </Tooltip>
+        ) : null
+
+    return {
+        hasBuildKitOverlay,
+        buildKitSection,
+        permissionOverrideHint,
+    }
+}

--- a/web/packages/agenta-entity-ui/src/DrillInView/SchemaControls/agentTemplate/useModelHarness.tsx
+++ b/web/packages/agenta-entity-ui/src/DrillInView/SchemaControls/agentTemplate/useModelHarness.tsx
@@ -34,6 +34,7 @@ import {HarnessSelectControl} from "../HarnessSelectControl"
 import {SandboxPermissionControl} from "../SandboxPermissionControl"
 
 import {enumLabel} from "./agentTemplateUtils"
+import {useBuildKit} from "./useBuildKit"
 
 export function useModelHarness({
     schema,
@@ -247,12 +248,22 @@ export function useModelHarness({
 
     const hasModelOrHarness = Boolean(props.llm || harnessProps.kind)
     const hasClaudePermissions = harnessValue === "claude"
+
+    // Playground-only "build kit" overlay (read-only) shown at the top of Advanced. It also flags
+    // sandbox-permission keys the overlay overrides for the user's own permission control below.
+    const {hasBuildKitOverlay, buildKitSection, permissionOverrideHint} = useBuildKit({
+        revisionId,
+        sandboxPermissions: (sandbox.permissions as Record<string, unknown> | null) ?? null,
+        disabled,
+    })
+
     const hasAdvanced = Boolean(
         props.llm || // Authentication lives in Advanced now
         sandboxProps.kind ||
         sandboxProps.permissions ||
         runnerProps.interactions ||
-        hasClaudePermissions,
+        hasClaudePermissions ||
+        hasBuildKitOverlay,
     )
 
     // The Model picker (inspect-filtered when available, else the schema catalog).
@@ -671,8 +682,15 @@ export function useModelHarness({
     // Shared Advanced controls, rendered by both the wide drawer body and the tabs-inline body.
     const advancedControls = (
         <>
+            {buildKitSection}
+
             {authControls ? (
-                <div>
+                <div
+                    className={cn(
+                        hasBuildKitOverlay &&
+                            "border-0 border-t border-solid border-[var(--ag-c-EAEFF5,#eaeff5)] pt-4",
+                    )}
+                >
                     <div className="mb-0.5 flex items-center gap-1.5">
                         <Key size={15} className="text-[var(--ag-c-586673,#586673)]" />
                         <span className="text-[13px] font-medium">Authentication</span>
@@ -705,15 +723,19 @@ export function useModelHarness({
                             />
                         )}
                         {sandboxProps.permissions ? (
-                            <SandboxPermissionControl
-                                value={
-                                    (sandbox.permissions as Record<string, unknown> | null) ?? null
-                                }
-                                onChange={(v) =>
-                                    setSection("sandbox", {...sandbox, permissions: v})
-                                }
-                                disabled={disabled}
-                            />
+                            <div className="flex flex-col gap-1.5">
+                                {permissionOverrideHint}
+                                <SandboxPermissionControl
+                                    value={
+                                        (sandbox.permissions as Record<string, unknown> | null) ??
+                                        null
+                                    }
+                                    onChange={(v) =>
+                                        setSection("sandbox", {...sandbox, permissions: v})
+                                    }
+                                    disabled={disabled}
+                                />
+                            </div>
                         ) : null}
                     </div>
                 </div>

--- a/web/packages/agenta-playground/src/state/execution/agentRequest.ts
+++ b/web/packages/agenta-playground/src/state/execution/agentRequest.ts
@@ -24,12 +24,22 @@
  *  - `project_id` / `application_id` ride the URL QUERY (never the body), and
  *    `project_id` only travels alongside auth — mirroring `executionItems.ts`.
  */
-import {workflowMolecule} from "@agenta/entities/workflow"
+import {
+    workflowAgentTemplateOverlayAtomFamily,
+    workflowBuildKitEnabledAtomFamily,
+    workflowMolecule,
+    type AgentTemplate,
+} from "@agenta/entities/workflow"
 import {projectIdAtom} from "@agenta/shared/state"
 import {getDefaultStore} from "jotai"
 
+import {withBuildKitOverlay} from "./buildKitOverlay"
 import {agentChannelModeAtom} from "./channelMode"
 import {executionHeadersAtom} from "./webWorkerIntegration"
+
+// Re-exported so existing consumers keep importing it from the request builder; the merge
+// implementation now lives in `buildKitOverlay.ts`.
+export {applyBuildKitOverlay} from "./buildKitOverlay"
 
 export interface AgentRequest {
     invocationUrl: string
@@ -306,10 +316,17 @@ export async function buildAgentRequest(
         | undefined
     // The execution sections (`harness`/`runner`/`sandbox`) are nested in the template at
     // `parameters.agent`. Default them, never overriding values the resolved config carries.
-    const parameters = pruneBlankEntries(withAgentRunDefaults(config ?? {})) as Record<
-        string,
-        unknown
-    >
+    const buildKitEnabled = store.get(workflowBuildKitEnabledAtomFamily(entityId)) as boolean
+    const agentTemplateOverlay = store.get(
+        workflowAgentTemplateOverlayAtomFamily(entityId),
+    ) as AgentTemplate | null
+    const parameters = pruneBlankEntries(
+        withBuildKitOverlay(
+            withAgentRunDefaults(config ?? {}) as Record<string, unknown>,
+            agentTemplateOverlay,
+            buildKitEnabled,
+        ),
+    ) as Record<string, unknown>
 
     const entity = store.get(workflowMolecule.selectors.data(entityId)) as
         | RevisionLike

--- a/web/packages/agenta-playground/src/state/execution/buildKitOverlay.ts
+++ b/web/packages/agenta-playground/src/state/execution/buildKitOverlay.ts
@@ -1,0 +1,149 @@
+/**
+ * Build-kit overlay merge — the playground-only overlay applied to the throwaway agent run copy.
+ *
+ * Extracted from `agentRequest.ts` so the request builder stays focused on composing the
+ * `/invoke` envelope. None of this touches the draft or the commit tree: `applyBuildKitOverlay`
+ * returns new objects and the request builder applies it only to the per-run `parameters`.
+ *
+ * Merge semantics:
+ *  - object sections (`sandbox`/`runner`/`harness`/`llm`/`instructions`) deep-merge (overlay wins
+ *    at the leaf),
+ *  - list sections (`tools`/`skills`/`mcps`) identity-merge: an overlay entry replaces a base entry
+ *    with the same identity (platform op, embed slug, or name), otherwise it is appended.
+ */
+import {type AgentTemplate} from "@agenta/entities/workflow"
+
+type AgentTemplateListKey = "tools" | "skills" | "mcps"
+type AgentTemplateObjectKey = "sandbox" | "runner" | "harness" | "llm" | "instructions"
+
+const isRecord = (value: unknown): value is Record<string, unknown> =>
+    Boolean(value && typeof value === "object" && !Array.isArray(value))
+
+const embedWorkflowSlug = (entry: unknown): string | undefined => {
+    if (!isRecord(entry)) return undefined
+    const embed = entry["@ag.embed"]
+    if (!isRecord(embed)) return undefined
+    const refs = embed["@ag.references"]
+    if (!isRecord(refs)) return undefined
+    const workflow = refs.workflow
+    if (isRecord(workflow) && typeof workflow.slug === "string") return workflow.slug
+    const revision = refs.workflow_revision
+    if (isRecord(revision) && typeof revision.slug === "string") return revision.slug
+    return undefined
+}
+
+const deepMerge = (
+    base: Record<string, unknown>,
+    overlay: Record<string, unknown>,
+): Record<string, unknown> => {
+    const result: Record<string, unknown> = {...base}
+    for (const [key, value] of Object.entries(overlay)) {
+        const existing = result[key]
+        result[key] = isRecord(existing) && isRecord(value) ? deepMerge(existing, value) : value
+    }
+    return result
+}
+
+const getToolIdentity = (entry: unknown): string | undefined => {
+    if (!isRecord(entry)) return undefined
+    if (entry.type === "platform" && typeof entry.op === "string") return `platform:${entry.op}`
+    const slug = embedWorkflowSlug(entry)
+    if (slug) return `workflow:${slug}`
+    return typeof entry.name === "string" ? `name:${entry.name}` : undefined
+}
+
+const getSkillIdentity = (entry: unknown): string | undefined => {
+    const slug = embedWorkflowSlug(entry)
+    return slug ? `workflow:${slug}` : undefined
+}
+
+const getMcpIdentity = (entry: unknown): string | undefined => {
+    if (!isRecord(entry)) return undefined
+    return typeof entry.name === "string" ? entry.name : undefined
+}
+
+const identityMerge = (
+    base: unknown[],
+    overlay: unknown[],
+    getIdentity: (entry: unknown) => string | undefined,
+): unknown[] => {
+    const result = [...base]
+    const indexByIdentity = new Map<string, number>()
+    result.forEach((entry, index) => {
+        const identity = getIdentity(entry)
+        if (identity) indexByIdentity.set(identity, index)
+    })
+    overlay.forEach((entry) => {
+        const identity = getIdentity(entry)
+        const index = identity ? indexByIdentity.get(identity) : undefined
+        if (index !== undefined) {
+            result[index] = entry
+            return
+        }
+        if (identity) indexByIdentity.set(identity, result.length)
+        result.push(entry)
+    })
+    return result
+}
+
+export function applyBuildKitOverlay(
+    base: AgentTemplate,
+    overlay: Partial<AgentTemplate>,
+): AgentTemplate {
+    const result: AgentTemplate = {...base}
+
+    for (const key of [
+        "sandbox",
+        "runner",
+        "harness",
+        "llm",
+        "instructions",
+    ] as const satisfies readonly AgentTemplateObjectKey[]) {
+        const overlayValue = overlay[key]
+        if (overlayValue !== undefined) {
+            result[key] = deepMerge(
+                isRecord(base[key]) ? (base[key] as Record<string, unknown>) : {},
+                isRecord(overlayValue) ? overlayValue : {},
+            )
+        }
+    }
+
+    const listMergers: Record<AgentTemplateListKey, (entry: unknown) => string | undefined> = {
+        tools: getToolIdentity,
+        skills: getSkillIdentity,
+        mcps: getMcpIdentity,
+    }
+
+    for (const key of Object.keys(listMergers) as AgentTemplateListKey[]) {
+        const overlayValue = overlay[key]
+        if (Array.isArray(overlayValue)) {
+            result[key] = identityMerge(
+                Array.isArray(base[key]) ? (base[key] as unknown[]) : [],
+                overlayValue,
+                listMergers[key],
+            )
+        }
+    }
+
+    return result
+}
+
+/**
+ * Apply the overlay to the run parameters. Handles both shapes `buildAgentRequest` produces: a
+ * `{agent: <template>}` wrapper and a bare template (no `agent` key). Skipping the bare shape would
+ * silently drop the build kit for the bare published default.
+ */
+export const withBuildKitOverlay = (
+    parameters: Record<string, unknown>,
+    overlay: AgentTemplate | null,
+    enabled: boolean,
+): Record<string, unknown> => {
+    if (!enabled || !overlay) return parameters
+    if (isRecord(parameters.agent)) {
+        return {
+            ...parameters,
+            agent: applyBuildKitOverlay(parameters.agent as AgentTemplate, overlay),
+        }
+    }
+    return applyBuildKitOverlay(parameters as AgentTemplate, overlay) as Record<string, unknown>
+}

--- a/web/packages/agenta-playground/src/state/execution/index.ts
+++ b/web/packages/agenta-playground/src/state/execution/index.ts
@@ -352,7 +352,12 @@ export {
 } from "./displayedEntities"
 
 // Agent-lane request builder (bypasses buffered-fetch execution; useChat streams).
-export {buildAgentRequest, buildAgentReferences, type AgentRequest} from "./agentRequest"
+export {
+    applyBuildKitOverlay,
+    buildAgentRequest,
+    buildAgentReferences,
+    type AgentRequest,
+} from "./agentRequest"
 // Stream vs batch response channel for the agent lane (read by buildAgentRequest's Accept header).
 export {agentChannelModeAtom, type AgentChannelMode} from "./channelMode"
 // Transport negotiation: try stream, fall back to batch on 406, error gracefully otherwise.

--- a/web/packages/agenta-playground/src/state/index.ts
+++ b/web/packages/agenta-playground/src/state/index.ts
@@ -175,7 +175,12 @@ export {inputVariableNamesAtom} from "./execution"
 // App-level mode selectors
 export {appTypeAtom, isChatModeAtom, type AppType} from "./execution"
 export {isAgentModeAtomFamily} from "./execution"
-export {buildAgentRequest, buildAgentReferences, type AgentRequest} from "./execution"
+export {
+    applyBuildKitOverlay,
+    buildAgentRequest,
+    buildAgentReferences,
+    type AgentRequest,
+} from "./execution"
 export {agentChannelModeAtom, type AgentChannelMode} from "./execution"
 export {createNegotiatingFetch, type NegotiatingFetch} from "./execution"
 export {agentShouldResumeAfterApproval} from "./execution"

--- a/web/packages/agenta-playground/tests/unit/agentRequest.test.ts
+++ b/web/packages/agenta-playground/tests/unit/agentRequest.test.ts
@@ -37,13 +37,23 @@ vi.mock("@agenta/entities/workflow", async (importOriginal) => {
                 isDirty: mk<boolean>(false),
             },
         },
+        workflowAgentTemplateOverlayAtomFamily: mk<Record<string, unknown> | null>(null),
+        workflowBuildKitEnabledAtomFamily: mk<boolean>(true),
     }
 })
 
-import {workflowMolecule} from "@agenta/entities/workflow"
+import {
+    workflowAgentTemplateOverlayAtomFamily,
+    workflowBuildKitEnabledAtomFamily,
+    workflowMolecule,
+} from "@agenta/entities/workflow"
 import {projectIdAtom} from "@agenta/shared/state"
 
-import {buildAgentRequest, buildAgentReferences} from "../../src/state/execution/agentRequest"
+import {
+    applyBuildKitOverlay,
+    buildAgentRequest,
+    buildAgentReferences,
+} from "../../src/state/execution/agentRequest"
 import {agentChannelModeAtom} from "../../src/state/execution/channelMode"
 import {executionHeadersAtom} from "../../src/state/execution/webWorkerIntegration"
 
@@ -62,6 +72,8 @@ function seed(
         config?: Record<string, unknown> | null
         data?: any
         isDirty?: boolean
+        overlay?: Record<string, unknown> | null
+        buildKitEnabled?: boolean
     },
 ) {
     set(
@@ -73,6 +85,22 @@ function seed(
     set(store, workflowMolecule.selectors.configuration, id, over.config ?? {temperature: 0.7})
     set(store, workflowMolecule.selectors.data, id, over.data ?? null)
     set(store, workflowMolecule.selectors.isDirty, id, over.isDirty ?? false)
+    store.set(
+        workflowAgentTemplateOverlayAtomFamily(id) as PrimitiveAtom<unknown>,
+        over.overlay ?? null,
+    )
+    store.set(
+        workflowBuildKitEnabledAtomFamily(id) as PrimitiveAtom<unknown>,
+        over.buildKitEnabled ?? true,
+    )
+}
+
+const authoringSkill = {
+    "@ag.embed": {"@ag.references": {workflow: {slug: "__ag__getting_started_with_agenta"}}},
+}
+
+const requestConnectionTool = {
+    "@ag.embed": {"@ag.references": {workflow: {slug: "__ag__request_connection"}}},
 }
 
 describe("buildAgentReferences (draft-id stripping)", () => {
@@ -186,6 +214,159 @@ describe("buildAgentRequest", () => {
         const req = await buildAgentRequest("e", [], {sessionId: "s1", store})
         const template = (req!.requestBody.data as any).parameters.agent
         expect(template.runner.interactions.headless).toBe("deny")
+    })
+
+    it("applies the build-kit overlay to a kit-on run with deep and identity merges", async () => {
+        const config = {
+            agent: {
+                sandbox: {kind: "local", permissions: {execute_code: "deny", network: "on"}},
+                tools: [
+                    {type: "platform", op: "find_capabilities", permission: "ask"},
+                    {type: "client", name: "weather"},
+                    requestConnectionTool,
+                ],
+                skills: [authoringSkill],
+            },
+        }
+        const overlay = {
+            sandbox: {permissions: {execute_code: "allow", write_files: "allow"}},
+            tools: [
+                {type: "platform", op: "find_capabilities", permission: "allow"},
+                {type: "platform", op: "commit_revision"},
+                requestConnectionTool,
+            ],
+            skills: [authoringSkill],
+        }
+        const before = JSON.parse(JSON.stringify(config))
+        seed(store, "e", {config, overlay, buildKitEnabled: true})
+
+        const req = await buildAgentRequest("e", [], {sessionId: "s1", store})
+        const template = (req!.requestBody.data as any).parameters.agent
+
+        expect(template.sandbox).toEqual({
+            kind: "local",
+            permissions: {execute_code: "allow", network: "on", write_files: "allow"},
+        })
+        expect(template.tools).toEqual([
+            {type: "platform", op: "find_capabilities", permission: "allow"},
+            {type: "client", name: "weather"},
+            requestConnectionTool,
+            {type: "platform", op: "commit_revision"},
+        ])
+        expect(template.skills).toEqual([authoringSkill])
+        expect(config).toEqual(before)
+    })
+
+    it("applies the build-kit overlay to a BARE template (no agent wrapper)", async () => {
+        // `withAgentRunDefaults` leaves a config with no `agent` key as a bare template, so the
+        // overlay must merge at the top level — not no-op (the bare published default case).
+        const config = {
+            sandbox: {kind: "local", permissions: {execute_code: "deny"}},
+            tools: [{type: "client", name: "weather"}],
+        }
+        seed(store, "e", {
+            config,
+            overlay: {
+                sandbox: {permissions: {execute_code: "allow", write_files: "allow"}},
+                tools: [{type: "platform", op: "commit_revision"}],
+                skills: [authoringSkill],
+            },
+            buildKitEnabled: true,
+        })
+
+        const req = await buildAgentRequest("e", [], {sessionId: "s1", store})
+        const params = (req!.requestBody.data as any).parameters
+
+        // Bare template → overlay applied at the top level, never wrapped under `agent`.
+        expect(params.agent).toBeUndefined()
+        expect(params.sandbox.permissions).toEqual({
+            execute_code: "allow",
+            write_files: "allow",
+        })
+        expect(params.tools).toEqual([
+            {type: "client", name: "weather"},
+            {type: "platform", op: "commit_revision"},
+        ])
+        expect(params.skills).toEqual([authoringSkill])
+    })
+
+    it("sends the bare agent config unchanged when the build kit is off", async () => {
+        const config = {
+            agent: {
+                sandbox: {kind: "local", permissions: {execute_code: "deny"}},
+                tools: [{type: "client", name: "weather"}],
+            },
+        }
+        seed(store, "e", {
+            config,
+            overlay: {
+                sandbox: {permissions: {execute_code: "allow", write_files: "allow"}},
+                tools: [{type: "platform", op: "commit_revision"}],
+                skills: [authoringSkill],
+            },
+            buildKitEnabled: false,
+        })
+
+        const req = await buildAgentRequest("e", [], {sessionId: "s1", store})
+        const template = (req!.requestBody.data as any).parameters.agent
+
+        expect(template.sandbox.permissions).toEqual({execute_code: "deny"})
+        expect(template.tools).toEqual([{type: "client", name: "weather"}])
+        expect(template.skills).toBeUndefined()
+    })
+
+    it("applies the kit only to the run copy, leaving entity parameters bare for commit", async () => {
+        // The commit path (web/packages/agenta-entities/src/workflow/state/commit.ts
+        // `prepareCommitParameters`) serializes `entity.data.parameters`, which the run never
+        // writes. This proves the two stay separate: the throwaway run copy carries the kit while
+        // the persisted config the commit reads is untouched.
+        const config = {
+            agent: {
+                sandbox: {kind: "local"},
+                tools: [{type: "client", name: "weather"}],
+            },
+        }
+        seed(store, "e", {
+            config,
+            overlay: {
+                sandbox: {permissions: {execute_code: "allow", write_files: "allow"}},
+                tools: [{type: "platform", op: "commit_revision"}],
+            },
+        })
+
+        const req = await buildAgentRequest("e", [], {sessionId: "s1", store})
+
+        // The run copy carries the kit (overlay applied)...
+        const runTemplate = (req!.requestBody.data as any).parameters.agent
+        expect(runTemplate.tools).toContainEqual({type: "platform", op: "commit_revision"})
+        expect(runTemplate.sandbox.permissions).toMatchObject({write_files: "allow"})
+
+        // ...but the persisted config the commit serializer reads is unmutated.
+        expect(store.get(workflowMolecule.selectors.configuration("e"))).toEqual(config)
+        expect(JSON.stringify(config)).not.toContain("commit_revision")
+        expect(JSON.stringify(config)).not.toContain("write_files")
+    })
+
+    it("applyBuildKitOverlay never mutates its input template", () => {
+        const base = {
+            sandbox: {kind: "local", permissions: {execute_code: "deny"}},
+            tools: [{type: "platform", op: "find_capabilities", permission: "ask"}],
+            skills: [],
+        }
+        const snapshot = JSON.parse(JSON.stringify(base))
+
+        const result = applyBuildKitOverlay(base, {
+            sandbox: {permissions: {execute_code: "allow"}},
+            tools: [{type: "platform", op: "find_capabilities", permission: "allow"}],
+            skills: [authoringSkill],
+        })
+
+        expect(base).toEqual(snapshot)
+        expect(result).not.toBe(base)
+        expect(result.sandbox).toEqual({
+            kind: "local",
+            permissions: {execute_code: "allow"},
+        })
     })
 
     it("INCLUDES references for a CLEAN committed revision run (marks it non-draft)", async () => {


### PR DESCRIPTION
## Context

When a user opens the playground to build a new agent, the assistant needs authoring scaffolding: the platform ops (find capabilities, commit a revision, etc.), the Agenta getting-started skill, and elevated sandbox permissions so it can write and execute files. That scaffolding is a build aid, not the user's app. The committed agent must carry only what the user authored.

Previously `build_agent_v0_default()` baked these into the published default, so every deployed agent shipped with platform tools and sandbox elevation baked in. This PR fixes that by separating "what the playground injects for a build run" from "what gets committed."

Design: `docs/design/agent-workflows/projects/default-agent-config/design.md`

## Changes

The backend now builds a **read-only agent-template overlay** and attaches it to the inspect response. The frontend merges it onto `parameters.agent` only for a playground run, and leaves it out when committing.

**Before:** `build_agent_v0_default()` returned a default that included platform tools, the authoring skill, and sandbox elevation. Every inspect response returned that enriched default. The commit path had to strip it out manually (or didn't, and it leaked in).

**After:** `build_agent_v0_default()` is bare. `fetch_simple_application` attaches `additional_context.playground_build_kit.agent_template_overlay` to the response. The frontend's `applyBuildKitOverlay` does a deep-merge of the overlay into the run config. The commit reads only persisted entity parameters, so the overlay is excluded for free.

The overlay shape:
```json
{
  "tools": [
    { "type": "platform", "op": "<op_name>" },
    { "@ag.embed": { "@ag.references": { "workflow": { "slug": "__ag__..." } } } }
  ],
  "skills": [{ "@ag.embed": { "@ag.references": { "workflow": { "slug": "__ag__getting_started_with_agenta" } } } }],
  "sandbox": { "permissions": { "write_files": "allow", "execute_code": "allow" } }
}
```

**Key files:**
- `api/oss/src/apis/fastapi/applications/overlay.py` (new) — `build_agent_template_overlay()` assembles the overlay from `PLATFORM_OPS` + reserved static workflow slugs + the authoring skill slug.
- `api/oss/src/apis/fastapi/applications/router.py` — `fetch_simple_application` attaches the overlay; create/edit/commit paths do not.
- `services/oss/src/agent/schemas.py` — reverted `build_agent_v0_default()` to bare (no platform tools, no skills, no sandbox elevation).
- `web/packages/agenta-playground/src/state/execution/agentRequest.ts` — `applyBuildKitOverlay` (deep-merge objects, identity-merge lists), called in `buildAgentRequest` only when the kit is enabled.
- `web/packages/agenta-entity-ui/.../AgentTemplateControl.tsx` — read-only "Playground build kit" panel with an enable/disable toggle and "Removed on commit" tag.

**Out of scope:** collapsible advanced-drawer sections (Change 1 from the design) — ships separately.

## Scope / risk

The overlay is computed fresh on every inspect call from static sources (`PLATFORM_OPS`, `_STATIC_WORKFLOWS`, the getting-started slug). It is never stored. A stale catalog entry would show in the overlay without affecting committed revisions.

The merge in `applyBuildKitOverlay` is shallow for top-level keys and identity-merge for lists. That means the overlay's `tools` list replaces (not appends to) a run's `tools` if the overlay is applied. Review whether deep-merge vs. replace is the right semantic for `tools` in edge cases where the user has also configured tools.

The frontend toggle (`buildKitEnabled`) defaults on. There is no server-side flag; disabling it is a client session state.

## Tests

- `api/oss/tests/pytest/unit/applications/test_build_kit_overlay.py` (new): overlay builder shape; inspect response carries `additional_context.playground_build_kit`.
- `services/oss/tests/pytest/unit/agent/test_default_agent_template.py`: published default is bare across builtin, inspect schema, and catalog.
- `web/packages/agenta-playground/tests/unit/agentRequest.test.ts`: kit-on merges overlay, kit-off sends bare config, commit excludes the kit, applier never mutates the input.

Codex-reported results: API overlay test 3/3, services default-agent test 5/5, playground vitest 148/148. Not independently re-run in CI on this branch yet.

## How to QA

**Prerequisites:** local dev stack (`run.sh --oss --dev` or `--ee --dev`).

**Steps:**
1. Open the Playground for any agent app.
2. Open the "Advanced" drawer. Confirm a "Playground build kit" section appears with tools and a skill listed, and a "Removed on commit" tag.
3. Run the agent. Confirm the run request (check network) includes the platform tools and skill from the overlay.
4. Click "Commit". Inspect the commit payload. Confirm it does not include the overlay tools or skill.
5. Toggle the build kit off. Run again. Confirm the overlay is absent from the run request.

**Expected result:** Overlay present on run, absent on commit. Toggle removes it from runs.

**Automated tests:**
```
cd api && uv run python -m pytest oss/tests/pytest/unit/applications/test_build_kit_overlay.py -v
cd services && uv run python -m pytest oss/tests/pytest/unit/agent/test_default_agent_template.py -v
cd web && pnpm --filter @agenta/playground test -- --run agentRequest
```

**Edge cases:** If the user has manually configured tools on their agent before the overlay merges, check that the commit writes only the user-configured tools and not the overlay tools.

https://claude.ai/code/session_01GYo3UEfvsZpncagqb28Mbc