### PR TITLE
[fix] Harden agent round-trip QA paths

### DIFF
--- a/api/oss/src/apis/fastapi/workflows/router.py
+++ b/api/oss/src/apis/fastapi/workflows/router.py
@@ -22,7 +22,7 @@ from oss.src.core.workflows.service import (
 from oss.src.core.environments.service import (
     EnvironmentsService,
 )
-from oss.src.core.workflows.dtos import WorkflowRevisionCommit
+from oss.src.core.workflows.dtos import WorkflowRevisionCommit, WorkflowRevisionData
 from oss.src.core.environments.dtos import (
     EnvironmentRevisionCommit,
     EnvironmentRevisionDelta,
@@ -423,6 +423,16 @@ class WorkflowsRouter:
             self.commit_workflow_revision,
             methods=["POST"],
             operation_id="commit_workflow_revision",
+            status_code=status.HTTP_200_OK,
+            response_model=WorkflowRevisionResponse,
+            response_model_exclude_none=True,
+        )
+
+        self.router.add_api_route(
+            "/revisions/commit/patch",
+            self.commit_workflow_revision_patch,
+            methods=["POST"],
+            operation_id="commit_workflow_revision_patch",
             status_code=status.HTTP_200_OK,
             response_model=WorkflowRevisionResponse,
             response_model_exclude_none=True,
@@ -1292,6 +1302,71 @@ class WorkflowsRouter:
         return workflow_revision_response
 
     @intercept_exceptions()
+    @handle_workflow_exceptions()
+    async def commit_workflow_revision_patch(
+        self,
+        request: Request,
+        *,
+        workflow_revision_commit_request: WorkflowRevisionCommitRequest,
+    ) -> WorkflowRevisionResponse:
+        if not await check_action_access(  # type: ignore
+            user_uid=request.state.user_id,
+            project_id=request.state.project_id,
+            permission=Permission.EDIT_WORKFLOWS,  # type: ignore
+        ):
+            raise FORBIDDEN_EXCEPTION  # type: ignore
+
+        workflow_revision_commit = workflow_revision_commit_request.workflow_revision
+        revision_data = workflow_revision_commit.data
+        if revision_data is None or not revision_data.model_dump(
+            mode="json", exclude_none=True
+        ):
+            raise HTTPException(
+                status_code=400,
+                detail="workflow_revision.data is required when committing a workflow revision.",
+            )
+
+        variant_id = (
+            workflow_revision_commit.workflow_variant_id
+            or workflow_revision_commit.variant_id
+        )
+        if variant_id is None:
+            raise HTTPException(
+                status_code=400,
+                detail="workflow_revision.workflow_variant_id is required when committing a workflow revision.",
+            )
+
+        current_revision = await self.workflows_service.fetch_workflow_revision(
+            project_id=UUID(request.state.project_id),
+            workflow_variant_ref=Reference(id=variant_id),
+            include_archived=False,
+        )
+        if current_revision and current_revision.data:
+            merged_data = _deep_merge_revision_data(
+                current_revision.data.model_dump(mode="json", exclude_none=True),
+                revision_data.model_dump(mode="json", exclude_none=True),
+            )
+            workflow_revision_commit.data = WorkflowRevisionData(**merged_data)
+
+        workflow_revision = await self.workflows_service.commit_workflow_revision(
+            project_id=UUID(request.state.project_id),
+            user_id=UUID(request.state.user_id),
+            workflow_revision_commit=workflow_revision_commit,
+        )
+
+        await invalidate_cache(project_id=request.state.project_id)
+
+        await _emit_committed_revision_data_event(
+            request=request,
+            workflow_revision=workflow_revision,
+        )
+
+        return WorkflowRevisionResponse(
+            count=1 if workflow_revision else 0,
+            workflow_revision=workflow_revision,
+        )
+
+    @intercept_exceptions()
     @suppress_exceptions(default=WorkflowRevisionResponse(), exclude=[HTTPException])
     async def fetch_workflow_revision(
         self,
@@ -1516,6 +1591,24 @@ class WorkflowsRouter:
             workflow_revision_commit_request.workflow_revision.workflow_variant_id
         ):
             return WorkflowRevisionResponse()
+
+        revision_data = workflow_revision_commit_request.workflow_revision.data
+        if revision_data is None or not revision_data.model_dump(
+            mode="json", exclude_none=True
+        ):
+            raise HTTPException(
+                status_code=400,
+                detail="workflow_revision.data is required when committing a workflow revision.",
+            )
+        if (
+            workflow_revision_commit_request.workflow_revision.workflow_variant_id
+            is None
+            and workflow_revision_commit_request.workflow_revision.variant_id is None
+        ):
+            raise HTTPException(
+                status_code=400,
+                detail="workflow_revision.workflow_variant_id is required when committing a workflow revision.",
+            )
 
         workflow_revision = await self.workflows_service.commit_workflow_revision(
             project_id=UUID(request.state.project_id),
@@ -1932,6 +2025,17 @@ async def _emit_committed_revision_data_event(
             "version": workflow_revision.version,
         },
     )
+
+
+def _deep_merge_revision_data(base: dict, patch: dict) -> dict:
+    merged = dict(base)
+    for key, value in patch.items():
+        current = merged.get(key)
+        if isinstance(current, dict) and isinstance(value, dict):
+            merged[key] = _deep_merge_revision_data(current, value)
+        else:
+            merged[key] = value
+    return merged
 
 
 async def _emit_data_event(

--- a/api/oss/src/core/workflows/static_catalog.py
+++ b/api/oss/src/core/workflows/static_catalog.py
@@ -104,7 +104,23 @@ def _client_tool_revision() -> WorkflowRevision:
                     "description": "Request a connection from the user.",
                     "input_schema": {
                         "type": "object",
-                        "additionalProperties": True,
+                        "properties": {
+                            "integration": {
+                                "type": "string",
+                                "description": "The external integration key the user should connect, for example 'slack' or 'github'.",
+                            },
+                            "slug": {
+                                "type": "string",
+                                "description": "Optional stable connection slug to create or reuse. Defaults to the integration key.",
+                            },
+                            "mode": {
+                                "type": "string",
+                                "enum": ["oauth", "api_key"],
+                                "description": "Connection flow to request. Defaults to 'oauth'.",
+                            },
+                        },
+                        "required": ["integration"],
+                        "additionalProperties": False,
                     },
                     "render": {"kind": "connect"},
                 }

--- a/sdks/python/agenta/sdk/agents/adapters/vercel/stream.py
+++ b/sdks/python/agenta/sdk/agents/adapters/vercel/stream.py
@@ -2,6 +2,7 @@
 
 from __future__ import annotations
 
+import json
 from typing import Any, AsyncIterator, Dict, Iterator, Optional
 
 from ...dtos import AgentResult
@@ -75,6 +76,7 @@ async def agent_run_to_vercel_parts(
     # Tool-call ids already surfaced as a tool part. An approval request attaches
     # to its tool part by id, so we synthesize one only when none preceded it.
     seen_tool_calls: set = set()
+    tool_names_by_id: Dict[Any, Any] = {}
 
     try:
         async for event in run:
@@ -121,6 +123,7 @@ async def agent_run_to_vercel_parts(
                 tool_call_id = data.get("id")
                 tool_name = data.get("name")
                 seen_tool_calls.add(tool_call_id)
+                tool_names_by_id[tool_call_id] = tool_name
                 yield {
                     "type": "tool-input-start",
                     "toolCallId": tool_call_id,
@@ -155,6 +158,14 @@ async def agent_run_to_vercel_parts(
                         "toolCallId": tool_call_id,
                         "output": out,
                     }
+                    committed = _committed_revision_data(
+                        tool_names_by_id.get(tool_call_id), out
+                    )
+                    if committed is not None:
+                        yield {
+                            "type": "data-committed-revision",
+                            "data": committed,
+                        }
                     if data.get("render") is not None:
                         yield _render_part(tool_call_id, data["render"])
             elif etype == "interaction_request":
@@ -236,6 +247,7 @@ async def agent_stream_to_vercel_stream(
     usage: Optional[Dict[str, Any]] = None
     stop_reason: Optional[str] = None
     seen_tool_calls: set = set()
+    tool_names_by_id: Dict[Any, Any] = {}
 
     try:
         async for event in events:
@@ -282,6 +294,7 @@ async def agent_stream_to_vercel_stream(
                 tool_call_id = data.get("id")
                 tool_name = data.get("name")
                 seen_tool_calls.add(tool_call_id)
+                tool_names_by_id[tool_call_id] = tool_name
                 yield {
                     "type": "tool-input-start",
                     "toolCallId": tool_call_id,
@@ -316,6 +329,14 @@ async def agent_stream_to_vercel_stream(
                         "toolCallId": tool_call_id,
                         "output": out,
                     }
+                    committed = _committed_revision_data(
+                        tool_names_by_id.get(tool_call_id), out
+                    )
+                    if committed is not None:
+                        yield {
+                            "type": "data-committed-revision",
+                            "data": committed,
+                        }
                     if data.get("render") is not None:
                         yield _render_part(tool_call_id, data["render"])
             elif etype == "interaction_request":
@@ -416,6 +437,36 @@ def _interaction_parts(
     if kind == "input":
         yield {"type": "data-input-request", "id": data.get("id"), "data": payload}
         return
+    if kind == "client_tool":
+        tool_call_id = payload.get("toolCallId")
+        tool_call = payload.get("toolCall")
+        if tool_call_id is None and isinstance(tool_call, dict):
+            tool_call_id = tool_call.get("id") or tool_call.get("toolCallId")
+        tool_name = payload.get("toolName")
+        if tool_name is None and isinstance(tool_call, dict):
+            tool_name = (
+                tool_call.get("name") or tool_call.get("title") or tool_call.get("kind")
+            )
+        real_input = payload.get("input")
+        if real_input is None and isinstance(tool_call, dict):
+            real_input = tool_call.get("rawInput") or tool_call.get("input")
+        if tool_call_id is not None and tool_call_id not in seen_tool_calls:
+            seen_tool_calls.add(tool_call_id)
+            yield {
+                "type": "tool-input-start",
+                "toolCallId": tool_call_id,
+                "toolName": tool_name,
+            }
+        if tool_call_id is not None:
+            yield {
+                "type": "tool-input-available",
+                "toolCallId": tool_call_id,
+                "toolName": tool_name,
+                "input": real_input,
+            }
+            if payload.get("render") is not None:
+                yield _render_part(tool_call_id, payload["render"])
+        return
     yield {
         "type": "data-interaction",
         "id": data.get("id"),
@@ -452,6 +503,36 @@ def _usage_metadata(data: Dict[str, Any]) -> Dict[str, Any]:
         for key in ("input", "output", "total", "cost")
         if data.get(key) is not None
     }
+
+
+def _committed_revision_data(tool_name: Any, output: Any) -> Optional[Dict[str, Any]]:
+    """Project a successful commit_revision tool output to the playground refresh event."""
+    if tool_name is not None and tool_name != "commit_revision":
+        return None
+
+    payload = output
+    if isinstance(payload, str):
+        try:
+            payload = json.loads(payload)
+        except json.JSONDecodeError:
+            return None
+    if not isinstance(payload, dict) or not payload.get("count"):
+        return None
+
+    revision = payload.get("workflow_revision")
+    if not isinstance(revision, dict):
+        return None
+
+    data = {
+        "variantId": revision.get("workflow_variant_id") or revision.get("variant_id"),
+        "revisionId": revision.get("id")
+        or revision.get("workflow_revision_id")
+        or revision.get("revision_id"),
+        "version": revision.get("version"),
+    }
+    if not all(data.values()):
+        return None
+    return data
 
 
 def _as_text(value: Any) -> str:

--- a/sdks/python/agenta/sdk/agents/platform/op_catalog.py
+++ b/sdks/python/agenta/sdk/agents/platform/op_catalog.py
@@ -252,15 +252,19 @@ _QUERY_WORKFLOWS_INPUT_SCHEMA: Dict[str, Any] = {
 # and stripped from the model-visible schema, so the agent can only ever target itself, never a
 # different variant in the project. Defaults to approval.
 _COMMIT_REVISION_DESCRIPTION = (
-    "Commit a new revision to your own workflow variant (update yourself). Supply the new "
-    "configuration under `workflow_revision.data` and an optional commit message; the variant "
-    "you are running is targeted automatically. This changes the agent and requires approval."
+    "Commit a new revision to your own workflow variant (update yourself). Supply the config "
+    "fields to change under `workflow_revision.data` and an optional commit message; existing "
+    "revision data is preserved. Put agent template edits under "
+    "`workflow_revision.data.parameters.agent`. The variant you are running is targeted "
+    "automatically. This changes the agent and requires approval."
 )
 _COMMIT_REVISION_INPUT_SCHEMA: Dict[str, Any] = {
     "type": "object",
+    "additionalProperties": False,
     "properties": {
         "workflow_revision": {
             "type": "object",
+            "additionalProperties": False,
             "description": "The revision to append to your variant's history.",
             "properties": {
                 # Bound from $ctx.workflow.variant.id and stripped before the model sees it.
@@ -274,10 +278,34 @@ _COMMIT_REVISION_INPUT_SCHEMA: Dict[str, Any] = {
                 },
                 "data": {
                     "type": "object",
-                    "description": "The new configuration (parameters, inputs) for the revision.",
+                    "additionalProperties": False,
+                    "description": (
+                        "Workflow revision data patch. For agent apps, put edits under "
+                        "parameters.agent; omitted existing fields are preserved."
+                    ),
+                    "properties": {
+                        "uri": {"type": "string"},
+                        "url": {"type": "string"},
+                        "headers": {"type": "object"},
+                        "runtime": {
+                            "type": "string",
+                            "enum": ["python", "typescript", "javascript"],
+                        },
+                        "script": {"type": "string"},
+                        "schemas": {"type": "object"},
+                        "parameters": {
+                            "type": "object",
+                            "additionalProperties": True,
+                            "description": (
+                                "Workflow parameters. For agent-template updates, include "
+                                "parameters.agent with instructions, llm, tools, mcps, skills, "
+                                "harness, runner, or sandbox fields as needed."
+                            ),
+                        },
+                    },
                 },
             },
-            "required": ["workflow_variant_id"],
+            "required": ["workflow_variant_id", "data"],
         },
     },
     "required": ["workflow_revision"],
@@ -466,7 +494,7 @@ PLATFORM_OPS: Dict[str, PlatformOp] = {
             op="commit_revision",
             description=_COMMIT_REVISION_DESCRIPTION,
             method="POST",
-            path="/api/workflows/revisions/commit",
+            path="/api/workflows/revisions/commit/patch",
             input_schema=_COMMIT_REVISION_INPUT_SCHEMA,
             context_bindings={
                 "workflow_revision.workflow_variant_id": "$ctx.workflow.variant.id"

--- a/sdks/python/oss/tests/pytest/unit/agents/adapters/test_vercel_stream_park.py
+++ b/sdks/python/oss/tests/pytest/unit/agents/adapters/test_vercel_stream_park.py
@@ -153,3 +153,167 @@ async def test_parked_tool_call_refreshes_real_args_on_approval() -> None:
     approval = next(p for p in parts if p["type"] == "tool-approval-request")
     assert approval["toolCallId"] == "tool-1"
     assert parts[-1]["type"] == "finish"
+
+
+def _commit_revision_run() -> AgentStream:
+    return AgentStream(
+        _records(
+            [
+                {
+                    "kind": "event",
+                    "event": {
+                        "type": "tool_call",
+                        "id": "tool-commit-1",
+                        "name": "commit_revision",
+                        "input": {},
+                    },
+                },
+                {
+                    "kind": "event",
+                    "event": {
+                        "type": "tool_result",
+                        "id": "tool-commit-1",
+                        "output": (
+                            '{"count":1,"workflow_revision":{'
+                            '"workflow_variant_id":"variant-1",'
+                            '"id":"revision-1",'
+                            '"version":"4"'
+                            "}}"
+                        ),
+                    },
+                },
+                {"kind": "event", "event": {"type": "done", "stopReason": "stop"}},
+                {
+                    "kind": "result",
+                    "result": {
+                        "ok": True,
+                        "output": "",
+                        "stopReason": "stop",
+                        "sessionId": "conv-1",
+                        "traceId": "trace-1",
+                    },
+                },
+            ]
+        )
+    )
+
+
+def _commit_revision_result_only_run() -> AgentStream:
+    return AgentStream(
+        _records(
+            [
+                {
+                    "kind": "event",
+                    "event": {
+                        "type": "tool_result",
+                        "id": "tool-commit-1",
+                        "output": (
+                            '{"count":1,"workflow_revision":{'
+                            '"workflow_variant_id":"variant-1",'
+                            '"id":"revision-1",'
+                            '"version":"4"'
+                            "}}"
+                        ),
+                    },
+                },
+                {"kind": "event", "event": {"type": "done", "stopReason": "stop"}},
+                {
+                    "kind": "result",
+                    "result": {
+                        "ok": True,
+                        "output": "",
+                        "stopReason": "stop",
+                        "sessionId": "conv-1",
+                        "traceId": "trace-1",
+                    },
+                },
+            ]
+        )
+    )
+
+
+@pytest.mark.asyncio
+async def test_commit_revision_tool_result_emits_refresh_data_part() -> None:
+    parts = [part async for part in agent_run_to_vercel_parts(_commit_revision_run())]
+
+    committed = next(p for p in parts if p["type"] == "data-committed-revision")
+    assert committed["data"] == {
+        "variantId": "variant-1",
+        "revisionId": "revision-1",
+        "version": "4",
+    }
+
+
+@pytest.mark.asyncio
+async def test_commit_revision_result_only_emits_refresh_data_part() -> None:
+    parts = [
+        part
+        async for part in agent_run_to_vercel_parts(_commit_revision_result_only_run())
+    ]
+
+    committed = next(p for p in parts if p["type"] == "data-committed-revision")
+    assert committed["data"] == {
+        "variantId": "variant-1",
+        "revisionId": "revision-1",
+        "version": "4",
+    }
+
+
+def _parked_client_tool_run() -> AgentStream:
+    return AgentStream(
+        _records(
+            [
+                {
+                    "kind": "event",
+                    "event": {
+                        "type": "interaction_request",
+                        "id": "client-tool-1",
+                        "kind": "client_tool",
+                        "payload": {
+                            "toolCallId": "tool-client-1",
+                            "toolName": "request_connection",
+                            "input": {"integration": "slack"},
+                            "render": {"kind": "connect"},
+                        },
+                    },
+                },
+                {"kind": "event", "event": {"type": "done", "stopReason": "paused"}},
+                {
+                    "kind": "result",
+                    "result": {
+                        "ok": True,
+                        "output": "",
+                        "stopReason": "paused",
+                        "sessionId": "conv-1",
+                        "traceId": "trace-1",
+                    },
+                },
+            ]
+        )
+    )
+
+
+@pytest.mark.asyncio
+async def test_parked_client_tool_emits_unsettled_tool_part() -> None:
+    parts = [
+        part async for part in agent_run_to_vercel_parts(_parked_client_tool_run())
+    ]
+
+    inputs = [p for p in parts if p.get("type") == "tool-input-available"]
+    assert inputs == [
+        {
+            "type": "tool-input-available",
+            "toolCallId": "tool-client-1",
+            "toolName": "request_connection",
+            "input": {"integration": "slack"},
+        }
+    ]
+    assert {
+        "type": "data-render",
+        "data": {
+            "toolCallId": "tool-client-1",
+            "render": {"kind": "connect"},
+        },
+    } in parts
+    assert not any(p.get("type") == "tool-output-available" for p in parts)
+    assert parts[-1]["type"] == "finish"

--- a/sdks/python/oss/tests/pytest/unit/agents/platform/test_op_catalog.py
+++ b/sdks/python/oss/tests/pytest/unit/agents/platform/test_op_catalog.py
@@ -196,7 +196,7 @@ async def test_commit_revision_binds_self_and_strips_bound_field(connection):
         [PlatformToolConfig(op="commit_revision")]
     )
     spec = resolution.tool_specs[0]
-    assert spec.call.path == "/api/workflows/revisions/commit"
+    assert spec.call.path == "/api/workflows/revisions/commit/patch"
     # The context binding rides as call.context — the runner fills it from runContext at dispatch.
     assert spec.call.context == {
         "workflow_revision.workflow_variant_id": "$ctx.workflow.variant.id"
@@ -206,7 +206,10 @@ async def test_commit_revision_binds_self_and_strips_bound_field(connection):
     workflow_revision = spec.input_schema["properties"]["workflow_revision"]
     assert "workflow_variant_id" not in workflow_revision["properties"]
     assert set(workflow_revision["properties"]) == {"message", "data"}
-    assert "required" not in workflow_revision  # only the bound field was required
+    assert workflow_revision["required"] == ["data"]
+    data = workflow_revision["properties"]["data"]
+    assert "parameters" in data["properties"]
+    assert "parameters.agent" in data["properties"]["parameters"]["description"]
 
 
 async def test_commit_revision_defaults_to_approval(connection):

--- a/services/agent/src/engines/sandbox_agent.ts
+++ b/services/agent/src/engines/sandbox_agent.ts
@@ -238,6 +238,10 @@ export async function runSandboxAgent(
       })
     : {};
   Object.assign(env, piExtEnv); // local daemon inherits it; daytona gets it via envVars
+  logger(
+    `tools=${plan.toolSpecs.length} executableTools=${plan.executableToolSpecs.length} ` +
+      `piPublicTools=${piExtEnv.AGENTA_AGENT_TOOLS_PUBLIC_SPECS ? "yes" : "no"}`,
+  );
   // undefined is fine: the local provider runs its own resolution and errors clearly.
   const binaryPath = (deps.resolveDaemonBinary ?? resolveDaemonBinary)();
   const runAgentDir = prepareLocalPiAssets({ plan, env, log: logger });
@@ -430,17 +434,18 @@ export async function runSandboxAgent(
       // raced against `parkedSignal` below so the turn ends even if this call rejects.
       void sandbox.destroySession?.(session.id).catch(() => {});
     };
+    const responder =
+      deps.responderFactory?.(request.permissionPolicy) ??
+      new HITLResponder(
+        extractApprovalDecisions(request),
+        policyFromRequest(request.permissionPolicy),
+        hasHumanSurface,
+      );
     attachPermissionResponder({
       session,
       run,
       onPark,
-      responder:
-        deps.responderFactory?.(request.permissionPolicy) ??
-        new HITLResponder(
-          extractApprovalDecisions(request),
-          policyFromRequest(request.permissionPolicy),
-          hasHumanSurface,
-        ),
+      responder,
     });
 
     if (plan.useToolRelay) {
@@ -455,6 +460,41 @@ export async function runSandboxAgent(
         plan.toolSpecs,
         request.toolCallback as ToolCallbackContext | undefined,
         policyFromRequest(request.permissionPolicy),
+        request.runContext,
+        {
+          onClientTool: async ({ id, toolCallId, toolName, input, spec }) => {
+            const decision = await responder.onClientTool({
+              id,
+              toolCallId,
+              toolName,
+              input,
+              raw: { spec },
+            });
+            if (decision === "park") {
+              run.emitEvent({
+                type: "interaction_request",
+                id,
+                kind: "client_tool",
+                payload: {
+                  toolCallId,
+                  toolName,
+                  input,
+                  render: spec.render,
+                  toolCall: {
+                    id: toolCallId,
+                    toolCallId,
+                    name: toolName,
+                    rawInput: input,
+                    input,
+                    kind: spec.kind,
+                  },
+                },
+              });
+            }
+            return decision;
+          },
+          onPark,
+        },
       );
     }
 

--- a/services/agent/src/engines/sandbox_agent/run-plan.ts
+++ b/services/agent/src/engines/sandbox_agent/run-plan.ts
@@ -308,7 +308,7 @@ export function buildRunPlan(
       usageOutPath: isPi ? `${cwd}/.agenta-usage.json` : undefined,
       toolSpecs,
       executableToolSpecs: executableToolSpecsForRun,
-      useToolRelay: executableToolSpecsForRun.length > 0,
+      useToolRelay: toolSpecs.length > 0,
       systemPrompt,
       appendSystemPrompt,
       hasSystemPrompt: !!(systemPrompt || appendSystemPrompt),

--- a/services/agent/src/extensions/agenta.ts
+++ b/services/agent/src/extensions/agenta.ts
@@ -49,6 +49,53 @@ function log(message: string): void {
   process.stderr.write(`[agenta-pi-ext] ${message}\n`);
 }
 
+function objectSchema(schema: unknown): Record<string, unknown> | undefined {
+  return schema && typeof schema === "object" && !Array.isArray(schema)
+    ? (schema as Record<string, unknown>)
+    : undefined;
+}
+
+function requiredFields(schema: unknown): string[] {
+  const object = objectSchema(schema);
+  const required = object?.required;
+  return Array.isArray(required)
+    ? required.filter((field): field is string => typeof field === "string")
+    : [];
+}
+
+function specInputSchema(spec: ResolvedToolSpec): Record<string, unknown> | null | undefined {
+  return (
+    spec.inputSchema ??
+    (spec as ResolvedToolSpec & { input_schema?: Record<string, unknown> | null })
+      .input_schema
+  );
+}
+
+function promptSnippet(spec: ResolvedToolSpec): string {
+  return spec.description ?? `Call ${spec.name}`;
+}
+
+function promptGuidelines(spec: ResolvedToolSpec): string[] {
+  const guidelines: string[] = [];
+  const required = requiredFields(specInputSchema(spec));
+  if (required.length > 0) {
+    guidelines.push(
+      `When calling ${spec.name}, include the required argument(s): ${required.join(", ")}.`,
+    );
+  }
+  if (spec.name === "request_connection") {
+    guidelines.push(
+      "When calling request_connection, set integration to the lowercase provider key such as slack or github; use mode oauth unless the user explicitly asks for an API key.",
+    );
+  }
+  if (spec.name === "commit_revision") {
+    guidelines.push(
+      "When calling commit_revision, include workflow_revision.data with the updated workflow configuration, usually workflow_revision.data.parameters.agent for agent-template changes.",
+    );
+  }
+  return guidelines;
+}
+
 /** Parse the JSON array of loaded skill names from AGENTA_AGENT_SKILLS_LOADED; [] on absent/malformed. */
 function parseSkillsLoaded(raw: string | undefined): string[] {
   if (!raw) return [];
@@ -82,8 +129,10 @@ function registerTools(pi: ExtensionAPI): void {
       name: spec.name,
       label: spec.name,
       description: spec.description ?? spec.name,
+      promptSnippet: promptSnippet(spec),
+      promptGuidelines: promptGuidelines(spec),
       // Pi accepts plain JSON Schema here (non-TypeBox validation path).
-      parameters: (spec.inputSchema as any) ?? EMPTY_OBJECT_SCHEMA,
+      parameters: (specInputSchema(spec) as any) ?? EMPTY_OBJECT_SCHEMA,
       async execute(toolCallId: string, params: unknown, signal?: AbortSignal) {
         const text = await runResolvedTool(spec, params, {
           toolCallId,

--- a/services/agent/src/server.ts
+++ b/services/agent/src/server.ts
@@ -122,6 +122,15 @@ function runCredential(request: AgentRunRequest): string {
   return (headers.authorization ?? headers.Authorization ?? "").trim();
 }
 
+function apiBaseFromRequest(request: AgentRunRequest): string | undefined {
+  const endpoint = request.telemetry?.exporters?.otlp?.endpoint?.trim();
+  if (!endpoint) return undefined;
+  const marker = "/otlp/";
+  const idx = endpoint.indexOf(marker);
+  if (idx === -1) return undefined;
+  return endpoint.slice(0, idx).replace(/\/+$/, "");
+}
+
 /**
  * Persist the session's sandbox id to the durable session-state row (best-effort), so the
  * inspector's States tab shows which sandbox backs the session. Authenticated AS the invoke
@@ -214,6 +223,11 @@ async function runAndStream(
   let aliveWatchdog: { release: () => Promise<void> } | undefined;
 
   if (sessionOwned) {
+    const requestApiBase = apiBaseFromRequest(request);
+    if (requestApiBase && !process.env.AGENTA_API_URL) {
+      process.env.AGENTA_API_URL = requestApiBase;
+      process.stderr.write(`[sessions] inferred AGENTA_API_URL=${requestApiBase}\n`);
+    }
     // The runner authenticates session calls AS the invoke caller (the run credential),
     // refreshing it for the turn's lifetime — never the admin key. Project scope is
     // resolved server-side from the credential, so no project_id rides the request.

--- a/services/agent/src/tools/direct.ts
+++ b/services/agent/src/tools/direct.ts
@@ -117,10 +117,10 @@ export function deepMerge(
 /**
  * Resolve a `call.context` token (`"$ctx.<dotted.path>"`) against the run's `runContext` blob.
  *
- * The descriptor is untrusted, so a malformed token (one that does not start with `$ctx.`) is
- * skipped rather than trusted: it returns `undefined`. A path that does not resolve in the blob
- * (no `runContext`, a missing sub-object, or a missing key) also returns `undefined`. Only a
- * non-`undefined` resolved value is bound — `null` is a real value and binds, `undefined` does not.
+ * The descriptor is untrusted, so a malformed token (one that does not start with `$ctx.`) returns
+ * `undefined`. A path that does not resolve in the blob (no `runContext`, a missing sub-object, or
+ * a missing key) also returns `undefined`. `assembleBody` treats that as a hard binding failure so
+ * self-targeting direct calls cannot silently drop their hidden target field.
  *
  * Traversal follows ONLY own, safe keys: an unsafe segment (`__proto__`/`constructor`/`prototype`)
  * or a key inherited from the prototype chain returns `undefined`, so a crafted token can never
@@ -219,15 +219,20 @@ export function assembleBody(
   if (call.body) body = deepMerge(body, call.body);
   // 3. Run-context binding wins over everything (filled LAST). For each [bodyPath, token] in
   //    call.context, the field is owned by run context alone: first clear whatever the model's args
-  //    or the static `body` put at that path, then deep-set the resolved value. A token that does
-  //    not resolve leaves the field ABSENT (the cleared state), so a missing run-context value can
-  //    never let a model-supplied value survive in a bound field — the model-invisible guarantee.
-  //    deepDelete / deepSet are prototype-pollution-safe and reject unsafe path segments.
+  //    or the static `body` put at that path, then deep-set the resolved value. A missing binding
+  //    value fails closed instead of silently no-oping; direct calls that declare context require
+  //    that context to target the platform safely. deepDelete / deepSet are prototype-pollution-safe
+  //    and reject unsafe path segments.
   if (call.context) {
     for (const [bodyPath, token] of Object.entries(call.context)) {
       deepDelete(body, bodyPath);
       const value = resolveCtxToken(runContext, token);
-      if (value !== undefined) deepSet(body, bodyPath, value);
+      if (value === undefined) {
+        throw new Error(
+          `missing run-context value for direct-call binding '${bodyPath}'`,
+        );
+      }
+      deepSet(body, bodyPath, value);
     }
   }
   return body;

--- a/services/agent/src/tools/dispatch.ts
+++ b/services/agent/src/tools/dispatch.ts
@@ -48,6 +48,64 @@ export interface RunResolvedToolOpts {
   signal?: AbortSignal;
 }
 
+function objectSchema(schema: unknown): Record<string, unknown> | undefined {
+  return schema && typeof schema === "object" && !Array.isArray(schema)
+    ? (schema as Record<string, unknown>)
+    : undefined;
+}
+
+function requiredFields(schema: unknown): string[] {
+  const object = objectSchema(schema);
+  const required = object?.required;
+  return Array.isArray(required)
+    ? required.filter((field): field is string => typeof field === "string")
+    : [];
+}
+
+function specInputSchema(spec: ResolvedToolSpec): Record<string, unknown> | null | undefined {
+  return (
+    spec.inputSchema ??
+    (spec as ResolvedToolSpec & { input_schema?: Record<string, unknown> | null })
+      .input_schema
+  );
+}
+
+function missingRequiredFields(
+  schema: unknown,
+  value: unknown,
+  path: string[] = [],
+): string[] {
+  const object = objectSchema(schema);
+  if (!object) return [];
+
+  const missing: string[] = [];
+  const required = requiredFields(object);
+  const record = objectSchema(value);
+  for (const field of required) {
+    if (!record || record[field] === undefined || record[field] === null) {
+      missing.push([...path, field].join("."));
+    }
+  }
+
+  const properties = objectSchema(object.properties);
+  if (!properties || !record) return missing;
+  for (const [field, childSchema] of Object.entries(properties)) {
+    if (record[field] !== undefined && record[field] !== null) {
+      missing.push(...missingRequiredFields(childSchema, record[field], [...path, field]));
+    }
+  }
+  return missing;
+}
+
+function assertRequiredArguments(spec: ResolvedToolSpec, params: unknown): void {
+  const missing = missingRequiredFields(specInputSchema(spec), params);
+  if (missing.length === 0) return;
+  throw new Error(
+    `Tool '${spec.name}' missing required argument(s): ${missing.join(", ")}. ` +
+      "Retry the tool call with those argument fields populated.",
+  );
+}
+
 /**
  * Daytona tool call: the in-sandbox process can't reach Agenta, so write the request to a
  * file the runner watches and poll for the response it writes back (see tools/relay.ts).
@@ -97,7 +155,7 @@ export async function relayToolCall(
  * turns the throw into a tool-error result so the model loop continues rather than crashing.
  *
  *  - `code`   -> reject as unsupported by the sidecar, no callback/relay.
- *  - `client` → signal pending: browser-fulfilled, never executed in-sandbox.
+ *  - `client` → relay to the runner so it can park the browser-fulfilled call.
  *  - default/`callback` → relay through the runner when `opts.relayDir` is set (Daytona),
  *    else POST directly to `opts.endpoint`.
  */
@@ -106,14 +164,15 @@ export async function runResolvedTool(
   params: unknown,
   opts: RunResolvedToolOpts,
 ): Promise<string> {
+  assertRequiredArguments(spec, params);
   if (spec.kind === "code") {
     return runCodeTool(spec.runtime, spec.code ?? "", spec.env, params, opts.signal);
   }
   if (spec.kind === "client") {
-    return JSON.stringify({
-      type: "client_tool_pending",
-      toolName: spec.name,
-    });
+    if (opts.relayDir) {
+      return relayToolCall(opts.relayDir, spec.name, opts.toolCallId, params, opts.signal);
+    }
+    throw new Error(`client tool '${spec.name}' is browser-fulfilled and cannot be executed`);
   }
   // callback (default): route back to Agenta's /tools/call (directly or via the Daytona relay).
   if (opts.relayDir) {

--- a/services/agent/src/tools/public-spec.ts
+++ b/services/agent/src/tools/public-spec.ts
@@ -11,6 +11,8 @@ export interface PublicToolSpec {
   name: string;
   description?: string;
   inputSchema?: Record<string, unknown> | null;
+  kind?: ResolvedToolSpec["kind"];
+  render?: ResolvedToolSpec["render"];
 }
 
 /** `client` tools are browser-fulfilled and are not executable by a runner child process. */
@@ -19,13 +21,20 @@ export function executableToolSpecs(specs: ResolvedToolSpec[]): ResolvedToolSpec
 }
 
 export function publicToolSpec(spec: ResolvedToolSpec): PublicToolSpec {
-  return {
+  const inputSchema =
+    spec.inputSchema ??
+    (spec as ResolvedToolSpec & { input_schema?: Record<string, unknown> | null })
+      .input_schema;
+  const out: PublicToolSpec = {
     name: spec.name,
     description: spec.description,
-    inputSchema: spec.inputSchema,
+    inputSchema,
   };
+  if (spec.kind) out.kind = spec.kind;
+  if (spec.render) out.render = spec.render;
+  return out;
 }
 
 export function publicToolSpecs(specs: ResolvedToolSpec[]): PublicToolSpec[] {
-  return executableToolSpecs(specs).map(publicToolSpec);
+  return specs.map(publicToolSpec);
 }

--- a/services/agent/src/tools/relay.ts
+++ b/services/agent/src/tools/relay.ts
@@ -31,7 +31,7 @@ import type {
   RunContext,
   ToolCallbackContext,
 } from "../protocol.ts";
-import type { PermissionPolicy } from "../responder.ts";
+import type { ClientToolOutcome, PermissionPolicy } from "../responder.ts";
 
 export const RELAY_REQ_SUFFIX = ".req.json";
 export const RELAY_RES_SUFFIX = ".res.json";
@@ -51,6 +51,76 @@ export interface RelayResponse {
   ok: boolean;
   text?: string;
   error?: string;
+}
+export interface ClientToolRelayRequest {
+  id: string;
+  toolCallId: string;
+  toolName: string;
+  input: unknown;
+  spec: ResolvedToolSpec;
+}
+export interface ClientToolRelay {
+  onClientTool: (request: ClientToolRelayRequest) => Promise<ClientToolOutcome>;
+  onPark?: (request: ClientToolRelayRequest) => void;
+}
+const CLIENT_TOOL_PARKED = Symbol("client-tool-parked");
+
+function objectSchema(schema: unknown): Record<string, unknown> | undefined {
+  return schema && typeof schema === "object" && !Array.isArray(schema)
+    ? (schema as Record<string, unknown>)
+    : undefined;
+}
+
+function requiredFields(schema: unknown): string[] {
+  const object = objectSchema(schema);
+  const required = object?.required;
+  return Array.isArray(required)
+    ? required.filter((field): field is string => typeof field === "string")
+    : [];
+}
+
+function specInputSchema(spec: ResolvedToolSpec): Record<string, unknown> | null | undefined {
+  return (
+    spec.inputSchema ??
+    (spec as ResolvedToolSpec & { input_schema?: Record<string, unknown> | null })
+      .input_schema
+  );
+}
+
+function missingRequiredFields(
+  schema: unknown,
+  value: unknown,
+  path: string[] = [],
+): string[] {
+  const object = objectSchema(schema);
+  if (!object) return [];
+
+  const missing: string[] = [];
+  const required = requiredFields(object);
+  const record = objectSchema(value);
+  for (const field of required) {
+    if (!record || record[field] === undefined || record[field] === null) {
+      missing.push([...path, field].join("."));
+    }
+  }
+
+  const properties = objectSchema(object.properties);
+  if (!properties || !record) return missing;
+  for (const [field, childSchema] of Object.entries(properties)) {
+    if (record[field] !== undefined && record[field] !== null) {
+      missing.push(...missingRequiredFields(childSchema, record[field], [...path, field]));
+    }
+  }
+  return missing;
+}
+
+function assertRequiredArguments(spec: ResolvedToolSpec, params: unknown): void {
+  const missing = missingRequiredFields(specInputSchema(spec), params);
+  if (missing.length === 0) return;
+  throw new Error(
+    `Tool '${spec.name}' missing required argument(s): ${missing.join(", ")}. ` +
+      "Retry the tool call with those argument fields populated.",
+  );
 }
 
 /** Make a tool-call id safe to use as a filename (and bounded). */
@@ -132,7 +202,31 @@ async function executeRelayedTool(
   callback: ToolCallbackContext | undefined,
   policy: PermissionPolicy,
   runContext: RunContext | undefined,
-): Promise<string> {
+  clientToolRelay: ClientToolRelay | undefined,
+): Promise<string | typeof CLIENT_TOOL_PARKED> {
+  assertRequiredArguments(spec, req.args);
+  if (spec.kind === "client") {
+    if (!clientToolRelay) {
+      throw new Error(`client tool '${spec.name}' is browser-fulfilled and cannot be executed`);
+    }
+    const toolCallId = req.toolCallId;
+    const request = {
+      id: toolCallId,
+      toolCallId,
+      toolName: spec.name,
+      input: req.args,
+      spec,
+    };
+    const decision = await clientToolRelay.onClientTool(request);
+    if (decision === "park") {
+      clientToolRelay.onPark?.(request);
+      return CLIENT_TOOL_PARKED;
+    }
+    if (decision === "deny") {
+      return `Client tool '${spec.name}' was denied.`;
+    }
+    return JSON.stringify(decision.output ?? {});
+  }
   // Layer 3 enforcement (S3b): gate the call on the spec's permission before it runs.
   // `deny` returns a refusal string (not a throw) so the harness folds it into the tool
   // result and the model loop continues. `ask`/unset degrade to the headless policy.
@@ -143,9 +237,6 @@ async function executeRelayedTool(
     }
     // ask/unset that the headless policy refused. TODO(S5): surface ask to HITL.
     return `Tool '${spec.name}' requires approval; denied in headless mode.`;
-  }
-  if (spec.kind === "client") {
-    throw new Error(`client tool '${spec.name}' is browser-fulfilled and cannot be executed`);
   }
   if (spec.kind === "code") {
     return runCodeTool(spec.runtime, spec.code ?? "", spec.env, req.args);
@@ -192,6 +283,7 @@ export function startToolRelay(
   callback: ToolCallbackContext | undefined,
   policy: PermissionPolicy,
   runContext?: RunContext,
+  clientToolRelay?: ClientToolRelay,
 ): { stop: () => Promise<void> } {
   let active = true;
   const seen = new Set<string>();
@@ -212,7 +304,9 @@ export function startToolRelay(
         callback,
         policy,
         runContext,
+        clientToolRelay,
       );
+      if (text === CLIENT_TOOL_PARKED) return;
       res = { ok: true, text };
     } catch (err) {
       res = { ok: false, error: err instanceof Error ? err.message : String(err) };

--- a/services/agent/tests/unit/extension-tools.test.ts
+++ b/services/agent/tests/unit/extension-tools.test.ts
@@ -48,7 +48,7 @@ describe("agenta extension tool registration", () => {
       {
         name: "secret_math",
         description: "qa math",
-        inputSchema: {
+        input_schema: {
           type: "object",
           properties: { x: { type: "integer" } },
           required: ["x"],
@@ -74,6 +74,11 @@ describe("agenta extension tool registration", () => {
       math.parameters && math.parameters.properties && math.parameters.properties.x,
       "passes the JSON Schema through to Pi",
     );
+    assert.equal(math.promptSnippet, "qa math", "opts the tool into Pi's Available tools prompt");
+    assert.ok(
+      math.promptGuidelines.some((line: string) => line.includes("required argument(s): x")),
+      "adds prompt guidance for required arguments",
+    );
     assert.equal(typeof math.execute, "function", "each tool has an execute() that relays");
 
     const noSchema = pi.registered[1];
@@ -91,6 +96,38 @@ describe("agenta extension tool registration", () => {
       pi.registered.length,
       0,
       "no tool env => registers nothing (no silent partial state)",
+    );
+  });
+
+  it("rejects missing required args before relaying a no-op tool call", async () => {
+    clearEnv();
+    process.env.AGENTA_AGENT_TOOLS_PUBLIC_SPECS = JSON.stringify([
+      {
+        name: "commit_revision",
+        description: "commit",
+        inputSchema: {
+          type: "object",
+          properties: {
+            workflow_revision: {
+              type: "object",
+              properties: {
+                data: { type: "object" },
+              },
+              required: ["data"],
+            },
+          },
+          required: ["workflow_revision"],
+        },
+      },
+    ]);
+    process.env.AGENTA_AGENT_TOOLS_RELAY_DIR = "/tmp/agenta-relay-test";
+
+    const pi = fakePi();
+    factory(pi as any);
+
+    await assert.rejects(
+      () => pi.registered[0].execute("call-1", {}),
+      /missing required argument\(s\): workflow_revision/,
     );
   });
 

--- a/services/agent/tests/unit/sandbox-agent-pi-assets.test.ts
+++ b/services/agent/tests/unit/sandbox-agent-pi-assets.test.ts
@@ -70,7 +70,12 @@ describe("buildPiExtensionEnv", () => {
         {
           name: "client_only",
           description: "browser fulfilled",
+          inputSchema: {
+            type: "object",
+            properties: { integration: { type: "string" } },
+          },
           kind: "client",
+          render: { kind: "connect" },
         },
       ],
     } as AgentRunRequest;
@@ -99,6 +104,17 @@ describe("buildPiExtensionEnv", () => {
         name: "safe_tool",
         description: "safe",
         inputSchema: { type: "object", properties: { x: { type: "string" } } },
+        kind: "callback",
+      },
+      {
+        name: "client_only",
+        description: "browser fulfilled",
+        inputSchema: {
+          type: "object",
+          properties: { integration: { type: "string" } },
+        },
+        kind: "client",
+        render: { kind: "connect" },
       },
     ]);
     assert.equal(JSON.stringify(specs).includes("server-secret-ref"), false);
@@ -123,6 +139,33 @@ describe("buildPiExtensionEnv", () => {
     assert.equal(env.TRACEPARENT, undefined);
     assert.equal(env.AGENTA_AGENT_TOOLS_PUBLIC_SPECS, undefined);
     assert.equal(env.AGENTA_AGENT_TOOLS_RELAY_DIR, undefined);
+  });
+
+  it("accepts snake_case tool schemas from older Python wire payloads", () => {
+    const env = buildPiExtensionEnv(
+      {
+        customTools: [
+          {
+            name: "request_connection",
+            kind: "client",
+            input_schema: {
+              type: "object",
+              required: ["integration"],
+              properties: { integration: { type: "string" } },
+            },
+          },
+        ],
+      } as AgentRunRequest,
+      false,
+      { relayDir: "/tmp/relay" },
+    );
+
+    const specs = JSON.parse(env.AGENTA_AGENT_TOOLS_PUBLIC_SPECS ?? "[]");
+    assert.deepEqual(specs[0].inputSchema, {
+      type: "object",
+      required: ["integration"],
+      properties: { integration: { type: "string" } },
+    });
   });
 
   it("carries the loaded skill names under tracing (F-029)", () => {

--- a/services/agent/tests/unit/sandbox-agent-run-plan.test.ts
+++ b/services/agent/tests/unit/sandbox-agent-run-plan.test.ts
@@ -91,11 +91,28 @@ describe("buildRunPlan", () => {
       result.plan.executableToolSpecs.map((tool) => tool.name),
       ["server_tool"],
     );
+    assert.deepEqual(
+      result.plan.toolSpecs.map((tool) => tool.name),
+      ["server_tool", "client_tool"],
+    );
     assert.equal(result.plan.useToolRelay, true);
     assert.deepEqual(result.plan.skillDirs, [
       { name: "alpha", dir: "/skills/alpha" },
     ]);
     assert.deepEqual(logs, ["resolved alpha", "skills: alpha"]);
+  });
+
+  it("keeps the relay enabled for client-only Pi tools", () => {
+    const result = buildRunPlan({
+      harness: "pi_agenta",
+      messages: [{ role: "user", content: "connect slack" }],
+      customTools: [{ name: "request_connection", kind: "client" }],
+    } as AgentRunRequest);
+
+    assert.equal(result.ok, true);
+    if (!result.ok) return;
+    assert.deepEqual(result.plan.executableToolSpecs, []);
+    assert.equal(result.plan.useToolRelay, true);
   });
 
   it("carries the sandbox permission onto the plan and leaves an unrestricted run alone", () => {

--- a/services/agent/tests/unit/tool-direct.test.ts
+++ b/services/agent/tests/unit/tool-direct.test.ts
@@ -182,53 +182,60 @@ describe("assembleBody context binding", () => {
     });
   });
 
-  it("handles a missing run-context key safely (the field stays unset)", () => {
+  it("fails closed when a run-context key is missing", () => {
     const call: DirectCall = {
       method: "POST",
       path: "/api/x",
       context: { latest: "$ctx.workflow.revision.missing" }, // not in RUN_CONTEXT
     };
-    const body = assembleBody(call, { a: 1 }, RUN_CONTEXT);
-    assert.deepEqual(body, { a: 1 });
-    assert.ok(!("latest" in body));
+    assert.throws(
+      () => assembleBody(call, { a: 1 }, RUN_CONTEXT),
+      /missing run-context value for direct-call binding 'latest'/,
+    );
   });
 
-  it("clears a colliding model arg when the bound key is missing (model-invisible)", () => {
+  it("fails closed when a colliding model arg cannot be bound from context", () => {
     const call: DirectCall = {
       method: "POST",
       path: "/api/x",
-      // The bound field is owned by run context; a missing key must leave it ABSENT, never let the
+      // The bound field is owned by run context; a missing key must fail the call, never let the
       // model's value survive.
       context: { workflow_variant_id: "$ctx.workflow.revision.missing" },
     };
-    const body = assembleBody(
-      call,
-      { workflow_variant_id: "someone-elses", keep: 1 },
-      RUN_CONTEXT,
+    assert.throws(
+      () =>
+        assembleBody(
+          call,
+          { workflow_variant_id: "someone-elses", keep: 1 },
+          RUN_CONTEXT,
+        ),
+      /missing run-context value for direct-call binding 'workflow_variant_id'/,
     );
-    assert.ok(!("workflow_variant_id" in body));
-    assert.equal(body.keep, 1);
   });
 
-  it("clears a colliding static body field when the bound key is missing", () => {
+  it("fails closed when a colliding static body field cannot be bound from context", () => {
     const call: DirectCall = {
       method: "POST",
       path: "/api/x",
       body: { trace_id: "from-body" },
       context: { trace_id: "$ctx.trace.missing" },
     };
-    const body = assembleBody(call, {}, RUN_CONTEXT);
-    assert.ok(!("trace_id" in body));
+    assert.throws(
+      () => assembleBody(call, {}, RUN_CONTEXT),
+      /missing run-context value for direct-call binding 'trace_id'/,
+    );
   });
 
-  it("handles an absent run context safely (no binding applied)", () => {
+  it("fails closed when run context is absent", () => {
     const call: DirectCall = {
       method: "POST",
       path: "/api/x",
       context: { "trace.trace_id": "$ctx.trace.trace_id" },
     };
-    // No runContext argument at all (the Phase-2 call shape): the binding is simply skipped.
-    assert.deepEqual(assembleBody(call, { a: 1 }), { a: 1 });
+    assert.throws(
+      () => assembleBody(call, { a: 1 }),
+      /missing run-context value for direct-call binding 'trace.trace_id'/,
+    );
   });
 
   it("lets a bound field win over a colliding model arg (the model cannot override it)", () => {
@@ -258,14 +265,16 @@ describe("assembleBody context binding", () => {
     assert.equal(body.trace_id, "trace-self");
   });
 
-  it("skips a malformed context token (one without the $ctx. prefix)", () => {
+  it("fails closed on a malformed context token (one without the $ctx. prefix)", () => {
     const call: DirectCall = {
       method: "POST",
       path: "/api/x",
-      context: { trace_id: "trace.trace_id" }, // missing the $ctx. prefix -> untrusted, skipped
+      context: { trace_id: "trace.trace_id" }, // missing the $ctx. prefix -> untrusted
     };
-    const body = assembleBody(call, { a: 1 }, RUN_CONTEXT);
-    assert.deepEqual(body, { a: 1 });
+    assert.throws(
+      () => assembleBody(call, { a: 1 }, RUN_CONTEXT),
+      /missing run-context value for direct-call binding 'trace_id'/,
+    );
   });
 
   it("is prototype-pollution-safe on the bound body path", () => {

--- a/services/agent/tests/unit/tool-dispatch.test.ts
+++ b/services/agent/tests/unit/tool-dispatch.test.ts
@@ -4,7 +4,7 @@
  * The kind-dispatch ("branch on spec.kind to execute a resolved tool") lives once in
  * `runResolvedTool`, used by the Pi extension (extensions/agenta.ts) and the MCP server
  * (tools/mcp-server.ts). These tests cover the routing into that function and the file relay:
- *  - runResolvedTool advertises code tools but fails their sidecar execution, and throws for `client`.
+ *  - runResolvedTool advertises code tools but fails their sidecar execution, and relays `client`.
  *  - relayToolCall reads back the relayed result from the Daytona file relay.
  *
  * No network and no harness: the `code` path now fails before any subprocess; the
@@ -23,6 +23,15 @@ import { RELAY_RES_SUFFIX, sanitizeRelayId } from "../../src/tools/relay.ts";
 import type { ResolvedToolSpec } from "../../src/protocol.ts";
 
 const clientSpec: ResolvedToolSpec = { name: "client_tool", kind: "client" };
+const requiredClientSpec = {
+  name: "request_connection",
+  kind: "client",
+  input_schema: {
+    type: "object",
+    properties: { integration: { type: "string" } },
+    required: ["integration"],
+  },
+} as ResolvedToolSpec;
 const codeSpec: ResolvedToolSpec = {
   name: "code_tool",
   kind: "code",
@@ -47,6 +56,33 @@ describe("runResolvedTool", () => {
       () => runResolvedTool(clientSpec, {}, { toolCallId: "call-2" }),
       /browser-fulfilled/,
       "client tool throws (never executed in-sandbox)",
+    );
+  });
+
+  it("relays a client spec when the Pi extension has a runner relay", async () => {
+    const dir = mkdtempSync(join(tmpdir(), "agenta-relay-test-"));
+    try {
+      const toolCallId = "call-client";
+      const resPath = join(dir, sanitizeRelayId(toolCallId) + RELAY_RES_SUFFIX);
+      writeFileSync(resPath, JSON.stringify({ ok: true, text: '{"connected":true}' }));
+      const out = await runResolvedTool(clientSpec, { integration: "slack" }, {
+        toolCallId,
+        relayDir: dir,
+      });
+      assert.equal(out, '{"connected":true}');
+    } finally {
+      rmSync(dir, { recursive: true, force: true });
+    }
+  });
+
+  it("rejects missing required args before any relay or callback execution", async () => {
+    await assert.rejects(
+      () =>
+        runResolvedTool(requiredClientSpec, {}, {
+          toolCallId: "call-required",
+          relayDir: "/tmp/agenta-relay-must-not-be-used",
+        }),
+      /missing required argument\(s\): integration/,
     );
   });
 });

--- a/services/agent/tests/unit/tool-relay-permission.test.ts
+++ b/services/agent/tests/unit/tool-relay-permission.test.ts
@@ -42,13 +42,14 @@ const codeSpec = (
 async function relayOnce(
   spec: ResolvedToolSpec,
   policy: "auto" | "deny",
+  args: unknown = { a: 1 },
 ): Promise<RelayResponse> {
   const dir = mkdtempSync(join(tmpdir(), "agenta-relay-disp-"));
   try {
     const id = "call-1";
     writeFileSync(
       join(dir, `${id}.req.json`),
-      JSON.stringify({ toolName: spec.name, toolCallId: id, args: { a: 1 } }),
+      JSON.stringify({ toolName: spec.name, toolCallId: id, args }),
     );
     const relay = startToolRelay(localRelayHost(), dir, [spec], undefined, policy);
     const resPath = join(dir, `${id}.res.json`);
@@ -101,9 +102,153 @@ describe("startToolRelay permission enforcement", () => {
     assert.match(res.error ?? "", /Code tools are not supported by the sidecar\./);
   });
 
+  it("rejects missing required args before executing a relayed tool", async () => {
+    const spec = {
+      ...codeSpec("needs_args", "allow"),
+      input_schema: {
+        type: "object",
+        properties: { required_value: { type: "string" } },
+        required: ["required_value"],
+      },
+    } as ResolvedToolSpec;
+    const res = await relayOnce(spec, "auto", {});
+    assert.equal(res.ok, false);
+    assert.match(res.error ?? "", /missing required argument\(s\): required_value/);
+    assert.ok(
+      !String(res.error).includes("Code tools are not supported"),
+      "validation failed before sidecar code execution",
+    );
+  });
+
   it("refuses an unset spec when the headless policy is deny", async () => {
     const res = await relayOnce(codeSpec("gated", undefined), "deny");
     assert.equal(res.ok, true);
     assert.equal(res.text, "Tool 'gated' requires approval; denied in headless mode.");
+  });
+
+  it("parks a browser-fulfilled client tool without writing a relay response", async () => {
+    const dir = mkdtempSync(join(tmpdir(), "agenta-relay-client-"));
+    try {
+      const id = "call-client";
+      const resPath = join(dir, `${id}.res.json`);
+      let parked = false;
+      let seenInput: unknown;
+      writeFileSync(
+        join(dir, `${id}.req.json`),
+        JSON.stringify({
+          toolName: "request_connection",
+          toolCallId: id,
+          args: { integration: "slack" },
+        }),
+      );
+      let resolveHandled: () => void = () => {};
+      const handled = new Promise<void>((resolve) => {
+        resolveHandled = resolve;
+      });
+      const relay = startToolRelay(
+          localRelayHost(),
+          dir,
+          [{ name: "request_connection", kind: "client" }],
+          undefined,
+          "auto",
+          undefined,
+          {
+            onClientTool: async (request) => {
+              seenInput = request.input;
+              return "park";
+            },
+            onPark: () => {
+              parked = true;
+              resolveHandled();
+            },
+          },
+      );
+      await handled;
+      await relay.stop();
+      assert.equal(parked, true);
+      assert.deepEqual(seenInput, { integration: "slack" });
+      assert.equal(existsSync(resPath), false);
+    } finally {
+      rmSync(dir, { recursive: true, force: true });
+    }
+  });
+
+  it("still parks a browser-fulfilled client tool under deny permission policy", async () => {
+    const dir = mkdtempSync(join(tmpdir(), "agenta-relay-client-"));
+    try {
+      const id = "call-client";
+      let parked = false;
+      writeFileSync(
+        join(dir, `${id}.req.json`),
+        JSON.stringify({
+          toolName: "request_connection",
+          toolCallId: id,
+          args: { integration: "slack" },
+        }),
+      );
+      let resolveHandled: () => void = () => {};
+      const handled = new Promise<void>((resolve) => {
+        resolveHandled = resolve;
+      });
+      const relay = startToolRelay(
+        localRelayHost(),
+        dir,
+        [{ name: "request_connection", kind: "client" }],
+        undefined,
+        "deny",
+        undefined,
+        {
+          onClientTool: async () => "park",
+          onPark: () => {
+            parked = true;
+            resolveHandled();
+          },
+        },
+      );
+      await handled;
+      await relay.stop();
+      assert.equal(parked, true);
+      assert.equal(existsSync(join(dir, `${id}.res.json`)), false);
+    } finally {
+      rmSync(dir, { recursive: true, force: true });
+    }
+  });
+
+  it("writes stored client-tool output when the browser already fulfilled it", async () => {
+    const dir = mkdtempSync(join(tmpdir(), "agenta-relay-client-"));
+    try {
+      const id = "call-client";
+      writeFileSync(
+        join(dir, `${id}.req.json`),
+        JSON.stringify({
+          toolName: "request_connection",
+          toolCallId: id,
+          args: { integration: "slack" },
+        }),
+      );
+      const relay = startToolRelay(
+        localRelayHost(),
+        dir,
+        [{ name: "request_connection", kind: "client" }],
+        undefined,
+        "auto",
+        undefined,
+        {
+          onClientTool: async () => ({ output: { connected: true } }),
+        },
+      );
+      const resPath = join(dir, `${id}.res.json`);
+      const deadline = Date.now() + 5000;
+      while (Date.now() < deadline && !existsSync(resPath)) {
+        await new Promise((r) => setTimeout(r, 20));
+      }
+      await relay.stop();
+      assert.ok(existsSync(resPath), "the relay wrote a response file");
+      const res = JSON.parse(readFileSync(resPath, "utf-8")) as RelayResponse;
+      assert.equal(res.ok, true);
+      assert.equal(res.text, JSON.stringify({ connected: true }));
+    } finally {
+      rmSync(dir, { recursive: true, force: true });
+    }
   });
 });

--- a/services/oss/src/agent/tracing.py
+++ b/services/oss/src/agent/tracing.py
@@ -104,23 +104,50 @@ def _run_context_reference(
     return None
 
 
+def _run_context_reference_from_any(
+    references: Optional[Dict[str, Any]],
+    keys: tuple[str, ...],
+    *,
+    with_version: bool = False,
+) -> Optional[RunContextReference]:
+    """Build one run-context reference from the first populated key in ``keys``.
+
+    Playground application and evaluator invocations carry application/evaluator references, but
+    platform tools bind workflow identity because applications and evaluators are workflow-backed.
+    Normalize those reference families into the workflow-shaped run context so self-targeting
+    platform tools can still bind their own variant server-side.
+    """
+    for key in keys:
+        reference = _run_context_reference(references, key, with_version=with_version)
+        if reference is not None:
+            return reference
+    return None
+
+
 def _run_context_workflow() -> Optional[RunContextWorkflow]:
     """The running workflow identity, best-effort, from the resolved tracing references.
 
     The references land on the tracing context after the resolver hydrates a stored
-    variant/environment reference, grouped into the platform's three workflow entities — the
-    artifact (``workflow``), the variant (``workflow_variant``), and the revision
-    (``workflow_revision``). A playground run of an unsaved inline config carries no revision
-    reference, so ``is_draft`` is ``True``; a run pinned to a stored revision is not a draft. A run
-    with no workflow identity at all returns ``None`` and the binding simply has no value — every
-    field is optional."""
+    variant/environment reference. Native workflow invocations use ``workflow*`` keys. Playground
+    application and evaluator invocations use ``application*`` / ``evaluator*`` keys, but those
+    entities are workflow-backed, so they normalize into the same run-context shape. A playground
+    run of an unsaved inline config carries no revision reference, so ``is_draft`` is ``True``; a
+    run pinned to a stored revision is not a draft. A run with no workflow identity at all returns
+    ``None`` and the binding simply has no value — every field is optional."""
     references = TracingContext.get().references
-    revision = _run_context_reference(
-        references, "workflow_revision", with_version=True
+    revision = _run_context_reference_from_any(
+        references,
+        ("workflow_revision", "application_revision", "evaluator_revision"),
+        with_version=True,
     )
     workflow = RunContextWorkflow(
-        artifact=_run_context_reference(references, "workflow"),
-        variant=_run_context_reference(references, "workflow_variant"),
+        artifact=_run_context_reference_from_any(
+            references, ("workflow", "application", "evaluator")
+        ),
+        variant=_run_context_reference_from_any(
+            references,
+            ("workflow_variant", "application_variant", "evaluator_variant"),
+        ),
         revision=revision,
     )
     if not workflow.model_dump(exclude_none=True):

--- a/services/oss/tests/pytest/unit/agent/test_tracing.py
+++ b/services/oss/tests/pytest/unit/agent/test_tracing.py
@@ -6,6 +6,8 @@ identity are captured separately, so a failure reading one must not drop the oth
 
 from __future__ import annotations
 
+from types import SimpleNamespace
+
 from agenta.sdk.agents import RunContextTrace, RunContextWorkflow
 
 from oss.src.agent import tracing
@@ -53,3 +55,32 @@ def test_run_context_none_when_both_empty(monkeypatch):
     monkeypatch.setattr(tracing, "_run_context_workflow", lambda: None)
     monkeypatch.setattr(tracing, "_run_context_trace", lambda: None)
     assert tracing.run_context() is None
+
+
+def test_run_context_workflow_normalizes_application_references(monkeypatch):
+    # Playground app runs carry application-family references. Platform tools still bind workflow
+    # identity because applications are workflow-backed, so the context normalizes those keys.
+    monkeypatch.setattr(
+        tracing.TracingContext,
+        "get",
+        lambda: SimpleNamespace(
+            references={
+                "application": {"id": "app-id", "slug": "agent-app"},
+                "application_variant": {"id": "variant-id", "slug": "default"},
+                "application_revision": {
+                    "id": "revision-id",
+                    "slug": "default",
+                    "version": "v2",
+                },
+            }
+        ),
+    )
+
+    workflow = tracing._run_context_workflow()
+
+    assert workflow is not None
+    assert workflow.artifact.id == "app-id"
+    assert workflow.variant.id == "variant-id"
+    assert workflow.revision.id == "revision-id"
+    assert workflow.revision.version == "v2"
+    assert workflow.is_draft is False

--- a/web/oss/src/components/AgentChatSlice/AgentChatPanel.tsx
+++ b/web/oss/src/components/AgentChatSlice/AgentChatPanel.tsx
@@ -1,7 +1,11 @@
 import {useCallback, useEffect, useLayoutEffect, useMemo, useRef, useState} from "react"
 
 import {invalidateAgentCommittedRevisionCache} from "@agenta/entities/workflow"
-import {agentShouldResumeAfterApproval, buildAgentRequest} from "@agenta/playground"
+import {
+    agentShouldResumeAfterApproval,
+    buildAgentRequest,
+    playgroundController,
+} from "@agenta/playground"
 import {simulatedAgentRunAtomFamily} from "@agenta/shared/state"
 import {generateId} from "@agenta/shared/utils"
 import {HeightCollapse} from "@agenta/ui"
@@ -175,6 +179,7 @@ const MessageRow = ({
 const AgentConversation = ({entityId, sessionId}: {entityId: string; sessionId: string}) => {
     const store = useStore()
     const persistMessages = useSetAtom(persistSessionMessagesAtom)
+    const switchEntity = useSetAtom(playgroundController.actions.switchEntity)
 
     const [input, setInput] = useState("")
     const [files, setFiles] = useState<UploadFile[]>([])
@@ -418,9 +423,12 @@ const AgentConversation = ({entityId, sessionId}: {entityId: string; sessionId: 
                 if (committedRevisionsSeenRef.current.has(key)) continue
                 committedRevisionsSeenRef.current.add(key)
                 invalidateAgentCommittedRevisionCache()
+                if (data?.revisionId && data.revisionId !== entityId) {
+                    switchEntity({currentEntityId: entityId, newEntityId: data.revisionId})
+                }
             }
         }
-    }, [messages])
+    }, [messages, entityId, switchEntity])
 
     // ── DT3 cancelled state: wrap stop() to mark the in-flight assistant turn ──
     const markStopped = useCallback(() => {

--- a/web/packages/agenta-entities/src/workflow/state/runnableSetup.ts
+++ b/web/packages/agenta-entities/src/workflow/state/runnableSetup.ts
@@ -238,8 +238,9 @@ export const appOpenApiSchemaAtomFamily = atomFamily((workflowId: string) =>
  * Invocation URL for workflow execution.
  *
  * Calls `POST {serviceUrl}/invoke` directly on the service dispatcher,
- * mirroring how `/inspect` works. The service URL is resolved from
- * `data.url` (stored) or built from `data.uri` via `buildServiceUrlFromUri`.
+ * mirroring how `/inspect` works. Builtin apps use `resolveBuiltinAppServiceUrl`
+ * (URI-derived proxy URL) so Docker-internal hostnames never reach the browser.
+ * Custom apps and evaluators fall back to `data.url` then URI.
  *
  * Unified for all workflow types (apps and evaluators).
  */
@@ -248,7 +249,13 @@ export const invocationUrlAtomFamily = atomFamily((workflowId: string) =>
         const entity = get(workflowBaseEntityAtomFamily(workflowId))
         if (!entity?.data) return null
 
-        // Resolve service URL: prefer stored url, fall back to building from URI
+        // Builtins: resolve via URI so the browser hits the public proxy, not Docker-internal.
+        const builtinUrl = resolveBuiltinAppServiceUrl(entity)
+        if (builtinUrl) {
+            return `${builtinUrl.replace(/\/+$/, "")}/invoke`
+        }
+
+        // Custom apps / evaluators: stored url then URI fallback.
         const serviceUrl =
             entity.data.url?.replace(/\/+$/, "") ?? buildServiceUrlFromUri(entity.data.uri)
 

--- a/web/packages/agenta-entity-ui/src/DrillInView/SchemaControls/AgentTemplateControl.tsx
+++ b/web/packages/agenta-entity-ui/src/DrillInView/SchemaControls/AgentTemplateControl.tsx
@@ -174,7 +174,7 @@ export function AgentTemplateControl({
 
     // Model & harness + Advanced own a lot of coupled, stateful logic (the model/connection state
     // feeds both sections), so they live in their own hook that returns the summaries + bodies.
-    const mh = useModelHarness({schema, config, onChange, disabled, withTooltip})
+    const mh = useModelHarness({schema, config, onChange, disabled, withTooltip, revisionId})
 
     // Tool add/remove (inline function, builtin, gateway, workflow reference) lives in its own hook.
     const {

--- a/web/packages/agenta-entity-ui/src/DrillInView/SchemaControls/agentTemplate/useModelHarness.tsx
+++ b/web/packages/agenta-entity-ui/src/DrillInView/SchemaControls/agentTemplate/useModelHarness.tsx
@@ -51,12 +51,14 @@ export function useModelHarness({
     onChange,
     disabled,
     withTooltip,
+    revisionId,
 }: {
     schema?: SchemaProperty | null
     config: Record<string, unknown>
     onChange: (next: Record<string, unknown>) => void
     disabled?: boolean
     withTooltip?: boolean
+    revisionId?: string | null
 }) {
     const props = (schema?.properties ?? {}) as Record<string, SchemaProperty>
     const subProps = useCallback(


### PR DESCRIPTION
## Context
Browser QA exposed two round-trip failures in the agent build-kit stack. A sparse `commit_revision` call could clobber stored agent config, and the playground did not reliably switch to the committed revision after a self-update. Resumed streams could also miss the committed-revision event when they only replayed the tool result.

## Changes
`commit_revision` now uses a preservation-only patch endpoint for self-updates. Omitted fields keep the current revision data instead of replacing it with a partial payload.

The Vercel stream adapter emits `data-committed-revision` from successful commit output even when the resumed stream does not replay the original tool call. The playground handles that event through `switchEntity`, so the URL and selection bridge move to the new revision.

The runner/direct-call path now fails closed when a run-context binding is missing, and tracing normalizes application references into workflow-shaped run context for self-targeting platform tools.

## Tests / notes
- `cd sdks/python && uv run --no-sync pytest oss/tests/pytest/unit/agents/adapters/test_vercel_stream_park.py oss/tests/pytest/unit/agents/platform/test_op_catalog.py`
- `cd services/agent && pnpm exec vitest run tests/unit/tool-direct.test.ts`
- `cd services/oss && uv run --no-sync pytest tests/pytest/unit/agent/test_tracing.py`
- Browser QA on `http://144.76.237.122:8280`: `commit_revision` switched to revision `019f1641-7708-78b2-937e-db2bc13de0f3` (`v10`) and preserved AGENTS.md with marker `codex-commit-qa-20260630-0235`.
- Browser QA on `request_connection`: invoke returned HTTP 200, streamed `toolName: request_connection`, and rendered the `Connection not completed` / `Retry` UI.

## What to QA
- In the QA agent playground, ask the agent to commit a revision. The URL should switch to the new `revisions=` id and the config panel should show the new version without losing the agent template.
- Ask the agent to call `request_connection` for Slack. The inline connection UI should render and settle cleanly if the connection is not completed.