### PR TITLE
[chore] Stop billing users, tighten retention tiers, lower base prices

### DIFF
--- a/api/ee/src/core/access/entitlements/types.py
+++ b/api/ee/src/core/access/entitlements/types.py
@@ -70,8 +70,9 @@ class Retention(int, Enum):
     EPHEMERAL = 0  # instant
     HOURLY = 60  # 1 hour = 60 minutes
     DAILY = 1440  # 24 hours = 1 day = 1440 minutes
+    WEEKLY = 10080  # 7 days = 168 hours = 10080 minutes
     MONTHLY = 44640  # 31 days = 744 hours = 44640 minutes
-    QUARTERLY = 131040  # 91 days = 2184 hours = 131040 minutes
+    QUARTERLY = 132480  # 92 days = 2208 hours = 132480 minutes
     YEARLY = 525600  # 365 days = 8760 hours = 525600 minutes
 
 
@@ -193,7 +194,7 @@ DEFAULT_CATALOG = [
         "description": "Great for hobby projects and POCs.",
         "type": "standard",
         "plan": DefaultPlan.CLOUD_V0_HOBBY.value,
-        "retention": Retention.MONTHLY.value,
+        "retention": Retention.WEEKLY.value,
         "price": {
             "base": {
                 "type": "flat",
@@ -206,7 +207,7 @@ DEFAULT_CATALOG = [
             "20 evaluations/month",
             "5k traces/month",
             "2 seats included",
-            "30 days retention period",
+            "1 week retention period",
             "Community support via Github",
         ],
     },
@@ -215,27 +216,12 @@ DEFAULT_CATALOG = [
         "description": "For production projects.",
         "type": "standard",
         "plan": DefaultPlan.CLOUD_V0_PRO.value,
-        "retention": Retention.QUARTERLY.value,
+        "retention": Retention.MONTHLY.value,
         "price": {
             "base": {
                 "type": "flat",
                 "currency": "USD",
-                "amount": 49.00,
-            },
-            "users": {
-                "type": "tiered",
-                "currency": "USD",
-                "tiers": [
-                    {
-                        "limit": 3,
-                        "amount": 0.00,
-                    },
-                    {
-                        "limit": 10,
-                        "amount": 20.00,
-                        "rate": 1,
-                    },
-                ],
+                "amount": 29.00,
             },
             "traces": {
                 "type": "tiered",
@@ -256,8 +242,8 @@ DEFAULT_CATALOG = [
             "Unlimited prompts",
             "Unlimited evaluations",
             "10k traces / month included then $5 for every 10k",
-            "3 seats included then $20 per seat",
-            "90 days retention period",
+            "Unlimited seats",
+            "1 month retention period",
             "In-app support",
         ],
     },
@@ -266,12 +252,12 @@ DEFAULT_CATALOG = [
         "description": "For scale, security, and support.",
         "type": "standard",
         "plan": DefaultPlan.CLOUD_V0_BUSINESS.value,
-        "retention": Retention.YEARLY.value,
+        "retention": Retention.QUARTERLY.value,
         "price": {
             "base": {
                 "type": "flat",
                 "currency": "USD",
-                "amount": 399.00,
+                "amount": 299.00,
             },
             "traces": {
                 "type": "tiered",
@@ -299,7 +285,7 @@ DEFAULT_CATALOG = [
             "HIPAA BAA [soon]",
             "Private Slack Channel",
             "Business SLA",
-            "365 days retention period",
+            "1 quarter retention period",
         ],
     },
     {
@@ -349,7 +335,7 @@ DEFAULT_ENTITLEMENTS = {
             Counter.TRACES_INGESTED: Quota(
                 free=5_000,
                 limit=5_000,
-                retention=Retention.MONTHLY,
+                retention=Retention.WEEKLY,
                 period=Period.MONTHLY,
             ),
             Counter.TRACES_RETRIEVED: Quota(
@@ -364,11 +350,11 @@ DEFAULT_ENTITLEMENTS = {
                 period=Period.MONTHLY,
             ),
             Counter.EVENTS_INGESTED: Quota(
-                retention=Retention.MONTHLY,
+                retention=Retention.WEEKLY,
                 period=Period.MONTHLY,
             ),
             Counter.RECORDS_INGESTED: Quota(
-                retention=Retention.MONTHLY,
+                retention=Retention.WEEKLY,
                 period=Period.MONTHLY,
             ),
         },
@@ -441,7 +427,7 @@ DEFAULT_ENTITLEMENTS = {
             ),
             Counter.TRACES_INGESTED: Quota(
                 free=10_000,
-                retention=Retention.QUARTERLY,
+                retention=Retention.MONTHLY,
                 period=Period.MONTHLY,
             ),
             Counter.TRACES_RETRIEVED: Quota(
@@ -456,18 +442,16 @@ DEFAULT_ENTITLEMENTS = {
                 period=Period.MONTHLY,
             ),
             Counter.EVENTS_INGESTED: Quota(
-                retention=Retention.QUARTERLY,
+                retention=Retention.MONTHLY,
                 period=Period.MONTHLY,
             ),
             Counter.RECORDS_INGESTED: Quota(
-                retention=Retention.QUARTERLY,
+                retention=Retention.MONTHLY,
                 period=Period.MONTHLY,
             ),
         },
         Tracker.GAUGES: {
             Gauge.USERS: Quota(
-                free=3,
-                limit=10,
                 strict=True,
             ),
         },
@@ -533,7 +517,7 @@ DEFAULT_ENTITLEMENTS = {
             ),
             Counter.TRACES_INGESTED: Quota(
                 free=1_000_000,
-                retention=Retention.YEARLY,
+                retention=Retention.QUARTERLY,
                 period=Period.MONTHLY,
             ),
             Counter.TRACES_RETRIEVED: Quota(
@@ -548,11 +532,11 @@ DEFAULT_ENTITLEMENTS = {
                 period=Period.MONTHLY,
             ),
             Counter.EVENTS_INGESTED: Quota(
-                retention=Retention.YEARLY,
+                retention=Retention.QUARTERLY,
                 period=Period.MONTHLY,
             ),
             Counter.RECORDS_INGESTED: Quota(
-                retention=Retention.YEARLY,
+                retention=Retention.QUARTERLY,
                 period=Period.MONTHLY,
             ),
         },
@@ -695,7 +679,6 @@ DEFAULT_ENTITLEMENTS = {
 # name to report under (`REPORTS[key]`).
 REPORTS: dict[str, str] = {
     Counter.TRACES_INGESTED.value: "traces",
-    Gauge.USERS.value: "users",
 }
 
 CONSTRAINTS = {

--- a/docs/designs/sandbox-metering/specs.md
+++ b/docs/designs/sandbox-metering/specs.md
@@ -1,0 +1,532 @@
+# Sandbox Metering & Entitlements — Design Spec
+
+Status: draft. Phase 0 (stop billing users) is a tiny standalone change, already
+applied. Phase 1 (metering) specified for build; Phase 2 (entitlements & gating)
+specified at design depth; Phases 3–4 (transcript-records metering, S3/SeaweedFS
+storage gauge) sketched at concept depth, to be refined before implementation.
+
+Branch: `feat/add-sandbox-metering`. Base: `big-agents` (same base as the
+`chore/add-sandbox-*` and `chore/add-harness-*` worktrees).
+
+This spec covers sandbox compute (Phases 1–2). It then extends the *same*
+metering machinery to two adjacent session-storage dimensions:
+
+- **Phase 3 — records.** Per-session **records** (the lines of a session
+  transcript). Today they have a retention policy but are **not metered or
+  billed**. Phase 3 adds a counter + billing, mirroring spans exactly: a **max
+  record size** cap, then **meter per-record count**, price set for typical size.
+  (The transcripts→records rename is separate work that lands before Phase 3 —
+  see §6.)
+- **Phase 4 — S3 / SeaweedFS storage.** Session mounts (S3 in prod, SeaweedFS
+  local) accrue durable bytes per org/project. Phase 4 meters stored size as a
+  **gauge** (a level, not a counter) and adds caps + later retention.
+
+> [!NOTE]
+> Naming: what the code calls *transcripts* is really the per-session container;
+> its lines are **transcript records** (events). Phase 3 names the meter for the
+> records, not the container.
+
+---
+
+## 1. Overview
+
+We run user **sessions** inside ephemeral cloud sandboxes (E2B, Daytona; also
+local/Modal). Each live sandbox consumes billable resources. This feature
+ingests per-sandbox resource consumption into the EE meter store and (Phase 2)
+gates sandbox usage through the existing entitlements machinery — so sandbox
+usage behaves like traces: a free tier per plan, soft overage billing on paid
+plans, hard blocks where configured.
+
+Two providers, **two ingestion mechanisms, one sink**:
+
+| Provider | Mechanism | Direction | Trigger |
+|---|---|---|---|
+| **E2B** | Lifecycle **webhook** | push (E2B → us) | `created` / `paused` / `resumed` / `killed` |
+| **Daytona** | Analytics **usage API** | pull (us → Daytona) | periodic poll job |
+
+Both normalize to the same base meters and write through the **same**
+`MetersService.adjust()` / `check_entitlements()` path that traces use. Each
+path is gated on a provider toggle **and** `is_ee()`; neither runs when its
+provider is off.
+
+> [!IMPORTANT]
+> Billing is on **allocation × wall-clock-alive-time**, not on actual CPU
+> utilization. An idle-but-alive sandbox still bills. Do **not** meter from
+> E2B's `getMetrics()` (5s utilization samples) — that is observability only.
+
+---
+
+## 2. Dimensions & degrees of freedom
+
+Sandbox usage is **not one variable**. There are **three independent base
+meters** (four with GPU), each a `rate × duration` integral over the sandbox's
+billable window:
+
+| Base meter (new `Counter`) | Unit | E2B rate | Daytona rate |
+|---|---|---|---|
+| `sandbox_vcpu_seconds` | vCPU·s | $0.000014/s | $0.000014/s |
+| `sandbox_ram_gib_seconds` | GiB·s | $0.0000045/s | $0.0000045/s |
+| `sandbox_disk_gib_seconds` | GiB·s | (paused-only storage) | $0.00000003/s (5 GiB free) |
+| `sandbox_gpu_seconds` *(optional, Daytona)* | GPU·s | n/a | per-GPU rate |
+
+Dollar price is a **derived** linear combination of these with per-region rate
+constants — we store the **physical resource-seconds** (rate-stable,
+re-priceable), not the vendor's dollar figure. Both vendors return raw
+resource-seconds, so this is always available.
+
+**Billable-window semantics differ per provider** and must be encoded per
+provider, not assumed:
+
+- **Daytona** bills the full *alive* window (running **and** stopped — disk
+  persists while stopped). The poll returns cumulative resource-seconds for the
+  window; we don't reconstruct the window ourselves.
+- **E2B** stops **compute** billing the instant a sandbox is `paused` / `killed`
+  / times out; only **storage** accrues while paused. We therefore **must**
+  process `paused`/`resumed` to close and reopen compute windows, or a
+  paused-mid-life session over-bills. A `created`→`killed` pair alone is wrong
+  for any paused session.
+
+---
+
+## 3. How this mirrors the existing meter/entitlements machinery
+
+The EE billing stack already implements exactly the shape we need. We are
+**adding new keys**, not new mechanism.
+
+### 3.1 The taxonomy (`api/ee/src/core/access/entitlements/types.py`)
+
+- `Counter` — monotonic metered usage (`traces_ingested`, `evaluations_run`,
+  `credits_consumed`, `events_ingested`). **Sandbox resource-seconds are
+  counters.**
+- `Quota(free, limit, strict, retention, scope, period)`:
+  - `free` — free-tier allowance for the period.
+  - `limit` — the cap value the predicate compares against.
+  - `strict=True` → **HARD** limit (block at the cap). `strict` falsey →
+    **SOFT** limit (allow overshoot, bill the overage). `limit=None` →
+    unlimited.
+  - `period` — `MONTHLY` for our counters (billing-period accumulation).
+- `REPORTS: dict[str, str]` — the "reportable to Stripe" set. A meter is synced
+  to Stripe **iff** its key is in `REPORTS`; the value is the Stripe-side meter
+  name. Today only `traces` and `users`. **Each sandbox meter we want billed
+  must be added here** with its Stripe meter slug.
+- `DEFAULT_ENTITLEMENTS[plan][Tracker.COUNTERS][counter] = Quota(...)` — this is
+  the **per-plan tiering table**. Tracing's real example, which sandbox meters
+  copy:
+  - Hobby: `Quota(free=5_000, limit=5_000, ...)` — capped at free tier (no
+    overage path; effectively blocked past free).
+  - Pro: `Quota(free=10_000, ...)` — free tier then **soft** (no `limit`/`strict`
+    → unlimited overage, billed).
+  - Business: `Quota(free=1_000_000, ...)` — bigger free tier, soft overage.
+
+This is precisely the "free tier + blocked-in-free, free tier + priced-overage
+in Pro, bigger tier + different price in Business" model requested.
+
+### 3.2 The meter store (`api/ee/src/core/meters/`, `api/ee/src/dbs/postgres/meters/`)
+
+- `Meters` enum (`core/meters/types.py`) mirrors the `Counter`/`Gauge` slugs —
+  **add the four sandbox counters here too.**
+- `MeterScope` = `(organization_id [→ workspace → project → user])`; hierarchy
+  enforced. We meter at **org** scope (with project for attribution).
+- `MetersDAO.adjust(meter, quota, anchor)` — atomic upsert that increments
+  `value += delta`, applies the quota predicate, returns `(allowed, meter,
+  commit_callable)`. Primary key `(organization_id, key, year, month)`;
+  `value` = accumulated, `synced` = last reported to Stripe.
+- `MetersService.report()` — the Stripe sync job. Counters report
+  `delta = value − synced` via `stripe.billing.MeterEvent.create(...)`
+  (deduplicated by a deterministic `identifier`); gauges set absolute quantity
+  via `Subscription.modify`. Sandbox counters ride the **counter** path
+  unchanged.
+
+### 3.3 The entitlement entry point (`api/ee/src/core/access/entitlements/service.py`)
+
+`check_entitlements(*, key, delta, cache, scope, period)` is the single call:
+
+- `cache=True` → **Layer 1** soft-check: Redis-cached read, **never writes DB**,
+  mirrors `adjust()`'s strict/non-strict predicate so it's never stricter than
+  Layer 2.
+- `cache=False` → **Layer 2**: atomic `adjust()` in DB, writes the meter,
+  refreshes/invalidates the Layer-1 cache.
+- `delta` is the increment. **Sandbox ingestion is just
+  `check_entitlements(key=Counter.SANDBOX_*_SECONDS, delta=<resource_seconds>,
+  cache=False, scope=<org scope>)`** — same call traces use, different key and a
+  larger delta.
+- Fails **open** on any non-config error (a meter glitch never blocks a
+  request).
+
+So **Phase 1 ingestion = compute resource-seconds, then call `adjust()` (or
+`check_entitlements(cache=False)`) per provider event/poll-row.** No new billing
+mechanism is introduced.
+
+---
+
+## 3b. Phase 0 — Stop billing users (standalone, applied)
+
+A tiny, self-contained change that ships independently of the sandbox work. We
+**keep metering users** (the `Gauge.USERS` meter and its `delta=±1` adjusts on
+org add/remove stay), but we **stop billing** them and **remove the cap except on
+free**. Three edits, all in `api/ee/src/core/access/entitlements/types.py`:
+
+1. **Stop billing:** drop `Gauge.USERS.value: "users"` from `REPORTS`. Because
+   `REPORTS` membership is the "reportable to Stripe" set, removing it means
+   `report()` skips users (it already skips-and-flushes any key not in `REPORTS`
+   — no error, existing user meters just stop syncing). The gauge keeps
+   incrementing in the DB; it's tracked, not invoiced.
+2. **Remove the cap except on free:** only **Pro** still had a paid cap
+   (`free=3, limit=10, strict=True`) → reduced to `Quota(strict=True)`
+   (`limit=None` ⇒ unlimited, per the `check_entitlements` predicate). Business /
+   Agenta-AI / Self-Hosted-Enterprise were already `Quota(strict=True)` with no
+   limit (uncapped). **Hobby (free) is unchanged** — it keeps `free=2, limit=2,
+   strict=True`.
+3. No change to call sites, `Meters`, or `CONSTRAINTS` — the gauge is still
+   adjusted exactly as before.
+
+Net effect: user count is still observable per org (and still capped on the free
+plan), but no longer a Stripe line item and no longer a hard ceiling on paid
+plans.
+
+---
+
+## 4. Phase 1 — Metering (build target)
+
+Goal: sandbox resource-seconds land in the meter store accurately for both
+providers, gated per provider, with **no gating behavior yet** (record only).
+
+### 4.1 New domain
+
+Follow the standard domain shape (`api/AGENTS.md`): a `sandboxes` (or
+`sandbox_metering`) domain under `apis/fastapi/`, `core/`, `dbs/postgres/`.
+EE-only billing logic stays in `api/ee/src/...`; the webhook receiver route may
+live in OSS (like the Composio receiver) with an `is_ee()`-guarded import for
+the meter write.
+
+New enum members (additive — no migration of existing rows):
+- `Counter.SANDBOX_VCPU_SECONDS = "sandbox_vcpu_seconds"`
+- `Counter.SANDBOX_RAM_GIB_SECONDS = "sandbox_ram_gib_seconds"`
+- `Counter.SANDBOX_DISK_GIB_SECONDS = "sandbox_disk_gib_seconds"`
+- (`Counter.SANDBOX_GPU_SECONDS` optional)
+- Same four mirrored into `Meters`.
+- `DEFAULT_ENTITLEMENTS`: add a `Quota(...)` for each, **per plan** (Phase 1 may
+  set them all unlimited/soft — `Quota(period=Period.MONTHLY)` — so nothing
+  blocks; Phase 2 sets the real free tiers).
+
+### 4.2 E2B ingestion — webhook (push)
+
+E2B's model is the **inverse of Composio's**. With Composio, *Composio*
+generates one signing secret per project and we **fetch** it (idempotent
+`GET/POST /webhook_subscriptions`), cache it encrypted in Redis (TTL 1h,
+auto-refresh), and all containers share it via Redis — no leader. With E2B, **we
+provide the secret** at registration (`POST https://api.e2b.app/events/webhooks`
+with `{name, url, enabled, events[], signature_secret}`).
+
+Decision (mirrors the user's instinct and the Composio storage pattern):
+
+- **Leader-generate once, store like a fetched secret.** At startup, if E2B is
+  enabled, one container generates a 32-byte secret **iff** not already present,
+  using a Redis `SET NX` guard so concurrent containers don't race; the winner
+  registers the webhook with E2B and writes the encrypted secret to the same
+  Redis namespace pattern the Composio resolver uses
+  (`encrypt(secret)`, decrypt on read). Losers read the winner's secret from
+  Redis. Net effect: identical to "store it as if it were the response from
+  Composio," so every API container verifies with the same secret.
+- **Idempotent registration:** `GET /events/webhooks` first; create only if our
+  callback URL isn't already registered (reconcile, don't duplicate). Mirror
+  `ComposioTriggersAdapter.ensure_webhook_subscription()`'s
+  check-then-create-with-conflict-arbitration.
+- **Startup hook:** register in the FastAPI `lifespan()` in
+  `api/entrypoints/routers.py`, guarded `if env.e2b.enabled:` and best-effort
+  (log on failure, don't block startup) — same shape as the Composio block.
+
+Receiver:
+- Route `POST /webhooks/e2b/events/` (public, unauthenticated, mirrors the
+  Composio/Stripe receiver). Verify `sha256(secret + raw_body)` base64 against
+  the `e2b-signature` header (use the **raw** body). Dedupe on
+  `e2b-delivery-id`. Ack fast (202), enqueue to the async broker, do meter work
+  off the request path.
+  > [!WARNING]
+  > E2B has a documented docs-vs-actual mismatch on header names / signature
+  > formatting (github e2b-dev/e2b #1103). Per the "diagnostics over
+  > introspection" rule: log the first real deliveries (headers + computed vs
+  > received signature) and pin the verifier to observed behavior, not the docs.
+
+Meter math (per event):
+- On `killed`/`paused`, payload carries `start_timestamp`, `vCPU`, `memory_mb`,
+  `duration_ms`. Compute `vcpu_seconds = vCPU × duration_ms/1000`,
+  `ram_gib_seconds = (memory_mb/1024) × duration_ms/1000`. Accumulate via
+  `adjust(delta=...)`.
+- On `paused` close the compute window; on `resumed` open a new one. Storage
+  during pause (if billed) accrues to `sandbox_disk_gib_seconds`.
+- **Idempotency:** events are incremental → accumulate, dedupe on
+  `e2b-delivery-id` to survive E2B retries.
+
+### 4.3 Daytona ingestion — poll (pull)
+
+- Auth: org-scoped API key as `Authorization: Bearer` **plus** the mandatory
+  `X-Daytona-Organization-ID` header.
+- Scheduled job (gated `if env.daytona.enabled and is_ee():`) calls, per
+  Agenta org that maps to a Daytona org, with `from = period_start, to = now`:
+  - `GET /organization/{org}/usage/aggregated` → period rollup
+    (`totalCPUSeconds`, `totalRAMGBSeconds`, `totalDiskGBSeconds`,
+    `totalGPUSeconds`, `totalPrice`, `sandboxCount`).
+  - `GET /organization/{org}/usage/sandbox` → per-sandbox breakdown for
+    project/session attribution (optional in Phase 1).
+- **Idempotency:** the poll returns **cumulative** totals for the window → write
+  with **set semantics** (overwrite the period's value to the authoritative
+  total), which is naturally idempotent and self-healing across missed/duplicate
+  runs. (Contrast: E2B accumulates.) This needs either a small extension to the
+  meter write to support "set to absolute" vs "increment by delta", or we
+  compute `delta = authoritative_total − current_value` and feed that to
+  `adjust()`. Prefer the delta approach to reuse `adjust()` unchanged.
+- **Job scheduling / lock:** reuse the existing singleton-job lock pattern
+  (Redis lock + TTL, self-healing on crash) used by `report()` so only one
+  worker polls per interval.
+
+### 4.4 Provider toggles & local dev
+
+- Env config in `api/oss/src/utils/env.py` (per `api/CLAUDE.md` — never
+  `os.getenv` in feature code). Two new config blocks with an `enabled`
+  property that is true only when required vars are present (mirror
+  `AIServicesConfig.enabled`):
+  - `E2BConfig`: `api_key`, optional `webhook_url` override, `enabled`.
+  - `DaytonaConfig`: `api_key`, `organization_id`/mapping, `api_url`, `enabled`.
+- Every ingestion entry point is double-gated: provider `.enabled` **and**
+  `is_ee()`.
+
+**Local-dev bridge — E2B genuinely needs a public URL; Composio does not.** The
+Composio "tunnel" is **not ngrok** — it's a WebSocket bridge
+(`api/entrypoints/dispatcher_composio.py`) that subscribes to Composio's
+WebSocket and forwards events to the in-network API. E2B has **no** WebSocket
+subscribe API; it only HTTP-pushes to a public URL. So for E2B local dev we need
+the **inverse**: an **ngrok-style public tunnel** that exposes the local API's
+`/webhooks/e2b/events/` and a registration that points E2B at that public URL.
+
+- Add an `e2b-bridge` (or `e2b-tunnel`) docker-compose service under the
+  `with-tunnel` profile in the `ee` + `oss` dev compose files, placed after the
+  `triggers-bridge`/`composio` service. For E2B this service runs **ngrok**
+  (not a WS dispatcher), and the public URL it mints is fed to startup
+  registration as the E2B `webhook_url` override (`env.e2b.webhook_url`). Add a
+  `run.sh` flag to toggle it independently (`--e2b-tunnel` / off by default), so
+  it only starts when E2B is being exercised locally.
+
+---
+
+## 5. Phase 2 — Entitlements & gating (design depth)
+
+Once meters are populated, gate sandbox usage like traces. No new mechanism —
+set the per-plan `Quota` table and wire the checks.
+
+### 5.1 Per-plan tiers (`DEFAULT_ENTITLEMENTS`)
+
+Replace the Phase-1 unlimited quotas with real tiers per base meter, e.g.
+(numbers TBD by pricing):
+- **Hobby**: small free allowance, **hard** (`strict=True`, `limit=free`) — no
+  paid sandbox usage on free.
+- **Pro**: larger free allowance, then **soft** overage (no `limit`/`strict`),
+  billed via Stripe.
+- **Business**: bigger free allowance, soft overage, possibly different Stripe
+  price.
+- Self-hosted / enterprise: unlimited.
+
+Add each billed meter to `REPORTS` with its Stripe meter slug, and register the
+corresponding Stripe prices per plan (the `get_stripe_meter_price(plan, name)`
+path `report()` already uses).
+
+### 5.2 Two-layer gating, adapted to post-hoc usage
+
+Tracing checks at ingestion. Sandbox usage is **post-hoc** — the authoritative
+resource-seconds only arrive on E2B `kill`/`pause` or the next Daytona poll. So
+the two layers map to **lifecycle moments**, not a single request:
+
+- **Layer 1 — create-time soft pre-check** (the real gatekeeping lever): before
+  launching a sandbox, `check_entitlements(key=..., cache=True)` against the
+  current meter; refuse to spin one up if the org is already over quota. To
+  account for in-flight cost, estimate live accrual
+  (`allocated_vcpu × elapsed + …`) and add it to the cached value for the
+  decision.
+- **Layer 2 — post-hoc true-up**: the webhook/poll `adjust(cache=False)` writes
+  the authoritative value and reconciles the cache.
+
+> [!IMPORTANT]
+> Keep **permissions** separate from **entitlements**. RBAC (`RUN_SESSIONS`)
+> answers "may this user run a sandbox"; entitlements answer "does this org have
+> sandbox quota left." Do not gate one through the other.
+
+### 5.3 Mid-session enforcement (hardest part, scope-flag it)
+
+Create-time gating is cheap and is the recommended default. Killing an
+**in-flight** over-quota session requires the sandbox **kill** API wired to the
+entitlement breach — which ties into the missing-user-kill gap already noted for
+sessions (`DELETE /sessions/streams/{id}` + runner `/kill`). Recommend Phase 2a
+= create-time gating only; Phase 2b = mid-session kill, dependent on the kill
+endpoint landing.
+
+---
+
+## 5b. Where each existing metered-ish thing stands (the map this builds on)
+
+Before Phases 3–4, the lay of the land in the meter taxonomy today:
+
+| Thing | Tracked? | Metered? | Billed (`REPORTS`)? | Retention? | Family |
+| --- | --- | --- | --- | --- | --- |
+| **Spans / traces** | yes | yes (`traces_ingested`) | **yes** (`"traces"`) | per-plan `Retention` | Counter |
+| **Events** (internal) | yes | yes (`events_ingested`) | **no** (not in `REPORTS`) | per-plan `Retention` | Counter |
+| **Records** (transcript lines) | yes (records persisted) | **no** | no | retention only (today) | — (Phase 3 adds Counter, count + max-size cap) |
+| **Users** | yes | yes (`users`) | **no** (Phase 0 dropped from `REPORTS`; capped on free only) | n/a | Gauge |
+| **Sandbox compute** | — | Phase 1 | Phase 2 | n/a | Counter ×3 |
+| **S3 / SeaweedFS storage** | — | Phase 4 | Phase 4 | later | **Gauge** (Phase 4) |
+
+The pattern to copy is explicit: **events** show a counter that is metered for
+*retention sizing* but deliberately **absent from `REPORTS`** (tracked, not
+billed). **traces** show the full metered+billed counter. **users** show the
+only existing **gauge** (a level, Stripe-synced as absolute quantity). Phase 3 =
+"make transcript records like traces." Phase 4 = "make storage like users
+(a gauge), but org/project-scoped and capped."
+
+---
+
+## 6 (Phase 3). Records metering & billing
+
+Goal: per-session **records** become a first-class metered, billable counter,
+**exactly like spans** — free tier per plan, soft overage on paid plans,
+retention per plan.
+
+> [!IMPORTANT]
+> **The transcripts→records rename is NOT part of Phase 3.** It lands separately
+> (another branch merged/rebased into this one before Phase 3 starts). Phase 3
+> assumes the domain is already named `records` and only adds the **metering +
+> billing** on top. Do not do any renaming here.
+
+**Unit decision — count, with a max-size cap (the spans model, decided).**
+Meter **per record (count)**, not bytes — this is precisely what spans do, and
+it's the right call:
+
+- Spans already meter by **count of root spans**:
+  `delta = sum(1 for span in spans if span.parent_id is None)`
+  (`api/oss/src/apis/fastapi/otlp/router.py`), not by byte size.
+- That works because each unit is **size-bounded**: the OTLP ingest enforces a
+  max payload (`MAX_OTLP_BATCH_SIZE = env.agenta.otlp.max_batch_bytes`, `413`
+  past the cap) plus per-worker byte limits. A bounded unit makes per-count
+  billing fair; the **per-record price is set to reflect the typical record
+  size** rather than billing raw bytes.
+- So records do the same: **enforce a max record size** (cap, reject/refuse
+  oversize like the OTLP `413`), then **meter `delta = count of records`**, and
+  modulate the per-record price for typical size. Byte-level metering is
+  reserved for genuine *storage* (Phase 4 gauge), not records.
+
+This is the most mechanical phase: the spans pattern with a new key. No new
+ingestion mechanism, no provider integration.
+
+- **Max record size:** confirm/define the per-record size cap (analogue of the
+  OTLP batch/span byte limit). If the records ingest path already has a size
+  guard, reuse it; otherwise add one (`env`-configured, reject oversize at the
+  edge). This bound is what makes per-count billing fair.
+- **New counter:** `Counter.RECORDS_INGESTED = "records_ingested"`. Mirror into
+  `Meters`. (Assumes the records domain already exists post-rename — Phase 3 only
+  adds the meter key, not the domain.)
+- **Per-plan `Quota`:** add to every plan in `DEFAULT_ENTITLEMENTS` with a
+  `free` tier + `period=MONTHLY` + a `retention=Retention.*` matching the plan
+  (Hobby `MONTHLY`, Pro `QUARTERLY`, Business `YEARLY`) — same shape traces use.
+  The `retention` field is what already drives record retention; it becomes the
+  *single* source for both the retention window and the metered allowance.
+- **Ingestion call site:** wherever records are persisted (the sessions/records
+  worker), add the same two-layer pair traces use:
+  `check_entitlements(key=Counter.RECORDS_INGESTED, delta=<n_records>,
+  cache=True)` at the request edge and `cache=False` in the persisting worker.
+  Delta = number of records in the batch (one per record, mirroring the
+  count-root-spans delta).
+- **Billing:** add `Counter.RECORDS_INGESTED.value: "records"` to `REPORTS`, and
+  the per-plan Stripe price under a `"records"` slot in `AGENTA_BILLING_PRICING`.
+  `report()` syncs it as a counter MeterEvent unchanged. Price-per-record chosen
+  to absorb the typical record size.
+- **Retention** continues to be driven by the `Quota.retention` field as today;
+  Phase 3 does not change the retention sweep, it just also bills.
+
+---
+
+## 7 (Phase 4). S3 / SeaweedFS mount storage — a gauge, not a counter
+
+Goal: meter durable bytes stored under session mounts (S3 in prod, SeaweedFS
+local), per org and per project, and add caps. Billing later; retention later.
+
+**This one is structurally different from every phase above: it is a GAUGE.**
+Counters accumulate monotonically over a billing period and reset; a gauge is a
+**level** — the current total size of stored data, which goes up on write and
+**down on delete**. The only existing gauge is `Gauge.USERS`, and it is the
+template:
+
+- **New gauge:** `Gauge.STORAGE_BYTES = "storage_bytes"` (mirror into `Meters`).
+  Consider a second gauge keyed at project scope if per-project caps are needed
+  (`MeterScope` already supports `project_id` under `organization_id`).
+- **Delta semantics:** adjust the gauge by **signed delta** the same way USERS
+  does (`check_entitlements(key=Gauge.STORAGE_BYTES, delta=+bytes)` on write,
+  `delta=-bytes` on delete). The meter `value` is the live total. Stripe sync
+  (`report()`) already treats gauges as **absolute quantity** via
+  `Subscription.modify` — correct for "current GB stored."
+- **Source of truth for size:** do **not** trust per-operation deltas alone to
+  stay consistent forever (drift on crashes/aborted multipart). Pair the
+  incremental deltas with a **periodic reconcile** that reads authoritative
+  usage from the backend and *sets* the gauge:
+  - **S3:** CloudWatch `BucketSizeBytes` per bucket, or S3 Storage Lens, or a
+    prefix-scoped `ListObjectsV2` size sum per `org/project` prefix.
+  - **SeaweedFS (local):** filer/volume size APIs or a `du`-equivalent over the
+    org/project prefix.
+  This mirrors the sandbox **poll** idea (Daytona): authoritative absolute value
+  on a schedule, reconciled into the gauge as `delta = authoritative − current`.
+- **Scoping:** key bytes by `org/project` prefix in the mount layout so the
+  reconcile and the meter scope line up (`MeterScope(organization_id,
+  workspace_id, project_id)`). The mount path convention must encode org+project
+  so size is attributable without per-file bookkeeping.
+- **Caps (the point of Phase 4):** a storage gauge with `Quota(free=<GiB>,
+  limit=<GiB>, strict=True)` per plan blocks new writes past the cap. Because the
+  write path is synchronous, the **create-time soft pre-check** is a genuine
+  gate here (unlike sandbox compute's post-hoc cost): check the gauge before
+  accepting an upload.
+- **Billing:** negligible per-GiB early; defer `REPORTS`/Stripe until volume
+  justifies it. Add `Gauge.STORAGE_BYTES.value: "storage"` to `REPORTS` + a
+  per-plan `"storage"` price when ready — no mechanism change.
+- **Retention:** later. A retention sweep that deletes old mount data simply
+  emits negative deltas (and the periodic reconcile corrects any drift).
+
+> [!IMPORTANT]
+> Gauge vs counter is the load-bearing distinction. Storage is the *amount held
+> right now*; sandbox-seconds and transcript-records are *amounts consumed this
+> period*. Modeling storage as a counter would never decrement on delete and
+> would bill cumulative writes instead of held size — wrong. Use the gauge path.
+
+---
+
+## 8. Open questions
+
+1. **Daytona org mapping:** how does an Agenta org resolve to a Daytona
+   organization id for the poll? One shared Daytona org for the platform, or one
+   per tenant? Determines whether `/usage/sandbox` attribution is required in
+   Phase 1.
+2. **Absolute-set vs delta for the poll:** confirm the `delta = total − current`
+   approach reuses `adjust()` cleanly across month boundaries (the cumulative
+   window must be clamped to the billing period, using the same anchor logic).
+3. **Disk while paused (E2B):** confirm whether we bill E2B paused-storage at
+   all in v1, or defer it (compute-only first).
+4. **GPU:** include `sandbox_gpu_seconds` now or defer until a GPU sandbox SKU
+   exists?
+5. **Stripe meter slugs & prices:** exact `REPORTS` names and per-plan price ids
+   (Phase 2, pricing-owned).
+
+---
+
+## 7. References (code, this worktree)
+
+- Entitlement types / plan tiers / `REPORTS`:
+  `api/ee/src/core/access/entitlements/types.py`
+- Entitlement entry point (two-layer):
+  `api/ee/src/core/access/entitlements/service.py` (`check_entitlements`)
+- Meter store: `api/ee/src/core/meters/{service,types}.py`,
+  `api/ee/src/dbs/postgres/meters/dao.py`
+- Stripe sync job: `MetersService.report()` in
+  `api/ee/src/core/meters/service.py`
+- Composio receiver / secret resolver (the pattern E2B inverts):
+  `api/oss/src/apis/fastapi/triggers/router.py`,
+  `api/oss/src/core/triggers/{service,utils}.py`,
+  `api/oss/src/core/triggers/providers/composio/adapter.py`
+- Composio startup registration: `lifespan()` in `api/entrypoints/routers.py`
+- Local-dev bridge (WebSocket, not ngrok):
+  `api/entrypoints/dispatcher_composio.py`; compose `with-tunnel` profile
+- Env/provider-toggle pattern: `api/oss/src/utils/env.py` (`*.enabled`)

--- a/docs/designs/sandbox-metering/tasks.md
+++ b/docs/designs/sandbox-metering/tasks.md
@@ -1,0 +1,260 @@
+# Tasks: Sandbox Metering & Entitlements
+
+Status: draft. Phase 1 is the build target; Phase 2 tasks are listed at design
+depth and will be refined (and pricing numbers filled in) before implementation.
+
+Conventions: new domain code follows `api/AGENTS.md` (Router → Service → DAO,
+DTOs not dicts, domain exceptions, env via `api/oss/src/utils/env.py`, no
+`os.getenv` in feature code). Every ingestion entry point is double-gated on the
+provider `.enabled` flag **and** `is_ee()`.
+
+---
+
+## Phase 0 — Stop billing users (applied)
+
+All in `api/ee/src/core/access/entitlements/types.py`.
+
+- [x] Remove `Gauge.USERS.value: "users"` from `REPORTS` (stop Stripe billing;
+  `report()` skips-and-flushes non-`REPORTS` keys, no error).
+- [x] Pro plan `Gauge.USERS`: `free=3, limit=10, strict=True` → `Quota(strict=True)`
+  (uncapped). Hobby (free) unchanged (`free=2, limit=2, strict=True`); Business /
+  Agenta-AI / Self-Hosted already uncapped.
+- [ ] Verify: adding users past 10 on Pro succeeds; the free plan still blocks
+  past 2; no `users` line in the next Stripe report run.
+- [ ] Note for ops: stale `users` price item on existing Pro/Business
+  subscriptions can be left or cleaned up separately (not load-bearing — it just
+  stops receiving usage).
+
+---
+
+## Phase 1 — Metering
+
+### Meter & entitlement keys (additive, no row migration)
+
+- [ ] Add sandbox counters to `Counter` in
+  `api/ee/src/core/access/entitlements/types.py`:
+  `SANDBOX_VCPU_SECONDS`, `SANDBOX_RAM_GIB_SECONDS`, `SANDBOX_DISK_GIB_SECONDS`
+  (+ optional `SANDBOX_GPU_SECONDS`).
+- [ ] Mirror the same members into `Meters` in `api/ee/src/core/meters/types.py`.
+- [ ] Add a Phase-1 **non-blocking** `Quota(period=Period.MONTHLY)` (no
+  `free`/`limit`/`strict`) for each new counter, in every plan of
+  `DEFAULT_ENTITLEMENTS`, so metering records without gating yet.
+- [ ] Confirm `compute_meter_id` (UUIDv5 over scope+period+key) and the
+  `(organization_id, key, year, month)` PK handle the new keys with no schema
+  change (they should — keys are generic).
+
+### Env config & provider toggles (`api/oss/src/utils/env.py`)
+
+- [ ] Add `E2BConfig` (`api_key`, optional `webhook_url` override) with an
+  `enabled` property true only when required vars are present (mirror
+  `AIServicesConfig`). Env: `AGENTA_E2B_API_KEY`, `AGENTA_E2B_WEBHOOK_URL`.
+- [ ] Add `DaytonaConfig` (`api_key`, `api_url`, org mapping) with `enabled`.
+  Env: `AGENTA_DAYTONA_API_KEY`, `AGENTA_DAYTONA_API_URL`,
+  `AGENTA_DAYTONA_ORGANIZATION_ID`.
+- [ ] Expose both on the shared `env` object.
+
+### New domain skeleton
+
+- [ ] Create the domain folders (`apis/fastapi/<sandboxes>/`, `core/<sandboxes>/`,
+  `dbs/postgres/<sandboxes>/`) per the standard shape. Decide name:
+  `sandbox_metering`.
+- [ ] Define typed DTOs in `core/<sandboxes>/dtos.py`:
+  `SandboxUsageDTO` (provider, sandbox_id, org/project scope, vcpu_seconds,
+  ram_gib_seconds, disk_gib_seconds, window start/end, source event id).
+- [ ] Define domain exceptions in `core/<sandboxes>/types.py` (e.g.
+  `SandboxWebhookSignatureInvalid`, `SandboxProviderDisabled`); catch at the
+  router boundary.
+- [ ] `core/<sandboxes>/service.py`: a `record_usage()` that converts a
+  `SandboxUsageDTO` into `check_entitlements(cache=False)` (or
+  `MetersService.adjust`) calls — **one per base meter** — at org scope. This is
+  the single sink both providers feed.
+
+### E2B — webhook receiver + secret + registration
+
+- [ ] **Secret (leader-generate, store like Composio's fetched secret):** at
+  startup, generate a 32-byte secret under a Redis `SET NX` guard so only one
+  container creates it; store `encrypt(secret)` in a Redis namespace mirroring
+  the Composio resolver (`api/oss/src/core/triggers/utils.py`
+  `WebhookSecretResolver`). Other containers read+decrypt the same value.
+- [ ] **Registration:** `ensure_e2b_webhook_registered()` — `GET
+  /events/webhooks` to reconcile, `POST /events/webhooks` with
+  `{name, url, enabled, events:[created,paused,resumed,killed], signature_secret}`
+  only if our callback URL isn't already registered. Mirror
+  `ComposioTriggersAdapter.ensure_webhook_subscription()`'s idempotent
+  check-then-create.
+- [ ] **Startup hook:** call it from `lifespan()` in
+  `api/entrypoints/routers.py`, guarded `if env.e2b.enabled:`, best-effort
+  (log on failure, don't block startup) — same shape as the Composio block.
+- [ ] **Receiver route** `POST /webhooks/e2b/events/` (public, unauthenticated;
+  mirror the Composio receiver in
+  `api/oss/src/apis/fastapi/triggers/router.py`). Verify
+  `sha256(secret + raw_body)` base64 vs `e2b-signature`; **read raw body**.
+- [ ] **Dedupe** on `e2b-delivery-id`. Ack 202 fast; enqueue to the async broker
+  (Redis stream like `streams:sandbox` / TaskIQ), do meter work off-request.
+- [ ] **Verifier diagnostics:** log first real deliveries (headers + computed vs
+  received signature); pin to observed behavior (E2B docs/header mismatch,
+  e2b-dev/e2b #1103).
+- [ ] **Window math in the worker:** on `killed`/`paused` compute
+  `vcpu_seconds = vCPU × duration_ms/1000`,
+  `ram_gib_seconds = (memory_mb/1024) × duration_ms/1000`; `resumed` opens a new
+  window. Accumulate via the `record_usage()` sink (incremental + delivery-id
+  dedupe).
+
+### Daytona — poll job
+
+- [ ] Poll job (reuse the singleton Redis-lock + TTL pattern that guards
+  `MetersService.report()`), gated `if env.daytona.enabled and is_ee():`.
+- [ ] HTTP client (typed DTO return, per `api/AGENTS.md`): `Authorization:
+  Bearer <key>` + `X-Daytona-Organization-ID` header. Call
+  `GET /organization/{org}/usage/aggregated` with `from=period_start,to=now`;
+  optionally `GET /organization/{org}/usage/sandbox` for attribution.
+- [ ] **Cumulative → delta write:** compute
+  `delta = authoritative_total_for_period − current_meter_value` per base meter
+  and feed `adjust()` (reuses `adjust()` unchanged; idempotent and
+  self-healing). Clamp the window to the billing period using the org anchor
+  (same anchor logic `check_entitlements`/`dao` already use).
+- [ ] Resolve Agenta-org → Daytona-org mapping (see open question 1).
+
+### Local dev bridge (E2B only)
+
+- [ ] Add an `e2b-bridge` docker-compose service under the `with-tunnel` profile
+  in the `ee` + `oss` **dev** compose files (after the `triggers-bridge`
+  service). Unlike the Composio WS dispatcher, this runs **ngrok** to expose the
+  local API's `/webhooks/e2b/events/`.
+- [ ] Feed the minted public URL into startup registration as
+  `env.e2b.webhook_url`.
+- [ ] Add a `run.sh` flag to toggle it independently (`--e2b-tunnel`, off by
+  default), so it only starts when E2B is exercised locally.
+
+### Verification (Phase 1)
+
+- [ ] Acceptance: an E2B `killed` webhook (signed) increments the three sandbox
+  counters for the org by the expected resource-seconds; replayed delivery
+  (same `e2b-delivery-id`) does not double-count.
+- [ ] Acceptance: a Daytona poll cycle writes the period totals; a second poll
+  with unchanged upstream totals is a no-op (delta 0).
+- [ ] With both providers disabled, neither the receiver registration, the poll
+  job, nor the bridge runs.
+- [ ] EE/OSS test accounts per `feedback_oss_ee_test_accounts` for any ungated
+  endpoint.
+
+---
+
+## Phase 2 — Entitlements & gating (design depth)
+
+### Per-plan tiers & Stripe wiring
+
+- [ ] Replace Phase-1 non-blocking quotas with real per-plan `Quota`s in
+  `DEFAULT_ENTITLEMENTS` (Hobby hard at free tier; Pro/Business free tier + soft
+  overage). Numbers owned by pricing.
+- [ ] Add each billed meter to `REPORTS` (`{counter.value: "<stripe slug>"}`)
+  so `MetersService.report()` syncs it (counters → `billing.MeterEvent.create`,
+  delta = value − synced).
+- [ ] Add per-plan Stripe price ids under the new slot names to
+  `AGENTA_BILLING_PRICING` (resolved by `get_stripe_meter_price(plan, name)` in
+  `api/ee/src/core/subscriptions/settings.py`). No `report()` code change.
+
+### Gating
+
+- [ ] **Create-time soft pre-check (Layer 1):** before launching a sandbox,
+  `check_entitlements(key=..., cache=True, scope=org)`; refuse launch if over.
+  Estimate in-flight accrual (`allocated_vcpu × elapsed + …`) and add to the
+  cached value for the decision.
+- [ ] **Post-hoc true-up (Layer 2):** the webhook/poll `record_usage()` already
+  does `adjust(cache=False)` — confirm it reconciles the Layer-1 cache
+  (the entitlements service already invalidates on reject).
+- [ ] Keep RBAC (`RUN_SESSIONS`) separate from the entitlement check
+  (`feedback_permissions_vs_entitlements`): permission = may-run, entitlement =
+  has-quota.
+
+### Mid-session enforcement (2b, dependent)
+
+- [ ] Wire an over-quota breach to the sandbox **kill** path. Depends on the
+  missing user-kill endpoint (`DELETE /sessions/streams/{id}` + runner `/kill`)
+  landing. Recommend shipping 2a (create-time gating) first.
+
+### Open questions to resolve before Phase 2 build
+
+- [ ] Daytona org mapping model (platform-wide vs per-tenant).
+- [ ] Bill E2B paused-storage in v1, or compute-only first?
+- [ ] Include GPU seconds now or defer?
+- [ ] Final Stripe meter slugs + per-plan price ids.
+
+---
+
+## Phase 3 — Records metering & billing
+
+The spans pattern with a new key: max-size cap + meter per-record count + price
+for typical size. No provider integration, no new mechanism. Unit = **count**
+(decided — mirrors `delta = count root spans`), not bytes.
+
+> **Dependency (not a Phase 3 task):** the transcripts→records **rename** lands
+> separately — another branch merged/rebased into this one before Phase 3
+> starts. Phase 3 assumes the domain is already `records` and does **no**
+> renaming; it only adds the meter key + billing.
+
+- [ ] Max record size: confirm/define a per-record size cap (analogue of
+  `MAX_OTLP_BATCH_SIZE` / per-span byte limit). Reuse an existing size guard on
+  the records path if present; else add an `env`-configured cap that rejects
+  oversize at the edge (like the OTLP `413`). This bound is what makes
+  per-count billing fair.
+- [ ] Add `Counter.RECORDS_INGESTED = "records_ingested"` to
+  `entitlements/types.py` and mirror into `Meters` (`core/meters/types.py`).
+- [ ] Add a per-plan `Quota(free=..., period=MONTHLY, retention=Retention.*)` to
+  every plan in `DEFAULT_ENTITLEMENTS` (retention matches the plan tier, as
+  traces do). Confirm this is the same field already driving record retention so
+  the window and the metered allowance share one source.
+- [ ] Wire the two-layer check at the records persist path:
+  `check_entitlements(key=Counter.RECORDS_INGESTED, delta=<n_records>,
+  cache=True)` at the request edge, `cache=False` in the worker (mirror the
+  OTLP-router + tracing-worker pair). Delta = one per record.
+- [ ] Billing: add `Counter.RECORDS_INGESTED.value: "records"` to `REPORTS`; add
+  a `"records"` price slot per plan to `AGENTA_BILLING_PRICING` (price-per-record
+  set for typical record size). No `report()` change.
+- [ ] Acceptance: persisting N records increments the counter by N; an oversize
+  record is rejected at the cap; retention sweep unchanged; meter appears in the
+  Stripe report once in `REPORTS`.
+
+---
+
+## Phase 4 — S3 / SeaweedFS storage gauge + caps
+
+Structurally different: a **gauge** (level), not a counter. `Gauge.USERS` is the
+template. Caps now; billing/retention later.
+
+- [ ] Add `Gauge.STORAGE_BYTES = "storage_bytes"` to `entitlements/types.py`,
+  mirror into `Meters`. Decide org-scope only vs also project-scope gauge.
+- [ ] Mount-layout prerequisite: ensure the S3/SeaweedFS path convention encodes
+  `org/project` prefix so stored size is attributable to a `MeterScope` without
+  per-file bookkeeping.
+- [ ] Incremental deltas: on mount write `check_entitlements(key=Gauge.STORAGE_BYTES,
+  delta=+bytes, scope=org[/project])`; on delete `delta=-bytes`. Gauge `value` =
+  live total.
+- [ ] Periodic reconcile job (mirror the Daytona poll/lock pattern): read
+  authoritative size and set the gauge via `delta = authoritative − current`.
+  - [ ] S3 source: CloudWatch `BucketSizeBytes` / Storage Lens / prefix-scoped
+    `ListObjectsV2` size sum.
+  - [ ] SeaweedFS source: filer/volume size API over the org/project prefix.
+- [ ] Caps: add `Quota(free=<GiB>, limit=<GiB>, strict=True)` per plan. Enforce
+  with a **synchronous create-time check** on the write path (genuine gate here,
+  unlike post-hoc sandbox compute).
+- [ ] Provider/scope toggle + `is_ee()` gating on the reconcile job, mirroring
+  Phase 1.
+- [ ] Billing (defer until volume justifies): add
+  `Gauge.STORAGE_BYTES.value: "storage"` to `REPORTS` + per-plan `"storage"`
+  price. `report()` syncs gauges as absolute quantity (`Subscription.modify`) —
+  no change.
+- [ ] Retention (later): a sweep deleting old mount data emits negative deltas;
+  the reconcile corrects drift.
+- [ ] Acceptance: write then delete the same bytes returns the gauge to its prior
+  level; reconcile corrects an injected drift; a write past the cap is rejected.
+
+### Open questions to resolve before Phase 3/4 build
+
+- [x] Record unit: **count + max-size cap** (decided — spans model). Not bytes.
+- [ ] Exact per-record size cap value, and whether an existing records-path size
+  guard already provides it (Phase 3).
+- [ ] Storage gauge scope: org-only vs org+project (Phase 4).
+- [ ] Authoritative S3 size source (CloudWatch vs Storage Lens vs list-sum) and
+  its latency/cost vs reconcile frequency.
+- [ ] Per-GiB price + free-tier GiB per plan (defer-billing decision).


### PR DESCRIPTION
## Context

This is the first, standalone step of the metering rework: changes to the **existing** meters and **existing** billing only. New meters (sandbox compute, records, storage) and new billing land in later tracks. Three things change here, all entangled with current pricing so they ship together and ahead of everything else:

1. We stop billing for users.
2. Data-retention windows shorten by one tier per plan.
3. Base prices drop on Pro and Business.

Everything lives in `api/ee/src/core/access/entitlements/types.py` (the `DEFAULT_ENTITLEMENTS` quotas that are enforced, plus the `DEFAULT_CATALOG` metadata the pricing modal renders) and its `REPORTS` map (what gets synced to Stripe).

## Changes

**Stop billing users.** `Gauge.USERS` is removed from `REPORTS`, so user count is no longer synced to Stripe. The gauge stays in place, so users are still metered and still capped on the free plan (Hobby remains hard-capped at 2). The Pro users quota is loosened to uncapped (dropping `free=3, limit=10`, keeping `strict`). Business, Agenta-AI, and Self-Hosted were already uncapped. In the catalog, the Pro `users` tiered price block and the "3 seats included then $20 per seat" line are gone; Pro and Business now read "Unlimited seats".

**Retention shifts down one tier per plan.** A new `Retention.WEEKLY = 10080` (7 days, in minutes) is added, and `QUARTERLY` is corrected to 92 days (`132480`). The three data meters (`TRACES_INGESTED`, `EVENTS_INGESTED`, `RECORDS_INGESTED`) move:

```
             before              after
Hobby        MONTHLY   (1 month) WEEKLY    (1 week)
Pro          QUARTERLY (1 quarter) MONTHLY (1 month)
Business     YEARLY    (1 year)  QUARTERLY (1 quarter)
Enterprise   unlimited           unlimited (unchanged)
```

Both sides move together: the enforced `DEFAULT_ENTITLEMENTS` quotas and the displayed `DEFAULT_CATALOG` (`retention` field plus the feature text, now phrased "1 week / 1 month / 1 quarter retention period" rather than day counts). The retention sweep reads `quota.retention` as raw minutes, so `WEEKLY` needs no consumer change.

**Base prices lowered** (catalog display amounts): Hobby $0 (unchanged), Pro $49 -> $29, Business $399 -> $299.

## Stripe / manual steps (outside the codebase)

The code changes what we display and what we enforce, and it stops us *sending* user updates to Stripe. It does not change existing subscriptions on Stripe's side. Those need manual work, because of how Stripe models this:

- **Users is a gauge.** `report()` bills gauges with `stripe.Subscription.modify(items=[{id, quantity}])`, which sets an absolute subscription-item quantity that Stripe keeps charging every cycle until the item is removed. Removing the key from `REPORTS` stops the updates but does **not** stop the charge. For every existing Pro/Business subscription, the `users` subscription item must be removed (delete it, or set quantity 0) so current subscribers stop being charged.

- **Stripe Prices are immutable.** You cannot edit the amount on an existing price. For the base-price drop, create new base price IDs at $29 / $299, point `AGENTA_BILLING_PRICING[<plan>]["base"]["price"]` at them (covers new subscriptions), then migrate each existing subscription's base item to the new price with `SubscriptionItem.modify` (mind `proration_behavior` so mid-cycle isn't a surprise credit or charge). Traces pricing is unchanged; users pricing is disappearing.

Order of operations: merge/deploy the code first (stops new user updates and stops new subscriptions attaching a `users` item), then sweep existing subscriptions.

## Tests / notes

- `ruff format` + `ruff check` clean on the changed file.
- Verified by import: `DEFAULT_ENTITLEMENTS` (enforced) and `DEFAULT_CATALOG` (displayed) agree per plan on retention; `Gauge.USERS` is absent from `REPORTS`; base amounts are $0 / $29 / $299; the Pro `users` price block is gone.
- The frontend pricing modal renders from the backend catalog (`plan.price.base.amount`, `plan.features`), so these edits flow to the UI with no frontend change. The unused `PRICING_PLANS_INFO` constant in `web/ee` is dead code and is intentionally left out of scope.
- Base branch is `big-agents`. This PR is the base of the metering stack; the two design docs (`docs/designs/sandbox-metering/{specs,tasks}.md`) land here so they're committed once.

## What to QA

- Open the pricing modal: Hobby shows $0 and "1 week retention period"; Pro shows $29, "1 month retention period", "Unlimited seats"; Business shows $299, "1 quarter retention period", "Unlimited seats". No per-seat pricing line anywhere.
- On a Pro org, add users past the old cap of 10: it should succeed. On the free plan, adding a 3rd user should still be blocked.
- Trigger a `report()` run and check the `[stripe]` logs: no `users` line should appear.
- Retention sweep: confirm the flush job uses the new cutoffs (e.g. Hobby traces older than 7 days get swept).
