### PR TITLE
feat(sdk): add annotate_trace platform-op

### DIFF
--- a/docs/design/agent-workflows/projects/builder-agent-reliability/annotate-op/README.md
+++ b/docs/design/agent-workflows/projects/builder-agent-reliability/annotate-op/README.md
@@ -1,0 +1,43 @@
+# `annotate_trace` platform-op
+
+A design-only workspace for one catalog op that lets a self-reflecting agent grade its own
+run. After a conversation, the agent writes a short reflection back onto the trace it just
+produced, and that reflection surfaces in the annotation and evaluation views like any other
+annotation. This is use case 3 of [builder-agent-reliability](../README.md).
+
+The plumbing already exists (`POST /api/annotations/`, plus the run's own trace bindable via
+`$ctx.trace.*`). The design work is one hard question the naive cut skipped: an annotation must
+reference an evaluator, and the evaluator decides whether the agent's reflection is even
+accepted. This workspace resolves where the evaluator comes from, then locks the self-target
+around that answer.
+
+## Files
+
+- [context.md](context.md), why this exists, the case-3 self-reflection use case, goals and
+  non-goals, and the background (no agent-callable annotate op existed).
+- [research.md](research.md), the read-only trace: the evaluator investigation (the
+  project-seeded `quality-rating` default and why its rigid schema cannot hold reflection), how
+  the annotations API validates payloads against the evaluator schema, the runner's advisory
+  arg validation (`relay.ts:211`), and the two self-target smuggle routes. With file/line
+  citations.
+- [plan.md](plan.md), the chosen design: one reserved self-reflection evaluator with a
+  structured schema, seeded per project and backfilled by migration, bound server-side;
+  airtight self-targeting by clearing and refilling the whole `links` and `references` subtrees;
+  the op shape, the permission default, and the phases.
+- [status.md](status.md), current state (design under review on PR #4999) and the one remaining
+  open question.
+
+## TL;DR
+
+- **The op:** `annotate_trace` wraps `POST /api/annotations/`. The model supplies only
+  `data.outputs` (the reflection content). The server binds the trace and the evaluator.
+- **The evaluator:** one reserved `agent-self-reflection` evaluator with a small structured
+  schema (a `reflection` string, a binary `score` to filter runs by success, and an open `meta`
+  object for extras), seeded on project creation like `quality-rating` plus a backfill migration
+  for existing projects, bound server-side. The model never names it. `reflection` and `score`
+  render in the annotation UI; `meta` is stored but not drawn as a form control.
+- **The self-target:** the server clears and refills the whole `links` and `references` subtrees
+  (delete then set), so a smuggled sibling `links` key or a `references.evaluator.id` cannot
+  retarget another trace or evaluator. The runner does not validate model args, so the closed
+  schema alone is only advisory.
+- **Permission:** `allow`, no approval. Additive self-metadata on the agent's own trace.

--- a/docs/design/agent-workflows/projects/builder-agent-reliability/annotate-op/context.md
+++ b/docs/design/agent-workflows/projects/builder-agent-reliability/annotate-op/context.md
@@ -1,0 +1,64 @@
+# Context
+
+Date: 2026-07-01
+Area: SDK op catalog (`sdks/python/agenta/sdk/agents/platform/op_catalog.py`), with a small
+API-side dependency (a reserved evaluator).
+
+## Why this work exists
+
+We want a running agent to grade its own run. This is use case 3 of
+[`builder-agent-reliability`](../README.md): the self-reflecting agent.
+
+After a conversation, the agent should write a short evaluation back onto the trace it just
+produced: what went right, what went wrong, what it learned, and a score. The platform's
+annotation and evaluation views then read that reflection like any other annotation. The
+agent grades itself, and the grade shows up next to human grades on the same trace.
+
+## The use case (case 3)
+
+The prompt: a self-reflecting agent that, after each conversation, reflects on how it did and
+records that reflection on its own trace. Each reflection carries a short write-up, a
+good-or-bad judgment, and whatever extra structured detail the run wants to attach. The write-up
+and judgment are the same fields every time; the extras vary run to run. One run might note
+`{"reflection": "answered in one turn", "score": "good", "meta": {"turns": 1}}`; the next might
+note `{"reflection": "user rephrased twice", "score": "bad", "meta": {"retries": 2}}`.
+
+For that to work, the agent needs a tool it can call at the end of a turn that says "annotate
+my current run's trace with this reflection." The tool must always target the agent's own
+trace, never another one, and it must accept the varying extras without the second call failing.
+
+## Background: what already existed, and what did not
+
+The plumbing was already there. The pieces are:
+
+- The annotations REST API (`POST /api/annotations/`) is production-grade. It creates an
+  annotation trace that links to the trace it annotates.
+- The run's own `trace_id` and `span_id` are captured per run in `RunContextTrace` and are
+  bindable through `$ctx.trace.*`. So a tool can target "my own trace" without the model ever
+  seeing or choosing a trace id.
+
+The missing piece was the tool itself. There was **no agent-callable annotate op**. The
+platform-op catalog (`PLATFORM_OPS`) shipped 19 ops (`find_capabilities`, `query_workflows`,
+`commit_revision`, the trigger and subscription ops), and none of them annotate a trace. No
+builtin, gateway, or MCP tool did either. A self-reflecting agent had the plumbing under it
+but no way to reach it.
+
+The gap was known and documented as a porting recommendation in `build-notes.md` (case 3),
+not a hack. This project designs the op that closes it.
+
+## Goals
+
+- Add one catalog op, `annotate_trace`, that lets an agent record a structured reflection on
+  its own current run's trace.
+- Make the self-target airtight. The agent can only ever annotate its own trace, under one
+  known evaluator, and can influence only the reflection content.
+- Accept a stable reflection shape (write-up, judgment) with open extras that vary run to run,
+  without the second call failing.
+
+## Non-goals
+
+- Annotating another agent's trace, or an arbitrary trace by id. The op is self-only.
+- A general annotation API for the model (arbitrary evaluators, arbitrary links). The model
+  supplies content only.
+- Aggregation or scoring UI. The reflection surfaces through the existing annotation and
+  evaluation views with no new UI.

--- a/docs/design/agent-workflows/projects/builder-agent-reliability/annotate-op/plan.md
+++ b/docs/design/agent-workflows/projects/builder-agent-reliability/annotate-op/plan.md
@@ -1,0 +1,282 @@
+# Plan
+
+Date: 2026-07-01
+
+The design for the `annotate_trace` platform-op. The findings behind each choice are in
+[research.md](research.md).
+
+## The shape of the design
+
+The agent supplies the reflection content and nothing else. The server owns both target
+selectors: which trace, and which evaluator. The agent can never retarget either.
+
+Three moving parts:
+
+1. One reserved evaluator with a small structured schema (a `reflection` string, a binary
+   `score`, and an open `meta` object), seeded per project and bound server-side. The model
+   never names it.
+2. Server-owned replacement of the `links` and `references` subtrees (clear the whole subtree,
+   then refill from context), so the self-target is airtight even though the runner does not
+   validate model args.
+3. The op itself in `PLATFORM_OPS`, permission `allow`.
+
+## 1. One reserved self-reflection evaluator
+
+An annotation must reference an evaluator, and the evaluator decides whether the reflection is
+even accepted (see research.md). The project default `quality-rating` cannot hold a reflection:
+its schema is a rigid `{approved: boolean}` with `additionalProperties: false`. And letting the
+model name a fresh slug per call creates evaluator sprawl and a `genson`-locked schema that
+rejects the second write once the keys change.
+
+So we reserve **one** well-known evaluator for agent self-reflection, slug
+`agent-self-reflection`, and follow the pattern the platform already uses for `quality-rating`:
+a fixed slug, a known schema, seeded and resolved the same way for every project.
+
+**The schema is structured, not a free-for-all.** A fully open `{outputs: object}` would accept
+anything but read as an opaque blob in the UI and give nothing to filter on. Instead the
+reflection has three fields: a `reflection` string, a binary `score` so runs can be filtered by
+success, and an open `meta` object for whatever structured extras a run wants to attach. This
+is the reflection content, what the model puts under `data.outputs`:
+
+```json
+{
+  "reflection": "user got the answer in one turn; tone was a little terse",
+  "score": "good",
+  "meta": { "turns": 1, "tools_used": ["search"] }
+}
+```
+
+The reserved evaluator's stored `data.schemas.outputs` (the JSON Schema that content is
+validated against, `sdks/python/agenta/sdk/models/workflows.py:62-165`, any valid JSON Schema
+per `check_schema`):
+
+```json
+{
+  "$schema": "https://json-schema.org/draft/2020-12/schema",
+  "type": "object",
+  "properties": {
+    "reflection": { "type": "string" },
+    "score": { "type": "string", "enum": ["good", "bad"] },
+    "meta": { "type": "object" }
+  },
+  "required": ["reflection", "score"],
+  "additionalProperties": false
+}
+```
+
+`meta` is the open extension point, so `additionalProperties: false` at the top level never
+rejects a well-formed reflection: fixed content goes in the named fields, everything else goes
+in `meta`. The keys are fixed, so there is no `genson`-lock and the second write always
+validates.
+
+**Verified against the annotation UI** (`transforms.ts:32-149`, `AnnotationInputs.tsx:341-453`,
+render check done for this design):
+
+- `reflection` (string) renders as a text field.
+- `score` renders as a control. The two-value `enum` renders as a select; a plain `boolean`
+  (`true`/`false`) is the more battle-tested control, since that is exactly how `quality-rating`
+  renders today. Either is fine; the enum reads as "good/bad", boolean reads as "True/False".
+- `meta` (an **open** object) is stored and enforced server-side but is **not** shown as an
+  editable control in the annotation form. The form renderer only draws a fixed set of scalar
+  types (`USEABLE_METRIC_TYPES`, `constants.ts:2-10`) and drops open objects. That is acceptable
+  here: `meta` is an overflow bucket for machine extras, not a field a human grades. If we ever
+  want `meta` visible and editable, give it fixed sub-properties (they flatten to `meta.<field>`
+  controls) or store it as a JSON string.
+
+**The agent never chooses or names the evaluator.** The op binds this reserved slug the same
+way it binds the trace id: server-side, hidden from the model. No sprawl, no schema drift, and
+every reflection lands under one recognizable evaluator in the annotation UI.
+
+### How the reserved evaluator is materialized: seed it, exactly like `quality-rating`
+
+The reserved evaluator is a normal seeded default with a fixed slug. There is no separate
+"reserved" evaluator machinery; `quality-rating` already is one, and we mirror it end to end.
+
+1. **Define the preset.** Add an `agent-self-reflection` preset next to the `quality-rating`
+   preset on the `agenta:custom:feedback:v0` catalog entry
+   (`sdks/python/agenta/sdk/engines/running/utils.py:138-158`), carrying the structured outputs
+   schema from §1.
+2. **Seed it on project creation.** Add one entry to `_DEFAULT_EVALUATORS`
+   (`api/oss/src/core/evaluators/defaults.py:62-81`), the same shape as the `quality-rating`
+   entry:
+
+   ```python
+   {
+       "template_key": "feedback",
+       "preset_key": "agent-self-reflection",
+       "slug": "agent-self-reflection",
+       "name": "Agent Self-Reflection",
+   }
+   ```
+
+   `create_default_evaluators` runs at project creation
+   (`api/oss/src/core/accounts/service.py:749-757`, gated on `seed_defaults`, default `True` at
+   `dtos.py:56`) and is idempotent (it swallows `EntityCreationConflict`). New projects get the
+   evaluator for free.
+3. **Backfill existing projects with a migration.** Seeding only helps *new* projects. Note
+   that `quality-rating` itself has **no** backfill migration; it was only ever seeded at
+   creation, so projects that predate it never got it. We do better here and ship a one-time
+   backfill that seeds `agent-self-reflection` into every existing project. There is no
+   evaluator backfill to copy, so mirror the closest existing pattern: the default-environments
+   backfill, which seeds a per-project entity idempotently
+   (`api/oss/databases/postgres/migrations/core/versions/c2d3e4f5a6b7_create_default_environments_for_projects_without_environments.py`
+   and its data migration
+   `api/oss/databases/postgres/migrations/core/data_migrations/default_environments.py`). That
+   migration paginates over projects *missing* the entity, resolves each project's owner from
+   `OrganizationDB.owner_id`, and does an idempotent get-or-create. Our backfill does the same:
+   find projects with no `agent-self-reflection` evaluator, resolve the owner, and call the same
+   seeding path (guarded by `EntityCreationConflict`), so it is safe to re-run.
+
+We do **not** auto-create the evaluator at annotation time. An annotation that targets a
+missing evaluator will fail, which is the correct signal: the project is missing its seed, and
+the fix is to run the backfill, not to silently mint a per-call evaluator (which is how the
+current draft locks a `genson`-inferred schema on the first write; see research.md).
+
+### Fallback for the agent when the evaluator is missing
+
+Belt-and-suspenders, on the agent side rather than the server side: the build-agent skill
+should carry a short troubleshooting resource. If an `annotate_trace` call errors because the
+`agent-self-reflection` evaluator does not exist (an un-backfilled or `seed_defaults=False`
+project), the skill tells the agent how to create it: `POST` the evaluator with slug
+`agent-self-reflection` and the exact outputs schema from §1, then retry the annotation. This
+keeps the server path simple (seed + migration only) while giving a self-hosting agent a
+documented recovery step. The skill edit is separate work, tracked as a note here, not part of
+this op's contract.
+
+## 2. Why the agent can only ever annotate its own trace
+
+The whole point of this op is self-reflection, so it must be impossible for an agent to
+annotate anything but the run it is in. An annotation carries a `links` field that says which
+trace and span it is attached to. If the model could set that field, it could attach its
+"reflection" to some other run in the same project. That is the hole to close.
+
+**How the target is supposed to be set.** The model never types a trace id. When the op runs,
+the runner already knows the run's own trace and span from its context, and it fills them into
+the request for the model. The request that reaches the annotations API looks like this:
+
+```json
+{
+  "annotation": {
+    "data": { "outputs": { "reflection": "...", "score": "good", "meta": {} } },
+    "links": { "invocation": { "trace_id": "<this run's own>", "span_id": "<this run's own>" } },
+    "references": { "evaluator": { "slug": "agent-self-reflection" } }
+  }
+}
+```
+
+Only `data.outputs` comes from the model. The runner fills `links` (which trace) and
+`references` (which evaluator) from context. The model does not see either field.
+
+**Why it is not airtight today.** The way the runner fills those fields is by writing two exact
+paths, `links.invocation.trace_id` and `links.invocation.span_id`. It writes over just those
+two leaves. Anything else the model put under `links` is left alone. So a model can smuggle a
+second entry next to `invocation`:
+
+```json
+"links": { "invocation": {}, "evil": { "trace_id": "<another run's id>" } }
+```
+
+The runner overwrites `invocation`, but `evil` rides along untouched, and the annotation ends
+up attached to that other run too. We proved this live: a crafted `links` sibling key lands the
+reflection on a different trace in the same project. The runner does not check the model's
+arguments against the op's schema before it builds the request (`relay.ts:211`), so the "no
+extra fields" rule on the schema is only a suggestion, not a guard. The self-target is not
+enforced.
+
+**The fix: clear the whole subtree, then refill.** Give the runner one small primitive: before
+it writes the trusted values, it deletes the entire `links` object the model sent, then writes
+back only the two bound leaves from context. Nothing the model put under `links` survives,
+because the whole subtree is wiped first. The result is always exactly:
+
+```json
+"links": { "invocation": { "trace_id": "<this run's own>", "span_id": "<this run's own>" } }
+```
+
+No sibling key, no list form, no extra fields can get through, because the refill starts from
+an empty subtree every time.
+
+The evaluator reference gets the same treatment. `references` is cleared and then set to the
+one reserved evaluator slug (a constant), so a model cannot slip in a `references.evaluator.id`
+that points at a different evaluator. See §1 for why the evaluator is a fixed, server-owned
+choice.
+
+With both subtrees cleared-then-refilled, the guarantee holds without trusting the model to
+behave: the agent supplies only the reflection content, and the reflection always lands on its
+own trace, under the one reserved evaluator.
+
+## 3. The op shape
+
+The op wraps `POST /api/annotations/` with `args_into="annotation"`. The model supplies only
+the reflection content. Both target selectors are server-owned.
+
+What the agent supplies (the entire model-visible schema):
+
+- `data.outputs`, the reflection content, shaped by the reserved evaluator schema from §1: a
+  `reflection` string, a binary `score`, and an open `meta` object for extras.
+
+What the server binds, hidden from the model:
+
+- `annotation.links`, the whole subtree, resolved from `$ctx.trace.*` to the run's own
+  trace/span.
+- `annotation.references`, the whole subtree, set to the reserved evaluator slug (a constant).
+
+Resulting request body:
+
+```json
+{
+  "annotation": {
+    "data": { "outputs": { "reflection": "handled it in one turn", "score": "good", "meta": { "turns": 1 } } },
+    "references": { "evaluator": { "slug": "agent-self-reflection" } },
+    "links": { "invocation": { "trace_id": "<run's own>", "span_id": "<run's own>" } }
+  }
+}
+```
+
+The model never sees `references` or `links`.
+
+## Permission
+
+Default `allow` / no approval (`default_permission="allow"`,
+`default_needs_approval=False`).
+
+With a reserved, pre-existing evaluator there is no evaluator-creation side effect per call.
+The op writes additive self-metadata onto the agent's own trace and nothing else. Requiring
+approval on every self-reflection would defeat the autonomous use case. Authors can still
+override per config (`permission` / `needs_approval` on `PlatformToolConfig`).
+
+One residual risk: each call still writes an annotation trace, so a runaway loop could spam
+annotations on its own trace. That is a rate/idempotency concern, not a permission one (see the
+upsert-vs-append question in status.md).
+
+## Phases
+
+1. **Runner (TS).** Support subtree-level context bindings and constant-object bound values in
+   `direct.ts`/`relay.ts` (the clear-the-whole-subtree-then-refill primitive from §2). Add arg
+   stripping to the cataloged fields before assembly. Extend runner unit tests.
+2. **Reserved evaluator (API).** Add the `agent-self-reflection` preset and `_DEFAULT_EVALUATORS`
+   entry with the structured schema. Add the backfill migration for existing projects. No
+   auto-create at annotation time.
+3. **The op (SDK).** Add the `annotate_trace` `PlatformOp` to `PLATFORM_OPS` with the closed
+   `data.outputs`-only schema, `args_into="annotation"`, the two subtree bindings, and the
+   `allow` default. Overlay it in the build kit (no build-kit change needed beyond the catalog
+   entry).
+4. **Tests.** Unit for the op shape and the runner bindings; an acceptance test that two
+   reflections with different `meta` contents both validate against the fixed schema; a
+   self-target test that a smuggled sibling `links` key and a smuggled `references.evaluator.id`
+   are both dropped.
+
+## What PR #4999 must change
+
+The current draft (see research.md) diverges on the three points above, in order of
+importance:
+
+1. **Evaluator handling.** Stop letting the model invent evaluators; bind the one reserved
+   evaluator.
+2. **Self-target.** Replace the two leaf bindings with whole-subtree, server-owned replacement
+   of `links` and `references`.
+3. **Arg enforcement.** Pair the closed schema with runner-side arg stripping, since
+   `additionalProperties: false` is advisory.
+
+What the draft got right and this design keeps: wrapping `POST /api/annotations/` with
+`args_into="annotation"`, binding the run's own trace from `$ctx.trace.*`, the closed
+model-visible schema as the contract, the build-kit overlay, and the `allow` default.

