### PR TITLE
feat(store): AGENTA_STORE_NAMESPACE — share one bucket across environments

### DIFF
--- a/api/entrypoints/routers.py
+++ b/api/entrypoints/routers.py
@@ -835,8 +835,9 @@ store = ObjectStore(
 
 mounts_service = MountsService(
     mounts_dao=mounts_dao,
-    mount_storage=store,
+    mounts_store=store,
     bucket=env.store.bucket,
+    namespace=env.store.namespace,
 )
 
 session_mounts_service = SessionMountsService(

--- a/api/oss/src/core/mounts/service.py
+++ b/api/oss/src/core/mounts/service.py
@@ -88,16 +88,28 @@ class MountsService:
         self,
         *,
         mounts_dao: MountsDAOInterface,
-        mount_storage: Optional[ObjectStore] = None,
+        mounts_store: Optional[ObjectStore] = None,
         bucket: Optional[str] = None,
+        namespace: Optional[str] = None,
     ):
         self.mounts_dao = mounts_dao
-        self.mount_storage = mount_storage
+        self.mounts_store = mounts_store
         self.bucket = bucket
+        self.namespace = namespace
 
     def _storage_key(self, *, project_id: UUID, mount: Mount, path: str = "") -> str:
-        """Object-key prefix for a mount: mounts/<project_id>/<mount_id>/<path>."""
-        base = f"mounts/{project_id}/{mount.id}"
+        """Object-key prefix for a mount: [<namespace>/]mounts/<project_id>/<mount_id>/<path>.
+
+        The optional namespace is the per-deployment "database" prefix that lets ephemeral
+        environments share one bucket; it is omitted entirely when unset, so a dedicated-bucket
+        deploy keeps the byte-identical `mounts/...` layout (no empty leading segment).
+        """
+        ns = (self.namespace or "").strip("/")
+        base = (
+            f"{ns}/mounts/{project_id}/{mount.id}"
+            if ns
+            else f"mounts/{project_id}/{mount.id}"
+        )
         return f"{base}/{path.lstrip('/')}" if path else f"{base}/"
 
     async def create_mount(
@@ -265,7 +277,7 @@ class MountsService:
         The master key signs the STS request API-side and never leaves; the returned
         key pair + session token are scoped to this mount's prefix and expire in minutes.
         """
-        if self.mount_storage is None:
+        if self.mounts_store is None:
             raise MountStorageUnavailable()
 
         mount = await self._resolve_mount(project_id=project_id, mount_id=mount_id)
@@ -273,14 +285,14 @@ class MountsService:
         # `<project_id>/<mount_id>` — the durable prefix, slug-independent (no trailing slash).
         prefix = self._storage_key(project_id=project_id, mount=mount).rstrip("/")
 
-        creds = await self.mount_storage.sign_temp_credentials(
+        creds = await self.mounts_store.sign_temp_credentials(
             bucket=bucket,
             prefix=prefix,
             duration_seconds=duration_seconds,
         )
         return MountCredentials(
-            endpoint=self.mount_storage.endpoint_url,
-            region=self.mount_storage.region,
+            endpoint=self.mounts_store.endpoint_url,
+            region=self.mounts_store.region,
             bucket=bucket,
             prefix=prefix,
             access_key=creds.access_key,
@@ -307,7 +319,7 @@ class MountsService:
             ).rstrip("/")
 
         list_prefix = prefix + "/"
-        objects = await self.mount_storage.list_objects_v2(
+        objects = await self.mounts_store.list_objects_v2(
             bucket=self._bucket(),
             prefix=list_prefix,
         )
@@ -344,7 +356,7 @@ class MountsService:
         mount = await self._resolve_mount(project_id=project_id, mount_id=mount_id)
 
         key = self._storage_key(project_id=project_id, mount=mount, path=path)
-        return await self.mount_storage.get_object(bucket=self._bucket(), key=key)
+        return await self.mounts_store.get_object(bucket=self._bucket(), key=key)
 
     async def read_file(
         self,
@@ -373,7 +385,7 @@ class MountsService:
         mount = await self._resolve_mount(project_id=project_id, mount_id=mount_id)
 
         key = self._storage_key(project_id=project_id, mount=mount, path=path)
-        size = await self.mount_storage.put_object(
+        size = await self.mounts_store.put_object(
             bucket=self._bucket(),
             key=key,
             body=content,
@@ -394,7 +406,7 @@ class MountsService:
         # is the S3 console convention for an explicit empty folder.
         folder = path.strip("/")
         key = self._storage_key(project_id=project_id, mount=mount, path=folder) + "/"
-        await self.mount_storage.put_object(
+        await self.mounts_store.put_object(
             bucket=self._bucket(),
             key=key,
             body=b"",
@@ -419,14 +431,14 @@ class MountsService:
         folder_prefix = exact_key + "/"
         bucket = self._bucket()
 
-        objects = await self.mount_storage.list_objects_v2(
+        objects = await self.mounts_store.list_objects_v2(
             bucket=bucket,
             prefix=folder_prefix,
         )
         keys = [key for key, _ in objects]
 
         # The exact file (or the folder marker) may also exist alongside contents.
-        single = await self.mount_storage.list_objects_v2(
+        single = await self.mounts_store.list_objects_v2(
             bucket=bucket,
             prefix=exact_key,
         )
@@ -437,7 +449,7 @@ class MountsService:
         if not unique_keys:
             raise MountFileNotFound()
 
-        count = await self.mount_storage.delete_keys(
+        count = await self.mounts_store.delete_keys(
             bucket=bucket,
             keys=unique_keys,
         )

--- a/api/oss/src/utils/env.py
+++ b/api/oss/src/utils/env.py
@@ -865,6 +865,7 @@ class StoreConfig(BaseModel):
     secret_key: str | None = os.getenv("AGENTA_STORE_SECRET_KEY")
     region: str = os.getenv("AGENTA_STORE_REGION", "us-east-1")
     bucket: str | None = os.getenv("AGENTA_STORE_BUCKET") or "agenta-store"
+    namespace: str | None = os.getenv("AGENTA_STORE_NAMESPACE") or None
 
     # AssumeRoleWithWebIdentity issuer (SeaweedFS only): the in-network API URL the store's OIDC
     # IAM uses to fetch our JWKS, and the RSA key signing the web-identity token. The key falls

--- a/api/oss/tests/pytest/unit/test_mounts_file_ops.py
+++ b/api/oss/tests/pytest/unit/test_mounts_file_ops.py
@@ -123,7 +123,7 @@ def _make_mount() -> Mount:
 def _make_service(mount: Mount) -> Tuple[MountsService, UUID, UUID]:
     service = MountsService(
         mounts_dao=_StubDAO(mount),
-        mount_storage=FakeMountStorage(),
+        mounts_store=FakeMountStorage(),
         bucket=_BUCKET,
     )
     return service, mount.project_id, mount.id
@@ -169,7 +169,7 @@ class TestMountFileOpsRoundtrip:
         await service.write_file(
             project_id=pid, mount_id=mid, path="notes.txt", content=b"x"
         )
-        stored_keys = list(service.mount_storage._store[_BUCKET].keys())
+        stored_keys = list(service.mounts_store._store[_BUCKET].keys())
         # Key is derived from identity: mounts/<project_id>/<mount_id>/<path>.
         assert stored_keys == [f"mounts/{pid}/{mid}/notes.txt"]
 

--- a/api/oss/tests/pytest/unit/test_mounts_injection.py
+++ b/api/oss/tests/pytest/unit/test_mounts_injection.py
@@ -93,10 +93,15 @@ class _UpsertDAO:
         return None
 
 
-def _make_service():
+def _make_service(namespace=None):
     dao = _UpsertDAO()
     storage = _FakeStorage()
-    service = MountsService(mounts_dao=dao, mount_storage=storage, bucket=_BUCKET)
+    service = MountsService(
+        mounts_dao=dao,
+        mounts_store=storage,
+        bucket=_BUCKET,
+        namespace=namespace,
+    )
     return service, dao, storage
 
 
@@ -169,6 +174,35 @@ class TestSignMountCredentials:
         assert creds.prefix == f"mounts/{pid}/{mount.id}"
         assert creds.bucket == _BUCKET
 
+    async def test_namespace_prefixes_the_signed_scope(self):
+        # A store namespace ("database") carves the shared bucket: the STS scope, and thus the
+        # signed credential, is anchored at <namespace>/mounts/<pid>/<mid> — the mount row stays
+        # the leaf, so isolation is unchanged, only qualified one level deeper.
+        service, _, storage = _make_service(namespace="env-ephemeral-42")
+        pid, uid = uuid4(), uuid4()
+        mount = await service.get_or_create_session_cwd(
+            project_id=pid, user_id=uid, session_id="sess-1"
+        )
+
+        creds = await service.sign_mount_credentials(project_id=pid, mount_id=mount.id)
+
+        expected = f"env-ephemeral-42/mounts/{pid}/{mount.id}"
+        assert storage.signed_with["prefix"] == expected
+        assert creds.prefix == expected
+
+    async def test_no_namespace_keeps_byte_identical_layout(self):
+        # Unset namespace must not introduce an empty leading segment (no "/mounts/...").
+        service, _, storage = _make_service(namespace=None)
+        pid, uid = uuid4(), uuid4()
+        mount = await service.get_or_create_session_cwd(
+            project_id=pid, user_id=uid, session_id="sess-1"
+        )
+
+        await service.sign_mount_credentials(project_id=pid, mount_id=mount.id)
+
+        assert storage.signed_with["prefix"] == f"mounts/{pid}/{mount.id}"
+        assert not storage.signed_with["prefix"].startswith("/")
+
     async def test_returns_scoped_not_master_credentials(self):
         service, _, _ = _make_service()
         pid, uid = uuid4(), uuid4()
@@ -199,7 +233,7 @@ class TestSignMountCredentials:
 
     async def test_unavailable_without_storage(self):
         dao = _UpsertDAO()
-        service = MountsService(mounts_dao=dao, mount_storage=None, bucket=_BUCKET)
+        service = MountsService(mounts_dao=dao, mounts_store=None, bucket=_BUCKET)
         pid, uid = uuid4(), uuid4()
         mount = await dao.upsert_mount(
             project_id=pid,

--- a/docs/docs/self-host/02-configuration.mdx
+++ b/docs/docs/self-host/02-configuration.mdx
@@ -164,6 +164,7 @@ reach the sandbox, which mounts the durable prefix as its working directory.
 | `AGENTA_STORE_SECRET_KEY` | `store.secret_key` | `store.secretKey` |
 | `AGENTA_STORE_REGION` | `store.region` | `store.region` |
 | `AGENTA_STORE_BUCKET` | `store.bucket` | `store.bucket` |
+| `AGENTA_STORE_NAMESPACE` | `store.namespace` | `store.namespace` |
 | `AGENTA_STORE_SIGNING_KEY` | n/a (store-side) | `store.signingKey` |
 | `AGENTA_STORE_JWT_ISSUER` | `store.jwt_issuer` | `store.jwtIssuer` |
 | `AGENTA_STORE_JWT_PRIVATE_KEY` | `store.jwt_private_key` | `store.jwtPrivateKey` |
@@ -172,6 +173,20 @@ reach the sandbox, which mounts the durable prefix as its working directory.
 `store.seaweedfs.enabled=true` bundles a SeaweedFS StatefulSet and auto-populates
 `store.endpointUrl`. Set it to `false` and supply `store.endpointUrl` to use an external
 S3-compatible store. This toggle mirrors `postgresql.enabled`.
+
+:::note `AGENTA_STORE_NAMESPACE` — sharing one bucket across environments
+The key layout treats the store as a small database: the **bucket** is the cluster, an optional
+**namespace** is the database, the entity prefix (`mounts/`) is the table, and `<project>/<mount>`
+is the row — so a full key is `<bucket>/[<namespace>/]mounts/<project_id>/<mount_id>/...`.
+
+Leave `NAMESPACE` unset for a dedicated bucket; the key layout is then identical to a single-tenant
+store (no empty leading segment). Set it — typically to a deployment or environment id — when
+several **ephemeral environments share one bucket**. Each environment's keys are prefixed with its
+namespace, and the short-lived credentials the API signs are scoped to that namespace, so one
+environment can never read or write another's objects even though they live in the same bucket.
+The namespace narrows the credential scope; it never widens it, and it is orthogonal to the store
+backend (it works on real S3/R2 and on bundled SeaweedFS alike).
+:::
 
 :::note SeaweedFS-only STS settings (real S3/R2 ignore these)
 `SIGNING_KEY`, `JWT_ISSUER`, and `JWT_PRIVATE_KEY` configure how the **bundled SeaweedFS** serves

--- a/hosting/docker-compose/ee/env.ee.dev.example
+++ b/hosting/docker-compose/ee/env.ee.dev.example
@@ -291,25 +291,16 @@ POSTHOG_API_KEY=phc_3urGRy5TL1HhaHnRYL0JSHxJxigRVackhphHtozUmdp
 # ================================================================== #
 # Object store (durable session mounts)
 # ================================================================== #
-# Durable object store for session/agent mounts. The bundled SeaweedFS store works with zero
-# config — every var below has a default (in code for the API, on the seaweedfs service for the
-# store), so only the keys need filling. Commented lines show the default; uncomment to override
-# and point at real S3 / R2 / MinIO (an empty endpoint = real AWS S3).
-#
-# ACCESS_KEY / SECRET_KEY are the only required values (the bundled store accepts any pair in dev).
+# Durable S3-compatible store for session/agent mounts. The bundled SeaweedFS store is zero-config
+# (every var has a default); only the keys need filling. Docs: https://docs.agenta.ai/self-host/configuration#store-durable-object-store
+# Required: ACCESS_KEY / SECRET_KEY. Commented lines show defaults.
 AGENTA_STORE_ACCESS_KEY=replace-me
 AGENTA_STORE_SECRET_KEY=replace-me
 # AGENTA_STORE_ENDPOINT_URL=http://seaweedfs:8333
 # AGENTA_STORE_REGION=us-east-1
 # AGENTA_STORE_BUCKET=agenta-store
-# SeaweedFS-only (real S3/R2 serve STS natively, ignore these):
-# - SIGNING_KEY: the HMAC key SeaweedFS signs its STS session tokens with. base64 of EXACTLY
-#   32 bytes or STS is silently disabled. Default shown; regenerate: `head -c 32 /dev/urandom | base64`.
+# AGENTA_STORE_NAMESPACE=
+# SeaweedFS-only (real S3/R2 serve STS natively):
 # AGENTA_STORE_SIGNING_KEY=dGhpcy1pcy1hLXNpZ25pbmcta2V5LWZvci1tb3VudHM=
-# - JWT_ISSUER: the in-network API URL SeaweedFS's OIDC IAM fetches the JWKS from to verify the
-#   API's RS256 web-identity token (AssumeRoleWithWebIdentity).
 # AGENTA_STORE_JWT_ISSUER=http://api:8000
-# - JWT_PRIVATE_KEY: RSA PEM signing that token. Unset = local-dev fallback baked into the code;
-#   preview/prod MUST set a stable PEM (PKCS#8) so the JWKS is consistent across replicas.
-#   Generate one: `openssl genpkey -algorithm RSA -pkeyopt rsa_keygen_bits:2048`
 # AGENTA_STORE_JWT_PRIVATE_KEY="-----BEGIN PRIVATE KEY-----\n...\n-----END PRIVATE KEY-----"

--- a/hosting/docker-compose/ee/env.ee.gh.example
+++ b/hosting/docker-compose/ee/env.ee.gh.example
@@ -292,24 +292,16 @@ POSTHOG_API_KEY=phc_3urGRy5TL1HhaHnRYL0JSHxJxigRVackhphHtozUmdp
 # ================================================================== #
 # Object store (durable session mounts)
 # ================================================================== #
-# Durable object store for session/agent mounts. Point these at your S3-compatible store (AWS S3
-# / Cloudflare R2 / MinIO / SeaweedFS). Endpoint defaults to real AWS S3 (empty); set it to the
-# gateway URL for any other store. Mounts stay disabled until ACCESS_KEY/SECRET_KEY are set.
-#
-# ACCESS_KEY / SECRET_KEY are the only required values.
+# Durable S3-compatible store for session/agent mounts. Docs (vars, SeaweedFS setup, namespaces):
+# https://docs.agenta.ai/self-host/configuration#store-durable-object-store
+# Required: ACCESS_KEY / SECRET_KEY. Commented lines show defaults.
 AGENTA_STORE_ACCESS_KEY=replace-me
 AGENTA_STORE_SECRET_KEY=replace-me
 # AGENTA_STORE_ENDPOINT_URL=
 # AGENTA_STORE_REGION=us-east-1
 # AGENTA_STORE_BUCKET=agenta-store
-# SeaweedFS-only (real S3/R2 serve STS natively, ignore these). A self-hosted-SeaweedFS deploy
-# must set all three — unlike dev, there are no bundled-store defaults here:
-# - SIGNING_KEY: the HMAC key SeaweedFS signs its STS session tokens with. base64 of EXACTLY
-#   32 bytes or STS is silently disabled. Generate: `head -c 32 /dev/urandom | base64`.
+# AGENTA_STORE_NAMESPACE=
+# SeaweedFS-only (real S3/R2 serve STS natively). Self-hosted SeaweedFS must set all three:
 # AGENTA_STORE_SIGNING_KEY=
-# - JWT_ISSUER: the in-network API URL SeaweedFS's OIDC IAM fetches the JWKS from to verify the
-#   API's RS256 web-identity token (AssumeRoleWithWebIdentity).
 # AGENTA_STORE_JWT_ISSUER=http://api:8000
-# - JWT_PRIVATE_KEY: a STABLE RSA PEM (PKCS#8) signing that token — REQUIRED in prod so every API
-#   replica shares one key. Generate: `openssl genpkey -algorithm RSA -pkeyopt rsa_keygen_bits:2048`
 # AGENTA_STORE_JWT_PRIVATE_KEY="-----BEGIN PRIVATE KEY-----\n...\n-----END PRIVATE KEY-----"

--- a/hosting/docker-compose/oss/env.oss.dev.example
+++ b/hosting/docker-compose/oss/env.oss.dev.example
@@ -291,25 +291,16 @@ POSTHOG_API_KEY=phc_hmVSxIjTW1REBHXgj2aw4HW9X6CXb6FzerBgP9XenC7
 # ================================================================== #
 # Object store (durable session mounts)
 # ================================================================== #
-# Durable object store for session/agent mounts. The bundled SeaweedFS store works with zero
-# config — every var below has a default (in code for the API, on the seaweedfs service for the
-# store), so only the keys need filling. Commented lines show the default; uncomment to override
-# and point at real S3 / R2 / MinIO (an empty endpoint = real AWS S3).
-#
-# ACCESS_KEY / SECRET_KEY are the only required values (the bundled store accepts any pair in dev).
+# Durable S3-compatible store for session/agent mounts. The bundled SeaweedFS store is zero-config
+# (every var has a default); only the keys need filling. Docs: https://docs.agenta.ai/self-host/configuration#store-durable-object-store
+# Required: ACCESS_KEY / SECRET_KEY. Commented lines show defaults.
 AGENTA_STORE_ACCESS_KEY=replace-me
 AGENTA_STORE_SECRET_KEY=replace-me
 # AGENTA_STORE_ENDPOINT_URL=http://seaweedfs:8333
 # AGENTA_STORE_REGION=us-east-1
 # AGENTA_STORE_BUCKET=agenta-store
-# SeaweedFS-only (real S3/R2 serve STS natively, ignore these):
-# - SIGNING_KEY: the HMAC key SeaweedFS signs its STS session tokens with. base64 of EXACTLY
-#   32 bytes or STS is silently disabled. Default shown; regenerate: `head -c 32 /dev/urandom | base64`.
+# AGENTA_STORE_NAMESPACE=
+# SeaweedFS-only (real S3/R2 serve STS natively):
 # AGENTA_STORE_SIGNING_KEY=dGhpcy1pcy1hLXNpZ25pbmcta2V5LWZvci1tb3VudHM=
-# - JWT_ISSUER: the in-network API URL SeaweedFS's OIDC IAM fetches the JWKS from to verify the
-#   API's RS256 web-identity token (AssumeRoleWithWebIdentity).
 # AGENTA_STORE_JWT_ISSUER=http://api:8000
-# - JWT_PRIVATE_KEY: RSA PEM signing that token. Unset = local-dev fallback baked into the code;
-#   preview/prod MUST set a stable PEM (PKCS#8) so the JWKS is consistent across replicas.
-#   Generate one: `openssl genpkey -algorithm RSA -pkeyopt rsa_keygen_bits:2048`
 # AGENTA_STORE_JWT_PRIVATE_KEY="-----BEGIN PRIVATE KEY-----\n...\n-----END PRIVATE KEY-----"

--- a/hosting/docker-compose/oss/env.oss.gh.example
+++ b/hosting/docker-compose/oss/env.oss.gh.example
@@ -292,24 +292,16 @@ POSTHOG_API_KEY=phc_hmVSxIjTW1REBHXgj2aw4HW9X6CXb6FzerBgP9XenC7
 # ================================================================== #
 # Object store (durable session mounts)
 # ================================================================== #
-# Durable object store for session/agent mounts. Point these at your S3-compatible store (AWS S3
-# / Cloudflare R2 / MinIO / SeaweedFS). Endpoint defaults to real AWS S3 (empty); set it to the
-# gateway URL for any other store. Mounts stay disabled until ACCESS_KEY/SECRET_KEY are set.
-#
-# ACCESS_KEY / SECRET_KEY are the only required values.
+# Durable S3-compatible store for session/agent mounts. Docs (vars, SeaweedFS setup, namespaces):
+# https://docs.agenta.ai/self-host/configuration#store-durable-object-store
+# Required: ACCESS_KEY / SECRET_KEY. Commented lines show defaults.
 AGENTA_STORE_ACCESS_KEY=replace-me
 AGENTA_STORE_SECRET_KEY=replace-me
 # AGENTA_STORE_ENDPOINT_URL=
 # AGENTA_STORE_REGION=us-east-1
 # AGENTA_STORE_BUCKET=agenta-store
-# SeaweedFS-only (real S3/R2 serve STS natively, ignore these). A self-hosted-SeaweedFS deploy
-# must set all three — unlike dev, there are no bundled-store defaults here:
-# - SIGNING_KEY: the HMAC key SeaweedFS signs its STS session tokens with. base64 of EXACTLY
-#   32 bytes or STS is silently disabled. Generate: `head -c 32 /dev/urandom | base64`.
+# AGENTA_STORE_NAMESPACE=
+# SeaweedFS-only (real S3/R2 serve STS natively). Self-hosted SeaweedFS must set all three:
 # AGENTA_STORE_SIGNING_KEY=
-# - JWT_ISSUER: the in-network API URL SeaweedFS's OIDC IAM fetches the JWKS from to verify the
-#   API's RS256 web-identity token (AssumeRoleWithWebIdentity).
 # AGENTA_STORE_JWT_ISSUER=http://api:8000
-# - JWT_PRIVATE_KEY: a STABLE RSA PEM (PKCS#8) signing that token — REQUIRED in prod so every API
-#   replica shares one key. Generate: `openssl genpkey -algorithm RSA -pkeyopt rsa_keygen_bits:2048`
 # AGENTA_STORE_JWT_PRIVATE_KEY="-----BEGIN PRIVATE KEY-----\n...\n-----END PRIVATE KEY-----"

--- a/hosting/kubernetes/ee/values.ee.example.yaml
+++ b/hosting/kubernetes/ee/values.ee.example.yaml
@@ -515,6 +515,7 @@ posthog:
 #   secretKey:
 #   region:
 #   bucket:
+#   namespace:  # optional key prefix to share one bucket across ephemeral envs; unset for a dedicated bucket
 #   signingKey:
 #   jwtIssuer:
 #   jwtPrivateKey:

--- a/hosting/kubernetes/helm/templates/_helpers.tpl
+++ b/hosting/kubernetes/helm/templates/_helpers.tpl
@@ -877,6 +877,10 @@ imagePullSecrets:
   value: {{ default "us-east-1" $store.region | quote }}
 - name: AGENTA_STORE_BUCKET
   value: {{ default "agenta-store" $store.bucket | quote }}
+{{- if $store.namespace }}
+- name: AGENTA_STORE_NAMESPACE
+  value: {{ $store.namespace | quote }}
+{{- end }}
 - name: AGENTA_STORE_ACCESS_KEY
   valueFrom:
     secretKeyRef:

--- a/hosting/kubernetes/helm/values.schema.json
+++ b/hosting/kubernetes/helm/values.schema.json
@@ -269,6 +269,7 @@
         "secretKey":   { "type": "string", "description": "AGENTA_STORE_SECRET_KEY via Secret." },
         "region":      { "type": "string", "description": "AGENTA_STORE_REGION." },
         "bucket":      { "type": "string", "description": "AGENTA_STORE_BUCKET." },
+        "namespace":   { "type": "string", "description": "AGENTA_STORE_NAMESPACE. Optional global key prefix (\"database\") to share one bucket across ephemeral environments; unset for a dedicated bucket." },
         "signingKey":  { "type": "string", "description": "AGENTA_STORE_SIGNING_KEY via Secret. SeaweedFS-only STS signing key (base64 of 32 bytes)." },
         "jwtIssuer":   { "type": "string", "description": "AGENTA_STORE_JWT_ISSUER. SeaweedFS-only: in-cluster API URL SeaweedFS fetches the JWKS from. Defaults to http://<release>-api:<api.port>." },
         "jwtPrivateKey": { "type": "string", "description": "AGENTA_STORE_JWT_PRIVATE_KEY via Secret. SeaweedFS-only: stable RSA PEM (PKCS#8) the API signs its web-identity token with; required so all API replicas share one key." },

--- a/hosting/kubernetes/helm/values.yaml
+++ b/hosting/kubernetes/helm/values.yaml
@@ -126,6 +126,7 @@ redisDurable:
 #   secretKey:
 #   region:
 #   bucket:
+#   namespace:  # optional key prefix ("database") to share one bucket across ephemeral envs; unset for a dedicated bucket
 #   signingKey:
 #   jwtIssuer:
 #   jwtPrivateKey:

--- a/hosting/kubernetes/oss/values.oss.example.yaml
+++ b/hosting/kubernetes/oss/values.oss.example.yaml
@@ -512,6 +512,7 @@ posthog:
 #   secretKey:
 #   region:
 #   bucket:
+#   namespace:  # optional key prefix to share one bucket across ephemeral envs; unset for a dedicated bucket
 #   signingKey:
 #   jwtIssuer:
 #   jwtPrivateKey:

--- a/hosting/railway/oss/scripts/configure.sh
+++ b/hosting/railway/oss/scripts/configure.sh
@@ -266,7 +266,8 @@ main() {
     unset_vars api AGENTA_LICENSE PORT SCRIPT_NAME REDIS_URI REDIS_URI_VOLATILE REDIS_URI_DURABLE SUPERTOKENS_CONNECTION_URI AGENTA_API_INTERNAL_URL ALEMBIC_CFG_PATH_CORE ALEMBIC_CFG_PATH_TRACING
 
     set_optional_vars api \
-        "COMPOSIO_API_KEY=${COMPOSIO_API_KEY:-}"
+        "COMPOSIO_API_KEY=${COMPOSIO_API_KEY:-}" \
+        "AGENTA_STORE_NAMESPACE=${AGENTA_STORE_NAMESPACE:-}"
 
     # The bundled store's entrypoint reads these to generate s3.json + iam.json. JWT_ISSUER is
     # the API URL its OIDC IAM fetches the JWKS from (it does NOT hold the private key).


### PR DESCRIPTION
## Context

The durable object store now backs every deployment surface (compose, Helm, Railway) after the Part I platform cleanup. It assumed a dedicated bucket per deployment. Ephemeral environments (previews) are cheaper to run against one shared bucket, but the key layout gave them no way to stay isolated inside it: every deployment wrote to the same `mounts/<project>/<mount>/...` root.

## Changes

**`AGENTA_STORE_NAMESPACE` — an optional global key prefix.** It carves one bucket into isolated logical databases. The key layout becomes `<bucket>/[<namespace>/]mounts/<project_id>/<mount_id>/...`, which reads as bucket = cluster, namespace = database, `mounts/` = table, `<project>/<mount>` = row.

The namespace is unset by default. A dedicated bucket keeps the byte-identical `mounts/...` layout — no empty leading segment, no migration. Set it (typically to a deployment/environment id) only when several ephemeral environments share one bucket.

Isolation moves with it for free. The namespace is prepended inside the single `_storage_key` builder, and that key is the exact string fed to the STS session policy. So a signed credential still scopes to one mount, now qualified one level deeper — an environment can never name a path outside its own namespace. The namespace narrows the credential scope; it never widens it, and it is orthogonal to the backend (works on real S3/R2 and bundled SeaweedFS alike).

Wired through every surface: `env.py` (`store.namespace`), `MountsService`, the compose env-file examples, Helm (`values` / `values.schema.json` / `_helpers.tpl`, emitted only when set), and Railway `configure.sh` (pass-through, omitted when empty).

**Two cleanups riding along.** The `MountsService` param `mount_storage` is renamed to `mounts_store` for consistency with the store generalization. And the bloated store-setup prose (SeaweedFS STS mechanism, key generation, shared-key-in-prod requirement) is moved out of the four env-file examples into the self-host configuration reference; the env files now point at the docs anchor and carry only the vars.

## Tests / notes

- Two new unit tests: the namespace prefixes the signed STS scope, and an unset namespace keeps the byte-identical `mounts/...` layout with no leading `/`. Full mounts suite green (39 passed).
- `helm template` renders `AGENTA_STORE_NAMESPACE` into API pods when `store.namespace` is set and omits it entirely when unset; `values.schema.json` (`additionalProperties: false`) declares the new key. `ruff format` / `ruff check` clean.
- Base is `big-agents` (this branch was cut from the up-to-date tip after PR #4968 merged).
