### PR TITLE
[fix] Make the Vercel adapter lossless inbound and always finish the stream

### DIFF
--- a/docs/designs/vercel-stream-conformance/specs.md
+++ b/docs/designs/vercel-stream-conformance/specs.md
@@ -1,0 +1,42 @@
+# Vercel stream conformance — specs
+
+> Closes the two Vercel data-stream protocol conformance bugs from the v3 assessment (F-3, F-4). Source:
+> `big-agents-audit/big-agents-assessment-v3.md`. SDK-only; both live in
+> `sdks/python/agenta/sdk/agents/adapters/vercel/`. Independent of the other worktrees.
+
+## F-3 — Inbound parser silently drops part types (Med)
+
+**Problem.** `_part_to_blocks` (`.../vercel/messages.py`) handles `text` / `file` / `tool-*` and falls
+through to `return []` for everything else — `reasoning`, `data-*`, `error`, `source-url`, `step-start`
+are dropped with **no log**. Outbound→inbound is lossy, which breaks round-trip fidelity against the
+Vercel data-stream protocol.
+
+**Fix.** Map the missing part kinds, or at minimum **preserve-and-forward** unknown parts rather than
+silently dropping them (an unknown part should survive the round-trip, even if as an opaque/passthrough
+block, and an unmapped kind should at least be observable — a debug log or a metric, never a silent drop).
+Prefer explicit mapping for the known kinds the outbound side emits (`reasoning` especially, since the
+stream layer emits reasoning frames — see `stream.py`), and passthrough for the genuinely unknown.
+
+**Done when:** a message containing a `reasoning` (and the other currently-dropped kinds) survives
+`_part_to_blocks` instead of vanishing; a round-trip golden asserts outbound→inbound is lossless for the
+kinds the adapter emits; unknown kinds are preserved-or-logged, never silently dropped.
+
+## F-4 — Mid-stream exception skips the finish frame (Low, Very-Low effort)
+
+**Problem.** In the stream loop (`.../vercel/stream.py`), a graceful terminal-failure result correctly
+emits no finish (tested, intentional). But a raw `except Exception` inside the loop does `yield error;
+return` with **no `finally`**, so the `finish-step` / `finish` tail never runs. A consumer counting on a
+finish frame (the AI SDK UI message stream requires every stream to terminate with `finish`) **hangs** on
+an unexpected error.
+
+**Fix.** Wrap the emit tail so the finish frame **always** fires — a `try/finally` around the stream body
+so the `finish-step`/`finish` frames emit on every exit path, including the unexpected-exception path.
+Keep the existing intentional no-finish behavior for graceful terminal-failure results (don't regress the
+tested case) — this is specifically about the untested raw-exception path.
+
+**Done when:** an unexpected exception mid-stream still emits the terminal `finish` frame (new test for the
+raw-exception path); the existing graceful-terminal-failure test still passes unchanged.
+
+## Non-goals
+No redesign of the adapter; no change to the finish-reason enum mapping beyond what F-4 requires. These are
+two contained protocol-conformance fixes in the Vercel adapter.

