### PR TITLE
[chore] Clean up big-agents platform/database Part II

### DIFF
--- a/api/oss/databases/postgres/migrations/core_oss/versions/oss000000006_add_mounts.py
+++ b/api/oss/databases/postgres/migrations/core_oss/versions/oss000000006_add_mounts.py
@@ -42,6 +42,8 @@ def upgrade() -> None:
             postgresql.JSONB(none_as_null=True, astext_type=sa.Text()),
             nullable=True,
         ),
+        sa.Column("tags", postgresql.JSONB(none_as_null=True), nullable=True),
+        sa.Column("meta", postgresql.JSON(none_as_null=True), nullable=True),
         sa.Column(
             "created_at",
             sa.TIMESTAMP(timezone=True),

--- a/api/oss/databases/postgres/migrations/core_oss/versions/oss000000007_add_session_states.py
+++ b/api/oss/databases/postgres/migrations/core_oss/versions/oss000000007_add_session_states.py
@@ -31,6 +31,9 @@ def upgrade() -> None:
             postgresql.JSON(astext_type=sa.Text()),
             nullable=True,
         ),
+        sa.Column("flags", postgresql.JSONB(none_as_null=True), nullable=True),
+        sa.Column("tags", postgresql.JSONB(none_as_null=True), nullable=True),
+        sa.Column("meta", postgresql.JSON(none_as_null=True), nullable=True),
         sa.Column(
             "created_at",
             sa.TIMESTAMP(timezone=True),
@@ -52,12 +55,6 @@ def upgrade() -> None:
     )
 
     op.create_index(
-        "ix_session_states_project_id",
-        "session_states",
-        ["project_id"],
-        unique=False,
-    )
-    op.create_index(
         "ix_session_states_project_id_session_id",
         "session_states",
         ["project_id", "session_id"],
@@ -69,5 +66,4 @@ def downgrade() -> None:
     op.drop_index(
         "ix_session_states_project_id_session_id", table_name="session_states"
     )
-    op.drop_index("ix_session_states_project_id", table_name="session_states")
     op.drop_table("session_states")

--- a/api/oss/databases/postgres/migrations/core_oss/versions/oss000000008_add_session_streams.py
+++ b/api/oss/databases/postgres/migrations/core_oss/versions/oss000000008_add_session_streams.py
@@ -31,10 +31,16 @@ def upgrade() -> None:
             nullable=True,
         ),
         sa.Column(
-            "status",
+            "tags",
             postgresql.JSONB(none_as_null=True),
             nullable=True,
         ),
+        sa.Column(
+            "meta",
+            postgresql.JSON(none_as_null=True),
+            nullable=True,
+        ),
+        sa.Column("status", sa.VARCHAR(), nullable=True),
         sa.Column(
             "created_at",
             sa.TIMESTAMP(timezone=True),

--- a/api/oss/databases/postgres/migrations/core_oss/versions/oss000000009_add_interactions.py
+++ b/api/oss/databases/postgres/migrations/core_oss/versions/oss000000009_add_interactions.py
@@ -26,9 +26,11 @@ def upgrade() -> None:
         sa.Column("turn_id", sa.String(), nullable=True),
         sa.Column("token", sa.String(), nullable=False),
         sa.Column("kind", sa.String(), nullable=False),
-        sa.Column("status", postgresql.JSONB(none_as_null=True), nullable=True),
+        sa.Column("status", sa.VARCHAR(), nullable=True),
         sa.Column("data", postgresql.JSON(none_as_null=True), nullable=True),
         sa.Column("flags", postgresql.JSONB(none_as_null=True), nullable=True),
+        sa.Column("tags", postgresql.JSONB(none_as_null=True), nullable=True),
+        sa.Column("meta", postgresql.JSON(none_as_null=True), nullable=True),
         sa.Column(
             "created_at",
             sa.TIMESTAMP(timezone=True),
@@ -50,9 +52,9 @@ def upgrade() -> None:
         ),
     )
     op.create_index(
-        "ix_session_interactions_project_id_created_at",
+        "ix_session_interactions_project_id_id",
         "session_interactions",
-        ["project_id", "created_at"],
+        ["project_id", "id"],
     )
     op.create_index(
         "ix_session_interactions_project_id_session_id",
@@ -68,9 +70,7 @@ def upgrade() -> None:
         "ix_session_interactions_pending",
         "session_interactions",
         ["project_id"],
-        postgresql_where=sa.text(
-            "(status->>'code') = 'pending' AND deleted_at IS NULL"
-        ),
+        postgresql_where=sa.text("status = 'pending' AND deleted_at IS NULL"),
     )
 
 
@@ -82,7 +82,7 @@ def downgrade() -> None:
         table_name="session_interactions",
     )
     op.drop_index(
-        "ix_session_interactions_project_id_created_at",
+        "ix_session_interactions_project_id_id",
         table_name="session_interactions",
     )
     op.drop_table("session_interactions")

--- a/api/oss/databases/postgres/migrations/core_oss/versions/oss000000010_backfill_workflow_revision_flags.py
+++ b/api/oss/databases/postgres/migrations/core_oss/versions/oss000000010_backfill_workflow_revision_flags.py
@@ -1,0 +1,62 @@
+"""backfill workflow_revisions flags (is_agent, is_skill)
+
+is_agent and is_skill were added to WorkflowRevisionFlags in big-agents with no
+backfill. Pre-existing rows lack the keys in stored JSON, so a containment filter
+(flags @> {"is_agent": false}) silently drops them — null and false are distinct
+result sets. Materialize both keys to false where absent; existing values win.
+
+is_static is server-owned (slug-derived, never stored/filtered), so it is not
+backfilled here.
+
+Revision ID: oss000000010
+Revises: oss000000009
+Create Date: 2026-07-01 00:00:00.000000
+
+"""
+
+from typing import Sequence, Union
+
+import sqlalchemy as sa
+from alembic import op
+
+revision: str = "oss000000010"
+down_revision: Union[str, None] = "oss000000009"
+branch_labels: Union[str, Sequence[str], None] = None
+depends_on: Union[str, Sequence[str], None] = None
+
+
+def upgrade() -> None:
+    conn = op.get_bind()
+
+    # Only add each key where absent — never overwrite an already-set value.
+    conn.execute(
+        sa.text(
+            """
+            UPDATE workflow_revisions
+            SET flags = COALESCE(flags, '{}'::jsonb)
+                || CASE WHEN NOT (COALESCE(flags, '{}'::jsonb) ? 'is_agent')
+                        THEN '{"is_agent": false}'::jsonb ELSE '{}'::jsonb END
+                || CASE WHEN NOT (COALESCE(flags, '{}'::jsonb) ? 'is_skill')
+                        THEN '{"is_skill": false}'::jsonb ELSE '{}'::jsonb END
+            WHERE flags IS NULL
+               OR NOT (flags ? 'is_agent')
+               OR NOT (flags ? 'is_skill')
+            """
+        )
+    )
+
+
+def downgrade() -> None:
+    # Strip only the false values this backfill added; leave rows that carried
+    # a real (true) value or predate the keys untouched beyond the removal.
+    conn = op.get_bind()
+    conn.execute(
+        sa.text(
+            """
+            UPDATE workflow_revisions
+            SET flags = flags - 'is_agent' - 'is_skill'
+            WHERE (flags ->> 'is_agent') = 'false'
+               OR (flags ->> 'is_skill') = 'false'
+            """
+        )
+    )

