### PR TITLE
docs(agent-workflows): streaming invoke for reliable multi-tool output

### DIFF
--- a/docs/design/agent-workflows/projects/builder-agent-reliability/streaming-invoke/README.md
+++ b/docs/design/agent-workflows/projects/builder-agent-reliability/streaming-invoke/README.md
@@ -1,0 +1,55 @@
+# Streaming invoke — reliable multi-tool output
+
+Design docs only. No code.
+
+A well-formed multi-tool agent run (list Slack channels, read GitHub commits/issues, post to
+Slack) comes back from the batch invoke as an EMPTY or mid-sentence reply, even when every tool
+executed. The caller cannot tell from the response whether the run reached its terminal action —
+it has to read the trace spans to find out. That is the "unreliable output" the builder kit works
+around today with a separate `check-tools.sh` span query.
+
+The full turn — every tool call, every tool result, the stop reason — is already produced by the
+runner and is fully visible over a **streaming invoke** (`Accept: application/x-ndjson`), confirmed
+live. Batch returns only the final assistant text, by design.
+
+## The direction
+
+Use **streaming everywhere** the full turn matters, and leave batch alone.
+
+- **Batch is unchanged.** It returns one final assistant message
+  (`services/oss/src/agent/app.py:303-321`). We are not coalescing the full turn into it.
+- **The external client streams** to get the whole turn. Already done in the lab kit
+  (`test-agent.sh`).
+- **The platform's own invoke must stream too.** When Agenta invokes an agent from inside the
+  platform — an agent invoking another app/agent as a tool, an evaluation running a
+  workflow-under-test, a trigger firing a workflow — it sends `Accept: application/json` today and
+  gets the same partial output. The proposed change is a draining `invoke_workflow_streaming` variant
+  on `WorkflowsService`, applied first to the workflow/agent-as-tool path
+  (`api/oss/src/apis/fastapi/tools/router.py:1306`).
+- **The approval boundary is a bug.** An auto-approved run stops at the tool gate because the runner
+  parks on any session id before consulting the `auto` policy
+  (`services/agent/src/responder.ts:257`). Full detail and fix in `approval-boundary.md`.
+
+## Files
+
+- `context.md` — the symptom, the live reproduction (batch vs streaming, same input), the direction
+  (stream everywhere, batch untouched), and the approval-boundary bug in brief. Goals and non-goals.
+- `research.md` — the mechanism with `file:line` citations: the batch handler, the streaming emitter,
+  the `AgentResult` shape, the Accept→`flags.stream` negotiation, the event vocabulary, **where the
+  platform invokes agents (batch vs streaming)**, and the corrected approval-boundary mechanism.
+- `plan.md` — the direction and the platform-side change: the draining `invoke_workflow_streaming`
+  variant, which platform sites to convert (workflow-as-tool first, evaluations second, triggers/
+  sessions already detached), the decisions, and the test matrix.
+- `approval-boundary.md` — the detailed page on the auto-approve-stops-at-the-gate bug: exact
+  behavior, root cause, when it was introduced (commit `b109cc51ef`), how the frontend hides it via
+  resume, the verdict (bug), and the recommended fix.
+- `status.md` — current state, what is decided, open questions, and what feedback this needs.
+
+## Status
+
+Design under review. Live-verified on `bighetzner.agenta.dev`. Sibling of `invoke-validation/`
+(that one is malformed-request → silent 500; this one is well-formed-run → partial output). The lab
+kit half (use streaming in `test-agent.sh`, make `check-tools.sh` optional) already shipped in
+`agent-creation-lab/kit/`; this workspace covers the platform-side change and the approval-boundary
+bug. See `status.md`.
+</content>

