### PR TITLE
[chore] Add Codex on Daytona sandbox

### DIFF
--- a/docs/design/agent-workflows/documentation/adapters/codex.md
+++ b/docs/design/agent-workflows/documentation/adapters/codex.md
@@ -63,10 +63,18 @@ Codex is OpenAI-locked. The capabilities table publishes the known model ids und
 `openai` provider family (`gpt-5.5`, `gpt-5.4`, `gpt-5.4-mini`, etc.). The runner passes the
 requested model to the session and reports whichever model the harness actually used.
 
+## Daytona (remote) sandbox support
+
+Supported. `prepareDaytonaCodexAssets` provisions `auth.json` into the remote sandbox at
+`DAYTONA_CODEX_DIR` before `createSession`, mirroring `prepareDaytonaPiAssets`. Both
+credential modes are covered: managed (`credentialMode="env"`) writes the resolved
+`OPENAI_API_KEY`/`CODEX_API_KEY` directly; self-managed (`runtime_provided`) uploads the
+runner's own local `auth.json` into the sandbox. The codex binary itself needs no explicit
+install step — the daemon auto-installs it on `createSession({ agent: "codex" })`.
+
 ## What is deferred
 
 - Static permission/config files (the `~/.codex/config.toml` or equivalent). When Codex gates
   tools at runtime, mirror the Claude `wire_harness_files` approach with a `codex_settings.py`
   equivalent.
-- Daytona (remote) sandbox support. Remote Codex is a matrix-fill item; the credential upload
-  path would mirror `prepareDaytonaPiAssets` for the codex auth file.
+- E2B sandbox support: see the codex-on-E2B branch.

