### PR TITLE
[chore] Add OpenCode on Daytona sandbox

### DIFF
--- a/docs/design/agent-workflows/projects/add-opencode-daytona/research.md
+++ b/docs/design/agent-workflows/projects/add-opencode-daytona/research.md
@@ -1,0 +1,104 @@
+# OpenCode on Daytona — investigation
+
+## Goal
+
+Make `harness="opencode"` run on the **Daytona** sandbox (remote). The opencode-local work
+(`chore/add-harness-opencode`) is the base — `OpencodeHarness`, `HarnessType.OPENCODE`,
+`OpencodeAgentTemplate`, the `opencode→opencode` ACP agent map, and the `planMode:false`
+static fallback all exist. This worktree adds the remote-sandbox axis.
+
+## How Pi-on-Daytona works (the pattern to clone)
+
+`services/agent/src/engines/sandbox_agent/daytona.ts` has two responsibilities:
+
+1. **`daytonaEnvVars(piExtEnv, secrets)`** — builds the env injected into the Daytona daemon at
+   sandbox-create time. It spreads `piExtEnv` (Pi extension vars: traceparent, OTLP, relay dir)
+   and `secrets` (provider API keys). This is called by `buildDaytonaCreate` in `provider.ts`,
+   which passes it to `daytona({ create: … })`. The env is **harness-agnostic**: the `secrets`
+   spread already puts `OPENAI_API_KEY` or `ANTHROPIC_API_KEY` into the daemon env for every
+   harness, not just Pi.
+
+2. **`prepareDaytonaPiAssets({ sandbox, plan })`** — runs after the sandbox starts and
+   BEFORE `createSession`. It uploads the Pi auth fallback, the Agenta extension bundle,
+   skill dirs, and system prompts into the sandbox via the filesystem API, then optionally
+   installs the Pi CLI (`npm install @earendil-works/pi-coding-agent`). It **early-returns on
+   `!plan.isPi`**, so any non-Pi harness skips it entirely today.
+
+For opencode the relevant question is: what does `prepareDaytonaPiAssets` do that opencode
+needs on Daytona? Answer: nothing. The daemon auto-installs opencode from a GitHub release
+binary zip at `createSession` time (the same auto-install that runs on local). The provider
+key is already in the daemon env from `daytonaEnvVars`. No auth file, no extension bundle,
+no skill dir upload is needed.
+
+## The credential story (plain managed provider key)
+
+opencode accepts both provider families (anthropic + openai) with `provider/model`-prefixed
+ids. Zen is a third-party hosted gateway; the daemon's Zen layer is experimental/disabled.
+The credential is simply a plain provider key (`OPENAI_API_KEY` or `ANTHROPIC_API_KEY`) in
+the sandbox env. The `secrets` spread in `daytonaEnvVars` already delivers it. No new
+`KNOWN_PROVIDER_ENV_VARS` entry, no auth file, no new clear-set variable.
+
+## The arch gotcha
+
+The daemon's `install_opencode` (`agent_manager.install_opencode` / `install_zip_binary`)
+fetches the GitHub release zip for the CURRENT system arch at install time. On a **dev host
+that is arm64 and a Daytona sandbox image that is also arm64**, this is correct and works.
+On a **dev host that is x64 and a Daytona sandbox image that is arm64** (uncommon but possible
+with cross-arch Daytona targets), the binary would be wrong.
+
+The PoC documented a `SIGTRAP` (`rosetta error … ld-linux-x86-64.so.2`) when the daemon
+on an arm64 sandbox installed the linux-x64 binary. The fix in the PoC was: after the
+failed install, overwrite `bin/opencode` and `bin/agent_processes/opencode/opencode` with
+the correct-arch release from `anomalyco/opencode`.
+
+**Runner disposition**: the runner cannot know the sandbox image's arch at create time
+without a sandbox probe. The correct fix is at the **sandbox image / snapshot** level: bake
+a snapshot with the correct-arch opencode binary pre-installed, or set an env override that
+tells the daemon which arch to fetch. The runner exports an override env var
+`AGENTA_AGENT_SANDBOX_OPENCODE_ARCH` that — when set — forces the in-sandbox arch string the
+daemon uses, e.g. `linux-arm64`. `daytonaEnvVars` injects it only when `acpAgent === "opencode"`
+(see `daytona.ts` `opencodeArchEnv`). On real x64 cloud Daytona, the arch matches and no
+override is needed. On a dev machine with an arm64 Daytona target, set
+`AGENTA_AGENT_SANDBOX_OPENCODE_ARCH=linux-arm64`.
+
+## Why the runner code change is minimal
+
+`sandbox_agent.ts` already calls `prepareDaytonaPiAssets({ sandbox, plan })` inside the
+`if (plan.isDaytona)` block. For non-Pi harnesses that block was a no-op (Pi guard returns
+early). The change: rename the call site to also call a new
+`prepareDaytonaOpencodeAssets({ sandbox, plan })` for the opencode case. For opencode,
+this function injects the arch override env and is otherwise a no-op. The Pi path is
+unchanged.
+
+## Foundation seam
+
+A "foundation" worktree (`chore/add-foundation-remote-bootstrap`) is generalizing the
+non-Pi remote bootstrap. The current code structure has two seams:
+
+1. `prepareDaytonaPiAssets` handles Pi-specific uploads.
+2. The new `prepareDaytonaOpencodeAssets` handles the opencode case (arch override only).
+
+When the foundation lands, these fold onto a single `prepareDaytonaHarnessAssets(sandbox,
+plan)` dispatcher that routes on `plan.acpAgent`. The interface is already there.
+
+## planMode: false
+
+Preserved. `capabilities.ts` static fallback already sets `planMode: false` for opencode,
+and the daemon skips `session/set_mode` for it. Nothing changes on Daytona.
+
+## anomalyco/opencode is OFFICIAL
+
+`anomalyco/opencode` is OpenCode's official repository (anomaly.co is the company behind
+OpenCode). It is never a fork. The binary zip the daemon fetches comes from this official
+release.
+
+## Files to touch
+
+- `services/agent/src/engines/sandbox_agent/daytona.ts` — add `opencodeArchEnv()` and
+  `prepareDaytonaOpencodeAssets(...)`; gate arch override in `daytonaEnvVars` on `acpAgent`.
+- `services/agent/src/engines/sandbox_agent.ts` — call the new function in the
+  `if (plan.isDaytona)` block.
+- `services/agent/tests/unit/sandbox-agent-daytona.test.ts` — tests for the new function
+  and the arch override.
+- `docs/design/agent-workflows/projects/add-opencode-daytona/` — this research, specs,
+  tasks.

