### PR TITLE
[chore] Add Claude harness on Daytona sandbox

### DIFF
--- a/docs/design/agent-workflows/projects/add-claude-daytona/research.md
+++ b/docs/design/agent-workflows/projects/add-claude-daytona/research.md
@@ -1,0 +1,136 @@
+# Claude on Daytona — investigation
+
+## Goal
+
+Make `harness="claude" sandbox="daytona"` work with both credential modes. This is the last
+unbuilt cell of the harness x sandbox matrix (pi/codex/opencode x local/e2b/daytona, and
+claude x local/e2b, all already exist on prior branches).
+
+## How Pi-on-Daytona works today (the shape to clone)
+
+Flow through `services/runner/src/engines/sandbox_agent.ts` for a Daytona run:
+
+```
+buildRunPlan           -> plan.isDaytona = true, plan.acpAgent = "claude"
+buildSandboxProvider   -> daytona({ create: buildDaytonaCreate(piExtEnv, secrets, ...) })
+SandboxAgent.start     -> creates the remote sandbox
+prepareDaytonaPiAssets -> no-op for claude (guards on plan.isPi)
+prepareWorkspace       -> mkdir cwd, relay dir, AGENTS.md, harnessFiles, skills
+createSession({ agent: "claude", cwd })
+```
+
+Key files:
+- `services/runner/src/engines/sandbox_agent/daytona.ts` -- `prepareDaytonaPiAssets`,
+  `uploadPiAuthToSandbox`, `DAYTONA_PI_DIR`, `daytonaEnvVars`, `createCookieFetch`
+- `services/runner/src/engines/sandbox_agent/provider.ts` -- `buildDaytonaCreate` seeds the
+  create-time env from `daytonaEnvVars(piExtEnv, secrets)`
+- `services/runner/src/engines/sandbox_agent/workspace.ts` -- `prepareWorkspace`'s
+  `isDaytona` branch writes `harnessFiles` (Claude's rendered `.claude/settings.json`) via
+  `sandbox.writeFsFile`
+- `services/runner/src/engines/sandbox_agent.ts` -- orchestration; the
+  `if (plan.isDaytona)` block currently calls only `prepareDaytonaPiAssets`
+
+## What already works for claude x daytona on this base
+
+- **Managed credentials**: `ANTHROPIC_API_KEY` is in `plan.secrets` on a `credentialMode="env"`
+  run. `daytonaEnvVars(piExtEnv, secrets)` spreads `secrets` into the Daytona create-time
+  `envVars`, so the key reaches the sandbox daemon's environment with no extra code.
+- **harnessFiles**: the Python `ClaudeHarness` adapter renders `.claude/settings.json` and
+  sets it on `request.harnessFiles`. `prepareWorkspace`'s `isDaytona` branch already writes
+  every `harnessFiles` entry into `plan.cwd` via the sandbox FS API, unconditionally of
+  harness -- this needed no Claude-specific code.
+- **The claude binary**: the sandbox-agent daemon auto-installs the harness CLI on
+  `createSession({ agent: "claude" })`, the same auto-install Pi and codex get on Daytona
+  (see `services/runner/src/engines/sandbox_agent/provider.ts`, `buildDaytonaCreate` comment
+  on the image/snapshot needing "the daemon and harness CLI" -- auto-install covers the gap
+  when the image lacks it, mirroring `DAYTONA_PI_INSTALL` for Pi). No install step is added
+  here; the codex-daytona precedent made the same call.
+
+## The one gap: own-login (`runtime_provided`) credentials
+
+`prepareDaytonaPiAssets` early-returns for any non-Pi harness (`if (!plan.isPi) return;`).
+There is no Daytona-side equivalent for Claude, so a self-managed
+(`credentialMode="runtime_provided"`) Claude-on-Daytona run has no `.credentials.json` in the
+sandbox -- the harness has no login and the run fails to authenticate. This mirrors exactly
+the gap `prepareDaytonaCodexAssets` (codex-daytona worktree) closed for codex.
+
+## Daemon user / home verification
+
+`DAYTONA_PI_DIR` and `DAYTONA_CODEX_DIR` (both precedent constants in `daytona.ts`) default to
+`/home/sandbox/.pi/agent` and `/home/sandbox/.codex` respectively, both documented inline as
+"on common Daytona images (daemon runs as user `sandbox`)". `run-plan.ts`'s
+`defaultDaytonaCwd` independently derives run cwds under `/home/sandbox/agenta-<hex>`, and the
+runtime remount path in `sandbox_agent.ts` uses `/home/sandbox/agenta/<prefix>` for the durable
+cwd. All three agree: the Daytona sandbox-agent image runs its daemon as the `sandbox` user
+with home `/home/sandbox`. Claude's own-login dir follows the same convention:
+`/home/sandbox/.claude`.
+
+## What Claude needs provisioned remotely
+
+| Item | Where | Mechanism |
+|---|---|---|
+| `.credentials.json` (own-login) | sandbox FS | write via `sandbox.writeFsFile`, allow-listed |
+| `ANTHROPIC_API_KEY` (managed) | daemon env at create time | already in `secrets`, flows through `daytonaEnvVars` -> `buildDaytonaCreate` |
+| `.claude/settings.json` | sandbox FS | already handled by `prepareWorkspace`'s `harnessFiles` loop |
+| claude binary | auto-installed | daemon does this on `createSession({ agent: "claude" })`; no action needed |
+
+The primary (only) blocker is `.credentials.json`. Per the E2B precedent
+(`chore-add-claude-e2b`'s `e2b.ts`), the allow-list is deliberately narrow: only
+`.credentials.json`, never `settings.json` (the run's own rendered `harnessFiles` copy must
+win over the host user's settings) and never a directory scan (`readdirSync`) that would
+over-share `.mcp.json` (other services' MCP tokens), `history.jsonl`, or caches.
+
+## Credential modes
+
+Same two modes as the E2B and codex-daytona precedents:
+
+- **Managed (`credentialMode="env"`)**: `ANTHROPIC_API_KEY` already in `plan.secrets`, already
+  in the Daytona create-time env via `daytonaEnvVars`. No file upload -- the daemon reads the
+  key from its own environment.
+- **Self-managed (`runtime_provided`)**: upload the runner's own `.credentials.json` into the
+  sandbox, mirroring `uploadPiAuthToSandbox` / `uploadCodexAuthToSandbox` / the E2B
+  `uploadClaudeAuthToE2BSandbox`.
+
+The gate reuses `shouldUploadOwnLogin` from `run-plan.ts` (same rule already used by Pi,
+codex, and E2B Claude): upload only when `credentialMode === "runtime_provided"`, or (back-compat)
+when no `credentialMode` was sent and no api key is present.
+
+## Env override precedent
+
+`AGENTA_AGENT_SANDBOX_PI_DIR` / `AGENTA_AGENT_SANDBOX_CODEX_DIR` (Daytona) and
+`AGENTA_AGENT_SANDBOX_CLAUDE_DIR` (already defined for E2B in `e2b.ts`) all follow the same
+naming shape: `AGENTA_AGENT_SANDBOX_<HARNESS>_DIR`. This branch reuses the SAME env var name,
+`AGENTA_AGENT_SANDBOX_CLAUDE_DIR`, for the Daytona destination override -- one override
+controls both sandbox kinds' Claude dir, consistent with how each harness has exactly one
+override var across sandbox types.
+
+## Known limitation: gateway/custom tools on claude x daytona
+
+The `gateway-tool-mcp` design (`docs/design/agent-workflows/projects/gateway-tool-mcp/`)
+tracks that Claude runs carrying gateway/custom tools currently hit a hard failure
+(`ok:false`) at delivery, not a silent drop -- a prior PR disabled the internal MCP channel
+alongside the (correctly) disabled user-facing stdio MCP. This applies to Claude on ANY
+sandbox, including Daytona, and is explicitly out of scope here: the real fix (an internal
+HTTP MCP channel, open question #3 in that design's status.md, notes Daytona loopback
+reachability as unresolved) is tracked separately. Tool-less Claude runs, and Pi runs (which
+never routed tools through that channel), are unaffected. This own-login provisioning change
+does not touch tool delivery at all.
+
+## Foundation seam note
+
+A separate "foundation" worktree is generalizing the non-Pi remote bootstrap. The
+Claude-specific path added here (`prepareDaytonaClaudeAssets`, `uploadClaudeAuthToSandbox`) is
+deliberately Claude-shaped and parallel to the Pi and codex shapes on THIS base -- it does not
+block on the foundation, and does not merge with the sibling `chore-add-codex-daytona`
+branch's `prepareDaytonaCodexAssets` (a stacked merge will place both calls side by side in
+the `if (plan.isDaytona)` block). When the foundation lands, all three fold into a single
+generic `prepareRemoteHarnessAssets` dispatch.
+
+## Files to change
+
+- `services/runner/src/engines/sandbox_agent/daytona.ts` -- add `DAYTONA_CLAUDE_DIR`,
+  `uploadClaudeAuthToSandbox`, `prepareDaytonaClaudeAssets`
+- `services/runner/src/engines/sandbox_agent.ts` -- call `prepareDaytonaClaudeAssets` in the
+  `if (plan.isDaytona)` block, next to the existing `prepareDaytonaPiAssets` call
+- Tests: extend `services/runner/tests/unit/sandbox-agent-daytona.test.ts`
+- No Python SDK changes needed (the Daytona path is purely a runner concern)

--- a/docs/design/agent-workflows/projects/add-claude-daytona/specs.md
+++ b/docs/design/agent-workflows/projects/add-claude-daytona/specs.md
@@ -1,0 +1,77 @@
+# Claude on Daytona — specs
+
+## Scope
+
+In: `harness="claude" sandbox="daytona"` own-login (`runtime_provided`) credential
+provisioning, both credential modes covered end to end. Out: Python SDK changes, wire
+contract changes, the claude binary install (already auto-installed by the daemon), the
+gateway-tool-mcp delivery fix (tracked separately).
+
+## Behavior
+
+- A Claude-on-Daytona run provisions `.credentials.json` into the remote sandbox before
+  `createSession` when the run is self-managed (`credentialMode="runtime_provided"`, or
+  back-compat: no `credentialMode` and no api key). Managed runs (`credentialMode="env"`)
+  need no file upload -- `ANTHROPIC_API_KEY` already reaches the sandbox daemon's env via
+  `daytonaEnvVars`.
+- Only `.credentials.json` is uploaded, matching the E2B allow-list exactly. `settings.json`
+  is never uploaded from the host: the run's own rendered `.claude/settings.json` (delivered
+  through `harnessFiles` / `prepareWorkspace`) must win. No directory scan
+  (`readdirSync`) -- an explicit allow-list only.
+- The claude binary is auto-installed by the daemon on `createSession({ agent: "claude" })`;
+  no explicit install step is added (mirrors the codex-daytona decision not to add one).
+- Tracing, tool delivery (subject to the known gateway-tool-mcp limitation below), model
+  selection, and the cookie fetch all apply unchanged -- they are harness-agnostic in the
+  runner.
+
+## Contracts
+
+- No wire changes. `prepareDaytonaClaudeAssets` is runner-internal.
+- `DAYTONA_CLAUDE_DIR` defaults to `/home/sandbox/.claude`; overridable via
+  `AGENTA_AGENT_SANDBOX_CLAUDE_DIR` -- the SAME env var name the E2B implementation already
+  defines for its own `E2B_CLAUDE_DIR` override, since each harness has one override name
+  shared across sandbox kinds (mirrors `AGENTA_AGENT_SANDBOX_PI_DIR`,
+  `AGENTA_AGENT_SANDBOX_CODEX_DIR`).
+- Source dir on the host: `process.env.CLAUDE_CONFIG_DIR || join(homedir(), ".claude")`,
+  identical to the E2B implementation's source resolution.
+
+## Decisions
+
+1. **Credential gate**: reuse `shouldUploadOwnLogin` from `run-plan.ts` -- same rule as Pi,
+   codex, and E2B Claude.
+2. **Allow-list, not directory upload**: `[".credentials.json"]` only. This is the E2B
+   implementation's post-security-fix shape (a prior E2B iteration uploaded the whole
+   `~/.claude` dir and over-shared `.mcp.json`/`settings.json`/`history.jsonl`; do not
+   reintroduce that on Daytona).
+3. **Gate on `plan.acpAgent === "claude"`**, not `plan.isPi` -- Claude and Pi are mutually
+   exclusive ACP agents in `run-plan.ts`, so this reads directly rather than through a
+   negation.
+4. **Best-effort, per-file**: a missing or unreadable file is logged and skipped; it never
+   aborts the run. A sandbox FS failure (mkdir or write) is logged, never thrown.
+5. **Foundation fold-in**: `prepareDaytonaClaudeAssets` / `uploadClaudeAuthToSandbox` are
+   Claude-specific clones of the Pi and codex Daytona shapes; when the foundation seam lands
+   they become calls into the generic bootstrap abstraction, and this fold-in note travels
+   with the sibling codex-daytona and E2B-claude branches' identical notes.
+
+## Known limitation (not fixed here)
+
+Gateway/custom tools on claude x daytona are affected by the tool-delivery gap tracked in
+`docs/design/agent-workflows/projects/gateway-tool-mcp/status.md`: a Claude run carrying
+gateway/custom tools currently hits a hard failure (`ok:false`) at delivery rather than a
+silent drop, because the internal MCP channel was disabled alongside the (correctly)
+disabled user-facing stdio MCP. This applies uniformly across sandboxes (local, e2b,
+daytona) and is not specific to the own-login change made here. Tool-less Claude runs and
+Pi runs (which route tools through a different, unaffected channel) are not impacted. The
+real fix (an internal HTTP MCP channel) is tracked in that design, including the open
+question of Daytona loopback reachability -- not resolved here.
+
+## Acceptance
+
+- Unit: managed run uploads nothing; self-managed uploads only `.credentials.json` (a decoy
+  `.mcp.json` present in the fixture dir must NOT be uploaded); a missing
+  `.credentials.json` warns and does not throw; non-claude runs are a no-op; both
+  `CLAUDE_CONFIG_DIR` and `AGENTA_AGENT_SANDBOX_CLAUDE_DIR` overrides are honored.
+- Integration (requires live daemon): claude-on-Daytona returns output and a trace, for both
+  credential modes. Cannot run in CI without a Daytona API key; deferred the same way the
+  codex-daytona and E2B-claude integration tests are deferred (`describe.skip` / a future
+  `@live-daemon` tag).

--- a/docs/design/agent-workflows/projects/add-claude-daytona/tasks.md
+++ b/docs/design/agent-workflows/projects/add-claude-daytona/tasks.md
@@ -1,0 +1,38 @@
+# Claude on Daytona — tasks
+
+## Done
+
+- [x] Research: how Pi-on-Daytona and codex-on-Daytona work; what already works for claude
+  x daytona on this base (managed key, harnessFiles, binary auto-install); the one gap
+  (own-login upload); daemon user/home verification (`sandbox` / `/home/sandbox`)
+- [x] `daytona.ts`: add `DAYTONA_CLAUDE_DIR`, `uploadClaudeAuthToSandbox`,
+  `prepareDaytonaClaudeAssets`
+- [x] `sandbox_agent.ts`: call `prepareDaytonaClaudeAssets` in the `if (plan.isDaytona)`
+  block, next to `prepareDaytonaPiAssets`
+- [x] Unit tests: extend `sandbox-agent-daytona.test.ts` with claude coverage (managed
+  no-upload, self-managed allow-list-only upload with a decoy file, missing file, non-claude
+  no-op, both dir overrides)
+
+## Integration test (requires live Daytona daemon)
+
+- [ ] Smoke: `harness="claude" sandbox="daytona"` returns output + trace
+- [ ] Managed credential: only `ANTHROPIC_API_KEY` in daemon env; no `.credentials.json`
+  written in sandbox
+- [ ] Self-managed: local `.credentials.json` uploaded into sandbox, `settings.json` not
+  overwritten by the host copy
+
+These cannot run in CI without a Daytona API key and a running daemon; mark them
+`@live-daemon` in a future test file when the infra is available.
+
+## Explicitly not fixed here
+
+- [ ] Gateway/custom tools on claude x daytona hard-fail at delivery (tracked in
+  `gateway-tool-mcp/status.md`, not this project)
+
+## Foundation fold-in (deferred)
+
+When the generic remote-bootstrap seam lands:
+- `uploadClaudeAuthToSandbox` becomes a credential writer passed to the generic bootstrap
+- `prepareDaytonaClaudeAssets` becomes a call into `prepareRemoteHarnessAssets`
+- `DAYTONA_CLAUDE_DIR` moves to the shared constants, alongside `DAYTONA_PI_DIR` and
+  `DAYTONA_CODEX_DIR`

--- a/services/runner/src/engines/sandbox_agent.ts
+++ b/services/runner/src/engines/sandbox_agent.ts
@@ -55,6 +55,7 @@ import { createAcpFetch } from "./sandbox_agent/acp-fetch.ts";
 import { buildDaemonEnv, resolveDaemonBinary } from "./sandbox_agent/daemon.ts";
 import {
   createCookieFetch,
+  prepareDaytonaClaudeAssets,
   prepareDaytonaPiAssets,
 } from "./sandbox_agent/daytona.ts";
 import { conciseError } from "./sandbox_agent/errors.ts";
@@ -470,6 +471,7 @@ export async function runSandboxAgent(
     // these use the host filesystem and the harness's own login (PI_CODING_AGENT_DIR).
     if (plan.isDaytona) {
       await prepareDaytonaPiAssets({ sandbox, plan, log: logger });
+      await prepareDaytonaClaudeAssets({ sandbox, plan, log: logger });
     }
 
     // Durable cwd: reuse the pre-signed creds (signed before buildRunPlan so the prefix drove the

--- a/services/runner/src/engines/sandbox_agent/daytona.ts
+++ b/services/runner/src/engines/sandbox_agent/daytona.ts
@@ -1,4 +1,5 @@
 import { existsSync, readFileSync } from "node:fs";
+import { homedir } from "node:os";
 import { join } from "node:path";
 
 import { createAcpFetch } from "./acp-fetch.ts";
@@ -138,6 +139,75 @@ export async function prepareDaytonaPiAssets({
     );
   }
   if (DAYTONA_PI_INSTALL) await installPiInSandbox(sandbox, log);
+}
+
+/** In-sandbox Claude config dir on common Daytona images (daemon runs as user `sandbox`). */
+export const DAYTONA_CLAUDE_DIR =
+  process.env.AGENTA_AGENT_SANDBOX_CLAUDE_DIR ?? "/home/sandbox/.claude";
+
+/**
+ * Explicit allow-list of `~/.claude` files needed for the own-login (`runtime_provided`)
+ * path. Only `.credentials.json` -- the OAuth/subscription login store -- is required; Claude
+ * Code reads it via `$HOME` / `CLAUDE_CONFIG_DIR`. `settings.json` is deliberately excluded:
+ * the run's own rendered `.claude/settings.json` is already written into the sandbox from
+ * `harnessFiles` by `prepareWorkspace`, and that rendered copy must win over the host user's
+ * settings. Mirrors the E2B allow-list exactly (`e2b.ts` `CLAUDE_OWN_LOGIN_ALLOWLIST`); never
+ * a directory scan, which would over-share `.mcp.json`, `history.jsonl`, and caches.
+ */
+const CLAUDE_OWN_LOGIN_ALLOWLIST = [".credentials.json"] as const;
+
+/**
+ * Upload the Claude own-login credentials from the host into a Daytona sandbox. Best-effort
+ * per file: an allow-listed file that is absent or unreadable is logged and skipped, it never
+ * aborts the others. Only called when `credentialMode === "runtime_provided"` (own-login path).
+ */
+export async function uploadClaudeAuthToSandbox(
+  sandbox: any,
+  log: Log = () => {},
+): Promise<void> {
+  const localDir = process.env.CLAUDE_CONFIG_DIR || join(homedir(), ".claude");
+  if (!existsSync(localDir)) return;
+  try {
+    await sandbox.mkdirFs({ path: DAYTONA_CLAUDE_DIR });
+  } catch (err) {
+    log(`claude auth upload skipped: ${(err as Error).message}`);
+    return;
+  }
+  for (const name of CLAUDE_OWN_LOGIN_ALLOWLIST) {
+    const filePath = join(localDir, name);
+    if (!existsSync(filePath)) {
+      log(`claude auth upload: ${name} not found in ${localDir}, skipping`);
+      continue;
+    }
+    try {
+      const content = readFileSync(filePath, "utf-8");
+      await sandbox.writeFsFile({ path: `${DAYTONA_CLAUDE_DIR}/${name}` }, content);
+      log(`claude auth upload: uploaded ${name}`);
+    } catch (err) {
+      log(`claude auth upload failed for ${name}: ${(err as Error).message}`);
+    }
+  }
+}
+
+export interface PrepareDaytonaClaudeAssetsInput {
+  sandbox: any;
+  plan: Pick<RunPlan, "acpAgent" | "credentialMode" | "hasApiKey">;
+  log?: Log;
+}
+
+/**
+ * Push the Claude own-login credentials into a Daytona sandbox when running under
+ * `runtime_provided` credential mode. Managed-key runs need no file upload: the key arrives
+ * via `daytonaEnvVars`. `harnessFiles` (`.claude/settings.json`) and the claude binary are
+ * handled elsewhere (`prepareWorkspace`, daemon auto-install respectively).
+ */
+export async function prepareDaytonaClaudeAssets({
+  sandbox,
+  plan,
+  log = () => {},
+}: PrepareDaytonaClaudeAssetsInput): Promise<void> {
+  if (plan.acpAgent !== "claude") return;
+  if (shouldUploadOwnLogin(plan)) await uploadClaudeAuthToSandbox(sandbox, log);
 }
 
 /**

--- a/services/runner/tests/unit/sandbox-agent-daytona.test.ts
+++ b/services/runner/tests/unit/sandbox-agent-daytona.test.ts
@@ -3,22 +3,30 @@
  *
  * Run: pnpm test (or: pnpm exec vitest run tests/unit/sandbox-agent-daytona.test.ts)
  */
-import { afterEach, describe, it } from "vitest";
+import { afterEach, describe, it, vi } from "vitest";
 import assert from "node:assert/strict";
-import { mkdtempSync, rmSync, writeFileSync } from "node:fs";
+import { mkdtempSync, mkdirSync, rmSync, writeFileSync } from "node:fs";
 import { tmpdir } from "node:os";
 import { join } from "node:path";
 
 import {
+  DAYTONA_CLAUDE_DIR,
   DAYTONA_PI_DIR,
   DAYTONA_PI_INSTALL,
   DAYTONA_PI_INSTALL_DIR,
   createCookieFetch,
   daytonaEnvVars,
+  prepareDaytonaClaudeAssets,
+  uploadClaudeAuthToSandbox,
   uploadPiAuthToSandbox,
 } from "../../src/engines/sandbox_agent/daytona.ts";
 
-const envKeys = ["PI_CODING_AGENT_DIR"];
+const envKeys = [
+  "PI_CODING_AGENT_DIR",
+  "HOME",
+  "CLAUDE_CONFIG_DIR",
+  "AGENTA_AGENT_SANDBOX_CLAUDE_DIR",
+];
 const previousEnv = new Map<string, string | undefined>();
 for (const key of envKeys) previousEnv.set(key, process.env[key]);
 
@@ -71,6 +79,253 @@ describe("uploadPiAuthToSandbox", () => {
       { path: `${DAYTONA_PI_DIR}/auth.json`, body: "{\"token\":\"x\"}" },
       { path: `${DAYTONA_PI_DIR}/settings.json`, body: "{\"approval\":\"never\"}" },
     ]);
+  });
+});
+
+function fakeSandbox() {
+  const calls: Array<{ op: "mkdir" | "write"; path: string; body?: string }> = [];
+  return {
+    calls,
+    sandbox: {
+      mkdirFs: async ({ path }: { path: string }) => calls.push({ op: "mkdir", path }),
+      writeFsFile: async ({ path }: { path: string }, body: string) =>
+        calls.push({ op: "write", path, body }),
+    },
+  };
+}
+
+describe("uploadClaudeAuthToSandbox", () => {
+  it("uploads only the allow-listed .credentials.json, not other ~/.claude files", async () => {
+    const fakeHome = mkdtempSync(join(tmpdir(), "agenta-claude-home-test-"));
+    dirs.push(fakeHome);
+    const claudeDir = join(fakeHome, ".claude");
+    mkdirSync(claudeDir);
+    writeFileSync(join(claudeDir, ".credentials.json"), '{"token":"abc"}', "utf-8");
+    // Files that must NOT be uploaded: other services' MCP tokens, settings/secrets, history.
+    writeFileSync(join(claudeDir, ".mcp.json"), '{"mcpServers":{"foo":{"token":"secret"}}}', "utf-8");
+    writeFileSync(join(claudeDir, "settings.json"), '{"auto":"true"}', "utf-8");
+    writeFileSync(join(claudeDir, "history.jsonl"), '{"cmd":"whoami"}', "utf-8");
+    process.env.HOME = fakeHome;
+    delete process.env.CLAUDE_CONFIG_DIR;
+
+    const { sandbox, calls } = fakeSandbox();
+    await uploadClaudeAuthToSandbox(sandbox);
+
+    assert.ok(
+      calls.some((c) => c.op === "mkdir" && c.path === DAYTONA_CLAUDE_DIR),
+      "creates the claude dir in the sandbox",
+    );
+    const creds = calls.find(
+      (c) => c.op === "write" && c.path === `${DAYTONA_CLAUDE_DIR}/.credentials.json`,
+    );
+    assert.ok(creds, "uploads .credentials.json");
+    assert.equal(creds!.body, '{"token":"abc"}');
+
+    const writePaths = calls.filter((c) => c.op === "write").map((c) => c.path);
+    assert.equal(writePaths.length, 1, "uploads exactly one file (the allow-list)");
+    assert.ok(
+      !calls.some((c) => c.op === "write" && c.path === `${DAYTONA_CLAUDE_DIR}/.mcp.json`),
+      "does NOT upload .mcp.json (other services' MCP tokens)",
+    );
+    assert.ok(
+      !calls.some((c) => c.op === "write" && c.path === `${DAYTONA_CLAUDE_DIR}/settings.json`),
+      "does NOT upload settings.json (the run's rendered harnessFiles copy wins)",
+    );
+    assert.ok(
+      !calls.some((c) => c.op === "write" && c.path === `${DAYTONA_CLAUDE_DIR}/history.jsonl`),
+      "does NOT upload history.jsonl",
+    );
+  });
+
+  it("honors CLAUDE_CONFIG_DIR for the source directory", async () => {
+    const fakeHome = mkdtempSync(join(tmpdir(), "agenta-claude-home-test-"));
+    dirs.push(fakeHome);
+    const relocatedDir = mkdtempSync(join(tmpdir(), "agenta-claude-relocated-test-"));
+    dirs.push(relocatedDir);
+    writeFileSync(join(relocatedDir, ".credentials.json"), '{"token":"relocated"}', "utf-8");
+    process.env.HOME = fakeHome;
+    process.env.CLAUDE_CONFIG_DIR = relocatedDir;
+
+    const { sandbox, calls } = fakeSandbox();
+    await uploadClaudeAuthToSandbox(sandbox);
+
+    const creds = calls.find(
+      (c) => c.op === "write" && c.path === `${DAYTONA_CLAUDE_DIR}/.credentials.json`,
+    );
+    assert.ok(creds, "reads from CLAUDE_CONFIG_DIR instead of ~/.claude");
+    assert.equal(creds!.body, '{"token":"relocated"}');
+  });
+
+  it("honors AGENTA_AGENT_SANDBOX_CLAUDE_DIR for the sandbox destination dir", async () => {
+    const fakeHome = mkdtempSync(join(tmpdir(), "agenta-claude-home-test-"));
+    dirs.push(fakeHome);
+    const claudeDir = join(fakeHome, ".claude");
+    mkdirSync(claudeDir);
+    writeFileSync(join(claudeDir, ".credentials.json"), "{}", "utf-8");
+    process.env.HOME = fakeHome;
+    delete process.env.CLAUDE_CONFIG_DIR;
+    process.env.AGENTA_AGENT_SANDBOX_CLAUDE_DIR = "/custom/claude/dir";
+
+    // Re-import with the env var set before module init so the const picks it up.
+    vi.resetModules();
+    const mod = await import("../../src/engines/sandbox_agent/daytona.ts");
+
+    const { sandbox, calls } = fakeSandbox();
+    await mod.uploadClaudeAuthToSandbox(sandbox);
+
+    assert.ok(
+      calls.some((c) => c.op === "mkdir" && c.path === "/custom/claude/dir"),
+      "creates the overridden sandbox dir",
+    );
+    assert.ok(
+      calls.some((c) => c.op === "write" && c.path === "/custom/claude/dir/.credentials.json"),
+      "writes into the overridden sandbox dir",
+    );
+  });
+
+  it("is best-effort: logs on mkdir sandbox error but does not throw", async () => {
+    const fakeHome = mkdtempSync(join(tmpdir(), "agenta-claude-home-test-"));
+    dirs.push(fakeHome);
+    const claudeDir = join(fakeHome, ".claude");
+    mkdirSync(claudeDir);
+    writeFileSync(join(claudeDir, ".credentials.json"), "{}", "utf-8");
+    process.env.HOME = fakeHome;
+    delete process.env.CLAUDE_CONFIG_DIR;
+
+    const logs: string[] = [];
+    const brokenSandbox = {
+      mkdirFs: async () => {
+        throw new Error("sandbox unavailable");
+      },
+      writeFsFile: async () => {},
+    };
+    await uploadClaudeAuthToSandbox(brokenSandbox, (msg) => logs.push(msg));
+    assert.ok(
+      logs.some((l) => l.includes("claude auth upload skipped")),
+      "error is logged, not thrown",
+    );
+  });
+
+  it("logs (does not throw) when writing an allow-listed file to the sandbox fails", async () => {
+    const fakeHome = mkdtempSync(join(tmpdir(), "agenta-claude-home-test-"));
+    dirs.push(fakeHome);
+    const claudeDir = join(fakeHome, ".claude");
+    mkdirSync(claudeDir);
+    writeFileSync(join(claudeDir, ".credentials.json"), "{}", "utf-8");
+    process.env.HOME = fakeHome;
+    delete process.env.CLAUDE_CONFIG_DIR;
+
+    const logs: string[] = [];
+    const writeFailsSandbox = {
+      mkdirFs: async () => {},
+      writeFsFile: async () => {
+        throw new Error("disk full");
+      },
+    };
+    await uploadClaudeAuthToSandbox(writeFailsSandbox, (msg) => logs.push(msg));
+    assert.ok(
+      logs.some((l) => l.includes("claude auth upload failed for .credentials.json")),
+      "write failure is logged with the file name, not silently swallowed",
+    );
+  });
+
+  it("skips upload when ~/.claude does not exist on the host", async () => {
+    const fakeHome = mkdtempSync(join(tmpdir(), "agenta-claude-home-test-"));
+    dirs.push(fakeHome);
+    process.env.HOME = fakeHome;
+    delete process.env.CLAUDE_CONFIG_DIR;
+
+    const { sandbox, calls } = fakeSandbox();
+    await uploadClaudeAuthToSandbox(sandbox);
+    assert.deepEqual(calls, []);
+  });
+});
+
+describe("prepareDaytonaClaudeAssets", () => {
+  it("is a no-op for non-claude runs", async () => {
+    const { sandbox, calls } = fakeSandbox();
+    await prepareDaytonaClaudeAssets({
+      sandbox,
+      plan: { acpAgent: "pi", credentialMode: "runtime_provided", hasApiKey: false },
+    });
+    assert.deepEqual(calls, []);
+  });
+
+  it("skips upload when credentialMode=env (managed key; no file upload)", async () => {
+    const { sandbox, calls } = fakeSandbox();
+    await prepareDaytonaClaudeAssets({
+      sandbox,
+      plan: { acpAgent: "claude", credentialMode: "env", hasApiKey: true },
+    });
+    assert.deepEqual(calls, []);
+  });
+
+  it("skips upload when credentialMode=none", async () => {
+    const { sandbox, calls } = fakeSandbox();
+    await prepareDaytonaClaudeAssets({
+      sandbox,
+      plan: { acpAgent: "claude", credentialMode: "none", hasApiKey: false },
+    });
+    assert.deepEqual(calls, []);
+  });
+
+  it("uploads own-login credentials on a runtime_provided run", async () => {
+    const fakeHome = mkdtempSync(join(tmpdir(), "agenta-claude-home-test-"));
+    dirs.push(fakeHome);
+    const claudeDir = join(fakeHome, ".claude");
+    mkdirSync(claudeDir);
+    writeFileSync(join(claudeDir, ".credentials.json"), '{"token":"abc"}', "utf-8");
+    process.env.HOME = fakeHome;
+    delete process.env.CLAUDE_CONFIG_DIR;
+
+    const { sandbox, calls } = fakeSandbox();
+    await prepareDaytonaClaudeAssets({
+      sandbox,
+      plan: { acpAgent: "claude", credentialMode: "runtime_provided", hasApiKey: false },
+    });
+
+    const creds = calls.find(
+      (c) => c.op === "write" && c.path === `${DAYTONA_CLAUDE_DIR}/.credentials.json`,
+    );
+    assert.ok(creds, "uploads .credentials.json on runtime_provided");
+    assert.equal(creds!.body, '{"token":"abc"}');
+  });
+
+  it("back-compat: uploads own-login when credentialMode is absent and no api key", async () => {
+    const fakeHome = mkdtempSync(join(tmpdir(), "agenta-claude-home-test-"));
+    dirs.push(fakeHome);
+    const claudeDir = join(fakeHome, ".claude");
+    mkdirSync(claudeDir);
+    writeFileSync(join(claudeDir, ".credentials.json"), "{}", "utf-8");
+    process.env.HOME = fakeHome;
+    delete process.env.CLAUDE_CONFIG_DIR;
+
+    const { sandbox, calls } = fakeSandbox();
+    await prepareDaytonaClaudeAssets({
+      sandbox,
+      plan: { acpAgent: "claude", credentialMode: undefined, hasApiKey: false },
+    });
+    assert.ok(
+      calls.some((c) => c.op === "write" && c.path.includes(".credentials.json")),
+      "uploads on back-compat (no credentialMode, no api key)",
+    );
+  });
+
+  it("back-compat: skips upload when credentialMode is absent but api key is present", async () => {
+    const fakeHome = mkdtempSync(join(tmpdir(), "agenta-claude-home-test-"));
+    dirs.push(fakeHome);
+    const claudeDir = join(fakeHome, ".claude");
+    mkdirSync(claudeDir);
+    writeFileSync(join(claudeDir, ".credentials.json"), "{}", "utf-8");
+    process.env.HOME = fakeHome;
+    delete process.env.CLAUDE_CONFIG_DIR;
+
+    const { sandbox, calls } = fakeSandbox();
+    await prepareDaytonaClaudeAssets({
+      sandbox,
+      plan: { acpAgent: "claude", credentialMode: undefined, hasApiKey: true },
+    });
+    assert.deepEqual(calls, []);
   });
 });
 

