### PR TITLE
[chore] Add Codex on E2B sandbox

### DIFF
--- a/api/oss/src/utils/env.py
+++ b/api/oss/src/utils/env.py
@@ -562,6 +562,18 @@ class DaytonaConfig(BaseModel):
 
 
 # ---------------------------------------------------------------------------
+# e2b
+# ---------------------------------------------------------------------------
+
+
+class E2BConfig(BaseModel):
+    api_key: str | None = os.getenv("E2B_API_KEY")
+    template: str | None = os.getenv("E2B_TEMPLATE")
+
+    model_config = ConfigDict(extra="ignore")
+
+
+# ---------------------------------------------------------------------------
 # docker
 # ---------------------------------------------------------------------------
 
@@ -1239,6 +1251,7 @@ class EnvironSettings(BaseModel):
     crisp: CrispConfig = CrispConfig()
     daytona: DaytonaConfig = DaytonaConfig()
     docker: DockerConfig = DockerConfig()
+    e2b: E2BConfig = E2BConfig()
     identity: IdentityConfig = IdentityConfig()
     llm: LLMConfig = LLMConfig()
     loops: LoopsConfig = LoopsConfig()

--- a/docs/design/agent-workflows/projects/add-codex-e2b/research.md
+++ b/docs/design/agent-workflows/projects/add-codex-e2b/research.md
@@ -1,0 +1,70 @@
+# Research: Codex on E2B
+
+## E2B sandbox-agent provider
+
+The `sandbox-agent/e2b` provider (from the `chore-add-sandbox-e2b` sibling branch) wraps
+the E2B SDK's sandbox lifecycle behind the sandbox-agent provider interface. Key options:
+
+- `template` — E2B sandbox template ID (default `agenta-sandbox-agent`; override with
+  `E2B_TEMPLATE`).
+- `create.envs` — environment variables injected into the sandbox at creation time.
+- `timeoutMs` — sandbox wall-clock timeout; the sandbox is paused (and billing stops) after
+  this interval of inactivity. Must be > 0 so a process-killed runner never leaks a
+  running sandbox indefinitely. Default 30 min; override with `E2B_TIMEOUT_MS`.
+- `autoPause` — when `true`, E2B pauses the sandbox (rather than terminating it) on
+  timeout; resumed by the next request. Set `true` to avoid losing work on idle.
+
+Auth: the provider reads `E2B_API_KEY` from the environment directly; no cookie is needed.
+The ACP fetch for E2B uses plain `createAcpFetch` (not `createCookieFetch`, which is
+Daytona-specific). 
+
+Baked template `agenta-sandbox-agent` contains the sandbox-agent daemon and (for Pi) the
+Pi binary. The codex binary is auto-installed by the daemon on first use if the template
+does not bake it, or can be baked into a custom template (`E2B_TEMPLATE`).
+
+Node >= 22.19 is required by the `sandbox-agent/e2b` peer; the default sidecar image pins
+Node 24, so this is satisfied.
+
+Restricted-network (`sandbox_permission.network`) is refused on E2B because the
+`sandbox-agent/e2b` provider exposes no egress-control API (unlike Daytona's
+`networkBlockAll`/`networkAllowList`). The refusal is unconditional (not gated on
+`enforcement`) — there is no path where the boundary is applied on E2B.
+
+## Codex credential requirements
+
+Codex reads `~/.codex/auth.json` as a FILE on startup; environment variables alone are
+insufficient. The file format is `{"OPENAI_API_KEY": "<key>"}`. The daemon also needs
+`OPENAI_API_KEY` in its environment for the ACP session to launch with the correct key.
+
+For local runs, `writeCodexAuthFile` (in `pi-assets.ts`) writes the file to the host's
+`~/.codex/auth.json` before the daemon starts.
+
+For E2B runs, the file must be uploaded into the sandbox via the sandbox FS API
+(`sandbox.mkdirFs` + `sandbox.writeFsFile`) after the sandbox starts but before the
+session is created. The daemon's `OPENAI_API_KEY` is injected at sandbox creation time via
+`create.envs`. Mode `agent-full-access` is selected by the harness adapter in the Python
+SDK (`CodexAgentTemplate`).
+
+## Credential modes
+
+- `credentialMode === "env"` (managed key): `OPENAI_API_KEY` is in `plan.secrets`; the
+  daemon env is cleared then the key applied. The auth.json upload uses the resolved key.
+- `credentialMode === "runtime_provided"`: the codex CLI uses its own login; no key upload.
+- `credentialMode === "none"` / absent: back-compat heuristic — upload only if no key
+  present.
+
+## Overlap with chore-add-sandbox-e2b
+
+The following files in this branch duplicate work from the `chore-add-sandbox-e2b` sibling
+branch and will need to be reconciled when the branches merge:
+
+| File | Overlap |
+|------|---------|
+| `services/agent/src/engines/sandbox_agent/e2b.ts` | Both branches add this file. The sibling branch's version covers Pi only; this version adds `uploadCodexAuthToE2bSandbox`. Merge: combine into one file. |
+| `services/agent/src/engines/sandbox_agent/provider.ts` | Both add `buildE2bCreate`, `e2bTimeoutMs`, `DEFAULT_E2B_TIMEOUT_MS`, and the `e2b` branch in `buildSandboxProvider`. The implementations are identical. |
+| `services/agent/src/engines/sandbox_agent/run-plan.ts` | Both add `isE2b`, `E2B_NETWORK_UNSUPPORTED_MESSAGE`, `defaultE2bCwd`, `createE2bCwd` dep. Identical. |
+| `services/agent/src/engines/sandbox_agent/usage.ts` | Both rename `isDaytona` → `isRemote` in `readRunUsage` and add `isE2b?` to `resolveRunUsage`. Identical. |
+| `services/agent/src/engines/sandbox_agent.ts` | Both add `isE2b` branches for workspace cleanup, MCP, piExtEnv, emitSpans, tool-relay, swallowed-error. This branch additionally gates the local codex auth write on `!isE2b` and adds the E2B codex auth upload. |
+| `api/oss/src/utils/env.py` | Both add `E2bConfig`. Identical. |
+| `tests/unit/sandbox-agent-e2b-run-plan.test.ts` | Both add this test file. This branch additionally covers codex-on-E2B scenarios. |
+| `tests/unit/sandbox-agent-e2b-provider.test.ts` | Both add this test file. Identical. |

--- a/docs/design/agent-workflows/projects/add-codex-e2b/specs.md
+++ b/docs/design/agent-workflows/projects/add-codex-e2b/specs.md
@@ -1,0 +1,75 @@
+# Specs: Codex on E2B
+
+## Goals
+
+Run the codex harness inside an E2B sandbox, so codex benefits from E2B's isolated remote
+execution environment and billing-based lifecycle management.
+
+## Non-goals
+
+- Daytona support for codex (separate concern).
+- Custom E2B template build pipeline (documented below; operator concern).
+- Restricted-network enforcement on E2B (not available; refused loudly).
+
+## Axes
+
+Two orthogonal axes compose independently:
+
+- **Harness axis**: `codex` — the OpenAI codex CLI driven over ACP.
+- **Sandbox axis**: `e2b` — an E2B cloud sandbox managed by the `sandbox-agent/e2b`
+  provider.
+
+## E2B provider options
+
+```
+template       = E2B_TEMPLATE ?? "agenta-sandbox-agent"
+timeoutMs      = E2B_TIMEOUT_MS ?? 1_800_000 (30 min); must be >= 1
+autoPause      = true
+create.envs    = { ...piExtEnv, OPENAI_API_KEY, CODEX_API_KEY? }
+```
+
+The `timeoutMs` + `autoPause` pair is the leak backstop: a process-killed runner skips the
+per-run `finally`; E2B pauses the sandbox after `timeoutMs` of inactivity, which stops
+billing. The sandbox is never left running indefinitely.
+
+## Codex credential provisioning
+
+1. `OPENAI_API_KEY` injected into the sandbox at create time via `create.envs`.
+2. `~/.codex/auth.json` written into the sandbox filesystem after start and before session
+   create, via `uploadCodexAuthToE2bSandbox`. Content: `{"OPENAI_API_KEY": "<key>"}`.
+3. `credentialMode === "env"`: use the resolved key. `credentialMode === "runtime_provided"`:
+   skip the upload (codex uses its own login, which is NOT uploaded to E2B — no
+   `shouldUploadOwnLogin` analogue for codex on E2B).
+
+## Network restriction
+
+A `sandbox_permission.network` (any mode other than `"on"`) is refused on E2B regardless
+of `enforcement`, with `E2B_NETWORK_UNSUPPORTED_MESSAGE`. E2B exposes no egress-control
+API.
+
+## Cwd
+
+`/root/work/agenta-<6-random-hex>` — root-owned because the E2B template daemon runs as
+root. Override `E2B_TEMPLATE` to change the user.
+
+## Fetch
+
+Plain `createAcpFetch` (no cookie). E2B's sandbox-agent endpoint does not use the Daytona
+per-sandbox auth cookie scheme.
+
+## Teardown / leak parity
+
+- Normal/error/client-disconnect: `finally` calls `sandbox.destroySandbox()` +
+  `sandbox.dispose()`. Same as Daytona.
+- Process KILL: `timeoutMs` backstop pauses the sandbox, stopping billing.
+- `inFlightSandboxes` set: shutdown signal handler best-effort deletes all live sandboxes.
+- No local cwd dir to clean up (workspace cleanup is skipped for E2B, same as Daytona).
+
+## Template requirements
+
+The baked template must contain:
+- The `sandbox-agent` daemon binary.
+- The codex CLI binary (or the daemon auto-installs it on first use; confirm with the
+  template maintainer — the Pi template bakes it, the default codex template may not).
+
+If the codex binary is not baked, set `E2B_TEMPLATE` to a custom template that includes it.

--- a/docs/design/agent-workflows/projects/add-codex-e2b/tasks.md
+++ b/docs/design/agent-workflows/projects/add-codex-e2b/tasks.md
@@ -1,0 +1,106 @@
+# Tasks: Codex on E2B
+
+## Status
+
+All implementation tasks below are DONE on this branch (`chore/add-codex-e2b`).
+
+---
+
+## Task 1 — E2B provider wiring (DONE)
+
+**Files changed:**
+- `services/agent/src/engines/sandbox_agent/provider.ts` — add `import { e2b } from
+  "sandbox-agent/e2b"`, `DEFAULT_E2B_TIMEOUT_MS`, `e2bTimeoutMs()`, `buildE2bCreate()`,
+  and the `sandboxId === "e2b"` branch in `buildSandboxProvider`.
+
+**Note:** duplicates work in the `chore-add-sandbox-e2b` sibling branch (identical diff).
+Reconcile on merge.
+
+---
+
+## Task 2 — Run-plan E2B additions (DONE)
+
+**Files changed:**
+- `services/agent/src/engines/sandbox_agent/run-plan.ts` — add `E2B_NETWORK_UNSUPPORTED_MESSAGE`,
+  `isE2b` field on `RunPlan`, `createE2bCwd` dep on `BuildRunPlanDeps`, `defaultE2bCwd()`,
+  `isE2b` derivation, network-restriction gate for E2B, `isE2b` in cwd selection, `isE2b`
+  on the returned plan.
+
+**Note:** duplicates work in the `chore-add-sandbox-e2b` sibling branch (identical diff).
+Reconcile on merge.
+
+---
+
+## Task 3 — E2B assets file (DONE)
+
+**Files changed:**
+- `services/agent/src/engines/sandbox_agent/e2b.ts` — new file. Adds `E2B_PI_DIR`,
+  `e2bEnvVars`, `uploadPiAuthToE2bSandbox`, `uploadCodexAuthToE2bSandbox` (codex-specific
+  addition not in sibling branch), `prepareE2bPiAssets`.
+
+**Note:** partially overlaps the `chore-add-sandbox-e2b` sibling branch. The sibling adds
+all functions except `uploadCodexAuthToE2bSandbox`. Merge: add the codex function to the
+sibling's version.
+
+---
+
+## Task 4 — Orchestration wiring (DONE)
+
+**Files changed:**
+- `services/agent/src/engines/sandbox_agent.ts` — import `prepareE2bPiAssets` and
+  `uploadCodexAuthToE2bSandbox` from `./sandbox_agent/e2b.ts`; add
+  `prepareE2bPiAssets` to `SandboxAgentDeps`; pass `createE2bCwd` to `buildRunPlan`; gate
+  local codex auth write on `!plan.isE2b`; skip workspace cleanup for E2B; add E2B branch
+  in the Daytona asset-prep section (calls `prepareE2bPiAssets` then
+  `uploadCodexAuthToE2bSandbox` for codex); pass `isE2b` to `buildSessionMcpServers`;
+  update `emitSpans` and tool-relay host to include `plan.isE2b`; pass `isE2b` to
+  `resolveRunUsage`; exclude E2B from swallowed-Pi-error check.
+- `services/agent/src/engines/sandbox_agent/usage.ts` — rename `isDaytona` → `isRemote`
+  in `readRunUsage`; add `isE2b?` to `resolveRunUsage` (combines with `isDaytona` for the
+  remote read).
+
+**Note:** usage.ts change and most sandbox_agent.ts changes duplicate the sibling branch.
+The codex auth upload block is unique to this branch.
+
+---
+
+## Task 5 — Python env config (DONE)
+
+**Files changed:**
+- `api/oss/src/utils/env.py` — add `E2bConfig` class (`E2B_API_KEY`, `E2B_TEMPLATE`) and
+  `e2b: E2bConfig = E2bConfig()` on `EnvironSettings`.
+
+**Note:** identical to the `chore-add-sandbox-e2b` sibling branch. Reconcile on merge.
+
+---
+
+## Task 6 — Tests (DONE)
+
+**Files added:**
+- `services/agent/tests/unit/sandbox-agent-e2b-run-plan.test.ts` — unit tests for E2B
+  run-plan: `isE2b` and E2B cwd, `isE2b=false` on local/daytona, restricted-network refusal
+  (strict and best_effort), E2B_NETWORK_UNSUPPORTED_MESSAGE constant, unrestricted/no-perm
+  allows, **codex-on-E2B plan fields**.
+- `services/agent/tests/unit/sandbox-agent-e2b-provider.test.ts` — unit tests for E2B
+  provider: `e2bTimeoutMs` clamping/defaults, `buildE2bCreate` fields (timeoutMs, autoPause,
+  envs merge).
+- `services/agent/tests/unit/sandbox-agent-codex-e2b.test.ts` — codex-specific E2B tests:
+  auth.json upload into sandbox, daemon env carries only OPENAI_API_KEY, local auth write
+  gated on `!isE2b`.
+
+**Note:** the run-plan and provider test files are identical to the sibling branch's versions
+plus the codex-on-E2B run-plan case. The codex-specific test file is unique to this branch.
+
+---
+
+## Open decisions
+
+1. **Codex binary in template**: confirm whether `agenta-sandbox-agent` template bakes the
+   codex binary or relies on auto-install. If auto-install, document the node >= 22.19
+   requirement and the first-run latency.
+2. **`CODEX_API_KEY` passthrough**: the daemon's `KNOWN_PROVIDER_ENV_VARS` already includes
+   `CODEX_API_KEY`. Confirm whether the auth.json upload should prefer `CODEX_API_KEY` over
+   `OPENAI_API_KEY` when both are present. Current implementation uses `OPENAI_API_KEY`.
+3. **Merge sequencing**: `chore-add-sandbox-e2b` should land first so this branch's
+   duplicate diffs become no-ops. After merge, remove the duplicate code and keep only the
+   codex-specific additions (`uploadCodexAuthToE2bSandbox` and its call site).

