### PR TITLE
feat(frontend): agent commit modal redesign + config-panel change indicators

### DIFF
--- a/web/oss/src/components/Playground/Components/Modals/CommitVariantChangesModal/index.tsx
+++ b/web/oss/src/components/Playground/Components/Modals/CommitVariantChangesModal/index.tsx
@@ -1,13 +1,16 @@
-import {useCallback, useMemo, useState} from "react"
+import {useCallback, useMemo} from "react"
 
 import {publishMutationAtom} from "@agenta/entities/runnable"
 import {workflowMolecule, createWorkflowFromEphemeralAtom} from "@agenta/entities/workflow"
 import {EntityCommitModal} from "@agenta/entity-ui"
-import type {CommitSubmitParams, CommitCreateFieldsConfig} from "@agenta/entity-ui"
+import type {
+    CommitSubmitParams,
+    CommitCreateFieldsConfig,
+    CommitDeployOption,
+} from "@agenta/entity-ui"
 import {playgroundController} from "@agenta/playground"
-import {EnvironmentTag, environmentColors} from "@agenta/ui"
+import {environmentColors} from "@agenta/ui"
 import {message} from "@agenta/ui/app-message"
-import {Checkbox, Select} from "antd"
 import {getDefaultStore, useAtomValue, useSetAtom} from "jotai"
 
 import {
@@ -47,26 +50,67 @@ const CommitVariantChangesModal: React.FC<CommitVariantChangesModalProps> = ({
     const createFromEphemeral = useSetAtom(createWorkflowFromEphemeralAtom)
     const {mutateAsync: publish} = useAtomValue(publishMutationAtom)
 
-    const [shouldDeploy, setShouldDeploy] = useState(false)
-    const [selectedEnvironment, setSelectedEnvironment] = useState<string | null>(null)
-
     const variantName = runnableData?.name || "Variant"
     const variantSlug = runnableData?.slug
 
-    const environmentOptions = useMemo(
-        () =>
-            (Object.keys(environmentColors) as (keyof typeof environmentColors)[]).map((env) => ({
-                value: env,
-                label: <EnvironmentTag environment={env} />,
-            })),
+    // Environments offered in the footer's "Commit & deploy to …" split-button dropdown.
+    const commitDeployOptions = useMemo<CommitDeployOption[]>(
+        () => Object.keys(environmentColors).map((env) => ({key: env, label: env})),
         [],
     )
 
     const handleClose = useCallback(() => {
         onCancel?.({} as never)
-        setShouldDeploy(false)
-        setSelectedEnvironment(null)
     }, [onCancel])
+
+    // Deploy the just-committed revision to each chosen environment. The deploy API is
+    // single-env per call (no batch endpoint), so we fan out and report partial failures.
+    const deployRevision = useCallback(
+        async (
+            newRevisionId: string,
+            label: string,
+            note: string | undefined,
+            deployEnvironments: string[] | undefined,
+            deployMessage?: string,
+        ) => {
+            if (!deployEnvironments || deployEnvironments.length === 0) return
+            const newRevisionData = workflowMolecule.get.data(newRevisionId)
+            const refs = {
+                revisionId: newRevisionId,
+                applicationId:
+                    newRevisionData?.workflow_id || runnableData?.workflow_id || appId || "",
+                workflowVariantId:
+                    newRevisionData?.workflow_variant_id ??
+                    runnableData?.workflow_variant_id ??
+                    undefined,
+                variantSlug:
+                    newRevisionData?.workflow_variant_slug ??
+                    newRevisionData?.variant_slug ??
+                    runnableData?.workflow_variant_slug ??
+                    runnableData?.variant_slug ??
+                    undefined,
+                revisionVersion: newRevisionData?.version ?? undefined,
+                note: deployMessage ?? note,
+            }
+            const succeeded: string[] = []
+            const failed: string[] = []
+            for (const environmentSlug of deployEnvironments) {
+                try {
+                    await publish({...refs, environmentSlug})
+                    succeeded.push(environmentSlug)
+                } catch {
+                    failed.push(environmentSlug)
+                }
+            }
+            if (succeeded.length) {
+                message.success(`Published ${label} to ${succeeded.join(", ")}`)
+            }
+            if (failed.length) {
+                message.error(`Couldn't publish ${label} to ${failed.join(", ")}`)
+            }
+        },
+        [publish, runnableData, appId],
+    )
 
     const handleSubmit = useCallback(
         async ({
@@ -74,6 +118,8 @@ const CommitVariantChangesModal: React.FC<CommitVariantChangesModalProps> = ({
             mode,
             entityName: editedName,
             entitySlug: editedSlug,
+            deployEnvironments,
+            deployMessage,
         }: CommitSubmitParams) => {
             // Ephemeral entities: create a new workflow via the entities package reducer
             if (isEphemeral) {
@@ -133,32 +179,13 @@ const CommitVariantChangesModal: React.FC<CommitVariantChangesModalProps> = ({
                     }
                 }
 
-                if (shouldDeploy && selectedEnvironment) {
-                    // Use the new revision's workflow data for references
-                    const newRevisionData = workflowMolecule.get.data(result.newRevisionId)
-                    await publish({
-                        revisionId: result.newRevisionId,
-                        environmentSlug: selectedEnvironment,
-                        applicationId:
-                            newRevisionData?.workflow_id ||
-                            runnableData?.workflow_id ||
-                            appId ||
-                            "",
-                        workflowVariantId:
-                            newRevisionData?.workflow_variant_id ??
-                            runnableData?.workflow_variant_id ??
-                            undefined,
-                        variantSlug:
-                            newRevisionData?.workflow_variant_slug ??
-                            newRevisionData?.variant_slug ??
-                            runnableData?.workflow_variant_slug ??
-                            runnableData?.variant_slug ??
-                            undefined,
-                        revisionVersion: newRevisionData?.version ?? undefined,
-                        note,
-                    })
-                    message.success(`Published ${variantNameToCreate} to ${selectedEnvironment}`)
-                }
+                await deployRevision(
+                    result.newRevisionId,
+                    variantNameToCreate,
+                    note,
+                    deployEnvironments,
+                    deployMessage,
+                )
 
                 clearRegistryVariantNameCache()
                 clearEvaluatorWorkflowCache()
@@ -181,28 +208,13 @@ const CommitVariantChangesModal: React.FC<CommitVariantChangesModalProps> = ({
                 }
             }
 
-            if (shouldDeploy && selectedEnvironment) {
-                const newRevisionData = workflowMolecule.get.data(result.newRevisionId)
-                await publish({
-                    revisionId: result.newRevisionId,
-                    environmentSlug: selectedEnvironment,
-                    applicationId:
-                        newRevisionData?.workflow_id || runnableData?.workflow_id || appId || "",
-                    workflowVariantId:
-                        newRevisionData?.workflow_variant_id ??
-                        runnableData?.workflow_variant_id ??
-                        undefined,
-                    variantSlug:
-                        newRevisionData?.workflow_variant_slug ??
-                        newRevisionData?.variant_slug ??
-                        runnableData?.workflow_variant_slug ??
-                        runnableData?.variant_slug ??
-                        undefined,
-                    revisionVersion: newRevisionData?.version ?? undefined,
-                    note,
-                })
-                message.success(`Published ${variantName} to ${selectedEnvironment}`)
-            }
+            await deployRevision(
+                result.newRevisionId,
+                variantName,
+                note,
+                deployEnvironments,
+                deployMessage,
+            )
 
             clearRegistryVariantNameCache()
             clearEvaluatorWorkflowCache()
@@ -218,10 +230,7 @@ const CommitVariantChangesModal: React.FC<CommitVariantChangesModalProps> = ({
             variantId,
             variantName,
             variantSlug,
-            shouldDeploy,
-            selectedEnvironment,
-            publish,
-            appId,
+            deployRevision,
             onSuccess,
             commitRevision,
         ],
@@ -232,10 +241,10 @@ const CommitVariantChangesModal: React.FC<CommitVariantChangesModalProps> = ({
             isEvaluator
                 ? [{id: "version", label: "As a new version"}]
                 : [
-                      {id: "version", label: "As a new version"},
-                      {id: "variant", label: "As a new variant"},
+                      {id: "version", label: `Update ${variantName}`},
+                      {id: "variant", label: "Save as a new variant"},
                   ],
-        [isEvaluator],
+        [isEvaluator, variantName],
     )
 
     // For ephemeral entities, render a simplified "Create" modal with editable name.
@@ -283,34 +292,11 @@ const CommitVariantChangesModal: React.FC<CommitVariantChangesModalProps> = ({
             }}
             commitModes={commitModes}
             defaultCommitMode="version"
-            renderModeContent={({mode}) => (
-                <div className="flex flex-col gap-3">
-                    {!isEvaluator && (
-                        <>
-                            <Checkbox
-                                checked={shouldDeploy}
-                                onChange={(e) => setShouldDeploy(e.target.checked)}
-                            >
-                                Deploy after commit
-                            </Checkbox>
-
-                            {shouldDeploy && (
-                                <Select
-                                    placeholder="Select environment"
-                                    value={selectedEnvironment ?? undefined}
-                                    onChange={(value) => setSelectedEnvironment(value)}
-                                    options={environmentOptions}
-                                />
-                            )}
-                        </>
-                    )}
-                </div>
-            )}
+            commitDeployOptions={isEvaluator ? undefined : commitDeployOptions}
             canSubmit={({mode, entityName}) => {
                 if (mode === "variant") {
                     if (!entityName?.trim()) return false
                 }
-                if (shouldDeploy && !selectedEnvironment) return false
                 return true
             }}
             createEntityFields={VARIANT_CREATE_FIELDS}

--- a/web/oss/src/components/Playground/Components/Modals/CommitVariantChangesModal/index.tsx
+++ b/web/oss/src/components/Playground/Components/Modals/CommitVariantChangesModal/index.tsx
@@ -92,16 +92,12 @@ const CommitVariantChangesModal: React.FC<CommitVariantChangesModalProps> = ({
                 revisionVersion: newRevisionData?.version ?? undefined,
                 note: deployMessage ?? note,
             }
-            const succeeded: string[] = []
-            const failed: string[] = []
-            for (const environmentSlug of deployEnvironments) {
-                try {
-                    await publish({...refs, environmentSlug})
-                    succeeded.push(environmentSlug)
-                } catch {
-                    failed.push(environmentSlug)
-                }
-            }
+            // Fan out concurrently — the calls are independent, so N environments cost 1× latency.
+            const results = await Promise.allSettled(
+                deployEnvironments.map((environmentSlug) => publish({...refs, environmentSlug})),
+            )
+            const succeeded = deployEnvironments.filter((_, i) => results[i].status === "fulfilled")
+            const failed = deployEnvironments.filter((_, i) => results[i].status === "rejected")
             if (succeeded.length) {
                 message.success(`Published ${label} to ${succeeded.join(", ")}`)
             }

--- a/web/oss/src/styles/theme-variables.css
+++ b/web/oss/src/styles/theme-variables.css
@@ -47,6 +47,10 @@
     --ag-colorErrorText: #d61010;
     --ag-colorError: #d61010;
     --ag-colorErrorBorder: #ef9f9f;
+    --ag-colorInfo: #1677ff;
+    --ag-colorInfoBorder: #91caff;
+    --ag-colorSuccessBorder: #b7eb8f;
+    --ag-colorWarningBorder: #ffe58f;
     --ag-colorBgContainerDisabled: rgba(5, 23, 41, 0.04);
     --ag-colorInfoBg: #f5f7fa;
     --ag-controlItemBgActive: #f5f7fa;
@@ -129,6 +133,12 @@
     --ag-colorErrorText: var(--ant-color-error-text);
     --ag-colorError: var(--ant-color-error);
     --ag-colorErrorBorder: var(--ant-color-error-border);
+    /* antd's `colorInfo` is repurposed as neutral slate in this theme, so the draft
+       indicator points at the blue palette directly to stay a distinct blue accent. */
+    --ag-colorInfo: var(--ant-blue-6, #1677ff);
+    --ag-colorInfoBorder: var(--ant-blue-5, #4096ff);
+    --ag-colorSuccessBorder: var(--ant-color-success-border);
+    --ag-colorWarningBorder: var(--ant-color-warning-border);
     --ag-colorBgContainerDisabled: var(--ant-color-bg-container-disabled);
     /* The project repurposes colorInfoBg as a neutral grey (#f5f7fa ≈ zinc-1, see
        agenta-ui/utils/styles.ts), not a blue info tint — so keep it neutral in

--- a/web/packages/agenta-entities/package.json
+++ b/web/packages/agenta-entities/package.json
@@ -37,6 +37,7 @@
         "./appRevision/snapshotAdapter": "./src/appRevision/snapshotAdapter.ts",
         "./workflow": "./src/workflow/index.ts",
         "./workflow/state": "./src/workflow/state/index.ts",
+        "./workflow/commitDiff": "./src/workflow/commitDiff/index.ts",
         "./workflow/snapshotAdapter": "./src/workflow/snapshotAdapter.ts",
         "./loadable": "./src/loadable/index.ts",
         "./runnable": "./src/runnable/index.ts",

--- a/web/packages/agenta-entities/src/workflow/commitDiff/accessors.ts
+++ b/web/packages/agenta-entities/src/workflow/commitDiff/accessors.ts
@@ -1,0 +1,163 @@
+/**
+ * Normalize an agent/LLM workflow's `parameters` object into a single
+ * `AgentConfigView`, resolving the three overlapping schema shapes:
+ *   - legacy nested:  parameters.prompt.{messages, llm_config.{model, tools, ...}}
+ *   - canonical:      parameters.{messages, llms[0].{model, tools}}
+ *   - flat root:      parameters.{messages, model, tools, temperature, ...}
+ *
+ * Pure and dependency-free so it can be unit-tested against fixtures for each shape.
+ */
+import {parseGatewayToolName} from "./gatewayName"
+import type {AgentConfigView, NormalizedTool} from "./types"
+
+/** Scalar config keys surfaced as "Advanced parameters". */
+export const PARAM_KEYS = [
+    "temperature",
+    "max_tokens",
+    "top_p",
+    "frequency_penalty",
+    "presence_penalty",
+    "tool_choice",
+    "response_format",
+    "stream",
+    "template_format",
+    "fallback_policy",
+    "retry_policy",
+] as const
+
+function isObj(v: unknown): v is Record<string, unknown> {
+    return typeof v === "object" && v !== null && !Array.isArray(v)
+}
+
+function firstArray(...vals: unknown[]): unknown[] {
+    for (const v of vals) if (Array.isArray(v)) return v
+    return []
+}
+
+function firstDefined<T = unknown>(...vals: unknown[]): T | undefined {
+    for (const v of vals) if (v !== undefined && v !== null) return v as T
+    return undefined
+}
+
+function sortKeysDeep(value: unknown): unknown {
+    if (!isObj(value)) return Array.isArray(value) ? value.map(sortKeysDeep) : value
+    const out: Record<string, unknown> = {}
+    for (const k of Object.keys(value).sort()) out[k] = sortKeysDeep(value[k])
+    return out
+}
+
+export function stableStringify(value: unknown): string {
+    return JSON.stringify(sortKeysDeep(value))
+}
+
+/** Coerce a message `content` (string | parts[] | object) into plain text. */
+function coerceContent(content: unknown): string {
+    if (typeof content === "string") return content
+    if (Array.isArray(content)) {
+        return content
+            .map((part) => (isObj(part) && typeof part.text === "string" ? part.text : ""))
+            .filter(Boolean)
+            .join("\n")
+    }
+    if (content == null) return ""
+    return JSON.stringify(content)
+}
+
+function normalizeTool(raw: unknown): NormalizedTool | null {
+    if (!isObj(raw)) return null
+    const fn = isObj(raw.function) ? raw.function : raw
+    const name = typeof fn.name === "string" ? fn.name : undefined
+    if (!name) return null
+    const description = typeof fn.description === "string" ? fn.description : ""
+    const params = isObj(fn.parameters) ? fn.parameters : {}
+    const parsed = parseGatewayToolName(name)
+    return {
+        key: name,
+        label: parsed.label,
+        source: parsed.source,
+        description,
+        params,
+        paramsJson: stableStringify(params),
+    }
+}
+
+export function readAgentConfig(parameters: unknown): AgentConfigView {
+    const p = isObj(parameters) ? parameters : {}
+    // agent-template shape: parameters.agent.{instructions.agents_md, llm.{model,...}, tools[]}
+    const agent = isObj(p.agent) ? p.agent : undefined
+    const prompt = isObj(p.prompt) ? p.prompt : undefined
+    const llm0 =
+        Array.isArray(p.llms) && isObj((p.llms as unknown[])[0])
+            ? ((p.llms as unknown[])[0] as Record<string, unknown>)
+            : undefined
+    const llmConfig = prompt && isObj(prompt.llm_config) ? prompt.llm_config : undefined
+    const llm = agent && isObj(agent.llm) ? agent.llm : isObj(p.llm) ? p.llm : undefined
+
+    // Instructions: agent-template `instructions.agents_md` (or a string), else prompt messages.
+    const messages = firstArray(prompt?.messages, p.messages, llm0?.messages)
+    const messageInstructions = messages
+        .map((m) => (isObj(m) ? coerceContent(m.content) : coerceContent(m)))
+        .join("\n\n")
+    const instrObj =
+        agent && isObj(agent.instructions)
+            ? agent.instructions
+            : isObj(p.instructions)
+              ? p.instructions
+              : undefined
+    const agentsMd = typeof instrObj?.agents_md === "string" ? instrObj.agents_md : undefined
+    const instrStr =
+        agent && typeof agent.instructions === "string"
+            ? agent.instructions
+            : typeof p.instructions === "string"
+              ? p.instructions
+              : undefined
+    const instructions = agentsMd ?? instrStr ?? messageInstructions
+
+    const toolsRaw = firstArray(agent?.tools, llmConfig?.tools, p.tools, llm0?.tools, prompt?.tools)
+    const tools = toolsRaw.map(normalizeTool).filter((t): t is NormalizedTool => t !== null)
+
+    const model = firstDefined<string>(
+        llm?.model,
+        llmConfig?.model,
+        p.model,
+        llm0?.model,
+        agent?.model,
+    )
+
+    const paramSources = [llm, llmConfig, llm0, prompt, agent, p].filter(isObj) as Record<
+        string,
+        unknown
+    >[]
+    const params: Record<string, unknown> = {}
+    for (const key of PARAM_KEYS) {
+        for (const src of paramSources) {
+            if (key in src) {
+                params[key] = src[key]
+                break
+            }
+        }
+    }
+
+    // Agent-template execution sections live at `agent.{harness,runner,sandbox}` (or the
+    // template root when there's no `agent` wrapper).
+    const section = (key: "harness" | "runner" | "sandbox") =>
+        agent && isObj(agent[key]) ? agent[key] : isObj(p[key]) ? p[key] : undefined
+
+    // Portable list sections (agent-template): flat on the definition.
+    const mcps = firstArray(agent?.mcps, p.mcps)
+    const skills = firstArray(agent?.skills, p.skills)
+
+    return {
+        instructions,
+        tools,
+        model,
+        params,
+        // Raw ModelRef (`{provider, model, connection}`) for the Model & harness section.
+        llm: isObj(llm) ? llm : undefined,
+        mcps,
+        skills,
+        harness: section("harness"),
+        runner: section("runner"),
+        sandbox: section("sandbox"),
+    }
+}

--- a/web/packages/agenta-entities/src/workflow/commitDiff/classify.ts
+++ b/web/packages/agenta-entities/src/workflow/commitDiff/classify.ts
@@ -8,8 +8,10 @@
 import {computeTextDiffLines} from "@agenta/ui/diff"
 
 import {PARAM_KEYS, readAgentConfig, stableStringify} from "./accessors"
+import {agentItemIdentity, type AgentItemKind} from "./identity"
 import type {
     AgentConfigView,
+    ChangeItem,
     ChangeSection,
     NormalizedTool,
     ScalarChange,
@@ -262,33 +264,36 @@ function entryLabel(entry: unknown): string {
     return "item"
 }
 
-/** Identity list-diff for portable sections (`mcps`/`skills`) keyed by human label. */
+/**
+ * Identity list-diff for portable sections (`mcps`/`skills`). Matching is keyed by the canonical
+ * {@link agentItemIdentity} (collision-free), while the row's display label comes from
+ * {@link entryLabel} — so two id-less entries never collapse the way a shared label would.
+ */
 function listSection(
     id: "mcps" | "skills",
     title: string,
     local: unknown[],
     remote: unknown[],
 ): ChangeSection | null {
-    const lMap = new Map(local.map((e) => [entryLabel(e), e]))
-    const rMap = new Map(remote.map((e) => [entryLabel(e), e]))
-    const added: string[] = []
-    const removed: string[] = []
-    const edited: string[] = []
+    const kind: AgentItemKind = id === "mcps" ? "mcp" : "skill"
+    const lMap = new Map(local.map((e, i) => [agentItemIdentity(kind, e, i), e] as const))
+    const rMap = new Map(remote.map((e, i) => [agentItemIdentity(kind, e, i), e] as const))
+    const added: [string, unknown][] = []
+    const removed: [string, unknown][] = []
+    const edited: [string, unknown][] = []
     for (const [key, entry] of lMap) {
         const prev = rMap.get(key)
-        if (prev === undefined) added.push(key)
-        else if (stableStringify(prev) !== stableStringify(entry)) edited.push(key)
+        if (prev === undefined) added.push([key, entry])
+        else if (stableStringify(prev) !== stableStringify(entry)) edited.push([key, entry])
     }
-    for (const key of rMap.keys()) if (!lMap.has(key)) removed.push(key)
+    for (const [key, entry] of rMap) if (!lMap.has(key)) removed.push([key, entry])
 
     const total = added.length + removed.length + edited.length
     if (total === 0) return null
 
-    const items = [
-        ...added.map((k) => ({id: k, label: k, kind: "added" as const})),
-        ...edited.map((k) => ({id: k, label: k, kind: "edited" as const})),
-        ...removed.map((k) => ({id: k, label: k, kind: "removed" as const})),
-    ]
+    const rows = (pairs: [string, unknown][], kindTag: ChangeItem["kind"]) =>
+        pairs.map(([key, entry]) => ({id: key, label: entryLabel(entry), kind: kindTag}))
+    const items = [...rows(added, "added"), ...rows(edited, "edited"), ...rows(removed, "removed")]
     const tags = []
     if (added.length) tags.push({kind: "added" as const, label: `${added.length} added`})
     if (edited.length) tags.push({kind: "edited" as const, label: `${edited.length} edited`})

--- a/web/packages/agenta-entities/src/workflow/commitDiff/classify.ts
+++ b/web/packages/agenta-entities/src/workflow/commitDiff/classify.ts
@@ -1,0 +1,318 @@
+/**
+ * Classify the difference between two agent configs into render-ready sections.
+ *
+ * `remote` is the committed side, `local` the edited side (added = present locally,
+ * removed = present remotely). Returns `[]` when nothing recognized changed, so the
+ * caller can fall back to the coarse "Configuration modified" + JSON view.
+ */
+import {computeTextDiffLines} from "@agenta/ui/diff"
+
+import {PARAM_KEYS, readAgentConfig, stableStringify} from "./accessors"
+import type {
+    AgentConfigView,
+    ChangeSection,
+    NormalizedTool,
+    ScalarChange,
+    ToolFieldChange,
+} from "./types"
+
+function fmtScalar(v: unknown): string | undefined {
+    if (v === undefined || v === null) return undefined
+    if (typeof v === "object") return JSON.stringify(v)
+    return String(v)
+}
+
+function isPlainObj(v: unknown): v is Record<string, unknown> {
+    return typeof v === "object" && v !== null && !Array.isArray(v)
+}
+
+/** Flatten nested config leaves to dot-path keys (arrays kept whole), for scalar diffing. */
+function flattenScalars(
+    obj: Record<string, unknown>,
+    prefix = "",
+    out: Record<string, unknown> = {},
+): Record<string, unknown> {
+    for (const [k, v] of Object.entries(obj)) {
+        const key = prefix ? `${prefix}.${k}` : k
+        if (isPlainObj(v)) flattenScalars(v, key, out)
+        else out[key] = v
+    }
+    return out
+}
+
+function toolProps(tool: NormalizedTool): Record<string, unknown> {
+    const props = tool.params?.properties
+    return typeof props === "object" && props !== null && !Array.isArray(props)
+        ? (props as Record<string, unknown>)
+        : {}
+}
+
+function diffToolFields(before: NormalizedTool, after: NormalizedTool): ToolFieldChange[] {
+    const changes: ToolFieldChange[] = []
+    if (before.description !== after.description) {
+        changes.push({field: "description", kind: "changed", detail: "description changed"})
+    }
+    const b = toolProps(before)
+    const a = toolProps(after)
+    const keys = new Set([...Object.keys(b), ...Object.keys(a)])
+    for (const key of keys) {
+        const inB = key in b
+        const inA = key in a
+        if (inA && !inB) {
+            const type =
+                typeof (a[key] as Record<string, unknown>)?.type === "string"
+                    ? `${(a[key] as Record<string, unknown>).type}, added`
+                    : "added"
+            changes.push({field: key, kind: "added", detail: type})
+        } else if (inB && !inA) {
+            changes.push({field: key, kind: "removed", detail: "removed"})
+        } else if (stableStringify(b[key]) !== stableStringify(a[key])) {
+            changes.push({field: key, kind: "changed", detail: "changed"})
+        }
+    }
+    return changes
+}
+
+function toolRowDetail(fields: ToolFieldChange[]): string | undefined {
+    const descChanged = fields.some((f) => f.field === "description")
+    const paramCount = fields.filter((f) => f.field !== "description").length
+    const parts: string[] = []
+    if (descChanged) parts.push("description")
+    if (paramCount) parts.push(paramCount === 1 ? "1 parameter" : `${paramCount} parameters`)
+    if (!parts.length) return undefined
+    return `${parts.join(" & ")} changed`
+}
+
+function toolsSection(local: AgentConfigView, remote: AgentConfigView): ChangeSection | null {
+    const localMap = new Map(local.tools.map((t) => [t.key, t]))
+    const remoteMap = new Map(remote.tools.map((t) => [t.key, t]))
+
+    const added: NormalizedTool[] = []
+    const removed: NormalizedTool[] = []
+    const edited: {tool: NormalizedTool; fields: ToolFieldChange[]}[] = []
+
+    for (const [key, tool] of localMap) {
+        const prev = remoteMap.get(key)
+        if (!prev) {
+            added.push(tool)
+        } else if (prev.description !== tool.description || prev.paramsJson !== tool.paramsJson) {
+            edited.push({tool, fields: diffToolFields(prev, tool)})
+        }
+    }
+    for (const [key, tool] of remoteMap) {
+        if (!localMap.has(key)) removed.push(tool)
+    }
+
+    const total = added.length + removed.length + edited.length
+    if (total === 0) return null
+
+    const items = [
+        ...added.map((t) => ({
+            id: t.key,
+            label: t.label,
+            detail: t.source,
+            kind: "added" as const,
+            rawKey: t.key,
+        })),
+        ...edited.map(({tool, fields}) => ({
+            id: tool.key,
+            label: tool.label,
+            detail: toolRowDetail(fields),
+            kind: "edited" as const,
+            rawKey: tool.key,
+            fieldChanges: fields,
+            descriptionDiff: fields.some((f) => f.field === "description")
+                ? {
+                      before: remoteMap.get(tool.key)?.description ?? "",
+                      after: tool.description,
+                  }
+                : undefined,
+        })),
+        ...removed.map((t) => ({
+            id: t.key,
+            label: t.label,
+            detail: t.source,
+            kind: "removed" as const,
+            rawKey: t.key,
+        })),
+    ]
+
+    const tags = []
+    if (added.length) tags.push({kind: "added" as const, label: `${added.length} added`})
+    if (edited.length) tags.push({kind: "edited" as const, label: `${edited.length} edited`})
+    if (removed.length) tags.push({kind: "removed" as const, label: `${removed.length} removed`})
+
+    return {
+        id: "tools",
+        title: "Tools",
+        tags,
+        totalCount: total,
+        defaultCollapsed: total > 20,
+        items,
+    }
+}
+
+function instructionsSection(
+    local: AgentConfigView,
+    remote: AgentConfigView,
+): ChangeSection | null {
+    if (local.instructions === remote.instructions) return null
+    const hunks = computeTextDiffLines(remote.instructions, local.instructions, {
+        enableFolding: true,
+    })
+    let added = 0
+    let removed = 0
+    for (const line of hunks) {
+        if (line.type === "added") added++
+        else if (line.type === "removed") removed++
+    }
+    const label = added + removed <= 2 ? "Edited" : `+${added} / −${removed}`
+    return {
+        id: "instructions",
+        title: "Instructions",
+        tags: [{kind: "edited", label}],
+        totalCount: 1,
+        textDiff: {added, removed, before: remote.instructions, after: local.instructions, hunks},
+    }
+}
+
+/** Diff two already-flattened scalar maps into a section. Null when nothing changed. */
+function scalarSection(
+    id: ChangeSection["id"],
+    title: string,
+    localMap: Record<string, unknown>,
+    remoteMap: Record<string, unknown>,
+): ChangeSection | null {
+    const changes: ScalarChange[] = []
+    for (const key of [...new Set([...Object.keys(remoteMap), ...Object.keys(localMap)])].sort()) {
+        if (stableStringify(remoteMap[key]) === stableStringify(localMap[key])) continue
+        changes.push({
+            key,
+            before: fmtScalar(remoteMap[key]),
+            after: fmtScalar(localMap[key]),
+            kind: !(key in remoteMap) ? "added" : !(key in localMap) ? "removed" : "changed",
+        })
+    }
+    if (!changes.length) return null
+    return {
+        id,
+        title,
+        tags: [{kind: "changed", label: `${changes.length} changed`}],
+        totalCount: changes.length,
+        defaultCollapsed: changes.length > 12,
+        scalarChanges: changes,
+    }
+}
+
+/** Prefix every leaf of a flattened section (e.g. `runner.` → `runner.interactions.headless`). */
+function prefixed(
+    prefix: string,
+    obj: Record<string, unknown> | undefined,
+): Record<string, unknown> {
+    if (!isPlainObj(obj)) return {}
+    const flat = flattenScalars(obj)
+    const out: Record<string, unknown> = {}
+    for (const [k, v] of Object.entries(flat)) out[`${prefix}.${k}`] = v
+    return out
+}
+
+/**
+ * Model & harness — just the model identity (`llm.model`) and the harness engine
+ * (`harness.kind`), mirroring the config panel's "Model & harness" control section. The rest of
+ * `llm` (connection/provider/auth) belongs to Advanced — the config panel groups it there.
+ */
+function modelHarnessBucket(v: AgentConfigView): Record<string, unknown> {
+    const out: Record<string, unknown> = {}
+    if (v.model !== undefined) out.model = v.model
+    if (isPlainObj(v.harness) && "kind" in v.harness) out["harness.kind"] = v.harness.kind
+    return out
+}
+
+/**
+ * Advanced — everything the config panel *artificially groups* under "Advanced", which lives in
+ * several JSON locations: the llm auth/connection (`llm.*` minus the model), generation params,
+ * the runner/sandbox execution sections, and the harness's non-`kind` knobs (e.g. permissions).
+ */
+function advancedBucket(v: AgentConfigView): Record<string, unknown> {
+    const out: Record<string, unknown> = {}
+    for (const key of PARAM_KEYS) if (v.params[key] !== undefined) out[key] = v.params[key]
+    // Authentication group: everything in `llm` except the model itself (that's Model & harness).
+    if (isPlainObj(v.llm)) {
+        const {model: _model, ...rest} = v.llm
+        Object.assign(out, prefixed("llm", rest))
+    }
+    Object.assign(out, prefixed("runner", v.runner))
+    Object.assign(out, prefixed("sandbox", v.sandbox))
+    if (isPlainObj(v.harness)) {
+        const {kind: _kind, ...rest} = v.harness
+        Object.assign(out, prefixed("harness", rest))
+    }
+    return out
+}
+
+/** Humanize a list entry (mcp/skill) for its summary row. */
+function entryLabel(entry: unknown): string {
+    if (!isPlainObj(entry)) return "item"
+    if (typeof entry.name === "string" && entry.name) return entry.name
+    if (typeof entry.slug === "string" && entry.slug) return entry.slug
+    const embed = isPlainObj(entry["@ag.embed"]) ? entry["@ag.embed"] : undefined
+    const refs = embed && isPlainObj(embed["@ag.references"]) ? embed["@ag.references"] : undefined
+    const wf = refs && isPlainObj(refs.workflow) ? refs.workflow : undefined
+    if (wf && typeof wf.slug === "string") return wf.slug
+    return "item"
+}
+
+/** Identity list-diff for portable sections (`mcps`/`skills`) keyed by human label. */
+function listSection(
+    id: "mcps" | "skills",
+    title: string,
+    local: unknown[],
+    remote: unknown[],
+): ChangeSection | null {
+    const lMap = new Map(local.map((e) => [entryLabel(e), e]))
+    const rMap = new Map(remote.map((e) => [entryLabel(e), e]))
+    const added: string[] = []
+    const removed: string[] = []
+    const edited: string[] = []
+    for (const [key, entry] of lMap) {
+        const prev = rMap.get(key)
+        if (prev === undefined) added.push(key)
+        else if (stableStringify(prev) !== stableStringify(entry)) edited.push(key)
+    }
+    for (const key of rMap.keys()) if (!lMap.has(key)) removed.push(key)
+
+    const total = added.length + removed.length + edited.length
+    if (total === 0) return null
+
+    const items = [
+        ...added.map((k) => ({id: k, label: k, kind: "added" as const})),
+        ...edited.map((k) => ({id: k, label: k, kind: "edited" as const})),
+        ...removed.map((k) => ({id: k, label: k, kind: "removed" as const})),
+    ]
+    const tags = []
+    if (added.length) tags.push({kind: "added" as const, label: `${added.length} added`})
+    if (edited.length) tags.push({kind: "edited" as const, label: `${edited.length} edited`})
+    if (removed.length) tags.push({kind: "removed" as const, label: `${removed.length} removed`})
+
+    return {id, title, tags, totalCount: total, defaultCollapsed: total > 20, items}
+}
+
+export function classifyAgentChanges(localParams: unknown, remoteParams: unknown): ChangeSection[] {
+    const local = readAgentConfig(localParams)
+    const remote = readAgentConfig(remoteParams)
+    // Grouped to mirror the agent-template control sections (Model & harness, Instructions,
+    // Tools, MCP servers, Skills, Advanced) so nothing changed is dropped or split.
+    return [
+        scalarSection(
+            "model",
+            "Model & harness",
+            modelHarnessBucket(local),
+            modelHarnessBucket(remote),
+        ),
+        instructionsSection(local, remote),
+        toolsSection(local, remote),
+        listSection("mcps", "MCP servers", local.mcps, remote.mcps),
+        listSection("skills", "Skills", local.skills, remote.skills),
+        scalarSection("params", "Advanced", advancedBucket(local), advancedBucket(remote)),
+    ].filter((s): s is ChangeSection => s !== null)
+}

--- a/web/packages/agenta-entities/src/workflow/commitDiff/gatewayName.ts
+++ b/web/packages/agenta-entities/src/workflow/commitDiff/gatewayName.ts
@@ -1,0 +1,34 @@
+/**
+ * Gateway tool function names are encoded as
+ * `tools__{provider}__{integration}__{ACTION}__{connection}` (double underscores
+ * because LLM APIs forbid dots in function names). Turn one into a friendly label
+ * + source so the commit summary never shows `tools__composio__gmail__ADD_LABEL__b81`.
+ */
+export interface ParsedToolName {
+    label: string
+    source?: string
+}
+
+function titleCase(token: string): string {
+    const cleaned = token.replace(/[_-]+/g, " ").trim().toLowerCase()
+    if (!cleaned) return token
+    return cleaned.charAt(0).toUpperCase() + cleaned.slice(1)
+}
+
+export function parseGatewayToolName(name: string): ParsedToolName {
+    if (!name) return {label: name}
+
+    const parts = name.split("__").filter(Boolean)
+    // tools__provider__integration__ACTION[__connection]
+    if (parts[0] === "tools" && parts.length >= 4) {
+        const integration = parts[2]
+        const action = parts[3]
+        return {
+            label: titleCase(action),
+            source: titleCase(integration),
+        }
+    }
+
+    // Plain function name (e.g. "gmail_search_emails") — humanize it.
+    return {label: titleCase(name)}
+}

--- a/web/packages/agenta-entities/src/workflow/commitDiff/identity.ts
+++ b/web/packages/agenta-entities/src/workflow/commitDiff/identity.ts
@@ -1,0 +1,56 @@
+/**
+ * Canonical, collision-free identity for an agent-template list item (tool / mcp / skill).
+ *
+ * Used to match a LIVE item against its COMMITTED counterpart when deciding new/edited/removed —
+ * both by the commit-diff classifier and by the config panel's per-row draft indicators. A stable
+ * id is preferred (reference slug, function name, platform op, name, embed slug); when an item
+ * carries none (e.g. a bare builtin tool `{type:"web_search"}`), it falls back to a POSITIONAL key
+ * so two id-less items never collapse onto the same map key (which would silently drop one).
+ *
+ * Pure and dependency-free so it can be shared across the classifier (`@agenta/entities`) and the
+ * config panel (`@agenta/entity-ui`) without pulling in either package's helpers.
+ */
+export type AgentItemKind = "tool" | "mcp" | "skill"
+
+function isObj(v: unknown): v is Record<string, unknown> {
+    return typeof v === "object" && v !== null && !Array.isArray(v)
+}
+
+/** The workflow slug an `@ag.embed` reference points at (skills, embedded workflow tools). */
+function embedSlug(rec: Record<string, unknown>): string | undefined {
+    const embed = isObj(rec["@ag.embed"]) ? rec["@ag.embed"] : undefined
+    const refs = embed && isObj(embed["@ag.references"]) ? embed["@ag.references"] : undefined
+    if (!refs) return undefined
+    const wf = isObj(refs.workflow)
+        ? refs.workflow
+        : isObj(refs.workflow_revision)
+          ? refs.workflow_revision
+          : undefined
+    return wf && typeof wf.slug === "string" ? wf.slug : undefined
+}
+
+export function agentItemIdentity(kind: AgentItemKind, item: unknown, index: number): string {
+    const rec = isObj(item) ? item : {}
+    if (kind === "tool") {
+        // Workflow-reference tool — keyed by the slug it targets.
+        if (rec.type === "reference" && typeof rec.slug === "string" && rec.slug)
+            return `ref:${rec.slug}`
+        // Function / gateway tool — keyed by its function name.
+        const fn = isObj(rec.function) ? rec.function : undefined
+        if (fn && typeof fn.name === "string" && fn.name) return `fn:${fn.name}`
+        // Platform op tool.
+        if (rec.type === "platform" && typeof rec.op === "string" && rec.op)
+            return `platform:${rec.op}`
+        // Bare builtin (only a `type`) or anything else — positional, so duplicates never collapse.
+        return `#${index}`
+    }
+    if (kind === "skill") {
+        const slug = embedSlug(rec)
+        if (slug) return `skill:${slug}`
+        if (typeof rec.name === "string" && rec.name) return `skill:${rec.name}`
+        return `#${index}`
+    }
+    // mcp
+    if (typeof rec.name === "string" && rec.name) return `mcp:${rec.name}`
+    return `#${index}`
+}

--- a/web/packages/agenta-entities/src/workflow/commitDiff/index.ts
+++ b/web/packages/agenta-entities/src/workflow/commitDiff/index.ts
@@ -6,6 +6,7 @@
  * plus an auto commit message. Consumed by the commit modal's changes summary.
  */
 export {readAgentConfig, PARAM_KEYS, stableStringify} from "./accessors"
+export {agentItemIdentity, type AgentItemKind} from "./identity"
 export {classifyAgentChanges} from "./classify"
 export {buildCommitSummaryMessage} from "./summaryMessage"
 export {parseGatewayToolName, type ParsedToolName} from "./gatewayName"

--- a/web/packages/agenta-entities/src/workflow/commitDiff/index.ts
+++ b/web/packages/agenta-entities/src/workflow/commitDiff/index.ts
@@ -1,0 +1,23 @@
+/**
+ * Semantic commit-diff for agent/LLM workflows.
+ *
+ * Pure, dependency-light logic that turns two `parameters` objects into a
+ * plain-language set of `ChangeSection`s (tools / instructions / model / params)
+ * plus an auto commit message. Consumed by the commit modal's changes summary.
+ */
+export {readAgentConfig, PARAM_KEYS, stableStringify} from "./accessors"
+export {classifyAgentChanges} from "./classify"
+export {buildCommitSummaryMessage} from "./summaryMessage"
+export {parseGatewayToolName, type ParsedToolName} from "./gatewayName"
+export type {
+    AgentConfigView,
+    NormalizedTool,
+    ChangeSection,
+    ChangeItem,
+    ChangeTag,
+    ChangeKind,
+    SectionId,
+    ScalarChange,
+    TextDiff,
+    ToolFieldChange,
+} from "./types"

--- a/web/packages/agenta-entities/src/workflow/commitDiff/summaryMessage.ts
+++ b/web/packages/agenta-entities/src/workflow/commitDiff/summaryMessage.ts
@@ -1,0 +1,65 @@
+/**
+ * Build a human commit message from classified sections, used to pre-fill the
+ * (editable) commit-message field. E.g.
+ *   "Added 24 tools, edited the instructions, and changed the model to claude-opus-4-8."
+ */
+import type {ChangeSection} from "./types"
+
+function plural(word: string, n: number): string {
+    return n === 1 ? word : `${word}s`
+}
+
+function joinClauses(parts: string[]): string {
+    if (parts.length <= 1) return parts.join("")
+    if (parts.length === 2) return `${parts[0]} and ${parts[1]}`
+    return `${parts.slice(0, -1).join(", ")}, and ${parts[parts.length - 1]}`
+}
+
+function toolsPhrase(section: ChangeSection): string {
+    const items = section.items ?? []
+    const counts = {added: 0, edited: 0, removed: 0}
+    for (const it of items) {
+        if (it.kind === "added") counts.added++
+        else if (it.kind === "removed") counts.removed++
+        else counts.edited++
+    }
+    const sub: string[] = []
+    if (counts.added) sub.push(`added ${counts.added} ${plural("tool", counts.added)}`)
+    if (counts.edited) sub.push(`edited ${counts.edited} ${plural("tool", counts.edited)}`)
+    if (counts.removed) sub.push(`removed ${counts.removed} ${plural("tool", counts.removed)}`)
+    return sub.join(", ")
+}
+
+export function buildCommitSummaryMessage(sections: ChangeSection[]): string {
+    const phrases: string[] = []
+    for (const section of sections) {
+        switch (section.id) {
+            case "tools":
+                phrases.push(toolsPhrase(section))
+                break
+            case "instructions":
+                phrases.push("edited the instructions")
+                break
+            case "model": {
+                const to = section.scalarChanges?.find((c) => c.key === "model")?.after
+                phrases.push(to ? `changed the model to ${to}` : "updated the model & harness")
+                break
+            }
+            case "mcps":
+                phrases.push("updated the MCP servers")
+                break
+            case "skills":
+                phrases.push("updated the skills")
+                break
+            case "params": {
+                const n = section.totalCount
+                phrases.push(`changed ${n} advanced ${plural("setting", n)}`)
+                break
+            }
+        }
+    }
+    const filtered = phrases.filter(Boolean)
+    if (!filtered.length) return ""
+    const sentence = joinClauses(filtered)
+    return `${sentence.charAt(0).toUpperCase()}${sentence.slice(1)}.`
+}

--- a/web/packages/agenta-entities/src/workflow/commitDiff/types.ts
+++ b/web/packages/agenta-entities/src/workflow/commitDiff/types.ts
@@ -1,0 +1,98 @@
+/**
+ * Semantic commit-diff types for agent/LLM workflows.
+ *
+ * The classifier turns two `parameters` objects into a small, render-ready set of
+ * `ChangeSection`s (tools / instructions / model / params). The commit modal renders
+ * these as a plain-language summary; the raw JSON diff stays available separately.
+ */
+import type {ExtendedDiffLine} from "@agenta/ui/diff"
+
+export type ChangeKind = "added" | "removed" | "edited" | "changed"
+
+export type SectionId = "tools" | "instructions" | "model" | "params" | "mcps" | "skills"
+
+export interface ChangeTag {
+    kind: ChangeKind
+    /** Short human label, e.g. "24 added", "Edited", "+182 / −37 lines". */
+    label: string
+}
+
+/** A single field/param change inside an edited tool. */
+export interface ToolFieldChange {
+    field: string
+    kind: ChangeKind
+    /** e.g. "description changed", "number, added". */
+    detail: string
+}
+
+/** A row in a section — a tool, or a labelled entry. */
+export interface ChangeItem {
+    id: string
+    label: string
+    detail?: string
+    kind: ChangeKind
+    /** Original key (e.g. gateway function name) for drill-in / JSON. */
+    rawKey?: string
+    /** Populated for edited tools so the detail view can show field-level changes. */
+    fieldChanges?: ToolFieldChange[]
+    /** description before/after for an edited tool. */
+    descriptionDiff?: {before: string; after: string}
+}
+
+/** A scalar before→after change (model, temperature, …). */
+export interface ScalarChange {
+    key: string
+    before: string | undefined
+    after: string | undefined
+    kind: ChangeKind
+}
+
+/** A text (prose) diff — instructions. */
+export interface TextDiff {
+    added: number
+    removed: number
+    before: string
+    after: string
+    hunks: ExtendedDiffLine[]
+}
+
+export interface ChangeSection {
+    id: SectionId
+    title: string
+    tags: ChangeTag[]
+    /** Total change count in this section — drives caps / collapse defaults. */
+    totalCount: number
+    defaultCollapsed?: boolean
+    items?: ChangeItem[]
+    scalarChanges?: ScalarChange[]
+    textDiff?: TextDiff
+}
+
+/** Normalized view of an agent's `parameters`, resolved across the 3 schema shapes. */
+export interface NormalizedTool {
+    key: string
+    label: string
+    /** e.g. "Gmail" — provider/integration, when derivable from a gateway name. */
+    source?: string
+    description: string
+    /** Stable-stringified `parameters` schema, for equality checks. */
+    paramsJson: string
+    /** The raw parameters object, for field-level diffing. */
+    params: Record<string, unknown>
+}
+
+export interface AgentConfigView {
+    instructions: string
+    tools: NormalizedTool[]
+    model: string | undefined
+    params: Record<string, unknown>
+    /** Raw ModelRef (`{provider, model, connection}`) — feeds the Model & harness section. */
+    llm: Record<string, unknown> | undefined
+    /** Portable list sections (agent-template). */
+    mcps: unknown[]
+    skills: unknown[]
+    /** Agent-template execution sections (`agent.{harness,runner,sandbox}`), when present. */
+    harness: Record<string, unknown> | undefined
+    runner: Record<string, unknown> | undefined
+    sandbox: Record<string, unknown> | undefined
+}

--- a/web/packages/agenta-entities/src/workflow/state/store.ts
+++ b/web/packages/agenta-entities/src/workflow/state/store.ts
@@ -12,7 +12,7 @@
  */
 
 import {projectIdAtom, sessionAtom} from "@agenta/shared/state"
-import {createBatchFetcher} from "@agenta/shared/utils"
+import {createBatchFetcher, stripEmptyCollectionsDeep} from "@agenta/shared/utils"
 import isEqual from "fast-deep-equal"
 import {atom, type Getter} from "jotai"
 import {getDefaultStore} from "jotai/vanilla"
@@ -1905,8 +1905,10 @@ export const workflowIsDirtyAtomFamily = atomFamily((workflowId: string) =>
                 })
             }
 
-            // Sort all object keys recursively (handles json_schema property order)
-            return sortObjectKeys(normalized)
+            // Sort all object keys recursively (handles json_schema property order), and drop
+            // present-but-empty collections so an add-then-remove (`skills: []` vs an absent key)
+            // isn't a false-positive dirty. Applied to both sides, so real changes still register.
+            return sortObjectKeys(stripEmptyCollectionsDeep(normalized))
         }
 
         // Server schemas.parameters stays flat for evaluators while the entity

--- a/web/packages/agenta-entities/tests/unit/agent-commit-diff.test.ts
+++ b/web/packages/agenta-entities/tests/unit/agent-commit-diff.test.ts
@@ -1,0 +1,334 @@
+/**
+ * Unit tests for the agent commit-diff classifier (accessor + classify + message).
+ * Covers the three overlapping `parameters` schema shapes and the change categories.
+ */
+import {describe, it, expect} from "vitest"
+
+import {readAgentConfig} from "../../src/workflow/commitDiff/accessors"
+import {classifyAgentChanges} from "../../src/workflow/commitDiff/classify"
+import {parseGatewayToolName} from "../../src/workflow/commitDiff/gatewayName"
+import {buildCommitSummaryMessage} from "../../src/workflow/commitDiff/summaryMessage"
+
+const tool = (
+    name: string,
+    description = "Search",
+    props: Record<string, unknown> = {query: {type: "string"}},
+) => ({
+    type: "function",
+    function: {name, description, parameters: {type: "object", properties: props}},
+})
+
+describe("readAgentConfig — three schema shapes normalize to one view", () => {
+    const expected = (v: ReturnType<typeof readAgentConfig>) => {
+        expect(v.instructions).toBe("You are helpful.")
+        expect(v.model).toBe("gpt-4o")
+        expect(v.params.temperature).toBe(0.7)
+        expect(v.tools).toHaveLength(1)
+        expect(v.tools[0].key).toBe("gmail_search")
+    }
+
+    it("legacy nested (prompt.llm_config)", () => {
+        expected(
+            readAgentConfig({
+                prompt: {
+                    messages: [{role: "system", content: "You are helpful."}],
+                    llm_config: {model: "gpt-4o", temperature: 0.7, tools: [tool("gmail_search")]},
+                },
+            }),
+        )
+    })
+
+    it("canonical (llms[0])", () => {
+        expected(
+            readAgentConfig({
+                messages: [{role: "system", content: "You are helpful."}],
+                llms: [{model: "gpt-4o", temperature: 0.7, tools: [tool("gmail_search")]}],
+            }),
+        )
+    })
+
+    it("flat root", () => {
+        expected(
+            readAgentConfig({
+                messages: [{role: "system", content: "You are helpful."}],
+                model: "gpt-4o",
+                temperature: 0.7,
+                tools: [tool("gmail_search")],
+            }),
+        )
+    })
+
+    it("agent-template shape (parameters.agent.{instructions.agents_md, llm, tools})", () => {
+        const v = readAgentConfig({
+            agent: {
+                kind: "claude",
+                instructions: {agents_md: "You are helpful."},
+                llm: {model: "gpt-4o", temperature: 0.7},
+                tools: [tool("gmail_search")],
+            },
+        })
+        expect(v.instructions).toBe("You are helpful.")
+        expect(v.model).toBe("gpt-4o")
+        expect(v.params.temperature).toBe(0.7)
+        expect(v.tools[0].key).toBe("gmail_search")
+    })
+
+    it("handles array (multimodal) message content", () => {
+        const v = readAgentConfig({
+            messages: [
+                {
+                    role: "system",
+                    content: [
+                        {type: "text", text: "hi"},
+                        {type: "text", text: "there"},
+                    ],
+                },
+            ],
+        })
+        expect(v.instructions).toBe("hi\nthere")
+    })
+})
+
+describe("classifyAgentChanges", () => {
+    const base = {
+        prompt: {
+            messages: [{role: "system", content: "You are a helpful assistant."}],
+            llm_config: {model: "gpt-4o", temperature: 0.7, tools: [tool("gmail_search")]},
+        },
+    }
+
+    it("no-op returns []", () => {
+        expect(classifyAgentChanges(base, base)).toEqual([])
+    })
+
+    it("added tool", () => {
+        const local = {
+            prompt: {
+                ...base.prompt,
+                llm_config: {
+                    ...base.prompt.llm_config,
+                    tools: [tool("gmail_search"), tool("gmail_send")],
+                },
+            },
+        }
+        const sections = classifyAgentChanges(local, base)
+        const tools = sections.find((s) => s.id === "tools")
+        expect(tools?.totalCount).toBe(1)
+        expect(tools?.items?.[0]).toMatchObject({kind: "added", rawKey: "gmail_send"})
+    })
+
+    it("removed tool", () => {
+        const local = {prompt: {...base.prompt, llm_config: {...base.prompt.llm_config, tools: []}}}
+        const tools = classifyAgentChanges(local, base).find((s) => s.id === "tools")
+        expect(tools?.items?.[0]).toMatchObject({kind: "removed", rawKey: "gmail_search"})
+    })
+
+    it("edited tool captures field-level changes", () => {
+        const local = {
+            prompt: {
+                ...base.prompt,
+                llm_config: {
+                    ...base.prompt.llm_config,
+                    tools: [
+                        tool("gmail_search", "Search and return IDs", {
+                            query: {type: "string"},
+                            max_results: {type: "number"},
+                        }),
+                    ],
+                },
+            },
+        }
+        const tools = classifyAgentChanges(local, base).find((s) => s.id === "tools")
+        const item = tools?.items?.[0]
+        expect(item?.kind).toBe("edited")
+        expect(item?.fieldChanges?.some((f) => f.field === "description")).toBe(true)
+        expect(
+            item?.fieldChanges?.some((f) => f.field === "max_results" && f.kind === "added"),
+        ).toBe(true)
+    })
+
+    it("instructions rewrite", () => {
+        const local = {
+            prompt: {
+                ...base.prompt,
+                messages: [
+                    {
+                        role: "system",
+                        content: "You are a helpful email assistant.\nAlways confirm.",
+                    },
+                ],
+            },
+        }
+        const instr = classifyAgentChanges(local, base).find((s) => s.id === "instructions")
+        expect(instr).toBeTruthy()
+        expect(instr?.textDiff?.added).toBeGreaterThan(0)
+    })
+
+    it("agent-template: instructions change is detected", () => {
+        const remote = {agent: {instructions: {agents_md: "You are a hello-world agent."}}}
+        const local = {
+            agent: {instructions: {agents_md: "You are a hello-world agent.\n\nAdd a test."}},
+        }
+        const instr = classifyAgentChanges(local, remote).find((s) => s.id === "instructions")
+        expect(instr?.textDiff?.added).toBeGreaterThan(0)
+    })
+
+    it("model swap", () => {
+        const local = {
+            prompt: {
+                ...base.prompt,
+                llm_config: {...base.prompt.llm_config, model: "claude-opus-4-8"},
+            },
+        }
+        const model = classifyAgentChanges(local, base).find((s) => s.id === "model")
+        expect(model?.scalarChanges?.[0]).toMatchObject({
+            before: "gpt-4o",
+            after: "claude-opus-4-8",
+        })
+    })
+
+    it("advanced param change", () => {
+        const local = {
+            prompt: {...base.prompt, llm_config: {...base.prompt.llm_config, temperature: 0.2}},
+        }
+        const params = classifyAgentChanges(local, base).find((s) => s.id === "params")
+        expect(params?.scalarChanges?.[0]).toMatchObject({
+            key: "temperature",
+            before: "0.7",
+            after: "0.2",
+        })
+    })
+
+    it("agent-template: harness (non-kind) change lands in Advanced with a prefixed path", () => {
+        const remote = {agent: {harness: {kind: "pi_core", max_iterations: 10}}}
+        const local = {agent: {harness: {kind: "pi_core", max_iterations: 25}}}
+        const advanced = classifyAgentChanges(local, remote).find((s) => s.id === "params")
+        expect(advanced?.title).toBe("Advanced")
+        expect(advanced?.scalarChanges).toContainEqual({
+            key: "harness.max_iterations",
+            before: "10",
+            after: "25",
+            kind: "changed",
+        })
+    })
+
+    it("agent-template: nested harness permission leaf uses a dot path in Advanced", () => {
+        const remote = {agent: {harness: {kind: "pi_core", permissions: {web_search: false}}}}
+        const local = {agent: {harness: {kind: "pi_core", permissions: {web_search: true}}}}
+        const advanced = classifyAgentChanges(local, remote).find((s) => s.id === "params")
+        expect(advanced?.scalarChanges).toContainEqual({
+            key: "harness.permissions.web_search",
+            before: "false",
+            after: "true",
+            kind: "changed",
+        })
+    })
+
+    it("agent-template: llm auth/connection change lands in Advanced, not Model & harness", () => {
+        const remote = {
+            agent: {llm: {model: "opus", provider: "anthropic", connection: {mode: "agenta"}}},
+        }
+        const local = {
+            agent: {
+                llm: {model: "opus", provider: "anthropic", connection: {mode: "self_managed"}},
+            },
+        }
+        const sections = classifyAgentChanges(local, remote)
+        // Model unchanged → no Model & harness section.
+        expect(sections.find((s) => s.id === "model")).toBeUndefined()
+        const advanced = sections.find((s) => s.id === "params")
+        expect(advanced?.scalarChanges).toContainEqual({
+            key: "llm.connection.mode",
+            before: "agenta",
+            after: "self_managed",
+            kind: "changed",
+        })
+    })
+
+    it("agent-template: a model-only change stays in Model & harness (no Advanced leak)", () => {
+        const remote = {agent: {llm: {model: "opus", provider: "anthropic"}}}
+        const local = {agent: {llm: {model: "opus[1m]", provider: "anthropic"}}}
+        const sections = classifyAgentChanges(local, remote)
+        expect(sections.find((s) => s.id === "params")).toBeUndefined()
+        const mh = sections.find((s) => s.id === "model")
+        expect(mh?.scalarChanges).toContainEqual({
+            key: "model",
+            before: "opus",
+            after: "opus[1m]",
+            kind: "changed",
+        })
+    })
+
+    it("agent-template: runner + sandbox changes land in Advanced", () => {
+        const remote = {agent: {runner: {kind: "sidecar"}, sandbox: {kind: "local"}}}
+        const local = {agent: {runner: {kind: "e2b"}, sandbox: {kind: "remote"}}}
+        const advanced = classifyAgentChanges(local, remote).find((s) => s.id === "params")
+        expect(advanced?.scalarChanges?.map((c) => c.key)).toEqual(["runner.kind", "sandbox.kind"])
+    })
+
+    it("agent-template: harness kind change lands in Model & harness", () => {
+        const remote = {agent: {harness: {kind: "pi_core"}, llm: {model: "gpt-4o"}}}
+        const local = {agent: {harness: {kind: "claude"}, llm: {model: "gpt-4o"}}}
+        const sections = classifyAgentChanges(local, remote)
+        const mh = sections.find((s) => s.id === "model")
+        expect(mh?.title).toBe("Model & harness")
+        expect(mh?.scalarChanges).toContainEqual({
+            key: "harness.kind",
+            before: "pi_core",
+            after: "claude",
+            kind: "changed",
+        })
+        // model + harness are one section, never split into two accordions.
+        expect(sections.filter((s) => s.id === "model")).toHaveLength(1)
+    })
+
+    it("agent-template: mcp servers list diff", () => {
+        const remote = {agent: {mcps: [{name: "github"}]}}
+        const local = {agent: {mcps: [{name: "github"}, {name: "linear"}]}}
+        const mcps = classifyAgentChanges(local, remote).find((s) => s.id === "mcps")
+        expect(mcps?.title).toBe("MCP servers")
+        expect(mcps?.items?.[0]).toMatchObject({kind: "added", label: "linear"})
+    })
+
+    it("agent-template: unchanged harness yields no Advanced section", () => {
+        const cfg = {agent: {harness: {kind: "pi_core"}, llm: {model: "gpt-4o"}}}
+        const local = {agent: {...cfg.agent, llm: {model: "claude-opus-4-8"}}}
+        const sections = classifyAgentChanges(local, cfg)
+        expect(sections.find((s) => s.id === "params")).toBeUndefined()
+        expect(sections.find((s) => s.id === "model")).toBeTruthy()
+    })
+})
+
+describe("parseGatewayToolName", () => {
+    it("humanizes a gateway function name", () => {
+        expect(parseGatewayToolName("tools__composio__gmail__ADD_LABEL_TO_EMAIL__b81")).toEqual({
+            label: "Add label to email",
+            source: "Gmail",
+        })
+    })
+    it("humanizes a plain function name", () => {
+        expect(parseGatewayToolName("gmail_search_emails")).toEqual({label: "Gmail search emails"})
+    })
+})
+
+describe("buildCommitSummaryMessage", () => {
+    it("composes a sentence from sections", () => {
+        const base = {
+            prompt: {
+                messages: [{role: "system", content: "a"}],
+                llm_config: {model: "gpt-4o", tools: []},
+            },
+        }
+        const local = {
+            prompt: {
+                messages: [{role: "system", content: "a much longer set of instructions here"}],
+                llm_config: {model: "claude-opus-4-8", tools: [tool("gmail_send")]},
+            },
+        }
+        // Ordered to mirror the config panel: Model & harness, Instructions, …, Tools.
+        const msg = buildCommitSummaryMessage(classifyAgentChanges(local, base))
+        expect(msg).toBe(
+            "Changed the model to claude-opus-4-8, edited the instructions, and added 1 tool.",
+        )
+    })
+})

--- a/web/packages/agenta-entities/tests/unit/agent-commit-diff.test.ts
+++ b/web/packages/agenta-entities/tests/unit/agent-commit-diff.test.ts
@@ -7,6 +7,7 @@ import {describe, it, expect} from "vitest"
 import {readAgentConfig} from "../../src/workflow/commitDiff/accessors"
 import {classifyAgentChanges} from "../../src/workflow/commitDiff/classify"
 import {parseGatewayToolName} from "../../src/workflow/commitDiff/gatewayName"
+import {agentItemIdentity} from "../../src/workflow/commitDiff/identity"
 import {buildCommitSummaryMessage} from "../../src/workflow/commitDiff/summaryMessage"
 
 const tool = (
@@ -296,6 +297,45 @@ describe("classifyAgentChanges", () => {
         const sections = classifyAgentChanges(local, cfg)
         expect(sections.find((s) => s.id === "params")).toBeUndefined()
         expect(sections.find((s) => s.id === "model")).toBeTruthy()
+    })
+})
+
+describe("agentItemIdentity — collision-free item identity", () => {
+    it("keys tools by reference slug / function name / positional fallback", () => {
+        expect(agentItemIdentity("tool", {type: "reference", slug: "wf-a"}, 0)).toBe("ref:wf-a")
+        expect(agentItemIdentity("tool", {function: {name: "gmail_send"}}, 0)).toBe("fn:gmail_send")
+        expect(agentItemIdentity("tool", {type: "platform", op: "list"}, 0)).toBe("platform:list")
+        // Bare builtin (only a type) has no stable id → positional, so duplicates never collapse.
+        expect(agentItemIdentity("tool", {type: "web_search"}, 2)).toBe("#2")
+    })
+
+    it("gives two id-less tools distinct identities (no map collapse)", () => {
+        const a = agentItemIdentity("tool", {type: "web_search"}, 0)
+        const b = agentItemIdentity("tool", {type: "code_execution"}, 1)
+        expect(a).not.toBe(b)
+    })
+
+    it("keys mcps by name and skills by embed slug / name", () => {
+        expect(agentItemIdentity("mcp", {name: "github"}, 0)).toBe("mcp:github")
+        expect(
+            agentItemIdentity(
+                "skill",
+                {"@ag.embed": {"@ag.references": {workflow: {slug: "sk-1"}}}},
+                0,
+            ),
+        ).toBe("skill:sk-1")
+        expect(agentItemIdentity("skill", {name: "writer"}, 0)).toBe("skill:writer")
+    })
+})
+
+describe("classifyAgentChanges — list identity is collision-free", () => {
+    it("does not collapse two id-less mcp entries onto one key", () => {
+        const remote = {agent: {mcps: [{}]}}
+        const local = {agent: {mcps: [{}, {}]}}
+        const mcps = classifyAgentChanges(local, remote).find((s) => s.id === "mcps")
+        // Positional identity: #0 unchanged, #1 added — the second entry is not silently dropped.
+        expect(mcps?.totalCount).toBe(1)
+        expect(mcps?.tags).toContainEqual({kind: "added", label: "1 added"})
     })
 })
 

--- a/web/packages/agenta-entities/vitest.config.ts
+++ b/web/packages/agenta-entities/vitest.config.ts
@@ -5,6 +5,12 @@ import {defineConfig} from "vitest/config"
 export default defineConfig({
     resolve: {
         alias: {
+            // Pure diff engine — resolve to the real module (no antd/Lexical).
+            // Must precede the "@agenta/ui" stub so the subpath matches first.
+            "@agenta/ui/diff": path.resolve(
+                __dirname,
+                "../agenta-ui/src/Editor/utils/diffUtils.ts",
+            ),
             // Stub @agenta/ui so Vitest doesn't transform the entire antd tree.
             // Entity tests only exercise Jotai atoms — no React rendering needed.
             "@agenta/ui": path.resolve(__dirname, "tests/__mocks__/agenta-ui.ts"),

--- a/web/packages/agenta-entity-ui/src/DrillInView/SchemaControls/AgentTemplateControl.tsx
+++ b/web/packages/agenta-entity-ui/src/DrillInView/SchemaControls/AgentTemplateControl.tsx
@@ -25,9 +25,13 @@ import {useCallback, useEffect, useMemo, useRef, useState} from "react"
 
 import type {SchemaProperty} from "@agenta/entities/shared"
 import {workflowBuildKitEnabledAtomFamily, workflowMolecule} from "@agenta/entities/workflow"
-import {classifyAgentChanges, stableStringify} from "@agenta/entities/workflow/commitDiff"
+import {
+    agentItemIdentity,
+    classifyAgentChanges,
+    stableStringify,
+} from "@agenta/entities/workflow/commitDiff"
 import {stripAgentaMetadataDeep} from "@agenta/shared/utils"
-import {ConfigAccordionSection} from "@agenta/ui/components/presentational"
+import {ConfigAccordionSection, sectionIndicatorColor} from "@agenta/ui/components/presentational"
 import {useDrillInUI} from "@agenta/ui/drill-in"
 import {cn} from "@agenta/ui/styles"
 import {
@@ -50,7 +54,6 @@ import {AgentIntegrationDrawer} from "./agentTemplate/AgentIntegrationDrawer"
 import {countSummary} from "./agentTemplate/agentTemplateUtils"
 import {AgentToolSelectorPopover} from "./agentTemplate/AgentToolSelectorPopover"
 import {ConfigItemList} from "./agentTemplate/ConfigItemList"
-import {toolName} from "./agentTemplate/itemDescriptors"
 import {ITEM_KINDS, type ItemKind} from "./agentTemplate/itemKinds"
 import {InstructionsFileRow, type ItemRowStatus} from "./agentTemplate/ItemRow"
 import {ToolManagementList} from "./agentTemplate/ToolManagementList"
@@ -305,44 +308,39 @@ export function AgentTemplateControl({
         return keys
     }, [config, committed])
 
-    // Per-item draft: identity → stable-stringified committed value, so a row reads as "new"
-    // (identity absent from the baseline) or "edited" (present but the value differs).
-    const identityOf = useMemo<Record<ItemKind, (item: unknown) => string>>(
-        () => ({
-            tool: (item) => String(toolName(item) ?? ""),
-            mcp: (item) => String((item as Record<string, unknown> | null)?.name ?? ""),
-            skill: (item) => {
-                const r = (item as Record<string, unknown> | null) ?? {}
-                return String(r.name ?? r.slug ?? "")
-            },
-        }),
-        [],
-    )
+    // Per-item draft: canonical identity → stable-stringified committed value, so a row reads as
+    // "new" (identity absent from the baseline) or "edited" (present but the value differs). The
+    // identity is collision-free (see agentItemIdentity) so id-less builtin/reference tools and
+    // unnamed items don't collapse onto one map key.
     const baseMaps = useMemo(() => {
-        const build = (list: unknown, identity: (x: unknown) => string) =>
-            new Map((Array.isArray(list) ? list : []).map((e) => [identity(e), stableStringify(e)]))
+        const build = (list: unknown, kind: ItemKind) =>
+            new Map(
+                (Array.isArray(list) ? list : []).map(
+                    (e, i) => [agentItemIdentity(kind, e, i), stableStringify(e)] as const,
+                ),
+            )
         return {
-            tool: build(committed?.tools, identityOf.tool),
-            mcp: build(committed?.mcps, identityOf.mcp),
-            skill: build(committed?.skills, identityOf.skill),
+            tool: build(committed?.tools, "tool"),
+            mcp: build(committed?.mcps, "mcp"),
+            skill: build(committed?.skills, "skill"),
         }
-    }, [committed, identityOf])
+    }, [committed])
 
     const statusForKind = useCallback(
         (kind: ItemKind) =>
-            (item: unknown): ItemRowStatus | undefined => {
+            (item: unknown, index: number): ItemRowStatus | undefined => {
                 if (ITEM_KINDS[kind].draftInvalid(item as Record<string, unknown>)) {
                     return {tone: "invalid", label: "Incomplete", tooltip: INVALID_ITEM_TIP[kind]}
                 }
                 if (!committed) return undefined
-                const prev = baseMaps[kind].get(identityOf[kind](item))
+                const prev = baseMaps[kind].get(agentItemIdentity(kind, item, index))
                 if (prev === undefined)
                     return {tone: "new", label: "New", tooltip: "Added since the last commit."}
                 if (prev !== stableStringify(stripAgentaMetadataDeep(item)))
                     return {tone: "edited", label: "Edited", tooltip: "Edited — not yet committed."}
                 return undefined
             },
-        [committed, baseMaps, identityOf],
+        [committed, baseMaps],
     )
     const toolStatusFor = useMemo(() => statusForKind("tool"), [statusForKind])
     const mcpStatusFor = useMemo(() => statusForKind("mcp"), [statusForKind])
@@ -383,12 +381,6 @@ export function AgentTemplateControl({
     const instructionsStatus: ItemRowStatus | undefined = draftSectionKeys.has("instructions")
         ? {tone: "edited", label: "Edited", tooltip: "Edited — not yet committed."}
         : undefined
-    const indicatorColor = (tone: "draft" | "invalid" | "incomplete") =>
-        tone === "invalid"
-            ? "var(--ag-colorError)"
-            : tone === "incomplete"
-              ? "var(--ag-colorWarning)"
-              : "var(--ag-colorInfo)"
 
     // Shared props for the tool picker, so the in-body popover and the header quick-add trigger
     // drive the same add flow.
@@ -599,7 +591,7 @@ export function AgentTemplateControl({
                                         style={
                                             s.indicator
                                                 ? {
-                                                      color: `color-mix(in srgb, ${indicatorColor(s.indicator.tone)} 45%, var(--ag-colorTextTertiary))`,
+                                                      color: `color-mix(in srgb, ${sectionIndicatorColor(s.indicator.tone)} 45%, var(--ag-colorTextTertiary))`,
                                                   }
                                                 : undefined
                                         }
@@ -609,7 +601,9 @@ export function AgentTemplateControl({
                                             <span
                                                 className="absolute -right-1 -top-0.5 h-1.5 w-1.5 rounded-full"
                                                 style={{
-                                                    background: indicatorColor(s.indicator.tone),
+                                                    background: sectionIndicatorColor(
+                                                        s.indicator.tone,
+                                                    ),
                                                 }}
                                             />
                                         ) : null}

--- a/web/packages/agenta-entity-ui/src/DrillInView/SchemaControls/AgentTemplateControl.tsx
+++ b/web/packages/agenta-entity-ui/src/DrillInView/SchemaControls/AgentTemplateControl.tsx
@@ -24,7 +24,9 @@
 import {useCallback, useEffect, useMemo, useRef, useState} from "react"
 
 import type {SchemaProperty} from "@agenta/entities/shared"
-import {workflowBuildKitEnabledAtomFamily} from "@agenta/entities/workflow"
+import {workflowBuildKitEnabledAtomFamily, workflowMolecule} from "@agenta/entities/workflow"
+import {classifyAgentChanges, stableStringify} from "@agenta/entities/workflow/commitDiff"
+import {stripAgentaMetadataDeep} from "@agenta/shared/utils"
 import {ConfigAccordionSection} from "@agenta/ui/components/presentational"
 import {useDrillInUI} from "@agenta/ui/drill-in"
 import {cn} from "@agenta/ui/styles"
@@ -48,14 +50,16 @@ import {AgentIntegrationDrawer} from "./agentTemplate/AgentIntegrationDrawer"
 import {countSummary} from "./agentTemplate/agentTemplateUtils"
 import {AgentToolSelectorPopover} from "./agentTemplate/AgentToolSelectorPopover"
 import {ConfigItemList} from "./agentTemplate/ConfigItemList"
-import {ITEM_KINDS} from "./agentTemplate/itemKinds"
-import {InstructionsFileRow} from "./agentTemplate/ItemRow"
+import {toolName} from "./agentTemplate/itemDescriptors"
+import {ITEM_KINDS, type ItemKind} from "./agentTemplate/itemKinds"
+import {InstructionsFileRow, type ItemRowStatus} from "./agentTemplate/ItemRow"
 import {ToolManagementList} from "./agentTemplate/ToolManagementList"
 import {useAgentTools} from "./agentTemplate/useAgentTools"
 import {useConfigItemDrawer} from "./agentTemplate/useConfigItemDrawer"
 import {useModelHarness} from "./agentTemplate/useModelHarness"
 import {agentTemplateLayoutAtom} from "./agentTemplateLayout"
 import {ConfigItemDrawer} from "./ConfigItemDrawer"
+import {modelIdFromConfig} from "./connectionUtils"
 import {InstructionsDrawer} from "./InstructionsDrawer"
 import {JsonObjectEditor} from "./JsonObjectEditor"
 import {SectionDrawer} from "./SectionDrawer"
@@ -66,6 +70,21 @@ import {
     useAgentTriggers,
 } from "./TriggerManagementSection"
 import {WorkflowReferenceSelector} from "./WorkflowReferenceSelector"
+
+// Tooltip copy for the config-panel draft/validation indicators.
+const INVALID_ITEM_TIP: Record<ItemKind, string> = {
+    tool: "This tool is missing its name.",
+    mcp: "This server is missing a required field (name, command, or URL).",
+    skill: "This skill is missing its name.",
+}
+const DRAFT_TIP: Record<string, string> = {
+    "model-harness": "Unsaved model or harness changes.",
+    instructions: "Unsaved instruction changes.",
+    tools: "Unsaved tool changes.",
+    mcp: "Unsaved MCP server changes.",
+    skills: "Unsaved skill changes.",
+    advanced: "Unsaved advanced-setting changes.",
+}
 
 export interface AgentTemplateControlProps {
     schema?: SchemaProperty | null
@@ -247,6 +266,130 @@ export function AgentTemplateControl({
         [props],
     )
 
+    // ── Draft + validation indicators ─────────────────────────────────────────
+    // Committed (server) template to diff the live config against. Null for a never-saved
+    // draft — then only validation (not draft) indicators show.
+    const committedConfig = useAtomValue(
+        useMemo(
+            () => workflowMolecule.selectors.serverConfiguration(revisionId ?? ""),
+            [revisionId],
+        ),
+    ) as Record<string, unknown> | null
+    const committed = useMemo(() => {
+        if (!committedConfig) return null
+        const agent = committedConfig.agent
+        const template =
+            agent && typeof agent === "object" && !Array.isArray(agent) ? agent : committedConfig
+        // Strip agenta metadata so it compares like-for-like against the live value.
+        return stripAgentaMetadataDeep(template) as Record<string, unknown>
+    }, [committedConfig])
+
+    // Header rollup: which sections changed vs the commit. Reuses the commit-diff classifier so
+    // the grouping matches (model+harness together; advanced = runner/sandbox/params).
+    const draftSectionKeys = useMemo(() => {
+        const keys = new Set<string>()
+        if (!committed) return keys
+        const map: Record<string, string> = {
+            model: "model-harness",
+            instructions: "instructions",
+            tools: "tools",
+            mcps: "mcp",
+            skills: "skills",
+            params: "advanced",
+        }
+        const local = stripAgentaMetadataDeep(config) as Record<string, unknown>
+        for (const s of classifyAgentChanges(local, committed)) {
+            const k = map[s.id]
+            if (k) keys.add(k)
+        }
+        return keys
+    }, [config, committed])
+
+    // Per-item draft: identity → stable-stringified committed value, so a row reads as "new"
+    // (identity absent from the baseline) or "edited" (present but the value differs).
+    const identityOf = useMemo<Record<ItemKind, (item: unknown) => string>>(
+        () => ({
+            tool: (item) => String(toolName(item) ?? ""),
+            mcp: (item) => String((item as Record<string, unknown> | null)?.name ?? ""),
+            skill: (item) => {
+                const r = (item as Record<string, unknown> | null) ?? {}
+                return String(r.name ?? r.slug ?? "")
+            },
+        }),
+        [],
+    )
+    const baseMaps = useMemo(() => {
+        const build = (list: unknown, identity: (x: unknown) => string) =>
+            new Map((Array.isArray(list) ? list : []).map((e) => [identity(e), stableStringify(e)]))
+        return {
+            tool: build(committed?.tools, identityOf.tool),
+            mcp: build(committed?.mcps, identityOf.mcp),
+            skill: build(committed?.skills, identityOf.skill),
+        }
+    }, [committed, identityOf])
+
+    const statusForKind = useCallback(
+        (kind: ItemKind) =>
+            (item: unknown): ItemRowStatus | undefined => {
+                if (ITEM_KINDS[kind].draftInvalid(item as Record<string, unknown>)) {
+                    return {tone: "invalid", label: "Incomplete", tooltip: INVALID_ITEM_TIP[kind]}
+                }
+                if (!committed) return undefined
+                const prev = baseMaps[kind].get(identityOf[kind](item))
+                if (prev === undefined)
+                    return {tone: "new", label: "New", tooltip: "Added since the last commit."}
+                if (prev !== stableStringify(stripAgentaMetadataDeep(item)))
+                    return {tone: "edited", label: "Edited", tooltip: "Edited — not yet committed."}
+                return undefined
+            },
+        [committed, baseMaps, identityOf],
+    )
+    const toolStatusFor = useMemo(() => statusForKind("tool"), [statusForKind])
+    const mcpStatusFor = useMemo(() => statusForKind("mcp"), [statusForKind])
+    const skillStatusFor = useMemo(() => statusForKind("skill"), [statusForKind])
+
+    // Section headers: a blocking problem (invalid) outranks unsaved edits (draft).
+    const sectionInvalidTip = (key: string): string | null => {
+        if (key === "model-harness")
+            return mh.hasModelOrHarness && !modelIdFromConfig(config.llm)
+                ? "No model is selected."
+                : null
+        if (key === "tools")
+            return tools.some((t) => ITEM_KINDS.tool.draftInvalid(t as Record<string, unknown>))
+                ? "A tool is missing its name."
+                : null
+        if (key === "mcp")
+            return mcpServers.some((m) => ITEM_KINDS.mcp.draftInvalid(m as Record<string, unknown>))
+                ? "An MCP server is missing a required field."
+                : null
+        if (key === "skills")
+            return skills.some((s) => ITEM_KINDS.skill.draftInvalid(s as Record<string, unknown>))
+                ? "A skill is missing its name."
+                : null
+        return null
+    }
+    const headerIndicator = (
+        key: string,
+    ): {tone: "draft" | "invalid" | "incomplete"; tooltip?: string} | undefined => {
+        const invalid = sectionInvalidTip(key)
+        if (invalid) return {tone: "invalid", tooltip: invalid}
+        if (draftSectionKeys.has(key))
+            return {
+                tone: "draft",
+                tooltip: DRAFT_TIP[key] ?? "Unsaved changes — not yet committed.",
+            }
+        return undefined
+    }
+    const instructionsStatus: ItemRowStatus | undefined = draftSectionKeys.has("instructions")
+        ? {tone: "edited", label: "Edited", tooltip: "Edited — not yet committed."}
+        : undefined
+    const indicatorColor = (tone: "draft" | "invalid" | "incomplete") =>
+        tone === "invalid"
+            ? "var(--ag-colorError)"
+            : tone === "incomplete"
+              ? "var(--ag-colorWarning)"
+              : "var(--ag-colorInfo)"
+
     // Shared props for the tool picker, so the in-body popover and the header quick-add trigger
     // drive the same add flow.
     const toolSelectorProps = {
@@ -279,6 +422,7 @@ export function AgentTemplateControl({
             icon: <Cpu size={16} />,
             title: "Model & harness",
             summary: mh.modelSummary,
+            indicator: headerIndicator("model-harness"),
             defaultOpen: true,
             onOpen: () => openSectionDrawer("model-harness"),
             content: mh.modelHarnessDrawerBody,
@@ -289,6 +433,7 @@ export function AgentTemplateControl({
             icon: <FileText size={16} />,
             title: fieldTitle("instructions", "Instructions"),
             summary: countSummary(1, "file"),
+            indicator: headerIndicator("instructions"),
             // The + is inert until the backend stores multiple instruction files; the section is
             // already a list so it lights up with no rework when that lands.
             extra: !disabled ? (
@@ -310,6 +455,7 @@ export function AgentTemplateControl({
                         filename="AGENTS.md"
                         content={agentsMd ?? ""}
                         onOpen={() => openInstruction("AGENTS.md", agentsMd ?? "")}
+                        status={instructionsStatus}
                     />
                 </div>
             ),
@@ -319,6 +465,7 @@ export function AgentTemplateControl({
             icon: <Wrench size={16} />,
             title: fieldTitle("tools", "Tools"),
             summary: countSummary(tools.length, "tool"),
+            indicator: headerIndicator("tools"),
             extra: !disabled ? (
                 <AgentToolSelectorPopover
                     {...toolSelectorProps}
@@ -343,6 +490,7 @@ export function AgentTemplateControl({
                     removeItem={removeItem}
                     closeEditor={closeEditor}
                     disabled={disabled}
+                    statusFor={toolStatusFor}
                     onOpenIntegration={gatewayTools?.enabled ? openIntegration : undefined}
                     // The empty-state add is the same popover as the header +.
                     emptyAdd={
@@ -359,6 +507,7 @@ export function AgentTemplateControl({
             icon: <Plugs size={16} />,
             title: fieldTitle("mcps", "MCP servers"),
             summary: countSummary(mcpServers.length, "server"),
+            indicator: headerIndicator("mcp"),
             extra: !disabled ? headerAddButton("Add MCP server", handleAddMcpServer) : undefined,
             defaultOpen: mcpServers.length > 0,
             content: (
@@ -369,6 +518,7 @@ export function AgentTemplateControl({
                     removeItem={removeItem}
                     closeEditor={closeEditor}
                     disabled={disabled}
+                    statusFor={mcpStatusFor}
                     emptyAdd={<AddTextLink label="add a server" onClick={handleAddMcpServer} />}
                 />
             ),
@@ -378,6 +528,7 @@ export function AgentTemplateControl({
             icon: <GraduationCap size={16} />,
             title: fieldTitle("skills", "Skills"),
             summary: countSummary(skills.length, "skill"),
+            indicator: headerIndicator("skills"),
             extra: !disabled ? headerAddButton("Add skill", handleAddSkill) : undefined,
             defaultOpen: skills.length > 0,
             content: (
@@ -388,6 +539,7 @@ export function AgentTemplateControl({
                     removeItem={removeItem}
                     closeEditor={closeEditor}
                     disabled={disabled}
+                    statusFor={skillStatusFor}
                     emptyAdd={<AddTextLink label="add a skill" onClick={handleAddSkill} />}
                 />
             ),
@@ -405,6 +557,7 @@ export function AgentTemplateControl({
             key: "advanced",
             icon: <SlidersHorizontal size={16} />,
             title: "Advanced",
+            indicator: headerIndicator("advanced"),
             defaultOpen: false,
             summary: mh.advancedSummary,
             onOpen: () => openSectionDrawer("advanced"),
@@ -417,6 +570,7 @@ export function AgentTemplateControl({
         title: React.ReactNode
         summary?: React.ReactNode
         extra?: React.ReactNode
+        indicator?: {tone: "draft" | "invalid" | "incomplete"; tooltip?: string}
         defaultOpen?: boolean
         onOpen?: () => void
         content: React.ReactNode
@@ -439,7 +593,28 @@ export function AgentTemplateControl({
                         key: s.key,
                         label: (
                             <span className="inline-flex items-center gap-1.5">
-                                {s.icon}
+                                <Tooltip title={s.indicator?.tooltip}>
+                                    <span
+                                        className="relative inline-flex items-center"
+                                        style={
+                                            s.indicator
+                                                ? {
+                                                      color: `color-mix(in srgb, ${indicatorColor(s.indicator.tone)} 45%, var(--ag-colorTextTertiary))`,
+                                                  }
+                                                : undefined
+                                        }
+                                    >
+                                        {s.icon}
+                                        {s.indicator ? (
+                                            <span
+                                                className="absolute -right-1 -top-0.5 h-1.5 w-1.5 rounded-full"
+                                                style={{
+                                                    background: indicatorColor(s.indicator.tone),
+                                                }}
+                                            />
+                                        ) : null}
+                                    </span>
+                                </Tooltip>
                                 {s.title}
                             </span>
                         ),
@@ -462,6 +637,7 @@ export function AgentTemplateControl({
                             title={s.title}
                             summary={s.summary}
                             extra={s.extra}
+                            indicator={s.indicator}
                             onOpen={s.onOpen}
                             collapsible={false}
                             noDivider
@@ -479,6 +655,7 @@ export function AgentTemplateControl({
                         title={s.title}
                         summary={s.summary}
                         extra={s.extra}
+                        indicator={s.indicator}
                         onOpen={s.onOpen}
                         defaultOpen={s.defaultOpen}
                         noDivider={index === sections.length - 1}

--- a/web/packages/agenta-entity-ui/src/DrillInView/SchemaControls/agentTemplate/ConfigItemList.tsx
+++ b/web/packages/agenta-entity-ui/src/DrillInView/SchemaControls/agentTemplate/ConfigItemList.tsx
@@ -7,7 +7,7 @@ import type {ReactNode} from "react"
 import type {ConfigItemView} from "../ConfigItemDrawer"
 
 import {ITEM_KINDS, type ItemKind} from "./itemKinds"
-import {ItemRow} from "./ItemRow"
+import {ItemRow, type ItemRowStatus} from "./ItemRow"
 
 export function ConfigItemList({
     kind,
@@ -17,6 +17,7 @@ export function ConfigItemList({
     closeEditor,
     disabled,
     emptyAdd,
+    statusFor,
 }: {
     kind: ItemKind
     items: unknown[]
@@ -26,6 +27,8 @@ export function ConfigItemList({
     disabled?: boolean
     /** The add trigger shown in the empty state (a popover for tools, a text link otherwise). */
     emptyAdd: ReactNode
+    /** Per-row draft/validation status (unsaved edits, missing fields). */
+    statusFor?: (item: unknown, index: number) => ItemRowStatus | undefined
 }) {
     const def = ITEM_KINDS[kind]
     if (items.length > 0) {
@@ -42,6 +45,7 @@ export function ConfigItemList({
                         }}
                         // Read-only items (static `__ag__*` skills) can't be removed and open disabled.
                         disabled={disabled || def.isReadOnly(item)}
+                        status={statusFor?.(item, index)}
                     />
                 ))}
             </div>

--- a/web/packages/agenta-entity-ui/src/DrillInView/SchemaControls/agentTemplate/ItemRow.tsx
+++ b/web/packages/agenta-entity-ui/src/DrillInView/SchemaControls/agentTemplate/ItemRow.tsx
@@ -3,11 +3,54 @@
  * tool/MCP/skill row, and the richer instructions-file row. All are dumb — they render an
  * {@link ItemDescriptor} and call back on open/remove; the section owners hold the state.
  */
+import {type ReactNode} from "react"
+
 import {cn} from "@agenta/ui/styles"
 import {CaretRight, Trash} from "@phosphor-icons/react"
-import {Tag, Typography} from "antd"
+import {Tag, Tooltip, Typography} from "antd"
 
 import {describeInstruction, type ItemDescriptor} from "./itemDescriptors"
+
+/**
+ * Draft/validation status for a config-item row: tints the row border and shows a tag.
+ * `"new"`/`"edited"` mark uncommitted changes; `"invalid"`/`"incomplete"` mark a blocking gap.
+ */
+export type ItemRowStatusTone = "new" | "edited" | "invalid" | "incomplete"
+export interface ItemRowStatus {
+    tone: ItemRowStatusTone
+    label: string
+    tooltip?: ReactNode
+}
+
+const STATUS_BORDER: Record<ItemRowStatusTone, string> = {
+    new: "var(--ag-colorSuccessBorder)",
+    edited: "var(--ag-colorInfoBorder)",
+    invalid: "var(--ag-colorErrorBorder)",
+    incomplete: "var(--ag-colorWarningBorder)",
+}
+const STATUS_TAG_COLOR: Record<ItemRowStatusTone, string> = {
+    new: "green",
+    edited: "blue",
+    invalid: "red",
+    incomplete: "gold",
+}
+// Solid accent for borderless child rows (an inset left bar, so rounded corners survive).
+const STATUS_ACCENT: Record<ItemRowStatusTone, string> = {
+    new: "var(--ag-colorSuccess)",
+    edited: "var(--ag-colorInfo)",
+    invalid: "var(--ag-colorError)",
+    incomplete: "var(--ag-colorWarning)",
+}
+
+function StatusTag({status}: {status: ItemRowStatus}) {
+    return (
+        <Tooltip title={status.tooltip}>
+            <Tag color={STATUS_TAG_COLOR[status.tone]} className="m-0 text-[11px]">
+                {status.label}
+            </Tag>
+        </Tooltip>
+    )
+}
 
 /** Colored avatar square (icon or monogram) at the start of a config-item row. */
 export function ItemAvatar({descriptor}: {descriptor: ItemDescriptor}) {
@@ -35,12 +78,14 @@ export function ItemRow({
     onRemove,
     disabled,
     locked,
+    status,
 }: {
     descriptor: ItemDescriptor
     onEdit?: () => void
     onRemove?: () => void
     disabled?: boolean
     locked?: boolean
+    status?: ItemRowStatus
 }) {
     const interactive = Boolean(onEdit) && !locked
     return (
@@ -58,9 +103,13 @@ export function ItemRow({
                       }
                     : undefined
             }
+            style={status ? {borderColor: STATUS_BORDER[status.tone]} : undefined}
             className={cn(
                 "group flex items-center gap-2.5 rounded border border-solid border-[var(--ag-c-EAEFF5,#eaeff5)] px-3 py-2 transition-colors",
-                interactive && "cursor-pointer hover:border-[var(--ag-c-97A4B0,#97a4b0)]",
+                interactive &&
+                    !status &&
+                    "cursor-pointer hover:border-[var(--ag-c-97A4B0,#97a4b0)]",
+                interactive && status && "cursor-pointer",
                 locked && "bg-[var(--ant-color-fill-quaternary)] opacity-70",
             )}
         >
@@ -83,6 +132,7 @@ export function ItemRow({
                 ) : null}
             </div>
             <div className="flex shrink-0 items-center gap-1.5">
+                {status ? <StatusTag status={status} /> : null}
                 {descriptor.tags.map((tag) => (
                     <Tag key={tag} className="m-0 text-[11px]">
                         {tag}
@@ -121,11 +171,13 @@ export function ItemChildRow({
     onEdit,
     onRemove,
     disabled,
+    status,
 }: {
     descriptor: ItemDescriptor
     onEdit: () => void
     onRemove?: () => void
     disabled?: boolean
+    status?: ItemRowStatus
 }) {
     return (
         <div
@@ -139,6 +191,7 @@ export function ItemChildRow({
                     onEdit()
                 }
             }}
+            style={status ? {boxShadow: `inset 2px 0 0 ${STATUS_ACCENT[status.tone]}`} : undefined}
             className="group flex cursor-pointer items-center gap-2.5 rounded px-2.5 py-1.5 transition-colors hover:bg-[var(--ag-colorFillSecondary)]"
         >
             <div className="min-w-0 flex-1">
@@ -163,6 +216,7 @@ export function ItemChildRow({
                 onClick={(e) => e.stopPropagation()}
                 role="presentation"
             >
+                {status ? <StatusTag status={status} /> : null}
                 {onRemove && !disabled ? (
                     <button
                         type="button"
@@ -191,10 +245,12 @@ export function InstructionsFileRow({
     filename,
     content,
     onOpen,
+    status,
 }: {
     filename: string
     content: string
     onOpen: () => void
+    status?: ItemRowStatus
 }) {
     const descriptor = describeInstruction(filename, content)
     const wordCount = content.trim().split(/\s+/).filter(Boolean).length
@@ -213,7 +269,11 @@ export function InstructionsFileRow({
                     onOpen()
                 }
             }}
-            className="group flex cursor-pointer items-start gap-3 rounded-lg border border-solid border-[var(--ag-c-EAEFF5,#eaeff5)] px-3 py-2.5 transition-colors hover:border-[var(--ag-c-97A4B0,#97a4b0)]"
+            style={status ? {borderColor: STATUS_BORDER[status.tone]} : undefined}
+            className={cn(
+                "group flex cursor-pointer items-start gap-3 rounded-lg border border-solid border-[var(--ag-c-EAEFF5,#eaeff5)] px-3 py-2.5 transition-colors",
+                !status && "hover:border-[var(--ag-c-97A4B0,#97a4b0)]",
+            )}
         >
             <ItemAvatar descriptor={descriptor} />
             <div className="min-w-0 flex-1">
@@ -226,6 +286,7 @@ export function InstructionsFileRow({
                     <Typography.Text type="secondary" className="shrink-0 text-[11px]">
                         {meta}
                     </Typography.Text>
+                    {status ? <StatusTag status={status} /> : null}
                 </div>
                 {/* `descriptor.description` is the stripped-markdown preview (or "Empty file");
                     clamp to 2 lines so long instructions get a real "…" rather than a hard cut. */}

--- a/web/packages/agenta-entity-ui/src/DrillInView/SchemaControls/agentTemplate/ToolManagementList.tsx
+++ b/web/packages/agenta-entity-ui/src/DrillInView/SchemaControls/agentTemplate/ToolManagementList.tsx
@@ -23,7 +23,10 @@ import {parseGatewayFunctionName} from "../toolUtils"
 
 import {describeTool, isFunctionTool, toolName} from "./itemDescriptors"
 import {ITEM_KINDS} from "./itemKinds"
-import {ItemChildRow, ItemRow} from "./ItemRow"
+import {ItemChildRow, ItemRow, type ItemRowStatus} from "./ItemRow"
+
+/** Per-tool draft/validation status, keyed by the tool's index in the flat `tools` array. */
+type ToolStatusFor = (item: unknown, index: number) => ItemRowStatus | undefined
 
 // Persisted per-agent expand state for connected-app groups (key = `${entityId}:${integrationKey}`).
 const toolGroupsExpandedAtom = atomWithStorage<Record<string, boolean>>(
@@ -60,6 +63,8 @@ export interface ToolManagementListProps {
     onOpenIntegration?: (integrationKey?: string) => void
     /** Add trigger shown in the empty state (the tool selector popover). */
     emptyAdd: ReactNode
+    /** Per-tool draft/validation status (unsaved edits, missing fields). */
+    statusFor?: ToolStatusFor
 }
 
 /** A flat, headed sub-section of bordered item rows (references / definitions / built-in). */
@@ -70,6 +75,7 @@ function FlatToolSection({
     removeItem,
     closeEditor,
     disabled,
+    statusFor,
 }: {
     label: string
     entries: IndexedTool[]
@@ -77,6 +83,7 @@ function FlatToolSection({
     removeItem: ToolManagementListProps["removeItem"]
     closeEditor: () => void
     disabled?: boolean
+    statusFor?: ToolStatusFor
 }) {
     if (entries.length === 0) return null
     return (
@@ -93,6 +100,7 @@ function FlatToolSection({
                             closeEditor()
                         }}
                         disabled={disabled || ITEM_KINDS.tool.isReadOnly(item)}
+                        status={statusFor?.(item, index)}
                     />
                 ))}
             </div>
@@ -113,6 +121,7 @@ function GatewayGroups({
     closeEditor,
     disabled,
     onOpenIntegration,
+    statusFor,
 }: {
     groups: ToolProviderGroup[]
     totalCount: number
@@ -122,6 +131,7 @@ function GatewayGroups({
     closeEditor: () => void
     disabled?: boolean
     onOpenIntegration?: (integrationKey?: string) => void
+    statusFor?: ToolStatusFor
 }) {
     const {integrations} = useToolCatalogIntegrations()
     const [expanded, setExpanded] = useAtom(toolGroupsExpandedAtom)
@@ -196,6 +206,7 @@ function GatewayGroups({
                                     closeEditor()
                                 }}
                                 disabled={disabled}
+                                status={statusFor?.(item, index)}
                             />
                         ))}
                     </CollapsibleProviderGroup>
@@ -214,6 +225,7 @@ export function ToolManagementList({
     disabled,
     onOpenIntegration,
     emptyAdd,
+    statusFor,
 }: ToolManagementListProps) {
     // Partition by kind, preserving each tool's original index (edit/remove address the flat array).
     // Uses only the tool object — no catalog needed here.
@@ -270,6 +282,7 @@ export function ToolManagementList({
                     closeEditor={closeEditor}
                     disabled={disabled}
                     onOpenIntegration={onOpenIntegration}
+                    statusFor={statusFor}
                 />
             )}
             <FlatToolSection
@@ -279,6 +292,7 @@ export function ToolManagementList({
                 removeItem={removeItem}
                 closeEditor={closeEditor}
                 disabled={disabled}
+                statusFor={statusFor}
             />
             <FlatToolSection
                 label="Tool definitions"
@@ -287,6 +301,7 @@ export function ToolManagementList({
                 removeItem={removeItem}
                 closeEditor={closeEditor}
                 disabled={disabled}
+                statusFor={statusFor}
             />
             <FlatToolSection
                 label="Built-in"
@@ -295,6 +310,7 @@ export function ToolManagementList({
                 removeItem={removeItem}
                 closeEditor={closeEditor}
                 disabled={disabled}
+                statusFor={statusFor}
             />
         </div>
     )

--- a/web/packages/agenta-entity-ui/src/adapters/variantAdapters.ts
+++ b/web/packages/agenta-entity-ui/src/adapters/variantAdapters.ts
@@ -11,7 +11,7 @@ import {syncPromptInputKeysInParameters} from "@agenta/entities/runnable"
 import {isLocalDraftId, getVersionLabel, formatLocalDraftLabel} from "@agenta/entities/shared"
 import {workflowMolecule, type Workflow} from "@agenta/entities/workflow"
 import {classifyAgentChanges, buildCommitSummaryMessage} from "@agenta/entities/workflow/commitDiff"
-import {stripAgentaMetadataDeep} from "@agenta/shared/utils"
+import {stripAgentaMetadataDeep, stripEmptyCollectionsDeep} from "@agenta/shared/utils"
 import {atom} from "jotai"
 
 import {
@@ -64,7 +64,9 @@ function buildGenericCommitContext(
     const currentVersion = version ?? 0
     const targetVersion = currentVersion + 1
 
-    // Diff the whole data object; parameters keep metadata-strip + input-key sync.
+    // Diff the whole data object; parameters keep metadata-strip + input-key sync. Empty
+    // collections are dropped so an add-then-remove (`skills: []` vs an absent key) doesn't read
+    // as a change — matching the semantic classifier, which already normalizes empty to absent.
     const buildSide = (data: Record<string, unknown> | null, syncParams: boolean) => {
         const d = data ?? {}
         const params = (d.parameters as Record<string, unknown> | null) ?? {}
@@ -72,7 +74,10 @@ function buildGenericCommitContext(
             ? ((syncPromptInputKeysInParameters(params) as Record<string, unknown> | null) ??
               params)
             : params
-        return {...d, parameters: stripAgentaMetadataDeep(normalizedParams)}
+        return {
+            ...d,
+            parameters: stripEmptyCollectionsDeep(stripAgentaMetadataDeep(normalizedParams)),
+        }
     }
 
     const remoteSide = buildSide(remoteData, false)

--- a/web/packages/agenta-entity-ui/src/adapters/variantAdapters.ts
+++ b/web/packages/agenta-entity-ui/src/adapters/variantAdapters.ts
@@ -83,16 +83,12 @@ function buildGenericCommitContext(
 
     // Semantic, section-grouped diff for agent/LLM configs. Returns [] when nothing
     // recognized changed (e.g. non-agent workflows) → we fall back to the coarse summary.
-    // Try `parameters` first; agent-template configs may instead live at the data root.
-    let sections = hasDiff
+    const sections = hasDiff
         ? classifyAgentChanges(
               (localSide as Record<string, unknown>).parameters,
               (remoteSide as Record<string, unknown>).parameters,
           )
         : []
-    if (hasDiff && !sections.length) {
-        sections = classifyAgentChanges(localSide, remoteSide)
-    }
     const suggestedMessage = sections.length ? buildCommitSummaryMessage(sections) : undefined
 
     const descriptions: string[] = []

--- a/web/packages/agenta-entity-ui/src/adapters/variantAdapters.ts
+++ b/web/packages/agenta-entity-ui/src/adapters/variantAdapters.ts
@@ -10,6 +10,7 @@
 import {syncPromptInputKeysInParameters} from "@agenta/entities/runnable"
 import {isLocalDraftId, getVersionLabel, formatLocalDraftLabel} from "@agenta/entities/shared"
 import {workflowMolecule, type Workflow} from "@agenta/entities/workflow"
+import {classifyAgentChanges, buildCommitSummaryMessage} from "@agenta/entities/workflow/commitDiff"
 import {stripAgentaMetadataDeep} from "@agenta/shared/utils"
 import {atom} from "jotai"
 
@@ -74,9 +75,25 @@ function buildGenericCommitContext(
         return {...d, parameters: stripAgentaMetadataDeep(normalizedParams)}
     }
 
-    const original = stableStringify(buildSide(remoteData, false))
-    const modified = stableStringify(buildSide(localData, true))
+    const remoteSide = buildSide(remoteData, false)
+    const localSide = buildSide(localData, true)
+    const original = stableStringify(remoteSide)
+    const modified = stableStringify(localSide)
     const hasDiff = original !== modified
+
+    // Semantic, section-grouped diff for agent/LLM configs. Returns [] when nothing
+    // recognized changed (e.g. non-agent workflows) → we fall back to the coarse summary.
+    // Try `parameters` first; agent-template configs may instead live at the data root.
+    let sections = hasDiff
+        ? classifyAgentChanges(
+              (localSide as Record<string, unknown>).parameters,
+              (remoteSide as Record<string, unknown>).parameters,
+          )
+        : []
+    if (hasDiff && !sections.length) {
+        sections = classifyAgentChanges(localSide, remoteSide)
+    }
+    const suggestedMessage = sections.length ? buildCommitSummaryMessage(sections) : undefined
 
     const descriptions: string[] = []
     if (hasDiff) descriptions.push("Configuration modified")
@@ -98,6 +115,8 @@ function buildGenericCommitContext(
                   }
                 : undefined,
         diffData: {original, modified, language: "json"},
+        sections: sections.length ? sections : undefined,
+        suggestedMessage,
     }
 }
 

--- a/web/packages/agenta-entity-ui/src/drawers/shared/SectionRail.tsx
+++ b/web/packages/agenta-entity-ui/src/drawers/shared/SectionRail.tsx
@@ -47,14 +47,14 @@ export function SectionRail({
                             type="text"
                             block
                             onClick={() => onChange(item.value)}
-                            className={`!h-8 !px-2.5 !text-xs ${
+                            className={`!h-8 !rounded-md !px-2.5 !text-xs transition-colors ${
                                 item.count != null
                                     ? "!flex !items-center !justify-between"
                                     : "!justify-start"
                             } ${
                                 active
                                     ? "!bg-[var(--ag-colorPrimaryBg)] !font-medium !text-[var(--ag-colorPrimary)]"
-                                    : "!text-[var(--ag-colorTextSecondary)]"
+                                    : "!text-[var(--ag-colorTextSecondary)] hover:!bg-[var(--ag-colorFillTertiary)] hover:!text-[var(--ag-colorText)]"
                             }`}
                         >
                             <span className="truncate">{item.label}</span>
@@ -65,7 +65,7 @@ export function SectionRail({
                     )
                 })}
             </div>
-            <div className="flex min-w-0 flex-1 flex-col gap-1.5 border-0 border-l border-solid border-[var(--ag-colorBorderSecondary)] pl-3">
+            <div className="flex min-w-0 flex-1 flex-col gap-1.5 border-0 border-l border-solid border-[var(--ag-colorBorder)] pl-4">
                 {children}
             </div>
         </div>

--- a/web/packages/agenta-entity-ui/src/index.ts
+++ b/web/packages/agenta-entity-ui/src/index.ts
@@ -290,6 +290,7 @@ export {
     type CommitSubmitResult,
     type CommitModeOption,
     type CommitCreateFieldsConfig,
+    type CommitDeployOption,
     // Commit modal state atoms
     commitModalOpenAtom,
     commitModalEntityAtom,

--- a/web/packages/agenta-entity-ui/src/modals/commit/components/EntityCommitContent.tsx
+++ b/web/packages/agenta-entity-ui/src/modals/commit/components/EntityCommitContent.tsx
@@ -7,6 +7,7 @@
 
 import {useState, useEffect, useRef} from "react"
 
+import {workflowMolecule} from "@agenta/entities/workflow"
 import {
     formatCount,
     generateSlugWithExistingSuffix,
@@ -23,7 +24,9 @@ import {ArrowClockwise, WarningCircle} from "@phosphor-icons/react"
 import {Input, Alert, Typography, Radio, Button, Tag} from "antd"
 import {useAtomValue, useSetAtom} from "jotai"
 
+import {SectionRail} from "../../../drawers/shared/SectionRail"
 import {
+    commitModalEntityAtom,
     commitModalEntityNameAtom,
     commitModalOriginalEntityNameAtom,
     commitModalEntitySlugAtom,
@@ -40,6 +43,8 @@ import {
     setCommitSlugEditingAtom,
     setCommitSlugFieldErrorAtom,
 } from "../state"
+
+import AgentChangesSummary from "./changes/AgentChangesSummary"
 
 // Lazy load DiffView to avoid bundling Lexical editor in _app chunk
 // const DiffView = dynamic(() => import("@agenta/ui/editor").then((mod) => ({default: mod.DiffView})))
@@ -62,6 +67,8 @@ export interface EntityCommitContentProps {
     entityNameEditable?: boolean
     /** Label for the editable entity name field. Defaults to "Name". */
     entityNameLabel?: string
+    /** Footer rendered inside the right pane (agent two-pane layout). */
+    footerSlot?: React.ReactNode
 }
 
 /**
@@ -87,6 +94,7 @@ export function EntityCommitContent({
     modeLabel,
     entityNameEditable = false,
     entityNameLabel = "Name",
+    footerSlot,
 }: EntityCommitContentProps) {
     const entityName = useAtomValue(commitModalEntityNameAtom)
     const originalEntityName = useAtomValue(commitModalOriginalEntityNameAtom)
@@ -96,6 +104,9 @@ export function EntityCommitContent({
     const canCommit = useAtomValue(commitModalCanCommitAtom)
     const context = useAtomValue(commitModalContextAtom)
     const actionLabel = useAtomValue(commitModalActionLabelAtom)
+    const commitEntity = useAtomValue(commitModalEntityAtom)
+    // App/artifact name (e.g. "sunday-agent") — clearer than the variant name in the agent title.
+    const appName = useAtomValue(workflowMolecule.selectors.artifactName(commitEntity?.id ?? ""))
     const slugEditing = useAtomValue(commitModalSlugEditingAtom)
     const slugFieldError = useAtomValue(commitModalSlugFieldErrorAtom)
     const setMessage = useSetAtom(setCommitMessageAtom)
@@ -198,6 +209,17 @@ export function EntityCommitContent({
         return () => cancelAnimationFrame(id)
     }, [context?.diffData?.original, context?.diffData?.modified])
 
+    // Pre-fill the commit message with the auto-generated summary (agent workflows),
+    // without ever clobbering what the user typed.
+    const suggestedMessage = context?.suggestedMessage
+    const suggestionAppliedRef = useRef<string | null>(null)
+    useEffect(() => {
+        if (!suggestedMessage || message.trim().length > 0) return
+        if (suggestionAppliedRef.current === suggestedMessage) return
+        suggestionAppliedRef.current = suggestedMessage
+        setMessage(suggestedMessage)
+    }, [suggestedMessage, message, setMessage])
+
     // Build changes description from context
     const changesDescription: string[] = []
     if (context?.changesSummary) {
@@ -228,6 +250,10 @@ export function EntityCommitContent({
     // Check if diff data is available
     const hasDiffData = context?.diffData?.original && context?.diffData?.modified
 
+    // Agent/LLM commits get the calm "Statement" left column + section summary.
+    const isAgentCommit = !!context?.sections?.length
+    const hasVariantMode = !!commitModes?.some((m) => m.id === "variant")
+
     // Calculate total changes for diff header (testcases + columns)
     const totalChanges =
         (context?.changesSummary?.modifiedCount ?? 0) +
@@ -237,58 +263,191 @@ export function EntityCommitContent({
         (context?.changesSummary?.renamedColumns ?? 0) +
         (context?.changesSummary?.deletedColumns ?? 0)
 
+    const isAgentTwoPane = isAgentCommit && !!hasDiffData
+
+    // Agent commits render the variant name/slug input inside the rail's "variant"
+    // content so the "necessary info" sits with the selected action, not far below it.
+    const nameEditorInRail =
+        entityNameEditable &&
+        isAgentCommit &&
+        actionLabel === "Commit" &&
+        hasVariantMode &&
+        (selectedMode ?? "version") === "variant"
+
+    const nameSlugEditor = (
+        <div className="flex flex-col gap-3">
+            <div className="flex flex-col gap-2">
+                <label htmlFor="entity-name" className="font-medium text-gray-700">
+                    {entityNameLabel}
+                </label>
+                <Input
+                    id="entity-name"
+                    value={entityName}
+                    onChange={(e) => setEntityName(e.target.value)}
+                    placeholder="Enter a name..."
+                    autoFocus
+                    className={isAgentCommit ? "!bg-[var(--ag-colorFillQuaternary)]" : undefined}
+                />
+            </div>
+
+            {entitySlug !== null && (
+                <div className="flex flex-col gap-1">
+                    {slugEditing ? (
+                        <>
+                            <label htmlFor="entity-slug" className="font-medium mb-1">
+                                Slug
+                            </label>
+                            <Input
+                                id="entity-slug"
+                                value={entitySlug}
+                                onChange={(e) => handleSlugInputChange(e.target.value)}
+                                status={slugFieldError || slugValidationError ? "error" : undefined}
+                                autoFocus
+                                className={
+                                    isAgentCommit
+                                        ? "!bg-[var(--ag-colorFillQuaternary)] [&_.ant-input]:!bg-transparent"
+                                        : undefined
+                                }
+                                suffix={
+                                    <Button
+                                        type="text"
+                                        size="small"
+                                        icon={<ArrowClockwise size={14} />}
+                                        onClick={handleRegenerate}
+                                        title="Regenerate random suffix"
+                                    />
+                                }
+                            />
+                            {(slugFieldError || slugValidationError) && (
+                                <div className="mt-0.5 flex items-start gap-1 text-[var(--ag-c-FF4D4F)]">
+                                    <WarningCircle size={16} className="mt-0.5 shrink-0" />
+                                    <span>{slugFieldError ?? slugValidationError}</span>
+                                </div>
+                            )}
+                            {!slugFieldError && !slugValidationError && (
+                                <Text className={cn(textColors.tertiary)}>
+                                    Edit freely - use the regenerate button to add a random suffix
+                                    back.
+                                </Text>
+                            )}
+                        </>
+                    ) : (
+                        <div className="flex min-w-0 items-center gap-2">
+                            <Text className="shrink-0 font-medium">Slug:</Text>
+                            <Tag
+                                className="min-w-0 max-w-[min(220px,calc(100%-88px))] truncate bg-gray-100 font-mono text-gray-500"
+                                title={entitySlug}
+                            >
+                                {entitySlug}
+                            </Tag>
+                            <Button
+                                type="link"
+                                size="small"
+                                className="shrink-0"
+                                onClick={handleEditClick}
+                            >
+                                Edit
+                            </Button>
+                        </div>
+                    )}
+                </div>
+            )}
+        </div>
+    )
+
     return (
         <div
             className={cn(
-                "flex gap-4 overflow-hidden",
-                hasDiffData ? "flex-row h-full" : "flex-col",
+                "flex overflow-hidden",
+                hasDiffData ? "flex-row" : "flex-col gap-4",
+                hasDiffData && !isAgentCommit && "h-full gap-4",
             )}
+            style={isAgentTwoPane ? {height: "min(450px, 72vh)"} : undefined}
         >
-            {/* Form section */}
+            {/* Form section — agent two-pane: sits on the RIGHT and holds the action footer. */}
             <div
                 className={cn(
                     "flex flex-col gap-4",
-                    hasDiffData ? "w-[320px] shrink-0 overflow-y-auto" : "w-full",
+                    hasDiffData
+                        ? isAgentCommit
+                            ? "order-2 w-[400px] shrink-0 overflow-hidden border-l border-[var(--ag-colorBorderSecondary)] px-6 py-5 min-h-0"
+                            : "w-[320px] shrink-0 overflow-y-auto"
+                        : "w-full",
                 )}
             >
-                {/* Version info panel — hidden when actionLabel is not "Commit" (e.g., "Create")
-                    since there's no existing entity to show version transitions for */}
-                {context?.versionInfo && actionLabel === "Commit" && (
-                    <div className="rounded-lg border border-zinc-2 bg-zinc-1 p-3">
-                        <Text className={textColors.secondary}>
-                            {selectedMode === "variant"
-                                ? "This will create a new variant from "
-                                : "This will create a new revision of "}
-                            <span className="font-medium">{originalEntityName}</span>.
-                        </Text>
-                        <div className="mt-2 flex items-center gap-2 min-w-0">
-                            <span className="flex items-center gap-1 min-w-0">
-                                <span
-                                    className={cn("truncate", textColors.secondary)}
-                                    title={originalEntityName}
-                                >
-                                    {originalEntityName}
-                                </span>
-                                <VersionBadge
-                                    version={context.versionInfo.currentVersion}
-                                    variant="chip"
-                                    className="shrink-0"
-                                />
-                            </span>
-                            <span className={cn("shrink-0", textColors.tertiary)}>→</span>
-                            {selectedMode === "variant" ? (
-                                <span className="flex items-center gap-1 min-w-0">
-                                    <span
-                                        className="truncate text-blue-7"
-                                        title={modeLabel || entityName || "new variant"}
+                {isAgentCommit ? (
+                    <Text className="shrink-0 text-base font-semibold">
+                        {actionLabel} {appName || originalEntityName}
+                    </Text>
+                ) : null}
+
+                {/* Body scrolls so a tall variant form can't squeeze the message textarea;
+                    the title above and footer below stay pinned. */}
+                <div
+                    className={cn(
+                        "flex flex-col gap-4",
+                        isAgentCommit && "min-h-0 flex-1 overflow-y-auto",
+                    )}
+                >
+                    {/* Agent commits: pick where the save lands (rail) + that action's summary (content). */}
+                    {context?.versionInfo && actionLabel === "Commit" && isAgentCommit && (
+                        <SectionRail
+                            items={[
+                                {value: "version", label: "New version"},
+                                ...(hasVariantMode
+                                    ? [{value: "variant", label: "New variant"}]
+                                    : []),
+                            ]}
+                            value={selectedMode ?? "version"}
+                            onChange={(v) => onModeChange?.(v)}
+                            railWidth="w-[108px]"
+                        >
+                            {(selectedMode ?? "version") === "variant" ? (
+                                <div className="flex flex-col gap-3">
+                                    <Text
+                                        className={cn(
+                                            "text-xs leading-relaxed",
+                                            textColors.secondary,
+                                        )}
                                     >
-                                        {modeLabel || entityName || "new variant"}
-                                    </span>
-                                    <span className="shrink-0 rounded bg-blue-1 px-1.5 py-0.5 text-xs font-medium text-blue-7">
-                                        v1
-                                    </span>
-                                </span>
+                                        Creates a separate variant.{" "}
+                                        <span className="font-medium text-[var(--ag-colorText)]">
+                                            {appName || originalEntityName}
+                                        </span>{" "}
+                                        stays on v{context.versionInfo.currentVersion}.
+                                    </Text>
+                                    {nameEditorInRail ? (
+                                        <div className="border-t border-[var(--ag-colorBorderSecondary)] pt-3">
+                                            {nameSlugEditor}
+                                        </div>
+                                    ) : null}
+                                </div>
                             ) : (
+                                <Text
+                                    className={cn("text-xs leading-relaxed", textColors.secondary)}
+                                >
+                                    Saves as{" "}
+                                    <span className="font-medium text-[var(--ag-colorText)]">
+                                        version {context.versionInfo.targetVersion}
+                                    </span>
+                                    . Everyone using {appName || originalEntityName} gets your
+                                    changes.
+                                </Text>
+                            )}
+                        </SectionRail>
+                    )}
+
+                    {/* Version info panel — hidden when actionLabel is not "Commit" (e.g., "Create")
+                    since there's no existing entity to show version transitions for */}
+                    {context?.versionInfo && actionLabel === "Commit" && !isAgentCommit && (
+                        <div className="rounded-lg border border-zinc-2 bg-zinc-1 p-3">
+                            <Text className={textColors.secondary}>
+                                {selectedMode === "variant"
+                                    ? "This will create a new variant from "
+                                    : "This will create a new revision of "}
+                                <span className="font-medium">{originalEntityName}</span>.
+                            </Text>
+                            <div className="mt-2 flex items-center gap-2 min-w-0">
                                 <span className="flex items-center gap-1 min-w-0">
                                     <span
                                         className={cn("truncate", textColors.secondary)}
@@ -296,162 +455,146 @@ export function EntityCommitContent({
                                     >
                                         {originalEntityName}
                                     </span>
-                                    <span className="shrink-0 rounded bg-blue-1 px-1.5 py-0.5 text-xs font-medium text-blue-7">
-                                        v{context.versionInfo.targetVersion}
-                                    </span>
+                                    <VersionBadge
+                                        version={context.versionInfo.currentVersion}
+                                        variant="chip"
+                                        className="shrink-0"
+                                    />
                                 </span>
-                            )}
-                        </div>
-                        {changesDescription.length > 0 && (
-                            <div className={cn("mt-2 text-xs", textColors.tertiary)}>
-                                Changes: {changesDescription.join(", ")}
-                            </div>
-                        )}
-                    </div>
-                )}
-
-                {/* Cannot commit warning */}
-                {!canCommit && (
-                    <Alert
-                        type="warning"
-                        title="This entity cannot be committed"
-                        description="Check that there are changes to commit and the entity is in a valid state."
-                        showIcon
-                    />
-                )}
-
-                {/* Commit mode selector (optional) */}
-                {commitModes && commitModes.length > 0 && (
-                    <div className="flex flex-col gap-2">
-                        <label htmlFor="commit-mode" className="font-medium text-gray-700">
-                            Save mode
-                        </label>
-                        <Radio.Group
-                            id="commit-mode"
-                            value={selectedMode}
-                            onChange={(e) => onModeChange?.(e.target.value)}
-                        >
-                            {commitModes.map((mode) => (
-                                <Radio key={mode.id} value={mode.id}>
-                                    {mode.label}
-                                </Radio>
-                            ))}
-                        </Radio.Group>
-                    </div>
-                )}
-
-                {/* Entity name — editable input for Create flows */}
-                {entityNameEditable && (
-                    <div className="flex flex-col gap-3">
-                        <div className="flex flex-col gap-2">
-                            <label htmlFor="entity-name" className="font-medium text-gray-700">
-                                {entityNameLabel}
-                            </label>
-                            <Input
-                                id="entity-name"
-                                value={entityName}
-                                onChange={(e) => setEntityName(e.target.value)}
-                                placeholder="Enter a name..."
-                                autoFocus
-                            />
-                        </div>
-
-                        {entitySlug !== null && (
-                            <div className="flex flex-col gap-1">
-                                {slugEditing ? (
-                                    <>
-                                        <label htmlFor="entity-slug" className="font-medium mb-1">
-                                            Slug
-                                        </label>
-                                        <Input
-                                            id="entity-slug"
-                                            value={entitySlug}
-                                            onChange={(e) => handleSlugInputChange(e.target.value)}
-                                            status={
-                                                slugFieldError || slugValidationError
-                                                    ? "error"
-                                                    : undefined
-                                            }
-                                            autoFocus
-                                            suffix={
-                                                <Button
-                                                    type="text"
-                                                    size="small"
-                                                    icon={<ArrowClockwise size={14} />}
-                                                    onClick={handleRegenerate}
-                                                    title="Regenerate random suffix"
-                                                />
-                                            }
-                                        />
-                                        {(slugFieldError || slugValidationError) && (
-                                            <div className="mt-0.5 flex items-start gap-1 text-[var(--ag-c-FF4D4F)]">
-                                                <WarningCircle
-                                                    size={16}
-                                                    className="mt-0.5 shrink-0"
-                                                />
-                                                <span>{slugFieldError ?? slugValidationError}</span>
-                                            </div>
-                                        )}
-                                        {!slugFieldError && !slugValidationError && (
-                                            <Text className={cn(textColors.tertiary)}>
-                                                Edit freely - use the regenerate button to add a
-                                                random suffix back.
-                                            </Text>
-                                        )}
-                                    </>
+                                <span className={cn("shrink-0", textColors.tertiary)}>→</span>
+                                {selectedMode === "variant" ? (
+                                    <span className="flex items-center gap-1 min-w-0">
+                                        <span
+                                            className="truncate text-blue-7"
+                                            title={modeLabel || entityName || "new variant"}
+                                        >
+                                            {modeLabel || entityName || "new variant"}
+                                        </span>
+                                        <span className="shrink-0 rounded bg-blue-1 px-1.5 py-0.5 text-xs font-medium text-blue-7">
+                                            v1
+                                        </span>
+                                    </span>
                                 ) : (
-                                    <div className="flex min-w-0 items-center gap-2">
-                                        <Text className="shrink-0 font-medium">Slug:</Text>
-                                        <Tag
-                                            className="min-w-0 max-w-[min(220px,calc(100%-88px))] truncate bg-gray-100 font-mono text-gray-500"
-                                            title={entitySlug}
+                                    <span className="flex items-center gap-1 min-w-0">
+                                        <span
+                                            className={cn("truncate", textColors.secondary)}
+                                            title={originalEntityName}
                                         >
-                                            {entitySlug}
-                                        </Tag>
-                                        <Button
-                                            type="link"
-                                            size="small"
-                                            className="shrink-0"
-                                            onClick={handleEditClick}
-                                        >
-                                            Edit
-                                        </Button>
-                                    </div>
+                                            {originalEntityName}
+                                        </span>
+                                        <span className="shrink-0 rounded bg-blue-1 px-1.5 py-0.5 text-xs font-medium text-blue-7">
+                                            v{context.versionInfo.targetVersion}
+                                        </span>
+                                    </span>
                                 )}
                             </div>
+                            {changesDescription.length > 0 && (
+                                <div className={cn("mt-2 text-xs", textColors.tertiary)}>
+                                    Changes: {changesDescription.join(", ")}
+                                </div>
+                            )}
+                        </div>
+                    )}
+
+                    {/* Cannot commit warning */}
+                    {!canCommit && (
+                        <Alert
+                            type="warning"
+                            title="This entity cannot be committed"
+                            description="Check that there are changes to commit and the entity is in a valid state."
+                            showIcon
+                        />
+                    )}
+
+                    {/* Commit mode selector (optional) — agent commits use the statement toggle. */}
+                    {!isAgentCommit && commitModes && commitModes.length > 0 && (
+                        <div className="flex flex-col gap-2">
+                            <label htmlFor="commit-mode" className="font-medium text-gray-700">
+                                Save mode
+                            </label>
+                            <Radio.Group
+                                id="commit-mode"
+                                value={selectedMode}
+                                onChange={(e) => onModeChange?.(e.target.value)}
+                            >
+                                {commitModes.map((mode) => (
+                                    <Radio key={mode.id} value={mode.id}>
+                                        {mode.label}
+                                    </Radio>
+                                ))}
+                            </Radio.Group>
+                        </div>
+                    )}
+
+                    {/* Entity name — editable input for Create flows. Agent variant commits
+                    render this inside the rail (nameEditorInRail) instead. */}
+                    {entityNameEditable && !nameEditorInRail && nameSlugEditor}
+
+                    {/* Additional mode-specific UI injected by consumers — agent commits get a
+                    hairline zone divider so Save target / Deploy / Message read as groups. */}
+                    {extraContent ? (
+                        <div className={cn(isAgentCommit && "border-t border-zinc-2 pt-4")}>
+                            {extraContent}
+                        </div>
+                    ) : null}
+
+                    {/* Commit/Create message — agent: fills spare room but holds a usable
+                        floor so it scrolls (not squeezes) when the form above is tall. */}
+                    <div
+                        className={cn(
+                            isAgentCommit &&
+                                "flex min-h-[132px] flex-1 flex-col border-t border-zinc-2 pt-4",
                         )}
+                    >
+                        <CommitMessageInput
+                            value={message}
+                            onChange={setMessage}
+                            label={`${actionLabel} message`}
+                            showOptional={false}
+                            placeholder="Describe your changes..."
+                            minRows={isAgentCommit ? 2 : 3}
+                            maxRows={6}
+                            disabled={!canCommit}
+                            fill={isAgentCommit}
+                            className={
+                                isAgentCommit
+                                    ? "[&_.ant-input-textarea-affix-wrapper]:!bg-[var(--ag-colorFillQuaternary)] [&_textarea]:!bg-transparent"
+                                    : undefined
+                            }
+                        />
                     </div>
-                )}
 
-                {/* Additional mode-specific UI injected by consumers */}
-                {extraContent}
+                    {/* Error display */}
+                    {error && (
+                        <Alert
+                            type="error"
+                            title={`${actionLabel} failed`}
+                            description={error.message}
+                            className="[&_.ant-alert]:!py-5"
+                            showIcon
+                        />
+                    )}
+                </div>
 
-                {/* Commit/Create message */}
-                <CommitMessageInput
-                    value={message}
-                    onChange={setMessage}
-                    label={`${actionLabel} message`}
-                    showOptional={false}
-                    placeholder="Describe your changes..."
-                    minRows={3}
-                    maxRows={6}
-                    disabled={!canCommit}
-                />
-
-                {/* Error display */}
-                {error && (
-                    <Alert
-                        type="error"
-                        title={`${actionLabel} failed`}
-                        description={error.message}
-                        className="[&_.ant-alert]:!py-5"
-                        showIcon
-                    />
-                )}
+                {/* Action footer lives with the form (agent two-pane). */}
+                {footerSlot ? (
+                    <div className="-mx-6 -mb-5 mt-auto border-t border-[var(--ag-colorBorderSecondary)] px-6 py-3">
+                        {footerSlot}
+                    </div>
+                ) : null}
             </div>
 
-            {/* Diff view section — deferred until after first paint to avoid blocking the modal */}
-            {hasDiffData && (
+            {/* Agent workflows: plain-language section summary (JSON stays one click away). */}
+            {hasDiffData && context?.sections?.length ? (
+                <div className="order-1 flex min-w-0 flex-1 flex-col overflow-hidden bg-[var(--ag-colorFillQuaternary)]">
+                    <AgentChangesSummary
+                        sections={context.sections}
+                        original={context.diffData?.original ?? ""}
+                        modified={context.diffData?.modified ?? ""}
+                        language={context.diffData?.language === "yaml" ? "yaml" : "json"}
+                    />
+                </div>
+            ) : hasDiffData ? (
                 <div className="flex min-w-0 flex-1 flex-col overflow-hidden rounded-lg border border-zinc-2 bg-zinc-1">
                     <div className="flex items-center justify-between border-b border-zinc-2 bg-zinc-1 px-3 py-2 shrink-0">
                         <Text
@@ -493,7 +636,7 @@ export function EntityCommitContent({
                         )} */}
                     </div>
                 </div>
-            )}
+            ) : null}
         </div>
     )
 }

--- a/web/packages/agenta-entity-ui/src/modals/commit/components/EntityCommitContent.tsx
+++ b/web/packages/agenta-entity-ui/src/modals/commit/components/EntityCommitContent.tsx
@@ -361,8 +361,8 @@ export function EntityCommitContent({
                 "flex overflow-hidden",
                 hasDiffData ? "flex-row" : "flex-col gap-4",
                 hasDiffData && !isAgentCommit && "h-full gap-4",
+                isAgentTwoPane && "h-[min(450px,72vh)]",
             )}
-            style={isAgentTwoPane ? {height: "min(450px, 72vh)"} : undefined}
         >
             {/* Form section — agent two-pane: sits on the RIGHT and holds the action footer. */}
             <div

--- a/web/packages/agenta-entity-ui/src/modals/commit/components/EntityCommitFooter.tsx
+++ b/web/packages/agenta-entity-ui/src/modals/commit/components/EntityCommitFooter.tsx
@@ -1,44 +1,155 @@
 /**
  * EntityCommitFooter Component
  *
- * Modal footer with cancel and commit buttons.
+ * Modal footer with cancel and commit buttons. When `deployOptions` are provided, the
+ * commit button becomes a split button: the main action commits, and the caret opens a
+ * small form to commit and then deploy to one or more environments with an optional
+ * deployment message.
  */
 
-import {useCallback} from "react"
+import {useCallback, useState} from "react"
 
 import {ModalFooter} from "@agenta/ui/components/modal"
+import {cn, textColors} from "@agenta/ui/styles"
+import {CaretUp} from "@phosphor-icons/react"
+import {Button, Checkbox, Dropdown, Input, Space} from "antd"
+
+import type {CommitDeployOption} from "../../types"
 
 interface EntityCommitFooterProps {
     /** Callback when modal is closed/cancelled */
     onClose: () => void
-    /** Callback when commit is confirmed */
-    onConfirm: () => Promise<void> | void
+    /** Callback when commit is confirmed; optional environments + message deploy after commit */
+    onConfirm: (deployEnvironments?: string[], deployMessage?: string) => Promise<void> | void
     /** Loading state */
     isLoading: boolean
     /** Whether commit can proceed */
     canProceed: boolean
     /** Confirm button label */
     confirmLabel?: string
+    /** When set, the commit button becomes a "commit & deploy" split button. */
+    deployOptions?: CommitDeployOption[]
 }
 
-/**
- * EntityCommitFooter
- *
- * Footer with:
- * - Cancel button
- * - Commit button (disabled if no message or cannot commit)
- * - Loading state during commit
- */
+function DeployForm({
+    options,
+    confirmLabel,
+    isLoading,
+    canProceed,
+    onDeploy,
+}: {
+    options: CommitDeployOption[]
+    confirmLabel: string
+    isLoading: boolean
+    canProceed: boolean
+    onDeploy: (envs: string[], message?: string) => void
+}) {
+    const [envs, setEnvs] = useState<string[]>([])
+    const [deployMessage, setDeployMessage] = useState("")
+
+    return (
+        <div
+            className="w-[300px] rounded-lg border border-[var(--ag-colorBorder)] bg-[var(--ag-colorBgElevated)] p-3"
+            style={{boxShadow: "0 10px 32px rgba(0, 0, 0, 0.55)"}}
+        >
+            <div className={cn("mb-2 text-xs font-medium", textColors.secondary)}>Deploy to</div>
+            <Checkbox.Group
+                className="flex flex-col gap-2"
+                value={envs}
+                onChange={(v) => setEnvs(v as string[])}
+                options={options.map((o) => ({
+                    label: o.hint ? (
+                        <span className="flex items-center gap-2">
+                            {o.label}
+                            <span className={cn("text-[11px]", textColors.tertiary)}>{o.hint}</span>
+                        </span>
+                    ) : (
+                        o.label
+                    ),
+                    value: o.key,
+                    disabled: o.disabled,
+                }))}
+            />
+            <div className={cn("mb-1.5 mt-4 text-xs font-medium", textColors.secondary)}>
+                Deployment message <span className={textColors.tertiary}>(optional)</span>
+            </div>
+            <Input.TextArea
+                value={deployMessage}
+                onChange={(e) => setDeployMessage(e.target.value)}
+                rows={2}
+                placeholder="Describe this deployment…"
+            />
+            <Button
+                type="primary"
+                block
+                className="mt-3"
+                loading={isLoading}
+                disabled={!canProceed || envs.length === 0}
+                onClick={() => onDeploy(envs, deployMessage.trim() || undefined)}
+            >
+                {confirmLabel} &amp; deploy
+            </Button>
+        </div>
+    )
+}
+
 export function EntityCommitFooter({
     onClose,
     onConfirm,
     isLoading,
     canProceed,
     confirmLabel = "Commit",
+    deployOptions,
 }: EntityCommitFooterProps) {
+    const [deployOpen, setDeployOpen] = useState(false)
+
     const handleCommit = useCallback(async () => {
         await onConfirm()
     }, [onConfirm])
+
+    if (deployOptions && deployOptions.length > 0) {
+        return (
+            <div className="flex items-center justify-end gap-2">
+                <Button onClick={onClose}>Cancel</Button>
+                <Space.Compact>
+                    <Button
+                        type="primary"
+                        loading={isLoading}
+                        disabled={!canProceed}
+                        onClick={handleCommit}
+                    >
+                        {confirmLabel}
+                    </Button>
+                    <Dropdown
+                        open={deployOpen}
+                        onOpenChange={setDeployOpen}
+                        trigger={["click"]}
+                        placement="topRight"
+                        disabled={!canProceed}
+                        dropdownRender={() => (
+                            <DeployForm
+                                options={deployOptions}
+                                confirmLabel={confirmLabel}
+                                isLoading={isLoading}
+                                canProceed={canProceed}
+                                onDeploy={(envs, message) => {
+                                    setDeployOpen(false)
+                                    onConfirm(envs, message)
+                                }}
+                            />
+                        )}
+                    >
+                        <Button
+                            type="primary"
+                            disabled={!canProceed}
+                            aria-label="Commit and deploy options"
+                            icon={<CaretUp size={12} />}
+                        />
+                    </Dropdown>
+                </Space.Compact>
+            </div>
+        )
+    }
 
     return (
         <ModalFooter

--- a/web/packages/agenta-entity-ui/src/modals/commit/components/EntityCommitModal.tsx
+++ b/web/packages/agenta-entity-ui/src/modals/commit/components/EntityCommitModal.tsx
@@ -18,6 +18,7 @@ import type {
     CommitSubmitResult,
     CommitSubmitParams,
     CommitCreateFieldsConfig,
+    CommitDeployOption,
 } from "../../types"
 import {
     commitModalOpenAtom,
@@ -70,6 +71,11 @@ export interface EntityCommitModalProps {
     successMessage?: string | null
     /** Custom confirm button label */
     submitLabel?: string
+    /**
+     * When provided, the footer renders a split "Commit" button. The main action commits;
+     * each option commits and then deploys the new revision to that environment.
+     */
+    commitDeployOptions?: CommitDeployOption[]
     /** Optional mode selector shown in content */
     commitModes?: CommitModeOption[]
     /** Default selected mode */
@@ -109,6 +115,7 @@ export interface EntityCommitModalProps {
 }
 
 const SLUG_CONFLICT_MESSAGE = "A resource with this slug already exists in this project."
+const AGENT_TWO_PANE_ROOT_CLASS = "agenta-agent-commit-two-pane"
 
 function getErrorStatus(error: unknown): number | undefined {
     return (error as {response?: {status?: number}})?.response?.status
@@ -152,6 +159,7 @@ export function EntityCommitModal({
     onAfterSuccess,
     successMessage = "Changes committed successfully",
     submitLabel,
+    commitDeployOptions,
     commitModes,
     defaultCommitMode,
     renderModeContent,
@@ -227,6 +235,8 @@ export function EntityCommitModal({
 
     // Check if diff data is available for dynamic width
     const hasDiffData = context?.diffData?.original && context?.diffData?.modified
+    // Agent commits render a full-bleed two-panel layout (title + footer live inside the body).
+    const isAgentTwoPane = !!hasDiffData && !!context?.sections?.length
 
     // Initialize controlled modal state without toggling global modal open state.
     // Uses a ref to track the last synced entity to avoid re-triggering from
@@ -373,128 +383,155 @@ export function EntityCommitModal({
               })
             : true)
 
-    const handleConfirm = useCallback(async () => {
-        if (onSubmit) {
-            if (!currentEntity) return
+    const handleConfirm = useCallback(
+        async (deployEnvironments?: string[], deployMessage?: string) => {
+            if (onSubmit) {
+                if (!currentEntity) return
 
-            setCommitLoading(true)
-            setCommitError(null)
-            setSlugFieldError(null)
+                setCommitLoading(true)
+                setCommitError(null)
+                setSlugFieldError(null)
 
-            try {
-                const result = await onSubmit({
-                    entity: currentEntity,
-                    message: commitMessage.trim() || null,
-                    mode: selectedMode,
-                    entityName: entityName || undefined,
-                    entitySlug: entitySlug || undefined,
-                })
+                try {
+                    const result = await onSubmit({
+                        entity: currentEntity,
+                        message: commitMessage.trim() || null,
+                        mode: selectedMode,
+                        entityName: entityName || undefined,
+                        entitySlug: entitySlug || undefined,
+                        deployEnvironments,
+                        deployMessage,
+                    })
 
-                if (!result.success) {
-                    const isSlugConflict = result.slugConflict || result.errorStatus === 409
-                    if (isSlugConflict) {
+                    if (!result.success) {
+                        const isSlugConflict = result.slugConflict || result.errorStatus === 409
+                        if (isSlugConflict) {
+                            setSlugFieldError(SLUG_CONFLICT_MESSAGE)
+                            setSlugEditing(true)
+                        }
+                        setCommitError(
+                            new Error(extractApiErrorMessage(result.error || "Commit failed")),
+                        )
+                        setCommitLoading(false)
+                        return
+                    }
+
+                    if (isExternallyControlled) {
+                        onClose?.()
+                    } else {
+                        closeModal()
+                    }
+
+                    if (successMessage) {
+                        message.success(successMessage)
+                    }
+
+                    handleSuccess({newRevisionId: result.newRevisionId})
+                    await onAfterSuccess?.(result)
+                    return
+                } catch (error) {
+                    const msg = extractApiErrorMessage(error)
+                    if (getErrorStatus(error) === 409) {
                         setSlugFieldError(SLUG_CONFLICT_MESSAGE)
                         setSlugEditing(true)
                     }
                     setCommitError(
-                        new Error(extractApiErrorMessage(result.error || "Commit failed")),
+                        error instanceof Error
+                            ? Object.assign(error, {message: msg})
+                            : new Error(msg),
                     )
                     setCommitLoading(false)
                     return
                 }
+            }
 
+            const result = await executeCommit()
+            if (result.success) {
                 if (isExternallyControlled) {
                     onClose?.()
-                } else {
-                    closeModal()
                 }
-
                 if (successMessage) {
                     message.success(successMessage)
                 }
+                handleSuccess({})
+            }
+        },
+        [
+            onSubmit,
+            currentEntity,
+            entityName,
+            entitySlug,
+            setCommitLoading,
+            setCommitError,
+            setSlugFieldError,
+            setSlugEditing,
+            commitMessage,
+            selectedMode,
+            isExternallyControlled,
+            onClose,
+            closeModal,
+            resetModal,
+            successMessage,
+            handleSuccess,
+            onAfterSuccess,
+            executeCommit,
+        ],
+    )
 
-                handleSuccess({newRevisionId: result.newRevisionId})
-                await onAfterSuccess?.(result)
-                return
-            } catch (error) {
-                const msg = extractApiErrorMessage(error)
-                if (getErrorStatus(error) === 409) {
-                    setSlugFieldError(SLUG_CONFLICT_MESSAGE)
-                    setSlugEditing(true)
-                }
-                setCommitError(
-                    error instanceof Error ? Object.assign(error, {message: msg}) : new Error(msg),
-                )
-                setCommitLoading(false)
-                return
-            }
-        }
-
-        const result = await executeCommit()
-        if (result.success) {
-            if (isExternallyControlled) {
-                onClose?.()
-            }
-            if (successMessage) {
-                message.success(successMessage)
-            }
-            handleSuccess({})
-        }
-    }, [
-        onSubmit,
-        currentEntity,
-        entityName,
-        entitySlug,
-        setCommitLoading,
-        setCommitError,
-        setSlugFieldError,
-        setSlugEditing,
-        commitMessage,
-        selectedMode,
-        isExternallyControlled,
-        onClose,
-        closeModal,
-        resetModal,
-        successMessage,
-        handleSuccess,
-        onAfterSuccess,
-        executeCommit,
-    ])
+    const footerNode = (
+        <EntityCommitFooter
+            onClose={handleClose}
+            onConfirm={handleConfirm}
+            isLoading={isLoading}
+            canProceed={canProceedWithExtension}
+            confirmLabel={submitLabel ?? actionLabel}
+            deployOptions={commitDeployOptions}
+        />
+    )
 
     return (
-        <EnhancedModal
-            open={isOpen}
-            onCancel={handleClose}
-            afterClose={handleAfterClose}
-            title={<EntityCommitTitle />}
-            footer={
-                <EntityCommitFooter
-                    onClose={handleClose}
-                    onConfirm={handleConfirm}
-                    isLoading={isLoading}
-                    canProceed={canProceedWithExtension}
-                    confirmLabel={submitLabel ?? actionLabel}
+        <>
+            {/* Scoped override: zero antd's container padding for the agent two-pane layout only.
+                This antd build puts the padding on `.ant-modal-container` (not `.ant-modal-content`). */}
+            {isAgentTwoPane ? (
+                <style>{`.${AGENT_TWO_PANE_ROOT_CLASS} .ant-modal-container{padding:0 !important;overflow:hidden;}`}</style>
+            ) : null}
+            <EnhancedModal
+                open={isOpen}
+                onCancel={handleClose}
+                afterClose={handleAfterClose}
+                rootClassName={isAgentTwoPane ? AGENT_TWO_PANE_ROOT_CLASS : undefined}
+                // Agent commits render title + footer inside the body (two full-bleed panels).
+                title={isAgentTwoPane ? null : <EntityCommitTitle />}
+                footer={isAgentTwoPane ? null : footerNode}
+                width={hasDiffData ? 900 : 520}
+                styles={
+                    isAgentTwoPane
+                        ? {
+                              container: {padding: 0, overflow: "hidden"},
+                              body: {padding: 0, overflow: "hidden"},
+                          }
+                        : {
+                              body: {
+                                  maxHeight: "calc(80vh - 110px)",
+                                  overflow: "hidden",
+                                  display: "flex",
+                                  flexDirection: "column",
+                              },
+                          }
+                }
+            >
+                <EntityCommitContent
+                    commitModes={commitModes}
+                    selectedMode={selectedMode}
+                    onModeChange={setSelectedMode}
+                    extraContent={renderModeContent?.({mode: selectedMode})}
+                    modeLabel={modeLabel}
+                    entityNameEditable={isEntityNameEditable}
+                    entityNameLabel={resolvedEntityNameLabel}
+                    footerSlot={isAgentTwoPane ? footerNode : undefined}
                 />
-            }
-            width={hasDiffData ? 900 : 520}
-            styles={{
-                body: {
-                    maxHeight: "calc(80vh - 110px)",
-                    overflow: "hidden",
-                    display: "flex",
-                    flexDirection: "column",
-                },
-            }}
-        >
-            <EntityCommitContent
-                commitModes={commitModes}
-                selectedMode={selectedMode}
-                onModeChange={setSelectedMode}
-                extraContent={renderModeContent?.({mode: selectedMode})}
-                modeLabel={modeLabel}
-                entityNameEditable={isEntityNameEditable}
-                entityNameLabel={resolvedEntityNameLabel}
-            />
-        </EnhancedModal>
+            </EnhancedModal>
+        </>
     )
 }

--- a/web/packages/agenta-entity-ui/src/modals/commit/components/changes/AgentChangesSummary.tsx
+++ b/web/packages/agenta-entity-ui/src/modals/commit/components/changes/AgentChangesSummary.tsx
@@ -1,0 +1,500 @@
+/**
+ * AgentChangesSummary
+ *
+ * Plain-language, section-grouped view of an agent workflow's commit changes.
+ * Each change is a self-contained card (header + a real diff/rows surface) so nothing
+ * bleeds onto the flat panel. Master → detail navigation inside a fixed frame: the summary
+ * list, an edited-tool detail, a full-instructions diff, and the raw JSON diff all render
+ * in the same scroll area so the modal never grows. Nothing inline grows unbounded.
+ */
+import {useMemo, useState} from "react"
+
+import type {ChangeItem, ChangeSection, ScalarChange} from "@agenta/entities/workflow/commitDiff"
+import {HeightCollapse} from "@agenta/ui/components"
+import {AdaptiveList} from "@agenta/ui/components/selection"
+import type {ExtendedDiffLine} from "@agenta/ui/diff"
+import {DiffView} from "@agenta/ui/editor"
+import {cn, textColors} from "@agenta/ui/styles"
+import {
+    ArrowLeft,
+    ArrowRight,
+    CaretDown,
+    CaretRight,
+    ChatText,
+    Code,
+    Cpu,
+    DotsThree,
+    Minus,
+    PencilSimple,
+    PlugsConnected,
+    Plus,
+    Sparkle,
+    SlidersHorizontal,
+    Wrench,
+} from "@phosphor-icons/react"
+import {Tag, Typography} from "antd"
+
+const {Text} = Typography
+
+const INLINE_TEXT_DIFF_LINES = 6
+const SUBGROUP_VISIBLE = 5
+const VIRTUALIZE_AT = 50
+
+const ADD_BG = "color-mix(in srgb, var(--ag-colorSuccess) 13%, transparent)"
+const DEL_BG = "color-mix(in srgb, var(--ag-colorError) 13%, transparent)"
+
+// One subtle surface for the whole card; header inherits it, the diff tints + open divider
+// carry the structure. Avoids stacking two lightening fills (no "darker body" token in dark mode).
+const CARD =
+    "overflow-hidden rounded-[10px] border border-[var(--ag-colorBorderSecondary)] bg-[var(--ag-colorFillTertiary)]"
+const CARD_HEAD = "flex items-center gap-2.5 px-3 py-2.5"
+const LINK_BTN = cn(
+    "inline-flex cursor-pointer items-center gap-1.5 border-0 bg-transparent p-0 transition-colors",
+    textColors.secondary,
+    "hover:text-[var(--ag-colorText)]",
+)
+
+type View =
+    | {kind: "summary"}
+    | {kind: "json"}
+    | {kind: "instructions"; sectionId: string}
+    | {kind: "tool"; sectionId: string; itemId: string}
+
+const SECTION_ICON: Record<ChangeSection["id"], React.ReactNode> = {
+    tools: <Wrench />,
+    instructions: <ChatText />,
+    model: <Cpu />,
+    mcps: <PlugsConnected />,
+    skills: <Sparkle />,
+    params: <SlidersHorizontal />,
+}
+
+const KIND_COLOR: Record<string, string> = {
+    added: "green",
+    removed: "red",
+    edited: "gold",
+    changed: "gold",
+}
+
+const kindIcon = (kind: string) => {
+    if (kind === "added") return <Plus />
+    if (kind === "removed") return <Minus />
+    return <PencilSimple />
+}
+
+const kindStyle = (kind: string) => {
+    if (kind === "added") return {color: "var(--ag-colorSuccess)"}
+    if (kind === "removed") return {color: "var(--ag-colorError)"}
+    return {color: "var(--ag-colorWarning)"}
+}
+
+function StatusTags({tags}: {tags: ChangeSection["tags"]}) {
+    return (
+        <>
+            {tags.map((t, i) => (
+                <Tag
+                    key={i}
+                    color={KIND_COLOR[t.kind]}
+                    bordered={false}
+                    className="!m-0 rounded-full !px-2 !text-[10.5px]"
+                >
+                    {t.label}
+                </Tag>
+            ))}
+        </>
+    )
+}
+
+/** Diff surface — tinted +/- rows with a sign gutter; long lines wrap. */
+function HunkRows({hunks, limit}: {hunks: ExtendedDiffLine[]; limit?: number}) {
+    const shown = limit ? hunks.slice(0, limit) : hunks
+    return (
+        <div className="py-2 font-mono text-[11.5px] leading-[1.8]">
+            {shown.map((line, i) => {
+                if (line.type === "fold") {
+                    return (
+                        <div key={i} className={cn("px-3.5 italic", textColors.tertiary)}>
+                            {line.content}
+                        </div>
+                    )
+                }
+                const isAdd = line.type === "added"
+                const isDel = line.type === "removed"
+                const style = isAdd
+                    ? {
+                          background: ADD_BG,
+                          boxShadow: "inset 2px 0 0 var(--ag-colorSuccess)",
+                          color: "var(--ag-colorSuccess)",
+                      }
+                    : isDel
+                      ? {
+                            background: DEL_BG,
+                            boxShadow: "inset 2px 0 0 var(--ag-colorError)",
+                            color: "var(--ag-colorError)",
+                        }
+                      : undefined
+                return (
+                    <div
+                        key={i}
+                        className={cn(
+                            "flex px-3.5",
+                            line.type === "context" && textColors.tertiary,
+                        )}
+                        style={style}
+                    >
+                        <span className="w-3.5 shrink-0 opacity-70">
+                            {isAdd ? "+" : isDel ? "−" : " "}
+                        </span>
+                        <span className="whitespace-pre-wrap break-words">{line.content}</span>
+                    </div>
+                )
+            })}
+        </div>
+    )
+}
+
+function ItemRow({it, onOpenTool}: {it: ChangeItem; onOpenTool?: (itemId: string) => void}) {
+    const clickable = it.kind === "edited" && !!onOpenTool
+    return (
+        <div
+            className={cn(
+                "flex items-center gap-2.5 px-3.5 py-1.5",
+                clickable && "cursor-pointer hover:bg-[var(--ag-colorFillQuaternary)]",
+            )}
+            onClick={clickable ? () => onOpenTool?.(it.id) : undefined}
+        >
+            <span style={kindStyle(it.kind)} className="flex w-4 shrink-0 justify-center">
+                {kindIcon(it.kind)}
+            </span>
+            <span className="min-w-0 flex-1 truncate text-xs">
+                {it.label}
+                {it.detail ? (
+                    <span className={cn("ml-1", textColors.tertiary)}>· {it.detail}</span>
+                ) : null}
+            </span>
+            {clickable ? <CaretRight className={textColors.tertiary} /> : null}
+        </div>
+    )
+}
+
+/** A capped list with "Show N more"; virtualizes only when a huge group is fully expanded. */
+function CappedItems({
+    items,
+    onOpenTool,
+}: {
+    items: ChangeItem[]
+    onOpenTool?: (itemId: string) => void
+}) {
+    const [expanded, setExpanded] = useState(false)
+
+    if (expanded && items.length > VIRTUALIZE_AT) {
+        return (
+            <AdaptiveList
+                items={items}
+                maxHeight={320}
+                estimateSize={30}
+                getItemKey={(it) => it.id}
+                renderItem={(it) => <ItemRow it={it} onOpenTool={onOpenTool} />}
+            />
+        )
+    }
+
+    const visible = expanded ? items : items.slice(0, SUBGROUP_VISIBLE)
+    const hidden = items.length - visible.length
+    return (
+        <div className="py-1">
+            {visible.map((it) => (
+                <ItemRow key={it.id} it={it} onOpenTool={onOpenTool} />
+            ))}
+            {hidden > 0 ? (
+                <button
+                    type="button"
+                    className={cn("px-3.5 py-1.5 text-[11.5px]", LINK_BTN)}
+                    onClick={() => setExpanded(true)}
+                >
+                    <DotsThree />
+                    Show {hidden} more
+                </button>
+            ) : null}
+        </div>
+    )
+}
+
+function ScalarRows({changes}: {changes: ScalarChange[]}) {
+    return (
+        <div className="py-1">
+            {changes.map((c) => (
+                <div
+                    key={c.key}
+                    className="flex items-center gap-2 px-3.5 py-1.5 font-mono text-[11.5px]"
+                >
+                    {c.key !== "model" ? (
+                        <span className={textColors.secondary}>{c.key}</span>
+                    ) : null}
+                    <span style={{color: "var(--ag-colorError)"}}>{c.before ?? "—"}</span>
+                    <ArrowRight className={textColors.tertiary} />
+                    <span style={{color: "var(--ag-colorSuccess)"}}>{c.after ?? "—"}</span>
+                </div>
+            ))}
+        </div>
+    )
+}
+
+function SectionCard({
+    section,
+    items,
+    open,
+    onToggle,
+    onOpenInstructions,
+    onOpenTool,
+}: {
+    section: ChangeSection
+    items?: ChangeItem[]
+    open: boolean
+    onToggle: () => void
+    onOpenInstructions: () => void
+    onOpenTool: (itemId: string) => void
+}) {
+    const toolItems = items ?? section.items
+    return (
+        <div className={cn(CARD, "mb-2.5")}>
+            <div
+                className={cn(
+                    CARD_HEAD,
+                    "cursor-pointer transition-colors hover:bg-[var(--ag-colorFillTertiary)]",
+                )}
+                onClick={onToggle}
+            >
+                <span className={cn("w-[18px] text-center", textColors.secondary)}>
+                    {SECTION_ICON[section.id]}
+                </span>
+                <span className="flex-1 text-[13px]">{section.title}</span>
+                <StatusTags tags={section.tags} />
+                <span className={textColors.tertiary}>{open ? <CaretDown /> : <CaretRight />}</span>
+            </div>
+            <HeightCollapse open={open}>
+                <div className="border-t border-[var(--ag-colorBorderSecondary)]">
+                    {section.id === "tools" && toolItems ? (
+                        <CappedItems items={toolItems} onOpenTool={onOpenTool} />
+                    ) : null}
+                    {section.scalarChanges ? <ScalarRows changes={section.scalarChanges} /> : null}
+                    {section.textDiff ? (
+                        <>
+                            <HunkRows
+                                hunks={section.textDiff.hunks}
+                                limit={INLINE_TEXT_DIFF_LINES}
+                            />
+                            <div className="flex items-center border-t border-[var(--ag-colorBorderSecondary)] px-3.5 py-2">
+                                <button
+                                    type="button"
+                                    className={cn("text-[11.5px]", LINK_BTN)}
+                                    onClick={onOpenInstructions}
+                                >
+                                    <ArrowRight />
+                                    View full diff
+                                    {section.textDiff.added + section.textDiff.removed > 2
+                                        ? ` · ${section.textDiff.added + section.textDiff.removed} lines`
+                                        : ""}
+                                </button>
+                            </div>
+                        </>
+                    ) : null}
+                </div>
+            </HeightCollapse>
+        </div>
+    )
+}
+
+export interface AgentChangesSummaryProps {
+    sections: ChangeSection[]
+    original: string
+    modified: string
+    language?: "json" | "yaml"
+}
+
+export default function AgentChangesSummary({
+    sections,
+    original,
+    modified,
+    language = "json",
+}: AgentChangesSummaryProps) {
+    const [view, setView] = useState<View>({kind: "summary"})
+    // Sections are collapsed by default; the user expands what they want to inspect.
+    const [openIds, setOpenIds] = useState<Set<string>>(() => new Set())
+    const totalChanges = useMemo(
+        () => sections.reduce((sum, s) => sum + s.totalCount, 0),
+        [sections],
+    )
+
+    const isOpen = (id: string) => openIds.has(id)
+    const toggleSection = (id: string) =>
+        setOpenIds((prev) => {
+            const next = new Set(prev)
+            if (next.has(id)) next.delete(id)
+            else next.add(id)
+            return next
+        })
+
+    const activeSection =
+        "sectionId" in view ? sections.find((s) => s.id === view.sectionId) : undefined
+    const activeTool =
+        view.kind === "tool" ? activeSection?.items?.find((it) => it.id === view.itemId) : undefined
+
+    const isDetail = view.kind !== "summary"
+
+    return (
+        <div className="flex h-full flex-col">
+            {/* compact toolbar */}
+            <div className="flex shrink-0 items-center justify-between px-4 pb-2.5 pt-5">
+                {isDetail ? (
+                    <button
+                        type="button"
+                        className={cn("text-xs", LINK_BTN, textColors.primary)}
+                        onClick={() => setView({kind: "summary"})}
+                    >
+                        <ArrowLeft />
+                        Changes
+                    </button>
+                ) : (
+                    <Text className="text-xs font-semibold">
+                        What&apos;s changing
+                        <span className={cn("ml-1.5 font-normal", textColors.tertiary)}>
+                            {totalChanges} {totalChanges === 1 ? "change" : "changes"}
+                        </span>
+                    </Text>
+                )}
+                {view.kind === "summary" ? (
+                    <button
+                        type="button"
+                        className={cn("text-[11.5px]", LINK_BTN)}
+                        onClick={() => setView({kind: "json"})}
+                    >
+                        <Code style={{fontSize: 13}} />
+                        View as JSON
+                    </button>
+                ) : null}
+            </div>
+
+            {/* body — the only scroll area */}
+            <div className="min-h-0 flex-1 overflow-auto px-4 pb-4">
+                {view.kind === "summary"
+                    ? sections.map((section) => (
+                          <SectionCard
+                              key={section.id}
+                              section={section}
+                              items={section.items}
+                              open={isOpen(section.id)}
+                              onToggle={() => toggleSection(section.id)}
+                              onOpenInstructions={() =>
+                                  setView({kind: "instructions", sectionId: section.id})
+                              }
+                              onOpenTool={(itemId) =>
+                                  setView({kind: "tool", sectionId: section.id, itemId})
+                              }
+                          />
+                      ))
+                    : null}
+
+                {view.kind === "instructions" && activeSection?.textDiff ? (
+                    <div className={CARD}>
+                        <div className={CARD_HEAD}>
+                            <ChatText className={textColors.secondary} />
+                            <span className="flex-1 text-[13px]">Instructions</span>
+                            <StatusTags tags={activeSection.tags} />
+                        </div>
+                        <div className="border-t border-[var(--ag-colorBorderSecondary)]">
+                            <HunkRows hunks={activeSection.textDiff.hunks} />
+                        </div>
+                    </div>
+                ) : null}
+
+                {view.kind === "tool" && activeTool ? (
+                    <div className={CARD}>
+                        <div className={CARD_HEAD}>
+                            <PencilSimple style={{color: "var(--ag-colorWarning)"}} />
+                            <span className="flex-1 text-[13px]">{activeTool.label}</span>
+                            {activeTool.rawKey ? (
+                                <span className={cn("font-mono text-[11px]", textColors.tertiary)}>
+                                    {activeTool.rawKey}
+                                </span>
+                            ) : null}
+                        </div>
+                        <div className="border-t border-[var(--ag-colorBorderSecondary)] px-3.5 py-3">
+                            {activeTool.descriptionDiff ? (
+                                <>
+                                    <div
+                                        className={cn(
+                                            "mb-1.5 text-[10.5px] uppercase tracking-wide",
+                                            textColors.tertiary,
+                                        )}
+                                    >
+                                        Description
+                                    </div>
+                                    <div className="font-mono text-[11.5px] leading-[1.8]">
+                                        <div style={{color: "var(--ag-colorError)"}}>
+                                            − {activeTool.descriptionDiff.before}
+                                        </div>
+                                        <div style={{color: "var(--ag-colorSuccess)"}}>
+                                            + {activeTool.descriptionDiff.after}
+                                        </div>
+                                    </div>
+                                </>
+                            ) : null}
+                            {activeTool.fieldChanges?.some((f) => f.field !== "description") ? (
+                                <>
+                                    <div
+                                        className={cn(
+                                            "mb-1.5 mt-3 text-[10.5px] uppercase tracking-wide",
+                                            textColors.tertiary,
+                                        )}
+                                    >
+                                        Parameters
+                                    </div>
+                                    {activeTool.fieldChanges
+                                        .filter((f) => f.field !== "description")
+                                        .map((f) => (
+                                            <div
+                                                key={f.field}
+                                                className="flex items-center gap-2 py-1"
+                                            >
+                                                <span
+                                                    style={kindStyle(f.kind)}
+                                                    className="flex w-4 shrink-0 justify-center"
+                                                >
+                                                    {kindIcon(f.kind)}
+                                                </span>
+                                                <span className="font-mono text-[11.5px]">
+                                                    {f.field}
+                                                </span>
+                                                <span
+                                                    className={cn(
+                                                        "text-[11px]",
+                                                        textColors.tertiary,
+                                                    )}
+                                                >
+                                                    · {f.detail}
+                                                </span>
+                                            </div>
+                                        ))}
+                                </>
+                            ) : null}
+                        </div>
+                    </div>
+                ) : null}
+
+                {view.kind === "json" ? (
+                    <div className={CARD}>
+                        <DiffView
+                            original={original}
+                            modified={modified}
+                            language={language === "yaml" ? "yaml" : "json"}
+                            enableFolding
+                            computeOnMountOnly
+                            showErrors
+                        />
+                    </div>
+                ) : null}
+            </div>
+        </div>
+    )
+}

--- a/web/packages/agenta-entity-ui/src/modals/index.ts
+++ b/web/packages/agenta-entity-ui/src/modals/index.ts
@@ -141,6 +141,7 @@ export type {
     UseBoundCommitOptions,
     UseBoundCommitReturn,
 } from "./commit"
+export type {CommitDeployOption} from "./types"
 
 // ============================================================================
 // SAVE MODAL

--- a/web/packages/agenta-entity-ui/src/modals/types.ts
+++ b/web/packages/agenta-entity-ui/src/modals/types.ts
@@ -7,6 +7,7 @@
 
 import type {ReactNode} from "react"
 
+import type {ChangeSection} from "@agenta/entities/workflow/commitDiff"
 import type {Atom, WritableAtom} from "jotai"
 
 // ============================================================================
@@ -118,6 +119,14 @@ export interface CommitContext {
     changesSummary?: CommitChangesSummary
     /** Diff data for preview */
     diffData?: CommitDiffData
+    /**
+     * Semantic, section-grouped changes for agent/LLM workflows. When present, the
+     * commit modal renders a plain-language summary; JSON stays available separately.
+     * Absent for non-agent entities (they use `changesSummary` + `diffData`).
+     */
+    sections?: ChangeSection[]
+    /** Auto-generated commit message derived from `sections` (editable by the user). */
+    suggestedMessage?: string
 }
 
 /**
@@ -290,6 +299,20 @@ export interface CommitSubmitParams {
     entityName?: string
     /** The entity slug (user-edited or auto-generated, only present in create flows) */
     entitySlug?: string
+    /** Environments to deploy the new revision to after a successful commit. */
+    deployEnvironments?: string[]
+    /** Optional message recorded with the deployment (separate from the commit message). */
+    deployMessage?: string
+}
+
+/** An environment offered in the footer's "Commit & deploy" form. */
+export interface CommitDeployOption {
+    /** Environment slug to deploy to. */
+    key: string
+    label: string
+    /** Optional hint shown next to the environment, e.g. "v5 now". */
+    hint?: string
+    disabled?: boolean
 }
 
 export interface CommitCreateFieldsConfig {
@@ -321,6 +344,11 @@ export interface EntityCommitModalProps {
     successMessage?: string | null
     /** Custom confirm button label */
     submitLabel?: string
+    /**
+     * When provided, the footer renders a split "Commit" button. The main action commits;
+     * each option commits and then deploys the new revision to that environment.
+     */
+    commitDeployOptions?: CommitDeployOption[]
     /** Optional mode selector shown in content */
     commitModes?: CommitModeOption[]
     /** Default selected mode */

--- a/web/packages/agenta-shared/src/index.ts
+++ b/web/packages/agenta-shared/src/index.ts
@@ -226,7 +226,7 @@ export {generateId} from "./utils"
 export {isBase64, dataUriToObjectUrl, isUrl} from "./utils"
 
 // Value extraction utilities (strip enhanced wrappers / metadata)
-export {stripAgentaMetadataDeep, stripEnhancedWrappers} from "./utils"
+export {stripAgentaMetadataDeep, stripEmptyCollectionsDeep, stripEnhancedWrappers} from "./utils"
 
 // Status inference utilities
 export {

--- a/web/packages/agenta-shared/src/utils/index.ts
+++ b/web/packages/agenta-shared/src/utils/index.ts
@@ -150,7 +150,11 @@ export {generateId} from "./generateId"
 export {dataUriToObjectUrl, isBase64, isUrl} from "./dataUri"
 
 // Value extraction utilities (strip enhanced wrappers / metadata)
-export {stripAgentaMetadataDeep, stripEnhancedWrappers} from "./valueExtraction"
+export {
+    stripAgentaMetadataDeep,
+    stripEmptyCollectionsDeep,
+    stripEnhancedWrappers,
+} from "./valueExtraction"
 
 // Slug utilities
 export {

--- a/web/packages/agenta-shared/src/utils/valueExtraction.ts
+++ b/web/packages/agenta-shared/src/utils/valueExtraction.ts
@@ -25,6 +25,39 @@ export function stripAgentaMetadataDeep<T = unknown>(value: T): T {
 }
 
 /**
+ * Recursively drop object keys whose value is an empty array or empty plain object, so a
+ * present-but-empty collection compares equal to an absent one.
+ *
+ * Applied symmetrically to both sides of a config diff (dirty-detection, commit diff), this only
+ * removes false-positive differences — e.g. adding then removing a tool/skill/mcp leaves
+ * `skills: []` where the committed baseline had no `skills` key. It can never hide a real change:
+ * a non-empty collection is never stripped, so any side that still holds content stays different
+ * from an empty/absent one. Array *elements* are preserved (only keys are dropped), so list order
+ * and length are untouched.
+ */
+export function stripEmptyCollectionsDeep<T = unknown>(value: T): T {
+    if (Array.isArray(value)) {
+        return value.map(stripEmptyCollectionsDeep) as T
+    }
+    if (value && typeof value === "object") {
+        const out: Record<string, unknown> = {}
+        for (const [key, val] of Object.entries(value as Record<string, unknown>)) {
+            const cleaned = stripEmptyCollectionsDeep(val)
+            const isEmptyArray = Array.isArray(cleaned) && cleaned.length === 0
+            const isEmptyObject =
+                !!cleaned &&
+                typeof cleaned === "object" &&
+                !Array.isArray(cleaned) &&
+                Object.keys(cleaned as Record<string, unknown>).length === 0
+            if (isEmptyArray || isEmptyObject) continue
+            out[key] = cleaned
+        }
+        return out as T
+    }
+    return value
+}
+
+/**
  * Recursively strip enhanced value wrappers (__id, __metadata) from objects
  * and unwrap {value: X} patterns where the object is a simple value wrapper.
  *

--- a/web/packages/agenta-shared/tests/unit/data-transforms.test.ts
+++ b/web/packages/agenta-shared/tests/unit/data-transforms.test.ts
@@ -4,7 +4,11 @@ import {
     extractApiErrorMessage,
     preserveResponseStatus,
 } from "../../src/utils/extractApiErrorMessage"
-import {stripAgentaMetadataDeep, stripEnhancedWrappers} from "../../src/utils/valueExtraction"
+import {
+    stripAgentaMetadataDeep,
+    stripEmptyCollectionsDeep,
+    stripEnhancedWrappers,
+} from "../../src/utils/valueExtraction"
 
 // ---------------------------------------------------------------------------
 // extractApiErrorMessage
@@ -113,6 +117,44 @@ describe("stripAgentaMetadataDeep", () => {
         expect(stripAgentaMetadataDeep("hello")).toBe("hello")
         expect(stripAgentaMetadataDeep(42)).toBe(42)
         expect(stripAgentaMetadataDeep(null)).toBeNull()
+    })
+})
+
+// ---------------------------------------------------------------------------
+// stripEmptyCollectionsDeep
+// ---------------------------------------------------------------------------
+
+describe("stripEmptyCollectionsDeep", () => {
+    it("makes a present-but-empty array compare equal to an absent key", () => {
+        // The QA repro: add then remove a skill leaves `skills: []`; it must normalize to the same
+        // shape as a config that never had the key, so both sides of the dirty diff match.
+        const added = {agent: {llm: {model: "opus"}, skills: []}}
+        const never = {agent: {llm: {model: "opus"}}}
+        expect(stripEmptyCollectionsDeep(added)).toEqual(stripEmptyCollectionsDeep(never))
+        expect(stripEmptyCollectionsDeep(added)).toEqual({agent: {llm: {model: "opus"}}})
+    })
+
+    it("drops empty arrays and empty objects recursively", () => {
+        expect(
+            stripEmptyCollectionsDeep({tools: [], mcps: [], harness: {permissions: {}}}),
+        ).toEqual({})
+    })
+
+    it("keeps non-empty collections (never hides a real change)", () => {
+        const input = {agent: {tools: [{type: "web_search"}], harness: {kind: "claude"}}}
+        expect(stripEmptyCollectionsDeep(input)).toEqual(input)
+    })
+
+    it("preserves array elements and order (only object keys are dropped)", () => {
+        expect(stripEmptyCollectionsDeep({list: [1, 2, 3]})).toEqual({list: [1, 2, 3]})
+        // Empty-object elements inside an array are preserved (dropping them would shift indices).
+        expect(stripEmptyCollectionsDeep({list: [{a: 1}, {}]})).toEqual({list: [{a: 1}, {}]})
+    })
+
+    it("returns primitives and null unchanged", () => {
+        expect(stripEmptyCollectionsDeep("x")).toBe("x")
+        expect(stripEmptyCollectionsDeep(0)).toBe(0)
+        expect(stripEmptyCollectionsDeep(null)).toBeNull()
     })
 })
 

--- a/web/packages/agenta-ui/package.json
+++ b/web/packages/agenta-ui/package.json
@@ -17,6 +17,7 @@
         "./table": "./src/InfiniteVirtualTable/index.ts",
         "./table/paginated": "./src/InfiniteVirtualTable/paginated/index.ts",
         "./editor": "./src/Editor/index.ts",
+        "./diff": "./src/Editor/utils/diffUtils.ts",
         "./shared-editor": "./src/SharedEditor/index.ts",
         "./rich-chat-input": "./src/RichChatInput/index.ts",
         "./chat-message": "./src/ChatMessage/index.ts",

--- a/web/packages/agenta-ui/src/Editor/index.ts
+++ b/web/packages/agenta-ui/src/Editor/index.ts
@@ -40,6 +40,14 @@ export {preloadEditorPlugins} from "./plugins"
 // DiffView component
 export {default as DiffView} from "./DiffView"
 
+// Diff utilities (text/JSON line diff engine)
+export {
+    computeDiff,
+    computeTextDiffLines,
+    type DiffLine,
+    type ExtendedDiffLine,
+} from "./utils/diffUtils"
+
 // Types
 export type {EditorProps, EditorPluginsProps, EditorContextType, EditorProviderProps} from "./types"
 

--- a/web/packages/agenta-ui/src/Editor/utils/diffUtils.ts
+++ b/web/packages/agenta-ui/src/Editor/utils/diffUtils.ts
@@ -224,7 +224,7 @@ function computeLineDiff(
 /**
  * Basic diff line type
  */
-interface DiffLine {
+export interface DiffLine {
     type: "context" | "added" | "removed"
     content: string
     oldLineNumber?: number
@@ -234,7 +234,7 @@ interface DiffLine {
 /**
  * Extended diff line type with folding support
  */
-interface ExtendedDiffLine {
+export interface ExtendedDiffLine {
     type: "context" | "added" | "removed" | "fold"
     content: string
     oldLineNumber?: number
@@ -469,6 +469,36 @@ export function computeDiff(
         .join("\n")
 
     return result
+}
+
+/**
+ * Line-by-line diff of two raw text blocks (NOT JSON-serialized).
+ *
+ * Unlike `computeDiff`, which JSON-stringifies its inputs, this diffs the text
+ * as-is — correct for prose like a system prompt or a tool description. Reuses
+ * the same LCS engine (incl. the large-diff safety cap) and optional folding.
+ */
+export function computeTextDiffLines(
+    original: string | null | undefined,
+    modified: string | null | undefined,
+    options: {
+        contextLines?: number
+        enableFolding?: boolean
+        foldThreshold?: number
+        showFoldedLineCount?: boolean
+    } = {},
+): ExtendedDiffLine[] {
+    const {
+        contextLines = 3,
+        enableFolding = false,
+        foldThreshold = 10,
+        showFoldedLineCount = true,
+    } = options
+    const oldLines = (original ?? "").split("\n")
+    const newLines = (modified ?? "").split("\n")
+    const base = computeLineDiff(oldLines, newLines, contextLines)
+    if (!enableFolding) return base as ExtendedDiffLine[]
+    return applyFolding(base, {contextLines, foldThreshold, showFoldedLineCount})
 }
 
 /**

--- a/web/packages/agenta-ui/src/components/presentational/index.ts
+++ b/web/packages/agenta-ui/src/components/presentational/index.ts
@@ -62,12 +62,14 @@ export {
     ConfigBlock,
     SectionSkeleton,
     ConfigAccordionSection,
+    sectionIndicatorColor,
     type SectionCardProps,
     type SectionHeaderRowProps,
     type SectionLabelProps,
     type ConfigBlockProps,
     type SectionSkeletonProps,
     type ConfigAccordionSectionProps,
+    type SectionIndicatorTone,
 } from "./section"
 
 // ============================================================================

--- a/web/packages/agenta-ui/src/components/presentational/inputs/CommitMessageInput.tsx
+++ b/web/packages/agenta-ui/src/components/presentational/inputs/CommitMessageInput.tsx
@@ -49,6 +49,11 @@ export interface CommitMessageInputProps {
     autoFocus?: boolean
     /** Additional class name for the wrapper */
     className?: string
+    /**
+     * When true, the textarea stretches to fill the available height of its (flex) parent
+     * instead of auto-sizing to content. The wrapper must be given a bounded height.
+     */
+    fill?: boolean
 }
 
 export const CommitMessageInput = memo(function CommitMessageInput({
@@ -63,9 +68,10 @@ export const CommitMessageInput = memo(function CommitMessageInput({
     disabled = false,
     autoFocus = false,
     className,
+    fill = false,
 }: CommitMessageInputProps) {
     return (
-        <div className={cn("flex flex-col gap-1", className)}>
+        <div className={cn("flex flex-col gap-1", fill && "min-h-0 flex-1", className)}>
             <Text className="font-medium">
                 {label}
                 {showOptional && (
@@ -77,10 +83,15 @@ export const CommitMessageInput = memo(function CommitMessageInput({
             </Text>
             <TextArea
                 placeholder={placeholder}
-                className="w-full"
+                className={cn(
+                    "w-full",
+                    // Fill the parent height: stretch the show-count wrapper + inner textarea.
+                    fill &&
+                        "min-h-0 flex-1 [&_.ant-input-textarea]:h-full [&_textarea]:!h-full [&_textarea]:!resize-none",
+                )}
                 value={value}
                 onChange={(e) => onChange(e.target.value)}
-                autoSize={{minRows, maxRows}}
+                autoSize={fill ? false : {minRows, maxRows}}
                 showCount
                 maxLength={maxLength}
                 disabled={disabled}

--- a/web/packages/agenta-ui/src/components/presentational/section/ConfigAccordionSection.tsx
+++ b/web/packages/agenta-ui/src/components/presentational/section/ConfigAccordionSection.tsx
@@ -36,6 +36,20 @@ import {HeightCollapse} from "../../HeightCollapse"
 
 const {Text} = Typography
 
+export type SectionIndicatorTone = "draft" | "invalid" | "incomplete"
+
+/**
+ * The accent token for a section/item change indicator. Single source of truth for the
+ * tone→token mapping, shared by the section header and the config panel's item indicators.
+ */
+export function sectionIndicatorColor(tone: SectionIndicatorTone): string {
+    return tone === "invalid"
+        ? "var(--ag-colorError)"
+        : tone === "incomplete"
+          ? "var(--ag-colorWarning)"
+          : "var(--ag-colorInfo)"
+}
+
 export interface ConfigAccordionSectionProps {
     /** Section title shown in the header. */
     title: ReactNode
@@ -122,13 +136,7 @@ export function ConfigAccordionSection({
     children,
 }: ConfigAccordionSectionProps) {
     // Indicator (unsaved edits / validation) takes precedence over the completion `status`.
-    const indicatorColor = indicator
-        ? indicator.tone === "invalid"
-            ? "var(--ag-colorError)"
-            : indicator.tone === "incomplete"
-              ? "var(--ag-colorWarning)"
-              : "var(--ag-colorInfo)"
-        : null
+    const indicatorColor = indicator ? sectionIndicatorColor(indicator.tone) : null
     // The glyph gets a soft, desaturated tint; the full accent lives on the dot so it still reads.
     const iconColor = indicatorColor
         ? `color-mix(in srgb, ${indicatorColor} 45%, var(--ag-colorTextTertiary))`

--- a/web/packages/agenta-ui/src/components/presentational/section/ConfigAccordionSection.tsx
+++ b/web/packages/agenta-ui/src/components/presentational/section/ConfigAccordionSection.tsx
@@ -83,6 +83,13 @@ export interface ConfigAccordionSectionProps {
      * (neutral, e.g. an empty optional field). @default "default"
      */
     status?: "default" | "complete" | "warning"
+    /**
+     * Change/validation indicator for the leading icon: tints the icon, adds a status dot,
+     * and (with `tooltip`) explains it on hover. Takes precedence over `status`. Used by the
+     * agent config panel to flag sections with unsaved edits (`"draft"`), a blocking problem
+     * (`"invalid"`), or an optional gap (`"incomplete"`).
+     */
+    indicator?: {tone: "draft" | "invalid" | "incomplete"; tooltip?: ReactNode}
     /** Only show `summary` while the section is collapsed. @default false (always). */
     summaryCollapsedOnly?: boolean
     /** Additional CSS class for the section wrapper. */
@@ -109,10 +116,27 @@ export function ConfigAccordionSection({
     noDivider = false,
     size = "default",
     status = "default",
+    indicator,
     summaryCollapsedOnly = false,
     className,
     children,
 }: ConfigAccordionSectionProps) {
+    // Indicator (unsaved edits / validation) takes precedence over the completion `status`.
+    const indicatorColor = indicator
+        ? indicator.tone === "invalid"
+            ? "var(--ag-colorError)"
+            : indicator.tone === "incomplete"
+              ? "var(--ag-colorWarning)"
+              : "var(--ag-colorInfo)"
+        : null
+    // The glyph gets a soft, desaturated tint; the full accent lives on the dot so it still reads.
+    const iconColor = indicatorColor
+        ? `color-mix(in srgb, ${indicatorColor} 45%, var(--ag-colorTextTertiary))`
+        : status === "complete"
+          ? "var(--ag-colorSuccess)"
+          : status === "warning"
+            ? "var(--ag-colorWarning)"
+            : "var(--ag-c-586673,#586673)"
     const isControlled = open !== undefined
     const [internalOpen, setInternalOpen] = useState(defaultOpen)
     // A section can either open a drawer (onOpen) or expand inline (the accordion default).
@@ -163,16 +187,20 @@ export function ConfigAccordionSection({
             >
                 <div className="flex min-w-0 items-center gap-2">
                     {icon ? (
-                        <span
-                            className={cn(
-                                "flex shrink-0 items-center",
-                                status === "complete" && "text-[var(--ag-colorSuccess)]",
-                                status === "warning" && "text-[var(--ag-colorWarning)]",
-                                status === "default" && "text-[var(--ag-c-586673,#586673)]",
-                            )}
-                        >
-                            {icon}
-                        </span>
+                        <Tooltip title={indicator?.tooltip}>
+                            <span
+                                className="relative flex shrink-0 items-center"
+                                style={{color: iconColor}}
+                            >
+                                {icon}
+                                {indicator ? (
+                                    <span
+                                        className="absolute -right-1 -top-0.5 h-2 w-2 rounded-full border-[1.5px] border-[var(--ag-colorBgContainer)]"
+                                        style={{background: indicatorColor ?? undefined}}
+                                    />
+                                ) : null}
+                            </span>
+                        </Tooltip>
                     ) : null}
                     <Text
                         className={cn(

--- a/web/packages/agenta-ui/src/components/presentational/section/index.tsx
+++ b/web/packages/agenta-ui/src/components/presentational/section/index.tsx
@@ -169,4 +169,9 @@ export function SectionSkeleton({lines = 4}: SectionSkeletonProps) {
     )
 }
 
-export {ConfigAccordionSection, type ConfigAccordionSectionProps} from "./ConfigAccordionSection"
+export {
+    ConfigAccordionSection,
+    type ConfigAccordionSectionProps,
+    sectionIndicatorColor,
+    type SectionIndicatorTone,
+} from "./ConfigAccordionSection"


### PR DESCRIPTION
## What

Two related frontend features for the agent playground, both driven by a new semantic commit-diff classifier.

### Commit modal redesign (agent workflows)
The commit modal for agent-type workflows is reworked for non-technical users while keeping full JSON access:
- **Two-pane, summary-first layout** — a plain-language "What's changing" summary on the left, controls on the right.
- **Save-mode rail** (`SectionRail`) to pick **New version** vs **New variant**; the variant name/slug form renders inside the rail's content.
- **Editable auto-generated commit message** derived from the detected changes.
- **Multi-environment deploy fan-out** from the footer (checkbox multi-select + deploy message), replacing the single-env dropdown.
- **Semantic change summary** grouped into the agent template's control sections (Model & harness, Instructions, Tools, MCP servers, Skills, Advanced), with per-section drill-in and a "View as JSON" escape hatch.

Non-agent (testset / evaluator / create) modals are gated out and unchanged.

### Config-panel change indicators
The agent template panel now flags what's changed or incomplete:
- **Section headers** — soft icon tint + status dot + explanatory tooltip (`draft` / `invalid` / `incomplete`).
- **Line items** (tool / MCP / skill / instruction rows) — border tint + status tag.
- **Draft** state reuses the classifier against the committed server config (`serverConfiguration`); **validity** reuses each item kind's `draftInvalid` guard.
- Adds the missing `colorInfo` / `*Border` semantic theme tokens (the theme previously neutralized `colorInfo` to grey).

## Key implementation notes
- New classifier: `@agenta/entities/workflow/commitDiff` — pure, dependency-light; buckets a config diff to mirror the panel's control sections. Note the "Advanced" grouping is *artificial*: it pulls auth/connection out of `llm` (everything except `llm.model`), plus `runner` / `sandbox` / `harness` (non-`kind`).
- Shared components extended via props (not rebuilt): `ConfigAccordionSection` (`indicator`), `ItemRow` (`status`), `CommitMessageInput` (`fill`).

## Testing
- 24 unit tests for the classifier (`agent-commit-diff.test.ts`) covering all schema shapes and change categories.
- `tsc --noEmit` clean across `@agenta/ui`, `@agenta/entities`, `@agenta/entity-ui`; eslint + prettier clean (pre-commit + pre-push turbo-lint passed).
