### PR TITLE
[fix] Record the real tool arguments in non-streaming run transcripts

### DIFF
--- a/sdks/python/agenta/sdk/agents/fold.py
+++ b/sdks/python/agenta/sdk/agents/fold.py
@@ -45,6 +45,7 @@ def fold(
     """
     messages: List[Message] = []
     open_text: Dict[Any, int] = {}  # message_start id -> index into `messages`
+    tool_calls: Dict[Any, int] = {}  # tool_call id -> index into `messages`
     event_stop_reason: Optional[str] = None
     last_interaction_request: Optional[Dict[str, Any]] = None
 
@@ -66,15 +67,35 @@ def fold(
         elif etype == "message_end":
             open_text.pop(data.get("id"), None)
         elif etype == "tool_call":
-            messages.append(
-                {
-                    "role": "tool",
-                    "content": "",
-                    "tool_call_id": data.get("id"),
-                    "tool_name": data.get("name"),
-                    "input": data.get("input"),
-                }
+            call_id = data.get("id")
+            # Prefer `rawInput` (the tool's real args, per ACP); the runner leaves the
+            # plain `input` empty on some tool-call paths — mirrors the vercel egress.
+            # `is not None` (not truthiness): a legit empty `{}` is real args, not absent.
+            input_value = (
+                data["rawInput"]
+                if data.get("rawInput") is not None
+                else data.get("input")
             )
+            idx = tool_calls.get(call_id) if call_id is not None else None
+            if idx is not None:
+                # A repeat tool_call for a seen id is an input REFRESH: the runner re-emits
+                # the call once the real args land on a later ACP tool_call_update (the
+                # announcement often carries absent/partial args). Update the one recorded
+                # call in place — keep its position and first-seen name (the refresh carries
+                # only the drift-prone ACP title) — mirroring the vercel stream egress.
+                messages[idx]["input"] = input_value
+            else:
+                if call_id is not None:
+                    tool_calls[call_id] = len(messages)
+                messages.append(
+                    {
+                        "role": "tool",
+                        "content": "",
+                        "tool_call_id": call_id,
+                        "tool_name": data.get("name"),
+                        "input": input_value,
+                    }
+                )
         elif etype == "tool_result":
             messages.append(
                 {

--- a/sdks/python/oss/tests/pytest/unit/agents/test_fold.py
+++ b/sdks/python/oss/tests/pytest/unit/agents/test_fold.py
@@ -94,6 +94,74 @@ def test_fold_tool_run_produces_call_and_result_messages_in_order():
     assert result["stop_reason"] == "stop"
 
 
+def test_fold_repeat_tool_call_is_an_input_refresh_not_a_duplicate():
+    # The runner announces a call early (absent/partial args — Pi streams arg deltas) and
+    # re-emits the SAME id once the real args land on a later ACP tool_call_update. A repeat
+    # tool_call for a seen id is an input REFRESH (see vercel/stream.py's seen-id refresh):
+    # the batch fold must record the final args on the ONE tool_call message, not keep the
+    # early partial delta nor append a duplicate.
+    events = [
+        {
+            "type": "tool_call",
+            "data": {"id": "t1", "name": "search", "input": {"use_cases": [""]}},
+        },
+        {
+            "type": "tool_call",
+            "data": {
+                "id": "t1",
+                "name": "search",
+                "input": {"use_cases": ["a", "b"], "limit": 5},
+            },
+        },
+        {"type": "tool_result", "data": {"id": "t1", "output": "42"}},
+        _done(),
+    ]
+    result = fold(events)
+    roles = [m["role"] for m in result["messages"]]
+    assert roles == ["tool", "tool"]  # one call + one result, no duplicate call
+    call = result["messages"][0]
+    assert call["input"] == {"use_cases": ["a", "b"], "limit": 5}
+    assert call["tool_call_id"] == "t1" and call["tool_name"] == "search"
+
+
+def test_fold_repeat_tool_call_keeps_first_seen_name_and_position():
+    # The refresh carries only the drift-prone ACP title; keep the first-seen name
+    # (mirrors the stream egress) and the call's original position before its result.
+    events = [
+        {"type": "tool_call", "data": {"id": "t1", "name": "search", "input": {}}},
+        {
+            "type": "tool_call",
+            "data": {"id": "t1", "name": "Searching the web", "input": {"q": "x"}},
+        },
+        {"type": "tool_result", "data": {"id": "t1", "output": "ok"}},
+        _done(),
+    ]
+    result = fold(events)
+    call, tool_result = result["messages"][0], result["messages"][1]
+    assert call["tool_name"] == "search"
+    assert call["input"] == {"q": "x"}
+    assert tool_result["content"] == "ok"
+
+
+def test_fold_tool_call_prefers_raw_input_over_input():
+    # Some tool-call paths leave the plain `input` empty and carry the real args on
+    # `rawInput` (ACP); mirror the stream egress preference. `{}` is real args, not absent.
+    events = [
+        {
+            "type": "tool_call",
+            "data": {
+                "id": "t1",
+                "name": "ls",
+                "input": None,
+                "rawInput": {"path": "/tmp"},
+            },
+        },
+        _done(),
+    ]
+    result = fold(events)
+    assert result["messages"][0]["input"] == {"path": "/tmp"}
+
+
 def test_fold_tool_result_error_flag_carried():
     events = [
         {"type": "tool_call", "data": {"id": "t1", "name": "bash"}},

--- a/services/runner/src/tracing/otel.ts
+++ b/services/runner/src/tracing/otel.ts
@@ -669,6 +669,16 @@ function acpBlockText(block: any): string {
  * or empty `{}` input and fills the args in on a later `tool_call_update`; both placeholders
  * count as "no args yet" so we know to refresh the tool_call once the real args land.
  */
+/** Serialized form of real tool args, for change detection; undefined when absent/`{}`. */
+function toolInputJson(input: unknown): string | undefined {
+  if (!hasToolArgs(input)) return undefined;
+  try {
+    return JSON.stringify(input);
+  } catch {
+    return undefined;
+  }
+}
+
 function hasToolArgs(input: unknown): boolean {
   if (input == null) return false;
   if (
@@ -891,7 +901,12 @@ export function createSandboxAgentOtel(
   let reasoningAccumulated = "";
   let usage: AgentUsage | undefined;
   const events: AgentEvent[] = [];
-  const toolSpans = new Map<string, { span?: Span; name: string; hasArgs: boolean }>();
+  // `inputJson` is the serialized form of the last-RECORDED input for the call, so a later
+  // `tool_call_update` can refresh the recorded args whenever they genuinely change.
+  const toolSpans = new Map<
+    string,
+    { span?: Span; name: string; inputJson?: string }
+  >();
 
   // Live emission. `record` is the single choke point for every event: it appends to the
   // result log and, on the streaming path, flushes the event the moment it is built — so
@@ -1134,24 +1149,32 @@ export function createSandboxAgentOtel(
         name: String(name),
         input: update.rawInput,
       });
-      toolSpans.set(id, { span, name: String(name), hasArgs: hasToolArgs(update.rawInput) });
+      toolSpans.set(id, { span, name: String(name), inputJson: toolInputJson(update.rawInput) });
       // A tool_call can arrive already completed (status set up front).
       maybeCloseTool(id, update);
       return;
     }
 
     if (kind === "tool_call_update") {
-      // The real args often land here, not on the initial `tool_call`. Refresh the input ONCE,
-      // by re-recording the tool_call with the real args, so a non-gated tool shows them instead
-      // of the placeholder `{}`. The egress projects a repeat tool_call for a seen id as an
-      // input refresh (no new tool-input-start), mirroring the gated approval-refresh path.
+      // The real args often land here, not on the initial `tool_call` — and they can land
+      // INCREMENTALLY: Pi streams a growing partial parse of the args (`{}` -> `{x:[""]}` ->
+      // the full args), and the announcement itself may already carry an early partial delta.
+      // Refresh the recorded input whenever the update carries genuinely NEW args (serialized
+      // compare against the last-recorded input), so the final recorded tool_call always has
+      // the args the executor actually ran with — a refresh-once / had-args-at-announce gate
+      // records an early partial delta as the call's input (the #5064 fold-path bug). The
+      // egress projects a repeat tool_call for a seen id as an input refresh (no new
+      // tool-input-start), mirroring the gated approval-refresh path.
       const id = update.toolCallId;
       const entry = id ? toolSpans.get(id) : undefined;
-      if (entry && !entry.hasArgs && hasToolArgs(update.rawInput)) {
-        if (entry.span)
-          setInputs(entry.span, update.rawInput as Record<string, unknown>, capture);
-        record({ type: "tool_call", id: String(id), name: entry.name, input: update.rawInput });
-        entry.hasArgs = true;
+      if (entry && hasToolArgs(update.rawInput)) {
+        const nextJson = toolInputJson(update.rawInput);
+        if (nextJson !== entry.inputJson) {
+          if (entry.span)
+            setInputs(entry.span, update.rawInput as Record<string, unknown>, capture);
+          record({ type: "tool_call", id: String(id), name: entry.name, input: update.rawInput });
+          entry.inputJson = nextJson;
+        }
       }
       maybeCloseTool(id, update);
       return;

--- a/services/runner/src/tracing/otel.ts
+++ b/services/runner/src/tracing/otel.ts
@@ -664,11 +664,6 @@ function acpBlockText(block: any): string {
   return "";
 }
 
-/**
- * Whether a tool's `rawInput` holds real, inspectable args. Pi announces a call with an absent
- * or empty `{}` input and fills the args in on a later `tool_call_update`; both placeholders
- * count as "no args yet" so we know to refresh the tool_call once the real args land.
- */
 /** Serialized form of real tool args, for change detection; undefined when absent/`{}`. */
 function toolInputJson(input: unknown): string | undefined {
   if (!hasToolArgs(input)) return undefined;
@@ -679,6 +674,12 @@ function toolInputJson(input: unknown): string | undefined {
   }
 }
 
+/**
+ * Whether a tool's `rawInput` holds real, inspectable args. A harness can announce a call with
+ * an absent or empty `{}` input and fill the args in on a later `tool_call_update` (Pi does);
+ * both placeholders count as "no args yet" so we know to refresh the tool_call once the real
+ * args land. Purely shape-based — no harness-specific logic.
+ */
 function hasToolArgs(input: unknown): boolean {
   if (input == null) return false;
   if (
@@ -1157,8 +1158,9 @@ export function createSandboxAgentOtel(
 
     if (kind === "tool_call_update") {
       // The real args often land here, not on the initial `tool_call` — and they can land
-      // INCREMENTALLY: Pi streams a growing partial parse of the args (`{}` -> `{x:[""]}` ->
-      // the full args), and the announcement itself may already carry an early partial delta.
+      // INCREMENTALLY: a harness may stream a growing partial parse of the args (Pi does:
+      // `{}` -> `{x:[""]}` -> the full args), and the announcement itself may already carry
+      // an early partial delta.
       // Refresh the recorded input whenever the update carries genuinely NEW args (serialized
       // compare against the last-recorded input), so the final recorded tool_call always has
       // the args the executor actually ran with — a refresh-once / had-args-at-announce gate

--- a/services/runner/tests/unit/stream-events.test.ts
+++ b/services/runner/tests/unit/stream-events.test.ts
@@ -186,6 +186,43 @@ describe("createSandboxAgentOtel state machine", () => {
     assert.ok(seq.indexOf("tool_call") < seq.indexOf("tool_result"), "tool_call precedes its result");
   });
 
+  it("scenario 7: growing arg deltas keep refreshing until the FINAL args are recorded", () => {
+    // The real Pi wire for streamed args: the initial `tool_call` announces with `{}`, then
+    // tool_call_update frames carry a GROWING partial parse of the args (e.g. {use_cases:[""]}),
+    // and the final update has the complete args. The last recorded tool_call input MUST be the
+    // final args — a refresh-once gate that stops at the first partial delta records a lie
+    // (the executor demonstrably ran with the full args).
+    const emitted: AgentEvent[] = [];
+    const run = createSandboxAgentOtel({ harness: "pi", model: "openai-codex/x", emit: (e) => emitted.push(e), emitSpans: false });
+    run.start({ prompt: "x" });
+    run.handleUpdate({ sessionUpdate: "tool_call", toolCallId: "c1", title: "compare", rawInput: {} });
+    run.handleUpdate({ sessionUpdate: "tool_call_update", toolCallId: "c1", rawInput: { use_cases: [""] } }); // early partial delta
+    run.handleUpdate({ sessionUpdate: "tool_call_update", toolCallId: "c1", rawInput: { use_cases: ["a", "b"], limit: 5 } }); // final args
+    run.handleUpdate({ sessionUpdate: "tool_call_update", toolCallId: "c1", status: "completed", content: [{ content: { type: "text", text: "ok" } }] });
+    run.finish();
+
+    const calls = ofType(emitted, "tool_call");
+    assert.deepEqual(calls[calls.length - 1].input, { use_cases: ["a", "b"], limit: 5 }, "the LAST refresh carries the final args");
+    const seq = types(emitted);
+    assert.ok(seq.lastIndexOf("tool_call") < seq.indexOf("tool_result"), "every refresh precedes the result");
+  });
+
+  it("scenario 8: a call announced with PARTIAL args still refreshes when the full args arrive", () => {
+    // The initial notification itself can carry an early partial parse (non-empty), so a
+    // has-args-at-announce gate must not suppress the refresh with the real args.
+    const emitted: AgentEvent[] = [];
+    const run = createSandboxAgentOtel({ harness: "pi", model: "openai-codex/x", emit: (e) => emitted.push(e), emitSpans: false });
+    run.start({ prompt: "x" });
+    run.handleUpdate({ sessionUpdate: "tool_call", toolCallId: "c1", title: "read", rawInput: { path: "/" } }); // partial
+    run.handleUpdate({ sessionUpdate: "tool_call_update", toolCallId: "c1", rawInput: { path: "/etc/hosts" } }); // real args
+    run.handleUpdate({ sessionUpdate: "tool_call_update", toolCallId: "c1", status: "completed", content: [{ content: { type: "text", text: "ok" } }] });
+    run.finish();
+
+    const calls = ofType(emitted, "tool_call");
+    assert.equal(calls.length, 2, "one initial surface + one input refresh");
+    assert.deepEqual(calls[calls.length - 1].input, { path: "/etc/hosts" }, "the refresh carries the real args");
+  });
+
   it("scenario 6: a call announced WITH args refreshes only on genuinely new args", () => {
     // If the initial notification already has real args, that's the input — a later update that
     // merely repeats/omits args must NOT emit a duplicate tool_call.


### PR DESCRIPTION
## Context

When you invoke an agent through `/services/agent/v0/invoke` without streaming, the response carries a transcript: the ordered list of assistant messages, tool calls, and tool results from the run. That transcript lied about tool arguments. A `tool_call` entry could show `{"command": ""}` while the tool result right next to it proved the tool ran the complete command. Anyone reading the transcript afterwards (debugging, replay, or the `test_run` verdict) saw arguments the tool never actually received.

Two terms this PR touches. The **runner** is the process that executes the agent (a coding-agent harness such as Pi) and emits the run as a stream of events. The **fold** is the SDK step that collapses that event stream into the single response transcript for a non-streaming request. Pi streams tool arguments incrementally, so early events carry a partial parse of the arguments and only a later event carries the final ones.

Observed live on 2026-07-05 on the #5064 fold path, and reproduced with the builtin bash tool. Before the fix, a non-streaming run (`flags: {stream: false}`) recorded:

```json
{"role": "tool", "tool_name": "bash", "input": {"command": ""}}
{"role": "tool", "content": "QA-CMP-eu-central-billing alerts|usage dashboards|anomaly detection-N3\n"}
```

The result line proves the full `echo` command ran; the recorded input is an early streamed argument delta. Other live cases showed `{"use_cases": [""]}` and `{"path": "/"}` in the same way.

Two bugs stacked to produce this:

1. **Runner** (`services/runner/src/tracing/otel.ts`). The runner announces a `tool_call` event up front and refreshes its input from a later ACP `tool_call_update`. That refresh was gated on "the announcement had no args" and fired at most once. So a partial parse at announce time, or an early partial delta winning the single refresh, suppressed the refresh that carried the final arguments. The event stream then never carried them at all.
2. **SDK** (`sdks/python/agenta/sdk/agents/fold.py`). The wire convention says a repeat `tool_call` event for an already-seen id is an input refresh, and the streaming (vercel) egress already honors that. The batch fold instead appended a new tool message for every `tool_call` event. So even a correct refresh produced a duplicate entry in the transcript, with the stale one first.

## What changed

**Runner.** The `tool_call_update` handler now re-records the `tool_call` whenever the update's `rawInput` genuinely changed, using a serialized comparison against the last-recorded input, instead of the once-and-only-if-empty gate. The last recorded call therefore always carries the arguments the tool ran with. An update that omits the arguments, or merely repeats them, still emits nothing.

**SDK fold.** A repeat `tool_call` for a seen id now updates the recorded call's `input` in place. The entry keeps its position in the transcript and its first-seen name, because the refresh event carries only the drift-prone ACP title. The fold also prefers `rawInput` over `input` when both exist, mirroring the stream egress; the check uses `is not None` so a legitimate empty `{}` still counts as real arguments.

After the fix, the same request records:

```json
{"role": "tool", "tool_name": "bash", "input": {"command": "echo \"QA-CMP-eu-central-billing alerts|usage dashboards|anomaly detection-N3\""}}
{"role": "tool", "content": "QA-CMP-eu-central-billing alerts|usage dashboards|anomaly detection-N3\n"}
```

## How to review this PR

The diff is four files, two production and two test. A sensible order:

1. `services/runner/src/tracing/otel.ts`. The `toolSpans` map entry now tracks `inputJson` (the serialized last-recorded input) instead of a `hasArgs` boolean, and the `tool_call_update` branch re-records on any genuine change. Check the negative property: an update with absent or identical arguments must emit nothing, so the stream does not fill with repeat events.
2. `services/runner/tests/unit/stream-events.test.ts`. Scenarios 7 (growing partial deltas; the final arguments must win) and 8 (partial arguments at announce must still refresh) are the failing-first regressions. Scenario 6, which predates this PR, pins that a repeat with identical arguments emits no duplicate.
3. `sdks/python/agenta/sdk/agents/fold.py`. The new seen-id map and the in-place refresh. Check the `rawInput` preference and that name and position come from the first-seen event.
4. `sdks/python/oss/tests/pytest/unit/agents/test_fold.py`. Three new tests, one property each: a repeat refreshes the input in place instead of duplicating, the first-seen name and position are kept, and `rawInput` is preferred over `input`.

## How to QA

**Prerequisites:** local dev stack with the agent sidecar. If the sidecar mounts `services/runner/src`, restart it after checkout (`docker restart agenta-claude-sub-sidecar`); it compiles on startup and has no hot reload.

**Steps:**

1. POST `/services/agent/v0/invoke?project_id=<pid>` with `flags: {"stream": false}`, an agent config containing `tools: [{"type": "builtin", "name": "bash"}]` and `runner: {"permissions": {"default": "allow"}}`, and a user message asking for two exact `echo` commands, one bash call each.
2. Read `data.outputs.messages` in the response.

**Expected result:** each `tool_call` entry's `input.command` is the exact command that its matching `tool_result` output proves ran. There is no `tool_call` entry with truncated or empty arguments, and no duplicate `tool_call` entries for one id.

This was verified live on the local stack (`:8280`, sidecar restarted to load the runner change) with one non-streaming two-tool bash invoke; the before/after snippets above come from those runs.

**Automated tests:**

```
cd services/runner && npx vitest run tests/unit/stream-events.test.ts
cd sdks/python && uv run --no-sync python -m pytest oss/tests/pytest/unit/agents/test_fold.py -n0
```

Both new runner scenarios and all three new SDK tests failed before the fix. Full suites after: runner `npx vitest run` 551 green with `tsc --noEmit` clean; SDK unit suite 1600 green; services agent unit 78 green; ruff clean.

**Edge cases:** a gated (approval) run must still surface the `tool_call` before its `interaction_request`; and a tool whose arguments legitimately never arrive (an empty `{}` announcement with no later arguments) must still record a single call with `{}` (scenario 5 pins this).

## Scope and risk

There is no wire shape change. The runner already emitted repeat `tool_call` events; it now emits them for every genuine argument change rather than only the empty-to-args transition. The streaming egress already projects repeats as input refreshes (no new `tool-input-start`), so the frontend path is unaffected by design.

One observable difference: the batch transcript can no longer contain two `tool_call` messages with the same id. Nothing consumed the duplicate (it was the bug), but flagging it in case something downstream counted messages.

Not touched: the HITL approval refresh path (`acp-interactions.ts`), the interaction payload reads, and the streaming fold in `adapters/vercel/stream.py`, which was already correct.

https://claude.ai/code/session_014iPB7HL5PjgT9npyPHaFMT
