### PR TITLE
feat(frontend): redesign agent-playground tool + workflow-reference selection

### DIFF
--- a/web/oss/src/components/DrillInView/OSSdrillInUIProvider.tsx
+++ b/web/oss/src/components/DrillInView/OSSdrillInUIProvider.tsx
@@ -32,25 +32,40 @@ import {
     useToolConnectionsQuery,
     useToolIntegrationDetail,
 } from "@agenta/entities/gatewayTool"
+import type {RunnablePort} from "@agenta/entities/shared"
 import {
+    discardLocalServerDataAtom,
+    evaluatorTemplatesMapAtom,
     nonArchivedWorkflowsAtom,
+    parseWorkflowKeyFromUri,
     queryWorkflowRevisionsByWorkflow,
     resolveInputSchema as resolveWorkflowInputSchema,
+    resolveOutputSchema as resolveWorkflowOutputSchema,
+    resolveParameters,
+    resolveScript,
     retrieveWorkflowRevision,
+    workflowLocalServerDataAtomFamily,
+    workflowMolecule,
     workflowsListQueryStateAtom,
+    type Workflow,
+    type WorkflowType,
 } from "@agenta/entities/workflow"
 import {
     DrillInUIProvider,
     type GatewayToolsBridge,
+    type WorkflowConfigPart,
+    type WorkflowConfigPayload,
     type WorkflowReferenceBridge,
     type WorkflowReferenceUI,
+    type WorkflowReferenceType,
     type WorkflowRevisionUI,
     type WorkflowEnvironmentUI,
 } from "@agenta/entity-ui/drill-in"
 import {projectIdAtom} from "@agenta/shared/state"
+import {KNOWN_ENVELOPE_SLOTS} from "@agenta/shared/utils"
 import {EditorProvider} from "@agenta/ui/editor"
 import {SharedEditor} from "@agenta/ui/shared-editor"
-import {useAtomValue, useSetAtom} from "jotai"
+import {getDefaultStore, useAtomValue, useSetAtom, useStore} from "jotai"
 import {atomFamily} from "jotai/utils"
 import {atomWithQuery} from "jotai-tanstack-query"
 
@@ -137,21 +152,392 @@ function useWorkflowEnvironments(workflow: WorkflowReferenceUI | null): {
  * its revisions (variant axis) and its environments (environment axis). Not EE-gated, so it ships
  * in both the tools-enabled and tools-disabled trees.
  */
+// Map the molecule's canonical workflow type down to the four the reference picker badges.
+function toReferenceType(t: WorkflowType | null | undefined): WorkflowReferenceType | undefined {
+    if (!t) return undefined
+    if (t === "agent" || t === "chat" || t === "completion") return t
+    return "custom"
+}
+
+// Classify a workflow by hydrating its fetched revision into the molecule and reading the SAME
+// `workflowType` selector the playground uses — list items lack capability flags, so a naive URI
+// parse mislabels agents (no prompt URI) and evaluators (heterogeneous code/match/llm kinds).
+// Evaluators are labeled `evaluator` up front so they don't fall through to `custom`.
+function classifyRevision(revision: Workflow): WorkflowReferenceType | undefined {
+    if (revision.flags?.is_evaluator) return "evaluator"
+    const store = getDefaultStore()
+    const localId = `local-agent-ref-type-${revision.slug ?? revision.id ?? "wf"}`
+    store.set(workflowLocalServerDataAtomFamily(localId), {...revision, id: localId})
+    try {
+        return toReferenceType(store.get(workflowMolecule.selectors.workflowType(localId)))
+    } finally {
+        store.set(discardLocalServerDataAtom, localId)
+    }
+}
+
+interface ReferenceTypeInfo {
+    type: WorkflowReferenceType | undefined
+    /** For evaluators: the evaluator template key (from the revision URI), for a finer badge label. */
+    evaluatorKey: string | null
+}
+
+// Resolve type + evaluator-key for a set of workflow slugs. Keyed by the sorted slug set so the batch
+// is cached and only refetches when the set changes.
+const referenceTypesQueryAtomFamily = atomFamily((slugsKey: string) =>
+    atomWithQuery((get) => {
+        const projectId = get(projectIdAtom)
+        const slugs = slugsKey ? slugsKey.split("\n") : []
+        return {
+            queryKey: ["agentReferenceWorkflowTypes", projectId, slugsKey],
+            enabled: Boolean(projectId) && slugs.length > 0,
+            staleTime: 300_000,
+            queryFn: async () => {
+                const pairs = await Promise.all(
+                    slugs.map(async (slug): Promise<[string, ReferenceTypeInfo]> => {
+                        try {
+                            const revision = await retrieveWorkflowRevision({
+                                projectId: projectId as string,
+                                workflowRef: {slug},
+                            })
+                            if (!revision) return [slug, {type: undefined, evaluatorKey: null}]
+                            return [
+                                slug,
+                                {
+                                    type: classifyRevision(revision),
+                                    evaluatorKey: revision.flags?.is_evaluator
+                                        ? parseWorkflowKeyFromUri(revision.data?.uri)
+                                        : null,
+                                },
+                            ]
+                        } catch {
+                            return [slug, {type: undefined, evaluatorKey: null}]
+                        }
+                    }),
+                )
+                return Object.fromEntries(pairs) as Record<string, ReferenceTypeInfo>
+            },
+        }
+    }),
+)
+
+// Humanize an evaluator key as a fallback when the template catalog lacks a display name.
+// e.g. "auto_exact_match" → "Exact Match".
+function humanizeEvaluatorKey(key: string): string {
+    return key
+        .replace(/^(auto|human)_/, "")
+        .replace(/_/g, " ")
+        .replace(/\b\w/g, (c) => c.toUpperCase())
+        .trim()
+}
+
+function useWorkflowReferenceTypes(workflows: WorkflowReferenceUI[]): {
+    typeBySlug: Record<string, WorkflowReferenceType | undefined>
+    labelBySlug?: Record<string, string | undefined>
+    loading: boolean
+} {
+    const slugsKey = useMemo(
+        () =>
+            workflows
+                .map((w) => w.slug)
+                .filter(Boolean)
+                .sort()
+                .join("\n"),
+        [workflows],
+    )
+    const res = useAtomValue(referenceTypesQueryAtomFamily(slugsKey))
+    // Evaluator template catalog (key → display name), for the evaluator sub-type badge.
+    const evaluatorNames = useAtomValue(evaluatorTemplatesMapAtom)
+
+    return useMemo(() => {
+        const data = (res.data ?? {}) as Record<string, ReferenceTypeInfo>
+        const typeBySlug: Record<string, WorkflowReferenceType | undefined> = {}
+        const labelBySlug: Record<string, string | undefined> = {}
+        for (const [slug, info] of Object.entries(data)) {
+            typeBySlug[slug] = info.type
+            if (info.evaluatorKey) {
+                labelBySlug[slug] =
+                    evaluatorNames.get(info.evaluatorKey) ?? humanizeEvaluatorKey(info.evaluatorKey)
+            }
+        }
+        return {typeBySlug, labelBySlug, loading: Boolean(res.isLoading)}
+    }, [res.data, res.isLoading, evaluatorNames])
+}
+
+function isPlainRecord(value: unknown): value is Record<string, unknown> {
+    return typeof value === "object" && value !== null && !Array.isArray(value)
+}
+
+// A prompt-shaped config object (`{messages, template_format, llm_config, ...}`) or an agent-shaped
+// one (`{instructions, tools, skills}`). Mirrors what the playground config panel edits.
+function isPromptLike(v: Record<string, unknown>): boolean {
+    return (
+        Array.isArray(v.messages) ||
+        isPlainRecord(v.llm_config) ||
+        typeof v.instructions === "string"
+    )
+}
+
+// One prompt/agent config → Configuration parts: the prompt Messages, model, remaining model
+// settings, tools, response_format, template_format, agent instructions/skills.
+function promptConfigParts(prefix: string, cfg: Record<string, unknown>): WorkflowConfigPart[] {
+    const parts: WorkflowConfigPart[] = []
+
+    // Messages (System / User / …) are one grouped part, not a rail item per role.
+    const messages = (Array.isArray(cfg.messages) ? cfg.messages : [])
+        .filter(isPlainRecord)
+        .map((m) => ({
+            role: typeof m.role === "string" ? m.role : "message",
+            content: typeof m.content === "string" ? m.content : JSON.stringify(m.content, null, 2),
+        }))
+        .filter((m) => m.content)
+    if (messages.length) {
+        parts.push({
+            key: `${prefix}messages`,
+            label: "Messages",
+            kind: "messages",
+            content: "",
+            messages,
+        })
+    }
+
+    const llm = isPlainRecord(cfg.llm_config) ? cfg.llm_config : null
+    if (llm) {
+        if (typeof llm.model === "string" && llm.model) {
+            parts.push({key: `${prefix}model`, label: "Model", kind: "text", content: llm.model})
+        }
+        const settings = {...llm}
+        delete settings.model
+        delete settings.tools
+        delete settings.response_format
+        if (Object.keys(settings).length) {
+            parts.push({
+                key: `${prefix}settings`,
+                label: "Model settings",
+                kind: "json",
+                content: JSON.stringify(settings, null, 2),
+            })
+        }
+        if (Array.isArray(llm.tools) && llm.tools.length) {
+            parts.push({
+                key: `${prefix}tools`,
+                label: "Tools",
+                kind: "json",
+                content: JSON.stringify(llm.tools, null, 2),
+            })
+        }
+        if (isPlainRecord(llm.response_format)) {
+            parts.push({
+                key: `${prefix}response_format`,
+                label: "Response format",
+                kind: "json",
+                content: JSON.stringify(llm.response_format, null, 2),
+            })
+        }
+    }
+
+    if (typeof cfg.template_format === "string" && cfg.template_format) {
+        parts.push({
+            key: `${prefix}template_format`,
+            label: "Template format",
+            kind: "text",
+            content: cfg.template_format,
+        })
+    }
+    if (typeof cfg.instructions === "string" && cfg.instructions.trim()) {
+        parts.push({
+            key: `${prefix}instructions`,
+            label: "Instructions",
+            kind: "text",
+            content: cfg.instructions,
+        })
+    }
+    if (Array.isArray(cfg.skills) && cfg.skills.length) {
+        parts.push({
+            key: `${prefix}skills`,
+            label: "Skills",
+            kind: "json",
+            content: JSON.stringify(cfg.skills, null, 2),
+        })
+    }
+
+    return parts
+}
+
+// Configuration parts from a revision's data: custom-workflow code, then each prompt/agent config
+// (params may BE a prompt config or hold several under named keys). JSON fallback if unrecognized.
+function buildConfigParts(data: unknown): WorkflowConfigPart[] {
+    const parts: WorkflowConfigPart[] = []
+
+    const script = resolveScript(data as Parameters<typeof resolveScript>[0])
+    if (typeof script === "string" && script.trim()) {
+        parts.push({
+            key: "code",
+            label: "Handler",
+            kind: "code",
+            content: script,
+            language: "python",
+        })
+    }
+
+    const params = resolveParameters(data as Parameters<typeof resolveParameters>[0])
+    if (isPlainRecord(params)) {
+        const entries: [string, Record<string, unknown>][] = isPromptLike(params)
+            ? [["", params]]
+            : Object.entries(params).filter(
+                  (e): e is [string, Record<string, unknown>] =>
+                      isPlainRecord(e[1]) && isPromptLike(e[1]),
+              )
+        const multiple = entries.length > 1
+        for (const [key, cfg] of entries) {
+            parts.push(...promptConfigParts(multiple && key ? `${key}-` : "", cfg))
+        }
+        if (parts.length === (script ? 1 : 0)) {
+            parts.push({
+                key: "config",
+                label: "Config",
+                kind: "json",
+                content: JSON.stringify(params, null, 2),
+            })
+        }
+    }
+
+    return parts
+}
+
+// The structured-output JSON schema declared in a prompt's `llm_config.response_format`, if any.
+function responseFormatSchema(data: unknown): Record<string, unknown> | null {
+    const params = resolveParameters(data as Parameters<typeof resolveParameters>[0])
+    if (!isPlainRecord(params)) return null
+    const configs = isPromptLike(params) ? [params] : Object.values(params).filter(isPlainRecord)
+    for (const cfg of configs) {
+        const llm = isPlainRecord(cfg.llm_config) ? cfg.llm_config : null
+        const rf = llm && isPlainRecord(llm.response_format) ? llm.response_format : null
+        const js = rf && isPlainRecord(rf.json_schema) ? rf.json_schema : null
+        const schema = js && isPlainRecord(js.schema) ? js.schema : null
+        if (schema) return schema
+    }
+    return null
+}
+
+// The top-level input key a JSONPath placeholder addresses, or null if it's not an input.
+// Mirrors `parseTemplateExpression`'s `$.` handling: `$.inputs.country`→"country",
+// `$.country`→"country" (testcase-spread), `$.outputs.*`→null (runtime-resolved, not an input).
+function jsonPathToInputKey(rawExpr: string): string | null {
+    const expr = rawExpr.trim()
+    if (!(expr === "$" || expr.startsWith("$.") || expr.startsWith("$["))) return null
+    const tokens = expr
+        .replace(/^\$\.?/, "")
+        .split(/[.[\]'"]/)
+        .filter(Boolean)
+    if (tokens.length === 0) return null
+    const first = tokens[0]
+    if (KNOWN_ENVELOPE_SLOTS.has(first)) {
+        return first === "inputs" ? (tokens[1] ?? null) : null
+    }
+    return first
+}
+
+// Recover input keys from JSONPath placeholders (`{{$.inputs.country}}`) that the SHARED template
+// extractor drops for curly/jinja2 (its `$`-marker guard rejects them as mustache inheritance). We
+// don't touch the shared extractor; this scoped scan makes the reference-drawer Schema section show
+// those inputs. Mustache/plain vars are already handled by the molecule's inputPorts.
+function extractJsonPathInputKeys(data: unknown): string[] {
+    const params = resolveParameters(data as Parameters<typeof resolveParameters>[0])
+    if (!isPlainRecord(params)) return []
+    const configs = isPromptLike(params) ? [params] : Object.values(params).filter(isPlainRecord)
+    const keys = new Set<string>()
+    const re = /\{\{\s*(\$[^}]*?)\s*\}\}/g
+    for (const cfg of configs) {
+        const messages = Array.isArray(cfg.messages) ? cfg.messages : []
+        for (const message of messages) {
+            const content =
+                isPlainRecord(message) && typeof message.content === "string" ? message.content : ""
+            if (!content) continue
+            let match: RegExpExecArray | null
+            while ((match = re.exec(content)) !== null) {
+                const key = jsonPathToInputKey(match[1])
+                if (key) keys.add(key)
+            }
+        }
+    }
+    return [...keys]
+}
+
+// Merge extra input keys into a JSON schema (as string props), creating one if needed.
+function mergeInputKeys(
+    schema: Record<string, unknown> | null,
+    keys: string[],
+): Record<string, unknown> | null {
+    if (keys.length === 0) return schema
+    const base = isPlainRecord(schema) && isPlainRecord(schema.properties) ? schema : null
+    const properties: Record<string, unknown> = base
+        ? {...(base.properties as Record<string, unknown>)}
+        : {}
+    for (const key of keys) {
+        if (!(key in properties)) properties[key] = {type: "string"}
+    }
+    return {
+        type: "object",
+        properties,
+        required: base && Array.isArray(base.required) ? base.required : [],
+    }
+}
+
+// Convert the molecule's derived input/output ports into a JSON schema for the Schema tree.
+function portsToSchema(ports: RunnablePort[]): Record<string, unknown> | null {
+    const properties: Record<string, unknown> = {}
+    const required: string[] = []
+    for (const port of ports) {
+        if (port.isFallback) continue
+        properties[port.key] = isPlainRecord(port.schema)
+            ? port.schema
+            : {type: port.type || "string"}
+        if (port.required) required.push(port.key)
+    }
+    if (Object.keys(properties).length === 0) return null
+    return {type: "object", properties, required}
+}
+
+// Read a fetched revision's input/output ports through the workflow molecule — the SAME derivation
+// the playground uses (declared schema → prompt template variables with nesting/JSONPath/sections).
+// The revision is hydrated into the molecule under a transient `local-` id and discarded after.
+function readWorkflowPorts(
+    store: ReturnType<typeof useStore>,
+    revision: Workflow,
+): {inputPorts: RunnablePort[]; outputPorts: RunnablePort[]} {
+    const localId = `local-agent-ref-${revision.slug ?? revision.id ?? "wf"}`
+    store.set(workflowLocalServerDataAtomFamily(localId), {...revision, id: localId})
+    try {
+        return {
+            inputPorts: store.get(workflowMolecule.selectors.inputPorts(localId)) as RunnablePort[],
+            outputPorts: store.get(
+                workflowMolecule.selectors.outputPorts(localId),
+            ) as RunnablePort[],
+        }
+    } finally {
+        store.set(discardLocalServerDataAtom, localId)
+    }
+}
+
 function useWorkflowReferenceBridge(): WorkflowReferenceBridge {
     const projectId = useAtomValue(projectIdAtom)
     const workflows = useAtomValue(nonArchivedWorkflowsAtom)
     const workflowsLoading = useAtomValue(workflowsListQueryStateAtom).isPending
+    const store = useStore()
 
     return useMemo<WorkflowReferenceBridge>(
         () => ({
             enabled: true,
+            // All project workflows are referenceable (apps + evaluators + …), not just apps. Type
+            // (incl. `evaluator`) is resolved per-slug via useWorkflowTypes.
             workflows: workflows
-                .filter((w) => typeof w.slug === "string" && !w.flags?.is_evaluator)
+                .filter((w) => typeof w.slug === "string")
                 .map((w) => ({
                     id: w.id,
                     slug: w.slug as string,
                     name: w.name ?? undefined,
                     description: w.description ?? undefined,
+                    // type is resolved asynchronously via useWorkflowTypes (needs the revision URI).
                 })),
             workflowsLoading,
             resolveInputSchema: async (workflow) => {
@@ -161,14 +547,56 @@ function useWorkflowReferenceBridge(): WorkflowReferenceBridge {
                     workflowRef: {slug: workflow.slug},
                 })
                 if (!revision?.data) return null
-                return resolveWorkflowInputSchema(
+                // Declared input schema first (richest — carries descriptions).
+                const declared = resolveWorkflowInputSchema(
                     revision.data as Parameters<typeof resolveWorkflowInputSchema>[0],
                 )
+                if (
+                    isPlainRecord(declared?.properties) &&
+                    Object.keys(declared!.properties).length > 0
+                ) {
+                    return declared
+                }
+                // Fallback: the prompt template's variables (the playground's own input-port
+                // derivation — plain/dotted vars, mustache sections, nesting), plus JSONPath inputs
+                // the shared curly/jinja2 extractor drops (recovered locally for this drawer).
+                const portSchema = portsToSchema(readWorkflowPorts(store, revision).inputPorts)
+                return mergeInputKeys(portSchema, extractJsonPathInputKeys(revision.data))
+            },
+            resolveOutputSchema: async (workflow) => {
+                if (!projectId || !workflow.slug) return null
+                const revision = await retrieveWorkflowRevision({
+                    projectId,
+                    workflowRef: {slug: workflow.slug},
+                })
+                if (!revision?.data) return null
+                const declared = resolveWorkflowOutputSchema(
+                    revision.data as Parameters<typeof resolveWorkflowOutputSchema>[0],
+                )
+                if (
+                    isPlainRecord(declared?.properties) &&
+                    Object.keys(declared!.properties).length > 0
+                ) {
+                    return declared
+                }
+                // Fallback: the structured-output JSON schema from `response_format`.
+                return responseFormatSchema(revision.data)
+            },
+            resolveConfigPayload: async (workflow): Promise<WorkflowConfigPayload | null> => {
+                if (!projectId || !workflow.slug) return null
+                const revision = await retrieveWorkflowRevision({
+                    projectId,
+                    workflowRef: {slug: workflow.slug},
+                })
+                if (!revision?.data) return null
+                const parts = buildConfigParts(revision.data)
+                return parts.length ? {parts} : null
             },
             useWorkflowRevisions,
             useWorkflowEnvironments,
+            useWorkflowTypes: useWorkflowReferenceTypes,
         }),
-        [workflows, workflowsLoading, projectId],
+        [workflows, workflowsLoading, projectId, store],
     )
 }
 

--- a/web/oss/src/components/DrillInView/OSSdrillInUIProvider.tsx
+++ b/web/oss/src/components/DrillInView/OSSdrillInUIProvider.tsx
@@ -267,13 +267,18 @@ function isPlainRecord(value: unknown): value is Record<string, unknown> {
     return typeof value === "object" && value !== null && !Array.isArray(value)
 }
 
-// A prompt-shaped config object (`{messages, template_format, llm_config, ...}`) or an agent-shaped
-// one (`{instructions, tools, skills}`). Mirrors what the playground config panel edits.
+// A prompt-shaped config (`{messages, llm_config, ...}`) or an agent-shaped one
+// (`{instructions: {agents_md}, llm, tools, skills}` — agents nest instructions and keep tools/skills
+// flat). Mirrors what the playground config panel edits.
 function isPromptLike(v: Record<string, unknown>): boolean {
     return (
         Array.isArray(v.messages) ||
         isPlainRecord(v.llm_config) ||
-        typeof v.instructions === "string"
+        isPlainRecord(v.llm) ||
+        typeof v.instructions === "string" ||
+        isPlainRecord(v.instructions) ||
+        Array.isArray(v.tools) ||
+        Array.isArray(v.skills)
     )
 }
 
@@ -300,7 +305,12 @@ function promptConfigParts(prefix: string, cfg: Record<string, unknown>): Workfl
         })
     }
 
-    const llm = isPlainRecord(cfg.llm_config) ? cfg.llm_config : null
+    // Model config lives under `llm_config` (prompts) or `llm` (agents).
+    const llm = isPlainRecord(cfg.llm_config)
+        ? cfg.llm_config
+        : isPlainRecord(cfg.llm)
+          ? cfg.llm
+          : null
     if (llm) {
         if (typeof llm.model === "string" && llm.model) {
             parts.push({key: `${prefix}model`, label: "Model", kind: "text", content: llm.model})
@@ -315,14 +325,6 @@ function promptConfigParts(prefix: string, cfg: Record<string, unknown>): Workfl
                 label: "Model settings",
                 kind: "json",
                 content: JSON.stringify(settings, null, 2),
-            })
-        }
-        if (Array.isArray(llm.tools) && llm.tools.length) {
-            parts.push({
-                key: `${prefix}tools`,
-                label: "Tools",
-                kind: "json",
-                content: JSON.stringify(llm.tools, null, 2),
             })
         }
         if (isPlainRecord(llm.response_format)) {
@@ -343,14 +345,39 @@ function promptConfigParts(prefix: string, cfg: Record<string, unknown>): Workfl
             content: cfg.template_format,
         })
     }
-    if (typeof cfg.instructions === "string" && cfg.instructions.trim()) {
+
+    // Instructions: a plain string, or an agent's nested `{agents_md}` document.
+    const instructionsText =
+        typeof cfg.instructions === "string"
+            ? cfg.instructions
+            : isPlainRecord(cfg.instructions) && typeof cfg.instructions.agents_md === "string"
+              ? cfg.instructions.agents_md
+              : ""
+    if (instructionsText.trim()) {
         parts.push({
             key: `${prefix}instructions`,
             label: "Instructions",
             kind: "text",
-            content: cfg.instructions,
+            content: instructionsText,
         })
     }
+
+    // Tools live under `llm_config.tools` (prompts) or flat on the object (agents).
+    const tools =
+        llm && Array.isArray(llm.tools) && llm.tools.length
+            ? (llm.tools as unknown[])
+            : Array.isArray(cfg.tools)
+              ? (cfg.tools as unknown[])
+              : []
+    if (tools.length) {
+        parts.push({
+            key: `${prefix}tools`,
+            label: "Tools",
+            kind: "json",
+            content: JSON.stringify(tools, null, 2),
+        })
+    }
+
     if (Array.isArray(cfg.skills) && cfg.skills.length) {
         parts.push({
             key: `${prefix}skills`,
@@ -547,7 +574,10 @@ function useWorkflowReferenceBridge(): WorkflowReferenceBridge {
                     workflowRef: {slug: workflow.slug},
                 })
                 if (!revision?.data) return null
-                // Declared input schema first (richest — carries descriptions).
+                // Declared input schema first (richest — carries descriptions), but still fold in
+                // JSONPath inputs the shared curly/jinja2 extractor drops, so a mixed template that
+                // has some declared props plus `{{$.inputs.*}}` doesn't publish an incomplete schema.
+                const recoveredKeys = extractJsonPathInputKeys(revision.data)
                 const declared = resolveWorkflowInputSchema(
                     revision.data as Parameters<typeof resolveWorkflowInputSchema>[0],
                 )
@@ -555,13 +585,12 @@ function useWorkflowReferenceBridge(): WorkflowReferenceBridge {
                     isPlainRecord(declared?.properties) &&
                     Object.keys(declared!.properties).length > 0
                 ) {
-                    return declared
+                    return mergeInputKeys(declared as Record<string, unknown>, recoveredKeys)
                 }
                 // Fallback: the prompt template's variables (the playground's own input-port
-                // derivation — plain/dotted vars, mustache sections, nesting), plus JSONPath inputs
-                // the shared curly/jinja2 extractor drops (recovered locally for this drawer).
+                // derivation — plain/dotted vars, mustache sections, nesting) + recovered JSONPath.
                 const portSchema = portsToSchema(readWorkflowPorts(store, revision).inputPorts)
-                return mergeInputKeys(portSchema, extractJsonPathInputKeys(revision.data))
+                return mergeInputKeys(portSchema, recoveredKeys)
             },
             resolveOutputSchema: async (workflow) => {
                 if (!projectId || !workflow.slug) return null

--- a/web/packages/agenta-entity-ui/src/DrillInView/SchemaControls/AgentTemplateControl.tsx
+++ b/web/packages/agenta-entity-ui/src/DrillInView/SchemaControls/AgentTemplateControl.tsx
@@ -11,8 +11,8 @@
  * just as the prompt control's value is the prompt template): the portable definition
  * (instructions/llm/tools/mcps/skills) is FLAT on it, and the execution parts
  * (harness/runner/sandbox) are nested sub-objects. It reuses the existing schema controls rather
- * than inventing new ones: the model selector (GroupedChoiceControl), the tool picker
- * (ToolSelectorPopover + ToolItemControl), the MCP server editor (McpServerItemControl), enum
+ * than inventing new ones: the model selector (GroupedChoiceControl), the agent tool picker
+ * (AgentToolSelectorPopover + ToolItemControl), the MCP server editor (McpServerItemControl), enum
  * selects (harness, sandbox, permission policy), and a textarea (agents_md). The shape is the
  * `agent-template` catalog type generated from the SDK model (AgentTemplateSchema in
  * agenta.sdk.utils.types); the agent service ships a thin `x-ag-type-ref` the playground resolves
@@ -44,10 +44,13 @@ import {useAtomValue, useStore} from "jotai"
 import {useOptionalDrillIn} from "../components/MoleculeDrillInContext"
 
 import {AddTextLink} from "./AddTextLink"
+import {AgentIntegrationDrawer} from "./agentTemplate/AgentIntegrationDrawer"
 import {countSummary} from "./agentTemplate/agentTemplateUtils"
+import {AgentToolSelectorPopover} from "./agentTemplate/AgentToolSelectorPopover"
 import {ConfigItemList} from "./agentTemplate/ConfigItemList"
 import {ITEM_KINDS} from "./agentTemplate/itemKinds"
 import {InstructionsFileRow} from "./agentTemplate/ItemRow"
+import {ToolManagementList} from "./agentTemplate/ToolManagementList"
 import {useAgentTools} from "./agentTemplate/useAgentTools"
 import {useConfigItemDrawer} from "./agentTemplate/useConfigItemDrawer"
 import {useModelHarness} from "./agentTemplate/useModelHarness"
@@ -56,7 +59,6 @@ import {ConfigItemDrawer} from "./ConfigItemDrawer"
 import {InstructionsDrawer} from "./InstructionsDrawer"
 import {JsonObjectEditor} from "./JsonObjectEditor"
 import {SectionDrawer} from "./SectionDrawer"
-import {ToolSelectorPopover} from "./ToolSelectorPopover"
 import {type ToolObj} from "./toolUtils"
 import {
     AddTriggerDropdown,
@@ -94,6 +96,16 @@ export function AgentTemplateControl({
     }, [config])
 
     const [referenceSelectorOpen, setReferenceSelectorOpen] = useState(false)
+    const [integrationDrawerOpen, setIntegrationDrawerOpen] = useState(false)
+    // Preselected app for the integration drawer: set when a provider group's "Add {app} tool" opens
+    // it (jump to that app's actions), cleared for the header + (open on the app grid).
+    const [integrationDefaultKey, setIntegrationDefaultKey] = useState<string | undefined>(
+        undefined,
+    )
+    const openIntegration = useCallback((integrationKey?: string) => {
+        setIntegrationDefaultKey(integrationKey)
+        setIntegrationDrawerOpen(true)
+    }, [])
     // Shared draft-then-save drawer for tools, MCP servers, and skills (writes via ITEM_KINDS).
     const {
         editing,
@@ -248,6 +260,8 @@ export function AgentTemplateControl({
         onReferenceWorkflow: workflowReference?.enabled
             ? () => setReferenceSelectorOpen(true)
             : undefined,
+        // Route the integration row to the agent-scoped drawer instead of the shared global catalog.
+        onOpenIntegration: gatewayTools?.enabled ? openIntegration : undefined,
     }
 
     // Compact "+" for a section header's `extra` slot (stops propagation, so it never toggles open).
@@ -306,7 +320,7 @@ export function AgentTemplateControl({
             title: fieldTitle("tools", "Tools"),
             summary: countSummary(tools.length, "tool"),
             extra: !disabled ? (
-                <ToolSelectorPopover
+                <AgentToolSelectorPopover
                     {...toolSelectorProps}
                     trigger={
                         <Tooltip title="Add tool">
@@ -322,16 +336,17 @@ export function AgentTemplateControl({
             ) : undefined,
             defaultOpen: true,
             content: (
-                <ConfigItemList
-                    kind="tool"
-                    items={tools}
+                <ToolManagementList
+                    tools={tools}
+                    entityId={revisionId}
                     openEdit={openEdit}
                     removeItem={removeItem}
                     closeEditor={closeEditor}
                     disabled={disabled}
+                    onOpenIntegration={gatewayTools?.enabled ? openIntegration : undefined}
                     // The empty-state add is the same popover as the header +.
                     emptyAdd={
-                        <ToolSelectorPopover
+                        <AgentToolSelectorPopover
                             {...toolSelectorProps}
                             trigger={<AddTextLink label="add a tool" />}
                         />
@@ -492,6 +507,7 @@ export function AgentTemplateControl({
                               subtitle={desc.subtitle}
                               footerNote="Changes apply to this agent configuration"
                               width={def.drawerWidth}
+                              contentFlush={def.formFlush}
                               view={drawerView}
                               onViewChange={setDrawerView}
                               onCancel={closeEditor}
@@ -573,6 +589,20 @@ export function AgentTemplateControl({
                         void handleAddWorkflowReference(payload)
                         setReferenceSelectorOpen(false)
                     }}
+                />
+            )}
+
+            {gatewayTools?.enabled && (
+                <AgentIntegrationDrawer
+                    open={integrationDrawerOpen}
+                    onClose={() => {
+                        setIntegrationDrawerOpen(false)
+                        setIntegrationDefaultKey(undefined)
+                    }}
+                    onAddTool={handleAddTool}
+                    onRemoveTool={handleRemoveToolByName}
+                    selectedToolNames={selectedToolNames}
+                    defaultIntegrationKey={integrationDefaultKey}
                 />
             )}
         </div>

--- a/web/packages/agenta-entity-ui/src/DrillInView/SchemaControls/ConfigItemDrawer.tsx
+++ b/web/packages/agenta-entity-ui/src/DrillInView/SchemaControls/ConfigItemDrawer.tsx
@@ -61,6 +61,12 @@ export interface ConfigItemDrawerProps {
     width?: number
     /** Read-only mode: disables the toggle and the Save action. */
     disabled?: boolean
+    /**
+     * Full-bleed body: drops the default 16px padding and makes the body a full-height flex column
+     * so a form can lay out its own edge-to-edge master/detail (e.g. the tool parameter editor).
+     * The JSON view keeps its padding regardless. @default false
+     */
+    contentFlush?: boolean
 }
 
 export function ConfigItemDrawer({
@@ -81,8 +87,11 @@ export function ConfigItemDrawer({
     jsonOnly = false,
     width = 600,
     disabled = false,
+    contentFlush = false,
 }: ConfigItemDrawerProps) {
     const effectiveView = jsonOnly ? "json" : view
+    // Flush layout only helps the form; keep the JSON editor padded and independently scrollable.
+    const flushForm = contentFlush && effectiveView === "form"
 
     return (
         <EnhancedDrawer
@@ -144,9 +153,25 @@ export function ConfigItemDrawer({
                     </div>
                 </div>
             }
-            styles={{body: {padding: 16}}}
+            styles={{
+                body: flushForm
+                    ? {
+                          padding: 0,
+                          height: "100%",
+                          display: "flex",
+                          flexDirection: "column",
+                          overflow: "hidden",
+                      }
+                    : {padding: 16},
+            }}
         >
-            {effectiveView === "form" ? form : json}
+            {effectiveView === "form" ? (
+                form
+            ) : contentFlush ? (
+                <div className="h-full overflow-auto p-4">{json}</div>
+            ) : (
+                json
+            )}
         </EnhancedDrawer>
     )
 }

--- a/web/packages/agenta-entity-ui/src/DrillInView/SchemaControls/ConfigItemDrawer.tsx
+++ b/web/packages/agenta-entity-ui/src/DrillInView/SchemaControls/ConfigItemDrawer.tsx
@@ -168,7 +168,9 @@ export function ConfigItemDrawer({
             {effectiveView === "form" ? (
                 form
             ) : contentFlush ? (
-                <div className="h-full overflow-auto p-4">{json}</div>
+                // Body already provides the padding here (flushForm is false in JSON view); the
+                // wrapper only adds full-height independent scroll — no extra `p-4` (double-pad).
+                <div className="h-full overflow-auto">{json}</div>
             ) : (
                 json
             )}

--- a/web/packages/agenta-entity-ui/src/DrillInView/SchemaControls/ReferenceToolFormView.tsx
+++ b/web/packages/agenta-entity-ui/src/DrillInView/SchemaControls/ReferenceToolFormView.tsx
@@ -80,14 +80,25 @@ function ReferenceBindingEditor({
     const [environment, setEnvironment] = useState<string | undefined>(
         typeof tool.environment === "string" ? tool.environment : undefined,
     )
+    // Selected variant id — kept even when following its latest (no pinned version).
+    const [variant, setVariant] = useState<string | undefined>(
+        typeof tool.variant_id === "string" ? tool.variant_id : undefined,
+    )
 
     const {environments, isLoading} = bridge.useWorkflowEnvironments(workflow)
 
     // Rebuild the reference tool from the current binding, clearing the now-irrelevant axis field.
-    const commit = (mode: "revision" | "environment", ver?: string, env?: string) => {
+    const commit = (
+        mode: "revision" | "environment",
+        ver?: string,
+        env?: string,
+        varId?: string,
+    ) => {
         const next = {...tool}
         if (mode === "revision") {
             next.ref_by = "variant"
+            if (varId) next.variant_id = varId
+            else delete next.variant_id
             if (ver) next.version = ver
             else delete next.version
             delete next.environment
@@ -96,6 +107,7 @@ function ReferenceBindingEditor({
             if (env) next.environment = env
             else delete next.environment
             delete next.version
+            delete next.variant_id
         }
         onChange(next)
     }
@@ -105,7 +117,7 @@ function ReferenceBindingEditor({
             bindMode={bindMode}
             onBindModeChange={(mode) => {
                 setBindMode(mode)
-                commit(mode, version, environment)
+                commit(mode, version, environment, variant)
             }}
             revisionAdapter={editReferenceRevisionAdapter}
             revisionPlaceholder={version ? `v${version}` : "Latest revision"}
@@ -113,8 +125,10 @@ function ReferenceBindingEditor({
                 const isRevision =
                     Boolean(sel.metadata.variantId) && sel.id !== sel.metadata.variantId
                 const ver = isRevision ? String(sel.metadata.revision) : undefined
+                const varId = sel.metadata.variantId ? String(sel.metadata.variantId) : undefined
                 setVersion(ver)
-                commit("revision", ver, environment)
+                setVariant(varId)
+                commit("revision", ver, environment, varId)
             }}
             revisionHint="Pin one variant + revision, or pick a variant to follow its latest."
             envOptions={environments.map((env) => ({value: env.slug, label: env.name || env.slug}))}

--- a/web/packages/agenta-entity-ui/src/DrillInView/SchemaControls/ReferenceToolFormView.tsx
+++ b/web/packages/agenta-entity-ui/src/DrillInView/SchemaControls/ReferenceToolFormView.tsx
@@ -19,8 +19,8 @@ import {
     type WorkflowReferenceBridge,
     type WorkflowReferenceUI,
 } from "@agenta/ui/drill-in"
-import {GitBranch, TreeStructure} from "@phosphor-icons/react"
-import {Spin} from "antd"
+import {GitBranch, Info, TreeStructure} from "@phosphor-icons/react"
+import {Input, Spin} from "antd"
 import {atom, useSetAtom} from "jotai"
 
 import {RailField} from "../../drawers/shared/RailField"
@@ -138,17 +138,19 @@ function ReferenceBindingEditor({
     )
 }
 
-/** Read-only binding summary shown when the workflow-reference bridge isn't available. */
-function ReadOnlyBinding({tool}: {tool: Record<string, unknown>}) {
-    const byEnv = tool.ref_by === "environment"
-    const target = byEnv
-        ? typeof tool.environment === "string"
+/** One-line summary of the current binding (collapsed section preview + read-only fallback). */
+function bindingSummary(tool: Record<string, unknown>): string {
+    if (tool.ref_by === "environment") {
+        return typeof tool.environment === "string"
             ? `Deployed in ${tool.environment}`
             : "A deployed environment"
-        : typeof tool.version === "string"
-          ? `Pinned to v${tool.version}`
-          : "Latest revision"
-    return <p className="m-0 text-xs text-[var(--ag-colorTextSecondary)]">{target}</p>
+    }
+    return typeof tool.version === "string" ? `Pinned to v${tool.version}` : "Latest revision"
+}
+
+/** Read-only binding summary shown when the workflow-reference bridge isn't available. */
+function ReadOnlyBinding({tool}: {tool: Record<string, unknown>}) {
+    return <p className="m-0 text-xs text-[var(--ag-colorTextSecondary)]">{bindingSummary(tool)}</p>
 }
 
 export function ReferenceToolFormView({value, onChange, disabled}: ReferenceToolFormViewProps) {
@@ -165,23 +167,34 @@ export function ReferenceToolFormView({value, onChange, disabled}: ReferenceTool
         [workflowReference, slug],
     )
 
+    const setDescription = (next: string) => onChange({...tool, description: next})
+
     return (
         <div className="min-h-0 flex-1 overflow-y-auto px-4 pb-6 pt-4">
             <div className="flex flex-col gap-4">
-                <RailField label="Exposed as" align="center">
-                    <div className="flex w-fit max-w-full items-center gap-1 rounded-md border border-solid border-[var(--ag-colorBorderSecondary)] bg-[var(--ag-colorFillTertiary)] py-0.5 pl-2.5 pr-1 font-mono text-xs text-[var(--ag-colorText)]">
-                        <span className="truncate">{slug}</span>
-                        <CopyButton text={slug} buttonText={null} icon type="text" />
-                    </div>
-                </RailField>
-
-                {description ? (
-                    <RailField label="Description">
-                        <p className="m-0 max-w-prose text-xs leading-relaxed text-[var(--ag-colorTextSecondary)]">
-                            {description}
-                        </p>
+                <ConfigAccordionSection
+                    size="compact"
+                    collapsible={false}
+                    icon={<Info size={15} />}
+                    title="Details"
+                >
+                    <RailField label="Exposed as" align="center">
+                        <div className="flex w-fit max-w-full items-center gap-1 rounded-md border border-solid border-[var(--ag-colorBorderSecondary)] bg-[var(--ag-colorFillTertiary)] py-0.5 pl-2.5 pr-1 font-mono text-xs text-[var(--ag-colorText)]">
+                            <span className="truncate">{slug}</span>
+                            <CopyButton text={slug} buttonText={null} icon type="text" />
+                        </div>
                     </RailField>
-                ) : null}
+
+                    <RailField label="Description">
+                        <Input.TextArea
+                            value={description}
+                            onChange={(e) => setDescription(e.target.value)}
+                            autoSize={{minRows: 2, maxRows: 6}}
+                            placeholder="What this tool does and when the agent should call it"
+                            disabled={disabled}
+                        />
+                    </RailField>
+                </ConfigAccordionSection>
 
                 <ConfigAccordionSection
                     size="compact"
@@ -197,10 +210,11 @@ export function ReferenceToolFormView({value, onChange, disabled}: ReferenceTool
 
                 <ConfigAccordionSection
                     size="compact"
-                    collapsible={false}
                     noDivider
                     icon={<GitBranch size={15} />}
                     title="Reference by"
+                    summary={bindingSummary(tool)}
+                    summaryCollapsedOnly
                 >
                     {workflowReference?.enabled && !disabled ? (
                         <ReferenceBindingEditor

--- a/web/packages/agenta-entity-ui/src/DrillInView/SchemaControls/ReferenceToolFormView.tsx
+++ b/web/packages/agenta-entity-ui/src/DrillInView/SchemaControls/ReferenceToolFormView.tsx
@@ -1,0 +1,219 @@
+/**
+ * ReferenceToolFormView
+ *
+ * Form side of the tool {@link ConfigItemDrawer} for a `type:"reference"` workflow tool (#4860) —
+ * the edit counterpart of the {@link WorkflowReferenceSelector} detail panel, so editing an existing
+ * reference reads the same as adding one (instead of a raw JSON blob). Shows the exposed tool name,
+ * description, and the resolved input schema (read-only, from the stored `input_schema`), plus an
+ * editable "Reference by" axis (pin a variant+version, or follow a deployed environment) wired to the
+ * workflow-reference bridge.
+ *
+ * Built from the shared pieces (`RailField`, `SchemaTree`, `RunVersionField`, `ConfigAccordionSection`);
+ * dark-safe (`--ag-color*` tokens only).
+ */
+import {useEffect, useMemo, useState} from "react"
+
+import {ConfigAccordionSection, CopyButton} from "@agenta/ui/components/presentational"
+import {
+    useDrillInUI,
+    type WorkflowReferenceBridge,
+    type WorkflowReferenceUI,
+} from "@agenta/ui/drill-in"
+import {GitBranch, TreeStructure} from "@phosphor-icons/react"
+import {Spin} from "antd"
+import {atom, useSetAtom} from "jotai"
+
+import {RailField} from "../../drawers/shared/RailField"
+import {RunVersionField} from "../../gatewayTrigger/drawers/shared/RunVersionField"
+import {createWorkflowRevisionAdapter, type WorkflowRevisionSelectionResult} from "../../selection"
+
+import {SchemaTree} from "./SchemaTree"
+
+// Revision picker scoped to the edited reference's workflow (module-level: only one reference drawer
+// is open at a time). Separate from the selector's atom so the two never collide.
+const editRefWorkflowIdAtom = atom<string | null>(null)
+const editReferenceRevisionAdapter = createWorkflowRevisionAdapter({
+    workflowIdAtom: editRefWorkflowIdAtom,
+})
+
+function isRecord(value: unknown): value is Record<string, unknown> {
+    return typeof value === "object" && value !== null && !Array.isArray(value)
+}
+
+function countProps(schema: Record<string, unknown> | null): number {
+    return schema && isRecord(schema.properties) ? Object.keys(schema.properties).length : 0
+}
+
+export interface ReferenceToolFormViewProps {
+    value: Record<string, unknown>
+    onChange: (next: Record<string, unknown>) => void
+    disabled?: boolean
+}
+
+/**
+ * The editable Reference-by axis. Isolated so the bridge hooks (`useWorkflowEnvironments`) are only
+ * mounted when the bridge is available. Commits binding changes onto the reference tool immediately.
+ */
+function ReferenceBindingEditor({
+    tool,
+    onChange,
+    bridge,
+    workflow,
+}: {
+    tool: Record<string, unknown>
+    onChange: (next: Record<string, unknown>) => void
+    bridge: WorkflowReferenceBridge
+    workflow: WorkflowReferenceUI | null
+}) {
+    const setWorkflowId = useSetAtom(editRefWorkflowIdAtom)
+    useEffect(() => {
+        setWorkflowId(workflow?.id ?? null)
+        return () => setWorkflowId(null)
+    }, [workflow?.id, setWorkflowId])
+
+    const [bindMode, setBindMode] = useState<"revision" | "environment">(
+        tool.ref_by === "environment" ? "environment" : "revision",
+    )
+    const [version, setVersion] = useState<string | undefined>(
+        typeof tool.version === "string" ? tool.version : undefined,
+    )
+    const [environment, setEnvironment] = useState<string | undefined>(
+        typeof tool.environment === "string" ? tool.environment : undefined,
+    )
+
+    const {environments, isLoading} = bridge.useWorkflowEnvironments(workflow)
+
+    // Rebuild the reference tool from the current binding, clearing the now-irrelevant axis field.
+    const commit = (mode: "revision" | "environment", ver?: string, env?: string) => {
+        const next = {...tool}
+        if (mode === "revision") {
+            next.ref_by = "variant"
+            if (ver) next.version = ver
+            else delete next.version
+            delete next.environment
+        } else {
+            next.ref_by = "environment"
+            if (env) next.environment = env
+            else delete next.environment
+            delete next.version
+        }
+        onChange(next)
+    }
+
+    return (
+        <RunVersionField
+            bindMode={bindMode}
+            onBindModeChange={(mode) => {
+                setBindMode(mode)
+                commit(mode, version, environment)
+            }}
+            revisionAdapter={editReferenceRevisionAdapter}
+            revisionPlaceholder={version ? `v${version}` : "Latest revision"}
+            onRevisionSelect={(sel: WorkflowRevisionSelectionResult) => {
+                const isRevision =
+                    Boolean(sel.metadata.variantId) && sel.id !== sel.metadata.variantId
+                const ver = isRevision ? String(sel.metadata.revision) : undefined
+                setVersion(ver)
+                commit("revision", ver, environment)
+            }}
+            revisionHint="Pin one variant + revision, or pick a variant to follow its latest."
+            envOptions={environments.map((env) => ({value: env.slug, label: env.name || env.slug}))}
+            envLoading={isLoading}
+            environmentSlug={environment}
+            onEnvironmentChange={(slug) => {
+                setEnvironment(slug)
+                commit("environment", version, slug)
+            }}
+            envNotFound={
+                isLoading ? (
+                    <Spin size="small" />
+                ) : (
+                    <span className="text-xs text-[var(--ag-colorTextTertiary)]">
+                        No environments deployed
+                    </span>
+                )
+            }
+            envHint="Calls whatever revision is deployed in the chosen environment."
+        />
+    )
+}
+
+/** Read-only binding summary shown when the workflow-reference bridge isn't available. */
+function ReadOnlyBinding({tool}: {tool: Record<string, unknown>}) {
+    const byEnv = tool.ref_by === "environment"
+    const target = byEnv
+        ? typeof tool.environment === "string"
+            ? `Deployed in ${tool.environment}`
+            : "A deployed environment"
+        : typeof tool.version === "string"
+          ? `Pinned to v${tool.version}`
+          : "Latest revision"
+    return <p className="m-0 text-xs text-[var(--ag-colorTextSecondary)]">{target}</p>
+}
+
+export function ReferenceToolFormView({value, onChange, disabled}: ReferenceToolFormViewProps) {
+    const tool = (value ?? {}) as Record<string, unknown>
+    const slug = typeof tool.slug === "string" ? tool.slug : ""
+    const description = typeof tool.description === "string" ? tool.description : ""
+    const inputSchema = isRecord(tool.input_schema)
+        ? (tool.input_schema as Record<string, unknown>)
+        : null
+
+    const {workflowReference} = useDrillInUI()
+    const workflow = useMemo(
+        () => workflowReference?.workflows.find((w) => w.slug === slug) ?? null,
+        [workflowReference, slug],
+    )
+
+    return (
+        <div className="min-h-0 flex-1 overflow-y-auto px-4 pb-6 pt-4">
+            <div className="flex flex-col gap-4">
+                <RailField label="Exposed as" align="center">
+                    <div className="flex w-fit max-w-full items-center gap-1 rounded-md border border-solid border-[var(--ag-colorBorderSecondary)] bg-[var(--ag-colorFillTertiary)] py-0.5 pl-2.5 pr-1 font-mono text-xs text-[var(--ag-colorText)]">
+                        <span className="truncate">{slug}</span>
+                        <CopyButton text={slug} buttonText={null} icon type="text" />
+                    </div>
+                </RailField>
+
+                {description ? (
+                    <RailField label="Description">
+                        <p className="m-0 max-w-prose text-xs leading-relaxed text-[var(--ag-colorTextSecondary)]">
+                            {description}
+                        </p>
+                    </RailField>
+                ) : null}
+
+                <ConfigAccordionSection
+                    size="compact"
+                    icon={<TreeStructure size={15} />}
+                    title="Schema"
+                    summary={`Inputs · ${countProps(inputSchema)}`}
+                    summaryCollapsedOnly
+                >
+                    <div className="max-h-[320px] max-w-prose overflow-y-auto overscroll-contain">
+                        <SchemaTree schema={inputSchema} emptyText="No declared inputs" />
+                    </div>
+                </ConfigAccordionSection>
+
+                <ConfigAccordionSection
+                    size="compact"
+                    collapsible={false}
+                    noDivider
+                    icon={<GitBranch size={15} />}
+                    title="Reference by"
+                >
+                    {workflowReference?.enabled && !disabled ? (
+                        <ReferenceBindingEditor
+                            tool={tool}
+                            onChange={onChange}
+                            bridge={workflowReference}
+                            workflow={workflow}
+                        />
+                    ) : (
+                        <ReadOnlyBinding tool={tool} />
+                    )}
+                </ConfigAccordionSection>
+            </div>
+        </div>
+    )
+}

--- a/web/packages/agenta-entity-ui/src/DrillInView/SchemaControls/SchemaTree.tsx
+++ b/web/packages/agenta-entity-ui/src/DrillInView/SchemaControls/SchemaTree.tsx
@@ -1,0 +1,132 @@
+/**
+ * SchemaTree
+ *
+ * Read-only, recursive JSON-schema viewer: each property renders name (mono) · type ·
+ * required|optional, with an optional muted description line, and nested object/array-of-object
+ * fields indent under a left guide line. Distinct from the EDITABLE `ParameterTree` — this
+ * one never mutates. Containment (max-height + scroll) is the caller's job so it can size the
+ * section body.
+ *
+ * Styling uses antd semantic tokens (`--ag-color*`) + antd `Tag` only — dark-safe.
+ */
+import {Tag} from "antd"
+
+export interface SchemaTreeProps {
+    /** A JSON-schema object node (`{type:"object", properties, required}`). */
+    schema: Record<string, unknown> | null | undefined
+    /** Shown when the schema declares no properties. */
+    emptyText?: string
+    className?: string
+}
+
+function isRecord(value: unknown): value is Record<string, unknown> {
+    return typeof value === "object" && value !== null && !Array.isArray(value)
+}
+
+function typeLabel(def: Record<string, unknown>): string {
+    const t = def.type
+    if (t === "array") {
+        const items = isRecord(def.items) ? def.items : null
+        const itemType = items && typeof items.type === "string" ? items.type : null
+        return itemType ? `array<${itemType}>` : "array"
+    }
+    if (Array.isArray(t)) {
+        const parts = t.filter((x): x is string => typeof x === "string")
+        return parts.length ? parts.join(" | ") : "any"
+    }
+    if (typeof t === "string") return t
+    return "any"
+}
+
+// The nested object schema to recurse into: an object's own props, or an array-of-objects' items.
+function childSchema(def: Record<string, unknown>): Record<string, unknown> | null {
+    if (def.type === "object" && isRecord(def.properties)) return def
+    if (def.type === "array" && isRecord(def.items)) {
+        const items = def.items
+        if (items.type === "object" && isRecord(items.properties)) return items
+    }
+    return null
+}
+
+function SchemaRows({node, depth}: {node: Record<string, unknown>; depth: number}) {
+    const props = isRecord(node.properties) ? node.properties : {}
+    const required = Array.isArray(node.required) ? (node.required as unknown[]) : []
+    const entries = Object.entries(props)
+    if (entries.length === 0) return null
+
+    return (
+        <div
+            className={
+                depth > 0
+                    ? "flex flex-col border-0 border-l border-solid border-[var(--ag-colorBorderSecondary)] pl-3"
+                    : "flex flex-col"
+            }
+        >
+            {entries.map(([name, rawDef]) => {
+                const def = isRecord(rawDef) ? rawDef : {}
+                const child = childSchema(def)
+                const description = typeof def.description === "string" ? def.description : ""
+                return (
+                    <div key={name} className="py-1.5">
+                        <div className="flex items-baseline gap-2">
+                            <span className="font-mono text-xs text-[var(--ag-colorText)]">
+                                {name}
+                            </span>
+                            <span className="text-[11px] text-[var(--ag-colorTextSecondary)]">
+                                {typeLabel(def)}
+                            </span>
+                            {required.includes(name) ? (
+                                <Tag
+                                    color="red"
+                                    bordered={false}
+                                    className="m-0 px-1.5 py-0 text-[10px] leading-[18px]"
+                                >
+                                    required
+                                </Tag>
+                            ) : (
+                                <span className="text-[10px] text-[var(--ag-colorTextTertiary)]">
+                                    optional
+                                </span>
+                            )}
+                        </div>
+                        {description ? (
+                            <p className="m-0 mt-0.5 text-[11px] leading-snug text-[var(--ag-colorTextTertiary)]">
+                                {description}
+                            </p>
+                        ) : null}
+                        {child ? (
+                            <div className="mt-1">
+                                <SchemaRows node={child} depth={depth + 1} />
+                            </div>
+                        ) : null}
+                    </div>
+                )
+            })}
+        </div>
+    )
+}
+
+export function SchemaTree({schema, emptyText = "No declared fields", className}: SchemaTreeProps) {
+    const node = isRecord(schema) ? schema : null
+    const props = node && isRecord(node.properties) ? node.properties : {}
+    const description = typeof node?.description === "string" ? node.description : ""
+
+    if (Object.keys(props).length === 0) {
+        return (
+            <div className={`text-[11px] text-[var(--ag-colorTextTertiary)] ${className ?? ""}`}>
+                {emptyText}
+            </div>
+        )
+    }
+
+    return (
+        <div className={className}>
+            {description ? (
+                <p className="m-0 mb-1.5 text-[11px] leading-snug text-[var(--ag-colorTextTertiary)]">
+                    {description}
+                </p>
+            ) : null}
+            <SchemaRows node={node as Record<string, unknown>} depth={0} />
+        </div>
+    )
+}

--- a/web/packages/agenta-entity-ui/src/DrillInView/SchemaControls/ToolFormView.tsx
+++ b/web/packages/agenta-entity-ui/src/DrillInView/SchemaControls/ToolFormView.tsx
@@ -1,16 +1,36 @@
 /**
  * ToolFormView
  *
- * Structured form view for a function tool, the Form side of {@link ConfigItemDrawer}. Edits
- * the OpenAI-style `function` shape — name, description, and a JSON-Schema `parameters` block.
- * Builtin/provider tools (a bare `type` with no editable `function`) have no meaningful form,
- * so the host renders the drawer JSON-only for those rather than this view.
+ * Structured Form side of the tool {@link ConfigItemDrawer} for a schema-only `function` tool. A
+ * two-panel master/detail: the left {@link ParameterTree} rail is the tool's JSON-Schema parameters;
+ * the right panel is contextual — the {@link ParameterNodeEditor} for the selected parameter, or the
+ * tool **basics** (name / description / permission) while nothing is selected, so the drawer never
+ * opens blank and the tool name is the first thing seen. The drawer's JSON toggle stays the lossless
+ * escape hatch for shapes the form can't express (enums, unions, tuples).
+ *
+ * Built to match the sibling drawers (WorkflowReferenceSelector, trigger drawers): 240px rail with a
+ * right border, independent scroll, shared `RowRemoveButton`, semantic `--ag-color*` tokens (dark-safe).
  */
-import {LabeledField} from "@agenta/ui/components/presentational"
-import {Code} from "@phosphor-icons/react"
-import {Input, Select} from "antd"
+import {useState} from "react"
 
-import {JsonObjectEditor} from "./JsonObjectEditor"
+import {Code} from "@phosphor-icons/react"
+import {Input, Select, Switch} from "antd"
+
+import {RailField} from "../../drawers/shared/RailField"
+
+import {ParameterNodeEditor} from "./agentTemplate/ParameterNodeEditor"
+import {ParameterTree} from "./agentTemplate/ParameterTree"
+import {
+    addPropertyAt,
+    getNodeAt,
+    getProps,
+    isRecord,
+    removeNodeAt,
+    type Schema,
+    type Seg,
+} from "./agentTemplate/schemaPaths"
+import {ReferenceToolFormView} from "./ReferenceToolFormView"
+import {parseGatewayFunctionName} from "./toolUtils"
 
 export interface ToolFormViewProps {
     value: Record<string, unknown>
@@ -54,18 +74,33 @@ function readPermission(
     return undefined
 }
 
-export function ToolFormView({value, onChange, disabled}: ToolFormViewProps) {
-    const tool = (value ?? {}) as Record<string, unknown>
+/** Tool basics — shown in the detail panel while no parameter node is selected. */
+function ToolBasics({
+    tool,
+    onChange,
+    disabled,
+}: {
+    tool: Record<string, unknown>
+    onChange: (next: Record<string, unknown>) => void
+    disabled?: boolean
+}) {
     const fn = (tool.function ?? {}) as Record<string, unknown>
-
-    const setFn = (key: string, fieldValue: unknown) => {
+    const setFn = (fieldKey: string, fieldValue: unknown) => {
         const nextFn = {...fn}
         if (fieldValue === undefined || fieldValue === null || fieldValue === "") {
-            delete nextFn[key]
+            delete nextFn[fieldKey]
         } else {
-            nextFn[key] = fieldValue
+            nextFn[fieldKey] = fieldValue
         }
         onChange({...tool, function: nextFn})
+    }
+
+    // `additionalProperties` on the parameters object: off (false) means only the listed params
+    // are accepted; on (true) allows extra keys. Undefined is treated as off.
+    const params = isRecord(fn.parameters) ? (fn.parameters as Record<string, unknown>) : {}
+    const additionalProperties = params.additionalProperties === true
+    const setAdditionalProperties = (on: boolean) => {
+        onChange({...tool, function: {...fn, parameters: {...params, additionalProperties: on}}})
     }
 
     const metadata = tool.agenta_metadata as Record<string, unknown> | undefined
@@ -88,62 +123,161 @@ export function ToolFormView({value, onChange, disabled}: ToolFormViewProps) {
     }
 
     return (
-        <div className="flex flex-col gap-3">
-            <LabeledField label="Name">
-                <Input
-                    value={(fn.name as string | undefined) ?? ""}
-                    onChange={(e) => setFn("name", e.target.value)}
-                    placeholder="get_weather"
-                    disabled={disabled}
-                />
-            </LabeledField>
-
-            <LabeledField label="Description">
-                <Input.TextArea
-                    value={(fn.description as string | undefined) ?? ""}
-                    onChange={(e) => setFn("description", e.target.value)}
-                    autoSize={{minRows: 2, maxRows: 6}}
-                    placeholder="What the tool does and when to use it"
-                    disabled={disabled}
-                />
-            </LabeledField>
-
-            <LabeledField
-                label="Permission"
-                description="How tool-use is gated: allow auto-approves, ask prompts the user, deny blocks. Leave unset to inherit the agent's permission policy."
-                withTooltip
-            >
-                <Select<ToolPermission>
-                    value={permission ?? undefined}
-                    onChange={(v) => setPermission(v ?? null)}
-                    options={PERMISSION_OPTIONS}
-                    placeholder={
-                        permissionDefault ? `${permissionDefault} (default)` : "Inherit policy"
-                    }
-                    allowClear
-                    className="w-full"
-                    disabled={disabled}
-                />
-            </LabeledField>
-
-            <div className="flex items-start gap-2 rounded border border-solid border-[var(--ag-c-EAEFF5,#eaeff5)] bg-[var(--ag-c-F5F7FA,#f5f7fa)] px-3 py-2 text-xs text-[var(--ag-c-586673,#586673)]">
-                <Code size={14} className="mt-0.5 shrink-0" />
-                <span>
-                    A schema-only tool — the model emits a call and your application executes it.
-                </span>
+        <div className="flex flex-col gap-4">
+            <div className="text-[11px] font-medium uppercase tracking-wide text-[var(--ag-colorTextTertiary)]">
+                Tool details
             </div>
 
-            <LabeledField
-                label="Input schema (JSON Schema)"
-                description="JSON Schema describing the tool's input arguments"
-                withTooltip
-            >
-                <JsonObjectEditor
-                    value={fn.parameters ?? {}}
-                    onChange={(parameters) => setFn("parameters", parameters)}
-                    disabled={disabled}
-                />
-            </LabeledField>
+            <div className="flex flex-col gap-3">
+                <RailField label="Name" align="center">
+                    <Input
+                        value={(fn.name as string | undefined) ?? ""}
+                        onChange={(e) => setFn("name", e.target.value)}
+                        placeholder="get_weather"
+                        disabled={disabled}
+                    />
+                </RailField>
+
+                <RailField label="Description">
+                    <Input.TextArea
+                        value={(fn.description as string | undefined) ?? ""}
+                        onChange={(e) => setFn("description", e.target.value)}
+                        autoSize={{minRows: 2, maxRows: 6}}
+                        placeholder="What the tool does and when to use it"
+                        disabled={disabled}
+                    />
+                </RailField>
+
+                <RailField label="Permission" align="center">
+                    <Select<ToolPermission>
+                        value={permission ?? undefined}
+                        onChange={(v) => setPermission(v ?? null)}
+                        options={PERMISSION_OPTIONS}
+                        placeholder={
+                            permissionDefault ? `${permissionDefault} (default)` : "Inherit policy"
+                        }
+                        allowClear
+                        className="w-full"
+                        disabled={disabled}
+                    />
+                </RailField>
+
+                <RailField label="Allow extra properties" align="center">
+                    <div className="flex items-center gap-2">
+                        <Switch
+                            checked={additionalProperties}
+                            onChange={setAdditionalProperties}
+                            disabled={disabled}
+                        />
+                        <span className="text-[11px] text-[var(--ag-colorTextTertiary)]">
+                            {additionalProperties
+                                ? "Inputs may include keys not listed above."
+                                : "Only the listed parameters are accepted."}
+                        </span>
+                    </div>
+                </RailField>
+            </div>
+
+            {(() => {
+                // A connected-app tool with no parameters means its provider input schema couldn't
+                // be loaded — say so, and prompt the user to define the inputs (instead of the
+                // generic schema-only hint that reads oddly for a fetched app tool).
+                const gateway = parseGatewayFunctionName(fn.name as string | undefined)
+                const noParams = Object.keys(getProps(params as Schema)).length === 0
+                if (gateway && noParams) {
+                    return (
+                        <div className="flex items-start gap-2 rounded border border-solid border-[var(--ag-colorBorderSecondary)] bg-[var(--ag-colorFillTertiary)] px-3 py-2 text-xs text-[var(--ag-colorWarningText)]">
+                            <Code
+                                size={14}
+                                className="mt-0.5 shrink-0 text-[var(--ag-colorWarning)]"
+                            />
+                            <span>
+                                Couldn&apos;t load {gateway.integration}&apos;s input schema for
+                                this action. Add the parameters it expects on the left (or paste
+                                them via JSON) so the model knows what to send.
+                            </span>
+                        </div>
+                    )
+                }
+                return (
+                    <div className="flex items-start gap-2 rounded border border-solid border-[var(--ag-colorBorderSecondary)] bg-[var(--ag-colorFillTertiary)] px-3 py-2 text-xs text-[var(--ag-colorTextSecondary)]">
+                        <Code size={14} className="mt-0.5 shrink-0" />
+                        <span>
+                            A schema-only tool — the model emits a call and your application
+                            executes it. Define the inputs it provides in the parameters on the
+                            left.
+                        </span>
+                    </div>
+                )
+            })()}
+        </div>
+    )
+}
+
+export function ToolFormView({value, onChange, disabled}: ToolFormViewProps) {
+    const tool = (value ?? {}) as Record<string, unknown>
+    // A workflow-reference tool has no editable `function` — it gets its own detail view (exposed
+    // name / schema / reference-by), the edit counterpart of the WorkflowReferenceSelector.
+    if (tool.type === "reference") {
+        return <ReferenceToolFormView value={tool} onChange={onChange} disabled={disabled} />
+    }
+    const fn = (tool.function ?? {}) as Record<string, unknown>
+    const parameters: Schema = isRecord(fn.parameters) ? (fn.parameters as Schema) : {}
+
+    // Selected parameter node (null → show tool basics). Local; the drawer remounts per item.
+    const [selectedPath, setSelectedPath] = useState<Seg[] | null>(null)
+
+    const setParameters = (next: Schema) => onChange({...tool, function: {...fn, parameters: next}})
+
+    const handleAddRoot = () => {
+        const {schema, key} = addPropertyAt(parameters, [])
+        setParameters(schema)
+        setSelectedPath([{p: key}])
+    }
+
+    const handleAddProperty = (parentPath: Seg[]) => {
+        const {schema, key} = addPropertyAt(parameters, parentPath)
+        setParameters(schema)
+        setSelectedPath([...parentPath, {p: key}])
+    }
+
+    const handleRemove = (parentPath: Seg[], key: string) => {
+        const next = removeNodeAt(parameters, parentPath, key)
+        setParameters(next)
+        // Drop the selection if the removed node was (an ancestor of) what was selected.
+        if (selectedPath && getNodeAt(next, selectedPath) === null) setSelectedPath(null)
+    }
+
+    const selectionValid = selectedPath != null && getNodeAt(parameters, selectedPath) !== null
+
+    return (
+        <div className="flex min-h-0 flex-1">
+            <ParameterTree
+                schema={parameters}
+                selectedPath={selectionValid ? selectedPath : null}
+                onSelect={setSelectedPath}
+                metaSelected={!selectionValid}
+                onSelectMeta={() => setSelectedPath(null)}
+                onAddRoot={handleAddRoot}
+                onAddProperty={handleAddProperty}
+                onRemove={handleRemove}
+                disabled={disabled}
+            />
+
+            <div className="min-w-0 flex-1 overflow-y-auto px-4 py-4">
+                {selectionValid && selectedPath ? (
+                    <ParameterNodeEditor
+                        schema={parameters}
+                        path={selectedPath}
+                        onChange={setParameters}
+                        onPathChange={setSelectedPath}
+                        onAddChild={handleAddProperty}
+                        disabled={disabled}
+                    />
+                ) : (
+                    <ToolBasics tool={tool} onChange={onChange} disabled={disabled} />
+                )}
+            </div>
         </div>
     )
 }

--- a/web/packages/agenta-entity-ui/src/DrillInView/SchemaControls/ToolSelectorPopover.tsx
+++ b/web/packages/agenta-entity-ui/src/DrillInView/SchemaControls/ToolSelectorPopover.tsx
@@ -67,6 +67,12 @@ export interface ToolSelectionMeta {
     toolLabel?: string
     integrationKey?: string
     connectionSlug?: string
+    /**
+     * Open the tool config editor instead of adding immediately (append on Save). Set when a
+     * gateway action's input schema couldn't be resolved, so the user defines the parameters in
+     * the editor rather than getting a silent schema-less tool. Transient — not persisted.
+     */
+    needsConfig?: boolean
 }
 
 export interface ToolSelectorPopoverProps {

--- a/web/packages/agenta-entity-ui/src/DrillInView/SchemaControls/TriggerManagementSection.tsx
+++ b/web/packages/agenta-entity-ui/src/DrillInView/SchemaControls/TriggerManagementSection.tsx
@@ -37,29 +37,27 @@ import {
 } from "@agenta/entities/gatewayTrigger"
 import {workflowMolecule} from "@agenta/entities/workflow"
 import {simulatedAgentRunAtomFamily} from "@agenta/shared/state"
-import {HeightCollapse, message} from "@agenta/ui"
+import {message} from "@agenta/ui"
 import {MoreOutlined} from "@ant-design/icons"
 import {
     ArrowsClockwise,
-    CaretDown,
     CaretRight,
     Clock,
     Flask,
     Lightning,
     ListChecks,
     PencilSimpleLine,
-    Plugs,
     Plus,
     Sparkle,
     Trash,
     XCircle,
 } from "@phosphor-icons/react"
-import {Button, Dropdown, Tag, Tooltip} from "antd"
+import {Button, Dropdown, Tooltip} from "antd"
 import type {MenuProps} from "antd"
 import {useAtom, useAtomValue, useSetAtom} from "jotai"
 import {atomWithStorage} from "jotai/utils"
-import Image from "next/image"
 
+import {AddItemMenu, type AddItemGroup} from "../../drawers/shared/AddItemMenu"
 import {loadRecentSamples, waitForNewDelivery} from "../../gatewayTrigger/drawers/shared/deliveries"
 import {
     EventSourcePicker,
@@ -70,6 +68,7 @@ import TriggerScheduleDrawer from "../../gatewayTrigger/drawers/TriggerScheduleD
 import TriggerSubscriptionDrawer from "../../gatewayTrigger/drawers/TriggerSubscriptionDrawer"
 
 import {AddTextLink} from "./AddTextLink"
+import {CollapsibleProviderGroup, SubSectionHeader} from "./sectionGroups"
 
 // Persisted per-agent expand state for provider groups (key = `${entityId}:${providerKey}`).
 const triggerGroupsExpandedAtom = atomWithStorage<Record<string, boolean>>(
@@ -88,20 +87,6 @@ function prettifyEventKey(key: string): string {
 function prettifyProvider(key: string): string {
     if (!key) return "Other"
     return key.charAt(0).toUpperCase() + key.slice(1)
-}
-
-function ProviderLogo({logo, size = 24}: {logo?: string | null; size?: number}) {
-    if (!logo) return <Plugs size={size} className="shrink-0 text-[var(--ag-colorTextSecondary)]" />
-    return (
-        <Image
-            src={logo}
-            alt=""
-            width={size}
-            height={size}
-            unoptimized
-            className="shrink-0 rounded object-contain"
-        />
-    )
 }
 
 interface ProviderGroupData {
@@ -737,132 +722,84 @@ export function TriggerManagementSection({entityId, disabled}: TriggerManagement
                     {/* App triggers — grouped by provider (subscriptions first). */}
                     {providerGroups.length > 0 && (
                         <div className="flex flex-col gap-2">
-                            <div className="flex items-center gap-1.5 px-0.5 text-[10px] uppercase tracking-wide text-[var(--ag-colorTextTertiary)]">
-                                <span>App triggers</span>
-                                <Tag
-                                    bordered
-                                    className="m-0 !px-1.5 !text-[10px] font-normal leading-[16px]"
-                                >
-                                    {scopedSubscriptions.length}
-                                </Tag>
-                            </div>
+                            <SubSectionHeader
+                                label="App triggers"
+                                count={scopedSubscriptions.length}
+                            />
                             {providerGroups.map((group) => {
                                 const open = isGroupOpen(group)
                                 const activeCount = group.subs.filter(isEntityActive).length
                                 return (
-                                    <div
+                                    <CollapsibleProviderGroup
                                         key={group.key}
-                                        className="overflow-hidden rounded border border-solid border-[var(--ag-colorBorderSecondary)]"
+                                        logo={group.logo}
+                                        name={group.name}
+                                        countText={`${activeCount} active · ${group.subs.length} total`}
+                                        open={open}
+                                        onToggle={() => toggleGroup(group)}
+                                        onAdd={
+                                            !disabled
+                                                ? () =>
+                                                      openSubscriptionDrawer({
+                                                          defaultReferences,
+                                                          defaultBoundLabel,
+                                                          playgroundEntityId: entityId ?? undefined,
+                                                          integrationKey: group.key,
+                                                          integrationName: group.name,
+                                                      })
+                                                : undefined
+                                        }
+                                        addLabel={`Add ${group.name} trigger`}
                                     >
-                                        <div
-                                            role="button"
-                                            tabIndex={0}
-                                            aria-expanded={open}
-                                            onClick={() => toggleGroup(group)}
-                                            onKeyDown={(e) => {
-                                                if (e.target !== e.currentTarget) return
-                                                if (e.key === "Enter" || e.key === " ") {
-                                                    e.preventDefault()
-                                                    toggleGroup(group)
-                                                }
-                                            }}
-                                            className="flex cursor-pointer items-center gap-2.5 bg-[var(--ag-colorFillQuaternary)] px-3 py-2 transition-colors hover:bg-[var(--ag-colorFillSecondary)]"
-                                        >
-                                            {open ? (
-                                                <CaretDown
-                                                    size={12}
-                                                    className="shrink-0 text-[var(--ag-colorTextSecondary)]"
-                                                />
-                                            ) : (
-                                                <CaretRight
-                                                    size={12}
-                                                    className="shrink-0 text-[var(--ag-colorTextSecondary)]"
-                                                />
-                                            )}
-                                            <ProviderLogo logo={group.logo} size={24} />
-                                            <span className="min-w-0 flex-1 truncate text-xs font-medium">
-                                                {group.name}
-                                            </span>
-                                            <span className="shrink-0 text-[11px] text-[var(--ag-colorTextTertiary)]">
-                                                {activeCount} active · {group.subs.length} total
-                                            </span>
-                                            {!disabled && (
-                                                <Tooltip title={`Add ${group.name} trigger`}>
-                                                    <Button
-                                                        type="text"
-                                                        icon={<Plus size={16} />}
-                                                        aria-label={`Add ${group.name} trigger`}
-                                                        onClick={(e) => {
-                                                            e.stopPropagation()
-                                                            openSubscriptionDrawer({
-                                                                defaultReferences,
-                                                                defaultBoundLabel,
-                                                                playgroundEntityId:
-                                                                    entityId ?? undefined,
-                                                                integrationKey: group.key,
-                                                                integrationName: group.name,
-                                                            })
-                                                        }}
-                                                    />
-                                                </Tooltip>
-                                            )}
-                                        </div>
-                                        <HeightCollapse open={open}>
-                                            <div className="flex flex-col gap-0.5 px-1.5 pb-1.5 pt-1">
-                                                {group.subs.map((record) => {
-                                                    const named = !!record.name?.trim()
-                                                    const eventLabel = prettifyEventKey(
-                                                        record.data?.event_key ?? "",
-                                                    )
-                                                    const primary = named
-                                                        ? (record.name as string)
-                                                        : eventLabel || "Untitled subscription"
-                                                    const secondary = named
-                                                        ? eventLabel || undefined
-                                                        : connectionLabel(record.connection_id) ||
-                                                          record.description ||
-                                                          undefined
-                                                    return (
-                                                        <SubscriptionChildRow
-                                                            key={`subscription-${record.id}`}
-                                                            primary={primary}
-                                                            primaryMuted={!named && !eventLabel}
-                                                            secondary={secondary}
-                                                            active={isEntityActive(record)}
-                                                            disabled={disabled}
-                                                            runSlot={
-                                                                <SubscriptionRunPopover
-                                                                    subscriptionId={record.id ?? ""}
-                                                                    label={
-                                                                        record.name ||
-                                                                        eventLabel ||
-                                                                        "trigger"
-                                                                    }
-                                                                    eventKey={
-                                                                        record.data?.event_key ??
-                                                                        undefined
-                                                                    }
-                                                                    playgroundEntityId={entityId}
-                                                                    disabled={
-                                                                        disabled || !record.id
-                                                                    }
-                                                                />
+                                        {group.subs.map((record) => {
+                                            const named = !!record.name?.trim()
+                                            const eventLabel = prettifyEventKey(
+                                                record.data?.event_key ?? "",
+                                            )
+                                            const primary = named
+                                                ? (record.name as string)
+                                                : eventLabel || "Untitled subscription"
+                                            const secondary = named
+                                                ? eventLabel || undefined
+                                                : connectionLabel(record.connection_id) ||
+                                                  record.description ||
+                                                  undefined
+                                            return (
+                                                <SubscriptionChildRow
+                                                    key={`subscription-${record.id}`}
+                                                    primary={primary}
+                                                    primaryMuted={!named && !eventLabel}
+                                                    secondary={secondary}
+                                                    active={isEntityActive(record)}
+                                                    disabled={disabled}
+                                                    runSlot={
+                                                        <SubscriptionRunPopover
+                                                            subscriptionId={record.id ?? ""}
+                                                            label={
+                                                                record.name ||
+                                                                eventLabel ||
+                                                                "trigger"
                                                             }
-                                                            onOpen={() =>
-                                                                record.id &&
-                                                                openSubscriptionDrawer({
-                                                                    subscriptionId: record.id,
-                                                                    playgroundEntityId:
-                                                                        entityId ?? undefined,
-                                                                })
+                                                            eventKey={
+                                                                record.data?.event_key ?? undefined
                                                             }
-                                                            menuItems={subscriptionMenu(record)}
+                                                            playgroundEntityId={entityId}
+                                                            disabled={disabled || !record.id}
                                                         />
-                                                    )
-                                                })}
-                                            </div>
-                                        </HeightCollapse>
-                                    </div>
+                                                    }
+                                                    onOpen={() =>
+                                                        record.id &&
+                                                        openSubscriptionDrawer({
+                                                            subscriptionId: record.id,
+                                                            playgroundEntityId:
+                                                                entityId ?? undefined,
+                                                        })
+                                                    }
+                                                    menuItems={subscriptionMenu(record)}
+                                                />
+                                            )
+                                        })}
+                                    </CollapsibleProviderGroup>
                                 )
                             })}
                         </div>
@@ -871,15 +808,7 @@ export function TriggerManagementSection({entityId, disabled}: TriggerManagement
                     {/* Schedules — flat (no provider), listed last. */}
                     {scopedSchedules.length > 0 && (
                         <div className="flex flex-col gap-2">
-                            <div className="flex items-center gap-1.5 px-0.5 text-[10px] uppercase tracking-wide text-[var(--ag-colorTextTertiary)]">
-                                <span>Schedules</span>
-                                <Tag
-                                    bordered
-                                    className="m-0 !px-1.5 !text-[10px] font-normal leading-[16px]"
-                                >
-                                    {scopedSchedules.length}
-                                </Tag>
-                            </div>
+                            <SubSectionHeader label="Schedules" count={scopedSchedules.length} />
                             {scopedSchedules.map((record) => {
                                 const cron = record.data?.schedule
                                 const named = !!record.name?.trim()
@@ -944,39 +873,49 @@ export function AddTriggerDropdown({
     const openSubscriptionDrawer = useSetAtom(triggerSubscriptionDrawerAtom)
     const openScheduleDrawer = useSetAtom(triggerScheduleDrawerAtom)
 
-    const items: MenuProps["items"] = useMemo(
+    // Shares the tools add-menu's row treatment (AddItemMenu). A trigger is always a NEW trigger of
+    // some kind, so the tools' "add existing / create new" split doesn't apply — one "Add new"
+    // section (kept labelled for visual consistency with the tools popover) lists the trigger types.
+    const groups: AddItemGroup[] = useMemo(
         () => [
             {
-                key: "ai",
-                label: (
-                    <Tooltip title="Coming soon">
-                        <span>Create with AI</span>
-                    </Tooltip>
-                ),
-                icon: <Sparkle size={16} />,
-                disabled: true,
-            },
-            {
-                key: "app",
-                label: "App trigger",
-                icon: <Lightning size={16} />,
-                onClick: () =>
-                    openSubscriptionDrawer({
-                        defaultReferences,
-                        defaultBoundLabel,
-                        playgroundEntityId: entityId ?? undefined,
-                    }),
-            },
-            {
-                key: "schedule",
-                label: "Scheduled trigger",
-                icon: <Clock size={16} />,
-                onClick: () =>
-                    openScheduleDrawer({
-                        defaultReferences,
-                        defaultBoundLabel,
-                        playgroundEntityId: entityId ?? undefined,
-                    }),
+                label: "Add new",
+                items: [
+                    {
+                        key: "app",
+                        icon: <Lightning size={17} />,
+                        title: "App trigger",
+                        subtitle: "React to an event from a connected app",
+                        opensDrawer: true,
+                        onSelect: () =>
+                            openSubscriptionDrawer({
+                                defaultReferences,
+                                defaultBoundLabel,
+                                playgroundEntityId: entityId ?? undefined,
+                            }),
+                    },
+                    {
+                        key: "schedule",
+                        icon: <Clock size={17} />,
+                        title: "Scheduled trigger",
+                        subtitle: "Run on a recurring schedule",
+                        opensDrawer: true,
+                        onSelect: () =>
+                            openScheduleDrawer({
+                                defaultReferences,
+                                defaultBoundLabel,
+                                playgroundEntityId: entityId ?? undefined,
+                            }),
+                    },
+                    {
+                        key: "ai",
+                        icon: <Sparkle size={17} />,
+                        title: "Create with AI",
+                        subtitle: "Describe it and let AI set it up",
+                        disabled: true,
+                        disabledHint: "Coming soon",
+                    },
+                ],
             },
         ],
         [
@@ -989,17 +928,21 @@ export function AddTriggerDropdown({
     )
 
     return (
-        <Dropdown trigger={["click"]} menu={{items}} styles={{root: {width: 200}}}>
-            {trigger ?? (
-                <Tooltip title="Add trigger">
-                    <Button
-                        type="text"
-                        icon={<Plus size={16} />}
-                        aria-label="Add trigger"
-                        onClick={(e) => e.stopPropagation()}
-                    />
-                </Tooltip>
-            )}
-        </Dropdown>
+        <AddItemMenu
+            groups={groups}
+            ariaLabel="Add trigger"
+            trigger={
+                trigger ?? (
+                    <Tooltip title="Add trigger">
+                        <Button
+                            type="text"
+                            icon={<Plus size={16} />}
+                            aria-label="Add trigger"
+                            onClick={(e) => e.stopPropagation()}
+                        />
+                    </Tooltip>
+                )
+            }
+        />
     )
 }

--- a/web/packages/agenta-entity-ui/src/DrillInView/SchemaControls/WorkflowReferenceSelector.tsx
+++ b/web/packages/agenta-entity-ui/src/DrillInView/SchemaControls/WorkflowReferenceSelector.tsx
@@ -1,38 +1,141 @@
 /**
  * WorkflowReferenceSelector
  *
- * A right-hand drawer for referencing a workflow as an agent tool (`type:"reference"`, #4860).
- * Opened from the "Reference a workflow" section's `+` in the tool selector. The author:
- *   1. picks a workflow from a searchable list (the `slug`),
- *   2. picks an axis — by variant (the workflow's latest revision or a pinned version) or by
- *      environment (whatever is deployed in a named environment),
- *   3. confirms, which emits a {@link WorkflowReferencePayload} the caller turns into a
- *      `ReferenceToolConfig`.
+ * Two-panel master/detail drawer for referencing a workflow as an agent tool
+ * (`type:"reference"`, #4860). Left rail: a searchable, type-badged list with present-only
+ * filter chips. Right panel: the selected workflow's detail — description, the tool name it's
+ * exposed as, the resolved input schema, and the axis controls (by variant/version or by
+ * environment) — then Add. When nothing is selected the detail panel shows a resting hint
+ * rather than dead space.
+ *
+ * Styling uses antd semantic tokens (`--ag-color*`) + antd `Tag` (theme-aware) only — dark-safe.
  * Built on the shared `EnhancedDrawer`.
  */
 import {useEffect, useMemo, useState} from "react"
 
+import {ConfigAccordionSection, CopyButton} from "@agenta/ui/components/presentational"
 import {EnhancedDrawer} from "@agenta/ui/drawer"
 import type {
+    WorkflowConfigPart,
     WorkflowReferenceBridge,
     WorkflowReferencePayload,
+    WorkflowReferenceType,
     WorkflowReferenceUI,
 } from "@agenta/ui/drill-in"
-import {ArrowLeft, GraphIcon, MagnifyingGlass} from "@phosphor-icons/react"
-import {Button, Empty, Input, Segmented, Select, Spin} from "antd"
+import {
+    GitBranch,
+    GraphIcon,
+    HandPointing,
+    MagnifyingGlass,
+    SlidersHorizontal,
+    TreeStructure,
+} from "@phosphor-icons/react"
+import {Empty, Input, Segmented, Skeleton, Spin, Tag} from "antd"
+import {atom, useSetAtom} from "jotai"
+
+import {DrawerFooter} from "../../drawers/shared/DrawerFooter"
+import {SectionRail} from "../../drawers/shared/SectionRail"
+import {RunVersionField} from "../../gatewayTrigger/drawers/shared/RunVersionField"
+import {createWorkflowRevisionAdapter, type WorkflowRevisionSelectionResult} from "../../selection"
+
+import {CodeEditor, type CodeEditorLanguage} from "./CodeEditor"
+import {SchemaTree} from "./SchemaTree"
 
 export interface WorkflowReferenceSelectorProps {
     open: boolean
     onClose: () => void
     /** Workflows available to reference (the caller filters out already-referenced ones). */
     workflows: WorkflowReferenceUI[]
-    /** Supplies the per-workflow revision and environment lookups. */
+    /** Supplies the per-workflow revision, environment, and input-schema lookups. */
     bridge: WorkflowReferenceBridge
     /** Emit the chosen reference (axis + slug + version/environment). */
     onSelect: (payload: WorkflowReferencePayload) => void
 }
 
-const LATEST_VALUE = "__latest__"
+// Workflow-scoped revision picker (2-level Variant → Revision) for the shared RunVersionField.
+// The atom is synced to the selected workflow so the cascader is scoped to it.
+const refWorkflowIdAtom = atom<string | null>(null)
+const referenceRevisionAdapter = createWorkflowRevisionAdapter({workflowIdAtom: refWorkflowIdAtom})
+
+// antd named colors adapt to dark mode via the theme algorithm.
+const TYPE_BADGE: Record<WorkflowReferenceType, {color: string; label: string}> = {
+    agent: {color: "purple", label: "agent"},
+    chat: {color: "blue", label: "chat"},
+    completion: {color: "cyan", label: "completion"},
+    custom: {color: "gold", label: "custom"},
+    evaluator: {color: "green", label: "evaluator"},
+}
+
+// Filter by the workflow's actual type, so the chips read the same as the row badges.
+type TypeFilter = "all" | WorkflowReferenceType
+
+const TYPE_FILTER_ORDER: WorkflowReferenceType[] = [
+    "completion",
+    "chat",
+    "agent",
+    "custom",
+    "evaluator",
+]
+
+function capitalize(value: string): string {
+    return value.charAt(0).toUpperCase() + value.slice(1)
+}
+
+function isRecord(value: unknown): value is Record<string, unknown> {
+    return typeof value === "object" && value !== null && !Array.isArray(value)
+}
+
+const noop = () => {}
+
+// Contained render of a Configuration part: the prompt "Messages" render as a role-tagged list;
+// plain text wraps in a box; code/JSON use the app's read-only code editor. Long content never grows
+// the panel (max-height + internal scroll).
+function ConfigPartContent({part}: {part: WorkflowConfigPart}) {
+    if (part.kind === "messages" && part.messages) {
+        return (
+            <div className="flex max-h-[360px] max-w-prose flex-col gap-3 overflow-y-auto overscroll-contain">
+                {part.messages.map((message, i) => (
+                    <div key={i} className="flex flex-col gap-1">
+                        <span className="text-[10px] font-medium uppercase tracking-wide text-[var(--ag-colorTextTertiary)]">
+                            {capitalize(message.role)}
+                        </span>
+                        <div className="whitespace-pre-wrap break-words rounded-md border border-solid border-[var(--ag-colorBorderSecondary)] bg-[var(--ag-colorFillTertiary)] px-2.5 py-2 text-xs leading-relaxed text-[var(--ag-colorText)]">
+                            {message.content}
+                        </div>
+                    </div>
+                ))}
+            </div>
+        )
+    }
+    if (part.kind === "text") {
+        return (
+            <div className="max-h-[320px] max-w-prose overflow-y-auto overscroll-contain whitespace-pre-wrap break-words rounded-md border border-solid border-[var(--ag-colorBorderSecondary)] bg-[var(--ag-colorFillTertiary)] px-2.5 py-2 text-xs leading-relaxed text-[var(--ag-colorText)]">
+                {part.content}
+            </div>
+        )
+    }
+    const language: CodeEditorLanguage =
+        part.kind === "json" ? "json" : ((part.language ?? "code") as CodeEditorLanguage)
+    return (
+        <div className="max-h-[360px] max-w-prose overflow-auto overscroll-contain">
+            <CodeEditor value={part.content} onChange={noop} language={language} disabled />
+        </div>
+    )
+}
+
+function TypeBadge({type, label}: {type: WorkflowReferenceType | undefined; label?: string}) {
+    if (!type) return null
+    const cfg = TYPE_BADGE[type]
+    return (
+        <Tag
+            color={cfg.color}
+            className="m-0 max-w-[140px] truncate px-1.5 py-0 text-[10px] leading-[18px]"
+            bordered={false}
+        >
+            {label || cfg.label}
+        </Tag>
+    )
+}
 
 export function WorkflowReferenceSelector({
     open,
@@ -42,47 +145,182 @@ export function WorkflowReferenceSelector({
     onSelect,
 }: WorkflowReferenceSelectorProps) {
     const [search, setSearch] = useState("")
+    const [filter, setFilter] = useState<TypeFilter>("all")
     const [selected, setSelected] = useState<WorkflowReferenceUI | null>(null)
-    const [refBy, setRefBy] = useState<"variant" | "environment">("variant")
+    // bindMode mirrors RunVersionField: "revision" (pin a variant+revision) | "environment" (deployed).
+    const [bindMode, setBindMode] = useState<"revision" | "environment">("revision")
     const [version, setVersion] = useState<string | undefined>(undefined)
     const [environment, setEnvironment] = useState<string | undefined>(undefined)
+    const [inputSchema, setInputSchema] = useState<Record<string, unknown> | null>(null)
+    const [outputSchema, setOutputSchema] = useState<Record<string, unknown> | null>(null)
+    const [schemaLoading, setSchemaLoading] = useState(false)
+    // Schema section's left-rail selection (Inputs / Outputs). Outputs appears only when the
+    // bridge resolves an output schema; otherwise the rail shows Inputs alone.
+    const [schemaTab, setSchemaTab] = useState<"inputs" | "outputs">("inputs")
+    // Configuration section: type-specific parts (code / prompt+model / agent) + selected part.
+    const [configParts, setConfigParts] = useState<WorkflowConfigPart[]>([])
+    const [configLoading, setConfigLoading] = useState(false)
+    const [configPartKey, setConfigPartKey] = useState<string | null>(null)
+    const setRefWorkflowId = useSetAtom(refWorkflowIdAtom)
 
-    // Reset to the workflow list whenever the drawer is (re)opened.
+    // Scope the revision picker to the selected workflow.
+    useEffect(() => {
+        setRefWorkflowId(selected?.id ?? null)
+    }, [selected?.id, setRefWorkflowId])
+
+    // Reset to a clean list state whenever the drawer is (re)opened.
     useEffect(() => {
         if (!open) return
         setSearch("")
+        setFilter("all")
         setSelected(null)
     }, [open])
 
-    // Reset the axis selection when the chosen workflow changes (or is cleared), so a previous
-    // workflow's version/environment pick doesn't bleed into the new reference.
+    // Reset the axis selection when the chosen workflow changes, so a previous pick doesn't bleed in.
     useEffect(() => {
-        setRefBy("variant")
+        setBindMode("revision")
         setVersion(undefined)
         setEnvironment(undefined)
+        setSchemaTab("inputs")
+        setConfigPartKey(null)
     }, [selected?.id])
 
-    const {revisions, isLoading: revisionsLoading} = bridge.useWorkflowRevisions(selected)
+    // Resolve the selected workflow's input + output schemas for the Schema section.
+    useEffect(() => {
+        if (!selected) {
+            setInputSchema(null)
+            setOutputSchema(null)
+            return
+        }
+        let cancelled = false
+        setSchemaLoading(true)
+        setInputSchema(null)
+        setOutputSchema(null)
+        Promise.all([
+            bridge.resolveInputSchema(selected).catch(() => null),
+            bridge.resolveOutputSchema?.(selected).catch(() => null) ?? Promise.resolve(null),
+        ])
+            .then(([input, output]) => {
+                if (cancelled) return
+                setInputSchema(input)
+                setOutputSchema(output)
+            })
+            .finally(() => {
+                if (!cancelled) setSchemaLoading(false)
+            })
+        return () => {
+            cancelled = true
+        }
+    }, [selected, bridge])
+
+    // Resolve the selected workflow's type-specific configuration for the Configuration section.
+    useEffect(() => {
+        if (!selected || !bridge.resolveConfigPayload) {
+            setConfigParts([])
+            return
+        }
+        let cancelled = false
+        setConfigLoading(true)
+        setConfigParts([])
+        bridge
+            .resolveConfigPayload(selected)
+            .then((payload) => {
+                if (!cancelled) setConfigParts(payload?.parts ?? [])
+            })
+            .catch(() => {
+                if (!cancelled) setConfigParts([])
+            })
+            .finally(() => {
+                if (!cancelled) setConfigLoading(false)
+            })
+        return () => {
+            cancelled = true
+        }
+    }, [selected, bridge])
+
     const {environments, isLoading: environmentsLoading} = bridge.useWorkflowEnvironments(selected)
+
+    // The picker selects a leaf id + carries the revision's version number in metadata. A leaf that
+    // equals the variant id means "the variant" (latest → no pinned version); else pin that version.
+    const handleRevisionSelect = (sel: WorkflowRevisionSelectionResult) => {
+        const isRevision = Boolean(sel.metadata.variantId) && sel.id !== sel.metadata.variantId
+        setVersion(isRevision ? String(sel.metadata.revision) : undefined)
+    }
+
+    // List items carry no type (capability flags live on the revision URI), so the bridge resolves
+    // types by slug — plus a finer badge label for evaluators (their kind). Merge both in so badges,
+    // filter chips, and detail all read the real type.
+    const {typeBySlug, labelBySlug} = bridge.useWorkflowTypes(workflows)
+    const typedWorkflows = useMemo(
+        () =>
+            workflows.map((w) => ({
+                ...w,
+                type: typeBySlug[w.slug] ?? w.type,
+                typeLabel: labelBySlug?.[w.slug] ?? w.typeLabel,
+            })),
+        [workflows, typeBySlug, labelBySlug],
+    )
+
+    // Filter chips: only the types present in the available workflows (plus "All").
+    const filterOptions = useMemo(() => {
+        const present = new Set(typedWorkflows.map((w) => w.type).filter(Boolean))
+        const opts: {label: string; value: TypeFilter}[] = [{label: "All", value: "all"}]
+        for (const t of TYPE_FILTER_ORDER) {
+            if (present.has(t)) opts.push({label: capitalize(t), value: t})
+        }
+        return opts
+    }, [typedWorkflows])
 
     const filtered = useMemo(() => {
         const q = search.trim().toLowerCase()
-        if (!q) return workflows
-        return workflows.filter((w) =>
-            `${w.slug} ${w.name ?? ""} ${w.description ?? ""}`.toLowerCase().includes(q),
-        )
-    }, [workflows, search])
+        return typedWorkflows.filter((w) => {
+            if (filter !== "all" && w.type !== filter) return false
+            if (!q) return true
+            return `${w.slug} ${w.name ?? ""} ${w.description ?? ""}`.toLowerCase().includes(q)
+        })
+    }, [typedWorkflows, search, filter])
 
-    const canConfirm = Boolean(selected) && (refBy === "variant" || Boolean(environment))
+    const countProps = (schema: Record<string, unknown> | null): number =>
+        isRecord(schema?.properties) ? Object.keys(schema!.properties).length : 0
+
+    // Left-rail tabs for the Schema section. Outputs appears only when the bridge resolves an
+    // output schema with declared properties.
+    const schemaTabs = useMemo(() => {
+        const tabs: {
+            key: "inputs" | "outputs"
+            label: string
+            count: number
+            schema: Record<string, unknown> | null
+        }[] = [
+            {key: "inputs", label: "Inputs", count: countProps(inputSchema), schema: inputSchema},
+        ]
+        if (countProps(outputSchema) > 0) {
+            tabs.push({
+                key: "outputs",
+                label: "Outputs",
+                count: countProps(outputSchema),
+                schema: outputSchema,
+            })
+        }
+        return tabs
+    }, [inputSchema, outputSchema])
+    const activeSchema =
+        schemaTabs.find((t) => t.key === schemaTab)?.schema ?? schemaTabs[0]?.schema ?? null
+
+    // Configuration section: the selected part (defaults to the first) and its content.
+    const activeConfigPart =
+        configParts.find((p) => p.key === configPartKey) ?? configParts[0] ?? null
+
+    const canConfirm = Boolean(selected) && (bindMode === "revision" || Boolean(environment))
 
     const handleConfirm = () => {
         if (!selected) return
-        if (refBy === "environment" && !environment) return
+        if (bindMode === "environment" && !environment) return
         onSelect({
             slug: selected.slug,
-            refBy,
-            version: refBy === "variant" ? version : undefined,
-            environment: refBy === "environment" ? environment : undefined,
+            refBy: bindMode === "revision" ? "variant" : "environment",
+            version: bindMode === "revision" ? version : undefined,
+            environment: bindMode === "environment" ? environment : undefined,
         })
         onClose()
     }
@@ -92,7 +330,7 @@ export function WorkflowReferenceSelector({
             open={open}
             onClose={onClose}
             placement="right"
-            width={480}
+            width={960}
             destroyOnClose
             title={
                 <div className="flex items-center gap-2">
@@ -100,162 +338,271 @@ export function WorkflowReferenceSelector({
                     <span className="text-sm font-medium">Reference a workflow</span>
                 </div>
             }
-            styles={{body: {padding: 16}}}
+            styles={{
+                body: {padding: 0, display: "flex", flexDirection: "column", overflow: "hidden"},
+            }}
         >
-            {!selected ? (
-                <div className="flex flex-col gap-3">
-                    <Input
-                        prefix={<MagnifyingGlass size={14} className="text-zinc-400" />}
-                        placeholder="Search workflows"
-                        value={search}
-                        onChange={(e) => setSearch(e.target.value)}
-                        allowClear
-                    />
-                    <p className="m-0 text-xs text-[var(--ag-c-97A4B0,#97a4b0)]">
-                        The agent calls the chosen workflow as a tool; it runs server-side and
-                        returns its output.
-                    </p>
-                    {bridge.workflowsLoading ? (
-                        <div className="flex justify-center py-6">
-                            <Spin size="small" />
-                        </div>
-                    ) : filtered.length === 0 ? (
-                        <Empty
-                            image={Empty.PRESENTED_IMAGE_SIMPLE}
-                            description={
-                                <span className="text-xs text-zinc-400">
-                                    No workflows to reference
-                                </span>
+            <div className="flex min-h-0 flex-1">
+                {/* Master rail */}
+                <div className="flex w-[260px] shrink-0 flex-col border-0 border-r border-solid border-[var(--ag-colorBorderSecondary)]">
+                    <div className="shrink-0 border-0 border-b border-solid border-[var(--ag-colorBorderSecondary)] p-3">
+                        <Input
+                            prefix={
+                                <MagnifyingGlass
+                                    size={14}
+                                    className="text-[var(--ag-colorTextTertiary)]"
+                                />
                             }
+                            placeholder="Search workflows"
+                            value={search}
+                            onChange={(e) => setSearch(e.target.value)}
+                            allowClear
                         />
-                    ) : (
-                        <div className="flex flex-col gap-0.5">
-                            {filtered.map((wf) => (
-                                <button
-                                    type="button"
-                                    key={wf.id}
-                                    onClick={() => setSelected(wf)}
-                                    className="flex w-full flex-col items-start gap-0.5 rounded-md border-none bg-transparent px-2 py-2 text-left cursor-pointer hover:bg-zinc-50 dark:hover:bg-[var(--ag-rgba-051729-04)]"
-                                >
-                                    <div className="flex w-full items-center gap-2">
-                                        <GraphIcon size={14} className="shrink-0 text-teal-600" />
-                                        <span className="truncate text-xs font-medium">
-                                            {wf.name || wf.slug}
-                                        </span>
-                                    </div>
-                                    <span className="truncate pl-6 text-[11px] text-zinc-400">
-                                        {wf.description || wf.slug}
+                        <p className="m-0 mt-2 text-[11px] leading-snug text-[var(--ag-colorTextTertiary)]">
+                            The agent calls the chosen workflow as a tool; it runs server-side and
+                            returns its output.
+                        </p>
+                        {filterOptions.length > 1 && (
+                            <div className="mt-2 overflow-x-auto">
+                                <Segmented
+                                    className="w-max"
+                                    value={filter}
+                                    onChange={(val) => setFilter(val as TypeFilter)}
+                                    options={filterOptions}
+                                />
+                            </div>
+                        )}
+                    </div>
+
+                    <div className="min-h-0 flex-1 overflow-y-auto p-1.5">
+                        {bridge.workflowsLoading ? (
+                            <div className="flex justify-center py-6">
+                                <Spin size="small" />
+                            </div>
+                        ) : filtered.length === 0 ? (
+                            <Empty
+                                image={Empty.PRESENTED_IMAGE_SIMPLE}
+                                description={
+                                    <span className="text-xs text-[var(--ag-colorTextTertiary)]">
+                                        No workflows to reference
                                     </span>
-                                </button>
-                            ))}
-                        </div>
-                    )}
-                </div>
-            ) : (
-                <div className="flex flex-col gap-4">
-                    <button
-                        type="button"
-                        onClick={() => setSelected(null)}
-                        className="flex w-fit items-center gap-1 border-none bg-transparent p-0 text-xs text-zinc-500 cursor-pointer hover:text-zinc-700"
-                    >
-                        <ArrowLeft size={12} />
-                        Back to workflows
-                    </button>
-
-                    <div className="flex items-center gap-2">
-                        <GraphIcon size={16} className="shrink-0 text-teal-600" />
-                        <div className="flex flex-col min-w-0">
-                            <span className="truncate text-sm font-medium">
-                                {selected.name || selected.slug}
-                            </span>
-                            <span className="truncate text-[11px] text-zinc-400">
-                                {selected.slug}
-                            </span>
-                        </div>
-                    </div>
-
-                    <div className="flex flex-col gap-1.5">
-                        <span className="text-xs font-medium text-zinc-500">Reference by</span>
-                        <Segmented
-                            size="small"
-                            value={refBy}
-                            onChange={(val) => setRefBy(val as "variant" | "environment")}
-                            options={[
-                                {label: "Variant", value: "variant"},
-                                {label: "Environment", value: "environment"},
-                            ]}
-                        />
-                    </div>
-
-                    {refBy === "variant" ? (
-                        <div className="flex flex-col gap-1.5">
-                            <span className="text-xs font-medium text-zinc-500">Version</span>
-                            <Select
-                                size="small"
-                                value={version ?? LATEST_VALUE}
-                                onChange={(val) =>
-                                    setVersion(val === LATEST_VALUE ? undefined : val)
                                 }
-                                loading={revisionsLoading}
-                                options={[
-                                    {label: "Latest", value: LATEST_VALUE},
-                                    ...revisions.map((r) => ({
-                                        label: r.label
-                                            ? `v${r.version} — ${r.label}`
-                                            : `v${r.version}`,
-                                        value: r.version,
-                                    })),
-                                ]}
                             />
-                            <span className="text-[11px] text-zinc-400">
-                                Latest follows the workflow&apos;s newest revision; a pinned version
-                                always calls that revision.
-                            </span>
+                        ) : (
+                            <div className="flex flex-col gap-0.5">
+                                {filtered.map((wf) => (
+                                    <button
+                                        type="button"
+                                        key={wf.id}
+                                        onClick={() => setSelected(wf)}
+                                        className={`flex w-full items-center gap-2 rounded-md border-none px-2 py-2 text-left [font:inherit] ${
+                                            selected?.id === wf.id
+                                                ? "bg-[var(--ag-colorFillSecondary)]"
+                                                : "cursor-pointer bg-transparent hover:bg-[var(--ag-colorFillTertiary)]"
+                                        }`}
+                                    >
+                                        <GraphIcon
+                                            size={15}
+                                            className="shrink-0 text-[var(--ag-colorTextSecondary)]"
+                                        />
+                                        <span className="flex min-w-0 flex-1 flex-col leading-tight">
+                                            <span className="truncate text-xs text-[var(--ag-colorText)]">
+                                                {wf.name || wf.slug}
+                                            </span>
+                                            <span className="truncate text-[10px] text-[var(--ag-colorTextTertiary)]">
+                                                {wf.slug}
+                                            </span>
+                                        </span>
+                                        <TypeBadge type={wf.type} label={wf.typeLabel} />
+                                    </button>
+                                ))}
+                            </div>
+                        )}
+                    </div>
+                </div>
+
+                {/* Detail */}
+                <div className="flex min-w-0 flex-1 flex-col">
+                    {!selected ? (
+                        <div className="flex flex-1 items-center justify-center p-6">
+                            <div className="max-w-[230px] text-center">
+                                <HandPointing
+                                    size={30}
+                                    className="mx-auto text-[var(--ag-colorTextTertiary)]"
+                                />
+                                <div className="mb-1.5 mt-3 text-sm font-medium text-[var(--ag-colorText)]">
+                                    Select a workflow
+                                </div>
+                                <p className="m-0 text-xs leading-relaxed text-[var(--ag-colorTextTertiary)]">
+                                    Preview its inputs and pick a version before adding it as a
+                                    tool.
+                                </p>
+                            </div>
                         </div>
                     ) : (
-                        <div className="flex flex-col gap-1.5">
-                            <span className="text-xs font-medium text-zinc-500">Environment</span>
-                            <Select
-                                size="small"
-                                placeholder="Select an environment"
-                                value={environment}
-                                onChange={(val) => setEnvironment(val)}
-                                loading={environmentsLoading}
-                                notFoundContent={
-                                    environmentsLoading ? (
-                                        <Spin size="small" />
+                        <div className="min-h-0 flex-1 overflow-y-auto px-4 pb-6">
+                            <div>
+                                {/* Header: workflow identity, above the sections */}
+                                <div className="flex items-center gap-2 pt-4">
+                                    <GraphIcon
+                                        size={18}
+                                        className="shrink-0 text-[var(--ag-colorTextSecondary)]"
+                                    />
+                                    <span className="truncate text-sm font-medium text-[var(--ag-colorText)]">
+                                        {selected.name || selected.slug}
+                                    </span>
+                                    <TypeBadge type={selected.type} label={selected.typeLabel} />
+                                </div>
+                                {selected.description ? (
+                                    <p className="m-0 mt-1.5 max-w-prose text-xs leading-relaxed text-[var(--ag-colorTextSecondary)]">
+                                        {selected.description}
+                                    </p>
+                                ) : null}
+
+                                {/* Exposed-as: a root-level field (no section chrome), 2-panel to
+                                    align with the sections' [rail | content] rhythm below. */}
+                                <div className="flex gap-3 border-0 border-b border-solid border-[var(--ag-c-EAEFF5,#eaeff5)] py-3">
+                                    <div className="box-border w-[116px] shrink-0 px-2.5 pt-1 text-xs text-[var(--ag-colorTextSecondary)]">
+                                        Exposed as
+                                    </div>
+                                    <div className="flex min-w-0 flex-1 flex-col border-0 border-l border-solid border-[var(--ag-colorBorderSecondary)] pl-3">
+                                        <div className="flex w-fit max-w-full items-center gap-1 rounded-md border border-solid border-[var(--ag-colorBorderSecondary)] bg-[var(--ag-colorFillTertiary)] py-0.5 pl-2.5 pr-1 font-mono text-xs text-[var(--ag-colorText)]">
+                                            <span className="truncate">{selected.slug}</span>
+                                            <CopyButton
+                                                text={selected.slug}
+                                                buttonText={null}
+                                                icon
+                                                type="text"
+                                            />
+                                        </div>
+                                    </div>
+                                </div>
+
+                                <ConfigAccordionSection
+                                    size="compact"
+                                    icon={<TreeStructure size={15} />}
+                                    title="Schema"
+                                    summary={`Inputs · ${countProps(inputSchema)}`}
+                                    summaryCollapsedOnly
+                                >
+                                    {schemaLoading ? (
+                                        <Skeleton
+                                            active
+                                            title={false}
+                                            paragraph={{rows: 3, width: ["60%", "80%", "45%"]}}
+                                        />
                                     ) : (
-                                        <span className="text-xs text-zinc-400">
-                                            No environments deployed
-                                        </span>
-                                    )
-                                }
-                                options={environments.map((env) => ({
-                                    label: env.name || env.slug,
-                                    value: env.slug,
-                                }))}
-                            />
-                            <span className="text-[11px] text-zinc-400">
-                                Calls whatever revision is deployed in the chosen environment.
-                            </span>
+                                        <SectionRail
+                                            items={schemaTabs.map((t) => ({
+                                                value: t.key,
+                                                label: t.label,
+                                                count: t.count,
+                                            }))}
+                                            value={schemaTab}
+                                            onChange={(v) =>
+                                                setSchemaTab(v as "inputs" | "outputs")
+                                            }
+                                        >
+                                            <div className="max-h-[320px] max-w-prose overflow-y-auto overscroll-contain">
+                                                <SchemaTree
+                                                    schema={activeSchema}
+                                                    emptyText={
+                                                        schemaTab === "outputs"
+                                                            ? "No declared outputs"
+                                                            : "No declared inputs"
+                                                    }
+                                                />
+                                            </div>
+                                        </SectionRail>
+                                    )}
+                                </ConfigAccordionSection>
+
+                                {(configLoading || configParts.length > 0) && (
+                                    <ConfigAccordionSection
+                                        size="compact"
+                                        icon={<SlidersHorizontal size={15} />}
+                                        title="Configuration"
+                                        summary={
+                                            configParts.length
+                                                ? `${configParts.length} ${
+                                                      configParts.length === 1 ? "part" : "parts"
+                                                  }`
+                                                : undefined
+                                        }
+                                        summaryCollapsedOnly
+                                    >
+                                        {configLoading ? (
+                                            <Skeleton
+                                                active
+                                                title={false}
+                                                paragraph={{
+                                                    rows: 4,
+                                                    width: ["70%", "90%", "80%", "50%"],
+                                                }}
+                                            />
+                                        ) : (
+                                            <SectionRail
+                                                items={configParts.map((p) => ({
+                                                    value: p.key,
+                                                    label: p.label,
+                                                }))}
+                                                value={activeConfigPart?.key ?? ""}
+                                                onChange={setConfigPartKey}
+                                            >
+                                                {activeConfigPart ? (
+                                                    <ConfigPartContent part={activeConfigPart} />
+                                                ) : null}
+                                            </SectionRail>
+                                        )}
+                                    </ConfigAccordionSection>
+                                )}
+
+                                <ConfigAccordionSection
+                                    size="compact"
+                                    collapsible={false}
+                                    noDivider
+                                    icon={<GitBranch size={15} />}
+                                    title="Reference by"
+                                    status={canConfirm ? "complete" : "warning"}
+                                >
+                                    <RunVersionField
+                                        bindMode={bindMode}
+                                        onBindModeChange={setBindMode}
+                                        revisionAdapter={referenceRevisionAdapter}
+                                        revisionPlaceholder="Latest revision"
+                                        onRevisionSelect={handleRevisionSelect}
+                                        revisionHint="Pin one variant + revision, or pick a variant to follow its latest."
+                                        envOptions={environments.map((env) => ({
+                                            value: env.slug,
+                                            label: env.name || env.slug,
+                                        }))}
+                                        envLoading={environmentsLoading}
+                                        environmentSlug={environment}
+                                        onEnvironmentChange={setEnvironment}
+                                        envNotFound={
+                                            environmentsLoading ? (
+                                                <Spin size="small" />
+                                            ) : (
+                                                <span className="text-xs text-[var(--ag-colorTextTertiary)]">
+                                                    No environments deployed
+                                                </span>
+                                            )
+                                        }
+                                        envHint="Calls whatever revision is deployed in the chosen environment."
+                                    />
+                                </ConfigAccordionSection>
+                            </div>
                         </div>
                     )}
-
-                    <div className="flex justify-end gap-2 pt-1">
-                        <Button size="small" onClick={onClose}>
-                            Cancel
-                        </Button>
-                        <Button
-                            size="small"
-                            type="primary"
-                            disabled={!canConfirm}
-                            onClick={handleConfirm}
-                        >
-                            Add reference
-                        </Button>
-                    </div>
                 </div>
-            )}
+            </div>
+
+            <DrawerFooter
+                onCancel={onClose}
+                onSubmit={handleConfirm}
+                submitLabel="Add reference"
+                canSave={canConfirm}
+            />
         </EnhancedDrawer>
     )
 }

--- a/web/packages/agenta-entity-ui/src/DrillInView/SchemaControls/WorkflowReferenceSelector.tsx
+++ b/web/packages/agenta-entity-ui/src/DrillInView/SchemaControls/WorkflowReferenceSelector.tsx
@@ -150,6 +150,8 @@ export function WorkflowReferenceSelector({
     // bindMode mirrors RunVersionField: "revision" (pin a variant+revision) | "environment" (deployed).
     const [bindMode, setBindMode] = useState<"revision" | "environment">("revision")
     const [version, setVersion] = useState<string | undefined>(undefined)
+    // Selected variant id — kept even when following its latest (no pinned version).
+    const [variant, setVariant] = useState<string | undefined>(undefined)
     const [environment, setEnvironment] = useState<string | undefined>(undefined)
     // Tool description the model sees — defaults to the workflow's own, editable before adding.
     const [description, setDescription] = useState("")
@@ -182,6 +184,7 @@ export function WorkflowReferenceSelector({
     useEffect(() => {
         setBindMode("revision")
         setVersion(undefined)
+        setVariant(undefined)
         setEnvironment(undefined)
         setSchemaTab("inputs")
         setConfigPartKey(null)
@@ -248,6 +251,8 @@ export function WorkflowReferenceSelector({
     const handleRevisionSelect = (sel: WorkflowRevisionSelectionResult) => {
         const isRevision = Boolean(sel.metadata.variantId) && sel.id !== sel.metadata.variantId
         setVersion(isRevision ? String(sel.metadata.revision) : undefined)
+        // Keep the variant either way, so following its latest still identifies the variant.
+        setVariant(sel.metadata.variantId ? String(sel.metadata.variantId) : undefined)
     }
 
     // List items carry no type (capability flags live on the revision URI), so the bridge resolves
@@ -322,6 +327,7 @@ export function WorkflowReferenceSelector({
         onSelect({
             slug: selected.slug,
             refBy: bindMode === "revision" ? "variant" : "environment",
+            variant: bindMode === "revision" ? variant : undefined,
             version: bindMode === "revision" ? version : undefined,
             environment: bindMode === "environment" ? environment : undefined,
             description: description.trim() || undefined,

--- a/web/packages/agenta-entity-ui/src/DrillInView/SchemaControls/WorkflowReferenceSelector.tsx
+++ b/web/packages/agenta-entity-ui/src/DrillInView/SchemaControls/WorkflowReferenceSelector.tsx
@@ -151,6 +151,8 @@ export function WorkflowReferenceSelector({
     const [bindMode, setBindMode] = useState<"revision" | "environment">("revision")
     const [version, setVersion] = useState<string | undefined>(undefined)
     const [environment, setEnvironment] = useState<string | undefined>(undefined)
+    // Tool description the model sees — defaults to the workflow's own, editable before adding.
+    const [description, setDescription] = useState("")
     const [inputSchema, setInputSchema] = useState<Record<string, unknown> | null>(null)
     const [outputSchema, setOutputSchema] = useState<Record<string, unknown> | null>(null)
     const [schemaLoading, setSchemaLoading] = useState(false)
@@ -183,6 +185,7 @@ export function WorkflowReferenceSelector({
         setEnvironment(undefined)
         setSchemaTab("inputs")
         setConfigPartKey(null)
+        setDescription(selected?.description ?? "")
     }, [selected?.id])
 
     // Resolve the selected workflow's input + output schemas for the Schema section.
@@ -321,6 +324,7 @@ export function WorkflowReferenceSelector({
             refBy: bindMode === "revision" ? "variant" : "environment",
             version: bindMode === "revision" ? version : undefined,
             environment: bindMode === "environment" ? environment : undefined,
+            description: description.trim() || undefined,
         })
         onClose()
     }
@@ -453,14 +457,9 @@ export function WorkflowReferenceSelector({
                                     </span>
                                     <TypeBadge type={selected.type} label={selected.typeLabel} />
                                 </div>
-                                {selected.description ? (
-                                    <p className="m-0 mt-1.5 max-w-prose text-xs leading-relaxed text-[var(--ag-colorTextSecondary)]">
-                                        {selected.description}
-                                    </p>
-                                ) : null}
 
-                                {/* Exposed-as: a root-level field (no section chrome), 2-panel to
-                                    align with the sections' [rail | content] rhythm below. */}
+                                {/* Exposed-as + Description: root-level fields (no section chrome),
+                                    2-panel to align with the sections' [rail | content] rhythm below. */}
                                 <div className="flex gap-3 border-0 border-b border-solid border-[var(--ag-c-EAEFF5,#eaeff5)] py-3">
                                     <div className="box-border w-[116px] shrink-0 px-2.5 pt-1 text-xs text-[var(--ag-colorTextSecondary)]">
                                         Exposed as
@@ -475,6 +474,21 @@ export function WorkflowReferenceSelector({
                                                 type="text"
                                             />
                                         </div>
+                                    </div>
+                                </div>
+
+                                <div className="flex gap-3 border-0 border-b border-solid border-[var(--ag-c-EAEFF5,#eaeff5)] py-3">
+                                    <div className="box-border w-[116px] shrink-0 px-2.5 pt-1 text-xs text-[var(--ag-colorTextSecondary)]">
+                                        Description
+                                    </div>
+                                    <div className="flex min-w-0 flex-1 flex-col border-0 border-l border-solid border-[var(--ag-colorBorderSecondary)] pl-3">
+                                        <Input.TextArea
+                                            className="max-w-prose"
+                                            value={description}
+                                            onChange={(e) => setDescription(e.target.value)}
+                                            autoSize={{minRows: 2, maxRows: 6}}
+                                            placeholder="What this tool does and when the agent should call it"
+                                        />
                                     </div>
                                 </div>
 

--- a/web/packages/agenta-entity-ui/src/DrillInView/SchemaControls/agentTemplate/AgentIntegrationDrawer.tsx
+++ b/web/packages/agenta-entity-ui/src/DrillInView/SchemaControls/agentTemplate/AgentIntegrationDrawer.tsx
@@ -1,0 +1,311 @@
+/**
+ * AgentIntegrationDrawer
+ *
+ * The agent-playground tools catalog drawer. Its body renders the SAME {@link CatalogChooser}
+ * the subscription drawer's "Choose a trigger" step uses (the 2-column app grid + connections
+ * rail + detail), pointed at the `@agenta/entities/gatewayTool` catalog hooks with an
+ * "add the action as a tool" leaf. No bespoke catalog UI here.
+ *
+ * Built on the shared `EnhancedDrawer` (like every other agent-playground drawer): an intent-based
+ * header, `closeOnLayoutClick={false}` so an accidental backdrop click mid-connect never drops the
+ * flow, and a footer whose count reflects the app tools added so far + a Done exit.
+ */
+import {useCallback, useMemo, useState} from "react"
+
+import {
+    buildToolSlug,
+    fetchToolActionDetail,
+    isConnectionActive,
+    toolIntegrationsSearchAtom,
+    useToolCatalogActions,
+    useToolCatalogIntegrations,
+    useToolConnectionsQuery,
+    type ToolCatalogAction,
+    type ToolCatalogActionDetails,
+    type ToolCatalogIntegration,
+    type ToolCatalogIntegrationDetails,
+    type ToolConnection,
+} from "@agenta/entities/gatewayTool"
+import {message} from "@agenta/ui"
+import {EnhancedDrawer} from "@agenta/ui/drawer"
+import {Plugs} from "@phosphor-icons/react"
+import {Button} from "antd"
+import {useSetAtom} from "jotai"
+
+import {CatalogChooser} from "../../../drawers/shared/CatalogChooser"
+import ConnectDrawer from "../../../gatewayTool/drawers/ConnectDrawer"
+import type {ToolSelectionMeta} from "../ToolSelectorPopover"
+import {parseGatewayFunctionName, type ToolObj} from "../toolUtils"
+
+type CatalogIntegrationItem = ToolCatalogIntegration | ToolCatalogIntegrationDetails
+
+export interface AgentIntegrationDrawerProps {
+    open: boolean
+    onClose: () => void
+    onAddTool: (tool: ToolObj, meta?: ToolSelectionMeta) => void
+    onRemoveTool?: (toolName: string) => void
+    selectedToolNames: Set<string>
+    /** Preselect this app on open (a provider group's "Add {app} tool" → its actions directly). */
+    defaultIntegrationKey?: string
+}
+
+function isRecord(value: unknown): value is Record<string, unknown> {
+    return typeof value === "object" && value !== null && !Array.isArray(value)
+}
+
+// Composio's per-action detail endpoint is flaky under bursts (rate limits / transient 5xx), which
+// is what surfaced as "Failed to add action". Retry a couple of times with backoff so an action
+// whose schema IS available doesn't fall back to a blank, guidance-less editor.
+async function fetchActionDetailWithRetry(
+    provider: string,
+    integrationKey: string,
+    actionKey: string,
+    retries = 2,
+) {
+    let lastError: unknown
+    for (let attempt = 0; attempt <= retries; attempt++) {
+        try {
+            return await fetchToolActionDetail(provider, integrationKey, actionKey)
+        } catch (error) {
+            lastError = error
+            if (attempt < retries) {
+                await new Promise((resolve) => setTimeout(resolve, 300 * (attempt + 1)))
+            }
+        }
+    }
+    throw lastError
+}
+
+function normalizeParameters(inputs: unknown): Record<string, unknown> {
+    if (!isRecord(inputs)) {
+        return {type: "object", properties: {}, required: [], additionalProperties: false}
+    }
+    const schema = {...inputs}
+    if (schema.type !== "object") schema.type = "object"
+    if (!isRecord(schema.properties)) schema.properties = {}
+    if (!Array.isArray(schema.required)) schema.required = []
+    if (typeof schema.additionalProperties !== "boolean") schema.additionalProperties = false
+    return schema
+}
+
+// Catalog data wrappers (custom hooks) adapting the tool catalog hooks to CatalogChooser's shape.
+function useToolIntegrationsList() {
+    const setSearch = useSetAtom(toolIntegrationsSearchAtom)
+    const r = useToolCatalogIntegrations()
+    return {
+        integrations: r.integrations,
+        hasNextPage: r.hasNextPage,
+        isFetchingNextPage: r.isFetchingNextPage,
+        isLoading: r.isLoading,
+        requestMore: r.requestMore,
+        setSearch,
+    }
+}
+
+function useToolActionList(integrationKey: string) {
+    const r = useToolCatalogActions(integrationKey)
+    return {
+        items: r.actions,
+        isLoading: r.isLoading,
+        hasNextPage: r.hasNextPage,
+        isFetchingNextPage: r.isFetchingNextPage,
+        requestMore: r.requestMore,
+        setSearch: r.setSearch,
+    }
+}
+
+// Body — mounted only while the drawer is open (Drawer destroyOnClose), so catalog queries don't
+// run in the background.
+function ToolCatalogContent({
+    onAddTool,
+    onRemoveTool,
+    selectedToolNames,
+    defaultIntegrationKey,
+}: Omit<AgentIntegrationDrawerProps, "open" | "onClose">) {
+    const [pending, setPending] = useState<string | null>(null)
+    const {connections} = useToolConnectionsQuery()
+
+    const slugFor = useCallback(
+        (conn: ToolConnection, actionKey: string) =>
+            buildToolSlug(
+                conn.provider_key ?? "composio",
+                conn.integration_key,
+                actionKey,
+                conn.slug ?? "",
+            ),
+        [],
+    )
+
+    // Add the chosen action as a function tool (toggles off if already added).
+    const toggle = useCallback(
+        async (conn: ToolConnection, action: ToolCatalogAction) => {
+            const slug = slugFor(conn, action.key)
+            if (selectedToolNames.has(slug)) {
+                onRemoveTool?.(slug)
+                return
+            }
+            setPending(slug)
+            // The model-facing input schema comes from the per-action detail endpoint, which
+            // errors provider-side for some actions. That must NOT block the add: the tool
+            // resolves server-side by slug regardless. When the schema resolves we add straight
+            // away (gateway is multi-select); when it doesn't, `needsConfig` opens the tool
+            // editor so the user defines the parameters instead of getting a schema-less tool.
+            let inputs: unknown
+            let fetchFailed = false
+            try {
+                const detail = await fetchActionDetailWithRetry(
+                    conn.provider_key ?? "composio",
+                    conn.integration_key,
+                    action.key,
+                )
+                const detailed =
+                    detail.action && "schemas" in detail.action
+                        ? (detail.action as ToolCatalogActionDetails)
+                        : null
+                inputs = detailed?.schemas?.inputs
+            } catch {
+                fetchFailed = true
+            }
+            try {
+                onAddTool(
+                    {
+                        type: "function",
+                        function: {
+                            name: slug,
+                            description: action.description || action.name || action.key,
+                            parameters: normalizeParameters(inputs),
+                        },
+                    },
+                    {
+                        source: "gateway",
+                        provider: conn.provider_key ?? "composio",
+                        toolCode: action.key,
+                        toolLabel: action.key,
+                        integrationKey: conn.integration_key,
+                        connectionSlug: conn.slug ?? "",
+                        needsConfig: fetchFailed,
+                    },
+                )
+            } catch {
+                message.error("Couldn't add this tool")
+            } finally {
+                setPending(null)
+            }
+        },
+        [slugFor, selectedToolNames, onAddTool, onRemoveTool],
+    )
+
+    return (
+        <div className="min-h-0 flex-1 overflow-hidden px-6 py-4">
+            <CatalogChooser<CatalogIntegrationItem, ToolCatalogAction, ToolConnection>
+                connections={connections}
+                defaultIntegrationKey={defaultIntegrationKey}
+                isConnectionActive={isConnectionActive}
+                useIntegrations={useToolIntegrationsList}
+                useItems={useToolActionList}
+                integration={{
+                    key: (i) => i.key,
+                    name: (i) => i.name,
+                    logo: (i) => i.logo,
+                    description: (i) => i.description,
+                    categories: (i) =>
+                        (i as {categories?: string[] | null}).categories ?? undefined,
+                    actionsCount: (i) => (i as {actions_count?: number | null}).actions_count,
+                }}
+                connection={{
+                    id: (c) => c.id ?? undefined,
+                    name: (c) => c.name ?? undefined,
+                    slug: (c) => c.slug ?? undefined,
+                    integrationKey: (c) => c.integration_key,
+                }}
+                item={{
+                    key: (a) => a.key,
+                    name: (a) => a.name ?? undefined,
+                    description: (a) => a.description ?? undefined,
+                    categories: (a) => a.categories ?? undefined,
+                    readOnly: (a) => a.read_only ?? undefined,
+                    deprecated: (a) => /^\s*deprecated\b/i.test(a.description ?? ""),
+                }}
+                itemsLabel="Choose an action"
+                itemsSearchPlaceholder="Search actions"
+                emptyItemsText="No actions for this app"
+                onPickItem={(conn, action) => void toggle(conn, action)}
+                itemState={(conn, action) => {
+                    const slug = slugFor(conn, action.key)
+                    if (pending === slug) return "pending"
+                    return selectedToolNames.has(slug) ? "selected" : "add"
+                }}
+                renderConnect={(integration, handlers) => (
+                    <ConnectDrawer
+                        open
+                        integrationKey={integration.key}
+                        integrationName={integration.name}
+                        integrationLogo={integration.logo ?? undefined}
+                        integrationDescription={integration.description ?? undefined}
+                        authSchemes={
+                            (integration as {auth_schemes?: string[] | null}).auth_schemes ?? []
+                        }
+                        onClose={handlers.onClose}
+                        onSuccess={handlers.onSuccess}
+                    />
+                )}
+            />
+        </div>
+    )
+}
+
+export function AgentIntegrationDrawer({
+    open,
+    onClose,
+    onAddTool,
+    onRemoveTool,
+    selectedToolNames,
+    defaultIntegrationKey,
+}: AgentIntegrationDrawerProps) {
+    // App tools already added — the footer count so the multi-add flow shows progress.
+    const addedCount = useMemo(() => {
+        let n = 0
+        for (const name of selectedToolNames) if (parseGatewayFunctionName(name)) n++
+        return n
+    }, [selectedToolNames])
+
+    return (
+        <EnhancedDrawer
+            open={open}
+            onClose={onClose}
+            placement="right"
+            width={960}
+            // Explicit exit only — an accidental backdrop click mid-connect must not drop the flow.
+            closeOnLayoutClick={false}
+            destroyOnClose
+            title={
+                <div className="flex items-center gap-2">
+                    <Plugs size={16} />
+                    <span className="text-sm font-medium">Add app tools</span>
+                </div>
+            }
+            styles={{
+                body: {padding: 0, display: "flex", flexDirection: "column", overflow: "hidden"},
+            }}
+            footer={
+                <div className="flex items-center justify-between gap-3">
+                    <span className="min-w-0 truncate text-xs text-[var(--ag-c-97A4B0,#97a4b0)]">
+                        {addedCount > 0
+                            ? `${addedCount} app ${addedCount === 1 ? "tool" : "tools"} added`
+                            : "Pick actions from a connected app — added instantly."}
+                    </span>
+                    <Button type="primary" onClick={onClose}>
+                        Done
+                    </Button>
+                </div>
+            }
+        >
+            <ToolCatalogContent
+                onAddTool={onAddTool}
+                onRemoveTool={onRemoveTool}
+                selectedToolNames={selectedToolNames}
+                defaultIntegrationKey={defaultIntegrationKey}
+            />
+        </EnhancedDrawer>
+    )
+}

--- a/web/packages/agenta-entity-ui/src/DrillInView/SchemaControls/agentTemplate/AgentToolSelectorPopover.tsx
+++ b/web/packages/agenta-entity-ui/src/DrillInView/SchemaControls/agentTemplate/AgentToolSelectorPopover.tsx
@@ -1,0 +1,129 @@
+/**
+ * AgentToolSelectorPopover
+ *
+ * Agent-playground-only tool picker (Approach B). A thin grouped menu (the shared
+ * {@link AddItemMenu}) that hands off to dedicated drawers instead of the legacy cascade:
+ *   - Add existing  → Reference a workflow (drawer) · Third-party integration (drawer)
+ *   - Create new    → Tool definition (opens the schema editor in create mode)
+ *
+ * Scoped to the agent template on purpose: the legacy prompt playground keeps the shared
+ * `ToolSelectorPopover` (built-in providers + inline gateway browsing). No built-in tools here.
+ */
+import {memo} from "react"
+
+import {useDrillInUI} from "@agenta/ui/drill-in"
+import {BracketsCurly, GraphIcon, Plugs, Plus, Sparkle} from "@phosphor-icons/react"
+import {Button} from "antd"
+
+import {AddItemMenu, type AddItemGroup} from "../../../drawers/shared/AddItemMenu"
+import type {ToolSelectorPopoverProps} from "../ToolSelectorPopover"
+import type {ToolObj} from "../toolUtils"
+
+// Drop-in for the agent path: accepts the props the host already spreads, plus an optional
+// `onOpenIntegration` to route the integration row to the agent-scoped drawer instead of the
+// shared global catalog. Without it, it falls back to `gatewayTools.onOpenCatalog`.
+export type AgentToolSelectorPopoverProps = ToolSelectorPopoverProps & {
+    onOpenIntegration?: () => void
+}
+
+// A fresh tool-definition seed. The schema editor opens on this and only appends on Save, so a
+// half-filled tool never lands in the config (mirrors the legacy custom-tool create flow).
+function buildToolDefinitionSeed(): ToolObj {
+    return {
+        type: "function",
+        function: {
+            name: "get_weather",
+            description: "Get current weather",
+            parameters: {
+                type: "object",
+                properties: {location: {type: "string", description: "City name"}},
+                required: ["location"],
+                additionalProperties: false,
+            },
+        },
+    }
+}
+
+export const AgentToolSelectorPopover = memo(function AgentToolSelectorPopover({
+    onAddTool,
+    disabled = false,
+    gatewayTools: gatewayToolsProp,
+    trigger,
+    onReferenceWorkflow,
+    onOpenIntegration,
+}: AgentToolSelectorPopoverProps) {
+    const {gatewayTools: gatewayToolsFromContext, workflowReference} = useDrillInUI()
+    const gatewayTools = gatewayToolsProp ?? gatewayToolsFromContext
+
+    const showReference = Boolean(workflowReference?.enabled && onReferenceWorkflow)
+    const showIntegration = Boolean(gatewayTools?.enabled)
+
+    const groups: AddItemGroup[] = []
+
+    const addExisting: AddItemGroup["items"] = []
+    if (showReference) {
+        addExisting.push({
+            key: "reference",
+            icon: <GraphIcon size={17} />,
+            title: "Reference a workflow",
+            subtitle: "Call a published workflow as a tool",
+            opensDrawer: true,
+            onSelect: onReferenceWorkflow,
+        })
+    }
+    if (showIntegration) {
+        addExisting.push({
+            key: "integration",
+            icon: <Plugs size={17} />,
+            title: "Third-party integration",
+            subtitle: "Connect an app, pick actions",
+            opensDrawer: true,
+            onSelect: () =>
+                onOpenIntegration ? onOpenIntegration() : gatewayTools?.onOpenCatalog(),
+        })
+    }
+    if (addExisting.length) groups.push({label: "Add existing", items: addExisting})
+
+    groups.push({
+        label: "Create new",
+        items: [
+            {
+                key: "definition",
+                icon: <BracketsCurly size={17} />,
+                title: "Tool definition",
+                subtitle: "JSON schema, executed by your app",
+                // The schema editor opens on this seed and only appends on Save.
+                onSelect: () => onAddTool(buildToolDefinitionSeed(), {source: "custom"}),
+            },
+            {
+                key: "ai",
+                icon: <Sparkle size={17} />,
+                title: "Create with AI",
+                subtitle: "Describe a tool and let AI build it",
+                disabled: true,
+                disabledHint: "Coming soon",
+            },
+        ],
+    })
+
+    return (
+        <AddItemMenu
+            groups={groups}
+            disabled={disabled}
+            ariaLabel="Add tool"
+            trigger={
+                trigger ?? (
+                    <Button
+                        variant="outlined"
+                        color="default"
+                        size="small"
+                        icon={<Plus size={14} />}
+                        disabled={disabled}
+                    >
+                        Tool
+                    </Button>
+                )
+            }
+        />
+    )
+})

--- a/web/packages/agenta-entity-ui/src/DrillInView/SchemaControls/agentTemplate/ItemRow.tsx
+++ b/web/packages/agenta-entity-ui/src/DrillInView/SchemaControls/agentTemplate/ItemRow.tsx
@@ -50,7 +50,13 @@ export function ItemRow({
         >
             <ItemAvatar descriptor={descriptor} />
             <div className="min-w-0 flex-1">
-                <div className="truncate font-mono text-xs font-medium">{descriptor.name}</div>
+                <div
+                    className={`truncate text-xs font-medium ${
+                        descriptor.monoName === false ? "" : "font-mono"
+                    }`}
+                >
+                    {descriptor.name}
+                </div>
                 {descriptor.description ? (
                     <Typography.Text
                         type="secondary"
@@ -66,6 +72,78 @@ export function ItemRow({
                         {tag}
                     </Tag>
                 ))}
+                {onRemove && !disabled ? (
+                    <button
+                        type="button"
+                        aria-label="Remove"
+                        onClick={(e) => {
+                            e.stopPropagation()
+                            onRemove()
+                        }}
+                        className="flex cursor-pointer items-center border-0 bg-transparent p-0 text-[var(--ag-c-97A4B0,#97a4b0)] opacity-0 transition-opacity hover:text-[var(--ag-c-FF4D4F,#ff4d4f)] group-hover:opacity-100"
+                    >
+                        <Trash size={14} />
+                    </button>
+                ) : null}
+                <CaretRight size={14} className="text-[var(--ag-c-97A4B0,#97a4b0)]" />
+            </div>
+        </div>
+    )
+}
+
+/**
+ * A compact child row for an item nested under a provider group (e.g. a connected-app tool inside its
+ * app group): borderless, name + description, hover-remove + chevron. Mirrors the trigger section's
+ * subscription child rows so tools and triggers read the same. The provider is shown by the group
+ * header, so no avatar/tags here.
+ */
+export function ItemChildRow({
+    descriptor,
+    onEdit,
+    onRemove,
+    disabled,
+}: {
+    descriptor: ItemDescriptor
+    onEdit: () => void
+    onRemove?: () => void
+    disabled?: boolean
+}) {
+    return (
+        <div
+            role="button"
+            tabIndex={0}
+            onClick={onEdit}
+            onKeyDown={(e) => {
+                if (e.target !== e.currentTarget) return
+                if (e.key === "Enter" || e.key === " ") {
+                    e.preventDefault()
+                    onEdit()
+                }
+            }}
+            className="group flex cursor-pointer items-center gap-2.5 rounded px-2.5 py-1.5 transition-colors hover:bg-[var(--ag-colorFillSecondary)]"
+        >
+            <div className="min-w-0 flex-1">
+                <div
+                    className={`truncate text-xs font-medium ${
+                        descriptor.monoName === false ? "" : "font-mono"
+                    }`}
+                >
+                    {descriptor.name}
+                </div>
+                {descriptor.description ? (
+                    <Typography.Text
+                        type="secondary"
+                        className="block truncate text-[11px] leading-snug"
+                    >
+                        {descriptor.description}
+                    </Typography.Text>
+                ) : null}
+            </div>
+            <div
+                className="flex shrink-0 items-center gap-1.5"
+                onClick={(e) => e.stopPropagation()}
+                role="presentation"
+            >
                 {onRemove && !disabled ? (
                     <button
                         type="button"

--- a/web/packages/agenta-entity-ui/src/DrillInView/SchemaControls/agentTemplate/ParameterNodeEditor.tsx
+++ b/web/packages/agenta-entity-ui/src/DrillInView/SchemaControls/agentTemplate/ParameterNodeEditor.tsx
@@ -1,0 +1,334 @@
+/**
+ * ParameterNodeEditor
+ *
+ * The right-hand detail of the tool-parameter master/detail editor: a contextual editor for the
+ * one parameter node selected in {@link ParameterTree}. An `EDITING · PATH` breadcrumb then a stack
+ * of shared {@link RailField} `[label │ control]` rows — Name (rename) / Type / Item type (arrays) /
+ * Allowed values + Default (scalars only) / Description / Required. A container node (object, or
+ * array-of-object) also gets an inline "Add property" button so children can be added while editing
+ * the container. Other advanced shapes (formats, unions, tuples, ranges) stay in the JSON toggle.
+ *
+ * All edits go through the immutable helpers in {@link schemaPaths} against the whole `parameters`
+ * root; a rename also moves the selection to the new key. Dark-safe (`--ag-color*` tokens only).
+ */
+import {useEffect, useState} from "react"
+
+import {Plus} from "@phosphor-icons/react"
+import {Button, Input, Select, Switch} from "antd"
+
+import {RailField} from "../../../drawers/shared/RailField"
+
+import {
+    defType,
+    getNodeAt,
+    getProps,
+    isRequiredAt,
+    ITEM_TYPE_OPTIONS,
+    itemsSchema,
+    leafKey,
+    parentPath,
+    pathLabel,
+    renamePropertyAt,
+    setNodeAt,
+    toggleRequiredAt,
+    TYPE_OPTIONS,
+    type Schema,
+    type Seg,
+} from "./schemaPaths"
+
+// Enum/default apply only to scalar leaves; object/array/boolean don't show those rows.
+const SCALAR_TYPES = new Set(["string", "number", "integer"])
+
+// Coerce a raw string to the parameter's JSON type; null when it can't (e.g. "abc" as a number).
+function coerceTo(raw: unknown, targetType: string): string | number | null {
+    if (targetType === "number" || targetType === "integer") {
+        const n = Number(raw)
+        if (!Number.isFinite(n)) return null
+        return targetType === "integer" ? Math.trunc(n) : n
+    }
+    return String(raw)
+}
+
+export interface ParameterNodeEditorProps {
+    /** The function tool's `parameters` root schema. */
+    schema: Schema
+    /** Path to the selected node (ends in a property step). */
+    path: Seg[]
+    onChange: (nextRoot: Schema) => void
+    /** Move the selection (used after a rename). */
+    onPathChange: (nextPath: Seg[]) => void
+    /** Add a child property under the object at `containerPath` (host adds it + selects it). */
+    onAddChild: (containerPath: Seg[]) => void
+    disabled?: boolean
+}
+
+export function ParameterNodeEditor({
+    schema,
+    path,
+    onChange,
+    onPathChange,
+    onAddChild,
+    disabled,
+}: ParameterNodeEditorProps) {
+    const def = getNodeAt(schema, path) ?? {type: "string"}
+    const key = leafKey(path) ?? ""
+    const parent = parentPath(path)
+    const type = defType(def)
+    const description = typeof def.description === "string" ? def.description : ""
+
+    const [nameLocal, setNameLocal] = useState(key)
+    useEffect(() => setNameLocal(key), [key])
+
+    const commitName = () => {
+        const next = nameLocal.trim()
+        if (next && next !== key) {
+            const nextRoot = renamePropertyAt(schema, parent, key, next)
+            if (nextRoot !== schema) {
+                onChange(nextRoot)
+                onPathChange([...parent, {p: next}])
+                return
+            }
+        }
+        setNameLocal(key)
+    }
+
+    const isScalar = SCALAR_TYPES.has(type)
+    const enumValues: string[] = Array.isArray(def.enum)
+        ? (def.enum as unknown[]).map((v) => String(v))
+        : []
+    const defaultValue = def.default
+
+    const changeType = (next: string) => {
+        const base: Schema = {}
+        if (description) base.description = description
+        // Preserve (re-coerce) enum/default across scalar↔scalar changes; drop on structural change.
+        if (SCALAR_TYPES.has(next)) {
+            if (Array.isArray(def.enum)) {
+                const vals = (def.enum as unknown[])
+                    .map((v) => coerceTo(v, next))
+                    .filter((v): v is string | number => v !== null)
+                if (vals.length) base.enum = vals
+            }
+            if (defaultValue !== undefined) {
+                const d = coerceTo(defaultValue, next)
+                if (d !== null && (!Array.isArray(base.enum) || base.enum.includes(d)))
+                    base.default = d
+            }
+        }
+        const nextDef: Schema =
+            next === "object"
+                ? {type: "object", properties: {}, required: [], ...base}
+                : next === "array"
+                  ? {type: "array", items: {type: "string"}, ...base}
+                  : {type: next, ...base}
+        onChange(setNodeAt(schema, path, nextDef))
+    }
+
+    // Allowed values (enum): free-text tags, coerced to the parameter's type. Clearing all values
+    // drops the constraint; a `default` no longer in the set is dropped too.
+    const changeEnum = (values: string[]) => {
+        const nextDef = {...def}
+        // antd tag tokens keep the separator's whitespace ("a, b" → ["a", " b"]), so trim, drop
+        // blanks, coerce, and dedupe before storing.
+        const coerced = Array.from(
+            new Set(
+                values
+                    .map((v) => v.trim())
+                    .filter((v) => v.length > 0)
+                    .map((v) => coerceTo(v, type))
+                    .filter((v): v is string | number => v !== null),
+            ),
+        )
+        if (coerced.length) {
+            nextDef.enum = coerced
+            if (
+                nextDef.default !== undefined &&
+                !coerced.includes(nextDef.default as string | number)
+            )
+                delete nextDef.default
+        } else {
+            delete nextDef.enum
+        }
+        onChange(setNodeAt(schema, path, nextDef))
+    }
+
+    const changeDefault = (raw: string | undefined) => {
+        const nextDef = {...def}
+        const coerced = raw == null || raw === "" ? null : coerceTo(raw, type)
+        if (coerced === null) delete nextDef.default
+        else nextDef.default = coerced
+        onChange(setNodeAt(schema, path, nextDef))
+    }
+
+    const changeItemType = (next: string) => {
+        const items =
+            next === "object" ? {type: "object", properties: {}, required: []} : {type: next}
+        onChange(setNodeAt(schema, path, {...def, type: "array", items}))
+    }
+
+    const changeDescription = (value: string) => {
+        const nextDef = {...def}
+        if (value) nextDef.description = value
+        else delete nextDef.description
+        onChange(setNodeAt(schema, path, nextDef))
+    }
+
+    const required = isRequiredAt(schema, parent, key)
+    const itemType = defType(itemsSchema(def))
+
+    // A node that can hold child properties: an object, or an array whose items are objects.
+    // Children live under the object itself, or under the array's `items`.
+    const childContainerPath: Seg[] | null =
+        type === "object"
+            ? path
+            : type === "array" && itemType === "object"
+              ? [...path, {items: true}]
+              : null
+    const childCount = childContainerPath
+        ? Object.keys(getProps(getNodeAt(schema, childContainerPath) ?? {})).length
+        : 0
+
+    const hint =
+        type === "array"
+            ? "Set item type to object to nest properties one level deeper."
+            : type === "object"
+              ? "This object groups nested properties."
+              : "The value the model provides for this parameter."
+
+    return (
+        <div className="flex flex-col gap-4">
+            <div className="text-[11px] font-medium uppercase tracking-wide text-[var(--ag-colorTextTertiary)]">
+                Editing · {pathLabel(path)}
+            </div>
+
+            <div className="flex flex-col gap-3">
+                <RailField label="Name" align="center">
+                    <Input
+                        className="font-mono"
+                        value={nameLocal}
+                        onChange={(e) => setNameLocal(e.target.value)}
+                        onBlur={commitName}
+                        onPressEnter={commitName}
+                        placeholder="parameter_name"
+                        disabled={disabled}
+                    />
+                </RailField>
+
+                <RailField label="Type" align="center">
+                    <div className={type === "array" ? "grid grid-cols-2 gap-2" : ""}>
+                        <Select
+                            className="w-full"
+                            value={type}
+                            options={TYPE_OPTIONS}
+                            onChange={changeType}
+                            disabled={disabled}
+                        />
+                        {type === "array" ? (
+                            <Select
+                                className="w-full"
+                                value={itemType}
+                                options={ITEM_TYPE_OPTIONS}
+                                onChange={changeItemType}
+                                disabled={disabled}
+                            />
+                        ) : null}
+                    </div>
+                </RailField>
+
+                {isScalar ? (
+                    <>
+                        <RailField label="Allowed values">
+                            <Select
+                                mode="tags"
+                                className="w-full"
+                                value={enumValues}
+                                onChange={changeEnum}
+                                tokenSeparators={[",", "\n"]}
+                                placeholder="Any value — add to restrict"
+                                open={false}
+                                suffixIcon={null}
+                                disabled={disabled}
+                            />
+                        </RailField>
+
+                        <RailField label="Default" align="center">
+                            {enumValues.length ? (
+                                <Select
+                                    className="w-full"
+                                    value={defaultValue != null ? String(defaultValue) : undefined}
+                                    onChange={(v) => changeDefault(v)}
+                                    options={enumValues.map((v) => ({value: v, label: v}))}
+                                    placeholder="No default"
+                                    allowClear
+                                    disabled={disabled}
+                                />
+                            ) : (
+                                <Input
+                                    value={defaultValue != null ? String(defaultValue) : ""}
+                                    onChange={(e) => changeDefault(e.target.value)}
+                                    inputMode={type === "string" ? undefined : "decimal"}
+                                    placeholder="No default"
+                                    disabled={disabled}
+                                />
+                            )}
+                        </RailField>
+                    </>
+                ) : null}
+
+                <RailField label="Description">
+                    <Input.TextArea
+                        value={description}
+                        onChange={(e) => changeDescription(e.target.value)}
+                        autoSize={{minRows: 2, maxRows: 5}}
+                        placeholder="What this parameter is for"
+                        disabled={disabled}
+                    />
+                </RailField>
+
+                <RailField label="Required" align="center">
+                    <div className="flex items-center gap-2">
+                        <Switch
+                            checked={required}
+                            onChange={(on) => onChange(toggleRequiredAt(schema, parent, key, on))}
+                            disabled={disabled}
+                        />
+                        <span className="text-[11px] text-[var(--ag-colorTextTertiary)]">
+                            The model must provide this parameter on every call.
+                        </span>
+                    </div>
+                </RailField>
+
+                {childContainerPath ? (
+                    <RailField label="Properties" align="center">
+                        <div className="flex items-center gap-2">
+                            <Button
+                                icon={<Plus size={13} />}
+                                onClick={() => onAddChild(childContainerPath)}
+                                disabled={disabled}
+                            >
+                                Add property
+                            </Button>
+                            <span className="text-[11px] text-[var(--ag-colorTextTertiary)]">
+                                {childCount === 0
+                                    ? "No nested properties yet."
+                                    : `${childCount} nested ${
+                                          childCount === 1 ? "property" : "properties"
+                                      } — edit them in the tree.`}
+                            </span>
+                        </div>
+                    </RailField>
+                ) : null}
+            </div>
+
+            <p className="m-0 text-[11px] leading-snug text-[var(--ag-colorTextTertiary)]">
+                {hint}
+            </p>
+
+            {path.length > 3 ? (
+                <p className="m-0 text-[11px] leading-snug text-[var(--ag-colorTextTertiary)]">
+                    Deeply nested — switch to JSON for full control over this structure.
+                </p>
+            ) : null}
+        </div>
+    )
+}

--- a/web/packages/agenta-entity-ui/src/DrillInView/SchemaControls/agentTemplate/ParameterNodeEditor.tsx
+++ b/web/packages/agenta-entity-ui/src/DrillInView/SchemaControls/agentTemplate/ParameterNodeEditor.tsx
@@ -39,12 +39,14 @@ import {
 // Enum/default apply only to scalar leaves; object/array/boolean don't show those rows.
 const SCALAR_TYPES = new Set(["string", "number", "integer"])
 
-// Coerce a raw string to the parameter's JSON type; null when it can't (e.g. "abc" as a number).
+// Coerce a raw string to the parameter's JSON type; null when it can't (e.g. "abc" as a number, or
+// "1.5" as an integer — rejected rather than silently truncated).
 function coerceTo(raw: unknown, targetType: string): string | number | null {
     if (targetType === "number" || targetType === "integer") {
         const n = Number(raw)
         if (!Number.isFinite(n)) return null
-        return targetType === "integer" ? Math.trunc(n) : n
+        if (targetType === "integer" && !Number.isInteger(n)) return null
+        return n
     }
     return String(raw)
 }

--- a/web/packages/agenta-entity-ui/src/DrillInView/SchemaControls/agentTemplate/ParameterTree.tsx
+++ b/web/packages/agenta-entity-ui/src/DrillInView/SchemaControls/agentTemplate/ParameterTree.tsx
@@ -1,0 +1,374 @@
+/**
+ * ParameterTree
+ *
+ * The left rail of the tool-parameter master/detail editor: a selectable, nesting tree of a
+ * function tool's JSON-Schema `parameters`. `+ Add` (header) appends a root property; object nodes
+ * expand to their child properties with a `+ Add property` affordance; array-of-object nodes recurse
+ * through an `items` group; scalar arrays show a muted `items: <type>` leaf. The active row is
+ * primary-tinted and each row hover-reveals a remove affordance (shared `RowRemoveButton`).
+ *
+ * Pure presentation over the schema — all mutation is delegated to the host via callbacks; expansion
+ * is the only local state (auto-opened along the selected path). Dark-safe (`--ag-color*` tokens).
+ */
+import {useEffect, useMemo, useState} from "react"
+
+import {CaretDown, CaretRight, Plus, Wrench} from "@phosphor-icons/react"
+import {Button} from "antd"
+
+import {RowRemoveButton} from "../../../drawers/shared/MasterDetailRail"
+
+import {
+    defType,
+    getProps,
+    getRequired,
+    isRecord,
+    itemsSchema,
+    pathKey,
+    type Schema,
+    type Seg,
+} from "./schemaPaths"
+
+export interface ParameterTreeProps {
+    /** The function tool's `parameters` object schema. */
+    schema: Schema
+    /** Currently selected node path (null = the meta row is active). */
+    selectedPath: Seg[] | null
+    onSelect: (path: Seg[]) => void
+    /** Whether the pinned "Tool details" row is the active selection (nothing else selected). */
+    metaSelected: boolean
+    /** Select the pinned "Tool details" row → return to editing the tool's name/description/permission. */
+    onSelectMeta: () => void
+    /** Append a root-level property (host adds it + selects the new key). */
+    onAddRoot: () => void
+    /** Append a child property under the object at `parentPath`. */
+    onAddProperty: (parentPath: Seg[]) => void
+    /** Remove property `key` from the object at `parentPath`. */
+    onRemove: (parentPath: Seg[], key: string) => void
+    disabled?: boolean
+}
+
+const TYPE_TINT = "text-[var(--ag-colorTextTertiary)]"
+
+// The nested object a node expands into: an object's own props, or an array-of-object's items.
+function expandableChild(def: Schema): Schema | null {
+    const type = defType(def)
+    if (type === "object") return def
+    if (type === "array" && defType(itemsSchema(def)) === "object") return itemsSchema(def)
+    return null
+}
+
+function typeLabel(def: Schema): string {
+    const type = defType(def)
+    if (type === "array") return `array<${defType(itemsSchema(def))}>`
+    return type
+}
+
+function LeadingGlyph({type}: {type: string}) {
+    if (type === "array") {
+        return <span className={`font-mono text-[11px] ${TYPE_TINT}`}>[ ]</span>
+    }
+    // Scalar: a small hollow dot.
+    return (
+        <span className="h-1.5 w-1.5 rounded-full border border-solid border-[var(--ag-colorTextQuaternary)]" />
+    )
+}
+
+function AddPropertyRow({
+    onClick,
+    disabled,
+    label,
+}: {
+    onClick: () => void
+    disabled?: boolean
+    label: string
+}) {
+    return (
+        <button
+            type="button"
+            onClick={onClick}
+            disabled={disabled}
+            className="flex w-full cursor-pointer appearance-none items-center gap-1 rounded border-0 bg-transparent px-2 py-1 text-left text-xs text-[var(--ag-colorPrimary)] hover:bg-[var(--ag-colorFillTertiary)] disabled:cursor-not-allowed disabled:opacity-50"
+        >
+            <Plus size={12} />
+            {label}
+        </button>
+    )
+}
+
+function TreeRow({
+    name,
+    def,
+    path,
+    required,
+    expandable,
+    expanded,
+    active,
+    onToggle,
+    onSelect,
+    onRemove,
+    disabled,
+}: {
+    name: string
+    def: Schema
+    path: Seg[]
+    required: boolean
+    expandable: boolean
+    expanded: boolean
+    active: boolean
+    onToggle: () => void
+    onSelect: () => void
+    onRemove: () => void
+    disabled?: boolean
+}) {
+    return (
+        <div
+            className={`group flex items-center gap-1 rounded px-1.5 py-1 ${
+                active ? "bg-[var(--ag-colorPrimaryBg)]" : "hover:bg-[var(--ag-colorFillTertiary)]"
+            }`}
+        >
+            {expandable ? (
+                <button
+                    type="button"
+                    aria-label={expanded ? "Collapse" : "Expand"}
+                    onClick={(e) => {
+                        e.stopPropagation()
+                        onToggle()
+                    }}
+                    className="flex h-4 w-4 shrink-0 cursor-pointer appearance-none items-center justify-center rounded border-0 bg-transparent p-0 text-[var(--ag-colorTextTertiary)] hover:text-[var(--ag-colorText)]"
+                >
+                    {expanded ? <CaretDown size={12} /> : <CaretRight size={12} />}
+                </button>
+            ) : (
+                <span className="flex h-4 w-4 shrink-0 items-center justify-center">
+                    <LeadingGlyph type={defType(def)} />
+                </span>
+            )}
+
+            <button
+                type="button"
+                onClick={onSelect}
+                className="flex min-w-0 flex-1 cursor-pointer appearance-none items-center gap-2 border-0 bg-transparent p-0 text-left"
+            >
+                <span
+                    className={`truncate font-mono text-xs ${
+                        active ? "text-[var(--ag-colorPrimary)]" : "text-[var(--ag-colorText)]"
+                    }`}
+                >
+                    {name}
+                </span>
+                {required ? (
+                    <span
+                        className="h-1.5 w-1.5 shrink-0 rounded-full bg-[var(--ag-colorError)]"
+                        title="Required"
+                    />
+                ) : null}
+                <span className={`ml-auto shrink-0 pl-2 text-[11px] ${TYPE_TINT}`}>
+                    {typeLabel(def)}
+                </span>
+            </button>
+
+            {!disabled ? <RowRemoveButton onRemove={onRemove} /> : null}
+        </div>
+    )
+}
+
+function TreeNodes({
+    node,
+    basePath,
+    selectedKey,
+    expanded,
+    toggle,
+    onSelect,
+    onAddProperty,
+    onRemove,
+    disabled,
+}: {
+    node: Schema
+    basePath: Seg[]
+    selectedKey: string | null
+    expanded: Set<string>
+    toggle: (key: string) => void
+    onSelect: (path: Seg[]) => void
+    onAddProperty: (parentPath: Seg[]) => void
+    onRemove: (parentPath: Seg[], key: string) => void
+    disabled?: boolean
+}) {
+    const props = getProps(node)
+    const required = getRequired(node)
+    const entries = Object.entries(props)
+
+    return (
+        <div className="flex flex-col gap-0.5">
+            {entries.map(([key, rawDef]) => {
+                const def = isRecord(rawDef) ? rawDef : {type: "string"}
+                const path = [...basePath, {p: key}]
+                const key$ = pathKey(path)
+                const child = expandableChild(def)
+                const isExpandable = child != null
+                const isExpanded = isExpandable && expanded.has(key$)
+                const type = defType(def)
+                const scalarArray = type === "array" && !child
+
+                return (
+                    <div key={key}>
+                        <TreeRow
+                            name={key}
+                            def={def}
+                            path={path}
+                            required={required.includes(key)}
+                            expandable={isExpandable}
+                            expanded={isExpanded}
+                            active={selectedKey === key$}
+                            onToggle={() => toggle(key$)}
+                            onSelect={() => onSelect(path)}
+                            onRemove={() => onRemove(basePath, key)}
+                            disabled={disabled}
+                        />
+
+                        {scalarArray ? (
+                            <div className="ml-3 border-0 border-l border-solid border-[var(--ag-colorBorderSecondary)] pl-3">
+                                <span className="block px-1.5 py-1 font-mono text-[11px] text-[var(--ag-colorTextTertiary)]">
+                                    items: {defType(itemsSchema(def))}
+                                </span>
+                            </div>
+                        ) : null}
+
+                        {isExpanded && child ? (
+                            <div className="ml-3 border-0 border-l border-solid border-[var(--ag-colorBorderSecondary)] pl-3">
+                                <TreeNodes
+                                    node={child}
+                                    basePath={type === "array" ? [...path, {items: true}] : path}
+                                    selectedKey={selectedKey}
+                                    expanded={expanded}
+                                    toggle={toggle}
+                                    onSelect={onSelect}
+                                    onAddProperty={onAddProperty}
+                                    onRemove={onRemove}
+                                    disabled={disabled}
+                                />
+                                {!disabled ? (
+                                    <AddPropertyRow
+                                        label="Add property"
+                                        onClick={() =>
+                                            onAddProperty(
+                                                type === "array" ? [...path, {items: true}] : path,
+                                            )
+                                        }
+                                    />
+                                ) : null}
+                            </div>
+                        ) : null}
+                    </div>
+                )
+            })}
+        </div>
+    )
+}
+
+export function ParameterTree({
+    schema,
+    selectedPath,
+    onSelect,
+    metaSelected,
+    onSelectMeta,
+    onAddRoot,
+    onAddProperty,
+    onRemove,
+    disabled,
+}: ParameterTreeProps) {
+    const [expanded, setExpanded] = useState<Set<string>>(new Set())
+    const selectedKey = selectedPath ? pathKey(selectedPath) : null
+
+    // Keep every ancestor of the selected node open, so adding/selecting deep never hides it.
+    useEffect(() => {
+        if (!selectedPath || selectedPath.length < 2) return
+        setExpanded((prev) => {
+            const next = new Set(prev)
+            for (let i = 1; i < selectedPath.length; i++)
+                next.add(pathKey(selectedPath.slice(0, i)))
+            return next
+        })
+    }, [selectedKey, selectedPath])
+
+    const toggle = (key: string) =>
+        setExpanded((prev) => {
+            const next = new Set(prev)
+            if (next.has(key)) next.delete(key)
+            else next.add(key)
+            return next
+        })
+
+    const rootProps = useMemo(() => getProps(schema), [schema])
+    const isEmpty = Object.keys(rootProps).length === 0
+
+    return (
+        <div className="flex w-[240px] shrink-0 flex-col overflow-hidden border-0 border-r border-solid border-[var(--ag-colorBorderSecondary)]">
+            {/* Pinned meta row — always reachable so property editing never traps you. */}
+            <div className="shrink-0 border-0 border-b border-solid border-[var(--ag-colorBorderSecondary)] px-2 pb-2 pt-3">
+                <button
+                    type="button"
+                    onClick={onSelectMeta}
+                    className={`flex w-full cursor-pointer appearance-none items-center gap-2 rounded border-0 px-1.5 py-1.5 text-left ${
+                        metaSelected
+                            ? "bg-[var(--ag-colorPrimaryBg)]"
+                            : "bg-transparent hover:bg-[var(--ag-colorFillTertiary)]"
+                    }`}
+                >
+                    <Wrench
+                        size={14}
+                        className={`shrink-0 ${
+                            metaSelected
+                                ? "text-[var(--ag-colorPrimary)]"
+                                : "text-[var(--ag-colorTextSecondary)]"
+                        }`}
+                    />
+                    <span
+                        className={`truncate text-xs ${
+                            metaSelected
+                                ? "font-medium text-[var(--ag-colorPrimary)]"
+                                : "text-[var(--ag-colorText)]"
+                        }`}
+                    >
+                        Tool details
+                    </span>
+                </button>
+            </div>
+
+            <div className="flex shrink-0 items-center justify-between gap-2 px-3 pb-2 pt-3">
+                <span className="text-[11px] font-medium uppercase tracking-wide text-[var(--ag-colorTextTertiary)]">
+                    Parameters
+                </span>
+                <Button
+                    type="link"
+                    className="!h-auto !p-0"
+                    icon={<Plus size={13} />}
+                    onClick={onAddRoot}
+                    disabled={disabled}
+                >
+                    Add
+                </Button>
+            </div>
+
+            <div className="min-h-0 flex-1 overflow-y-auto px-2 pb-3">
+                {isEmpty ? (
+                    <p className="m-0 px-1.5 py-2 text-[11px] leading-snug text-[var(--ag-colorTextTertiary)]">
+                        No parameters yet. Add the inputs the model provides when it calls this
+                        tool.
+                    </p>
+                ) : (
+                    <TreeNodes
+                        node={schema}
+                        basePath={[]}
+                        selectedKey={selectedKey}
+                        expanded={expanded}
+                        toggle={toggle}
+                        onSelect={onSelect}
+                        onAddProperty={onAddProperty}
+                        onRemove={onRemove}
+                        disabled={disabled}
+                    />
+                )}
+            </div>
+        </div>
+    )
+}

--- a/web/packages/agenta-entity-ui/src/DrillInView/SchemaControls/agentTemplate/ToolManagementList.tsx
+++ b/web/packages/agenta-entity-ui/src/DrillInView/SchemaControls/agentTemplate/ToolManagementList.tsx
@@ -1,0 +1,297 @@
+/**
+ * ToolManagementList
+ *
+ * The Tools section body, structured to match the triggers section: tools are partitioned into
+ * sub-sections — Connected apps (third-party/gateway tools **grouped by provider**, each an
+ * expandable app card), Workflow references, Tool definitions, and Built-in — each with a labelled
+ * count header. Connected-app grouping mirrors the trigger section's provider groups (shared
+ * {@link CollapsibleProviderGroup} / {@link SubSectionHeader}); the other kinds are flat row lists.
+ *
+ * The provider catalog (for app names/logos) only loads when there are gateway tools — the parent
+ * partitions with the tool function-name alone, and the catalog hook lives in {@link GatewayGroups},
+ * mounted only when a group exists. Dark-safe (`--ag-color*` tokens only).
+ */
+import {type ReactNode, useCallback, useMemo} from "react"
+
+import {useToolCatalogIntegrations} from "@agenta/entities/gatewayTool"
+import {useAtom} from "jotai"
+import {atomWithStorage} from "jotai/utils"
+
+import type {ConfigItemView} from "../ConfigItemDrawer"
+import {CollapsibleProviderGroup, SubSectionHeader} from "../sectionGroups"
+import {parseGatewayFunctionName} from "../toolUtils"
+
+import {describeTool, isFunctionTool, toolName} from "./itemDescriptors"
+import {ITEM_KINDS} from "./itemKinds"
+import {ItemChildRow, ItemRow} from "./ItemRow"
+
+// Persisted per-agent expand state for connected-app groups (key = `${entityId}:${integrationKey}`).
+const toolGroupsExpandedAtom = atomWithStorage<Record<string, boolean>>(
+    "agenta:tools:groups-expanded",
+    {},
+)
+
+interface IndexedTool {
+    item: unknown
+    index: number
+}
+interface ToolProviderGroup {
+    key: string
+    items: IndexedTool[]
+}
+
+function prettifyProvider(key: string): string {
+    if (!key) return "Other"
+    return key.charAt(0).toUpperCase() + key.slice(1)
+}
+
+export interface ToolManagementListProps {
+    tools: unknown[]
+    /** The open agent's revision id — scopes persisted group-expand state. */
+    entityId: string | null
+    openEdit: (kind: "tool", index: number, item: unknown, view: ConfigItemView) => void
+    removeItem: (kind: "tool", index: number) => void
+    closeEditor: () => void
+    disabled?: boolean
+    /**
+     * Opens the agent integration drawer. An `integrationKey` preselects that app (a provider group's
+     * "Add {app} tool" jumps straight to its actions); omit it to open on the app grid (header +).
+     */
+    onOpenIntegration?: (integrationKey?: string) => void
+    /** Add trigger shown in the empty state (the tool selector popover). */
+    emptyAdd: ReactNode
+}
+
+/** A flat, headed sub-section of bordered item rows (references / definitions / built-in). */
+function FlatToolSection({
+    label,
+    entries,
+    openEdit,
+    removeItem,
+    closeEditor,
+    disabled,
+}: {
+    label: string
+    entries: IndexedTool[]
+    openEdit: ToolManagementListProps["openEdit"]
+    removeItem: ToolManagementListProps["removeItem"]
+    closeEditor: () => void
+    disabled?: boolean
+}) {
+    if (entries.length === 0) return null
+    return (
+        <div className="flex flex-col gap-2">
+            <SubSectionHeader label={label} count={entries.length} />
+            <div className="flex flex-col gap-2">
+                {entries.map(({item, index}) => (
+                    <ItemRow
+                        key={`tool-${index}`}
+                        descriptor={describeTool(item)}
+                        onEdit={() => openEdit("tool", index, item, ITEM_KINDS.tool.editView(item))}
+                        onRemove={() => {
+                            removeItem("tool", index)
+                            closeEditor()
+                        }}
+                        disabled={disabled || ITEM_KINDS.tool.isReadOnly(item)}
+                    />
+                ))}
+            </div>
+        </div>
+    )
+}
+
+/**
+ * Connected-app tools grouped by provider. Isolated in its own component so the (paginated) tool
+ * catalog only loads when gateway tools actually exist.
+ */
+function GatewayGroups({
+    groups,
+    totalCount,
+    entityId,
+    openEdit,
+    removeItem,
+    closeEditor,
+    disabled,
+    onOpenIntegration,
+}: {
+    groups: ToolProviderGroup[]
+    totalCount: number
+    entityId: string | null
+    openEdit: ToolManagementListProps["openEdit"]
+    removeItem: ToolManagementListProps["removeItem"]
+    closeEditor: () => void
+    disabled?: boolean
+    onOpenIntegration?: (integrationKey?: string) => void
+}) {
+    const {integrations} = useToolCatalogIntegrations()
+    const [expanded, setExpanded] = useAtom(toolGroupsExpandedAtom)
+
+    const intgByKey = useMemo(
+        () => new Map(integrations.map((i) => [i.key, i] as const)),
+        [integrations],
+    )
+
+    const resolved = useMemo(
+        () =>
+            groups
+                .map((g) => {
+                    const intg = intgByKey.get(g.key)
+                    return {
+                        ...g,
+                        name: intg?.name || prettifyProvider(g.key),
+                        logo: intg?.logo ?? null,
+                    }
+                })
+                .sort((a, b) => a.name.localeCompare(b.name)),
+        [groups, intgByKey],
+    )
+
+    const isGroupOpen = useCallback(
+        (key: string, size: number) => expanded[`${entityId}:${key}`] ?? size === 1,
+        [expanded, entityId],
+    )
+    const toggleGroup = useCallback(
+        (key: string, size: number) => {
+            const k = `${entityId}:${key}`
+            setExpanded((prev) => ({...prev, [k]: !(prev[k] ?? size === 1)}))
+        },
+        [entityId, setExpanded],
+    )
+
+    return (
+        <div className="flex flex-col gap-2">
+            <SubSectionHeader label="Connected apps" count={totalCount} />
+            {resolved.map((group) => {
+                const open = isGroupOpen(group.key, group.items.length)
+                return (
+                    <CollapsibleProviderGroup
+                        key={group.key}
+                        logo={group.logo}
+                        name={group.name}
+                        countText={`${group.items.length} ${
+                            group.items.length === 1 ? "tool" : "tools"
+                        }`}
+                        open={open}
+                        onToggle={() => toggleGroup(group.key, group.items.length)}
+                        onAdd={
+                            !disabled && onOpenIntegration
+                                ? () => onOpenIntegration(group.key)
+                                : undefined
+                        }
+                        addLabel={`Add ${group.name} tool`}
+                    >
+                        {group.items.map(({item, index}) => (
+                            <ItemChildRow
+                                key={`tool-${index}`}
+                                descriptor={describeTool(item)}
+                                onEdit={() =>
+                                    openEdit("tool", index, item, ITEM_KINDS.tool.editView(item))
+                                }
+                                onRemove={() => {
+                                    removeItem("tool", index)
+                                    closeEditor()
+                                }}
+                                disabled={disabled}
+                            />
+                        ))}
+                    </CollapsibleProviderGroup>
+                )
+            })}
+        </div>
+    )
+}
+
+export function ToolManagementList({
+    tools,
+    entityId,
+    openEdit,
+    removeItem,
+    closeEditor,
+    disabled,
+    onOpenIntegration,
+    emptyAdd,
+}: ToolManagementListProps) {
+    // Partition by kind, preserving each tool's original index (edit/remove address the flat array).
+    // Uses only the tool object — no catalog needed here.
+    const {gatewayGroups, gatewayCount, references, definitions, builtins} = useMemo(() => {
+        const references: IndexedTool[] = []
+        const definitions: IndexedTool[] = []
+        const builtins: IndexedTool[] = []
+        const groups = new Map<string, ToolProviderGroup>()
+        tools.forEach((item, index) => {
+            const t = (item ?? {}) as Record<string, unknown>
+            if (t.type === "reference") {
+                references.push({item, index})
+                return
+            }
+            const gw = parseGatewayFunctionName(toolName(item))
+            if (gw) {
+                let group = groups.get(gw.integration)
+                if (!group) {
+                    group = {key: gw.integration, items: []}
+                    groups.set(gw.integration, group)
+                }
+                group.items.push({item, index})
+                return
+            }
+            if (!isFunctionTool(item)) {
+                builtins.push({item, index})
+                return
+            }
+            definitions.push({item, index})
+        })
+        const gatewayGroups = [...groups.values()]
+        const gatewayCount = gatewayGroups.reduce((n, g) => n + g.items.length, 0)
+        return {gatewayGroups, gatewayCount, references, definitions, builtins}
+    }, [tools])
+
+    if (tools.length === 0) {
+        if (disabled) return null
+        return (
+            <span className="text-xs text-[var(--ag-c-97A4B0,#97a4b0)]">
+                {ITEM_KINDS.tool.emptyLabel} — {emptyAdd}
+            </span>
+        )
+    }
+
+    return (
+        <div className="flex flex-col gap-3">
+            {gatewayGroups.length > 0 && (
+                <GatewayGroups
+                    groups={gatewayGroups}
+                    totalCount={gatewayCount}
+                    entityId={entityId}
+                    openEdit={openEdit}
+                    removeItem={removeItem}
+                    closeEditor={closeEditor}
+                    disabled={disabled}
+                    onOpenIntegration={onOpenIntegration}
+                />
+            )}
+            <FlatToolSection
+                label="Workflow references"
+                entries={references}
+                openEdit={openEdit}
+                removeItem={removeItem}
+                closeEditor={closeEditor}
+                disabled={disabled}
+            />
+            <FlatToolSection
+                label="Tool definitions"
+                entries={definitions}
+                openEdit={openEdit}
+                removeItem={removeItem}
+                closeEditor={closeEditor}
+                disabled={disabled}
+            />
+            <FlatToolSection
+                label="Built-in"
+                entries={builtins}
+                openEdit={openEdit}
+                removeItem={removeItem}
+                closeEditor={closeEditor}
+                disabled={disabled}
+            />
+        </div>
+    )
+}

--- a/web/packages/agenta-entity-ui/src/DrillInView/SchemaControls/agentTemplate/ToolManagementList.tsx
+++ b/web/packages/agenta-entity-ui/src/DrillInView/SchemaControls/agentTemplate/ToolManagementList.tsx
@@ -146,12 +146,16 @@ function GatewayGroups({
         [groups, intgByKey],
     )
 
+    // Persist expand state per entity; without an entityId, don't write to the shared atom under a
+    // colliding `null:*` key — just fall back to the default (single-group open).
     const isGroupOpen = useCallback(
-        (key: string, size: number) => expanded[`${entityId}:${key}`] ?? size === 1,
+        (key: string, size: number) =>
+            (entityId ? expanded[`${entityId}:${key}`] : undefined) ?? size === 1,
         [expanded, entityId],
     )
     const toggleGroup = useCallback(
         (key: string, size: number) => {
+            if (!entityId) return
             const k = `${entityId}:${key}`
             setExpanded((prev) => ({...prev, [k]: !(prev[k] ?? size === 1)}))
         },

--- a/web/packages/agenta-entity-ui/src/DrillInView/SchemaControls/agentTemplate/itemDescriptors.tsx
+++ b/web/packages/agenta-entity-ui/src/DrillInView/SchemaControls/agentTemplate/itemDescriptors.tsx
@@ -9,8 +9,10 @@ import {parseGatewayFunctionName, type ToolObj} from "../toolUtils"
 
 /** How a config-item row presents itself: avatar, name + description, and type tags. */
 export interface ItemDescriptor {
-    /** Primary label (rendered monospace). */
+    /** Primary label (rendered monospace unless `monoName` is false). */
     name: string
+    /** Render the name as prose, not monospace (e.g. a humanized connected-app action). @default mono */
+    monoName?: boolean
     /** Secondary description line. */
     description?: string
     /** Avatar monogram, used when no `icon` is given. */
@@ -73,9 +75,68 @@ export function isFunctionTool(tool: unknown): boolean {
     return Boolean(fn && typeof fn === "object")
 }
 
+/** Whether a tool is a `type:"reference"` workflow tool (#4860) — edited via its own detail view. */
+export function isReferenceTool(tool: unknown): boolean {
+    return Boolean(asObj(tool)?.type === "reference")
+}
+
 /** Two-char monogram, title-cased ("gmail" -> "Gm", "zendesk" -> "Ze"). */
 export function monogram(value: string): string {
     return (value.charAt(0).toUpperCase() + (value.charAt(1) ?? "")).trim() || "?"
+}
+
+/** Uppercase the first character (leaves the rest untouched). */
+function capitalizeFirst(value: string): string {
+    return value ? value.charAt(0).toUpperCase() + value.slice(1) : value
+}
+
+// Whole-word tokens kept uppercase when humanizing an action key (GitHub/Composio actions are
+// littered with these). Everything else is sentence-cased.
+const ACTION_ACRONYMS = new Set([
+    "API",
+    "URL",
+    "URI",
+    "ID",
+    "PR",
+    "CI",
+    "CD",
+    "SSO",
+    "SSH",
+    "IP",
+    "DNS",
+    "SLA",
+    "SMS",
+    "PDF",
+    "CSV",
+    "JSON",
+    "HTTP",
+    "HTTPS",
+    "SDK",
+    "UUID",
+    "GPG",
+    "OAUTH",
+    "2FA",
+    "MFA",
+])
+
+/**
+ * Turn a provider action key into a readable label: `ADD_ASSIGNEES_TO_AN_ISSUE` → "Add assignees to
+ * an issue". Sentence-cased, common acronyms kept uppercase. Used for connected-app tool rows, whose
+ * stored `function.name` is the slug (the friendly catalog name isn't persisted).
+ */
+export function humanizeActionKey(key: string): string {
+    const words = key
+        .toLowerCase()
+        .split(/[_\s]+/)
+        .filter(Boolean)
+    if (words.length === 0) return key
+    return words
+        .map((word, index) => {
+            const upper = word.toUpperCase()
+            if (ACTION_ACRONYMS.has(upper)) return upper
+            return index === 0 ? word.charAt(0).toUpperCase() + word.slice(1) : word
+        })
+        .join(" ")
 }
 
 /** Classify a tool into its row avatar / name / description / type tags. */
@@ -113,9 +174,16 @@ export function describeTool(tool: unknown): ItemDescriptor {
     // Third-party / gateway tool: tools__provider__integration__action__connection.
     const gateway = fnName ? parseGatewayFunctionName(fnName) : null
     if (gateway) {
+        // Some action keys repeat the integration (GITHUB_ADD_...) — drop it; the group header
+        // already names the app. Then humanize the key into a readable label.
+        const intgPrefix = `${gateway.integration.toUpperCase()}_`
+        const actionKey = gateway.action.toUpperCase().startsWith(intgPrefix)
+            ? gateway.action.slice(intgPrefix.length)
+            : gateway.action
         return {
-            name: gateway.action,
-            description,
+            name: humanizeActionKey(actionKey),
+            monoName: false,
+            description: description ? capitalizeFirst(description) : undefined,
             mono: monogram(gateway.integration),
             color: "#1c2c3d",
             tags: [gateway.integration],

--- a/web/packages/agenta-entity-ui/src/DrillInView/SchemaControls/agentTemplate/itemKinds.tsx
+++ b/web/packages/agenta-entity-ui/src/DrillInView/SchemaControls/agentTemplate/itemKinds.tsx
@@ -18,6 +18,7 @@ import {
     describeTool,
     isEmbedRefSkill,
     isFunctionTool,
+    isReferenceTool,
     isStaticSkill,
     type ItemDescriptor,
 } from "./itemDescriptors"
@@ -49,6 +50,8 @@ export interface ItemKindDef {
     drawerTitle: (draft: Record<string, unknown>) => string
     /** Wider drawer for kinds that need it (skills are two-pane). */
     drawerWidth?: number
+    /** Full-bleed body so the Form can lay out its own master/detail (the tool parameter editor). */
+    formFlush?: boolean
     /** Default Form/JSON view when opening an existing item. */
     editView: (item: unknown) => ConfigItemView
     /** Items with no structured form open JSON-only (no Form/JSON toggle). */
@@ -70,12 +73,17 @@ export const ITEM_KINDS: Record<ItemKind, ItemKindDef> = {
         emptyLabel: "No tools yet",
         describe: describeTool,
         FormView: ToolFormView,
+        // Two-panel parameter master/detail — needs width + a full-bleed body.
+        drawerWidth: 800,
+        formFlush: true,
         drawerTitle: (draft) => {
             const name = describeTool(draft).name
             return name && name !== "Tool" ? name : "New tool"
         },
-        editView: (item) => (isFunctionTool(item) ? "form" : "json"),
-        jsonOnly: (draft) => !isFunctionTool(draft),
+        // Function tools and workflow-reference tools both have a structured Form; only bare
+        // builtin/provider tools (a naked `type`) stay JSON-only.
+        editView: (item) => (isFunctionTool(item) || isReferenceTool(item) ? "form" : "json"),
+        jsonOnly: (draft) => !isFunctionTool(draft) && !isReferenceTool(draft),
         isReadOnly: () => false,
         // Unused for tools: creation seeds from the picker (buildInlineFunctionTool), not this.
         createSeed: () => ({}),

--- a/web/packages/agenta-entity-ui/src/DrillInView/SchemaControls/agentTemplate/schemaPaths.ts
+++ b/web/packages/agenta-entity-ui/src/DrillInView/SchemaControls/agentTemplate/schemaPaths.ts
@@ -1,0 +1,195 @@
+/**
+ * schemaPaths
+ *
+ * Pure, immutable JSON-Schema helpers for the tool-parameter master/detail editor. A node is
+ * addressed by a `Seg[]` path from the root `parameters` object: `{p}` steps into an object
+ * property, `{items:true}` steps into an array's `items`. The `{items:true}` sentinel (vs a bare
+ * "items" string) avoids colliding with a property literally named "items".
+ *
+ * Every mutator returns a fresh schema; renames preserve property insertion order and remap the
+ * `required` array. No React, no side effects — unit-testable in isolation.
+ */
+
+export type Schema = Record<string, unknown>
+
+/** A property step (`.properties[p]`) or an array-items step (`.items`). */
+export type Seg = {p: string} | {items: true}
+
+export const TYPE_OPTIONS = [
+    {value: "string", label: "string"},
+    {value: "number", label: "number"},
+    {value: "integer", label: "integer"},
+    {value: "boolean", label: "boolean"},
+    {value: "object", label: "object"},
+    {value: "array", label: "array"},
+]
+// Array items: scalars + object (no array-of-array in the form — use JSON for that).
+export const ITEM_TYPE_OPTIONS = TYPE_OPTIONS.filter((o) => o.value !== "array")
+
+export function isRecord(value: unknown): value is Schema {
+    return typeof value === "object" && value !== null && !Array.isArray(value)
+}
+
+export function isItemsSeg(seg: Seg): seg is {items: true} {
+    return "items" in seg
+}
+
+export function getProps(schema: Schema): Record<string, Schema> {
+    return isRecord(schema.properties) ? (schema.properties as Record<string, Schema>) : {}
+}
+
+export function getRequired(schema: Schema): string[] {
+    return Array.isArray(schema.required)
+        ? (schema.required as unknown[]).filter((x): x is string => typeof x === "string")
+        : []
+}
+
+export function defType(def: unknown): string {
+    return isRecord(def) && typeof def.type === "string" ? def.type : "string"
+}
+
+/** An array's item schema (defaults to a string item). */
+export function itemsSchema(def: Schema): Schema {
+    return isRecord(def.items) ? (def.items as Schema) : {type: "string"}
+}
+
+export function buildObjectSchema(
+    prev: Schema,
+    properties: Record<string, Schema>,
+    required: string[],
+): Schema {
+    return {
+        ...prev,
+        type: "object",
+        properties,
+        required,
+        additionalProperties:
+            isRecord(prev) && typeof prev.additionalProperties === "boolean"
+                ? prev.additionalProperties
+                : false,
+    }
+}
+
+/** Resolve the schema node at `path`, or null if any step is missing. */
+export function getNodeAt(root: Schema, path: Seg[]): Schema | null {
+    let node: Schema | null = isRecord(root) ? root : null
+    for (const seg of path) {
+        if (!node) return null
+        if (isItemsSeg(seg)) {
+            node = isRecord(node.items) ? (node.items as Schema) : null
+        } else {
+            const props = getProps(node)
+            node = isRecord(props[seg.p]) ? props[seg.p] : null
+        }
+    }
+    return node
+}
+
+/** Immutably replace the node at `path` with `next` (rebuilding parents along the way). */
+export function setNodeAt(root: Schema, path: Seg[], next: Schema): Schema {
+    if (path.length === 0) return next
+    const [seg, ...rest] = path
+    if (isItemsSeg(seg)) {
+        const items = isRecord(root.items) ? (root.items as Schema) : {type: "string"}
+        return {...root, type: "array", items: setNodeAt(items, rest, next)}
+    }
+    const props = getProps(root)
+    const child = isRecord(props[seg.p]) ? props[seg.p] : {type: "string"}
+    return buildObjectSchema(
+        root,
+        {...props, [seg.p]: setNodeAt(child, rest, next)},
+        getRequired(root),
+    )
+}
+
+/** Rename the property `key` under the object at `parentPath`, preserving order + `required`. */
+export function renamePropertyAt(
+    root: Schema,
+    parentPath: Seg[],
+    key: string,
+    nextKey: string,
+): Schema {
+    const parent = getNodeAt(root, parentPath)
+    if (!parent) return root
+    const props = getProps(parent)
+    if (!nextKey || nextKey === key || props[nextKey]) return root
+    const nextProps: Record<string, Schema> = {}
+    for (const [k, v] of Object.entries(props)) nextProps[k === key ? nextKey : k] = v
+    const nextRequired = getRequired(parent).map((r) => (r === key ? nextKey : r))
+    return setNodeAt(root, parentPath, buildObjectSchema(parent, nextProps, nextRequired))
+}
+
+/** Append a fresh `string` property under the object at `parentPath`; returns the new schema + key. */
+export function addPropertyAt(root: Schema, parentPath: Seg[]): {schema: Schema; key: string} {
+    const parent = getNodeAt(root, parentPath) ?? {type: "object", properties: {}, required: []}
+    const props = getProps(parent)
+    let i = Object.keys(props).length + 1
+    let key = `param${i}`
+    while (props[key]) key = `param${++i}`
+    const nextParent = buildObjectSchema(
+        parent,
+        {...props, [key]: {type: "string"}},
+        getRequired(parent),
+    )
+    return {schema: setNodeAt(root, parentPath, nextParent), key}
+}
+
+/** Remove the property `key` from the object at `parentPath` (drops it from `required` too). */
+export function removeNodeAt(root: Schema, parentPath: Seg[], key: string): Schema {
+    const parent = getNodeAt(root, parentPath)
+    if (!parent) return root
+    const nextProps = {...getProps(parent)}
+    delete nextProps[key]
+    return setNodeAt(
+        root,
+        parentPath,
+        buildObjectSchema(
+            parent,
+            nextProps,
+            getRequired(parent).filter((r) => r !== key),
+        ),
+    )
+}
+
+/** Toggle whether `key` is required on the object at `parentPath`. */
+export function toggleRequiredAt(
+    root: Schema,
+    parentPath: Seg[],
+    key: string,
+    on: boolean,
+): Schema {
+    const parent = getNodeAt(root, parentPath)
+    if (!parent) return root
+    const required = getRequired(parent)
+    const nextRequired = on
+        ? Array.from(new Set([...required, key]))
+        : required.filter((r) => r !== key)
+    return setNodeAt(root, parentPath, buildObjectSchema(parent, getProps(parent), nextRequired))
+}
+
+/** Whether the property `key` under the object at `parentPath` is required. */
+export function isRequiredAt(root: Schema, parentPath: Seg[], key: string): boolean {
+    const parent = getNodeAt(root, parentPath)
+    return parent ? getRequired(parent).includes(key) : false
+}
+
+/** The trailing property key of a path (the leaf's own name), or null for the root / an items leaf. */
+export function leafKey(path: Seg[]): string | null {
+    const last = path[path.length - 1]
+    return last && !isItemsSeg(last) ? last.p : null
+}
+
+/** The path to a leaf's parent object (drops the trailing property step). */
+export function parentPath(path: Seg[]): Seg[] {
+    return path.slice(0, -1)
+}
+
+/** Uppercase dotted breadcrumb for the detail header, e.g. `FILTERS.SOURCES` (items → `[ ]`). */
+export function pathLabel(path: Seg[]): string {
+    return path.map((seg) => (isItemsSeg(seg) ? "[ ]" : seg.p.toUpperCase())).join(" · ")
+}
+
+/** Serialize a path to a stable string for selection equality (`p:key` / `items`). */
+export function pathKey(path: Seg[]): string {
+    return path.map((seg) => (isItemsSeg(seg) ? "[]" : `p:${seg.p}`)).join("/")
+}

--- a/web/packages/agenta-entity-ui/src/DrillInView/SchemaControls/agentTemplate/schemaPaths.ts
+++ b/web/packages/agenta-entity-ui/src/DrillInView/SchemaControls/agentTemplate/schemaPaths.ts
@@ -63,8 +63,10 @@ export function buildObjectSchema(
         type: "object",
         properties,
         required,
+        // Preserve any declared value (boolean OR a schema object, e.g. `{type:"string"}`); only
+        // default to strict `false` when the source object never declared it.
         additionalProperties:
-            isRecord(prev) && typeof prev.additionalProperties === "boolean"
+            isRecord(prev) && prev.additionalProperties !== undefined
                 ? prev.additionalProperties
                 : false,
     }

--- a/web/packages/agenta-entity-ui/src/DrillInView/SchemaControls/agentTemplate/useAgentTools.ts
+++ b/web/packages/agenta-entity-ui/src/DrillInView/SchemaControls/agentTemplate/useAgentTools.ts
@@ -41,22 +41,25 @@ export function useAgentTools({
 
     const handleAddTool = useCallback(
         (tool: ToolObj, meta?: ToolSelectionMeta) => {
+            // `needsConfig` is a transient routing flag — never persist it in the tool metadata.
+            const {needsConfig, ...toolMeta} = meta ?? ({} as ToolSelectionMeta)
+            const hasMeta = Object.keys(toolMeta).length > 0
             const next =
-                meta && tool && typeof tool === "object" && !Array.isArray(tool)
+                hasMeta && tool && typeof tool === "object" && !Array.isArray(tool)
                     ? {
                           ...(tool as Record<string, unknown>),
                           agenta_metadata: {
                               ...(((tool as Record<string, unknown>).agenta_metadata as
                                   | Record<string, unknown>
                                   | undefined) ?? {}),
-                              ...meta,
+                              ...toolMeta,
                           },
                       }
                     : tool
-            // A custom (inline function) tool starts blank — edit it in a create drawer and only
-            // append on Save, so a half-filled tool never lands in the config. Builtin/gateway
-            // tools arrive complete (and gateway is multi-select), so add those straight away.
-            if (meta?.source === "custom") {
+            // Open the config editor (append only on Save) for a custom tool, or a gateway action
+            // whose input schema couldn't be resolved — so a half-filled/schema-less tool never
+            // lands silently. Complete gateway tools add straight away (gateway is multi-select).
+            if (toolMeta.source === "custom" || needsConfig) {
                 openCreate("tool", next as Record<string, unknown>, "form")
                 return
             }

--- a/web/packages/agenta-entity-ui/src/DrillInView/SchemaControls/agentTemplate/useAgentTools.ts
+++ b/web/packages/agenta-entity-ui/src/DrillInView/SchemaControls/agentTemplate/useAgentTools.ts
@@ -97,7 +97,7 @@ export function useAgentTools({
                     ? {environment: payload.environment}
                     : {}),
                 name: wf?.name || payload.slug,
-                description: wf?.description ?? wf?.name ?? "",
+                description: payload.description ?? wf?.description ?? wf?.name ?? "",
                 input_schema: inputSchema ?? {type: "object", properties: {}},
             }
             onChange({...latest, tools: [...latestTools, referenceTool]})

--- a/web/packages/agenta-entity-ui/src/DrillInView/SchemaControls/agentTemplate/useAgentTools.ts
+++ b/web/packages/agenta-entity-ui/src/DrillInView/SchemaControls/agentTemplate/useAgentTools.ts
@@ -90,6 +90,9 @@ export function useAgentTools({
                 type: "reference",
                 ref_by: payload.refBy,
                 slug: payload.slug,
+                ...(payload.refBy === "variant" && payload.variant
+                    ? {variant_id: payload.variant}
+                    : {}),
                 ...(payload.refBy === "variant" && payload.version
                     ? {version: payload.version}
                     : {}),

--- a/web/packages/agenta-entity-ui/src/DrillInView/SchemaControls/sectionGroups.tsx
+++ b/web/packages/agenta-entity-ui/src/DrillInView/SchemaControls/sectionGroups.tsx
@@ -1,0 +1,122 @@
+/**
+ * sectionGroups
+ *
+ * Shared presentational primitives for the agent config panel's grouped sections — the triggers
+ * section and the tools section render the same shapes, so they share these:
+ *  - {@link SubSectionHeader}: an uppercase label + count tag ("App triggers · 3", "Connected apps · 5").
+ *  - {@link ProviderLogo}: a connected-app logo (falls back to a plug glyph).
+ *  - {@link CollapsibleProviderGroup}: a collapsible provider card — caret + logo + name + a count
+ *    line + an optional per-group "add" button, with a `HeightCollapse` body of child rows.
+ *
+ * Pure presentation: state (expanded map) and data (which items belong to which provider) stay with
+ * the caller. Dark-safe — antd semantic tokens (`--ag-color*`) only.
+ */
+import type {ReactNode} from "react"
+
+import {HeightCollapse} from "@agenta/ui"
+import {CaretDown, CaretRight, Plugs, Plus} from "@phosphor-icons/react"
+import {Button, Tag, Tooltip} from "antd"
+import Image from "next/image"
+
+/** A connected-app logo square; a plug glyph when no logo is known (catalog not loaded yet). */
+export function ProviderLogo({logo, size = 24}: {logo?: string | null; size?: number}) {
+    if (!logo) return <Plugs size={size} className="shrink-0 text-[var(--ag-colorTextSecondary)]" />
+    return (
+        <Image
+            src={logo}
+            alt=""
+            width={size}
+            height={size}
+            unoptimized
+            className="shrink-0 rounded object-contain"
+        />
+    )
+}
+
+/** A sub-section label above a group of rows: uppercase text + a bordered count tag. */
+export function SubSectionHeader({label, count}: {label: string; count: number}) {
+    return (
+        <div className="flex items-center gap-1.5 px-0.5 text-[10px] uppercase tracking-wide text-[var(--ag-colorTextTertiary)]">
+            <span>{label}</span>
+            <Tag bordered className="m-0 !px-1.5 !text-[10px] font-normal leading-[16px]">
+                {count}
+            </Tag>
+        </div>
+    )
+}
+
+/**
+ * A collapsible provider card: a header (caret, logo, name, right-aligned count line, optional
+ * per-group add button) over a `HeightCollapse` body of child rows supplied by the caller.
+ */
+export function CollapsibleProviderGroup({
+    logo,
+    name,
+    countText,
+    open,
+    onToggle,
+    onAdd,
+    addLabel,
+    children,
+}: {
+    logo?: string | null
+    name: string
+    /** Right-aligned summary line, e.g. "2 active · 3 total" or "3 tools". */
+    countText: string
+    open: boolean
+    onToggle: () => void
+    /** Per-group add affordance; omit to hide the button (e.g. read-only). */
+    onAdd?: () => void
+    /** Tooltip + aria-label for the add button. */
+    addLabel?: string
+    children: ReactNode
+}) {
+    return (
+        <div className="overflow-hidden rounded border border-solid border-[var(--ag-colorBorderSecondary)]">
+            <div
+                role="button"
+                tabIndex={0}
+                aria-expanded={open}
+                onClick={onToggle}
+                onKeyDown={(e) => {
+                    if (e.target !== e.currentTarget) return
+                    if (e.key === "Enter" || e.key === " ") {
+                        e.preventDefault()
+                        onToggle()
+                    }
+                }}
+                className="flex cursor-pointer items-center gap-2.5 bg-[var(--ag-colorFillQuaternary)] px-3 py-2 transition-colors hover:bg-[var(--ag-colorFillSecondary)]"
+            >
+                {open ? (
+                    <CaretDown size={12} className="shrink-0 text-[var(--ag-colorTextSecondary)]" />
+                ) : (
+                    <CaretRight
+                        size={12}
+                        className="shrink-0 text-[var(--ag-colorTextSecondary)]"
+                    />
+                )}
+                <ProviderLogo logo={logo} size={24} />
+                <span className="min-w-0 flex-1 truncate text-xs font-medium">{name}</span>
+                <span className="shrink-0 text-[11px] text-[var(--ag-colorTextTertiary)]">
+                    {countText}
+                </span>
+                {onAdd ? (
+                    <Tooltip title={addLabel}>
+                        <Button
+                            type="text"
+                            icon={<Plus size={16} />}
+                            aria-label={addLabel}
+                            onClick={(e) => {
+                                e.stopPropagation()
+                                onAdd()
+                            }}
+                        />
+                    </Tooltip>
+                ) : null}
+            </div>
+            <HeightCollapse open={open}>
+                <div className="flex flex-col gap-0.5 px-1.5 pb-1.5 pt-1">{children}</div>
+            </HeightCollapse>
+        </div>
+    )
+}

--- a/web/packages/agenta-entity-ui/src/DrillInView/index.ts
+++ b/web/packages/agenta-entity-ui/src/DrillInView/index.ts
@@ -111,9 +111,12 @@ export type {
     GatewayToolsBridge,
     WorkflowReferenceBridge,
     WorkflowReferenceUI,
+    WorkflowReferenceType,
     WorkflowRevisionUI,
     WorkflowEnvironmentUI,
     WorkflowReferencePayload,
+    WorkflowConfigPart,
+    WorkflowConfigPayload,
 } from "@agenta/ui/drill-in"
 
 // Core Types

--- a/web/packages/agenta-entity-ui/src/drawers/shared/AddItemMenu.tsx
+++ b/web/packages/agenta-entity-ui/src/drawers/shared/AddItemMenu.tsx
@@ -1,0 +1,142 @@
+/**
+ * AddItemMenu
+ *
+ * Shared "+ add" popover for entity config sections (tools + triggers): grouped rows with an
+ * icon, title, optional subtitle, and a chevron for rows that open a drawer. Data-driven — each
+ * caller passes `groups`; the menu owns open/close and fires `onSelect` after closing.
+ *
+ * Keeps the tools and triggers add-menus visually identical. Dark-safe (`--ag-color*` tokens).
+ */
+import {memo, useCallback, useState, type ReactNode} from "react"
+
+import {CaretRight, Plus} from "@phosphor-icons/react"
+import {Button, Dropdown, Tooltip, Typography} from "antd"
+
+export interface AddItemMenuItem {
+    key: string
+    icon: ReactNode
+    title: string
+    subtitle?: string
+    /** Show a trailing chevron — the row opens a drawer rather than acting inline. */
+    opensDrawer?: boolean
+    disabled?: boolean
+    /** Tooltip shown when `disabled` (e.g. "Coming soon"). */
+    disabledHint?: string
+    onSelect?: () => void
+}
+
+export interface AddItemGroup {
+    /** Uppercase section label; omit for an unlabeled group. */
+    label?: string
+    items: AddItemMenuItem[]
+}
+
+function GroupLabel({children}: {children: ReactNode}) {
+    return (
+        <Typography.Text className="block px-2 pb-1 pt-2 text-[11px] font-medium uppercase tracking-wide text-[var(--ag-colorTextTertiary)]">
+            {children}
+        </Typography.Text>
+    )
+}
+
+function Row({item, onPick}: {item: AddItemMenuItem; onPick: (item: AddItemMenuItem) => void}) {
+    const body = (
+        <button
+            type="button"
+            disabled={item.disabled}
+            onClick={() => !item.disabled && onPick(item)}
+            className={`flex w-full items-center gap-2.5 rounded-md border-none bg-transparent px-2 py-1.5 text-left [font:inherit] ${
+                item.disabled
+                    ? "cursor-not-allowed opacity-50"
+                    : "cursor-pointer hover:bg-[var(--ag-colorFillTertiary)]"
+            }`}
+        >
+            <span className="flex h-[18px] w-[18px] shrink-0 items-center justify-center text-[var(--ag-colorTextSecondary)]">
+                {item.icon}
+            </span>
+            <span className="flex min-w-0 flex-1 flex-col leading-tight">
+                <span className="truncate text-xs text-[var(--ag-colorText)]">{item.title}</span>
+                {item.subtitle ? (
+                    <span className="truncate text-[11px] text-[var(--ag-colorTextTertiary)]">
+                        {item.subtitle}
+                    </span>
+                ) : null}
+            </span>
+            {item.opensDrawer ? (
+                <CaretRight size={13} className="shrink-0 text-[var(--ag-colorTextTertiary)]" />
+            ) : null}
+        </button>
+    )
+    return item.disabled && item.disabledHint ? (
+        <Tooltip title={item.disabledHint}>{body}</Tooltip>
+    ) : (
+        body
+    )
+}
+
+export const AddItemMenu = memo(function AddItemMenu({
+    groups,
+    trigger,
+    disabled = false,
+    ariaLabel = "Add",
+    minWidth = 288,
+}: {
+    groups: AddItemGroup[]
+    /** Custom trigger element (e.g. an inline text-link). Defaults to a `+` text button. */
+    trigger?: ReactNode
+    disabled?: boolean
+    ariaLabel?: string
+    minWidth?: number
+}) {
+    const [open, setOpen] = useState(false)
+
+    const handlePick = useCallback((item: AddItemMenuItem) => {
+        setOpen(false)
+        item.onSelect?.()
+    }, [])
+
+    const content = (
+        <div
+            className="rounded-lg border border-solid border-[var(--ag-colorBorderSecondary)] bg-[var(--ag-colorBgElevated)] p-1.5 shadow-sm"
+            style={{minWidth}}
+        >
+            {groups.map((group, gi) => (
+                <div key={group.label ?? `group-${gi}`}>
+                    {gi > 0 && (
+                        <div className="mx-2 my-1.5 h-px bg-[var(--ag-colorBorderSecondary)]" />
+                    )}
+                    {group.label ? <GroupLabel>{group.label}</GroupLabel> : null}
+                    {group.items.map((item) => (
+                        <Row key={item.key} item={item} onPick={handlePick} />
+                    ))}
+                </div>
+            ))}
+        </div>
+    )
+
+    return (
+        <Dropdown
+            open={!disabled && open}
+            onOpenChange={(next) => {
+                if (disabled) return
+                setOpen(next)
+            }}
+            trigger={["click"]}
+            placement="bottomLeft"
+            arrow={false}
+            menu={{items: []}}
+            popupRender={() => content}
+            classNames={{root: "[&_.ant-dropdown-menu]:hidden [&_.ant-dropdown]:p-0"}}
+        >
+            {trigger ?? (
+                <Button
+                    type="text"
+                    icon={<Plus size={16} />}
+                    aria-label={ariaLabel}
+                    disabled={disabled}
+                    onClick={(e) => e.stopPropagation()}
+                />
+            )}
+        </Dropdown>
+    )
+})

--- a/web/packages/agenta-entity-ui/src/drawers/shared/AddItemMenu.tsx
+++ b/web/packages/agenta-entity-ui/src/drawers/shared/AddItemMenu.tsx
@@ -67,8 +67,11 @@ function Row({item, onPick}: {item: AddItemMenuItem; onPick: (item: AddItemMenuI
             ) : null}
         </button>
     )
+    // A disabled <button> swallows mouse events, so wrap it in a span for the tooltip to trigger.
     return item.disabled && item.disabledHint ? (
-        <Tooltip title={item.disabledHint}>{body}</Tooltip>
+        <Tooltip title={item.disabledHint}>
+            <span className="block cursor-not-allowed">{body}</span>
+        </Tooltip>
     ) : (
         body
     )

--- a/web/packages/agenta-entity-ui/src/drawers/shared/CatalogAppCard.tsx
+++ b/web/packages/agenta-entity-ui/src/drawers/shared/CatalogAppCard.tsx
@@ -1,0 +1,85 @@
+/**
+ * Catalog app card + logo — the provider tile shared by every Composio catalog grid (the
+ * subscription "Choose a trigger" chooser AND the tools "Third-party integration" catalog), so
+ * the app grid looks identical across triggers and tools. Dark-safe (`--ag-color*` tokens).
+ */
+import {Lightning, Plugs} from "@phosphor-icons/react"
+import {Tooltip} from "antd"
+import Image from "next/image"
+
+/** An app's logo (catalog `integration.logo`), with a neutral plug fallback. */
+export function AppLogo({logo, size = 20}: {logo?: string | null; size?: number}) {
+    if (!logo) return <Plugs size={size} className="shrink-0 text-[var(--ag-colorTextSecondary)]" />
+    return (
+        <Image
+            src={logo}
+            alt=""
+            width={size}
+            height={size}
+            unoptimized
+            className="shrink-0 rounded object-contain"
+        />
+    )
+}
+
+export function AppCard({
+    logo,
+    name,
+    description,
+    categories,
+    actionsCount,
+    connected,
+    onClick,
+}: {
+    logo?: string | null
+    name: string
+    description?: string | null
+    categories?: string[]
+    actionsCount?: number | null
+    connected?: boolean
+    onClick: () => void
+}) {
+    const shownCategories = (categories ?? []).filter(Boolean).slice(0, 2)
+    return (
+        <button
+            type="button"
+            onClick={onClick}
+            className="group flex h-full min-h-[112px] cursor-pointer flex-col gap-2 rounded-lg border border-solid border-[var(--ag-colorBorder)] bg-transparent p-3 text-left hover:border-[var(--ag-colorPrimary)] hover:bg-[var(--ag-colorFillQuaternary)]"
+        >
+            <div className="flex items-center gap-2.5">
+                <AppLogo logo={logo} size={28} />
+                <div className="flex min-w-0 flex-1 items-center gap-1.5">
+                    <span className="truncate text-xs font-medium">{name}</span>
+                    {connected && (
+                        <Tooltip title="Connected">
+                            <span className="size-1.5 shrink-0 rounded-full bg-[var(--ag-colorSuccess)]" />
+                        </Tooltip>
+                    )}
+                </div>
+            </div>
+            {description ? (
+                <p className="m-0 line-clamp-2 text-[11px] leading-snug text-[var(--ag-colorTextSecondary)]">
+                    {description}
+                </p>
+            ) : (
+                <span className="flex-1" />
+            )}
+            <div className="mt-auto flex items-center gap-1.5">
+                {shownCategories.map((cat) => (
+                    <span
+                        key={cat}
+                        className="truncate rounded bg-[var(--ag-colorFillTertiary)] px-1.5 py-0.5 text-[10px] capitalize leading-none text-[var(--ag-colorTextSecondary)]"
+                    >
+                        {cat}
+                    </span>
+                ))}
+                {typeof actionsCount === "number" && actionsCount > 0 && (
+                    <span className="ml-auto flex shrink-0 items-center gap-1 text-[10px] text-[var(--ag-colorTextTertiary)]">
+                        <Lightning size={11} weight="fill" />
+                        {actionsCount}
+                    </span>
+                )}
+            </div>
+        </button>
+    )
+}

--- a/web/packages/agenta-entity-ui/src/drawers/shared/CatalogChooser.tsx
+++ b/web/packages/agenta-entity-ui/src/drawers/shared/CatalogChooser.tsx
@@ -1,0 +1,564 @@
+/**
+ * CatalogChooser
+ *
+ * The Composio app/source chooser — the EXACT inner content from the subscription drawer's
+ * "Choose a trigger" step (a "Your connections" rail + a responsive 2-column "All apps" grid with
+ * the good infinite scroll + an app detail panel). Extracted so the tools "Third-party integration"
+ * flow renders the SAME component and layout, differing only by the per-app item leaf (pick an event
+ * → subscription vs. add an action → tool), supplied via props.
+ *
+ * Consumers wrap this in their own drawer/section. Dark-safe (`--ag-color*` tokens).
+ */
+import {useEffect, useMemo, useState, type ReactNode} from "react"
+
+import {ScrollSentinel} from "@agenta/ui"
+import {ArrowLeft, Check, MagnifyingGlass, Plus} from "@phosphor-icons/react"
+import {Button, Input, Spin, Typography} from "antd"
+
+import {AppCard, AppLogo} from "./CatalogAppCard"
+
+export type CatalogItemState = "add" | "selected" | "pending"
+
+export interface CatalogChooserProps<I, T, C> {
+    connections: C[]
+    isConnectionActive: (c: C) => boolean
+    useIntegrations: () => {
+        integrations: I[]
+        hasNextPage: boolean
+        isFetchingNextPage: boolean
+        isLoading: boolean
+        requestMore: () => void
+        setSearch: (s: string) => void
+    }
+    useItems: (integrationKey: string) => {
+        items: T[]
+        isLoading: boolean
+        hasNextPage: boolean
+        isFetchingNextPage: boolean
+        requestMore: () => void
+        /** Server-side item search (drives the paginated query). */
+        setSearch: (s: string) => void
+    }
+    integration: {
+        key: (i: I) => string
+        name: (i: I) => string
+        logo: (i: I) => string | null | undefined
+        description: (i: I) => string | null | undefined
+        categories: (i: I) => string[] | undefined
+        actionsCount: (i: I) => number | null | undefined
+    }
+    connection: {
+        id: (c: C) => string | undefined
+        name: (c: C) => string | undefined
+        slug: (c: C) => string | undefined
+        integrationKey: (c: C) => string
+        connectedAt?: (c: C) => string | undefined
+    }
+    item: {
+        key: (t: T) => string
+        name: (t: T) => string | undefined
+        /** Secondary description line for an item row (optional — omitted rows show name only). */
+        description?: (t: T) => string | null | undefined
+        /** Category chips for an item row (e.g. an action's `["CI/CD"]`). */
+        categories?: (t: T) => string[] | null | undefined
+        /** Read-only items get a subtle badge (e.g. a non-mutating provider action). */
+        readOnly?: (t: T) => boolean | null | undefined
+        /** Deprecated items get a warning badge and a muted name (e.g. a superseded provider event). */
+        deprecated?: (t: T) => boolean | null | undefined
+    }
+    /** "Choose an event" / "Choose an action". */
+    itemsLabel: string
+    /** Placeholder for the item search box. @default "Search…" */
+    itemsSearchPlaceholder?: string
+    emptyItemsText: string
+    onPickItem: (connection: C, item: T) => void
+    /** Per-item affordance (tools track selected/pending). Defaults to "add". */
+    itemState?: (connection: C, item: T) => CatalogItemState
+    /** Connect a not-yet-connected app — render the surface's connect drawer. */
+    renderConnect: (
+        integration: I,
+        handlers: {onClose: () => void; onSuccess: () => void},
+    ) => ReactNode
+    defaultIntegrationKey?: string
+}
+
+function ItemTrailing({state}: {state: CatalogItemState}) {
+    if (state === "pending") return <Spin size="small" />
+    if (state === "selected")
+        return <Check size={13} className="shrink-0 text-[var(--ag-colorPrimary)]" />
+    return <Plus size={13} className="shrink-0 text-[var(--ag-colorTextTertiary)]" />
+}
+
+function CatalogItemList<I, T, C>({
+    connection,
+    props,
+}: {
+    connection: C
+    props: CatalogChooserProps<I, T, C>
+}) {
+    const {items, isLoading, hasNextPage, isFetchingNextPage, requestMore, setSearch} =
+        props.useItems(props.connection.integrationKey(connection))
+    const [query, setQuery] = useState("")
+    const [listEl, setListEl] = useState<HTMLDivElement | null>(null)
+    // Debounce into the server-side item search; clear the shared atom when leaving this app.
+    useEffect(() => {
+        const t = setTimeout(() => setSearch(query.trim()), 250)
+        return () => clearTimeout(t)
+    }, [query, setSearch])
+    useEffect(() => () => setSearch(""), [setSearch])
+
+    const describe = props.item.description
+    const searching = query.trim().length > 0
+
+    return (
+        <div className="flex min-h-0 flex-1 flex-col gap-2.5">
+            <Input
+                allowClear
+                placeholder={props.itemsSearchPlaceholder ?? "Search…"}
+                prefix={
+                    <MagnifyingGlass size={13} className="text-[var(--ag-colorTextTertiary)]" />
+                }
+                value={query}
+                onChange={(e) => setQuery(e.target.value)}
+            />
+            <div
+                ref={setListEl}
+                className="flex min-h-0 flex-1 flex-col gap-0.5 overflow-y-auto pr-1"
+            >
+                {isLoading && items.length === 0 ? (
+                    <div className="flex justify-center py-8">
+                        <Spin size="small" />
+                    </div>
+                ) : items.length === 0 ? (
+                    <div className="px-2 py-4 text-xs text-[var(--ag-colorTextTertiary)]">
+                        {searching ? `No matches for “${query.trim()}”.` : props.emptyItemsText}
+                    </div>
+                ) : (
+                    <>
+                        {items.map((it) => {
+                            const state = props.itemState?.(connection, it) ?? "add"
+                            const description = describe?.(it)
+                            const categories = (props.item.categories?.(it) ?? []).filter(Boolean)
+                            const readOnly = props.item.readOnly?.(it) === true
+                            const deprecated = props.item.deprecated?.(it) === true
+                            // Deprecated items are visible but not addable — unless one is already
+                            // selected, so it stays removable.
+                            const isSelected = state === "selected"
+                            const disabledRow = deprecated && !isSelected
+                            return (
+                                <button
+                                    key={props.item.key(it)}
+                                    type="button"
+                                    disabled={disabledRow}
+                                    title={
+                                        disabledRow
+                                            ? "Deprecated — use the recommended event instead"
+                                            : undefined
+                                    }
+                                    onClick={() =>
+                                        !disabledRow &&
+                                        state !== "pending" &&
+                                        props.onPickItem(connection, it)
+                                    }
+                                    className={`flex w-full items-start gap-3 rounded-md border-0 bg-transparent px-2.5 py-2 text-left ${
+                                        disabledRow
+                                            ? "cursor-not-allowed opacity-60"
+                                            : "cursor-pointer hover:bg-[var(--ag-colorFillSecondary)]"
+                                    }`}
+                                >
+                                    <span className="min-w-0 flex-1">
+                                        <span className="flex items-center gap-1.5">
+                                            <span
+                                                className={`min-w-0 truncate text-[12.5px] font-medium ${
+                                                    deprecated
+                                                        ? "text-[var(--ag-colorTextTertiary)]"
+                                                        : "text-[var(--ag-colorText)]"
+                                                }`}
+                                            >
+                                                {props.item.name(it) || props.item.key(it)}
+                                            </span>
+                                            {deprecated ? (
+                                                <span className="shrink-0 rounded bg-[var(--ag-colorFillSecondary)] px-1 py-px text-[9px] uppercase tracking-wide text-[var(--ag-colorWarningText)]">
+                                                    deprecated
+                                                </span>
+                                            ) : null}
+                                            {readOnly ? (
+                                                <span className="shrink-0 rounded bg-[var(--ag-colorFillSecondary)] px-1 py-px text-[9px] uppercase tracking-wide text-[var(--ag-colorTextTertiary)]">
+                                                    read-only
+                                                </span>
+                                            ) : null}
+                                        </span>
+                                        {description ? (
+                                            <span className="mt-1 line-clamp-2 text-[11px] leading-snug text-[var(--ag-colorTextTertiary)]">
+                                                {description}
+                                            </span>
+                                        ) : null}
+                                        {categories.length > 0 ? (
+                                            <span className="mt-1.5 flex flex-wrap gap-1">
+                                                {categories.slice(0, 3).map((c) => (
+                                                    <span
+                                                        key={c}
+                                                        className="rounded bg-[var(--ag-colorFillSecondary)] px-1.5 py-0.5 text-[10px] leading-none text-[var(--ag-colorTextTertiary)]"
+                                                    >
+                                                        {c}
+                                                    </span>
+                                                ))}
+                                            </span>
+                                        ) : null}
+                                    </span>
+                                    <span className="mt-0.5 shrink-0">
+                                        {disabledRow ? null : <ItemTrailing state={state} />}
+                                    </span>
+                                </button>
+                            )
+                        })}
+                        {isFetchingNextPage && (
+                            <div className="flex justify-center py-3">
+                                <Spin size="small" />
+                            </div>
+                        )}
+                        <ScrollSentinel
+                            onVisible={requestMore}
+                            hasMore={hasNextPage}
+                            isFetching={isFetchingNextPage}
+                            root={listEl}
+                            rootMargin="0px 0px 600px 0px"
+                        />
+                    </>
+                )}
+            </div>
+        </div>
+    )
+}
+
+function ConnectionDetail<I, T, C>({
+    connection,
+    integration,
+    props,
+}: {
+    connection: C
+    integration?: I
+    props: CatalogChooserProps<I, T, C>
+}) {
+    const active = props.isConnectionActive(connection)
+    const account = props.connection.name(connection) || props.connection.slug(connection) || ""
+    const connectedAt = props.connection.connectedAt?.(connection) || ""
+    return (
+        <div className="flex items-center gap-2.5 rounded-lg border border-solid border-[var(--ag-colorBorder)] px-3 py-2">
+            <AppLogo
+                logo={integration ? props.integration.logo(integration) : undefined}
+                size={20}
+            />
+            <div className="min-w-0 flex-1">
+                <div className="truncate text-xs font-medium">
+                    {integration
+                        ? props.integration.name(integration)
+                        : props.connection.integrationKey(connection)}
+                </div>
+                <div className="truncate text-[11px] text-[var(--ag-colorTextTertiary)]">
+                    {account || props.connection.integrationKey(connection)}
+                    {connectedAt ? ` · connected ${connectedAt}` : ""}
+                </div>
+            </div>
+            <span
+                className={`inline-flex shrink-0 items-center gap-1 text-[11px] ${
+                    active ? "text-[var(--ag-colorSuccess)]" : "text-[var(--ag-colorTextTertiary)]"
+                }`}
+            >
+                <span
+                    className={`h-1.5 w-1.5 rounded-full ${
+                        active
+                            ? "bg-[var(--ag-colorSuccess)]"
+                            : "bg-[var(--ag-colorTextQuaternary)]"
+                    }`}
+                />
+                {active ? "Active" : "Inactive"}
+            </span>
+        </div>
+    )
+}
+
+function AppRailItem({
+    active,
+    logo,
+    name,
+    sub,
+    connected,
+    onClick,
+}: {
+    active: boolean
+    logo?: string | null
+    name: string
+    sub?: string
+    connected?: boolean
+    onClick: () => void
+}) {
+    return (
+        <button
+            type="button"
+            onClick={onClick}
+            className={`flex w-full cursor-pointer items-center gap-2 rounded border-0 px-2 py-1.5 text-left ${
+                active
+                    ? "bg-[var(--ag-colorPrimaryBg)]"
+                    : "bg-transparent hover:bg-[var(--ag-colorFillTertiary)]"
+            }`}
+        >
+            <AppLogo logo={logo} size={18} />
+            <span className="min-w-0 flex-1">
+                <span
+                    className={`block truncate text-xs ${
+                        active
+                            ? "font-medium text-[var(--ag-colorPrimary)]"
+                            : "text-[var(--ag-colorText)]"
+                    }`}
+                >
+                    {name}
+                </span>
+                {sub && (
+                    <span className="block truncate text-[10px] text-[var(--ag-colorTextTertiary)]">
+                        {sub}
+                    </span>
+                )}
+            </span>
+            {connected && (
+                <span className="h-1.5 w-1.5 shrink-0 rounded-full bg-[var(--ag-colorSuccess)]" />
+            )}
+        </button>
+    )
+}
+
+function ConnectInvite<I, T, C>({
+    integration,
+    props,
+    onConnect,
+}: {
+    integration?: I
+    props: CatalogChooserProps<I, T, C>
+    onConnect: () => void
+}) {
+    const name = integration ? props.integration.name(integration) : undefined
+    const description = integration ? props.integration.description(integration) : undefined
+    return (
+        <div className="flex flex-1 flex-col items-center justify-center gap-2 py-6 text-center">
+            <AppLogo
+                logo={integration ? props.integration.logo(integration) : undefined}
+                size={32}
+            />
+            <div className="text-xs font-medium">{name ?? "This app"}</div>
+            {description && (
+                <div className="max-w-[280px] text-[11px] leading-snug text-[var(--ag-colorTextTertiary)]">
+                    {description}
+                </div>
+            )}
+            <Button type="primary" onClick={onConnect}>
+                Connect {name ?? "app"}
+            </Button>
+        </div>
+    )
+}
+
+export function CatalogChooser<I, T, C>(props: CatalogChooserProps<I, T, C>) {
+    const {connections, defaultIntegrationKey} = props
+    const {integrations, hasNextPage, isFetchingNextPage, isLoading, requestMore, setSearch} =
+        props.useIntegrations()
+
+    const byKey = useMemo(() => {
+        const m = new Map<string, I>()
+        integrations.forEach((i) => m.set(props.integration.key(i), i))
+        return m
+    }, [integrations, props.integration])
+    const connectedKeys = useMemo(
+        () => new Set(connections.map((c) => props.connection.integrationKey(c))),
+        [connections, props.connection],
+    )
+
+    const [searchInput, setSearchInput] = useState("")
+    useEffect(() => {
+        const t = setTimeout(() => setSearch(searchInput), 250)
+        return () => clearTimeout(t)
+    }, [searchInput, setSearch])
+    const searching = searchInput.trim().length > 0
+
+    const [selected, setSelected] = useState<{kind: "conn" | "intg"; id: string} | null>(
+        defaultIntegrationKey ? {kind: "intg", id: defaultIntegrationKey} : null,
+    )
+    const [gridEl, setGridEl] = useState<HTMLDivElement | null>(null)
+    const selectedConn =
+        selected?.kind === "conn"
+            ? connections.find((c) => props.connection.id(c) === selected.id)
+            : selected?.kind === "intg"
+              ? connections.find((c) => props.connection.integrationKey(c) === selected.id)
+              : undefined
+    const selectedIntegration = selectedConn
+        ? byKey.get(props.connection.integrationKey(selectedConn))
+        : selected?.kind === "intg"
+          ? byKey.get(selected.id)
+          : undefined
+    const [connectIntegration, setConnectIntegration] = useState<I | null>(null)
+
+    const hasConnections = connections.length > 0
+
+    return (
+        <div className="flex h-full min-h-[260px] gap-3">
+            {hasConnections && (
+                <div className="flex w-[220px] shrink-0 flex-col gap-0.5 overflow-y-auto">
+                    <div className="px-1 pb-1 text-[10px] uppercase tracking-wide text-[var(--ag-colorTextTertiary)]">
+                        Your connections
+                    </div>
+                    {connections.map((c) => {
+                        const app = byKey.get(props.connection.integrationKey(c))
+                        const appName = app
+                            ? props.integration.name(app)
+                            : props.connection.integrationKey(c)
+                        const account = props.connection.name(c)?.trim()
+                        return (
+                            <AppRailItem
+                                key={props.connection.id(c) ?? props.connection.integrationKey(c)}
+                                active={
+                                    selected?.kind === "conn" &&
+                                    selected.id === props.connection.id(c)
+                                }
+                                logo={app ? props.integration.logo(app) : undefined}
+                                name={account || appName}
+                                sub={account ? appName : undefined}
+                                connected
+                                onClick={() => {
+                                    const id = props.connection.id(c)
+                                    if (id) setSelected({kind: "conn", id})
+                                }}
+                            />
+                        )
+                    })}
+                </div>
+            )}
+
+            <div
+                className={`flex min-h-0 min-w-0 flex-1 flex-col ${
+                    hasConnections
+                        ? "border-0 border-l border-solid border-[var(--ag-colorBorderSecondary)] pl-3"
+                        : ""
+                }`}
+            >
+                {selected ? (
+                    <div className="flex min-h-0 flex-1 flex-col overflow-hidden">
+                        <button
+                            type="button"
+                            onClick={() => setSelected(null)}
+                            className="mb-3 flex shrink-0 cursor-pointer items-center gap-1 self-start border-0 bg-transparent p-0 text-[11px] text-[var(--ag-colorTextSecondary)] hover:text-[var(--ag-colorText)]"
+                        >
+                            <ArrowLeft size={13} /> All apps
+                        </button>
+                        {selectedConn ? (
+                            <div className="flex min-h-0 flex-1 flex-col">
+                                <div className="shrink-0">
+                                    <ConnectionDetail
+                                        connection={selectedConn}
+                                        integration={selectedIntegration}
+                                        props={props}
+                                    />
+                                    <div className="mb-2 mt-4 flex items-center justify-between gap-2">
+                                        <Typography.Text
+                                            type="secondary"
+                                            className="!text-[10px] uppercase !tracking-wide"
+                                        >
+                                            {props.itemsLabel}
+                                        </Typography.Text>
+                                        {selectedIntegration && (
+                                            <button
+                                                type="button"
+                                                onClick={() =>
+                                                    setConnectIntegration(selectedIntegration)
+                                                }
+                                                className="cursor-pointer border-0 bg-transparent p-0 text-[11px] text-[var(--ag-colorPrimary)] hover:underline"
+                                            >
+                                                + Connect another account
+                                            </button>
+                                        )}
+                                    </div>
+                                </div>
+                                <CatalogItemList
+                                    key={props.connection.integrationKey(selectedConn)}
+                                    connection={selectedConn}
+                                    props={props}
+                                />
+                            </div>
+                        ) : (
+                            <ConnectInvite
+                                integration={selectedIntegration}
+                                props={props}
+                                onConnect={() =>
+                                    selectedIntegration &&
+                                    setConnectIntegration(selectedIntegration)
+                                }
+                            />
+                        )}
+                    </div>
+                ) : (
+                    <>
+                        <Input
+                            allowClear
+                            placeholder="Search apps…"
+                            prefix={
+                                <MagnifyingGlass
+                                    size={13}
+                                    className="text-[var(--ag-colorTextTertiary)]"
+                                />
+                            }
+                            value={searchInput}
+                            onChange={(e) => setSearchInput(e.target.value)}
+                        />
+                        <div className="mb-1 mt-2 px-0.5 text-[10px] uppercase tracking-wide text-[var(--ag-colorTextTertiary)]">
+                            {searching ? "Search results" : "All apps"}
+                        </div>
+                        <div
+                            ref={setGridEl}
+                            className="grid min-h-0 flex-1 auto-rows-min gap-2 overflow-y-auto [grid-template-columns:repeat(auto-fill,minmax(220px,1fr))]"
+                        >
+                            {integrations.map((i) => (
+                                <AppCard
+                                    key={props.integration.key(i)}
+                                    logo={props.integration.logo(i)}
+                                    name={props.integration.name(i)}
+                                    description={props.integration.description(i)}
+                                    categories={props.integration.categories(i)}
+                                    actionsCount={props.integration.actionsCount(i)}
+                                    connected={connectedKeys.has(props.integration.key(i))}
+                                    onClick={() =>
+                                        setSelected({kind: "intg", id: props.integration.key(i)})
+                                    }
+                                />
+                            ))}
+                            {!isLoading && integrations.length === 0 && (
+                                <div className="col-span-full py-6 text-center text-[11px] text-[var(--ag-colorTextTertiary)]">
+                                    {searching
+                                        ? `No apps match “${searchInput}”.`
+                                        : "No apps found."}
+                                </div>
+                            )}
+                            <div className="col-span-full">
+                                {(isLoading || isFetchingNextPage) && (
+                                    <div className="flex justify-center py-3">
+                                        <Spin size="small" />
+                                    </div>
+                                )}
+                                <ScrollSentinel
+                                    onVisible={requestMore}
+                                    hasMore={hasNextPage}
+                                    isFetching={isFetchingNextPage}
+                                    root={gridEl}
+                                    rootMargin="0px 0px 1600px 0px"
+                                />
+                            </div>
+                        </div>
+                    </>
+                )}
+            </div>
+
+            {connectIntegration &&
+                props.renderConnect(connectIntegration, {
+                    onClose: () => setConnectIntegration(null),
+                    onSuccess: () => setConnectIntegration(null),
+                })}
+        </div>
+    )
+}

--- a/web/packages/agenta-entity-ui/src/drawers/shared/CatalogChooser.tsx
+++ b/web/packages/agenta-entity-ui/src/drawers/shared/CatalogChooser.tsx
@@ -377,6 +377,9 @@ export function CatalogChooser<I, T, C>(props: CatalogChooserProps<I, T, C>) {
         const t = setTimeout(() => setSearch(searchInput), 250)
         return () => clearTimeout(t)
     }, [searchInput, setSearch])
+    // The integrations search is a shared atom — clear it on unmount so a stale query doesn't
+    // filter the next open (mirrors the item-search cleanup above).
+    useEffect(() => () => setSearch(""), [setSearch])
     const searching = searchInput.trim().length > 0
 
     const [selected, setSelected] = useState<{kind: "conn" | "intg"; id: string} | null>(

--- a/web/packages/agenta-entity-ui/src/drawers/shared/DrawerFooter.tsx
+++ b/web/packages/agenta-entity-ui/src/drawers/shared/DrawerFooter.tsx
@@ -3,14 +3,15 @@ import type {ReactNode} from "react"
 import {Button, Divider, Switch} from "antd"
 
 /**
- * Shared footer for the trigger config drawers (schedule + subscription): an Active
- * toggle on the left, and Cancel / [run slot] / Save on the right. The run affordance
- * differs per trigger kind (a preview popover for schedules, an event-source popover for
- * subscriptions), so it is passed in as a slot rather than baked in.
+ * Shared footer for entity config drawers (triggers: schedule + subscription; tools: integration
+ * + reference). Cancel / [run slot] / Save on the right; the left side is an Active toggle when
+ * `onEnabledChange` is supplied (triggers), otherwise an optional `left` slot or empty (tools).
+ * The run affordance differs per surface, so it is passed in as a slot rather than baked in.
  */
-export function TriggerDrawerFooter({
+export function DrawerFooter({
     enabled,
     onEnabledChange,
+    left,
     onCancel,
     run,
     isMutating,
@@ -18,8 +19,11 @@ export function TriggerDrawerFooter({
     submitLabel,
     onSubmit,
 }: {
-    enabled: boolean
-    onEnabledChange: (value: boolean) => void
+    /** When `onEnabledChange` is provided, render an Active toggle on the left. */
+    enabled?: boolean
+    onEnabledChange?: (value: boolean) => void
+    /** Left-side content when there's no Active toggle. */
+    left?: ReactNode
     onCancel: () => void
     /** Optional run-in-playground affordance (playground only). */
     run?: ReactNode
@@ -33,8 +37,16 @@ export function TriggerDrawerFooter({
             <Divider className="!m-0" />
             <div className="flex shrink-0 items-center justify-between gap-2 px-6 py-3">
                 <div className="flex items-center gap-2">
-                    <Switch checked={enabled} onChange={onEnabledChange} />
-                    <span className="text-xs text-[var(--ag-colorTextSecondary)]">Active</span>
+                    {onEnabledChange ? (
+                        <>
+                            <Switch checked={enabled} onChange={onEnabledChange} />
+                            <span className="text-xs text-[var(--ag-colorTextSecondary)]">
+                                Active
+                            </span>
+                        </>
+                    ) : (
+                        left
+                    )}
                 </div>
                 <div className="flex items-center gap-2">
                     <Button onClick={onCancel}>Cancel</Button>

--- a/web/packages/agenta-entity-ui/src/drawers/shared/GatewayCatalogDrawer.tsx
+++ b/web/packages/agenta-entity-ui/src/drawers/shared/GatewayCatalogDrawer.tsx
@@ -621,13 +621,16 @@ export function GatewayCatalogDrawer<I, T, C>({
     const [selected, setSelected] = useState<I | null>(null)
     const [connectFor, setConnectFor] = useState<I | null>(null)
 
-    // Reset navigation when closed externally (e.g. picking an item closes the drawer from the host).
+    // Reset navigation AND the shared searches when closed externally (e.g. picking an item closes
+    // the drawer from the host), matching handleClose so the next open starts clean.
     useEffect(() => {
         if (!open) {
             setSelected(null)
             setConnectFor(null)
+            adapter.setIntegrationsSearch("")
+            adapter.setItemsSearch("")
         }
-    }, [open])
+    }, [open, adapter])
 
     const handleClose = useCallback(() => {
         setSelected(null)

--- a/web/packages/agenta-entity-ui/src/drawers/shared/GatewayCatalogDrawer.tsx
+++ b/web/packages/agenta-entity-ui/src/drawers/shared/GatewayCatalogDrawer.tsx
@@ -540,6 +540,8 @@ function ItemsView<I, T, C>({
                     <div className="flex flex-col gap-2">
                         {items.map((item, i) => {
                             const state = config.itemTrailing?.(activeConn ?? null, item) ?? "add"
+                            // A pending add or a missing connection must not fire another pick.
+                            const pickDisabled = state === "pending" || !activeConn
                             const categories = adapter.item.categories?.(item)
                             const itemDescription = adapter.item.description?.(item)
                             return (
@@ -552,10 +554,12 @@ function ItemsView<I, T, C>({
                                         />
                                     )}
                                     <Card
-                                        hoverable
-                                        className="cursor-pointer"
+                                        hoverable={!pickDisabled}
+                                        className={
+                                            pickDisabled ? "cursor-not-allowed" : "cursor-pointer"
+                                        }
                                         size="small"
-                                        onClick={() => handlePick(item)}
+                                        onClick={pickDisabled ? undefined : () => handlePick(item)}
                                     >
                                         <div className="flex items-start gap-2">
                                             <div className="flex min-w-0 flex-1 flex-col gap-0.5">

--- a/web/packages/agenta-entity-ui/src/drawers/shared/GatewayCatalogDrawer.tsx
+++ b/web/packages/agenta-entity-ui/src/drawers/shared/GatewayCatalogDrawer.tsx
@@ -1,0 +1,682 @@
+/**
+ * GatewayCatalogDrawer
+ *
+ * The shared Composio catalog drawer used by BOTH the triggers catalog (pick an event → create a
+ * subscription) and the tools catalog (pick an action → add it as a tool). One implementation:
+ * a "Your connections" rail (expandable connection → items) + a searchable "All apps" grid +
+ * inline connect. Surfaces differ only in data + leaf, supplied via `adapter` + `config`.
+ *
+ * Tools and triggers share the same `gateway_connections` rows, so this drawer is genuinely the
+ * same component pointed at different catalog hooks. Dark-safe (`--ag-color*` tokens + antd).
+ */
+import React, {useCallback, useEffect, useMemo, useRef, useState, type ReactNode} from "react"
+
+import {ScrollSentinel, ScrollToTopButton} from "@agenta/ui"
+import {
+    ArrowLeft,
+    CaretDown,
+    CaretRight,
+    Check,
+    Lightning,
+    MagnifyingGlass,
+    Plus,
+} from "@phosphor-icons/react"
+import type {MenuProps} from "antd"
+import {Button, Card, Divider, Drawer, Dropdown, Empty, Input, Spin, Tag, Typography} from "antd"
+import Image from "next/image"
+
+import {AppCard} from "./CatalogAppCard"
+
+interface InfiniteList<X> {
+    total: number
+    prefetchThreshold: number
+    isLoading: boolean
+    hasNextPage: boolean
+    isFetchingNextPage: boolean
+    requestMore: () => void
+    items: X[]
+}
+
+/** Data layer — parallel trigger/tool catalog hooks + field accessors (shapes differ per surface). */
+export interface CatalogAdapter<I, T, C> {
+    useIntegrations: () => InfiniteList<I>
+    useConnections: () => {connections: C[]}
+    useIntegrationConnections: (integrationKey: string) => {connections: C[]}
+    useItems: (integrationKey: string) => InfiniteList<T>
+    isConnectionActive: (c: C) => boolean
+    /** Build a minimal integration from a connection (rail "view all" navigates to its items). */
+    integrationFromConnection: (c: C) => I
+    setIntegrationsSearch: (search: string) => void
+    setItemsSearch: (search: string) => void
+    integration: {
+        key: (i: I) => string
+        name: (i: I) => string
+        logo: (i: I) => string | undefined
+        description: (i: I) => string | undefined
+        authSchemes: (i: I) => string[]
+        categories?: (i: I) => string[] | undefined
+        itemCount?: (i: I) => number | undefined
+    }
+    connection: {
+        id: (c: C) => string | undefined
+        name: (c: C) => string | undefined
+        slug: (c: C) => string | undefined
+        integrationKey: (c: C) => string
+    }
+    item: {
+        key: (t: T) => string
+        name: (t: T) => string | undefined
+        description?: (t: T) => string | undefined
+        categories?: (t: T) => string[] | undefined
+    }
+}
+
+export type ItemTrailing = "add" | "selected" | "pending"
+
+/** Presentation + leaf behavior. */
+export interface CatalogConfig<I, T, C> {
+    /** Drawer title; receives the selected integration (items view) or null (browse). */
+    title: (selected: I | null) => string
+    appsSearchPlaceholder: string
+    itemsSearchPlaceholder: string
+    /** Footer hint in the connections rail. */
+    connectionsHint: ReactNode
+    /** Empty state when an app exposes no items. */
+    emptyItemsText: string
+    /** Pick an item bound to a connection. `integration` is set in the items view, null from the rail. */
+    onPickItem: (connection: C, item: T, integration: I | null) => void
+    /** Trailing affordance per item (tools track selected/pending). Defaults to "add". */
+    itemTrailing?: (connection: C | null, item: T) => ItemTrailing
+    /** Optional items-view "Connect" split-menu of existing connections (triggers: open events drawer). */
+    onConnectionMenu?: (connection: C) => void
+    /** Render the connect flow (ConnectDrawer / TriggerConnectDrawer) for the chosen integration. */
+    renderConnect: (
+        integration: I,
+        handlers: {onClose: () => void; onSuccess: () => void},
+    ) => ReactNode
+}
+
+function ExpandableText({text}: {text: string}) {
+    return (
+        <Typography.Paragraph
+            type="secondary"
+            className="!mb-0 !text-xs"
+            ellipsis={{
+                rows: 3,
+                expandable: "collapsible",
+                symbol: (expanded) => (expanded ? "see less" : "see more"),
+            }}
+        >
+            {text}
+        </Typography.Paragraph>
+    )
+}
+
+function ItemTrailingIcon({state}: {state: ItemTrailing}) {
+    if (state === "pending") return <Spin size="small" />
+    if (state === "selected")
+        return <Check size={13} className="shrink-0 text-[var(--ag-colorPrimary)]" />
+    return <Plus size={13} className="shrink-0 text-[var(--ag-colorTextTertiary)]" />
+}
+
+// Lazy-loaded items for one connection's integration (mounted only when its rail row is expanded).
+function ConnectionItemsList<I, T, C>({
+    connection,
+    adapter,
+    config,
+    onViewAll,
+}: {
+    connection: C
+    adapter: CatalogAdapter<I, T, C>
+    config: CatalogConfig<I, T, C>
+    onViewAll: () => void
+}) {
+    const {items, isLoading, hasNextPage} = adapter.useItems(
+        adapter.connection.integrationKey(connection),
+    )
+
+    if (isLoading && items.length === 0) {
+        return (
+            <div className="flex justify-center py-3">
+                <Spin size="small" />
+            </div>
+        )
+    }
+    if (items.length === 0) {
+        return (
+            <div className="px-3 py-2 text-[11px] text-[var(--ag-colorTextTertiary)]">
+                {config.emptyItemsText}
+            </div>
+        )
+    }
+    return (
+        <div className="flex flex-col gap-0.5 p-1">
+            {items.map((it) => {
+                const state = config.itemTrailing?.(connection, it) ?? "add"
+                return (
+                    <button
+                        key={adapter.item.key(it)}
+                        type="button"
+                        onClick={() =>
+                            state !== "pending" && config.onPickItem(connection, it, null)
+                        }
+                        className="flex w-full cursor-pointer items-center gap-2 rounded border-0 bg-transparent px-2 py-1.5 text-left hover:bg-[var(--ag-colorFillSecondary)]"
+                    >
+                        <Lightning
+                            size={13}
+                            className="shrink-0 text-[var(--ag-colorTextTertiary)]"
+                        />
+                        <span className="min-w-0 flex-1 truncate text-[12.5px]">
+                            {adapter.item.name(it) || adapter.item.key(it)}
+                        </span>
+                        <ItemTrailingIcon state={state} />
+                    </button>
+                )
+            })}
+            {hasNextPage && (
+                <button
+                    type="button"
+                    onClick={onViewAll}
+                    className="flex w-full cursor-pointer border-0 bg-transparent px-2 py-1.5 text-left text-[12px] text-[var(--ag-colorTextSecondary)] hover:bg-[var(--ag-colorFillSecondary)]"
+                >
+                    View all…
+                </button>
+            )}
+        </div>
+    )
+}
+
+function IntegrationsView<I, T, C>({
+    adapter,
+    config,
+    onSelect,
+}: {
+    adapter: CatalogAdapter<I, T, C>
+    config: CatalogConfig<I, T, C>
+    onSelect: (integration: I) => void
+}) {
+    const scrollRef = useRef<HTMLDivElement>(null)
+    const [searchValue, setSearchValue] = useState("")
+    const {connections} = adapter.useConnections()
+    const [expanded, setExpanded] = useState<string | null>(null)
+    const connectedKeys = useMemo(
+        () => new Set(connections.map((c) => adapter.connection.integrationKey(c))),
+        [connections, adapter],
+    )
+
+    const onSearch = useCallback(
+        (v: string) => {
+            setSearchValue(v)
+            adapter.setIntegrationsSearch(v)
+        },
+        [adapter],
+    )
+
+    const {
+        items: integrations,
+        total,
+        prefetchThreshold,
+        isLoading,
+        hasNextPage,
+        isFetchingNextPage,
+        requestMore,
+    } = adapter.useIntegrations()
+
+    const sentinelIndex = useMemo(
+        () => Math.max(0, integrations.length - prefetchThreshold),
+        [integrations.length, prefetchThreshold],
+    )
+
+    const hasConnections = connections.length > 0
+
+    return (
+        <div className="flex h-full min-h-0 overflow-hidden">
+            {hasConnections && (
+                <div className="flex w-[280px] shrink-0 flex-col overflow-hidden border-0 border-r border-solid border-[var(--ag-colorBorderSecondary)]">
+                    <div className="shrink-0 px-4 pb-2 pt-4">
+                        <Typography.Text type="secondary" className="text-xs">
+                            Your connections
+                        </Typography.Text>
+                    </div>
+                    <div className="flex flex-1 flex-col gap-1.5 overflow-y-auto overscroll-contain px-3 pb-2">
+                        {connections.map((conn) => {
+                            const cid =
+                                adapter.connection.id(conn) ??
+                                adapter.connection.slug(conn) ??
+                                adapter.connection.integrationKey(conn)
+                            const isOpen = expanded === cid
+                            return (
+                                <div
+                                    key={cid}
+                                    className="overflow-hidden rounded border border-solid border-[var(--ag-colorBorderSecondary)]"
+                                >
+                                    <button
+                                        type="button"
+                                        onClick={() => setExpanded(isOpen ? null : cid)}
+                                        className="flex w-full cursor-pointer items-center gap-2 border-0 bg-transparent px-2.5 py-2 text-left hover:bg-[var(--ag-colorFillSecondary)]"
+                                    >
+                                        {isOpen ? (
+                                            <CaretDown
+                                                size={12}
+                                                className="shrink-0 text-[var(--ag-colorTextTertiary)]"
+                                            />
+                                        ) : (
+                                            <CaretRight
+                                                size={12}
+                                                className="shrink-0 text-[var(--ag-colorTextTertiary)]"
+                                            />
+                                        )}
+                                        <div className="min-w-0 flex-1">
+                                            <div className="truncate text-xs font-medium">
+                                                {adapter.connection.name(conn) ||
+                                                    adapter.connection.slug(conn) ||
+                                                    adapter.connection.integrationKey(conn)}
+                                            </div>
+                                            <div className="truncate text-[11px] text-[var(--ag-colorTextTertiary)]">
+                                                {adapter.connection.integrationKey(conn)}
+                                            </div>
+                                        </div>
+                                        {adapter.isConnectionActive(conn) && (
+                                            <span className="h-1.5 w-1.5 shrink-0 rounded-full bg-[var(--ag-colorSuccess)]" />
+                                        )}
+                                    </button>
+                                    {isOpen && (
+                                        <div className="border-0 border-t border-solid border-[var(--ag-colorBorderSecondary)]">
+                                            <ConnectionItemsList
+                                                connection={conn}
+                                                adapter={adapter}
+                                                config={config}
+                                                onViewAll={() =>
+                                                    onSelect(
+                                                        adapter.integrationFromConnection(conn),
+                                                    )
+                                                }
+                                            />
+                                        </div>
+                                    )}
+                                </div>
+                            )
+                        })}
+                    </div>
+                    <div className="mt-auto flex shrink-0 items-start gap-1.5 border-0 border-t border-solid border-[var(--ag-colorBorderSecondary)] px-4 py-3 text-[11px] leading-snug text-[var(--ag-colorTextTertiary)]">
+                        <Lightning size={13} className="mt-[1px] shrink-0" />
+                        <span>{config.connectionsHint}</span>
+                    </div>
+                </div>
+            )}
+
+            <div className="flex min-w-0 flex-1 flex-col overflow-hidden">
+                <div className="flex shrink-0 flex-col gap-2 px-6 pb-3 pt-4">
+                    <Typography.Text type="secondary" className="text-xs">
+                        {hasConnections ? "Or connect a new app" : "Connect an app"}
+                    </Typography.Text>
+                    <Input
+                        placeholder={config.appsSearchPlaceholder}
+                        prefix={<MagnifyingGlass size={16} />}
+                        value={searchValue}
+                        onChange={(e) => onSearch(e.target.value)}
+                        allowClear
+                        onClear={() => onSearch("")}
+                    />
+                    <Typography.Text type="secondary" className="text-xs">
+                        {total} integration{total !== 1 ? "s" : ""}
+                    </Typography.Text>
+                </div>
+
+                <Divider className="!m-0" />
+
+                <div
+                    ref={scrollRef}
+                    className="relative flex-1 overflow-y-auto overscroll-contain px-6 py-3"
+                >
+                    {isLoading && integrations.length === 0 ? (
+                        <div className="flex items-center justify-center py-12">
+                            <Spin />
+                        </div>
+                    ) : integrations.length === 0 ? (
+                        <Empty description="No integrations found" />
+                    ) : (
+                        <div className="grid auto-rows-min gap-2 [grid-template-columns:repeat(auto-fill,minmax(220px,1fr))]">
+                            {integrations.map((integration, i) => (
+                                <React.Fragment key={adapter.integration.key(integration)}>
+                                    {i === sentinelIndex && (
+                                        <div className="col-span-full">
+                                            <ScrollSentinel
+                                                onVisible={requestMore}
+                                                hasMore={hasNextPage}
+                                                isFetching={isFetchingNextPage}
+                                            />
+                                        </div>
+                                    )}
+                                    <AppCard
+                                        logo={adapter.integration.logo(integration)}
+                                        name={adapter.integration.name(integration)}
+                                        description={adapter.integration.description(integration)}
+                                        categories={adapter.integration.categories?.(integration)}
+                                        actionsCount={adapter.integration.itemCount?.(integration)}
+                                        connected={connectedKeys.has(
+                                            adapter.integration.key(integration),
+                                        )}
+                                        onClick={() => onSelect(integration)}
+                                    />
+                                </React.Fragment>
+                            ))}
+
+                            <div className="col-span-full">
+                                <ScrollSentinel
+                                    onVisible={requestMore}
+                                    hasMore={hasNextPage}
+                                    isFetching={isFetchingNextPage}
+                                />
+                                {isFetchingNextPage && (
+                                    <div className="flex items-center justify-center py-4">
+                                        <Spin size="small" />
+                                    </div>
+                                )}
+                            </div>
+                        </div>
+                    )}
+
+                    <ScrollToTopButton scrollRef={scrollRef} />
+                </div>
+            </div>
+        </div>
+    )
+}
+
+function ItemsView<I, T, C>({
+    integration,
+    adapter,
+    config,
+    onBack,
+    onConnect,
+}: {
+    integration: I
+    adapter: CatalogAdapter<I, T, C>
+    config: CatalogConfig<I, T, C>
+    onBack: () => void
+    onConnect: () => void
+}) {
+    const scrollRef = useRef<HTMLDivElement>(null)
+    const [searchValue, setSearchValue] = useState("")
+    const {connections} = adapter.useIntegrationConnections(adapter.integration.key(integration))
+
+    const onSearch = useCallback(
+        (v: string) => {
+            setSearchValue(v)
+            adapter.setItemsSearch(v)
+        },
+        [adapter],
+    )
+
+    // Picking an item needs a connection to bind. Prefer an active one; fall back to the first.
+    const activeConn = useMemo(
+        () => connections.find((c) => adapter.isConnectionActive(c)) ?? connections[0],
+        [connections, adapter],
+    )
+
+    const handlePick = useCallback(
+        (item: T) => {
+            if (!activeConn) return
+            config.onPickItem(activeConn, item, integration)
+        },
+        [activeConn, config, integration],
+    )
+
+    const connectionMenu = useMemo<MenuProps["items"]>(
+        () =>
+            config.onConnectionMenu
+                ? connections.map((conn) => ({
+                      key: adapter.connection.id(conn) ?? adapter.connection.slug(conn) ?? "",
+                      label: (
+                          <div className="flex items-center gap-2">
+                              <span className="truncate">
+                                  {adapter.connection.name(conn) || adapter.connection.slug(conn)}
+                              </span>
+                              {adapter.isConnectionActive(conn) && (
+                                  <span className="h-1.5 w-1.5 shrink-0 rounded-full bg-[var(--ag-colorSuccess)]" />
+                              )}
+                          </div>
+                      ),
+                      onClick: () => config.onConnectionMenu?.(conn),
+                  }))
+                : undefined,
+        [connections, adapter, config],
+    )
+
+    const {
+        items,
+        total,
+        prefetchThreshold,
+        isLoading,
+        hasNextPage,
+        isFetchingNextPage,
+        requestMore,
+    } = adapter.useItems(adapter.integration.key(integration))
+
+    const sentinelIndex = useMemo(
+        () => Math.max(0, items.length - prefetchThreshold),
+        [items.length, prefetchThreshold],
+    )
+
+    const description = adapter.integration.description(integration)
+    const logo = adapter.integration.logo(integration)
+
+    return (
+        <div className="flex h-full flex-col overflow-hidden">
+            <div className="flex shrink-0 flex-col gap-3 px-6 pb-3 pt-4">
+                <div className="flex items-center gap-3">
+                    <Button
+                        type="text"
+                        aria-label="Go back"
+                        icon={<ArrowLeft size={16} />}
+                        onClick={onBack}
+                        className="shrink-0"
+                    />
+                    {logo && (
+                        <Image
+                            src={logo}
+                            alt={adapter.integration.name(integration)}
+                            width={32}
+                            height={32}
+                            className="h-8 w-8 shrink-0 rounded object-contain"
+                            unoptimized
+                        />
+                    )}
+                    <Typography.Text strong className="flex-1 truncate">
+                        {adapter.integration.name(integration)}
+                    </Typography.Text>
+                    <div className="shrink-0">
+                        {connectionMenu && connections.length > 0 ? (
+                            <Dropdown.Button
+                                type="primary"
+                                trigger={["click"]}
+                                menu={{items: connectionMenu}}
+                                icon={<CaretDown size={12} />}
+                                onClick={onConnect}
+                            >
+                                <Plus size={14} />
+                                Connect
+                            </Dropdown.Button>
+                        ) : (
+                            <Button type="primary" icon={<Plus size={14} />} onClick={onConnect}>
+                                Connect
+                            </Button>
+                        )}
+                    </div>
+                </div>
+                {description && <ExpandableText text={description} />}
+
+                <Input
+                    placeholder={config.itemsSearchPlaceholder}
+                    prefix={<MagnifyingGlass size={16} />}
+                    value={searchValue}
+                    onChange={(e) => onSearch(e.target.value)}
+                    allowClear
+                    onClear={() => onSearch("")}
+                />
+
+                <Typography.Text type="secondary" className="text-xs">
+                    {total} item{total !== 1 ? "s" : ""}
+                </Typography.Text>
+            </div>
+
+            <Divider className="!m-0" />
+
+            <div
+                ref={scrollRef}
+                className="relative flex-1 overflow-y-auto overscroll-contain px-6 py-3"
+            >
+                {isLoading && items.length === 0 ? (
+                    <div className="flex items-center justify-center py-8">
+                        <Spin />
+                    </div>
+                ) : items.length === 0 ? (
+                    <Empty
+                        image={Empty.PRESENTED_IMAGE_SIMPLE}
+                        description={config.emptyItemsText}
+                    />
+                ) : (
+                    <div className="flex flex-col gap-2">
+                        {items.map((item, i) => {
+                            const state = config.itemTrailing?.(activeConn ?? null, item) ?? "add"
+                            const categories = adapter.item.categories?.(item)
+                            const itemDescription = adapter.item.description?.(item)
+                            return (
+                                <React.Fragment key={adapter.item.key(item)}>
+                                    {i === sentinelIndex && (
+                                        <ScrollSentinel
+                                            onVisible={requestMore}
+                                            hasMore={hasNextPage}
+                                            isFetching={isFetchingNextPage}
+                                        />
+                                    )}
+                                    <Card
+                                        hoverable
+                                        className="cursor-pointer"
+                                        size="small"
+                                        onClick={() => handlePick(item)}
+                                    >
+                                        <div className="flex items-start gap-2">
+                                            <div className="flex min-w-0 flex-1 flex-col gap-0.5">
+                                                <div className="flex items-center gap-2">
+                                                    <Typography.Text strong className="truncate">
+                                                        {adapter.item.name(item) ||
+                                                            adapter.item.key(item)}
+                                                    </Typography.Text>
+                                                    {categories?.slice(0, 2).map((c) => (
+                                                        <Tag key={c} className="text-xs">
+                                                            {c}
+                                                        </Tag>
+                                                    ))}
+                                                </div>
+                                                {itemDescription && (
+                                                    <Typography.Text
+                                                        type="secondary"
+                                                        className="text-xs"
+                                                    >
+                                                        {itemDescription}
+                                                    </Typography.Text>
+                                                )}
+                                            </div>
+                                            <span className="mt-0.5">
+                                                <ItemTrailingIcon state={state} />
+                                            </span>
+                                        </div>
+                                    </Card>
+                                </React.Fragment>
+                            )
+                        })}
+
+                        <ScrollSentinel
+                            onVisible={requestMore}
+                            hasMore={hasNextPage}
+                            isFetching={isFetchingNextPage}
+                        />
+                        {isFetchingNextPage && (
+                            <div className="flex items-center justify-center py-4">
+                                <Spin size="small" />
+                            </div>
+                        )}
+                    </div>
+                )}
+
+                <ScrollToTopButton scrollRef={scrollRef} />
+            </div>
+        </div>
+    )
+}
+
+export function GatewayCatalogDrawer<I, T, C>({
+    open,
+    onClose,
+    adapter,
+    config,
+}: {
+    open: boolean
+    onClose: () => void
+    adapter: CatalogAdapter<I, T, C>
+    config: CatalogConfig<I, T, C>
+}) {
+    const [selected, setSelected] = useState<I | null>(null)
+    const [connectFor, setConnectFor] = useState<I | null>(null)
+
+    // Reset navigation when closed externally (e.g. picking an item closes the drawer from the host).
+    useEffect(() => {
+        if (!open) {
+            setSelected(null)
+            setConnectFor(null)
+        }
+    }, [open])
+
+    const handleClose = useCallback(() => {
+        setSelected(null)
+        setConnectFor(null)
+        adapter.setIntegrationsSearch("")
+        adapter.setItemsSearch("")
+        onClose()
+    }, [onClose, adapter])
+
+    const handleBack = useCallback(() => {
+        setSelected(null)
+        adapter.setItemsSearch("")
+    }, [adapter])
+
+    return (
+        <>
+            <Drawer
+                open={open}
+                onClose={handleClose}
+                title={config.title(selected)}
+                size="large"
+                destroyOnClose
+                styles={{
+                    body: {
+                        padding: 0,
+                        display: "flex",
+                        flexDirection: "column",
+                        overflow: "hidden",
+                    },
+                }}
+            >
+                {selected ? (
+                    <ItemsView
+                        integration={selected}
+                        adapter={adapter}
+                        config={config}
+                        onBack={handleBack}
+                        onConnect={() => setConnectFor(selected)}
+                    />
+                ) : (
+                    <IntegrationsView adapter={adapter} config={config} onSelect={setSelected} />
+                )}
+            </Drawer>
+
+            {connectFor &&
+                config.renderConnect(connectFor, {
+                    onClose: () => setConnectFor(null),
+                    onSuccess: () => setConnectFor(null),
+                })}
+        </>
+    )
+}

--- a/web/packages/agenta-entity-ui/src/drawers/shared/MasterDetailRail.tsx
+++ b/web/packages/agenta-entity-ui/src/drawers/shared/MasterDetailRail.tsx
@@ -121,11 +121,11 @@ export function EntityListRow({
 }
 
 /**
- * The master-detail left rail shared by the schedule + subscription drawers: a "New …"
+ * Master-detail left rail shared across entity config drawers (triggers + tools): a "New …"
  * button on top and a scrollable list of rows below. Rows (drafts + entities) are
  * composed by the caller from {@link DraftListRow} / {@link EntityListRow}.
  */
-export function TriggerListRail({
+export function MasterDetailRail({
     newLabel,
     onNew,
     canCreate,

--- a/web/packages/agenta-entity-ui/src/drawers/shared/RailField.tsx
+++ b/web/packages/agenta-entity-ui/src/drawers/shared/RailField.tsx
@@ -1,0 +1,35 @@
+/**
+ * RailField
+ *
+ * One `[label column │ content]` row in the drawer's shared rail rhythm: a fixed 116px label column
+ * (padding counted inside via `box-border`, so its separator lines up with the section rails) and a
+ * content panel split off by a left border. Matches the "Exposed as" field and `SectionRail` content
+ * edge, so stacked fields in a detail panel share one vertical separator.
+ *
+ * Styling uses antd semantic tokens (`--ag-color*`) only — dark-safe.
+ */
+import type {ReactNode} from "react"
+
+export interface RailFieldProps {
+    label: ReactNode
+    /** Vertical alignment of the label against the content. @default "top" */
+    align?: "top" | "center"
+    children: ReactNode
+}
+
+export function RailField({label, align = "top", children}: RailFieldProps) {
+    return (
+        <div className="flex gap-3">
+            <div
+                className={`box-border w-[116px] shrink-0 px-2.5 text-xs text-[var(--ag-colorTextSecondary)] ${
+                    align === "center" ? "self-center" : "pt-1.5"
+                }`}
+            >
+                {label}
+            </div>
+            <div className="flex min-w-0 flex-1 flex-col border-0 border-l border-solid border-[var(--ag-colorBorderSecondary)] pl-3">
+                {children}
+            </div>
+        </div>
+    )
+}

--- a/web/packages/agenta-entity-ui/src/drawers/shared/RailField.tsx
+++ b/web/packages/agenta-entity-ui/src/drawers/shared/RailField.tsx
@@ -6,7 +6,8 @@
  * content panel split off by a left border. Matches the "Exposed as" field and `SectionRail` content
  * edge, so stacked fields in a detail panel share one vertical separator.
  *
- * Styling uses antd semantic tokens (`--ag-color*`) only — dark-safe.
+ * The content is capped at `max-w-prose` so inputs in a section panel keep a readable width instead
+ * of stretching the full drawer. Styling uses antd semantic tokens (`--ag-color*`) only — dark-safe.
  */
 import type {ReactNode} from "react"
 
@@ -27,7 +28,7 @@ export function RailField({label, align = "top", children}: RailFieldProps) {
             >
                 {label}
             </div>
-            <div className="flex min-w-0 flex-1 flex-col border-0 border-l border-solid border-[var(--ag-colorBorderSecondary)] pl-3">
+            <div className="flex min-w-0 max-w-prose flex-1 flex-col border-0 border-l border-solid border-[var(--ag-colorBorderSecondary)] pl-3">
                 {children}
             </div>
         </div>

--- a/web/packages/agenta-entity-ui/src/drawers/shared/SectionRail.tsx
+++ b/web/packages/agenta-entity-ui/src/drawers/shared/SectionRail.tsx
@@ -1,0 +1,73 @@
+/**
+ * SectionRail
+ *
+ * The drawer's consistent `[left rail | right content]` section-body layout: a narrow vertical
+ * toggle list (antd text buttons, primary-tinted when active) beside a content panel separated by
+ * a left border. Shared by the workflow-reference detail sections (Schema, Configuration) and the
+ * `RunVersionField` Pinned/Deployed axis, so every rail in the drawer looks and behaves the same.
+ *
+ * Styling uses antd semantic tokens (`--ag-color*`) only — dark-safe.
+ */
+import type {ReactNode} from "react"
+
+import {Button} from "antd"
+
+export interface SectionRailItem {
+    value: string
+    label: string
+    /** Optional trailing count (e.g. a schema's field count). */
+    count?: number
+}
+
+export interface SectionRailProps {
+    items: SectionRailItem[]
+    value: string
+    onChange: (value: string) => void
+    /** Rail column width. @default "w-[116px]" */
+    railWidth?: string
+    /** Right-hand content panel; separated from the rail by a left border. */
+    children: ReactNode
+}
+
+export function SectionRail({
+    items,
+    value,
+    onChange,
+    railWidth = "w-[116px]",
+    children,
+}: SectionRailProps) {
+    return (
+        <div className="flex gap-3">
+            <div className={`flex ${railWidth} shrink-0 flex-col gap-0.5`}>
+                {items.map((item) => {
+                    const active = item.value === value
+                    return (
+                        <Button
+                            key={item.value}
+                            type="text"
+                            block
+                            onClick={() => onChange(item.value)}
+                            className={`!h-8 !px-2.5 !text-xs ${
+                                item.count != null
+                                    ? "!flex !items-center !justify-between"
+                                    : "!justify-start"
+                            } ${
+                                active
+                                    ? "!bg-[var(--ag-colorPrimaryBg)] !font-medium !text-[var(--ag-colorPrimary)]"
+                                    : "!text-[var(--ag-colorTextSecondary)]"
+                            }`}
+                        >
+                            <span className="truncate">{item.label}</span>
+                            {item.count != null ? (
+                                <span className="text-[10px] opacity-70">{item.count}</span>
+                            ) : null}
+                        </Button>
+                    )
+                })}
+            </div>
+            <div className="flex min-w-0 flex-1 flex-col gap-1.5 border-0 border-l border-solid border-[var(--ag-colorBorderSecondary)] pl-3">
+                {children}
+            </div>
+        </div>
+    )
+}

--- a/web/packages/agenta-entity-ui/src/drawers/shared/useDraftMasterDetail.ts
+++ b/web/packages/agenta-entity-ui/src/drawers/shared/useDraftMasterDetail.ts
@@ -1,6 +1,6 @@
 import {useCallback, useEffect, useRef, useState} from "react"
 
-import {DRAFT_PREFIX} from "./TriggerListRail"
+import {DRAFT_PREFIX} from "./MasterDetailRail"
 
 /**
  * Master-detail draft state shared by the schedule + subscription drawers. Owns the

--- a/web/packages/agenta-entity-ui/src/gatewayTrigger/drawers/TriggerCatalogDrawer.tsx
+++ b/web/packages/agenta-entity-ui/src/gatewayTrigger/drawers/TriggerCatalogDrawer.tsx
@@ -1,4 +1,13 @@
-import React, {useCallback, useMemo, useRef, useState} from "react"
+/**
+ * TriggerCatalogDrawer
+ *
+ * The triggers catalog: a THIN wrapper over the shared {@link GatewayCatalogDrawer} (the same
+ * component the tools catalog uses), pointed at the `@agenta/entities/gatewayTrigger` catalog
+ * hooks with a "pick an event → create a subscription" leaf. Connecting an app and browsing a
+ * connection's events (events drawer) are wired through the generic's connect + connection-menu
+ * hooks. No bespoke catalog UI lives here anymore.
+ */
+import {useCallback, useMemo} from "react"
 
 import {
     isConnectionActive,
@@ -15,73 +24,46 @@ import {
     type TriggerCatalogIntegration,
     type TriggerConnection,
 } from "@agenta/entities/gatewayTrigger"
-import {useDebouncedAtomSearch} from "@agenta/shared/hooks"
-import {ScrollSentinel, ScrollToTopButton} from "@agenta/ui"
-import {
-    ArrowLeft,
-    CaretDown,
-    CaretRight,
-    Lightning,
-    MagnifyingGlass,
-    Plus,
-} from "@phosphor-icons/react"
-import type {MenuProps} from "antd"
-import {
-    Button,
-    Card,
-    Divider,
-    Drawer,
-    Dropdown,
-    Empty,
-    Input,
-    Spin,
-    Tag,
-    Typography,
-    message,
-} from "antd"
 import {useAtom, useSetAtom} from "jotai"
-import Image from "next/image"
+
+import {
+    GatewayCatalogDrawer,
+    type CatalogAdapter,
+    type CatalogConfig,
+} from "../../drawers/shared/GatewayCatalogDrawer"
 
 import TriggerConnectDrawer from "./TriggerConnectDrawer"
 
-// ---------------------------------------------------------------------------
-// Expandable description — 2-line clamp with inline "see more" / "see less"
-// (identical to gatewayTool CatalogDrawer).
-// ---------------------------------------------------------------------------
-
-function ExpandableText({text}: {text: string}) {
-    return (
-        <Typography.Paragraph
-            type="secondary"
-            className="!text-xs !mb-0"
-            ellipsis={{
-                rows: 3,
-                expandable: "collapsible",
-                symbol: (expanded) => (expanded ? "see less" : "see more"),
-            }}
-        >
-            {text}
-        </Typography.Paragraph>
-    )
-}
-
-// ---------------------------------------------------------------------------
-// TriggerCatalogDrawer (root) — mirrors gatewayTool CatalogDrawer with the
-// tools "action" leaf swapped for the triggers "event" leaf.
-// ---------------------------------------------------------------------------
-
 interface Props {
     onConnectionCreated?: () => void
-    /**
-     * Pre-bind any subscription created from this catalog (by picking an event)
-     * to a workflow — e.g. the current agent when opened from its config panel.
-     * Keyed like `data.references` (`application`/`application_variant`).
-     */
+    /** Pre-bind any subscription created here to a workflow (keyed like `data.references`). */
     defaultReferences?: Record<string, {id?: string; slug?: string}>
-    /** Human-readable label for `defaultReferences` (e.g. the agent's name). */
     defaultBoundLabel?: string
-    /** Agent entityId for the subscription drawer's "Run in playground" action. */
     playgroundEntityId?: string
+}
+
+const integrationAccessors = {
+    key: (i: TriggerCatalogIntegration) => i.key,
+    name: (i: TriggerCatalogIntegration) => i.name,
+    logo: (i: TriggerCatalogIntegration) => i.logo ?? undefined,
+    description: (i: TriggerCatalogIntegration) => i.description ?? undefined,
+    authSchemes: (i: TriggerCatalogIntegration) => i.auth_schemes ?? [],
+    categories: (i: TriggerCatalogIntegration) =>
+        (i as {categories?: string[] | null}).categories ?? undefined,
+}
+
+const connectionAccessors = {
+    id: (c: TriggerConnection) => c.id ?? undefined,
+    name: (c: TriggerConnection) => c.name ?? undefined,
+    slug: (c: TriggerConnection) => c.slug ?? undefined,
+    integrationKey: (c: TriggerConnection) => c.integration_key,
+}
+
+const itemAccessors = {
+    key: (t: TriggerCatalogEvent) => t.key,
+    name: (t: TriggerCatalogEvent) => t.name ?? undefined,
+    description: (t: TriggerCatalogEvent) => t.description ?? undefined,
+    categories: (t: TriggerCatalogEvent) => t.categories ?? undefined,
 }
 
 export default function TriggerCatalogDrawer({
@@ -91,612 +73,118 @@ export default function TriggerCatalogDrawer({
     playgroundEntityId,
 }: Props) {
     const [open, setOpen] = useAtom(triggerCatalogDrawerOpenAtom)
-    const [selectedIntegration, setSelectedIntegration] =
-        useState<TriggerCatalogIntegration | null>(null)
-    const [connectIntegration, setConnectIntegration] = useState<TriggerCatalogIntegration | null>(
-        null,
-    )
-
     const setIntegrationsSearch = useSetAtom(triggerIntegrationsSearchAtom)
     const setEventsSearch = useSetAtom(triggerEventsSearchAtom)
     const openSubscription = useSetAtom(triggerSubscriptionDrawerAtom)
-
-    const handleClose = useCallback(() => {
-        setOpen(false)
-        setSelectedIntegration(null)
-        setConnectIntegration(null)
-        setIntegrationsSearch("")
-        setEventsSearch("")
-    }, [setOpen, setIntegrationsSearch, setEventsSearch])
-
-    const handleBack = useCallback(() => {
-        setSelectedIntegration(null)
-        setEventsSearch("")
-    }, [setEventsSearch])
-
-    const handleConnect = useCallback((integration: TriggerCatalogIntegration) => {
-        setConnectIntegration(integration)
-    }, [])
-
-    const handleConnectionSuccess = useCallback(() => {
-        handleClose()
-        onConnectionCreated?.()
-    }, [handleClose, onConnectionCreated])
-
-    // Picking an event leaves the catalog and opens the subscription config drawer,
-    // prefilled with the chosen connection + event and pre-bound via defaultReferences.
-    const handleCreateFromEvent = useCallback(
-        (connectionId: string, eventKey: string) => {
-            const integration = selectedIntegration
-            handleClose()
-            openSubscription({
-                connectionId,
-                integrationKey: integration?.key,
-                integrationName: integration?.name,
-                eventKey,
-                defaultReferences,
-                defaultBoundLabel,
-                playgroundEntityId,
-            })
-        },
-        [
-            selectedIntegration,
-            handleClose,
-            openSubscription,
-            defaultReferences,
-            defaultBoundLabel,
-            playgroundEntityId,
-        ],
-    )
-
-    // Reuse an EXISTING connection: jump straight to that app's events (skipping
-    // the integration browse). Picking an event there opens the subscription drawer
-    // with the connection resolved — the same proven path as the browse flow.
-    const handlePickConnection = useCallback((connection: TriggerConnection) => {
-        if (!connection.integration_key) return
-        setSelectedIntegration({
-            key: connection.integration_key,
-            name: connection.name || connection.integration_key,
-        } as TriggerCatalogIntegration)
-    }, [])
-
-    // Picking an event under an existing connection creates the trigger directly —
-    // same as the browse → event path, but the connection is already known.
-    const handleCreateFromConnectionEvent = useCallback(
-        (connection: TriggerConnection, eventKey: string) => {
-            if (!connection.id) return
-            handleClose()
-            openSubscription({
-                connectionId: connection.id,
-                integrationKey: connection.integration_key,
-                integrationName: connection.name ?? connection.integration_key,
-                eventKey,
-                defaultReferences,
-                defaultBoundLabel,
-                playgroundEntityId,
-            })
-        },
-        [handleClose, openSubscription, defaultReferences, defaultBoundLabel, playgroundEntityId],
-    )
-
-    return (
-        <>
-            <Drawer
-                open={open}
-                onClose={handleClose}
-                title={selectedIntegration ? "Choose an event" : "Add an app trigger"}
-                size="large"
-                destroyOnClose
-                styles={{
-                    body: {
-                        padding: 0,
-                        display: "flex",
-                        flexDirection: "column",
-                        overflow: "hidden",
-                    },
-                }}
-            >
-                {selectedIntegration ? (
-                    <EventsView
-                        integration={selectedIntegration}
-                        onBack={handleBack}
-                        onConnect={() => handleConnect(selectedIntegration)}
-                        onCreateFromEvent={handleCreateFromEvent}
-                    />
-                ) : (
-                    <IntegrationsView
-                        onSelect={setSelectedIntegration}
-                        onPickConnection={handlePickConnection}
-                        onCreateFromConnectionEvent={handleCreateFromConnectionEvent}
-                    />
-                )}
-            </Drawer>
-
-            {connectIntegration && (
-                <TriggerConnectDrawer
-                    open={!!connectIntegration}
-                    integrationKey={connectIntegration.key}
-                    integrationName={connectIntegration.name}
-                    integrationLogo={connectIntegration.logo ?? undefined}
-                    integrationDescription={connectIntegration.description ?? undefined}
-                    authSchemes={connectIntegration.auth_schemes ?? []}
-                    onClose={() => setConnectIntegration(null)}
-                    onSuccess={handleConnectionSuccess}
-                />
-            )}
-        </>
-    )
-}
-
-// ---------------------------------------------------------------------------
-// ConnectionEventsList — lazy-loaded trigger events for one connection's
-// integration (mounted only when its accordion row is expanded). Picking an
-// event creates the trigger directly.
-// ---------------------------------------------------------------------------
-
-function ConnectionEventsList({
-    connection,
-    onPickEvent,
-    onViewAll,
-}: {
-    connection: TriggerConnection
-    onPickEvent: (eventKey: string) => void
-    onViewAll: () => void
-}) {
-    const {events, isLoading, hasNextPage} = useTriggerCatalogEvents(connection.integration_key)
-
-    if (isLoading && events.length === 0) {
-        return (
-            <div className="flex justify-center py-3">
-                <Spin size="small" />
-            </div>
-        )
-    }
-    if (events.length === 0) {
-        return (
-            <div className="px-3 py-2 text-[11px] text-[var(--ag-colorTextTertiary)]">
-                No events for this app
-            </div>
-        )
-    }
-    return (
-        <div className="flex flex-col gap-0.5 p-1">
-            {events.map((ev) => (
-                <button
-                    key={ev.key}
-                    type="button"
-                    onClick={() => onPickEvent(ev.key)}
-                    className="flex w-full cursor-pointer items-center gap-2 rounded border-0 bg-transparent px-2 py-1.5 text-left hover:bg-[var(--ag-colorFillSecondary)]"
-                >
-                    <Lightning size={13} className="shrink-0 text-[var(--ag-colorTextTertiary)]" />
-                    <span className="min-w-0 flex-1 truncate text-[12.5px]">
-                        {ev.name || ev.key}
-                    </span>
-                    <Plus size={13} className="shrink-0 text-[var(--ag-colorTextTertiary)]" />
-                </button>
-            ))}
-            {hasNextPage && (
-                <button
-                    type="button"
-                    onClick={onViewAll}
-                    className="flex w-full cursor-pointer border-0 bg-transparent px-2 py-1.5 text-left text-[12px] text-[var(--ag-colorTextSecondary)] hover:bg-[var(--ag-colorFillSecondary)]"
-                >
-                    View all events…
-                </button>
-            )}
-        </div>
-    )
-}
-
-// ---------------------------------------------------------------------------
-// Integrations view
-// ---------------------------------------------------------------------------
-
-function IntegrationsView({
-    onSelect,
-    onPickConnection,
-    onCreateFromConnectionEvent,
-}: {
-    onSelect: (integration: TriggerCatalogIntegration) => void
-    onPickConnection: (connection: TriggerConnection) => void
-    onCreateFromConnectionEvent: (connection: TriggerConnection, eventKey: string) => void
-}) {
-    const setAtom = useSetAtom(triggerIntegrationsSearchAtom)
-    const search = useDebouncedAtomSearch(setAtom)
-    const scrollRef = useRef<HTMLDivElement>(null)
-    const {connections} = useTriggerConnectionsQuery()
-    const [expandedConn, setExpandedConn] = useState<string | null>(null)
-
-    const {
-        integrations,
-        total,
-        prefetchThreshold,
-        isLoading,
-        hasNextPage,
-        isFetchingNextPage,
-        requestMore,
-    } = useTriggerCatalogIntegrations()
-
-    const sentinelIndex = useMemo(
-        () => Math.max(0, integrations.length - prefetchThreshold),
-        [integrations.length, prefetchThreshold],
-    )
-
-    const hasConnections = connections.length > 0
-
-    return (
-        <div className="flex h-full min-h-0 overflow-hidden">
-            {hasConnections && (
-                <div className="flex w-[280px] shrink-0 flex-col overflow-hidden border-0 border-r border-solid border-[var(--ag-colorBorderSecondary)]">
-                    <div className="shrink-0 px-4 pb-2 pt-4">
-                        <Typography.Text type="secondary" className="text-xs">
-                            Your connections
-                        </Typography.Text>
-                    </div>
-                    <div className="flex flex-1 flex-col gap-1.5 overflow-y-auto overscroll-contain px-3 pb-2">
-                        {connections.map((conn) => {
-                            const cid = conn.id ?? conn.slug ?? conn.integration_key ?? ""
-                            const isOpen = expandedConn === cid
-                            return (
-                                <div
-                                    key={cid}
-                                    className="overflow-hidden rounded border border-solid border-[var(--ag-colorBorderSecondary)]"
-                                >
-                                    <button
-                                        type="button"
-                                        onClick={() => setExpandedConn(isOpen ? null : cid)}
-                                        className="flex w-full cursor-pointer items-center gap-2 border-0 bg-transparent px-2.5 py-2 text-left hover:bg-[var(--ag-colorFillSecondary)]"
-                                    >
-                                        {isOpen ? (
-                                            <CaretDown
-                                                size={12}
-                                                className="shrink-0 text-[var(--ag-colorTextTertiary)]"
-                                            />
-                                        ) : (
-                                            <CaretRight
-                                                size={12}
-                                                className="shrink-0 text-[var(--ag-colorTextTertiary)]"
-                                            />
-                                        )}
-                                        <div className="min-w-0 flex-1">
-                                            <div className="truncate text-xs font-medium">
-                                                {conn.name || conn.slug || conn.integration_key}
-                                            </div>
-                                            <div className="truncate text-[11px] text-[var(--ag-colorTextTertiary)]">
-                                                {conn.integration_key}
-                                            </div>
-                                        </div>
-                                        {isConnectionActive(conn) && (
-                                            <span className="h-1.5 w-1.5 shrink-0 rounded-full bg-[var(--ag-colorSuccess)]" />
-                                        )}
-                                    </button>
-                                    {isOpen && (
-                                        <div className="border-0 border-t border-solid border-[var(--ag-colorBorderSecondary)]">
-                                            <ConnectionEventsList
-                                                connection={conn}
-                                                onPickEvent={(eventKey) =>
-                                                    onCreateFromConnectionEvent(conn, eventKey)
-                                                }
-                                                onViewAll={() => onPickConnection(conn)}
-                                            />
-                                        </div>
-                                    )}
-                                </div>
-                            )
-                        })}
-                    </div>
-                    <div className="mt-auto flex shrink-0 items-start gap-1.5 border-0 border-t border-solid border-[var(--ag-colorBorderSecondary)] px-4 py-3 text-[11px] leading-snug text-[var(--ag-colorTextTertiary)]">
-                        <Lightning size={13} className="mt-[1px] shrink-0" />
-                        <span>Pick an event to create a trigger — no setup needed.</span>
-                    </div>
-                </div>
-            )}
-
-            <div className="flex min-w-0 flex-1 flex-col overflow-hidden">
-                <div className="flex shrink-0 flex-col gap-2 px-6 pb-3 pt-4">
-                    <Typography.Text type="secondary" className="text-xs">
-                        {hasConnections ? "Or connect a new app" : "Connect an app"}
-                    </Typography.Text>
-                    <Input
-                        placeholder="Search integrations…"
-                        prefix={<MagnifyingGlass size={16} />}
-                        value={search.value}
-                        onChange={(e) => search.onChange(e.target.value)}
-                        allowClear
-                        onClear={() => search.onChange("")}
-                    />
-                    <Typography.Text type="secondary" className="text-xs">
-                        {total} integration{total !== 1 ? "s" : ""}
-                    </Typography.Text>
-                </div>
-
-                <Divider className="!m-0" />
-
-                <div
-                    ref={scrollRef}
-                    className="relative flex-1 overflow-y-auto overscroll-contain px-6 py-3"
-                >
-                    {isLoading && integrations.length === 0 ? (
-                        <div className="flex items-center justify-center py-12">
-                            <Spin />
-                        </div>
-                    ) : integrations.length === 0 ? (
-                        <Empty description="No integrations found" />
-                    ) : (
-                        <div className="flex flex-col gap-2">
-                            {integrations.map((integration, i) => (
-                                <React.Fragment key={integration.key}>
-                                    {i === sentinelIndex && (
-                                        <ScrollSentinel
-                                            onVisible={requestMore}
-                                            hasMore={hasNextPage}
-                                            isFetching={isFetchingNextPage}
-                                        />
-                                    )}
-                                    <Card
-                                        hoverable
-                                        onClick={() => onSelect(integration)}
-                                        className="cursor-pointer"
-                                        size="small"
-                                    >
-                                        <div className="flex items-start gap-3">
-                                            {integration.logo && (
-                                                <Image
-                                                    src={integration.logo}
-                                                    alt={integration.name}
-                                                    width={32}
-                                                    height={32}
-                                                    className="w-8 h-8 rounded object-contain shrink-0"
-                                                    unoptimized
-                                                />
-                                            )}
-                                            <div className="flex min-w-0 flex-1 flex-col gap-0.5">
-                                                <Typography.Text strong className="truncate">
-                                                    {integration.name}
-                                                </Typography.Text>
-                                                {integration.description && (
-                                                    <Typography.Text
-                                                        type="secondary"
-                                                        className="text-xs line-clamp-2"
-                                                    >
-                                                        {integration.description}
-                                                    </Typography.Text>
-                                                )}
-                                            </div>
-                                        </div>
-                                    </Card>
-                                </React.Fragment>
-                            ))}
-
-                            <ScrollSentinel
-                                onVisible={requestMore}
-                                hasMore={hasNextPage}
-                                isFetching={isFetchingNextPage}
-                            />
-
-                            {isFetchingNextPage && (
-                                <div className="flex items-center justify-center py-4">
-                                    <Spin size="small" />
-                                </div>
-                            )}
-                        </div>
-                    )}
-
-                    <ScrollToTopButton scrollRef={scrollRef} />
-                </div>
-            </div>
-        </div>
-    )
-}
-
-// ---------------------------------------------------------------------------
-// Events view — browse an integration's events; Connect + open-events on a
-// chosen existing connection (mirrors tools ActionsView).
-// ---------------------------------------------------------------------------
-
-function EventsView({
-    integration,
-    onBack,
-    onConnect,
-    onCreateFromEvent,
-}: {
-    integration: TriggerCatalogIntegration
-    onBack: () => void
-    onConnect: () => void
-    onCreateFromEvent: (connectionId: string, eventKey: string) => void
-}) {
-    const setAtom = useSetAtom(triggerEventsSearchAtom)
-    const search = useDebouncedAtomSearch(setAtom)
-    const scrollRef = useRef<HTMLDivElement>(null)
     const setEventsDrawer = useSetAtom(triggerEventsDrawerAtom)
-    const {connections} = useTriggerIntegrationConnections(integration.key)
 
-    // Picking an event needs a connection to bind. Prefer an active one; fall back
-    // to the first connection. With none, the user must Connect first.
-    const handlePickEvent = useCallback(
-        (event: TriggerCatalogEvent) => {
-            const connection = connections.find((c) => isConnectionActive(c)) ?? connections[0]
-            if (!connection?.id) {
-                message.info("Connect this integration first to create a trigger")
-                return
-            }
-            onCreateFromEvent(connection.id, event.key)
-        },
-        [connections, onCreateFromEvent],
+    const adapter = useMemo<
+        CatalogAdapter<TriggerCatalogIntegration, TriggerCatalogEvent, TriggerConnection>
+    >(
+        () => ({
+            useIntegrations: () => {
+                const r = useTriggerCatalogIntegrations()
+                return {
+                    items: r.integrations,
+                    total: r.total,
+                    prefetchThreshold: r.prefetchThreshold,
+                    isLoading: r.isLoading,
+                    hasNextPage: r.hasNextPage,
+                    isFetchingNextPage: r.isFetchingNextPage,
+                    requestMore: r.requestMore,
+                }
+            },
+            useConnections: () => useTriggerConnectionsQuery(),
+            useIntegrationConnections: (key: string) => useTriggerIntegrationConnections(key),
+            useItems: (key: string) => {
+                const r = useTriggerCatalogEvents(key)
+                return {
+                    items: r.events,
+                    total: r.total,
+                    prefetchThreshold: r.prefetchThreshold,
+                    isLoading: r.isLoading,
+                    hasNextPage: r.hasNextPage,
+                    isFetchingNextPage: r.isFetchingNextPage,
+                    requestMore: r.requestMore,
+                }
+            },
+            isConnectionActive,
+            integrationFromConnection: (c: TriggerConnection) =>
+                ({
+                    key: c.integration_key,
+                    name: c.name || c.integration_key,
+                }) as TriggerCatalogIntegration,
+            setIntegrationsSearch,
+            setItemsSearch: setEventsSearch,
+            integration: integrationAccessors,
+            connection: connectionAccessors,
+            item: itemAccessors,
+        }),
+        [setIntegrationsSearch, setEventsSearch],
     )
 
-    const handleOpenConnectionEvents = useCallback(
-        (conn: TriggerConnection) => {
-            setEventsDrawer({
-                providerKey: conn.provider_key ?? "composio",
-                integrationKey: conn.integration_key,
-                integrationName: integration.name,
-                connectionId: conn.id ?? undefined,
+    // Pick an event → leave the catalog and open the subscription config drawer, prefilled with the
+    // chosen connection + event and pre-bound via defaultReferences.
+    const handlePickEvent = useCallback(
+        (
+            conn: TriggerConnection,
+            event: TriggerCatalogEvent,
+            integration: TriggerCatalogIntegration | null,
+        ) => {
+            if (!conn.id) return
+            setOpen(false)
+            openSubscription({
+                connectionId: conn.id,
+                integrationKey: integration?.key ?? conn.integration_key,
+                integrationName: integration?.name ?? conn.name ?? conn.integration_key,
+                eventKey: event.key,
+                defaultReferences,
+                defaultBoundLabel,
+                playgroundEntityId,
             })
         },
-        [setEventsDrawer, integration.name],
+        [setOpen, openSubscription, defaultReferences, defaultBoundLabel, playgroundEntityId],
     )
 
-    const connectMenuItems = useMemo<MenuProps["items"]>(
-        () =>
-            connections.map((conn) => ({
-                key: conn.id ?? conn.slug ?? "",
-                label: (
-                    <div className="flex items-center gap-2">
-                        <span className="truncate">{conn.name || conn.slug}</span>
-                        {isConnectionActive(conn) && (
-                            <span className="w-1.5 h-1.5 rounded-full bg-green-500 shrink-0" />
-                        )}
-                    </div>
-                ),
-                onClick: () => handleOpenConnectionEvents(conn),
-            })),
-        [connections, handleOpenConnectionEvents],
-    )
-
-    const {
-        events,
-        total,
-        prefetchThreshold,
-        isLoading,
-        hasNextPage,
-        isFetchingNextPage,
-        requestMore,
-    } = useTriggerCatalogEvents(integration.key)
-
-    const sentinelIndex = useMemo(
-        () => Math.max(0, events.length - prefetchThreshold),
-        [events.length, prefetchThreshold],
-    )
+    const config: CatalogConfig<TriggerCatalogIntegration, TriggerCatalogEvent, TriggerConnection> =
+        {
+            title: (selected) => (selected ? "Choose an event" : "Add an app trigger"),
+            appsSearchPlaceholder: "Search integrations…",
+            itemsSearchPlaceholder: "Search events…",
+            connectionsHint: "Pick an event to create a trigger — no setup needed.",
+            emptyItemsText: "This app has no triggers",
+            onPickItem: handlePickEvent,
+            // Items-view "Connect" split-menu: open a chosen connection's full events list.
+            onConnectionMenu: (conn) =>
+                setEventsDrawer({
+                    providerKey: conn.provider_key ?? "composio",
+                    integrationKey: conn.integration_key,
+                    integrationName: conn.name ?? conn.integration_key,
+                    connectionId: conn.id ?? undefined,
+                }),
+            renderConnect: (integration, handlers) => (
+                <TriggerConnectDrawer
+                    open
+                    integrationKey={integration.key}
+                    integrationName={integration.name}
+                    integrationLogo={integration.logo ?? undefined}
+                    integrationDescription={integration.description ?? undefined}
+                    authSchemes={integration.auth_schemes ?? []}
+                    onClose={handlers.onClose}
+                    onSuccess={() => {
+                        handlers.onSuccess()
+                        onConnectionCreated?.()
+                    }}
+                />
+            ),
+        }
 
     return (
-        <div className="flex flex-col h-full overflow-hidden">
-            <div className="flex flex-col gap-3 px-6 pt-4 pb-3 shrink-0">
-                <div className="flex items-center gap-3">
-                    <Button
-                        type="text"
-                        aria-label="Go back"
-                        icon={<ArrowLeft size={16} />}
-                        onClick={onBack}
-                        className="shrink-0"
-                    />
-                    {integration.logo && (
-                        <Image
-                            src={integration.logo}
-                            alt={integration.name}
-                            width={32}
-                            height={32}
-                            className="w-8 h-8 rounded object-contain shrink-0"
-                            unoptimized
-                        />
-                    )}
-                    <Typography.Text strong className="truncate flex-1">
-                        {integration.name}
-                    </Typography.Text>
-                    <div className="shrink-0">
-                        {connections.length > 0 ? (
-                            <Dropdown.Button
-                                type="primary"
-                                trigger={["click"]}
-                                menu={{items: connectMenuItems}}
-                                icon={<CaretDown size={12} />}
-                                onClick={onConnect}
-                            >
-                                <Plus size={14} />
-                                Connect
-                            </Dropdown.Button>
-                        ) : (
-                            <Button type="primary" icon={<Plus size={14} />} onClick={onConnect}>
-                                Connect
-                            </Button>
-                        )}
-                    </div>
-                </div>
-                {integration.description && <ExpandableText text={integration.description} />}
-
-                <Input
-                    placeholder="Search events…"
-                    prefix={<MagnifyingGlass size={16} />}
-                    value={search.value}
-                    onChange={(e) => search.onChange(e.target.value)}
-                    allowClear
-                    onClear={() => search.onChange("")}
-                />
-
-                <Typography.Text type="secondary" className="text-xs">
-                    {total} event{total !== 1 ? "s" : ""}
-                </Typography.Text>
-            </div>
-
-            <Divider className="!m-0" />
-
-            <div
-                ref={scrollRef}
-                className="flex-1 overflow-y-auto overscroll-contain px-6 py-3 relative"
-            >
-                {isLoading && events.length === 0 ? (
-                    <div className="flex items-center justify-center py-8">
-                        <Spin />
-                    </div>
-                ) : events.length === 0 ? (
-                    <Empty
-                        image={Empty.PRESENTED_IMAGE_SIMPLE}
-                        description="This app has no triggers"
-                    />
-                ) : (
-                    <div className="flex flex-col gap-2">
-                        {events.map((event: TriggerCatalogEvent, i) => (
-                            <React.Fragment key={event.key}>
-                                {i === sentinelIndex && (
-                                    <ScrollSentinel
-                                        onVisible={requestMore}
-                                        hasMore={hasNextPage}
-                                        isFetching={isFetchingNextPage}
-                                    />
-                                )}
-                                <Card
-                                    hoverable
-                                    className="cursor-pointer"
-                                    size="small"
-                                    onClick={() => handlePickEvent(event)}
-                                >
-                                    <div className="flex flex-col gap-0.5">
-                                        <div className="flex items-center gap-2">
-                                            <Typography.Text strong className="truncate">
-                                                {event.name}
-                                            </Typography.Text>
-                                            {event.categories?.slice(0, 2).map((c) => (
-                                                <Tag key={c} className="text-xs">
-                                                    {c}
-                                                </Tag>
-                                            ))}
-                                        </div>
-                                        {event.description && (
-                                            <Typography.Text type="secondary" className="text-xs">
-                                                {event.description}
-                                            </Typography.Text>
-                                        )}
-                                    </div>
-                                </Card>
-                            </React.Fragment>
-                        ))}
-
-                        <ScrollSentinel
-                            onVisible={requestMore}
-                            hasMore={hasNextPage}
-                            isFetching={isFetchingNextPage}
-                        />
-
-                        {isFetchingNextPage && (
-                            <div className="flex items-center justify-center py-4">
-                                <Spin size="small" />
-                            </div>
-                        )}
-                    </div>
-                )}
-
-                <ScrollToTopButton scrollRef={scrollRef} />
-            </div>
-        </div>
+        <GatewayCatalogDrawer
+            open={open}
+            onClose={() => setOpen(false)}
+            adapter={adapter}
+            config={config}
+        />
     )
 }

--- a/web/packages/agenta-entity-ui/src/gatewayTrigger/drawers/TriggerCatalogDrawer.tsx
+++ b/web/packages/agenta-entity-ui/src/gatewayTrigger/drawers/TriggerCatalogDrawer.tsx
@@ -42,6 +42,40 @@ interface Props {
     playgroundEntityId?: string
 }
 
+// The integration handed to the connect flow may be synthesized from a connection (only key/name,
+// no auth_schemes). Resolve the full catalog integration by key so the connect drawer has real auth
+// modes; fall back to the passed one if it isn't in the loaded catalog.
+function TriggerConnectFlow({
+    integration,
+    handlers,
+    onConnectionCreated,
+}: {
+    integration: TriggerCatalogIntegration
+    handlers: {onClose: () => void; onSuccess: () => void}
+    onConnectionCreated?: () => void
+}) {
+    const {integrations} = useTriggerCatalogIntegrations()
+    const full =
+        (integration.auth_schemes?.length ? integration : null) ??
+        integrations.find((i) => i.key === integration.key) ??
+        integration
+    return (
+        <TriggerConnectDrawer
+            open
+            integrationKey={full.key}
+            integrationName={full.name}
+            integrationLogo={full.logo ?? undefined}
+            integrationDescription={full.description ?? undefined}
+            authSchemes={full.auth_schemes ?? []}
+            onClose={handlers.onClose}
+            onSuccess={() => {
+                handlers.onSuccess()
+                onConnectionCreated?.()
+            }}
+        />
+    )
+}
+
 const integrationAccessors = {
     key: (i: TriggerCatalogIntegration) => i.key,
     name: (i: TriggerCatalogIntegration) => i.name,
@@ -163,18 +197,10 @@ export default function TriggerCatalogDrawer({
                     connectionId: conn.id ?? undefined,
                 }),
             renderConnect: (integration, handlers) => (
-                <TriggerConnectDrawer
-                    open
-                    integrationKey={integration.key}
-                    integrationName={integration.name}
-                    integrationLogo={integration.logo ?? undefined}
-                    integrationDescription={integration.description ?? undefined}
-                    authSchemes={integration.auth_schemes ?? []}
-                    onClose={handlers.onClose}
-                    onSuccess={() => {
-                        handlers.onSuccess()
-                        onConnectionCreated?.()
-                    }}
+                <TriggerConnectFlow
+                    integration={integration}
+                    handlers={handlers}
+                    onConnectionCreated={onConnectionCreated}
                 />
             ),
         }

--- a/web/packages/agenta-entity-ui/src/gatewayTrigger/drawers/TriggerScheduleDrawer.tsx
+++ b/web/packages/agenta-entity-ui/src/gatewayTrigger/drawers/TriggerScheduleDrawer.tsx
@@ -35,13 +35,18 @@ import {CalendarBlank, ChatText, Clock, GitBranch, Play, Tag} from "@phosphor-ic
 import {Button, DatePicker, Form, Input, Modal, Popover, Spin, Tooltip, Typography} from "antd"
 import {useAtom, useAtomValue, useSetAtom} from "jotai"
 
+import {DrawerFooter} from "../../drawers/shared/DrawerFooter"
+import {
+    DraftListRow,
+    EntityListRow,
+    MasterDetailRail,
+    isDraftId,
+} from "../../drawers/shared/MasterDetailRail"
+import {useDraftMasterDetail} from "../../drawers/shared/useDraftMasterDetail"
 import {createWorkflowRevisionAdapter, type WorkflowRevisionSelectionResult} from "../../selection"
 
 import {ScheduleBuilderField} from "./ScheduleBuilderField"
 import {RunVersionField, buildRunVersionReferences} from "./shared/RunVersionField"
-import {TriggerDrawerFooter} from "./shared/TriggerDrawerFooter"
-import {DraftListRow, EntityListRow, TriggerListRail, isDraftId} from "./shared/TriggerListRail"
-import {useDraftMasterDetail} from "./shared/useDraftMasterDetail"
 
 // Weekly (Monday 09:00 UTC) so the builder opens on the Weekly cadence by default.
 const DEFAULT_CRON = "0 9 * * 1"
@@ -301,7 +306,7 @@ function SchedulesList({
         })
 
     return (
-        <TriggerListRail
+        <MasterDetailRail
             newLabel="New schedule"
             onNew={onNew}
             canCreate={canCreate}
@@ -332,7 +337,7 @@ function SchedulesList({
                     onRemove={s.id ? () => confirmDeleteSchedule(s) : undefined}
                 />
             ))}
-        </TriggerListRail>
+        </MasterDetailRail>
     )
 }
 
@@ -850,7 +855,7 @@ function ScheduleForm({
                 </Form>
             </div>
 
-            <TriggerDrawerFooter
+            <DrawerFooter
                 enabled={enabled}
                 onEnabledChange={setEnabled}
                 onCancel={onClose}

--- a/web/packages/agenta-entity-ui/src/gatewayTrigger/drawers/TriggerSubscriptionDrawer.tsx
+++ b/web/packages/agenta-entity-ui/src/gatewayTrigger/drawers/TriggerSubscriptionDrawer.tsx
@@ -25,6 +25,7 @@ import {
     useTriggerSubscription,
     useTriggerSubscriptions,
     type SubscriptionDrawerState,
+    type TriggerCatalogEvent,
     type TriggerCatalogIntegration,
     type TriggerConnection,
     type TriggerSubscription,
@@ -36,7 +37,7 @@ import {extractInputPortsFromSchema} from "@agenta/entities/runnable"
 import {appWorkflowsListQueryStateAtom, workflowMolecule} from "@agenta/entities/workflow"
 import {simulatedAgentRunAtomFamily} from "@agenta/shared/state"
 import {dayjs} from "@agenta/shared/utils"
-import {message, ScrollSentinel} from "@agenta/ui"
+import {message} from "@agenta/ui"
 import {ConfigAccordionSection} from "@agenta/ui/components/presentational"
 import {EnhancedDrawer} from "@agenta/ui/drawer"
 import {Editor} from "@agenta/ui/editor"
@@ -45,25 +46,29 @@ import {
     FlowArrow,
     GitBranch,
     Lightning,
-    MagnifyingGlass,
     PencilSimple,
-    Plugs,
     Plus,
     Tag,
 } from "@phosphor-icons/react"
 import {Button, Form, Input, Modal, Spin, Tooltip, Typography} from "antd"
 import {atom, useAtom, useAtomValue, useSetAtom} from "jotai"
-import Image from "next/image"
 
+import {AppLogo} from "../../drawers/shared/CatalogAppCard"
+import {CatalogChooser} from "../../drawers/shared/CatalogChooser"
+import {DrawerFooter} from "../../drawers/shared/DrawerFooter"
+import {
+    DraftListRow,
+    EntityListRow,
+    MasterDetailRail,
+    isDraftId,
+} from "../../drawers/shared/MasterDetailRail"
+import {useDraftMasterDetail} from "../../drawers/shared/useDraftMasterDetail"
 import SchemaForm, {type SchemaFormHandle} from "../../gatewayTool/components/SchemaForm"
 import {createWorkflowRevisionAdapter, type WorkflowRevisionSelectionResult} from "../../selection"
 
 import {loadRecentSamples, waitForNewDelivery} from "./shared/deliveries"
 import {EventSourcePicker, type SampledEvent} from "./shared/EventSourcePicker"
 import {RunVersionField, buildRunVersionReferences} from "./shared/RunVersionField"
-import {TriggerDrawerFooter} from "./shared/TriggerDrawerFooter"
-import {DraftListRow, EntityListRow, TriggerListRail, isDraftId} from "./shared/TriggerListRail"
-import {useDraftMasterDetail} from "./shared/useDraftMasterDetail"
 import TriggerConnectDrawer from "./TriggerConnectDrawer"
 
 // How many unsaved drafts can exist at once (config knob; see schedule drawer).
@@ -300,7 +305,7 @@ function SubscriptionDrawerContent({
 }
 
 // ---------------------------------------------------------------------------
-// SubscriptionsList — master-detail left rail (reuses TriggerListRail).
+// SubscriptionsList — master-detail left rail (reuses MasterDetailRail).
 // ---------------------------------------------------------------------------
 
 function SubscriptionsList({
@@ -351,7 +356,7 @@ function SubscriptionsList({
         })
 
     return (
-        <TriggerListRail
+        <MasterDetailRail
             newLabel="New trigger"
             onNew={onNew}
             canCreate={canCreate}
@@ -386,7 +391,7 @@ function SubscriptionsList({
                     />
                 )
             })}
-        </TriggerListRail>
+        </MasterDetailRail>
     )
 }
 
@@ -1046,7 +1051,7 @@ function SubscriptionForm({
                 </Form>
             </div>
 
-            <TriggerDrawerFooter
+            <DrawerFooter
                 enabled={enabled}
                 onEnabledChange={setEnabled}
                 onCancel={onClose}
@@ -1077,21 +1082,6 @@ function SubscriptionForm({
 
 function connectionName(conn: TriggerConnection | undefined): string {
     return conn?.name || conn?.slug || conn?.integration_key || ""
-}
-
-// An app's logo (catalog `integration.logo`), with a neutral plug fallback.
-function AppLogo({logo, size = 20}: {logo?: string | null; size?: number}) {
-    if (!logo) return <Plugs size={size} className="shrink-0 text-[var(--ag-colorTextSecondary)]" />
-    return (
-        <Image
-            src={logo}
-            alt=""
-            width={size}
-            height={size}
-            unoptimized
-            className="shrink-0 rounded object-contain"
-        />
-    )
 }
 
 // SourceField (in the section): the CHOSEN source as a 2-panel summary (source on the
@@ -1222,10 +1212,46 @@ function SourceBrowsePage({
     )
 }
 
-// SourceChooser — your connected accounts on the left (only when you have any), and a grid
-// of larger app cards filling the right (popular by default, searchable across all). The
-// right is always populated — no dead empty state. Selecting an app/account drills into its
-// events (or a connect invite), with an "← All apps" return.
+// Catalog data wrappers (custom hooks) adapting the trigger catalog hooks to CatalogChooser's shape.
+function useTriggerIntegrationsList() {
+    const r = useTriggerCatalogIntegrations()
+    return {
+        integrations: r.integrations,
+        hasNextPage: r.hasNextPage,
+        isFetchingNextPage: r.isFetchingNextPage,
+        isLoading: r.isLoading,
+        requestMore: r.requestMore,
+        setSearch: r.setSearch,
+    }
+}
+
+function useTriggerEventList(integrationKey: string) {
+    const r = useTriggerCatalogEvents(integrationKey)
+    return {
+        items: r.events,
+        isLoading: r.isLoading,
+        hasNextPage: r.hasNextPage,
+        isFetchingNextPage: r.isFetchingNextPage,
+        requestMore: r.requestMore,
+        setSearch: r.setSearch,
+    }
+}
+
+// Composio marks superseded events with a "DEPRECATED: use X instead." description prefix (there's
+// no structured flag) — surface it as a badge so the user avoids picking a dead event.
+function isDeprecatedEvent(description?: string | null): boolean {
+    return /^\s*deprecated\b/i.test(description ?? "")
+}
+
+// Drop the redundant trailing "Trigger" from a catalog event name ("Reaction Added Trigger" →
+// "Reaction Added") — we're already in a "Choose a trigger" context.
+function cleanEventName(name?: string | null): string | undefined {
+    if (!name) return undefined
+    return name.replace(/\s+trigger$/i, "").trim() || name
+}
+
+// SourceChooser — connected-accounts rail + 2-column app grid + app detail. Shared with the tools
+// catalog via the generic CatalogChooser; the events leaf picks an event -> onPick(connId, eventKey).
 function SourceChooser({
     connections,
     defaultIntegrationKey,
@@ -1235,447 +1261,53 @@ function SourceChooser({
     defaultIntegrationKey?: string
     onPick: (connectionId: string, eventKey: string) => void
 }) {
-    const {integrations, hasNextPage, isFetchingNextPage, isLoading, requestMore, setSearch} =
-        useTriggerCatalogIntegrations()
-    const byKey = useMemo(() => {
-        const m = new Map<string, TriggerCatalogIntegration>()
-        integrations.forEach((i) => m.set(i.key, i))
-        return m
-    }, [integrations])
-    const connectedKeys = useMemo(
-        () => new Set(connections.map((c) => c.integration_key)),
-        [connections],
-    )
-
-    const [searchInput, setSearchInput] = useState("")
-    useEffect(() => {
-        const t = setTimeout(() => setSearch(searchInput), 250)
-        return () => clearTimeout(t)
-    }, [searchInput, setSearch])
-    const searching = searchInput.trim().length > 0
-    // The grid shows every app with infinite scroll (the catalog returns popular ones first);
-    // searching filters the list server-side.
-    const gridItems = integrations
-
-    // Selection is a specific connection (an account) or an integration (browse). Null = the
-    // app grid (the default — never an empty panel). A `defaultIntegrationKey` (e.g. opened via
-    // a provider group's "+") drills straight into that provider.
-    const [selected, setSelected] = useState<{kind: "conn" | "intg"; id: string} | null>(
-        defaultIntegrationKey ? {kind: "intg", id: defaultIntegrationKey} : null,
-    )
-    // Callback-ref state for the grid's scroll container, so ScrollSentinel can observe
-    // against it (a ref wouldn't re-render the sentinel once the element mounts).
-    const [gridEl, setGridEl] = useState<HTMLDivElement | null>(null)
-    // Resolve to a connection: a chosen account directly, or — for a chosen integration —
-    // its first connection if one exists. So once a connect completes and the list refetches,
-    // the right panel flips from the connect invite to that account's events automatically.
-    const selectedConn =
-        selected?.kind === "conn"
-            ? connections.find((c) => c.id === selected.id)
-            : selected?.kind === "intg"
-              ? connections.find((c) => c.integration_key === selected.id)
-              : undefined
-    const selectedIntegration = selectedConn
-        ? byKey.get(selectedConn.integration_key)
-        : selected?.kind === "intg"
-          ? byKey.get(selected.id)
-          : undefined
-    const [connectIntegration, setConnectIntegration] = useState<TriggerCatalogIntegration | null>(
-        null,
-    )
-
-    const hasConnections = connections.length > 0
-
     return (
-        <div className="flex h-full min-h-[260px] gap-3">
-            {hasConnections && (
-                <div className="flex w-[220px] shrink-0 flex-col gap-0.5 overflow-y-auto">
-                    <div className="px-1 pb-1 text-[10px] uppercase tracking-wide text-[var(--ag-colorTextTertiary)]">
-                        Your connections
-                    </div>
-                    {connections.map((c) => {
-                        const app = byKey.get(c.integration_key)
-                        const appName = app?.name ?? c.integration_key
-                        // Lead with the connection's own name so multiple accounts of the
-                        // same provider are distinct.
-                        const account = c.name?.trim()
-                        return (
-                            <AppRailItem
-                                key={c.id ?? c.integration_key}
-                                active={selected?.kind === "conn" && selected.id === c.id}
-                                logo={app?.logo}
-                                name={account || appName}
-                                sub={account ? appName : undefined}
-                                connected
-                                onClick={() => c.id && setSelected({kind: "conn", id: c.id})}
-                            />
-                        )
-                    })}
-                </div>
-            )}
-
-            <div
-                className={`flex min-h-0 min-w-0 flex-1 flex-col ${
-                    hasConnections
-                        ? "border-0 border-l border-solid border-[var(--ag-colorBorderSecondary)] pl-3"
-                        : ""
-                }`}
-            >
-                {selected ? (
-                    <div className="flex min-h-0 flex-1 flex-col overflow-y-auto">
-                        <button
-                            type="button"
-                            onClick={() => setSelected(null)}
-                            className="mb-2 flex cursor-pointer items-center gap-1 self-start border-0 bg-transparent p-0 text-[11px] text-[var(--ag-colorTextSecondary)] hover:text-[var(--ag-colorText)]"
-                        >
-                            <ArrowLeft size={13} /> All apps
-                        </button>
-                        {selectedConn ? (
-                            <>
-                                <ConnectionDetail
-                                    connection={selectedConn}
-                                    integration={selectedIntegration}
-                                />
-                                <div className="mb-1 mt-2 flex items-center justify-between gap-2">
-                                    <Typography.Text
-                                        type="secondary"
-                                        className="!text-[11px] leading-snug"
-                                    >
-                                        Choose an event
-                                    </Typography.Text>
-                                    {selectedIntegration && (
-                                        <button
-                                            type="button"
-                                            onClick={() =>
-                                                setConnectIntegration(selectedIntegration)
-                                            }
-                                            className="cursor-pointer border-0 bg-transparent p-0 text-[11px] text-[var(--ag-colorPrimary)] hover:underline"
-                                        >
-                                            + Connect another account
-                                        </button>
-                                    )}
-                                </div>
-                                <ConnectionEventList
-                                    integrationKey={selectedConn.integration_key}
-                                    onPick={(ek) => onPick(selectedConn.id as string, ek)}
-                                />
-                            </>
-                        ) : (
-                            <ConnectInvite
-                                integration={selectedIntegration}
-                                onConnect={() =>
-                                    selectedIntegration &&
-                                    setConnectIntegration(selectedIntegration)
-                                }
-                            />
-                        )}
-                    </div>
-                ) : (
-                    <>
-                        <Input
-                            allowClear
-                            placeholder="Search apps…"
-                            prefix={
-                                <MagnifyingGlass
-                                    size={13}
-                                    className="text-[var(--ag-colorTextTertiary)]"
-                                />
-                            }
-                            value={searchInput}
-                            onChange={(e) => setSearchInput(e.target.value)}
-                        />
-                        <div className="mb-1 mt-2 px-0.5 text-[10px] uppercase tracking-wide text-[var(--ag-colorTextTertiary)]">
-                            {searching ? "Search results" : "All apps"}
-                        </div>
-                        <div
-                            ref={setGridEl}
-                            className="grid min-h-0 flex-1 auto-rows-min gap-2 overflow-y-auto [grid-template-columns:repeat(auto-fill,minmax(220px,1fr))]"
-                        >
-                            {gridItems.map((i) => (
-                                <AppCard
-                                    key={i.key}
-                                    logo={i.logo}
-                                    name={i.name}
-                                    description={i.description}
-                                    categories={i.categories}
-                                    actionsCount={i.actions_count}
-                                    connected={connectedKeys.has(i.key)}
-                                    onClick={() => setSelected({kind: "intg", id: i.key})}
-                                />
-                            ))}
-                            {!isLoading && gridItems.length === 0 && (
-                                <div className="col-span-full py-6 text-center text-[11px] text-[var(--ag-colorTextTertiary)]">
-                                    {searching
-                                        ? `No apps match “${searchInput}”.`
-                                        : "No apps found."}
-                                </div>
-                            )}
-                            {/* IntersectionObserver prefetch, observed against the grid's own
-                                scroll container with a big bottom margin so it loads the next
-                                page well before the user reaches the bottom. Re-fires after each
-                                fetch (effect depends on isFetching), filling short grids too. */}
-                            <div className="col-span-full">
-                                {(isLoading || isFetchingNextPage) && (
-                                    <div className="flex justify-center py-3">
-                                        <Spin size="small" />
-                                    </div>
-                                )}
-                                <ScrollSentinel
-                                    onVisible={requestMore}
-                                    hasMore={hasNextPage}
-                                    isFetching={isFetchingNextPage}
-                                    root={gridEl}
-                                    rootMargin="0px 0px 1600px 0px"
-                                />
-                            </div>
-                        </div>
-                    </>
-                )}
-            </div>
-
-            {connectIntegration && (
+        <CatalogChooser<TriggerCatalogIntegration, TriggerCatalogEvent, TriggerConnection>
+            connections={connections}
+            defaultIntegrationKey={defaultIntegrationKey}
+            isConnectionActive={isConnectionActive}
+            useIntegrations={useTriggerIntegrationsList}
+            useItems={useTriggerEventList}
+            integration={{
+                key: (i) => i.key,
+                name: (i) => i.name,
+                logo: (i) => i.logo,
+                description: (i) => i.description,
+                categories: (i) => i.categories,
+                actionsCount: (i) => i.actions_count,
+            }}
+            connection={{
+                id: (c) => c.id ?? undefined,
+                name: (c) => c.name ?? undefined,
+                slug: (c) => c.slug ?? undefined,
+                integrationKey: (c) => c.integration_key,
+                connectedAt: (c) =>
+                    c.created_at ? dayjs(c.created_at).format("MMM D, YYYY") : undefined,
+            }}
+            item={{
+                key: (e) => e.key,
+                name: (e) => cleanEventName(e.name),
+                description: (e) => e.description ?? undefined,
+                categories: (e) => e.categories ?? undefined,
+                deprecated: (e) => isDeprecatedEvent(e.description),
+            }}
+            itemsLabel="Choose an event"
+            itemsSearchPlaceholder="Search events"
+            emptyItemsText="No events for this app"
+            onPickItem={(conn, event) => conn.id && onPick(conn.id, event.key)}
+            renderConnect={(integration, h) => (
                 <TriggerConnectDrawer
-                    open={!!connectIntegration}
-                    integrationKey={connectIntegration.key}
-                    integrationName={connectIntegration.name}
-                    integrationLogo={connectIntegration.logo ?? undefined}
-                    integrationDescription={connectIntegration.description ?? undefined}
-                    authSchemes={connectIntegration.auth_schemes ?? []}
-                    onClose={() => setConnectIntegration(null)}
-                    onSuccess={() => setConnectIntegration(null)}
+                    open
+                    integrationKey={integration.key}
+                    integrationName={integration.name}
+                    integrationLogo={integration.logo ?? undefined}
+                    integrationDescription={integration.description ?? undefined}
+                    authSchemes={integration.auth_schemes ?? []}
+                    onClose={h.onClose}
+                    onSuccess={h.onSuccess}
                 />
             )}
-        </div>
-    )
-}
-
-// A larger app card for the discover grid: logo + name (+ connected hint).
-function AppCard({
-    logo,
-    name,
-    description,
-    categories,
-    actionsCount,
-    connected,
-    onClick,
-}: {
-    logo?: string | null
-    name: string
-    description?: string | null
-    categories?: string[]
-    actionsCount?: number | null
-    connected?: boolean
-    onClick: () => void
-}) {
-    const shownCategories = (categories ?? []).filter(Boolean).slice(0, 2)
-    return (
-        <button
-            type="button"
-            onClick={onClick}
-            className="group flex h-full min-h-[112px] cursor-pointer flex-col gap-2 rounded-lg border border-solid border-[var(--ag-colorBorder)] bg-transparent p-3 text-left hover:border-[var(--ag-colorPrimary)] hover:bg-[var(--ag-colorFillQuaternary)]"
-        >
-            <div className="flex items-center gap-2.5">
-                <AppLogo logo={logo} size={28} />
-                <div className="flex min-w-0 flex-1 items-center gap-1.5">
-                    <span className="truncate text-xs font-medium">{name}</span>
-                    {connected && (
-                        <Tooltip title="Connected">
-                            <span className="size-1.5 shrink-0 rounded-full bg-[var(--ag-colorSuccess)]" />
-                        </Tooltip>
-                    )}
-                </div>
-            </div>
-            {description ? (
-                <p className="m-0 line-clamp-2 text-[11px] leading-snug text-[var(--ag-colorTextSecondary)]">
-                    {description}
-                </p>
-            ) : (
-                <span className="flex-1" />
-            )}
-            <div className="mt-auto flex items-center gap-1.5">
-                {shownCategories.map((cat) => (
-                    <span
-                        key={cat}
-                        className="truncate rounded bg-[var(--ag-colorFillTertiary)] px-1.5 py-0.5 text-[10px] capitalize leading-none text-[var(--ag-colorTextSecondary)]"
-                    >
-                        {cat}
-                    </span>
-                ))}
-                {typeof actionsCount === "number" && actionsCount > 0 && (
-                    <span className="ml-auto flex shrink-0 items-center gap-1 text-[10px] text-[var(--ag-colorTextTertiary)]">
-                        <Lightning size={11} weight="fill" />
-                        {actionsCount}
-                    </span>
-                )}
-            </div>
-        </button>
-    )
-}
-
-// Richer detail for a connected app: account label, status, and connected date.
-function ConnectionDetail({
-    connection,
-    integration,
-}: {
-    connection: TriggerConnection
-    integration?: TriggerCatalogIntegration
-}) {
-    const active = isConnectionActive(connection)
-    const account = connection.name || connection.slug || ""
-    const connectedAt = connection.created_at
-        ? dayjs(connection.created_at).format("MMM D, YYYY")
-        : ""
-    return (
-        <div className="flex items-center gap-2.5 rounded-lg border border-solid border-[var(--ag-colorBorder)] px-3 py-2">
-            <AppLogo logo={integration?.logo} size={20} />
-            <div className="min-w-0 flex-1">
-                <div className="truncate text-xs font-medium">
-                    {integration?.name ?? connection.integration_key}
-                </div>
-                <div className="truncate text-[11px] text-[var(--ag-colorTextTertiary)]">
-                    {account || connection.integration_key}
-                    {connectedAt ? ` · connected ${connectedAt}` : ""}
-                </div>
-            </div>
-            <span
-                className={`inline-flex shrink-0 items-center gap-1 text-[11px] ${
-                    active ? "text-[var(--ag-colorSuccess)]" : "text-[var(--ag-colorTextTertiary)]"
-                }`}
-            >
-                <span
-                    className={`h-1.5 w-1.5 rounded-full ${
-                        active
-                            ? "bg-[var(--ag-colorSuccess)]"
-                            : "bg-[var(--ag-colorTextQuaternary)]"
-                    }`}
-                />
-                {active ? "Active" : "Inactive"}
-            </span>
-        </div>
-    )
-}
-
-function AppRailItem({
-    active,
-    logo,
-    name,
-    sub,
-    connected,
-    onClick,
-}: {
-    active: boolean
-    logo?: string | null
-    name: string
-    sub?: string
-    connected?: boolean
-    onClick: () => void
-}) {
-    return (
-        <button
-            type="button"
-            onClick={onClick}
-            className={`flex w-full cursor-pointer items-center gap-2 rounded border-0 px-2 py-1.5 text-left ${
-                active
-                    ? "bg-[var(--ag-colorPrimaryBg)]"
-                    : "bg-transparent hover:bg-[var(--ag-colorFillTertiary)]"
-            }`}
-        >
-            <AppLogo logo={logo} size={18} />
-            <span className="min-w-0 flex-1">
-                <span
-                    className={`block truncate text-xs ${
-                        active
-                            ? "font-medium text-[var(--ag-colorPrimary)]"
-                            : "text-[var(--ag-colorText)]"
-                    }`}
-                >
-                    {name}
-                </span>
-                {sub && (
-                    <span className="block truncate text-[10px] text-[var(--ag-colorTextTertiary)]">
-                        {sub}
-                    </span>
-                )}
-            </span>
-            {connected && (
-                <span className="h-1.5 w-1.5 shrink-0 rounded-full bg-[var(--ag-colorSuccess)]" />
-            )}
-        </button>
-    )
-}
-
-// Invite to connect a not-yet-connected app (logo + name + blurb + connect CTA).
-function ConnectInvite({
-    integration,
-    onConnect,
-}: {
-    integration?: TriggerCatalogIntegration
-    onConnect: () => void
-}) {
-    return (
-        <div className="flex flex-1 flex-col items-center justify-center gap-2 py-6 text-center">
-            <AppLogo logo={integration?.logo} size={32} />
-            <div className="text-xs font-medium">{integration?.name ?? "This app"}</div>
-            {integration?.description && (
-                <div className="max-w-[280px] text-[11px] leading-snug text-[var(--ag-colorTextTertiary)]">
-                    {integration.description}
-                </div>
-            )}
-            <Button type="primary" onClick={onConnect}>
-                Connect {integration?.name ?? "app"}
-            </Button>
-        </div>
-    )
-}
-
-function ConnectionEventList({
-    integrationKey,
-    onPick,
-}: {
-    integrationKey: string
-    onPick: (eventKey: string) => void
-}) {
-    const {events, isLoading, hasNextPage, requestMore} = useTriggerCatalogEvents(integrationKey)
-    if (isLoading && events.length === 0) {
-        return (
-            <div className="flex justify-center py-3">
-                <Spin size="small" />
-            </div>
-        )
-    }
-    if (events.length === 0) {
-        return (
-            <div className="px-3 py-2 text-[11px] text-[var(--ag-colorTextTertiary)]">
-                No events for this app
-            </div>
-        )
-    }
-    return (
-        <div className="flex max-h-[220px] flex-col gap-0.5 overflow-y-auto p-1">
-            {events.map((ev) => (
-                <button
-                    key={ev.key}
-                    type="button"
-                    onClick={() => onPick(ev.key)}
-                    className="flex w-full cursor-pointer items-center gap-2 rounded border-0 bg-transparent px-2 py-1.5 text-left hover:bg-[var(--ag-colorFillSecondary)]"
-                >
-                    <Lightning size={13} className="shrink-0 text-[var(--ag-colorTextTertiary)]" />
-                    <span className="min-w-0 flex-1 truncate text-[12.5px]">
-                        {ev.name || ev.key}
-                    </span>
-                    <Plus size={13} className="shrink-0 text-[var(--ag-colorTextTertiary)]" />
-                </button>
-            ))}
-            {hasNextPage && (
-                <button
-                    type="button"
-                    onClick={requestMore}
-                    className="flex w-full cursor-pointer border-0 bg-transparent px-2 py-1.5 text-left text-[12px] text-[var(--ag-colorTextSecondary)] hover:bg-[var(--ag-colorFillSecondary)]"
-                >
-                    Load more…
-                </button>
-            )}
-        </div>
+        />
     )
 }
 

--- a/web/packages/agenta-entity-ui/src/gatewayTrigger/drawers/shared/RunVersionField.tsx
+++ b/web/packages/agenta-entity-ui/src/gatewayTrigger/drawers/shared/RunVersionField.tsx
@@ -1,5 +1,6 @@
-import {Button, Select, Typography} from "antd"
+import {Select, Typography} from "antd"
 
+import {SectionRail} from "../../../drawers/shared/SectionRail"
 import {
     createWorkflowRevisionAdapter,
     EntityPicker,
@@ -100,64 +101,44 @@ export function RunVersionField({
     railWidth?: string
 }) {
     return (
-        <div className="flex gap-3">
-            <div className={`flex ${railWidth} shrink-0 flex-col gap-0.5`}>
-                {(
-                    [
-                        {value: "revision", label: "Pinned"},
-                        {value: "environment", label: "Deployed"},
-                    ] as const
-                ).map((m) => {
-                    const active = bindMode === m.value
-                    return (
-                        <Button
-                            key={m.value}
-                            type="text"
-                            block
-                            onClick={() => onBindModeChange(m.value)}
-                            className={`!h-8 !justify-start !px-2.5 !text-xs ${
-                                active
-                                    ? "!bg-[var(--ag-colorPrimaryBg)] !font-medium !text-[var(--ag-colorPrimary)]"
-                                    : "!text-[var(--ag-colorTextSecondary)]"
-                            }`}
-                        >
-                            {m.label}
-                        </Button>
-                    )
-                })}
-            </div>
-
-            <div className="flex min-w-0 flex-1 flex-col gap-1.5 border-0 border-l border-solid border-[var(--ag-colorBorderSecondary)] pl-3">
-                {bindMode === "revision" ? (
-                    <>
-                        <Typography.Text type="secondary" className="!text-[11px] leading-snug">
-                            {revisionHint}
-                        </Typography.Text>
-                        <EntityPicker<WorkflowRevisionSelectionResult>
-                            variant="popover-cascader"
-                            adapter={revisionAdapter}
-                            onSelect={onRevisionSelect}
-                            className="!flex w-full max-w-prose !justify-between"
-                            placeholder={revisionPlaceholder}
-                        />
-                    </>
-                ) : (
-                    <>
-                        <Typography.Text type="secondary" className="!text-[11px] leading-snug">
-                            {envHint}
-                        </Typography.Text>
-                        <Select
-                            placeholder="Select an environment"
-                            className="w-full max-w-prose"
-                            value={environmentSlug ?? undefined}
-                            onChange={onEnvironmentChange}
-                            loading={envLoading}
-                            options={envOptions}
-                            notFoundContent={envNotFound}
-                        />
-                    </>
-                )}
-            </div>
-        </div>
+        <SectionRail
+            items={[
+                {value: "revision", label: "Pinned"},
+                {value: "environment", label: "Deployed"},
+            ]}
+            value={bindMode}
+            onChange={(v) => onBindModeChange(v as RunVersionBindMode)}
+            railWidth={railWidth}
+        >
+            {bindMode === "revision" ? (
+                <>
+                    <Typography.Text type="secondary" className="!text-[11px] leading-snug">
+                        {revisionHint}
+                    </Typography.Text>
+                    <EntityPicker<WorkflowRevisionSelectionResult>
+                        variant="popover-cascader"
+                        adapter={revisionAdapter}
+                        onSelect={onRevisionSelect}
+                        className="!flex w-full max-w-prose !justify-between"
+                        placeholder={revisionPlaceholder}
+                    />
+                </>
+            ) : (
+                <>
+                    <Typography.Text type="secondary" className="!text-[11px] leading-snug">
+                        {envHint}
+                    </Typography.Text>
+                    <Select
+                        placeholder="Select an environment"
+                        className="w-full max-w-prose"
+                        value={environmentSlug ?? undefined}
+                        onChange={onEnvironmentChange}
+                        loading={envLoading}
+                        options={envOptions}
+                        notFoundContent={envNotFound}
+                    />
+                </>
+            )}
+        </SectionRail>
     )
 }

--- a/web/packages/agenta-entity-ui/tests/unit/schemaPaths.test.ts
+++ b/web/packages/agenta-entity-ui/tests/unit/schemaPaths.test.ts
@@ -1,0 +1,92 @@
+/**
+ * Unit pins for the tool-parameter path helpers driving the master/detail editor. They guard the
+ * tricky bits: rename preserves property order + remaps `required`, type-switch rebuilds the def,
+ * and the `{items:true}` sentinel descends into array items for add/remove at depth.
+ */
+import {describe, expect, it} from "vitest"
+
+import {
+    addPropertyAt,
+    getNodeAt,
+    isRequiredAt,
+    pathLabel,
+    removeNodeAt,
+    renamePropertyAt,
+    setNodeAt,
+    toggleRequiredAt,
+    type Schema,
+} from "../../src/DrillInView/SchemaControls/agentTemplate/schemaPaths"
+
+const base = (): Schema => ({
+    type: "object",
+    properties: {
+        query: {type: "string"},
+        filters: {
+            type: "object",
+            properties: {
+                max_age: {type: "number"},
+                sources: {type: "array", items: {type: "string"}},
+            },
+            required: ["max_age"],
+        },
+        limit: {type: "number"},
+    },
+    required: ["query"],
+})
+
+describe("schemaPaths", () => {
+    it("resolves nested and array-item nodes", () => {
+        const s = base()
+        expect(getNodeAt(s, [{p: "filters"}, {p: "sources"}])).toMatchObject({type: "array"})
+        // Descend into an object item via the {items:true} sentinel.
+        const arrObj = setNodeAt(s, [{p: "filters"}, {p: "sources"}], {
+            type: "array",
+            items: {type: "object", properties: {url: {type: "string"}}, required: []},
+        })
+        expect(
+            getNodeAt(arrObj, [{p: "filters"}, {p: "sources"}, {items: true}, {p: "url"}]),
+        ).toMatchObject({type: "string"})
+    })
+
+    it("renames a property preserving order and remapping required", () => {
+        const s = base()
+        const next = renamePropertyAt(s, [], "query", "q")
+        const props = next.properties as Record<string, Schema>
+        expect(Object.keys(props)).toEqual(["q", "filters", "limit"])
+        expect(next.required).toEqual(["q"])
+    })
+
+    it("rejects a rename onto an existing key (returns same reference)", () => {
+        const s = base()
+        expect(renamePropertyAt(s, [], "query", "limit")).toBe(s)
+    })
+
+    it("switches type by replacing the def (children dropped) via setNodeAt", () => {
+        const s = base()
+        const next = setNodeAt(s, [{p: "filters"}], {type: "string"})
+        expect(getNodeAt(next, [{p: "filters"}])).toEqual({type: "string"})
+        // Sibling untouched.
+        expect(getNodeAt(next, [{p: "query"}])).toEqual({type: "string"})
+    })
+
+    it("adds a fresh property with a non-colliding key and toggles required", () => {
+        const s = base()
+        const {schema, key} = addPropertyAt(s, [{p: "filters"}])
+        expect(key).toBe("param3")
+        expect(getNodeAt(schema, [{p: "filters"}, {p: key}])).toEqual({type: "string"})
+        const req = toggleRequiredAt(schema, [{p: "filters"}], key, true)
+        expect(isRequiredAt(req, [{p: "filters"}], key)).toBe(true)
+    })
+
+    it("removes a property and drops it from required", () => {
+        const s = base()
+        const next = removeNodeAt(s, [{p: "filters"}], "max_age")
+        expect(getNodeAt(next, [{p: "filters"}, {p: "max_age"}])).toBeNull()
+        expect(getNodeAt(next, [{p: "filters"}])?.required).toEqual([])
+    })
+
+    it("labels a path as an uppercase breadcrumb", () => {
+        expect(pathLabel([{p: "filters"}, {p: "sources"}])).toBe("FILTERS · SOURCES")
+        expect(pathLabel([{p: "sources"}, {items: true}, {p: "url"}])).toBe("SOURCES · [ ] · URL")
+    })
+})

--- a/web/packages/agenta-ui/src/drill-in/context.ts
+++ b/web/packages/agenta-ui/src/drill-in/context.ts
@@ -220,8 +220,11 @@ export {
     type GatewayToolsBridge,
     type WorkflowReferenceBridge,
     type WorkflowReferenceUI,
+    type WorkflowReferenceType,
     type WorkflowRevisionUI,
     type WorkflowEnvironmentUI,
     type WorkflowReferencePayload,
+    type WorkflowConfigPart,
+    type WorkflowConfigPayload,
     type DrillInUIProviderProps,
 } from "./context/DrillInUIContext"

--- a/web/packages/agenta-ui/src/drill-in/context/DrillInUIContext.tsx
+++ b/web/packages/agenta-ui/src/drill-in/context/DrillInUIContext.tsx
@@ -124,7 +124,10 @@ export interface WorkflowEnvironmentUI {
 export interface WorkflowReferencePayload {
     slug: string
     refBy: "variant" | "environment"
-    /** Pinned workflow revision version; variant axis only, omitted = latest. */
+    /** Selected variant id; variant axis only. Kept so "follow a variant's latest" (no pinned
+     * version) still identifies which variant to follow — without it the reference is ambiguous. */
+    variant?: string
+    /** Pinned workflow revision version; variant axis only, omitted = follow the variant's latest. */
     version?: string
     /** Environment slug; environment axis only. */
     environment?: string

--- a/web/packages/agenta-ui/src/drill-in/context/DrillInUIContext.tsx
+++ b/web/packages/agenta-ui/src/drill-in/context/DrillInUIContext.tsx
@@ -128,6 +128,8 @@ export interface WorkflowReferencePayload {
     version?: string
     /** Environment slug; environment axis only. */
     environment?: string
+    /** Tool description the model sees (defaults to the workflow's own description). */
+    description?: string
 }
 
 /** A single role-tagged prompt message (for a `messages`-kind config part). */

--- a/web/packages/agenta-ui/src/drill-in/context/DrillInUIContext.tsx
+++ b/web/packages/agenta-ui/src/drill-in/context/DrillInUIContext.tsx
@@ -85,11 +85,21 @@ export interface GatewayToolsBridge {
     }>
 }
 
+/** Coarse workflow kind for the reference list's badge + filter chips. Derived by the provider from
+ * the workflow's role/capability flags. `evaluator` covers all evaluator workflows (code/match/llm/…)
+ * so they read as evaluators rather than falling through to `custom`. */
+export type WorkflowReferenceType = "agent" | "chat" | "completion" | "custom" | "evaluator"
+
 export interface WorkflowReferenceUI {
     id: string
     slug: string
     name?: string
     description?: string
+    /** Workflow kind for badge/filter display; omitted when the provider can't classify it. */
+    type?: WorkflowReferenceType
+    /** Finer-grained badge text overriding the generic type label (e.g. an evaluator's kind
+     * "Exact Match" instead of "evaluator"). `type` still drives the badge color + filter chip. */
+    typeLabel?: string
 }
 
 /** A selectable revision of a referenced workflow, for the variant-axis "pin a version" picker. */
@@ -120,6 +130,32 @@ export interface WorkflowReferencePayload {
     environment?: string
 }
 
+/** A single role-tagged prompt message (for a `messages`-kind config part). */
+export interface WorkflowConfigMessage {
+    role: string
+    content: string
+}
+
+/** One part of a referenced workflow's configuration, shown in the Configuration section's rail
+ * (e.g. the prompt "Messages", a "Model", a custom workflow's "handler.py", an agent's "Instructions"). */
+export interface WorkflowConfigPart {
+    key: string
+    label: string
+    /** How to render: "code" (read-only editor), "text" (plain), "json" (pretty JSON), "messages"
+     * (role-tagged message list from `messages`). */
+    kind: "code" | "text" | "json" | "messages"
+    content: string
+    /** Highlighting language when `kind` is "code" (e.g. "python", "typescript"). */
+    language?: string
+    /** Role-tagged messages when `kind` is "messages". */
+    messages?: WorkflowConfigMessage[]
+}
+
+/** A referenced workflow's type-specific configuration for the Configuration section. */
+export interface WorkflowConfigPayload {
+    parts: WorkflowConfigPart[]
+}
+
 /**
  * Bridge for the "reference a workflow as a tool" source in the tool selector (#4860).
  * OSS supplies the project's workflows plus resolvers for a workflow's input schema, its
@@ -134,6 +170,12 @@ export interface WorkflowReferenceBridge {
     /** Resolve the referenced workflow's input JSON-schema to pre-fill the tool's `input_schema`.
      * Returns null when unavailable; the caller falls back to an empty object schema. */
     resolveInputSchema: (workflow: WorkflowReferenceUI) => Promise<Record<string, unknown> | null>
+    /** Resolve the workflow's output JSON-schema for the Schema section's Outputs tab.
+     * Optional; when absent or resolving null, the Outputs tab is hidden. */
+    resolveOutputSchema?: (workflow: WorkflowReferenceUI) => Promise<Record<string, unknown> | null>
+    /** Resolve the workflow's type-specific configuration (code / prompt / agent) for the
+     * Configuration section. Optional; when absent or resolving null, the section is hidden. */
+    resolveConfigPayload?: (workflow: WorkflowReferenceUI) => Promise<WorkflowConfigPayload | null>
     /** List a workflow's revisions for the variant-axis "pin a version" picker. */
     useWorkflowRevisions: (workflow: WorkflowReferenceUI | null) => {
         revisions: WorkflowRevisionUI[]
@@ -143,6 +185,18 @@ export interface WorkflowReferenceBridge {
     useWorkflowEnvironments: (workflow: WorkflowReferenceUI | null) => {
         environments: WorkflowEnvironmentUI[]
         isLoading: boolean
+    }
+    /**
+     * Resolve the reference type (agent/chat/completion/custom) for a batch of workflows.
+     * List items carry only role flags — the capability flags that determine type live on the
+     * revision URI — so type can't be derived synchronously from a list item. This reads each
+     * workflow's latest-revision URI (cached) and returns a slug→type map + a loading flag.
+     */
+    useWorkflowTypes: (workflows: WorkflowReferenceUI[]) => {
+        typeBySlug: Record<string, WorkflowReferenceType | undefined>
+        /** Finer-grained badge text per slug (e.g. an evaluator's kind), overriding the type label. */
+        labelBySlug?: Record<string, string | undefined>
+        loading: boolean
     }
 }
 

--- a/web/packages/agenta-ui/src/drill-in/context/index.ts
+++ b/web/packages/agenta-ui/src/drill-in/context/index.ts
@@ -10,8 +10,11 @@ export {
     type GatewayToolsBridge,
     type WorkflowReferenceBridge,
     type WorkflowReferenceUI,
+    type WorkflowReferenceType,
     type WorkflowRevisionUI,
     type WorkflowEnvironmentUI,
     type WorkflowReferencePayload,
+    type WorkflowConfigPart,
+    type WorkflowConfigPayload,
     type DrillInUIProviderProps,
 } from "./DrillInUIContext"

--- a/web/packages/agenta-ui/src/drill-in/index.ts
+++ b/web/packages/agenta-ui/src/drill-in/index.ts
@@ -80,9 +80,12 @@ export type {
     GatewayToolsBridge,
     WorkflowReferenceBridge,
     WorkflowReferenceUI,
+    WorkflowReferenceType,
     WorkflowRevisionUI,
     WorkflowEnvironmentUI,
     WorkflowReferencePayload,
+    WorkflowConfigPart,
+    WorkflowConfigPayload,
 } from "./context"
 
 // ============================================================================


### PR DESCRIPTION
## What

Redesigns agent-playground tool / workflow-reference selection (agent-playground scoped — never the legacy prompt playground). Split into three review-oriented commits, in dependency order.

### 1. Shared drawer primitives (`refactor`)
Moves the trigger-drawer building blocks up to `drawers/shared` so the agent drawers reuse them instead of duplicating:
- `DrawerFooter`, `MasterDetailRail`, `useDraftMasterDetail` moved out of `gatewayTrigger/`.
- New: `SectionRail` (`[rail | content]`), `RailField`, `CatalogChooser` + `CatalogAppCard` (2-col app grid), `AddItemMenu`, `GatewayCatalogDrawer`.
- Trigger drawers refactored onto them (`SourceChooser` → `CatalogChooser`; `RunVersionField` → `SectionRail`), so every drawer rail looks the same.

### 2. Workflow-reference drawer detail (`feat`)
Rebuilds the "reference a workflow" detail into a `ConfigAccordionSection` stack (Exposed as / Schema / Configuration / Reference by):
- New `SchemaTree` (read-only recursive schema viewer).
- Bridge gains `resolveOutputSchema`, `resolveConfigPayload`, `useWorkflowTypes`; `WorkflowConfigPart/Message` + an `evaluator` reference type.
- Inputs derive via the molecule's `inputPorts` (declared schema → prompt template variables) with local recovery for curly/jinja JSONPath inputs the shared extractor drops; output from `response_format`; Configuration from the full prompt (grouped Messages, model, tools, response_format).
- Type badges classify via the molecule's `workflowType` on a hydrated revision (agents get a tag); evaluators labelled by their template kind.

### 3. Tool selection: definition form + catalog + add-menu (`feat`)
- Tool definition form split into `ParameterTree` + `ParameterNodeEditor` over pure, unit-tested `schemaPaths` helpers. Per-parameter **Allowed values** (enum) + **Default** (scalar-only, type-coerced) and a tool-level `additionalProperties` toggle; JSON stays the lossless escape hatch.
- `AddItemMenu`-based picker (Add existing / Create new): `AgentToolSelectorPopover`, `AgentIntegrationDrawer` (third-party via `CatalogChooser`), `ReferenceToolFormView`, `ToolManagementList`.

## Notes

- Dark-safe throughout (antd semantic `--ag-color*` tokens).
- One pre-existing baseline `tsc` error remains in `useModelHarness.tsx` (predates this branch).
- Known follow-up: curly/jinja `{{$.inputs.x}}` inputs are recovered locally here; the underlying shared extractor gap is a separate playground ticket.