--- a/docs/design/agent-workflows/projects/builder-agent-reliability/streaming-invoke/approval-boundary.md
+++ b/docs/design/agent-workflows/projects/builder-agent-reliability/streaming-invoke/approval-boundary.md
@@ -1,0 +1,235 @@
+# Approval boundary — an auto-approved run stops at the tool gate (bug)
+
+This page investigates a specific behavior the streaming reproduction exposed, decides whether it is
+a bug, shows how the frontend hides it, pins when it was introduced with a commit, and recommends a
+fix. It is the detailed companion to `context.md` and `research.md`.
+
+## The behavior we see
+
+Same run as the rest of this workspace: the `uc9-digest` agent with tools `LIST_COMMITS`,
+`LIST_REPOSITORY_ISSUES`, `LIST_ALL_CHANNELS`, then the side-effecting `SEND_MESSAGE`. The agent is
+configured headless with `runner.interactions.headless: "auto"` (auto-approve).
+
+- **Streaming** trace `894862fe8af0c3aae9e63e2637babab9`: the stream runs `LIST_COMMITS`,
+  `LIST_REPOSITORY_ISSUES`, `LIST_ALL_CHANNELS` with their `tool_result`s, then emits
+  `tool_call SEND_MESSAGE`, an `interaction_request` (`kind: user_approval`), `usage`, `done`. Four
+  `tool_call`s, only three `tool_result`s. The run **stops at the `SEND_MESSAGE` gate**; the terminal
+  tool's result never streams.
+- **Batch** trace `901d24c25f3491fe3badbbb521ea5a55`: the same run, so the assistant text ends
+  mid-sentence right before the terminal tool. Batch returns only the final assistant text, so the
+  stop is invisible except that the reply is cut off.
+
+The puzzle the user raised: the tool is set to **auto-approve**, and the auto-approval happens inside
+the sidecar. That is not a real human interaction. So the run should just continue — approve in
+place, run the tool, stream its result, finish. Instead it emits an `interaction_request` and stops.
+This page confirms that is a bug and shows exactly why it happens.
+
+## Why the run stops — the root cause, in one chain
+
+The stop is not the `auto` policy running the tool out of band. The `auto` policy is never consulted.
+One line short-circuits it.
+
+1. **The permission event is emitted unconditionally, before any policy decision.** When the harness
+   raises an ACP permission request, `attachPermissionResponder` first emits the
+   `interaction_request(user_approval)` event, then asks the responder what to do
+   (`services/agent/src/engines/sandbox_agent/permissions.ts:63-77`). This is the only emitter of
+   `kind: user_approval` in the codebase, so the event in the trace fires for every gate the harness
+   raises, regardless of policy.
+
+2. **The responder parks on a "human surface" before it checks the policy.**
+   `HITLResponder.onPermission` (`services/agent/src/responder.ts:254-259`):
+
+   ```ts
+   async onPermission(request: PermissionRequest): Promise<ResponderOutcome> {
+     const stored = this.lookupPermission(request);
+     if (stored) return stored;
+     if (this.hasHumanSurface) return "park";               // line 257 — parks REGARDLESS of policy
+     return this.basePolicy === "deny" ? "deny" : "allow";  // headless-only, unreachable in practice
+   }
+   ```
+
+   Line 257 returns `park` whenever `hasHumanSurface` is true, *before* it ever looks at
+   `basePolicy`. The auto-allow branch on line 258 is only reachable when there is no human surface.
+   `PermissionPolicy` is only `"auto" | "deny"` (`responder.ts:33`) — there is no `ask` value — so the
+   responder cannot tell "this specific tool needs a human" from "the policy auto-approves
+   everything." It parks on all of them.
+
+3. **`hasHumanSurface` is just "is there a sessionId".**
+   `services/agent/src/engines/sandbox_agent.ts:511`:
+   `const hasHumanSurface = !!(request.sessionId && request.sessionId.trim());`
+   The responder is built with that flag (`sandbox_agent.ts:537-544`).
+
+4. **The SDK mints a sessionId for every invoke, headless or not.** The running-middleware normalizer
+   resolves a session id once before the handler runs and mints one when it is absent
+   (`sdks/python/agenta/sdk/middlewares/running/normalizer.py:302-308`,
+   `sdks/python/agenta/sdk/models/shared.py:13-22` — `resolve_session_id` returns `uuid4().hex`). It
+   flows into `SessionConfig.session_id` (`services/oss/src/agent/app.py:216, 254`) and becomes the
+   runner's `AgentRunRequest.sessionId`.
+
+**Put together:** every productized invoke carries a `sessionId`, so `hasHumanSurface` is always true,
+so `onPermission` always short-circuits to `park` at `responder.ts:257`, so the `auto` policy is dead
+code for any harness that raises gates. A "headless one-shot invoke" parks at the first gated tool
+exactly like an interactive one.
+
+## What "stops" actually means — park ends the turn
+
+Park is not "await a reply on the same stream." It tears the turn down and expects a *new* turn (a
+resume) to carry the decision:
+
+- On park the responder sends **no** `respondPermission`, so the gated tool is never approved
+  (`permissions.ts:85-93`).
+- `onPark` sets `parked = true`, aborts the loopback MCP, and cancels the in-flight prompt with
+  `sandbox.destroySession(session.id)` (`sandbox_agent.ts:524-536`).
+- The turn loop races the prompt against the park signal and, on park, sets
+  `stopReason: "paused"` (`sandbox_agent.ts:616-632`), then reads usage and finishes
+  (`sandbox_agent.ts:638-699`).
+
+That produces the `usage` then `done` tail we saw, with the terminal tool's `tool_result` absent
+because the tool was never run this turn. Over a one-shot HTTP invoke there is no resume, so the run
+simply ends at the gate.
+
+## Harness nuance — this is a Claude run, not Pi
+
+Only Claude gates tool use. Pi never raises ACP permission requests (`permissions: false`), so a Pi
+run never parks and never emits `user_approval`
+(`web/packages/agenta-entity-ui/src/DrillInView/SchemaControls/agentTemplate/useModelHarness.tsx:111`;
+`.../ClaudePermissionsControl.tsx:12`). The trace that emits `interaction_request(user_approval)` is
+therefore a Claude run. Claude auto-runs the read-only `LIST_*` tools via its rendered
+`.claude/settings.json` allowlist (no ACP gate), and raises a gate on the side-effecting
+`SEND_MESSAGE` — which is why we see three `tool_result`s for four `tool_call`s, with the park landing
+on the fourth. `permission_policy: "auto"` is explicitly *not* a blanket bypass of Claude's per-tool
+gates (`sdks/python/agenta/sdk/agents/adapters/claude_settings.py:30`).
+
+The tool relay has a separate per-tool permission layer for runner-executed (gateway/code) tools
+(`services/agent/src/tools/relay.ts:101-110`). It does not emit `interaction_request`, and `ask` there
+"degrades to the run policy" with an explicit `TODO(S5): surface ask to HITL` (`relay.ts:108`). So the
+per-tool `permission` field never reaches the ACP responder — a second reason the responder can only
+park all-or-nothing on the presence of a session id.
+
+## How the frontend hides it (why the playground works)
+
+The playground does not see this because it auto-answers each park and re-sends the conversation,
+which cold-replays the run to completion. A one-shot HTTP caller has no equivalent.
+
+- The chat panel drives the run with Vercel AI SDK `useChat` and an auto-resume predicate:
+  `useChat({ ..., sendAutomaticallyWhen: agentShouldResumeAfterApproval })`
+  (`web/oss/src/components/AgentChatSlice/AgentChatPanel.tsx:259-265`; same wiring in
+  `AgentChatConversation.tsx:96`).
+- `agentShouldResumeAfterApproval` returns true once a parked interaction is freshly resolved and
+  every non-provider tool part is settled
+  (`web/packages/agenta-playground/src/state/execution/agentApprovalResume.ts:108-122`). When true,
+  `useChat` re-sends the whole conversation.
+- `agentMessageQueue.ts:39-61` holds typed-ahead messages during the paused window so they do not
+  inject mid-gate.
+
+The event round-trip that closes the loop:
+
+1. SDK egress turns the runner's `interaction_request(user_approval)` into the Vercel
+   `tool-approval-request` chunk on the tool part, state `approval-requested`
+   (`sdks/python/agenta/sdk/agents/adapters/vercel/stream.py:390-434`).
+2. The frontend decision becomes a `tool_result` whose output is an `{ "approved": bool }` envelope
+   (`sdks/python/agenta/sdk/agents/adapters/vercel/messages.py:192-227`).
+3. On the resumed turn the runner reads that envelope back via `extractApprovalDecisions`
+   (`services/agent/src/responder.ts:384-408`); `HITLResponder.lookupPermission` (`responder.ts:255,
+   268-282`) resolves the re-raised gate to `allow`/`deny`, sends `respondPermission`, the tool runs,
+   and the run finishes.
+
+This is the same ingress/egress path hardened in the merged PR #4859 ("Resume HITL Deny end-to-end"),
+which fixed the deny case by emitting the `{approved}` envelope for the inline tool-part shape. The
+approve/resume machinery it relies on is exactly what a one-shot HTTP invoke lacks: there is no
+`sendAutomaticallyWhen`, nothing re-POSTs the envelope, so the turn stays at `stopReason: "paused"` and
+the tool result never arrives.
+
+## When this was introduced
+
+Before this, the runner always answered the gate inline and continued in-band. The stop was introduced
+with the HITL path and finalized as a true no-reply park.
+
+| Commit | Date | Change |
+| --- | --- | --- |
+| `965e180562` | initial | `responder.ts` created with only `PolicyResponder`: a hardcoded auto-approve answered the gate **inline**; the run always continued. |
+| `3ecd43704b` | 2026-06-23 | Split the emit into `permissions.ts`; owns today's `interaction_request(user_approval)` emit. |
+| `34026d2670` | 2026-06-24 | First `HITLResponder` + `hasHumanSurface`; the human-surface branch was `return "deny"` (deny-park). |
+| **`b109cc51ef`** | **2026-06-25** | **Decisive change.** `if (this.hasHumanSurface) return "park"` (was `"deny"`); park sends no `respondPermission`. This is where auto-approve stopped continuing in-band. |
+| `558423025e` | 2026-06-26 | `onPark → destroySession` so a parked turn ends gracefully instead of hanging (F-040). |
+| `d271ee0fa7` | 2026-06-30 | `onCreateInteraction`/`onResolveInteraction` plumbing (JP Vega). |
+
+The decisive diff (`git show b109cc51ef -- services/agent/src/responder.ts`):
+
+```diff
+-    if (this.hasHumanSurface) return "deny"; // park: do not run the unapproved tool this turn
++    if (this.hasHumanSurface) return "park"; // human must decide; end the turn, tool pending
+     return this.basePolicy === "deny" ? "deny" : "allow"; // headless: PolicyResponder parity
+```
+
+Answer to "was there a version where auto-approve continued in-band?" — yes, before 2026-06-24. The
+park was made conditional only on `hasHumanSurface`, never on the resolved policy, and because the
+normalizer always mints a `sessionId`, `hasHumanSurface` is always true, so `auto` runs park too.
+
+## Verdict — this is a bug
+
+For the `auto` policy on any non-interactive path, this is a bug, not intended behavior.
+
+- The documented intent of `permission_policy: "auto"` is to auto-approve tool prompts in a headless
+  run (`sdks/python/agenta/sdk/agents/dtos.py:846`, `responder.ts:504-506`). The `HITLResponder`
+  docstring even claims its headless branch is byte-identical to `PolicyResponder`, so `/invoke` is
+  unchanged.
+- That headless branch is unreachable in practice. The always-minted `sessionId` makes
+  `hasHumanSurface` always true, so `onPermission` short-circuits to `park` at `responder.ts:257` and
+  never consults `basePolicy`. `auto` is silently overridden into "park and wait for a human," which
+  for any non-interactive caller means "stop at the first gated tool and never finish."
+- The responder cannot even tell whether a given gate genuinely needs a human, because per-tool
+  disposition is not plumbed to it (`PermissionPolicy` is only `auto|deny`; per-tool `permission` is
+  handled only in `relay.ts` with `TODO(S5)`).
+
+## Recommended fix
+
+**Consult the policy before parking**, at `services/agent/src/responder.ts:254-259`, so an `auto` run
+streams through in-band and only a genuine human-decision policy parks:
+
+```ts
+async onPermission(request: PermissionRequest): Promise<ResponderOutcome> {
+  const stored = this.lookupPermission(request);
+  if (stored) return stored;
+  if (this.basePolicy === "deny") return "deny";
+  if (this.basePolicy === "auto") return "allow";   // continue in-band, stream the tool_result
+  if (this.hasHumanSurface) return "park";           // only when the policy genuinely defers to a human
+  return "allow";
+}
+```
+
+With `auto` answering `allow`, `permissions.ts:97-100` sends `respondPermission("once")`, the tool
+runs, its `tool_result` streams, and the turn finishes. This is exactly the user's read: an
+auto-approval inside the sidecar is not a real interaction, so the responder should answer in place and
+keep going. The `interaction_request` emit at `permissions.ts:63-75` can stay as a passive
+notification; it just must not terminate the run.
+
+**Necessary caveat (why the one-liner is not the whole story).** Today `PermissionPolicy` is only
+`auto|deny`, so the playground relies on the gate *parking* to show its approval prompt. If `auto`
+streams through, an interactive `auto` session stops prompting. The complete fix needs a third
+disposition — `ask` — or it must plumb the per-tool `permission` field already resolved in `relay.ts`
+into the ACP responder, and park **only** when the resolved disposition is `ask`. That is the
+`TODO(S5)` at `relay.ts:108`. So: the reported symptom (an `auto` run must not stop) is fixed at
+`responder.ts:257`; keeping HITL working in the playground is fixed by giving the responder an `ask`
+signal.
+
+## Key files
+
+- `services/agent/src/responder.ts` — `HITLResponder.onPermission` (254-259, the park at 257),
+  `PermissionPolicy` (33), `policyFromRequest` (507-515), `extractApprovalDecisions` (384-408).
+- `services/agent/src/engines/sandbox_agent/permissions.ts` — unconditional emit (63-75), responder
+  consult (76-77), park with no reply (85-93), `respondPermission` (97-100).
+- `services/agent/src/engines/sandbox_agent.ts` — `hasHumanSurface` (511), responder build (537-544),
+  `onPark`/`destroySession` (524-536), prompt-vs-park race and `stopReason:"paused"` (616-632).
+- `services/agent/src/tools/relay.ts` — per-tool permission layer (101-110), `TODO(S5)` (108).
+- `sdks/python/agenta/sdk/middlewares/running/normalizer.py:302-308`,
+  `sdks/python/agenta/sdk/models/shared.py:13-22` — the always-minted `session_id`.
+- `services/oss/src/agent/app.py:216, 254` — `session_id` into the runner.
+- Frontend resume: `web/oss/src/components/AgentChatSlice/AgentChatPanel.tsx:259-265`;
+  `web/packages/agenta-playground/src/state/execution/agentApprovalResume.ts:108-122`;
+  `.../agentMessageQueue.ts:39-61`.
+- SDK egress/ingress: `sdks/python/agenta/sdk/agents/adapters/vercel/stream.py:390-434`;
+  `.../vercel/messages.py:192-227`.
+- Related merged work: PR #4859 (Resume HITL Deny end-to-end).
+</content>
+</invoke>

