### PR TITLE
fix(workflows): serve canonical builtin service URLs, never a stored Docker-internal host

### DIFF
--- a/web/packages/agenta-entities/src/workflow/state/runnableSetup.ts
+++ b/web/packages/agenta-entities/src/workflow/state/runnableSetup.ts
@@ -238,9 +238,8 @@ export const appOpenApiSchemaAtomFamily = atomFamily((workflowId: string) =>
  * Invocation URL for workflow execution.
  *
  * Calls `POST {serviceUrl}/invoke` directly on the service dispatcher,
- * mirroring how `/inspect` works. Builtin apps use `resolveBuiltinAppServiceUrl`
- * (URI-derived proxy URL) so Docker-internal hostnames never reach the browser.
- * Custom apps and evaluators fall back to `data.url` then URI.
+ * mirroring how `/inspect` works. The service URL is resolved from
+ * `data.url` (stored) or built from `data.uri` via `buildServiceUrlFromUri`.
  *
  * Unified for all workflow types (apps and evaluators).
  */
@@ -249,13 +248,7 @@ export const invocationUrlAtomFamily = atomFamily((workflowId: string) =>
         const entity = get(workflowBaseEntityAtomFamily(workflowId))
         if (!entity?.data) return null
 
-        // Builtins: resolve via URI so the browser hits the public proxy, not Docker-internal.
-        const builtinUrl = resolveBuiltinAppServiceUrl(entity)
-        if (builtinUrl) {
-            return `${builtinUrl.replace(/\/+$/, "")}/invoke`
-        }
-
-        // Custom apps / evaluators: stored url then URI fallback.
+        // Resolve service URL: prefer stored url, fall back to building from URI
         const serviceUrl =
             entity.data.url?.replace(/\/+$/, "") ?? buildServiceUrlFromUri(entity.data.uri)
 


### PR DESCRIPTION
## Symptom

A builtin **agent** app could not be invoked from the playground. The browser tried to
`POST` to a Docker-internal host and failed before reaching the service:

```
POST http://agenta-agent:8000/v0/invoke/inspect  ->  net::ERR_NAME_NOT_RESOLVED
The agent run failed — Failed to fetch
```

## Root cause

Builtin app/evaluator service URLs are deterministic from the URI
(`{AGENTA_SERVICES_URL}/{key}/{version}`). The backend was supposed to never store a URL
for them — but the read path (`_normalize_revision_for_read`, `_get_service_url`,
`_build_simple_workflow_data`) only recomputed the URL when `data.url` was *empty*, and
the commit path only *skipped* setting one (it never stripped an incoming value).

On 2026-06-29 an agent self-update via the `commit_revision` platform op persisted
`data.url = http://agenta-agent:8000/v0/invoke` (the agent service's internal address)
onto a builtin agent revision. Because that value was non-empty, the API served it
verbatim, and the browser cannot resolve `agenta-agent`. Stored DB values confirmed it:

```
agenta:builtin:agent:v0 | http://agenta-agent:8000/v0/invoke   (v7-v9, agent QA self-commits)
agenta:builtin:agent:v0 | http://144.76.237.122:8280/services/agent/v0   (v2, v6, UI)
```

The FE workaround added in #4936 (`invocationUrlAtomFamily` routing builtins through
`resolveBuiltinAppServiceUrl`) only ever covered `completion`/`chat`, never `agent`, so it
did **not** fix the broken case — and it was unnecessary for completion/chat, which had
run for ~3 months on the plain `data.url` path since #3883 removed that helper from invoke.

## Change

- **Backend (root cause):** add `_resolve_service_url`, which always recomputes the
  canonical URL from the URI for builtin apps/evaluators (ignoring any stored value), and
  keeps the stored value for non-builtin (custom) workflows. Use it on all read paths. On
  commit, drop any incoming `data.url` for builtin apps so a bad value is never persisted
  again.
- **Frontend:** revert the #4936 `invocationUrlAtomFamily` hunk so builtins use the normal
  `data.url` / URI path. (`resolveBuiltinAppServiceUrl` stays; it is still used by
  `deploymentUrlAtomFamily` and `store.ts`.)

## Verification

- New unit test `test_service_url_resolution.py` (8 cases) + existing
  `test_retrieve_resolve.py` green.
- Live EE dev stack: the previously broken agent revision (v9, project `pi-agents`) now
  invokes against `http://144.76.237.122:8280/services/agent/v0/invoke` → **HTTP 200**.
  The run executes end to end; the only remaining failure is a downstream Anthropic model
  error (`"thinking.type.enabled" is not supported for this model`), unrelated to this fix.

https://claude.ai/code/session_014emxsaD8EFiNP3m3f56nhD