--- a/services/runner/package.json
+++ b/services/runner/package.json
@@ -21,6 +21,7 @@
   },
   "dependencies": {
     "@daytonaio/sdk": "^0.187.0",
+    "@e2b/code-interpreter": "^1.0.0",
     "@earendil-works/pi-coding-agent": "0.79.4",
     "@opentelemetry/api": "1.9.0",
     "@opentelemetry/exporter-trace-otlp-proto": "0.54.0",

--- a/services/runner/pnpm-lock.yaml
+++ b/services/runner/pnpm-lock.yaml
@@ -11,6 +11,9 @@ importers:
       '@daytonaio/sdk':
         specifier: ^0.187.0
         version: 0.187.0(ws@8.21.0)
+      '@e2b/code-interpreter':
+        specifier: ^1.0.0
+        version: 1.5.1
       '@earendil-works/pi-coding-agent':
         specifier: 0.79.4
         version: 0.79.4(ws@8.21.0)(zod@4.4.3)
@@ -40,7 +43,7 @@ importers:
         version: 0.0.29
       sandbox-agent:
         specifier: 0.4.2
-        version: 0.4.2(@daytonaio/sdk@0.187.0(ws@8.21.0))(zod@4.4.3)
+        version: 0.4.2(@daytonaio/sdk@0.187.0(ws@8.21.0))(@e2b/code-interpreter@1.5.1)(zod@4.4.3)
       undici:
         specifier: 8.3.0
         version: 8.3.0
@@ -306,6 +309,20 @@ packages:
     resolution: {integrity: sha512-6zABk/ECA/QYSCQ1NGiVwwbQerUCZ+TQbp64Q3AgmfNvurHH0j8TtXa1qbShXA6qqkpAj4V5W8pP6mLe1mcMqA==}
     engines: {node: '>=18'}
 
+  '@bufbuild/protobuf@2.12.1':
+    resolution: {integrity: sha512-BvAMfS6LrgZiryOAZ4pBYucu4wG/Ei/9o9DZ9akbREnMLbPJiom2i8b9C8IsKErQoiKqVhrerzt3kOT/RrzLHg==}
+
+  '@connectrpc/connect-web@2.0.0-rc.3':
+    resolution: {integrity: sha512-w88P8Lsn5CCsA7MFRl2e6oLY4J/5toiNtJns/YJrlyQaWOy3RO8pDgkz+iIkG98RPMhj2thuBvsd3Cn4DKKCkw==}
+    peerDependencies:
+      '@bufbuild/protobuf': ^2.2.0
+      '@connectrpc/connect': 2.0.0-rc.3
+
+  '@connectrpc/connect@2.0.0-rc.3':
+    resolution: {integrity: sha512-ARBt64yEyKbanyRETTjcjJuHr2YXorzQo0etyS5+P6oSeW8xEuzajA9g+zDnMcj1hlX2dQE93foIWQGfpru7gQ==}
+    peerDependencies:
+      '@bufbuild/protobuf': ^2.2.0
+
   '@daytona/api-client@0.187.0':
     resolution: {integrity: sha512-riKOJ6eSuy67DL6iJlAa3Bfjnm4iQmkOdJk0B5hqrYMZeZmVDsgdiZtYvFpyoa+2KCZFNb0Gs5dQwO1d6NhGCw==}
 
@@ -315,6 +332,10 @@ packages:
   '@daytonaio/sdk@0.187.0':
     resolution: {integrity: sha512-j6PfT6735Uu34t4JoxBi4IMh1JLNrEDg5w3ZUaT0Mgkas2UfoAAhQ2Eg1LqMhy4n1CTffvCyJID9W6Ldi4xEGQ==}
     deprecated: 'Moved to @daytona/sdk, same API, no breaking changes. Please update: npm uninstall @daytonaio/sdk && npm i @daytona/sdk'
+
+  '@e2b/code-interpreter@1.5.1':
+    resolution: {integrity: sha512-mkyKjAW2KN5Yt0R1I+1lbH3lo+W/g/1+C2lnwlitXk5wqi/g94SEO41XKdmDf5WWpKG3mnxWDR5d6S/lyjmMEw==}
+    engines: {node: '>=18'}
 
   '@earendil-works/pi-agent-core@0.79.4':
     resolution: {integrity: sha512-xkaZ3yK2XbP9HYdHrrdj/6HqZPM0o/mwbjMSU4RTJyR3HjDG0ZrPz76Hg6s0W+G4u6PpJr1mGx/srCG+3eQA8A==}
@@ -1390,6 +1411,9 @@ packages:
     resolution: {integrity: sha512-FQN4MRfuJeHf7cBbBMJFXhKSDq+2kAArBlmRBvcvFE5BB1HZKXtSFASDhdlz9zOYwxh8lDdnvmMOe/+5cdoEdg==}
     engines: {node: '>= 0.8'}
 
+  compare-versions@6.1.1:
+    resolution: {integrity: sha512-4hm4VPpIecmlg59CHXnRDnqGplJFrbLG4aFEl5vl6cK1u76ws3LLvX7ikFnTDl5vo39sjWD6AaDPYodJp/NNHg==}
+
   convert-source-map@2.0.0:
     resolution: {integrity: sha512-Kvp459HrV2FEJ1CAsi1Ku+MY3kasH19TFykTz2xWmMeq6bk2NU3XXvfJ+Q61m0xktWwt+1HSYf3JZsTms3aRJg==}
 
@@ -1429,6 +1453,10 @@ packages:
   dunder-proto@1.0.1:
     resolution: {integrity: sha512-KIN/nDJBQRcXw0MLVhZE9iQHmG68qAVIBg9CqmUYjmQIhgij9U5MFvrqkUL5FbtyyzZuOeOt0zdeRe4UY7ct+A==}
     engines: {node: '>= 0.4'}
+
+  e2b@1.13.2:
+    resolution: {integrity: sha512-m8acE/MzMAJo1A57DakR2X1Sl5Mt1tcQO2aJfygNaQHLXby/4xsjF0UeJUB70jF7xntiR41pAMbZEHnkzrT9tw==}
+    engines: {node: '>=18'}
 
   ecdsa-sig-formatter@1.0.11:
     resolution: {integrity: sha512-nagl3RYrbNv6kQkeJIpt6NJZy8twLB/2vtz6yN9Z4vRKHN4/QZJIEbqohALSgwKdnksuY3k5Addp5lg8sVoVcQ==}
@@ -1870,6 +1898,12 @@ packages:
       zod:
         optional: true
 
+  openapi-fetch@0.9.8:
+    resolution: {integrity: sha512-zM6elH0EZStD/gSiNlcPrzXcVQ/pZo3BDvC6CDwRDUt1dDzxlshpmQnpD6cZaJ39THaSmwVCxxRrPKNM1hHrDg==}
+
+  openapi-typescript-helpers@0.0.8:
+    resolution: {integrity: sha512-1eNjQtbfNi5Z/kFhagDIaIRj6qqDzhjNJKz8cmMW0CVdGwT6e1GLbAfgI0d28VTJa1A8jz82jm/4dG8qNoNS8g==}
+
   p-retry@4.6.2:
     resolution: {integrity: sha512-312Id396EbJdvRONlngUx0NydfrIQ5lsYu0znKVUzVvArzEIt08V1qhtyESbGVd1FGX7UKtiFp5uwKZdM8wIuQ==}
     engines: {node: '>=8'}
@@ -1911,6 +1945,9 @@ packages:
   picomatch@4.0.4:
     resolution: {integrity: sha512-QP88BAKvMam/3NxH6vj2o21R6MjxZUAd6nlwAS/pnGvN9IVLocLHxGYIzFhg6fUQ+5th6P4dv4eW9jX3DSIj7A==}
     engines: {node: '>=12'}
+
+  platform@1.3.6:
+    resolution: {integrity: sha512-fnWVljUchTro6RiCFvCXBbNhJc2NijN7oIQxbwsyL0buWJPG85v81ehlHI9fXrJsMNgTofEoWIQeClKpgxFLrg==}
 
   postcss@8.5.15:
     resolution: {integrity: sha512-FfR8sjd4em2T6fb3I2MwAJU7HWVMr9zba+enmQeeWFfCbm+UOC/0X4DS8XtpUTMwWMGbjKYP7xjfNekzyGmB3A==}
@@ -2740,6 +2777,17 @@ snapshots:
 
   '@bcoe/v8-coverage@1.0.2': {}
 
+  '@bufbuild/protobuf@2.12.1': {}
+
+  '@connectrpc/connect-web@2.0.0-rc.3(@bufbuild/protobuf@2.12.1)(@connectrpc/connect@2.0.0-rc.3(@bufbuild/protobuf@2.12.1))':
+    dependencies:
+      '@bufbuild/protobuf': 2.12.1
+      '@connectrpc/connect': 2.0.0-rc.3(@bufbuild/protobuf@2.12.1)
+
+  '@connectrpc/connect@2.0.0-rc.3(@bufbuild/protobuf@2.12.1)':
+    dependencies:
+      '@bufbuild/protobuf': 2.12.1
+
   '@daytona/api-client@0.187.0':
     dependencies:
       axios: 1.18.0
@@ -2783,6 +2831,10 @@ snapshots:
       - debug
       - supports-color
       - ws
+
+  '@e2b/code-interpreter@1.5.1':
+    dependencies:
+      e2b: 1.13.2
 
   '@earendil-works/pi-agent-core@0.79.4(ws@8.21.0)(zod@4.4.3)':
     dependencies:
@@ -3836,6 +3888,8 @@ snapshots:
     dependencies:
       delayed-stream: 1.0.0
 
+  compare-versions@6.1.1: {}
+
   convert-source-map@2.0.0: {}
 
   cross-spawn@7.0.6:
@@ -3863,6 +3917,15 @@ snapshots:
       call-bind-apply-helpers: 1.0.2
       es-errors: 1.3.0
       gopd: 1.2.0
+
+  e2b@1.13.2:
+    dependencies:
+      '@bufbuild/protobuf': 2.12.1
+      '@connectrpc/connect': 2.0.0-rc.3(@bufbuild/protobuf@2.12.1)
+      '@connectrpc/connect-web': 2.0.0-rc.3(@bufbuild/protobuf@2.12.1)(@connectrpc/connect@2.0.0-rc.3(@bufbuild/protobuf@2.12.1))
+      compare-versions: 6.1.1
+      openapi-fetch: 0.9.8
+      platform: 1.3.6
 
   ecdsa-sig-formatter@1.0.11:
     dependencies:
@@ -4285,6 +4348,12 @@ snapshots:
       ws: 8.21.0
       zod: 4.4.3
 
+  openapi-fetch@0.9.8:
+    dependencies:
+      openapi-typescript-helpers: 0.0.8
+
+  openapi-typescript-helpers@0.0.8: {}
+
   p-retry@4.6.2:
     dependencies:
       '@types/retry': 0.12.0
@@ -4315,6 +4384,8 @@ snapshots:
   picomatch@2.3.2: {}
 
   picomatch@4.0.4: {}
+
+  platform@1.3.6: {}
 
   postcss@8.5.15:
     dependencies:
@@ -4411,12 +4482,13 @@ snapshots:
 
   safe-buffer@5.2.1: {}
 
-  sandbox-agent@0.4.2(@daytonaio/sdk@0.187.0(ws@8.21.0))(zod@4.4.3):
+  sandbox-agent@0.4.2(@daytonaio/sdk@0.187.0(ws@8.21.0))(@e2b/code-interpreter@1.5.1)(zod@4.4.3):
     dependencies:
       '@sandbox-agent/cli-shared': 0.4.2
       acp-http-client: 0.4.2(zod@4.4.3)
     optionalDependencies:
       '@daytonaio/sdk': 0.187.0(ws@8.21.0)
+      '@e2b/code-interpreter': 1.5.1
       '@sandbox-agent/cli': 0.4.2
     transitivePeerDependencies:
       - zod

--- a/services/runner/src/engines/sandbox_agent.ts
+++ b/services/runner/src/engines/sandbox_agent.ts
@@ -58,6 +58,10 @@ import {
   createCookieFetch,
   prepareDaytonaPiAssets,
 } from "./sandbox_agent/daytona.ts";
+import {
+  prepareE2BCodexAssets,
+  prepareE2BPiAssets,
+} from "./sandbox_agent/e2b.ts";
 import { conciseError } from "./sandbox_agent/errors.ts";
 import { buildSessionMcpServers } from "./sandbox_agent/mcp.ts";
 import { applyModel } from "./sandbox_agent/model.ts";
@@ -213,6 +217,7 @@ export interface SandboxAgentDeps extends BuildRunPlanDeps {
   buildSandboxProvider?: typeof buildSandboxProvider;
   createCookieFetch?: typeof createCookieFetch;
   createAcpFetch?: typeof createAcpFetch;
+  prepareE2BPiAssets?: typeof prepareE2BPiAssets;
   prepareWorkspace?: typeof prepareWorkspace;
   probeCapabilities?: typeof probeCapabilities;
   applyModel?: typeof applyModel;
@@ -315,6 +320,7 @@ export async function runSandboxAgent(
     createLocalCwd: deps.createLocalCwd,
     createDaytonaCwd: deps.createDaytonaCwd,
     durableCwd,
+    createE2BCwd: deps.createE2BCwd,
     resolveSkillDirs: deps.resolveSkillDirs,
     log: logger,
   });
@@ -340,7 +346,7 @@ export async function runSandboxAgent(
   // via the Agenta extension. Tool execution always relays back to this runner, which keeps
   // private specs, scoped env, callback endpoints, and callback auth in memory.
   const piExtEnv = plan.isPi
-    ? buildPiExtensionEnv(request, !plan.isDaytona, {
+    ? buildPiExtensionEnv(request, !plan.isRemoteSandbox, {
         relayDir: plan.relayDir,
         usageOutPath: plan.usageOutPath,
         // The materialized skill names (author + forced `_agenta.*`) so Pi's own agent span
@@ -360,7 +366,7 @@ export async function runSandboxAgent(
   // Codex reads ~/.codex/auth.json as a FILE (env alone is insufficient); provision it for local runs.
   // Only delete it in the finally when this run created it (never delete a pre-existing file).
   let codexAuthWritten = false;
-  if (plan.acpAgent === "codex" && !plan.isDaytona) {
+  if (plan.acpAgent === "codex" && !plan.isRemoteSandbox) {
     codexAuthWritten = prepareLocalCodexAssets(plan, logger);
   }
 
@@ -381,7 +387,7 @@ export async function runSandboxAgent(
   // store prefix, so the `finally` can unmount it. Undefined for non-session/remote/unmounted runs.
   let mountedCwd: string | undefined;
   const mountLocalDurableCwd = async (reason: string): Promise<boolean> => {
-    if (!mountCreds || plan.isDaytona) return false;
+    if (!mountCreds || plan.isRemoteSandbox) return false;
     logger(
       `local durable cwd mount (${reason}) session=${sessionForMount} cwd=${plan.cwd}`,
     );
@@ -393,7 +399,7 @@ export async function runSandboxAgent(
   };
   let localDurableCwdEnotconnRemounts = 0;
   const reSignAndRemountLocalCwd = async (): Promise<boolean> => {
-    if (!sessionForMount || !runCred || plan.isDaytona) return false;
+    if (!sessionForMount || !runCred || plan.isRemoteSandbox) return false;
     if (
       localDurableCwdEnotconnRemounts >=
       LOCAL_DURABLE_CWD_ENOTCONN_REMOUNT_LIMIT
@@ -421,7 +427,7 @@ export async function runSandboxAgent(
   };
   let runtimeRemount: Promise<boolean> | undefined;
   const remountLocalCwdAfterRuntimeEnotconn = (event: unknown): void => {
-    if (plan.isDaytona || !mountCreds || !mountedCwd) return;
+    if (plan.isRemoteSandbox || !mountCreds || !mountedCwd) return;
     if (runtimeRemount || !containsTransportEndpointDisconnected(event)) return;
     logger(
       `local durable cwd ENOTCONN observed in ACP event session=${sessionForMount} cwd=${plan.cwd}; re-signing and remounting`,
@@ -433,11 +439,12 @@ export async function runSandboxAgent(
       return false;
     });
   };
-  let workspace: { cleanup: () => Promise<void> } | undefined = plan.isDaytona
-    ? undefined
-    : {
-        cleanup: async () => rmSync(plan.cwd, { recursive: true, force: true }),
-      };
+  let workspace: { cleanup: () => Promise<void> } | undefined =
+    plan.isRemoteSandbox
+      ? undefined
+      : {
+          cleanup: async () => rmSync(plan.cwd, { recursive: true, force: true }),
+        };
 
   try {
     // Persist events in-process so a follow-up turn can resume by session id.
@@ -474,18 +481,25 @@ export async function runSandboxAgent(
     // normal exit so it is never double-deleted.
     if (sandbox) inFlightSandboxes.add(sandbox);
 
-    // On Daytona, push the harness login, the extension, and AGENTS.md into the remote
-    // sandbox via the filesystem API (nothing secret is baked into the image). Locally
-    // these use the host filesystem and the harness's own login (PI_CODING_AGENT_DIR).
+    // On Daytona/E2B, push the harness login, the extension, and AGENTS.md into the remote
+    // sandbox via the filesystem API. Locally these use the host filesystem.
     if (plan.isDaytona) {
       await prepareDaytonaPiAssets({ sandbox, plan, log: logger });
+    } else if (plan.isE2B) {
+      await (deps.prepareE2BPiAssets ?? prepareE2BPiAssets)({
+        sandbox,
+        plan,
+        log: logger,
+      });
+      // Codex on E2B: provision credentials for both managed and self-managed modes.
+      await prepareE2BCodexAssets({ sandbox, plan, log: logger });
     }
 
     // Durable cwd: reuse the pre-signed creds (signed before buildRunPlan so the prefix drove the
     // cwd derivation). The mount lands BEFORE createSession so the session opens inside it.
     // Local: on-host geesefs; scoped creds never enter agent space.
     // Remote (Daytona): geesefs inside the sandbox over the ngrok tunnel.
-    if (mountCreds && !plan.isDaytona) {
+    if (mountCreds && !plan.isRemoteSandbox) {
       // Mount before local workspace materialization so AGENTS.md, harness files, and skills
       // land in the durable prefix instead of being hidden under the later FUSE mount.
       await mountLocalDurableCwd("initial");
@@ -499,7 +513,7 @@ export async function runSandboxAgent(
       });
     } catch (err) {
       if (
-        !plan.isDaytona &&
+        !plan.isRemoteSandbox &&
         mountCreds &&
         isTransportEndpointDisconnected(err) &&
         (await reSignAndRemountLocalCwd())
@@ -567,8 +581,9 @@ export async function runSandboxAgent(
       isPi: plan.isPi,
       capabilities,
       harness: plan.harness,
-      // Daytona: skip the internal loopback HTTP MCP channel (unreachable from the in-sandbox
-      // harness); gateway tools are delivered through the Daytona file relay started below.
+      // Any remote sandbox: skip the internal loopback HTTP MCP channel (unreachable from the
+      // in-sandbox harness); gateway tools are delivered through the file relay started below.
+      isRemote: plan.isRemoteSandbox,
       isDaytona: plan.isDaytona,
       toolSpecs: plan.toolSpecs,
       userMcpServers: request.mcpServers,
@@ -606,7 +621,7 @@ export async function runSandboxAgent(
       endpoint: request.telemetry?.exporters?.otlp?.endpoint,
       authorization: request.telemetry?.exporters?.otlp?.headers?.authorization,
       captureContent: request.telemetry?.capture?.content?.enabled,
-      emitSpans: !plan.isPi || plan.isDaytona,
+      emitSpans: !plan.isPi || plan.isRemoteSandbox,
       emit,
     });
     otel = run;
@@ -705,7 +720,7 @@ export async function runSandboxAgent(
       // permission degrades to the run's headless permission policy (the same policy the
       // PolicyResponder uses for Claude builtins above).
       toolRelay = (deps.startToolRelay ?? startToolRelay)(
-        plan.isDaytona
+        plan.isRemoteSandbox
           ? (deps.sandboxRelayHost ?? sandboxRelayHost)(sandbox)
           : (deps.localRelayHost ?? localRelayHost)(),
         plan.relayDir,
@@ -784,7 +799,7 @@ export async function runSandboxAgent(
     const usage = await resolveRunUsage({
       sandbox,
       usageOutPath: plan.usageOutPath,
-      isDaytona: plan.isDaytona,
+      isRemote: plan.isRemoteSandbox,
       promptResult: result,
       streamUsage: run.usage(),
     });
@@ -801,7 +816,7 @@ export async function runSandboxAgent(
     // sandbox).
     const swallowedPiError =
       plan.isPi &&
-      !plan.isDaytona &&
+      !plan.isRemoteSandbox &&
       !run.output().trim() &&
       !run.events().some((e) => e.type === "tool_call")
         ? findSwallowedPiError(plan.sourcePiAgentDir, plan.cwd)

--- a/services/runner/src/engines/sandbox_agent/e2b.ts
+++ b/services/runner/src/engines/sandbox_agent/e2b.ts
@@ -1,0 +1,169 @@
+import { existsSync, readFileSync } from "node:fs";
+import { homedir } from "node:os";
+import { join } from "node:path";
+
+import {
+  uploadPiExtensionToSandbox,
+  uploadSkillsToSandbox,
+  uploadSystemPromptToSandbox,
+} from "./pi-assets.ts";
+import { shouldUploadOwnLogin, type RunPlan } from "./run-plan.ts";
+
+type Log = (message: string) => void;
+
+/** In-sandbox Pi agent dir (daemon runs as root in the E2B template). */
+export const E2B_PI_DIR =
+  process.env.AGENTA_AGENT_SANDBOX_PI_DIR ?? "/root/.pi/agent";
+
+/** In-sandbox codex auth dir (E2B runs as root). */
+export const E2B_CODEX_DIR =
+  process.env.AGENTA_AGENT_SANDBOX_CODEX_DIR ?? "/root/.codex";
+
+/**
+ * In-sandbox env for the E2B daemon: provider keys + Agenta extension env so the remote
+ * agent traces and runs tools exactly like local.
+ */
+export function e2bEnvVars(
+  piExtEnv: Record<string, string>,
+  secrets: Record<string, string>,
+): Record<string, string> {
+  return {
+    PI_CODING_AGENT_DIR: E2B_PI_DIR,
+    ...piExtEnv,
+    ...secrets,
+  };
+}
+
+/**
+ * Upload Pi's fallback `auth.json` into an E2B sandbox. Best-effort.
+ */
+export async function uploadPiAuthToE2BSandbox(
+  sandbox: any,
+  log: Log = () => {},
+): Promise<void> {
+  const localDir =
+    process.env.PI_CODING_AGENT_DIR || join(process.env.HOME ?? "", ".pi/agent");
+  const authPath = join(localDir, "auth.json");
+  if (!existsSync(authPath)) return;
+  try {
+    await sandbox.mkdirFs({ path: E2B_PI_DIR });
+    await sandbox.writeFsFile(
+      { path: `${E2B_PI_DIR}/auth.json` },
+      readFileSync(authPath, "utf-8"),
+    );
+    const settingsPath = join(localDir, "settings.json");
+    if (existsSync(settingsPath)) {
+      await sandbox.writeFsFile(
+        { path: `${E2B_PI_DIR}/settings.json` },
+        readFileSync(settingsPath, "utf-8"),
+      );
+    }
+  } catch (err) {
+    log(`pi auth upload skipped: ${(err as Error).message}`);
+  }
+}
+
+/**
+ * Write the codex auth file into an E2B sandbox.
+ *
+ * Managed mode: the resolved `apiKey` is written as `{"OPENAI_API_KEY":"..."}`.
+ * Self-managed mode: pass `undefined` and the local `~/.codex/auth.json` is uploaded verbatim.
+ * Best-effort: failures are logged but do not abort the run.
+ */
+export async function uploadCodexAuthToE2BSandbox(
+  sandbox: any,
+  apiKey: string | undefined,
+  log: Log = () => {},
+): Promise<void> {
+  try {
+    await sandbox.mkdirFs({ path: E2B_CODEX_DIR });
+    if (apiKey) {
+      await sandbox.writeFsFile(
+        { path: `${E2B_CODEX_DIR}/auth.json` },
+        JSON.stringify({ OPENAI_API_KEY: apiKey }),
+      );
+      return;
+    }
+    const localAuth = join(homedir(), ".codex", "auth.json");
+    if (existsSync(localAuth)) {
+      await sandbox.writeFsFile(
+        { path: `${E2B_CODEX_DIR}/auth.json` },
+        readFileSync(localAuth, "utf-8"),
+      );
+    }
+  } catch (err) {
+    log(`codex auth.json upload skipped: ${(err as Error).message}`);
+  }
+}
+
+export interface PrepareE2BCodexAssetsInput {
+  sandbox: any;
+  plan: Pick<RunPlan, "acpAgent" | "hasApiKey" | "credentialMode" | "secrets">;
+  log?: Log;
+}
+
+/**
+ * Push codex credentials into an E2B sandbox.
+ *
+ * Managed (`credentialMode="env"`): writes `auth.json` from the resolved `OPENAI_API_KEY ?? CODEX_API_KEY`.
+ * Self-managed (`runtime_provided`): uploads the runner's own `~/.codex/auth.json`.
+ * Returns immediately for non-codex runs.
+ */
+export async function prepareE2BCodexAssets({
+  sandbox,
+  plan,
+  log = () => {},
+}: PrepareE2BCodexAssetsInput): Promise<void> {
+  if (plan.acpAgent !== "codex") return;
+
+  const resolvedKey = plan.secrets.OPENAI_API_KEY ?? plan.secrets.CODEX_API_KEY;
+  if (plan.credentialMode === "env" && resolvedKey) {
+    await uploadCodexAuthToE2BSandbox(sandbox, resolvedKey, log);
+    return;
+  }
+  if (shouldUploadOwnLogin(plan)) {
+    await uploadCodexAuthToE2BSandbox(sandbox, undefined, log);
+  }
+}
+
+export interface PrepareE2BPiAssetsInput {
+  sandbox: any;
+  plan: Pick<
+    RunPlan,
+    | "isPi"
+    | "hasApiKey"
+    | "credentialMode"
+    | "skillDirs"
+    | "hasSystemPrompt"
+    | "systemPrompt"
+    | "appendSystemPrompt"
+  >;
+  log?: Log;
+}
+
+/**
+ * Push the Pi login fallback, Agenta extension, forced skills, and system prompts into an
+ * E2B sandbox. Pi is baked into the template — no in-sandbox install needed.
+ */
+export async function prepareE2BPiAssets({
+  sandbox,
+  plan,
+  log = () => {},
+}: PrepareE2BPiAssetsInput): Promise<void> {
+  if (!plan.isPi) return;
+
+  if (shouldUploadOwnLogin(plan)) await uploadPiAuthToE2BSandbox(sandbox, log);
+  await uploadPiExtensionToSandbox(sandbox, E2B_PI_DIR, log);
+  if (plan.skillDirs.length > 0) {
+    await uploadSkillsToSandbox(sandbox, E2B_PI_DIR, plan.skillDirs, log);
+  }
+  if (plan.hasSystemPrompt) {
+    await uploadSystemPromptToSandbox(
+      sandbox,
+      E2B_PI_DIR,
+      plan.systemPrompt,
+      plan.appendSystemPrompt,
+      log,
+    );
+  }
+}

--- a/services/runner/src/engines/sandbox_agent/mcp.ts
+++ b/services/runner/src/engines/sandbox_agent/mcp.ts
@@ -159,14 +159,15 @@ export interface BuildSessionMcpServersInput {
   capabilities: HarnessCapabilities;
   harness: string;
   /**
-   * True when the run executes in a REMOTE Daytona sandbox (the harness runs IN the sandbox,
-   * not on the runner host). Gates the internal gateway-tool channel: the channel's loopback
-   * (`127.0.0.1`) HTTP MCP URL resolves to the SANDBOX's loopback there, not the runner's, so
-   * advertising it would hand the in-sandbox harness an unreachable URL. On Daytona the channel
-   * is skipped and gateway tools are delivered through the file relay instead (the relay loop
-   * already polls the sandbox filesystem on Daytona — see `engines/sandbox_agent.ts`). See the
-   * Daytona guard in `buildSessionMcpServers`.
+   * True when the run executes in ANY remote sandbox (Daytona or E2B — the harness runs IN the
+   * sandbox, not on the runner host). Gates the internal gateway-tool channel: the channel's
+   * loopback (`127.0.0.1`) HTTP MCP URL resolves to the SANDBOX's loopback there, not the
+   * runner's, so advertising it would hand the in-sandbox harness an unreachable URL. On any
+   * remote sandbox the channel is skipped and gateway tools are delivered through the file relay
+   * instead (the relay loop already polls the sandbox filesystem — see `engines/sandbox_agent.ts`).
    */
+  isRemote: boolean;
+  /** True specifically for Daytona; only used to name the provider in the relay log line. */
   isDaytona: boolean;
   toolSpecs: ResolvedToolSpec[];
   userMcpServers?: McpServerConfig[];
@@ -205,6 +206,7 @@ export async function buildSessionMcpServers({
   isPi,
   capabilities,
   harness,
+  isRemote,
   isDaytona,
   toolSpecs,
   userMcpServers,
@@ -223,16 +225,16 @@ export async function buildSessionMcpServers({
   }
 
   // Layer 1: INTERNAL gateway-tool channel (do not merge with the user gate below). LOCAL ONLY:
-  // its advertised URL is a runner loopback (`127.0.0.1`), unreachable from a remote Daytona
-  // sandbox where the harness runs. On Daytona, skip the loopback HTTP advertisement and let the
-  // file relay deliver the tools (the relay loop polls the sandbox filesystem; see the Daytona
+  // its advertised URL is a runner loopback (`127.0.0.1`), unreachable from a remote sandbox
+  // where the harness runs. On any remote sandbox, skip the loopback HTTP advertisement and let
+  // the file relay deliver the tools (the relay loop polls the sandbox filesystem; see the
   // tool relay in `engines/sandbox_agent.ts`).
-  const internal = isDaytona
+  const internal = isRemote
     ? { servers: [], close: async () => {} }
     : await buildToolMcpServers(toolSpecs, relayDir, log);
-  if (isDaytona && toolSpecs.length > 0) {
+  if (isRemote && toolSpecs.length > 0) {
     log(
-      `daytona: ${toolSpecs.length} gateway tool(s) delivered via the file relay, not a ` +
+      `${isDaytona ? "daytona" : "e2b"}: ${toolSpecs.length} gateway tool(s) delivered via the file relay, not a ` +
         `loopback MCP URL (unreachable from the sandbox)`,
     );
   }

--- a/services/runner/src/engines/sandbox_agent/pi-assets.ts
+++ b/services/runner/src/engines/sandbox_agent/pi-assets.ts
@@ -198,7 +198,7 @@ export interface PrepareLocalPiAssetsInput {
   plan: Pick<
     RunPlan,
     | "isPi"
-    | "isDaytona"
+    | "isRemoteSandbox"
     | "skillDirs"
     | "hasSystemPrompt"
     | "systemPrompt"
@@ -219,7 +219,7 @@ export function prepareLocalPiAssets({
   env,
   log = () => {},
 }: PrepareLocalPiAssetsInput): string | undefined {
-  if (!plan.isPi || plan.isDaytona) return undefined;
+  if (!plan.isPi || plan.isRemoteSandbox) return undefined;
 
   if (plan.skillDirs.length > 0 || plan.hasSystemPrompt) {
     const runAgentDir = prepareLocalAgentDir(

--- a/services/runner/src/engines/sandbox_agent/provider.ts
+++ b/services/runner/src/engines/sandbox_agent/provider.ts
@@ -1,5 +1,6 @@
 import { local } from "sandbox-agent/local";
 import { daytona } from "sandbox-agent/daytona";
+import { e2b } from "sandbox-agent/e2b";
 
 import type { SandboxPermission } from "../../protocol.ts";
 import { daytonaEnvVars } from "./daytona.ts";
@@ -98,6 +99,41 @@ export function buildDaytonaCreate(
   };
 }
 
+/** Default E2B sandbox timeout (ms): self-reaps a leaked sandbox that process-KILL skips the `finally`. */
+export const DEFAULT_E2B_TIMEOUT_MS = 30 * 60 * 1000; // 30 minutes
+
+/** E2B sandbox timeout ms from env, clamped to >= 1 ms (0 would disable the backstop). */
+export function e2bTimeoutMs(
+  rawValue: string | undefined = process.env.E2B_TIMEOUT_MS,
+): number {
+  const parsed = Number(rawValue);
+  if (!Number.isFinite(parsed) || parsed < 1) return DEFAULT_E2B_TIMEOUT_MS;
+  return Math.floor(parsed);
+}
+
+export interface E2BCreateOptions {
+  envs: Record<string, string>;
+  timeoutMs: number;
+  autoPause: boolean;
+}
+
+/**
+ * Build the E2B provider options from the runner's env + the resolved run inputs.
+ *
+ * Pulled out as a pure function so the create options can be tested without constructing
+ * a real E2B client (which needs E2B_API_KEY).
+ */
+export function buildE2BCreate(
+  piExtEnv: Record<string, string>,
+  secrets: Record<string, string>,
+): E2BCreateOptions {
+  return {
+    envs: { ...piExtEnv, ...secrets },
+    timeoutMs: e2bTimeoutMs(),
+    autoPause: true,
+  };
+}
+
 /**
  * Build the sandbox-agent provider for the requested axis.
  *
@@ -121,6 +157,17 @@ export function buildSandboxProvider(
     return daytona({
       ...(image ? { image } : {}),
       create: buildDaytonaCreate(piExtEnv, secrets, sandboxPermission) as any,
+    });
+  }
+
+  if (sandboxId === "e2b") {
+    const template = process.env.E2B_TEMPLATE ?? "agenta-sandbox-agent";
+    const { envs, timeoutMs, autoPause } = buildE2BCreate(piExtEnv, secrets);
+    return e2b({
+      template,
+      create: { envs } as any,
+      timeoutMs,
+      autoPause,
     });
   }
 

--- a/services/runner/src/engines/sandbox_agent/run-plan.ts
+++ b/services/runner/src/engines/sandbox_agent/run-plan.ts
@@ -37,6 +37,11 @@ export const LOCAL_NETWORK_UNSUPPORTED_MESSAGE =
   "Network sandbox policy is not enforceable on the local sandbox (the sidecar runs on this " +
   "host with no egress control); run on daytona, or remove sandbox_permission.network.";
 
+/** A restricted `network` policy on E2B is not enforceable (the e2b provider exposes no egress control). */
+export const E2B_NETWORK_UNSUPPORTED_MESSAGE =
+  "Network sandbox policy is not enforceable on the e2b sandbox (the sandbox-agent/e2b " +
+  "provider exposes no egress control); run on daytona, or remove sandbox_permission.network.";
+
 /** `filesystem` confinement is declared on the wire but applied by no backend. */
 export const FILESYSTEM_UNSUPPORTED_MESSAGE =
   "Filesystem sandbox policy is not implemented (no backend applies a filesystem jail); " +
@@ -48,6 +53,9 @@ export interface RunPlan {
   sandboxId: string;
   isPi: boolean;
   isDaytona: boolean;
+  isE2B: boolean;
+  /** True for any remote sandbox (`isDaytona || isE2B`); use for remoteness-only checks. */
+  isRemoteSandbox: boolean;
   prompt: string;
   turnText: string;
   agentsMd?: string;
@@ -104,6 +112,7 @@ export interface BuildRunPlanDeps {
   sandboxProvider?: string;
   createLocalCwd?: (durableCwd?: string) => string;
   createDaytonaCwd?: (durableCwd?: string) => string;
+  createE2BCwd?: () => string;
   /** Pre-computed durable cwd derived from the sign prefix; when set, skips the ephemeral helpers. */
   durableCwd?: string;
   resolveSkillDirs?: typeof defaultResolveSkillDirs;
@@ -149,12 +158,17 @@ function defaultDaytonaCwd(durableCwd?: string): string {
   return durableCwd ?? `/home/sandbox/agenta-${randomBytes(6).toString("hex")}`;
 }
 
+function defaultE2BCwd(): string {
+  return `/root/work/agenta-${randomBytes(6).toString("hex")}`;
+}
+
 export function buildRunPlan(
   request: AgentRunRequest,
   {
     sandboxProvider = process.env.SANDBOX_AGENT_PROVIDER,
     createLocalCwd = defaultLocalCwd,
     createDaytonaCwd = defaultDaytonaCwd,
+    createE2BCwd = defaultE2BCwd,
     durableCwd,
     resolveSkillDirs = defaultResolveSkillDirs,
     log = () => {},
@@ -186,6 +200,8 @@ export function buildRunPlan(
 
   const isPi = acpAgent === "pi";
   const isDaytona = sandboxId === "daytona";
+  const isE2B = sandboxId === "e2b";
+  const isRemoteSandbox = isDaytona || isE2B;
 
   const secrets = request.secrets ?? {};
   const legacyHarnessApiKeyVar =
@@ -207,10 +223,14 @@ export function buildRunPlan(
 
   // A restricted `network` policy on the LOCAL sandbox cannot be enforced (the sidecar runs on
   // this host with no per-run egress control), so it errors regardless of `enforcement`. On
-  // Daytona the policy IS applied (`provider.ts` `daytonaNetworkFields`).
+  // Daytona the policy IS applied (`provider.ts` `daytonaNetworkFields`). E2B exposes no egress
+  // control in the sandbox-agent/e2b wrapper, so it is refused like local.
   const network = request.sandboxPermission?.network;
   const networkRestricted = !!network && (network.mode ?? "on") !== "on";
-  if (networkRestricted && !isDaytona) {
+  if (networkRestricted && isE2B) {
+    return { ok: false, error: E2B_NETWORK_UNSUPPORTED_MESSAGE };
+  }
+  if (networkRestricted && !isDaytona && !isE2B) {
     return { ok: false, error: LOCAL_NETWORK_UNSUPPORTED_MESSAGE };
   }
 
@@ -264,13 +284,23 @@ export function buildRunPlan(
     }
   }
 
-  const cwd = isDaytona ? createDaytonaCwd(durableCwd) : createLocalCwd(durableCwd);
+  const cwd = isDaytona
+    ? createDaytonaCwd(durableCwd)
+    : isE2B
+      ? createE2BCwd()
+      : createLocalCwd(durableCwd);
   // The tool-relay scratch (req/res JSON) is ephemeral runner<->child IPC, NOT durable session
   // data — keep it OFF the geesefs-mounted cwd. A relay dir inside the mount routes every tool
   // call through FUSE/S3, so a flaky mount surfaces as ENOTCONN on the relay file. Use an
   // ephemeral sibling: a plain host tmp dir (local) or an in-VM dir (daytona), never the mount.
-  const relayBase = isDaytona ? "/home/sandbox/agenta/relay" : join(tmpdir(), "agenta", "relay");
-  const relayDir = join(relayBase, basename(cwd));
+  // E2B's cwd is never geesefs-mounted and its relay is polled via the sandbox FS API, so it
+  // nests under the cwd.
+  const relayDir = isE2B
+    ? `${cwd}/.agenta-tools`
+    : join(
+        isDaytona ? "/home/sandbox/agenta/relay" : join(tmpdir(), "agenta", "relay"),
+        basename(cwd),
+      );
 
   // Skills materialize once from the resolved inline packages. Pi/Agenta consume the dirs
   // through Pi's agent-dir user scope; Claude consumes the same packages from the project-local
@@ -310,6 +340,8 @@ export function buildRunPlan(
       sandboxId,
       isPi,
       isDaytona,
+      isE2B,
+      isRemoteSandbox,
       prompt,
       turnText: buildTurnText(request),
       agentsMd: request.agentsMd?.trim() || undefined,

--- a/services/runner/src/engines/sandbox_agent/usage.ts
+++ b/services/runner/src/engines/sandbox_agent/usage.ts
@@ -6,12 +6,12 @@ import type { AgentRunResult, AgentUsage } from "../../protocol.ts";
 export async function readRunUsage(
   sandbox: any,
   path: string | undefined,
-  isDaytona: boolean,
+  isRemote: boolean,
 ): Promise<AgentRunResult["usage"]> {
   if (!path) return undefined;
   try {
     let raw: string;
-    if (isDaytona) {
+    if (isRemote) {
       const bytes = await sandbox.readFsFile({ path });
       raw = typeof bytes === "string" ? bytes : new TextDecoder().decode(bytes);
     } else {
@@ -43,18 +43,18 @@ export function mergePromptAndStreamUsage(
 export async function resolveRunUsage({
   sandbox,
   usageOutPath,
-  isDaytona,
+  isRemote,
   promptResult,
   streamUsage,
 }: {
   sandbox: any;
   usageOutPath: string | undefined;
-  isDaytona: boolean;
+  isRemote: boolean;
   promptResult: any;
   streamUsage: AgentUsage | undefined;
 }): Promise<AgentRunResult["usage"]> {
   return (
-    (await readRunUsage(sandbox, usageOutPath, isDaytona)) ??
+    (await readRunUsage(sandbox, usageOutPath, isRemote)) ??
     mergePromptAndStreamUsage(promptResult, streamUsage)
   );
 }

--- a/services/runner/src/engines/sandbox_agent/workspace.ts
+++ b/services/runner/src/engines/sandbox_agent/workspace.ts
@@ -1,5 +1,6 @@
 import { cpSync, mkdirSync, rmSync, writeFileSync } from "node:fs";
-import { dirname, join } from "node:path";
+import { dirname, join, resolve, sep } from "node:path";
+import { dirname as posixDirname, join as posixJoin, resolve as posixResolve } from "node:path/posix";
 
 import type { RunPlan } from "./run-plan.ts";
 import { uploadDirToSandbox } from "./pi-assets.ts";
@@ -14,7 +15,7 @@ export interface PrepareWorkspaceInput {
   sandbox: any;
   plan: Pick<
     RunPlan,
-    | "isDaytona"
+    | "isRemoteSandbox"
     | "isPi"
     | "cwd"
     | "relayDir"
@@ -25,6 +26,20 @@ export interface PrepareWorkspaceInput {
     | "skillDirs"
   >;
   log?: Log;
+}
+
+/** Rejects a harnessFile path that resolves outside `cwd` (e.g. `../escape`). */
+function assertContained(cwd: string, filePath: string, resolvedPath: string): void {
+  if (resolvedPath !== cwd && !resolvedPath.startsWith(cwd + sep)) {
+    throw new Error(`harnessFile path escapes workspace cwd: ${filePath}`);
+  }
+}
+
+/** Posix variant of `assertContained` for remote sandbox paths (always posix, regardless of host OS). */
+function assertContainedPosix(cwd: string, filePath: string, resolvedPath: string): void {
+  if (resolvedPath !== cwd && !resolvedPath.startsWith(cwd + "/")) {
+    throw new Error(`harnessFile path escapes workspace cwd: ${filePath}`);
+  }
 }
 
 /**
@@ -42,7 +57,7 @@ export async function prepareWorkspace({
   const harnessFiles = plan.harnessFiles ?? [];
   const projectSkillRoot = plan.isPi ? undefined : `.${plan.acpAgent}/skills`;
 
-  if (plan.isDaytona) {
+  if (plan.isRemoteSandbox) {
     await sandbox.mkdirFs({ path: plan.cwd }).catch((err: Error) => {
       log(`workspace mkdir skipped: ${err.message}`);
     });
@@ -55,8 +70,9 @@ export async function prepareWorkspace({
       await sandbox.writeFsFile({ path: `${plan.cwd}/AGENTS.md` }, plan.agentsMd);
     }
     for (const file of harnessFiles) {
-      const path = `${plan.cwd}/${file.path}`;
-      const parent = dirname(path);
+      const path = posixJoin(plan.cwd, file.path);
+      assertContainedPosix(posixResolve(plan.cwd), file.path, posixResolve(path));
+      const parent = posixDirname(path);
       await sandbox.mkdirFs({ path: parent }).catch((err: Error) => {
         log(`harness file dir mkdir skipped: ${err.message}`);
       });
@@ -80,6 +96,7 @@ export async function prepareWorkspace({
   if (plan.agentsMd) writeFileSync(join(plan.cwd, "AGENTS.md"), plan.agentsMd, "utf-8");
   for (const file of harnessFiles) {
     const path = join(plan.cwd, file.path);
+    assertContained(resolve(plan.cwd), file.path, resolve(path));
     mkdirSync(dirname(path), { recursive: true });
     writeFileSync(path, file.content, "utf-8");
   }

--- a/services/runner/tests/unit/sandbox-agent-codex-e2b.test.ts
+++ b/services/runner/tests/unit/sandbox-agent-codex-e2b.test.ts
@@ -1,0 +1,336 @@
+/**
+ * Unit tests for codex-specific E2B provisioning.
+ *
+ * Covers `uploadCodexAuthToE2BSandbox` (managed + self-managed), `prepareE2BCodexAssets`
+ * (both modes, CODEX_API_KEY fallback, no-op for non-codex), and the `!plan.isRemoteSandbox`
+ * gate on the local `writeCodexAuthFile` call.
+ *
+ * Run: pnpm test (or: pnpm exec vitest run tests/unit/sandbox-agent-codex-e2b.test.ts)
+ */
+import { afterEach, describe, it } from "vitest";
+import assert from "node:assert/strict";
+import { mkdtempSync, mkdirSync, rmSync, writeFileSync } from "node:fs";
+import { tmpdir } from "node:os";
+import { join } from "node:path";
+
+import {
+  E2B_CODEX_DIR,
+  prepareE2BCodexAssets,
+  uploadCodexAuthToE2BSandbox,
+} from "../../src/engines/sandbox_agent/e2b.ts";
+import { buildRunPlan } from "../../src/engines/sandbox_agent/run-plan.ts";
+import type { AgentRunRequest } from "../../src/protocol.ts";
+
+const dirs: string[] = [];
+afterEach(() => {
+  for (const dir of dirs.splice(0)) rmSync(dir, { recursive: true, force: true });
+});
+
+// ---------------------------------------------------------------------------
+// uploadCodexAuthToE2BSandbox — managed mode
+// ---------------------------------------------------------------------------
+
+describe("uploadCodexAuthToE2BSandbox", () => {
+  it("writes auth.json with OPENAI_API_KEY into the sandbox (managed)", async () => {
+    const written: Record<string, string> = {};
+    const mkdirs: string[] = [];
+    const sandbox = {
+      mkdirFs: ({ path }: { path: string }) => {
+        mkdirs.push(path);
+        return Promise.resolve();
+      },
+      writeFsFile: ({ path }: { path: string }, content: string) => {
+        written[path] = content;
+        return Promise.resolve();
+      },
+    };
+
+    await uploadCodexAuthToE2BSandbox(sandbox, "sk-e2b-test");
+
+    assert.equal(mkdirs.length, 1);
+    assert.match(mkdirs[0], /\.codex$/);
+    const authPath = `${mkdirs[0]}/auth.json`;
+    assert.ok(written[authPath], "auth.json was not written");
+    const parsed = JSON.parse(written[authPath]);
+    assert.equal(parsed.OPENAI_API_KEY, "sk-e2b-test");
+  });
+
+  it("logs and does not throw when mkdirFs rejects", async () => {
+    const logs: string[] = [];
+    const sandbox = {
+      mkdirFs: () => Promise.reject(new Error("E2B filesystem error")),
+      writeFsFile: () => Promise.resolve(),
+    };
+
+    await uploadCodexAuthToE2BSandbox(sandbox, "sk-test", (msg) => logs.push(msg));
+
+    assert.ok(
+      logs.some((l) => l.includes("codex auth.json upload skipped")),
+      `expected skip log, got: ${logs.join(", ")}`,
+    );
+  });
+
+  it("uploads local ~/.codex/auth.json when apiKey is undefined (self-managed)", async () => {
+    const fakeHome = mkdtempSync(join(tmpdir(), "agenta-e2b-codex-home-"));
+    dirs.push(fakeHome);
+    mkdirSync(join(fakeHome, ".codex"));
+    writeFileSync(join(fakeHome, ".codex", "auth.json"), '{"OPENAI_API_KEY":"sk-own"}', "utf-8");
+    const originalHome = process.env.HOME;
+    process.env.HOME = fakeHome;
+
+    const calls: Array<{ path: string; body?: string }> = [];
+    const sandbox = {
+      mkdirFs: async ({ path }: { path: string }) => calls.push({ path }),
+      writeFsFile: async ({ path }: { path: string }, body: string) => calls.push({ path, body }),
+    };
+
+    try {
+      await uploadCodexAuthToE2BSandbox(sandbox, undefined);
+    } finally {
+      if (originalHome === undefined) delete process.env.HOME;
+      else process.env.HOME = originalHome;
+    }
+
+    const writeCall = calls.find((c) => c.path === `${E2B_CODEX_DIR}/auth.json`);
+    assert.ok(writeCall, "auth.json must be uploaded from local home");
+    assert.equal(writeCall?.body, '{"OPENAI_API_KEY":"sk-own"}');
+  });
+
+  it("does nothing when apiKey is undefined and no local auth.json exists", async () => {
+    const emptyHome = mkdtempSync(join(tmpdir(), "agenta-e2b-empty-home-"));
+    dirs.push(emptyHome);
+    const originalHome = process.env.HOME;
+    process.env.HOME = emptyHome;
+
+    const calls: Array<{ path: string; body?: string }> = [];
+    const sandbox = {
+      mkdirFs: async ({ path }: { path: string }) => calls.push({ path }),
+      writeFsFile: async ({ path }: { path: string }, body: string) => calls.push({ path, body }),
+    };
+
+    try {
+      await uploadCodexAuthToE2BSandbox(sandbox, undefined);
+    } finally {
+      if (originalHome === undefined) delete process.env.HOME;
+      else process.env.HOME = originalHome;
+    }
+
+    assert.equal(
+      calls.some((c) => c.path === `${E2B_CODEX_DIR}/auth.json`),
+      false,
+      "no auth.json written when nothing to upload",
+    );
+  });
+});
+
+// ---------------------------------------------------------------------------
+// prepareE2BCodexAssets
+// ---------------------------------------------------------------------------
+
+describe("prepareE2BCodexAssets", () => {
+  function makeSandbox(): { calls: Array<{ path: string; body?: string }>; sandbox: any } {
+    const calls: Array<{ path: string; body?: string }> = [];
+    const sandbox = {
+      mkdirFs: async ({ path }: { path: string }) => calls.push({ path }),
+      writeFsFile: async ({ path }: { path: string }, body: string) => calls.push({ path, body }),
+    };
+    return { calls, sandbox };
+  }
+
+  it("is a no-op for non-codex runs", async () => {
+    const { calls, sandbox } = makeSandbox();
+
+    await prepareE2BCodexAssets({
+      sandbox,
+      plan: { acpAgent: "pi", credentialMode: "env", hasApiKey: true, secrets: {} },
+    });
+
+    assert.equal(calls.length, 0);
+  });
+
+  it("writes auth.json from the resolved key on a managed run", async () => {
+    const { calls, sandbox } = makeSandbox();
+
+    await prepareE2BCodexAssets({
+      sandbox,
+      plan: {
+        acpAgent: "codex",
+        credentialMode: "env",
+        hasApiKey: true,
+        secrets: { OPENAI_API_KEY: "sk-managed" },
+      },
+    });
+
+    const writeCall = calls.find((c) => c.path === `${E2B_CODEX_DIR}/auth.json`);
+    assert.ok(writeCall, "auth.json must be written for a managed run");
+    assert.equal(writeCall?.body, JSON.stringify({ OPENAI_API_KEY: "sk-managed" }));
+  });
+
+  it("prefers OPENAI_API_KEY over CODEX_API_KEY on a managed run", async () => {
+    const { calls, sandbox } = makeSandbox();
+
+    await prepareE2BCodexAssets({
+      sandbox,
+      plan: {
+        acpAgent: "codex",
+        credentialMode: "env",
+        hasApiKey: true,
+        secrets: { OPENAI_API_KEY: "sk-openai", CODEX_API_KEY: "sk-codex" },
+      },
+    });
+
+    const writeCall = calls.find((c) => c.path === `${E2B_CODEX_DIR}/auth.json`);
+    assert.ok(writeCall);
+    assert.equal(writeCall?.body, JSON.stringify({ OPENAI_API_KEY: "sk-openai" }));
+  });
+
+  it("falls back to CODEX_API_KEY when OPENAI_API_KEY is absent", async () => {
+    const { calls, sandbox } = makeSandbox();
+
+    await prepareE2BCodexAssets({
+      sandbox,
+      plan: {
+        acpAgent: "codex",
+        credentialMode: "env",
+        hasApiKey: true,
+        secrets: { CODEX_API_KEY: "sk-codex-only" },
+      },
+    });
+
+    const writeCall = calls.find((c) => c.path === `${E2B_CODEX_DIR}/auth.json`);
+    assert.ok(writeCall);
+    assert.equal(writeCall?.body, JSON.stringify({ OPENAI_API_KEY: "sk-codex-only" }));
+  });
+
+  it("does nothing on a managed run with no resolved key", async () => {
+    const { calls, sandbox } = makeSandbox();
+
+    await prepareE2BCodexAssets({
+      sandbox,
+      plan: {
+        acpAgent: "codex",
+        credentialMode: "env",
+        hasApiKey: false,
+        secrets: {},
+      },
+    });
+
+    assert.equal(
+      calls.some((c) => c.path === `${E2B_CODEX_DIR}/auth.json`),
+      false,
+      "no auth.json written when managed key is absent",
+    );
+  });
+
+  it("uploads local auth.json on a runtime_provided run", async () => {
+    const fakeHome = mkdtempSync(join(tmpdir(), "agenta-e2b-codex-rtprov-"));
+    dirs.push(fakeHome);
+    mkdirSync(join(fakeHome, ".codex"));
+    writeFileSync(join(fakeHome, ".codex", "auth.json"), '{"OPENAI_API_KEY":"sk-own"}', "utf-8");
+    const originalHome = process.env.HOME;
+    process.env.HOME = fakeHome;
+
+    const { calls, sandbox } = makeSandbox();
+    try {
+      await prepareE2BCodexAssets({
+        sandbox,
+        plan: {
+          acpAgent: "codex",
+          credentialMode: "runtime_provided",
+          hasApiKey: false,
+          secrets: {},
+        },
+      });
+    } finally {
+      if (originalHome === undefined) delete process.env.HOME;
+      else process.env.HOME = originalHome;
+    }
+
+    const writeCall = calls.find((c) => c.path === `${E2B_CODEX_DIR}/auth.json`);
+    assert.ok(writeCall, "auth.json must be uploaded on runtime_provided");
+    assert.equal(writeCall?.body, '{"OPENAI_API_KEY":"sk-own"}');
+  });
+
+  it("does not upload on a credentialMode=none run", async () => {
+    const { calls, sandbox } = makeSandbox();
+
+    await prepareE2BCodexAssets({
+      sandbox,
+      plan: {
+        acpAgent: "codex",
+        credentialMode: "none",
+        hasApiKey: false,
+        secrets: {},
+      },
+    });
+
+    assert.equal(
+      calls.some((c) => c.path === `${E2B_CODEX_DIR}/auth.json`),
+      false,
+    );
+  });
+});
+
+// ---------------------------------------------------------------------------
+// Local codex auth write is gated on !isRemoteSandbox
+// ---------------------------------------------------------------------------
+
+describe("codex auth.json write gating", () => {
+  it("codex+local plan sets isE2B=false and isRemoteSandbox=false (local write path applies)", () => {
+    const result = buildRunPlan(
+      {
+        harness: "codex",
+        sandbox: "local",
+        messages: [{ role: "user", content: "hi" }],
+        secrets: { OPENAI_API_KEY: "sk-local" },
+        credentialMode: "env",
+      } as AgentRunRequest,
+      { createLocalCwd: () => "/tmp/codex-local" },
+    );
+
+    assert.equal(result.ok, true);
+    if (!result.ok) return;
+    assert.equal(result.plan.isE2B, false);
+    assert.equal(result.plan.isRemoteSandbox, false);
+    assert.equal(result.plan.acpAgent, "codex");
+    assert.equal(result.plan.hasApiKey, true);
+  });
+
+  it("codex+e2b plan sets isE2B=true and isRemoteSandbox=true (sandbox upload path applies, not local write)", () => {
+    const result = buildRunPlan(
+      {
+        harness: "codex",
+        sandbox: "e2b",
+        messages: [{ role: "user", content: "hi" }],
+        secrets: { OPENAI_API_KEY: "sk-e2b" },
+        credentialMode: "env",
+      } as AgentRunRequest,
+      { createE2BCwd: () => "/root/work/agenta-abc" },
+    );
+
+    assert.equal(result.ok, true);
+    if (!result.ok) return;
+    assert.equal(result.plan.isE2B, true);
+    assert.equal(result.plan.isRemoteSandbox, true);
+    assert.equal(result.plan.acpAgent, "codex");
+    assert.equal(result.plan.hasApiKey, true);
+  });
+
+  it("daemon env carries OPENAI_API_KEY for codex (the only codex provider key)", () => {
+    const result = buildRunPlan(
+      {
+        harness: "codex",
+        sandbox: "e2b",
+        messages: [{ role: "user", content: "hi" }],
+        secrets: { OPENAI_API_KEY: "sk-e2b-codex" },
+        credentialMode: "env",
+      } as AgentRunRequest,
+      { createE2BCwd: () => "/root/work/agenta-abc" },
+    );
+
+    assert.equal(result.ok, true);
+    if (!result.ok) return;
+    assert.equal(result.plan.secrets.OPENAI_API_KEY, "sk-e2b-codex");
+    assert.equal(result.plan.secrets.ANTHROPIC_API_KEY, undefined);
+  });
+});

--- a/services/runner/tests/unit/sandbox-agent-e2b-provider.test.ts
+++ b/services/runner/tests/unit/sandbox-agent-e2b-provider.test.ts
@@ -1,0 +1,93 @@
+/**
+ * Unit tests for the E2B provider options and leak-backstop logic.
+ *
+ * `buildE2BCreate` is tested directly because the real `e2b()` provider constructs an
+ * E2B client (needs E2B_API_KEY), so it cannot be inspected through `buildSandboxProvider`.
+ *
+ * Run: pnpm test (or: pnpm exec vitest run tests/unit/sandbox-agent-e2b-provider.test.ts)
+ */
+import { afterEach, describe, it } from "vitest";
+import assert from "node:assert/strict";
+
+import {
+  DEFAULT_E2B_TIMEOUT_MS,
+  buildE2BCreate,
+  e2bTimeoutMs,
+} from "../../src/engines/sandbox_agent/provider.ts";
+
+const TIMEOUT_ENV = "E2B_TIMEOUT_MS";
+const previousTimeout = process.env[TIMEOUT_ENV];
+
+afterEach(() => {
+  if (previousTimeout === undefined) delete process.env[TIMEOUT_ENV];
+  else process.env[TIMEOUT_ENV] = previousTimeout;
+});
+
+describe("e2bTimeoutMs (leak backstop)", () => {
+  it("uses the env value when it is a positive integer", () => {
+    assert.equal(e2bTimeoutMs("60000"), 60000);
+  });
+
+  it("floors a fractional env value", () => {
+    assert.equal(e2bTimeoutMs("12000.9"), 12000);
+  });
+
+  it("falls back to the default when the env is unset", () => {
+    assert.equal(e2bTimeoutMs(undefined), DEFAULT_E2B_TIMEOUT_MS);
+  });
+
+  it("falls back to the default for a non-numeric env value", () => {
+    assert.equal(e2bTimeoutMs("soon"), DEFAULT_E2B_TIMEOUT_MS);
+  });
+
+  it("clamps 0 to the default so the backstop is never disabled", () => {
+    assert.equal(e2bTimeoutMs("0"), DEFAULT_E2B_TIMEOUT_MS);
+  });
+
+  it("clamps a negative value to the default", () => {
+    assert.equal(e2bTimeoutMs("-5000"), DEFAULT_E2B_TIMEOUT_MS);
+  });
+
+  it("the default is a positive backstop (never zero)", () => {
+    assert.ok(DEFAULT_E2B_TIMEOUT_MS >= 1);
+  });
+});
+
+describe("buildE2BCreate (leak backstop on the create object)", () => {
+  it("carries a positive timeoutMs + autoPause by default (self-reaps a leak)", () => {
+    delete process.env[TIMEOUT_ENV];
+    const create = buildE2BCreate({}, {});
+    assert.equal(create.timeoutMs, DEFAULT_E2B_TIMEOUT_MS);
+    assert.ok(create.timeoutMs > 0, "timeoutMs must be > 0 or the sandbox never self-reaps on process KILL");
+    assert.equal(create.autoPause, true);
+  });
+
+  it("carries the env-configured timeoutMs", () => {
+    process.env[TIMEOUT_ENV] = "120000";
+    const create = buildE2BCreate({}, {});
+    assert.equal(create.timeoutMs, 120000);
+    assert.equal(create.autoPause, true);
+  });
+
+  it("merges piExtEnv and secrets into envs", () => {
+    const create = buildE2BCreate(
+      { TRACEPARENT: "trace-id", OTEL_EXPORTER_OTLP_TRACES_ENDPOINT: "http://otel" },
+      { OPENAI_API_KEY: "sk-test" },
+    );
+    assert.deepEqual(create.envs, {
+      TRACEPARENT: "trace-id",
+      OTEL_EXPORTER_OTLP_TRACES_ENDPOINT: "http://otel",
+      OPENAI_API_KEY: "sk-test",
+    });
+  });
+
+  it("produces empty envs when no env or secrets are passed", () => {
+    const create = buildE2BCreate({}, {});
+    assert.deepEqual(create.envs, {});
+  });
+
+  it("codex key in secrets appears in create envs (daemon needs it at start)", () => {
+    const create = buildE2BCreate({}, { OPENAI_API_KEY: "sk-codex-key" });
+    assert.equal(create.envs.OPENAI_API_KEY, "sk-codex-key");
+  });
+});

--- a/services/runner/tests/unit/sandbox-agent-e2b-run-plan.test.ts
+++ b/services/runner/tests/unit/sandbox-agent-e2b-run-plan.test.ts
@@ -1,0 +1,214 @@
+/**
+ * Unit tests for E2B-specific run-plan normalization.
+ *
+ * Run: pnpm test (or: pnpm exec vitest run tests/unit/sandbox-agent-e2b-run-plan.test.ts)
+ */
+import { describe, it } from "vitest";
+import assert from "node:assert/strict";
+
+import type { AgentRunRequest } from "../../src/protocol.ts";
+import {
+  buildRunPlan,
+  E2B_NETWORK_UNSUPPORTED_MESSAGE,
+} from "../../src/engines/sandbox_agent/run-plan.ts";
+
+describe("buildRunPlan — E2B sandbox", () => {
+  it("sets isE2B and uses the E2B cwd factory", () => {
+    const result = buildRunPlan(
+      {
+        harness: "pi_core",
+        sandbox: "e2b",
+        messages: [{ role: "user", content: "hello" }],
+      } as AgentRunRequest,
+      { createE2BCwd: () => "/root/work/agenta-abc123" },
+    );
+
+    assert.equal(result.ok, true);
+    if (!result.ok) return;
+    assert.equal(result.plan.isE2B, true);
+    assert.equal(result.plan.isDaytona, false);
+    assert.equal(result.plan.isRemoteSandbox, true);
+    assert.equal(result.plan.sandboxId, "e2b");
+    assert.equal(result.plan.cwd, "/root/work/agenta-abc123");
+    assert.equal(result.plan.relayDir, "/root/work/agenta-abc123/.agenta-tools");
+  });
+
+  it("local runs have isE2B=false and isRemoteSandbox=false", () => {
+    const result = buildRunPlan(
+      {
+        harness: "pi_core",
+        sandbox: "local",
+        messages: [{ role: "user", content: "hello" }],
+      } as AgentRunRequest,
+      { createLocalCwd: () => "/tmp/local-cwd" },
+    );
+
+    assert.equal(result.ok, true);
+    if (!result.ok) return;
+    assert.equal(result.plan.isE2B, false);
+    assert.equal(result.plan.isRemoteSandbox, false);
+  });
+
+  it("daytona runs have isE2B=false and isRemoteSandbox=true", () => {
+    const result = buildRunPlan(
+      {
+        harness: "claude",
+        sandbox: "daytona",
+        messages: [{ role: "user", content: "hello" }],
+      } as AgentRunRequest,
+      { createDaytonaCwd: () => "/home/sandbox/agenta-fixed" },
+    );
+
+    assert.equal(result.ok, true);
+    if (!result.ok) return;
+    assert.equal(result.plan.isE2B, false);
+    assert.equal(result.plan.isDaytona, true);
+    assert.equal(result.plan.isRemoteSandbox, true);
+  });
+
+  it("refuses a restricted-network E2B run under strict (no egress control)", () => {
+    const result = buildRunPlan(
+      {
+        harness: "pi_core",
+        sandbox: "e2b",
+        messages: [{ role: "user", content: "hello" }],
+        sandboxPermission: {
+          network: { mode: "off" },
+          enforcement: "strict",
+        },
+      } as AgentRunRequest,
+      { createE2BCwd: () => "/root/work/agenta-abc123" },
+    );
+
+    assert.equal(result.ok, false);
+    if (result.ok) return;
+    assert.match(result.error, /not enforceable on the e2b sandbox/);
+  });
+
+  it("refuses a restricted-network E2B run even under best_effort (no silent unenforced boundary)", () => {
+    const result = buildRunPlan(
+      {
+        harness: "pi_core",
+        sandbox: "e2b",
+        messages: [{ role: "user", content: "hello" }],
+        sandboxPermission: {
+          network: { mode: "allowlist", allowlist: ["10.0.0.0/8"] },
+          enforcement: "best_effort",
+        },
+      } as AgentRunRequest,
+      { createE2BCwd: () => "/root/work/agenta-abc123" },
+    );
+
+    assert.equal(result.ok, false);
+    if (result.ok) return;
+    assert.match(result.error, /not enforceable on the e2b sandbox/);
+  });
+
+  it("the E2B refusal message is the E2B_NETWORK_UNSUPPORTED_MESSAGE constant", () => {
+    const result = buildRunPlan(
+      {
+        harness: "pi_core",
+        sandbox: "e2b",
+        messages: [{ role: "user", content: "hello" }],
+        sandboxPermission: { network: { mode: "off" }, enforcement: "strict" },
+      } as AgentRunRequest,
+      { createE2BCwd: () => "/root/work/agenta-abc123" },
+    );
+
+    assert.equal(result.ok, false);
+    if (result.ok) return;
+    assert.equal(result.error, E2B_NETWORK_UNSUPPORTED_MESSAGE);
+  });
+
+  it("allows an unrestricted (network: on) E2B run", () => {
+    const result = buildRunPlan(
+      {
+        harness: "pi_core",
+        sandbox: "e2b",
+        messages: [{ role: "user", content: "hello" }],
+        sandboxPermission: {
+          network: { mode: "on" },
+          enforcement: "strict",
+        },
+      } as AgentRunRequest,
+      { createE2BCwd: () => "/root/work/agenta-abc123" },
+    );
+
+    assert.equal(result.ok, true);
+  });
+
+  it("allows an E2B run with no sandbox permission", () => {
+    const result = buildRunPlan(
+      {
+        harness: "pi_core",
+        sandbox: "e2b",
+        messages: [{ role: "user", content: "hello" }],
+      } as AgentRunRequest,
+      { createE2BCwd: () => "/root/work/agenta-abc123" },
+    );
+
+    assert.equal(result.ok, true);
+  });
+});
+
+describe("buildRunPlan — codex on E2B", () => {
+  it("codex+e2b sets isE2B=true, acpAgent=codex, legacyHarnessApiKeyVar=OPENAI_API_KEY", () => {
+    const result = buildRunPlan(
+      {
+        harness: "codex",
+        sandbox: "e2b",
+        messages: [{ role: "user", content: "hello" }],
+        secrets: { OPENAI_API_KEY: "sk-test" },
+        credentialMode: "env",
+      } as AgentRunRequest,
+      { createE2BCwd: () => "/root/work/agenta-codex-abc" },
+    );
+
+    assert.equal(result.ok, true);
+    if (!result.ok) return;
+    assert.equal(result.plan.isE2B, true);
+    assert.equal(result.plan.isDaytona, false);
+    assert.equal(result.plan.isRemoteSandbox, true);
+    assert.equal(result.plan.isPi, false);
+    assert.equal(result.plan.acpAgent, "codex");
+    assert.equal(result.plan.harness, "codex");
+    assert.equal(result.plan.legacyHarnessApiKeyVar, "OPENAI_API_KEY");
+    assert.equal(result.plan.hasApiKey, true);
+    assert.equal(result.plan.cwd, "/root/work/agenta-codex-abc");
+    assert.equal(result.plan.usageOutPath, undefined);
+    assert.equal(result.plan.credentialMode, "env");
+  });
+
+  it("codex+e2b refuses a restricted-network run", () => {
+    const result = buildRunPlan(
+      {
+        harness: "codex",
+        sandbox: "e2b",
+        messages: [{ role: "user", content: "hello" }],
+        sandboxPermission: { network: { mode: "off" }, enforcement: "strict" },
+      } as AgentRunRequest,
+      { createE2BCwd: () => "/root/work/agenta-codex-abc" },
+    );
+
+    assert.equal(result.ok, false);
+    if (result.ok) return;
+    assert.equal(result.error, E2B_NETWORK_UNSUPPORTED_MESSAGE);
+  });
+
+  it("codex+local has isE2B=false and isRemoteSandbox=false (local path unaffected)", () => {
+    const result = buildRunPlan(
+      {
+        harness: "codex",
+        sandbox: "local",
+        messages: [{ role: "user", content: "hello" }],
+      } as AgentRunRequest,
+      { createLocalCwd: () => "/tmp/codex-local" },
+    );
+
+    assert.equal(result.ok, true);
+    if (!result.ok) return;
+    assert.equal(result.plan.isE2B, false);
+    assert.equal(result.plan.isRemoteSandbox, false);
+    assert.equal(result.plan.acpAgent, "codex");
+  });
+});

--- a/services/runner/tests/unit/sandbox-agent-run-plan.test.ts
+++ b/services/runner/tests/unit/sandbox-agent-run-plan.test.ts
@@ -77,6 +77,7 @@ describe("buildRunPlan", () => {
     assert.equal(result.plan.harness, "pi_agenta");
     assert.equal(result.plan.acpAgent, "pi");
     assert.equal(result.plan.sandboxId, "local");
+    assert.equal(result.plan.isRemoteSandbox, false);
     assert.equal(result.plan.cwd, "/tmp/local-cwd");
     // The relay dir + usage capture are ephemeral runner files kept OFF the (possibly geesefs)
     // cwd: an ephemeral sibling whose leaf is the cwd basename.
@@ -593,6 +594,7 @@ describe("buildRunPlan", () => {
     assert.equal(result.plan.acpAgent, "claude");
     assert.equal(result.plan.isPi, false);
     assert.equal(result.plan.isDaytona, true);
+    assert.equal(result.plan.isRemoteSandbox, true);
     assert.equal(result.plan.cwd, "/home/sandbox/agenta-fixed");
     assert.equal(result.plan.usageOutPath, undefined);
     assert.equal(result.plan.legacyHarnessApiKeyVar, "ANTHROPIC_API_KEY");

--- a/services/runner/tests/unit/sandbox-agent-usage.test.ts
+++ b/services/runner/tests/unit/sandbox-agent-usage.test.ts
@@ -72,7 +72,7 @@ describe("resolveRunUsage", () => {
       await resolveRunUsage({
         sandbox: {},
         usageOutPath: file,
-        isDaytona: false,
+        isRemote: false,
         promptResult: { usage: { inputTokens: 99, outputTokens: 99 } },
         streamUsage: { input: 0, output: 0, total: 0, cost: 1 },
       }),

--- a/services/runner/tests/unit/sandbox-agent-workspace.test.ts
+++ b/services/runner/tests/unit/sandbox-agent-workspace.test.ts
@@ -30,7 +30,7 @@ describe("prepareWorkspace", () => {
     const workspace = await prepareWorkspace({
       sandbox: {},
       plan: {
-        isDaytona: false,
+        isRemoteSandbox: false,
         cwd,
         relayDir: join(cwd, ".agenta-tools"),
         useToolRelay: true,
@@ -69,7 +69,7 @@ describe("prepareWorkspace", () => {
     const workspace = await prepareWorkspace({
       sandbox: {},
       plan: {
-        isDaytona: false,
+        isRemoteSandbox: false,
         cwd,
         relayDir: join(cwd, ".agenta-tools"),
         useToolRelay: false,
@@ -95,7 +95,7 @@ describe("prepareWorkspace", () => {
     await prepareWorkspace({
       sandbox: {},
       plan: {
-        isDaytona: false,
+        isRemoteSandbox: false,
         cwd,
         relayDir: join(cwd, ".agenta-tools"),
         useToolRelay: false,
@@ -120,7 +120,7 @@ describe("prepareWorkspace", () => {
     const workspace = await prepareWorkspace({
       sandbox,
       plan: {
-        isDaytona: true,
+        isRemoteSandbox: true,
         cwd: "/home/sandbox/agenta-fixed",
         relayDir: "/home/sandbox/agenta-fixed/.agenta-tools",
         useToolRelay: true,
@@ -155,7 +155,7 @@ describe("prepareWorkspace", () => {
     await prepareWorkspace({
       sandbox,
       plan: {
-        isDaytona: true,
+        isRemoteSandbox: true,
         cwd: "/home/sandbox/agenta-fixed",
         relayDir: "/home/sandbox/agenta-fixed/.agenta-tools",
         useToolRelay: false,
@@ -193,7 +193,7 @@ describe("prepareWorkspace", () => {
     await prepareWorkspace({
       sandbox,
       plan: {
-        isDaytona: true,
+        isRemoteSandbox: true,
         cwd: "/home/sandbox/agenta-fixed",
         relayDir: "/home/sandbox/agenta-fixed/.agenta-tools",
         useToolRelay: false,
@@ -219,7 +219,7 @@ describe("prepareWorkspace", () => {
     await prepareWorkspace({
       sandbox: {},
       plan: {
-        isDaytona: false,
+        isRemoteSandbox: false,
         cwd,
         relayDir: join(cwd, ".agenta-tools"),
         useToolRelay: false,
@@ -251,7 +251,7 @@ describe("prepareWorkspace", () => {
     await prepareWorkspace({
       sandbox,
       plan: {
-        isDaytona: true,
+        isRemoteSandbox: true,
         cwd: "/home/sandbox/agenta-fixed",
         relayDir: "/home/sandbox/agenta-fixed/.agenta-tools",
         useToolRelay: false,
@@ -269,6 +269,185 @@ describe("prepareWorkspace", () => {
             "/home/sandbox/agenta-fixed/.claude/skills/release-notes/SKILL.md",
       ),
       "SKILL.md is uploaded to Claude's project-local skill tree",
+    );
+  });
+
+  it("prepares an E2B cwd through the sandbox fs API (same path as Daytona)", async () => {
+    const calls: Array<{ op: "mkdir" | "write"; path: string; body?: string }> = [];
+    const sandbox = {
+      mkdirFs: async ({ path }: { path: string }) => calls.push({ op: "mkdir", path }),
+      writeFsFile: async ({ path }: { path: string }, body: string) =>
+        calls.push({ op: "write", path, body }),
+    };
+
+    const workspace = await prepareWorkspace({
+      sandbox,
+      plan: {
+        isRemoteSandbox: true,
+        cwd: "/root/work/agenta-e2btest",
+        relayDir: "/root/work/agenta-e2btest/.agenta-tools",
+        useToolRelay: true,
+        agentsMd: "agent instructions",
+        acpAgent: "claude",
+        isPi: false,
+        skillDirs: [],
+      },
+    });
+    await workspace.cleanup();
+
+    assert.deepEqual(calls, [
+      { op: "mkdir", path: "/root/work/agenta-e2btest" },
+      { op: "mkdir", path: "/root/work/agenta-e2btest/.agenta-tools" },
+      {
+        op: "write",
+        path: "/root/work/agenta-e2btest/AGENTS.md",
+        body: "agent instructions",
+      },
+    ]);
+  });
+
+  it("writes a nested harnessFiles entry on E2B via the fs API", async () => {
+    const calls: Array<{ op: "mkdir" | "write"; path: string; body?: string }> = [];
+    const sandbox = {
+      mkdirFs: async ({ path }: { path: string }) => calls.push({ op: "mkdir", path }),
+      writeFsFile: async ({ path }: { path: string }, body: string) =>
+        calls.push({ op: "write", path, body }),
+    };
+    const content = JSON.stringify(
+      { permissions: { defaultMode: "acceptEdits", deny: ["WebFetch"] } },
+      null,
+      2,
+    );
+
+    await prepareWorkspace({
+      sandbox,
+      plan: {
+        isRemoteSandbox: true,
+        cwd: "/root/work/agenta-e2btest",
+        relayDir: "/root/work/agenta-e2btest/.agenta-tools",
+        useToolRelay: false,
+        agentsMd: undefined,
+        acpAgent: "claude",
+        isPi: false,
+        harnessFiles: [{ path: ".claude/settings.json", content }],
+        skillDirs: [],
+      },
+    });
+
+    const claudeDir = calls.find(
+      (c) => c.op === "mkdir" && c.path === "/root/work/agenta-e2btest/.claude",
+    );
+    assert.ok(claudeDir, ".claude dir is created via the fs API on E2B");
+    const write = calls.find(
+      (c) =>
+        c.op === "write" && c.path === "/root/work/agenta-e2btest/.claude/settings.json",
+    );
+    assert.ok(write, "settings.json is written via the fs API on E2B");
+    assert.equal(write!.body, content);
+  });
+
+  it("uploads Claude skills into the project-local .claude/skills tree on E2B", async () => {
+    const calls: Array<{ op: "mkdir" | "write"; path: string; body?: string }> = [];
+    const skillDir = tempDir();
+    writeFileSync(join(skillDir, "SKILL.md"), "skill-content", "utf-8");
+    const sandbox = {
+      mkdirFs: async ({ path }: { path: string }) => calls.push({ op: "mkdir", path }),
+      writeFsFile: async ({ path }: { path: string }, body: string) =>
+        calls.push({ op: "write", path, body }),
+    };
+
+    await prepareWorkspace({
+      sandbox,
+      plan: {
+        isRemoteSandbox: true,
+        cwd: "/root/work/agenta-e2btest",
+        relayDir: "/root/work/agenta-e2btest/.agenta-tools",
+        useToolRelay: false,
+        acpAgent: "claude",
+        isPi: false,
+        skillDirs: [{ name: "my-skill", dir: skillDir }],
+      },
+    });
+
+    assert.ok(
+      calls.some(
+        (c) =>
+          c.op === "write" &&
+          c.path === "/root/work/agenta-e2btest/.claude/skills/my-skill/SKILL.md",
+      ),
+      "SKILL.md is uploaded to Claude's project-local skill tree on E2B",
+    );
+  });
+
+  it("writes no harness file on E2B for a plan with no harnessFiles", async () => {
+    const calls: Array<{ op: "mkdir" | "write"; path: string; body?: string }> = [];
+    const sandbox = {
+      mkdirFs: async ({ path }: { path: string }) => calls.push({ op: "mkdir", path }),
+      writeFsFile: async ({ path }: { path: string }, body: string) =>
+        calls.push({ op: "write", path, body }),
+    };
+
+    await prepareWorkspace({
+      sandbox,
+      plan: {
+        isRemoteSandbox: true,
+        cwd: "/root/work/agenta-e2btest",
+        relayDir: "/root/work/agenta-e2btest/.agenta-tools",
+        useToolRelay: false,
+        acpAgent: "pi",
+        isPi: true,
+        skillDirs: [],
+      },
+    });
+
+    assert.ok(
+      !calls.some((c) => c.path.includes(".claude")),
+      "no .claude path is touched on a Pi-on-E2B run",
+    );
+  });
+
+  it("rejects a harnessFiles path-traversal escape for a local run", async () => {
+    const cwd = tempDir();
+
+    await assert.rejects(
+      prepareWorkspace({
+        sandbox: {},
+        plan: {
+          isRemoteSandbox: false,
+          cwd,
+          relayDir: join(cwd, ".agenta-tools"),
+          useToolRelay: false,
+          acpAgent: "claude",
+          isPi: false,
+          harnessFiles: [{ path: "../escape", content: "evil" }],
+          skillDirs: [],
+        },
+      }),
+      /escapes workspace cwd/,
+    );
+  });
+
+  it("rejects a harnessFiles path-traversal escape for a remote sandbox run", async () => {
+    const sandbox = {
+      mkdirFs: async () => {},
+      writeFsFile: async () => {},
+    };
+
+    await assert.rejects(
+      prepareWorkspace({
+        sandbox,
+        plan: {
+          isRemoteSandbox: true,
+          cwd: "/root/work/agenta-e2btest",
+          relayDir: "/root/work/agenta-e2btest/.agenta-tools",
+          useToolRelay: false,
+          acpAgent: "claude",
+          isPi: false,
+          harnessFiles: [{ path: "../escape", content: "evil" }],
+          skillDirs: [],
+        },
+      }),
+      /escapes workspace cwd/,
     );
   });
 });

--- a/services/runner/tests/unit/session-mcp-layering.test.ts
+++ b/services/runner/tests/unit/session-mcp-layering.test.ts
@@ -57,6 +57,7 @@ describe("buildSessionMcpServers layering (do-not-merge regression guard)", () =
   it("(a) gateway tools + no user MCP -> internal channel present, no throw", async () => {
     const { servers } = await build({
       isPi: false,
+      isRemote: false,
       isDaytona: false,
       capabilities: mcpCapable,
       harness: "claude",
@@ -84,6 +85,7 @@ describe("buildSessionMcpServers layering (do-not-merge regression guard)", () =
       () =>
         buildSessionMcpServers({
           isPi: false,
+          isRemote: false,
           isDaytona: false,
           capabilities: mcpCapable,
           harness: "claude",
@@ -99,6 +101,7 @@ describe("buildSessionMcpServers layering (do-not-merge regression guard)", () =
   it("(c) gateway tools + user http MCP -> BOTH delivered; user stdio still refused", async () => {
     const { servers } = await build({
       isPi: false,
+      isRemote: false,
       isDaytona: false,
       capabilities: mcpCapable,
       harness: "claude",
@@ -126,6 +129,7 @@ describe("buildSessionMcpServers layering (do-not-merge regression guard)", () =
       () =>
         buildSessionMcpServers({
           isPi: false,
+          isRemote: false,
           isDaytona: false,
           capabilities: mcpCapable,
           harness: "claude",
@@ -140,6 +144,7 @@ describe("buildSessionMcpServers layering (do-not-merge regression guard)", () =
   it("Pi gets [] (native delivery, no MCP channel) even with gateway tools", async () => {
     const { servers } = await build({
       isPi: true,
+      isRemote: false,
       isDaytona: false,
       capabilities: mcpCapable,
       harness: "pi_agenta",
@@ -156,6 +161,7 @@ describe("buildSessionMcpServers layering (do-not-merge regression guard)", () =
   it("a non-MCP harness gets [] (capability gate), no internal server started", async () => {
     const { servers } = await build({
       isPi: false,
+      isRemote: false,
       isDaytona: false,
       capabilities: { mcpTools: false, toolCalls: false },
       harness: "no-mcp",
@@ -168,6 +174,7 @@ describe("buildSessionMcpServers layering (do-not-merge regression guard)", () =
   it("the internal channel advertisement carries no credential (server-side invariant)", async () => {
     const { servers } = await build({
       isPi: false,
+      isRemote: false,
       isDaytona: false,
       capabilities: mcpCapable,
       harness: "claude",
@@ -194,6 +201,7 @@ describe("buildSessionMcpServers layering (do-not-merge regression guard)", () =
     // Finding-1 regression guard.
     const { servers } = await build({
       isPi: false,
+      isRemote: true,
       isDaytona: true,
       capabilities: mcpCapable,
       harness: "claude",
@@ -217,6 +225,7 @@ describe("buildSessionMcpServers layering (do-not-merge regression guard)", () =
     // delivered on Daytona unchanged.
     const { servers } = await build({
       isPi: false,
+      isRemote: true,
       isDaytona: true,
       capabilities: mcpCapable,
       harness: "claude",


### PR DESCRIPTION
## Context
With Codex working locally and E2B established as a sandbox provider (in the sibling `chore/add-sandbox-e2b` branch, built for Pi), Codex needed its own E2B-side wiring: auth-file upload, provider options, and MCP relay support.

## Changes
Adds Codex E2B asset prep and auth upload in `e2b.ts`, extends `provider.ts` and `run-plan.ts` for the Codex x E2B combination, and carries forward the `mcp.ts`/`workspace.ts`/`usage.ts` E2B plumbing needed for a second harness to reuse the same sandbox provider.

## Tests / notes
- New coverage: `sandbox-agent-codex-e2b.test.ts`, plus updates to `sandbox-agent-e2b-provider.test.ts`, `sandbox-agent-e2b-run-plan.test.ts`, `sandbox-agent-workspace.test.ts`.
- Base is `chore/add-harness-codex`, not `big-agents`. This branch was developed in parallel with `chore/add-sandbox-e2b`; expect the E2B plumbing here to converge with that branch's canonical version during the merge pass.
- Codex-on-E2B runs with tools will hit the loud-refuse gate from `chore/add-remote-tools-gate` until the relay-client shim lands.