--- a/docs/design/agent-workflows/projects/builder-agent-reliability/annotate-op/research.md
+++ b/docs/design/agent-workflows/projects/builder-agent-reliability/annotate-op/research.md
@@ -1,0 +1,197 @@
+# Research
+
+Date: 2026-07-01
+Source: [`../../../scratch/console/builder-kit/findings/annotation.md`](../../../scratch/console/builder-kit/findings/annotation.md)
+
+Read-only trace of the annotations path and the runner assembly path. This is where the hard
+part lives. The plumbing is easy. The evaluator is not.
+
+## What an annotation is
+
+An annotation is a special trace (a `SimpleTrace`) that links to the trace it annotates. Its
+create contract is `AnnotationCreate` (`api/oss/src/core/annotations/types.py:48`, a
+`SimpleTraceCreate`). It needs three things:
+
+- `data`, the annotation payload, by convention `{"outputs": {...}}` (the scores, labels,
+  notes being recorded).
+- `references.evaluator`, a required `Reference` to an evaluator
+  (`AnnotationReferences.evaluator` at `types.py:41`).
+- `links`, where the annotated trace/span is named, under the conventional key `invocation`:
+  `{"invocation": {"trace_id": "...", "span_id": "..."}}`.
+
+The API is `POST /api/annotations/`, handler `create_annotation`
+(`api/oss/src/apis/fastapi/annotations/router.py:102`), request wrapper
+`{"annotation": AnnotationCreate}`.
+
+The self-target plumbing is ready. `RunContextTrace`
+(`sdks/python/agenta/sdk/agents/dtos.py:440`) models `trace_id` + `span_id`. The service
+populates it per run from the active OTel span
+(`services/oss/src/agent/tracing.py:161`, `_run_context_trace()`). So `$ctx.trace.*` already
+resolves to the run's own trace/span end to end. Only the catalog entry was missing.
+
+## The load-bearing finding: the evaluator decides the schema
+
+The evaluator reference is not decoration. On create, the annotations service uses it to pick
+the **schema the annotation payload is validated against**
+(`api/oss/src/core/annotations/service.py:83-160`):
+
+1. It resolves the evaluator from `references.evaluator` (`retrieve_evaluator_revision`). A
+   slug that does not resolve returns `None` cleanly.
+2. If no evaluator exists for that reference, it **infers an outputs schema from the
+   annotation's own `data` with `genson`** and creates a "simple evaluator" for that slug
+   (`service.py:105-143`, URI `agenta:custom:feedback:v0`). This is the auto-create path.
+3. It then **validates** the annotation `data` against the evaluator's stored
+   `schemas.outputs` (`service.py:155`, `validate_data_against_schema`, a strict jsonschema
+   check that raises 422 on mismatch).
+
+So an evaluator is a **named, versioned schema** for the annotation payload, stored as a
+workflow artifact (`is_evaluator=True`). Two consequences follow, and both bite a naive op:
+
+- **The schema is inferred once and then locks the shape.** `genson` builds the schema from
+  the *first* write and marks every key it sees as `required`. A second write to the same slug
+  that omits a previously-seen key fails with a 422. Freeform reflection that varies its keys
+  breaks on the second call.
+- **A new slug per call creates a new evaluator per call.** The catalog fills with throwaway
+  evaluator artifacts, none sharing a schema, so nothing aggregates.
+
+## Is there a project default evaluator? Yes.
+
+Every project seeds three default evaluators at creation time
+(`api/oss/src/core/accounts/service.py:749-757` calls `create_default_evaluators` when
+`seed_defaults` is true; `seed_defaults` defaults to `True` at
+`api/oss/src/core/accounts/dtos.py:56`). The three are defined in
+`api/oss/src/core/evaluators/defaults.py:62-81`:
+
+- `exact-match` (auto)
+- `contains-json` (auto)
+- **`quality-rating`**, a human/feedback evaluator, built from the `quality-rating` preset on
+  the `agenta:custom:feedback:v0` catalog entry.
+
+So a default *feedback* evaluator does exist, per project, with a fixed, predictable slug. It
+is seeded, not auto-created, and the seed is idempotent (`create_default_evaluators` swallows
+`EntityCreationConflict`). Defaults are seeded at the **project** level only.
+
+One gap worth naming: seeding runs **only at project creation**, and there is **no backfill
+migration** that ever added `quality-rating` to projects that predate it. A grep of the
+migrations (`api/oss/databases/postgres/migrations/`) for `quality-rating` /
+`create_default_evaluators` / `agenta:custom:feedback` finds nothing; the evaluator migrations
+that exist only convert legacy evaluator rows to the new form. So mirroring `quality-rating`
+gets a new reserved evaluator into new projects but **not** existing ones. A reserved evaluator
+that must also reach old projects needs its own backfill, and there is a clean template to copy:
+the default-environments backfill
+(`.../migrations/core/versions/c2d3e4f5a6b7_create_default_environments_for_projects_without_environments.py`
+and `.../data_migrations/default_environments.py`) paginates over projects *missing* the
+entity, resolves each owner from `OrganizationDB.owner_id`, and does an idempotent
+get-or-create.
+
+## Can the default hold a reflection payload? No.
+
+The `quality-rating` preset carries this exact outputs schema
+(`sdks/python/agenta/sdk/engines/running/utils.py:147-155`, preset block `:138-158`):
+
+```json
+{
+  "$schema": "https://json-schema.org/draft/2020-12/schema",
+  "type": "object",
+  "properties": { "approved": { "type": "boolean" } },
+  "required": ["approved"],
+  "additionalProperties": false
+}
+```
+
+That is a thumbs up / thumbs down. It requires exactly one boolean `approved` and, because
+`additionalProperties` is false, **rejects everything else**. A reflection payload of
+`{"reflection": "...", "score": "good"}` fails validation against it. The default evaluator is
+real but the wrong shape for a self-reflection with more than one boolean.
+
+There is also a data-shape wrinkle: this preset schema describes `data` as `{approved}`
+directly, while the annotation convention wraps content in `data.outputs`. That mismatch is
+orthogonal to the op but is flagged in `status.md`.
+
+## What the annotation UI can render (constrains the schema)
+
+The annotation form draws a control per field in the evaluator's outputs schema, but only for a
+fixed set of scalar types. `transformMetadata` keeps only `USEABLE_METRIC_TYPES`
+(`web/oss/src/components/SharedDrawers/AnnotateDrawer/assets/constants.ts:2-10` =
+`number`/`integer`/`float`/`boolean`/`string`/`array`/`class`), and the field renderer
+(`.../AnnotateDrawer/assets/transforms.ts:32-149`,
+`.../EvalRunDetails/.../ScenarioAnnotationPanel/AnnotationInputs.tsx:341-453`) maps: `string` to
+a text field, `boolean` to a True/False radio (what `quality-rating` uses), `number` to a
+numeric input, and an `enum` to a select. An **open** `object` (no fixed `properties`) is
+**dropped** before rendering; a *closed* object with fixed properties flattens to `field.sub`
+leaf controls. So a structured schema of `string` + binary + open `object` renders the first two
+as controls and stores the `object` without drawing it. This is why the reserved evaluator uses
+`reflection` (string) and `score` (binary) as rendered fields and `meta` (open object) as a
+stored-only overflow bucket.
+
+## The runner does not validate model args (the gotcha)
+
+The runner assembles the request body in
+`services/agent/src/tools/direct.ts::assembleBody`: it deep-sets the model's args at the
+`args_into` path, deep-merges any static `call.body`, then for each context binding it deletes
+that exact path and deep-sets the resolved value.
+
+Crucially, **the runner does not validate the model's args against the op's `input_schema`
+before assembly.** Confirmed: `relay.ts:211` calls `assembleBody(spec.call, req.args,
+runContext)` with the raw args. So `additionalProperties: false` on the advertised schema is
+**advisory**. A model that returns extra keys keeps them in the body unless a binding
+overwrites that exact path.
+
+## The self-target smuggle routes
+
+A leaf-only self-target (binding just `links.invocation.trace_id` and `.span_id`) leaves two
+holes, because the runner overwrites only those two exact paths:
+
+- **Sibling link keys.** `links` is `Union[Dict[str, Link], List[Link]]`
+  (`api/oss/src/core/tracing/dtos.py:307`). A model that returns
+  `links: {"invocation": {...}, "evil": {"trace_id": "<someone else's>"}}` keeps the `evil`
+  sibling. The leaf bindings only overwrite `invocation.trace_id`/`.span_id`. The annotation
+  then links to a second, attacker-chosen trace and surfaces on **another** trace.
+- **Model-controlled references.** If the op lets the model touch `references`, a model can add
+  `references.evaluator.id` pointing at any evaluator in the project. Even a static `call.body`
+  that pins the slug deep-merges, so a sibling `id` survives and retargets the evaluator (and
+  its schema).
+
+Both routes route the annotation somewhere the agent should not reach. The fix (in
+[plan.md](plan.md)) is to server-own and *replace* the whole `links` and `references`
+subtrees, not merge them.
+
+## What PR #4999 ships today (the implementation-first cut)
+
+The draft on `feat/annotate-trace-op` took the naive path. It lets the model name a fresh
+`references.evaluator.slug` on every call (so a new slug auto-creates an evaluator, and its
+schema is genson-locked on the first write), binds only the two invocation leaf paths (so the
+sibling-`links` smuggle is open), and leaves `references` model-controlled. It relies on the
+advisory `additionalProperties: false` that the runner never enforces. Those are the three
+misses this design corrects.
+
+## Key references
+
+- `sdks/python/agenta/sdk/agents/platform/op_catalog.py:470`, `PLATFORM_OPS`; the op lives here.
+- `api/oss/src/core/annotations/service.py:83-160`, evaluator resolve, auto-create,
+  payload validation.
+- `api/oss/src/core/annotations/types.py:40-49`, `AnnotationReferences.evaluator` required;
+  `AnnotationCreate`.
+- `api/oss/src/apis/fastapi/annotations/router.py:102`, `POST /api/annotations/`.
+- `api/oss/src/core/evaluators/defaults.py:62-81`, the three seeded default evaluators.
+- `api/oss/src/core/accounts/service.py:749-757` and `dtos.py:56`, `create_default_evaluators`,
+  `seed_defaults=True`.
+- `sdks/python/agenta/sdk/engines/running/utils.py:147-155` (preset block `:138-158`), the
+  `quality-rating` outputs schema (`{approved: boolean}`); a new preset goes next to it.
+- `api/oss/src/core/evaluators/defaults.py:182-235`, `create_default_evaluators` (idempotent,
+  swallows `EntityCreationConflict` at `:222-227`); called at project creation from
+  `accounts/service.py:754`, `services/commoners.py:214`, `routers/projects_router.py:234`,
+  `services/admin_manager.py:204`, `services/db_manager.py:2778`.
+- `api/oss/databases/postgres/migrations/core/data_migrations/default_environments.py` (version
+  `.../versions/c2d3e4f5a6b7_create_default_environments_for_projects_without_environments.py`),
+  the backfill template: paginate projects missing the entity, resolve `OrganizationDB.owner_id`,
+  idempotent get-or-create. No `quality-rating` backfill exists to copy.
+- `web/oss/src/components/SharedDrawers/AnnotateDrawer/assets/constants.ts:2-10`
+  (`USEABLE_METRIC_TYPES`) and `.../assets/transforms.ts:32-149` /
+  `.../ScenarioAnnotationPanel/AnnotationInputs.tsx:341-453`, the annotation-form renderer:
+  string/boolean/number/enum render, open objects are filtered out.
+- `services/agent/src/tools/direct.ts::assembleBody` and `relay.ts:211`, body assembly; model
+  args not schema-validated pre-assembly.
+- `api/oss/src/core/tracing/dtos.py:307`, `SimpleTraceLinks = Union[Dict[str, Link], List[Link]]`.
+- `sdks/python/agenta/sdk/agents/dtos.py:440` (`RunContextTrace`) and
+  `services/oss/src/agent/tracing.py:161` (`_run_context_trace`), the `$ctx.trace.*` source.