--- a/docs/design/agent-workflows/projects/builder-agent-reliability/streaming-invoke/context.md
+++ b/docs/design/agent-workflows/projects/builder-agent-reliability/streaming-invoke/context.md
@@ -1,0 +1,96 @@
+# Context
+
+## The symptom
+
+A multi-tool agent — the `uc9-digest` repo-digest agent: `LIST_COMMITS`, `LIST_REPOSITORY_ISSUES`,
+`LIST_ALL_CHANNELS`, then `SEND_MESSAGE` — is invoked with one instruction to run all four steps
+and post to Slack. The batch invoke (`POST {host}/services/agent/v0/invoke`, default
+`Accept: application/json`) returns:
+
+```
+I have all the data. Picking `team-testing` (C085TMJJ0PK) as the test channel and posting the
+digest now.
+```
+
+That is the whole response body's assistant content: a **mid-sentence** string that ends right
+before the terminal tool call. There is no indication that the four tools ran, no digest content,
+no confirmation the post happened. A caller reading only this response cannot tell success from a
+run that wandered off and never posted. To find out, the builder kit runs a **second** request
+against `/api/spans/query` (`check-tools.sh`) and reads the tool spans.
+
+## The live reproduction (batch vs streaming, same input)
+
+Same agent, same message, two calls that differ only in the `Accept` header.
+
+**Batch** (`Accept: application/json`) — trace `901d24c25f3491fe3badbbb521ea5a55`:
+- Response: one assistant message, `"...posting the digest now."` (105 chars, mid-sentence).
+- `/api/spans/query` on the trace: all four tools executed, including `SEND_MESSAGE`.
+
+**Streaming** (`Accept: application/x-ndjson`) — trace `894862fe8af0c3aae9e63e2637babab9`:
+- 48 events: `thought_*`, `message_*`, **4 `tool_call`** (`LIST_COMMITS`,
+  `LIST_REPOSITORY_ISSUES`, `LIST_ALL_CHANNELS`, `SEND_MESSAGE`), **3 `tool_result`** (the three
+  reads), `usage`, one `interaction_request` (`kind: user_approval` on `SEND_MESSAGE`, carrying the
+  full rendered digest as `payload.toolCall.rawInput`), then `done`.
+- `/api/spans/query`: the same four tools executed.
+
+The streaming response is far more self-describing: it shows every tool the run called, in order, up
+to the terminal `SEND_MESSAGE`, plus the exact channel and digest text that tool was called with. The
+batch response, for the identical run, shows none of it. (Streaming still stops at the approval gate —
+that is the separate bug below.)
+
+Streaming is not a workaround bolted on for this test. It is a first-class negotiated format the SDK
+routing already supports (`Accept: text/event-stream | application/x-ndjson | application/jsonl`, or
+`flags.stream: true`). All three return 200 with the full event stream.
+
+## The direction: stream everywhere, leave batch alone
+
+Batch returns only the final assistant text by design, and it stays that way. It is the right shape for
+a caller that wants one final message. We are **not** reshaping batch or coalescing the full turn into
+its response.
+
+The answer to "the multi-tool output is unreliable" is to use **streaming** on every path that needs
+the whole turn. There are two such paths:
+
+1. **The external client.** A client asks for a stream (`Accept: application/x-ndjson`) and reads the
+   full turn directly. This is already done in the lab kit (`test-agent.sh` streams and prints the
+   ordered tool list; see `plan.md`).
+2. **The platform's own invoke.** When Agenta invokes an agent from *inside* the platform — an agent
+   invoking another app/agent as a tool, an evaluation running a workflow-under-test, a trigger firing
+   a workflow — the same batch-vs-stream choice applies, set by the `Accept` header the platform sends.
+   Today those paths send `Accept: application/json` and read a single batch body, so they hit the
+   identical empty/mid-sentence problem, now server-side. The platform-side change is to make the
+   result-consuming invoke paths stream and drain the event stream. Where the platform invokes agents,
+   which paths are batch today, and the proposed change are in `plan.md` and `research.md`.
+
+## The second finding: the approval boundary is a bug
+
+The streaming run stops at the `SEND_MESSAGE` gate: it emits `interaction_request` and then `done`,
+and the terminal tool's `tool_result` never streams, even though `SEND_MESSAGE` is set to
+auto-approve. The user's read is that an auto-approval inside the sidecar is not a real interaction, so
+the run should continue. That read is correct: this is a bug.
+
+The runner's `HITLResponder.onPermission` parks on any "human surface" *before* it consults the `auto`
+policy (`services/agent/src/responder.ts:257`), and the SDK mints a `sessionId` for every invoke, so
+`hasHumanSurface` is always true and the `auto` policy is never applied in-band. The playground hides
+this by auto-resending the conversation on the park (a resume); a one-shot invoke has no resume, so the
+run just stops. The full investigation — the root-cause chain, the harness nuance (Claude gates, Pi
+does not), the frontend resume mechanism, when it was introduced (commit `b109cc51ef`, 2026-06-25), and
+the recommended fix — is in `approval-boundary.md`.
+
+## Goals
+
+- Every path that needs the full turn uses streaming: the external client (done) and the platform's own
+  internal invoke paths (proposed).
+- Leave batch as it is: one final assistant message, negotiated by `Accept: application/json`.
+- Fix the approval-boundary bug so an auto-approved run continues in-band and its terminal tool's result
+  reaches the streamed output.
+
+## Non-goals
+
+- Changing the batch response shape or the `flags.history` knob.
+- Changing how the runner produces events, or the tracing pipeline.
+- Request-shape validation (owned by the sibling `invoke-validation/`).
+- Building an interactive human-approval reply channel over one-shot HTTP invoke. The approval-boundary
+  fix only asks that an *auto*-approved tool run in-band; it does not add human approval to a headless
+  call.
+</content>

