### PR TITLE
[chore] Add harness-agnostic remote asset-prep seam

### DIFF
--- a/docs/design/agent-workflows/projects/foundation-remote-bootstrap/research.md
+++ b/docs/design/agent-workflows/projects/foundation-remote-bootstrap/research.md
@@ -68,13 +68,14 @@ if (plan.isDaytona) {
 Replace with:
 
 ```
-if (plan.isDaytona || plan.isE2b) {
+if (plan.isDaytona || plan.isE2B) {
   await prepareRemoteHarnessAssets({ sandbox, plan, log: logger });
 }
 ```
 
-`plan.isE2b` lands in `chore/add-sandbox-e2b`; the seam is designed to accept it without
-signature changes.
+`plan.isE2B` lands in `chore/add-sandbox-e2b`; the seam is designed to accept it without
+signature changes. Once merged, the derived `isRemoteSandbox` flag added by the E2B
+branches is the eventual gate here, replacing this `isDaytona || isE2B` pair.
 
 ## No provider class hierarchy
 

--- a/docs/design/agent-workflows/projects/foundation-remote-bootstrap/research.md
+++ b/docs/design/agent-workflows/projects/foundation-remote-bootstrap/research.md
@@ -1,0 +1,82 @@
+# Research: Foundation Remote Bootstrap
+
+## Problem
+
+Non-Pi harnesses (codex, opencode, claude) on remote sandboxes (Daytona, E2B) have no credential
+provisioning. `prepareDaytonaPiAssets` returns early for non-Pi. The daemon image has no
+harness auth files.
+
+## Existing paths
+
+### Local (any harness)
+
+Credentials live on the host already: `ANTHROPIC_API_KEY` et al in env, `~/.codex/auth.json`
+on disk. `buildDaemonEnv` inherits them. No upload step needed.
+
+### Daytona + Pi
+
+`prepareDaytonaPiAssets` handles Pi only (returns early when `!plan.isPi`). It uploads
+`auth.json`, the Agenta extension, skills, and system prompts into the sandbox via
+`sandbox.writeFsFile` / `sandbox.mkdirFs`.
+
+### Daytona + Claude
+
+Key rides `envVars` in `buildDaytonaCreate` via `daytonaEnvVars → secrets`. The daemon
+launches with those env vars in scope. No file write needed.
+
+### E2B + Pi (proposed, sibling worktree)
+
+Same shape as Daytona. Asset-prep must work with the E2B sandbox handle (same duck-typed API).
+
+## Sandbox handle interface
+
+Daytona and E2B sandbox handles both expose `mkdirFs` / `writeFsFile` through the
+`sandbox-agent` npm package. The runner types this `any`; asset-prep functions use duck-typing.
+A minimal `SandboxHandle` interface formalises the two methods needed for uploads.
+
+## Per-harness credential requirements (verified vs daemon binary)
+
+| Harness | Env key | File required | File path |
+| ------- | ------- | ------------- | --------- |
+| pi      | via env OR file | `auth.json` | `~/.pi/agent/auth.json` |
+| claude  | `ANTHROPIC_API_KEY` in env | None | — |
+| codex   | `OPENAI_API_KEY` in env | ALWAYS `~/.codex/auth.json` | `~/.codex/auth.json` |
+| opencode | provider key in env | None | — |
+
+Critical: codex reads `~/.codex/auth.json` as a file, not just env. Both `credentialMode=env`
+(managed key) and `credentialMode=runtime_provided` (own login) must write that file.
+
+## Dispatch design
+
+`prepareRemoteHarnessAssets(plan, sandbox)`:
+
+- `pi` → delegate to existing `prepareDaytonaPiAssets` (no change to Pi path).
+- `codex` → write `~/.codex/auth.json` with the resolved `OPENAI_API_KEY`.
+- `claude` → no-op (key already in env via daemon envVars).
+- `opencode` → no-op (key in env).
+
+## Call site
+
+`sandbox_agent.ts` currently gates on `plan.isDaytona`. The call is:
+
+```
+if (plan.isDaytona) {
+  await prepareDaytonaPiAssets({ sandbox, plan, log: logger });
+}
+```
+
+Replace with:
+
+```
+if (plan.isDaytona || plan.isE2b) {
+  await prepareRemoteHarnessAssets({ sandbox, plan, log: logger });
+}
+```
+
+`plan.isE2b` lands in `chore/add-sandbox-e2b`; the seam is designed to accept it without
+signature changes.
+
+## No provider class hierarchy
+
+Functions, not classes. Dispatch is a switch on `plan.acpAgent`. Same idiom as every other
+helper in this directory.

--- a/docs/design/agent-workflows/projects/foundation-remote-bootstrap/specs.md
+++ b/docs/design/agent-workflows/projects/foundation-remote-bootstrap/specs.md
@@ -72,13 +72,14 @@ Replace the existing `if (plan.isDaytona)` block:
 -   if (plan.isDaytona) {
 -     await prepareDaytonaPiAssets({ sandbox, plan, log: logger });
 -   }
-+   if (plan.isDaytona || (plan as any).isE2b) {
++   if (plan.isDaytona || (plan as any).isE2B) {
 +     await prepareRemoteHarnessAssets({ sandbox, plan, log: logger });
 +   }
 ```
 
-`plan.isE2b` is a future field (`chore/add-sandbox-e2b`); the cast avoids a compile error
-until that field is added to `RunPlan`. Once E2B lands the cast drops.
+`plan.isE2B` is a future field (`chore/add-sandbox-e2b`); the cast avoids a compile error
+until that field is added to `RunPlan`. Once E2B lands the cast drops, and the derived
+`isRemoteSandbox` flag added by those branches becomes the eventual gate here.
 
 ## Tests
 

--- a/docs/design/agent-workflows/projects/foundation-remote-bootstrap/specs.md
+++ b/docs/design/agent-workflows/projects/foundation-remote-bootstrap/specs.md
@@ -1,0 +1,97 @@
+# Specs: Foundation Remote Bootstrap
+
+## Seam: `prepareRemoteHarnessAssets`
+
+File: `services/runner/src/engines/sandbox_agent/remote-assets.ts`
+
+### Interface
+
+```ts
+export interface SandboxHandle {
+  mkdirFs(opts: { path: string }): Promise<unknown>;
+  writeFsFile(opts: { path: string }, content: string): Promise<unknown>;
+}
+
+export interface PrepareRemoteHarnessAssetsInput {
+  sandbox: SandboxHandle;
+  plan: Pick<RunPlan,
+    | "acpAgent"
+    | "secrets"
+    | "credentialMode"
+    | "hasApiKey"
+    | "isPi"
+    | "skillDirs"
+    | "hasSystemPrompt"
+    | "systemPrompt"
+    | "appendSystemPrompt"
+  >;
+  log?: (message: string) => void;
+}
+
+export async function prepareRemoteHarnessAssets(
+  input: PrepareRemoteHarnessAssetsInput,
+): Promise<void>
+```
+
+### Dispatch
+
+```
+switch (plan.acpAgent) {
+  case "pi":      → prepareDaytonaPiAssets (unchanged)
+  case "codex":   → writeCodexAuthToSandbox
+  case "claude":  → no-op
+  case "opencode":→ no-op
+  default:        → log warning
+}
+```
+
+### `writeCodexAuthToSandbox`
+
+Writes `~/.codex/auth.json`:
+
+```json
+{ "providers": [{ "name": "openai", "apiKey": "<OPENAI_API_KEY>" }] }
+```
+
+Source: `plan.secrets.OPENAI_API_KEY`. Best-effort: if the key is absent (empty string or
+undefined), logs and skips. Always writes the file regardless of `credentialMode` (codex
+always reads it from disk).
+
+### Security
+
+- The auth file content is derived solely from `plan.secrets`, which was already cleared-then-
+  applied (Security rule 5). No extra clearing needed here.
+- `shouldUploadOwnLogin` semantics do not apply to codex: codex has no OAuth login, only an
+  API key. The file is written whenever the key is present.
+
+## Call site change: `sandbox_agent.ts`
+
+Replace the existing `if (plan.isDaytona)` block:
+
+```diff
+-   if (plan.isDaytona) {
+-     await prepareDaytonaPiAssets({ sandbox, plan, log: logger });
+-   }
++   if (plan.isDaytona || (plan as any).isE2b) {
++     await prepareRemoteHarnessAssets({ sandbox, plan, log: logger });
++   }
+```
+
+`plan.isE2b` is a future field (`chore/add-sandbox-e2b`); the cast avoids a compile error
+until that field is added to `RunPlan`. Once E2B lands the cast drops.
+
+## Tests
+
+File: `services/runner/tests/unit/sandbox-agent-remote-assets.test.ts`
+
+(Not `src/engines/sandbox_agent/__tests__/`: the vitest config includes only
+`tests/unit/**/*.test.ts`; a `__tests__` dir inside `src/` would be silently skipped.)
+
+### Coverage
+
+1. Pi → delegates to `prepareDaytonaPiAssets` (calls `mkdirFs` / `writeFsFile` for Pi auth)
+2. Codex → writes `~/.codex/auth.json` with the resolved key
+3. Codex with no key → logs, skips the write
+4. Claude → no writes (no-op)
+5. Opencode → no writes (no-op)
+6. Unknown acpAgent → no throw (log + return)

--- a/docs/design/agent-workflows/projects/foundation-remote-bootstrap/tasks.md
+++ b/docs/design/agent-workflows/projects/foundation-remote-bootstrap/tasks.md
@@ -1,0 +1,55 @@
+# Tasks: Foundation Remote Bootstrap
+
+## T1 — Create `remote-assets.ts`
+
+File: `services/runner/src/engines/sandbox_agent/remote-assets.ts`
+
+- Export `SandboxHandle` (minimal duck-typed interface: `mkdirFs`, `writeFsFile`).
+- Export `PrepareRemoteHarnessAssetsInput`.
+- Export `prepareRemoteHarnessAssets` (the main dispatch).
+- Export `writeCodexAuthToSandbox` (testable unit).
+- `pi` case delegates to `prepareDaytonaPiAssets`; all other Pi-specific plumbing
+  (`installPiInSandbox` etc.) stays in `daytona.ts`.
+- `codex` case: mkdir `~/.codex`, write `auth.json`.
+- `claude`, `opencode`: no-op.
+- Default: log unknown agent, return.
+
+## T2 — Update `sandbox_agent.ts`
+
+- Import `prepareRemoteHarnessAssets` from `./sandbox_agent/remote-assets.ts`.
+- Replace the `if (plan.isDaytona) { await prepareDaytonaPiAssets(...) }` block with
+  `if (plan.isDaytona) { await prepareRemoteHarnessAssets(...) }`.
+- Remove the now-redundant `prepareDaytonaPiAssets` import (it is called via
+  `prepareRemoteHarnessAssets`).
+- Note: `isE2b` extension will widen the guard to `isDaytona || isE2b` in the sibling
+  worktree; the seam is already ready.
+
+## T3 — Add unit tests
+
+File: `services/runner/tests/unit/sandbox-agent-remote-assets.test.ts`
+
+Six tests (see specs.md). Each uses a minimal in-memory sandbox stub; no disk access.
+
+## T4 — Typecheck + test
+
+```
+cd services/runner
+pnpm run typecheck
+pnpm test
+```
+
+Both must pass (zero type errors, all tests green).
+
+## Dependencies
+
+- T1 before T2, T3 (they import from `remote-assets.ts`).
+- T4 after T1, T2, T3.
+
+## Out of scope
+
+- E2B sandbox provider integration (sibling worktree `chore/add-sandbox-e2b`).
+- codex/opencode harness adapters (sibling worktrees `chore/add-harness-codex`,
+  `chore/add-harness-opencode`).
+- Pi install/auto-install on E2B (same sibling worktree).
+- opencode provider-key selection (multiple providers supported; env already carries the
+  right key from `plan.secrets`; no file write needed).

--- a/docs/design/agent-workflows/projects/foundation-remote-bootstrap/tasks.md
+++ b/docs/design/agent-workflows/projects/foundation-remote-bootstrap/tasks.md
@@ -21,8 +21,9 @@ File: `services/runner/src/engines/sandbox_agent/remote-assets.ts`
   `if (plan.isDaytona) { await prepareRemoteHarnessAssets(...) }`.
 - Remove the now-redundant `prepareDaytonaPiAssets` import (it is called via
   `prepareRemoteHarnessAssets`).
-- Note: `isE2b` extension will widen the guard to `isDaytona || isE2b` in the sibling
-  worktree; the seam is already ready.
+- Note: `isE2B` extension will widen the guard to `isDaytona || isE2B` in the sibling
+  worktree; the seam is already ready. Once merged, the derived `isRemoteSandbox` flag
+  becomes the eventual gate.
 
 ## T3 — Add unit tests
 

--- a/services/runner/src/engines/sandbox_agent.ts
+++ b/services/runner/src/engines/sandbox_agent.ts
@@ -466,7 +466,7 @@ export async function runSandboxAgent(
     // On remote sandboxes, push harness credentials and Pi assets into the sandbox via
     // the filesystem API (nothing secret is baked into the image). Locally these use the
     // host filesystem and the harness's own login.
-    if (plan.isDaytona || (plan as any).isE2b) {
+    if (plan.isDaytona || (plan as any).isE2B) {
       await prepareRemoteHarnessAssets({ sandbox, plan, log: logger });
     }
 

--- a/services/runner/src/engines/sandbox_agent.ts
+++ b/services/runner/src/engines/sandbox_agent.ts
@@ -53,10 +53,8 @@ import {
 } from "./sandbox_agent/capabilities.ts";
 import { createAcpFetch } from "./sandbox_agent/acp-fetch.ts";
 import { buildDaemonEnv, resolveDaemonBinary } from "./sandbox_agent/daemon.ts";
-import {
-  createCookieFetch,
-  prepareDaytonaPiAssets,
-} from "./sandbox_agent/daytona.ts";
+import { createCookieFetch } from "./sandbox_agent/daytona.ts";
+import { prepareRemoteHarnessAssets } from "./sandbox_agent/remote-assets.ts";
 import { conciseError } from "./sandbox_agent/errors.ts";
 import { buildSessionMcpServers } from "./sandbox_agent/mcp.ts";
 import { applyModel } from "./sandbox_agent/model.ts";
@@ -465,11 +463,11 @@ export async function runSandboxAgent(
     // normal exit so it is never double-deleted.
     if (sandbox) inFlightSandboxes.add(sandbox);
 
-    // On Daytona, push the harness login, the extension, and AGENTS.md into the remote
-    // sandbox via the filesystem API (nothing secret is baked into the image). Locally
-    // these use the host filesystem and the harness's own login (PI_CODING_AGENT_DIR).
-    if (plan.isDaytona) {
-      await prepareDaytonaPiAssets({ sandbox, plan, log: logger });
+    // On remote sandboxes, push harness credentials and Pi assets into the sandbox via
+    // the filesystem API (nothing secret is baked into the image). Locally these use the
+    // host filesystem and the harness's own login.
+    if (plan.isDaytona || (plan as any).isE2b) {
+      await prepareRemoteHarnessAssets({ sandbox, plan, log: logger });
     }
 
     // Durable cwd: reuse the pre-signed creds (signed before buildRunPlan so the prefix drove the

--- a/services/runner/src/engines/sandbox_agent/remote-assets.ts
+++ b/services/runner/src/engines/sandbox_agent/remote-assets.ts
@@ -1,0 +1,81 @@
+import { prepareDaytonaPiAssets } from "./daytona.ts";
+import type { RunPlan } from "./run-plan.ts";
+
+type Log = (message: string) => void;
+
+/** Minimal sandbox filesystem surface used for remote asset uploads. */
+export interface SandboxHandle {
+  mkdirFs(opts: { path: string }): Promise<unknown>;
+  writeFsFile(opts: { path: string }, content: string): Promise<unknown>;
+  runProcess?(opts: unknown): Promise<unknown>;
+}
+
+export interface PrepareRemoteHarnessAssetsInput {
+  sandbox: SandboxHandle;
+  plan: Pick<
+    RunPlan,
+    | "acpAgent"
+    | "secrets"
+    | "isPi"
+    | "credentialMode"
+    | "hasApiKey"
+    | "skillDirs"
+    | "hasSystemPrompt"
+    | "systemPrompt"
+    | "appendSystemPrompt"
+  >;
+  log?: Log;
+}
+
+const CODEX_DIR =
+  process.env.AGENTA_AGENT_SANDBOX_CODEX_DIR ?? "/root/.codex";
+
+/** Write `~/.codex/auth.json` with the resolved OpenAI key. Best-effort. */
+export async function writeCodexAuthToSandbox(
+  sandbox: SandboxHandle,
+  secrets: Record<string, string>,
+  log: Log,
+): Promise<void> {
+  const key = secrets.OPENAI_API_KEY;
+  if (!key) {
+    log("codex remote auth skipped: no OPENAI_API_KEY in secrets");
+    return;
+  }
+  try {
+    await sandbox.mkdirFs({ path: CODEX_DIR });
+    await sandbox.writeFsFile(
+      { path: `${CODEX_DIR}/auth.json` },
+      JSON.stringify({ OPENAI_API_KEY: key }),
+    );
+  } catch (err) {
+    log(`codex auth upload skipped: ${(err as Error).message}`);
+  }
+}
+
+/**
+ * Provision harness credentials in a remote sandbox (Daytona, E2B, ...).
+ *
+ * Pi delegates to `prepareDaytonaPiAssets` unchanged. Codex writes
+ * `~/.codex/auth.json` (codex always reads credentials from disk, not just env).
+ * Claude and opencode receive their keys via env vars in the sandbox create object
+ * and need no file upload.
+ */
+export async function prepareRemoteHarnessAssets({
+  sandbox,
+  plan,
+  log = () => {},
+}: PrepareRemoteHarnessAssetsInput): Promise<void> {
+  switch (plan.acpAgent) {
+    case "pi":
+      await prepareDaytonaPiAssets({ sandbox, plan, log });
+      break;
+    case "codex":
+      await writeCodexAuthToSandbox(sandbox, plan.secrets, log);
+      break;
+    case "claude":
+    case "opencode":
+      break;
+    default:
+      log(`prepareRemoteHarnessAssets: unknown acpAgent '${plan.acpAgent}', skipping`);
+  }
+}

--- a/services/runner/tests/unit/sandbox-agent-remote-assets.test.ts
+++ b/services/runner/tests/unit/sandbox-agent-remote-assets.test.ts
@@ -1,0 +1,145 @@
+/**
+ * Unit tests for the harness-agnostic remote asset-prep seam.
+ *
+ * Run: pnpm test (or: pnpm exec vitest run tests/unit/sandbox-agent-remote-assets.test.ts)
+ */
+import { describe, it } from "vitest";
+import assert from "node:assert/strict";
+
+import {
+  prepareRemoteHarnessAssets,
+  writeCodexAuthToSandbox,
+} from "../../src/engines/sandbox_agent/remote-assets.ts";
+
+type Call = { op: "mkdir" | "write"; path: string; body?: string };
+
+function makeSandbox(calls: Call[]) {
+  return {
+    mkdirFs: async ({ path }: { path: string }) => calls.push({ op: "mkdir", path }),
+    writeFsFile: async ({ path }: { path: string }, body: string) =>
+      calls.push({ op: "write", path, body }),
+    runProcess: async () => ({ exitCode: 0, stderr: "" }),
+  };
+}
+
+function basePlan(overrides: Record<string, unknown> = {}) {
+  return {
+    acpAgent: "pi",
+    secrets: {} as Record<string, string>,
+    credentialMode: undefined,
+    hasApiKey: false,
+    isPi: true,
+    skillDirs: [],
+    hasSystemPrompt: false,
+    systemPrompt: undefined,
+    appendSystemPrompt: undefined,
+    ...overrides,
+  };
+}
+
+describe("prepareRemoteHarnessAssets / pi", () => {
+  it("delegates to prepareDaytonaPiAssets for the pi agent", async () => {
+    const calls: Call[] = [];
+    const sandbox = makeSandbox(calls);
+    await prepareRemoteHarnessAssets({
+      sandbox,
+      plan: basePlan({ acpAgent: "pi", isPi: true, credentialMode: "runtime_provided" }),
+    });
+    // prepareDaytonaPiAssets calls mkdirFs for the Pi agent dir (even when auth is absent)
+    // and then installPiInSandbox (which calls mkdirFs + runProcess). At minimum it calls
+    // mkdirFs at least once (the Pi agent dir).
+    const mkdirs = calls.filter((c) => c.op === "mkdir");
+    assert.ok(mkdirs.length > 0, "expected Pi asset-prep to run mkdirFs");
+  });
+});
+
+describe("prepareRemoteHarnessAssets / codex", () => {
+  it("writes ~/.codex/auth.json with the resolved key", async () => {
+    const calls: Call[] = [];
+    const sandbox = makeSandbox(calls);
+    await prepareRemoteHarnessAssets({
+      sandbox,
+      plan: basePlan({
+        acpAgent: "codex",
+        isPi: false,
+        secrets: { OPENAI_API_KEY: "sk-test-key" },
+      }),
+    });
+    const write = calls.find((c) => c.op === "write" && c.path.endsWith("auth.json"));
+    assert.ok(write, "expected auth.json write");
+    const parsed = JSON.parse(write!.body ?? "{}");
+    assert.deepEqual(parsed, { OPENAI_API_KEY: "sk-test-key" });
+  });
+
+  it("skips the write when no OPENAI_API_KEY is present", async () => {
+    const calls: Call[] = [];
+    const logs: string[] = [];
+    const sandbox = makeSandbox(calls);
+    await prepareRemoteHarnessAssets({
+      sandbox,
+      plan: basePlan({ acpAgent: "codex", isPi: false, secrets: {} }),
+      log: (msg) => logs.push(msg),
+    });
+    assert.equal(calls.length, 0, "expected no sandbox calls");
+    assert.ok(logs.some((l) => l.includes("OPENAI_API_KEY")), "expected log about missing key");
+  });
+});
+
+describe("prepareRemoteHarnessAssets / claude", () => {
+  it("is a no-op (key already in env via sandbox envVars)", async () => {
+    const calls: Call[] = [];
+    const sandbox = makeSandbox(calls);
+    await prepareRemoteHarnessAssets({
+      sandbox,
+      plan: basePlan({
+        acpAgent: "claude",
+        isPi: false,
+        secrets: { ANTHROPIC_API_KEY: "key" },
+      }),
+    });
+    assert.equal(calls.length, 0, "expected no sandbox calls for claude");
+  });
+});
+
+describe("prepareRemoteHarnessAssets / opencode", () => {
+  it("is a no-op (key already in env via sandbox envVars)", async () => {
+    const calls: Call[] = [];
+    const sandbox = makeSandbox(calls);
+    await prepareRemoteHarnessAssets({
+      sandbox,
+      plan: basePlan({
+        acpAgent: "opencode",
+        isPi: false,
+        secrets: { OPENAI_API_KEY: "key" },
+      }),
+    });
+    assert.equal(calls.length, 0, "expected no sandbox calls for opencode");
+  });
+});
+
+describe("prepareRemoteHarnessAssets / unknown agent", () => {
+  it("logs and returns without throwing", async () => {
+    const calls: Call[] = [];
+    const logs: string[] = [];
+    const sandbox = makeSandbox(calls);
+    await prepareRemoteHarnessAssets({
+      sandbox,
+      plan: basePlan({ acpAgent: "future-harness", isPi: false }),
+      log: (msg) => logs.push(msg),
+    });
+    assert.equal(calls.length, 0, "expected no sandbox calls for unknown agent");
+    assert.ok(logs.some((l) => l.includes("future-harness")), "expected log about unknown agent");
+  });
+});
+
+describe("writeCodexAuthToSandbox", () => {
+  it("creates the dir and writes the auth file", async () => {
+    const calls: Call[] = [];
+    const sandbox = makeSandbox(calls);
+    await writeCodexAuthToSandbox(sandbox, { OPENAI_API_KEY: "sk-direct" }, () => {});
+    assert.deepEqual(calls[0], { op: "mkdir", path: "/root/.codex" });
+    assert.ok(calls[1]?.path.endsWith("auth.json"));
+    const body = JSON.parse(calls[1]!.body ?? "{}");
+    assert.equal(body.OPENAI_API_KEY, "sk-direct");
+  });
+});


### PR DESCRIPTION
## Context
Remote-sandbox credential/asset provisioning (writing auth files, uploading config) only existed as a Pi-specific code path (`prepareDaytonaPiAssets`), copy-pasted per harness as new harnesses landed on remote sandboxes. There was no shared seam, so every new harness x remote-sandbox cell risked its own drift in credential handling.

## Changes
Adds `prepareRemoteHarnessAssets` in `services/runner/src/engines/sandbox_agent/remote-assets.ts`, a single dispatch point keyed on `plan.acpAgent` that later harness/sandbox branches plug into instead of hand-rolling their own prep function. Wires it into `sandbox_agent.ts`. Also fixes casing (`E2b` to `E2B`) picked up in this seam during the matrix build, and trims the now-stale `session-alive.test.ts` assertion that checked for a `status` field the streams redesign already dropped from the heartbeat contract.

## Tests / notes
- New unit coverage in `sandbox-agent-remote-assets.test.ts`.
- This branch is a shared dependency: `chore/add-codex-daytona`, `chore/add-codex-e2b`, `chore/add-opencode-daytona`, `chore/add-opencode-e2b`, and `chore/add-claude-daytona` were built to layer onto this seam even though they're stacked directly on `big-agents` for now — expect a follow-up fold-in pass once this lands.