--- a/docs/designs/vercel-stream-conformance/tasks.md
+++ b/docs/designs/vercel-stream-conformance/tasks.md
@@ -1,0 +1,31 @@
+# Vercel stream conformance — tasks
+
+> Companion to `specs.md`. One worktree (`feat/vercel-stream-conformance`). Two independent WPs in the
+> SDK Vercel adapter. Effort: Low · Very Low.
+
+- **WP1 — F-3: stop dropping inbound part types.** Effort: Low. Level: SDK.
+  - `sdks/python/agenta/sdk/agents/adapters/vercel/messages.py` — `_part_to_blocks` currently falls
+    through to `return []` for `reasoning` / `data-*` / `error` / `source-url` / `step-start`. Map the
+    known kinds the outbound side emits (esp. `reasoning`, which `stream.py` emits), and preserve-and-forward
+    genuinely-unknown parts instead of silently dropping; make an unmapped kind observable (debug log or
+    metric), never a silent drop.
+  - Add a **round-trip golden** asserting outbound→inbound is lossless for the emitted kinds.
+
+- **WP2 — F-4: finish frame always fires.** Effort: Very Low. Level: SDK.
+  - `sdks/python/agenta/sdk/agents/adapters/vercel/stream.py` — wrap the emit tail in `try/finally` so the
+    `finish-step`/`finish` frames emit on every exit path, including the raw-`except Exception` path (today
+    `yield error; return` skips the tail). Do NOT regress the intentional graceful-terminal-failure
+    no-finish case (it's tested).
+  - Add a test for the raw-exception path asserting the terminal `finish` frame is still emitted.
+
+## Verify
+- SDK: from `sdks/python/` run `ruff format` then `ruff check --fix`. Run the existing Vercel adapter
+  tests plus your new ones: `cd sdks/python && uv run --no-sync python -m pytest oss/tests/pytest/unit/agents/adapters -q`
+  (existing suites: `test_vercel_stream_finish_reason.py`, `test_vercel_stream_park.py`). Report REAL results.
+- Do NOT commit. Do NOT deploy.
+
+## Constraints
+- **No audit/finding identifiers** (`F-3`, `F-4`, etc.) anywhere in code, tests, or comments — describe
+  behavior plainly.
+- One terse comment line max, or none.
+- Match the adapter's existing style.

--- a/sdks/python/agenta/sdk/agents/adapters/vercel/messages.py
+++ b/sdks/python/agenta/sdk/agents/adapters/vercel/messages.py
@@ -64,6 +64,28 @@ def _ui_message_to_message(raw: Any) -> Optional[Message]:
 
 
 def _part_to_blocks(part: Any) -> List[ContentBlock]:
+    """A Vercel ``UIMessage`` part -> zero or more neutral ``ContentBlock``s.
+
+    Agenta's ``ContentBlock`` model is canonical. This mapper only ever produces
+    ``ContentBlock`` types Agenta already defines internally (``text``, ``image``,
+    ``resource``, ``tool_call``, ``tool_result``). To support a new Vercel part kind,
+    first add first-class support for it in the Agenta ``ContentBlock`` model, then map
+    it here — never fabricate an adapter-specific block type or pass an unmapped kind
+    through opaquely. A part kind Agenta does not define is dropped (observably via a
+    debug log), not fabricated.
+
+    Keep this channel symmetric: a kind must be handled in both directions or neither. If
+    something is mapped inbound it must map outbound too (and vice versa); a kind dropped
+    here must also be absent in ``_block_to_parts`` — never add one side alone. The only
+    exception is a direction that explicitly cannot occur (e.g. the one-way live event
+    stream in ``stream.py``, which has no inbound counterpart by design).
+
+    Reasoning is such a stream-only concept: the live event stream maps the ``thought``
+    event to Vercel ``reasoning`` frames. Stored ``UIMessage`` conversion has no reasoning
+    kind on either side — ``_block_to_parts`` emits none — so an inbound ``reasoning`` part
+    is dropped here to stay symmetric. To carry reasoning through stored messages, add it
+    to the Agenta ``ContentBlock`` model first, then map both directions.
+    """
     if not isinstance(part, dict):
         return []
     ptype = str(part.get("type", ""))
@@ -101,6 +123,9 @@ def _part_to_blocks(part: Any) -> List[ContentBlock]:
     ):
         return _tool_part_blocks(part, ptype)
 
+    log.debug(
+        "vercel adapter: dropping inbound part with no ContentBlock mapping: %r", ptype
+    )
     return []
 
 
@@ -252,6 +277,21 @@ def _content_to_parts(content: Any) -> List[Dict[str, Any]]:
 
 
 def _block_to_parts(block: ContentBlock) -> List[Dict[str, Any]]:
+    """A neutral ``ContentBlock`` -> zero or more Vercel ``UIMessage`` parts.
+
+    Agenta's ``ContentBlock`` model is canonical. This mapper only ever renders
+    ``ContentBlock`` types Agenta already defines internally into their Vercel part
+    shape. To support a new Agenta block type, first add first-class support for it in
+    the Agenta ``ContentBlock`` model, then map it here — never invent a Vercel part kind
+    or forward an unmapped block opaquely. A block type Agenta does not define is
+    dropped, not fabricated.
+
+    Keep this channel symmetric: a kind must be handled in both directions or neither. If
+    something is mapped here outbound it must map inbound too (and vice versa); a kind
+    dropped in ``_part_to_blocks`` must also be absent here — never add one side alone. The
+    only exception is a direction that explicitly cannot occur (e.g. the one-way live event
+    stream in ``stream.py``, which has no inbound counterpart by design).
+    """
     if block.type == "text":
         return [{"type": "text", "text": block.text or ""}]
     if block.type in ("image", "resource"):

--- a/sdks/python/agenta/sdk/agents/adapters/vercel/stream.py
+++ b/sdks/python/agenta/sdk/agents/adapters/vercel/stream.py
@@ -221,6 +221,9 @@ async def agent_run_to_vercel_parts(
                 if reason is not None:
                     stop_reason = reason
     except Exception as exc:
+        # A graceful terminal failure (the run's own AgentResult says ok=false) surfaces here
+        # as a plain exception from AgentStream iteration; that case intentionally ends the
+        # stream on the error part with no finish frame, so this path stays as-is.
         yield {"type": "error", "errorText": str(exc)}
         return
 
@@ -429,21 +432,22 @@ async def agent_stream_to_vercel_stream(
                     stop_reason = reason
     except Exception as exc:
         yield {"type": "error", "errorText": str(exc)}
-        return
-
-    yield {"type": "finish-step"}
-    finish: Dict[str, Any] = {"type": "finish"}
-    finish_reason = _map_finish_reason(stop_reason)
-    if finish_reason is not None:
-        finish["finishReason"] = finish_reason
-    metadata: Dict[str, Any] = {}
-    if usage:
-        metadata["usage"] = usage
-    if trace_id is not None:
-        metadata["traceId"] = trace_id
-    if metadata:
-        finish["messageMetadata"] = metadata
-    yield finish
+    finally:
+        # Every exit path — including the raw exception above — must still drain to a
+        # finish frame, or a consumer waiting on it hangs.
+        yield {"type": "finish-step"}
+        finish: Dict[str, Any] = {"type": "finish"}
+        finish_reason = _map_finish_reason(stop_reason)
+        if finish_reason is not None:
+            finish["finishReason"] = finish_reason
+        metadata: Dict[str, Any] = {}
+        if usage:
+            metadata["usage"] = usage
+        if trace_id is not None:
+            metadata["traceId"] = trace_id
+        if metadata:
+            finish["messageMetadata"] = metadata
+        yield finish
 
 
 def _interaction_parts(

--- a/sdks/python/oss/tests/pytest/unit/agents/adapters/test_vercel_messages_roundtrip.py
+++ b/sdks/python/oss/tests/pytest/unit/agents/adapters/test_vercel_messages_roundtrip.py
@@ -1,0 +1,147 @@
+"""Round-trip fidelity for the Vercel ``UIMessage`` part <-> ``ContentBlock`` mapping.
+
+``message_to_vercel_ui_message`` (outbound) and ``vercel_ui_messages_to_messages`` (inbound)
+sit at opposite edges of the same adapter. A part kind the outbound side emits must survive
+being fed back in, or a client that persists and replays its own transcript loses content on
+every turn. Agenta's ``ContentBlock`` model is canonical, so this only holds for kinds that map
+onto an existing ``ContentBlock`` type; kinds Agenta has no block for are dropped, observably.
+"""
+
+from __future__ import annotations
+
+import logging
+
+from agenta.sdk.agents import ContentBlock, Message
+from agenta.sdk.agents.adapters.vercel import (
+    message_to_vercel_ui_message,
+    vercel_ui_messages_to_messages,
+)
+
+
+def _roundtrip(message: Message) -> Message:
+    ui = message_to_vercel_ui_message(message)
+    [back] = vercel_ui_messages_to_messages([ui])
+    return back
+
+
+class TestRoundTripLosslessForEmittedKinds:
+    def test_text_roundtrips(self):
+        back = _roundtrip(Message(role="assistant", content="hello there"))
+        assert back.content == "hello there"
+
+    def test_tool_call_and_result_roundtrip(self):
+        message = Message(
+            role="assistant",
+            content=[
+                ContentBlock(
+                    type="tool_call",
+                    tool_call_id="call_1",
+                    tool_name="getWeather",
+                    input={"city": "Paris"},
+                ),
+                ContentBlock(
+                    type="tool_result",
+                    tool_call_id="call_1",
+                    tool_name="getWeather",
+                    output={"weather": "sunny"},
+                    is_error=False,
+                ),
+            ],
+        )
+        back = _roundtrip(message)
+        wire = [b.to_wire() for b in back.content]
+        # The call's input and the result's output both survive the round trip (each
+        # outbound tool part comes back as its own block; a duplicate no-input tool_call
+        # from the output part is a pre-existing quirk of this mapping, not this fix's
+        # concern, so this checks presence/content rather than exact list shape).
+        calls_with_input = [
+            b for b in wire if b["type"] == "tool_call" and "input" in b
+        ]
+        results = [b for b in wire if b["type"] == "tool_result"]
+        assert calls_with_input == [
+            {
+                "type": "tool_call",
+                "toolCallId": "call_1",
+                "toolName": "getWeather",
+                "input": {"city": "Paris"},
+            }
+        ]
+        assert results == [
+            {
+                "type": "tool_result",
+                "toolCallId": "call_1",
+                "toolName": "getWeather",
+                "output": {"weather": "sunny"},
+                "isError": False,
+            }
+        ]
+
+    def test_resource_block_roundtrips(self):
+        message = Message(
+            role="user",
+            content=[
+                ContentBlock(
+                    type="resource",
+                    uri="s3://bucket/doc.pdf",
+                    mime_type="application/pdf",
+                ),
+            ],
+        )
+        back = _roundtrip(message)
+        block = back.content[0]
+        assert block.type == "resource"
+        assert block.uri == "s3://bucket/doc.pdf"
+        assert block.mime_type == "application/pdf"
+
+
+class TestInboundReasoningDroppedSymmetrically:
+    def test_inbound_reasoning_part_is_dropped_and_logged(self, caplog):
+        # Reasoning is stream-only (stream.py maps `thought` events to `reasoning` frames).
+        # Stored-message conversion emits no reasoning on the outbound side, so an inbound
+        # reasoning part is dropped here to stay symmetric — not folded, not fabricated.
+        caplog.set_level(logging.DEBUG)
+        msgs = vercel_ui_messages_to_messages(
+            [
+                {
+                    "id": "m1",
+                    "role": "assistant",
+                    "parts": [
+                        {"type": "reasoning", "text": "step one"},
+                        {"type": "text", "text": "the answer"},
+                    ],
+                }
+            ]
+        )
+        assert msgs[0].content == "the answer"
+        assert "reasoning" in caplog.text
+
+
+class TestUnmappedPartsAreDroppedObservably:
+    def test_unmapped_kind_is_dropped_but_logged(self, caplog):
+        caplog.set_level(logging.DEBUG)
+        msgs = vercel_ui_messages_to_messages(
+            [
+                {
+                    "id": "m1",
+                    "role": "assistant",
+                    "parts": [
+                        {"type": "data-custom", "data": {"foo": "bar"}},
+                        {"type": "text", "text": "still here"},
+                    ],
+                }
+            ]
+        )
+        # The unmapped part contributes nothing to content ...
+        assert msgs[0].content == "still here"
+        # ... but its kind is observable, not a silent drop.
+        assert "data-custom" in caplog.text
+
+    def test_error_and_source_url_and_step_start_are_dropped_observably(self, caplog):
+        caplog.set_level(logging.DEBUG)
+        for ptype in ("error", "source-url", "step-start"):
+            caplog.clear()
+            msgs = vercel_ui_messages_to_messages(
+                [{"id": "m1", "role": "assistant", "parts": [{"type": ptype}]}]
+            )
+            assert msgs[0].content == ""
+            assert ptype in caplog.text

--- a/sdks/python/oss/tests/pytest/unit/agents/adapters/test_vercel_stream_finish_reason.py
+++ b/sdks/python/oss/tests/pytest/unit/agents/adapters/test_vercel_stream_finish_reason.py
@@ -166,3 +166,32 @@ async def test_handler_stream_then_adapter_carries_paused_end_to_end() -> None:
 # Guard the DTO import surface the fakes lean on (Event/AgentResult stay importable here).
 def test_dto_imports_present() -> None:
     assert Event is not None and AgentResult is not None
+
+
+# --- a raw mid-stream exception still drains to a finish frame ----------------
+
+
+async def _events_then_raise(
+    items: List[Dict[str, Any]],
+) -> AsyncIterator[Dict[str, Any]]:
+    for item in items:
+        yield item
+    raise ValueError("unexpected adapter bug")
+
+
+@pytest.mark.asyncio
+async def test_raw_exception_mid_stream_still_emits_finish() -> None:
+    """An unexpected exception raised while iterating the event stream (not a graceful
+    terminal-failure result) must still drain to a `finish` frame, or a consumer waiting
+    on it hangs forever."""
+    parts = [
+        part
+        async for part in agent_stream_to_vercel_stream(
+            _events_then_raise([{"type": "message", "data": {"text": "partial"}}])
+        )
+    ]
+    types = [p["type"] for p in parts]
+    assert "error" in types
+    assert types[-2:] == ["finish-step", "finish"]
+    error = next(p for p in parts if p["type"] == "error")
+    assert "unexpected adapter bug" in error["errorText"]


### PR DESCRIPTION
## Context

Two conformance gaps in the Vercel data-stream adapter.

First, the inbound UIMessage parser silently dropped part kinds it did not recognize. `_part_to_blocks` handled `text`, `file`, and `tool-*`, then hit `return []` for everything else (`reasoning`, `data-*`, `error`, `source-url`, `step-start`) with no log. Outbound to inbound was lossy.

Second, an unexpected exception mid-stream skipped the terminal finish frame. A graceful terminal-failure result correctly emits no finish (intentional, tested), but a raw `except Exception` in the stream loop did `yield error; return` with no `finally`, so the `finish-step`/`finish` tail never ran. A consumer that waits for a finish frame hung.

## Changes

Inbound parser. Unmapped part kinds are now dropped observably (a debug log) instead of silently. The parser only ever produces `ContentBlock` types that Agenta already defines. It does not fabricate an adapter-specific block type and does not forward unknown parts opaquely.

Reasoning is handled by symmetry, not by invention. Agenta represents reasoning as the `thought` event, and the live stream maps `thought` to Vercel `reasoning` frames. Stored-message conversion (`ContentBlock`) has no reasoning kind on either side, so an inbound `reasoning` part is dropped here to stay symmetric with the outbound side, which emits none. Both mappers carry a docstring stating the rule: a kind must be handled in both directions or neither, unless a direction cannot occur (the one-way live stream).

Finish frame. The emit tail of the live-stream path is wrapped in `try/finally` so the finish frames fire on every exit path, including the raw-exception path.

Before (raw exception mid-stream):

```
yield error
return          # finish-step / finish never emitted -> consumer hangs
```

After:

```
try:
    ... stream body ...
finally:
    yield finish-step
    yield finish   # always fires
```

The fix applies only to the live-stream function. The development-only path raises a plain `RuntimeError` on a terminal `ok:false` result, which is the intentional graceful-no-finish contract, so it is left unchanged.

## Tests

- 60 adapter unit tests pass. New: a raw-exception-mid-stream test asserting the terminal finish still fires, and a round-trip test set covering `text`, `tool_call`/`tool_result`, and `resource` losslessness plus reasoning-dropped-symmetrically and unmapped-kind-dropped-but-logged.
- The existing graceful-terminal-failure no-finish test still passes unchanged.
- `ruff format`/`ruff check` clean.

## What to QA

- Drive a stream that raises an unexpected error partway through. The consumer still receives a terminal `finish` frame and does not hang.
- Regression: a graceful terminal-failure run still emits an error part and no finish, exactly as before.
