### PR TITLE
fix(agent): load agents_md on the claude harness via CLAUDE.md (runner half)

### DIFF
--- a/services/agent/src/engines/sandbox_agent/workspace.ts
+++ b/services/agent/src/engines/sandbox_agent/workspace.ts
@@ -28,11 +28,17 @@ export interface PrepareWorkspaceInput {
 }
 
 /**
- * Prepare the run cwd, relay directory, optional AGENTS.md, generic `harnessFiles`, and
- * non-Pi skill packages for local or Daytona runs. `harnessFiles` are written blind: the
+ * Prepare the run cwd, relay directory, the instructions memory file, generic `harnessFiles`,
+ * and non-Pi skill packages for local or Daytona runs. `harnessFiles` are written blind: the
  * Python harness adapter already rendered them. Skills stay resolved inline packages on the
  * wire; Pi installs them through its agent dir, while Claude loads project-local
  * `.claude/skills/<name>` directories from the cwd.
+ *
+ * The instructions (`agentsMd`) filename is harness-aware. Claude runs through
+ * `@anthropic-ai/claude-agent-sdk`, whose memory loader auto-loads `CLAUDE.md` only and never
+ * reads `AGENTS.md`, so for the claude harness the instructions must land in `CLAUDE.md` to be
+ * read at all (the ACP adapter's `settingSources` already includes `project`+`local`, which
+ * loads a root `CLAUDE.md`). Pi reads `AGENTS.md`, so every non-claude harness keeps that name.
  */
 export async function prepareWorkspace({
   sandbox,
@@ -41,6 +47,11 @@ export async function prepareWorkspace({
 }: PrepareWorkspaceInput): Promise<Workspace> {
   const harnessFiles = plan.harnessFiles ?? [];
   const projectSkillRoot = plan.isPi ? undefined : `.${plan.acpAgent}/skills`;
+  // Claude's memory loader reads CLAUDE.md, never AGENTS.md; Pi (and any other harness) reads
+  // AGENTS.md. See the doc comment above and docs/design/agent-workflows/projects/
+  // builder-agent-reliability/agentsmd-claude-fix/README.md.
+  const instructionsFile =
+    plan.acpAgent === "claude" ? "CLAUDE.md" : "AGENTS.md";
 
   if (plan.isDaytona) {
     await sandbox.mkdirFs({ path: plan.cwd }).catch((err: Error) => {
@@ -52,7 +63,10 @@ export async function prepareWorkspace({
       });
     }
     if (plan.agentsMd) {
-      await sandbox.writeFsFile({ path: `${plan.cwd}/AGENTS.md` }, plan.agentsMd);
+      await sandbox.writeFsFile(
+        { path: `${plan.cwd}/${instructionsFile}` },
+        plan.agentsMd,
+      );
     }
     for (const file of harnessFiles) {
       const path = `${plan.cwd}/${file.path}`;
@@ -69,7 +83,9 @@ export async function prepareWorkspace({
           skill.dir,
           `${plan.cwd}/${projectSkillRoot}/${skill.name}`,
         ).catch((err: Error) => {
-          log(`skill workspace upload skipped for ${skill.name}: ${err.message}`);
+          log(
+            `skill workspace upload skipped for ${skill.name}: ${err.message}`,
+          );
         });
       }
     }
@@ -77,7 +93,8 @@ export async function prepareWorkspace({
   }
 
   if (plan.useToolRelay) mkdirSync(plan.relayDir, { recursive: true });
-  if (plan.agentsMd) writeFileSync(join(plan.cwd, "AGENTS.md"), plan.agentsMd, "utf-8");
+  if (plan.agentsMd)
+    writeFileSync(join(plan.cwd, instructionsFile), plan.agentsMd, "utf-8");
   for (const file of harnessFiles) {
     const path = join(plan.cwd, file.path);
     mkdirSync(dirname(path), { recursive: true });

--- a/services/agent/tests/unit/sandbox-agent-workspace.test.ts
+++ b/services/agent/tests/unit/sandbox-agent-workspace.test.ts
@@ -5,7 +5,13 @@
  */
 import { afterEach, describe, it } from "vitest";
 import assert from "node:assert/strict";
-import { existsSync, mkdtempSync, readFileSync, rmSync, writeFileSync } from "node:fs";
+import {
+  existsSync,
+  mkdtempSync,
+  readFileSync,
+  rmSync,
+  writeFileSync,
+} from "node:fs";
 import { tmpdir } from "node:os";
 import { join } from "node:path";
 
@@ -20,7 +26,8 @@ function tempDir(): string {
 }
 
 afterEach(() => {
-  for (const dir of dirs.splice(0)) rmSync(dir, { recursive: true, force: true });
+  for (const dir of dirs.splice(0))
+    rmSync(dir, { recursive: true, force: true });
 });
 
 describe("prepareWorkspace", () => {
@@ -42,12 +49,44 @@ describe("prepareWorkspace", () => {
     });
 
     assert.equal(existsSync(join(cwd, ".agenta-tools")), true);
-    assert.equal(readFileSync(join(cwd, "AGENTS.md"), "utf-8"), "agent instructions");
+    assert.equal(
+      readFileSync(join(cwd, "AGENTS.md"), "utf-8"),
+      "agent instructions",
+    );
     // A Pi run never gets a Claude settings file.
     assert.equal(existsSync(join(cwd, ".claude", "settings.json")), false);
 
     await workspace.cleanup();
     assert.equal(existsSync(cwd), false);
+  });
+
+  it("writes claude instructions to CLAUDE.md, not AGENTS.md (local)", async () => {
+    // claude-agent-sdk's memory loader auto-loads CLAUDE.md, never AGENTS.md, so the claude
+    // harness's instructions must land in CLAUDE.md to be read at all.
+    const cwd = tempDir();
+
+    const workspace = await prepareWorkspace({
+      sandbox: {},
+      plan: {
+        isDaytona: false,
+        cwd,
+        relayDir: join(cwd, ".agenta-tools"),
+        useToolRelay: false,
+        agentsMd: "agent instructions",
+        acpAgent: "claude",
+        isPi: false,
+        skillDirs: [],
+      },
+    });
+
+    assert.equal(
+      readFileSync(join(cwd, "CLAUDE.md"), "utf-8"),
+      "agent instructions",
+    );
+    // The AGENTS.md name is Pi's; a claude run must not use it (the loader ignores it).
+    assert.equal(existsSync(join(cwd, "AGENTS.md")), false);
+
+    await workspace.cleanup();
   });
 
   it("writes a nested harnessFiles entry (.claude/settings.json) for a local run", async () => {
@@ -110,9 +149,11 @@ describe("prepareWorkspace", () => {
   });
 
   it("prepares a Daytona cwd through the sandbox fs API", async () => {
-    const calls: Array<{ op: "mkdir" | "write"; path: string; body?: string }> = [];
+    const calls: Array<{ op: "mkdir" | "write"; path: string; body?: string }> =
+      [];
     const sandbox = {
-      mkdirFs: async ({ path }: { path: string }) => calls.push({ op: "mkdir", path }),
+      mkdirFs: async ({ path }: { path: string }) =>
+        calls.push({ op: "mkdir", path }),
       writeFsFile: async ({ path }: { path: string }, body: string) =>
         calls.push({ op: "write", path, body }),
     };
@@ -143,14 +184,60 @@ describe("prepareWorkspace", () => {
     ]);
   });
 
-  it("writes a nested harnessFiles entry on Daytona via the fs API", async () => {
-    const calls: Array<{ op: "mkdir" | "write"; path: string; body?: string }> = [];
+  it("writes claude instructions to CLAUDE.md on Daytona", async () => {
+    const calls: Array<{ op: "mkdir" | "write"; path: string; body?: string }> =
+      [];
     const sandbox = {
-      mkdirFs: async ({ path }: { path: string }) => calls.push({ op: "mkdir", path }),
+      mkdirFs: async ({ path }: { path: string }) =>
+        calls.push({ op: "mkdir", path }),
       writeFsFile: async ({ path }: { path: string }, body: string) =>
         calls.push({ op: "write", path, body }),
     };
-    const content = JSON.stringify({ permissions: { deny: ["Bash"] } }, null, 2);
+
+    await prepareWorkspace({
+      sandbox,
+      plan: {
+        isDaytona: true,
+        cwd: "/home/sandbox/agenta-fixed",
+        relayDir: "/home/sandbox/agenta-fixed/.agenta-tools",
+        useToolRelay: false,
+        agentsMd: "agent instructions",
+        acpAgent: "claude",
+        isPi: false,
+        skillDirs: [],
+      },
+    });
+
+    // The instructions land in CLAUDE.md (the name claude-agent-sdk loads), never AGENTS.md.
+    assert.ok(
+      calls.some(
+        (c) =>
+          c.op === "write" &&
+          c.path === "/home/sandbox/agenta-fixed/CLAUDE.md" &&
+          c.body === "agent instructions",
+      ),
+      "instructions are written to CLAUDE.md via the fs API",
+    );
+    assert.ok(
+      !calls.some((c) => c.path === "/home/sandbox/agenta-fixed/AGENTS.md"),
+      "a claude run never writes AGENTS.md",
+    );
+  });
+
+  it("writes a nested harnessFiles entry on Daytona via the fs API", async () => {
+    const calls: Array<{ op: "mkdir" | "write"; path: string; body?: string }> =
+      [];
+    const sandbox = {
+      mkdirFs: async ({ path }: { path: string }) =>
+        calls.push({ op: "mkdir", path }),
+      writeFsFile: async ({ path }: { path: string }, body: string) =>
+        calls.push({ op: "write", path, body }),
+    };
+    const content = JSON.stringify(
+      { permissions: { deny: ["Bash"] } },
+      null,
+      2,
+    );
 
     await prepareWorkspace({
       sandbox,
@@ -169,7 +256,8 @@ describe("prepareWorkspace", () => {
 
     // The parent dir of the nested path is created via the fs API.
     const claudeDir = calls.find(
-      (c) => c.op === "mkdir" && c.path === "/home/sandbox/agenta-fixed/.claude",
+      (c) =>
+        c.op === "mkdir" && c.path === "/home/sandbox/agenta-fixed/.claude",
     );
     assert.ok(claudeDir, ".claude dir is created via the fs API");
     const write = calls.find(
@@ -183,9 +271,11 @@ describe("prepareWorkspace", () => {
   });
 
   it("writes no harness file on Daytona for a plan with no harnessFiles", async () => {
-    const calls: Array<{ op: "mkdir" | "write"; path: string; body?: string }> = [];
+    const calls: Array<{ op: "mkdir" | "write"; path: string; body?: string }> =
+      [];
     const sandbox = {
-      mkdirFs: async ({ path }: { path: string }) => calls.push({ op: "mkdir", path }),
+      mkdirFs: async ({ path }: { path: string }) =>
+        calls.push({ op: "mkdir", path }),
       writeFsFile: async ({ path }: { path: string }, body: string) =>
         calls.push({ op: "write", path, body }),
     };
@@ -239,11 +329,13 @@ describe("prepareWorkspace", () => {
   });
 
   it("uploads Claude skills into the project-local .claude/skills tree on Daytona", async () => {
-    const calls: Array<{ op: "mkdir" | "write"; path: string; body?: string }> = [];
+    const calls: Array<{ op: "mkdir" | "write"; path: string; body?: string }> =
+      [];
     const skillDir = tempDir();
     writeFileSync(join(skillDir, "SKILL.md"), "skill", "utf-8");
     const sandbox = {
-      mkdirFs: async ({ path }: { path: string }) => calls.push({ op: "mkdir", path }),
+      mkdirFs: async ({ path }: { path: string }) =>
+        calls.push({ op: "mkdir", path }),
       writeFsFile: async ({ path }: { path: string }, body: string) =>
         calls.push({ op: "write", path, body }),
     };


### PR DESCRIPTION
## Runner half of the agents_md / CLAUDE.md fix

Companion to #5000 (SDK half). This is the runner file that #5000 could not carry, because its base `big-agents` does not contain the `services/agent/` tree.

### Symptom
A claude agent's `instructions.agents_md` was written to disk but never read. The runner materialized it as `AGENTS.md` in the run cwd for every harness. Claude runs through `@anthropic-ai/claude-agent-sdk`, whose memory loader auto-loads `CLAUDE.md` only and never reads `AGENTS.md`. So a claude agent fell through to Claude Code's default coding persona instead of loading its configured instructions.

### Fix
Choose the instructions filename by harness in `prepareWorkspace` (both the Daytona and local paths):

- **before:** always write `AGENTS.md`
- **after:** `claude -> CLAUDE.md` (the name the loader reads; the ACP adapter's `settingSources` already includes `project`+`local`, which loads a root `CLAUDE.md`), `pi` and every other harness -> `AGENTS.md` (unchanged).

The SDK half mirrors the same rule in `Harness._provisioning` and rides #5000.

### Base
Based on `fix/infinite-loop-in-big-agents` (the #4967 merge source), whose `services/agent/` tree is byte-identical to the fix's baseline. `feat/agent-runner-engines` has drifted off this structure, so it is not a valid base. The design docs for this fix live on #5000 under `docs/design/agent-workflows/projects/builder-agent-reliability/agentsmd-claude-fix/`.

### Tests
- `sandbox-agent-workspace.test.ts` passes 10/10 (extends the existing suite to assert `CLAUDE.md` for claude, `AGENTS.md` for pi, on both the local and Daytona paths).
- The fix adds no new `tsc --noEmit` errors and is `prettier` clean. (Two failures on the base tree, one orchestration deepEqual and one `pi-assets` tsc error, pre-date this change and are unrelated.)

https://claude.ai/code/session_01WSp2LqKrEtXnm2fsPWuQWa