### PR TITLE
revert(API): remove commit/patch router changes from #4936

### DIFF
--- a/api/oss/src/apis/fastapi/workflows/router.py
+++ b/api/oss/src/apis/fastapi/workflows/router.py
@@ -1517,43 +1517,6 @@ class WorkflowsRouter:
         ):
             return WorkflowRevisionResponse()
 
-        workflow_revision_commit = workflow_revision_commit_request.workflow_revision
-
-        variant_id = (
-            workflow_revision_commit.workflow_variant_id
-            or workflow_revision_commit.variant_id
-        )
-        if variant_id is None:
-            raise HTTPException(
-                status_code=400,
-                detail="workflow_revision.workflow_variant_id is required when committing a workflow revision.",
-            )
-
-        # A commit carries data (full replace) or delta (ops merged onto the latest revision),
-        # never both. Empty is allowed only as the v0 seed (intentionally null data/flags/meta);
-        # once the variant has a data revision, an empty commit is rejected.
-        has_data = bool(
-            workflow_revision_commit.data
-            and workflow_revision_commit.data.model_dump(mode="json", exclude_none=True)
-        )
-        has_delta = workflow_revision_commit.delta is not None
-        if has_data and has_delta:
-            raise HTTPException(
-                status_code=400,
-                detail="Provide either data or delta for a commit, not both.",
-            )
-        if not has_data and not has_delta:
-            current_revision = await self.workflows_service.fetch_workflow_revision(
-                project_id=UUID(request.state.project_id),
-                workflow_variant_ref=Reference(id=variant_id),
-                include_archived=False,
-            )
-            if current_revision and current_revision.data:
-                raise HTTPException(
-                    status_code=400,
-                    detail="workflow_revision.data is required when committing a workflow revision.",
-                )
-
         workflow_revision = await self.workflows_service.commit_workflow_revision(
             project_id=UUID(request.state.project_id),
             user_id=UUID(request.state.user_id),

--- a/sdks/python/agenta/sdk/agents/platform/op_catalog.py
+++ b/sdks/python/agenta/sdk/agents/platform/op_catalog.py
@@ -252,19 +252,15 @@ _QUERY_WORKFLOWS_INPUT_SCHEMA: Dict[str, Any] = {
 # and stripped from the model-visible schema, so the agent can only ever target itself, never a
 # different variant in the project. Defaults to approval.
 _COMMIT_REVISION_DESCRIPTION = (
-    "Commit a new revision to your own workflow variant (update yourself). Send only the "
-    "fields you are changing under `workflow_revision.delta.set` (deep-merged onto your "
-    "current config) and any field paths to drop under `delta.remove`. Put agent-template "
-    "edits under `delta.set.parameters.agent`. The variant you are running is targeted "
-    "automatically. This changes the agent and requires approval."
+    "Commit a new revision to your own workflow variant (update yourself). Supply the new "
+    "configuration under `workflow_revision.data` and an optional commit message; the variant "
+    "you are running is targeted automatically. This changes the agent and requires approval."
 )
 _COMMIT_REVISION_INPUT_SCHEMA: Dict[str, Any] = {
     "type": "object",
-    "additionalProperties": False,
     "properties": {
         "workflow_revision": {
             "type": "object",
-            "additionalProperties": False,
             "description": "The revision to append to your variant's history.",
             "properties": {
                 # Bound from $ctx.workflow.variant.id and stripped before the model sees it.
@@ -276,34 +272,12 @@ _COMMIT_REVISION_INPUT_SCHEMA: Dict[str, Any] = {
                     "type": "string",
                     "description": "Commit message describing the change.",
                 },
-                "delta": {
+                "data": {
                     "type": "object",
-                    "additionalProperties": False,
-                    "description": (
-                        "Change set applied to your current revision. `set` is deep-merged "
-                        "(omitted fields preserved); `remove` deletes the listed paths."
-                    ),
-                    "properties": {
-                        "set": {
-                            "type": "object",
-                            "additionalProperties": True,
-                            "description": (
-                                "Partial workflow revision data to merge. For agent-template "
-                                "updates, include parameters.agent with instructions, llm, tools, "
-                                "mcps, skills, harness, runner, or sandbox fields as needed."
-                            ),
-                        },
-                        "remove": {
-                            "type": "array",
-                            "items": {"type": "string"},
-                            "description": (
-                                "Dotted field paths to delete, e.g. parameters.agent.tools."
-                            ),
-                        },
-                    },
+                    "description": "The new configuration (parameters, inputs) for the revision.",
                 },
             },
-            "required": ["workflow_variant_id", "delta"],
+            "required": ["workflow_variant_id"],
         },
     },
     "required": ["workflow_revision"],


### PR DESCRIPTION
## What

#4936 put patch/merge/validation semantics into the **core** workflows router. It added a `WorkflowRevisionData` import, registered a forked `POST /workflows/revisions/commit/patch` endpoint, added a `commit_workflow_revision_patch` handler plus a `_deep_merge_revision_data` helper, and added two `400` checks (missing `data` / missing variant id) inside the existing `commit_workflow_revision`. On the SDK side it tightened the `commit_revision` op schema (typed `data` sub-properties, `additionalProperties: false`, `data` required) and pointed the op at `/commit/patch`.

A follow-up commit on `big-agents` (`4ae6289d68` "[fix] patch > delta ?") then reworked that into a `data`-vs-`delta` model: it removed the forked `/patch` route/handler/helper but left a `data`-vs-`delta` validation block in the same core handler, and switched the SDK op to a `delta.set` / `delta.remove` schema.

This PR reverts **both** of those layers in the two affected files and restores them to their **pre-#4936** state:

- `api/oss/src/apis/fastapi/workflows/router.py` — the `commit_workflow_revision` handler no longer validates/merges; it commits the supplied revision directly.
- `sdks/python/agenta/sdk/agents/platform/op_catalog.py` — `commit_revision` goes back to the looser `workflow_revision.data` object schema (no `additionalProperties: false`, no typed sub-properties, `data` not required) and the plain `/api/workflows/revisions/commit` path.

## Why

That validation/merge/patch logic does not belong in the core workflows router. `commit_revision` will be redesigned as a proper agenta tool. Until that lands, `commit_revision` returns to its pre-#4936 **replace** behavior.

## Scope

Exactly two files are touched, and both are byte-identical to their pre-#4936 content (`74755ebc^1`). The `$ctx.workflow.variant.id` context binding on the `commit_revision` op is unchanged.

Out of scope by design: `4ae6289d68`'s sibling changes to `core/workflows/dtos.py`, `core/workflows/service.py`, the generated clients, and `sdks/.../test_op_catalog.py` are left in place. The reviewer should confirm that leaving the `delta` plumbing in the DTOs/service while the router no longer uses it (and the op no longer emits it) is acceptable for this interim revert, and note that `test_op_catalog.py` still asserts the `delta` schema.

https://claude.ai/code/session_014emxsaD8EFiNP3m3f56nhD
