### PR TITLE
fix(agent): load agents_md on the claude harness via CLAUDE.md

### DIFF
--- a/docs/design/agent-workflows/projects/builder-agent-reliability/agentsmd-claude-fix/README.md
+++ b/docs/design/agent-workflows/projects/builder-agent-reliability/agentsmd-claude-fix/README.md
@@ -1,0 +1,38 @@
+# Load `agents_md` on the claude harness via `CLAUDE.md`
+
+A design-only workspace for a small runner fix. An agent configured `harness: claude` with
+`instructions.agents_md` set ignores those instructions. The instruction is written to disk as
+`AGENTS.md`, but the bundled `@anthropic-ai/claude-agent-sdk` memory loader auto-loads
+`CLAUDE.md` only. So the file is written and never read, and the claude agent falls through to
+Claude Code's default coding persona. This is the likely root of the broader "the claude agent
+ignores its instructions" reports. Part of [builder-agent-reliability](../README.md).
+
+The fix is one harness-aware line in the runner: write `CLAUDE.md` for the claude harness, keep
+`AGENTS.md` for pi. The wire and the golden fixtures do not change, because the filename is a
+materialization detail, not a wire-contract detail.
+
+## Files
+
+- [context.md](context.md), the bug, why it matters (likely root of "agent ignores its
+  instructions"), and the background on how instructions reach a claude run. Goals and
+  non-goals.
+- [research.md](research.md), the read-only root-cause trace with file/line citations: the
+  runner writes `AGENTS.md` at `workspace.ts:80`, the claude-agent-sdk loader auto-loads
+  `CLAUDE.md` only, `settingSources` already permits `CLAUDE.md` but none is written. Plus the
+  deeper persona `_meta` path, noted as out of scope.
+- [plan.md](plan.md), the fix: the sidecar/runner materialization step writes `CLAUDE.md` for
+  the claude harness and keeps `AGENTS.md` for pi, mirrored in the SDK. Options A/B/C, with A
+  chosen. Verification steps.
+- [status.md](status.md), current state (design under review on PR #5000) and the decision.
+
+## TL;DR
+
+- **Root cause:** the runner writes `instructions.agents_md` to `AGENTS.md`
+  (`workspace.ts:80`), but `@anthropic-ai/claude-agent-sdk@0.2.83` auto-loads `CLAUDE.md` only.
+  Written, never read.
+- **Fix (option A):** make the filename harness-aware in `workspace.ts` (and mirror it in the
+  SDK `interfaces.py`): claude → `CLAUDE.md`, pi → `AGENTS.md`. `settingSources` already loads a
+  project-root `CLAUDE.md`, so nothing else changes. The wire and golden fixtures are untouched.
+- **Out of scope (option B):** delivering `agents_md` as an appended system prompt so it
+  overrides the coding persona for verb-less input. Blocked by sandbox-agent 0.4.2 stripping
+  `_meta`; a separate cross-package fix.

--- a/docs/design/agent-workflows/projects/builder-agent-reliability/agentsmd-claude-fix/context.md
+++ b/docs/design/agent-workflows/projects/builder-agent-reliability/agentsmd-claude-fix/context.md
@@ -1,0 +1,53 @@
+# Context
+
+Date: 2026-07-01
+Area: the sidecar runner file-materialization step
+(`services/agent/src/engines/sandbox_agent/workspace.ts`), mirrored in the SDK
+(`sdks/python/agenta/sdk/agents/interfaces.py`).
+
+## The bug
+
+An agent configured `harness: claude` with `instructions.agents_md` set (for example, "You are
+a text summarizer, summarize the text, no questions back") ignores those instructions. Sent a
+bare pasted paragraph with no instruction verb, it answers like the Claude Code CLI ("Is there
+something I can help with, a coding task?") instead of summarizing.
+
+The user's read was: "agents.md is not considered at all in claude, it ignores it." That
+observation is correct. For the claude harness the instructions are written to disk and never
+read.
+
+## Why it matters
+
+This is the likely root of the broader "agent ignores its instructions" complaints on the
+claude harness. It is not a dropped field or a mapper bug. The instruction survives the SDK
+adapter, survives the wire, survives the runner, and lands on disk. It is simply written to a
+filename the claude memory loader never reads. So every claude agent that relies on
+`instructions.agents_md` to set its behavior falls through to Claude Code's default coding
+persona, no matter what the user wrote.
+
+Pi is unaffected. Pi reads `AGENTS.md`, and additionally gets `agents_md` appended after its
+system prompt, so the instruction takes effect there.
+
+## Background: how instructions reach a claude run
+
+`instructions.agents_md` is carried as a neutral `agentsMd` string on the `/run` wire. The wire
+says nothing about a filename. The runner is the component that turns `agentsMd` into a file on
+disk in the run cwd, and it writes the file as `AGENTS.md` for every harness. Claude runs
+through the bundled `@anthropic-ai/claude-agent-sdk`, whose memory loader auto-loads `CLAUDE.md`
+only. The two never meet. The full file-by-file trace is in [research.md](research.md).
+
+## Goals
+
+- Make `instructions.agents_md` actually take effect on the claude harness: land it as project
+  memory the claude-agent-sdk loads.
+- Keep the change in the one place that owns the filename (the runner materialization step),
+  and keep it small.
+- Keep Pi and Agenta behavior unchanged.
+
+## Non-goals
+
+- The persona / system-prompt path. Delivering `agents_md` as an *appended system prompt* so it
+  overrides the coding persona for verb-less input is a larger cross-package change (blocked by
+  `sandbox-agent` 0.4.2 stripping `_meta`). It is out of scope here and tracked in
+  [research.md](research.md) and [plan.md](plan.md) as the deeper fix.
+- Any wire-contract or golden-fixture change. The filename is not on the wire.

--- a/docs/design/agent-workflows/projects/builder-agent-reliability/agentsmd-claude-fix/plan.md
+++ b/docs/design/agent-workflows/projects/builder-agent-reliability/agentsmd-claude-fix/plan.md
@@ -1,0 +1,89 @@
+# Plan
+
+Date: 2026-07-01
+
+The fix for `instructions.agents_md` on the claude harness. The root-cause trace is in
+[research.md](research.md).
+
+## The fix
+
+Make the instructions filename **harness-aware** in the file-materialization step:
+
+- claude harness → write the instructions to **`CLAUDE.md`** (the filename the
+  claude-agent-sdk memory loader reads).
+- pi / everything else → keep **`AGENTS.md`** (unchanged).
+
+`CLAUDE.md` at the cwd root is a "project" memory file. The Zed adapter's existing
+`settingSources` (`project` + `local`, `acp-agent.js:954`) already loads it, so no other runner
+or adapter change is needed. This turns "ignored" into "considered as project memory."
+
+## Why it goes in the runner/sidecar, not the wire or the Python mapper
+
+The choice of filename is a **materialization** detail, not a wire-contract detail. The wire
+already carries the instructions as a neutral `agentsMd` string (golden
+`run_request.claude.json`), and the wire says nothing about a filename. The runner is the
+component that turns `agentsMd` into a file on disk, so the runner is where the filename is
+chosen. Keeping the wire neutral means the Python harness adapter
+(`ClaudeHarness._to_harness_config`) does not change and the golden fixtures do not change; only
+the sidecar's on-disk placement does.
+
+## Options
+
+- **A (chosen): write a `CLAUDE.md` for the claude harness.** Smallest change, works with the
+  current stack. In `workspace.ts`, for the claude ACP agent write `plan.agentsMd` to
+  `CLAUDE.md` instead of `AGENTS.md`. `settingSources` already includes `project`+`local`, so
+  the SDK memory loader picks it up. Pi keeps `AGENTS.md`.
+- **B: deliver `agents_md` as an appended system prompt.** Makes it override the coding persona
+  for ambiguous, verb-less input. Blocked today: sandbox-agent 0.4.2 strips `_meta` from
+  `sessionInit`, so the runner cannot reach the Zed adapter's `_meta.systemPrompt.append` hook.
+  It needs a cross-package change (sandbox-agent exposes a `systemPrompt`/append option on
+  `createSession`, then `run-plan.ts` stops gating the append behind `isPi` for claude, then
+  `sandbox_agent.ts:453` passes it). Out of scope here; tracked in research.md as the deeper
+  fix.
+- **C: do both.** A `CLAUDE.md` for durable project context plus an appended system prompt for
+  persona-level instructions, mirroring Pi's two-layer split (AGENTS.md preamble +
+  append_system persona). This is A plus B, so it inherits B's block.
+
+**Chosen: A.** It alone makes `agents_md` actually take effect on claude, with a one-line,
+local change and no wire or fixture churn. B is the real fix for the persona problem but is
+blocked cross-package; it lands later. With A, `agents_md` lands as project memory (considered
+instead of ignored); a strongly worded persona is honored, and for a bare verb-less paste the
+message-composition workaround (frame the task with a verb) remains the belt-and-suspenders path
+until B lands.
+
+## What changes
+
+1. `services/agent/src/engines/sandbox_agent/workspace.ts`, pick the instructions filename by
+   harness (`plan.acpAgent === "claude" ? "CLAUDE.md" : "AGENTS.md"`) and use it on both the
+   local (`writeFileSync`) and Daytona (`writeFsFile`) paths. This is the live fix.
+2. `sdks/python/agenta/sdk/agents/interfaces.py`, `Harness._provisioning` picks the same
+   filename by `self.harness_type`. This path is currently dead for claude (the sidecar buffers
+   provisioning informationally and the local claude backend is not-yet-implemented / Phase 4),
+   but keeping the two sides mirrored (like `protocol.ts` and `wire.py`) prevents a regression
+   when that backend lands.
+
+## What deliberately does NOT change
+
+- **The persona / `_meta.systemPrompt` path.** That is option B, blocked by sandbox-agent 0.4.2
+  stripping `_meta`. Out of scope; see research.md.
+- The wire contract (`protocol.ts` / `wire.py`) and the golden fixtures. The filename is not on
+  the wire.
+- Pi / Agenta behavior. They keep `AGENTS.md`.
+
+## Verification
+
+- **Unit (runner):** `services/agent/tests/unit/sandbox-agent-workspace.test.ts`, extend so the
+  existing Pi cases assert `AGENTS.md` and new claude cases assert `CLAUDE.md` (and the absence
+  of `AGENTS.md`) on both local and Daytona paths. Run from `services/agent`: `pnpm test` (or
+  `pnpm exec vitest run tests/unit/sandbox-agent-workspace.test.ts`).
+- **Unit (SDK):** `sdks/python/oss/tests/pytest/unit/agents/test_environment_lifecycle.py`, add
+  a claude case asserting `_provisioning` returns `{"CLAUDE.md": ...}`; the existing Pi case
+  still asserts `{"AGENTS.md": ...}`.
+- **Typecheck:** `pnpm run typecheck` in `services/agent`.
+- **Live (needs redeploy):** the deployed sidecar image bakes the runner, so the fix is only
+  live after a rebuild/restart (`docker restart agenta-claude-sub-sidecar` for the local
+  subscription sidecar, or `run.sh --build` for the compose `agent-pi`/sidecar). After redeploy:
+  create a `harness: claude` agent whose `instructions` is a summarizer persona, send a bare
+  paragraph with no instruction verb, and confirm it summarizes instead of replying "how can I
+  help?". Before the fix it writes `AGENTS.md` (ignored); after, it writes `CLAUDE.md` (loaded
+  as project memory).

--- a/docs/design/agent-workflows/projects/builder-agent-reliability/agentsmd-claude-fix/research.md
+++ b/docs/design/agent-workflows/projects/builder-agent-reliability/agentsmd-claude-fix/research.md
@@ -1,0 +1,113 @@
+# Research
+
+Date: 2026-07-01
+Source: [`../../../scratch/console/builder-kit/findings/agents-md-claude.md`](../../../scratch/console/builder-kit/findings/agents-md-claude.md)
+
+Read-only trace of how `instructions.agents_md` travels from the SDK harness adapter, over the
+`/run` wire, through the runner, and into Claude Code. The instruction is written to disk and
+never read. It is a filename mismatch, not a dropped field.
+
+## The trace (file:line)
+
+### 1. SDK harness adapter, agents_md set, no system prompt for claude
+
+`ClaudeHarness._to_harness_config`
+(`sdks/python/agenta/sdk/agents/adapters/harnesses.py:101-112`) builds
+`ClaudeAgentTemplate(agents_md=config.agent.instructions, ...)`. It sets no `system` /
+`append_system`; those are Pi-only extras (`PiHarness` at `harnesses.py:78-79`, `AgentaHarness`
+at `:143-144`). So the user's raw `instructions` becomes `agents_md` and nothing else. Claude
+gets neither the Agenta preamble nor a persona append that pi_agenta gets from
+`agenta_builtins.py:331-340`.
+
+### 2. Wire, claude carries `agentsMd`, never `systemPrompt`
+
+- Golden `sdks/python/oss/tests/pytest/unit/agents/golden/run_request.claude.json:5` , 
+  `"agentsMd": "..."`, and no `systemPrompt`/`appendSystemPrompt`.
+- Golden `run_request.pi_core.json:73-74`, pi does carry `systemPrompt`/`appendSystemPrompt`.
+- `services/agent/src/protocol.ts:366-379`, the wire doc says `systemPrompt` /
+  `appendSystemPrompt` are "Pi only"; `agentsMd` is "AGENTS.md text injected as the agent's
+  instructions."
+
+### 3. Runner run-plan, systemPrompt/append gated behind `isPi`
+
+- `services/agent/src/engines/sandbox_agent/run-plan.ts:297-302` , 
+  `systemPrompt = isPi ? request.systemPrompt : undefined`, same for `appendSystemPrompt`. For
+  claude (`isPi === false`) both are `undefined`.
+- `run-plan.ts:327`, `agentsMd: request.agentsMd?.trim() || undefined` is put on the plan.
+  That is the only channel `agents_md` survives on for claude.
+
+### 4. Runner workspace, agents_md becomes an `AGENTS.md` file (the write site)
+
+- `services/agent/src/engines/sandbox_agent/workspace.ts:80` (local) and `:54-56` (Daytona) , 
+  `writeFileSync(join(cwd, "AGENTS.md"), plan.agentsMd)`. Written as **AGENTS.md**, always, for
+  every harness.
+- `buildTurnText` (`transcript.ts:69-81`) does not fold `agents_md` into the prompt for any
+  harness. So for claude the only place `agents_md` exists at run time is the `AGENTS.md` file
+  on disk.
+
+### 5. Session creation, no system prompt; base persona is the claude_code preset
+
+- `services/agent/src/engines/sandbox_agent.ts:453-457` , 
+  `createSession({ agent: "claude", cwd, sessionInit: { cwd, mcpServers } })`. No system
+  prompt, no memory hint. The cwd is the temp dir that holds `AGENTS.md`.
+- Zed adapter `@zed-industries/claude-agent-acp@0.23.1/dist/acp-agent.js`: `:923` base
+  `systemPrompt = { type: "preset", preset: "claude_code" }` (the full coding-CLI persona)
+  unless `params._meta.systemPrompt` is given; `:924-933` it would honor `_meta.systemPrompt`;
+  `:954` `settingSources: ["user", "project", "local"]`.
+
+### 6. The load gap, settingSources loads CLAUDE.md, but the file is AGENTS.md
+
+- `@anthropic-ai/claude-agent-sdk@0.2.83/sdk.d.ts:1211`, settingSources "Must include
+  `'project'` to load **CLAUDE.md** files." The adapter includes project+local, so a `CLAUDE.md`
+  at the cwd root **would** load.
+- The memory-file loader in `.../claude-agent-sdk/cli.js` (function `Vj`) collects, per ancestor
+  dir: `CLAUDE.md`, `.claude/CLAUDE.md`, `.claude/rules`, `CLAUDE.local.md`. **`AGENTS.md` is
+  never in the loader.** The only two `AGENTS.md` strings in `cli.js` (lines 4756, 4818) are
+  inside the `/init` command prompt, not the auto-load path.
+- Result: the runner writes `AGENTS.md`; the SDK looks for `CLAUDE.md`; they never meet.
+
+### 7. No system-prompt lever through sandbox-agent 0.4.2
+
+- `sandbox-agent@0.4.2/dist/index.d.ts:2950-2960`, `SessionCreateRequest.sessionInit` is
+  `Omit<NewSessionRequest, "_meta">`. `_meta` is stripped, and there is no
+  `systemPrompt`/append option on `createSession`. So the runner, on this daemon version,
+  cannot reach the Zed adapter's `_meta.systemPrompt.append` hook even though the adapter
+  supports it. The filesystem (a memory file) is the runner's only delivery channel to claude
+  today.
+
+## Root cause
+
+Two compounding faults, one primary:
+
+1. **Delivery mismatch (primary, "ignored").** claude's `agents_md` is materialized as
+   `AGENTS.md`, but `claude-agent-sdk@0.2.83` auto-loads `CLAUDE.md` only. The instruction is
+   written to a filename the harness never reads, so it is dropped in effect. This is the
+   literal reason the user sees no influence, and the thing the fix corrects.
+2. **Strength/altitude (secondary, "overridden").** Even loaded as a `CLAUDE.md`, `agents_md`
+   is project *memory* sitting under the `claude_code` system-prompt preset. For a bare,
+   verb-less paste the coding-CLI persona dominates and the model asks "what can I help with?".
+   The runner never threads `agents_md` into the SDK's `systemPrompt` (Pi-only path,
+   `run-plan.ts:297-302`), and sandbox-agent 0.4.2 exposes no hook for it (#7 above).
+
+So "agents.md is not considered at all in claude" is true as an observation. The mechanism is
+"written to the wrong filename for the loader," not "the field is discarded in the mapper."
+
+## Why the persona `_meta` path is out of scope
+
+Fault #2 is the deeper fix: deliver `agents_md` as an *appended system prompt* so it overrides
+the coding persona for ambiguous input. The Zed adapter already honors
+`_meta.systemPrompt = { type: "preset", preset: "claude_code", append: <agents_md> }`
+(`acp-agent.js:924-933`). But it is blocked today: sandbox-agent 0.4.2 strips `_meta` from
+`sessionInit` (#7), so the runner cannot reach that hook. Unblocking it is a cross-package
+change (sandbox-agent must expose a `systemPrompt`/append option on `createSession`, then
+`run-plan.ts` must stop gating the append behind `isPi` for claude, then `sandbox_agent.ts:453`
+must pass it). That is a separate, larger fix and is not in this workspace. See fault #2 and the
+kit-level workaround below.
+
+## Kit-level workaround (already in use, not a fix)
+
+Frame the task explicitly in the message: "Summarize the following text:\n<paragraph>" rather
+than relying on `agents_md` to install the persona. With an explicit instruction verb the
+coding-CLI persona still answers the task correctly; only the bare, verb-less paste falls
+through to "how can I help?". This is message composition, not a fix. The delivery mismatch
+above is the thing to correct.

--- a/docs/design/agent-workflows/projects/builder-agent-reliability/agentsmd-claude-fix/status.md
+++ b/docs/design/agent-workflows/projects/builder-agent-reliability/agentsmd-claude-fix/status.md
@@ -1,0 +1,37 @@
+# Status
+
+**State:** DESIGN ONLY. Not implemented, not merged. Under review on draft PR #5000
+(`fix/agent-claude-agentsmd`, base `big-agents`).
+
+**Date:** 2026-07-01
+
+## What is done
+
+- Traced the bug end to end: `instructions.agents_md` survives the SDK adapter, the wire, and
+  the runner, then lands on disk as `AGENTS.md` (`workspace.ts:80`). The bundled
+  `@anthropic-ai/claude-agent-sdk` memory loader auto-loads `CLAUDE.md` only, never `AGENTS.md`.
+  The adapter's `settingSources` already permits `CLAUDE.md`, but none is written. So the
+  instruction is written and never read. Full trace in [research.md](research.md).
+- Chose the fix: make the instructions filename harness-aware in the runner materialization step
+  (claude → `CLAUDE.md`, pi → `AGENTS.md`), mirrored in the SDK. This is option A ("smallest,
+  works with the current stack"). See [plan.md](plan.md).
+- Scoped out the deeper persona / `_meta.systemPrompt` path (option B): blocked by sandbox-agent
+  0.4.2 stripping `_meta`, a cross-package change tracked for later.
+
+## Decision
+
+Ship option A. It alone makes `agents_md` take effect on claude, as a one-line local change with
+no wire or golden-fixture churn. Option B (appended system prompt) is the real fix for the
+verb-less-input persona problem but is blocked cross-package and lands separately.
+
+## Residual behavior after A
+
+With A, `agents_md` lands as project memory for claude, which makes it considered instead of
+ignored. A strongly worded persona is honored. For a bare, verb-less paste the coding-CLI
+persona can still surface; the message-composition workaround (frame the task with a verb) is
+the belt-and-suspenders path until option B lands.
+
+## Cross-references
+
+- Parent project: [builder-agent-reliability](../README.md).
+- Research source: [`../../../scratch/console/builder-kit/findings/agents-md-claude.md`](../../../scratch/console/builder-kit/findings/agents-md-claude.md).

--- a/sdks/python/agenta/sdk/agents/interfaces.py
+++ b/sdks/python/agenta/sdk/agents/interfaces.py
@@ -233,11 +233,21 @@ class Harness(ABC):
         """Map the neutral config into this harness's own config (the mapping logic)."""
 
     def _provisioning(self, config: SessionConfig) -> Mapping[str, bytes]:
-        """Files this harness needs laid into the sandbox before the run."""
+        """Files this harness needs laid into the sandbox before the run.
+
+        The instructions filename is harness-aware, mirroring the runner's workspace
+        materialization (``services/agent/.../workspace.ts``): Claude runs through
+        ``claude-agent-sdk``, whose memory loader auto-loads ``CLAUDE.md`` only and never reads
+        ``AGENTS.md``, so the claude harness's instructions must land in ``CLAUDE.md``. Pi (and
+        any other harness) reads ``AGENTS.md``.
+        """
         files: dict[str, bytes] = {}
         instructions = config.agent.instructions
         if instructions and instructions.strip():
-            files["AGENTS.md"] = instructions.encode("utf-8")
+            filename = (
+                "CLAUDE.md" if self.harness_type is HarnessType.CLAUDE else "AGENTS.md"
+            )
+            files[filename] = instructions.encode("utf-8")
         return files
 
     async def create_session(self, config: SessionConfig) -> Session:

--- a/sdks/python/oss/tests/pytest/unit/agents/test_environment_lifecycle.py
+++ b/sdks/python/oss/tests/pytest/unit/agents/test_environment_lifecycle.py
@@ -12,6 +12,7 @@ import pytest
 from agenta.sdk.agents import (
     AgentTemplate,
     AgentResult,
+    ClaudeHarness,
     HarnessType,
     Message,
     PiHarness,
@@ -69,6 +70,16 @@ async def test_provisioning_writes_agents_md_only_when_present(make_env):
     assert harness._provisioning(_config("")) == {}
     assert harness._provisioning(_config("   ")) == {}
     assert harness._provisioning(_config(None)) == {}
+
+
+async def test_provisioning_writes_claude_md_for_claude_harness(make_env):
+    # claude-agent-sdk's memory loader auto-loads CLAUDE.md, never AGENTS.md, so the claude
+    # harness's instructions must land in CLAUDE.md (mirrors the runner's workspace.ts rule).
+    env = make_env()
+    harness = ClaudeHarness(env)
+
+    assert harness._provisioning(_config("hello")) == {"CLAUDE.md": b"hello"}
+    assert harness._provisioning(_config("")) == {}
 
 
 async def test_create_session_adds_files_when_provisioned(make_env):

--- a/services/runner/src/engines/sandbox_agent/workspace.ts
+++ b/services/runner/src/engines/sandbox_agent/workspace.ts
@@ -28,11 +28,17 @@ export interface PrepareWorkspaceInput {
 }
 
 /**
- * Prepare the run cwd, relay directory, optional AGENTS.md, generic `harnessFiles`, and
- * non-Pi skill packages for local or Daytona runs. `harnessFiles` are written blind: the
+ * Prepare the run cwd, relay directory, the instructions memory file, generic `harnessFiles`,
+ * and non-Pi skill packages for local or Daytona runs. `harnessFiles` are written blind: the
  * Python harness adapter already rendered them. Skills stay resolved inline packages on the
  * wire; Pi installs them through its agent dir, while Claude loads project-local
  * `.claude/skills/<name>` directories from the cwd.
+ *
+ * The instructions (`agentsMd`) filename is harness-aware. Claude runs through
+ * `@anthropic-ai/claude-agent-sdk`, whose memory loader auto-loads `CLAUDE.md` only and never
+ * reads `AGENTS.md`, so for the claude harness the instructions must land in `CLAUDE.md` to be
+ * read at all (the ACP adapter's `settingSources` already includes `project`+`local`, which
+ * loads a root `CLAUDE.md`). Pi reads `AGENTS.md`, so every non-claude harness keeps that name.
  */
 export async function prepareWorkspace({
   sandbox,
@@ -41,6 +47,11 @@ export async function prepareWorkspace({
 }: PrepareWorkspaceInput): Promise<Workspace> {
   const harnessFiles = plan.harnessFiles ?? [];
   const projectSkillRoot = plan.isPi ? undefined : `.${plan.acpAgent}/skills`;
+  // Claude's memory loader reads CLAUDE.md, never AGENTS.md; Pi (and any other harness) reads
+  // AGENTS.md. See the doc comment above and docs/design/agent-workflows/projects/
+  // builder-agent-reliability/agentsmd-claude-fix/README.md.
+  const instructionsFile =
+    plan.acpAgent === "claude" ? "CLAUDE.md" : "AGENTS.md";
 
   if (plan.isDaytona) {
     await sandbox.mkdirFs({ path: plan.cwd }).catch((err: Error) => {
@@ -52,7 +63,10 @@ export async function prepareWorkspace({
       });
     }
     if (plan.agentsMd) {
-      await sandbox.writeFsFile({ path: `${plan.cwd}/AGENTS.md` }, plan.agentsMd);
+      await sandbox.writeFsFile(
+        { path: `${plan.cwd}/${instructionsFile}` },
+        plan.agentsMd,
+      );
     }
     for (const file of harnessFiles) {
       const path = `${plan.cwd}/${file.path}`;
@@ -69,7 +83,9 @@ export async function prepareWorkspace({
           skill.dir,
           `${plan.cwd}/${projectSkillRoot}/${skill.name}`,
         ).catch((err: Error) => {
-          log(`skill workspace upload skipped for ${skill.name}: ${err.message}`);
+          log(
+            `skill workspace upload skipped for ${skill.name}: ${err.message}`,
+          );
         });
       }
     }
@@ -77,7 +93,8 @@ export async function prepareWorkspace({
   }
 
   if (plan.useToolRelay) mkdirSync(plan.relayDir, { recursive: true });
-  if (plan.agentsMd) writeFileSync(join(plan.cwd, "AGENTS.md"), plan.agentsMd, "utf-8");
+  if (plan.agentsMd)
+    writeFileSync(join(plan.cwd, instructionsFile), plan.agentsMd, "utf-8");
   for (const file of harnessFiles) {
     const path = join(plan.cwd, file.path);
     mkdirSync(dirname(path), { recursive: true });

--- a/services/runner/tests/unit/sandbox-agent-workspace.test.ts
+++ b/services/runner/tests/unit/sandbox-agent-workspace.test.ts
@@ -5,7 +5,13 @@
  */
 import { afterEach, describe, it } from "vitest";
 import assert from "node:assert/strict";
-import { existsSync, mkdtempSync, readFileSync, rmSync, writeFileSync } from "node:fs";
+import {
+  existsSync,
+  mkdtempSync,
+  readFileSync,
+  rmSync,
+  writeFileSync,
+} from "node:fs";
 import { tmpdir } from "node:os";
 import { join } from "node:path";
 
@@ -20,7 +26,8 @@ function tempDir(): string {
 }
 
 afterEach(() => {
-  for (const dir of dirs.splice(0)) rmSync(dir, { recursive: true, force: true });
+  for (const dir of dirs.splice(0))
+    rmSync(dir, { recursive: true, force: true });
 });
 
 describe("prepareWorkspace", () => {
@@ -42,12 +49,44 @@ describe("prepareWorkspace", () => {
     });
 
     assert.equal(existsSync(join(cwd, ".agenta-tools")), true);
-    assert.equal(readFileSync(join(cwd, "AGENTS.md"), "utf-8"), "agent instructions");
+    assert.equal(
+      readFileSync(join(cwd, "AGENTS.md"), "utf-8"),
+      "agent instructions",
+    );
     // A Pi run never gets a Claude settings file.
     assert.equal(existsSync(join(cwd, ".claude", "settings.json")), false);
 
     await workspace.cleanup();
     assert.equal(existsSync(cwd), false);
+  });
+
+  it("writes claude instructions to CLAUDE.md, not AGENTS.md (local)", async () => {
+    // claude-agent-sdk's memory loader auto-loads CLAUDE.md, never AGENTS.md, so the claude
+    // harness's instructions must land in CLAUDE.md to be read at all.
+    const cwd = tempDir();
+
+    const workspace = await prepareWorkspace({
+      sandbox: {},
+      plan: {
+        isDaytona: false,
+        cwd,
+        relayDir: join(cwd, ".agenta-tools"),
+        useToolRelay: false,
+        agentsMd: "agent instructions",
+        acpAgent: "claude",
+        isPi: false,
+        skillDirs: [],
+      },
+    });
+
+    assert.equal(
+      readFileSync(join(cwd, "CLAUDE.md"), "utf-8"),
+      "agent instructions",
+    );
+    // The AGENTS.md name is Pi's; a claude run must not use it (the loader ignores it).
+    assert.equal(existsSync(join(cwd, "AGENTS.md")), false);
+
+    await workspace.cleanup();
   });
 
   it("writes a nested harnessFiles entry (.claude/settings.json) for a local run", async () => {
@@ -110,9 +149,11 @@ describe("prepareWorkspace", () => {
   });
 
   it("prepares a Daytona cwd through the sandbox fs API", async () => {
-    const calls: Array<{ op: "mkdir" | "write"; path: string; body?: string }> = [];
+    const calls: Array<{ op: "mkdir" | "write"; path: string; body?: string }> =
+      [];
     const sandbox = {
-      mkdirFs: async ({ path }: { path: string }) => calls.push({ op: "mkdir", path }),
+      mkdirFs: async ({ path }: { path: string }) =>
+        calls.push({ op: "mkdir", path }),
       writeFsFile: async ({ path }: { path: string }, body: string) =>
         calls.push({ op: "write", path, body }),
     };
@@ -143,14 +184,60 @@ describe("prepareWorkspace", () => {
     ]);
   });
 
-  it("writes a nested harnessFiles entry on Daytona via the fs API", async () => {
-    const calls: Array<{ op: "mkdir" | "write"; path: string; body?: string }> = [];
+  it("writes claude instructions to CLAUDE.md on Daytona", async () => {
+    const calls: Array<{ op: "mkdir" | "write"; path: string; body?: string }> =
+      [];
     const sandbox = {
-      mkdirFs: async ({ path }: { path: string }) => calls.push({ op: "mkdir", path }),
+      mkdirFs: async ({ path }: { path: string }) =>
+        calls.push({ op: "mkdir", path }),
       writeFsFile: async ({ path }: { path: string }, body: string) =>
         calls.push({ op: "write", path, body }),
     };
-    const content = JSON.stringify({ permissions: { deny: ["Bash"] } }, null, 2);
+
+    await prepareWorkspace({
+      sandbox,
+      plan: {
+        isDaytona: true,
+        cwd: "/home/sandbox/agenta-fixed",
+        relayDir: "/home/sandbox/agenta-fixed/.agenta-tools",
+        useToolRelay: false,
+        agentsMd: "agent instructions",
+        acpAgent: "claude",
+        isPi: false,
+        skillDirs: [],
+      },
+    });
+
+    // The instructions land in CLAUDE.md (the name claude-agent-sdk loads), never AGENTS.md.
+    assert.ok(
+      calls.some(
+        (c) =>
+          c.op === "write" &&
+          c.path === "/home/sandbox/agenta-fixed/CLAUDE.md" &&
+          c.body === "agent instructions",
+      ),
+      "instructions are written to CLAUDE.md via the fs API",
+    );
+    assert.ok(
+      !calls.some((c) => c.path === "/home/sandbox/agenta-fixed/AGENTS.md"),
+      "a claude run never writes AGENTS.md",
+    );
+  });
+
+  it("writes a nested harnessFiles entry on Daytona via the fs API", async () => {
+    const calls: Array<{ op: "mkdir" | "write"; path: string; body?: string }> =
+      [];
+    const sandbox = {
+      mkdirFs: async ({ path }: { path: string }) =>
+        calls.push({ op: "mkdir", path }),
+      writeFsFile: async ({ path }: { path: string }, body: string) =>
+        calls.push({ op: "write", path, body }),
+    };
+    const content = JSON.stringify(
+      { permissions: { deny: ["Bash"] } },
+      null,
+      2,
+    );
 
     await prepareWorkspace({
       sandbox,
@@ -169,7 +256,8 @@ describe("prepareWorkspace", () => {
 
     // The parent dir of the nested path is created via the fs API.
     const claudeDir = calls.find(
-      (c) => c.op === "mkdir" && c.path === "/home/sandbox/agenta-fixed/.claude",
+      (c) =>
+        c.op === "mkdir" && c.path === "/home/sandbox/agenta-fixed/.claude",
     );
     assert.ok(claudeDir, ".claude dir is created via the fs API");
     const write = calls.find(
@@ -183,9 +271,11 @@ describe("prepareWorkspace", () => {
   });
 
   it("writes no harness file on Daytona for a plan with no harnessFiles", async () => {
-    const calls: Array<{ op: "mkdir" | "write"; path: string; body?: string }> = [];
+    const calls: Array<{ op: "mkdir" | "write"; path: string; body?: string }> =
+      [];
     const sandbox = {
-      mkdirFs: async ({ path }: { path: string }) => calls.push({ op: "mkdir", path }),
+      mkdirFs: async ({ path }: { path: string }) =>
+        calls.push({ op: "mkdir", path }),
       writeFsFile: async ({ path }: { path: string }, body: string) =>
         calls.push({ op: "write", path, body }),
     };
@@ -239,11 +329,13 @@ describe("prepareWorkspace", () => {
   });
 
   it("uploads Claude skills into the project-local .claude/skills tree on Daytona", async () => {
-    const calls: Array<{ op: "mkdir" | "write"; path: string; body?: string }> = [];
+    const calls: Array<{ op: "mkdir" | "write"; path: string; body?: string }> =
+      [];
     const skillDir = tempDir();
     writeFileSync(join(skillDir, "SKILL.md"), "skill", "utf-8");
     const sandbox = {
-      mkdirFs: async ({ path }: { path: string }) => calls.push({ op: "mkdir", path }),
+      mkdirFs: async ({ path }: { path: string }) =>
+        calls.push({ op: "mkdir", path }),
       writeFsFile: async ({ path }: { path: string }, body: string) =>
         calls.push({ op: "write", path, body }),
     };


### PR DESCRIPTION
## The bug

A `harness: claude` agent ignored its own `instructions.agents_md`. Configure one with
"You are a text summarizer, summarize the text, no questions back", paste a bare paragraph,
and it replies like the Claude Code CLI ("Is there something I can help with, a coding
task?") instead of summarizing.

It is a filename mismatch, not a dropped field:

- The runner writes `agents_md` to a file named **`AGENTS.md`** in the run cwd, for every
  harness (`services/agent/src/engines/sandbox_agent/workspace.ts`).
- Claude runs through `@anthropic-ai/claude-agent-sdk`, whose memory loader auto-loads
  **`CLAUDE.md`** / `.claude/CLAUDE.md` / `CLAUDE.local.md` only. It never reads `AGENTS.md`.
- The ACP adapter already sets `settingSources: ["user","project","local"]`, so a root
  `CLAUDE.md` *would* load. But none was written.

Net effect: for claude the instructions were written to disk and never read, so the agent
fell through to Claude Code's default coding persona. Pi is unaffected — Pi reads `AGENTS.md`.

## The fix

Choose the instructions filename by harness in the file-materialization step:

- claude harness -> **`CLAUDE.md`** (the name the loader reads)
- pi / everything else -> **`AGENTS.md`** (unchanged)

The filename is a materialization detail, not a wire detail — the wire already carries the
neutral `agentsMd` string and says nothing about a filename. So this lands in the runner
(the sidecar), the wire contract and golden fixtures are untouched, and the Python harness
mapper does not change. The SDK's own materialization mirror (`Harness._provisioning`) gets
the same one-line rule so both paths agree.

### Before / after (claude harness)

| | file written in cwd | loaded by claude-agent-sdk? |
| --- | --- | --- |
| before | `AGENTS.md` | no — instructions ignored |
| after | `CLAUDE.md` | yes — loaded as project memory |

## Out of scope (deliberately)

Delivering `agents_md` as an *appended system prompt* so it overrides the coding persona for
verb-less input is a separate, larger fix: `sandbox-agent` 0.4.2 strips `_meta` from
`sessionInit`, so the runner can't reach the adapter's append hook today. This PR makes
`agents_md` "considered as project memory" (the "ignored" bug); the persona-strength lever is
tracked in the design doc.

## Tests

- `services/agent/tests/unit/sandbox-agent-workspace.test.ts` — new claude cases assert
  `CLAUDE.md` (and no `AGENTS.md`) on local + Daytona; existing Pi cases still assert
  `AGENTS.md`. Full runner suite: 402 passing; `tsc --noEmit` clean.
- `sdks/python/oss/tests/pytest/unit/agents/test_environment_lifecycle.py` — new claude case
  asserts `_provisioning` returns `{"CLAUDE.md": ...}`. Full agents unit suite: 454 passing
  (wire golden unchanged).

## Verifying live

The sidecar image bakes the runner, so this is only live after a sidecar rebuild/restart.
After redeploy: create a `harness: claude` agent whose instructions are a summarizer persona,
send a bare paragraph with no instruction verb, and confirm it summarizes instead of asking
"how can I help?".

Design doc: `docs/design/agent-workflows/projects/builder-agent-reliability/agentsmd-claude-fix/README.md`

https://claude.ai/code/session_01WSp2LqKrEtXnm2fsPWuQWa
