### PR TITLE
feat(api): validate the agent template on commit and test_run

### DIFF
--- a/api/oss/src/apis/fastapi/workflows/exceptions.py
+++ b/api/oss/src/apis/fastapi/workflows/exceptions.py
@@ -6,10 +6,11 @@ inside ``@intercept_exceptions()`` so the typed HTTP exception is the one re-rai
 """
 
 from functools import wraps
+from typing import Any, Dict, List
 
 from fastapi import HTTPException
 
-from oss.src.core.workflows.types import StaticWorkflowSlug
+from oss.src.core.workflows.types import AgentTemplateInvalid, StaticWorkflowSlug
 
 
 class StaticWorkflowSlugException(HTTPException):
@@ -20,6 +21,24 @@ class StaticWorkflowSlugException(HTTPException):
         super().__init__(status_code=400, detail=message)
 
 
+class AgentTemplateInvalidException(HTTPException):
+    """A 400 whose detail names every offending ``parameters.agent`` field path.
+
+    The commit caller is often a model that must self-remediate, so the body carries both a
+    summary ``message`` and the structured ``errors`` list (``loc`` / ``msg`` / ``type``).
+    """
+
+    def __init__(
+        self,
+        errors: List[Dict[str, Any]],
+        message: str = "The agent template configuration failed validation.",
+    ):
+        super().__init__(
+            status_code=400,
+            detail={"message": message, "errors": errors},
+        )
+
+
 def handle_workflow_exceptions():
     def decorator(func):
         @wraps(func)
@@ -28,6 +47,11 @@ def handle_workflow_exceptions():
                 return await func(*args, **kwargs)
             except StaticWorkflowSlug as e:
                 raise StaticWorkflowSlugException(message=e.message) from e
+            except AgentTemplateInvalid as e:
+                raise AgentTemplateInvalidException(
+                    errors=e.errors,
+                    message=e.message,
+                ) from e
 
         return wrapper
 

--- a/api/oss/src/core/tools/platform_handlers.py
+++ b/api/oss/src/core/tools/platform_handlers.py
@@ -63,6 +63,12 @@ from oss.src.core.workflows.dtos import (
     WorkflowServiceRequestData,
 )
 from oss.src.core.workflows.service import WorkflowsService
+from oss.src.core.workflows.types import AgentTemplateInvalid
+from oss.src.core.workflows.agent_validation import (
+    format_agent_template_errors,
+    validate_agent_template,
+)
+from oss.src.utils.env import env
 
 AGENTA_TOOL_CALL_REF_PREFIX = "tools.agenta."
 TEST_RUN_CALL_REF = "tools.agenta.test_run"
@@ -227,6 +233,17 @@ async def _build_test_workflow_request(
             raise PlatformToolHandlerError(
                 "test_run could not resolve the revision delta."
             )
+        # Same strict agent-template validation as the commit path, on the in-memory
+        # delta-resolved data — a malformed override must fail loud (with the offending field
+        # paths) rather than run a broken agent.
+        if env.agenta.agent_template.commit_validation:
+            try:
+                validate_agent_template(resolved.data)
+            except AgentTemplateInvalid as e:
+                raise PlatformToolHandlerRefused(
+                    "test_run delta produced an invalid agent template: "
+                    f"{format_agent_template_errors(e.errors)}"
+                ) from e
         workflow_request.data.revision = {"data": resolved.data.model_dump(mode="json")}
 
     return workflow_request

--- a/api/oss/src/core/workflows/agent_validation.py
+++ b/api/oss/src/core/workflows/agent_validation.py
@@ -1,0 +1,277 @@
+"""Strict server-side validation of a committed ``parameters.agent`` value.
+
+Nothing else guards the agent template on the write path: without this, a builder agent can commit
+a ``harness.kind: "claude"`` paired with a non-Anthropic provider, or a malformed tools/skills
+entry, and the commit succeeds silently — the agent then never runs or falls back. This module
+validates the delta-resolved final ``parameters.agent`` object against the same strict
+:class:`AgentTemplateSchema` the playground editor is generated from, adds one cross-field rule
+(``claude`` requires an Anthropic-provider model), and raises :class:`AgentTemplateInvalid` naming
+the offending field paths.
+
+The commit path is also a DRAFT surface: the playground commits work-in-progress entries verbatim
+(blank skill/MCP drafts, tools still in the OpenAI ``{type: "function"}`` shape it rewrites only at
+run time, bare builtin tools like ``{type: "web_search"}``). So ``tools`` / ``mcps`` / ``skills``
+are validated entry-wise with a shape-vs-completeness split: wrong SHAPE (unknown keys, wrong
+types, an invalid typed tool config) rejects; INCOMPLETENESS (missing / blank / mid-edit values)
+is tolerated for skills and mcps, mirroring the frontend's own run-time drop rules. Tools tolerate
+incompleteness only through the loose/legacy passthrough shapes (function-shape, flat, bare
+builtin) — a TYPED tool entry (``type`` in the config union) must be complete, since typed configs
+come from discovery output or the agent's own commit, both of which emit complete entries.
+``@ag.embed`` entries always pass through untouched, so the default agent-template overlay stays
+committable.
+
+The harness -> provider constraint is read from the single capability source of truth
+(:func:`agenta.sdk.agents.capabilities.harness_allows_provider`); it is never re-encoded here.
+"""
+
+from typing import Any, Dict, FrozenSet, List, Optional
+
+from pydantic import ValidationError
+
+from agenta.sdk.utils.types import AgentTemplateSchema, SkillTemplateSchema
+from agenta.sdk.agents.capabilities import harness_allows_provider
+from agenta.sdk.agents.mcp.models import MCPServerConfig
+from agenta.sdk.agents.tools.models import TOOL_CONFIG_ADAPTER
+
+from oss.src.core.workflows.types import AgentTemplateInvalid
+
+# The agent template sits at ``parameters.agent`` (like the prompt template at
+# ``parameters.prompt``); the builtin interface binds ``agenta:builtin:agent:v0``. Presence of the
+# ``agent`` key is the trigger — the uri is a secondary signal only.
+AGENT_TEMPLATE_URI_PREFIX = "agenta:builtin:agent"
+_AGENT_PARAMETER_KEY = "agent"
+_EMBED_MARKER = "@ag.embed"
+
+_ROOT = "parameters.agent"
+
+# The ``type`` values of the canonical typed tool-config union. Anything else is the loose legacy
+# surface (OpenAI function shape, flat ``{name, ...}``, bare builtin names) the runtime coerces.
+_TYPED_TOOL_KINDS: FrozenSet[str] = frozenset(
+    {"builtin", "gateway", "code", "client", "reference", "platform"}
+)
+
+# Error types that signal an incomplete (draft) entry rather than a wrong shape. Dropped for the
+# entry-wise skill/MCP checks so a work-in-progress config stays committable.
+_INCOMPLETENESS_ERROR_TYPES: FrozenSet[str] = frozenset(
+    {"missing", "string_too_short", "string_pattern_mismatch"}
+)
+
+
+def _is_embed(entry: Any) -> bool:
+    return isinstance(entry, dict) and _EMBED_MARKER in entry
+
+
+def _extract_agent(data: Any) -> Any:
+    """Return the raw value at ``data.parameters.agent`` (any type), or ``None`` when absent.
+
+    ``None`` means "not an agent template" — the caller skips validation. A present-but-non-dict
+    value is returned as-is so the schema pass flags it.
+    """
+    parameters = getattr(data, "parameters", None)
+    if not isinstance(parameters, dict):
+        return None
+    if _AGENT_PARAMETER_KEY not in parameters:
+        return None
+    return parameters[_AGENT_PARAMETER_KEY]
+
+
+def _convert_errors(
+    exc: ValidationError,
+    *,
+    prefix: str,
+    ignore_types: FrozenSet[str] = frozenset(),
+) -> List[Dict[str, Any]]:
+    converted: List[Dict[str, Any]] = []
+    for error in exc.errors():
+        error_type = error.get("type", "")
+        if error_type in ignore_types:
+            continue
+        loc = ".".join(str(part) for part in error.get("loc", ()))
+        full_loc = f"{prefix}.{loc}" if loc else prefix
+        converted.append(
+            {
+                "loc": full_loc,
+                "msg": error.get("msg", ""),
+                "type": error_type,
+            }
+        )
+    return converted
+
+
+def _infer_provider(agent: Dict[str, Any]) -> Optional[str]:
+    llm = agent.get("llm")
+    if not isinstance(llm, dict):
+        return None
+    provider = llm.get("provider")
+    if isinstance(provider, str) and provider.strip():
+        return provider.strip()
+    model = llm.get("model")
+    if isinstance(model, str) and "/" in model:
+        return model.split("/", 1)[0].strip() or None
+    return None
+
+
+def _harness_provider_errors(agent: Dict[str, Any]) -> List[Dict[str, Any]]:
+    """The one cross-field rule: a ``claude`` harness requires an Anthropic-provider model.
+
+    Only enforced when the provider is determinable (an explicit ``llm.provider`` or a
+    ``provider/model`` string). A bare Claude alias (``sonnet``) with no provider is left alone so
+    the harness's implicit Anthropic default stays committable.
+    """
+    harness = agent.get("harness")
+    kind = harness.get("kind") if isinstance(harness, dict) else None
+    if kind != "claude":
+        return []
+    provider = _infer_provider(agent)
+    if provider is None or harness_allows_provider("claude", provider):
+        return []
+    return [
+        {
+            "loc": f"{_ROOT}.llm.provider",
+            "msg": (
+                "Harness 'claude' requires an Anthropic-provider model; "
+                f"got provider '{provider}'."
+            ),
+            "type": "value_error.harness_provider",
+        }
+    ]
+
+
+def _tool_errors(tools: List[Any]) -> List[Dict[str, Any]]:
+    errors: List[Dict[str, Any]] = []
+    for index, entry in enumerate(tools):
+        if _is_embed(entry):
+            continue
+        prefix = f"{_ROOT}.tools.{index}"
+        if not isinstance(entry, dict):
+            errors.append(
+                {
+                    "loc": prefix,
+                    "msg": "Tool entry must be an object or an @ag.embed reference.",
+                    "type": "type_error.tool",
+                }
+            )
+            continue
+        kind = entry.get("type")
+        if isinstance(kind, str) and kind in _TYPED_TOOL_KINDS:
+            try:
+                TOOL_CONFIG_ADAPTER.validate_python(entry)
+            except ValidationError as exc:
+                errors.extend(_convert_errors(exc, prefix=prefix))
+            continue
+        # Loose legacy surfaces the runtime coerces (and the playground commits verbatim):
+        # the OpenAI function shape, the flat named shape, and bare builtin type strings.
+        if isinstance(kind, str) and kind:
+            continue
+        if kind is None and (
+            isinstance(entry.get("name"), str)
+            or isinstance(entry.get("function"), dict)
+        ):
+            continue
+        errors.append(
+            {
+                "loc": prefix,
+                "msg": (
+                    "Unrecognized tool configuration shape; expected a typed tool config "
+                    f"(type in {sorted(_TYPED_TOOL_KINDS)}), an OpenAI function tool, or an "
+                    "@ag.embed reference."
+                ),
+                "type": "value_error.tool_shape",
+            }
+        )
+    return errors
+
+
+def _skill_errors(skills: List[Any]) -> List[Dict[str, Any]]:
+    errors: List[Dict[str, Any]] = []
+    for index, entry in enumerate(skills):
+        if _is_embed(entry):
+            continue
+        try:
+            SkillTemplateSchema.model_validate(entry)
+        except ValidationError as exc:
+            errors.extend(
+                _convert_errors(
+                    exc,
+                    prefix=f"{_ROOT}.skills.{index}",
+                    ignore_types=_INCOMPLETENESS_ERROR_TYPES,
+                )
+            )
+    return errors
+
+
+def _mcp_errors(mcps: List[Any]) -> List[Dict[str, Any]]:
+    errors: List[Dict[str, Any]] = []
+    for index, entry in enumerate(mcps):
+        try:
+            MCPServerConfig.model_validate(entry)
+        except ValidationError as exc:
+            errors.extend(
+                _convert_errors(
+                    exc,
+                    prefix=f"{_ROOT}.mcps.{index}",
+                    ignore_types=_INCOMPLETENESS_ERROR_TYPES,
+                )
+            )
+    return errors
+
+
+def _collect_errors(agent: Any) -> List[Dict[str, Any]]:
+    errors: List[Dict[str, Any]] = []
+
+    # The list sections are validated entry-wise below (with the draft/legacy tolerance the
+    # playground's committed shapes need), so blank them for the strict top-level pass.
+    top_level = agent
+    if isinstance(agent, dict):
+        top_level = {
+            **agent,
+            **{
+                key: []
+                for key in ("tools", "mcps", "skills")
+                if isinstance(agent.get(key), list)
+            },
+        }
+
+    try:
+        AgentTemplateSchema.model_validate(top_level)
+    except ValidationError as exc:
+        errors.extend(_convert_errors(exc, prefix=_ROOT))
+
+    if isinstance(agent, dict):
+        if isinstance(agent.get("tools"), list):
+            errors.extend(_tool_errors(agent["tools"]))
+        if isinstance(agent.get("skills"), list):
+            errors.extend(_skill_errors(agent["skills"]))
+        if isinstance(agent.get("mcps"), list):
+            errors.extend(_mcp_errors(agent["mcps"]))
+        errors.extend(_harness_provider_errors(agent))
+
+    return errors
+
+
+def is_agent_template_data(data: Any) -> bool:
+    """Whether ``data`` carries an agent template (a ``parameters.agent`` value)."""
+    return _extract_agent(data) is not None
+
+
+def validate_agent_template(data: Any) -> None:
+    """Validate ``data``'s ``parameters.agent`` value; no-op when ``data`` is not an agent template.
+
+    Raises :class:`AgentTemplateInvalid` (translated to a structured HTTP 400 at the boundary) when
+    the value fails the strict schema, an entry-wise tools/skills/mcps shape check, or the
+    claude/provider rule.
+    """
+    agent = _extract_agent(data)
+    if agent is None:
+        return
+    errors = _collect_errors(agent)
+    if errors:
+        raise AgentTemplateInvalid(errors=errors)
+
+
+def format_agent_template_errors(errors: List[Dict[str, Any]]) -> str:
+    """Human-readable one-line rendering of the field-path errors (for string-detail callers)."""
+    return "; ".join(
+        f"{error.get('loc', '')}: {error.get('msg', '')}".strip(": ")
+        for error in errors
+    )

--- a/api/oss/src/core/workflows/service.py
+++ b/api/oss/src/core/workflows/service.py
@@ -101,6 +101,7 @@ from oss.src.core.workflows.types import (
     WorkflowDetachedStartFailed,
     is_static_workflow_slug,
 )
+from oss.src.core.workflows.agent_validation import validate_agent_template
 
 # Resolution is now handled by EmbedsService
 from oss.src.core.embeds.dtos import (
@@ -1799,6 +1800,12 @@ class WorkflowsService:
         # A snippet (skill) is non-runnable content: strip every execution-surface field, only uri +
         # parameters survive. Holds even if a caller posts the skill uri under a normal slug.
         data = normalize_snippet_data(workflow_revision_commit.data)
+
+        # Validate the delta-resolved agent template before it is persisted, so a malformed
+        # parameters.agent (bad schema, malformed skill, claude+non-anthropic) fails loud with the
+        # offending field paths instead of committing silently and never running.
+        if env.agenta.agent_template.commit_validation:
+            validate_agent_template(data)
         if data and data.uri and not data.url:
             _, kind, _, _ = parse_uri(data.uri)
             if kind != "builtin":

--- a/api/oss/src/core/workflows/types.py
+++ b/api/oss/src/core/workflows/types.py
@@ -5,7 +5,7 @@ These are raised by the workflows service and translated to HTTP responses at th
 never raise ``HTTPException`` directly.
 """
 