--- a/docs/design/agent-workflows/projects/add-opencode-daytona/specs.md
+++ b/docs/design/agent-workflows/projects/add-opencode-daytona/specs.md
@@ -1,0 +1,63 @@
+# OpenCode on Daytona — specs
+
+## Scope
+
+In: `harness="opencode"` on the `sandbox="daytona"` sandbox. Out: any changes to the wire
+contract, the Python SDK, the local sandbox path, or the Pi-on-Daytona path.
+
+## Behavior
+
+- A `/run` request with `harness="opencode"` and `sandbox="daytona"` provisions a Daytona
+  sandbox that carries the managed provider key (`OPENAI_API_KEY` or `ANTHROPIC_API_KEY`)
+  in the daemon env. The daemon auto-installs opencode from the official `anomalyco/opencode`
+  GitHub release binary zip at `createSession` time; no extra provisioning by the runner.
+- `planMode` stays **false** on Daytona (unchanged from local; the daemon skips
+  `session/set_mode` for opencode regardless of sandbox).
+- The arch override env var `AGENTA_AGENT_SANDBOX_OPENCODE_ARCH` — when set in the runner's
+  environment — is injected into the Daytona daemon env so the daemon fetches the correct-arch
+  opencode binary. On real x64 cloud Daytona this is a no-op (default arch matches). On a dev
+  machine targeting an arm64 Daytona snapshot, set `AGENTA_AGENT_SANDBOX_OPENCODE_ARCH=linux-arm64`.
+- The cookie fetch (`createCookieFetch`) is used on Daytona for all harnesses (unchanged).
+- Pi-on-Daytona is entirely unchanged.
+
+## Contracts
+
+- Wire unchanged; the `harness` field is a free string.
+- No new Python SDK changes; `OpencodeAgentTemplate.wire()` already sets
+  `sandbox="daytona"` as a string, and the runner reads it.
+- No new Python harness or capability changes; `HARNESS_CONNECTION_CAPABILITIES["opencode"]`
+  is already complete.
+
+## Decisions — LOCKED
+
+1. **No auth file upload for opencode.** The credential is a plain managed provider key in
+   the daemon env. No `~/.opencode/auth.json` or equivalent. The `credentialMode="env"` path
+   never uploads a fallback file.
+2. **The arch override is a runner env var, not a per-request wire field.** It is a deploy
+   concern (which Daytona snapshot is in use), not a per-run API concern.
+3. **anomalyco/opencode is the official OpenCode, never a fork.** The daemon fetches from
+   there. We never fork, copy, or re-host opencode.
+4. **No new `KNOWN_PROVIDER_ENV_VARS` entry.** `OPENAI_API_KEY` and `ANTHROPIC_API_KEY` are
+   already in the clear set.
+
+## Non-goals / invariants
+
+- Pi-on-Daytona: unchanged.
+- `daytonaEnvVars` gains an `acpAgent` parameter; the arch override is gated on
+  `acpAgent === "opencode"` inline. No separate helper function.
+- Local sandbox path for opencode: unchanged.
+- No codex, claude, or other harness on Daytona is in scope.
+
+## Acceptance
+
+- Unit (no live daemon):
+  - `prepareDaytonaOpencodeAssets` calls nothing on the sandbox (opencode needs no uploads).
+  - When `AGENTA_AGENT_SANDBOX_OPENCODE_ARCH` is set and `acpAgent === "opencode"`,
+    `daytonaEnvVars` injects it; when unset or for any other harness, it is absent.
+  - `prepareDaytonaPiAssets` is not called for an opencode plan (`isPi=false`).
+  - `planMode` is false in the static fallback for `opencode` (already tested in capabilities
+    tests; no new test needed).
+- Integration (requires a live Daytona daemon with the sandbox-agent daemon binary and a
+  Daytona API key; marked `@requires-live-daemon`):
+  - An opencode-on-Daytona run returns output and a trace with `harness="opencode"`.
+  - Only the resolved provider key is present in the sandbox; no Zen or auth-file artefact.