--- a/docs/design/agent-workflows/projects/builder-agent-reliability/annotate-op/status.md
+++ b/docs/design/agent-workflows/projects/builder-agent-reliability/annotate-op/status.md
@@ -1,0 +1,54 @@
+# Status
+
+**State:** DESIGN ONLY. Not implemented, not merged. Under review on draft PR #4999
+(`feat/annotate-trace-op`, base `big-agents`).
+
+**Date:** 2026-07-01
+
+## What is done
+
+- Confirmed the annotations plumbing is ready: `POST /api/annotations/` works, and the run's
+  own `trace_id`/`span_id` are captured and bindable via `$ctx.trace.*`. Only the catalog op
+  was missing.
+- Resolved the evaluator question. The project-seeded `quality-rating` default exists but its
+  schema is a rigid `{approved: boolean}` thumbs, unfit for reflection. We reserve one
+  dedicated evaluator, slug `agent-self-reflection`, with a **structured** outputs schema
+  (`reflection` string, `score` binary good/bad, `meta` open object), bound server-side. The
+  structure is enough to render in the annotation UI and to filter runs by success, and the
+  `meta` object carries whatever extras a run wants. See [plan.md](plan.md) §1.
+- Decided materialization: seed the reserved evaluator on project creation exactly like
+  `quality-rating` (a preset plus a `_DEFAULT_EVALUATORS` entry) **and** ship a backfill
+  migration for existing projects. We do not auto-create it at annotation time; the build-agent
+  skill carries the create-it-yourself fallback instead.
+- Made the self-target airtight in plain terms: the runner clears the whole `links` subtree the
+  model sent, then refills only the two bound leaves from run context, so no smuggled sibling
+  link survives. Same clear-then-refill for the evaluator `references`. See [plan.md](plan.md)
+  §2.
+- Wrote the op shape (model supplies `data.outputs` only), the permission default (`allow`),
+  and the phases.
+
+## Open question (one, minor)
+
+- **Upsert vs append.** Should repeated `annotate_trace` calls on the same trace upsert (edit
+  the one existing self-reflection annotation) rather than append a new one each time? Lean:
+  **append**, because each reflection is a distinct record and reads naturally as its own row
+  in the annotation UI. Upsert is worth keeping as an option to bound a runaway loop that would
+  otherwise spam annotations on its own trace (the annotations API supports edit by
+  trace/span). This is a rate/idempotency choice, not a permission one.
+
+## Notes and residual wrinkles
+
+- **Data-shape convention.** The `quality-rating` preset schema describes `data` directly as
+  `{approved}`, while the annotation convention (and this op) wraps content in `data.outputs`.
+  The reserved evaluator's stored schema must match the `data.outputs` shape the op actually
+  sends, so the two stay consistent. The pre-existing `quality-rating` inconsistency is
+  orthogonal and flagged for the annotations team.
+- **Single vs multiple categories.** MVP is one reserved evaluator. A later fixed set (quality,
+  safety) becomes additional reserved evaluators or a bound-from-config choice, never
+  free-invented slugs.
+
+## Cross-references
+
+- Parent project: [builder-agent-reliability](../README.md) (use case 3).
+- Research source: [`../../../scratch/console/builder-kit/findings/annotation.md`](../../../scratch/console/builder-kit/findings/annotation.md).
+- Documented gap: `../build-notes.md` (case 3, the porting recommendation).