-from typing import Optional
+from typing import Any, Dict, List, Optional
 
 # Reserved-slug detection is canonical in the SDK (it also drives is_static inference there). The
 # API re-exports it so every write path can reject a reserved slug and every read path can
@@ -41,6 +41,27 @@ class StaticWorkflowSlug(WorkflowError):
                 f"The slug prefix '__ag__' is reserved for static workflows. "
                 f"Choose a different slug than '{slug}'."
             )
+        )
+
+
+class AgentTemplateInvalid(WorkflowError):
+    """Raised when a committed (or test_run delta-resolved) ``parameters.agent`` value fails the
+    strict agent-template schema or a cross-field rule (e.g. a ``claude`` harness paired with a
+    non-Anthropic provider).
+
+    ``errors`` is a list of ``{"loc", "msg", "type"}`` entries naming the offending field paths
+    (rooted at ``parameters.agent``) so a self-remediating caller can fix the exact fields.
+    Translated to HTTP 400 at the router.
+    """
+
+    def __init__(
+        self,
+        errors: List[Dict[str, Any]],
+        message: Optional[str] = None,
+    ):
+        self.errors = errors
+        super().__init__(
+            message or "The agent template configuration failed validation."
         )
 
 

--- a/api/oss/src/utils/env.py
+++ b/api/oss/src/utils/env.py
@@ -261,6 +261,23 @@ class ApiConfig(BaseModel):
 
 
 # ---------------------------------------------------------------------------