--- a/docs/design/agent-workflows/projects/builder-agent-reliability/streaming-invoke/plan.md
+++ b/docs/design/agent-workflows/projects/builder-agent-reliability/streaming-invoke/plan.md
@@ -1,0 +1,128 @@
+# Plan — direction, platform-side change, decisions, tests
+
+Design only. No code in this PR.
+
+## The direction, in one line
+
+Use **streaming everywhere** the full turn matters. Batch stays exactly as it is (single final
+message). The client side already streams (the lab kit). The new work is to make the **platform's own
+internal invoke paths stream and drain the event stream**, so a run driven from inside Agenta is
+complete and self-describing the same way a streaming client call is. Separately, the approval boundary
+is a confirmed runner bug tracked in `approval-boundary.md`.
+
+## Batch is unchanged
+
+`_agent_batch` (`services/oss/src/agent/app.py:303-321`) returns only the final assistant text, and it
+keeps doing that. We are not coalescing the full turn into the batch response and not touching the
+`flags.history` knob. Batch is the right shape for callers that want one final message. The answer to
+"the multi-tool output is unreliable" is not to reshape batch; it is to use streaming on the paths that
+need the whole turn.
+
+## Streaming everywhere — the two sides
+
+### Client side (already shipped, not in this PR)
+
+Streaming already returns the full event stream today. A client gets a reliable, self-describing result
+by sending `Accept: application/x-ndjson | text/event-stream | application/jsonl` (or `flags.stream:
+true`). This is already implemented in the lab kit: `agent-creation-lab/kit/scripts/test-agent.sh`
+streams, parses the ndjson, and prints the assembled `OUTPUT`, the ordered `TOOLS` list, and any
+`APPROVAL`; `BUILD-AGENT.md`'s "Verify" section reads the `TOOLS` line as the reliable signal and marks
+`check-tools.sh` optional (research §6). No platform change is needed for a client to stream.
+
+### Platform side (the change this PR proposes)
+
+When Agenta invokes an agent **from inside the platform**, the invoke goes over HTTP to the deployed
+workflow service, and the shape is chosen by the `Accept` header the platform sends. Today every
+result-consuming platform path sends `Accept: application/json` and reads a single batch body, so it
+gets the same final-text-only response — the identical empty/mid-sentence problem, now server-side.
+
+All platform invoke traffic funnels through two methods on `WorkflowsService`
+(`api/oss/src/core/workflows/service.py`):
+
+- `invoke_workflow` (2073) → `_post_service_json` (2101), which sends `Accept: application/json`
+  (service.py:556) and reads one JSON body. **Batch.**
+- `invoke_workflow_detached` (2115) → `_stream_service_started` (2152), which sends
+  `Accept: application/x-ndjson` (service.py:602) but reads only the **first** frame and closes the
+  connection (service.py:630, 643). **Fire-and-forget**, not a drained turn.
+
+No platform call site drains the full agent event stream synchronously. The result-consuming sites:
+
+| Platform invoke site | File:line | Today | Note |
+| --- | --- | --- | --- |
+| **Workflow/agent as a tool** (an agent invoking another app/agent as a tool) | `api/oss/src/apis/fastapi/tools/router.py:1306` → `invoke_workflow`, reads `response.data.outputs` (1320) | **Batch** | The real one. An agent-as-tool gets only the callee's final text, so a multi-tool callee returns the same partial output. |
+| Trigger / schedule dispatch | `api/oss/src/tasks/asyncio/triggers/dispatcher.py:296` (batch fallback) vs `api/entrypoints/routers.py:768` `_dispatch_detached_run` (production) | **Detached in production**; batch only in the minimal/test composition | Production wires `dispatch_fn=_dispatch_detached_run` (routers.py:807-811), so a fired trigger runs detached (runner owns the run, persists out of band). It does not synchronously consume a result, so it does not surface the partial-output symptom the same way. |
+| Session respond-via-invoke | `api/oss/src/tasks/asyncio/sessions/interactions_dispatcher.py:72` / `sessions/router.py:852` (batch fallback) vs `worker_interactions.py:103` detached (production) | **Detached in production**; batch fallback | Same two-way switch as triggers. |
+| Evaluations runtime | `api/oss/src/core/evaluations/runtime/adapters.py:104, 508` → `invoke_workflow`, reads `response.outputs` | **Batch** | The workflow-under-test runs batch; the adapter reads only the terminal `outputs`/`status`. |
+
+The Accept→`flags.stream` negotiation that makes this work is
+`sdks/python/agenta/sdk/decorators/routing.py:551-554` (`STREAM_MEDIA_TYPES` at 117-119), consumed at
+`services/oss/src/agent/app.py:214`. So the platform-side change is a header change plus a drain.
+
+### The proposed platform-side change
+
+Add a draining streaming variant on `WorkflowsService`, e.g. `invoke_workflow_streaming`, that:
+
+1. Reuses the `_prepare_invoke` prelude (service.py:2086) for auth and ref resolution.
+2. Sends `Accept: application/x-ndjson` and opens `client.stream("POST", .../invoke, ...)` like
+   `_stream_service_started` (service.py:614), but **drains all frames** with `aiter_lines`
+   (accumulating the `{"kind":"event"}` records and the terminal `{"kind":"result"}`) instead of
+   returning on the first frame (service.py:643).
+3. Produces the already-declared-but-unused `WorkflowServiceStreamResponse` (service.py:2084) carrying
+   the full turn plus the terminal result.
+
+Then, per site:
+
+- **Workflow/agent as a tool (`tools/router.py:1306`) — highest value.** Switch to the draining
+  variant so the tool result reflects the callee's full turn (every tool call/result, the terminal
+  action), not just its final text. The router already has an events channel (`_emit_data_event`,
+  tools/router.py:1365) it can forward intermediate events onto, and it still emits the terminal
+  `ToolResult` on the terminal record.
+- **Evaluations (`adapters.py:104, 508`).** Switch to the draining variant, keep the last result, and
+  map its terminal `outputs`/`status`/`trace_id` to `WorkflowExecutionResult` exactly as today. The
+  change is internal to the runner method; the adapters already read only the terminal fields. Optional
+  per-event progress callbacks give live token/step visibility.
+- **Triggers / schedules / session respond.** Production already streams via the detached path. If we
+  want *inline* drain-to-completion (with intermediate persistence) rather than fire-and-forget, swap
+  the batch fallback for the draining variant and write incremental delivery rows as events arrive
+  (dispatcher writes one terminal row today at dispatcher.py:343). Otherwise leave as-is.
+
+## The approval boundary (tracked as a bug, see `approval-boundary.md`)
+
+Streaming fixes observability of the turn, but a related runner bug means an auto-approved run still
+stops at the tool gate. `HITLResponder.onPermission` parks on any "human surface" before it consults
+the `auto` policy (`services/agent/src/responder.ts:257`), and the SDK mints a `sessionId` for every
+invoke, so `hasHumanSurface` is always true and `auto` never auto-approves in-band. The turn ends at the
+gate with `stopReason: "paused"`; the terminal tool's `tool_result` never streams. The playground hides
+this by auto-resending on the park (resume); a one-shot invoke has no resume. This is a bug. The full
+investigation, the git history (introduced in `b109cc51ef`, 2026-06-25), the frontend resume mechanism,
+and the recommended fix at `responder.ts:254-259` are in `approval-boundary.md`. Streaming everywhere
+depends on this fix to carry the terminal gated tool's result all the way through.
+
+## Decisions
+
+1. **Batch unchanged.** Decided. No coalescing, no history-default change.
+2. **Streaming everywhere the full turn matters.** Client side done; platform side is the
+   `invoke_workflow_streaming` drain above.
+3. **First platform site to convert:** workflow/agent-as-tool (`tools/router.py:1306`) — it is the one
+   result-consuming batch path that visibly reproduces the partial-output problem. Evaluations second.
+   Triggers/sessions already stream via detached; convert to inline drain only if we want live
+   persistence.
+4. **Approval boundary is a bug** (`approval-boundary.md`), fixed at `responder.ts:257` with the
+   `ask`-disposition follow-up. Streaming everywhere is only fully reliable once this lands.
+
+## Test matrix (for the implementation PR, not this one)
+
+- Streaming client, multi-tool run: full event stream, all tool calls/results in order — regression
+  guard (unchanged today, must stay unchanged).
+- Batch, single-tool and multi-tool: unchanged, one final assistant message (batch is untouched).
+- Platform workflow-as-tool, multi-tool callee: after the drain, the `ToolResult` reflects the callee's
+  full turn and terminal action, not just its final text.
+- Evaluations runtime, multi-tool workflow-under-test: terminal `outputs`/`status`/`trace_id`
+  unchanged after switching to the draining variant (behavior-preserving for the adapter).
+- Approval boundary (once the `responder.ts` fix lands): an `auto` run streams past the gated terminal
+  tool and emits its `tool_result`; the playground still surfaces an approval prompt when the
+  disposition is `ask`. Capture a live pass as an agent replay test (per the `agent-replay-test` skill).
+- `keep-docs-in-sync`: update the agent-workflows invoke docs and the interface inventory to state that
+  the full-turn path is streaming (client and platform), that batch returns only the final message by
+  design, and the approval-boundary fix.
+</content>

