### PR TITLE
feat(agent): agent playground — turn inspector, HITL dock, and tool I/O fidelity

### DIFF
--- a/docs/design/agent-workflows/projects/agent-turn-inspector/design.md
+++ b/docs/design/agent-workflows/projects/agent-turn-inspector/design.md
@@ -1,0 +1,146 @@
+# Project: Agent Turn Inspector (Build-mode tooling)
+
+| | |
+| --- | --- |
+| **Status** | Design. Approved via brainstorming on 2026-07-02. Not yet planned/implemented. |
+| **Type** | Frontend feature (agent playground, Build mode). Sequenced, test-driven. |
+| **Audience** | Internal builders — the team actively building the agent system, debugging in the playground. |
+| **Scope** | A dedicated, agent-native "Turn Inspector" panel for deep per-turn debugging, plus a per-turn capture of what was actually sent to the agent. The inline Build-mode step log stays as-is. |
+| **Owner files (today)** | `web/oss/src/components/AgentChatSlice/components/ToolActivity.tsx`, `.../components/AgentMessage.tsx`, `.../AgentChatPanel.tsx` (transport + temp diagnostic), `web/packages/agenta-playground/src/state/execution/agentRequest.ts` (`buildAgentRequest`). |
+
+## 1. Problem
+
+The agent chat view was deliberately kept calm for non-technical users. That calm hides the
+information the team building the system needs to debug it. Across one working session we hit
+this repeatedly and could not answer, from the UI alone:
+
+- **Why did the agent misbehave?** e.g. a `commit_revision` loop where it re-committed and
+  re-answered "already done" several times in one turn.
+- **What did the agent actually run with?** The effective config (instructions / model / tools)
+  and the exact `messages` array we sent — *as of that turn*. This is **invisible today**; it
+  only exists in a temporary `console.warn` (`[AgentChat OUTGOING]`) added during the loop
+  investigation.
+- **Were the tool calls correct?** Right input in, right output back — the `{}`-input question,
+  malformed args, error payloads.
+
+The root difficulty is that the agent's *actual execution* is not legible: we watch what it
+produces, but not what it saw. The re-commit loop, for instance, is best explained by the FE
+re-sending a config that had drifted out from under the agent after its own self-commit — a
+fact no surface in the app exposes.
+
+## 2. Goals / non-goals
+
+**Goals** (priority order, from the builders):
+
+1. Diagnose *why it misbehaved* (loops, wrong tool, ignored context).
+2. See *what it actually ran with* (effective config + exact messages sent, accurate at that turn).
+3. Verify *tool-call correctness* (full input/output/error per call).
+
+**Non-goals:**
+
+- Do **not** touch the existing trace drawer (avoid regressions in a working surface).
+- Do **not** reduce the inline Build-mode step log — the panel is purely additive.
+- No speed/cost analytics (explicitly deprioritized).
+- Read-only. No re-running/editing steps from the panel (possible future work).
+
+## 3. Surfaces
+
+Two surfaces with a clean division of labor:
+
+- **Inline step log** — exists (`ToolActivity` `detailed` mode, gated on Build via
+  `chatPanelMaximizedAtom`). The fast, in-transcript read: every step with tool I/O. **Unchanged.**
+- **Turn Inspector** — new. A dedicated panel opened from a turn, for the deep dive. Its own
+  shell and its own Jotai state. It shares only generic UI primitives (e.g. `EnhancedDrawer` from
+  `@agenta/ui`); it does **not** import or mutate the trace-drawer store.
+
+## 4. The Turn Inspector
+
+**Gating:** Build mode only (`!chatPanelMaximizedAtom`), same signal the inline log uses.
+
+**Open affordance:** an "Inspect turn" control on each assistant turn (near the existing
+`View full trace` link / the turn's hover actions). Opens a right-side drawer focused on that
+turn. Optional deep-link: clicking a step in the inline log opens the panel scrolled to that step.
+
+**Three tabs:**
+
+| Tab | Shows | Data source |
+| --- | --- | --- |
+| **Timeline** | Every interaction in order: reasoning, each tool call with full input/output/error, text, and HITL events (approval requested / approved / denied). The step log, exhaustive and un-truncated. | The turn's `UIMessage.parts` — already on the client. No new plumbing. |
+| **Context** | *What the agent ran with this turn* — the effective config (instructions / model / tools) as of that turn, and the exact `messages` array sent (post-`hasAnswer` filter). When a turn made multiple requests (HITL/auto-resume), shows all of them with a diff. | The per-turn capture (§5). |
+| **Raw** | The literal outgoing request body and raw response/events, for copy-paste repro and bug reports. Copy-as-JSON. | The per-turn capture (§5) + read-only reads of trace data via existing atoms (no trace-drawer UI). |
+
+The **Timeline** tab ships essentially for free (message parts). **Context** and **Raw** carry
+the real new value and the only real new engineering, because "what we actually sent" is not
+persisted anywhere today.
+
+## 5. The per-turn capture (the one new data mechanism)
+
+**Decision: capture-at-send, not reconstruct-on-demand.** Reconstructing later re-reads the
+*current* config/messages, which have already drifted (exactly the bug we chase). We snapshot at
+the moment of sending, so Context/Raw are accurate *at that turn*.
+
+**Where:** in the transport's `prepareSendMessagesRequest` in `AgentChatPanel` — the exact spot
+the temporary `console.warn` lives now. The built `req` is already in hand. This **productizes
+and replaces the temp `[AgentChat OUTGOING]` diagnostic** with a structured store write.
+
+**Snapshot shape (per send):**
+
+```ts
+interface TurnRequestCapture {
+    requestId: string          // nonce, generated at send
+    at: number                 // Date.now() at send
+    triggerUserMessageId: string   // last role:"user" message id in the sent array
+    parameters: unknown        // config-as-sent (config-at-turn)
+    messages: unknown[]        // exact array sent (post-hasAnswer)
+    references: unknown        // as sent
+    sessionId: string
+    invocationUrl: string      // body/URL only; auth headers + secrets stripped
+}
+```
+
+**Correlation (the subtle bit):** key each capture by `triggerUserMessageId` = the id of the
+last `role:"user"` message in the sent array. The initial send **and every HITL/auto-resume of
+that turn share it**, so one turn maps to a *list* of captures. Given an assistant turn, find its
+preceding user message → pull all captures for that id.
+
+**Payoff:** keeping *every* send lets the Context tab show "this turn = N requests" and diff
+them — which surfaces the re-commit loop and the stale-config re-injection directly. That view
+is what was missing all session.
+
+**Storage:** a session-scoped, in-memory Jotai atom (ephemeral — this is a debugging surface),
+capped to the last N turns to bound memory. Not `localStorage` (payloads can be large);
+persistence is a possible later option.
+
+**Redaction:** capture the request *body* only; strip `Authorization` and any secret-bearing
+headers. The body itself must not carry secrets.
+
+## 6. Phasing
+
+1. **Inspector shell + Timeline tab** — no new plumbing (renders `UIMessage.parts`). Ships value
+   immediately and is independently useful.
+2. **Capture store + Context tab** — the snapshot mechanism (§5) + the config/messages view,
+   including the multi-send-per-turn diff. Replaces the temp diagnostic.
+3. **Raw tab** — literal payloads, copy-as-JSON, read-only trace correlation.
+
+## 7. Testing
+
+- **Unit:** the capture reducer + correlation — `triggerUserMessageId` grouping, resends
+  collapsing into one turn, N-cap eviction.
+- **Component:** Timeline renders reasoning / tool-I/O / HITL in order; Context renders config +
+  messages; empty/no-capture states (a turn hydrated from a prior session has no capture).
+- **Manual:** Build-mode-only gating; a HITL/resume turn shows multiple captures and a usable diff.
+
+## 8. Open questions / future
+
+- Deep-link from an inline step into the panel (nice-to-have, Phase 1 or later).
+- Persisting captures across reload (currently ephemeral).
+- "Re-run / fork from this turn" actions (out of scope now; the panel is read-only).
+- Whether Timeline should also show server-recorded events not present in `UIMessage.parts`
+  (would need a read-only trace correlation, same as Raw).
+
+## See also
+
+- `docs/design/agent-workflows/documentation/agent-configuration.md` — the schema-driven config
+  the Context tab surfaces.
+- The `hasAnswer` filter in `web/packages/agenta-playground/src/state/execution/agentRequest.ts`
+  — why the sent `messages` differ from the rendered transcript.

--- a/docs/design/agent-workflows/projects/agent-turn-inspector/plan.md
+++ b/docs/design/agent-workflows/projects/agent-turn-inspector/plan.md
@@ -1,0 +1,919 @@
+# Agent Turn Inspector Implementation Plan
+
+> **For agentic workers:** REQUIRED SUB-SKILL: Use superpowers:subagent-driven-development (recommended) or superpowers:executing-plans to implement this plan task-by-task. Steps use checkbox (`- [ ]`) syntax for tracking.
+
+**Goal:** Add a dedicated, agent-native "Turn Inspector" panel to the agent playground's Build mode, plus a per-turn capture of exactly what was sent to the agent, so the team can debug why the agent misbehaved, what it ran with, and whether tool calls were correct.
+
+**Architecture:** Pure capture/correlation logic lives in `@agenta/playground` (unit-tested). A session-scoped in-memory Jotai store in `web/oss` holds the request snapshots, written from the chat transport at send time (replacing the temp `[AgentChat OUTGOING]` diagnostic). A new `TurnInspector` drawer (its own state, not the trace drawer) renders three tabs — Timeline (message parts), Context (captures), Raw (payloads). The inline Build-mode step log is unchanged.
+
+**Tech Stack:** React, Jotai, TypeScript, antd + `@agenta/ui` (`EnhancedDrawer`), Tailwind (v3, semantic antd tokens), AI SDK `UIMessage`. Package tests: vitest. Node 24 via `export PATH="$HOME/.nvm/versions/node/v24.15.0/bin:$PATH"`.
+
+**Spec:** `docs/design/agent-workflows/projects/agent-turn-inspector/design.md`
+
+---
+
+## Conventions for every task
+
+- Run FE lint/tsc with Node 24: `export PATH="$HOME/.nvm/versions/node/v24.15.0/bin:$PATH"` first.
+- Lint changed files: from `web/`, `npx eslint --fix <paths>`.
+- Typecheck oss: from `web/oss`, `npx tsc --noEmit` (grep for your files — the repo has a pre-existing error baseline; only NEW errors in your files matter).
+- Package tests: from `web/packages/agenta-playground`, `npx vitest run tests/unit/<file>`.
+- Commit convention: `type(area): Title`. No `Co-Authored-By`, no "Claude"/Anthropic in messages.
+- Commit with `git commit --no-verify` after linting manually (the pre-commit `turbo lint` hook has timed out and reverted files in this repo).
+- Text size default is `text-xs` (12px); dark mode via antd semantic tokens (`text-colorText`, `bg-colorFillTertiary`, …), never `dark:`.
+
+---
+
+## Phase 1 — Timeline inspector (no new plumbing)
+
+Ships a working inspector that renders any turn's steps exhaustively from data already on the client.
+
+### Task 1: Inspector open-state atom
+
+**Files:**
+- Create: `web/oss/src/components/AgentChatSlice/state/turnInspector.ts`
+
+- [ ] **Step 1: Write the atom + target type**
+
+```ts
+import {atom} from "jotai"
+
+/** Which assistant turn the Turn Inspector is open on. `null` = closed. */
+export interface TurnInspectorTarget {
+    sessionId: string
+    /** The assistant turn's message id (its parts drive the Timeline tab). */
+    assistantMessageId: string
+}
+
+export const turnInspectorAtom = atom<TurnInspectorTarget | null>(null)
+```
+
+- [ ] **Step 2: Typecheck**
+
+Run (from `web/oss`): `npx tsc --noEmit 2>&1 | grep turnInspector`
+Expected: no output (no errors in the new file).
+
+- [ ] **Step 3: Commit**
+
+```bash
+git add web/oss/src/components/AgentChatSlice/state/turnInspector.ts
+git commit --no-verify -m "feat(frontend): turn-inspector open-state atom"
+```
+
+---
+
+### Task 2: Timeline tab component
+
+Renders every part of an assistant turn in order: reasoning, tool calls with full input/output/error, text, and HITL/approval state. Reuses the existing `formatValue`/`IOBlock` idiom from `ToolActivity` but shows everything, un-truncated.
+
+**Files:**
+- Create: `web/oss/src/components/AgentChatSlice/components/TurnInspector/TimelineTab.tsx`
+
+- [ ] **Step 1: Write the component**
+
+```tsx
+import {memo} from "react"
+
+import type {ToolUIPart, UIMessage} from "ai"
+import {Typography} from "antd"
+
+const {Text} = Typography
+
+const isToolPart = (t: string) => t.startsWith("tool-") || t === "dynamic-tool"
+
+const toolName = (part: ToolUIPart): string => {
+    const type = part.type as string
+    if (type === "dynamic-tool") return (part as {toolName?: string}).toolName || "tool"
+    return type.replace(/^tool-/, "")
+}
+
+const format = (value: unknown): string => {
+    if (value == null) return ""
+    if (typeof value === "string") return value
+    try {
+        return JSON.stringify(value, null, 2)
+    } catch {
+        return String(value)
+    }
+}
+
+const Block = ({label, value, danger}: {label: string; value: string; danger?: boolean}) => (
+    <div className="flex min-w-0 flex-col gap-0.5">
+        <span className="font-mono text-[10px] text-colorTextTertiary">{label}</span>
+        <pre
+            className={`m-0 max-h-72 overflow-auto whitespace-pre-wrap break-all rounded px-2 py-1.5 font-mono text-[11px] leading-snug ${
+                danger ? "bg-[var(--ant-color-error-bg)] !text-colorErrorText" : "bg-colorFillTertiary text-colorTextSecondary"
+            }`}
+        >
+            {value}
+        </pre>
+    </div>
+)
+
+const PartNode = ({part}: {part: UIMessage["parts"][number]}) => {
+    const type = part.type as string
+    if (type === "reasoning") {
+        const text = (part as {text?: string}).text ?? ""
+        return (
+            <div className="flex flex-col gap-1">
+                <Text type="secondary" className="!text-[11px] font-medium">reasoning</Text>
+                <div className="text-xs italic text-colorTextTertiary whitespace-pre-wrap">{text}</div>
+            </div>
+        )
+    }
+    if (type === "text") {
+        const text = (part as {text?: string}).text ?? ""
+        if (!text.trim()) return null
+        return (
+            <div className="flex flex-col gap-1">
+                <Text type="secondary" className="!text-[11px] font-medium">text</Text>
+                <div className="text-xs text-colorText whitespace-pre-wrap">{text}</div>
+            </div>
+        )
+    }
+    if (isToolPart(type)) {
+        const p = part as ToolUIPart
+        const state = p.state as string
+        const input = (p as {input?: unknown}).input
+        const output = (p as {output?: unknown}).output
+        const errorText = (p as {errorText?: string}).errorText
+        return (
+            <div className="flex flex-col gap-1.5">
+                <div className="flex items-center gap-2">
+                    <Text className="!text-xs !font-medium font-mono">{toolName(p)}</Text>
+                    <Text
+                        type={state === "output-error" ? "danger" : "secondary"}
+                        className="!text-[11px]"
+                    >
+                        {state}
+                    </Text>
+                </div>
+                {input != null ? <Block label="input" value={format(input)} /> : null}
+                {errorText !== undefined ? (
+                    <Block label="error" value={errorText} danger />
+                ) : output != null ? (
+                    <Block label="output" value={format(output)} />
+                ) : null}
+            </div>
+        )
+    }
+    return (
+        <div className="flex flex-col gap-1">
+            <Text type="secondary" className="!text-[11px] font-medium">{type}</Text>
+        </div>
+    )
+}
+
+/** The Timeline tab: every part of one assistant turn, in order, un-truncated. */
+const TimelineTab = ({message}: {message: UIMessage | null}) => {
+    if (!message) {
+        return <div className="p-4 text-xs text-colorTextTertiary">No turn selected.</div>
+    }
+    const parts = message.parts ?? []
+    return (
+        <div className="flex flex-col gap-4 p-4">
+            {parts.length === 0 ? (
+                <div className="text-xs text-colorTextTertiary">This turn produced no parts.</div>
+            ) : (
+                parts.map((part, i) => (
+                    <div key={`${message.id}-${i}`} className="border-0 border-l-2 border-solid border-colorBorderSecondary pl-3">
+                        <PartNode part={part} />
+                    </div>
+                ))
+            )}
+        </div>
+    )
+}
+
+export default memo(TimelineTab)
+```
+
+- [ ] **Step 2: Lint + typecheck**
+
+Run (from `web`): `npx eslint --fix oss/src/components/AgentChatSlice/components/TurnInspector/TimelineTab.tsx`
+Run (from `web/oss`): `npx tsc --noEmit 2>&1 | grep TimelineTab`
+Expected: eslint clean; no tsc output for the file.
+
+- [ ] **Step 3: Commit**
+
+```bash
+git add web/oss/src/components/AgentChatSlice/components/TurnInspector/TimelineTab.tsx
+git commit --no-verify -m "feat(frontend): turn-inspector Timeline tab"
+```
+
+---
+
+### Task 3: Inspector drawer shell (Timeline only for now)
+
+**Files:**
+- Create: `web/oss/src/components/AgentChatSlice/components/TurnInspector/TurnInspector.tsx`
+- Reference: `web/packages/agenta-ui` exports `EnhancedDrawer` (confirm the import path with `grep -rn "EnhancedDrawer" web/packages/agenta-ui/src/index.ts`).
+
+- [ ] **Step 1: Confirm the drawer primitive export**
+
+Run: `grep -rn "EnhancedDrawer" web/packages/agenta-ui/src`
+Expected: an exported `EnhancedDrawer` (used by the cron/schedule drawers). Note its exact import specifier (e.g. `@agenta/ui`); use it below. If it does not exist, fall back to antd `Drawer` with `rootClassName` for dark-mode tokens.
+
+- [ ] **Step 2: Write the shell**
+
+```tsx
+import {useMemo, useState} from "react"
+
+import {EnhancedDrawer} from "@agenta/ui"
+import type {UIMessage} from "ai"
+import {Segmented} from "antd"
+import {useAtom, useAtomValue} from "jotai"
+
+import {sessionMessagesAtom} from "../../state/sessions"
+import {turnInspectorAtom} from "../../state/turnInspector"
+
+import TimelineTab from "./TimelineTab"
+
+type Tab = "timeline" | "context" | "raw"
+
+/** Dedicated Build-mode turn inspector. Own state (`turnInspectorAtom`), NOT the trace drawer. */
+const TurnInspector = () => {
+    const [target, setTarget] = useAtom(turnInspectorAtom)
+    const allMessages = useAtomValue(sessionMessagesAtom)
+    const [tab, setTab] = useState<Tab>("timeline")
+
+    const message: UIMessage | null = useMemo(() => {
+        if (!target) return null
+        const list = allMessages[target.sessionId] ?? []
+        return list.find((m) => m.id === target.assistantMessageId) ?? null
+    }, [target, allMessages])
+
+    return (
+        <EnhancedDrawer
+            open={!!target}
+            onClose={() => setTarget(null)}
+            width={560}
+            title="Turn inspector"
+            destroyOnClose
+        >
+            <div className="flex h-full min-h-0 flex-col">
+                <div className="px-4 pt-2">
+                    <Segmented<Tab>
+                        value={tab}
+                        onChange={setTab}
+                        options={[
+                            {label: "Timeline", value: "timeline"},
+                            {label: "Context", value: "context"},
+                            {label: "Raw", value: "raw"},
+                        ]}
+                    />
+                </div>
+                <div className="min-h-0 flex-1 overflow-y-auto">
+                    {tab === "timeline" ? <TimelineTab message={message} /> : null}
+                    {tab === "context" ? (
+                        <div className="p-4 text-xs text-colorTextTertiary">Context — added in Phase 2.</div>
+                    ) : null}
+                    {tab === "raw" ? (
+                        <div className="p-4 text-xs text-colorTextTertiary">Raw — added in Phase 3.</div>
+                    ) : null}
+                </div>
+            </div>
+        </EnhancedDrawer>
+    )
+}
+
+export default TurnInspector
+```
+
+- [ ] **Step 3: Lint + typecheck**
+
+Run (from `web`): `npx eslint --fix oss/src/components/AgentChatSlice/components/TurnInspector/TurnInspector.tsx`
+Run (from `web/oss`): `npx tsc --noEmit 2>&1 | grep TurnInspector`
+Expected: eslint clean; no tsc output. If `EnhancedDrawer`'s props differ (e.g. no `width`/`title`), adjust to its real signature discovered in Step 1.
+
+- [ ] **Step 4: Commit**
+
+```bash
+git add web/oss/src/components/AgentChatSlice/components/TurnInspector/TurnInspector.tsx
+git commit --no-verify -m "feat(frontend): turn-inspector drawer shell"
+```
+
+---
+
+### Task 4: Mount the inspector + add the "Inspect turn" affordance
+
+**Files:**
+- Modify: `web/oss/src/components/AgentChatSlice/AgentChatPanel.tsx`
+
+The affordance is added in `AgentConversation`'s `renderMessage`, next to the existing per-turn `Stopped`/`Resend` block, gated on Build mode (`!chatMaximized`) and assistant role. The `<TurnInspector />` is mounted once at the panel root.
+
+- [ ] **Step 1: Add imports**
+
+Add near the other component imports in `AgentChatPanel.tsx`:
+
+```ts
+import TurnInspector from "./components/TurnInspector/TurnInspector"
+import {turnInspectorAtom} from "./state/turnInspector"
+```
+
+- [ ] **Step 2: Read Build mode + the setter inside `AgentConversation`**
+
+Find where `AgentConversation` reads atoms (near `const detailed`/other `useAtomValue` calls in the inner component) and add:
+
+```ts
+const openTurnInspector = useSetAtom(turnInspectorAtom)
+const buildMode = !useAtomValue(chatPanelMaximizedAtom)
+```
+
+(`chatPanelMaximizedAtom` and `useSetAtom` are already imported in this file.)
+
+- [ ] **Step 3: Add the affordance in `renderMessage`**
+
+In `renderMessage`, in the block that already renders the `Stopped` tag for `isLast && message.role === "assistant"`, add an always-available (Build-mode) inspect button for assistant turns. Insert this just after the existing `{stopped && isLast && message.role === "assistant" && (...)}` block, inside the `<MessageRow>`:
+
+```tsx
+{buildMode && message.role === "assistant" && (
+    <button
+        type="button"
+        onClick={() =>
+            openTurnInspector({sessionId, assistantMessageId: message.id})
+        }
+        className="flex w-fit cursor-pointer items-center gap-1 self-start rounded border-0 bg-transparent px-1 py-0.5 text-xs text-colorTextTertiary transition-colors hover:text-colorPrimary"
+    >
+        <TreeStructure size={12} />
+        Inspect turn
+    </button>
+)}
+```
+
+`TreeStructure` is already imported from `@phosphor-icons/react` in `AgentMessage.tsx`; add it to the `AgentChatPanel.tsx` phosphor import (verify with `grep -n "@phosphor-icons/react" web/oss/src/components/AgentChatSlice/AgentChatPanel.tsx` and extend that import).
+
+- [ ] **Step 4: Mount the inspector at the panel root**
+
+In the `AgentConversation` return, just after the opening root `<div className="relative flex h-full min-h-0 w-full flex-col gap-3" ...>` (where `modalContextHolder` is rendered), add:
+
+```tsx
+<TurnInspector />
+```
+
+- [ ] **Step 5: Lint + typecheck**
+
+Run (from `web`): `npx eslint --fix oss/src/components/AgentChatSlice/AgentChatPanel.tsx`
+Run (from `web/oss`): `npx tsc --noEmit 2>&1 | grep AgentChatPanel`
+Expected: clean.
+
+- [ ] **Step 6: Manual verification**
+
+Deploy locally (see `hosting/AGENTS.md`), open an agent in the playground, run a tool-using turn, ensure Build mode (config panel visible). Confirm: an "Inspect turn" control appears on the assistant turn; clicking it opens the drawer; the Timeline tab lists reasoning/tool/text parts with input/output/error, un-truncated. In Chat mode (maximized) the control is absent.
+
+- [ ] **Step 7: Commit**
+
+```bash
+git add web/oss/src/components/AgentChatSlice/AgentChatPanel.tsx
+git commit --no-verify -m "feat(frontend): mount turn inspector + inspect-turn affordance"
+```
+
+---
+
+## Phase 2 — Capture store + Context tab
+
+### Task 5: Pure capture + correlation logic (TDD, in the package)
+
+**Files:**
+- Create: `web/packages/agenta-playground/src/state/execution/turnCapture.ts`
+- Test: `web/packages/agenta-playground/tests/unit/turnCapture.test.ts`
+- Modify: `web/packages/agenta-playground/src/index.ts` (or the execution barrel that already exports `buildAgentRequest`) to export the new symbols.
+
+- [ ] **Step 1: Write the failing test**
+
+```ts
+import {describe, expect, it} from "vitest"
+
+import {
+    appendCapped,
+    buildTurnCapture,
+    capturesForTrigger,
+    triggerUserMessageId,
+} from "../../src/state/execution/turnCapture"
+
+describe("turnCapture", () => {
+    it("finds the last user message id as the trigger", () => {
+        const messages = [
+            {id: "u1", role: "user"},
+            {id: "a1", role: "assistant"},
+            {id: "u2", role: "user"},
+            {id: "a2", role: "assistant"},
+        ]
+        expect(triggerUserMessageId(messages)).toBe("u2")
+    })
+
+    it("returns null when there is no user message", () => {
+        expect(triggerUserMessageId([{id: "a1", role: "assistant"}])).toBeNull()
+    })
+
+    it("builds a capture from a built AgentRequest", () => {
+        const req = {
+            invocationUrl: "https://x/invoke?project_id=p",
+            requestBody: {
+                session_id: "s1",
+                references: {application: {id: "app"}},
+                data: {
+                    inputs: {messages: [{id: "u1", role: "user"}]},
+                    parameters: {agent: {instructions: {agents_md: "hi"}}},
+                },
+            },
+        }
+        const c = buildTurnCapture(req, "req-1", 1000)
+        expect(c).toEqual({
+            requestId: "req-1",
+            at: 1000,
+            triggerUserMessageId: "u1",
+            parameters: {agent: {instructions: {agents_md: "hi"}}},
+            messages: [{id: "u1", role: "user"}],
+            references: {application: {id: "app"}},
+            sessionId: "s1",
+            invocationUrl: "https://x/invoke?project_id=p",
+        })
+    })
+
+    it("groups all sends of a turn under one trigger id", () => {
+        const base = {parameters: {}, messages: [], references: null, sessionId: "s", invocationUrl: "u"}
+        const captures = [
+            {...base, requestId: "r1", at: 1, triggerUserMessageId: "u1"},
+            {...base, requestId: "r2", at: 2, triggerUserMessageId: "u1"},
+            {...base, requestId: "r3", at: 3, triggerUserMessageId: "u2"},
+        ]
+        expect(capturesForTrigger(captures, "u1").map((c) => c.requestId)).toEqual(["r1", "r2"])
+        expect(capturesForTrigger(captures, null)).toEqual([])
+    })
+
+    it("evicts the oldest whole turns beyond the cap, keeping all sends of kept turns", () => {
+        const base = {parameters: {}, messages: [], references: null, sessionId: "s", invocationUrl: "u"}
+        let list: ReturnType<typeof capturesForTrigger> = []
+        list = appendCapped(list, {...base, requestId: "r1", at: 1, triggerUserMessageId: "u1"}, 2)
+        list = appendCapped(list, {...base, requestId: "r1b", at: 2, triggerUserMessageId: "u1"}, 2)
+        list = appendCapped(list, {...base, requestId: "r2", at: 3, triggerUserMessageId: "u2"}, 2)
+        list = appendCapped(list, {...base, requestId: "r3", at: 4, triggerUserMessageId: "u3"}, 2)
+        // u1 (oldest turn) evicted; both u1 sends gone; u2 + u3 kept.
+        expect(list.map((c) => c.triggerUserMessageId)).toEqual(["u2", "u3"])
+    })
+})
+```
+
+- [ ] **Step 2: Run it to verify it fails**
+
+Run (from `web/packages/agenta-playground`): `npx vitest run tests/unit/turnCapture.test.ts`
+Expected: FAIL — cannot resolve `../../src/state/execution/turnCapture`.
+
+- [ ] **Step 3: Write the implementation**
+
+```ts
+/** A snapshot of one request sent to the agent, taken at send time so the Context/Raw tabs are
+ * accurate AT THAT TURN (the config drifts after a self-commit; reconstructing later lies). */
+export interface TurnRequestCapture {
+    requestId: string
+    at: number
+    /** Last `role:"user"` message id in the sent array; shared by a turn's initial send + resumes. */
+    triggerUserMessageId: string | null
+    parameters: unknown
+    messages: unknown[]
+    references: unknown
+    sessionId: string
+    invocationUrl: string
+}
+
+interface MessageLike {
+    id?: string
+    role?: string
+}
+
+export const triggerUserMessageId = (messages: MessageLike[]): string | null => {
+    for (let i = messages.length - 1; i >= 0; i--) {
+        if (messages[i]?.role === "user") return messages[i]?.id ?? null
+    }
+    return null
+}
+
+/** Build a capture from a built `AgentRequest` (the return of `buildAgentRequest`). `requestId`
+ * and `at` are supplied by the caller so this stays pure/testable. */
+export const buildTurnCapture = (
+    req: {invocationUrl: string; requestBody: Record<string, unknown>},
+    requestId: string,
+    at: number,
+): TurnRequestCapture => {
+    const body = req.requestBody as {
+        session_id?: string
+        references?: unknown
+        data?: {inputs?: {messages?: unknown[]}; parameters?: unknown}
+    }
+    const messages = body.data?.inputs?.messages ?? []
+    return {
+        requestId,
+        at,
+        triggerUserMessageId: triggerUserMessageId(messages as MessageLike[]),
+        parameters: body.data?.parameters ?? null,
+        messages,
+        references: body.references ?? null,
+        sessionId: body.session_id ?? "",
+        invocationUrl: req.invocationUrl,
+    }
+}
+
+/** All sends belonging to one turn (initial + resumes), by trigger id. */
+export const capturesForTrigger = (
+    captures: TurnRequestCapture[],
+    triggerId: string | null,
+): TurnRequestCapture[] =>
+    triggerId ? captures.filter((c) => c.triggerUserMessageId === triggerId) : []
+
+/** Append a capture, evicting the OLDEST whole turns (by distinct trigger id) beyond `maxTurns`
+ * so a kept turn never loses some of its sends. */
+export const appendCapped = (
+    captures: TurnRequestCapture[],
+    capture: TurnRequestCapture,
+    maxTurns: number,
+): TurnRequestCapture[] => {
+    const next = [...captures, capture]
+    const triggers: string[] = []
+    for (const c of next) {
+        const t = c.triggerUserMessageId ?? c.requestId
+        if (!triggers.includes(t)) triggers.push(t)
+    }
+    if (triggers.length <= maxTurns) return next
+    const keep = new Set(triggers.slice(triggers.length - maxTurns))
+    return next.filter((c) => keep.has(c.triggerUserMessageId ?? c.requestId))
+}
+```
+
+- [ ] **Step 4: Export the symbols**
+
+In the barrel that already exports `buildAgentRequest` (find it: `grep -rn "buildAgentRequest" web/packages/agenta-playground/src/index.ts`), add:
+
+```ts
+export {
+    appendCapped,
+    buildTurnCapture,
+    capturesForTrigger,
+    triggerUserMessageId,
+    type TurnRequestCapture,
+} from "./state/execution/turnCapture"
+```
+
+- [ ] **Step 5: Run the test to verify it passes**
+
+Run (from `web/packages/agenta-playground`): `npx vitest run tests/unit/turnCapture.test.ts`
+Expected: PASS (5 tests).
+
+- [ ] **Step 6: Commit**
+
+```bash
+git add web/packages/agenta-playground/src/state/execution/turnCapture.ts web/packages/agenta-playground/tests/unit/turnCapture.test.ts web/packages/agenta-playground/src/index.ts
+git commit --no-verify -m "feat(playground): per-turn request capture + correlation helpers"
+```
+
+---
+
+### Task 6: Capture store atom
+
+**Files:**
+- Create: `web/oss/src/components/AgentChatSlice/state/turnCaptures.ts`
+
+- [ ] **Step 1: Write the store**
+
+```ts
+import {appendCapped, type TurnRequestCapture} from "@agenta/playground"
+import {atom} from "jotai"
+import {atomFamily} from "jotai/utils"
+
+/** Keep the last N turns' captures per session (ephemeral; debugging surface, not persisted). */
+const MAX_TURNS = 20
+
+const capturesBySessionAtom = atom<Record<string, TurnRequestCapture[]>>({})
+
+/** Write one send's capture (called from the transport at send time). */
+export const captureTurnRequestAtom = atom(
+    null,
+    (get, set, capture: TurnRequestCapture) => {
+        if (!capture.sessionId) return
+        const all = get(capturesBySessionAtom)
+        const list = all[capture.sessionId] ?? []
+        set(capturesBySessionAtom, {
+            ...all,
+            [capture.sessionId]: appendCapped(list, capture, MAX_TURNS),
+        })
+    },
+)
+
+/** Read all captures for a session. */
+export const sessionCapturesAtomFamily = atomFamily((sessionId: string) =>
+    atom((get) => get(capturesBySessionAtom)[sessionId] ?? []),
+)
+```
+
+- [ ] **Step 2: Typecheck**
+
+Run (from `web/oss`): `npx tsc --noEmit 2>&1 | grep turnCaptures`
+Expected: no output. (If `@agenta/playground` doesn't resolve the new export, re-run `pnpm --filter @agenta/playground build` or `pnpm install`.)
+
+- [ ] **Step 3: Commit**
+
+```bash
+git add web/oss/src/components/AgentChatSlice/state/turnCaptures.ts
+git commit --no-verify -m "feat(frontend): session-scoped turn-capture store"
+```
+
+---
+
+### Task 7: Capture at send time (replace the temp diagnostic)
+
+**Files:**
+- Modify: `web/oss/src/components/AgentChatSlice/AgentChatPanel.tsx`
+
+The transport's `prepareSendMessagesRequest` currently holds the temp `[AgentChat OUTGOING]` `console.warn`. Replace it with a capture write. The setter is read via a ref (the transport `useMemo` must not depend on it).
+
+- [ ] **Step 1: Add imports**
+
+```ts
+import {buildTurnCapture} from "@agenta/playground"
+import {generateId} from "@agenta/shared/utils"
+import {captureTurnRequestAtom} from "./state/turnCaptures"
+```
+
+(`buildAgentRequest` is already imported from `@agenta/playground`; `generateId` may already be imported — verify and don't duplicate.)
+
+- [ ] **Step 2: Add a ref'd setter inside `AgentConversation`**
+
+Near `entityIdRef` in `AgentConversation`:
+
+```ts
+const captureTurnRequest = useSetAtom(captureTurnRequestAtom)
+const captureRef = useRef(captureTurnRequest)
+captureRef.current = captureTurnRequest
+```
+
+- [ ] **Step 3: Replace the temp diagnostic block**
+
+In `prepareSendMessagesRequest`, delete the entire `// TEMP DIAGNOSTIC …` try/catch block (the `[AgentChat OUTGOING]` console.warn) and replace it with:
+
+```ts
+captureRef.current(buildTurnCapture(req, generateId(), Date.now()))
+```
+
+Placed after the `if (!req) { throw … }` guard and before `return {api: req.invocationUrl, …}`.
+
+- [ ] **Step 4: Lint + typecheck**
+
+Run (from `web`): `npx eslint --fix oss/src/components/AgentChatSlice/AgentChatPanel.tsx`
+Run (from `web/oss`): `npx tsc --noEmit 2>&1 | grep AgentChatPanel`
+Expected: clean. The temp `console.warn` is gone (removes the loose diagnostic).
+
+- [ ] **Step 5: Commit**
+
+```bash
+git add web/oss/src/components/AgentChatSlice/AgentChatPanel.tsx
+git commit --no-verify -m "feat(frontend): capture outgoing agent request per send"
+```
+
+---
+
+### Task 8: Context tab
+
+Shows, for the selected turn, every send (initial + resumes) with its config-at-turn and exact messages. Multiple sends render as a numbered list so the loop/stale-config is visible.
+
+**Files:**
+- Create: `web/oss/src/components/AgentChatSlice/components/TurnInspector/ContextTab.tsx`
+- Modify: `web/oss/src/components/AgentChatSlice/components/TurnInspector/TurnInspector.tsx` (wire the tab + compute the trigger id)
+
+- [ ] **Step 1: Write `ContextTab`**
+
+```tsx
+import {memo} from "react"
+
+import {type TurnRequestCapture} from "@agenta/playground"
+import {Typography} from "antd"
+
+const {Text} = Typography
+
+const format = (value: unknown): string => {
+    if (value == null) return "null"
+    try {
+        return JSON.stringify(value, null, 2)
+    } catch {
+        return String(value)
+    }
+}
+
+const agentInstructions = (parameters: unknown): string | null => {
+    const p = parameters as {agent?: {instructions?: {agents_md?: unknown}}} | null
+    const md = p?.agent?.instructions?.agents_md
+    return typeof md === "string" ? md : null
+}
+
+const agentModel = (parameters: unknown): string | null => {
+    const p = parameters as {agent?: {llm?: {model?: unknown}; model?: unknown}} | null
+    const m = p?.agent?.llm?.model ?? p?.agent?.model
+    return typeof m === "string" ? m : null
+}
+
+const Block = ({label, value}: {label: string; value: string}) => (
+    <div className="flex min-w-0 flex-col gap-0.5">
+        <span className="font-mono text-[10px] text-colorTextTertiary">{label}</span>
+        <pre className="m-0 max-h-72 overflow-auto whitespace-pre-wrap break-all rounded bg-colorFillTertiary px-2 py-1.5 font-mono text-[11px] leading-snug text-colorTextSecondary">
+            {value}
+        </pre>
+    </div>
+)
+
+const Send = ({capture, index, total}: {capture: TurnRequestCapture; index: number; total: number}) => {
+    const model = agentModel(capture.parameters)
+    const instructions = agentInstructions(capture.parameters)
+    return (
+        <div className="flex flex-col gap-2 rounded-lg border border-solid border-colorBorderSecondary p-3">
+            <div className="flex items-center gap-2">
+                <Text className="!text-xs !font-medium">Request {index + 1} of {total}</Text>
+                {model ? <Text type="secondary" className="!text-[11px] font-mono">{model}</Text> : null}
+            </div>
+            {instructions != null ? <Block label="instructions (agents_md)" value={instructions} /> : null}
+            <Block label="parameters (config as sent)" value={format(capture.parameters)} />
+            <Block label={`messages sent (${(capture.messages ?? []).length})`} value={format(capture.messages)} />
+        </div>
+    )
+}
+
+/** The Context tab: every send for the selected turn, config-at-turn + exact messages. */
+const ContextTab = ({captures}: {captures: TurnRequestCapture[]}) => {
+    if (captures.length === 0) {
+        return (
+            <div className="p-4 text-xs text-colorTextTertiary">
+                No capture for this turn. Captures are recorded live in Build mode; a turn restored from a
+                previous session has none.
+            </div>
+        )
+    }
+    return (
+        <div className="flex flex-col gap-3 p-4">
+            {captures.length > 1 ? (
+                <Text type="secondary" className="!text-xs">
+                    This turn made {captures.length} requests (initial + resumes). Compare them to spot
+                    drift or a loop.
+                </Text>
+            ) : null}
+            {captures.map((c, i) => (
+                <Send key={c.requestId} capture={c} index={i} total={captures.length} />
+            ))}
+        </div>
+    )
+}
+
+export default memo(ContextTab)
+```
+
+- [ ] **Step 2: Wire it into the shell**
+
+In `TurnInspector.tsx`: import the tab + capture reads; compute the trigger id (the user message immediately before the assistant turn) and the captures for it; render `<ContextTab captures={captures} />` in the `context` branch.
+
+Add imports:
+
+```ts
+import {capturesForTrigger} from "@agenta/playground"
+
+import {sessionCapturesAtomFamily} from "../../state/turnCaptures"
+
+import ContextTab from "./ContextTab"
+```
+
+Add derivations (after `message` is computed):
+
+```ts
+const captures = useAtomValue(sessionCapturesAtomFamily(target?.sessionId ?? ""))
+const turnCaptures = useMemo(() => {
+    if (!target) return []
+    const list = allMessages[target.sessionId] ?? []
+    const idx = list.findIndex((m) => m.id === target.assistantMessageId)
+    // The trigger is the last user message at or before this assistant turn.
+    let triggerId: string | null = null
+    for (let i = idx; i >= 0; i--) {
+        if (list[i]?.role === "user") {
+            triggerId = list[i].id
+            break
+        }
+    }
+    return capturesForTrigger(captures, triggerId)
+}, [target, allMessages, captures])
+```
+
+Replace the `context` placeholder with:
+
+```tsx
+{tab === "context" ? <ContextTab captures={turnCaptures} /> : null}
+```
+
+- [ ] **Step 3: Lint + typecheck**
+
+Run (from `web`): `npx eslint --fix oss/src/components/AgentChatSlice/components/TurnInspector/ContextTab.tsx oss/src/components/AgentChatSlice/components/TurnInspector/TurnInspector.tsx`
+Run (from `web/oss`): `npx tsc --noEmit 2>&1 | grep -E "ContextTab|TurnInspector"`
+Expected: clean.
+
+- [ ] **Step 4: Manual verification**
+
+Local deploy. Run a turn that triggers a HITL approval (so it makes ≥2 requests), approve it, then open the inspector → Context tab. Confirm: multiple "Request k of N" cards; each shows the instructions/model and the exact messages sent for that send; you can eyeball drift between sends.
+
+- [ ] **Step 5: Commit**
+
+```bash
+git add web/oss/src/components/AgentChatSlice/components/TurnInspector/ContextTab.tsx web/oss/src/components/AgentChatSlice/components/TurnInspector/TurnInspector.tsx
+git commit --no-verify -m "feat(frontend): turn-inspector Context tab (config + messages sent)"
+```
+
+---
+
+## Phase 3 — Raw tab
+
+### Task 9: Raw tab (literal payloads + copy)
+
+**Files:**
+- Create: `web/oss/src/components/AgentChatSlice/components/TurnInspector/RawTab.tsx`
+- Modify: `web/oss/src/components/AgentChatSlice/components/TurnInspector/TurnInspector.tsx` (wire the `raw` branch)
+
+- [ ] **Step 1: Write `RawTab`**
+
+```tsx
+import {memo} from "react"
+
+import {type TurnRequestCapture} from "@agenta/playground"
+import {App, Button, Typography} from "antd"
+
+const {Text} = Typography
+
+/** One capture's literal outgoing request body, copyable for repro / bug reports. */
+const RawTab = ({captures}: {captures: TurnRequestCapture[]}) => {
+    const {message} = App.useApp()
+    if (captures.length === 0) {
+        return <div className="p-4 text-xs text-colorTextTertiary">No capture for this turn.</div>
+    }
+    return (
+        <div className="flex flex-col gap-3 p-4">
+            {captures.map((c, i) => {
+                const body = {
+                    session_id: c.sessionId,
+                    references: c.references,
+                    data: {inputs: {messages: c.messages}, parameters: c.parameters},
+                }
+                const json = JSON.stringify(body, null, 2)
+                return (
+                    <div key={c.requestId} className="flex flex-col gap-1.5 rounded-lg border border-solid border-colorBorderSecondary p-3">
+                        <div className="flex items-center gap-2">
+                            <Text className="!text-xs !font-medium">Request {i + 1} of {captures.length}</Text>
+                            <Text type="secondary" className="!text-[11px] font-mono truncate">{c.invocationUrl}</Text>
+                            <Button
+                                type="link"
+                                className="!ml-auto !px-0 !text-xs"
+                                onClick={() => {
+                                    navigator.clipboard?.writeText(json)
+                                    message.success("Request body copied")
+                                }}
+                            >
+                                Copy JSON
+                            </Button>
+                        </div>
+                        <pre className="m-0 max-h-96 overflow-auto whitespace-pre-wrap break-all rounded bg-colorFillTertiary px-2 py-1.5 font-mono text-[11px] leading-snug text-colorTextSecondary">
+                            {json}
+                        </pre>
+                    </div>
+                )
+            })}
+        </div>
+    )
+}
+
+export default memo(RawTab)
+```
+
+- [ ] **Step 2: Wire it into the shell**
+
+In `TurnInspector.tsx`, import `RawTab` and replace the `raw` placeholder:
+
+```tsx
+{tab === "raw" ? <RawTab captures={turnCaptures} /> : null}
+```
+
+- [ ] **Step 3: Lint + typecheck**
+
+Run (from `web`): `npx eslint --fix oss/src/components/AgentChatSlice/components/TurnInspector/RawTab.tsx oss/src/components/AgentChatSlice/components/TurnInspector/TurnInspector.tsx`
+Run (from `web/oss`): `npx tsc --noEmit 2>&1 | grep -E "RawTab|TurnInspector"`
+Expected: clean.
+
+- [ ] **Step 4: Manual verification**
+
+Local deploy. Open the inspector → Raw tab. Confirm the literal request body renders per send and "Copy JSON" copies it (paste elsewhere to verify). Dark mode: toggle the theme, confirm tokens (bg/text) read correctly in both.
+
+- [ ] **Step 5: Commit**
+
+```bash
+git add web/oss/src/components/AgentChatSlice/components/TurnInspector/RawTab.tsx web/oss/src/components/AgentChatSlice/components/TurnInspector/TurnInspector.tsx
+git commit --no-verify -m "feat(frontend): turn-inspector Raw tab (copyable payloads)"
+```
+
+---
+
+## Final verification
+
+- [ ] From `web/packages/agenta-playground`: `npx vitest run tests/unit/turnCapture.test.ts` — all pass.
+- [ ] From `web/oss`: `npx tsc --noEmit 2>&1 | grep -E "TurnInspector|TimelineTab|ContextTab|RawTab|turnCaptures|turnInspector|AgentChatPanel"` — no new errors.
+- [ ] From `web`: `npx eslint oss/src/components/AgentChatSlice/components/TurnInspector oss/src/components/AgentChatSlice/state/turnInspector.ts oss/src/components/AgentChatSlice/state/turnCaptures.ts` — clean.
+- [ ] Manual: Build mode shows "Inspect turn"; Chat mode hides it; Timeline/Context/Raw all render; a HITL turn shows multiple captures; the inline step log is unchanged; the trace drawer is untouched.

--- a/sdks/python/agenta/sdk/agents/adapters/vercel/messages.py
+++ b/sdks/python/agenta/sdk/agents/adapters/vercel/messages.py
@@ -9,7 +9,11 @@ from __future__ import annotations
 
 from typing import Any, Dict, List, Optional
 
+from agenta.sdk.utils.logging import get_module_logger
+
 from ...dtos import AgentResult, ContentBlock, Message
+
+log = get_module_logger(__name__)
 
 TOOL_APPROVAL_REQUEST = "tool-approval-request"
 TOOL_APPROVAL_RESPONSE = "tool-approval-response"
@@ -155,6 +159,18 @@ def _tool_part_blocks(part: Dict[str, Any], ptype: str) -> List[ContentBlock]:
         # `extractApprovalDecisions` resolves the parked gate.
         approved = _approval_decision(part, state)
         if approved is not None:
+            # INGRESS side of the HITL key: the inline decision the FE round-tripped, folded into
+            # the `{approved}` envelope the runner's extractApprovalDecisions keys by name+args.
+            _input = part.get("input")
+            log.info(
+                "[HITL] ingress approval-responded id=%s name=%s approved=%s input_keys=%s",
+                tool_call_id,
+                tool_name,
+                approved,
+                list(_input.keys())
+                if isinstance(_input, dict)
+                else type(_input).__name__,
+            )
             blocks.append(
                 ContentBlock(
                     type="tool_result",

--- a/sdks/python/agenta/sdk/agents/adapters/vercel/stream.py
+++ b/sdks/python/agenta/sdk/agents/adapters/vercel/stream.py
@@ -127,13 +127,20 @@ async def agent_run_to_vercel_parts(
             elif etype == "tool_call":
                 tool_call_id = data.get("id")
                 tool_name = data.get("name")
+                # A repeat tool_call for an already-seen id is an input REFRESH: the runner
+                # re-emits the call once the real args arrive on a later ACP tool_call_update
+                # (Pi announces the call first with absent/`{}` args). Emit `tool-input-start`
+                # only the first time — a second start would reset the FE tool part after its
+                # approval/output. Mirrors the seen-id refresh in `_interaction_parts`.
+                first_seen = tool_call_id not in seen_tool_calls
                 seen_tool_calls.add(tool_call_id)
                 tool_names_by_id[tool_call_id] = tool_name
-                yield {
-                    "type": "tool-input-start",
-                    "toolCallId": tool_call_id,
-                    "toolName": tool_name,
-                }
+                if first_seen:
+                    yield {
+                        "type": "tool-input-start",
+                        "toolCallId": tool_call_id,
+                        "toolName": tool_name,
+                    }
                 yield {
                     "type": "tool-input-available",
                     "toolCallId": tool_call_id,
@@ -307,13 +314,20 @@ async def agent_stream_to_vercel_stream(
             elif etype == "tool_call":
                 tool_call_id = data.get("id")
                 tool_name = data.get("name")
+                # A repeat tool_call for an already-seen id is an input REFRESH: the runner
+                # re-emits the call once the real args arrive on a later ACP tool_call_update
+                # (Pi announces the call first with absent/`{}` args). Emit `tool-input-start`
+                # only the first time — a second start would reset the FE tool part after its
+                # approval/output. Mirrors the seen-id refresh in `_interaction_parts`.
+                first_seen = tool_call_id not in seen_tool_calls
                 seen_tool_calls.add(tool_call_id)
                 tool_names_by_id[tool_call_id] = tool_name
-                yield {
-                    "type": "tool-input-start",
-                    "toolCallId": tool_call_id,
-                    "toolName": tool_name,
-                }
+                if first_seen:
+                    yield {
+                        "type": "tool-input-start",
+                        "toolCallId": tool_call_id,
+                        "toolName": tool_name,
+                    }
                 yield {
                     "type": "tool-input-available",
                     "toolCallId": tool_call_id,

--- a/sdks/python/agenta/sdk/agents/adapters/vercel/stream.py
+++ b/sdks/python/agenta/sdk/agents/adapters/vercel/stream.py
@@ -134,7 +134,13 @@ async def agent_run_to_vercel_parts(
                 # approval/output. Mirrors the seen-id refresh in `_interaction_parts`.
                 first_seen = tool_call_id not in seen_tool_calls
                 seen_tool_calls.add(tool_call_id)
-                tool_names_by_id[tool_call_id] = tool_name
+                # Record the name only on first sight. On a repeat (arg-refresh) keep the
+                # best-known name: an intervening approval may have upgraded it to the STABLE
+                # spec name, and this refresh carries only the drift-prone ACP title — letting it
+                # clobber the spec name re-breaks the cross-turn resume key (the HITL loop).
+                if first_seen:
+                    tool_names_by_id[tool_call_id] = tool_name
+                tool_name = tool_names_by_id.get(tool_call_id) or tool_name
                 if first_seen:
                     yield {
                         "type": "tool-input-start",
@@ -184,7 +190,7 @@ async def agent_run_to_vercel_parts(
                     if data.get("render") is not None:
                         yield _render_part(tool_call_id, data["render"])
             elif etype == "interaction_request":
-                for part in _interaction_parts(data, seen_tool_calls):
+                for part in _interaction_parts(data, seen_tool_calls, tool_names_by_id):
                     yield part
             elif etype == "data":
                 part: Dict[str, Any] = {
@@ -321,7 +327,13 @@ async def agent_stream_to_vercel_stream(
                 # approval/output. Mirrors the seen-id refresh in `_interaction_parts`.
                 first_seen = tool_call_id not in seen_tool_calls
                 seen_tool_calls.add(tool_call_id)
-                tool_names_by_id[tool_call_id] = tool_name
+                # Record the name only on first sight. On a repeat (arg-refresh) keep the
+                # best-known name: an intervening approval may have upgraded it to the STABLE
+                # spec name, and this refresh carries only the drift-prone ACP title — letting it
+                # clobber the spec name re-breaks the cross-turn resume key (the HITL loop).
+                if first_seen:
+                    tool_names_by_id[tool_call_id] = tool_name
+                tool_name = tool_names_by_id.get(tool_call_id) or tool_name
                 if first_seen:
                     yield {
                         "type": "tool-input-start",
@@ -371,7 +383,7 @@ async def agent_stream_to_vercel_stream(
                     if data.get("render") is not None:
                         yield _render_part(tool_call_id, data["render"])
             elif etype == "interaction_request":
-                for part in _interaction_parts(data, seen_tool_calls):
+                for part in _interaction_parts(data, seen_tool_calls, tool_names_by_id):
                     yield part
             elif etype == "data":
                 part: Dict[str, Any] = {
@@ -413,7 +425,9 @@ async def agent_stream_to_vercel_stream(
 
 
 def _interaction_parts(
-    data: Dict[str, Any], seen_tool_calls: set
+    data: Dict[str, Any],
+    seen_tool_calls: set,
+    tool_names_by_id: Optional[Dict[Any, Any]] = None,
 ) -> Iterator[Dict[str, Any]]:
     """Project a neutral ``interaction_request`` event to Vercel stream parts.
 
@@ -424,6 +438,7 @@ def _interaction_parts(
     didn't, synthesize a tool part from the request payload so the approval has something to
     render against.
     """
+    names = tool_names_by_id if tool_names_by_id is not None else {}
     kind = data.get("kind")
     payload = data.get("payload") or {}
     if kind == "user_approval":
@@ -435,6 +450,10 @@ def _interaction_parts(
             # gate (responder.ts `permissionToolName`). Otherwise the cross-turn key silently
             # stops matching and the gate re-parks every turn (the HITL resume loop).
             tool_name = _approval_tool_name(tool_call)
+            # Record it as the AUTHORITATIVE name for this id, so a later arg-refresh tool_call
+            # (which carries only the drift-prone ACP title) cannot downgrade it back and re-break
+            # the resume key. See the tool_call handler's `tool_names_by_id.get(...)` preference.
+            names[tool_call_id] = tool_name
             real_input = tool_call.get("rawInput") or tool_call.get("input")
             # EGRESS side of the HITL key: what name+args the FE persists on the approval part
             # (and folds back on resume). Compare to the runner's live `[HITL] gate` identity.
@@ -545,15 +564,16 @@ def _tool_spec_of(tool_call: Dict[str, Any]) -> Optional[Dict[str, Any]]:
 def _approval_tool_name(tool_call: Dict[str, Any]) -> Optional[Any]:
     """The gated tool's name for the cross-turn resume key.
 
-    Prefer the resolved spec's canonical ``name`` — STABLE across cold-replay turns — over the
-    ACP display fields (``title``/``kind``), which the harness can vary between the park turn and
-    the re-raise. The runner's ``permissionToolName`` (responder.ts) uses the same precedence, so
-    the stored key (this name, folded back on resume) and the live re-raised key agree. Falls back
-    to ``name -> title -> kind`` when no spec is resolved (unchanged behavior).
+    Prefer ``resolvedName`` — the recorded ``tool_call`` name the runner stamps on the gate, the
+    SAME value the transcript folds into the stored key — so the egress names the part exactly as
+    the responder keys it. Then the resolved spec's canonical ``name`` (when a spec exists). Only
+    then the ACP display fields (``title``/``kind``), which drift between the park frame and the
+    permission frame and were the resume-loop root cause. Falls back to ``name -> title -> kind``.
     """
     spec = _tool_spec_of(tool_call)
     return (
-        (spec or {}).get("name")
+        tool_call.get("resolvedName")
+        or (spec or {}).get("name")
         or tool_call.get("name")
         or tool_call.get("title")
         or tool_call.get("kind")

--- a/sdks/python/agenta/sdk/agents/adapters/vercel/stream.py
+++ b/sdks/python/agenta/sdk/agents/adapters/vercel/stream.py
@@ -4,6 +4,7 @@ from __future__ import annotations
 
 import json
 from typing import Any, AsyncIterator, Dict, Iterator, Optional
+from uuid import uuid4
 
 from agenta.sdk.utils.logging import get_module_logger
 
@@ -231,7 +232,7 @@ async def agent_stream_to_vercel_stream(
     events: AsyncIterator[Dict[str, Any]],
     *,
     session_id: Optional[str] = None,
-    message_id: str = "msg-1",
+    message_id: Optional[str] = None,
     trace_id: Optional[str] = None,
 ) -> AsyncIterator[Dict[str, Any]]:
     """Project a stream of neutral agenta events into Vercel UI Message Stream parts.
@@ -243,7 +244,13 @@ async def agent_stream_to_vercel_stream(
     ``done`` events; ``trace_id`` is passed in by routing (off the response), since there is no
     run to fall back to here.
     """
-    start: Dict[str, Any] = {"type": "start", "messageId": message_id}
+    # Every turn needs a UNIQUE messageId — the client keys messages by it, so a shared constant
+    # collides across turns (duplicate React keys, dropped turns). Prefer the run's trace_id (stable,
+    # correlatable), else a fresh uuid.
+    resolved_message_id = message_id or (
+        f"msg-{trace_id}" if trace_id else f"msg-{uuid4().hex}"
+    )
+    start: Dict[str, Any] = {"type": "start", "messageId": resolved_message_id}
     if session_id is not None:
         start["messageMetadata"] = {"sessionId": session_id}
     yield start

--- a/sdks/python/agenta/sdk/agents/adapters/vercel/stream.py
+++ b/sdks/python/agenta/sdk/agents/adapters/vercel/stream.py
@@ -5,9 +5,13 @@ from __future__ import annotations
 import json
 from typing import Any, AsyncIterator, Dict, Iterator, Optional
 
+from agenta.sdk.utils.logging import get_module_logger
+
 from ...dtos import AgentResult
 from ...streaming import AgentStream
 from .messages import TOOL_APPROVAL_REQUEST
+
+log = get_module_logger(__name__)
 
 
 # The AI SDK UI message stream (`ai@6`) validates the `finish` frame's
@@ -133,7 +137,10 @@ async def agent_run_to_vercel_parts(
                     "type": "tool-input-available",
                     "toolCallId": tool_call_id,
                     "toolName": tool_name,
-                    "input": data.get("input"),
+                    # Prefer `rawInput` (the tool's real args, per ACP); the runner leaves the
+                    # plain `input` empty on some tool-call paths — mirrors the approval /
+                    # client-tool reads in `_interaction_parts` so every path shows real args.
+                    "input": data.get("rawInput") or data.get("input"),
                 }
                 if data.get("render") is not None:
                     yield _render_part(tool_call_id, data["render"])
@@ -304,7 +311,10 @@ async def agent_stream_to_vercel_stream(
                     "type": "tool-input-available",
                     "toolCallId": tool_call_id,
                     "toolName": tool_name,
-                    "input": data.get("input"),
+                    # Prefer `rawInput` (the tool's real args, per ACP); the runner leaves the
+                    # plain `input` empty on some tool-call paths — mirrors the approval /
+                    # client-tool reads in `_interaction_parts` so every path shows real args.
+                    "input": data.get("rawInput") or data.get("input"),
                 }
                 if data.get("render") is not None:
                     yield _render_part(tool_call_id, data["render"])
@@ -399,10 +409,23 @@ def _interaction_parts(
         tool_call_id = _approval_tool_call_id(payload)
         tool_call = payload.get("toolCall")
         if tool_call_id is not None and isinstance(tool_call, dict):
-            tool_name = (
-                tool_call.get("name") or tool_call.get("title") or tool_call.get("kind")
-            )
+            # Prefer the STABLE resolved spec name over the drift-prone ACP title/kind so the
+            # part the FE persists (and folds back on resume) keys the same as the live re-raised
+            # gate (responder.ts `permissionToolName`). Otherwise the cross-turn key silently
+            # stops matching and the gate re-parks every turn (the HITL resume loop).
+            tool_name = _approval_tool_name(tool_call)
             real_input = tool_call.get("rawInput") or tool_call.get("input")
+            # EGRESS side of the HITL key: what name+args the FE persists on the approval part
+            # (and folds back on resume). Compare to the runner's live `[HITL] gate` identity.
+            log.info(
+                "[HITL] egress approval-request id=%s name=%s spec=%s input_keys=%s",
+                tool_call_id,
+                tool_name,
+                (_tool_spec_of(tool_call) or {}).get("name"),
+                list(real_input.keys())
+                if isinstance(real_input, dict)
+                else type(real_input).__name__,
+            )
             if tool_call_id not in seen_tool_calls:
                 # The runner parked without first surfacing the tool call, so
                 # synthesize a tool part for the approval to render against.
@@ -419,10 +442,11 @@ def _interaction_parts(
                     "input": real_input,
                 }
             elif real_input:
-                # The tool call was already surfaced, often with empty input on a
-                # cold-replay resume. The approval request carries the real args, so
-                # re-emit `tool-input-available` to refresh the parked call's input
-                # instead of persisting `{}` (HITL approve-empty-input bug).
+                # The tool call was already surfaced (often by the tracing tool_call event, whose
+                # name is the ACP title/kind, and often with empty input on a cold-replay resume).
+                # Re-emit `tool-input-available` to refresh BOTH the stable `toolName` and the real
+                # args, instead of persisting the drift-prone name + `{}` input (HITL
+                # approve-empty-input / name-drift bug).
                 yield {
                     "type": "tool-input-available",
                     "toolCallId": tool_call_id,
@@ -486,6 +510,33 @@ def _render_part(tool_call_id: Any, render: Any) -> Dict[str, Any]:
         "type": "data-render",
         "data": {"toolCallId": tool_call_id, "render": render},
     }
+
+
+def _tool_spec_of(tool_call: Dict[str, Any]) -> Optional[Dict[str, Any]]:
+    """The resolved agenta tool spec attached to an ACP tool call, under any of its aliases."""
+    for key in ("spec", "toolSpec", "resolvedTool", "tool"):
+        spec = tool_call.get(key)
+        if isinstance(spec, dict):
+            return spec
+    return None
+
+
+def _approval_tool_name(tool_call: Dict[str, Any]) -> Optional[Any]:
+    """The gated tool's name for the cross-turn resume key.
+
+    Prefer the resolved spec's canonical ``name`` — STABLE across cold-replay turns — over the
+    ACP display fields (``title``/``kind``), which the harness can vary between the park turn and
+    the re-raise. The runner's ``permissionToolName`` (responder.ts) uses the same precedence, so
+    the stored key (this name, folded back on resume) and the live re-raised key agree. Falls back
+    to ``name -> title -> kind`` when no spec is resolved (unchanged behavior).
+    """
+    spec = _tool_spec_of(tool_call)
+    return (
+        (spec or {}).get("name")
+        or tool_call.get("name")
+        or tool_call.get("title")
+        or tool_call.get("kind")
+    )
 
 
 def _approval_tool_call_id(payload: Dict[str, Any]) -> Optional[Any]:

--- a/sdks/python/oss/tests/pytest/unit/agents/adapters/test_vercel_stream_park.py
+++ b/sdks/python/oss/tests/pytest/unit/agents/adapters/test_vercel_stream_park.py
@@ -155,6 +155,62 @@ async def test_parked_tool_call_refreshes_real_args_on_approval() -> None:
     assert parts[-1]["type"] == "finish"
 
 
+@pytest.mark.asyncio
+async def test_approval_prefers_resolved_name_over_drifting_title() -> None:
+    """When the runner stamps ``resolvedName`` (the recorded tool_call name) on the gate, the
+    egress names the FE part with it — matching the responder's live key — even though the ACP
+    permission ``title`` is the drift-prone specific command. This is the live Claude-tool shape."""
+    run = AgentStream(
+        _records(
+            [
+                {
+                    "kind": "event",
+                    "event": {
+                        "type": "tool_call",
+                        "id": "tool-1",
+                        "name": "Terminal",
+                        "input": {},
+                    },
+                },
+                {
+                    "kind": "event",
+                    "event": {
+                        "type": "interaction_request",
+                        "id": "perm-1",
+                        "kind": "user_approval",
+                        "payload": {
+                            "toolCallId": "tool-1",
+                            "toolCall": {
+                                "id": "tool-1",
+                                "resolvedName": "Terminal",
+                                "title": "cat ~/.claude/settings.json",
+                                "kind": "execute",
+                                "rawInput": {"command": "cat ~/.claude/settings.json"},
+                            },
+                        },
+                    },
+                },
+                {"kind": "event", "event": {"type": "done", "stopReason": "paused"}},
+                {
+                    "kind": "result",
+                    "result": {
+                        "ok": True,
+                        "output": "",
+                        "stopReason": "paused",
+                        "sessionId": "conv-1",
+                        "traceId": "trace-1",
+                    },
+                },
+            ]
+        )
+    )
+    parts = [part async for part in agent_run_to_vercel_parts(run)]
+    inputs = [p for p in parts if p.get("type") == "tool-input-available"]
+    assert inputs[-1]["toolName"] == "Terminal", (
+        "the resolved (recorded) name wins over the drifting permission title"
+    )
+
+
 def _parked_run_with_spec_name() -> AgentStream:
     """A parked turn whose tracing ``tool_call`` surfaced the drift-prone ACP display name
     (``Terminal``), while the approval request carries the resolved spec's STABLE canonical name
@@ -217,6 +273,86 @@ async def test_approval_refreshes_part_with_stable_spec_name() -> None:
     # The refreshing emit from the approval request names the tool by its stable spec name.
     assert inputs[-1]["toolName"] == "Bash"
     assert inputs[-1]["input"] == {"cmd": "ls"}
+
+
+def _parked_run_with_late_arg_refresh() -> AgentStream:
+    """The regression order: the tool_call surfaces (empty), the approval upgrades the part to the
+    stable spec name (``Bash``), and THEN Pi's real args land on a later tool_call_update — which
+    the runner replays as a repeat ``tool_call`` carrying only the drift-prone ACP title. That
+    late refresh must NOT clobber the spec name back to the title, or the cross-turn resume key
+    breaks and the gate loops again (the regression from the input-`{}` fix)."""
+    return AgentStream(
+        _records(
+            [
+                {
+                    "kind": "event",
+                    "event": {
+                        "type": "tool_call",
+                        "id": "tool-1",
+                        "name": "Terminal",
+                        "input": {},
+                    },
+                },
+                {
+                    "kind": "event",
+                    "event": {
+                        "type": "interaction_request",
+                        "id": "perm-1",
+                        "kind": "user_approval",
+                        "payload": {
+                            "toolCallId": "tool-1",
+                            "toolCall": {
+                                "id": "tool-1",
+                                "title": "Terminal",
+                                "kind": "execute",
+                                "spec": {"name": "Bash"},
+                                "rawInput": {"cmd": "ls"},
+                            },
+                        },
+                    },
+                },
+                # Pi fills the args in AFTER the gate: a repeat tool_call with only the ACP title.
+                {
+                    "kind": "event",
+                    "event": {
+                        "type": "tool_call",
+                        "id": "tool-1",
+                        "name": "Terminal",
+                        "rawInput": {"cmd": "ls"},
+                    },
+                },
+                {"kind": "event", "event": {"type": "done", "stopReason": "paused"}},
+                {
+                    "kind": "result",
+                    "result": {
+                        "ok": True,
+                        "output": "",
+                        "stopReason": "paused",
+                        "sessionId": "conv-1",
+                        "traceId": "trace-1",
+                    },
+                },
+            ]
+        )
+    )
+
+
+@pytest.mark.asyncio
+async def test_late_arg_refresh_does_not_clobber_stable_spec_name() -> None:
+    """A late arg-refresh (repeat tool_call) after the approval keeps the stable spec name, so the
+    FE part the resume folds back still keys as ``Bash`` (not the drift-prone ``Terminal``)."""
+    parts = [
+        part
+        async for part in agent_run_to_vercel_parts(_parked_run_with_late_arg_refresh())
+    ]
+    inputs = [p for p in parts if p.get("type") == "tool-input-available"]
+    # Every emission for this id keeps the stable name; the last (the late refresh) must too.
+    assert inputs[-1]["toolName"] == "Bash", (
+        "the late arg-refresh must not downgrade the approval's stable spec name"
+    )
+    assert inputs[-1]["input"] == {"cmd": "ls"}
+    # And there is exactly ONE tool-input-start (the refresh must not reset the part).
+    assert sum(1 for p in parts if p.get("type") == "tool-input-start") == 1
 
 
 def _commit_revision_run() -> AgentStream:

--- a/sdks/python/oss/tests/pytest/unit/agents/adapters/test_vercel_stream_park.py
+++ b/sdks/python/oss/tests/pytest/unit/agents/adapters/test_vercel_stream_park.py
@@ -437,3 +437,71 @@ async def test_plain_tool_call_prefers_raw_input() -> None:
     inputs = [p for p in parts if p.get("type") == "tool-input-available"]
     assert len(inputs) == 1
     assert inputs[0]["input"] == {"path": "memory://users/self/profile.md"}
+
+
+def _tool_call_then_input_refresh_run() -> AgentStream:
+    """A non-gated tool the runner surfaces up front with an empty input, then re-emits with the
+    real args once they arrive on the ACP ``tool_call_update`` (the runner's input-refresh)."""
+    return AgentStream(
+        _records(
+            [
+                {
+                    "kind": "event",
+                    "event": {
+                        "type": "tool_call",
+                        "id": "tool-1",
+                        "name": "query_workflows",
+                        "input": {},
+                    },
+                },
+                {
+                    "kind": "event",
+                    "event": {
+                        "type": "tool_call",
+                        "id": "tool-1",
+                        "name": "query_workflows",
+                        "input": {"kind": "agent"},
+                    },
+                },
+                {
+                    "kind": "event",
+                    "event": {
+                        "type": "tool_result",
+                        "id": "tool-1",
+                        "output": "3 found",
+                    },
+                },
+                {"kind": "event", "event": {"type": "done", "stopReason": "stop"}},
+                {
+                    "kind": "result",
+                    "result": {
+                        "ok": True,
+                        "output": "",
+                        "stopReason": "stop",
+                        "sessionId": "conv-1",
+                        "traceId": "trace-1",
+                    },
+                },
+            ]
+        )
+    )
+
+
+@pytest.mark.asyncio
+async def test_repeat_tool_call_refreshes_input_without_a_second_start() -> None:
+    """A repeat ``tool_call`` for a seen id is an input REFRESH: it re-emits ``tool-input-available``
+    with the real args but must NOT emit a second ``tool-input-start`` (which would reset the FE
+    tool part and make it look like the tool re-ran). Mirrors the gated approval-refresh path."""
+    parts = [
+        part
+        async for part in agent_run_to_vercel_parts(_tool_call_then_input_refresh_run())
+    ]
+
+    starts = [p for p in parts if p.get("type") == "tool-input-start"]
+    inputs = [p for p in parts if p.get("type") == "tool-input-available"]
+    # Exactly one start (the call surfaces once), two inputs (empty, then the refresh with args).
+    assert len(starts) == 1
+    assert [p["input"] for p in inputs] == [{}, {"kind": "agent"}]
+    # The refresh precedes the result — input is settled before output arrives.
+    types = [p.get("type") for p in parts]
+    assert types.index("tool-input-available") < types.index("tool-output-available")

--- a/sdks/python/oss/tests/pytest/unit/agents/adapters/test_vercel_stream_park.py
+++ b/sdks/python/oss/tests/pytest/unit/agents/adapters/test_vercel_stream_park.py
@@ -155,6 +155,70 @@ async def test_parked_tool_call_refreshes_real_args_on_approval() -> None:
     assert parts[-1]["type"] == "finish"
 
 
+def _parked_run_with_spec_name() -> AgentStream:
+    """A parked turn whose tracing ``tool_call`` surfaced the drift-prone ACP display name
+    (``Terminal``), while the approval request carries the resolved spec's STABLE canonical name
+    (``Bash``). The egress must key the FE part on the spec name so the cross-turn resume key
+    matches the runner's live re-raised gate (which also prefers ``spec.name``)."""
+    return AgentStream(
+        _records(
+            [
+                {
+                    "kind": "event",
+                    "event": {
+                        "type": "tool_call",
+                        "id": "tool-1",
+                        "name": "Terminal",  # ACP title/kind — varies across turns
+                        "input": {},
+                    },
+                },
+                {
+                    "kind": "event",
+                    "event": {
+                        "type": "interaction_request",
+                        "id": "perm-1",
+                        "kind": "user_approval",
+                        "payload": {
+                            "toolCallId": "tool-1",
+                            "toolCall": {
+                                "id": "tool-1",
+                                "title": "Terminal",
+                                "kind": "execute",
+                                "spec": {"name": "Bash"},
+                                "rawInput": {"cmd": "ls"},
+                            },
+                        },
+                    },
+                },
+                {"kind": "event", "event": {"type": "done", "stopReason": "paused"}},
+                {
+                    "kind": "result",
+                    "result": {
+                        "ok": True,
+                        "output": "",
+                        "stopReason": "paused",
+                        "sessionId": "conv-1",
+                        "traceId": "trace-1",
+                    },
+                },
+            ]
+        )
+    )
+
+
+@pytest.mark.asyncio
+async def test_approval_refreshes_part_with_stable_spec_name() -> None:
+    """The approval refresh re-keys the parked part on the resolved spec name (stable across
+    cold-replay turns), not the drift-prone ACP title/kind the tracing tool_call surfaced."""
+    parts = [
+        part async for part in agent_run_to_vercel_parts(_parked_run_with_spec_name())
+    ]
+    inputs = [p for p in parts if p.get("type") == "tool-input-available"]
+    # The refreshing emit from the approval request names the tool by its stable spec name.
+    assert inputs[-1]["toolName"] == "Bash"
+    assert inputs[-1]["input"] == {"cmd": "ls"}
+
+
 def _commit_revision_run() -> AgentStream:
     return AgentStream(
         _records(
@@ -317,3 +381,59 @@ async def test_parked_client_tool_emits_unsettled_tool_part() -> None:
     } in parts
     assert not any(p.get("type") == "tool-output-available" for p in parts)
     assert parts[-1]["type"] == "finish"
+
+
+def _plain_tool_call_with_raw_input() -> AgentStream:
+    """A non-gated tool call where the runner surfaced the real args under ``rawInput`` (the ACP
+    field) and left the plain ``input`` empty — the common shape behind tool logs showing ``{}``
+    for tools that never go through an approval refresh."""
+    return AgentStream(
+        _records(
+            [
+                {
+                    "kind": "event",
+                    "event": {
+                        "type": "tool_call",
+                        "id": "tool-1",
+                        "name": "read_file",
+                        "input": {},
+                        "rawInput": {"path": "memory://users/self/profile.md"},
+                    },
+                },
+                {
+                    "kind": "event",
+                    "event": {
+                        "type": "tool_result",
+                        "id": "tool-1",
+                        "output": {"ok": True},
+                    },
+                },
+                {"kind": "event", "event": {"type": "done", "stopReason": "stop"}},
+                {
+                    "kind": "result",
+                    "result": {
+                        "ok": True,
+                        "output": "",
+                        "stopReason": "stop",
+                        "sessionId": "conv-1",
+                        "traceId": "trace-1",
+                    },
+                },
+            ]
+        )
+    )
+
+
+@pytest.mark.asyncio
+async def test_plain_tool_call_prefers_raw_input() -> None:
+    """A non-gated tool call projects its real args from ``rawInput`` when the runner leaves the
+    plain ``input`` empty. Without this, only approval-gated tools recovered their args (via the
+    approval refresh) and every other tool log rendered ``{}``."""
+    parts = [
+        part
+        async for part in agent_run_to_vercel_parts(_plain_tool_call_with_raw_input())
+    ]
+
+    inputs = [p for p in parts if p.get("type") == "tool-input-available"]
+    assert len(inputs) == 1
+    assert inputs[0]["input"] == {"path": "memory://users/self/profile.md"}

--- a/services/runner/src/engines/sandbox_agent.ts
+++ b/services/runner/src/engines/sandbox_agent.ts
@@ -36,6 +36,7 @@ import {
 import {
   HITLResponder,
   extractApprovalDecisions,
+  nonConvergingToolNames,
   policyFromRequest,
   type Responder,
 } from "../responder.ts";
@@ -649,14 +650,31 @@ export async function runSandboxAgent(
     };
     const responder =
       deps.responderFactory?.(request.permissionPolicy) ??
-      new HITLResponder(
-        extractApprovalDecisions(request),
-        policyFromRequest(request.permissionPolicy),
-        hasHumanSurface,
-      );
+      (() => {
+        const decisions = extractApprovalDecisions(request);
+        const looping = nonConvergingToolNames(request);
+        // Dump the STORED side of the HITL resume: the decision keys the transcript folded and any
+        // tools flagged as non-converging. Compare against the runner's `[HITL] gate ...` lines
+        // (the LIVE re-raised keys) to see exactly what drifted.
+        if (hasHumanSurface) {
+          logger(
+            `[HITL] resume state: humanSurface=${hasHumanSurface} ` +
+              `decisions=${JSON.stringify([...decisions.entries()])} ` +
+              `looping=${JSON.stringify([...looping])}`,
+          );
+        }
+        return new HITLResponder(
+          decisions,
+          policyFromRequest(request.permissionPolicy),
+          hasHumanSurface,
+          looping,
+          logger,
+        );
+      })();
     attachPermissionResponder({
       session,
       run,
+      log: logger,
       onPark,
       onCreateInteraction: (token, toolName, toolArgs) => {
         const cred = runCredential(request);

--- a/services/runner/src/engines/sandbox_agent/permissions.ts
+++ b/services/runner/src/engines/sandbox_agent/permissions.ts
@@ -14,6 +14,8 @@ export interface AttachPermissionResponderInput {
    * paused and the resume cold-replays. Fires at most once per turn (the first park wins).
    */
   onPark?: () => void;
+  /** Diagnostic sink for the raw ACP permission ground truth (name/spec/args the harness sends). */
+  log?: (msg: string) => void;
   /** Called on park to record the parked gate as an interaction (fire-and-forget). */
   onCreateInteraction?: (
     token: string,
@@ -40,6 +42,7 @@ export function attachPermissionResponder({
   run,
   responder,
   onPark,
+  log,
   onCreateInteraction,
   onResolveInteraction,
 }: AttachPermissionResponderInput): void {
@@ -47,6 +50,28 @@ export function attachPermissionResponder({
     const id = String(req?.id ?? "");
     const availableReplies: string[] = req?.availableReplies ?? [];
     const toolCall = req?.toolCall;
+    // GROUND TRUTH: exactly what the harness hands us for this gate — the resolved spec (and its
+    // stable name) if any, the drift-prone display fields, and the arg shape. This is the earliest
+    // and most authoritative HITL log; everything downstream keys off these fields.
+    if (log) {
+      const spec =
+        toolCall?.spec ?? toolCall?.toolSpec ?? toolCall?.resolvedTool ?? toolCall?.tool;
+      const args = toolCall?.rawInput ?? toolCall?.input;
+      log(
+        `[HITL] ACP permission id=${id} ` +
+          JSON.stringify({
+            toolCallId: toolCall?.toolCallId,
+            specName: spec && typeof spec === "object" ? spec.name : undefined,
+            specKind: spec && typeof spec === "object" ? spec.kind : undefined,
+            name: toolCall?.name,
+            title: toolCall?.title,
+            kind: toolCall?.kind,
+            argKeys:
+              args && typeof args === "object" ? Object.keys(args) : typeof args,
+            availableReplies,
+          }),
+      );
+    }
     // The harness raises a permission request before running ANY gated tool. We branch on the
     // tool's resolved spec: a `kind: "client"` tool is not really a sandbox permission gate — it
     // is a tool whose execution belongs to the browser (e.g. `request_connection`, which renders a

--- a/services/runner/src/engines/sandbox_agent/permissions.ts
+++ b/services/runner/src/engines/sandbox_agent/permissions.ts
@@ -3,7 +3,7 @@ import { decisionToReply, type ClientToolOutcome, type Responder } from "../../r
 
 export interface AttachPermissionResponderInput {
   session: any;
-  run: { emitEvent: (event: AgentEvent) => void };
+  run: { emitEvent: (event: AgentEvent) => void; events?: () => AgentEvent[] };
   responder: Responder;
   /**
    * Called when the responder PARKS a gate (cross-turn HITL). The orchestration loop uses
@@ -50,6 +50,18 @@ export function attachPermissionResponder({
     const id = String(req?.id ?? "");
     const availableReplies: string[] = req?.availableReplies ?? [];
     const toolCall = req?.toolCall;
+    // NAME ANCHOR (the HITL resume-loop root cause): Claude-over-ACP names the SAME tool call
+    // differently across frames — the `session/update` tool_call titles it by category ("Terminal"),
+    // the permission request titles it by the specific invocation ("cat ~/.claude/settings.json ...").
+    // Neither carries a stable `name`/`spec`. The transcript (and thus the stored approval key)
+    // records the tool_call name, so the cross-turn key must ALSO use it — not the permission
+    // frame's own drifting title. Recover the recorded tool_call name for THIS id (same id within a
+    // turn) and stamp it as `resolvedName`, which `permissionToolName` (responder) and
+    // `_approval_tool_name` (egress) both prefer, so the live re-raised key equals the stored key.
+    if (toolCall && typeof toolCall === "object" && !toolCall.resolvedName) {
+      const recorded = recordedToolName(run, toolCall.toolCallId);
+      if (recorded) toolCall.resolvedName = recorded;
+    }
     // GROUND TRUTH: exactly what the harness hands us for this gate — the resolved spec (and its
     // stable name) if any, the drift-prone display fields, and the arg shape. This is the earliest
     // and most authoritative HITL log; everything downstream keys off these fields.
@@ -156,6 +168,27 @@ export function attachPermissionResponder({
       })
       .catch(() => {});
   });
+}
+
+/**
+ * The name the runner already recorded for this tool-call id via the `session/update` `tool_call`
+ * event — the SAME value the transcript folds into the stored approval key. Used to key the live
+ * permission gate so it matches the stored decision across the cold-replay resume (the ACP
+ * permission frame's own title drifts from the tool_call's, breaking the key otherwise).
+ */
+function recordedToolName(
+  run: { events?: () => AgentEvent[] },
+  toolCallId: unknown,
+): string | undefined {
+  if (typeof toolCallId !== "string" || !toolCallId || !run.events) return undefined;
+  // Last match wins: a later tool_call for the same id (an arg-refresh) carries the same name.
+  let name: string | undefined;
+  for (const event of run.events()) {
+    if (event.type === "tool_call" && event.id === toolCallId && event.name) {
+      name = event.name;
+    }
+  }
+  return name;
 }
 
 function clientToolSpecOf(toolCall: any): any | undefined {

--- a/services/runner/src/responder.ts
+++ b/services/runner/src/responder.ts
@@ -313,7 +313,15 @@ function permissionRequestKeys(request: PermissionRequest): string[] {
  */
 function gateIdentity(toolCall: unknown): string {
   const tc = toolCall as
-    | { toolCallId?: unknown; name?: unknown; title?: unknown; kind?: unknown; rawInput?: unknown; input?: unknown }
+    | {
+        toolCallId?: unknown;
+        resolvedName?: unknown;
+        name?: unknown;
+        title?: unknown;
+        kind?: unknown;
+        rawInput?: unknown;
+        input?: unknown;
+      }
     | undefined;
   const spec = specOf(toolCall);
   const args = tc?.rawInput ?? tc?.input;
@@ -321,6 +329,7 @@ function gateIdentity(toolCall: unknown): string {
     args && typeof args === "object" ? Object.keys(args as object) : typeof args;
   return JSON.stringify({
     id: tc?.toolCallId,
+    resolvedName: tc?.resolvedName,
     specName: spec?.name,
     name: tc?.name,
     title: tc?.title,
@@ -362,9 +371,19 @@ function specOf(toolCall: unknown): { name?: unknown } | undefined {
  */
 function permissionToolName(toolCall: unknown): string | undefined {
   const tc = toolCall as
-    | { name?: unknown; title?: unknown; kind?: unknown }
+    | { resolvedName?: unknown; name?: unknown; title?: unknown; kind?: unknown }
     | undefined;
-  for (const candidate of [specOf(toolCall)?.name, tc?.name, tc?.title, tc?.kind]) {
+  // `resolvedName` (the recorded tool_call name, stamped by the engine) comes FIRST: it is the
+  // same value the transcript folds into the stored key, so preferring it makes the cross-turn
+  // resume key match. `spec.name` next (when a resolved spec exists), then the drift-prone ACP
+  // display fields as a last resort.
+  for (const candidate of [
+    tc?.resolvedName,
+    specOf(toolCall)?.name,
+    tc?.name,
+    tc?.title,
+    tc?.kind,
+  ]) {
     if (typeof candidate === "string" && candidate) return candidate;
   }
   return undefined;

--- a/services/runner/src/responder.ts
+++ b/services/runner/src/responder.ts
@@ -196,12 +196,45 @@ export class HITLResponder implements Responder {
     private readonly decisions: ApprovalDecisions,
     private readonly basePolicy: PermissionPolicy,
     private readonly hasHumanSurface: boolean,
+    /** Tool names in a non-converging resume loop; the next gate for one is denied (loop-breaker). */
+    private readonly nonConverging: ReadonlySet<string> = new Set(),
+    /** Diagnostic sink (a miss or a loop-break). No-op by default so the responder stays pure in tests. */
+    private readonly log: (msg: string) => void = () => {},
   ) {}
 
   async onPermission(request: PermissionRequest): Promise<ResponderOutcome> {
+    const toolCall = (request.raw as { toolCall?: unknown } | undefined)?.toolCall;
+    const name = permissionToolName(toolCall);
+    const keys = permissionRequestKeys(request);
+
     const stored = this.lookupPermission(request);
-    if (stored) return stored;
-    if (this.hasHumanSurface) return "park"; // human must decide; end the turn, tool pending
+    if (stored) {
+      this.log(
+        `[HITL] gate "${name}" -> stored ${stored} (resume matched) keys=${JSON.stringify(keys)}`,
+      );
+      return stored;
+    }
+    // Loop-breaker: a gate with no stored decision whose tool has been approved repeatedly
+    // without ever executing is a non-converging cold-replay resume (the name/arg key never
+    // re-matched). DENY it — a clean terminal failure the model stops re-issuing — instead of
+    // parking forever (the infinite re-approval loop). Fail-safe under the real key fix above.
+    if (name && this.nonConverging.has(name)) {
+      this.log(
+        `[HITL] loop-breaker: denying "${name}" — approved repeatedly but never executed ` +
+          `(resume key never matched; likely name/arg drift). ` +
+          `keys=${JSON.stringify(keys)} identity=${gateIdentity(toolCall)}`,
+      );
+      return "deny";
+    }
+    if (this.hasHumanSurface) {
+      // First-time gate (or a fresh park after a miss). Dump the full ground-truth identity so a
+      // later re-raise can be compared field-by-field to see what drifted.
+      this.log(
+        `[HITL] gate "${name}" -> PARK (awaiting human) keys=${JSON.stringify(keys)} ` +
+          `identity=${gateIdentity(toolCall)}`,
+      );
+      return "park"; // human must decide; end the turn, tool pending
+    }
     return this.basePolicy === "deny" ? "deny" : "allow"; // headless: PolicyResponder parity
   }
 
@@ -213,9 +246,19 @@ export class HITLResponder implements Responder {
   }
 
   private lookupPermission(request: PermissionRequest): PermissionDecision | undefined {
-    for (const key of permissionRequestKeys(request)) {
+    const keys = permissionRequestKeys(request);
+    for (const key of keys) {
       const decision = this.decisions.get(key);
       if (isPermissionDecision(decision)) return decision;
+    }
+    // Diagnostic: a gate that misses while decisions ARE present is the resume-key-drift
+    // signature (the stored approve/deny key never matched the re-raised gate). Dump both so a
+    // single live session pins whether the NAME or the ARGS drifted.
+    if (this.decisions.size > 0) {
+      this.log(
+        `[HITL] gate miss keys=${JSON.stringify(keys)} ` +
+          `stored=${JSON.stringify([...this.decisions.keys()])}`,
+      );
     }
     return undefined;
   }
@@ -262,6 +305,30 @@ function permissionRequestKeys(request: PermissionRequest): string[] {
   return keys;
 }
 
+/**
+ * A compact ground-truth dump of an ACP tool call for HITL logs: every name candidate the key
+ * derivation sees (so a park vs. its re-raise can be diffed field-by-field) plus the arg shape.
+ * This is the single most useful diagnostic for the resume-loop: it shows whether the harness
+ * even attaches a resolved `spec` (and its name), and whether title/kind/args drift across turns.
+ */
+function gateIdentity(toolCall: unknown): string {
+  const tc = toolCall as
+    | { toolCallId?: unknown; name?: unknown; title?: unknown; kind?: unknown; rawInput?: unknown; input?: unknown }
+    | undefined;
+  const spec = specOf(toolCall);
+  const args = tc?.rawInput ?? tc?.input;
+  const argKeys =
+    args && typeof args === "object" ? Object.keys(args as object) : typeof args;
+  return JSON.stringify({
+    id: tc?.toolCallId,
+    specName: spec?.name,
+    name: tc?.name,
+    title: tc?.title,
+    kind: tc?.kind,
+    argKeys,
+  });
+}
+
 function clientToolRequestKeys(request: ClientToolRequest): string[] {
   const keys: string[] = [];
   if (request.toolCallId) keys.push(request.toolCallId);
@@ -270,12 +337,34 @@ function clientToolRequestKeys(request: ClientToolRequest): string[] {
   return keys;
 }
 
-/** Resolve the gated tool's name the same way the egress does: name, then title, then kind. */
+/** The resolved agenta tool spec attached to an ACP tool call, under any of its aliases. */
+function specOf(toolCall: unknown): { name?: unknown } | undefined {
+  const tc = toolCall as
+    | {
+        spec?: unknown;
+        toolSpec?: unknown;
+        resolvedTool?: unknown;
+        tool?: unknown;
+      }
+    | undefined;
+  const spec = tc?.spec ?? tc?.toolSpec ?? tc?.resolvedTool ?? tc?.tool;
+  return spec && typeof spec === "object" ? (spec as { name?: unknown }) : undefined;
+}
+
+/**
+ * Resolve the gated tool's name for the cold-replay key. Prefer the resolved spec's canonical
+ * `name` — it is STABLE across turns — over the ACP display fields (`title`/`kind`), which the
+ * harness can vary between the park turn and the re-raise (a Claude tool has no ACP `name`, so
+ * the previous `name -> title -> kind` chain keyed on a drift-prone display string and the
+ * cross-turn key silently stopped matching -> re-park loop). The egress
+ * (`vercel/stream.py::_interaction_request`) prefers `spec.name` the same way, so the stored key
+ * and this live key agree. Falls back to the old chain when no spec is resolved (unchanged).
+ */
 function permissionToolName(toolCall: unknown): string | undefined {
   const tc = toolCall as
     | { name?: unknown; title?: unknown; kind?: unknown }
     | undefined;
-  for (const candidate of [tc?.name, tc?.title, tc?.kind]) {
+  for (const candidate of [specOf(toolCall)?.name, tc?.name, tc?.title, tc?.kind]) {
     if (typeof candidate === "string" && candidate) return candidate;
   }
   return undefined;
@@ -340,6 +429,56 @@ export function extractApprovalDecisions(
     }
   }
   return decisions;
+}
+
+/**
+ * Tool names whose HITL approvals are NOT converging into real executions — the fingerprint of a
+ * cold-replay resume loop. A successful approve makes the tool RUN and emit a real `tool_result`
+ * on the next turn, so a healthy tool has ~one real result per approval. When a tool's `{approved:
+ * true}` envelopes outnumber its real results by `threshold` or more, the resume key never matched
+ * (name/arg drift) and the gate re-parked every turn. The caller denies the next gate for such a
+ * tool (a clean terminal failure) instead of parking forever. Denies (`{approved: false}`) are
+ * terminal, never a loop, so they are ignored.
+ */
+export function nonConvergingToolNames(
+  request: AgentRunRequest,
+  threshold = 3,
+): Set<string> {
+  const nameById = new Map<string, string | undefined>();
+  for (const message of request.messages ?? []) {
+    const content = message?.content;
+    if (!Array.isArray(content)) continue;
+    for (const block of content) {
+      if (block?.type === "tool_call" && block.toolCallId) {
+        nameById.set(block.toolCallId, block.toolName);
+      }
+    }
+  }
+  const approved = new Map<string, number>();
+  const executed = new Map<string, number>();
+  for (const message of request.messages ?? []) {
+    const content = message?.content;
+    if (!Array.isArray(content)) continue;
+    for (const block of content) {
+      if (block?.type !== "tool_result") continue;
+      const name =
+        block.toolName ??
+        (block.toolCallId ? nameById.get(block.toolCallId) : undefined);
+      if (!name) continue;
+      const out = block.output;
+      const flag =
+        out && typeof out === "object" && !Array.isArray(out)
+          ? (out as { approved?: unknown }).approved
+          : undefined;
+      if (flag === true) approved.set(name, (approved.get(name) ?? 0) + 1);
+      else if (flag !== false) executed.set(name, (executed.get(name) ?? 0) + 1);
+    }
+  }
+  const looping = new Set<string>();
+  for (const [name, count] of approved) {
+    if (count - (executed.get(name) ?? 0) >= threshold) looping.add(name);
+  }
+  return looping;
 }
 
 function isPermissionDecision(value: unknown): value is PermissionDecision {

--- a/services/runner/src/tracing/otel.ts
+++ b/services/runner/src/tracing/otel.ts
@@ -661,6 +661,22 @@ function acpBlockText(block: any): string {
   return "";
 }
 
+/**
+ * Whether a tool's `rawInput` holds real, inspectable args. Pi announces a call with an absent
+ * or empty `{}` input and fills the args in on a later `tool_call_update`; both placeholders
+ * count as "no args yet" so we know to refresh the tool_call once the real args land.
+ */
+function hasToolArgs(input: unknown): boolean {
+  if (input == null) return false;
+  if (
+    typeof input === "object" &&
+    !Array.isArray(input) &&
+    Object.keys(input as Record<string, unknown>).length === 0
+  )
+    return false;
+  return true;
+}
+
 /** Text of an ACP tool_call `content` array (ToolCallContent[]). */
 function acpToolContentText(content: any): string {
   if (!content) return "";
@@ -872,7 +888,7 @@ export function createSandboxAgentOtel(
   let reasoningAccumulated = "";
   let usage: AgentUsage | undefined;
   const events: AgentEvent[] = [];
-  const toolSpans = new Map<string, { span?: Span; name: string; recorded: boolean }>();
+  const toolSpans = new Map<string, { span?: Span; name: string; hasArgs: boolean }>();
 
   // Live emission. `record` is the single choke point for every event: it appends to the
   // result log and, on the streaming path, flushes the event the moment it is built — so
@@ -1105,36 +1121,34 @@ export function createSandboxAgentOtel(
         if (update.rawInput != null)
           setInputs(span, update.rawInput as Record<string, unknown>, capture);
       }
-      // Defer the tool_call event until the args are actually present. Pi announces the call
-      // first (often with an empty `rawInput`) and fills the args in on a later
-      // `tool_call_update`; emitting now with an empty input is what made every tool log show
-      // `{}`. Record here only if the args already arrived — otherwise on the update, or (as a
-      // last resort) at close so the call still surfaces.
-      const recorded = update.rawInput != null;
-      if (recorded) {
-        record({
-          type: "tool_call",
-          id: String(id),
-          name: String(name),
-          input: update.rawInput,
-        });
-      }
-      toolSpans.set(id, { span, name: String(name), recorded });
+      // Emit the tool_call up front — the FE tool part, the HITL approval part, and the loop
+      // breaker all attach to it, so it MUST surface before any approval/result for this id.
+      // Pi often announces the call with absent/`{}` args and fills them on a later
+      // `tool_call_update`; we refresh the input there (see below), never by delaying this.
+      record({
+        type: "tool_call",
+        id: String(id),
+        name: String(name),
+        input: update.rawInput,
+      });
+      toolSpans.set(id, { span, name: String(name), hasArgs: hasToolArgs(update.rawInput) });
       // A tool_call can arrive already completed (status set up front).
       maybeCloseTool(id, update);
       return;
     }
 
     if (kind === "tool_call_update") {
-      // The args often land here, not on the initial `tool_call`. Emit the deferred tool_call
-      // event now with the real input (once), before the tool closes.
+      // The real args often land here, not on the initial `tool_call`. Refresh the input ONCE,
+      // by re-recording the tool_call with the real args, so a non-gated tool shows them instead
+      // of the placeholder `{}`. The egress projects a repeat tool_call for a seen id as an
+      // input refresh (no new tool-input-start), mirroring the gated approval-refresh path.
       const id = update.toolCallId;
       const entry = id ? toolSpans.get(id) : undefined;
-      if (entry && !entry.recorded && update.rawInput != null) {
+      if (entry && !entry.hasArgs && hasToolArgs(update.rawInput)) {
         if (entry.span)
           setInputs(entry.span, update.rawInput as Record<string, unknown>, capture);
         record({ type: "tool_call", id: String(id), name: entry.name, input: update.rawInput });
-        entry.recorded = true;
+        entry.hasArgs = true;
       }
       maybeCloseTool(id, update);
       return;
@@ -1163,13 +1177,6 @@ export function createSandboxAgentOtel(
     if (!entry) return;
     const status = update?.status;
     if (status !== "completed" && status !== "failed") return;
-    // Last resort: if `rawInput` never arrived on any update, still surface the call (with
-    // whatever this closing update carries) BEFORE its result, so the SDK/FE get a
-    // tool_call -> tool_result pair rather than an orphaned result.
-    if (!entry.recorded) {
-      record({ type: "tool_call", id, name: entry.name, input: update.rawInput ?? null });
-      entry.recorded = true;
-    }
     const out =
       acpToolContentText(update.content) ||
       acpToolContentText(update.rawOutput);

--- a/services/runner/src/tracing/otel.ts
+++ b/services/runner/src/tracing/otel.ts
@@ -872,7 +872,7 @@ export function createSandboxAgentOtel(
   let reasoningAccumulated = "";
   let usage: AgentUsage | undefined;
   const events: AgentEvent[] = [];
-  const toolSpans = new Map<string, { span?: Span; name: string }>();
+  const toolSpans = new Map<string, { span?: Span; name: string; recorded: boolean }>();
 
   // Live emission. `record` is the single choke point for every event: it appends to the
   // result log and, on the streaming path, flushes the event the moment it is built — so
@@ -1105,20 +1105,38 @@ export function createSandboxAgentOtel(
         if (update.rawInput != null)
           setInputs(span, update.rawInput as Record<string, unknown>, capture);
       }
-      toolSpans.set(id, { span, name: String(name) });
-      record({
-        type: "tool_call",
-        id: String(id),
-        name: String(name),
-        input: update.rawInput,
-      });
+      // Defer the tool_call event until the args are actually present. Pi announces the call
+      // first (often with an empty `rawInput`) and fills the args in on a later
+      // `tool_call_update`; emitting now with an empty input is what made every tool log show
+      // `{}`. Record here only if the args already arrived — otherwise on the update, or (as a
+      // last resort) at close so the call still surfaces.
+      const recorded = update.rawInput != null;
+      if (recorded) {
+        record({
+          type: "tool_call",
+          id: String(id),
+          name: String(name),
+          input: update.rawInput,
+        });
+      }
+      toolSpans.set(id, { span, name: String(name), recorded });
       // A tool_call can arrive already completed (status set up front).
       maybeCloseTool(id, update);
       return;
     }
 
     if (kind === "tool_call_update") {
-      maybeCloseTool(update.toolCallId, update);
+      // The args often land here, not on the initial `tool_call`. Emit the deferred tool_call
+      // event now with the real input (once), before the tool closes.
+      const id = update.toolCallId;
+      const entry = id ? toolSpans.get(id) : undefined;
+      if (entry && !entry.recorded && update.rawInput != null) {
+        if (entry.span)
+          setInputs(entry.span, update.rawInput as Record<string, unknown>, capture);
+        record({ type: "tool_call", id: String(id), name: entry.name, input: update.rawInput });
+        entry.recorded = true;
+      }
+      maybeCloseTool(id, update);
       return;
     }
 
@@ -1145,6 +1163,13 @@ export function createSandboxAgentOtel(
     if (!entry) return;
     const status = update?.status;
     if (status !== "completed" && status !== "failed") return;
+    // Last resort: if `rawInput` never arrived on any update, still surface the call (with
+    // whatever this closing update carries) BEFORE its result, so the SDK/FE get a
+    // tool_call -> tool_result pair rather than an orphaned result.
+    if (!entry.recorded) {
+      record({ type: "tool_call", id, name: entry.name, input: update.rawInput ?? null });
+      entry.recorded = true;
+    }
     const out =
       acpToolContentText(update.content) ||
       acpToolContentText(update.rawOutput);

--- a/services/runner/tests/unit/responder.test.ts
+++ b/services/runner/tests/unit/responder.test.ts
@@ -493,6 +493,62 @@ function permReqWithSpec(
   };
 }
 
+// The LIVE production shape (from runner logs): a Claude-over-ACP gate with NO spec and a
+// permission-frame `title` that is the specific invocation ("cat ~/...") — which DIFFERS from the
+// `session/update` tool_call title the transcript stored ("Terminal"). The engine recovers the
+// recorded tool_call name and stamps it as `resolvedName`; the key must anchor on THAT.
+function permReqResolved(
+  toolCallId: string,
+  resolvedName: string,
+  driftingTitle: string,
+  rawInput?: unknown,
+): PermissionRequest {
+  return {
+    id: "perm-1",
+    availableReplies: ["once", "always", "reject"],
+    raw: {
+      id: "perm-1",
+      toolCall: { toolCallId, resolvedName, title: driftingTitle, kind: "execute", rawInput },
+    },
+  };
+}
+
+describe("HITLResponder — recorded-name anchor (the live ACP title-drift loop)", () => {
+  it("resumes: stored key uses the tool_call name (Terminal) while the permission title drifts (cat ...)", async () => {
+    // Exactly the logged failure: stored `Terminal#{command,description}` -> allow, re-raised gate
+    // whose ACP permission title is the full command. Without `resolvedName` the live key would be
+    // `cat ...#args` and never match -> re-park loop. With it, the live key is `Terminal#args`.
+    const args = { command: "cat ~/.claude/settings.json", description: "Read global settings" };
+    const decisions = new Map<string, PermissionDecision>([
+      [parkedCallKey("Terminal", args)!, "allow"],
+    ]);
+    const responder = new HITLResponder(decisions, "auto", true);
+    assert.equal(
+      await responder.onPermission(
+        permReqResolved("fresh-id", "Terminal", "cat ~/.claude/settings.json", args),
+      ),
+      "allow",
+      "the recorded tool_call name anchors the resume despite the drifting permission title",
+    );
+  });
+
+  it("the loop-breaker also matches on the recorded name (looping set is keyed the same way)", async () => {
+    const args = { command: "cat x" };
+    const responder = new HITLResponder(
+      new Map(),
+      "auto",
+      true,
+      new Set(["Terminal"]), // nonConverging is keyed by the stored (recorded) name
+      () => {},
+    );
+    // The live gate resolves to "Terminal" (not the "cat x" title), so the breaker engages.
+    assert.equal(
+      await responder.onPermission(permReqResolved("fresh", "Terminal", "cat x", args)),
+      "deny",
+    );
+  });
+});
+
 describe("HITLResponder — stable spec.name anchor (name-drift fix)", () => {
   it("resumes when the stored key used the spec name but the re-raised gate only has a drifting title", async () => {
     // Park turn: the tool was stored under its canonical spec name (what the egress now writes).

--- a/services/runner/tests/unit/responder.test.ts
+++ b/services/runner/tests/unit/responder.test.ts
@@ -19,6 +19,7 @@ import {
   parkedCallKey,
   decisionToReply,
   extractApprovalDecisions,
+  nonConvergingToolNames,
   policyFromRequest,
   type PermissionDecision,
   type PermissionRequest,
@@ -464,5 +465,197 @@ describe("emitEvent", () => {
     const ev = run.events().find((e) => e.type === "data");
     assert.ok(ev, "data event recorded with no live sink");
     assert.equal((ev as any).name, "weather");
+  });
+});
+
+// A permission request whose ACP tool call carries a resolved spec (with a STABLE canonical
+// name) plus drift-prone display fields (title/kind). The live wire for a Claude tool has no
+// `name`, so the key must anchor on `spec.name`, not the title/kind that varies across turns.
+function permReqWithSpec(
+  toolCallId: string,
+  specName: string,
+  displayTitle: string,
+  rawInput?: unknown,
+): PermissionRequest {
+  return {
+    id: "perm-1",
+    availableReplies: ["once", "always", "reject"],
+    raw: {
+      id: "perm-1",
+      toolCall: {
+        toolCallId,
+        title: displayTitle,
+        kind: "execute",
+        spec: { name: specName },
+        rawInput,
+      },
+    },
+  };
+}
+
+describe("HITLResponder — stable spec.name anchor (name-drift fix)", () => {
+  it("resumes when the stored key used the spec name but the re-raised gate only has a drifting title", async () => {
+    // Park turn: the tool was stored under its canonical spec name (what the egress now writes).
+    const decisions = new Map<string, PermissionDecision>([
+      [parkedCallKey("commit_revision", { message: "hi" })!, "allow"],
+    ]);
+    const responder = new HITLResponder(decisions, "auto", true);
+    // Re-raise: fresh id, NO ACP `name`, a display title that differs from the spec name.
+    // The old `name -> title -> kind` chain would key on "Commit changes" and never match.
+    assert.equal(
+      await responder.onPermission(
+        permReqWithSpec("fresh-id", "commit_revision", "Commit changes", {
+          message: "hi",
+        }),
+      ),
+      "allow",
+      "spec.name anchors the resume even when the display title drifts",
+    );
+  });
+
+  it("SECURITY: the spec-name anchor is still args-scoped (different args re-prompt)", async () => {
+    const decisions = new Map<string, PermissionDecision>([
+      [parkedCallKey("commit_revision", { message: "hi" })!, "allow"],
+    ]);
+    const responder = new HITLResponder(decisions, "auto", true);
+    assert.equal(
+      await responder.onPermission(
+        permReqWithSpec("call-b", "commit_revision", "Commit changes", {
+          message: "DIFFERENT",
+        }),
+      ),
+      "park",
+      "a different-args call must re-prompt even under the same spec name",
+    );
+  });
+});
+
+describe("nonConvergingToolNames — HITL resume loop detection", () => {
+  // Build a transcript with `approves` {approved:true} envelopes and `execs` real results for
+  // one tool, mirroring what the Vercel ingress folds onto each turn.
+  function transcriptFor(
+    name: string,
+    approves: number,
+    execs: number,
+  ): AgentRunRequest {
+    const content: any[] = [];
+    for (let i = 0; i < approves; i++)
+      content.push({
+        type: "tool_result",
+        toolCallId: `a-${i}`,
+        toolName: name,
+        output: { approved: true },
+      });
+    for (let i = 0; i < execs; i++)
+      content.push({
+        type: "tool_result",
+        toolCallId: `e-${i}`,
+        toolName: name,
+        output: "real output",
+      });
+    return { messages: [{ role: "tool", content }] };
+  }
+
+  it("flags a tool approved repeatedly but never executed", () => {
+    const looping = nonConvergingToolNames(transcriptFor("commit_revision", 3, 0));
+    assert.ok(looping.has("commit_revision"));
+  });
+
+  it("does NOT flag a converging tool (each approval produced a real result)", () => {
+    const looping = nonConvergingToolNames(transcriptFor("edit", 3, 3));
+    assert.equal(looping.has("edit"), false);
+  });
+
+  it("does NOT flag below the threshold (a couple of retries are tolerated)", () => {
+    const looping = nonConvergingToolNames(transcriptFor("bash", 2, 0));
+    assert.equal(looping.has("bash"), false);
+  });
+
+  it("recovers the tool name from the correlated tool_call when the result omits it", () => {
+    const request: AgentRunRequest = {
+      messages: [
+        {
+          role: "assistant",
+          content: [
+            { type: "tool_call", toolCallId: "t1", toolName: "deploy" },
+            { type: "tool_call", toolCallId: "t2", toolName: "deploy" },
+            { type: "tool_call", toolCallId: "t3", toolName: "deploy" },
+          ],
+        },
+        {
+          role: "tool",
+          content: [
+            { type: "tool_result", toolCallId: "t1", output: { approved: true } },
+            { type: "tool_result", toolCallId: "t2", output: { approved: true } },
+            { type: "tool_result", toolCallId: "t3", output: { approved: true } },
+          ],
+        },
+      ],
+    };
+    assert.ok(nonConvergingToolNames(request).has("deploy"));
+  });
+});
+
+describe("HITLResponder — loop-breaker + diagnostics", () => {
+  it("DENIES a gate whose tool is non-converging, instead of parking forever", async () => {
+    const logs: string[] = [];
+    // No stored decision matches (the drift), and the tool is flagged as looping.
+    const responder = new HITLResponder(
+      new Map(),
+      "auto",
+      true, // human surface -> would normally park
+      new Set(["commit_revision"]),
+      (m) => logs.push(m),
+    );
+    assert.equal(
+      await responder.onPermission(
+        permReqWithSpec("fresh", "commit_revision", "Commit changes", {
+          message: "x",
+        }),
+      ),
+      "deny",
+      "the loop-breaker denies rather than re-parking",
+    );
+    assert.ok(
+      logs.some((l) => l.includes("loop-breaker")),
+      "the loop-break is logged for diagnostics",
+    );
+  });
+
+  it("still parks a NON-looping tool with no stored decision (loop-breaker is scoped)", async () => {
+    const responder = new HITLResponder(
+      new Map(),
+      "auto",
+      true,
+      new Set(["commit_revision"]),
+      () => {},
+    );
+    assert.equal(
+      await responder.onPermission(
+        permReqWithSpec("fresh", "edit", "Edit file", { path: "a.txt" }),
+      ),
+      "park",
+      "a different tool that is not looping still parks normally",
+    );
+  });
+
+  it("logs a gate MISS when decisions are present but none match (drift diagnostic)", async () => {
+    const logs: string[] = [];
+    const decisions = new Map<string, PermissionDecision>([
+      [parkedCallKey("edit", { path: "a.txt" })!, "allow"],
+    ]);
+    const responder = new HITLResponder(
+      decisions,
+      "auto",
+      true,
+      new Set(),
+      (m) => logs.push(m),
+    );
+    // A gate that does not match the stored key -> park, but the miss is logged with both sides.
+    await responder.onPermission(permReqWithSpec("fresh", "edit", "Edit", { path: "OTHER" }));
+    assert.ok(
+      logs.some((l) => l.includes("gate miss") && l.includes("stored=")),
+      "the miss dumps live keys and stored keys",
+    );
   });
 });

--- a/services/runner/tests/unit/sandbox-agent-permissions.test.ts
+++ b/services/runner/tests/unit/sandbox-agent-permissions.test.ts
@@ -81,6 +81,46 @@ describe("attachPermissionResponder", () => {
     assert.deepEqual(replies, [{ id: "perm-1", reply: "once" }]);
   });
 
+  it("stamps resolvedName from the recorded tool_call so the resume key matches (ACP title-drift fix)", async () => {
+    // Live shape: the `session/update` tool_call named the tool "Terminal"; the permission frame
+    // titles it by the specific command. The responder must see `resolvedName: "Terminal"` (the
+    // recorded name) so its key matches the stored `Terminal#args`, not the drifting command title.
+    let handler: ((req: any) => void) | undefined;
+    const session = {
+      onPermissionRequest(cb: (req: any) => void) {
+        handler = cb;
+      },
+      async respondPermission() {},
+    };
+    const recorded: AgentEvent[] = [
+      { type: "tool_call", id: "tool-1", name: "Terminal", input: {} },
+    ];
+    const seen: PermissionRequest[] = [];
+    const responder: Responder = {
+      async onPermission(request) {
+        seen.push(request);
+        return "allow";
+      },
+      async onClientTool() {
+        return "deny";
+      },
+    };
+    attachPermissionResponder({
+      session,
+      run: { emitEvent: () => {}, events: () => recorded },
+      responder,
+    });
+    handler?.({
+      id: "perm-1",
+      availableReplies: ["once", "reject"],
+      toolCall: { toolCallId: "tool-1", title: "cat ~/.claude/settings.json", kind: "execute" },
+    });
+    await flushPromises();
+
+    const tc = (seen[0]?.raw as any)?.toolCall;
+    assert.equal(tc.resolvedName, "Terminal", "recorded tool_call name stamped onto the gate");
+  });
+
   it("parks: emits the interaction_request but sends NO harness reply (F-024 regression)", async () => {
     // The park outcome must never reach the harness as a reply: a `reject` would make Claude
     // emit a failed tool call ("User refused permission") whose tool_result{isError} clobbers

--- a/services/runner/tests/unit/stream-events.test.ts
+++ b/services/runner/tests/unit/stream-events.test.ts
@@ -115,7 +115,9 @@ describe("createSandboxAgentOtel state machine", () => {
     }
 
     // The structured tool/usage events are still present, with exactly one done.
-    assert.equal(ofType(events, "tool_call").length, 1, "tool_call present");
+    const calls = ofType(events, "tool_call");
+    assert.equal(calls.length, 1, "tool_call present");
+    assert.deepEqual(calls[0].input, { city: "Paris" }, "tool_call carries the args from the initial notification");
     assert.equal(ofType(events, "tool_result").length, 1, "tool_result present");
     assert.equal(ofType(events, "usage").length, 1, "usage present");
     assert.equal(ofType(events, "done").length, 1, "exactly one done");
@@ -142,5 +144,42 @@ describe("createSandboxAgentOtel state machine", () => {
     );
     assert.equal(ofType(events, "done").length, 1, "exactly one done without spans");
     assert.ok(types(events).indexOf("usage") < types(events).indexOf("done"), "usage precedes done");
+  });
+
+  it("scenario 4: captures tool args that arrive on a later tool_call_update (rawInput deferral)", () => {
+    // The real Pi wire: the initial `tool_call` announces the call with NO args, and the args
+    // land on a subsequent `tool_call_update`. Emitting the tool_call up front used to freeze
+    // an empty input, so every tool logged `{}`. The event must carry the deferred args.
+    const emitted: AgentEvent[] = [];
+    const run = createSandboxAgentOtel({ harness: "pi", model: "openai-codex/x", emit: (e) => emitted.push(e), emitSpans: false });
+    run.start({ prompt: "list connections" });
+    run.handleUpdate({ sessionUpdate: "tool_call", toolCallId: "c1", title: "list_connections" }); // no rawInput
+    run.handleUpdate({ sessionUpdate: "tool_call_update", toolCallId: "c1", rawInput: { limit: 50 } }); // args land here
+    run.handleUpdate({ sessionUpdate: "tool_call_update", toolCallId: "c1", status: "completed", content: [{ content: { type: "text", text: "ok" } }] });
+    run.finish();
+
+    const calls = ofType(emitted, "tool_call");
+    assert.equal(calls.length, 1, "exactly one tool_call event (no duplicate from the deferral)");
+    assert.deepEqual(calls[0].input, { limit: 50 }, "input captured from the tool_call_update, not the empty initial call");
+    const seq = types(emitted);
+    assert.ok(seq.indexOf("tool_call") !== -1 && seq.indexOf("tool_call") < seq.indexOf("tool_result"), "tool_call precedes its result");
+  });
+
+  it("scenario 5: falls back to a bare tool_call when rawInput never arrives", () => {
+    // A genuinely arg-less tool that never carries rawInput must still surface as a
+    // tool_call -> tool_result pair (with a null input), not an orphaned result.
+    const emitted: AgentEvent[] = [];
+    const run = createSandboxAgentOtel({ harness: "pi", model: "openai-codex/x", emit: (e) => emitted.push(e), emitSpans: false });
+    run.start({ prompt: "x" });
+    run.handleUpdate({ sessionUpdate: "tool_call", toolCallId: "c1", title: "noArgs" }); // no rawInput, ever
+    run.handleUpdate({ sessionUpdate: "tool_call_update", toolCallId: "c1", status: "completed", content: [{ content: { type: "text", text: "done" } }] });
+    run.finish();
+
+    const calls = ofType(emitted, "tool_call");
+    assert.equal(calls.length, 1, "tool_call still surfaces");
+    assert.equal(calls[0].input, null, "bare call records a null input");
+    assert.equal(ofType(emitted, "tool_result").length, 1, "tool_result present");
+    const seq = types(emitted);
+    assert.ok(seq.indexOf("tool_call") < seq.indexOf("tool_result"), "tool_call precedes its result");
   });
 });

--- a/services/runner/tests/unit/stream-events.test.ts
+++ b/services/runner/tests/unit/stream-events.test.ts
@@ -146,40 +146,58 @@ describe("createSandboxAgentOtel state machine", () => {
     assert.ok(types(events).indexOf("usage") < types(events).indexOf("done"), "usage precedes done");
   });
 
-  it("scenario 4: captures tool args that arrive on a later tool_call_update (rawInput deferral)", () => {
+  it("scenario 4: surfaces the tool_call up front, then refreshes its input from a later tool_call_update", () => {
     // The real Pi wire: the initial `tool_call` announces the call with NO args, and the args
-    // land on a subsequent `tool_call_update`. Emitting the tool_call up front used to freeze
-    // an empty input, so every tool logged `{}`. The event must carry the deferred args.
+    // land on a subsequent `tool_call_update`. The tool_call MUST surface immediately (the FE
+    // tool part + HITL approval attach to it), and then a second tool_call REFRESHES the input
+    // once the real args arrive — so a non-gated tool shows its args instead of `{}`.
     const emitted: AgentEvent[] = [];
     const run = createSandboxAgentOtel({ harness: "pi", model: "openai-codex/x", emit: (e) => emitted.push(e), emitSpans: false });
     run.start({ prompt: "list connections" });
-    run.handleUpdate({ sessionUpdate: "tool_call", toolCallId: "c1", title: "list_connections" }); // no rawInput
+    run.handleUpdate({ sessionUpdate: "tool_call", toolCallId: "c1", title: "list_connections" }); // no rawInput yet
+    // The call surfaces immediately (emit-first invariant), before any args or result.
+    assert.equal(ofType(emitted, "tool_call").length, 1, "tool_call emitted up front, on the initial notification");
     run.handleUpdate({ sessionUpdate: "tool_call_update", toolCallId: "c1", rawInput: { limit: 50 } }); // args land here
     run.handleUpdate({ sessionUpdate: "tool_call_update", toolCallId: "c1", status: "completed", content: [{ content: { type: "text", text: "ok" } }] });
     run.finish();
 
     const calls = ofType(emitted, "tool_call");
-    assert.equal(calls.length, 1, "exactly one tool_call event (no duplicate from the deferral)");
-    assert.deepEqual(calls[0].input, { limit: 50 }, "input captured from the tool_call_update, not the empty initial call");
+    assert.equal(calls.length, 2, "one initial surface + one input refresh");
+    assert.deepEqual(calls[calls.length - 1].input, { limit: 50 }, "the refresh carries the real args from the tool_call_update");
     const seq = types(emitted);
     assert.ok(seq.indexOf("tool_call") !== -1 && seq.indexOf("tool_call") < seq.indexOf("tool_result"), "tool_call precedes its result");
   });
 
-  it("scenario 5: falls back to a bare tool_call when rawInput never arrives", () => {
-    // A genuinely arg-less tool that never carries rawInput must still surface as a
-    // tool_call -> tool_result pair (with a null input), not an orphaned result.
+  it("scenario 5: an empty initial input is not refreshed when no real args ever arrive", () => {
+    // An `{}` announcement with no later args stays a single surfaced call — no phantom refresh,
+    // still a clean tool_call -> tool_result pair.
     const emitted: AgentEvent[] = [];
     const run = createSandboxAgentOtel({ harness: "pi", model: "openai-codex/x", emit: (e) => emitted.push(e), emitSpans: false });
     run.start({ prompt: "x" });
-    run.handleUpdate({ sessionUpdate: "tool_call", toolCallId: "c1", title: "noArgs" }); // no rawInput, ever
+    run.handleUpdate({ sessionUpdate: "tool_call", toolCallId: "c1", title: "noArgs", rawInput: {} }); // empty placeholder
     run.handleUpdate({ sessionUpdate: "tool_call_update", toolCallId: "c1", status: "completed", content: [{ content: { type: "text", text: "done" } }] });
     run.finish();
 
     const calls = ofType(emitted, "tool_call");
-    assert.equal(calls.length, 1, "tool_call still surfaces");
-    assert.equal(calls[0].input, null, "bare call records a null input");
+    assert.equal(calls.length, 1, "single surfaced call, no refresh");
+    assert.deepEqual(calls[0].input, {}, "keeps the placeholder input");
     assert.equal(ofType(emitted, "tool_result").length, 1, "tool_result present");
     const seq = types(emitted);
     assert.ok(seq.indexOf("tool_call") < seq.indexOf("tool_result"), "tool_call precedes its result");
+  });
+
+  it("scenario 6: a call announced WITH args refreshes only on genuinely new args", () => {
+    // If the initial notification already has real args, that's the input — a later update that
+    // merely repeats/omits args must NOT emit a duplicate tool_call.
+    const emitted: AgentEvent[] = [];
+    const run = createSandboxAgentOtel({ harness: "pi", model: "openai-codex/x", emit: (e) => emitted.push(e), emitSpans: false });
+    run.start({ prompt: "x" });
+    run.handleUpdate({ sessionUpdate: "tool_call", toolCallId: "c1", title: "getWeather", rawInput: { city: "Paris" } });
+    run.handleUpdate({ sessionUpdate: "tool_call_update", toolCallId: "c1", status: "completed", content: [{ content: { type: "text", text: "sunny" } }] });
+    run.finish();
+
+    const calls = ofType(emitted, "tool_call");
+    assert.equal(calls.length, 1, "no refresh — args were present up front");
+    assert.deepEqual(calls[0].input, { city: "Paris" }, "keeps the initial args");
   });
 });

--- a/web/oss/src/components/AgentChatSlice/AgentChatPanel.tsx
+++ b/web/oss/src/components/AgentChatSlice/AgentChatPanel.tsx
@@ -980,7 +980,7 @@ const AgentConversation = ({entityId, sessionId}: {entityId: string; sessionId: 
 
     return (
         <div
-            className="relative flex h-full min-h-0 w-full flex-col gap-3"
+            className="relative flex h-full min-h-0 w-full flex-row"
             onDragEnter={onDragEnter}
             onDragOver={onDragOver}
             onDragLeave={onDragLeave}
@@ -988,149 +988,159 @@ const AgentConversation = ({entityId, sessionId}: {entityId: string; sessionId: 
         >
             {/* Themed confirm dialogs (rewind-past-a-tool) mount through this holder. */}
             {modalContextHolder}
-            <TurnInspector sessionId={sessionId} messages={messages} />
-            {isDragging && (
-                <div className="pointer-events-none absolute inset-0 z-30 flex flex-col items-center justify-center gap-1.5 rounded-lg border-2 border-dashed border-colorPrimary bg-[var(--ant-color-primary-bg)]">
-                    <UploadSimple size={26} className="text-colorPrimary" />
-                    <span className="text-sm font-medium text-colorPrimary">Drop files here</span>
-                    <span className="text-xs text-colorTextSecondary">
-                        {limits.label} · up to {limits.maxCount},{" "}
-                        {Math.round(limits.maxBytes / 1024 / 1024)} MB each
-                    </span>
-                </div>
-            )}
-            {/* Stream errors are surfaced inline on the failing turn (red error bubble with the
+            {/* Chat column. The turn inspector is a flex sibling (below) so it pushes this column
+                aside rather than overlaying it. */}
+            <div className="relative flex h-full min-h-0 min-w-0 flex-1 flex-col gap-3">
+                {isDragging && (
+                    <div className="pointer-events-none absolute inset-0 z-30 flex flex-col items-center justify-center gap-1.5 rounded-lg border-2 border-dashed border-colorPrimary bg-[var(--ant-color-primary-bg)]">
+                        <UploadSimple size={26} className="text-colorPrimary" />
+                        <span className="text-sm font-medium text-colorPrimary">
+                            Drop files here
+                        </span>
+                        <span className="text-xs text-colorTextSecondary">
+                            {limits.label} · up to {limits.maxCount},{" "}
+                            {Math.round(limits.maxBytes / 1024 / 1024)} MB each
+                        </span>
+                    </div>
+                )}
+                {/* Stream errors are surfaced inline on the failing turn (red error bubble with the
                 real reason), stamped in the effect above — no separate top-level banner. */}
-            <div className="relative flex min-h-0 flex-1 flex-col">
-                <div
-                    ref={(el) => {
-                        scrollRef.current = el
-                    }}
-                    onScroll={onScroll}
-                    // Capture a fresh SC-3 anchor before a click acts (expand/collapse a tool step,
-                    // reasoning fold): those resize the transcript without a scroll, so onScroll never
-                    // refreshes the anchor and the ResizeObserver would compensate against a stale one.
-                    onPointerDownCapture={recordAnchor}
-                    role="log"
-                    aria-live="polite"
-                    aria-label="Agent conversation"
-                    // `pt-8` (32px) ≥ the 28px fade so the first message clears it at rest; `pb-6`
-                    // + `[overflow-anchor:none]` are the SC scroll-engineering essentials (browser
-                    // anchoring off so our pin/anchor logic owns the scroll position).
-                    className="flex min-h-0 flex-1 flex-col gap-3 overflow-y-auto overflow-x-hidden p-3 pt-8 pb-6 [overflow-anchor:none]"
-                    // Fade content into the top edge (under the tab bar) and the bottom edge (into the
-                    // composer) as it scrolls. A gradient mask on the scroll container: transparent at
-                    // each edge → opaque across the middle. GPU-composited, no JS, theme-agnostic.
-                    style={{
-                        maskImage: EDGE_FADE_MASK,
-                        WebkitMaskImage: EDGE_FADE_MASK,
-                    }}
-                >
-                    {messages.length === 0 && (
-                        <AgentChatEmptyState entityId={entityId} onStart={handleSubmit} />
-                    )}
-                    {messages.slice(0, activeStart).map((m, i) => renderMessage(m, i))}
-                    {activeStart < messages.length && (
-                        // The active turn reserves a viewport (min-h-full) when there's prior
-                        // conversation, so sticking to the bottom shows the question at the top with the
-                        // answer streaming into the space below — the "pin" is this layout, not JS.
-                        // `pt-8` keeps the question clear of the top fade once it reaches the top.
-                        <div
-                            className={`flex flex-col gap-3${reserveActive ? " min-h-full pt-8" : ""}`}
-                        >
-                            {messages
-                                .slice(activeStart)
-                                .map((m, i) => renderMessage(m, activeStart + i))}
-                        </div>
-                    )}
+                <div className="relative flex min-h-0 flex-1 flex-col">
+                    <div
+                        ref={(el) => {
+                            scrollRef.current = el
+                        }}
+                        onScroll={onScroll}
+                        // Capture a fresh SC-3 anchor before a click acts (expand/collapse a tool step,
+                        // reasoning fold): those resize the transcript without a scroll, so onScroll never
+                        // refreshes the anchor and the ResizeObserver would compensate against a stale one.
+                        onPointerDownCapture={recordAnchor}
+                        role="log"
+                        aria-live="polite"
+                        aria-label="Agent conversation"
+                        // `pt-8` (32px) ≥ the 28px fade so the first message clears it at rest; `pb-6`
+                        // + `[overflow-anchor:none]` are the SC scroll-engineering essentials (browser
+                        // anchoring off so our pin/anchor logic owns the scroll position).
+                        className="flex min-h-0 flex-1 flex-col gap-3 overflow-y-auto overflow-x-hidden p-3 pt-8 pb-6 [overflow-anchor:none]"
+                        // Fade content into the top edge (under the tab bar) and the bottom edge (into the
+                        // composer) as it scrolls. A gradient mask on the scroll container: transparent at
+                        // each edge → opaque across the middle. GPU-composited, no JS, theme-agnostic.
+                        style={{
+                            maskImage: EDGE_FADE_MASK,
+                            WebkitMaskImage: EDGE_FADE_MASK,
+                        }}
+                    >
+                        {messages.length === 0 && (
+                            <AgentChatEmptyState entityId={entityId} onStart={handleSubmit} />
+                        )}
+                        {messages.slice(0, activeStart).map((m, i) => renderMessage(m, i))}
+                        {activeStart < messages.length && (
+                            // The active turn reserves a viewport (min-h-full) when there's prior
+                            // conversation, so sticking to the bottom shows the question at the top with the
+                            // answer streaming into the space below — the "pin" is this layout, not JS.
+                            // `pt-8` keeps the question clear of the top fade once it reaches the top.
+                            <div
+                                className={`flex flex-col gap-3${reserveActive ? " min-h-full pt-8" : ""}`}
+                            >
+                                {messages
+                                    .slice(activeStart)
+                                    .map((m, i) => renderMessage(m, activeStart + i))}
+                            </div>
+                        )}
+                    </div>
+
+                    {/* Always mounted so it can fade + slide in/out; hidden state is non-interactive and
+                    keeps `-translate-x-1/2` (Tailwind composes x/y translate on one transform). */}
+                    <Button
+                        size="small"
+                        shape="round"
+                        icon={<ArrowDown size={14} />}
+                        onClick={jumpToLatest}
+                        tabIndex={showJump ? 0 : -1}
+                        aria-hidden={!showJump}
+                        // Solid elevated surface + border + shadow so the pill reads clearly when it
+                        // floats over streamed text (a transparent pill let the text bleed through).
+                        className={`!absolute bottom-2 left-1/2 -translate-x-1/2 !border !border-solid !border-colorBorderSecondary !bg-colorBgElevated shadow-md transition-[opacity,transform] duration-200 ease-out ${
+                            showJump
+                                ? "translate-y-0 opacity-100"
+                                : "pointer-events-none translate-y-3 opacity-0"
+                        }`}
+                        aria-label="Jump to latest message"
+                    >
+                        Jump to latest
+                    </Button>
                 </div>
 
-                {/* Always mounted so it can fade + slide in/out; hidden state is non-interactive and
-                    keeps `-translate-x-1/2` (Tailwind composes x/y translate on one transform). */}
-                <Button
-                    size="small"
-                    shape="round"
-                    icon={<ArrowDown size={14} />}
-                    onClick={jumpToLatest}
-                    tabIndex={showJump ? 0 : -1}
-                    aria-hidden={!showJump}
-                    // Solid elevated surface + border + shadow so the pill reads clearly when it
-                    // floats over streamed text (a transparent pill let the text bleed through).
-                    className={`!absolute bottom-2 left-1/2 -translate-x-1/2 !border !border-solid !border-colorBorderSecondary !bg-colorBgElevated shadow-md transition-[opacity,transform] duration-200 ease-out ${
-                        showJump
-                            ? "translate-y-0 opacity-100"
-                            : "pointer-events-none translate-y-3 opacity-0"
-                    }`}
-                    aria-label="Jump to latest message"
-                >
-                    Jump to latest
-                </Button>
-            </div>
-
-            {/* Queue sits BETWEEN the messages and the composer, so showing it never shifts the
+                {/* Queue sits BETWEEN the messages and the composer, so showing it never shifts the
                 composer (and the editor) upward. Streaming itself is signalled by the composer's
                 send button (it becomes a spinning Stop button), so there's no "Streaming…" row. */}
-            {queued.length > 0 && (
-                <div className={`${CHAT_COLUMN} flex items-center gap-2 px-3 pb-2`}>
-                    <QueuedMessages queued={queued} onRemove={removeQueued} onClear={clearQueue} />
-                </div>
-            )}
+                {queued.length > 0 && (
+                    <div className={`${CHAT_COLUMN} flex items-center gap-2 px-3 pb-2`}>
+                        <QueuedMessages
+                            queued={queued}
+                            onRemove={removeQueued}
+                            onClear={clearQueue}
+                        />
+                    </div>
+                )}
 
-            {/* Rich markdown composer (Lexical). Enter sends; attachments via header/prefix slots.
+                {/* Rich markdown composer (Lexical). Enter sends; attachments via header/prefix slots.
                 Wrapper `px-3` keeps the session-bar gutter; the input centers on CHAT_COLUMN so it
                 aligns with the (also centered) message column when the panel is wide. The persistent
                 HITL approval dock lives in this same block (above the input) — always mounted so it
                 animates in/out, and inside the composer region so the paused gate can't scroll out
                 of reach and its collapse adds no gap to the surrounding column. */}
-            <div className="px-3">
-                <ApprovalDock
-                    className={CHAT_COLUMN}
-                    approvals={pendingApprovals}
-                    onApprovalResponse={addToolApprovalResponse}
-                    onViewTrace={openPausedTurnTrace}
-                />
-                <RichChatInput
-                    ref={richInputRef}
-                    className={`${CHAT_COLUMN} mb-3`}
-                    onSubmit={handleSubmit}
-                    placeholder="Ask the agent… (Enter to send, ⌘/Ctrl+Enter for newline)"
-                    onPasteFile={(pasted) => addFiles(Array.from(pasted))}
-                    sendForceEnabled={files.length > 0}
-                    streaming={busy}
-                    onStop={handleStop}
-                    prefix={
-                        // Attach button is gated until the agent service is ready for inline
-                        // file parts (big-agents d4b119af26); paste / drag-to-add still work.
-                        <Tooltip
-                            title={
-                                atMax
-                                    ? `Up to ${limits.maxCount} files`
-                                    : "Attach files coming soon"
-                            }
-                        >
-                            <Button
-                                type="text"
-                                icon={<Paperclip size={16} />}
-                                disabled={true}
-                                onClick={() => setAttachmentsOpen((open) => !open)}
-                                aria-label="Attach files"
-                            />
-                        </Tooltip>
-                    }
-                    header={
-                        <HeightCollapse open={attachmentsOpen || files.length > 0}>
-                            <ComposerAttachments
-                                files={files}
-                                rejections={rejections}
-                                limits={limits}
-                                onAdd={addFiles}
-                                onRemove={removeFile}
-                                onDismissRejections={() => setRejections([])}
-                            />
-                        </HeightCollapse>
-                    }
-                />
+                <div className="px-3">
+                    <ApprovalDock
+                        className={CHAT_COLUMN}
+                        approvals={pendingApprovals}
+                        onApprovalResponse={addToolApprovalResponse}
+                        onViewTrace={openPausedTurnTrace}
+                    />
+                    <RichChatInput
+                        ref={richInputRef}
+                        className={`${CHAT_COLUMN} mb-3`}
+                        onSubmit={handleSubmit}
+                        placeholder="Ask the agent… (Enter to send, ⌘/Ctrl+Enter for newline)"
+                        onPasteFile={(pasted) => addFiles(Array.from(pasted))}
+                        sendForceEnabled={files.length > 0}
+                        streaming={busy}
+                        onStop={handleStop}
+                        prefix={
+                            // Attach button is gated until the agent service is ready for inline
+                            // file parts (big-agents d4b119af26); paste / drag-to-add still work.
+                            <Tooltip
+                                title={
+                                    atMax
+                                        ? `Up to ${limits.maxCount} files`
+                                        : "Attach files coming soon"
+                                }
+                            >
+                                <Button
+                                    type="text"
+                                    icon={<Paperclip size={16} />}
+                                    disabled={true}
+                                    onClick={() => setAttachmentsOpen((open) => !open)}
+                                    aria-label="Attach files"
+                                />
+                            </Tooltip>
+                        }
+                        header={
+                            <HeightCollapse open={attachmentsOpen || files.length > 0}>
+                                <ComposerAttachments
+                                    files={files}
+                                    rejections={rejections}
+                                    limits={limits}
+                                    onAdd={addFiles}
+                                    onRemove={removeFile}
+                                    onDismissRejections={() => setRejections([])}
+                                />
+                            </HeightCollapse>
+                        }
+                    />
+                </div>
             </div>
+            <TurnInspector sessionId={sessionId} messages={messages} />
         </div>
     )
 }

--- a/web/oss/src/components/AgentChatSlice/AgentChatPanel.tsx
+++ b/web/oss/src/components/AgentChatSlice/AgentChatPanel.tsx
@@ -980,7 +980,7 @@ const AgentConversation = ({entityId, sessionId}: {entityId: string; sessionId: 
 
     return (
         <div
-            className="relative flex h-full min-h-0 w-full flex-row"
+            className="ag-canvas relative flex h-full min-h-0 w-full flex-row"
             onDragEnter={onDragEnter}
             onDragOver={onDragOver}
             onDragLeave={onDragLeave}

--- a/web/oss/src/components/AgentChatSlice/AgentChatPanel.tsx
+++ b/web/oss/src/components/AgentChatSlice/AgentChatPanel.tsx
@@ -940,7 +940,7 @@ const AgentConversation = ({entityId, sessionId}: {entityId: string; sessionId: 
         >
             {/* Themed confirm dialogs (rewind-past-a-tool) mount through this holder. */}
             {modalContextHolder}
-            <TurnInspector />
+            <TurnInspector sessionId={sessionId} messages={messages} />
             {isDragging && (
                 <div className="pointer-events-none absolute inset-0 z-30 flex flex-col items-center justify-center gap-1.5 rounded-lg border-2 border-dashed border-colorPrimary bg-[var(--ant-color-primary-bg)]">
                     <UploadSimple size={26} className="text-colorPrimary" />

--- a/web/oss/src/components/AgentChatSlice/AgentChatPanel.tsx
+++ b/web/oss/src/components/AgentChatSlice/AgentChatPanel.tsx
@@ -250,6 +250,13 @@ const AgentConversation = ({entityId, sessionId}: {entityId: string; sessionId: 
     const programmaticScrollRef = useRef(false)
     // Teardown for the in-flight smooth scroll (removes its listeners + fallback timer).
     const pinCleanupRef = useRef<(() => void) | null>(null)
+    // Last observed scrollTop. A content shrink (tool gutter collapsing, reasoning folding) clamps
+    // scrollTop to the new smaller bottom and fires a scroll event that isn't a user gesture; comparing
+    // against this lets onScroll tell a real scroll-DOWN-to-edge from that clamp (which only decreases).
+    const lastScrollTopRef = useRef(0)
+    // rAF handle coalescing the jump-pill measurement (querySelectorAll + getBoundingClientRect) to once
+    // per frame — a fast wheel/drag and every streamed render would otherwise re-measure a dirtied layout.
+    const showJumpRafRef = useRef(0)
 
     // `useChat` pins its `Chat` (and thus this transport) for the life of the session `id`; it is
     // NOT recreated when `entityId` changes (only on an `id` change). So the request builder must
@@ -548,9 +555,26 @@ const AgentConversation = ({entityId, sessionId}: {entityId: string; sessionId: 
     // ── DT4 autoscroll: stick to the bottom of the scrollable area while following ──
     // The fill (min-h-full turn group) makes "question at top" the scroll bottom for a short answer
     // and the answer's end the bottom for a long one, so scrollHeight is the right target (+ pb-6 gap).
+    // Only writes when not already pinned: the ResizeObserver (below) and the follow effect both pin on
+    // the same streamed growth, so the guard drops the redundant write (and the scroll event it fires).
     const scrollToBottom = useCallback(() => {
         const el = scrollRef.current
-        if (el) el.scrollTop = el.scrollHeight
+        if (!el) return
+        const target = el.scrollHeight - el.clientHeight
+        if (el.scrollTop < target - 0.5) el.scrollTop = target
+    }, [])
+
+    // Recompute jump-pill visibility, coalesced to one rAF per frame. The measurement (atLiveEdge →
+    // querySelectorAll + getBoundingClientRect) is display-only, so a one-frame lag is invisible; the
+    // correctness-critical follow decision (stickRef) and SC-3 anchor stay synchronous in onScroll.
+    const scheduleShowJump = useCallback(() => {
+        if (showJumpRafRef.current) return
+        showJumpRafRef.current = requestAnimationFrame(() => {
+            showJumpRafRef.current = 0
+            const el = scrollRef.current
+            if (!el) return
+            setShowJump(!stickRef.current && !atLiveEdge(el))
+        })
     }, [])
 
     // Smoothly scroll the log to `target` (the SC-1 pin / jump-to-latest). Uses the browser's NATIVE
@@ -602,7 +626,13 @@ const AgentConversation = ({entityId, sessionId}: {entityId: string; sessionId: 
     }, [])
 
     // Stop any in-flight pin animation on unmount (tab close / revision swap).
-    useEffect(() => () => pinCleanupRef.current?.(), [])
+    useEffect(
+        () => () => {
+            pinCleanupRef.current?.()
+            if (showJumpRafRef.current) cancelAnimationFrame(showJumpRafRef.current)
+        },
+        [],
+    )
 
     // After each commit, mark on-screen messages as seen so they don't re-animate on later renders
     // (e.g. streaming tokens). Done in an effect, not during render, so StrictMode's double invoke
@@ -620,15 +650,25 @@ const AgentConversation = ({entityId, sessionId}: {entityId: string; sessionId: 
     const onScroll = useCallback(() => {
         const el = scrollRef.current
         if (!el) return
+        // Track scrollTop even for our own pins (recorded, then ignored) so the next real event has an
+        // accurate baseline to compare against.
+        const prevTop = lastScrollTopRef.current
+        lastScrollTopRef.current = el.scrollTop
         // Ignore the scroll event our own pin produced — only a real user scroll changes follow state.
         if (programmaticScrollRef.current) return
         // Follow ONLY when at the very bottom of the scrollable area; a partial scroll must not enable
-        // it (that was the yank). The jump pill instead tracks whether the real latest message is in view.
-        stickRef.current = el.scrollHeight - el.scrollTop - el.clientHeight < 24
-        setShowJump(!atLiveEdge(el))
-        // Remember where the reader is parked so SC-3 can hold it through layout changes above.
+        // it (that was the yank). Re-arm follow ONLY when the user actively scrolls DOWN to the edge (or
+        // is already following): a content shrink (tool gutter collapsing to "Used N tools", reasoning
+        // folding) clamps scrollTop to the new smaller bottom and fires a scroll event, but a clamp only
+        // ever DECREASES scrollTop, so `> prevTop` rejects it — otherwise the next token would snap the
+        // min-h-full active turn to the top (reported as the chat "jumping to the top" mid-stream).
+        const atBottom = el.scrollHeight - el.scrollTop - el.clientHeight < 24
+        stickRef.current = atBottom && (stickRef.current || el.scrollTop > prevTop)
+        // Anchor is correctness-critical for SC-3 (the RO reads it next resize) → capture synchronously.
         if (!stickRef.current) recordAnchor()
-    }, [recordAnchor])
+        // Pill is display-only → coalesce its costly measurement to one rAF/frame.
+        scheduleShowJump()
+    }, [recordAnchor, scheduleShowJump])
 
     const jumpToLatest = useCallback(() => {
         const el = scrollRef.current
@@ -655,7 +695,7 @@ const AgentConversation = ({entityId, sessionId}: {entityId: string; sessionId: 
         const onResize = () => {
             if (programmaticScrollRef.current) return
             if (stickRef.current) {
-                el.scrollTop = el.scrollHeight
+                scrollToBottom() // guarded: no-op if the follow effect already pinned this growth
                 return
             }
             const a = anchorRef.current
@@ -686,7 +726,7 @@ const AgentConversation = ({entityId, sessionId}: {entityId: string; sessionId: 
         const ro = new ResizeObserver(onResize)
         el.querySelectorAll("[data-mid]").forEach((w) => ro.observe(w))
         return () => ro.disconnect()
-    }, [messages.length])
+    }, [messages.length, scrollToBottom])
 
     // SC-1 (submit) / SC-2 (restore): scroll the log to the bottom, once, when armed. With the active
     // turn reserving a viewport (min-h-full + top padding to clear the fade), "bottom" shows the new
@@ -715,11 +755,11 @@ const AgentConversation = ({entityId, sessionId}: {entityId: string; sessionId: 
 
     // Keep the jump pill honest as content streams/settles: show it when the real latest message is
     // below the fold (e.g. a long answer growing past the viewport while parked at the top), and hide
-    // it once that message is visible or while we're following.
-    useLayoutEffect(() => {
-        const el = scrollRef.current
-        if (el) setShowJump(!stickRef.current && !atLiveEdge(el))
-    }, [messages, status])
+    // it once that message is visible or while we're following. Coalesced (not a sync layout read per
+    // streamed render) — the pill is display-only, so one frame of lag is imperceptible.
+    useEffect(() => {
+        scheduleShowJump()
+    }, [messages, status, scheduleShowJump])
 
     // SC-4: interaction is intent, not just scrolling. While following, a real text selection inside
     // the transcript — or opening a link in it — means the reader is engaging here, so release follow

--- a/web/oss/src/components/AgentChatSlice/AgentChatPanel.tsx
+++ b/web/oss/src/components/AgentChatSlice/AgentChatPanel.tsx
@@ -31,6 +31,7 @@ import {
 import {filesToParts} from "./assets/files"
 import {messageText, sideEffectingToolsInRange} from "./assets/rewind"
 import {getMessageTraceId} from "./assets/trace"
+import AgentChatEmptyState from "./components/AgentChatEmptyState"
 import AgentMessage from "./components/AgentMessage"
 import ApprovalDock, {getPendingApprovals} from "./components/ApprovalDock"
 import type {ClientToolOutputHandler} from "./components/clientTools"
@@ -667,6 +668,13 @@ const AgentConversation = ({entityId, sessionId}: {entityId: string; sessionId: 
             }
             if (!node) return
             const delta = node.getBoundingClientRect().top - el.getBoundingClientRect().top - a.top
+            // A stale anchor (its node scrolled far off after a programmatic jump / follow) yields an
+            // implausible delta; applying it would slam the scroll to the top. Drop it and let the next
+            // scroll / pointer-down re-anchor. A real collapse/expand moves the anchor well under a viewport.
+            if (Math.abs(delta) > el.clientHeight) {
+                anchorRef.current = null
+                return
+            }
             if (Math.abs(delta) > 0.5) {
                 programmaticScrollRef.current = true
                 el.scrollTop += delta
@@ -959,6 +967,10 @@ const AgentConversation = ({entityId, sessionId}: {entityId: string; sessionId: 
                         scrollRef.current = el
                     }}
                     onScroll={onScroll}
+                    // Capture a fresh SC-3 anchor before a click acts (expand/collapse a tool step,
+                    // reasoning fold): those resize the transcript without a scroll, so onScroll never
+                    // refreshes the anchor and the ResizeObserver would compensate against a stale one.
+                    onPointerDownCapture={recordAnchor}
                     role="log"
                     aria-live="polite"
                     aria-label="Agent conversation"
@@ -975,9 +987,7 @@ const AgentConversation = ({entityId, sessionId}: {entityId: string; sessionId: 
                     }}
                 >
                     {messages.length === 0 && (
-                        <div className="m-auto text-center text-xs text-colorTextTertiary">
-                            Ask a question to start the agent conversation.
-                        </div>
+                        <AgentChatEmptyState entityId={entityId} onStart={handleSubmit} />
                     )}
                     {messages.slice(0, activeStart).map((m, i) => renderMessage(m, i))}
                     {activeStart < messages.length && (

--- a/web/oss/src/components/AgentChatSlice/AgentChatPanel.tsx
+++ b/web/oss/src/components/AgentChatSlice/AgentChatPanel.tsx
@@ -1097,7 +1097,7 @@ const AgentChatPanel = ({entityId}: {entityId: string}) => {
             </div>
             <Tabs
                 animated={false}
-                className="flex min-h-0 flex-1 flex-col [&_.ant-tabs-content]:h-full [&_.ant-tabs-content-holder]:min-h-0 [&_.ant-tabs-content-holder]:flex-1 [&_.ant-tabs-tabpane]:h-full"
+                className="flex min-h-0 min-w-0 flex-1 flex-col [&_.ant-tabs-content]:h-full [&_.ant-tabs-content-holder]:min-h-0 [&_.ant-tabs-content-holder]:flex-1 [&_.ant-tabs-tabpane]:h-full"
                 activeKey={activeId}
                 onChange={setActiveSession}
                 renderTabBar={() => (

--- a/web/oss/src/components/AgentChatSlice/AgentChatPanel.tsx
+++ b/web/oss/src/components/AgentChatSlice/AgentChatPanel.tsx
@@ -19,6 +19,7 @@ import type {UploadFile} from "antd"
 import {useAtomValue, useSetAtom, useStore} from "jotai"
 
 import {SessionInspectorButton} from "@/oss/components/SessionInspector"
+import {openTraceDrawerAtom} from "@/oss/components/SharedDrawers/TraceDrawer/store/traceDrawerStore"
 
 import {AgentChatTransport} from "./assets/AgentChatTransport"
 import {
@@ -30,6 +31,7 @@ import {filesToParts} from "./assets/files"
 import {messageText, sideEffectingToolsInRange} from "./assets/rewind"
 import {getMessageTraceId} from "./assets/trace"
 import AgentMessage from "./components/AgentMessage"
+import ApprovalDock, {getPendingApprovals} from "./components/ApprovalDock"
 import type {ClientToolOutputHandler} from "./components/clientTools"
 import ComposerAttachments from "./components/ComposerAttachments"
 import QueuedMessages from "./components/QueuedMessages"
@@ -61,9 +63,12 @@ const ignoreStreamRejection = () => {}
 /** Height of the top-edge fade, in px. Shared by the CSS mask and the SC-1 pin so a pinned turn
  * lands BELOW the fade (otherwise the freshly-asked question renders partially faded). */
 const TOP_FADE_PX = 28
-/** Top-edge fade for the message scroll area: transparent at the very top, fully opaque by
- * TOP_FADE_PX. Applied as a CSS mask so the content itself fades (correct in any theme). */
-const TOP_FADE_MASK = `linear-gradient(to bottom, transparent 0, #000 ${TOP_FADE_PX}px)`
+/** Height of the bottom-edge fade, matching the top so content dissolves into the composer edge. */
+const BOTTOM_FADE_PX = 28
+/** Edge fades for the message scroll area: transparent at the very top, fully opaque by TOP_FADE_PX,
+ * then fading back to transparent over the last BOTTOM_FADE_PX. Applied as a CSS mask so the content
+ * itself fades (correct in any theme). */
+const EDGE_FADE_MASK = `linear-gradient(to bottom, transparent 0, #000 ${TOP_FADE_PX}px, #000 calc(100% - ${BOTTOM_FADE_PX}px), transparent 100%)`
 /** Centered reading column for the chat body. Caps line length / bubble width so a wide (maximized)
  * panel doesn't sprawl into oversized bubbles and over-spaced turns; freed side space is whitespace. */
 const CHAT_COLUMN = "mx-auto w-full max-w-[880px]"
@@ -347,6 +352,10 @@ const AgentConversation = ({entityId, sessionId}: {entityId: string; sessionId: 
         (item: QueuedMessage) => {
             stickRef.current = true
             setShowJump(false)
+            // Any actual send supersedes a prior user-stop, so clear the marker here (covers the
+            // queue-release path; the manual path also clears it in handleSubmit) — otherwise the
+            // "Stopped" tag would smear onto the freshly-sent turn.
+            setStopped(false)
             sendMessage(
                 item.fileParts && item.fileParts.length
                     ? item.text
@@ -359,12 +368,25 @@ const AgentConversation = ({entityId, sessionId}: {entityId: string; sessionId: 
     )
 
     // Queue messages typed while a turn is streaming or paused on a HITL approval; released
-    // one-by-one once the turn truly settles (never mid-approval).
+    // one-by-one once the turn truly settles (never mid-approval). A user stop is the exception —
+    // it voids the pending gate, so `stopped` lets a fresh send go immediately (not queue).
     const {queued, submit, removeQueued, clearQueue, hitlPending} = useAgentChatQueue({
         status,
         messages,
+        stopped,
         sendQueued,
     })
+
+    // Pending HITL gates for the paused turn, surfaced in the persistent ApprovalDock above the
+    // composer (not inline in the transcript, so a paused run can't scroll out of reach). Trace
+    // opens the paused turn's own trace drawer.
+    const openTraceDrawer = useSetAtom(openTraceDrawerAtom)
+    const pendingApprovals = useMemo(() => getPendingApprovals(messages), [messages])
+    const openPausedTurnTrace = useMemo(() => {
+        const last = messages[messages.length - 1]
+        const traceId = last ? getMessageTraceId(last) : undefined
+        return traceId ? () => openTraceDrawer({traceId}) : undefined
+    }, [messages, openTraceDrawer])
 
     // Publish this session's run state (single source of truth: drives the tab bar's status dot
     // AND the Session inspector's live-watcher signal, which derives "streaming" from `running`).
@@ -577,7 +599,9 @@ const AgentConversation = ({entityId, sessionId}: {entityId: string; sessionId: 
     }, [messages])
 
     useEffect(() => {
-        if (stickRef.current) scrollToBottom()
+        // Don't instant-jump while a programmatic glide (SC-1 submit / jump-to-latest) owns the
+        // scroll — that snap would override the animation. The glide's own settle re-pins to bottom.
+        if (stickRef.current && !programmaticScrollRef.current) scrollToBottom()
     }, [messages, status, scrollToBottom])
 
     const onScroll = useCallback(() => {
@@ -849,7 +873,6 @@ const AgentConversation = ({entityId, sessionId}: {entityId: string; sessionId: 
                     isStreaming={busy && isLast}
                     isLastMessage={isLast}
                     onRewind={() => handleRewind(message)}
-                    onApprovalResponse={addToolApprovalResponse}
                     onClientToolOutput={handleClientToolOutput}
                     precededByEmptyAssistant={
                         index > 0 && isEmptyAssistantTurn(messages[index - 1])
@@ -918,12 +941,12 @@ const AgentConversation = ({entityId, sessionId}: {entityId: string; sessionId: 
                     // + `[overflow-anchor:none]` are the SC scroll-engineering essentials (browser
                     // anchoring off so our pin/anchor logic owns the scroll position).
                     className="flex min-h-0 flex-1 flex-col gap-3 overflow-y-auto overflow-x-hidden p-3 pt-8 pb-6 [overflow-anchor:none]"
-                    // Fade content into the top edge (under the tab bar) as it scrolls up. A
-                    // gradient mask on the scroll container: transparent at the very top → opaque
-                    // by 28px → opaque the rest of the way. GPU-composited, no JS, theme-agnostic.
+                    // Fade content into the top edge (under the tab bar) and the bottom edge (into the
+                    // composer) as it scrolls. A gradient mask on the scroll container: transparent at
+                    // each edge → opaque across the middle. GPU-composited, no JS, theme-agnostic.
                     style={{
-                        maskImage: TOP_FADE_MASK,
-                        WebkitMaskImage: TOP_FADE_MASK,
+                        maskImage: EDGE_FADE_MASK,
+                        WebkitMaskImage: EDGE_FADE_MASK,
                     }}
                 >
                     {messages.length === 0 && (
@@ -947,47 +970,50 @@ const AgentConversation = ({entityId, sessionId}: {entityId: string; sessionId: 
                     )}
                 </div>
 
-                {showJump && (
-                    <Button
-                        size="small"
-                        shape="round"
-                        icon={<ArrowDown size={14} />}
-                        onClick={jumpToLatest}
-                        // Solid elevated surface + border + shadow so the pill reads clearly when it
-                        // floats over streamed text (a transparent pill let the text bleed through).
-                        className="!absolute bottom-2 left-1/2 -translate-x-1/2 !border !border-solid !border-colorBorderSecondary !bg-colorBgElevated shadow-md"
-                        aria-label="Jump to latest message"
-                    >
-                        Jump to latest
-                    </Button>
-                )}
+                {/* Always mounted so it can fade + slide in/out; hidden state is non-interactive and
+                    keeps `-translate-x-1/2` (Tailwind composes x/y translate on one transform). */}
+                <Button
+                    size="small"
+                    shape="round"
+                    icon={<ArrowDown size={14} />}
+                    onClick={jumpToLatest}
+                    tabIndex={showJump ? 0 : -1}
+                    aria-hidden={!showJump}
+                    // Solid elevated surface + border + shadow so the pill reads clearly when it
+                    // floats over streamed text (a transparent pill let the text bleed through).
+                    className={`!absolute bottom-2 left-1/2 -translate-x-1/2 !border !border-solid !border-colorBorderSecondary !bg-colorBgElevated shadow-md transition-[opacity,transform] duration-200 ease-out ${
+                        showJump
+                            ? "translate-y-0 opacity-100"
+                            : "pointer-events-none translate-y-3 opacity-0"
+                    }`}
+                    aria-label="Jump to latest message"
+                >
+                    Jump to latest
+                </Button>
             </div>
 
-            {/* Queue / approval status sits BETWEEN the messages and the composer, so showing it
-                never shifts the composer (and the editor) upward. Streaming itself is signalled by
-                the composer's send button (it becomes a spinning Stop button), so there's no
-                separate "Streaming…" row. */}
-            {(hitlPending || queued.length > 0) && (
-                <div className={`${CHAT_COLUMN} flex items-center justify-between gap-2 px-3 pb-2`}>
-                    {queued.length > 0 ? (
-                        <QueuedMessages
-                            queued={queued}
-                            onRemove={removeQueued}
-                            onClear={clearQueue}
-                        />
-                    ) : (
-                        <span />
-                    )}
-                    {hitlPending ? (
-                        <span className="text-xs text-colorTextTertiary">Waiting for approval</span>
-                    ) : null}
+            {/* Queue sits BETWEEN the messages and the composer, so showing it never shifts the
+                composer (and the editor) upward. Streaming itself is signalled by the composer's
+                send button (it becomes a spinning Stop button), so there's no "Streaming…" row. */}
+            {queued.length > 0 && (
+                <div className={`${CHAT_COLUMN} flex items-center gap-2 px-3 pb-2`}>
+                    <QueuedMessages queued={queued} onRemove={removeQueued} onClear={clearQueue} />
                 </div>
             )}
 
             {/* Rich markdown composer (Lexical). Enter sends; attachments via header/prefix slots.
                 Wrapper `px-3` keeps the session-bar gutter; the input centers on CHAT_COLUMN so it
-                aligns with the (also centered) message column when the panel is wide. */}
+                aligns with the (also centered) message column when the panel is wide. The persistent
+                HITL approval dock lives in this same block (above the input) — always mounted so it
+                animates in/out, and inside the composer region so the paused gate can't scroll out
+                of reach and its collapse adds no gap to the surrounding column. */}
             <div className="px-3">
+                <ApprovalDock
+                    className={CHAT_COLUMN}
+                    approvals={pendingApprovals}
+                    onApprovalResponse={addToolApprovalResponse}
+                    onViewTrace={openPausedTurnTrace}
+                />
                 <RichChatInput
                     ref={richInputRef}
                     className={`${CHAT_COLUMN} mb-3`}

--- a/web/oss/src/components/AgentChatSlice/AgentChatPanel.tsx
+++ b/web/oss/src/components/AgentChatSlice/AgentChatPanel.tsx
@@ -12,7 +12,7 @@ import {HeightCollapse} from "@agenta/ui"
 import {RichChatInput, type RichChatInputHandle} from "@agenta/ui/rich-chat-input"
 import {useChat} from "@ai-sdk/react"
 import {Bubble} from "@ant-design/x"
-import {ArrowDown, Paperclip, UploadSimple} from "@phosphor-icons/react"
+import {ArrowDown, Paperclip, TreeStructure, UploadSimple} from "@phosphor-icons/react"
 import {type UIMessage} from "ai"
 import {Button, Modal, Tabs, Tag, Tooltip} from "antd"
 import type {UploadFile} from "antd"
@@ -38,6 +38,7 @@ import QueuedMessages from "./components/QueuedMessages"
 import SessionHistoryMenu from "./components/SessionHistoryMenu"
 import SessionRail from "./components/SessionRail"
 import SessionTagBar from "./components/SessionTagBar"
+import TurnInspector from "./components/TurnInspector/TurnInspector"
 import {useAgentChatQueue, type QueuedMessage} from "./hooks/useAgentChatQueue"
 import {chatPanelMaximizedAtom} from "./state/panelLayout"
 import {useChatScopeKey} from "./state/scope"
@@ -54,6 +55,7 @@ import {
     setSessionStatusAtom,
     stampMessagesCreatedAtAtom,
 } from "./state/sessions"
+import {turnInspectorAtom} from "./state/turnInspector"
 
 /** A stream error/abort is already surfaced via `useChat`'s `onError` + the in-chat `error`
  * alert; swallow the floating `sendMessage`/`regenerate` rejection so it doesn't bubble to the
@@ -200,6 +202,8 @@ const AgentConversation = ({entityId, sessionId}: {entityId: string; sessionId: 
     const stampMessagesCreatedAt = useSetAtom(stampMessagesCreatedAtAtom)
     const switchEntity = useSetAtom(playgroundController.actions.switchEntity)
     const setSessionStatus = useSetAtom(setSessionStatusAtom)
+    const openTurnInspector = useSetAtom(turnInspectorAtom)
+    const buildMode = !useAtomValue(chatPanelMaximizedAtom)
 
     const [files, setFiles] = useState<UploadFile[]>([])
     // Files turned away by the guardrails (too big, wrong type, over the count), shown inline.
@@ -902,6 +906,18 @@ const AgentConversation = ({entityId, sessionId}: {entityId: string; sessionId: 
                         </Button>
                     </div>
                 )}
+                {buildMode && message.role === "assistant" && (
+                    <button
+                        type="button"
+                        onClick={() =>
+                            openTurnInspector({sessionId, assistantMessageId: message.id})
+                        }
+                        className="flex w-fit cursor-pointer items-center gap-1 self-start rounded border-0 bg-transparent px-1 py-0.5 text-xs text-colorTextTertiary transition-colors hover:text-colorPrimary"
+                    >
+                        <TreeStructure size={12} />
+                        Inspect turn
+                    </button>
+                )}
             </MessageRow>
         )
     }
@@ -916,6 +932,7 @@ const AgentConversation = ({entityId, sessionId}: {entityId: string; sessionId: 
         >
             {/* Themed confirm dialogs (rewind-past-a-tool) mount through this holder. */}
             {modalContextHolder}
+            <TurnInspector />
             {isDragging && (
                 <div className="pointer-events-none absolute inset-0 z-30 flex flex-col items-center justify-center gap-1.5 rounded-lg border-2 border-dashed border-colorPrimary bg-[var(--ant-color-primary-bg)]">
                     <UploadSimple size={26} className="text-colorPrimary" />

--- a/web/oss/src/components/AgentChatSlice/AgentChatPanel.tsx
+++ b/web/oss/src/components/AgentChatSlice/AgentChatPanel.tsx
@@ -4,6 +4,7 @@ import {invalidateAgentCommittedRevisionCache} from "@agenta/entities/workflow"
 import {
     agentShouldResumeAfterApproval,
     buildAgentRequest,
+    buildTurnCapture,
     playgroundController,
 } from "@agenta/playground"
 import {simulatedAgentRunAtomFamily} from "@agenta/shared/state"
@@ -55,6 +56,7 @@ import {
     setSessionStatusAtom,
     stampMessagesCreatedAtAtom,
 } from "./state/sessions"
+import {captureTurnRequestAtom} from "./state/turnCaptures"
 import {turnInspectorAtom} from "./state/turnInspector"
 
 /** A stream error/abort is already surfaced via `useChat`'s `onError` + the in-chat `error`
@@ -256,6 +258,11 @@ const AgentConversation = ({entityId, sessionId}: {entityId: string; sessionId: 
     const entityIdRef = useRef(entityId)
     entityIdRef.current = entityId
 
+    // Turn Inspector capture write, read via ref so the transport `useMemo` doesn't depend on it.
+    const captureTurnRequest = useSetAtom(captureTurnRequestAtom)
+    const captureRef = useRef(captureTurnRequest)
+    captureRef.current = captureTurnRequest
+
     // Transport feeds the v6 stream request from the playground pipeline. `api` here is a
     // placeholder that `prepareSendMessagesRequest` overrides per request.
     const transport = useMemo(
@@ -271,6 +278,7 @@ const AgentConversation = ({entityId, sessionId}: {entityId: string; sessionId: 
                             "This agent workflow has no invocation URL — it can’t be run yet.",
                         )
                     }
+                    captureRef.current(buildTurnCapture(req, generateId(), Date.now()))
                     return {api: req.invocationUrl, headers: req.headers, body: req.requestBody}
                 },
             }),

--- a/web/oss/src/components/AgentChatSlice/assets/AgentChatTransport.ts
+++ b/web/oss/src/components/AgentChatSlice/assets/AgentChatTransport.ts
@@ -1,4 +1,5 @@
 import {createNegotiatingFetch, type NegotiatingFetch} from "@agenta/playground"
+import {generateId} from "@agenta/shared/utils"
 import {DefaultChatTransport, type UIMessage, type UIMessageChunk} from "ai"
 
 /**
@@ -133,7 +134,12 @@ function batchJsonToUiMessageStream(
                     (json as Record<string, unknown>)?.trace_id ??
                     ((json as Record<string, unknown>)?.data as Record<string, unknown>)?.trace_id
 
-                const start: Record<string, unknown> = {type: "start", messageId: msg.id ?? "msg-1"}
+                // Unique fallback id per replay — a constant made every id-less batch turn
+                // collide on the same React key (duplicate-key warning + dropped turns).
+                const start: Record<string, unknown> = {
+                    type: "start",
+                    messageId: msg.id ?? `msg-batch-${generateId()}`,
+                }
                 if (sessionId) start.messageMetadata = {sessionId}
                 emit(start)
                 emit({type: "start-step"})

--- a/web/oss/src/components/AgentChatSlice/assets/markdown.tsx
+++ b/web/oss/src/components/AgentChatSlice/assets/markdown.tsx
@@ -29,9 +29,14 @@ export const MD_CLASS =
     "[&_h4]:mt-2 [&_h4]:mb-0.5 [&_h4]:text-xs [&_h4]:font-semibold " +
     "[&_h5]:mt-2 [&_h5]:mb-0.5 [&_h5]:text-xs [&_h5]:font-semibold " +
     "[&_h6]:mt-2 [&_h6]:mb-0.5 [&_h6]:text-xs [&_h6]:font-medium [&_h6]:text-colorTextSecondary " +
-    // Blockquote — a quiet left-ruled aside (kill the browser's 40px indent).
-    "[&_blockquote]:my-2 [&_blockquote]:mx-0 [&_blockquote]:border-0 [&_blockquote]:border-l-2 " +
-    "[&_blockquote]:border-solid [&_blockquote]:border-colorBorderSecondary [&_blockquote]:pl-3 " +
+    // Blockquote — a quiet left-ruled aside. Layout is forced (!important) so nothing (the UA's
+    // logical `margin-inline: 40px`, the Bubble's placement styles, etc.) can push the content into
+    // a centered/over-indented look: no horizontal margin, a small left padding, left-aligned.
+    // Zero the non-left borders with per-side longhands (NOT `border-0`, whose `border-width`
+    // shorthand wins over `border-l-2` as an arbitrary variant and drops the left rule).
+    "[&_blockquote]:my-2 [&_blockquote]:!mx-0 [&_blockquote]:!pl-3 [&_blockquote]:!text-left " +
+    "[&_blockquote]:border-y-0 [&_blockquote]:border-r-0 [&_blockquote]:border-l-2 " +
+    "[&_blockquote]:border-solid [&_blockquote]:border-colorTextTertiary " +
     "[&_blockquote]:text-colorTextSecondary [&_blockquote]:italic " +
     // Rule, images, emphasis, strikethrough, and task-list checkboxes.
     "[&_hr]:my-3 [&_hr]:border-0 [&_hr]:border-t [&_hr]:border-solid [&_hr]:border-colorBorderSecondary " +

--- a/web/oss/src/components/AgentChatSlice/components/AgentChatConversation.tsx
+++ b/web/oss/src/components/AgentChatSlice/components/AgentChatConversation.tsx
@@ -16,6 +16,7 @@ import {createAgentChatTransport} from "../assets/transport"
 import {persistSessionMessagesAtom, sessionMessagesAtom} from "../state/sessions"
 
 import AgentMessage from "./AgentMessage"
+import ApprovalDock, {getPendingApprovals} from "./ApprovalDock"
 import type {ClientToolOutputHandler} from "./clientTools"
 
 const {Text} = Typography
@@ -102,6 +103,10 @@ const AgentChatConversation = ({
     })
 
     const busy = status === "submitted" || status === "streaming"
+
+    // HITL gates the paused turn is blocked on — surfaced in the persistent ApprovalDock above
+    // the composer (the inline tool row is just an "Awaiting approval" marker).
+    const pendingApprovals = useMemo(() => getPendingApprovals(messages), [messages])
 
     // Settle a parked client tool (#4920) — same wrapper as AgentChatPanel. `addToolOutput` matches
     // the part by `toolCallId` on the last turn; `tool` is only the typed-tools key, so a cast onto
@@ -266,7 +271,6 @@ const AgentChatConversation = ({
                         isStreaming={busy && index === messages.length - 1}
                         isLastMessage={index === messages.length - 1}
                         onRewind={handleRewind}
-                        onApprovalResponse={addToolApprovalResponse}
                         onClientToolOutput={handleClientToolOutput}
                     />
                 ))}
@@ -275,71 +279,82 @@ const AgentChatConversation = ({
                 )}
             </div>
 
-            <Sender
-                ref={senderRef}
-                value={input}
-                onChange={setInput}
-                loading={busy}
-                onSubmit={handleSubmit}
-                onCancel={stop}
-                onPasteFile={(pasted) => {
-                    setFiles((prev) => [
-                        ...prev,
-                        ...Array.from(pasted).map((file) => ({
-                            uid: `${file.name}-${file.lastModified}-${file.size}`,
-                            name: file.name,
-                            status: "done" as const,
-                            originFileObj: file as UploadFile["originFileObj"],
-                        })),
-                    ])
-                    setAttachmentsOpen(true)
-                }}
-                prefix={
-                    <Tooltip title="Attach files coming soon">
-                        <Button
-                            type="text"
-                            size="small"
-                            icon={<Paperclip size={16} />}
-                            onClick={() => setAttachmentsOpen((open) => !open)}
-                            disabled={
-                                true /* TODO: re-enable once we can read the files into data: URLs at send time */
-                            }
-                        />
-                    </Tooltip>
-                }
-                header={
-                    // Own the collapse instead of `Sender.Header`: its `CSSMotion` hides via
-                    // `display:none`, so the *enter* can't paint a height:0 baseline and jumps
-                    // to full height (only leave animates). The grid 0fr→1fr trick animates
-                    // symmetrically to the exact content height and never uses display:none, so
-                    // `Attachments` stays mounted and drop-to-attach keeps working while closed.
-                    <div
-                        className={`grid overflow-hidden transition-[grid-template-rows,opacity] duration-300 ease-in-out ${
-                            attachmentsOpen || files.length > 0
-                                ? "grid-rows-[1fr] opacity-100"
-                                : "grid-rows-[0fr] opacity-0"
-                        }`}
-                    >
-                        <div className="min-h-0 overflow-hidden">
-                            <div className="border-b border-solid border-colorBorderSecondary p-2">
-                                <Attachments
-                                    items={files}
-                                    // Never auto-upload — keep the File and send it inline as a data: URL.
-                                    beforeUpload={() => false}
-                                    onChange={({fileList}) => setFiles(fileList)}
-                                    getDropContainer={() => dropContainerRef.current}
-                                    placeholder={(type) => ({
-                                        title: type === "drop" ? "Drop files here" : "Attach files",
-                                        description:
-                                            "Click or drag — sent inline to the agent as data URLs.",
-                                    })}
-                                />
+            {/* Dock + composer share one flex child so the root's gap-3 adds no space around the
+                dock while it's collapsed; the dock's own margin spaces it from the composer. */}
+            <div className="flex flex-col">
+                <ApprovalDock
+                    approvals={pendingApprovals}
+                    onApprovalResponse={addToolApprovalResponse}
+                />
+                <Sender
+                    ref={senderRef}
+                    value={input}
+                    onChange={setInput}
+                    loading={busy}
+                    onSubmit={handleSubmit}
+                    onCancel={stop}
+                    onPasteFile={(pasted) => {
+                        setFiles((prev) => [
+                            ...prev,
+                            ...Array.from(pasted).map((file) => ({
+                                uid: `${file.name}-${file.lastModified}-${file.size}`,
+                                name: file.name,
+                                status: "done" as const,
+                                originFileObj: file as UploadFile["originFileObj"],
+                            })),
+                        ])
+                        setAttachmentsOpen(true)
+                    }}
+                    prefix={
+                        <Tooltip title="Attach files coming soon">
+                            <Button
+                                type="text"
+                                size="small"
+                                icon={<Paperclip size={16} />}
+                                onClick={() => setAttachmentsOpen((open) => !open)}
+                                disabled={
+                                    true /* TODO: re-enable once we can read the files into data: URLs at send time */
+                                }
+                            />
+                        </Tooltip>
+                    }
+                    header={
+                        // Own the collapse instead of `Sender.Header`: its `CSSMotion` hides via
+                        // `display:none`, so the *enter* can't paint a height:0 baseline and jumps
+                        // to full height (only leave animates). The grid 0fr→1fr trick animates
+                        // symmetrically to the exact content height and never uses display:none, so
+                        // `Attachments` stays mounted and drop-to-attach keeps working while closed.
+                        <div
+                            className={`grid overflow-hidden transition-[grid-template-rows,opacity] duration-300 ease-in-out ${
+                                attachmentsOpen || files.length > 0
+                                    ? "grid-rows-[1fr] opacity-100"
+                                    : "grid-rows-[0fr] opacity-0"
+                            }`}
+                        >
+                            <div className="min-h-0 overflow-hidden">
+                                <div className="border-b border-solid border-colorBorderSecondary p-2">
+                                    <Attachments
+                                        items={files}
+                                        // Never auto-upload — keep the File and send it inline as a data: URL.
+                                        beforeUpload={() => false}
+                                        onChange={({fileList}) => setFiles(fileList)}
+                                        getDropContainer={() => dropContainerRef.current}
+                                        placeholder={(type) => ({
+                                            title:
+                                                type === "drop"
+                                                    ? "Drop files here"
+                                                    : "Attach files",
+                                            description:
+                                                "Click or drag — sent inline to the agent as data URLs.",
+                                        })}
+                                    />
+                                </div>
                             </div>
                         </div>
-                    </div>
-                }
-                placeholder="Ask the agent… (Enter to send, Shift+Enter for newline)"
-            />
+                    }
+                    placeholder="Ask the agent… (Enter to send, Shift+Enter for newline)"
+                />
+            </div>
         </div>
     )
 }

--- a/web/oss/src/components/AgentChatSlice/components/AgentChatEmptyState.tsx
+++ b/web/oss/src/components/AgentChatSlice/components/AgentChatEmptyState.tsx
@@ -1,0 +1,145 @@
+import {useMemo} from "react"
+
+import {workflowMolecule} from "@agenta/entities/workflow"
+import {ArrowRight, Robot} from "@phosphor-icons/react"
+import {Typography} from "antd"
+import {useAtomValue} from "jotai"
+
+import {chatPanelMaximizedAtom} from "../state/panelLayout"
+
+const {Text} = Typography
+
+/** Curated starter prompts for the Build-mode empty state. Clicking one sends it. */
+const BUILD_STARTERS = [
+    "What can you do?",
+    "Show me your current configuration",
+    "List the tools you can call",
+]
+
+/** Read the agent config shape (same layout as ContextTab / buildAgentRequest). */
+const agentModel = (config: unknown): string | null => {
+    const a = (config as {agent?: {llm?: {model?: unknown}; model?: unknown}} | null)?.agent
+    const m = a?.llm?.model ?? a?.model
+    return typeof m === "string" && m ? m : null
+}
+
+const agentSummary = (config: unknown): string | null => {
+    const md = (config as {agent?: {instructions?: {agents_md?: unknown}}} | null)?.agent
+        ?.instructions?.agents_md
+    if (typeof md !== "string" || !md.trim()) return null
+    const line = md
+        .trim()
+        .split("\n")[0]
+        .replace(/^#+\s*/, "")
+    return line.length > 140 ? `${line.slice(0, 140)}…` : line
+}
+
+const capabilityLabel = (config: unknown): string | null => {
+    const a = (config as {agent?: {tools?: unknown[]; skills?: unknown[]}} | null)?.agent
+    const tools = Array.isArray(a?.tools) ? a!.tools!.length : 0
+    const skills = Array.isArray(a?.skills) ? a!.skills!.length : 0
+    const parts: string[] = []
+    if (tools) parts.push(`${tools} tool${tools === 1 ? "" : "s"}`)
+    if (skills) parts.push(`${skills} skill${skills === 1 ? "" : "s"}`)
+    return parts.length ? parts.join(" · ") : null
+}
+
+const Bot = ({size = 44}: {size?: number}) => (
+    <div
+        className="flex shrink-0 items-center justify-center rounded-full bg-colorFillTertiary"
+        style={{width: size, height: size}}
+    >
+        <Robot size={Math.round(size * 0.5)} className="text-colorTextSecondary" />
+    </div>
+)
+
+/**
+ * The agent chat empty state, adapting to the playground mode:
+ *  - Chat (maximized): a warm minimal welcome.
+ *  - Build: an agent-aware card (name, model, capabilities, a one-line summary) plus starter
+ *    prompts that send on click — for the team building the agent.
+ */
+const AgentChatEmptyState = ({
+    entityId,
+    onStart,
+}: {
+    entityId: string
+    onStart: (text: string) => void
+}) => {
+    const buildMode = !useAtomValue(chatPanelMaximizedAtom)
+    const name = useAtomValue(workflowMolecule.selectors.artifactName(entityId))
+    const config = useAtomValue(
+        useMemo(() => workflowMolecule.selectors.configuration(entityId), [entityId]),
+    )
+
+    if (!buildMode) {
+        return (
+            <div className="m-auto flex max-w-sm flex-col items-center gap-2.5 text-center">
+                <Bot />
+                <Text className="!text-base !font-medium">What can I help you with?</Text>
+                <Text type="secondary" className="!text-xs !leading-relaxed">
+                    Ask a question, or describe a task you want this agent to run.
+                </Text>
+            </div>
+        )
+    }
+
+    const model = agentModel(config)
+    const capabilities = capabilityLabel(config)
+    const summary = agentSummary(config)
+
+    return (
+        <div className="m-auto w-full max-w-[420px]">
+            <div className="flex flex-col gap-3 rounded-xl border border-solid border-colorBorderSecondary bg-colorFillQuaternary p-4">
+                <div className="flex items-center gap-2.5">
+                    <Bot size={34} />
+                    <div className="min-w-0">
+                        <Text
+                            className="!text-sm !font-medium block truncate"
+                            title={name || "Agent"}
+                        >
+                            {name || "Agent"}
+                        </Text>
+                        <div className="mt-0.5 flex flex-wrap items-center gap-1.5">
+                            {model ? (
+                                <span className="rounded-full border border-solid border-colorBorderSecondary bg-colorBgContainer px-1.5 py-px font-mono text-[11px] text-colorTextSecondary">
+                                    {model}
+                                </span>
+                            ) : null}
+                            {capabilities ? (
+                                <span className="rounded-full border border-solid border-colorBorderSecondary bg-colorBgContainer px-1.5 py-px text-[11px] text-colorTextSecondary">
+                                    {capabilities}
+                                </span>
+                            ) : null}
+                        </div>
+                    </div>
+                </div>
+
+                {summary ? (
+                    <Text type="secondary" className="!text-xs !leading-relaxed">
+                        {summary}
+                    </Text>
+                ) : null}
+
+                <div className="flex flex-col items-start gap-1.5">
+                    <Text type="secondary" className="!text-[11px]">
+                        Try
+                    </Text>
+                    {BUILD_STARTERS.map((starter) => (
+                        <button
+                            key={starter}
+                            type="button"
+                            onClick={() => onStart(starter)}
+                            className="flex w-fit max-w-full cursor-pointer items-center gap-1.5 rounded-full border border-solid border-colorBorder bg-colorBgContainer px-3 py-1.5 text-left text-xs text-colorTextSecondary transition-colors hover:border-colorPrimary hover:text-colorText"
+                        >
+                            <ArrowRight size={13} className="shrink-0" />
+                            <span className="truncate">{starter}</span>
+                        </button>
+                    ))}
+                </div>
+            </div>
+        </div>
+    )
+}
+
+export default AgentChatEmptyState

--- a/web/oss/src/components/AgentChatSlice/components/AgentMessage.tsx
+++ b/web/oss/src/components/AgentChatSlice/components/AgentMessage.tsx
@@ -435,7 +435,7 @@ const AgentMessage = ({
         )
 
     // Control toolbar — an X `Actions` row that sits in a reserved lane BELOW the bubble (the
-    // `pb-7` on the row), so it never overlays the last content line and never reaches the next
+    // `pb-10` on the row), so it never overlays the last content line and never reaches the next
     // turn. The lane is always present (stable height), so revealing it only fades opacity — no
     // layout shift either way (the scroll engineering is sensitive to hover-driven reflow).
     // `pointer-events-none` while hidden keeps the invisible buttons unclickable. `Actions`
@@ -504,7 +504,7 @@ const AgentMessage = ({
     // the left, user bubbles the right, neither spans the full column.
     return (
         <div
-            className={`group relative flex items-start pb-7 ${isUser ? "justify-end" : "justify-start"}`}
+            className={`group relative flex items-start pb-10 ${isUser ? "justify-end" : "justify-start"}`}
         >
             <Bubble<React.ReactNode>
                 placement={isUser ? "end" : "start"}

--- a/web/oss/src/components/AgentChatSlice/components/AgentMessage.tsx
+++ b/web/oss/src/components/AgentChatSlice/components/AgentMessage.tsx
@@ -28,6 +28,7 @@ import {
     getMessageUsage,
     type MessageUsageMetrics,
 } from "../assets/trace"
+import {chatPanelMaximizedAtom} from "../state/panelLayout"
 import {messageCreatedAtAtomFamily, nowTickAtom, timeAgo} from "../state/sessions"
 
 import {ClientToolPart, isClientToolPart, type ClientToolOutputHandler} from "./clientTools"
@@ -95,13 +96,22 @@ const isToolPart = (type: string) => type.startsWith("tool-") || type === "dynam
  * "streaming"`) it auto-expands so the thoughts stream live; once done it auto-collapses to a
  * "Thought" toggle — click to re-expand. A manual toggle sticks (we stop auto-driving it).
  */
-const ReasoningPart = ({text, streaming}: {text: string; streaming: boolean}) => {
-    const [expanded, setExpanded] = useState(streaming)
+const ReasoningPart = ({
+    text,
+    streaming,
+    detailed = false,
+}: {
+    text: string
+    streaming: boolean
+    detailed?: boolean
+}) => {
+    // Build mode (`detailed`) keeps reasoning expanded as a step in the log; Chat auto-collapses it.
+    const [expanded, setExpanded] = useState(streaming || detailed)
     const userToggled = useRef(false)
 
     useEffect(() => {
-        if (!userToggled.current) setExpanded(streaming)
-    }, [streaming])
+        if (!userToggled.current) setExpanded(streaming || detailed)
+    }, [streaming, detailed])
 
     return (
         <div className="flex flex-col">
@@ -203,6 +213,9 @@ const AgentMessage = ({
 }: AgentMessageProps) => {
     const openTraceDrawer = useSetAtom(openTraceDrawerAtom)
     const isUser = message.role === "user"
+    // Build vs Chat: Build (config panel open, not maximized) shows the full step log — per-tool
+    // input/output/error + expanded reasoning; Chat keeps the calm collapsed summary.
+    const detailed = !useAtomValue(chatPanelMaximizedAtom)
 
     const traceId = getMessageTraceId(message)
     const usage = getMessageUsage(message)
@@ -330,6 +343,7 @@ const AgentMessage = ({
                     key={partKey}
                     text={reasoning.text}
                     streaming={reasoning.state === "streaming"}
+                    detailed={detailed}
                 />
             )
         }
@@ -373,6 +387,7 @@ const AgentMessage = ({
                             key={`${message.id}-tools-${item.index}`}
                             parts={item.parts}
                             isStreaming={isStreaming}
+                            detailed={detailed}
                             onViewTrace={onViewTrace}
                         />
                     )

--- a/web/oss/src/components/AgentChatSlice/components/AgentMessage.tsx
+++ b/web/oss/src/components/AgentChatSlice/components/AgentMessage.tsx
@@ -78,7 +78,6 @@ interface AgentMessageProps {
     /** Stable across renders (parent passes a `useCallback`'d handler) so the `memo()` below
      * isn't defeated — the message to rewind to is passed in, not closed over per render. */
     onRewind: (message: UIMessage) => void
-    onApprovalResponse: (args: {id: string; approved: boolean}) => void
     /** Settle a parked client tool (#4920) — the dispatcher calls this from a widget. */
     onClientToolOutput: ClientToolOutputHandler
     /** The previous turn was also an empty (content-less) assistant turn. Used to collapse a
@@ -198,7 +197,6 @@ const AgentMessage = ({
     isStreaming = false,
     isLastMessage = false,
     onRewind,
-    onApprovalResponse,
     onClientToolOutput,
     precededByEmptyAssistant = false,
     turnTraceId,
@@ -223,13 +221,9 @@ const AgentMessage = ({
     const timeSummary = traceId ? ownSummary : pairedSummary
     const messageTime = parseTraceTime(timeSummary.rootSpan?.start_time) ?? createdAt
     // A failure can reach us two ways: recorded on the trace (backend), or stamped onto the turn
-    // FE-side from the useChat stream error (AgentChatPanel). Prefer whichever is present.
+    // FE-side from the useChat stream error (AgentChatPanel). `errorText` is derived below, once
+    // we know whether the turn produced an answer.
     const runError = getMessageRunError(message)
-    const errorText = traceError || runError
-    // Surface a settled-turn error even when the model emitted partial output before the
-    // stream died — not only when the turn is answer-less. (`isError` stays answer-less-only
-    // so the *whole* bubble only turns red when there's nothing else to show.)
-    const showError = !isStreaming && !!errorText
     const fullText = message.parts
         .filter((p) => p.type === "text")
         .map((p) => (p as {text: string}).text)
@@ -259,6 +253,17 @@ const AgentMessage = ({
     // read as frozen/broken. Keyed on `isStreaming`, not the conversation-level `busy`, so
     // earlier answer-less turns don't all light up while a later turn streams.
     const noResponse = !isUser && !isStreaming && !hasAnswer
+
+    // A trace-leaf error means a model/tool call failed. When the turn still produced an answer,
+    // the agent recovered from it — that failure belongs inline in ToolActivity ("· N failed"),
+    // NOT as a run failure. So trust `traceError` only on an answer-less turn (the swallowed
+    // quota/model error it was written for). A stream death (`runError`) is a real run failure
+    // even with partial output, so it always counts.
+    const errorText = noResponse ? traceError || runError : runError
+    // Surface a settled-turn error even when the model emitted partial output before the stream
+    // died. (`isError` stays answer-less-only so the *whole* bubble only turns red when there's
+    // nothing else to show.)
+    const showError = !isStreaming && !!errorText
     // A settled no-answer turn whose trace recorded an error → render the bubble itself as a
     // failure (red), with the message inline — not a nested alert box.
     const isError = noResponse && showError
@@ -368,7 +373,6 @@ const AgentMessage = ({
                             key={`${message.id}-tools-${item.index}`}
                             parts={item.parts}
                             isStreaming={isStreaming}
-                            onApprovalResponse={onApprovalResponse}
                             onViewTrace={onViewTrace}
                         />
                     )

--- a/web/oss/src/components/AgentChatSlice/components/AgentMessage.tsx
+++ b/web/oss/src/components/AgentChatSlice/components/AgentMessage.tsx
@@ -305,9 +305,40 @@ const AgentMessage = ({
         | {kind: "part"; part: UIMessage["parts"][number]; index: number}
         | {kind: "tools"; parts: ToolUIPart[]; index: number}
         | {kind: "clientTool"; part: ToolUIPart; index: number}
+    // A HITL-approved tool's part LINGERS in `approval-responded` (a perpetual spinner, no output):
+    // the cold-replay runner re-issues the approved call under a FRESH id, so its execution output
+    // lands on a SEPARATE sibling part. Drop the answered gate once its executed sibling exists (same
+    // tool + same input), so the turn shows the single completed call with its output — not a stuck
+    // spinner beside a duplicate. Until the execution settles, the gate stays (it is genuinely
+    // in-flight).
+    const toolIdentity = (p: ToolUIPart): string => {
+        let inputKey = ""
+        try {
+            inputKey = JSON.stringify((p as {input?: unknown}).input ?? null)
+        } catch {
+            inputKey = ""
+        }
+        return `${p.type}::${inputKey}`
+    }
+    const executedToolIdentities = new Set(
+        message.parts
+            .filter(
+                (p) =>
+                    isToolPart(p.type) &&
+                    ((p as ToolUIPart).state === "output-available" ||
+                        (p as ToolUIPart).state === "output-error"),
+            )
+            .map((p) => toolIdentity(p as ToolUIPart)),
+    )
+    const isSupersededGate = (p: ToolUIPart): boolean =>
+        p.state === "approval-responded" && executedToolIdentities.has(toolIdentity(p))
+
     const renderItems: RenderItem[] = []
     message.parts.forEach((part, i) => {
         if (isToolPart(part.type)) {
+            // The answered gate whose execution already landed on a sibling part — drop it so the
+            // turn doesn't show a stuck approval spinner beside the real, completed call.
+            if (isSupersededGate(part as ToolUIPart)) return
             // A browser-fulfilled client tool (#4920) renders as its own widget/chip, NOT folded
             // into the "Used N tools" group — so it breaks any current tool run.
             if (isClientToolPart(part as ToolUIPart, {isStreaming, isLastMessage})) {

--- a/web/oss/src/components/AgentChatSlice/components/ApprovalDock.tsx
+++ b/web/oss/src/components/AgentChatSlice/components/ApprovalDock.tsx
@@ -132,7 +132,7 @@ const ApprovalDock = ({
         >
             <div className="min-h-0 overflow-hidden">
                 {current ? (
-                    <div className="mb-2 flex flex-col gap-2.5 rounded-lg border border-solid border-colorBorderSecondary bg-colorBgElevated p-3">
+                    <div className="ag-surface-chat mb-2 flex flex-col gap-2.5 rounded-lg p-3">
                         {/* Header: a quiet primary cue (not an error tint) + the ask + a count when batched. */}
                         <div className="flex items-center gap-2">
                             <ShieldCheck
@@ -174,7 +174,7 @@ const ApprovalDock = ({
 
                         {/* The payload — collapsed to a one-line preview, expandable to the full request. */}
                         {payload ? (
-                            <div className="overflow-hidden rounded bg-colorFillTertiary">
+                            <div className="ag-surface-inset overflow-hidden rounded">
                                 <button
                                     type="button"
                                     onClick={() => setShowPayload((s) => !s)}

--- a/web/oss/src/components/AgentChatSlice/components/ApprovalDock.tsx
+++ b/web/oss/src/components/AgentChatSlice/components/ApprovalDock.tsx
@@ -1,0 +1,245 @@
+import {memo, useEffect, useMemo, useRef, useState} from "react"
+
+import {HeightCollapse} from "@agenta/ui"
+import {ArrowSquareOut, CaretRight, ShieldCheck} from "@phosphor-icons/react"
+import type {ToolUIPart, UIMessage} from "ai"
+import {Button, Typography} from "antd"
+
+const {Text} = Typography
+
+export interface PendingApproval {
+    approvalId: string
+    toolName: string
+    input: unknown
+}
+
+interface ApprovalRef {
+    id: string
+}
+
+const isToolPart = (type: string) => type.startsWith("tool-") || type === "dynamic-tool"
+
+/** Friendly name for a tool part — mirrors ToolActivity: `dynamic-tool` carries `toolName`, typed
+ * parts encode it as `tool-<name>`. */
+const partToolName = (part: ToolUIPart): string => {
+    const type = part.type as string
+    if (type === "dynamic-tool") return (part as {toolName?: string}).toolName || "tool"
+    return type.replace(/^tool-/, "")
+}
+
+/**
+ * Approvals the run is currently blocked on. HITL only ever pauses the LAST assistant turn (see
+ * `isHitlPending`), so we read pending tool gates off that turn — a turn can request several at
+ * once (parallel tool calls), so this returns all of them in order.
+ */
+export const getPendingApprovals = (messages: UIMessage[]): PendingApproval[] => {
+    const last = messages[messages.length - 1]
+    if (!last || last.role !== "assistant") return []
+    const out: PendingApproval[] = []
+    for (const part of last.parts ?? []) {
+        const p = part as ToolUIPart
+        const approval = (p as {approval?: ApprovalRef}).approval
+        if (isToolPart(p.type as string) && p.state === "approval-requested" && approval?.id) {
+            out.push({approvalId: approval.id, toolName: partToolName(p), input: p.input})
+        }
+    }
+    return out
+}
+
+/** A source label we can state factually from the tool name — not a guessed risk level. */
+const sourceLabel = (name: string): string | null => {
+    if (name.startsWith("mcp__")) return "MCP tool"
+    return null
+}
+
+const formatInput = (input: unknown): string => {
+    if (input == null) return ""
+    if (typeof input === "string") return input.trim()
+    try {
+        return JSON.stringify(input, null, 2)
+    } catch {
+        return String(input)
+    }
+}
+
+interface ApprovalDockProps {
+    /** Pending gates for the paused turn (index 0 is acted on first). */
+    approvals: PendingApproval[]
+    onApprovalResponse: (args: {id: string; approved: boolean}) => void
+    /** Open the paused turn's trace drawer (full tool input/output). */
+    onViewTrace?: () => void
+    className?: string
+}
+
+/**
+ * Persistent human-in-the-loop approval band. Lives in the composer region (between the transcript
+ * and the input), NOT in the scrolling transcript, so a run paused on a tool gate can't scroll out
+ * of reach. It owns the Approve/Deny action (the inline tool row is just an "Awaiting approval"
+ * marker) and surfaces the request's context: which tool, its source, and the exact payload.
+ *
+ * A turn can request several gates at once; we act on the first and let the SDK flip its state,
+ * which re-renders us onto the next — so `responding` resets whenever the current id changes.
+ */
+const ApprovalDock = ({
+    approvals,
+    onApprovalResponse,
+    onViewTrace,
+    className,
+}: ApprovalDockProps) => {
+    const open = approvals.length > 0
+    // Latch the last non-empty set so the card stays visible while the dock animates closed — a
+    // leave transition needs its content to persist through the height collapse.
+    const shownRef = useRef(approvals)
+    if (open) shownRef.current = approvals
+    const shown = shownRef.current
+    const current = shown[0]
+    const count = shown.length
+
+    const [responding, setResponding] = useState(false)
+    const [showPayload, setShowPayload] = useState(false)
+
+    // The current gate changed (we answered one, the next slid in) — re-enable + recollapse.
+    useEffect(() => {
+        setResponding(false)
+        setShowPayload(false)
+    }, [current?.approvalId])
+
+    const payload = useMemo(() => (current ? formatInput(current.input) : ""), [current])
+    const payloadPreview = payload.replace(/\s+/g, " ").trim()
+
+    const source = current ? sourceLabel(current.toolName) : null
+
+    const respond = (approved: boolean) => {
+        if (responding || !current) return
+        setResponding(true)
+        onApprovalResponse({id: current.approvalId, approved})
+    }
+    const approveAll = () => {
+        if (responding) return
+        setResponding(true)
+        shown.forEach((a) => onApprovalResponse({id: a.approvalId, approved: true}))
+    }
+
+    // Always mounted; enter + leave animate via the grid-rows 0fr↔1fr height collapse (+ opacity),
+    // the same idiom as the reasoning block and composer attachments. `inert` while closed drops the
+    // (clipped, latched) card from tab order + a11y so a keyboard user can't reach hidden buttons.
+    return (
+        <div
+            className={`grid transition-[grid-template-rows,opacity] duration-200 ease-out ${
+                open ? "grid-rows-[1fr] opacity-100" : "grid-rows-[0fr] opacity-0"
+            } ${className ?? ""}`}
+            inert={!open}
+        >
+            <div className="min-h-0 overflow-hidden">
+                {current ? (
+                    <div className="mb-2 flex flex-col gap-2.5 rounded-lg border border-solid border-colorBorderSecondary bg-colorBgElevated p-3">
+                        {/* Header: a quiet primary cue (not an error tint) + the ask + a count when batched. */}
+                        <div className="flex items-center gap-2">
+                            <ShieldCheck
+                                size={15}
+                                weight="fill"
+                                className="shrink-0 text-colorPrimary"
+                            />
+                            <Text className="!text-xs !font-medium">
+                                Approval needed to continue
+                            </Text>
+                            {count > 1 ? (
+                                <Text
+                                    type="secondary"
+                                    className="!text-[11px] ml-auto tabular-nums"
+                                >
+                                    1 of {count}
+                                </Text>
+                            ) : null}
+                        </div>
+
+                        {/* Identity: which tool, plus a factual source tag when we can name one. */}
+                        <div className="flex min-w-0 items-center gap-2">
+                            <Text
+                                className="!text-xs !font-medium min-w-0 truncate"
+                                title={current.toolName}
+                            >
+                                {current.toolName}
+                            </Text>
+                            {source ? (
+                                <span className="shrink-0 rounded border border-solid border-colorBorderSecondary bg-colorFillQuaternary px-1.5 py-px text-[11px] text-colorTextSecondary">
+                                    {source}
+                                </span>
+                            ) : null}
+                        </div>
+
+                        <Text type="secondary" className="!text-xs">
+                            The agent wants to run this tool before it can keep going.
+                        </Text>
+
+                        {/* The payload — collapsed to a one-line preview, expandable to the full request. */}
+                        {payload ? (
+                            <div className="overflow-hidden rounded bg-colorFillTertiary">
+                                <button
+                                    type="button"
+                                    onClick={() => setShowPayload((s) => !s)}
+                                    aria-expanded={showPayload}
+                                    className="flex w-full min-w-0 cursor-pointer items-center gap-1.5 border-0 bg-transparent px-2.5 py-1.5 text-left"
+                                >
+                                    <CaretRight
+                                        size={11}
+                                        weight="bold"
+                                        className={`shrink-0 text-colorTextTertiary transition-transform ${
+                                            showPayload ? "rotate-90" : ""
+                                        }`}
+                                    />
+                                    <span className="shrink-0 text-[11px] font-medium text-colorTextSecondary">
+                                        Payload
+                                    </span>
+                                    {!showPayload ? (
+                                        <span className="min-w-0 truncate font-mono text-[11px] text-colorTextTertiary">
+                                            {payloadPreview}
+                                        </span>
+                                    ) : null}
+                                </button>
+                                <HeightCollapse open={showPayload}>
+                                    <pre className="m-0 max-h-48 overflow-auto whitespace-pre-wrap break-all px-2.5 pb-2.5 font-mono text-[11px] leading-snug text-colorTextSecondary">
+                                        {payload}
+                                    </pre>
+                                </HeightCollapse>
+                            </div>
+                        ) : null}
+
+                        {/* Actions: trace on the left, decision on the right. Approve is the single primary. */}
+                        <div className="flex items-center gap-2">
+                            {onViewTrace ? (
+                                <button
+                                    type="button"
+                                    onClick={onViewTrace}
+                                    className="flex cursor-pointer items-center gap-1 border-0 bg-transparent px-0 py-0.5 text-xs text-colorPrimary transition-colors hover:underline"
+                                >
+                                    <ArrowSquareOut size={12} />
+                                    View full trace
+                                </button>
+                            ) : null}
+                            <div className="ml-auto flex items-center gap-1.5">
+                                {count > 1 ? (
+                                    <Button disabled={responding} onClick={approveAll}>
+                                        Approve all
+                                    </Button>
+                                ) : null}
+                                <Button disabled={responding} onClick={() => respond(false)}>
+                                    Deny
+                                </Button>
+                                <Button
+                                    type="primary"
+                                    loading={responding}
+                                    onClick={() => respond(true)}
+                                >
+                                    Approve
+                                </Button>
+                            </div>
+                        </div>
+                    </div>
+                ) : null}
+            </div>
+        </div>
+    )
+}
+
+export default memo(ApprovalDock)

--- a/web/oss/src/components/AgentChatSlice/components/SessionRail.tsx
+++ b/web/oss/src/components/AgentChatSlice/components/SessionRail.tsx
@@ -1,7 +1,7 @@
 import {useCallback, useEffect, useRef, useState} from "react"
 
 import {MagnifyingGlass, Plus, Trash} from "@phosphor-icons/react"
-import {Button, Empty, Input, Tag, Tooltip} from "antd"
+import {Button, Empty, Input, Tooltip} from "antd"
 import clsx from "clsx"
 import {useAtomValue, useSetAtom} from "jotai"
 
@@ -84,9 +84,7 @@ const SessionRailRow = ({
                     }}
                     className={clsx(
                         "group flex cursor-pointer items-center gap-2 rounded-md border border-solid px-2 py-1.5 transition-colors",
-                        active
-                            ? "border-colorBorder bg-colorFillSecondary"
-                            : "border-transparent hover:bg-colorFillTertiary",
+                        active ? "ag-surface-selected" : "ag-row-hover border-transparent",
                     )}
                 >
                     <SessionStatusDot sessionId={session.id} />
@@ -107,9 +105,9 @@ const SessionRailRow = ({
                     </div>
                     <div className="flex shrink-0 items-center gap-0.5">
                         {open && !active && (
-                            <Tag color="processing" className="!m-0 !text-[11px]">
+                            <span className="ag-surface-chip rounded px-1.5 py-px text-[11px] text-colorTextSecondary">
                                 open
-                            </Tag>
+                            </span>
                         )}
                         {active && <SessionInspectorButton sessionId={session.id} />}
                         <Tooltip title="Delete session">
@@ -208,11 +206,11 @@ const SessionRail = ({activeId, className}: SessionRailProps) => {
     return (
         <div
             className={clsx(
-                "flex h-full min-h-0 flex-col border-0 border-r border-solid border-colorBorderSecondary",
+                "ag-panel-raised flex h-full min-h-0 flex-col border-0 border-r border-solid border-[var(--ag-surface-divider)]",
                 className,
             )}
         >
-            <div className="flex h-[48px] shrink-0 items-center justify-between gap-2 border-0 border-b border-solid border-colorBorderSecondary px-3">
+            <div className="flex h-[48px] shrink-0 items-center justify-between gap-2 border-0 border-b border-solid border-[var(--ag-surface-divider)] px-3">
                 <span className="text-xs font-medium text-colorTextSecondary">Sessions</span>
                 <Tooltip title="New session">
                     <Button
@@ -232,7 +230,7 @@ const SessionRail = ({activeId, className}: SessionRailProps) => {
                     onChange={(e) => setQuery(e.target.value)}
                     placeholder="Search sessions"
                     prefix={<MagnifyingGlass size={14} className="text-colorTextTertiary" />}
-                    className="!text-xs"
+                    className="!text-xs !border-[var(--ag-surface-inset-border)] !bg-[var(--ag-surface-inset)]"
                 />
             </div>
 

--- a/web/oss/src/components/AgentChatSlice/components/SessionTagBar.tsx
+++ b/web/oss/src/components/AgentChatSlice/components/SessionTagBar.tsx
@@ -149,20 +149,29 @@ const SessionTagBar = ({
                             onRename={(title) => onRename(session.id, title)}
                         />
                     ))}
-                    <Tooltip title="New session">
-                        <Button
-                            type="text"
-                            aria-label="New session"
-                            icon={<Plus size={14} />}
-                            onClick={onAdd}
-                            className="!h-7 !w-7 !min-w-0 shrink-0 !p-0"
-                        />
-                    </Tooltip>
                 </div>
             ) : (
                 <div className="min-w-0 flex-1" />
             )}
-            {extra && <div className="flex shrink-0 items-center gap-1">{extra}</div>}
+            {/* Fixed session-actions cluster — pinned outside the scroll area so New session (+) sits
+                at the end of the tab strip without scrolling away, grouped with the inspect/history
+                controls. */}
+            {(showSessions || extra) && (
+                <div className="flex shrink-0 items-center gap-1">
+                    {showSessions && (
+                        <Tooltip title="New session">
+                            <Button
+                                type="text"
+                                aria-label="New session"
+                                icon={<Plus size={14} />}
+                                onClick={onAdd}
+                                className="!h-7 !w-7 !min-w-0 shrink-0 !p-0"
+                            />
+                        </Tooltip>
+                    )}
+                    {extra}
+                </div>
+            )}
         </div>
     )
 }

--- a/web/oss/src/components/AgentChatSlice/components/ToolActivity.tsx
+++ b/web/oss/src/components/AgentChatSlice/components/ToolActivity.tsx
@@ -32,6 +32,12 @@ const partToolName = (part: ToolUIPart): string => {
 const SETTLED = new Set(["output-available", "output-error", "output-denied"])
 const isSettled = (state: string) => SETTLED.has(state)
 
+/** Strip a surrounding markdown code fence — backends wrap tool output/errors in ```…```. */
+const stripFence = (value: string): string => {
+    const m = value.trim().match(/^```[\w-]*\n?([\s\S]*?)\n?```$/)
+    return m ? m[1].trim() : value
+}
+
 /**
  * Derive a single human line from a tool's output. Output shape is arbitrary, so this stays
  * conservative: it recognises the common shapes and otherwise returns null (the row then shows
@@ -43,7 +49,7 @@ const summarizeOutput = (output: unknown): string | null => {
         return `${output.length} result${output.length === 1 ? "" : "s"}`
     }
     if (typeof output === "string") {
-        const s = output.trim().replace(/\s+/g, " ")
+        const s = stripFence(output).trim().replace(/\s+/g, " ")
         if (!s) return null
         return s.length > 80 ? `${s.slice(0, 80)}…` : s
     }
@@ -77,6 +83,10 @@ const StatusIcon = ({state}: {state: string}) => {
         return <Prohibit size={13} className="shrink-0 text-colorTextTertiary" />
     if (state === "approval-requested")
         return <Wrench size={13} className="shrink-0 text-colorWarning" />
+    // An answered gate whose execution landed on a sibling part (cold-replay fresh id). Usually
+    // deduped away in AgentMessage; if it slips through, show it as approved — never a stuck spinner.
+    if (state === "approval-responded")
+        return <CheckCircle size={13} className="shrink-0 text-colorTextTertiary" />
     return <Spinner size={13} className="shrink-0 animate-spin text-colorPrimary" />
 }
 
@@ -91,22 +101,16 @@ const formatValue = (value: unknown): string => {
     }
 }
 
-/** Strip a surrounding markdown code fence — backends sometimes wrap an error in ```…```. */
-const stripFence = (value: string): string => {
-    const m = value.trim().match(/^```[\w-]*\n?([\s\S]*?)\n?```$/)
-    return m ? m[1].trim() : value
-}
-
 /** One labeled monospace block (input / output / error) in the Build-mode step log. Capped in
  * height with its own scroll so a large payload can't blow up the transcript. */
 const IOBlock = ({label, value, danger}: {label: string; value: string; danger?: boolean}) => (
     <div className="flex min-w-0 flex-col gap-0.5">
         <span className="font-mono text-[10px] text-colorTextTertiary">{label}</span>
         <pre
-            className={`m-0 max-h-40 overflow-auto whitespace-pre-wrap break-all rounded px-2 py-1.5 font-mono text-[11px] leading-snug ${
+            className={`ag-surface-inset m-0 max-h-40 overflow-auto whitespace-pre-wrap break-all rounded px-2 py-1.5 font-mono text-[11px] leading-snug ${
                 danger
-                    ? "bg-[var(--ant-color-error-bg)] !text-colorErrorText"
-                    : "bg-colorFillTertiary text-colorTextSecondary"
+                    ? "!bg-[var(--ant-color-error-bg)] !border-transparent !text-colorErrorText"
+                    : "text-colorTextSecondary"
             }`}
         >
             {value}
@@ -128,21 +132,26 @@ const ToolRow = ({
 }) => {
     const name = partToolName(part)
     const state = part.state as string
-    const running = !isSettled(state) && state !== "approval-requested"
+    // `approval-responded` is resolved (the user answered) — not "running". Its execution shows on
+    // a sibling part, so this must not spin forever (the cold-replay lingering-gate spinner).
+    const running =
+        !isSettled(state) && state !== "approval-requested" && state !== "approval-responded"
     // The line after the name: an awaiting-approval marker, a live "running…", the settled one-line
     // summary (Chat), or a short status word (Build shows the full output block below instead).
     const midText =
         state === "approval-requested"
             ? "Awaiting approval"
-            : live && running
-              ? "running…"
-              : detailed
-                ? state === "output-error"
-                    ? "failed"
-                    : state === "output-denied"
-                      ? "denied"
-                      : null
-                : rowSummary(part)
+            : state === "approval-responded"
+              ? "approved"
+              : live && running
+                ? "running…"
+                : detailed
+                  ? state === "output-error"
+                      ? "failed"
+                      : state === "output-denied"
+                        ? "denied"
+                        : null
+                  : rowSummary(part)
 
     const input = (part as {input?: unknown}).input
     const output = (part as {output?: unknown}).output
@@ -201,7 +210,17 @@ const ToolRow = ({
                         {errorText !== undefined ? (
                             <IOBlock label="error" value={stripFence(errorText)} danger />
                         ) : state === "output-available" && output != null ? (
-                            <IOBlock label="output" value={formatValue(output)} />
+                            <IOBlock
+                                label="output"
+                                value={
+                                    // Backends wrap tool results in a markdown code fence (```console
+                                    // …```) for the model; the IOBlock is already a monospace <pre>, so
+                                    // strip the redundant fence instead of printing the backticks.
+                                    typeof output === "string"
+                                        ? stripFence(output)
+                                        : formatValue(output)
+                                }
+                            />
                         ) : null}
                     </div>
                 </HeightCollapse>

--- a/web/oss/src/components/AgentChatSlice/components/ToolActivity.tsx
+++ b/web/oss/src/components/AgentChatSlice/components/ToolActivity.tsx
@@ -11,7 +11,7 @@ import {
     Wrench,
 } from "@phosphor-icons/react"
 import type {ToolUIPart} from "ai"
-import {Button, Typography} from "antd"
+import {Typography} from "antd"
 
 const {Text} = Typography
 
@@ -80,77 +80,40 @@ const StatusIcon = ({state}: {state: string}) => {
     return <Spinner size={13} className="shrink-0 animate-spin text-colorPrimary" />
 }
 
-interface ApprovalRef {
-    id: string
-    approved?: boolean
-    reason?: string
-}
-
-const ApprovalButtons = ({
-    approvalId,
-    onApprovalResponse,
-}: {
-    approvalId: string
-    onApprovalResponse: (args: {id: string; approved: boolean}) => void
-}) => {
-    // Guard a double-submit between the click and the SDK flipping the part to
-    // `approval-responded` (which removes the buttons). Not tied to conversation `busy` —
-    // an approval can only appear mid-stream, so gating on busy would disable it the whole turn.
-    const [responding, setResponding] = useState(false)
-    const respond = (approved: boolean) => {
-        if (responding) return
-        setResponding(true)
-        onApprovalResponse({id: approvalId, approved})
-    }
-    return (
-        <div className="ml-auto flex items-center gap-1.5">
-            <Button type="primary" loading={responding} onClick={() => respond(true)}>
-                Approve
-            </Button>
-            <Button disabled={responding} onClick={() => respond(false)}>
-                Deny
-            </Button>
-        </div>
-    )
-}
-
-/** One tool's row: name, derived one-line summary, status. Used in both modes. */
-const ToolRow = ({
-    part,
-    live,
-    onApprovalResponse,
-}: {
-    part: ToolUIPart
-    live: boolean
-    onApprovalResponse: (args: {id: string; approved: boolean}) => void
-}) => {
+/** One tool's row: name, derived one-line summary, status. Used in both modes. The Approve/Deny
+ * action lives in the persistent ApprovalDock (composer region), so a gate here is just marked
+ * "Awaiting approval" rather than carrying the buttons that used to scroll away with the turn. */
+const ToolRow = ({part, live}: {part: ToolUIPart; live: boolean}) => {
     const name = partToolName(part)
     const state = part.state as string
-    const approval = (part as {approval?: ApprovalRef}).approval
     const summary = rowSummary(part)
     const running = !isSettled(state) && state !== "approval-requested"
-    // The line between the name and the trailing status/buttons: the prompt for an approval,
-    // a live "running…", or the settled one-line output summary.
+    // The line after the name: an awaiting-approval marker, a live "running…", or the settled
+    // one-line output summary.
     const midText =
-        state === "approval-requested" ? "Run this tool?" : live && running ? "running…" : summary
+        state === "approval-requested"
+            ? "Awaiting approval"
+            : live && running
+              ? "running…"
+              : summary
 
     return (
         <div className="flex min-w-0 items-center gap-2 py-1">
-            <StatusIcon state={state} />
-            <Text className="!text-xs !font-medium shrink-0">{name}</Text>
-            {midText ? (
-                <Text
-                    type={state === "output-error" ? "danger" : "secondary"}
-                    className="!text-xs truncate"
-                    title={typeof midText === "string" ? midText : undefined}
-                >
-                    {midText}
+            <div className="flex min-w-0 flex-1 items-center gap-2">
+                <StatusIcon state={state} />
+                <Text className="!text-xs !font-medium min-w-0 truncate" title={name}>
+                    {name}
                 </Text>
-            ) : null}
-
-            {state === "approval-requested" && approval?.id ? (
-                <ApprovalButtons approvalId={approval.id} onApprovalResponse={onApprovalResponse} />
-            ) : null}
+                {midText ? (
+                    <Text
+                        type={state === "output-error" ? "danger" : "secondary"}
+                        className="!text-xs min-w-0 truncate"
+                        title={typeof midText === "string" ? midText : undefined}
+                    >
+                        {midText}
+                    </Text>
+                ) : null}
+            </div>
         </div>
     )
 }
@@ -160,7 +123,6 @@ interface ToolActivityProps {
     parts: ToolUIPart[]
     /** This turn is the one being generated right now. */
     isStreaming?: boolean
-    onApprovalResponse: (args: {id: string; approved: boolean}) => void
     /** Open the turn's trace drawer (full input/output). Absent if the turn has no trace yet. */
     onViewTrace?: () => void
 }
@@ -168,25 +130,21 @@ interface ToolActivityProps {
 /**
  * Renders a group of tool calls inside an agent turn. Two modes:
  *  - **Live** (streaming + a tool still in flight): a left-gutter timeline, always shown, so
- *    you watch each tool fire. An `approval-requested` tool surfaces Approve/Deny inline.
+ *    you watch each tool fire. An `approval-requested` tool is marked "Awaiting approval"; the
+ *    Approve/Deny action lives in the persistent ApprovalDock above the composer.
  *  - **Settled**: a single quiet "Used N tools" line; click to expand the per-tool list with
  *    one-line output summaries and a "View full trace" link.
  *
  * Output is summarised to one line per tool; the raw input/output lives in the trace drawer.
  * The FE only renders tool calls — it never executes them.
  */
-const ToolActivity = ({
-    parts,
-    isStreaming = false,
-    onApprovalResponse,
-    onViewTrace,
-}: ToolActivityProps) => {
+const ToolActivity = ({parts, isStreaming = false, onViewTrace}: ToolActivityProps) => {
     const anyUnsettled = parts.some((p) => !isSettled(p.state as string))
     const live = isStreaming && anyUnsettled
     const approvalPending = parts.some((p) => (p.state as string) === "approval-requested")
 
     const [open, setOpen] = useState(false)
-    // An approval must stay reachable, so force the list open whenever one is pending.
+    // Keep the gate visible in-context: force the list open whenever one is awaiting approval.
     const expanded = open || approvalPending
 
     // ---- Live: the gutter timeline (always visible while tools are in flight) ----
@@ -194,12 +152,7 @@ const ToolActivity = ({
         return (
             <div className="flex min-w-0 flex-col border-0 border-l-2 border-solid border-colorBorderSecondary pl-3">
                 {parts.map((part, i) => (
-                    <ToolRow
-                        key={`${part.toolCallId || part.type}-${i}`}
-                        part={part}
-                        live
-                        onApprovalResponse={onApprovalResponse}
-                    />
+                    <ToolRow key={`${part.toolCallId || part.type}-${i}`} part={part} live />
                 ))}
             </div>
         )
@@ -244,7 +197,6 @@ const ToolActivity = ({
                             key={`${part.toolCallId || part.type}-${i}`}
                             part={part}
                             live={false}
-                            onApprovalResponse={onApprovalResponse}
                         />
                     ))}
                     {onViewTrace && (

--- a/web/oss/src/components/AgentChatSlice/components/ToolActivity.tsx
+++ b/web/oss/src/components/AgentChatSlice/components/ToolActivity.tsx
@@ -91,6 +91,12 @@ const formatValue = (value: unknown): string => {
     }
 }
 
+/** Strip a surrounding markdown code fence — backends sometimes wrap an error in ```…```. */
+const stripFence = (value: string): string => {
+    const m = value.trim().match(/^```[\w-]*\n?([\s\S]*?)\n?```$/)
+    return m ? m[1].trim() : value
+}
+
 /** One labeled monospace block (input / output / error) in the Build-mode step log. Capped in
  * height with its own scroll so a large payload can't blow up the transcript. */
 const IOBlock = ({label, value, danger}: {label: string; value: string; danger?: boolean}) => (
@@ -193,7 +199,7 @@ const ToolRow = ({
                             <IOBlock label="input" value={formatValue(input)} />
                         ) : null}
                         {errorText !== undefined ? (
-                            <IOBlock label="error" value={errorText} danger />
+                            <IOBlock label="error" value={stripFence(errorText)} danger />
                         ) : state === "output-available" && output != null ? (
                             <IOBlock label="output" value={formatValue(output)} />
                         ) : null}

--- a/web/oss/src/components/AgentChatSlice/components/ToolActivity.tsx
+++ b/web/oss/src/components/AgentChatSlice/components/ToolActivity.tsx
@@ -80,26 +80,73 @@ const StatusIcon = ({state}: {state: string}) => {
     return <Spinner size={13} className="shrink-0 animate-spin text-colorPrimary" />
 }
 
-/** One tool's row: name, derived one-line summary, status. Used in both modes. The Approve/Deny
- * action lives in the persistent ApprovalDock (composer region), so a gate here is just marked
- * "Awaiting approval" rather than carrying the buttons that used to scroll away with the turn. */
-const ToolRow = ({part, live}: {part: ToolUIPart; live: boolean}) => {
+/** Pretty-print a tool input/output value for the Build-mode step log: a string as-is, anything
+ * else as indented JSON. Never throws — the raw payload also lives in the trace drawer. */
+const formatValue = (value: unknown): string => {
+    if (typeof value === "string") return value
+    try {
+        return JSON.stringify(value, null, 2)
+    } catch {
+        return String(value)
+    }
+}
+
+/** One labeled monospace block (input / output / error) in the Build-mode step log. Capped in
+ * height with its own scroll so a large payload can't blow up the transcript. */
+const IOBlock = ({label, value, danger}: {label: string; value: string; danger?: boolean}) => (
+    <div className="flex min-w-0 flex-col gap-0.5">
+        <span className="font-mono text-[10px] text-colorTextTertiary">{label}</span>
+        <pre
+            className={`m-0 max-h-40 overflow-auto whitespace-pre-wrap break-all rounded px-2 py-1.5 font-mono text-[11px] leading-snug ${
+                danger
+                    ? "bg-[var(--ant-color-error-bg)] !text-colorErrorText"
+                    : "bg-colorFillTertiary text-colorTextSecondary"
+            }`}
+        >
+            {value}
+        </pre>
+    </div>
+)
+
+/** One tool's row: name + status, plus (in Build's `detailed` step log) the tool's input and its
+ * output/error as monospace blocks. Chat mode keeps the quiet one-line summary. The Approve/Deny
+ * action lives in the persistent ApprovalDock, so a gate here is just marked "Awaiting approval". */
+const ToolRow = ({
+    part,
+    live,
+    detailed = false,
+}: {
+    part: ToolUIPart
+    live: boolean
+    detailed?: boolean
+}) => {
     const name = partToolName(part)
     const state = part.state as string
-    const summary = rowSummary(part)
     const running = !isSettled(state) && state !== "approval-requested"
-    // The line after the name: an awaiting-approval marker, a live "running…", or the settled
-    // one-line output summary.
+    // The line after the name: an awaiting-approval marker, a live "running…", the settled one-line
+    // summary (Chat), or a short status word (Build shows the full output block below instead).
     const midText =
         state === "approval-requested"
             ? "Awaiting approval"
             : live && running
               ? "running…"
-              : summary
+              : detailed
+                ? state === "output-error"
+                    ? "failed"
+                    : state === "output-denied"
+                      ? "denied"
+                      : null
+                : rowSummary(part)
+
+    const input = (part as {input?: unknown}).input
+    const output = (part as {output?: unknown}).output
+    const errorText = (part as {errorText?: string}).errorText
+    const hasIO =
+        detailed && (input != null || state === "output-available" || errorText !== undefined)
 
     return (
-        <div className="flex min-w-0 items-center gap-2 py-1">
-            <div className="flex min-w-0 flex-1 items-center gap-2">
+        <div className="flex min-w-0 flex-col py-1">
+            <div className="flex min-w-0 items-center gap-2">
                 <StatusIcon state={state} />
                 <Text className="!text-xs !font-medium min-w-0 truncate" title={name}>
                     {name}
@@ -114,6 +161,17 @@ const ToolRow = ({part, live}: {part: ToolUIPart; live: boolean}) => {
                     </Text>
                 ) : null}
             </div>
+
+            {hasIO ? (
+                <div className="mt-1 flex min-w-0 flex-col gap-1.5 pl-[21px]">
+                    {input != null ? <IOBlock label="input" value={formatValue(input)} /> : null}
+                    {errorText !== undefined ? (
+                        <IOBlock label="error" value={errorText} danger />
+                    ) : state === "output-available" && output != null ? (
+                        <IOBlock label="output" value={formatValue(output)} />
+                    ) : null}
+                </div>
+            ) : null}
         </div>
     )
 }
@@ -123,22 +181,30 @@ interface ToolActivityProps {
     parts: ToolUIPart[]
     /** This turn is the one being generated right now. */
     isStreaming?: boolean
+    /** Build mode: render the full step log (per-tool input + output/error inline), instead of the
+     * calm collapsed "Used N tools" summary Chat mode shows. */
+    detailed?: boolean
     /** Open the turn's trace drawer (full input/output). Absent if the turn has no trace yet. */
     onViewTrace?: () => void
 }
 
 /**
- * Renders a group of tool calls inside an agent turn. Two modes:
- *  - **Live** (streaming + a tool still in flight): a left-gutter timeline, always shown, so
- *    you watch each tool fire. An `approval-requested` tool is marked "Awaiting approval"; the
- *    Approve/Deny action lives in the persistent ApprovalDock above the composer.
- *  - **Settled**: a single quiet "Used N tools" line; click to expand the per-tool list with
- *    one-line output summaries and a "View full trace" link.
+ * Renders a group of tool calls inside an agent turn. Three modes:
+ *  - **Build step log** (`detailed`): a left-gutter timeline of every tool with its input and
+ *    output/error as monospace blocks — the power-user view, scoped to Build mode.
+ *  - **Live** (streaming + a tool still in flight, Chat mode): the same gutter but one-line rows,
+ *    so you watch each tool fire.
+ *  - **Chat settled**: a single quiet "Used N tools" line; click to expand a one-line-summary list.
  *
- * Output is summarised to one line per tool; the raw input/output lives in the trace drawer.
- * The FE only renders tool calls — it never executes them.
+ * An `approval-requested` tool is marked "Awaiting approval" in every mode; the Approve/Deny action
+ * lives in the persistent ApprovalDock. The FE only renders tool calls — it never executes them.
  */
-const ToolActivity = ({parts, isStreaming = false, onViewTrace}: ToolActivityProps) => {
+const ToolActivity = ({
+    parts,
+    isStreaming = false,
+    detailed = false,
+    onViewTrace,
+}: ToolActivityProps) => {
     const anyUnsettled = parts.some((p) => !isSettled(p.state as string))
     const live = isStreaming && anyUnsettled
     const approvalPending = parts.some((p) => (p.state as string) === "approval-requested")
@@ -147,13 +213,28 @@ const ToolActivity = ({parts, isStreaming = false, onViewTrace}: ToolActivityPro
     // Keep the gate visible in-context: force the list open whenever one is awaiting approval.
     const expanded = open || approvalPending
 
-    // ---- Live: the gutter timeline (always visible while tools are in flight) ----
-    if (live) {
+    // ---- Build step log (detailed) OR live streaming: the gutter timeline, always visible ----
+    if (detailed || live) {
         return (
             <div className="flex min-w-0 flex-col border-0 border-l-2 border-solid border-colorBorderSecondary pl-3">
                 {parts.map((part, i) => (
-                    <ToolRow key={`${part.toolCallId || part.type}-${i}`} part={part} live />
+                    <ToolRow
+                        key={`${part.toolCallId || part.type}-${i}`}
+                        part={part}
+                        live={live}
+                        detailed={detailed}
+                    />
                 ))}
+                {detailed && onViewTrace ? (
+                    <button
+                        type="button"
+                        onClick={onViewTrace}
+                        className="mt-1 flex w-fit cursor-pointer items-center gap-1 rounded border-0 bg-transparent px-0 py-0.5 text-xs text-colorPrimary transition-colors hover:underline"
+                    >
+                        <ArrowSquareOut size={12} />
+                        View full trace
+                    </button>
+                ) : null}
             </div>
         )
     }

--- a/web/oss/src/components/AgentChatSlice/components/ToolActivity.tsx
+++ b/web/oss/src/components/AgentChatSlice/components/ToolActivity.tsx
@@ -143,34 +143,62 @@ const ToolRow = ({
     const errorText = (part as {errorText?: string}).errorText
     const hasIO =
         detailed && (input != null || state === "output-available" || errorText !== undefined)
+    // Each detailed step collapses on its own — Build's step log can get long. Default expanded.
+    const [open, setOpen] = useState(true)
+
+    const header = (
+        <>
+            <StatusIcon state={state} />
+            <Text className="!text-xs !font-medium min-w-0 truncate" title={name}>
+                {name}
+            </Text>
+            {midText ? (
+                <Text
+                    type={state === "output-error" ? "danger" : "secondary"}
+                    className="!text-xs min-w-0 truncate"
+                    title={typeof midText === "string" ? midText : undefined}
+                >
+                    {midText}
+                </Text>
+            ) : null}
+        </>
+    )
 
     return (
         <div className="flex min-w-0 flex-col py-1">
-            <div className="flex min-w-0 items-center gap-2">
-                <StatusIcon state={state} />
-                <Text className="!text-xs !font-medium min-w-0 truncate" title={name}>
-                    {name}
-                </Text>
-                {midText ? (
-                    <Text
-                        type={state === "output-error" ? "danger" : "secondary"}
-                        className="!text-xs min-w-0 truncate"
-                        title={typeof midText === "string" ? midText : undefined}
-                    >
-                        {midText}
-                    </Text>
-                ) : null}
-            </div>
+            {hasIO ? (
+                <button
+                    type="button"
+                    onClick={() => setOpen((o) => !o)}
+                    aria-expanded={open}
+                    className="flex min-w-0 cursor-pointer items-center gap-2 border-0 bg-transparent p-0 text-left"
+                >
+                    <CaretRight
+                        size={11}
+                        weight="bold"
+                        className={`shrink-0 text-colorTextTertiary transition-transform ${
+                            open ? "rotate-90" : ""
+                        }`}
+                    />
+                    {header}
+                </button>
+            ) : (
+                <div className="flex min-w-0 items-center gap-2">{header}</div>
+            )}
 
             {hasIO ? (
-                <div className="mt-1 flex min-w-0 flex-col gap-1.5 pl-[21px]">
-                    {input != null ? <IOBlock label="input" value={formatValue(input)} /> : null}
-                    {errorText !== undefined ? (
-                        <IOBlock label="error" value={errorText} danger />
-                    ) : state === "output-available" && output != null ? (
-                        <IOBlock label="output" value={formatValue(output)} />
-                    ) : null}
-                </div>
+                <HeightCollapse open={open}>
+                    <div className="mt-1 flex min-w-0 flex-col gap-1.5 pl-[21px]">
+                        {input != null ? (
+                            <IOBlock label="input" value={formatValue(input)} />
+                        ) : null}
+                        {errorText !== undefined ? (
+                            <IOBlock label="error" value={errorText} danger />
+                        ) : state === "output-available" && output != null ? (
+                            <IOBlock label="output" value={formatValue(output)} />
+                        ) : null}
+                    </div>
+                </HeightCollapse>
             ) : null}
         </div>
     )

--- a/web/oss/src/components/AgentChatSlice/components/TurnInspector/ContextTab.tsx
+++ b/web/oss/src/components/AgentChatSlice/components/TurnInspector/ContextTab.tsx
@@ -74,14 +74,14 @@ const Send = ({
 const ContextTab = ({captures}: {captures: TurnRequestCapture[]}) => {
     if (captures.length === 0) {
         return (
-            <div className="p-4 text-xs text-colorTextTertiary">
+            <div className="text-xs text-colorTextTertiary">
                 No capture for this turn. Captures are recorded live in Build mode; a turn restored
                 from a previous session has none.
             </div>
         )
     }
     return (
-        <div className="flex flex-col gap-3 p-4">
+        <div className="flex flex-col gap-3">
             {captures.length > 1 ? (
                 <Text type="secondary" className="!text-xs">
                     This turn made {captures.length} requests (initial + resumes). Compare them to

--- a/web/oss/src/components/AgentChatSlice/components/TurnInspector/ContextTab.tsx
+++ b/web/oss/src/components/AgentChatSlice/components/TurnInspector/ContextTab.tsx
@@ -1,0 +1,98 @@
+import {memo} from "react"
+
+import {type TurnRequestCapture} from "@agenta/playground"
+import {Typography} from "antd"
+
+const {Text} = Typography
+
+const format = (value: unknown): string => {
+    if (value == null) return "null"
+    try {
+        return JSON.stringify(value, null, 2)
+    } catch {
+        return String(value)
+    }
+}
+
+const agentInstructions = (parameters: unknown): string | null => {
+    const p = parameters as {agent?: {instructions?: {agents_md?: unknown}}} | null
+    const md = p?.agent?.instructions?.agents_md
+    return typeof md === "string" ? md : null
+}
+
+const agentModel = (parameters: unknown): string | null => {
+    const p = parameters as {agent?: {llm?: {model?: unknown}; model?: unknown}} | null
+    const m = p?.agent?.llm?.model ?? p?.agent?.model
+    return typeof m === "string" ? m : null
+}
+
+const Block = ({label, value}: {label: string; value: string}) => (
+    <div className="flex min-w-0 flex-col gap-0.5">
+        <span className="font-mono text-[10px] text-colorTextTertiary">{label}</span>
+        <pre className="m-0 max-h-72 overflow-auto whitespace-pre-wrap break-all rounded bg-colorFillTertiary px-2 py-1.5 font-mono text-[11px] leading-snug text-colorTextSecondary">
+            {value}
+        </pre>
+    </div>
+)
+
+const Send = ({
+    capture,
+    index,
+    total,
+}: {
+    capture: TurnRequestCapture
+    index: number
+    total: number
+}) => {
+    const model = agentModel(capture.parameters)
+    const instructions = agentInstructions(capture.parameters)
+    return (
+        <div className="flex flex-col gap-2 rounded-lg border border-solid border-colorBorderSecondary p-3">
+            <div className="flex items-center gap-2">
+                <Text className="!text-xs !font-medium">
+                    Request {index + 1} of {total}
+                </Text>
+                {model ? (
+                    <Text type="secondary" className="!text-[11px] font-mono">
+                        {model}
+                    </Text>
+                ) : null}
+            </div>
+            {instructions != null ? (
+                <Block label="instructions (agents_md)" value={instructions} />
+            ) : null}
+            <Block label="parameters (config as sent)" value={format(capture.parameters)} />
+            <Block
+                label={`messages sent (${(capture.messages ?? []).length})`}
+                value={format(capture.messages)}
+            />
+        </div>
+    )
+}
+
+/** The Context tab: every send for the selected turn, config-at-turn + exact messages. */
+const ContextTab = ({captures}: {captures: TurnRequestCapture[]}) => {
+    if (captures.length === 0) {
+        return (
+            <div className="p-4 text-xs text-colorTextTertiary">
+                No capture for this turn. Captures are recorded live in Build mode; a turn restored
+                from a previous session has none.
+            </div>
+        )
+    }
+    return (
+        <div className="flex flex-col gap-3 p-4">
+            {captures.length > 1 ? (
+                <Text type="secondary" className="!text-xs">
+                    This turn made {captures.length} requests (initial + resumes). Compare them to
+                    spot drift or a loop.
+                </Text>
+            ) : null}
+            {captures.map((c, i) => (
+                <Send key={c.requestId} capture={c} index={i} total={captures.length} />
+            ))}
+        </div>
+    )
+}
+
+export default memo(ContextTab)

--- a/web/oss/src/components/AgentChatSlice/components/TurnInspector/ContextTab.tsx
+++ b/web/oss/src/components/AgentChatSlice/components/TurnInspector/ContextTab.tsx
@@ -29,7 +29,7 @@ const agentModel = (parameters: unknown): string | null => {
 const Block = ({label, value}: {label: string; value: string}) => (
     <div className="flex min-w-0 flex-col gap-0.5">
         <span className="font-mono text-[10px] text-colorTextTertiary">{label}</span>
-        <pre className="m-0 max-h-72 overflow-auto whitespace-pre-wrap break-all rounded bg-colorFillTertiary px-2 py-1.5 font-mono text-[11px] leading-snug text-colorTextSecondary">
+        <pre className="ag-surface-inset m-0 max-h-72 overflow-auto whitespace-pre-wrap break-all rounded px-2 py-1.5 font-mono text-[11px] leading-snug text-colorTextSecondary">
             {value}
         </pre>
     </div>

--- a/web/oss/src/components/AgentChatSlice/components/TurnInspector/RawTab.tsx
+++ b/web/oss/src/components/AgentChatSlice/components/TurnInspector/RawTab.tsx
@@ -47,7 +47,7 @@ const RawTab = ({captures}: {captures: TurnRequestCapture[]}) => {
                         >
                             {c.invocationUrl}
                         </Text>
-                        <pre className="m-0 max-h-96 overflow-auto whitespace-pre-wrap break-all rounded bg-colorFillTertiary px-2 py-1.5 font-mono text-[11px] leading-snug text-colorTextSecondary">
+                        <pre className="ag-surface-inset m-0 max-h-96 overflow-auto whitespace-pre-wrap break-all rounded px-2 py-1.5 font-mono text-[11px] leading-snug text-colorTextSecondary">
                             {json}
                         </pre>
                     </div>

--- a/web/oss/src/components/AgentChatSlice/components/TurnInspector/RawTab.tsx
+++ b/web/oss/src/components/AgentChatSlice/components/TurnInspector/RawTab.tsx
@@ -9,10 +9,10 @@ const {Text} = Typography
 const RawTab = ({captures}: {captures: TurnRequestCapture[]}) => {
     const {message} = App.useApp()
     if (captures.length === 0) {
-        return <div className="p-4 text-xs text-colorTextTertiary">No capture for this turn.</div>
+        return <div className="text-xs text-colorTextTertiary">No capture for this turn.</div>
     }
     return (
-        <div className="flex flex-col gap-3 p-4">
+        <div className="flex flex-col gap-3">
             {captures.map((c, i) => {
                 const body = {
                     session_id: c.sessionId,
@@ -26,15 +26,12 @@ const RawTab = ({captures}: {captures: TurnRequestCapture[]}) => {
                         className="flex flex-col gap-1.5 rounded-lg border border-solid border-colorBorderSecondary p-3"
                     >
                         <div className="flex items-center gap-2">
-                            <Text className="!text-xs !font-medium">
+                            <Text className="!text-xs !font-medium whitespace-nowrap shrink-0">
                                 Request {i + 1} of {captures.length}
-                            </Text>
-                            <Text type="secondary" className="!text-[11px] font-mono truncate">
-                                {c.invocationUrl}
                             </Text>
                             <Button
                                 type="link"
-                                className="!ml-auto !px-0 !text-xs"
+                                className="!ml-auto !shrink-0 !px-0 !text-xs"
                                 onClick={() => {
                                     navigator.clipboard?.writeText(json)
                                     message.success("Request body copied")
@@ -43,6 +40,13 @@ const RawTab = ({captures}: {captures: TurnRequestCapture[]}) => {
                                 Copy JSON
                             </Button>
                         </div>
+                        <Text
+                            type="secondary"
+                            className="!text-[11px] font-mono truncate"
+                            title={c.invocationUrl}
+                        >
+                            {c.invocationUrl}
+                        </Text>
                         <pre className="m-0 max-h-96 overflow-auto whitespace-pre-wrap break-all rounded bg-colorFillTertiary px-2 py-1.5 font-mono text-[11px] leading-snug text-colorTextSecondary">
                             {json}
                         </pre>

--- a/web/oss/src/components/AgentChatSlice/components/TurnInspector/RawTab.tsx
+++ b/web/oss/src/components/AgentChatSlice/components/TurnInspector/RawTab.tsx
@@ -1,0 +1,56 @@
+import {memo} from "react"
+
+import {type TurnRequestCapture} from "@agenta/playground"
+import {App, Button, Typography} from "antd"
+
+const {Text} = Typography
+
+/** One capture's literal outgoing request body, copyable for repro / bug reports. */
+const RawTab = ({captures}: {captures: TurnRequestCapture[]}) => {
+    const {message} = App.useApp()
+    if (captures.length === 0) {
+        return <div className="p-4 text-xs text-colorTextTertiary">No capture for this turn.</div>
+    }
+    return (
+        <div className="flex flex-col gap-3 p-4">
+            {captures.map((c, i) => {
+                const body = {
+                    session_id: c.sessionId,
+                    references: c.references,
+                    data: {inputs: {messages: c.messages}, parameters: c.parameters},
+                }
+                const json = JSON.stringify(body, null, 2)
+                return (
+                    <div
+                        key={c.requestId}
+                        className="flex flex-col gap-1.5 rounded-lg border border-solid border-colorBorderSecondary p-3"
+                    >
+                        <div className="flex items-center gap-2">
+                            <Text className="!text-xs !font-medium">
+                                Request {i + 1} of {captures.length}
+                            </Text>
+                            <Text type="secondary" className="!text-[11px] font-mono truncate">
+                                {c.invocationUrl}
+                            </Text>
+                            <Button
+                                type="link"
+                                className="!ml-auto !px-0 !text-xs"
+                                onClick={() => {
+                                    navigator.clipboard?.writeText(json)
+                                    message.success("Request body copied")
+                                }}
+                            >
+                                Copy JSON
+                            </Button>
+                        </div>
+                        <pre className="m-0 max-h-96 overflow-auto whitespace-pre-wrap break-all rounded bg-colorFillTertiary px-2 py-1.5 font-mono text-[11px] leading-snug text-colorTextSecondary">
+                            {json}
+                        </pre>
+                    </div>
+                )
+            })}
+        </div>
+    )
+}
+
+export default memo(RawTab)

--- a/web/oss/src/components/AgentChatSlice/components/TurnInspector/TimelineTab.tsx
+++ b/web/oss/src/components/AgentChatSlice/components/TurnInspector/TimelineTab.tsx
@@ -105,7 +105,11 @@ const TimelineTab = ({message}: {message: UIMessage | null}) => {
     if (!message) {
         return <div className="p-4 text-xs text-colorTextTertiary">No turn selected.</div>
     }
-    const parts = message.parts ?? []
+    // Drop the AI SDK step boundary markers — they carry no content, just noise in the log.
+    const parts = (message.parts ?? []).filter((p) => {
+        const t = p.type as string
+        return t !== "step-start" && t !== "step-end"
+    })
     return (
         <div className="flex flex-col gap-4 p-4">
             {parts.length === 0 ? (

--- a/web/oss/src/components/AgentChatSlice/components/TurnInspector/TimelineTab.tsx
+++ b/web/oss/src/components/AgentChatSlice/components/TurnInspector/TimelineTab.tsx
@@ -24,6 +24,12 @@ const format = (value: unknown): string => {
     }
 }
 
+/** Strip a surrounding markdown code fence — backends sometimes wrap an error in ```…```. */
+const stripFence = (value: string): string => {
+    const m = value.trim().match(/^```[\w-]*\n?([\s\S]*?)\n?```$/)
+    return m ? m[1].trim() : value
+}
+
 const userText = (message: UIMessage): string =>
     (message.parts ?? [])
         .filter((p) => (p as {type?: string}).type === "text")
@@ -95,7 +101,7 @@ const ToolStep = ({part}: {part: ToolUIPart}) => {
             </div>
             {input != null ? <Block label="input" value={format(input)} /> : null}
             {errorText !== undefined ? (
-                <Block label="error" value={errorText} danger />
+                <Block label="error" value={stripFence(errorText)} danger />
             ) : output != null ? (
                 <Block label="output" value={format(output)} />
             ) : null}

--- a/web/oss/src/components/AgentChatSlice/components/TurnInspector/TimelineTab.tsx
+++ b/web/oss/src/components/AgentChatSlice/components/TurnInspector/TimelineTab.tsx
@@ -1,0 +1,127 @@
+import {memo} from "react"
+
+import type {ToolUIPart, UIMessage} from "ai"
+import {Typography} from "antd"
+
+const {Text} = Typography
+
+const isToolPart = (t: string) => t.startsWith("tool-") || t === "dynamic-tool"
+
+const toolName = (part: ToolUIPart): string => {
+    const type = part.type as string
+    if (type === "dynamic-tool") return (part as {toolName?: string}).toolName || "tool"
+    return type.replace(/^tool-/, "")
+}
+
+const format = (value: unknown): string => {
+    if (value == null) return ""
+    if (typeof value === "string") return value
+    try {
+        return JSON.stringify(value, null, 2)
+    } catch {
+        return String(value)
+    }
+}
+
+const Block = ({label, value, danger}: {label: string; value: string; danger?: boolean}) => (
+    <div className="flex min-w-0 flex-col gap-0.5">
+        <span className="font-mono text-[10px] text-colorTextTertiary">{label}</span>
+        <pre
+            className={`m-0 max-h-72 overflow-auto whitespace-pre-wrap break-all rounded px-2 py-1.5 font-mono text-[11px] leading-snug ${
+                danger
+                    ? "bg-[var(--ant-color-error-bg)] !text-colorErrorText"
+                    : "bg-colorFillTertiary text-colorTextSecondary"
+            }`}
+        >
+            {value}
+        </pre>
+    </div>
+)
+
+const PartNode = ({part}: {part: UIMessage["parts"][number]}) => {
+    const type = part.type as string
+    if (type === "reasoning") {
+        const text = (part as {text?: string}).text ?? ""
+        return (
+            <div className="flex flex-col gap-1">
+                <Text type="secondary" className="!text-[11px] font-medium">
+                    reasoning
+                </Text>
+                <div className="text-xs italic text-colorTextTertiary whitespace-pre-wrap">
+                    {text}
+                </div>
+            </div>
+        )
+    }
+    if (type === "text") {
+        const text = (part as {text?: string}).text ?? ""
+        if (!text.trim()) return null
+        return (
+            <div className="flex flex-col gap-1">
+                <Text type="secondary" className="!text-[11px] font-medium">
+                    text
+                </Text>
+                <div className="text-xs text-colorText whitespace-pre-wrap">{text}</div>
+            </div>
+        )
+    }
+    if (isToolPart(type)) {
+        const p = part as ToolUIPart
+        const state = p.state as string
+        const input = (p as {input?: unknown}).input
+        const output = (p as {output?: unknown}).output
+        const errorText = (p as {errorText?: string}).errorText
+        return (
+            <div className="flex flex-col gap-1.5">
+                <div className="flex items-center gap-2">
+                    <Text className="!text-xs !font-medium font-mono">{toolName(p)}</Text>
+                    <Text
+                        type={state === "output-error" ? "danger" : "secondary"}
+                        className="!text-[11px]"
+                    >
+                        {state}
+                    </Text>
+                </div>
+                {input != null ? <Block label="input" value={format(input)} /> : null}
+                {errorText !== undefined ? (
+                    <Block label="error" value={errorText} danger />
+                ) : output != null ? (
+                    <Block label="output" value={format(output)} />
+                ) : null}
+            </div>
+        )
+    }
+    return (
+        <div className="flex flex-col gap-1">
+            <Text type="secondary" className="!text-[11px] font-medium">
+                {type}
+            </Text>
+        </div>
+    )
+}
+
+/** The Timeline tab: every part of one assistant turn, in order, un-truncated. */
+const TimelineTab = ({message}: {message: UIMessage | null}) => {
+    if (!message) {
+        return <div className="p-4 text-xs text-colorTextTertiary">No turn selected.</div>
+    }
+    const parts = message.parts ?? []
+    return (
+        <div className="flex flex-col gap-4 p-4">
+            {parts.length === 0 ? (
+                <div className="text-xs text-colorTextTertiary">This turn produced no parts.</div>
+            ) : (
+                parts.map((part, i) => (
+                    <div
+                        key={`${message.id}-${i}`}
+                        className="border-0 border-l-2 border-solid border-colorBorderSecondary pl-3"
+                    >
+                        <PartNode part={part} />
+                    </div>
+                ))
+            )}
+        </div>
+    )
+}
+
+export default memo(TimelineTab)

--- a/web/oss/src/components/AgentChatSlice/components/TurnInspector/TimelineTab.tsx
+++ b/web/oss/src/components/AgentChatSlice/components/TurnInspector/TimelineTab.tsx
@@ -1,5 +1,6 @@
-import {memo} from "react"
+import {memo, type ReactNode} from "react"
 
+import {CheckCircle, CircleNotch, Prohibit, Warning} from "@phosphor-icons/react"
 import type {ToolUIPart, UIMessage} from "ai"
 import {Typography} from "antd"
 
@@ -23,6 +24,13 @@ const format = (value: unknown): string => {
     }
 }
 
+const userText = (message: UIMessage): string =>
+    (message.parts ?? [])
+        .filter((p) => (p as {type?: string}).type === "text")
+        .map((p) => (p as {text?: string}).text ?? "")
+        .join("\n")
+        .trim()
+
 const Block = ({label, value, danger}: {label: string; value: string; danger?: boolean}) => (
     <div className="flex min-w-0 flex-col gap-0.5">
         <span className="font-mono text-[10px] text-colorTextTertiary">{label}</span>
@@ -30,7 +38,7 @@ const Block = ({label, value, danger}: {label: string; value: string; danger?: b
             className={`m-0 max-h-72 overflow-auto whitespace-pre-wrap break-all rounded px-2 py-1.5 font-mono text-[11px] leading-snug ${
                 danger
                     ? "bg-[var(--ant-color-error-bg)] !text-colorErrorText"
-                    : "bg-colorFillTertiary text-colorTextSecondary"
+                    : "bg-colorBgContainer text-colorTextSecondary"
             }`}
         >
             {value}
@@ -38,94 +46,120 @@ const Block = ({label, value, danger}: {label: string; value: string; danger?: b
     </div>
 )
 
-const PartNode = ({part}: {part: UIMessage["parts"][number]}) => {
+const ToolStatus = ({state}: {state: string}) => {
+    if (state === "output-available")
+        return <CheckCircle size={13} weight="fill" className="shrink-0 text-colorSuccess" />
+    if (state === "output-error")
+        return <Warning size={13} weight="fill" className="shrink-0 text-colorError" />
+    if (state === "output-denied")
+        return <Prohibit size={13} className="shrink-0 text-colorTextTertiary" />
+    return <CircleNotch size={13} className="shrink-0 animate-spin text-colorPrimary" />
+}
+
+/** A labeled, left-ruled timeline row (user message / reasoning / response). */
+const Row = ({label, accent, children}: {label: string; accent?: boolean; children: ReactNode}) => (
+    <div
+        className={`flex flex-col gap-1 border-0 border-l-2 border-solid pl-3 ${
+            accent ? "border-colorPrimary" : "border-colorBorderSecondary"
+        }`}
+    >
+        <Text type="secondary" className="!text-[11px] font-medium">
+            {label}
+        </Text>
+        {children}
+    </div>
+)
+
+/** A tool call as a distinct, inspectable step card: status + name, then input and output/error. */
+const ToolStep = ({part}: {part: ToolUIPart}) => {
+    const state = part.state as string
+    const input = (part as {input?: unknown}).input
+    const output = (part as {output?: unknown}).output
+    const errorText = (part as {errorText?: string}).errorText
+    return (
+        <div className="flex flex-col gap-1.5 rounded-lg border border-solid border-colorBorderSecondary bg-colorFillQuaternary p-2.5">
+            <div className="flex min-w-0 items-center gap-2">
+                <ToolStatus state={state} />
+                <Text
+                    className="!text-xs !font-medium font-mono min-w-0 truncate"
+                    title={toolName(part)}
+                >
+                    {toolName(part)}
+                </Text>
+                <Text
+                    type={state === "output-error" ? "danger" : "secondary"}
+                    className="!text-[11px] ml-auto shrink-0"
+                >
+                    {state}
+                </Text>
+            </div>
+            {input != null ? <Block label="input" value={format(input)} /> : null}
+            {errorText !== undefined ? (
+                <Block label="error" value={errorText} danger />
+            ) : output != null ? (
+                <Block label="output" value={format(output)} />
+            ) : null}
+        </div>
+    )
+}
+
+const AssistantPart = ({part}: {part: UIMessage["parts"][number]}) => {
     const type = part.type as string
     if (type === "reasoning") {
         const text = (part as {text?: string}).text ?? ""
+        if (!text.trim()) return null
         return (
-            <div className="flex flex-col gap-1">
-                <Text type="secondary" className="!text-[11px] font-medium">
-                    reasoning
-                </Text>
-                <div className="text-xs italic text-colorTextTertiary whitespace-pre-wrap">
+            <Row label="Thought">
+                <div className="whitespace-pre-wrap text-xs italic text-colorTextTertiary">
                     {text}
                 </div>
-            </div>
+            </Row>
         )
     }
     if (type === "text") {
         const text = (part as {text?: string}).text ?? ""
         if (!text.trim()) return null
         return (
-            <div className="flex flex-col gap-1">
-                <Text type="secondary" className="!text-[11px] font-medium">
-                    text
-                </Text>
-                <div className="text-xs text-colorText whitespace-pre-wrap">{text}</div>
-            </div>
+            <Row label="Response">
+                <div className="whitespace-pre-wrap text-xs text-colorText">{text}</div>
+            </Row>
         )
     }
-    if (isToolPart(type)) {
-        const p = part as ToolUIPart
-        const state = p.state as string
-        const input = (p as {input?: unknown}).input
-        const output = (p as {output?: unknown}).output
-        const errorText = (p as {errorText?: string}).errorText
-        return (
-            <div className="flex flex-col gap-1.5">
-                <div className="flex items-center gap-2">
-                    <Text className="!text-xs !font-medium font-mono">{toolName(p)}</Text>
-                    <Text
-                        type={state === "output-error" ? "danger" : "secondary"}
-                        className="!text-[11px]"
-                    >
-                        {state}
-                    </Text>
-                </div>
-                {input != null ? <Block label="input" value={format(input)} /> : null}
-                {errorText !== undefined ? (
-                    <Block label="error" value={errorText} danger />
-                ) : output != null ? (
-                    <Block label="output" value={format(output)} />
-                ) : null}
-            </div>
-        )
-    }
+    if (isToolPart(type)) return <ToolStep part={part as ToolUIPart} />
+    // Drop the AI SDK step boundary markers — they carry no content.
+    if (type === "step-start" || type === "step-end") return null
     return (
-        <div className="flex flex-col gap-1">
-            <Text type="secondary" className="!text-[11px] font-medium">
-                {type}
-            </Text>
-        </div>
+        <Row label={type}>
+            <span />
+        </Row>
     )
 }
 
-/** The Timeline tab: every part of one assistant turn, in order, un-truncated. */
-const TimelineTab = ({message}: {message: UIMessage | null}) => {
-    if (!message) {
-        return <div className="p-4 text-xs text-colorTextTertiary">No turn selected.</div>
+/**
+ * The Timeline tab: the whole round — the user message that started the turn, then every step the
+ * agent took (reasoning, tool calls with I/O, responses), in order. Reads the live message parts.
+ */
+const TimelineTab = ({round}: {round: UIMessage[]}) => {
+    if (round.length === 0) {
+        return <div className="text-xs text-colorTextTertiary">No turn selected.</div>
     }
-    // Drop the AI SDK step boundary markers — they carry no content, just noise in the log.
-    const parts = (message.parts ?? []).filter((p) => {
-        const t = p.type as string
-        return t !== "step-start" && t !== "step-end"
-    })
-    return (
-        <div className="flex flex-col gap-4 p-4">
-            {parts.length === 0 ? (
-                <div className="text-xs text-colorTextTertiary">This turn produced no parts.</div>
-            ) : (
-                parts.map((part, i) => (
-                    <div
-                        key={`${message.id}-${i}`}
-                        className="border-0 border-l-2 border-solid border-colorBorderSecondary pl-3"
-                    >
-                        <PartNode part={part} />
+    const nodes: ReactNode[] = []
+    round.forEach((msg) => {
+        if (msg.role === "user") {
+            nodes.push(
+                <Row key={msg.id} label="You" accent>
+                    <div className="whitespace-pre-wrap text-xs text-colorText">
+                        {userText(msg) || "—"}
                     </div>
-                ))
-            )}
-        </div>
-    )
+                </Row>,
+            )
+            return
+        }
+        ;(msg.parts ?? []).forEach((part, i) => {
+            nodes.push(<AssistantPart key={`${msg.id}-${i}`} part={part} />)
+        })
+    })
+    return <div className="flex flex-col gap-3">{nodes}</div>
 }
 
 export default memo(TimelineTab)

--- a/web/oss/src/components/AgentChatSlice/components/TurnInspector/TimelineTab.tsx
+++ b/web/oss/src/components/AgentChatSlice/components/TurnInspector/TimelineTab.tsx
@@ -43,8 +43,8 @@ const Block = ({label, value, danger}: {label: string; value: string; danger?: b
         <pre
             className={`m-0 max-h-72 overflow-auto whitespace-pre-wrap break-all rounded px-2 py-1.5 font-mono text-[11px] leading-snug ${
                 danger
-                    ? "bg-[var(--ant-color-error-bg)] !text-colorErrorText"
-                    : "bg-colorBgContainer text-colorTextSecondary"
+                    ? "ag-surface-error-well !text-colorErrorText"
+                    : "ag-surface-inset text-colorTextSecondary"
             }`}
         >
             {value}
@@ -83,7 +83,7 @@ const ToolStep = ({part}: {part: ToolUIPart}) => {
     const output = (part as {output?: unknown}).output
     const errorText = (part as {errorText?: string}).errorText
     return (
-        <div className="flex flex-col gap-1.5 rounded-lg border border-solid border-colorBorderSecondary bg-colorFillQuaternary p-2.5">
+        <div className="ag-surface-card flex flex-col gap-1.5 rounded-[11px] p-2.5">
             <div className="flex min-w-0 items-center gap-2">
                 <ToolStatus state={state} />
                 <Text
@@ -92,12 +92,17 @@ const ToolStep = ({part}: {part: ToolUIPart}) => {
                 >
                     {toolName(part)}
                 </Text>
-                <Text
-                    type={state === "output-error" ? "danger" : "secondary"}
-                    className="!text-[11px] ml-auto shrink-0"
+                <span
+                    className={`ml-auto shrink-0 rounded px-1.5 py-px font-mono text-[10px] ${
+                        state === "output-error"
+                            ? "ag-status-error"
+                            : state === "output-available"
+                              ? "ag-status-success"
+                              : "ag-surface-chip text-colorTextSecondary"
+                    }`}
                 >
                     {state}
-                </Text>
+                </span>
             </div>
             {input != null ? <Block label="input" value={format(input)} /> : null}
             {errorText !== undefined ? (
@@ -116,7 +121,7 @@ const AssistantPart = ({part}: {part: UIMessage["parts"][number]}) => {
         if (!text.trim()) return null
         return (
             <Row label="Thought">
-                <div className="whitespace-pre-wrap text-xs italic text-colorTextTertiary">
+                <div className="ag-surface-inset whitespace-pre-wrap rounded px-2.5 py-2 text-xs italic text-colorTextTertiary">
                     {text}
                 </div>
             </Row>
@@ -154,7 +159,7 @@ const TimelineTab = ({round}: {round: UIMessage[]}) => {
         if (msg.role === "user") {
             nodes.push(
                 <Row key={msg.id} label="You" accent>
-                    <div className="whitespace-pre-wrap text-xs text-colorText">
+                    <div className="ag-surface-inset whitespace-pre-wrap rounded px-2.5 py-2 text-xs text-colorText">
                         {userText(msg) || "—"}
                     </div>
                 </Row>,

--- a/web/oss/src/components/AgentChatSlice/components/TurnInspector/TurnInspector.tsx
+++ b/web/oss/src/components/AgentChatSlice/components/TurnInspector/TurnInspector.tsx
@@ -1,7 +1,7 @@
 import {useMemo, useState} from "react"
 
 import {capturesForTrigger} from "@agenta/playground"
-import {EnhancedDrawer} from "@agenta/ui/drawer"
+import {X} from "@phosphor-icons/react"
 import type {UIMessage} from "ai"
 import {Button} from "antd"
 import {useAtom, useAtomValue} from "jotai"
@@ -21,12 +21,15 @@ const TABS: {value: Tab; label: string}[] = [
     {value: "raw", label: "Raw"},
 ]
 
+const PANEL_WIDTH = 480
+
 /**
  * Dedicated Build-mode turn inspector. Mounted per session inside `AgentConversation` so it reads
  * the LIVE `useChat` `messages` (the same list the transcript renders) — accurate turn + live
- * streaming — and opens ONLY for the session that is the current inspector target. Laid out with the
- * drawer siderail pattern (vertical Timeline/Context/Raw rail + bordered content). Own state
- * (`turnInspectorAtom`), NOT the trace drawer.
+ * streaming — and opens ONLY for the session that is the current inspector target. Rendered as an
+ * inline side panel (a flex sibling of the chat column) so it pushes the transcript aside instead of
+ * overlaying it. Siderail pattern inside (vertical Timeline/Context/Raw rail + bordered content).
+ * Own state (`turnInspectorAtom`), NOT the trace drawer.
  */
 const TurnInspector = ({sessionId, messages}: {sessionId: string; messages: UIMessage[]}) => {
     const [target, setTarget] = useAtom(turnInspectorAtom)
@@ -65,45 +68,61 @@ const TurnInspector = ({sessionId, messages}: {sessionId: string; messages: UIMe
         return capturesForTrigger(captures, triggerId)
     }, [open, target, messages, captures])
 
+    // Stays mounted and animates its width (0↔PANEL_WIDTH) in lockstep with the build/chat mode
+    // switch, so it slides in/out instead of snapping. Clipped + `inert` while collapsed.
     return (
-        <EnhancedDrawer
-            open={open}
-            onClose={() => setTarget(null)}
-            width={560}
-            title="Turn inspector"
-            destroyOnHidden
-            styles={{body: {padding: 0}}}
+        <div
+            className="h-full shrink-0 overflow-hidden motion-safe:transition-[width] motion-safe:duration-[240ms] motion-safe:ease-[cubic-bezier(0.4,0,0.2,1)]"
+            style={{width: open ? PANEL_WIDTH : 0}}
+            inert={!open}
         >
-            <div className="flex h-full min-h-0 gap-3 p-3">
-                <div className="flex w-[104px] shrink-0 flex-col gap-0.5">
-                    {TABS.map((t) => {
-                        const active = t.value === tab
-                        return (
-                            <Button
-                                key={t.value}
-                                type="text"
-                                block
-                                onClick={() => setTab(t.value)}
-                                className={`!h-8 !justify-start !rounded-md !px-2.5 !text-xs transition-colors ${
-                                    active
-                                        ? "!bg-[var(--ag-colorPrimaryBg)] !font-medium !text-[var(--ag-colorPrimary)]"
-                                        : "!text-[var(--ag-colorTextSecondary)] hover:!bg-[var(--ag-colorFillTertiary)] hover:!text-[var(--ag-colorText)]"
-                                }`}
-                            >
-                                {t.label}
-                            </Button>
-                        )
-                    })}
+            <div
+                className="flex h-full min-h-0 flex-col border-0 border-l border-solid border-[var(--ag-colorBorder)] bg-[var(--ag-colorBgContainer)]"
+                style={{width: PANEL_WIDTH}}
+            >
+                <div className="flex shrink-0 items-center justify-between border-0 border-b border-solid border-[var(--ag-colorBorder)] px-3 py-2">
+                    <span className="text-xs font-medium text-[var(--ag-colorText)]">
+                        Turn inspector
+                    </span>
+                    <Button
+                        type="text"
+                        size="small"
+                        icon={<X size={14} />}
+                        onClick={() => setTarget(null)}
+                        aria-label="Close turn inspector"
+                    />
                 </div>
-                <div className="flex min-h-0 min-w-0 flex-1 flex-col border-0 border-l border-solid border-[var(--ag-colorBorder)] pl-3">
-                    <div className="min-h-0 flex-1 overflow-y-auto pr-1">
-                        {tab === "timeline" ? <TimelineTab round={round} /> : null}
-                        {tab === "context" ? <ContextTab captures={turnCaptures} /> : null}
-                        {tab === "raw" ? <RawTab captures={turnCaptures} /> : null}
+                <div className="flex min-h-0 flex-1 gap-3 p-3">
+                    <div className="flex w-[104px] shrink-0 flex-col gap-0.5">
+                        {TABS.map((t) => {
+                            const active = t.value === tab
+                            return (
+                                <Button
+                                    key={t.value}
+                                    type="text"
+                                    block
+                                    onClick={() => setTab(t.value)}
+                                    className={`!h-8 !justify-start !rounded-md !px-2.5 !text-xs transition-colors ${
+                                        active
+                                            ? "!bg-[var(--ag-colorPrimaryBg)] !font-medium !text-[var(--ag-colorPrimary)]"
+                                            : "!text-[var(--ag-colorTextSecondary)] hover:!bg-[var(--ag-colorFillTertiary)] hover:!text-[var(--ag-colorText)]"
+                                    }`}
+                                >
+                                    {t.label}
+                                </Button>
+                            )
+                        })}
+                    </div>
+                    <div className="flex min-h-0 min-w-0 flex-1 flex-col border-0 border-l border-solid border-[var(--ag-colorBorder)] pl-3">
+                        <div className="min-h-0 flex-1 overflow-y-auto pr-1">
+                            {tab === "timeline" ? <TimelineTab round={round} /> : null}
+                            {tab === "context" ? <ContextTab captures={turnCaptures} /> : null}
+                            {tab === "raw" ? <RawTab captures={turnCaptures} /> : null}
+                        </div>
                     </div>
                 </div>
             </div>
-        </EnhancedDrawer>
+        </div>
     )
 }
 

--- a/web/oss/src/components/AgentChatSlice/components/TurnInspector/TurnInspector.tsx
+++ b/web/oss/src/components/AgentChatSlice/components/TurnInspector/TurnInspector.tsx
@@ -1,0 +1,65 @@
+import {useMemo, useState} from "react"
+
+import {EnhancedDrawer} from "@agenta/ui/drawer"
+import type {UIMessage} from "ai"
+import {Segmented} from "antd"
+import {useAtom, useAtomValue} from "jotai"
+
+import {sessionMessagesAtom} from "../../state/sessions"
+import {turnInspectorAtom} from "../../state/turnInspector"
+
+import TimelineTab from "./TimelineTab"
+
+type Tab = "timeline" | "context" | "raw"
+
+/** Dedicated Build-mode turn inspector. Own state (`turnInspectorAtom`), NOT the trace drawer. */
+const TurnInspector = () => {
+    const [target, setTarget] = useAtom(turnInspectorAtom)
+    const allMessages = useAtomValue(sessionMessagesAtom)
+    const [tab, setTab] = useState<Tab>("timeline")
+
+    const message: UIMessage | null = useMemo(() => {
+        if (!target) return null
+        const list = allMessages[target.sessionId] ?? []
+        return list.find((m) => m.id === target.assistantMessageId) ?? null
+    }, [target, allMessages])
+
+    return (
+        <EnhancedDrawer
+            open={!!target}
+            onClose={() => setTarget(null)}
+            width={560}
+            title="Turn inspector"
+            destroyOnHidden
+        >
+            <div className="flex h-full min-h-0 flex-col">
+                <div className="px-4 pt-2">
+                    <Segmented<Tab>
+                        value={tab}
+                        onChange={setTab}
+                        options={[
+                            {label: "Timeline", value: "timeline"},
+                            {label: "Context", value: "context"},
+                            {label: "Raw", value: "raw"},
+                        ]}
+                    />
+                </div>
+                <div className="min-h-0 flex-1 overflow-y-auto">
+                    {tab === "timeline" ? <TimelineTab message={message} /> : null}
+                    {tab === "context" ? (
+                        <div className="p-4 text-xs text-colorTextTertiary">
+                            Context — added in Phase 2.
+                        </div>
+                    ) : null}
+                    {tab === "raw" ? (
+                        <div className="p-4 text-xs text-colorTextTertiary">
+                            Raw — added in Phase 3.
+                        </div>
+                    ) : null}
+                </div>
+            </div>
+        </EnhancedDrawer>
+    )
+}
+
+export default TurnInspector

--- a/web/oss/src/components/AgentChatSlice/components/TurnInspector/TurnInspector.tsx
+++ b/web/oss/src/components/AgentChatSlice/components/TurnInspector/TurnInspector.tsx
@@ -11,6 +11,7 @@ import {sessionCapturesAtomFamily} from "../../state/turnCaptures"
 import {turnInspectorAtom} from "../../state/turnInspector"
 
 import ContextTab from "./ContextTab"
+import RawTab from "./RawTab"
 import TimelineTab from "./TimelineTab"
 
 type Tab = "timeline" | "context" | "raw"
@@ -66,11 +67,7 @@ const TurnInspector = () => {
                 <div className="min-h-0 flex-1 overflow-y-auto">
                     {tab === "timeline" ? <TimelineTab message={message} /> : null}
                     {tab === "context" ? <ContextTab captures={turnCaptures} /> : null}
-                    {tab === "raw" ? (
-                        <div className="p-4 text-xs text-colorTextTertiary">
-                            Raw — added in Phase 3.
-                        </div>
-                    ) : null}
+                    {tab === "raw" ? <RawTab captures={turnCaptures} /> : null}
                 </div>
             </div>
         </EnhancedDrawer>

--- a/web/oss/src/components/AgentChatSlice/components/TurnInspector/TurnInspector.tsx
+++ b/web/oss/src/components/AgentChatSlice/components/TurnInspector/TurnInspector.tsx
@@ -6,7 +6,6 @@ import type {UIMessage} from "ai"
 import {Segmented} from "antd"
 import {useAtom, useAtomValue} from "jotai"
 
-import {sessionMessagesAtom} from "../../state/sessions"
 import {sessionCapturesAtomFamily} from "../../state/turnCaptures"
 import {turnInspectorAtom} from "../../state/turnInspector"
 
@@ -16,37 +15,42 @@ import TimelineTab from "./TimelineTab"
 
 type Tab = "timeline" | "context" | "raw"
 
-/** Dedicated Build-mode turn inspector. Own state (`turnInspectorAtom`), NOT the trace drawer. */
-const TurnInspector = () => {
+/**
+ * Dedicated Build-mode turn inspector. Mounted per session inside `AgentConversation` so it reads
+ * the LIVE `useChat` `messages` (the same list the transcript renders) — the selected turn is found
+ * by id in the live list, and it updates as the turn streams. It opens ONLY for the session that is
+ * the current inspector target, so the N mounted tabs don't each pop a drawer. Own state
+ * (`turnInspectorAtom`), NOT the trace drawer.
+ */
+const TurnInspector = ({sessionId, messages}: {sessionId: string; messages: UIMessage[]}) => {
     const [target, setTarget] = useAtom(turnInspectorAtom)
-    const allMessages = useAtomValue(sessionMessagesAtom)
     const [tab, setTab] = useState<Tab>("timeline")
 
-    const message: UIMessage | null = useMemo(() => {
-        if (!target) return null
-        const list = allMessages[target.sessionId] ?? []
-        return list.find((m) => m.id === target.assistantMessageId) ?? null
-    }, [target, allMessages])
+    const open = target?.sessionId === sessionId
 
-    const captures = useAtomValue(sessionCapturesAtomFamily(target?.sessionId ?? ""))
+    const message: UIMessage | null = useMemo(() => {
+        if (!open || !target) return null
+        return messages.find((m) => m.id === target.assistantMessageId) ?? null
+    }, [open, target, messages])
+
+    const captures = useAtomValue(sessionCapturesAtomFamily(sessionId))
     const turnCaptures = useMemo(() => {
-        if (!target) return []
-        const list = allMessages[target.sessionId] ?? []
-        const idx = list.findIndex((m) => m.id === target.assistantMessageId)
+        if (!open || !target) return []
+        const idx = messages.findIndex((m) => m.id === target.assistantMessageId)
         // The trigger is the last user message at or before this assistant turn.
         let triggerId: string | null = null
         for (let i = idx; i >= 0; i--) {
-            if (list[i]?.role === "user") {
-                triggerId = list[i].id
+            if (messages[i]?.role === "user") {
+                triggerId = messages[i].id
                 break
             }
         }
         return capturesForTrigger(captures, triggerId)
-    }, [target, allMessages, captures])
+    }, [open, target, messages, captures])
 
     return (
         <EnhancedDrawer
-            open={!!target}
+            open={open}
             onClose={() => setTarget(null)}
             width={560}
             title="Turn inspector"

--- a/web/oss/src/components/AgentChatSlice/components/TurnInspector/TurnInspector.tsx
+++ b/web/oss/src/components/AgentChatSlice/components/TurnInspector/TurnInspector.tsx
@@ -77,10 +77,10 @@ const TurnInspector = ({sessionId, messages}: {sessionId: string; messages: UIMe
             inert={!open}
         >
             <div
-                className="flex h-full min-h-0 flex-col border-0 border-l border-solid border-[var(--ag-colorBorder)] bg-[var(--ag-colorBgContainer)]"
+                className="ag-inspector-panel flex h-full min-h-0 flex-col"
                 style={{width: PANEL_WIDTH}}
             >
-                <div className="flex shrink-0 items-center justify-between border-0 border-b border-solid border-[var(--ag-colorBorder)] px-3 py-2">
+                <div className="flex shrink-0 items-center justify-between border-0 border-b border-solid border-[var(--ag-surface-divider)] px-3 py-2">
                     <span className="text-xs font-medium text-[var(--ag-colorText)]">
                         Turn inspector
                     </span>
@@ -113,7 +113,7 @@ const TurnInspector = ({sessionId, messages}: {sessionId: string; messages: UIMe
                             )
                         })}
                     </div>
-                    <div className="flex min-h-0 min-w-0 flex-1 flex-col border-0 border-l border-solid border-[var(--ag-colorBorder)] pl-3">
+                    <div className="flex min-h-0 min-w-0 flex-1 flex-col border-0 border-l border-solid border-[var(--ag-surface-divider)] pl-3">
                         <div className="min-h-0 flex-1 overflow-y-auto pr-1">
                             {tab === "timeline" ? <TimelineTab round={round} /> : null}
                             {tab === "context" ? <ContextTab captures={turnCaptures} /> : null}

--- a/web/oss/src/components/AgentChatSlice/components/TurnInspector/TurnInspector.tsx
+++ b/web/oss/src/components/AgentChatSlice/components/TurnInspector/TurnInspector.tsx
@@ -1,13 +1,16 @@
 import {useMemo, useState} from "react"
 
+import {capturesForTrigger} from "@agenta/playground"
 import {EnhancedDrawer} from "@agenta/ui/drawer"
 import type {UIMessage} from "ai"
 import {Segmented} from "antd"
 import {useAtom, useAtomValue} from "jotai"
 
 import {sessionMessagesAtom} from "../../state/sessions"
+import {sessionCapturesAtomFamily} from "../../state/turnCaptures"
 import {turnInspectorAtom} from "../../state/turnInspector"
 
+import ContextTab from "./ContextTab"
 import TimelineTab from "./TimelineTab"
 
 type Tab = "timeline" | "context" | "raw"
@@ -23,6 +26,22 @@ const TurnInspector = () => {
         const list = allMessages[target.sessionId] ?? []
         return list.find((m) => m.id === target.assistantMessageId) ?? null
     }, [target, allMessages])
+
+    const captures = useAtomValue(sessionCapturesAtomFamily(target?.sessionId ?? ""))
+    const turnCaptures = useMemo(() => {
+        if (!target) return []
+        const list = allMessages[target.sessionId] ?? []
+        const idx = list.findIndex((m) => m.id === target.assistantMessageId)
+        // The trigger is the last user message at or before this assistant turn.
+        let triggerId: string | null = null
+        for (let i = idx; i >= 0; i--) {
+            if (list[i]?.role === "user") {
+                triggerId = list[i].id
+                break
+            }
+        }
+        return capturesForTrigger(captures, triggerId)
+    }, [target, allMessages, captures])
 
     return (
         <EnhancedDrawer
@@ -46,11 +65,7 @@ const TurnInspector = () => {
                 </div>
                 <div className="min-h-0 flex-1 overflow-y-auto">
                     {tab === "timeline" ? <TimelineTab message={message} /> : null}
-                    {tab === "context" ? (
-                        <div className="p-4 text-xs text-colorTextTertiary">
-                            Context — added in Phase 2.
-                        </div>
-                    ) : null}
+                    {tab === "context" ? <ContextTab captures={turnCaptures} /> : null}
                     {tab === "raw" ? (
                         <div className="p-4 text-xs text-colorTextTertiary">
                             Raw — added in Phase 3.

--- a/web/oss/src/components/AgentChatSlice/components/TurnInspector/TurnInspector.tsx
+++ b/web/oss/src/components/AgentChatSlice/components/TurnInspector/TurnInspector.tsx
@@ -3,7 +3,7 @@ import {useMemo, useState} from "react"
 import {capturesForTrigger} from "@agenta/playground"
 import {EnhancedDrawer} from "@agenta/ui/drawer"
 import type {UIMessage} from "ai"
-import {Segmented} from "antd"
+import {Button} from "antd"
 import {useAtom, useAtomValue} from "jotai"
 
 import {sessionCapturesAtomFamily} from "../../state/turnCaptures"
@@ -15,11 +15,17 @@ import TimelineTab from "./TimelineTab"
 
 type Tab = "timeline" | "context" | "raw"
 
+const TABS: {value: Tab; label: string}[] = [
+    {value: "timeline", label: "Timeline"},
+    {value: "context", label: "Context"},
+    {value: "raw", label: "Raw"},
+]
+
 /**
  * Dedicated Build-mode turn inspector. Mounted per session inside `AgentConversation` so it reads
- * the LIVE `useChat` `messages` (the same list the transcript renders) — the selected turn is found
- * by id in the live list, and it updates as the turn streams. It opens ONLY for the session that is
- * the current inspector target, so the N mounted tabs don't each pop a drawer. Own state
+ * the LIVE `useChat` `messages` (the same list the transcript renders) — accurate turn + live
+ * streaming — and opens ONLY for the session that is the current inspector target. Laid out with the
+ * drawer siderail pattern (vertical Timeline/Context/Raw rail + bordered content). Own state
  * (`turnInspectorAtom`), NOT the trace drawer.
  */
 const TurnInspector = ({sessionId, messages}: {sessionId: string; messages: UIMessage[]}) => {
@@ -28,9 +34,20 @@ const TurnInspector = ({sessionId, messages}: {sessionId: string; messages: UIMe
 
     const open = target?.sessionId === sessionId
 
-    const message: UIMessage | null = useMemo(() => {
-        if (!open || !target) return null
-        return messages.find((m) => m.id === target.assistantMessageId) ?? null
+    // The whole round: the user message that started the turn, then the assistant turn.
+    const round = useMemo<UIMessage[]>(() => {
+        if (!open || !target) return []
+        const idx = messages.findIndex((m) => m.id === target.assistantMessageId)
+        if (idx < 0) return []
+        const assistant = messages[idx]
+        let user: UIMessage | null = null
+        for (let i = idx - 1; i >= 0; i--) {
+            if (messages[i]?.role === "user") {
+                user = messages[i]
+                break
+            }
+        }
+        return user ? [user, assistant] : [assistant]
     }, [open, target, messages])
 
     const captures = useAtomValue(sessionCapturesAtomFamily(sessionId))
@@ -55,23 +72,35 @@ const TurnInspector = ({sessionId, messages}: {sessionId: string; messages: UIMe
             width={560}
             title="Turn inspector"
             destroyOnHidden
+            styles={{body: {padding: 0}}}
         >
-            <div className="flex h-full min-h-0 flex-col">
-                <div className="px-4 pt-2">
-                    <Segmented<Tab>
-                        value={tab}
-                        onChange={setTab}
-                        options={[
-                            {label: "Timeline", value: "timeline"},
-                            {label: "Context", value: "context"},
-                            {label: "Raw", value: "raw"},
-                        ]}
-                    />
+            <div className="flex h-full min-h-0 gap-3 p-3">
+                <div className="flex w-[104px] shrink-0 flex-col gap-0.5">
+                    {TABS.map((t) => {
+                        const active = t.value === tab
+                        return (
+                            <Button
+                                key={t.value}
+                                type="text"
+                                block
+                                onClick={() => setTab(t.value)}
+                                className={`!h-8 !justify-start !rounded-md !px-2.5 !text-xs transition-colors ${
+                                    active
+                                        ? "!bg-[var(--ag-colorPrimaryBg)] !font-medium !text-[var(--ag-colorPrimary)]"
+                                        : "!text-[var(--ag-colorTextSecondary)] hover:!bg-[var(--ag-colorFillTertiary)] hover:!text-[var(--ag-colorText)]"
+                                }`}
+                            >
+                                {t.label}
+                            </Button>
+                        )
+                    })}
                 </div>
-                <div className="min-h-0 flex-1 overflow-y-auto">
-                    {tab === "timeline" ? <TimelineTab message={message} /> : null}
-                    {tab === "context" ? <ContextTab captures={turnCaptures} /> : null}
-                    {tab === "raw" ? <RawTab captures={turnCaptures} /> : null}
+                <div className="flex min-h-0 min-w-0 flex-1 flex-col border-0 border-l border-solid border-[var(--ag-colorBorder)] pl-3">
+                    <div className="min-h-0 flex-1 overflow-y-auto pr-1">
+                        {tab === "timeline" ? <TimelineTab round={round} /> : null}
+                        {tab === "context" ? <ContextTab captures={turnCaptures} /> : null}
+                        {tab === "raw" ? <RawTab captures={turnCaptures} /> : null}
+                    </div>
                 </div>
             </div>
         </EnhancedDrawer>

--- a/web/oss/src/components/AgentChatSlice/hooks/useAgentChatQueue.ts
+++ b/web/oss/src/components/AgentChatSlice/hooks/useAgentChatQueue.ts
@@ -13,6 +13,10 @@ export interface QueuedMessage {
 interface UseAgentChatQueueArgs {
     status: string
     messages: UIMessage[]
+    /** The last turn was user-stopped (cancelled). A stop voids any pending approval / imminent
+     * auto-resume, so the aborted turn's tool parts still reading as mid-HITL must NOT hold a new
+     * send — a stopped-and-settled conversation is releasable. */
+    stopped: boolean
     /** Send one released message into the conversation (wraps `useChat`'s `sendMessage`). Must be
      * referentially stable so the release effect doesn't churn on every streamed token. */
     sendQueued: (item: QueuedMessage) => void
@@ -23,9 +27,24 @@ interface UseAgentChatQueueArgs {
  * stream truly settles. It never releases mid human-in-the-loop (a tool-approval gate) — that
  * decision lives in `canReleaseQueuedMessage`. Releasing one message flips the conversation back
  * to busy, so the next stays queued until that turn settles too.
+ *
+ * Exception: a user STOP. Stopping aborts the run, which cancels any pending approval or the tick
+ * before an auto-resume — but the aborted turn's tool parts keep their `approval-requested` /
+ * `approval-responded` / client-tool-result shape, so `canReleaseQueuedMessage` would keep holding.
+ * When `stopped`, a settled conversation is releasable so a fresh send goes immediately.
  */
-export const useAgentChatQueue = ({status, messages, sendQueued}: UseAgentChatQueueArgs) => {
+export const useAgentChatQueue = ({
+    status,
+    messages,
+    stopped,
+    sendQueued,
+}: UseAgentChatQueueArgs) => {
     const [queued, setQueued] = useState<QueuedMessage[]>([])
+
+    // Settled = the stream is over (done or failed). A stop lands here (abort → "ready").
+    const settled = status === "ready" || status === "error"
+    // Releasable now: the normal gate, OR a stopped-and-settled turn (the stop voided its gate).
+    const canReleaseNow = canReleaseQueuedMessage(status, messages) || (stopped && settled)
 
     // One latch shared by both send paths caps releases to one per settle and preserves FIFO.
     const releasingRef = useRef(false)
@@ -38,18 +57,14 @@ export const useAgentChatQueue = ({status, messages, sendQueued}: UseAgentChatQu
     const submit = useCallback(
         (item: {text: string; fileParts?: FileUIPart[]}) => {
             const message: QueuedMessage = {...item, id: generateId()}
-            if (
-                !releasingRef.current &&
-                queuedRef.current.length === 0 &&
-                canReleaseQueuedMessage(status, messages)
-            ) {
+            if (!releasingRef.current && queuedRef.current.length === 0 && canReleaseNow) {
                 releasingRef.current = true
                 sendQueued(message)
             } else {
                 setQueued((q) => [...q, message])
             }
         },
-        [status, messages, sendQueued],
+        [canReleaseNow, sendQueued],
     )
 
     const removeQueued = useCallback((id: string) => {
@@ -58,19 +73,22 @@ export const useAgentChatQueue = ({status, messages, sendQueued}: UseAgentChatQu
 
     const clearQueue = useCallback(() => setQueued([]), [])
 
-    // Release the queue head once the stream settles; the latch caps it at one per settle.
+    // Release the queue head once the stream settles; the latch caps it at one per settle. Both
+    // "ready" and "error" are settled — releasing on "error" retries the failed turn with the
+    // queued message (which clears the error) instead of stranding the queue. "submitted"/
+    // "streaming" are in-flight: reset the latch and hold.
     useEffect(() => {
-        if (status !== "ready") {
+        if (!settled) {
             releasingRef.current = false
             return
         }
         if (releasingRef.current || queued.length === 0) return
-        if (!canReleaseQueuedMessage(status, messages)) return
+        if (!canReleaseNow) return
         releasingRef.current = true
         const [head, ...rest] = queued
         setQueued(rest)
         sendQueued(head)
-    }, [status, messages, queued, sendQueued])
+    }, [settled, canReleaseNow, queued, sendQueued])
 
     return {
         queued,

--- a/web/oss/src/components/AgentChatSlice/state/turnCaptures.ts
+++ b/web/oss/src/components/AgentChatSlice/state/turnCaptures.ts
@@ -1,0 +1,24 @@
+import {appendCapped, type TurnRequestCapture} from "@agenta/playground"
+import {atom} from "jotai"
+import {atomFamily} from "jotai/utils"
+
+/** Keep the last N turns' captures per session (ephemeral; debugging surface, not persisted). */
+const MAX_TURNS = 20
+
+const capturesBySessionAtom = atom<Record<string, TurnRequestCapture[]>>({})
+
+/** Write one send's capture (called from the transport at send time). */
+export const captureTurnRequestAtom = atom(null, (get, set, capture: TurnRequestCapture) => {
+    if (!capture.sessionId) return
+    const all = get(capturesBySessionAtom)
+    const list = all[capture.sessionId] ?? []
+    set(capturesBySessionAtom, {
+        ...all,
+        [capture.sessionId]: appendCapped(list, capture, MAX_TURNS),
+    })
+})
+
+/** Read all captures for a session. */
+export const sessionCapturesAtomFamily = atomFamily((sessionId: string) =>
+    atom((get) => get(capturesBySessionAtom)[sessionId] ?? []),
+)

--- a/web/oss/src/components/AgentChatSlice/state/turnInspector.ts
+++ b/web/oss/src/components/AgentChatSlice/state/turnInspector.ts
@@ -1,0 +1,10 @@
+import {atom} from "jotai"
+
+/** Which assistant turn the Turn Inspector is open on. `null` = closed. */
+export interface TurnInspectorTarget {
+    sessionId: string
+    /** The assistant turn's message id (its parts drive the Timeline tab). */
+    assistantMessageId: string
+}
+
+export const turnInspectorAtom = atom<TurnInspectorTarget | null>(null)

--- a/web/oss/src/components/Layout/assets/Breadcrumbs.tsx
+++ b/web/oss/src/components/Layout/assets/Breadcrumbs.tsx
@@ -81,7 +81,7 @@ const BreadcrumbContainer = memo(({appTheme}: {appTheme: string}) => {
         <section
             className={clsx(
                 classes.breadcrumbContainer,
-                "sticky top-0 z-[100] bg-[var(--ag-c-FFFFFF)] max-w-full overflow-hidden gap-4 !px-3",
+                "sticky top-0 z-[100] bg-[var(--ag-surface-raised)] border-0 border-b border-solid border-[var(--ag-surface-divider)] max-w-full overflow-hidden gap-4 !px-3",
             )}
         >
             <div className="flex flex-nowrap items-center shrink-1 min-w-0">

--- a/web/oss/src/components/Playground/Components/AgentRevisionSelector/index.tsx
+++ b/web/oss/src/components/Playground/Components/AgentRevisionSelector/index.tsx
@@ -1,0 +1,88 @@
+import {useCallback, useMemo} from "react"
+
+import {isLocalDraftId} from "@agenta/entities/shared"
+import {workflowMolecule} from "@agenta/entities/workflow"
+import {createWorkflowRevisionAdapter} from "@agenta/entity-ui/selection"
+import {playgroundController} from "@agenta/playground"
+import {Tooltip} from "antd"
+import {useAtomValue, useSetAtom} from "jotai"
+import dynamic from "next/dynamic"
+
+import {routerAppIdAtom} from "@/oss/state/app/atoms/fetcher"
+
+const SelectVariant = dynamic(() => import("../Menus/SelectVariant"), {ssr: false})
+
+/**
+ * The agent playground's revision selector — the borderless "variant ⌄" picker plus a compact
+ * `v{n} ● Draft/Saved` status. Lifted out of the config-panel header (PlaygroundVariantConfigHeader)
+ * so the page header can host it next to the agent's name. Variant-scoped: it derives everything
+ * from `variantId`, so it stays in sync wherever it's rendered.
+ */
+const AgentRevisionSelector = ({variantId}: {variantId: string}) => {
+    // Project-scoped playground (no app in URL) browses all workflows; app-scoped stays scoped.
+    const appId = useAtomValue(routerAppIdAtom)
+    const isProjectScoped = !appId
+
+    const runnableData = useAtomValue(workflowMolecule.selectors.data(variantId || ""))
+    const isDirty = useAtomValue(workflowMolecule.selectors.isDirty(variantId || ""))
+    const isLocalDraftVariant = variantId ? isLocalDraftId(variantId) : false
+
+    const _variantId = runnableData?.id ?? null
+    const variantRevision = (runnableData?.version as number | null) ?? null
+    const hasChanges = isDirty
+
+    // App browse picker (project-scoped only) — skip-variant, non-evaluator.
+    const appOnlyAdapter = useMemo(
+        () =>
+            createWorkflowRevisionAdapter({
+                skipVariantLevel: true,
+                excludeRevisionZero: true,
+                flags: {is_evaluator: false, is_feedback: false},
+                parentLabel: "Application",
+            }),
+        [],
+    )
+
+    const switchEntity = useSetAtom(playgroundController.actions.switchEntity)
+    const handleSwitchVariant = useCallback(
+        (newVariantId: string) => {
+            switchEntity({currentEntityId: variantId || "", newEntityId: newVariantId})
+        },
+        [switchEntity, variantId],
+    )
+
+    if (!variantId || isLocalDraftVariant) return null
+
+    return (
+        <div className="flex min-w-0 items-center gap-2">
+            <SelectVariant
+                mode={isProjectScoped ? "browse" : "scoped"}
+                customBrowseAdapter={isProjectScoped ? appOnlyAdapter : undefined}
+                showCreateNew
+                onChange={(value) => handleSwitchVariant(value)}
+                value={_variantId ?? undefined}
+                borderlessTrigger
+            />
+            {variantRevision !== null && variantRevision !== undefined && (
+                <span className="rounded bg-[var(--ant-color-fill-secondary)] px-1.5 py-0.5 text-xs text-[var(--ant-color-text-secondary)]">
+                    v{variantRevision}
+                </span>
+            )}
+            <Tooltip title={hasChanges ? "Draft — unsaved changes" : "Saved"}>
+                <span className="flex items-center gap-1.5 text-xs text-[var(--ant-color-text-tertiary)]">
+                    <span
+                        className="h-[7px] w-[7px] rounded-full"
+                        style={{
+                            backgroundColor: hasChanges
+                                ? "var(--ant-color-warning)"
+                                : "var(--ant-color-success)",
+                        }}
+                    />
+                    {hasChanges ? "Draft" : "Saved"}
+                </span>
+            </Tooltip>
+        </div>
+    )
+}
+
+export default AgentRevisionSelector

--- a/web/oss/src/components/Playground/Components/MainLayout/index.tsx
+++ b/web/oss/src/components/Playground/Components/MainLayout/index.tsx
@@ -277,7 +277,13 @@ const PlaygroundMainView = ({
             className={clsx("flex flex-col grow h-full overflow-hidden", className)}
             {...divProps}
         >
-            <div className="w-full max-h-full h-full grow relative overflow-hidden">
+            <div
+                className={clsx("w-full max-h-full h-full grow relative overflow-hidden", {
+                    // Agent Build view: recess the whole workspace to a near-black/soft-grey base so
+                    // the raised Config panel and the Chat canvas read as two distinct surfaces.
+                    "ag-app-ground": isAgentConfig,
+                })}
+            >
                 <Splitter
                     key={`${splitterKey}-splitter`}
                     className={clsx("h-full playground-splitter", {
@@ -305,6 +311,8 @@ const PlaygroundMainView = ({
                                     "grow w-full h-full overflow-y-auto": !isComparisonView,
                                     "grow w-full h-full overflow-x-auto flex [&::-webkit-scrollbar]:w-0":
                                         isComparisonView,
+                                    // Config = the raised authoring surface.
+                                    "ag-panel-raised": isAgentConfig,
                                 },
                             ])}
                         >
@@ -364,6 +372,8 @@ const PlaygroundMainView = ({
                                         !isComparisonView,
                                     "grow w-full h-full overflow-auto [&::-webkit-scrollbar]:w-0":
                                         isComparisonView,
+                                    // Chat = the recessed canvas the message/composer surfaces sit on.
+                                    "ag-canvas": isAgentConfig,
                                 },
                             ])}
                         >

--- a/web/oss/src/components/Playground/Components/MainLayout/index.tsx
+++ b/web/oss/src/components/Playground/Components/MainLayout/index.tsx
@@ -281,6 +281,9 @@ const PlaygroundMainView = ({
                 <Splitter
                     key={`${splitterKey}-splitter`}
                     className={clsx("h-full playground-splitter", {
+                        // Agent mode has no collapse pill (Build/Chat lives in the header), so the
+                        // drag handle needs its own discoverability treatment (a visible grip).
+                        "playground-splitter-agent": isAgentConfig,
                         "playground-splitter-collapsed": configCollapsed,
                         "playground-splitter-animated": animateSplit,
                     })}

--- a/web/oss/src/components/Playground/Components/PlaygroundHeader/index.tsx
+++ b/web/oss/src/components/Playground/Components/PlaygroundHeader/index.tsx
@@ -22,7 +22,7 @@ import {
     type AgentChannelMode,
 } from "@agenta/playground"
 import {usePlaygroundLayout} from "@agenta/playground-ui/hooks"
-import {bgColors, textColors} from "@agenta/ui"
+import {textColors} from "@agenta/ui"
 import {VersionBadge} from "@agenta/ui/components/presentational"
 import {CloseOutlined, DownOutlined, MoreOutlined} from "@ant-design/icons"
 import {Check, Gavel, GearSix, PencilSimple, Plus, Robot} from "@phosphor-icons/react"
@@ -538,8 +538,7 @@ const PlaygroundHeader: React.FC<PlaygroundHeaderProps> = ({className, ...divPro
         <>
             <div
                 className={clsx(
-                    "flex items-center justify-between gap-4 px-2.5 py-2",
-                    bgColors.active,
+                    "flex items-center justify-between gap-4 px-2.5 py-2 bg-[var(--ag-surface-raised)] border-0 border-b border-solid border-[var(--ag-surface-divider)]",
                     className,
                 )}
                 {...divProps}

--- a/web/oss/src/components/Playground/Components/PlaygroundHeader/index.tsx
+++ b/web/oss/src/components/Playground/Components/PlaygroundHeader/index.tsx
@@ -51,6 +51,7 @@ import {writePlaygroundSelectionToQuery} from "@/oss/state/url/playground"
 import {currentWorkflowAtom, currentWorkflowContextAtom} from "@/oss/state/workflow"
 import {workspaceMemberByIdFamily} from "@/oss/state/workspace/atoms/selectors"
 
+import AgentRevisionSelector from "../AgentRevisionSelector"
 import type {BaseContainerProps} from "../types"
 
 import RunEvaluationButton from "./RunEvaluationButton"
@@ -569,15 +570,21 @@ const PlaygroundHeader: React.FC<PlaygroundHeaderProps> = ({className, ...divPro
                         </Dropdown>
                     ) : null}
                     {isAgentWorkflow ? (
-                        <div className="flex items-center gap-2">
+                        <div className="flex min-w-0 items-center gap-2">
                             <Tooltip title="Agent">
                                 <span className="flex h-6 w-6 shrink-0 items-center justify-center rounded-md bg-[var(--ant-color-fill-secondary)] text-[var(--ag-c-13C2C2)]">
                                     <Robot size={15} weight="fill" />
                                 </span>
                             </Tooltip>
-                            <Typography className="whitespace-nowrap text-[16px] leading-[18px] font-[600]">
+                            <Typography className="truncate whitespace-nowrap text-[16px] leading-[18px] font-[600]">
                                 {currentWorkflow?.name || "Agent"}
                             </Typography>
+                            {rootEntityId ? (
+                                <>
+                                    <Divider orientation="vertical" className="!mx-1 h-5" />
+                                    <AgentRevisionSelector variantId={rootEntityId} />
+                                </>
+                            ) : null}
                         </div>
                     ) : (
                         <Typography className="whitespace-nowrap text-[16px] leading-[18px] font-[600]">

--- a/web/oss/src/components/Playground/Components/PlaygroundVariantConfig/assets/PlaygroundVariantConfigHeader.tsx
+++ b/web/oss/src/components/Playground/Components/PlaygroundVariantConfig/assets/PlaygroundVariantConfigHeader.tsx
@@ -176,84 +176,71 @@ const PlaygroundVariantConfigHeader = ({
             {...divProps}
         >
             <div className="flex items-center gap-2 grow min-w-0 overflow-hidden">
-                {!embedded && !isLocalDraftVariant && (
-                    <SelectVariant
-                        mode={isProjectScoped ? "browse" : "scoped"}
-                        customBrowseAdapter={isProjectScoped ? browseAdapter : undefined}
-                        showCreateNew={!isEvaluatorEntity}
-                        onChange={(value) => handleSwitchVariant?.(value)}
-                        value={_variantId ?? undefined}
-                        borderlessTrigger={isAgent}
-                    />
-                )}
-                {/* Local draft: show Draft tag then source revision info */}
-                {isLocalDraftVariant && (
-                    <div className="flex items-center gap-2 min-w-0">
-                        <DraftTag />
-                        {variantRevision !== null && variantRevision !== undefined && (
-                            <span className="text-gray-500 whitespace-nowrap truncate min-w-0">
-                                from {rawVariantName} v{variantRevision}
-                            </span>
-                        )}
-                    </div>
-                )}
-                {/* Don't show VariantDetailsWithStatus for local drafts — source info is shown above */}
-                {!isLocalDraftVariant && (
+                {isAgent && !embedded ? (
+                    // Agent playground: the revision selector moved up to the page header (next to the
+                    // agent name), so this bar reads as the config panel's "Configuration" header.
+                    <span className="text-[13px] font-semibold text-[var(--ant-color-text)]">
+                        Configuration
+                    </span>
+                ) : (
                     <>
-                        {embedded && !runnableData ? (
-                            <div className="flex items-center gap-2 grow mr-4">
-                                <span className="text-sm text-gray-700 truncate">
-                                    {rawVariantName as any}
-                                </span>
-                                {variantRevision !== null && variantRevision !== undefined && (
-                                    <span className="text-xs px-2 py-0.5 rounded bg-gray-100 text-gray-700">
-                                        rev {String(variantRevision)}
-                                    </span>
-                                )}
-                            </div>
-                        ) : isAgent && !embedded ? (
-                            // Compact agent status: a version chip + a state dot, instead of the
-                            // verbose "Last modified" row. Discard stays available in the kebab.
-                            <div className="mr-4 flex items-center gap-2">
-                                {variantRevision !== null && variantRevision !== undefined && (
-                                    <span className="rounded bg-[var(--ant-color-fill-secondary)] px-1.5 py-0.5 text-xs text-[var(--ant-color-text-secondary)]">
-                                        v{variantRevision}
-                                    </span>
-                                )}
-                                <Tooltip title={hasChanges ? "Draft — unsaved changes" : "Saved"}>
-                                    <span className="flex items-center gap-1.5 text-xs text-[var(--ant-color-text-tertiary)]">
-                                        <span
-                                            className="h-[7px] w-[7px] rounded-full"
-                                            style={{
-                                                backgroundColor: hasChanges
-                                                    ? "var(--ant-color-warning)"
-                                                    : "var(--ant-color-success)",
-                                            }}
-                                        />
-                                        {hasChanges ? "Draft" : "Saved"}
-                                    </span>
-                                </Tooltip>
-                            </div>
-                        ) : (
-                            <VariantDetailsWithStatus
-                                className="mr-4 gap-2"
-                                revision={variantRevision ?? null}
-                                variant={variantMin}
-                                showBadges
-                                hideName={!embedded}
-                                variantName={rawVariantName as any}
-                                showRevisionAsTag={true}
-                                hasChanges={hasChanges}
-                                isLatest={isLatestRevision}
-                                onDiscardDraft={handleRevisionDiscardDraft}
+                        {!embedded && !isLocalDraftVariant && (
+                            <SelectVariant
+                                mode={isProjectScoped ? "browse" : "scoped"}
+                                customBrowseAdapter={isProjectScoped ? browseAdapter : undefined}
+                                showCreateNew={!isEvaluatorEntity}
+                                onChange={(value) => handleSwitchVariant?.(value)}
+                                value={_variantId ?? undefined}
                             />
                         )}
+                        {/* Local draft: show Draft tag then source revision info */}
+                        {isLocalDraftVariant && (
+                            <div className="flex items-center gap-2 min-w-0">
+                                <DraftTag />
+                                {variantRevision !== null && variantRevision !== undefined && (
+                                    <span className="text-gray-500 whitespace-nowrap truncate min-w-0">
+                                        from {rawVariantName} v{variantRevision}
+                                    </span>
+                                )}
+                            </div>
+                        )}
+                        {/* Don't show VariantDetailsWithStatus for local drafts — source info above */}
+                        {!isLocalDraftVariant && (
+                            <>
+                                {embedded && !runnableData ? (
+                                    <div className="flex items-center gap-2 grow mr-4">
+                                        <span className="text-sm text-gray-700 truncate">
+                                            {rawVariantName as any}
+                                        </span>
+                                        {variantRevision !== null &&
+                                            variantRevision !== undefined && (
+                                                <span className="text-xs px-2 py-0.5 rounded bg-gray-100 text-gray-700">
+                                                    rev {String(variantRevision)}
+                                                </span>
+                                            )}
+                                    </div>
+                                ) : (
+                                    <VariantDetailsWithStatus
+                                        className="mr-4 gap-2"
+                                        revision={variantRevision ?? null}
+                                        variant={variantMin}
+                                        showBadges
+                                        hideName={!embedded}
+                                        variantName={rawVariantName as any}
+                                        showRevisionAsTag={true}
+                                        hasChanges={hasChanges}
+                                        isLatest={isLatestRevision}
+                                        onDiscardDraft={handleRevisionDiscardDraft}
+                                    />
+                                )}
+                            </>
+                        )}
+                        {evaluatorLabel && !embedded && (
+                            <span className="text-xs px-2 py-0.5 rounded bg-blue-50 text-blue-600 flex-shrink-0">
+                                {evaluatorLabel}
+                            </span>
+                        )}
                     </>
-                )}
-                {evaluatorLabel && !embedded && (
-                    <span className="text-xs px-2 py-0.5 rounded bg-blue-50 text-blue-600 flex-shrink-0">
-                        {evaluatorLabel}
-                    </span>
                 )}
             </div>
             <div className="flex items-center justify-end gap-2 shrink-0 grow min-w-0">

--- a/web/oss/src/components/Sidebar/Sidebar.tsx
+++ b/web/oss/src/components/Sidebar/Sidebar.tsx
@@ -90,7 +90,7 @@ const Sidebar: React.FC<{showSettingsView?: boolean; lastPath?: string}> = ({
     }, [openKeys[0]])
 
     return (
-        <div className="border-0 border-r border-solid border-gray-100">
+        <div className="border-0 border-r border-solid border-[var(--ag-surface-divider)]">
             <Sider
                 theme={appTheme}
                 className="sticky top-0 bottom-0 h-screen bg-[var(--ag-sidebar-bg)]"

--- a/web/oss/src/styles/globals.css
+++ b/web/oss/src/styles/globals.css
@@ -154,6 +154,60 @@ body {
     opacity: 0.4 !important;
 }
 
+/* Agent playground: the collapse pill is disabled (Build/Chat switch lives in the header), so the
+   drag handle is the ONLY resize affordance and must be discoverable on its own. Render a persistent
+   centered grip on the divider — neutral at rest, then an accent TINT + taller on hover/drag — so it
+   reads as a draggable handle without turning into a loud bar. Geometry is fully specified so it
+   doesn't depend on antd's default pseudo-element placement. */
+.playground-splitter-agent .ant-splitter-bar-dragger::before {
+    content: "" !important;
+    position: absolute !important;
+    top: 0 !important;
+    bottom: 0 !important;
+    left: 50% !important;
+    right: auto !important;
+    width: 2px !important;
+    height: auto !important;
+    border-radius: 0 !important;
+    transform: translateX(-50%) !important;
+    background: var(--ag-colorBorderSecondary) !important;
+}
+.playground-splitter-agent .ant-splitter-bar-dragger::after {
+    content: "" !important;
+    position: absolute !important;
+    top: 50% !important;
+    bottom: auto !important;
+    left: 50% !important;
+    right: auto !important;
+    width: 4px !important;
+    height: 24px !important;
+    border-radius: 9999px !important;
+    transform: translate(-50%, -50%) !important;
+    background: var(--ag-colorTextTertiary) !important;
+    transition:
+        background 150ms ease,
+        opacity 150ms ease,
+        height 150ms ease;
+}
+/* Hover + active: the full-height DIVIDER only strengthens to a neutral border tone — a long line in
+   the accent colour reads as too loud. The small GRIP takes the accent (`colorPrimary`), softened to a
+   TINT via opacity so it stays a clear-but-quiet handle in both themes (the tinted-primary border
+   token blended into the dark divider; the full colour was too strong). `:not(-active)` mirrors the
+   base `.playground-splitter` hover rule's specificity so we win the tie by source order — otherwise
+   that base rule would swap the divider to a faint fill on hover (the fade). */
+.playground-splitter-agent
+    .ant-splitter-bar-dragger:hover:not(.ant-splitter-bar-dragger-active)::before,
+.playground-splitter-agent .ant-splitter-bar-dragger-active::before {
+    background: var(--ag-colorBorder) !important;
+}
+.playground-splitter-agent
+    .ant-splitter-bar-dragger:hover:not(.ant-splitter-bar-dragger-active)::after,
+.playground-splitter-agent .ant-splitter-bar-dragger-active::after {
+    height: 36px !important;
+    background: var(--ag-colorPrimary) !important;
+    opacity: 0.7 !important;
+}
+
 /* Build/Chat mode transitions: ease the panels' flex-basis (config → 0, chat → full) and fade the
    inert split bar instead of snapping. `-animated` is added by MainLayout only around a toggle (off
    during drag, so resizing stays 1:1). Gated on `prefers-reduced-motion` for parity with the rail's

--- a/web/oss/src/styles/globals.css
+++ b/web/oss/src/styles/globals.css
@@ -207,6 +207,82 @@ body {
     background: var(--ag-colorPrimary) !important;
     opacity: 0.7 !important;
 }
+/* Agent playground: the divider is the GUTTER between the raised Config panel and the recessed
+   Chat canvas — a real ~12px channel (not a hairline) that says "two workspaces". Widen the bar and
+   tint it the near-black/soft-grey gutter tone; the grip pseudo-elements above still read as the
+   handle. */
+.playground-splitter-agent .ant-splitter-bar {
+    background: var(--ag-surface-gutter) !important;
+    flex-basis: 12px !important;
+    width: 12px !important;
+}
+
+/* ── Agent Playground surface classes ──────────────────────────────────────────────────────────
+   Semantic surfaces for the panel-contrast treatment. Multi-value shadows + fill + border are set
+   together here (more reliable than Tailwind arbitrary-value shadows) and reference the per-theme
+   ladder in theme-variables.css. Roles invert by theme automatically via the token values. */
+.ag-app-ground {
+    background: var(--ag-surface-app);
+}
+.ag-panel-raised {
+    background: var(--ag-surface-raised);
+    box-shadow: var(--ag-surface-raised-shadow);
+}
+.ag-canvas {
+    background: var(--ag-surface-canvas);
+}
+.ag-surface-card {
+    background: var(--ag-surface-card);
+    border: 1px solid var(--ag-surface-card-border);
+    box-shadow: var(--ag-surface-card-shadow);
+}
+.ag-surface-chat {
+    background: var(--ag-surface-chat);
+    border: 1px solid var(--ag-surface-chat-border);
+    box-shadow: var(--ag-surface-chat-shadow);
+}
+.ag-surface-inset {
+    background: var(--ag-surface-inset);
+    border: 1px solid var(--ag-surface-inset-border);
+}
+/* Right-docked Turn inspector: a raised panel floating above the recessed chat canvas — raised
+   tone + a left seam + a soft left-edge shadow so it reads as sitting on top. */
+.ag-inspector-panel {
+    background: var(--ag-surface-raised);
+    border-left: 1px solid var(--ag-surface-divider);
+    box-shadow: var(--ag-surface-inspector-shadow);
+}
+.ag-surface-chip {
+    background: var(--ag-surface-chip);
+    border: 1px solid var(--ag-surface-chip-border);
+}
+.ag-surface-error-well {
+    background: var(--ag-surface-error-well);
+    border: 1px solid var(--ag-surface-error-well-border);
+}
+/* Status chips — the only semantic colour in the treatment (kept subtle). */
+.ag-status-error {
+    background: var(--ag-status-error-bg);
+    border: 1px solid var(--ag-status-error-border);
+    color: var(--ag-status-error-text);
+}
+.ag-status-success {
+    background: var(--ag-status-success-bg);
+    border: 1px solid var(--ag-status-success-border);
+    color: var(--ag-status-success-text);
+}
+/* List-row hover fill (session rows, etc.). */
+.ag-row-hover:hover {
+    background: var(--ag-surface-row-hover);
+}
+/* Selected list row — a lifted card surface with a brand accent bar on the left. Pairs with a base
+   `border border-solid` on the row (this sets the colour + a 2px accent left border + shadow). */
+.ag-surface-selected {
+    background: var(--ag-surface-card);
+    border-color: var(--ag-surface-card-border);
+    border-left: 2px solid var(--ag-surface-accent);
+    box-shadow: var(--ag-surface-card-shadow);
+}
 
 /* Build/Chat mode transitions: ease the panels' flex-basis (config → 0, chat → full) and fade the
    inert split bar instead of snapping. `-animated` is added by MainLayout only around a toggle (off

--- a/web/oss/src/styles/theme-variables.css
+++ b/web/oss/src/styles/theme-variables.css
@@ -477,10 +477,11 @@
    one step darker than the content surface (#141414) so the nav rail recedes
    and reads as distinct chrome instead of merging into a single flat panel. */
 :root {
-    --ag-sidebar-bg: #ffffff;
+    /* Sidebar is raised chrome — one continuous surface with the top bars + config panel. */
+    --ag-sidebar-bg: var(--ag-surface-raised);
 }
 .dark {
-    --ag-sidebar-bg: #0d0d0d;
+    --ag-sidebar-bg: var(--ag-surface-raised);
 }
 
 /* Evaluations "Application" cell (app name + variant slug + version chip). The
@@ -624,4 +625,72 @@
     --ag-slate-800: rgba(255, 255, 255, 0.75);
     --ag-slate-900: var(--ant-color-text);
     --ag-slate-950: rgba(255, 255, 255, 0.92);
+}
+
+/**
+ * Agent Playground surface ladder — panel-contrast treatment.
+ *
+ * The Build view is two workspaces (Configuration = authoring, Chat = observing) that used
+ * to share one flat background. These tokens separate them with elevation + containment,
+ * not hue. The relationship INVERTS by theme: the raised surface is lighter than the canvas
+ * in dark mode, and white over soft-grey in light mode — so the values differ per theme but
+ * the roles are the same. Values from the approved mockup (Playground.dc.html "elevated").
+ * Scoped to the playground panels; the rest of the app keeps the antd semantic tokens above.
+ */
+:root {
+    --ag-surface-app: #e9ebee; /* root behind the columns */
+    --ag-surface-gutter: #dfe1e5; /* channel between the two columns */
+    --ag-surface-divider: #ededee; /* hairline between chrome planes (sidebar edge, bar bottoms) */
+    --ag-surface-raised: #ffffff; /* Configuration panel */
+    --ag-surface-raised-shadow: 0 1px 3px rgba(16, 18, 22, 0.05);
+    --ag-surface-card: #ffffff; /* a config section */
+    --ag-surface-card-border: #e7e8eb;
+    --ag-surface-card-shadow: 0 1px 2px rgba(16, 18, 22, 0.06);
+    --ag-surface-inset: #f3f4f6; /* nested well (AGENTS.md file, Slack row, code block) */
+    --ag-surface-inset-border: #e7e8eb;
+    --ag-surface-canvas: #f4f5f7; /* recessed Chat canvas */
+    --ag-surface-chat: #ffffff; /* a surface on the canvas (bubble, composer, approval) */
+    --ag-surface-chat-border: #e7e8eb;
+    --ag-surface-chat-shadow: 0 1px 2px rgba(16, 18, 22, 0.06);
+    --ag-surface-inspector-shadow: -8px 0 24px rgba(16, 18, 22, 0.08); /* raised right-docked panel */
+    --ag-surface-chip: #edeef0; /* neutral chip/badge (open badge, code chip) */
+    --ag-surface-chip-border: #e3e4e6;
+    --ag-surface-accent: #c2d54a; /* brand accent (selected-row bar) — constant across themes */
+    --ag-surface-row-hover: #f3f4f6; /* list-row hover fill */
+    --ag-surface-error-well: #fdf3f3; /* faintly error-tinted well (a failed tool payload) */
+    --ag-surface-error-well-border: #f3d0ce;
+    --ag-status-error-bg: #fdecec; /* status chip — the only place semantic colour is used */
+    --ag-status-error-border: #f5c6c4;
+    --ag-status-error-text: #c0362f;
+    --ag-status-success-bg: #eaf6ec;
+    --ag-status-success-border: #bfe3c6;
+    --ag-status-success-text: #2e7d3a;
+}
+.dark {
+    --ag-surface-app: #0a0a0c;
+    --ag-surface-gutter: #060607;
+    --ag-surface-divider: #1c1c1f;
+    --ag-surface-raised: #1a1b1e;
+    --ag-surface-raised-shadow: inset 0 1px 0 rgba(255, 255, 255, 0.045);
+    --ag-surface-card: #212327;
+    --ag-surface-card-border: #2d3036;
+    --ag-surface-card-shadow: 0 1px 2px rgba(0, 0, 0, 0.4), inset 0 1px 0 rgba(255, 255, 255, 0.03);
+    --ag-surface-inset: #111214;
+    --ag-surface-inset-border: #26282d;
+    --ag-surface-canvas: #0c0c0e;
+    --ag-surface-chat: #17181b;
+    --ag-surface-chat-border: #26282d;
+    --ag-surface-chat-shadow: 0 1px 3px rgba(0, 0, 0, 0.45);
+    --ag-surface-inspector-shadow: -8px 0 24px rgba(0, 0, 0, 0.35);
+    --ag-surface-chip: #2a2a2e;
+    --ag-surface-chip-border: #303035;
+    --ag-surface-row-hover: #212327;
+    --ag-surface-error-well: #1e1416;
+    --ag-surface-error-well-border: #4a2226;
+    --ag-status-error-bg: #2a1618;
+    --ag-status-error-border: #5a2a2e;
+    --ag-status-error-text: #f0857c;
+    --ag-status-success-bg: #16231a;
+    --ag-status-success-border: #2c4a34;
+    --ag-status-success-text: #7fcf8f;
 }

--- a/web/packages/agenta-entity-ui/src/DrillInView/SchemaControls/AgentTemplateControl.tsx
+++ b/web/packages/agenta-entity-ui/src/DrillInView/SchemaControls/AgentTemplateControl.tsx
@@ -619,6 +619,10 @@ export function AgentTemplateControl({
         inlineContent?: React.ReactNode
     }[]
 
+    // Each config section is a contained card on the raised Config panel — the surface tokens give
+    // it depth against the panel (see theme-variables.css "Agent Playground surface ladder").
+    const sectionCardClass = "ag-surface-card rounded-[11px] px-4"
+
     return (
         <div className={cn("flex flex-col", className)}>
             {sections.length === 0 ? (
@@ -683,28 +687,31 @@ export function AgentTemplateControl({
                             onOpen={s.onOpen}
                             collapsible={false}
                             noDivider
-                            className="rounded border border-solid border-[var(--ag-c-EAEFF5,#eaeff5)] px-3"
+                            className={sectionCardClass}
                         >
                             {s.content}
                         </ConfigAccordionSection>
                     ))}
                 </div>
             ) : (
-                sections.map((s, index) => (
-                    <ConfigAccordionSection
-                        key={s.key}
-                        icon={s.icon}
-                        title={s.title}
-                        summary={s.summary}
-                        extra={s.extra}
-                        indicator={s.indicator}
-                        onOpen={s.onOpen}
-                        defaultOpen={s.defaultOpen}
-                        noDivider={index === sections.length - 1}
-                    >
-                        {s.content}
-                    </ConfigAccordionSection>
-                ))
+                <div className="flex flex-col gap-3 pt-1">
+                    {sections.map((s) => (
+                        <ConfigAccordionSection
+                            key={s.key}
+                            icon={s.icon}
+                            title={s.title}
+                            summary={s.summary}
+                            extra={s.extra}
+                            indicator={s.indicator}
+                            onOpen={s.onOpen}
+                            defaultOpen={s.defaultOpen}
+                            noDivider
+                            className={sectionCardClass}
+                        >
+                            {s.content}
+                        </ConfigAccordionSection>
+                    ))}
+                </div>
             )}
 
             {editing

--- a/web/packages/agenta-entity-ui/src/DrillInView/SchemaControls/AgentTemplateControl.tsx
+++ b/web/packages/agenta-entity-ui/src/DrillInView/SchemaControls/AgentTemplateControl.tsx
@@ -39,6 +39,7 @@ import {
     Wrench,
 } from "@phosphor-icons/react"
 import {Button, Tabs, Tooltip, Typography} from "antd"
+import deepEqual from "fast-deep-equal"
 import {useAtomValue, useStore} from "jotai"
 
 import {useOptionalDrillIn} from "../components/MoleculeDrillInContext"
@@ -131,35 +132,60 @@ export function AgentTemplateControl({
         setEditingInstruction({filename})
     }, [])
 
-    // Section drawers (Model & harness, Advanced). Edits apply live; a config snapshot taken on open
-    // is restored on Cancel, giving the same draft-then-save feel as the item drawers.
+    // Section drawers (Model & harness, Advanced) use a SCOPED draft: edits are buffered locally and
+    // relayed to the entity only on Save (Cancel discards; Save is gated on a real diff vs. the value
+    // we opened with). The build-kit enable toggle lives OUTSIDE the config (a persisted atom), so it
+    // is buffered alongside the config draft and committed to the atom on Save.
     const [openSection, setOpenSection] = useState<null | "model-harness" | "advanced">(null)
-    const sectionSnapshot = useRef<Record<string, unknown> | null>(null)
-    // Snapshot + restore for the build-kit enabled atom (lives outside config; needs separate tracking).
+    const [draftConfig, setDraftConfig] = useState<Record<string, unknown> | null>(null)
+    const [draftBuildKit, setDraftBuildKit] = useState<boolean | null>(null)
+    const sectionBaseline = useRef<{config: Record<string, unknown>; buildKit: boolean} | null>(
+        null,
+    )
     const store = useStore()
     const revisionIdRef = useRef<string | null>(null)
-    const buildKitEnabledSnapshot = useRef<boolean | null>(null)
+    const applyDraftConfig = useCallback(
+        (next: Record<string, unknown>) => setDraftConfig(next),
+        [],
+    )
+    // Swallow writes from the draft hook while its drawer is closed (its body isn't rendered, so an
+    // internal auto-correction effect must not leak into `draftConfig`). The live `mh` handles any
+    // real auto-correction against the entity.
+    const noopConfigChange = useCallback(() => {}, [])
     const openSectionDrawer = useCallback(
         (key: "model-harness" | "advanced") => {
-            sectionSnapshot.current = value ?? {}
-            buildKitEnabledSnapshot.current = store.get(
+            const snapshotConfig = (value ?? {}) as Record<string, unknown>
+            const snapshotBuildKit = store.get(
                 workflowBuildKitEnabledAtomFamily(revisionIdRef.current ?? ""),
             )
+            setDraftConfig(snapshotConfig)
+            setDraftBuildKit(snapshotBuildKit)
+            sectionBaseline.current = {config: snapshotConfig, buildKit: snapshotBuildKit}
             setOpenSection(key)
         },
         [value, store],
     )
-    const cancelSection = useCallback(() => {
-        if (sectionSnapshot.current) onChange(sectionSnapshot.current)
-        if (buildKitEnabledSnapshot.current !== null) {
-            store.set(
-                workflowBuildKitEnabledAtomFamily(revisionIdRef.current ?? ""),
-                buildKitEnabledSnapshot.current,
-            )
-        }
+    const closeSectionDraft = useCallback(() => {
         setOpenSection(null)
-    }, [onChange, store])
-    const saveSection = useCallback(() => setOpenSection(null), [])
+        setDraftConfig(null)
+        setDraftBuildKit(null)
+        sectionBaseline.current = null
+    }, [])
+    // Cancel: nothing was written live, so just drop the draft.
+    const cancelSection = closeSectionDraft
+    const saveSection = useCallback(() => {
+        if (draftConfig !== null) onChange(draftConfig)
+        if (draftBuildKit !== null) {
+            store.set(workflowBuildKitEnabledAtomFamily(revisionIdRef.current ?? ""), draftBuildKit)
+        }
+        closeSectionDraft()
+    }, [draftConfig, draftBuildKit, onChange, store, closeSectionDraft])
+    // Enable Save only when the draft actually differs from what we opened with (config or build-kit).
+    const sectionDirty =
+        openSection !== null &&
+        sectionBaseline.current !== null &&
+        (!deepEqual(draftConfig, sectionBaseline.current.config) ||
+            draftBuildKit !== sectionBaseline.current.buildKit)
 
     // Layout (accordion / tabs / cards) is a global persisted preference; the panel only reads it.
     const layout = useAtomValue(agentTemplateLayoutAtom)
@@ -186,7 +212,29 @@ export function AgentTemplateControl({
 
     // Model & harness + Advanced own a lot of coupled, stateful logic (the model/connection state
     // feeds both sections), so they live in their own hook that returns the summaries + bodies.
+    //
+    // TWO instances, on purpose:
+    //  - `mh` is bound to the LIVE entity — it drives the accordion header summaries + the inline
+    //    tabs bodies. Keeping it live means a section header NEVER reflects the drawer's unsaved draft
+    //    (the reported bug: editing in the open drawer updated the background summary).
+    //  - `mhDraft` is bound to the DRAFT (config + build-kit) — it drives the OPEN section drawer's
+    //    body, so its forms edit the buffer and Save relays it to the entity/atom. When no drawer is
+    //    open its `onChange` is a no-op (and its body isn't rendered), so the extra hook is inert.
     const mh = useModelHarness({schema, config, onChange, disabled, withTooltip, revisionId})
+    const mhDraft = useModelHarness({
+        schema,
+        config: draftConfig ?? config,
+        onChange: openSection !== null ? applyDraftConfig : noopConfigChange,
+        disabled,
+        withTooltip,
+        revisionId,
+        buildKitEnabledOverride:
+            draftBuildKit !== null ? {value: draftBuildKit, onChange: setDraftBuildKit} : undefined,
+        // "Current" marks the SAVED harness (from the live entity), not the draft pick.
+        savedHarnessValue:
+            ((config.harness as Record<string, unknown> | undefined)?.kind as string | undefined) ??
+            null,
+    })
 
     // Tool add/remove (inline function, builtin, gateway, workflow reference) lives in its own hook.
     const {
@@ -561,10 +609,10 @@ export function AgentTemplateControl({
                 icon={<Cpu size={16} />}
                 onCancel={cancelSection}
                 onSave={saveSection}
-                disabled={disabled}
-                width={mh.modelHarnessDrawerWidth}
+                disabled={disabled || !sectionDirty}
+                width={mhDraft.modelHarnessDrawerWidth}
             >
-                {mh.modelHarnessDrawerBody}
+                {mhDraft.modelHarnessDrawerBody}
             </SectionDrawer>
 
             <SectionDrawer
@@ -573,10 +621,10 @@ export function AgentTemplateControl({
                 icon={<SlidersHorizontal size={16} />}
                 onCancel={cancelSection}
                 onSave={saveSection}
-                disabled={disabled}
+                disabled={disabled || !sectionDirty}
                 width={880}
             >
-                {mh.advancedDrawerBody}
+                {mhDraft.advancedDrawerBody}
             </SectionDrawer>
 
             {workflowReference?.enabled && (

--- a/web/packages/agenta-entity-ui/src/DrillInView/SchemaControls/ClaudePermissionsControl.tsx
+++ b/web/packages/agenta-entity-ui/src/DrillInView/SchemaControls/ClaudePermissionsControl.tsx
@@ -14,9 +14,9 @@
  */
 import {memo, useCallback, useMemo} from "react"
 
-import {LabeledField} from "@agenta/ui/components/presentational"
-import {cn} from "@agenta/ui/styles"
 import {Input, Select} from "antd"
+
+import {RailField, railInfoLabel} from "../../drawers/shared/RailField"
 
 type ClaudePermissionMode = "default" | "acceptEdits" | "plan" | "bypassPermissions"
 
@@ -34,8 +34,6 @@ export interface ClaudePermissionsControlProps {
     onChange: (value: Record<string, unknown>) => void
     /** Disable the control */
     disabled?: boolean
-    /** Additional CSS classes */
-    className?: string
     /**
      * The `default_mode` field schema (its `enum` + `title`/`description`). When provided, the mode
      * option set and the field label/description follow the template schema instead of the
@@ -82,7 +80,6 @@ export const ClaudePermissionsControl = memo(function ClaudePermissionsControl({
     value,
     onChange,
     disabled = false,
-    className,
     modeSchema,
 }: ClaudePermissionsControlProps) {
     const current = useMemo(() => readValue(value), [value])
@@ -137,8 +134,8 @@ export const ClaudePermissionsControl = memo(function ClaudePermissionsControl({
     )
 
     return (
-        <div className={cn("flex flex-col gap-2", className)}>
-            <LabeledField label={modeLabel} description={modeDescription} withTooltip>
+        <>
+            <RailField label={railInfoLabel(modeLabel, modeDescription)} align="center">
                 <Select<ClaudePermissionMode>
                     value={current.defaultMode ?? undefined}
                     onChange={(v) => write({defaultMode: v ?? null})}
@@ -147,14 +144,14 @@ export const ClaudePermissionsControl = memo(function ClaudePermissionsControl({
                     placeholder="Claude default"
                     allowClear
                     className="w-full"
-                    size="small"
                 />
-            </LabeledField>
+            </RailField>
 
-            <LabeledField
-                label="Allow rules"
-                description='Per-tool allow rules, one per line (e.g. "Read", "Bash(npm run:*)").'
-                withTooltip
+            <RailField
+                label={railInfoLabel(
+                    "Allow rules",
+                    'Per-tool allow rules, one per line (e.g. "Read", "Bash(npm run:*)").',
+                )}
             >
                 <Input.TextArea
                     value={current.allow.join("\n")}
@@ -162,14 +159,15 @@ export const ClaudePermissionsControl = memo(function ClaudePermissionsControl({
                     disabled={disabled}
                     placeholder={"Read\nBash(npm run:*)"}
                     rows={2}
-                    className="resize-y font-mono text-xs"
+                    className="resize-y font-mono"
                 />
-            </LabeledField>
+            </RailField>
 
-            <LabeledField
-                label="Ask rules"
-                description="Per-tool rules that prompt before use, one per line."
-                withTooltip
+            <RailField
+                label={railInfoLabel(
+                    "Ask rules",
+                    "Per-tool rules that prompt before use, one per line.",
+                )}
             >
                 <Input.TextArea
                     value={current.ask.join("\n")}
@@ -177,14 +175,15 @@ export const ClaudePermissionsControl = memo(function ClaudePermissionsControl({
                     disabled={disabled}
                     placeholder="Bash(rm:*)"
                     rows={2}
-                    className="resize-y font-mono text-xs"
+                    className="resize-y font-mono"
                 />
-            </LabeledField>
+            </RailField>
 
-            <LabeledField
-                label="Deny rules"
-                description="Per-tool rules that are always blocked, one per line."
-                withTooltip
+            <RailField
+                label={railInfoLabel(
+                    "Deny rules",
+                    "Per-tool rules that are always blocked, one per line.",
+                )}
             >
                 <Input.TextArea
                     value={current.deny.join("\n")}
@@ -192,9 +191,9 @@ export const ClaudePermissionsControl = memo(function ClaudePermissionsControl({
                     disabled={disabled}
                     placeholder={"Write\nmcp__server__tool"}
                     rows={2}
-                    className="resize-y font-mono text-xs"
+                    className="resize-y font-mono"
                 />
-            </LabeledField>
-        </div>
+            </RailField>
+        </>
     )
 })

--- a/web/packages/agenta-entity-ui/src/DrillInView/SchemaControls/McpServerFormView.tsx
+++ b/web/packages/agenta-entity-ui/src/DrillInView/SchemaControls/McpServerFormView.tsx
@@ -12,8 +12,9 @@
  */
 import {useState} from "react"
 
-import {LabeledField} from "@agenta/ui/components/presentational"
 import {Input, Select} from "antd"
+
+import {RailField, railInfoLabel} from "../../drawers/shared/RailField"
 
 import {CodeEditor} from "./CodeEditor"
 
@@ -95,16 +96,16 @@ export function McpServerFormView({value, onChange, disabled}: McpServerFormView
 
     return (
         <div className="flex flex-col gap-3">
-            <LabeledField label="Server name">
+            <RailField label="Server name" align="center">
                 <Input
                     value={server.name ?? ""}
                     onChange={(e) => set("name", e.target.value)}
                     placeholder="my-mcp-server"
                     disabled={disabled}
                 />
-            </LabeledField>
+            </RailField>
 
-            <LabeledField label="Transport">
+            <RailField label="Transport" align="center">
                 <Select
                     className="w-full"
                     value={transport}
@@ -115,19 +116,19 @@ export function McpServerFormView({value, onChange, disabled}: McpServerFormView
                         {label: "http (remote URL)", value: "http"},
                     ]}
                 />
-            </LabeledField>
+            </RailField>
 
             {transport === "stdio" ? (
                 <>
-                    <LabeledField label="Command">
+                    <RailField label="Command">
                         <CodeEditor
                             value={server.command ?? ""}
                             onChange={(v) => set("command", v)}
                             placeholder="npx"
                             disabled={disabled}
                         />
-                    </LabeledField>
-                    <LabeledField label="Arguments">
+                    </RailField>
+                    <RailField label="Arguments" align="center">
                         <Select
                             mode="tags"
                             className="w-full"
@@ -138,32 +139,33 @@ export function McpServerFormView({value, onChange, disabled}: McpServerFormView
                             open={false}
                             suffixIcon={null}
                         />
-                    </LabeledField>
+                    </RailField>
                 </>
             ) : (
-                <LabeledField label="Server URL">
+                <RailField label="Server URL" align="center">
                     <Input
                         value={server.url ?? ""}
                         onChange={(e) => set("url", e.target.value)}
                         placeholder="https://example.com/mcp"
                         disabled={disabled}
                     />
-                </LabeledField>
+                </RailField>
             )}
 
-            <LabeledField label="Environment" description="KEY=value per line" withTooltip>
+            <RailField label={railInfoLabel("Environment", "KEY=value per line")}>
                 <KeyValueLines
                     value={server.env}
                     onChange={(env) => set("env", Object.keys(env).length ? env : undefined)}
                     placeholder={"NODE_ENV=production"}
                     disabled={disabled}
                 />
-            </LabeledField>
+            </RailField>
 
-            <LabeledField
-                label="Secrets"
-                description="Map an env var to a vault secret name: ENV_VAR=secret_name"
-                withTooltip
+            <RailField
+                label={railInfoLabel(
+                    "Secrets",
+                    "Map an env var to a vault secret name: ENV_VAR=secret_name",
+                )}
             >
                 <KeyValueLines
                     value={server.secrets}
@@ -173,12 +175,14 @@ export function McpServerFormView({value, onChange, disabled}: McpServerFormView
                     placeholder={"API_KEY=my_api_key"}
                     disabled={disabled}
                 />
-            </LabeledField>
+            </RailField>
 
-            <LabeledField
-                label="Exposed tools"
-                description="Optional allowlist — leave empty to expose all of the server's tools"
-                withTooltip
+            <RailField
+                label={railInfoLabel(
+                    "Exposed tools",
+                    "Optional allowlist — leave empty to expose all of the server's tools",
+                )}
+                align="center"
             >
                 <Select
                     mode="tags"
@@ -190,7 +194,7 @@ export function McpServerFormView({value, onChange, disabled}: McpServerFormView
                     open={false}
                     suffixIcon={null}
                 />
-            </LabeledField>
+            </RailField>
         </div>
     )
 }

--- a/web/packages/agenta-entity-ui/src/DrillInView/SchemaControls/SandboxPermissionControl.tsx
+++ b/web/packages/agenta-entity-ui/src/DrillInView/SchemaControls/SandboxPermissionControl.tsx
@@ -16,8 +16,9 @@
  */
 import {useCallback, useMemo} from "react"
 
-import {LabeledField} from "@agenta/ui/components/presentational"
-import {Input, Select, Typography} from "antd"
+import {Input, Select} from "antd"
+
+import {RailField, railInfoLabel} from "../../drawers/shared/RailField"
 
 type NetworkMode = "on" | "off" | "allowlist"
 type FilesystemMode = "on" | "readonly" | "off"
@@ -56,6 +57,14 @@ const ENFORCEMENT_OPTIONS: {value: Enforcement; label: string}[] = [
     {value: "strict", label: "Strict (fail if unenforceable)"},
     {value: "best_effort", label: "Best effort"},
 ]
+
+const NETWORK_EGRESS_HINT =
+    "Outbound network access for the sandbox. Declared config; enforced by the runner."
+const ALLOWLIST_HINT = "CIDR ranges allowed for outbound egress, one per line (e.g. 10.0.0.0/8)."
+const FILESYSTEM_HINT =
+    "Declared filesystem access for the sandbox. Optional; leave unset for no declared boundary."
+const ENFORCEMENT_HINT =
+    "Strict fails the run when the boundary can't be applied; best effort continues."
 
 /** Read the value with the SDK's defaults applied, so the form is never blank. */
 function readValue(value: Record<string, unknown> | null | undefined) {
@@ -100,14 +109,8 @@ export function SandboxPermissionControl({
     )
 
     return (
-        <div className="flex flex-col gap-3 border-0 border-t border-solid border-[var(--ag-c-EAEFF5,#eaeff5)] pt-3">
-            <Typography.Text className="text-xs font-medium">Sandbox permissions</Typography.Text>
-
-            <LabeledField
-                label="Network egress"
-                description="Outbound network access for the sandbox. Declared config; enforced by the runner."
-                withTooltip
-            >
+        <>
+            <RailField label={railInfoLabel("Network egress", NETWORK_EGRESS_HINT)} align="center">
                 <Select<NetworkMode>
                     value={current.networkMode}
                     onChange={(v) => write({networkMode: v})}
@@ -115,14 +118,10 @@ export function SandboxPermissionControl({
                     disabled={disabled}
                     className="w-full"
                 />
-            </LabeledField>
+            </RailField>
 
             {current.networkMode === "allowlist" ? (
-                <LabeledField
-                    label="Allowlist"
-                    description="CIDR ranges allowed for outbound egress, one per line (e.g. 10.0.0.0/8)."
-                    withTooltip
-                >
+                <RailField label={railInfoLabel("Allowlist", ALLOWLIST_HINT)}>
                     <Input.TextArea
                         value={current.allowlist.join("\n")}
                         onChange={(e) =>
@@ -138,14 +137,10 @@ export function SandboxPermissionControl({
                         autoSize={{minRows: 2, maxRows: 6}}
                         className="font-mono"
                     />
-                </LabeledField>
+                </RailField>
             ) : null}
 
-            <LabeledField
-                label="Filesystem"
-                description="Declared filesystem access for the sandbox. Optional; leave unset for no declared boundary."
-                withTooltip
-            >
+            <RailField label={railInfoLabel("Filesystem", FILESYSTEM_HINT)} align="center">
                 <Select<FilesystemMode>
                     value={current.filesystem ?? undefined}
                     onChange={(v) => write({filesystem: (v as FilesystemMode | undefined) ?? null})}
@@ -155,13 +150,9 @@ export function SandboxPermissionControl({
                     allowClear
                     className="w-full"
                 />
-            </LabeledField>
+            </RailField>
 
-            <LabeledField
-                label="Enforcement"
-                description="Strict fails the run when the boundary can't be applied; best effort continues."
-                withTooltip
-            >
+            <RailField label={railInfoLabel("Enforcement", ENFORCEMENT_HINT)} align="center">
                 <Select<Enforcement>
                     value={current.enforcement}
                     onChange={(v) => write({enforcement: v})}
@@ -169,7 +160,7 @@ export function SandboxPermissionControl({
                     disabled={disabled}
                     className="w-full"
                 />
-            </LabeledField>
-        </div>
+            </RailField>
+        </>
     )
 }

--- a/web/packages/agenta-entity-ui/src/DrillInView/SchemaControls/agentTemplate/useBuildKit.tsx
+++ b/web/packages/agenta-entity-ui/src/DrillInView/SchemaControls/agentTemplate/useBuildKit.tsx
@@ -14,16 +14,18 @@
  * Kept beside useModelHarness (which owns the Advanced section) so the overlay and the user's own
  * sandbox/permission controls render together.
  */
-import {useMemo, useState} from "react"
+import {useMemo} from "react"
 
 import {
     workflowAgentTemplateOverlayAtomFamily,
     workflowBuildKitEnabledAtomFamily,
 } from "@agenta/entities/workflow"
-import {cn} from "@agenta/ui/styles"
-import {CaretRight, Warning, Wrench} from "@phosphor-icons/react"
+import {ConfigAccordionSection} from "@agenta/ui/components/presentational"
+import {Warning, Wrench} from "@phosphor-icons/react"
 import {Switch, Tag, Tooltip, Typography} from "antd"
 import {useAtom, useAtomValue} from "jotai"
+
+import {RailField} from "../../../drawers/shared/RailField"
 
 import {asObj, staticEmbedSlug, type ItemDescriptor} from "./itemDescriptors"
 import {ItemRow} from "./ItemRow"
@@ -111,18 +113,25 @@ export function useBuildKit({
     revisionId,
     sandboxPermissions,
     disabled,
+    enabledOverride,
 }: {
     revisionId: string | null
     sandboxPermissions: Record<string, unknown> | null
     disabled?: boolean
+    /**
+     * When set, the enable toggle reads/writes this buffer instead of the persisted atom — so a
+     * section drawer can scope the change to its draft and commit it to the atom only on Save.
+     */
+    enabledOverride?: {value: boolean; onChange: (value: boolean) => void}
 }) {
     const agentTemplateOverlay = useAtomValue(
         useMemo(() => workflowAgentTemplateOverlayAtomFamily(revisionId ?? ""), [revisionId]),
     )
-    const [buildKitEnabled, setBuildKitEnabled] = useAtom(
+    const [atomBuildKitEnabled, setAtomBuildKitEnabled] = useAtom(
         useMemo(() => workflowBuildKitEnabledAtomFamily(revisionId ?? ""), [revisionId]),
     )
-    const [buildKitExpanded, setBuildKitExpanded] = useState(false)
+    const buildKitEnabled = enabledOverride ? enabledOverride.value : atomBuildKitEnabled
+    const setBuildKitEnabled = enabledOverride ? enabledOverride.onChange : setAtomBuildKitEnabled
 
     const overlayTools = useMemo(
         () => (Array.isArray(agentTemplateOverlay?.tools) ? agentTemplateOverlay.tools : []),
@@ -163,112 +172,85 @@ export function useBuildKit({
     )
 
     const buildKitSection = hasBuildKitOverlay ? (
-        <div className="rounded border border-solid border-[var(--ag-c-EAEFF5,#eaeff5)]">
-            <button
-                type="button"
-                aria-expanded={buildKitExpanded}
-                onClick={() => setBuildKitExpanded((open) => !open)}
-                className="flex w-full cursor-pointer items-center gap-2 border-0 bg-transparent px-3 py-2.5 text-left"
-            >
-                <Wrench size={15} className="text-[var(--ag-c-586673,#586673)]" />
-                <span className="text-[13px] font-medium">Playground build kit</span>
-                <span className="ml-auto inline-flex items-center gap-1.5 text-[11px] text-[var(--ag-c-586673,#586673)]">
-                    <span className="h-1.5 w-1.5 rounded-full bg-[#d97706]" />
+        <ConfigAccordionSection
+            size="compact"
+            defaultOpen={false}
+            icon={<Wrench size={15} />}
+            title="Playground build kit"
+            summary={
+                <span className="inline-flex items-center gap-1.5">
+                    <span className="h-1.5 w-1.5 rounded-full bg-[var(--ag-colorWarning)]" />
                     Removed on commit
                 </span>
-                <span onClick={(e) => e.stopPropagation()} className="inline-flex items-center">
-                    <Switch
-                        size="small"
-                        checked={buildKitEnabled}
-                        onChange={setBuildKitEnabled}
-                        disabled={disabled}
-                    />
-                </span>
-                <CaretRight
-                    size={14}
-                    className={cn(
-                        "text-[var(--ag-c-97A4B0,#97a4b0)] transition-transform",
-                        buildKitExpanded && "rotate-90",
-                    )}
+            }
+            extra={
+                <Switch
+                    checked={buildKitEnabled}
+                    onChange={setBuildKitEnabled}
+                    disabled={disabled}
                 />
-            </button>
-            {buildKitExpanded ? (
-                <div className="flex flex-col gap-3 border-0 border-t border-solid border-[var(--ag-c-EAEFF5,#eaeff5)] px-3 pb-3 pt-2.5">
-                    <p className="m-0 text-[11.5px] leading-snug text-[var(--ag-c-586673,#586673)]">
-                        These playground-only tools, skills, and permissions help the assistant
-                        build and revise this agent. None of this is part of the published agent.
-                    </p>
-                    {!buildKitEnabled ? (
-                        <div className="rounded border border-solid border-[var(--ant-color-info-border)] bg-[var(--ant-color-info-bg)] px-2.5 py-2 text-[11.5px] leading-snug text-[var(--ant-color-info-text)]">
-                            The assistant can no longer create files, run code, or edit the agent
-                            here.
-                        </div>
-                    ) : null}
-                    {platformOverlayTools.length > 0 ? (
-                        <div className="flex flex-col gap-1.5">
-                            <Typography.Text className="text-xs font-medium">
-                                Platform tools
-                            </Typography.Text>
-                            {platformOverlayTools.map((tool, index) => (
-                                <ItemRow
-                                    key={`build-kit-platform-tool-${index}`}
-                                    descriptor={describeBuildKitPlatformTool(tool)}
-                                    locked
-                                />
-                            ))}
-                        </div>
-                    ) : null}
-                    {embeddedOverlayTools.length > 0 ? (
-                        <div className="flex flex-col gap-1.5">
-                            <Typography.Text className="text-xs font-medium">
-                                Embedded tools
-                            </Typography.Text>
-                            {embeddedOverlayTools.map((tool, index) => (
-                                <ItemRow
-                                    key={`build-kit-embedded-tool-${index}`}
-                                    descriptor={describeBuildKitEmbed(tool, "tool")}
-                                    locked
-                                />
-                            ))}
-                        </div>
-                    ) : null}
-                    {embeddedOverlaySkills.length > 0 ? (
-                        <div className="flex flex-col gap-1.5">
-                            <Typography.Text className="text-xs font-medium">
-                                Embedded skills
-                            </Typography.Text>
-                            {embeddedOverlaySkills.map((skill, index) => (
-                                <ItemRow
-                                    key={`build-kit-embedded-skill-${index}`}
-                                    descriptor={describeBuildKitEmbed(skill, "skill")}
-                                    locked
-                                />
-                            ))}
-                        </div>
-                    ) : null}
-                    {overlayPermissions && Object.keys(overlayPermissions).length > 0 ? (
-                        <div className="flex flex-col gap-1.5">
-                            <Typography.Text className="text-xs font-medium">
-                                Sandbox permissions
-                            </Typography.Text>
-                            <div className="flex flex-col gap-1.5 opacity-70">
-                                {Object.entries(overlayPermissions).map(([key, value]) => (
-                                    <div
-                                        key={key}
-                                        className="flex items-center justify-between gap-3 rounded border border-solid border-[var(--ag-c-EAEFF5,#eaeff5)] bg-[var(--ant-color-fill-quaternary)] px-3 py-2 text-xs"
-                                    >
-                                        <span className="font-mono">{key}</span>
-                                        <Tag className="m-0 font-mono text-[11px]">
-                                            {formatPermissionValue(value)}
-                                        </Tag>
-                                    </div>
-                                ))}
-                            </div>
-                        </div>
-                    ) : null}
+            }
+        >
+            <Typography.Text type="secondary" className="text-[11px] leading-snug">
+                These playground-only tools, skills, and permissions help the assistant build and
+                revise this agent. None of this is part of the published agent.
+            </Typography.Text>
+            {!buildKitEnabled ? (
+                <div className="rounded border border-solid border-[var(--ant-color-info-border)] bg-[var(--ant-color-info-bg)] px-2.5 py-2 text-[11.5px] leading-snug text-[var(--ant-color-info-text)]">
+                    The assistant can no longer create files, run code, or edit the agent here.
                 </div>
             ) : null}
-        </div>
+            {platformOverlayTools.length > 0 ? (
+                <RailField label="Platform tools">
+                    {platformOverlayTools.map((tool, index) => (
+                        <ItemRow
+                            key={`build-kit-platform-tool-${index}`}
+                            descriptor={describeBuildKitPlatformTool(tool)}
+                            locked
+                        />
+                    ))}
+                </RailField>
+            ) : null}
+            {embeddedOverlayTools.length > 0 ? (
+                <RailField label="Embedded tools">
+                    {embeddedOverlayTools.map((tool, index) => (
+                        <ItemRow
+                            key={`build-kit-embedded-tool-${index}`}
+                            descriptor={describeBuildKitEmbed(tool, "tool")}
+                            locked
+                        />
+                    ))}
+                </RailField>
+            ) : null}
+            {embeddedOverlaySkills.length > 0 ? (
+                <RailField label="Embedded skills">
+                    {embeddedOverlaySkills.map((skill, index) => (
+                        <ItemRow
+                            key={`build-kit-embedded-skill-${index}`}
+                            descriptor={describeBuildKitEmbed(skill, "skill")}
+                            locked
+                        />
+                    ))}
+                </RailField>
+            ) : null}
+            {overlayPermissions && Object.keys(overlayPermissions).length > 0 ? (
+                <RailField label="Sandbox permissions">
+                    <div className="flex flex-col gap-1.5 opacity-70">
+                        {Object.entries(overlayPermissions).map(([key, value]) => (
+                            <div
+                                key={key}
+                                className="flex items-center justify-between gap-3 rounded border border-solid border-[var(--ag-colorBorderSecondary)] bg-[var(--ant-color-fill-quaternary)] px-3 py-2 text-xs"
+                            >
+                                <span className="font-mono">{key}</span>
+                                <Tag className="m-0 font-mono text-[11px]">
+                                    {formatPermissionValue(value)}
+                                </Tag>
+                            </div>
+                        ))}
+                    </div>
+                </RailField>
+            ) : null}
+        </ConfigAccordionSection>
     ) : null
 
     const permissionOverrideHint =

--- a/web/packages/agenta-entity-ui/src/DrillInView/SchemaControls/agentTemplate/useModelHarness.tsx
+++ b/web/packages/agenta-entity-ui/src/DrillInView/SchemaControls/agentTemplate/useModelHarness.tsx
@@ -2,29 +2,21 @@
  * useModelHarness — the Model & harness + Advanced sections (the panel's most stateful part). One
  * hook because the model/connection state feeds both; returns each section's summary + bodies.
  */
-import {useCallback, useEffect, useMemo, useState} from "react"
+import {useCallback, useEffect, useMemo} from "react"
 
 import {vaultSecretsQueryAtom} from "@agenta/entities/secret"
 import type {SchemaProperty} from "@agenta/entities/shared"
 import {harnessCapabilitiesAtomFamily} from "@agenta/entities/workflow"
-import {LabeledField} from "@agenta/ui/components/presentational"
+import {ConfigAccordionSection, LabeledField} from "@agenta/ui/components/presentational"
 import {SelectLLMProviderBase} from "@agenta/ui/select-llm-provider"
 import {cn} from "@agenta/ui/styles"
-import {
-    CaretRight,
-    Check,
-    Cube,
-    EyeSlash,
-    Key,
-    Lightbulb,
-    ShieldCheck,
-    Warning,
-} from "@phosphor-icons/react"
-import {Select, Switch, Typography} from "antd"
+import {Check, Cube, EyeSlash, Key, Lightbulb, ShieldCheck, Warning} from "@phosphor-icons/react"
+import {Select, Typography} from "antd"
 import {useAtomValue} from "jotai"
 
+import {RailField, railInfoLabel} from "../../../drawers/shared/RailField"
+import {SectionRail} from "../../../drawers/shared/SectionRail"
 import {ClaudePermissionsControl} from "../ClaudePermissionsControl"
-import {CodeEditor} from "../CodeEditor"
 import {
     allowedConnectionModes,
     buildModelOptionGroups,
@@ -52,6 +44,8 @@ export function useModelHarness({
     disabled,
     withTooltip,
     revisionId,
+    buildKitEnabledOverride,
+    savedHarnessValue,
 }: {
     schema?: SchemaProperty | null
     config: Record<string, unknown>
@@ -59,6 +53,14 @@ export function useModelHarness({
     disabled?: boolean
     withTooltip?: boolean
     revisionId?: string | null
+    /** Draft buffer for the build-kit toggle (used by the section drawer's scoped-edit mode). */
+    buildKitEnabledOverride?: {value: boolean; onChange: (value: boolean) => void}
+    /**
+     * The SAVED (committed) harness value, for the "Current" badge — so it marks the persisted harness
+     * even while `config` holds an unsaved draft pick (the draft pick is shown by the radio, not the
+     * badge). Defaults to this instance's own harness, so the live instance is unaffected.
+     */
+    savedHarnessValue?: string | null
 }) {
     const props = (schema?.properties ?? {}) as Record<string, SchemaProperty>
     const subProps = useCallback(
@@ -203,44 +205,6 @@ export function useModelHarness({
         [vaultSecrets, capabilities, harnessValue, connection.provider],
     )
 
-    // Raw-JSON escape hatch for the whole `agent.llm` value (collapsed by default).
-    const [showModelJson, setShowModelJson] = useState(false)
-    const [modelJsonText, setModelJsonText] = useState(() => JSON.stringify(llm ?? "", null, 2))
-    const handleModelJsonChange = useCallback(
-        (text: string) => {
-            setModelJsonText(text)
-            try {
-                setAgentField("llm", text ? JSON.parse(text) : "")
-            } catch {
-                // Keep the invalid text in the editor; don't propagate until it parses.
-            }
-        },
-        [setAgentField],
-    )
-    const handleToggleModelJson = useCallback(
-        (next: boolean) => {
-            if (next) setModelJsonText(JSON.stringify(llm ?? "", null, 2))
-            setShowModelJson(next)
-        },
-        [llm],
-    )
-    // Keep the open JSON buffer in sync when `agent.llm` changes from OUTSIDE the editor
-    // (the model picker or the authentication cards). Guard with a structural compare so we
-    // only resync on external changes — when the buffer already represents `agent.llm`
-    // (the user is typing here) we skip, so we never reformat mid-edit or fight the cursor.
-    useEffect(() => {
-        if (!showModelJson) return
-        let bufferValue: unknown
-        try {
-            bufferValue = modelJsonText ? JSON.parse(modelJsonText) : ""
-        } catch {
-            return // invalid in-progress JSON — leave the user's text untouched
-        }
-        if (JSON.stringify(bufferValue) !== JSON.stringify(llm ?? "")) {
-            setModelJsonText(JSON.stringify(llm ?? "", null, 2))
-        }
-    }, [llm, showModelJson, modelJsonText])
-
     // Claude permissions (Layer 1, Claude-only): the Claude harness's own permission knobs, the
     // first-class `harness.permissions` slice. Shown in Advanced only for the Claude harness.
     const claudePermissions = useMemo(() => {
@@ -266,12 +230,8 @@ export function useModelHarness({
         revisionId: revisionId ?? null,
         sandboxPermissions: (sandbox.permissions as Record<string, unknown> | null) ?? null,
         disabled,
+        enabledOverride: buildKitEnabledOverride,
     })
-
-    // Collapsed-by-default state for each advanced group (independent; multiple can be open).
-    const [authExpanded, setAuthExpanded] = useState(false)
-    const [execExpanded, setExecExpanded] = useState(false)
-    const [permsExpanded, setPermsExpanded] = useState(false)
 
     const hasAdvanced = Boolean(
         props.llm || // Authentication lives in Advanced now
@@ -282,14 +242,21 @@ export function useModelHarness({
         hasBuildKitOverlay,
     )
 
-    // The Model picker (inspect-filtered when available, else the schema catalog).
+    // The Model picker (inspect-filtered when available, else the schema catalog), as a rail row —
+    // the info tooltip only applies to the inspect-filtered variant (the fallback is the full catalog).
     const modelPicker = props.llm ? (
-        hasInspectModels ? (
-            <LabeledField
-                label="Model"
-                description="Filtered to the models this harness can reach. Selecting a model also sets its provider."
-                withTooltip={withTooltip}
-            >
+        <RailField
+            label={
+                hasInspectModels
+                    ? railInfoLabel(
+                          "Model",
+                          "Filtered to the models this harness can reach. Selecting a model also sets its provider.",
+                      )
+                    : "Model"
+            }
+            align="center"
+        >
+            {hasInspectModels ? (
                 <SelectLLMProviderBase
                     showGroup
                     options={modelGroups}
@@ -299,20 +266,18 @@ export function useModelHarness({
                     placeholder="Select a model…"
                     className="w-full"
                 />
-            </LabeledField>
-        ) : (
-            <GroupedChoiceControl
-                schema={
-                    (props.llm?.properties as Record<string, SchemaProperty> | undefined)?.model ??
-                    props.llm
-                }
-                label="Model"
-                value={modelId}
-                onChange={(v) => writeModel({modelId: v})}
-                withTooltip={withTooltip}
-                disabled={disabled}
-            />
-        )
+            ) : (
+                <GroupedChoiceControl
+                    schema={
+                        (props.llm?.properties as Record<string, SchemaProperty> | undefined)
+                            ?.model ?? props.llm
+                    }
+                    value={modelId}
+                    onChange={(v) => writeModel({modelId: v})}
+                    disabled={disabled}
+                />
+            )}
+        </RailField>
     ) : null
 
     // Shared version-history placeholder for the section drawers (real revision diffs are deferred).
@@ -342,23 +307,19 @@ export function useModelHarness({
         </div>
     )
 
-    // Harness list + compatibility (provider/model reachability + connection mode) derive from the
-    // inspect capabilities map. GAP (tracked): harness_capabilities covers model/provider/mode/hosting
-    // only — NOT tools/skills/MCP — so switching harness can silently leave unsupported tools
-    // unwarned. Extend the panel when the backend adds that. See design.md ("Known gap").
+    // Harness list, from the inspect capabilities map. Model compatibility is shown per-card (below).
+    // GAP (tracked): harness_capabilities covers model/provider/mode/hosting only — NOT tools/skills/
+    // MCP — so switching harness can silently leave unsupported tools unwarned. See design.md.
     const harnessList = capabilities ? Object.keys(capabilities) : []
-    const modelReachable =
-        !modelId ||
-        !capabilities ||
-        !harnessValue ||
-        harnessAllowsModel(capabilities, harnessValue, modelId)
-    const authSupported = modeOptions.length === 0 || modeOptions.includes(connection.mode)
 
     const harnessCards = (
         <div className="flex flex-col gap-2">
             {harnessList.map((h) => {
                 const caps = capabilities?.[h]
+                // `selected` = the (draft) pick → drives the radio + border. `isCurrent` = the SAVED
+                // harness → drives the "Current" badge, so the badge stays put until the draft is saved.
                 const selected = harnessValue === h
+                const isCurrent = (savedHarnessValue ?? harnessValue) === h
                 const providers = caps?.providers ?? []
                 const deployments = caps?.deployments ?? []
                 const modelCount = caps
@@ -367,7 +328,17 @@ export function useModelHarness({
                           0,
                       )
                     : 0
-                const keepsModel = !modelId || harnessAllowsModel(capabilities, h, modelId)
+                // A harness supports the model if it lists the exact id OR the model's PROVIDER family.
+                // The provider fallback matters because harnesses use different id namespaces: Claude
+                // Code's short alias "opus" isn't in Pi's full-id catalog, but Pi does list the anthropic
+                // provider — so it can run the model. Without this, cross-harness checks read as false
+                // "model not available". (Exact-id alone still can't map aliases; the provider is the
+                // reliable signal we have on the config.)
+                const modelProvider = connection.provider
+                const keepsModel =
+                    !modelId ||
+                    harnessAllowsModel(capabilities, h, modelId) ||
+                    (!!modelProvider && providers.includes(modelProvider))
                 return (
                     <button
                         key={h}
@@ -378,7 +349,7 @@ export function useModelHarness({
                             "flex w-full flex-col gap-1.5 rounded-lg border border-solid p-2.5 text-left transition-colors",
                             disabled ? "cursor-not-allowed opacity-60" : "cursor-pointer",
                             selected
-                                ? "border-[var(--ant-color-primary)] bg-[var(--ant-color-fill-secondary)]"
+                                ? "border-[var(--ant-color-primary-border-hover)] bg-[var(--ant-color-fill-secondary)]"
                                 : "border-[var(--ant-color-border)] bg-[var(--ant-color-fill-quaternary)] hover:border-[var(--ant-color-text-quaternary)] hover:bg-[var(--ant-color-fill-tertiary)]",
                         )}
                     >
@@ -388,7 +359,7 @@ export function useModelHarness({
                                     "flex h-3.5 w-3.5 shrink-0 items-center justify-center rounded-full border border-solid",
                                     selected
                                         ? "border-[var(--ant-color-primary)]"
-                                        : "border-[var(--ag-c-97A4B0,#97a4b0)]",
+                                        : "border-[var(--ant-color-text-tertiary)]",
                                 )}
                             >
                                 {selected && (
@@ -398,23 +369,29 @@ export function useModelHarness({
                             <span className="text-xs font-medium">
                                 {enumLabel(harnessProps.kind, h) || h}
                             </span>
-                            {selected ? (
-                                <span className="ml-auto rounded-full bg-[var(--ant-color-fill-secondary)] px-2 text-[10px] text-[var(--ant-color-primary-text)]">
-                                    Current
-                                </span>
-                            ) : modelId ? (
-                                <span
-                                    className={cn(
-                                        "ml-auto inline-flex items-center gap-1 text-[10.5px]",
-                                        keepsModel
-                                            ? "text-[var(--ant-color-success)]"
-                                            : "text-[var(--ant-color-warning)]",
-                                    )}
-                                >
-                                    {keepsModel ? <Check size={11} /> : <Warning size={11} />}
-                                    {keepsModel ? "supports your model" : "model not available"}
-                                </span>
-                            ) : null}
+                            <span className="ml-auto flex items-center gap-2">
+                                {/* Model compatibility lives on the card itself: warn on the CURRENT
+                                    harness when it can't run the selected model (quiet when it can);
+                                    for alternatives, show whether switching would keep the model. */}
+                                {modelId && (!keepsModel || !selected) ? (
+                                    <span
+                                        className={cn(
+                                            "inline-flex items-center gap-1 text-[10.5px]",
+                                            keepsModel
+                                                ? "text-[var(--ant-color-success)]"
+                                                : "text-[var(--ant-color-warning)]",
+                                        )}
+                                    >
+                                        {keepsModel ? <Check size={11} /> : <Warning size={11} />}
+                                        {keepsModel ? "supports your model" : "model not available"}
+                                    </span>
+                                ) : null}
+                                {isCurrent ? (
+                                    <span className="rounded-full bg-[var(--ant-color-fill-secondary)] px-2 text-[10px] text-[var(--ant-color-primary-text)]">
+                                        Current
+                                    </span>
+                                ) : null}
+                            </span>
                         </div>
                         {providers.length > 0 || modelCount > 0 ? (
                             <div className="pl-[22px] text-[11px] text-[var(--ag-c-97A4B0,#97a4b0)]">
@@ -434,110 +411,10 @@ export function useModelHarness({
         </div>
     )
 
-    const compatibilityPanel =
-        capabilities && harnessValue ? (
-            <div className="flex flex-col gap-4">
-                <div>
-                    <div className="mb-2 text-[11px] uppercase tracking-wide text-[var(--ag-c-97A4B0,#97a4b0)]">
-                        Current setup
-                    </div>
-                    <div className="flex flex-col gap-2 text-xs">
-                        {modelId ? (
-                            <div
-                                className={cn(
-                                    "flex items-start gap-1.5",
-                                    modelReachable
-                                        ? "text-[var(--ant-color-success)]"
-                                        : "text-[var(--ant-color-warning)]",
-                                )}
-                            >
-                                {modelReachable ? (
-                                    <Check size={14} className="mt-px shrink-0" />
-                                ) : (
-                                    <Warning size={14} className="mt-px shrink-0" />
-                                )}
-                                <span>
-                                    <span className="font-mono">{modelId}</span>{" "}
-                                    {modelReachable ? "is reachable." : "is not reachable here."}
-                                </span>
-                            </div>
-                        ) : (
-                            <span className="text-[var(--ag-c-97A4B0,#97a4b0)]">
-                                No model selected.
-                            </span>
-                        )}
-                        {props.llm ? (
-                            <div
-                                className={cn(
-                                    "flex items-start gap-1.5",
-                                    authSupported
-                                        ? "text-[var(--ant-color-success)]"
-                                        : "text-[var(--ant-color-warning)]",
-                                )}
-                            >
-                                {authSupported ? (
-                                    <Check size={14} className="mt-px shrink-0" />
-                                ) : (
-                                    <Warning size={14} className="mt-px shrink-0" />
-                                )}
-                                <span>
-                                    {connection.mode === "agenta"
-                                        ? "Agenta-managed"
-                                        : "Self-managed"}{" "}
-                                    auth{" "}
-                                    {authSupported ? "is supported." : "is not supported here."}
-                                </span>
-                            </div>
-                        ) : null}
-                    </div>
-                </div>
-
-                {modelId && harnessList.some((h) => h !== harnessValue) ? (
-                    <div>
-                        <div className="mb-2 text-[11px] uppercase tracking-wide text-[var(--ag-c-97A4B0,#97a4b0)]">
-                            If you switch
-                        </div>
-                        <div className="flex flex-col gap-2 text-xs">
-                            {harnessList
-                                .filter((h) => h !== harnessValue)
-                                .map((h) => {
-                                    const keeps = harnessAllowsModel(capabilities, h, modelId)
-                                    return (
-                                        <div key={h} className="flex items-start gap-1.5">
-                                            {keeps ? (
-                                                <Check
-                                                    size={14}
-                                                    className="mt-px shrink-0 text-[var(--ant-color-success)]"
-                                                />
-                                            ) : (
-                                                <Warning
-                                                    size={14}
-                                                    className="mt-px shrink-0 text-[var(--ant-color-warning)]"
-                                                />
-                                            )}
-                                            <span className="text-[var(--ag-c-586673,#586673)]">
-                                                <span className="text-[var(--ag-c-1C2C3D,#1c2c3d)]">
-                                                    {enumLabel(harnessProps.kind, h) || h}
-                                                </span>{" "}
-                                                {keeps
-                                                    ? "supports your model."
-                                                    : "doesn't support your model — pick a new one."}
-                                            </span>
-                                        </div>
-                                    )
-                                })}
-                        </div>
-                    </div>
-                ) : null}
-
-                {versionHistorySkeleton}
-            </div>
-        ) : null
-
     // Model & harness drawer body. With inspect capabilities: harness cards + model picker on the
-    // left, a real compatibility panel on the right. Without them: the plain harness select.
-    // Shared Model & harness controls — rendered by both the wide drawer body (with the
-    // compatibility side panel) and the trimmed tabs-inline body (single column, no chrome).
+    // left (each card owns its model-compat state), version history on the right — same two-panel
+    // shape as the Advanced drawer. Without capabilities: the plain harness select, single column.
+    // Shared Model & harness controls — rendered by both the wide drawer body and the tabs-inline body.
     const modelHarnessControls = capabilities ? (
         <>
             <div className="flex gap-2 rounded-md bg-[var(--ant-color-fill-quaternary)] p-2.5">
@@ -547,25 +424,21 @@ export function useModelHarness({
                     hosting and connection options you can use.
                 </span>
             </div>
-            <div>
-                <div className="mb-2 text-[11px] uppercase tracking-wide text-[var(--ag-c-97A4B0,#97a4b0)]">
-                    Harness
-                </div>
-                {harnessCards}
-            </div>
+            <RailField label="Harness">{harnessCards}</RailField>
             {modelPicker}
         </>
     ) : (
         <>
             {harnessProps.kind && (
-                <HarnessSelectControl
-                    schema={harnessProps.kind}
-                    label="Harness"
-                    value={(harness.kind as string | null) ?? null}
-                    onChange={(v) => setSection("harness", {...harness, kind: v})}
-                    withTooltip={withTooltip}
-                    disabled={disabled}
-                />
+                <RailField label="Harness" align="center">
+                    <HarnessSelectControl
+                        schema={harnessProps.kind}
+                        value={(harness.kind as string | null) ?? null}
+                        onChange={(v) => setSection("harness", {...harness, kind: v})}
+                        withTooltip={withTooltip}
+                        disabled={disabled}
+                    />
+                </RailField>
             )}
             {modelPicker}
         </>
@@ -576,7 +449,7 @@ export function useModelHarness({
             <div className="flex min-w-0 flex-1 flex-col gap-4 overflow-y-auto pr-1">
                 {modelHarnessControls}
             </div>
-            <div className="w-[240px] shrink-0 overflow-y-auto">{compatibilityPanel}</div>
+            <div className="w-[240px] shrink-0 overflow-y-auto">{versionHistorySkeleton}</div>
         </div>
     ) : (
         <div className="flex h-full flex-col gap-3 overflow-y-auto">{modelHarnessControls}</div>
@@ -586,101 +459,58 @@ export function useModelHarness({
     // two-panel split or side panel (which read as out-of-place chrome inside a tab).
     const modelHarnessInline = <div className="flex flex-col gap-4">{modelHarnessControls}</div>
 
-    // Authentication (credential source) — moved out of Model & harness into Advanced.
+    // Authentication (credential source) — moved out of Model & harness into Advanced. The
+    // credential-source axis reads as the drawer's shared `[rail | content]`: mode toggle on the
+    // left, the active mode's description + (Agenta-managed) connection picker on the right.
+    const authDescription =
+        connection.mode === "agenta"
+            ? "Agenta supplies the credential from this project's vault — the default provider key, or a named connection you pick below."
+            : "The harness signs in itself (an environment variable or a prior OAuth login). Agenta injects no credential."
+    const authConnectionField =
+        connection.mode === "agenta" ? (
+            <LabeledField
+                label="Connection"
+                description="Which stored connection supplies the credential. Project default uses the project's provider key."
+                withTooltip={withTooltip}
+            >
+                <Select<string>
+                    value={connection.slug ?? "__default__"}
+                    onChange={(v) => writeModel({slug: v === "__default__" ? null : (v ?? null)})}
+                    options={[
+                        {value: "__default__", label: "Project default"},
+                        ...connectionOptions.map((o) => ({value: o.value, label: o.label})),
+                    ]}
+                    disabled={disabled}
+                    className="w-full"
+                    showSearch
+                    optionFilterProp="label"
+                />
+            </LabeledField>
+        ) : null
     const authControls = props.llm ? (
-        <div className="flex flex-col gap-2">
-            {modeOptions.map((m) => {
-                const selected = connection.mode === m
-                const title = m === "agenta" ? "Agenta-managed" : "Self-managed"
-                const desc =
-                    m === "agenta"
-                        ? "Agenta supplies the credential from this project's vault — the default provider key, or a named connection you pick below."
-                        : "The harness signs in itself (an environment variable or a prior OAuth login). Agenta injects no credential."
-                return (
-                    <button
-                        key={m}
-                        type="button"
-                        role="radio"
-                        aria-checked={selected}
-                        disabled={disabled}
-                        onClick={() => writeModel({mode: m})}
-                        className={cn(
-                            "flex w-full items-start gap-2.5 rounded-lg border border-solid p-2.5 text-left transition-colors",
-                            disabled ? "cursor-not-allowed opacity-60" : "cursor-pointer",
-                            selected
-                                ? "border-[var(--ant-color-primary)] bg-[var(--ant-color-fill-secondary)]"
-                                : "border-[var(--ant-color-border)] bg-[var(--ant-color-fill-quaternary)] hover:border-[var(--ant-color-text-quaternary)] hover:bg-[var(--ant-color-fill-tertiary)]",
-                        )}
-                    >
-                        <span
-                            className={cn(
-                                "mt-0.5 flex h-4 w-4 shrink-0 items-center justify-center rounded-full border border-solid",
-                                selected
-                                    ? "border-[var(--ant-color-primary)]"
-                                    : "border-[var(--ant-color-text-tertiary)]",
-                            )}
-                        >
-                            {selected && (
-                                <span className="h-2 w-2 rounded-full bg-[var(--ant-color-primary)]" />
-                            )}
-                        </span>
-                        <span className="flex flex-col gap-0.5">
-                            <Typography.Text
-                                className={cn(
-                                    "text-xs font-medium leading-none",
-                                    selected && "!text-[var(--ant-color-primary-text)]",
-                                )}
-                            >
-                                {title}
-                            </Typography.Text>
-                            <Typography.Text type="secondary" className="text-[11px] leading-snug">
-                                {desc}
-                            </Typography.Text>
-                        </span>
-                    </button>
-                )
-            })}
-            {connection.mode === "agenta" && (
-                <LabeledField
-                    label="Connection"
-                    description="Which stored connection supplies the credential. Project default uses the project's provider key."
-                    withTooltip={withTooltip}
-                >
-                    <Select<string>
-                        value={connection.slug ?? "__default__"}
-                        onChange={(v) =>
-                            writeModel({slug: v === "__default__" ? null : (v ?? null)})
-                        }
-                        options={[
-                            {value: "__default__", label: "Project default"},
-                            ...connectionOptions.map((o) => ({value: o.value, label: o.label})),
-                        ]}
-                        disabled={disabled}
-                        className="w-full"
-                        showSearch
-                        optionFilterProp="label"
-                    />
-                </LabeledField>
-            )}
-
-            {/* Raw-JSON escape hatch for the whole `agent.llm` value, collapsed by default. */}
-            <div className="flex items-center gap-2">
-                <Switch
-                    checked={showModelJson}
-                    onChange={handleToggleModelJson}
-                    disabled={disabled}
-                />
-                <Typography.Text className="text-xs">Edit as JSON</Typography.Text>
+        modeOptions.length > 0 ? (
+            <SectionRail
+                disabled={disabled}
+                items={modeOptions.map((m) => ({
+                    value: m,
+                    label: m === "agenta" ? "Agenta-managed" : "Self-managed",
+                }))}
+                value={connection.mode}
+                onChange={(m) => writeModel({mode: m as ConnectionMode})}
+            >
+                <Typography.Text type="secondary" className="text-[11px] leading-snug">
+                    {authDescription}
+                </Typography.Text>
+                {authConnectionField}
+            </SectionRail>
+        ) : (
+            <div className="flex flex-col gap-2">
+                <Typography.Text type="secondary" className="text-[11px] leading-snug">
+                    {authDescription}
+                </Typography.Text>
+                {authConnectionField}
             </div>
-            {showModelJson && (
-                <CodeEditor
-                    value={modelJsonText}
-                    onChange={handleModelJsonChange}
-                    language="json"
-                    disabled={disabled}
-                />
-            )}
-        </div>
+        )
     ) : null
 
     // Advanced header summary: auth mode + sandbox, so the collapsed header still conveys state.
@@ -696,218 +526,145 @@ export function useModelHarness({
     const hasExecutionGroup = Boolean(sandboxProps.kind || sandboxProps.permissions)
     const hasPermissionsGroup = Boolean(headlessSchema || hasClaudePermissions)
     // Shared Advanced controls, rendered by both the wide drawer body and the tabs-inline body.
+    // Each group is a `ConfigAccordionSection` (the shared drawer section shell used by the trigger
+    // and tools drawers); inside, configuration reads as the drawer's `[rail | content]` rhythm via
+    // `SectionRail` (Authentication mode) and `RailField` (labelled control rows).
     const advancedControls = (
         <>
             {buildKitSection}
 
             {authControls ? (
-                <div
-                    className={cn(
-                        "rounded border border-solid border-[var(--ag-c-EAEFF5,#eaeff5)]",
-                        hasBuildKitOverlay && "mt-0",
-                    )}
+                <ConfigAccordionSection
+                    size="compact"
+                    defaultOpen={false}
+                    icon={<Key size={15} />}
+                    title="Authentication"
+                    summary={
+                        props.llm
+                            ? connection.mode === "agenta"
+                                ? "Agenta-managed"
+                                : "Self-managed"
+                            : undefined
+                    }
+                    summaryCollapsedOnly
                 >
-                    <button
-                        type="button"
-                        aria-expanded={authExpanded}
-                        onClick={() => setAuthExpanded((open) => !open)}
-                        className="flex w-full cursor-pointer items-center gap-2 border-0 bg-transparent px-3 py-2.5 text-left"
-                    >
-                        <Key size={15} className="text-[var(--ag-c-586673,#586673)]" />
-                        <span className="text-[13px] font-medium">Authentication</span>
-                        {!authExpanded ? (
-                            <span className="ml-auto text-[11px] text-[var(--ag-c-97A4B0,#97a4b0)]">
-                                {props.llm
-                                    ? connection.mode === "agenta"
-                                        ? "Agenta-managed"
-                                        : "Self-managed"
-                                    : ""}
-                            </span>
-                        ) : (
-                            <span className="ml-auto" />
-                        )}
-                        <CaretRight
-                            size={14}
-                            className={cn(
-                                "text-[var(--ag-c-97A4B0,#97a4b0)] transition-transform",
-                                authExpanded && "rotate-90",
-                            )}
-                        />
-                    </button>
-                    {authExpanded ? (
-                        <div className="border-0 border-t border-solid border-[var(--ag-c-EAEFF5,#eaeff5)] px-3 pb-3 pt-2.5">
-                            <p className="mb-2.5 text-[11.5px] leading-snug text-[var(--ag-c-97A4B0,#97a4b0)]">
-                                Where the model credential comes from when this agent runs.
-                            </p>
-                            {authControls}
-                        </div>
-                    ) : null}
-                </div>
+                    <Typography.Text type="secondary" className="text-[11px] leading-snug">
+                        Where the model credential comes from when this agent runs.
+                    </Typography.Text>
+                    {authControls}
+                </ConfigAccordionSection>
             ) : null}
 
             {hasExecutionGroup ? (
-                <div className="rounded border border-solid border-[var(--ag-c-EAEFF5,#eaeff5)]">
-                    <button
-                        type="button"
-                        aria-expanded={execExpanded}
-                        onClick={() => setExecExpanded((open) => !open)}
-                        className="flex w-full cursor-pointer items-center gap-2 border-0 bg-transparent px-3 py-2.5 text-left"
-                    >
-                        <Cube size={15} className="text-[var(--ag-c-586673,#586673)]" />
-                        <span className="text-[13px] font-medium">Execution environment</span>
-                        {!execExpanded ? (
-                            <span className="ml-auto text-[11px] text-[var(--ag-c-97A4B0,#97a4b0)]">
-                                {sandbox.kind ? `Sandbox: ${String(sandbox.kind)}` : ""}
-                            </span>
-                        ) : (
-                            <span className="ml-auto" />
-                        )}
-                        <CaretRight
-                            size={14}
-                            className={cn(
-                                "text-[var(--ag-c-97A4B0,#97a4b0)] transition-transform",
-                                execExpanded && "rotate-90",
-                            )}
-                        />
-                    </button>
-                    {execExpanded ? (
-                        <div className="border-0 border-t border-solid border-[var(--ag-c-EAEFF5,#eaeff5)] px-3 pb-3 pt-2.5">
-                            <p className="mb-2.5 text-[11.5px] leading-snug text-[var(--ag-c-97A4B0,#97a4b0)]">
-                                Where the agent&apos;s tools and code run, and what that sandbox may
-                                touch.
-                            </p>
-                            <div className="flex flex-col gap-2.5">
-                                {sandboxProps.kind && (
-                                    <EnumSelectControl
-                                        schema={sandboxProps.kind}
-                                        label="Sandbox"
-                                        value={(sandbox.kind as string | null) ?? null}
-                                        onChange={(v) =>
-                                            setSection("sandbox", {...sandbox, kind: v})
-                                        }
-                                        withTooltip={withTooltip}
-                                        disabled={disabled}
-                                    />
-                                )}
-                                {sandboxProps.permissions ? (
-                                    <div className="flex flex-col gap-1.5">
-                                        {permissionOverrideHint}
-                                        <SandboxPermissionControl
-                                            value={
-                                                (sandbox.permissions as Record<
-                                                    string,
-                                                    unknown
-                                                > | null) ?? null
-                                            }
-                                            onChange={(v) =>
-                                                setSection("sandbox", {
-                                                    ...sandbox,
-                                                    permissions: v,
-                                                })
-                                            }
-                                            disabled={disabled}
-                                        />
-                                    </div>
-                                ) : null}
-                            </div>
-                        </div>
+                <ConfigAccordionSection
+                    size="compact"
+                    defaultOpen={false}
+                    icon={<Cube size={15} />}
+                    title="Execution environment"
+                    summary={sandbox.kind ? `Sandbox: ${String(sandbox.kind)}` : undefined}
+                    summaryCollapsedOnly
+                >
+                    <Typography.Text type="secondary" className="text-[11px] leading-snug">
+                        Where the agent&apos;s tools and code run, and what that sandbox may touch.
+                    </Typography.Text>
+                    {sandboxProps.kind ? (
+                        <RailField label="Sandbox" align="center">
+                            <EnumSelectControl
+                                schema={sandboxProps.kind}
+                                value={(sandbox.kind as string | null) ?? null}
+                                onChange={(v) => setSection("sandbox", {...sandbox, kind: v})}
+                                withTooltip={withTooltip}
+                                disabled={disabled}
+                            />
+                        </RailField>
                     ) : null}
-                </div>
+                    {sandboxProps.permissions ? (
+                        <>
+                            {permissionOverrideHint}
+                            {/* Renders its knobs as peer RailField rows (Network egress / Filesystem
+                                / Enforcement) sharing this section's rail — no nested sub-form. */}
+                            <SandboxPermissionControl
+                                value={
+                                    (sandbox.permissions as Record<string, unknown> | null) ?? null
+                                }
+                                onChange={(v) =>
+                                    setSection("sandbox", {...sandbox, permissions: v})
+                                }
+                                disabled={disabled}
+                            />
+                        </>
+                    ) : null}
+                </ConfigAccordionSection>
             ) : null}
 
             {hasPermissionsGroup ? (
-                <div className="rounded border border-solid border-[var(--ag-c-EAEFF5,#eaeff5)]">
-                    <button
-                        type="button"
-                        aria-expanded={permsExpanded}
-                        onClick={() => setPermsExpanded((open) => !open)}
-                        className="flex w-full cursor-pointer items-center gap-2 border-0 bg-transparent px-3 py-2.5 text-left"
-                    >
-                        <ShieldCheck size={15} className="text-[var(--ag-c-586673,#586673)]" />
-                        <span className="text-[13px] font-medium">Permissions</span>
-                        {!permsExpanded ? (
-                            <span className="ml-auto text-[11px] text-[var(--ag-c-97A4B0,#97a4b0)]">
-                                Auto
-                            </span>
-                        ) : (
-                            <span className="ml-auto" />
-                        )}
-                        <CaretRight
-                            size={14}
-                            className={cn(
-                                "text-[var(--ag-c-97A4B0,#97a4b0)] transition-transform",
-                                permsExpanded && "rotate-90",
+                <ConfigAccordionSection
+                    size="compact"
+                    defaultOpen={false}
+                    icon={<ShieldCheck size={15} />}
+                    title="Permissions"
+                    summary="Auto"
+                    summaryCollapsedOnly
+                >
+                    <Typography.Text type="secondary" className="text-[11px] leading-snug">
+                        What the agent may do on its own before it must ask.
+                    </Typography.Text>
+                    {headlessSchema ? (
+                        <RailField label="Policy" align="center">
+                            {isPiHarness ? (
+                                <span className="flex items-center gap-1.5 text-[11px] text-[var(--ag-colorTextTertiary)]">
+                                    <EyeSlash size={13} />
+                                    Permission policy isn&apos;t used by the Pi harness.
+                                </span>
+                            ) : (
+                                <EnumSelectControl
+                                    schema={headlessSchema}
+                                    value={headlessValue}
+                                    onChange={(v) =>
+                                        setSection("runner", {
+                                            ...runner,
+                                            interactions: {...runnerInteractions, headless: v},
+                                        })
+                                    }
+                                    withTooltip={withTooltip}
+                                    disabled={disabled}
+                                />
                             )}
-                        />
-                    </button>
-                    {permsExpanded ? (
-                        <div className="border-0 border-t border-solid border-[var(--ag-c-EAEFF5,#eaeff5)] px-3 pb-3 pt-2.5">
-                            <p className="mb-2.5 text-[11.5px] leading-snug text-[var(--ag-c-97A4B0,#97a4b0)]">
-                                What the agent may do on its own before it must ask.
-                            </p>
-                            <div className="flex flex-col gap-2.5">
-                                {headlessSchema ? (
-                                    isPiHarness ? (
-                                        <div className="flex items-center gap-1.5 text-[11px] text-[var(--ag-c-97A4B0,#97a4b0)]">
-                                            <EyeSlash size={13} />
-                                            Permission policy isn&apos;t used by the Pi harness.
-                                        </div>
-                                    ) : (
-                                        <EnumSelectControl
-                                            schema={headlessSchema}
-                                            label="Permission policy"
-                                            value={headlessValue}
-                                            onChange={(v) =>
-                                                setSection("runner", {
-                                                    ...runner,
-                                                    interactions: {
-                                                        ...runnerInteractions,
-                                                        headless: v,
-                                                    },
-                                                })
-                                            }
-                                            withTooltip={withTooltip}
-                                            disabled={disabled}
-                                        />
-                                    )
-                                ) : null}
-                                {hasClaudePermissions ? (
-                                    <div className="flex flex-col gap-1.5">
-                                        <div className="flex items-center gap-1.5">
-                                            <Typography.Text className="text-xs font-medium">
-                                                Claude permissions
-                                            </Typography.Text>
-                                            <span className="rounded-full bg-[var(--ant-color-fill-secondary)] px-2 text-[10px] text-[var(--ant-color-primary-text)]">
-                                                Claude harness
-                                            </span>
-                                        </div>
-                                        <ClaudePermissionsControl
-                                            value={claudePermissions}
-                                            onChange={setClaudePermissions}
-                                            disabled={disabled}
-                                            // Mode options + labels come from the harness `permissions`
-                                            // sub-schema (`default_mode` enum) so they follow the template.
-                                            modeSchema={
-                                                (
-                                                    harnessProps.permissions?.properties as
-                                                        | Record<string, SchemaProperty>
-                                                        | undefined
-                                                )?.default_mode
-                                            }
-                                        />
-                                    </div>
-                                ) : null}
-                            </div>
-                        </div>
+                        </RailField>
                     ) : null}
-                </div>
+                    {hasClaudePermissions ? (
+                        <>
+                            {/* Caption then peer rail rows (mode / allow / ask / deny) sharing the
+                                section rail — the control renders its own RailField rows. */}
+                            <span className="w-fit rounded-full bg-[var(--ant-color-fill-secondary)] px-2 text-[10px] text-[var(--ant-color-primary-text)]">
+                                Claude harness
+                            </span>
+                            <ClaudePermissionsControl
+                                value={claudePermissions}
+                                onChange={setClaudePermissions}
+                                disabled={disabled}
+                                // Mode options + labels come from the harness `permissions`
+                                // sub-schema (`default_mode` enum) so they follow the template.
+                                modeSchema={
+                                    (
+                                        harnessProps.permissions?.properties as
+                                            | Record<string, SchemaProperty>
+                                            | undefined
+                                    )?.default_mode
+                                }
+                            />
+                        </>
+                    ) : null}
+                </ConfigAccordionSection>
             ) : null}
         </>
     )
 
+    // The stacked sections carry their own dividers; drop the trailing one on whichever section
+    // renders last (they're conditional, so target the last child rather than a fixed section).
     const advancedDrawerBody = (
         <div className="flex h-full min-h-0 gap-6">
-            <div className="flex min-w-0 flex-1 flex-col gap-4 overflow-y-auto pr-1">
+            <div className="flex min-w-0 flex-1 flex-col overflow-y-auto pr-1 [&>*:last-child]:!border-b-0">
                 {advancedControls}
             </div>
             <div className="w-[240px] shrink-0 overflow-y-auto">{versionHistorySkeleton}</div>
@@ -915,7 +672,9 @@ export function useModelHarness({
     )
 
     // Trimmed body for the tabs layout: the grouped controls in one column, no side panel.
-    const advancedInline = <div className="flex flex-col gap-4">{advancedControls}</div>
+    const advancedInline = (
+        <div className="flex flex-col [&>*:last-child]:!border-b-0">{advancedControls}</div>
+    )
 
     return {
         hasModelOrHarness,

--- a/web/packages/agenta-entity-ui/src/drawers/shared/RailField.tsx
+++ b/web/packages/agenta-entity-ui/src/drawers/shared/RailField.tsx
@@ -11,12 +11,28 @@
  */
 import type {ReactNode} from "react"
 
+import {Info} from "@phosphor-icons/react"
+import {Tooltip} from "antd"
+
 export interface RailFieldProps {
     label: ReactNode
     /** Vertical alignment of the label against the content. @default "top" */
     align?: "top" | "center"
     children: ReactNode
 }
+
+/**
+ * A rail-field label with a trailing info tooltip. Keeps each knob's help text without a separate
+ * description line, so rail rows stay one field per row (used by the sandbox/Claude permission forms).
+ */
+export const railInfoLabel = (label: ReactNode, hint: ReactNode): ReactNode => (
+    <span className="inline-flex items-center gap-1">
+        {label}
+        <Tooltip title={hint}>
+            <Info size={13} className="shrink-0 text-[var(--ag-colorTextTertiary)]" />
+        </Tooltip>
+    </span>
+)
 
 export function RailField({label, align = "top", children}: RailFieldProps) {
     return (

--- a/web/packages/agenta-entity-ui/src/drawers/shared/SectionRail.tsx
+++ b/web/packages/agenta-entity-ui/src/drawers/shared/SectionRail.tsx
@@ -25,6 +25,8 @@ export interface SectionRailProps {
     onChange: (value: string) => void
     /** Rail column width. @default "w-[116px]" */
     railWidth?: string
+    /** Disable the rail toggles (e.g. a read-only revision). @default false */
+    disabled?: boolean
     /** Right-hand content panel; separated from the rail by a left border. */
     children: ReactNode
 }
@@ -34,6 +36,7 @@ export function SectionRail({
     value,
     onChange,
     railWidth = "w-[116px]",
+    disabled = false,
     children,
 }: SectionRailProps) {
     return (
@@ -46,6 +49,7 @@ export function SectionRail({
                             key={item.value}
                             type="text"
                             block
+                            disabled={disabled}
                             onClick={() => onChange(item.value)}
                             className={`!h-8 !px-2.5 !text-xs ${
                                 item.count != null

--- a/web/packages/agenta-playground/src/index.ts
+++ b/web/packages/agenta-playground/src/index.ts
@@ -82,6 +82,14 @@ export type {AgentRequest, AgentChannelMode, NegotiatingFetch} from "./state"
 export {agentShouldResumeAfterApproval} from "./state"
 // Queued-message release gate for the agent chat composer (HITL-safe, one-by-one).
 export {canReleaseQueuedMessage, isHitlPending} from "./state"
+// Per-turn request capture + correlation helpers (Turn Inspector Context/Raw tabs).
+export {
+    appendCapped,
+    buildTurnCapture,
+    capturesForTrigger,
+    triggerUserMessageId,
+    type TurnRequestCapture,
+} from "./state"
 
 // ============================================================================
 // ENTITY CONTEXT (Dependency Injection)

--- a/web/packages/agenta-playground/src/state/execution/agentApprovalResume.ts
+++ b/web/packages/agenta-playground/src/state/execution/agentApprovalResume.ts
@@ -109,14 +109,30 @@ export function agentShouldResumeAfterApproval({messages}: {messages: MessageLik
     const last = messages[messages.length - 1]
     if (!last || last.role !== "assistant") return false
 
-    const toolParts = (last.parts ?? []).filter(
-        (part) => isToolPart(part) && part.providerExecuted !== true,
-    )
+    const parts = last.parts ?? []
+    const toolParts = parts.filter((part) => isToolPart(part) && part.providerExecuted !== true)
     if (toolParts.length === 0) return false
 
-    const hasResolved = toolParts.some(
-        (part) => isRespondedToolPart(part) || isClientToolResult(part),
-    )
+    // Index of the LAST freshly-resolved parked interaction (an approval response or a
+    // browser-fulfilled client-tool result). Using the last one handles chained gates: a second
+    // approval later in the turn is what should drive the (next) resume.
+    let lastResolvedIdx = -1
+    for (let i = 0; i < parts.length; i++) {
+        if (isRespondedToolPart(parts[i]) || isClientToolResult(parts[i])) lastResolvedIdx = i
+    }
+    if (lastResolvedIdx === -1) return false
+
+    // ALREADY RESUMED guard (the post-resolve loop). The cold-replay runner re-issues the approved
+    // tool under a FRESH id, so its execution output attaches to a NEW part and the original
+    // `approval-responded` part LINGERS in this same assistant message forever. Once the model has
+    // continued past the approval, a new step begins — a `step-start` part appears AFTER it. Without
+    // this guard the predicate keeps seeing the lingering `approval-responded` and auto-resends after
+    // every completion, re-running the whole turn endlessly (the loop the HITL fix exposed).
+    const resumedAlready = parts
+        .slice(lastResolvedIdx + 1)
+        .some((part) => part.type === "step-start")
+    if (resumedAlready) return false
+
     const allSettled = toolParts.every(isSettledToolPart)
-    return hasResolved && allSettled
+    return allSettled
 }

--- a/web/packages/agenta-playground/src/state/execution/agentMessageQueue.ts
+++ b/web/packages/agenta-playground/src/state/execution/agentMessageQueue.ts
@@ -32,29 +32,37 @@ const isToolPart = (part: ToolPartLike): boolean => {
 }
 
 /**
- * The last assistant turn is mid human-in-the-loop: a tool part is either awaiting the user's
- * decision (`approval-requested`) or carries one just given (`approval-responded`, a resume is
- * imminent). Either way the turn isn't really done, even though the stream may have settled.
+ * The last assistant turn is paused awaiting the user's decision on a tool gate
+ * (`approval-requested`) — the one HITL state the user can act on (via the ApprovalDock).
+ *
+ * Deliberately NOT `approval-responded`: that "resume is imminent" hold belongs SOLELY to
+ * `agentShouldResumeAfterApproval` (which `canReleaseQueuedMessage` composes). Counting it here too
+ * was redundant when the resume fires — and a trap when it doesn't: if the resume run dies before the
+ * approved tool part transitions (leaving an orphaned `approval-responded` alongside an unsettled
+ * sibling), the resume predicate goes false but this stayed true, freezing the queue with NO dock to
+ * unblock it (the dock reads `approval-requested` only, mirroring this). Narrowing to
+ * `approval-requested` keeps this in lockstep with `getPendingApprovals` so the freeze and the
+ * unblock UI can never disagree.
  */
 export function isHitlPending(messages: MessageLike[]): boolean {
     const last = messages[messages.length - 1]
     if (!last || last.role !== "assistant") return false
     return (last.parts ?? []).some(
-        (part) =>
-            isToolPart(part) &&
-            (part.state === "approval-requested" || part.state === "approval-responded"),
+        (part) => isToolPart(part) && part.state === "approval-requested",
     )
 }
 
 /**
- * A queued message may release ONLY when the stream has truly settled: the conversation is idle
- * (`status` "ready"), not mid-HITL, and not in the tick before the SDK auto-resumes an answered
- * approval. An "error" status deliberately does NOT release — the queue is held so the user can
- * retry or clear rather than firing follow-ups into a failed turn.
+ * A queued message may release ONLY when the stream has truly settled: the conversation is not
+ * busy, not awaiting a user approval decision, and not in the tick before the SDK auto-resumes an
+ * answered approval (that pre-resume hold is `agentShouldResumeAfterApproval`'s job alone). Both
+ * "ready" (turn done) and "error" (turn failed) are settled — releasing on "error" fires the
+ * user's queued message as a fresh turn (which clears the error), so a failed turn can't strand
+ * the queue forever. "submitted"/"streaming" are in-flight and hold.
  */
 export function canReleaseQueuedMessage(status: string, messages: MessageLike[]): boolean {
     return (
-        status === "ready" &&
+        (status === "ready" || status === "error") &&
         !isHitlPending(messages) &&
         !agentShouldResumeAfterApproval({messages})
     )

--- a/web/packages/agenta-playground/src/state/execution/index.ts
+++ b/web/packages/agenta-playground/src/state/execution/index.ts
@@ -366,3 +366,11 @@ export {createNegotiatingFetch, type NegotiatingFetch} from "./agentNegotiation"
 export {agentShouldResumeAfterApproval} from "./agentApprovalResume"
 // Agent-lane queued-message release gate (never releases mid-HITL or pre-resume).
 export {canReleaseQueuedMessage, isHitlPending} from "./agentMessageQueue"
+// Per-turn request capture + correlation helpers (Turn Inspector Context/Raw tabs).
+export {
+    appendCapped,
+    buildTurnCapture,
+    capturesForTrigger,
+    triggerUserMessageId,
+    type TurnRequestCapture,
+} from "./turnCapture"

--- a/web/packages/agenta-playground/src/state/execution/turnCapture.ts
+++ b/web/packages/agenta-playground/src/state/execution/turnCapture.ts
@@ -1,0 +1,75 @@
+/** A snapshot of one request sent to the agent, taken at send time so the Context/Raw tabs are
+ * accurate AT THAT TURN (the config drifts after a self-commit; reconstructing later lies). */
+export interface TurnRequestCapture {
+    requestId: string
+    at: number
+    /** Last `role:"user"` message id in the sent array; shared by a turn's initial send + resumes. */
+    triggerUserMessageId: string | null
+    parameters: unknown
+    messages: unknown[]
+    references: unknown
+    sessionId: string
+    invocationUrl: string
+}
+
+interface MessageLike {
+    id?: string
+    role?: string
+}
+
+export const triggerUserMessageId = (messages: MessageLike[]): string | null => {
+    for (let i = messages.length - 1; i >= 0; i--) {
+        if (messages[i]?.role === "user") return messages[i]?.id ?? null
+    }
+    return null
+}
+
+/** Build a capture from a built `AgentRequest` (the return of `buildAgentRequest`). `requestId`
+ * and `at` are supplied by the caller so this stays pure/testable. */
+export const buildTurnCapture = (
+    req: {invocationUrl: string; requestBody: Record<string, unknown>},
+    requestId: string,
+    at: number,
+): TurnRequestCapture => {
+    const body = req.requestBody as {
+        session_id?: string
+        references?: unknown
+        data?: {inputs?: {messages?: unknown[]}; parameters?: unknown}
+    }
+    const messages = body.data?.inputs?.messages ?? []
+    return {
+        requestId,
+        at,
+        triggerUserMessageId: triggerUserMessageId(messages as MessageLike[]),
+        parameters: body.data?.parameters ?? null,
+        messages,
+        references: body.references ?? null,
+        sessionId: body.session_id ?? "",
+        invocationUrl: req.invocationUrl,
+    }
+}
+
+/** All sends belonging to one turn (initial + resumes), by trigger id. */
+export const capturesForTrigger = (
+    captures: TurnRequestCapture[],
+    triggerId: string | null,
+): TurnRequestCapture[] =>
+    triggerId ? captures.filter((c) => c.triggerUserMessageId === triggerId) : []
+
+/** Append a capture, evicting the OLDEST whole turns (by distinct trigger id) beyond `maxTurns`
+ * so a kept turn never loses some of its sends. */
+export const appendCapped = (
+    captures: TurnRequestCapture[],
+    capture: TurnRequestCapture,
+    maxTurns: number,
+): TurnRequestCapture[] => {
+    const next = [...captures, capture]
+    const triggers: string[] = []
+    for (const c of next) {
+        const t = c.triggerUserMessageId ?? c.requestId
+        if (!triggers.includes(t)) triggers.push(t)
+    }
+    if (triggers.length <= maxTurns) return next
+    const keep = new Set(triggers.slice(triggers.length - maxTurns))
+    return next.filter((c) => keep.has(c.triggerUserMessageId ?? c.requestId))
+}

--- a/web/packages/agenta-playground/src/state/index.ts
+++ b/web/packages/agenta-playground/src/state/index.ts
@@ -185,6 +185,13 @@ export {agentChannelModeAtom, type AgentChannelMode} from "./execution"
 export {createNegotiatingFetch, type NegotiatingFetch} from "./execution"
 export {agentShouldResumeAfterApproval} from "./execution"
 export {canReleaseQueuedMessage, isHitlPending} from "./execution"
+export {
+    appendCapped,
+    buildTurnCapture,
+    capturesForTrigger,
+    triggerUserMessageId,
+    type TurnRequestCapture,
+} from "./execution"
 
 export {filterUnreferencedColumnsForSource} from "./execution"
 

--- a/web/packages/agenta-playground/tests/unit/agentApprovalResume.test.ts
+++ b/web/packages/agenta-playground/tests/unit/agentApprovalResume.test.ts
@@ -251,6 +251,72 @@ describe("agentShouldResumeAfterApproval", () => {
         expect(agentShouldResumeAfterApproval({messages})).toBe(false)
     })
 
+    it("does NOT resume once the model continued past the approval (post-resolve loop guard)", () => {
+        // The cold-replay resume APPENDS to the same assistant message: after the approved gate,
+        // a new step (`step-start`) begins and the tool re-runs under a fresh id (output-available).
+        // The original `approval-responded` part lingers — but the turn already resumed, so a
+        // SECOND auto-resend would re-run the whole turn forever. A step-start AFTER the resolved
+        // approval is the "already resumed" signal.
+        const messages = [
+            user("show config"),
+            {
+                id: "a1",
+                role: "assistant",
+                parts: [
+                    {type: "step-start"},
+                    {
+                        type: "tool-Terminal",
+                        toolCallId: "call_old",
+                        state: "approval-responded",
+                        input: {command: "cat settings.json"},
+                        approval: {id: "perm_1", approved: true},
+                    },
+                    {type: "step-start"},
+                    {
+                        type: "tool-Terminal",
+                        toolCallId: "call_new",
+                        state: "output-available",
+                        input: {command: "cat settings.json"},
+                        output: "No global settings found",
+                    },
+                    {type: "text", text: "Here's the current configuration…"},
+                ],
+            },
+        ]
+        expect(agentShouldResumeAfterApproval({messages})).toBe(false)
+    })
+
+    it("STILL resumes on a chained second approval later in the turn", () => {
+        // Two gates in one turn: the first was approved-and-resumed (step-start follows it), then a
+        // SECOND gate was just approved and is the tail — its approval still needs the resume.
+        const messages = [
+            user("do two"),
+            {
+                id: "a1",
+                role: "assistant",
+                parts: [
+                    {type: "step-start"},
+                    {
+                        type: "tool-Terminal",
+                        toolCallId: "call_1",
+                        state: "approval-responded",
+                        input: {command: "a"},
+                        approval: {id: "perm_1", approved: true},
+                    },
+                    {type: "step-start"},
+                    {
+                        type: "tool-Terminal",
+                        toolCallId: "call_2",
+                        state: "approval-responded",
+                        input: {command: "b"},
+                        approval: {id: "perm_2", approved: true},
+                    },
+                ],
+            },
+        ]
+        expect(agentShouldResumeAfterApproval({messages})).toBe(true)
+    })
+
     it("ignores provider-executed tool parts when deciding completeness", () => {
         const messages = [
             user("do it"),

--- a/web/packages/agenta-playground/tests/unit/agentMessageQueue.test.ts
+++ b/web/packages/agenta-playground/tests/unit/agentMessageQueue.test.ts
@@ -4,7 +4,10 @@
  * The load-bearing rule is HITL SAFETY: a queued user message must NOT be released while the
  * conversation is paused on a tool-approval gate (`approval-requested`) or in the tick after the
  * user answered it but before `useChat` auto-resumes (`approval-responded`). Releasing there
- * would inject a user turn between the assistant's tool gate and its resume.
+ * would inject a user turn between the assistant's tool gate and its resume. The pre-resume hold is
+ * owned by `agentShouldResumeAfterApproval` (composed into `canReleaseQueuedMessage`), NOT by
+ * `isHitlPending` — which tracks only the user-actionable `approval-requested` gate, in lockstep
+ * with the ApprovalDock, so a settled-but-un-resumed turn can't freeze the queue with no dock.
  */
 import {describe, expect, it} from "vitest"
 
@@ -33,15 +36,41 @@ const assistantWithTool = (state: string, approved?: boolean) => ({
     ],
 })
 
+/**
+ * The orphan-wedge: the user answered an approval (`approval-responded`) but the resume run died
+ * before the approved tool transitioned, leaving a sibling tool call stuck `input-available`. The
+ * turn has settled, `agentShouldResumeAfterApproval` won't fire (a sibling isn't settled), and no
+ * `approval-requested` remains → the dock is empty. This state must NOT freeze the queue.
+ */
+const assistantWithOrphanApproval = () => ({
+    id: "a1",
+    role: "assistant",
+    parts: [
+        {type: "step-start"},
+        {
+            type: "tool-deleteFile",
+            toolCallId: "call_1",
+            state: "approval-responded",
+            input: {path: "/x"},
+            approval: {id: "perm_1", approved: true},
+        },
+        {type: "tool-listFiles", toolCallId: "call_2", state: "input-available", input: {}},
+    ],
+})
+
 describe("isHitlPending", () => {
     it("is true while awaiting the user's decision (approval-requested)", () => {
         expect(isHitlPending([user("do it"), assistantWithTool("approval-requested")])).toBe(true)
     })
 
-    it("is true right after a decision, before the resume fires (approval-responded)", () => {
+    it("is false after a decision (approval-responded) — the pre-resume hold is the resume predicate's job, not this", () => {
         expect(isHitlPending([user("do it"), assistantWithTool("approval-responded", true)])).toBe(
-            true,
+            false,
         )
+    })
+
+    it("is false for an orphaned approval-responded turn (no approval-requested → nothing to act on)", () => {
+        expect(isHitlPending([user("do it"), assistantWithOrphanApproval()])).toBe(false)
     })
 
     it("is false once the tool has run (output-available)", () => {
@@ -74,8 +103,17 @@ describe("canReleaseQueuedMessage", () => {
         expect(canReleaseQueuedMessage("submitted", [user("hi")])).toBe(false)
     })
 
-    it("does NOT release on error (queue is held for retry/clear)", () => {
-        expect(canReleaseQueuedMessage("error", [user("hi"), assistantText("partial")])).toBe(false)
+    it("releases on error so a failed turn re-sends the queued message (which clears the error)", () => {
+        expect(canReleaseQueuedMessage("error", [user("hi"), assistantText("partial")])).toBe(true)
+    })
+
+    it("does NOT release on error while a tool approval is still pending", () => {
+        expect(
+            canReleaseQueuedMessage("error", [
+                user("do it"),
+                assistantWithTool("approval-requested"),
+            ]),
+        ).toBe(false)
     })
 
     it("does NOT release while a tool approval is pending, even though status is ready", () => {
@@ -106,6 +144,15 @@ describe("canReleaseQueuedMessage", () => {
                 assistantWithTool("approval-responded", false),
             ]),
         ).toBe(false)
+    })
+
+    it("RELEASES an orphaned approval-responded turn so a wedged run can't freeze the queue forever", () => {
+        // Resume died before the approved tool transitioned; a sibling is stuck `input-available`, so
+        // `agentShouldResumeAfterApproval` is false and no `approval-requested` remains (empty dock).
+        // The queue must release here — the freed message re-sends and recovers the wedged turn.
+        expect(
+            canReleaseQueuedMessage("ready", [user("do it"), assistantWithOrphanApproval()]),
+        ).toBe(true)
     })
 
     it("releases once the approved tool has produced output and the turn settled", () => {

--- a/web/packages/agenta-playground/tests/unit/turnCapture.test.ts
+++ b/web/packages/agenta-playground/tests/unit/turnCapture.test.ts
@@ -1,0 +1,83 @@
+import {describe, expect, it} from "vitest"
+
+import {
+    appendCapped,
+    buildTurnCapture,
+    capturesForTrigger,
+    triggerUserMessageId,
+} from "../../src/state/execution/turnCapture"
+
+describe("turnCapture", () => {
+    it("finds the last user message id as the trigger", () => {
+        const messages = [
+            {id: "u1", role: "user"},
+            {id: "a1", role: "assistant"},
+            {id: "u2", role: "user"},
+            {id: "a2", role: "assistant"},
+        ]
+        expect(triggerUserMessageId(messages)).toBe("u2")
+    })
+
+    it("returns null when there is no user message", () => {
+        expect(triggerUserMessageId([{id: "a1", role: "assistant"}])).toBeNull()
+    })
+
+    it("builds a capture from a built AgentRequest", () => {
+        const req = {
+            invocationUrl: "https://x/invoke?project_id=p",
+            requestBody: {
+                session_id: "s1",
+                references: {application: {id: "app"}},
+                data: {
+                    inputs: {messages: [{id: "u1", role: "user"}]},
+                    parameters: {agent: {instructions: {agents_md: "hi"}}},
+                },
+            },
+        }
+        const c = buildTurnCapture(req, "req-1", 1000)
+        expect(c).toEqual({
+            requestId: "req-1",
+            at: 1000,
+            triggerUserMessageId: "u1",
+            parameters: {agent: {instructions: {agents_md: "hi"}}},
+            messages: [{id: "u1", role: "user"}],
+            references: {application: {id: "app"}},
+            sessionId: "s1",
+            invocationUrl: "https://x/invoke?project_id=p",
+        })
+    })
+
+    it("groups all sends of a turn under one trigger id", () => {
+        const base = {
+            parameters: {},
+            messages: [],
+            references: null,
+            sessionId: "s",
+            invocationUrl: "u",
+        }
+        const captures = [
+            {...base, requestId: "r1", at: 1, triggerUserMessageId: "u1"},
+            {...base, requestId: "r2", at: 2, triggerUserMessageId: "u1"},
+            {...base, requestId: "r3", at: 3, triggerUserMessageId: "u2"},
+        ]
+        expect(capturesForTrigger(captures, "u1").map((c) => c.requestId)).toEqual(["r1", "r2"])
+        expect(capturesForTrigger(captures, null)).toEqual([])
+    })
+
+    it("evicts the oldest whole turns beyond the cap, keeping all sends of kept turns", () => {
+        const base = {
+            parameters: {},
+            messages: [],
+            references: null,
+            sessionId: "s",
+            invocationUrl: "u",
+        }
+        let list: ReturnType<typeof capturesForTrigger> = []
+        list = appendCapped(list, {...base, requestId: "r1", at: 1, triggerUserMessageId: "u1"}, 2)
+        list = appendCapped(list, {...base, requestId: "r1b", at: 2, triggerUserMessageId: "u1"}, 2)
+        list = appendCapped(list, {...base, requestId: "r2", at: 3, triggerUserMessageId: "u2"}, 2)
+        list = appendCapped(list, {...base, requestId: "r3", at: 4, triggerUserMessageId: "u3"}, 2)
+        // u1 (oldest turn) evicted; both u1 sends gone; u2 + u3 kept.
+        expect(list.map((c) => c.triggerUserMessageId)).toEqual(["u2", "u3"])
+    })
+})

--- a/web/packages/agenta-ui/src/RichChatInput/RichChatInput.tsx
+++ b/web/packages/agenta-ui/src/RichChatInput/RichChatInput.tsx
@@ -2,11 +2,14 @@ import {forwardRef, type ReactNode, useEffect, useImperativeHandle, useRef, useS
 
 import {CodeHighlightNode, CodeNode} from "@lexical/code"
 import {HistoryExtension} from "@lexical/history"
+import {LinkNode} from "@lexical/link"
 import {ListItemNode, ListNode} from "@lexical/list"
 import {$convertFromMarkdownString} from "@lexical/markdown"
 import {AutoFocusPlugin} from "@lexical/react/LexicalAutoFocusPlugin"
+import {ClickableLinkPlugin} from "@lexical/react/LexicalClickableLinkPlugin"
 import {ContentEditable} from "@lexical/react/LexicalContentEditable"
 import {LexicalExtensionComposer} from "@lexical/react/LexicalExtensionComposer"
+import {LinkPlugin} from "@lexical/react/LexicalLinkPlugin"
 import {ListPlugin} from "@lexical/react/LexicalListPlugin"
 import {MarkdownShortcutPlugin} from "@lexical/react/LexicalMarkdownShortcutPlugin"
 import {TabIndentationPlugin} from "@lexical/react/LexicalTabIndentationPlugin"
@@ -17,8 +20,10 @@ import {$createParagraphNode, $getRoot, defineExtension, type LexicalEditor} fro
 import {chatInputTheme} from "./assets/theme"
 import {CHAT_TRANSFORMERS} from "./assets/transformers"
 import {CharacterCountPlugin} from "./plugins/CharacterCountPlugin"
+import {CodeFencePlugin} from "./plugins/CodeFencePlugin"
 import {EditableSyncPlugin} from "./plugins/EditableSyncPlugin"
 import {EditorRefBridge} from "./plugins/EditorRefBridge"
+import {LinkPastePlugin} from "./plugins/LinkPastePlugin"
 import {SendButton} from "./plugins/SendButton"
 import {SubmitPlugin} from "./plugins/SubmitPlugin"
 
@@ -63,7 +68,7 @@ const chatInputExtension = defineExtension({
     name: "@agenta/ui/rich-chat-input",
     namespace: "@agenta/ui/rich-chat-input",
     dependencies: [RichTextExtension, HistoryExtension],
-    nodes: [ListNode, ListItemNode, CodeNode, CodeHighlightNode],
+    nodes: [ListNode, ListItemNode, CodeNode, CodeHighlightNode, LinkNode],
     theme: chatInputTheme,
 })
 
@@ -205,7 +210,15 @@ export const RichChatInput = forwardRef<RichChatInputHandle, RichChatInputProps>
                     <ListPlugin />
                     {/* Tab / Shift+Tab indents + outdents list items (nesting). */}
                     <TabIndentationPlugin />
+                    {/* Link node behavior + the TOGGLE_LINK_COMMAND the paste plugin dispatches.
+                        ClickableLinkPlugin opens a clicked link in a new tab (newTab defaults true);
+                        it still lets you drag-select link text to edit it. */}
+                    <LinkPlugin />
+                    <ClickableLinkPlugin newTab />
+                    <LinkPastePlugin />
                     <MarkdownShortcutPlugin transformers={CHAT_TRANSFORMERS} />
+                    {/* Enter on a lone ``` fence opener → code block (runs before SubmitPlugin). */}
+                    <CodeFencePlugin />
                     <SubmitPlugin onSubmit={onSubmit} />
                     <CharacterCountPlugin onCountChange={setCount} />
                 </div>

--- a/web/packages/agenta-ui/src/RichChatInput/RichChatInput.tsx
+++ b/web/packages/agenta-ui/src/RichChatInput/RichChatInput.tsx
@@ -142,9 +142,9 @@ export const RichChatInput = forwardRef<RichChatInputHandle, RichChatInputProps>
                         // editor + toolbar to the rounded corners. The toolbar has no divider of its
                         // own, so the bottom edge reads as one border, not two.
                         "relative flex flex-col overflow-hidden rounded-lg border border-solid bg-[var(--ag-colorBgContainer)] transition-colors",
-                        // Neutral, low-key focus emphasis — a soft border darkening rather than the
-                        // full brand-primary ring, which was too loud for a chat composer.
-                        "border-[var(--ag-colorBorder)] focus-within:border-[var(--ag-colorTextTertiary)]",
+                        // Neutral, low-key focus emphasis — a soft one-step border darkening rather
+                        // than the full brand-primary ring, which was too loud for a chat composer.
+                        "border-[var(--ag-colorBorderSecondary)] focus-within:border-[var(--ag-colorBorder)]",
                         disabled && "opacity-60",
                         className,
                     )}
@@ -181,25 +181,33 @@ export const RichChatInput = forwardRef<RichChatInputHandle, RichChatInputProps>
                             <ShortcutHint keys="↵" label="Send" />
                             <ShortcutHint keys={`${modKey} ↵`} label="Newline" />
                         </div>
-                        <span
-                            className={clsx(
-                                "ml-auto shrink-0 text-xs tabular-nums",
-                                overLimit
-                                    ? "text-[var(--ag-colorError)]"
-                                    : "text-[var(--ag-colorTextTertiary)]",
+                        <div className="ml-auto flex items-center gap-2">
+                            {/* Only show a counter when there's a limit to track against, or when the
+                                user has actually typed — a lone "0" beside the button is just clutter. */}
+                            {(typeof maxLength === "number" || count > 0) && (
+                                <span
+                                    className={clsx(
+                                        "shrink-0 text-xs tabular-nums",
+                                        overLimit
+                                            ? "text-[var(--ag-colorError)]"
+                                            : "text-[var(--ag-colorTextTertiary)]",
+                                    )}
+                                >
+                                    {typeof maxLength === "number"
+                                        ? `${count}/${maxLength}`
+                                        : count}
+                                </span>
                             )}
-                        >
-                            {typeof maxLength === "number" ? `${count}/${maxLength}` : count}
-                        </span>
-                        {hideSendButton ? null : (
-                            <SendButton
-                                onSubmit={onSubmit}
-                                forceEnabled={sendForceEnabled}
-                                disabled={disabled}
-                                streaming={streaming}
-                                onStop={onStop}
-                            />
-                        )}
+                            {hideSendButton ? null : (
+                                <SendButton
+                                    onSubmit={onSubmit}
+                                    forceEnabled={sendForceEnabled}
+                                    disabled={disabled}
+                                    streaming={streaming}
+                                    onStop={onStop}
+                                />
+                            )}
+                        </div>
                     </div>
 
                     {footer ? <div className="px-2 pb-1.5">{footer}</div> : null}

--- a/web/packages/agenta-ui/src/RichChatInput/assets/theme.ts
+++ b/web/packages/agenta-ui/src/RichChatInput/assets/theme.ts
@@ -1,14 +1,21 @@
 import {type EditorThemeClasses} from "lexical"
 
 /**
- * Self-contained theme using Tailwind utilities + antd semantic tokens (no
- * `dark:` — dark mode is handled by the CSS variables). bold/italic need
- * explicit classes or Lexical renders the format unstyled.
+ * Self-contained theme using Tailwind utilities + antd semantic tokens (no `dark:` — dark mode is
+ * handled by the CSS variables). bold/italic need explicit classes or Lexical renders the format
+ * unstyled.
+ *
+ * Kept in lock-step with the message bubble's markdown styling (web/oss AgentChatSlice
+ * assets/markdown.tsx `MD_CLASS`) — same tokens/values — so a block looks identical while you type
+ * it and after it's sent. In particular the blockquote needs the left rule + secondary text + italic
+ * (the italic is what visually distinguishes it from a paragraph); a subtle border alone reads as
+ * plain text.
  */
 export const chatInputTheme: EditorThemeClasses = {
     paragraph: "m-0",
-    code: "my-1 block overflow-x-auto whitespace-pre rounded bg-[var(--ag-colorFillSecondary)] p-2 font-mono text-[0.85em] leading-snug",
-    quote: "my-1 border-l-2 border-solid border-[var(--ag-colorBorder)] pl-3 text-[var(--ag-colorTextSecondary)]",
+    link: "text-colorPrimary underline break-all cursor-pointer",
+    code: "my-1 block overflow-x-auto whitespace-pre rounded bg-colorFillTertiary p-2 font-mono text-[0.85em] leading-snug",
+    quote: "my-1 mx-0 pl-3 text-left border-y-0 border-r-0 border-l-2 border-solid border-colorTextTertiary italic text-colorTextSecondary",
     list: {
         ul: "my-1 list-disc pl-5",
         ol: "my-1 list-decimal pl-5",
@@ -20,6 +27,6 @@ export const chatInputTheme: EditorThemeClasses = {
     text: {
         bold: "font-semibold",
         italic: "italic",
-        code: "rounded bg-[var(--ag-colorFillSecondary)] px-1 py-0.5 font-mono text-[0.85em]",
+        code: "rounded bg-colorFillTertiary px-1 py-0.5 font-mono text-[0.85em]",
     },
 }

--- a/web/packages/agenta-ui/src/RichChatInput/assets/transformers.ts
+++ b/web/packages/agenta-ui/src/RichChatInput/assets/transformers.ts
@@ -7,6 +7,7 @@ import {
     INLINE_CODE,
     ITALIC_STAR,
     ITALIC_UNDERSCORE,
+    LINK,
     ORDERED_LIST,
     QUOTE,
     UNORDERED_LIST,
@@ -17,7 +18,8 @@ import {
  * Curated markdown transformer set for the chat composer. Drives BOTH live
  * typing (e.g. `- ` → bullet list, ` ``` ` → code block) and serialization on
  * send, so what the user types round-trips to markdown cleanly. Deliberately
- * omits headings, checklists, links and tables to keep a chat message light.
+ * omits headings, checklists and tables to keep a chat message light. LINK is
+ * included so a pasted URL (wrapped over a selection) serializes to `[text](url)`.
  */
 export const CHAT_TRANSFORMERS: Transformer[] = [
     UNORDERED_LIST,
@@ -33,4 +35,6 @@ export const CHAT_TRANSFORMERS: Transformer[] = [
     BOLD_UNDERSCORE,
     ITALIC_STAR,
     ITALIC_UNDERSCORE,
+    // Text-match: `[text](url)` ↔ link node (serialization + typed-markdown).
+    LINK,
 ]

--- a/web/packages/agenta-ui/src/RichChatInput/plugins/CodeFencePlugin.tsx
+++ b/web/packages/agenta-ui/src/RichChatInput/plugins/CodeFencePlugin.tsx
@@ -1,0 +1,49 @@
+import {useEffect} from "react"
+
+import {$createCodeNode} from "@lexical/code"
+import {useLexicalComposerContext} from "@lexical/react/LexicalComposerContext"
+import {
+    $getSelection,
+    $isParagraphNode,
+    $isRangeSelection,
+    COMMAND_PRIORITY_CRITICAL,
+    KEY_ENTER_COMMAND,
+} from "lexical"
+
+// A whole line that is just a fence opener: ``` optionally followed by a bare language token.
+const FENCE_OPENER = /^`{3,}[a-z0-9+#-]*$/i
+
+/**
+ * Basic code-block support for the chat composer. Pressing Enter on a line that is a lone ``` fence
+ * opener turns it into a (plain, no-highlight) code block. Needed because plain Enter is Send and
+ * ⌘/Shift+Enter is a newline (both handled by SubmitPlugin), so the markdown CODE transformer's own
+ * Enter trigger never fires here. Runs at CRITICAL priority so it wins over SubmitPlugin; anything
+ * that isn't a fence opener falls through to the normal send/newline behaviour. (The ``` + space
+ * markdown shortcut keeps working too.)
+ */
+export function CodeFencePlugin() {
+    const [editor] = useLexicalComposerContext()
+
+    useEffect(() => {
+        return editor.registerCommand(
+            KEY_ENTER_COMMAND,
+            (event) => {
+                if (!editor.isEditable() || (event && event.isComposing)) return false
+                const selection = $getSelection()
+                if (!$isRangeSelection(selection) || !selection.isCollapsed()) return false
+                const block = selection.anchor.getNode().getTopLevelElement()
+                if (!$isParagraphNode(block) || !FENCE_OPENER.test(block.getTextContent().trim())) {
+                    return false
+                }
+                event?.preventDefault()
+                const codeNode = $createCodeNode()
+                block.replace(codeNode)
+                codeNode.selectStart()
+                return true
+            },
+            COMMAND_PRIORITY_CRITICAL,
+        )
+    }, [editor])
+
+    return null
+}

--- a/web/packages/agenta-ui/src/RichChatInput/plugins/LinkPastePlugin.tsx
+++ b/web/packages/agenta-ui/src/RichChatInput/plugins/LinkPastePlugin.tsx
@@ -1,0 +1,47 @@
+import {useEffect} from "react"
+
+import {TOGGLE_LINK_COMMAND} from "@lexical/link"
+import {useLexicalComposerContext} from "@lexical/react/LexicalComposerContext"
+import {$getSelection, $isRangeSelection, COMMAND_PRIORITY_CRITICAL, PASTE_COMMAND} from "lexical"
+
+const URL_WITH_SCHEME = /^(?:https?:\/\/|mailto:)[^\s]+$/i
+const BARE_WWW = /^www\.[^\s]+$/i
+
+/** Normalize pasted text to a link href, or null when it isn't a single bare URL. */
+function toLinkHref(text: string): string | null {
+    if (URL_WITH_SCHEME.test(text)) return text
+    if (BARE_WWW.test(text)) return `https://${text}`
+    return null
+}
+
+/**
+ * Paste a URL over a non-empty text selection → wrap the selection in a link (the expected rich-editor
+ * behaviour). Registered at CRITICAL priority so it runs before Lexical's default paste, which would
+ * otherwise just drop the URL in as text. It only acts on "a lone URL over a range selection" and
+ * returns false otherwise, so ordinary paste and the file-paste handler are left untouched.
+ */
+export function LinkPastePlugin() {
+    const [editor] = useLexicalComposerContext()
+
+    useEffect(() => {
+        return editor.registerCommand(
+            PASTE_COMMAND,
+            (event) => {
+                const clipboard = (event as ClipboardEvent).clipboardData
+                if (!clipboard) return false
+                // A URL paste never carries files; bail so the file-paste path stays in charge.
+                if (clipboard.files && clipboard.files.length > 0) return false
+                const href = toLinkHref(clipboard.getData("text/plain").trim())
+                if (!href) return false
+                const selection = $getSelection()
+                if (!$isRangeSelection(selection) || selection.isCollapsed()) return false
+                event.preventDefault()
+                editor.dispatchCommand(TOGGLE_LINK_COMMAND, href)
+                return true
+            },
+            COMMAND_PRIORITY_CRITICAL,
+        )
+    }, [editor])
+
+    return null
+}

--- a/web/packages/agenta-ui/src/RichChatInput/plugins/SendButton.tsx
+++ b/web/packages/agenta-ui/src/RichChatInput/plugins/SendButton.tsx
@@ -40,19 +40,33 @@ export function SendButton({onSubmit, forceEnabled, disabled, streaming, onStop}
 
     if (streaming) {
         // A spinning ring (stream in progress) around a Stop square — one affordance that both
-        // signals progress and stops the run on click.
+        // signals progress and stops the run on click. Two-layer ring: a faint neutral track under
+        // a thin, muted-primary arc, so the accent reads as a calm progress cue rather than a loud
+        // full-saturation halo; the Stop glyph stays neutral so the accent isn't doubled up.
         return (
             <span className="relative inline-flex">
                 <span
                     aria-hidden
-                    className="pointer-events-none absolute inset-0 animate-spin rounded-full border-2 border-solid border-[var(--ag-colorPrimary)] border-t-transparent"
+                    className="pointer-events-none absolute inset-0 rounded-full border-[1.5px] border-solid border-[var(--ag-colorFillSecondary)]"
+                />
+                <span
+                    aria-hidden
+                    className="pointer-events-none absolute inset-0 animate-spin rounded-full border-[1.5px] border-solid border-transparent"
+                    style={{
+                        borderTopColor:
+                            "color-mix(in srgb, var(--ag-colorPrimary) 60%, var(--ag-colorBgContainer))",
+                    }}
                 />
                 <Button
                     type="text"
                     shape="circle"
                     aria-label="Stop"
                     icon={
-                        <Stop size={14} weight="fill" className="text-[var(--ag-colorPrimary)]" />
+                        <Stop
+                            size={13}
+                            weight="fill"
+                            className="text-[var(--ag-colorTextSecondary)]"
+                        />
                     }
                     onClick={onStop}
                 />


### PR DESCRIPTION
## What

A batch of agent-playground work layered on `big-agents`: builder-facing tooling for inspecting a turn, a persistent HITL approval surface, richer chat input, and a set of runner/SDK/FE fixes so tool inputs, outputs, and approvals render faithfully. Includes the end-to-end fix for the HITL approval **resume loop**.

## Why

The agent playground could run an agent but gave builders little insight into *what happened* in a turn, and several streaming-fidelity bugs made tool activity hard to trust — tool inputs showed `{}`, and any tool requiring human approval got stuck in an **infinite re-approval loop**, never showing its output.

## Changes

**Turn Inspector (Build-mode tooling)** — a per-session inline side panel (Timeline / Context / Raw) that reads the live `useChat` messages: the full round (user message → reasoning → tool I/O → response), the exact config + messages sent, and copyable raw payloads. Mode-adaptive empty state (agent-aware in Build, warm-minimal in Chat). Design + plan docs under `docs/design/agent-workflows/projects/agent-turn-inspector/`.

**Build-mode step log** — inline per-tool input/output/error blocks, individually collapsible.

**HITL approval dock** — a persistent, non-scrolling approval surface with a hardened queue release, replacing the inline-only gate.

**Chat UX** — rich chat input (links, code blocks), calmer composer, and scroll engineering (pin new turn, stop jump-to-top on stream-state change / tool collapse).

### HITL approval resume loop — root cause + fix (runner · SDK · FE)

An approved tool kept re-parking forever and never showed output. Traced through the live runner logs to a chain of same-root issues — the cold-replay runner re-issues the approved tool under a **fresh tool-call id**, so its output never lands on the approved part:

- **Runner** — the cross-turn approval key drifted. Claude-over-ACP names the same call differently across frames (the `session/update` tool_call titles it `Terminal`; the permission request titles it the full command), and neither carries a stable `name`/`spec`. The key now anchors on the **recorded tool_call name** (stamped as `resolvedName`), so the live re-raised key equals the stored key and the gate resolves. Kept the non-converging loop-breaker + `[HITL]` diagnostics as a fail-safe.
- **SDK** — the vercel egress mirrors that anchor (`resolvedName` → spec name → title) and no longer lets a late arg-refresh downgrade the name; `[HITL]` egress/ingress logging for the round-trip.
- **FE (resume predicate)** — `agentShouldResumeAfterApproval` re-sent after every completion because the answered `approval-responded` part lingers in the message; now guarded on "already resumed" (a `step-start` follows the approval), so it resumes exactly once.
- **FE (tool rendering)** — the lingering answered gate rendered as a perpetual spinner with no output. `AgentMessage` collapses it into its executed sibling (same tool + input), `ToolActivity` treats `approval-responded` as resolved (approved, not running), and tool **output** (not just errors) has its markdown code fence stripped.

**Tool inputs** — emit the `tool_call` up front (so the FE part + HITL approval attach to it), then refresh its input when the real args arrive on a later `tool_call_update`; fixes the always-`{}` display for non-gated tools without breaking the emit-first invariant. Unique vercel-stream `messageId` per turn.

## Verification

- Runner: `tsc` clean; unit suite green. Live-log confirmed: `gate "Terminal" -> stored allow (resume matched)` and the tool executes.
- SDK: agents unit suite green + ruff clean; new egress tests (spec/resolved-name anchor, arg-refresh no-clobber, park-refresh).
- Frontend: resume-predicate tests green (post-resolve guard + chained approval); `tsc` clean for the touched agent-chat files.

Merged latest `big-agents` in (resolved two cosmetic conflicts: copy-button "Copied" feedback in `AgentMessage`, and chat-input `theme.ts` quote style kept in lock-step with the message bubble's `markdown.tsx`). Manual browser verification of the inspector / dock / step-log and a park→approve→run pass is still worth doing before merge.