--- a/docs/design/agent-workflows/projects/add-codex-daytona/research.md
+++ b/docs/design/agent-workflows/projects/add-codex-daytona/research.md
@@ -1,0 +1,79 @@
+# Codex harness on Daytona — investigation
+
+## Goal
+
+Make `harness="codex" sandbox="daytona"` work. The codex-local branch already ships
+`CodexHarness`, `HarnessType.CODEX`, `CodexAgentTemplate`, the `codex` ACP agent mapping in
+`run-plan.ts`, `CODEX_API_KEY` in `KNOWN_PROVIDER_ENV_VARS`, and `writeCodexAuthFile()` for
+local runs. This worktree extends that to the remote (Daytona) sandbox axis.
+
+## How Pi-on-Daytona works today (the shape to clone)
+
+Flow through `sandbox_agent.ts` for a Daytona run:
+
+```
+buildRunPlan          → plan.isDaytona = true
+buildSandboxProvider  → daytona({ create: buildDaytonaCreate(piExtEnv, secrets, ...) })
+SandboxAgent.start    → creates the remote sandbox
+prepareDaytonaPiAssets → uploads Pi login, extension, skills, system prompts; installs pi CLI
+prepareWorkspace      → mkdir cwd, relay dir, AGENTS.md, harnessFiles
+createSession({ agent: "pi"|"claude", cwd })
+```
+
+Key files:
+- `services/agent/src/engines/sandbox_agent/daytona.ts` — `prepareDaytonaPiAssets`,
+  `uploadPiAuthToSandbox`, `DAYTONA_PI_DIR`, `daytonaEnvVars`, `createCookieFetch`
+- `services/agent/src/engines/sandbox_agent/provider.ts` — `buildDaytonaCreate`,
+  `daytonaEnvVars` used to seed the create-time env
+- `services/agent/src/engines/sandbox_agent/sandbox_agent.ts` — orchestration;
+  the `if (plan.isDaytona)` block that calls `prepareDaytonaPiAssets`
+
+## Why `prepareDaytonaPiAssets` early-returns for non-Pi
+
+Line 120: `if (!plan.isPi) return;`. The Pi path is the only remote-bootstrap case that
+existed before the codex-local worktree; a codex Daytona run silently does nothing here
+because `isPi` is false for codex. The local path writes `~/.codex/auth.json` via
+`writeCodexAuthFile`, but that branch is guarded `!plan.isDaytona`, so a codex-on-Daytona
+run receives no credentials at all.
+
+## What codex needs provisioned remotely
+
+| Item | Where | Mechanism |
+|---|---|---|
+| `~/.codex/auth.json` | sandbox FS | write via `sandbox.writeFsFile` |
+| `OPENAI_API_KEY` (managed) | daemon env at create time | already in `secrets`, flows through `daytonaEnvVars` → `buildDaytonaCreate` |
+| codex binary | auto-installed | daemon does this on `createSession({ agent: "codex" })`; no action needed |
+
+The primary blocker is `~/.codex/auth.json`. The codex CLI reads it as a FILE, not just the
+env var — confirmed in the PoC matrix (codex/sessions/demo). The sandbox user is `sandbox`
+so the path is `/home/sandbox/.codex/auth.json`.
+
+## Credential modes
+
+Same two modes as local (per the codex-local specs):
+
+- **Managed (`credentialMode="env"`)**: `OPENAI_API_KEY` already in `plan.secrets`, already
+  in the Daytona create-time env via `daytonaEnvVars`. Still need to write `auth.json`
+  from that key INTO the sandbox.
+- **Self-managed (`runtime_provided`)**: upload the runner's own `~/.codex/auth.json` into
+  the sandbox, mirroring `uploadPiAuthToSandbox`.
+
+The gate logic reuses `shouldUploadOwnLogin` (same rule as Pi, defined in `run-plan.ts`).
+
+## Foundation seam note
+
+A separate "foundation" worktree is generalizing the non-Pi remote bootstrap. The codex-
+specific path added here (`prepareDaytonaCodexAssets`, `uploadCodexAuthToSandbox`) is
+deliberately codex-shaped and parallel to the Pi shape — it does NOT block on the foundation.
+When the foundation lands, this code folds into the generic remote-bootstrap seam:
+`prepareDaytonaCodexAssets` becomes a call into the foundation's `prepareRemoteHarnessAssets`
+with a codex-flavored credential writer.
+
+## Files to change
+
+- `services/agent/src/engines/sandbox_agent/daytona.ts` — add `DAYTONA_CODEX_DIR`,
+  `uploadCodexAuthToSandbox`, `prepareDaytonaCodexAssets`
+- `services/agent/src/engines/sandbox_agent/sandbox_agent.ts` — call
+  `prepareDaytonaCodexAssets` in the `if (plan.isDaytona)` block
+- Tests: extend `sandbox-agent-daytona.test.ts`
+- No Python SDK changes needed (the Daytona path is purely a runner concern)

