### PR TITLE
[fix] Refuse tools on non-Pi harness x remote sandbox instead of silently dropping them

### DIFF
--- a/docs/design/agent-workflows/projects/remote-tools-delivery/research.md
+++ b/docs/design/agent-workflows/projects/remote-tools-delivery/research.md
@@ -1,0 +1,105 @@
+# Research
+
+Verified against the working tree. Paths are repo-relative under `services/runner/`.
+
+## 1. The bug (F1, audit finding)
+
+A non-Pi harness (Claude today; any future MCP-only harness) running on a **remote** sandbox
+(Daytona) has no working delivery path for gateway/custom tools at all:
+
+- `engines/sandbox_agent/mcp.ts` `buildSessionMcpServers` builds the internal gateway-tool
+  channel as a runner-loopback (`127.0.0.1`) HTTP MCP server
+  (`tools/tool-mcp-http.ts` `startInternalToolMcpServer`). On Daytona the harness runs **inside**
+  the sandbox, where `127.0.0.1` resolves to the sandbox's own loopback, not the runner's — an
+  unreachable URL. `buildSessionMcpServers` correctly skips advertising it there
+  (`isDaytona ? { servers: [], close... } : await buildToolMcpServers(...)`).
+- The code's own comment claimed the gap was covered: "gateway tools are delivered through the
+  file relay instead (the relay loop already polls the sandbox filesystem on Daytona)." This is
+  false for a non-Pi harness. The file-relay protocol (`tools/relay.ts`) has two halves: a
+  **runner-side poller** (works for any sandbox, harness-agnostic) and a **sandbox-side writer**
+  that must ask the runner to run a tool by dropping a `<id>.req.json` file into the relay dir.
+  That writer exists in exactly one place: `extensions/agenta.ts` `registerTools`, which is Pi's
+  bundled extension (`pi.registerTool` + `runResolvedTool` in the `execute` callback). It is
+  installed only into Pi's agent directory and loaded only when Pi runs. Claude (or any other
+  non-Pi harness) has no code path that writes a relay request file.
+- The capability gate that should have caught this doesn't, because it is checking the wrong
+  thing: `engines/sandbox_agent/capabilities.ts` `assertRequiredCapabilities` only asserts that
+  the harness *can accept an MCP server and call a tool* (`capabilities.mcpTools` +
+  `capabilities.toolCalls`, from the daemon probe). Claude reports both `true` — correctly, in
+  general, since Claude can and does consume the internal channel over loopback HTTP locally.
+  The gate has no notion of "reachable from here"; it never looks at `isDaytona`.
+- Net effect before this fix: the run proceeds, the harness receives an empty tool list, the
+  turn completes, `mcp.ts` logs a specific but FALSE message
+  (`"daytona: N gateway tool(s) delivered via the file relay, not a loopback MCP URL"`), and the
+  `/run` result comes back `ok:true`. A caller has no signal that every tool call the model might
+  have made was structurally impossible.
+
+## 2. Why Pi is unaffected
+
+Pi never uses either MCP path for tools. `buildSessionMcpServers` short-circuits to
+`{ servers: [], close: async () => {} }` for `isPi` before either layer runs
+(`if (isPi || !capabilities.mcpTools) { ... return ... }`). Pi's tools ride entirely through
+`extensions/agenta.ts`: the daemon loads the extension into the Pi process (local or inside the
+Daytona sandbox — `prepareDaytonaPiAssets` uploads it there), the extension reads
+`AGENTA_AGENT_TOOLS_PUBLIC_SPECS` / `AGENTA_AGENT_TOOLS_RELAY_DIR` from its environment, and its
+`execute` callback calls `runResolvedTool`, which is the SAME sandbox-side relay-writer used by
+the file-relay protocol (`tools/dispatch.ts`). So "the file relay works on Daytona" is true only
+because Pi ships its own relay-writing client bundled as a harness extension. No other harness
+has an equivalent.
+
+## 3. What already exists to build on
+
+- **Loopback HTTP MCP server** (`tools/tool-mcp-http.ts`): a from-scratch, dependency-free
+  Streamable-HTTP JSON-RPC server (`initialize` / `tools/list` / `tools/call`), started per
+  session on an OS-assigned port, bound to `127.0.0.1` only. This is the piece that needs a
+  reachable address on Daytona, or an in-sandbox counterpart — see the two candidates below.
+- **File-relay protocol** (`tools/relay.ts`): request/response JSON files in a shared dir,
+  polled by the runner (`startToolRelay`), written by whichever process wants a tool run. Already
+  harness-agnostic on the runner side. Already reaches into the Daytona sandbox filesystem via
+  the daemon API (see `engines/sandbox_agent.ts`, the "Daytona tool relay" section) — the runner
+  polls files that live inside the sandbox, not on the runner host.
+- **Pi's bundled extension pattern** (`extensions/agenta.ts`): a fully-worked example of a
+  sandbox-side relay-writing client — esbuild-bundled, env-driven, self-contained. It is a
+  concrete template for a hypothetical non-Pi equivalent, though it depends on the harness having
+  an extension/plugin mechanism to load into (Pi does; Claude's ACP agent and Codex's may not).
+- **Daytona's own remote-reachability precedent — the preview proxy**: the runner already talks
+  to a Daytona-hosted ACP HTTP endpoint through Daytona's preview-proxy mechanism
+  (`engines/sandbox_agent/daytona.ts` `createCookieFetch`: "Daytona's preview proxy
+  authenticates with a … cookie jar"). This means Daytona already exposes an authenticated
+  reverse proxy from outside the sandbox to a port inside it — the reverse of what the internal
+  tool-MCP channel would need (inside the sandbox reaching a URL that resolves to the runner),
+  but it establishes that Daytona has a general request-routing/proxy primitive worth
+  investigating for the other direction, or for exposing a runner-side port that a
+  Daytona-issued URL can forward into the sandbox's network namespace.
+- **The ngrok tunnel used for durable-cwd mounting** (`engines/sandbox_agent/mount.ts`
+  `discoverTunnelEndpoint`): a working precedent for making a runner-side service reachable from
+  inside a Daytona sandbox over the public internet (geesefs inside the sandbox mounts the
+  runner's storage over this tunnel). This is the closest existing analogue to "advertise the
+  internal tool-MCP on a sandbox-reachable URL" (candidate (a) below) — the same tunnel
+  infrastructure could plausibly carry the tool-MCP's HTTP traffic too, provided auth is added
+  (the mount path currently authenticates via signed mount credentials, not a bearer suitable for
+  MCP).
+- **No E2B path on this branch.** `mount.ts` mentions "e2b" only in a comment; there is no E2B
+  sandbox provider implemented (`engines/sandbox_agent/provider.ts` only builds `local` and
+  `daytona`). The interim gate below is written against the two providers this codebase actually
+  has: `local` (loopback reachable) and `daytona` (loopback unreachable).
+
+## 4. The interim fix implemented alongside these docs
+
+`engines/sandbox_agent/run-plan.ts` `buildRunPlan` now refuses, before any cwd or sandbox is
+created, any run where `!isPi && isDaytona && executableToolSpecsForRun.length > 0` —
+`REMOTE_TOOLS_UNSUPPORTED_MESSAGE`. This mirrors the existing not-implemented gates in the same
+file (`CODE_TOOL_UNSUPPORTED_MESSAGE`, `USER_MCP_UNSUPPORTED_MESSAGE`,
+`PI_USER_MCP_UNSUPPORTED_MESSAGE`, `FILESYSTEM_UNSUPPORTED_MESSAGE`,
+`LOCAL_NETWORK_UNSUPPORTED_MESSAGE`): fail loud with a single named message instead of silently
+dropping a declared capability. `executableToolSpecsForRun` (already computed earlier in the
+function via `executableToolSpecs(toolSpecs)`) excludes `client`-kind tools, which are
+browser-fulfilled and were never advertised over the internal channel in the first place
+(`tool-mcp-http.ts` `tools/list` filters them out too), so a client-only tool run is unaffected.
+The `mcp.ts` "delivered via the file relay" log is now conditioned on `isPi` so it can never again
+claim a delivery that isn't happening, as defense-in-depth against a future gate bypass (the
+run-plan gate should make the branch it guards dead code, but the log no longer trusts that).
+
+This is explicitly the interim/shipping fix, not the real feature — it trades "some valid
+combinations now error where they used to (silently) proceed" for "no combination silently drops
+tools." The real feature (making the combination actually work) is scoped below.

--- a/docs/design/agent-workflows/projects/remote-tools-delivery/specs.md
+++ b/docs/design/agent-workflows/projects/remote-tools-delivery/specs.md
@@ -1,0 +1,117 @@
+# Specs
+
+## Goal
+
+Make gateway/custom tool delivery work for a non-Pi harness (Claude today; any future MCP-only
+harness) on a remote sandbox (Daytona today; any future non-local provider), closing the gap the
+interim gate in `run-plan.ts` currently refuses outright. Non-goals: user-declared stdio MCP
+(stays disabled, unrelated security decision) and user-declared HTTP MCP (already works
+unchanged on every sandbox, since it is a remote URL the harness dials directly).
+
+## The gap, precisely
+
+The internal gateway-tool channel has two jobs: **advertise** a way for the harness to discover
+and call the tools, and **execute** a call by relaying it back to the runner, where the private
+spec / scoped env / callback auth are applied server-side. Execution already works
+sandbox-agnostically (`tools/relay.ts`, `tools/dispatch.ts`). Only advertisement is missing for
+a non-Pi harness in a remote sandbox: there is no artifact inside the sandbox that speaks
+whatever protocol the harness expects for "here are your tools."
+
+Two shapes close that gap:
+
+## Candidate (a): advertise the internal tool-MCP on a sandbox-reachable URL
+
+Keep today's design (`tools/tool-mcp-http.ts`'s HTTP MCP server, `mcp.ts`'s advertisement of a
+`type: "http"` ACP MCP server) but bind or expose it so a URL reachable **from inside the
+sandbox** resolves back to the runner process, instead of binding to loopback only. Three
+sub-options for the "reachable URL" part:
+
+1. **Runner binds non-loopback.** Bind `tool-mcp-http.ts` to `0.0.0.0` (or a specific
+   routable interface) instead of `127.0.0.1`, and advertise the runner's own network address.
+   Only viable if the runner and the Daytona sandbox share a network path that doesn't already
+   exist today (they don't — the sandbox is a separate remote VM/container with its own network
+   namespace; nothing routes a Daytona sandbox's outbound traffic to the runner host's private
+   IP without additional infrastructure). Effectively requires one of the other two sub-options
+   underneath it anyway.
+2. **A tunnel** (reusing `discoverTunnelEndpoint`'s ngrok infrastructure, already used to expose
+   the runner's storage mount to a Daytona sandbox). The internal MCP server binds loopback as
+   today; the runner also registers/reuses an ngrok tunnel forwarding a public HTTPS URL to that
+   local port; that URL is what gets advertised as the ACP MCP server's `url`.
+3. **A sandbox-side port-forward issued by the provider** (Daytona's own preview-proxy
+   mechanism, the same one that already fronts the ACP HTTP endpoint with cookie-jar auth in
+   `daytona.ts` `createCookieFetch`). If Daytona (or a future provider) can forward a port
+   **into** the sandbox's own loopback from a runner-controlled listener, the sandbox's existing
+   `127.0.0.1` advertisement becomes correct again with zero harness-side change — the forwarded
+   port simply makes the runner's server locally reachable inside the sandbox.
+
+**Auth story required in all three:** today's channel deliberately carries no secret because it
+never leaves the runner's own loopback (no attacker can reach `127.0.0.1` on the runner host from
+outside it). The moment the URL is reachable from the sandbox — let alone from the tunnel's
+public internet hop in sub-option 2 — the channel needs its own bearer/token so a compromised or
+malicious in-sandbox process (or, worse, anyone who guesses the tunnel URL) cannot call
+`tools/call` and trigger a credentialed gateway action. This is new work: a per-run random token,
+checked on every request, threaded through the ACP `headers` field (the `McpServerHttp` shape
+already supports headers — `toAcpMcpServers` does exactly this for user HTTP MCP servers).
+
+## Candidate (b): an in-sandbox relay CLIENT for non-Pi harnesses
+
+Ship (or have the daemon spawn) a small MCP-server shim that runs **inside** the sandbox,
+alongside the harness, and translates between "the harness's native tool-delivery mechanism" and
+"the file-relay protocol" (write a `<id>.req.json`, poll for `<id>.res.json` — exactly what
+`extensions/agenta.ts` `registerTools` already does for Pi, minus the Pi-extension plumbing
+around it). Two delivery mechanisms for getting the shim into the sandbox:
+
+1. **Daemon-spawned**, analogous to how the daemon already knows how to run each harness: the
+   daemon starts the shim as a sibling process/MCP server alongside the ACP agent process and
+   wires it into the session's MCP server list the way it wires in any other stdio MCP server —
+   except this stdio server runs **inside the sandbox**, not on the runner host, so it does not
+   reintroduce the runner-host-process security hole that `USER_MCP_UNSUPPORTED_MESSAGE` guards
+   against. This needs the daemon (`sandbox-agent` package, not this repo) to grow a concept of
+   "an extra in-sandbox MCP server the runner wants attached," which does not exist today for a
+   non-Pi harness.
+2. **Shipped like Pi's extension**, if the target harness has an equivalent
+   plugin/extension-loading mechanism. Claude Code's ACP agent
+   (`@zed-industries/claude-agent-acp`) would need to expose something analogous to Pi's
+   `ExtensionAPI`/`registerTool` for this to apply; unconfirmed whether it does. If it doesn't,
+   this sub-option collapses into (1).
+
+**Auth/exposure story**: strictly better than (a) — the shim's traffic never leaves the sandbox
+(it talks to the relay dir on the sandbox filesystem, the same file-based IPC Pi already uses,
+which the runner already reaches via the Daytona daemon filesystem API). No new network exposure,
+no new secret to mint or rotate, no tunnel.
+
+## Comparison
+
+| Axis | (a) Reachable URL | (b) In-sandbox relay client |
+| --- | --- | --- |
+| **Auth / exposure** | New secret required; sub-option 2 exposes a URL over the public internet (mitigated by a bearer, but still a new attack surface); sub-option 3 depends on provider-level port-forward trust boundaries being sound | No new exposure — traffic stays inside the sandbox filesystem, same trust boundary the runner already crosses for Daytona mounts |
+| **Latency** | Extra network hop (sandbox → tunnel/proxy → runner) per tool call, on top of the existing relay-execution hop back to the runner; for sub-option 2 specifically, adds public-internet round-trip latency | One hop shorter: the shim talks file-relay directly, same mechanism Pi already uses at today's measured latency (the relay-poll interval, `RELAY_POLL_MS`, dominates either way) |
+| **Per-provider work** | Daytona: reuse `discoverTunnelEndpoint`/preview-proxy (some infra exists); a future E2B-style provider not on this branch would need its own equivalent (host-side port exposure, different proxy model) — the design is NOT provider-agnostic, each provider needs its own "how do I get a URL routed here" answer | Provider-agnostic once the daemon can spawn/attach a sandbox-side process at all (which every provider already supports, since it's how the harness itself runs) — the only per-provider work is none beyond what already exists to launch a process/write files inside that sandbox |
+| **Per-harness work** | None once built — the ACP `McpServerHttp` advertisement is harness-agnostic (any harness that accepts `type: "http"` MCP, which Claude already does) | Needs the daemon to grow "attach an extra in-sandbox MCP server" (sub-option 1) OR needs each harness to expose an extension mechanism (sub-option 2, uncertain for non-Pi harnesses) — the harder, more novel piece of engineering |
+| **Which cells does it unblock** | All remote-sandbox non-Pi combinations at once, retroactively, for any current or future provider that can offer the reachable-URL primitive — but gated on that primitive existing per-provider | All remote-sandbox non-Pi combinations at once IF the daemon-spawned sub-option lands (provider-agnostic); narrower if stuck relying on per-harness extension support |
+| **Security review surface** | New: a bearer-secured internet-reachable (or provider-proxied) endpoint serving a JSON-RPC tool-call API — needs its own threat model, closer in shape to the SSRF-guarded user-HTTP-MCP path (`mcp.ts` `validateUserMcpUrl`) than to today's "carries no secret because unreachable" internal channel | Reuses the EXACT trust boundary already accepted for Pi + Daytona (file relay inside a daemon-managed sandbox filesystem) — no new category of risk, just a second writer of an existing protocol |
+
+## Recommendation
+
+**Candidate (b), daemon-spawned sub-option**, is the better target: it reuses an
+already-accepted trust boundary (the same one Pi's extension operates in today), needs no new
+secret/token lifecycle, is provider-agnostic (works identically on Daytona and any future
+provider, since it only depends on "can the daemon run an extra process/write files inside the
+sandbox," which every provider must already support to run the harness at all), and does not add
+a network hop or a new externally-reachable service to threat-model. Its cost is concentrated in
+one place — teaching the daemon (the `sandbox-agent` package) to attach a non-Pi in-sandbox
+relay-client MCP server to a session — rather than spread across every sandbox provider's
+networking model the way (a) would require.
+
+Candidate (a) is worth keeping as a fallback if the daemon cannot be taught to spawn an
+in-sandbox process for a non-Pi harness (e.g., if the ACP agent's process model doesn't allow the
+daemon to run a sibling process next to it) — in that case, reusing the existing Daytona tunnel
+infrastructure (sub-option 2) is the least-new-code path, accepting the added secret-management
+and public-exposure review it requires.
+
+## Non-goals for this design (explicitly out of scope)
+
+- Removing or relaxing the interim `run-plan.ts` gate before a working delivery path ships —
+  the gate stays until one of the above lands and is tested end-to-end.
+- Any change to user-declared MCP (stdio stays disabled; HTTP stays as-is).
+- Supporting a sandbox provider not already in this codebase (no E2B provider exists here today).

--- a/docs/design/agent-workflows/projects/remote-tools-delivery/tasks.md
+++ b/docs/design/agent-workflows/projects/remote-tools-delivery/tasks.md
@@ -1,0 +1,103 @@
+# Tasks
+
+Design-only. Nothing below is built yet; this is the implementation queue for the recommended
+fix (specs.md candidate (b), daemon-spawned in-sandbox relay client), once approved.
+
+## 0. Pre-work / confirm before starting
+
+- [ ] Confirm with the daemon owner (`sandbox-agent` package, a separate repo/dependency from
+      this one) whether it can spawn a sibling process, or attach an extra stdio MCP server that
+      runs INSIDE the sandbox, alongside a non-Pi harness (Claude's ACP agent process). This is
+      the load-bearing assumption for candidate (b); if it's a hard no, fall back to specs.md
+      candidate (a) sub-option 2 (tunnel) instead and re-plan from there.
+- [ ] Confirm whether Claude's ACP agent (`@zed-industries/claude-agent-acp`) exposes any
+      extension/plugin hook analogous to Pi's `ExtensionAPI` — if it does, sub-option 2 of
+      candidate (b) (ship a bundled shim like Pi's) may be simpler than daemon-spawning a
+      separate process. Time-boxed spike, not a blocker for the daemon-side investigation above.
+
+## 1. Build the in-sandbox relay-client shim
+
+- [ ] Extract the relay-writing logic Pi's extension uses
+      (`extensions/agenta.ts` `registerTools` → `runResolvedTool`) into a harness-agnostic,
+      standalone shim: given `AGENTA_AGENT_TOOLS_PUBLIC_SPECS` + `AGENTA_AGENT_TOOLS_RELAY_DIR`
+      in its environment, expose those tools over whatever local protocol the daemon needs
+      (stdio MCP is the natural choice, since it mirrors the ACP `McpServerStdio` shape already
+      used for user-declared stdio servers — except this one runs inside the sandbox, so the
+      `USER_MCP_UNSUPPORTED_MESSAGE` security concern does not apply).
+  - Reuse `EMPTY_OBJECT_SCHEMA`, `promptSnippet`/`promptGuidelines`-equivalent tool metadata
+    shaping from `extensions/agenta.ts` where useful, but the shim does not need Pi's
+    `ExtensionAPI` — it is a standalone MCP server binary, esbuild-bundled the way the Pi
+    extension already is (`pnpm run build:extension`).
+- [ ] Decide how the shim reaches the sandbox filesystem for the relay dir: it should be the
+      SAME relay dir the runner-side poller already watches (`plan.relayDir`), so no new relay
+      protocol is needed — only a new writer.
+
+## 2. Wire the shim into a non-Pi remote session
+
+- [ ] In `engines/sandbox_agent.ts`, for a non-Pi harness on a remote sandbox with
+      `executableToolSpecs.length > 0`, have the daemon start the shim (mechanism depends on
+      task 0's finding) and add it to the session's `mcpServers` list instead of (or alongside)
+      today's `buildSessionMcpServers` internal-channel call.
+- [ ] Update `engines/sandbox_agent/mcp.ts` `buildSessionMcpServers`: the Daytona branch currently
+      returns `{ servers: [], close: async () => {} }` for the internal channel unconditionally.
+      Replace that with "start the in-sandbox shim and return its MCP server entry" for the
+      non-Pi + remote case. Keep the local-loopback path (`buildToolMcpServers`) for `!isDaytona`
+      unchanged — this fix only targets the remote case.
+- [ ] Correct the log this project's interim fix made conditional on `isPi`
+      (`mcp.ts`, "daytona: N gateway tool(s) delivered via the file relay") so it fires for the
+      NEW real delivery path too, once true.
+
+## 3. Remove the interim gate
+
+- [ ] Delete (or narrow) the `run-plan.ts` `REMOTE_TOOLS_UNSUPPORTED_MESSAGE` gate added by the
+      interim fix, once the shim path is implemented and tested end-to-end. Narrow rather than
+      delete outright if the fix only covers Daytona and a future non-Daytona remote provider is
+      added later without the same shim support — keep the gate provider-scoped in that case.
+- [ ] Update/remove the four unit tests in `tests/unit/sandbox-agent-run-plan.test.ts`
+      (`describe("remote-tools gate ...")`) that currently assert the refusal; replace with tests
+      asserting the shim path is wired (claude x daytona x tools → session includes the shim MCP
+      server, tool call round-trips through the relay dir).
+- [ ] Revert the three Layer-2 network-boundary tests that were switched from `harness: "claude"`
+      to `harness: "pi_agenta"` as part of the interim fix (`sandbox-agent-run-plan.test.ts`,
+      search "Pi (not claude)") back to exercising Claude directly, since the F1 gate they were
+      moved to avoid will no longer intercept them first — OR keep both harnesses covered if the
+      Layer-2 network-bypass concern (code/gateway tools running on the runner host bypass the
+      sandbox network boundary) still applies to the new shim path. Re-verify: does the in-sandbox
+      shim change WHERE execution happens? (No — `runResolvedTool` still executes on the runner
+      via the relay; only the advertisement/discovery moved into the sandbox.) So the Layer-2
+      network-boundary gate's reasoning is unchanged and this test set can stay dual-covered
+      (Pi and Claude) rather than only reverted.
+
+## 4. Auth / security review (if candidate (a) is chosen instead)
+
+Only applies if task 0 forces a pivot to candidate (a):
+
+- [ ] Design a per-run bearer token for the internal tool-MCP channel; thread it through
+      `McpServerHttp.headers` the way `toAcpMcpServers` already does for user HTTP MCP servers.
+- [ ] Threat-model the tunnel/proxy exposure (reuse or extend the SSRF-style review already done
+      for user HTTP MCP in `mcp.ts` `validateUserMcpUrl` / `isInternalHost` — the new channel is
+      the INVERSE direction, so the guard needs to protect the runner's endpoint from arbitrary
+      external callers, not protect the runner from calling out to one).
+- [ ] Security review sign-off before removing the interim gate for the reachable-URL path.
+
+## 5. Tests (either candidate)
+
+- [ ] Unit: shim/relay-writer logic in isolation (given specs + relay dir, writes the expected
+      `<id>.req.json`, parses `<id>.res.json`), mirroring `tests/unit/extension-tools.test.ts`'s
+      coverage of Pi's `registerTools`.
+- [ ] Unit: `buildSessionMcpServers` non-Pi + Daytona + tools now returns a non-empty server list
+      (contrast with today's `session-mcp-layering.test.ts` case asserting the loopback channel
+      is ABSENT on Daytona — that assertion should be updated to assert the NEW channel present).
+- [ ] Integration/acceptance (if the harness exists in this repo's test tooling): an end-to-end
+      Claude-on-Daytona run with a gateway tool that actually gets called and returns a result,
+      closing the loop the interim gate currently blocks at plan-build time.
+- [ ] Regression: keep a test pinning that user stdio MCP (`USER_MCP_UNSUPPORTED_MESSAGE`) is
+      UNCHANGED by this work — the new in-sandbox server is internal/synthesized, not user-facing,
+      and must not be reachable through `request.mcpServers`.
+
+## Dependencies / sequencing
+
+- Task 0 blocks everything else (chooses (a) vs (b)).
+- Tasks 1-2 (build + wire the shim) block task 3 (removing the interim gate) — the gate must
+  stay live until its replacement is proven in task 5's tests.
+- Task 4 only applies to the candidate-(a) fallback branch.

--- a/services/runner/src/engines/sandbox_agent/mcp.ts
+++ b/services/runner/src/engines/sandbox_agent/mcp.ts
@@ -233,15 +233,17 @@ export async function buildSessionMcpServers({
   const internal = isDaytona
     ? { servers: [], close: async () => {} }
     : await buildToolMcpServers(toolSpecs, relayDir, log);
-  // Only Pi has a sandbox-side file-relay writer (its bundled extension); this line runs after
-  // the `isPi` early-return above, so it is dead for a harness that could actually claim relay
-  // delivery. Kept as a defense-in-depth check — a future change to the early-return above must
-  // not resurrect the F1 false log ("delivered via the file relay" for a harness with no relay
-  // writer). `run-plan.ts` refuses this combination before it ever reaches here.
-  if (isDaytona && toolSpecs.length > 0 && isPi) {
+  // Only Pi has a sandbox-side file-relay writer (its bundled extension), and Pi never reaches
+  // this point (the `isPi` early-return above), so no harness that gets here has ANY delivery
+  // path on Daytona. `run-plan.ts` (`REMOTE_TOOLS_UNSUPPORTED_MESSAGE`) refuses that combination
+  // before a session is built; if it ever reaches here anyway, log the honest fact — the
+  // advertisement was skipped — and never claim a file-relay delivery that isn't happening
+  // (the F1 false log).
+  if (isDaytona && toolSpecs.length > 0) {
     log(
-      `daytona: ${toolSpecs.length} gateway tool(s) delivered via the file relay, not a ` +
-        `loopback MCP URL (unreachable from the sandbox)`,
+      `daytona: skipped the loopback tool-MCP advertisement for ${toolSpecs.length} tool(s) ` +
+        `(runner loopback unreachable from the sandbox; no delivery path for this harness — ` +
+        `run-plan should have refused this run)`,
     );
   }
   // Layer 2: USER MCP capability (stdio disabled, http delivered; do not merge with Layer 1).

--- a/services/runner/src/engines/sandbox_agent/mcp.ts
+++ b/services/runner/src/engines/sandbox_agent/mcp.ts
@@ -190,10 +190,15 @@ export interface SessionMcpServers {
  *     MCP server that delivers the run's resolved gateway/callback tools to the harness. Carries
  *     only public metadata; execution relays server-side. RESTORED — but advertised over a
  *     loopback (`127.0.0.1`) URL, so it is LOCAL-ONLY. On Daytona the harness runs IN the sandbox,
- *     where `127.0.0.1` is the sandbox's loopback, not the runner's, so the channel is SKIPPED and
- *     the tools reach the harness through the file relay instead (the relay loop already works on
- *     Daytona; gateway-tool-mcp open question 3). This honors the #4844 decision: HTTP advertisement
- *     for local, file relay for Daytona.
+ *     where `127.0.0.1` is the sandbox's loopback, not the runner's, so the channel is SKIPPED.
+ *     For a non-Pi harness this means NO delivery path exists (F1, audit finding): the file relay
+ *     has a sandbox-side writer only inside Pi's bundled extension
+ *     (`extensions/agenta.ts` `registerTools`), which no other harness loads — a claim this
+ *     function used to log unconditionally, which was FALSE for non-Pi harnesses. `run-plan.ts`
+ *     (`REMOTE_TOOLS_UNSUPPORTED_MESSAGE`) now refuses that combination before a session is ever
+ *     built, so this function should never see non-Pi + Daytona + tools. The log below stays
+ *     Pi-only anyway, as a defense against a future gate bypass: it must never again claim a
+ *     delivery that isn't happening.
  *  2. USER MCP capability (`toAcpMcpServers`): the user's own declared servers — stdio DISABLED,
  *     http delivered (#4834). UNCHANGED on every sandbox: a user http MCP is a REMOTE url the
  *     harness dials directly (not a runner loopback), so it stays reachable from a Daytona sandbox.
@@ -224,13 +229,16 @@ export async function buildSessionMcpServers({
 
   // Layer 1: INTERNAL gateway-tool channel (do not merge with the user gate below). LOCAL ONLY:
   // its advertised URL is a runner loopback (`127.0.0.1`), unreachable from a remote Daytona
-  // sandbox where the harness runs. On Daytona, skip the loopback HTTP advertisement and let the
-  // file relay deliver the tools (the relay loop polls the sandbox filesystem; see the Daytona
-  // tool relay in `engines/sandbox_agent.ts`).
+  // sandbox where the harness runs. On Daytona, skip the loopback HTTP advertisement.
   const internal = isDaytona
     ? { servers: [], close: async () => {} }
     : await buildToolMcpServers(toolSpecs, relayDir, log);
-  if (isDaytona && toolSpecs.length > 0) {
+  // Only Pi has a sandbox-side file-relay writer (its bundled extension); this line runs after
+  // the `isPi` early-return above, so it is dead for a harness that could actually claim relay
+  // delivery. Kept as a defense-in-depth check — a future change to the early-return above must
+  // not resurrect the F1 false log ("delivered via the file relay" for a harness with no relay
+  // writer). `run-plan.ts` refuses this combination before it ever reaches here.
+  if (isDaytona && toolSpecs.length > 0 && isPi) {
     log(
       `daytona: ${toolSpecs.length} gateway tool(s) delivered via the file relay, not a ` +
         `loopback MCP URL (unreachable from the sandbox)`,

--- a/services/runner/src/engines/sandbox_agent/run-plan.ts
+++ b/services/runner/src/engines/sandbox_agent/run-plan.ts
@@ -43,18 +43,20 @@ export const FILESYSTEM_UNSUPPORTED_MESSAGE =
   "remove sandbox_permission.filesystem.";
 
 /**
- * A non-Pi harness (MCP-only tool delivery) on a remote (Daytona) sandbox cannot receive
- * gateway/custom tools at all today (F1, audit finding): the internal tool-MCP channel is a
- * runner-loopback (`127.0.0.1`) HTTP server, unreachable from inside the sandbox, so
- * `buildSessionMcpServers` skips it on Daytona; the fallback path (the file relay) has a
+ * A non-Pi harness (MCP-only tool delivery) on a remote sandbox cannot receive gateway/custom
+ * tools at all today (F1, audit finding): the internal tool-MCP channel is a runner-loopback
+ * (`127.0.0.1`) HTTP server, unreachable from inside a remote sandbox, so
+ * `buildSessionMcpServers` skips it there; the fallback path (the file relay) has a
  * sandbox-side writer ONLY inside Pi's bundled extension (`extensions/agenta.ts`
  * `registerTools`), which no other harness loads. Before this gate, the run proceeded anyway,
  * `mcp.ts` logged a false "delivered via the file relay", and the harness silently received
  * zero tools with `ok:true` (the silent-tool-drop bug). Refuse loud instead, mirroring the
- * other not-implemented gates above.
+ * other not-implemented gates above. The gate keys on "not local" rather than "is daytona" so
+ * a NEW remote provider (e.g. the in-flight E2B one) fails closed with this error until tool
+ * delivery is proven there, instead of silently re-opening F1 one provider over.
  */
 export const REMOTE_TOOLS_UNSUPPORTED_MESSAGE =
-  "Tools are not supported for a non-Pi harness on a remote (daytona) sandbox: the internal " +
+  "Tools are not supported for a non-Pi harness on a remote sandbox: the internal " +
   "tool-MCP channel is loopback-only (unreachable from inside the sandbox), and there is no " +
   "in-sandbox relay client for this harness (only Pi's bundled extension writes the file " +
   "relay). Run on the local sandbox, use the Pi harness, or remove the tools. Tracked in " +
@@ -206,6 +208,11 @@ export function buildRunPlan(
 
   const isPi = acpAgent === "pi";
   const isDaytona = sandboxId === "daytona";
+  // Any non-local sandbox counts as remote for the F1 tools gate below. An unknown provider id
+  // currently falls through to the LOCAL cwd/provider path further down, but for tool delivery
+  // it must fail CLOSED: a future provider (E2B et al.) has no proven delivery path until it
+  // ships one, and "unknown" must not silently behave like "reachable loopback".
+  const isRemoteSandbox = sandboxId !== "local";
 
   const secrets = request.secrets ?? {};
   const legacyHarnessApiKeyVar =
@@ -262,14 +269,17 @@ export function buildRunPlan(
     return { ok: false, error: USER_MCP_UNSUPPORTED_MESSAGE };
   }
 
-  // F1 (audit finding, silent-tool-drop): a non-Pi harness on a remote (Daytona) sandbox has NO
-  // working delivery path for gateway/custom tools. The internal tool-MCP is loopback-only
-  // (unreachable from inside the sandbox), and the file-relay fallback has a sandbox-side writer
-  // only inside Pi's bundled extension. Before this gate the run proceeded, silently dropped
-  // every tool, and still returned `ok:true`. Refuse up front, the way the other not-implemented
-  // gates above do. `executableToolSpecsForRun` excludes `client` tools (browser-fulfilled, never
-  // routed through this channel), matching what the internal MCP channel actually advertises.
-  if (!isPi && isDaytona && executableToolSpecsForRun.length > 0) {
+  // F1 (audit finding, silent-tool-drop): a non-Pi harness on a remote sandbox has NO working
+  // delivery path for gateway/custom tools. The internal tool-MCP is loopback-only (unreachable
+  // from inside the sandbox), and the file-relay fallback has a sandbox-side writer only inside
+  // Pi's bundled extension. Before this gate the run proceeded, silently dropped every tool, and
+  // still returned `ok:true`. Refuse up front, the way the other not-implemented gates above do,
+  // and fail CLOSED for any non-local provider (see `isRemoteSandbox`) so a new remote provider
+  // cannot silently re-open F1. `executableToolSpecsForRun` excludes `client` tools
+  // (browser-fulfilled, never routed through this channel), matching what the internal MCP
+  // channel actually advertises; #4985 moves client tools onto that channel and owns tightening
+  // this exemption when it lands.
+  if (!isPi && isRemoteSandbox && executableToolSpecsForRun.length > 0) {
     return { ok: false, error: REMOTE_TOOLS_UNSUPPORTED_MESSAGE };
   }
 

--- a/services/runner/src/engines/sandbox_agent/run-plan.ts
+++ b/services/runner/src/engines/sandbox_agent/run-plan.ts
@@ -42,6 +42,24 @@ export const FILESYSTEM_UNSUPPORTED_MESSAGE =
   "Filesystem sandbox policy is not implemented (no backend applies a filesystem jail); " +
   "remove sandbox_permission.filesystem.";
 
+/**
+ * A non-Pi harness (MCP-only tool delivery) on a remote (Daytona) sandbox cannot receive
+ * gateway/custom tools at all today (F1, audit finding): the internal tool-MCP channel is a
+ * runner-loopback (`127.0.0.1`) HTTP server, unreachable from inside the sandbox, so
+ * `buildSessionMcpServers` skips it on Daytona; the fallback path (the file relay) has a
+ * sandbox-side writer ONLY inside Pi's bundled extension (`extensions/agenta.ts`
+ * `registerTools`), which no other harness loads. Before this gate, the run proceeded anyway,
+ * `mcp.ts` logged a false "delivered via the file relay", and the harness silently received
+ * zero tools with `ok:true` (the silent-tool-drop bug). Refuse loud instead, mirroring the
+ * other not-implemented gates above.
+ */
+export const REMOTE_TOOLS_UNSUPPORTED_MESSAGE =
+  "Tools are not supported for a non-Pi harness on a remote (daytona) sandbox: the internal " +
+  "tool-MCP channel is loopback-only (unreachable from inside the sandbox), and there is no " +
+  "in-sandbox relay client for this harness (only Pi's bundled extension writes the file " +
+  "relay). Run on the local sandbox, use the Pi harness, or remove the tools. Tracked in " +
+  "docs/design/agent-workflows/projects/remote-tools-delivery/.";
+
 export interface RunPlan {
   harness: string;
   acpAgent: string;
@@ -242,6 +260,17 @@ export function buildRunPlan(
   // tools are gated — keep the wire shape, but the delivery is not supported.
   if (hasStdioMcpServer(request.mcpServers)) {
     return { ok: false, error: USER_MCP_UNSUPPORTED_MESSAGE };
+  }
+
+  // F1 (audit finding, silent-tool-drop): a non-Pi harness on a remote (Daytona) sandbox has NO
+  // working delivery path for gateway/custom tools. The internal tool-MCP is loopback-only
+  // (unreachable from inside the sandbox), and the file-relay fallback has a sandbox-side writer
+  // only inside Pi's bundled extension. Before this gate the run proceeded, silently dropped
+  // every tool, and still returned `ok:true`. Refuse up front, the way the other not-implemented
+  // gates above do. `executableToolSpecsForRun` excludes `client` tools (browser-fulfilled, never
+  // routed through this channel), matching what the internal MCP channel actually advertises.
+  if (!isPi && isDaytona && executableToolSpecsForRun.length > 0) {
+    return { ok: false, error: REMOTE_TOOLS_UNSUPPORTED_MESSAGE };
   }
 
   // Layer 2: even on Daytona, code/gateway tools run on the RUNNER HOST via the relay, not

--- a/services/runner/tests/unit/sandbox-agent-run-plan.test.ts
+++ b/services/runner/tests/unit/sandbox-agent-run-plan.test.ts
@@ -440,9 +440,29 @@ describe("buildRunPlan", () => {
 
       assert.equal(result.ok, false);
       if (result.ok) return;
-      assert.match(result.error, /non-Pi harness on a remote \(daytona\) sandbox/);
+      assert.match(result.error, /non-Pi harness on a remote sandbox/);
       assert.match(result.error, /docs\/design\/agent-workflows\/projects\/remote-tools-delivery\//);
       assert.equal(created, false, "fails before any cwd is created (up-front gate)");
+    });
+
+    it("refuses claude x UNKNOWN remote provider x tools (fails closed, not open)", () => {
+      // The gate keys on `sandbox !== "local"`, not `sandbox === "daytona"`, so a new remote
+      // provider (the in-flight E2B one, or anything after it) is refused with the same loud
+      // error until it ships a proven tool-delivery path — instead of silently re-opening the
+      // F1 zero-tools drop one provider over.
+      const result = buildRunPlan(
+        {
+          harness: "claude",
+          sandbox: "e2b",
+          messages: [{ role: "user", content: "hello" }],
+          customTools: [{ name: "server_tool", kind: "callback" }],
+        } as AgentRunRequest,
+        { createLocalCwd: () => "/tmp/local-cwd" },
+      );
+
+      assert.equal(result.ok, false);
+      if (result.ok) return;
+      assert.match(result.error, /non-Pi harness on a remote sandbox/);
     });
 
     it("allows claude x daytona x NO tools", () => {

--- a/services/runner/tests/unit/sandbox-agent-run-plan.test.ts
+++ b/services/runner/tests/unit/sandbox-agent-run-plan.test.ts
@@ -238,9 +238,13 @@ describe("buildRunPlan", () => {
   });
 
   it("rejects a strict restricted-network Daytona run with a runner-host tool", () => {
+    // Pi (not claude): a non-Pi harness with tools on Daytona is now refused earlier and
+    // unconditionally by the F1 remote-tools gate (no delivery path exists at all), which would
+    // otherwise mask this network-boundary-bypass gate. Pi tools ride its native extension, so
+    // Pi is exempt from the F1 gate and still exercises this Layer-2 network check.
     const result = buildRunPlan(
       {
-        harness: "claude",
+        harness: "pi_agenta",
         sandbox: "daytona",
         messages: [{ role: "user", content: "hello" }],
         customTools: [{ name: "server_tool", kind: "callback" }],
@@ -262,10 +266,10 @@ describe("buildRunPlan", () => {
     // The Python service always fills enforcement="strict", but a DIRECT runner caller may omit
     // it. The wire schema defaults it to "strict", so an omitted value must rebuff a runner-host
     // tool on a restricted-network Daytona run the same as an explicit "strict" — only an
-    // explicit "best_effort" opts out.
+    // explicit "best_effort" opts out. Pi (see note above): exempt from the F1 remote-tools gate.
     const result = buildRunPlan(
       {
-        harness: "claude",
+        harness: "pi_agenta",
         sandbox: "daytona",
         messages: [{ role: "user", content: "hello" }],
         customTools: [{ name: "server_tool", kind: "callback" }],
@@ -284,10 +288,11 @@ describe("buildRunPlan", () => {
 
   it("lets best_effort opt out of the runner-host-tool guard (LOW-6 contrast)", () => {
     // The explicit opt-out: best_effort accepts that the network boundary is not a hard
-    // guarantee, so the same restricted-network Daytona run with a host tool is allowed.
+    // guarantee, so the same restricted-network Daytona run with a host tool is allowed. Pi (see
+    // note above): exempt from the F1 remote-tools gate.
     const result = buildRunPlan(
       {
-        harness: "claude",
+        harness: "pi_agenta",
         sandbox: "daytona",
         messages: [{ role: "user", content: "hello" }],
         customTools: [{ name: "server_tool", kind: "callback" }],
@@ -411,6 +416,94 @@ describe("buildRunPlan", () => {
     assert.equal(result.ok, true);
   });
 
+  describe("remote-tools gate (F1: non-Pi harness x remote sandbox x tools)", () => {
+    it("refuses claude x daytona x tools (no delivery path exists)", () => {
+      // F1, audit finding: the internal tool-MCP is loopback-only (unreachable from inside the
+      // sandbox), and the file-relay fallback has a sandbox-side writer only inside Pi's bundled
+      // extension. Before this gate the run proceeded, silently dropped every tool, and returned
+      // ok:true. Refuse up front, before any cwd/sandbox is created.
+      let created = false;
+      const result = buildRunPlan(
+        {
+          harness: "claude",
+          sandbox: "daytona",
+          messages: [{ role: "user", content: "hello" }],
+          customTools: [{ name: "server_tool", kind: "callback" }],
+        } as AgentRunRequest,
+        {
+          createDaytonaCwd: () => {
+            created = true;
+            return "/home/sandbox/agenta-fixed";
+          },
+        },
+      );
+
+      assert.equal(result.ok, false);
+      if (result.ok) return;
+      assert.match(result.error, /non-Pi harness on a remote \(daytona\) sandbox/);
+      assert.match(result.error, /docs\/design\/agent-workflows\/projects\/remote-tools-delivery\//);
+      assert.equal(created, false, "fails before any cwd is created (up-front gate)");
+    });
+
+    it("allows claude x daytona x NO tools", () => {
+      const result = buildRunPlan(
+        {
+          harness: "claude",
+          sandbox: "daytona",
+          messages: [{ role: "user", content: "hello" }],
+        } as AgentRunRequest,
+        { createDaytonaCwd: () => "/home/sandbox/agenta-fixed" },
+      );
+
+      assert.equal(result.ok, true);
+    });
+
+    it("allows pi x daytona x tools (the file relay works for Pi)", () => {
+      const result = buildRunPlan(
+        {
+          harness: "pi_agenta",
+          sandbox: "daytona",
+          messages: [{ role: "user", content: "hello" }],
+          customTools: [{ name: "server_tool", kind: "callback" }],
+        } as AgentRunRequest,
+        { createDaytonaCwd: () => "/home/sandbox/agenta-fixed" },
+      );
+
+      assert.equal(result.ok, true);
+    });
+
+    it("allows claude x local x tools (the loopback MCP channel is reachable)", () => {
+      const result = buildRunPlan(
+        {
+          harness: "claude",
+          sandbox: "local",
+          messages: [{ role: "user", content: "hello" }],
+          customTools: [{ name: "server_tool", kind: "callback" }],
+        } as AgentRunRequest,
+        { createLocalCwd: () => "/tmp/local-cwd" },
+      );
+
+      assert.equal(result.ok, true);
+    });
+
+    it("allows claude x daytona x client-only tools (browser-fulfilled, not routed through the channel)", () => {
+      // `client` tools are excluded from `executableToolSpecsForRun` — they are fulfilled by the
+      // browser across a turn boundary and were never advertised over the internal tool-MCP
+      // channel (`tool-mcp-http.ts` `tools/list` filters them out too), so they carry no F1 gap.
+      const result = buildRunPlan(
+        {
+          harness: "claude",
+          sandbox: "daytona",
+          messages: [{ role: "user", content: "hello" }],
+          customTools: [{ name: "request_connection", kind: "client" }],
+        } as AgentRunRequest,
+        { createDaytonaCwd: () => "/home/sandbox/agenta-fixed" },
+      );
+
+      assert.equal(result.ok, true);
+    });
+  });
+
   it("errors on any run carrying a code tool (code execution removed, fail loud)", () => {
     // Code tools were removed for security (F-010). The run is refused up-front so the failure
     // surfaces as a non-success result (ok:false) rather than being laundered into a 200 reply
@@ -480,9 +573,12 @@ describe("buildRunPlan", () => {
   });
 
   it("allows a best_effort restricted-network Daytona run with a runner-host tool", () => {
+    // Pi (not claude): see the note on the "rejects a strict restricted-network..." test above —
+    // a non-Pi harness with tools on Daytona is refused unconditionally by the F1 gate before
+    // this Layer-2 network check ever runs.
     const result = buildRunPlan(
       {
-        harness: "claude",
+        harness: "pi_agenta",
         sandbox: "daytona",
         messages: [{ role: "user", content: "hello" }],
         customTools: [{ name: "server_tool", kind: "callback" }],

--- a/services/runner/tests/unit/session-alive.test.ts
+++ b/services/runner/tests/unit/session-alive.test.ts
@@ -70,7 +70,7 @@ describe("startAliveWatchdog", () => {
     await w2.release();
   });
 
-  it("release() sends a final heartbeat with is_running=false and status=ended", async () => {
+  it("release() sends a final heartbeat with is_running=false (status derived server-side)", async () => {
     const watchdog = startAliveWatchdog("sess-2", "turn-xyz", "proj-2");
     await flushMicrotasks();
     fetchCalls.length = 0; // reset after the start heartbeat
@@ -82,7 +82,7 @@ describe("startAliveWatchdog", () => {
     const body = final.body as Record<string, unknown>;
     assert.equal(body["is_running"], false);
     assert.equal(body["turn_id"], "turn-xyz");
-    assert.deepEqual(body["status"], { code: "ended" });
+    assert.ok(!("status" in body), "status was dropped from the heartbeat contract");
   });
 
   it("swallows heartbeat failures — never throws", async () => {

--- a/services/runner/tests/unit/session-mcp-layering.test.ts
+++ b/services/runner/tests/unit/session-mcp-layering.test.ts
@@ -211,6 +211,27 @@ describe("buildSessionMcpServers layering (do-not-merge regression guard)", () =
     );
   });
 
+  it("(Daytona, non-Pi) never logs the file-relay delivery claim (F1: it would be false)", async () => {
+    // F1: a non-Pi harness has no sandbox-side file-relay writer (only Pi's bundled extension has
+    // one), so claiming "delivered via the file relay" here would be false. `run-plan.ts` now
+    // refuses this combination before a session is built, but this pins the log itself as a
+    // defense-in-depth: it must never make that claim for a non-Pi harness.
+    const logs: string[] = [];
+    await build({
+      isPi: false,
+      isDaytona: true,
+      capabilities: mcpCapable,
+      harness: "claude",
+      toolSpecs: [gatewayTool],
+      relayDir,
+      log: (message) => logs.push(message),
+    });
+    assert.ok(
+      !logs.some((line) => line.includes("delivered via the file relay")),
+      "must not claim file-relay delivery for a harness with no relay writer",
+    );
+  });
+
   it("(Daytona) a user http MCP is STILL delivered (remote url, not a runner loopback)", async () => {
     // The Daytona guard is scoped to the INTERNAL loopback channel only. A user http MCP is a
     // remote url the harness dials directly, so it stays reachable from the sandbox and must be


### PR DESCRIPTION
## Context
Any custom tool, including gateway/callback tools or a client tool like `request_connection`, silently vanished when run with a non-Pi harness on a remote sandbox: the model would receive zero tools with no error surfaced anywhere. The internal MCP server the runner exposes for tool calls listens on the runner's own loopback (`127.0.0.1`) in `tool-mcp-http.ts`, which a remote sandbox (Daytona or E2B) can't reach, so `mcp.ts` silently skipped attaching it. Pi didn't hit this because it carries its own in-sandbox extension that relays tool calls back; Claude, Codex, and OpenCode have no such relay yet.

## Changes
`run-plan.ts` now fails the run plan up front — before the sandbox is even created — when the harness is not Pi, the sandbox is remote, and the run actually requested executable tools: `if (!isPi && isDaytona && executableToolSpecsForRun.length > 0) return { ok: false, error: REMOTE_TOOLS_UNSUPPORTED_MESSAGE }`. Client-kind tools (the `request_connection` style, handled entirely client-side) are exempted since they never touch the runner's MCP server. This is the interim fix; the real fix is a relay-client shim so non-Pi harnesses can reach the runner's tool server from a remote sandbox, tracked in `docs/design/agent-workflows/projects/remote-tools-delivery/`.

## Tests / notes
- New coverage in `sandbox-agent-run-plan.test.ts` and `session-mcp-layering.test.ts` covering the gate firing, the client-tool exemption, and Pi being unaffected.
- Ships as a loud, early failure rather than the previous silent zero-tools behavior; no user-visible change for Pi or for any harness on the local sandbox.