+# agenta.agent_template
+# ---------------------------------------------------------------------------
+
+
+class AgentTemplateConfig(BaseModel):
+    """Agent-template server-side validation feature flags."""
+
+    # Kill switch for the strict agent-template validation on the commit / test_run paths.
+    # Enabled by default; set falsy to skip validation entirely.
+    commit_validation: bool = (
+        os.getenv("AGENTA_AGENT_TEMPLATE_COMMIT_VALIDATION") or "true"
+    ).lower() in _TRUTHY
+
+    model_config = ConfigDict(extra="ignore")
+
+
+# ---------------------------------------------------------------------------
 # agenta.extras
 # ---------------------------------------------------------------------------
 
@@ -447,6 +464,7 @@ class AgentaConfig(BaseModel):
     crypt_key: str = os.getenv("AGENTA_CRYPT_KEY") or "replace-me"
 
     access: AccessConfig = AccessConfig()
+    agent_template: AgentTemplateConfig = AgentTemplateConfig()
     ai_services: AIServicesConfig = AIServicesConfig()
     api: ApiConfig = ApiConfig()
     billing: BillingConfig = BillingConfig()

--- a/api/oss/tests/pytest/unit/tools/test_platform_handlers.py
+++ b/api/oss/tests/pytest/unit/tools/test_platform_handlers.py
@@ -320,7 +320,7 @@ async def test_test_run_applies_delta_in_memory(monkeypatch):
     workflows = FakeWorkflowsService(
         delta_data={
             "url": "https://agent.internal",
-            "parameters": {"agent": {"model": "changed"}},
+            "parameters": {"agent": {"llm": {"model": "changed"}}},
         }
     )
 
