### PR TITLE
feat(store): sign remote-S3 credentials with GetFederationToken

### DIFF
--- a/api/entrypoints/routers.py
+++ b/api/entrypoints/routers.py
@@ -831,6 +831,8 @@ store = ObjectStore(
     access_key=env.store.access_key,
     secret_key=env.store.secret_key,
     region=env.store.region,
+    sts_endpoint_url=env.store.sts_endpoint_url,
+    signing_key=env.store.signing_key,
 )
 
 mounts_service = MountsService(

--- a/api/oss/src/core/store/storage.py
+++ b/api/oss/src/core/store/storage.py
@@ -1,13 +1,15 @@
-from datetime import datetime
+from datetime import datetime, timezone
+from hashlib import sha256
 from io import BytesIO
 from json import dumps
 from typing import List, Optional, Tuple
-from urllib.parse import urlencode, urlparse
+from urllib.parse import urlencode, urlparse, urlsplit
 from xml.etree import ElementTree
 
 import aiohttp
 from miniopy_async import Minio
 from miniopy_async.credentials import Credentials
+from miniopy_async.signer import sign_v4_sts
 from miniopy_async.deleteobjects import DeleteObject
 from miniopy_async.error import S3Error
 
@@ -64,11 +66,15 @@ class ObjectStore:
         access_key: Optional[str],
         secret_key: Optional[str],
         region: str = "us-east-1",
+        sts_endpoint_url: Optional[str] = None,
+        signing_key: Optional[str] = None,
     ):
         self._endpoint_url = endpoint_url
         self._access_key = access_key
         self._secret_key = secret_key
         self._region = region
+        self._sts_endpoint_url = sts_endpoint_url
+        self._signing_key = signing_key
 
     @property
     def enabled(self) -> bool:
@@ -82,16 +88,19 @@ class ObjectStore:
     def region(self) -> str:
         return self._region
 
+    @property
+    def is_seaweedfs(self) -> bool:
+        # The bundled SeaweedFS store is the only backend that signs credentials through its
+        # OIDC IAM (AssumeRoleWithWebIdentity), which requires a SIGNING_KEY. A remote
+        # S3-compatible store (AWS, MinIO) has none and uses GetFederationToken instead.
+        return bool(self._signing_key)
+
     def _host_secure(self) -> Tuple[str, bool]:
-        # miniopy-async wants a scheme-less host:port plus a `secure` flag; an empty
-        # endpoint_url means real AWS S3 (the SDK default host, always TLS).
-        if self._endpoint_url:
-            parsed = urlparse(self._endpoint_url)
-            host = parsed.netloc or parsed.path
-            secure = parsed.scheme != "http"
-        else:
-            host = "s3.amazonaws.com"
-            secure = True
+        # miniopy-async wants a scheme-less host:port plus a `secure` flag. The endpoint is
+        # always explicit (SeaweedFS defaults it in env; a remote store must set it).
+        parsed = urlparse(self._endpoint_url or "")
+        host = parsed.netloc or parsed.path
+        secure = parsed.scheme != "http"
         return host, secure
 
     def _client(self) -> Minio:
@@ -123,8 +132,11 @@ class ObjectStore:
         """Inline STS session policy scoping credentials to one mount prefix.
 
         Three statements, and the split matters:
-          - ObjRW: object verbs on `<bucket>/<prefix>/*`. Includes the multipart verbs —
-            FUSE/geesefs uploads multipart, so omitting them denies large writes.
+          - ObjRW: object verbs on `<bucket>/<prefix>/*`. `s3:PutObject` authorizes the whole
+            multipart upload flow (CreateMultipartUpload / UploadPart / CompleteMultipartUpload
+            are S3 API calls, NOT distinct IAM actions — geesefs uploads multipart, but those
+            names are invalid in an AWS policy and would be rejected). Only Abort and
+            ListMultipartUploadParts exist as their own actions.
           - BktMeta: GetBucketLocation + ListBucketMultipartUploads, UNCONDITIONED. These
             are bucket-level preflights (the S3 client issues GetBucketLocation on first use);
             they carry no `s3:prefix`, so gating them on one denies the preflight and aborts
@@ -147,10 +159,6 @@ class ObjectStore:
                             "s3:PutObject",
                             "s3:DeleteObject",
                             "s3:GetObjectAttributes",
-                            "s3:CreateMultipartUpload",
-                            "s3:UploadPart",
-                            "s3:UploadPartCopy",
-                            "s3:CompleteMultipartUpload",
                             "s3:AbortMultipartUpload",
                             "s3:ListMultipartUploadParts",
                         ],
@@ -185,18 +193,21 @@ class ObjectStore:
     ) -> Credentials:
         """STS-sign short-lived credentials scoped to `<bucket>/<prefix>/*`.
 
-        Calls `AssumeRoleWithWebIdentity` on the store's STS endpoint with a short-lived
-        RS256 web-identity token the API mints and self-signs (the store's OIDC IAM fetches
-        our public JWKS to verify it — see core/store/webidentity.py). This is the only STS
-        path SeaweedFS's OIDC IAM authorizes; `GetFederationToken` yields actionless tokens.
+        Both backends narrow a bucket-wide identity to one mount prefix with the SAME inline
+        session `Policy` (see `_scope_policy`); only the STS verb differs, because the two
+        stores authorize different ones (backend chosen by SIGNING_KEY presence, see
+        `is_seaweedfs`):
 
-        The role grants the whole bucket; the inline session `Policy` narrows the credentials
-        to this one mount prefix (effective permission = role ∩ session). One shared bucket,
-        per-mount prefix isolation — identical on SeaweedFS and real S3.
+        - SeaweedFS: the API presents a self-minted RS256 web-identity token to the store's
+          OIDC IAM via `AssumeRoleWithWebIdentity` (see core/store/webidentity.py).
+          `GetFederationToken` is unusable there — SeaweedFS returns actionless tokens.
+        - Remote S3-compatible (AWS, MinIO): the API holds S3 credentials, so it calls
+          `GetFederationToken` — SigV4-signed with those keys — against the store's STS
+          endpoint (the S3 endpoint by default; AWS splits it onto `sts.<region>.*`).
 
