### PR TITLE
[chore] Add OpenCode on E2B sandbox

### DIFF
--- a/api/oss/src/utils/env.py
+++ b/api/oss/src/utils/env.py
@@ -562,6 +562,18 @@ class DaytonaConfig(BaseModel):
 
 
 # ---------------------------------------------------------------------------
+# e2b
+# ---------------------------------------------------------------------------
+
+
+class E2BConfig(BaseModel):
+    api_key: str | None = os.getenv("E2B_API_KEY")
+    template: str | None = os.getenv("E2B_TEMPLATE")
+
+    model_config = ConfigDict(extra="ignore")
+
+
+# ---------------------------------------------------------------------------
 # docker
 # ---------------------------------------------------------------------------
 
@@ -1239,6 +1251,7 @@ class EnvironSettings(BaseModel):
     crisp: CrispConfig = CrispConfig()
     daytona: DaytonaConfig = DaytonaConfig()
     docker: DockerConfig = DockerConfig()
+    e2b: E2BConfig = E2BConfig()
     identity: IdentityConfig = IdentityConfig()
     llm: LLMConfig = LLMConfig()
     loops: LoopsConfig = LoopsConfig()

--- a/docs/design/agent-workflows/projects/add-opencode-e2b/research.md
+++ b/docs/design/agent-workflows/projects/add-opencode-e2b/research.md
@@ -1,0 +1,97 @@
+# opencode on E2B — investigation
+
+## What this worktree adds
+
+opencode harness on the E2B sandbox. opencode-local (`add-harness-opencode`) is
+already done on this branch; this layer adds the E2B sandbox axis.
+
+## Sandbox-agent/e2b provider (sourced from sibling `chore/add-sandbox-e2b`)
+
+The `sandbox-agent@0.4.2` package exports `sandbox-agent/e2b`. It requires
+`@e2b/code-interpreter >=1.0.0` as an optional peer dep — add it as a direct dep
+so the subpath import resolves. The provider options are:
+
+| Option | Purpose |
+|---|---|
+| `template` | E2B template ID (env `E2B_TEMPLATE`, default `agenta-sandbox-agent`) |
+| `create.envs` | In-sandbox env vars (piExtEnv + secrets merged) |
+| `timeoutMs` | Sandbox lifetime backstop; self-reaps a leaked sandbox on process KILL |
+| `autoPause` | Pause (not delete) after idle; reduces billing; set `true` |
+
+`E2B_API_KEY` is picked up by the `@e2b/code-interpreter` SDK automatically from env;
+the runner does not need to pass it. `SANDBOX_AGENT_PROVIDER=e2b` routes the run.
+
+### Leak backstop
+
+`timeoutMs` is the E2B equivalent of Daytona's `ephemeral + autoStopInterval`. A process
+KILL skips the `finally` teardown; `timeoutMs` self-reaps the sandbox after it goes idle.
+Default: 30 min (`DEFAULT_E2B_TIMEOUT_MS`). Override with `E2B_TIMEOUT_MS`.
+Clamped to >= 1 ms (0 would re-disable the backstop).
+
+### Network policy on E2B
+
+The `sandbox-agent/e2b` wrapper exposes no egress-control API. A restricted
+`network` policy on E2B is therefore refused up-front (same rule as local), not silently
+accepted. `E2B_NETWORK_UNSUPPORTED_MESSAGE` mirrors `LOCAL_NETWORK_UNSUPPORTED_MESSAGE`.
+
+### Default cwd on E2B
+
+The E2B base image (`e2bdev/code-interpreter`) uses `/root/work` as working dir.
+`defaultE2bCwd()` returns `/root/work/agenta-<6-byte-hex>` so each run gets an isolated
+subdir without conflicting across concurrent runs.
+
+## opencode credential on E2B
+
+opencode uses a **plain managed provider key** — `ANTHROPIC_API_KEY` or `OPENAI_API_KEY`.
+No Zen gateway, no auth file, no cookie fetch. The key is injected through `create.envs`
+(the same secrets dict that `plan.secrets` carries from the wire request). The daemon on
+the E2B template auto-installs opencode on first use (same as local); no bake is needed
+for the binary itself.
+
+### planMode: false
+
+Unchanged from opencode-local: `capabilities.ts` static fallback already excludes opencode
+from `session/set_mode`. No E2B-specific change needed here.
+
+### Plain `createAcpFetch`
+
+No Daytona auth cookie — use `createAcpFetch()` directly (same as local). The engine
+already selects `createCookieFetch` only for `isDaytona`.
+
+## The arch gotcha (opencode binary on E2B)
+
+The daemon's `install-agent opencode` downloads the linux-**x64** Bun binary even on
+arm64 hosts → SIGTRAP (`rosetta error … ld-linux-x86-64.so.2`). E2B runs on real x86-64
+cloud hardware, so the default x64 download is **correct** — no arch override needed on
+E2B. The gotcha only bites on local arm64 dev machines. Document but do not fix (not
+applicable to E2B).
+
+This "E2B is always x86-64" assumption is load-bearing: if E2B ever offers arm64
+templates, the opencode arch override must be ported here too (see the daytona
+sibling's `opencodeArchEnv` in `daytona.ts`).
+
+## Node version in the E2B template
+
+The `e2bdev/code-interpreter` base image ships Node 20. `pi-acp` requires `>=22.19`. The
+template must upgrade to Node 22 before installing the pi-acp adapter. The sibling
+`chore/add-sandbox-e2b` Dockerfile already handles this. For opencode the daemon
+auto-installs the binary at runtime; no Node constraint applies to the opencode binary
+(it is a Bun single-file binary, not a Node script). Node 22 is still required in the
+template because the `sandbox-agent` daemon itself is a Node process.
+
+## Overlap with sibling branch `chore/add-sandbox-e2b`
+
+These files are modified in both this branch and `chore/add-sandbox-e2b`:
+
+| File | Overlap nature |
+|---|---|
+| `services/agent/src/engines/sandbox_agent/provider.ts` | E2B wiring (`buildE2bCreate`, `e2bTimeoutMs`, `e2b` branch) is byte-identical |
+| `services/agent/src/engines/sandbox_agent/run-plan.ts` | E2B wiring (`isE2b`, `E2B_NETWORK_UNSUPPORTED_MESSAGE`, `defaultE2bCwd`, `createE2bCwd`) is byte-identical; opencode acpAgent comment differs |
+| `services/agent/package.json` | `@e2b/code-interpreter` dep added in both |
+| `api/oss/src/utils/env.py` | `E2bConfig` + `EnvironSettings.e2b` added in both |
+| `services/agent/sandbox-images/e2b/e2b.Dockerfile` | Sibling has Pi-only; this branch adds opencode note to README but Dockerfile is same |
+| `services/agent/tests/unit/sandbox-agent-provider.test.ts` | E2B tests are identical |
+| `services/agent/tests/unit/sandbox-agent-run-plan.test.ts` | E2B tests are identical; opencode tests differ (this branch only) |
+
+Dedup strategy: when these branches merge, keep one copy of the shared E2B wiring and
+deduplicate in a follow-up chore.

--- a/docs/design/agent-workflows/projects/add-opencode-e2b/specs.md
+++ b/docs/design/agent-workflows/projects/add-opencode-e2b/specs.md
@@ -1,0 +1,86 @@
+# opencode on E2B — spec
+
+## Scope
+
+Add the E2B sandbox provider to this branch (opencode-local already done) so the
+`harness=opencode, sandbox=e2b` combination works. E2B-specific wiring is duplicated from
+the sibling `chore/add-sandbox-e2b` branch; it will be deduped after both land.
+
+## Provider wiring (`services/agent/src/engines/sandbox_agent/provider.ts`)
+
+```
+import { e2b } from "sandbox-agent/e2b";
+
+DEFAULT_E2B_TIMEOUT_MS = 30 * 60 * 1000  // 30 min backstop
+e2bTimeoutMs(raw?)      // parse E2B_TIMEOUT_MS; clamp >= 1 ms
+buildE2bCreate(piExtEnv, secrets) -> { envs, timeoutMs, autoPause: true }
+
+buildSandboxProvider(...):
+  if sandboxId === "e2b":
+    template = E2B_TEMPLATE ?? "agenta-sandbox-agent"
+    create = buildE2bCreate(piExtEnv, secrets)
+    return e2b({ template, create: { envs }, timeoutMs, autoPause })
+```
+
+## Run-plan wiring (`services/agent/src/engines/sandbox_agent/run-plan.ts`)
+
+```
+E2B_NETWORK_UNSUPPORTED_MESSAGE   // new named constant (parallel to LOCAL_)
+RunPlan.isE2b: boolean            // new field
+BuildRunPlanDeps.createE2bCwd?    // injectable for tests
+defaultE2bCwd()                   // /root/work/agenta-<hex>
+
+buildRunPlan():
+  isE2b = sandboxId === "e2b"
+  if networkRestricted && isE2b -> error E2B_NETWORK_UNSUPPORTED_MESSAGE
+  if networkRestricted && !isDaytona && !isE2b -> error LOCAL_NETWORK_UNSUPPORTED_MESSAGE
+  cwd = isDaytona ? createDaytonaCwd() : isE2b ? createE2bCwd() : createLocalCwd()
+  plan.isE2b = isE2b
+```
+
+## Credential provisioning
+
+opencode reads `ANTHROPIC_API_KEY` or `OPENAI_API_KEY` from env. Both are present in
+`plan.secrets` (from the wire request) and injected via `buildE2bCreate(...).envs`. No
+auth file, no Zen key, no cookie fetch. `planMode: false` is already set in
+`capabilities.ts` and does not change for E2B.
+
+## `api/oss/src/utils/env.py` — E2bConfig
+
+```python
+class E2bConfig(BaseModel):
+    api_key: str | None = os.getenv("E2B_API_KEY")
+    template: str | None = os.getenv("E2B_TEMPLATE")
+    model_config = ConfigDict(extra="ignore")
+
+# EnvironSettings:
+    e2b: E2bConfig = E2bConfig()
+```
+
+## `services/agent/package.json`
+
+Add `"@e2b/code-interpreter": "^1.0.0"` to `dependencies`.
+
+## `services/agent/sandbox-images/e2b/`
+
+Reuse the `e2b.Dockerfile` from the Pi-only sibling template. The opencode binary is
+auto-installed at runtime by the daemon (`install-agent opencode`), so no additional
+bake step is needed. The README notes both Pi and opencode support.
+
+## Sandbox teardown / leak parity
+
+The engine `finally` calls `sandbox.destroySandbox()` on every exit path. The
+`timeoutMs` backstop self-reaps a leaked sandbox when a process KILL skips the `finally`.
+`autoPause: true` pauses (not deletes) after idle, so billing stops. No sandbox outlives
+its run.
+
+## Network policy enforcement
+
+E2B exposes no egress-control API. Any restricted `network` policy on E2B is refused
+up-front via `E2B_NETWORK_UNSUPPORTED_MESSAGE` — never silently accepted.
+
+## Arch gotcha
+
+E2B runs on real x86-64 cloud. The daemon's `install-agent opencode` fetches the linux-x64
+binary, which is correct on E2B. No arch override needed. The SIGTRAP gotcha only applies
+to local arm64 dev machines.

--- a/docs/design/agent-workflows/projects/add-opencode-e2b/tasks.md
+++ b/docs/design/agent-workflows/projects/add-opencode-e2b/tasks.md
@@ -1,0 +1,39 @@
+# opencode on E2B — tasks
+
+## T1: TypeScript runner — E2B provider
+
+- [x] `provider.ts`: `import { e2b } from "sandbox-agent/e2b"`
+- [x] `provider.ts`: `DEFAULT_E2B_TIMEOUT_MS`, `e2bTimeoutMs()`, `buildE2bCreate()`
+- [x] `provider.ts`: `buildSandboxProvider` E2B branch
+- [x] `run-plan.ts`: `E2B_NETWORK_UNSUPPORTED_MESSAGE`
+- [x] `run-plan.ts`: `RunPlan.isE2b`, `BuildRunPlanDeps.createE2bCwd`, `defaultE2bCwd()`
+- [x] `run-plan.ts`: E2B network gate + cwd selection + `plan.isE2b`
+- [x] `package.json`: `@e2b/code-interpreter ^1.0.0`
+
+## T2: Python API — E2bConfig
+
+- [x] `api/oss/src/utils/env.py`: `E2bConfig` class + `EnvironSettings.e2b`
+
+## T3: Sandbox image
+
+- [x] `services/agent/sandbox-images/e2b/e2b.Dockerfile`: Node 22, sandbox-agent, pi-acp
+- [x] `services/agent/sandbox-images/e2b/README.md`: note Pi + opencode (auto-installed)
+
+## T4: Unit tests
+
+- [x] `sandbox-agent-provider.test.ts`: `buildE2bCreate`, `e2bTimeoutMs`, `DEFAULT_E2B_TIMEOUT_MS`
+- [x] `sandbox-agent-run-plan.test.ts`: opencode-on-E2B normalizes; isE2b=true; restricted network refused
+- [x] `sandbox-agent-run-plan.test.ts`: opencode-on-E2B with ANTHROPIC_API_KEY carries key via secrets
+
+## T5: Integration test (deferred — requires live E2B account)
+
+- [ ] opencode-on-E2B returns `ok:true` output + trace (needs `E2B_API_KEY` + `ANTHROPIC_API_KEY`)
+- [ ] sandbox is torn down after run (verify no leaked sandboxes)
+
+## Decisions already made
+
+- No Zen, no auth file: opencode uses plain provider key only.
+- No cookie fetch: `createAcpFetch()` like local (cookie is Daytona-only).
+- Arch override not needed on E2B (real x64 hardware, daemon fetches correct binary).
+- E2B network policy: refused (not silently accepted) — no egress control API.
+- Template default: `agenta-sandbox-agent` (shared with Pi template, opencode auto-installs).

--- a/services/runner/package.json
+++ b/services/runner/package.json
@@ -21,6 +21,7 @@
   },
   "dependencies": {
     "@daytonaio/sdk": "^0.187.0",
+    "@e2b/code-interpreter": "^1.0.0",
     "@earendil-works/pi-coding-agent": "0.79.4",
     "@opentelemetry/api": "1.9.0",
     "@opentelemetry/exporter-trace-otlp-proto": "0.54.0",

--- a/services/runner/pnpm-lock.yaml
+++ b/services/runner/pnpm-lock.yaml
@@ -11,6 +11,9 @@ importers:
       '@daytonaio/sdk':
         specifier: ^0.187.0
         version: 0.187.0(ws@8.21.0)
+      '@e2b/code-interpreter':
+        specifier: ^1.0.0
+        version: 1.5.1
       '@earendil-works/pi-coding-agent':
         specifier: 0.79.4
         version: 0.79.4(ws@8.21.0)(zod@4.4.3)
@@ -40,7 +43,7 @@ importers:
         version: 0.0.29
       sandbox-agent:
         specifier: 0.4.2
-        version: 0.4.2(@daytonaio/sdk@0.187.0(ws@8.21.0))(zod@4.4.3)
+        version: 0.4.2(@daytonaio/sdk@0.187.0(ws@8.21.0))(@e2b/code-interpreter@1.5.1)(zod@4.4.3)
       undici:
         specifier: 8.3.0
         version: 8.3.0
@@ -306,6 +309,20 @@ packages:
     resolution: {integrity: sha512-6zABk/ECA/QYSCQ1NGiVwwbQerUCZ+TQbp64Q3AgmfNvurHH0j8TtXa1qbShXA6qqkpAj4V5W8pP6mLe1mcMqA==}
     engines: {node: '>=18'}
 
+  '@bufbuild/protobuf@2.12.1':
+    resolution: {integrity: sha512-BvAMfS6LrgZiryOAZ4pBYucu4wG/Ei/9o9DZ9akbREnMLbPJiom2i8b9C8IsKErQoiKqVhrerzt3kOT/RrzLHg==}
+
+  '@connectrpc/connect-web@2.0.0-rc.3':
+    resolution: {integrity: sha512-w88P8Lsn5CCsA7MFRl2e6oLY4J/5toiNtJns/YJrlyQaWOy3RO8pDgkz+iIkG98RPMhj2thuBvsd3Cn4DKKCkw==}
+    peerDependencies:
+      '@bufbuild/protobuf': ^2.2.0
+      '@connectrpc/connect': 2.0.0-rc.3
+
+  '@connectrpc/connect@2.0.0-rc.3':
+    resolution: {integrity: sha512-ARBt64yEyKbanyRETTjcjJuHr2YXorzQo0etyS5+P6oSeW8xEuzajA9g+zDnMcj1hlX2dQE93foIWQGfpru7gQ==}
+    peerDependencies:
+      '@bufbuild/protobuf': ^2.2.0
+
   '@daytona/api-client@0.187.0':
     resolution: {integrity: sha512-riKOJ6eSuy67DL6iJlAa3Bfjnm4iQmkOdJk0B5hqrYMZeZmVDsgdiZtYvFpyoa+2KCZFNb0Gs5dQwO1d6NhGCw==}
 
@@ -315,6 +332,10 @@ packages:
   '@daytonaio/sdk@0.187.0':
     resolution: {integrity: sha512-j6PfT6735Uu34t4JoxBi4IMh1JLNrEDg5w3ZUaT0Mgkas2UfoAAhQ2Eg1LqMhy4n1CTffvCyJID9W6Ldi4xEGQ==}
     deprecated: 'Moved to @daytona/sdk, same API, no breaking changes. Please update: npm uninstall @daytonaio/sdk && npm i @daytona/sdk'
+
+  '@e2b/code-interpreter@1.5.1':
+    resolution: {integrity: sha512-mkyKjAW2KN5Yt0R1I+1lbH3lo+W/g/1+C2lnwlitXk5wqi/g94SEO41XKdmDf5WWpKG3mnxWDR5d6S/lyjmMEw==}
+    engines: {node: '>=18'}
 
   '@earendil-works/pi-agent-core@0.79.4':
     resolution: {integrity: sha512-xkaZ3yK2XbP9HYdHrrdj/6HqZPM0o/mwbjMSU4RTJyR3HjDG0ZrPz76Hg6s0W+G4u6PpJr1mGx/srCG+3eQA8A==}
@@ -1390,6 +1411,9 @@ packages:
     resolution: {integrity: sha512-FQN4MRfuJeHf7cBbBMJFXhKSDq+2kAArBlmRBvcvFE5BB1HZKXtSFASDhdlz9zOYwxh8lDdnvmMOe/+5cdoEdg==}
     engines: {node: '>= 0.8'}
 
+  compare-versions@6.1.1:
+    resolution: {integrity: sha512-4hm4VPpIecmlg59CHXnRDnqGplJFrbLG4aFEl5vl6cK1u76ws3LLvX7ikFnTDl5vo39sjWD6AaDPYodJp/NNHg==}
+
   convert-source-map@2.0.0:
     resolution: {integrity: sha512-Kvp459HrV2FEJ1CAsi1Ku+MY3kasH19TFykTz2xWmMeq6bk2NU3XXvfJ+Q61m0xktWwt+1HSYf3JZsTms3aRJg==}
 
@@ -1429,6 +1453,10 @@ packages:
   dunder-proto@1.0.1:
     resolution: {integrity: sha512-KIN/nDJBQRcXw0MLVhZE9iQHmG68qAVIBg9CqmUYjmQIhgij9U5MFvrqkUL5FbtyyzZuOeOt0zdeRe4UY7ct+A==}
     engines: {node: '>= 0.4'}
+
+  e2b@1.13.2:
+    resolution: {integrity: sha512-m8acE/MzMAJo1A57DakR2X1Sl5Mt1tcQO2aJfygNaQHLXby/4xsjF0UeJUB70jF7xntiR41pAMbZEHnkzrT9tw==}
+    engines: {node: '>=18'}
 
   ecdsa-sig-formatter@1.0.11:
     resolution: {integrity: sha512-nagl3RYrbNv6kQkeJIpt6NJZy8twLB/2vtz6yN9Z4vRKHN4/QZJIEbqohALSgwKdnksuY3k5Addp5lg8sVoVcQ==}
@@ -1870,6 +1898,12 @@ packages:
       zod:
         optional: true
 
+  openapi-fetch@0.9.8:
+    resolution: {integrity: sha512-zM6elH0EZStD/gSiNlcPrzXcVQ/pZo3BDvC6CDwRDUt1dDzxlshpmQnpD6cZaJ39THaSmwVCxxRrPKNM1hHrDg==}
+
+  openapi-typescript-helpers@0.0.8:
+    resolution: {integrity: sha512-1eNjQtbfNi5Z/kFhagDIaIRj6qqDzhjNJKz8cmMW0CVdGwT6e1GLbAfgI0d28VTJa1A8jz82jm/4dG8qNoNS8g==}
+
   p-retry@4.6.2:
     resolution: {integrity: sha512-312Id396EbJdvRONlngUx0NydfrIQ5lsYu0znKVUzVvArzEIt08V1qhtyESbGVd1FGX7UKtiFp5uwKZdM8wIuQ==}
     engines: {node: '>=8'}
@@ -1911,6 +1945,9 @@ packages:
   picomatch@4.0.4:
     resolution: {integrity: sha512-QP88BAKvMam/3NxH6vj2o21R6MjxZUAd6nlwAS/pnGvN9IVLocLHxGYIzFhg6fUQ+5th6P4dv4eW9jX3DSIj7A==}
     engines: {node: '>=12'}
+
+  platform@1.3.6:
+    resolution: {integrity: sha512-fnWVljUchTro6RiCFvCXBbNhJc2NijN7oIQxbwsyL0buWJPG85v81ehlHI9fXrJsMNgTofEoWIQeClKpgxFLrg==}
 
   postcss@8.5.15:
     resolution: {integrity: sha512-FfR8sjd4em2T6fb3I2MwAJU7HWVMr9zba+enmQeeWFfCbm+UOC/0X4DS8XtpUTMwWMGbjKYP7xjfNekzyGmB3A==}
@@ -2740,6 +2777,17 @@ snapshots:
 
   '@bcoe/v8-coverage@1.0.2': {}
 
+  '@bufbuild/protobuf@2.12.1': {}
+
+  '@connectrpc/connect-web@2.0.0-rc.3(@bufbuild/protobuf@2.12.1)(@connectrpc/connect@2.0.0-rc.3(@bufbuild/protobuf@2.12.1))':
+    dependencies:
+      '@bufbuild/protobuf': 2.12.1
+      '@connectrpc/connect': 2.0.0-rc.3(@bufbuild/protobuf@2.12.1)
+
+  '@connectrpc/connect@2.0.0-rc.3(@bufbuild/protobuf@2.12.1)':
+    dependencies:
+      '@bufbuild/protobuf': 2.12.1
+
   '@daytona/api-client@0.187.0':
     dependencies:
       axios: 1.18.0
@@ -2783,6 +2831,10 @@ snapshots:
       - debug
       - supports-color
       - ws
+
+  '@e2b/code-interpreter@1.5.1':
+    dependencies:
+      e2b: 1.13.2
 
   '@earendil-works/pi-agent-core@0.79.4(ws@8.21.0)(zod@4.4.3)':
     dependencies:
@@ -3836,6 +3888,8 @@ snapshots:
     dependencies:
       delayed-stream: 1.0.0
 
+  compare-versions@6.1.1: {}
+
   convert-source-map@2.0.0: {}
 
   cross-spawn@7.0.6:
@@ -3863,6 +3917,15 @@ snapshots:
       call-bind-apply-helpers: 1.0.2
       es-errors: 1.3.0
       gopd: 1.2.0
+
+  e2b@1.13.2:
+    dependencies:
+      '@bufbuild/protobuf': 2.12.1
+      '@connectrpc/connect': 2.0.0-rc.3(@bufbuild/protobuf@2.12.1)
+      '@connectrpc/connect-web': 2.0.0-rc.3(@bufbuild/protobuf@2.12.1)(@connectrpc/connect@2.0.0-rc.3(@bufbuild/protobuf@2.12.1))
+      compare-versions: 6.1.1
+      openapi-fetch: 0.9.8
+      platform: 1.3.6
 
   ecdsa-sig-formatter@1.0.11:
     dependencies:
@@ -4285,6 +4348,12 @@ snapshots:
       ws: 8.21.0
       zod: 4.4.3
 
+  openapi-fetch@0.9.8:
+    dependencies:
+      openapi-typescript-helpers: 0.0.8
+
+  openapi-typescript-helpers@0.0.8: {}
+
   p-retry@4.6.2:
     dependencies:
       '@types/retry': 0.12.0
@@ -4315,6 +4384,8 @@ snapshots:
   picomatch@2.3.2: {}
 
   picomatch@4.0.4: {}
+
+  platform@1.3.6: {}
 
   postcss@8.5.15:
     dependencies:
@@ -4411,12 +4482,13 @@ snapshots:
 
   safe-buffer@5.2.1: {}
 
-  sandbox-agent@0.4.2(@daytonaio/sdk@0.187.0(ws@8.21.0))(zod@4.4.3):
+  sandbox-agent@0.4.2(@daytonaio/sdk@0.187.0(ws@8.21.0))(@e2b/code-interpreter@1.5.1)(zod@4.4.3):
     dependencies:
       '@sandbox-agent/cli-shared': 0.4.2
       acp-http-client: 0.4.2(zod@4.4.3)
     optionalDependencies:
       '@daytonaio/sdk': 0.187.0(ws@8.21.0)
+      '@e2b/code-interpreter': 1.5.1
       '@sandbox-agent/cli': 0.4.2
     transitivePeerDependencies:
       - zod

--- a/services/runner/sandbox-images/e2b/README.md
+++ b/services/runner/sandbox-images/e2b/README.md
@@ -1,0 +1,56 @@
+# E2B Sandbox Template
+
+Baked E2B template for the Agenta sandbox-agent runner. Contains the rivet daemon
+(`sandbox-agent`) and the Pi harness (`@earendil-works/pi-coding-agent` + `pi-acp`
+adapter). Pi is baked in; opencode and Claude are auto-installed at runtime by the daemon.
+
+## Build
+
+```bash
+npx @e2b/cli template create agenta-sandbox-agent -d e2b.Dockerfile
+```
+
+The template name `agenta-sandbox-agent` is the default the runner reads from
+`E2B_TEMPLATE`. Rebuild after changing `e2b.Dockerfile` or pinned package versions.
+
+## Configure the runner
+
+```bash
+SANDBOX_AGENT_PROVIDER=e2b
+E2B_API_KEY=...
+E2B_TEMPLATE=agenta-sandbox-agent
+```
+
+For opencode, also supply the provider key in the run request `secrets`:
+
+```bash
+# Anthropic-backed opencode
+ANTHROPIC_API_KEY=sk-ant-...
+
+# OpenAI-backed opencode
+OPENAI_API_KEY=sk-...
+```
+
+`E2B_TEMPLATE` defaults to `agenta-sandbox-agent`; omit it if you kept the default name.
+
+## What is baked in
+
+- `sandbox-agent` daemon binary (rivet, Apache-2.0)
+- `pi-acp` ACP adapter (MIT) at the version pinned in `services/agent/package.json`
+- `@earendil-works/pi-coding-agent` CLI (MIT) at the same pinned version
+- Node 22 (the E2B base ships Node 20; `pi-acp` requires >=22.19)
+
+Claude Code and opencode are NOT baked — they are installed from their upstreams at
+runtime by the daemon (`install-agent claude` / `install-agent opencode`). Credentials
+are injected at runtime via `envs`, never baked.
+
+## Arch note (opencode)
+
+E2B runs on real x86-64 cloud hardware. The daemon's `install-agent opencode` fetches the
+linux-x64 Bun binary, which is correct on E2B. No arch override is needed. The SIGTRAP
+gotcha (`rosetta error … ld-linux-x86-64.so.2`) only affects local arm64 dev machines.
+
+## Scope
+
+Pi (baked) + Claude + opencode (both auto-installed). The Daytona equivalent is
+`services/agent/sandbox-images/daytona/build_snapshot.py`.

--- a/services/runner/sandbox-images/e2b/e2b.Dockerfile
+++ b/services/runner/sandbox-images/e2b/e2b.Dockerfile
@@ -1,0 +1,36 @@
+# E2B baked template: sandbox-agent daemon + Pi. Pi-only; other harnesses deferred.
+# Build: npx @e2b/cli template create agenta-sandbox-agent -d e2b.Dockerfile
+FROM e2bdev/code-interpreter:latest
+
+USER root
+
+RUN apt-get update && apt-get install -y --no-install-recommends \
+      bash ca-certificates curl git procps \
+    && rm -rf /var/lib/apt/lists/*
+
+# node 22 — base ships node 20; pi-acp requires >=22.19
+RUN curl -fsSL https://deb.nodesource.com/setup_22.x | bash - \
+    && apt-get install -y nodejs \
+    && node --version
+
+# rivet sandbox-agent daemon (install-agent hangs in the E2B builder; replicate manually)
+RUN curl -fsSL https://releases.rivet.dev/sandbox-agent/0.4.x/install.sh | sh \
+    && sandbox-agent --version
+
+# pi-acp adapter; versions match services/agent/package.json pins
+# ENV does not persist across RUN layers in the E2B builder — paths are hardcoded
+# launcher written via base64 -d because printf '\n' is mangled in the builder
+RUN mkdir -p /root/.local/share/sandbox-agent/bin/agent_processes/pi \
+    && cd /root/.local/share/sandbox-agent/bin/agent_processes/pi \
+    && npm install pi-acp@0.0.29
+RUN npm install -g --ignore-scripts @earendil-works/pi-coding-agent@0.79.4 \
+    && pi --version || true
+RUN echo 'IyEvdXNyL2Jpbi9lbnYgc2gKc2V0IC1lCmV4ZWMgL3Jvb3QvLmxvY2FsL3NoYXJlL3NhbmRib3gtYWdlbnQvYmluL2FnZW50X3Byb2Nlc3Nlcy9waS9ub2RlX21vZHVsZXMvLmJpbi9waS1hY3AgIiRAIgo=' \
+      | base64 -d > /root/.local/share/sandbox-agent/bin/agent_processes/pi-acp \
+    && chmod +x /root/.local/share/sandbox-agent/bin/agent_processes/pi-acp
+
+# opencode is auto-installed at runtime by the daemon (install-agent opencode).
+# E2B runs on real x86-64 cloud hardware so the default linux-x64 Bun binary is correct.
+# No arch override needed here (the SIGTRAP gotcha only affects local arm64 dev machines).
+
+WORKDIR /root/work

--- a/services/runner/src/engines/sandbox_agent.ts
+++ b/services/runner/src/engines/sandbox_agent.ts
@@ -311,6 +311,7 @@ export async function runSandboxAgent(
     sandboxProvider: deps.sandboxProvider,
     createLocalCwd: deps.createLocalCwd,
     createDaytonaCwd: deps.createDaytonaCwd,
+    createE2BCwd: deps.createE2BCwd,
     durableCwd,
     resolveSkillDirs: deps.resolveSkillDirs,
     log: logger,
@@ -337,7 +338,7 @@ export async function runSandboxAgent(
   // via the Agenta extension. Tool execution always relays back to this runner, which keeps
   // private specs, scoped env, callback endpoints, and callback auth in memory.
   const piExtEnv = plan.isPi
-    ? buildPiExtensionEnv(request, !plan.isDaytona, {
+    ? buildPiExtensionEnv(request, !plan.isRemoteSandbox, {
         relayDir: plan.relayDir,
         usageOutPath: plan.usageOutPath,
         // The materialized skill names (author + forced `_agenta.*`) so Pi's own agent span
@@ -372,7 +373,7 @@ export async function runSandboxAgent(
   // store prefix, so the `finally` can unmount it. Undefined for non-session/remote/unmounted runs.
   let mountedCwd: string | undefined;
   const mountLocalDurableCwd = async (reason: string): Promise<boolean> => {
-    if (!mountCreds || plan.isDaytona) return false;
+    if (!mountCreds || plan.isRemoteSandbox) return false;
     logger(
       `local durable cwd mount (${reason}) session=${sessionForMount} cwd=${plan.cwd}`,
     );
@@ -384,7 +385,7 @@ export async function runSandboxAgent(
   };
   let localDurableCwdEnotconnRemounts = 0;
   const reSignAndRemountLocalCwd = async (): Promise<boolean> => {
-    if (!sessionForMount || !runCred || plan.isDaytona) return false;
+    if (!sessionForMount || !runCred || plan.isRemoteSandbox) return false;
     if (
       localDurableCwdEnotconnRemounts >=
       LOCAL_DURABLE_CWD_ENOTCONN_REMOUNT_LIMIT
@@ -412,7 +413,7 @@ export async function runSandboxAgent(
   };
   let runtimeRemount: Promise<boolean> | undefined;
   const remountLocalCwdAfterRuntimeEnotconn = (event: unknown): void => {
-    if (plan.isDaytona || !mountCreds || !mountedCwd) return;
+    if (plan.isRemoteSandbox || !mountCreds || !mountedCwd) return;
     if (runtimeRemount || !containsTransportEndpointDisconnected(event)) return;
     logger(
       `local durable cwd ENOTCONN observed in ACP event session=${sessionForMount} cwd=${plan.cwd}; re-signing and remounting`,
@@ -424,11 +425,12 @@ export async function runSandboxAgent(
       return false;
     });
   };
-  let workspace: { cleanup: () => Promise<void> } | undefined = plan.isDaytona
-    ? undefined
-    : {
-        cleanup: async () => rmSync(plan.cwd, { recursive: true, force: true }),
-      };
+  let workspace: { cleanup: () => Promise<void> } | undefined =
+    plan.isRemoteSandbox
+      ? undefined
+      : {
+          cleanup: async () => rmSync(plan.cwd, { recursive: true, force: true }),
+        };
 
   try {
     // Persist events in-process so a follow-up turn can resume by session id.
@@ -476,7 +478,7 @@ export async function runSandboxAgent(
     // cwd derivation). The mount lands BEFORE createSession so the session opens inside it.
     // Local: on-host geesefs; scoped creds never enter agent space.
     // Remote (Daytona): geesefs inside the sandbox over the ngrok tunnel.
-    if (mountCreds && !plan.isDaytona) {
+    if (mountCreds && !plan.isRemoteSandbox) {
       // Mount before local workspace materialization so AGENTS.md, harness files, and skills
       // land in the durable prefix instead of being hidden under the later FUSE mount.
       await mountLocalDurableCwd("initial");
@@ -490,7 +492,7 @@ export async function runSandboxAgent(
       });
     } catch (err) {
       if (
-        !plan.isDaytona &&
+        !plan.isRemoteSandbox &&
         mountCreds &&
         isTransportEndpointDisconnected(err) &&
         (await reSignAndRemountLocalCwd())
@@ -558,8 +560,9 @@ export async function runSandboxAgent(
       isPi: plan.isPi,
       capabilities,
       harness: plan.harness,
-      // Daytona: skip the internal loopback HTTP MCP channel (unreachable from the in-sandbox
-      // harness); gateway tools are delivered through the Daytona file relay started below.
+      // Any remote sandbox: skip the internal loopback HTTP MCP channel (unreachable from the
+      // in-sandbox harness); gateway tools are delivered through the file relay started below.
+      isRemote: plan.isRemoteSandbox,
       isDaytona: plan.isDaytona,
       toolSpecs: plan.toolSpecs,
       userMcpServers: request.mcpServers,
@@ -597,7 +600,7 @@ export async function runSandboxAgent(
       endpoint: request.telemetry?.exporters?.otlp?.endpoint,
       authorization: request.telemetry?.exporters?.otlp?.headers?.authorization,
       captureContent: request.telemetry?.capture?.content?.enabled,
-      emitSpans: !plan.isPi || plan.isDaytona,
+      emitSpans: !plan.isPi || plan.isRemoteSandbox,
       emit,
     });
     otel = run;
@@ -696,7 +699,7 @@ export async function runSandboxAgent(
       // permission degrades to the run's headless permission policy (the same policy the
       // PolicyResponder uses for Claude builtins above).
       toolRelay = (deps.startToolRelay ?? startToolRelay)(
-        plan.isDaytona
+        plan.isRemoteSandbox
           ? (deps.sandboxRelayHost ?? sandboxRelayHost)(sandbox)
           : (deps.localRelayHost ?? localRelayHost)(),
         plan.relayDir,
@@ -775,7 +778,7 @@ export async function runSandboxAgent(
     const usage = await resolveRunUsage({
       sandbox,
       usageOutPath: plan.usageOutPath,
-      isDaytona: plan.isDaytona,
+      isRemote: plan.isRemoteSandbox,
       promptResult: result,
       streamUsage: run.usage(),
     });
@@ -792,7 +795,7 @@ export async function runSandboxAgent(
     // sandbox).
     const swallowedPiError =
       plan.isPi &&
-      !plan.isDaytona &&
+      !plan.isRemoteSandbox &&
       !run.output().trim() &&
       !run.events().some((e) => e.type === "tool_call")
         ? findSwallowedPiError(plan.sourcePiAgentDir, plan.cwd)

--- a/services/runner/src/engines/sandbox_agent/mcp.ts
+++ b/services/runner/src/engines/sandbox_agent/mcp.ts
@@ -159,14 +159,15 @@ export interface BuildSessionMcpServersInput {
   capabilities: HarnessCapabilities;
   harness: string;
   /**
-   * True when the run executes in a REMOTE Daytona sandbox (the harness runs IN the sandbox,
-   * not on the runner host). Gates the internal gateway-tool channel: the channel's loopback
-   * (`127.0.0.1`) HTTP MCP URL resolves to the SANDBOX's loopback there, not the runner's, so
-   * advertising it would hand the in-sandbox harness an unreachable URL. On Daytona the channel
-   * is skipped and gateway tools are delivered through the file relay instead (the relay loop
-   * already polls the sandbox filesystem on Daytona — see `engines/sandbox_agent.ts`). See the
-   * Daytona guard in `buildSessionMcpServers`.
+   * True when the run executes in ANY remote sandbox (Daytona or E2B — the harness runs IN the
+   * sandbox, not on the runner host). Gates the internal gateway-tool channel: the channel's
+   * loopback (`127.0.0.1`) HTTP MCP URL resolves to the SANDBOX's loopback there, not the
+   * runner's, so advertising it would hand the in-sandbox harness an unreachable URL. On any
+   * remote sandbox the channel is skipped and gateway tools are delivered through the file relay
+   * instead (the relay loop already polls the sandbox filesystem — see `engines/sandbox_agent.ts`).
    */
+  isRemote: boolean;
+  /** True specifically for Daytona; only used to name the provider in the relay log line. */
   isDaytona: boolean;
   toolSpecs: ResolvedToolSpec[];
   userMcpServers?: McpServerConfig[];
@@ -205,6 +206,7 @@ export async function buildSessionMcpServers({
   isPi,
   capabilities,
   harness,
+  isRemote,
   isDaytona,
   toolSpecs,
   userMcpServers,
@@ -223,16 +225,16 @@ export async function buildSessionMcpServers({
   }
 
   // Layer 1: INTERNAL gateway-tool channel (do not merge with the user gate below). LOCAL ONLY:
-  // its advertised URL is a runner loopback (`127.0.0.1`), unreachable from a remote Daytona
-  // sandbox where the harness runs. On Daytona, skip the loopback HTTP advertisement and let the
-  // file relay deliver the tools (the relay loop polls the sandbox filesystem; see the Daytona
+  // its advertised URL is a runner loopback (`127.0.0.1`), unreachable from a remote sandbox
+  // where the harness runs. On any remote sandbox, skip the loopback HTTP advertisement and let
+  // the file relay deliver the tools (the relay loop polls the sandbox filesystem; see the
   // tool relay in `engines/sandbox_agent.ts`).
-  const internal = isDaytona
+  const internal = isRemote
     ? { servers: [], close: async () => {} }
     : await buildToolMcpServers(toolSpecs, relayDir, log);
-  if (isDaytona && toolSpecs.length > 0) {
+  if (isRemote && toolSpecs.length > 0) {
     log(
-      `daytona: ${toolSpecs.length} gateway tool(s) delivered via the file relay, not a ` +
+      `${isDaytona ? "daytona" : "e2b"}: ${toolSpecs.length} gateway tool(s) delivered via the file relay, not a ` +
         `loopback MCP URL (unreachable from the sandbox)`,
     );
   }

--- a/services/runner/src/engines/sandbox_agent/pi-assets.ts
+++ b/services/runner/src/engines/sandbox_agent/pi-assets.ts
@@ -198,7 +198,7 @@ export interface PrepareLocalPiAssetsInput {
   plan: Pick<
     RunPlan,
     | "isPi"
-    | "isDaytona"
+    | "isRemoteSandbox"
     | "skillDirs"
     | "hasSystemPrompt"
     | "systemPrompt"
@@ -219,7 +219,7 @@ export function prepareLocalPiAssets({
   env,
   log = () => {},
 }: PrepareLocalPiAssetsInput): string | undefined {
-  if (!plan.isPi || plan.isDaytona) return undefined;
+  if (!plan.isPi || plan.isRemoteSandbox) return undefined;
 
   if (plan.skillDirs.length > 0 || plan.hasSystemPrompt) {
     const runAgentDir = prepareLocalAgentDir(

--- a/services/runner/src/engines/sandbox_agent/provider.ts
+++ b/services/runner/src/engines/sandbox_agent/provider.ts
@@ -1,5 +1,6 @@
 import { local } from "sandbox-agent/local";
 import { daytona } from "sandbox-agent/daytona";
+import { e2b } from "sandbox-agent/e2b";
 
 import type { SandboxPermission } from "../../protocol.ts";
 import { daytonaEnvVars } from "./daytona.ts";
@@ -98,6 +99,35 @@ export function buildDaytonaCreate(
   };
 }
 
+/** Default E2B sandbox timeout (ms): self-reaps a leaked sandbox that process-KILL skips the `finally`. */
+export const DEFAULT_E2B_TIMEOUT_MS = 30 * 60 * 1000; // 30 minutes
+
+/** E2B sandbox timeout ms from env, clamped to >= 1 ms (0 would disable the backstop). */
+export function e2bTimeoutMs(
+  rawValue: string | undefined = process.env.E2B_TIMEOUT_MS,
+): number {
+  const parsed = Number(rawValue);
+  if (!Number.isFinite(parsed) || parsed < 1) return DEFAULT_E2B_TIMEOUT_MS;
+  return Math.floor(parsed);
+}
+
+/**
+ * Build the E2B provider options from the runner's env + the resolved run inputs.
+ *
+ * Pulled out as a pure function so the create options can be tested without constructing
+ * a real E2B client (which needs E2B_API_KEY).
+ */
+export function buildE2BCreate(
+  piExtEnv: Record<string, string>,
+  secrets: Record<string, string>,
+): Record<string, unknown> {
+  return {
+    envs: { ...piExtEnv, ...secrets },
+    timeoutMs: e2bTimeoutMs(),
+    autoPause: true,
+  };
+}
+
 /**
  * Build the sandbox-agent provider for the requested axis.
  *
@@ -121,6 +151,17 @@ export function buildSandboxProvider(
     return daytona({
       ...(image ? { image } : {}),
       create: buildDaytonaCreate(piExtEnv, secrets, sandboxPermission) as any,
+    });
+  }
+
+  if (sandboxId === "e2b") {
+    const template = process.env.E2B_TEMPLATE ?? "agenta-sandbox-agent";
+    const create = buildE2BCreate(piExtEnv, secrets);
+    return e2b({
+      template,
+      create: { envs: (create as any).envs } as any,
+      timeoutMs: (create as any).timeoutMs,
+      autoPause: (create as any).autoPause,
     });
   }
 

--- a/services/runner/src/engines/sandbox_agent/run-plan.ts
+++ b/services/runner/src/engines/sandbox_agent/run-plan.ts
@@ -37,6 +37,11 @@ export const LOCAL_NETWORK_UNSUPPORTED_MESSAGE =
   "Network sandbox policy is not enforceable on the local sandbox (the sidecar runs on this " +
   "host with no egress control); run on daytona, or remove sandbox_permission.network.";
 
+/** A restricted `network` policy on E2B is not enforceable (the e2b provider exposes no egress control). */
+export const E2B_NETWORK_UNSUPPORTED_MESSAGE =
+  "Network sandbox policy is not enforceable on the e2b sandbox (the sandbox-agent/e2b " +
+  "provider exposes no egress control); run on daytona, or remove sandbox_permission.network.";
+
 /** `filesystem` confinement is declared on the wire but applied by no backend. */
 export const FILESYSTEM_UNSUPPORTED_MESSAGE =
   "Filesystem sandbox policy is not implemented (no backend applies a filesystem jail); " +
@@ -48,6 +53,9 @@ export interface RunPlan {
   sandboxId: string;
   isPi: boolean;
   isDaytona: boolean;
+  isE2B: boolean;
+  /** True for any remote sandbox (`isDaytona || isE2B`); use for remoteness-only checks. */
+  isRemoteSandbox: boolean;
   prompt: string;
   turnText: string;
   agentsMd?: string;
@@ -104,6 +112,7 @@ export interface BuildRunPlanDeps {
   sandboxProvider?: string;
   createLocalCwd?: (durableCwd?: string) => string;
   createDaytonaCwd?: (durableCwd?: string) => string;
+  createE2BCwd?: () => string;
   /** Pre-computed durable cwd derived from the sign prefix; when set, skips the ephemeral helpers. */
   durableCwd?: string;
   resolveSkillDirs?: typeof defaultResolveSkillDirs;
@@ -149,12 +158,17 @@ function defaultDaytonaCwd(durableCwd?: string): string {
   return durableCwd ?? `/home/sandbox/agenta-${randomBytes(6).toString("hex")}`;
 }
 
+function defaultE2BCwd(): string {
+  return `/root/work/agenta-${randomBytes(6).toString("hex")}`;
+}
+
 export function buildRunPlan(
   request: AgentRunRequest,
   {
     sandboxProvider = process.env.SANDBOX_AGENT_PROVIDER,
     createLocalCwd = defaultLocalCwd,
     createDaytonaCwd = defaultDaytonaCwd,
+    createE2BCwd = defaultE2BCwd,
     durableCwd,
     resolveSkillDirs = defaultResolveSkillDirs,
     log = () => {},
@@ -187,6 +201,8 @@ export function buildRunPlan(
 
   const isPi = acpAgent === "pi";
   const isDaytona = sandboxId === "daytona";
+  const isE2B = sandboxId === "e2b";
+  const isRemoteSandbox = isDaytona || isE2B;
 
   const secrets = request.secrets ?? {};
   // opencode accepts both providers; fall back to OPENAI_API_KEY as the legacy heuristic var.
@@ -209,10 +225,14 @@ export function buildRunPlan(
 
   // A restricted `network` policy on the LOCAL sandbox cannot be enforced (the sidecar runs on
   // this host with no per-run egress control), so it errors regardless of `enforcement`. On
-  // Daytona the policy IS applied (`provider.ts` `daytonaNetworkFields`).
+  // Daytona the policy IS applied (`provider.ts` `daytonaNetworkFields`). E2B exposes no egress
+  // control in the sandbox-agent/e2b wrapper, so it is refused like local.
   const network = request.sandboxPermission?.network;
   const networkRestricted = !!network && (network.mode ?? "on") !== "on";
-  if (networkRestricted && !isDaytona) {
+  if (networkRestricted && isE2B) {
+    return { ok: false, error: E2B_NETWORK_UNSUPPORTED_MESSAGE };
+  }
+  if (networkRestricted && !isDaytona && !isE2B) {
     return { ok: false, error: LOCAL_NETWORK_UNSUPPORTED_MESSAGE };
   }
 
@@ -266,13 +286,21 @@ export function buildRunPlan(
     }
   }
 
-  const cwd = isDaytona ? createDaytonaCwd(durableCwd) : createLocalCwd(durableCwd);
+  const cwd = isDaytona
+    ? createDaytonaCwd(durableCwd)
+    : isE2B
+      ? createE2BCwd()
+      : createLocalCwd(durableCwd);
   // The tool-relay scratch (req/res JSON) is ephemeral runner<->child IPC, NOT durable session
   // data — keep it OFF the geesefs-mounted cwd. A relay dir inside the mount routes every tool
   // call through FUSE/S3, so a flaky mount surfaces as ENOTCONN on the relay file. Use an
   // ephemeral sibling: a plain host tmp dir (local) or an in-VM dir (daytona), never the mount.
+  // E2B: the relay is polled through the sandbox FS API, so the dir must live IN the sandbox;
+  // the E2B cwd is never geesefs-mounted, so nesting under it is safe.
   const relayBase = isDaytona ? "/home/sandbox/agenta/relay" : join(tmpdir(), "agenta", "relay");
-  const relayDir = join(relayBase, basename(cwd));
+  const relayDir = isE2B
+    ? `${cwd}/.agenta-tools`
+    : join(relayBase, basename(cwd));
 
   // Skills materialize once from the resolved inline packages. Pi/Agenta consume the dirs
   // through Pi's agent-dir user scope; Claude consumes the same packages from the project-local
@@ -312,6 +340,8 @@ export function buildRunPlan(
       sandboxId,
       isPi,
       isDaytona,
+      isE2B,
+      isRemoteSandbox,
       prompt,
       turnText: buildTurnText(request),
       agentsMd: request.agentsMd?.trim() || undefined,

--- a/services/runner/src/engines/sandbox_agent/usage.ts
+++ b/services/runner/src/engines/sandbox_agent/usage.ts
@@ -6,12 +6,12 @@ import type { AgentRunResult, AgentUsage } from "../../protocol.ts";
 export async function readRunUsage(
   sandbox: any,
   path: string | undefined,
-  isDaytona: boolean,
+  isRemote: boolean,
 ): Promise<AgentRunResult["usage"]> {
   if (!path) return undefined;
   try {
     let raw: string;
-    if (isDaytona) {
+    if (isRemote) {
       const bytes = await sandbox.readFsFile({ path });
       raw = typeof bytes === "string" ? bytes : new TextDecoder().decode(bytes);
     } else {
@@ -43,18 +43,18 @@ export function mergePromptAndStreamUsage(
 export async function resolveRunUsage({
   sandbox,
   usageOutPath,
-  isDaytona,
+  isRemote,
   promptResult,
   streamUsage,
 }: {
   sandbox: any;
   usageOutPath: string | undefined;
-  isDaytona: boolean;
+  isRemote: boolean;
   promptResult: any;
   streamUsage: AgentUsage | undefined;
 }): Promise<AgentRunResult["usage"]> {
   return (
-    (await readRunUsage(sandbox, usageOutPath, isDaytona)) ??
+    (await readRunUsage(sandbox, usageOutPath, isRemote)) ??
     mergePromptAndStreamUsage(promptResult, streamUsage)
   );
 }

--- a/services/runner/src/engines/sandbox_agent/workspace.ts
+++ b/services/runner/src/engines/sandbox_agent/workspace.ts
@@ -14,7 +14,7 @@ export interface PrepareWorkspaceInput {
   sandbox: any;
   plan: Pick<
     RunPlan,
-    | "isDaytona"
+    | "isRemoteSandbox"
     | "isPi"
     | "cwd"
     | "relayDir"
@@ -42,7 +42,7 @@ export async function prepareWorkspace({
   const harnessFiles = plan.harnessFiles ?? [];
   const projectSkillRoot = plan.isPi ? undefined : `.${plan.acpAgent}/skills`;
 
-  if (plan.isDaytona) {
+  if (plan.isRemoteSandbox) {
     await sandbox.mkdirFs({ path: plan.cwd }).catch((err: Error) => {
       log(`workspace mkdir skipped: ${err.message}`);
     });

--- a/services/runner/tests/unit/sandbox-agent-e2b-provider.test.ts
+++ b/services/runner/tests/unit/sandbox-agent-e2b-provider.test.ts
@@ -1,0 +1,101 @@
+/**
+ * Unit tests for the E2B provider options and leak-backstop logic.
+ *
+ * `buildE2BCreate` is tested directly because the real `e2b()` provider constructs an
+ * E2B client (needs E2B_API_KEY), so it cannot be inspected through `buildSandboxProvider`.
+ *
+ * Run: pnpm test (or: pnpm exec vitest run tests/unit/sandbox-agent-e2b-provider.test.ts)
+ */
+import { afterEach, describe, it } from "vitest";
+import assert from "node:assert/strict";
+
+import {
+  DEFAULT_E2B_TIMEOUT_MS,
+  buildE2BCreate,
+  e2bTimeoutMs,
+} from "../../src/engines/sandbox_agent/provider.ts";
+
+const TIMEOUT_ENV = "E2B_TIMEOUT_MS";
+const previousTimeout = process.env[TIMEOUT_ENV];
+
+afterEach(() => {
+  if (previousTimeout === undefined) delete process.env[TIMEOUT_ENV];
+  else process.env[TIMEOUT_ENV] = previousTimeout;
+});
+
+describe("e2bTimeoutMs (leak backstop)", () => {
+  it("uses the env value when it is a positive integer", () => {
+    assert.equal(e2bTimeoutMs("60000"), 60000);
+  });
+
+  it("floors a fractional env value", () => {
+    assert.equal(e2bTimeoutMs("12000.9"), 12000);
+  });
+
+  it("falls back to the default when the env is unset", () => {
+    assert.equal(e2bTimeoutMs(undefined), DEFAULT_E2B_TIMEOUT_MS);
+  });
+
+  it("falls back to the default for a non-numeric env value", () => {
+    assert.equal(e2bTimeoutMs("soon"), DEFAULT_E2B_TIMEOUT_MS);
+  });
+
+  it("clamps 0 to the default so the backstop is never disabled", () => {
+    assert.equal(e2bTimeoutMs("0"), DEFAULT_E2B_TIMEOUT_MS);
+  });
+
+  it("clamps a negative value to the default", () => {
+    assert.equal(e2bTimeoutMs("-5000"), DEFAULT_E2B_TIMEOUT_MS);
+  });
+
+  it("the default is a positive backstop (never zero)", () => {
+    assert.ok(DEFAULT_E2B_TIMEOUT_MS >= 1);
+  });
+});
+
+describe("buildE2BCreate (leak backstop on the create object)", () => {
+  it("carries a positive timeoutMs + autoPause by default (self-reaps a leak)", () => {
+    delete process.env[TIMEOUT_ENV];
+    const create = buildE2BCreate({}, {});
+    assert.equal((create as any).timeoutMs, DEFAULT_E2B_TIMEOUT_MS);
+    assert.ok(
+      ((create as any).timeoutMs as number) > 0,
+      "timeoutMs must be > 0 or the sandbox never self-reaps on process KILL",
+    );
+    assert.equal((create as any).autoPause, true);
+  });
+
+  it("carries the env-configured timeoutMs", () => {
+    process.env[TIMEOUT_ENV] = "120000";
+    const create = buildE2BCreate({}, {});
+    assert.equal((create as any).timeoutMs, 120000);
+    assert.equal((create as any).autoPause, true);
+  });
+
+  it("merges piExtEnv and secrets into envs", () => {
+    const create = buildE2BCreate(
+      { TRACEPARENT: "trace-id", OTEL_EXPORTER_OTLP_TRACES_ENDPOINT: "http://otel" },
+      { OPENAI_API_KEY: "sk-test" },
+    );
+    assert.deepEqual((create as any).envs, {
+      TRACEPARENT: "trace-id",
+      OTEL_EXPORTER_OTLP_TRACES_ENDPOINT: "http://otel",
+      OPENAI_API_KEY: "sk-test",
+    });
+  });
+
+  it("produces empty envs when no env or secrets are passed", () => {
+    const create = buildE2BCreate({}, {});
+    assert.deepEqual((create as any).envs, {});
+  });
+
+  it("opencode ANTHROPIC_API_KEY secrets reach buildE2BCreate envs", () => {
+    const create = buildE2BCreate({}, { ANTHROPIC_API_KEY: "sk-ant-test" });
+    assert.equal((create as any).envs.ANTHROPIC_API_KEY, "sk-ant-test");
+  });
+
+  it("opencode OPENAI_API_KEY secrets also reach buildE2BCreate envs", () => {
+    const create = buildE2BCreate({}, { OPENAI_API_KEY: "sk-oai-test" });
+    assert.equal((create as any).envs.OPENAI_API_KEY, "sk-oai-test");
+  });
+});

--- a/services/runner/tests/unit/sandbox-agent-e2b-run-plan.test.ts
+++ b/services/runner/tests/unit/sandbox-agent-e2b-run-plan.test.ts
@@ -1,0 +1,225 @@
+/**
+ * Unit tests for E2B-specific run-plan normalization.
+ *
+ * Run: pnpm test (or: pnpm exec vitest run tests/unit/sandbox-agent-e2b-run-plan.test.ts)
+ */
+import { describe, it } from "vitest";
+import assert from "node:assert/strict";
+
+import type { AgentRunRequest } from "../../src/protocol.ts";
+import {
+  buildRunPlan,
+  E2B_NETWORK_UNSUPPORTED_MESSAGE,
+} from "../../src/engines/sandbox_agent/run-plan.ts";
+
+describe("buildRunPlan — E2B sandbox", () => {
+  it("sets isE2B and uses the E2B cwd factory", () => {
+    const result = buildRunPlan(
+      {
+        harness: "pi_core",
+        sandbox: "e2b",
+        messages: [{ role: "user", content: "hello" }],
+      } as AgentRunRequest,
+      { createE2BCwd: () => "/root/work/agenta-abc123" },
+    );
+
+    assert.equal(result.ok, true);
+    if (!result.ok) return;
+    assert.equal(result.plan.isE2B, true);
+    assert.equal(result.plan.isDaytona, false);
+    assert.equal(result.plan.isRemoteSandbox, true);
+    assert.equal(result.plan.sandboxId, "e2b");
+    assert.equal(result.plan.cwd, "/root/work/agenta-abc123");
+    assert.equal(result.plan.relayDir, "/root/work/agenta-abc123/.agenta-tools");
+  });
+
+  it("local runs have isE2B=false and isRemoteSandbox=false", () => {
+    const result = buildRunPlan(
+      {
+        harness: "pi_core",
+        sandbox: "local",
+        messages: [{ role: "user", content: "hello" }],
+      } as AgentRunRequest,
+      { createLocalCwd: () => "/tmp/local-cwd" },
+    );
+
+    assert.equal(result.ok, true);
+    if (!result.ok) return;
+    assert.equal(result.plan.isE2B, false);
+    assert.equal(result.plan.isRemoteSandbox, false);
+  });
+
+  it("daytona runs have isE2B=false and isRemoteSandbox=true", () => {
+    const result = buildRunPlan(
+      {
+        harness: "claude",
+        sandbox: "daytona",
+        messages: [{ role: "user", content: "hello" }],
+      } as AgentRunRequest,
+      { createDaytonaCwd: () => "/home/sandbox/agenta-fixed" },
+    );
+
+    assert.equal(result.ok, true);
+    if (!result.ok) return;
+    assert.equal(result.plan.isE2B, false);
+    assert.equal(result.plan.isDaytona, true);
+    assert.equal(result.plan.isRemoteSandbox, true);
+  });
+
+  it("refuses a restricted-network E2B run under strict (no egress control)", () => {
+    const result = buildRunPlan(
+      {
+        harness: "pi_core",
+        sandbox: "e2b",
+        messages: [{ role: "user", content: "hello" }],
+        sandboxPermission: {
+          network: { mode: "off" },
+          enforcement: "strict",
+        },
+      } as AgentRunRequest,
+      { createE2BCwd: () => "/root/work/agenta-abc123" },
+    );
+
+    assert.equal(result.ok, false);
+    if (result.ok) return;
+    assert.match(result.error, /not enforceable on the e2b sandbox/);
+  });
+
+  it("refuses a restricted-network E2B run even under best_effort (no silent unenforced boundary)", () => {
+    const result = buildRunPlan(
+      {
+        harness: "pi_core",
+        sandbox: "e2b",
+        messages: [{ role: "user", content: "hello" }],
+        sandboxPermission: {
+          network: { mode: "allowlist", allowlist: ["10.0.0.0/8"] },
+          enforcement: "best_effort",
+        },
+      } as AgentRunRequest,
+      { createE2BCwd: () => "/root/work/agenta-abc123" },
+    );
+
+    assert.equal(result.ok, false);
+    if (result.ok) return;
+    assert.match(result.error, /not enforceable on the e2b sandbox/);
+  });
+
+  it("the E2B refusal message is the E2B_NETWORK_UNSUPPORTED_MESSAGE constant", () => {
+    const result = buildRunPlan(
+      {
+        harness: "pi_core",
+        sandbox: "e2b",
+        messages: [{ role: "user", content: "hello" }],
+        sandboxPermission: { network: { mode: "off" }, enforcement: "strict" },
+      } as AgentRunRequest,
+      { createE2BCwd: () => "/root/work/agenta-abc123" },
+    );
+
+    assert.equal(result.ok, false);
+    if (result.ok) return;
+    assert.equal(result.error, E2B_NETWORK_UNSUPPORTED_MESSAGE);
+  });
+
+  it("allows an unrestricted (network: on) E2B run", () => {
+    const result = buildRunPlan(
+      {
+        harness: "pi_core",
+        sandbox: "e2b",
+        messages: [{ role: "user", content: "hello" }],
+        sandboxPermission: {
+          network: { mode: "on" },
+          enforcement: "strict",
+        },
+      } as AgentRunRequest,
+      { createE2BCwd: () => "/root/work/agenta-abc123" },
+    );
+
+    assert.equal(result.ok, true);
+  });
+
+  it("allows an E2B run with no sandbox permission", () => {
+    const result = buildRunPlan(
+      {
+        harness: "pi_core",
+        sandbox: "e2b",
+        messages: [{ role: "user", content: "hello" }],
+      } as AgentRunRequest,
+      { createE2BCwd: () => "/root/work/agenta-abc123" },
+    );
+
+    assert.equal(result.ok, true);
+  });
+
+  it("opencode on E2B: acpAgent=opencode with isE2B/isRemoteSandbox true", () => {
+    const result = buildRunPlan(
+      {
+        harness: "opencode",
+        sandbox: "e2b",
+        messages: [{ role: "user", content: "hello" }],
+        secrets: { ANTHROPIC_API_KEY: "sk-ant" },
+        credentialMode: "env",
+      } as AgentRunRequest,
+      { createE2BCwd: () => "/root/work/agenta-abc123" },
+    );
+
+    assert.equal(result.ok, true);
+    if (!result.ok) return;
+    assert.equal(result.plan.harness, "opencode");
+    assert.equal(result.plan.acpAgent, "opencode");
+    assert.equal(result.plan.isPi, false);
+    assert.equal(result.plan.isDaytona, false);
+    assert.equal(result.plan.isE2B, true);
+    assert.equal(result.plan.isRemoteSandbox, true);
+    assert.equal(result.plan.cwd, "/root/work/agenta-abc123");
+  });
+
+  it("opencode on E2B: restricted network is refused (no egress control)", () => {
+    const result = buildRunPlan(
+      {
+        harness: "opencode",
+        sandbox: "e2b",
+        messages: [{ role: "user", content: "hello" }],
+        sandboxPermission: { network: { mode: "off" }, enforcement: "strict" },
+      } as AgentRunRequest,
+      { createE2BCwd: () => "/root/work/agenta-abc123" },
+    );
+
+    assert.equal(result.ok, false);
+    if (result.ok) return;
+    assert.equal(result.error, E2B_NETWORK_UNSUPPORTED_MESSAGE);
+  });
+
+  it("opencode on E2B: ANTHROPIC_API_KEY secrets reach the plan", () => {
+    const result = buildRunPlan(
+      {
+        harness: "opencode",
+        sandbox: "e2b",
+        messages: [{ role: "user", content: "hi" }],
+        secrets: { ANTHROPIC_API_KEY: "sk-ant-e2b" },
+        credentialMode: "env",
+      } as AgentRunRequest,
+      { createE2BCwd: () => "/root/work/agenta-abc123" },
+    );
+
+    assert.equal(result.ok, true);
+    if (!result.ok) return;
+    assert.deepEqual(result.plan.secrets, { ANTHROPIC_API_KEY: "sk-ant-e2b" });
+  });
+
+  it("opencode on E2B: OPENAI_API_KEY secrets reach the plan (legacy heuristic var)", () => {
+    const result = buildRunPlan(
+      {
+        harness: "opencode",
+        sandbox: "e2b",
+        messages: [{ role: "user", content: "hi" }],
+        secrets: { OPENAI_API_KEY: "sk-oai-e2b" },
+      } as AgentRunRequest,
+      { createE2BCwd: () => "/root/work/agenta-abc123" },
+    );
+
+    assert.equal(result.ok, true);
+    if (!result.ok) return;
+    assert.deepEqual(result.plan.secrets, { OPENAI_API_KEY: "sk-oai-e2b" });
+    assert.equal(result.plan.legacyHarnessApiKeyVar, "OPENAI_API_KEY");
+  });
+});

--- a/services/runner/tests/unit/sandbox-agent-provider.test.ts
+++ b/services/runner/tests/unit/sandbox-agent-provider.test.ts
@@ -13,17 +13,24 @@ import assert from "node:assert/strict";
 
 import {
   DEFAULT_DAYTONA_AUTOSTOP_MINUTES,
+  DEFAULT_E2B_TIMEOUT_MS,
   buildDaytonaCreate,
+  buildE2BCreate,
   daytonaAutoStopMinutes,
   daytonaNetworkFields,
+  e2bTimeoutMs,
 } from "../../src/engines/sandbox_agent/provider.ts";
 
 const AUTOSTOP_ENV = "DAYTONA_AUTOSTOP";
+const E2B_TIMEOUT_ENV = "E2B_TIMEOUT_MS";
 const previousAutoStop = process.env[AUTOSTOP_ENV];
+const previousE2BTimeout = process.env[E2B_TIMEOUT_ENV];
 
 afterEach(() => {
   if (previousAutoStop === undefined) delete process.env[AUTOSTOP_ENV];
   else process.env[AUTOSTOP_ENV] = previousAutoStop;
+  if (previousE2BTimeout === undefined) delete process.env[E2B_TIMEOUT_ENV];
+  else process.env[E2B_TIMEOUT_ENV] = previousE2BTimeout;
 });
 
 describe("daytonaNetworkFields", () => {
@@ -124,5 +131,73 @@ describe("buildDaytonaCreate (leak backstop on the create object)", () => {
     const create = buildDaytonaCreate({}, {}, undefined);
     assert.equal(create.autoStopInterval, 42);
     assert.equal(create.ephemeral, true);
+  });
+});
+
+describe("e2bTimeoutMs (leak backstop)", () => {
+  it("uses the env value when it is a positive integer", () => {
+    assert.equal(e2bTimeoutMs("60000"), 60000);
+  });
+
+  it("floors a fractional env value", () => {
+    assert.equal(e2bTimeoutMs("1500.9"), 1500);
+  });
+
+  it("falls back to the default when env is unset", () => {
+    assert.equal(e2bTimeoutMs(undefined), DEFAULT_E2B_TIMEOUT_MS);
+  });
+
+  it("falls back to the default for a non-numeric env value", () => {
+    assert.equal(e2bTimeoutMs("soon"), DEFAULT_E2B_TIMEOUT_MS);
+  });
+
+  it("clamps 0 to the default so the backstop is never re-disabled", () => {
+    assert.equal(e2bTimeoutMs("0"), DEFAULT_E2B_TIMEOUT_MS);
+  });
+
+  it("clamps a negative env value to the default", () => {
+    assert.equal(e2bTimeoutMs("-1000"), DEFAULT_E2B_TIMEOUT_MS);
+  });
+
+  it("the default is a positive backstop (timeout stays ON)", () => {
+    assert.ok(DEFAULT_E2B_TIMEOUT_MS >= 1);
+  });
+});
+
+describe("buildE2BCreate (envs + timeout + autoPause)", () => {
+  it("merges piExtEnv and secrets into envs, carries timeoutMs and autoPause:true", () => {
+    delete process.env[E2B_TIMEOUT_ENV];
+    const create = buildE2BCreate(
+      { TRACE_ID: "t1" },
+      { ANTHROPIC_API_KEY: "sk-ant" },
+    );
+    assert.deepEqual((create as any).envs, {
+      TRACE_ID: "t1",
+      ANTHROPIC_API_KEY: "sk-ant",
+    });
+    assert.equal((create as any).autoPause, true);
+    assert.equal((create as any).timeoutMs, DEFAULT_E2B_TIMEOUT_MS);
+    assert.ok(
+      (create as any).timeoutMs > 0,
+      "timeoutMs must be > 0 or the backstop is disabled",
+    );
+  });
+
+  it("carries an env-configured timeout", () => {
+    process.env[E2B_TIMEOUT_ENV] = "900000";
+    const create = buildE2BCreate({}, {});
+    assert.equal((create as any).timeoutMs, 900000);
+  });
+
+  it("opencode provider key (ANTHROPIC_API_KEY) lands in envs via secrets", () => {
+    delete process.env[E2B_TIMEOUT_ENV];
+    const create = buildE2BCreate({}, { ANTHROPIC_API_KEY: "sk-ant-test" });
+    assert.equal((create as any).envs.ANTHROPIC_API_KEY, "sk-ant-test");
+  });
+
+  it("opencode OPENAI_API_KEY variant also lands in envs", () => {
+    delete process.env[E2B_TIMEOUT_ENV];
+    const create = buildE2BCreate({}, { OPENAI_API_KEY: "sk-oai-test" });
+    assert.equal((create as any).envs.OPENAI_API_KEY, "sk-oai-test");
   });
 });

--- a/services/runner/tests/unit/sandbox-agent-run-plan.test.ts
+++ b/services/runner/tests/unit/sandbox-agent-run-plan.test.ts
@@ -10,6 +10,7 @@ import type { AgentRunRequest } from "../../src/protocol.ts";
 import {
   buildRunPlan,
   shouldUploadOwnLogin,
+  E2B_NETWORK_UNSUPPORTED_MESSAGE,
 } from "../../src/engines/sandbox_agent/run-plan.ts";
 
 const previousPiDir = process.env.PI_CODING_AGENT_DIR;
@@ -77,6 +78,7 @@ describe("buildRunPlan", () => {
     assert.equal(result.plan.harness, "pi_agenta");
     assert.equal(result.plan.acpAgent, "pi");
     assert.equal(result.plan.sandboxId, "local");
+    assert.equal(result.plan.isRemoteSandbox, false);
     assert.equal(result.plan.cwd, "/tmp/local-cwd");
     // The relay dir + usage capture are ephemeral runner files kept OFF the (possibly geesefs)
     // cwd: an ephemeral sibling whose leaf is the cwd basename.
@@ -593,6 +595,7 @@ describe("buildRunPlan", () => {
     assert.equal(result.plan.acpAgent, "claude");
     assert.equal(result.plan.isPi, false);
     assert.equal(result.plan.isDaytona, true);
+    assert.equal(result.plan.isRemoteSandbox, true);
     assert.equal(result.plan.cwd, "/home/sandbox/agenta-fixed");
     assert.equal(result.plan.usageOutPath, undefined);
     assert.equal(result.plan.legacyHarnessApiKeyVar, "ANTHROPIC_API_KEY");
@@ -644,6 +647,115 @@ describe("buildRunPlan", () => {
     if (!result.ok) return;
     assert.equal(result.plan.legacyHarnessApiKeyVar, "OPENAI_API_KEY");
     assert.equal(result.plan.hasApiKey, true);
+  });
+
+  it("normalizes an opencode-on-E2B run: isE2B=true, cwd under /root/work", () => {
+    const result = buildRunPlan(
+      {
+        harness: "opencode",
+        sandbox: "e2b",
+        messages: [{ role: "user", content: "hello" }],
+        secrets: { ANTHROPIC_API_KEY: "sk-ant" },
+        credentialMode: "env",
+      },
+      { createE2BCwd: () => "/root/work/agenta-abc123" },
+    );
+
+    assert.equal(result.ok, true);
+    if (!result.ok) return;
+    assert.equal(result.plan.harness, "opencode");
+    assert.equal(result.plan.acpAgent, "opencode");
+    assert.equal(result.plan.isPi, false);
+    assert.equal(result.plan.isDaytona, false);
+    assert.equal(result.plan.isE2B, true);
+    assert.equal(result.plan.isRemoteSandbox, true);
+    assert.equal(result.plan.cwd, "/root/work/agenta-abc123");
+    assert.equal(result.plan.usageOutPath, undefined);
+    assert.equal(result.plan.credentialMode, "env");
+  });
+
+  it("opencode-on-E2B: restricted network is refused (E2B has no egress control)", () => {
+    const result = buildRunPlan(
+      {
+        harness: "opencode",
+        sandbox: "e2b",
+        messages: [{ role: "user", content: "hello" }],
+        sandboxPermission: { network: { mode: "off" }, enforcement: "strict" },
+      } as AgentRunRequest,
+      { createE2BCwd: () => "/root/work/agenta-abc123" },
+    );
+
+    assert.equal(result.ok, false);
+    if (result.ok) return;
+    assert.equal(result.error, E2B_NETWORK_UNSUPPORTED_MESSAGE);
+  });
+
+  it("opencode-on-E2B: restricted network refused even under best_effort (no egress API)", () => {
+    const result = buildRunPlan(
+      {
+        harness: "opencode",
+        sandbox: "e2b",
+        messages: [{ role: "user", content: "hello" }],
+        sandboxPermission: { network: { mode: "off" }, enforcement: "best_effort" },
+      } as AgentRunRequest,
+      { createE2BCwd: () => "/root/work/agenta-abc123" },
+    );
+
+    assert.equal(result.ok, false);
+    if (result.ok) return;
+    assert.equal(result.error, E2B_NETWORK_UNSUPPORTED_MESSAGE);
+  });
+
+  it("opencode-on-E2B: unrestricted network (mode:on) is allowed", () => {
+    const result = buildRunPlan(
+      {
+        harness: "opencode",
+        sandbox: "e2b",
+        messages: [{ role: "user", content: "hello" }],
+        sandboxPermission: { network: { mode: "on" }, enforcement: "strict" },
+      } as AgentRunRequest,
+      { createE2BCwd: () => "/root/work/agenta-abc123" },
+    );
+
+    assert.equal(result.ok, true);
+  });
+
+  it("opencode-on-E2B: ANTHROPIC_API_KEY in secrets reaches the plan", () => {
+    const result = buildRunPlan(
+      {
+        harness: "opencode",
+        sandbox: "e2b",
+        messages: [{ role: "user", content: "hi" }],
+        secrets: { ANTHROPIC_API_KEY: "sk-ant-e2b" },
+        credentialMode: "env",
+      },
+      { createE2BCwd: () => "/root/work/agenta-abc123" },
+    );
+
+    assert.equal(result.ok, true);
+    if (!result.ok) return;
+    assert.deepEqual(result.plan.secrets, { ANTHROPIC_API_KEY: "sk-ant-e2b" });
+  });
+
+  it("planMode is false for opencode (static fallback; no E2B-specific change)", () => {
+    // capabilities.ts static fallback already excludes opencode from planMode;
+    // this is a run-plan smoke-check that the harness/acpAgent mapping is correct.
+    const result = buildRunPlan(
+      {
+        harness: "opencode",
+        sandbox: "e2b",
+        messages: [{ role: "user", content: "build it" }],
+        secrets: { ANTHROPIC_API_KEY: "sk-ant" },
+      },
+      { createE2BCwd: () => "/root/work/agenta-abc123" },
+    );
+
+    assert.equal(result.ok, true);
+    if (!result.ok) return;
+    // acpAgent "opencode" is what the daemon receives; planMode gate is in capabilities.ts
+    assert.equal(result.plan.acpAgent, "opencode");
+    assert.equal(result.plan.isE2B, true);
+    assert.equal(result.plan.isRemoteSandbox, true);
   });
 });
 

--- a/services/runner/tests/unit/sandbox-agent-usage.test.ts
+++ b/services/runner/tests/unit/sandbox-agent-usage.test.ts
@@ -43,6 +43,19 @@ describe("readRunUsage", () => {
       cost: 0,
     });
   });
+
+  it("reads E2B Pi usage writeback through the sandbox fs API (isRemote=true)", async () => {
+    const sandbox = {
+      readFsFile: async () => JSON.stringify({ input: 2, output: 6, total: 8, cost: 0.01 }),
+    };
+
+    assert.deepEqual(await readRunUsage(sandbox, "/tmp/usage.json", true), {
+      input: 2,
+      output: 6,
+      total: 8,
+      cost: 0.01,
+    });
+  });
 });
 
 describe("mergePromptAndStreamUsage", () => {
@@ -72,11 +85,28 @@ describe("resolveRunUsage", () => {
       await resolveRunUsage({
         sandbox: {},
         usageOutPath: file,
-        isDaytona: false,
+        isRemote: false,
         promptResult: { usage: { inputTokens: 99, outputTokens: 99 } },
         streamUsage: { input: 0, output: 0, total: 0, cost: 1 },
       }),
       { input: 3, output: 4, total: 7, cost: 0.03 },
+    );
+  });
+
+  it("reads E2B Pi usage through sandbox fs API when isRemote=true", async () => {
+    const sandbox = {
+      readFsFile: async () => JSON.stringify({ input: 5, output: 10, total: 15, cost: 0.05 }),
+    };
+
+    assert.deepEqual(
+      await resolveRunUsage({
+        sandbox,
+        usageOutPath: "/tmp/usage.json",
+        isRemote: true,
+        promptResult: { usage: { inputTokens: 99, outputTokens: 99 } },
+        streamUsage: { input: 0, output: 0, total: 0, cost: 1 },
+      }),
+      { input: 5, output: 10, total: 15, cost: 0.05 },
     );
   });
 });

--- a/services/runner/tests/unit/sandbox-agent-workspace.test.ts
+++ b/services/runner/tests/unit/sandbox-agent-workspace.test.ts
@@ -30,7 +30,7 @@ describe("prepareWorkspace", () => {
     const workspace = await prepareWorkspace({
       sandbox: {},
       plan: {
-        isDaytona: false,
+        isRemoteSandbox: false,
         cwd,
         relayDir: join(cwd, ".agenta-tools"),
         useToolRelay: true,
@@ -69,7 +69,7 @@ describe("prepareWorkspace", () => {
     const workspace = await prepareWorkspace({
       sandbox: {},
       plan: {
-        isDaytona: false,
+        isRemoteSandbox: false,
         cwd,
         relayDir: join(cwd, ".agenta-tools"),
         useToolRelay: false,
@@ -95,7 +95,7 @@ describe("prepareWorkspace", () => {
     await prepareWorkspace({
       sandbox: {},
       plan: {
-        isDaytona: false,
+        isRemoteSandbox: false,
         cwd,
         relayDir: join(cwd, ".agenta-tools"),
         useToolRelay: false,
@@ -120,7 +120,7 @@ describe("prepareWorkspace", () => {
     const workspace = await prepareWorkspace({
       sandbox,
       plan: {
-        isDaytona: true,
+        isRemoteSandbox: true,
         cwd: "/home/sandbox/agenta-fixed",
         relayDir: "/home/sandbox/agenta-fixed/.agenta-tools",
         useToolRelay: true,
@@ -155,7 +155,7 @@ describe("prepareWorkspace", () => {
     await prepareWorkspace({
       sandbox,
       plan: {
-        isDaytona: true,
+        isRemoteSandbox: true,
         cwd: "/home/sandbox/agenta-fixed",
         relayDir: "/home/sandbox/agenta-fixed/.agenta-tools",
         useToolRelay: false,
@@ -193,7 +193,7 @@ describe("prepareWorkspace", () => {
     await prepareWorkspace({
       sandbox,
       plan: {
-        isDaytona: true,
+        isRemoteSandbox: true,
         cwd: "/home/sandbox/agenta-fixed",
         relayDir: "/home/sandbox/agenta-fixed/.agenta-tools",
         useToolRelay: false,
@@ -219,7 +219,7 @@ describe("prepareWorkspace", () => {
     await prepareWorkspace({
       sandbox: {},
       plan: {
-        isDaytona: false,
+        isRemoteSandbox: false,
         cwd,
         relayDir: join(cwd, ".agenta-tools"),
         useToolRelay: false,
@@ -251,7 +251,7 @@ describe("prepareWorkspace", () => {
     await prepareWorkspace({
       sandbox,
       plan: {
-        isDaytona: true,
+        isRemoteSandbox: true,
         cwd: "/home/sandbox/agenta-fixed",
         relayDir: "/home/sandbox/agenta-fixed/.agenta-tools",
         useToolRelay: false,
@@ -269,6 +269,131 @@ describe("prepareWorkspace", () => {
             "/home/sandbox/agenta-fixed/.claude/skills/release-notes/SKILL.md",
       ),
       "SKILL.md is uploaded to Claude's project-local skill tree",
+    );
+  });
+
+  it("prepares an E2B cwd through the sandbox fs API (same path as Daytona)", async () => {
+    const calls: Array<{ op: "mkdir" | "write"; path: string; body?: string }> = [];
+    const sandbox = {
+      mkdirFs: async ({ path }: { path: string }) => calls.push({ op: "mkdir", path }),
+      writeFsFile: async ({ path }: { path: string }, body: string) =>
+        calls.push({ op: "write", path, body }),
+    };
+
+    const workspace = await prepareWorkspace({
+      sandbox,
+      plan: {
+        isRemoteSandbox: true,
+        cwd: "/root/work/agenta-e2btest",
+        relayDir: "/root/work/agenta-e2btest/.agenta-tools",
+        useToolRelay: true,
+        agentsMd: "agent instructions",
+        acpAgent: "opencode",
+        isPi: false,
+        skillDirs: [],
+      },
+    });
+    await workspace.cleanup();
+
+    assert.deepEqual(calls, [
+      { op: "mkdir", path: "/root/work/agenta-e2btest" },
+      { op: "mkdir", path: "/root/work/agenta-e2btest/.agenta-tools" },
+      {
+        op: "write",
+        path: "/root/work/agenta-e2btest/AGENTS.md",
+        body: "agent instructions",
+      },
+    ]);
+  });
+
+  it("writes a nested harnessFiles entry on E2B via the fs API (opencode)", async () => {
+    const calls: Array<{ op: "mkdir" | "write"; path: string; body?: string }> = [];
+    const sandbox = {
+      mkdirFs: async ({ path }: { path: string }) => calls.push({ op: "mkdir", path }),
+      writeFsFile: async ({ path }: { path: string }, body: string) =>
+        calls.push({ op: "write", path, body }),
+    };
+    const content = JSON.stringify({ mcp: { linear: { type: "remote" } } }, null, 2);
+
+    await prepareWorkspace({
+      sandbox,
+      plan: {
+        isRemoteSandbox: true,
+        cwd: "/root/work/agenta-e2btest",
+        relayDir: "/root/work/agenta-e2btest/.agenta-tools",
+        useToolRelay: false,
+        agentsMd: undefined,
+        acpAgent: "opencode",
+        isPi: false,
+        harnessFiles: [{ path: "opencode.json", content }],
+        skillDirs: [],
+      },
+    });
+
+    const write = calls.find(
+      (c) => c.op === "write" && c.path === "/root/work/agenta-e2btest/opencode.json",
+    );
+    assert.ok(write, "opencode.json is written via the fs API on E2B");
+    assert.equal(write!.body, content);
+  });
+
+  it("uploads opencode skills into the project-local .opencode/skills tree on E2B", async () => {
+    const calls: Array<{ op: "mkdir" | "write"; path: string; body?: string }> = [];
+    const skillDir = tempDir();
+    writeFileSync(join(skillDir, "SKILL.md"), "skill-content", "utf-8");
+    const sandbox = {
+      mkdirFs: async ({ path }: { path: string }) => calls.push({ op: "mkdir", path }),
+      writeFsFile: async ({ path }: { path: string }, body: string) =>
+        calls.push({ op: "write", path, body }),
+    };
+
+    await prepareWorkspace({
+      sandbox,
+      plan: {
+        isRemoteSandbox: true,
+        cwd: "/root/work/agenta-e2btest",
+        relayDir: "/root/work/agenta-e2btest/.agenta-tools",
+        useToolRelay: false,
+        acpAgent: "opencode",
+        isPi: false,
+        skillDirs: [{ name: "my-skill", dir: skillDir }],
+      },
+    });
+
+    assert.ok(
+      calls.some(
+        (c) =>
+          c.op === "write" &&
+          c.path === "/root/work/agenta-e2btest/.opencode/skills/my-skill/SKILL.md",
+      ),
+      "SKILL.md is uploaded to opencode's project-local skill tree on E2B",
+    );
+  });
+
+  it("writes no harness file on E2B for a plan with no harnessFiles", async () => {
+    const calls: Array<{ op: "mkdir" | "write"; path: string; body?: string }> = [];
+    const sandbox = {
+      mkdirFs: async ({ path }: { path: string }) => calls.push({ op: "mkdir", path }),
+      writeFsFile: async ({ path }: { path: string }, body: string) =>
+        calls.push({ op: "write", path, body }),
+    };
+
+    await prepareWorkspace({
+      sandbox,
+      plan: {
+        isRemoteSandbox: true,
+        cwd: "/root/work/agenta-e2btest",
+        relayDir: "/root/work/agenta-e2btest/.agenta-tools",
+        useToolRelay: false,
+        acpAgent: "pi",
+        isPi: true,
+        skillDirs: [],
+      },
+    });
+
+    assert.ok(
+      !calls.some((c) => c.path.includes(".claude") || c.path.includes(".opencode")),
+      "no harness-specific path is touched on a Pi-on-E2B run",
     );
   });
 });

--- a/services/runner/tests/unit/session-mcp-layering.test.ts
+++ b/services/runner/tests/unit/session-mcp-layering.test.ts
@@ -57,6 +57,7 @@ describe("buildSessionMcpServers layering (do-not-merge regression guard)", () =
   it("(a) gateway tools + no user MCP -> internal channel present, no throw", async () => {
     const { servers } = await build({
       isPi: false,
+      isRemote: false,
       isDaytona: false,
       capabilities: mcpCapable,
       harness: "claude",
@@ -84,6 +85,7 @@ describe("buildSessionMcpServers layering (do-not-merge regression guard)", () =
       () =>
         buildSessionMcpServers({
           isPi: false,
+          isRemote: false,
           isDaytona: false,
           capabilities: mcpCapable,
           harness: "claude",
@@ -99,6 +101,7 @@ describe("buildSessionMcpServers layering (do-not-merge regression guard)", () =
   it("(c) gateway tools + user http MCP -> BOTH delivered; user stdio still refused", async () => {
     const { servers } = await build({
       isPi: false,
+      isRemote: false,
       isDaytona: false,
       capabilities: mcpCapable,
       harness: "claude",
@@ -126,6 +129,7 @@ describe("buildSessionMcpServers layering (do-not-merge regression guard)", () =
       () =>
         buildSessionMcpServers({
           isPi: false,
+          isRemote: false,
           isDaytona: false,
           capabilities: mcpCapable,
           harness: "claude",
@@ -140,6 +144,7 @@ describe("buildSessionMcpServers layering (do-not-merge regression guard)", () =
   it("Pi gets [] (native delivery, no MCP channel) even with gateway tools", async () => {
     const { servers } = await build({
       isPi: true,
+      isRemote: false,
       isDaytona: false,
       capabilities: mcpCapable,
       harness: "pi_agenta",
@@ -156,6 +161,7 @@ describe("buildSessionMcpServers layering (do-not-merge regression guard)", () =
   it("a non-MCP harness gets [] (capability gate), no internal server started", async () => {
     const { servers } = await build({
       isPi: false,
+      isRemote: false,
       isDaytona: false,
       capabilities: { mcpTools: false, toolCalls: false },
       harness: "no-mcp",
@@ -168,6 +174,7 @@ describe("buildSessionMcpServers layering (do-not-merge regression guard)", () =
   it("the internal channel advertisement carries no credential (server-side invariant)", async () => {
     const { servers } = await build({
       isPi: false,
+      isRemote: false,
       isDaytona: false,
       capabilities: mcpCapable,
       harness: "claude",
@@ -194,6 +201,7 @@ describe("buildSessionMcpServers layering (do-not-merge regression guard)", () =
     // Finding-1 regression guard.
     const { servers } = await build({
       isPi: false,
+      isRemote: true,
       isDaytona: true,
       capabilities: mcpCapable,
       harness: "claude",
@@ -217,6 +225,7 @@ describe("buildSessionMcpServers layering (do-not-merge regression guard)", () =
     // delivered on Daytona unchanged.
     const { servers } = await build({
       isPi: false,
+      isRemote: true,
       isDaytona: true,
       capabilities: mcpCapable,
       harness: "claude",
@@ -235,6 +244,52 @@ describe("buildSessionMcpServers layering (do-not-merge regression guard)", () =
       servers.map((s) => s.name),
       ["linear"],
       "only the user http server is delivered on Daytona (no internal loopback)",
+    );
+  });
+
+  it("(E2B) gateway tools -> NO internal loopback advertisement (file relay delivers them)", async () => {
+    const { servers } = await build({
+      isPi: false,
+      isRemote: true,
+      isDaytona: false,
+      capabilities: mcpCapable,
+      harness: "opencode",
+      toolSpecs: [gatewayTool],
+      relayDir,
+    });
+    assert.equal(
+      servers.find((s) => s.name === "agenta-tools"),
+      undefined,
+      "no internal agenta-tools server is advertised on E2B",
+    );
+    assert.ok(
+      !JSON.stringify(servers).includes("127.0.0.1"),
+      "the E2B session never carries an unreachable loopback MCP url",
+    );
+  });
+
+  it("(E2B) a user http MCP is STILL delivered (remote url, not a runner loopback)", async () => {
+    const { servers } = await build({
+      isPi: false,
+      isRemote: true,
+      isDaytona: false,
+      capabilities: mcpCapable,
+      harness: "opencode",
+      toolSpecs: [gatewayTool],
+      userMcpServers: [
+        {
+          name: "linear",
+          transport: "http",
+          url: "https://mcp.linear.app/sse",
+          env: { Authorization: "Bearer x" },
+        },
+      ],
+      relayDir,
+    });
+    assert.deepEqual(
+      servers.map((s) => s.name),
+      ["linear"],
+      "only the user http server is delivered on E2B (no internal loopback)",
     );
   });
 });


### PR DESCRIPTION
## Context
With OpenCode working locally and E2B established as a sandbox provider, OpenCode needed its own E2B wiring for provider options, usage reporting, and MCP relay parity with the other harnesses on E2B.

## Changes
Extends `provider.ts`, `run-plan.ts`, `usage.ts`, and `workspace.ts` for the OpenCode x E2B combination, carrying forward the same E2B plumbing pattern established for Pi and Codex.

## Tests / notes
- New coverage: `sandbox-agent-e2b-provider.test.ts`, `sandbox-agent-e2b-run-plan.test.ts`, `sandbox-agent-provider.test.ts`, `sandbox-agent-run-plan.test.ts`, `sandbox-agent-usage.test.ts`, `sandbox-agent-workspace.test.ts`, `session-mcp-layering.test.ts`.
- Base is `chore/add-harness-opencode`, not `big-agents`. Developed in parallel with `chore/add-sandbox-e2b`; expect the E2B plumbing here to converge with that branch's canonical version during the merge pass.
- OpenCode-on-E2B runs with tools will hit the loud-refuse gate from `chore/add-remote-tools-gate` until the relay-client shim lands.