### PR TITLE
fix(secrets): resolve llm provider and secret mismatches (#5032)

### DIFF
--- a/api/oss/src/core/secrets/utils.py
+++ b/api/oss/src/core/secrets/utils.py
@@ -9,10 +9,12 @@ from oss.src.models.api.evaluation_model import LMProvidersEnum
 
 _LEGACY_SYSTEM_ENV_NAMES = {
     LMProvidersEnum.mistral.value: ("MISTRALAI_API_KEY",),
+    LMProvidersEnum.togetherai.value: ("TOGETHERAI_API_KEY",),
 }
 
 _PROVIDER_ENV_ALIASES = {
     "mistralai": LMProvidersEnum.mistral.value,
+    "togetherai": LMProvidersEnum.togetherai.value,
 }
 
 

--- a/api/oss/src/models/api/evaluation_model.py
+++ b/api/oss/src/models/api/evaluation_model.py
@@ -158,7 +158,7 @@ class LMProvidersEnum(str, Enum):
     anyscale = "ANYSCALE_API_KEY"
     perplexityai = "PERPLEXITYAI_API_KEY"
     deepinfra = "DEEPINFRA_API_KEY"
-    togetherai = "TOGETHERAI_API_KEY"
+    togetherai = "TOGETHER_API_KEY"
     alephalpha = "ALEPHALPHA_API_KEY"
     openrouter = "OPENROUTER_API_KEY"
     groq = "GROQ_API_KEY"

--- a/api/oss/src/utils/env.py
+++ b/api/oss/src/utils/env.py
@@ -791,7 +791,9 @@ class LLMConfig(BaseModel):
     openai: str = os.getenv("OPENAI_API_KEY", "")
     openrouter: str = os.getenv("OPENROUTER_API_KEY", "")
     perplexityai: str = os.getenv("PERPLEXITYAI_API_KEY", "")
-    togetherai: str = os.getenv("TOGETHERAI_API_KEY", "")
+    togetherai: str = os.getenv("TOGETHER_API_KEY") or os.getenv(
+        "TOGETHERAI_API_KEY", ""
+    )
     minimax: str = os.getenv("MINIMAX_API_KEY", "")
 
     model_config = ConfigDict(extra="ignore")

--- a/api/oss/tests/legacy/conftest.py
+++ b/api/oss/tests/legacy/conftest.py
@@ -48,11 +48,12 @@ API_KEYS_MAPPING = {
     "ANYSCALE_API_KEY": "anyscale",
     "PERPLEXITYAI_API_KEY": "perplexityai",
     "DEEPINFRA_API_KEY": "deepinfra",
-    "TOGETHERAI_API_KEY": "togetherai",
+    "TOGETHER_API_KEY": "togetherai",
     "ALEPHALPHA_API_KEY": "alephalpha",
     "OPENROUTER_API_KEY": "openrouter",
     "GROQ_API_KEY": "groq",
     "GEMINI_API_KEY": "gemini",
+    "MINIMAX_API_KEY": "minimax",
 }
 
 

--- a/api/oss/tests/pytest/unit/secrets/test_utils.py
+++ b/api/oss/tests/pytest/unit/secrets/test_utils.py
@@ -58,7 +58,8 @@ async def test_get_user_llm_providers_secrets_normalizes_legacy_provider_slugs(
 
     assert secrets["MISTRAL_API_KEY"] == "mistral-key"
     assert "MISTRALAI_API_KEY" not in secrets
-    assert secrets["TOGETHERAI_API_KEY"] == "together-key"
+    assert secrets["TOGETHER_API_KEY"] == "together-key"
+    assert "TOGETHERAI_API_KEY" not in secrets
     assert "TOGETHER_AI_API_KEY" not in secrets
     assert secrets["MINIMAX_API_KEY"] == "minimax-vault-key"
 
@@ -72,3 +73,16 @@ async def test_get_system_llm_providers_secrets_reads_legacy_mistralai_env(monke
 
     assert secrets["MISTRAL_API_KEY"] == "legacy-mistral-key"
     assert "MISTRALAI_API_KEY" not in secrets
+
+
+@pytest.mark.asyncio
+async def test_get_system_llm_providers_secrets_reads_legacy_togetherai_env(
+    monkeypatch,
+):
+    monkeypatch.delenv("TOGETHER_API_KEY", raising=False)
+    monkeypatch.setenv("TOGETHERAI_API_KEY", "legacy-together-key")
+
+    secrets = await get_system_llm_providers_secrets()
+
+    assert secrets["TOGETHER_API_KEY"] == "legacy-together-key"
+    assert "TOGETHERAI_API_KEY" not in secrets

--- a/sdks/python/agenta/sdk/engines/running/runners/daytona.py
+++ b/sdks/python/agenta/sdk/engines/running/runners/daytona.py
@@ -163,8 +163,8 @@ class DaytonaRunner(CodeRunner):
             "mistralai": "MISTRAL_API_KEY",
             "anthropic": "ANTHROPIC_API_KEY",
             "perplexityai": "PERPLEXITYAI_API_KEY",
-            # Secret kind is "together_ai" (underscore) even though the env var is TOGETHERAI_API_KEY
-            "together_ai": "TOGETHERAI_API_KEY",
+            # Secret kind is "together_ai" (underscore) and env var is TOGETHER_API_KEY
+            "together_ai": "TOGETHER_API_KEY",
             "openrouter": "OPENROUTER_API_KEY",
             "gemini": "GEMINI_API_KEY",
         }

--- a/sdks/python/oss/tests/legacy/new_tests/conftest.py
+++ b/sdks/python/oss/tests/legacy/new_tests/conftest.py
@@ -51,11 +51,12 @@ API_KEYS_MAPPING = {
     "ANYSCALE_API_KEY": "anyscale",
     "PERPLEXITYAI_API_KEY": "perplexityai",
     "DEEPINFRA_API_KEY": "deepinfra",
-    "TOGETHERAI_API_KEY": "togetherai",
+    "TOGETHER_API_KEY": "togetherai",
     "ALEPHALPHA_API_KEY": "alephalpha",
     "OPENROUTER_API_KEY": "openrouter",
     "GROQ_API_KEY": "groq",
     "GEMINI_API_KEY": "gemini",
+    "MINIMAX_API_KEY": "minimax",
 }
 
 

--- a/web/packages/agenta-entities/src/secret/core/transforms.ts
+++ b/web/packages/agenta-entities/src/secret/core/transforms.ts
@@ -43,7 +43,7 @@ const STANDARD_PROVIDER_ENV_BY_KIND: Partial<Record<StandardProviderKind, string
     [StandardProviderKind.Mistral]: "MISTRAL_API_KEY",
     [StandardProviderKind.Anthropic]: "ANTHROPIC_API_KEY",
     [StandardProviderKind.Perplexityai]: "PERPLEXITYAI_API_KEY",
-    [StandardProviderKind.TogetherAi]: "TOGETHERAI_API_KEY",
+    [StandardProviderKind.TogetherAi]: "TOGETHER_API_KEY",
     [StandardProviderKind.Openrouter]: "OPENROUTER_API_KEY",
     [StandardProviderKind.Gemini]: "GEMINI_API_KEY",
     [StandardProviderKind.Minimax]: "MINIMAX_API_KEY",
@@ -53,6 +53,7 @@ const STANDARD_PROVIDER_ENV_BY_KIND: Partial<Record<StandardProviderKind, string
 // counterpart. Used only in the reverse direction (env → kind).
 const STANDARD_PROVIDER_ENV_ALIASES: Record<string, StandardProviderKind> = {
     MISTRALAI_API_KEY: StandardProviderKind.Mistral,
+    TOGETHERAI_API_KEY: StandardProviderKind.TogetherAi,
 }
 
 /**

--- a/web/packages/agenta-shared/src/utils/llmProviders.ts
+++ b/web/packages/agenta-shared/src/utils/llmProviders.ts
@@ -25,7 +25,7 @@ export const llmAvailableProviders: LlmProvider[] = [
     {title: "Anyscale", key: "", name: "ANYSCALE_API_KEY"},
     {title: "Perplexity AI", key: "", name: "PERPLEXITYAI_API_KEY"},
     {title: "DeepInfra", key: "", name: "DEEPINFRA_API_KEY"},
-    {title: "Together AI", key: "", name: "TOGETHERAI_API_KEY"},
+    {title: "Together AI", key: "", name: "TOGETHER_API_KEY"},
     {title: "Aleph Alpha", key: "", name: "ALEPHALPHA_API_KEY"},
     {title: "OpenRouter", key: "", name: "OPENROUTER_API_KEY"},
     {title: "Groq", key: "", name: "GROQ_API_KEY"},


### PR DESCRIPTION
## Summary
Together AI was mapped inconsistently across the codebase. The frontend (`@agenta/entities`) and SDK (`daytona.py`) looked for `TOGETHERAI_API_KEY`, while standard LLM providers in the backend expected `TOGETHER_API_KEY`. Furthermore, `MINIMAX_API_KEY` was missing from the test suite mappings.

As a result, users configuring Together AI or MiniMax encountered secret resolution failures during evaluation and playground execution because the system looked for different environment variable names across layers.

This PR aligns Together AI on `TOGETHER_API_KEY` across the frontend packages, FastAPI backend, and SDK runners. To prevent breaking existing deployments that saved secrets under the legacy name, fallback aliases (`TOGETHERAI_API_KEY`) are added in both the frontend (`STANDARD_PROVIDER_ENV_ALIASES`) and backend secrets core (`_LEGACY_SYSTEM_ENV_NAMES`). It also adds `MINIMAX_API_KEY` to the test mappings.

Before:
```python
# Backend evaluation model
togetherai = "TOGETHERAI_API_KEY"

# SDK Daytona runner
"together_ai": "TOGETHERAI_API_KEY",
```

After:
```python
# Backend evaluation model
togetherai = "TOGETHER_API_KEY"

# SDK Daytona runner
"together_ai": "TOGETHER_API_KEY",

# Fallback in secrets utils
_LEGACY_SYSTEM_ENV_NAMES = {
    LMProvidersEnum.togetherai.value: ("TOGETHERAI_API_KEY",),
}
```

## Testing
### Verified locally
- Ran backend secrets unit tests via `uv run --project api pytest api/oss/tests/pytest/unit/secrets/test_utils.py` (all 3 unit tests passed).
- Ran frontend unit tests via `pnpm --filter="@agenta/entities" test` (675 tests passed) and `pnpm --filter="@agenta/shared" test` (189 tests passed).
- Verified code formatting and linting via `ruff format`, `ruff check`, and `pnpm lint-fix` on modified packages with zero errors or warnings.

### Added or updated tests
- Updated `test_utils.py` in API unit tests to assert `TOGETHER_API_KEY` resolution.
- Added `test_get_system_llm_providers_secrets_reads_legacy_togetherai_env` in `test_utils.py` to verify system secret fallback when only `TOGETHERAI_API_KEY` is set in the environment.
- Updated `conftest.py` in both API and SDK legacy test suites to use `TOGETHER_API_KEY` and added `MINIMAX_API_KEY` to `API_KEYS_MAPPING`.

### QA follow-up
- Validate configuring a Together AI provider key in the UI vault and running a playground prompt using a Together AI model.
- Verify that an existing deployment with `TOGETHERAI_API_KEY` set in the system environment still resolves correctly when executing evaluations without needing manual secret re-entry.

## Demo
<img width="1281" height="282" alt="image" src="https://github.com/user-attachments/assets/ba9a3c3c-12f3-4458-8154-570240755fee" />

<img width="936" height="431" alt="image" src="https://github.com/user-attachments/assets/ba92b7f7-dc25-4f7b-9710-aab25bb0d344" />



## Checklist
- [x] I have included a video or screen recording for UI changes, or marked Demo as N/A
- [x] Relevant tests pass locally
- [x] Relevant linting and formatting pass locally
- [x] I have signed the CLA, or I will sign it when the bot prompts me

## Contributor Resources
- [Contributing guide](https://agenta.ai/docs/contributing/overview)
- [Creating your first PR](https://agenta.ai/docs/contributing/first-pr)
- [Development mode](https://agenta.ai/docs/contributing/guides/development-mode)
- [Testing](https://agenta.ai/docs/contributing/guides/testing)
- [Formatting and linting](https://agenta.ai/docs/contributing/guides/formatting-and-linting)
- [Slack support](https://join.slack.com/t/agenta-hq/shared_invite/zt-37pnbp5s6-mbBrPL863d_oLB61GSNFjw)
