### PR TITLE
[feat] Gate Pi native builtins through the permission relay

### DIFF
--- a/docs/design/agent-workflows/documentation/protocol.md
+++ b/docs/design/agent-workflows/documentation/protocol.md
@@ -124,3 +124,9 @@ Request fields include:
 One-shot calls return one JSON result. Streaming calls use NDJSON internally: one
 `{"kind":"event"}` record per live event, followed by one `{"kind":"result"}` terminal
 record. The browser never sees this NDJSON directly; `/messages` converts it to Vercel SSE.
+
+This page covers the `/run` wire only. A separate internal channel, the relay directory the
+runner shares with the sandbox (used for Daytona tool calls and, now, for Pi builtin
+permission checks), recently gained a second record kind. See
+[Tools](tools.md#built-in-tools-the-harness-runs-them-natively-gated-through-the-same-relay)
+for the permission record shape.

--- a/docs/design/agent-workflows/documentation/tools.md
+++ b/docs/design/agent-workflows/documentation/tools.md
@@ -332,10 +332,11 @@ session's allowlist and Pi runs its own implementation of `read`, `write`, `web_
 on. Nothing is resolved and nothing is delivered. Note that built-ins are a Pi concept here;
 they are not delivered to non-Pi harnesses over ACP, which bring their own native tool set.
 
-Pi's builtins now flow through the same permission relay as gateway and code tools. The
+Pi's builtins now flow through the same permission relay as gateway tools (code tools are
+declared but not yet executable in the runner; the relay path is shared either way). The
 bundled Pi extension's `tool_call` hook reports every builtin call over the relay directory as
 a permission record (`kind: "permission"`), and the runner decides it through the same shared
-`decide()` in `permission-plan.ts` the relay already uses for gateway and code tools. An `ask`
+`decide()` in `permission-plan.ts` the relay already uses for gateway tools. An `ask`
 verdict pauses the turn exactly like a relay tool does. The extension hook then maps a
 non-allow verdict to Pi's own `{ block: true }`, because Pi, not the runner, is the thing that
 would otherwise execute the call.

--- a/docs/design/agent-workflows/documentation/tools.md
+++ b/docs/design/agent-workflows/documentation/tools.md
@@ -325,12 +325,26 @@ The pause itself is shared by both delivery paths through one seam
 A client tool's `render` hint can be `{ kind: "connect" }` (e.g. `request_connection`), the typed
 member of `RenderHint` that asks the frontend to draw the connect widget.
 
-### Built-in tools: the harness runs them natively
+### Built-in tools: the harness runs them natively, gated through the same relay
 
 Execution is the harness's own. A built-in tool is just a name. The runner adds it to the
 session's allowlist and Pi runs its own implementation of `read`, `write`, `web_search`, and so
 on. Nothing is resolved and nothing is delivered. Note that built-ins are a Pi concept here;
 they are not delivered to non-Pi harnesses over ACP, which bring their own native tool set.
+
+Pi's builtins now flow through the same permission relay as gateway and code tools. The
+bundled Pi extension's `tool_call` hook reports every builtin call over the relay directory as
+a permission record (`kind: "permission"`), and the runner decides it through the same shared
+`decide()` in `permission-plan.ts` the relay already uses for gateway and code tools. An `ask`
+verdict pauses the turn exactly like a relay tool does. The extension hook then maps a
+non-allow verdict to Pi's own `{ block: true }`, because Pi, not the runner, is the thing that
+would otherwise execute the call.
+
+The grant list (the wire `tools` field: the builtins an author selected) is enforced
+separately, at session start. The extension edits Pi's active tool set at
+`before_agent_start`, replacing only the builtin slice with the granted names and leaving
+every non-builtin tool untouched. A builtin outside the grant list is simply absent from the
+model's active tools, so no call for it ever fires, and the permission hook never sees it.
 
 ### MCP servers: a server process the daemon launches
 
@@ -371,10 +385,12 @@ Two gates consult this same decision:
   raises these today: it checks its own settings file first, and only an undecided call reaches
   the responder.
 - **The tool relay**, `services/runner/src/tools/relay.ts`, enforces permission on tools the
-  runner executes directly (gateway, code). It only needs to, because on Claude the harness
-  settings file plus the ACP responder already decide before a call reaches the relay. On Pi
-  there is no harness-side gate, so the relay is the only enforcement point, and it now gives Pi
-  the same human-in-the-loop behavior Claude gets.
+  runner executes directly (gateway, code) and, now, on Pi's own builtins, relayed through the
+  bundled extension's `tool_call` hook. It only needs to, because on Claude the harness settings
+  file plus the ACP responder already decide before a call reaches the relay. On Pi there is no
+  separate harness-side settings gate, so the relay is the enforcement point for everything Pi
+  runs, including its native builtins, and it gives Pi the same human-in-the-loop behavior
+  Claude gets.
 
 Client tools are a carve-out from that same ladder. They are decided by the responder's
 `onClientTool` (consulted at the ACP gate on Claude, and by the relay on Pi), not by the
@@ -515,9 +531,11 @@ The contract and the field-by-field Composio→Agenta mapping live in the
   Agenta are the default harnesses, so `mcp_servers` is a silent no-op for most runs. It would
   reach Claude only. Do not confuse this with the `agenta-tools` server, which is an internal
   tool-delivery vehicle for Claude, not a user MCP server.
-- A tool's `permission` is honored on both harnesses now. Claude checks its rendered settings
-  file first, then the ACP responder; Pi has no native gate, so the relay enforces it directly.
-  An `ask` pauses the run and asks a human on either harness.
+- A tool's `permission` is honored on both harnesses now, including Pi's own builtins. Claude
+  checks its rendered settings file first, then the ACP responder. Pi has no separate
+  harness-side settings gate, so the relay decides everything Pi runs: gateway and code tools
+  directly, and builtins relayed through the extension's `tool_call` hook. An `ask` pauses the
+  run and asks a human on either harness.
 - Gateway tools support only the `composio` provider today; other providers raise.
 - The `render` hint is plumbed end to end on the runner side, but full frontend projection of
   every render kind is still in progress.

--- a/docs/design/agent-workflows/interfaces/in-service/permission-responder.md
+++ b/docs/design/agent-workflows/interfaces/in-service/permission-responder.md
@@ -60,7 +60,10 @@ because the effective permission is resolved before the stored decision is consu
 `ApprovalResponder` is Gate 2, for tools the harness gates natively (Claude Code's
 `.claude/settings.json` layer decides first; anything it leaves undecided reaches this
 responder over ACP). The tool relay (`services/runner/src/tools/relay.ts`) is Gate 3, for
-tools the runner executes itself (gateway, code, client). Both gates call the same
+tools the runner executes itself (gateway, code, client) and, since the pi-builtin-gating
+slice, for Pi's own builtins too: the bundled Pi extension's `tool_call` hook reports each
+builtin call over the relay directory as a permission record, and the relay decides it
+through this same `decide()` before answering. Both gates call the same
 `effectivePermission`/`decide` pair from `permission-plan.ts`, so they can never disagree
 about a tool's permission. The relay only needs to enforce on Pi, since Claude's Gate 1 and
 Gate 2 already decide before a call reaches the relay.

--- a/docs/design/agent-workflows/projects/approval-boundary/status.md
+++ b/docs/design/agent-workflows/projects/approval-boundary/status.md
@@ -93,13 +93,22 @@ analysis that diagnosed the live loop.
   the terminal result's value; the live stream path should too. Display is unaffected (the
   FE keys off the `interaction_request` part), so this is wire-fidelity, not UX.
 
