### PR TITLE
feat(frontend): agent client-tool round-trip (#4920)

### DIFF
--- a/web/oss/src/components/AgentChatSlice/AgentChatPanel.tsx
+++ b/web/oss/src/components/AgentChatSlice/AgentChatPanel.tsx
@@ -1,5 +1,6 @@
 import {useCallback, useEffect, useLayoutEffect, useMemo, useRef, useState} from "react"
 
+import {invalidateAgentCommittedRevisionCache} from "@agenta/entities/workflow"
 import {agentShouldResumeAfterApproval, buildAgentRequest} from "@agenta/playground"
 import {simulatedAgentRunAtomFamily} from "@agenta/shared/state"
 import {generateId} from "@agenta/shared/utils"
@@ -21,6 +22,7 @@ import {
 import {filesToParts} from "./assets/files"
 import {messageText, sideEffectingToolsInRange} from "./assets/rewind"
 import AgentMessage from "./components/AgentMessage"
+import type {ClientToolOutputHandler} from "./components/clientTools"
 import ComposerAttachments from "./components/ComposerAttachments"
 import QueuedMessages from "./components/QueuedMessages"
 import SessionHistoryMenu from "./components/SessionHistoryMenu"
@@ -244,6 +246,7 @@ const AgentConversation = ({entityId, sessionId}: {entityId: string; sessionId: 
         regenerate,
         setMessages,
         addToolApprovalResponse,
+        addToolOutput,
         error,
     } = useChat({
         id: sessionId,
@@ -260,6 +263,30 @@ const AgentConversation = ({entityId, sessionId}: {entityId: string; sessionId: 
     })
 
     const busy = status === "submitted" || status === "streaming"
+
+    // Settle a parked client tool (#4920). The dispatcher calls this from a widget (e.g. the connect
+    // widget) with the structured reference; `addToolOutput` matches the part by `toolCallId` on the
+    // last turn and the resume predicate auto-resends. `tool` is only the typed-tools key — matching
+    // is by id — so a cast onto the untyped UIMessage tool map is safe.
+    const handleClientToolOutput = useCallback<ClientToolOutputHandler>(
+        ({toolName, toolCallId, output, errorText}) => {
+            if (errorText !== undefined) {
+                addToolOutput({
+                    state: "output-error",
+                    tool: toolName as never,
+                    toolCallId,
+                    errorText,
+                }).catch(ignoreStreamRejection)
+            } else {
+                addToolOutput({
+                    tool: toolName as never,
+                    toolCallId,
+                    output: (output ?? {}) as never,
+                }).catch(ignoreStreamRejection)
+            }
+        },
+        [addToolOutput],
+    )
 
     // ── "Run in playground" seam (producer: a trigger drawer's Run-in-playground) ──
     // A trigger fires server-side and never reaches the playground; this lets a user
@@ -359,6 +386,27 @@ const AgentConversation = ({entityId, sessionId}: {entityId: string; sessionId: 
         if (status === "streaming") return
         persistMessages({id: sessionId, messages})
     }, [messages, status, sessionId, persistMessages])
+
+    // ── #4920 Application 1: refresh the config on a committed revision ──
+    // When the agent commits a new revision of itself, the backend emits a one-way
+    // `data-committed-revision` part (same channel as `data-trace`), in BOTH the gated approval path
+    // and the direct `needs_approval=false` path. On receipt we invalidate the latest-revision and
+    // inspect caches so the config panel, section drawers, and build-kit view all re-read the new
+    // config. Deduped by revision id so a re-render (token stream) doesn't re-invalidate.
+    const committedRevisionsSeenRef = useRef<Set<string>>(new Set())
+    useEffect(() => {
+        for (const message of messages) {
+            for (const part of message.parts) {
+                if ((part as {type?: string}).type !== "data-committed-revision") continue
+                const data = (part as {data?: {revisionId?: string; version?: string}}).data
+                // A stable key per commit: prefer the revision id, fall back to the whole payload.
+                const key = data?.revisionId ?? JSON.stringify(data ?? {}) ?? "committed"
+                if (committedRevisionsSeenRef.current.has(key)) continue
+                committedRevisionsSeenRef.current.add(key)
+                invalidateAgentCommittedRevisionCache()
+            }
+        }
+    }, [messages])
 
     // ── DT3 cancelled state: wrap stop() to mark the in-flight assistant turn ──
     const markStopped = useCallback(() => {
@@ -734,8 +782,10 @@ const AgentConversation = ({entityId, sessionId}: {entityId: string; sessionId: 
                 <AgentMessage
                     message={message}
                     isStreaming={busy && isLast}
+                    isLastMessage={isLast}
                     onRewind={() => handleRewind(message)}
                     onApprovalResponse={addToolApprovalResponse}
+                    onClientToolOutput={handleClientToolOutput}
                     precededByEmptyAssistant={
                         index > 0 && isEmptyAssistantTurn(messages[index - 1])
                     }

--- a/web/oss/src/components/AgentChatSlice/components/AgentChatConversation.tsx
+++ b/web/oss/src/components/AgentChatSlice/components/AgentChatConversation.tsx
@@ -16,6 +16,7 @@ import {createAgentChatTransport} from "../assets/transport"
 import {persistSessionMessagesAtom, sessionMessagesAtom} from "../state/sessions"
 
 import AgentMessage from "./AgentMessage"
+import type {ClientToolOutputHandler} from "./clientTools"
 
 const {Text} = Typography
 
@@ -84,6 +85,7 @@ const AgentChatConversation = ({
         regenerate,
         setMessages,
         addToolApprovalResponse,
+        addToolOutput,
         error,
     } = useChat({
         id: sessionId,
@@ -100,6 +102,29 @@ const AgentChatConversation = ({
     })
 
     const busy = status === "submitted" || status === "streaming"
+
+    // Settle a parked client tool (#4920) — same wrapper as AgentChatPanel. `addToolOutput` matches
+    // the part by `toolCallId` on the last turn; `tool` is only the typed-tools key, so a cast onto
+    // the untyped UIMessage tool map is safe.
+    const handleClientToolOutput = useCallback<ClientToolOutputHandler>(
+        ({toolName, toolCallId, output, errorText}) => {
+            if (errorText !== undefined) {
+                addToolOutput({
+                    state: "output-error",
+                    tool: toolName as never,
+                    toolCallId,
+                    errorText,
+                }).catch(ignoreStreamRejection)
+            } else {
+                addToolOutput({
+                    tool: toolName as never,
+                    toolCallId,
+                    output: (output ?? {}) as never,
+                }).catch(ignoreStreamRejection)
+            }
+        },
+        [addToolOutput],
+    )
 
     // `handleRewind` must stay referentially stable (it's passed to every memo'd `AgentMessage`)
     // so a streamed token doesn't recreate it and re-render the whole list. `messages`/`busy`
@@ -239,8 +264,10 @@ const AgentChatConversation = ({
                         key={message.id}
                         message={message}
                         isStreaming={busy && index === messages.length - 1}
+                        isLastMessage={index === messages.length - 1}
                         onRewind={handleRewind}
                         onApprovalResponse={addToolApprovalResponse}
+                        onClientToolOutput={handleClientToolOutput}
                     />
                 ))}
                 {status === "submitted" && messages[messages.length - 1]?.role !== "assistant" && (

--- a/web/oss/src/components/AgentChatSlice/components/AgentMessage.tsx
+++ b/web/oss/src/components/AgentChatSlice/components/AgentMessage.tsx
@@ -28,6 +28,7 @@ import {
     type MessageUsageMetrics,
 } from "../assets/trace"
 
+import {ClientToolPart, isClientToolPart, type ClientToolOutputHandler} from "./clientTools"
 import ToolActivity from "./ToolActivity"
 
 const {Text} = Typography
@@ -48,10 +49,15 @@ interface AgentMessageProps {
     /** This is the last message AND the conversation is streaming — i.e. the one being
      * generated right now. Only it shows the loading state; settled turns never do. */
     isStreaming?: boolean
+    /** This is the last message in the conversation. A parked client tool only lands on the last
+     * turn, so the unknown-client-tool fallback only arms there (see `isClientToolPart`). */
+    isLastMessage?: boolean
     /** Stable across renders (parent passes a `useCallback`'d handler) so the `memo()` below
      * isn't defeated — the message to rewind to is passed in, not closed over per render. */
     onRewind: (message: UIMessage) => void
     onApprovalResponse: (args: {id: string; approved: boolean}) => void
+    /** Settle a parked client tool (#4920) — the dispatcher calls this from a widget. */
+    onClientToolOutput: ClientToolOutputHandler
     /** The previous turn was also an empty (content-less) assistant turn. Used to collapse a
      * run of "no response" bubbles down to the first one. */
     precededByEmptyAssistant?: boolean
@@ -164,8 +170,10 @@ const avatarFor = (isUser: boolean) => (
 const AgentMessage = ({
     message,
     isStreaming = false,
+    isLastMessage = false,
     onRewind,
     onApprovalResponse,
+    onClientToolOutput,
     precededByEmptyAssistant = false,
 }: AgentMessageProps) => {
     const openTraceDrawer = useSetAtom(openTraceDrawerAtom)
@@ -240,9 +248,16 @@ const AgentMessage = ({
     type RenderItem =
         | {kind: "part"; part: UIMessage["parts"][number]; index: number}
         | {kind: "tools"; parts: ToolUIPart[]; index: number}
+        | {kind: "clientTool"; part: ToolUIPart; index: number}
     const renderItems: RenderItem[] = []
     message.parts.forEach((part, i) => {
         if (isToolPart(part.type)) {
+            // A browser-fulfilled client tool (#4920) renders as its own widget/chip, NOT folded
+            // into the "Used N tools" group — so it breaks any current tool run.
+            if (isClientToolPart(part as ToolUIPart, {isStreaming, isLastMessage})) {
+                renderItems.push({kind: "clientTool", part: part as ToolUIPart, index: i})
+                return
+            }
             const last = renderItems[renderItems.length - 1]
             if (last && last.kind === "tools") last.parts.push(part as ToolUIPart)
             else renderItems.push({kind: "tools", parts: [part as ToolUIPart], index: i})
@@ -317,6 +332,15 @@ const AgentMessage = ({
                             isStreaming={isStreaming}
                             onApprovalResponse={onApprovalResponse}
                             onViewTrace={onViewTrace}
+                        />
+                    )
+                }
+                if (item.kind === "clientTool") {
+                    return (
+                        <ClientToolPart
+                            key={`${message.id}-clienttool-${item.part.toolCallId || item.index}`}
+                            part={item.part}
+                            onOutput={onClientToolOutput}
                         />
                     )
                 }

--- a/web/oss/src/components/AgentChatSlice/components/clientTools/ClientToolPart.tsx
+++ b/web/oss/src/components/AgentChatSlice/components/clientTools/ClientToolPart.tsx
@@ -1,0 +1,57 @@
+/**
+ * Client-tool dispatcher (#4920) — the sibling to `ToolActivity` that renders a single client-tool
+ * part. It resolves the widget by `render.kind` → `toolName` (the registry) and falls back to the
+ * explicit "can't handle that" surface for an unknown client tool. The widget settles the part via
+ * `settle`, which calls the panel's `addToolOutput`; the resume predicate then auto-resends.
+ */
+import {createElement, memo, useCallback} from "react"
+
+import type {ToolUIPart} from "ai"
+
+import {clientToolMeta} from "./meta"
+import {resolveClientToolHandler} from "./registry"
+import UnhandledClientTool from "./UnhandledClientTool"
+
+/** Settle a parked client tool. The panel maps this onto `addToolOutput` (success or error). */
+export type ClientToolOutputHandler = (args: {
+    toolName: string
+    toolCallId: string
+    output?: Record<string, unknown>
+    errorText?: string
+}) => void
+
+const ClientToolPart = ({
+    part,
+    onOutput,
+}: {
+    part: ToolUIPart
+    onOutput: ClientToolOutputHandler
+}) => {
+    const meta = clientToolMeta(part)
+    // The handler is a STABLE module-level component picked from the registry (not created during
+    // render), so dispatch via `createElement` — `<Handler/>` would trip the static-components rule.
+    const handler = resolveClientToolHandler(meta) ?? UnhandledClientTool
+
+    const settle = useCallback(
+        (args: {output: Record<string, unknown>} | {errorText: string}) => {
+            if ("errorText" in args) {
+                onOutput({
+                    toolName: meta.toolName,
+                    toolCallId: meta.toolCallId,
+                    errorText: args.errorText,
+                })
+            } else {
+                onOutput({
+                    toolName: meta.toolName,
+                    toolCallId: meta.toolCallId,
+                    output: args.output,
+                })
+            }
+        },
+        [onOutput, meta.toolName, meta.toolCallId],
+    )
+
+    return createElement(handler, {meta, settle})
+}
+
+export default memo(ClientToolPart)

--- a/web/oss/src/components/AgentChatSlice/components/clientTools/ConnectToolWidget.tsx
+++ b/web/oss/src/components/AgentChatSlice/components/clientTools/ConnectToolWidget.tsx
@@ -1,0 +1,305 @@
+/**
+ * Connect widget — the `request_connection` / `render.kind: "connect"` client tool (#4920).
+ *
+ * The agent asked for a connection it lacks (e.g. GitHub). This widget runs the Agenta OAuth flow in
+ * the playground and settles the parked call with a **reference, never a secret**: the runner
+ * re-resolves the credential from the project vault on resume. It reuses the existing connection
+ * machinery (`useToolsConnections` → `POST /tools/connections/`, then a popup on the returned
+ * `redirect_url`) rather than reinventing the OAuth call.
+ *
+ * Security (hard requirement, design §"Security"): the popup posts back a `tools:oauth:complete`
+ * message; we trust it ONLY when `event.origin` equals the Agenta API origin (the callback page's
+ * origin) and the payload shape matches. Everything else is dropped.
+ *
+ * Settle on every terminal path (design §"Settle on every path"), so the run never hangs:
+ *   success → {connected:true, integration, slug} · cancel/abandon → {connected:false,
+ *   reason:"cancelled"} · timeout → {connected:false, reason:"timeout"} · failure → errorText.
+ *
+ * Result UX is U1 — an inline status chip in the same visual language as approve/deny: "Connect
+ * GitHub" → "Connecting GitHub…" → "GitHub connected" ✓, or "Connection not completed" + Retry.
+ */
+import {useCallback, useEffect, useRef, useState} from "react"
+
+import {ArrowClockwise, CheckCircle, Plugs, Spinner, Warning} from "@phosphor-icons/react"
+import {Button, Typography} from "antd"
+
+import {getAgentaApiUrl} from "@/oss/lib/helpers/api"
+
+import {useToolsConnections} from "../../../pages/settings/Tools/hooks/useToolsConnections"
+
+import type {ClientToolHandlerProps} from "./types"
+
+const {Text} = Typography
+
+/**
+ * No terminal signal within this bound settles the call as a timeout so the run can't wait forever.
+ * Armed only once the popup is open (the user is mid-flow). 3 minutes covers a real OAuth consent.
+ * NOTE for Mahmoud: confirm the bound — open question §"abandon timeout".
+ */
+const CONNECT_TIMEOUT_MS = 180_000
+/** Popup-closed poll cadence, matching the existing ConnectModal. */
+const POPUP_POLL_MS = 1000
+
+/** The settled call's reference shape (what the runner re-resolves against). */
+interface ConnectOutput {
+    connected?: boolean
+    integration?: string
+    slug?: string
+    reason?: string
+}
+
+/** `github` → `GitHub`-ish: a readable label without a provider catalog lookup. */
+const prettyIntegration = (key: string): string =>
+    key ? key.charAt(0).toUpperCase() + key.slice(1) : "the service"
+
+/** Read the API origin the OAuth callback page posts from; null if it can't be resolved. */
+const agentaApiOrigin = (): string | null => {
+    try {
+        const url = getAgentaApiUrl()
+        if (!url) return null
+        return new URL(url, typeof window !== "undefined" ? window.location.href : undefined).origin
+    } catch {
+        return null
+    }
+}
+
+type Phase = "idle" | "connecting" | "error"
+
+const ConnectToolWidget = ({meta, settle}: ClientToolHandlerProps) => {
+    const input = (meta.input ?? {}) as Record<string, unknown>
+    const integration = typeof input.integration === "string" ? input.integration : ""
+    // Connection slug: the call may pin one; default to the integration key. The output carries it
+    // back as the reference the runner re-resolves.
+    const slug =
+        typeof input.slug === "string" && input.slug ? input.slug : integration || "default"
+    const mode = input.mode === "api_key" ? "api_key" : "oauth"
+    const label = prettyIntegration(integration)
+
+    const {handleCreate, invalidate} = useToolsConnections(integration)
+
+    const [phase, setPhase] = useState<Phase>("idle")
+    const [errorText, setErrorText] = useState<string | null>(null)
+    // A retry started AFTER the parked call already settled (as a failure) succeeded. The settled
+    // part can't be re-resolved, but the connection now exists in the vault, so we flip the chip to
+    // "connected" — the agent's re-ask resolves cleanly on its next turn.
+    const [manuallyConnected, setManuallyConnected] = useState(false)
+
+    // One-shot guard so the parked call settles exactly once, plus shared cleanup for the running
+    // popup's listener/poll/timeout.
+    const settledRef = useRef(false)
+    const popupRef = useRef<Window | null>(null)
+    const cleanupRef = useRef<(() => void) | null>(null)
+
+    const teardown = useCallback(() => {
+        cleanupRef.current?.()
+        cleanupRef.current = null
+        popupRef.current = null
+    }, [])
+
+    // Settle the parked part exactly once (success/cancel/timeout/failure all route through here).
+    const finish = useCallback(
+        (result: ConnectOutput | {errorText: string}) => {
+            if (settledRef.current) return
+            settledRef.current = true
+            teardown()
+            if ("errorText" in result) settle({errorText: result.errorText})
+            else settle({output: result as Record<string, unknown>})
+        },
+        [settle, teardown],
+    )
+
+    useEffect(() => () => teardown(), [teardown])
+
+    /**
+     * Run the Agenta OAuth flow: create the connection, open the popup, and watch its three terminal
+     * signals (origin-validated success message, popup closed without success, or timeout backstop).
+     *
+     * `settleParkedCall` distinguishes the two callers:
+     *  - the live parked interaction (`true`): each terminal signal settles the parked tool call so
+     *    the run resumes;
+     *  - a manual retry after the call already settled (`false`): nothing to settle, so success just
+     *    flips the local "connected" chip and primes the vault for the agent's re-ask.
+     */
+    const runConnect = useCallback(
+        async (settleParkedCall: boolean) => {
+            if (phase === "connecting") return
+            if (settleParkedCall && settledRef.current) return
+            setErrorText(null)
+            setPhase("connecting")
+            try {
+                const result = await handleCreate({slug, name: slug, mode})
+                const redirectUrl =
+                    typeof result.connection?.data?.redirect_url === "string"
+                        ? result.connection.data.redirect_url
+                        : undefined
+
+                const onSuccess = () => {
+                    invalidate()
+                    if (settleParkedCall) finish({connected: true, integration, slug})
+                    else {
+                        setManuallyConnected(true)
+                        setPhase("idle")
+                    }
+                }
+
+                if (!redirectUrl) {
+                    // No OAuth step (e.g. api_key created inline): the connection already exists.
+                    onSuccess()
+                    return
+                }
+
+                const popup = window.open(
+                    redirectUrl,
+                    "tools_oauth",
+                    "width=600,height=700,popup=yes",
+                )
+                if (!popup) {
+                    setPhase("error")
+                    setErrorText("Couldn’t open the connection window. Allow popups and retry.")
+                    return
+                }
+                popupRef.current = popup
+
+                const apiOrigin = agentaApiOrigin()
+                let succeeded = false
+
+                const onMessage = (event: MessageEvent) => {
+                    // HARD requirement: only trust the callback from the Agenta API origin.
+                    if (apiOrigin && event.origin !== apiOrigin) return
+                    const data = event.data as {type?: unknown} | null
+                    if (!data || data.type !== "tools:oauth:complete") return
+                    succeeded = true
+                    teardown()
+                    onSuccess()
+                }
+                window.addEventListener("message", onMessage)
+
+                const poll = window.setInterval(() => {
+                    if (!popupRef.current?.closed || succeeded) return
+                    // Abandon: closed without a success message.
+                    teardown()
+                    if (settleParkedCall)
+                        finish({connected: false, integration, slug, reason: "cancelled"})
+                    else setPhase("idle")
+                }, POPUP_POLL_MS)
+
+                const timeout = window.setTimeout(() => {
+                    if (succeeded) return
+                    teardown()
+                    if (settleParkedCall)
+                        finish({connected: false, integration, slug, reason: "timeout"})
+                    else setPhase("idle")
+                }, CONNECT_TIMEOUT_MS)
+
+                cleanupRef.current = () => {
+                    window.removeEventListener("message", onMessage)
+                    window.clearInterval(poll)
+                    window.clearTimeout(timeout)
+                    try {
+                        popupRef.current?.close()
+                    } catch {
+                        // best effort
+                    }
+                }
+            } catch (err) {
+                const message = err instanceof Error ? err.message : "Connection failed."
+                // A create failure is terminal for the parked call: settle so the run resumes; for a
+                // manual retry just surface the reason with another Retry.
+                setPhase("error")
+                setErrorText(message)
+                if (settleParkedCall) finish({connected: false, integration, slug, reason: message})
+            }
+        },
+        [phase, handleCreate, slug, mode, invalidate, finish, teardown, integration],
+    )
+
+    // Explicit cancel while the popup is open: settle the parked call as cancelled (or, for a manual
+    // retry, just stop).
+    const cancel = useCallback(() => {
+        teardown()
+        if (!settledRef.current) finish({connected: false, integration, slug, reason: "cancelled"})
+        else setPhase("idle")
+    }, [finish, teardown, integration, slug])
+
+    // ── Connecting: popup open (either the live flow or a manual retry) ──────────────────────────
+    if (phase === "connecting") {
+        return (
+            <ChipRow icon={<Spinner size={13} className="animate-spin text-colorPrimary" />}>
+                <Text type="secondary" className="!text-xs">
+                    Connecting {label}…
+                </Text>
+                <Button type="text" onClick={cancel} className="!px-2">
+                    Cancel
+                </Button>
+            </ChipRow>
+        )
+    }
+
+    // ── Settled: the result chip (U1) ───────────────────────────────────────────────────────────
+    if (meta.settled) {
+        const output = (meta.output ?? {}) as ConnectOutput
+        if (manuallyConnected || output.connected === true) {
+            return (
+                <ChipRow
+                    icon={<CheckCircle size={13} weight="fill" className="text-colorSuccess" />}
+                >
+                    <Text className="!text-xs">{label} connected</Text>
+                </ChipRow>
+            )
+        }
+        // Cancelled / timeout / failed: a Retry re-runs the OAuth fresh (the parked call already
+        // resolved, so this primes the vault and flips the chip on success).
+        return (
+            <ChipRow icon={<Warning size={13} weight="fill" className="text-colorWarning" />}>
+                <Text type="secondary" className="!text-xs">
+                    Connection not completed
+                </Text>
+                <RetryButton onClick={() => runConnect(false)} />
+            </ChipRow>
+        )
+    }
+
+    // ── Error (create failed, popup blocked) on the live flow: show reason + Retry ───────────────
+    if (phase === "error") {
+        return (
+            <ChipRow icon={<Warning size={13} weight="fill" className="text-colorError" />}>
+                <Text type="danger" className="!text-xs truncate" title={errorText ?? undefined}>
+                    {errorText ?? "Connection failed."}
+                </Text>
+                <RetryButton onClick={() => runConnect(true)} />
+            </ChipRow>
+        )
+    }
+
+    // ── Idle: the initial prompt ────────────────────────────────────────────────────────────────
+    return (
+        <ChipRow icon={<Plugs size={13} className="text-colorPrimary" />}>
+            <Text className="!text-xs">Connect {label}</Text>
+            <Button type="primary" onClick={() => runConnect(true)}>
+                Connect
+            </Button>
+        </ChipRow>
+    )
+}
+
+/** A compact tool-activity row, matching ToolActivity's visual language. */
+const ChipRow = ({icon, children}: {icon: React.ReactNode; children: React.ReactNode}) => (
+    <div className="flex min-w-0 items-center gap-2 py-1">
+        <span className="shrink-0">{icon}</span>
+        {children}
+    </div>
+)
+
+const RetryButton = ({onClick, disabled}: {onClick: () => void; disabled?: boolean}) => (
+    <Button
+        type="text"
+        onClick={onClick}
+        disabled={disabled}
+        icon={<ArrowClockwise size={13} />}
+        className="!px-2"
+    >
+        Retry
+    </Button>
+)
+
+export default ConnectToolWidget

--- a/web/oss/src/components/AgentChatSlice/components/clientTools/UnhandledClientTool.tsx
+++ b/web/oss/src/components/AgentChatSlice/components/clientTools/UnhandledClientTool.tsx
@@ -1,0 +1,33 @@
+/**
+ * Fallback surface for a parked client tool with no registered widget (design §"Where dispatch
+ * lives"). It must SETTLE the part so the run never hangs silently: on mount it settles an error,
+ * which resumes the run and lets the agent re-ask or move on. The row stays as a brief explanation.
+ */
+import {useEffect, useRef} from "react"
+
+import {Warning} from "@phosphor-icons/react"
+import {Typography} from "antd"
+
+import type {ClientToolHandlerProps} from "./types"
+
+const {Text} = Typography
+
+const UnhandledClientTool = ({meta, settle}: ClientToolHandlerProps) => {
+    const settledRef = useRef(false)
+    useEffect(() => {
+        if (settledRef.current || meta.settled) return
+        settledRef.current = true
+        settle({errorText: `This app can’t handle the "${meta.toolName}" request.`})
+    }, [meta.settled, meta.toolName, settle])
+
+    return (
+        <div className="flex min-w-0 items-center gap-2 py-1">
+            <Warning size={13} weight="fill" className="shrink-0 text-colorWarning" />
+            <Text type="secondary" className="!text-xs truncate">
+                Can’t handle the “{meta.toolName}” request
+            </Text>
+        </div>
+    )
+}
+
+export default UnhandledClientTool

--- a/web/oss/src/components/AgentChatSlice/components/clientTools/index.ts
+++ b/web/oss/src/components/AgentChatSlice/components/clientTools/index.ts
@@ -1,0 +1,9 @@
+/**
+ * Client-tool round-trip (#4920): a browser-fulfilled tool the runner emits-and-parks, dispatched
+ * here by `render.kind` → `toolName` → an explicit "can't handle that" fallback. v1 ships the
+ * connect widget (`request_connection`). See `types.ts` for the contract.
+ */
+export {default as ClientToolPart, type ClientToolOutputHandler} from "./ClientToolPart"
+export {clientToolMeta, isClientToolPart, clientToolName} from "./meta"
+export {hasClientToolHandler, resolveClientToolHandler} from "./registry"
+export type {ClientToolMeta, ClientToolHandlerProps} from "./types"

--- a/web/oss/src/components/AgentChatSlice/components/clientTools/meta.ts
+++ b/web/oss/src/components/AgentChatSlice/components/clientTools/meta.ts
@@ -1,0 +1,66 @@
+/**
+ * Normalise a tool UI part into the {@link ClientToolMeta} the dispatcher reads, and decide whether
+ * a part is a client tool the playground must fulfill (vs an ordinary server tool or an approval
+ * gate, which `ToolActivity` owns).
+ */
+import type {ToolUIPart} from "ai"
+
+import {hasClientToolHandler} from "./registry"
+import type {ClientToolMeta} from "./types"
+
+const SETTLED = new Set(["output-available", "output-error"])
+const APPROVAL = new Set(["approval-requested", "approval-responded"])
+
+/** Friendly tool name: `tool-<name>` carries it in the type; `dynamic-tool` on `toolName`. */
+export const clientToolName = (part: ToolUIPart): string => {
+    const type = part.type as string
+    if (type === "dynamic-tool") return (part as {toolName?: string}).toolName || "tool"
+    return type.replace(/^tool-/, "")
+}
+
+/** Read the optional render hint off the part (may be absent on the wire in v1). */
+const renderKindOf = (part: ToolUIPart): string | undefined => {
+    const render = (part as {render?: {kind?: unknown}}).render
+    return render && typeof render.kind === "string" ? render.kind : undefined
+}
+
+export const clientToolMeta = (part: ToolUIPart): ClientToolMeta => {
+    const state = part.state as string
+    return {
+        toolCallId: part.toolCallId,
+        toolName: clientToolName(part),
+        renderKind: renderKindOf(part),
+        state,
+        input: (part as {input?: unknown}).input,
+        output: (part as {output?: unknown}).output,
+        settled: SETTLED.has(state),
+        part,
+    }
+}
+
+/**
+ * Whether a tool part is a client tool the playground renders (a widget or a settled chip), rather
+ * than letting it fall through to `ToolActivity`. Two ways a part qualifies:
+ *
+ *  1. **Known client tool** — its `render.kind`/`toolName` is in the registry. Rendered in every
+ *     state so the result UX (chip) shows after it settles.
+ *  2. **Parked unknown client tool** — the turn has finished (not streaming) yet a non-provider-
+ *     executed tool part is still unsettled and is not an approval gate. The runner only leaves a
+ *     part in this "turn done, part unsettled, not providerExecuted" state for a client tool, so we
+ *     surface the explicit "can't handle that" widget (which settles the part so it never hangs).
+ */
+export const isClientToolPart = (
+    part: ToolUIPart,
+    ctx: {isStreaming: boolean; isLastMessage: boolean},
+): boolean => {
+    const state = part.state as string
+    if (APPROVAL.has(state)) return false
+    if ((part as {providerExecuted?: boolean}).providerExecuted === true) return false
+
+    const meta = clientToolMeta(part)
+    if (hasClientToolHandler(meta)) return true
+
+    // Parked unknown client tool: the run ended with this part still unsettled.
+    const parkedUnsettled = !ctx.isStreaming && ctx.isLastMessage && !meta.settled
+    return parkedUnsettled
+}

--- a/web/oss/src/components/AgentChatSlice/components/clientTools/registry.tsx
+++ b/web/oss/src/components/AgentChatSlice/components/clientTools/registry.tsx
@@ -1,0 +1,39 @@
+/**
+ * Client-tool handler registry (#4920).
+ *
+ * Dispatch precedence is **`render.kind` → `toolName` → generic fallback** (design §"Where dispatch
+ * lives"). v1 ships exactly one real entry, `request_connection` (the connect widget), keyed by both
+ * its `render.kind` (`connect`) and its `toolName` so it dispatches whether or not the render hint
+ * reaches the browser (verify-first seam #1: for v1 we dispatch by `toolName`). Each later client
+ * tool is one added entry, not a protocol change.
+ *
+ * A streamed client tool with no entry is NOT an error here — `ClientToolPart` renders the explicit
+ * "this app can't handle that request" surface and settles the part so the run never hangs.
+ */
+import type {ComponentType} from "react"
+
+import ConnectToolWidget from "./ConnectToolWidget"
+import type {ClientToolHandlerProps, ClientToolMeta} from "./types"
+
+type ClientToolHandler = ComponentType<ClientToolHandlerProps>
+
+/** Handlers keyed by `render.kind` (checked first — the finer dispatch axis). */
+const BY_RENDER_KIND: Record<string, ClientToolHandler> = {
+    connect: ConnectToolWidget,
+}
+
+/** Handlers keyed by `toolName` (checked when no render hint matched). */
+const BY_TOOL_NAME: Record<string, ClientToolHandler> = {
+    request_connection: ConnectToolWidget,
+}
+
+/** Resolve the widget for a client tool, or `null` when none is registered. */
+export const resolveClientToolHandler = (meta: ClientToolMeta): ClientToolHandler | null => {
+    if (meta.renderKind && BY_RENDER_KIND[meta.renderKind]) return BY_RENDER_KIND[meta.renderKind]
+    if (BY_TOOL_NAME[meta.toolName]) return BY_TOOL_NAME[meta.toolName]
+    return null
+}
+
+/** Whether this client tool has a dedicated widget (used to route known tools in every state). */
+export const hasClientToolHandler = (meta: ClientToolMeta): boolean =>
+    resolveClientToolHandler(meta) !== null

--- a/web/oss/src/components/AgentChatSlice/components/clientTools/types.ts
+++ b/web/oss/src/components/AgentChatSlice/components/clientTools/types.ts
@@ -1,0 +1,52 @@
+/**
+ * Shared types for the client-tool round-trip (#4920).
+ *
+ * A *client tool* is a tool the playground fulfills, not the sandbox. The runner streams the call
+ * as a standard unsettled tool part (`tool-input-available`, no output, `providerExecuted` falsy)
+ * and parks the turn. The playground dispatches a widget; the widget drives the interaction and
+ * settles the part with a structured **reference** (never a secret) via `addToolOutput`. The
+ * `sendAutomaticallyWhen` predicate then auto-resends and the runner resumes on cold-replay.
+ *
+ * These types are structural (no `ai` import) so the dispatcher, registry, and widgets agree on the
+ * one shape they read off a UI message part.
+ */
+import type {ToolUIPart} from "ai"
+
+/** The optional presentation hint that rides the one-way render channel (`data-<name>`). v1 may not
+ * see it on the wire — dispatch falls back to `toolName` — but the shape is reserved so a future
+ * `render.kind` (e.g. `config-diff`) lands with no protocol change. */
+export interface ClientToolRenderHint {
+    kind?: string
+}
+
+/**
+ * Normalised view of a tool part the dispatcher works with. `toolName` is read off the typed
+ * `tool-<name>` part type or a `dynamic-tool`'s `toolName`; `renderKind` off the (optional) render
+ * hint. `state` is the AI SDK tool-part state machine value.
+ */
+export interface ClientToolMeta {
+    toolCallId: string
+    toolName: string
+    renderKind?: string
+    state: string
+    input: unknown
+    output: unknown
+    /** A browser-fulfilled result already settled it (`output-available`/`output-error`). */
+    settled: boolean
+    /** The raw part, for handlers that need fields beyond the normalised view. */
+    part: ToolUIPart
+}
+
+/** Settle the parked part. Mirrors `addToolOutput` but keyed by the values a widget already holds.
+ * Exactly one of `output` / `errorText` is supplied (success vs error envelope). */
+export interface SettleClientTool {
+    (args: {output: Record<string, unknown>}): void
+    (args: {errorText: string}): void
+}
+
+/** Props every client-tool widget receives. */
+export interface ClientToolHandlerProps {
+    meta: ClientToolMeta
+    /** Settle the part (resumes the run). No-op once already settled. */
+    settle: SettleClientTool
+}

--- a/web/packages/agenta-entities/src/workflow/index.ts
+++ b/web/packages/agenta-entities/src/workflow/index.ts
@@ -230,6 +230,7 @@ export {
     // Cache invalidation
     invalidateWorkflowsListCache,
     invalidateWorkflowCache,
+    invalidateAgentCommittedRevisionCache,
     seedCreatedWorkflowCache,
     // ListQueryState wrappers (for selection adapters and relations)
     workflowVariantsListQueryStateAtomFamily,

--- a/web/packages/agenta-entities/src/workflow/state/index.ts
+++ b/web/packages/agenta-entities/src/workflow/state/index.ts
@@ -62,6 +62,7 @@ export {
     // Cache invalidation
     invalidateWorkflowsListCache,
     invalidateWorkflowCache,
+    invalidateAgentCommittedRevisionCache,
     seedCreatedWorkflowCache,
     // ListQueryState wrappers (for selection adapters and relations)
     workflowVariantsListQueryStateAtomFamily,

--- a/web/packages/agenta-entities/src/workflow/state/store.ts
+++ b/web/packages/agenta-entities/src/workflow/state/store.ts
@@ -2473,3 +2473,25 @@ export function invalidateWorkflowRevisionsByVariantCache(
     }
     store.set(workflowRevisionsQueryAtomFamily(variantId))
 }
+
+/**
+ * Refresh the playground's read-only views after the agent commits a new revision of itself
+ * (#4920 — Application 1). A commit lands a new revision, so this invalidates both the
+ * latest-revision query (the config panel + section drawers re-read the new config) and the inspect
+ * query (harness-capabilities / any inspect-derived view).
+ *
+ * Fired on the one-way `data-committed-revision` stream signal (which the backend emits in BOTH the
+ * gated approval path and the direct `needs_approval=false` path), not on approval — so a single
+ * emit point covers both. The payload's ids aren't needed: a prefix invalidation refetches every
+ * active observer, which is exactly the set the playground has mounted.
+ */
+export function invalidateAgentCommittedRevisionCache(options?: StoreOptions) {
+    const store = getStore(options)
+    try {
+        const qc = store.get(queryClientAtom)
+        qc.invalidateQueries({queryKey: ["workflows", "latestRevision"], exact: false})
+        qc.invalidateQueries({queryKey: ["workflows", "inspect"], exact: false})
+    } catch {
+        // queryClientAtom may not be initialized yet
+    }
+}

--- a/web/packages/agenta-playground/src/state/execution/agentApprovalResume.ts
+++ b/web/packages/agenta-playground/src/state/execution/agentApprovalResume.ts
@@ -1,21 +1,26 @@
 /**
- * Agent-lane HITL resume predicate.
+ * Agent-lane resume predicate — for BOTH parked client tools and HITL approval gates.
  *
- * `useChat`'s `sendAutomaticallyWhen` decides when the conversation auto-resends after the
- * user resolves a tool-approval gate. The AI SDK ships
- * `lastAssistantMessageIsCompleteWithApprovalResponses`, which DOES fire for a deny-only
- * decision (a denied tool part is still `approval-responded`). We wrap it in an explicit,
- * unit-tested predicate so the deny → resume contract is pinned at the FE seam rather than
- * left implicit in the SDK internals:
+ * `useChat`'s `sendAutomaticallyWhen` decides when the conversation auto-resends after a parked
+ * client interaction settles. The agent FE round-trip (#4920) generalizes the existing approval
+ * round-trip to an arbitrary browser-fulfilled tool: the runner emits the tool call and parks the
+ * turn; the playground fulfills it with `addToolOutput`; the turn must then auto-resend so the
+ * runner cold-replays and resumes. Two settle shapes drive a resume here:
  *
- *   - Approve and Deny BOTH resume. On resume the runner receives the `{approved}` envelope
- *     (the SDK ingress maps an `approval-responded` tool part to a `tool_result`), maps a
- *     deny to reject → tool-error, and the model continues — no deadlock, no limbo
- *     `approval-responded` state (the F-036 dead-end).
- *   - A pending gate (`approval-requested`, still awaiting the user) does NOT resume.
+ *   - **Approval response.** Approve AND Deny both resume — a denied tool part is still
+ *     `approval-responded`, so the runner gets the denial round-trip (the SDK ingress maps it to a
+ *     `tool_result`, a deny → tool-error) and the model continues. No `approval-responded` limbo
+ *     (the F-036 dead-end).
+ *   - **Client-tool result.** A parked client tool fulfilled by the browser settles to
+ *     `output-available`/`output-error` with `providerExecuted` falsy (it was NOT run server-side).
+ *     That fulfilled output must resume the run exactly as an approval does.
  *
- * Pure + structurally typed so the package needs no `ai` dependency: it reads only the
- * fields the AI SDK puts on a UI message (`role`, `parts[].type/state/approval`).
+ * A pending interaction (`approval-requested`, or a still-`input-available` client tool awaiting the
+ * user) does NOT resume. Server-executed tool parts (`providerExecuted === true`) are ignored — they
+ * settle within the turn and never park, so they neither gate nor trigger a resume.
+ *
+ * Pure + structurally typed so the package needs no `ai` dependency: it reads only the fields the AI
+ * SDK puts on a UI message (`role`, `parts[].type/state/providerExecuted`).
  */
 
 interface ApprovalLike {
@@ -43,6 +48,24 @@ const isToolPart = (part: ToolPartLike): boolean => {
 const isRespondedToolPart = (part: ToolPartLike): boolean =>
     isToolPart(part) && part.state === "approval-responded"
 
+/**
+ * A browser-fulfilled client-tool result: a tool part the playground settled via `addToolOutput`
+ * (`output-available`/`output-error`) that the server did NOT run (`providerExecuted` falsy) and
+ * carries NO approval metadata. This is how a parked `request_connection` (or any client tool) reads
+ * once the widget settles it.
+ *
+ * The `approval == null` guard is load-bearing: an approval-gated tool that was approved and then RAN
+ * also lands in `output-available` with `providerExecuted` falsy, but it is NOT a parked client tool
+ * (its turn already continued) — it keeps its `approval` field, so excluding it here stops a spurious
+ * resume (and stops the queue gate, which composes this predicate, from holding forever). v1 client
+ * tools are never approval-gated; an approval-gated client tool would need a richer signal.
+ */
+const isClientToolResult = (part: ToolPartLike): boolean =>
+    isToolPart(part) &&
+    part.providerExecuted !== true &&
+    part.approval == null &&
+    (part.state === "output-available" || part.state === "output-error")
+
 /** A resolved tool part is settled when it has run, errored, or carries a decision. */
 const isSettledToolPart = (part: ToolPartLike): boolean =>
     isToolPart(part) &&
@@ -51,10 +74,14 @@ const isSettledToolPart = (part: ToolPartLike): boolean =>
         part.state === "approval-responded")
 
 /**
- * Resume when the last assistant turn carries at least one responded approval and EVERY
- * non-provider-executed tool part on it is settled. Deny-only counts: a denied tool part is
- * `approval-responded`, so a turn the user only denied still resumes and the runner gets the
- * denial round-trip (the fix for the deny dead-end).
+ * Resume when the last assistant turn carries at least one freshly-resolved parked interaction (an
+ * approval response OR a browser-fulfilled client-tool result) and EVERY non-provider-executed tool
+ * part on it is settled. Both paths share one rule so a single `sendAutomaticallyWhen` covers
+ * approvals and client tools alike:
+ *   - Approval (approve OR deny): a denied tool part is `approval-responded`, so a deny-only turn
+ *     still resumes and the runner gets the denial round-trip (the deny dead-end fix).
+ *   - Client tool: a `request_connection` the widget settled (success, cancel, failure, abandon)
+ *     reads as a client-tool result, so the run resumes and the runner re-resolves on cold-replay.
  */
 export function agentShouldResumeAfterApproval({messages}: {messages: MessageLike[]}): boolean {
     const last = messages[messages.length - 1]
@@ -65,7 +92,9 @@ export function agentShouldResumeAfterApproval({messages}: {messages: MessageLik
     )
     if (toolParts.length === 0) return false
 
-    const hasResponded = toolParts.some(isRespondedToolPart)
+    const hasResolved = toolParts.some(
+        (part) => isRespondedToolPart(part) || isClientToolResult(part),
+    )
     const allSettled = toolParts.every(isSettledToolPart)
-    return hasResponded && allSettled
+    return hasResolved && allSettled
 }

--- a/web/packages/agenta-playground/tests/unit/agentApprovalResume.test.ts
+++ b/web/packages/agenta-playground/tests/unit/agentApprovalResume.test.ts
@@ -27,6 +27,22 @@ const assistantWithTool = (state: string, approved?: boolean) => ({
     ],
 })
 
+/** A parked client tool (e.g. `request_connection`): no approval, `providerExecuted` falsy. */
+const assistantWithClientTool = (state: string, output?: unknown) => ({
+    id: "a1",
+    role: "assistant",
+    parts: [
+        {type: "step-start"},
+        {
+            type: "tool-request_connection",
+            toolCallId: "call_c",
+            state,
+            input: {integration: "github"},
+            ...(output === undefined ? {} : {output}),
+        },
+    ],
+})
+
 describe("agentShouldResumeAfterApproval", () => {
     it("RESUMES on a deny-only decision (the F-036 dead-end fix)", () => {
         const messages = [user("do it"), assistantWithTool("approval-responded", false)]
@@ -114,6 +130,100 @@ describe("agentShouldResumeAfterApproval", () => {
 
     it("does NOT resume when there are no messages", () => {
         expect(agentShouldResumeAfterApproval({messages: []})).toBe(false)
+    })
+
+    it("RESUMES when a parked client tool is fulfilled (output-available)", () => {
+        const messages = [
+            user("connect github"),
+            assistantWithClientTool("output-available", {
+                connected: true,
+                integration: "github",
+                slug: "github-main",
+            }),
+        ]
+        expect(agentShouldResumeAfterApproval({messages})).toBe(true)
+    })
+
+    it("RESUMES when a client tool settles as a failure (cancel/abandon/error)", () => {
+        const messages = [
+            user("connect github"),
+            assistantWithClientTool("output-error", undefined),
+        ]
+        // output-error counts as settled even with no `output` payload (errorText path).
+        expect(agentShouldResumeAfterApproval({messages})).toBe(true)
+    })
+
+    it("does NOT resume while a client tool is still parked (input-available)", () => {
+        const messages = [user("connect github"), assistantWithClientTool("input-available")]
+        expect(agentShouldResumeAfterApproval({messages})).toBe(false)
+    })
+
+    it("does NOT resume while a client tool is still streaming its input", () => {
+        const messages = [user("connect github"), assistantWithClientTool("input-streaming")]
+        expect(agentShouldResumeAfterApproval({messages})).toBe(false)
+    })
+
+    it("resumes when a fulfilled client tool sits alongside a responded approval", () => {
+        const messages = [
+            user("do it then connect"),
+            {
+                id: "a1",
+                role: "assistant",
+                parts: [
+                    {type: "step-start"},
+                    {
+                        type: "tool-deleteFile",
+                        toolCallId: "call_1",
+                        state: "approval-responded",
+                        input: {path: "/x"},
+                        approval: {id: "perm_1", approved: true},
+                    },
+                    {
+                        type: "tool-request_connection",
+                        toolCallId: "call_c",
+                        state: "output-available",
+                        input: {integration: "github"},
+                        output: {connected: true, integration: "github", slug: "github-main"},
+                    },
+                ],
+            },
+        ]
+        expect(agentShouldResumeAfterApproval({messages})).toBe(true)
+    })
+
+    it("does NOT resume when a fulfilled client tool sits beside an unsettled sibling", () => {
+        const messages = [
+            user("connect both"),
+            {
+                id: "a1",
+                role: "assistant",
+                parts: [
+                    {type: "step-start"},
+                    {
+                        type: "tool-request_connection",
+                        toolCallId: "call_c",
+                        state: "output-available",
+                        input: {integration: "github"},
+                        output: {connected: true, integration: "github", slug: "github-main"},
+                    },
+                    {
+                        type: "tool-request_connection",
+                        toolCallId: "call_d",
+                        state: "input-available",
+                        input: {integration: "slack"},
+                    },
+                ],
+            },
+        ]
+        expect(agentShouldResumeAfterApproval({messages})).toBe(false)
+    })
+
+    it("does NOT resume for an APPROVED tool that ran (output-available WITH approval)", () => {
+        // An approval-gated tool that was approved and then produced output keeps its `approval`
+        // field. It is not a parked client tool — the turn already continued — so it must not be
+        // read as a client-tool result (else the queue gate, which composes this, holds forever).
+        const messages = [user("do it"), assistantWithTool("output-available", true)]
+        expect(agentShouldResumeAfterApproval({messages})).toBe(false)
     })
 
     it("ignores provider-executed tool parts when deciding completeness", () => {


### PR DESCRIPTION
## Context

Backend PR #4925 makes the agent runner emit-and-park a browser-fulfilled tool (e.g. `request_connection`), resume the run from the returned `tool_result`, and emit a one-way `data-committed-revision` event when the agent commits a new revision of itself. This PR is the frontend half. Without it a parked client-tool call has no UI: the turn finishes with the part unsettled and the agent appears to hang.

Stacked on #4925, so this PR's base is `feat/client-tool-roundtrip-4920` and the diff is frontend-only.

## Changes

Four pieces, all reusing the existing HITL approval machinery rather than a new transport.

**Resume predicate.** `agentShouldResumeAfterApproval` now also resumes on a browser-fulfilled client-tool result, not only on an approval response. A client-tool result is a settled tool part (`output-available` / `output-error`) that was not provider-executed and carries no approval metadata. That last guard is load-bearing: an approval-gated tool that was approved and then ran also lands in `output-available` with `providerExecuted` falsy, so without the guard the queued-message gate (which composes this predicate) would hold forever.

**Client-tool dispatcher** (`AgentChatSlice/components/clientTools/`). A sibling to `ToolActivity` that renders a widget for an unsettled client-tool part, chosen from a registry keyed `render.kind`, then `toolName`, then a generic fallback. An unknown client tool gets an explicit "this app can't handle that request" surface that settles the part, so a parked call never hangs silently. v1 registers one real widget.

**Connect widget** (`request_connection`). Reuses the existing connection machinery (`useToolsConnections` plus the OAuth popup). It validates the callback `postMessage` origin against the Agenta API origin before trusting it, and settles on every terminal path (success, explicit cancel, abandoned popup, timeout) so the run always resumes. Result UX is a compact inline status chip in the same visual language as approve/deny: "Connect GitHub", then "Connecting...", then "GitHub connected", or "Connection not completed" with Retry.

**Refresh on commit.** The chat consumer listens for the `data-committed-revision` message part and calls a new `invalidateAgentCommittedRevisionCache`, which invalidates the latest-revision and inspect caches so the config panel refreshes in both the gated and the direct (`needs_approval=false`) commit paths.

## Tests / notes

- `tsc --noEmit` clean for `@agenta/entities` and `@agenta/playground`; oss `tsc` shows no net-new errors against the base.
- eslint + prettier clean on the changed files.
- Unit tests for the resume predicate cover the approval path, the client-tool path, and the approved-then-ran guard.
- Known v1 seam: the render hint reaches the browser as a separate `data-render` part keyed by `toolCallId`, which the dispatcher does not consume yet, so dispatch is by `toolName` for v1 (the connect widget still resolves correctly). Reading `data-render` is a small follow-up.
- No end-to-end run yet. The OAuth round-trip needs the merged backend up plus a configured connection provider.

## What to QA

Requires the merged backend (#4925) running, an agent whose toolset includes `request_connection`, and a connection provider configured.

- Drive an agent that calls `request_connection(github)`. A "Connect GitHub" chip appears under the turn. Click Connect and finish OAuth in the popup. The chip flips to "GitHub connected" and the run resumes with the reference.
- Abandon path: open the popup and close it without finishing. The chip reads "Connection not completed" with Retry, and the run resumes with a failure result rather than hanging.
- Commit refresh: have the agent commit a revision (approve it, or with `needs_approval=false`). The config panel updates to the new revision with no manual reload.