--- a/docs/design/agent-workflows/projects/add-codex-daytona/specs.md
+++ b/docs/design/agent-workflows/projects/add-codex-daytona/specs.md
@@ -1,0 +1,42 @@
+# Codex harness on Daytona — specs
+
+## Scope
+
+In: `harness="codex" sandbox="daytona"` runs with both credential modes. Out: Python SDK
+changes, wire contract changes (the codex-local branch already covers those).
+
+## Behavior
+
+- A codex-on-Daytona run provisions `~/.codex/auth.json` into the remote sandbox before
+  `createSession` — managed mode writes the resolved key; self-managed uploads the runner's
+  own local file.
+- The codex binary is auto-installed by the daemon on `createSession({ agent: "codex" })`
+  (the same auto-install the local path gets); no explicit install step needed.
+- `OPENAI_API_KEY` already flows into the Daytona create-time env via `daytonaEnvVars` +
+  `buildDaytonaCreate` (it is in `plan.secrets` on a managed run); the auth file write is
+  additive, not a replacement.
+- Runs mode `agent-full-access` (the daemon's codex ACP bridge default).
+- Tracing, tool delivery (MCP), model selection, and the cookie fetch all apply unchanged —
+  they are harness-agnostic in the runner.
+
+## Contracts
+
+- No wire changes. `prepareDaytonaCodexAssets` is runner-internal.
+- `DAYTONA_CODEX_DIR` defaults to `/home/sandbox/.codex`; overridable via
+  `AGENTA_AGENT_SANDBOX_CODEX_DIR` (mirrors `DAYTONA_PI_DIR` / `AGENTA_AGENT_SANDBOX_PI_DIR`).
+
+## Decisions
+
+1. **Credential gate**: reuse `shouldUploadOwnLogin` from `run-plan.ts` — same rule as Pi.
+2. **Auth file format**: `{"OPENAI_API_KEY": "<key>"}` — matches `writeCodexAuthFile` (local).
+3. **Managed key source**: prefer `OPENAI_API_KEY` over `CODEX_API_KEY` (both are in
+   `KNOWN_PROVIDER_ENV_VARS`; managed runs resolve to `OPENAI_API_KEY`).
+4. **Foundation fold-in**: the new functions are codex-specific clones of the Pi shape;
+   when the foundation seam lands they become calls into the generic bootstrap abstraction.
+
+## Acceptance
+
+- Unit: managed run writes auth.json with the resolved key; self-managed uploads local file;
+  non-codex run is a no-op; managed with no key does nothing.
+- Integration (requires live daemon): codex-on-Daytona returns output and trace. Marked
+  as requiring live daemon (cannot run in CI without Daytona API key).

--- a/docs/design/agent-workflows/projects/add-codex-daytona/tasks.md
+++ b/docs/design/agent-workflows/projects/add-codex-daytona/tasks.md
@@ -1,0 +1,26 @@
+# Codex harness on Daytona — tasks
+
+## Done
+
+- [x] Research: how Pi-on-Daytona works; why `prepareDaytonaPiAssets` skips non-Pi;
+  what codex needs remotely (auth.json, no binary install needed)
+- [x] `daytona.ts`: add `DAYTONA_CODEX_DIR`, `uploadCodexAuthToSandbox`,
+  `prepareDaytonaCodexAssets`
+- [x] `sandbox_agent.ts`: call `prepareDaytonaCodexAssets` in the `if (plan.isDaytona)` block
+- [x] Unit tests: extend `sandbox-agent-daytona.test.ts` with codex coverage
+
+## Integration test (requires live Daytona daemon)
+
+- [ ] Smoke: `harness="codex" sandbox="daytona"` returns output + trace
+- [ ] Managed credential: only `OPENAI_API_KEY` in daemon env; auth.json written in sandbox
+- [ ] Self-managed: local `~/.codex/auth.json` uploaded into sandbox
+
+These cannot run in CI without a Daytona API key and a running daemon; mark them
+`@live-daemon` in a future test file when the infra is available.
+
+## Foundation fold-in (deferred)
+
+When the generic remote-bootstrap seam lands:
+- `uploadCodexAuthToSandbox` becomes a credential writer passed to the generic bootstrap
+- `prepareDaytonaCodexAssets` becomes a call into `prepareRemoteHarnessAssets`
+- `DAYTONA_CODEX_DIR` moves to the shared constants

--- a/services/runner/src/engines/sandbox_agent.ts
+++ b/services/runner/src/engines/sandbox_agent.ts
@@ -56,6 +56,7 @@ import { createAcpFetch } from "./sandbox_agent/acp-fetch.ts";
 import { buildDaemonEnv, resolveDaemonBinary } from "./sandbox_agent/daemon.ts";
 import {
   createCookieFetch,
+  prepareDaytonaCodexAssets,
   prepareDaytonaPiAssets,
 } from "./sandbox_agent/daytona.ts";
 import { conciseError } from "./sandbox_agent/errors.ts";
@@ -474,11 +475,12 @@ export async function runSandboxAgent(
     // normal exit so it is never double-deleted.
     if (sandbox) inFlightSandboxes.add(sandbox);
 
-    // On Daytona, push the harness login, the extension, and AGENTS.md into the remote
-    // sandbox via the filesystem API (nothing secret is baked into the image). Locally
-    // these use the host filesystem and the harness's own login (PI_CODING_AGENT_DIR).
+    // On Daytona, push harness credentials and config into the remote sandbox via the
+    // filesystem API (nothing secret is baked into the image). Locally these use the host
+    // filesystem and the harness's own login (PI_CODING_AGENT_DIR / ~/.codex/auth.json).
     if (plan.isDaytona) {
       await prepareDaytonaPiAssets({ sandbox, plan, log: logger });
+      await prepareDaytonaCodexAssets({ sandbox, plan, log: logger });
     }
 
     // Durable cwd: reuse the pre-signed creds (signed before buildRunPlan so the prefix drove the

--- a/services/runner/src/engines/sandbox_agent/daytona.ts
+++ b/services/runner/src/engines/sandbox_agent/daytona.ts
@@ -1,4 +1,5 @@
 import { existsSync, readFileSync } from "node:fs";
+import { homedir } from "node:os";
 import { join } from "node:path";
 
 import { createAcpFetch } from "./acp-fetch.ts";
@@ -90,6 +91,85 @@ export async function uploadPiAuthToSandbox(sandbox: any, log: Log = () => {}): 
     }
   } catch (err) {
     log(`pi auth upload skipped: ${(err as Error).message}`);
+  }
+}
+
+/** In-sandbox codex config dir on common Daytona images (daemon runs as user `sandbox`). */
+export const DAYTONA_CODEX_DIR =
+  process.env.AGENTA_AGENT_SANDBOX_CODEX_DIR ?? "/home/sandbox/.codex";
+
+/**
+ * Write the codex auth file into a Daytona sandbox.
+ *
+ * Managed mode: the resolved `apiKey` is written directly as `{"OPENAI_API_KEY":"..."}`.
+ * Self-managed mode: the caller passes `undefined` and we fall back to the local
+ * `~/.codex/auth.json` (mirroring `uploadPiAuthToSandbox` for the runtime_provided path).
+ * Best-effort: failures are logged but do not abort the run.
+ *
+ * NOTE: This is the codex-specific remote path that mirrors the local `writeCodexAuthFile`
+ * in pi-assets.ts. When a generic remote-bootstrap seam lands (the "foundation" worktree),
+ * this can fold into that abstraction.
+ */
+export async function uploadCodexAuthToSandbox(
+  sandbox: any,
+  apiKey: string | undefined,
+  log: Log = () => {},
+): Promise<void> {
+  try {
+    await sandbox.mkdirFs({ path: DAYTONA_CODEX_DIR });
+    if (apiKey) {
+      await sandbox.writeFsFile(
+        { path: `${DAYTONA_CODEX_DIR}/auth.json` },
+        JSON.stringify({ OPENAI_API_KEY: apiKey }),
+      );
+      return;
+    }
+    // Self-managed fallback: upload the local ~/.codex/auth.json when it exists.
+    const localAuth = join(homedir(), ".codex", "auth.json");
+    if (existsSync(localAuth)) {
+      await sandbox.writeFsFile(
+        { path: `${DAYTONA_CODEX_DIR}/auth.json` },
+        readFileSync(localAuth, "utf-8"),
+      );
+    }
+  } catch (err) {
+    log(`codex auth upload skipped: ${(err as Error).message}`);
+  }
+}
+
+export interface PrepareDaytonaCodexAssetsInput {
+  sandbox: any;
+  plan: Pick<RunPlan, "acpAgent" | "hasApiKey" | "credentialMode" | "secrets">;
+  log?: Log;
+}
+
+/**
+ * Push codex credentials into a Daytona sandbox.
+ *
+ * Managed (`credentialMode="env"`): writes `auth.json` from the resolved `OPENAI_API_KEY`.
+ * Self-managed (`runtime_provided`): uploads the runner's own `~/.codex/auth.json` when the
+ * credential is runtime-provided (mirrors `shouldUploadOwnLogin` for Pi).
+ * The daemon already auto-installs the codex binary on `createSession`, so we only need to
+ * provision credentials.
+ *
+ * Returns immediately for non-codex runs.
+ */
+export async function prepareDaytonaCodexAssets({
+  sandbox,
+  plan,
+  log = () => {},
+}: PrepareDaytonaCodexAssetsInput): Promise<void> {
+  if (plan.acpAgent !== "codex") return;
+
+  const resolvedKey = plan.secrets.OPENAI_API_KEY ?? plan.secrets.CODEX_API_KEY;
+  if (plan.credentialMode === "env" && resolvedKey) {
+    await uploadCodexAuthToSandbox(sandbox, resolvedKey, log);
+    return;
+  }
+  // Self-managed (runtime_provided) or un-migrated (no credentialMode, no api key): upload
+  // the runner's own login — same `shouldUploadOwnLogin` gate as Pi.
+  if (shouldUploadOwnLogin(plan)) {
+    await uploadCodexAuthToSandbox(sandbox, undefined, log);
   }
 }
 

