### PR TITLE
fix(api): Composio catalog emit canonical action slugs

### DIFF
--- a/api/oss/src/core/tools/providers/composio/catalog.py
+++ b/api/oss/src/core/tools/providers/composio/catalog.py
@@ -209,9 +209,15 @@ class ComposioCatalogClient:
         """
         page_limit = min(limit, MAX_PAGE_SIZE) if limit else DEFAULT_PAGE_SIZE
 
+        # Do NOT pin ``toolkit_versions=latest`` here: Composio's "latest" toolkit
+        # version emits SHORT action slugs (e.g. GITHUB_ACCEPT_REPOSITORY_INVITATION)
+        # that its single-tool GET and execute endpoints reject unless the same
+        # version is threaded through — and execute rejects the latest short slugs
+        # outright. The default (pinned) toolkit version emits the canonical LONG
+        # slugs (GITHUB_ACCEPT_A_REPOSITORY_INVITATION) that get_action AND execute
+        # both accept with no version param, so list/get/execute stay consistent.
         params: Dict[str, Any] = {
             "toolkit_slug": integration_key,
-            "toolkit_versions": "latest",
             "include_deprecated": False,
             "limit": page_limit,
         }


### PR DESCRIPTION
## Problem

Attaching Composio gateway tools to an agent and running it fails with `Gateway tool resolution failed (HTTP 404)`.

## Root cause

`list_actions` (the source the tool picker reads) queried Composio with `toolkit_versions=latest`, which returns **short** action slugs (e.g. `GITHUB_ACCEPT_REPOSITORY_INVITATION`). But `get_action` (`GET /tools/{slug}`) and `execute` (`POST /tools/execute/{slug}`) send no version, so Composio resolves against its default **pinned** toolkit version whose canonical slugs are the **long** form (`GITHUB_ACCEPT_A_REPOSITORY_INVITATION`).

The picker handed the agent short slugs → resolve-time `get_action(short)` → Composio 404 → `ActionNotFoundError` → the tools router maps it to HTTP 404 → the SDK gateway resolver raises `GatewayToolResolutionError (HTTP 404)`. Composio's `latest` execute endpoint also rejects the short slugs, so `latest` is unusable end-to-end.

## Fix

Drop `toolkit_versions=latest` so the catalog emits canonical slugs that list + get + execute all accept.

## Verification

Verified on a live self-host:
- `list_actions` now returns canonical slugs.
- `GET /tools/catalog/providers/composio/integrations/<int>/actions/<CANONICAL>` → 200 (short slug was 404).
- `resolve_tools` for real github/slack connections → OK.

## Note for operators

Agents configured before this fix reference the old short slugs and must have their tools re-selected in the picker. Also flush any cached `tools:catalog*` / `tools:discover*` keys.

https://claude.ai/code/session_01STbkKsnAUZn5v9PiDRiSsY