### PR DESCRIPTION
## What

Adds an `annotate_trace` entry to `PLATFORM_OPS` so a running agent can record an annotation (evaluation feedback) on **its own current run's trace** — "grade myself". This closes the last gap for the self-reflecting-agent use case (builder-agent-reliability use case 3): the annotations REST API and the run-context trace plumbing already existed; only the catalog entry was missing.

## How it mirrors `commit_revision`

`annotate_trace` is a mutating, self-targeting platform-op built exactly like `commit_revision`:

- Wraps `POST /api/annotations/` (`args_into="annotation"`, request wrapper is `{"annotation": AnnotationCreate}`).
- The run's own `trace_id`/`span_id` are bound from run context and hidden from the model, so the agent can only ever annotate its OWN trace:
  ```
  context_bindings={
      "annotation.links.invocation.trace_id": "$ctx.trace.trace_id",
      "annotation.links.invocation.span_id": "$ctx.trace.span_id",
  }
  ```
  (`commit_revision` binds `$ctx.workflow.variant.id` the same way.)
- Model-visible schema is closed (`additionalProperties: False`) and exposes only `references.evaluator.slug` + `data.outputs`. `links` is never model-supplied.

Assembled body:
```json
{
  "annotation": {
    "references": { "evaluator": { "slug": "self_reflection" } },
    "data": { "outputs": { "score": 0.9, "note": "…" } },
    "links": { "invocation": { "trace_id": "<run's own>", "span_id": "<run's own>" } }
  }
}
```

