### PR TITLE
fix(hosting): don't strip /api at Traefik (fixes broken self-host redirects)

### DIFF
--- a/hosting/docker-compose/ee/docker-compose.gh.local.yml
+++ b/hosting/docker-compose/ee/docker-compose.gh.local.yml
@@ -72,9 +72,8 @@ services:
         labels:
             - "traefik.http.routers.api.rule=PathPrefix(`/api/`)"
             - "traefik.http.routers.api.entrypoints=web"
-            - "traefik.http.middlewares.api-strip.stripprefix.prefixes=/api"
-            - "traefik.http.middlewares.api-strip.stripprefix.forceslash=true"
-            - "traefik.http.routers.api.middlewares=api-strip"
+            # Do NOT strip /api: the app is mounted at /api (SCRIPT_NAME + FastAPI root_path).
+            # Forward /api/* unchanged so app-generated redirects keep the prefix.
             - "traefik.http.services.api.loadbalancer.server.port=8000"
             - "traefik.http.routers.api.service=api"
         # === LIFECYCLE ============================================ #

--- a/hosting/docker-compose/ee/docker-compose.gh.yml
+++ b/hosting/docker-compose/ee/docker-compose.gh.yml
@@ -81,9 +81,8 @@ services:
         labels:
             - "traefik.http.routers.api.rule=PathPrefix(`/api/`)"
             - "traefik.http.routers.api.entrypoints=web"
-            - "traefik.http.middlewares.api-strip.stripprefix.prefixes=/api"
-            - "traefik.http.middlewares.api-strip.stripprefix.forceslash=true"
-            - "traefik.http.routers.api.middlewares=api-strip"
+            # Do NOT strip /api: the app is mounted at /api (SCRIPT_NAME + FastAPI root_path).
+            # Forward /api/* unchanged so app-generated redirects keep the prefix.
             - "traefik.http.services.api.loadbalancer.server.port=8000"
             - "traefik.http.routers.api.service=api"
         # === LIFECYCLE ============================================ #

--- a/hosting/docker-compose/oss/docker-compose.gh.local.yml
+++ b/hosting/docker-compose/oss/docker-compose.gh.local.yml
@@ -70,9 +70,8 @@ services:
         labels:
             - "traefik.http.routers.api.rule=PathPrefix(`/api/`)"
             - "traefik.http.routers.api.entrypoints=web"
-            - "traefik.http.middlewares.api-strip.stripprefix.prefixes=/api"
-            - "traefik.http.middlewares.api-strip.stripprefix.forceslash=true"
-            - "traefik.http.routers.api.middlewares=api-strip"
+            # Do NOT strip /api: the app is mounted at /api (SCRIPT_NAME + FastAPI root_path).
+            # Forward /api/* unchanged so app-generated redirects keep the prefix.
             - "traefik.http.services.api.loadbalancer.server.port=8000"
             - "traefik.http.routers.api.service=api"
         # === LIFECYCLE ============================================ #

--- a/hosting/docker-compose/oss/docker-compose.gh.ssl.yml
+++ b/hosting/docker-compose/oss/docker-compose.gh.ssl.yml
@@ -75,9 +75,8 @@ services:
         labels:
             - "traefik.http.routers.api.rule=Host(`${TRAEFIK_DOMAIN}`) && PathPrefix(`/api/`)"
             - "traefik.http.routers.api.entrypoints=web,web-secure"
-            - "traefik.http.middlewares.api-strip.stripprefix.prefixes=/api"
-            - "traefik.http.middlewares.api-strip.stripprefix.forceslash=true"
-            - "traefik.http.routers.api.middlewares=api-strip"
+            # Do NOT strip /api: the app is mounted at /api (SCRIPT_NAME + FastAPI root_path).
+            # Forward /api/* unchanged so app-generated redirects keep the prefix.
             - "traefik.http.services.api.loadbalancer.server.port=8000"
             - "traefik.http.routers.api.service=api"
             - "traefik.http.routers.api.tls=true"

--- a/hosting/docker-compose/oss/docker-compose.gh.yml
+++ b/hosting/docker-compose/oss/docker-compose.gh.yml
@@ -79,9 +79,8 @@ services:
         labels:
             - "traefik.http.routers.api.rule=PathPrefix(`/api/`)"
             - "traefik.http.routers.api.entrypoints=web"
-            - "traefik.http.middlewares.api-strip.stripprefix.prefixes=/api"
-            - "traefik.http.middlewares.api-strip.stripprefix.forceslash=true"
-            - "traefik.http.routers.api.middlewares=api-strip"
+            # Do NOT strip /api: the app is mounted at /api (SCRIPT_NAME + FastAPI root_path).
+            # Forward /api/* unchanged so app-generated redirects keep the prefix.
             - "traefik.http.services.api.loadbalancer.server.port=8000"
             - "traefik.http.routers.api.service=api"
         # === LIFECYCLE ============================================ #


### PR DESCRIPTION
## Problem

On self-hosted deploys, API endpoints intermittently return `308` and the UI can get stuck (e.g. tool catalog, any no-trailing-slash request), especially behind a TLS-terminating proxy (Cloudflare, CDN, LB).

## Root cause

The app is mounted at `/api` (`SCRIPT_NAME=/api` + FastAPI `root_path="/api"`, and the auth middleware's `_PUBLIC_ENDPOINTS` lists both `/x` and `/api/x`), but Traefik **also** strips `/api` via a `stripprefix` middleware — double-accounting. The app therefore never sees `/api`; its trailing-slash redirects are built from the stripped path and drop `/api` (and use the wrong scheme behind a proxy) → Cloudflare upgrades to a 308 pointing at `/…` which hits the web app, not the API.

## Fix

Stop stripping `/api`; forward `/api/*` unchanged. The app already handles the prefix; internal service→API calls use bare paths which remain matched by the `PathPrefix(`/api/`)` router rule. This also fixes auth-middleware checks that only match `/api/...`.

Removed from each `api` service's Traefik labels (kept the router rule/entrypoint/service/port labels):

```
- "traefik.http.middlewares.api-strip.stripprefix.prefixes=/api"
- "traefik.http.middlewares.api-strip.stripprefix.forceslash=true"
- "traefik.http.routers.api.middlewares=api-strip"
```

## Files changed

Only compose files whose `api` service sets `SCRIPT_NAME=/api` were touched:

- `hosting/docker-compose/oss/docker-compose.gh.yml`
- `hosting/docker-compose/oss/docker-compose.gh.ssl.yml`
- `hosting/docker-compose/oss/docker-compose.gh.local.yml`
- `hosting/docker-compose/ee/docker-compose.gh.yml`
- `hosting/docker-compose/ee/docker-compose.gh.local.yml`

`hosting/docker-compose/ee/docker-compose.dev.yml` has the same `api-strip` pattern **but does not set `SCRIPT_NAME=/api`** (no `SCRIPT_NAME` in the service env or `.env.ee.dev`), so it was deliberately left untouched. If the dev image is in fact mounted at `/api` by other means, it should get the same strip removal in a follow-up.

## Compatibility

Safe for all deployments — no route loses coverage (public endpoints are dual-listed; internal bare-path calls still match). Verified on a live self-host: with-slash 200; no-slash now redirects to the correct `/api/...` path and resolves 200.

https://claude.ai/code/session_01STbkKsnAUZn5v9PiDRiSsY
