### PR TITLE
fix(sdk): claude harness carries the forced platform skills and AGENTS.md preamble

### DIFF
--- a/sdks/python/agenta/sdk/agents/adapters/harnesses.py
+++ b/sdks/python/agenta/sdk/agents/adapters/harnesses.py
@@ -7,7 +7,9 @@ turning the neutral :class:`SessionConfig` into the harness's own config, especi
 - **pi_core** takes built-in tools by name *and* resolved tool specs, delivered natively (Pi
   has no MCP). The runner relay enforces the shared permission plan.
 - **claude** has no built-in tools (they are a Pi concept), delivers tools over MCP, and
-  receives the same runner permission plan.
+  receives the same runner permission plan. It is a first-class harness for platform agents
+  too, so it also gets the forced AGENTS.md preamble and forced platform skill(s) (see
+  :mod:`.agenta_builtins`); it has no Pi `system`/`append_system` slot, so no persona is forced.
 - **pi_agenta** is Pi with an opinion: the same engine and config shape, plus a fixed set of
   forced tools, a base AGENTS.md preamble, and a persona (see :mod:`.agenta_builtins`).
   Skills ride the neutral config as resolved inline packages. Pi and Agenta install them
@@ -92,6 +94,10 @@ class ClaudeHarness(Harness):
                 "ClaudeHarness ignores %d built-in tool(s); built-ins are a Pi concept",
                 len(config.builtin_names),
             )
+        # Claude is a first-class harness for platform agents too: the same forced Agenta
+        # preamble and forced platform skill(s) that pi_agenta gets are carried onto claude
+        # runs (see :mod:`.agenta_builtins`). Claude has no Pi `system`/`append_system` slot,
+        # so only the preamble and skills are forced here.
         # Skills stay on the harness config; the runner materializes them under `.claude/skills`
         # in the session cwd so Claude ACP can load the same resolved inline packages.
         # The harness's first-class `permissions` slice (plus sandbox_permission + mcp_servers) is