## Permission default

Leans `allow` / no-approval — annotating your own trace is additive self-metadata (unlike `commit_revision`, which mutates config and defaults to `ask`). Authors can override per-config, and `ask` is the documented alternative (a brand-new evaluator slug auto-creates an evaluator artifact).

## Files

- `sdks/python/agenta/sdk/agents/platform/op_catalog.py` — the op + its description/schema constants.
- `sdks/python/oss/tests/pytest/unit/agents/platform/test_op_catalog.py` — added to the catalog set + two focused tests (self-target bind + hidden `links`; auto-allow default).
- `docs/design/agent-workflows/projects/builder-agent-reliability/annotate-op/README.md` — design doc.

The build-kit overlay enumerates `PLATFORM_OPS` dynamically, so the op is offered to builder agents automatically.

## Verification

- `pytest oss/tests/pytest/unit/agents/platform/` — 87 passed.
- API `test_build_kit_overlay.py` — 4 passed.
- `ruff format` + `ruff check --fix` clean.

## Review asks

- Confirm the `$ctx.trace.*` token names (`$ctx.trace.trace_id` / `.span_id`) — the load-bearing binding. Verified against `RunContextTrace`, `RunContext.to_wire()`, and `resolveCtxToken` in the TS runner.
- Confirm the annotation body shape (`{"annotation": {data.outputs, references.evaluator, links.invocation.{trace_id,span_id}}}`) — verified against the router request model and the annotations acceptance test.
- Sign off on the `allow` permission default vs `ask`.

Draft — do not merge.

https://claude.ai/code/session_01WSp2LqKrEtXnm2fsPWuQWa