--- a/services/runner/tests/unit/sandbox-agent-daytona.test.ts
+++ b/services/runner/tests/unit/sandbox-agent-daytona.test.ts
@@ -5,20 +5,24 @@
  */
 import { afterEach, describe, it } from "vitest";
 import assert from "node:assert/strict";
-import { mkdtempSync, rmSync, writeFileSync } from "node:fs";
+import { mkdtempSync, mkdirSync, rmSync, writeFileSync } from "node:fs";
+import { homedir } from "node:os";
 import { tmpdir } from "node:os";
 import { join } from "node:path";
 
 import {
+  DAYTONA_CODEX_DIR,
   DAYTONA_PI_DIR,
   DAYTONA_PI_INSTALL,
   DAYTONA_PI_INSTALL_DIR,
   createCookieFetch,
   daytonaEnvVars,
+  prepareDaytonaCodexAssets,
+  uploadCodexAuthToSandbox,
   uploadPiAuthToSandbox,
 } from "../../src/engines/sandbox_agent/daytona.ts";
 
-const envKeys = ["PI_CODING_AGENT_DIR"];
+const envKeys = ["PI_CODING_AGENT_DIR", "AGENTA_AGENT_SANDBOX_CODEX_DIR"];
 const previousEnv = new Map<string, string | undefined>();
 for (const key of envKeys) previousEnv.set(key, process.env[key]);
 