--- a/docs/design/agent-workflows/projects/builder-agent-reliability/streaming-invoke/research.md
+++ b/docs/design/agent-workflows/projects/builder-agent-reliability/streaming-invoke/research.md
@@ -1,0 +1,157 @@
+# Research — the mechanism, with citations
+
+All paths are from the repo root. Live evidence is from `bighetzner.agenta.dev`, project
+`019f1a24-52d1-7253-a675-e569105bc0b5`, agent `019f1a84-b778-7c22-97ce-3816e5edbb09` (UC9 Repo
+Digest).
+
+## 1. Batch returns the final text; streaming yields the full turn
+
+`services/oss/src/agent/app.py`, the `_agent` handler picks its shape from the `stream` flag
+(`app.py:214`), which the HTTP edge negotiates from `Accept` (see §3):
+
+- `stream = True` → `_agent_event_stream` (`app.py:282-300`): runs `harness.stream(...)` and yields
+  **every** event as a neutral `{"type": event.type, "data": event.data}` dict.
+- `stream = False` → `_agent_batch` (`app.py:303-321`): runs the **same** `harness.stream(...)`,
+  drains it (`async for _ in run: pass`), takes `result = run.result()`, and returns:
+
+  ```python
+  return {"messages": [{"role": "assistant", "content": result.output}]}
+  ```
+
+So batch returns one synthetic assistant message holding only `result.output` (the final text). This
+is by design and stays that way (see `plan.md`): batch is the single-final-message shape. Streaming is
+the shape that carries the whole turn. The point of this workspace is to use streaming on every path
+that needs the full turn, not to reshape batch.
+
+## 2. `AgentResult` carries the full turn (what a drain consumes)
+
+`sdks/python/agenta/sdk/agents/dtos.py:504-517`:
+
+```python
+class AgentResult(BaseModel):
+    output: str = ""                    # the final assistant text (what batch returns)
+    messages: List[Message] = []        # the full turn
+    events: List[Event] = []            # every tool_call / tool_result / thought / message / usage
+    usage: Optional[Dict[str, Any]] = None
+    stop_reason: Optional[str] = None   # e.g. "tool_use" vs "end_turn"
+    ...
+```
+
+`result_from_wire` (`sdks/python/agenta/sdk/agents/utils/wire.py:149-183`) parses the runner's `/run`
+result and populates `messages`, `events`, and `stop_reason` from the wire (`data["messages"]`,
+`data["events"]`, `data["stopReason"]`). So the runner emits the full turn and the SDK models it. This
+matters for the platform-side drain (§5): a streaming platform caller drains these events and reads the
+terminal result rather than the batch `output`.
+
+## 3. Streaming is a first-class, already-supported format
+
+`sdks/python/agenta/sdk/decorators/routing.py`:
+
+- `STREAM_MEDIA_TYPES = {text/event-stream, application/x-ndjson, application/jsonl}`
+  (`routing.py:117-119`).
+- The invoke endpoint fills `flags.stream` from `Accept` when the body did not set it
+  (`routing.py:551-554`): `_flags["stream"] = _accept in STREAM_MEDIA_TYPES`. An explicit body
+  `flags.stream` wins; the header only fills an unset flag.
+- `handle_invoke_success` (`routing.py:333-394`) returns a `StreamingResponse` for a stream Accept
+  (`_make_stream_response`, `routing.py:268-305`): ndjson (`{...}\n` per event) or SSE
+  (`data: {...}\n\n`). A batch response with a stream Accept → 406.
+
+Live confirmation (tiny "hi" probe):
+- `Accept: application/x-ndjson` → 200, `content-type: application/x-ndjson`, ndjson event lines.
+- `Accept: text/event-stream` → 200, SSE frames.
+- `Accept: application/jsonl` → 200, ndjson.
+- body `flags.stream:true` + `Accept: application/json` → **406** "Runnable produced a stream
+  response but Accept requested 'application/json'." (correct: you must ask for a stream Accept).
+
+## 4. The event vocabulary
+
+`Event` (`dtos.py:332-346`): `type` ∈ `message | thought | tool_call | tool_result | usage | error
+| done`, `data` carries the rest verbatim. The live wire is finer-grained (the runner passes ACP
+`session/update`s through): observed types include `message_start`, `message_delta`, `message_end`,
+`thought_start`, `thought_delta`, `thought_end`, `tool_call`, `tool_result`, `usage`,
+`interaction_request`, `done`. Field shapes captured live:
+
+- `tool_call.data`: `{ type, id, name, input }` — `name` is the full
+  `mcp__agenta-tools__<integration>__<ACTION>`.
+- `tool_result.data`: `{ type, id, isError, output }`.
+- `message_delta.data`: `{ type, id, delta }` — concatenate `delta` to assemble the reply.
+- `interaction_request.data`: `{ type, id, kind, payload }` where `payload.toolCall.title` is the
+  gated tool and `payload.toolCall.rawInput` is its arguments.
+
+## 5. Where the platform invokes agents (batch vs streaming)
+
+The platform (`api/`) invokes a deployed workflow/agent by HTTP `POST {service_url}/invoke`, and the
+shape is chosen by the `Accept` header the platform sends. All invoke traffic funnels through two
+methods on `WorkflowsService` (`api/oss/src/core/workflows/service.py`):
+
+- `invoke_workflow` (2073) → `_post_service_json` (2101), Accept `application/json` (service.py:556),
+  reads one JSON body. **Batch.** (Its return type names `WorkflowServiceStreamResponse`, but no code
+  path produces it today — an aspirational placeholder at service.py:2084.)
+- `invoke_workflow_detached` (2115) → `_stream_service_started` (2152), Accept `application/x-ndjson`
+  (service.py:602), but `aiter_lines` returns on the **first** frame and closes (service.py:630, 643).
+  **Fire-and-forget**, not a drained turn.
+
+Result-consuming platform invoke sites:
+
+| # | Site (file:line) | Invokes | Today |
+| --- | --- | --- | --- |
+| 1 | `api/oss/src/apis/fastapi/tools/router.py:1306` — **workflow/agent as a tool** | `invoke_workflow`, reads `response.data.outputs` (1320), serializes to `ToolResult.content` (1337) | **Batch** |
+| 2 | `api/oss/src/tasks/asyncio/triggers/dispatcher.py:296` — trigger/schedule (batch fallback) | `invoke_workflow`, reads `response.outputs` (317) | Batch fallback; **detached in production** |
+| 3 | `api/oss/src/tasks/asyncio/sessions/interactions_dispatcher.py:72` / `sessions/router.py:852` — session respond | `invoke_workflow` | Batch fallback; **detached in production** |
+| 4 | `api/oss/src/core/evaluations/runtime/adapters.py:104, 508` — evaluation runtime | `invoke_workflow`, reads `response.outputs` (125, 539) | **Batch** |
+| — | `api/entrypoints/routers.py:768` / `worker_interactions.py:103` — `_dispatch_detached_run` | `invoke_workflow_detached` | Detached (single frame) |
+
+Note on sites 2/3: the dispatchers have a two-way switch — `if self._dispatch_fn is not None:` they take
+the detached path (dispatcher.py:270-293; interactions_dispatcher.py:63-70). The real composition roots
+supply `dispatch_fn=_dispatch_detached_run` (routers.py:807-811; worker_interactions.py:114), so
+triggers/schedules and session-respond run **detached** in production; the `invoke_workflow` batch
+branches are minimal/test-composition fallbacks. Detached does not synchronously consume a result, so it
+does not surface the partial-output symptom the way the batch sites do.
+
+**Key gap:** no platform call site drains the full agent event stream synchronously. `_stream_service_
+started` reads one handshake frame and abandons the rest; every path that wants a *result* uses the
+batch method and gets final text (agent) / terminal `outputs` (workflows). The proposed change (a
+draining `invoke_workflow_streaming` variant) is in `plan.md`.
+
+The only full drains of the stream in the tree are inside the deployed service, not the platform API:
+`sdks/python/agenta/sdk/agents/utils/ts_runner.py:176, 188` (`deliver_http_stream`, harness → TS runner)
+and the runner itself. The producers are `routing.py:290, 295, 298, 302` (`StreamingResponse`) and the
+agent `_agent_event_stream`.
+
+## 6. The approval boundary — corrected mechanism (full detail in `approval-boundary.md`)
+
+An earlier draft of this research guessed that the headless `auto` policy answered the approval and ran
+the terminal tool out of band after the stream closed. That guess was **wrong**. The correct mechanism,
+pinned by a deeper investigation:
+
+- The `auto` policy is never consulted. `HITLResponder.onPermission` returns `park` whenever
+  `hasHumanSurface` is true (`services/agent/src/responder.ts:257`), **before** it looks at
+  `basePolicy`.
+- `hasHumanSurface` is just `!!sessionId` (`services/agent/src/engines/sandbox_agent.ts:511`), and the
+  SDK normalizer mints a `sessionId` for every invoke (`sdks/python/agenta/sdk/middlewares/running/
+  normalizer.py:302-308`, `sdks/python/agenta/sdk/models/shared.py:13-22`). So `hasHumanSurface` is
+  always true and `auto` is dead code for a gating harness.
+- Park sends no `respondPermission` (`permissions.ts:85-93`), calls `destroySession`
+  (`sandbox_agent.ts:524-536`), and ends the turn with `stopReason: "paused"`
+  (`sandbox_agent.ts:616-632`). The gated tool never runs this turn, so its `tool_result` is not in the
+  stream. The span showing `SEND_MESSAGE` executed is from a resume or a relay/gate timing race, not an
+  inline auto-approval — it is not statically provable from this repo.
+- Only Claude gates (`permissions: false` for Pi), so the trace is a Claude run; the read-only `LIST_*`
+  tools are allowlisted (no gate), `SEND_MESSAGE` gates and parks.
+
+This is a bug for `auto` on any non-interactive path. The frontend hides it by auto-resending on the
+park (`useChat` + `sendAutomaticallyWhen: agentShouldResumeAfterApproval`). It was introduced in commit
+`b109cc51ef` (2026-06-25). The recommended fix is at `responder.ts:254-259`. Full report, git history,
+frontend resume mechanism, and fix: `approval-boundary.md`.
+
+## 7. What the lab kit did with these findings (already shipped, not in this PR)
+
+`agent-creation-lab/kit/scripts/test-agent.sh` now invokes with `Accept: application/x-ndjson`,
+parses the ndjson, and prints an `OUTPUT` line (assembled message deltas), a `TOOLS` line (every
+`tool_call` in order + call/result counts), and an `APPROVAL` line (any `interaction_request`).
+`BUILD-AGENT.md`'s "Verify" section was rewritten to read the `TOOLS` line as the reliable
+"did it reach the terminal tool" signal and to mark `check-tools.sh` optional (a fallback only for
+confirming a gated WRITE's `ok:true`, the approval-boundary gap). This is the client-side proof that
+streaming everywhere is the right shape; the platform-side change extends the same drain to Agenta's own
+internal invoke paths.
+</content>

--- a/docs/design/agent-workflows/projects/builder-agent-reliability/streaming-invoke/status.md
+++ b/docs/design/agent-workflows/projects/builder-agent-reliability/streaming-invoke/status.md
@@ -1,0 +1,73 @@
+# Status
+
+**State: design under review. No platform code changed.** Live-verified on
+`bighetzner.agenta.dev`.
+
+The direction is **streaming everywhere** the full turn matters, with **batch left unchanged**. The
+external client already streams (the lab kit). The platform's own internal invoke paths still send
+`Accept: application/json` and get the same partial output, so the platform-side change is to make the
+result-consuming invoke paths stream and drain the event stream. A separate, confirmed runner bug (the
+approval boundary) stops an auto-approved run at the tool gate; it is documented in
+`approval-boundary.md`.
+
+## What is decided / established
+
+- **Batch is unchanged.** `_agent_batch` returns one final assistant message
+  (`services/oss/src/agent/app.py:303-321`). We do not coalesce the full turn into it and do not touch
+  `flags.history`. Decided from the user's review.
+- **Streaming is the full-turn path** and is a first-class negotiated format
+  (`Accept: application/x-ndjson | text/event-stream | application/jsonl`, or `flags.stream:true`);
+  the batch↔stream choice is `flags.stream`, negotiated from `Accept`
+  (`sdks/python/agenta/sdk/decorators/routing.py:551-554`). Confirmed live.
+- **Client side shipped.** The lab kit `agent-creation-lab/kit/scripts/test-agent.sh` streams (prints
+  OUTPUT + ordered TOOLS + APPROVAL) and `BUILD-AGENT.md` reads the TOOLS line as the reliable signal;
+  `check-tools.sh` marked optional. Not in this PR.
+- **Platform invoke paths mapped** (research §5). All platform invoke goes through
+  `WorkflowsService.invoke_workflow` (batch, `Accept: application/json`, service.py:556) or
+  `invoke_workflow_detached` (single-frame ndjson, service.py:602-643). Result-consuming batch sites:
+  workflow/agent-as-tool (`api/oss/src/apis/fastapi/tools/router.py:1306`), evaluations runtime
+  (`api/oss/src/core/evaluations/runtime/adapters.py:104, 508`). Triggers/schedules and session-respond
+  run detached in production. No platform path drains the full stream synchronously.
+- **Platform-side proposal:** a draining `invoke_workflow_streaming` variant on `WorkflowsService`
+  (Accept ndjson + drain all frames to the terminal result), converting workflow/agent-as-tool first,
+  evaluations second. Detail in `plan.md`.
+- **Approval boundary is a bug** (`approval-boundary.md`). `HITLResponder.onPermission` parks on any
+  session id before consulting the `auto` policy (`services/agent/src/responder.ts:257`), and the SDK
+  mints a `sessionId` for every invoke, so `auto` never auto-approves in-band; the turn ends at the gate
+  with `stopReason: "paused"`. Introduced in `b109cc51ef` (2026-06-25). The playground hides it by
+  auto-resending on the park. Recommended fix at `responder.ts:254-259`.
+
+## Live evidence
+
+- Batch trace `901d24c25f3491fe3badbbb521ea5a55` — response was mid-sentence
+  `"...posting the digest now."`; spans show all 4 tools ran.
+- Streaming trace `894862fe8af0c3aae9e63e2637babab9` — 48 events, all 4 `tool_call`s incl.
+  `SEND_MESSAGE`, 3 `tool_result`s, the `user_approval` interaction with the full digest payload,
+  `done`; the run stops at the gate (approval-boundary bug).
+- Re-run via the new streaming `test-agent.sh`: trace `1af7bda57e9ae50d388b6c567130ce77` — the
+  invoke response itself listed `github__LIST_COMMITS -> github__LIST_REPOSITORY_ISSUES ->
+  slack__LIST_ALL_CHANNELS -> slack__SEND_MESSAGE (4 calls, 3 results)` plus the approval line, with
+  no separate span query.
+
+## Open questions
+
+1. **First platform site to convert.** Lean workflow/agent-as-tool (`tools/router.py:1306`) — it is the
+   result-consuming batch path that visibly reproduces the partial output. Evaluations second. Do
+   triggers/sessions need inline drain (with intermediate persistence) or is detached fire-and-forget
+   enough? Lean: leave detached unless live persistence is wanted.
+2. **`invoke_workflow_streaming` shape.** Confirm the terminal `{"kind":"result"}` record populates
+   `messages`/`events`/`stop_reason` the same way `result_from_wire` populates the one-shot `/run`
+   result (`wire.py:149-183`), so the drained platform result is behavior-preserving for the adapters.
+3. **Approval-boundary fix scope.** The one-liner at `responder.ts:257` makes `auto` stream through, but
+   the playground relies on the park to show its approval prompt. Add an `ask` disposition (or plumb the
+   per-tool `permission` from `relay.ts`, `TODO(S5)` at relay.ts:108) so it parks only on a genuine
+   human decision. Sequence the one-liner and the `ask` disposition.
+
+## Next steps
+
+- Get this design reviewed (see the PR comment for exactly what feedback is needed).
+- On approval: implement the draining `invoke_workflow_streaming` variant and convert workflow/
+  agent-as-tool + evaluations; fix the approval boundary at `responder.ts` with the `ask`-disposition
+  follow-up; capture a live pass as a replay test; run `keep-docs-in-sync` for the invoke docs +
+  interface inventory.
+</content>


### PR DESCRIPTION
## What

Design docs only (no code). Second-round revision of the streaming-invoke workspace under `docs/design/agent-workflows/projects/builder-agent-reliability/streaming-invoke/`, per the review on this PR. Now six files (adds `approval-boundary.md`).

## The direction (revised)

Use **streaming everywhere** the full turn matters, and **leave batch alone**.

- **Batch is unchanged.** `_agent_batch` keeps returning one final assistant message (`services/oss/src/agent/app.py:303-321`). The earlier batch-coalescing proposal is dropped.
- **The external client streams** to get the whole turn (already shipped in the lab kit `test-agent.sh`).
- **The platform's own invoke must stream too.** When Agenta invokes an agent from inside the platform, it sends `Accept: application/json` today and gets the same partial output. The result-consuming batch paths are the **workflow/agent-as-tool** path (`api/oss/src/apis/fastapi/tools/router.py:1306`) and the **evaluations runtime** (`api/oss/src/core/evaluations/runtime/adapters.py:104,508`). Triggers/schedules and session-respond run **detached** in production, not batch. Proposal: a draining `invoke_workflow_streaming` variant on `WorkflowsService`, applied to workflow-as-tool first.

## New page: `approval-boundary.md`

An auto-approved run stops at the tool gate. `HITLResponder.onPermission` returns `park` whenever a session id is present, **before** it consults the `auto` policy (`services/agent/src/responder.ts:257`), and the SDK mints a `sessionId` for every invoke, so `auto` never auto-approves in-band. The turn ends at the gate with `stopReason: "paused"`; the terminal tool's `tool_result` never streams. The playground hides this by auto-resending on the park (`useChat` + `sendAutomaticallyWhen`). Introduced in commit `b109cc51ef` (2026-06-25). **Verdict: bug.** Recommended fix at `responder.ts:254-259`, with an `ask`-disposition follow-up so the playground still prompts.

Built via temp-index `commit-tree` on `origin/big-agents` (zero working-tree touch). Diff is exactly the six doc files.

https://claude.ai/code/session_01WSp2LqKrEtXnm2fsPWuQWa