--- a/api/oss/databases/postgres/migrations/tracing_oss/versions/oss000000002_add_records.py
+++ b/api/oss/databases/postgres/migrations/tracing_oss/versions/oss000000002_add_records.py
@@ -23,13 +23,14 @@ def upgrade() -> None:
     op.create_table(
         "records",
         sa.Column("project_id", sa.UUID(), nullable=False),
-        sa.Column("id", sa.UUID(), nullable=False),
-        sa.Column("session_id", sa.UUID(), nullable=False),
-        sa.Column("event_index", sa.Integer(), nullable=True),
-        sa.Column("sender", sa.String(), nullable=True),
-        sa.Column("session_update", sa.String(), nullable=True),
+        sa.Column("record_id", sa.UUID(), nullable=False),
+        sa.Column("session_id", sa.String(), nullable=False),
+        sa.Column("record_index", sa.Integer(), nullable=True),
+        sa.Column("timestamp", sa.TIMESTAMP(timezone=True), nullable=True),
+        sa.Column("record_type", sa.String(), nullable=True),
+        sa.Column("record_source", sa.String(), nullable=True),
         sa.Column(
-            "payload",
+            "attributes",
             postgresql.JSONB(none_as_null=True, astext_type=sa.Text()),
             nullable=True,
         ),
@@ -44,46 +45,25 @@ def upgrade() -> None:
         sa.Column("created_by_id", sa.UUID(), nullable=True),
         sa.Column("updated_by_id", sa.UUID(), nullable=True),
         sa.Column("deleted_by_id", sa.UUID(), nullable=True),
-        sa.PrimaryKeyConstraint("project_id", "id"),
+        sa.PrimaryKeyConstraint("project_id", "record_id"),
     )
 
     op.create_index(
-        "ix_records_project_id",
+        "ix_records_project_id_session_id_record_id",
         "records",
-        ["project_id"],
+        ["project_id", "session_id", "record_id"],
         unique=False,
     )
     op.create_index(
-        "ix_records_project_id_session_id",
+        "ix_records_attributes_gin",
         "records",
-        ["project_id", "session_id"],
-        unique=False,
-    )
-    op.create_index(
-        "ix_records_project_id_id",
-        "records",
-        ["project_id", "id"],
-        unique=False,
-    )
-    op.create_index(
-        "ix_records_project_id_session_id_id",
-        "records",
-        ["project_id", "session_id", "id"],
-        unique=False,
-    )
-    op.create_index(
-        "ix_records_payload_gin",
-        "records",
-        ["payload"],
+        ["attributes"],
         unique=False,
         postgresql_using="gin",
     )
 
 
 def downgrade() -> None:
-    op.drop_index("ix_records_payload_gin", table_name="records")
-    op.drop_index("ix_records_project_id_session_id_id", table_name="records")
-    op.drop_index("ix_records_project_id_id", table_name="records")
-    op.drop_index("ix_records_project_id_session_id", table_name="records")
-    op.drop_index("ix_records_project_id", table_name="records")
+    op.drop_index("ix_records_attributes_gin", table_name="records")
+    op.drop_index("ix_records_project_id_session_id_record_id", table_name="records")
     op.drop_table("records")

--- a/api/oss/src/apis/fastapi/sessions/models.py
+++ b/api/oss/src/apis/fastapi/sessions/models.py
@@ -1,5 +1,5 @@
+from datetime import datetime
 from typing import Any, Dict, List, Optional
-from uuid import UUID
 
 from pydantic import BaseModel, Field
 
@@ -98,7 +98,7 @@ class SessionStateUpsertRequest(BaseModel):
 
 
 class SessionRecordQueryRequest(BaseModel):
-    session_id: UUID
+    session_id: str
 
 
 class SessionRecordsQueryResponse(BaseModel):
@@ -123,6 +123,8 @@ class SessionInteractionCreateRequest(BaseModel):
     kind: SessionInteractionKind
     data: Optional[SessionInteractionData] = None
     flags: SessionInteractionFlags = SessionInteractionFlags()
+    tags: Optional[Dict[str, Any]] = None
+    meta: Optional[Dict[str, Any]] = None
 
 
 class SessionInteractionTransitionRequest(BaseModel):
@@ -186,7 +188,8 @@ class SessionMountsResponse(BaseModel):
 class SessionRecordIngestRequest(BaseModel):
     # project scope comes from the caller's credential, never the body
     session_id: str
-    event_index: Optional[int] = None
-    sender: Optional[str] = None
-    session_update: Optional[str] = None
-    payload: Optional[Dict[str, Any]] = None
+    record_index: Optional[int] = None
+    timestamp: Optional[datetime] = None
+    record_type: Optional[str] = None
+    record_source: Optional[str] = None
+    attributes: Optional[Dict[str, Any]] = None

--- a/api/oss/src/apis/fastapi/sessions/router.py
+++ b/api/oss/src/apis/fastapi/sessions/router.py
@@ -27,6 +27,7 @@ from oss.src.core.sessions.streams.dtos import (
     SessionHeartbeatRequest,
     SessionStreamCommandRequest,
     SessionStreamQuery,
+    SessionStreamQueryFlags,
 )
 from oss.src.core.sessions.streams.types import (
     ConcurrencyCapExceeded,
@@ -387,8 +388,10 @@ class SessionStreamsRouter:
             project_id=project_id,
             filter=SessionStreamQuery(
                 session_id=payload.session_id,
-                is_alive=payload.is_alive,
-                is_running=payload.is_running,
+                flags=SessionStreamQueryFlags(
+                    is_alive=payload.is_alive,
+                    is_running=payload.is_running,
+                ),
             ),
         )
         return SessionStreamsResponseModel(count=len(streams), streams=streams)
@@ -495,7 +498,7 @@ class RecordsRouter:
             response_model_exclude_none=True,
         )
         self.router.add_api_route(
-            "/{event_id}",
+            "/{record_id}",
             self.get_record_event,
             methods=["GET"],
             operation_id="get_record_event",
@@ -539,7 +542,7 @@ class RecordsRouter:
     async def get_record_event(
         self,
         request: Request,
-        event_id: UUID,
+        record_id: UUID,
     ) -> Union[SessionRecordResponse, JSONResponse]:
         if not await check_action_access(
             user_uid=request.state.user_id,
@@ -550,7 +553,7 @@ class RecordsRouter:
 
         record = await self.records_service.get_event(
             project_id=UUID(request.state.project_id),
-            event_id=event_id,
+            record_id=record_id,
         )
         return SessionRecordResponse(record=record)
 
@@ -574,12 +577,13 @@ class RecordsRouter:
             organization_id=UUID(request.state.organization_id),
             project_id=UUID(project_id),
             record_event=SessionRecordEvent(
-                session_id=UUID(body.session_id),
+                session_id=body.session_id,
                 project_id=UUID(project_id),
-                event_index=body.event_index,
-                sender=body.sender,
-                session_update=body.session_update,
-                payload=body.payload,
+                record_index=body.record_index,
+                timestamp=body.timestamp,
+                record_type=body.record_type,
+                record_source=body.record_source,
+                attributes=body.attributes,
             ),
         )
         return {"ok": True}
@@ -667,6 +671,8 @@ class InteractionsRouter:
                 kind=body.kind,
                 data=body.data,
                 flags=body.flags,
+                tags=body.tags,
+                meta=body.meta,
             ),
         )
         return SessionInteractionResponse(count=1, interaction=interaction)
@@ -808,7 +814,10 @@ class InteractionsRouter:
                 detail="Interaction not found",
             )
 
