### PR TITLE
[fix] Resolve broken use of composio auth_scheme

### DIFF
--- a/api/oss/src/apis/fastapi/tools/router.py
+++ b/api/oss/src/apis/fastapi/tools/router.py
@@ -710,13 +710,6 @@ class ToolsRouter:
                 },
             )
 
-        if isinstance(body.connection.data, dict):
-            body.connection.data = {
-                k: v
-                for k, v in body.connection.data.items()
-                if k not in {"callback_url", "auth_scheme"}
-            } or None
-
         connection = await self.tools_service.create_connection(
             project_id=UUID(request.state.project_id),
             user_id=UUID(request.state.user_id),

--- a/api/oss/src/apis/fastapi/triggers/router.py
+++ b/api/oss/src/apis/fastapi/triggers/router.py
@@ -508,13 +508,6 @@ class TriggersRouter:
                 },
             )
 
-        if isinstance(body.connection.data, dict):
-            body.connection.data = {
-                k: v
-                for k, v in body.connection.data.items()
-                if k not in {"callback_url", "auth_scheme"}
-            } or None
-
         connection = await self.triggers_service.create_connection(
             project_id=UUID(request.state.project_id),
             user_id=UUID(request.state.user_id),

--- a/api/oss/src/core/gateway/connections/dtos.py
+++ b/api/oss/src/core/gateway/connections/dtos.py
@@ -1,5 +1,5 @@
 from enum import Enum
-from typing import Any, Dict, Optional, Union
+from typing import Any, Dict, Optional
 
 from pydantic import BaseModel, Field
 
@@ -37,9 +37,18 @@ class ConnectionStatus(BaseModel):
 
 
 class ConnectionCreateData(BaseModel):
+    # Control inputs (from the API): route the provider auth-config type. Never
+    # persisted — the service overwrites data wholesale before the DAO write.
     callback_url: Optional[str] = None
-    #
     auth_scheme: Optional[ConnectionAuthScheme] = None
+    # Provider + service outputs (persisted): the service fills these from the
+    # provider result before persistence. No secrets — the API key is entered on
+    # the provider's hosted redirect UI, never in this payload.
+    connected_account_id: Optional[str] = None
+    auth_config_id: Optional[str] = None
+    redirect_url: Optional[str] = None
+    project_id: Optional[str] = None
+    no_auth: Optional[bool] = None
 
 
 class Connection(
@@ -96,9 +105,7 @@ class ConnectionCreate(
     provider_key: ConnectionProviderKind
     integration_key: str
     #
-    # Either the typed create input (from the API) or the provider-shaped payload
-    # the service builds before persistence (provider field names are opaque here).
-    data: Optional[Union[ConnectionCreateData, Json]] = None
+    data: Optional[ConnectionCreateData] = None
 
 
 class Usage(BaseModel):

--- a/api/oss/src/core/gateway/connections/service.py
+++ b/api/oss/src/core/gateway/connections/service.py
@@ -178,10 +178,18 @@ class ConnectionsService:
             ),
         )
 
+        # Effective auth scheme is a durable fact about the connection; persist it.
+        auth_scheme = (
+            connection_create_data.auth_scheme.value
+            if connection_create_data and connection_create_data.auth_scheme
+            else None
+        )
+
         # Merge provider-returned connection_data with service-level project_id.
         # The adapter owns provider-specific field names; the service adds project scope.
         data: Dict[str, Any] = dict(provider_result.connection_data)
         data["project_id"] = str(project_id)
+        data["auth_scheme"] = auth_scheme
         connection_create.data = data
 
         # Validity is server-owned, never client-supplied. An auth-backed connection is

--- a/api/oss/src/core/tools/dtos.py
+++ b/api/oss/src/core/tools/dtos.py
@@ -118,7 +118,7 @@ class ToolConnection(Connection):
 
 class ToolConnectionCreate(ConnectionCreate):
     provider_key: ToolProviderKind
-    data: Optional[Union[ToolConnectionCreateData, Json]] = None
+    data: Optional[ToolConnectionCreateData] = None
 
 
 # ---------------------------------------------------------------------------

--- a/api/oss/src/core/triggers/dtos.py
+++ b/api/oss/src/core/triggers/dtos.py
@@ -18,7 +18,6 @@ from oss.src.core.gateway.connections.dtos import (
 from oss.src.core.shared.dtos import (
     Header,
     Identifier,
-    Json,
     Lifecycle,
     Metadata,
     Reference,
@@ -192,7 +191,7 @@ class TriggerConnection(Connection):
 
 class TriggerConnectionCreate(ConnectionCreate):
     provider_key: TriggerProviderKind
-    data: Optional[Union[TriggerConnectionCreateData, Json]] = None
+    data: Optional[TriggerConnectionCreateData] = None
 
 
 # ---------------------------------------------------------------------------

--- a/api/oss/src/dbs/postgres/gateway/connections/mappings.py
+++ b/api/oss/src/dbs/postgres/gateway/connections/mappings.py
@@ -17,11 +17,12 @@ def map_connection_create_to_dbe(
     #
     dto: ConnectionCreate,
 ) -> ConnectionDBE:
-    # Serialize provider-specific data to dict if present
+    # The service replaces data with a provider-shaped dict before persistence;
+    # a typed model (validate-on-assignment is off) is dumped, dropping unset keys.
     data = None
     if dto.data:
         if isinstance(dto.data, BaseModel):
-            data = dto.data.model_dump()
+            data = dto.data.model_dump(exclude_none=True)
         else:
             data = dto.data
 

--- a/web/oss/src/components/pages/settings/Tools/components/ConnectModal.tsx
+++ b/web/oss/src/components/pages/settings/Tools/components/ConnectModal.tsx
@@ -57,9 +57,6 @@ export default function ConnectModal({
                 slug: values.slug,
                 name: values.name || values.slug,
                 mode: selectedMode,
-                ...(selectedMode === "api_key" && values.api_key
-                    ? {credentials: {api_key: values.api_key}}
-                    : {}),
             }
 
             const result = await handleCreate(payload)
@@ -69,7 +66,7 @@ export default function ConnectModal({
                     : undefined
 
             if (redirectUrl) {
-                // OAuth: open popup window
+                // OAuth and API key both authorize on the provider's hosted redirect UI.
                 const popup = window.open(
                     redirectUrl,
                     "tools_oauth",
@@ -90,7 +87,7 @@ export default function ConnectModal({
                     }
                 }, 1000)
             } else {
-                // API key flow: connection created immediately
+                // No-auth toolkit: connection created immediately, no redirect.
                 handleClose()
             }
         } catch {
@@ -136,16 +133,6 @@ export default function ConnectModal({
                                 label: m === "oauth" ? "OAuth" : "API Key",
                             }))}
                         />
-                    </Form.Item>
-                )}
-
-                {selectedMode === "api_key" && (
-                    <Form.Item
-                        name="api_key"
-                        label="API Key"
-                        rules={[{required: true, message: "API key is required"}]}
-                    >
-                        <Input.Password placeholder="Enter API key" />
                     </Form.Item>
                 )}
             </Form>

--- a/web/oss/src/components/pages/settings/Tools/components/ConnectionsList.tsx
+++ b/web/oss/src/components/pages/settings/Tools/components/ConnectionsList.tsx
@@ -3,7 +3,7 @@ import {useMemo} from "react"
 import type {ToolConnection} from "@agenta/entities/gatewayTool"
 import {ConnectionStatusBadge} from "@agenta/entity-ui/gatewayTool"
 import {ArrowClockwise, GearSix, Trash} from "@phosphor-icons/react"
-import {Button, Table, Tooltip, Typography} from "antd"
+import {Button, Table, Tag, Tooltip, Typography} from "antd"
 import type {ColumnsType} from "antd/es/table"
 
 import AlertPopup from "@/oss/components/AlertPopup/AlertPopup"
@@ -20,6 +20,11 @@ const getRedirectUrl = (connection: ToolConnection | null | undefined): string |
     if (!connection) return undefined
     const dataRedirect = connection.data?.redirect_url
     return typeof dataRedirect === "string" && dataRedirect ? dataRedirect : undefined
+}
+
+const AUTH_SCHEME_LABELS: Record<string, string> = {
+    oauth: "OAuth",
+    api_key: "API Key",
 }
 
 export default function ConnectionsList({integrationKey, connections}: Props) {
@@ -75,6 +80,19 @@ export default function ConnectionsList({integrationKey, connections}: Props) {
                 key: "status",
                 width: 120,
                 render: (_, record) => <ConnectionStatusBadge connection={record} />,
+            },
+            {
+                title: "Auth",
+                key: "auth_scheme",
+                width: 100,
+                render: (_, record) => {
+                    const scheme =
+                        typeof record.data?.auth_scheme === "string"
+                            ? record.data.auth_scheme
+                            : undefined
+                    if (!scheme) return <Typography.Text type="secondary">—</Typography.Text>
+                    return <Tag>{AUTH_SCHEME_LABELS[scheme] ?? scheme}</Tag>
+                },
             },
             {
                 title: "Created",

--- a/web/oss/src/components/pages/settings/Tools/components/GatewayToolsSection.tsx
+++ b/web/oss/src/components/pages/settings/Tools/components/GatewayToolsSection.tsx
@@ -23,6 +23,11 @@ import AlertPopup from "@/oss/components/AlertPopup/AlertPopup"
 import {getAgentaApiUrl, getAgentaWebUrl} from "@/oss/lib/helpers/api"
 import {formatDay} from "@/oss/lib/helpers/dateTimeHelper"
 
+const AUTH_SCHEME_LABELS: Record<string, string> = {
+    oauth: "OAuth",
+    api_key: "API Key",
+}
+
 export default function GatewayToolsSection() {
     const {connections, isLoading, refetch} = useToolConnectionsQuery()
     const {handleDelete, handleRefresh, handleRevoke, invalidateConnections} =
@@ -213,6 +218,21 @@ export default function GatewayToolsSection() {
                     style: {minWidth: 120},
                 }),
                 render: (_, record) => <ConnectionStatusBadge connection={record} />,
+            },
+            {
+                title: "Auth",
+                key: "auth_scheme",
+                onHeaderCell: () => ({
+                    style: {minWidth: 100},
+                }),
+                render: (_, record) => {
+                    const scheme =
+                        typeof record.data?.auth_scheme === "string"
+                            ? record.data.auth_scheme
+                            : undefined
+                    if (!scheme) return <Typography.Text type="secondary">—</Typography.Text>
+                    return <Tag>{AUTH_SCHEME_LABELS[scheme] ?? scheme}</Tag>
+                },
             },
             {
                 title: "Created at",

--- a/web/oss/src/components/pages/settings/Tools/hooks/useToolsConnections.ts
+++ b/web/oss/src/components/pages/settings/Tools/hooks/useToolsConnections.ts
@@ -15,7 +15,6 @@ export interface CreateConnectionInput {
     name?: string
     description?: string
     mode?: "oauth" | "api_key"
-    credentials?: Record<string, string>
 }
 
 export const useToolsConnections = (integrationKey: string) => {
@@ -43,13 +42,7 @@ export const useToolsConnections = (integrationKey: string) => {
                     description: payload.description,
                     provider_key: DEFAULT_PROVIDER,
                     integration_key: integrationKey,
-                    data:
-                        payload.mode || payload.credentials
-                            ? {
-                                  auth_scheme: payload.mode,
-                                  credentials: payload.credentials,
-                              }
-                            : undefined,
+                    data: payload.mode ? {auth_scheme: payload.mode} : undefined,
                 },
             }
 

--- a/web/packages/agenta-entities/src/gatewayTool/api/api.ts
+++ b/web/packages/agenta-entities/src/gatewayTool/api/api.ts
@@ -129,8 +129,6 @@ export const fetchToolConnection = async (
 export const createToolConnection = async (
     payload: ToolConnectionCreatePayload,
 ): Promise<ToolConnectionResponse> => {
-    // Cast through Parameters<...> because Fern's typed payload doesn't
-    // model the legacy `credentials` field that the backend still accepts.
     return getToolsClient().createToolConnection(
         payload as Parameters<ReturnType<typeof getToolsClient>["createToolConnection"]>[0],
         projectScopedRequest(),

--- a/web/packages/agenta-entities/src/gatewayTool/core/types.ts
+++ b/web/packages/agenta-entities/src/gatewayTool/core/types.ts
@@ -60,19 +60,7 @@ export type ToolResult = AgentaApi.ToolResult
 export type ToolResultData = AgentaApi.ToolResultData
 export type Status = AgentaApi.Status
 
-// ---------------------------------------------------------------------------
-// Legacy API extension
-//
-// The backend accepts an additional `credentials` field inside the create-
-// connection payload's `data` object (used by the API-key auth path), but
-// the OpenAPI spec used by Fern doesn't model it yet. We extend the Fern
-// type so existing flows compile; when the spec is updated this alias can
-// be removed.
-// ---------------------------------------------------------------------------
-
-export type ToolConnectionCreatePayloadData = ToolConnectionCreateData & {
-    credentials?: Record<string, string>
-}
+export type ToolConnectionCreatePayloadData = ToolConnectionCreateData
 
 export interface ToolConnectionCreatePayload {
     connection: Omit<ToolConnectionCreate, "data"> & {


### PR DESCRIPTION
## Context

When you connected a Composio tool that supports both OAuth and API key (e.g. Prisma), picking "API Key" still sent you through the OAuth flow. Every attempt authorized with Composio-managed OAuth regardless of what you chose.

The root cause was a type coercion that silently dropped the auth scheme. `ToolConnectionCreate.data` was typed `Optional[Union[ToolConnectionCreateData, Json]]`. `Json` is a plain dict, so Pydantic parsed the incoming `{"auth_scheme": "api_key", ...}` as the raw dict arm, never as the typed model. The tools router then ran an `isinstance(data, dict)` branch that stripped `auth_scheme` and `callback_url` out of the payload before it reached the service. The service saw `auth_scheme=None` and defaulted the Composio adapter to `use_composio_managed_auth` (OAuth). The API key field in the modal was also dead: the value was collected but never used (Composio collects credentials on its own hosted redirect UI).

## Changes

Removed the `Union[..., Json]` from the create-input DTOs (tools and triggers) so `data` always parses as the typed `ConnectionCreateData`. Deleted the router strip in both routers. `ConnectionCreateData` now carries all fields (the control inputs plus the provider/service outputs), so there is no second untyped shape.

Before, the effective auth scheme reaching the adapter:

```
auth_scheme=None            -> {'type': 'use_composio_managed_auth'}   (always OAuth)
```

After:

```
auth_scheme='api_key'       -> {'type': 'use_custom_auth', 'authScheme': 'API_KEY'}
auth_scheme='oauth'         -> {'type': 'use_composio_managed_auth'}
```

The service now persists the effective `auth_scheme` into the connection's `data`, so it is a durable fact about the connection. The settings tables (`GatewayToolsSection` and `ConnectionsList`) render a new "Auth" column showing OAuth / API Key, or `—` for connections created before this fix (they never stored the scheme) and for no-auth toolkits.

On the web side, the dead `credentials` field was dropped from the create payload and the modal (the API key is entered on Composio's redirect UI, never in our request), and the API-key path now correctly follows the redirect popup instead of closing the modal without redirecting.

## Tests / notes

- Verified end to end against the local EE stack. Logs confirm `auth_scheme='api_key'` now produces `use_custom_auth` and `auth_scheme='oauth'` produces `use_composio_managed_auth`.
- Confirmed new rows persist the scheme (`prisma-7cu` -> `api_key`, `prisma-z23` -> `oauth`) and pre-fix rows read back cleanly with the scheme absent.
- No migration needed. The read model reads `data` as an open dict, so pre-fix rows parse unchanged and show `—` in the Auth column.
- Not yet run: `pnpm lint-fix` across the web changes and the Fern client regen (the create payload no longer needs the `credentials` extension once the spec is regenerated).

## What to QA

- Connect a Composio integration that supports both schemes (Prisma). Pick "API Key". You should land on Composio's API-key entry screen, not the OAuth consent screen.
- Pick "OAuth" for the same integration. You should get the OAuth consent flow as before.
- In the Tools settings table, the new Auth column shows "API Key" or "OAuth" for connections you just made, and "—" for the older Prisma rows.
- Regression: connect a no-auth toolkit (e.g. codeinterpreter). It should create immediately with no redirect, and show "—" under Auth.