@@ -90,5 +94,240 @@ describe("createCookieFetch", () => {
     await cookieFetch("https://other.example.test/first");
 
     assert.deepEqual(seenCookies, [null, "existing=1; session=abc", null]);
+  });
+});
+
+describe("uploadCodexAuthToSandbox", () => {
+  it("writes auth.json from a resolved key (managed mode)", async () => {
+    const calls: Array<{ path: string; body?: string }> = [];
+    const sandbox = {
+      mkdirFs: async ({ path }: { path: string }) => calls.push({ path }),
+      writeFsFile: async ({ path }: { path: string }, body: string) =>
+        calls.push({ path, body }),
+    };
+
+    await uploadCodexAuthToSandbox(sandbox, "sk-test-key");
+
+    assert.deepEqual(calls, [
+      { path: DAYTONA_CODEX_DIR },
+      {
+        path: `${DAYTONA_CODEX_DIR}/auth.json`,
+        body: JSON.stringify({ OPENAI_API_KEY: "sk-test-key" }),
+      },
+    ]);
+  });
+
+  it("uploads local ~/.codex/auth.json when no key is given (self-managed fallback)", async () => {
+    const localCodexDir = mkdtempSync(join(tmpdir(), "agenta-codex-auth-test-"));
+    dirs.push(localCodexDir);
+    // Temporarily point HOME at our temp dir so homedir() resolves there.
+    const originalHome = process.env.HOME;
+    const fakeHome = mkdtempSync(join(tmpdir(), "agenta-codex-home-test-"));
+    dirs.push(fakeHome);
+    mkdirSync(join(fakeHome, ".codex"));
+    writeFileSync(
+      join(fakeHome, ".codex", "auth.json"),
+      '{"OPENAI_API_KEY":"sk-local"}',
+      "utf-8",
+    );
+    process.env.HOME = fakeHome;
+
+    const calls: Array<{ path: string; body?: string }> = [];
+    const sandbox = {
+      mkdirFs: async ({ path }: { path: string }) => calls.push({ path }),
+      writeFsFile: async ({ path }: { path: string }, body: string) =>
+        calls.push({ path, body }),
+    };
+
+    try {
+      await uploadCodexAuthToSandbox(sandbox, undefined);
+    } finally {
+      if (originalHome === undefined) delete process.env.HOME;
+      else process.env.HOME = originalHome;
+    }
+
+    // The auth.json from the fake HOME is uploaded verbatim.
+    const writeCall = calls.find((c) => c.path === `${DAYTONA_CODEX_DIR}/auth.json`);
+    assert.ok(writeCall, "auth.json must be written");
+    assert.equal(writeCall?.body, '{"OPENAI_API_KEY":"sk-local"}');
+  });
+
+  it("does nothing when no key is given and no local auth.json exists", async () => {
+    const emptyHome = mkdtempSync(join(tmpdir(), "agenta-codex-empty-home-"));
+    dirs.push(emptyHome);
+    const originalHome = process.env.HOME;
+    process.env.HOME = emptyHome;
+
+    const calls: Array<{ path: string; body?: string }> = [];
+    const sandbox = {
+      mkdirFs: async ({ path }: { path: string }) => calls.push({ path }),
+      writeFsFile: async ({ path }: { path: string }, body: string) =>
+        calls.push({ path, body }),
+    };
+
+    try {
+      await uploadCodexAuthToSandbox(sandbox, undefined);
+    } finally {
+      if (originalHome === undefined) delete process.env.HOME;
+      else process.env.HOME = originalHome;
+    }
+
+    // mkdirFs was called but no writeFsFile since there is nothing to upload.
+    assert.equal(
+      calls.some((c) => c.path === `${DAYTONA_CODEX_DIR}/auth.json`),
+      false,
+    );
+  });
+});
+
+describe("prepareDaytonaCodexAssets", () => {
+  function makeSandbox(): {
+    calls: Array<{ path: string; body?: string }>;
+    sandbox: any;
+  } {
+    const calls: Array<{ path: string; body?: string }> = [];
+    const sandbox = {
+      mkdirFs: async ({ path }: { path: string }) => calls.push({ path }),
+      writeFsFile: async ({ path }: { path: string }, body: string) =>
+        calls.push({ path, body }),
+    };
+    return { calls, sandbox };
+  }
+
+  it("is a no-op for non-codex runs", async () => {
+    const { calls, sandbox } = makeSandbox();
+
+    await prepareDaytonaCodexAssets({
+      sandbox,
+      plan: { acpAgent: "pi", credentialMode: "env", hasApiKey: true, secrets: {} },
+    });
+
+    assert.equal(calls.length, 0);
+  });
+
+  it("writes auth.json from the resolved key on a managed run", async () => {
+    const { calls, sandbox } = makeSandbox();
+
+    await prepareDaytonaCodexAssets({
+      sandbox,
+      plan: {
+        acpAgent: "codex",
+        credentialMode: "env",
+        hasApiKey: true,
+        secrets: { OPENAI_API_KEY: "sk-managed" },
+      },
+    });
+
+    const writeCall = calls.find((c) => c.path === `${DAYTONA_CODEX_DIR}/auth.json`);
+    assert.ok(writeCall, "auth.json must be written for a managed run");
+    assert.equal(writeCall?.body, JSON.stringify({ OPENAI_API_KEY: "sk-managed" }));
+  });
+
+  it("prefers OPENAI_API_KEY over CODEX_API_KEY on a managed run", async () => {
+    const { calls, sandbox } = makeSandbox();
+
+    await prepareDaytonaCodexAssets({
+      sandbox,
+      plan: {
+        acpAgent: "codex",
+        credentialMode: "env",
+        hasApiKey: true,
+        secrets: { OPENAI_API_KEY: "sk-openai", CODEX_API_KEY: "sk-codex" },
+      },
+    });
+
+    const writeCall = calls.find((c) => c.path === `${DAYTONA_CODEX_DIR}/auth.json`);
+    assert.ok(writeCall);
+    assert.equal(writeCall?.body, JSON.stringify({ OPENAI_API_KEY: "sk-openai" }));
+  });
+
+  it("falls back to CODEX_API_KEY when OPENAI_API_KEY is absent", async () => {
+    const { calls, sandbox } = makeSandbox();
+
+    await prepareDaytonaCodexAssets({
+      sandbox,
+      plan: {
+        acpAgent: "codex",
+        credentialMode: "env",
+        hasApiKey: true,
+        secrets: { CODEX_API_KEY: "sk-codex-only" },
+      },
+    });
+
+    const writeCall = calls.find((c) => c.path === `${DAYTONA_CODEX_DIR}/auth.json`);
+    assert.ok(writeCall);
+    assert.equal(writeCall?.body, JSON.stringify({ OPENAI_API_KEY: "sk-codex-only" }));
+  });
+
+  it("does nothing on a managed run with no resolved key", async () => {
+    const { calls, sandbox } = makeSandbox();
+
+    await prepareDaytonaCodexAssets({
+      sandbox,
+      plan: {
+        acpAgent: "codex",
+        credentialMode: "env",
+        hasApiKey: false,
+        secrets: {},
+      },
+    });
+
+    assert.equal(
+      calls.some((c) => c.path === `${DAYTONA_CODEX_DIR}/auth.json`),
+      false,
+      "no auth.json written when managed key is absent",
+    );
+  });
+
+  it("uploads local auth.json on a runtime_provided run", async () => {
+    const fakeHome = mkdtempSync(join(tmpdir(), "agenta-codex-rtprov-"));
+    dirs.push(fakeHome);
+    mkdirSync(join(fakeHome, ".codex"));
+    writeFileSync(
+      join(fakeHome, ".codex", "auth.json"),
+      '{"OPENAI_API_KEY":"sk-own"}',
+      "utf-8",
+    );
+    const originalHome = process.env.HOME;
+    process.env.HOME = fakeHome;
+
+    const { calls, sandbox } = makeSandbox();
+    try {
+      await prepareDaytonaCodexAssets({
+        sandbox,
+        plan: {
+          acpAgent: "codex",
+          credentialMode: "runtime_provided",
+          hasApiKey: false,
+          secrets: {},
+        },
+      });
+    } finally {
+      if (originalHome === undefined) delete process.env.HOME;
+      else process.env.HOME = originalHome;
+    }
+
+    const writeCall = calls.find((c) => c.path === `${DAYTONA_CODEX_DIR}/auth.json`);
+    assert.ok(writeCall, "auth.json must be uploaded on runtime_provided");
+    assert.equal(writeCall?.body, '{"OPENAI_API_KEY":"sk-own"}');
+  });
+
+  it("does not upload on a credentialMode=none run", async () => {
+    const { calls, sandbox } = makeSandbox();
+
+    await prepareDaytonaCodexAssets({
+      sandbox,
+      plan: {
+        acpAgent: "codex",
+        credentialMode: "none",
+        hasApiKey: false,
+        secrets: {},
+      },
+    });
+
+    assert.equal(
+      calls.some((c) => c.path === `${DAYTONA_CODEX_DIR}/auth.json`),
+      false,
+    );
   });
 });


### PR DESCRIPTION
## Context
Codex existed only on the local sandbox. Getting it onto Daytona meant adding Daytona-side auth-file provisioning for Codex, matching the pattern already established for Pi.

## Changes
Adds Codex asset prep in `daytona.ts`, writing `~/.codex/auth.json` (Daytona-side path) in both credential modes (managed env var and self-managed file), mirroring the local-sandbox behavior from the base harness branch.

## Tests / notes
- New coverage in `sandbox-agent-daytona.test.ts` covering both credential modes.
- Base is `chore/add-harness-codex`, not `big-agents` — this PR's diff should show only the Daytona-specific delta.
- Codex-on-Daytona runs with tools will hit the loud-refuse gate from `chore/add-remote-tools-gate` until the relay-client shim lands.