-        if interaction.status and interaction.status.code != "pending":
+        if (
+            interaction.status
+            and interaction.status != SessionInteractionStatus.pending
+        ):
             raise HTTPException(
                 status_code=status.HTTP_409_CONFLICT,
                 detail="Interaction is no longer pending",

--- a/api/oss/src/core/mounts/dtos.py
+++ b/api/oss/src/core/mounts/dtos.py
@@ -1,5 +1,5 @@
 from datetime import datetime
-from typing import List, Optional
+from typing import Any, Dict, List, Optional
 from uuid import UUID
 
 from pydantic import BaseModel, Field
@@ -29,16 +29,22 @@ class Mount(Identifier, Slug, Header, Lifecycle):
     data: MountData = Field(default_factory=MountData)
     #
     flags: MountFlags = Field(default_factory=MountFlags)
+    tags: Optional[Dict[str, Any]] = None
+    meta: Optional[Dict[str, Any]] = None
 
 
 class MountCreate(Slug, Header):
     session_id: Optional[str] = None
     #
     flags: MountFlags = Field(default_factory=MountFlags)
+    tags: Optional[Dict[str, Any]] = None
+    meta: Optional[Dict[str, Any]] = None
 
 
 class MountEdit(Identifier, Header):
     flags: MountFlags = Field(default_factory=MountFlags)
+    tags: Optional[Dict[str, Any]] = None
+    meta: Optional[Dict[str, Any]] = None
 
 
 class MountQuery(BaseModel):

--- a/api/oss/src/core/sessions/interactions/dtos.py
+++ b/api/oss/src/core/sessions/interactions/dtos.py
@@ -4,7 +4,7 @@ from uuid import UUID
 
 from pydantic import BaseModel
 
-from oss.src.core.shared.dtos import Reference, Selector, Status
+from oss.src.core.shared.dtos import Reference, Selector
 
 
 class SessionInteractionKind(str, Enum):
@@ -33,6 +33,11 @@ class SessionInteractionFlags(BaseModel):
     delivered_webhook: bool = False
 
 
+class SessionInteractionQueryFlags(BaseModel):
+    delivered_in_band: Optional[bool] = None
+    delivered_webhook: Optional[bool] = None
+
+
 class SessionInteraction(BaseModel):
     id: Optional[UUID] = None
     #
@@ -48,9 +53,11 @@ class SessionInteraction(BaseModel):
     turn_id: Optional[str] = None
     token: str
     kind: SessionInteractionKind
-    status: Optional[Status] = None
+    status: Optional[SessionInteractionStatus] = None
     data: Optional[SessionInteractionData] = None
     flags: SessionInteractionFlags = SessionInteractionFlags()
+    tags: Optional[Dict[str, Any]] = None
+    meta: Optional[Dict[str, Any]] = None
 
 
 class SessionInteractionCreate(BaseModel):
@@ -61,6 +68,8 @@ class SessionInteractionCreate(BaseModel):
     kind: SessionInteractionKind
     data: Optional[SessionInteractionData] = None
     flags: SessionInteractionFlags = SessionInteractionFlags()
+    tags: Optional[Dict[str, Any]] = None
+    meta: Optional[Dict[str, Any]] = None
 
 
 class SessionInteractionTransition(BaseModel):
@@ -75,4 +84,5 @@ class SessionInteractionQuery(BaseModel):
     turn_id: Optional[str] = None
     kind: Optional[SessionInteractionKind] = None
     status: Optional[SessionInteractionStatus] = None
+    flags: Optional[SessionInteractionQueryFlags] = None
     actionable_only: bool = False

--- a/api/oss/src/core/sessions/records/dtos.py
+++ b/api/oss/src/core/sessions/records/dtos.py
@@ -6,28 +6,30 @@ from pydantic import BaseModel
 
 
 class SessionRecordEvent(BaseModel):
-    session_id: UUID
+    session_id: str
     project_id: UUID
 
-    event_index: Optional[int] = None
-    sender: Optional[str] = None
-    session_update: Optional[str] = None
-    payload: Optional[Dict[str, Any]] = None
+    record_index: Optional[int] = None
+    timestamp: Optional[datetime] = None
+    record_type: Optional[str] = None
+    record_source: Optional[str] = None
+    attributes: Optional[Dict[str, Any]] = None
 
 
 class SessionRecord(BaseModel):
-    id: UUID
+    record_id: UUID
 
-    session_id: UUID
+    session_id: str
     project_id: UUID
 
-    event_index: Optional[int] = None
-    sender: Optional[str] = None
-    session_update: Optional[str] = None
-    payload: Optional[Dict[str, Any]] = None
+    record_index: Optional[int] = None
+    timestamp: Optional[datetime] = None
+    record_type: Optional[str] = None
+    record_source: Optional[str] = None
+    attributes: Optional[Dict[str, Any]] = None
 
     created_at: Optional[datetime] = None
 
 
 class SessionRecordQuery(BaseModel):
-    session_id: UUID
+    session_id: str

--- a/api/oss/src/core/sessions/records/interfaces.py
+++ b/api/oss/src/core/sessions/records/interfaces.py
@@ -19,7 +19,7 @@ class RecordsDAOInterface:
         self,
         *,
         project_id: UUID,
-        session_id: UUID,
+        session_id: str,
     ) -> List[SessionRecord]:
         raise NotImplementedError
 
@@ -27,6 +27,6 @@ class RecordsDAOInterface:
         self,
         *,
         project_id: UUID,
-        event_id: UUID,
+        record_id: UUID,
     ) -> Optional[SessionRecord]:
         raise NotImplementedError

--- a/api/oss/src/core/sessions/records/service.py
+++ b/api/oss/src/core/sessions/records/service.py
@@ -23,7 +23,7 @@ class RecordsService:
         self,
         *,
         project_id: UUID,
-        session_id: UUID,
+        session_id: str,
     ) -> List[SessionRecord]:
         return await self.records_dao.get_records(
             project_id=project_id,
@@ -34,9 +34,9 @@ class RecordsService:
         self,
         *,
         project_id: UUID,
-        event_id: UUID,
+        record_id: UUID,
     ) -> Optional[SessionRecord]:
         return await self.records_dao.get_event(
             project_id=project_id,
-            event_id=event_id,
+            record_id=record_id,
         )

--- a/api/oss/src/core/sessions/records/streaming.py
+++ b/api/oss/src/core/sessions/records/streaming.py
@@ -18,8 +18,8 @@ log = get_module_logger(__name__)
 
 MAXLEN_STREAMS_RECORDS = 100_000
 
-# Truncate payload at ingest to avoid storing unbounded event bodies.
-MAX_PAYLOAD_BYTES = 64 * 1024  # 64 KB per event
+# Truncate attributes at ingest to avoid storing unbounded record bodies.
+MAX_ATTRIBUTES_BYTES = 64 * 1024  # 64 KB per record
 
 
 def _orjson_default(obj):