@@ -328,7 +328,7 @@ async def test_test_run_applies_delta_in_memory(monkeypatch):
         arguments=_args(
             terminal_tool=None,
             delta={
-                "set": {"parameters": {"agent": {"model": "changed"}}},
+                "set": {"parameters": {"agent": {"llm": {"model": "changed"}}}},
                 "remove": ["parameters.agent.old"],
             },
         ),
@@ -343,7 +343,38 @@ async def test_test_run_applies_delta_in_memory(monkeypatch):
     assert workflows.ensure_calls
     assert workflows.delta_calls
     revision = http.calls[0]["json"]["data"]["revision"]["data"]
-    assert revision["parameters"]["agent"]["model"] == "changed"
+    assert revision["parameters"]["agent"]["llm"]["model"] == "changed"
+
+
+async def test_test_run_delta_with_invalid_agent_template_is_refused(monkeypatch):
+    http = HttpxController(monkeypatch)
+    workflows = FakeWorkflowsService(
+        delta_data={
+            "url": "https://agent.internal",
+            "parameters": {
+                "agent": {
+                    "llm": {"model": "gpt-4o"},
+                    "skills": [{"slug": "my-skill", "content": "oops"}],
+                }
+            },
+        }
+    )
+
+    with pytest.raises(PlatformToolHandlerRefused) as exc_info:
+        await handle_test_run(
+            arguments=_args(
+                terminal_tool=None,
+                delta={"set": {"parameters": {"agent": {"llm": {"model": "gpt-4o"}}}}},
+            ),
+            headers={},
+            project_id=uuid4(),
+            user_id=uuid4(),
+            workflows_service=workflows,
+            tracing_service=FakeTracingService(),
+        )
+
+    assert "parameters.agent.skills.0" in str(exc_info.value)
+    assert http.calls == []
 
 
 async def test_test_run_delta_requires_existing_project_scoped_variant(monkeypatch):
