### PR TITLE
feat(frontend): collapsible advanced config sections

### DIFF
--- a/web/packages/agenta-entity-ui/src/DrillInView/SchemaControls/AgentTemplateControl.tsx
+++ b/web/packages/agenta-entity-ui/src/DrillInView/SchemaControls/AgentTemplateControl.tsx
@@ -24,6 +24,7 @@
 import {useCallback, useEffect, useMemo, useRef, useState} from "react"
 
 import type {SchemaProperty} from "@agenta/entities/shared"
+import {workflowBuildKitEnabledAtomFamily} from "@agenta/entities/workflow"
 import {ConfigAccordionSection} from "@agenta/ui/components/presentational"
 import {useDrillInUI} from "@agenta/ui/drill-in"
 import {cn} from "@agenta/ui/styles"
@@ -38,7 +39,7 @@ import {
     Wrench,
 } from "@phosphor-icons/react"
 import {Button, Tabs, Tag, Tooltip, Typography} from "antd"
-import {useAtomValue} from "jotai"
+import {useAtomValue, useStore} from "jotai"
 
 import {useOptionalDrillIn} from "../components/MoleculeDrillInContext"
 
@@ -122,17 +123,30 @@ export function AgentTemplateControl({
     // is restored on Cancel, giving the same draft-then-save feel as the item drawers.
     const [openSection, setOpenSection] = useState<null | "model-harness" | "advanced">(null)
     const sectionSnapshot = useRef<Record<string, unknown> | null>(null)
+    // Snapshot + restore for the build-kit enabled atom (lives outside config; needs separate tracking).
+    const store = useStore()
+    const revisionIdRef = useRef<string | null>(null)
+    const buildKitEnabledSnapshot = useRef<boolean | null>(null)
     const openSectionDrawer = useCallback(
         (key: "model-harness" | "advanced") => {
             sectionSnapshot.current = value ?? {}
+            buildKitEnabledSnapshot.current = store.get(
+                workflowBuildKitEnabledAtomFamily(revisionIdRef.current ?? ""),
+            )
             setOpenSection(key)
         },
-        [value],
+        [value, store],
     )
     const cancelSection = useCallback(() => {
         if (sectionSnapshot.current) onChange(sectionSnapshot.current)
+        if (buildKitEnabledSnapshot.current !== null) {
+            store.set(
+                workflowBuildKitEnabledAtomFamily(revisionIdRef.current ?? ""),
+                buildKitEnabledSnapshot.current,
+            )
+        }
         setOpenSection(null)
-    }, [onChange])
+    }, [onChange, store])
     const saveSection = useCallback(() => setOpenSection(null), [])
 
     // Layout (accordion / tabs / cards) is a global persisted preference; the panel only reads it.
