### PR TITLE
fix(runner): settle sibling tool calls deferred by an approval pause

### DIFF
--- a/docs/design/parallel-approval-gates/README.md
+++ b/docs/design/parallel-approval-gates/README.md
@@ -1,0 +1,34 @@
+# Parallel approval gates: phantom "failed" tool in the playground
+
+Planning workspace for issue 2 of the 2026-07-06 approval-flow investigation: when the
+model calls two approval-gated tools in one turn, the runner's one-pause-per-turn latch
+drops the second gate, the client is left with an orphaned tool part, and the frontend
+fabricates a `This app can't handle the ... request.` failure for a tool that never
+ran. The user then pays two sequential approval round-trips.
+
+**TL;DR of the recommendation** (details in [options.md](options.md)): fix it in the
+runner, in two layers. Option A (small, ship now): at pause time, settle every
+announced-but-unresolved sibling tool call with a deterministic "not executed, paused
+for another approval" result before tearing the session down. Option B (follow-up,
+medium): additionally synthesize approval requests for gated siblings whose args are
+trustworthy, so the user approves everything in one dock pass and the cold replay
+executes all of it in one resume. B contains A as its fallback; nothing is thrown
+away. No frontend tool-name lists anywhere (hard constraint).
+
+## Files
+
+| File | What it holds |
+|---|---|
+| [context.md](context.md) | The bug, the framing decisions from Mahmoud, goals, non-goals. |
+| [research.md](research.md) | Verified mechanics with file:line for every claim: the ACP wire trace, the CLI's serial gate scheduling, teardown cancellation, the FE orphan path, the resume machinery, corrections to the earlier findings doc. |
+| [flows.md](flows.md) | Mermaid sequence diagrams and example frames: today's broken flow, Option A, Option B, each at the wire / stream / user level. |
+| [options.md](options.md) | Both remedies with honest complexity assessments, why A is a stepping stone to B, the recommendation, and one independent flag about the FE force-settle pattern. |
+| [plan.md](plan.md) | Phased implementation: files to change, tests (runner unit, FE unit, replay regression), live-stack verification, docs sync, open questions. |
+| [status.md](status.md) | Current state and next steps. Source of truth for progress. |
+
+## Prior art
+
+- `docs/design/agent-workflows/scratch/approval-turn-duplication-findings.md`: the
+  original investigation (both issues). Issue 1 (duplicate turn blocks from message-id
+  churn) is out of scope here.
+- F-040 pause contract: `services/runner/src/engines/sandbox_agent/pause.ts:1-27`.

--- a/docs/design/parallel-approval-gates/context.md
+++ b/docs/design/parallel-approval-gates/context.md
@@ -1,0 +1,73 @@
+# Context: parallel approval gates, one pause, one phantom failure
+
+## The bug
+
+In the agent playground (harness `claude` over ACP, runner `sidecar`, session
+`67a00253-ac61-48ab-a907-4af49f059bd0`), the model called two approval-gated platform
+tools in one turn: `mcp__agenta-tools__commit_revision` and
+`mcp__agenta-tools__create_subscription`.
+
+What the user saw:
+
+1. An approval prompt for `commit_revision`. Fine.
+2. A `failed` chip on `create_subscription` with the error
+   `This app can't handle the "mcp__agenta-tools__create_subscription" request.`
+   Nothing failed. Nothing even ran. The browser invented that error.
+3. After approving `commit_revision`, a second approval prompt for
+   `create_subscription`. Approving it worked.
+
+So the flow recovers, but the user sees a bogus failure and pays two sequential
+approval round-trips for one turn.
+
+## Why it happens (short form)
+
+The runner allows exactly one pause per turn (`PendingApprovalLatch`,
+`services/runner/src/engines/sandbox_agent/acp-interactions.ts:78`). The first gate wins,
+the runner pauses, and it tears the sandbox session down without replying to the harness
+(the F-040 contract, `services/runner/src/engines/sandbox_agent/pause.ts:1-27`). The
+second gate loses the latch and is dropped with no trace. But its tool call already
+streamed to the client. The client is left holding a tool part with no approval, no
+output, no error. When the turn ends, the frontend classifies that orphan as a "parked
+unknown client tool" (`web/oss/src/components/AgentChatSlice/components/clientTools/meta.ts:52-66`)
+and force-settles it with a synthetic browser-side error
+(`web/oss/src/components/AgentChatSlice/components/clientTools/UnhandledClientTool.tsx:17-21`).
+
+Full verified mechanics, with one correction to the earlier findings doc, are in
+[research.md](research.md). Sequence diagrams are in [flows.md](flows.md).
+
+## Decisions that frame this plan (from Mahmoud)
+
+1. **The frontend must not special-case tool names.** No excluding
+   `mcp__agenta-tools__*` from the unknown-client-tool path. The bug is created where
+   the orphan is created: in the runner. The frontend has no responsibility for it.
+   (We do flag, independently, that force-settling unsettled parts with a fake error
+   is itself a questionable pattern. See [options.md](options.md), "Independent flag".)
+2. **Explain the flow precisely.** What exactly does the harness send when two gated
+   calls happen in one turn? Answered from source in [research.md](research.md) and
+   drawn in [flows.md](flows.md).
+3. **Explore both remedies with an honest complexity assessment.**
+   - Option A: settle the losing sibling deterministically before teardown.
+   - Option B: batch all pending approvals into one pause.
+   Both are assessed in [options.md](options.md), including whether A is a stepping
+   stone to B (it is).
+4. **End with a recommendation and a phased plan.** [options.md](options.md) carries
+   the recommendation; [plan.md](plan.md) carries the phases, files, and tests.
+
+## Goals
+
+- The playground never shows a fabricated failure for a tool the backend never ran.
+- Every tool part the server streams gets a truthful terminal state.
+- Reduce (Option B) or at least keep honest (Option A) the approval round-trips when
+  one turn raises several gates.
+- No frontend tool-name lists. No change to the F-040 pause contract's core rule
+  (never reply to a harness gate that a human must decide).
+
+## Non-goals
+
+- Issue 1 from the same investigation (duplicate turn blocks from the
+  `msg-{trace_id}` message-id churn). That is a separate fix with its own plan.
+- Warm sessions / avoiding cold replay. The session still dies on every pause.
+- Redesigning the frontend client-tool fallback surface (flagged as follow-up only).
+- Pi relay parity beyond noting where the same latch drop exists
+  (`services/runner/src/tools/relay.ts:255-263`); the incident harness is Claude and
+  the fix seam we choose covers both paths at the pause controller.

--- a/docs/design/parallel-approval-gates/flows.md
+++ b/docs/design/parallel-approval-gates/flows.md
@@ -1,0 +1,234 @@
+# Flows: today, Option A, Option B
+
+Three views per flow where they differ: the harness/ACP wire, our `/messages` stream
+parts, and what the user sees. Tool A is `mcp__agenta-tools__commit_revision`, tool B
+is `mcp__agenta-tools__create_subscription`. Both are `ask`-gated write tools, so the
+CLI schedules them serially (research.md §2b).
+
+## 1. Today: the broken flow
+
+### 1a. Harness / ACP wire
+
+```mermaid
+sequenceDiagram
+    participant CLI as claude CLI (sandbox)
+    participant ACP as claude-agent-acp
+    participant D as sandbox-agent daemon
+    participant R as runner
+
+    Note over CLI: assistant message streams<br/>two tool_use blocks (A, B)
+    CLI->>ACP: content_block_start tool_use A
+    ACP->>D: session/update tool_call A (pending, rawInput {})
+    D->>R: event tool_call A
+    CLI->>ACP: content_block_start tool_use B
+    ACP->>D: session/update tool_call B (pending, rawInput {})
+    D->>R: event tool_call B
+    CLI->>ACP: full assistant message
+    ACP--)D: tool_call_update A (real args)
+    ACP--)D: tool_call_update B (real args)  [delivery races the teardown below]
+
+    Note over CLI: serial scheduler starts tool A
+    CLI->>ACP: control_request can_use_tool(A)
+    ACP->>D: session/request_permission A (rawInput = real args)
+    D->>R: onPermissionRequest(A)
+    Note over R: decide() = pendingApproval<br/>latch.tryAcquire() = true
+    R->>R: emit interaction_request(A), pause()
+    R->>D: destroySession (never replies to gate A)
+    D-->>ACP: gate A resolves outcome=cancelled
+    ACP-->>CLI: canUseTool(A) throws "Tool use aborted"
+
+    Note over CLI: scheduler unblocks, tries tool B
+    CLI->>ACP: control_request can_use_tool(B)
+    ACP->>D: session/request_permission B  [teardown race]
+    D->>R: onPermissionRequest(B)
+    Note over R: latch.tryAcquire() = false<br/>return. B is DROPPED silently.
+    Note over D: teardown resolves gate B<br/>outcome=cancelled
+```
+
+### 1b. /messages stream and the playground
+
+```mermaid
+sequenceDiagram
+    participant R as runner
+    participant E as egress (stream.py)
+    participant C as AI SDK client
+    participant U as user
+
+    R->>E: tool_call A ({}), tool_call B ({})
+    E->>C: tool-input-start/available A ({}), B ({})
+    R->>E: interaction_request A (real args)
+    E->>C: tool-input-available A (real args) + tool-approval-request A
+    R->>E: done (stopReason paused)
+    E->>C: finish (finishReason "other")
+
+    Note over C: part A: approval-requested<br/>part B: input-available, ORPHAN
+    C->>U: ApprovalDock shows gate A
+    Note over C: turn ended, B unsettled, no handler:<br/>UnhandledClientTool settles B with<br/>"This app can't handle the ... request."
+    C->>U: tool B chip shows FAILED (fake)
+
+    U->>C: Approve A
+    Note over C: predicate: all parts settled -> auto resend
+    C->>R: POST /messages (full history: A approved, B fake error)
+    Note over R: cold replay. Stored decision allows A.<br/>Model re-calls A, executes.<br/>Model sees B's fake error, retries B (real args).
+    R->>C: tool-approval-request B (second pause)
+    C->>U: SECOND approval prompt (B)
+    U->>C: Approve B
+    C->>R: POST /messages (resume #2)
+    Note over R: stored decision allows B. Executes. Turn completes.
+```
+
+### 1c. What the user sees
+
+| Step | UI |
+|---|---|
+| Turn streams | Two tool chips appear (A and B). |
+| Turn pauses | Approval dock asks about A. B's chip flips to `failed` with "This app can't handle the ... request." |
+| Approve A | New turn block streams. A runs. Model retries B. Dock asks about B. |
+| Approve B | New turn block streams. B runs. Done. |
+
+Two approval round-trips, one fabricated failure, and (issue 1, out of scope here) the
+repeated turn blocks.
+
+## 2. Option A: settle the losing sibling deterministically
+
+Only the pause step changes. Before teardown, the runner scans its own event log for
+announced tool calls with no result (excluding the paused one) and emits a truthful
+terminal `tool_result` for each.
+
+### 2a. Wire (delta only)
+
+```mermaid
+sequenceDiagram
+    participant R as runner
+    participant E as egress (stream.py)
+    participant C as AI SDK client
+
+    Note over R: pause(): latch winner is A.<br/>Scan events: tool_call B has no tool_result.
+    R->>E: tool_result B {isError: true, output:<br/>"Not executed: the turn paused for approval of<br/>another tool call. Call the tool again if needed."}
+    E->>C: tool-output-error B (honest server-side state)
+    R->>E: interaction_request A, done(paused)
+    Note over C: part B settled -> classifier never<br/>parks it, no fake browser error
+```
+
+Nothing changes at the ACP layer. Gate B (if it arrives in the teardown race) still
+loses the latch and is still ignored; its tool call is already settled.
+
+### 2b. Resume (same shape as today, honest content)
+
+The history now carries B's deterministic "not executed" error instead of the browser's
+"can't handle" text. The replayed transcript renders
+`[mcp__agenta-tools__create_subscription error: Not executed: ...]`
+(`transcript.ts:53-55`), the model retries B, the gate pauses, the user approves
+second. Still two round-trips, but every state shown was true.
+
+### 2c. What the user sees
+
+| Step | UI |
+|---|---|
+| Turn pauses | Dock asks about A. B's chip shows "Not executed: waiting on another approval" (error-styled but truthful; exact copy TBD). |
+| Approve A | A runs, model retries B, dock asks about B. |
+| Approve B | B runs. Done. |
+
+## 3. Option B: batch all pending approvals into one pause
+
+The runner cannot wait for the harness to raise gate B (research.md §3). Instead, at
+pause time it synthesizes the sibling's approval request from its own record: any
+announced, unresolved tool call whose `decide()` verdict would be `pendingApproval`
+and whose recorded args are trustworthy. Everything downstream already supports it.
+
+### 3a. Wire and stream
+
+```mermaid
+sequenceDiagram
+    participant R as runner
+    participant E as egress (stream.py)
+    participant C as AI SDK client
+    participant U as user
+
+    Note over R: gate A wins the latch.<br/>pause(): scan events for siblings.<br/>B: unresolved + decide()=ask + real args recorded
+    R->>E: interaction_request A (harness gate)
+    R->>E: interaction_request B (synthetic, from recorded call)
+    R->>E: tool_result for any OTHER unresolved call (Option A fallback)
+    E->>C: approval-request A + approval-request B
+    Note over C: parts A and B: approval-requested
+    C->>U: dock shows "1 of 2" (queue already built)
+    U->>C: Approve A, Approve B (or "Approve all")
+    Note over C: predicate holds resume until BOTH settle,<br/>then ONE auto resend
+    C->>R: POST /messages (history: A approved, B approved)
+    Note over R: cold replay with TWO stored decisions.<br/>Model re-calls A -> gate matched -> runs.<br/>Model re-calls B -> gate matched -> runs.
+    R->>C: single continuation stream, turn completes
+```
+
+### 3b. What the user sees
+
+| Step | UI |
+|---|---|
+| Turn pauses | Dock shows "Approval needed, 1 of 2" with A's payload. B's chip shows "Awaiting approval". |
+| Approve A (or Approve all) | Dock slides to B. |
+| Approve B | One resume. Both tools run in order. Done. |
+
+One approval interaction, one round-trip, no fabricated state.
+
+### 3c. The fallback inside Option B
+
+A sibling that fails the trust check falls back to Option A's deterministic settle:
+
+- recorded args are `{}` or absent (the refresh lost the race, research.md §4). Asking
+  a human to approve an invisible payload is unacceptable, and the stored decision key
+  `name#{}` would not match the re-raised gate anyway (`responder.ts:65-76`), forcing a
+  second prompt regardless.
+- `decide()` says `allow` or `deny` for the sibling (it never needed a human), but it
+  cannot run because the session is dying: settle it with the deferred error so the
+  model retries it after resume.
+
+## 4. Example frames (obfuscated, shapes verified)
+
+ACP announcement the runner receives (first encounter, streamed):
+
+```json
+{"sessionUpdate": "tool_call", "toolCallId": "toolu_01AbC...", "status": "pending",
+ "title": "create_subscription", "kind": "other", "rawInput": {},
+ "_meta": {"claudeCode": {"toolName": "mcp__agenta-tools__create_subscription"}}}
+```
+
+ACP permission request (the gate; carries real args):
+
+```json
+{"sessionId": "sess_...", "options": [
+   {"kind": "allow_always", "name": "Always Allow", "optionId": "allow_always"},
+   {"kind": "allow_once", "name": "Allow", "optionId": "allow"},
+   {"kind": "reject_once", "name": "Reject", "optionId": "reject"}],
+ "toolCall": {"toolCallId": "toolu_01AbC...",
+   "rawInput": {"plan": "pro", "seats": 3}}}
+```
+
+Runner `interaction_request` event (what the egress projects; the synthetic Option B
+sibling uses the same shape, mirroring the Pi relay emission at
+`sandbox_agent.ts:777-792`):
+
+```json
+{"type": "interaction_request", "id": "toolu_01AbC...", "kind": "user_approval",
+ "payload": {"toolCallId": "toolu_01AbC...",
+   "toolCall": {"toolCallId": "toolu_01AbC...", "resolvedName":
+     "mcp__agenta-tools__create_subscription", "rawInput": {"plan": "pro", "seats": 3}},
+   "availableReplies": ["once", "reject"]}}
+```
+
+Stream parts the client receives for one gated call:
+
+```json
+{"type": "tool-input-available", "toolCallId": "toolu_01AbC...",
+ "toolName": "mcp__agenta-tools__create_subscription",
+ "input": {"plan": "pro", "seats": 3}}
+{"type": "tool-approval-request", "approvalId": "toolu_01AbC...",
+ "toolCallId": "toolu_01AbC..."}
+```
+
+Approval decision as it returns in the next request's history (after ingress folding,
+`messages.py:174-181`):
+
+```json
+{"type": "tool_result", "tool_call_id": "toolu_01AbC...",
+ "tool_name": "mcp__agenta-tools__create_subscription",
+ "output": {"approved": true}}
+```

--- a/docs/design/parallel-approval-gates/options.md
+++ b/docs/design/parallel-approval-gates/options.md
@@ -140,12 +140,16 @@ is thrown away.
    Measure with the existing `[HITL]` logs (`acp-interactions.ts:170-187`,
    `stream.py:486-494`).
 