@@ -479,7 +510,7 @@ async def test_test_run_delta_with_edit_workflows_permission_invokes(monkeypatch
     workflows = FakeWorkflowsService(
         delta_data={
             "url": "https://agent.internal",
-            "parameters": {"agent": {"model": "changed"}},
+            "parameters": {"agent": {"llm": {"model": "changed"}}},
         }
     )
     router = ToolsRouter(

--- a/api/oss/tests/pytest/unit/workflows/test_agent_template_validation.py
+++ b/api/oss/tests/pytest/unit/workflows/test_agent_template_validation.py
@@ -1,0 +1,402 @@
+"""Strict server-side validation of a committed ``parameters.agent`` value.
+
+Covers the validator directly (schema, embeds tolerance, malformed skill, claude/provider rule)
+and its two hook points via faked DAOs: the workflows commit path and the env kill switch. See
+``oss.src.core.workflows.agent_validation``.
+"""
+
+from unittest.mock import AsyncMock
+from uuid import uuid4
+
+import pytest
+
+from oss.src.core.workflows.agent_validation import (
+    validate_agent_template,
+    is_agent_template_data,
+)
+from oss.src.core.workflows.dtos import (
+    Workflow,
+    WorkflowArtifactFlags,
+    WorkflowRevision,
+    WorkflowRevisionCommit,
+    WorkflowRevisionData,
+    WorkflowRevisionFlags,
+)
+from oss.src.core.workflows.service import WorkflowsService
+from oss.src.core.workflows.types import AgentTemplateInvalid
+from oss.src.utils.env import env
+
+
+AGENT_URI = "agenta:builtin:agent:v0"
+
+
+def _valid_agent() -> dict:
+    return {
+        "instructions": {"agents_md": "Be helpful."},
+        "llm": {"provider": "openai", "model": "gpt-5.5"},
+        "tools": [],
+        "mcps": [],
+        "skills": [],
+        "harness": {"kind": "pi_core"},
+        "runner": {"kind": "sidecar", "permissions": {"default": "allow_reads"}},
+        "sandbox": {"kind": "local"},
+    }
+
+
+def _agent_data(agent: dict) -> WorkflowRevisionData:
+    return WorkflowRevisionData(uri=AGENT_URI, parameters={"agent": agent})
+
+
+# validator -------------------------------------------------------------------
+
+
+def test_valid_agent_template_passes():
+    validate_agent_template(_agent_data(_valid_agent()))
+
+
+def test_embeds_in_tools_and_skills_are_tolerated():
+    agent = _valid_agent()
+    agent["skills"] = [
+        {
+            "@ag.embed": {
+                "@ag.references": {"workflow": {"slug": "__ag__build_an_agent"}},
+                "@ag.selector": {"path": "parameters.skill"},
+            },
+            "name": "Build an agent",
+        }
+    ]
+    agent["tools"] = [
+        {"type": "builtin", "name": "read"},
+        {"type": "platform", "op": "test_run"},
+        {
+            "@ag.embed": {
+                "@ag.references": {"workflow": {"slug": "__ag__some_tool"}},
+                "@ag.selector": {"path": "parameters.tool"},
+            }
+        },
+    ]
+    validate_agent_template(_agent_data(agent))
+
+
+def test_malformed_skill_entry_raises_with_field_paths():
+    agent = _valid_agent()
+    # A skill written with a workflow-ish shape (top-level slug/content) instead of the
+    # skill-template shape (name/description/body).
+    agent["skills"] = [{"slug": "my-skill", "content": "do things"}]
+
+    with pytest.raises(AgentTemplateInvalid) as exc_info:
+        validate_agent_template(_agent_data(agent))
+
+    locs = {error["loc"] for error in exc_info.value.errors}
+    assert any(loc.startswith("parameters.agent.skills.0") for loc in locs)
+    # The unknown keys are named; missing-field errors are draft-tolerated and not raised.
+    assert "parameters.agent.skills.0.slug" in locs
+    assert "parameters.agent.skills.0.content" in locs
+
+
+def test_blank_skill_draft_is_tolerated():
+    # The playground commits a freshly-added skill (blank name/description/body) verbatim and
+    # only drops it at run time; commit must stay possible.
+    agent = _valid_agent()
+    agent["skills"] = [{"name": "", "description": "", "body": ""}]
+    validate_agent_template(_agent_data(agent))
+
+
+def test_half_filled_skill_draft_is_tolerated():
+    agent = _valid_agent()
+    agent["skills"] = [{"name": "my-skill", "description": "", "body": ""}]
+    validate_agent_template(_agent_data(agent))
+
+
+def test_openai_function_tool_shape_is_tolerated():
+    # The shared tool form commits tools in the OpenAI shape; the run path rewrites them to
+    # typed client configs, but the committed revision carries them verbatim.
+    agent = _valid_agent()
+    agent["tools"] = [
+        {
+            "type": "function",
+            "function": {"name": "lookup", "description": "d", "parameters": {}},
+        },
+        {"type": "web_search"},
+        {"name": "flat-legacy-tool", "parameters": {}},
+    ]
+    validate_agent_template(_agent_data(agent))
+
+
+def test_typed_tool_with_bad_shape_raises():
+    agent = _valid_agent()
+    agent["tools"] = [{"type": "builtin"}]
+
+    with pytest.raises(AgentTemplateInvalid) as exc_info:
+        validate_agent_template(_agent_data(agent))
+
+    joined = " ".join(error["loc"] for error in exc_info.value.errors)
+    assert "parameters.agent.tools.0" in joined
+
+
+def test_unrecognized_tool_shape_raises():
+    agent = _valid_agent()
+    agent["tools"] = [{"foo": "bar"}]
+
+    with pytest.raises(AgentTemplateInvalid) as exc_info:
+        validate_agent_template(_agent_data(agent))
+
+    locs = {error["loc"] for error in exc_info.value.errors}
+    assert "parameters.agent.tools.0" in locs
+
+
+def test_blank_mcp_draft_is_tolerated_and_wrong_mcp_shape_raises():
+    agent = _valid_agent()
+    agent["mcps"] = [{"name": "", "transport": "stdio"}]
+    validate_agent_template(_agent_data(agent))
+
+    agent["mcps"] = [{"name": "srv", "transport": "carrier-pigeon"}]
+    with pytest.raises(AgentTemplateInvalid) as exc_info:
+        validate_agent_template(_agent_data(agent))
+    joined = " ".join(error["loc"] for error in exc_info.value.errors)
+    assert "parameters.agent.mcps.0" in joined
+
+
+def test_claude_harness_non_anthropic_provider_raises():
+    agent = _valid_agent()
+    agent["harness"] = {"kind": "claude"}
+    agent["llm"] = {"provider": "openai", "model": "gpt-4o"}
+
+    with pytest.raises(AgentTemplateInvalid) as exc_info:
+        validate_agent_template(_agent_data(agent))
+
+    locs = {error["loc"] for error in exc_info.value.errors}
+    assert "parameters.agent.llm.provider" in locs
+
+
+def test_claude_harness_anthropic_provider_passes():
+    agent = _valid_agent()
+    agent["harness"] = {"kind": "claude"}
+    agent["llm"] = {"provider": "anthropic", "model": "sonnet"}
+
+    validate_agent_template(_agent_data(agent))
+
+
+def test_claude_harness_provider_inferred_from_model_prefix_raises():
+    agent = _valid_agent()
+    agent["harness"] = {"kind": "claude"}
+    agent["llm"] = {"model": "openai/gpt-4o"}
+
+    with pytest.raises(AgentTemplateInvalid):
+        validate_agent_template(_agent_data(agent))
+
+
+def test_unknown_top_level_agent_key_raises():
+    agent = _valid_agent()
+    agent["surprise"] = True
+
+    with pytest.raises(AgentTemplateInvalid) as exc_info:
+        validate_agent_template(_agent_data(agent))
+
+    joined = " ".join(error["loc"] for error in exc_info.value.errors)
+    assert "surprise" in joined
+
+
+def test_default_template_with_overlay_shape_is_committable():
+    # The shipped default (build_agent_v0_default) merged with the playground overlay's tool /
+    # skill / sandbox additions must always pass — this is the shape the playground commits.
+    from agenta.sdk.utils.types import build_agent_v0_default
+
+    agent = build_agent_v0_default(
+        skill_slug="__ag__build_an_agent",
+        include_sandbox_permission=True,
+    )
+    agent["tools"] = [
+        {"type": "builtin", "name": "read"},
+        {"type": "platform", "op": "test_run"},
+        {
+            "@ag.embed": {
+                "@ag.references": {"workflow": {"slug": "__ag__telegram"}},
+                "@ag.selector": {"path": "parameters.tool"},
+            },
+            "name": "Telegram",
+        },
+    ]
+    agent["sandbox"]["permissions"] = {
+        **agent["sandbox"].get("permissions", {}),
+        "write_files": "allow",
+        "execute_code": "allow",
+    }
+    validate_agent_template(_agent_data(agent))
+
+
+def test_non_agent_data_is_noop():
+    # A normal (non-agent) revision has no parameters.agent — nothing to validate.
+    assert (
+        is_agent_template_data(WorkflowRevisionData(uri="agenta:builtin:chat:v0"))
+        is False
+    )
+    validate_agent_template(WorkflowRevisionData(uri="agenta:builtin:chat:v0"))
+    validate_agent_template(WorkflowRevisionData(parameters={"prompt": {}}))
+
+
+# router translation ----------------------------------------------------------
+
+
+@pytest.mark.asyncio
+async def test_handle_workflow_exceptions_translates_to_structured_400():
+    from fastapi import HTTPException
+
+    from oss.src.apis.fastapi.workflows.exceptions import handle_workflow_exceptions
+
+    @handle_workflow_exceptions()
+    async def _boom():
+        raise AgentTemplateInvalid(
+            errors=[
+                {
+                    "loc": "parameters.agent.skills.0.slug",
+                    "msg": "Extra inputs are not permitted",
+                    "type": "extra_forbidden",
+                }
+            ]
+        )
+
+    with pytest.raises(HTTPException) as exc_info:
+        await _boom()
+
+    assert exc_info.value.status_code == 400
+    detail = exc_info.value.detail
+    assert detail["errors"][0]["loc"] == "parameters.agent.skills.0.slug"
+    assert detail["message"]
+
+
+# service commit hook ---------------------------------------------------------
+
+
+def _commit(service: WorkflowsService, *, agent: dict, artifact_id, variant_id):
+    return service.commit_workflow_revision(
+        project_id=uuid4(),
+        user_id=uuid4(),
+        workflow_revision_commit=WorkflowRevisionCommit(
+            workflow_id=artifact_id,
+            workflow_variant_id=variant_id,
+            slug="rev",
+            data=_agent_data(agent),
+        ),
+    )
+
+
+def _seed_dao() -> tuple[AsyncMock, object, object]:
+    workflows_dao = AsyncMock()
+    artifact_id = uuid4()
+    variant_id = uuid4()
+    revision_id = uuid4()
+    workflows_dao.commit_revision.return_value = WorkflowRevision(
+        id=revision_id,
+        workflow_id=artifact_id,
+        workflow_variant_id=variant_id,
+        slug="rev",
+        flags=WorkflowRevisionFlags(is_agent=True),
+        data=_agent_data(_valid_agent()),
+    )
+    workflows_dao.fetch_artifact.return_value = Workflow(
+        id=artifact_id,
+        slug="wf",
+        flags=WorkflowArtifactFlags(is_application=True),
+    )
+    return workflows_dao, artifact_id, variant_id
+
+
+@pytest.mark.asyncio
+async def test_commit_valid_agent_template_persists():
+    workflows_dao, artifact_id, variant_id = _seed_dao()
+    service = WorkflowsService(workflows_dao=workflows_dao)
+
+    revision = await _commit(
+        service, agent=_valid_agent(), artifact_id=artifact_id, variant_id=variant_id
+    )
+
+    assert revision is not None
+    workflows_dao.commit_revision.assert_awaited_once()
+
+
+@pytest.mark.asyncio
+async def test_commit_malformed_agent_template_rejected_before_persist():
+    workflows_dao, artifact_id, variant_id = _seed_dao()
+    service = WorkflowsService(workflows_dao=workflows_dao)
+
+    agent = _valid_agent()
+    agent["skills"] = [{"slug": "my-skill", "content": "do things"}]
+
+    with pytest.raises(AgentTemplateInvalid):
+        await _commit(
+            service, agent=agent, artifact_id=artifact_id, variant_id=variant_id
+        )
+
+    workflows_dao.commit_revision.assert_not_awaited()
+
+
+@pytest.mark.asyncio
+async def test_commit_claude_non_anthropic_rejected_before_persist():
+    workflows_dao, artifact_id, variant_id = _seed_dao()
+    service = WorkflowsService(workflows_dao=workflows_dao)
+
+    agent = _valid_agent()
+    agent["harness"] = {"kind": "claude"}
+    agent["llm"] = {"provider": "openai", "model": "gpt-4o"}
+
+    with pytest.raises(AgentTemplateInvalid):
+        await _commit(
+            service, agent=agent, artifact_id=artifact_id, variant_id=variant_id
+        )
+
+    workflows_dao.commit_revision.assert_not_awaited()
+
+
+@pytest.mark.asyncio
+async def test_kill_switch_bypasses_validation(monkeypatch):
+    workflows_dao, artifact_id, variant_id = _seed_dao()
+    service = WorkflowsService(workflows_dao=workflows_dao)
+
+    monkeypatch.setattr(env.agenta.agent_template, "commit_validation", False)
+
+    agent = _valid_agent()
+    agent["skills"] = [{"slug": "my-skill", "content": "do things"}]
+
+    revision = await _commit(
+        service, agent=agent, artifact_id=artifact_id, variant_id=variant_id
+    )
+
+    assert revision is not None
+    workflows_dao.commit_revision.assert_awaited_once()
+
+
+@pytest.mark.asyncio
+async def test_non_agent_workflow_commit_unaffected():
+    workflows_dao = AsyncMock()
+    artifact_id = uuid4()
+    variant_id = uuid4()
+    revision_id = uuid4()
+    workflows_dao.commit_revision.return_value = WorkflowRevision(
+        id=revision_id,
+        workflow_id=artifact_id,
+        workflow_variant_id=variant_id,
+        slug="rev",
+        flags=WorkflowRevisionFlags(is_chat=True, has_url=True),
+        data=WorkflowRevisionData(uri="agenta:builtin:chat:v0"),
+    )
+    workflows_dao.fetch_artifact.return_value = Workflow(
+        id=artifact_id,
+        slug="wf",
+        flags=WorkflowArtifactFlags(is_application=True),
+    )
+    service = WorkflowsService(workflows_dao=workflows_dao)
+
+    revision = await service.commit_workflow_revision(
+        project_id=uuid4(),
+        user_id=uuid4(),
+        workflow_revision_commit=WorkflowRevisionCommit(
+            workflow_id=artifact_id,
+            workflow_variant_id=variant_id,
+            slug="rev",
+            data=WorkflowRevisionData(uri="agenta:builtin:chat:v0"),
+        ),
+    )
+
+    assert revision is not None
+    workflows_dao.commit_revision.assert_awaited_once()


### PR DESCRIPTION
## Context

Nothing guarded `parameters.agent` on the write path. A builder agent could commit `harness.kind: "claude"` with an OpenAI provider, or a skill entry with `slug`/`content` at the top level, and the commit succeeded silently. The agent then never runs, or silently falls back to a default config, and the model that made the mistake gets no signal to fix it. The strict `AgentTemplateSchema` already existed in the SDK; it was only used to generate the playground editor, never enforced.

## Changes

New `api/oss/src/core/workflows/agent_validation.py` validates the delta-resolved final `parameters.agent` in `commit_workflow_revision` (covers `POST /workflows/revisions/commit`, initial creates, and the applications/evaluators services that delegate there) and in the `tools.agenta.test_run` handler's in-memory delta.

A failing commit now returns a structured 400 a self-remediating model can act on:

```json
{"message": "The agent template configuration failed validation.",
 "errors": [{"loc": "parameters.agent.skills.0.slug", "msg": "Extra inputs are not permitted", "type": "extra_forbidden"}]}
```

One cross-field rule rides on top: `harness.kind: "claude"` requires an Anthropic provider, read from the existing capability table (`harness_allows_provider`), never re-encoded.

The commit path is also a draft surface, so validation splits shape from completeness: `@ag.embed` entries pass through untouched; the playground's loose tool shapes (OpenAI `{type: "function"}`, flat, bare builtin) are tolerated; blank or half-filled skill/MCP drafts are tolerated; wrong shapes (unknown keys, wrong types, invalid typed tool configs) reject. The shipped default template plus the build-kit overlay is pinned committable by a test.

Kill switch: `AGENTA_AGENT_TEMPLATE_COMMIT_VALIDATION` (default on) in `env.py`.

## Scope / risk

Write-path only: stored revisions are never re-validated. Two conscious calls, flagged inline: a persisted legacy-shape agent revision (flat `model` instead of `llm.model`) will be refused on its next commit or test_run delta (the kill switch is the escape hatch, and only dev data is known to have that shape); Claude via Bedrock/Vertex would be rejected by the pairing rule because the capability table lists Anthropic only. The `/applications/revisions/commit` route delegates to the same service so invalid data is blocked there too, but that router lacks the exception decorator and would surface a 500 instead of the structured 400 (pre-existing gap, one-decorator follow-up).

## Tests

- New `test_agent_template_validation.py` (20 tests) covering the validator, both hook points, the kill switch, and the router translation; `test_platform_handlers.py` extended with a refusal test.
- Full api unit suite: 1230 passed.
- Live check on a dev stack: malformed skill entry and claude+openai both returned the structured 400 with exact field paths; a valid delta committed fine.

## How to QA

**Prerequisites:** local dev stack, any project API key, an agent app.

**Steps:**
1. `POST /api/workflows/revisions/commit` with `delta.set.parameters.agent.skills = [{"slug": "bad", "content": "nope"}]`.
2. Same endpoint with `delta.set.parameters.agent = {"harness": {"kind": "claude"}, "llm": {"provider": "openai", "model": "gpt-5.5", "connection": {"mode": "agenta"}}}`.
3. Same endpoint with a plain instructions update.

**Expected result:** steps 1 and 2 return 400 with `errors[].loc` naming the offending fields; step 3 returns 200 with a new revision.

**Automated tests:**
```
cd api && uv run --no-sync python -m pytest oss/tests/pytest/unit/workflows/ oss/tests/pytest/unit/tools/ -q
```

**Edge cases:** commit the untouched default agent template from the playground (must pass); commit a non-agent workflow (must be unaffected); set `AGENTA_AGENT_TEMPLATE_COMMIT_VALIDATION=false` and repeat step 1 (must pass through).

https://claude.ai/code/session_01N2djTMgXnpk84EqtugHDJB