### PR TITLE
PostHog tracking for agents & agent playground

### DIFF
--- a/api/oss/src/apis/fastapi/applications/router.py
+++ b/api/oss/src/apis/fastapi/applications/router.py
@@ -91,6 +91,7 @@ from oss.src.resources.workflows.catalog import (
 from oss.src.core.access.permissions.types import Permission
 from oss.src.core.access.permissions.service import check_action_access
 from oss.src.apis.fastapi.shared.exceptions import FORBIDDEN_EXCEPTION
+from oss.src.apis.fastapi.shared.utils import agent_feature_analytics_props
 
 
 log = get_module_logger(__name__)
@@ -1655,6 +1656,21 @@ class ApplicationsRouter:
             count=1 if application_revision else 0,
             application_revision=application_revision,
         )
+
+        # Analytics: segment the app_revision_created event by role (apps vs snippets) and
+        # agent-ness, and — for agents — its committed feature composition (the middleware
+        # attaches these request.state props).
+        if application_revision and application_revision.flags:
+            request.state.is_application = bool(
+                application_revision.flags.is_application
+            )
+            request.state.is_snippet = bool(application_revision.flags.is_snippet)
+            request.state.is_agent = bool(application_revision.flags.is_agent)
+            if request.state.is_agent and application_revision.data:
+                for _prop, _value in agent_feature_analytics_props(
+                    application_revision.data.parameters
+                ).items():
+                    setattr(request.state, _prop, _value)
 
         # commit emission lives in ApplicationsService.commit_application_revision
 