@@ -61,19 +61,19 @@ async def publish_record(
         return False
 
     try:
-        # Truncate payload before publishing so oversized event bodies are
+        # Truncate attributes before publishing so oversized record bodies are
         # caught at the producer boundary, not after touching the DB.
         truncated_event = record_event
-        if record_event.payload is not None:
-            raw_payload = dumps(record_event.payload, default=_orjson_default)
-            if len(raw_payload) > MAX_PAYLOAD_BYTES:
+        if record_event.attributes is not None:
+            raw_attributes = dumps(record_event.attributes, default=_orjson_default)
+            if len(raw_attributes) > MAX_ATTRIBUTES_BYTES:
                 log.warning(
-                    "[RECORDS] Payload truncated",
+                    "[RECORDS] Attributes truncated",
                     session_id=str(record_event.session_id),
-                    original_bytes=len(raw_payload),
+                    original_bytes=len(raw_attributes),
                 )
                 truncated_event = record_event.model_copy(
-                    update={"payload": {"_truncated": True}}
+                    update={"attributes": {"_truncated": True}}
                 )
 
         message = {

--- a/api/oss/src/core/sessions/records/utils.py
+++ b/api/oss/src/core/sessions/records/utils.py
@@ -86,12 +86,14 @@ def coalesce_events(
     """Coalesce chunk events and drop empty agent messages.
 
     Rules (ported from PoC ``streamSession``):
-    1. Consecutive ``agent_message_chunk`` events are folded into a single
-       ``agent_message`` event whose text is the concatenation of all chunk
+    1. Consecutive ``agent_message_chunk`` records are folded into a single
+       ``agent_message`` record whose text is the concatenation of all chunk
        texts.
     2. A standalone ``agent_message`` whose content is empty (no text, or
        text == "") is dropped.  These are emitted by some harnesses as a
        sentinel before chunks start and would shadow the assembled message.
+
+    Records are dicts keyed by ``record_type`` with the body under ``attributes``.
     """
     result: List[Dict[str, Any]] = []
     chunk_buffer: List[Dict[str, Any]] = []
@@ -100,16 +102,18 @@ def coalesce_events(
         if not chunk_buffer:
             return
         combined_text = "".join(
-            c.get("payload", {}).get("text", "") or ""
+            c.get("attributes", {}).get("text", "") or ""
             for c in chunk_buffer
-            if isinstance(c.get("payload"), dict)
+            if isinstance(c.get("attributes"), dict)
         )
         if combined_text:
             base = chunk_buffer[0].copy()
-            base["session_update"] = "agent_message"
-            base["payload"] = {
+            base["record_type"] = "agent_message"
+            base["attributes"] = {
                 **(
-                    {} if not isinstance(base.get("payload"), dict) else base["payload"]
+                    {}
+                    if not isinstance(base.get("attributes"), dict)
+                    else base["attributes"]
                 ),
                 "text": combined_text,
             }
@@ -117,7 +121,7 @@ def coalesce_events(
         chunk_buffer.clear()
 
     for event in events:
-        update = event.get("session_update", "")
+        update = event.get("record_type", "")
 
         if update == "agent_message_chunk":
             chunk_buffer.append(event)
@@ -127,8 +131,8 @@ def coalesce_events(
         _flush_chunks()
 
         if update == "agent_message":
-            payload = event.get("payload") or {}
-            text = payload.get("text", "") if isinstance(payload, dict) else ""
+            attributes = event.get("attributes") or {}
+            text = attributes.get("text", "") if isinstance(attributes, dict) else ""
             if not text:
                 # drop empty sentinel agent_message
                 continue

--- a/api/oss/src/core/sessions/states/dtos.py
+++ b/api/oss/src/core/sessions/states/dtos.py
@@ -6,6 +6,10 @@ from pydantic import BaseModel, Field
 from oss.src.core.shared.dtos import Lifecycle
 
 
+class SessionStateFlags(BaseModel):
+    pass
+
+
 class SessionState(Lifecycle):
     id: Optional[UUID] = Field(default=None, description="Own uuid7 pk (state_id).")
     project_id: Optional[UUID] = Field(default=None)
@@ -18,6 +22,9 @@ class SessionState(Lifecycle):
         default=None,
         description="Remote sandbox id — the single source of truth resume pointer.",
     )
+    flags: SessionStateFlags = Field(default_factory=SessionStateFlags)
+    tags: Optional[Dict[str, Any]] = Field(default=None)
+    meta: Optional[Dict[str, Any]] = Field(default=None)
 
 
 class SessionStateUpsert(BaseModel):

--- a/api/oss/src/core/sessions/streams/dtos.py
+++ b/api/oss/src/core/sessions/streams/dtos.py
@@ -1,21 +1,16 @@
 from datetime import datetime
 from enum import Enum
-from typing import Optional
+from typing import Any, Dict, Optional
 from uuid import UUID
 
 from pydantic import BaseModel
 
 
-class StreamStatusCode(str, Enum):
+class SessionStreamStatus(str, Enum):
     running = "running"
     detached = "detached"
     idle = "idle"
     ended = "ended"
-
-
-class SessionStreamStatus(BaseModel):
-    code: Optional[StreamStatusCode] = None
-    message: Optional[str] = None
 
 
 class SessionStreamFlags(BaseModel):
@@ -28,6 +23,12 @@ class SessionStreamFlags(BaseModel):
     is_alive: bool = False
     is_running: bool = False
     is_attached: bool = False
+
+
+class SessionStreamQueryFlags(BaseModel):
+    is_alive: Optional[bool] = None
+    is_running: Optional[bool] = None
+    is_attached: Optional[bool] = None
 
 
 class SessionStream(BaseModel):
@@ -43,27 +44,32 @@ class SessionStream(BaseModel):
     project_id: UUID
     session_id: str
     flags: SessionStreamFlags = SessionStreamFlags()
+    tags: Optional[Dict[str, Any]] = None
+    meta: Optional[Dict[str, Any]] = None
     turn_id: Optional[str] = None
-    status: SessionStreamStatus = SessionStreamStatus()
+    status: Optional[SessionStreamStatus] = None
 
 
 class SessionStreamCreate(BaseModel):
     session_id: str
     flags: Optional[SessionStreamFlags] = None
+    tags: Optional[Dict[str, Any]] = None
+    meta: Optional[Dict[str, Any]] = None
     turn_id: Optional[str] = None
     status: Optional[SessionStreamStatus] = None
 
 
 class SessionStreamEdit(BaseModel):
     flags: Optional[SessionStreamFlags] = None
+    tags: Optional[Dict[str, Any]] = None
+    meta: Optional[Dict[str, Any]] = None
     turn_id: Optional[str] = None
     status: Optional[SessionStreamStatus] = None
 
 
 class SessionStreamQuery(BaseModel):
     session_id: Optional[str] = None
-    is_alive: Optional[bool] = None
-    is_running: Optional[bool] = None
+    flags: Optional[SessionStreamQueryFlags] = None
 
 
 class CommandMode(str, Enum):

--- a/api/oss/src/core/sessions/streams/service.py
+++ b/api/oss/src/core/sessions/streams/service.py
@@ -48,7 +48,6 @@ from oss.src.core.sessions.streams.dtos import (
     SessionStreamFlags,
     SessionStreamQuery,
     SessionStreamStatus,
-    StreamStatusCode,
 )
 from oss.src.core.sessions.streams.types import (
     ConcurrencyCapExceeded,
@@ -276,10 +275,10 @@ class SessionStreamsService:
             session_id=request.session_id,
         )
 
-        status = request.status or SessionStreamStatus(
-            code=StreamStatusCode.running
+        status = request.status or (
+            SessionStreamStatus.running
             if request.is_running
-            else StreamStatusCode.idle
+            else SessionStreamStatus.idle
         )
 
         if stream is None:
@@ -364,7 +363,7 @@ class SessionStreamsService:
         await acquire_running(self._lock, session_id=session_id, turn_id=turn_id)
 
         flags = SessionStreamFlags(is_alive=True, is_running=True, is_attached=False)
-        status = SessionStreamStatus(code=StreamStatusCode.running)
+        status = SessionStreamStatus.running
         stream = await self._dao.get_by_session_id(
             project_id=project_id,
             session_id=session_id,
@@ -426,6 +425,6 @@ class SessionStreamsService:
                 flags=SessionStreamFlags(
                     is_alive=False, is_running=False, is_attached=False
                 ),
-                status=SessionStreamStatus(code=StreamStatusCode.ended),
+                status=SessionStreamStatus.ended,
             ),
         )

--- a/api/oss/src/dbs/postgres/mounts/dbas.py
+++ b/api/oss/src/dbs/postgres/mounts/dbas.py
@@ -6,8 +6,10 @@ from oss.src.dbs.postgres.shared.dbas import (
     HeaderDBA,
     IdentifierDBA,
     LifecycleDBA,
+    MetaDBA,
     ProjectScopeDBA,
     SlugDBA,
+    TagsDBA,
 )
 
 
@@ -19,6 +21,8 @@ class MountDBA(
     HeaderDBA,
     DataDBA,
     FlagsDBA,
+    TagsDBA,
+    MetaDBA,
 ):
     __abstract__ = True
 

--- a/api/oss/src/dbs/postgres/mounts/mappings.py
+++ b/api/oss/src/dbs/postgres/mounts/mappings.py
@@ -41,6 +41,8 @@ def map_mount_dto_to_dbe_upsert(
         "name": mount_create.name,
         "description": mount_create.description,
         "flags": mount_create.flags.model_dump(),
+        "tags": mount_create.tags,
+        "meta": mount_create.meta,
         "data": {},
     }
 
@@ -64,6 +66,8 @@ def map_mount_dto_to_dbe_create(
         description=mount_create.description,
         #
         flags=mount_create.flags.model_dump(),
+        tags=mount_create.tags,
+        meta=mount_create.meta,
         #
         data={},
     )
@@ -93,6 +97,8 @@ def map_mount_dbe_to_dto(
         data=MountData.model_validate(mount_dbe.data),
         #
         flags=MountFlags(**(mount_dbe.flags or {})),
+        tags=mount_dbe.tags,
+        meta=mount_dbe.meta,
     )
 
 
@@ -110,3 +116,7 @@ def map_mount_dto_to_dbe_edit(
     mount_dbe.description = mount_edit.description
 
     mount_dbe.flags = mount_edit.flags.model_dump()
+    if mount_edit.tags is not None:
+        mount_dbe.tags = mount_edit.tags
+    if mount_edit.meta is not None:
+        mount_dbe.meta = mount_edit.meta

--- a/api/oss/src/dbs/postgres/sessions/interactions/dao.py
+++ b/api/oss/src/dbs/postgres/sessions/interactions/dao.py
@@ -103,12 +103,10 @@ class SessionInteractionsDAO(SessionInteractionsDAOInterface):
                     SessionInteractionDBE.project_id == transition.project_id,
                     SessionInteractionDBE.session_id == transition.session_id,
                     SessionInteractionDBE.token == transition.token,
-                    SessionInteractionDBE.status["code"].astext.in_(
-                        ("pending", "responded")
-                    ),
+                    SessionInteractionDBE.status.in_(("pending", "responded")),
                 )
                 .values(
-                    status={"code": transition.status.value},
+                    status=transition.status.value,
                     updated_at=datetime.now(timezone.utc),
                 )
                 .returning(SessionInteractionDBE)
@@ -136,10 +134,10 @@ class SessionInteractionsDAO(SessionInteractionsDAOInterface):
                 .where(
                     SessionInteractionDBE.project_id == project_id,
                     SessionInteractionDBE.session_id == session_id,
-                    SessionInteractionDBE.status["code"].astext == "pending",
+                    SessionInteractionDBE.status == "pending",
                 )
                 .values(
-                    status={"code": "cancelled"},
+                    status="cancelled",
                     updated_at=datetime.now(timezone.utc),
                 )
             )
@@ -177,9 +175,16 @@ class SessionInteractionsDAO(SessionInteractionsDAOInterface):
                     )
                 if query.status is not None:
                     stmt = stmt.where(
-                        SessionInteractionDBE.status["code"].astext
-                        == query.status.value,
+                        SessionInteractionDBE.status == query.status.value,
                     )
+                if query.flags is not None:
+                    flags_filter = query.flags.model_dump(
+                        exclude_none=True, exclude_unset=True
+                    )
+                    if flags_filter:
+                        stmt = stmt.where(
+                            SessionInteractionDBE.flags.contains(flags_filter),
+                        )
                 if query.actionable_only:
                     from sqlalchemy import text  # noqa: PLC0415
 

--- a/api/oss/src/dbs/postgres/sessions/interactions/dbas.py
+++ b/api/oss/src/dbs/postgres/sessions/interactions/dbas.py
@@ -1,12 +1,13 @@
-from sqlalchemy import Column, String
+from sqlalchemy import Column, String, VARCHAR
 
 from oss.src.dbs.postgres.shared.dbas import (
     DataDBA,
     FlagsDBA,
     IdentifierDBA,
     LifecycleDBA,
+    MetaDBA,
     ProjectScopeDBA,
-    StatusDBA,
+    TagsDBA,
 )
 
 
@@ -14,9 +15,10 @@ class SessionInteractionDBA(
     ProjectScopeDBA,
     LifecycleDBA,
     IdentifierDBA,
-    StatusDBA,
     DataDBA,
     FlagsDBA,
+    TagsDBA,
+    MetaDBA,
 ):
     __abstract__ = True
 
@@ -24,3 +26,4 @@ class SessionInteractionDBA(
     turn_id = Column(String, nullable=True)
     token = Column(String, nullable=False)
     kind = Column(String, nullable=False)
+    status = Column(VARCHAR, nullable=True)

--- a/api/oss/src/dbs/postgres/sessions/interactions/dbes.py
+++ b/api/oss/src/dbs/postgres/sessions/interactions/dbes.py
@@ -23,9 +23,9 @@ class SessionInteractionDBE(Base, SessionInteractionDBA):
             name="uq_session_interactions_project_session_token",
         ),
         Index(
-            "ix_session_interactions_project_id_created_at",
+            "ix_session_interactions_project_id_id",
             "project_id",
-            "created_at",
+            "id",
         ),
         Index(
             "ix_session_interactions_project_id_session_id",
@@ -41,8 +41,6 @@ class SessionInteractionDBE(Base, SessionInteractionDBA):
         Index(
             "ix_session_interactions_pending",
             "project_id",
-            postgresql_where=text(
-                "(status->>'code') = 'pending' AND deleted_at IS NULL"
-            ),
+            postgresql_where=text("status = 'pending' AND deleted_at IS NULL"),
         ),
     )

--- a/api/oss/src/dbs/postgres/sessions/interactions/mappings.py
+++ b/api/oss/src/dbs/postgres/sessions/interactions/mappings.py
@@ -7,8 +7,8 @@ from oss.src.core.sessions.interactions.dtos import (
     SessionInteractionData,
     SessionInteractionFlags,
     SessionInteractionKind,
+    SessionInteractionStatus,
 )
-from oss.src.core.shared.dtos import Status
 from oss.src.dbs.postgres.sessions.interactions.dbes import SessionInteractionDBE
 
 
@@ -29,13 +29,15 @@ def map_interaction_dto_to_dbe_create(
         token=interaction.token,
         kind=interaction.kind.value,
         #
-        status={"code": "pending"},
+        status=SessionInteractionStatus.pending.value,
         #
         data=interaction.data.model_dump(mode="json", exclude_none=True)
         if interaction.data
         else None,
         #
         flags=interaction.flags.model_dump(),
+        tags=interaction.tags,
+        meta=interaction.meta,
     )
 
 
@@ -58,9 +60,11 @@ def map_interaction_dbe_to_dto(
         token=dbe.token,
         kind=SessionInteractionKind(dbe.kind),
         #
-        status=Status.model_validate(dbe.status) if dbe.status else Status(),
+        status=SessionInteractionStatus(dbe.status) if dbe.status else None,
         #
         data=SessionInteractionData.model_validate(dbe.data) if dbe.data else None,
         #
         flags=SessionInteractionFlags(**(dbe.flags or {})),
+        tags=dbe.tags,
+        meta=dbe.meta,
     )

--- a/api/oss/src/dbs/postgres/sessions/records/dao.py
+++ b/api/oss/src/dbs/postgres/sessions/records/dao.py
@@ -50,7 +50,7 @@ class RecordsDAO(RecordsDAOInterface):
         self,
         *,
         project_id: UUID,
-        session_id: UUID,
+        session_id: str,
     ) -> List[SessionRecord]:
         async with self.engine.session() as session:
             stmt = (
@@ -59,7 +59,7 @@ class RecordsDAO(RecordsDAOInterface):
                     RecordDBE.project_id == project_id,
                     RecordDBE.session_id == session_id,
                 )
-                .order_by(RecordDBE.id.asc())
+                .order_by(RecordDBE.record_id.asc())
             )
 
             dbes = (await session.execute(stmt)).scalars().all()
@@ -69,12 +69,12 @@ class RecordsDAO(RecordsDAOInterface):
         self,
         *,
         project_id: UUID,
-        event_id: UUID,
+        record_id: UUID,
     ) -> Optional[SessionRecord]:
         async with self.engine.session() as session:
             stmt = select(RecordDBE).where(
                 RecordDBE.project_id == project_id,
-                RecordDBE.id == event_id,
+                RecordDBE.record_id == record_id,
             )
 
             dbe = (await session.execute(stmt)).scalars().first()

--- a/api/oss/src/dbs/postgres/sessions/records/dbas.py
+++ b/api/oss/src/dbs/postgres/sessions/records/dbas.py
@@ -1,39 +1,49 @@
 import uuid_utils.compat as uuid
 
-from sqlalchemy import Column, UUID, Integer, String
+from sqlalchemy import Column, UUID, TIMESTAMP, String, Integer
 from sqlalchemy.dialects.postgresql import JSONB
 
 
 class RecordDBA:
     __abstract__ = True
 
-    # PK — uuid7 provides time-ordered, globally-unique identity + ordering key.
-    id = Column(
+    # DB-minted uuid7 — records have no upstream id (unlike span_id/event_id).
+    # Time-ordered, so it doubles as the ordering key.
+    record_id = Column(
         UUID(as_uuid=True),
         nullable=False,
         default=uuid.uuid7,
     )
 
     session_id = Column(
-        UUID(as_uuid=True),
+        String,
         nullable=False,
     )
 
-    event_index = Column(
+    # Producer-stamped per-session ordinal; not the ordering key (that is record_id),
+    # kept as a stable human-readable sequence from the producer.
+    record_index = Column(
         Integer,
         nullable=True,
     )
-    sender = Column(
+
+    # Producer (runner) event time, distinct from LifecycleDBA.created_at (ingest time).
+    timestamp = Column(
+        TIMESTAMP(timezone=True),
+        nullable=True,
+    )
+
+    # Top-level discriminators, mirroring span_type/span_kind and event_type.
+    record_type = Column(
         String,
         nullable=True,
     )
-    session_update = Column(
+    record_source = Column(
         String,
         nullable=True,
     )
 
-    # JSONB — deliberate; payload is an event body, mirrors spans/events.
-    payload = Column(
+    attributes = Column(
         JSONB(none_as_null=True),
         nullable=True,
     )

--- a/api/oss/src/dbs/postgres/sessions/records/dbes.py
+++ b/api/oss/src/dbs/postgres/sessions/records/dbes.py
@@ -14,19 +14,16 @@ class RecordDBE(
     __tablename__ = "records"
 
     __table_args__ = (
-        PrimaryKeyConstraint("project_id", "id"),
-        Index("ix_records_project_id", "project_id"),
-        Index("ix_records_project_id_session_id", "project_id", "session_id"),
-        Index("ix_records_project_id_id", "project_id", "id"),
+        PrimaryKeyConstraint("project_id", "record_id"),
         Index(
-            "ix_records_project_id_session_id_id",
+            "ix_records_project_id_session_id_record_id",
             "project_id",
             "session_id",
-            "id",
+            "record_id",
         ),
         Index(
-            "ix_records_payload_gin",
-            "payload",
+            "ix_records_attributes_gin",
+            "attributes",
             postgresql_using="gin",
         ),
     )

--- a/api/oss/src/dbs/postgres/sessions/records/mappings.py
+++ b/api/oss/src/dbs/postgres/sessions/records/mappings.py
@@ -14,24 +14,26 @@ def map_record_event_to_dbe(
     # The DAO inserts via an explicit insert().values(...), which bypasses the column's
     # ORM-side default=uuid7; mint the pk here so it is never null at insert.
     return RecordDBE(
-        id=uuid.uuid7(),
+        record_id=uuid.uuid7(),
         project_id=event.project_id,
         session_id=event.session_id,
-        event_index=event.event_index,
-        sender=event.sender,
-        session_update=event.session_update,
-        payload=event.payload,
+        record_index=event.record_index,
+        timestamp=event.timestamp,
+        record_type=event.record_type,
+        record_source=event.record_source,
+        attributes=event.attributes,
     )
 
 
 def map_record_dbe_to_dto(*, dbe: RecordDBE) -> SessionRecord:
     return SessionRecord(
-        id=dbe.id,
+        record_id=dbe.record_id,
         session_id=dbe.session_id,
         project_id=dbe.project_id,
-        event_index=dbe.event_index,
-        sender=dbe.sender,
-        session_update=dbe.session_update,
-        payload=dbe.payload,
+        record_index=dbe.record_index,
+        timestamp=dbe.timestamp,
+        record_type=dbe.record_type,
+        record_source=dbe.record_source,
+        attributes=dbe.attributes,
         created_at=dbe.created_at,
     )

--- a/api/oss/src/dbs/postgres/sessions/states/dao.py
+++ b/api/oss/src/dbs/postgres/sessions/states/dao.py
@@ -11,7 +11,11 @@ from oss.src.utils.logging import get_module_logger
 from oss.src.utils.exceptions import suppress_exceptions
 
 from oss.src.core.sessions.states.interfaces import SessionStatesDAOInterface
-from oss.src.core.sessions.states.dtos import SessionState, SessionStateUpsert
+from oss.src.core.sessions.states.dtos import (
+    SessionState,
+    SessionStateFlags,
+    SessionStateUpsert,
+)
 
 from oss.src.dbs.postgres.shared.engine import (
     TransactionsEngine,
@@ -66,6 +70,7 @@ class SessionStatesDAO(SessionStatesDAOInterface):
             "session_id": session_id,
             "data": upsert.data,
             "sandbox_id": upsert.sandbox_id,
+            "flags": SessionStateFlags().model_dump(mode="json"),
             "created_at": now,
             "updated_at": None,
             "created_by_id": user_id,

--- a/api/oss/src/dbs/postgres/sessions/states/dbes.py
+++ b/api/oss/src/dbs/postgres/sessions/states/dbes.py
@@ -12,7 +12,10 @@ from oss.src.dbs.postgres.shared.dbas import (
     IdentifierDBA,
     ProjectScopeDBA,
     DataDBA,
+    FlagsDBA,
     LifecycleDBA,
+    MetaDBA,
+    TagsDBA,
 )
 
 
@@ -21,6 +24,9 @@ class SessionStateDBE(
     ProjectScopeDBA,
     IdentifierDBA,
     DataDBA,
+    FlagsDBA,
+    TagsDBA,
+    MetaDBA,
     LifecycleDBA,
 ):
     __tablename__ = "session_states"
@@ -37,7 +43,6 @@ class SessionStateDBE(
             "session_id",
             name="uq_session_states_project_session_id",
         ),
-        Index("ix_session_states_project_id", "project_id"),
         Index("ix_session_states_project_id_session_id", "project_id", "session_id"),
     )
 

--- a/api/oss/src/dbs/postgres/sessions/states/mappings.py
+++ b/api/oss/src/dbs/postgres/sessions/states/mappings.py
@@ -1,4 +1,4 @@
-from oss.src.core.sessions.states.dtos import SessionState
+from oss.src.core.sessions.states.dtos import SessionState, SessionStateFlags
 from oss.src.dbs.postgres.sessions.states.dbes import SessionStateDBE
 
 
@@ -9,6 +9,11 @@ def dbe_to_dto(dbe: SessionStateDBE) -> SessionState:
         session_id=dbe.session_id,
         data=dbe.data,
         sandbox_id=dbe.sandbox_id,
+        flags=SessionStateFlags.model_validate(dbe.flags)
+        if dbe.flags
+        else SessionStateFlags(),
+        tags=dbe.tags,
+        meta=dbe.meta,
         created_at=dbe.created_at,
         updated_at=dbe.updated_at,
         deleted_at=dbe.deleted_at,

--- a/api/oss/src/dbs/postgres/sessions/streams/dao.py
+++ b/api/oss/src/dbs/postgres/sessions/streams/dao.py
@@ -9,7 +9,7 @@ from oss.src.core.sessions.streams.dtos import (
     SessionStreamCreate,
     SessionStreamEdit,
     SessionStreamQuery,
-    StreamStatusCode,
+    SessionStreamStatus,
 )
 from oss.src.core.sessions.streams.interfaces import SessionStreamsDAOInterface
 
@@ -98,16 +98,12 @@ class SessionStreamsDAO(SessionStreamsDAOInterface):
             )
             if filter.session_id is not None:
                 stmt = stmt.where(SessionStreamDBE.session_id == filter.session_id)
-            if filter.is_alive is not None:
-                stmt = stmt.where(
-                    SessionStreamDBE.flags["is_alive"].astext
-                    == ("true" if filter.is_alive else "false")
+            if filter.flags is not None:
+                flags_filter = filter.flags.model_dump(
+                    exclude_none=True, exclude_unset=True
                 )
-            if filter.is_running is not None:
-                stmt = stmt.where(
-                    SessionStreamDBE.flags["is_running"].astext
-                    == ("true" if filter.is_running else "false")
-                )
+                if flags_filter:
+                    stmt = stmt.where(SessionStreamDBE.flags.contains(flags_filter))
             stmt = stmt.order_by(SessionStreamDBE.created_at.desc())
             result = await session.execute(stmt)
             dbes = result.scalars().all()
@@ -173,8 +169,7 @@ class SessionStreamsDAO(SessionStreamsDAOInterface):
                 .select_from(SessionStreamDBE)
                 .where(
                     SessionStreamDBE.deleted_at.is_(None),
-                    SessionStreamDBE.status["code"].astext
-                    == StreamStatusCode.running.value,
+                    SessionStreamDBE.status == SessionStreamStatus.running.value,
                 )
             )
             if project_id is not None:

--- a/api/oss/src/dbs/postgres/sessions/streams/dbes.py
+++ b/api/oss/src/dbs/postgres/sessions/streams/dbes.py
@@ -5,6 +5,7 @@ from sqlalchemy import (
     PrimaryKeyConstraint,
     String,
     UniqueConstraint,
+    VARCHAR,
 )
 
 from oss.src.dbs.postgres.shared.base import Base
@@ -12,13 +13,20 @@ from oss.src.dbs.postgres.shared.dbas import (
     FlagsDBA,
     IdentifierDBA,
     LifecycleDBA,
+    MetaDBA,
     ProjectScopeDBA,
-    StatusDBA,
+    TagsDBA,
 )
 
 
 class SessionStreamDBE(
-    Base, IdentifierDBA, ProjectScopeDBA, LifecycleDBA, FlagsDBA, StatusDBA
+    Base,
+    IdentifierDBA,
+    ProjectScopeDBA,
+    LifecycleDBA,
+    FlagsDBA,
+    TagsDBA,
+    MetaDBA,
 ):
     """Ephemeral run/liveness facet for a session — the durable mirror of the
     Redis nest (alive ⊇ running ⊇ attached).
@@ -37,6 +45,9 @@ class SessionStreamDBE(
     # Current turn (uuid7 minted by the service); the Postgres mirror of the Redis
     # alive/running lock value. Null when idle/ended. Not a pk — a token-like correlator.
     turn_id = Column(String, nullable=True)
+
+    # FSM as a root enum column (SessionStreamStatus).
+    status = Column(VARCHAR, nullable=True)
 
     __table_args__ = (
         ForeignKeyConstraint(

--- a/api/oss/src/dbs/postgres/sessions/streams/mappings.py
+++ b/api/oss/src/dbs/postgres/sessions/streams/mappings.py
@@ -22,8 +22,10 @@ def map_stream_dto_to_dbe_create(
         created_by_id=user_id,
         session_id=stream.session_id,
         flags=stream.flags.model_dump(mode="json") if stream.flags else None,
+        tags=stream.tags,
+        meta=stream.meta,
         turn_id=stream.turn_id,
-        status=stream.status.model_dump(mode="json") if stream.status else None,
+        status=stream.status.value if stream.status else None,
     )
 
 
@@ -45,9 +47,9 @@ def map_stream_dbe_to_dto(
         flags=SessionStreamFlags.model_validate(stream_dbe.flags)
         if stream_dbe.flags
         else SessionStreamFlags(),
-        status=SessionStreamStatus.model_validate(stream_dbe.status)
-        if stream_dbe.status
-        else SessionStreamStatus(),
+        tags=stream_dbe.tags,
+        meta=stream_dbe.meta,
+        status=SessionStreamStatus(stream_dbe.status) if stream_dbe.status else None,
     )
 
 
@@ -60,7 +62,11 @@ def map_stream_dto_to_dbe_edit(
     stream_dbe.updated_by_id = user_id
     if stream.flags is not None:
         stream_dbe.flags = stream.flags.model_dump(mode="json")
+    if stream.tags is not None:
+        stream_dbe.tags = stream.tags
+    if stream.meta is not None:
+        stream_dbe.meta = stream.meta
     if stream.turn_id is not None:
         stream_dbe.turn_id = stream.turn_id
     if stream.status is not None:
-        stream_dbe.status = stream.status.model_dump(mode="json")
+        stream_dbe.status = stream.status.value

--- a/api/oss/src/tasks/asyncio/sessions/orphan_sweep.py
+++ b/api/oss/src/tasks/asyncio/sessions/orphan_sweep.py
@@ -17,7 +17,6 @@ from oss.src.dbs.postgres.sessions.streams.dbes import SessionStreamDBE
 from oss.src.core.sessions.streams.dtos import (
     SessionStreamFlags,
     SessionStreamStatus,
-    StreamStatusCode,
 )
 
 from sqlalchemy import select
@@ -52,10 +51,7 @@ async def run_orphan_sweep(engine: TransactionsEngine) -> None:
             row.flags = SessionStreamFlags(
                 is_alive=False, is_running=False, is_attached=False
             ).model_dump(mode="json")
-            row.status = SessionStreamStatus(
-                code=StreamStatusCode.ended,
-                message="orphan sweep",
-            ).model_dump(mode="json")
+            row.status = SessionStreamStatus.ended.value
             row.updated_at = now
             log.warning(
                 "orphan_sweep: marking session_stream ended",

--- a/api/oss/tests/pytest/acceptance/mounts/test_mounts_injection.py
+++ b/api/oss/tests/pytest/acceptance/mounts/test_mounts_injection.py
@@ -49,7 +49,9 @@ class TestSessionMountSign:
         assert mount["session_id"] == session_id
 
         # Credentials are prefix-scoped to THIS mount, never the bucket root.
-        assert creds["prefix"] == f"{mount['project_id']}/{mount['id']}"
+        # The key layout is [<namespace>/]mounts/<project_id>/<mount_id>; assert the
+        # mount-scoped tail without coupling to the deployment namespace prefix.
+        assert creds["prefix"].endswith(f"mounts/{mount['project_id']}/{mount['id']}")
         assert creds["access_key"]
         assert creds["secret_key"]
         assert creds["bucket"]
@@ -105,7 +107,7 @@ class TestMountSign:
         assert resp.status_code == 200, resp.text
 
         creds = resp.json()["credentials"]
-        assert creds["prefix"] == f"{mount['project_id']}/{mount['id']}"
+        assert creds["prefix"].endswith(f"mounts/{mount['project_id']}/{mount['id']}")
 
     def test_sign_missing_mount_returns_404(self, authed_api):
         resp = authed_api("POST", f"/mounts/{uuid4()}/sign")

--- a/api/oss/tests/pytest/unit/records/test_record_utils.py
+++ b/api/oss/tests/pytest/unit/records/test_record_utils.py
@@ -128,8 +128,8 @@ class TestStripReplay:
 
 def _evt(update: str, text: str = "", **kwargs):
     return {
-        "session_update": update,
-        "payload": {"text": text},
+        "record_type": update,
+        "attributes": {"text": text},
         **kwargs,
     }
 
@@ -149,8 +149,8 @@ class TestCoalesceEvents:
         events = [_evt("agent_message_chunk", "hello")]
         result = coalesce_events(events)
         assert len(result) == 1
-        assert result[0]["session_update"] == "agent_message"
-        assert result[0]["payload"]["text"] == "hello"
+        assert result[0]["record_type"] == "agent_message"
+        assert result[0]["attributes"]["text"] == "hello"
 
     def test_multiple_chunks_merged(self):
         events = [
@@ -160,8 +160,8 @@ class TestCoalesceEvents:
         ]
         result = coalesce_events(events)
         assert len(result) == 1
-        assert result[0]["session_update"] == "agent_message"
-        assert result[0]["payload"]["text"] == "foo bar baz"
+        assert result[0]["record_type"] == "agent_message"
+        assert result[0]["attributes"]["text"] == "foo bar baz"
 
     def test_chunks_flushed_before_next_event(self):
         events = [
@@ -172,10 +172,10 @@ class TestCoalesceEvents:
         ]
         result = coalesce_events(events)
         assert len(result) == 3
-        assert result[0]["session_update"] == "user_message"
-        assert result[1]["session_update"] == "agent_message"
-        assert result[1]["payload"]["text"] == "Answer"
-        assert result[2]["session_update"] == "tool_call"
+        assert result[0]["record_type"] == "user_message"
+        assert result[1]["record_type"] == "agent_message"
+        assert result[1]["attributes"]["text"] == "Answer"
+        assert result[2]["record_type"] == "tool_call"
 
     def test_empty_agent_message_dropped(self):
         events = [
@@ -184,7 +184,7 @@ class TestCoalesceEvents:
         ]
         result = coalesce_events(events)
         assert len(result) == 1
-        assert result[0]["payload"]["text"] == "real response"
+        assert result[0]["attributes"]["text"] == "real response"
 
     def test_empty_chunk_sequence_produces_nothing(self):
         """Chunks with no text content → empty combined text → nothing stored."""
@@ -197,7 +197,7 @@ class TestCoalesceEvents:
 
     def test_non_agent_events_preserved(self):
         events = [
-            {"session_update": "tool_result", "payload": {"data": 123}},
+            {"record_type": "tool_result", "attributes": {"data": 123}},
         ]
         result = coalesce_events(events)
         assert result == events
@@ -210,8 +210,8 @@ class TestCoalesceEvents:
         ]
         result = coalesce_events(events)
         assert len(result) == 3
-        assert result[0]["payload"]["text"] == "first"
-        assert result[0]["session_update"] == "agent_message"
-        assert result[1]["session_update"] == "user_message"
-        assert result[2]["payload"]["text"] == "second"
-        assert result[2]["session_update"] == "agent_message"
+        assert result[0]["attributes"]["text"] == "first"
+        assert result[0]["record_type"] == "agent_message"
+        assert result[1]["record_type"] == "user_message"
+        assert result[2]["attributes"]["text"] == "second"
+        assert result[2]["record_type"] == "agent_message"

--- a/api/oss/tests/pytest/unit/sessions/test_interactions_dispatcher.py
+++ b/api/oss/tests/pytest/unit/sessions/test_interactions_dispatcher.py
@@ -15,8 +15,9 @@ def _make_interaction(*, with_refs=True):
         SessionInteraction,
         SessionInteractionData,
         SessionInteractionKind,
+        SessionInteractionStatus,
     )
-    from oss.src.core.shared.dtos import Reference, Status
+    from oss.src.core.shared.dtos import Reference
 
     refs = {"workflow": Reference(slug="wf-1")} if with_refs else None
     return SessionInteraction(
@@ -25,7 +26,7 @@ def _make_interaction(*, with_refs=True):
         session_id="sess-test-1",
         token="tok-abc",
         kind=SessionInteractionKind.user_input,
-        status=Status(code="pending", message="pending"),
+        status=SessionInteractionStatus.pending,
         data=SessionInteractionData(references=refs, selector=None),
     )
 

--- a/api/oss/tests/pytest/unit/sessions/test_record_ingest_endpoint.py
+++ b/api/oss/tests/pytest/unit/sessions/test_record_ingest_endpoint.py
@@ -41,9 +41,9 @@ async def test_record_ingest_writes_to_stream():
 
     body = SessionRecordIngestRequest(
         session_id=str(session_id),
-        event_index=0,
-        sender="user",
-        payload={"text": "hello"},
+        record_index=0,
+        record_source="user",
+        attributes={"text": "hello"},
     )
 
     app = FastAPI()
@@ -70,10 +70,10 @@ async def test_record_ingest_writes_to_stream():
     assert call_kwargs["organization_id"] == organization_id
     assert call_kwargs["project_id"] == project_id
     event = call_kwargs["record_event"]
-    assert event.session_id == session_id
+    assert event.session_id == str(session_id)
     assert event.project_id == project_id
-    assert event.sender == "user"
-    assert event.payload == {"text": "hello"}
+    assert event.record_source == "user"
+    assert event.attributes == {"text": "hello"}
 
 
 async def test_record_ingest_rejects_without_permission():

--- a/services/runner/src/sessions/persist.ts
+++ b/services/runner/src/sessions/persist.ts
@@ -54,10 +54,11 @@ async function postEvent(
         },
         body: JSON.stringify({
           session_id: sessionId,
-          event_index: eventIndex,
-          sender,
-          session_update: event.type,
-          payload: event,
+          record_index: eventIndex,
+          timestamp: new Date().toISOString(),
+          record_source: sender,
+          record_type: event.type,
+          attributes: event,
         }),
       });
       if (!res.ok) throw new Error(`HTTP ${res.status}`);
@@ -108,8 +109,8 @@ export async function drainPersist(sessionId: string): Promise<void> {
 
 /**
  * Build an emitter that persists every event via the ingest chain AND calls the
- * original emitter (for live streaming). Returns a stateful counter so event_index
- * increments monotonically per session.
+ * original emitter (for live streaming). Returns a stateful counter so record_index
+ * increments monotonically per session (a stable ordinal; the DB orders by record_id).
  *
  * The `stripReplay` filter coalesces the delta family (message_start / message_delta
  * / message_end) into a single `message` event for storage; the raw deltas are

--- a/services/runner/tests/unit/session-persist.test.ts
+++ b/services/runner/tests/unit/session-persist.test.ts
@@ -51,8 +51,8 @@ describe("buildPersistingEmitter", () => {
     assert.deepEqual(live[0], { type: "message", text: "hello" });
     assert.equal(postedBodies.length, 1);
     const body = postedBodies[0] as Record<string, unknown>;
-    assert.equal(body["session_update"], "message");
-    assert.equal(body["event_index"], 0);
+    assert.equal(body["record_type"], "message");
+    assert.equal(body["record_index"], 0);
   });
 
   it("coalesces message_start/delta/end into a single persisted message", async () => {
@@ -74,7 +74,7 @@ describe("buildPersistingEmitter", () => {
     // Persist sees only one coalesced message.
     assert.equal(postedBodies.length, 1);
     const body = postedBodies[0] as Record<string, unknown>;
-    const payload = body["payload"] as Record<string, unknown>;
+    const payload = body["attributes"] as Record<string, unknown>;
     assert.equal(payload["type"], "message");
     assert.equal(payload["text"], "hello");
   });
@@ -88,12 +88,12 @@ describe("buildPersistingEmitter", () => {
 
     assert.equal(postedBodies.length, 2);
     const types = (postedBodies as Array<Record<string, unknown>>).map(
-      (b) => (b["payload"] as Record<string, unknown>)["type"],
+      (b) => (b["attributes"] as Record<string, unknown>)["type"],
     );
     assert.deepEqual(types, ["tool_call", "done"]);
   });
 
-  it("event_index increments monotonically across events", async () => {
+  it("record_index increments monotonically across events", async () => {
     const { emit, flush } = buildPersistingEmitter("sess-4", () => "Secret t");
 
     emit({ type: "message", text: "a" });
@@ -102,7 +102,7 @@ describe("buildPersistingEmitter", () => {
     await flush();
 
     const indices = (postedBodies as Array<Record<string, unknown>>).map(
-      (b) => b["event_index"],
+      (b) => b["record_index"],
     );
     assert.deepEqual(indices, [0, 1, 2]);
   });

--- a/web/oss/src/components/SessionInspector/tabs/RecordsTab.tsx
+++ b/web/oss/src/components/SessionInspector/tabs/RecordsTab.tsx
@@ -31,19 +31,17 @@ const RecordsTab = ({sessionId}: {sessionId: string}) => {
             <Collapse
                 size="small"
                 items={records.map((event) => ({
-                    key: event.id,
+                    key: event.record_id,
                     label: (
                         <span className="flex items-center gap-2">
-                            <Tag>{event.event_index ?? "—"}</Tag>
-                            <span>{event.sender ?? "event"}</span>
-                            {event.session_update ? (
-                                <Tag color="blue">{event.session_update}</Tag>
-                            ) : null}
+                            <Tag>{event.record_index ?? "—"}</Tag>
+                            <span>{event.record_source ?? "record"}</span>
+                            {event.record_type ? <Tag color="blue">{event.record_type}</Tag> : null}
                         </span>
                     ),
                     children: (
                         <pre className="m-0 max-h-[40vh] overflow-auto text-xs">
-                            {JSON.stringify(event.payload ?? {}, null, 2)}
+                            {JSON.stringify(event.attributes ?? {}, null, 2)}
                         </pre>
                     ),
                 }))}


### PR DESCRIPTION
## Context

The sessions entities added since the big-agents fork (records, interactions, streams, states, mounts) drifted from the codebase's DBE/DBA/DTO conventions. Records used an upstream-style `id` PK with a UUID `session_id` and an ad-hoc `payload`/`sender`/`session_update` body; interactions and streams stored their FSM state as a nested `{code, message}` JSONB blob instead of the root enum column the rest of the platform uses (eval-runs, tracing); several entities were missing the standard `flags`/`tags`/`meta` trio. This is Part II of the big-agents platform cleanup and aligns those tables before the branch merges up.

## Changes

**Records realigned to the tracing shape.** `id` becomes `record_id` (DB-minted uuid7, still time-ordered so it doubles as the ordering key), `session_id` becomes a `String` to match the rest of sessions, and the body columns move to the tracing vocabulary.

Before:
```
id (UUID PK) · session_id (UUID) · event_index · sender · session_update · payload (JSONB)
```

After:
```
record_id (uuid7 PK) · session_id (String) · record_index · timestamp · record_type · record_source · attributes (JSONB)
```

`record_index` is the producer-stamped per-session ordinal (kept, not the ordering key), and `timestamp` is the runner event time, distinct from `created_at` (ingest time). The rename flows end to end: FastAPI ingest model and router, the runner `persist.ts` wire body, and the frontend `RecordsTab`.

**FSM status is now a root enum column, not nested JSONB.** Interactions and streams drop the `{code, message}` blob for a plain `status` VARCHAR holding a str-enum value, matching eval-runs and tracing. The stream enum is renamed `StreamStatusCode` to `SessionStreamStatus` (the `<Domain>Status` convention, mirroring `SessionInteractionStatus`), and the write-only `status_message` (only ever set by the orphan sweep, never read) is dropped.

Before (streams):
```
status: SessionStreamStatus = { code: "running", message: null }   # nested JSONB
```

After:
```
status: Optional[SessionStreamStatus] = "running"                  # root enum column
```

**Standard trio backfilled.** States and mounts gain `flags`/`tags`/`meta`; interactions and streams gain `tags`/`meta` plus a base/query flags split (materialized `bool=False` on write, three-valued `Optional[bool]` for JSONB-containment queries), and streams/interactions redundant indexes are cleaned up.

**Migrations.** Every entity above was created in big-agents, so its initial migration is edited in place rather than stacked with a fix-up revision (there is no released history to preserve): `oss000000002` (records), `oss000000006` (mounts), `oss000000007` (states), `oss000000008` (streams), `oss000000009` (interactions). The one genuinely additive migration is `oss000000010`, which backfills `is_agent`/`is_skill` onto `workflow_revisions` (a pre-big-agents table) using the set-based `jsonb ||`/`CASE` idiom from `oss000000004`, with a symmetric downgrade that strips only the keys it added. Server-owned `is_static` is slug-derived and excluded.

## Tests / notes

- `py-run-tests --api`: 1425 unit pass; acceptance green after fixing the three stale sessions tests (interactions dispatcher and record-ingest built the old shapes) and two mounts-injection assertions that predated the `[<namespace>/]mounts/<project_id>/<mount_id>` store-key prefix.
- `py-run-tests --sdk` and `--services`: green.
- Reviewers should watch the in-place migration edits: they are correct only because these tables have no released history on `main`. The `workflow_revisions` backfill is the only one that must remain a separate revision.