@@ -99,13 +105,16 @@ class ClaudeHarness(Harness):
         # adapter) renders `.claude/settings.json` as a generic `harnessFiles` entry. No
         # claude-specific parsing happens here; the runner just writes the files into the cwd.
         return ClaudeAgentTemplate(
-            agents_md=config.agent.instructions,
+            agents_md=compose_instructions(config.agent.instructions),
             model=config.agent.model,
             resolved_connection=config.resolved_connection,
             tool_specs=list(config.tool_specs),
             tool_callback=config.tool_callback,
             mcp_servers=list(config.mcp_servers),
-            skills=list(config.agent.skills),
+            # Force the platform skill(s) into every run, de-duped by name, mirroring
+            # AgentaHarness: a custom config that drops the default template's `_agenta` embed
+            # still gets the platform skill.
+            skills=force_skills(list(config.agent.skills)),
             sandbox_permission=config.agent.sandbox_permission,
             permission_default=config.permission_default,
             harness_permissions=config.agent.harness_permissions,

--- a/sdks/python/oss/tests/pytest/unit/agents/test_harness_adapters.py
+++ b/sdks/python/oss/tests/pytest/unit/agents/test_harness_adapters.py
@@ -261,8 +261,53 @@ def test_claude_carries_skills_for_project_local_materialization(make_env):
 
     # Claude keeps resolved inline packages on the config. The runner materializes them under
     # `.claude/skills/<name>` in the session cwd, matching Claude's project-local skill layout.
-    assert [s.name for s in result.skills] == ["release-notes"]
+    # The forced platform skill is unioned in after the author's own skill(s), same as Agenta.
+    skill_names = [s.name for s in result.skills]
+    assert skill_names[0] == "release-notes"
+    assert GETTING_STARTED_WITH_AGENTA_SKILL.name in skill_names
     assert result.wire_skills()["skills"][0]["name"] == "release-notes"
+
+
+def test_claude_forces_platform_skill_on_a_skill_less_config(make_env):
+    # Mirrors AgentaHarness: a claude config with no skills still carries the platform skill on
+    # every run, so a claude-harness platform agent gets the getting-started skill too.
+    harness = ClaudeHarness(make_env(supported=[HarnessType.CLAUDE]))
+    config = _session_config(
+        agent=AgentTemplate(instructions="hi", model="m", skills=[])
+    )
+
+    result = harness._to_harness_config(config)
+
+    assert [s.name for s in result.skills] == [GETTING_STARTED_WITH_AGENTA_SKILL.name]
+
+
+def test_claude_does_not_duplicate_an_already_present_platform_skill(make_env):
+    # A config that already carries the resolved platform skill (e.g. via the default template's
+    # embed) is not doubled: the author's copy wins on the name clash.
+    harness = ClaudeHarness(make_env(supported=[HarnessType.CLAUDE]))
+    existing = GETTING_STARTED_WITH_AGENTA_SKILL.model_dump(mode="json")
+    config = _session_config(
+        agent=AgentTemplate(instructions="hi", model="m", skills=[existing])
+    )
+
+    result = harness._to_harness_config(config)
+
+    names = [s.name for s in result.skills]
+    assert names.count(GETTING_STARTED_WITH_AGENTA_SKILL.name) == 1
+
+
+def test_claude_composes_instructions_with_the_agenta_preamble(make_env):
+    # Claude runs now get the same forced AGENTS.md preamble as pi_agenta, so a claude-harness
+    # platform agent isn't left without the getting-started preamble.
+    harness = ClaudeHarness(make_env(supported=[HarnessType.CLAUDE]))
+    config = _session_config(
+        agent=AgentTemplate(instructions="My project rules.", model="m")
+    )
+
+    result = harness._to_harness_config(config)
+
+    assert result.agents_md.startswith(AGENTA_PREAMBLE)
+    assert result.agents_md.endswith("My project rules.")
 
 
 def test_claude_no_warning_without_builtins(make_env, monkeypatch):


### PR DESCRIPTION
## Context

The forced-extras guarantee ("every platform agent carries the getting-started skill and the Agenta AGENTS.md preamble") only held for `pi_agenta`. `ClaudeHarness._to_harness_config` passed instructions and skills through raw, so a claude-harness platform agent got neither unless its config happened to embed them. Claude is a first-class harness for platform agents (it is what the builder-agent flow runs), so it gets the same guarantee.

## Changes

`ClaudeHarness._to_harness_config` now wraps instructions with `compose_instructions(...)` and skills with `force_skills(...)`, exactly like `AgentaHarness`. The Pi-only pieces stay Pi-only: no forced persona (`append_system` is not a `ClaudeAgentTemplate` field) and no forced builtin tools (Claude has no Pi builtins; the existing drop behavior is untouched). `force_skills` is name-deduped and author-wins, so a config that already embeds the platform skill is not doubled.

## Scope / risk

Design flag for review: there is a single `HarnessType.CLAUDE`, unlike Pi's `pi_core` (plain) vs `pi_agenta` (opinionated) split, so this forces the preamble and the getting-started skill onto every claude run with no plain-claude opt-out. Both forced items are small orientation content, but if an un-opinionated claude harness is wanted later it needs its own harness kind. No golden or wire impact: the wire model is unchanged and the claude golden builds `ClaudeAgentTemplate` directly. Pre-existing and untouched: the provisioning path writes the raw (uncomposed) instructions to the on-disk file while the wire carries the composed ones; that asymmetry existed for `pi_agenta` before this change.

## Tests

- `test_harness_adapters.py`: three new tests (forced skill on a skill-less config, no duplication when already present, preamble composition) plus the updated materialization test; PiHarness passthrough tests unchanged and green. Full agents suite: 549 passed. Wire-contract and golden tests: unchanged, green.

https://claude.ai/code/session_01N2djTMgXnpk84EqtugHDJB