--- a/docs/design/agent-workflows/projects/add-opencode-daytona/tasks.md
+++ b/docs/design/agent-workflows/projects/add-opencode-daytona/tasks.md
@@ -1,0 +1,59 @@
+# OpenCode on Daytona — tasks
+
+## T1 — Extend daytona.ts
+
+`services/agent/src/engines/sandbox_agent/daytona.ts`
+
+- Add `opencodeArchEnvVar()` — reads `AGENTA_AGENT_SANDBOX_OPENCODE_ARCH`; returns the
+  env-var name+value pair or `{}`.
+- Add `prepareDaytonaOpencodeAssets({ sandbox, plan, log })` — documented no-op for uploads
+  (daemon auto-installs the binary at createSession); injects arch override into sandbox env
+  if the var is set. Returns the env additions so `sandbox_agent.ts` can merge them.
+- Export from `daytona.ts`; import in `sandbox_agent.ts`.
+
+Status: DONE
+
+## T2 — Call from sandbox_agent.ts
+
+`services/agent/src/engines/sandbox_agent.ts`
+
+In the `if (plan.isDaytona)` block (line ~302), after `prepareDaytonaPiAssets`:
+
+- Call `prepareDaytonaOpencodeAssets` when `plan.acpAgent === "opencode"`.
+
+Status: DONE
+
+## T3 — Unit tests
+
+`services/agent/tests/unit/sandbox-agent-daytona.test.ts`
+
+- `prepareDaytonaOpencodeAssets` makes no sandbox calls for a minimal opencode plan.
+- When `AGENTA_AGENT_SANDBOX_OPENCODE_ARCH` is set, the returned env carries it.
+- When unset, the returned env does not carry it.
+- A Pi plan still goes through `prepareDaytonaPiAssets` (existing test coverage; no change).
+
+Status: DONE
+
+## T4 — Design docs
+
+`docs/design/agent-workflows/projects/add-opencode-daytona/`
+
+- `research.md` — the Pi-on-Daytona pattern, credential story, arch gotcha, foundation seam.
+- `specs.md` — scope, behavior, decisions, acceptance criteria.
+- `tasks.md` — this file.
+
+Status: DONE
+
+## Foundation seam note
+
+When `chore/add-foundation-remote-bootstrap` lands, the two per-harness Daytona-prep calls
+(`prepareDaytonaPiAssets` + `prepareDaytonaOpencodeAssets`) fold into a single
+`prepareDaytonaHarnessAssets(sandbox, plan)` dispatcher. The interface here already anticipates
+that shape — `prepareDaytonaOpencodeAssets` takes the same `{ sandbox, plan, log }` signature
+as `prepareDaytonaPiAssets`.
+
+## Decisions resolved
+
+- **Arch override delivery**: RESOLVED — the override is injected into `buildDaytonaCreate`
+  (create-env path). The daemon reads arch at `createSession` time, so create-env is correct.
+  No post-start `runProcess` injection is needed.