-        Isolation rests ENTIRELY on that session policy being present: the role is bucket-wide,
-        so a token signed without the inline policy inherits the whole bucket (every tenant's
-        mount). Fail closed — refuse to sign when the policy cannot be built for a prefix.
+        Isolation rests ENTIRELY on the session policy being present: the identity is
+        bucket-wide, so a credential signed without the inline policy inherits the whole bucket
+        (every tenant's mount). Fail closed — refuse to sign when no prefix-scoped policy exists.
         """
         if not self.enabled:
             raise MountStorageUnavailable()
@@ -207,6 +218,14 @@ class ObjectStore:
                 "Refusing to sign store credentials without a prefix-scoped session policy."
             )
 
+        if self.is_seaweedfs:
+            return await self._sign_web_identity(scope_policy, duration_seconds)
+        return await self._sign_federation_token(scope_policy, duration_seconds)
+
+    async def _sign_web_identity(
+        self, scope_policy: str, duration_seconds: int
+    ) -> Credentials:
+        """SeaweedFS path: unauthenticated `AssumeRoleWithWebIdentity` against the store endpoint."""
         host, secure = self._host_secure()
         endpoint = f"{'https' if secure else 'http'}://{host}"
         body = urlencode(
@@ -231,6 +250,63 @@ class ObjectStore:
                 if resp.status != 200:
                     raise MountStorageUnavailable(
                         f"STS AssumeRoleWithWebIdentity failed ({resp.status})."
+                    )
+
+        return _parse_sts_credentials(text)
+
+    async def _sign_federation_token(
+        self, scope_policy: str, duration_seconds: int
+    ) -> Credentials:
+        """Remote-S3 path: SigV4-signed `GetFederationToken` against the store's STS endpoint.
+
+        The STS endpoint defaults to the S3 endpoint (MinIO co-locates STS there); AWS splits
+        it onto `sts.<region>.amazonaws.com`, set via AGENTA_STORE_STS_ENDPOINT_URL. Duration is
+        clamped to STS's 900s floor. The request is signed with the store's master keys; the
+        returned credentials carry only the inline `Policy`'s permissions.
+        """
+        endpoint = (self._sts_endpoint_url or self._endpoint_url or "").rstrip("/")
+        if not endpoint:
+            raise MountStorageUnavailable(
+                "Refusing to sign: no STS or S3 endpoint configured for the remote store."
+            )
+        body = urlencode(
+            {
+                "Action": "GetFederationToken",
+                "Version": "2011-06-15",
+                "Name": webidentity.STORE_SUBJECT,
+                "DurationSeconds": str(max(duration_seconds, 900)),
+                "Policy": scope_policy,
+            }
+        )
+        payload = body.encode()
+        content_sha256 = sha256(payload).hexdigest()
+        url = urlsplit(endpoint + "/")
+        now = datetime.now(timezone.utc)
+        headers = sign_v4_sts(
+            "POST",
+            url,
+            self._region,
+            {
+                "Host": url.netloc,
+                "Content-Type": "application/x-www-form-urlencoded",
+                "X-Amz-Date": now.strftime("%Y%m%dT%H%M%SZ"),
+            },
+            Credentials(
+                access_key=self._access_key,
+                secret_key=self._secret_key,
+            ),
+            content_sha256,
+            now,
+        )
+
+        async with aiohttp.ClientSession() as session:
+            async with session.post(
+                endpoint + "/", data=payload, headers=headers
+            ) as resp:
+                text = await resp.text()
+                if resp.status != 200:
+                    raise MountStorageUnavailable(
+                        f"STS GetFederationToken failed ({resp.status})."
                     )
 
         return _parse_sts_credentials(text)

--- a/api/oss/src/utils/env.py
+++ b/api/oss/src/utils/env.py
@@ -867,6 +867,16 @@ class StoreConfig(BaseModel):
     bucket: str | None = os.getenv("AGENTA_STORE_BUCKET") or "agenta-store"
     namespace: str | None = os.getenv("AGENTA_STORE_NAMESPACE") or None
 
+    # STS endpoint for the GetFederationToken path (non-SeaweedFS stores). Defaults to the S3
+    # endpoint (MinIO co-locates STS there); override only when the store splits STS onto
+    # another host (AWS: https://sts.<region>.amazonaws.com).
+    sts_endpoint_url: str | None = os.getenv("AGENTA_STORE_STS_ENDPOINT_URL") or None
+
+    # Backend selector: SIGNING_KEY present => bundled SeaweedFS (STS via OIDC/web-identity);
+    # absent => remote S3-compatible store (STS via GetFederationToken). Also passed to the
+    # bundled SeaweedFS as its STS HMAC key; the API only reads it to pick the signing path.
+    signing_key: str | None = os.getenv("AGENTA_STORE_SIGNING_KEY") or None
+
     # AssumeRoleWithWebIdentity issuer (SeaweedFS only): the in-network API URL the store's OIDC
     # IAM uses to fetch our JWKS, and the RSA key signing the web-identity token. The key falls
     # back to a baked-in local-dev key when unset (see core/store/webidentity.py).

--- a/api/oss/tests/pytest/unit/test_mounts_injection.py
+++ b/api/oss/tests/pytest/unit/test_mounts_injection.py
@@ -302,3 +302,137 @@ class TestStoragePolicyScope:
         assert creds.session_token == "scoped-token"
         # The scoped key is NOT the master key.
         assert creds.access_key != _MASTER_KEY
+
+
+# ---------------------------------------------------------------------------
+# STS backend fork (storage layer): remote AWS S3 vs bundled SeaweedFS
+# ---------------------------------------------------------------------------
+
+
+class _CapturingPost:
+    """Stand-in for aiohttp.ClientSession that captures the one POST and returns fixed XML."""
+
+    def __init__(self, xml: str):
+        self._xml = xml
+        self.url = None
+        self.data = None
+        self.headers = None
+
+    def post(self, url, data=None, headers=None):
+        self.url = url
+        self.data = data.decode() if isinstance(data, (bytes, bytearray)) else data
+        self.headers = headers
+        capturer = self
+
+        class _Resp:
+            status = 200
+
+            async def text(self):
+                return capturer._xml
+
+            async def __aenter__(self):
+                return self
+
+            async def __aexit__(self, *a):
+                return False
+
+        return _Resp()
+
+    async def __aenter__(self):
+        return self
+
+    async def __aexit__(self, *a):
+        return False
+
+
+_STS_XML = (
+    '<?xml version="1.0"?>'
+    '<GetFederationTokenResponse xmlns="https://sts.amazonaws.com/doc/2011-06-15/">'
+    "<GetFederationTokenResult><Credentials>"
+    "<AccessKeyId>ASIASCOPED</AccessKeyId>"
+    "<SecretAccessKey>scoped-secret</SecretAccessKey>"
+    "<SessionToken>scoped-token</SessionToken>"
+    "<Expiration>2026-06-30T08:00:00Z</Expiration>"
+    "</Credentials></GetFederationTokenResult></GetFederationTokenResponse>"
+)
+
+
+@pytest.mark.asyncio
+class TestStsBackendFork:
+    async def test_remote_s3_uses_signed_get_federation_token(self, monkeypatch):
+        import oss.src.core.store.storage as storage_mod
+        from oss.src.core.store.storage import ObjectStore
+
+        # No signing key => remote S3; explicit STS endpoint (AWS split host).
+        store = ObjectStore(
+            endpoint_url="https://s3.eu-central-1.amazonaws.com",
+            sts_endpoint_url="https://sts.eu-central-1.amazonaws.com",
+            access_key=_MASTER_KEY,
+            secret_key=_MASTER_SECRET,
+            region="eu-central-1",
+        )
+        assert store.is_seaweedfs is False
+
+        cap = _CapturingPost(_STS_XML)
+        monkeypatch.setattr(storage_mod.aiohttp, "ClientSession", lambda: cap)
+
+        creds = await store.sign_temp_credentials(
+            bucket=_BUCKET, prefix="ns/mounts/p/m", duration_seconds=900
+        )
+
+        # Posts to the configured STS endpoint, GetFederationToken, SigV4-signed with the key.
+        assert cap.url == "https://sts.eu-central-1.amazonaws.com/"
+        assert "Action=GetFederationToken" in cap.data
+        assert "Policy=" in cap.data
+        assert cap.headers["Authorization"].startswith("AWS4-HMAC-SHA256 Credential=")
+        assert "/eu-central-1/sts/aws4_request" in cap.headers["Authorization"]
+        # Scoped creds returned, not the master key.
+        assert creds.access_key == "ASIASCOPED"
+        assert creds.access_key != _MASTER_KEY
+
+    async def test_remote_s3_sts_defaults_to_s3_endpoint(self, monkeypatch):
+        import oss.src.core.store.storage as storage_mod
+        from oss.src.core.store.storage import ObjectStore
+
+        # No sts_endpoint_url => STS posts to the S3 endpoint (MinIO co-locates it).
+        store = ObjectStore(
+            endpoint_url="http://minio:9000",
+            access_key=_MASTER_KEY,
+            secret_key=_MASTER_SECRET,
+            region="us-east-1",
+        )
+        cap = _CapturingPost(_STS_XML)
+        monkeypatch.setattr(storage_mod.aiohttp, "ClientSession", lambda: cap)
+
+        await store.sign_temp_credentials(
+            bucket=_BUCKET, prefix="mounts/p/m", duration_seconds=60
+        )
+        assert cap.url == "http://minio:9000/"
+        assert "Action=GetFederationToken" in cap.data
+        assert "DurationSeconds=900" in cap.data
+
+    async def test_seaweedfs_uses_web_identity_against_endpoint(self, monkeypatch):
+        import oss.src.core.store.storage as storage_mod
+        from oss.src.core.store.storage import ObjectStore
+
+        # Signing key present => bundled SeaweedFS.
+        store = ObjectStore(
+            endpoint_url="http://seaweedfs:8333",
+            access_key=_MASTER_KEY,
+            secret_key=_MASTER_SECRET,
+            signing_key="dummy-signing-key",
+        )
+        assert store.is_seaweedfs is True
+
+        cap = _CapturingPost(_STS_XML)
+        monkeypatch.setattr(storage_mod.aiohttp, "ClientSession", lambda: cap)
+
+        await store.sign_temp_credentials(
+            bucket=_BUCKET, prefix="mounts/p/m", duration_seconds=900
+        )
+
+        # Web-identity, unauthenticated, posted to the store endpoint (not AWS STS).
+        assert cap.url == "http://seaweedfs:8333/"
+        assert "Action=AssumeRoleWithWebIdentity" in cap.data
+        assert "WebIdentityToken=" in cap.data
+        assert "Authorization" not in (cap.headers or {})


### PR DESCRIPTION
## Context

Durable mounts on preview and live run an external S3-compatible store, not the bundled SeaweedFS. But the store signed per-mount credentials only through `AssumeRoleWithWebIdentity` — the STS path SeaweedFS's OIDC IAM authorizes. A remote S3 store (AWS, MinIO) has no OIDC provider and does not model that call, so signing could never succeed there: preview/live mounts had no working credential path.

## Changes

The store now has two signing backends and picks between them from config, not a mode flag:

- **`AGENTA_STORE_SIGNING_KEY` present → bundled SeaweedFS.** Unchanged web-identity path (`AssumeRoleWithWebIdentity` against the store's OIDC IAM).
- **absent → remote S3-compatible.** A SigV4-signed `GetFederationToken`, authenticated with the store's own access keys. This is the standard temporary-credential call AWS and MinIO both implement; it needs no role, no OIDC provider, and no extra IAM setup.

Both backends reuse the same inline session `Policy` (`_scope_policy`) for per-mount scoping, so the isolation model — a bucket-wide identity narrowed to `<bucket>/[<namespace>/]mounts/<project>/<mount>/*` per request — is identical across stores.

The STS endpoint defaults to the S3 endpoint (MinIO co-locates STS there) and is overridable via `AGENTA_STORE_STS_ENDPOINT_URL` for stores that split STS onto another host (AWS: `sts.<region>.amazonaws.com`). The endpoint is now always explicit — the old `s3.amazonaws.com` fallback, which special-cased AWS by inferring it from an empty endpoint, is gone.

`GetFederationToken` is built the same way the web-identity request already was: a form-encoded POST via aiohttp, here SigV4-signed with miniopy-async's `sign_v4_sts`. No new dependency.

## Tests / notes

- Verified end to end against real AWS S3 from a running container: config resolves to the federation path, `GetFederationToken` returns a scoped `ASIA...` session credential, a write to the mount's own prefix returns 200, and a write to another mount's prefix returns 403.
- Unit tests cover the three request shapes: AWS split STS host, MinIO STS-defaults-to-S3-endpoint, and SeaweedFS web-identity. Full mounts suite green (42 passed).
- R2 is out of scope: it does not support AWS-STS `GetFederationToken` (its temporary credentials use a Cloudflare-specific scheme). Supported remote stores are AWS S3 and MinIO.
- Base is `big-agents` (rebased on the current tip).