-## Independent flag (out of scope, worth a follow-up issue)
+## Independent flag (pulled into this PR on Mahmoud's review)
 
 The frontend pattern of force-settling any unsettled part with a synthetic error
 (`UnhandledClientTool.tsx:17-21`) manufactures history that the model later trusts as
 a real tool failure. After Option A, only genuinely unknown client tools reach it,
 which is its intended job. Still, the settle text lies about agency ("this app can't
-handle X" for things that are not client requests). A follow-up could settle with a
-neutral "not handled by this client" and render it as informational, without any
-tool-name special-casing. Not part of this plan.
+handle X" for things that are not client requests). The fix: settle with a neutral
+"not handled by this client" output and render it as informational, without any
+tool-name special-casing. Mahmoud asked for this in this PR ("let's do that in this
+pr already"), so it ships here: the settle is now the structured output
+`{status: "not_handled", ...}` and `ToolActivity` renders that shape (and the
+runner's `DEFERRED_NOT_EXECUTED:` sentinel on deferred siblings) muted, not red.
+Both branches key on structured shape, never a tool name.

--- a/docs/design/parallel-approval-gates/options.md
+++ b/docs/design/parallel-approval-gates/options.md
@@ -1,0 +1,151 @@
+# Options and recommendation
+
+Both options fix the same root cause: the latch loser leaves an announced tool call
+with no terminal state, and no layer downstream can tell the difference between "the
+server is still working on it" and "the server abandoned it". The fix in both cases is
+that the runner, at pause time, gives every announced call a truthful state before it
+kills the session. Neither option touches the frontend's classifier or adds tool-name
+lists anywhere.
+
+## Option A: settle the losing sibling deterministically
+
+### Mechanism
+
+At `pause()` time, before `destroySession`, scan the run's event log
+(`run.events()`, `otel.ts:1337`) for every `tool_call` id that has no matching
+`tool_result` and is not the paused call (`pause.isPausedToolCall`). For each, emit:
+
+```json
+{"type": "tool_result", "id": "<toolCallId>", "isError": true,
+ "output": "Not executed: the turn paused for approval of another tool call. Call the tool again if it is still needed."}
+```
+
+and close its open tool span. The natural home is a small method on the otel run
+handle (it owns both the event log and `toolSpans`), for example
+`run.settleOpenToolCalls(excludeIds, message)`, called from the pause controller's
+destroy callback in `sandbox_agent.ts:710-715`. That seam covers every pause path
+(ACP gate, Pi relay, client tool) with one hook.
+
+This also fixes a wider case than the incident: ANY in-flight sibling call at pause
+time (gated or not, for example a read tool mid-execution) is killed by the teardown
+and currently orphans a part the FE then fake-fails. Option A settles all of them.
+
+### Effects
+
+- Frontend: part B settles as `output-error` with server text. The classifier never
+  parks it (`meta.ts:64` requires unsettled), `UnhandledClientTool` never mounts, no
+  fabricated error. Zero FE changes.
+- Model: on resume, the transcript shows the deterministic error
+  (`transcript.ts:53-55`); the model retries the tool; the user approves it second.
+  Sequential approvals stay: same round-trip count as today, honest states.
+- Wire contract: no new fields. Reuses the existing `tool_result` event and
+  `tool-output-error` part. Golden fixtures unaffected.
+- F-040: unchanged. Still no reply to any harness gate.
+
+### Complexity and risk: SMALL
+
+One helper plus wiring, runner-only, fully unit-testable with the existing fake
+session in `sandbox-agent-orchestration.test.ts` (which already drives real pause
+wiring, see its F-040 cases). Risks are minor: the error text becomes model-visible
+prompt material (keep it short, stable, and directive), and the tool chip shows an
+error state for something that is not the user's fault (copy can soften this; the
+part-level UI treatment is a FE nicety, not a name list).
+
+## Option B: batch all pending approvals into one pause
+
+### The key research results (from research.md)
+
+1. **You cannot collect gates by waiting.** The CLI serializes write tools; gate B is
+   only raised after gate A resolves, which under F-040 means only inside the teardown
+   race (§3). Batching must synthesize the sibling's approval from the runner's own
+   record of the announced call, not from the ACP wire.
+2. **ACP teardown handles N unanswered gates already.** The daemon holds pending
+   permissions in a map and cancels all of them on session destroy
+   (`chunk-TVCDKGSM.js:2215-2265`). No protocol obstacle.
+3. **Our wire and client already support N approvals per message.** Multiple
+   `tool-approval-request` parts are valid; the AI SDK flips each matching part
+   independently (`ai dist:4775-4781`); the dock renders a queue with "1 of N" and
+   "Approve all" (`ApprovalDock.tsx:35-47, 119-155`); the resume predicate holds the
+   auto-resend until no gate is pending
+   (`agentApprovalResume.ts:108-138`). All pre-built.
+4. **Cold replay already consumes N decisions.** `extractApprovalDecisions` maps every
+   `{approved}` envelope by name+args; each re-raised gate on replay is answered
+   silently (`responder.ts:247-332`). So Mahmoud's hunch is right: batching is mostly
+   about RECORDING all pending gates before teardown, not about holding sessions open.
+
+### Mechanism
+
+At `pause()` time, for each unresolved sibling `tool_call`:
+
+1. Build a `GateDescriptor` from the recorded name and args (the same derivation
+   `buildGateDescriptor` uses, including the `mcp__<server>__` server-permission
+   parse, `acp-interactions.ts:238-275`).
+2. Run `decide()`:
+   - `pendingApproval` AND recorded args are trustworthy (non-empty, refreshed by the
+     full-message `tool_call_update`): emit a synthetic
+     `interaction_request` (kind `user_approval`, same payload shape as the Pi relay
+     emission at `sandbox_agent.ts:777-792`), mark the id paused (suppresses teardown
+     frames), and record the durable interaction.
+   - anything else (verdict `allow`/`deny`, or args untrusted): fall back to
+     Option A's deterministic settle.
+3. Teardown as today. On resume, the history carries N approval envelopes; replay
+   answers each re-raised gate; one round-trip total.
+
+### Effects
+
+- User: one approval interaction ("1 of 2" in the dock, or Approve all), one resume,
+  both tools run. This is the actual UX win.
+- Model: the replayed transcript shows both calls with `[... returned:
+  {"approved":true}]`; the model re-issues both. If it re-issues with different args,
+  the key misses and that gate re-pauses: graceful degradation to today's flow.
+- Wire contract: still no new fields.
+- F-040: unchanged. The synthetic gate is a runner-side event, not a harness reply.
+
+### Complexity and risk: MEDIUM
+
+Runner-only code again, but more of it, and two real risks:
+
+1. **Args fidelity.** The sibling's real args ride a `tool_call_update` whose delivery
+   races the pause (§4 of research.md; the incident lost that race). Without the
+   refresh, Option B degrades to Option A for that call. A small pre-teardown drain
+   (flush the ACP event stream for a bounded window, ~100-250ms, before
+   `destroySession`) would make the refresh win almost always. That drain is the one
+   genuinely new moving part and needs care (it must not delay pause on a dead
+   daemon).
+2. **Approving a call the harness never asked about.** The synthetic gate asserts
+   "this tool will run if you approve". That promise holds because replay re-raises
+   the gate and the stored decision only matches the same name+args. A mismatch never
+   silently authorizes something else; it re-prompts. Worst case equals today.
+
+Also needs: a multi-approval e2e pass (dock queue, Approve all, deny-one-approve-one),
+and a decision on ordering (emit the harness gate's part first so the dock asks about
+the call the model attempted first).
+
+## A is a stepping stone to B
+
+They are not alternatives; B contains A. B's fallback path for untrusted args and for
+non-gated in-flight siblings IS Option A. Shipping A first fixes the phantom failure
+immediately with small risk; B then upgrades trusted gated siblings from
+"deferred error + retry + second prompt" to "batched approval + one prompt". No A code
+is thrown away.
+
+## Recommendation
+
+1. **Ship Option A now.** It removes the fabricated failure, gives every part a
+   truthful state, changes no contracts, and is small enough to land with unit tests
+   in one slice.
+2. **Ship Option B as a follow-up slice on top of A**, in two steps: first the
+   synthetic sibling gates (with the args-trust guard, no drain), then the
+   pre-teardown drain if real-world runs show the args refresh losing the race often.
+   Measure with the existing `[HITL]` logs (`acp-interactions.ts:170-187`,
+   `stream.py:486-494`).
+
+## Independent flag (out of scope, worth a follow-up issue)
+
+The frontend pattern of force-settling any unsettled part with a synthetic error
+(`UnhandledClientTool.tsx:17-21`) manufactures history that the model later trusts as
+a real tool failure. After Option A, only genuinely unknown client tools reach it,
+which is its intended job. Still, the settle text lies about agency ("this app can't
+handle X" for things that are not client requests). A follow-up could settle with a
+neutral "not handled by this client" and render it as informational, without any
+tool-name special-casing. Not part of this plan.

--- a/docs/design/parallel-approval-gates/phantom-execution-findings.md
+++ b/docs/design/parallel-approval-gates/phantom-execution-findings.md
@@ -195,3 +195,35 @@ per-turn transcript is where the contradiction lives, so fix it there.
 - Pi relay path: Pi folds the same `{approved}` envelope through the same transcript.
   The relay answers gates differently, but the phantom-success reading of the replay
   applies there too; verify once on Pi.
+
+## Hotfix round (2026-07-06, live testing of the first fix)
+
+Live testing of the honest-replay fix surfaced an approval LOOP, the args-drift open
+question above made real. The model re-issued `commit_revision` but copied the args off
+the flattened text transcript, re-serializing the object-valued `workflow_revision` as a
+JSON string. The exact-args key missed, the runner raised a NEW gate, and every resume
+added one more stale "NOT run yet, call it again NOW" envelope (approval-responded parts
+never leave that state and re-fold on each request), so the loop compounded: approve →
+resume → re-issue with drifted args → new gate → approve again.
+
+Two fixes landed on the same lane:
+
+- **Tolerant canonicalization (`responder.ts`):** `canonicalJson` now runs a
+  `normalizeJsonish` pre-pass — any string value that parses as a JSON object/array is
+  replaced by the parsed value, recursively, before the key-order-insensitive stable
+  stringify. Both sides (history extraction and live gates) share the path, so
+  `{"workflow_revision": "{\"delta\":…}"}` and `{"workflow_revision": {"delta":…}}`
+  produce the same key. No name-only fallback: semantically different args still miss.
+- **Smart envelope rendering (`transcript.ts`):** a pre-pass (`approvalRenderHints`)
+  over the whole prior history classifies each allow-envelope: rendered as
+  `[user APPROVED T; executed below]` when a later real (non-envelope) result for the
+  same tool exists (tool-name approximation, rendering only); the "call it again NOW"
+  nudge only on the LAST unresolved envelope per tool; older unresolved duplicates as a
+  neutral `[user approved T earlier.]`. Deny rendering unchanged.
+
+Verified live (claude/sonnet, self_managed sidecar): one approval, one re-issue, gate
+`outcome=allow` from the stored decision, revision v3 landed, and the next turn replayed
+without a nudge (plain answer, no gate). Unit-pinned in `responder.test.ts` (JSON-string
+drift matches, different args still miss, end-to-end `ConversationDecisions.take`) and
+`transcript.test.ts` (executed-below, single-nudge, cross-tool isolation, deny
+unchanged).

--- a/docs/design/parallel-approval-gates/phantom-execution-findings.md
+++ b/docs/design/parallel-approval-gates/phantom-execution-findings.md
@@ -1,0 +1,197 @@
+# Phantom execution: approved tool calls that never run
+
+Third finding in the playground approval saga. Read-only investigation, 2026-07-06.
+Companions: `docs/design/agent-workflows/scratch/approval-turn-duplication-findings.md`
+and `docs/design/parallel-approval-gates/research.md`.
+
+## Symptom
+
+Session with harness `claude`, runner `sidecar`. The model called the gated platform
+tools `mcp__agenta-tools__commit_revision` and later `create_subscription`. The user
+approved each one in the UI. After resume, the model said "The agent revision is
+already saved with those values" and later "The subscription is active now." It never
+visibly re-issued `commit_revision`. In reality, no revision commit exists and no
+subscription exists. The user approved, the UI showed approved, the agent claimed
+done, and nothing ran.
+
+## How execution is supposed to happen (the path as it actually is)
+
+The key fact first: **the runner never executes an approved call itself.** Approval
+resume works only if the model re-issues the same tool call on the fresh session. The
+stored approval then answers the re-raised permission gate. If the model does not
+re-issue the call, the approval sits unconsumed and nothing executes. There is no
+proactive execution path anywhere in the runner.
+
+Step by step:
+
+1. Turn 1: the model calls the gated tool. The ACP gate reaches
+   `attachPermissionResponder` (`services/runner/src/engines/sandbox_agent/acp-interactions.ts:204-214`).
+   No stored decision exists, so `decide()` returns `pendingApproval`
+   (`services/runner/src/permission-plan.ts:138-151`). The runner emits an
+   `interaction_request`, never replies to the gate, and destroys the session
+   (F-040 pause, `services/runner/src/engines/sandbox_agent/pause.ts:22-27`,
+   `acp-interactions.ts:73-95`).
+2. The user approves. The AI SDK flips the tool part to `state: "approval-responded"`
+   with `approval: {approved: true}` and auto-resends the FULL history as a new POST
+   (`web/packages/agenta-playground/src/state/execution/agentApprovalResume.ts:108-138`).
+3. SDK ingress folds that part into TWO content blocks: a `tool_call` block (name +
+   input, `sdks/python/agenta/sdk/agents/adapters/vercel/messages.py:119-127`) and a
+   `tool_result` block whose output is the envelope `{"approved": true}`
+   (`messages.py:151-181`, emit at 174-181). Note: the decision becomes a
+   **tool_result on the same toolCallId**, indistinguishable downstream from a real
+   tool output except by its shape.
+4. The runner builds the decision store from the inbound history:
+   `extractApprovalDecisions` (`services/runner/src/responder.ts:247-259`) finds every
+   `tool_result` whose output is an `{approved: boolean}` envelope
+   (`approvalDecisionOf`, `responder.ts:344-358`), recovers name + args from the
+   matching `tool_call` block (`coldReplayKey`, `responder.ts:322-332`), and keys it by
+   `approvedCallKey(name, args)` (`responder.ts:65-76`). Wired at
+   `services/runner/src/engines/sandbox_agent.ts:731-744`.
+5. The runner cold-starts a fresh sandbox and replays prior turns as flattened text:
+   `buildTurnText` (`services/runner/src/engines/sandbox_agent/transcript.ts:69-81`)
+   over `messageTranscript` (`transcript.ts:43-63`). The stored decisions are NOT used
+   here. They wait, passively, for a live gate.
+6. **Only if** the model re-issues the same call: the harness raises a new gate,
+   `decide()` consults the store (`permission-plan.ts:147-149`,
+   `ConversationDecisions.take` at `responder.ts:148-155`), gets `allow`, and
+   `replyPermission` answers the gate with `"once"`
+   (`acp-interactions.ts:123-141`, reply mapping `responder.ts:370-378`).
+7. Claude then executes the MCP tool for real: `tools/call` to the internal loopback
+   MCP server (`services/runner/src/tools/tool-mcp-http.ts:152-234`) →
+   `runResolvedTool` (`services/runner/src/tools/dispatch.ts:224-273`) → file relay
+   (`dispatch.ts:66-111`) → relay loop (`services/runner/src/tools/relay.ts:463-513`)
+   → `callAgentaTool` POST to Agenta's `/tools/call` (`relay.ts:305`). Failures come
+   back as MCP `isError` results the model can see (`tool-mcp-http.ts:219-234`).
+
+Step 6 never happened in this session. The model skipped the re-issue, so the chain
+stopped at step 5.
+
+## What the model sees on replay (the root cause)
+
+`messageTranscript` renders content blocks like this (`transcript.ts:51-55`):
+
+- `tool_call` → `[called mcp__agenta-tools__commit_revision({"name":"...","parameters":{...}})]`
+- `tool_result` → `[mcp__agenta-tools__commit_revision returned: {"approved":true}]`
+
+So the approved-but-never-executed call appears in the replayed transcript as:
+
+```
+assistant: ...reasoning text... [called mcp__agenta-tools__commit_revision({...args...})]
+[mcp__agenta-tools__commit_revision returned: {"approved":true}]
+```
+
+That reads as a **completed call with a successful-looking result**. `"approved":
+true` looks like a success payload. Nothing says "this call has not run yet" or
+"re-issue this call to execute it." The whole resume design depends on the model
+re-issuing the call, and `research.md` section 6 states that assumption outright
+("The model re-issues the approved call"), but the transcript actively tells the model
+the opposite. So the model reasonably answers "the revision is already saved" and
+moves on. The stored decision is never consumed. Nothing executes. Phantom success.
+
+Two aggravators make it worse:
+
+- **The approval envelope re-folds forever.** The FE part stays
+  `approval-responded` (no output ever arrives to flip it), so every later request
+  re-emits the same `{approved: true}` result into history and the transcript. The
+  claim of completion compounds each turn.
+- **The duplicate-turn bug (finding 1) multiplies the evidence.** Each resume clones
+  the whole assistant turn into a new message, so the replay can contain the same
+  `[called ...] [... returned: {"approved":true}]` pair several times. Several
+  "records" of the call makes "it already ran" even more plausible to the model.
+
+## The create_subscription case (secondary check)
+
+The transcript sequence fits the same cause, twice over:
+
+1. Turn 1: both tools gated in parallel. `commit_revision` wins the pause latch;
+   `create_subscription` is dropped (`acp-interactions.ts:78`) and the FE later
+   force-settles it with the fake error `This app can't handle the
+   "mcp__agenta-tools__create_subscription" request.` (finding 2).
+2. Resume 1: the replay shows `commit_revision` "returned {approved:true}" (never
+   re-issued, phantom no. 1) and `create_subscription` with a real error result. The
+   model retries `create_subscription` because the error is the one honest signal in
+   the transcript. New live gate, no stored decision for it, second approval prompt.
+   This is why the re-issue happened for this tool only: an error result reads as
+   "not done," an `{approved:true}` result reads as "done."
+3. Resume 2: history now holds `create_subscription` in `approval-responded`. Replay
+   renders `[mcp__agenta-tools__create_subscription returned: {"approved":true}]`.
+   Same trap: the model treats it as executed and says "The subscription is active
+   now." Phantom no. 2. No third gate ever fired, so the stored decision was never
+   consumed and `/tools/call` was never hit.
+
+Had the model re-issued after resume 2, the path in step 6-7 above is sound: the gate
+answers `"once"` from the store and Claude executes the MCP call over the live
+loopback server; an API failure would surface as an `isError` tool result the model
+sees. The only known answered-but-lost gap is the documented pause race: on
+pause/teardown the abort signal destroys in-flight MCP sockets while a dispatched
+`runResolvedTool` keeps running server-side and its result is dropped
+(`tool-mcp-http.ts:66-72` and `381-394`). That produces the inverse bug (executed but
+unreported), not this one, and there is no transcript evidence it fired here.
+
+## Failure mode classification
+
+- **(a) Model assumes success from the replay, never re-issues, decision never
+  consumed.** Likelihood: near certain, for both tools. The transcript quotes match
+  exactly what a model would say after reading `returned: {"approved":true}`
+  ("already saved," "active now"), the model never re-issued `commit_revision` at
+  all, and the code shows no other execution path exists.
+- **(b) Gate answered but execution lost.** Likelihood: very low here. It requires
+  the model to re-issue (it did not for `commit_revision`), and a re-issued call
+  either executes or returns a visible `isError` result. The pause-race result-drop
+  exists but produces executed-but-unreported, the opposite symptom.
+- **(c) Executed but side effect landed elsewhere.** Likelihood: very low. The relay
+  binds the call to the run's own callback endpoint and auth (`relay.ts:280-307`); a
+  wrong-target write would still leave SOME commit or subscription, and none exists.
+
+## Fix directions
+
+Where the fix lives, by layer, roughly in order of value:
+
+1. **Render the approval envelope honestly in the replay transcript** (runner,
+   small). In `messageTranscript` (`transcript.ts:53-55`), detect the
+   `{approved: boolean}` envelope (reuse the shape test in `approvalDecisionOf`,
+   `responder.ts:344-358`) and render something like
+   `[user APPROVED mcp__agenta-tools__commit_revision({...args}); the call has NOT
+   run yet. Call the tool again with the same arguments to execute it.]` and the
+   deny twin for `approved: false`. One file plus a helper export and unit tests.
+   Risk: a real tool whose genuine output is `{approved: true}` would be
+   misrendered; the shape is narrow and the same ambiguity already exists in
+   `extractApprovalDecisions`, so this adds no new confusion.
+2. **Nudge the model in the turn text** (runner, small-medium). `buildTurnText`
+   (`transcript.ts:69-81`) can append an explicit list: approved calls that have no
+   real (non-envelope) `tool_result`, told to the model as "approved and pending
+   execution, re-issue now." The runner already computes exactly this set
+   (`extractApprovalDecisions` keys). Belt to fix 1's suspenders; makes the re-issue
+   an instruction, not an inference.
+3. **Proactive execution at resume** (runner, large). Execute each approved call
+   directly from history before or instead of waiting for a re-issue, then inject a
+   synthetic real `tool_result` into the stream and history. Removes the dependence
+   on model cooperation entirely, but changes the HITL contract: the runner must
+   resolve the spec, run `/tools/call`, emit egress frames for a call the live
+   harness never made, and reconcile if the model re-issues anyway (double
+   execution risk). Needs a design pass; do not rush this one.
+4. **Distinguish the envelope on the wire** (SDK + runner, medium). Instead of
+   folding the decision as a plain `tool_result` (`messages.py:174-181`), mark it
+   (a distinct block type or a flag). Downstream consumers (transcript,
+   `extractApprovalDecisions`) then match on the marker, not on the output shape.
+   Touches `protocol.ts`, `wire.py`, and the golden contract fixtures.
+5. **Detection/telemetry** (runner, small). Log when a turn ends with stored
+   decisions never taken (`ConversationDecisions` knows). Turns future phantoms
+   into a greppable `[HITL]` line instead of a user report.
+
+Model-instruction-only fixes (system prompt text) are not enough on their own; the
+per-turn transcript is where the contradiction lives, so fix it there.
+
+## Open questions
+
+- Does Claude reliably re-issue after fix 1 or 2, or does it sometimes ask the user
+  instead? Needs a live QA cell on the approval matrix.
+- Args drift: the stored key is `approvedCallKey(name, args)`. If the re-issued call
+  varies its args even slightly (or the FE persisted `{}` input, as finding 2 saw for
+  the dropped sibling), the decision misses and the user gets re-prompted. Safe but
+  annoying; worth a `[HITL]` log when a re-issued gate near-misses a stored key.
+- Should fix 1 also cap or dedupe the replay when the duplicate-turn bug (finding 1)
+  has cloned the same call several times, or do we rely on that bug's own fix?
+- Pi relay path: Pi folds the same `{approved}` envelope through the same transcript.
+  The relay answers gates differently, but the phantom-success reading of the replay
+  applies there too; verify once on Pi.

--- a/docs/design/parallel-approval-gates/plan.md
+++ b/docs/design/parallel-approval-gates/plan.md
@@ -1,55 +1,92 @@
 # Implementation plan
 
-Phased so each slice lands green on its own. Phase 1 is Option A; Phases 2-3 are
-Option B layered on top. Recommendation and rationale: [options.md](options.md).
+Phased so each slice lands green on its own. Phase 1 is Option A (IMPLEMENTED in this
+PR, together with three companions the review pass pulled in: the FIFO decision store,
+the honest replay transcript, and the FE neutral rendering); Phases 2-3 are Option B
+layered on top (follow-up). Recommendation and rationale: [options.md](options.md).
 
-## Phase 1: deterministic settle for latch losers (Option A)
+## Phase 1: deterministic settle for latch losers (Option A) — IMPLEMENTED
 
-### Code
+### Code (as landed)
 
 1. `services/runner/src/tracing/otel.ts`
-   - Add `settleOpenToolCalls(excludeIds: ReadonlySet<string>, message: string)` to the
-     run handle (near `maybeCloseTool`, `otel.ts:1202-1224`). It walks the recorded
-     events (`otel.ts:904`), finds `tool_call` ids with no `tool_result`, and for each:
-     ends the open span with error status and records
-     `{type: "tool_result", id, isError: true, output: message}`.
-   - Export the message as a named constant so tests and the transcript stay stable,
-     for example `TOOL_NOT_EXECUTED_PAUSED = "Not executed: the turn paused for
-     approval of another tool call. Call the tool again if it is still needed."`.
+   - `settleOpenToolCalls(isExcluded: (id: string) => boolean, message: string)` on the
+     run handle. It sweeps the open-tool-call map (`toolSpans`, which holds exactly the
+     announced calls with no terminal result), skips excluded ids, ends each open span
+     with error status, and records
+     `{type: "tool_result", id, isError: true, output: message}` through the shared
+     `record()` choke point (live sink + batch log). Idempotent: a settled id leaves the
+     map, so a second sweep is a no-op for it.
+   - The message is the exported constant `TOOL_NOT_EXECUTED_PAUSED =
+     "DEFERRED_NOT_EXECUTED: paused for another approval; retry the same call if still
+     required."`. The stable `DEFERRED_NOT_EXECUTED:` prefix is the structured sentinel
+     the frontend keys its muted rendering on (shape, not tool name), and the sentence
+     doubles as the model-visible retry instruction on replay.
 2. `services/runner/src/engines/sandbox_agent.ts`
-   - In the pause controller's destroy callback (`sandbox_agent.ts:710-715`), call
-     `run.settleOpenToolCalls(pause.pausedToolCallIds, ...)` before `mcpAbort.abort()`
-     and `destroySession`. Expose the paused-id set from
-     `PendingApprovalPauseController` (today it is private, `pause.ts:11`).
-   - Ordering note: `pause()` runs synchronously before the prompt race resolves
-     (`sandbox_agent.ts:858-871`), so the synthetic `tool_result` events reach the
-     live sink before the egress emits `finish`.
+   - The pause controller's destroy callback calls
+     `run.settleOpenToolCalls((id) => pause.isPausedToolCall(id), TOOL_NOT_EXECUTED_PAUSED)`
+     first, before `mcpAbort.abort()` and `destroySession`. The paused-id set stays
+     private in `PendingApprovalPauseController`; the sweep receives only the existing
+     narrow membership predicate (`isPausedToolCall`), per the review note that the
+     mutable set must not leak.
+   - Ordering (verified in the live-sink test): `interaction_request` first (it is
+     emitted before `pause()` runs), then the sibling's `tool_result` from the sweep,
+     then `done`. The client always holds the sibling's terminal state before the turn
+     finishes.
+3. `services/runner/src/responder.ts` (companion fix, was a review finding)
+   - `extractApprovalDecisions` and `ConversationDecisions.take()` now keep a FIFO list
+     per `approvedCallKey`, mirroring the client-tool output store next to them. Two
+     IDENTICAL gated calls (same tool, same canonical args) no longer collapse to one
+     stored decision; each re-raised gate consumes the next decision in order.
+4. `services/runner/src/engines/sandbox_agent/transcript.ts` (companion fix, from
+   [phantom-execution-findings.md](phantom-execution-findings.md))
+   - `messageTranscript` renders an `{approved: boolean}` envelope honestly:
+     approved-but-not-executed calls replay as "user APPROVED <tool>; the call has NOT
+     run yet. Call the tool again..." instead of `returned: {"approved":true}`, so the
+     model re-issues instead of claiming phantom success. Shape detection reuses the
+     now-exported `approvalDecisionOf` from `responder.ts`.
 
-No SDK, wire, or frontend change. The egress already maps `tool_result{isError}` to
+No SDK or wire change. The egress already maps `tool_result{isError}` to
 `tool-output-error` (`stream.py:376-381`), and a settled part never enters the FE's
-parked-unknown path (`meta.ts:64`).
+parked-unknown path (`meta.ts:64`). The frontend change in this PR (see "Frontend
+neutral settle" below) is presentation-only.
 
-### Tests
+### Frontend neutral settle (pulled into this PR per Mahmoud's options.md comment)
 
-- `services/runner/tests/unit/sandbox-agent-orchestration.test.ts`: extend the real
-  pause-wiring block (it already drives F-040 cases around lines 869-1093) with a fake
-  session that announces two gated tool calls and raises two permission requests. When
-  the run returns: `stopReason === "paused"`, exactly one `interaction_request`, and a
-  synthetic `tool_result` for the loser with the constant message; the paused id has
-  none.
-- `services/runner/tests/unit/stream-events.test.ts`: the live-sink ordering (the
-  loser's `tool_result` precedes `done`).
-- New unit for `settleOpenToolCalls` (span closed, idempotent, excludes paused ids;
-  place next to the otel tests).
-- Run `pnpm test` and `pnpm run typecheck` in `services/runner`.
+- `web/oss/src/components/AgentChatSlice/components/clientTools/UnhandledClientTool.tsx`:
+  a genuinely unhandled client tool now settles with a neutral output
+  (`{status: "not_handled", ...}`), not a fabricated error, and renders informational.
+- `web/oss/src/components/AgentChatSlice/components/ToolActivity.tsx`: two settled
+  shapes render muted/informational instead of red "failed": an `output-error` whose
+  `errorText` starts with the `DEFERRED_NOT_EXECUTED:` sentinel ("waiting on another
+  approval", clock icon), and an `output-available` whose output is the
+  `{status: "not_handled"}` shape. Both branch on structured shape; there is no
+  tool-name list anywhere (the hard constraint holds).
+
+### Tests (as landed)
+
+- `sandbox-agent-orchestration.test.ts`: the primary serialized-write regression (two
+  announced calls, one gate, pause -> exactly one `interaction_request` for the winner
+  and one deterministic `tool_result` for the sibling, none for the winner); the
+  read-only concurrent-gates race (both gates arrive, latch drops one, sweep settles
+  it); the live-sink ordering test (sibling result before `done`).
+- `stream-events.test.ts`: `settleOpenToolCalls` exclusion + idempotency at the otel
+  level.
+- `responder.test.ts`: duplicate identical approvals stay FIFO (two takes succeed, the
+  third returns undefined).
+- `transcript.test.ts`: approval envelopes render as APPROVED/DENIED + not-run text;
+  genuine tool results keep the original rendering.
+- Run `pnpm test` and `pnpm run typecheck` in `services/runner`; `pnpm lint-fix` in
+  `web`.
 
 ### Verification on the live stack
 
 Reproduce the incident: agent playground, harness `claude`, prompt that calls
 `commit_revision` and `create_subscription` in one turn (the incident prompt works).
-Expect: gate for A, honest "Not executed" state on B, no "can't handle" text anywhere,
-second gate after approving A, both tools run. Use the `[HITL]` log lines to confirm
-gate B arrived and was dropped post-settle.
+Expect: gate for A, muted "waiting on another approval" state on B, no "can't handle"
+text anywhere, second gate after approving A, both tools run AND their side effects
+actually exist server-side (the phantom-execution check). Use the `[HITL]` log lines to
+confirm gate B arrived and was dropped post-settle.
 
 ## Phase 2: synthetic sibling gates (Option B, no drain)
 

--- a/docs/design/parallel-approval-gates/plan.md
+++ b/docs/design/parallel-approval-gates/plan.md
@@ -1,0 +1,142 @@
+# Implementation plan
+
+Phased so each slice lands green on its own. Phase 1 is Option A; Phases 2-3 are
+Option B layered on top. Recommendation and rationale: [options.md](options.md).
+
+## Phase 1: deterministic settle for latch losers (Option A)
+
+### Code
+
+1. `services/runner/src/tracing/otel.ts`
+   - Add `settleOpenToolCalls(excludeIds: ReadonlySet<string>, message: string)` to the
+     run handle (near `maybeCloseTool`, `otel.ts:1202-1224`). It walks the recorded
+     events (`otel.ts:904`), finds `tool_call` ids with no `tool_result`, and for each:
+     ends the open span with error status and records
+     `{type: "tool_result", id, isError: true, output: message}`.
+   - Export the message as a named constant so tests and the transcript stay stable,
+     for example `TOOL_NOT_EXECUTED_PAUSED = "Not executed: the turn paused for
+     approval of another tool call. Call the tool again if it is still needed."`.
+2. `services/runner/src/engines/sandbox_agent.ts`
+   - In the pause controller's destroy callback (`sandbox_agent.ts:710-715`), call
+     `run.settleOpenToolCalls(pause.pausedToolCallIds, ...)` before `mcpAbort.abort()`
+     and `destroySession`. Expose the paused-id set from
+     `PendingApprovalPauseController` (today it is private, `pause.ts:11`).
+   - Ordering note: `pause()` runs synchronously before the prompt race resolves
+     (`sandbox_agent.ts:858-871`), so the synthetic `tool_result` events reach the
+     live sink before the egress emits `finish`.
+
+No SDK, wire, or frontend change. The egress already maps `tool_result{isError}` to
+`tool-output-error` (`stream.py:376-381`), and a settled part never enters the FE's
+parked-unknown path (`meta.ts:64`).
+
+### Tests
+
+- `services/runner/tests/unit/sandbox-agent-orchestration.test.ts`: extend the real
+  pause-wiring block (it already drives F-040 cases around lines 869-1093) with a fake
+  session that announces two gated tool calls and raises two permission requests. When
+  the run returns: `stopReason === "paused"`, exactly one `interaction_request`, and a
+  synthetic `tool_result` for the loser with the constant message; the paused id has
+  none.
+- `services/runner/tests/unit/stream-events.test.ts`: the live-sink ordering (the
+  loser's `tool_result` precedes `done`).
+- New unit for `settleOpenToolCalls` (span closed, idempotent, excludes paused ids;
+  place next to the otel tests).
+- Run `pnpm test` and `pnpm run typecheck` in `services/runner`.
+
+### Verification on the live stack
+
+Reproduce the incident: agent playground, harness `claude`, prompt that calls
+`commit_revision` and `create_subscription` in one turn (the incident prompt works).
+Expect: gate for A, honest "Not executed" state on B, no "can't handle" text anywhere,
+second gate after approving A, both tools run. Use the `[HITL]` log lines to confirm
+gate B arrived and was dropped post-settle.
+
+## Phase 2: synthetic sibling gates (Option B, no drain)
+
+### Code
+
+1. `services/runner/src/engines/sandbox_agent.ts` (or a new
+   `engines/sandbox_agent/pause-batch.ts`): at pause time, before the Phase 1 settle,
+   walk unresolved sibling `tool_call`s and for each:
+   - build a `GateDescriptor` (share the derivation with
+     `buildGateDescriptor`, `acp-interactions.ts:238-275`; export it or lift it to a
+     shared module),
+   - if `decide()` (`permission-plan.ts:138-151`) returns `pendingApproval` AND the
+     recorded input passes the trust check (non-empty object; refreshed at least once
+     via `tool_call_update`, which Phase 2 must start tracking on the run handle),
+     emit the synthetic `interaction_request` (payload shape of
+     `sandbox_agent.ts:777-792`, `availableReplies: ["once","reject"]`,
+     `resolvedName` stamped), `pause.markPausedToolCall(id)`, and
+     `recordPendingInteraction(...)`,
+   - otherwise leave it for the Phase 1 settle sweep.
+2. Keep the latch semantics for harness-raised gates untouched; the batch emission
+   runs once inside the pause path, guarded by the controller's `pendingApproval`
+   flag (`pause.ts:22-27`).
+
+### Tests
+
+- Orchestration test: two announced gated calls with real args -> two
+  `interaction_request` events, no synthetic `tool_result` for the second call; with
+  empty args on the second call -> one `interaction_request` plus the deferred
+  `tool_result` (fallback).
+- `responder.test.ts` already covers multi-key decision extraction; add a case with
+  two `{approved}` envelopes bound via `buildCallShapeIndex`.
+- Frontend: `web/packages/agenta-playground/tests/unit/agentApprovalResume.test.ts`
+  gets a two-pending-gates case (approve one -> no resume; approve both -> resume).
+  The dock queue and Approve all need a manual pass (no FE code change expected).
+- A replay regression test per the `agent-replay-test` skill: capture the real
+  two-gate run once Phase 2 works end to end, redact, and pin it under the QA runs
+  convention (`docs/design/agent-workflows/qa/runs/`).
+
+### Verification on the live stack
+
+Same repro. Expect: dock shows "1 of 2", Approve all leads to ONE resume and both
+tools execute, deny-one/approve-one leads to one resume where the denied tool returns
+the denial and the approved one runs.
+
+## Phase 3 (optional, data-driven): pre-teardown drain
+
+Only if Phase 2 telemetry shows the sibling args refresh frequently loses the race
+(watch `[HITL] egress approval-request ... input_keys` vs the runner's recorded args):
+delay `destroySession` by a bounded drain window (~100-250ms) that keeps consuming ACP
+events so the full-message `tool_call_update` lands. Must be bounded and must not
+delay teardown when the daemon is already gone. Skip if Phase 2 data says the race is
+rare.
+
+## Phase 4: docs sync
+
+Per the `keep-docs-in-sync` skill, in the same PRs:
+
+- Update the F-040 pause contract notes (`pause.ts` header comment and the
+  agent-workflows documentation pages that describe pause/park) with the settle sweep
+  and, after Phase 2, the batch semantics.
+- Update `docs/design/agent-workflows/scratch/approval-turn-duplication-findings.md`
+  issue-2 section to point here.
+- QA matrix: add the two-gate cell to the `agent-workflows-qa` matrix.
+
+## Open questions
+
+1. **Copy for the deferred state.** The settle text is model-visible AND user-visible.
+   Proposed: "Not executed: the turn paused for approval of another tool call. Call
+   the tool again if it is still needed." Good enough for the model; is it good
+   enough as user-facing chip copy, or should the FE render `tool-output-error` with
+   this exact constant differently? (Rendering by error TEXT is close to the
+   name-list smell; probably accept plain error styling.)
+2. **Pi relay parity.** The relayed-tool path returns `PAUSED` to the loser without
+   checking `emitted` (`relay.ts:255-263`), unlike the builtin path
+   (`relay.ts:433-446`). Pi self-announces calls through its extension, so the orphan
+   shape differs. Verify whether Pi turns show the same phantom and whether the
+   Phase 1 sweep (which is engine-level) already covers it.
+3. **Approve all ordering.** `addToolApprovalResponse` runs per part through the job
+   executor; the dock fires them in order. Confirm no double-resume when the two
+   settles interleave with a slow render (the predicate should make the first call a
+   no-op; verify in the FE unit test).
+4. **Deny semantics in a batch.** Deny A + approve B: replay answers gate A with
+   `reject`; Claude emits a failed tool_result for A and should continue to B. Confirm
+   the F-024 clobber does not resurface on the replayed turn (the stored-decision
+   reply path replies `reject` on a LIVE gate, which is allowed; only unanswered
+   human gates must never be replied to).
+5. **Read-only parallel gates.** Two `readOnlyHint: true` gated tools can raise
+   truly concurrent gates (research.md §3). The latch still picks one; Phase 2's
+   batch covers the other via the same sweep. No extra work expected; note it in the
+   orchestration test matrix.

--- a/docs/design/parallel-approval-gates/research.md
+++ b/docs/design/parallel-approval-gates/research.md
@@ -98,7 +98,8 @@ and on `pendingApproval` calls `pauseUserApproval`
   (`sandbox_agent.ts:858-871`) and the egress maps it to `finishReason: "other"`
   (`stream.py:35-40`).
 
-The loser hits the same `tryAcquire` and returns. No event, no reply, no record.
+The loser hits the same `tryAcquire` and returns. No approval interaction, no reply, and
+no terminal `tool_result` (the earlier `tool_call` announcement stays in the event log).
 That silent return is the bug.
 
 ### 2e. Teardown: every unanswered gate resolves as "cancelled"
@@ -184,7 +185,11 @@ indexes every such envelope by `approvedCallKey(name, args)` (name + canonical a
 recovered from the matching `tool_call` block by id):
 `extractApprovalDecisions` at `services/runner/src/responder.ts:247-259`,
 `coldReplayKey` at 322-332, key shape at 65-76. **The store is a Map. It already holds
-any number of decisions per turn.**
+any number of decisions per turn** — for distinct calls. Two IDENTICAL calls (same tool,
+same canonical args) collapse to one key, so the second stored approval used to overwrite
+the first and only one re-raised gate got answered from history. Fixed in this PR: the
+store keeps a FIFO list per key (mirroring the client-tool output store right below it),
+so each identical re-raised gate consumes the next stored decision in order.
 
 The resumed run cold-starts a fresh sandbox and replays prior turns as flattened text
 (`services/runner/src/engines/sandbox_agent/transcript.ts:43-81`; an approval envelope

--- a/docs/design/parallel-approval-gates/research.md
+++ b/docs/design/parallel-approval-gates/research.md
@@ -1,0 +1,264 @@
+# Research: what actually happens when one turn raises two approval gates
+
+Everything below was verified against source on 2026-07-06. Paths are relative to the
+repo root. Vendored package paths are under `services/runner/node_modules/` and
+`web/node_modules/`. This doc corrects the earlier findings doc in one place; see
+"Corrections" at the bottom.
+
+## 1. The layers
+
+```
+Claude model (API)
+  └─ claude CLI  (cli.js, spawned by the Claude Agent SDK inside the sandbox)
+      └─ Claude Agent SDK 0.2.83 (stdio control protocol: can_use_tool, hooks)
+          └─ claude-agent-acp 0.23.1 (SDK messages -> ACP session updates;
+             canUseTool -> ACP session/request_permission)
+              └─ sandbox-agent daemon 0.4.2 (ACP over HTTP; holds pending permissions)
+                  └─ runner (services/runner; latch, pause, egress events)
+                      └─ SDK Vercel adapter (stream.py; events -> UI message parts)
+                          └─ playground (AI SDK v6 client + AgentChatSlice)
+```
+
+## 2. The wire trace: two gated tool calls in one turn
+
+### 2a. Announcement: both calls stream before anything executes
+
+The CLI streams the assistant message. Each `tool_use` block's `content_block_start`
+becomes an ACP `session/update` with `sessionUpdate: "tool_call"`, `status: "pending"`,
+and `rawInput` taken from the block's input at that moment
+(`@zed-industries/claude-agent-acp/dist/acp-agent.js:1500-1518`). For a streamed call
+that input is `{}`: the adapter ignores `input_json_delta` chunks entirely
+(`acp-agent.js:1576-1582`).
+
+When the complete assistant message arrives, the adapter sees each `tool_use` id again
+(`alreadyCached`) and sends `sessionUpdate: "tool_call_update"` with the real
+`rawInput` (`acp-agent.js:1484-1499`). So the real arguments normally reach the runner
+in a second frame, before execution starts.
+
+The runner records both frames: the announcement emits a `tool_call` event immediately
+(`services/runner/src/tracing/otel.ts:1147-1152`), and the update refreshes the
+recorded input when the args genuinely change (`otel.ts:1159-1183`). The egress
+projects the refresh as a repeat `tool-input-available` for the same `toolCallId`
+(`sdks/python/agenta/sdk/agents/adapters/vercel/stream.py:330-368`).
+
+### 2b. Scheduling: write tools execute one at a time
+
+This is the crux fact. The CLI groups consecutive `tool_use` blocks by
+`isConcurrencySafe` and runs them group by group (`VS8` and `nF_` in the minified
+`@anthropic-ai/claude-agent-sdk/cli.js`; found via
+`grep -o "async function\*VS8.\{1200\}" cli.js`):
+
+- A concurrency-safe group runs in parallel, capped by `MAX_TOOL_USE_CONCURRENCY`
+  (default 10).
+- An unsafe group runs strictly serially (`rF_`: `for (const block of blocks)` with an
+  awaited inner loop per tool).
+
+An MCP tool is concurrency-safe only when its `readOnlyHint` annotation is true:
+`isConcurrencySafe(){return z.annotations?.readOnlyHint??!1}` (cli.js, MCP tool
+wrapper). `commit_revision` and `create_subscription` are write tools, so they are in
+one serial group. **The CLI does not ask permission for tool B until tool A's
+permission resolves and tool A finishes.**
+
+### 2c. The gate: canUseTool becomes session/request_permission
+
+Before executing each tool, the CLI sends a `can_use_tool` control request over stdio.
+The SDK dispatches control requests fire-and-forget (`readMessages` calls
+`handleControlRequest` without awaiting, `sdk.mjs`), so the SDK layer CAN hold several
+at once; the serialization in 2b comes from the CLI's scheduler, not the protocol.
+
+`claude-agent-acp` answers `can_use_tool` by calling `client.requestPermission({...})`,
+one ACP `session/request_permission` reverse-RPC per gate
+(`acp-agent.js:697-820`, the generic path at 772-788). The request carries
+`toolCall.toolCallId` (the `tool_use` id) and `toolCall.rawInput` (the real args, from
+`canUseTool`'s `toolInput`), plus the options `allow_always` / `allow` / `reject`.
+
+The sandbox-agent daemon holds each pending gate in a Map keyed by a random
+`pendingId`, with no one-at-a-time constraint
+(`sandbox-agent/dist/chunk-TVCDKGSM.js:2215-2247`, `enqueuePermissionRequests` map at
+1098). Nothing at the ACP or daemon layer forbids concurrent unanswered gates.
+
+### 2d. The runner: one latch, first gate wins
+
+`attachPermissionResponder` handles each gate: it builds a `GateDescriptor`, asks the
+`ApprovalResponder` (`decide()` ladder in `services/runner/src/permission-plan.ts:138-151`),
+and on `pendingApproval` calls `pauseUserApproval`
+(`services/runner/src/engines/sandbox_agent/acp-interactions.ts:161-215`).
+
+`pauseUserApproval` starts with `if (!latch.tryAcquire()) return;`
+(`acp-interactions.ts:78`). The winner:
+
+- marks its tool-call id as paused (`onPausedToolCall`, so later teardown frames for
+  it are suppressed, `sandbox_agent.ts:176-187` + `pause.ts:34-41`),
+- emits the `interaction_request` event (kind `user_approval`) that the egress turns
+  into a `tool-approval-request` part (`stream.py:449-527`),
+- records a durable interaction (`sandbox_agent.ts:747-768`),
+- calls `onPause` -> `PendingApprovalPauseController.pause()`, which resolves the pause
+  signal and destroys the sandbox session (`pause.ts:22-27`,
+  `sandbox_agent.ts:710-715`). The prompt race then returns `stopReason: "paused"`
+  (`sandbox_agent.ts:858-871`) and the egress maps it to `finishReason: "other"`
+  (`stream.py:35-40`).
+
+The loser hits the same `tryAcquire` and returns. No event, no reply, no record.
+That silent return is the bug.
+
+### 2e. Teardown: every unanswered gate resolves as "cancelled"
+
+Destroying the session makes the daemon resolve every pending permission for that
+session with `cancelledPermissionResponse()`
+(`chunk-TVCDKGSM.js:2257-2265`, and again on dispose at 1189-1191). Back in
+`claude-agent-acp`, a cancelled outcome makes `canUseTool` throw `"Tool use aborted"`
+(`acp-agent.js:789-791`). The harness never sees a `reject`, which is what F-040
+requires: a reject would make Claude emit a failed `tool_result` that clobbers the
+approval part (the F-024 clobber, `acp-interactions.ts:68-72`).
+
+## 3. Answer: does the harness send two concurrent request_permission requests?
+
+**For write tools (our case): no.** The CLI serializes them (2b). Gate B is raised
+only after gate A resolves. Under F-040 the runner never answers gate A; the only
+thing that "resolves" it is the teardown cancel (2e). So gate B is raised, if at all,
+inside the teardown race window: cancel A -> CLI unblocks -> tries tool B ->
+`can_use_tool` B -> `session/request_permission` B arrives at a runner that is mid
+teardown but still has its listener attached. That is exactly what the incident shows:
+the second gate reached `handleRequest`, lost the latch, and vanished.
+
+**For read-only-annotated tools: concurrency is possible.** Two gated tools with
+`readOnlyHint: true` land in one parallel group, and their `can_use_tool` requests can
+genuinely overlap (2b, 2c). The latch drops the loser the same way.
+
+Two consequences for the design:
+
+1. The runner cannot "wait and collect all gates of the turn". For serial tools the
+   second gate does not exist until the first is answered or cancelled. Holding gate A
+   open forever just blocks the CLI.
+2. The loser's gate arrival is a race, not a guarantee. Any fix that depends on
+   receiving gate B on the wire is unreliable. The reliable inventory of sibling calls
+   is the runner's own event log: every announced `tool_call` without a `tool_result`
+   (`otel.ts:904`, `run.events()` at 1337).
+
+## 4. Why the losing call shows empty input
+
+The FE part for `create_subscription` held `input: {}`. Per 2a the `{}` comes from the
+streamed announcement, and the real args ride the later `tool_call_update`. The
+adapter's prompt loop sends session updates sequentially over stdio -> daemon -> HTTP,
+while the gate RPC travels a separate async path. In the incident the pause destroyed
+the session before the refresh for `create_subscription` was delivered, so the client
+kept `{}`. The refresh is therefore best-effort at pause time. This matters for
+Option B: you should not ask a human to approve a call whose args you do not have.
+
+## 5. What the client holds after the pause
+
+Stream received by the client (see [flows.md](flows.md) for the full sequence):
+
+- tool A: `tool-input-start`/`available`, then a refreshed `tool-input-available` with
+  real args plus `tool-approval-request` (from `_interaction_parts`,
+  `stream.py:495-526`). Part state: `approval-requested`.
+- tool B: `tool-input-start`/`available` with `{}`. Nothing else, ever. Part state:
+  `input-available`. No approval, no output, no error, no `providerExecuted`.
+- `finish` with `finishReason: "other"`.
+
+When the turn is no longer streaming, the app-layer classifier treats B as a client
+tool because it is unsettled, non-approval, non-provider-executed, and the turn ended
+(`meta.ts:52-66`). The registry knows only `request_connection`
+(`registry.tsx:26-28`), so B falls to the generic fallback, which force-settles it:
+`settle({errorText: 'This app can't handle the "<toolName>" request.'})`
+(`UnhandledClientTool.tsx:17-21`). That synthetic error is what the user saw, and it
+enters the message history as a real tool error.
+
+## 6. The resume machinery (and why it already supports multiple approvals)
+
+On approve, the AI SDK flips the part to `approval-responded`
+(`addToolApprovalResponse`, `ai@6.0.0-beta.150 dist/index.js:11162-11188`) and calls
+`sendAutomaticallyWhen`. Ours is `agentShouldResumeAfterApproval`
+(`web/packages/agenta-playground/src/state/execution/agentApprovalResume.ts:108-138`),
+wired at `web/oss/src/components/AgentChatSlice/AgentChatPanel.tsx:368`. It resumes
+only when at least one gate was freshly resolved AND every non-provider-executed tool
+part on the turn is settled (`output-available`, `output-error`, or
+`approval-responded`). So with two pending gates, approving the first does not resume;
+approving the last does. The predicate was already designed for this.
+
+The resume POST carries the full history. The SDK ingress folds each
+`approval-responded` part into a `tool_result` block with an `{approved: bool}`
+envelope keyed by `toolCallId`
+(`sdks/python/agenta/sdk/agents/adapters/vercel/messages.py:152-182`). The runner
+indexes every such envelope by `approvedCallKey(name, args)` (name + canonical args,
+recovered from the matching `tool_call` block by id):
+`extractApprovalDecisions` at `services/runner/src/responder.ts:247-259`,
+`coldReplayKey` at 322-332, key shape at 65-76. **The store is a Map. It already holds
+any number of decisions per turn.**
+
+The resumed run cold-starts a fresh sandbox and replays prior turns as flattened text
+(`services/runner/src/engines/sandbox_agent/transcript.ts:43-81`; an approval envelope
+renders as `[<tool> returned: {"approved":true}]`). The model re-issues the approved
+call; the re-raised gate matches the stored decision by name+args and is answered
+`"once"` silently (`decide()` at `permission-plan.ts:147-149`, reply mapping at
+`responder.ts:370-378`). Two stored decisions would answer two re-raised gates in
+sequence with zero extra prompts.
+
+## 7. Frontend and AI SDK readiness for multiple pending approvals
+
+Checked for Option B; all of it already exists:
+
+- **Wire**: `tool-approval-request` is a per-toolCallId chunk; nothing limits one per
+  message (`stream.py:522-526`; chunk handler in `ai dist/index.js:4775-4781` just
+  flips the matching part). Two approval parts in one assistant message are valid
+  today.
+- **Dock**: `getPendingApprovals` collects ALL `approval-requested` parts on the last
+  turn (`web/oss/src/components/AgentChatSlice/components/ApprovalDock.tsx:35-47`).
+  The dock renders a queue ("1 of N", `ApprovalDock.tsx:148-155`) and has an
+  "Approve all" action (119-123). It was explicitly written for "a turn can request
+  several at once".
+- **Resume predicate**: holds the auto-resend until no gate is pending (section 6).
+- **Ingress + runner store**: fold and match N decisions (section 6).
+
+What does NOT exist: the runner never emits more than one `interaction_request` per
+turn (the latch), and, per section 3, it will never receive the sibling's gate
+reliably. That is the only missing piece for batching.
+
+## 8. Pi relay: same latch, partially better behavior
+
+Pi gates through the relay instead of ACP. The builtin-gating path already answers the
+latch loser deterministically: `"Another approval is pending; retry after it
+resolves."` goes back to the tool child (`services/runner/src/tools/relay.ts:433-446`,
+`emitted:false` from `sandbox_agent.ts:774-796`). The relayed-tool path does not check
+`emitted` and returns `PAUSED` regardless (`relay.ts:255-263`). Pi announces its calls
+through its own extension, so the orphan shape differs; parity is an open question in
+[plan.md](plan.md), not part of the incident.
+
+## 9. Corrections to the earlier findings doc
+
+`docs/design/agent-workflows/scratch/approval-turn-duplication-findings.md` is accurate
+on the runner and FE mechanics. Two refinements:
+
+1. It leaves open how the second gate reaches the runner. Verified: for write tools the
+   harness serializes gates; the second one arrives only in the teardown race after the
+   first is cancelled (section 3). It is not a stable concurrent pair of RPCs.
+2. Its "Fix direction" item 2 suggests the FE should recognize `mcp__agenta-tools__*`
+   names. That direction is rejected by decision: the frontend must not special-case
+   tool names. The fix belongs where the orphan is created (the runner).
+
+## 10. File index
+
+| Concern | Location |
+|---|---|
+| One-pause latch, loser dropped | `services/runner/src/engines/sandbox_agent/acp-interactions.ts:73-95` (line 78) |
+| Latch | `services/runner/src/permission-plan.ts:173-185` |
+| F-040 pause = destroy, never reply | `services/runner/src/engines/sandbox_agent/pause.ts:1-27` |
+| Pause controller wiring, suppression | `services/runner/src/engines/sandbox_agent.ts:710-729` |
+| Pi relay pause + loser reason | `services/runner/src/tools/relay.ts:255-263`, `433-446`; `sandbox_agent.ts:771-797` |
+| Event log the runner keeps | `services/runner/src/tracing/otel.ts:904`, `1097-1224`, `1337` |
+| tool_use -> ACP tool_call / update | `claude-agent-acp/dist/acp-agent.js:1433-1518`; deltas ignored at 1576-1582 |
+| canUseTool -> request_permission | `claude-agent-acp/dist/acp-agent.js:697-820`; cancelled -> throw at 789-791 |
+| CLI serial/parallel scheduler | `@anthropic-ai/claude-agent-sdk/cli.js` (`VS8`/`nF_`/`rF_`; MCP `isConcurrencySafe` = `readOnlyHint ?? false`) |
+| Daemon pending-permission map + cancel | `sandbox-agent/dist/chunk-TVCDKGSM.js:2215-2265`, `1189-1191` |
+| Egress: events -> parts, approval part | `sdks/python/agenta/sdk/agents/adapters/vercel/stream.py:330-368`, `449-527` |
+| finishReason mapping (`paused` -> `other`) | `stream.py:22-54` |
+| Ingress: parts -> blocks, `{approved}` fold | `sdks/python/agenta/sdk/agents/adapters/vercel/messages.py:91-208` |
+| Decision store, cold-replay key | `services/runner/src/responder.ts:65-76`, `247-332`, `370-378` |
+| Transcript replay | `services/runner/src/engines/sandbox_agent/transcript.ts:43-81` |
+| FE classifier (parked unknown client tool) | `web/oss/src/components/AgentChatSlice/components/clientTools/meta.ts:52-66` |
+| FE registry (only `request_connection`) | `.../clientTools/registry.tsx:26-28` |
+| FE fake error | `.../clientTools/UnhandledClientTool.tsx:17-21` |
+| Resume predicate | `web/packages/agenta-playground/src/state/execution/agentApprovalResume.ts:108-138` |
+| Approval response + auto-send | `ai@6.0.0-beta.150 dist/index.js:11162-11188`; chunk handler 4775-4781 |
+| ApprovalDock queue + Approve all | `web/oss/src/components/AgentChatSlice/components/ApprovalDock.tsx:35-47`, `119-155` |
+| Dock wiring | `web/oss/src/components/AgentChatSlice/AgentChatPanel.tsx:359-368`, `625-629`, `1394-1397` |

--- a/docs/design/parallel-approval-gates/status.md
+++ b/docs/design/parallel-approval-gates/status.md
@@ -1,18 +1,38 @@
 # Status
 
-**Phase: research + plan complete. Awaiting Mahmoud's decision on the recommendation.**
+**Phase: DECIDED and IMPLEMENTED (this PR). Option A + companions are in; Option B is a
+follow-up.**
+
+Mahmoud reviewed the plan on PR #5089 ("lgtm see comments though") and set the scope:
+
+- **In this PR (implemented):** Option A (the runner settles latch-loser siblings with a
+  deterministic `tool_result` before pause teardown), the FIFO approval-decision store
+  (duplicate identical gated calls no longer collapse), the honest replay transcript for
+  `{approved}` envelopes (fixes the phantom-execution bug in
+  [phantom-execution-findings.md](phantom-execution-findings.md)), and the frontend
+  neutral settle: unhandled client tools settle informational, and deferred siblings
+  render muted ("waiting on another approval"), never as a red failure. Mahmoud's UX bar
+  from the review: the UI must not be confusing; the deferred chip must read clearly.
+- **Follow-up (not in this PR):** Option B, synthetic sibling gates batched into one
+  pause (plan.md Phases 2-3), plus the optional pre-teardown drain if telemetry shows
+  the args refresh losing the race often.
 
 - 2026-07-06: workspace created. All mechanics verified against source (runner,
   claude-agent-acp 0.23.1, Claude Agent SDK 0.2.83 cli.js, sandbox-agent 0.4.2,
-  vercel adapter, AI SDK 6.0.0-beta.150, playground). No product code touched.
+  vercel adapter, AI SDK 6.0.0-beta.150, playground).
+- 2026-07-06 (later): implementation landed on the same lane per the review. See
+  plan.md "as landed" sections for the exact shape.
 
 ## Decisions taken
 
-- No frontend tool-name special-casing (Mahmoud, hard constraint).
+- No frontend tool-name special-casing (Mahmoud, hard constraint). The FE rendering
+  keys on structured shape (the `DEFERRED_NOT_EXECUTED:` sentinel prefix and the
+  `{status: "not_handled"}` output), never on a tool name.
 - F-040 core rule stays: never reply to a harness gate that needs a human.
-- Recommendation on the table: Option A first (small, honest states, no contract
-  change), Option B layered on top (synthetic sibling gates + args-trust guard;
-  drain only if data demands it). See options.md.
+- Option A first, Option B follow-up (Mahmoud approved this sequencing on the PR).
+- The FE unhandled-client-tool neutral settle, flagged as an independent follow-up in
+  options.md, was pulled into this PR on Mahmoud's comment ("let's do that in this pr
+  already").
 
 ## Key verified facts driving the design
 
@@ -21,7 +41,7 @@
   synthesize from the runner's own tool_call record.
 - Everything downstream of the runner already supports N approvals per turn: wire
   parts, AI SDK client, ApprovalDock queue + Approve all, resume predicate, ingress
-  folding, multi-key decision store, cold-replay matching.
+  folding, multi-key decision store (now FIFO per key), cold-replay matching.
 - The losing call's args can be `{}` at pause time (refresh races teardown), so
   Option B needs an args-trust guard with Option A as its fallback.
 
@@ -31,6 +51,7 @@ None.
 
 ## Next
 
-1. Mahmoud reviews options.md + plan.md, picks scope (A only, or A then B).
-2. Implement Phase 1 per plan.md (runner-only, unit tests first).
-3. Live repro verification on the dev stack, then the replay regression capture.
+1. Option B (plan.md Phases 2-3) as a follow-up slice: synthetic sibling gates with
+   the args-trust guard, then the drain only if data demands it.
+2. A replay regression capture of the two-gate scenario once Option B lands
+   (agent-replay-test), pinned under the QA runs convention.

--- a/docs/design/parallel-approval-gates/status.md
+++ b/docs/design/parallel-approval-gates/status.md
@@ -1,0 +1,36 @@
+# Status
+
+**Phase: research + plan complete. Awaiting Mahmoud's decision on the recommendation.**
+
+- 2026-07-06: workspace created. All mechanics verified against source (runner,
+  claude-agent-acp 0.23.1, Claude Agent SDK 0.2.83 cli.js, sandbox-agent 0.4.2,
+  vercel adapter, AI SDK 6.0.0-beta.150, playground). No product code touched.
+
+## Decisions taken
+
+- No frontend tool-name special-casing (Mahmoud, hard constraint).
+- F-040 core rule stays: never reply to a harness gate that needs a human.
+- Recommendation on the table: Option A first (small, honest states, no contract
+  change), Option B layered on top (synthetic sibling gates + args-trust guard;
+  drain only if data demands it). See options.md.
+
+## Key verified facts driving the design
+
+- The Claude CLI serializes gated write tools; the second gate reaches the runner
+  only in the teardown race. "Wait and collect gates" is impossible; batching must
+  synthesize from the runner's own tool_call record.
+- Everything downstream of the runner already supports N approvals per turn: wire
+  parts, AI SDK client, ApprovalDock queue + Approve all, resume predicate, ingress
+  folding, multi-key decision store, cold-replay matching.
+- The losing call's args can be `{}` at pause time (refresh races teardown), so
+  Option B needs an args-trust guard with Option A as its fallback.
+
+## Blockers
+
+None.
+
+## Next
+
+1. Mahmoud reviews options.md + plan.md, picks scope (A only, or A then B).
+2. Implement Phase 1 per plan.md (runner-only, unit tests first).
+3. Live repro verification on the dev stack, then the replay regression capture.

--- a/docs/design/parallel-approval-gates/status.md
+++ b/docs/design/parallel-approval-gates/status.md
@@ -45,6 +45,20 @@ Mahmoud reviewed the plan on PR #5089 ("lgtm see comments though") and set the s
 - The losing call's args can be `{}` at pause time (refresh races teardown), so
   Option B needs an args-trust guard with Option A as its fallback.
 
+## Hotfix round (2026-07-06)
+
+Mahmoud's live testing hit an approval loop introduced by the honest-replay fix: the
+model re-issued the approved call with an object arg re-serialized as a JSON string, the
+exact-args key missed, a new gate fired, and stale "NOT run yet" envelopes compounded
+each resume. Fixed on the same lane with (a) JSON-normalizing canonicalization in
+`approvedCallKey` (string values that parse as objects/arrays are parsed before the
+stable stringify, both on stored decisions and live gates; no name-only fallback) and
+(b) history-aware envelope rendering in `buildTurnText` (executed-below when a later
+real result exists, the nudge only on the last unresolved envelope per tool, neutral
+"approved earlier" for older duplicates, deny unchanged). Verified live: one approval,
+one re-issue, decision consumed, revision landed, no repeat nudge on the next turn. Full
+detail in [phantom-execution-findings.md](phantom-execution-findings.md) §"Hotfix round".
+
 ## Blockers
 
 None.

--- a/services/runner/src/engines/sandbox_agent.ts
+++ b/services/runner/src/engines/sandbox_agent.ts
@@ -29,7 +29,10 @@ import { apiBase } from "../apiBase.ts";
 
 import { SandboxAgent, InMemorySessionPersistDriver } from "sandbox-agent";
 
-import { createSandboxAgentOtel } from "../tracing/otel.ts";
+import {
+  createSandboxAgentOtel,
+  TOOL_NOT_EXECUTED_PAUSED,
+} from "../tracing/otel.ts";
 import {
   localRelayHost,
   sandboxRelayHost,
@@ -708,6 +711,10 @@ export async function runSandboxAgent(
     });
 
     const pause = new PendingApprovalPauseController(() => {
+      run.settleOpenToolCalls(
+        (id) => pause.isPausedToolCall(id),
+        TOOL_NOT_EXECUTED_PAUSED,
+      );
       // Abort any in-flight loopback `tools/call` (a paused Claude client tool) BEFORE the
       // session teardown, so its handler cannot write a result after the turn ends.
       mcpAbort.abort();
@@ -724,6 +731,15 @@ export async function runSandboxAgent(
         toolCallIndex.record(update);
         if (!shouldSuppressPausedToolCallUpdate(update, pause)) {
           run.handleUpdate(update);
+          // A sibling announced AFTER the pause won the latch can never execute (the session
+          // is already being destroyed), and the pause-time sweep has already run — settle it
+          // immediately so the client never holds an orphaned part (idempotent re-sweep).
+          if (pause.active) {
+            run.settleOpenToolCalls(
+              (id) => pause.isPausedToolCall(id),
+              TOOL_NOT_EXECUTED_PAUSED,
+            );
+          }
         }
       }
     });

--- a/services/runner/src/engines/sandbox_agent/pause.ts
+++ b/services/runner/src/engines/sandbox_agent/pause.ts
@@ -3,6 +3,8 @@
  *
  * F-040: an unanswered approval must end the turn, destroy the session, and never reply to the
  * harness gate. Historical docs call this "park"; this module uses pause/pendingApproval names.
+ * The destroy callback also settles every announced-but-unresolved sibling tool call with a
+ * deterministic `tool_result` before teardown, so the client never holds an orphaned part.
  */
 export const PAUSED = Symbol("paused");
 

--- a/services/runner/src/engines/sandbox_agent/transcript.ts
+++ b/services/runner/src/engines/sandbox_agent/transcript.ts
@@ -7,6 +7,8 @@ import {
 } from "../../protocol.ts";
 import { approvalDecisionOf } from "../../responder.ts";
 
+export type ApprovalRenderHint = "executed" | "lastPending" | "stalePending";
+
 /** Prior turns (everything before the latest user message) for trace + history. */
 export function priorMessages(request: AgentRunRequest): ChatMessage[] {
   const messages = request.messages ?? [];
@@ -27,6 +29,80 @@ export function priorMessages(request: AgentRunRequest): ChatMessage[] {
   return lastMatch === -1 ? messages : messages.filter((_, i) => i !== lastMatch);
 }
 
+/**
+ * Approval envelopes are replayed as plain text to a cold model. Without a history-wide view,
+ * every old `{approved:true}` envelope keeps saying "call this again now", even after a later
+ * real result proves the tool executed, or after duplicate stale envelopes pile up. This pre-pass
+ * marks approval-result blocks with the least confusing rendering for the whole prior transcript.
+ */
+export function approvalRenderHints(
+  history: readonly {
+    content: string | ContentBlock[] | undefined;
+  }[],
+): Map<ContentBlock, ApprovalRenderHint> {
+  const toolResults: {
+    block: ContentBlock;
+    toolName: string | undefined;
+    decision: ReturnType<typeof approvalDecisionOf>;
+  }[] = [];
+
+  for (const message of history) {
+    const content = message.content;
+    if (!Array.isArray(content)) continue;
+    for (const block of content) {
+      if (block?.type !== "tool_result") continue;
+      toolResults.push({
+        block,
+        toolName: block.toolName,
+        decision: approvalDecisionOf(block),
+      });
+    }
+  }
+
+  const hints = new Map<ContentBlock, ApprovalRenderHint>();
+  const unresolved = new Map<
+    string | undefined,
+    { block: ContentBlock; index: number }[]
+  >();
+
+  for (let index = 0; index < toolResults.length; index++) {
+    const entry = toolResults[index];
+    if (entry.decision !== "allow") continue;
+
+    // Rendering only: use tool-name proximity to suppress stale nudges. The actual approval
+    // decision store still matches on name + canonical args and never consumes by name alone.
+    const hasLaterRealResult = toolResults
+      .slice(index + 1)
+      .some(
+        (later) =>
+          later.toolName === entry.toolName && later.decision === undefined,
+      );
+    if (hasLaterRealResult) {
+      hints.set(entry.block, "executed");
+      continue;
+    }
+
+    const list = unresolved.get(entry.toolName) ?? [];
+    list.push({ block: entry.block, index });
+    unresolved.set(entry.toolName, list);
+  }
+
+  for (const list of unresolved.values()) {
+    let lastIndex = -1;
+    for (const entry of list) {
+      if (entry.index > lastIndex) lastIndex = entry.index;
+    }
+    for (const entry of list) {
+      hints.set(
+        entry.block,
+        entry.index === lastIndex ? "lastPending" : "stalePending",
+      );
+    }
+  }
+
+  return hints;
+}
+
 function safeJson(value: unknown): string {
   if (value === undefined || value === null) return "";
   try {
@@ -41,7 +117,10 @@ function safeJson(value: unknown): string {
  * the cold model, ACP prompt content blocks cannot carry tool calls/results, so resolved
  * interactions are encoded as text.
  */
-export function messageTranscript(content: string | ContentBlock[] | undefined): string {
+export function messageTranscript(
+  content: string | ContentBlock[] | undefined,
+  hints?: Map<ContentBlock, ApprovalRenderHint>,
+): string {
   if (!content) return "";
   if (typeof content === "string") return content;
   const parts: string[] = [];
@@ -55,11 +134,20 @@ export function messageTranscript(content: string | ContentBlock[] | undefined):
       const decision = approvalDecisionOf(block);
       if (decision !== undefined) {
         const toolName = block.toolName ?? "tool";
-        parts.push(
-          decision === "allow"
-            ? `[user APPROVED ${toolName}; the call has NOT run yet. Call the tool again with the same arguments now to execute it.]`
-            : `[user DENIED ${toolName}; the call was not executed.]`,
-        );
+        if (decision === "allow") {
+          const hint = hints?.get(block) ?? "lastPending";
+          if (hint === "executed") {
+            parts.push(`[user APPROVED ${toolName}; executed below]`);
+          } else if (hint === "stalePending") {
+            parts.push(`[user approved ${toolName} earlier.]`);
+          } else {
+            parts.push(
+              `[user APPROVED ${toolName}; the call has NOT run yet. Call the tool again with the same arguments now to execute it.]`,
+            );
+          }
+        } else {
+          parts.push(`[user DENIED ${toolName}; the call was not executed.]`);
+        }
       } else {
         const body = safeJson(block.output);
         parts.push(
@@ -81,11 +169,17 @@ export function messageTranscript(content: string | ContentBlock[] | undefined):
  */
 export function buildTurnText(request: AgentRunRequest): string {
   const latest = resolvePromptText(request);
-  const history = priorMessages(request).filter((m) => messageTranscript(m.content));
+  const prior = priorMessages(request);
+  const hints = approvalRenderHints(prior);
+  const history = prior
+    .map((m) => ({ message: m, text: messageTranscript(m.content, hints) }))
+    .filter((entry) => entry.text);
   if (history.length === 0) return latest;
 
   const maxChars = Number(process.env.AGENTA_AGENT_HISTORY_MAX_CHARS ?? 24000);
-  let transcript = history.map((m) => `${m.role}: ${messageTranscript(m.content)}`).join("\n");
+  let transcript = history
+    .map(({ message, text }) => `${message.role}: ${text}`)
+    .join("\n");
   if (transcript.length > maxChars) transcript = transcript.slice(-maxChars);
   return (
     `Conversation so far:\n${transcript}\n\n` +

--- a/services/runner/src/engines/sandbox_agent/transcript.ts
+++ b/services/runner/src/engines/sandbox_agent/transcript.ts
@@ -5,6 +5,7 @@ import {
   messageText,
   resolvePromptText,
 } from "../../protocol.ts";
+import { approvalDecisionOf } from "../../responder.ts";
 
 /** Prior turns (everything before the latest user message) for trace + history. */
 export function priorMessages(request: AgentRunRequest): ChatMessage[] {
@@ -51,8 +52,20 @@ export function messageTranscript(content: string | ContentBlock[] | undefined):
     } else if (block.type === "tool_call") {
       parts.push(`[called ${block.toolName ?? "tool"}(${safeJson(block.input)})]`);
     } else if (block.type === "tool_result") {
-      const body = safeJson(block.output);
-      parts.push(`[${block.toolName ?? "tool"} ${block.isError ? "error" : "returned"}: ${body}]`);
+      const decision = approvalDecisionOf(block);
+      if (decision !== undefined) {
+        const toolName = block.toolName ?? "tool";
+        parts.push(
+          decision === "allow"
+            ? `[user APPROVED ${toolName}; the call has NOT run yet. Call the tool again with the same arguments now to execute it.]`
+            : `[user DENIED ${toolName}; the call was not executed.]`,
+        );
+      } else {
+        const body = safeJson(block.output);
+        parts.push(
+          `[${block.toolName ?? "tool"} ${block.isError ? "error" : "returned"}: ${body}]`,
+        );
+      }
     } else if (block.type === "image") {
       parts.push("[image]");
     } else if (block.type === "resource") {

--- a/services/runner/src/responder.ts
+++ b/services/runner/src/responder.ts
@@ -89,6 +89,52 @@ function stableArgsHash(input: unknown): string | undefined {
 }
 
 function canonicalJson(value: unknown): string {
+  return canonicalJsonValue(normalizeJsonish(value));
+}
+
+/**
+ * Models sometimes copy object-valued args out of the flattened replay transcript as JSON
+ * strings. Normalize only JSON strings that parse to objects/arrays before hashing so the
+ * stored approval and the live re-issued gate meet at the same semantic key without falling
+ * back to a weaker name-only match.
+ */
+function normalizeJsonish(value: unknown): unknown {
+  if (typeof value === "string") {
+    try {
+      const parsed = JSON.parse(value) as unknown;
+      if (isJsonContainer(parsed)) return normalizeJsonish(parsed);
+    } catch {
+      // Not a JSON-encoded object/array; keep the string literal.
+    }
+    return value;
+  }
+  if (Array.isArray(value)) return value.map(normalizeJsonish);
+  if (isPlainObject(value)) {
+    return Object.fromEntries(
+      Object.entries(value).map(([key, entry]) => [
+        key,
+        normalizeJsonish(entry),
+      ]),
+    );
+  }
+  return value;
+}
+
+function isJsonContainer(
+  value: unknown,
+): value is unknown[] | Record<string, unknown> {
+  return Array.isArray(value) || isPlainObject(value);
+}
+
+function isPlainObject(value: unknown): value is Record<string, unknown> {
+  if (value === null || typeof value !== "object" || Array.isArray(value)) {
+    return false;
+  }
+  const proto = Object.getPrototypeOf(value);
+  return proto === Object.prototype || proto === null;
+}
+
+function canonicalJsonValue(value: unknown): string {
   if (value === null) return "null";
   if (value === undefined) throw new Error("undefined is not JSON");
   if (typeof value === "bigint") throw new Error("bigint is not JSON");
@@ -99,17 +145,16 @@ function canonicalJson(value: unknown): string {
   }
   if (typeof value !== "object") return JSON.stringify(value);
   if (Array.isArray(value)) {
-    return `[${value.map(canonicalJson).join(",")}]`;
+    return `[${value.map(canonicalJsonValue).join(",")}]`;
   }
   // Only plain objects are stable JSON; reject Date/Map/Set/etc. so they don't collapse to {}.
-  const proto = Object.getPrototypeOf(value);
-  if (proto !== Object.prototype && proto !== null) {
+  if (!isPlainObject(value)) {
     throw new Error("non-plain object is not JSON");
   }
   const entries = Object.entries(value as Record<string, unknown>)
     .filter(([, v]) => v !== undefined)
     .sort(([a], [b]) => (a < b ? -1 : a > b ? 1 : 0));
-  return `{${entries.map(([k, v]) => `${JSON.stringify(k)}:${canonicalJson(v)}`).join(",")}}`;
+  return `{${entries.map(([k, v]) => `${JSON.stringify(k)}:${canonicalJsonValue(v)}`).join(",")}}`;
 }
 
 /**

--- a/services/runner/src/responder.ts
+++ b/services/runner/src/responder.ts
@@ -136,21 +136,32 @@ export type ClientToolOutputs = ReadonlyMap<string, readonly unknown[]>;
  * under the shared key (FIFO), so neither overwrites the other.
  */
 export class ConversationDecisions implements StoredPermissionDecisions {
+  private readonly decisionQueues: Map<string, unknown[]>;
   /** Per-key FIFO cursor: how many outputs under a key this conversation already consumed. */
   private readonly clientOutputCursor = new Map<string, number>();
 
   constructor(
-    private readonly byKey: Map<string, unknown>,
+    byKey: Map<string, unknown>,
     private readonly clientOutputs: ClientToolOutputs = new Map(),
-  ) {}
+  ) {
+    this.decisionQueues = new Map<string, unknown[]>(
+      [...byKey].map(([key, value]) => [
+        key,
+        Array.isArray(value) ? [...value] : [value],
+      ]),
+    );
+  }
 
   /** allow|deny for this exact call (name + canonical args), consumed on first take. */
   take(gate: GateDescriptor): "allow" | "deny" | undefined {
     const key = approvedCallKey(gate.toolName, gate.args);
-    if (!key || !this.byKey.has(key)) return undefined;
-    const value = this.byKey.get(key);
+    if (!key) return undefined;
+    const queue = this.decisionQueues.get(key);
+    if (!queue || queue.length === 0) return undefined;
+    const value = queue[0];
     if (!isPermissionDecision(value)) return undefined;
-    this.byKey.delete(key);
+    queue.shift();
+    if (queue.length === 0) this.decisionQueues.delete(key);
     return value;
   }
 
@@ -246,14 +257,17 @@ export class ApprovalResponder implements Responder {
  */
 export function extractApprovalDecisions(
   request: AgentRunRequest,
-): Map<string, unknown> {
-  const decisions = new Map<string, unknown>();
+): Map<string, unknown[]> {
+  const decisions = new Map<string, unknown[]>();
   const callShapeById = buildCallShapeIndex(request);
   for (const block of toolResultBlocks(request)) {
     const decision = approvalDecisionOf(block);
     if (decision === undefined) continue;
     const argsKey = coldReplayKey(block, callShapeById);
-    if (argsKey) decisions.set(argsKey, decision);
+    if (!argsKey) continue;
+    const list = decisions.get(argsKey) ?? [];
+    list.push(decision);
+    decisions.set(argsKey, list);
   }
   return decisions;
 }
@@ -341,7 +355,7 @@ function isPermissionDecision(value: unknown): value is PermissionDecision {
  * `"allow"`/`"deny"` for one, or `undefined` for any other tool_result (a real browser/client
  * output).
  */
-function approvalDecisionOf(
+export function approvalDecisionOf(
   block: ContentBlock,
 ): PermissionDecision | undefined {
   if (!block || block.type !== "tool_result") return undefined;

--- a/services/runner/src/tracing/otel.ts
+++ b/services/runner/src/tracing/otel.ts
@@ -54,6 +54,9 @@ import { ATTR_SERVICE_NAME } from "@opentelemetry/semantic-conventions";
 
 import type { AgentEvent, AgentUsage, EmitEvent } from "../protocol.ts";
 
+export const TOOL_NOT_EXECUTED_PAUSED =
+  "DEFERRED_NOT_EXECUTED: paused for another approval; retry the same call if still required.";
+
 // ---------------------------------------------------------------------------
 // Shared, process-wide tracing infrastructure
 // ---------------------------------------------------------------------------
@@ -872,6 +875,11 @@ export interface SandboxAgentOtel {
   output(): string;
   /** The structured event log built from the ACP stream (tool calls, usage, final message). */
   events(): AgentEvent[];
+  /** Settle open tool calls except those intentionally left pending. */
+  settleOpenToolCalls(
+    isExcluded: (id: string) => boolean,
+    message: string,
+  ): void;
   /** Run token/cost totals from the stream, when the harness reported `usage_update`. */
   usage(): AgentUsage | undefined;
 }
@@ -1223,6 +1231,21 @@ export function createSandboxAgentOtel(
     });
   }
 
+  function settleOpenToolCalls(
+    isExcluded: (id: string) => boolean,
+    message: string,
+  ): void {
+    for (const [id, entry] of [...toolSpans.entries()]) {
+      if (isExcluded(id)) continue;
+      if (entry.span) {
+        entry.span.setStatus({ code: SpanStatusCode.ERROR });
+        entry.span.end();
+      }
+      toolSpans.delete(id);
+      record({ type: "tool_result", id, output: message, isError: true });
+    }
+  }
+
   /**
    * Stamp a run-level error (the user-facing message + the provider that failed) and an OTel
    * exception event so a trace carries the same diagnostic the HTTP response does (F-030).
@@ -1335,6 +1358,7 @@ export function createSandboxAgentOtel(
     traceId: () => runTraceId,
     output: () => accumulated,
     events: () => events,
+    settleOpenToolCalls,
     usage: () => usage,
   };
 }

--- a/services/runner/tests/unit/responder.test.ts
+++ b/services/runner/tests/unit/responder.test.ts
@@ -97,6 +97,65 @@ describe("approvedCallKey", () => {
     assert.equal(approvedCallKey("edit", { x: NaN }), undefined);
     assert.equal(approvedCallKey("edit", new Map()), undefined);
   });
+
+  it("matches object-valued args re-issued as JSON strings", () => {
+    const toolName = "mcp__agenta-tools__commit_revision";
+    const workflowRevision = { delta: { a: 1 } };
+
+    assert.equal(
+      approvedCallKey(toolName, {
+        workflow_revision: workflowRevision,
+      }),
+      approvedCallKey(toolName, {
+        workflow_revision: JSON.stringify(workflowRevision),
+      }),
+    );
+  });
+
+  it("keeps key ordering stable inside stringified JSON args", () => {
+    const toolName = "mcp__agenta-tools__commit_revision";
+
+    assert.equal(
+      approvedCallKey(toolName, {
+        workflow_revision: { delta: { a: 1, b: 2 } },
+      }),
+      approvedCallKey(toolName, {
+        workflow_revision: '{"delta":{"b":2,"a":1}}',
+      }),
+    );
+    assert.equal(
+      approvedCallKey(toolName, {
+        workflow_revision: '{"delta":{"a":1,"b":2}}',
+      }),
+      approvedCallKey(toolName, {
+        workflow_revision: '{"delta":{"b":2,"a":1}}',
+      }),
+    );
+  });
+
+  it("does not match semantically different args", () => {
+    const toolName = "mcp__agenta-tools__commit_revision";
+
+    assert.notEqual(
+      approvedCallKey(toolName, {
+        workflow_revision: { delta: { a: 1 } },
+      }),
+      approvedCallKey(toolName, {
+        workflow_revision: JSON.stringify({ delta: { a: 2 } }),
+      }),
+    );
+  });
+
+  it("keeps plain non-JSON strings canonicalizable", () => {
+    assert.equal(
+      approvedCallKey("echo", { message: "hello world" }),
+      approvedCallKey("echo", { message: "hello world" }),
+    );
+    assert.notEqual(
+      approvedCallKey("echo", { message: "hello world" }),
+      approvedCallKey("echo", { message: { text: "hello world" } }),
+    );
+  });
 });
 
 describe("ApprovalResponder", () => {
@@ -357,6 +416,46 @@ describe("extractApprovalDecisions", () => {
     assert.equal(stored.take(duplicateGate), "allow");
     assert.equal(stored.take(duplicateGate), "allow");
     assert.equal(stored.take(duplicateGate), undefined);
+  });
+
+  it("consumes an approval when the live gate re-issues an object arg as a JSON string", () => {
+    const workflowRevision = { delta: { a: 1 } };
+    const request: AgentRunRequest = {
+      sessionId: "s-jsonish",
+      messages: [
+        {
+          role: "assistant",
+          content: [
+            {
+              type: "tool_call",
+              toolCallId: "tc-jsonish",
+              toolName: "mcp__agenta-tools__commit_revision",
+              input: { workflow_revision: workflowRevision },
+            },
+          ],
+        },
+        {
+          role: "tool",
+          content: [
+            {
+              type: "tool_result",
+              toolCallId: "tc-jsonish",
+              output: { approved: true },
+            },
+          ],
+        },
+      ],
+    };
+    const stored = new ConversationDecisions(extractApprovalDecisions(request));
+
+    assert.equal(
+      stored.take({
+        executor: "harness",
+        toolName: "mcp__agenta-tools__commit_revision",
+        args: { workflow_revision: JSON.stringify(workflowRevision) },
+      }),
+      "allow",
+    );
   });
 
   it("routes a correlated client-tool output to the CLIENT store, not the approval store", () => {

--- a/services/runner/tests/unit/responder.test.ts
+++ b/services/runner/tests/unit/responder.test.ts
@@ -303,10 +303,60 @@ describe("extractApprovalDecisions", () => {
     };
 
     const decisions = extractApprovalDecisions(request);
-    assert.equal(decisions.get(approvedCallKey("edit", { path: "a.txt" })!), "allow");
-    assert.equal(decisions.get(approvedCallKey("bash", { cmd: "ls" })!), "deny");
+    assert.deepEqual(decisions.get(approvedCallKey("edit", { path: "a.txt" })!), ["allow"]);
+    assert.deepEqual(decisions.get(approvedCallKey("bash", { cmd: "ls" })!), ["deny"]);
     assert.equal(decisions.has("edit"), false);
     assert.equal(decisions.has("tc-1"), false);
+  });
+
+  it("keeps duplicate identical approval decisions in FIFO order", () => {
+    const request: AgentRunRequest = {
+      sessionId: "s-duplicates",
+      messages: [
+        {
+          role: "assistant",
+          content: [
+            {
+              type: "tool_call",
+              toolCallId: "tc-1",
+              toolName: "edit",
+              input: { path: "a.txt" },
+            },
+            {
+              type: "tool_call",
+              toolCallId: "tc-2",
+              toolName: "edit",
+              input: { path: "a.txt" },
+            },
+          ],
+        },
+        {
+          role: "tool",
+          content: [
+            {
+              type: "tool_result",
+              toolCallId: "tc-1",
+              output: { approved: true },
+            },
+            {
+              type: "tool_result",
+              toolCallId: "tc-2",
+              output: { approved: true },
+            },
+          ],
+        },
+      ],
+    };
+    const key = approvedCallKey("edit", { path: "a.txt" })!;
+    const decisions = extractApprovalDecisions(request);
+
+    assert.deepEqual(decisions.get(key), ["allow", "allow"]);
+
+    const stored = new ConversationDecisions(decisions);
+    const duplicateGate = gate({ toolName: "edit", args: { path: "a.txt" } });
+    assert.equal(stored.take(duplicateGate), "allow");
+    assert.equal(stored.take(duplicateGate), "allow");
+    assert.equal(stored.take(duplicateGate), undefined);
   });
 
   it("routes a correlated client-tool output to the CLIENT store, not the approval store", () => {
@@ -420,7 +470,7 @@ describe("client-tool output store (separate from approvals)", () => {
     assert.equal(outputs.has(approvedCallKey("edit", { path: "a" })!), false);
     // ...and lives only in the approval store.
     const decisions = extractApprovalDecisions(request);
-    assert.equal(decisions.get(approvedCallKey("edit", { path: "a" })!), "allow");
+    assert.deepEqual(decisions.get(approvedCallKey("edit", { path: "a" })!), ["allow"]);
   });
 
   it("resolves two identical client calls from the FIFO store, in order", async () => {

--- a/services/runner/tests/unit/sandbox-agent-orchestration.test.ts
+++ b/services/runner/tests/unit/sandbox-agent-orchestration.test.ts
@@ -9,7 +9,10 @@ import { tmpdir } from "node:os";
 import { join } from "node:path";
 
 import type { AgentEvent, AgentRunRequest } from "../../src/protocol.ts";
-import { createSandboxAgentOtel } from "../../src/tracing/otel.ts";
+import {
+  createSandboxAgentOtel,
+  TOOL_NOT_EXECUTED_PAUSED,
+} from "../../src/tracing/otel.ts";
 import { PendingApprovalPauseController } from "../../src/engines/sandbox_agent/pause.ts";
 import type { PermissionDecision } from "../../src/responder.ts";
 import {
@@ -35,6 +38,10 @@ interface FakeOptions {
   promptError?: Error;
   permissionDecision?: PermissionDecision;
   emitPermission?: boolean;
+  permissionToolCallId?: string;
+  permissionToolName?: string;
+  permissionRawInput?: unknown;
+  permissionRequests?: Array<Record<string, unknown>>;
   // Model Claude-over-ACP: the prompt NEVER resolves on its own after a permission gate. The
   // runner must end the turn another way (the park -> destroySession -> cancel path, F-040).
   hangPrompt?: boolean;
@@ -95,11 +102,20 @@ function fakeHarness(options: FakeOptions = {}) {
       for (const event of promptEvents) eventHandler?.(event);
       await options.afterPromptEvents?.();
       if (options.emitPermission) {
-        permissionHandler?.({
-          id: "perm-1",
-          availableReplies: ["once", "always", "reject"],
-          toolCall: { toolCallId: "tool-1", name: "edit" },
-        });
+        const permissionRequests = options.permissionRequests ?? [
+          {
+            id: "perm-1",
+            availableReplies: ["once", "always", "reject"],
+            toolCall: {
+              toolCallId: options.permissionToolCallId ?? "tool-1",
+              name: options.permissionToolName ?? "edit",
+              title: options.permissionToolName ?? "edit",
+              rawInput: options.permissionRawInput,
+              input: options.permissionRawInput,
+            },
+          },
+        ];
+        for (const request of permissionRequests) permissionHandler?.(request);
       }
       if (options.postPermissionEvents?.length) {
         if (options.emitPermission) await flushPromises();
@@ -175,6 +191,10 @@ function fakeHarness(options: FakeOptions = {}) {
     events() {
       return events;
     },
+    settleOpenToolCalls(
+      _isExcluded: (id: string) => boolean,
+      _message: string,
+    ) {},
     traceId() {
       return "trace-1";
     },
@@ -927,6 +947,316 @@ describe("runSandboxAgent default ApprovalResponder wiring", () => {
     assert.deepEqual(calls.permissionReplies, []);
   });
 
+  it("settles serialized write-tool sibling calls before pause teardown", async () => {
+    const { deps } = fakeHarness({
+      promptEvents: [
+        {
+          payload: {
+            update: {
+              sessionUpdate: "tool_call",
+              toolCallId: "tool-a",
+              title: "commit_revision",
+              rawInput: { revision: "r1" },
+            },
+          },
+        },
+        {
+          payload: {
+            update: {
+              sessionUpdate: "tool_call",
+              toolCallId: "tool-b",
+              title: "create_subscription",
+              rawInput: { plan: "pro" },
+            },
+          },
+        },
+      ],
+      emitPermission: true,
+      permissionToolCallId: "tool-a",
+      permissionToolName: "commit_revision",
+      permissionRawInput: { revision: "r1" },
+      hangPrompt: true,
+    });
+    delete deps.responderFactory;
+    deps.createOtel = createSandboxAgentOtel as any;
+
+    const result = await runSandboxAgent(
+      {
+        harness: "claude",
+        permissions: { default: "ask" },
+        messages: [{ role: "user", content: "commit and subscribe" }],
+      } as AgentRunRequest,
+      undefined,
+      undefined,
+      deps,
+    );
+    await flushPromises();
+
+    assert.equal(result.ok, true);
+    if (!result.ok) return;
+    assert.equal(result.stopReason, "paused");
+
+    const interactions = result.events?.filter(
+      (event) => event.type === "interaction_request",
+    );
+    assert.equal(interactions?.length, 1);
+    assert.equal((interactions?.[0] as any).payload?.toolCallId, "tool-a");
+
+    const toolResults = result.events
+      ?.filter((event) => event.type === "tool_result")
+      .map((event) => ({
+        id: (event as any).id,
+        output: (event as any).output,
+        isError: (event as any).isError,
+      }));
+    assert.deepEqual(toolResults, [
+      {
+        id: "tool-b",
+        output: TOOL_NOT_EXECUTED_PAUSED,
+        isError: true,
+      },
+    ]);
+    assert.equal(toolResults?.some((event) => event.id === "tool-a"), false);
+  });
+
+  it("settles a latch-loser sibling when read-only permission requests race", async () => {
+    const readOnlySpec = (name: string) => ({
+      name,
+      kind: "callback",
+      readOnly: true,
+      permission: "ask",
+    });
+    const { deps } = fakeHarness({
+      promptEvents: [
+        {
+          payload: {
+            update: {
+              sessionUpdate: "tool_call",
+              toolCallId: "tool-a",
+              title: "read_alpha",
+              rawInput: { path: "a" },
+            },
+          },
+        },
+        {
+          payload: {
+            update: {
+              sessionUpdate: "tool_call",
+              toolCallId: "tool-b",
+              title: "read_beta",
+              rawInput: { path: "b" },
+            },
+          },
+        },
+      ],
+      emitPermission: true,
+      permissionRequests: [
+        {
+          id: "perm-a",
+          availableReplies: ["once", "always", "reject"],
+          toolCall: {
+            toolCallId: "tool-a",
+            name: "read_alpha",
+            title: "read_alpha",
+            rawInput: { path: "a" },
+            input: { path: "a" },
+            spec: readOnlySpec("read_alpha"),
+          },
+        },
+        {
+          id: "perm-b",
+          availableReplies: ["once", "always", "reject"],
+          toolCall: {
+            toolCallId: "tool-b",
+            name: "read_beta",
+            title: "read_beta",
+            rawInput: { path: "b" },
+            input: { path: "b" },
+            spec: readOnlySpec("read_beta"),
+          },
+        },
+      ],
+      hangPrompt: true,
+    });
+    delete deps.responderFactory;
+    deps.createOtel = createSandboxAgentOtel as any;
+
+    const result = await runSandboxAgent(
+      {
+        harness: "claude",
+        permissions: { default: "ask" },
+        messages: [{ role: "user", content: "read both" }],
+      } as AgentRunRequest,
+      undefined,
+      undefined,
+      deps,
+    );
+    await flushPromises();
+
+    assert.equal(result.ok, true);
+    if (!result.ok) return;
+    assert.equal(result.stopReason, "paused");
+
+    const interactions = result.events?.filter(
+      (event) => event.type === "interaction_request",
+    );
+    assert.equal(interactions?.length, 1);
+    assert.equal((interactions?.[0] as any).payload?.toolCallId, "tool-a");
+
+    const toolResults = result.events
+      ?.filter((event) => event.type === "tool_result")
+      .map((event) => ({
+        id: (event as any).id,
+        output: (event as any).output,
+        isError: (event as any).isError,
+      }));
+    assert.deepEqual(toolResults, [
+      {
+        id: "tool-b",
+        output: TOOL_NOT_EXECUTED_PAUSED,
+        isError: true,
+      },
+    ]);
+  });
+
+  it("settles a sibling whose announcement arrives AFTER the pause (teardown race)", async () => {
+    // The live incident shape: the sibling's `tool_call` announcement rides the ACP event
+    // stream and can arrive at the runner AFTER the gate won the latch and the pause-time
+    // sweep already ran. The event-handler re-sweep must settle it deterministically.
+    const { deps } = fakeHarness({
+      promptEvents: [
+        {
+          payload: {
+            update: {
+              sessionUpdate: "tool_call",
+              toolCallId: "tool-a",
+              title: "commit_revision",
+              rawInput: { revision: "r1" },
+            },
+          },
+        },
+      ],
+      emitPermission: true,
+      permissionToolCallId: "tool-a",
+      permissionToolName: "commit_revision",
+      permissionRawInput: { revision: "r1" },
+      // Announced only after the permission gate fired (and the pause ran its sweep).
+      postPermissionEvents: [
+        {
+          payload: {
+            update: {
+              sessionUpdate: "tool_call",
+              toolCallId: "tool-late",
+              title: "request_connection",
+              rawInput: { integration: "slack" },
+            },
+          },
+        },
+      ],
+      hangPrompt: true,
+    });
+    delete deps.responderFactory;
+    deps.createOtel = createSandboxAgentOtel as any;
+
+    const result = await runSandboxAgent(
+      {
+        harness: "claude",
+        permissions: { default: "ask" },
+        messages: [{ role: "user", content: "commit and connect" }],
+      } as AgentRunRequest,
+      undefined,
+      undefined,
+      deps,
+    );
+    await flushPromises();
+
+    assert.equal(result.ok, true);
+    if (!result.ok) return;
+    assert.equal(result.stopReason, "paused");
+    const toolResults = result.events
+      ?.filter((event) => event.type === "tool_result")
+      .map((event) => ({
+        id: (event as any).id,
+        output: (event as any).output,
+        isError: (event as any).isError,
+      }));
+    assert.deepEqual(toolResults, [
+      {
+        id: "tool-late",
+        output: TOOL_NOT_EXECUTED_PAUSED,
+        isError: true,
+      },
+    ]);
+  });
+
+  it("emits the deferred sibling result before the paused turn is done", async () => {
+    const emitted: AgentEvent[] = [];
+    const { deps } = fakeHarness({
+      promptEvents: [
+        {
+          payload: {
+            update: {
+              sessionUpdate: "tool_call",
+              toolCallId: "tool-a",
+              title: "commit_revision",
+              rawInput: { revision: "r1" },
+            },
+          },
+        },
+        {
+          payload: {
+            update: {
+              sessionUpdate: "tool_call",
+              toolCallId: "tool-b",
+              title: "create_subscription",
+              rawInput: { plan: "pro" },
+            },
+          },
+        },
+      ],
+      emitPermission: true,
+      permissionToolCallId: "tool-a",
+      permissionToolName: "commit_revision",
+      permissionRawInput: { revision: "r1" },
+      hangPrompt: true,
+    });
+    delete deps.responderFactory;
+    deps.createOtel = createSandboxAgentOtel as any;
+
+    const result = await runSandboxAgent(
+      {
+        harness: "claude",
+        permissions: { default: "ask" },
+        messages: [{ role: "user", content: "commit and subscribe" }],
+      } as AgentRunRequest,
+      (event) => emitted.push(event),
+      undefined,
+      deps,
+    );
+    await flushPromises();
+
+    assert.equal(result.ok, true);
+    const interactionIndex = emitted.findIndex(
+      (event) => event.type === "interaction_request",
+    );
+    const siblingResultIndex = emitted.findIndex(
+      (event) => event.type === "tool_result" && (event as any).id === "tool-b",
+    );
+    const doneIndex = emitted.findIndex((event) => event.type === "done");
+
+    assert.notEqual(interactionIndex, -1, "approval request is emitted");
+    assert.notEqual(siblingResultIndex, -1, "sibling result is emitted");
+    assert.notEqual(doneIndex, -1, "done is emitted");
+    assert.ok(
+      interactionIndex < siblingResultIndex,
+      "approval request is emitted before the teardown sweep runs",
+    );
+    assert.ok(
+      siblingResultIndex < doneIndex,
+      "sibling result reaches the live sink before turn finish",
+    );
+  });
+
   it("drops teardown tool updates after a Pi relay approval pause while keeping other ids", async () => {
     const relayPause = { fire: () => {} };
     const { calls, deps } = fakeHarness({
@@ -1015,7 +1345,7 @@ describe("runSandboxAgent default ApprovalResponder wiring", () => {
           output: (event as any).output,
           isError: (event as any).isError,
         })),
-      [{ id: "tool-2", output: "other failed", isError: true }],
+      [{ id: "tool-2", output: TOOL_NOT_EXECUTED_PAUSED, isError: true }],
     );
   });
 

--- a/services/runner/tests/unit/stream-events.test.ts
+++ b/services/runner/tests/unit/stream-events.test.ts
@@ -11,7 +11,10 @@
 import { describe, it } from "vitest";
 import assert from "node:assert/strict";
 
-import { createSandboxAgentOtel } from "../../src/tracing/otel.ts";
+import {
+  createSandboxAgentOtel,
+  TOOL_NOT_EXECUTED_PAUSED,
+} from "../../src/tracing/otel.ts";
 import type { AgentEvent } from "../../src/protocol.ts";
 
 const textChunk = (text: string) => ({
@@ -184,6 +187,50 @@ describe("createSandboxAgentOtel state machine", () => {
     assert.equal(ofType(emitted, "tool_result").length, 1, "tool_result present");
     const seq = types(emitted);
     assert.ok(seq.indexOf("tool_call") < seq.indexOf("tool_result"), "tool_call precedes its result");
+  });
+
+  it("settleOpenToolCalls excludes paused calls and is idempotent per open sibling", () => {
+    const emitted: AgentEvent[] = [];
+    const run = createSandboxAgentOtel({
+      harness: "claude",
+      model: "anthropic/x",
+      emit: (e) => emitted.push(e),
+      emitSpans: false,
+    });
+    run.start({ prompt: "x" });
+    run.handleUpdate(toolCall("call_1", "needsApproval", { a: 1 }));
+    run.handleUpdate(toolCall("call_2", "sibling", { b: 2 }));
+
+    run.settleOpenToolCalls(
+      (id) => id === "call_1",
+      TOOL_NOT_EXECUTED_PAUSED,
+    );
+
+    let results = ofType(emitted, "tool_result");
+    assert.equal(
+      results.some((event) => event.id === "call_1"),
+      false,
+      "excluded call remains pending",
+    );
+    assert.deepEqual(
+      results
+        .filter((event) => event.id === "call_2")
+        .map((event) => ({ output: event.output, isError: event.isError })),
+      [{ output: TOOL_NOT_EXECUTED_PAUSED, isError: true }],
+    );
+
+    run.settleOpenToolCalls(() => false, "second sweep");
+    results = ofType(emitted, "tool_result");
+    assert.equal(
+      results.filter((event) => event.id === "call_2").length,
+      1,
+      "already-settled sibling is not recorded twice",
+    );
+    assert.equal(
+      results.filter((event) => event.id === "call_1").length,
+      1,
+      "previously excluded call can settle on a later sweep",
+    );
   });
 
   it("scenario 7: growing arg deltas keep refreshing until the FINAL args are recorded", () => {

--- a/services/runner/tests/unit/transcript.test.ts
+++ b/services/runner/tests/unit/transcript.test.ts
@@ -1,24 +1,60 @@
 import { describe, it } from "vitest";
 import assert from "node:assert/strict";
 
-import { messageTranscript } from "../../src/engines/sandbox_agent/transcript.ts";
-import type { ContentBlock } from "../../src/protocol.ts";
+import {
+  buildTurnText,
+  messageTranscript,
+} from "../../src/engines/sandbox_agent/transcript.ts";
+import type { AgentRunRequest, ContentBlock } from "../../src/protocol.ts";
+
+const COMMIT_TOOL = "mcp__agenta-tools__commit_revision";
+const OTHER_TOOL = "mcp__agenta-tools__summarize";
 
 function toolApprovalContent(approved: boolean): ContentBlock[] {
   return [
     {
       type: "tool_call",
       toolCallId: "call-1",
-      toolName: "mcp__agenta-tools__commit_revision",
+      toolName: COMMIT_TOOL,
       input: { name: "draft", parameters: { temperature: 0.2 } },
     },
     {
       type: "tool_result",
       toolCallId: "call-1",
-      toolName: "mcp__agenta-tools__commit_revision",
+      toolName: COMMIT_TOOL,
       output: { approved },
     },
   ];
+}
+
+function approvalResult(
+  toolCallId: string,
+  approved: boolean,
+  toolName = COMMIT_TOOL,
+): ContentBlock {
+  return {
+    type: "tool_result",
+    toolCallId,
+    toolName,
+    output: { approved },
+  };
+}
+
+function realResult(toolName = COMMIT_TOOL): ContentBlock {
+  return {
+    type: "tool_result",
+    toolName,
+    output: { ok: true },
+  };
+}
+
+function turnTextFor(
+  prior: { role: string; content: string | ContentBlock[] }[],
+): string {
+  const request: AgentRunRequest = {
+    messages: [...prior, { role: "user", content: "continue" }],
+  };
+  return buildTurnText(request);
 }
 
 describe("messageTranscript", () => {
@@ -65,5 +101,88 @@ describe("messageTranscript", () => {
 
     assert.match(transcript, /APPROVED approval_status/);
     assert.match(transcript, /NOT run yet/);
+  });
+});
+
+describe("buildTurnText approval transcript hints", () => {
+  it("renders an approval envelope as executed once a later real result exists for the same tool", () => {
+    const transcript = turnTextFor([
+      {
+        role: "assistant",
+        content: [approvalResult("call-1", true)],
+      },
+      {
+        role: "tool",
+        content: [realResult(COMMIT_TOOL)],
+      },
+    ]);
+
+    assert.match(
+      transcript,
+      /APPROVED mcp__agenta-tools__commit_revision; executed below/,
+    );
+    assert.doesNotMatch(transcript, /NOT run yet/);
+    assert.doesNotMatch(transcript, /Call the tool again/);
+  });
+
+  it("keeps only the latest unresolved approval nudge for duplicate pending envelopes", () => {
+    const transcript = turnTextFor([
+      {
+        role: "assistant",
+        content: [
+          approvalResult("call-1", true),
+          approvalResult("call-2", true),
+        ],
+      },
+    ]);
+
+    assert.equal((transcript.match(/Call the tool again/g) ?? []).length, 1);
+    assert.equal((transcript.match(/NOT run yet/g) ?? []).length, 1);
+    assert.match(
+      transcript,
+      /approved mcp__agenta-tools__commit_revision earlier/,
+    );
+    assert.doesNotMatch(transcript, /executed below/);
+  });
+
+  it("does not treat a later real result for a different tool as execution", () => {
+    const transcript = turnTextFor([
+      {
+        role: "assistant",
+        content: [approvalResult("call-1", true, COMMIT_TOOL)],
+      },
+      {
+        role: "tool",
+        content: [realResult(OTHER_TOOL)],
+      },
+    ]);
+
+    assert.match(transcript, /APPROVED mcp__agenta-tools__commit_revision/);
+    assert.match(transcript, /NOT run yet/);
+    assert.match(transcript, /Call the tool again/);
+    assert.doesNotMatch(
+      transcript,
+      /APPROVED mcp__agenta-tools__commit_revision; executed below/,
+    );
+  });
+
+  it("keeps denied envelopes denied even if a later same-tool result exists", () => {
+    const transcript = turnTextFor([
+      {
+        role: "assistant",
+        content: [approvalResult("call-1", false, COMMIT_TOOL)],
+      },
+      {
+        role: "tool",
+        content: [realResult(COMMIT_TOOL)],
+      },
+    ]);
+
+    assert.match(transcript, /DENIED mcp__agenta-tools__commit_revision/);
+    assert.match(transcript, /not executed/);
+    assert.doesNotMatch(
+      transcript,
+      /DENIED mcp__agenta-tools__commit_revision; executed below/,
+    );
   });
 });

--- a/services/runner/tests/unit/transcript.test.ts
+++ b/services/runner/tests/unit/transcript.test.ts
@@ -1,0 +1,69 @@
+import { describe, it } from "vitest";
+import assert from "node:assert/strict";
+
+import { messageTranscript } from "../../src/engines/sandbox_agent/transcript.ts";
+import type { ContentBlock } from "../../src/protocol.ts";
+
+function toolApprovalContent(approved: boolean): ContentBlock[] {
+  return [
+    {
+      type: "tool_call",
+      toolCallId: "call-1",
+      toolName: "mcp__agenta-tools__commit_revision",
+      input: { name: "draft", parameters: { temperature: 0.2 } },
+    },
+    {
+      type: "tool_result",
+      toolCallId: "call-1",
+      toolName: "mcp__agenta-tools__commit_revision",
+      output: { approved },
+    },
+  ];
+}
+
+describe("messageTranscript", () => {
+  it("renders approved permission envelopes as pending execution, not tool output", () => {
+    const transcript = messageTranscript(toolApprovalContent(true));
+
+    assert.match(transcript, /APPROVED mcp__agenta-tools__commit_revision/);
+    assert.match(transcript, /NOT run yet/);
+    assert.match(transcript, /Call the tool again with the same arguments now to execute it/);
+    assert.doesNotMatch(transcript, /returned: \{"approved":true\}/);
+  });
+
+  it("renders denied permission envelopes as not executed", () => {
+    const transcript = messageTranscript(toolApprovalContent(false));
+
+    assert.match(transcript, /DENIED mcp__agenta-tools__commit_revision/);
+    assert.match(transcript, /not executed/);
+  });
+
+  it("keeps unrelated tool results on the generic returned path", () => {
+    const transcript = messageTranscript([
+      {
+        type: "tool_result",
+        toolName: "mcp__agenta-tools__summarize",
+        output: { summary: "3 issues found" },
+      },
+    ]);
+
+    assert.match(
+      transcript,
+      /mcp__agenta-tools__summarize returned: \{"summary":"3 issues found"\}/,
+    );
+  });
+
+  it("documents the accepted ambiguity for real tool data shaped like an approval", () => {
+    // This narrow ambiguity already exists in the approval decision store.
+    const transcript = messageTranscript([
+      {
+        type: "tool_result",
+        toolName: "approval_status",
+        output: { approved: true },
+      },
+    ]);
+
+    assert.match(transcript, /APPROVED approval_status/);
+    assert.match(transcript, /NOT run yet/);
+  });
+});

--- a/web/oss/src/components/AgentChatSlice/components/ToolActivity.tsx
+++ b/web/oss/src/components/AgentChatSlice/components/ToolActivity.tsx
@@ -5,6 +5,8 @@ import {
     ArrowSquareOut,
     CaretRight,
     CheckCircle,
+    Clock,
+    Info,
     Prohibit,
     Spinner,
     Warning,
@@ -33,6 +35,15 @@ const partToolName = (part: ToolUIPart): string => {
 // (preparing input, running, awaiting/just-answered an approval) is still in flight.
 const SETTLED = new Set(["output-available", "output-error", "output-denied"])
 const isSettled = (state: string) => SETTLED.has(state)
+
+const DEFERRED_PREFIX = "DEFERRED_NOT_EXECUTED:"
+const isDeferredError = (errorText: string | undefined): boolean =>
+    !!errorText && errorText.startsWith(DEFERRED_PREFIX)
+
+const isNotHandledOutput = (output: unknown): boolean =>
+    !!output &&
+    typeof output === "object" &&
+    (output as {status?: unknown}).status === "not_handled"
 
 /**
  * Derive a single human line from a tool's output. Output shape is arbitrary, so this stays
@@ -63,18 +74,31 @@ const summarizeOutput = (output: unknown): string | null => {
 }
 
 const rowSummary = (part: ToolUIPart): string | null => {
-    if (part.state === "output-available") return summarizeOutput(part.output)
-    if (part.state === "output-error") return "failed"
+    if (part.state === "output-available") {
+        if (isNotHandledOutput(part.output)) return "not handled by this client"
+        return summarizeOutput(part.output)
+    }
+    if (part.state === "output-error") {
+        const errorText = (part as {errorText?: string}).errorText
+        return isDeferredError(errorText) ? "waiting on another approval" : "failed"
+    }
     if (part.state === "output-denied") return "denied"
     return null
 }
 
 /** Per-tool status glyph, shared by the live gutter and the expanded list. */
-const StatusIcon = ({state}: {state: string}) => {
-    if (state === "output-available")
+const StatusIcon = ({part}: {part: ToolUIPart}) => {
+    const state = part.state as string
+    if (state === "output-available") {
+        if (isNotHandledOutput((part as {output?: unknown}).output))
+            return <Info size={13} className="shrink-0 text-colorTextTertiary" />
         return <CheckCircle size={13} weight="fill" className="shrink-0 text-colorSuccess" />
-    if (state === "output-error")
+    }
+    if (state === "output-error") {
+        if (isDeferredError((part as {errorText?: string}).errorText))
+            return <Clock size={13} className="shrink-0 text-colorTextTertiary" />
         return <Warning size={13} weight="fill" className="shrink-0 text-colorError" />
+    }
     if (state === "output-denied")
         return <Prohibit size={13} className="shrink-0 text-colorTextTertiary" />
     if (state === "approval-requested")
@@ -117,6 +141,11 @@ const ToolRow = ({
 }) => {
     const name = partToolName(part)
     const state = part.state as string
+    const input = (part as {input?: unknown}).input
+    const output = (part as {output?: unknown}).output
+    const errorText = (part as {errorText?: string}).errorText
+    const deferred = state === "output-error" && isDeferredError(errorText)
+    const notHandled = state === "output-available" && isNotHandledOutput(output)
     // `approval-responded` is resolved (the user answered) — not "running". Its execution shows on
     // a sibling part, so this must not spin forever (the cold-replay lingering-gate spinner).
     const running =
@@ -131,16 +160,17 @@ const ToolRow = ({
               : live && running
                 ? "running…"
                 : detailed
-                  ? state === "output-error"
-                      ? "failed"
-                      : state === "output-denied"
-                        ? "denied"
-                        : null
+                  ? deferred
+                      ? "waiting on another approval"
+                      : state === "output-error"
+                        ? "failed"
+                        : state === "output-denied"
+                          ? "denied"
+                          : notHandled
+                            ? "not handled by this client"
+                            : null
                   : rowSummary(part)
 
-    const input = (part as {input?: unknown}).input
-    const output = (part as {output?: unknown}).output
-    const errorText = (part as {errorText?: string}).errorText
     // Track presence explicitly: a legit `null` output is real (don't hide it), and
     // `output-available` with no `output` key must not open an empty expander.
     const hasInput = input !== undefined
@@ -153,13 +183,13 @@ const ToolRow = ({
 
     const header = (
         <>
-            <StatusIcon state={state} />
+            <StatusIcon part={part} />
             <Text className="!text-xs !font-medium min-w-0 truncate" title={name}>
                 {name}
             </Text>
             {midText ? (
                 <Text
-                    type={state === "output-error" ? "danger" : "secondary"}
+                    type={state === "output-error" && !deferred ? "danger" : "secondary"}
                     className="!text-xs min-w-0 truncate"
                     title={typeof midText === "string" ? midText : undefined}
                 >
@@ -196,7 +226,11 @@ const ToolRow = ({
                     <div className="mt-1 flex min-w-0 flex-col gap-1.5 pl-[21px]">
                         {hasInput ? <IOBlock label="input" value={formatToolValue(input)} /> : null}
                         {hasError ? (
-                            <IOBlock label="error" value={stripFence(errorText)} danger />
+                            <IOBlock
+                                label={deferred ? "note" : "error"}
+                                value={stripFence(errorText)}
+                                danger={!deferred}
+                            />
                         ) : hasOutput ? (
                             <IOBlock label="output" value={formatToolValue(output)} />
                         ) : null}
@@ -271,7 +305,11 @@ const ToolActivity = ({
     }
 
     // ---- Settled: the quiet "Used N tools" line + expandable list ----
-    const failed = parts.filter((p) => (p.state as string) === "output-error").length
+    const failed = parts.filter(
+        (p) =>
+            (p.state as string) === "output-error" &&
+            !isDeferredError((p as {errorText?: string}).errorText),
+    ).length
     const count = parts.length
     const label = count === 1 ? `Used ${partToolName(parts[0])}` : `Used ${count} tools`
     const SummaryIcon = failed > 0 ? Warning : CheckCircle

--- a/web/oss/src/components/AgentChatSlice/components/clientTools/UnhandledClientTool.tsx
+++ b/web/oss/src/components/AgentChatSlice/components/clientTools/UnhandledClientTool.tsx
@@ -1,11 +1,11 @@
 /**
  * Fallback surface for a parked client tool with no registered widget (design §"Where dispatch
- * lives"). It must SETTLE the part so the run never hangs silently: on mount it settles an error,
- * which resumes the run and lets the agent re-ask or move on. The row stays as a brief explanation.
+ * lives"). It must SETTLE the part so the run never hangs silently: on mount it settles a neutral
+ * non-error output, which resumes the run and lets the agent re-ask or move on.
  */
 import {useEffect, useRef} from "react"
 
-import {Warning} from "@phosphor-icons/react"
+import {Info} from "@phosphor-icons/react"
 import {Typography} from "antd"
 
 import type {ClientToolHandlerProps} from "./types"
@@ -17,14 +17,14 @@ const UnhandledClientTool = ({meta, settle}: ClientToolHandlerProps) => {
     useEffect(() => {
         if (settledRef.current || meta.settled) return
         settledRef.current = true
-        settle({errorText: `This app can’t handle the "${meta.toolName}" request.`})
-    }, [meta.settled, meta.toolName, settle])
+        settle({output: {status: "not_handled", message: "Not handled by this client."}})
+    }, [meta.settled, settle])
 
     return (
-        <div className="flex min-w-0 items-center gap-2 py-1">
-            <Warning size={13} weight="fill" className="shrink-0 text-colorWarning" />
-            <Text type="secondary" className="!text-xs truncate">
-                Can’t handle the “{meta.toolName}” request
+        <div className="flex min-w-0 items-center gap-2 py-1" title={meta.toolName}>
+            <Info size={13} className="shrink-0 text-colorTextTertiary" />
+            <Text type="secondary" className="!text-xs !text-colorTextTertiary truncate">
+                Not handled by this client
             </Text>
         </div>
     )


### PR DESCRIPTION
## Context

When the agent called two approval-gated tools in one playground turn, the second tool showed a fake red failure: "This app can't handle the \"mcp__agenta-tools__create_subscription\" request." Nothing failed. Nothing ran. The runner lets only one tool call pause a turn (the `PendingApprovalLatch`), and it silently dropped the second gate. That tool call had already streamed to the client, so the browser held a tool part with no result, classified it as an unknown client tool, and invented the error.

A second bug rode on the same flow: the replay transcript rendered an approved call as `[tool returned: {"approved":true}]`. That reads as a completed call, so the model claimed success ("the revision is already saved") and never re-issued it. The user approved, the UI said approved, and nothing existed server-side. Full writeup: `docs/design/parallel-approval-gates/phantom-execution-findings.md`.

## Changes

**Runner: settle deferred siblings truthfully (Option A from the plan).** At pause time, before the session is destroyed, the runner sweeps every announced tool call with no result (except the one that won the latch) and settles it with a deterministic terminal result:

```
{type: "tool_result", isError: true,
 output: "DEFERRED_NOT_EXECUTED: paused for another approval; retry the same call if still required."}
```

The sweep re-runs when an announcement arrives after the pause already won. Live testing showed this race is the common case: the sibling's `tool_call` frame rides the ACP event stream and often lands after the gate RPC paused the turn.

**Runner: FIFO decision store.** Two identical gated calls (same tool, same args) used to collapse to one stored approval, so only one re-raised gate got answered on replay. The store now keeps a FIFO list per key, mirroring the client-tool output store next to it.

**Runner: honest replay transcript.** An `{approved: true}` envelope now replays as `[user APPROVED <tool>; the call has NOT run yet. Call the tool again with the same arguments now to execute it.]` (plus a deny twin). The model re-issues the call, the stored decision answers the re-raised gate, and the call actually executes.

**Frontend: neutral rendering, no tool-name lists.** The deferred sibling renders muted with a clock icon and "waiting on another approval", not a red "failed". A genuinely unhandled client tool now settles with the neutral output `{status: "not_handled"}` and renders informational ("not handled by this client") instead of fabricating an error the model later trusts as real. Both branches key on structured shape (the `DEFERRED_NOT_EXECUTED:` sentinel prefix and the `status` field), never on a tool name.

UI before and after:

| | Before | After |
|---|---|---|
| Deferred sibling | red Warning, "failed", error text "This app can't handle the ... request." | muted Clock, "waiting on another approval" |
| Unhandled client tool | red Warning + fabricated error in history | muted Info, "not handled by this client", neutral output in history |
| After approving the winner | new duplicated turn block | turn continues in place, next gate appears |
| Approved call on replay | model claims success, nothing runs | model re-issues, call executes for real |

## Scope / risk

This ships Option A plus the review companions. Option B (batching all pending approvals into one dock pass with synthetic sibling gates) is the planned follow-up; see `docs/design/parallel-approval-gates/plan.md` Phases 2-3. Not touched: the F-040 pause contract (the runner still never replies to a harness gate that needs a human), the wire contract (no new fields; the settle reuses the existing `tool_result` event), the approval dock, and the resume predicate.

Known limitation (pre-existing, documented): if the model re-issues an approved call with different args (it likes to rewrite long instruction strings on each replay), the stored decision misses on the name+args key and the user gets re-prompted. Safe but chatty. This existed before this PR; the honest transcript makes the model retry reliably, which is what surfaces it.

## Tests

- `services/runner`: `pnpm run typecheck` and `pnpm test` green, 46 files / 547 tests. New coverage: the serialized-write sibling settle, the read-only concurrent-gates race, the post-pause announcement race, live-sink ordering (sibling result before `done`), `settleOpenToolCalls` idempotency, FIFO duplicate decisions, and the transcript rendering (new `transcript.test.ts`).
- `web`: `pnpm lint-fix` clean. No render-test harness exists for these components; none was invented.
- Live E2E on the dev stack (claude harness, sonnet, self-managed via the subscription sidecar): reproduced the original two-gated-tools scenario from the agent-home builder. The sibling showed the muted deferred state, no phantom failure appeared anywhere, the turn resumed in place after each approval, and the approved `commit_revision` executed for real: revision v2 ("Add Slack #support → GitHub issue triage agent") exists in the database.

## How to QA

**Prerequisites:** the dev stack on the Hetzner box (port 8280) with the subscription sidecar running and holding a Claude login (`subscription-sidecar` skill). The runner compiles at container start, so restart the sidecar after pulling this branch.

**Steps:**
1. On the project home, use the composer: "create an agent that reads new messages in our support channel and checks github for existing issues, else creates one".
2. In the playground session that opens, answer the follow-up with: "Slack channel #support, repo agenta-ai/agenta. Do both steps in parallel: commit the revision AND create the subscription in the same turn."
3. Watch the tool rows when the approval dock appears.
4. Approve the gate. Repeat if the model re-prompts (it rewrites its args; see the known limitation).

**Expected result:** the winning tool shows "Awaiting approval" in the dock. Every sibling tool in the same turn shows a muted clock row reading "waiting on another approval". No row shows "This app can't handle the ... request." After approving, the turn continues inside the same block (no duplicate turn), and once the stored decision matches, the tool executes: check `workflow_revisions` for the new revision.

**Automated tests:**
```
cd services/runner && pnpm test
```

**Edge cases:** a genuinely unknown client tool (no registered widget) must settle informational ("not handled by this client"), not as an error. A real tool failure must still render red; only the `DEFERRED_NOT_EXECUTED:` sentinel gets the muted treatment.

https://claude.ai/code/session_01N2djTMgXnpk84EqtugHDJB