--- a/services/runner/src/engines/sandbox_agent.ts
+++ b/services/runner/src/engines/sandbox_agent.ts
@@ -55,6 +55,7 @@ import { createAcpFetch } from "./sandbox_agent/acp-fetch.ts";
 import { buildDaemonEnv, resolveDaemonBinary } from "./sandbox_agent/daemon.ts";
 import {
   createCookieFetch,
+  prepareDaytonaOpencodeAssets,
   prepareDaytonaPiAssets,
 } from "./sandbox_agent/daytona.ts";
 import { conciseError } from "./sandbox_agent/errors.ts";
@@ -211,6 +212,7 @@ export interface SandboxAgentDeps extends BuildRunPlanDeps {
   createCookieFetch?: typeof createCookieFetch;
   createAcpFetch?: typeof createAcpFetch;
   prepareWorkspace?: typeof prepareWorkspace;
+  prepareDaytonaOpencodeAssets?: typeof prepareDaytonaOpencodeAssets;
   probeCapabilities?: typeof probeCapabilities;
   applyModel?: typeof applyModel;
   startToolRelay?: typeof startToolRelay;
@@ -441,6 +443,7 @@ export async function runSandboxAgent(
     sandbox = await startSandboxAgent({
       sandbox: (deps.buildSandboxProvider ?? buildSandboxProvider)(
         plan.sandboxId,
+        plan.acpAgent,
         env,
         binaryPath,
         piExtEnv,
@@ -465,11 +468,17 @@ export async function runSandboxAgent(
     // normal exit so it is never double-deleted.
     if (sandbox) inFlightSandboxes.add(sandbox);
 
-    // On Daytona, push the harness login, the extension, and AGENTS.md into the remote
-    // sandbox via the filesystem API (nothing secret is baked into the image). Locally
-    // these use the host filesystem and the harness's own login (PI_CODING_AGENT_DIR).
+    // On Daytona, prepare harness-specific remote assets before createSession. Pi uploads its
+    // auth fallback, extension bundle, skills, and installs the CLI. Opencode needs no uploads
+    // (daemon auto-installs the binary; provider key rides the create env); the call is a named
+    // seam that logs the arch override when set and folds cleanly onto the foundation bootstrap.
     if (plan.isDaytona) {
       await prepareDaytonaPiAssets({ sandbox, plan, log: logger });
+      await (deps.prepareDaytonaOpencodeAssets ?? prepareDaytonaOpencodeAssets)({
+        sandbox,
+        plan,
+        log: logger,
+      });
     }
 
     // Durable cwd: reuse the pre-signed creds (signed before buildRunPlan so the prefix drove the

--- a/services/runner/src/engines/sandbox_agent/daytona.ts
+++ b/services/runner/src/engines/sandbox_agent/daytona.ts
@@ -24,11 +24,34 @@ export const DAYTONA_PI_INSTALL =
 export const DAYTONA_PI_VERSION = process.env.AGENTA_AGENT_SANDBOX_PI_VERSION ?? "0.79.4";
 
 /**
+ * Arch override the daemon uses when fetching the opencode binary zip from
+ * `anomalyco/opencode` releases. The daemon defaults to the sandbox image's own arch;
+ * override with e.g. `linux-arm64` when the image is arm64 but the daemon's default
+ * detection picks x64 (a known SIGTRAP on arm64 Daytona targets from the PoC). Unset on
+ * real x64 cloud Daytona where the default is already correct.
+ */
+export const DAYTONA_OPENCODE_ARCH_ENV_VAR = "AGENTA_AGENT_SANDBOX_OPENCODE_ARCH";
+
+/**
+ * Env addition for opencode: the arch override the daemon reads when auto-installing the
+ * opencode binary. Returns `{}` when the var is unset (x64 cloud Daytona — no override
+ * needed). Set `AGENTA_AGENT_SANDBOX_OPENCODE_ARCH=linux-arm64` on a dev host that targets
+ * an arm64 Daytona snapshot to avoid the x64-on-arm64 SIGTRAP the PoC surfaced.
+ */
+export function opencodeArchEnv(): Record<string, string> {
+  const arch = process.env[DAYTONA_OPENCODE_ARCH_ENV_VAR];
+  if (!arch) return {};
+  return { [DAYTONA_OPENCODE_ARCH_ENV_VAR]: arch };
+}
+
+/**
  * In-sandbox env for the Daytona daemon: where Pi reads its login, any provider keys,
  * and the Agenta extension env (traceparent + OTLP + tool spec) so the remote Pi traces
- * and runs tools exactly like local. No local-only paths (PATH/PI_ACP_PI_COMMAND) here.
+ * and runs tools exactly like local. Injects the opencode arch override only for the
+ * opencode harness. No local-only paths (PATH/PI_ACP_PI_COMMAND) here.
  */
 export function daytonaEnvVars(
+  acpAgent: string,
   piExtEnv: Record<string, string>,
   secrets: Record<string, string>,
 ): Record<string, string> {
@@ -42,6 +65,8 @@ export function daytonaEnvVars(
   if (DAYTONA_PI_INSTALL) {
     env.PI_ACP_PI_COMMAND = `${DAYTONA_PI_INSTALL_DIR}/node_modules/.bin/pi`;
   }
+  // Arch override: only inject for opencode (daemon reads it at createSession time).
+  if (acpAgent === "opencode") Object.assign(env, opencodeArchEnv());
   return env;
 }
 
@@ -138,6 +163,32 @@ export async function prepareDaytonaPiAssets({
     );
   }
   if (DAYTONA_PI_INSTALL) await installPiInSandbox(sandbox, log);
+}
+
+export interface PrepareDaytonaOpencodeAssetsInput {
+  sandbox: any;
+  plan: Pick<RunPlan, "acpAgent">;
+  log?: Log;
+}
+
+/**
+ * Prepare Daytona sandbox assets for an opencode run.
+ *
+ * opencode needs no runner-side uploads: the daemon auto-installs the binary from the
+ * official `anomalyco/opencode` GitHub release zip at createSession time, and the provider
+ * key reaches the daemon env via `daytonaEnvVars` / `buildDaytonaCreate` (the `secrets`
+ * spread). This function is a named no-op seam — calling it from `sandbox_agent.ts` makes
+ * the opencode Daytona path explicit and testable, and provides a clean fold point for the
+ * foundation remote-bootstrap generalization.
+ */
+export async function prepareDaytonaOpencodeAssets({
+  plan,
+  log = () => {},
+}: PrepareDaytonaOpencodeAssetsInput): Promise<void> {
+  if (plan.acpAgent !== "opencode") return;
+  // Nothing to upload: daemon auto-installs the binary; provider key is in the create env.
+  const arch = process.env[DAYTONA_OPENCODE_ARCH_ENV_VAR];
+  if (arch) log(`opencode daytona: arch override ${DAYTONA_OPENCODE_ARCH_ENV_VAR}=${arch}`);
 }
 
 /**

--- a/services/runner/src/engines/sandbox_agent/provider.ts
+++ b/services/runner/src/engines/sandbox_agent/provider.ts
@@ -73,6 +73,7 @@ export function daytonaAutoStopMinutes(
  * object carries the auto-stop leak backstop (and `ephemeral`).
  */
 export function buildDaytonaCreate(
+  acpAgent: string,
   piExtEnv: Record<string, string>,
   secrets: Record<string, string>,
   sandboxPermission: SandboxPermission | undefined,
@@ -86,7 +87,7 @@ export function buildDaytonaCreate(
     ...(snapshot ? { snapshot, image: undefined } : {}),
     ...(target ? { target } : {}),
     ...daytonaNetworkFields(sandboxPermission),
-    envVars: daytonaEnvVars(piExtEnv, secrets),
+    envVars: daytonaEnvVars(acpAgent, piExtEnv, secrets),
     // Server-side leak backstop: `ephemeral` only auto-DELETES a sandbox when it STOPS, and the
     // sandbox-agent wrapper hardcodes `autoStopInterval: 0` (auto-stop OFF) — the two cancel out,
     // so a sandbox the runner leaks (a process KILL skips the per-run teardown `finally`) never
@@ -110,6 +111,7 @@ export function buildDaytonaCreate(
  */
 export function buildSandboxProvider(
   sandboxId: string,
+  acpAgent: string,
   env: Record<string, string>,
   binaryPath: string | undefined,
   piExtEnv: Record<string, string>,
@@ -120,7 +122,7 @@ export function buildSandboxProvider(
     const image = process.env.DAYTONA_IMAGE;
     return daytona({
       ...(image ? { image } : {}),
-      create: buildDaytonaCreate(piExtEnv, secrets, sandboxPermission) as any,
+      create: buildDaytonaCreate(acpAgent, piExtEnv, secrets, sandboxPermission) as any,
     });
   }
 

--- a/services/runner/tests/unit/sandbox-agent-daytona.test.ts
+++ b/services/runner/tests/unit/sandbox-agent-daytona.test.ts
@@ -10,15 +10,18 @@ import { tmpdir } from "node:os";
 import { join } from "node:path";
 
 import {
+  DAYTONA_OPENCODE_ARCH_ENV_VAR,
   DAYTONA_PI_DIR,
   DAYTONA_PI_INSTALL,
   DAYTONA_PI_INSTALL_DIR,
   createCookieFetch,
   daytonaEnvVars,
+  opencodeArchEnv,
+  prepareDaytonaOpencodeAssets,
   uploadPiAuthToSandbox,
 } from "../../src/engines/sandbox_agent/daytona.ts";
 
-const envKeys = ["PI_CODING_AGENT_DIR"];
+const envKeys = ["PI_CODING_AGENT_DIR", DAYTONA_OPENCODE_ARCH_ENV_VAR];
 const previousEnv = new Map<string, string | undefined>();
 for (const key of envKeys) previousEnv.set(key, process.env[key]);
 
@@ -36,7 +39,9 @@ afterEach(() => {
 
 describe("daytonaEnvVars", () => {
   it("combines Pi agent dir, extension env, provider secrets, and Pi command", () => {
+    delete process.env[DAYTONA_OPENCODE_ARCH_ENV_VAR];
     const env = daytonaEnvVars(
+      "pi",
       { TRACEPARENT: "trace", AGENTA_AGENT_TOOLS_RELAY_DIR: "/relay" },
       { OPENAI_API_KEY: "key" },
     );
@@ -48,6 +53,100 @@ describe("daytonaEnvVars", () => {
     if (DAYTONA_PI_INSTALL) {
       assert.equal(env.PI_ACP_PI_COMMAND, `${DAYTONA_PI_INSTALL_DIR}/node_modules/.bin/pi`);
     }
+  });
+
+  it("injects arch override for opencode when AGENTA_AGENT_SANDBOX_OPENCODE_ARCH is set", () => {
+    process.env[DAYTONA_OPENCODE_ARCH_ENV_VAR] = "linux-arm64";
+    const env = daytonaEnvVars("opencode", {}, { ANTHROPIC_API_KEY: "key" });
+    assert.equal(env[DAYTONA_OPENCODE_ARCH_ENV_VAR], "linux-arm64");
+  });
+
+  it("omits arch override for opencode when AGENTA_AGENT_SANDBOX_OPENCODE_ARCH is unset", () => {
+    delete process.env[DAYTONA_OPENCODE_ARCH_ENV_VAR];
+    const env = daytonaEnvVars("opencode", {}, {});
+    assert.equal(env[DAYTONA_OPENCODE_ARCH_ENV_VAR], undefined);
+  });
+
+  it("omits arch override for pi even when AGENTA_AGENT_SANDBOX_OPENCODE_ARCH is set", () => {
+    process.env[DAYTONA_OPENCODE_ARCH_ENV_VAR] = "linux-arm64";
+    const env = daytonaEnvVars("pi", {}, {});
+    assert.equal(env[DAYTONA_OPENCODE_ARCH_ENV_VAR], undefined);
+  });
+
+  it("omits arch override for unknown harnesses even when AGENTA_AGENT_SANDBOX_OPENCODE_ARCH is set", () => {
+    process.env[DAYTONA_OPENCODE_ARCH_ENV_VAR] = "linux-arm64";
+    const env = daytonaEnvVars("codex", {}, {});
+    assert.equal(env[DAYTONA_OPENCODE_ARCH_ENV_VAR], undefined);
+  });
+});
+
+describe("opencodeArchEnv", () => {
+  it("returns arch var when set", () => {
+    process.env[DAYTONA_OPENCODE_ARCH_ENV_VAR] = "linux-arm64";
+    assert.deepEqual(opencodeArchEnv(), { [DAYTONA_OPENCODE_ARCH_ENV_VAR]: "linux-arm64" });
+  });
+
+  it("returns empty record when unset", () => {
+    delete process.env[DAYTONA_OPENCODE_ARCH_ENV_VAR];
+    assert.deepEqual(opencodeArchEnv(), {});
+  });
+});
+
+describe("prepareDaytonaOpencodeAssets", () => {
+  it("makes no sandbox calls for an opencode plan", async () => {
+    const calls: string[] = [];
+    const sandbox = {
+      mkdirFs: async () => { calls.push("mkdirFs"); },
+      writeFsFile: async () => { calls.push("writeFsFile"); },
+      runProcess: async () => { calls.push("runProcess"); return { exitCode: 0 }; },
+    };
+
+    await prepareDaytonaOpencodeAssets({ sandbox, plan: { acpAgent: "opencode" } });
+
+    assert.deepEqual(calls, [], "no sandbox fs calls for opencode");
+  });
+
+  it("skips when acpAgent is not opencode", async () => {
+    const calls: string[] = [];
+    const sandbox = {
+      mkdirFs: async () => { calls.push("mkdirFs"); },
+      writeFsFile: async () => { calls.push("writeFsFile"); },
+    };
+
+    await prepareDaytonaOpencodeAssets({ sandbox, plan: { acpAgent: "pi" } });
+
+    assert.deepEqual(calls, [], "no calls for non-opencode agent");
+  });
+
+  it("logs the arch override when set", async () => {
+    process.env[DAYTONA_OPENCODE_ARCH_ENV_VAR] = "linux-arm64";
+    const logs: string[] = [];
+    const sandbox = {};
+
+    await prepareDaytonaOpencodeAssets({
+      sandbox,
+      plan: { acpAgent: "opencode" },
+      log: (msg) => logs.push(msg),
+    });
+
+    assert.ok(
+      logs.some((l) => l.includes("linux-arm64")),
+      "should log the arch override",
+    );
+  });
+
+  it("does not log when arch override is unset", async () => {
+    delete process.env[DAYTONA_OPENCODE_ARCH_ENV_VAR];
+    const logs: string[] = [];
+    const sandbox = {};
+
+    await prepareDaytonaOpencodeAssets({
+      sandbox,
+      plan: { acpAgent: "opencode" },
+      log: (msg) => logs.push(msg),
+    });
+
+    assert.equal(logs.length, 0, "no log when arch override absent");
   });
 });
 

--- a/services/runner/tests/unit/sandbox-agent-orchestration.test.ts
+++ b/services/runner/tests/unit/sandbox-agent-orchestration.test.ts
@@ -700,8 +700,8 @@ describe("runSandboxAgent orchestration", () => {
     );
 
     assert.equal(result.ok, true);
-    // sandboxId, env, binaryPath, piExtEnv, secrets, sandboxPermission
-    assert.deepEqual(calls.providerArgs[5], sandboxPermission);
+    // sandboxId, acpAgent, env, binaryPath, piExtEnv, secrets, sandboxPermission
+    assert.deepEqual(calls.providerArgs[6], sandboxPermission);
   });
 
   it("passes cancellation signals into SandboxAgent.start", async () => {
@@ -739,7 +739,7 @@ describe("runSandboxAgent orchestration", () => {
     // Managed run -> clear-then-apply: buildDaemonEnv is asked to clear the inherited provider env.
     assert.deepEqual(calls.daemonOptions, { clearProviderEnv: true });
     // The env handed to buildSandboxProvider carries only the resolved key + the custom base url.
-    const env = calls.providerArgs[1] as Record<string, string>;
+    const env = calls.providerArgs[2] as Record<string, string>;
     assert.equal(env.ANTHROPIC_API_KEY, "resolved");
     assert.equal(env.ANTHROPIC_BASE_URL, "https://claude-gw.example/v1");
     assert.equal(env.ANTHROPIC_MODEL, undefined);
@@ -763,7 +763,7 @@ describe("runSandboxAgent orchestration", () => {
     );
 
     assert.equal(result.ok, true);
-    const env = calls.providerArgs[1] as Record<string, string>;
+    const env = calls.providerArgs[2] as Record<string, string>;
     // The Tool-Search toggle is Claude-specific: a Pi run must not carry it.
     assert.equal(env.ENABLE_TOOL_SEARCH, undefined);
   });
@@ -787,7 +787,7 @@ describe("runSandboxAgent orchestration", () => {
     );
 
     assert.equal(result.ok, true);
-    const env = calls.providerArgs[1] as Record<string, string>;
+    const env = calls.providerArgs[2] as Record<string, string>;
     assert.equal(env.CLAUDE_CODE_USE_BEDROCK, "1");
     assert.equal(env.AWS_ACCESS_KEY_ID, "AKIA");
     assert.equal(env.AWS_REGION, "us-east-1");
@@ -820,7 +820,7 @@ describe("runSandboxAgent orchestration", () => {
     );
 
     assert.equal(result.ok, true);
-    const env = calls.providerArgs[1] as Record<string, string>;
+    const env = calls.providerArgs[2] as Record<string, string>;
     assert.equal(env.CLAUDE_CODE_USE_VERTEX, "1");
     assert.equal(env.GOOGLE_CLOUD_PROJECT, "proj");
     assert.equal(env.ANTHROPIC_MODEL, "claude-sonnet-4");
@@ -843,7 +843,7 @@ describe("runSandboxAgent orchestration", () => {
     assert.equal(result.ok, true);
     // runtime_provided -> keep the harness's own inherited env (do not clear).
     assert.deepEqual(calls.daemonOptions, { clearProviderEnv: false });
-    const env = calls.providerArgs[1] as Record<string, string>;
+    const env = calls.providerArgs[2] as Record<string, string>;
     assert.equal(env.ANTHROPIC_BASE_URL, undefined);
   });
 });

--- a/services/runner/tests/unit/sandbox-agent-provider.test.ts
+++ b/services/runner/tests/unit/sandbox-agent-provider.test.ts
@@ -109,7 +109,7 @@ describe("daytonaAutoStopMinutes (leak backstop)", () => {
 describe("buildDaytonaCreate (leak backstop on the create object)", () => {
   it("carries a positive auto-stop interval + ephemeral by default (self-reaps a leak)", () => {
     delete process.env[AUTOSTOP_ENV];
-    const create = buildDaytonaCreate({}, {}, undefined);
+    const create = buildDaytonaCreate("pi", {}, {}, undefined);
     // ephemeral auto-deletes ON STOP; a non-zero auto-stop is what makes a leaked sandbox stop.
     assert.equal(create.ephemeral, true);
     assert.equal(create.autoStopInterval, DEFAULT_DAYTONA_AUTOSTOP_MINUTES);
@@ -121,7 +121,7 @@ describe("buildDaytonaCreate (leak backstop on the create object)", () => {
 
   it("carries the env-configured auto-stop interval", () => {
     process.env[AUTOSTOP_ENV] = "42";
-    const create = buildDaytonaCreate({}, {}, undefined);
+    const create = buildDaytonaCreate("pi", {}, {}, undefined);
     assert.equal(create.autoStopInterval, 42);
     assert.equal(create.ephemeral, true);
   });


### PR DESCRIPTION
## Context
OpenCode existed only on the local sandbox. Getting it onto Daytona surfaced an architecture gotcha: the upstream OpenCode binary needs an explicit arch override on some Daytona node images, and the provider key has to travel via the sandbox's create-time env rather than a written file.

## Changes
Adds OpenCode asset prep in `daytona.ts` (gated arch override, provider-key delivered through the sandbox create env instead of a credential file) and the matching `sandbox_agent.ts`/`provider.ts` wiring.

## Tests / notes
- New/updated coverage: `sandbox-agent-daytona.test.ts`, `sandbox-agent-orchestration.test.ts`, `sandbox-agent-provider.test.ts`.
- Base is `chore/add-harness-opencode`, not `big-agents`.
- OpenCode-on-Daytona runs with tools will hit the loud-refuse gate from `chore/add-remote-tools-gate` until the relay-client shim lands.