### PR TITLE
fix(frontend): surface nameless tools (workflow references) in the commit-diff Tools section

### DIFF
--- a/web/packages/agenta-entities/src/workflow/commitDiff/accessors.ts
+++ b/web/packages/agenta-entities/src/workflow/commitDiff/accessors.ts
@@ -74,7 +74,14 @@ function normalizeTool(raw: unknown, index: number): NormalizedTool | null {
     if (!isObj(raw)) return null
     const key = agentItemIdentity("tool", raw, index)
     const fingerprint = stableStringify(raw)
-    const fn = isObj(raw.function) ? raw.function : undefined
+    // Function tool: either the wrapped `{function:{name,...}}` shape or the flat legacy
+    // `{name, description, parameters}` shape (guarded so reference/builtin tools, which carry a
+    // non-function `type`, don't get misread as flat function tools).
+    const fn = isObj(raw.function)
+        ? raw.function
+        : (raw.type === undefined || raw.type === "function") && typeof raw.name === "string"
+          ? raw
+          : undefined
     const fnName = fn && typeof fn.name === "string" ? fn.name : undefined
 
     // Function / gateway tool.

--- a/web/packages/agenta-entities/src/workflow/commitDiff/accessors.ts
+++ b/web/packages/agenta-entities/src/workflow/commitDiff/accessors.ts
@@ -8,6 +8,7 @@
  * Pure and dependency-free so it can be unit-tested against fixtures for each shape.
  */
 import {parseGatewayToolName} from "./gatewayName"
+import {agentItemIdentity} from "./identity"
 import type {AgentConfigView, NormalizedTool} from "./types"
 
 /** Scalar config keys surfaced as "Advanced parameters". */
@@ -63,21 +64,75 @@ function coerceContent(content: unknown): string {
     return JSON.stringify(content)
 }
 
-function normalizeTool(raw: unknown): NormalizedTool | null {
+/**
+ * Normalize one tool entry. Every tool subtype is surfaced (nothing dropped): function/gateway
+ * tools keyed by name, workflow-reference tools by slug, builtin/platform tools by type — so a
+ * builtin or reference tool added/removed/edited still shows in the Tools diff. Field-level detail
+ * only applies to function tools; the rest rely on `fingerprint` (the whole-tool hash) for edits.
+ */
+function normalizeTool(raw: unknown, index: number): NormalizedTool | null {
     if (!isObj(raw)) return null
-    const fn = isObj(raw.function) ? raw.function : raw
-    const name = typeof fn.name === "string" ? fn.name : undefined
-    if (!name) return null
-    const description = typeof fn.description === "string" ? fn.description : ""
-    const params = isObj(fn.parameters) ? fn.parameters : {}
-    const parsed = parseGatewayToolName(name)
+    const key = agentItemIdentity("tool", raw, index)
+    const fingerprint = stableStringify(raw)
+    const fn = isObj(raw.function) ? raw.function : undefined
+    const fnName = fn && typeof fn.name === "string" ? fn.name : undefined
+
+    // Function / gateway tool.
+    if (fnName) {
+        const parsed = parseGatewayToolName(fnName)
+        const params = isObj(fn?.parameters) ? (fn?.parameters as Record<string, unknown>) : {}
+        return {
+            key,
+            label: parsed.label,
+            rawKey: fnName,
+            source: parsed.source,
+            description: typeof fn?.description === "string" ? fn.description : "",
+            params,
+            paramsJson: stableStringify(params),
+            fingerprint,
+            isFunction: true,
+        }
+    }
+
+    // Workflow-reference tool (#4860) — keyed by the slug it targets.
+    if (raw.type === "reference") {
+        const slug = typeof raw.slug === "string" ? raw.slug : undefined
+        return {
+            key,
+            label: slug || "Workflow tool",
+            rawKey: slug,
+            description: "",
+            params: {},
+            paramsJson: "{}",
+            fingerprint,
+            isFunction: false,
+        }
+    }
+
+    // Builtin / platform tool (`{type:"web_search"}`, `{type:"platform", op}`) — a bare type.
+    if (typeof raw.type === "string" && raw.type) {
+        const op = typeof raw.op === "string" ? raw.op : undefined
+        return {
+            key,
+            label: parseGatewayToolName(op || raw.type).label,
+            rawKey: op ? `${raw.type}:${op}` : raw.type,
+            description: "",
+            params: {},
+            paramsJson: "{}",
+            fingerprint,
+            isFunction: false,
+        }
+    }
+
+    // Unrecognized shape — surface it (positional key) rather than silently drop it.
     return {
-        key: name,
-        label: parsed.label,
-        source: parsed.source,
-        description,
-        params,
-        paramsJson: stableStringify(params),
+        key,
+        label: "Tool",
+        description: "",
+        params: {},
+        paramsJson: "{}",
+        fingerprint,
+        isFunction: false,
     }
 }
 
@@ -114,7 +169,9 @@ export function readAgentConfig(parameters: unknown): AgentConfigView {
     const instructions = agentsMd ?? instrStr ?? messageInstructions
 
     const toolsRaw = firstArray(agent?.tools, llmConfig?.tools, p.tools, llm0?.tools, prompt?.tools)
-    const tools = toolsRaw.map(normalizeTool).filter((t): t is NormalizedTool => t !== null)
+    const tools = toolsRaw
+        .map((t, i) => normalizeTool(t, i))
+        .filter((t): t is NormalizedTool => t !== null)
 
     const model = firstDefined<string>(
         llm?.model,

--- a/web/packages/agenta-entities/src/workflow/commitDiff/classify.ts
+++ b/web/packages/agenta-entities/src/workflow/commitDiff/classify.ts
@@ -101,8 +101,9 @@ function toolsSection(local: AgentConfigView, remote: AgentConfigView): ChangeSe
         if (!prev) {
             added.push(tool)
         } else if (prev.fingerprint !== tool.fingerprint) {
-            // Field-level detail only for function tools; others still register as edited.
-            edited.push({tool, fields: diffToolFields(prev, tool)})
+            // Field-level detail only for function tools; reference/builtin edits register with the
+            // generic "changed" detail (they have no function fields to itemize).
+            edited.push({tool, fields: tool.isFunction ? diffToolFields(prev, tool) : []})
         }
     }
     for (const [key, tool] of remoteMap) {

--- a/web/packages/agenta-entities/src/workflow/commitDiff/classify.ts
+++ b/web/packages/agenta-entities/src/workflow/commitDiff/classify.ts
@@ -81,7 +81,10 @@ function toolRowDetail(fields: ToolFieldChange[]): string | undefined {
     const parts: string[] = []
     if (descChanged) parts.push("description")
     if (paramCount) parts.push(paramCount === 1 ? "1 parameter" : `${paramCount} parameters`)
-    if (!parts.length) return undefined
+    // Fingerprint-based edit detection can flag a change in a field diffToolFields doesn't inspect
+    // (or a nameless reference/builtin tool with no fields) — fall back to a generic label so the
+    // "edited" badge is never left unexplained.
+    if (!parts.length) return "changed"
     return `${parts.join(" & ")} changed`
 }
 

--- a/web/packages/agenta-entities/src/workflow/commitDiff/classify.ts
+++ b/web/packages/agenta-entities/src/workflow/commitDiff/classify.ts
@@ -97,7 +97,8 @@ function toolsSection(local: AgentConfigView, remote: AgentConfigView): ChangeSe
         const prev = remoteMap.get(key)
         if (!prev) {
             added.push(tool)
-        } else if (prev.description !== tool.description || prev.paramsJson !== tool.paramsJson) {
+        } else if (prev.fingerprint !== tool.fingerprint) {
+            // Field-level detail only for function tools; others still register as edited.
             edited.push({tool, fields: diffToolFields(prev, tool)})
         }
     }
@@ -114,14 +115,14 @@ function toolsSection(local: AgentConfigView, remote: AgentConfigView): ChangeSe
             label: t.label,
             detail: t.source,
             kind: "added" as const,
-            rawKey: t.key,
+            rawKey: t.rawKey,
         })),
         ...edited.map(({tool, fields}) => ({
             id: tool.key,
             label: tool.label,
             detail: toolRowDetail(fields),
             kind: "edited" as const,
-            rawKey: tool.key,
+            rawKey: tool.rawKey,
             fieldChanges: fields,
             descriptionDiff: fields.some((f) => f.field === "description")
                 ? {
@@ -135,7 +136,7 @@ function toolsSection(local: AgentConfigView, remote: AgentConfigView): ChangeSe
             label: t.label,
             detail: t.source,
             kind: "removed" as const,
-            rawKey: t.key,
+            rawKey: t.rawKey,
         })),
     ]
 

