### PR TITLE
docs(runner): agent runner code review findings + roadmap

### DIFF
--- a/docs/design/agent-workflows/scratch/runner-review-2026-07-05/PLAN.md
+++ b/docs/design/agent-workflows/scratch/runner-review-2026-07-05/PLAN.md
@@ -1,0 +1,24 @@
+# Runner code review — 2026-07-05
+
+Full-scope review of `services/runner/` (TS agent runner) before the agents launch next week.
+Context: started as a POC, now near production. Primary author is a Python developer writing TS.
+
+## Method (map-reduce)
+
+Wave 1 — parallel reviewers, detailed findings in `findings/`:
+
+- A `arch-boundaries` (Fable, deep): system architecture, responsibilities, boundaries, protocol design, extensibility/portability
+- B `engine-sandbox-agent` (Fable, deep): engines/sandbox_agent/* — orchestration, run-plan, local vs Daytona, harness matrix, lifecycle, correctness
+- C `tools-permissions-security` (Fable, deep): tools/*, permission-plan, Pi extension, secrets, MCP-disabled path, threat model
+- D `entrypoints-sessions` (Sonnet): server/cli/entry/responder/sessions/*
+- E `tracing-otel` (Sonnet): tracing/otel.ts state machine
+- F `tests-qa` (Sonnet): test suite, coverage, gaps, goldens, QA
+- G `ts-idioms-quality` (Fable, deep): idiomatic TS sweep, code organization per lgrammel / Mitchell Hashimoto principles
+
+Wave 2 — synthesis into `reports/`: executive summary + per-area reports with short/medium/long-term actions.
+
+## Status
+
+- [x] Scout
+- [x] Wave 1 — 7 findings files in findings/ (2 blocker, 36 high, 58 medium, 28 low)
+- [x] Wave 2 — reports/00-executive-summary.md (cross-cutting themes + triaged roadmap)

--- a/docs/design/agent-workflows/scratch/runner-review-2026-07-05/findings/arch-boundaries.md
+++ b/docs/design/agent-workflows/scratch/runner-review-2026-07-05/findings/arch-boundaries.md
@@ -1,0 +1,669 @@
+# Runner review — A. Architecture, responsibilities, boundaries
+
+Reviewer: A (system-level). Scope: the runner as a system — responsibility split across
+SDK/service/runner, subsystem boundaries, the `/run` wire contract, the engine abstraction,
+extensibility, scalability/operability, and target structure. Subsystem internals (engine
+correctness, tools/permissions security, tracing state machine, tests, TS idioms) belong to
+reviewers B–G; where I touch them it is only to make a structural point.
+
+Date: 2026-07-05. Verified against code at `services/runner/src/`,
+`services/oss/src/agent/`, `sdks/python/agenta/sdk/agents/`, `hosting/docker-compose/`,
+`hosting/kubernetes/helm/`.
+
+---
+
+## 1. How the system actually works (verified, with doc drift noted)
+
+**The pipeline.** The playground/API calls the Python agent service
+(`services/oss/src/agent/app.py`, 316 lines), which mounts `/invoke` as an Agenta workflow.
+The service parses the agent config, resolves tools/MCP/secrets/connections server-side,
+and calls SDK primitives (`agenta.sdk.agents`). The SDK assembles a camelCase JSON
+`AgentRunRequest` (`utils/wire.py` + per-harness `wire_*()` fragments in `dtos.py`) and
+POSTs it to the Node runner sidecar — over HTTP when `AGENTA_RUNNER_INTERNAL_URL` is set
+(the deployed path, `http://runner:8765`), else as a one-shot subprocess
+(`pnpm exec tsx src/cli.ts`). The live path is always NDJSON streaming
+(`Accept: application/x-ndjson`); the SDK folds the stream into the batch result.
+
+**Inside the runner** there is exactly ONE engine: `runSandboxAgent`
+(`src/engines/sandbox_agent.ts:317`). It builds a `RunPlan`
+(`engines/sandbox_agent/run-plan.ts`), boots the `sandbox-agent` daemon on one of two
+sandbox backends (`local` = child process on the sidecar host, `daytona` = remote cloud
+sandbox), creates an ACP session for the requested harness (`pi_core`/`pi_agenta` → ACP
+agent `pi`; `claude` → ACP agent `claude`), materializes the workspace (AGENTS.md or
+CLAUDE.md, skills, `harnessFiles`), wires tool delivery (Pi: bundled extension + file relay;
+Claude: a loopback HTTP MCP server named `agenta-tools`), drives one prompt, and converts
+the ACP event stream into `AgentEvent`s + OTel spans via `tracing/otel.ts`. Permission
+gating (HITL) runs through a shared plan (`permission-plan.ts` + `responder.ts`), pausing a
+turn on `pendingApproval` and resuming cold from replayed message history. Session-owned
+runs (a `sessionId` present) additionally heartbeat an alive lock, persist events, and
+FUSE-mount a durable cwd (geesefs over an S3 prefix) — all via the Agenta HTTP API
+(`sessions/*`, `engines/sandbox_agent/mount.ts`); the runner never touches Redis directly.
+
+**Deployment.** The `runner` compose service exists in all six OSS/EE compose files, is
+always on (no profile), `restart: always`, healthchecked, with `SYS_ADMIN` + `/dev/fuse` +
+`apparmor:unconfined` for the FUSE mount. The API container `depends_on` it healthy. Helm
+has a full runner Deployment (default `replicas: 1`, `/health` probes). Prod runs
+`tsx src/server.ts` directly (no compile step, full dev deps in the image), as `USER node`.
+No resource limits and no concurrency limits anywhere. `AGENTA_RUNNER_TOKEN` auth is
+default OFF; compose overrides the code's loopback default to `0.0.0.0`.
+
+**Doc drift (the short version — full list in the docs sweep below, finding A-19).**
+`services/runner/README.md` describes a removed design: it lists `engines/pi.ts` (does not
+exist), claims routing "by the request's `backend` field" (no such wire field; the selector
+is `harness`, and there is no engine selector at all — `protocol.ts:369`,
+`server.ts:166-169`), calls MCP delivery to non-Pi harnesses "disabled" (it is the ACTIVE
+Claude delivery channel, restored over loopback HTTP — `tools/mcp-bridge.ts:1-31`), and its
+example uses harness id `"pi"` (real ids: `pi_core`/`pi_agenta`/`claude`, `version.ts:15`).
+`AGENTS.md` still says "pnpm install # from services/agent". Across
+`docs/design/agent-workflows/documentation/` there are 44 stale `services/agent/` paths, a
+wrong compose service name (`sandbox-agent` → real name `runner`), and the MCP gate env var
+is cited with the wrong name AND the wrong default polarity (docs:
+`AGENTA_AGENT_ENABLE_MCP`, off-by-default; code: `AGENTA_AGENT_MCPS_ENABLED`, default
+`"true"` — `services/oss/src/agent/tools/resolver.py:27`).
+
+---
+
+## 2. Strengths — keep this
+
+These are genuinely good decisions for a POC-to-prod codebase; the roadmap below should
+build on them, not replace them.
+
+- **The golden-fixture wire contract.** Five shared fixtures asserted in-place by BOTH
+  languages (`test_wire_contract.py` / `tests/unit/wire-contract.test.ts`), plus a
+  compile-time `keyof AgentRunRequest` guard on the TS side and a Pydantic schema mirror
+  (`wire_models.py`) on the Python side. Hand-mirroring is risky in general; this is about
+  the strongest guard you can build without codegen, and it demonstrably works.
+- **"Python decides what, runner runs it" is a real, mostly-held boundary.** All secret,
+  tool, connection, and skill resolution happens server-side; the runner receives resolved
+  material. The `harnessFiles` mechanism (`protocol.ts:459`, Python renders
+  `.claude/settings.json`, runner writes it blind) is exactly the right generic pattern for
+  keeping harness knowledge in Python.
+- **Fail-loud gates.** The `*_UNSUPPORTED_MESSAGE` family (`run-plan.ts:42-69`,
+  `capabilities.ts:51`) refuses runs the runner cannot honestly serve (code tools, stdio
+  MCP, tools on non-Pi remote sandboxes, unenforceable network policy) instead of silently
+  degrading. The "fail CLOSED for any unknown remote provider" stance
+  (`run-plan.ts:275-281`) is the right default for the next sandbox backend.
+- **Capability probing exists.** `probeCapabilities` + `assertRequiredCapabilities`
+  (`engines/sandbox_agent/capabilities.ts`) is the right (Vercel-AI-SDK-style) mechanism:
+  branch on what the harness can do, not on its name. It is half-adopted (see A-8) but the
+  scaffolding is there.
+- **Testable seams at the entrypoints.** `createAgentServer(run)` / `runCli(raw, {run})`
+  and the `SandboxAgentDeps` injection bag let the HTTP/CLI layer and the engine be tested
+  with fakes. ~45 unit test files exercise them.
+- **Resource-lifecycle discipline.** In-flight sandbox registry + SIGTERM sweep
+  (`server.ts:378-399`), the Daytona `ephemeral` + auto-stop leak backstop
+  (`provider.ts:41-99`), per-run `finally` teardown, watchdog credential refresh. Someone
+  thought hard about leaks.
+- **Clear security posture at the credential layer.** Clear-then-apply provider env
+  (`daemon.ts:73-162`), SSRF guard on user MCP URLs (`engines/sandbox_agent/mcp.ts:47-95`),
+  secrets never in the extension env, non-root prod image, no `env_file` on the compose
+  service by design.
+
+---
+
+## 3. Findings
+
+Severity: blocker / high / medium / low. Horizon: **short** = before/at launch,
+**medium** = 1–2 months, **long** = structural.
+
+---
+
+### A-1 (HIGH, short→medium) — The run's Agenta credential and API base are smuggled through telemetry config
+
+**Where:** `server.ts:118-134` (`runCredential`, `apiBaseFromRequest`),
+`engines/sandbox_agent.ts:121-128` (a second copy of `runCredential`),
+`sessions/alive.ts`, `mount.ts` consumers; wire side `protocol.ts:64-72` (`Telemetry`).
+
+**What:** The single most load-bearing credential in the system — the ephemeral Agenta
+Secret the runner uses to heartbeat, persist events, sign mounts, create interactions, and
+refresh itself — has no wire field. It is extracted from
+`request.telemetry.exporters.otlp.headers.authorization`, i.e. from the OTLP *exporter
+config*. The Agenta API base is likewise recovered by string-slicing the OTLP endpoint on
+the marker `"/otlp/"` (`server.ts:127-134`). Classified by semantic role, a
+**credential** and a **routing** value are riding inside operator **telemetry config**.
+
+**Why it matters:** (a) Turning off or redirecting tracing silently breaks sessions,
+mounts, and HITL interactions — completely unrelated features. (b) The extraction logic is
+duplicated in two files and consumed by five subsystems, so any change to telemetry shape
+is a cross-cutting hazard. (c) It makes the contract unreadable: a reviewer of
+`protocol.ts` cannot see that the runner authenticates back to Agenta at all. (d) The
+comment "it rides the telemetry exporter headers (where the run's Agenta secret already
+lives, kept verbatim)" documents the accident rather than fixing it.
+
+**Recommendation:** Add a first-class wire block, e.g.
+`platform?: { endpoint: string; authorization: string }` (routing + credential together,
+owned by the service, per-call lifecycle). Runner: one `platformAuth(request)` accessor in
+a single module; keep the telemetry fallback for one release (mirror of the `/run`→`/stream`
+alias policy). Python: emit both for one release. Golden fixtures updated deliberately.
+Short horizon for centralizing the extraction into one function; medium for the wire field.
+
+---
+
+### A-2 (HIGH, short) — `process.env` is mutated per-request; module-level caches keyed on per-run credentials
+
+**Where:** `server.ts:227-232` (`process.env.AGENTA_API_URL = requestApiBase` inside the
+request handler), `tracing/otel.ts:68-91` (`traceTargets`, `exporterCache` keyed by
+`endpoint + authorization`).
+
+**What:** A request-derived value is written into process-global env at request time
+(guarded by "only if unset", but that means the FIRST request wins forever, and it races
+with concurrent first requests). Separately, `exporterCache` creates and caches one
+`OTLPTraceExporter` per distinct `endpoint\nauthorization` pair; the authorization on the
+live path is a ~15-minute **ephemeral** Secret, so a busy sidecar accumulates one exporter
+(with its own HTTP machinery) per run credential, unbounded. `traceTargets` is cleaned on
+flush (`otel.ts:141`); `exporterCache` is never evicted.
+
+**Why:** These are the two pieces of state that would poison a long-lived multi-tenant
+sidecar: cross-request contamination via env, and slow memory growth via the cache. Both
+are invisible in tests (one run at a time).
+
+**Recommendation:** Delete the env write — thread the API base through the same
+first-class `platform` field as A-1 (or a per-run context object). Key `exporterCache` by
+endpoint only and pass the Authorization header per export, or add an LRU with eviction +
+`shutdown()`. Short horizon; small diffs.
+
+---
+
+### A-3 (HIGH, medium) — `runSandboxAgent` is a 650-line God function; the engine's phases have no seams
+
+**Where:** `engines/sandbox_agent.ts:317-973`.
+
+**What:** One function owns: mount signing and the durable-cwd derivation, run-plan
+building, daemon env assembly, Claude-specific env quirks, Pi extension env, sandbox boot,
+Daytona asset upload, workspace prep with an ENOTCONN retry state machine, capability
+probing and gating, MCP channel construction with a deferred-relay indirection, session
+creation, model resolution, otel wiring, HITL responder + pause-controller + latch +
+interaction-recording wiring, the tool relay, the prompt race against the pause signal,
+usage resolution, swallowed-Pi-error recovery, and an 8-step `finally`. The
+`SandboxAgentDeps` bag has ~25 injectable members (`sandbox_agent.ts:247-269`) — a symptom:
+the only way to test any phase is to inject around all the others.
+
+**Why:** Every reviewer of every future change must re-read the whole function to know
+what ordering invariants they are breaking (the code comments themselves track at least
+five: sign-before-plan, mount-before-workspace, relay-after-responder,
+usage-before-finish, abort-before-teardown). This is the file where the next three
+production bugs will live.
+
+**Recommendation:** Extract the phases along the lifecycle the comments already name:
+`prepare` (plan + mounts + workspace) → `connect` (sandbox + session + capabilities) →
+`wire` (tools/MCP/HITL/tracing) → `drive` (prompt/pause/usage) → `settle` (result/error) →
+`dispose` (the finally). Each phase takes/returns an explicit `RunState`; `finally` becomes
+a stack of registered disposers (push a cleanup when you acquire a resource — this also
+kills the "did the finally cover the new resource?" class of leak). No behavior change;
+mechanical, test-preserving. Medium horizon, but start with `dispose` (the disposer stack)
+short-term since it is the highest-risk part.
+
+---
+
+### A-4 (HIGH, medium) — Harness knowledge is smeared across the runner despite the "dumb writer" doctrine
+
+**Where (the smear):**
+- `engines/sandbox_agent.ts:189-245` `applyClaudeConnectionEnv` — Claude env vars,
+  Bedrock/Vertex flags, the `ENABLE_TOOL_SEARCH` workaround;
+- `engines/sandbox_agent/workspace.ts:49-54` — `CLAUDE.md` vs `AGENTS.md`,
+  `.${acpAgent}/skills` skill root, immediately below a doc comment that says harness
+  files are "written blind — no harness knowledge on the runner";
+- `run-plan.ts:249-265` — the `pi_core|pi_agenta → pi` mapping;
+  `run-plan.ts:284-285` — `legacyHarnessApiKeyVar` by harness name;
+- `capabilities.ts:99-116` — static capability fallback keyed on `harness === "pi"`;
+- `sandbox_agent.ts:771` — the permission-gate locus decision `enforce: plan.isPi`
+  (the comment itself says "if more harness families arrive, move this");
+- `pi-error.ts` — reads Pi's private session transcript format off disk;
+- `pi-assets.ts` — Pi agent-dir layout, extension install, auth.json upload;
+- `tracing/otel.ts` `emitSpans: !plan.isPi || plan.isDaytona` (`sandbox_agent.ts:696`);
+- usage: Pi writes a file, others report on PromptResponse (`usage.ts`).
+
+`grep -c isPi` in src = 34; `grep -c isDaytona` = 35.
+
+**What/why:** The stated architecture ("the Python harness adapter renders harness
+specifics; the runner stays a dumb writer", `protocol.ts:450-458`) is the right target and
+`harnessFiles` proves it works — but only Claude's settings.json made the jump. Everything
+else is `if (isPi)` / `if (acpAgent === "claude")` scattered over nine files. Adding a
+harness (codex/opencode) today touches, at minimum: `version.ts` HARNESSES, `run-plan.ts`
+mapping + legacy key var, `capabilities.ts` static table, `workspace.ts` instructions file
++ skill root, `sandbox_agent.ts` env quirks + gate locus + emitSpans, usage resolution,
+plus Python `capabilities.py`, `harnesses.py`, and possibly a settings renderer — **10+
+touch points across two languages** with no checklist.
+
+**Recommendation:** Introduce ONE table: a `HarnessProfile` record per harness id
+(`acpAgent`, `instructionsFileName`, `projectSkillRoot`, `toolDelivery: "extension" |
+"mcp"`, `permissionGateLocus: "relay" | "acp"`, `usageSource: "file" | "prompt-response"`,
+`selfInstruments: boolean`, `applyConnectionEnv(env, request)`, `legacyApiKeyVar`) in one
+module, consumed everywhere the branches live today. This is the Lars-Grammel provider
+pattern: the harness becomes a value, not a condition. Do it incrementally — each extracted
+branch is its own small PR. Medium horizon; the payoff is that "add codex" becomes one
+profile object + one Python adapter.
+
+---
+
+### A-5 (HIGH, medium) — The sandbox backend is a boolean, not a port
+
+**Where:** `plan.isDaytona` branches in `run-plan.ts` (cwd + relay base paths, hardcoded
+`/home/sandbox/agenta/...` at `sandbox_agent.ts:344-351` and `run-plan.ts:388-390`),
+`workspace.ts:56-93` (two full copies of workspace prep: sandbox-FS API vs node:fs),
+`mcp.ts:244-263` (loopback reachability), `tools/relay.ts:165-203`
+(`localRelayHost`/`sandboxRelayHost`), `daytona.ts`, `mount.ts` (local geesefs vs remote
+tunnel mount), `provider.ts:111-130`, `usage.ts`, `pi-error.ts` ("never on Daytona").
+Everything takes `sandbox: any` (64 `: any` occurrences in src, most of them this handle).
+
+**What/why:** The second variability axis (where the daemon runs) is expressed as
+`isDaytona: boolean` plus an `isRemoteSandbox` fallback. A k8s-pod or Firecracker/E2B
+backend cannot be added by implementing an interface; it requires re-editing every branch.
+The good news: the code already fails closed for unknown providers (`run-plan.ts:275-281`)
+and the file-relay abstraction (`RelayHost`) shows the team knows how to cut this seam.
+
+**Recommendation:** Define a `SandboxBackend` port that owns what the booleans currently
+select: `{ id, isRemote, cwdRoot(), relayRoot(), fs: {mkdir, writeFile, readFile, upload},
+exec(), mountDurable(), buildProvider(), capabilities: {runnerLoopbackReachable} }`, with
+`LocalBackend` and `DaytonaBackend` implementations wrapping today's code, and type the
+sandbox-agent handle once instead of `any`. `workspace.ts` collapses to one code path over
+`backend.fs`. Medium/long horizon; do the typed handle (kill `sandbox: any`) short-term.
+
+---
+
+### A-6 (HIGH, short) — No admission control: unbounded concurrent runs on a process with no resource limits
+
+**Where:** `server.ts:294-357` (no in-flight cap, no body-size limit, no per-run timeout),
+compose files (no `mem_limit`/`cpus` anywhere), Helm (`resources` optional, default none).
+
+**What:** Every `POST /run` immediately starts a run. A local-sandbox run spawns a
+`sandbox-agent` daemon child + a harness process + possibly a FUSE mount **on the sidecar
+host**; there is no semaphore, no queue, no 429/503, and no request-body cap
+(`readBody` buffers the whole body — with `messages` carrying full conversation history,
+a large replay is fully materialized in memory per request). There is also no server-side
+run deadline: the Python client times out at 180s, but a client that disconnects leaves a
+session-owned run running by design — with nothing bounding how many do so.
+
+**Why:** This is the most likely production failure mode in week one: a burst of playground
+runs (or one retry loop) forks N daemons and OOMs the container; `restart: always` then
+kills every in-flight run on the box, including well-behaved ones.
+
+**Recommendation (short):** (1) a max-inflight semaphore (env-tunable, e.g. 8 local / 32
+daytona) returning 503 + `Retry-After` when saturated; (2) a body-size cap on `readBody`;
+(3) a server-side max run duration that aborts the run's signal; (4) compose/Helm memory
+limits sized to the semaphore. Expose in-flight count on `/health` for the sweeper and for
+horizontal-scaling decisions later.
+
+---
+
+### A-7 (HIGH, short) — The versioning story exists on the server and has no client: skew is undetected
+
+**Where:** `version.ts:1-35` (`PROTOCOL_VERSION = 1`, `/health` returns
+`{runner, protocol, engines, harnesses}` "so a client can detect an incompatible runner
+before the first run"); `sdks/python/agenta/sdk/agents/utils/ts_runner.py` — **no** call to
+`/health`, no protocol check anywhere in the SDK (verified by grep); the SDK still posts the
+back-compat alias `/run` while the productized route is `/stream` (`server.ts:314-318`,
+"kept for one release"); the CLI transport has no version surface at all; the runner never
+validates the request beyond `JSON.parse` (`server.ts:326` — a cast, not a check).
+
+**What happens on skew in prod today:** an old runner silently ignores unknown fields (new
+SDK feature no-ops — the F-032 silent-drop class this codebase has repeatedly fought); a new
+runner receiving an old request relies on per-field back-compat heuristics
+(`credentialMode` absent → `hasApiKey` guess, `run-plan.ts:475-481`). Compose pins api+
+runner together (`depends_on`), so compose skew is bounded to deploy windows — but Helm
+tags the runner image independently (`agentRunner.image.tag`), and the "one release" alias
+promise has no mechanism enforcing it.
+
+**Recommendation (short, cheap):** In `SandboxAgentBackend`/`ts_runner`, probe `/health`
+once per process (cached), warn on `protocol` mismatch, fail on a major the SDK does not
+support; switch the SDK to `/stream` at the same time. Medium: echo
+`protocol` in every result envelope so the CLI path is covered too, and add a
+`protocolVersion` field to the request that the runner logs when it differs. Long: see A-9.
+
+---
+
+### A-8 (MEDIUM, medium) — Capability-based branching is half-adopted; the other half re-branches on names
+
+**Where:** `probeCapabilities` (good) vs: static fallback by `harness === "pi"`
+(`capabilities.ts:99-116`); relay-vs-ACP permission gate chosen by `plan.isPi`
+(`sandbox_agent.ts:769-771`); tool delivery chosen by `isPi` (extension) before the
+`mcpTools` capability is even consulted (`mcp.ts:231`); `emitSpans` by `!plan.isPi`.
+
+**What/why:** The README claims "branches on capabilities, not the harness name"; in
+reality the *tool-count gate* does, and the delivery/gating/tracing decisions do not. These
+name-keyed decisions are exactly the ones a new harness trips over. They are also
+runner-local capabilities (does this harness self-instrument? does it load our extension?)
+that sandbox-agent's probe can never answer — which is fine: they belong in the
+`HarnessProfile` of A-4, next to the probed capabilities, not scattered.
+
+**Recommendation:** Fold the name-keyed decisions into the A-4 profile as declared
+capabilities (`selfInstruments`, `loadsAgentaExtension`, `permissionGateLocus`), keeping the
+runtime probe for what the daemon genuinely knows. Medium horizon; pairs with A-4.
+
+---
+
+### A-9 (MEDIUM, long) — The hand-mirrored contract is at its complexity ceiling; move to a schema-first contract
+
+**Where:** `protocol.ts` (556 lines, types only, erased at runtime) mirrored by
+`utils/wire.py` (192 lines, hand-built dict) **and** `wire_models.py` (509 lines, a second
+Pydantic mirror that exists only to emit JSON Schema) **and** the golden fixtures **and**
+two contract tests. A field change touches 3 definitions + goldens + 2 tests, per
+`AGENTS.md`'s own instructions. Cross-language constants live outside the guard entirely:
+`INTERNAL_TOOL_MCP_SERVER = "agenta-tools"` in `claude_settings.py:52-60` must match four
+TS files with only a comment; permission-mode vocab is duplicated in
+`permission-plan.ts:67-73` and the SDK.
+
+**What/why:** The current guard is genuinely strong (see Strengths) and is NOT the launch
+risk. But it is O(n) human discipline per field, it validates nothing at runtime (the
+runner trusts `JSON.parse` casts; `wire_models.py:20-25` says explicitly "NOT a runtime
+guard"), and the third mirror (`wire_models.py`) exists precisely because the hand-built
+dict cannot express its own schema. That is the signal the approach has topped out.
+
+**Recommendation (long, incremental):** Make ONE side authoritative and derive the other.
+Pragmatic path given the team: author the contract as **zod schemas in the runner**
+(`protocol.ts` types become `z.infer` — no consumer changes), then (1) the runner gains
+runtime validation at the boundary for free (fail-loud on malformed requests, per the
+codebase's own doctrine); (2) emit JSON Schema from zod in CI and assert
+`wire_models.py`'s schema equals it (deleting drift by construction, then eventually
+deleting `wire_models.py` in favor of datamodel-code-generated Pydantic); (3) keep the
+golden fixtures as the semantic layer on top. Also add a tiny golden that pins the shared
+constants (`agenta-tools`, relay suffixes, permission vocab).
+
+---
+
+### A-10 (MEDIUM, short) — Wire fields misclassified by role: Pi-only knobs and a policy default living in generic positions
+
+**Where:** `protocol.ts:378-389` (`systemPrompt` / `appendSystemPrompt`, documented "Pi
+only" and silently ignored for Claude — `run-plan.ts:403-408`); `protocol.ts:428`
+(`tools?: string[]` documented "Built-in tools to enable" but actually interpreted ONLY as
+Pi builtin grants — `normalizePiBuiltinGrants`, `run-plan.ts:169-182`, silently drops
+non-Pi names); `permission-plan.ts:111` (the effective **default** permission mode
+`allow_reads` is decided in the RUNNER when the request omits it — policy ownership
+belongs to the SDK/service, which should always send an explicit resolved default);
+`protocol.ts:484-488` (`projectId` documented "so the runner can include it in heartbeat
+and record-ingest calls" while `sessions/alive.ts:51-53` documents the opposite — "no
+project_id rides the request"; nothing reads `request.projectId` in src).
+
+**What/why:** By the interface-design rule (classify fields by what they ARE), these are
+harness-scoped config and policy defaults sitting in generic top-level positions. Each one
+is a silent-drop trap for the next harness and an ownership ambiguity between Python and
+TS. `projectId` is a dead field carrying a false doc.
+
+**Recommendation (short, contract-compatible):** Fix the doc comments now (mark `tools` as
+Pi-builtin grants; delete or honestly document `projectId`); make the service always send
+`permissions.default` explicitly so the runner's fallback becomes dead code. Medium: fold
+Pi-only knobs into the `harnessFiles`/harness-options pattern that Claude's settings
+already use — one `harnessOptions?: Record<string, unknown>` envelope rendered by the
+Python harness adapter, so the top level stays harness-neutral.
+
+---
+
+### A-11 (MEDIUM, medium) — `tracing/otel.ts` is a dual-purpose God module: event normalization lives inside the tracer
+
+**Where:** `tracing/otel.ts` (1315 lines — the largest file in the runner). It contains:
+the OTLP export machinery (processor, batching-by-trace, exporter cache), `createAgentaOtel`
+(the Pi-extension tracer, runs INSIDE the sandbox), `createSandboxAgentOtel` (the engine's
+ACP-update → `AgentEvent` state machine — `handleUpdate`, `emitEvent`, `events()`,
+`output()`, `usage()`, `finish()`), and text utilities (`stripStartupBanner` etc.).
+
+**What/why:** The engine cannot produce its *result* (`output`, `messages`, `events`)
+without instantiating the tracer — the run's event log and the span exporter are one
+object. That inverts the dependency: tracing should observe the event stream, not own it.
+It also couples the two runtime environments (see A-12) into one file, and it makes the
+tracing reviewer's (E's) surface include protocol semantics.
+
+**Recommendation:** Split into `run-events.ts` (ACP update → AgentEvent normalization +
+run-state accumulation; pure, no OTel imports) and `tracing/` (span building + export,
+subscribing to the event stream). `createSandboxAgentOtel` becomes a thin composition of
+the two. Medium horizon; mechanical but large — do it before the streaming/event surface
+grows further.
+
+---
+
+### A-12 (MEDIUM, medium) — The sidecar/extension runtime boundary is invisible in the source tree
+
+**Where:** `extensions/agenta.ts` imports `tools/dispatch.ts`, `tools/callback.ts`,
+`tools/spec-schema.ts`, `tracing/otel.ts` — and is then esbuild-bundled into
+`dist/extensions/agenta.js`, which executes in a DIFFERENT process and often a DIFFERENT
+machine (inside Pi, possibly in a Daytona sandbox).
+
+**What/why:** Nothing in the tree marks which modules are "safe to run inside the
+sandbox". An innocent edit to `dispatch.ts` (e.g. importing `apiBase.ts` or a
+sessions module) would silently ship sidecar-only assumptions — or worse, secrets-handling
+code — into the sandbox bundle, and take effect only after `build:extension` (the
+stale-bundle failure mode already bitten once: custom tools silently undelivered on a stale
+extension, QA finding). The duplication of `PI_BUILTIN_TOOL_NAMES` between
+`extensions/agenta.ts:58-66` and `permission-plan.ts:40-48` exists precisely because the
+boundary is unclear.
+
+**Recommendation:** Create a `src/shared/` (or `src/ext-safe/`) layer containing exactly
+what the extension may import (protocol types, spec-schema, the relay file protocol
+constants, the extension-side tracer), enforce it with an eslint boundary rule or a tiny
+import-graph test, and make the extension bundle build part of `pnpm test`/CI so a stale
+`dist/` cannot ship. Medium horizon.
+
+---
+
+### A-13 (MEDIUM, short) — Cyclic import between `tools/` and `engines/`
+
+**Where:** `tools/mcp-bridge.ts:24` imports `type { McpServerHttp } from
+"../engines/sandbox_agent/mcp.ts"`; `engines/sandbox_agent/mcp.ts:6-10` imports
+`buildToolMcpServers`, `USER_MCP_UNSUPPORTED_MESSAGE`, `McpServerStdio` from
+`tools/mcp-bridge.ts`. `run-plan.ts` (engine) also imports refusal constants from
+`tools/mcp-bridge.ts` and `tools/code.ts`.
+
+**What/why:** Runtime-safe today (one direction is type-only), but the layering statement
+"engines depend on tools, tools depend on protocol" is broken: the tools layer names an
+engine-internal type. The refusal-message constants form a shared vocabulary that has no
+home, so they get imported from wherever they happen to live.
+
+**Recommendation (short, one-hour fix):** Move `McpServerHttp`/`McpServerStdio` (they are
+ACP wire shapes, not engine logic) and the `*_UNSUPPORTED_MESSAGE` constants into a
+leaf module (e.g. `src/acp-types.ts` / `src/messages.ts` or into `protocol.ts`-adjacent
+shared code). After that, enforce direction: `entry → engines → tools → core → protocol`.
+
+---
+
+### A-14 (MEDIUM, medium) — The service re-implements the SDK's orchestration instead of using its seam
+
+**Where (Python):** `handler.py:86-179` defines `AgentComposition` +
+`make_agent_handler(composition)` — an injectable seam built exactly so the service can
+plug `select_backend` / `resolve_session_connection` / tracing. The service does not use
+it: `app.py:207-278` re-implements the `_agent` body (~70 lines), with
+`_agent_model_ref` copied verbatim (`app.py:77-89` == `handler.py:102-107`), plus a second
+independent read of `AGENTA_RUNNER_TIMEOUT_SECONDS` (`ts_runner.py:16` vs
+`sandbox_agent.py:137`) and duplicated URL-selection logic.
+
+**What/why:** This is the main Python-side layering defect: two orchestrations that must
+be kept in sync by hand, one of which is the deployed one. They already differ slightly.
+Every new run-level feature (streaming changes, new wire field, capability check) must be
+added twice or silently diverges.
+
+**Recommendation:** Make `app.py` construct an `AgentComposition` and call
+`make_agent_handler` — delete the duplicated body. If the handler seam is missing a hook
+the service needs, extend the seam rather than forking the body. Medium horizon; this is a
+one-file refactor with existing tests on both sides.
+
+---
+
+### A-15 (MEDIUM, medium) — `/kill` is a process-wide hammer; replica-level teardown vs session-level intent
+
+**Where:** `server.ts:303-312` — `POST /kill` calls `destroyInFlightSandboxes()`, which
+tears down EVERY in-flight sandbox on the replica; the comment says it exists "so the
+orphan sweeper can force a process-wide teardown out-of-band".
+
+**What/why:** With one concurrent run this is fine. With A-6's semaphore admitting 8
+concurrent runs, an orphan sweep targeting one leaked session destroys seven healthy runs.
+The granularity of the endpoint does not match the granularity of its caller's intent.
+
+**Recommendation:** Accept an optional `sessionId`/`turnId` body and tear down only the
+matching in-flight entry (the `inFlightSandboxes` registry needs to become a
+Map keyed by run/session); keep the no-body process-wide behavior for the true
+shutdown/last-resort case. Medium horizon, small change, do it together with A-6.
+
+---
+
+### A-16 (MEDIUM, medium) — Horizontal scaling is designed-for but unproven and undocumented at the ops layer
+
+**Where:** `sessions/alive.ts:26-33` (`replica_id`, owner-affinity keys — genuine
+multi-replica design), Helm `replicas` default 1, compose no scaling, `/kill` per-replica
+(A-15), local-sandbox runs pinned to the replica's own filesystem/FUSE mounts, in-process
+`InMemorySessionPersistDriver` per run.
+
+**What/why:** The coordination plane (alive lock via API, replica affinity) is built for
+N>1, but nothing routes a *resume* or a *steer* to the owning replica at the HTTP layer —
+the runner is called through one service URL (`http://runner:8765`), which load-balances
+blind under compose/k8s. Cross-turn state is deliberately cold (history replays), so plain
+`/run` scale-out mostly works — but session-owned features (durable cwd mounts on the
+local backend, mid-turn `/kill`, interaction resume racing) have replica-affinity
+assumptions that hold only at replicas=1.
+
+**Recommendation:** Write the scaling contract down (one page in the runner README): what
+is safe at N replicas today (stateless cold runs) and what is not (local durable-cwd
+sessions). Short: keep Helm default 1 and add an explicit warning on `agentRunner.replicas`.
+Medium: either route by `owner:session:<id>` affinity at the service (it already knows the
+replica id from heartbeats) or declare Daytona-only for multi-replica session runs.
+
+---
+
+### A-17 (MEDIUM, medium) — Tool executor kinds dispatch in three places; adding a kind is a shotgun change
+
+**Where:** `tools/dispatch.ts:221-268` (`runResolvedTool`, the declared "single dispatch
+home"), but `tools/relay.ts:205-265` (`executeRelayedTool`) re-implements kind branching
+for the relay path, and `tools/tool-mcp-http.ts` carries its own client-tool pause
+branch; `run-plan.ts:161-166,323-356` gates kinds a fourth time (`hasCodeTool`, client
+tools in the remote gate).
+
+**What/why:** `dispatch.ts`'s header says the point of the module is that a kind change is
+"a one-line edit, not several" — that promise no longer holds. Adding a `browser` or
+`workflow` executor kind touches dispatch, relay, the MCP HTTP server, the run-plan gates,
+`spec-schema`, the SDK resolver, and the wire docs.
+
+**Recommendation:** An executor registry: `Record<kind, {execute, gate, advertisable}>`
+consumed by all three delivery paths, with the run-plan gates asking the registry
+(`registry[kind].supported(plan)`) instead of hand-listing kinds. Medium horizon; pairs
+naturally with A-4/A-5.
+
+---
+
+### A-18 (LOW, medium) — Observability is stderr prose; no metrics, no structured logs, no run correlation
+
+**Where:** every subsystem logs via `process.stderr.write("[tag] ...")` with per-module
+tags (`[sandbox-agent]`, `[sessions]`, `[HITL]`, `[sessions/alive]`); no request/run id is
+attached to log lines; there is no `/metrics`, no counter for runs started/failed/paused,
+queue depth, sandbox boot latency, relay poll latency.
+
+**Why:** Next week, "the playground hangs" gets debugged by grepping interleaved stderr of
+concurrent runs with no correlation key. The information exists (turnId, sessionId) but is
+inconsistently included.
+
+**Recommendation:** Short: one `log(runId, msg)` helper threaded through deps (the `Log`
+type already exists everywhere — change its signature once) so every line carries the run
+id. Medium: counters on `/health` (in-flight, total, failed, paused) — the sweep/ops
+tooling can poll it; full metrics endpoint only when there is a consumer.
+
+---
+
+### A-19 (HIGH severity for a docs item because it actively misleads, short) — README/AGENTS.md and the design docs describe a removed architecture
+
+**Where/what (verified):**
+- `services/runner/README.md:22` — routing "by the request's `backend` field": no such
+  field (`protocol.ts:369`; grep confirms `backend` appears only in prose).
+- `README.md:30-32,46-54` — `engines/pi.ts` listed as a live engine: file does not exist;
+  harness values given as `pi`/`claude`/`agenta` vs real `pi_core`/`claude`/`pi_agenta`
+  (`version.ts:15`).
+- `README.md:39-40,91-96` — MCP delivery described as disabled; `tools/mcp-bridge.ts` is
+  the ACTIVE Claude delivery channel over loopback HTTP (the stdio `mcp-server.ts` is the
+  removed one). The README inverts which module is dead.
+- `README.md:125` — the quickstart example sends `{"backend":"sandbox-agent","harness":"pi"}`
+  — both fields wrong; a new contributor's first command fails.
+- `AGENTS.md:21` — "pnpm install # from services/agent" (stale path).
+- `docs/design/agent-workflows/documentation/`: 44 stale `services/agent/` paths across 8
+  docs; `architecture.md:48,59` compose service `sandbox-agent` → real `runner`; MCP gate
+  cited as `AGENTA_AGENT_ENABLE_MCP` off-by-default in 5 docs vs real
+  `AGENTA_AGENT_MCPS_ENABLED` default `"true"` (`tools/resolver.py:27`) — name AND
+  polarity wrong; `tools.md:195` describes the stdio bridge that was replaced by
+  `tool-mcp-http.ts`; stale line cites (`sandbox_agent.ts:150`→`:501`, `app.py:49`→`:192`).
+- Wire-doc contradiction inside the code itself: `protocol.ts:484-488` (`projectId` rides
+  heartbeats) vs `sessions/alive.ts:51-53` (no project_id rides the request) — see A-10.
+
+**Recommendation (short, before launch):** Rewrite `README.md` from
+`architecture.md`'s accurate "what the deployed service actually runs" section; sweep
+`services/agent/` → `services/runner/`; fix the MCP gate name/polarity everywhere; fix the
+two AGENTS.md stale lines. This is half a day and prevents every new contributor (and
+every agent run against this repo) from being trained on a false architecture.
+
+---
+
+### A-20 (LOW, long) — Prod runs TypeScript through `tsx` with full dev dependencies in the image
+
+**Where:** `docker/Dockerfile:48-75` — `pnpm install --frozen-lockfile` (full, because
+`tsx` and `esbuild` are devDependencies), `CMD ["node_modules/.bin/tsx", "src/server.ts"]`.
+
+**What/why:** No compile step means no `tsc` gate at image build (a type error ships and
+throws at first request-touch), a larger image/attack surface (vitest et al. in prod), and
+slower cold start. Not a launch blocker — `tsc --noEmit` runs in CI — but it is the
+"libraries first, binary last" step not yet taken.
+
+**Recommendation (long):** Add a real build (`tsc` or esbuild-bundle `server.ts` the same
+way the extension is bundled), `pnpm install --prod` in the final stage, and run
+`node dist/server.js`. Do it when the package split (A-21) happens anyway.
+
+---
+
+### A-21 (structural summary, long) — Target structure and migration path
+
+The current flat layout was right for the POC. Judged by the stated reference points —
+small composable modules with explicit boundary types and provider/registry patterns
+(Grammel), and layered packages with strict dependency direction where the entrypoint is
+the last, thinnest layer (Hashimoto) — the gaps are: no enforced layering (A-13), two God
+modules (A-3, A-11), variability expressed as booleans/branches instead of
+providers/profiles (A-4, A-5, A-8, A-17), and an invisible second runtime target (A-12).
+
+**Target tree (same package, no big bang — directories first, packages only if ever needed):**
+
+```
+src/
+  protocol/        wire contract (zod source → types), shared vocab constants   [leaf]
+  core/            permission-plan, responder, run-events (from otel.ts), errors
+  harness/         HarnessProfile table + per-harness profile modules (pi, claude)
+  sandbox/         SandboxBackend port + local/, daytona/ implementations
+  tools/           executor registry + delivery channels (relay, mcp-http, callback)
+  tracing/         span building + OTLP export only (subscribes to core/run-events)
+  sessions/        alive / persist / interactions / mount (platform-API client in one place)
+  engine/          the one orchestrator, now phase-structured (A-3), consuming the ports
+  ext/             the Pi extension + its import-allowlisted shared surface (A-12)
+  entry/           server.ts, cli.ts  (thin; last layer)
+```
+
+Dependency rule (enforced by lint or an import test): left/lower may never import
+right/upper; `protocol/` and `core/` import nothing internal; `entry/` imports anything.
+
+**Migration order (each step independently shippable):**
+1. **Now (pre-launch):** A-6 admission control, A-2 env/cache fixes, A-1 centralize the
+   credential accessor, A-7 SDK `/health` probe, A-19 doc rewrite, A-13 break the cycle.
+2. **Month 1:** A-3 phase extraction + disposer stack; A-11 split run-events out of
+   otel.ts; A-14 service uses the handler seam; A-15 targeted `/kill`.
+3. **Month 2:** A-4 HarnessProfile + A-8 capability fold-in; A-5 SandboxBackend port +
+   typed handle; A-17 executor registry; A-12 ext boundary + CI bundle build.
+4. **Later:** A-9 zod-first contract with generated Python; A-20 real build; revisit
+   multi-replica routing (A-16) when scale demands it.
+
+---
+
+## 4. Top-10 priorities
+
+1. **A-6** Admission control + body cap + run deadline + memory limits (short) — the
+   week-one production risk.
+2. **A-19** Rewrite README/AGENTS.md + docs sweep (short) — actively misleading today,
+   half a day to fix.
+3. **A-7** SDK probes `/health`, checks `protocol`, moves to `/stream` (short) — the skew
+   guard exists server-side; give it its client.
+4. **A-1** First-class `platform {endpoint, authorization}` wire block; single accessor
+   now (short→medium) — stop smuggling the system's most important credential through
+   telemetry config.
+5. **A-2** Delete the request-time `process.env` write; fix the exporter cache keyed on
+   ephemeral credentials (short).
+6. **A-3** Phase-structure `runSandboxAgent`; disposer stack for the `finally` (medium) —
+   the file where the next bugs live.
+7. **A-4 + A-8** `HarnessProfile` table; fold name-keyed branches into declared
+   capabilities (medium) — makes "add codex/opencode" a one-object change.
+8. **A-14** Service adopts the SDK's `AgentComposition` seam; delete the duplicated
+   orchestration (medium).
+9. **A-11** Split event normalization (`run-events`) out of `tracing/otel.ts` (medium) —
+   unblocks the streaming/event roadmap and shrinks the tracing surface.
+10. **A-5** `SandboxBackend` port + typed sandbox handle (medium→long) — the prerequisite
+    for k8s/Firecracker/E2B backends, and it deletes 35 `isDaytona` branches.
+
+**Counts:** 0 blocker · 8 high (A-1, A-2, A-3, A-4, A-5, A-6, A-7, A-19) · 10 medium
+(A-8…A-17 excl. A-9's long tail) · 3 low (A-18, A-20, plus doc-comment fixes inside A-10).

--- a/docs/design/agent-workflows/scratch/runner-review-2026-07-05/findings/engine-sandbox-agent.md
+++ b/docs/design/agent-workflows/scratch/runner-review-2026-07-05/findings/engine-sandbox-agent.md
@@ -1,0 +1,513 @@
+# Engine review: `engines/sandbox_agent` (runner) — 2026-07-05
+
+Deep read-only review of the sandbox_agent engine subsystem (~3.5k lines) ahead of the
+production launch. Scope: `services/runner/src/engines/sandbox_agent.ts`, everything under
+`services/runner/src/engines/sandbox_agent/`, `engines/skills.ts`, their unit tests, and
+the `sandbox-agent` npm surface as used. Adjacent modules (`server.ts`, `tools/relay.ts`,
+`tools/dispatch.ts`, `sessions/*`) were read where the engine's control flow crosses into
+them.
+
+All file:line references are against the working tree on 2026-07-05.
+
+---
+
+## 1. How a run actually flows (verified)
+
+### local + pi (the default cell)
+
+1. `runSandboxAgent` (`sandbox_agent.ts:317`) — if the request is session-owned and
+   carries a run credential, it first POSTs `/sessions/mounts/sign` (`mount.ts:54`) and
+   derives a **durable cwd** `/tmp/agenta/mounts/<project>/<mount>` from the returned
+   prefix (`sandbox_agent.ts:344-352`). Best-effort: a 503/failed sign means ephemeral cwd.
+2. `buildRunPlan` (`run-plan.ts:238`) — pure derivation: harness→ACP agent mapping
+   (`pi_core`/`pi_agenta`→`pi`), fail-loud gates (filesystem policy, local network policy,
+   code tools, Pi user-MCP, stdio MCP, non-Pi remote tools, strict-network + executable
+   tools), cwd creation (`mkdtemp` or the durable dir), relay dir
+   (`/tmp/agenta/relay/<basename(cwd)>`), skill materialization (`skills.ts:115`).
+3. Daemon env is built clear-then-apply (`daemon.ts:132`), `plan.secrets` applied, Claude
+   connection env if applicable, Pi extension env (traceparent, OTLP, public tool specs,
+   relay dir, usage path, builtin gating) (`pi-assets.ts:33`).
+4. `prepareLocalPiAssets` (`pi-assets.ts:229`) — skills or system prompt present → a
+   throwaway agent dir seeded with `auth.json`/`settings.json` + extension + skills, and
+   `env.PI_CODING_AGENT_DIR` repointed at it; otherwise the extension is installed into
+   `process.env.PI_CODING_AGENT_DIR` **only if that env var is set**.
+5. `SandboxAgent.start` with the `local()` provider — spawns a **fresh
+   `sandbox-agent server` daemon per run** on a free loopback port, custom long-timeout
+   undici fetch (`acp-fetch.ts:48`), the caller's abort signal, in-memory persist. Handle
+   registered in `inFlightSandboxes` for the SIGTERM sweeper.
+6. Durable cwd geesefs-mounted on-host **before** workspace materialization
+   (`sandbox_agent.ts:544-548`), with a stale-ENOTCONN detection + one re-sign/remount
+   retry, plus a runtime remount trigger scanning every ACP event for ENOTCONN
+   (`sandbox_agent.ts:479-491`).
+7. `prepareWorkspace` (`workspace.ts:43`) writes `AGENTS.md` (or `CLAUDE.md` for claude),
+   `harnessFiles`, relay dir, and non-Pi project-local skills into the cwd.
+8. Capability probe (`capabilities.ts:120`) + `assertRequiredCapabilities` (non-Pi + tools
+   + no `mcpTools`/`toolCalls` → refuse). `buildSessionMcpServers` (`mcp.ts:218`) — for Pi
+   returns `[]` (tools ride the extension); for local Claude starts the loopback HTTP MCP
+   server on port 0.
+9. `createSession({agent, cwd, mcpServers})`, `applyModel` (exact → suffix-match →
+   harness default; `strict` throws for pinned Claude deployments), otel run created from
+   the resolved model, `session.onEvent` wired into the otel state machine with
+   paused-tool-call frame suppression.
+10. Permission plumbing: ACP reverse-RPC responder (`acp-interactions.ts:39`) for
+    harness-raised gates (Claude), the file-relay permission protocol for Pi builtins, the
+    shared client-tool relay (`client-tools.ts:196`). One pause per turn
+    (`PendingApprovalLatch`); a pause destroys the session, never replies to the gate
+    (F-024/F-040), and resolves `pause.signal`.
+11. If the plan has tools or builtin gating, `startToolRelay` (`relay.ts:399`) polls the
+    relay dir; Pi's extension writes `<id>.req.json`, the runner executes the private spec
+    (gateway `/tools/call`, direct call, or client-tool pause) and writes `<id>.res.json`.
+12. `session.prompt([...])` raced against `pause.signal`. Paused → `stopReason:"paused"`,
+    result undefined. Usage resolved (Pi usage file → prompt/stream merge), swallowed Pi
+    error peeked from Pi's transcript on empty output, trace finished + flushed, result
+    returned.
+13. `finally`: await runtime remount, deregister handle, stop relay, abort loopback MCP
+    calls, close MCP server, `destroySandbox()` (kills the daemon), `dispose()`, unmount
+    durable cwd, `workspace.cleanup()` (recursive rm of cwd), remove throwaway agent dir,
+    remove skills temp root.
+
+### daytona + claude
+
+Differences: `buildSandboxProvider` returns `daytona({create})` with snapshot/target,
+network policy fields, `envVars` (extension env + secrets), `ephemeral: true` +
+`autoStopInterval ≥ 1` as the leak backstop (`provider.ts:75-99`). The SDK creates the
+sandbox and starts the daemon inside it; ACP HTTP goes through the Daytona preview proxy
+with a per-host cookie jar fetch (`daytona.ts:152`). `prepareDaytonaPiAssets` is a no-op
+for Claude. Workspace files are written through the sandbox FS API. Tools are refused
+up-front (`REMOTE_TOOLS_UNSUPPORTED_MESSAGE`, `run-plan.ts:355-357`) because the loopback
+MCP channel is unreachable from inside the sandbox and only Pi's extension writes the file
+relay. `CLAUDE.md` is the instructions filename. Session-owned runs additionally discover
+the ngrok tunnel and geesefs-mount the store prefix **inside** the sandbox — but only
+*after* the workspace was materialized (see finding 2). Teardown deletes the Daytona
+sandbox; a killed process is covered by the signal sweeper and, failing that, by
+auto-stop + ephemeral delete.
+
+The `agenta` harness is `pi_agenta`: same `pi` ACP agent, but forced `_agenta.*` skills
+always arrive on the request, so it always takes the throwaway-agent-dir path — which
+matters for finding 6.
+
+---
+
+## 2. Strengths — keep this
+
+- **Fail-loud gate discipline.** `run-plan.ts` refuses every capability the runner cannot
+  actually deliver (code tools, stdio MCP, Pi user-MCP, non-Pi remote tools, unenforceable
+  network/filesystem policy) with named-constant messages, *before* any resource is
+  created. The capability gate (`assertRequiredCapabilities`) extends this to probed
+  capabilities. This is the single best property of the subsystem — protect it.
+- **Layered leak backstops.** Per-run `finally` → `inFlightSandboxes` + SIGTERM handler
+  (`server.ts:378`) → Daytona `ephemeral + autoStopInterval` server-side self-reap
+  (`provider.ts:41-99`). Each layer documents which failure mode the next one covers.
+- **Clear-then-apply credential env** (`daemon.ts:73-159`): the managed-run daemon
+  inherits zero provider keys; the clear set is deliberately a superset of the apply set.
+- **DI seams everywhere.** `SandboxAgentDeps` lets the 1100-line orchestration test drive
+  the whole engine with fakes; pure helpers (`run-plan`, `capabilities`, `model`, `usage`,
+  `skills`, `mount`) are directly unit-tested. 20+ test files cover the subsystem.
+- **Comments carry rationale and finding IDs** (F-024, F-040, F1, S1b, Security rule 5/6).
+  A new reader can reconstruct *why* every odd branch exists. Rare and valuable.
+- **Careful pause semantics**: one latch per turn, no harness reply on pause, paused-id
+  frame suppression, prompt-vs-pause race with orphan-rejection swallowing.
+- **Wire-boundary re-validation** in `skills.ts` (name slug, path traversal, SKILL.md
+  clobber, exec default-deny) and the SSRF guard in `mcp.ts`.
+
+---
+
+## 3. Findings
+
+Severity: blocker / high / medium / low. Horizon: short (before/at launch), medium
+(1-2 months), long (structural).
+
+### F1 — BLOCKER: no run deadline anywhere; a hung harness leaks everything, forever
+
+- **Where:** `sandbox_agent.ts:858-871` (the prompt race has only two exits: resolve or
+  pause), `acp-fetch.ts:32-41` (`headersTimeout`/`bodyTimeout` default **0** = disabled),
+  `server.ts:204-213` (session-owned runs deliberately do NOT abort on client disconnect).
+- **What:** `session.prompt()` has no timeout, and the HITL fix disabled the only
+  transport-level timeouts. For a session-owned run there is no abort path at all: the
+  client disconnecting does nothing, and nothing else ever fires.
+- **Failure scenario:** a provider outage / pi-acp adapter wedge / Daytona proxy stall
+  makes the prompt never resolve. The `finally` never runs → the local daemon (or Daytona
+  sandbox, kept non-idle by the open connection) lives forever, the geesefs mount stays
+  held, the HTTP response is held open, and the alive watchdog **keeps heartbeating the
+  session lock indefinitely** (`server.ts:236`, released only in the handler's `finally`)
+  — so the platform believes the session is live and healthy while it is wedged. Under
+  load, N wedged runs = N leaked daemons + N held sockets on a single-process Node server.
+- **Recommendation (short):** add a configurable overall run deadline (env, generous
+  default e.g. 30-60 min; HITL pauses already end the turn so they don't need the
+  connection held). Race it alongside `pause.signal`, treat expiry as
+  `{ok:false, error:"run timed out after ..."}`, and let the existing `finally` reclaim
+  everything. Consider a separate, shorter first-event/health deadline (daemon up but
+  harness never responds).
+
+### F2 — HIGH: Daytona durable-cwd mount happens AFTER workspace materialization, hiding AGENTS.md / CLAUDE.md / harnessFiles / skills
+
+- **Where:** `sandbox_agent.ts:550-574` (`prepareWorkspace` writes into `plan.cwd`) runs
+  before `sandbox_agent.ts:576-599` (`mountStorageRemote` geesefs-mounts *the same*
+  `plan.cwd` inside the sandbox). The local path explicitly does the opposite, with a
+  comment explaining why (`sandbox_agent.ts:544-548`: "Mount before local workspace
+  materialization so AGENTS.md, harness files, and skills land in the durable prefix
+  instead of being hidden under the later FUSE mount").
+- **What:** on a session-owned Daytona run with the store tunnel up, the instructions
+  file, the harness config files, and the non-Pi skill tree are written into the plain
+  directory, then the FUSE mount shadows them for the whole run. `harnessFiles` includes
+  the rendered `.claude/settings.json` **permissions** for Claude — so the Layer-1
+  permission config silently does not apply. (If geesefs instead refuses the non-empty
+  mountpoint, the failure inverts: the durable cwd silently doesn't attach.)
+- **Failure scenario:** daytona + claude + session: the agent runs with no instructions
+  and no authored permission rules; nothing errors.
+- **Recommendation (short):** move the remote mount above `prepareWorkspace`, mirroring
+  the local ordering (the local block already sits above it; hoist the daytona block to
+  the same spot). Add an orchestration test asserting call order for the daytona path.
+
+### F3 — HIGH: stale relay request files are re-executed on the next turn of a durable session (duplicate side effects, stolen client-tool outputs)
+
+- **Where:** `run-plan.ts:388-391` (`relayDir = <base>/relay/<basename(cwd)>` — constant
+  across turns for a durable cwd), `relay.ts:465-487` (the loop's `seen` set is per-run;
+  any `.req.json` not seen this run is executed), `tools/dispatch.ts:66-108` (the
+  extension unlinks req/res only after a response arrives — a paused or torn-down call
+  leaves its `.req.json` behind). No code ever removes `relayDir` (grep confirms: no
+  cleanup site).
+- **What:** turn N pauses on a client tool (or the daemon dies mid-call, or the extension
+  times out) → `<id>.req.json` stays on disk. Turn N+1 of the same session reuses the same
+  `relayDir`, and the fresh relay loop re-executes the stale request.
+- **Failure scenarios:**
+  - A *gateway* tool req is replayed → a second `POST /tools/call` → the external action
+    (send email, create ticket) executes twice.
+  - A stale *client* tool req calls `onClientTool({consume:true})` and can consume the
+    stored browser output intended for the harness's re-raised call — the real call then
+    finds nothing, pauses again, and the session ping-pongs.
+  - `usageOutPath` (`run-plan.ts:442`, same dir) is never deleted after reading
+    (`usage.ts:6-26`), so a turn where Pi fails to write reports the *previous* turn's
+    usage as its own.
+- **Recommendation (short):** clear the relay dir (or at minimum all `*.req.json` /
+  `*.res.json` / the usage file) at run start before `startToolRelay`, and/or make the
+  relay dir per-turn (`<basename(cwd)>-<turnId>`) with best-effort removal in the
+  `finally`. Also fixes the unbounded `/tmp/agenta/relay` accumulation.
+
+### F4 — HIGH: `rmSync(cwd, recursive)` after a *best-effort* unmount can delete durable store data through a live FUSE mount
+
+- **Where:** `sandbox_agent.ts:961-967`: `unmountStorage(mountedCwd)` (best-effort,
+  swallows failure) is immediately followed by `workspace.cleanup()` →
+  `rmSync(plan.cwd, {recursive, force})` (`workspace.ts:112-115`, and the pre-init
+  fallback at `sandbox_agent.ts:492-496`). `unmountStorage` itself logs — and proceeds
+  past — the case where the mountpoint is *still present after detach*
+  (`mount.ts:294-302`).
+- **What:** the rm is unconditional; the unmount is not. If `fusermount -uz` fails
+  (EPERM, binary missing, race) or the lazy detach hasn't landed, the recursive delete
+  walks *through the mounted filesystem* and erases the session's objects in the store —
+  the exact data the durable-cwd feature exists to preserve.
+- **Failure scenario:** flaky fusermount on one host → every completed turn on that host
+  silently wipes its session's durable files; users see their workspace reset each turn.
+- **Recommendation (short):** make the rm conditional: after unmount, re-check
+  `mountpoint -q` (the check already exists inside `unmountStorage`) and **skip** the
+  recursive rm when the path is still a mountpoint (or when `mountedCwd` was set at all —
+  the durable dir under `/tmp/agenta/mounts/...` is cheap to leave and is reused next
+  turn anyway; only ephemeral `mkdtemp` cwds need rm).
+
+### F5 — HIGH: unknown sandbox id silently falls back to LOCAL host execution
+
+- **Where:** `provider.ts:119-129` (`if (sandboxId === "daytona") ... else local(...)`),
+  `run-plan.ts:381-383` (`cwd = isDaytona ? ... : createLocalCwd(...)`). The fail-closed
+  treatment exists only for the tools gate (`isRemoteSandbox`, `run-plan.ts:279-282`) —
+  the comment even acknowledges the fall-through.
+- **What:** a request with `sandbox: "e2b"` (or any typo/future provider) runs the
+  harness **on the runner host** with `ok: true`, while the caller believes it bought
+  sandbox isolation. That inverts the trust boundary the rest of the file works hard to
+  fail-closed on (network policy, remote tools).
+- **Recommendation (short):** whitelist sandbox ids in `buildRunPlan`
+  (`local | daytona`) and refuse anything else with a named
+  `SANDBOX_UNSUPPORTED_MESSAGE`, exactly like the other gates.
+
+### F6 — HIGH: swallowed-Pi-error detection reads the wrong agent dir whenever skills or a system prompt are present — i.e. always, for the `agenta` harness
+
+- **Where:** `sandbox_agent.ts:897-903` passes `plan.sourcePiAgentDir` to
+  `findSwallowedPiError`; `run-plan.ts:453-454` sets it from
+  `process.env.PI_CODING_AGENT_DIR`; but `prepareLocalPiAssets` (`pi-assets.ts:236-251`)
+  repoints the **daemon's** `PI_CODING_AGENT_DIR` at the throwaway per-run dir whenever
+  skills or a system prompt exist — so Pi writes its session transcript under
+  `<runAgentDir>/sessions`, and the scan looks in the untouched source dir.
+- **What:** the F-030 "silent No response" fix is dead for exactly those runs: a provider
+  failure (bad key, out of quota) returns `ok:true` with empty output again. `pi_agenta`
+  always ships forced skills, so the whole agenta harness is unprotected. Worse, on a
+  durable cwd the scan can match an *older* transcript for the same cwd and attribute a
+  previous turn's error to this turn.
+- **Recommendation (short):** carry the *effective* agent dir on the plan (or return it
+  from `prepareLocalPiAssets` and pass it to the scan): `runAgentDir ?? plan.sourcePiAgentDir`.
+  One-line-ish fix; add a test with skills present.
+
+### F7 — HIGH: no per-session concurrency guard in the runner; a second concurrent turn shares the durable cwd and relay dir with the first, and the first finisher tears both down
+
+- **Where:** the durable cwd is keyed only by the sign prefix (`sandbox_agent.ts:344-352`);
+  `mountStorage` is idempotent ("already mounted" short-circuit, `mount.ts:212-215`); the
+  `finally` unmounts + rm's unconditionally (`sandbox_agent.ts:961-967`); relayDir shares
+  the same key (F3). Nothing runner-side rejects a second in-flight run for the same
+  `sessionId` (the alive watchdog *heartbeats* the lock but never checks ownership before
+  running).
+- **Failure scenario:** the coordination plane's turn lock is the only guard; any path
+  around it (retry after a timeout the runner didn't observe, a direct API caller, a
+  replica split-brain) means run B's cwd is lazily unmounted and recursively deleted
+  under it mid-prompt by run A's `finally`, and both relay loops consume each other's
+  req files.
+- **Recommendation (short/medium):** an in-process `Map<sessionId, Promise>` mutex (cheap,
+  single-replica correct today since affinity routing pins a session to a replica) that
+  either queues or refuses a concurrent same-session run with a clear error. Reference-count
+  or key the mount per turn if true concurrency is ever wanted.
+
+### F8 — HIGH (config-dependent): production compose never sets `PI_CODING_AGENT_DIR`, so a plain local Pi run (no skills, no system prompt) silently loses the extension — tracing, usage capture, builtin gating, and tool delivery
+
+- **Where:** `pi-assets.ts:254-257` (`if (process.env.PI_CODING_AGENT_DIR)
+  installPiExtensionLocal(...)` — else nothing); the gh compose sets no such env
+  (`hosting/docker-compose/ee/docker-compose.gh.yml:266-289`), only the dev compose does
+  (`.../docker-compose.dev.yml:404`).
+- **What:** without the env, the extension is never installed into the default
+  `~/.pi/agent`, and Pi loads nothing: no OTel self-instrumentation, no usage file, no
+  native tool registration (the relay loop polls a dir nobody writes → tools advertised
+  in the plan are silently never callable), no builtin gating enforcement
+  (`AGENTA_AGENT_BUILTIN_GATING` env is set but the enforcing extension is absent).
+  A run *with* a system prompt or skills takes the throwaway-dir path and works — so the
+  degradation is intermittent per-request, the worst kind.
+- **Recommendation (short):** set `PI_CODING_AGENT_DIR` in the gh compose (as dev does),
+  AND make the code fail loud: if `plan.isPi && (plan.useToolRelay || tracing wanted)` and
+  no agent dir is configured, either always use a throwaway dir (cheap; it already exists
+  for the skills path) or refuse the run. Silent-drop is exactly what the rest of
+  `run-plan.ts` was built to prevent.
+
+### F9 — MEDIUM: Claude runs silently drop `systemPrompt` / `appendSystemPrompt`
+
+- **Where:** `run-plan.ts:403-408` — both are gated `isPi ? ... : undefined`; no refusal,
+  no log for the non-Pi case.
+- **What:** a request that sets a system prompt on a claude run gets `ok:true` with the
+  prompt ignored — the F-032-class silent drop the codebase elsewhere refuses loudly. (If
+  the Python adapter renders it into `harnessFiles`/CLAUDE.md, then the runner-side field
+  is dead for claude and should be *refused* when present, to keep one source of truth.)
+- **Recommendation (short):** either deliver (Claude Agent SDK supports
+  append-system-prompt via its options; could ride `harnessFiles`) or gate with a
+  `SYSTEM_PROMPT_UNSUPPORTED_MESSAGE` like the other unsupported combinations.
+
+### F10 — MEDIUM: durable-cwd sandbox detection duplicates — and disagrees with — `buildRunPlan`
+
+- **Where:** `sandbox_agent.ts:345-348` uses
+  `request.sandbox ?? process.env.SANDBOX_AGENT_PROVIDER ?? "local"`, while
+  `buildRunPlan` uses `request.sandbox || deps.sandboxProvider || "local"`
+  (`run-plan.ts:250`). Two drifts: `??` vs `||` (an empty-string `sandbox` picks the
+  local durable path while the plan goes daytona), and the engine ignores the injected
+  `deps.sandboxProvider` (tests / embedders that inject it get a mis-derived durable cwd).
+- **Failure scenario:** `SANDBOX_AGENT_PROVIDER=daytona` + `sandbox:""` → durableCwd is
+  `/tmp/agenta/...` (a host path) handed to `createDaytonaCwd` as the *in-sandbox* cwd.
+- **Recommendation (short):** derive "is daytona" once. Either sign after `buildRunPlan`
+  with a plan-provided flag (the sign inputs don't need the plan; only the *derivation*
+  does), or extract one `resolveSandboxId(request, deps)` used by both.
+
+### F11 — MEDIUM: `process.env.AGENTA_API_URL` is mutated from request data
+
+- **Where:** `server.ts:229-232` — the first session-owned request whose OTLP endpoint
+  parses sets a process-global env var used by `apiBase()` for *all* subsequent
+  heartbeats/persists/mount-signs.
+- **What:** first-request-wins global state; a request with a wrong/malicious endpoint
+  poisons every later run's API base (until restart) when `AGENTA_API_INTERNAL_URL` is
+  unset. Also a hidden ordering dependency that will confound debugging.
+- **Recommendation (short):** thread the per-request api base explicitly (the mount code
+  already takes `apiBase` as a dep) instead of writing env; require
+  `AGENTA_API_INTERNAL_URL` in deployment.
+
+### F12 — MEDIUM: error surfacing loses fidelity — two-pattern taxonomy, first-line truncation, and raw `err.stack` on the transport catch
+
+- **Where:** `errors.ts:39-54` (only insufficient-credit and auth patterns; everything
+  else is `raw.split("\n")[0]`), `server.ts:263-265` and `server.ts:352-354` (engine
+  *throws* — which should be impossible but are the ones you most need context for —
+  return the full JS stack to the platform user).
+- **What:** the platform shows these strings to users. "fetch failed" (the most common
+  daemon/proxy failure) reaches users verbatim with zero actionable content; rate-limit,
+  model-not-found, and network classes all collapse to their first line; meanwhile the
+  transport catch leaks internals (paths, module names).
+- **Recommendation (short):** wrap results in a small error envelope
+  `{kind, message, detail?}` with a few more recognized classes (rate limit, model not
+  found, sandbox create failed, daemon unreachable, timeout — pairs with F1); log the full
+  error server-side, return the classified line; never return `err.stack` on the HTTP
+  edge. (medium): move classification next to the wire contract so the Python side can
+  branch on `kind`.
+
+### F13 — MEDIUM: per-run Daytona `npm install` of the Pi CLI (default ON)
+
+- **Where:** `daytona.ts:50-70`, `DAYTONA_PI_INSTALL` defaults true; gh compose sets
+  `AGENTA_AGENT_SANDBOX_PI_INSTALLED: false` → wait, it sets the *env* default `false`
+  which makes `DAYTONA_PI_INSTALL = process.env... !== "false"` → install **disabled** in
+  gh. The dev default (`true`) still pays up to 180 s of npm registry time per run, and a
+  registry hiccup is "best-effort logged" (`daytona.ts:67-69`) then the run proceeds and
+  fails later with an opaque pi-acp spawn error.
+- **Recommendation (medium):** bake `pi` into the snapshot everywhere (the memory-noted
+  `agenta-sandbox-pi` snapshot already does); when install *is* enabled and fails, fail
+  the run loudly instead of proceeding.
+
+### F14 — MEDIUM: `containsTransportEndpointDisconnected` deep-walks every ACP event on the hot path
+
+- **Where:** `sandbox_agent.ts:284-315` and its call inside `session.onEvent`
+  (`sandbox_agent.ts:717-718`), active on every local mounted run.
+- **What:** a full recursive traversal (every string, every array element) of every
+  event — including large `agent_message_chunk` payloads — per event, for the life of the
+  prompt, to find one ENOTCONN marker. O(total stream bytes) extra CPU on the
+  single-threaded server; also a false-positive vector (a run whose *content* contains
+  "ENOTCONN" triggers a remount).
+- **Recommendation (medium):** only inspect the frames that can carry an error (e.g.
+  `tool_call_update` error fields / adapter error notifications) or cap depth/size; the
+  remount limit of 1 already bounds the damage, so precision matters more than recall.
+
+### F15 — MEDIUM: managed runs still expose the host harness login (HOME / CLAUDE_CONFIG_DIR always inherited)
+
+- **Where:** `daemon.ts:146-150` — `CLAUDE_CONFIG_DIR` and `HOME` are copied on every
+  run, including `credentialMode === "env"`.
+- **What:** clear-then-apply scrubs env keys, but a local Claude harness whose resolved
+  key is rejected can silently fall back to the sidecar's own OAuth login files —
+  spending the operator's subscription and mislabeling billing, with nothing in the
+  result revealing which credential actually authenticated. (Pi has the same shape:
+  `PI_CODING_AGENT_DIR` seeded with the host `auth.json` even for managed runs,
+  `pi-assets.ts:196-203`.)
+- **Recommendation (medium):** on `credentialMode === "env"`, point HOME /
+  CLAUDE_CONFIG_DIR / the Pi agent-dir seed at a login-less throwaway dir so a bad key
+  fails loud as auth (which `errors.ts` already classifies) instead of falling back.
+
+### F16 — MEDIUM: `finally` teardown is serial and unbounded against a slow Daytona API
+
+- **Where:** `sandbox_agent.ts:952-972` — six sequential awaits; `destroySandbox()` has
+  no timeout here (the *shutdown* sweep is bounded, the per-run path is not), and
+  `toolRelay.stop()` waits for the current poll sleep + all in-flight tool executions.
+- **What:** a slow Daytona delete (30-60 s under API degradation) holds the HTTP
+  response and the event-loop slot for every finishing run; N finishing runs serialize
+  their slowness onto the caller-visible latency.
+- **Recommendation (medium):** send the terminal result *before* the heavy teardown
+  (restructure so the result is computed, streamed, then cleanup runs detached with its
+  own bounded timeout + the in-flight registry as backstop), or bound `destroySandbox`
+  with a race + rely on autostop.
+
+### F17 — MEDIUM: capability probe failure is indistinguishable from "capabilities absent", and the static fallback guesses generously
+
+- **Where:** `capabilities.ts:120-134` — `catch {}` on `getAgent` collapses "daemon
+  down", "agent unknown", and "no capabilities field" into the same static guess, which
+  asserts `toolCalls: true, streamingDeltas: true, sessionLifecycle: true` for any
+  harness.
+- **What:** a daemon that is actually broken proceeds to `createSession` and fails there
+  with a less specific error; a new harness gets optimistic defaults that re-enable the
+  silent-drop class the gate exists to prevent (the gate only checks `mcpTools`+`toolCalls`,
+  both guessed true for non-Pi).
+- **Recommendation (medium):** log the probe error with its class; for an *unknown*
+  harness id, prefer pessimistic static flags (`mcpTools:false`) so the tool gate
+  fails closed on guesses, consistent with `isRemoteSandbox`'s fail-closed reasoning.
+
+### F18 — LOW: README layout is stale (`engines/pi.ts` no longer exists; result example says `POST /run` only)
+
+- **Where:** `services/runner/README.md:31,47` list `engines/pi.ts` as a live engine;
+  `src/engines/` contains only `sandbox_agent`. `AGENTS.md` already says "one engine".
+  Also `/stream` (the productized route, `server.ts:314-319`) is absent from the README.
+- **Recommendation (short, cheap):** delete the pi-engine references, document `/stream`
+  and `/kill`.
+
+### F19 — LOW: `readBody` is unbounded; one giant body OOMs the single-process sidecar
+
+- **Where:** `server.ts:285-291`. Trusted-network mitigates; a Content-Length cap
+  (a few MB) is one line. Horizon: short.
+
+### F20 — LOW: `pickModel` suffix matching can silently select a different provider's model
+
+- **Where:** `model.ts:7-16` — `wanted "openai/gpt-x"` matches `"azureopenai/gpt-x"` by
+  suffix. The resolved id is at least returned/logged/stamped on the span. Horizon: medium
+  (tighten to same-provider suffix match, or log the cross-provider hop).
+
+### F21 — LOW: `buildRunPlan` creates the cwd before its own trailing asserts, leaking a temp dir on an invariant trip
+
+- **Where:** `run-plan.ts:381` (cwd) vs `run-plan.ts:413-421` (asserts) — also
+  `resolveSkillDirs` at 396 leaks its temp root if a later assert throws (the cleanup
+  only rides the returned plan). Invariants "should never fire", so low. Horizon: medium
+  (order asserts before resource creation).
+
+### F22 — LOW: `uploadDirToSandbox` reads every file as UTF-8
+
+- **Where:** `pi-assets.ts:304-307` — a binary asset in a skill (image, wasm) is
+  corrupted on upload. Wire skills are strings today, so latent. Horizon: medium (read
+  Buffer, pass bytes; `writeFsFile` accepts `BodyInit`).
+
+### F23 — LOW: history replay is quadratic and truncates mid-message
+
+- **Where:** `transcript.ts:69-81` — every turn re-sends the whole prior transcript as
+  text (cold model: token cost grows O(n²) over a conversation) and `slice(-maxChars)`
+  can cut a message mid-way, and the "Conversation so far:" framing is spoofable by
+  message content (a user message containing "assistant:" lines). Known design
+  trade-off; note for the session/persistence roadmap. Horizon: long.
+
+### F24 — LOW: `KNOWN_PROVIDER_ENV_VARS` is a hand-synced list across three codebases
+
+- **Where:** `daemon.ts:73-108` — the comment demands agreement with Python
+  `_PROVIDER_ENV_VARS`, SDK `capabilities.py`, and `_CLOUD_SECRET_ENV_BY_DEPLOYMENT`,
+  with no test pinning it. A new provider added on the Python side silently re-opens the
+  inherited-credential leak for managed runs. Horizon: medium (a golden-fixture parity
+  test like the wire contract's).
+
+---
+
+## 4. Structure and quality (the 973-line orchestrator)
+
+**Verdict: the extraction into `sandbox_agent/*` modules is genuinely good; the residual
+orchestrator is the remaining debt.**
+
+- `runSandboxAgent` is one ~650-line function. The worst offender is the durable-cwd
+  concern: `signMount` + derivation + `mountLocalDurableCwd` + `reSignAndRemountLocalCwd`
+  + `remountLocalCwdAfterRuntimeEnotconn` + the remount-retry wrapper around
+  `prepareWorkspace` + three `finally` steps ≈ 130 lines of closures interleaved with
+  everything else (`sandbox_agent.ts:326-497, 544-599, 953-967`). Extract a
+  `DurableCwdController` (mount/ensure/handleEvent/teardown) in `mount.ts`'s module and
+  the function shrinks by a third *and* F2/F4/F10 become single-owner fixes. Horizon: medium.
+- Sandbox branching is one honest seam (`plan.isDaytona`, 37 refs) and mostly lives in
+  the right modules (mount local vs remote, workspace, mcp gate, relay host, usage read).
+  Two leaks back into the orchestrator: the daytona-asset block and the mount-ordering
+  divergence (F2). Acceptable.
+- Harness branching: name-string checks are well-contained (7 sites, all funneled through
+  `buildRunPlan`-derived facts: `acpAgent`, `isPi`, `instructionsFile`, `legacyHarnessApiKeyVar`).
+  But `plan.isPi` appears ~34 times, encoding a *bundle* of facts (tool delivery =
+  extension, self-tracing when local, usage via file, system-prompt support, relay
+  permission enforcement, swallowed-error recovery). A third harness family (codex is on
+  the roadmap) forces a re-audit of every `isPi`. Derive a `HarnessProfile`
+  (`toolDelivery: "extension"|"mcp"`, `selfTraces`, `usageSource`, `supportsSystemPromptFiles`,
+  `instructionsFile`, `permissionGate: "relay"|"acp"`) once in `buildRunPlan` and branch on
+  named facts. Horizon: medium/long.
+- Positional argument counts: `buildSandboxProvider(6)` (`provider.ts:111-118`),
+  `startToolRelay(7)` (`relay.ts:399-407`) — Python-style positional bags in TS; convert
+  to option objects before the signatures grow again. Horizon: medium.
+- `sandbox: any`, `session: any`, `event: any` throughout, even though
+  `sandbox-agent/dist/index.d.ts` fully types `SandboxAgent`/`Session`/`SessionEvent`.
+  Adopting the SDK types (or a narrowed structural interface) would have flagged the
+  event-shape guessing (`payload?.params?.update ?? payload?.update`) and will catch the
+  next SDK upgrade drift at `tsc` time. Horizon: medium.
+- Dead-ish: `plan.legacyHarnessApiKeyVar` is consumed only inside `buildRunPlan` to
+  compute `hasApiKey` (and one test); it needn't ride the plan. `mcp.ts`'s
+  `McpServerStdio` half of `McpServerEntry` is a permanently-throwing path kept for shape.
+  Low.
+- Tests: strong pure-helper and DI-orchestration coverage (~4.6k test lines). **Untested
+  seams that the findings above live in:** the `finally` ordering with a mounted cwd,
+  daytona workspace/mount ordering, relayDir reuse across two sequential runs, concurrent
+  same-session runs, any timeout behavior, and the swallowed-error path with skills
+  present. Each blocker/high fix above should land with one.
+
+---
+
+## 5. Top-10 priorities
+
+1. **F1 (blocker, short):** overall run deadline + first-response deadline; wire into the
+   prompt race so the existing `finally` reclaims resources.
+2. **F4 (high, short):** never `rmSync` a cwd that is (or may still be) a live FUSE
+   mount — condition the cleanup on the unmount verification.
+3. **F3 (high, short):** clear/scope the relay dir per turn; delete the usage file after
+   reading.
+4. **F2 (high, short):** hoist the Daytona remote mount above `prepareWorkspace`, mirror
+   the local ordering, add a call-order test.
+5. **F6 (high, short):** point `findSwallowedPiError` at the effective (per-run) Pi agent
+   dir — the `agenta` harness currently has zero swallowed-error protection.
+6. **F5 (high, short):** whitelist sandbox ids; refuse unknown providers instead of
+   silently executing on the host.
+7. **F8 (high, short):** set `PI_CODING_AGENT_DIR` in gh compose AND make missing
+   extension delivery fail loud (or always use the throwaway dir).
+8. **F7 (high, short/medium):** in-process per-session mutex so concurrent turns can't
+   tear down each other's mount/relay.
+9. **F12 (medium, short):** error envelope with kind classification; stop returning
+   `err.stack`; grow `conciseError` beyond two patterns.
+10. **Structure (medium):** extract `DurableCwdController`; introduce `HarnessProfile`
+    to collapse the `isPi` fact-bundle; adopt the SDK types; add lifecycle integration
+    tests (mount ordering, relay reuse, teardown ordering).

--- a/docs/design/agent-workflows/scratch/runner-review-2026-07-05/findings/entrypoints-sessions.md
+++ b/docs/design/agent-workflows/scratch/runner-review-2026-07-05/findings/entrypoints-sessions.md
@@ -1,0 +1,414 @@
+# Runner review — entrypoints + sessions (server.ts, cli.ts, entry.ts, apiBase.ts, version.ts, responder.ts, protocol.ts, sessions/*)
+
+Reviewer scope: HTTP/CLI entrypoints, the streaming responder, the wire-contract types
+(mechanical quality only), and the sessions subsystem (alive/auth/contract/interactions/persist).
+Read-only review. Other reviewers cover `engines/`, `tools/`, `tracing/`, and contract *design*.
+
+## How it actually works (verified)
+
+**Two entrypoints, meant to share one contract.** `src/server.ts` runs a bare `node:http`
+server on `:8765` (`GET /health`, `POST /run|/stream`, `POST /kill`); `src/cli.ts` reads one
+JSON request from stdin and writes one result to stdout, with an optional `--stream` NDJSON
+mode. Both call `runSandboxAgent` directly (`engines/sandbox_agent.ts`) — there is exactly one
+engine, selected internally by harness, not by an engine selector. Both export a testable seam
+(`createAgentServer(run)` / `runCli(raw, stream, io)`) that tests use with a fake engine.
+
+**Auth on the HTTP path is optional and off by default.** `AGENTA_RUNNER_TOKEN` unset (the
+default) means `/run`/`/stream`/`/kill` accept any caller reachable on the loopback bind; set,
+every request must present a matching bearer via `Authorization: Bearer` or
+`X-Agenta-Runner-Token`, checked in constant time (`timingSafeEqual`). `/health` is always
+open (no secrets in the payload). The CLI has no auth concept — stdin is trusted by
+construction (subprocess transport).
+
+**Streaming (`runAndStream`) branches into two behaviorally different modes** based on
+whether `request.sessionId` is non-empty (`isSessionOwned`):
+- **Non-session runs**: `res.on("close", ...)` aborts the engine when the client disconnects.
+  Events stream live; nothing is persisted server-side beyond the HTTP response itself.
+- **Session-owned runs**: the run survives client disconnect (abort is never wired). The
+  runner (a) starts an alive-lock heartbeat watchdog (`sessions/alive.ts`) that keeps a Redis
+  lock + `session_streams` row live on a 30s interval and periodically refreshes the bearer
+  credential; (b) fire-and-forgets `cancelStaleInteractions` for the new turn; (c)
+  fire-and-forgets `persistSandboxId`; (d) wraps the live emitter in a persisting emitter
+  (`sessions/persist.ts`) that POSTs every event to `/sessions/records/ingest`, coalescing
+  the `*_delta` families into one durable event per message/thought. All of this authenticates
+  "as the invoke caller" using a bearer pulled out of `request.telemetry.exporters.otlp.headers`
+  — there is no separate session-auth token type; `sessions/auth.ts` just re-mints a fresh-TTL
+  copy of the same credential via `/access/permissions/check`.
+
+**`sessions/contract.ts`** is a hand-mirrored copy of the Python Redis contract (TTLs, key
+names, the release-if-owner Lua script, `CONCURRENCY_CAP`, `validateSessionId`), pinned by a
+golden-fixture test. The runner itself never touches Redis directly — everything routes
+through the API's HTTP endpoints (heartbeat, records/ingest, interactions), so this file is
+really just shared vocabulary + a validator, most of which (see findings) is not called from
+runner code.
+
+**`responder.ts`** turns ACP permission gates and client-tool pauses into verdicts using a
+shared `decide()` ladder (out of scope — `permission-plan.ts`) plus two separate stores:
+`ConversationDecisions` for consume-once allow/deny replay, and a FIFO-per-key store for
+client-tool browser outputs (explicitly separated so a literal `"allow"`/`"deny"` output string
+can't be misread as a permission decision). This module is well-isolated and its cold-replay
+key derivation (`approvedCallKey`/`canonicalJson`) is careful about non-JSON values.
+
+## Strengths — keep this
+
+- The `createAgentServer(run)` / `runCli(raw, stream, io)` testing seams are genuinely good:
+  both entrypoints are unit-tested end-to-end with a fake engine, no live harness needed.
+- The shutdown handler for the HTTP server (`registerShutdownHandler`) is well-designed where
+  it exists: idempotent against repeated signals, bounded so it can never hang, injectable for
+  tests, and actually tested (signal → cleanup → exit, cleanup-rejects still exits, no
+  double-cleanup).
+- The `Authorization: Bearer` header parser deliberately avoids `/^Bearer\s+(.+)$/` (polynomial
+  ReDoS) in favor of a fixed-prefix check + `slice/trim` — a real, documented threat-modeling
+  decision, not an accident.
+- `responder.ts`'s separation of permission decisions from client-tool outputs (and the FIFO
+  list for duplicate identical calls) is a deliberate fix for a real collision class, and it's
+  covered by tests for the duplicate-call case.
+- The persistence chain (`sessions/persist.ts`) correctly serializes writes per-session via a
+  promise-chain tail, is fire-and-forget mid-run but drained before teardown, and swallows
+  failures without ever blocking or throwing into the run.
+- `PermissionMode`/`ToolPermission`/`AgentEvent`/`RenderHint` are properly modeled as
+  discriminated unions/string-literal unions in `protocol.ts` — where the authors did this, it's
+  done well.
+
+## Findings
+
+### 1. [HIGH] `cli.ts` has zero process-lifecycle hardening — the CLI transport can leak Daytona sandboxes on kill
+**File:** `src/cli.ts` (whole file); compare `src/server.ts:378-430`.
+
+`server.ts` installs `registerShutdownHandler()` (destroys in-flight sandboxes on
+SIGTERM/SIGINT) plus `unhandledRejection`/`uncaughtException` handlers, specifically because
+"a shutdown handler... Without this, `docker stop` kills the process while the per-run
+`finally`... is still waiting... so the sandbox it created is never deleted and leaks (a
+Daytona credit-burner)." `cli.ts` has none of this: no signal handler, no
+`destroyInFlightSandboxes()` call, no `unhandledRejection`/`uncaughtException` handler. The CLI
+is exactly the transport the SDK uses "when `AGENTA_RUNNER_INTERNAL_URL` is unset" (README) —
+i.e., whenever the subprocess model is in play. If the Python caller kills the subprocess
+(timeout, SIGTERM, SIGKILL) while a Daytona-backed run is in flight, the sandbox created by
+that run is never torn down — the identical leak class `server.ts`'s handler exists to close,
+just on the other entrypoint.
+**Recommendation:** register the same signal + unhandled-rejection/exception handlers in
+`cli.ts`'s entrypoint guard (share the implementation — see finding 7). SIGKILL obviously can't
+be caught, but SIGTERM (the normal "give up on this subprocess" signal) can and today isn't.
+**Horizon:** short (ships next week; this is the same class of bug the team already fixed once
+on the other transport).
+
+### 2. [HIGH] Shutdown handler doesn't stop accepting new connections before sweeping — a request that races the signal still leaks its sandbox
+**File:** `src/server.ts:378-430`.
+
+`registerShutdownHandler` calls `onCleanup()` (`destroyInFlightSandboxes`, a one-time sweep of
+whatever is in `inFlightSandboxes` *at that instant*) and then `exit(0)`. It never calls
+`server.close()` (the server instance isn't even threaded into the handler). During the
+window between the signal arriving and `process.exit(0)` actually firing (bounded by the
+`destroyInFlightSandboxes` timeout, up to 5s), the HTTP server keeps accepting and starting new
+`/run`/`/stream` requests. A request that starts a Daytona sandbox *after* the sweep already
+ran is added to `inFlightSandboxes` but is never destroyed before `process.exit(0)` — the exact
+leak this mechanism exists to prevent, just via a slightly different race. This matters most on
+rolling deploys/redeploys, which is exactly when SIGTERM fires under normal operation (not just
+crash scenarios).
+**Recommendation:** on signal, first stop the server from accepting new connections
+(`server.close()`), *then* sweep in-flight sandboxes, *then* exit. Thread the `Server` instance
+into `registerShutdownHandler` (or return a closer from `createAgentServer` and call both from
+the entrypoint block).
+**Horizon:** short.
+
+### 3. [HIGH] `apiBaseFromRequest` mutates `process.env.AGENTA_API_URL` globally from per-request, caller-supplied data
+**File:** `src/server.ts:127-134, 228-232`.
+
+```ts
+const requestApiBase = apiBaseFromRequest(request);
+if (requestApiBase && !process.env.AGENTA_API_URL) {
+  process.env.AGENTA_API_URL = requestApiBase;
+  ...
+}
+```
+This derives an API base URL from the *run request's own* `telemetry.exporters.otlp.endpoint`
+field (arbitrary string, caller-controlled) and, the first time it fires in the process's
+lifetime, pins it into `process.env.AGENTA_API_URL` — global mutable state read by every
+subsequent request via `apiBase()` (`src/apiBase.ts`), used to build the URLs for heartbeat,
+persist, interactions, and credential refresh, all of which carry live bearer tokens in the
+`Authorization` header. In a shared runner process serving concurrent sessions (the normal
+production shape — one sidecar, many `/run` calls), whichever request happens to be first to
+hit this code path with an unset `AGENTA_API_URL` permanently decides where *every other
+session's* authenticated session-coordination calls go, for the life of the process. In the
+common deployment (`AGENTA_API_INTERNAL_URL` set via compose/k8s) this branch never fires
+because `apiBase()` prefers that var first — but the mutation targets `AGENTA_API_URL`
+specifically as a fallback-only knob, meaning it's exactly the path that *would* fire in a
+misconfigured or "internal URL not set" deployment, and once it fires once, it's baked in.
+There is no test covering this function or this mutation at all.
+**Recommendation:** don't mutate `process.env` from per-request data. If a request-derived
+fallback is needed, thread it explicitly through the call chain (or cache it per-session, not
+globally) instead of writing to global process state that every other concurrent request also
+reads.
+**Horizon:** short — this is a live correctness/credential-routing risk, not hypothetical, in
+any deployment shape where `AGENTA_API_INTERNAL_URL` isn't set.
+
+### 4. [HIGH] The two entrypoints diverge on error shape for the same failure (malformed JSON + streaming requested)
+**File:** `src/server.ts:323-332` vs `src/cli.ts:55-62`.
+
+`cli.ts`'s invalid-JSON handling produces a stream-shaped record when `stream` is true:
+`write(stream ? JSON.stringify({ kind: "result", result: failure }) + "\n" : ...)`. `server.ts`
+checks for invalid JSON *before* it looks at `wantsStream`, and on failure always calls
+`send(res, 400, {...})` — a flat, non-NDJSON JSON body with `content-type: application/json`,
+regardless of whether the caller sent `Accept: application/x-ndjson`. So: a caller that always
+expects NDJSON on the stream path (which is what "the live agent always requests," per the
+comment at `server.ts:342-345`) gets a *different response shape* for malformed input than it
+would from the CLI transport for the identical input — and a caller line-parsing NDJSON that
+gets a bare 400 JSON body has to special-case that. This is the one config both entrypoints are
+supposed to keep "actually shared" and it's exactly where they've drifted.
+**Recommendation:** for the streaming path, emit the same `{kind:"result", result: {ok:false,
+error}}` NDJSON line (with a 200 or 400 status, pick one deliberately) that the CLI produces,
+instead of branching to a differently-shaped error body before checking `Accept`.
+**Horizon:** short (this is exactly the kind of drift a golden-fixture-style test should pin,
+similar to the wire-contract test).
+
+### 5. [MEDIUM] No request body size limit on `POST /run`/`/stream`
+**File:** `src/server.ts:285-291` (`readBody`), `src/cli.ts:87-93` (`readStdin`, less of a
+concern since it's a trusted subprocess pipe).
+
+`readBody` accumulates every chunk into an array and concatenates with no cap. A `/run` request
+legitimately carries full conversation history plus any image/file attachments as base64 —
+that can be large even in good faith, and there is no `Content-Length` pre-check or streaming
+cap that would turn an oversized body into a clean `413` before it's fully buffered in memory.
+Combined with finding 15 (no concurrency cap), a handful of large concurrent requests can
+exhaust the process's memory.
+**Recommendation:** enforce a configurable max body size (check `Content-Length` up front where
+present, and abort the read if actual bytes exceed it while streaming) and return `413` instead
+of buffering unbounded.
+**Horizon:** short-medium (low likelihood given the loopback trust boundary, but cheap to add
+and this is exactly the kind of thing that's much harder to retrofit under load next week).
+
+### 6. [MEDIUM] `POST /kill` tears down every in-flight sandbox process-wide, not just the caller's
+**File:** `src/server.ts:303-312`, `src/engines/sandbox_agent.ts:160-174`.
+
+`destroyInFlightSandboxes()` iterates `inFlightSandboxes` (a single process-wide `Set`) and
+destroys all of them — there is no session/run-scoped selector. The `/kill` endpoint's own
+comment frames this as intentional ("lets the orphan sweeper force a process-wide teardown
+out-of-band. Always ok.") but if one sidecar process ever serves more than one concurrent
+session (which the whole alive/persist/heartbeat design assumes it does), a single `/kill` call
+— triggered for one orphaned session — takes down every other session's live sandbox on that
+replica too. Worth confirming this is genuinely intended for the deployment topology (e.g., if
+each replica is expected to host exactly one active run at a time, this is fine and the comment
+is accurate; if replicas are shared across concurrent sessions, this is a blast-radius bug).
+**Recommendation:** confirm the intended concurrency-per-replica model; if replicas are shared,
+scope `/kill` to a `sessionId`/sandbox id instead of sweeping the whole process.
+**Horizon:** medium (cross-cutting with `engines/` — flagging here since the HTTP surface for it
+lives in this reviewer's scope).
+
+### 7. [MEDIUM] `server.ts` and `cli.ts` reimplement the same wire-handling logic instead of sharing it
+**File:** `src/server.ts:181-274, 285-291, 323-348` vs `src/cli.ts:47-93`.
+
+Both files independently: parse raw JSON with the same try/catch-and-produce-an-error-result
+pattern; wrap the engine's `EmitEvent` to build NDJSON event lines; write exactly one terminal
+`{kind:"result"}` line with `events` stripped to `[]`; and read an input stream chunk-by-chunk
+into a `Buffer`. `AGENTS.md` frames the two entrypoints as sharing "the same contract," but the
+actual code for producing that contract's wire shapes is copy-pasted, not shared — which is
+precisely how finding 4 happened, and will happen again on the next change to either the error
+path or the streaming envelope. `RunAgent` itself is even declared twice with two different
+signatures (server.ts's carries a `signal` parameter; cli.ts's doesn't), so a future change to
+one won't even fail to compile in the other.
+**Recommendation:** extract a shared module (e.g. `src/streamProtocol.ts`) owning: JSON-parse
+with the standard error result, the NDJSON record writer/emit wrapper, and the "terminal result
+strips events" rule. Both entrypoints call into it; behavior differences (e.g., HTTP status
+codes, session coordination) stay local to each entrypoint.
+**Horizon:** medium (worth doing before more streaming-path features land on either side).
+
+### 8. [MEDIUM] `sessions/persist.ts`'s `record_index` claim ("monotonic per session") doesn't match the implementation ("monotonic per turn")
+**File:** `src/sessions/persist.ts:108-125`.
+
+The doc comment says the returned counter is built "so record_index increments monotonically
+**per session**." But `buildPersistingEmitter(sessionId, ...)` is called fresh once per
+`runAndStream` invocation (i.e., once per **turn**, from `server.ts:247`), and `eventIndex`
+starts at `0` inside that closure every time. A session with N turns will POST records with
+`record_index` values `0,1,2,...` **for every turn**, not a value that keeps climbing across
+the session's lifetime. If the ingest endpoint or any downstream consumer treats
+`(session_id, record_index)` as an ordering or uniqueness key scoped to the whole session
+(plausible, given the comment's own framing), turn 2's `record_index=0` collides with turn 1's.
+Verifying the API-side (Python) contract for `/sessions/records/ingest` is out of this
+reviewer's scope, but the runner-side comment and implementation disagree with each other
+regardless of what the API does with it, which is itself worth fixing.
+**Recommendation:** either rename the comment to say "monotonic per turn" (if that's genuinely
+what the ingest endpoint expects — e.g., it's scoped by `(session_id, turn_id, record_index)`),
+or seed `eventIndex` from a per-session cursor if cross-turn uniqueness is actually required.
+**Horizon:** short — cheap to check against the API contract, and wrong in one direction or the
+other today.
+
+### 9. [MEDIUM] `protocol.ts`: several fields with a known, finite, documented value set are typed as bare `string`
+**File:** `src/protocol.ts:369-424` (`harness`, `sandbox`, `provider`, `connection.mode`,
+`deployment`, `credentialMode`), `:29-33` (`ChatMessage.role`).
+
+The doc comments spell out the exact allowed values — `harness?: string;` is commented
+`"pi_core" | "pi_agenta" | "claude"`; `sandbox?: string;` is commented `"local" | "daytona"`;
+`deployment?: string;` is commented `"direct" | "azure" | "bedrock" | "vertex" | "custom"` — but
+none of these are actually typed as unions, unlike `PermissionMode`/`ToolPermission` a few lines
+above them, which *are* proper string-literal unions. This is an inconsistency within the same
+file, not a blanket "everything should be a union" complaint: the authors clearly know how to do
+this (and did, for the permission types) and just didn't apply it here. The practical cost is
+every consumer of `request.harness`/`request.sandbox`/etc. gets `string` and has to
+re-establish the invariant with runtime checks or comments instead of the compiler catching a
+typo (`"clause"` instead of `"claude"`) at the call site. `version.ts`'s `HARNESSES` constant
+(`["pi_core", "claude", "pi_agenta"] as const`) is *right there* as a ready-made literal union
+source (`(typeof HARNESSES)[number]`) but `AgentRunRequest.harness` doesn't use it.
+**Recommendation:** introduce literal unions for these fields (deriving from `version.ts`'s
+`HARNESSES`/`ENGINES` where applicable), or — if forward-compat with an as-yet-unknown value is
+a deliberate requirement — use the `SomeUnion | (string & {})` pattern to keep autocomplete
+without losing openness. `ChatMessage.role` similarly could be
+`"user" | "assistant" | "system" | "tool"`.
+**Horizon:** medium (mechanical cleanup; touches the mirrored Python wire only if you also
+change the shape, which you wouldn't here — purely a TS-side tightening).
+
+### 10. [LOW/MEDIUM] `SESSION_ID_PATTERN`/`validateSessionId` exist but are never called from runner code
+**File:** `src/sessions/contract.ts:83-89`.
+
+`validateSessionId` is exported, has its own dedicated tests
+(`tests/unit/session-redis-contract.test.ts:149-159`), and encodes a real invariant (max 128
+chars, `[a-zA-Z0-9_-]` only — explicitly rejecting `"path/injection"` and `"has space"` in its
+own test). But grepping the whole `src/` tree, nothing calls it: `server.ts` never validates
+`request.sessionId` before using it to build URLs (`persistSandboxId` does
+`encodeURIComponent(sessionId)`, which defuses URL-injection but not oversized/garbage ids) or
+before handing it to the alive watchdog / persist chain / interactions calls. Either this
+validation is meant to happen runner-side at the `/run` boundary (in which case it's a real gap
+— a malformed `sessionId` flows all the way into heartbeat/persist/interactions calls before
+anything downstream might reject it) or it's enforced API-side only and this function is dead
+code that should be removed (or documented as "kept for parity/tests only").
+**Recommendation:** either call `validateSessionId` at the top of the session-owned path in
+`runAndStream` (reject cleanly, e.g. treat as a non-session run or 400) or delete the unused
+export and its "guards against injection" framing if the API is solely responsible.
+**Horizon:** short to confirm intent; the fix itself is small either way.
+
+### 11. [LOW] `server.ts:195` non-null-asserts `sessionId` outside the guard that makes it safe, then re-guards it anyway
+**File:** `src/server.ts:194-201`.
+
+```ts
+const sessionOwned = isSessionOwned(request);
+const sessionId = request.sessionId!;
+const turnId = resolveTurnId(request);
+...
+`[sessions] stream sessionOwned=${sessionOwned} sessionId=${sessionId ?? "-"} ...`
+```
+`sessionId` is force-unwrapped to `string` via `!`, then two lines later defended against
+`undefined`/falsy with `?? "-"` as if it might still be missing — which, per the type, it can't
+be, but per reality (an empty/whitespace `sessionId` makes `isSessionOwned` false while
+`request.sessionId` is still `""` or `"   "`, not `undefined`) it demonstrates the assertion was
+never really justified. It happens to be harmless today because the actual session-owned logic
+below is gated on `sessionOwned`, not on `sessionId` truthiness directly. But the `!` plus the
+immediate defensive `??` is a tell that the author didn't trust their own assertion — a future
+edit that reads `sessionId` outside the `if (sessionOwned)` block (e.g., adding it to another
+log line) inherits a lie the type system can no longer catch.
+**Recommendation:** type it as `request.sessionId?.trim()` (or compute it only inside the
+`if (sessionOwned)` block where it's actually used) instead of asserting non-null and then
+re-guarding.
+**Horizon:** short, trivial.
+
+### 12. [LOW] Top-level catch-all in the HTTP listener returns the raw stack trace in the response body
+**File:** `src/server.ts:351-355`.
+
+```ts
+} catch (err) {
+  const message = err instanceof Error ? err.stack ?? err.message : String(err);
+  return send(res, 500, { ok: false, error: message });
+}
+```
+This is distinct from the `AgentRunResult.error` field (which is part of the documented
+contract and expected to carry rich detail back to the Python side) — this is the outer
+listener's defensive catch for anything unexpected in request handling itself (e.g. a
+`JSON.stringify` failure in `send()`, or a thrown error from `isAuthorized`). Returning
+`err.stack` here leaks internal file paths and call structure over the wire. Bounded today by
+the loopback bind + optional token, so not urgent, but "don't put stack traces in HTTP
+responses" is a cheap habit to fix before this ships more broadly.
+**Recommendation:** log `err.stack` to stderr, return `err.message` (or a generic message) in
+the response body.
+**Horizon:** short, trivial.
+
+### 13. [LOW] `runAndStream` mixes session-coordination orchestration with response streaming in one ~90-line function
+**File:** `src/server.ts:181-274`.
+
+The function does, at one abstraction level: write HTTP headers, decide session ownership,
+build an abort controller, wire disconnect handling, log a diagnostic, and then — at a much
+lower level — infer an API base from telemetry headers and mutate `process.env` (finding 3),
+start a watchdog, fire two best-effort side calls, build a persisting emitter, invoke the
+engine, flush persistence, release the watchdog, and write the terminal record. It's readable
+today because it's well-commented, but any of the "session-owned" branch's five side effects
+(watchdog, stale-interaction cancel, sandbox-id persist, persisting emitter, credential
+plumbing) is a plausible spot for the next bug, and none of them are independently testable
+without going through the whole HTTP request.
+**Recommendation:** extract a `beginSessionCoordination(request)` / `endSessionCoordination()`
+pair (or a small class) that owns the watchdog + persistence + best-effort side calls, so
+`runAndStream` itself reads as "stream the run, optionally coordinated."
+**Horizon:** medium.
+
+### 14. [LOW] Session-coordination `fetch` calls have no timeout — a hung API stalls the run's teardown
+**File:** `src/sessions/alive.ts:54-87`, `src/sessions/persist.ts:36-73`,
+`src/sessions/interactions.ts:52-119`, `src/sessions/auth.ts:18-35`.
+
+None of these `fetch` calls pass an `AbortSignal`/timeout. They're individually swallowed on
+error (fine), but `runAndStream`'s `finally` path does `await flushPersist()` before releasing
+the alive lock — if the API is up but slow/hanging (not erroring), `drainPersist` can block on
+an in-flight `postEvent` for however long the runtime's default fetch timeout is (undici's
+default is on the order of minutes, not seconds), holding the HTTP response open and the alive
+lock un-released for that whole window.
+**Recommendation:** give these calls an explicit short timeout (a few seconds) via
+`AbortSignal.timeout(...)`, consistent with the "never blocks the turn" framing already used in
+the comments.
+**Horizon:** medium.
+
+### 15. [LOW] No concurrency cap/backpressure on `/run`, despite one being defined in the mirrored contract
+**File:** `src/sessions/contract.ts:77` (`CONCURRENCY_CAP = 1000`), `src/server.ts` (whole
+request listener).
+
+`CONCURRENCY_CAP` is asserted against in a golden-fixture test
+(`tests/unit/session-redis-contract.test.ts:144`) but is never read by any runner code path —
+presumably it's enforced API-side (out of scope here), but the runner itself will start
+executing any number of concurrent `/run`/`/stream` requests with no local queue or rejection,
+each of which may spin up a real sandbox/subprocess. Combined with finding 5 (unbounded body
+size), a burst of concurrent requests has no local circuit breaker.
+**Recommendation:** at minimum, log/monitor concurrent in-flight count; consider a soft local
+cap that returns 429 rather than accepting unbounded parallel runs on one sidecar process.
+**Horizon:** long (this is a capacity-planning/backpressure feature, not a pre-launch fix).
+
+### 16. [LOW] `GET /health` never checks reachability of its own dependencies
+**File:** `src/version.ts:27-35`, `src/server.ts:299-301`.
+
+`runnerInfo()` always returns `status: "ok"` — it reports the runner's own identity/version but
+never probes whether the API (`apiBase()`) or Redis-backed coordination it depends on for
+session-owned runs is reachable. An orchestrator's liveness/readiness probe (Kubernetes,
+Compose healthcheck) can't distinguish "sidecar is up and fully functional" from "sidecar is up
+but every session-owned run will 401/timeout against a dead API." Not necessarily wrong for a
+liveness probe (a "don't restart me" signal, separate from an API dependency), but worth being
+deliberate about which one this is meant to be.
+**Recommendation:** if this is meant to double as a readiness probe, add an optional
+dependency check (or a separate `/ready`); if it's meant purely as liveness, say so in the
+comment so a future reader doesn't wire it to the wrong Kubernetes probe type.
+**Horizon:** long.
+
+## Top 10
+
+1. **[HIGH]** `cli.ts` has no signal/shutdown handling at all — the subprocess transport can
+   leak Daytona sandboxes on kill, the same bug class `server.ts` already fixed for itself.
+   (`src/cli.ts`)
+2. **[HIGH]** The HTTP shutdown handler sweeps in-flight sandboxes without first stopping new
+   connections (`server.close()`), so a request racing the SIGTERM still leaks its sandbox.
+   (`src/server.ts:378-430`)
+3. **[HIGH]** `apiBaseFromRequest` mutates global `process.env.AGENTA_API_URL` from
+   caller-supplied, per-request data, first-write-wins, untested — a real credential-routing
+   risk in any deployment where `AGENTA_API_INTERNAL_URL` isn't set. (`src/server.ts:127-134,
+   228-232`)
+4. **[HIGH]** Server vs. CLI diverge on error shape for malformed JSON while streaming is
+   requested — the "same contract" claim is untrue exactly where it matters most.
+   (`src/server.ts:323-348` vs `src/cli.ts:55-62`)
+5. **[MEDIUM]** No request body size cap on `/run`/`/stream` — unbounded memory buffering, no
+   413. (`src/server.ts:285-291`)
+6. **[MEDIUM]** `/kill` tears down every in-flight sandbox process-wide, not scoped to a
+   session — confirm this matches the intended per-replica concurrency model.
+   (`src/server.ts:303-312`)
+7. **[MEDIUM]** `server.ts`/`cli.ts` duplicate the JSON-parse/NDJSON-assembly logic instead of
+   sharing it — the root cause behind finding 4 and future drift. (`src/server.ts` +
+   `src/cli.ts`)
+8. **[MEDIUM]** `persist.ts`'s "record_index increments monotonically per session" comment
+   doesn't match the per-turn-reset implementation — verify against the ingest endpoint's
+   actual key. (`src/sessions/persist.ts:108-125`)
+9. **[MEDIUM]** `protocol.ts` leaves `harness`/`sandbox`/`provider`/`connection.mode`/
+   `deployment`/`credentialMode` as bare `string` despite documented finite value sets, while
+   `PermissionMode`/`ToolPermission` right next to them are proper unions. (`src/protocol.ts`)
+10. **[LOW/MEDIUM]** `validateSessionId` is fully built and tested but never called from any
+    runner code path — confirm intent (dead code vs. missing boundary check).
+    (`src/sessions/contract.ts:83-89`)

--- a/docs/design/agent-workflows/scratch/runner-review-2026-07-05/findings/tests-qa.md
+++ b/docs/design/agent-workflows/scratch/runner-review-2026-07-05/findings/tests-qa.md
@@ -1,0 +1,431 @@
+# Runner review — tests & QA (reviewer F)
+
+Scope: `services/runner/tests/**`, `vitest.config.ts`, `package.json` scripts, CI wiring, the
+wire-contract golden setup, and how much of the manual QA matrix could be automated. Does not
+review `src/` logic itself (other reviewers cover that) — only what is and isn't tested, and
+how well.
+
+## Test run status (2026-07-05)
+
+Ran everything locally on Node v24.16.0 (matches the pinned Node 24 requirement).
+
+| Command | Result |
+| --- | --- |
+| `pnpm run typecheck` | **PASS**, clean, no errors |
+| `pnpm run test:unit` | **PASS** — 44 files, 525 tests, 4.4s |
+| `pnpm run test:integration` | **PASS** — 1 file, 8 tests, 0.6s (Redis-dependent assertions self-skip when Redis is absent, which it was) |
+| `pnpm run test:acceptance` | **PASS** — 1 file, 16 tests, 0.65s |
+| `pnpm run test:coverage` | **RAN** — v8 coverage, see table below |
+
+All three layers are green. CI (`.github/workflows/12-check-unit-tests.yml`, jobs
+`run-runner-tests` / `run-runner-integration-tests` / `run-runner-acceptance-tests`) runs
+typecheck + all three layers as separate jobs with JUnit publishing, gated only by
+"not a draft PR" — **this suite is wired into CI**, not just a local convention. No coverage
+job exists in CI; `test:coverage` is local/manual only, with no thresholds configured
+anywhere (`vitest.config.ts` has no `coverage` block).
+
+## Coverage map
+
+Per-file v8 statement coverage from the actual run, cross-referenced against which test
+file(s) exercise each module (found by tracing both static and dynamic `import()` in every
+`tests/unit/*.test.ts`). "Behavior/detail" is my read of whether the test asserts observable
+behavior (status codes, wire shapes, side effects) vs. internal call order/implementation
+detail.
+
+| src module | test file(s) | stmt cov | behavior/detail | note |
+| --- | --- | --- | --- | --- |
+| `apiBase.ts` | *(no dedicated test; exercised transitively via sessions/*)* | 100%* | detail-only | *not asserted directly — the internal/public precedence and trailing-slash trim have no dedicated test, just incidental execution with unset env vars |
+| `cli.ts` | `cli.test.ts` | 57.1% | behavior | seam (`runCli(raw, stream, io)`) used correctly; uncovered = `main()`/stdin/`isEntrypoint` glue, inert by design during tests |
+| `entry.ts` | *(none directly; exercised via cli/server module load)* | 60% | — | trivial, low-risk |
+| `permission-plan.ts` | `permission-plan.test.ts`, `permission-parity.test.ts`, `tool-relay-permission*.test.ts` | 91.75% | behavior | strong; cross-language golden pinned too |
+| `protocol.ts` | `wire-contract.test.ts` + almost every other file (types) | 75% | behavior | the few runtime helpers (`resolvePromptText`, `messageText`, `resolveRunSessionId`) are well exercised |
+| `responder.ts` | `responder.test.ts`, `tool-relay-permission*.test.ts` | 94.7% | behavior | strong |
+| `server.ts` | `server.test.ts`, `server-smoke.test.ts`, `server-contract.test.ts` | 64.4% | behavior | HTTP surface strongly covered; shutdown-handler tests are a standout (see Strengths); uncovered lines are mostly less-common branches |
+| `engines/sandbox_agent.ts` (orchestration) | `sandbox-agent-orchestration.test.ts`, `continuation.test.ts`, `mcp-servers.test.ts` | 81.2% | behavior | `runSandboxAgent` driven directly with an injected fake harness (25 tests); `destroyInFlightSandboxes` NOT exercised at all — its tracking `Set` is module-private, no test seam |
+| `engines/skills.ts` | `skills.test.ts` | 94.1% | behavior | strong |
+| `engines/sandbox_agent/acp-fetch.ts` | `sandbox-agent-acp-fetch.test.ts` | 90% | behavior | good |
+| `engines/sandbox_agent/acp-interactions.ts` | `sandbox-agent-acp-interactions.test.ts` | 89.5% | behavior | good, incl. a concurrent-pending-gates test |
+| `engines/sandbox_agent/capabilities.ts` | `sandbox-agent-capabilities.test.ts` | 100% | behavior | strong |
+| `engines/sandbox_agent/client-tools.ts` | `client-tools.test.ts` | 96.1% | behavior | strong |
+| `engines/sandbox_agent/daemon.ts` | `sandbox-agent-daemon.test.ts` | 44.7% | **split** | `buildDaemonEnv` (security-critical clear-then-apply) is thoroughly tested; `resolveDaemonBinary` (env/package/pnpm-store fallback chain) is **0% covered** |
+| `engines/sandbox_agent/daytona.ts` | `sandbox-agent-daytona.test.ts` | 71.2% | behavior | moderate; only 3 tests for a provider integration |
+| `engines/sandbox_agent/errors.ts` | `sandbox-agent-errors.test.ts` | 100% | behavior | strong |
+| `engines/sandbox_agent/mcp.ts` | `mcp-servers.test.ts`, `session-mcp-layering.test.ts` | 96.9% | behavior | strong |
+| `engines/sandbox_agent/model.ts` | `sandbox-agent-model.test.ts` | 61.1% | behavior | moderate, only 7 tests |
+| `engines/sandbox_agent/mount.ts` | `sandbox-agent-mount.test.ts` | 71.0% | behavior | moderate |
+| `engines/sandbox_agent/pause.ts` | `sandbox-agent-orchestration.test.ts` (indirect) | 87.5% | behavior | no dedicated file, fine given the size |
+| `engines/sandbox_agent/pi-assets.ts` | `sandbox-agent-pi-assets.test.ts` | 68.9% | behavior | moderate |
+| `engines/sandbox_agent/pi-error.ts` | `sandbox-agent-pi-error.test.ts` | 84.3% | behavior | good |
+| `engines/sandbox_agent/provider.ts` | `sandbox-agent-provider.test.ts` | 77.3% | behavior | moderate |
+| `engines/sandbox_agent/run-plan.ts` | `sandbox-agent-run-plan.test.ts` (47 tests) | 93.1% | behavior | strong, the biggest single test file by test count |
+| `engines/sandbox_agent/transcript.ts` | `continuation.test.ts` | 64.6% | behavior | pure functions (`priorMessages`/`messageTranscript`/`buildTurnText`), light coverage for logic that shapes what a cold-sandbox turn sees of history |
+| `engines/sandbox_agent/usage.ts` | `sandbox-agent-usage.test.ts` | 94.7% | behavior | strong |
+| `engines/sandbox_agent/workspace.ts` | `sandbox-agent-workspace.test.ts` | 89.2% | behavior | strong |
+| `extensions/agenta.ts` | `extension-tools.test.ts` | 58.2% | behavior | light — only 9 tests for 141 statements on a core Pi delivery path |
+| `sessions/alive.ts` | `session-alive.test.ts` | 67.9% | behavior | good pattern (fetch stub), some branches missed |
+| `sessions/auth.ts` | *(none)* | **0%** | — | `refreshCredential` entirely untested |
+| `sessions/contract.ts` | `session-redis-contract.test.ts` | 100% | behavior | strong |
+| `sessions/interactions.ts` | `session-interactions.test.ts` | 42.1% | **split** | only `createInteraction`'s happy/retry path tested; `buildWorkflowReferences`, `resolveInteraction`, `cancelStaleInteractions` all **0%** |
+| `sessions/persist.ts` | `session-persist.test.ts` | 74.2% | behavior | good coverage of coalescing/retry/drain |
+| `tools/callback.ts` | *(none)* | **7.4%** | — | `callAgentaTool` — the one shared `/tools/call` transport — essentially untested |
+| `tools/client-tool-relay.ts` | n/a | n/a | — | types-only, no runtime code |
+| `tools/code.ts` | `code-tool.test.ts` | 100% | behavior | 1 test, small surface |
+| `tools/direct.ts` | `tool-direct.test.ts` (45 tests) | 91.9% | behavior | strong, incl. SSRF-guard and secret-leak checks |
+| `tools/dispatch.ts` | `tool-dispatch.test.ts`, `tool-dispatch-permission.test.ts` | 92.2% | behavior | strong |
+| `tools/mcp-bridge.ts` | `tool-bridge.test.ts`, `mcp-servers.test.ts`, `session-mcp-layering.test.ts` | 100% | behavior | strong (of mcp-bridge.ts itself; see tool-mcp-http.ts below for the gap it hides) |
+| `tools/public-spec.ts` | (indirect via `extension-tools.test.ts`, `sandbox-agent-run-plan.test.ts`) | 100% | detail | no dedicated assertions of `advertisedToolSpec`/`executableToolSpecs` shape, just incidental use |
+| `tools/relay.ts` | `tool-bridge.test.ts`, `tool-direct.test.ts`, `tool-dispatch.test.ts`, `tool-relay-permission*.test.ts` | 84.7% | behavior | strong overall |
+| `tools/spec-schema.ts` | `spec-schema.test.ts` | 100% | behavior | strong |
+| `tools/tool-mcp-http.ts` | *(only indirectly, via `mcp-bridge.ts` consumers)* | 71.3% | **split** | happy path (`tools/list`/single `tools/call`) covered; batch requests, `MAX_BODY_BYTES` rejection, malformed JSON (400), non-POST (405), and the abort/`MCP_PAUSED` pause-suppression logic are **all uncovered** |
+| `tracing/otel.ts` | `otel-skills-error.test.ts`, `responder.test.ts`, `stream-events.test.ts`, `startup-banner.test.ts`, `sandbox-agent-orchestration.test.ts` (indirect) | 68.5%/53.6% branch | **split** | span lifecycle/state-machine has some coverage; the OpenInference/GenAI attribute-mapping functions (`emitMessages`, `applyAssistant`, tool-call/result rendering, usage/cache/cost fields) are **largely uncovered** — 1315 lines, the biggest file in `src/` |
+| `version.ts` | (indirect, via `server.test.ts` `/health`) | 100%* | detail | no dedicated test of `runnerInfo()` shape beyond what `/health` incidentally checks |
+
+\* "100%" here means every statement executed at least once somewhere in the suite, not that
+the function's actual decision logic (env-var precedence, trailing-slash trim) is directly
+asserted.
+
+## Strengths — keep this
+
+1. **Seam discipline is real, not aspirational.** `createAgentServer(run)` / `runCli(raw, stream, io)`
+   are used consistently across `tests/unit/server.test.ts`, `tests/integration/server-smoke.test.ts`,
+   and `tests/acceptance/server-contract.test.ts`. All three bind real loopback HTTP servers on
+   port 0 (OS-assigned) with a fake engine — no live Pi/Claude/sandbox-agent, no real network
+   beyond loopback, no port collisions.
+2. **Graceful-shutdown testing is genuinely good.** `tests/unit/server.test.ts`
+   (`registerShutdownHandler` describe block, ~line 233) drives `process.emit("SIGUSR2", ...)`
+   against dependency-injected `exit()`/`onCleanup()` callbacks — avoids touching real
+   `SIGTERM`/`SIGINT` (which would kill the test runner) while still proving: cleanup-then-exit,
+   cleanup-rejects-but-still-exits (a failing Daytona delete must never hang shutdown), and
+   idempotency (a repeated signal doesn't double-run cleanup). This is exactly the kind of
+   test most projects skip.
+3. **Cross-language wire-contract pinning is excellent.** `tests/unit/wire-contract.test.ts` +
+   `tests/unit/permission-parity.test.ts` load the SAME golden JSON files
+   (`sdks/python/oss/tests/pytest/unit/agents/golden/`) that the Python side asserts in
+   `test_wire_contract.py`, with a compile-time key-guard (`KNOWN_REQUEST_KEYS as (keyof
+   AgentRunRequest)[]`) so a drifted `protocol.ts` fails `tsc`, plus deep runtime assertions on
+   every nested field (tool axes, skills, sandbox permission, tracing propagation). The
+   commentary explaining *why* each assertion exists is unusually good documentation-as-test.
+4. **The acceptance suite is a real contract test, not a smoke test.** `server-contract.test.ts`
+   systematically covers status codes + response shape for every route (`/health`, `/run`
+   JSON + NDJSON, `/stream` alias, `/kill`, 404), both auth-gate states, and both bearer/header
+   auth forms — 16 tests, each named after the exact behavior it proves.
+5. **Security-relevant env handling is thoroughly tested where it matters most.**
+   `sandbox-agent-daemon.test.ts`'s `buildDaemonEnv` tests assert the full
+   `KNOWN_PROVIDER_ENV_VARS` inventory (all 8 direct provider keys + AWS/GCP/Azure cloud
+   groups) is cleared on a managed run and preserved on a non-managed run — a real security
+   property (Rule 5, clear-then-apply), not just a shape check.
+6. **Fakes are structurally, not just nominally, typed against the real SDK.**
+   `SandboxAgentDeps` (in `engines/sandbox_agent.ts`) types its injectable seams as
+   `typeof SandboxAgent.start`, `typeof buildDaemonEnv`, etc. — actual function types from the
+   real modules, not a hand-maintained parallel interface. `pnpm run typecheck` passing clean
+   is real evidence the test fakes have not silently drifted from the real `sandbox-agent`
+   package's shape.
+7. **CI wiring is already solid.** Typecheck + unit + integration + acceptance run as four
+   separate CI jobs (`.github/workflows/12-check-unit-tests.yml`), each publishing JUnit
+   results, gated sensibly (skips on draft PRs, respects `workflow_dispatch` package
+   selection), with an explicit comment that the runner-tests job intentionally has **no**
+   "has_tests" skip guard, so an empty/broken suite fails loud rather than silently passing.
+
+## Findings
+
+### 1. [blocker] No automated regression test exists for any real captured agent run — despite dozens sitting ready in the QA matrix
+
+The manual QA effort (`docs/design/agent-workflows/projects/qa/`) has produced ~70 real
+captured `/run` request/response pairs across environments, harnesses, and capabilities
+(`qa/runs/*.json`), a purpose-built skill for exactly this conversion
+(`.agents/skills/agent-replay-test/SKILL.md`), and its own explicit call-out in
+`qa/matrix.md`: *"When F-001 is fixed, E2/E3 flip to pass and this becomes the regression
+test."* None of it has happened. `grep -rl "replay" services/runner/tests/` and a repo-wide
+search for replay test files under `sdks/python/.../recordings/` both come back empty.
+
+Today `tests/unit/sandbox-agent-orchestration.test.ts` exercises `runSandboxAgent` against a
+**hand-built** fake ACP session (`fakeHarness()`), which encodes the author's mental model of
+how Pi/Claude behave over ACP — useful and typesafe, but never checked against a real
+transcript. Bugs like F-001 (append_system dropped on sandbox-agent) were only caught by
+*manual* re-verification across several QA passes (2026-06-20 fail → 2026-06-25 fix
+confirmed → 2026-06-25 re-run confirmed again) — exactly the kind of regression an automated
+replay test would have caught for free on every subsequent PR.
+
+**Recommendation:** pick 2-3 already-green QA cells and turn them into TS-side tests that feed
+a *recorded* ACP transcript through `runSandboxAgent` (not the hand-tuned `fakeHarness`) and
+assert the real captured output shape. Start with the F-001 append_system regression (it's
+explicitly flagged as "should become the regression test") and the code-tool / builtin-bash
+happy path (already captured in `qa/runs/E2__code_tool_pi_core.json` etc.). This is a new
+artifact — the existing `agent-replay-test` skill targets the Python SDK layer
+(`sdks/python/.../recordings/`), which pins the *SDK's* handling of a runner result, not the
+TS runner's own orchestration; a TS-side sibling is what's actually missing here.
+
+**Files:** `services/runner/tests/unit/sandbox-agent-orchestration.test.ts`,
+`docs/design/agent-workflows/projects/qa/runs/*.json`, `docs/design/agent-workflows/projects/qa/matrix.md`.
+**Horizon:** short.
+
+### 2. [high] `tools/tool-mcp-http.ts` — Claude's only tool delivery channel — has untested batch/abort/pause/error paths
+
+71.3% statement coverage, but every uncovered line is a real failure or edge-case path, not
+dead code: the JSON-RPC **batch** request branch (array of messages, lines ~319-337), the
+`MAX_BODY_BYTES` request-too-large rejection (~252-255), malformed-JSON 400 handling
+(~306-314), the non-POST 405 response (~295-297), and — most concerning — the
+`MCP_PAUSED`-sentinel / abort-on-signal logic (~386-404) that deliberately destroys an
+in-flight HTTP socket with no body so a paused `client` tool call doesn't settle late. All
+current coverage of this file is *incidental*, via `tool-bridge.test.ts` /
+`mcp-servers.test.ts` / `session-mcp-layering.test.ts`, which build the server through
+`buildToolMcpServers` (`mcp-bridge.ts`) and only ever send a single well-formed request.
+Given this file's own docstring says it "REPLACES the pre-#4831 stdio bridge" and is the sole
+way Claude receives gateway/callback/client tools in production, its pause/abort/error paths
+deserve direct tests against `startInternalToolMcpServer` itself.
+
+**File:** `services/runner/src/tools/tool-mcp-http.ts`. **Horizon:** short.
+
+### 3. [high] `tracing/otel.ts`'s attribute-mapping logic is the least-tested part of the biggest file in `src/`
+
+1315 lines, 68.5%/53.6% branch coverage — the lowest branch coverage of any src file. The
+uncovered ranges are concentrated in `emitMessages`, `applyAssistant`, `toolResultText`, and
+the token/cache/cost attribute emission (`gen_ai.usage.*`, `gen_ai.response.finish_reasons`,
+etc.) — pure functions (`Span` in, `setAttribute` calls out) that are cheap to unit test with
+a fake `Span` but currently aren't. This is exactly the class of bug the project has been
+bitten by before: a shape mismatch here doesn't throw, it just silently drops a field from a
+trace, discovered only later by reading Agenta's UI (see prior incident:
+`ag.metrics.duration.cumulative` intentionally scalar; and the QA matrix's own F-029 "skills
+invisible in traces" / F-030 "error runs carry only a count, no message" findings — both are
+this same class of otel-shape gap, found manually, that a direct unit test on these functions
+would catch immediately and for free.
+
+**File:** `services/runner/src/tracing/otel.ts`. **Horizon:** short-medium.
+
+### 4. [high] `resolveDaemonBinary()` — the sandbox-agent binary lookup — has zero test coverage
+
+`daemon.ts` is 44.7% covered overall, but that number is misleading: `buildDaemonEnv` (the
+security-critical clear-then-apply half) is thoroughly tested (see Strengths #5);
+`resolveDaemonBinary()` (env-var override → platform CLI package → pnpm-store directory scan
+→ not-found) is **completely untested**, 0 of its statements executed by any test. This is
+boring, load-bearing, three-branch fallback logic — precisely the kind that breaks silently
+when a Docker base image's `node_modules/.pnpm` layout shifts, or a new platform/arch
+combination is added, and the failure mode is "every run fails at daemon startup," not a
+localized bug. It's easily testable by mocking `node:fs`'s `existsSync`/`readdirSync` to drive
+each branch plus the not-found case.
+
+**File:** `services/runner/src/engines/sandbox_agent/daemon.ts` (lines 24-50).
+**Horizon:** short.
+
+### 5. [medium] `sessions/interactions.ts` — three functions at 0%, all turn-lifecycle-critical
+
+Only `createInteraction`'s happy/retry path is tested (`session-interactions.test.ts`).
+Completely untested:
+- `buildWorkflowReferences` — shapes which workflow/variant/revision an interaction record
+  carries, so a later respond-invoke re-resolves the *same* revision. A bug here means a
+  resumed approval could silently re-resolve the wrong revision.
+- `resolveInteraction` — transitions an interaction to `resolved` after the runner forwards a
+  stored decision to the harness.
+- `cancelStaleInteractions` — cancels orphaned pending-approval gates from a prior turn when
+  the user sends a new message instead of answering. A bug here leaves stale gates that block
+  or confuse a later turn.
+
+All three are fire-and-forget/best-effort by design (errors are logged and swallowed), which
+is exactly why they need tests: a regression fails silently in production with no crash to
+notice. The existing `createInteraction` test already establishes the fetch-mocking pattern to
+extend to these.
+
+**File:** `services/runner/src/sessions/interactions.ts` (lines 20-37, 97-119, 127-145).
+**Horizon:** short.
+
+### 6. [medium] `sessions/auth.ts`'s `refreshCredential` is completely untested
+
+0% coverage, no test file references it. This re-mints the runner's short-lived (~15 min TTL)
+Secret token so a long-running turn doesn't lose auth mid-run. A silent regression means turns
+that exceed the TTL start failing auth partway through, with no test surfacing it beforehand.
+Small (23 lines) and follows the same `vi.stubGlobal("fetch", ...)` pattern already
+established in `sessions/alive.ts` and `sessions/interactions.ts` — cheap to add.
+
+**File:** `services/runner/src/sessions/auth.ts`. **Horizon:** short.
+
+### 7. [medium] `tools/callback.ts`'s `callAgentaTool` — the one shared `/tools/call` transport — is 7.4% covered
+
+Per its own docstring this is the single implementation of the tool round-trip used by both
+the Pi-extension path and the MCP-bridge path, specifically so "a change to the `/tools/call`
+contract is a one-line edit, not several." Untested: the `AbortSignal.any` timeout-combination
+logic, non-2xx response handling, all three response-body-parse branches (string `content`,
+object `content` re-stringified, non-JSON fallback to raw body), and the transport-error → thrown
+`Error` mapping. A regression here breaks every tool call on every harness, silently until a
+real run fails.
+
+**File:** `services/runner/src/tools/callback.ts`. **Horizon:** short.
+
+### 8. [medium] Fakes are structurally typed but not behaviorally verified — document the residual risk
+
+`fakeHarness()` in `sandbox-agent-orchestration.test.ts` (and similar inline fakes elsewhere)
+are hand-rolled duck-typed plain objects for the ACP session/sandbox. `SandboxAgentDeps`
+typing them against `typeof SandboxAgent.start` etc. (real SDK function types) does catch a
+*shape* drift at `tsc` time (a real strength, see Strengths #6) but cannot catch a *behavioral*
+drift: whether the real `sandbox-agent` package's `prompt()` really never resolves after a
+permission pause the way the `hangPrompt` fake option assumes, whether event ordering
+guarantees the fakes encode actually hold, or whether a new SDK version changes error object
+shapes without changing the type signature. This is an inherent limit of any seam-based fake,
+not a bug — but it's exactly what finding #1 (recorded-transcript replay tests) would give
+periodic, low-cost verification against.
+
+**Files:** `services/runner/tests/unit/sandbox-agent-orchestration.test.ts`.
+**Horizon:** medium.
+
+### 9. [medium] Duplicated test setup wants shared `tests/utils/` helpers
+
+- The `listen(run)` helper (start `createAgentServer`, bind an ephemeral loopback port, return
+  `{url, close}`) is copy-pasted **verbatim** in `tests/unit/server.test.ts`,
+  `tests/integration/server-smoke.test.ts`, and `tests/acceptance/server-contract.test.ts`.
+- A hand-rolled `mkdtempSync(join(tmpdir(), "..."))` + cleanup pattern is repeated across at
+  least 14 unit test files (`sandbox-agent-daytona`, `tool-dispatch`,
+  `sandbox-agent-workspace`, `permission-record-fixture`, `sandbox-agent-usage`,
+  `sandbox-agent-run-plan`, `sandbox-agent-pi-error`, `tool-dispatch-permission`,
+  `sandbox-agent-pi-assets`, `tool-direct`, `tool-relay-permission*.test.ts`, `tool-bridge`).
+
+`tests/utils/` currently holds only `golden.ts`. Extracting `listenServer(run)` and a
+`withTempDir()` helper means a future change to server-bootstrap or temp-dir cleanup
+discipline is a one-file fix instead of an N-file grep-and-replace, and gives new tests an
+obvious default to reach for instead of reinventing the pattern (there's already a lot of
+`AGENTS.md`-encouraged growth in this test suite; this duplication only gets worse).
+
+**Files:** the helper is duplicated across 3 server test files and inlined in 14+ others.
+**Horizon:** short (cheap, high leverage).
+
+### 10. [medium] No test exercises concurrent `/run` requests, and `destroyInFlightSandboxes` has no direct test at all
+
+Every test in the suite drives one request at a time against `createAgentServer`. Nothing
+proves that two overlapping `POST /run` calls (a realistic production scenario — a sidecar
+handling concurrent playground sessions) don't interleave their NDJSON writes, that one run's
+kill/abort doesn't touch another's in-flight sandbox, or that the shutdown-drain sweep
+(`destroyInFlightSandboxes` in `engines/sandbox_agent.ts`) correctly races more than one
+in-flight sandbox against its timeout. `destroyInFlightSandboxes` itself is not directly unit
+tested at all today — its tracking `Set` is module-private with no exported seam, so the only
+way to exercise its `Promise.allSettled`-races-a-timeout / swallow-errors behavior is a full
+real run, which is why it isn't tested. `registerShutdownHandler`'s tests (Strengths #2)
+verify the *signal-handling* half well; they inject a fake `onCleanup`, so they never actually
+exercise `destroyInFlightSandboxes`'s own logic.
+
+**Recommendation:** (a) add a concurrency test firing 2+ overlapping `POST /run` requests with
+fake engines that resolve out of order, asserting responses don't cross-contaminate; (b) add a
+minimal test-only export/reset hook for the in-flight sandbox set so `destroyInFlightSandboxes`
+can be unit tested directly (seed 2-3 fake handles, one whose `destroySandbox` hangs past the
+timeout, assert the sweep still resolves and doesn't throw).
+
+**Files:** `services/runner/src/engines/sandbox_agent.ts` (lines 150-174),
+`services/runner/tests/unit/server.test.ts`. **Horizon:** medium.
+
+### 11. [low] Real timers everywhere — no test uses `vi.useFakeTimers()`
+
+Every retry/backoff and polling test uses real wall-clock delays:
+`sessions/persist.ts`/`sessions/interactions.ts`/`sessions/alive.ts` retry tests, and the
+permission-relay poll loops in `tool-relay-permission*.test.ts` /
+`tool-dispatch-permission.test.ts` (a `waitForFile` with a 1000ms real deadline). This is why
+individual test files take 300ms-3.9s each for what is otherwise pure logic
+(`tool-relay-permission-record.test.ts` alone is ~3.9s), and is a latent flakiness risk on a
+loaded CI runner — none of it has flaked yet, but the pattern doesn't scale as more
+retry/backoff logic is added. `grep -rl "useFakeTimers" tests/` returns nothing in the entire
+suite.
+
+**Recommendation:** switch the deterministic-retry-count cases to
+`vi.useFakeTimers()` + `vi.advanceTimersByTimeAsync()`; keep real timers only where a test
+genuinely polls a real filesystem side effect and a fake clock wouldn't help.
+
+**Horizon:** medium.
+
+### 12. [low] `pnpm test` (the documented pre-push command) only runs the unit layer
+
+`services/runner/AGENTS.md`'s "Before committing" section says "Run `pnpm test` and
+`pnpm run typecheck` before pushing," but `package.json`'s `"test"` script is aliased to
+`"test:unit"` only — it silently skips the integration and acceptance layers that CI runs as
+separate jobs. A contributor following the documented checklist can push a change that breaks
+`server-contract.test.ts` or `server-smoke.test.ts` and only discover it from CI.
+
+**Recommendation:** either update the AGENTS.md instruction to list all three commands
+explicitly, or change `pnpm test` to chain `test:unit && test:integration && test:acceptance`
+to match what the instruction already implies.
+
+**Files:** `services/runner/package.json`, `services/runner/AGENTS.md`. **Horizon:** short.
+
+### 13. [low] No coverage thresholds, and `test:coverage` isn't wired into CI at all
+
+`vitest.config.ts` has no `coverage` block (no `thresholds`, no `exclude` policy beyond
+defaults). `test:coverage` is a local-only, developer-initiated report — it does not run in
+any CI job. So a coverage regression on a security-relevant module (e.g., a new unclearved
+branch added to `buildDaemonEnv`, or a new response path in `tools/callback.ts`) would not be
+caught by CI, only by a human who happens to run the report.
+
+**Recommendation:** add `coverage.thresholds` scoped at minimum to `sessions/**`,
+`permission-plan.ts`, and `engines/sandbox_agent/daemon.ts` (the credential-handling/env-clearing
+surface), and add a CI job running `test:coverage` — non-blocking at first if the thresholds
+need calibrating, blocking once stable.
+
+**Files:** `services/runner/vitest.config.ts`, `.github/workflows/12-check-unit-tests.yml`.
+**Horizon:** medium.
+
+### 14. [low] A few core-path files have moderate rather than strong coverage
+
+`extensions/agenta.ts` (141 stmts, the Pi extension's `registerTools` — the actual wiring of
+custom tools into Pi under sandbox-agent/ACP) is only 58.2% covered off 9 tests — light for a
+core Pi delivery path. `cli.ts` (57.1%, 4 tests) and `server.ts` (64.4%, 15 tests) are also
+moderate, though most of their uncovered lines are `main()`/`isEntrypoint()`/stdin-reading glue
+that's inert during tests by design, not real logic gaps. Worth a look, lower priority than
+findings 2-7.
+
+**Horizon:** long.
+
+## QA-matrix automation potential
+
+The manual QA program (`docs/design/agent-workflows/projects/qa/`) is unusually rigorous:
+`matrix.md` defines an environment × harness × capability product with explicit validity
+rules, Gherkin scenarios with an "unguessable token + negative control" discipline, and ~70
+real captured `/run` pairs under `qa/runs/`. Almost none of it is automated yet.
+
+**Highest-value first automation — matches finding #1 above:** the F-001 append_system
+regression. `matrix.md` explicitly flags it: *"When F-001 is fixed, E2/E3 flip to pass and
+this becomes the regression test."* The team has already manually re-verified this exact
+scenario three times across QA passes (2026-06-20 fail → 2026-06-25 confirmed fixed →
+2026-06-25 second pass confirmed again) purely because no automated test exists to pin it.
+That repeated manual cost, paid three times already, is the clearest signal of where a replay
+test pays for itself immediately — and the request/result pairs are already captured
+(`qa/runs/E2_2026-06-25__INV_append_system_pi_core.json` and siblings).
+
+**Second-highest value:** the "Credential-isolation sub-scenarios" in `matrix.md` (provider-key
+leak between runs — a security property, currently checked manually via a `leak_probe` code
+tool). The matrix document itself notes these will only start meaningfully passing once the
+`provider-model-auth` redesign lands — which is exactly when an automated version should exist,
+so that redesign can prove itself continuously rather than via one more manual QA pass.
+
+Both are TS-runner-observable without a live LLM if captured as recorded ACP transcripts
+feeding `runSandboxAgent` directly (per finding #1): the actual assertion in both cases is
+structural (did the built prompt text carry `append_system`; is a given provider env var
+absent from the daemon's env), not model prose, which is exactly the kind of assertion the
+`agent-replay-test` skill's own guidance recommends ("assert the structural facts a recorded
+run proves ... not assistant prose").
+
+## Top 10 (ranked, with the single highest-value item first)
+
+1. **[blocker/short] Convert the F-001 append_system QA-matrix cell (already captured,
+   already re-verified 3x manually) into a TS-side recorded-transcript replay test through the
+   real `runSandboxAgent`.** This is the single highest-value missing test to add before
+   launch — it eliminates the exact repeated-manual-verification cost the team has already
+   paid three times, and it exercises the real orchestration path finding #1/#8 point out is
+   otherwise only unit-tested against hand-built fakes.
+2. [high/short] Unit-test `tool-mcp-http.ts`'s batch/abort/pause/malformed-body paths directly
+   — it's Claude's only tool delivery channel and the untested lines are all real failure
+   modes, not dead code.
+3. [high/short] Unit-test `otel.ts`'s attribute-mapping functions (`emitMessages`,
+   `applyAssistant`, tool-call/result rendering, usage/cache/cost) against a fake `Span` —
+   this class of bug has already bitten the project (F-029/F-030, the duration-scalar
+   incident) and is cheap to test directly.
+4. [high/short] Unit-test `daemon.ts`'s `resolveDaemonBinary()` fallback chain (env override /
+   platform package / pnpm-store scan / not-found) via a mocked `fs` — currently 0% covered,
+   and a regression here fails every run in an affected environment.
+5. [medium/short] Unit-test `sessions/interactions.ts`'s `buildWorkflowReferences`,
+   `resolveInteraction`, `cancelStaleInteractions` — all 0%, all fire-and-forget so bugs are
+   silent, all following an already-established fetch-mock pattern.
+6. [medium/short] Unit-test `sessions/auth.ts`'s `refreshCredential` (0% covered) — same
+   fetch-mock pattern as neighboring session modules.
+7. [medium/short] Unit-test `tools/callback.ts`'s `callAgentaTool` timeout/response-parse
+   branches (7.4% covered) — the one shared `/tools/call` transport for every harness.
+8. [medium/short] Extract `tests/utils/` helpers for the duplicated `listen(run)` server
+   bootstrap (3 copies) and the `mkdtempSync` temp-dir pattern (14+ copies).
+9. [medium/medium] Add a concurrent-`/run` test plus a test-only seam for
+   `destroyInFlightSandboxes` so its timeout-race/error-swallow logic gets direct coverage.
+10. [low/medium] Replace real-timer waits with `vi.useFakeTimers()` in retry/backoff and
+    permission-poll tests; wire `test:coverage` into CI with thresholds on the
+    credential/env-handling modules.

--- a/docs/design/agent-workflows/scratch/runner-review-2026-07-05/findings/tools-permissions-security.md
+++ b/docs/design/agent-workflows/scratch/runner-review-2026-07-05/findings/tools-permissions-security.md
@@ -1,0 +1,256 @@
+# Runner tools, permissions & security — deep review (2026-07-05)
+
+Scope: `services/runner/src/tools/*`, `permission-plan.ts`, `extensions/agenta.ts`,
+`sessions/auth.ts`, secret propagation, `engines/sandbox_agent*`, and the MCP-disabled path.
+First-party pre-launch review. READ-ONLY — no source changed.
+
+Deployed topologies considered:
+- **Dockerized sidecar in Compose (EE/OSS)** — one long-lived runner process; `local` sandbox
+  runs the harness as a child process **on the runner host, same uid**; `daytona` sandbox runs
+  the harness in an isolated cloud VM.
+- **Daytona** — the actual isolation boundary. `local` is NOT an isolation boundary.
+
+---
+
+## Verified map: tool execution + permission flow
+
+**Where the /run request originates.** Python agent service (`services/oss/src/agent/`) resolves
+tools, secrets, trace, permissions and POSTs the wire request to the runner (`server.ts` `/run` /
+`/stream`). The runner *runs*; it does not decide *what* to run.
+
+**Three tool executor kinds** (`ResolvedToolSpec.kind`): `code` (disabled — throws), `client`
+(browser-fulfilled, paused across a turn), `callback`/default (POST back to Agenta `/tools/call`,
+or a `call` direct-call descriptor for reference/platform tools).
+
+**Three delivery channels, one dispatch.**
+- **Pi** loads the bundled extension (`extensions/agenta.ts`), which `registerTool`s each public
+  spec; `execute` → `runResolvedTool` (`dispatch.ts`) → file relay (`relay.ts`) → runner memory →
+  `/tools/call` or a direct call. Private spec/`callRef`/scoped env/callback auth NEVER leave the
+  runner; only `{name, description, inputSchema}` cross to the harness.
+- **Claude (local)** takes tools over an **internal loopback HTTP MCP server**
+  (`tool-mcp-http.ts`, bound `127.0.0.1`, ephemeral port, no auth), advertised as a
+  `type:"http"` MCP server. `tools/call` → `runResolvedTool` → same relay/dispatch.
+- **Daytona** — internal MCP is skipped (loopback unreachable from the VM); Pi uses the sandbox
+  **file relay** (`sandboxRelayHost` = remote `ls`/read/write). Non-Pi + Daytona + tools is
+  **refused** up front (`REMOTE_TOOLS_UNSUPPORTED_MESSAGE`).
+
+**Permission decision points (four, all keyed off `permission-plan.ts` `decide`):**
+1. Python SDK `claude_settings.py` pre-answers Claude gates (out of scope here).
+2. **ACP responder** (`acp-interactions.ts`) — Claude raises gates over ACP; runner answers or
+   pauses. `enforce:false` for the relay on Claude (harness gates first).
+3. **Relay enforcement** (`relay.ts`) — the ONLY gate for Pi (`enforce:true`). Also the Pi
+   builtin gate via `handlePermissionRelayRequest` (protocol-versioned, unknown builtin → deny).
+4. **Client-tool ladder** (`responder.ts`) across pause/resume.
+
+**Defaults.** No `permissions` block → `default:"allow_reads"` (reads allow, writes → ask →
+pendingApproval). Unparseable policy → `ask`. `SANDBOX_AGENT_DENY_PERMISSIONS=true` → deny-all
+kill switch. A tool with no record and no readOnly hint is treated as a **write → ask** (fails
+safe). `specPermission` (author-set) short-circuits everything.
+
+---
+
+## Strengths — keep this
+
+- **`code` execution is genuinely sealed.** `runCodeTool` throws unconditionally; `run-plan.ts`
+  `hasCodeTool` refuses the run up front (avoids laundering a per-call throw into an `ok:true`
+  reply). Defense-in-depth at every delivery path.
+- **stdio MCP is sealed on three sides.** `run-plan.ts` `hasStdioMcpServer` refusal +
+  `toAcpMcpServers` throw + `mcp-server.ts` refusing stub. No route reopens the runner-host child
+  process. Internal channel restored as loopback HTTP (no child process) — correctly kept
+  independent of the user-MCP gate.
+- **`directCallUrl` SSRF guard is well built** (`direct.ts`): method allowlist, single-absolute-
+  path check, `..`/backslash/CRLF rejection, origin lock to the run's own callback origin, mount
+  confinement, `redirect:"manual"` (no SSRF-via-redirect), scalar-only path params, error detail
+  kept server-side. Prototype-pollution guards (`deepSet`/`deepMerge`/`resolveCtxToken` reject
+  `__proto__`/`constructor`/`prototype`, own-keys only).
+- **Clear-then-apply secret discipline** (`daemon.ts` `KNOWN_PROVIDER_ENV_VARS` + managed run
+  clears all provider env, applies only resolved `plan.secrets`) — an inherited key for another
+  provider cannot leak into a managed run. Superset clear list covers AWS/GCP/Azure groups.
+- **Secrets are not logged.** Log lines print key **names** only (`secretKeys=[...]`,
+  `auth=yes/no`); debug tool-body logging is env-gated (`AGENTA_RUNNER_DEBUG_TOOLS`). Mount creds
+  ride env, never argv (no process-table leak). Direct-call errors keep URL/body server-side.
+- **User HTTP MCP SSRF guard** (`mcp.ts` `validateUserMcpUrl`): https-only, blocks
+  loopback/link-local/`169.254.169.254`/private literals; capability flag-gated off by default.
+- **Fail-loud not-implemented gates** for local `network`, any `filesystem`, remote non-Pi tools.
+- **Permission engine is heavily unit-tested** (`permission-plan.test.ts` truth table,
+  `permission-parity.test.ts` ≥36 cases, protocol-version + unknown-builtin fail-closed).
+- **Body size bound** (`MAX_BODY_BYTES` 1 MB) on the internal MCP server; constant-time `/run`
+  token compare; ReDoS-safe bearer parse; loopback default bind.
+
+---
+
+## Findings
+
+### F1 — Local sandbox is not a tenant boundary: cross-run secret theft via `/proc` — **HIGH** (local topology)
+`engines/sandbox_agent.ts:370-395`, `daemon.ts:132-162`, `provider.ts:127-129`
+On the `local` sandbox the harness (LLM-steered, prompt-injectable) runs as a **child process on
+the runner host under the same uid** as every other concurrent run's daemon. Provider keys and the
+caller's OTLP bearer live in each daemon's process env (see F2). A prompt-injected agent in run A
+with any shell/read primitive can enumerate `/proc/<pid>/environ` of run B's daemon and exfiltrate
+run B's provider key + bearer token. Filesystem IPC compounds it: relay dirs live in world-
+traversable `os.tmpdir()/agenta/relay/<basename(cwd)>` and the internal MCP server is unauthenticated
+loopback (F3) — both reachable across runs on the shared host.
+- **Scenario:** two tenants' runs land on the same Compose sidecar with `sandbox:"local"`. Tenant A's
+  prompt injection reads `/proc/*/environ`, harvests Tenant B's `OPENAI_API_KEY` and Agenta bearer.
+- **Recommendation:** treat `local` as **single-tenant / trusted-only**. For multi-tenant cloud,
+  force `sandbox:"daytona"` at the Python service and reject `sandbox:"local"` requests there;
+  document `local` as a dev/single-tenant mode in the deployment proposal. Longer term: per-run uid
+  or namespace isolation if `local` must ever be multi-tenant. **Horizon: short** (config/policy),
+  **long** (isolation).
+
+### F2 — Caller's Agenta bearer token is placed in the agent-readable environment — **HIGH**
+`pi-assets.ts:50-51` (`OTEL_EXPORTER_OTLP_HEADERS=Authorization=<bearer>`), spread into the daemon
+env (`sandbox_agent.ts:395`) and into the Daytona sandbox env (`daytona.ts:31-46` `daytonaEnvVars`
+spreads `piExtEnv`).
+`trace.authorization` is the caller's **reusable user bearer token** (per the sidecar-trust doc).
+It is injected as an env var the harness process can read. On **Daytona** it crosses into the
+sandbox env, so a prompt-injected agent runs `env | grep -i authorization`, gets the token, and
+(with default `network:on`) POSTs it anywhere — full user impersonation against the platform until
+expiry. On **local** the same token is in the host daemon env (F1).
+- **Recommendation:** do NOT hand the trace-export bearer to the harness environment. Options:
+  export spans from the **runner** (which already holds the credential) rather than from inside Pi;
+  or scope/shorten the export token to trace-ingest-only (the deferred "short-lived, audience-scoped
+  token" item). At minimum, when Daytona `network` is unrestricted, treat the in-sandbox bearer as
+  exposed. **Horizon: short** (stop injecting on Daytona), **medium** (runner-side export / scoped token).
+
+### F3 — Internal tool MCP server is unauthenticated; cross-run reachable on the shared local host — **HIGH** (local topology)
+`tool-mcp-http.ts:49-52, 271-419`, `mcp-bridge.ts:118-131` (`headers: []`)
+The internal channel is bound to `127.0.0.1` on an ephemeral port with **no auth** ("carries no
+credential; loopback only"). That reasoning holds for network isolation but NOT for a **shared
+host**: on `local`, run A's prompt-injected agent shares the host loopback, can scan `127.0.0.1`
+ports, find run B's `/mcp`, and call `tools/call` for run B's tools. Execution relays server-side
+using **run B's** callback authorization held in run B's runner memory — so A drives B's
+gateway/reference tools (and B's connection auth) without ever seeing the credential.
+- **Scenario:** cross-tenant tool invocation / data exfiltration through another run's gateway
+  connection on a shared local sidecar.
+- **Recommendation:** add a per-run bearer to the internal channel even on loopback (mint a random
+  token per server, advertise it in the ACP `headers`, require it in `tools/call`); the harness
+  already carries MCP headers, so this is cheap. Independently, ties to F1 (local not multi-tenant).
+  **Horizon: short.**
+
+### F4 — Harness-side permission enforcement shares the trust domain it gates (Pi builtins) — **MEDIUM** (HIGH if local + any write primitive)
+`extensions/agenta.ts:159-201` (the `tool_call` hook), `relay.ts` file IPC, `dispatch.ts`
+`relayPermissionCheck`
+Pi builtin gating is enforced by the extension **inside the Pi process the model steers**, over a
+filesystem relay (`<id>.req.json` → poll `<id>.res.json`). The relay dir is writable by the same
+process the agent controls. A prompt-injected agent that obtains ONE filesystem-write primitive can
+pre-write a forged `<id>.res.json` with `verdict:"allow"` (or race the runner) to self-authorize
+its own subsequent `bash`/`write`/`edit` builtin calls — defeating the gate. The gate is a
+boundary against a well-behaved harness, not against a compromised one in the same process. On
+**Daytona** the blast radius is contained to the sandbox (forging only harms that sandbox, which is
+already isolated). On **local** it is a host-level bypass (leads to F1).
+- **Recommendation:** document explicitly that Pi builtin gating is advisory within the sandbox and
+  the real boundary is the sandbox (Daytona). Consider making relay files runner-owned/unwritable by
+  the harness where the FS allows, or move builtin enforcement out of the model's process. Do not
+  rely on builtin gating for host safety on `local`. **Horizon: medium** (structural).
+
+### F5 — `permissions.default:"allow"` disables all Pi builtin gating (unconfined `bash` on the host) — **MEDIUM** (local) / low (daytona)
+`run-plan.ts:193-220` `computeBuiltinGatingActive` (returns false when default is `allow`, grants
+default, no builtin rules), `extensions/agenta.ts:291-301`
+With `default:"allow"` and default grants, **no gating hook is registered** and every builtin
+(`bash`, `write`, `edit`) runs with no confirmation. On `local` that is unconfined shell execution
+on the runner host, steered by untrusted model output. This is "working as designed" (allow means
+allow) but the blast radius on `local` is the whole host.
+- **Recommendation:** ensure the Python service never sends `default:"allow"` for a `local` run in a
+  multi-tenant context; or refuse `allow` + `local`. Note in docs that `allow` presumes Daytona.
+  **Horizon: short** (policy).
+
+### F6 — Relay directory is world-traversable and cross-run readable/forgeable on `local` — **MEDIUM** (local)
+`relay.ts:165-177` `localRelayHost`, `run-plan.ts:384-391` (`os.tmpdir()/agenta/relay/<basename(cwd)>`),
+`workspace.ts:95` (`mkdirSync` default mode)
+Relay req/res files carry only public metadata (no secrets — good), but on the shared host another
+run's agent can read run B's tool arguments/results and forge B's responses/permission verdicts
+(the write side of F3/F4). `basename(cwd)` is `mkdtemp`-random (unpredictable — mitigates blind
+targeting) but enumerable by listing the parent dir.
+- **Recommendation:** create the relay root mode `0700`, per-run subdir owned by the run; or a
+  per-run random dir not under a shared predictable parent. **Horizon: short.**
+
+### F7 — Gateway `/tools/call` callback endpoint is not origin-locked (unlike direct calls) — **LOW/MEDIUM**
+`callback.ts:31-64`, `relay.ts:296-303`
+`callAgentaTool` POSTs to `request.toolCallback.endpoint` with `toolCallback.authorization`
+verbatim — no origin/host validation (contrast the strong `directCallUrl` guard). The endpoint is
+**service-supplied** (config trust), so this is safe under the current trust model, but if the
+`/run` edge is ever reachable by an attacker (F8) a forged request could point the callback at an
+attacker host — though it would only leak the attacker's own supplied token. Note the asymmetry: the
+direct-call path is hardened, the gateway path relies entirely on caller trust.
+- **Recommendation:** apply the same origin allowlist / scheme check to the gateway endpoint as a
+  defense-in-depth; validate it against a configured Agenta origin. **Horizon: medium.**
+
+### F8 — `/run` transport is unauthenticated by default; carries plaintext secrets + two bearer tokens — **MEDIUM** (accepted risk, documented)
+`server.ts:41-90`
+`AGENTA_RUNNER_TOKEN` is **off by default**; with it unset any client that can reach the port can
+submit arbitrary runs (prompt injection, tool abuse, resource exhaustion) against configured creds,
+and the body (provider keys + `trace.authorization` + `toolCallback.authorization`) is plaintext
+HTTP. This is the explicitly-accepted "trusted network only" model (Part 1 of the sidecar-trust
+doc), with loopback bind as the floor. Real risk only if the sidecar port is exposed or a co-tenant
+lands on the trusted network.
+- **Recommendation:** for the launch, **turn `AGENTA_RUNNER_TOKEN` ON** in EE/OSS Compose defaults
+  (defense-in-depth is free once wired), verify the port is never published, and put the deferred
+  TLS/mTLS + scoped-token items on the near-term hardening backlog before any cross-host topology.
+  **Horizon: short** (enable token), **medium** (TLS/scoped tokens).
+
+### F9 — Provider keys are, by design, readable by the LLM-steered harness — **MEDIUM** (structural, note)
+`daytona.ts:31-46` (secrets → sandbox env), `sandbox_agent.ts:373` (secrets → local daemon env)
+The harness must authenticate to the model provider, so resolved vault provider keys are placed in
+the agent's environment (sandbox env on Daytona, daemon env on local). A prompt-injected agent can
+read and exfiltrate the tenant's Agenta-managed shared provider key (with default open egress). This
+is inherent to "the harness calls the model directly," but it means an Agenta-managed key is exposed
+to untrusted model-steered code on every run.
+- **Recommendation:** prefer a **proxy/gateway** for model calls (key stays server-side, harness
+  talks to an Agenta-fronted endpoint) for managed keys; or restrict egress (Daytona `network`
+  allowlist to the provider only) so a stolen key can't be exfiltrated. Document that self-managed
+  keys are exposed to the agent. **Horizon: medium/long.**
+
+### F10 — `credentialMode` fallback can upload the operator's own Pi/Claude login into a tenant run — **LOW/MEDIUM**
+`run-plan.ts:475-481` `shouldUploadOwnLogin`, `daytona.ts:77-94` `uploadPiAuthToSandbox`
+For an un-migrated caller (no `credentialMode`) with no api key, the runner uploads the **host's own**
+`~/.pi/agent/auth.json` (the operator's OAuth login) into the run/sandbox. In a shared deployment
+that mixes the operator's subscription login with tenant runs, a tenant's agent could end up
+authenticated as (and could read) the operator's login inside the sandbox.
+- **Recommendation:** require an explicit `credentialMode` in production; never fall back to a
+  host login for a multi-tenant run. Gate `uploadPiAuthToSandbox` behind a "self-managed dev" flag.
+  **Horizon: short** (require credentialMode in prod).
+
+### F11 — Content capture puts prompts/args/results into trace spans — **LOW** (note)
+`tracing/otel.ts` `setInputs`/`emitMessages`/`applyAssistant` (gated on `captureContent`, default on)
+Tool arguments and results (which may contain data the tool fetched under a tenant credential) are
+written to span attributes and exported. This is a product feature (observability), not a bug, but
+worth stating: trace storage inherits whatever sensitivity the tool I/O carries. `captureContent`
+can be disabled per run. No provider secrets are captured (only names).
+- **Recommendation:** document the data-sensitivity of captured content; ensure trace export honors
+  tenant scoping. **Horizon: medium** (doc/policy).
+
+### F12 — `client`-tool advertisement vs pause path relies on the model behaving — **LOW**
+`tool-mcp-http.ts:126-204`, `relay.ts:213-237`
+Client tools are advertised so the model can call them; the call is paused/relayed. The abort/pause
+plumbing is careful (the `MCP_PAUSED` sentinel, in-flight socket destroy). One noted self-documented
+gap: the engine abort suppresses the response but does **not** cancel an in-flight `runResolvedTool`
+dispatch (comment at `tool-mcp-http.ts:68-73`) — a paused call's server-side execution still
+completes (its result is discarded). Low severity (execution is idempotent-ish and server-side), but
+a slow tool keeps running after pause.
+- **Recommendation:** thread the abort signal into `runResolvedTool` dispatch (already a noted
+  follow-up). **Horizon: medium.**
+
+---
+
+## Top-10 priority list
+
+| # | Finding | Sev | Horizon |
+|---|---------|-----|---------|
+| 1 | F1 — local sandbox = shared host/uid; cross-run secret theft via `/proc` | HIGH | short (policy) / long (isolation) |
+| 2 | F2 — caller bearer token injected into agent-readable env (esp. Daytona) | HIGH | short / medium |
+| 3 | F3 — internal tool MCP server unauthenticated, cross-run reachable on local | HIGH | short |
+| 4 | F8 — enable `AGENTA_RUNNER_TOKEN` by default; port never published | MEDIUM | short |
+| 5 | F5 — `default:"allow"` disables builtin gating → unconfined host bash on local | MEDIUM | short (policy) |
+| 6 | F10 — require explicit `credentialMode`; no host-login fallback in prod | MED/LOW | short |
+| 7 | F4 — Pi builtin gating shares the model's process (advisory, not a boundary) | MEDIUM | medium |
+| 8 | F6 — relay dir world-traversable/forgeable on local (mode 0700, per-run) | MEDIUM | short |
+| 9 | F9 — managed provider keys exposed to LLM-steered harness (proxy / egress-limit) | MEDIUM | medium/long |
+| 10 | F7 — origin-lock the gateway `/tools/call` endpoint like direct calls | LOW/MED | medium |
+
+**One-line launch gate:** the runner's isolation story is Daytona; `local` is a single-tenant/dev
+boundary, not a tenant boundary. Before multi-tenant cloud launch, (a) force Daytona for tenant
+runs, (b) stop handing the caller bearer + provider keys to agent-readable env where avoidable, and
+(c) authenticate the internal MCP channel + `/run`. Everything Daytona-isolated + single-tenant-local
+is in good shape; the sharp edges are all on the shared-host `local` topology and the two bearer
+tokens that ride into the agent's environment.

--- a/docs/design/agent-workflows/scratch/runner-review-2026-07-05/findings/tracing-otel.md
+++ b/docs/design/agent-workflows/scratch/runner-review-2026-07-05/findings/tracing-otel.md
@@ -1,0 +1,451 @@
+# Tracing review: `services/runner/src/tracing/otel.ts`
+
+Scope: `src/tracing/otel.ts` (1,315 lines), its two call sites (`src/engines/sandbox_agent.ts`,
+`src/extensions/agenta.ts`), and its tests (`tests/unit/otel-skills-error.test.ts`,
+`tests/unit/stream-events.test.ts`, `tests/unit/startup-banner.test.ts`). Cross-checked against
+Agenta's OTel ingest conventions in `api/oss/src/apis/fastapi/otlp/extractors/adapters/*.py` and
+`api/oss/src/apis/fastapi/otlp/opentelemetry/semconv.py`. Read-only review; no source changed.
+
+## The event -> span pipeline, as verified
+
+Two independent tracer factories live in the same file and build the SAME conceptual span tree
+(`invoke_agent` AGENT -> `turn N` CHAIN -> `chat <model>` LLM / `execute_tool <name>` TOOL), from
+two different event sources:
+
+- **`createAgentaOtel`** (lines 408-639) — a Pi extension factory. Pi runs in-process (local
+  runs only) and calls back via `pi.on(event, handler)` for real lifecycle events
+  (`before_agent_start`, `agent_start`, `context`, `turn_start`, `before_provider_request`,
+  `message_end`, `tool_execution_start/end`, `turn_end`, `agent_end`). One `turn`/`chat` span
+  pair is opened per actual Pi-internal turn, so a multi-round tool-calling loop shows N chat
+  spans with per-call usage.
+- **`createSandboxAgentOtel`** (lines 872-1315) — used by `engines/sandbox_agent.ts` for every
+  harness driven through `sandbox-agent`/ACP (Claude always; Pi too when on Daytona or when
+  `emitSpans` forces span-less mode false). Fed by `handleUpdate(update)` on each ACP
+  `session/update` (`agent_message_chunk`, `agent_thought_chunk`, `tool_call`,
+  `tool_call_update`, `usage_update`). Opens exactly **one** `turn 0`/`chat` pair for the whole
+  run in `start()`, and one `execute_tool` span per ACP tool-call id.
+
+Both factories share: `ensureProvider()` (one process-wide `NodeTracerProvider` +
+`TraceBatchProcessor`), the `traceTargets`/`exporterCache` maps, `flushTrace(traceId)`, and the
+`parentContext(traceparent)` W3C-context bridge. `TraceBatchProcessor` buffers a trace's spans by
+`traceId` and exports in one OTLP batch either when the local root span ends or when the caller
+calls `flushTrace` explicitly (the cross-boundary case, since `invoke_agent`'s parent is remote
+and never ends in this process). `runSandboxAgent` (`engines/sandbox_agent.ts:685-939`) always
+calls `run.finish()` then `await run.flush()` before returning, on both the success and
+`catch` paths, so under normal operation a run's spans do export before the process/response
+returns.
+
+Verified against the Python ingest side: `ag.meta.*` and `ag.exception.*` are genuinely
+recognized top-level buckets (`canonical_attributes.py`), so the code comments about avoiding
+`ag.agent.*`/`ag.error.*` relocation to `ag.unsupported.*` are correct, not superstition. The
+dual "current + legacy" `gen_ai.usage.*` emission (lines 376-386) is a deliberate, justified
+hedge against exactly the kind of adapter-mapping drift this review found elsewhere (see #1).
+
+## Strengths — keep this
+
+- The defensive design principle "tracing must never break the run" is explicit in comments and
+  mostly honored: `record()`'s sink call is try/caught, `recordError` is fully try/caught, and
+  the call site wraps `flush()` in `.catch(() => {})`.
+- `orderParentFirst` (189-216) is a correct, well-reasoned preorder-DFS with a documented
+  same-millisecond tie-break rationale and a defensive "never drop an unreached span" fallback.
+- The W3C traceparent parsing/bridging (`parentContext`, 219-235) is spec-correct (`00-<trace>-<span>-<flags>`,
+  sampled-bit honored, remote context).
+- The streaming startup-banner suppression (`splitLeadingBanner`, 761-796) correctly handles a
+  banner straddling chunk boundaries without over-buffering a genuine answer — a genuinely
+  tricky streaming problem, backed by its own dedicated test file.
+- `stream-events.test.ts` scenarios 4-6 specifically pin the real, tricky Pi wire behavior
+  (empty-args announcement refreshed by a later `tool_call_update`) rather than an idealized
+  version of the protocol — good instinct to test the actual observed quirk.
+- Per-run span state (`agentSpan`, `toolSpans`, etc.) is correctly closure-scoped so concurrent
+  runs' own span references never collide — the isolation design is right for most state; see
+  #5 for the part of the state that is NOT scoped this way.
+- The dual current/legacy `gen_ai.usage.*` emission for prompt/completion tokens shows the author
+  already anticipated adapter-mapping drift for the base token counts — just not applied
+  consistently to every metric (#1, #11).
+
+## Findings
+
+### 1. [HIGH] Cache-token attribute keys don't match either Python ingest mapping — silently dropped
+`src/tracing/otel.ts:387-393`
+
+```ts
+if (u.cacheRead)
+  span.setAttribute("gen_ai.usage.cache_read_input_tokens", u.cacheRead);
+if (u.cacheWrite)
+  span.setAttribute("gen_ai.usage.cache_creation_input_tokens", u.cacheWrite);
+```
+
+Agenta's own ingest recognizes only the **dotted** form:
+`api/oss/src/apis/fastapi/otlp/extractors/adapters/logfire_adapter.py:190,192-193`:
+`("gen_ai.usage.cache_read.input_tokens", "ag.metrics.unit.tokens.cache_read")` and
+`("gen_ai.usage.cache_creation.input_tokens", "ag.metrics.unit.tokens.cache_creation")`. The
+legacy fallback table (`semconv.py:18-19`) has no cache-token entries at all. Checked every other
+adapter (`openinference_adapter.py`, `openllmetry_adapter.py`, `default_agenta_adapter.py`,
+`vercelai_adapter.py`) — none map the underscore form either.
+
+What/why: a Claude run using Anthropic prompt caching (heavy read/write reuse, a real and
+increasingly important cost signal) will show **zero** cache tokens in Agenta despite Pi's
+extension capturing them correctly in `msg.usage.cacheRead`/`cacheWrite` — silent metric loss,
+no error anywhere, because the emitted key simply matches nothing on ingest.
+
+Recommendation: change the emitted keys to the dotted form (`cache_read.input_tokens`,
+`cache_creation.input_tokens`), or — matching the existing dual-emit pattern for
+prompt/completion tokens at 379-386 — emit both forms defensively. Add a test that pins the
+literal key string against a copy of the Python mapping (or at minimum a comment citing the file
+and line so the two sides get updated together next time either changes).
+
+Horizon: short.
+
+### 2. [HIGH] A duplicate `tool_call` notification for the same id orphans the previous span
+`src/tracing/otel.ts:1109-1141`
+
+Every `kind === "tool_call"` event unconditionally does `tracer.startSpan(...)` then
+`toolSpans.set(id, {...})`, with no check for an existing entry. If a second `tool_call` arrives
+for an id already open (a retried/duplicated ACP notification, or a future harness that resends
+the announcement), the first span reference is overwritten in the map and never `.end()`'d —
+it's silently dropped (not exported; the trace is missing that `execute_tool` span) rather than
+merely duplicated.
+
+Recommendation: in the `tool_call` branch, if `toolSpans.has(id)`, treat it like
+`tool_call_update`'s refresh path (update the input, don't create a second span) instead of
+blindly overwriting.
+
+Horizon: short.
+
+### 3. [HIGH] `tool_call_update` for an id that never had a `tool_call` silently vanishes the whole call
+`src/tracing/otel.ts:1143-1158`, `maybeCloseTool` at `1176-1199`
+
+If the initial `tool_call` notification is lost, reordered, or simply never arrives (an ACP
+transport hiccup, or events crossing on the same tick), `toolSpans.get(id)` is `undefined` in
+both the args-refresh branch and `maybeCloseTool`. Both silently no-op: no span is ever created,
+no `tool_call` event is recorded, and the later `tool_call_update` (even one carrying
+`status: "completed"`) produces no `tool_result` either. The tool call disappears from the trace
+**and** from `events()`/the live stream entirely — with no log line — even though the harness
+genuinely ran a tool. This is the concrete "event-ordering assumption" failure mode the review
+was scoped to find.
+
+Recommendation: when `tool_call_update` arrives for an unknown id, synthesize a minimal
+`tool_call` record (best-effort `name: "tool"`, `input: update.rawInput`) before applying the
+rest of the update, and log once via stderr so a swallowed sequence is at least observable in
+practice, rather than only in theory.
+
+Horizon: short.
+
+### 4. [MEDIUM] Force-closed orphan tool spans never get a matching `tool_result` event
+`src/tracing/otel.ts:1285-1286` (`finish()`) vs. the rest of the events log
+
+A tool call that starts but never completes before the stream ends (crash mid-run, or the
+prompt racing the HITL pause signal — see `engines/sandbox_agent.ts:862-871`) gets its **span**
+force-`.end()`'d in `finish()`, but no compensating `tool_result` is ever `record()`'d. A
+consumer that pairs `tool_call` -> `tool_result` (the FE, or the HITL correlation logic in
+`engines/sandbox_agent/client-tools.ts`) is left with a call that never resolves.
+
+Recommendation: in `finish()`, for every entry still in `toolSpans`, also emit
+`{ type: "tool_result", id, output: "", isError: true }` so every `tool_call` is guaranteed a
+terminal counterpart.
+
+Horizon: short/medium.
+
+### 5. [HIGH] Process-wide export state is keyed only by `traceId`; two concurrent runs sharing a traceparent corrupt each other's export
+`src/tracing/otel.ts:68-160` (module-level `traceTargets`, `exporterCache`,
+`TraceBatchProcessor.buffers`), `start()`/`agent_start` (`499-504`, `1056-1057`)
+
+The file's own docstring says "the service may drive several runs in one process" (the HTTP
+sidecar, `server.ts`). Per-run span *references* are correctly closure-scoped, but the export
+plumbing is not: `TraceBatchProcessor.buffers` is a single `Map<traceId, ReadableSpan[]>`, and
+`traceTargets` is a single `Map<traceId, ExportTarget>`. A W3C child span inherits its parent's
+trace id, so **two concurrent `/run` calls that carry the same `traceparent`** (plausible: a
+parallel sub-agent fan-out under one workflow span, or a caller-side retry of the same request)
+produce spans with the identical `traceId`. Consequences:
+
+- `traceTargets.set(traceId, ...)` from the second run silently overwrites the first run's
+  export target (endpoint/credential) — could belong to a different project.
+- Both runs' spans interleave into the **same** `buffers` entry.
+- The auto-flush heuristic (`if (!span.parentSpanId) this.flush(traceId)`) fires on whichever
+  run's `agentSpan` happens to end first, which `flush()`+**deletes** the whole buffer — sweeping
+  up the other run's already-ended spans early and leaving its still-open spans unbuffered when
+  it later tries to flush an now-empty/wrong-target entry.
+
+Recommendation: scope the buffer/target keys by `(traceId, per-run correlation id)` rather than
+`traceId` alone, or move to one real per-run exporter/processor pair instead of a shared global
+buffer. At minimum, log loudly if `traceTargets` already holds an entry for a `traceId` when a
+new run starts — that's the tripwire for this scenario actually occurring.
+
+Horizon: medium (structural; not yet observed in practice, but plausible given the file's own
+stated multi-run-per-process design, and worth a guard before it ships wider).
+
+### 6. [HIGH] OTLP export failures are silently swallowed — never logged, never surfaced
+`src/tracing/otel.ts:136-145` (`TraceBatchProcessor.flush`)
+
+```ts
+return new Promise((resolve) =>
+  getExporter(target).export(orderParentFirst(spans), () => resolve()),
+);
+```
+
+The exporter's callback receives an `ExportResult` (`{ code, error }`) and it is discarded
+entirely — success and failure resolve identically. If the OTLP endpoint is unreachable, the
+Authorization header is stale/wrong (401), or the 10s `timeoutMillis` is hit, the run still
+returns `ok: true` and the trace simply never appears in Agenta, with zero log line anywhere in
+the process. Given tracing ships to production next week, this is exactly the "does it degrade
+silently, and is the silence logged" failure mode the review was scoped to catch — today: yes,
+and no.
+
+Recommendation: check `result.code !== ExportResultCode.SUCCESS` in the callback and write one
+stderr line with the `traceId` and `result.error`; consider threading a `tracingDegraded` flag
+onto the run result so the Python side can alert distinctly from a real agent failure.
+
+Horizon: short.
+
+### 7. [MEDIUM] `exporterCache`/`traceTargets` have no eviction — unbounded growth over process lifetime
+`src/tracing/otel.ts:71`, `140-141`
+
+`exporterCache` is a `Map` keyed by `endpoint+authorization`, never pruned, each entry holding a
+live `OTLPTraceExporter` (a keep-alive HTTP client). If the Authorization value is per-request
+rather than a stable per-project key (`request.telemetry.exporters.otlp.headers.authorization`
+is read fresh off every request in `engines/sandbox_agent.ts:694`), a long-lived sidecar process
+(`server.ts`) accumulates one exporter per distinct token forever. `traceTargets` is deleted on
+flush so it is self-bounded *unless* a run never reaches flush (see #3, #5, #8), in which case
+those entries also leak permanently.
+
+Recommendation: cap `exporterCache` with a bounded LRU (closing evicted exporters via
+`.shutdown()`), and confirm with the Python/service side whether the OTLP Authorization header
+is in fact stable per project — if so, document that assumption at the cache; if not, the cache
+needs eviction regardless of the rest of this review.
+
+Horizon: medium.
+
+### 8. [MEDIUM] `finish()` is not defensively wrapped, unlike `recordError` and the call site's own pattern
+`src/tracing/otel.ts:1250-1300` (finish) vs. `1213-1248` (recordError, internally try/caught) and
+`engines/sandbox_agent.ts:945-947`
+
+```ts
+otel?.recordError(error, request.provider);
+otel?.finish();                    // not wrapped
+await otel?.flush().catch(() => {}); // wrapped
+```
+
+The stated design principle ("tracing must never break the run") is enforced for `recordError`
+(its own internal try/catch) and for `flush()` at the call site, but not for `finish()` itself.
+If `emitMessages`/`stampUsage`/`span.end()` throws for any reason (a malformed event field, an
+unexpected `null`), the exception propagates out of the `catch` block in `runSandboxAgent`,
+turning what should be a graceful `{ ok: false, error }` result into an unhandled promise
+rejection — the opposite of what the surrounding code is trying to guarantee.
+
+Recommendation: wrap the body of `finish()` in try/catch (mirroring `recordError`'s own pattern),
+or at minimum wrap the call site the same way `flush()` already is.
+
+Horizon: short.
+
+### 9. [MEDIUM] The streaming (live-sink) path likely double-emits the final `usage` event
+`src/tracing/otel.ts:921-933` (`setUsage`), `engines/sandbox_agent.ts:879-886` (`run.setUsage(usage)`
+always called before `run.finish()`, regardless of whether a live `emit` sink is wired)
+
+```ts
+function setUsage(finalUsage: AgentUsage | undefined): void {
+  if (!finalUsage) return;
+  usage = finalUsage;
+  const event: AgentEvent = { type: "usage", ...finalUsage };
+  if (!sink) {
+    const index = events.findLastIndex((e) => e.type === "usage");
+    if (index !== -1) { events[index] = event; return; }
+  }
+  record(event);
+}
+```
+
+The one-shot (no-sink) branch de-duplicates by overwriting the last "usage" entry in `events[]`.
+The streaming branch skips that guard entirely (`if (!sink)` only covers the no-sink case) and
+always calls `record(event)` — so a live consumer that already received one or more
+`usage_update`-driven "usage" events during the run gets **another** one right before `done`,
+duplicating the final total. The only existing test asserting "final usage replaces stream-only
+usage" (`stream-events.test.ts` scenario 3) exercises the **no-sink** path
+(`createSandboxAgentOtel({ ..., emitSpans: false })` with no `emit`); there is no equivalent
+assertion for the sink-present path, so this asymmetry is untested as well as (apparently) live.
+
+Recommendation: apply the same "replace, don't append" semantics regardless of whether a sink is
+wired (the dedup is over `events[]`, not the sink itself — skip re-emitting to the sink only if
+the value is unchanged, or always replace-then-flush-the-replacement). Add a streaming-path test
+mirroring scenario 3.
+
+Horizon: short (cheap fix; needs a test either way).
+
+### 10. [MEDIUM] Pi-native and ACP tracers emit structurally different span-tree granularity for the same kind of run
+`src/tracing/otel.ts:1060-1078` (`createSandboxAgentOtel.start`, one `turn 0`/`chat` pair, ever)
+vs. `513-548` (`createAgentaOtel`, a new `turn`/`chat` pair per real Pi `turn_start`/
+`before_provider_request`)
+
+`createAgentaOtel` opens a new turn/chat span pair per actual internal LLM round (so a multi-step
+tool-calling loop shows N `chat` spans with per-call usage). `createSandboxAgentOtel` opens
+**exactly one** `turn 0`/`chat` span for the entire run in `start()` and never reopens it,
+regardless of how many tool-call round trips the ACP stream reports — there is no ACP signal
+consumed to detect a new provider round, so all model interaction (however many actual LLM calls
+underlie it) collapses into one span whose usage is the run's grand total, not a per-call
+breakdown. For Claude/other non-Pi harnesses doing multi-step tool loops, this is a materially
+less informative trace than the same kind of run on Pi.
+
+Recommendation: either explicitly document this as an accepted ACP protocol limitation (today
+`session/update` gives no clean "new provider round" boundary), or investigate whether one can
+be synthesized (e.g., a new `chat` span each time `agent_message_chunk` resumes after a
+`tool_call_update: completed`, mirroring the streaming banner logic's own text/tool
+interleaving detection at `958-1021`).
+
+Horizon: long (either needs upstream ACP signal or a deliberate product decision to accept the
+gap).
+
+### 11. [MEDIUM] Agent-span/chat-span construction and usage-stamping are duplicated between the two factories, and have already drifted
+`src/tracing/otel.ts:476-505` vs `1036-1058` (agent span setup); `528-548` vs `1065-1078` (chat
+span setup); `applyAssistant` (`363-402`) vs `stampUsage` (`911-919`)
+
+Both factories independently set `openinference.span.kind`, `gen_ai.operation.name`,
+`gen_ai.agent.name`, `ag.meta.skills.*`, `session.id`/`gen_ai.conversation.id`, and call
+`setInputs(...)` for the agent span — near-identical ~30-line blocks. The chat-span setup is
+duplicated the same way. The usage-stamping logic is *also* duplicated and has already drifted:
+`applyAssistant` sets `gen_ai.response.finish_reasons`, `gen_ai.response.model`,
+`gen_ai.response.id`, and cache tokens; `stampUsage` sets none of these. Some of that gap is
+legitimate (ACP's `usage_update` genuinely carries less data than Pi's in-process message, see
+finding #16) — but because the logic is duplicated rather than shared, the gap is an accidental
+byproduct of copy-paste rather than a decision visible at either call site.
+
+Recommendation: extract shared helpers used by both factories — `startAgentSpan(tracer, parent,
+{harness, sessionId, skills, prompt, capture})`, `startChatSpan(tracer, parent, {provider,
+modelId, messages, capture})`, and a single `stampGenAiUsage(span, usage, { cache?, finishReason?
+})` — so future attribute additions/renames (including the fix for #1) happen exactly once.
+
+Horizon: medium (pairs naturally with the decomposition in #15).
+
+### 12. [LOW] Event payloads are `any`-typed throughout the state machine
+`src/tracing/otel.ts` — every `pi.on(...)` handler (`468, 472, 509, 513, 528, 550, 559, 579, 590,
+605`), `handleUpdate(update: any)` (`1081`), `messageText(msg: any)`, `applyAssistant(span, msg:
+any, ...)`, `toolResultText(result: any)`
+
+The file's entire correctness burden is "does this event shape map to the right span operation,"
+yet none of it is statically checked — a property rename upstream (the Pi SDK or the ACP client)
+silently becomes a runtime no-op (`event?.toolCallId` just reads `undefined`) instead of a
+compile error. `@earendil-works/pi-coding-agent` ships real `pi.on` event types, and ACP's
+`SessionUpdate` is a known discriminated union; most of these `any`s look avoidable.
+
+Recommendation: introduce a minimal local `AcpSessionUpdate` union covering the 4-5 kinds this
+file actually switches on, and type `handleUpdate`/`maybeCloseTool` against it; type the Pi
+`pi.on` callbacks against the SDK's own event types rather than `any`.
+
+Horizon: medium.
+
+### 13. [LOW] Attribute-key strings are duplicated as literals across the TS/Python boundary with no shared source of truth
+`src/tracing/otel.ts` (~40 literal keys: `gen_ai.usage.input_tokens`, `ag.meta.skills.loaded`,
+`openinference.span.kind`, etc.) vs. Python's `logfire_adapter.py` / `semconv.py` /
+`openinference_adapter.py`, which independently hardcode the same strings in mapping tables —
+verified in this review to already disagree once (#1).
+
+Recommendation: at minimum, centralize the TS-side literals into a local `tracing/attrs.ts`
+constants module (cheap, in-repo, no cross-language tooling needed) so a future rename is a
+TypeScript compile error on this side. Longer-term, flag to whoever owns the ingest adapters that
+a generated/shared attribute-key manifest — checked by a contract test the way `protocol.ts` /
+`wire.py` are pinned by golden fixtures (per this repo's own `services/runner/CLAUDE.md`) — would
+have caught #1 before it shipped.
+
+Horizon: medium/long.
+
+### 14. [LOW] Pi startup-banner text-scrubbing is a distinct concern living inside the OTel file
+`src/tracing/otel.ts:696-796` (`isBannerLine`, `stripStartupBanner`, `splitLeadingBanner`)
+
+~100 lines of pi-acp startup-banner regex-scrubbing (a harness-output-cleanup concern with
+nothing to do with span/attribute mapping) live in the middle of the tracing state machine,
+exported purely so `tests/unit/startup-banner.test.ts` can test it as its own thing — which it
+already effectively is. This is direct evidence for the split proposed in #15: the seam is
+already proven by the existing separate test file.
+
+Recommendation: move to its own module (e.g. `tracing/pi-startup-banner.ts`), imported by the ACP
+tracer. Mechanical, low-risk.
+
+Horizon: short.
+
+### 15. Decomposition proposal for the 1,315-line file
+
+Cut along the seams the tests already imply, not along arbitrary line counts:
+
+- **`tracing/exporter.ts`** (~230 lines) — `TraceBatchProcessor`, `ensureProvider`/`provider`/
+  `processor`, `exporterCache`, `traceTargets`, `getExporter`, `defaultTarget`, `flushTrace`,
+  `orderParentFirst`, `parentContext`, `targetKey`. Pure lifecycle/resource-management code.
+  **Currently has zero direct test coverage** — every existing test fakes `createOtel`
+  (`sandbox-agent-orchestration.test.ts`) or spies the OTel tracer, never a real exporter/
+  processor. Splitting it out makes that gap visible and easy to close (a fake `SpanExporter` +
+  a couple of `TraceBatchProcessor` unit tests would directly cover #5, #6, #7).
+- **`tracing/attributes.ts`** (~150 lines) — `setOutput`, `setInputs`, `emitMessages`,
+  `applyAssistant`, `stampUsage` (merged per #11), `messageText`, `toolResultText`,
+  `lastAssistantText`, `oiRole`, `splitModel`. Pure functions, trivially unit-testable
+  independent of the OTel API.
+- **`tracing/pi-startup-banner.ts`** (~90 lines) — `isBannerLine`/`stripStartupBanner`/
+  `splitLeadingBanner`; already has its own test file, just needs its own module.
+- **`tracing/pi-extension-tracer.ts`** (~230 lines) — `createAgentaOtel` + `RunConfig`.
+- **`tracing/acp-tracer.ts`** (~350 lines) — `createSandboxAgentOtel` + `acpBlockText`/
+  `hasToolArgs`/`acpToolContentText`.
+- `tracing/otel.ts` becomes a thin barrel (or is deleted and the two call sites
+  `extensions/agenta.ts` / `engines/sandbox_agent.ts` import directly from the new paths).
+
+Judged against the existing tests: `stream-events.test.ts` only needs `acp-tracer.ts` +
+`attributes.ts`; `otel-skills-error.test.ts` needs `acp-tracer.ts` + `pi-extension-tracer.ts` +
+`attributes.ts`; `startup-banner.test.ts` only needs the banner module. No existing test
+currently exercises `exporter.ts` — closing that gap should happen as part of the split, not
+after it.
+
+Horizon: medium (do alongside the correctness fixes above, before the file grows further).
+
+### 16. [LOW] ACP chat spans never get `gen_ai.response.finish_reasons`/`response.model`/`response.id`
+`stampUsage` (`911-919`) vs `applyAssistant` (`364-372`)
+
+ACP's `usage_update` genuinely carries no finish-reason/response-id, so `stampUsage` can't set
+them from the stream directly — but the run's own `stopReason` **is** known by the time
+`finish()` runs (`engines/sandbox_agent.ts` resolves it from the raced prompt result) and is
+never threaded into `finish()` to stamp on `llmSpan`; it only reaches the HTTP result, not the
+trace.
+
+Recommendation: thread `stopReason` into `finish(stopReason?)` and set
+`gen_ai.response.finish_reasons` on `llmSpan` before ending it, mirroring what the Pi path already
+does per-turn.
+
+Horizon: medium.
+
+### 17. [LOW] Failed tool-call spans get bare ERROR status, no exception/message, unlike run-level errors
+`maybeCloseTool` (`1186-1191`) vs `recordError` (`1213-1248`)
+
+A failed tool call sets `SpanStatusCode.ERROR` and whatever raw output text happened to come
+back as `output.value` — no `recordException`, no explicit error-message attribute — much
+thinner diagnostics than the run-level error handling built for F-030 (message + provider +
+`recordException` + status).
+
+Recommendation: on `status === "failed"`, also call
+`entry.span.recordException({ name: "ToolCallError", message: out || "tool call failed" })` for
+parity and debuggability.
+
+Horizon: low/medium.
+
+## Top 10
+
+1. **[HIGH, short]** Cache-token attribute keys (`cache_read_input_tokens`/
+   `cache_creation_input_tokens`) don't match either Python ingest mapping table — prompt-cache
+   token/cost data is silently dropped end to end. (#1)
+2. **[HIGH, short]** `tool_call_update` for an id whose `tool_call` was lost/reordered silently
+   erases the whole tool call from the trace and the event log — no span, no events, no log.
+   (#3)
+3. **[HIGH, short]** OTLP export failures are never checked or logged — a dead endpoint or bad
+   credential means a trace just never shows up, with zero visibility anywhere. (#6)
+4. **[HIGH, medium]** `TraceBatchProcessor`/`traceTargets`/`exporterCache` are process-wide state
+   keyed only by `traceId`; two concurrent runs sharing a traceparent (plausible per the file's
+   own "several runs in one process" design) can corrupt each other's export. (#5)
+5. **[HIGH, short]** A duplicate `tool_call` notification for the same id silently orphans the
+   previous span (never `.end()`'d, never exported). (#2)
+6. **[MEDIUM, short]** `finish()` isn't defensively wrapped like `recordError`/`flush()` are — an
+   exception inside it can turn a graceful `{ok:false}` result into an unhandled rejection. (#8)
+7. **[MEDIUM, short]** The streaming path likely double-emits the final `usage` event; only the
+   no-sink path is tested/de-duplicated. (#9)
+8. **[MEDIUM, medium]** Split the 1,315-line file along the seams the tests already prove exist
+   (exporter / attributes / banner / pi-extension-tracer / acp-tracer), and use the split to close
+   the current zero-coverage gap on the exporter/lifecycle code. (#15)
+9. **[MEDIUM, medium]** Agent-span/chat-span construction and usage-stamping are duplicated
+   between the two factories and have already drifted (finish_reasons/response.model/cache
+   tokens present on one side only, not by decision). (#11)
+10. **[MEDIUM, long]** Pi and every other harness get structurally different span-tree
+    granularity for the same kind of run (Pi: one chat span per real round; ACP: always exactly
+    one, however many rounds actually happened) — either document as an accepted ACP limitation
+    or investigate a fix. (#10)

--- a/docs/design/agent-workflows/scratch/runner-review-2026-07-05/findings/ts-idioms-quality.md
+++ b/docs/design/agent-workflows/scratch/runner-review-2026-07-05/findings/ts-idioms-quality.md
@@ -1,0 +1,533 @@
+# TS idioms & code-organization review — services/runner
+
+Reviewer scope: code-level quality and file/module organization across all of `services/runner/src/`
+(~10.6k lines, 46 files), plus `package.json` / `tsconfig.json` / `vitest.config.ts` hygiene.
+Architecture, engine correctness, security, tracing semantics, and tests are other reviewers' lanes;
+where a finding brushes those, it is framed strictly as a code-quality issue.
+
+Date: 2026-07-05. Baseline: branch `gitbutler/workspace`.
+
+---
+
+## Strengths — keep this
+
+This does not read like "a Python dev's first TypeScript". Credit where due:
+
+1. **Discriminated unions are used where they matter.** `AgentEvent` (protocol.ts:303),
+   `Verdict` (permission-plan.ts:60), `RenderHint` (protocol.ts:293), `StreamRecord`
+   (protocol.ts:520), and `BuildRunPlanResult` (run-plan.ts:129) are exactly the Lars-Grammel
+   shape: tagged unions at boundaries, exhaustively narrowable. `BuildRunPlanResult`
+   (`{ok:true,plan}|{ok:false,error}`) is a proper result type instead of exceptions-as-control-flow.
+2. **The dependency-injection seam pattern is consistent and disciplined.** `SandboxAgentDeps`
+   (sandbox_agent.ts:247), `SignMountDeps`/`MountStorageDeps` (mount.ts), `BuildRunPlanDeps`
+   (run-plan.ts:132), `createAgentServer(run)` / `runCli(raw, {run})` — every side-effecting module
+   takes `deps = {}` with production defaults. This is the "make the core a library" idea applied
+   at function granularity, and it is why the test suite runs without a live harness.
+3. **Small single-purpose modules already exist where the code was refactored recently.**
+   `pause.ts` (46 lines, one class), `spec-schema.ts` (one accessor + one walk, with a doc comment
+   explaining the exact duplication it killed), `client-tool-relay.ts` (pure types), `entry.ts`
+   (one function). The newer the file, the better the granularity — the trend line is right.
+4. **Untrusted-input paranoia in the deep utilities.** `deepSet`/`deepMerge`/`resolveCtxToken`
+   (direct.ts:52-158) reject `__proto__`/`constructor`/`prototype` and traverse own-keys only; the
+   one `hasOwnProperty` dance in the codebase (direct.ts:143,154) is *justified*, not a Python-ism.
+   `canonicalJson` (responder.ts:91) correctly rejects non-plain objects instead of collapsing them.
+5. **Node idioms done right in the entrypoints:** `timingSafeEqual` for the token check with a
+   written ReDoS analysis (server.ts:71-75), `isEntrypoint()` instead of a `require.main` hack,
+   `unhandledRejection`/`uncaughtException` handlers installed only under the entrypoint guard,
+   signal-handler idempotency (server.ts:388), `interval.unref()` so the watchdog can't hold the
+   process open.
+6. **Conditional-spread respect for optional properties** (`...(signal ? { signal } : {})`,
+   relay.ts:154 `...(value.reason === undefined ? {} : {reason})`) — the codebase already mostly
+   writes in the style `exactOptionalPropertyTypes` demands, which makes enabling it cheap.
+7. **Comment quality is exceptional.** Nearly every non-obvious decision carries the *why* and the
+   incident/finding ID (F-024, F-030, #4831…). This is a maintainability asset most codebases never have.
+8. **The wire contract is compile-time pinned** (protocol.ts + golden fixtures + a TS key guard that
+   fails `tsc` on drift). That is a real contract, not a convention.
+
+The gaps below are mostly (a) the untyped ACP/SDK seam bleeding `any` inward, (b) missing validation
+at the IO edges, (c) copy-paste helpers that have already started to diverge, and (d) a few big files
+the refactor wave hasn't reached yet.
+
+---
+
+## Offenders table — `any` / `as` casts / non-null `!` per file (top 10)
+
+Counts: explicit `: any` + `<any>` + `any[]` sites; `as` type assertions (excluding `as const`,
+import aliases); non-null `!`.
+
+| file | `any` sites | `as` casts | `!` | note |
+|---|---:|---:|---:|---|
+| tracing/otel.ts | 30 | 5 | 0 | every event/msg param is `any`; the single worst cluster |
+| engines/sandbox_agent/acp-interactions.ts | 10 | 3 | 0 | `req: any`, `toolCall: any` throughout |
+| engines/sandbox_agent/pi-assets.ts | 4 | 8 | 0 | `sandbox: any` + `(err as Error)` ×6 |
+| engines/sandbox_agent/daytona.ts | 6 | 4 | 0 | `sandbox: any`, cookie-jar fetch `input: any` |
+| engines/sandbox_agent.ts | 3 | 5 | 1* | `sandbox: any`, `session.onEvent((event: any))`, `(raced as any)?.stopReason` |
+| engines/sandbox_agent/model.ts | 4 | 3 | 0 | `session: any`, `(o: any)`, `(c: any)` |
+| engines/sandbox_agent/usage.ts | 4 | 0 | 0 | `sandbox: any`, `promptResult: any` |
+| extensions/agenta.ts | 2 | 5 | 0 | `parameters: … as any`, `registerTool({...} as any)` |
+| engines/sandbox_agent/provider.ts | 3 | 3 | 0 | `create: … as any`, `logMode as any` |
+| server.ts | 0 | 3 | 1 | `JSON.parse(raw) as AgentRunRequest`, `request.sessionId!` |
+
+Totals across src: **~68 `: any` sites, 12 `as any`, ~68 other `as` casts, 1 non-null `!`**
+(sandbox_agent.ts:870 `(raced as any)` counted under `as any`). The single `!` (server.ts:195) is
+also the riskiest one — see finding 8. For strict-mode TS written fast, one `!` in 10k lines is
+genuinely good; the `any` mass is concentrated on one seam (the sandbox-agent/ACP SDK) and is
+therefore fixable in one move (finding 2).
+
+---
+
+## Findings
+
+### 1. No validation at the IO boundaries — `JSON.parse(...) as T` everywhere (HIGH, short)
+
+The `/run` request body — the single most important input in the service, carrying secrets, tool
+specs, and permission policy — is parsed and *cast*, never validated:
+
+- server.ts:326 — `request = raw.trim() ? (JSON.parse(raw) as AgentRunRequest) : {};`
+- cli.ts:57 — same cast on stdin.
+- extensions/agenta.ts:249 — `specs = JSON.parse(raw)` into `ResolvedToolSpec[]` from an env var
+  (no shape check at all; a malformed spec array crashes `registerTool` deep inside Pi).
+- tools/relay.ts:419 — `JSON.parse(raw) as RelayRequest` (a file written by the sandbox child —
+  an *untrusted* boundary per the module's own doc comment). `parsePermissionRelayResponse` shows
+  the team knows how to hand-validate; the execute-request path just casts.
+- mount.ts:76-87 — sign response cast to an inline shape; guarded by four field checks, decent but
+  hand-rolled.
+- sessions/auth.ts:29 — `(await res.json()) as { credentials?: string }`.
+
+Downstream code compensates with defensive `?.`/`typeof` checks scattered everywhere (that is the
+Python "EAFP + isinstance sprinkles" pattern in TS clothing). One zod schema per boundary deletes
+dozens of those checks and turns garbage input into a 400 with a field path instead of a mid-run
+`TypeError`.
+
+**Fix:** add `zod` (this package is standalone; the dependency cost is contained). Define
+`agentRunRequestSchema` next to protocol.ts and derive the type (`export type AgentRunRequest =
+z.infer<...>`) so the wire contract and validator can never drift — the golden-fixture test then
+pins the schema too. Priority order: (1) `/run` body in server.ts + cli.ts, (2) relay request files,
+(3) the extension's `AGENTA_AGENT_TOOLS_PUBLIC_SPECS` env. Horizon: **short** for (1)–(2); the rest medium.
+
+### 2. The untyped SDK seam bleeds `any` through the whole engine layer (HIGH, medium)
+
+`sandbox: any` / `session: any` / `update: any` / `event: any` appear in **10 files**:
+sandbox_agent.ts:419,717; capabilities.ts:71,121; model.ts:19,46; usage.ts:50; workspace.ts:14;
+pi-assets.ts; daytona.ts:50,77; mount.ts:357 (this one, `SandboxExec`, is actually typed — the model
+to copy); acp-interactions.ts:14,51; otel.ts:839,881 (`handleUpdate(update: any)`).
+
+The `sandbox-agent` SDK presumably exports types; even if it doesn't (or they're too loose), the
+runner touches maybe a dozen members. `mount.ts:357` already shows the right pattern — a minimal
+structural interface (`SandboxExec.runProcess`). Nobody did it for the big handles.
+
+**Fix:** one `src/engines/sandbox_agent/acp-types.ts` with minimal structural interfaces:
+`SandboxHandle` (createSession, destroySandbox, dispose, getAgent, readFsFile, writeFsFile, mkdirFs,
+runProcess), `SessionHandle` (id, prompt, onEvent, setModel, getConfigOptions, onPermissionRequest,
+respondPermission), and a discriminated `AcpSessionUpdate` union
+(`agent_message_chunk | agent_thought_chunk | tool_call | tool_call_update | usage_update` — the
+five variants `handleUpdate` already branches on by string). That last union alone converts
+otel.ts's 30 `any` sites into narrowed access and would have caught bugs like reading
+`update.title || update.kind` at otel.ts:1116 on the wrong variant. Horizon: **medium** (1-2 days,
+mechanical).
+
+### 3. `exporterCache` grows unboundedly, keyed by a per-run ephemeral credential (HIGH, short)
+
+tracing/otel.ts:71-90: `exporterCache` is a module-level `Map` keyed by
+`endpoint + "\n" + authorization`. The authorization for session-owned runs is the invoke caller's
+**ephemeral ~15-minute Secret token** — a new value nearly every run. Each miss constructs a new
+`OTLPTraceExporter` (which owns an HTTP client) and caches it **forever**; `shutdown()` iterates the
+cache but is only reachable via `TraceBatchProcessor.shutdown`, which the server never calls. In the
+long-lived sidecar this is a slow memory + socket leak, and the "cache one exporter per distinct
+endpoint+auth" comment is false in practice (hit rate ≈ 0).
+
+**Fix (code-level):** don't cache on the credential — build the exporter per flush and `shutdown()`
+it after export, or cache per endpoint and pass headers per export if the exporter API allows, or
+add an LRU with eviction+shutdown. Horizon: **short**. (Flagging to the tracing reviewer as well.)
+
+### 4. Global mutable state written from request data + no config module (HIGH, medium)
+
+Two related problems:
+
+- server.ts:229-231 mutates `process.env.AGENTA_API_URL` from the *request body*
+  (`if (requestApiBase && !process.env.AGENTA_API_URL) process.env.AGENTA_API_URL = ...`). First
+  request wins for the process lifetime; a multi-project sidecar silently pins every later session's
+  API base to the first caller's. Writing process-global config from a request is the classic
+  module-global Python-ism.
+- **~45 `process.env` reads across 19 files** (extensions/agenta.ts 13, daemon.ts 9, server.ts 5,
+  provider.ts 5, …). Some are read at module load and frozen (`REPLICA_ID` alive.ts:32,
+  `RELAY_POLL_MS` relay.ts:57, `DAYTONA_PI_DIR` daytona.ts:15 — untestable without module-cache
+  tricks), some per call — no rule for which. The repo's own convention exists for the Python API
+  ("add env vars to `env.py`, never `os.getenv` directly" — root AGENTS.md); the runner has no
+  equivalent.
+
+**Fix:** `src/config.ts` exporting a typed, zod-validated `env` object (lazy getters where hot-reload
+matters), and replace the env write in server.ts with an explicit `apiBase` parameter threaded to the
+session helpers (they all already call `apiBase()` — give that function an injected override instead).
+Exception: extensions/agenta.ts legitimately reads env (it runs inside the Pi process and env *is*
+its wire) — give it its own tiny typed env reader. Horizon: **medium**.
+
+### 5. `runSandboxAgent` is a 650-line orchestration function (HIGH, medium→long)
+
+engines/sandbox_agent.ts:317-973. One function holds: mount signing, durable-cwd derivation, plan
+build, env assembly, Claude connection env, Pi asset prep, sandbox start, Daytona asset push,
+workspace prep with ENOTCONN retry, capability probe, MCP channel build, session create, model
+apply, otel wiring, pause controller, permission responder wiring, client-tool relay, tool relay,
+the prompt race, usage resolution, swallowed-error recovery, and an 8-step `finally`. It declares
+**11 mutable `let`s** and three inline closure state machines (`mountLocalDurableCwd` /
+`reSignAndRemountLocalCwd` / `remountLocalCwdAfterRuntimeEnotconn`, lines 433-491).
+
+The extraction pattern is already established (run-plan.ts, workspace.ts, client-tools.ts were
+clearly carved out of this file). Two more carves pay the most:
+
+- **`durable-cwd.ts`**: the mount/remount lifecycle (sign → derive cwd → mount → ENOTCONN
+  re-sign/remount → unmount) as an object with `ensureMounted()`, `onAcpEvent()`, `cleanup()` —
+  it is a self-contained state machine currently interleaved with everything else.
+- **`turn-wiring.ts`** (or fold into client-tools.ts): the responder/latch/pause/interaction wiring
+  block (lines 710-835), which builds seven collaborators and knots them together.
+
+Target: `runSandboxAgent` as a ~150-line phase script (plan → provision → wire → prompt → collect →
+cleanup). Horizon: **medium** for the two carves; the full phase split is **long** (post-launch).
+
+### 6. Copy-paste helpers, several already diverged (MEDIUM, short)
+
+The grep-verified inventory:
+
+| helper | copies | divergence |
+|---|---|---|
+| `runCredential(request)` | server.ts:122, sandbox_agent.ts:122 | one casts headers to `Record<string,string>`, one doesn't — same today, drift-bait |
+| `readBody(req)` | server.ts:285, tool-mcp-http.ts:246 | **already diverged**: MCP copy enforces `MAX_BODY_BYTES`, the main `/run` copy is unbounded (see 7) |
+| `isRecord` | relay.ts:338, permission-plan.ts:271 | identical |
+| `errorMessage(err)` | cli.ts:32, acp-interactions.ts:331 | one returns `stack ?? message`, the other `message` only |
+| `PAUSED` sentinel | pause.ts:7 (exported), relay.ts:130 (private duplicate) | two symbols for the same concept in one call chain |
+| `INGEST_MAX_RETRIES` / `INGEST_RETRY_BASE_MS` | persist.ts:23, interactions.ts:40 | identical constants, two owners |
+| `AbortSignal.any` feature-detect via `as any` | callback.ts:43, direct.ts:350 | identical — and unnecessary (see 11) |
+| Pi builtin tool name list | permission-plan.ts:40 (`PI_BUILTIN_TOOL_IDENTITY`, canonical), run-plan.ts:166 (derived — good), extensions/agenta.ts:58 (**hard-coded second list**) | adding a Pi builtin now requires editing two lists; the extension one silently drifts |
+| `type Log = (message: string) => void` | 9 definitions | identical |
+| `function log(msg)` with hard-coded `[prefix]` | 6 definitions + ad-hoc `process.stderr.write` | see 13 |
+| `messageText` | protocol.ts:525 (typed), otel.ts:294 (`msg: any` re-implementation) | the otel copy also handles a message object vs content — near-dup |
+
+**Fix:** a small `src/internal/` (or `src/lib/`) with `guards.ts` (`isRecord`), `errors.ts`
+(`errorMessage`), `http.ts` (`readBody(req, maxBytes)`), `logger.ts` (finding 13); export `PAUSED`
+from pause.ts into relay.ts; move the builtin list to permission-plan and have the extension import
+it (the extension is esbuild-bundled, so a src-internal import is free). Horizon: **short** — this
+is an afternoon and removes real divergence risk before launch.
+
+### 7. The main `/run` body read is unbounded while the loopback MCP body is capped (MEDIUM, short)
+
+server.ts:285-291 accumulates the request body with no size cap; tool-mcp-http.ts:52 caps its
+loopback-only endpoint at 1 MB with an explicit "cannot exhaust runner memory" comment. The
+*internet-adjacent* endpoint has the weaker guard — backwards. Direct consequence of duplicate
+`readBody` implementations (finding 6). **Fix:** one shared `readBody(req, {maxBytes})`, cap `/run`
+generously (requests carry inline skills/tools; e.g. 32 MB via env-tunable). Horizon: **short**.
+
+### 8. `request.sessionId!` asserts on a path where it is genuinely undefined (MEDIUM, short)
+
+server.ts:195: `const sessionId = request.sessionId!;` executes for **every** streaming request,
+including non-session ones where `sessionId` is `undefined`. The very next use (line 201) writes
+`sessionId ?? "-"` — dead code under the `!`, and proof the author knows it can be undefined. The
+value then flows into `runAndStream`'s session-owned block, where correctness silently depends on
+the `if (sessionOwned)` guard being the only consumer. One future edit inside that function turns
+this into `undefined` hitting `startAliveWatchdog(sessionId, ...)`.
+
+**Fix:** make `isSessionOwned` a type-carrying narrowing instead:
+`const session = request.sessionId?.trim() ? { id: request.sessionId, turnId: resolveTurnId(request) } : undefined;`
+and branch on `session`. Deletes the `!`, the `?? "-"`, and the latent trap. Horizon: **short**.
+
+### 9. Layering: a tools↔engines type cycle, and the extension's cross-process imports (MEDIUM, medium)
+
+The implicit layering is good — `protocol.ts` (wire) ← `permission-plan/responder` (domain) ←
+`tools/` + `sessions/` (adapters) ← `engines/` (orchestration) ← `server/cli` (entrypoints) — and
+imports point inward almost everywhere. Two violations:
+
+- **tools/mcp-bridge.ts:24 imports `McpServerHttp` from `engines/sandbox_agent/mcp.ts`, while
+  engines/sandbox_agent/mcp.ts:7 imports `buildToolMcpServers` from tools/mcp-bridge.ts.** A
+  tools→engines dependency (wrong direction) forming a cycle (type-only, so it runs, but `tsc`
+  layering intent is gone). `McpServerHttp` is an ACP wire shape — it belongs beside the other
+  shared types (protocol.ts or the new acp-types.ts from finding 2), which breaks the cycle and
+  fixes the direction in one move.
+- **extensions/agenta.ts imports `../tracing/otel.ts` and `../tools/dispatch.ts`** — but this file
+  is esbuild-bundled and executes inside the *Pi process*, not the runner. It therefore drags
+  runner modules (including otel.ts's module-level provider/exporter singletons and dispatch's
+  sync-fs relay client) across a process boundary. It works because those modules are ambient-free
+  enough, but nothing marks them as "must stay bundle-safe". At minimum add a header comment
+  contract to otel.ts/dispatch.ts/spec-schema.ts ("bundled into the Pi extension — no top-level
+  side effects, no Node-server-only imports"); better, move the shared parts (relay client,
+  spec-schema, the Pi tracer) into an `src/shared-with-extension/` (or `extension-runtime/`) layer
+  the bundle and the runner both import, so the boundary is visible in the tree. Horizon: **medium**.
+
+Also: sandbox_agent.ts:111-115 and relay.ts:50-53 keep "compatibility re-exports" for moved symbols;
+tests still import `buildTurnText` via the engine barrel (tests/unit/continuation.test.ts:14).
+Finish the migrations and delete the re-exports — they are how import graphs rot. **short**.
+
+### 10. File-naming convention split: `snake_case` vs `kebab-case` vs `camelCase` (MEDIUM, short)
+
+`engines/sandbox_agent.ts` + the `engines/sandbox_agent/` dir are Python-style snake_case; every
+other multiword file is kebab-case (`tool-mcp-http.ts`, `client-tool-relay.ts`, `permission-plan.ts`,
+`run-plan.ts`); `apiBase.ts` is camelCase. Inside the code, naming is clean (no snake_case
+identifiers outside deliberate wire fields like `args_into`/`session_id`, which are documented).
+**Fix:** rename `sandbox_agent` → `sandbox-agent` and `apiBase.ts` → `api-base.ts` now, while the
+import count is small and there's no downstream consumer of paths. Horizon: **short** (mechanical;
+do it before launch or accept it forever).
+
+### 11. AbortSignal propagation: good spine, three gaps + one obsolete polyfill (MEDIUM, short/medium)
+
+The spine is right: HTTP disconnect → `AbortController` → `runSandboxAgent(signal)` →
+`SandboxAgent.start({signal})`. Gaps:
+
+- **Obsolete feature-detection:** callback.ts:43 and direct.ts:350 do
+  `const anyOf = (AbortSignal as any).any` with a fallback. `AbortSignal.any` is native since Node
+  20.3 and typed in @types/node 24 — the package pins Node 24. Replace both with
+  `AbortSignal.any([signal, timeoutSignal])`, deleting two `as any`. **short**
+- `startToolRelay` (relay.ts:399) has no signal; cancellation is a bespoke `active` flag +
+  `stop()`. Fine, but the in-flight `handle()` executions it spawns get no signal either, so a
+  caller abort waits out `TOOL_CALL_TIMEOUT_MS` per in-flight call. Thread `signal` through
+  `executeRelayedTool` → `callAgentaTool`/`callDirect` (they already accept one). **medium**
+- tool-mcp-http.ts:68-73 documents its own gap ("threading this signal into dispatch is a known
+  follow-up") — the abort destroys sockets but lets `runResolvedTool` run to completion. Same
+  threading fixes it. **medium**
+- No floating-promise bugs found by inspection — the codebase is diligent with `void` + `.catch()`
+  on fire-and-forget (server.ts:240-246, sandbox_agent.ts:760, pause.ts:26) and the tricky
+  `promptPromise.catch(() => {})` before `Promise.race` (sandbox_agent.ts:858-861) is exactly
+  right. But nothing *enforces* this — one missed `.catch` on a fire-and-forget is an
+  `unhandledRejection` log at best. That's the eslint case (finding 19/tooling).
+
+### 12. Sync fs on the runner's hot loops (MEDIUM, medium)
+
+- relay.ts:165-177 (`localRelayHost`): `readdirSync`/`readFileSync`/`writeFileSync` wrapped in
+  `async` arrows, called from the poll loop every 300 ms for the whole turn — each call blocks the
+  event loop of the single-threaded sidecar that is simultaneously serving other runs' streams.
+  Small files, so it's latency noise today, but it's on a FUSE-adjacent path where a stall (ENOTCONN,
+  slow S3) freezes the **entire process**, not just this run. This is the strongest "sync fs in an
+  async server" case in the codebase.
+- pi-error.ts:99-140 (`findSwallowedPiError`): synchronously `readdirSync` + `readFileSync` **every
+  transcript of every Pi session on the host** on the request path (reads whole files to check line 1,
+  then re-reads the match). O(sessions × transcript size) of event-loop blocking per empty-output
+  Pi run; the sessions dir only grows.
+
+The `RelayHost` interface is already async — only the local implementation cheats. **Fix:** swap to
+`node:fs/promises` in `localRelayHost` and pi-error.ts (and cap the pi-error scan to N most-recent
+dirs by mtime). Note the *deliberate* sync fs in dispatch.ts:66-108/`relayPermissionCheck` runs
+inside the Pi child process, not the runner — leave it. Horizon: **medium**.
+
+### 13. Three logging patterns coexist; no levels; two debug gates (MEDIUM, short)
+
+- Pattern A: per-module `function log(msg)` with a hard-coded prefix — 6 copies
+  (`[sandbox-agent]`, `[agenta-pi-ext]`, `[sessions/auth]`, `[sessions/alive]`,
+  `[sessions/interactions]`, `[sessions/persist]`, `[sandbox_agent/mount]`).
+- Pattern B: raw `process.stderr.write("[tag] ...")` inline — server.ts ×8, relay.ts:325, others.
+- Pattern C: `console.error` — direct.ts:372,383 and the `dbg` gate in callback.ts:47 (the only
+  place a *debug level* exists, via `AGENTA_RUNNER_DEBUG_TOOLS`, also checked in client-tools.ts:223).
+
+No levels, no way to silence heartbeat spam (alive.ts logs every OK heartbeat, persist.ts logs every
+ingest OK — that's a log line per event per session at INFO-equivalent), and greppable tags are
+inconsistent. stdout discipline (reserved for CLI JSON) is the one rule everyone did follow.
+
+**Fix:** one `src/internal/logger.ts`: `createLogger(tag)` returning `{debug, info, warn, error}`,
+stderr-only, level from `AGENTA_RUNNER_LOG_LEVEL`, `debug` folding in the existing
+`AGENTA_RUNNER_DEBUG_TOOLS`. Mechanical adoption (every module already funnels through a local
+`log`). Horizon: **short**.
+
+### 14. Type-level nits that cost narrowing (LOW→MEDIUM, short)
+
+- protocol.ts:13 — `type: "text" | "image" | "resource" | "tool_call" | "tool_result" | string`:
+  the trailing `| string` collapses the union to `string`; no narrowing, no completion, no typo
+  protection. Use the standard `| (string & {})` trick to keep completions, or split
+  `KnownContentBlockType` from the open wire type.
+- protocol.ts:369/374 — `harness?: string; sandbox?: string` on the wire is a deliberate
+  open-world choice (fine), but the *internal* `RunPlan.acpAgent` (run-plan.ts:73) stays `string`
+  even though the whole engine branches on `"pi" | "claude"`; `version.ts:15` already has
+  `HARNESSES` as a const tuple — derive `type Harness = (typeof HARNESSES)[number]` and use it
+  internally so the assert at run-plan.ts:262 becomes a compile-time exhaustiveness check.
+- sessions/alive.ts:123-125 — `(interval as unknown as { unref?: () => void }).unref` is
+  unnecessary: `setInterval` returns `NodeJS.Timeout` (typed `unref()`) under `types: ["node"]`.
+  Delete the double cast.
+- cli.ts:47 — `runCli(raw, stream, io)` boolean-trap positional; fold `stream` into the options
+  object (`runCli(raw, {stream, run, write})`). Call sites: 2.
+- responder.ts:111 — `.sort(([a],[b]) => (a < b ? -1 : ...))` — fine, but `localeCompare` is a
+  footgun here and correctly avoided; leave as is (noted so nobody "fixes" it).
+
+### 15. `tracing/otel.ts` is four modules in one 1315-line file (MEDIUM, medium)
+
+Contents: (1) process-wide export infrastructure (`TraceBatchProcessor`, exporter cache,
+`ensureProvider`, `orderParentFirst`) lines 57-235; (2) the Pi-extension tracer `createAgentaOtel`
+lines 404-639; (3) the ACP-stream tracer `createSandboxAgentOtel` lines 806-1315; (4) pure text
+utilities — the pi-acp startup-banner stripper and streaming splitter (`isBannerLine`,
+`stripStartupBanner`, `splitLeadingBanner`, lines 697-796) which have *nothing* to do with OTel and
+are unit-tested independently. The two tracers also share duplicated attribute-stamping blocks
+(`stampUsage` vs the inline block at 614-625; two `invoke_agent` start blocks).
+
+**Fix:** split into `tracing/export.ts` (infra), `tracing/pi-otel.ts`, `tracing/acp-otel.ts`,
+`tracing/banner.ts` (pure), and a shared `tracing/attrs.ts` for the GenAI attribute stamping. The
+banner utilities move first — zero-risk, and they're the part streaming code imports. Note the
+bundle-safety constraint from finding 9 (pi-otel + export are compiled into the extension).
+Horizon: **medium**.
+
+### 16. Error-handling patterns: 4 coexisting, mostly coherent, two rough edges (LOW→MEDIUM)
+
+Inventory: (a) result objects at boundaries (`{ok,error}`, `BuildRunPlanResult`) — good; (b) thrown
+plain `Error`s inside, converted at each edge — consistent, though there are **zero Error
+subclasses**, so edge code discriminates by regex on messages (errors.ts:47-52 matching
+"credit balance is too low|401|unauthorized"; isTransportEndpointDisconnected matching "ENOTCONN"
+in strings) — brittle, and a `RunnerError extends Error` with a `code` field would let
+`conciseError` switch on codes with the regexes as fallback for foreign errors only; (c) sentinel
+symbols for the pause outcome — **three of them** (pause.ts `PAUSED`, relay.ts's private `PAUSED`,
+tool-mcp-http.ts `MCP_PAUSED`) expressing one concept; `executeRelayedTool` returns
+`string | typeof PAUSED` where a small union `{kind:"text",text} | {kind:"paused"}` would be
+self-documenting and mergeable; (d) `assert()` invariants (capabilities.ts:41) — good and
+well-scoped. **Fix:** short: unify the PAUSED symbols (export one). Medium: introduce
+`RunnerError{code}` for the classes `conciseError`/ENOTCONN-detection sniff for.
+
+### 17. Dead exports and a booby-trapped tombstone file (LOW→MEDIUM, short)
+
+Verified by cross-referencing src+tests (false-positive caveat: option-bag interfaces of exported
+functions are legitimately exported; excluded below):
+
+- Value exports referenced nowhere outside their own module (knip would flag): `persistEvent`
+  (persist.ts:80), `allowedModels` (model.ts:19), `validateUserMcpUrl` (mcp.ts:78),
+  `installPiInSandbox` (daytona.ts:50), `DAYTONA_PI_VERSION`, `EXTENSION_BUNDLE`,
+  `installPiExtensionLocal`, `installSkillsLocal` (pi-assets.ts), `advertisedToolSpec`
+  (public-spec.ts:24), `createRequestListener` (server.ts:294), `SESSION_ID_PATTERN`,
+  `makeDisplacementPayload`, `displacedChannel`, `ownerKey`… (contract.ts — deliberate
+  contract mirrors, keep), `RELAY_POLL_IDLE_GROW_AFTER` (relay.ts). Several are "exported for
+  symmetry"; demote to module-private or add a `// exported for tests` marker once knip is in CI.
+- **tools/mcp-server.ts is a tombstone that executes `process.exit(1)` at module top level.** Any
+  future accidental `import "./mcp-server.ts"` (a barrel, a test glob, an IDE auto-import) kills
+  the process at import time with a one-line stderr message. If the tombstone must stay, make it
+  `throw new Error(...)` inside an entrypoint guard (`if (isEntrypoint(...))`), or just delete the
+  file — git history remembers. **short**
+
+### 18. Package/tsconfig hygiene (MEDIUM, short)
+
+- **Both `pnpm-lock.yaml` and `package-lock.json` are committed.** The npm lockfile is drift bait
+  (it will silently disagree with the pnpm one) and contradicts the package's own AGENTS.md
+  (pnpm-only, own lockfile). Delete `package-lock.json`; add `"packageManager"` is already set —
+  also consider a root `.npmrc` `engine-strict=true`.
+- **No `"engines"` field** despite hard Node-24 assumptions (native `AbortSignal.any`,
+  `Array.findLastIndex`, `fetch`). Add `"engines": {"node": ">=24"}`.
+- Version pinning is inconsistent without a policy: exact (`undici 8.3.0`, `tsx 4.19.2`,
+  OTel `1.28.0`, `sandbox-agent 0.4.2`, `pi-coding-agent 0.79.4`) vs caret (`@daytonaio/sdk`,
+  `@zed-industries/claude-agent-acp`, `typescript`). The pins on harness/OTel packages look
+  deliberate (wire-compat sensitive) — write the policy down in one comment or pin everything;
+  a caret on `claude-agent-acp` is exactly the kind of dependency the pins elsewhere guard against.
+- tsconfig: see finding 19 for flags. Also `lib: ["ES2023"]` with `target: "ES2022"` is fine but
+  `ES2024` lib matches Node 24 better (e.g. `Object.groupBy`, `Promise.withResolvers` are available
+  at runtime but not typed).
+
+### 19. Missing strictness flags — measured cost (MEDIUM, short→medium)
+
+Currently on: `strict` only (plus the module/interop set). Not on, ranked by value here:
+
+| flag | what it would catch here | est. cost |
+|---|---|---|
+| `noUncheckedIndexedAccess` | `lines[i]` in `splitLeadingBanner`/`stripStartupBanner` (otel.ts:742,775-795), `messages[i]` (protocol.ts:539-543, transcript.ts:20), `raw.split("\n")[0]` (errors.ts:44), `parts[parts.length-1]` (direct.ts:71) — exactly the off-by-one surface of the trickiest code (the streaming banner splitter) | ~30-50 errors, 0.5-1 day; highest value |
+| `exactOptionalPropertyTypes` | drift between `x?: T` and `x: T \| undefined` on the wire types; the codebase already writes conditional-spread style, so mostly clean | ~10-20 errors, half day |
+| `noUnusedLocals` / `noUnusedParameters` | the `_req` (server.ts:182), `_harness` (daemon.ts:133) conventions already anticipate it | near-zero (underscore convention holds) |
+| `noFallthroughCasesInSwitch`, `noImplicitOverride`, `noImplicitReturns` | hygiene; almost no switches today | free |
+| `verbatimModuleSyntax` | already using `import type` consistently; locks it in | near-zero |
+
+Recommendation: turn on everything except `noUncheckedIndexedAccess` immediately; schedule that one
+as its own PR (it will touch the banner splitter — do it with the unit tests green).
+
+### 20. Module-global mutable state constrains "the core as a library" (LOW, long)
+
+`persistChains` (persist.ts:31), `traceTargets`/`exporterCache`/`provider` (otel.ts:68-163),
+`inFlightSandboxes` (sandbox_agent.ts:150), `REPLICA_ID` (alive.ts:32). All documented, all
+correct today — but they mean two `createAgentServer()` instances in one process share hidden
+state, and tests depend on module-cache isolation. The Hashimoto move is a `RunnerRuntime` object
+(created in the entrypoint, holding persist chains, in-flight registry, tracer provider) threaded
+through the existing `deps` seams — the seams already exist, so this is wiring, not redesign.
+Horizon: **long** (post-launch, alongside finding 5's phase split).
+
+---
+
+## Top 10 by payoff-per-effort
+
+1. **Adopt eslint (flat config below) with `no-floating-promises` + strict-type-checked** — locks in
+   the discipline the code already mostly has; catches the one class of async bug nothing guards today. (hours)
+2. **Delete `package-lock.json`; add `"engines": {"node": ">=24"}`** — two-line drift/footgun removal. (minutes)
+3. **zod-validate the `/run` body in server.ts + cli.ts** (finding 1) — the highest-blast-radius
+   unvalidated input; schema doubles as wire documentation. (half day)
+4. **Fix `request.sessionId!` narrowing + cap `/run` `readBody`** (findings 7, 8) — two latent
+   production traps, both minutes to fix. (hour)
+5. **Dedupe the helper inventory into `src/internal/`** (finding 6) — kills already-observed
+   divergence (readBody, errorMessage, builtin list) before it bites. (half day)
+6. **`acp-types.ts` structural interfaces for sandbox/session/update** (finding 2) — converts ~50
+   of the 68 `any` sites into checked code in one mechanical pass. (1-2 days)
+7. **Exporter-cache eviction in otel.ts** (finding 3) — a real leak in a long-lived process. (hours)
+8. **One logger module with levels** (finding 13) — mechanical, silences heartbeat spam, makes the
+   debug gate uniform. (half day)
+9. **Turn on the cheap tsconfig flags now; `noUncheckedIndexedAccess` as its own PR** (finding 19). (half day + 1 day)
+10. **knip in CI + delete/disarm the mcp-server.ts tombstone + native `AbortSignal.any`**
+    (findings 11, 17) — dead-code hygiene and two `as any` deleted. (hours)
+
+Deliberately below the line: the runSandboxAgent phase split (5) and otel.ts split (15) are the
+right *medium* refactors but should not gate launch; the file renames (10) should happen now or never.
+
+## Recommended eslint setup
+
+```jsonc
+// package.json devDependencies to add:
+// "eslint": "^9", "typescript-eslint": "^8", "eslint-plugin-import-x": "^4" (optional), "knip": "^5"
+```
+
+```js
+// eslint.config.js (flat)
+import tseslint from "typescript-eslint";
+
+export default tseslint.config(
+  { ignores: ["dist/", "coverage/", "tests/results/"] },
+  ...tseslint.configs.strictTypeChecked,
+  ...tseslint.configs.stylisticTypeChecked,
+  {
+    languageOptions: {
+      parserOptions: { projectService: true, tsconfigRootDir: import.meta.dirname },
+    },
+    rules: {
+      // The two rules that pay for the whole setup:
+      "@typescript-eslint/no-floating-promises": ["error", { ignoreVoid: true }], // `void fn()` stays legal fire-and-forget
+      "@typescript-eslint/no-misused-promises": ["error", { checksVoidReturn: { arguments: false } }],
+
+      // Ratchet, don't block: the SDK seam makes these warnings until acp-types.ts lands.
+      "@typescript-eslint/no-explicit-any": "warn",
+      "@typescript-eslint/no-unsafe-assignment": "warn",
+      "@typescript-eslint/no-unsafe-member-access": "warn",
+      "@typescript-eslint/no-unsafe-argument": "warn",
+      "@typescript-eslint/no-unsafe-call": "warn",
+      "@typescript-eslint/no-unsafe-return": "warn",
+
+      "@typescript-eslint/consistent-type-imports": ["error", { fixStyle: "inline-type-imports" }],
+      "@typescript-eslint/switch-exhaustiveness-check": "error",
+      "@typescript-eslint/no-non-null-assertion": "error", // there is exactly 1; fix it and lock the door
+      "@typescript-eslint/restrict-template-expressions": ["error", { allowNumber: true, allowBoolean: true }],
+
+      // Config-module enforcement (finding 4): whitelist src/config.ts (and the extension) via overrides.
+      "no-restricted-properties": ["error", {
+        object: "process", property: "env",
+        message: "Read config through src/config.ts, not process.env directly.",
+      }],
+      "no-console": ["error", { allow: [] }], // stderr logger only (finding 13)
+    },
+  },
+  {
+    // The Pi extension legitimately reads env (env IS its wire), and config.ts is the one reader.
+    files: ["src/config.ts", "src/extensions/**", "src/apiBase.ts"],
+    rules: { "no-restricted-properties": "off" },
+  },
+  {
+    files: ["tests/**"],
+    rules: {
+      "@typescript-eslint/no-explicit-any": "off",
+      "@typescript-eslint/no-unsafe-assignment": "off",
+      "@typescript-eslint/no-non-null-assertion": "off",
+    },
+  },
+);
+```
+
+```jsonc
+// knip.json
+{
+  "entry": ["src/server.ts", "src/cli.ts", "src/extensions/agenta.ts", "scripts/build-extension.mjs"],
+  "project": ["src/**/*.ts"],
+  "ignoreExportsUsedInFile": true
+}
+```
+
+CI: `pnpm exec eslint . --max-warnings 200` initially (the unsafe-* warnings from the `any` seam),
+ratcheting the cap down as acp-types.ts lands; `knip` as a non-blocking report first week, then blocking.

--- a/docs/design/agent-workflows/scratch/runner-review-2026-07-05/reports/00-executive-summary.md
+++ b/docs/design/agent-workflows/scratch/runner-review-2026-07-05/reports/00-executive-summary.md
@@ -1,0 +1,257 @@
+# Runner review — executive summary
+
+Date: 2026-07-05. Scope: `services/runner/` (the TypeScript agent runner) in the context of the
+Python agent service and the SDK adapters that call it. Seven reviewers read the code in parallel:
+three at high depth (architecture, the sandbox_agent engine, security), four at medium depth
+(entrypoints and sessions, tracing, tests and QA, TypeScript idioms). The detailed findings for
+each area live in `../findings/`. This summary ties them together.
+
+## The one-paragraph verdict
+
+The runner is in good shape for something that grew out of a POC. The core discipline is real:
+fail-loud gates that refuse any capability the runner cannot honestly deliver, a golden-fixture
+contract that pins the wire format across two languages, dependency-injection seams that let the
+whole engine run under test with fakes, and a credential-clearing routine that keeps one tenant's
+provider keys out of another's run. A Python developer wrote strict-mode TypeScript here and mostly
+wrote it well. The gaps are not sloppiness. They are the parts a POC never has to face and a
+production service does: what happens when a run hangs, when two runs share a process, when a
+sandbox fails to unmount, when the harness is not Pi, and when the deployment is multi-tenant. Those
+are the areas to close before launch.
+
+## What the whole codebase got right (keep these)
+
+Every reviewer, independently, flagged the same strengths. They are worth stating because the
+roadmap builds on them rather than replacing them.
+
+- **Fail-loud gates.** `run-plan.ts` refuses code tools, stdio MCP, tools on non-Pi remote
+  sandboxes, and unenforceable policy before it creates any resource. This is the single best
+  property of the runner. Every "silent drop" finding below is really a place where this discipline
+  has a hole, not a place where the discipline is wrong.
+- **The cross-language wire contract.** Shared golden fixtures asserted by both Python and
+  TypeScript, plus a compile-time key guard that fails `tsc` on drift. It is close to the strongest
+  guard you can build by hand.
+- **Injection seams everywhere.** `createAgentServer(run)`, `runCli(raw, {run})`, and the
+  `SandboxAgentDeps` bag let the tests drive real orchestration with fakes. The suite is green: 525
+  unit tests, plus integration and acceptance layers, all wired into CI.
+- **Credential clearing.** The managed-run daemon inherits zero provider keys and applies only the
+  resolved secrets. Secrets are logged by name, never by value.
+- **Layered leak backstops.** Per-run cleanup, a SIGTERM sweep, and Daytona self-reap each cover the
+  next one's failure. The design anticipated leaks. The findings below are the cases the backstops
+  miss.
+- **Comments that carry the why.** Nearly every odd branch cites the incident or finding that
+  created it. A new reader can reconstruct the reasoning. This is rare.
+
+## The two blockers
+
+Two findings gate the launch on their own.
+
+1. **No run has a deadline.** `session.prompt()` has no timeout, the transport timeouts were
+   disabled to support human-in-the-loop pauses, and a session-owned run never aborts when the
+   client disconnects. A hung provider, a wedged adapter, or a stalled Daytona proxy means the run
+   never finishes. The cleanup never runs. The daemon, the sandbox, the mount, and the HTTP socket
+   all leak, and the watchdog keeps reporting the session as healthy while it is wedged. Under load,
+   N hung runs leak N daemons on one Node process. (Engine review, F1.)
+
+2. **No real agent run is pinned by a regression test.** The QA effort captured roughly 70 real
+   `/run` pairs and wrote a skill to convert them into replay tests. None of that happened. The
+   orchestration tests drive a hand-built fake harness that encodes the author's mental model of how
+   Pi and Claude behave over ACP, never a real transcript. The append_system bug (F-001) was caught
+   and re-verified by hand three times because no test pins it. (Tests review, finding 1.)
+
+## The cross-cutting themes
+
+Read across all seven reports, the individual findings cluster into a small number of root causes.
+Fixing the root cause is cheaper than fixing each symptom.
+
+### Theme 1: resource lifecycle is the weakest system
+
+This is the largest risk and it shows up in four reports. The blocker above (no deadline) is the
+core of it. Around it sit: no admission control, so a burst of runs forks unbounded daemons and FUSE
+mounts on a process with no memory limit (architecture, A-6); the CLI transport has no signal
+handling at all, so killing the subprocess leaks the Daytona sandbox it created (entrypoints, 1);
+the server's own shutdown sweeps in-flight sandboxes without first refusing new connections, so a
+run that races the SIGTERM still leaks (entrypoints, 2); and teardown deletes a workspace directory
+through a FUSE mount that may still be live, which can erase the session's durable data (engine,
+F4). These are one system, resource lifecycle, and it needs a deliberate pass before launch, not
+four separate patches.
+
+### Theme 2: process-global state breaks the moment two runs share a process
+
+The runner is a long-lived server, but several pieces of state assume one run at a time. The request
+handler writes `process.env.AGENTA_API_URL` from the first request's data, and that value then
+routes every later session's authenticated calls for the life of the process (architecture A-2,
+entrypoints 3, idioms 4). The OTLP exporter cache is keyed on a per-run ephemeral credential, so it
+never hits and grows without bound (tracing 7, idioms 3). The trace export buffers are keyed only by
+trace id, so two runs that share a traceparent corrupt each other's export (tracing 5). None of
+these show up in tests, because the tests run one request at a time. All of them surface the first
+busy day in production.
+
+### Theme 3: the platform credential rides inside telemetry config
+
+The most load-bearing secret in the system, the token the runner uses to heartbeat, persist, sign
+mounts, and refresh itself, has no wire field. The runner digs it out of the OTLP exporter headers,
+and it recovers the Agenta API base by slicing the OTLP endpoint string. Turning off tracing would
+silently break sessions and mounts, features that have nothing to do with tracing (architecture,
+A-1). The security review found the sharp edge of the same design: that token is the caller's
+reusable user bearer, and it gets injected as an environment variable the harness process can read.
+On Daytona it crosses into the sandbox, where a prompt-injected agent can read it and impersonate the
+user (security, F2). One first-class `platform { endpoint, authorization }` wire block fixes the
+design smell, and keeping that token out of the agent's environment fixes the leak.
+
+### Theme 4: the local sandbox is not a tenant boundary
+
+The security review is emphatic and correct: everything isolated by Daytona is solid, and every
+sharp edge is the shared-host `local` topology. On `local`, every tenant's LLM-steered harness runs
+as a child process on the same host under the same uid. A prompt-injected agent can read another
+run's secrets through `/proc`, reach another run's unauthenticated tool server on loopback, and read
+or forge another run's relay files (security, F1, F3, F6). The fix is policy before code: force
+Daytona for tenant runs, document `local` as single-tenant and development-only, and turn on the
+`/run` token that today defaults off (security, F1, F5, F8, F10).
+
+### Theme 5: fail-loud has holes, and they all drop something a user needs
+
+The gate discipline is the codebase's best property, which makes its holes worth naming. Production
+compose never sets `PI_CODING_AGENT_DIR`, so a plain Pi run silently loses its extension, and with it
+tracing, usage, and tool delivery (engine, F8). The swallowed-error scan reads the wrong directory
+whenever skills are present, which is always for the agenta harness, so the "No response" bug is
+re-opened for that whole harness (engine, F6). An unknown sandbox id falls back to running on the
+host instead of refusing (engine, F5). Cache-token attribute keys do not match the ingest mapping, so
+prompt-cache cost data vanishes with no error (tracing, 1). OTLP export failures are never logged, so
+a trace can disappear with zero visibility (tracing, 6). Each of these is a one-place fix that
+extends the gate discipline to a spot it missed.
+
+### Theme 6: the variability axes are booleans, not seams
+
+The runner has two real axes of variation: which harness (Pi, Claude, and the experimental agenta)
+and where it runs (local, Daytona). Both are expressed as scattered booleans. `grep` finds 34 `isPi`
+and 35 `isDaytona` branches across nine files. Adding codex or opencode touches at least ten places
+across two languages with no checklist (architecture A-4). Adding a k8s or Firecracker backend means
+editing every branch (architecture A-5). The fix is the provider pattern the team already knows: one
+`HarnessProfile` table and one `SandboxBackend` port. This is the medium-term structural work that
+turns "add a harness" from a week into a day. It is not a launch blocker, but every week it waits, a
+few more branches accrete.
+
+### Theme 7: two God files hold the next three bugs
+
+`runSandboxAgent` is a single 650-line function with an 8-step cleanup and five ordering invariants
+tracked only in comments. `tracing/otel.ts` is 1,315 lines and does four jobs, including owning the
+run's event log, which means the engine cannot produce its result without instantiating the tracer.
+Both files are where the correctness findings above actually live. Both have a clean extraction path
+that the tests already imply. This is medium-term work, but the disposer-stack piece of the engine
+cleanup is worth doing early, because it kills the "did the new resource get cleaned up?" class of
+leak that Theme 1 keeps producing.
+
+### Theme 8: the boundaries trust their input
+
+The `/run` body, the single most important input, is parsed and cast, never validated (idioms 1).
+Downstream code compensates with defensive checks scattered everywhere, which is the Python
+"isinstance sprinkles" habit in TypeScript clothing. The SDK handle for the sandbox and session is
+typed `any` in ten files, which is where roughly 50 of the 68 `any` sites come from and why the
+tracer guesses at event shapes (idioms 2). One zod schema at the boundary and one `acp-types.ts`
+file fix both, mechanically, and the schema doubles as contract documentation.
+
+### Theme 9: the docs describe a system that was removed
+
+The README lists an engine file that no longer exists, names a wire field that was never on the wire,
+calls the active Claude tool channel "disabled," and ships a quickstart command that fails. The
+design docs carry 44 stale paths and cite an environment variable with the wrong name and the wrong
+default (architecture, A-19). This trains every new contributor, and every agent run against this
+repo, on a false architecture. It is half a day to fix and it should be fixed before launch.
+
+## Severity dashboard
+
+| Area | Blocker | High | Medium | Low |
+|---|---:|---:|---:|---:|
+| Architecture and boundaries | 0 | 8 | 10 | 3 |
+| sandbox_agent engine | 1 | 7 | 9 | 7 |
+| Tools, permissions, security | 0 | 3 | 6 | 3 |
+| Entrypoints and sessions | 0 | 4 | 6 | 6 |
+| Tracing | 0 | 5 | 9 | 3 |
+| Tests and QA | 1 | 4 | 6 | 3 |
+| TypeScript idioms | 0 | 5 | 12 | 3 |
+| **Total** | **2** | **36** | **58** | **28** |
+
+The two blockers and a subset of the highs gate the launch. The rest is the medium and long-term
+cleanup the review was commissioned to produce.
+
+## The roadmap
+
+The horizon labels come from the individual reports. I have triaged the "short" items into two
+groups: those that must gate the launch because they lose data, burn credits, break tenant isolation,
+or silently drop a core feature, and those worth doing in launch week but not worth blocking on.
+
+### Must gate the launch
+
+These prevent data loss, credential leaks, credit burn, or the silent loss of a shipped feature.
+
+1. **Add a run deadline.** Overall and first-response, raced alongside the pause signal, so the
+   existing cleanup reclaims everything. (Engine F1, the blocker.)
+2. **Add admission control.** A max-inflight semaphore returning 503, a body-size cap, and memory
+   limits in compose and Helm sized to the semaphore. (Architecture A-6.)
+3. **Close the sandbox-leak paths.** Signal handling in the CLI, `server.close()` before the
+   shutdown sweep, and never delete a workspace through a mount that may still be live. (Entrypoints
+   1 and 2, engine F4.)
+4. **Force Daytona for tenant runs and refuse the unsafe local combinations.** Reject `local` for
+   multi-tenant, reject `default:"allow"` on local, require an explicit `credentialMode`, and turn on
+   `AGENTA_RUNNER_TOKEN` by default in compose. (Security F1, F5, F8, F10.)
+5. **Keep the caller bearer out of the agent-readable environment**, especially on Daytona, and
+   authenticate the internal tool MCP channel. (Security F2, F3.)
+6. **Fix the Daytona durable-session bugs.** Mount before materializing the workspace so instructions
+   and permission files are not hidden, and clear or scope the relay directory per turn so stale
+   requests are not re-executed. (Engine F2, F3.)
+7. **Whitelist sandbox ids.** Refuse an unknown provider instead of silently running on the host.
+   (Engine F5.)
+8. **Restore the silently-dropped Pi features.** Set `PI_CODING_AGENT_DIR` in the gh compose and make
+   missing extension delivery fail loud, and point the swallowed-error scan at the effective agent
+   directory so the agenta harness regains its protection. (Engine F8, F6.)
+9. **Fix the tracing silent drops.** Correct the cache-token attribute keys, log OTLP export
+   failures, and wrap `finish()` so a tracing error cannot turn a clean failure into an unhandled
+   rejection. (Tracing 1, 6, 8.)
+10. **Delete the request-time `process.env` mutation.** Thread the API base explicitly. (Architecture
+    A-2, entrypoints 3.)
+11. **Add the replay regression test.** Convert the F-001 append_system cell, already captured and
+    re-verified three times, into a TS-side replay through the real orchestration. Add direct tests
+    for the four zero-coverage load-bearing functions: `resolveDaemonBinary`, `refreshCredential`,
+    the interactions lifecycle, and `callAgentaTool`. (Tests 1, 4, 5, 6, 7, the second blocker.)
+12. **Rewrite the README and sweep the stale docs.** (Architecture A-19.)
+13. **Validate the `/run` body with zod** and fix the `sessionId` narrowing and the unbounded body
+    read. (Idioms 1, 7, 8.)
+
+### Launch week, not launch-blocking
+
+Cheap wins that harden the service without gating the release: the first-class `platform` wire block
+and its single accessor (A-1), scoping `/kill` to a session instead of the whole process (A-15,
+entrypoints 6), the SDK probing `/health` for version skew (A-7), the exporter-cache eviction
+(tracing 7), the helper de-duplication and the one logger module (idioms 6, 13), adopting eslint with
+`no-floating-promises`, and deleting the committed npm lockfile.
+
+### Medium term (one to two months)
+
+The structural work that pays for itself on the next harness and the next backend: phase-structure
+`runSandboxAgent` with a disposer stack (A-3), split the event log out of the tracer (A-11, tracing
+15), introduce the `HarnessProfile` table and fold the name-keyed branches into it (A-4, A-8), define
+the `SandboxBackend` port and type the sandbox handle (A-5), build the executor registry (A-17), make
+the service use the SDK's orchestration seam instead of re-implementing it (A-14), and make the
+extension's cross-process boundary visible in the tree (A-12).
+
+### Long term (structural)
+
+Move the hand-mirrored contract to a schema-first source so the Python side is generated, not
+hand-kept (A-9). Give the runner a real build so production stops running TypeScript through `tsx`
+with full dev dependencies (A-20). Revisit multi-replica routing when scale demands it (A-16).
+
+## How to read the detail
+
+Each area has its own report in `../findings/`, with file-and-line references, concrete failure
+scenarios, and a per-area top-10:
+
+- `arch-boundaries.md` — the system, the contract, extensibility, the target structure.
+- `engine-sandbox-agent.md` — the run flow across every local-vs-Daytona and Pi-vs-Claude cell, and
+  the lifecycle bugs.
+- `tools-permissions-security.md` — the permission model, the local-vs-Daytona trust boundary, and
+  secret hygiene.
+- `entrypoints-sessions.md` — the server, the CLI, and session coordination.
+- `tracing-otel.md` — the event-to-span state machine and its silent drops.
+- `tests-qa.md` — the coverage map, the seam discipline, and the highest-value tests to add.
+- `ts-idioms-quality.md` — the type-safety and organization sweep, with an eslint and knip config
+  ready to adopt.


### PR DESCRIPTION
Multi-agent review of the TypeScript agent runner (\`services/runner/\`) ahead of the agents launch, read in the context of the Python agent service and the SDK adapters. Scratch docs only — **no source changes**.

## What's here

Seven parallel reviewers, one report each in \`docs/design/agent-workflows/scratch/runner-review-2026-07-05/findings/\`:

- \`arch-boundaries.md\` — system, wire contract, extensibility, target structure
- \`engine-sandbox-agent.md\` — run flow across every local/Daytona × Pi/Claude cell, lifecycle bugs
- \`tools-permissions-security.md\` — permission model, local-vs-Daytona trust boundary, secret hygiene
- \`entrypoints-sessions.md\` — server, CLI, session coordination
- \`tracing-otel.md\` — event→span state machine and its silent drops
- \`tests-qa.md\` — coverage map, seam discipline, highest-value tests to add
- \`ts-idioms-quality.md\` — type-safety + organization sweep, with an eslint/knip config

Cross-cutting synthesis and a triaged short/medium/long roadmap in \`reports/00-executive-summary.md\`.

## Headline

**2 blockers, 36 high, 58 medium, 28 low.** The core discipline (fail-loud gates, the golden-fixture contract, injection seams, credential clearing) is genuinely strong. The gaps are the parts a POC never faces: run lifecycle under hang/load, process-global state when two runs share a process, the local sandbox not being a tenant boundary, and fail-loud holes that each silently drop a shipped feature.

Two blockers gate launch on their own: no run deadline (a hung run leaks daemon/sandbox/mount forever), and no replay regression test pinning any real captured run.

## Why a PR

For review and discussion of the roadmap. These are planning docs, not a code change — merge whenever, or keep open as the working reference while we knock out the launch-gating items.

https://claude.ai/code/session_01AbsewA4QStifB89UBJiHap