### PR TITLE
feat(sdk): refresh OpenRouter default model list

### DIFF
--- a/sdks/python/agenta/sdk/utils/assets.py
+++ b/sdks/python/agenta/sdk/utils/assets.py
@@ -125,38 +125,43 @@ supported_llm_models = {
         "gpt-3.5-turbo-1106",
         "gpt-3.5-turbo",
     ],
+    # OpenRouter's ~20 most-used models as of 2026-07-01, from the public usage
+    # rankings (openrouter.ai/rankings and third-party token/spend leaderboards).
+    # Every id below is also a valid key in Pi's vendored OpenRouter catalog
+    # (drop the "openrouter/" prefix), so it is settable by the Pi harness picker.
     "openrouter": [
         # Anthropic via OpenRouter
-        "openrouter/anthropic/claude-opus-4.5",
-        "openrouter/anthropic/claude-opus-4.1",
+        "openrouter/anthropic/claude-opus-4.8",
+        "openrouter/anthropic/claude-opus-4.7",
+        "openrouter/anthropic/claude-sonnet-4.6",
         "openrouter/anthropic/claude-sonnet-4.5",
-        "openrouter/anthropic/claude-haiku-4.5",
-        "openrouter/anthropic/claude-3.7-sonnet",
-        "openrouter/anthropic/claude-3.5-sonnet",
         # DeepSeek via OpenRouter
-        "openrouter/deepseek/deepseek-chat",
-        "openrouter/deepseek/deepseek-r1",
-        "openrouter/deepseek/deepseek-r1-0528",
+        "openrouter/deepseek/deepseek-v4-flash",
+        "openrouter/deepseek/deepseek-v4-pro",
         "openrouter/deepseek/deepseek-v3.2",
         # Google via OpenRouter
-        "openrouter/google/gemini-2.5-pro",
-        "openrouter/google/gemini-2.5-flash",
-        "openrouter/google/gemini-2.0-flash-001",
-        # Meta-Llama via OpenRouter
-        "openrouter/meta-llama/llama-3-70b-instruct",
-        # Mistral via OpenRouter
-        "openrouter/mistralai/mistral-large",
-        "openrouter/mistralai/mistral-small-3.2-24b-instruct",
-        "openrouter/mistralai/mixtral-8x22b-instruct",
+        "openrouter/google/gemini-3.5-flash",
+        "openrouter/google/gemini-3-flash-preview",
+        "openrouter/google/gemini-3.1-pro-preview",
+        # MiniMax via OpenRouter
+        "openrouter/minimax/minimax-m3",
+        # MoonshotAI via OpenRouter
+        "openrouter/moonshotai/kimi-k2.6",
+        # Nvidia via OpenRouter
+        "openrouter/nvidia/nemotron-3-super-120b-a12b",
         # OpenAI via OpenRouter
-        "openrouter/openai/gpt-4o",
-        "openrouter/openai/gpt-4.1",
-        "openrouter/openai/gpt-5",
+        "openrouter/openai/gpt-5.5",
+        "openrouter/openai/gpt-5.4",
         # Qwen via OpenRouter
-        "openrouter/qwen/qwen-2.5-coder-32b-instruct",
-        "openrouter/qwen/qwen3-235b-a22b-2507",
+        "openrouter/qwen/qwen3.7-max",
+        # Tencent via OpenRouter
+        "openrouter/tencent/hy3-preview",
+        # Xiaomi via OpenRouter
+        "openrouter/xiaomi/mimo-v2.5-pro",
         # xAI via OpenRouter
-        "openrouter/x-ai/grok-4",
+        "openrouter/x-ai/grok-4.3",
+        # Z.ai via OpenRouter
+        "openrouter/z-ai/glm-5",
     ],
     # NOTE: provider kind must match Secrets API enums ("perplexityai").
     # Models remain "perplexity/..." but the provider key is used to match secrets.


### PR DESCRIPTION
## What

Refresh the OpenRouter default model list in `sdks/python/agenta/sdk/utils/assets.py` to the ~20 most-used OpenRouter models as of **2026-07-01**. The previous list still led with 2025-era models (Claude 3.5/3.7 Sonnet, GPT-4o, Gemini 2.x, Mixtral, Llama-3-70B, Grok-4) that have fallen off OpenRouter's usage leaderboard.

This one list feeds three consumers, so every id is kept valid: the litellm completion path, the Pi harness model picker (`capabilities.py` `_pi_models()` reads `supported_llm_models["openrouter"]`), and the frontend picker. The `openrouter/` prefix format is preserved on every entry.

## Ranking source