@@ -153,6 +167,7 @@ export function AgentTemplateControl({
     // useModelHarness) and bound-trigger scoping both key off it.
     const drillIn = useOptionalDrillIn<unknown>()
     const revisionId = drillIn?.entityId ?? null
+    revisionIdRef.current = revisionId
     // Triggers bound to this agent (for the section count badge). The section body and the header
     // add-dropdown derive scoping from the same hook.
     const {count: triggerCount} = useAgentTriggers(revisionId)

--- a/web/packages/agenta-entity-ui/src/DrillInView/SchemaControls/agentTemplate/useBuildKit.tsx
+++ b/web/packages/agenta-entity-ui/src/DrillInView/SchemaControls/agentTemplate/useBuildKit.tsx
@@ -149,7 +149,7 @@ export function useBuildKit({
     const [buildKitEnabled, setBuildKitEnabled] = useAtom(
         useMemo(() => workflowBuildKitEnabledAtomFamily(revisionId ?? ""), [revisionId]),
     )
-    const [buildKitExpanded, setBuildKitExpanded] = useState(true)
+    const [buildKitExpanded, setBuildKitExpanded] = useState(false)
 
     const overlayTools = useMemo(
         () => (Array.isArray(agentTemplateOverlay?.tools) ? agentTemplateOverlay.tools : []),
@@ -193,6 +193,7 @@ export function useBuildKit({
         <div className="rounded border border-solid border-[var(--ag-c-EAEFF5,#eaeff5)] bg-[#fcfcfa]">
             <button
                 type="button"
+                aria-expanded={buildKitExpanded}
                 onClick={() => setBuildKitExpanded((open) => !open)}
                 className="flex w-full cursor-pointer items-center gap-2 border-0 bg-transparent px-3 py-2.5 text-left"
             >

--- a/web/packages/agenta-entity-ui/src/DrillInView/SchemaControls/agentTemplate/useModelHarness.tsx
+++ b/web/packages/agenta-entity-ui/src/DrillInView/SchemaControls/agentTemplate/useModelHarness.tsx
@@ -707,6 +707,7 @@ export function useModelHarness({
                 >
                     <button
                         type="button"
+                        aria-expanded={authExpanded}
                         onClick={() => setAuthExpanded((open) => !open)}
                         className="flex w-full cursor-pointer items-center gap-2 border-0 bg-transparent px-3 py-2.5 text-left"
                     >
@@ -746,6 +747,7 @@ export function useModelHarness({
                 <div className="rounded border border-solid border-[var(--ag-c-EAEFF5,#eaeff5)]">
                     <button
                         type="button"
+                        aria-expanded={execExpanded}
                         onClick={() => setExecExpanded((open) => !open)}
                         className="flex w-full cursor-pointer items-center gap-2 border-0 bg-transparent px-3 py-2.5 text-left"
                     >
@@ -815,6 +817,7 @@ export function useModelHarness({
                 <div className="rounded border border-solid border-[var(--ag-c-EAEFF5,#eaeff5)]">
                     <button
                         type="button"
+                        aria-expanded={permsExpanded}
                         onClick={() => setPermsExpanded((open) => !open)}
                         className="flex w-full cursor-pointer items-center gap-2 border-0 bg-transparent px-3 py-2.5 text-left"
                     >

--- a/web/packages/agenta-entity-ui/src/DrillInView/SchemaControls/agentTemplate/useModelHarness.tsx
+++ b/web/packages/agenta-entity-ui/src/DrillInView/SchemaControls/agentTemplate/useModelHarness.tsx
@@ -10,7 +10,16 @@ import {harnessCapabilitiesAtomFamily} from "@agenta/entities/workflow"
 import {LabeledField} from "@agenta/ui/components/presentational"
 import {SelectLLMProviderBase} from "@agenta/ui/select-llm-provider"
 import {cn} from "@agenta/ui/styles"
-import {Check, Cube, EyeSlash, Key, Lightbulb, ShieldCheck, Warning} from "@phosphor-icons/react"
+import {
+    CaretRight,
+    Check,
+    Cube,
+    EyeSlash,
+    Key,
+    Lightbulb,
+    ShieldCheck,
+    Warning,
+} from "@phosphor-icons/react"
 import {Select, Switch, Typography} from "antd"
 import {useAtomValue} from "jotai"
 
@@ -256,6 +265,11 @@ export function useModelHarness({
         sandboxPermissions: (sandbox.permissions as Record<string, unknown> | null) ?? null,
         disabled,
     })
+
+    // Collapsed-by-default state for each advanced group (independent; multiple can be open).
+    const [authExpanded, setAuthExpanded] = useState(false)
+    const [execExpanded, setExecExpanded] = useState(false)
+    const [permsExpanded, setPermsExpanded] = useState(false)
 
     const hasAdvanced = Boolean(
         props.llm || // Authentication lives in Advanced now
@@ -687,119 +701,200 @@ export function useModelHarness({
             {authControls ? (
                 <div
                     className={cn(
-                        hasBuildKitOverlay &&
-                            "border-0 border-t border-solid border-[var(--ag-c-EAEFF5,#eaeff5)] pt-4",
+                        "rounded border border-solid border-[var(--ag-c-EAEFF5,#eaeff5)]",
+                        hasBuildKitOverlay && "mt-0",
                     )}
                 >
-                    <div className="mb-0.5 flex items-center gap-1.5">
+                    <button
+                        type="button"
+                        onClick={() => setAuthExpanded((open) => !open)}
+                        className="flex w-full cursor-pointer items-center gap-2 border-0 bg-transparent px-3 py-2.5 text-left"
+                    >
                         <Key size={15} className="text-[var(--ag-c-586673,#586673)]" />
                         <span className="text-[13px] font-medium">Authentication</span>
-                    </div>
-                    <p className="mb-2.5 ml-[22px] text-[11.5px] leading-snug text-[var(--ag-c-97A4B0,#97a4b0)]">
-                        Where the model credential comes from when this agent runs.
-                    </p>
-                    <div className="ml-[22px]">{authControls}</div>
+                        {!authExpanded ? (
+                            <span className="ml-auto text-[11px] text-[var(--ag-c-97A4B0,#97a4b0)]">
+                                {props.llm
+                                    ? connection.mode === "agenta"
+                                        ? "Agenta-managed"
+                                        : "Self-managed"
+                                    : ""}
+                            </span>
+                        ) : (
+                            <span className="ml-auto" />
+                        )}
+                        <CaretRight
+                            size={14}
+                            className={cn(
+                                "text-[var(--ag-c-97A4B0,#97a4b0)] transition-transform",
+                                authExpanded && "rotate-90",
+                            )}
+                        />
+                    </button>
+                    {authExpanded ? (
+                        <div className="border-0 border-t border-solid border-[var(--ag-c-EAEFF5,#eaeff5)] px-3 pb-3 pt-2.5">
+                            <p className="mb-2.5 text-[11.5px] leading-snug text-[var(--ag-c-97A4B0,#97a4b0)]">
+                                Where the model credential comes from when this agent runs.
+                            </p>
+                            {authControls}
+                        </div>
+                    ) : null}
                 </div>
             ) : null}
 
             {hasExecutionGroup ? (
-                <div className="border-0 border-t border-solid border-[var(--ag-c-EAEFF5,#eaeff5)] pt-4">
-                    <div className="mb-0.5 flex items-center gap-1.5">
+                <div className="rounded border border-solid border-[var(--ag-c-EAEFF5,#eaeff5)]">
+                    <button
+                        type="button"
+                        onClick={() => setExecExpanded((open) => !open)}
+                        className="flex w-full cursor-pointer items-center gap-2 border-0 bg-transparent px-3 py-2.5 text-left"
+                    >
                         <Cube size={15} className="text-[var(--ag-c-586673,#586673)]" />
                         <span className="text-[13px] font-medium">Execution environment</span>
-                    </div>
-                    <p className="mb-2.5 ml-[22px] text-[11.5px] leading-snug text-[var(--ag-c-97A4B0,#97a4b0)]">
-                        Where the agent&apos;s tools and code run, and what that sandbox may touch.
-                    </p>
-                    <div className="ml-[22px] flex flex-col gap-2.5">
-                        {sandboxProps.kind && (
-                            <EnumSelectControl
-                                schema={sandboxProps.kind}
-                                label="Sandbox"
-                                value={(sandbox.kind as string | null) ?? null}
-                                onChange={(v) => setSection("sandbox", {...sandbox, kind: v})}
-                                withTooltip={withTooltip}
-                                disabled={disabled}
-                            />
+                        {!execExpanded ? (
+                            <span className="ml-auto text-[11px] text-[var(--ag-c-97A4B0,#97a4b0)]">
+                                {sandbox.kind ? `Sandbox: ${String(sandbox.kind)}` : ""}
+                            </span>
+                        ) : (
+                            <span className="ml-auto" />
                         )}
-                        {sandboxProps.permissions ? (
-                            <div className="flex flex-col gap-1.5">
-                                {permissionOverrideHint}
-                                <SandboxPermissionControl
-                                    value={
-                                        (sandbox.permissions as Record<string, unknown> | null) ??
-                                        null
-                                    }
-                                    onChange={(v) =>
-                                        setSection("sandbox", {...sandbox, permissions: v})
-                                    }
-                                    disabled={disabled}
-                                />
+                        <CaretRight
+                            size={14}
+                            className={cn(
+                                "text-[var(--ag-c-97A4B0,#97a4b0)] transition-transform",
+                                execExpanded && "rotate-90",
+                            )}
+                        />
+                    </button>
+                    {execExpanded ? (
+                        <div className="border-0 border-t border-solid border-[var(--ag-c-EAEFF5,#eaeff5)] px-3 pb-3 pt-2.5">
+                            <p className="mb-2.5 text-[11.5px] leading-snug text-[var(--ag-c-97A4B0,#97a4b0)]">
+                                Where the agent&apos;s tools and code run, and what that sandbox may
+                                touch.
+                            </p>
+                            <div className="flex flex-col gap-2.5">
+                                {sandboxProps.kind && (
+                                    <EnumSelectControl
+                                        schema={sandboxProps.kind}
+                                        label="Sandbox"
+                                        value={(sandbox.kind as string | null) ?? null}
+                                        onChange={(v) =>
+                                            setSection("sandbox", {...sandbox, kind: v})
+                                        }
+                                        withTooltip={withTooltip}
+                                        disabled={disabled}
+                                    />
+                                )}
+                                {sandboxProps.permissions ? (
+                                    <div className="flex flex-col gap-1.5">
+                                        {permissionOverrideHint}
+                                        <SandboxPermissionControl
+                                            value={
+                                                (sandbox.permissions as Record<
+                                                    string,
+                                                    unknown
+                                                > | null) ?? null
+                                            }
+                                            onChange={(v) =>
+                                                setSection("sandbox", {
+                                                    ...sandbox,
+                                                    permissions: v,
+                                                })
+                                            }
+                                            disabled={disabled}
+                                        />
+                                    </div>
+                                ) : null}
                             </div>
-                        ) : null}
-                    </div>
+                        </div>
+                    ) : null}
                 </div>
             ) : null}
 
             {hasPermissionsGroup ? (
-                <div className="border-0 border-t border-solid border-[var(--ag-c-EAEFF5,#eaeff5)] pt-4">
-                    <div className="mb-0.5 flex items-center gap-1.5">
+                <div className="rounded border border-solid border-[var(--ag-c-EAEFF5,#eaeff5)]">
+                    <button
+                        type="button"
+                        onClick={() => setPermsExpanded((open) => !open)}
+                        className="flex w-full cursor-pointer items-center gap-2 border-0 bg-transparent px-3 py-2.5 text-left"
+                    >
                         <ShieldCheck size={15} className="text-[var(--ag-c-586673,#586673)]" />
                         <span className="text-[13px] font-medium">Permissions</span>
-                    </div>
-                    <p className="mb-2.5 ml-[22px] text-[11.5px] leading-snug text-[var(--ag-c-97A4B0,#97a4b0)]">
-                        What the agent may do on its own before it must ask.
-                    </p>
-                    <div className="ml-[22px] flex flex-col gap-2.5">
-                        {headlessSchema ? (
-                            isPiHarness ? (
-                                <div className="flex items-center gap-1.5 text-[11px] text-[var(--ag-c-97A4B0,#97a4b0)]">
-                                    <EyeSlash size={13} />
-                                    Permission policy isn&apos;t used by the Pi harness.
-                                </div>
-                            ) : (
-                                <EnumSelectControl
-                                    schema={headlessSchema}
-                                    label="Permission policy"
-                                    value={headlessValue}
-                                    onChange={(v) =>
-                                        setSection("runner", {
-                                            ...runner,
-                                            interactions: {...runnerInteractions, headless: v},
-                                        })
-                                    }
-                                    withTooltip={withTooltip}
-                                    disabled={disabled}
-                                />
-                            )
-                        ) : null}
-                        {hasClaudePermissions ? (
-                            <div className="flex flex-col gap-1.5">
-                                <div className="flex items-center gap-1.5">
-                                    <Typography.Text className="text-xs font-medium">
-                                        Claude permissions
-                                    </Typography.Text>
-                                    <span className="rounded-full bg-[var(--ant-color-fill-secondary)] px-2 text-[10px] text-[var(--ant-color-primary-text)]">
-                                        Claude harness
-                                    </span>
-                                </div>
-                                <ClaudePermissionsControl
-                                    value={claudePermissions}
-                                    onChange={setClaudePermissions}
-                                    disabled={disabled}
-                                    // Mode options + labels come from the harness `permissions`
-                                    // sub-schema (`default_mode` enum) so they follow the template.
-                                    modeSchema={
-                                        (
-                                            harnessProps.permissions?.properties as
-                                                | Record<string, SchemaProperty>
-                                                | undefined
-                                        )?.default_mode
-                                    }
-                                />
+                        {!permsExpanded ? (
+                            <span className="ml-auto text-[11px] text-[var(--ag-c-97A4B0,#97a4b0)]">
+                                Auto
+                            </span>
+                        ) : (
+                            <span className="ml-auto" />
+                        )}
+                        <CaretRight
+                            size={14}
+                            className={cn(
+                                "text-[var(--ag-c-97A4B0,#97a4b0)] transition-transform",
+                                permsExpanded && "rotate-90",
+                            )}
+                        />
+                    </button>
+                    {permsExpanded ? (
+                        <div className="border-0 border-t border-solid border-[var(--ag-c-EAEFF5,#eaeff5)] px-3 pb-3 pt-2.5">
+                            <p className="mb-2.5 text-[11.5px] leading-snug text-[var(--ag-c-97A4B0,#97a4b0)]">
+                                What the agent may do on its own before it must ask.
+                            </p>
+                            <div className="flex flex-col gap-2.5">
+                                {headlessSchema ? (
+                                    isPiHarness ? (
+                                        <div className="flex items-center gap-1.5 text-[11px] text-[var(--ag-c-97A4B0,#97a4b0)]">
+                                            <EyeSlash size={13} />
+                                            Permission policy isn&apos;t used by the Pi harness.
+                                        </div>
+                                    ) : (
+                                        <EnumSelectControl
+                                            schema={headlessSchema}
+                                            label="Permission policy"
+                                            value={headlessValue}
+                                            onChange={(v) =>
+                                                setSection("runner", {
+                                                    ...runner,
+                                                    interactions: {
+                                                        ...runnerInteractions,
+                                                        headless: v,
+                                                    },
+                                                })
+                                            }
+                                            withTooltip={withTooltip}
+                                            disabled={disabled}
+                                        />
+                                    )
+                                ) : null}
+                                {hasClaudePermissions ? (
+                                    <div className="flex flex-col gap-1.5">
+                                        <div className="flex items-center gap-1.5">
+                                            <Typography.Text className="text-xs font-medium">
+                                                Claude permissions
+                                            </Typography.Text>
+                                            <span className="rounded-full bg-[var(--ant-color-fill-secondary)] px-2 text-[10px] text-[var(--ant-color-primary-text)]">
+                                                Claude harness
+                                            </span>
+                                        </div>
+                                        <ClaudePermissionsControl
+                                            value={claudePermissions}
+                                            onChange={setClaudePermissions}
+                                            disabled={disabled}
+                                            // Mode options + labels come from the harness `permissions`
+                                            // sub-schema (`default_mode` enum) so they follow the template.
+                                            modeSchema={
+                                                (
+                                                    harnessProps.permissions?.properties as
+                                                        | Record<string, SchemaProperty>
+                                                        | undefined
+                                                )?.default_mode
+                                            }
+                                        />
+                                    </div>
+                                ) : null}
                             </div>
-                        ) : null}
-                    </div>
+                        </div>
+                    ) : null}
                 </div>
             ) : null}
         </>


### PR DESCRIPTION
## What changed

The three advanced committed-config groups in the agent Advanced drawer — **Authentication**, **Execution environment**, and **Permissions** — were flat `border-t`-separated `<div>` blocks that stacked into a long scroll.

They are now independent collapsible accordion items, matching the pattern the existing "Playground build kit" section already uses.

**Before:** three sections always visible, stacked vertically, separated by a top border.

**After:** three bordered card rows, each collapsed by default. Clicking the header expands only that section. Multiple sections can be open at once. The collapsed header shows a one-line summary on the right (Authentication → `Agenta-managed` or `Self-managed`; Execution environment → `Sandbox: <kind>`; Permissions → `Auto`). A `CaretRight` chevron rotates 90° when open.

## Scope

One file changed: `web/packages/agenta-entity-ui/src/DrillInView/SchemaControls/agentTemplate/useModelHarness.tsx`.

No contract change. No commit-logic change. No new components — reuses the same button/CaretRight/`cn` pattern the build-kit section already uses. The `buildKitSection` itself is untouched.

## Verification

- `tsc --noEmit` on `@agenta/entity-ui`: clean.
- `pnpm lint-fix` in `web/`: 11/11 tasks successful, no warnings or errors.
- `vitest run` on `@agenta/entity-ui`: 126/126 tests pass.

## What to review

1. Accordion behavior: each group collapses and expands independently (not single-open).
2. Summaries: Authentication shows the connection mode label, Execution environment shows the sandbox kind, Permissions shows "Auto".
3. No commit-logic path was touched — only the `advancedControls` JSX block changed.