### PR TITLE
docs(agent-workflows): plan for custom providers + model auth in Pi

### DIFF
--- a/docs/design/agent-workflows/projects/custom-providers-in-pi/README.md
+++ b/docs/design/agent-workflows/projects/custom-providers-in-pi/README.md
@@ -1,48 +1,69 @@
-# Custom providers and model auth for the Pi harness
+# OpenAI-compatible models on the Pi harness
 
-Make provider plus model selection work end to end for the Pi harness, including custom
-providers. A user picks a model and a provider for a Pi agent. Built-in providers work once a
-`provider_key` is stored (OpenRouter works this way today: Pi ships 253 built-in OpenRouter
-models and reads `OPENROUTER_API_KEY`). Custom providers do not work, models drop silently, and
-one provider is misnamed. This project closes those gaps.
+Let a user run an OpenAI-compatible model through a Pi agent. The user stores a connection (a base
+URL, a key, and one or more model ids), picks that connection and a model in the playground, and
+the run reaches the model. The connection's **slug** is its identity from the vault, through the
+resolver, across the wire, into the Pi config the runner writes. Two connections that speak the same
+protocol stay distinct because their slugs differ.
 
-## The shape in one paragraph
+## What changed since the first plan
 
-Two sibling projects already own most of the mechanism. `provider-model-auth` (BUILT, PR #4815)
-owns the connection resolver, the harness capability table, and clear-then-apply credential
-injection. `model-config` (DESIGNED, not built) owns the Pi `auth.json`/`models.json` write, the
-fail-loud unsettable-model path, and the model-choice surface. This project sits on top of both.
-It fixes the one resolver line that mislabels a known-direct custom provider as a non-`direct`
-deployment (which the Pi capability gate rejects), builds the model-config `auth.json`/`models.json`
-write in the runner so a custom base URL and genuinely custom model ids reach Pi, makes a
-dropped model fail loud, surfaces a project's custom-provider models in the frontend picker, and
-corrects the Together env var name. No new wire field, no vault storage change.
+This plan was written on 2026-07-02 and revised on 2026-07-14 after code review. Three of the
+original slices landed in the meantime, and six review comments reshaped the rest. See
+[status.md](status.md) for the decision log and [research.md](research.md) for the dated
+re-verification.
 
-## The five gaps
+Landed already:
 
-1. Deployment gate blocks a known-direct custom provider (server-side, the fastest unblock).
-2. The runner never teaches Pi a custom provider (no `models.json` write).
-3. A requested model that cannot be set drops silently and returns HTTP 200 on the wrong model.
-4. The frontend picker never shows a project's custom-provider models.
-5. Together's env var name is wrong, so a Together key silently fails.
+- The three provider-to-env maps are now one canonical `PROVIDER_ENV_VARS`
+  (`capabilities.py:111-125`), with `together_ai -> TOGETHER_API_KEY` and `minimax`. The old
+  Slice 0 is done.
+- A custom connection whose kind is a known provider family resolves to `deployment="direct"`
+  (`connections.py:330-335`) and passes Pi's `["direct"]` gate. The old Slice 1 is done for known
+  families.
+- The runner fails loud on an unsettable model by default: `allowedModels` reads `c.value ?? c.id`
+  (`model.ts:72`), `AGENTA_AGENT_MODEL_STRICT` is wired for every harness and defaults to true
+  (`sandbox_agent.ts:374`), and `applyModel` raises a typed `ModelNotSettableError`. The old
+  Slice 3a is done, and it shipped strict-by-default directly, so the staged "flip later" step is
+  moot.
+
+## The gap that remains
+
+A connection whose kind is **not** a known provider family (an Ollama gateway, an in-house proxy,
+any named OpenAI-compatible endpoint) still fails before it runs. The runner also never writes a Pi
+`models.json`, so a custom base URL and a genuinely custom model id never reach Pi. This plan closes
+that path.
+
+## The revised slices
+
+1. **Service: connection identity and gate.** Add `slug` to `ResolvedConnection` and its wire form.
+   A provider-less or unknown-kind custom connection resolves to the OpenAI-compatible family with
+   `deployment="custom"`, and Pi's capability table allows the `custom` deployment. The known-family
+   `direct` path stays as it landed.
+2. **Runner: teach Pi the connection.** A model-config builder writes `models.json` keyed by
+   `providers[<slug>]`, dialect `openai-completions`, `apiKey` as a `"$ENV"` reference, and the one
+   selected model. The runner creates an isolated managed Pi directory (no operator `auth.json` on a
+   managed run) on both the local and Daytona paths, and sets the exact `<slug>/<model>` id.
+3. **UI: rename the type label.** Rename the visible type from "Custom provider" to
+   "OpenAI-compatible endpoint" at the three UI locations.
+
+The model picker expansion is out of scope. It moves to the `model-config` sibling (Part 3).
 
 ## Read in this order
 
-1. [context.md](context.md): why this exists, what is already built, goals, non-goals.
-2. [research.md](research.md): the five gaps with verified file and line references, the two
-   path corrections this session found, and the startup-banner appendix.
-3. [design.md](design.md): the contract analysis. Every field this plan defines or changes is
-   classified by semantic role (the `design-interfaces` pass on paper).
-4. [plan.md](plan.md): the sliced plan, mapped to gaps, with the recommended order and tests.
-5. [status.md](status.md): current state, decisions, open decisions, risks.
+1. [context.md](context.md): why this exists, what the siblings own, goals and non-goals.
+2. [research.md](research.md): the gaps with verified file and line references, and the dated
+   2026-07-14 re-verification of what closed and what remains.
+3. [design.md](design.md): the contracts, each field classified by semantic role (the
+   `design-interfaces` pass on paper).
+4. [plan.md](plan.md): the sliced plan, in dependency order, with tests.
+5. [status.md](status.md): current state, decisions, risks, next steps.
 
 ## Builds on
 
 - [../provider-model-auth/](../provider-model-auth/): the connection resolver, the
-  `ResolvedConnection` contract, the harness capability table, and the runner clear-then-apply.
-  This project extends its `deployment` classification and consumes its resolved connection.
-- [../model-config/](../model-config/): the Pi per-run `auth.json`/`models.json` write (Part 1),
-  fail-loud on an unsettable model (Part 2), and model choices per harness (Part 3). This project
-  implements Parts 1 and 2 and extends Part 3 to include the vault's custom-provider models.
-</content>
-</invoke>
+  `ResolvedConnection` contract, and the harness capability table. This plan adds one field to that
+  contract (the slug) and one allowed deployment to Pi's row.
+- [../model-config/](../model-config/): the Pi per-run `models.json` write and the fail-loud model
+  path. This plan implements the write and inherits the fail-loud model that already landed. The
+  picker work (Part 3) stays with that sibling.

--- a/docs/design/agent-workflows/projects/custom-providers-in-pi/README.md
+++ b/docs/design/agent-workflows/projects/custom-providers-in-pi/README.md
@@ -1,0 +1,48 @@
+# Custom providers and model auth for the Pi harness
+
+Make provider plus model selection work end to end for the Pi harness, including custom
+providers. A user picks a model and a provider for a Pi agent. Built-in providers work once a
+`provider_key` is stored (OpenRouter works this way today: Pi ships 253 built-in OpenRouter
+models and reads `OPENROUTER_API_KEY`). Custom providers do not work, models drop silently, and
+one provider is misnamed. This project closes those gaps.
+
+## The shape in one paragraph
+
+Two sibling projects already own most of the mechanism. `provider-model-auth` (BUILT, PR #4815)
+owns the connection resolver, the harness capability table, and clear-then-apply credential
+injection. `model-config` (DESIGNED, not built) owns the Pi `auth.json`/`models.json` write, the
+fail-loud unsettable-model path, and the model-choice surface. This project sits on top of both.
+It fixes the one resolver line that mislabels a known-direct custom provider as a non-`direct`
+deployment (which the Pi capability gate rejects), builds the model-config `auth.json`/`models.json`
+write in the runner so a custom base URL and genuinely custom model ids reach Pi, makes a
+dropped model fail loud, surfaces a project's custom-provider models in the frontend picker, and
+corrects the Together env var name. No new wire field, no vault storage change.
+
+## The five gaps
+
+1. Deployment gate blocks a known-direct custom provider (server-side, the fastest unblock).
+2. The runner never teaches Pi a custom provider (no `models.json` write).
+3. A requested model that cannot be set drops silently and returns HTTP 200 on the wrong model.
+4. The frontend picker never shows a project's custom-provider models.
+5. Together's env var name is wrong, so a Together key silently fails.
+
+## Read in this order
+
+1. [context.md](context.md): why this exists, what is already built, goals, non-goals.
+2. [research.md](research.md): the five gaps with verified file and line references, the two
+   path corrections this session found, and the startup-banner appendix.
+3. [design.md](design.md): the contract analysis. Every field this plan defines or changes is
+   classified by semantic role (the `design-interfaces` pass on paper).
+4. [plan.md](plan.md): the sliced plan, mapped to gaps, with the recommended order and tests.
+5. [status.md](status.md): current state, decisions, open decisions, risks.
+
+## Builds on
+
+- [../provider-model-auth/](../provider-model-auth/): the connection resolver, the
+  `ResolvedConnection` contract, the harness capability table, and the runner clear-then-apply.
+  This project extends its `deployment` classification and consumes its resolved connection.
+- [../model-config/](../model-config/): the Pi per-run `auth.json`/`models.json` write (Part 1),
+  fail-loud on an unsettable model (Part 2), and model choices per harness (Part 3). This project
+  implements Parts 1 and 2 and extends Part 3 to include the vault's custom-provider models.
+</content>
+</invoke>

--- a/docs/design/agent-workflows/projects/custom-providers-in-pi/context.md
+++ b/docs/design/agent-workflows/projects/custom-providers-in-pi/context.md
@@ -1,0 +1,96 @@
+# Context
+
+## Why this exists
+
+A user selects a model and a provider for a Pi agent in the playground. The run should call that
+model with that provider's credential. Today this works for a built-in provider once its
+`provider_key` is stored. It does not work for a custom provider, and it can fail silently for a
+built-in provider too. This project makes the full path work for Pi, custom providers included.
+
+The concrete trigger: OpenRouter works when stored as a `provider_key` (Pi ships 253 built-in
+OpenRouter models and reads `OPENROUTER_API_KEY`), but the same OpenRouter stored as a
+`custom_provider` is rejected before the run even starts. That single inconsistency exposes four
+more gaps around it. All five are diagnosed in [research.md](research.md) with verified file and
+line references.
+
+## What is already built (do not rebuild)
+
+This project is deliberately small because two siblings already did the heavy lifting.
+
+- **`provider-model-auth` (BUILT, PR #4815 to `big-agents`).** It replaced the whole-vault
+  credential dump with a deterministic single-connection resolver built from the existing
+  `GET /secrets/` catalog (`sdks/python/agenta/sdk/agents/platform/connections.py`). It added the
+  `ResolvedConnection` contract (`provider`, `model`, `deployment`, `credential_mode`, `env`,
+  `endpoint`), the harness capability table (`sdks/python/agenta/sdk/agents/capabilities.py`),
+  the pre-resolve and post-resolve capability checks in `services/oss/src/agent/app.py`, and the
+  runner clear-then-apply of provider env. Its Slice 4 already emits `resolved_connection` on the
+  `/run` wire (`wire_resolved_connection()`), carrying `endpoint.baseUrl` and the exact selected
+  model id. So the inputs this project needs already reach the runner.
+- **`model-config` (DESIGNED, not built).** Its `proposal.md` specifies Part 1 (write
+  `auth.json`/`models.json` into Pi's per-run agent dir), Part 2 (fail loud on an unsettable model,
+  staged `AGENTA_AGENT_MODEL_STRICT`), and Part 3 (model choices in the schema per harness). This
+  project implements Parts 1 and 2 in the runner and extends Part 3's choice surface.
+
+## Current state, with citations
+
+Every reference below was re-verified on 2026-07-02. Full snippets are in
+[research.md](research.md). Two corrections to the prior docs came out of that pass:
+
+- The runner TypeScript lives at `services/runner/src/`, not `services/agent/src/`. The rename
+  landed in commit `b323a8516f` (`chore(runner): rename sandbox-agent -> runner`). Prior sibling
+  docs still cite `services/agent/src/`; every runner path here uses `services/runner/src/`.
+- The frontend reads the harness capability catalog from `GET /workflows/catalog/harnesses/`
+  (served from `capabilities.py` `harness_catalog_document`), not from the `/inspect` response
+  `meta`. The `connectionUtils.ts` file header still claims `/inspect`; that comment is stale.
+
+The five gaps, each a one-line statement of the current behavior:
+
+1. `_custom_provider_candidate` (`connections.py:274-309`) sets `deployment` to the raw vault
+   `kind`, so a known-direct custom provider (OpenRouter, OpenAI) resolves with, for example,
+   `deployment="openrouter"`. The post-resolve check (`app.py:110-125`,
+   `harness_allows_deployment` at `capabilities.py:225-236`) rejects it because Pi advertises
+   `deployments=["direct"]` (`capabilities.py:146`).
+2. The runner never writes a Pi `models.json` (grep of `services/runner/src/` returns zero). It
+   only copies the login's `auth.json`/`settings.json` (`pi-assets.ts:178-195`). A custom base URL
+   and genuinely custom model ids never reach Pi.
+3. `applyModel` (`model.ts:46-74`) silently falls back to the harness default when `setModel`
+   fails. Strict is wired for Claude only (`sandbox_agent.ts:193-200`, `582-587`). A
+   requested-but-unsettable model returns HTTP 200 on the wrong model.
+4. The picker is built only from the static harness catalog. `buildModelOptionGroups`
+   (`connectionUtils.ts:239-256`) reads only `capabilities[harness].models`; each vault
+   custom-provider's `models` array is dropped at the `VaultConnectionEntry` type boundary.
+5. The provider-to-env map emits `TOGETHERAI_API_KEY` for `together_ai`
+   (`platform/secrets.py:100` and two sibling copies), but Pi reads `TOGETHER_API_KEY`.
+
+## Goals
+
+1. A custom provider whose kind is a known direct provider works on Pi, exactly like the same
+   provider stored as a `provider_key`.
+2. A custom base URL and genuinely custom model ids reach Pi through its per-run agent dir, local
+   and Daytona alike, without a raw secret ever landing on disk.
+3. A requested model that cannot be set fails loud with the allowed set, not a silent wrong-model
+   HTTP 200.
+4. The frontend picker shows a project's custom-provider models for the selected harness.
+5. A Together key reaches Pi.
+
+## Non-goals
+
+- Bedrock, Vertex, and Azure consumption on Pi stays fail-loud, exactly as
+  `provider-model-auth` and `model-config` already stage it. This project does not wire multi-var
+  cloud credential delivery into Pi.
+- No vault storage change: no new secret kind, no migration, no `/secrets` write path. This
+  project reads the existing `provider_key` and `custom_provider` secrets.
+- No new `/run` wire field. Every input already rides `resolved_connection` and `secrets`; the
+  runner derives the Pi config from them.
+- No change to the prompt/completion path. It keeps its own LiteLLM reader of the same vault.
+
+## Constraints inherited from the codebase
+
+- The Python service decides what to run; the runner runs it. The Pi `auth.json`/`models.json`
+  write is derived inside the runner from `request.secrets` and `resolved_connection`, both
+  already on the stable `/run` contract. Do not widen the wire (per `model-config` Part 3's
+  boundary note and the `provider-model-auth` design).
+- The provider-to-env map is duplicated across three files today
+  (`platform/secrets.py`, `platform/connections.py`, `connections/resolver.py`) and has already
+  drifted on `minimax`. Any map fix touches all copies and should note the drift.
+</content>

--- a/docs/design/agent-workflows/projects/custom-providers-in-pi/context.md
+++ b/docs/design/agent-workflows/projects/custom-providers-in-pi/context.md
@@ -3,94 +3,75 @@
 ## Why this exists
 
 A user selects a model and a provider for a Pi agent in the playground. The run should call that
-model with that provider's credential. Today this works for a built-in provider once its
-`provider_key` is stored. It does not work for a custom provider, and it can fail silently for a
-built-in provider too. This project makes the full path work for Pi, custom providers included.
+model with that provider's credential. This works for a built-in provider once its `provider_key`
+is stored, and, since this plan was first written, it also works for a custom connection whose kind
+is a known provider family (a custom OpenRouter or OpenAI record now resolves to `deployment="direct"`
+and passes Pi's gate). What still does not work is a **named OpenAI-compatible connection** whose
+kind is not a known family: an Ollama gateway, an in-house proxy, any endpoint the user names
+themselves. This plan makes that path work for Pi.
 
-The concrete trigger: OpenRouter works when stored as a `provider_key` (Pi ships 253 built-in
-OpenRouter models and reads `OPENROUTER_API_KEY`), but the same OpenRouter stored as a
-`custom_provider` is rejected before the run even starts. That single inconsistency exposes four
-more gaps around it. All five are diagnosed in [research.md](research.md) with verified file and
-line references.
+The original trigger was narrower. OpenRouter worked when stored as a `provider_key` but was rejected
+when stored as a `custom_provider`. That specific inconsistency is fixed. Closing it exposed the
+deeper requirement: the vault already lets a user store an arbitrary base URL, key, and model list,
+but nothing carries that record through to Pi.
 
 ## What is already built (do not rebuild)
 
-This project is deliberately small because two siblings already did the heavy lifting.
+This project sits on top of two siblings.
 
 - **`provider-model-auth` (BUILT, PR #4815 to `big-agents`).** It replaced the whole-vault
   credential dump with a deterministic single-connection resolver built from the existing
   `GET /secrets/` catalog (`sdks/python/agenta/sdk/agents/platform/connections.py`). It added the
   `ResolvedConnection` contract (`provider`, `model`, `deployment`, `credential_mode`, `env`,
-  `endpoint`), the harness capability table (`sdks/python/agenta/sdk/agents/capabilities.py`),
-  the pre-resolve and post-resolve capability checks in `services/oss/src/agent/app.py`, and the
-  runner clear-then-apply of provider env. Its Slice 4 already emits `resolved_connection` on the
-  `/run` wire (`wire_resolved_connection()`), carrying `endpoint.baseUrl` and the exact selected
-  model id. So the inputs this project needs already reach the runner.
-- **`model-config` (DESIGNED, not built).** Its `proposal.md` specifies Part 1 (write
-  `auth.json`/`models.json` into Pi's per-run agent dir), Part 2 (fail loud on an unsettable model,
-  staged `AGENTA_AGENT_MODEL_STRICT`), and Part 3 (model choices in the schema per harness). This
-  project implements Parts 1 and 2 in the runner and extends Part 3's choice surface.
+  `endpoint`), the harness capability table (`sdks/python/agenta/sdk/agents/capabilities.py`), the
+  pre-resolve and post-resolve capability checks, and the runner clear-then-apply of provider env.
+  Its wire step emits `resolved_connection` on the `/run` contract, carrying `endpoint.baseUrl` and
+  the selected model id.
+- **`model-config` (DESIGNED, partly built).** It specifies the Pi per-run config write, the
+  fail-loud unsettable-model path, and the model-choice surface. The fail-loud model already landed
+  in the runner (strict-by-default, typed error). This project implements the `models.json` write.
+  The model-choice picker stays with that sibling (Part 3).
 
-## Current state, with citations
+## Current state
 
-Every reference below was re-verified on 2026-07-02. Full snippets are in
-[research.md](research.md). Two corrections to the prior docs came out of that pass:
+The gaps and their file references are re-verified in [research.md](research.md), including a dated
+2026-07-14 pass that records which closed and which remain. In short:
 
-- The runner TypeScript lives at `services/runner/src/`, not `services/agent/src/`. The rename
-  landed in commit `b323a8516f` (`chore(runner): rename sandbox-agent -> runner`). Prior sibling
-  docs still cite `services/agent/src/`; every runner path here uses `services/runner/src/`.
-- The frontend reads the harness capability catalog from `GET /workflows/catalog/harnesses/`
-  (served from `capabilities.py` `harness_catalog_document`), not from the `/inspect` response
-  `meta`. The `connectionUtils.ts` file header still claims `/inspect`; that comment is stale.
-
-The five gaps, each a one-line statement of the current behavior:
-
-1. `_custom_provider_candidate` (`connections.py:274-309`) sets `deployment` to the raw vault
-   `kind`, so a known-direct custom provider (OpenRouter, OpenAI) resolves with, for example,
-   `deployment="openrouter"`. The post-resolve check (`app.py:110-125`,
-   `harness_allows_deployment` at `capabilities.py:225-236`) rejects it because Pi advertises
-   `deployments=["direct"]` (`capabilities.py:146`).
-2. The runner never writes a Pi `models.json` (grep of `services/runner/src/` returns zero). It
-   only copies the login's `auth.json`/`settings.json` (`pi-assets.ts:178-195`). A custom base URL
-   and genuinely custom model ids never reach Pi.
-3. `applyModel` (`model.ts:46-74`) silently falls back to the harness default when `setModel`
-   fails. Strict is wired for Claude only (`sandbox_agent.ts:193-200`, `582-587`). A
-   requested-but-unsettable model returns HTTP 200 on the wrong model.
-4. The picker is built only from the static harness catalog. `buildModelOptionGroups`
-   (`connectionUtils.ts:239-256`) reads only `capabilities[harness].models`; each vault
-   custom-provider's `models` array is dropped at the `VaultConnectionEntry` type boundary.
-5. The provider-to-env map emits `TOGETHERAI_API_KEY` for `together_ai`
-   (`platform/secrets.py:100` and two sibling copies), but Pi reads `TOGETHER_API_KEY`.
+- Closed since 2026-07-02: the env-var map drift (one canonical `PROVIDER_ENV_VARS`), the
+  known-family deployment gate (known kind resolves `direct`), and the silent model drop (strict is
+  on by default and raises a typed error).
+- Still open: an arbitrary named OpenAI-compatible connection is rejected before it runs; the runner
+  writes no Pi `models.json`; the runner copies the operator's personal `auth.json` into a managed
+  run on the local path; and `ResolvedConnection` carries no slug, so two custom connections of the
+  same kind are indistinguishable at the runner.
 
 ## Goals
 
-1. A custom provider whose kind is a known direct provider works on Pi, exactly like the same
-   provider stored as a `provider_key`.
-2. A custom base URL and genuinely custom model ids reach Pi through its per-run agent dir, local
-   and Daytona alike, without a raw secret ever landing on disk.
-3. A requested model that cannot be set fails loud with the allowed set, not a silent wrong-model
-   HTTP 200.
-4. The frontend picker shows a project's custom-provider models for the selected harness.
-5. A Together key reaches Pi.
+1. A named OpenAI-compatible connection (arbitrary kind, arbitrary base URL, arbitrary model ids)
+   runs on Pi.
+2. The connection's slug identifies it end to end: the vault record, the resolver, the wire, and the
+   Pi `models.json` the runner writes all agree on the same slug.
+3. A custom base URL and genuinely custom model ids reach Pi through its per-run agent dir, local and
+   Daytona alike, with no raw secret on disk.
+4. A managed run never authenticates with the operator's personal login.
 
 ## Non-goals
 
-- Bedrock, Vertex, and Azure consumption on Pi stays fail-loud, exactly as
-  `provider-model-auth` and `model-config` already stage it. This project does not wire multi-var
-  cloud credential delivery into Pi.
-- No vault storage change: no new secret kind, no migration, no `/secrets` write path. This
-  project reads the existing `provider_key` and `custom_provider` secrets.
-- No new `/run` wire field. Every input already rides `resolved_connection` and `secrets`; the
-  runner derives the Pi config from them.
+- Bedrock, Vertex, and Azure consumption on Pi stays fail-loud, exactly as `provider-model-auth` and
+  `model-config` already stage it. This project does not wire multi-var cloud credential delivery
+  into Pi.
+- No vault storage change: no new secret kind, no migration, no `/secrets` write path. This project
+  reads the existing `provider_key` and `custom_provider` secrets.
+- **Exactly one new `/run` wire field: the connection slug on `ResolvedConnection`.** Everything else
+  the runner still derives from `resolved_connection` and `secrets`. (This replaces the first plan's
+  "no new wire field" non-goal, which the models.json keying made impossible.)
+- The model picker stays as it is in this plan. Its expansion moves to `model-config` Part 3.
 - No change to the prompt/completion path. It keeps its own LiteLLM reader of the same vault.
 
 ## Constraints inherited from the codebase
 
-- The Python service decides what to run; the runner runs it. The Pi `auth.json`/`models.json`
-  write is derived inside the runner from `request.secrets` and `resolved_connection`, both
-  already on the stable `/run` contract. Do not widen the wire (per `model-config` Part 3's
-  boundary note and the `provider-model-auth` design).
-- The provider-to-env map is duplicated across three files today
-  (`platform/secrets.py`, `platform/connections.py`, `connections/resolver.py`) and has already
-  drifted on `minimax`. Any map fix touches all copies and should note the drift.
-</content>
+- The Python service decides what to run; the runner runs it. The Pi `models.json` write is derived
+  inside the runner from `request.secrets` and `resolved_connection`. The wire grows by one field
+  (the slug) and no more.
+- The runner TypeScript lives at `services/runner/src/`, not `services/agent/src/`. The
+  `sandbox_agent.ts` monolith split into `services/runner/src/engines/sandbox_agent/{model,daemon,daytona,pi-assets}.ts`.

--- a/docs/design/agent-workflows/projects/custom-providers-in-pi/design.md
+++ b/docs/design/agent-workflows/projects/custom-providers-in-pi/design.md
@@ -1,77 +1,69 @@
 # Design: the contracts, classified by role
 
-This project touches five contracts. Each one below is run through the `design-interfaces` pass:
-what the field is, who owns it, when it changes, and which semantic role it plays (data, config,
-policy, credentials, routing, or metadata). The point is to fix the shape while it is on paper.
+This plan touches four contracts. Each one runs through the `design-interfaces` pass: what the field
+is, who owns it, when it changes, and which semantic role it plays (data, config, policy,
+credentials, routing, metadata, or protocol context). The point is to fix the shape while it is on
+paper. The one rule: classify a field by the role it plays, not the feature it touches.
 
-The one rule: classify a field by the role it plays, not the feature it touches.
+Two of these contracts already landed in part. This doc marks what is settled and what this plan
+adds.
 
-## 1. The `deployment` field on `ResolvedConnection`
+## 1. The `deployment` field and the OpenAI-compatible family
 
-### What it is today
+### What it is
 
-`deployment: str = "direct"` on `ResolvedConnection` (`connections.py`, emitted at `:431-438`).
-Values in play: `direct`, `azure`, `bedrock`, `vertex`/`vertex_ai`, `custom`, and, by the bug,
-any raw vault kind such as `openrouter`. It is read by `harness_allows_deployment`
-(`capabilities.py:225-236`) to gate a run against the harness's advertised `deployments`.
+`deployment: Deployment = "direct"` on `ResolvedConnection` (`connections/models.py:178`). It answers
+"which access surface and auth mechanism does the harness use to reach this model." It is a
+routing field, service-derived, and it changes per connection, never per call. Pi advertises
+`deployments=["direct"]` today, and `harness_allows_deployment` (`capabilities.py:299-310`) gates a
+run against that set.
 
-### The role it should play
+### What landed
 
-`deployment` is a **routing/config** field. It answers "which access surface and auth mechanism
-does the harness use to reach this model." It is service-derived (the resolver sets it after
-selecting the secret) and it changes per connection, never per call. A direct API-key provider,
-an Azure OpenAI deployment, Bedrock, and Vertex are genuinely different surfaces: different auth
-shapes, different endpoint mechanics, different harness flags. That is a real routing distinction
-and the field earns its place.
+A custom connection whose kind is a known provider family now resolves to `deployment="direct"`
+(`connections.py:330-335`, `deployment = "direct" if provider is not None else provider_kind`). Its
+base URL rides `endpoint`, its key rides `env`. A custom OpenRouter or OpenAI connection passes Pi's
+gate with no other change. This is correct and it stays.
 
-### The defect: it conflates two different questions
+### What this plan adds: the named OpenAI-compatible connection
 
-Today `deployment` answers a second, unrelated question: "is this vault record a `custom_provider`
-or a `provider_key`." A custom OpenRouter connection is a single bearer key sent to an
-OpenAI-completions endpoint at a base URL. In every routing sense it is `direct`. Its only "custom"
-property is the base URL override, and that already lives in a separate field (`endpoint.base_url`).
-So echoing the record kind into `deployment` (`connections.py:281`) leaks an implementation detail
-(the vault storage kind) into a routing field. That is the `design-interfaces` rule 6 violation
-(do not expose an implementation detail as interface structure) and rule 10 (separate intent from
-mechanism).
+A connection whose kind is not a known family (an Ollama gateway, an in-house proxy) resolves with
+`provider=None`, so it keeps `deployment=provider_kind` and Pi rejects it. The requirement is a
+**named OpenAI-compatible connection**, not a known family disguised as custom. The fix, by role:
 
-### The fix, by role
+- Keep `deployment="custom"` for a record whose kind is not a known family. "Custom" is a real access
+  surface here: a single bearer key sent to an OpenAI-completions endpoint at an operator-named base
+  URL. It is not one of the built-in direct providers, and it is not a cloud surface.
+- After the trusted vault record resolves, default a provider-less custom record to the
+  OpenAI-compatible family. This is a service-side default on an already-resolved, trusted record. It
+  needs no stored-schema change and no vault write.
+- Add the `custom` deployment to Pi's capability row, paired with the OpenAI-compatible protocol. Pi
+  then allows the `(custom, openai-compatible)` pair explicitly, so a named connection reaches the
+  runner instead of dying at the gate.
 
-Normalize `deployment` to the closed set of real access surfaces, and let `endpoint` carry the
-"customness":
+The known-family `direct` normalization is untouched. This section adds the missing branch: an
+unknown kind is a named OpenAI-compatible endpoint, resolved to `deployment="custom"` and the
+OpenAI-compatible family, which Pi allows.
 
-- A `custom_provider` whose kind is in `_PROVIDER_ENV_VARS` (a known single-key direct provider:
-  OpenAI, OpenRouter, Anthropic, Gemini, Mistral, Groq, Minimax, Together) resolves as
-  `deployment="direct"`. Its base URL and version ride `endpoint`; its key rides `env`.
-- A `custom_provider` whose kind is `azure` / `bedrock` / `vertex` keeps its cloud-surface
-  `deployment`. Those stay fail-loud on Pi in v1 (non-goal).
-- `deployment` becomes a closed enum of access surfaces (`direct`, `azure`, `bedrock`, `vertex`),
-  not an open echo of the vault kind. The free `"custom"` value goes away: a custom endpoint is
-  `direct` plus an `endpoint`.
+Rejected alternative: add every unknown kind to Pi's `deployments` as a distinct surface, or force
+each named endpoint into `direct`. The first turns the capability table into a registry of user
+strings. The second erases the difference between a built-in provider and an operator-named endpoint,
+which is exactly the difference the slug needs to preserve (Section 3).
 
-This is the smallest correct change and it needs nothing new on the wire. After it, a custom
-OpenRouter connection passes Pi's `["direct"]` gate, and `resolved_env` already emits
-`OPENROUTER_API_KEY`, so a built-in OpenRouter id is settable through Pi's env-var channel.
+## 2. The Pi `models.json` shape and the model-config builder
 
-Rejected alternative: add each known-direct kind (`openrouter`, `openai`, ...) to Pi's
-`deployments` list. That is a category error. Those are providers, not deployment surfaces, and it
-would make the capability table advertise "openrouter" as a deployment. Keep `deployment` a
-surface and `provider` a provider.
-
-## 2. The Pi `models.json` shape (Slice 2, the runner write)
-
-The runner writes this file into `PI_CODING_AGENT_DIR`. It is Pi's own config format
-(`docs/models.md`), so the outer shape is fixed by Pi. The `design-interfaces` work is on how each
-value is sourced and, above all, that the credential is a reference, not a secret.
+The runner writes this file into the per-run Pi agent dir. It is Pi's own config format, so the outer
+shape is fixed by Pi. The `design-interfaces` work is on how each value is sourced, that the
+credential is a reference and not a secret, and that the map is keyed by a stable identity.
 
 ```json
 {
   "providers": {
-    "openrouter": {
-      "baseUrl": "https://openrouter.ai/api/v1",
+    "my-ollama-gateway": {
+      "baseUrl": "https://gateway.internal/v1",
       "api": "openai-completions",
-      "apiKey": "$OPENROUTER_API_KEY",
-      "models": [{ "id": "anthropic/claude-3.5-sonnet" }]
+      "apiKey": "$CONNECTION__MY_OLLAMA_GATEWAY__API_KEY",
+      "models": [{ "id": "llama-3.1-70b" }]
     }
   }
 }
@@ -79,104 +71,131 @@ value is sourced and, above all, that the credential is a reference, not a secre
 
 | Field | Role | Owner / lifecycle | Source in our contract |
 | --- | --- | --- | --- |
-| `providers` | config, extensible map (plural, correct) | service, per run | keyed by `resolved_connection.provider` |
-| `providers.<p>.baseUrl` | routing (the endpoint being contacted, nested under the provider) | service, per run | `resolved_connection.endpoint.baseUrl` |
-| `providers.<p>.api` | config (the wire dialect) | service, per run | derived from provider (default `openai-completions`; Anthropic to `anthropic-messages`) |
-| `providers.<p>.apiKey` | credentials, expressed as an env **reference** | service, per run | `"$" + env_var(provider)`, never the raw key |
-| `providers.<p>.models[].id` | config/data (the registered model catalog) | service, per run | `resolved_connection.model` (the selected exact id) |
+| `providers` | config, extensible map | service, per run | keyed by the connection **slug**, not the provider |
+| `providers.<slug>.baseUrl` | routing (the endpoint being contacted) | service, per run | `resolved_connection.endpoint.baseUrl` |
+| `providers.<slug>.api` | protocol context (the wire dialect) | service, per run | fixed `openai-completions` in v1 |
+| `providers.<slug>.apiKey` | credentials, expressed as an env **reference** | service, per run | `"$" + env_var`, never the raw key |
+| `providers.<slug>.models[].id` | config/data (the registered model) | service, per run | `resolved_connection.model` (the selected id) |
 
-The load-bearing rule is `design-interfaces` rule 8: prefer a reference over a raw secret. `apiKey`
-is written as `"$OPENROUTER_API_KEY"`, an env interpolation Pi resolves at request time from the
-daemon env. The real key rides `resolved_connection.env` and the runner injects it into the daemon
-env (the same channel `auth.json` uses). So `models.json` on disk carries no secret value. `auth.json`
-follows the same rule: `{ "openrouter": { "type": "api_key", "key": "$OPENROUTER_API_KEY" } }`,
-merged with the login's copied `auth.json` so OAuth still works.
+### Key by slug, not provider
 
-Write `models.json` only when there is something custom to say: a base URL override, or a model id
-that is not in Pi's built-in catalog. For a built-in id, `auth.json` (or the env var alone) is
-enough. This keeps the common case to a single small write.
+Two custom connections can both resolve to the OpenAI-compatible family, and a provider-less one may
+carry no provider at all. Keying `providers` by `resolved_connection.provider` would collide or fail
+to produce a Pi provider id. Key by the connection slug. Each connection gets a stable, unique Pi
+identity, and the selected model registers under that entry. This is the reason the wire gains a slug
+(Section 3).
 
-## 3. How base URL and custom models reach the runner (the wire boundary)
+### The dialect is `openai-completions` only in v1
 
-This is the boundary decision, and it is already settled by the two siblings. Do not add a
-Pi-specific field to the `/run` wire.
+`api` is protocol context: it tells Pi which request and response semantics to use. In v1 it is
+strictly `openai-completions`. Do not infer `anthropic-messages` from a provider label. Anthropic
+Messages has materially different request and response semantics and must not be half-supported. The
+builder exposes a protocol discriminator so a later version can add another dialect, and v1 rejects
+any unsupported protocol loudly rather than guessing.
 
-- The base URL rides `resolved_connection.endpoint.baseUrl`. Already on the wire
-  (`wire_resolved_connection()`, `provider-model-auth` Slice 4).
-- The selected model id rides `resolved_connection.model`. Already on the wire.
+### The credential is a reference
+
+`design-interfaces` rule 8: prefer a reference over a raw secret. `apiKey` is written as a `"$ENV"`
+interpolation Pi resolves at request time from the daemon or sandbox environment. The real key rides
+`resolved_connection.env` and the runner injects it into that environment. So `models.json` on disk
+carries no secret value.
+
+### The builder returns files plus the exact model id
+
+The model-config builder is a small pure function. It returns two things:
+
+```
+{ files: { "models.json": <content> }, exactModelId: "<slug>/<model>" }
+```
+
+`exactModelId` is the fully qualified Pi id, `<slug>/<model>`. The runner passes that exact id to
+`setModel`. This bypasses the suffix-match fallback in `pickModel` (`model.ts:49-59`), which can pick
+the wrong provider when two providers share a model suffix. The wire keeps the bare selected model id
+(Section 3); the runner derives the qualified id.
+
+### The isolated managed directory
+
+For a managed run (`credentialMode="env"`), the runner must not reuse the operator's personal login.
+`prepareLocalAgentDir` (`pi-assets.ts:475-490`) copies the operator's `auth.json` and `settings.json`
+today, which would let a managed run authenticate with an operator subscription or the wrong
+provider. The Daytona path already refuses to copy a personal `auth.json` (`daytona.ts:168-171`); the
+local path must match it. The runner builds an isolated managed Pi directory that carries only
+non-credential settings plus `models.json` with the `"$ENV"` apiKey reference. The raw key stays
+solely in the daemon or sandbox environment. This fixes the existing local managed path, not only the
+new custom-provider case.
+
+## 3. The wire boundary: exactly one new field
+
+The first plan promised no new wire field. Keying `models.json` by slug makes that impossible: the
+runner cannot reconstruct the connection slug from `provider`, `model`, `deployment`, and `endpoint`.
+So the wire gains exactly one field, and no more.
+
+| Field | Role | Owner / lifecycle | Notes |
+| --- | --- | --- | --- |
+| `slug` on `ResolvedConnection.to_wire()` | identity / metadata | the vault record; changes per connection edit | the connection's stable name; the Pi `providers` key |
+
+Everything else the runner still derives:
+
+- The base URL rides `resolved_connection.endpoint.baseUrl`. Already on the wire.
+- The selected model id rides `resolved_connection.model`. Already on the wire. The runner derives
+  `<slug>/<model>` (Section 2).
 - The credential rides `request.secrets` (the resolved `env`). Already on the wire.
 
-The runner **derives** `auth.json`/`models.json` from these three inputs. This is
-`design-interfaces` rule 10 (separate the user-facing API from internal execution): the wire says
-"here is the provider, the model, the endpoint, and the credential env"; the runner decides the Pi
-file layout. The Python service stays thin. This matches `model-config` Part 3's explicit
-boundary note ("derive in the runner, do not widen the wire") and the `provider-model-auth`
-design's harness-adapter split.
+The runner derives `models.json` and the exact model id from the slug plus these three inputs. This
+keeps `design-interfaces` rule 10 (separate the user-facing API from internal execution): the wire
+says "here is the connection identity, the model, the endpoint, and the credential env"; the runner
+decides the Pi file layout.
 
-The one field that does not fit a single run: a `custom_provider` can list many custom model ids,
-but `resolved_connection.model` carries only the selected one. That is correct for the run itself
-(you register the one model you are about to use). The full list matters only for the frontend
-picker, which reads the vault directly (Section 5).
+Note the docstring on `ResolvedConnection` states the harness adapter "never sees a vault, a
+connection, or a slug." That sentence changes with this plan. The slug is not a secret; it is the
+connection's identity, and it must reach the runner for the `models.json` key to be stable. Update
+the docstring alongside the field.
 
-## 4. The `AGENTA_AGENT_MODEL_STRICT` flag (Slice 3)
+## 4. Fail-loud on an unsettable model (already landed)
 
-`AGENTA_AGENT_MODEL_STRICT` is a **policy** field: it decides what is allowed to happen when a
-requested model cannot be set (fail the run, or fall back to the harness default). It is
-operator-owned and service-level, not per call. It reuses the `strict` parameter already threaded
-into `applyModel` for Claude (`model.ts:57-59`), so the flag simply extends an existing policy knob
-to Pi rather than inventing a mechanism.
+This contract landed already, so this plan mostly inherits it. `AGENTA_AGENT_MODEL_STRICT` is a
+policy field: it decides what happens when a requested model cannot be set (fail the run, or fall
+back to the harness default). It is operator-owned and service-level. It shipped wired for every
+harness and defaulting to true (`modelResolutionStrict` at `sandbox_agent.ts:374`), which diverges
+from the first plan's staged rollout (default false, flip later). The staged flip is moot.
 
-Staged rollout, per `model-config` Part 2: default `false` (warn and fall back, today's behavior)
-in the first release, then flip to `true` once the QA matrix confirms the common models are
-settable and the advertised default is reconciled. The reason is a real trap: the agent config's
-advertised default model is `gpt-5.5`, which the playground echoes on every run, so strict-by-default
-would fail runs that never chose a model. A no-model-requested run always uses the documented
-default and is never an error; only a requested-but-unsettable model fails.
+The typed error `ModelNotSettableError` (`model.ts:9`) is output, system-owned: it carries the
+requested model and the allowed set so the caller learns the valid values instead of guessing. No
+secret enters it.
 
-The typed error `ModelNotSettableError` is **output** (system-owned): it carries the requested
-model and the allowed set (from `allowedFromError` plus the fixed `allowedModels`) so the caller
-learns the valid values instead of guessing. No secret ever enters it.
+There is no separate `engines/pi.ts`; the single `sandbox_agent` engine's `model.ts` is the shared
+path for both Pi and Claude, so both already raise the typed error under strict. The only
+model-correctness work left is Section 2's exact-id derivation, which removes the suffix fallback's
+wrong-provider risk. That work lives in the runner slice, not here.
 
-## 5. The picker-choices contract (Slice 4)
+## 5. The UI change: rename the type label only
 
-The picker draws model choices from two sources that play different roles and have different
-owners. The current code merges only the first. The fix keeps them distinct and joins them under a
-harness policy filter.
+The model picker expansion is out of scope for this plan. It moves to the `model-config` sibling
+(Part 3), which owns the model-choice surface. The `VaultConnectionEntry` symbol the first plan named
+for this change does not exist in `web/`; it was a stale name.
 
-| Source | Role | Owner / lifecycle |
-| --- | --- | --- |
-| Static harness catalog (`capabilities[harness].models` from `GET /workflows/catalog/harnesses/`) | config/metadata | service, per Pi release, harness-scoped |
-| Project vault custom-provider models (`LlmProvider.models` from `GET /secrets/`) | data | project, per edit, project-scoped |
-| Harness reachability (which providers/deployments the harness can use) | policy/routing | service, per harness |
+The UI change in this plan is exactly one thing. Rename the visible type "Custom provider" to
+"OpenAI-compatible endpoint" at three locations:
 
-The two source lists have different owners and lifecycles, so `design-interfaces` says keep them in
-two branches and join them at the read boundary, not conflate them into one bucket. Concretely:
+- `web/packages/agenta-entity-ui/src/DrillInView/SchemaControls/agentTemplate/ProviderCredentialsSection.tsx:87`
+  and `:416`.
+- `web/packages/agenta-entities/src/secret/core/types.ts:98`.
+- `web/oss/src/components/pages/settings/Secrets/SecretProviderTable/index.tsx:206`.
 
-- `buildModelOptionGroups` takes both the capability catalog and the vault entries, and produces
-  grouped options. A vault custom-provider's models appear only if that provider (and its
-  now-`direct` deployment) is reachable by the selected harness, the same policy filter
-  `namedConnectionOptions` already applies to the Connection dropdown.
-- `VaultConnectionEntry` (`connectionUtils.ts:302-312`) gains `models?: string[]`, so the array
-  `transformSecret` already produces stops being dropped at the type boundary.
-- Each option should carry provenance (built-in vs project connection) as **metadata**, so the UI
-  can label a project-specific model and the two lists never silently collide.
-
-Open decision recorded in [status.md](status.md): read the vault client-side (it is already
-fetched on this screen via `vaultSecretsQueryAtom`, so no new endpoint) versus adding a per-project
-model list to a server inspect field. The lean is client-side, consistent with the
-`provider-model-auth` design ("the frontend intersects the capability table with the vault"). The
-static grouped-choice baseline (`model-config` Part 3 layer 1) is independent and can land first.
+The existing UI already creates the record and sends its selected connection and model. Nothing else
+in the picker changes here.
 
 ## Summary of contract changes
 
-- `ResolvedConnection.deployment` becomes a closed access-surface enum; a known-direct
-  `custom_provider` normalizes to `direct` (Slice 1). No wire change.
-- The runner derives Pi `auth.json`/`models.json` from `resolved_connection` plus `secrets`; the
-  credential is a `"$ENV"` reference, never a raw value (Slice 2). No wire change.
-- `AGENTA_AGENT_MODEL_STRICT` extends the existing `strict` policy knob to Pi; `ModelNotSettableError`
-  is the typed output (Slice 3).
-- `VaultConnectionEntry` gains `models?: string[]`; `buildModelOptionGroups` joins the static
-  catalog and the vault under the harness policy filter, tagging provenance (Slice 4).
-- The provider-to-env map value `together_ai -> TOGETHER_API_KEY`, fixed in all three copies, with
-  `minimax` added where missing (Slice 0).
-</content>
+- `ResolvedConnection.deployment`: known-family custom is `direct` (landed). A provider-less or
+  unknown-kind custom keeps `deployment="custom"` and defaults to the OpenAI-compatible family
+  post-resolve; Pi's capability row allows the `(custom, openai-compatible)` pair.
+- The runner derives Pi `models.json`, keyed by `providers[<slug>]`, dialect `openai-completions` in
+  v1 (with a protocol discriminator for later), `apiKey` as a `"$ENV"` reference, one selected model.
+  The builder returns the files and the exact `<slug>/<model>` id, which the runner sets directly.
+- The runner builds an isolated managed Pi directory on the local path (no operator `auth.json` on a
+  managed run), matching the Daytona path.
+- The wire gains exactly one field: `slug` on `ResolvedConnection.to_wire()`.
+- Fail-loud on an unsettable model already landed (strict-by-default, typed `ModelNotSettableError`).
+- The UI renames the type label "Custom provider" to "OpenAI-compatible endpoint" at three locations.
+  The picker expansion moves to `model-config` Part 3.

--- a/docs/design/agent-workflows/projects/custom-providers-in-pi/design.md
+++ b/docs/design/agent-workflows/projects/custom-providers-in-pi/design.md
@@ -1,0 +1,182 @@
+# Design: the contracts, classified by role
+
+This project touches five contracts. Each one below is run through the `design-interfaces` pass:
+what the field is, who owns it, when it changes, and which semantic role it plays (data, config,
+policy, credentials, routing, or metadata). The point is to fix the shape while it is on paper.
+
+The one rule: classify a field by the role it plays, not the feature it touches.
+
+## 1. The `deployment` field on `ResolvedConnection`
+
+### What it is today
+
+`deployment: str = "direct"` on `ResolvedConnection` (`connections.py`, emitted at `:431-438`).
+Values in play: `direct`, `azure`, `bedrock`, `vertex`/`vertex_ai`, `custom`, and, by the bug,
+any raw vault kind such as `openrouter`. It is read by `harness_allows_deployment`
+(`capabilities.py:225-236`) to gate a run against the harness's advertised `deployments`.
+
+### The role it should play
+
+`deployment` is a **routing/config** field. It answers "which access surface and auth mechanism
+does the harness use to reach this model." It is service-derived (the resolver sets it after
+selecting the secret) and it changes per connection, never per call. A direct API-key provider,
+an Azure OpenAI deployment, Bedrock, and Vertex are genuinely different surfaces: different auth
+shapes, different endpoint mechanics, different harness flags. That is a real routing distinction
+and the field earns its place.
+
+### The defect: it conflates two different questions
+
+Today `deployment` answers a second, unrelated question: "is this vault record a `custom_provider`
+or a `provider_key`." A custom OpenRouter connection is a single bearer key sent to an
+OpenAI-completions endpoint at a base URL. In every routing sense it is `direct`. Its only "custom"
+property is the base URL override, and that already lives in a separate field (`endpoint.base_url`).
+So echoing the record kind into `deployment` (`connections.py:281`) leaks an implementation detail
+(the vault storage kind) into a routing field. That is the `design-interfaces` rule 6 violation
+(do not expose an implementation detail as interface structure) and rule 10 (separate intent from
+mechanism).
+
+### The fix, by role
+
+Normalize `deployment` to the closed set of real access surfaces, and let `endpoint` carry the
+"customness":
+
+- A `custom_provider` whose kind is in `_PROVIDER_ENV_VARS` (a known single-key direct provider:
+  OpenAI, OpenRouter, Anthropic, Gemini, Mistral, Groq, Minimax, Together) resolves as
+  `deployment="direct"`. Its base URL and version ride `endpoint`; its key rides `env`.
+- A `custom_provider` whose kind is `azure` / `bedrock` / `vertex` keeps its cloud-surface
+  `deployment`. Those stay fail-loud on Pi in v1 (non-goal).
+- `deployment` becomes a closed enum of access surfaces (`direct`, `azure`, `bedrock`, `vertex`),
+  not an open echo of the vault kind. The free `"custom"` value goes away: a custom endpoint is
+  `direct` plus an `endpoint`.
+
+This is the smallest correct change and it needs nothing new on the wire. After it, a custom
+OpenRouter connection passes Pi's `["direct"]` gate, and `resolved_env` already emits
+`OPENROUTER_API_KEY`, so a built-in OpenRouter id is settable through Pi's env-var channel.
+
+Rejected alternative: add each known-direct kind (`openrouter`, `openai`, ...) to Pi's
+`deployments` list. That is a category error. Those are providers, not deployment surfaces, and it
+would make the capability table advertise "openrouter" as a deployment. Keep `deployment` a
+surface and `provider` a provider.
+
+## 2. The Pi `models.json` shape (Slice 2, the runner write)
+
+The runner writes this file into `PI_CODING_AGENT_DIR`. It is Pi's own config format
+(`docs/models.md`), so the outer shape is fixed by Pi. The `design-interfaces` work is on how each
+value is sourced and, above all, that the credential is a reference, not a secret.
+
+```json
+{
+  "providers": {
+    "openrouter": {
+      "baseUrl": "https://openrouter.ai/api/v1",
+      "api": "openai-completions",
+      "apiKey": "$OPENROUTER_API_KEY",
+      "models": [{ "id": "anthropic/claude-3.5-sonnet" }]
+    }
+  }
+}
+```
+
+| Field | Role | Owner / lifecycle | Source in our contract |
+| --- | --- | --- | --- |
+| `providers` | config, extensible map (plural, correct) | service, per run | keyed by `resolved_connection.provider` |
+| `providers.<p>.baseUrl` | routing (the endpoint being contacted, nested under the provider) | service, per run | `resolved_connection.endpoint.baseUrl` |
+| `providers.<p>.api` | config (the wire dialect) | service, per run | derived from provider (default `openai-completions`; Anthropic to `anthropic-messages`) |
+| `providers.<p>.apiKey` | credentials, expressed as an env **reference** | service, per run | `"$" + env_var(provider)`, never the raw key |
+| `providers.<p>.models[].id` | config/data (the registered model catalog) | service, per run | `resolved_connection.model` (the selected exact id) |
+
+The load-bearing rule is `design-interfaces` rule 8: prefer a reference over a raw secret. `apiKey`
+is written as `"$OPENROUTER_API_KEY"`, an env interpolation Pi resolves at request time from the
+daemon env. The real key rides `resolved_connection.env` and the runner injects it into the daemon
+env (the same channel `auth.json` uses). So `models.json` on disk carries no secret value. `auth.json`
+follows the same rule: `{ "openrouter": { "type": "api_key", "key": "$OPENROUTER_API_KEY" } }`,
+merged with the login's copied `auth.json` so OAuth still works.
+
+Write `models.json` only when there is something custom to say: a base URL override, or a model id
+that is not in Pi's built-in catalog. For a built-in id, `auth.json` (or the env var alone) is
+enough. This keeps the common case to a single small write.
+
+## 3. How base URL and custom models reach the runner (the wire boundary)
+
+This is the boundary decision, and it is already settled by the two siblings. Do not add a
+Pi-specific field to the `/run` wire.
+
+- The base URL rides `resolved_connection.endpoint.baseUrl`. Already on the wire
+  (`wire_resolved_connection()`, `provider-model-auth` Slice 4).
+- The selected model id rides `resolved_connection.model`. Already on the wire.
+- The credential rides `request.secrets` (the resolved `env`). Already on the wire.
+
+The runner **derives** `auth.json`/`models.json` from these three inputs. This is
+`design-interfaces` rule 10 (separate the user-facing API from internal execution): the wire says
+"here is the provider, the model, the endpoint, and the credential env"; the runner decides the Pi
+file layout. The Python service stays thin. This matches `model-config` Part 3's explicit
+boundary note ("derive in the runner, do not widen the wire") and the `provider-model-auth`
+design's harness-adapter split.
+
+The one field that does not fit a single run: a `custom_provider` can list many custom model ids,
+but `resolved_connection.model` carries only the selected one. That is correct for the run itself
+(you register the one model you are about to use). The full list matters only for the frontend
+picker, which reads the vault directly (Section 5).
+
+## 4. The `AGENTA_AGENT_MODEL_STRICT` flag (Slice 3)
+
+`AGENTA_AGENT_MODEL_STRICT` is a **policy** field: it decides what is allowed to happen when a
+requested model cannot be set (fail the run, or fall back to the harness default). It is
+operator-owned and service-level, not per call. It reuses the `strict` parameter already threaded
+into `applyModel` for Claude (`model.ts:57-59`), so the flag simply extends an existing policy knob
+to Pi rather than inventing a mechanism.
+
+Staged rollout, per `model-config` Part 2: default `false` (warn and fall back, today's behavior)
+in the first release, then flip to `true` once the QA matrix confirms the common models are
+settable and the advertised default is reconciled. The reason is a real trap: the agent config's
+advertised default model is `gpt-5.5`, which the playground echoes on every run, so strict-by-default
+would fail runs that never chose a model. A no-model-requested run always uses the documented
+default and is never an error; only a requested-but-unsettable model fails.
+
+The typed error `ModelNotSettableError` is **output** (system-owned): it carries the requested
+model and the allowed set (from `allowedFromError` plus the fixed `allowedModels`) so the caller
+learns the valid values instead of guessing. No secret ever enters it.
+
+## 5. The picker-choices contract (Slice 4)
+
+The picker draws model choices from two sources that play different roles and have different
+owners. The current code merges only the first. The fix keeps them distinct and joins them under a
+harness policy filter.
+
+| Source | Role | Owner / lifecycle |
+| --- | --- | --- |
+| Static harness catalog (`capabilities[harness].models` from `GET /workflows/catalog/harnesses/`) | config/metadata | service, per Pi release, harness-scoped |
+| Project vault custom-provider models (`LlmProvider.models` from `GET /secrets/`) | data | project, per edit, project-scoped |
+| Harness reachability (which providers/deployments the harness can use) | policy/routing | service, per harness |
+
+The two source lists have different owners and lifecycles, so `design-interfaces` says keep them in
+two branches and join them at the read boundary, not conflate them into one bucket. Concretely:
+
+- `buildModelOptionGroups` takes both the capability catalog and the vault entries, and produces
+  grouped options. A vault custom-provider's models appear only if that provider (and its
+  now-`direct` deployment) is reachable by the selected harness, the same policy filter
+  `namedConnectionOptions` already applies to the Connection dropdown.
+- `VaultConnectionEntry` (`connectionUtils.ts:302-312`) gains `models?: string[]`, so the array
+  `transformSecret` already produces stops being dropped at the type boundary.
+- Each option should carry provenance (built-in vs project connection) as **metadata**, so the UI
+  can label a project-specific model and the two lists never silently collide.
+
+Open decision recorded in [status.md](status.md): read the vault client-side (it is already
+fetched on this screen via `vaultSecretsQueryAtom`, so no new endpoint) versus adding a per-project
+model list to a server inspect field. The lean is client-side, consistent with the
+`provider-model-auth` design ("the frontend intersects the capability table with the vault"). The
+static grouped-choice baseline (`model-config` Part 3 layer 1) is independent and can land first.
+
+## Summary of contract changes
+
+- `ResolvedConnection.deployment` becomes a closed access-surface enum; a known-direct
+  `custom_provider` normalizes to `direct` (Slice 1). No wire change.
+- The runner derives Pi `auth.json`/`models.json` from `resolved_connection` plus `secrets`; the
+  credential is a `"$ENV"` reference, never a raw value (Slice 2). No wire change.
+- `AGENTA_AGENT_MODEL_STRICT` extends the existing `strict` policy knob to Pi; `ModelNotSettableError`
+  is the typed output (Slice 3).
+- `VaultConnectionEntry` gains `models?: string[]`; `buildModelOptionGroups` joins the static
+  catalog and the vault under the harness policy filter, tagging provenance (Slice 4).
+- The provider-to-env map value `together_ai -> TOGETHER_API_KEY`, fixed in all three copies, with
+  `minimax` added where missing (Slice 0).
+</content>

--- a/docs/design/agent-workflows/projects/custom-providers-in-pi/plan.md
+++ b/docs/design/agent-workflows/projects/custom-providers-in-pi/plan.md
@@ -1,0 +1,143 @@
+# Plan
+
+Five slices, each mapped to one gap. Two slices (1 and 5) are new to this project. Three
+(2, 3, and part of 4) implement or extend designs the `model-config` sibling already wrote. The
+recommended order front-loads the fastest unblock and keeps each slice independently shippable.
+
+## Slice-to-gap map
+
+| Slice | Gap | New or from a sibling | Where |
+| --- | --- | --- | --- |
+| 0 | 5 (Together env var) | new one-liner | `platform/secrets.py`, `platform/connections.py`, `connections/resolver.py` |
+| 1 | 1 (deployment gate) | new | `platform/connections.py` |
+| 2 | 2 (runner teaches Pi) | `model-config` Part 1 | `services/runner/src/engines/sandbox_agent/` |
+| 3 | 3 (silent model drop) | `model-config` Part 2 | `services/runner/src/engines/sandbox_agent/model.ts`, `sandbox_agent.ts` |
+| 4 | 4 (picker) | extends `model-config` Part 3 | `web/packages/agenta-entity-ui/...`, `capabilities.py` |
+
+## Slice 0: fix the Together env var (Gap 5)
+
+The independent quick win. Change `together_ai -> TOGETHER_API_KEY` in all three provider-to-env
+maps (`platform/secrets.py:100`, `platform/connections.py:49`, `connections/resolver.py:38`). Add
+the missing `minimax -> MINIMAX_API_KEY` to the two maps that omit it (`secrets.py`,
+`resolver.py`), since `PI_VAULT_PROVIDERS` advertises `minimax` and a `minimax` key silently
+produces no env var today. Audit every remaining entry against Pi's `getApiKeyEnvVars`.
+
+This is behavior-preserving except for the two providers it repairs. It has no ordering
+dependency, so it can land first or in parallel.
+
+Tests: a unit assertion that the three maps agree (a cross-copy equality test, noted but not
+written by the siblings), and that `together_ai` and `minimax` resolve to the Pi-correct env var.
+
+## Slice 1: normalize the deployment of a known-direct custom provider (Gap 1)
+
+The fastest unblock, and the whole reason this project exists. In `_custom_provider_candidate`
+(`connections.py:274-309`), when the vault kind is in `_PROVIDER_ENV_VARS`, set
+`deployment="direct"` instead of echoing the kind. Keep `azure`/`bedrock`/`vertex` as their cloud
+surface (they stay fail-loud on Pi). Tighten `ResolvedConnection.deployment` to the closed
+access-surface set (`direct`/`azure`/`bedrock`/`vertex`); drop the free `"custom"` echo (a custom
+endpoint is `direct` plus an `endpoint`). The role analysis is in [design.md](design.md) Section 1.
+
+After this, a custom OpenRouter or OpenAI connection passes Pi's `["direct"]` gate. Because
+`resolved_env` already emits the provider's `*_API_KEY` (`connections.py:238-245`) and the runner
+already forwards `request.secrets` into the Pi daemon env, a model id that is already in Pi's
+built-in catalog (all 253 OpenRouter ids, the `openai/*` ids) becomes settable with no runner
+change. This slice alone closes the headline "OpenRouter works as a provider_key but not as a
+custom provider" complaint for any built-in id.
+
+Custom base URLs and genuinely custom (non-built-in) ids still need Slice 2.
+
+Tests: unit on `_custom_provider_candidate` (a known-direct kind resolves `deployment="direct"`,
+provider set, endpoint and env intact; a cloud kind keeps its surface). Integration
+(httpx-mocked resolver, fake runner): a custom OpenRouter connection with a built-in id no longer
+raises `UnsupportedDeploymentError` and reaches the runner with `OPENROUTER_API_KEY` in `secrets`.
+
+## Slice 2: teach Pi the custom provider in the runner (Gap 2, model-config Part 1)
+
+Write, into the per-run agent dir the runner controls, and into `DAYTONA_PI_DIR` for the remote
+path:
+
+- `auth.json` from the resolved provider keys, each value a `"$ENV"` reference, merged with the
+  login's copied `auth.json` so OAuth still works.
+- `models.json` only when `resolved_connection.endpoint.baseUrl` is set or the selected model id is
+  not a Pi built-in: one `providers.<provider>` block with `baseUrl`, `api`, `apiKey` (`"$ENV"`),
+  and the one selected model id. The shape and its role analysis are in [design.md](design.md)
+  Section 2.
+
+Prerequisites inside this slice:
+
+- Make "the run carries a resolved provider connection" a third reason to create and point at the
+  per-run agent dir, alongside skills and system prompt (`pi-assets.ts:224`). Otherwise the write
+  lands nowhere the daemon reads for the exact failing case (a plain model override).
+- Local and Daytona parity: mirror `uploadPiAuthToSandbox` (`daytona.ts:77-94`) with a
+  `models.json` uploader, and confirm the key reaches the sandbox env via `daytonaEnvVars`
+  (`daytona.ts:31-46`).
+
+All inputs already ride the wire (`resolved_connection` plus `secrets`); no wire change. This is
+the runner half of the fix and it stays in `services/runner/src/engines/sandbox_agent/`.
+
+Tests: unit that given `resolved_connection` with a base URL and a key, the runner writes an
+`auth.json` referencing `"$OPENROUTER_API_KEY"` and a `models.json` with the base URL and the
+selected id, and never a raw secret. Integration: a custom-base-URL run resolves the model rather
+than falling back. Live acceptance (llm_required): a custom OpenRouter connection with a genuinely
+custom id runs.
+
+## Slice 3: fail loud on an unsettable model (Gap 3, model-config Part 2)
+
+Fix `allowedModels` to read `c.value ?? c.id` (`model.ts:19-30`) so the allowed set is real. Raise
+a typed `ModelNotSettableError` carrying the requested model and the allowed set when a requested
+model cannot be set after the retry. Gate it behind `AGENTA_AGENT_MODEL_STRICT`, default `false`
+first (warn and fall back, today's behavior), then flip to `true` once the QA matrix confirms the
+common models are settable and the advertised default is reconciled. A no-model-requested run still
+uses the harness default and is never an error. Keep the in-process Pi path consistent
+(`engines/pi.ts` `pickModel` should raise the same error rather than silently substituting). The
+role analysis is in [design.md](design.md) Section 4.
+
+Tests: a requested model with no key raises and the concise error renders the available set; no
+model requested still runs the default; strict off preserves today's fallback.
+
+## Slice 4: surface custom-provider models in the picker (Gap 4)
+
+Add `models?: string[]` to `VaultConnectionEntry` (`connectionUtils.ts:302-312`). Thread the vault
+entries into `buildModelOptionGroups` (`:239-256`) or its `useModelHarness` caller, and merge each
+reachable custom provider's models into the harness-filtered group, tagging provenance so the UI
+labels a project-specific model. Apply the same harness reachability filter
+`namedConnectionOptions` already uses. Land the static grouped-choice baseline first
+(`model-config` Part 3 layer 1: give the agent `model` field real grouped choices from
+`supported_llm_models`), which is independent and cheap. The picker-choices contract and its role
+split are in [design.md](design.md) Section 5.
+
+Tests: helper unit that a custom provider's models appear in the group for a harness that reaches
+that provider and are absent for one that does not; a built-in-only picker is unchanged.
+
+## Recommended order
+
+1. **Slice 0** (Together env var). Independent, trivial, unblocks Together and Minimax now.
+2. **Slice 1** (deployment gate). The fastest unblock: one resolver change makes a custom
+   known-direct provider work on Pi for any built-in id, with no runner or frontend work.
+3. **Slice 2** (runner write). Extends the reach to custom base URLs and genuinely custom ids.
+   Contained to the runner.
+4. **Slice 3a** (louder error, `allowedModels` fix, `AGENTA_AGENT_MODEL_STRICT` defaulting false).
+   The safe half of the fail-loud fix.
+5. **Slice 4** (picker), with the static grouped-choice baseline first.
+6. **Slice 3b** (flip `AGENTA_AGENT_MODEL_STRICT` to strict) once the QA matrix is green.
+
+Slice 1 is the single highest-value change and should ship first after Slice 0. Slices 0, 1, and 4
+are new to this project; Slices 2 and 3 build the `model-config` design.
+
+## Non-goals
+
+- Bedrock, Vertex, and Azure consumption on Pi stays fail-loud. This project does not wire
+  multi-var cloud credential delivery into Pi.
+- No vault storage change: no new secret kind, no migration, no `/secrets` write path.
+- No new `/run` wire field.
+- The prompt/completion path is untouched.
+
+## Appendix: the Pi startup-banner leak (separately shippable, not a slice)
+
+`isBannerLine` (`services/runner/src/tracing/otel.ts:699-713`) does not match pi-acp's newer
+`## Extensions` section or its `.js` extension paths, and `stripStartupBanner` (`:719-728`) strips
+only a leading contiguous run, so the Extensions block and the trailing "New version available"
+notice leak into replies. Fix `isBannerLine` to match the `Extensions` heading and a `.js` path
+(or strip the whole banner block). Ship on its own lane; it does not block the five gaps. Full
+detail in [research.md](research.md).
+</content>

--- a/docs/design/agent-workflows/projects/custom-providers-in-pi/plan.md
+++ b/docs/design/agent-workflows/projects/custom-providers-in-pi/plan.md
@@ -1,143 +1,109 @@
 # Plan
 
-Five slices, each mapped to one gap. Two slices (1 and 5) are new to this project. Three
-(2, 3, and part of 4) implement or extend designs the `model-config` sibling already wrote. The
-recommended order front-loads the fastest unblock and keeps each slice independently shippable.
+The goal is a named OpenAI-compatible model running through a Pi agent, with the connection slug as
+its identity end to end. Three of the first plan's slices already landed. The rest is three slices in
+dependency order, each independently shippable, each with tests. The banner-leak appendix stays a
+separate lane.
 
-## Slice-to-gap map
+## Landed already
 
-| Slice | Gap | New or from a sibling | Where |
-| --- | --- | --- | --- |
-| 0 | 5 (Together env var) | new one-liner | `platform/secrets.py`, `platform/connections.py`, `connections/resolver.py` |
-| 1 | 1 (deployment gate) | new | `platform/connections.py` |
-| 2 | 2 (runner teaches Pi) | `model-config` Part 1 | `services/runner/src/engines/sandbox_agent/` |
-| 3 | 3 (silent model drop) | `model-config` Part 2 | `services/runner/src/engines/sandbox_agent/model.ts`, `sandbox_agent.ts` |
-| 4 | 4 (picker) | extends `model-config` Part 3 | `web/packages/agenta-entity-ui/...`, `capabilities.py` |
+- **Env-var map (old Slice 0).** One canonical `PROVIDER_ENV_VARS`
+  (`sdks/python/agenta/sdk/agents/capabilities.py:111-125`) with `together_ai -> TOGETHER_API_KEY`
+  and `minimax`. Parity test: `sdks/python/oss/tests/pytest/unit/agents/test_provider_env_vars_parity.py`.
+- **Known-family deployment gate (old Slice 1).** `_custom_provider_candidate`
+  (`sdks/python/agenta/sdk/agents/platform/connections.py:330-335`) resolves a known-family custom
+  connection to `deployment="direct"`, which passes Pi's `["direct"]` gate.
+- **Fail-loud model (old Slice 3a).** `allowedModels` reads `c.value ?? c.id`
+  (`services/runner/src/engines/sandbox_agent/model.ts:72`); `applyModel` raises a typed
+  `ModelNotSettableError` (`model.ts:9`); `AGENTA_AGENT_MODEL_STRICT` is wired for every harness and
+  defaults to true (`sandbox_agent.ts:374`, applied at `:1692-1696`). This shipped strict-by-default
+  directly, so the first plan's staged "flip to strict later" step (old Slice 3b) is moot.
 
-## Slice 0: fix the Together env var (Gap 5)
+## Slice 1: connection identity and gate (service)
 
-The independent quick win. Change `together_ai -> TOGETHER_API_KEY` in all three provider-to-env
-maps (`platform/secrets.py:100`, `platform/connections.py:49`, `connections/resolver.py:38`). Add
-the missing `minimax -> MINIMAX_API_KEY` to the two maps that omit it (`secrets.py`,
-`resolver.py`), since `PI_VAULT_PROVIDERS` advertises `minimax` and a `minimax` key silently
-produces no env var today. Audit every remaining entry against Pi's `getApiKeyEnvVars`.
+Give a named OpenAI-compatible connection an identity and let it through Pi's gate.
 
-This is behavior-preserving except for the two providers it repairs. It has no ordering
-dependency, so it can land first or in parallel.
+- Add `slug` to `ResolvedConnection` (`connections/models.py:162-183`) and its wire form `to_wire()`
+  (`:190-207`). Update the docstring, which currently states the adapter never sees a slug. The slug
+  is the connection's identity, not a secret.
+- Resolve a provider-less or unknown-kind custom connection to the OpenAI-compatible family with
+  `deployment="custom"`, defaulting the family after the trusted vault record resolves. No stored
+  schema change.
+- Add the `custom` deployment to Pi's capability row, paired with the OpenAI-compatible protocol, so
+  `harness_allows_deployment` (`capabilities.py:299-310`) and the pre-resolve provider check
+  (`capabilities.py:281-284`) let a named connection through instead of raising
+  `UnsupportedProviderError` / `UnsupportedDeploymentError` (`handler.py:117-119`, `:135-137`).
 
-Tests: a unit assertion that the three maps agree (a cross-copy equality test, noted but not
-written by the siblings), and that `together_ai` and `minimax` resolve to the Pi-correct env var.
+The role analysis is in [design.md](design.md) Sections 1 and 3.
 
-## Slice 1: normalize the deployment of a known-direct custom provider (Gap 1)
+Tests:
 
-The fastest unblock, and the whole reason this project exists. In `_custom_provider_candidate`
-(`connections.py:274-309`), when the vault kind is in `_PROVIDER_ENV_VARS`, set
-`deployment="direct"` instead of echoing the kind. Keep `azure`/`bedrock`/`vertex` as their cloud
-surface (they stay fail-loud on Pi). Tighten `ResolvedConnection.deployment` to the closed
-access-surface set (`direct`/`azure`/`bedrock`/`vertex`); drop the free `"custom"` echo (a custom
-endpoint is `direct` plus an `endpoint`). The role analysis is in [design.md](design.md) Section 1.
+- Resolver unit tests: the slug rides the wire; an Ollama-style record (unknown kind, base URL, key)
+  resolves to `deployment="custom"` and the OpenAI-compatible family and passes the Pi gate; a
+  known-family record still resolves `direct` and is unchanged.
+- A wire golden test for `ResolvedConnection` if one exists (the runner mirrors the wire in
+  `protocol.ts` with a shared golden; update both sides and the golden together).
 
-After this, a custom OpenRouter or OpenAI connection passes Pi's `["direct"]` gate. Because
-`resolved_env` already emits the provider's `*_API_KEY` (`connections.py:238-245`) and the runner
-already forwards `request.secrets` into the Pi daemon env, a model id that is already in Pi's
-built-in catalog (all 253 OpenRouter ids, the `openai/*` ids) becomes settable with no runner
-change. This slice alone closes the headline "OpenRouter works as a provider_key but not as a
-custom provider" complaint for any built-in id.
+## Slice 2: teach Pi the connection (runner)
 
-Custom base URLs and genuinely custom (non-built-in) ids still need Slice 2.
+Write the Pi config and set the exact model.
 
-Tests: unit on `_custom_provider_candidate` (a known-direct kind resolves `deployment="direct"`,
-provider set, endpoint and env intact; a cloud kind keeps its surface). Integration
-(httpx-mocked resolver, fake runner): a custom OpenRouter connection with a built-in id no longer
-raises `UnsupportedDeploymentError` and reaches the runner with `OPENROUTER_API_KEY` in `secrets`.
+- A pure model-config builder returns `{ files, exactModelId }`. `files` holds `models.json` keyed by
+  `providers[<slug>]`, dialect `openai-completions`, `apiKey` as a `"$ENV"` reference, and the one
+  selected model. `exactModelId` is `<slug>/<model>`. The shape and its role analysis are in
+  [design.md](design.md) Section 2.
+- Write `models.json` into the per-run Pi agent dir, local and Daytona alike. Make "the run carries a
+  resolved provider connection" a reason to create and point at that dir, alongside skills and a
+  system prompt.
+- Build an isolated managed Pi directory for a managed run (`credentialMode="env"`): non-credential
+  settings plus `models.json` only, never the operator's `auth.json`. This fixes the local path
+  (`pi-assets.ts:475-490` copies it today) to match the Daytona path (`daytona.ts:168-171`).
+- Pass `exactModelId` to `setModel`, bypassing the suffix-match fallback in `pickModel`
+  (`model.ts:49-59`) that can pick the wrong provider.
 
-## Slice 2: teach Pi the custom provider in the runner (Gap 2, model-config Part 1)
+All new inputs ride the slug added in Slice 1 plus the existing `resolved_connection` and `secrets`.
 
-Write, into the per-run agent dir the runner controls, and into `DAYTONA_PI_DIR` for the remote
-path:
+Tests:
 
-- `auth.json` from the resolved provider keys, each value a `"$ENV"` reference, merged with the
-  login's copied `auth.json` so OAuth still works.
-- `models.json` only when `resolved_connection.endpoint.baseUrl` is set or the selected model id is
-  not a Pi built-in: one `providers.<provider>` block with `baseUrl`, `api`, `apiKey` (`"$ENV"`),
-  and the one selected model id. The shape and its role analysis are in [design.md](design.md)
-  Section 2.
+- Builder unit tests: the content keys by slug, uses `openai-completions`, references `"$ENV"` and
+  never writes a raw secret to disk, and returns the exact `<slug>/<model>` id.
+- Managed-dir isolation test: a managed run's Pi dir has no operator `auth.json`.
+- Daytona parity: the same `models.json` reaches the sandbox and the key reaches the sandbox env.
+- Live acceptance (llm_required): a connection with a custom base URL and a custom model id runs.
 
-Prerequisites inside this slice:
+## Slice 3: rename the UI type label (frontend)
 
-- Make "the run carries a resolved provider connection" a third reason to create and point at the
-  per-run agent dir, alongside skills and system prompt (`pi-assets.ts:224`). Otherwise the write
-  lands nowhere the daemon reads for the exact failing case (a plain model override).
-- Local and Daytona parity: mirror `uploadPiAuthToSandbox` (`daytona.ts:77-94`) with a
-  `models.json` uploader, and confirm the key reaches the sandbox env via `daytonaEnvVars`
-  (`daytona.ts:31-46`).
+Rename the visible type "Custom provider" to "OpenAI-compatible endpoint" at three locations:
 
-All inputs already ride the wire (`resolved_connection` plus `secrets`); no wire change. This is
-the runner half of the fix and it stays in `services/runner/src/engines/sandbox_agent/`.
+- `web/packages/agenta-entity-ui/src/DrillInView/SchemaControls/agentTemplate/ProviderCredentialsSection.tsx:87`
+  and `:416`.
+- `web/packages/agenta-entities/src/secret/core/types.ts:98`.
+- `web/oss/src/components/pages/settings/Secrets/SecretProviderTable/index.tsx:206`.
 
-Tests: unit that given `resolved_connection` with a base URL and a key, the runner writes an
-`auth.json` referencing `"$OPENROUTER_API_KEY"` and a `models.json` with the base URL and the
-selected id, and never a raw secret. Integration: a custom-base-URL run resolves the model rather
-than falling back. Live acceptance (llm_required): a custom OpenRouter connection with a genuinely
-custom id runs.
+Nothing else in the picker changes. The picker expansion moves to `model-config` Part 3. See
+[design.md](design.md) Section 5.
 
-## Slice 3: fail loud on an unsettable model (Gap 3, model-config Part 2)
+Tests: the settings secrets table and the provider-credentials section render the new label; no other
+picker behavior changes.
 
-Fix `allowedModels` to read `c.value ?? c.id` (`model.ts:19-30`) so the allowed set is real. Raise
-a typed `ModelNotSettableError` carrying the requested model and the allowed set when a requested
-model cannot be set after the retry. Gate it behind `AGENTA_AGENT_MODEL_STRICT`, default `false`
-first (warn and fall back, today's behavior), then flip to `true` once the QA matrix confirms the
-common models are settable and the advertised default is reconciled. A no-model-requested run still
-uses the harness default and is never an error. Keep the in-process Pi path consistent
-(`engines/pi.ts` `pickModel` should raise the same error rather than silently substituting). The
-role analysis is in [design.md](design.md) Section 4.
+## Order
 
-Tests: a requested model with no key raises and the concise error renders the available set; no
-model requested still runs the default; strict off preserves today's fallback.
-
-## Slice 4: surface custom-provider models in the picker (Gap 4)
-
-Add `models?: string[]` to `VaultConnectionEntry` (`connectionUtils.ts:302-312`). Thread the vault
-entries into `buildModelOptionGroups` (`:239-256`) or its `useModelHarness` caller, and merge each
-reachable custom provider's models into the harness-filtered group, tagging provenance so the UI
-labels a project-specific model. Apply the same harness reachability filter
-`namedConnectionOptions` already uses. Land the static grouped-choice baseline first
-(`model-config` Part 3 layer 1: give the agent `model` field real grouped choices from
-`supported_llm_models`), which is independent and cheap. The picker-choices contract and its role
-split are in [design.md](design.md) Section 5.
-
-Tests: helper unit that a custom provider's models appear in the group for a harness that reaches
-that provider and are absent for one that does not; a built-in-only picker is unchanged.
-
-## Recommended order
-
-1. **Slice 0** (Together env var). Independent, trivial, unblocks Together and Minimax now.
-2. **Slice 1** (deployment gate). The fastest unblock: one resolver change makes a custom
-   known-direct provider work on Pi for any built-in id, with no runner or frontend work.
-3. **Slice 2** (runner write). Extends the reach to custom base URLs and genuinely custom ids.
-   Contained to the runner.
-4. **Slice 3a** (louder error, `allowedModels` fix, `AGENTA_AGENT_MODEL_STRICT` defaulting false).
-   The safe half of the fail-loud fix.
-5. **Slice 4** (picker), with the static grouped-choice baseline first.
-6. **Slice 3b** (flip `AGENTA_AGENT_MODEL_STRICT` to strict) once the QA matrix is green.
-
-Slice 1 is the single highest-value change and should ship first after Slice 0. Slices 0, 1, and 4
-are new to this project; Slices 2 and 3 build the `model-config` design.
+1. **Slice 1** (service). The slug and the gate. Slice 2 depends on the slug on the wire.
+2. **Slice 2** (runner). The `models.json` write, the isolated managed dir, and the exact id.
+3. **Slice 3** (frontend). Independent of the other two; can land any time.
 
 ## Non-goals
 
-- Bedrock, Vertex, and Azure consumption on Pi stays fail-loud. This project does not wire
-  multi-var cloud credential delivery into Pi.
+- Bedrock, Vertex, and Azure consumption on Pi stays fail-loud.
 - No vault storage change: no new secret kind, no migration, no `/secrets` write path.
-- No new `/run` wire field.
+- Exactly one new `/run` wire field: the connection slug. No others.
+- The model picker expansion stays with `model-config` Part 3.
 - The prompt/completion path is untouched.
 
 ## Appendix: the Pi startup-banner leak (separately shippable, not a slice)
 
-`isBannerLine` (`services/runner/src/tracing/otel.ts:699-713`) does not match pi-acp's newer
-`## Extensions` section or its `.js` extension paths, and `stripStartupBanner` (`:719-728`) strips
-only a leading contiguous run, so the Extensions block and the trailing "New version available"
-notice leak into replies. Fix `isBannerLine` to match the `Extensions` heading and a `.js` path
-(or strip the whole banner block). Ship on its own lane; it does not block the five gaps. Full
-detail in [research.md](research.md).
-</content>
+`isBannerLine` (`services/runner/src/tracing/otel.ts`) does not match pi-acp's newer `## Extensions`
+section or its `.js` extension paths, and `stripStartupBanner` strips only a leading contiguous run,
+so the Extensions block and the trailing "New version available" notice leak into replies. Fix
+`isBannerLine` to match the `Extensions` heading and a `.js` path (or strip the whole banner block).
+Ship on its own lane. Full detail in [research.md](research.md).

--- a/docs/design/agent-workflows/projects/custom-providers-in-pi/research.md
+++ b/docs/design/agent-workflows/projects/custom-providers-in-pi/research.md
@@ -1,214 +1,111 @@
-# Research: the five gaps, verified
+# Research: the gaps, verified
 
-All references re-verified on 2026-07-02 against the working tree. This doc records the exact
-locations and the mechanism behind each gap, plus two path corrections and one appendix. It does
-not repeat the sibling research; read `../model-config/research.md` for how Pi decides a model is
-available, and `../provider-model-auth/design.md` for the resolver and capability contracts.
+The first pass verified five gaps on 2026-07-02. A second pass on 2026-07-14 re-checked them against
+the working tree. Three gaps closed in the meantime. This doc leads with that dated re-verification,
+then keeps the mechanism detail for the gaps that remain. It does not repeat the sibling research;
+read `../model-config/research.md` for how Pi decides a model is available and
+`../provider-model-auth/design.md` for the resolver and capability contracts.
 
-## Two corrections to prior docs
+## Re-verification (2026-07-14)
 
-- **Runner path.** The runner TypeScript is at `services/runner/src/`, not `services/agent/src/`
-  as the siblings cite. The rename is commit `b323a8516f`. The monolithic `sandbox_agent.ts` also
-  split into `services/runner/src/engines/sandbox_agent/{model,daemon,daytona,pi-assets,errors}.ts`,
-  so several functions moved. Every runner line below is the current location.
-- **Frontend capability source.** The harness catalog reaches the frontend from
-  `GET /workflows/catalog/harnesses/` (served from `capabilities.py` `harness_catalog_document`,
-  via `api/oss/src/apis/fastapi/workflows/router.py`), not the `/inspect` `meta`. The
-  `connectionUtils.ts` header comment still says `/inspect`; it is stale. The live query atom is
-  `harnessCatalogQueryAtom` in
-  `web/packages/agenta-entities/src/workflow/state/inspectMeta.ts`.
+### Closed since 2026-07-02
 
-## Gap 1: the deployment gate blocks a known-direct custom provider
+- **The provider-to-env map drift.** The three hand-copied maps are gone. One canonical
+  `PROVIDER_ENV_VARS` (`sdks/python/agenta/sdk/agents/capabilities.py:111-125`) is the source of
+  truth, with `together_ai -> TOGETHER_API_KEY` and `minimax -> MINIMAX_API_KEY`. `platform/secrets.py`
+  and `connections/resolver.py` import it instead of redefining it. A parity regression test pins
+  this: `sdks/python/oss/tests/pytest/unit/agents/test_provider_env_vars_parity.py`. (Was Slice 0.)
+- **The known-family deployment gate.** `_custom_provider_candidate`
+  (`sdks/python/agenta/sdk/agents/platform/connections.py:330-335`) now sets
+  `deployment = "direct" if provider is not None else provider_kind`. A custom connection whose kind
+  is a known family (OpenRouter, OpenAI) resolves to `direct` and passes Pi's `["direct"]` gate with
+  no runner or frontend change. (Was Slice 1, for the known-family case.)
+- **The silent model drop.** `allowedModels` reads `c.value ?? c.id`
+  (`services/runner/src/engines/sandbox_agent/model.ts:72`), so the allowed set is real for pi-acp.
+  `applyModel` raises a typed `ModelNotSettableError` (`model.ts:9`) when a requested model cannot be
+  set, and `AGENTA_AGENT_MODEL_STRICT` is wired for every harness, defaulting to true
+  (`modelResolutionStrict` at `services/runner/src/engines/sandbox_agent.ts:374`, applied at
+  `:1692-1696`). (Was Slice 3a. It shipped strict-by-default directly, not staged, so the planned
+  "flip later" step is moot.)
 
-A `provider_key` always resolves with `deployment="direct"`
-(`connections.py:258-271`, `_provider_key_candidate`, the value is hard-coded at `:269`). A
-`custom_provider` echoes its raw kind:
+### Still open
 
-```python
-# sdks/python/agenta/sdk/agents/platform/connections.py:281
-deployment = _stripped(data.get("kind")) or "custom"
-```
+- **An arbitrary named OpenAI-compatible connection is rejected before it runs.** A custom
+  connection whose kind is not in `PROVIDER_ENV_VARS` (an Ollama gateway, an in-house proxy)
+  resolves with `provider=None`. It then dies at one of two gates depending on how the model was
+  referenced:
+  - A provider-prefixed ref dies pre-resolve in `_check_harness_pre_resolve` via
+    `harness_allows_provider` (closed by default, `capabilities.py:281-284`), raising
+    `UnsupportedProviderError` (`handler.py:117-119`).
+  - A bare slug-named ref dies post-resolve in `harness_allows_deployment`
+    (`capabilities.py:299-310`), raising `UnsupportedDeploymentError` (`handler.py:135-137`),
+    because a provider-less record keeps `deployment=provider_kind`, which Pi does not list.
+- **`ResolvedConnection` carries no slug.** The model (`connections/models.py:162-183`) and its wire
+  form `to_wire()` (`:190-207`) carry `provider`, `model`, `deployment`, `credentialMode`, `env`,
+  and `endpoint`, but no connection slug. Its docstring even states the harness adapter "never sees
+  a vault, a connection, or a slug." Two custom connections with the same kind both resolve to the
+  same `provider` and are indistinguishable at the runner (`connections.py:258-259`).
+- **The runner writes no Pi `models.json`.** A grep of `services/runner/src/` for `models.json`
+  returns zero. A custom base URL and genuinely custom model ids never reach Pi.
+- **The runner copies the operator's personal login into a managed run.** `prepareLocalAgentDir`
+  (`services/runner/src/engines/sandbox_agent/pi-assets.ts:475-490`) copies the operator's
+  `auth.json` and `settings.json` into the per-run dir even for a managed run
+  (`credentialMode="env"`) on the local path. The Daytona path deliberately never copies a personal
+  `auth.json` (`daytona.ts:168-171`), so the two paths disagree today.
+- **The suffix-match fallback can pick the wrong provider.** `pickModel`
+  (`model.ts:49-59`) matches on the substring after the first `/`. When two providers advertise the
+  same model suffix, it can select the first wrong one.
+- **The picker never shows a project's custom-provider models.** `buildModelOptionGroups`
+  (`web/packages/agenta-entity-ui/src/DrillInView/SchemaControls/connectionUtils.ts:283-324`) reads
+  only the harness capability catalog. `transformSecret` produces a `models` array
+  (`web/packages/agenta-entities/src/secret/core/transforms.ts:109`) that the secrets table consumes
+  but the model picker does not. **The `VaultConnectionEntry` symbol the first plan named does not
+  exist in `web/`.** It was a stale name. The picker work is out of scope here (it moves to
+  `model-config` Part 3); this plan touches the UI only to rename the type label (below).
 
-`_custom_provider_candidate` (`:274-309`) already resolves the rest correctly. It sets
-`provider = data_kind if data_kind in _PROVIDER_ENV_VARS else None` (`:295-296`), builds the
-`Endpoint` from `settings.url`/`version` plus region (`:287-291`), and carries `model_slugs`
-/`model_keys`. So a custom OpenRouter connection resolves with `provider="openrouter"`, a real
-`endpoint.base_url`, the selected model id, and, from `resolved_env`, the right env var:
+### The UI type label
 
-```python
-# connections.py:238-245  _ConnectionCandidate.resolved_env
-env_var = _provider_env_var(provider) or _provider_env_var(self.provider)
-if self.api_key and env_var:
-    env.setdefault(env_var, self.api_key)   # e.g. {"OPENROUTER_API_KEY": "<key>"}
-```
+The visible type "Custom provider" appears at three locations:
 
-The only wrong field is `deployment`, which becomes `"openrouter"` and rides into
-`ResolvedConnection.deployment` verbatim (`connections.py:431-438`, `deployment=chosen.deployment`).
-Then the post-resolve check rejects it:
+- `web/packages/agenta-entity-ui/src/DrillInView/SchemaControls/agentTemplate/ProviderCredentialsSection.tsx:87`
+  and `:416`.
+- `web/packages/agenta-entities/src/secret/core/types.ts:98`.
+- `web/oss/src/components/pages/settings/Secrets/SecretProviderTable/index.tsx:206`.
 
-```python
-# services/oss/src/agent/app.py:110-125
-if not harness_allows_deployment(harness, resolved.deployment):
-    raise UnsupportedDeploymentError(deployment=resolved.deployment, harness=harness)
-```
+This plan renames it to "OpenAI-compatible endpoint" at all three.
 
-```python
-# sdks/python/agenta/sdk/agents/capabilities.py:225-236
-normalized = "vertex_ai" if deployment == "vertex" else deployment
-return normalized in entry.deployments        # Pi: ["direct"] (capabilities.py:146, :152)
-```
+## Mechanism detail for the open gaps
 
-`"openrouter"` is not in `["direct"]`, so `UnsupportedDeploymentError` (a 422) fires before the
-runner is ever called. This is exactly why "OpenRouter works as a `provider_key` but not as a
-custom provider." Because `resolved_env` already emits `OPENROUTER_API_KEY` and the runner already
-forwards `request.secrets` into the Pi daemon env, fixing only the deployment label makes a
-built-in OpenRouter id settable through Pi's env-var channel with no other change. That is why
-Gap 1 is the fastest unblock.
+### Why an arbitrary connection needs a family default
 
-The classification the field should carry is worked out in [design.md](design.md).
+A provider-less custom record has no entry in `PROVIDER_ENV_VARS`, so `provider` stays `None` and no
+`*_API_KEY` name is derived. The fix defaults such a record to the OpenAI-compatible family after the
+trusted vault record resolves, keeps `deployment="custom"`, and lets Pi's capability table allow the
+`(custom, openai-compatible)` pair. The base URL already rides `endpoint`; the key already rides
+`env`. The design in [design.md](design.md) Section 1 works out the roles.
 
-## Gap 2: the runner never teaches Pi a custom provider
+### Why the models.json must key by slug
 
-The runner writes no Pi `models.json`. A grep of `services/runner/src/` for `models.json` returns
-zero matches. The per-run agent dir seed copies exactly two files:
+Two custom connections can both resolve to the OpenAI-compatible family, and a provider-less one may
+carry no provider at all. Keying `providers` by `resolved_connection.provider` would collide or fail
+to produce a Pi provider id. Keying by the connection slug gives each connection a stable, unique Pi
+identity. That is the reason the wire gains a slug field. [design.md](design.md) Section 2 and 3
+carry the shape and the wire decision.
 
-```ts
-// services/runner/src/engines/sandbox_agent/pi-assets.ts:184-191  prepareLocalAgentDir
-for (const name of ["auth.json", "settings.json"]) {
-  const src = join(sourceAgentDir, name);
-  if (existsSync(src)) copyFileSync(src, join(dir, name));
-}
-```
+### Why a managed run must not copy the operator auth.json
 
-A custom base URL is applied only for Claude:
-
-```ts
-// services/runner/src/engines/sandbox_agent.ts:162, :176-180  applyClaudeConnectionEnv
-if (acpAgent !== "claude") return false;
-...
-const baseUrl = request.endpoint?.baseUrl;
-if (baseUrl) { env.ANTHROPIC_BASE_URL = baseUrl; ... }
-```
-
-So Pi never sees `endpoint.baseUrl` and never learns a genuinely custom (non-built-in) model id.
-This is `model-config` Part 1: write `auth.json` (provider keys as `"$ENV"` references) and
-`models.json` (base URL override plus custom models) into `PI_CODING_AGENT_DIR`, local and
-Daytona. The per-run agent dir is created today only when skills or a system prompt exist, so a
-plain model override skips it:
-
-```ts
-// services/runner/src/engines/sandbox_agent/pi-assets.ts:224  prepareLocalPiAssets
-if (plan.skillDirs.length > 0 || plan.hasSystemPrompt) {
-  const runAgentDir = prepareLocalAgentDir(plan.sourcePiAgentDir, plan.skillDirs, log);
-```
-
-The Daytona uploaders that this write must mirror: `uploadPiAuthToSandbox`
-(`services/runner/src/engines/sandbox_agent/daytona.ts:77-94`, into `DAYTONA_PI_DIR`),
-`daytonaEnvVars` (`daytona.ts:31-46`), and the local daemon env forwarding in
-`buildDaemonEnv` (`services/runner/src/engines/sandbox_agent/daemon.ts:132-162`).
-
-## Gap 3: a dropped model is silent
-
-```ts
-// services/runner/src/engines/sandbox_agent/model.ts:46-74  applyModel
-try {
-  await session.setModel(wanted);
-  return wanted;
-} catch (err) {
-  if (options.strict) {
-    throw new Error(`model '${wanted}' not settable (${(err as Error).message})`);
-  }
-  const allowed = allowedFromError(err);
-  const fallbackAllowed = allowed.length ? allowed : await allowedModels(session);
-  ...
-  log(`model '${wanted}' not settable (...); using harness default`);
-  return undefined;                         // silent fallback, HTTP 200 on the wrong model
-}
-```
-
-`strict` is threaded for Claude only. `applyClaudeConnectionEnv` returns a strict flag
-(`sandbox_agent.ts:193-200`), assigned at `:330`, passed at `applyModel(session, request.model,
-logger, { strict: strictModel })` (`:582-587`). Pi runs never set strict.
-
-`allowedModels` reads the wrong field:
-
-```ts
-// services/runner/src/engines/sandbox_agent/model.ts:19-30  allowedModels
-const choices = modelOpt?.options ?? [];
-return choices.map((c: any) => c.id).filter(Boolean);   // pi-acp options carry `value`, not `id`
-```
-
-pi-acp builds each model option as `{ value: model.modelId, name, description }`, so mapping `c.id`
-returns `[]` and the fallback enumeration is blind. `model-config` Part 2 already specifies the
-fix: read `c.value ?? c.id`, raise a typed `ModelNotSettableError` with the allowed set, and gate
-strictness behind `AGENTA_AGENT_MODEL_STRICT` (default false first, flip later; the reason for the
-staged rollout is the `gpt-5.5` advertised-default trap documented in `../model-config/proposal.md`).
-
-## Gap 4: the picker never shows custom-provider models
-
-```ts
-// web/packages/agenta-entity-ui/src/DrillInView/SchemaControls/connectionUtils.ts:239-256
-export function buildModelOptionGroups(capabilities, harness, metadata) {
-  const models = capsFor(capabilities, harness)?.models   // only the static harness catalog
-  if (!models) return []
-  ...
-}
-```
-
-`capabilities[harness].models` comes from `_pi_models()` (`capabilities.py:97-116`), which lists
-`supported_llm_models` for the static `PI_VAULT_PROVIDERS` (`capabilities.py:45-54`). The vault is
-read on the same screen, but only for the Connection dropdown, and only three fields per secret:
-
-```ts
-// connectionUtils.ts:341-344  namedConnectionOptions (the only vault reader in the file)
-if (secret.type !== "custom_provider") continue
-const slug = secret.name?.trim()
-...
-const secretProvider = secret.provider?.toLowerCase() || null   // never reads `models`
-```
-
-The vault entry does carry the models. `transformSecret`
-(`web/packages/agenta-entities/src/secret/core/transforms.ts:108`) sets
-`models: data.models.map((m) => m.slug)` on the in-app `LlmProvider`. But `useModelHarness.tsx`
-casts that to `VaultConnectionEntry` (`connectionUtils.ts:302-312`), whose type has no `models`
-field, so the array is dropped at the type boundary. `buildModelOptionGroups` never receives the
-vault at all. Surfacing these is an uncovered gap: `model-config` Part 3 sources choices from the
-static catalog plus the runner, never from the vault. The contract for the merge is in
-[design.md](design.md).
-
-## Gap 5: the Together env var name is wrong
-
-```python
-# sdks/python/agenta/sdk/agents/platform/secrets.py:93-102  _PROVIDER_ENV_VARS
-"together_ai": "TOGETHERAI_API_KEY",   # Pi reads TOGETHER_API_KEY (env-api-keys.js)
-```
-
-The same map is copied in three files and has already drifted:
-
-- `platform/secrets.py:93-102`: 8 entries, no `minimax`. `together_ai -> TOGETHERAI_API_KEY`.
-- `platform/connections.py:41-51`: 9 entries, includes `minimax -> MINIMAX_API_KEY`.
-  `together_ai -> TOGETHERAI_API_KEY` (`:49`).
-- `connections/resolver.py:31-40`: 8 entries, no `minimax`. `together_ai -> TOGETHERAI_API_KEY`.
-
-`capabilities.py` `PI_VAULT_PROVIDERS` lists both `minimax` and `together_ai`, so a `minimax`
-`provider_key` resolved through `secrets.py` or `resolver.py` today produces no env var at all
-(the same silent-drop class, a second instance). One extra corroboration:
-`connections.py` `_ALLOWED_EXTRA_ENV_KEYS` already lists both `TOGETHERAI_API_KEY` (`:116`) and
-`TOGETHER_API_KEY` (`:117`), so an extras-supplied Together key with the right name already passes
-through; only the mapped `provider_key` emit is wrong.
-
-The Slice 0 audit: fix `together_ai -> TOGETHER_API_KEY` in all three maps, add the missing
-`minimax` entry to the two that omit it, and confirm each entry against Pi's `getApiKeyEnvVars`.
+`prepareLocalAgentDir` copies the operator's `auth.json` unconditionally. For a managed run, that
+personal login state can authenticate the run with an operator subscription or the wrong provider.
+The runner must instead build an isolated managed Pi directory that carries only non-credential
+settings plus `models.json` with a `"$ENV"` apiKey reference, and leave the raw key in the daemon or
+sandbox environment. [design.md](design.md) Section 2 specifies the isolated directory.
 
 ## Appendix: the Pi startup-banner leak (related, separately shippable)
 
-This is not one of the five gaps and it is not a slice here. `isBannerLine`
-(`services/runner/src/tracing/otel.ts:699-713`) strips Pi's startup banner from replies, but its
-section-heading regex matches only `Context` and `Skills` (`:706`) and its path regex requires a
-`.md` suffix (`:708`). pi-acp's newer banner adds an `## Extensions` section with `.js` extension
-paths. `stripStartupBanner` (`otel.ts:719-728`) strips only a leading contiguous run of banner
-lines, so the first unmatched line (`## Extensions`) halts the strip, and the Extensions block
-plus the trailing "New version available" notice leak into the reply. The fix is to extend
-`isBannerLine` to match the `Extensions` heading and a `.js` path (or to strip the whole banner
-block rather than a leading run). Track it on its own lane; it does not block the five gaps.
-</content>
+This is not a slice here. `isBannerLine` (`services/runner/src/tracing/otel.ts`) strips Pi's startup
+banner from replies, but its section-heading regex matches only `Context` and `Skills` and its path
+regex requires a `.md` suffix. pi-acp's newer banner adds an `## Extensions` section with `.js`
+extension paths, and `stripStartupBanner` strips only a leading contiguous run, so the Extensions
+block and the trailing "New version available" notice leak into the reply. The fix extends
+`isBannerLine` to match the `Extensions` heading and a `.js` path (or strips the whole banner block).
+Track it on its own lane; it does not block this plan.

--- a/docs/design/agent-workflows/projects/custom-providers-in-pi/research.md
+++ b/docs/design/agent-workflows/projects/custom-providers-in-pi/research.md
@@ -1,0 +1,214 @@
+# Research: the five gaps, verified
+
+All references re-verified on 2026-07-02 against the working tree. This doc records the exact
+locations and the mechanism behind each gap, plus two path corrections and one appendix. It does
+not repeat the sibling research; read `../model-config/research.md` for how Pi decides a model is
+available, and `../provider-model-auth/design.md` for the resolver and capability contracts.
+
+## Two corrections to prior docs
+
+- **Runner path.** The runner TypeScript is at `services/runner/src/`, not `services/agent/src/`
+  as the siblings cite. The rename is commit `b323a8516f`. The monolithic `sandbox_agent.ts` also
+  split into `services/runner/src/engines/sandbox_agent/{model,daemon,daytona,pi-assets,errors}.ts`,
+  so several functions moved. Every runner line below is the current location.
+- **Frontend capability source.** The harness catalog reaches the frontend from
+  `GET /workflows/catalog/harnesses/` (served from `capabilities.py` `harness_catalog_document`,
+  via `api/oss/src/apis/fastapi/workflows/router.py`), not the `/inspect` `meta`. The
+  `connectionUtils.ts` header comment still says `/inspect`; it is stale. The live query atom is
+  `harnessCatalogQueryAtom` in
+  `web/packages/agenta-entities/src/workflow/state/inspectMeta.ts`.
+
+## Gap 1: the deployment gate blocks a known-direct custom provider
+
+A `provider_key` always resolves with `deployment="direct"`
+(`connections.py:258-271`, `_provider_key_candidate`, the value is hard-coded at `:269`). A
+`custom_provider` echoes its raw kind:
+
+```python
+# sdks/python/agenta/sdk/agents/platform/connections.py:281
+deployment = _stripped(data.get("kind")) or "custom"
+```
+
+`_custom_provider_candidate` (`:274-309`) already resolves the rest correctly. It sets
+`provider = data_kind if data_kind in _PROVIDER_ENV_VARS else None` (`:295-296`), builds the
+`Endpoint` from `settings.url`/`version` plus region (`:287-291`), and carries `model_slugs`
+/`model_keys`. So a custom OpenRouter connection resolves with `provider="openrouter"`, a real
+`endpoint.base_url`, the selected model id, and, from `resolved_env`, the right env var:
+
+```python
+# connections.py:238-245  _ConnectionCandidate.resolved_env
+env_var = _provider_env_var(provider) or _provider_env_var(self.provider)
+if self.api_key and env_var:
+    env.setdefault(env_var, self.api_key)   # e.g. {"OPENROUTER_API_KEY": "<key>"}
+```
+
+The only wrong field is `deployment`, which becomes `"openrouter"` and rides into
+`ResolvedConnection.deployment` verbatim (`connections.py:431-438`, `deployment=chosen.deployment`).
+Then the post-resolve check rejects it:
+
+```python
+# services/oss/src/agent/app.py:110-125
+if not harness_allows_deployment(harness, resolved.deployment):
+    raise UnsupportedDeploymentError(deployment=resolved.deployment, harness=harness)
+```
+
+```python
+# sdks/python/agenta/sdk/agents/capabilities.py:225-236
+normalized = "vertex_ai" if deployment == "vertex" else deployment
+return normalized in entry.deployments        # Pi: ["direct"] (capabilities.py:146, :152)
+```
+
+`"openrouter"` is not in `["direct"]`, so `UnsupportedDeploymentError` (a 422) fires before the
+runner is ever called. This is exactly why "OpenRouter works as a `provider_key` but not as a
+custom provider." Because `resolved_env` already emits `OPENROUTER_API_KEY` and the runner already
+forwards `request.secrets` into the Pi daemon env, fixing only the deployment label makes a
+built-in OpenRouter id settable through Pi's env-var channel with no other change. That is why
+Gap 1 is the fastest unblock.
+
+The classification the field should carry is worked out in [design.md](design.md).
+
+## Gap 2: the runner never teaches Pi a custom provider
+
+The runner writes no Pi `models.json`. A grep of `services/runner/src/` for `models.json` returns
+zero matches. The per-run agent dir seed copies exactly two files:
+
+```ts
+// services/runner/src/engines/sandbox_agent/pi-assets.ts:184-191  prepareLocalAgentDir
+for (const name of ["auth.json", "settings.json"]) {
+  const src = join(sourceAgentDir, name);
+  if (existsSync(src)) copyFileSync(src, join(dir, name));
+}
+```
+
+A custom base URL is applied only for Claude:
+
+```ts
+// services/runner/src/engines/sandbox_agent.ts:162, :176-180  applyClaudeConnectionEnv
+if (acpAgent !== "claude") return false;
+...
+const baseUrl = request.endpoint?.baseUrl;
+if (baseUrl) { env.ANTHROPIC_BASE_URL = baseUrl; ... }
+```
+
+So Pi never sees `endpoint.baseUrl` and never learns a genuinely custom (non-built-in) model id.
+This is `model-config` Part 1: write `auth.json` (provider keys as `"$ENV"` references) and
+`models.json` (base URL override plus custom models) into `PI_CODING_AGENT_DIR`, local and
+Daytona. The per-run agent dir is created today only when skills or a system prompt exist, so a
+plain model override skips it:
+
+```ts
+// services/runner/src/engines/sandbox_agent/pi-assets.ts:224  prepareLocalPiAssets
+if (plan.skillDirs.length > 0 || plan.hasSystemPrompt) {
+  const runAgentDir = prepareLocalAgentDir(plan.sourcePiAgentDir, plan.skillDirs, log);
+```
+
+The Daytona uploaders that this write must mirror: `uploadPiAuthToSandbox`
+(`services/runner/src/engines/sandbox_agent/daytona.ts:77-94`, into `DAYTONA_PI_DIR`),
+`daytonaEnvVars` (`daytona.ts:31-46`), and the local daemon env forwarding in
+`buildDaemonEnv` (`services/runner/src/engines/sandbox_agent/daemon.ts:132-162`).
+
+## Gap 3: a dropped model is silent
+
+```ts
+// services/runner/src/engines/sandbox_agent/model.ts:46-74  applyModel
+try {
+  await session.setModel(wanted);
+  return wanted;
+} catch (err) {
+  if (options.strict) {
+    throw new Error(`model '${wanted}' not settable (${(err as Error).message})`);
+  }
+  const allowed = allowedFromError(err);
+  const fallbackAllowed = allowed.length ? allowed : await allowedModels(session);
+  ...
+  log(`model '${wanted}' not settable (...); using harness default`);
+  return undefined;                         // silent fallback, HTTP 200 on the wrong model
+}
+```
+
+`strict` is threaded for Claude only. `applyClaudeConnectionEnv` returns a strict flag
+(`sandbox_agent.ts:193-200`), assigned at `:330`, passed at `applyModel(session, request.model,
+logger, { strict: strictModel })` (`:582-587`). Pi runs never set strict.
+
+`allowedModels` reads the wrong field:
+
+```ts
+// services/runner/src/engines/sandbox_agent/model.ts:19-30  allowedModels
+const choices = modelOpt?.options ?? [];
+return choices.map((c: any) => c.id).filter(Boolean);   // pi-acp options carry `value`, not `id`
+```
+
+pi-acp builds each model option as `{ value: model.modelId, name, description }`, so mapping `c.id`
+returns `[]` and the fallback enumeration is blind. `model-config` Part 2 already specifies the
+fix: read `c.value ?? c.id`, raise a typed `ModelNotSettableError` with the allowed set, and gate
+strictness behind `AGENTA_AGENT_MODEL_STRICT` (default false first, flip later; the reason for the
+staged rollout is the `gpt-5.5` advertised-default trap documented in `../model-config/proposal.md`).
+
+## Gap 4: the picker never shows custom-provider models
+
+```ts
+// web/packages/agenta-entity-ui/src/DrillInView/SchemaControls/connectionUtils.ts:239-256
+export function buildModelOptionGroups(capabilities, harness, metadata) {
+  const models = capsFor(capabilities, harness)?.models   // only the static harness catalog
+  if (!models) return []
+  ...
+}
+```
+
+`capabilities[harness].models` comes from `_pi_models()` (`capabilities.py:97-116`), which lists
+`supported_llm_models` for the static `PI_VAULT_PROVIDERS` (`capabilities.py:45-54`). The vault is
+read on the same screen, but only for the Connection dropdown, and only three fields per secret:
+
+```ts
+// connectionUtils.ts:341-344  namedConnectionOptions (the only vault reader in the file)
+if (secret.type !== "custom_provider") continue
+const slug = secret.name?.trim()
+...
+const secretProvider = secret.provider?.toLowerCase() || null   // never reads `models`
+```
+
+The vault entry does carry the models. `transformSecret`
+(`web/packages/agenta-entities/src/secret/core/transforms.ts:108`) sets
+`models: data.models.map((m) => m.slug)` on the in-app `LlmProvider`. But `useModelHarness.tsx`
+casts that to `VaultConnectionEntry` (`connectionUtils.ts:302-312`), whose type has no `models`
+field, so the array is dropped at the type boundary. `buildModelOptionGroups` never receives the
+vault at all. Surfacing these is an uncovered gap: `model-config` Part 3 sources choices from the
+static catalog plus the runner, never from the vault. The contract for the merge is in
+[design.md](design.md).
+
+## Gap 5: the Together env var name is wrong
+
+```python
+# sdks/python/agenta/sdk/agents/platform/secrets.py:93-102  _PROVIDER_ENV_VARS
+"together_ai": "TOGETHERAI_API_KEY",   # Pi reads TOGETHER_API_KEY (env-api-keys.js)
+```
+
+The same map is copied in three files and has already drifted:
+
+- `platform/secrets.py:93-102`: 8 entries, no `minimax`. `together_ai -> TOGETHERAI_API_KEY`.
+- `platform/connections.py:41-51`: 9 entries, includes `minimax -> MINIMAX_API_KEY`.
+  `together_ai -> TOGETHERAI_API_KEY` (`:49`).
+- `connections/resolver.py:31-40`: 8 entries, no `minimax`. `together_ai -> TOGETHERAI_API_KEY`.
+
+`capabilities.py` `PI_VAULT_PROVIDERS` lists both `minimax` and `together_ai`, so a `minimax`
+`provider_key` resolved through `secrets.py` or `resolver.py` today produces no env var at all
+(the same silent-drop class, a second instance). One extra corroboration:
+`connections.py` `_ALLOWED_EXTRA_ENV_KEYS` already lists both `TOGETHERAI_API_KEY` (`:116`) and
+`TOGETHER_API_KEY` (`:117`), so an extras-supplied Together key with the right name already passes
+through; only the mapped `provider_key` emit is wrong.
+
+The Slice 0 audit: fix `together_ai -> TOGETHER_API_KEY` in all three maps, add the missing
+`minimax` entry to the two that omit it, and confirm each entry against Pi's `getApiKeyEnvVars`.
+
+## Appendix: the Pi startup-banner leak (related, separately shippable)
+
+This is not one of the five gaps and it is not a slice here. `isBannerLine`
+(`services/runner/src/tracing/otel.ts:699-713`) strips Pi's startup banner from replies, but its
+section-heading regex matches only `Context` and `Skills` (`:706`) and its path regex requires a
+`.md` suffix (`:708`). pi-acp's newer banner adds an `## Extensions` section with `.js` extension
+paths. `stripStartupBanner` (`otel.ts:719-728`) strips only a leading contiguous run of banner
+lines, so the first unmatched line (`## Extensions`) halts the strip, and the Extensions block
+plus the trailing "New version available" notice leak into the reply. The fix is to extend
+`isBannerLine` to match the `Extensions` heading and a `.js` path (or to strip the whole banner
+block rather than a leading run). Track it on its own lane; it does not block the five gaps.
+</content>

--- a/docs/design/agent-workflows/projects/custom-providers-in-pi/status.md
+++ b/docs/design/agent-workflows/projects/custom-providers-in-pi/status.md
@@ -1,0 +1,80 @@
+# Status
+
+Source of truth for where this work stands. Keep it current.
+
+## State
+
+**PLANNED, not built.** This is a docs-only planning workspace created on 2026-07-02. No code has
+changed. All five gaps and their file references were re-verified on 2026-07-02 against the working
+tree. The plan sits on top of two siblings: `provider-model-auth` (BUILT, PR #4815) and
+`model-config` (DESIGNED, not built).
+
+Last updated: 2026-07-02.
+
+## Decisions
+
+- **A known-direct custom provider is `deployment="direct"`.** Normalize it at resolve time in
+  `_custom_provider_candidate`, so its key injects exactly like a `provider_key`. The base URL
+  rides the orthogonal `endpoint` field, which already reaches the runner. This is the smallest
+  correct fix and needs no wire change.
+- **`deployment` is a closed access-surface enum**, not an echo of the vault record kind. Values:
+  `direct`, `azure`, `bedrock`, `vertex`. A custom endpoint is `direct` plus an `endpoint`; the
+  free `"custom"` value is dropped.
+- **The runner derives Pi `auth.json`/`models.json`** from `resolved_connection` plus `secrets`.
+  The credential is always a `"$ENV"` reference, never a raw value on disk. No new wire field.
+- **Fail loud is staged.** `AGENTA_AGENT_MODEL_STRICT` defaults `false` first (warn and fall
+  back), then flips to `true` after the QA matrix confirms the common models are settable. A
+  no-model-requested run always uses the harness default and is never an error.
+- **The picker reads two sources kept distinct**: the static harness catalog (service config) and
+  the project vault's custom-provider models (project data), joined under the harness reachability
+  filter. `VaultConnectionEntry` gains `models?: string[]`.
+- **Slice 1 is the fastest unblock** and ships first after the Slice 0 one-liner.
+
+## Open decisions (do not block the plan)
+
+- **Where the deployment normalization lives.** The lean is to normalize a known-direct
+  `custom_provider` to `deployment="direct"` at resolve time (Slice 1). The alternative, gating it
+  differently in the harness check (treating a known-direct kind as allowed), was rejected because
+  it would leave a routing field carrying a provider name and push provider knowledge into the
+  capability gate. Confirm the resolve-time normalization is acceptable to the `provider-model-auth`
+  owner, since it changes that project's `_custom_provider_candidate`.
+- **How Slice 4 reads the vault.** Client-side (the vault is already fetched on the picker screen
+  via `vaultSecretsQueryAtom`, so no new endpoint) versus a new per-project model list on a server
+  inspect field. The lean is client-side, consistent with `provider-model-auth`'s "the frontend
+  intersects the capability table with the vault." A server field would be needed only if a
+  non-browser caller must discover the per-project set.
+- **Whether to close the `deployment` enum in the same slice** as the normalization, or to
+  normalize first and tighten the type in a follow-up. Tightening the type may touch call sites
+  beyond this project.
+
+## Risks
+
+- The deployment change is in `provider-model-auth`'s resolver
+  (`sdks/python/agenta/sdk/agents/platform/connections.py`), a file that project owns. Coordinate
+  before editing; the change is one line plus the enum tightening, but it belongs in a coordinated
+  lane.
+- The provider-to-env map is duplicated across three files and has already drifted on `minimax`.
+  The Slice 0 fix must touch all three and should add the cross-copy equality test the siblings
+  deferred.
+- Slice 2 lands in the runner, which multiple sessions edit. The runner path moved to
+  `services/runner/src/` and the functions split across `sandbox_agent/` submodules, so any stale
+  `services/agent/src/` reference in a sibling doc or test will miss.
+- Flipping `AGENTA_AGENT_MODEL_STRICT` to strict can fail runs that echo the advertised default
+  `gpt-5.5` on a backend where it is not settable. Reconcile the advertised default with the
+  per-harness settable set before flipping (Slice 3b gate).
+
+## Non-goals
+
+- Bedrock, Vertex, and Azure consumption on Pi stays fail-loud.
+- No vault storage change, no migration, no `/secrets` write path.
+- No new `/run` wire field.
+- The prompt/completion path is untouched.
+
+## Next steps
+
+1. Coordinate the Slice 1 resolver change with the `provider-model-auth` owner.
+2. Land Slice 0 and Slice 1 (the two smallest, highest-value changes).
+3. Build Slice 2 in the runner, with local and Daytona parity, then Slices 3 and 4.
+4. Verify on the live matrix: a custom OpenRouter connection with a built-in id (Slice 1) and with
+   a genuinely custom id and base URL (Slice 2), and a Together key (Slice 0).
+</content>

--- a/docs/design/agent-workflows/projects/custom-providers-in-pi/status.md
+++ b/docs/design/agent-workflows/projects/custom-providers-in-pi/status.md
@@ -4,77 +4,85 @@ Source of truth for where this work stands. Keep it current.
 
 ## State
 
-**PLANNED, not built.** This is a docs-only planning workspace created on 2026-07-02. No code has
-changed. All five gaps and their file references were re-verified on 2026-07-02 against the working
-tree. The plan sits on top of two siblings: `provider-model-auth` (BUILT, PR #4815) and
-`model-config` (DESIGNED, not built).
+**PLAN REVISED 2026-07-14 after code review. Partly built.** The plan was created on 2026-07-02.
+Three of its original slices have since landed in the codebase, and six review comments on 2026-07-14
+reshaped the rest. The remaining work is three slices (service, runner, frontend). It still sits on
+top of `provider-model-auth` (BUILT, PR #4815) and `model-config` (partly built).
 
-Last updated: 2026-07-02.
+Landed since 2026-07-02 (verified against the working tree, file references in
+[research.md](research.md)):
 
-## Decisions
+- The env-var maps collapsed into one canonical `PROVIDER_ENV_VARS` (`capabilities.py:111-125`), with
+  a parity regression test. (Old Slice 0.)
+- A known-family custom connection resolves to `deployment="direct"` and passes Pi's gate
+  (`connections.py:330-335`). (Old Slice 1, known-family case.)
+- The runner fails loud on an unsettable model: strict is wired for every harness and defaults to
+  true (`sandbox_agent.ts:374`), `allowedModels` reads `c.value ?? c.id` (`model.ts:72`), and
+  `applyModel` raises a typed `ModelNotSettableError` (`model.ts:9`). **Divergence from the plan:**
+  the code shipped strict-by-default directly, not the staged default-false-then-flip rollout the
+  first plan described. The planned "Slice 3b flip" is therefore moot.
 
-- **A known-direct custom provider is `deployment="direct"`.** Normalize it at resolve time in
-  `_custom_provider_candidate`, so its key injects exactly like a `provider_key`. The base URL
-  rides the orthogonal `endpoint` field, which already reaches the runner. This is the smallest
-  correct fix and needs no wire change.
-- **`deployment` is a closed access-surface enum**, not an echo of the vault record kind. Values:
-  `direct`, `azure`, `bedrock`, `vertex`. A custom endpoint is `direct` plus an `endpoint`; the
-  free `"custom"` value is dropped.
-- **The runner derives Pi `auth.json`/`models.json`** from `resolved_connection` plus `secrets`.
-  The credential is always a `"$ENV"` reference, never a raw value on disk. No new wire field.
-- **Fail loud is staged.** `AGENTA_AGENT_MODEL_STRICT` defaults `false` first (warn and fall
-  back), then flips to `true` after the QA matrix confirms the common models are settable. A
-  no-model-requested run always uses the harness default and is never an error.
-- **The picker reads two sources kept distinct**: the static harness catalog (service config) and
-  the project vault's custom-provider models (project data), joined under the harness reachability
-  filter. `VaultConnectionEntry` gains `models?: string[]`.
-- **Slice 1 is the fastest unblock** and ships first after the Slice 0 one-liner.
+Last updated: 2026-07-14.
 
-## Open decisions (do not block the plan)
+## Decisions (six review dispositions, all accepted 2026-07-14)
 
-- **Where the deployment normalization lives.** The lean is to normalize a known-direct
-  `custom_provider` to `deployment="direct"` at resolve time (Slice 1). The alternative, gating it
-  differently in the harness check (treating a known-direct kind as allowed), was rejected because
-  it would leave a routing field carrying a provider name and push provider knowledge into the
-  capability gate. Confirm the resolve-time normalization is acceptable to the `provider-model-auth`
-  owner, since it changes that project's `_custom_provider_candidate`.
-- **How Slice 4 reads the vault.** Client-side (the vault is already fetched on the picker screen
-  via `vaultSecretsQueryAtom`, so no new endpoint) versus a new per-project model list on a server
-  inspect field. The lean is client-side, consistent with `provider-model-auth`'s "the frontend
-  intersects the capability table with the vault." A server field would be needed only if a
-  non-browser caller must discover the per-project set.
-- **Whether to close the `deployment` enum in the same slice** as the normalization, or to
-  normalize first and tighten the type in a follow-up. Tightening the type may touch call sites
-  beyond this project.
+1. **A named OpenAI-compatible connection, not a known family disguised as custom.** Keep
+   `deployment="custom"` for a record whose kind is not a known family, default a provider-less
+   record to the OpenAI-compatible family after the trusted vault record resolves, and let Pi's
+   capability table allow the `(custom, openai-compatible)` pair. Why: the known-family `direct`
+   normalization that landed does nothing for an arbitrary kind like `ollama`, which is the actual
+   requirement. The known-family case stays as it landed.
+2. **Key `models.json` by the connection slug, not `resolved_connection.provider`.** Why: two custom
+   connections can resolve to the same family and a provider-less one has no provider id, so the
+   provider key would collide or be empty; the slug is unique and stable. This adds `slug` to
+   `ResolvedConnection` and its wire form.
+3. **Speak `openai-completions` only in v1.** Do not infer `anthropic-messages` from a provider
+   label. Why: Anthropic Messages has different request and response semantics. A pure builder exposes
+   a protocol discriminator for later dialects; v1 rejects unsupported protocols loudly.
+4. **Do not merge the operator `auth.json` into a managed run.** Build an isolated managed Pi
+   directory carrying only non-credential settings plus `models.json` with a `"$ENV"` apiKey
+   reference. Why: the copied personal login could authenticate a managed run with an operator
+   subscription. This also fixes the existing local managed path, which copies `auth.json` today
+   (`pi-assets.ts:475-490`) while Daytona already refuses (`daytona.ts:168-171`).
+5. **The wire keeps the bare model id; the runner derives `<slug>/<model>`.** The builder returns the
+   file content and the exact runtime id, which the runner passes to `setModel`. Why: this bypasses
+   the suffix-match fallback (`model.ts:49-59`) that can select the wrong provider.
+6. **Cut the picker expansion from this plan; rename the UI type label only.** The picker work moves
+   to `model-config` Part 3. Why: the schema/picker change was out of the agreed scope, and the
+   `VaultConnectionEntry` symbol the first plan named never existed in `web/`. The UI change here is
+   the one rename, "Custom provider" to "OpenAI-compatible endpoint", at three locations.
+
+## Dropped non-goal
+
+- The first plan's non-goal "no new `/run` wire field" is dropped. Keying `models.json` by slug needs
+  the slug on the wire. It is replaced by: **exactly one new wire field, the connection slug on
+  `ResolvedConnection`.** Everything else the runner still derives.
 
 ## Risks
 
-- The deployment change is in `provider-model-auth`'s resolver
-  (`sdks/python/agenta/sdk/agents/platform/connections.py`), a file that project owns. Coordinate
-  before editing; the change is one line plus the enum tightening, but it belongs in a coordinated
-  lane.
-- The provider-to-env map is duplicated across three files and has already drifted on `minimax`.
-  The Slice 0 fix must touch all three and should add the cross-copy equality test the siblings
-  deferred.
-- Slice 2 lands in the runner, which multiple sessions edit. The runner path moved to
-  `services/runner/src/` and the functions split across `sandbox_agent/` submodules, so any stale
-  `services/agent/src/` reference in a sibling doc or test will miss.
-- Flipping `AGENTA_AGENT_MODEL_STRICT` to strict can fail runs that echo the advertised default
-  `gpt-5.5` on a backend where it is not settable. Reconcile the advertised default with the
-  per-harness settable set before flipping (Slice 3b gate).
+- The wire change touches the provider/model/auth contract from `provider-model-auth` (PR #4815). The
+  slug rides `ResolvedConnection.to_wire()`, which the runner mirrors in `protocol.ts` with a shared
+  golden fixture. Update both sides and the golden together, and coordinate with that project's owner.
+- The runner slice edits `services/runner/src/engines/sandbox_agent/`, which several sessions touch.
+  The managed-dir isolation changes the local `pi-assets.ts` copy behavior; verify no non-managed run
+  loses its login state.
+- Defaulting a provider-less record to the OpenAI-compatible family runs after the vault record is
+  trusted. Confirm no untrusted input can reach that default.
 
 ## Non-goals
 
 - Bedrock, Vertex, and Azure consumption on Pi stays fail-loud.
 - No vault storage change, no migration, no `/secrets` write path.
-- No new `/run` wire field.
+- Exactly one new `/run` wire field: the connection slug.
+- The model picker expansion stays with `model-config` Part 3.
 - The prompt/completion path is untouched.
 
 ## Next steps
 
-1. Coordinate the Slice 1 resolver change with the `provider-model-auth` owner.
-2. Land Slice 0 and Slice 1 (the two smallest, highest-value changes).
-3. Build Slice 2 in the runner, with local and Daytona parity, then Slices 3 and 4.
-4. Verify on the live matrix: a custom OpenRouter connection with a built-in id (Slice 1) and with
-   a genuinely custom id and base URL (Slice 2), and a Together key (Slice 0).
-</content>
+1. Land Slice 1 (service): the slug on the wire, the OpenAI-compatible family default, and the Pi
+   `custom` deployment allowance. Coordinate the `ResolvedConnection` change with `provider-model-auth`.
+2. Land Slice 2 (runner): the `models.json` builder, the isolated managed dir on local and Daytona,
+   and the exact `<slug>/<model>` id.
+3. Land Slice 3 (frontend): the type-label rename.
+4. Verify on the live matrix: a named OpenAI-compatible connection (custom base URL and custom model
+   id) runs on Pi, local and Daytona, and a managed run carries no operator login.


### PR DESCRIPTION
## Goal

Let a user run an OpenAI-compatible model through a Pi agent. The user stores a connection (a base URL, a key, and one or more model ids), picks that connection and a model in the playground, and the run reaches the model. The connection's slug is its identity end to end: the vault record, the resolver, the wire, and the Pi config the runner writes all agree on the same slug, so two connections that speak the same protocol stay distinct.

This is a docs-only plan-feature workspace at `docs/design/agent-workflows/projects/custom-providers-in-pi/`. No code changes.

## What already landed since the plan was written

The plan was written on 2026-07-02. Three of its original slices have since landed in the codebase, so this revision marks them done and re-sequences the rest:

- The three provider-to-env maps collapsed into one canonical `PROVIDER_ENV_VARS` (`capabilities.py:111-125`), with `together_ai -> TOGETHER_API_KEY` and `minimax`. There is a parity regression test.
- A custom connection whose kind is a known provider family resolves to `deployment="direct"` (`connections.py:330-335`) and passes Pi's `["direct"]` gate.
- The runner fails loud on an unsettable model: `allowedModels` reads `c.value ?? c.id` (`model.ts:72`), `applyModel` raises a typed `ModelNotSettableError`, and `AGENTA_AGENT_MODEL_STRICT` is wired for every harness and defaults to true (`sandbox_agent.ts:374`). This shipped strict-by-default directly, so the plan's staged "flip later" step is moot.

## What remains, and the revised design

A connection whose kind is not a known family (an Ollama gateway, an in-house proxy, any named OpenAI-compatible endpoint) still fails before it runs, and the runner writes no Pi `models.json`. Six review comments on the design reshaped how the plan closes that path. All six were accepted:

- Keep `deployment="custom"` for a record whose kind is not a known family, default a provider-less record to the OpenAI-compatible family after the trusted vault record resolves, and let Pi allow the `(custom, openai-compatible)` pair. The known-family `direct` normalization that landed stays.
- Key `models.json` by the connection slug, not `resolved_connection.provider`, because two custom connections can resolve to the same family and a provider-less one has no provider id.
- Speak `openai-completions` only in v1. Do not infer `anthropic-messages` from a provider label. A pure builder exposes a protocol discriminator for later; v1 rejects unsupported protocols loudly.
- Build an isolated managed Pi directory for a managed run, carrying only non-credential settings plus `models.json` with a `"$ENV"` apiKey reference. The raw key stays in the daemon or sandbox environment. This also fixes the existing local path, which copies the operator `auth.json` today while Daytona already refuses.
- Keep the bare model id on the wire; the runner derives the exact `<slug>/<model>` id and sets it directly, bypassing the suffix fallback that can pick the wrong provider.
- Cut the picker expansion (it moves to the `model-config` sibling, Part 3). The UI change here is one rename: "Custom provider" to "OpenAI-compatible endpoint".

### One new wire field

The first plan's non-goal "no new `/run` wire field" is dropped. Keying `models.json` by slug needs the slug on the wire. It is replaced by: exactly one new field, `slug` on `ResolvedConnection.to_wire()`. Everything else the runner still derives from `resolved_connection` and `secrets`.

## The revised slices

1. Service: add `slug` to `ResolvedConnection` and its wire form; a provider-less or unknown-kind custom connection resolves to the OpenAI-compatible family with `deployment="custom"`; Pi's capability table allows `custom`.
2. Runner: a model-config builder writes `models.json` keyed by `providers[<slug>]` (dialect `openai-completions`, `"$ENV"` apiKey, the one selected model) and returns the exact `<slug>/<model>` id; the runner creates an isolated managed Pi dir on the local and Daytona paths and sets that exact id.
3. Frontend: rename the type label at three locations.

Each slice is independently shippable and carries tests (resolver unit tests and a wire golden for slice 1; builder, managed-dir isolation, Daytona parity, and a live acceptance run for slice 2; a render check for slice 3). The Pi startup-banner leak stays a separate lane.

## Files

Six files in the plan workspace: `README.md`, `context.md`, `research.md`, `design.md`, `plan.md`, `status.md`. `research.md` gains a dated 2026-07-14 re-verification section. `design.md` keeps the design-interfaces role tables as its spine.

https://claude.ai/code/session_01HCMtsTWnCdh8fPEzGrda6C