--- a/services/runner/tests/unit/session-alive.test.ts
+++ b/services/runner/tests/unit/session-alive.test.ts
@@ -70,7 +70,7 @@ describe("startAliveWatchdog", () => {
     await w2.release();
   });
 
-  it("release() sends a final heartbeat with is_running=false and status=ended", async () => {
+  it("release() sends a final heartbeat with is_running=false (status derived server-side)", async () => {
     const watchdog = startAliveWatchdog("sess-2", "turn-xyz", "proj-2");
     await flushMicrotasks();
     fetchCalls.length = 0; // reset after the start heartbeat
@@ -82,7 +82,7 @@ describe("startAliveWatchdog", () => {
     const body = final.body as Record<string, unknown>;
     assert.equal(body["is_running"], false);
     assert.equal(body["turn_id"], "turn-xyz");
-    assert.deepEqual(body["status"], { code: "ended" });
+    assert.ok(!("status" in body), "status was dropped from the heartbeat contract");
   });
 
   it("swallows heartbeat failures — never throws", async () => {


### PR DESCRIPTION
## Context
Claude was the one harness x sandbox cell missing from the matrix on Daytona (it already worked on local and, in a sibling branch, on E2B). Both Codex-style credential modes needed a Daytona-side provisioning path analogous to the existing Pi one.

## Changes
Adds `prepareDaytonaClaudeAssets` / `uploadClaudeAuthToSandbox` in `daytona.ts`. Own-login credential upload uses an explicit allow-list of exactly `[".credentials.json"]` (never a directory scan) sourced from `process.env.CLAUDE_CONFIG_DIR || join(homedir(), ".claude")`, written to `DAYTONA_CLAUDE_DIR` (defaults to `/home/sandbox/.claude`, overridable via `AGENTA_AGENT_SANDBOX_CLAUDE_DIR`). Managed-credential mode is also supported.

## Tests / notes
- New coverage in `sandbox-agent-daytona.test.ts` covering both credential modes and the allow-list behavior.
- Note: `chore/add-remote-tools-gate` in this same batch means Claude-on-Daytona runs with tools will hit the new loud-refuse gate rather than silently dropping tools, until the relay-client shim lands.