### PR TITLE
fix(frontend): dark-mode the playground build kit by reusing ItemRow

### DIFF
--- a/web/packages/agenta-entity-ui/src/DrillInView/SchemaControls/agentTemplate/ItemRow.tsx
+++ b/web/packages/agenta-entity-ui/src/DrillInView/SchemaControls/agentTemplate/ItemRow.tsx
@@ -3,6 +3,7 @@
  * tool/MCP/skill row, and the richer instructions-file row. All are dumb — they render an
  * {@link ItemDescriptor} and call back on open/remove; the section owners hold the state.
  */
+import {cn} from "@agenta/ui/styles"
 import {CaretRight, Trash} from "@phosphor-icons/react"
 import {Tag, Typography} from "antd"
 
@@ -23,30 +24,45 @@ export function ItemAvatar({descriptor}: {descriptor: ItemDescriptor}) {
 /**
  * A config-item row (a tool or MCP server): type avatar, name + description, type tags, and a
  * chevron. The whole row opens the item drawer; remove appears on hover.
+ *
+ * `locked` renders a read-only variant (muted fill, a "Locked" tag, no chevron/remove and no
+ * interaction) — used for platform-owned items that can be shown but not edited, e.g. the
+ * playground build kit. Passing no `onEdit` also makes the row non-interactive.
  */
 export function ItemRow({
     descriptor,
     onEdit,
     onRemove,
     disabled,
+    locked,
 }: {
     descriptor: ItemDescriptor
-    onEdit: () => void
+    onEdit?: () => void
     onRemove?: () => void
     disabled?: boolean
+    locked?: boolean
 }) {
+    const interactive = Boolean(onEdit) && !locked
     return (
         <div
-            role="button"
-            tabIndex={0}
-            onClick={onEdit}
-            onKeyDown={(e) => {
-                if (e.key === "Enter" || e.key === " ") {
-                    e.preventDefault()
-                    onEdit()
-                }
-            }}
-            className="group flex cursor-pointer items-center gap-2.5 rounded border border-solid border-[var(--ag-c-EAEFF5,#eaeff5)] px-3 py-2 transition-colors hover:border-[var(--ag-c-97A4B0,#97a4b0)]"
+            role={interactive ? "button" : undefined}
+            tabIndex={interactive ? 0 : undefined}
+            onClick={interactive ? onEdit : undefined}
+            onKeyDown={
+                interactive
+                    ? (e) => {
+                          if (e.key === "Enter" || e.key === " ") {
+                              e.preventDefault()
+                              onEdit?.()
+                          }
+                      }
+                    : undefined
+            }
+            className={cn(
+                "group flex items-center gap-2.5 rounded border border-solid border-[var(--ag-c-EAEFF5,#eaeff5)] px-3 py-2 transition-colors",
+                interactive && "cursor-pointer hover:border-[var(--ag-c-97A4B0,#97a4b0)]",
+                locked && "bg-[var(--ant-color-fill-quaternary)] opacity-70",
+            )}
         >
             <ItemAvatar descriptor={descriptor} />
             <div className="min-w-0 flex-1">
@@ -66,7 +82,8 @@ export function ItemRow({
                         {tag}
                     </Tag>
                 ))}
-                {onRemove && !disabled ? (
+                {locked ? <Tag className="m-0 text-[11px]">Locked</Tag> : null}
+                {onRemove && !disabled && !locked ? (
                     <button
                         type="button"
                         aria-label="Remove"
@@ -79,7 +96,9 @@ export function ItemRow({
                         <Trash size={14} />
                     </button>
                 ) : null}
-                <CaretRight size={14} className="text-[var(--ag-c-97A4B0,#97a4b0)]" />
+                {interactive ? (
+                    <CaretRight size={14} className="text-[var(--ag-c-97A4B0,#97a4b0)]" />
+                ) : null}
             </div>
         </div>
     )

--- a/web/packages/agenta-entity-ui/src/DrillInView/SchemaControls/agentTemplate/useBuildKit.tsx
+++ b/web/packages/agenta-entity-ui/src/DrillInView/SchemaControls/agentTemplate/useBuildKit.tsx
@@ -26,7 +26,7 @@ import {Switch, Tag, Tooltip, Typography} from "antd"
 import {useAtom, useAtomValue} from "jotai"
 
 import {asObj, staticEmbedSlug, type ItemDescriptor} from "./itemDescriptors"
-import {ItemAvatar} from "./ItemRow"
+import {ItemRow} from "./ItemRow"
 
 /** Display name for an `@ag.embed` row: the overlay's sibling `name`, else the referenced
  * workflow's `name`, else undefined (callers fall back to the slug). */
@@ -35,33 +35,6 @@ function embedDisplayName(entry: Record<string, unknown>): string | undefined {
     const refs = asObj(asObj(entry["@ag.embed"])?.["@ag.references"])
     const wfName = asObj(refs?.workflow)?.name ?? asObj(refs?.workflow_revision)?.name
     return typeof wfName === "string" && wfName ? wfName : undefined
-}
-
-function ReadOnlyItemRow({descriptor}: {descriptor: ItemDescriptor}) {
-    return (
-        <div className="flex items-center gap-2.5 rounded border border-solid border-[var(--ag-c-EAEFF5,#eaeff5)] bg-[var(--ant-color-fill-quaternary)] px-3 py-2 opacity-70">
-            <ItemAvatar descriptor={descriptor} />
-            <div className="min-w-0 flex-1">
-                <div className="truncate font-mono text-xs font-medium">{descriptor.name}</div>
-                {descriptor.description ? (
-                    <Typography.Text
-                        type="secondary"
-                        className="block truncate text-xs leading-tight"
-                    >
-                        {descriptor.description}
-                    </Typography.Text>
-                ) : null}
-            </div>
-            <div className="flex shrink-0 items-center gap-1.5">
-                {descriptor.tags.map((tag) => (
-                    <Tag key={tag} className="m-0 text-[11px]">
-                        {tag}
-                    </Tag>
-                ))}
-                <Tag className="m-0 text-[11px]">Locked</Tag>
-            </div>
-        </div>
-    )
 }
 
 function isEmbedRefEntry(entry: unknown): entry is Record<string, unknown> {
@@ -190,7 +163,7 @@ export function useBuildKit({
     )
 
     const buildKitSection = hasBuildKitOverlay ? (
-        <div className="rounded border border-solid border-[var(--ag-c-EAEFF5,#eaeff5)] bg-[#fcfcfa]">
+        <div className="rounded border border-solid border-[var(--ag-c-EAEFF5,#eaeff5)]">
             <button
                 type="button"
                 aria-expanded={buildKitExpanded}
@@ -237,9 +210,10 @@ export function useBuildKit({
                                 Platform tools
                             </Typography.Text>
                             {platformOverlayTools.map((tool, index) => (
-                                <ReadOnlyItemRow
+                                <ItemRow
                                     key={`build-kit-platform-tool-${index}`}
                                     descriptor={describeBuildKitPlatformTool(tool)}
+                                    locked
                                 />
                             ))}
                         </div>
@@ -250,9 +224,10 @@ export function useBuildKit({
                                 Embedded tools
                             </Typography.Text>
                             {embeddedOverlayTools.map((tool, index) => (
-                                <ReadOnlyItemRow
+                                <ItemRow
                                     key={`build-kit-embedded-tool-${index}`}
                                     descriptor={describeBuildKitEmbed(tool, "tool")}
+                                    locked
                                 />
                             ))}
                         </div>
@@ -263,9 +238,10 @@ export function useBuildKit({
                                 Embedded skills
                             </Typography.Text>
                             {embeddedOverlaySkills.map((skill, index) => (
-                                <ReadOnlyItemRow
+                                <ItemRow
                                     key={`build-kit-embedded-skill-${index}`}
                                     descriptor={describeBuildKitEmbed(skill, "skill")}
+                                    locked
                                 />
                             ))}
                         </div>


### PR DESCRIPTION
## Problem

The **Playground build kit** block in the agent playground's Advanced config drawer broke in dark mode. The container hardcoded a near-white background (`bg-[#fcfcfa]`), so the card stayed light and its text rendered white-on-white (invisible). It also shipped a private `ReadOnlyItemRow` — a duplicate of the shared config-item row that already themes correctly.

## Before / After

| | Before | After |
|---|---|---|
| Dark mode | White card, invisible tool names | Themed card, legible rows |
| Row markup | Local `ReadOnlyItemRow` clone | Shared `ItemRow` |

## Changes

- **Extend the shared `ItemRow`** with a `locked` prop: muted fill, a "Locked" tag, no chevron/remove, non-interactive. `onEdit` is now optional so a non-clickable row is a first-class state.
- **Drop `ReadOnlyItemRow`** — platform tools, embedded tools, and embedded skills now render through the shared `ItemRow` with `locked`.
- **Remove the hardcoded background** so the card matches the sibling Advanced sections (Authentication / Execution environment / Permissions), which theme correctly in both light and dark.

Net: the build kit inherits theming from the shared `ItemRow` by construction, so parity with the tools config section is guaranteed rather than hand-maintained.

## Scope

Two files in `@agenta/entity-ui`: `ItemRow.tsx`, `useBuildKit.tsx`. No behavior change beyond styling and the read-only-row consolidation.