-- **Selection-time enforcement for Pi builtins.** Pi's native tools never reach a
-  runner gate, so today the global policy modes do not bind them (headless QA proved
-  `default: deny` does not stop a granted `bash`). The design: filter `builtin_names`
-  at resolution by effective permission, using a small read-only table for Pi's seven
-  builtins (`read/grep/find/ls` read, `bash/edit/write` write); `deny` and un-pausable
-  `ask` exclude the builtin (deny-by-omission is Pi's one native control). Until then,
-  a per-builtin `permission` is dropped with a logged warning instead of silently.
+- **Selection-time enforcement for Pi builtins. SHIPPED**, by the pi-builtin-gating slice
+  (implemented and live-QA'd 2026-07-04). At the time this follow-up was written, Pi's
+  native tools never reached a runner gate, so the global policy modes did not bind them.
+  The shipped design supersedes the selection-time sketch below with call-time gating: the
+  bundled Pi extension's `tool_call` hook reports each builtin call over the relay
+  directory, and the runner decides it through the same shared `decide()` the relay already
+  used for gateway and code tools, pausing on `ask` exactly like any other tool. The grant
+  list (which builtins an author selects) is still enforced at selection time, through the
+  extension's active-tool-set edit at `before_agent_start`, so a non-granted builtin is
+  simply absent from the model's tools. See
+  `docs/design/agent-workflows/projects/pi-builtin-gating/` for the full design and status.
+  The original sketch, for context: filter `builtin_names` at resolution by effective
+  permission, using a small read-only table for Pi's seven builtins (`read/grep/find/ls`
+  read, `bash/edit/write` write); `deny` and un-pausable `ask` exclude the builtin
+  (deny-by-omission is Pi's one native control). Until then, a per-builtin `permission` is
+  dropped with a logged warning instead of silently.
 
 ## Known unknowns
 

--- a/docs/design/agent-workflows/projects/pi-builtin-gating/README.md
+++ b/docs/design/agent-workflows/projects/pi-builtin-gating/README.md
@@ -1,0 +1,49 @@
+# Pi builtin gating: route native tools through the permission relay
+
+Pi ships seven native builtin tools (`read`, `bash`, `edit`, `write`, `grep`, `find`,
+`ls`). Today they run outside our permission system. The author cannot say "ask before
+`bash`", and the "which builtins are enabled" list the UI shows does nothing. This
+workspace explains why, picks a design, and lays out the build.
+
+Everything here is documentation and planning. No code ships with this PR.
+
+## The two gaps
+
+1. **`bash: ask` is inexpressible.** Our permission plan supports `allow | ask | deny` per
+   tool and four global modes. Custom tools and Claude's own tools honor it. Pi's seven
+   builtins never reach a gate, so any authored rule on them is silently ignored. An agent
+   that should pause before running a shell command just runs it.
+
+2. **The builtin grant list is dead.** The run request carries `tools?: string[]`
+   ("Built-in tools to enable", `services/runner/src/protocol.ts:423`). The SDK still emits
+   it and the playground still writes the author's selection into it. Nothing in the runner
+   reads it. It went dead on 2026-06-24 in commit `0e71bd0f7a`, which deleted the old
+   in-process engine that was its only consumer. So every builtin is always on, whatever the
+   author selected.
+
+## The design in three sentences
+
+Our Pi extension gains a `tool_call` hook. Pi fires it before every builtin runs, and the
+hook can block. For a granted builtin, the hook asks the runner for a decision through the
+existing relay-directory file protocol, the runner decides with the real tool name and real
+arguments in the one shared decision module (`decide()` in
+`services/runner/src/permission-plan.ts`), and the hook blocks or allows on the answer.
+
+## Reading order
+
+1. [context.md](context.md): why this matters and how it ties to the approval-boundary work.
+2. [research.md](research.md): the verified facts about the code this builds on, with
+   file and line references.
+3. [design.md](design.md): the relay record shape, the decision mapping, the env config,
+   grant-list enforcement, and the pause/resume flow and its failure modes.
+4. [plan.md](plan.md): the phased build, tests, and the live spike that de-risks the design.
+5. [status.md](status.md): current state, the decision log (Option B over A and C), and
+   open risks.
+
+## The decisions to weigh in on
+
+- The shape of the new permission record on the relay protocol (design.md). A Codex round
+  already settled the record into a discriminated union and the gate onto the existing
+  `"harness"` executor; the remaining call is whether that shape reads right to you.
+- How to mitigate the re-issue risk if Pi treats a blocked call as terminal (design.md,
+  plan.md Phase 0). This is the top open risk and the reason Phase 0 is a spike, not code.

--- a/docs/design/agent-workflows/projects/pi-builtin-gating/README.md
+++ b/docs/design/agent-workflows/projects/pi-builtin-gating/README.md
@@ -1,11 +1,15 @@
 # Pi builtin gating: route native tools through the permission relay
 
 Pi ships seven native builtin tools (`read`, `bash`, `edit`, `write`, `grep`, `find`,
-`ls`). Today they run outside our permission system. The author cannot say "ask before
-`bash`", and the "which builtins are enabled" list the UI shows does nothing. This
-workspace explains why, picks a design, and lays out the build.
+`ls`). Before this work they ran outside our permission system. The author could not say
+"ask before `bash`", and the "which builtins are enabled" list the UI shows did nothing.
+This workspace explains why, picks a design, and lays out the build.
 
-Everything here is documentation and planning. No code ships with this PR.
+This PR now ships BOTH the workspace and the implementation: the runner-side permission
+record and builtin identity table, the extension's policy hook and grant enforcement, the
+env plumbing, and the test suite. status.md tracks the live state (implemented,
+live-QA'd, S1 5/5 bar met); build-notes.md records how the build actually went. The two
+gaps below are written in the present tense of the design phase; they are both closed.
 
 ## The two gaps
 

--- a/docs/design/agent-workflows/projects/pi-builtin-gating/build-notes.md
+++ b/docs/design/agent-workflows/projects/pi-builtin-gating/build-notes.md
@@ -1,0 +1,27 @@
+
+## 2026-07-04 implementation run
+
+- **Phase 0 stage-A spike PASSED** (see status.md): cross-turn re-issue 3/3 with identical
+  args; the match projection was born from the one drift case (a spontaneous `timeout`
+  param on bash).
+- **Phases 1-4 implemented** (Codex xhigh implemented, orchestrator reviewed each diff;
+  Sonnet wrote the Phase 4 cross-cutting tests). Runner suite grew 444 -> 525, tsc clean,
+  extension bundle rebuilt. Key review confirmations: `approvedCallKey` routes through the
+  shared `storedDecisionKeyShape`, so the gate side and the transcript-extraction side can
+  never disagree on the resume key; the relay permission branch writes verdicts verbatim on
+  every path; the run-plan predicate honors the kill switch and the `undefined` vs `[]`
+  grant distinction.
+- **Live QA immediately caught the design's own predicted failure class.** First S1 run
+  showed zero gating. Not stale runner code: the dev sidecar mounts only `src/` from the
+  worktree, so the runner computed gating correctly while the Pi extension installed into
+  each sandbox came from the image's BAKED `dist/` bundle (dated July 1, no hook). New
+  runner + old extension is the silent direction of the version skew: the old bundle never
+  writes a permission record, so the `protocol: 1` pin has nothing to reject. Fixed on the
+  box by copying the fresh bundle into the container (survives restart, not recreation).
+  Durable fixes noted: mount or build `dist/` in the sidecar recipe, and a possible
+  runner-side hardening (fail loud when a gating-active Pi turn ends with zero permission
+  records for a policy that must gate) filed as a follow-up candidate.
+- **Concurrency note:** implemented alongside mcp-mvp-claude's live client-tools work in
+  the same worktree. Six files' hunks (relay.ts, responder.ts, agenta.ts, sandbox_agent.ts,
+  two tests) are frozen worktree-only until their lane merges; the lane is deliberately
+  unpushed while its tip would not compile standalone. Board rows carry the handshake.

--- a/docs/design/agent-workflows/projects/pi-builtin-gating/context.md
+++ b/docs/design/agent-workflows/projects/pi-builtin-gating/context.md
@@ -1,0 +1,70 @@
+# Context: why gate Pi's builtins
+
+## What a builtin is
+
+Pi runs an agent loop with seven tools built into the harness: `read`, `bash`, `edit`,
+`write`, `grep`, `find`, and `ls`. The model calls them the same way it calls a custom tool.
+The difference is where they execute. A custom tool runs through our code. A builtin runs
+inside Pi itself, and Pi never asks us for permission first.
+
+## Gap 1: the author cannot gate a builtin
+
+Our permission model is small and clear. An author sets one global default and optional
+per-tool rules. Each tool resolves to `allow`, `ask`, or `deny`. The four global modes are
+`allow`, `ask`, `deny`, and `allow_reads` (reads run, everything else asks). This model is
+described in the approval-boundary workspace at
+[projects/approval-boundary/how-approvals-work.md](../approval-boundary/how-approvals-work.md).
+
+The model works for every tool that reaches a gate. Claude's tools reach a gate because
+Claude asks over its own protocol. Our custom tools reach a gate because we execute them
+and check first. Pi's builtins reach no gate at all. So `bash: ask` does nothing on Pi. The
+shell command runs. This is the sharpest gap, because `bash` is the one builtin most authors
+would want to pause on.
+
+## Gap 2: the grant list stopped working
+
+The run request has a field for the enabled builtins: `tools?: string[]` at
+`services/runner/src/protocol.ts:423`, commented "Built-in tools to enable". The SDK fills
+it from the author's selection (`PiAgentTemplate.wire_tools` in
+`sdks/python/agenta/sdk/agents/dtos.py:829` emits `"tools": list(self.builtin_names)`), and
+the playground's Pi settings control writes that selection.
+
+The runner ignores the field. It went dead in commit `0e71bd0f7a` (2026-06-24, "remove
+legacy in-process backend"). That commit deleted the old in-process engine, and that engine
+held the only code that read the list. So the selection an author makes in the UI has no
+effect. Every builtin is always available. The commit message is honest that it removed the
+in-process path as dead code; the grant list was collateral, and no one has re-wired it since.
+
+## Why the two gaps share one fix
+
+Both gaps are the same missing thing: a point where the runner sees a builtin call before it
+runs and gets to decide. Add that one interception point and both gaps close. A non-granted
+builtin gets refused. A granted builtin gets the author's `allow | ask | deny`.
+
+## Tie to the approval-boundary redesign
+
+The approval-boundary workspace ([projects/approval-boundary/](../approval-boundary/))
+established a doctrine we follow here: **one decision module.** The rule about whether a tool
+runs, pauses, or is denied lives in exactly one place, `decide()` in
+`services/runner/src/permission-plan.ts`, and every gate calls it. That workspace's plan
+([projects/approval-boundary/plan.md](../approval-boundary/plan.md)) lists the gates: the SDK
+settings renderer for Claude, the ACP responder for Claude's live gates, and the relay for
+tools the runner executes itself.
+
+Builtin gating adds a fourth caller of the same `decide()`. It does not add a second policy
+engine. The whole point of the design below is that the runner decides builtins with the same
+function, the same `GateDescriptor`, and the same stored-decision resume machinery that
+custom-tool asks already use. The extension only reports the call and enforces the answer.
+This keeps the doctrine intact: the sandbox never decides policy; it asks the runner.
+
+## Non-goals
+
+- No new policy language. Authors express builtin rules with the existing `allow | ask |
+  deny` and the four global modes.
+- No per-builtin permission field on the config yet. The SDK currently drops a per-builtin
+  permission loudly (`BuiltinToolConfig._drop_unenforceable_permission` in
+  `sdks/python/agenta/sdk/agents/tools/models.py:87`) because nothing enforced it. This
+  design makes enforcement possible, so re-enabling that field becomes a small follow-up, but
+  it is out of scope here. Authors still gate builtins through global-mode rules and pattern
+  rules (for example `bash(git:*)`).
+- No change to Claude. Claude already gates its own tools.

--- a/docs/design/agent-workflows/projects/pi-builtin-gating/design.md
+++ b/docs/design/agent-workflows/projects/pi-builtin-gating/design.md
@@ -1,0 +1,273 @@
+# Design
+
+## The shape of the thing
+
+Pi fires a `tool_call` event before it runs any tool, and the handler can block. We add that
+handler to our extension. For each builtin call the handler does two checks in order:
+
+1. **Grant.** Is this builtin one the author enabled? If not, the call never runs.
+2. **Policy.** For a granted builtin, ask the runner: allow, deny, or ask? The runner
+   decides with the real name and real arguments in `decide()`, then the handler enforces the
+   answer.
+
+The runner decides. The extension only reports and enforces. That is the whole design in one
+line, and it is the line that keeps the "one decision module" doctrine intact.
+
+## The grant list: shape Pi's active-tool set at turn start
+
+The cleanest way to enforce "which builtins exist" is to not offer the non-granted ones at
+all. Pi exposes `pi.setActiveTools([...])` and `getActiveTools()` / `getAllTools()` on the
+extension API (research.md). When gating is active, the extension sets the active set so that
+only the granted builtins remain, and the model never sees a non-granted builtin.
+
+Two corrections from the Codex review shape how this is done:
+
+- **Not at extension init.** Pi's loader stubs the action methods while the factory loads, so
+  `setActiveTools` cannot run at init; only `registerTool` is safe there. The active-set edit
+  runs at an early runtime event instead, `before_agent_start`, and the build must verify it
+  takes effect for the current turn's system prompt (so the model does not see a tool that is
+  about to be removed).
+- **Replace only the builtin portion.** Do not set the active list to "granted builtins plus
+  the custom tool names I registered". That could drop a user or local extension tool, or
+  activate one that was off. Read the current active set with `getActiveTools()`, read the
+  full set with `getAllTools()`, and replace only the seven builtins' slice with the granted
+  subset. Non-builtin tools pass through untouched.
+
+This maps the grant gap to the mechanism that fits it. The `tools` field means "built-in
+tools to enable", which is exactly what an active-tool allowlist expresses. The `tool_call`
+hook is then free to handle only the second question, the per-call policy on the tools that
+are enabled.
+
+A fallback exists if `before_agent_start` proves too late to hide a tool from the model: the
+`tool_call` hook blocks any builtin not in the grant list, with a reason that says the tool is
+not enabled. This is strictly weaker (the model can try and fail), so the active-set approach
+is primary and block-in-hook is the backstop. Phase 2 picks one after a live check.
+
+## The permission record on the relay protocol
+
+The per-call policy check reuses the relay directory. The extension already knows how to
+write a request file and poll for a response (dispatch.ts `relayToolCall`). A permission check
+is a new record on the same channel.
+
+I apply the interface-design lens: classify each field by what it *is*, not by the feature it
+serves.
+
+**Request record** (`<id>.req.json`, extended with a discriminator):
+
+| field | role | why it is here |
+| --- | --- | --- |
+| `kind: "execute" \| "permission"` | protocol / routing | Tells the runner loop which branch to run. Absent means `"execute"`, so the existing custom-tool record is unchanged. |
+| `toolName` | data / identity | The builtin name (`bash`), the thing being decided. |
+| `toolCallId` | protocol context | Correlates the response file and names it. Already present. |
+| `args` | data | The real `event.input`. Load-bearing: prefix rules and read classification need it. |
+
+No credentials, no config, and no policy live in the record. Credentials never touch the
+sandbox by design. Policy lives in the runner. The record carries only what the runner cannot
+otherwise know: which builtin, which call, which arguments.
+
+The TS types are a real discriminated union, not "RelayResponse plus an optional field". An
+execute response and a permission response mean different things, so they are distinct types
+keyed by `kind`. The permission response also carries `kind: "permission"` (or is parsed
+through a dedicated `PermissionRelayResponse` validator) so that the existing `relayToolCall`
+path can never mis-read one. Without that, a permission response `{ ok: true, effect:
+"block" }` would look to `relayToolCall` like an empty successful tool result.
+
+**Response record** (`<id>.res.json`, its own permission variant):
+
+| field | role | why it is here |
+| --- | --- | --- |
+| `kind: "permission"` | protocol / routing | Marks this as a permission response so no other reader parses it as a tool result. |
+| `ok` | protocol | False on a runner-side error; the handler then fails closed per the failure-mode table below. |
+| `effect: "allow" \| "block"` | control | The single bit the handler acts on. Named `effect`, not `decision`, to avoid colliding with the permission module's own `"allow" \| "deny"` decisions. |
+| `reason?` | data | The text shown to the model on a block, reusing the authored-deny and policy-deny wording from relay.ts. |
+
+Note there is no `"pending"` value on the wire. Pending collapses to `block` with a reason,
+because on a builtin **Pi is the executor**. The runner cannot withhold execution the way it
+does for a custom tool; the only way to stop Pi from running the builtin is for the hook to
+return `{ block: true }`. So a pending decision produces two effects at once: the runner
+pauses the turn through `onPendingApproval` (the normal ask path), and it writes a `block`
+response so the hook stops the native call. On resume the model re-issues and the stored
+decision replays. See the flow and the risk below.
+
+### Why a discriminator rather than a second file suffix
+
+A `kind` field keeps one request stream and one response stream, so `startToolRelay`'s single
+poll loop, its `seen` set, and its host abstraction all serve both record types unchanged. A
+separate suffix pair would fork the loop. The discriminator is the smaller change and reads
+more honestly: these are two variants of "the sandbox is asking the runner about a call", not
+two protocols. The Codex review agreed, on the condition that the records be a real
+discriminated union (not one type with optional fields) and that the permission response go
+through its own validator, both folded in above.
+
+## Mapping to the GateDescriptor
+
+The runner's permission branch builds a `GateDescriptor` from the record:
+
+- `executor`: `"harness"` (see the executor question below).
+- `toolName`: the builtin name from the record.
+- `readOnlyHint`: looked up in the runner-side table (`read`, `grep`, `find`, `ls` = read;
+  `bash`, `edit`, `write` = write). Not sent by the sandbox. Classification stays runner-side.
+- `args`: the real arguments from the record.
+- `specPermission` and `serverPermission`: unset. A builtin has no resolved spec and no MCP
+  server, so its permission comes from pattern rules and the global default only.
+
+Then it calls the same `decide(gate, permissionPlan, decisions)` the relay already uses, and
+maps the verdict: `allow` -> write `{ effect: "allow" }`; `deny` -> write `{ effect: "block",
+reason }`; `pendingApproval` -> call `onPendingApproval` and write `{ effect: "block",
+reason }`. The pending-to-block mapping lives in the permission-record handler, not in the
+descriptor.
+
+### The executor question: reuse `"harness"`, not a new value
+
+The Codex review talked me out of a new `"builtin"` executor, and I agree. `GateExecutor`
+names the *component* that executes the tool. Pi runs its own builtins, so the executing
+component is the harness. `executor: "harness"` is the honest value. The things I thought
+justified a new value are real but belong elsewhere:
+
+- **Pending means block here, not withhold.** True, but that is post-decision handling. It
+  lives in the permission-record handler that writes the response, not in the descriptor. The
+  handler knows it is servicing a builtin permission record and writes a block on pending; the
+  descriptor does not need to encode it.
+- **`readOnlyHint` has a different source.** Also true, but it is resolved before the
+  descriptor is built. The handler looks it up in the runner table and sets the field. The
+  descriptor just carries the resolved hint, same as for any tool.
+
+If a genuinely separate dimension is ever needed (for example to branch resume anchoring by
+tool category), add a named dimension like `toolClass` or `gateSource`, not an executor value
+named after a tool category. For now `"harness"` plus a builtin-aware handler covers it with
+no new enum value.
+
+## Env config shape
+
+`buildPiExtensionEnv` (pi-assets.ts) gains the gating config so an allow-everything run pays
+nothing. Proposed variables, read by the extension:
+
+- `AGENTA_AGENT_BUILTIN_GATING = "true"`: the master switch. When absent the extension does
+  not register the `tool_call` hook and does not touch the active tool set. Native builtins
+  behave exactly as they do today. This keeps a plain `pi` session and any all-`allow`,
+  all-granted run completely untouched. One catch the Codex review caught: the extension's
+  inertness guard (agenta.ts:165) currently returns early when a run has no tools, tracing, or
+  usage. A gating-only run (gated builtins, no custom tools, no tracing) hits that early return
+  and never registers the hook. The guard must add `hasBuiltinGating` so gating alone keeps the
+  extension live.
+- `AGENTA_AGENT_BUILTIN_GRANTS`: a JSON array of the granted builtin names, from
+  `request.tools`, de-duped and filtered to the seven known builtin names. Drives the
+  active-set edit and the grant check. Decide explicitly whether an unknown name is dropped or
+  fails the run closed; the lean is to drop unknowns and log.
+- `AGENTA_AGENT_TOOLS_RELAY_DIR`: already exists. Reused for the permission records. Must now
+  be set when gating is active even with zero custom tools.
+
+The runner decides when gating is active. The Codex review corrected two things here:
+
+- **Compute from the resolved plan, not the raw request.** Derive the policy from
+  `permissionsFromRequest(request)` (permission-plan.ts:58), not raw `request.permissions`.
+  That function folds in the operator kill switch (`SANDBOX_AGENT_DENY_PERMISSIONS=true`) and
+  the invalid-policy fail-to-ask behavior. A fast path off the raw field would bypass the kill
+  switch.
+- **The grant list alone can require gating.** Pi's default active builtins are `read`, `bash`,
+  `edit`, `write`, not all seven. So the requested grant set can differ from Pi's default even
+  under a blanket `allow`: `tools: ["read", "write"]` must run gating to remove `bash` and
+  `edit`; `tools` that includes `grep`, `find`, or `ls` must run gating to enable them. And
+  `tools: undefined` (author never chose) is not the same as `tools: []` (author chose none).
+
+So gating is active when the run is Pi and either the resolved policy could produce anything
+other than `allow` for a builtin (any mode except blanket `allow`, or any pattern rule touching
+a builtin), or the requested grant set differs from Pi's default active builtins. When neither
+holds, gating stays off and the fast path is unchanged. When unsure, default to on; an
+on-gating run with an all-`allow` policy just allows every call at the cost of one relay
+round-trip per builtin.
+
+## Starting the relay when gating is active
+
+`useToolRelay` at run-plan.ts:329 becomes `toolSpecs.length > 0 || builtinGatingActive`, and
+the relay-dir creation in workspace.ts follows the same condition. The relay then runs for a
+Pi run that has gated builtins and no custom tools.
+
+## The pause and resume flow
+
+Consider an agent with `bash: ask` and a user watching the playground.
+
+1. The model calls `bash` with `{ command: "npm test" }`. Pi fires `tool_call` before running
+   it.
+2. The extension hook sees `bash` is granted, so it moves to the policy check. It writes a
+   permission record `{ kind: "permission", toolName: "bash", toolCallId, args: { command:
+   "npm test" } }` and polls for the response.
+3. The runner loop reads the record, builds the `GateDescriptor` (`executor: "builtin"`,
+   `readOnlyHint: false` from the table, real args), and calls `decide()`. The effective
+   permission is `ask`, and no stored decision exists, so the verdict is `pendingApproval`.
+4. The runner calls `onPendingApproval`. It acquires the single-pending latch, marks the
+   paused tool call, emits the `interaction_request` event the playground renders as
+   Approve/Deny, records the durable interaction, and pauses the turn. It also writes the
+   response `{ kind: "permission", effect: "block", reason: "Waiting for approval of bash." }`.
+5. The hook reads the block and returns `{ block: true, reason }`. Pi does not run the shell
+   command. The turn is already pausing, so the model does not act on the reason this turn.
+6. The user clicks Approve. The run resumes. The stored decision now holds `allow` for this
+   builtin and these args.
+7. The model re-issues the `bash` call. The hook checks again, the runner's `decide()` finds
+   the stored `allow`, and the response is `{ kind: "permission", effect: "allow" }`. The hook
+   returns nothing, Pi runs the command, and the turn continues.
+
+For `deny` the flow stops at step 3 with a straight block and the deny reason. For `allow`
+the hook writes and reads a round-trip that always says allow; that is the overhead the
+gating-active predicate exists to avoid on all-`allow` runs.
+
+## Failure modes
+
+**The re-issue risk (top risk).** Step 7 assumes Pi re-issues the `bash` call after the block
+plus resume. The relay-ask flow proves the model re-issues a *custom* tool after a pause,
+because the pause path is shared. A builtin blocked through `tool_call` is a different
+stimulus. The Codex review confirmed from Pi's source that Pi core turns `{ block: true }`
+into an **error tool result** carrying the reason, not a silent hold. So whether the model
+re-issues is entirely a model-behavior question, and it is unverified. If Pi does not
+re-issue, the approved call never runs and the agent stalls.
+
+Mitigation is a real spike, not a soft fallback. Phase 0 must watch the actual resumed
+transcript with the real runner pause and teardown in the loop, not a throwaway local block.
+Treat "the retry-nudge reason works" as an observed outcome to confirm, never as a guarantee
+to lean on. If Pi does not reliably re-issue after approval, this design should stop and go
+back to you, because the alternative (holding the turn open on the hook side instead of
+blocking) is a materially different design.
+
+**Relay polling timeout.** The hook polls for the decision up to 60s (`RELAY_TIMEOUT_MS`). The
+runner must therefore **always** write a response for a permission record, including on
+pending. This is the key divergence from the custom-tool relay, which writes nothing on
+`PAUSED`. If the runner ever failed to write, the hook would hang for 60s and then Pi would
+surface a tool timeout error. The Phase 1 loop writes a response on every branch, and a test
+pins that.
+
+**Concurrent builtins and the single-pending latch.** Pi preflights sibling tool calls
+sequentially, then runs them concurrently. Two builtins in one assistant message can both be
+pending. The latch lets only the first raise an approval event. The second still needs a
+response so its hook does not hang, so on a pending-but-latch-held call the runner writes
+`{ kind: "permission", effect: "block", reason: "Another approval is pending; retry after it
+resolves." }`. The second call is refused this turn and re-issued later.
+
+This needs a small contract change the Codex review flagged: `RelayPermissions.onPendingApproval`
+returns `void` today (relay.ts:69), so a caller cannot tell whether it actually raised the
+event or the latch was already held. Change it to return a boolean (or `{ emitted: boolean }`)
+so the permission handler writes the plain waiting-for-approval reason when it emitted, and the
+another-approval-pending reason when it did not. A test covers two concurrent pending builtins.
+
+**Args mutation ordering.** The `tool_call` handlers chain, and an earlier handler can mutate
+`event.input` (our tracing handler does not, but Pi's docs allow it). The permission check
+must read the input the tool will actually run with. Our hook reads `event.input` at call
+time and the runner decides on that snapshot, so a later mutation by another handler would
+escape the gate. We register the permission hook so it runs after any argument-normalizing
+handler, and the plan notes this ordering as a review point.
+
+**Fail direction on a runner error.** If the runner writes `{ ok: false }` or the record is
+malformed, the hook fails closed: it blocks the call with a generic reason. An
+uninspectable decision must never fall through to running the tool, mirroring the runner's own
+rule that an unparseable policy asks rather than runs (permission-plan.ts:74).
+
+**Daytona teardown.** On Daytona a pause disposes the sandbox (F-040). The in-sandbox hook is
+mid-poll when that happens. It dies with the sandbox, which is fine: the decision already
+emitted its event and paused the turn on the runner side. The runner-side response write may
+race the teardown; the write is best-effort and the resume path does not depend on it.
+
+## What stays out of the sandbox
+
+The sandbox never learns the policy, the rules, the credentials, or the read-only table. It
+learns only which builtins are granted (so it can shape the active set) and it reports each
+call. Every decision that could leak intent or secrets stays in the runner. This is the same
+trust boundary the custom-tool relay already holds, extended to builtins without widening it.

--- a/docs/design/agent-workflows/projects/pi-builtin-gating/design.md
+++ b/docs/design/agent-workflows/projects/pi-builtin-gating/design.md
@@ -84,14 +84,27 @@ Two corrections from the Codex review shape how this is done:
   activate one that was off. Read the current active set with `getActiveTools()`, read the
   full set with `getAllTools()`, and replace only the seven builtins' slice with the granted
   subset. Non-builtin tools pass through untouched.
+- **`before_agent_start` handlers chain on a stale prompt copy.** Pi runs every registered
+  `before_agent_start` handler in turn, and each receives the current system prompt and may
+  return a replacement. A handler that built its replacement from a copy it captured before
+  our edit ran can hand back a prompt that still lists a builtin we just removed, silently
+  leaking it back in after `setActiveTools` already rebuilt the base prompt. The Phase 2 build
+  must assert, in a test, that a removed builtin's name is absent from the *final* system
+  prompt of the turn, not just from the value our own handler returns. Other extensions calling
+  `setActiveTools` again after ours, to re-enable a builtin we removed, is out of scope for this
+  slice: every run we install carries exactly one extension, ours. That becomes a real ordering
+  question the day a user-supplied Pi extension ships alongside ours, and is noted here so it is
+  not forgotten then.
 
 The `tool_call` hook is then free to handle only the per-call policy on the tools that are
 enabled; the grant never needs re-checking at call time.
 
-A fallback exists if `before_agent_start` proves too late to hide a tool from the model: the
-`tool_call` hook blocks any builtin not in the grant list, with a reason that says the tool is
-not enabled. This is strictly weaker (the model can try and fail), so the active-set approach
-is primary and block-in-hook is the backstop. Phase 2 picks one after a live check.
+The `tool_call` hook never checks the grant. A non-granted builtin is not in the active set,
+so no call for it ever fires, and there is nothing for the hook to check. If a call for a
+non-granted builtin somehow does fire anyway, that means the active-set edit did not take
+(a bug in the `before_agent_start` path), and it surfaces there, on the policy side, not as a
+second grant check in the hook. Phase 2 verifies live that `before_agent_start` actually hides
+the tool from the model for the current turn.
 
 ## The permission record on the relay protocol
 
@@ -154,12 +167,22 @@ through its own validator, both folded in above.
 The runner's permission branch builds a `GateDescriptor` from the record:
 
 - `executor`: `"harness"` (see the executor question below).
-- `toolName`: the builtin name from the record.
+- `toolName`: the builtin name from the record, normalized (see below).
 - `readOnlyHint`: looked up in the runner-side table (`read`, `grep`, `find`, `ls` = read;
   `bash`, `edit`, `write` = write). Not sent by the sandbox. Classification stays runner-side.
 - `args`: the real arguments from the record.
 - `specPermission` and `serverPermission`: unset. A builtin has no resolved spec and no MCP
   server, so its permission comes from pattern rules and the global default only.
+
+**Case normalization.** Authored rules use the Claude-style capitalized vocabulary, for example
+`Bash(npm:*)`, because that vocabulary was written for Claude's tool names. Pi's builtin names
+are lowercase (`bash`, `read`, `edit`). Left alone, a `Bash(...)` rule would never match a Pi
+`bash` call, and gating would silently fall through to the global default instead of the
+authored rule. The permission-record handler normalizes the builtin name through the same
+runner-side table that supplies `readOnlyHint`: one table maps a Pi builtin name to both its
+canonical rule name and its read-only bit, so `Bash(npm:*)` matches a Pi `bash` call regardless
+of which casing the author used. That table is the single place builtin identity lives; nothing
+else invents a second mapping between Pi's names and the authored rule vocabulary.
 
 Then it calls the same `decide(gate, permissionPlan, decisions)` the relay already uses and
 writes the verdict verbatim: `allow` -> `{ verdict: "allow" }`; `deny` -> `{ verdict: "deny",
@@ -174,10 +197,11 @@ names the *component* that executes the tool. Pi runs its own builtins, so the e
 component is the harness. `executor: "harness"` is the honest value. The things I thought
 justified a new value are real but belong elsewhere:
 
-- **Pending means block here, not withhold.** True, but that is post-decision handling. It
-  lives in the permission-record handler that writes the response, not in the descriptor. The
-  handler knows it is servicing a builtin permission record and writes a block on pending; the
-  descriptor does not need to encode it.
+- **Pending means block here, not withhold.** True, but that is post-decision handling, and it
+  is split across two places, not owned by the descriptor. The runner-side handler writes the
+  verdict verbatim (`{ verdict: "pendingApproval", reason }`); the extension hook, the one place
+  that knows Pi's `{ block: true }` mechanics, maps that verdict to a block. The descriptor does
+  not need to encode either half.
 - **`readOnlyHint` has a different source.** Also true, but it is resolved before the
   descriptor is built. The handler looks it up in the runner table and sets the field. The
   descriptor just carries the resolved hint, same as for any tool.
@@ -202,8 +226,8 @@ nothing. Proposed variables, read by the extension:
   extension live.
 - `AGENTA_AGENT_BUILTIN_GRANTS`: a JSON array of the granted builtin names, from
   `request.tools`, de-duped and filtered to the seven known builtin names. Drives the
-  active-set edit and the grant check. Decide explicitly whether an unknown name is dropped or
-  fails the run closed; the lean is to drop unknowns and log.
+  active-set edit, the only place the grant is enforced. Decide explicitly whether an unknown
+  name is dropped or fails the run closed; the lean is to drop unknowns and log.
 - `AGENTA_AGENT_TOOLS_RELAY_DIR`: already exists. Reused for the permission records. Must now
   be set when gating is active even with zero custom tools.
 
@@ -249,17 +273,19 @@ Consider an agent with `bash: ask` and a user watching the playground.
    paused tool call, emits the `interaction_request` event the playground renders as
    Approve/Deny, records the durable interaction, and pauses the turn. It also writes the
    response `{ kind: "permission", verdict: "pendingApproval", reason: "Waiting for approval of bash." }`.
-5. The hook reads the block and returns `{ block: true, reason }`. Pi does not run the shell
-   command. The turn is already pausing, so the model does not act on the reason this turn.
+5. The hook reads the `pendingApproval` verdict, verbatim as the runner wrote it, and maps it
+   to `{ block: true, reason }`. Pi does not run the shell command. The turn is already
+   pausing, so the model does not act on the reason this turn.
 6. The user clicks Approve. The run resumes. The stored decision now holds `allow` for this
    builtin and these args.
 7. The model re-issues the `bash` call. The hook checks again, the runner's `decide()` finds
    the stored `allow`, and the response is `{ kind: "permission", verdict: "allow" }`. The hook
-   returns nothing, Pi runs the command, and the turn continues.
+   maps `allow` to nothing (no block), Pi runs the command, and the turn continues.
 
-For `deny` the flow stops at step 3 with a straight block and the deny reason. For `allow`
-the hook writes and reads a round-trip that always says allow; that is the overhead the
-gating-active predicate exists to avoid on all-`allow` runs.
+For `deny` the flow stops at step 3: the runner writes `{ verdict: "deny", reason }` verbatim
+and the hook maps it to a block with the deny reason. For `allow` the hook writes and reads a
+round-trip that always says allow; that is the overhead the gating-active predicate exists to
+avoid on all-`allow` runs.
 
 ## Failure modes
 
@@ -314,6 +340,16 @@ rule that an unparseable policy asks rather than runs (permission-plan.ts:74).
 mid-poll when that happens. It dies with the sandbox, which is fine: the decision already
 emitted its event and paused the turn on the runner side. The runner-side response write may
 race the teardown; the write is best-effort and the resume path does not depend on it.
+
+**Version skew between the runner and the baked extension bundle.** The runner installs a
+pre-built bundle, `dist/extensions/agenta.js`, not the source tree. A stale bundle means the
+gating hook and the active-set edit silently do not exist in the running agent, even though the
+runner-side code looks correct. This exact class of bug bit us before, when a stale bundle
+silently dropped custom tools. The permission record carries a `protocol: 1` field to catch it
+mechanically rather than relying on remembering to rebuild: the runner's permission-record
+handler fails closed (verdict `deny`, logged loudly) on a missing or unrecognized protocol
+version, and the extension hook treats a malformed or version-mismatched response the same way.
+A version bump on either side without the matching bump on the other fails loud, not silent.
 
 ## What stays out of the sandbox
 

--- a/docs/design/agent-workflows/projects/pi-builtin-gating/design.md
+++ b/docs/design/agent-workflows/projects/pi-builtin-gating/design.md
@@ -55,6 +55,23 @@ When that lands, the extension's active-set edit disappears and the same config 
 declaratively. The author config, the wire field, and the playground control are identical in
 both worlds; only the enforcement mechanism moves.
 
+### The folder is the delivery vehicle either way
+
+We do use folders, exactly as the setup path does for skills and prompts: the extension ships
+inside the per-run agent dir. The folder route and the extension route are the same route.
+What Pi lacks is only a declarative settings field for tools, so the folder must carry a
+small piece of code instead of a config line. If Pi grows that field, the folder carries
+config and nothing else moves.
+
+That shape buys a property the review named as a goal in its own right: portability. Any Pi
+process that loads the agent dir enforces the same grant, whether pi-acp spawned it under our
+runner or someone runs `pi` natively against the same directory. The configuration travels
+with the folder, not with our transport. The two non-ACP alternatives fail exactly this test:
+a `pi` binary shim in the sandbox image (wrap the real binary, inject `--tools` from a
+runner-set env var) reaches the native flag today but couples enforcement to our images and
+breaks native use; waiting for the upstream passthrough leaves the grant dead in the meantime
+and only ever helps runs that go through sandbox-agent.
+
 Two corrections from the Codex review shape how this is done:
 
 - **Not at extension init.** Pi's loader stubs the action methods while the factory loads, so

--- a/docs/design/agent-workflows/projects/pi-builtin-gating/design.md
+++ b/docs/design/agent-workflows/projects/pi-builtin-gating/design.md
@@ -3,22 +3,57 @@
 ## The shape of the thing
 
 Pi fires a `tool_call` event before it runs any tool, and the handler can block. We add that
-handler to our extension. For each builtin call the handler does two checks in order:
+handler to our extension, and it does one job: the per-call policy check. For each builtin
+call it asks the runner: allow, deny, or ask? The runner decides with the real name and real
+arguments in `decide()`, then the handler enforces the answer.
 
-1. **Grant.** Is this builtin one the author enabled? If not, the call never runs.
-2. **Policy.** For a granted builtin, ask the runner: allow, deny, or ask? The runner
-   decides with the real name and real arguments in `decide()`, then the handler enforces the
-   answer.
+Which builtins exist at all is a separate question with a separate mechanism (next section).
+The hook never re-checks the grant: a non-granted builtin is not in Pi's active tool set, so
+no call for it ever fires.
 
 The runner decides. The extension only reports and enforces. That is the whole design in one
 line, and it is the line that keeps the "one decision module" doctrine intact.
 
-## The grant list: shape Pi's active-tool set at turn start
+### What our extension does today
 
-The cleanest way to enforce "which builtins exist" is to not offer the non-granted ones at
-all. Pi exposes `pi.setActiveTools([...])` and `getActiveTools()` / `getAllTools()` on the
-extension API (research.md). When gating is active, the extension sets the active set so that
-only the granted builtins remain, and the model never sees a non-granted builtin.
+Two things, neither about permissions. It registers the resolved custom and relay tools with
+`pi.registerTool`, so the model can call them and each call round-trips to the runner through
+the relay directory. And it flushes tracing and usage data on `agent_end`. The bundle
+(`dist/extensions/agenta.js`) is installed into the per-run agent dir on every run, local and
+Daytona. This design adds the `tool_call` policy hook and the active-tool-set edit to that
+same bundle; nothing else about the extension changes.
+
+## The grant list: one config, enforced at the only layer we can reach
+
+The author's builtin selection already exists and stays the single source of truth: the
+builtin entries in the agent config, shipped on the wire as `tools` ("built-in tools to
+enable"). This design adds no second configuration. The open question was only where to
+enforce the one that exists, because today nothing does (the wire field lost its last reader
+in `0e71bd0f7a`).
+
+The declarative route (write the grant into a Pi config file, the way Claude gets
+`.claude/settings.json`) does not exist: Pi's settings schema has no tool field of any kind
+(its settings.md covers extensions, skills, packages, prompts, and themes; see research.md,
+"Native tool-selection surfaces"). Pi does take a grant list natively, but only at process
+launch: `pi --tools read,bash,...` (args.js:79-95), or `createAgentSession({ tools })` in the
+SDK, which is exactly what the deleted in-process engine passed. Neither is reachable on our
+path. The runner talks to sandbox-agent, whose `SessionCreateRequest` has no tools field; the
+ACP `session/new` schema carries only `cwd` and `mcpServers`; and pi-acp hard-codes pi's argv
+(`--mode rpc --no-themes`, pi-acp index.js:134). Every layer between the runner and the flag
+drops it.
+
+That leaves one enforcement point we control today: our extension, which runs inside the
+already-spawned pi process. Pi exposes `pi.setActiveTools([...])` and `getActiveTools()` /
+`getAllTools()` on the extension API (research.md). When gating is active, the extension sets
+the active set so that only the granted builtins remain, and the model never sees a
+non-granted builtin.
+
+The durable fix is upstream, and it is filed as a follow-up rather than built here: a `tools`
+field on sandbox-agent's `SessionCreateRequest`, forwarded by pi-acp into pi's argv (or an
+env-driven passthrough in pi-acp, which already inherits the runner-controlled environment).
+When that lands, the extension's active-set edit disappears and the same config flows
+declaratively. The author config, the wire field, and the playground control are identical in
+both worlds; only the enforcement mechanism moves.
 
 Two corrections from the Codex review shape how this is done:
 
@@ -33,10 +68,8 @@ Two corrections from the Codex review shape how this is done:
   full set with `getAllTools()`, and replace only the seven builtins' slice with the granted
   subset. Non-builtin tools pass through untouched.
 
-This maps the grant gap to the mechanism that fits it. The `tools` field means "built-in
-tools to enable", which is exactly what an active-tool allowlist expresses. The `tool_call`
-hook is then free to handle only the second question, the per-call policy on the tools that
-are enabled.
+The `tool_call` hook is then free to handle only the per-call policy on the tools that are
+enabled; the grant never needs re-checking at call time.
 
 A fallback exists if `before_agent_start` proves too late to hide a tool from the model: the
 `tool_call` hook blocks any builtin not in the grant list, with a reason that says the tool is
@@ -69,8 +102,8 @@ The TS types are a real discriminated union, not "RelayResponse plus an optional
 execute response and a permission response mean different things, so they are distinct types
 keyed by `kind`. The permission response also carries `kind: "permission"` (or is parsed
 through a dedicated `PermissionRelayResponse` validator) so that the existing `relayToolCall`
-path can never mis-read one. Without that, a permission response `{ ok: true, effect:
-"block" }` would look to `relayToolCall` like an empty successful tool result.
+path can never mis-read one. Without that, a permission response `{ ok: true, verdict:
+"deny" }` would look to `relayToolCall` like an empty successful tool result.
 
 **Response record** (`<id>.res.json`, its own permission variant):
 
@@ -78,16 +111,16 @@ path can never mis-read one. Without that, a permission response `{ ok: true, ef
 | --- | --- | --- |
 | `kind: "permission"` | protocol / routing | Marks this as a permission response so no other reader parses it as a tool result. |
 | `ok` | protocol | False on a runner-side error; the handler then fails closed per the failure-mode table below. |
-| `effect: "allow" \| "block"` | control | The single bit the handler acts on. Named `effect`, not `decision`, to avoid colliding with the permission module's own `"allow" \| "deny"` decisions. |
+| `verdict: "allow" \| "deny" \| "pendingApproval"` | control | The decision module's own verdict, transported verbatim. The hook maps anything but `allow` to Pi's `{ block: true }`. Named after `decide()`'s vocabulary so the wire and the module read the same. |
 | `reason?` | data | The text shown to the model on a block, reusing the authored-deny and policy-deny wording from relay.ts. |
 
-Note there is no `"pending"` value on the wire. Pending collapses to `block` with a reason,
-because on a builtin **Pi is the executor**. The runner cannot withhold execution the way it
-does for a custom tool; the only way to stop Pi from running the builtin is for the hook to
-return `{ block: true }`. So a pending decision produces two effects at once: the runner
-pauses the turn through `onPendingApproval` (the normal ask path), and it writes a `block`
-response so the hook stops the native call. On resume the model re-issues and the stored
-decision replays. See the flow and the risk below.
+The wire carries `pendingApproval` verbatim, but in Pi it lands as a block, because on a
+builtin **Pi is the executor**. The runner cannot withhold execution the way it does for a
+custom tool; the only way to stop Pi from running the builtin is for the hook to return
+`{ block: true }`. So a pending verdict produces two things at once: the runner pauses the
+turn through `onPendingApproval` (the normal ask path), and the hook blocks the native call.
+On resume the model re-issues and the stored decision replays. See the flow and the risk
+below.
 
 ### Why a discriminator rather than a second file suffix
 
@@ -111,11 +144,11 @@ The runner's permission branch builds a `GateDescriptor` from the record:
 - `specPermission` and `serverPermission`: unset. A builtin has no resolved spec and no MCP
   server, so its permission comes from pattern rules and the global default only.
 
-Then it calls the same `decide(gate, permissionPlan, decisions)` the relay already uses, and
-maps the verdict: `allow` -> write `{ effect: "allow" }`; `deny` -> write `{ effect: "block",
-reason }`; `pendingApproval` -> call `onPendingApproval` and write `{ effect: "block",
-reason }`. The pending-to-block mapping lives in the permission-record handler, not in the
-descriptor.
+Then it calls the same `decide(gate, permissionPlan, decisions)` the relay already uses and
+writes the verdict verbatim: `allow` -> `{ verdict: "allow" }`; `deny` -> `{ verdict: "deny",
+reason }`; `pendingApproval` -> call `onPendingApproval`, then `{ verdict: "pendingApproval",
+reason }`. The verdict-to-block mapping lives in the extension hook at the Pi boundary, the
+one place that knows Pi's `{ block: true }` mechanics.
 
 ### The executor question: reuse `"harness"`, not a new value
 
@@ -189,22 +222,22 @@ Consider an agent with `bash: ask` and a user watching the playground.
 
 1. The model calls `bash` with `{ command: "npm test" }`. Pi fires `tool_call` before running
    it.
-2. The extension hook sees `bash` is granted, so it moves to the policy check. It writes a
-   permission record `{ kind: "permission", toolName: "bash", toolCallId, args: { command:
+2. The extension hook fires (a non-granted builtin would not be in the active set, so no
+   grant check happens here). It writes a permission record `{ kind: "permission", toolName: "bash", toolCallId, args: { command:
    "npm test" } }` and polls for the response.
-3. The runner loop reads the record, builds the `GateDescriptor` (`executor: "builtin"`,
+3. The runner loop reads the record, builds the `GateDescriptor` (`executor: "harness"`,
    `readOnlyHint: false` from the table, real args), and calls `decide()`. The effective
    permission is `ask`, and no stored decision exists, so the verdict is `pendingApproval`.
 4. The runner calls `onPendingApproval`. It acquires the single-pending latch, marks the
    paused tool call, emits the `interaction_request` event the playground renders as
    Approve/Deny, records the durable interaction, and pauses the turn. It also writes the
-   response `{ kind: "permission", effect: "block", reason: "Waiting for approval of bash." }`.
+   response `{ kind: "permission", verdict: "pendingApproval", reason: "Waiting for approval of bash." }`.
 5. The hook reads the block and returns `{ block: true, reason }`. Pi does not run the shell
    command. The turn is already pausing, so the model does not act on the reason this turn.
 6. The user clicks Approve. The run resumes. The stored decision now holds `allow` for this
    builtin and these args.
 7. The model re-issues the `bash` call. The hook checks again, the runner's `decide()` finds
-   the stored `allow`, and the response is `{ kind: "permission", effect: "allow" }`. The hook
+   the stored `allow`, and the response is `{ kind: "permission", verdict: "allow" }`. The hook
    returns nothing, Pi runs the command, and the turn continues.
 
 For `deny` the flow stops at step 3 with a straight block and the deny reason. For `allow`
@@ -239,8 +272,8 @@ pins that.
 sequentially, then runs them concurrently. Two builtins in one assistant message can both be
 pending. The latch lets only the first raise an approval event. The second still needs a
 response so its hook does not hang, so on a pending-but-latch-held call the runner writes
-`{ kind: "permission", effect: "block", reason: "Another approval is pending; retry after it
-resolves." }`. The second call is refused this turn and re-issued later.
+`{ kind: "permission", verdict: "pendingApproval", reason: "Another approval is pending;
+retry after it resolves." }`. The second call is refused this turn and re-issued later.
 
 This needs a small contract change the Codex review flagged: `RelayPermissions.onPendingApproval`
 returns `void` today (relay.ts:69), so a caller cannot tell whether it actually raised the

--- a/docs/design/agent-workflows/projects/pi-builtin-gating/design.md
+++ b/docs/design/agent-workflows/projects/pi-builtin-gating/design.md
@@ -174,6 +174,16 @@ The runner's permission branch builds a `GateDescriptor` from the record:
 - `specPermission` and `serverPermission`: unset. A builtin has no resolved spec and no MCP
   server, so its permission comes from pattern rules and the global default only.
 
+**Match projection (from the Phase 0 spike).** The model sometimes adds a benign optional
+parameter on re-issue (observed once in thirteen spike runs: `timeout: 10` appeared on a
+`bash` call). Full-args matching would miss and re-prompt, which is safe but needless
+friction. The builtin table therefore also owns a per-builtin match projection used ONLY for
+stored-decision matching: `bash` matches on `command` alone (the command carries the full
+semantics; a timeout cannot change what runs), while `edit` and `write` keep full canonical
+args (a content change must never auto-match a stale approval), and the read-only builtins
+keep full args too. The projection never affects the permission decision itself, only the
+resume-match key.
+
 **Case normalization.** Authored rules use the Claude-style capitalized vocabulary, for example
 `Bash(npm:*)`, because that vocabulary was written for Claude's tool names. Pi's builtin names
 are lowercase (`bash`, `read`, `edit`). Left alone, a `Bash(...)` rule would never match a Pi

--- a/docs/design/agent-workflows/projects/pi-builtin-gating/plan.md
+++ b/docs/design/agent-workflows/projects/pi-builtin-gating/plan.md
@@ -22,11 +22,14 @@ Steps:
   error tool result, so re-issue is a pure model-behavior outcome; confirm it on the real
   resume path, not in isolation.
 
-Exit: either "Pi re-issues reliably" (proceed), or "Pi needs the retry-nudge reason"
-(proceed, and make that reason the default), or "Pi does not re-issue" (stop and rethink;
-the fallback would be to hold the turn open on the hook side rather than block, which is a
-different design and would go back to you before any build). This phase is a few hours and
-saves days.
+Pass condition: run the spike 5 times through the real runner pause and teardown. Phase 0
+PASSES only if, across all 5 of 5 runs, the approved builtin executes exactly once after
+resume, never before approval, with the same canonical args each time (so the stored decision
+matches). Record the resumed transcript from each run as evidence. Any run that misses the bar,
+a double execution, a pre-approval execution, an args mismatch, or no re-issue at all, fails
+the phase. On any failure, stop and take the design back to the owner rather than patching
+around it; the fallback (holding the turn open on the hook side instead of blocking) is a
+materially different design and needs sign-off before it is built.
 
 ## Phase 1: the relay permission record and the runner decision
 
@@ -38,8 +41,9 @@ saves days.
 - In `startToolRelay`'s `handle` (relay.ts:312), branch on `kind`. For `"permission"`: build
   the `GateDescriptor` (`executor: "harness"`, `toolName`, `readOnlyHint` from the new builtin
   table, `args`), call `decide`, and write a response on **every** branch, including pending.
-  On pending, call `onPendingApproval` first, then write the block response. The
-  pending-to-block mapping lives in this handler.
+  On pending, call `onPendingApproval` first, then write `{ verdict: "pendingApproval", reason
+  }` verbatim, the same as `decide()` returned. This handler never writes a block; the
+  verdict-to-block mapping lives in the extension hook at the Pi boundary.
 - Add the builtin read-only table next to `decide()` in
   `services/runner/src/permission-plan.ts`. No new `GateExecutor` value; builtins use
   `"harness"`.
@@ -48,7 +52,8 @@ saves days.
   waiting-for-approval reason when it emitted and the another-approval-pending reason when the
   latch was already held.
 - Unit tests: allow, deny, and pending each produce the right response record; a pending
-  record both calls `onPendingApproval` and writes a block; a latch-held pending writes the
+  record both calls `onPendingApproval` and writes the `pendingApproval` verdict verbatim
+  (never a block, the handler does not map verdicts); a latch-held pending writes the
   another-approval reason; an all-`allow` policy produces allow for `bash`; a read builtin
   (`grep`) allows under `allow_reads` while a write builtin (`write`) asks; a `bash(git:*)`
   prefix rule matches on the real command argument.
@@ -58,8 +63,8 @@ saves days.
 - Add `hasBuiltinGating` to the extension's inertness guard (agenta.ts:165) so a gating-only
   run (no custom tools, no tracing, no usage) does not early-return before registering the hook.
 - Add the `tool_call` hook to `services/runner/src/extensions/agenta.ts`, registered only
-  when `AGENTA_AGENT_BUILTIN_GATING` is set. Narrow with `isToolCallEventType`. For a builtin:
-  grant check first, then write a permission record through a new
+  when `AGENTA_AGENT_BUILTIN_GATING` is set. Narrow with `isToolCallEventType`. For a builtin,
+  the hook does policy only, no grant check: it writes a permission record through a new
   `relayPermissionCheck(dir, toolName, toolCallId, args)` helper in `dispatch.ts` (sibling of
   `relayToolCall`, reusing `sanitizeRelayId`, `RELAY_POLL_MS`, `RELAY_TIMEOUT_MS`, and a
   dedicated permission-response validator). Return `{ block: true, reason }` on block, nothing
@@ -67,15 +72,24 @@ saves days.
 - Grant enforcement: shape the active tool set at `before_agent_start` (not extension init,
   where Pi stubs the action methods). Read `getActiveTools()` and `getAllTools()` and replace
   only the builtin portion with the granted subset, so user and local extension tools pass
-  through untouched. Verify it affects the current turn's system prompt. Keep the block-in-hook
-  path as the documented fallback if `before_agent_start` is too late to hide a tool.
+  through untouched. A non-granted builtin is then absent from the active set, so its
+  `tool_call` never fires; there is no second grant check anywhere else.
+- Prompt-ordering guard: `before_agent_start` handlers chain, and a later handler can hand back
+  a system prompt built from a stale copy that still lists a builtin we just removed. Assert,
+  in a test, that a removed builtin's name is absent from the *final* system prompt of the
+  turn (after every registered handler has run), not only from the value our own handler
+  returns. Re-enabling a builtin from a second extension's `setActiveTools` call is out of
+  scope for this slice (every run installs exactly one extension, ours); noted for the day a
+  user-supplied extension ships alongside ours.
 - Validate `AGENTA_AGENT_BUILTIN_GRANTS`: de-dupe, keep only the seven known builtin names, and
   drop-and-log unknowns.
 - Rebuild the bundle (`scripts/build-extension.mjs`) so the local and Daytona installs carry
   the hook.
-- Tests: the hook blocks a non-granted builtin; a granted builtin round-trips a permission
-  record; the hook is absent when the gating env is unset (the inert path); a gating-only run
-  still registers the hook (the inertness-guard fix).
+- Tests: a non-granted builtin is absent from Pi's active tool set after `before_agent_start`,
+  and therefore its `tool_call` never fires; a granted builtin round-trips a permission record;
+  the hook is absent when the gating env is unset (the inert path); a gating-only run still
+  registers the hook (the inertness-guard fix); a removed builtin's name is absent from the
+  final system prompt of the turn (the prompt-ordering guard above).
 
 ## Phase 3: env plumbing and always-on relay when gating is active
 
@@ -108,10 +122,18 @@ saves days.
   builtin `/run` and replay it without a live LLM, so the wiring cannot silently regress the
   way the grant list did in `0e71bd0f7a`.
 - Re-enable the grant list assertion: a run whose `tools` omits `bash` cannot call `bash`.
-- Case sensitivity: pattern rules match case-sensitively today, and existing tests use
-  Claude-style `Bash(npm run:*)` while Pi emits lowercase `bash`. Either normalize the known
-  builtin rule aliases or document that Pi builtin rules must be lowercase, and add a test for
-  both spellings so a `Bash(...)` rule does not silently miss a Pi `bash` call.
+- Case normalization: add the runner-side table that maps a Pi builtin name to both its
+  canonical rule name and its read-only bit (the same table `readOnlyHint` comes from), and
+  route the permission-record handler's `toolName` through it before calling `decide`. Test
+  that an authored `Bash(npm:*)` rule matches a Pi `bash` call, so a `Bash(...)` rule does not
+  silently miss a lowercase Pi call.
+- Version skew guard: add a `protocol: 1` field to the permission record. Test that the
+  runner's permission-record handler fails closed (verdict `deny`, logged) on a missing or
+  unknown protocol version, and that the extension hook treats a malformed or
+  version-mismatched response the same way. Add a build/CI guard, reusing the existing
+  `build:extension` step, that fails when `dist/extensions/agenta.js` is stale relative to
+  `src/extensions` (source changed, bundle not rebuilt), so a stale-bundle regression like the
+  one that silently dropped custom tools cannot recur for gating.
 
 ## Phase 5: live validation across the matrix
 

--- a/docs/design/agent-workflows/projects/pi-builtin-gating/plan.md
+++ b/docs/design/agent-workflows/projects/pi-builtin-gating/plan.md
@@ -1,0 +1,136 @@
+# Plan
+
+The build is small because it reuses the decision module, the relay loop, and the pause path
+whole. The risk is not the code; it is whether Pi re-issues a blocked builtin after approval.
+So Phase 0 buys down that risk before anything else.
+
+## Phase 0: spike the re-issue behavior (do this first)
+
+Goal: watch Pi's behavior after a `tool_call` hook blocks a builtin, then resume, with the
+real relay pause in the loop.
+
+Steps:
+
+- Write a throwaway extension whose `tool_call` hook blocks `bash` once with `{ block: true,
+  reason: "..." }`, then allows it. Load it into local Pi and run a prompt that calls `bash`.
+- Confirm the model calls `bash` again after the block, and that the second call carries the
+  same arguments (so stored-decision matching would hit).
+- Try two reason texts: a neutral one and one that explicitly says to retry after approval.
+  Record which produces a reliable re-issue.
+- Then repeat the spike through the real runner pause and teardown, not just a throwaway local
+  block, and inspect the actual resumed transcript. Pi core turns `{ block: true }` into an
+  error tool result, so re-issue is a pure model-behavior outcome; confirm it on the real
+  resume path, not in isolation.
+
+Exit: either "Pi re-issues reliably" (proceed), or "Pi needs the retry-nudge reason"
+(proceed, and make that reason the default), or "Pi does not re-issue" (stop and rethink;
+the fallback would be to hold the turn open on the hook side rather than block, which is a
+different design and would go back to you before any build). This phase is a few hours and
+saves days.
+
+## Phase 1: the relay permission record and the runner decision
+
+- Extend the relay records into a real discriminated union keyed by `kind` (`"execute"` vs
+  `"permission"`), not a shared type with optional fields (`services/runner/src/tools/relay.ts`
+  types at lines 46-55). The permission response carries `kind: "permission"`, `ok`, `effect:
+  "allow" | "block"`, and `reason?`. Parse it through a dedicated validator so the existing
+  `relayToolCall` path can never mis-read a permission response as a tool result.
+- In `startToolRelay`'s `handle` (relay.ts:312), branch on `kind`. For `"permission"`: build
+  the `GateDescriptor` (`executor: "harness"`, `toolName`, `readOnlyHint` from the new builtin
+  table, `args`), call `decide`, and write a response on **every** branch, including pending.
+  On pending, call `onPendingApproval` first, then write the block response. The
+  pending-to-block mapping lives in this handler.
+- Add the builtin read-only table next to `decide()` in
+  `services/runner/src/permission-plan.ts`. No new `GateExecutor` value; builtins use
+  `"harness"`.
+- Change `RelayPermissions.onPendingApproval` (relay.ts:69) to return whether it emitted the
+  approval event (a boolean or `{ emitted }`), so the handler writes the plain
+  waiting-for-approval reason when it emitted and the another-approval-pending reason when the
+  latch was already held.
+- Unit tests: allow, deny, and pending each produce the right response record; a pending
+  record both calls `onPendingApproval` and writes a block; a latch-held pending writes the
+  another-approval reason; an all-`allow` policy produces allow for `bash`; a read builtin
+  (`grep`) allows under `allow_reads` while a write builtin (`write`) asks; a `bash(git:*)`
+  prefix rule matches on the real command argument.
+
+## Phase 2: extension interception and grant enforcement
+
+- Add `hasBuiltinGating` to the extension's inertness guard (agenta.ts:165) so a gating-only
+  run (no custom tools, no tracing, no usage) does not early-return before registering the hook.
+- Add the `tool_call` hook to `services/runner/src/extensions/agenta.ts`, registered only
+  when `AGENTA_AGENT_BUILTIN_GATING` is set. Narrow with `isToolCallEventType`. For a builtin:
+  grant check first, then write a permission record through a new
+  `relayPermissionCheck(dir, toolName, toolCallId, args)` helper in `dispatch.ts` (sibling of
+  `relayToolCall`, reusing `sanitizeRelayId`, `RELAY_POLL_MS`, `RELAY_TIMEOUT_MS`, and a
+  dedicated permission-response validator). Return `{ block: true, reason }` on block, nothing
+  on allow. Fail closed on a bad or missing response.
+- Grant enforcement: shape the active tool set at `before_agent_start` (not extension init,
+  where Pi stubs the action methods). Read `getActiveTools()` and `getAllTools()` and replace
+  only the builtin portion with the granted subset, so user and local extension tools pass
+  through untouched. Verify it affects the current turn's system prompt. Keep the block-in-hook
+  path as the documented fallback if `before_agent_start` is too late to hide a tool.
+- Validate `AGENTA_AGENT_BUILTIN_GRANTS`: de-dupe, keep only the seven known builtin names, and
+  drop-and-log unknowns.
+- Rebuild the bundle (`scripts/build-extension.mjs`) so the local and Daytona installs carry
+  the hook.
+- Tests: the hook blocks a non-granted builtin; a granted builtin round-trips a permission
+  record; the hook is absent when the gating env is unset (the inert path); a gating-only run
+  still registers the hook (the inertness-guard fix).
+
+## Phase 3: env plumbing and always-on relay when gating is active
+
+- Add a first-class `builtinGatingActive` flag and a normalized `builtinGrants` list to
+  `RunPlan` (run-plan.ts), computed once. Do not recompute the predicate separately in env
+  building, workspace prep, and relay startup.
+- Compute the predicate from `permissionsFromRequest(request)` (permission-plan.ts:58), not
+  raw `request.permissions`, so the operator kill switch and the fail-to-ask behavior are
+  honored. Gating is active when the run is Pi and either the resolved policy could produce
+  anything but `allow` for a builtin, or the requested grant set differs from Pi's default
+  active builtins (`read`, `bash`, `edit`, `write`). Distinguish `tools: undefined` from
+  `tools: []`. Default to on when unsure.
+- `buildPiExtensionEnv` (pi-assets.ts:33) emits `AGENTA_AGENT_BUILTIN_GATING`,
+  `AGENTA_AGENT_BUILTIN_GRANTS`, and `AGENTA_AGENT_TOOLS_RELAY_DIR` from the plan fields.
+- `useToolRelay` (run-plan.ts:329) becomes `toolSpecs.length > 0 || builtinGatingActive`, and
+  the relay-dir creation in `workspace.ts` follows.
+- Tests: `tools: ["read","write"]` under blanket `allow` turns gating on (must remove `bash`
+  and `edit`); `tools` with `grep`/`find`/`ls` turns it on (must enable them); an all-`allow`
+  run with the default builtins granted leaves gating off and the fast path unchanged; the
+  kill switch (`SANDBOX_AGENT_DENY_PERMISSIONS=true`) forces gating on; gating-active flags set
+  the three env vars and turn `useToolRelay` on with zero custom tools.
+
+## Phase 4: contract, parity, and pin tests
+
+- The relay record types are runtime files, not part of the `/run` golden wire, so no golden
+  changes. Add a small fixture test for the permission record round-trip.
+- Parity test: `bash: ask` produces a pending on Pi that mirrors the pending a custom `ask`
+  tool produces (same event shape, same `availableReplies`).
+- Pin test (agent-replay style, per the `agent-replay-test` skill): capture one real gated
+  builtin `/run` and replay it without a live LLM, so the wiring cannot silently regress the
+  way the grant list did in `0e71bd0f7a`.
+- Re-enable the grant list assertion: a run whose `tools` omits `bash` cannot call `bash`.
+- Case sensitivity: pattern rules match case-sensitively today, and existing tests use
+  Claude-style `Bash(npm run:*)` while Pi emits lowercase `bash`. Either normalize the known
+  builtin rule aliases or document that Pi builtin rules must be lowercase, and add a test for
+  both spellings so a `Bash(...)` rule does not silently miss a Pi `bash` call.
+
+## Phase 5: live validation across the matrix
+
+Run the `agent-workflows-qa` matrix for the gated builtin cases:
+
+- Local Pi: `bash: ask` pauses in the playground, Approve runs the command, Deny refuses,
+  the whole flow re-issues cleanly (the Phase 0 behavior, now end to end).
+- Daytona Pi: the same, to confirm the sandbox relay host carries the permission record and
+  the teardown race is benign.
+- `allow_reads`: `grep`/`find`/`ls`/`read` run without a pause; `bash`/`edit`/`write` ask.
+- Grant list: a run that enables only `read` and `grep` cannot `bash`.
+- Regression: a Pi run with a blanket `allow` policy and all builtins granted shows no relay
+  overhead and behaves exactly as today.
+
+## Documentation to keep in sync (per the `keep-docs-in-sync` skill)
+
+- The agent-workflows tools and protocol pages under
+  `docs/design/agent-workflows/documentation/`.
+- The interface inventory entry for the relay record and the `tools` field.
+- The `BuiltinToolConfig` note in `sdks/python/agenta/sdk/agents/tools/models.py:87`: once
+  builtins are enforceable, the "selection-time enforcement is the designed follow-up" comment
+  should point here, and re-enabling a per-builtin permission becomes a scoped follow-up.

--- a/docs/design/agent-workflows/projects/pi-builtin-gating/plan.md
+++ b/docs/design/agent-workflows/projects/pi-builtin-gating/plan.md
@@ -44,9 +44,10 @@ materially different design and needs sign-off before it is built.
   On pending, call `onPendingApproval` first, then write `{ verdict: "pendingApproval", reason
   }` verbatim, the same as `decide()` returned. This handler never writes a block; the
   verdict-to-block mapping lives in the extension hook at the Pi boundary.
-- Add the builtin read-only table next to `decide()` in
-  `services/runner/src/permission-plan.ts`. No new `GateExecutor` value; builtins use
-  `"harness"`.
+- Add the builtin identity table next to `decide()` in
+  `services/runner/src/permission-plan.ts`: canonical rule name, read-only bit, and the
+  match projection (bash -> `command` only; every other builtin -> full canonical args).
+  No new `GateExecutor` value; builtins use `"harness"`.
 - Change `RelayPermissions.onPendingApproval` (relay.ts:69) to return whether it emitted the
   approval event (a boolean or `{ emitted }`), so the handler writes the plain
   waiting-for-approval reason when it emitted and the another-approval-pending reason when the

--- a/docs/design/agent-workflows/projects/pi-builtin-gating/plan.md
+++ b/docs/design/agent-workflows/projects/pi-builtin-gating/plan.md
@@ -32,8 +32,8 @@ saves days.
 
 - Extend the relay records into a real discriminated union keyed by `kind` (`"execute"` vs
   `"permission"`), not a shared type with optional fields (`services/runner/src/tools/relay.ts`
-  types at lines 46-55). The permission response carries `kind: "permission"`, `ok`, `effect:
-  "allow" | "block"`, and `reason?`. Parse it through a dedicated validator so the existing
+  types at lines 46-55). The permission response carries `kind: "permission"`, `ok`, `verdict:
+  "allow" | "deny" | "pendingApproval"`, and `reason?`. Parse it through a dedicated validator so the existing
   `relayToolCall` path can never mis-read a permission response as a tool result.
 - In `startToolRelay`'s `handle` (relay.ts:312), branch on `kind`. For `"permission"`: build
   the `GateDescriptor` (`executor: "harness"`, `toolName`, `readOnlyHint` from the new builtin

--- a/docs/design/agent-workflows/projects/pi-builtin-gating/research.md
+++ b/docs/design/agent-workflows/projects/pi-builtin-gating/research.md
@@ -140,3 +140,31 @@ the re-issued call, anchored on `toolName` and canonical `args`. This is the sam
 relay-ask flow already uses and that was live-QA'd for custom tools. Whether Pi re-issues a
 builtin call after the block is the one behavior this design has not yet verified live; it is
 the top open risk (design.md, plan.md Phase 0).
+
+## Native tool-selection surfaces (review round 1)
+
+Mahmoud asked why the grant list is not written into Pi's configuration the way Claude gets
+`.claude/settings.json`. Verified answer: Pi has native tool selection, but no surface of it
+is reachable on our path.
+
+- **Settings file: does not exist.** Pi's full settings reference
+  (`@earendil-works/pi-coding-agent/docs/settings.md`) has no tools field of any kind. The
+  resources it knows are extensions, skills, packages, prompts, and themes. So the per-run
+  agent dir the runner already materializes cannot express a builtin grant.
+- **CLI flags: exist, honored in RPC mode.** `--tools`, `--no-builtin-tools`, `--no-tools`,
+  `--exclude-tools` (dist/cli/args.js:79-95); mapped into session options in dist/main.js
+  (330-340, 556-558) for every mode including `--mode rpc`.
+- **SDK: exists.** `CreateAgentSessionOptions.tools?: string[]` (dist/core/sdk.d.ts:11-46).
+  The deleted in-process engine passed exactly this (`toolAllowlist` in the old runPi.ts,
+  removed in 0e71bd0f7a).
+- **The chain that drops it:** the runner calls `sandbox.createSession({ agent, cwd,
+  sessionInit })` (sandbox_agent.ts:634-638); sandbox-agent's `SessionCreateRequest` has no
+  tools field (sandbox-agent dist/index.d.ts:2950-2960); ACP `session/new` carries only
+  `cwd` and `mcpServers` (types.gen.d.ts:1480); pi-acp hard-codes pi's argv to
+  `--mode rpc --no-themes` (pi-acp dist/index.js:134-136) and reads no `_meta`. No env var
+  reaches tool selection either (no `PI_*TOOL*` variable exists).
+- **Consequence:** the extension (inside the spawned pi process) is the only layer we control
+  downstream of the fixed argv, which is why `setActiveTools` is the enforcement mechanism in
+  this slice. The upstream follow-up that replaces it: a `tools` field on sandbox-agent's
+  `SessionCreateRequest` forwarded by pi-acp into pi's argv, or an env passthrough in pi-acp
+  (it already spawns pi with the inherited environment, index.js:138).

--- a/docs/design/agent-workflows/projects/pi-builtin-gating/research.md
+++ b/docs/design/agent-workflows/projects/pi-builtin-gating/research.md
@@ -119,8 +119,12 @@ from one assistant message are preflighted sequentially, then executed concurren
 `pi.setActiveTools([...])` on the extension API, and `--no-builtin-tools` /
 `noTools: "builtin"` to start with builtins off. `setActiveTools` takes the full enabled set,
 including custom and extension tool names (`sdk.md:553`). This gives a second, cleaner
-mechanism for the grant list: set the active set to exactly the granted builtins plus our
-registered custom tools, so the model never sees a non-granted builtin at all. See design.md.
+mechanism for the grant list, corrected from an earlier draft of this idea: not "set the active
+set to the granted builtins plus our registered custom tools" (that would drop or wrongly
+activate any tool this extension did not itself register, including another extension's
+tools), but read `getActiveTools()` and `getAllTools()` first, then replace only the seven
+builtins' slice with the granted subset and leave every non-builtin tool exactly as it was.
+The model never sees a non-granted builtin, and no other tool is touched. See design.md.
 
 ## Read-only classification lives runner-side
 

--- a/docs/design/agent-workflows/projects/pi-builtin-gating/research.md
+++ b/docs/design/agent-workflows/projects/pi-builtin-gating/research.md
@@ -1,0 +1,142 @@
+# Research: the code this builds on
+
+Every claim below was read in the shipped tree on the `gitbutler/workspace` branch. File and
+line numbers are from that read and can drift by a few lines.
+
+## The grant list has no reader
+
+`services/runner/src/protocol.ts:423` declares `tools?: string[]` on `AgentRunRequest`,
+commented "Built-in tools to enable". A grep across `services/runner/src` for any read of
+`request.tools` or `.tools` on the request finds nothing. The SDK still emits it:
+`PiAgentTemplate.wire_tools` at `sdks/python/agenta/sdk/agents/dtos.py:829` returns
+`"tools": list(self.builtin_names)`. `git show 0e71bd0f7a` confirms that commit removed the
+in-process engine (`runner engines/pi.ts`) and its guard, which held the old
+`toolAllowlist` that read this field. So the field is emitted and mirrored on the wire but
+dead on arrival.
+
+## The one decision module
+
+`services/runner/src/permission-plan.ts` owns the whole decision. `decide(gate, plan,
+stored)` at line 99 returns `allow`, `deny`, or `pendingApproval`. It calls
+`effectivePermission(gate, plan)` at line 86, which resolves the tool's permission from, in
+order: the spec's explicit author permission, the owning MCP server's permission, a matching
+pattern rule, then the global default. Under `allow_reads` the default splits on
+`gate.readOnlyHint` (line 193): a read runs, anything else asks.
+
+The input is a `GateDescriptor` (line 17). Its fields:
+
+- `executor: "harness" | "relay" | "client"` (line 14): which component runs the tool;
+  the file's own comment says this "decides how resume matching anchors names".
+- `toolName?`: the stable tool name for resume matching.
+- `specPermission?`, `serverPermission?`: explicit author permissions, when present.
+- `readOnlyHint?`: the catalog read hint. Absent counts as a write under `allow_reads`.
+- `args?`: the real call arguments, used by stored-decision matching and by prefix rules.
+
+Pattern rules can be exact (`bash`) or a prefix (`bash(git:*)`). The prefix path
+(`ruleMatches`, line 155) reads the first string argument of `args`, so it needs the real
+arguments to work. This is the crux of why Option A was rejected: a gate that only sees a
+synthetic call has no real `args`, so prefix rules and read classification break.
+
+## The relay and its permission interface
+
+`services/runner/src/tools/relay.ts` runs the runner-side loop that executes tools the
+sandbox cannot run itself. `RelayPermissions` (line 63) is the contract between the relay and
+the decision module:
+
+- `enforce: boolean`: true when the relay is the only gate (Pi), false when the harness
+  gates first (Claude).
+- `decide: (gate) => Verdict`.
+- `onPendingApproval(info)`: emit the approval event and pause the turn.
+
+It is constructed at `services/runner/src/engines/sandbox_agent.ts:726`. There, `enforce` is
+`plan.isPi`, `decide` is `(gate) => decide(gate, permissionPlan, decisions)`, and
+`onPendingApproval` acquires the single-pending latch, marks the paused tool call, emits an
+`interaction_request` event with `availableReplies: ["once", "reject"]`, records the durable
+interaction, and calls `pause.pause()`.
+
+`executeRelayedTool` (relay.ts:193) is where a custom tool gets decided today. When
+`permissions.enforce` is set it builds a `GateDescriptor` with `executor: "relay"`, `toolName:
+spec.name`, `specPermission: spec.permission`, `readOnlyHint: spec.readOnly`, `args: req.args`
+(line 226), calls `decide`, and on `pendingApproval` calls `onPendingApproval` and returns the
+`PAUSED` sentinel. **On `PAUSED` the loop writes no response file** (relay.ts:328,
+`if (text === PAUSED) return;`). That is safe for custom tools because the runner is the
+executor: withholding the response withholds the result, and the turn is tearing down anyway.
+This detail matters for builtins, where the runner is not the executor (see design.md).
+
+## The relay-directory file protocol
+
+The sandbox and the runner talk through files in a relay dir. The sandbox side lives in
+`services/runner/src/tools/dispatch.ts`. `relayToolCall` (line 113) writes
+`<id>.req.json` with `{ toolName, toolCallId, args }` and polls for `<id>.res.json` with
+`{ ok, text?, error? }`, up to `RELAY_TIMEOUT_MS` (60s, relay.ts:42) polling every
+`RELAY_POLL_MS` (300ms, relay.ts:39). The record types `RelayRequest` and `RelayResponse`
+are at relay.ts:46-55. The runner side is `startToolRelay` (relay.ts:298): it polls the dir,
+reads each new `.req.json`, looks up the spec by `req.toolName` in a `specsByName` map
+(line 310), executes it, and writes `.res.json`. A request whose `toolName` has no matching
+spec throws "unknown tool" (line 319). So the current loop assumes every request names a
+resolved spec. A builtin has no spec, so the loop needs a new branch.
+
+The host abstraction (`RelayHost`, relay.ts:148) has `list`, `read`, `write`, with a local
+filesystem implementation (line 155) and a Daytona sandbox implementation (line 170). Any new
+record type rides the same host, so it works locally and on Daytona for free.
+
+## The relay only starts when custom tools exist
+
+`useToolRelay` is set at `services/runner/src/engines/sandbox_agent/run-plan.ts:329` as
+`toolSpecs.length > 0`. The relay loop is started only when that flag is true
+(`sandbox_agent.ts:776`), and the relay dir is created only then
+(`workspace.ts:95`). So a Pi run with no custom tools has no relay at all. Builtin gating must
+also start the relay when gating is active, even with zero custom tools.
+
+## The extension and its env
+
+Our extension is `services/runner/src/extensions/agenta.ts`. It is a Pi `ExtensionFactory`
+(default export, line 154) that is fully inert unless Agenta set its env
+(line 165). It registers custom tools with `pi.registerTool` (line 128), each executing
+through `runResolvedTool` -> the relay. It has no `tool_call` hook today.
+
+The env is built by `buildPiExtensionEnv` in
+`services/runner/src/engines/sandbox_agent/pi-assets.ts:33`. It sets
+`AGENTA_AGENT_TOOLS_PUBLIC_SPECS` and `AGENTA_AGENT_TOOLS_RELAY_DIR` only when there are
+public specs and a relay dir (line 57). The extension is installed per run by
+`installPiExtensionLocal` (pi-assets.ts:66) and `uploadPiExtensionToSandbox`
+(pi-assets.ts:139), and bundled by `scripts/build-extension.mjs`.
+
+## Pi's `tool_call` hook (from Pi's own docs)
+
+`node_modules/@earendil-works/pi-coding-agent/docs/extensions.md:700` documents the hook.
+`pi.on("tool_call", async (event, ctx) => ...)` fires after `tool_execution_start` and
+**before the tool executes**, and it **can block** by returning `{ block: true, reason?:
+string }`. `event.toolName` covers the native builtins (the docs list "bash", "read",
+"write", "edit"). `event.input` is the real, mutable argument object. `event.toolCallId` is
+the call id. `isToolCallEventType("bash", event)` narrows the input type. Sibling tool calls
+from one assistant message are preflighted sequentially, then executed concurrently
+(extensions.md:706), so each concurrent builtin still gets its own `tool_call` before it runs.
+
+## Pi can also restrict the active tool set
+
+`extensions.md:1540-1552` documents `pi.getActiveTools()` and
+`pi.setActiveTools([...])` on the extension API, and `--no-builtin-tools` /
+`noTools: "builtin"` to start with builtins off. `setActiveTools` takes the full enabled set,
+including custom and extension tool names (`sdk.md:553`). This gives a second, cleaner
+mechanism for the grant list: set the active set to exactly the granted builtins plus our
+registered custom tools, so the model never sees a non-granted builtin at all. See design.md.
+
+## Read-only classification lives runner-side
+
+`effectivePermission` reads `gate.readOnlyHint`. For custom tools it comes from `spec.readOnly`.
+Pi ships no read-only flag for its builtins, so the runner must hold the table itself:
+`read`, `grep`, `find`, `ls` are reads; `bash`, `edit`, `write` are writes. This table belongs
+next to `decide()` so classification stays in the one decision module, not in the sandbox.
+
+## Resume and the paused-call teardown
+
+A pending approval pauses the turn. `PauseController.markPausedToolCall`
+(`services/runner/src/engines/sandbox_agent/pause.ts:34`) records the paused call id, and
+`isPausedToolCall` (line 39) lets teardown suppress the errors from a call that was
+deliberately abandoned. On the user's decision the run resumes and the stored-decision
+matcher (`StoredPermissionDecisions.take`, permission-plan.ts:41) replays the answer against
+the re-issued call, anchored on `toolName` and canonical `args`. This is the same path the
+relay-ask flow already uses and that was live-QA'd for custom tools. Whether Pi re-issues a
+builtin call after the block is the one behavior this design has not yet verified live; it is
+the top open risk (design.md, plan.md Phase 0).

--- a/docs/design/agent-workflows/projects/pi-builtin-gating/status.md
+++ b/docs/design/agent-workflows/projects/pi-builtin-gating/status.md
@@ -172,3 +172,17 @@ technical adds. All seven folded into design.md, plan.md, and research.md:
 
 The three technical adds, the prompt-ordering assert, the protocol-version pin, and case
 normalization, came from Codex reading Pi's shipped source, not from re-reading our own docs.
+
+## Phase 0 spike, stage A: PASSED (2026-07-04)
+
+Host-local Pi (openai-codex subscription, gpt-5.4-mini), 13 runs, throwaway block-once
+extension. Results: cross-turn re-issue after an approval message 3/3 with byte-identical
+args; same-turn retry 0/10 regardless of reason wording (a blocked call is terminal for its
+turn, which suits the pause design: the turn tears down anyway); zero double executions, zero
+pre-approval executions. One finding: 1/13 runs added a spontaneous optional param
+(`timeout: 10` on bash), so the design gains a per-builtin match projection (bash matches on
+`command` alone; edit/write keep full args). Evidence: scratchpad pi-spike run logs.
+
+Gate call: stage A passes the model-behavior question, so the build proceeds. The plan's
+full 5-of-5 bar through the real runner pause and teardown runs as the live-QA acceptance
+once phases 1-3 land; a failure there still stops the ship.

--- a/docs/design/agent-workflows/projects/pi-builtin-gating/status.md
+++ b/docs/design/agent-workflows/projects/pi-builtin-gating/status.md
@@ -2,9 +2,8 @@
 
 ## State
 
-Design awaiting Mahmoud's review. No code has shipped. This workspace is the design and the
-plan. The build starts after the design is approved and after the Phase 0 spike confirms Pi
-re-issues a blocked builtin.
+Implemented and live-QA'd (2026-07-04). PR finalization is pending the #4985 merge: six
+files' hunks are frozen until then (see build-notes.md).
 
 ## Decision log
 
@@ -186,3 +185,49 @@ pre-approval executions. One finding: 1/13 runs added a spontaneous optional par
 Gate call: stage A passes the model-behavior question, so the build proceeds. The plan's
 full 5-of-5 bar through the real runner pause and teardown runs as the live-QA acceptance
 once phases 1-3 land; a failure there still stops the ship.
+
+## Live QA (full pass)
+
+Full live QA ran against the real runner pause and teardown, past the Phase 0 host-local
+spike.
+
+- **S1 5/5 bar met, over six live runs.** Each run showed one prompt, no execution before
+  approval, exactly one execution after approval, and stable canonical arguments across the
+  pause and resume.
+- **Deny, read-free, grant-enforcement, deny-all, and fast-path scenarios all pass.** A
+  denied builtin call is refused and never runs. A read-only builtin call under
+  `allow_reads` runs without a prompt. A builtin outside the grant list is absent from Pi's
+  active tool set, so the model cannot call it at all. A blanket `deny` policy blocks every
+  builtin. A run with gating inactive skips the relay round-trip entirely.
+- **The headless paused envelope carries the tool.** A paused batch response's interaction
+  payload names the pending tool as `bash`, so a headless caller can tell which call is
+  waiting without guessing.
+- **Custom-tool relay regression is clean.** The existing relay path for gateway and code
+  tools still works with the new permission-record branch alongside it, verified with an
+  unguessable-token proof that a permission record and a tool-execute record never cross
+  each other's handling.
+
+## Follow-ups (filed, not this PR)
+
+- **Denied tool card shows an "approved" badge.** A frontend label bug: the card for a
+  denied builtin call still shows the "approved" badge. The underlying behavior is correct
+  (the call is refused), so this is cosmetic.
+- **The executed builtin block renders an empty command input on the resumed turn.** The
+  SSE `tool-input` events stop delivering the command text at `""` once the turn resumes
+  after approval. Execution itself uses the right arguments; only the rendered card is
+  affected. Cosmetic.
+- **An approval persists for identical re-calls across turns in one session.** Each turn
+  rebuilds the stored decisions from the transcript, so a call approved once keeps matching
+  on later turns in the same session, not just the one it was approved for. This behavior is
+  inherited from the approval-boundary design, not new here. Whether "once" should mean
+  "once per turn" instead of "once per session" is an open decision.
+- **A headless batch invoke without `x-ag-messages-format: vercel` fails with a 500.** The
+  error is "No user message to send" where a 4xx would better signal a caller mistake. This
+  is a service developer-experience gap, not a gating bug.
+- **Hardening candidate: fail loud when a gating-active turn ends with zero permission
+  records.** The `protocol: 1` pin catches an old runner talking to a new extension bundle,
+  but not the reverse: a new runner talking to an old extension bundle writes no permission
+  record at all, so the pin has nothing to reject and gating silently does not exist. A
+  policy that must gate could detect this directly: if a turn is gating-active but produces
+  zero permission records, fail loud instead of succeeding silently. The live sidecar hit
+  exactly this case, from an image-baked stale `dist/` bundle.

--- a/docs/design/agent-workflows/projects/pi-builtin-gating/status.md
+++ b/docs/design/agent-workflows/projects/pi-builtin-gating/status.md
@@ -1,0 +1,99 @@
+# Status
+
+## State
+
+Design awaiting Mahmoud's review. No code has shipped. This workspace is the design and the
+plan. The build starts after the design is approved and after the Phase 0 spike confirms Pi
+re-issues a blocked builtin.
+
+## Decision log
+
+**Option B chosen: intercept in our extension, decide in the runner.** The extension's
+`tool_call` hook reports each builtin call, and the runner decides it through the existing
+relay permission machinery and the one shared `decide()`. This makes `bash: ask` expressible
+on Pi and re-activates the builtin grant list, with the real tool name and real arguments on
+the runner side.
+
+**Option A rejected: `ctx.ui.confirm` over ACP.** In that shape the runner-side gate would
+see only a synthetic tool call. The real arguments stay in the sandbox. So argument-prefix
+rules (`bash(git:*)`) and read-only classification would split across two sides, and the
+decision module would no longer be the single source of truth. That breaks the doctrine this
+design exists to uphold.
+
+**Option C rejected: fork Pi.** The `tool_call` hook already exists and already can block. A
+fork buys nothing and costs re-patching every Pi release in the runner image and the Daytona
+snapshot forever.
+
+**Executor reuses `"harness"` (settled, was open).** The first draft leaned toward a new
+`GateExecutor` value `"builtin"`. The Codex review argued that `executor` names the executing
+*component*, and Pi runs its own builtins, so the honest value is `"harness"`. The
+pending-to-block mapping and the read-only lookup are post-decision handling that lives in the
+builtin permission-record handler, not in the descriptor. Accepted. No new enum value; add a
+named `toolClass`/`gateSource` dimension later only if resume anchoring ever needs it.
+
+**Grant list via `setActiveTools`, at `before_agent_start` (leaning yes, open).** The grant
+gap maps most cleanly to Pi's active-tool allowlist, so the model never sees a non-granted
+builtin. The Codex review corrected two things: `setActiveTools` cannot run at extension init
+(Pi stubs the action methods there), so the edit runs at `before_agent_start`; and the edit
+must preserve non-builtin active tools (`getActiveTools()` + `getAllTools()`, replace only the
+builtin slice) so it never drops a user or local extension tool. Block-in-hook stays the
+fallback. Phase 2 confirms after a live check.
+
+**Discriminator over a second file suffix (settled).** One `kind` field keeps a single relay
+poll loop and one host abstraction serving both record types. Codex agreed, with the condition
+that the types be a real discriminated union (not a shared type with optional fields) and that
+the permission response be parsed through its own validator so `relayToolCall` never reads it
+as a tool result. Both folded into design.md.
+
+## Open risks
+
+1. **Re-issue after block (top risk).** Whether Pi re-issues a builtin call after the hook
+   blocks it and the turn resumes is unverified. Phase 0 spikes it before any build. Fallback
+   is a retry-nudge reason, or, if Pi will not re-issue at all, a return to you before
+   building.
+2. **Relay polling timeout.** The runner must always write a response for a permission record,
+   including on pending, or the hook hangs 60s. Pinned by a Phase 1 test.
+3. **Concurrent pending builtins and the single-pending latch.** The second pending builtin in
+   one message must still get a block response so its hook does not hang. Handled and tested in
+   Phase 1.
+4. **Gating-active predicate.** Getting it wrong the safe way (gating on when it could be off)
+   only costs a relay round-trip per builtin. Getting it wrong the unsafe way (off when it
+   should be on) would silently skip the gate, so the predicate defaults to on when unsure.
+
+## Provenance
+
+Design workspace created 2026-07-04. Research read against the `gitbutler/workspace` branch.
+Codex review folded in below.
+
+## Codex review
+
+**Round 1 (2026-07-04, gpt-5.5 at xhigh, read-only).** Codex read the workspace and Pi's own
+source. Every finding was accepted and folded into design.md and plan.md. Nothing was rejected.
+
+Blockers folded in:
+
+1. `setActiveTools` cannot run at extension init (Pi stubs the action methods there). Moved to
+   `before_agent_start`, with a check that it affects the current turn's system prompt.
+2. The gating-active predicate was wrong. Pi's default active builtins are `read`, `bash`,
+   `edit`, `write`, not all seven, so the requested grant set alone can require gating even
+   under blanket `allow`. Predicate rewritten; `tools: undefined` now distinct from `tools: []`.
+3. Compute the predicate from `permissionsFromRequest(request)`, not raw `request.permissions`,
+   so the `SANDBOX_AGENT_DENY_PERMISSIONS` kill switch and fail-to-ask are honored.
+4. The re-issue mitigation was too soft. Pi turns `{ block: true }` into an error tool result,
+   so re-issue is pure model behavior. Phase 0 now spikes it through the real runner pause and
+   teardown and inspects the resumed transcript; if Pi will not re-issue, the design stops.
+5. The concurrent-pending handling needs `onPendingApproval` to return whether it emitted;
+   today it returns `void`. Contract change recorded in design.md and plan.md.
+6. The extension's inertness guard (agenta.ts:165) early-returns a gating-only run. Added
+   `hasBuiltinGating` to the guard.
+
+Improvements folded in: real discriminated-union record types with a dedicated permission
+validator so `relayToolCall` never mis-parses a permission response; `executor: "harness"`
+instead of a new `"builtin"` value; preserve non-builtin active tools when editing the active
+set; first-class `builtinGatingActive` + `builtinGrants` on `RunPlan`; lowercase Pi builtin
+rule names versus Claude-style `Bash(...)`.
+
+Nits folded in: response field renamed `decision` -> `effect` to avoid colliding with the
+permission module's `allow | deny`; validate `AGENTA_AGENT_BUILTIN_GRANTS` (de-dupe, known
+seven, drop-and-log unknowns). Codex also confirmed the pending-and-block double effect is
+sound because `toolRelay.stop()` drains inflight handlers before teardown.

--- a/docs/design/agent-workflows/projects/pi-builtin-gating/status.md
+++ b/docs/design/agent-workflows/projects/pi-builtin-gating/status.md
@@ -121,3 +121,13 @@ Four comments on design.md, all folded:
   at the Pi boundary.
 - **Extension context added.** design.md now opens with what our extension does today
   (registers relay-backed custom tools, flushes tracing and usage on `agent_end`).
+
+## Review round 2 (Mahmoud, 2026-07-04)
+
+Two comments on the grant section, folded as a new design.md subsection ("The folder is the
+delivery vehicle either way"): the folder route and the extension route are the same route
+(the extension ships in the per-run agent dir, like skills); Pi only lacks a declarative
+settings field, so the folder carries code instead of a config line. Portability recorded as
+a design goal: the same agent dir enforces the same grant under native `pi` use, outside our
+ACP path. Considered and rejected: a `pi` binary shim in the sandbox image (image-coupled,
+breaks native use) and waiting for the upstream passthrough (leaves the grant dead, ACP-only).

--- a/docs/design/agent-workflows/projects/pi-builtin-gating/status.md
+++ b/docs/design/agent-workflows/projects/pi-builtin-gating/status.md
@@ -2,8 +2,8 @@
 
 ## State
 
-Implemented and live-QA'd (2026-07-04). PR finalization is pending the #4985 merge: six
-files' hunks are frozen until then (see build-notes.md).
+MERGED to big-agents via PR #5066 (2026-07-05), after Mahmoud's review, all CI suites
+green, and the post-#4985 deployment smoke (all pass, no drift).
 
 ## Decision log
 
@@ -224,8 +224,13 @@ spike.
 - **A headless batch invoke without `x-ag-messages-format: vercel` fails with a 500.** The
   error is "No user message to send" where a 4xx would better signal a caller mistake. This
   is a service developer-experience gap, not a gating bug.
-- **Hardening candidate: fail loud when a gating-active turn ends with zero permission
-  records.** The `protocol: 1` pin catches an old runner talking to a new extension bundle,
+- **Hardening, upgraded from candidate to next slice (CodeRabbit called it correctly: a
+  silent gate bypass, not polish). Fail loud when a gating-active turn ends with zero
+  permission records.** Design direction: a handshake record the extension writes at
+  `before_agent_start` when gating is active; the runner errors the turn if it is absent.
+  Exposure note: the prod image builds the bundle and the runner in one docker build
+  (the Dockerfile runs `build:extension`), so the skew is a dev-mount artifact.
+  Original finding: The `protocol: 1` pin catches an old runner talking to a new extension bundle,
   but not the reverse: a new runner talking to an old extension bundle writes no permission
   record at all, so the pin has nothing to reject and gating silently does not exist. A
   policy that must gate could detect this directly: if a turn is gating-active but produces

--- a/docs/design/agent-workflows/projects/pi-builtin-gating/status.md
+++ b/docs/design/agent-workflows/projects/pi-builtin-gating/status.md
@@ -93,7 +93,31 @@ instead of a new `"builtin"` value; preserve non-builtin active tools when editi
 set; first-class `builtinGatingActive` + `builtinGrants` on `RunPlan`; lowercase Pi builtin
 rule names versus Claude-style `Bash(...)`.
 
-Nits folded in: response field renamed `decision` -> `effect` to avoid colliding with the
+Nits folded in (the `effect` rename was later reversed in review round 1, see below): response field renamed `decision` -> `effect` to avoid colliding with the
 permission module's `allow | deny`; validate `AGENTA_AGENT_BUILTIN_GRANTS` (de-dupe, known
 seven, drop-and-log unknowns). Codex also confirmed the pending-and-block double effect is
 sound because `toolRelay.stop()` drains inflight handlers before teardown.
+
+## Review round 1 (Mahmoud, 2026-07-04)
+
+Four comments on design.md, all folded:
+
+- **The hook does policy only.** The grant check came out of the `tool_call` handler. A
+  non-granted builtin is simply absent from Pi's active tool set, so no call fires and
+  nothing is checked twice.
+- **No duplicated configuration.** The author's builtin selection stays the single source
+  (the existing config and wire `tools` field). Asked why the grant is not written into Pi's
+  config the way Claude gets settings.json: verified that Pi has no settings-file surface
+  for tools at all, and its native surfaces (the `--tools` launch flag, the SDK's
+  `createAgentSession({tools})`) are dropped by every layer of the sandbox-agent/ACP chain
+  (evidence in research.md, "Native tool-selection surfaces"). The extension's
+  `setActiveTools` is therefore the only reachable enforcement point today. The durable
+  upstream fix (a `tools` field on sandbox-agent's SessionCreateRequest forwarded by pi-acp
+  into pi's argv) is filed as a follow-up; when it lands, the extension edit disappears and
+  the same config flows declaratively.
+- **Nomenclature aligned.** The permission response now transports `decide()`'s verdict
+  verbatim (`verdict: "allow" | "deny" | "pendingApproval"`) instead of the invented
+  `effect: allow | block`. The mapping to Pi's `{ block: true }` lives in the extension hook
+  at the Pi boundary.
+- **Extension context added.** design.md now opens with what our extension does today
+  (registers relay-backed custom tools, flushes tracing and usage on `agent_end`).

--- a/docs/design/agent-workflows/projects/pi-builtin-gating/status.md
+++ b/docs/design/agent-workflows/projects/pi-builtin-gating/status.md
@@ -26,10 +26,12 @@ snapshot forever.
 
 **Executor reuses `"harness"` (settled, was open).** The first draft leaned toward a new
 `GateExecutor` value `"builtin"`. The Codex review argued that `executor` names the executing
-*component*, and Pi runs its own builtins, so the honest value is `"harness"`. The
-pending-to-block mapping and the read-only lookup are post-decision handling that lives in the
-builtin permission-record handler, not in the descriptor. Accepted. No new enum value; add a
-named `toolClass`/`gateSource` dimension later only if resume anchoring ever needs it.
+*component*, and Pi runs its own builtins, so the honest value is `"harness"`. Pending-to-block
+mapping and the read-only lookup are post-decision handling that does not belong in the
+descriptor: the runner-side permission-record handler writes the verdict verbatim, and the
+extension hook, at the Pi boundary, maps that verdict to Pi's `{ block: true }`. Accepted. No
+new enum value; add a named `toolClass`/`gateSource` dimension later only if resume anchoring
+ever needs it.
 
 **Grant list via `setActiveTools`, at `before_agent_start` (leaning yes, open).** The grant
 gap maps most cleanly to Pi's active-tool allowlist, so the model never sees a non-granted
@@ -131,3 +133,42 @@ settings field, so the folder carries code instead of a config line. Portability
 a design goal: the same agent dir enforces the same grant under native `pi` use, outside our
 ACP path. Considered and rejected: a `pi` binary shim in the sandbox image (image-coupled,
 breaks native use) and waiting for the upstream passthrough (leaves the grant dead, ACP-only).
+
+## Codex re-review (round 2)
+
+**Verdict: fix first.** Codex re-read the workspace, found stale text left over from earlier
+drafts and three underspecified risks, and read Pi's shipped source again to source the three
+technical adds. All seven folded into design.md, plan.md, and research.md:
+
+1. Purged stale hook-side grant language. The `tool_call` hook does policy only; it never
+   checks the grant. A non-granted builtin is absent from the active set, so no call fires; if
+   one somehow does, that is a bug in the active-set edit, not a second grant check.
+2. Fixed block-mapping location inconsistencies. The runner writes `decide()`'s verdict
+   verbatim; only the extension hook, at the Pi boundary, maps a non-allow verdict to Pi's
+   `{ block: true }`. Several passages had drifted into saying the runner handler writes or
+   owns a block.
+3. Added the prompt-ordering mitigation for `setActiveTools`. `before_agent_start` handlers
+   chain on a system prompt each may replace from a stale copy, so a later handler can leak a
+   removed builtin back into the prompt. Phase 2 now asserts the removed builtin's name is
+   absent from the turn's final system prompt. A second extension re-enabling a builtin after
+   ours is declared out of scope for this slice (we install exactly one extension), noted as a
+   real question the day a user-supplied extension ships.
+4. Corrected the stale "set active tools to granted builtins plus our registered custom tools"
+   idea in research.md to the actual mechanism: read `getActiveTools()`/`getAllTools()`,
+   replace only the seven builtins' slice, leave every non-builtin tool untouched.
+5. Added a version-skew failure mode. The runner installs a pre-built bundle; a stale bundle
+   means gating silently does not exist, the same class of bug that once silently dropped
+   custom tools. The permission record now carries `protocol: 1`; both sides fail closed (deny,
+   logged) on a missing or unknown version. Plan.md adds a build/CI guard that the bundle is
+   rebuilt when `src/extensions` changes, plus the protocol-version pin test.
+6. Sharpened Phase 0's pass condition: 5 of 5 spike runs must show the approved builtin
+   executing exactly once after resume, never before approval, with matching canonical args,
+   with the resumed transcript recorded as evidence. Anything else fails the phase and the
+   design goes back to the owner.
+7. Added case normalization for rule matching: authored rules use Claude-style capitalized
+   names (`Bash(...)`), Pi's builtins are lowercase (`bash`). The permission-record handler now
+   normalizes through the same runner-side table that supplies `readOnlyHint`, so `Bash(npm:*)`
+   matches a Pi `bash` call. That table is the single place builtin identity lives.
+
+The three technical adds, the prompt-ordering assert, the protocol-version pin, and case
+normalization, came from Codex reading Pi's shipped source, not from re-reading our own docs.

--- a/services/oss/tests/pytest/unit/agent/recordings/pi-gated-bash-pause.json
+++ b/services/oss/tests/pytest/unit/agent/recordings/pi-gated-bash-pause.json
@@ -1,0 +1,25 @@
+{
+  "_provenance": "Captured from a live E2 (service / sandbox-agent local) run, 2026-07-02, during the pi-builtin-gating QA pass (see docs/design/agent-workflows/projects/pi-builtin-gating/). Config: harness pi_core, runner.permissions.default 'allow_reads', all seven builtins granted (read/bash/edit/write/grep/find/ls). Prompt asked the agent to run `echo qa-gate-7431` over bash. The real run paused with a user_approval interaction naming bash, exactly as this fixture replays. Redacted: tool_call/interaction ids -> fixed placeholders. The `command` value is the real captured argument, not a secret.",
+  "stop_reason": "paused",
+  "events": [
+    {
+      "type": "interaction_request",
+      "data": {
+        "id": "call_test-1|fc_test-1",
+        "kind": "user_approval",
+        "payload": {
+          "toolCallId": "call_test-1|fc_test-1",
+          "toolCall": {
+            "toolCallId": "call_test-1|fc_test-1",
+            "name": "bash",
+            "title": "bash",
+            "rawInput": { "command": "echo qa-gate-7431" },
+            "input": { "command": "echo qa-gate-7431" }
+          },
+          "availableReplies": ["once", "reject"]
+        }
+      }
+    },
+    { "type": "done", "data": {} }
+  ]
+}

--- a/services/oss/tests/pytest/unit/agent/test_invoke_handler.py
+++ b/services/oss/tests/pytest/unit/agent/test_invoke_handler.py
@@ -8,7 +8,9 @@ network-touching helpers stubbed. No runner, no LLM, no HTTP. This is where the 
 from __future__ import annotations
 
 import inspect
+import json
 from itertools import product
+from pathlib import Path
 
 import pytest
 
@@ -155,6 +157,47 @@ async def test_batch_paused_run_surfaces_pending_interaction(monkeypatch, fake_b
         "pending_interaction": dict(
             interaction, type="interaction_request", tool="deleteFile"
         ),
+    }
+
+
+_RECORDINGS = Path(__file__).parent / "recordings"
+
+
+async def test_batch_paused_run_replays_gated_bash_builtin(monkeypatch, fake_backend):
+    """Pin the live-QA'd gated-builtin pause (agent-replay-test skill).
+
+    Captured 2026-07-02 from a real E2 (service / sandbox-agent local) run: pi_core, all
+    seven builtins granted, `runner.permissions.default: allow_reads`, prompted to run
+    `echo qa-gate-7431` over bash. The real run paused with `stop_reason: paused` and a
+    `user_approval` interaction naming `bash`, carrying the raw command. Recorded (ids
+    redacted) at `recordings/pi-gated-bash-pause.json`; replayed here through the real event
+    stream -> fold path with no live LLM, so the pi-builtin-gating wiring cannot silently
+    regress the way the grant list did in 0e71bd0f7a.
+    """
+    recorded = json.loads((_RECORDINGS / "pi-gated-bash-pause.json").read_text())
+    events = [Event(type=e["type"], data=e["data"]) for e in recorded["events"]]
+    backend = fake_backend(
+        result=AgentResult(
+            output="",
+            stop_reason=recorded["stop_reason"],
+            events=events,
+        )
+    )
+    _patch_handler(
+        monkeypatch,
+        backend,
+        builtins=["read", "bash", "edit", "write", "grep", "find", "ls"],
+    )
+
+    body = await _invoke("pi_core", permission_default="allow_reads")
+
+    # Structural facts the real run proved: it paused, and the pause names `bash` with the
+    # exact command the model tried to run.
+    assert body["stop_reason"] == "paused"
+    interaction = body["pending_interaction"]
+    assert interaction["tool"] == "bash"
+    assert interaction["payload"]["toolCall"]["rawInput"] == {
+        "command": "echo qa-gate-7431"
     }
 
 

--- a/services/runner/src/engines/sandbox_agent.ts
+++ b/services/runner/src/engines/sandbox_agent.ts
@@ -770,7 +770,7 @@ export async function runSandboxAgent(
       enforce: plan.isPi,
       decide: (gate) => decide(gate, permissionPlan, decisions),
       onPendingApproval: ({ toolCallId, toolName, args }) => {
-        if (!latch.tryAcquire()) return;
+        if (!latch.tryAcquire()) return { emitted: false };
         pause.markPausedToolCall(toolCallId);
         run.emitEvent({
           type: "interaction_request",
@@ -790,6 +790,7 @@ export async function runSandboxAgent(
         });
         recordPendingInteraction(toolCallId, toolName, args);
         pause.pause();
+        return { emitted: true };
       },
     };
     const serverPermissions = serverPermissionsFromRequest(request);

--- a/services/runner/src/engines/sandbox_agent.ts
+++ b/services/runner/src/engines/sandbox_agent.ts
@@ -44,7 +44,7 @@ import {
   type ClientToolOutcome,
   type Responder,
 } from "../responder.ts";
-import type { ClientToolRelay } from "../tools/relay.ts";
+import type { ClientToolRelay } from "../tools/client-tool-relay.ts";
 import {
   buildClientToolRelay,
   createToolCallCorrelationIndex,
@@ -384,6 +384,8 @@ export async function runSandboxAgent(
     ? buildPiExtensionEnv(request, !plan.isDaytona, {
         relayDir: plan.relayDir,
         usageOutPath: plan.usageOutPath,
+        builtinGatingActive: plan.builtinGatingActive,
+        builtinGrants: plan.builtinGrants,
         // The materialized skill names (author + forced `_agenta.*`) so Pi's own agent span
         // records which skills loaded (F-029); local Pi self-instruments, so the runner's
         // sandbox-agent otel has no span to stamp here.
@@ -653,9 +655,9 @@ export async function runSandboxAgent(
       toolSpecs: plan.toolSpecs,
       userMcpServers: request.mcpServers,
       relayDir: plan.relayDir,
-      // Local Claude only: lets the internal channel advertise + pause `client` tools. The
-      // deferred ref resolves before any `tools/call` arrives. buildSessionMcpServers ignores it
-      // for Pi / Daytona (no internal channel there).
+      // Any LOCAL non-Pi harness (Claude today): lets the internal channel advertise + pause
+      // `client` tools. The deferred ref resolves before any `tools/call` arrives.
+      // buildSessionMcpServers ignores it for Pi / Daytona (no internal channel there).
       clientToolRelay: deferredClientToolRelay,
       signal: mcpAbort.signal,
       log: logger,
@@ -718,7 +720,7 @@ export async function runSandboxAgent(
       const update = payload?.params?.update ?? payload?.update;
       if (update) {
         // Record live ACP tool_call ids so a paused client_tool can correlate to Claude's
-        // bubble (recorded even for suppressed frames; the index is first-write-wins).
+        // bubble (recorded even for suppressed frames; a lookup CONSUMES its matched id).
         toolCallIndex.record(update);
         if (!shouldSuppressPausedToolCallUpdate(update, pause)) {
           run.handleUpdate(update);

--- a/services/runner/src/engines/sandbox_agent/pi-assets.ts
+++ b/services/runner/src/engines/sandbox_agent/pi-assets.ts
@@ -33,7 +33,13 @@ export const EXTENSION_BUNDLE =
 export function buildPiExtensionEnv(
   request: AgentRunRequest,
   tracing: boolean,
-  opts: { relayDir?: string; usageOutPath?: string; skills?: string[] } = {},
+  opts: {
+    relayDir?: string;
+    usageOutPath?: string;
+    skills?: string[];
+    builtinGatingActive?: boolean;
+    builtinGrants?: string[];
+  } = {},
 ): Record<string, string> {
   const env: Record<string, string> = {};
   const propagation = tracing ? request.context?.propagation : undefined;
@@ -58,7 +64,13 @@ export function buildPiExtensionEnv(
     env.AGENTA_AGENT_TOOLS_PUBLIC_SPECS = JSON.stringify(specs);
     env.AGENTA_AGENT_TOOLS_RELAY_DIR = opts.relayDir;
   }
-  if (opts.usageOutPath) env.AGENTA_AGENT_USAGE_CAPTURE_PATH = opts.usageOutPath;
+  if (opts.builtinGatingActive) {
+    env.AGENTA_AGENT_BUILTIN_GATING = "1";
+    env.AGENTA_AGENT_BUILTIN_GRANTS = (opts.builtinGrants ?? []).join(",");
+    if (opts.relayDir) env.AGENTA_AGENT_TOOLS_RELAY_DIR = opts.relayDir;
+  }
+  if (opts.usageOutPath)
+    env.AGENTA_AGENT_USAGE_CAPTURE_PATH = opts.usageOutPath;
   return env;
 }
 

--- a/services/runner/src/engines/sandbox_agent/run-plan.ts
+++ b/services/runner/src/engines/sandbox_agent/run-plan.ts
@@ -17,6 +17,12 @@ import {
   USER_MCP_UNSUPPORTED_MESSAGE,
 } from "../../tools/mcp-bridge.ts";
 import {
+  PI_BUILTIN_TOOL_IDENTITY,
+  permissionsFromRequest,
+  piBuiltinIdentity,
+  type PermissionPlan,
+} from "../../permission-plan.ts";
+import {
   type MaterializedSkill,
   resolveSkillDirs as defaultResolveSkillDirs,
 } from "../skills.ts";
@@ -92,6 +98,10 @@ export interface RunPlan {
   usageOutPath?: string;
   toolSpecs: ResolvedToolSpec[];
   executableToolSpecs: ResolvedToolSpec[];
+  /** Normalized Pi builtin grants for the extension active-tool edit. */
+  builtinGrants: string[];
+  /** True when Pi builtin grants or permissions need extension enforcement. */
+  builtinGatingActive: boolean;
   useToolRelay: boolean;
   systemPrompt?: string;
   appendSystemPrompt?: string;
@@ -117,8 +127,7 @@ export interface RunPlan {
 }
 
 export type BuildRunPlanResult =
-  | { ok: true; plan: RunPlan }
-  | { ok: false; error: string };
+  { ok: true; plan: RunPlan } | { ok: false; error: string };
 
 export interface BuildRunPlanDeps {
   sandboxProvider?: string;
@@ -151,6 +160,63 @@ function hasStdioMcpServer(servers: McpServerConfig[] | undefined): boolean {
  */
 function hasCodeTool(specs: ResolvedToolSpec[]): boolean {
   return specs.some((spec) => spec.kind === "code");
+}
+
+const PI_DEFAULT_ACTIVE_BUILTINS = ["read", "bash", "edit", "write"];
+const PI_BUILTIN_TOOL_NAMES = Object.keys(PI_BUILTIN_TOOL_IDENTITY);
+const PI_BUILTIN_TOOL_NAME_SET = new Set<string>(PI_BUILTIN_TOOL_NAMES);
+
+function normalizePiBuiltinGrants(tools: string[] | undefined): string[] {
+  if (tools === undefined) return [...PI_DEFAULT_ACTIVE_BUILTINS];
+  if (!Array.isArray(tools)) return [];
+  const grants: string[] = [];
+  const seen = new Set<string>();
+  for (const tool of tools) {
+    if (typeof tool !== "string") continue;
+    const name = tool.trim().toLowerCase();
+    if (!PI_BUILTIN_TOOL_NAME_SET.has(name) || seen.has(name)) continue;
+    seen.add(name);
+    grants.push(name);
+  }
+  return grants;
+}
+
+function sameStringSet(
+  left: readonly string[],
+  right: readonly string[],
+): boolean {
+  if (left.length !== right.length) return false;
+  const rightSet = new Set(right);
+  return left.every((value) => rightSet.has(value));
+}
+
+function permissionPlanCouldGatePiBuiltin(plan: PermissionPlan): boolean {
+  if (plan.default !== "allow") return true;
+  return plan.rules.some((rule) =>
+    permissionRuleTargetsPiBuiltin(rule.pattern),
+  );
+}
+
+function permissionRuleTargetsPiBuiltin(pattern: string): boolean {
+  const open = pattern.indexOf("(");
+  const toolName = open === -1 ? pattern : pattern.slice(0, open);
+  return piBuiltinIdentity(toolName) !== undefined;
+}
+
+function computeBuiltinGatingActive(
+  isPi: boolean,
+  permissionPlan: PermissionPlan,
+  builtinGrants: readonly string[],
+): boolean {
+  if (!isPi) return false;
+  try {
+    return (
+      permissionPlanCouldGatePiBuiltin(permissionPlan) ||
+      !sameStringSet(builtinGrants, PI_DEFAULT_ACTIVE_BUILTINS)
+    );
+  } catch {
+    return true;
+  }
 }
 
 function defaultLocalCwd(durableCwd?: string): string {
@@ -219,6 +285,13 @@ export function buildRunPlan(
     acpAgent === "claude" ? "ANTHROPIC_API_KEY" : "OPENAI_API_KEY";
   const toolSpecs = (request.customTools as ResolvedToolSpec[]) ?? [];
   const executableToolSpecsForRun = executableToolSpecs(toolSpecs);
+  const permissionPlan = permissionsFromRequest(request);
+  const builtinGrants = normalizePiBuiltinGrants(request.tools);
+  const builtinGatingActive = computeBuiltinGatingActive(
+    isPi,
+    permissionPlan,
+    builtinGrants,
+  );
 
   // Not-implemented boundary gates (sidecar-trust Part 2): a declared capability the runner
   // cannot actually enforce fails loudly, the way code tools do (`tools/code.ts`), rather than
@@ -305,12 +378,16 @@ export function buildRunPlan(
     }
   }
 
-  const cwd = isDaytona ? createDaytonaCwd(durableCwd) : createLocalCwd(durableCwd);
+  const cwd = isDaytona
+    ? createDaytonaCwd(durableCwd)
+    : createLocalCwd(durableCwd);
   // The tool-relay scratch (req/res JSON) is ephemeral runner<->child IPC, NOT durable session
   // data — keep it OFF the geesefs-mounted cwd. A relay dir inside the mount routes every tool
   // call through FUSE/S3, so a flaky mount surfaces as ENOTCONN on the relay file. Use an
   // ephemeral sibling: a plain host tmp dir (local) or an in-VM dir (daytona), never the mount.
-  const relayBase = isDaytona ? "/home/sandbox/agenta/relay" : join(tmpdir(), "agenta", "relay");
+  const relayBase = isDaytona
+    ? "/home/sandbox/agenta/relay"
+    : join(tmpdir(), "agenta", "relay");
   const relayDir = join(relayBase, basename(cwd));
 
   // Skills materialize once from the resolved inline packages. Pi/Agenta consume the dirs
@@ -365,7 +442,9 @@ export function buildRunPlan(
       usageOutPath: isPi ? join(relayDir, ".agenta-usage.json") : undefined,
       toolSpecs,
       executableToolSpecs: executableToolSpecsForRun,
-      useToolRelay: toolSpecs.length > 0,
+      builtinGrants,
+      builtinGatingActive,
+      useToolRelay: toolSpecs.length > 0 || builtinGatingActive,
       systemPrompt,
       appendSystemPrompt,
       hasSystemPrompt: !!(systemPrompt || appendSystemPrompt),

--- a/services/runner/src/extensions/agenta.ts
+++ b/services/runner/src/extensions/agenta.ts
@@ -25,7 +25,12 @@
  */
 import { writeFileSync } from "node:fs";
 
-import type { ExtensionAPI } from "@earendil-works/pi-coding-agent";
+import {
+  isToolCallEventType,
+  type ExtensionAPI,
+  type ToolCallEvent,
+  type ToolCallEventResult,
+} from "@earendil-works/pi-coding-agent";
 
 import { createAgentaOtel } from "../tracing/otel.ts";
 import type { ResolvedToolSpec } from "../protocol.ts";
@@ -44,10 +49,155 @@ function authorizationFromOtlpHeaders(raw?: string): string | undefined {
   }
   return undefined;
 }
-import { runResolvedTool } from "../tools/dispatch.ts";
+import { relayPermissionCheck, runResolvedTool } from "../tools/dispatch.ts";
 
 function log(message: string): void {
   process.stderr.write(`[agenta-pi-ext] ${message}\n`);
+}
+
+const PI_BUILTIN_TOOL_NAMES = [
+  "read",
+  "bash",
+  "edit",
+  "write",
+  "grep",
+  "find",
+  "ls",
+] as const;
+
+type PiBuiltinToolName = (typeof PI_BUILTIN_TOOL_NAMES)[number];
+
+const PI_BUILTIN_TOOL_NAME_SET = new Set<string>(PI_BUILTIN_TOOL_NAMES);
+
+function isTruthyFlag(raw: string | undefined): boolean {
+  const normalized = raw?.trim().toLowerCase();
+  return normalized === "1" || normalized === "true";
+}
+
+function isPiBuiltinToolName(name: string): name is PiBuiltinToolName {
+  return PI_BUILTIN_TOOL_NAME_SET.has(name);
+}
+
+export function normalizeBuiltinGrants(
+  raw: string | undefined,
+  logDrop: (message: string) => void = log,
+): PiBuiltinToolName[] {
+  if (!raw) return [];
+  const grants: PiBuiltinToolName[] = [];
+  const seen = new Set<string>();
+  const unknown = new Set<string>();
+  for (const part of raw.split(",")) {
+    const name = part.trim().toLowerCase();
+    if (!name) continue;
+    if (!isPiBuiltinToolName(name)) {
+      if (!unknown.has(name)) {
+        unknown.add(name);
+        logDrop(`dropping unknown builtin grant '${name}'`);
+      }
+      continue;
+    }
+    if (seen.has(name)) continue;
+    seen.add(name);
+    grants.push(name);
+  }
+  return grants;
+}
+
+export function replaceActiveBuiltinTools(
+  activeTools: string[],
+  allTools: Array<{ name: string }>,
+  builtinGrants: readonly PiBuiltinToolName[],
+): string[] {
+  const grantSet = new Set<string>(builtinGrants);
+  const inserted = new Set<string>();
+  const grantedBuiltinTools = allTools
+    .map((tool) => tool.name)
+    .filter(isPiBuiltinToolName)
+    .filter((name) => {
+      if (!grantSet.has(name) || inserted.has(name)) return false;
+      inserted.add(name);
+      return true;
+    });
+
+  let replacedBuiltinSlice = false;
+  const next: string[] = [];
+  for (const name of activeTools) {
+    if (isPiBuiltinToolName(name)) {
+      if (!replacedBuiltinSlice) {
+        next.push(...grantedBuiltinTools);
+        replacedBuiltinSlice = true;
+      }
+      continue;
+    }
+    next.push(name);
+  }
+
+  if (!replacedBuiltinSlice) next.push(...grantedBuiltinTools);
+  return next;
+}
+
+function builtinToolNameFromEvent(
+  event: ToolCallEvent,
+): PiBuiltinToolName | undefined {
+  if (isToolCallEventType("read", event)) return "read";
+  if (isToolCallEventType("bash", event)) return "bash";
+  if (isToolCallEventType("edit", event)) return "edit";
+  if (isToolCallEventType("write", event)) return "write";
+  if (isToolCallEventType("grep", event)) return "grep";
+  if (isToolCallEventType("find", event)) return "find";
+  if (isToolCallEventType("ls", event)) return "ls";
+  return undefined;
+}
+
+function blockReason(reason: string | undefined): ToolCallEventResult {
+  return {
+    block: true,
+    reason: reason || "Denied by the permission policy.",
+  };
+}
+
+function registerBuiltinGating(
+  pi: ExtensionAPI,
+  relayDir: string | undefined,
+  builtinGrants: readonly PiBuiltinToolName[],
+): void {
+  pi.on("before_agent_start", async () => {
+    pi.setActiveTools(
+      replaceActiveBuiltinTools(
+        pi.getActiveTools(),
+        pi.getAllTools(),
+        builtinGrants,
+      ),
+    );
+  });
+
+  pi.on(
+    "tool_call",
+    async (event): Promise<ToolCallEventResult | undefined> => {
+      const toolName = builtinToolNameFromEvent(event);
+      if (!toolName) return undefined;
+      if (!relayDir) {
+        return blockReason(
+          "Permission check denied because the relay directory is missing.",
+        );
+      }
+
+      try {
+        const response = await relayPermissionCheck(
+          relayDir,
+          toolName,
+          event.toolCallId,
+          event.input,
+        );
+        if (response.verdict === "allow") return undefined;
+        return blockReason(response.reason);
+      } catch (err) {
+        return blockReason(
+          err instanceof Error ? err.message : "Permission check failed.",
+        );
+      }
+    },
+  );
 }
 
 function promptSnippet(spec: ResolvedToolSpec): string {
@@ -136,14 +286,19 @@ const factory = (pi: ExtensionAPI): void => {
   const hasTracing = !!(
     process.env.TRACEPARENT || process.env.OTEL_EXPORTER_OTLP_TRACES_ENDPOINT
   );
-  const hasTools = !!(
-    process.env.AGENTA_AGENT_TOOLS_PUBLIC_SPECS &&
-    process.env.AGENTA_AGENT_TOOLS_RELAY_DIR
+  const relayDir = process.env.AGENTA_AGENT_TOOLS_RELAY_DIR;
+  const hasTools = !!(process.env.AGENTA_AGENT_TOOLS_PUBLIC_SPECS && relayDir);
+  const hasBuiltinGating = isTruthyFlag(
+    process.env.AGENTA_AGENT_BUILTIN_GATING,
+  );
+  const builtinGrants = normalizeBuiltinGrants(
+    process.env.AGENTA_AGENT_BUILTIN_GRANTS,
   );
   const usageOut = process.env.AGENTA_AGENT_USAGE_CAPTURE_PATH;
-  if (!hasTracing && !hasTools && !usageOut) return;
+  if (!hasTracing && !hasTools && !hasBuiltinGating && !usageOut) return;
 
   if (hasTools) registerTools(pi);
+  if (hasBuiltinGating) registerBuiltinGating(pi, relayDir, builtinGrants);
   // Tracing exports the span tree (when the OTLP target is reachable, i.e. local runs).
   // Usage accumulation is needed both for that export AND for the writeback the runner
   // uses on Daytona (where the in-sandbox process can't reach Agenta's OTLP, so the
@@ -154,8 +309,11 @@ const factory = (pi: ExtensionAPI): void => {
   const otel = createAgentaOtel({
     traceparent: process.env.TRACEPARENT,
     endpoint: process.env.OTEL_EXPORTER_OTLP_TRACES_ENDPOINT,
-    authorization: authorizationFromOtlpHeaders(process.env.OTEL_EXPORTER_OTLP_HEADERS),
-    captureContent: process.env.AGENTA_AGENT_CONTENT_CAPTURE_ENABLED !== "false",
+    authorization: authorizationFromOtlpHeaders(
+      process.env.OTEL_EXPORTER_OTLP_HEADERS,
+    ),
+    captureContent:
+      process.env.AGENTA_AGENT_CONTENT_CAPTURE_ENABLED !== "false",
     // The skills that loaded for this run (author + forced `_agenta.*`), stamped on the agent
     // span so a trace shows which skills surfaced (F-029). A JSON array string from the runner.
     skills: parseSkillsLoaded(process.env.AGENTA_AGENT_SKILLS_LOADED),

--- a/services/runner/src/permission-plan.ts
+++ b/services/runner/src/permission-plan.ts
@@ -8,7 +8,11 @@
  *  - Client-tool ladder: `services/runner/src/responder.ts` handles browser-fulfilled tools
  *    across the pause/resume boundary.
  */
-import type { AgentRunRequest, PermissionMode, ToolPermission } from "./protocol.ts";
+import type {
+  AgentRunRequest,
+  PermissionMode,
+  ToolPermission,
+} from "./protocol.ts";
 
 /** Which component executes the gated tool; decides how resume matching anchors names. */
 export type GateExecutor = "harness" | "relay" | "client";
@@ -33,10 +37,28 @@ export interface PermissionPlan {
   rules: { pattern: string; permission: ToolPermission }[];
 }
 
+export const PI_BUILTIN_TOOL_IDENTITY = {
+  read: { ruleName: "Read", readOnly: true },
+  bash: { ruleName: "Bash", readOnly: false },
+  edit: { ruleName: "Edit", readOnly: false },
+  write: { ruleName: "Write", readOnly: false },
+  grep: { ruleName: "Grep", readOnly: true },
+  find: { ruleName: "Find", readOnly: true },
+  ls: { ruleName: "Ls", readOnly: true },
+} as const satisfies Record<string, { ruleName: string; readOnly: boolean }>;
+
+export type PiBuiltinToolName = keyof typeof PI_BUILTIN_TOOL_IDENTITY;
+export type PiBuiltinRuleName =
+  (typeof PI_BUILTIN_TOOL_IDENTITY)[PiBuiltinToolName]["ruleName"];
+
+export interface PiBuiltinIdentity {
+  toolName: PiBuiltinToolName;
+  ruleName: PiBuiltinRuleName;
+  readOnly: boolean;
+}
+
 export type Verdict =
-  | { kind: "allow" }
-  | { kind: "deny" }
-  | { kind: "pendingApproval" };
+  { kind: "allow" } | { kind: "deny" } | { kind: "pendingApproval" };
 
 export interface StoredPermissionDecisions {
   take(gate: GateDescriptor): "allow" | "deny" | undefined;
@@ -54,6 +76,23 @@ const RULE_RANK: Record<ToolPermission, number> = {
   ask: 1,
   deny: 2,
 };
+const PI_BUILTIN_CANONICAL_NAMES = new Map<string, PiBuiltinIdentity>(
+  (
+    Object.entries(PI_BUILTIN_TOOL_IDENTITY) as Array<
+      [PiBuiltinToolName, (typeof PI_BUILTIN_TOOL_IDENTITY)[PiBuiltinToolName]]
+    >
+  ).flatMap(([toolName, identity]) => {
+    const builtin: PiBuiltinIdentity = {
+      toolName,
+      ruleName: identity.ruleName,
+      readOnly: identity.readOnly,
+    };
+    return [
+      [toolName, builtin],
+      [identity.ruleName, builtin],
+    ];
+  }),
+);
 
 export function permissionsFromRequest(
   request: AgentRunRequest,
@@ -109,6 +148,26 @@ export function decide(
   if (storedDecision === "allow") return { kind: "allow" };
   if (storedDecision === "deny") return { kind: "deny" };
   return { kind: "pendingApproval" };
+}
+
+export function piBuiltinIdentity(
+  toolName: string,
+): PiBuiltinIdentity | undefined {
+  return PI_BUILTIN_CANONICAL_NAMES.get(toolName);
+}
+
+export function storedDecisionKeyShape(
+  toolName: string | undefined,
+  args: unknown,
+): { toolName: string | undefined; args: unknown } {
+  if (!toolName) return { toolName, args };
+  const identity = piBuiltinIdentity(toolName);
+  if (!identity) return { toolName, args };
+  return {
+    toolName: identity.ruleName,
+    args:
+      identity.toolName === "bash" ? projectBashStoredDecisionArgs(args) : args,
+  };
 }
 
 export class PendingApprovalLatch {
@@ -194,6 +253,11 @@ function defaultPermission(
     return gate.readOnlyHint === true ? "allow" : "ask";
   }
   return mode;
+}
+
+function projectBashStoredDecisionArgs(args: unknown): unknown {
+  if (!isRecord(args) || !("command" in args)) return args;
+  return { command: args.command };
 }
 
 function isPermissionMode(value: unknown): value is PermissionMode {

--- a/services/runner/src/responder.ts
+++ b/services/runner/src/responder.ts
@@ -10,6 +10,7 @@ import type { AgentRunRequest, ContentBlock } from "./protocol.ts";
 import {
   decide,
   effectivePermission,
+  storedDecisionKeyShape,
   type GateDescriptor,
   type PermissionPlan,
   type StoredPermissionDecisions,
@@ -18,7 +19,8 @@ import {
 
 export type PermissionDecision = "allow" | "deny";
 
-export type ClientToolOutcome = "deny" | "pendingApproval" | { output: unknown };
+export type ClientToolOutcome =
+  "deny" | "pendingApproval" | { output: unknown };
 
 /** A permission gate raised by the harness, normalized from the ACP request. */
 export interface PermissionGateRequest {
@@ -64,11 +66,13 @@ export function approvedCallKey(
   toolName: string | undefined,
   input: unknown,
 ): string | undefined {
-  if (!toolName) return undefined;
-  const args = input === null || input === undefined ? {} : input;
+  const shape = storedDecisionKeyShape(toolName, input);
+  if (!shape.toolName) return undefined;
+  const args =
+    shape.args === null || shape.args === undefined ? {} : shape.args;
   const hash = stableArgsHash(args);
   if (hash === undefined) return undefined;
-  return `${toolName}#${hash}`;
+  return `${shape.toolName}#${hash}`;
 }
 
 /**
@@ -89,7 +93,8 @@ function canonicalJson(value: unknown): string {
   if (value === undefined) throw new Error("undefined is not JSON");
   if (typeof value === "bigint") throw new Error("bigint is not JSON");
   if (typeof value === "number") {
-    if (!Number.isFinite(value)) throw new Error("non-finite number is not JSON");
+    if (!Number.isFinite(value))
+      throw new Error("non-finite number is not JSON");
     return JSON.stringify(value);
   }
   if (typeof value !== "object") return JSON.stringify(value);
@@ -291,7 +296,10 @@ function buildCallShapeIndex(
     if (!Array.isArray(content)) continue;
     for (const block of content) {
       if (block?.type === "tool_call" && block.toolCallId) {
-        index.set(block.toolCallId, { name: block.toolName, input: block.input });
+        index.set(block.toolCallId, {
+          name: block.toolName,
+          input: block.input,
+        });
       }
     }
   }
@@ -315,7 +323,9 @@ function coldReplayKey(
   block: ContentBlock,
   callShapeById: Map<string, { name?: string; input?: unknown }>,
 ): string | undefined {
-  const shape = block.toolCallId ? callShapeById.get(block.toolCallId) : undefined;
+  const shape = block.toolCallId
+    ? callShapeById.get(block.toolCallId)
+    : undefined;
   const name = block.toolName ?? shape?.name;
   const input = block.input ?? shape?.input;
   return approvedCallKey(name, input);
@@ -331,7 +341,9 @@ function isPermissionDecision(value: unknown): value is PermissionDecision {
  * `"allow"`/`"deny"` for one, or `undefined` for any other tool_result (a real browser/client
  * output).
  */
-function approvalDecisionOf(block: ContentBlock): PermissionDecision | undefined {
+function approvalDecisionOf(
+  block: ContentBlock,
+): PermissionDecision | undefined {
   if (!block || block.type !== "tool_result") return undefined;
   const output = block.output;
   if (
@@ -344,7 +356,6 @@ function approvalDecisionOf(block: ContentBlock): PermissionDecision | undefined
   }
   return undefined;
 }
-
 
 /**
  * Map an allow/deny decision onto the harness's available ACP replies.

--- a/services/runner/src/tools/dispatch.ts
+++ b/services/runner/src/tools/dispatch.ts
@@ -19,19 +19,29 @@
  * `relayToolCall` lives here (not in extensions/agenta.ts) so this module is the single
  * dispatch home with no import cycle back into a call site.
  */
-import { existsSync, mkdirSync, readFileSync, unlinkSync, writeFileSync } from "node:fs";
+import {
+  existsSync,
+  mkdirSync,
+  readFileSync,
+  unlinkSync,
+  writeFileSync,
+} from "node:fs";
 
 import type { ResolvedToolSpec } from "../protocol.ts";
 import { callAgentaTool } from "./callback.ts";
 import { runCodeTool } from "./code.ts";
 import { assertRequiredArguments } from "./spec-schema.ts";
 import {
+  RELAY_PERMISSION_PROTOCOL,
   RELAY_POLL_MS,
   RELAY_REQ_SUFFIX,
   RELAY_RES_SUFFIX,
   RELAY_TIMEOUT_MS,
+  parsePermissionRelayResponse,
   sanitizeRelayId,
   sleep,
+  type PermissionRelayRequest,
+  type PermissionRelayResponse,
   type RelayResponse,
 } from "./relay.ts";
 
@@ -68,7 +78,11 @@ export async function relayToolCall(
   } catch {
     // The runner also creates it; a race here is harmless.
   }
-  writeFileSync(reqPath, JSON.stringify({ toolName, toolCallId, args: params ?? {} }), "utf-8");
+  writeFileSync(
+    reqPath,
+    JSON.stringify({ toolName, toolCallId, args: params ?? {} }),
+    "utf-8",
+  );
 
   const deadline = Date.now() + RELAY_TIMEOUT_MS;
   while (Date.now() < deadline) {
@@ -93,6 +107,108 @@ export async function relayToolCall(
   throw new Error(`tool relay timed out for ${toolName}`);
 }
 
+function oneLineReason(reason: string): string {
+  return reason.replace(/\s+/g, " ").trim() || "Permission check failed.";
+}
+
+function denyPermissionRelayResponse(reason: string): PermissionRelayResponse {
+  return {
+    kind: "permission",
+    ok: false,
+    verdict: "deny",
+    reason: oneLineReason(reason),
+  };
+}
+
+/**
+ * Pi builtin permission check: write a permission request into the same relay directory the
+ * runner watches for tool execution, then poll for its permission response. The extension must
+ * fail closed because returning nothing lets Pi execute the builtin.
+ */
+export async function relayPermissionCheck(
+  dir: string,
+  toolName: string,
+  toolCallId: string,
+  args: unknown,
+): Promise<PermissionRelayResponse> {
+  const id = sanitizeRelayId(toolCallId);
+  const reqPath = `${dir}/${id}${RELAY_REQ_SUFFIX}`;
+  const resPath = `${dir}/${id}${RELAY_RES_SUFFIX}`;
+  try {
+    mkdirSync(dir, { recursive: true });
+  } catch {
+    // The runner also creates it; a race here is harmless.
+  }
+
+  const req: PermissionRelayRequest = {
+    kind: "permission",
+    protocol: RELAY_PERMISSION_PROTOCOL,
+    toolName,
+    toolCallId,
+    args: args ?? {},
+  };
+  try {
+    writeFileSync(reqPath, JSON.stringify(req), "utf-8");
+  } catch (err) {
+    return denyPermissionRelayResponse(
+      `permission relay request for ${toolName} could not be written: ${
+        err instanceof Error ? err.message : String(err)
+      }`,
+    );
+  }
+
+  const cleanup = (): void => {
+    try {
+      unlinkSync(reqPath);
+    } catch {
+      /* best-effort cleanup */
+    }
+    try {
+      unlinkSync(resPath);
+    } catch {
+      /* best-effort cleanup */
+    }
+  };
+
+  const deadline = Date.now() + RELAY_TIMEOUT_MS;
+  while (Date.now() < deadline) {
+    if (existsSync(resPath)) {
+      let parsed: PermissionRelayResponse | undefined;
+      try {
+        parsed = parsePermissionRelayResponse(
+          JSON.parse(readFileSync(resPath, "utf-8")),
+        );
+      } catch {
+        cleanup();
+        return denyPermissionRelayResponse(
+          `permission relay response for ${toolName} was unparseable`,
+        );
+      }
+      cleanup();
+      if (!parsed) {
+        return denyPermissionRelayResponse(
+          `permission relay response for ${toolName} was unparseable`,
+        );
+      }
+      if (!parsed.ok) {
+        return denyPermissionRelayResponse(
+          parsed.reason || `permission relay failed for ${toolName}`,
+        );
+      }
+      return parsed;
+    }
+    await sleep(RELAY_POLL_MS);
+  }
+  try {
+    unlinkSync(reqPath);
+  } catch {
+    /* best-effort cleanup */
+  }
+  return denyPermissionRelayResponse(
+    `permission relay timed out for ${toolName}`,
+  );
+}
+
 /**
  * Execute one resolved tool and return its result text. Throws on failure; every call site
  * turns the throw into a tool-error result so the model loop continues rather than crashing.
@@ -109,17 +225,37 @@ export async function runResolvedTool(
 ): Promise<string> {
   assertRequiredArguments(spec, params);
   if (spec.kind === "code") {
-    return runCodeTool(spec.runtime, spec.code ?? "", spec.env, params, opts.signal);
+    return runCodeTool(
+      spec.runtime,
+      spec.code ?? "",
+      spec.env,
+      params,
+      opts.signal,
+    );
   }
   if (spec.kind === "client") {
     if (opts.relayDir) {
-      return relayToolCall(opts.relayDir, spec.name, opts.toolCallId, params, opts.signal);
+      return relayToolCall(
+        opts.relayDir,
+        spec.name,
+        opts.toolCallId,
+        params,
+        opts.signal,
+      );
     }
-    throw new Error(`client tool '${spec.name}' is browser-fulfilled and cannot be executed`);
+    throw new Error(
+      `client tool '${spec.name}' is browser-fulfilled and cannot be executed`,
+    );
   }
   // callback (default): route back to Agenta's /tools/call (directly or via the Daytona relay).
   if (opts.relayDir) {
-    return relayToolCall(opts.relayDir, spec.name, opts.toolCallId, params, opts.signal);
+    return relayToolCall(
+      opts.relayDir,
+      spec.name,
+      opts.toolCallId,
+      params,
+      opts.signal,
+    );
   }
   return callAgentaTool(
     opts.endpoint ?? "",

--- a/services/runner/src/tools/relay.ts
+++ b/services/runner/src/tools/relay.ts
@@ -15,7 +15,13 @@
  *
  * The same loop supports local filesystem relays and Daytona sandbox filesystem relays.
  */
-import { existsSync, mkdirSync, readdirSync, readFileSync, writeFileSync } from "node:fs";
+import {
+  existsSync,
+  mkdirSync,
+  readdirSync,
+  readFileSync,
+  writeFileSync,
+} from "node:fs";
 
 import { callAgentaTool } from "./callback.ts";
 import { runCodeTool } from "./code.ts";
@@ -31,9 +37,20 @@ import type {
   RunContext,
   ToolCallbackContext,
 } from "../protocol.ts";
-import type { GateDescriptor, Verdict } from "../permission-plan.ts";
-import type { ClientToolOutcome } from "../responder.ts";
+import {
+  piBuiltinIdentity,
+  type GateDescriptor,
+  type Verdict,
+} from "../permission-plan.ts";
+import type { ClientToolRelay } from "./client-tool-relay.ts";
 import { assertRequiredArguments } from "./spec-schema.ts";
+
+// Compatibility re-export: the type moved to `client-tool-relay.ts` (a pure type module);
+// importers that still reach it through this module keep working while they migrate.
+export type {
+  ClientToolRelay,
+  ClientToolRelayRequest,
+} from "./client-tool-relay.ts";
 
 export const RELAY_REQ_SUFFIX = ".req.json";
 export const RELAY_RES_SUFFIX = ".res.json";
@@ -58,6 +75,7 @@ export const RELAY_POLL_MAX_MS = Number(
 export const RELAY_POLL_IDLE_GROW_AFTER = Number(
   process.env.AGENTA_AGENT_TOOLS_RELAY_IDLE_GROW_AFTER ?? 5,
 );
+export const RELAY_PERMISSION_PROTOCOL = 1;
 
 /** The next poll delay given the count of consecutive idle polls (no new request seen). */
 export function relayPollDelayMs(idlePolls: number): number {
@@ -66,23 +84,37 @@ export function relayPollDelayMs(idlePolls: number): number {
   return Math.min(RELAY_POLL_MS * factor, RELAY_POLL_MAX_MS);
 }
 
-export interface RelayRequest {
+export interface ExecuteRelayRequest {
+  kind?: "execute";
   toolName: string;
   toolCallId: string;
   args: unknown;
 }
-export interface RelayResponse {
+export interface PermissionRelayRequest {
+  kind: "permission";
+  protocol: typeof RELAY_PERMISSION_PROTOCOL;
+  toolName: string;
+  toolCallId: string;
+  args: unknown;
+}
+export type RelayRequest = ExecuteRelayRequest | PermissionRelayRequest;
+
+export interface ExecuteRelayResponse {
+  kind?: "execute";
   ok: boolean;
   text?: string;
   error?: string;
 }
-export interface ClientToolRelayRequest {
-  id: string;
-  toolCallId: string;
-  toolName: string;
-  input: unknown;
-  spec: ResolvedToolSpec;
+export type RelayResponse = ExecuteRelayResponse;
+export type PermissionRelayVerdict = "allow" | "deny" | "pendingApproval";
+export interface PermissionRelayResponse {
+  kind: "permission";
+  ok: boolean;
+  verdict: PermissionRelayVerdict;
+  reason?: string;
 }
+export type RelayRecordResponse =
+  ExecuteRelayResponse | PermissionRelayResponse;
 export interface RelayPermissions {
   /** False when the harness raises its own gates first (Claude); the relay then executes
    *  what reaches it. True when the relay is the only gate (Pi). */
@@ -93,12 +125,7 @@ export interface RelayPermissions {
     toolCallId: string;
     toolName: string;
     args: unknown;
-  }) => void;
-}
-
-export interface ClientToolRelay {
-  onClientTool: (request: ClientToolRelayRequest) => Promise<ClientToolOutcome>;
-  onPause?: (request: ClientToolRelayRequest) => void;
+  }) => { emitted: boolean };
 }
 const PAUSED = Symbol("paused");
 
@@ -107,8 +134,26 @@ export function sanitizeRelayId(id: string): string {
   return id.replace(/[^A-Za-z0-9_-]/g, "_").slice(0, 120) || "tool";
 }
 
-export const sleep = (ms: number): Promise<void> => new Promise((r) => setTimeout(r, ms));
+export const sleep = (ms: number): Promise<void> =>
+  new Promise((r) => setTimeout(r, ms));
 
+export function parsePermissionRelayResponse(
+  value: unknown,
+): PermissionRelayResponse | undefined {
+  if (!isRecord(value)) return undefined;
+  if (value.kind !== "permission") return undefined;
+  if (typeof value.ok !== "boolean") return undefined;
+  if (!isPermissionRelayVerdict(value.verdict)) return undefined;
+  if (value.reason !== undefined && typeof value.reason !== "string") {
+    return undefined;
+  }
+  return {
+    kind: "permission",
+    ok: value.ok,
+    verdict: value.verdict,
+    ...(value.reason === undefined ? {} : { reason: value.reason }),
+  };
+}
 
 export interface RelayHost {
   list: (dir: string) => Promise<string[]>;
@@ -147,7 +192,9 @@ export function sandboxRelayHost(sandbox: any): RelayHost {
     },
     read: async (path) => {
       const bytes = await sandbox.readFsFile({ path });
-      return typeof bytes === "string" ? bytes : new TextDecoder().decode(bytes);
+      return typeof bytes === "string"
+        ? bytes
+        : new TextDecoder().decode(bytes);
     },
     write: async (path, contents) => {
       await sandbox.writeFsFile({ path }, contents);
@@ -157,7 +204,7 @@ export function sandboxRelayHost(sandbox: any): RelayHost {
 
 async function executeRelayedTool(
   spec: ResolvedToolSpec,
-  req: RelayRequest,
+  req: ExecuteRelayRequest,
   callback: ToolCallbackContext | undefined,
   permissions: RelayPermissions,
   runContext: RunContext | undefined,
@@ -166,7 +213,9 @@ async function executeRelayedTool(
   if (spec.kind === "client") {
     assertRequiredArguments(spec, req.args);
     if (!clientToolRelay) {
-      throw new Error(`client tool '${spec.name}' is browser-fulfilled and cannot be executed`);
+      throw new Error(
+        `client tool '${spec.name}' is browser-fulfilled and cannot be executed`,
+      );
     }
     const toolCallId = req.toolCallId;
     const request = {
@@ -198,9 +247,9 @@ async function executeRelayedTool(
     const verdict = permissions.decide(gate);
     if (verdict.kind === "deny") {
       if (spec.permission === "deny") {
-        return `Tool '${spec.name}' is denied by policy.`;
+        return authoredDenyReason(spec.name);
       }
-      return `Tool '${spec.name}' is denied by the permission policy.`;
+      return permissionPolicyDenyReason(spec.name);
     }
     if (verdict.kind === "pendingApproval") {
       permissions.onPendingApproval({
@@ -217,7 +266,7 @@ async function executeRelayedTool(
 
 async function executeAllowedRelayedTool(
   spec: ResolvedToolSpec,
-  req: RelayRequest,
+  req: ExecuteRelayRequest,
   callback: ToolCallbackContext | undefined,
   runContext: RunContext | undefined,
 ): Promise<string> {
@@ -260,6 +309,93 @@ async function executeAllowedRelayedTool(
  * the in-sandbox extension is waiting on. Returns `stop()` to end the loop and drain any
  * in-flight executions; call it once the prompt resolves.
  */
+function permissionPolicyDenyReason(toolName: string): string {
+  return `Tool '${toolName}' is denied by the permission policy.`;
+}
+
+function authoredDenyReason(toolName: string): string {
+  return `Tool '${toolName}' is denied by policy.`;
+}
+
+function permissionProtocolMismatchReason(): string {
+  return "Permission check denied because of a runner/extension version mismatch.";
+}
+
+function logPermissionRelayError(message: string): void {
+  process.stderr.write(`[tool-relay] ERROR ${message}\n`);
+}
+
+function permissionDenyResponse(reason: string): PermissionRelayResponse {
+  return { kind: "permission", ok: true, verdict: "deny", reason };
+}
+
+function isPermissionRelayVerdict(
+  value: unknown,
+): value is PermissionRelayVerdict {
+  return value === "allow" || value === "deny" || value === "pendingApproval";
+}
+
+function isRecord(value: unknown): value is Record<string, unknown> {
+  return typeof value === "object" && value !== null && !Array.isArray(value);
+}
+
+async function handlePermissionRelayRequest(
+  req: Partial<PermissionRelayRequest> & {
+    kind: "permission";
+    protocol?: unknown;
+  },
+  fallbackId: string,
+  permissions: RelayPermissions,
+): Promise<PermissionRelayResponse> {
+  const toolName =
+    typeof req.toolName === "string" ? req.toolName : "<unknown>";
+  if (req.protocol !== RELAY_PERMISSION_PROTOCOL) {
+    logPermissionRelayError(
+      `permission protocol mismatch for ${toolName}: got ${JSON.stringify(
+        req.protocol,
+      )}, expected ${RELAY_PERMISSION_PROTOCOL}; denying`,
+    );
+    return permissionDenyResponse(permissionProtocolMismatchReason());
+  }
+
+  const identity = piBuiltinIdentity(toolName);
+  if (!identity) {
+    logPermissionRelayError(
+      `unknown builtin permission tool ${toolName}; denying`,
+    );
+    return permissionDenyResponse(permissionPolicyDenyReason(toolName));
+  }
+
+  const gate: GateDescriptor = {
+    executor: "harness",
+    toolName: identity.ruleName,
+    readOnlyHint: identity.readOnly,
+    args: req.args,
+  };
+  const verdict = permissions.decide(gate);
+  if (verdict.kind === "allow") {
+    return { kind: "permission", ok: true, verdict: "allow" };
+  }
+  if (verdict.kind === "deny") {
+    return permissionDenyResponse(permissionPolicyDenyReason(toolName));
+  }
+
+  const pending = permissions.onPendingApproval({
+    toolCallId:
+      typeof req.toolCallId === "string" ? req.toolCallId : fallbackId,
+    toolName,
+    args: req.args,
+  });
+  return {
+    kind: "permission",
+    ok: true,
+    verdict: "pendingApproval",
+    reason: pending.emitted
+      ? `Waiting for approval of ${toolName}.`
+      : "Another approval is pending; retry after it resolves.",
+  };
+}
+
 export function startToolRelay(
   host: RelayHost,
   relayDir: string,
@@ -276,27 +412,51 @@ export function startToolRelay(
 
   const handle = async (reqName: string): Promise<void> => {
     const id = reqName.slice(0, -RELAY_REQ_SUFFIX.length);
-    let res: RelayResponse;
+    let res: RelayRecordResponse;
+    let permissionReqName: string | undefined;
     try {
       const raw = await host.read(`${relayDir}/${reqName}`);
       const req = JSON.parse(raw) as RelayRequest;
-      const spec = specsByName.get(req.toolName);
-      if (!spec) throw new Error(`unknown tool '${req.toolName}'`);
-      const text = await executeRelayedTool(
-        spec,
-        { ...req, toolCallId: req.toolCallId ?? id },
-        callback,
-        permissions,
-        runContext,
-        clientToolRelay,
-      );
-      if (text === PAUSED) return;
-      res = { ok: true, text };
+      if (req.kind === "permission") {
+        permissionReqName =
+          typeof req.toolName === "string" ? req.toolName : undefined;
+        res = await handlePermissionRelayRequest(req, id, permissions);
+      } else {
+        const spec = specsByName.get(req.toolName);
+        if (!spec) throw new Error(`unknown tool '${req.toolName}'`);
+        const text = await executeRelayedTool(
+          spec,
+          { ...req, toolCallId: req.toolCallId ?? id },
+          callback,
+          permissions,
+          runContext,
+          clientToolRelay,
+        );
+        if (text === PAUSED) return;
+        res = { ok: true, text };
+      }
     } catch (err) {
-      res = { ok: false, error: err instanceof Error ? err.message : String(err) };
+      if (permissionReqName !== undefined) {
+        logPermissionRelayError(
+          `permission request for ${permissionReqName} failed: ${
+            err instanceof Error ? err.message : String(err)
+          }; denying`,
+        );
+        res = permissionDenyResponse(
+          permissionPolicyDenyReason(permissionReqName),
+        );
+      } else {
+        res = {
+          ok: false,
+          error: err instanceof Error ? err.message : String(err),
+        };
+      }
     }
     try {
-      await host.write(`${relayDir}/${id}${RELAY_RES_SUFFIX}`, JSON.stringify(res));
+      await host.write(
+        `${relayDir}/${id}${RELAY_RES_SUFFIX}`,
+        JSON.stringify(res),
+      );
     } catch {
       // The extension will time out and surface a tool error; nothing else to do here.
     }

--- a/services/runner/tests/unit/extension-tools.test.ts
+++ b/services/runner/tests/unit/extension-tools.test.ts
@@ -13,7 +13,10 @@
 import { afterEach, describe, it } from "vitest";
 import assert from "node:assert/strict";
 
-import factory from "../../src/extensions/agenta.ts";
+import factory, {
+  normalizeBuiltinGrants,
+  replaceActiveBuiltinTools,
+} from "../../src/extensions/agenta.ts";
 
 const TOOL_ENV = [
   "AGENTA_AGENT_TOOLS_PUBLIC_SPECS",
@@ -22,16 +25,32 @@ const TOOL_ENV = [
   "OTEL_EXPORTER_OTLP_TRACES_ENDPOINT",
   "AGENTA_AGENT_USAGE_CAPTURE_PATH",
   "AGENTA_AGENT_CONTENT_CAPTURE_ENABLED",
+  "AGENTA_AGENT_BUILTIN_GATING",
+  "AGENTA_AGENT_BUILTIN_GRANTS",
 ];
 
-function fakePi() {
+function fakePi(opts: { activeTools?: string[]; allTools?: string[] } = {}) {
   const registered: any[] = [];
+  const handlers: Record<string, any[]> = {};
+  let activeTools = opts.activeTools ?? [];
   return {
     registered,
+    handlers,
     registerTool(spec: any) {
       registered.push(spec);
     },
-    on() {},
+    on(event: string, handler: any) {
+      (handlers[event] ??= []).push(handler);
+    },
+    getActiveTools() {
+      return activeTools;
+    },
+    getAllTools() {
+      return (opts.allTools ?? []).map((name) => ({ name }));
+    },
+    setActiveTools(next: string[]) {
+      activeTools = next;
+    },
   };
 }
 
@@ -96,6 +115,85 @@ describe("agenta extension tool registration", () => {
       pi.registered.length,
       0,
       "no tool env => registers nothing (no silent partial state)",
+    );
+  });
+
+  it("does not register builtin gating hooks when gating env is absent", () => {
+    clearEnv();
+    const pi = fakePi();
+    factory(pi as any);
+    assert.equal(pi.handlers.before_agent_start?.length ?? 0, 0);
+    assert.equal(pi.handlers.tool_call?.length ?? 0, 0);
+  });
+
+  it("registers builtin gating hooks for a gating-only run", () => {
+    clearEnv();
+    process.env.AGENTA_AGENT_BUILTIN_GATING = "true";
+    process.env.AGENTA_AGENT_BUILTIN_GRANTS = "read";
+    process.env.AGENTA_AGENT_TOOLS_RELAY_DIR = "/tmp/agenta-relay-test";
+
+    const pi = fakePi();
+    factory(pi as any);
+
+    assert.equal(pi.registered.length, 0);
+    assert.equal(pi.handlers.before_agent_start?.length ?? 0, 1);
+    assert.equal(pi.handlers.tool_call?.length ?? 0, 1);
+  });
+
+  it("removes non-granted builtins from the active set at before_agent_start", async () => {
+    clearEnv();
+    process.env.AGENTA_AGENT_BUILTIN_GATING = "1";
+    process.env.AGENTA_AGENT_BUILTIN_GRANTS = "read,write";
+    process.env.AGENTA_AGENT_TOOLS_RELAY_DIR = "/tmp/agenta-relay-test";
+
+    const pi = fakePi({
+      activeTools: ["read", "bash", "edit", "write", "custom_tool"],
+      allTools: [
+        "read",
+        "bash",
+        "edit",
+        "write",
+        "grep",
+        "find",
+        "ls",
+        "custom_tool",
+      ],
+    });
+    factory(pi as any);
+
+    await pi.handlers.before_agent_start[0]({});
+
+    assert.deepEqual(pi.getActiveTools(), ["read", "write", "custom_tool"]);
+  });
+
+  it("validates builtin grants by de-duping and dropping unknown names", () => {
+    const logs: string[] = [];
+
+    const grants = normalizeBuiltinGrants(
+      "read,unknown,read,Find,BASH,unknown",
+      (message) => logs.push(message),
+    );
+
+    assert.deepEqual(grants, ["read", "find", "bash"]);
+    assert.deepEqual(logs, ["dropping unknown builtin grant 'unknown'"]);
+  });
+
+  it("replaces only the builtin portion of the active tool set", () => {
+    assert.deepEqual(
+      replaceActiveBuiltinTools(
+        ["custom_before", "read", "bash", "custom_after"],
+        [
+          { name: "read" },
+          { name: "bash" },
+          { name: "edit" },
+          { name: "write" },
+          { name: "grep" },
+          { name: "custom_before" },
+          { name: "custom_after" },
+        ],
+        ["read", "grep"],
+      ),
+      ["custom_before", "read", "grep", "custom_after"],
     );
   });
 

--- a/services/runner/tests/unit/permission-record-fixture.test.ts
+++ b/services/runner/tests/unit/permission-record-fixture.test.ts
@@ -1,0 +1,150 @@
+/**
+ * Phase 4 (docs/design/agent-workflows/projects/pi-builtin-gating/plan.md): "The relay record
+ * types are runtime files, not part of the `/run` golden wire, so no golden changes. Add a
+ * small fixture test for the permission record round-trip."
+ *
+ * This pins the on-disk shape of the permission relay records: the REQUEST record
+ * `{kind, protocol, toolName, toolCallId, args}` and the three RESPONSE verdict variants
+ * (allow / deny+reason / pendingApproval+reason), each written to a temp relay dir and read
+ * back exactly as `startToolRelay` and the extension's `relayPermissionCheck` would see them
+ * over the filesystem. It also pins two parser boundaries in `parsePermissionRelayResponse`:
+ * an unknown extra field must not break parsing (forward compatibility), and an execute-record
+ * shape (no `kind`) must never be accepted as a permission response (the discriminated-union
+ * boundary Phase 1 introduced so the two record kinds can never be cross-read).
+ *
+ * Run: pnpm test (or: pnpm exec vitest run tests/unit/permission-record-fixture.test.ts)
+ */
+import { afterEach, describe, it } from "vitest";
+import assert from "node:assert/strict";
+import { mkdtempSync, readFileSync, rmSync, writeFileSync } from "node:fs";
+import { tmpdir } from "node:os";
+import { join } from "node:path";
+
+import {
+  parsePermissionRelayResponse,
+  RELAY_PERMISSION_PROTOCOL,
+  type PermissionRelayResponse,
+} from "../../src/tools/relay.ts";
+
+const dirs: string[] = [];
+
+afterEach(() => {
+  while (dirs.length > 0) {
+    const dir = dirs.pop();
+    if (dir) rmSync(dir, { recursive: true, force: true });
+  }
+});
+
+function tempRelayDir(): string {
+  const dir = mkdtempSync(join(tmpdir(), "agenta-permission-record-fixture-"));
+  dirs.push(dir);
+  return dir;
+}
+
+/** Write `value` as JSON to `<dir>/<name>`, then read the bytes back off disk. Mirrors the
+ *  relay's own file round trip (`host.write` then `host.read` in `tools/relay.ts`). */
+function roundTripJson(
+  dir: string,
+  name: string,
+  value: unknown,
+): { raw: string; parsed: unknown } {
+  const path = join(dir, name);
+  const raw = JSON.stringify(value);
+  writeFileSync(path, raw, "utf-8");
+  const readBack = readFileSync(path, "utf-8");
+  assert.equal(readBack, raw, "the bytes on disk match what was written exactly");
+  return { raw: readBack, parsed: JSON.parse(readBack) };
+}
+
+describe("permission relay request record fixture", () => {
+  it("round-trips the request record shape {kind, protocol, toolName, toolCallId, args}", () => {
+    const dir = tempRelayDir();
+    const request = {
+      kind: "permission" as const,
+      protocol: RELAY_PERMISSION_PROTOCOL,
+      toolName: "bash",
+      toolCallId: "call-42",
+      args: { command: "npm test" },
+    };
+
+    const { parsed } = roundTripJson(dir, "call-42.req.json", request);
+
+    assert.deepEqual(parsed, request);
+  });
+});
+
+describe("permission relay response record fixture (allow / deny / pendingApproval)", () => {
+  const variants: Array<{ name: string; response: PermissionRelayResponse }> = [
+    {
+      name: "allow",
+      response: { kind: "permission", ok: true, verdict: "allow" },
+    },
+    {
+      name: "deny with reason",
+      response: {
+        kind: "permission",
+        ok: true,
+        verdict: "deny",
+        reason: "Tool 'bash' is denied by the permission policy.",
+      },
+    },
+    {
+      name: "pendingApproval with reason",
+      response: {
+        kind: "permission",
+        ok: true,
+        verdict: "pendingApproval",
+        reason: "Waiting for approval of bash.",
+      },
+    },
+  ];
+
+  for (const { name, response } of variants) {
+    it(`round-trips the ${name} response byte-stably through parsePermissionRelayResponse`, () => {
+      const dir = tempRelayDir();
+      const { raw, parsed } = roundTripJson(dir, "call-42.res.json", response);
+
+      assert.deepEqual(parsed, response);
+
+      const reparsed = parsePermissionRelayResponse(parsed);
+      assert.deepEqual(reparsed, response);
+
+      // Byte-stable: re-serializing the parsed record reproduces the exact bytes written to
+      // disk, so there is no field reordering or silent coercion across the round trip.
+      assert.equal(JSON.stringify(reparsed), raw);
+    });
+  }
+
+  it("tolerates an unknown extra field without breaking parsing", () => {
+    const dir = tempRelayDir();
+    const withExtraField = {
+      kind: "permission",
+      ok: true,
+      verdict: "allow",
+      // A field a future protocol revision might add; today's parser must ignore it rather
+      // than reject the whole record (forward compatibility across a runner/extension skew).
+      futureField: "some-value-from-a-newer-runner",
+    };
+
+    const { parsed } = roundTripJson(dir, "call-99.res.json", withExtraField);
+
+    assert.deepEqual(parsePermissionRelayResponse(parsed), {
+      kind: "permission",
+      ok: true,
+      verdict: "allow",
+    });
+  });
+
+  it("does NOT parse an execute-record shape {toolName, toolCallId, args} (no kind) as a permission response", () => {
+    const dir = tempRelayDir();
+    const executeRecord = {
+      toolName: "server_tool",
+      toolCallId: "call-1",
+      args: { a: 1 },
+    };
+
+    const { parsed } = roundTripJson(dir, "call-1.req.json", executeRecord);
+
+    assert.equal(parsePermissionRelayResponse(parsed), undefined);
+  });
+});

--- a/services/runner/tests/unit/sandbox-agent-pi-assets.test.ts
+++ b/services/runner/tests/unit/sandbox-agent-pi-assets.test.ts
@@ -141,6 +141,19 @@ describe("buildPiExtensionEnv", () => {
     assert.equal(env.AGENTA_AGENT_TOOLS_RELAY_DIR, undefined);
   });
 
+  it("sets builtin gating env and relay dir without custom tools", () => {
+    const env = buildPiExtensionEnv({} as AgentRunRequest, false, {
+      relayDir: "/tmp/relay",
+      builtinGatingActive: true,
+      builtinGrants: ["read", "write"],
+    });
+
+    assert.equal(env.AGENTA_AGENT_BUILTIN_GATING, "1");
+    assert.equal(env.AGENTA_AGENT_BUILTIN_GRANTS, "read,write");
+    assert.equal(env.AGENTA_AGENT_TOOLS_RELAY_DIR, "/tmp/relay");
+    assert.equal(env.AGENTA_AGENT_TOOLS_PUBLIC_SPECS, undefined);
+  });
+
   it("accepts snake_case tool schemas from older Python wire payloads", () => {
     const env = buildPiExtensionEnv(
       {

--- a/services/runner/tests/unit/sandbox-agent-run-plan.test.ts
+++ b/services/runner/tests/unit/sandbox-agent-run-plan.test.ts
@@ -13,10 +13,14 @@ import {
 } from "../../src/engines/sandbox_agent/run-plan.ts";
 
 const previousPiDir = process.env.PI_CODING_AGENT_DIR;
+const previousDenyPermissions = process.env.SANDBOX_AGENT_DENY_PERMISSIONS;
 
 afterEach(() => {
   if (previousPiDir === undefined) delete process.env.PI_CODING_AGENT_DIR;
   else process.env.PI_CODING_AGENT_DIR = previousPiDir;
+  if (previousDenyPermissions === undefined)
+    delete process.env.SANDBOX_AGENT_DENY_PERMISSIONS;
+  else process.env.SANDBOX_AGENT_DENY_PERMISSIONS = previousDenyPermissions;
 });
 
 describe("buildRunPlan", () => {
@@ -116,6 +120,147 @@ describe("buildRunPlan", () => {
     if (!result.ok) return;
     assert.deepEqual(result.plan.executableToolSpecs, []);
     assert.equal(result.plan.useToolRelay, true);
+  });
+
+  it("turns builtin gating on when blanket allow has a reduced grant set", () => {
+    const result = buildRunPlan(
+      {
+        harness: "pi_core",
+        messages: [{ role: "user", content: "hello" }],
+        permissions: { default: "allow", rules: [] },
+        tools: ["read", "write"],
+      } as AgentRunRequest,
+      { createLocalCwd: () => "/tmp/local-cwd" },
+    );
+
+    assert.equal(result.ok, true);
+    if (!result.ok) return;
+    assert.deepEqual(result.plan.builtinGrants, ["read", "write"]);
+    assert.equal(result.plan.builtinGatingActive, true);
+    assert.equal(result.plan.useToolRelay, true);
+  });
+
+  it("turns builtin gating on when grants include Pi-nondefault builtins", () => {
+    const result = buildRunPlan(
+      {
+        harness: "pi_core",
+        messages: [{ role: "user", content: "hello" }],
+        permissions: { default: "allow", rules: [] },
+        tools: ["read", "bash", "edit", "write", "grep", "find", "ls"],
+      } as AgentRunRequest,
+      { createLocalCwd: () => "/tmp/local-cwd" },
+    );
+
+    assert.equal(result.ok, true);
+    if (!result.ok) return;
+    assert.deepEqual(result.plan.builtinGrants, [
+      "read",
+      "bash",
+      "edit",
+      "write",
+      "grep",
+      "find",
+      "ls",
+    ]);
+    assert.equal(result.plan.builtinGatingActive, true);
+  });
+
+  it("leaves the all-allow default-grants Pi fast path off", () => {
+    const result = buildRunPlan(
+      {
+        harness: "pi_core",
+        messages: [{ role: "user", content: "hello" }],
+        permissions: { default: "allow", rules: [] },
+      } as AgentRunRequest,
+      { createLocalCwd: () => "/tmp/local-cwd" },
+    );
+
+    assert.equal(result.ok, true);
+    if (!result.ok) return;
+    assert.deepEqual(result.plan.builtinGrants, [
+      "read",
+      "bash",
+      "edit",
+      "write",
+    ]);
+    assert.equal(result.plan.builtinGatingActive, false);
+    assert.equal(result.plan.useToolRelay, false);
+  });
+
+  it("distinguishes omitted tools from an explicit empty grant set", () => {
+    const omitted = buildRunPlan(
+      {
+        harness: "pi_core",
+        messages: [{ role: "user", content: "hello" }],
+        permissions: { default: "allow", rules: [] },
+      } as AgentRunRequest,
+      { createLocalCwd: () => "/tmp/local-cwd" },
+    );
+    const none = buildRunPlan(
+      {
+        harness: "pi_core",
+        messages: [{ role: "user", content: "hello" }],
+        permissions: { default: "allow", rules: [] },
+        tools: [],
+      } as AgentRunRequest,
+      { createLocalCwd: () => "/tmp/local-cwd" },
+    );
+
+    assert.equal(omitted.ok, true);
+    assert.equal(none.ok, true);
+    if (!omitted.ok || !none.ok) return;
+    assert.deepEqual(omitted.plan.builtinGrants, [
+      "read",
+      "bash",
+      "edit",
+      "write",
+    ]);
+    assert.equal(omitted.plan.builtinGatingActive, false);
+    assert.deepEqual(none.plan.builtinGrants, []);
+    assert.equal(none.plan.builtinGatingActive, true);
+    assert.equal(none.plan.useToolRelay, true);
+  });
+
+  it("turns builtin gating on when the permission kill switch is set", () => {
+    process.env.SANDBOX_AGENT_DENY_PERMISSIONS = "true";
+
+    const result = buildRunPlan(
+      {
+        harness: "pi_core",
+        messages: [{ role: "user", content: "hello" }],
+        permissions: { default: "allow", rules: [] },
+      } as AgentRunRequest,
+      { createLocalCwd: () => "/tmp/local-cwd" },
+    );
+
+    assert.equal(result.ok, true);
+    if (!result.ok) return;
+    assert.deepEqual(result.plan.builtinGrants, [
+      "read",
+      "bash",
+      "edit",
+      "write",
+    ]);
+    assert.equal(result.plan.builtinGatingActive, true);
+    assert.equal(result.plan.useToolRelay, true);
+  });
+
+  it("turns builtin gating on when an all-allow policy has a builtin rule", () => {
+    const result = buildRunPlan(
+      {
+        harness: "pi_core",
+        messages: [{ role: "user", content: "hello" }],
+        permissions: {
+          default: "allow",
+          rules: [{ pattern: "Bash(npm:*)", permission: "allow" }],
+        },
+      } as AgentRunRequest,
+      { createLocalCwd: () => "/tmp/local-cwd" },
+    );
+
+    assert.equal(result.ok, true);
+    if (!result.ok) return;
+    assert.equal(result.plan.builtinGatingActive, true);
   });
 
   it("carries the sandbox permission onto the plan and leaves an unrestricted run alone", () => {
@@ -499,6 +644,22 @@ describe("buildRunPlan", () => {
           sandbox: "local",
           messages: [{ role: "user", content: "hello" }],
           customTools: [{ name: "server_tool", kind: "callback" }],
+        } as AgentRunRequest,
+        { createLocalCwd: () => "/tmp/local-cwd" },
+      );
+
+      assert.equal(result.ok, true);
+    });
+
+    it("allows claude x local x client-only tools (the feature's primary configuration)", () => {
+      // Client tools ride the internal loopback MCP channel on local Claude (advertised in
+      // tools/list, paused in tools/call), so this combination must pass the gate.
+      const result = buildRunPlan(
+        {
+          harness: "claude",
+          sandbox: "local",
+          messages: [{ role: "user", content: "hello" }],
+          customTools: [{ name: "request_connection", kind: "client" }],
         } as AgentRunRequest,
         { createLocalCwd: () => "/tmp/local-cwd" },
       );

--- a/services/runner/tests/unit/tool-direct.test.ts
+++ b/services/runner/tests/unit/tool-direct.test.ts
@@ -17,7 +17,13 @@
  */
 import { afterEach, describe, it } from "vitest";
 import assert from "node:assert/strict";
-import { existsSync, mkdtempSync, readFileSync, rmSync, writeFileSync } from "node:fs";
+import {
+  existsSync,
+  mkdtempSync,
+  readFileSync,
+  rmSync,
+  writeFileSync,
+} from "node:fs";
 import { tmpdir } from "node:os";
 import { join } from "node:path";
 
@@ -67,7 +73,9 @@ function stubFetch(body: string, ok = true, status = 200): CapturedFetch[] {
   const calls: CapturedFetch[] = [];
   globalThis.fetch = (async (url: any, init: any) => {
     calls.push({ url: String(url), init: init ?? {} });
-    return new Response(body, { status: ok ? status : status >= 400 ? status : 500 });
+    return new Response(body, {
+      status: ok ? status : status >= 400 ? status : 500,
+    });
   }) as typeof fetch;
   return calls;
 }
@@ -147,7 +155,10 @@ describe("assembleBody", () => {
       path: "/api/x",
       args_into: "__proto__.polluted",
     };
-    assert.throws(() => assembleBody(call, true), /unsafe path segment '__proto__'/);
+    assert.throws(
+      () => assembleBody(call, true),
+      /unsafe path segment '__proto__'/,
+    );
     assert.equal(({} as any).polluted, undefined);
   });
 
@@ -246,7 +257,10 @@ describe("assembleBody context binding", () => {
     };
     const body = assembleBody(
       call,
-      { workflow_variant_id: "someone-elses", parameters: { temperature: 0.2 } },
+      {
+        workflow_variant_id: "someone-elses",
+        parameters: { temperature: 0.2 },
+      },
       RUN_CONTEXT,
     );
     // Bound to the run's OWN variant, not the model's attempt.
@@ -305,14 +319,20 @@ describe("resolveCtxToken", () => {
       resolveCtxToken(RUN_CONTEXT, "$ctx.workflow.variant.missing"),
       undefined,
     );
-    assert.equal(resolveCtxToken(RUN_CONTEXT, "workflow.variant.id"), undefined);
+    assert.equal(
+      resolveCtxToken(RUN_CONTEXT, "workflow.variant.id"),
+      undefined,
+    );
     assert.equal(resolveCtxToken(undefined, "$ctx.trace.trace_id"), undefined);
   });
 
   it("rejects unsafe / inherited segments in the token (prototype-safe at the source)", () => {
     // The token is untrusted: it must never walk the prototype chain out of the run-context blob,
     // even though `__proto__`/`constructor` resolve on any object.
-    assert.equal(resolveCtxToken(RUN_CONTEXT, "$ctx.workflow.__proto__"), undefined);
+    assert.equal(
+      resolveCtxToken(RUN_CONTEXT, "$ctx.workflow.__proto__"),
+      undefined,
+    );
     assert.equal(
       resolveCtxToken(RUN_CONTEXT, "$ctx.__proto__.polluted"),
       undefined,
@@ -353,7 +373,10 @@ describe("deepSet / deepMerge", () => {
     assert.deepEqual(target, { a: { c: 2 }, keep: 3 });
     deepDelete(target, "x.y.z"); // missing parent -> no-op, no throw
     assert.deepEqual(target, { a: { c: 2 }, keep: 3 });
-    assert.throws(() => deepDelete(target, "__proto__.polluted"), /unsafe path segment/);
+    assert.throws(
+      () => deepDelete(target, "__proto__.polluted"),
+      /unsafe path segment/,
+    );
   });
 });
 
@@ -398,7 +421,10 @@ describe("directCallUrl", () => {
       },
       { id: "sched 1" },
     );
-    assert.equal(url, "https://agenta.example/api/triggers/schedules/sched%201");
+    assert.equal(
+      url,
+      "https://agenta.example/api/triggers/schedules/sched%201",
+    );
   });
 
   it("rejects a missing path parameter", () => {
@@ -453,7 +479,8 @@ describe("directCallUrl", () => {
     // `/api/%2e%2e/admin` URL-normalizes to `/admin`: the literal `..` check misses it, but the
     // mount confinement (after resolution) rejects it.
     assert.throws(
-      () => directCallUrl(ENDPOINT, { method: "POST", path: "/api/%2e%2e/admin" }),
+      () =>
+        directCallUrl(ENDPOINT, { method: "POST", path: "/api/%2e%2e/admin" }),
       /is outside the Agenta API mount '\/api'/,
     );
   });
@@ -471,7 +498,11 @@ describe("directCallUrl", () => {
 
   it("rejects a protocol-relative path", () => {
     assert.throws(
-      () => directCallUrl(ENDPOINT, { method: "POST", path: "//evil.example/api/x" }),
+      () =>
+        directCallUrl(ENDPOINT, {
+          method: "POST",
+          path: "//evil.example/api/x",
+        }),
       /must be an absolute path starting with a single '\/'/,
     );
   });
@@ -493,7 +524,9 @@ describe("directCallUrl", () => {
 
 describe("pathParamNames", () => {
   it("extracts the {name} tokens from a path", () => {
-    assert.deepEqual(pathParamNames("/api/triggers/schedules/{id}/stop"), ["id"]);
+    assert.deepEqual(pathParamNames("/api/triggers/schedules/{id}/stop"), [
+      "id",
+    ]);
     assert.deepEqual(pathParamNames("/api/x/{a}/y/{b.c}"), ["a", "b.c"]);
   });
 
@@ -549,7 +582,7 @@ async function relayOnce(
       {
         enforce: false,
         decide: () => ({ kind: "allow" }),
-        onPendingApproval: () => {},
+        onPendingApproval: () => ({ emitted: false }),
       },
       runContext,
     );
@@ -603,13 +636,19 @@ describe("startToolRelay direct branch (host makes the call for the sandbox)", (
     const res = await relayOnce(
       selfSpec,
       { endpoint: ENDPOINT, authorization: "ApiKey secret" },
-      { workflow_variant_id: "someone-elses", parameters: { temperature: 0.2 } },
+      {
+        workflow_variant_id: "someone-elses",
+        parameters: { temperature: 0.2 },
+      },
       RUN_CONTEXT,
     );
 
     assert.equal(res.ok, true);
     assert.equal(calls.length, 1);
-    assert.equal(calls[0].url, "https://agenta.example/api/workflows/revisions/commit");
+    assert.equal(
+      calls[0].url,
+      "https://agenta.example/api/workflows/revisions/commit",
+    );
     assert.deepEqual(JSON.parse(calls[0].init.body as string), {
       workflow_variant_id: "own-variant", // bound to the run's own variant, not the model's
       parameters: { temperature: 0.2 },
@@ -634,7 +673,10 @@ describe("startToolRelay direct branch (host makes the call for the sandbox)", (
 
     assert.equal(res.ok, true);
     assert.equal(calls.length, 1);
-    assert.equal(calls[0].url, "https://agenta.example/api/triggers/schedules/sched_1/stop");
+    assert.equal(
+      calls[0].url,
+      "https://agenta.example/api/triggers/schedules/sched_1/stop",
+    );
     assert.deepEqual(JSON.parse(calls[0].init.body as string), {});
   });
 

--- a/services/runner/tests/unit/tool-dispatch-permission.test.ts
+++ b/services/runner/tests/unit/tool-dispatch-permission.test.ts
@@ -1,0 +1,144 @@
+/**
+ * Unit tests for the Pi builtin permission relay helper.
+ *
+ * Run: pnpm test (or: pnpm exec vitest run tests/unit/tool-dispatch-permission.test.ts)
+ */
+import { afterEach, describe, it, vi } from "vitest";
+import assert from "node:assert/strict";
+import { existsSync, mkdtempSync, readFileSync, rmSync, writeFileSync } from "node:fs";
+import { tmpdir } from "node:os";
+import { join } from "node:path";
+
+const dirs: string[] = [];
+
+function tempDir(): string {
+  const dir = mkdtempSync(join(tmpdir(), "agenta-permission-relay-test-"));
+  dirs.push(dir);
+  return dir;
+}
+
+afterEach(() => {
+  vi.unstubAllEnvs();
+  for (const dir of dirs.splice(0)) {
+    rmSync(dir, { recursive: true, force: true });
+  }
+});
+
+async function waitForFile(path: string): Promise<void> {
+  const deadline = Date.now() + 1000;
+  while (Date.now() < deadline) {
+    if (existsSync(path)) return;
+    await new Promise((resolve) => setTimeout(resolve, 5));
+  }
+  throw new Error(`timed out waiting for ${path}`);
+}
+
+describe("relayPermissionCheck", () => {
+  it("round-trips a permission request and parses the response", async () => {
+    const { relayPermissionCheck } = await import("../../src/tools/dispatch.ts");
+    const {
+      RELAY_PERMISSION_PROTOCOL,
+      RELAY_REQ_SUFFIX,
+      RELAY_RES_SUFFIX,
+      sanitizeRelayId,
+    } = await import("../../src/tools/relay.ts");
+    const dir = tempDir();
+    const toolCallId = "call/bash:1";
+    const id = sanitizeRelayId(toolCallId);
+    const reqPath = join(dir, `${id}${RELAY_REQ_SUFFIX}`);
+    const resPath = join(dir, `${id}${RELAY_RES_SUFFIX}`);
+
+    const pending = relayPermissionCheck(dir, "bash", toolCallId, {
+      command: "npm test",
+    });
+    await waitForFile(reqPath);
+
+    assert.deepEqual(JSON.parse(readFileSync(reqPath, "utf-8")), {
+      kind: "permission",
+      protocol: RELAY_PERMISSION_PROTOCOL,
+      toolName: "bash",
+      toolCallId,
+      args: { command: "npm test" },
+    });
+
+    writeFileSync(
+      resPath,
+      JSON.stringify({ kind: "permission", ok: true, verdict: "allow" }),
+      "utf-8",
+    );
+
+    assert.deepEqual(await pending, {
+      kind: "permission",
+      ok: true,
+      verdict: "allow",
+    });
+  });
+
+  it("fails closed on an unparseable response", async () => {
+    const { relayPermissionCheck } = await import("../../src/tools/dispatch.ts");
+    const { RELAY_RES_SUFFIX, sanitizeRelayId } = await import(
+      "../../src/tools/relay.ts"
+    );
+    const dir = tempDir();
+    const toolCallId = "call-unparseable";
+    writeFileSync(
+      join(dir, `${sanitizeRelayId(toolCallId)}${RELAY_RES_SUFFIX}`),
+      "not json",
+      "utf-8",
+    );
+
+    const response = await relayPermissionCheck(dir, "write", toolCallId, {
+      file_path: "x",
+    });
+
+    assert.equal(response.kind, "permission");
+    assert.equal(response.ok, false);
+    assert.equal(response.verdict, "deny");
+    assert.match(response.reason ?? "", /unparseable/);
+  });
+
+  it("fails closed when the runner responds ok:false", async () => {
+    const { relayPermissionCheck } = await import("../../src/tools/dispatch.ts");
+    const { RELAY_RES_SUFFIX, sanitizeRelayId } = await import(
+      "../../src/tools/relay.ts"
+    );
+    const dir = tempDir();
+    const toolCallId = "call-failed";
+    writeFileSync(
+      join(dir, `${sanitizeRelayId(toolCallId)}${RELAY_RES_SUFFIX}`),
+      JSON.stringify({
+        kind: "permission",
+        ok: false,
+        verdict: "allow",
+        reason: "runner failed\nwhile deciding",
+      }),
+      "utf-8",
+    );
+
+    const response = await relayPermissionCheck(dir, "edit", toolCallId, {});
+
+    assert.deepEqual(response, {
+      kind: "permission",
+      ok: false,
+      verdict: "deny",
+      reason: "runner failed while deciding",
+    });
+  });
+
+  it("fails closed on timeout", async () => {
+    vi.resetModules();
+    vi.stubEnv("AGENTA_AGENT_TOOLS_RELAY_TIMEOUT", "10");
+    vi.stubEnv("AGENTA_AGENT_TOOLS_RELAY_POLLING", "1");
+    const { relayPermissionCheck } = await import("../../src/tools/dispatch.ts");
+    const dir = tempDir();
+
+    const response = await relayPermissionCheck(dir, "read", "call-timeout", {
+      file_path: "README.md",
+    });
+
+    assert.equal(response.kind, "permission");
+    assert.equal(response.ok, false);
+    assert.equal(response.verdict, "deny");
+    assert.match(response.reason ?? "", /timed out/);
+  });
+});

--- a/services/runner/tests/unit/tool-relay-permission-parity.test.ts
+++ b/services/runner/tests/unit/tool-relay-permission-parity.test.ts
@@ -1,0 +1,192 @@
+/**
+ * Phase 4 (docs/design/agent-workflows/projects/pi-builtin-gating/plan.md): parity and
+ * regression-pin tests for the relay's builtin-gating seam.
+ *
+ * Parity: a builtin `bash` pending (a `kind: "permission"` record, handled by
+ * `handlePermissionRelayRequest`) and a custom relay tool's `ask` pending (a `kind: "execute"`
+ * record, handled by `executeRelayedTool`) are two different code paths inside
+ * `startToolRelay`, but both route through the SAME `onPendingApproval` callback with the SAME
+ * `{toolCallId, toolName, args}` shape. A caller downstream of the relay (the responder / SSE
+ * pause plumbing) can treat every pending pause uniformly, regardless of which path produced
+ * it — the engine wraps both identically.
+ *
+ * Regression pin (0e71bd0f7a): a run whose `tools` omits `bash` must not grant it, both at the
+ * `RunPlan` layer (`buildRunPlan`) and at the extension's active-tool-set layer
+ * (`replaceActiveBuiltinTools`). This bug shipped once as a silently-dropped grant list; pin it
+ * at both layers so it cannot recur unnoticed at either one.
+ *
+ * Run: pnpm test (or: pnpm exec vitest run tests/unit/tool-relay-permission-parity.test.ts)
+ */
+import { describe, it } from "vitest";
+import assert from "node:assert/strict";
+import { mkdtempSync, rmSync, writeFileSync } from "node:fs";
+import { tmpdir } from "node:os";
+import { join } from "node:path";
+
+import {
+  localRelayHost,
+  RELAY_PERMISSION_PROTOCOL,
+  startToolRelay,
+  type RelayPermissions,
+} from "../../src/tools/relay.ts";
+import type { AgentRunRequest, ResolvedToolSpec } from "../../src/protocol.ts";
+import { decide, type PermissionPlan } from "../../src/permission-plan.ts";
+import { ConversationDecisions } from "../../src/responder.ts";
+import { buildRunPlan } from "../../src/engines/sandbox_agent/run-plan.ts";
+import { replaceActiveBuiltinTools } from "../../src/extensions/agenta.ts";
+
+type PendingInfo = { toolCallId: string; toolName: string; args: unknown };
+
+function askPlan(): PermissionPlan {
+  return { default: "ask", rules: [] };
+}
+
+/** A RelayPermissions whose `decide` always resolves through an `ask` default plan, and whose
+ *  `onPendingApproval` appends every call it receives to `pending` verbatim. */
+function collectingPermissions(pending: PendingInfo[]): RelayPermissions {
+  const decisions = new ConversationDecisions(new Map());
+  const plan = askPlan();
+  return {
+    enforce: true,
+    decide: (gate) => decide(gate, plan, decisions),
+    onPendingApproval: (info) => {
+      pending.push(info);
+      return { emitted: true };
+    },
+  };
+}
+
+/** Write one relay request record, start the relay, and wait until `onPendingApproval` has
+ *  fired (or the deadline passes), then stop the relay. */
+async function relayUntilPending(input: {
+  record: Record<string, unknown>;
+  permissions: RelayPermissions;
+  pending: PendingInfo[];
+  specs?: ResolvedToolSpec[];
+}): Promise<void> {
+  const dir = mkdtempSync(join(tmpdir(), "agenta-relay-parity-"));
+  try {
+    const id =
+      typeof input.record.toolCallId === "string"
+        ? input.record.toolCallId
+        : "call-1";
+    writeFileSync(join(dir, `${id}.req.json`), JSON.stringify(input.record));
+    const relay = startToolRelay(
+      localRelayHost(),
+      dir,
+      input.specs ?? [],
+      undefined,
+      input.permissions,
+    );
+    const deadline = Date.now() + 5000;
+    while (Date.now() < deadline && input.pending.length === 0) {
+      await new Promise((resolve) => setTimeout(resolve, 20));
+    }
+    await relay.stop();
+  } finally {
+    rmSync(dir, { recursive: true, force: true });
+  }
+}
+
+describe("onPendingApproval parity: builtin permission record vs custom relay tool", () => {
+  it("delivers the same {toolCallId, toolName, args} shape from both pending paths", async () => {
+    const builtinPending: PendingInfo[] = [];
+    await relayUntilPending({
+      record: {
+        kind: "permission",
+        protocol: RELAY_PERMISSION_PROTOCOL,
+        toolName: "bash",
+        toolCallId: "builtin-call-1",
+        args: { command: "npm test" },
+      },
+      permissions: collectingPermissions(builtinPending),
+      pending: builtinPending,
+    });
+
+    const customPending: PendingInfo[] = [];
+    const customSpec: ResolvedToolSpec = {
+      name: "send_email",
+      kind: "code",
+      runtime: "python",
+      code: "def main(**kw):\n    return kw\n",
+      permission: "ask",
+    };
+    await relayUntilPending({
+      record: {
+        toolName: "send_email",
+        toolCallId: "custom-call-1",
+        args: { to: "a@b.com" },
+      },
+      permissions: collectingPermissions(customPending),
+      pending: customPending,
+      specs: [customSpec],
+    });
+
+    assert.equal(builtinPending.length, 1, "the builtin path paused exactly once");
+    assert.equal(customPending.length, 1, "the custom-tool path paused exactly once");
+
+    const [builtin] = builtinPending;
+    const [custom] = customPending;
+
+    // Same seam, same keys: neither path leaks extra fields (e.g. a `kind` discriminator) into
+    // the callback, and neither drops one of the three.
+    assert.deepEqual(Object.keys(builtin).sort(), ["args", "toolCallId", "toolName"]);
+    assert.deepEqual(Object.keys(custom).sort(), ["args", "toolCallId", "toolName"]);
+
+    assert.deepEqual(builtin, {
+      toolCallId: "builtin-call-1",
+      toolName: "bash",
+      args: { command: "npm test" },
+    });
+    assert.deepEqual(custom, {
+      toolCallId: "custom-call-1",
+      toolName: "send_email",
+      args: { to: "a@b.com" },
+    });
+  });
+});
+
+describe("grant-list regression pin (0e71bd0f7a)", () => {
+  it("buildRunPlan excludes bash from builtinGrants and turns gating on when `tools` omits it", () => {
+    const result = buildRunPlan(
+      {
+        harness: "pi_core",
+        messages: [{ role: "user", content: "hello" }],
+        tools: ["read"],
+      } as AgentRunRequest,
+      { createLocalCwd: () => "/tmp/local-cwd" },
+    );
+
+    assert.equal(result.ok, true);
+    if (!result.ok) return;
+    assert.deepEqual(result.plan.builtinGrants, ["read"]);
+    assert.ok(
+      !result.plan.builtinGrants.includes("bash"),
+      "bash must not be silently re-granted",
+    );
+    assert.equal(result.plan.builtinGatingActive, true);
+  });
+
+  it("replaceActiveBuiltinTools drops bash/edit/write and keeps read when only read is granted", () => {
+    const allTools = [
+      { name: "read" },
+      { name: "bash" },
+      { name: "edit" },
+      { name: "write" },
+      { name: "grep" },
+      { name: "find" },
+      { name: "ls" },
+    ];
+
+    const next = replaceActiveBuiltinTools(
+      ["read", "bash", "edit", "write"],
+      allTools,
+      ["read"],
+    );
+
+    assert.deepEqual(next, ["read"]);
+    assert.ok(!next.includes("bash"));
+    assert.ok(!next.includes("edit"));
+    assert.ok(!next.includes("write"));
+  });
+});

--- a/services/runner/tests/unit/tool-relay-permission-record.test.ts
+++ b/services/runner/tests/unit/tool-relay-permission-record.test.ts
@@ -1,0 +1,400 @@
+/**
+ * Unit tests for builtin permission records on the runner relay.
+ *
+ * Run: pnpm test (or: pnpm exec vitest run tests/unit/tool-relay-permission-record.test.ts)
+ */
+import { describe, it } from "vitest";
+import assert from "node:assert/strict";
+import {
+  existsSync,
+  mkdtempSync,
+  readFileSync,
+  rmSync,
+  writeFileSync,
+} from "node:fs";
+import { tmpdir } from "node:os";
+import { join } from "node:path";
+
+import {
+  localRelayHost,
+  parsePermissionRelayResponse,
+  RELAY_PERMISSION_PROTOCOL,
+  startToolRelay,
+  type PermissionRelayResponse,
+  type RelayPermissions,
+  type RelayResponse,
+} from "../../src/tools/relay.ts";
+import type { ResolvedToolSpec } from "../../src/protocol.ts";
+import {
+  decide,
+  type GateDescriptor,
+  type PermissionPlan,
+} from "../../src/permission-plan.ts";
+import { approvedCallKey, ConversationDecisions } from "../../src/responder.ts";
+
+const codeSpec: ResolvedToolSpec = {
+  name: "server_tool",
+  kind: "code",
+  runtime: "python",
+  code: "def main(**kw):\n    return kw\n",
+};
+
+function permissionPlan(
+  defaultMode: PermissionPlan["default"],
+  rules: PermissionPlan["rules"] = [],
+): PermissionPlan {
+  return { default: defaultMode, rules };
+}
+
+function permissions(
+  input: {
+    plan?: PermissionPlan;
+    decisions?: ConversationDecisions;
+    pending?: Array<{ toolCallId: string; toolName: string; args: unknown }>;
+    gates?: GateDescriptor[];
+    pendingEmitted?: boolean;
+  } = {},
+): RelayPermissions {
+  const plan = input.plan ?? permissionPlan("allow");
+  const decisions = input.decisions ?? new ConversationDecisions(new Map());
+  return {
+    enforce: true,
+    decide: (gate) => {
+      input.gates?.push(gate);
+      return decide(gate, plan, decisions);
+    },
+    onPendingApproval: (info) => {
+      input.pending?.push(info);
+      return { emitted: input.pendingEmitted ?? true };
+    },
+  };
+}
+
+function permissionRecord(
+  toolName: string,
+  args: unknown = { command: "pwd" },
+): Record<string, unknown> {
+  return {
+    kind: "permission",
+    protocol: RELAY_PERMISSION_PROTOCOL,
+    toolName,
+    toolCallId: "call-1",
+    args,
+  };
+}
+
+async function relayRecordOnce(input: {
+  record: Record<string, unknown>;
+  permissions: RelayPermissions;
+  specs?: ResolvedToolSpec[];
+}): Promise<unknown> {
+  const dir = mkdtempSync(join(tmpdir(), "agenta-relay-permission-record-"));
+  try {
+    const id =
+      typeof input.record.toolCallId === "string"
+        ? input.record.toolCallId
+        : "call-1";
+    writeFileSync(join(dir, `${id}.req.json`), JSON.stringify(input.record));
+    const relay = startToolRelay(
+      localRelayHost(),
+      dir,
+      input.specs ?? [],
+      undefined,
+      input.permissions,
+    );
+    const resPath = join(dir, `${id}.res.json`);
+    const deadline = Date.now() + 5000;
+    while (Date.now() < deadline && !existsSync(resPath)) {
+      await new Promise((resolve) => setTimeout(resolve, 20));
+    }
+    await relay.stop();
+    assert.ok(existsSync(resPath), "the relay wrote a response file");
+    return JSON.parse(readFileSync(resPath, "utf-8")) as unknown;
+  } finally {
+    rmSync(dir, { recursive: true, force: true });
+  }
+}
+
+async function permissionRelayOnce(input: {
+  record: Record<string, unknown>;
+  permissions: RelayPermissions;
+}): Promise<PermissionRelayResponse> {
+  const raw = await relayRecordOnce(input);
+  const parsed = parsePermissionRelayResponse(raw);
+  assert.ok(parsed, `permission response validated: ${JSON.stringify(raw)}`);
+  return parsed;
+}
+
+describe("parsePermissionRelayResponse", () => {
+  it("accepts permission responses and rejects execute-shaped records", () => {
+    assert.deepEqual(
+      parsePermissionRelayResponse({
+        kind: "permission",
+        ok: true,
+        verdict: "allow",
+      }),
+      { kind: "permission", ok: true, verdict: "allow" },
+    );
+    assert.equal(
+      parsePermissionRelayResponse({ ok: true, text: "{}" }),
+      undefined,
+    );
+  });
+});
+
+describe("startToolRelay builtin permission records", () => {
+  it("writes an allow permission response under an all-allow policy", async () => {
+    const pending: Array<{
+      toolCallId: string;
+      toolName: string;
+      args: unknown;
+    }> = [];
+    const gates: GateDescriptor[] = [];
+
+    const res = await permissionRelayOnce({
+      record: permissionRecord("bash", { command: "pwd" }),
+      permissions: permissions({
+        plan: permissionPlan("allow"),
+        pending,
+        gates,
+      }),
+    });
+
+    assert.deepEqual(res, { kind: "permission", ok: true, verdict: "allow" });
+    assert.deepEqual(pending, []);
+    assert.deepEqual(gates, [
+      {
+        executor: "harness",
+        toolName: "Bash",
+        readOnlyHint: false,
+        args: { command: "pwd" },
+      },
+    ]);
+  });
+
+  it("writes a deny permission response with the relay policy wording", async () => {
+    const res = await permissionRelayOnce({
+      record: permissionRecord("bash", { command: "rm -rf /tmp/nope" }),
+      permissions: permissions({ plan: permissionPlan("deny") }),
+    });
+
+    assert.deepEqual(res, {
+      kind: "permission",
+      ok: true,
+      verdict: "deny",
+      reason: "Tool 'bash' is denied by the permission policy.",
+    });
+  });
+
+  it("calls onPendingApproval and writes pendingApproval verbatim", async () => {
+    const pending: Array<{
+      toolCallId: string;
+      toolName: string;
+      args: unknown;
+    }> = [];
+
+    const res = await permissionRelayOnce({
+      record: permissionRecord("bash", { command: "npm test" }),
+      permissions: permissions({
+        plan: permissionPlan("ask"),
+        pending,
+      }),
+    });
+
+    assert.deepEqual(pending, [
+      { toolCallId: "call-1", toolName: "bash", args: { command: "npm test" } },
+    ]);
+    assert.deepEqual(res, {
+      kind: "permission",
+      ok: true,
+      verdict: "pendingApproval",
+      reason: "Waiting for approval of bash.",
+    });
+  });
+
+  it("writes the another-approval reason when the pending latch is held", async () => {
+    const pending: Array<{
+      toolCallId: string;
+      toolName: string;
+      args: unknown;
+    }> = [];
+
+    const res = await permissionRelayOnce({
+      record: permissionRecord("write", { path: "a.txt", content: "x" }),
+      permissions: permissions({
+        plan: permissionPlan("ask"),
+        pending,
+        pendingEmitted: false,
+      }),
+    });
+
+    assert.deepEqual(pending, [
+      {
+        toolCallId: "call-1",
+        toolName: "write",
+        args: { path: "a.txt", content: "x" },
+      },
+    ]);
+    assert.deepEqual(res, {
+      kind: "permission",
+      ok: true,
+      verdict: "pendingApproval",
+      reason: "Another approval is pending; retry after it resolves.",
+    });
+  });
+
+  it("allows read builtins under allow_reads and asks for write builtins", async () => {
+    const pending: Array<{
+      toolCallId: string;
+      toolName: string;
+      args: unknown;
+    }> = [];
+    const relayPermissions = permissions({
+      plan: permissionPlan("allow_reads"),
+      pending,
+    });
+
+    const grep = await permissionRelayOnce({
+      record: permissionRecord("grep", { pattern: "TODO", path: "." }),
+      permissions: relayPermissions,
+    });
+    assert.deepEqual(grep, { kind: "permission", ok: true, verdict: "allow" });
+
+    const write = await permissionRelayOnce({
+      record: permissionRecord("write", { path: "a.txt", content: "x" }),
+      permissions: relayPermissions,
+    });
+    assert.equal(write.verdict, "pendingApproval");
+    assert.deepEqual(pending, [
+      {
+        toolCallId: "call-1",
+        toolName: "write",
+        args: { path: "a.txt", content: "x" },
+      },
+    ]);
+  });
+
+  it("matches Bash prefix rules on the real command arg after name normalization", async () => {
+    const gates: GateDescriptor[] = [];
+
+    const res = await permissionRelayOnce({
+      record: permissionRecord("bash", { command: "git status" }),
+      permissions: permissions({
+        plan: permissionPlan("deny", [
+          { pattern: "Bash(git:*)", permission: "allow" },
+        ]),
+        gates,
+      }),
+    });
+
+    assert.deepEqual(res, { kind: "permission", ok: true, verdict: "allow" });
+    assert.deepEqual(gates[0], {
+      executor: "harness",
+      toolName: "Bash",
+      readOnlyHint: false,
+      args: { command: "git status" },
+    });
+  });
+
+  it("projects stored bash approvals by command but keeps write approvals exact", async () => {
+    const bashKey = approvedCallKey("bash", { command: "npm test" })!;
+    const writeKey = approvedCallKey("write", {
+      path: "a.txt",
+      content: "old",
+    })!;
+    const pending: Array<{
+      toolCallId: string;
+      toolName: string;
+      args: unknown;
+    }> = [];
+    const relayPermissions = permissions({
+      plan: permissionPlan("ask"),
+      decisions: new ConversationDecisions(
+        new Map([
+          [bashKey, "allow"],
+          [writeKey, "allow"],
+        ]),
+      ),
+      pending,
+    });
+
+    const bash = await permissionRelayOnce({
+      record: permissionRecord("bash", { command: "npm test", timeout: 10 }),
+      permissions: relayPermissions,
+    });
+    assert.deepEqual(bash, { kind: "permission", ok: true, verdict: "allow" });
+
+    const write = await permissionRelayOnce({
+      record: permissionRecord("write", { path: "a.txt", content: "new" }),
+      permissions: relayPermissions,
+    });
+    assert.equal(write.verdict, "pendingApproval");
+    assert.deepEqual(pending, [
+      {
+        toolCallId: "call-1",
+        toolName: "write",
+        args: { path: "a.txt", content: "new" },
+      },
+    ]);
+  });
+
+  it("fails closed on missing or unknown permission protocol versions", async () => {
+    for (const record of [
+      { kind: "permission", toolName: "bash", toolCallId: "call-1", args: {} },
+      {
+        kind: "permission",
+        protocol: 999,
+        toolName: "bash",
+        toolCallId: "call-1",
+        args: {},
+      },
+    ]) {
+      const res = await permissionRelayOnce({
+        record,
+        permissions: permissions({ plan: permissionPlan("allow") }),
+      });
+
+      assert.equal(res.kind, "permission");
+      assert.equal(res.ok, true);
+      assert.equal(res.verdict, "deny");
+      assert.match(res.reason ?? "", /runner\/extension version mismatch/);
+    }
+  });
+
+  it("fails closed on an unknown builtin without calling decide", async () => {
+    const gates: GateDescriptor[] = [];
+
+    const res = await permissionRelayOnce({
+      record: permissionRecord("cat", { path: "a.txt" }),
+      permissions: permissions({ plan: permissionPlan("allow"), gates }),
+    });
+
+    assert.deepEqual(gates, []);
+    assert.deepEqual(res, {
+      kind: "permission",
+      ok: true,
+      verdict: "deny",
+      reason: "Tool 'cat' is denied by the permission policy.",
+    });
+  });
+
+  it("leaves execute records with no kind on the existing relay path", async () => {
+    const raw = await relayRecordOnce({
+      record: { toolName: "server_tool", toolCallId: "call-1", args: { a: 1 } },
+      permissions: {
+        enforce: false,
+        decide: () => ({ kind: "allow" }),
+        onPendingApproval: () => ({ emitted: false }),
+      },
+      specs: [codeSpec],
+    });
+    const res = raw as RelayResponse;
+
+    assert.equal("kind" in (raw as Record<string, unknown>), false);
+    assert.equal(res.ok, false);
+    assert.match(
+      res.error ?? "",
+      /Code tools are not supported by the sidecar\./,
+    );
+  });
+});

--- a/services/runner/tests/unit/tool-relay-permission.test.ts
+++ b/services/runner/tests/unit/tool-relay-permission.test.ts
@@ -5,7 +5,13 @@
  */
 import { describe, it } from "vitest";
 import assert from "node:assert/strict";
-import { existsSync, mkdtempSync, readFileSync, rmSync, writeFileSync } from "node:fs";
+import {
+  existsSync,
+  mkdtempSync,
+  readFileSync,
+  rmSync,
+  writeFileSync,
+} from "node:fs";
 import { tmpdir } from "node:os";
 import { join } from "node:path";
 
@@ -21,20 +27,25 @@ import {
 } from "../../src/tools/relay.ts";
 import type { ResolvedToolSpec } from "../../src/protocol.ts";
 import { decide, type PermissionPlan } from "../../src/permission-plan.ts";
-import {
-  approvedCallKey,
-  ConversationDecisions,
-} from "../../src/responder.ts";
+import { approvedCallKey, ConversationDecisions } from "../../src/responder.ts";
 
 describe("relayPollDelayMs (idle backoff)", () => {
   it("polls at the base rate while busy, then backs off geometrically up to the cap", () => {
     // No idle polls -> base rate.
     assert.equal(relayPollDelayMs(0), RELAY_POLL_MS);
-    assert.equal(relayPollDelayMs(4), RELAY_POLL_MS, "still base before the grow threshold");
+    assert.equal(
+      relayPollDelayMs(4),
+      RELAY_POLL_MS,
+      "still base before the grow threshold",
+    );
     // After the threshold the delay grows but never exceeds the cap.
     assert.ok(relayPollDelayMs(5) > RELAY_POLL_MS, "grows once idle");
     assert.ok(relayPollDelayMs(5) <= RELAY_POLL_MAX_MS);
-    assert.equal(relayPollDelayMs(100), RELAY_POLL_MAX_MS, "saturates at the cap");
+    assert.equal(
+      relayPollDelayMs(100),
+      RELAY_POLL_MAX_MS,
+      "saturates at the cap",
+    );
     // Monotonic non-decreasing.
     assert.ok(relayPollDelayMs(6) >= relayPollDelayMs(5));
   });
@@ -48,12 +59,14 @@ const codeSpec = (
   name,
   kind: "code",
   runtime: "python",
-  code: "def main(**kw):\n    return {\"ran\": True, \"echo\": kw}\n",
+  code: 'def main(**kw):\n    return {"ran": True, "echo": kw}\n',
   permission,
   readOnly,
 });
 
-function permissionPlan(defaultMode: PermissionPlan["default"]): PermissionPlan {
+function permissionPlan(
+  defaultMode: PermissionPlan["default"],
+): PermissionPlan {
   return { default: defaultMode, rules: [] };
 }
 
@@ -70,6 +83,7 @@ function permissions(input: {
     decide: (gate) => decide(gate, plan, decisions),
     onPendingApproval: (info) => {
       input.pending?.push(info);
+      return { emitted: true };
     },
   };
 }
@@ -112,7 +126,11 @@ async function relayOnce(input: {
     await relay.stop();
     const wroteResponse = existsSync(resPath);
     if (input.expectResponse === false) {
-      assert.equal(wroteResponse, false, "the relay did not write a response file");
+      assert.equal(
+        wroteResponse,
+        false,
+        "the relay did not write a response file",
+      );
       return undefined;
     }
     assert.ok(wroteResponse, "the relay wrote a response file");
@@ -124,12 +142,19 @@ async function relayOnce(input: {
 
 function assertCodeToolExecuted(res: RelayResponse | undefined): void {
   assert.equal(res?.ok, false);
-  assert.match(res?.error ?? "", /Code tools are not supported by the sidecar\./);
+  assert.match(
+    res?.error ?? "",
+    /Code tools are not supported by the sidecar\./,
+  );
 }
 
 describe("startToolRelay permission enforcement", () => {
   it("enforce=false executes an ask spec without pausing", async () => {
-    const pending: Array<{ toolCallId: string; toolName: string; args: unknown }> = [];
+    const pending: Array<{
+      toolCallId: string;
+      toolName: string;
+      args: unknown;
+    }> = [];
     const res = await relayOnce({
       spec: codeSpec("needs_approval", "ask"),
       permissions: permissions({
@@ -144,16 +169,28 @@ describe("startToolRelay permission enforcement", () => {
   });
 
   it("enforce=true allows allowed tools and refuses authored deny distinctly", async () => {
-    const pending: Array<{ toolCallId: string; toolName: string; args: unknown }> = [];
+    const pending: Array<{
+      toolCallId: string;
+      toolName: string;
+      args: unknown;
+    }> = [];
     const allow = await relayOnce({
       spec: codeSpec("permitted", "allow"),
-      permissions: permissions({ enforce: true, plan: permissionPlan("ask"), pending }),
+      permissions: permissions({
+        enforce: true,
+        plan: permissionPlan("ask"),
+        pending,
+      }),
     });
     assertCodeToolExecuted(allow);
 
     const deny = await relayOnce({
       spec: codeSpec("blocked", "deny"),
-      permissions: permissions({ enforce: true, plan: permissionPlan("allow"), pending }),
+      permissions: permissions({
+        enforce: true,
+        plan: permissionPlan("allow"),
+        pending,
+      }),
     });
     assert.equal(deny?.ok, true);
     assert.equal(deny?.text, "Tool 'blocked' is denied by policy.");
@@ -174,10 +211,18 @@ describe("startToolRelay permission enforcement", () => {
   });
 
   it("ask with no stored decision pauses without writing a response or executing", async () => {
-    const pending: Array<{ toolCallId: string; toolName: string; args: unknown }> = [];
+    const pending: Array<{
+      toolCallId: string;
+      toolName: string;
+      args: unknown;
+    }> = [];
     await relayOnce({
       spec: codeSpec("approval_needed", "ask"),
-      permissions: permissions({ enforce: true, plan: permissionPlan("allow"), pending }),
+      permissions: permissions({
+        enforce: true,
+        plan: permissionPlan("allow"),
+        pending,
+      }),
       expectResponse: false,
       stopWhen: () => pending.length === 1,
     });
@@ -189,7 +234,11 @@ describe("startToolRelay permission enforcement", () => {
 
   it("ask with a stored allow executes once and consumes the stored decision", async () => {
     const key = approvedCallKey("approval_needed", { a: 1 })!;
-    const pending: Array<{ toolCallId: string; toolName: string; args: unknown }> = [];
+    const pending: Array<{
+      toolCallId: string;
+      toolName: string;
+      args: unknown;
+    }> = [];
     const relayPermissions = permissions({
       enforce: true,
       plan: permissionPlan("allow"),
@@ -218,7 +267,11 @@ describe("startToolRelay permission enforcement", () => {
   });
 
   it("allow_reads executes read-hinted tools and pauses tools without a read hint", async () => {
-    const pending: Array<{ toolCallId: string; toolName: string; args: unknown }> = [];
+    const pending: Array<{
+      toolCallId: string;
+      toolName: string;
+      args: unknown;
+    }> = [];
     const relayPermissions = permissions({
       enforce: true,
       plan: permissionPlan("allow_reads"),


### PR DESCRIPTION
## Context

Pi's seven native builtins (`read`, `bash`, `edit`, `write`, `grep`, `find`, `ls`) ran outside the permission system. An author could not say "ask before `bash`": the builtins never crossed a gate, so authored rules on them were silently ignored. And the builtin selection in the playground did nothing, because the wire's `tools` field lost its only reader on June 24 (`0e71bd0f7a` removed the old in-process engine). Every builtin was always on, whatever the author chose.

This PR carries the design workspace (docs/design/agent-workflows/projects/pi-builtin-gating/, reviewed in two rounds by Mahmoud and two Codex passes) plus the implementation.

## Changes

The runner decides; the extension only reports and enforces:

- **Per-call policy.** Our Pi extension registers a `tool_call` hook. For each builtin call it writes a `{kind: "permission", protocol: 1, toolName, toolCallId, args}` record into the existing relay directory and waits. The runner's relay loop resolves it through the same shared `decide()` every other gate uses, with the real name and real arguments, and writes the verdict back verbatim (`allow | deny | pendingApproval`). The extension maps anything but `allow` to Pi's `{block: true}`. `ask` pauses the turn through the exact pause machinery relay tools already use; approve resumes and the model re-issues the call.
- **The grant list works again.** The extension replaces the builtin slice of Pi's active tool set at `before_agent_start` with the author's selection, leaving non-builtin tools untouched. A non-granted builtin never appears to the model. (Pi has no settings-file field for tools, and its native `--tools` flag is dropped by every hop of the sandbox-agent/ACP chain, so the extension is the only reachable enforcement point; the upstream passthrough is a filed follow-up.)
- **One table owns builtin identity** (`permission-plan.ts`): canonical rule name (`Bash` for Pi's `bash`, so authored `Bash(git:*)` rules match), the read-only bit `allow_reads` consults, and the match projection for stored approvals (`bash` matches on `command` alone, because models sometimes add a benign `timeout`; `edit`/`write` keep full args so content changes never auto-match).
- **Gating only when needed.** The run plan computes one predicate (kill-switch aware, `tools: undefined` vs `[]` distinguished). All-allow runs with default grants skip gating entirely; gating-only runs start the relay with zero custom tools.
- **Version skew fails closed** where it can: a permission record with a missing or unknown `protocol` is denied loudly. The silent direction (new runner, stale extension bundle) is covered by a build guard and hit us live once during QA; a fail-loud hardening candidate is filed.

Before: `bash` ran under a `deny` policy, and deselecting builtins changed nothing. After: `bash: ask` pauses for approval on Pi exactly like a relay tool, and a builtin the author did not grant does not exist for the model.

## Scope / risk

- Reviving the grant list is a real behavior change: a config whose `tools` selects only some builtins now actually loses the others (that is the point, but existing configs will feel it).
- The relay permission record is runtime-internal (the relay directory); the `/run` wire and goldens are unchanged.
- Cross-turn approval persistence (an identical re-call in the same session reuses the transcript approval) is inherited from the approval-boundary design, unchanged here, and filed as a follow-up question.
- Coordinated with the client-tools-over-MCP work (#4985): the relay file protocol's execute records are untouched; this PR sequenced its shared-file commits behind that lane.

## Tests

- Runner: 525 unit tests green (+81 for this feature: decision truth table extensions, relay record round-trips, protocol/unknown fail-closed, grant normalization, active-set slice replacement, run-plan predicate incl. kill switch, dispatch fail-closed paths, parity of builtin vs custom-tool pendings, the `0e71bd0f7a` regression pin), typecheck clean.
- Phase 0 spike (13 live Pi runs): cross-turn re-issue after approval 3/3 with identical args; zero double or pre-approval executions. Evidence in the workspace.
- Live QA on the EE dev stack, all pass: the 5-of-5 approve bar on `bash: ask` (one prompt, never pre-approval, exactly once after, stable args), deny, read-free under `allow_reads`, grant enforcement (model does not see ungranted builtins), deny-all, the all-allow fast path, the headless paused envelope (`stop_reason: "paused"`, `pending_interaction.tool: "bash"`), and a custom-tool regression with an unguessable-token proof.

## How to QA

**Prerequisites:** EE dev stack; restart the runner sidecar after checkout AND ensure it serves the freshly built extension bundle (`pnpm run build:extension`; the dev sidecar mounts `src/` only, so copy or mount `dist/` — a stale bundle silently disables gating).

**Steps:**
1. Open an agent app, Pi harness, cheap model. Advanced > Permissions: policy "Allow reads", all builtins granted.
2. Chat: "Run the shell command `echo qa-1234` using the bash tool."
3. Approve the prompt. Then repeat in a fresh session and Deny.
4. Set the builtin selection to only "read", policy "Allow all", fresh session: ask the model to list its tools and run the echo.
5. Set policy "Allow all" with all builtins: repeat step 2.

**Expected:** step 2 shows exactly one Approve/Deny prompt that stays; step 3 approve resumes and runs the command exactly once (deny refuses cleanly, no error card); step 4 shows no bash in the model's tools and no execution; step 5 runs immediately with no prompt.

**Automated tests:** `cd services/runner && pnpm test`.

**Edge cases:** two gated builtins in one assistant message (one prompt, the second call is refused this turn with the another-approval-pending reason); a `Bash(git:*)` rule with a `git status` command (matches despite Pi's lowercase name); an approval followed by the model adding a `timeout` param on re-issue (still matches: the bash projection).

## Reading order for review

Workspace README, then design.md (the record protocol, the identity table, the folder-portability section), then status.md (decision log, live-QA results, follow-ups) and build-notes.md (how the build went, including the version-skew catch). Inline REVIEW GUIDE comments mark the load-bearing code.

https://claude.ai/code/session_01DGj7GKafjkZeQXMsryWhb2
