### PR TITLE
[feat] Bake pinned Pi into the Daytona snapshot

### DIFF
--- a/services/runner/sandbox-images/daytona/README.md
+++ b/services/runner/sandbox-images/daytona/README.md
@@ -17,9 +17,35 @@ DAYTONA_SNAPSHOT=agenta-sandbox-pi
 AGENTA_AGENT_SANDBOX_PI_INSTALLED=false
 ```
 
-The recipe currently bases on the upstream full sandbox-agent image and adds the Pi CLI.
-That image includes Claude Code. We do not distribute the resulting snapshot. Cloud builds its
-own internal snapshot; self-hosters build their own.
+## What is baked
+
+The recipe bases on `rivetdev/sandbox-agent:*-full`. That base image already installs the
+Claude, Codex, and OpenCode native binaries and ACP adapters. It also includes the Pi ACP
+adapter, but not the standalone `pi` CLI that the adapter launches.
+
+The snapshot recipe therefore:
+
+- installs `@earendil-works/pi-coding-agent@0.80.6`;
+- fails the build unless `pi --version` succeeds;
+- verifies that the Claude, Codex, and OpenCode binaries are still present; and
+- installs the FUSE and geesefs dependencies used for durable remote working directories.
+
+## Pi installation controls
+
+The runner keeps the reliable bare-image behavior by default:
+
+- unset or `AGENTA_AGENT_SANDBOX_PI_INSTALLED=true`: install the pinned Pi version into
+  each new sandbox session and point `pi-acp` at it;
+- `AGENTA_AGENT_SANDBOX_PI_INSTALLED=false`: skip the session-time install because the
+  configured snapshot already contains Pi; and
+- `AGENTA_AGENT_SANDBOX_PI_VERSION`: override the pinned session-time fallback version.
+
+Despite its historical `_INSTALLED` name, the boolean controls whether the runner performs
+the session-time installation. Set it to `false` only together with a snapshot known to
+contain Pi, such as `agenta-sandbox-pi`.
+
+The full base image includes Claude Code. We do not distribute the resulting snapshot. Agenta
+Cloud builds its own internal snapshot, and self-hosters build their own.
 
 Keep credentials out of the image and snapshot. Provider keys and self-managed login paths are
 runtime concerns.

--- a/services/runner/sandbox-images/daytona/build_snapshot.py
+++ b/services/runner/sandbox-images/daytona/build_snapshot.py
@@ -4,9 +4,11 @@
 # ///
 """Build a Daytona snapshot for the Agenta sandbox-agent runner.
 
-Bakes the `pi` CLI into a sandbox-agent base image (which already ships the sandbox-agent
-daemon, the Claude CLI, and CA certs) so Daytona runs don't pay a ~150s per-invoke
-`npm install pi`. Set the runner service to use it:
+The full sandbox-agent base image already bakes the Claude, Codex, and OpenCode
+native binaries and ACP adapters. It also includes the Pi ACP adapter, but not the
+standalone `pi` CLI that adapter launches. This recipe adds the pinned Pi CLI and
+verifies the other baked harnesses so Daytona runs do not pay their installation cost
+for every fresh sandbox. Set the runner service to use it:
 
     DAYTONA_SNAPSHOT=agenta-sandbox-pi
     AGENTA_AGENT_SANDBOX_PI_INSTALLED=false
@@ -18,14 +20,11 @@ Licensing (see services/runner/docker/README.md):
     runs it builds the snapshot in their own Daytona account: Agenta Cloud builds
     its own for internal use; self-hosters build their own. We never hand anyone a
     Claude-containing image, so this is compliant even though the `-full` base bundles
-    Claude (Anthropic's Commercial Terms forbid us *distributing* Claude Code, not
-    building/using it).
+    Claude.
 
     Cleaner-provenance follow-up (needs a live Daytona build to verify): base on a
-    daemon-only sandbox-agent image and install Claude from Anthropic at build (npm
-    `@anthropic-ai/claude-code` or `claude.ai/install.sh`), so the snapshot's Claude
-    comes straight from Anthropic instead of from a third party's bundled image. Pin
-    that only after confirming the daemon-only tag also ships the ACP adapters.
+    daemon-only sandbox-agent image and install Claude from Anthropic at build, then
+    pin that only after confirming the daemon-only tag also ships the ACP adapters.
 """
 
 import sys
@@ -41,7 +40,7 @@ from daytona import (
 
 SNAPSHOT_NAME = "agenta-sandbox-pi"
 SANDBOX_AGENT_IMAGE = "rivetdev/sandbox-agent:0.5.0-rc.2-full"
-PI_PACKAGE = "@earendil-works/pi-coding-agent@0.79.4"
+PI_PACKAGE = "@earendil-works/pi-coding-agent@0.80.6"
 # Durable session cwd: geesefs (FUSE-over-S3) mounts the store prefix INSIDE the sandbox for
 # remote runs. fuse provides fusermount + /etc/fuse.conf; geesefs is the static mount binary.
 # amd64 is correct here regardless of the builder's local arch: the snapshot is built and run
@@ -70,14 +69,20 @@ def main() -> None:
         print(f"deleting existing snapshot '{SNAPSHOT_NAME}'...")
         daytona.snapshot.delete(existing)
 
-    # Base on the full sandbox-agent image (daemon + claude + certs) and add the pi CLI globally
-    # so it is on PATH for the sandbox user the daemon runs as. The image's default user
-    # is the non-root `sandbox`, so switch to root for the global install, then back.
+    # Add Pi globally so it is on PATH for the non-root sandbox user. The full base
+    # already bakes Claude, Codex, and OpenCode, so verify their native binaries
+    # instead of reinstalling them.
     image = Image.base(SANDBOX_AGENT_IMAGE).dockerfile_commands(
         [
             "USER root",
             f"RUN npm install -g --ignore-scripts {PI_PACKAGE}",
-            "RUN pi --version || true",
+            "RUN pi --version",
+            "RUN test -x /home/sandbox/.local/share/sandbox-agent/bin/claude "
+            "&& echo claude-baked-in-base-image",
+            "RUN test -x /home/sandbox/.local/share/sandbox-agent/bin/codex "
+            "&& echo codex-baked-in-base-image",
+            "RUN test -x /home/sandbox/.local/share/sandbox-agent/bin/opencode "
+            "&& echo opencode-baked-in-base-image",
             # Durable cwd: fuse + geesefs so the remote sandbox can mount its store prefix.
             "RUN apt-get update && apt-get install -y --no-install-recommends fuse curl "
             "&& rm -rf /var/lib/apt/lists/* && echo user_allow_other >> /etc/fuse.conf",

--- a/services/runner/sandbox-images/daytona/build_snapshot.py
+++ b/services/runner/sandbox-images/daytona/build_snapshot.py
@@ -37,6 +37,7 @@ from daytona import (
     Image,
     Resources,
 )
+from daytona.common.errors import DaytonaNotFoundError
 
 SNAPSHOT_NAME = "agenta-sandbox-pi"
 SANDBOX_AGENT_IMAGE = "rivetdev/sandbox-agent:0.5.0-rc.2-full"
@@ -59,7 +60,7 @@ def main() -> None:
 
     try:
         existing = daytona.snapshot.get(SNAPSHOT_NAME)
-    except Exception:
+    except DaytonaNotFoundError:
         existing = None
 
     if existing and not force:
@@ -68,6 +69,17 @@ def main() -> None:
     if existing:
         print(f"deleting existing snapshot '{SNAPSHOT_NAME}'...")
         daytona.snapshot.delete(existing)
+        deadline = time.monotonic() + 120
+        while True:
+            try:
+                daytona.snapshot.get(SNAPSHOT_NAME)
+            except DaytonaNotFoundError:
+                break
+            if time.monotonic() >= deadline:
+                raise TimeoutError(
+                    "Timed out waiting for the old Daytona snapshot to delete"
+                )
+            time.sleep(2)
 
     # Add Pi globally so it is on PATH for the non-root sandbox user. The full base
     # already bakes Claude, Codex, and OpenCode, so verify their native binaries

--- a/services/runner/src/engines/sandbox_agent/daytona.ts
+++ b/services/runner/src/engines/sandbox_agent/daytona.ts
@@ -15,13 +15,13 @@ type Log = (message: string) => void;
 export const DAYTONA_PI_DIR =
   process.env.AGENTA_AGENT_SANDBOX_PI_DIR ?? "/home/sandbox/.pi/agent";
 
-// Some Daytona images ship the pi-acp adapter but not the `pi` CLI, so by default we install
-// it into the sandbox at session time and point pi-acp at it. A custom snapshot that
-// pre-installs `pi` can set AGENTA_AGENT_SANDBOX_PI_INSTALLED=false.
+// Keep fresh bare images reliable by installing Pi at session time by default. A
+// snapshot that already bakes the pinned CLI can explicitly set
+// AGENTA_AGENT_SANDBOX_PI_INSTALLED=false to skip that work.
 export const DAYTONA_PI_INSTALL_DIR = "/home/sandbox/.agenta-pi";
 export const DAYTONA_PI_INSTALL =
   process.env.AGENTA_AGENT_SANDBOX_PI_INSTALLED !== "false";
-export const DAYTONA_PI_VERSION = process.env.AGENTA_AGENT_SANDBOX_PI_VERSION ?? "0.79.4";
+export const DAYTONA_PI_VERSION = process.env.AGENTA_AGENT_SANDBOX_PI_VERSION ?? "0.80.6";
 
 /**
  * In-sandbox env for the Daytona daemon: where Pi reads its login, any provider keys,

--- a/services/runner/tests/unit/sandbox-agent-daytona.test.ts
+++ b/services/runner/tests/unit/sandbox-agent-daytona.test.ts
@@ -3,7 +3,7 @@
  *
  * Run: pnpm test (or: pnpm exec vitest run tests/unit/sandbox-agent-daytona.test.ts)
  */
-import { afterEach, describe, it } from "vitest";
+import { afterEach, describe, it, vi } from "vitest";
 import assert from "node:assert/strict";
 import { mkdtempSync, rmSync, writeFileSync } from "node:fs";
 import { tmpdir } from "node:os";
@@ -13,12 +13,14 @@ import {
   DAYTONA_PI_DIR,
   DAYTONA_PI_INSTALL,
   DAYTONA_PI_INSTALL_DIR,
+  DAYTONA_PI_VERSION,
   createCookieFetch,
   daytonaEnvVars,
+  installPiInSandbox,
   uploadPiAuthToSandbox,
 } from "../../src/engines/sandbox_agent/daytona.ts";
 
-const envKeys = ["PI_CODING_AGENT_DIR"];
+const envKeys = ["PI_CODING_AGENT_DIR", "AGENTA_AGENT_SANDBOX_PI_INSTALLED"];
 const previousEnv = new Map<string, string | undefined>();
 for (const key of envKeys) previousEnv.set(key, process.env[key]);
 
@@ -48,6 +50,63 @@ describe("daytonaEnvVars", () => {
     if (DAYTONA_PI_INSTALL) {
       assert.equal(env.PI_ACP_PI_COMMAND, `${DAYTONA_PI_INSTALL_DIR}/node_modules/.bin/pi`);
     }
+  });
+});
+
+describe("DAYTONA_PI_INSTALL default", () => {
+  afterEach(() => {
+    vi.resetModules();
+  });
+
+  it("defaults to installing Pi for a fresh bare sandbox", async () => {
+    delete process.env.AGENTA_AGENT_SANDBOX_PI_INSTALLED;
+    vi.resetModules();
+    const mod = await import("../../src/engines/sandbox_agent/daytona.ts");
+    assert.equal(mod.DAYTONA_PI_INSTALL, true);
+  });
+
+  it("installs Pi when explicitly enabled", async () => {
+    process.env.AGENTA_AGENT_SANDBOX_PI_INSTALLED = "true";
+    vi.resetModules();
+    const mod = await import("../../src/engines/sandbox_agent/daytona.ts");
+    assert.equal(mod.DAYTONA_PI_INSTALL, true);
+  });
+
+  it("skips the session install only when the snapshot already bakes Pi", async () => {
+    process.env.AGENTA_AGENT_SANDBOX_PI_INSTALLED = "false";
+    vi.resetModules();
+    const mod = await import("../../src/engines/sandbox_agent/daytona.ts");
+    assert.equal(mod.DAYTONA_PI_INSTALL, false);
+  });
+});
+
+describe("installPiInSandbox", () => {
+  it("installs the pinned Pi version", async () => {
+    const calls: any[] = [];
+    const sandbox = {
+      mkdirFs: async () => {},
+      runProcess: async (input: any) => {
+        calls.push(input);
+        return { exitCode: 0 };
+      },
+    };
+
+    await installPiInSandbox(sandbox);
+
+    assert.equal(DAYTONA_PI_VERSION, "0.80.6");
+    assert.deepEqual(calls, [
+      {
+        command: "npm",
+        args: [
+          "install",
+          "--no-fund",
+          "--no-audit",
+          "@earendil-works/pi-coding-agent@0.80.6",
+        ],
+        cwd: DAYTONA_PI_INSTALL_DIR,
+        timeoutMs: 180_000,
+      },
+    ]);
   });
 });
 


### PR DESCRIPTION
## Context

The Daytona full sandbox-agent base already contains Claude, Codex, and OpenCode plus the Pi ACP adapter, but it does not contain the standalone Pi CLI that pi-acp launches.

Fresh bare images remain reliable by default: with AGENTA_AGENT_SANDBOX_PI_INSTALLED unset or true, the runner installs our pinned Pi version into the new sandbox session. Operators set it to false only when DAYTONA_SNAPSHOT points at a snapshot that already bakes Pi.

## Changes

- rebuild the stale PR on the current big-agents head
- bake @earendil-works/pi-coding-agent 0.80.6 into agenta-sandbox-pi
- fail the snapshot build if pi --version does not work
- verify that the base image still contains the Claude, Codex, and OpenCode binaries
- keep the session-time Pi install enabled by default and pin its fallback version to 0.80.6
- wait for asynchronous snapshot deletion before recreating the fixed snapshot name
- document the exact environment contract and add regression coverage for unset, true, and false

## Scope

This PR changes the Daytona snapshot recipe and Pi installation behavior only. It does not add model-catalog entries; those remain in #5198.

## Validation

- GitHub runner unit, integration, and acceptance jobs: passed
- runner typecheck: passed
- Daytona helper unit test: 7 passed
- runner unit suite excluding two pre-existing failed QA captures: 739 passed
- snapshot recipe ruff and Python compilation: passed
- live agenta-sandbox-pi rebuild: ACTIVE in 522 seconds
- live snapshot checks: Pi 0.80.6; Claude, Codex, OpenCode, and geesefs present
- live Pi catalogs: gpt-5.6-luna, gpt-5.6-sol, and gpt-5.6-terra present under openai and openai-codex
- Daytona sandbox count: 0 before and 0 after

The API, SDK, and web jobs also fail on the big-agents integration PR at the same base SHA with the same unrelated test failures. This PR touches none of those areas.