### PR TITLE
fix(frontend): keep agent chat mounted across revision switches

### DIFF
--- a/web/oss/src/components/AgentChatSlice/AgentChatPanel.tsx
+++ b/web/oss/src/components/AgentChatSlice/AgentChatPanel.tsx
@@ -228,6 +228,14 @@ const AgentConversation = ({entityId, sessionId}: {entityId: string; sessionId: 
     // Teardown for the in-flight smooth scroll (removes its listeners + fallback timer).
     const pinCleanupRef = useRef<(() => void) | null>(null)
 
+    // `useChat` pins its `Chat` (and thus this transport) for the life of the session `id`; it is
+    // NOT recreated when `entityId` changes (only on an `id` change). So the request builder must
+    // read the CURRENT entity through a ref — capturing `entityId` by value would send every turn
+    // with the revision that was displayed when the session first mounted, even after a switch or a
+    // self-commit. Reading `entityIdRef.current` at send time keeps runs on the live revision.
+    const entityIdRef = useRef(entityId)
+    entityIdRef.current = entityId
+
     // Transport feeds the v6 stream request from the playground pipeline. `api` here is a
     // placeholder that `prepareSendMessagesRequest` overrides per request.
     const transport = useMemo(
@@ -235,7 +243,7 @@ const AgentConversation = ({entityId, sessionId}: {entityId: string; sessionId: 
             new AgentChatTransport({
                 api: "",
                 prepareSendMessagesRequest: async ({messages, id}) => {
-                    const req = await buildAgentRequest(entityId, messages, {
+                    const req = await buildAgentRequest(entityIdRef.current, messages, {
                         sessionId: id ?? sessionId,
                     })
                     if (!req) {
@@ -246,7 +254,7 @@ const AgentConversation = ({entityId, sessionId}: {entityId: string; sessionId: 
                     return {api: req.invocationUrl, headers: req.headers, body: req.requestBody}
                 },
             }),
-        [entityId, sessionId],
+        [sessionId],
     )
 
     const {

--- a/web/oss/src/components/Playground/Components/MainLayout/index.tsx
+++ b/web/oss/src/components/Playground/Components/MainLayout/index.tsx
@@ -1,5 +1,6 @@
-import {memo, useCallback, useRef, type ReactNode} from "react"
+import {memo, useCallback, useMemo, useRef, type ReactNode} from "react"
 
+import {workflowMolecule} from "@agenta/entities/workflow"
 import type {ConfigViewMode} from "@agenta/entity-ui"
 import {
     executionController,
@@ -127,6 +128,33 @@ const PlaygroundMainView = ({
 
     // Which entity IDs to render config panels for
     const configEntityIds = configEntityIdsOverride ?? layoutEntityIds
+
+    // ── Agent generation host: keep a stable key across revision switches ──
+    // The agent chat surface lives inside the generation panel below. Keying that panel by the
+    // revision id (`variantId`) tears the whole conversation down on every revision switch —
+    // whether the agent self-commits a new revision or the user picks one in the config header —
+    // which aborts the live stream ("connection lost") and drops the still-streaming turn
+    // (persistence is skipped mid-stream). Agents are single-entity (excluded from comparison),
+    // so we give the single-agent generation panel a stable key; a switch then flows through as an
+    // `entityId` prop update, not a remount, and the conversation (app/session-scoped) survives.
+    // A freshly committed revision's flags load a beat after the swap (workflowType falls back to
+    // "completion" until then), so we LATCH the agent host across that gap and only drop it once
+    // the single entity has loaded as a definitively non-agent workflow.
+    const singleEntityId =
+        !isComparisonView && layoutEntityIds.length === 1 ? layoutEntityIds[0]! : ""
+    const isSingleAgentEntity = useAtomValue(isAgentModeAtomFamily(singleEntityId))
+    const singleEntityQuery = useAtomValue(
+        useMemo(() => workflowMolecule.selectors.query(singleEntityId), [singleEntityId]),
+    )
+    const agentHostRef = useRef(false)
+    if (!singleEntityId) {
+        agentHostRef.current = false
+    } else if (isSingleAgentEntity) {
+        agentHostRef.current = true
+    } else if (!singleEntityQuery.isPending) {
+        agentHostRef.current = false
+    }
+    const renderAgentGenerationHost = agentHostRef.current
 
     // The agent config panel is a compact read-only summary (editing happens in section drawers), so
     // it stays narrow (550px) instead of the prompt config's 50/50 split. The default is a fixed px
@@ -336,8 +364,22 @@ const PlaygroundMainView = ({
                             ) : isComparisonView && hasDisplayedEntities ? (
                                 <GenerationComparisonRenderer />
                             ) : (
-                                layoutEntityIds.map((variantId) =>
-                                    displayedEntities.includes(variantId) || isEvaluatorMode ? (
+                                layoutEntityIds.map((variantId) => {
+                                    // Single-agent view: a stable key so a revision switch updates
+                                    // the entityId prop instead of remounting the live conversation.
+                                    // Rendered unconditionally (not gated on `displayedEntities`) so
+                                    // it can't blink to the placeholder during the atomic id swap.
+                                    if (renderAgentGenerationHost) {
+                                        return (
+                                            <ExecutionItems
+                                                key="agent-generation-host"
+                                                entityId={variantId}
+                                                renderTestsetActions={renderTestsetActions}
+                                            />
+                                        )
+                                    }
+                                    return displayedEntities.includes(variantId) ||
+                                        isEvaluatorMode ? (
                                         <ExecutionItems
                                             key={variantId}
                                             entityId={variantId}
@@ -347,8 +389,8 @@ const PlaygroundMainView = ({
                                         <GenerationPanelPlaceholder
                                             key={`generation-placeholder-${variantId}`}
                                         />
-                                    ),
-                                )
+                                    )
+                                })
                             )}
                         </section>
                     </SplitterPanel>

--- a/web/packages/agenta-playground-ui/src/components/ExecutionItems/index.tsx
+++ b/web/packages/agenta-playground-ui/src/components/ExecutionItems/index.tsx
@@ -67,13 +67,11 @@ const PlaygroundGenerations: React.FC<PlaygroundGenerationsProps> = ({
         agentSurfaceRef.current = false
     }
     if (agentSurfaceRef.current && AgentGenerationPanel) {
+        // No ExecutionHeader: it self-nulls for agents (`if (isAgent) return null`), but during the
+        // switch load gap `isAgent` is momentarily false, so rendering it would flash the non-agent
+        // header + register the run-all shortcut over the agent chat. Agents own their composer.
         return (
             <div className="flex h-full min-h-0 w-full flex-col">
-                <ExecutionHeader
-                    entityId={entityId}
-                    renderTestsetActions={renderTestsetActions}
-                    onRepeatCountChange={onRepeatCountChange}
-                />
                 <div className="min-h-0 flex-1">
                     <AgentGenerationPanel entityId={entityId} />
                 </div>

--- a/web/packages/agenta-playground-ui/src/components/ExecutionItems/index.tsx
+++ b/web/packages/agenta-playground-ui/src/components/ExecutionItems/index.tsx
@@ -1,4 +1,4 @@
-import {useMemo} from "react"
+import {useMemo, useRef} from "react"
 
 import {workflowMolecule} from "@agenta/entities/workflow"
 import {executionController} from "@agenta/playground"
@@ -51,6 +51,35 @@ const PlaygroundGenerations: React.FC<PlaygroundGenerationsProps> = ({
     // Agent surface is injected from OSS (package can't import the app layer).
     const AgentGenerationPanel = usePlaygroundUIOptional()?.AgentGenerationPanel
     const isExecutionLoading = runnableQuery.isPending || isChat === undefined
+
+    // Latch the agent surface so a revision switch never unmounts the live chat conversation.
+    // A switch (self-commit or the config-header picker) points `entityId` at a new revision whose
+    // flags load a beat later — `isAgent` flips false and the query goes pending, which would drop
+    // this panel to the skeleton and tear down the agent chat (aborting the live stream, losing the
+    // in-progress turn). Once an agent, we keep rendering the agent panel across that load gap so
+    // the switch is just an `entityId` prop update; we only release the latch when the entity has
+    // loaded as a definitively non-agent workflow. (Paired with the stable key in MainLayout, which
+    // keeps THIS component mounted so the latch survives the switch.)
+    const agentSurfaceRef = useRef(false)
+    if (isAgent) {
+        agentSurfaceRef.current = true
+    } else if (!runnableQuery.isPending) {
+        agentSurfaceRef.current = false
+    }
+    if (agentSurfaceRef.current && AgentGenerationPanel) {
+        return (
+            <div className="flex h-full min-h-0 w-full flex-col">
+                <ExecutionHeader
+                    entityId={entityId}
+                    renderTestsetActions={renderTestsetActions}
+                    onRepeatCountChange={onRepeatCountChange}
+                />
+                <div className="min-h-0 flex-1">
+                    <AgentGenerationPanel entityId={entityId} />
+                </div>
+            </div>
+        )
+    }
 
     if (isExecutionLoading) {
         return (


### PR DESCRIPTION
## Problem

In the agent playground, switching the displayed revision — the agent **self-committing** a new revision, or the user **picking one in the config header** — caused two symptoms at once:

- the chat transcript for the in-flight turn **disappeared**, and
- the chat showed **"connection lost"**.

Both are one root cause. The conversation lives inside a generation subtree keyed by the revision id (`<ExecutionItems key={variantId}>` in `MainLayout` → `AgentChatPanel` → `useChat`). A revision switch changes that key and **remounts the whole conversation**:

- on unmount, the D9 teardown aborts the in-flight stream → "connection lost";
- on remount, `useChat` re-seeds messages from localStorage, which **omits the still-streaming turn** (persistence is deliberately skipped mid-stream) → the transcript vanishes.

A one-line "defer the switch" isn't enough: the manual picker remounts the same way, and even keeping `ExecutionItems` mounted isn't sufficient because `ExecutionItems` itself drops to its loading skeleton / swaps render modes during the fresh-revision load gap.

## Fix

Decouple the conversation's **mount identity** from the revision id at the two layers that tear it down:

1. **`MainLayout`** — give the single-agent generation panel a **stable key** instead of `variantId`, so a switch flows through as an `entityId` **prop update**, not a remount. (Agents are single-entity; they're excluded from comparison.)
2. **`ExecutionItems`** — **latch the agent surface** so it keeps rendering across the fresh-revision load gap (where flags load a beat late: `isAgent` flips false and the query goes pending) instead of unmounting the chat to show the skeleton.

Both use a flip-proof latch keyed on the workflow query's pending state, released only once the entity has loaded as a **definitively non-agent** workflow (`isPending === false ⟺ flags loaded ⟺ agent-ness is accurate`).

### Follow-up: keep new turns on the live revision

Removing the remount exposed a second issue in the **request chain**. `useChat` pins its `Chat` (and the transport it holds) for the life of the session `id` and does **not** recreate it when `entityId` changes. The transport's `prepareSendMessagesRequest` captured `entityId` by value, and `buildAgentRequest` reads the config/`references` from whatever id it's given — so without a remount, every subsequent turn would have gone out with the config of the revision displayed when the session first mounted. Fixed by reading `entityId` through a ref in the request builder, so each send resolves the **currently displayed** revision (restoring the pre-fix "next turn uses the new revision" behavior, without the stream-resetting remount).

Net effect: `sessionId` never changes across a revision switch, so `useChat` keeps its live stream and messages — no abort, no re-seed — **and** new turns still run against the live revision's config.

## Scope / blast radius

- **FE-only.** The conversation is already app/session-scoped in localStorage; **no backend/SDK/service change** and no move toward server-side sessions (not used in the first release).
- Non-agent **chat / completion / comparison** and the **create/edit drawer** fall through to the identical original code paths (both keying changes are gated on agent-ness).

## Testing

Verified live against a running `big-agents` EE-dev stack:

- ✅ Manual picker switch **while streaming** → stream completes, transcript intact, no error.
- ✅ Manual picker switch **idle** → transcript persists, no reconnect.
- ✅ UI **Commit** (creates + switches revision) with a settled transcript → transcript persists.
- ✅ **Agent self-commit mid-stream** (the original repro) → streaming turn survives, config refreshes to the new revision.

Also: `tsc` clean on all touched files, ESLint + prettier clean.

**Recommended extra QA for the follow-up:** after switching revisions mid-conversation, send a new message and confirm the outgoing request body carries the **newly selected** revision's config/`references` (inspect the network request) — the visual checks above don't cover which revision the *next* turn runs against.