--- a/web/packages/agenta-entities/src/workflow/commitDiff/identity.ts
+++ b/web/packages/agenta-entities/src/workflow/commitDiff/identity.ts
@@ -35,9 +35,16 @@ export function agentItemIdentity(kind: AgentItemKind, item: unknown, index: num
         // Workflow-reference tool — keyed by the slug it targets.
         if (rec.type === "reference" && typeof rec.slug === "string" && rec.slug)
             return `ref:${rec.slug}`
-        // Function / gateway tool — keyed by its function name.
+        // Function / gateway tool — keyed by its function name (wrapped `function.name` or the
+        // flat legacy shape `{name, description, parameters}`).
         const fn = isObj(rec.function) ? rec.function : undefined
         if (fn && typeof fn.name === "string" && fn.name) return `fn:${fn.name}`
+        if (
+            (rec.type === undefined || rec.type === "function") &&
+            typeof rec.name === "string" &&
+            rec.name
+        )
+            return `fn:${rec.name}`
         // Platform op tool.
         if (rec.type === "platform" && typeof rec.op === "string" && rec.op)
             return `platform:${rec.op}`

--- a/web/packages/agenta-entities/src/workflow/commitDiff/types.ts
+++ b/web/packages/agenta-entities/src/workflow/commitDiff/types.ts
@@ -70,8 +70,11 @@ export interface ChangeSection {
 
 /** Normalized view of an agent's `parameters`, resolved across the 3 schema shapes. */
 export interface NormalizedTool {
+    /** Canonical, collision-free identity (see `agentItemIdentity`) — the diff map key. */
     key: string
     label: string
+    /** Technical name shown in the detail view: function name / reference slug / builtin type. */
+    rawKey?: string
     /** e.g. "Gmail" — provider/integration, when derivable from a gateway name. */
     source?: string
     description: string
@@ -79,6 +82,10 @@ export interface NormalizedTool {
     paramsJson: string
     /** The raw parameters object, for field-level diffing. */
     params: Record<string, unknown>
+    /** Stable-stringified whole tool — edit detection across all tool subtypes (incl. nameless). */
+    fingerprint: string
+    /** A function-call tool (`function.name`); only these get field-level diffs. */
+    isFunction: boolean
 }
 
 export interface AgentConfigView {

--- a/web/packages/agenta-entities/tests/unit/agent-commit-diff.test.ts
+++ b/web/packages/agenta-entities/tests/unit/agent-commit-diff.test.ts
@@ -25,7 +25,7 @@ describe("readAgentConfig — three schema shapes normalize to one view", () => 
         expect(v.model).toBe("gpt-4o")
         expect(v.params.temperature).toBe(0.7)
         expect(v.tools).toHaveLength(1)
-        expect(v.tools[0].key).toBe("gmail_search")
+        expect(v.tools[0].rawKey).toBe("gmail_search")
     }
 
     it("legacy nested (prompt.llm_config)", () => {
@@ -71,7 +71,7 @@ describe("readAgentConfig — three schema shapes normalize to one view", () => 
         expect(v.instructions).toBe("You are helpful.")
         expect(v.model).toBe("gpt-4o")
         expect(v.params.temperature).toBe(0.7)
-        expect(v.tools[0].key).toBe("gmail_search")
+        expect(v.tools[0].rawKey).toBe("gmail_search")
     })
 
     it("handles array (multimodal) message content", () => {
@@ -146,6 +146,36 @@ describe("classifyAgentChanges", () => {
         expect(
             item?.fieldChanges?.some((f) => f.field === "max_results" && f.kind === "added"),
         ).toBe(true)
+    })
+
+    it("agent-template: workflow-reference tools are diffed, not dropped", () => {
+        // The agent flow adds reference tools (`type:"reference"`, no `function.name`) via
+        // "Reference a workflow"; normalizeTool used to drop them → invisible in the Tools diff.
+        const remote = {agent: {tools: []}}
+        const local = {agent: {tools: [{type: "reference", slug: "sub-workflow"}]}}
+        const tools = classifyAgentChanges(local, remote).find((s) => s.id === "tools")
+        expect(tools?.tags).toContainEqual({kind: "added", label: "1 added"})
+        expect(tools?.items?.[0]).toMatchObject({
+            kind: "added",
+            label: "sub-workflow",
+            rawKey: "sub-workflow",
+        })
+    })
+
+    it("agent-template: editing a reference tool (no function fields) still registers", () => {
+        const remote = {agent: {tools: [{type: "reference", slug: "wf", version: "1"}]}}
+        const local = {agent: {tools: [{type: "reference", slug: "wf", version: "2"}]}}
+        const tools = classifyAgentChanges(local, remote).find((s) => s.id === "tools")
+        expect(tools?.items?.[0]).toMatchObject({kind: "edited", rawKey: "wf"})
+    })
+
+    it("classifier: nameless builtin tools are diffed too (prompt playground / legacy)", () => {
+        // Builtins aren't offered in the agent tool picker, but the prompt playground reuses this
+        // classifier and does have them — they must not be dropped there either.
+        const remote = {prompt: {llm_config: {tools: [{type: "web_search"}]}}}
+        const local = {prompt: {llm_config: {tools: []}}}
+        const tools = classifyAgentChanges(local, remote).find((s) => s.id === "tools")
+        expect(tools?.items?.[0]).toMatchObject({kind: "removed", label: "Web search"})
     })
 
     it("instructions rewrite", () => {

--- a/web/packages/agenta-entities/tests/unit/agent-commit-diff.test.ts
+++ b/web/packages/agenta-entities/tests/unit/agent-commit-diff.test.ts
@@ -171,11 +171,23 @@ describe("classifyAgentChanges", () => {
 
     it("classifier: nameless builtin tools are diffed too (prompt playground / legacy)", () => {
         // Builtins aren't offered in the agent tool picker, but the prompt playground reuses this
-        // classifier and does have them — they must not be dropped there either.
+        // classifier and does have them — they must not be dropped, added or removed.
         const remote = {prompt: {llm_config: {tools: [{type: "web_search"}]}}}
         const local = {prompt: {llm_config: {tools: []}}}
+        const removed = classifyAgentChanges(local, remote).find((s) => s.id === "tools")
+        expect(removed?.items?.[0]).toMatchObject({kind: "removed", label: "Web search"})
+
+        const added = classifyAgentChanges(remote, local).find((s) => s.id === "tools")
+        expect(added?.items?.[0]).toMatchObject({kind: "added", label: "Web search"})
+    })
+
+    it("flat legacy function tool ({name,...}, no wrapper) keeps fn identity + field diffs", () => {
+        const remote = {prompt: {llm_config: {tools: [{name: "lookup", description: "old"}]}}}
+        const local = {prompt: {llm_config: {tools: [{name: "lookup", description: "new"}]}}}
         const tools = classifyAgentChanges(local, remote).find((s) => s.id === "tools")
-        expect(tools?.items?.[0]).toMatchObject({kind: "removed", label: "Web search"})
+        const item = tools?.items?.[0]
+        expect(item).toMatchObject({kind: "edited", rawKey: "lookup"})
+        expect(item?.fieldChanges?.some((f) => f.field === "description")).toBe(true)
     })
 
     it("instructions rewrite", () => {
@@ -337,6 +349,15 @@ describe("agentItemIdentity — collision-free item identity", () => {
         expect(agentItemIdentity("tool", {type: "platform", op: "list"}, 0)).toBe("platform:list")
         // Bare builtin (only a type) has no stable id → positional, so duplicates never collapse.
         expect(agentItemIdentity("tool", {type: "web_search"}, 2)).toBe("#2")
+    })
+
+    it("keys the flat legacy function shape {name,...} by fn:<name>", () => {
+        expect(agentItemIdentity("tool", {name: "get_weather", parameters: {}}, 0)).toBe(
+            "fn:get_weather",
+        )
+        expect(agentItemIdentity("tool", {type: "function", name: "get_weather"}, 0)).toBe(
+            "fn:get_weather",
+        )
     })
 
     it("gives two id-less tools distinct identities (no map collapse)", () => {


### PR DESCRIPTION
## What

Follow-up to #5035. The commit-diff classifier's `normalizeTool` dropped any tool without a `function.name` (`return null`). The agent tool flow adds **workflow-reference tools** (`{type: "reference", slug}`) via **"Reference a workflow"** — these have no `function.name`, so they were invisible to the **Tools** section:

- adding / removing / editing a reference tool never appeared in the commit-modal summary, and
- the config panel's **Tools** header never tinted for them — even though the per-item row indicator *did* flag them (it uses the canonical `agentItemIdentity`), so the header and its rows disagreed.

> Note: the agent tool picker (`AgentToolSelectorPopover`) offers **no builtin tools** ("No built-in tools here") — only reference / third-party gateway / create-definition. Builtins live in the *prompt* playground's `ToolSelectorPopover`, which reuses this same classifier — so the fix also keeps builtin/platform tools from being dropped there (plus legacy/defensive cover).

## Fix

`normalizeTool` now surfaces every tool subtype instead of dropping the nameless ones:

- keyed by the canonical `agentItemIdentity` (function name → reference slug → platform op → positional fallback), so entries never collapse;
- a `fingerprint` (whole-tool stable hash) drives edit detection across all subtypes — function tools keep their field-level detail (`diffToolFields`); reference/builtin edits register via the fingerprint;
- `NormalizedTool` gains `rawKey` (technical name shown in the detail view), `fingerprint`, and `isFunction`.

Labels: function/gateway via `parseGatewayToolName`, reference → slug, builtin → humanized type.

## Testing

- New unit tests: reference tool added; reference tool edited (no function fields); builtin tool diffed via the prompt shape. Existing tool tests updated to assert on `rawKey`. **31/31 pass.**
- `tsc --noEmit` clean for `@agenta/entities` and `@agenta/entity-ui`; eslint/prettier/turbo-lint green.
