### PR TITLE
fix: migrate legacy prompt.model to prompt.llm_config.model on model change

### DIFF
--- a/web/packages/agenta-entity-ui/src/DrillInView/components/PlaygroundConfigSection.tsx
+++ b/web/packages/agenta-entity-ui/src/DrillInView/components/PlaygroundConfigSection.tsx
@@ -949,8 +949,16 @@ function PlaygroundConfigSection({
                     ),
                 }
             } else {
-                updatedPrompt = updateConfigKey(currentPrompt, key, newValue)
-            }
+    // Migrate legacy flat prompt.model → prompt.llm_config.model
+    // so old-format prompts get upgraded on first model change.
+    const existingLlmConfig = (currentPrompt.llm_config as Record<string, unknown> | undefined) ?? {}
+    updatedPrompt = {
+        ...currentPrompt,
+        llm_config: updateConfigKey(existingLlmConfig, key, newValue),
+    }
+    // Remove legacy flat key to avoid duplicate
+    delete (updatedPrompt as Record<string, unknown>)[key]
+}
 
             dispatchUpdate(revisionId, {
                 ...parameters,


### PR DESCRIPTION
## Summary
Fixes model selection not working for old-format prompts when using 
custom/local LLM providers (e.g. LM Studio).

**Root cause:** Old prompts stored model at `prompt.model` (flat). 
When user changed the model selector, `updatePromptLLMConfigKey` 
detected no `llm_config` object and wrote the new model back to 
`prompt.model` (flat path). The backend never saw it in 
`llm_config.model` and fell back to the default `gpt-4o-mini`.

New prompts already work correctly because they have `llm_config` 
nested — confirmed by @pniedzwiedzinski's repro in the issue thread.

**Fix:** When no `llm_config` exists on the prompt, create it and 
write model there instead of flat on the prompt root. Also removes 
the legacy flat key to avoid duplicates. This is a one-way migration 
— on first model change, old prompts get upgraded to the canonical 
`prompt.llm_config.model` shape.

## Changes
- `PlaygroundConfigSection.tsx`: updated `updatePromptLLMConfigKey` 
  else-branch to migrate flat `prompt.model` → `prompt.llm_config.model`

## Testing
TypeScript compiles clean. Repro steps from issue #4933 confirmed 
the data-model mismatch as root cause — fix addresses the exact 
write-back path where the regression occurred.

Fixes #4933