OpenRouter's public usage rankings (https://openrouter.ai/rankings and https://openrouter.ai/models), cross-referenced against three mid-2026 token-volume / agent-spend leaderboards (officechai June 2026, digitalapplied April 2026, codesota agent-usage snapshot 2026-06-23). Date of ranking capture: **2026-07-01**. Selection blends raw usage with vendor breadth for a practical default picker.

## Final list (20)

```
# Anthropic
openrouter/anthropic/claude-opus-4.8
openrouter/anthropic/claude-opus-4.7
openrouter/anthropic/claude-sonnet-4.6
openrouter/anthropic/claude-sonnet-4.5
# DeepSeek
openrouter/deepseek/deepseek-v4-flash
openrouter/deepseek/deepseek-v4-pro
openrouter/deepseek/deepseek-v3.2
# Google
openrouter/google/gemini-3.5-flash
openrouter/google/gemini-3-flash-preview
openrouter/google/gemini-3.1-pro-preview
# MiniMax
openrouter/minimax/minimax-m3
# MoonshotAI
openrouter/moonshotai/kimi-k2.6
# Nvidia
openrouter/nvidia/nemotron-3-super-120b-a12b
# OpenAI
openrouter/openai/gpt-5.5
openrouter/openai/gpt-5.4
# Qwen
openrouter/qwen/qwen3.7-max
# Tencent
openrouter/tencent/hy3-preview
# Xiaomi
openrouter/xiaomi/mimo-v2.5-pro
# xAI
openrouter/x-ai/grok-4.3
# Z.ai
openrouter/z-ai/glm-5
```

## Added (18 new ids)

`claude-opus-4.8`, `claude-opus-4.7`, `claude-sonnet-4.6`, `deepseek-v4-flash`, `deepseek-v4-pro`, `gemini-3.5-flash`, `gemini-3-flash-preview`, `gemini-3.1-pro-preview`, `minimax-m3`, `kimi-k2.6`, `nemotron-3-super-120b-a12b`, `gpt-5.5`, `gpt-5.4`, `qwen3.7-max`, `hy3-preview`, `mimo-v2.5-pro`, `grok-4.3`, `glm-5`.

## Removed (21 stale ids)

`claude-opus-4.5`, `claude-opus-4.1`, `claude-haiku-4.5`, `claude-3.7-sonnet`, `claude-3.5-sonnet`, `deepseek-chat`, `deepseek-r1`, `deepseek-r1-0528`, `gemini-2.5-pro`, `gemini-2.5-flash`, `gemini-2.0-flash-001`, `llama-3-70b-instruct`, `mistral-large`, `mistral-small-3.2-24b-instruct`, `mixtral-8x22b-instruct`, `gpt-4o`, `gpt-4.1`, `gpt-5`, `qwen-2.5-coder-32b-instruct`, `qwen3-235b-a22b-2507`, `grok-4` (upgraded to `grok-4.3`).

Kept from the old list: `claude-sonnet-4.5`, `deepseek-v3.2`. **Meta-Llama and Mistral are dropped as vendors** — neither appears in any 2026 OpenRouter usage top-20; Chinese OSS models (DeepSeek, MiniMax, Moonshot, Xiaomi, Tencent, Z.ai) and the frontier families displaced them.

Two selections are vendor-breadth/continuity picks rather than strict top-20 usage cites: `x-ai/grok-4.3` (keeps xAI represented, upgrading the old `grok-4`) and one of the two Gemini flashes; all others are directly grounded in the ranking sources.

## Pi vendored-catalog cross-check

Each id (minus the `openrouter/` prefix) must be a valid key in Pi's static OpenRouter catalog to be settable by the Pi harness. Checked against `@earendil-works/pi-ai@0.79.4` (`dist/models.generated.js`, `openrouter` block).

**Result: all 20 ids are present in Pi's vendored catalog. None are missing.**

## Verification

- `from agenta.sdk.utils.assets import supported_llm_models; len(supported_llm_models["openrouter"])` → `20`.
- `ruff format` + `ruff check --fix` on `assets.py`: clean.
- `oss/tests/pytest/unit/agents/connections/test_capabilities.py`: 12 passed.

## Note on PR base

Base is `big-agents`, not `main`. This GitButler workspace targets `big-agents`, so a `main`-based PR would show ~1,634 unrelated files (the whole big-agents stack). `assets.py` is identical on `main` and `big-agents`, so this change applies cleanly to either; `big-agents` is used to keep the diff to exactly one file for review.

https://claude.ai/code/session_01HCMtsTWnCdh8fPEzGrda6C