--- a/api/oss/src/apis/fastapi/shared/utils.py
+++ b/api/oss/src/apis/fastapi/shared/utils.py
@@ -1,4 +1,4 @@
-from typing import Optional, Tuple, List, Any
+from typing import Optional, Tuple, List, Any, Dict
 from json import loads
 
 from oss.src.core.shared.dtos import (
@@ -86,6 +86,43 @@ class SupportHeadersMiddleware:
             await self.app(scope, receive, send_with_support)
         finally:
             support_ctx.reset(token)
+
+
+def agent_feature_analytics_props(parameters: Optional[Any]) -> Dict[str, Any]:
+    """Analytics props describing an agent revision's feature composition, read defensively
+    from the committed ``parameters.agent`` template. Only keys present with the expected type
+    are returned, so a template shape change omits a prop rather than emitting a wrong one.
+    """
+    agent = parameters.get("agent") if isinstance(parameters, dict) else None
+    if not isinstance(agent, dict):
+        return {}
+
+    props: Dict[str, Any] = {}
+
+    for key, prop in (
+        ("tools", "tool_count"),
+        ("mcps", "mcp_server_count"),
+        ("skills", "skill_count"),
+        ("triggers", "trigger_count"),
+    ):
+        value = agent.get(key)
+        if isinstance(value, list):
+            props[prop] = len(value)
+
+    if "trigger_count" in props:
+        props["has_triggers"] = props["trigger_count"] > 0
+
+    harness = agent.get("harness")
+    if isinstance(harness, dict):
+        harness = harness.get("kind") or harness.get("value")
+    if isinstance(harness, str) and harness:
+        props["harness"] = harness
+
+    connection_mode = agent.get("connection_mode")
+    if isinstance(connection_mode, str) and connection_mode:
+        props["connection_mode"] = connection_mode
+
+    return props
 
 
 def parse_metadata(

--- a/api/oss/src/apis/fastapi/tools/router.py
+++ b/api/oss/src/apis/fastapi/tools/router.py
@@ -724,6 +724,8 @@ class ToolsRouter:
             connection_create=body.connection,
         )
 
+        request.state.integration = body.connection.integration_key
+
         return ToolConnectionResponse(
             count=1,
             connection=connection,

--- a/api/oss/src/apis/fastapi/workflows/router.py
+++ b/api/oss/src/apis/fastapi/workflows/router.py
@@ -73,6 +73,7 @@ from oss.src.apis.fastapi.workflows.models import (
     SimpleWorkflowsResponse,
 )
 from oss.src.apis.fastapi.shared.utils import (
+    agent_feature_analytics_props,
     compute_next_windowing,
 )
 from oss.src.apis.fastapi.workflows.utils import (
@@ -821,6 +822,12 @@ class WorkflowsRouter:
         # Invalidate legacy caches so the registry/apps list reflects the change
         await invalidate_cache(project_id=request.state.project_id)
 
+        # Analytics: apps and snippets share this route, so the app_archived event carries the role
+        # flags to keep it filterable (the artifact has no is_agent — that's a revision flag).
+        if workflow and workflow.flags:
+            request.state.is_application = bool(workflow.flags.is_application)
+            request.state.is_snippet = bool(workflow.flags.is_snippet)
+
         workflow_response = WorkflowResponse(
             count=1 if workflow else 0,
             workflow=workflow,
@@ -1568,6 +1575,20 @@ class WorkflowsRouter:
             request=request,
             workflow_revision=workflow_revision,
         )
+
+        # Analytics: segment the app_revision_created event by role (apps vs snippets, which share
+        # this route) and agent-ness, and — for agents — its committed feature composition (the
+        # middleware attaches these request.state props). This is the route the frontend commits
+        # through (POST /workflows/revisions/commit).
+        if workflow_revision and workflow_revision.flags:
+            request.state.is_application = bool(workflow_revision.flags.is_application)
+            request.state.is_snippet = bool(workflow_revision.flags.is_snippet)
+            request.state.is_agent = bool(workflow_revision.flags.is_agent)
+            if request.state.is_agent and workflow_revision.data:
+                for _prop, _value in agent_feature_analytics_props(
+                    workflow_revision.data.parameters
+                ).items():
+                    setattr(request.state, _prop, _value)
 
         workflow_revision_response = WorkflowRevisionResponse(
             count=1 if workflow_revision else 0,

--- a/api/oss/src/middlewares/analytics.py
+++ b/api/oss/src/middlewares/analytics.py
@@ -43,6 +43,23 @@ ACTIVATION_EVENTS = {
     "user_invitation_sent_v1": ("invited_user_v1", None),
 }
 
+# Optional analytics props a handler may set on `request.state` for the middleware to
+# attach to its event (e.g. agent detection, agent feature composition). This allowlist is a
+# deliberate boundary: only these keys cross from request.state to the external analytics sink.
+_HANDLER_ANALYTICS_PROPS = (
+    "is_agent",
+    "is_application",
+    "is_snippet",
+    "integration",
+    "tool_count",
+    "mcp_server_count",
+    "skill_count",
+    "trigger_count",
+    "has_triggers",
+    "harness",
+    "connection_mode",
+)
+
 
 async def _set_activation_property(
     distinct_id: str,
@@ -196,6 +213,14 @@ async def analytics_middleware(request: Request, call_next: Callable):
             ):
                 properties["organization_name"] = request.state.organization_name
 
+            # Handler-supplied analytics props (e.g. agent detection, activation route,
+            # committed agent feature composition). Handlers set these on request.state;
+            # `is not None` keeps False / 0 values (an agent with no tools is still an agent).
+            for _prop in _HANDLER_ANALYTICS_PROPS:
+                _value = getattr(request.state, _prop, None)
+                if _value is not None:
+                    properties[_prop] = _value
+
             # Check daily limits if the event is one of those to be limited per auth method
             _project_id = getattr(request.state, "project_id", None)
             _user_id = getattr(request.state, "user_id", None)
@@ -294,6 +319,17 @@ def _get_event_name_from_path(
     # <-------- Application Events -------->
     if method == "POST" and path == "/apps":
         return "app_created"
+
+    elif (
+        method == "POST"
+        and path.endswith("/archive")
+        and ("workflows" in path_parts or "applications" in path_parts)
+        and "variants" not in path_parts
+        and "revisions" not in path_parts
+    ):
+        # App archival goes through the generic workflow artifact route
+        # (`POST /workflows/{id}/archive`); other domains own their own /archive.
+        return "app_archived"
     # <-------- End of Application Events -------->
 
     # <----------- Configuration Events ------------->
@@ -304,7 +340,10 @@ def _get_event_name_from_path(
         return "app_revision_created"
 
     elif method == "POST" and (
-        "/variants/configs/commit" in path or "/variants/configs/fork" in path
+        "/variants/configs/commit" in path
+        or "/variants/configs/fork" in path
+        or "/applications/revisions/commit" in path
+        or "/workflows/revisions/commit" in path
     ):
         return "app_revision_created"
 
@@ -316,6 +355,11 @@ def _get_event_name_from_path(
     elif method == "POST" and "/variants/configs/fetch" in path:
         return "app_revision_fetched"
     # <----------- End of Configuration Events ------------->
+
+    # <----------- Tools Events ------------->
+    if method == "POST" and path.endswith("/tools/connections/"):
+        return "tool_connection_created"
+    # <----------- End of Tools Events ------------->
 
     # <----------- Testsets Events ------------->
     if method == "POST" and "/testsets" in path:

--- a/web/oss/src/components/AgentChatSlice/AgentChatPanel.tsx
+++ b/web/oss/src/components/AgentChatSlice/AgentChatPanel.tsx
@@ -19,6 +19,7 @@ import type {UploadFile} from "antd"
 import {useAtomValue, useSetAtom, useStore} from "jotai"
 
 import {SessionInspectorButton} from "@/oss/components/SessionInspector"
+import {usePostHogAg} from "@/oss/lib/helpers/analytics/hooks/usePostHogAg"
 
 import {AgentChatTransport} from "./assets/AgentChatTransport"
 import {
@@ -1055,6 +1056,13 @@ const AgentChatPanel = ({entityId}: {entityId: string}) => {
     const renameSession = useSetAtom(renameSessionAtomFamily(scope))
     const setActiveSession = useSetAtom(setActiveSessionAtomFamily(scope))
     const chatMaximized = useAtomValue(chatPanelMaximizedAtom)
+    const posthog = usePostHogAg()
+
+    // Explicit user "new session" (the tab bar +), distinct from the bootstrap/trigger adds below.
+    const handleAddSession = useCallback(() => {
+        posthog?.capture("agent_session_created")
+        addSession()
+    }, [posthog, addSession])
 
     // Always keep at least one tab. Re-arms when the list drains without double-firing
     // under StrictMode.
@@ -1112,7 +1120,7 @@ const AgentChatPanel = ({entityId}: {entityId: string}) => {
                             sessions={sessions}
                             activeId={activeId}
                             onSelect={setActiveSession}
-                            onAdd={addSession}
+                            onAdd={handleAddSession}
                             onClose={closeSession}
                             onRename={(id, title) => renameSession({id, title})}
                             showSessions={!chatMaximized}

--- a/web/oss/src/components/AgentChatSlice/components/SessionRail.tsx
+++ b/web/oss/src/components/AgentChatSlice/components/SessionRail.tsx
@@ -6,6 +6,7 @@ import clsx from "clsx"
 import {useAtomValue, useSetAtom} from "jotai"
 
 import {SessionInspectorButton} from "@/oss/components/SessionInspector"
+import {usePostHogAg} from "@/oss/lib/helpers/analytics/hooks/usePostHogAg"
 
 import {useChatScopeKey} from "../state/scope"
 import {
@@ -151,6 +152,11 @@ const SessionRail = ({activeId, className}: SessionRailProps) => {
     const resolvedActiveId = useAtomValue(activeSessionIdAtomFamily(scope))
     const openSession = useSetAtom(openSessionAtomFamily(scope))
     const addSession = useSetAtom(addSessionAtomFamily(scope))
+    const posthog = usePostHogAg()
+    const handleAddSession = useCallback(() => {
+        posthog?.capture("agent_session_created")
+        addSession()
+    }, [posthog, addSession])
     const deleteSession = useSetAtom(deleteSessionAtomFamily(scope))
     const renameSession = useSetAtom(renameSessionAtomFamily(scope))
 
@@ -219,7 +225,7 @@ const SessionRail = ({activeId, className}: SessionRailProps) => {
                         type="text"
                         aria-label="New session"
                         icon={<Plus size={14} />}
-                        onClick={() => addSession()}
+                        onClick={handleAddSession}
                         className="!h-7 !w-7 !min-w-0 shrink-0 !p-0"
                     />
                 </Tooltip>

--- a/web/oss/src/components/AgentChatSlice/components/ToolActivity.tsx
+++ b/web/oss/src/components/AgentChatSlice/components/ToolActivity.tsx
@@ -13,6 +13,8 @@ import {
 import type {ToolUIPart} from "ai"
 import {Button, Typography} from "antd"
 
+import {usePostHogAg} from "@/oss/lib/helpers/analytics/hooks/usePostHogAg"
+
 const {Text} = Typography
 
 /** Friendly name for a tool part. `dynamic-tool` carries the name on `toolName`; the typed
@@ -97,9 +99,11 @@ const ApprovalButtons = ({
     // `approval-responded` (which removes the buttons). Not tied to conversation `busy` —
     // an approval can only appear mid-stream, so gating on busy would disable it the whole turn.
     const [responding, setResponding] = useState(false)
+    const posthog = usePostHogAg()
     const respond = (approved: boolean) => {
         if (responding) return
         setResponding(true)
+        posthog?.capture("agent_tool_approval_submitted", {approved})
         onApprovalResponse({id: approvalId, approved})
     }
     return (

--- a/web/oss/src/components/pages/app-management/components/ApplicationManagementSection.tsx
+++ b/web/oss/src/components/pages/app-management/components/ApplicationManagementSection.tsx
@@ -1,16 +1,18 @@
 import {useCallback, useEffect, useMemo} from "react"
 
-import {workflowMolecule} from "@agenta/entities/workflow"
+import {workflowAppTypeAtomFamily, workflowMolecule} from "@agenta/entities/workflow"
 import {extractApiErrorMessage} from "@agenta/shared/utils"
 import {InfiniteVirtualTableFeatureShell, useTableManager} from "@agenta/ui/table"
 import {Tray} from "@phosphor-icons/react"
 import {Button, Empty, Space, Typography, message} from "antd"
 import {useAtomValue, useSetAtom} from "jotai"
+import {getDefaultStore} from "jotai/vanilla"
 import {useRouter} from "next/router"
 
 import {openDeleteAppModalAtom} from "@/oss/components/pages/app-management/modals/DeleteAppModal/store/deleteAppModalStore"
 import {usePlaygroundNavigation} from "@/oss/hooks/usePlaygroundNavigation"
 import useURL from "@/oss/hooks/useURL"
+import {usePostHogAg} from "@/oss/lib/helpers/analytics/hooks/usePostHogAg"
 import {useAppsData} from "@/oss/state/app"
 import {getProjectValues} from "@/oss/state/project"
 
@@ -39,6 +41,7 @@ const ApplicationManagementSection = ({mode = "active"}: ApplicationManagementSe
     const router = useRouter()
     const {baseAppURL} = useURL()
     const {goToPlayground} = usePlaygroundNavigation()
+    const posthog = usePostHogAg()
     const openDeleteAppModal = useSetAtom(openDeleteAppModalAtom)
     const setWorkflowTypeFilter = useSetAtom(workflowTypeFilterAtom)
     const setWorkflowInvokableOnly = useSetAtom(workflowInvokableOnlyAtom)
@@ -87,6 +90,15 @@ const ApplicationManagementSection = ({mode = "active"}: ApplicationManagementSe
             },
             onOpenPlayground: (record) => {
                 if (!isArchived) {
+                    const appType = getDefaultStore().get(
+                        workflowAppTypeAtomFamily(record.workflowId),
+                    )
+                    if (appType === "agent") {
+                        posthog?.capture("agent_playground_opened", {
+                            appId: record.workflowId,
+                            source: "menu",
+                        })
+                    }
                     goToPlayground(undefined, {appId: record.workflowId})
                 }
             },
@@ -112,7 +124,7 @@ const ApplicationManagementSection = ({mode = "active"}: ApplicationManagementSe
                 }
             },
         }),
-        [router, baseAppURL, isArchived, goToPlayground, openDeleteAppModal, mutateApps],
+        [router, baseAppURL, isArchived, goToPlayground, openDeleteAppModal, mutateApps, posthog],
     )
 
     const columns = useMemo(() => createAppWorkflowColumns(actions, {mode}), [actions, mode])

--- a/web/oss/src/state/newPlayground/workflowEntityBridge.ts
+++ b/web/oss/src/state/newPlayground/workflowEntityBridge.ts
@@ -25,6 +25,7 @@ import {
     type WorkflowCommitResult,
     type WorkflowArchiveResult,
 } from "@agenta/entities/workflow"
+import {registerEntityUiAnalytics} from "@agenta/entity-ui"
 import {playgroundController, setOnSelectionChangeCallback} from "@agenta/playground"
 import {
     workflowRevisionDrawerEntityIdAtom as drawerVariantIdAtom,
@@ -37,6 +38,7 @@ import {
     registryPaginatedStore,
     clearRegistryVariantNameCache,
 } from "@/oss/components/VariantsComponents/store/registryStore"
+import {posthogAtom} from "@/oss/lib/helpers/analytics/store/atoms"
 import {routerAppNavigationAtom} from "@/oss/state/app"
 import {writePlaygroundSelectionToQuery} from "@/oss/state/url/playground"
 
@@ -308,3 +310,12 @@ registerWorkflowArchiveCallbacks({
         }
     },
 })
+
+// ============================================================================
+// ANALYTICS
+// Inject the app's PostHog capture into entity-ui (which can't import @/oss)
+// ============================================================================
+
+registerEntityUiAnalytics((event, payload) =>
+    getDefaultStore().get(posthogAtom)?.capture(event, payload),
+)

--- a/web/packages/agenta-entity-ui/src/DrillInView/SchemaControls/AgentTemplateControl.tsx
+++ b/web/packages/agenta-entity-ui/src/DrillInView/SchemaControls/AgentTemplateControl.tsx
@@ -41,6 +41,7 @@ import {
 import {Button, Tabs, Tooltip, Typography} from "antd"
 import {useAtomValue, useStore} from "jotai"
 
+import {captureEntityUiEvent} from "../../analytics"
 import {useOptionalDrillIn} from "../components/MoleculeDrillInContext"
 
 import {AddTextLink} from "./AddTextLink"
@@ -204,20 +205,20 @@ export function AgentTemplateControl({
         () => (Array.isArray(config.mcps) ? (config.mcps as unknown[]) : []),
         [config.mcps],
     )
-    const handleAddMcpServer = useCallback(
-        () => openCreate("mcp", ITEM_KINDS.mcp.createSeed(), "form"),
-        [openCreate],
-    )
+    const handleAddMcpServer = useCallback(() => {
+        captureEntityUiEvent("agent_mcp_server_add_started", {mcpServerCount: mcpServers.length})
+        openCreate("mcp", ITEM_KINDS.mcp.createSeed(), "form")
+    }, [openCreate, mcpServers.length])
 
     // Skills: a flat array of inline SKILL.md packages or `@ag.embed` references the backend inlines.
     const skills = useMemo(
         () => (Array.isArray(config.skills) ? (config.skills as unknown[]) : []),
         [config.skills],
     )
-    const handleAddSkill = useCallback(
-        () => openCreate("skill", ITEM_KINDS.skill.createSeed(), "form"),
-        [openCreate],
-    )
+    const handleAddSkill = useCallback(() => {
+        captureEntityUiEvent("agent_skill_add_started", {skillCount: skills.length})
+        openCreate("skill", ITEM_KINDS.skill.createSeed(), "form")
+    }, [openCreate, skills.length])
 
     // ``instructions.agents_md`` is the one instruction document (flat on the template).
     const instructions =

--- a/web/packages/agenta-entity-ui/src/DrillInView/SchemaControls/TriggerManagementSection.tsx
+++ b/web/packages/agenta-entity-ui/src/DrillInView/SchemaControls/TriggerManagementSection.tsx
@@ -57,6 +57,7 @@ import type {MenuProps} from "antd"
 import {useAtom, useAtomValue, useSetAtom} from "jotai"
 import {atomWithStorage} from "jotai/utils"
 
+import {captureEntityUiEvent} from "../../analytics"
 import {AddItemMenu, type AddItemGroup} from "../../drawers/shared/AddItemMenu"
 import {loadRecentSamples, waitForNewDelivery} from "../../gatewayTrigger/drawers/shared/deliveries"
 import {
@@ -931,6 +932,7 @@ export function AddTriggerDropdown({
         <AddItemMenu
             groups={groups}
             ariaLabel="Add trigger"
+            onOpen={() => captureEntityUiEvent("agent_trigger_menu_opened")}
             trigger={
                 trigger ?? (
                     <Tooltip title="Add trigger">

--- a/web/packages/agenta-entity-ui/src/DrillInView/SchemaControls/agentTemplate/AgentToolSelectorPopover.tsx
+++ b/web/packages/agenta-entity-ui/src/DrillInView/SchemaControls/agentTemplate/AgentToolSelectorPopover.tsx
@@ -15,6 +15,7 @@ import {useDrillInUI} from "@agenta/ui/drill-in"
 import {BracketsCurly, GraphIcon, Plugs, Plus, Sparkle} from "@phosphor-icons/react"
 import {Button} from "antd"
 
+import {captureEntityUiEvent} from "../../../analytics"
 import {AddItemMenu, type AddItemGroup} from "../../../drawers/shared/AddItemMenu"
 import type {ToolSelectorPopoverProps} from "../ToolSelectorPopover"
 import type {ToolObj} from "../toolUtils"
@@ -51,6 +52,7 @@ export const AgentToolSelectorPopover = memo(function AgentToolSelectorPopover({
     trigger,
     onReferenceWorkflow,
     onOpenIntegration,
+    existingToolCount = 0,
 }: AgentToolSelectorPopoverProps) {
     const {gatewayTools: gatewayToolsFromContext, workflowReference} = useDrillInUI()
     const gatewayTools = gatewayToolsProp ?? gatewayToolsFromContext
@@ -111,6 +113,9 @@ export const AgentToolSelectorPopover = memo(function AgentToolSelectorPopover({
             groups={groups}
             disabled={disabled}
             ariaLabel="Add tool"
+            onOpen={() =>
+                captureEntityUiEvent("agent_tool_picker_opened", {toolCount: existingToolCount})
+            }
             trigger={
                 trigger ?? (
                     <Button

--- a/web/packages/agenta-entity-ui/src/analytics.ts
+++ b/web/packages/agenta-entity-ui/src/analytics.ts
@@ -1,0 +1,20 @@
+/**
+ * Analytics injection seam for `@agenta/entity-ui`.
+ *
+ * This package must not import the app's PostHog helpers (`@/oss/...`), so the host app injects a
+ * capture function at startup via `registerEntityUiAnalytics` (mirroring `registerEntityAdapter`).
+ * Package components emit events through `captureEntityUiEvent`; if nothing is registered the calls
+ * are silent no-ops, so the package stays app-agnostic and needs no PostHog in tests.
+ */
+
+type CaptureFn = (event: string, payload?: Record<string, unknown>) => void
+
+let _capture: CaptureFn | null = null
+
+export function registerEntityUiAnalytics(capture: CaptureFn): void {
+    _capture = capture
+}
+
+export function captureEntityUiEvent(event: string, payload?: Record<string, unknown>): void {
+    _capture?.(event, payload)
+}

--- a/web/packages/agenta-entity-ui/src/drawers/shared/AddItemMenu.tsx
+++ b/web/packages/agenta-entity-ui/src/drawers/shared/AddItemMenu.tsx
@@ -83,6 +83,7 @@ export const AddItemMenu = memo(function AddItemMenu({
     disabled = false,
     ariaLabel = "Add",
     minWidth = 288,
+    onOpen,
 }: {
     groups: AddItemGroup[]
     /** Custom trigger element (e.g. an inline text-link). Defaults to a `+` text button. */
@@ -90,6 +91,8 @@ export const AddItemMenu = memo(function AddItemMenu({
     disabled?: boolean
     ariaLabel?: string
     minWidth?: number
+    /** Fires when the menu opens (analytics); callers opt in — the menu itself is analytics-free. */
+    onOpen?: () => void
 }) {
     const [open, setOpen] = useState(false)
 
@@ -122,6 +125,7 @@ export const AddItemMenu = memo(function AddItemMenu({
             open={!disabled && open}
             onOpenChange={(next) => {
                 if (disabled) return
+                if (next) onOpen?.()
                 setOpen(next)
             }}
             trigger={["click"]}

--- a/web/packages/agenta-entity-ui/src/index.ts
+++ b/web/packages/agenta-entity-ui/src/index.ts
@@ -39,6 +39,9 @@
 export {SharedGenerationResultUtils, type SharedGenerationResultUtilsProps} from "./shared"
 export {RunnableOutputValue, formatOutputValue, type RunnableOutputValueProps} from "./shared"
 
+// Analytics injection seam (host app registers a PostHog capture fn; package components emit)
+export {registerEntityUiAnalytics, captureEntityUiEvent} from "./analytics"
+
 // ============================================================================
 // DRILL-IN VIEW (Molecule-first API)
 // ============================================================================


### PR DESCRIPTION
## Context

Agent activity was either grouped into generic app events or missing when the interaction never reached the API. The API analytics middleware could identify a request from its path, but it could not inspect the committed agent configuration. Shared `@agenta/entity-ui` components also could not call the OSS app's PostHog helpers without breaking package boundaries.

This PR implements the tracking plan. API handlers now enrich middleware-owned events through an explicit `request.state` allowlist, while the OSS app injects a capture function into `@agenta/entity-ui` for UI-only discovery events. The package remains analytics-provider agnostic and silently no-ops when no host capture function is registered.

## Trackers added

The properties column lists the event-specific tags added by this PR. Existing middleware context such as project, organization, user, path, method, and status remains unchanged.

| Event tag | Change | Capture site | Properties / tags | Why |
|---|---|---|---|---|
| `app_revision_created` | Existing event, enriched | API middleware after application or workflow revision commit | `is_agent`, `is_application`, `is_snippet`, `tool_count`, `mcp_server_count`, `skill_count`, `trigger_count`, `has_triggers`, `harness`, `connection_mode` | Measures agent configuration commits and the feature composition present at the committed revision. |
| `app_archived` | New event mapping | API middleware for workflow/application archive routes | `is_application`, `is_snippet` | Measures application lifecycle and churn while keeping shared workflow routes segmentable by artifact role. |
| `tool_connection_created` | New event | API middleware after a tool connection is created | `integration` | Measures which third-party integrations are connected. |
| `agent_playground_opened` | New frontend event | Apps table, when an agent is opened in the playground from its menu | `appId`, `source: "menu"` | Measures agent playground entry because the action is client-side navigation with no dedicated backend signal. |
| `agent_session_created` | New frontend event | Agent chat session tab `+` action | None | Measures explicit new-session creation. Bootstrap and trigger-created sessions are excluded. |
| `agent_tool_approval_submitted` | New frontend event | Agent tool approval buttons | `approved` | Measures human-in-the-loop adoption and approval rate. |
| `agent_tool_picker_opened` | New frontend event | Agent tool picker open transition | `toolCount` | Distinguishes tool discovery from committed tool adoption. |
| `agent_trigger_menu_opened` | New frontend event | Agent trigger menu open transition | None | Distinguishes trigger discovery from committed trigger adoption. |
| `agent_mcp_server_add_started` | New frontend event | Add MCP server action | `mcpServerCount` | Measures MCP setup intent before a configuration is committed. |
| `agent_skill_add_started` | New frontend event | Add skill action | `skillCount` | Measures skill setup intent before a configuration is committed. |

## Implementation notes

- Backend handlers derive agent feature counts from committed `parameters.agent` data. Missing or unexpected shapes omit a property instead of reporting an incorrect value.
- Only allowlisted handler properties cross from `request.state` into PostHog. `false` and `0` values are retained for accurate segmentation.
- `@agenta/entity-ui` exposes a small capture registration seam. The OSS playground bridge connects it to the existing PostHog atom, so the package does not import app-layer analytics code.
- Agent run volume and message counts continue to come from existing tracing and `spans_created`; this PR does not add a duplicate run event.

## Tests / notes

- `git diff --check` passes for the resolved tracking changes.
- `pnpm --filter @agenta/entity-ui types:check` currently stops at the unrelated existing type mismatch in `useModelHarness.tsx:266` (`string | null | undefined` to `string | null`).

## What to QA

- Commit an agent revision with tools, MCP servers, skills, and triggers. Confirm `app_revision_created` includes the agent role and matching feature-composition tags.
- Commit a non-agent app revision. Confirm the role tags are present without agent feature-composition tags.
- Archive an app and create a tool connection. Confirm `app_archived` and `tool_connection_created` carry their listed tags.
- From the Apps page, open an agent playground, create a session, and approve or reject a tool call. Confirm each frontend event fires once with the listed payload.
- Open the tool and trigger pickers, then start adding an MCP server and a skill. Confirm the four discovery events fire once and do not commit configuration by themselves.
