### PR TITLE
docs(design): let triggers follow a variant's latest revision (Latest binding)

### DIFF
--- a/docs/design/trigger-latest-binding/README.md
+++ b/docs/design/trigger-latest-binding/README.md
@@ -1,0 +1,46 @@
+# Trigger "Latest" binding
+
+Give triggers (schedules + subscriptions) a first-class **Latest** binding: run the
+newest revision of a variant, resolved fresh at each fire. The backend already does this
+for variant-only references; the frontend can neither express nor render it, and a
+backend workaround (create-time pinning, commit `fe4a01f`) was added that this project
+reverts.
+
+## Read in this order
+
+1. **[context.md](context.md)** — why, goals, non-goals, the design decisions (rail
+   choice, reference shape, the marker question). Start here.
+2. **[research.md](research.md)** — verified findings with `file:line` citations. Every
+   claim in the plan traces back here. Re-verified 2026-07-07.
+3. **[plan.md](plan.md)** — phases A–F with concrete per-file edits, sized for narrow
+   subagents.
+4. **[status.md](status.md)** — source of truth for state. **DESIGN DRAFT, awaiting
+   Mahmoud's review on the draft PR.**
+
+## One-paragraph summary
+
+Three binding modes, one per policy: **Latest** (variant-only ref, follow head at fire),
+**Pinned** (revision ref, frozen), **Deployed** (environment ref, follow deployment).
+The wire already encodes the policy in the reference *shape* — the absence of a revision
+ref **is** the follow-latest signal, and the dispatcher re-resolves from raw references on
+every fire. So the backend work is a **revert** (undo the create-time pin) plus keeping
+one good fix from the same lane (422 handlers on the subscription endpoints). The real
+work is frontend: a third rail item, and **one shared prefix-symmetric classifier** for
+every reference read — the drawers and settings list currently never read the
+`workflow_*` family that agent-created triggers store, which is the gap the pin papered
+over. Prefill recognizes the variant-only shape (any prefix) as Latest instead of
+stuffing a variant id into a revision field, the picker shows its current value, and the
+settings list labels Latest triggers by name + tag. Then fix the op-catalog descriptions
+that post-revert would tell the model the opposite of what its own triggers do.
+
+## Key touch points (all paths absolute from repo root)
+
+- Backend un-pin: `api/oss/src/core/triggers/service.py` `_validate_references`
+- Backend test reshape: `api/oss/tests/pytest/unit/triggers/test_triggers_reference_defaulting.py`
+- FE control: `web/packages/agenta-entity-ui/src/gatewayTrigger/drawers/shared/RunVersionField.tsx`
+- FE drawers: `web/packages/agenta-entity-ui/src/gatewayTrigger/drawers/TriggerScheduleDrawer.tsx`,
+  `.../TriggerSubscriptionDrawer.tsx`
+- FE settings list: `web/oss/src/components/pages/settings/Triggers/components/GatewaySchedulesSection.tsx`,
+  `.../GatewaySubscriptionsSection.tsx`
+- Wording: `sdks/python/agenta/sdk/agents/platform/op_catalog.py`,
+  `sdks/python/agenta/sdk/agents/adapters/agenta_builtins.py`

--- a/docs/design/trigger-latest-binding/README.md
+++ b/docs/design/trigger-latest-binding/README.md
@@ -1,46 +1,104 @@
 # Trigger "Latest" binding
 
-Give triggers (schedules + subscriptions) a first-class **Latest** binding: run the
-newest revision of a variant, resolved fresh at each fire. The backend already does this
-for variant-only references; the frontend can neither express nor render it, and a
-backend workaround (create-time pinning, commit `fe4a01f`) was added that this project
-reverts.
+A trigger is a schedule (cron) or a subscription (a provider event). When it fires, it
+runs a workflow. This project lets a user bind a trigger to "the latest revision of a
+variant" from the UI, and makes the UI display that binding honestly.
 
-## Read in this order
+The surprise: the backend already supports Latest. Almost all the work is frontend.
 
-1. **[context.md](context.md)** — why, goals, non-goals, the design decisions (rail
-   choice, reference shape, the marker question). Start here.
-2. **[research.md](research.md)** — verified findings with `file:line` citations. Every
-   claim in the plan traces back here. Re-verified 2026-07-07.
-3. **[plan.md](plan.md)** — phases A–F with concrete per-file edits, sized for narrow
-   subagents.
-4. **[status.md](status.md)** — source of truth for state. **DESIGN DRAFT, awaiting
-   Mahmoud's review on the draft PR.**
+## How the trigger endpoints behave today
 
-## One-paragraph summary
+You create a trigger with `POST /api/triggers/schedules/` or
+`POST /api/triggers/subscriptions/`. The request carries `data.references`, a small
+object that names what to run. The endpoint validates the references and stores them
+exactly as you sent them. It does not rewrite them.
 
-Three binding modes, one per policy: **Latest** (variant-only ref, follow head at fire),
-**Pinned** (revision ref, frozen), **Deployed** (environment ref, follow deployment).
-The wire already encodes the policy in the reference *shape* — the absence of a revision
-ref **is** the follow-latest signal, and the dispatcher re-resolves from raw references on
-every fire. So the backend work is a **revert** (undo the create-time pin) plus keeping
-one good fix from the same lane (422 handlers on the subscription endpoints). The real
-work is frontend: a third rail item, and **one shared prefix-symmetric classifier** for
-every reference read — the drawers and settings list currently never read the
-`workflow_*` family that agent-created triggers store, which is the gap the pin papered
-over. Prefill recognizes the variant-only shape (any prefix) as Latest instead of
-stuffing a variant id into a revision field, the picker shows its current value, and the
-settings list labels Latest triggers by name + tag. Then fix the op-catalog descriptions
-that post-revert would tell the model the opposite of what its own triggers do.
+The decision about which revision runs happens at fire time, not at save time. On every
+fire, the dispatcher rebuilds the run request from the stored references, and the
+workflow service resolves a revision from them:
 
-## Key touch points (all paths absolute from repo root)
+| References you store                          | What runs at each fire                                  | Name     |
+|-----------------------------------------------|---------------------------------------------------------|----------|
+| `{application_revision: {id}}`                | that exact revision, every time                         | Pinned   |
+| `{application_variant: {id}}`, no revision    | the variant's newest revision, looked up fresh each fire | Latest   |
+| `{environment: {slug}}`                       | whatever is deployed to that environment right now      | Deployed |
 
-- Backend un-pin: `api/oss/src/core/triggers/service.py` `_validate_references`
-- Backend test reshape: `api/oss/tests/pytest/unit/triggers/test_triggers_reference_defaulting.py`
-- FE control: `web/packages/agenta-entity-ui/src/gatewayTrigger/drawers/shared/RunVersionField.tsx`
-- FE drawers: `web/packages/agenta-entity-ui/src/gatewayTrigger/drawers/TriggerScheduleDrawer.tsx`,
-  `.../TriggerSubscriptionDrawer.tsx`
-- FE settings list: `web/oss/src/components/pages/settings/Triggers/components/GatewaySchedulesSection.tsx`,
-  `.../GatewaySubscriptionsSection.tsx`
-- Wording: `sdks/python/agenta/sdk/agents/platform/op_catalog.py`,
-  `sdks/python/agenta/sdk/agents/adapters/agenta_builtins.py`
+## How to get "latest" from the backend
+
+Leave the revision out. That is the entire configuration. If the stored references name
+a variant but no revision, the workflow service resolves the variant's head revision at
+fire time, and it does that again on every fire. Commit a new revision, and the next
+fire runs it. There is no flag, no marker, no extra field.
+
+Two details matter:
+
+- The resolution lives in `_ensure_request_revision`
+  (`api/oss/src/core/workflows/service.py`). It writes the resolved revision into that
+  one run request only. It never writes back to the trigger.
+- Reference keys come in three prefixes: `application_*`, `workflow_*`, and
+  `evaluator_*`. The backend treats them the same. The UI writes `application_variant`;
+  agent-created triggers write `workflow_variant`. Both mean the same thing.
+
+## What is broken
+
+The frontend does not know Latest exists. Three symptoms:
+
+1. **You cannot choose it.** The "Which version runs?" control offers two modes: pick
+   an exact revision (Pinned) or pick an environment (Deployed). There is no way to say
+   "follow the variant".
+2. **The UI renders a Latest trigger as broken.** On edit, the drawer stuffs the
+   variant id into a revision field. The revision lookup fails, so the drawer shows an
+   empty, required "Select workflow revision" field and blocks saving. The settings
+   list shows the same trigger as a raw id or "-".
+3. **The frontend never reads the `workflow_*` keys.** Agent-created triggers store
+   `workflow_variant`, so they hit both problems above every time.
+
+We first tried to patch this in the backend. PR #5103 made the endpoints pin the
+variant's head revision into the stored references at save time, so the frontend would
+always find a revision key it knew how to read. That traded a correct binding for a
+wrong one: the trigger stopped following new commits. Mahmoud closed that PR on
+2026-07-09. The pin commit still sits on the local lane
+`fix/trigger-revision-default-head`; Phase A of the plan removes it.
+
+## What we will build
+
+Frontend, the real work:
+
+1. **A third option in the version control.** The "Which version runs?" rail becomes
+   `Latest | Pinned | Deployed`. Picking Latest shows a variant picker (workflow, then
+   variant, no revision level). On save, the drawer submits
+   `{application: {id}, application_variant: {id}}` with no revision. That is exactly
+   the shape the backend already reads as "follow latest".
+2. **One shared reader for stored references.** A small pure function classifies any
+   stored references into a mode: a revision key means Pinned, a variant key with no
+   revision means Latest, an environment key means Deployed. It checks all three
+   prefixes. Both drawers and both settings tables use it. This fixes edit (the drawer
+   opens in the right mode and shows the current value) and the list (each trigger
+   shows its workflow name plus a tag: Latest, v3, or @production).
+
+Backend, cleanup only: remove the pin from the closed PR's lane. Keep its one good
+piece: the subscription endpoints now return 422 instead of 500 when a reference does
+not resolve.
+
+SDK wording: the op catalog tells agents that a schedule "binds at creation time and
+does not follow later commits". Once the pin is gone, that is backwards. Fix the
+descriptions so agents draw the right conclusion about their own triggers.
+
+## What it looks like when done
+
+- You create a schedule, choose Latest, pick a variant, and save. You commit a new
+  revision. The next fire runs the new revision.
+- The settings page shows the workflow name with a Latest tag, not a raw id.
+- You reopen the trigger. The drawer opens in Latest mode with your variant selected.
+  Renaming the trigger and saving does not touch the binding.
+- An agent creates a schedule through the `create_schedule` op (variant only). It
+  renders and edits exactly like the one you made by hand.
+
+## Read the rest in this order
+
+1. [context.md](context.md): goals, non-goals, and each design decision with its
+   trade-offs and open questions.
+2. [plan.md](plan.md): implementation phases A to F with exact files.
+3. [research.md](research.md): the verified code findings behind every claim, with
+   `file:line` citations.
+4. [status.md](status.md): current state and the questions waiting on Mahmoud.

--- a/docs/design/trigger-latest-binding/context.md
+++ b/docs/design/trigger-latest-binding/context.md
@@ -1,0 +1,242 @@
+# Context: Trigger "Latest" binding
+
+## The problem
+
+A trigger (a cron **schedule** or a provider-event **subscription**) binds to a workflow
+so it knows what to run when it fires. Today a trigger can bind three ways in intent, but
+the product only exposes two:
+
+- **Pinned** — run one exact revision, frozen. The UI supports this.
+- **Deployed** — run whatever revision is deployed to an environment. The UI supports
+  this.
+- **Latest** — run the newest revision of a variant, re-resolved on every fire. **The UI
+  cannot express or render this**, even though the backend already implements it.
+
+The backend follows-latest whenever the stored references name a variant (or artifact)
+but no revision: the dispatcher rebuilds the invoke request from the *raw stored
+references* on every fire, and the workflow service resolves the variant HEAD fresh when
+no revision ref is present (see research.md §1). Agent-created triggers already rely on
+this — the `create_schedule` / `create_subscription` ops context-bind only the variant id.
+
+Three things broke because the frontend never modeled Latest:
+
+1. **The FE mis-renders a variant-only trigger.** Edit-prefill takes the variant id out of
+   `application_variant.id` and feeds it to revision-only selectors, which return null, so
+   the "Which version runs?" section shows an empty "Select workflow revision" placeholder
+   under a required asterisk — as if the trigger had no binding, when it has a perfectly
+   valid follow-latest binding.
+
+2. **The FE read paths never read the `workflow_*` reference family** — and agent-created
+   triggers store exactly `{workflow_variant: {id}}` (research.md §10). The drawer
+   prefills read `application_revision ?? application_variant ?? workflow_revision`; the
+   settings list reads `application ?? application_variant ?? application_revision`.
+   Neither reads `workflow_variant`. The `fe4a01f` pin "fixed" agent triggers only
+   because, being prefix-agnostic, it wrote `workflow_revision` — which the drawers DO
+   read. So a plain revert with `application_*`-only FE work would leave an agent trigger
+   prefilling null, rendering the empty required picker, blocking even a name-only edit
+   on submit validation, and showing "-" in the settings list. The FE classifier must be
+   **prefix-symmetric** (decision D2).
+
+3. **A backend workaround was added to hide those FE gaps.** Commit `fe4a01f` (lane
+   `fix/trigger-revision-default-head`, PR #5103) made `_validate_references` **pin** a
+   bare variant reference to its current HEAD revision at create/edit time, so the FE
+   always receives a revision key it reads. That freezes follow-latest at save time — it
+   trades a correct-but-unrendered binding for a wrong-but-rendered one. It must be
+   reverted; the fix belongs on the frontend (render Latest, read all prefixes), not on
+   the write path.
+
+## Goals
+
+- Add a first-class **Latest** binding mode to both trigger drawers: the user picks a
+  variant and the trigger follows its newest revision, resolved at each fire.
+- Correctly **round-trip** all three modes through create → edit → save without losing or
+  corrupting the binding — **for every reference prefix the backend accepts**
+  (`application_*`, `workflow_*`, `evaluator_*`), so agent-created triggers render too.
+- **Revert** the create-time pin so variant-only means follow-latest again, while keeping
+  the unrelated-but-good fix from the same lane (typed `TriggerReferenceInvalid` → HTTP
+  422 on the *subscription* create/edit endpoints, which previously surfaced 500s; the
+  schedule endpoints already had the handler — research.md §3).
+- **Render** Latest triggers honestly in the settings list ("Bound workflow" column),
+  using the same prefix-symmetric classifier as the drawers.
+- **Fix the wording** in the op catalog: post-revert, the `commit_revision` description's
+  claim that "existing schedules and subscriptions keep pointing at the old revision" is
+  actively wrong for the common agent case (a variant-bound self-schedule DOES pick up
+  the new commit). This is a correctness fix, not polish (research.md §9).
+
+## Non-goals (explicitly out of scope)
+
+- **Recording which revision actually ran on each delivery** — issue **#5110**, assigned
+  to jp. Latest triggers resolve HEAD at fire time; the delivery record does not yet
+  capture the resolved revision. Out of scope here; mentioned so a reader does not expect
+  it.
+- **Scoping the settings-mode picker to the trigger's own app.** The Pinned/Latest picker
+  in settings lists *every* application workflow in the project (unscoped) — part of the
+  "weird options" complaint. Real, but orthogonal to Latest. **Defer to a follow-up
+  issue** to keep this PR tight (see decision D5).
+- **Two pre-existing dangling-reference render gaps** (acknowledged so they are not
+  mistaken for regressions from this work): a **Pinned** trigger whose revision was
+  archived renders an empty picker, and a **Deployed** trigger whose environment was
+  deleted renders a blank select. Both predate this project and are unchanged by it.
+- **A data migration.** None is needed (see decision D6).
+- **A new wire field / explicit binding marker.** Considered and declined for now
+  (see decision D2).
+
+## Design decisions
+
+### D1 — UX: a third rail item ("Latest" | "Pinned" | "Deployed")
+
+The "Which version runs?" control is a left rail of mutually exclusive modes with a
+mode-specific control on the right (`RunVersionField.tsx`). Today the rail has two items:
+`Pinned` (a workflow→variant→revision cascader) and `Deployed` (an environment select).
+
+**Recommendation: add a third peer rail item, `Latest`.** Order: `Latest | Pinned |
+Deployed`.
+
+Why a peer rail item rather than a leaf inside the Pinned picker or a checkbox:
+
+- The three modes are three **binding policies** (follow-head / frozen / follow-deployment).
+  A rail already means "pick a policy." Making Latest a peer keeps the policy explicit and
+  visible, and it round-trips cleanly because the mode is derivable from the stored
+  reference shape.
+- A "Latest revision" *leaf inside the Pinned cascader* would bury the policy inside a
+  tree whose other leaves are frozen revisions, and it complicates the picker's value
+  model (a variant node and a revision node mean different things). Rejected.
+- A *checkbox* ("follow latest") is a hidden modifier on Pinned; users miss it and it
+  muddies the "one control, one policy" model. Rejected.
+- Note **Deployed is already a kind of "floating" binding** — it also re-resolves at fire
+  time, just against an environment instead of a variant HEAD. Latest is the variant-HEAD
+  sibling of that idea, so a third peer is conceptually consistent.
+
+Copy:
+
+- **Latest** — hint: *"Always runs the newest committed revision of this variant
+  (ignores environments)."* The parenthetical disambiguates from Deployed, which is also
+  a floating binding. Right-side control: a variant picker (workflow → variant; no
+  revision leaf). The selection resolves to the variant node.
+- **Pinned** — hint (unchanged): *"Runs one exact variant + revision."* Cascader unchanged.
+- **Deployed** — hint (unchanged): *"Follows the revision deployed to an environment."*
+
+**Default mode — OPEN QUESTION for Mahmoud (do not decide silently).** Recommendation:
+new triggers default to **Latest** (the most common intent and the shape agent-created
+triggers already use). But when the drawer opens from a context carrying a *concrete
+revision* — e.g. the playground positioned on a specific revision — should it instead
+open **Pinned**, pre-selected to that revision? Note the current create-mode default-bind
+already discards the revision context (it seeds the selection with the variant id and a
+hardcoded `revision: 0` — `TriggerScheduleDrawer.tsx:496-507`). Recommendation: **yes**,
+honor a concrete revision context as Pinned-preselected; plain contexts default to
+Latest. Flagged as Mahmoud's call in status.md.
+
+Implementation note: `buildRunVersionReferences` already emits a variant-only ref when the
+selected leaf id equals the variant id (`isRevision = !!meta.variantId && leafId !==
+meta.variantId`, research.md §4). So "Latest" is largely a matter of letting the user
+*select the variant node* and tagging the mode, not new reference-assembly logic.
+
+### D2 — Reference shape: no new field; absence of a revision ref IS the policy; reads are prefix-symmetric
+
+Classified by semantic role (per the design-interfaces skill), all three are
+**routing / binding-policy** references, owned by the trigger author, changed only on
+edit:
+
+| Mode     | Submitted references (FE drawers)                     |
+|----------|-------------------------------------------------------|
+| Latest   | `{application: {id}, application_variant: {id}}`       |
+| Pinned   | `{application: {id}, application_revision: {id}}`      |
+| Deployed | `{environment: {slug}, application: {slug}}`           |
+
+The **absence of a revision reference is the follow-latest signal.** This is already the
+contract the backend enforces (`_ensure_request_revision` resolves HEAD when
+`request.data.revision` is absent and no revision ref is present — research.md §1). No new
+field is required.
+
+**Prefix rule — writes are `application_*`, reads are prefix-symmetric.** The trigger
+drawers and `buildRunVersionReferences` *write* the `application_*` family. But
+agent-created triggers *store* `workflow_variant` (research.md §10), and the backend is
+prefix-agnostic — it detects the prefix among `application` / `evaluator` / `workflow`
+(`api/oss/src/core/triggers/service.py:782-789`) and follows-latest identically for all.
+So every FE **read path** (drawer prefill, settings-list rendering) must classify with
+**one shared prefix-symmetric classifier**, mirroring the backend's own prefix detection:
+
+> for `prefix` in `{application, workflow, evaluator}`:
+> `{prefix}_revision` present → **Pinned** carrying that revision id;
+> `{prefix}_variant` present with no `{prefix}_revision` → **Latest** carrying that
+> variant id; `environment` present → **Deployed**.
+
+This classifier is shared by both drawers AND both settings sections (plan.md Phases
+B–D). An earlier draft of this decision said "FE work stays on `application_*`" — that
+sentence encoded the agent-trigger rendering bug and is retracted.
+
+**Accepted silent prefix migration on re-pick.** The resubmit path is already safe:
+editing without re-picking echoes the stored references verbatim
+(`RunVersionField.tsx:63` `fallbackReferences`, fed from the stored refs at
+`TriggerScheduleDrawer.tsx:622` / `TriggerSubscriptionDrawer.tsx:697`), so a
+`workflow_variant` trigger keeps its shape across a name-only edit. An active re-pick in
+the drawer rewrites the references to `application_*` — harmless, since the backend is
+prefix-agnostic. We accept this as a deliberate, silent prefix migration on user edit; no
+code needs to preserve the `workflow_*` prefix on write.
+
+**The marker question (flagged explicitly).** Should Latest carry an explicit marker, e.g.
+`binding: "latest"`, instead of relying on the absence of a revision ref?
+
+- **Recommendation: no, not now.** The shape is already unambiguous and the backend
+  already keys off it. A marker would be a *second* source of truth for one policy and
+  could drift from the ref shape (the classic two-fields-one-fact bug).
+- The one real risk the marker would remove: a future reader (human or code) misreading
+  variant-only as "incomplete / binding not finished" rather than "intentionally latest."
+  That is exactly the misread that produced the `fe4a01f` workaround. **But the correct
+  remedy for that is FE rendering** — show a "Latest" tag so the binding reads as
+  deliberate — not a wire marker.
+- **When to revisit:** if we ever need a policy that the ref shape *cannot* express — e.g.
+  "freeze at the revision deployed at create time" (which is neither today's Pinned nor
+  Deployed), or per-trigger opt-out of follow-latest while still naming a variant. At that
+  point an explicit `binding` enum earns its keep. Until then, absence-of-revision is
+  canonical and consistent with the rest of the workflow-invoke contract.
+
+### D3 — Edit round-trip
+
+Prefill must **classify the stored shape into a mode** via the shared prefix-symmetric
+classifier (D2), instead of flattening everything into one revision-id field:
+
+- `environment` ref present → **Deployed** (existing behavior, correct).
+- `{prefix}_revision` present (any prefix) → **Pinned**; `workflowRevId = revision id`;
+  the picker highlights it via `selectedValue` (the `EntityPicker` supports
+  `selectedValue` / `displayRender` — research.md §7 — the drawer just never passes them).
+- `{prefix}_variant` present (any prefix) with **no** revision → **Latest**; store the
+  variant id in its own state (`variantId`), set mode to `latest`. **Do not** assign the
+  variant id to `workflowRevId` (that is the current bug — research.md §5).
+
+Switching modes rebuilds the correct references via `buildRunVersionReferences`. Submit
+validation gets a `latest` arm (mode `latest` && no variant selected → "Pick a variant").
+
+### D4 — Settings list rendering ("Bound workflow" column)
+
+The column must use the **same shared classifier** as the drawers (D2) — so agent-created
+`workflow_variant` triggers get a workflow name + Latest tag, not a bare id or "-". Then
+resolve the display name and append a mode tag:
+
+- Latest → `<workflow name>` + a `Latest` tag.
+- Pinned → `<workflow name> · v<n>` (or just the name if the version isn't resolvable).
+- Deployed → `<workflow name> @ <env>`.
+
+Resolve the display name (workflow molecule `artifactName` / variant selectors, as the
+drawers do) rather than showing a raw id; the raw-id rendering is part of what this
+project fixes. If name resolution proves heavy in the table context, the floor is:
+resolved-or-id **plus the mode tag**, never a bare undifferentiated id.
+
+### D5 — Cascader scoping: defer
+
+The settings-mode picker uses `applicationRevisionAdapter`
+(`createWorkflowRevisionAdapter({workflowListAtom: appWorkflowsListQueryStateAtom})`),
+which lists **every** application workflow in the project, unscoped to the trigger's app —
+part of the "weird options" complaint. This is a pre-existing issue orthogonal to Latest.
+**Defer to a follow-up issue.** Keep this PR tight.
+
+### D6 — Migration / compatibility: none
+
+- Triggers pinned by `fe4a01f` in the last day (dev stacks) carry an explicit
+  `{prefix}_revision` (including `workflow_revision` for agent triggers). After the revert
+  they simply render as **Pinned** via the prefix-symmetric classifier — correct and
+  harmless; they stay pinned until re-pointed.
+- Agent-created and pre-pin variant-only triggers become correctly-rendered **Latest**.
+- A re-pick in the drawer silently migrates `workflow_*` refs to `application_*` (accepted
+  — see D2).
+- No stored data changes shape. **No migration.**

--- a/docs/design/trigger-latest-binding/context.md
+++ b/docs/design/trigger-latest-binding/context.md
@@ -1,242 +1,203 @@
 # Context: Trigger "Latest" binding
 
+README.md explains how trigger binding and fire-time resolution work. This file
+explains why the project exists, what it will and will not do, and each design
+decision with its trade-offs.
+
 ## The problem
 
-A trigger (a cron **schedule** or a provider-event **subscription**) binds to a workflow
-so it knows what to run when it fires. Today a trigger can bind three ways in intent, but
-the product only exposes two:
+A trigger can bind to a workflow in three ways. The product exposes two:
 
-- **Pinned** — run one exact revision, frozen. The UI supports this.
-- **Deployed** — run whatever revision is deployed to an environment. The UI supports
-  this.
-- **Latest** — run the newest revision of a variant, re-resolved on every fire. **The UI
-  cannot express or render this**, even though the backend already implements it.
+- **Pinned**: run one exact revision, frozen. The UI supports this.
+- **Deployed**: run whatever is deployed to an environment. The UI supports this.
+- **Latest**: run the newest revision of a variant, resolved at each fire. The backend
+  supports this. The UI cannot express it, and it renders triggers that use it as
+  broken.
 
-The backend follows-latest whenever the stored references name a variant (or artifact)
-but no revision: the dispatcher rebuilds the invoke request from the *raw stored
-references* on every fire, and the workflow service resolves the variant HEAD fresh when
-no revision ref is present (see research.md §1). Agent-created triggers already rely on
-this — the `create_schedule` / `create_subscription` ops context-bind only the variant id.
+Three frontend defects cause this:
 
-Three things broke because the frontend never modeled Latest:
+1. **Edit mis-renders a variant-only trigger.** The drawer prefill takes the variant id
+   from the stored references and puts it in a revision field. Revision lookups fail on
+   a variant id, so the drawer shows an empty, required "Select workflow revision"
+   field. The trigger has a valid binding; the UI says it has none. Saving is blocked,
+   even for a name-only edit.
 
-1. **The FE mis-renders a variant-only trigger.** Edit-prefill takes the variant id out of
-   `application_variant.id` and feeds it to revision-only selectors, which return null, so
-   the "Which version runs?" section shows an empty "Select workflow revision" placeholder
-   under a required asterisk — as if the trigger had no binding, when it has a perfectly
-   valid follow-latest binding.
+2. **The frontend never reads the `workflow_*` reference keys.** The drawers read
+   `application_revision`, then `application_variant`, then `workflow_revision`. The
+   settings list reads a similar chain. Neither reads `workflow_variant`. Agent-created
+   triggers store exactly `{workflow_variant: {id}}`, so the UI treats them as unbound
+   and the settings list shows "-".
 
-2. **The FE read paths never read the `workflow_*` reference family** — and agent-created
-   triggers store exactly `{workflow_variant: {id}}` (research.md §10). The drawer
-   prefills read `application_revision ?? application_variant ?? workflow_revision`; the
-   settings list reads `application ?? application_variant ?? application_revision`.
-   Neither reads `workflow_variant`. The `fe4a01f` pin "fixed" agent triggers only
-   because, being prefix-agnostic, it wrote `workflow_revision` — which the drawers DO
-   read. So a plain revert with `application_*`-only FE work would leave an agent trigger
-   prefilling null, rendering the empty required picker, blocking even a name-only edit
-   on submit validation, and showing "-" in the settings list. The FE classifier must be
-   **prefix-symmetric** (decision D2).
+3. **A backend workaround hid the frontend gaps.** PR #5103 made the create and edit
+   endpoints pin a bare variant reference to its head revision at save time. The
+   frontend then always found a revision key it could read. But the trigger stopped
+   following new commits, which defeats the point of a variant-only binding. Mahmoud
+   closed that PR on 2026-07-09. The pin commit still sits on its local lane; Phase A
+   removes it.
 
-3. **A backend workaround was added to hide those FE gaps.** Commit `fe4a01f` (lane
-   `fix/trigger-revision-default-head`, PR #5103) made `_validate_references` **pin** a
-   bare variant reference to its current HEAD revision at create/edit time, so the FE
-   always receives a revision key it reads. That freezes follow-latest at save time — it
-   trades a correct-but-unrendered binding for a wrong-but-rendered one. It must be
-   reverted; the fix belongs on the frontend (render Latest, read all prefixes), not on
-   the write path.
+The fix belongs on the frontend read paths, not on the backend write path.
 
 ## Goals
 
-- Add a first-class **Latest** binding mode to both trigger drawers: the user picks a
-  variant and the trigger follows its newest revision, resolved at each fire.
-- Correctly **round-trip** all three modes through create → edit → save without losing or
-  corrupting the binding — **for every reference prefix the backend accepts**
+- Add a first-class **Latest** mode to both trigger drawers. The user picks a variant;
+  the trigger follows its newest revision.
+- Round-trip all three modes through create, edit, and save without corrupting the
+  binding. This must work for every reference prefix the backend accepts
   (`application_*`, `workflow_*`, `evaluator_*`), so agent-created triggers render too.
-- **Revert** the create-time pin so variant-only means follow-latest again, while keeping
-  the unrelated-but-good fix from the same lane (typed `TriggerReferenceInvalid` → HTTP
-  422 on the *subscription* create/edit endpoints, which previously surfaced 500s; the
-  schedule endpoints already had the handler — research.md §3).
-- **Render** Latest triggers honestly in the settings list ("Bound workflow" column),
-  using the same prefix-symmetric classifier as the drawers.
-- **Fix the wording** in the op catalog: post-revert, the `commit_revision` description's
-  claim that "existing schedules and subscriptions keep pointing at the old revision" is
-  actively wrong for the common agent case (a variant-bound self-schedule DOES pick up
-  the new commit). This is a correctness fix, not polish (research.md §9).
+- Keep the pin out of the codebase, and salvage the one good fix from the closed PR:
+  the subscription create and edit endpoints should return 422, not 500, when a
+  reference does not resolve. The schedule endpoints already return 422.
+- Show Latest triggers honestly in the settings list, using the same classification
+  logic as the drawers.
+- Fix the SDK op-catalog descriptions. Without the pin, the claim that "existing
+  schedules and subscriptions keep pointing at the old revision" is wrong for
+  variant-bound triggers: they pick up new commits on the next fire. An agent that
+  trusts the current text will reason wrongly about its own schedules.
 
-## Non-goals (explicitly out of scope)
+## Non-goals
 
-- **Recording which revision actually ran on each delivery** — issue **#5110**, assigned
-  to jp. Latest triggers resolve HEAD at fire time; the delivery record does not yet
-  capture the resolved revision. Out of scope here; mentioned so a reader does not expect
-  it.
-- **Scoping the settings-mode picker to the trigger's own app.** The Pinned/Latest picker
-  in settings lists *every* application workflow in the project (unscoped) — part of the
-  "weird options" complaint. Real, but orthogonal to Latest. **Defer to a follow-up
-  issue** to keep this PR tight (see decision D5).
-- **Two pre-existing dangling-reference render gaps** (acknowledged so they are not
-  mistaken for regressions from this work): a **Pinned** trigger whose revision was
-  archived renders an empty picker, and a **Deployed** trigger whose environment was
-  deleted renders a blank select. Both predate this project and are unchanged by it.
-- **A data migration.** None is needed (see decision D6).
-- **A new wire field / explicit binding marker.** Considered and declined for now
-  (see decision D2).
+- **Recording which revision actually ran on each delivery.** Latest triggers resolve
+  the head at fire time, and the delivery record does not capture the result. That is
+  issue #5110, assigned to jp.
+- **Scoping the version picker to the trigger's own app.** In settings, the picker
+  lists every application workflow in the project. Real problem, unrelated to Latest.
+  Deferred to a follow-up issue (decision D5).
+- **Two pre-existing render gaps for dangling references.** A Pinned trigger whose
+  revision was archived shows an empty picker. A Deployed trigger whose environment was
+  deleted shows a blank select. Both predate this project and stay unchanged. Listed so
+  nobody mistakes them for regressions.
+- **A data migration.** None is needed (decision D6).
+- **A new wire field or binding marker.** Considered and declined for now (decision
+  D2).
 
 ## Design decisions
 
-### D1 — UX: a third rail item ("Latest" | "Pinned" | "Deployed")
+### D1: The control is a third rail item, "Latest | Pinned | Deployed"
 
-The "Which version runs?" control is a left rail of mutually exclusive modes with a
-mode-specific control on the right (`RunVersionField.tsx`). Today the rail has two items:
-`Pinned` (a workflow→variant→revision cascader) and `Deployed` (an environment select).
+The "Which version runs?" control (`RunVersionField.tsx`) is a left rail of modes with
+a mode-specific control on the right. Today the rail has two items: Pinned (a workflow
+to variant to revision cascader) and Deployed (an environment select).
 
-**Recommendation: add a third peer rail item, `Latest`.** Order: `Latest | Pinned |
-Deployed`.
+We add Latest as a third peer item, first in the list. When selected, the right side
+shows a variant picker: workflow, then variant, no revision level.
 
-Why a peer rail item rather than a leaf inside the Pinned picker or a checkbox:
+Why a peer item and not something smaller:
 
-- The three modes are three **binding policies** (follow-head / frozen / follow-deployment).
-  A rail already means "pick a policy." Making Latest a peer keeps the policy explicit and
-  visible, and it round-trips cleanly because the mode is derivable from the stored
-  reference shape.
-- A "Latest revision" *leaf inside the Pinned cascader* would bury the policy inside a
-  tree whose other leaves are frozen revisions, and it complicates the picker's value
-  model (a variant node and a revision node mean different things). Rejected.
-- A *checkbox* ("follow latest") is a hidden modifier on Pinned; users miss it and it
-  muddies the "one control, one policy" model. Rejected.
-- Note **Deployed is already a kind of "floating" binding** — it also re-resolves at fire
-  time, just against an environment instead of a variant HEAD. Latest is the variant-HEAD
-  sibling of that idea, so a third peer is conceptually consistent.
+- The three modes are three binding policies: follow the head, freeze, follow a
+  deployment. A rail already means "pick a policy". A peer item keeps the policy
+  visible.
+- A "Latest" leaf inside the Pinned cascader would bury the policy in a tree of frozen
+  revisions, and it would give the picker two value types that mean different things.
+  Rejected.
+- A "follow latest" checkbox is a hidden modifier on Pinned. Users would miss it.
+  Rejected.
+- Deployed already re-resolves at fire time. Latest is the same idea aimed at a variant
+  head instead of an environment, so a third peer reads as consistent.
 
-Copy:
+Hint copy:
 
-- **Latest** — hint: *"Always runs the newest committed revision of this variant
-  (ignores environments)."* The parenthetical disambiguates from Deployed, which is also
-  a floating binding. Right-side control: a variant picker (workflow → variant; no
-  revision leaf). The selection resolves to the variant node.
-- **Pinned** — hint (unchanged): *"Runs one exact variant + revision."* Cascader unchanged.
-- **Deployed** — hint (unchanged): *"Follows the revision deployed to an environment."*
+- Latest: "Always runs the newest committed revision of this variant (ignores
+  environments)." The parenthetical separates it from Deployed, which also floats.
+- Pinned (unchanged): "Runs one exact variant + revision."
+- Deployed (unchanged): "Follows the revision deployed to an environment."
 
-**Default mode — OPEN QUESTION for Mahmoud (do not decide silently).** Recommendation:
-new triggers default to **Latest** (the most common intent and the shape agent-created
-triggers already use). But when the drawer opens from a context carrying a *concrete
-revision* — e.g. the playground positioned on a specific revision — should it instead
-open **Pinned**, pre-selected to that revision? Note the current create-mode default-bind
-already discards the revision context (it seeds the selection with the variant id and a
-hardcoded `revision: 0` — `TriggerScheduleDrawer.tsx:496-507`). Recommendation: **yes**,
-honor a concrete revision context as Pinned-preselected; plain contexts default to
-Latest. Flagged as Mahmoud's call in status.md.
+**Open question for Mahmoud: the default mode.** Recommendation: new triggers default
+to Latest. It is the most common intent, and it is the shape agent-created triggers
+already use. But when the drawer opens from a context that carries a concrete revision
+(for example, the playground positioned on a specific revision), it should probably
+open in Pinned with that revision pre-selected. Today the code discards that context
+and hardcodes `revision: 0` (`TriggerScheduleDrawer.tsx:496-507`). Recommendation:
+honor a concrete revision as Pinned; default to Latest everywhere else.
 
-Implementation note: `buildRunVersionReferences` already emits a variant-only ref when the
-selected leaf id equals the variant id (`isRevision = !!meta.variantId && leafId !==
-meta.variantId`, research.md §4). So "Latest" is largely a matter of letting the user
-*select the variant node* and tagging the mode, not new reference-assembly logic.
+### D2: No new wire field; leaving out the revision IS the "latest" signal; reads accept all prefixes
 
-### D2 — Reference shape: no new field; absence of a revision ref IS the policy; reads are prefix-symmetric
+The three modes map to three reference shapes the drawers submit:
 
-Classified by semantic role (per the design-interfaces skill), all three are
-**routing / binding-policy** references, owned by the trigger author, changed only on
-edit:
+| Mode     | Submitted references                              |
+|----------|---------------------------------------------------|
+| Latest   | `{application: {id}, application_variant: {id}}`  |
+| Pinned   | `{application: {id}, application_revision: {id}}` |
+| Deployed | `{environment: {slug}, application: {slug}}`      |
 
-| Mode     | Submitted references (FE drawers)                     |
-|----------|-------------------------------------------------------|
-| Latest   | `{application: {id}, application_variant: {id}}`       |
-| Pinned   | `{application: {id}, application_revision: {id}}`      |
-| Deployed | `{environment: {slug}, application: {slug}}`           |
+The absence of a revision reference means "resolve the head at fire time". The backend
+already enforces exactly this contract (research.md §1). No new field is required.
 
-The **absence of a revision reference is the follow-latest signal.** This is already the
-contract the backend enforces (`_ensure_request_revision` resolves HEAD when
-`request.data.revision` is absent and no revision ref is present — research.md §1). No new
-field is required.
+**The marker question, flagged for Mahmoud.** Should Latest instead carry an explicit
+marker, such as `binding: "latest"`? Recommendation: no, not now. The shape is
+unambiguous, and the backend already keys off it. A marker would be a second source of
+truth for one fact, and the two could drift apart. The one real risk of shape-only is
+that a reader mistakes a variant-only reference for an unfinished binding rather than a
+deliberate one. That exact misread produced the pin PR. The remedy is rendering: show a
+Latest tag so the binding looks intentional. Revisit the marker only if we ever need a
+policy the shape cannot express, for example "freeze at whatever was deployed when I
+created this trigger".
 
-**Prefix rule — writes are `application_*`, reads are prefix-symmetric.** The trigger
-drawers and `buildRunVersionReferences` *write* the `application_*` family. But
-agent-created triggers *store* `workflow_variant` (research.md §10), and the backend is
-prefix-agnostic — it detects the prefix among `application` / `evaluator` / `workflow`
-(`api/oss/src/core/triggers/service.py:782-789`) and follows-latest identically for all.
-So every FE **read path** (drawer prefill, settings-list rendering) must classify with
-**one shared prefix-symmetric classifier**, mirroring the backend's own prefix detection:
+**The prefix rule: write `application_*`, read every prefix.** The drawers write the
+`application_*` family. Agent-created triggers store `workflow_variant`. The backend
+accepts three prefixes (`application`, `workflow`, `evaluator`) and treats them alike
+(`api/oss/src/core/triggers/service.py:782-789`). So every frontend read must classify
+references through one shared, prefix-symmetric function:
 
-> for `prefix` in `{application, workflow, evaluator}`:
-> `{prefix}_revision` present → **Pinned** carrying that revision id;
-> `{prefix}_variant` present with no `{prefix}_revision` → **Latest** carrying that
-> variant id; `environment` present → **Deployed**.
+> For each prefix in {application, workflow, evaluator}: a `{prefix}_revision` key
+> means Pinned with that revision; a `{prefix}_variant` key with no `{prefix}_revision`
+> means Latest with that variant; an `environment` key means Deployed.
 
-This classifier is shared by both drawers AND both settings sections (plan.md Phases
-B–D). An earlier draft of this decision said "FE work stays on `application_*`" — that
-sentence encoded the agent-trigger rendering bug and is retracted.
+Both drawers and both settings tables use this one function (plan.md, Phases B to D).
+An earlier draft kept frontend work on `application_*` only. That draft encoded the
+agent-trigger rendering bug and is retracted.
 
-**Accepted silent prefix migration on re-pick.** The resubmit path is already safe:
-editing without re-picking echoes the stored references verbatim
-(`RunVersionField.tsx:63` `fallbackReferences`, fed from the stored refs at
-`TriggerScheduleDrawer.tsx:622` / `TriggerSubscriptionDrawer.tsx:697`), so a
-`workflow_variant` trigger keeps its shape across a name-only edit. An active re-pick in
-the drawer rewrites the references to `application_*` — harmless, since the backend is
-prefix-agnostic. We accept this as a deliberate, silent prefix migration on user edit; no
-code needs to preserve the `workflow_*` prefix on write.
+**Accepted: a re-pick silently migrates the prefix.** Editing a trigger without
+touching the picker resubmits the stored references verbatim
+(`RunVersionField.tsx:63`), so a `workflow_variant` trigger keeps its shape across a
+name-only edit. If the user actively re-picks in the drawer, the references are
+rewritten to `application_*`. The backend does not care, so we accept this instead of
+adding prefix-preserving write logic.
 
-**The marker question (flagged explicitly).** Should Latest carry an explicit marker, e.g.
-`binding: "latest"`, instead of relying on the absence of a revision ref?
+### D3: Edit opens in the mode the stored shape implies
 
-- **Recommendation: no, not now.** The shape is already unambiguous and the backend
-  already keys off it. A marker would be a *second* source of truth for one policy and
-  could drift from the ref shape (the classic two-fields-one-fact bug).
-- The one real risk the marker would remove: a future reader (human or code) misreading
-  variant-only as "incomplete / binding not finished" rather than "intentionally latest."
-  That is exactly the misread that produced the `fe4a01f` workaround. **But the correct
-  remedy for that is FE rendering** — show a "Latest" tag so the binding reads as
-  deliberate — not a wire marker.
-- **When to revisit:** if we ever need a policy that the ref shape *cannot* express — e.g.
-  "freeze at the revision deployed at create time" (which is neither today's Pinned nor
-  Deployed), or per-trigger opt-out of follow-latest while still naming a variant. At that
-  point an explicit `binding` enum earns its keep. Until then, absence-of-revision is
-  canonical and consistent with the rest of the workflow-invoke contract.
+Prefill classifies the stored references with the shared function from D2, instead of
+flattening everything into one revision-id field:
 
-### D3 — Edit round-trip
+- An `environment` reference: open in Deployed. This already works.
+- A `{prefix}_revision` reference, any prefix: open in Pinned, with that revision shown
+  as selected in the picker. The picker component already supports showing a selected
+  value (`selectedValue` / `displayRender`, research.md §7); the drawer just never
+  passes it.
+- A `{prefix}_variant` reference with no revision, any prefix: open in Latest with that
+  variant selected. Do not put the variant id in the revision field; that is the
+  current bug (research.md §5).
 
-Prefill must **classify the stored shape into a mode** via the shared prefix-symmetric
-classifier (D2), instead of flattening everything into one revision-id field:
+Switching modes rebuilds the references through `buildRunVersionReferences`. Submit
+validation gains a Latest arm: Latest with no variant selected is an error ("Pick a
+variant").
 
-- `environment` ref present → **Deployed** (existing behavior, correct).
-- `{prefix}_revision` present (any prefix) → **Pinned**; `workflowRevId = revision id`;
-  the picker highlights it via `selectedValue` (the `EntityPicker` supports
-  `selectedValue` / `displayRender` — research.md §7 — the drawer just never passes them).
-- `{prefix}_variant` present (any prefix) with **no** revision → **Latest**; store the
-  variant id in its own state (`variantId`), set mode to `latest`. **Do not** assign the
-  variant id to `workflowRevId` (that is the current bug — research.md §5).
+### D4: The settings list names the workflow and tags the mode
 
-Switching modes rebuilds the correct references via `buildRunVersionReferences`. Submit
-validation gets a `latest` arm (mode `latest` && no variant selected → "Pick a variant").
+The "Bound workflow" column classifies with the same shared function, resolves the
+workflow's display name, and appends a mode tag:
 
-### D4 — Settings list rendering ("Bound workflow" column)
+- Latest: workflow name plus a `Latest` tag.
+- Pinned: workflow name plus `v<n>`, or just the name if the version cannot be
+  resolved.
+- Deployed: workflow name plus `@ <environment>`.
 
-The column must use the **same shared classifier** as the drawers (D2) — so agent-created
-`workflow_variant` triggers get a workflow name + Latest tag, not a bare id or "-". Then
-resolve the display name and append a mode tag:
+Today the column prints a raw id, or "-" for agent-created triggers. If name resolution
+proves heavy inside the table, the floor is: resolved-name-or-id plus the mode tag.
+Never a bare id with no tag.
 
-- Latest → `<workflow name>` + a `Latest` tag.
-- Pinned → `<workflow name> · v<n>` (or just the name if the version isn't resolvable).
-- Deployed → `<workflow name> @ <env>`.
+### D5: Defer the picker-scoping fix
 
-Resolve the display name (workflow molecule `artifactName` / variant selectors, as the
-drawers do) rather than showing a raw id; the raw-id rendering is part of what this
-project fixes. If name resolution proves heavy in the table context, the floor is:
-resolved-or-id **plus the mode tag**, never a bare undifferentiated id.
+The settings-mode picker lists every application workflow in the project, not just the
+trigger's own app. Real problem (part of the "weird options" complaint), unrelated to
+Latest. Deferred to a follow-up issue to keep this project tight.
 
-### D5 — Cascader scoping: defer
+### D6: No migration
 
-The settings-mode picker uses `applicationRevisionAdapter`
-(`createWorkflowRevisionAdapter({workflowListAtom: appWorkflowsListQueryStateAtom})`),
-which lists **every** application workflow in the project, unscoped to the trigger's app —
-part of the "weird options" complaint. This is a pre-existing issue orthogonal to Latest.
-**Defer to a follow-up issue.** Keep this PR tight.
-
-### D6 — Migration / compatibility: none
-
-- Triggers pinned by `fe4a01f` in the last day (dev stacks) carry an explicit
-  `{prefix}_revision` (including `workflow_revision` for agent triggers). After the revert
-  they simply render as **Pinned** via the prefix-symmetric classifier — correct and
-  harmless; they stay pinned until re-pointed.
-- Agent-created and pre-pin variant-only triggers become correctly-rendered **Latest**.
-- A re-pick in the drawer silently migrates `workflow_*` refs to `application_*` (accepted
-  — see D2).
-- No stored data changes shape. **No migration.**
+- Triggers that the closed PR's pin touched on dev stacks carry an explicit revision
+  reference. They classify as Pinned, render correctly, and stay pinned until someone
+  re-points them. Correct and harmless.
+- Older variant-only triggers, including all agent-created ones, classify as Latest and
+  finally render correctly.
+- A re-pick in the drawer silently migrates `workflow_*` references to `application_*`
+  (accepted, see D2).
+- Stored data never changes shape. No migration.

--- a/docs/design/trigger-latest-binding/plan.md
+++ b/docs/design/trigger-latest-binding/plan.md
@@ -1,281 +1,278 @@
 # Plan: Trigger "Latest" binding
 
-Six phases, A–F. Each is sized for a narrow subagent and names exact files. Phases B–D
-are frontend and depend on A being merged/available only for end-to-end QA, not for
-coding (the FE change is self-contained). E and F ride existing lanes / are verification.
+Six phases, A to F. Each names exact files and is sized for a narrow subagent. Phases
+B, C, and D are one logical frontend change, split into smaller units. Phase A
+(backend) can run in parallel with the frontend work; the frontend change is
+self-contained and only needs A for end-to-end QA. Phase E rides existing lanes. Phase
+F is verification.
 
-Dependency order: **A → (B → C → D) → E → F**. B/C/D are one logical FE change; split only
-if a subagent needs smaller units. A and E can proceed in parallel with the FE work.
+Dependency order: A, then B then C then D, then E, then F.
 
-**Cross-phase invariant (blocker C1, review round 1):** every FE *read* of trigger
-references — drawer prefill (Phase C) and settings-list rendering (Phase D) — goes
-through **one shared prefix-symmetric classifier** (defined in Phase B) that handles the
-`application_*`, `workflow_*`, and `evaluator_*` families, mirroring the backend's prefix
-detection at `api/oss/src/core/triggers/service.py:782-789`. Agent-created triggers store
-`{workflow_variant: {id}}` (research.md §10); the current FE reads never touch
-`workflow_variant`, and only the `fe4a01f` pin (which wrote `workflow_revision`) made them
-render. Any phase that reads references without the shared classifier reintroduces the
-bug the pin papered over. Writes stay `application_*` (a re-pick silently migrates the
-prefix — accepted, context.md D2).
+**The invariant every phase must respect:** every frontend read of trigger references
+goes through one shared, prefix-symmetric classifier, defined in Phase B. It handles
+the `application_*`, `workflow_*`, and `evaluator_*` families, mirroring the backend's
+prefix detection at `api/oss/src/core/triggers/service.py:782-789`. Agent-created
+triggers store `{workflow_variant: {id}}` (research.md §10), and no current frontend
+read recognizes that key. Any phase that reads references without the shared classifier
+reintroduces that bug. Writes stay `application_*`; an active re-pick silently migrates
+the prefix (accepted, context.md D2).
 
 ---
 
-## Phase A — Backend: un-pin, keep the 422 fix, reshape the test
+## Phase A: Backend. Remove the pin, keep the 422 fix, reshape the tests.
 
-**This reworks the existing lane `fix/trigger-revision-default-head`; PR #5103 becomes the
-implementation PR for this project** (retitle it to describe the follow-latest behavior,
-not the pin).
+PR #5103 (the create-time pin) was closed unmerged on 2026-07-09: pinning at save time
+is the wrong behavior. Its commit still sits on the local lane
+`fix/trigger-revision-default-head`. Phase A reworks that lane into the follow-latest
+backend change and opens a fresh PR. Do not reuse #5103.
 
-### A1. Revert the create-time pin
+### A1. Remove the create-time pin
 
 File: `api/oss/src/core/triggers/service.py`, `_validate_references`.
 
-- Delete the pin block (research.md §2, currently `:820-829`):
-  ```python
-  if (environment_ref is None and workflow_variant_ref is not None
-      and workflow_revision_ref is None):
-      references[f"{prefix}_revision"] = Reference(...)
-  ```
-- Restore the pre-`fe4a01f` validate-only docstring (`:756-773`). Recover the exact old
-  text with `git show fe4a01f^:api/oss/src/core/triggers/service.py` (the "…without
-  pinning it… means 'resolve latest at trigger time'… dispatcher re-resolves from the raw
-  references on every fire… latest-tracking is preserved" version).
-- **Keep** the `retrieve_workflow_revision` call and the `revision is None → raise
-  TriggerReferenceInvalid` guard (graceful-failure validation). The extracted
-  `workflow_variant_ref` / `workflow_revision_ref` locals may stay or be re-inlined; either
-  is fine.
+- Delete the pin block (research.md §2, currently `:820-829`): the branch that writes
+  `references[f"{prefix}_revision"]` when a variant reference has no revision.
+- Restore the pre-pin, validate-only docstring (`:756-773`). Recover the exact old text
+  with `git show fe4a01f^:api/oss/src/core/triggers/service.py`. Its key sentences:
+  validation deliberately does not overwrite the stored references; a variant without a
+  revision means "resolve latest at trigger time"; the dispatcher re-resolves from the
+  raw references on every fire.
+- Keep the `retrieve_workflow_revision` call (`:807-814`) and the
+  `revision is None → raise TriggerReferenceInvalid` guard (`:815-818`). That is the
+  graceful-failure validation, and it stays. The extracted `workflow_variant_ref` /
+  `workflow_revision_ref` locals can stay or be re-inlined; either is fine.
 
 ### A2. Keep the 422 handlers
 
-File: `api/oss/src/apis/fastapi/triggers/router.py`. **No change** — leave the
-`TriggerReferenceInvalid → HTTPException(422)` handlers on `create_subscription`
-(`:1006-1007`) and `edit_subscription` (`:1126-1127`) exactly as `fe4a01f` added them.
-Verify they survive the lane rework. (Scope note: only the *subscription* endpoints had
-the 500 gap; `create_schedule` / `edit_schedule` already had the handler at `:1283-1284`
-/ `:1379-1380` — research.md §3.)
+File: `api/oss/src/apis/fastapi/triggers/router.py`. No change; just verify these
+survive the lane rework. `create_subscription` (`:1006-1007`) and `edit_subscription`
+(`:1126-1127`) translate `TriggerReferenceInvalid` into HTTP 422. Before the pin lane,
+those two endpoints surfaced a 500. The schedule endpoints already had the same
+handlers (`:1283-1284`, `:1379-1380`; research.md §3).
 
-### A3. Reshape the test
+### A3. Reshape the tests
 
 File: `api/oss/tests/pytest/unit/triggers/test_triggers_reference_defaulting.py`.
 
-- **Delete** the pinning tests: `TestValidateReferencesPinsHead.
-  test_variant_only_is_pinned_to_head_revision`, `.test_application_prefix_variant_only_is
-  _pinned`, and the whole `TestCreateScheduleDefaultsVariantToHead` /
-  `TestCreateSubscriptionDefaultsVariantToHead` classes' *pins-head* cases
-  (`test_create_schedule_pins_head_revision_when_only_variant_given`,
-  `test_create_subscription_pins_head_revision_when_only_variant_given`).
-- **Keep / adapt** the validation-still-works cases:
-  - zero-revision variant → `TriggerReferenceInvalid`
-    (`test_variant_with_no_revisions_raises_typed_error`,
-    `test_create_schedule_raises_when_variant_has_no_revisions`,
-    `test_create_subscription_raises_when_variant_has_no_revisions`) — keep as-is.
-  - refs-left-verbatim: `test_artifact_only_reference_stays_unpinned`,
-    `test_environment_reference_stays_unpinned`,
-    `test_revision_already_present_is_left_untouched` — keep.
-  - explicit-revision-untouched through the service entry points:
-    `test_create_schedule_leaves_explicit_revision_untouched` (`:209`) — keep (it
-    asserts a caller-pinned revision survives create, which stays true after the
-    revert). No subscription twin exists today (`TestCreateSubscriptionDefaults…` has
-    only the pins-head and raises cases); **add one** for parity while reshaping.
-- **Add** an explicit "variant-only is NOT rewritten" assertion (the inverse of the
-  deleted pin test): after `_validate_references` on `{"application_variant": {"id": ...}}`,
-  assert `"application_revision" not in references` and the input dict is unchanged. This
-  locks the revert.
-- Rename the module + docstring away from "defaulting"/"pins HEAD" toward
-  "validate-only / follow-latest" (e.g. `test_triggers_reference_validation.py`); update
-  the top-of-file docstring which currently describes pinning.
+Delete the pins-head cases:
 
-**Verify A:** `cd api && py-run-tests` (or target the triggers unit tests). Then a live
-check: create a variant-only trigger, confirm the stored references contain **no**
-`application_revision`, commit a new revision, fire it, confirm HEAD runs (manual QA in
-Phase F).
+- `TestValidateReferencesPinsHead.test_variant_only_is_pinned_to_head_revision`
+- `TestValidateReferencesPinsHead.test_application_prefix_variant_only_is_pinned`
+- `test_create_schedule_pins_head_revision_when_only_variant_given`
+- `test_create_subscription_pins_head_revision_when_only_variant_given`
+
+Keep the validation cases:
+
+- Zero-revision variant raises: `test_variant_with_no_revisions_raises_typed_error`,
+  `test_create_schedule_raises_when_variant_has_no_revisions`,
+  `test_create_subscription_raises_when_variant_has_no_revisions`.
+- References left verbatim: `test_artifact_only_reference_stays_unpinned`,
+  `test_environment_reference_stays_unpinned`,
+  `test_revision_already_present_is_left_untouched`.
+- Explicit revision survives create: `test_create_schedule_leaves_explicit_revision_untouched`.
+  No subscription twin exists today; add one for parity.
+
+Add the inverse of the deleted pin test: after `_validate_references` on
+`{"application_variant": {"id": ...}}`, assert `"application_revision" not in
+references` and the input dict is unchanged. This locks the follow-latest behavior.
+
+Rename the module away from "defaulting", for example
+`test_triggers_reference_validation.py`, and rewrite the module docstring, which
+currently describes pinning.
+
+Verify: `cd api && py-run-tests`. The live follow-latest check happens in Phase F.
 
 ---
 
-## Phase B — Frontend: `RunVersionField` Latest mode + the shared classifier
+## Phase B: Frontend. Latest mode in `RunVersionField`, plus the shared classifier.
 
-File: `web/packages/agenta-entity-ui/src/gatewayTrigger/drawers/shared/RunVersionField.tsx`
-(the classifier may live in a sibling `shared/` module, e.g. `triggerReferences.ts`).
+File: `web/packages/agenta-entity-ui/src/gatewayTrigger/drawers/shared/RunVersionField.tsx`.
+The classifier may live in a sibling `shared/` module, for example
+`triggerReferences.ts`.
 
-- **Add the shared prefix-symmetric classifier** (the cross-phase invariant). A pure
-  exported function, consumed by both drawers (Phase C) and both settings sections
-  (Phase D):
+Add the shared prefix-symmetric classifier, a pure exported function consumed by both
+drawers (Phase C) and both settings sections (Phase D):
 
-  ```typescript
-  // classifyTriggerReferences(refs) → mirror of the backend prefix detection
-  // (api/oss/src/core/triggers/service.py:782-789)
-  // - refs.environment present → {mode: "environment", environmentSlug, appSlug}
-  // - for prefix in ["application", "workflow", "evaluator"]:
-  //     refs[`${prefix}_revision`]?.id → {mode: "revision", revisionId, workflowId?}
-  //     refs[`${prefix}_variant`]?.id (no `${prefix}_revision`) →
-  //         {mode: "latest", variantId, workflowId?}
-  // - nothing matched → {mode: null}
-  ```
+```typescript
+// classifyTriggerReferences(refs): mirrors the backend prefix detection
+// (api/oss/src/core/triggers/service.py:782-789)
+// - refs.environment present -> {mode: "environment", environmentSlug, appSlug}
+// - for prefix in ["application", "workflow", "evaluator"]:
+//     refs[`${prefix}_revision`]?.id -> {mode: "revision", revisionId, workflowId?}
+//     refs[`${prefix}_variant`]?.id with no `${prefix}_revision` ->
+//         {mode: "latest", variantId, workflowId?}
+// - nothing matched -> {mode: null}
+```
 
-  A `{workflow_variant: {id}}` input (agent-created trigger) MUST classify as Latest —
-  this is the blocker-C1 case; unit-test it in Phase F.
+A `{workflow_variant: {id}}` input (an agent-created trigger) MUST classify as Latest.
+Unit-test that case in Phase F.
+
+Then in `RunVersionField.tsx`:
+
 - Extend `RunVersionBindMode` (`:10`) to `"latest" | "revision" | "environment"`.
-- Add a third rail item (`:104-112`): `{value:"latest", label:"Latest"}`, ordered
+- Add a third rail item (`:104-112`): `{value: "latest", label: "Latest"}`, ordered
   `Latest | Pinned | Deployed`.
-- Add a Latest branch to the render (`:113-141`):
-  - hint: *"Always runs the newest committed revision of this variant (ignores
-    environments)."* (disambiguates from Deployed — context.md D1/U2).
-  - a **variant** picker: reuse the popover-cascader but present workflow→variant (no
-    revision leaf). Simplest path: pass the same `revisionAdapter` and let the user select
-    the variant node; on select, emit a selection whose `id === metadata.variantId` so
-    `buildRunVersionReferences` produces the variant-only ref. If a variant-scoped adapter
-    is cleaner, add one alongside `applicationRevisionAdapter` in the drawers (out of this
-    file). Keep the decision local and documented in a one-line comment.
-- `buildRunVersionReferences` (`:29-64`): add an explicit `latest` arm for clarity —
-  when `bindMode === "latest"`, return `{application:{id}?, application_variant:{id:
-  variantId}}` from the current selection/`variantId`, never a revision ref. (Functionally
-  the existing `else` already does this when `leafId === variantId`; the explicit arm makes
-  intent legible and prevents a future edit from routing Latest into `application_revision`.)
-  Writes stay `application_*`; the edit-without-repick fallback (`:63`) keeps echoing
-  `fallbackReferences` verbatim so a stored `workflow_*` shape survives metadata-only
-  edits (research.md §5, "resubmit is already prefix-safe").
-- Accept a `selectedValue` prop and forward it to the `EntityPicker` (`:118-124`) so Pinned
-  mode reflects the current binding (research.md §6). Latest mode's picker shows the
-  selected variant analogously.
+- Add a Latest branch to the render (`:113-141`). Hint: "Always runs the newest
+  committed revision of this variant (ignores environments)." Control: a variant
+  picker. Simplest path: reuse the popover-cascader and let the user select the variant
+  node, so the selection's `id` equals `metadata.variantId` and
+  `buildRunVersionReferences` produces the variant-only reference. If a variant-scoped
+  adapter is cleaner, add one next to `applicationRevisionAdapter` in the drawers. Keep
+  the choice local and note it in a one-line comment.
+- `buildRunVersionReferences` (`:29-64`): add an explicit `latest` arm. When
+  `bindMode === "latest"`, return `{application: {id}?, application_variant: {id:
+  variantId}}` and never a revision reference. The existing `else` already does this
+  when the picked leaf is the variant node; the explicit arm makes the intent legible
+  and keeps a future edit from routing Latest into `application_revision`. Keep the
+  edit-without-repick fallback (`:63`) echoing `fallbackReferences` verbatim, so a
+  stored `workflow_*` shape survives metadata-only edits (research.md §5).
+- Accept a `selectedValue` prop and forward it to the `EntityPicker` (`:118-124`), so
+  Pinned mode shows the current binding (research.md §6). Latest mode shows the
+  selected variant the same way.
 
-**No behavioral change to Deployed.** Keep `envHint` / env `Select` as-is.
+No behavior change to Deployed. Keep `envHint` and the environment `Select` as they
+are.
 
 ---
 
-## Phase C — Frontend: drawer prefill + picker value display
+## Phase C: Frontend. Drawer prefill and picker value display.
 
-Files: `TriggerScheduleDrawer.tsx`, `TriggerSubscriptionDrawer.tsx` (same package).
+Files: `TriggerScheduleDrawer.tsx` and `TriggerSubscriptionDrawer.tsx` (same package).
 
-- Add `variantId` (or reuse a clearly-named state) distinct from `workflowRevId`, and let
-  `bindMode` hold `"latest" | "revision" | "environment"`.
-- **Prefill classification** (schedule `:456-479`, subscription `:526-550`): replace the
-  hand-rolled fallback chains with the **shared classifier from Phase B**. The current
-  chains read `application_revision ?? application_variant ?? workflow_revision` and never
-  read `workflow_variant`, so agent-created triggers prefill null (blocker C1 —
-  research.md §5). Via the classifier:
-  - `{mode: "environment"}` → `bindMode = "environment"` (unchanged behavior).
-  - `{mode: "revision", revisionId}` (any prefix, incl. `workflow_revision` from
-    `fe4a01f`-pinned triggers) → `bindMode = "revision"`, `workflowRevId = revisionId`.
-  - `{mode: "latest", variantId}` (any prefix, incl. `workflow_variant` from agent
-    triggers) → `bindMode = "latest"`, `variantId` set. **Do not** assign it to
-    `workflowRevId` (removes the research.md §5 bug).
-  - Delete/replace `extractBoundRevId` (subscription `:116-125`) — it collapses the
-    variant-vs-revision distinction the classifier makes explicit.
-- **Picker value:** pass `selectedValue={workflowRevId}` (Pinned) / the variant id
-  (Latest) into `RunVersionField` so the `EntityPicker` shows the current binding, not a
-  placeholder. Resolve the human label via the existing molecule selectors
-  (`artifactName` / `variantLabel` / `data`), but note those are **revision-only** — for
-  Latest, resolve the *variant* label instead (variant molecule selector), since a variant
-  id won't resolve through revision selectors.
-- **Submit validation:** add a `latest` arm alongside `bindMode === "revision" &&
-  !workflowRevId` (schedule `:595-596`): `bindMode === "latest" && !variantId` →
-  `message.error("Pick a variant")`. Mirror in the subscription drawer. (Post-classifier,
-  an agent trigger in edit mode carries a valid `variantId`, so a name-only edit is no
-  longer blocked — the C1 regression scenario.)
-- **`versionChosen` / summary** (schedule `:700-702`): include the Latest case
-  (`bindMode === "latest" ? !!variantId : …`).
-- **Create-mode default-bind** (schedule `:486-510`, subscription `:552-576`): agent /
-  `defaultReferences` binding provides a variant id — open in Latest with the variant
-  pre-selected. **Pending Mahmoud's answer to the default-mode open question**
-  (context.md D1): if he opts for revision-context honoring, a `defaultReferences` that
-  carries a concrete revision (the current code discards it and hardcodes `revision: 0` —
-  schedule `:496-507`) should instead open **Pinned** pre-selected to that revision.
-  Implement his choice; don't decide silently.
+- Add a `variantId` state, distinct from `workflowRevId`. Let `bindMode` hold
+  `"latest" | "revision" | "environment"`.
+- Prefill (schedule `:456-479`, subscription `:526-550`): replace the hand-rolled
+  fallback chains with the shared classifier from Phase B. The current chains read
+  `application_revision ?? application_variant ?? workflow_revision` and never read
+  `workflow_variant`, so agent-created triggers prefill null (research.md §5). Via the
+  classifier:
+  - `{mode: "environment"}`: `bindMode = "environment"`. Unchanged behavior.
+  - `{mode: "revision", revisionId}` (any prefix, including `workflow_revision` from
+    pin-era triggers): `bindMode = "revision"`, `workflowRevId = revisionId`.
+  - `{mode: "latest", variantId}` (any prefix, including `workflow_variant` from agent
+    triggers): `bindMode = "latest"`, set `variantId`. Do not assign it to
+    `workflowRevId`; that is the current bug.
+  - Delete `extractBoundRevId` (subscription `:116-125`). It collapses the
+    variant-versus-revision distinction the classifier makes explicit.
+- Picker value: pass `selectedValue={workflowRevId}` in Pinned mode and the variant id
+  in Latest mode, so the `EntityPicker` shows the current binding instead of a
+  placeholder. Resolve the human label through the existing molecule selectors
+  (`artifactName` / `variantLabel` / `data`). Those are revision-only, so Latest must
+  resolve the variant label through the variant selectors instead.
+- Submit validation: add a Latest arm next to the existing
+  `bindMode === "revision" && !workflowRevId` check (schedule `:595-596`):
+  `bindMode === "latest" && !variantId` shows "Pick a variant". Mirror it in the
+  subscription drawer. With the classifier in place, an agent trigger in edit mode
+  carries a valid `variantId`, so a name-only edit saves again.
+- `versionChosen` and the summary (schedule `:700-702`): include the Latest case
+  (`bindMode === "latest" ? !!variantId : ...`).
+- Create-mode default binding (schedule `:486-510`, subscription `:552-576`): when the
+  drawer opens with a `defaultReferences` variant id, open in Latest with the variant
+  pre-selected. This part waits on Mahmoud's default-mode answer (context.md D1): if he
+  opts to honor a concrete revision context, a `defaultReferences` that carries a
+  revision should open Pinned, pre-selected to that revision. Today the code discards
+  it and hardcodes `revision: 0` (schedule `:496-507`). Implement his choice; do not
+  decide silently.
 
 ---
 
-## Phase D — Frontend: settings-list rendering
+## Phase D: Frontend. Settings-list rendering.
 
-Files (note the `components/` subfolder — research.md §8):
+Files (note the `components/` subfolder, research.md §8):
 `web/oss/src/components/pages/settings/Triggers/components/GatewaySchedulesSection.tsx`
 and `.../GatewaySubscriptionsSection.tsx`.
 
-- Rework the "Bound workflow" column render (schedules `:116-127`) **on top of the
-  shared classifier from Phase B** — the current read chain (`application ??
-  application_variant ?? application_revision`) never reads `workflow_*`, so an
-  agent-created trigger renders "-" (blocker C1 — research.md §8). Via the classifier:
-  - Resolve the workflow/variant display name via the workflow molecule (`artifactName`
-    and the variant selectors, as the drawers do) instead of printing the raw id.
-  - Append a mode tag: `{mode:"revision"}` → `· v<n>` (or just the name);
-    `{mode:"environment"}` → `@ <env slug>`; `{mode:"latest"}` → a `Latest` tag. An
-    agent trigger must show a workflow NAME + `Latest` tag, not a bare id or "-".
-  - Floor if name resolution is heavy in the table context: resolved-or-id **plus the
-    mode tag** — never a bare undifferentiated id (context.md D4).
-- Apply the same to the subscriptions section for parity.
-- Import note: the classifier is a pure function in `@agenta/entity-ui`'s gatewayTrigger
-  shared module; the settings sections live in `web/oss` and already consume that package,
-  so a subpath export is the only wiring needed.
+- Rework the "Bound workflow" column (schedules `:116-127`) on top of the shared
+  classifier. The current read chain
+  (`application ?? application_variant ?? application_revision`) never reads
+  `workflow_*`, so an agent-created trigger renders "-".
+- Resolve the workflow or variant display name through the workflow molecule
+  (`artifactName` and the variant selectors, as the drawers do) instead of printing a
+  raw id.
+- Append a mode tag: `{mode: "revision"}` shows `· v<n>`; `{mode: "environment"}` shows
+  `@ <env slug>`; `{mode: "latest"}` shows a `Latest` tag. An agent trigger must show a
+  workflow name plus the Latest tag, never a bare id or "-".
+- If name resolution is heavy in the table context, the floor is: resolved-name-or-id
+  plus the mode tag (context.md D4).
+- Apply the same change to the subscriptions section.
+- Wiring note: the classifier is a pure function in `@agenta/entity-ui`'s
+  gatewayTrigger shared module. The settings sections live in `web/oss` and already
+  consume that package, so a subpath export is the only wiring needed.
 
 ---
 
-## Phase E — Op-catalog correctness fix + skill re-verify (rides existing lanes)
+## Phase E: SDK wording fixes (rides existing lanes).
+
+These are correctness fixes, not polish (research.md §9). Without the pin, the current
+text tells an agent the opposite of what the platform does with the agent's own
+triggers.
 
 File: `sdks/python/agenta/sdk/agents/platform/op_catalog.py` (PR #5105 lane).
 
-These are **correctness fixes, not wording polish** (research.md §9): post-revert, the
-current text tells the model the opposite of what the platform does for its own
-variant-bound triggers.
-
 - `_CREATE_SCHEDULE_DESCRIPTION` (`:861-866`): replace "binds to the variant's latest
-  revision **at creation time and does not follow later commits**" with follow-latest
-  wording, e.g. *"When no revision is specified, the schedule follows the variant's latest
-  revision, re-resolved on every run."*
+  revision at creation time and does not follow later commits" with follow-latest
+  wording, for example: "When no revision is specified, the schedule follows the
+  variant's latest revision, re-resolved on every run."
 - `_CREATE_SUBSCRIPTION_DESCRIPTION` (`:905-910`): same change.
 - `_COMMIT_REVISION_DESCRIPTION` (`:699-701`): the sentence "existing schedules and
-  subscriptions keep pointing at the old revision until you re-point them" is **actively
-  wrong for the common agent case** — an agent's self-created schedule is variant-bound
-  and DOES pick up the new commit on its next fire. The replacement must distinguish the
-  two cases explicitly, e.g. *"revision-pinned schedules and subscriptions keep pointing
-  at the old revision until you re-point them; triggers bound to the variant (latest)
-  pick up the new revision on their next run."*
+  subscriptions keep pointing at the old revision until you re-point them" is wrong for
+  variant-bound triggers, which pick up the new commit on their next fire. The
+  replacement must distinguish the two cases, for example: "revision-pinned schedules
+  and subscriptions keep pointing at the old revision until you re-point them; triggers
+  bound to the variant (latest) pick up the new revision on their next run."
 
 File: `sdks/python/agenta/sdk/agents/adapters/agenta_builtins.py` (PR #5106 lane).
 
-- Re-grep the trigger sections (`:407-535`) for creation-time / freeze language and align
-  to follow-latest. As of 2026-07-07 there is nothing to change (research.md §9); confirm
-  at implementation time since the skill lane may have drifted. **Do not** touch the
-  `run_a_workflow` "does not change what runs" text at `:183-191` — that's a different
-  tool with an explicit version pin.
+- Re-grep the trigger sections (`:407-535`) for creation-time or freeze language and
+  align them to follow-latest. As of 2026-07-07 nothing needed changing (research.md
+  §9); re-verify at implementation time, since the skill lane may drift. Do not touch
+  the `run_a_workflow` "does not change what runs" text at `:183-191`; that describes a
+  different tool with an explicit version pin.
 
 ---
 
-## Phase F — QA matrix (manual + automated)
+## Phase F: QA matrix (automated plus manual).
 
-**Automated:**
-- API: `cd api && py-run-tests` — the reshaped triggers unit tests pass (Phase A3).
+Automated:
+
+- API: `cd api && py-run-tests`. The reshaped trigger unit tests pass (Phase A3).
 - FE: add `web/packages/agenta-entity-ui/tests/unit/buildRunVersionReferences.test.ts`
-  (vitest, matching the existing pure-function suites — research.md §11) covering:
-  Latest → variant-only ref (no revision); Pinned → revision ref; Deployed →
-  environment ref; edit-without-repick fallback echoes stored refs verbatim (including a
-  `workflow_*` shape).
-- FE: unit-test the **shared classifier** (Phase B) — this is the blocker-C1 lock:
-  - `{application_revision}` → Pinned; `{application_variant}` (no revision) → Latest;
-    `{environment, application}` → Deployed.
-  - **`{workflow_variant}` → Latest** (agent-created trigger — the C1 case).
-  - `{workflow_variant, workflow_revision}` → Pinned (an `fe4a01f`-pinned agent trigger).
-  - `{evaluator_variant}` → Latest (prefix symmetry).
-  - empty/null refs → no mode.
-  Run `pnpm --filter @agenta/entity-ui test` (or the package's test script).
+  (vitest, matching the existing pure-function suites, research.md §11). Cover: Latest
+  produces a variant-only reference with no revision; Pinned produces a revision
+  reference; Deployed produces an environment reference; the edit-without-repick
+  fallback echoes stored references verbatim, including a `workflow_*` shape.
+- FE: unit-test the shared classifier. This locks the agent-trigger case:
+  - `{application_revision}` classifies as Pinned.
+  - `{application_variant}` with no revision classifies as Latest.
+  - `{environment, application}` classifies as Deployed.
+  - `{workflow_variant}` classifies as Latest (the agent-created shape).
+  - `{workflow_variant, workflow_revision}` classifies as Pinned (a pin-era agent
+    trigger).
+  - `{evaluator_variant}` classifies as Latest (prefix symmetry).
+  - Empty or null references classify as no mode.
+  Run `pnpm --filter @agenta/entity-ui test`.
 - FE lint: `pnpm lint-fix` in `web`.
 
-**Manual (live stack — use the debug-local-deployment skill):**
-1. Create a **Latest** schedule on a variant → stored refs have `application_variant`, no
-   `application_revision`. Commit a new revision → fire → HEAD runs.
-2. Create a **Pinned** schedule → stored refs have `application_revision`. Commit a new
-   revision → fire → the pinned revision runs.
-3. Create a **Deployed** subscription → fires against the deployed revision; redeploy →
-   next fire follows.
-4. **Edit round-trip** each of the three: reopen the drawer → the correct rail item is
-   selected and the picker shows the current binding (no empty "Select workflow revision"
-   placeholder for a Latest trigger).
-5. **Settings list**: each trigger's "Bound workflow" column shows name + the right tag
-   (Latest / vN / @env).
-6. **Agent-created** schedule (via `create_schedule` op, stored as `workflow_variant`) →
-   settings list shows workflow name + Latest tag (not "-"), drawer opens in Latest mode
-   with the variant shown, a **name-only edit saves without touching the binding** (the
-   C1 regression scenario), and the trigger follows HEAD after a new commit.
-7. **422 path**: attempt to bind a variant with zero runnable revisions → 422, not 500
-   (subscription endpoints; schedules already had the handler).
+Manual, on a live stack (use the debug-local-deployment skill):
 
-Record results in this workspace (append a QA section here or in status.md) before
-marking the PR ready.
+1. Create a Latest schedule on a variant. The stored references have
+   `application_variant` and no `application_revision`. Commit a new revision, fire,
+   and confirm the head runs.
+2. Create a Pinned schedule. Commit a new revision, fire, and confirm the pinned
+   revision runs.
+3. Create a Deployed subscription. It fires against the deployed revision; redeploy,
+   and the next fire follows.
+4. Edit round-trip all three: reopen each drawer, confirm the correct rail item is
+   selected and the picker shows the current binding. No empty "Select workflow
+   revision" placeholder for a Latest trigger.
+5. Settings list: each trigger's "Bound workflow" column shows a name plus the right
+   tag (Latest, vN, or @env).
+6. Agent-created schedule (via the `create_schedule` op, stored as `workflow_variant`):
+   the settings list shows the workflow name plus a Latest tag, the drawer opens in
+   Latest mode with the variant shown, a name-only edit saves without touching the
+   binding, and the trigger follows the head after a new commit.
+7. 422 path: bind a variant with zero runnable revisions and confirm a 422, not a 500,
+   on the subscription endpoints. Schedules already had the handler.
+
+Record the results in this workspace (a QA section here or in status.md) before marking
+the implementation PR ready.

--- a/docs/design/trigger-latest-binding/plan.md
+++ b/docs/design/trigger-latest-binding/plan.md
@@ -1,0 +1,281 @@
+# Plan: Trigger "Latest" binding
+
+Six phases, A–F. Each is sized for a narrow subagent and names exact files. Phases B–D
+are frontend and depend on A being merged/available only for end-to-end QA, not for
+coding (the FE change is self-contained). E and F ride existing lanes / are verification.
+
+Dependency order: **A → (B → C → D) → E → F**. B/C/D are one logical FE change; split only
+if a subagent needs smaller units. A and E can proceed in parallel with the FE work.
+
+**Cross-phase invariant (blocker C1, review round 1):** every FE *read* of trigger
+references — drawer prefill (Phase C) and settings-list rendering (Phase D) — goes
+through **one shared prefix-symmetric classifier** (defined in Phase B) that handles the
+`application_*`, `workflow_*`, and `evaluator_*` families, mirroring the backend's prefix
+detection at `api/oss/src/core/triggers/service.py:782-789`. Agent-created triggers store
+`{workflow_variant: {id}}` (research.md §10); the current FE reads never touch
+`workflow_variant`, and only the `fe4a01f` pin (which wrote `workflow_revision`) made them
+render. Any phase that reads references without the shared classifier reintroduces the
+bug the pin papered over. Writes stay `application_*` (a re-pick silently migrates the
+prefix — accepted, context.md D2).
+
+---
+
+## Phase A — Backend: un-pin, keep the 422 fix, reshape the test
+
+**This reworks the existing lane `fix/trigger-revision-default-head`; PR #5103 becomes the
+implementation PR for this project** (retitle it to describe the follow-latest behavior,
+not the pin).
+
+### A1. Revert the create-time pin
+
+File: `api/oss/src/core/triggers/service.py`, `_validate_references`.
+
+- Delete the pin block (research.md §2, currently `:820-829`):
+  ```python
+  if (environment_ref is None and workflow_variant_ref is not None
+      and workflow_revision_ref is None):
+      references[f"{prefix}_revision"] = Reference(...)
+  ```
+- Restore the pre-`fe4a01f` validate-only docstring (`:756-773`). Recover the exact old
+  text with `git show fe4a01f^:api/oss/src/core/triggers/service.py` (the "…without
+  pinning it… means 'resolve latest at trigger time'… dispatcher re-resolves from the raw
+  references on every fire… latest-tracking is preserved" version).
+- **Keep** the `retrieve_workflow_revision` call and the `revision is None → raise
+  TriggerReferenceInvalid` guard (graceful-failure validation). The extracted
+  `workflow_variant_ref` / `workflow_revision_ref` locals may stay or be re-inlined; either
+  is fine.
+
+### A2. Keep the 422 handlers
+
+File: `api/oss/src/apis/fastapi/triggers/router.py`. **No change** — leave the
+`TriggerReferenceInvalid → HTTPException(422)` handlers on `create_subscription`
+(`:1006-1007`) and `edit_subscription` (`:1126-1127`) exactly as `fe4a01f` added them.
+Verify they survive the lane rework. (Scope note: only the *subscription* endpoints had
+the 500 gap; `create_schedule` / `edit_schedule` already had the handler at `:1283-1284`
+/ `:1379-1380` — research.md §3.)
+
+### A3. Reshape the test
+
+File: `api/oss/tests/pytest/unit/triggers/test_triggers_reference_defaulting.py`.
+
+- **Delete** the pinning tests: `TestValidateReferencesPinsHead.
+  test_variant_only_is_pinned_to_head_revision`, `.test_application_prefix_variant_only_is
+  _pinned`, and the whole `TestCreateScheduleDefaultsVariantToHead` /
+  `TestCreateSubscriptionDefaultsVariantToHead` classes' *pins-head* cases
+  (`test_create_schedule_pins_head_revision_when_only_variant_given`,
+  `test_create_subscription_pins_head_revision_when_only_variant_given`).
+- **Keep / adapt** the validation-still-works cases:
+  - zero-revision variant → `TriggerReferenceInvalid`
+    (`test_variant_with_no_revisions_raises_typed_error`,
+    `test_create_schedule_raises_when_variant_has_no_revisions`,
+    `test_create_subscription_raises_when_variant_has_no_revisions`) — keep as-is.
+  - refs-left-verbatim: `test_artifact_only_reference_stays_unpinned`,
+    `test_environment_reference_stays_unpinned`,
+    `test_revision_already_present_is_left_untouched` — keep.
+  - explicit-revision-untouched through the service entry points:
+    `test_create_schedule_leaves_explicit_revision_untouched` (`:209`) — keep (it
+    asserts a caller-pinned revision survives create, which stays true after the
+    revert). No subscription twin exists today (`TestCreateSubscriptionDefaults…` has
+    only the pins-head and raises cases); **add one** for parity while reshaping.
+- **Add** an explicit "variant-only is NOT rewritten" assertion (the inverse of the
+  deleted pin test): after `_validate_references` on `{"application_variant": {"id": ...}}`,
+  assert `"application_revision" not in references` and the input dict is unchanged. This
+  locks the revert.
+- Rename the module + docstring away from "defaulting"/"pins HEAD" toward
+  "validate-only / follow-latest" (e.g. `test_triggers_reference_validation.py`); update
+  the top-of-file docstring which currently describes pinning.
+
+**Verify A:** `cd api && py-run-tests` (or target the triggers unit tests). Then a live
+check: create a variant-only trigger, confirm the stored references contain **no**
+`application_revision`, commit a new revision, fire it, confirm HEAD runs (manual QA in
+Phase F).
+
+---
+
+## Phase B — Frontend: `RunVersionField` Latest mode + the shared classifier
+
+File: `web/packages/agenta-entity-ui/src/gatewayTrigger/drawers/shared/RunVersionField.tsx`
+(the classifier may live in a sibling `shared/` module, e.g. `triggerReferences.ts`).
+
+- **Add the shared prefix-symmetric classifier** (the cross-phase invariant). A pure
+  exported function, consumed by both drawers (Phase C) and both settings sections
+  (Phase D):
+
+  ```typescript
+  // classifyTriggerReferences(refs) → mirror of the backend prefix detection
+  // (api/oss/src/core/triggers/service.py:782-789)
+  // - refs.environment present → {mode: "environment", environmentSlug, appSlug}
+  // - for prefix in ["application", "workflow", "evaluator"]:
+  //     refs[`${prefix}_revision`]?.id → {mode: "revision", revisionId, workflowId?}
+  //     refs[`${prefix}_variant`]?.id (no `${prefix}_revision`) →
+  //         {mode: "latest", variantId, workflowId?}
+  // - nothing matched → {mode: null}
+  ```
+
+  A `{workflow_variant: {id}}` input (agent-created trigger) MUST classify as Latest —
+  this is the blocker-C1 case; unit-test it in Phase F.
+- Extend `RunVersionBindMode` (`:10`) to `"latest" | "revision" | "environment"`.
+- Add a third rail item (`:104-112`): `{value:"latest", label:"Latest"}`, ordered
+  `Latest | Pinned | Deployed`.
+- Add a Latest branch to the render (`:113-141`):
+  - hint: *"Always runs the newest committed revision of this variant (ignores
+    environments)."* (disambiguates from Deployed — context.md D1/U2).
+  - a **variant** picker: reuse the popover-cascader but present workflow→variant (no
+    revision leaf). Simplest path: pass the same `revisionAdapter` and let the user select
+    the variant node; on select, emit a selection whose `id === metadata.variantId` so
+    `buildRunVersionReferences` produces the variant-only ref. If a variant-scoped adapter
+    is cleaner, add one alongside `applicationRevisionAdapter` in the drawers (out of this
+    file). Keep the decision local and documented in a one-line comment.
+- `buildRunVersionReferences` (`:29-64`): add an explicit `latest` arm for clarity —
+  when `bindMode === "latest"`, return `{application:{id}?, application_variant:{id:
+  variantId}}` from the current selection/`variantId`, never a revision ref. (Functionally
+  the existing `else` already does this when `leafId === variantId`; the explicit arm makes
+  intent legible and prevents a future edit from routing Latest into `application_revision`.)
+  Writes stay `application_*`; the edit-without-repick fallback (`:63`) keeps echoing
+  `fallbackReferences` verbatim so a stored `workflow_*` shape survives metadata-only
+  edits (research.md §5, "resubmit is already prefix-safe").
+- Accept a `selectedValue` prop and forward it to the `EntityPicker` (`:118-124`) so Pinned
+  mode reflects the current binding (research.md §6). Latest mode's picker shows the
+  selected variant analogously.
+
+**No behavioral change to Deployed.** Keep `envHint` / env `Select` as-is.
+
+---
+
+## Phase C — Frontend: drawer prefill + picker value display
+
+Files: `TriggerScheduleDrawer.tsx`, `TriggerSubscriptionDrawer.tsx` (same package).
+
+- Add `variantId` (or reuse a clearly-named state) distinct from `workflowRevId`, and let
+  `bindMode` hold `"latest" | "revision" | "environment"`.
+- **Prefill classification** (schedule `:456-479`, subscription `:526-550`): replace the
+  hand-rolled fallback chains with the **shared classifier from Phase B**. The current
+  chains read `application_revision ?? application_variant ?? workflow_revision` and never
+  read `workflow_variant`, so agent-created triggers prefill null (blocker C1 —
+  research.md §5). Via the classifier:
+  - `{mode: "environment"}` → `bindMode = "environment"` (unchanged behavior).
+  - `{mode: "revision", revisionId}` (any prefix, incl. `workflow_revision` from
+    `fe4a01f`-pinned triggers) → `bindMode = "revision"`, `workflowRevId = revisionId`.
+  - `{mode: "latest", variantId}` (any prefix, incl. `workflow_variant` from agent
+    triggers) → `bindMode = "latest"`, `variantId` set. **Do not** assign it to
+    `workflowRevId` (removes the research.md §5 bug).
+  - Delete/replace `extractBoundRevId` (subscription `:116-125`) — it collapses the
+    variant-vs-revision distinction the classifier makes explicit.
+- **Picker value:** pass `selectedValue={workflowRevId}` (Pinned) / the variant id
+  (Latest) into `RunVersionField` so the `EntityPicker` shows the current binding, not a
+  placeholder. Resolve the human label via the existing molecule selectors
+  (`artifactName` / `variantLabel` / `data`), but note those are **revision-only** — for
+  Latest, resolve the *variant* label instead (variant molecule selector), since a variant
+  id won't resolve through revision selectors.
+- **Submit validation:** add a `latest` arm alongside `bindMode === "revision" &&
+  !workflowRevId` (schedule `:595-596`): `bindMode === "latest" && !variantId` →
+  `message.error("Pick a variant")`. Mirror in the subscription drawer. (Post-classifier,
+  an agent trigger in edit mode carries a valid `variantId`, so a name-only edit is no
+  longer blocked — the C1 regression scenario.)
+- **`versionChosen` / summary** (schedule `:700-702`): include the Latest case
+  (`bindMode === "latest" ? !!variantId : …`).
+- **Create-mode default-bind** (schedule `:486-510`, subscription `:552-576`): agent /
+  `defaultReferences` binding provides a variant id — open in Latest with the variant
+  pre-selected. **Pending Mahmoud's answer to the default-mode open question**
+  (context.md D1): if he opts for revision-context honoring, a `defaultReferences` that
+  carries a concrete revision (the current code discards it and hardcodes `revision: 0` —
+  schedule `:496-507`) should instead open **Pinned** pre-selected to that revision.
+  Implement his choice; don't decide silently.
+
+---
+
+## Phase D — Frontend: settings-list rendering
+
+Files (note the `components/` subfolder — research.md §8):
+`web/oss/src/components/pages/settings/Triggers/components/GatewaySchedulesSection.tsx`
+and `.../GatewaySubscriptionsSection.tsx`.
+
+- Rework the "Bound workflow" column render (schedules `:116-127`) **on top of the
+  shared classifier from Phase B** — the current read chain (`application ??
+  application_variant ?? application_revision`) never reads `workflow_*`, so an
+  agent-created trigger renders "-" (blocker C1 — research.md §8). Via the classifier:
+  - Resolve the workflow/variant display name via the workflow molecule (`artifactName`
+    and the variant selectors, as the drawers do) instead of printing the raw id.
+  - Append a mode tag: `{mode:"revision"}` → `· v<n>` (or just the name);
+    `{mode:"environment"}` → `@ <env slug>`; `{mode:"latest"}` → a `Latest` tag. An
+    agent trigger must show a workflow NAME + `Latest` tag, not a bare id or "-".
+  - Floor if name resolution is heavy in the table context: resolved-or-id **plus the
+    mode tag** — never a bare undifferentiated id (context.md D4).
+- Apply the same to the subscriptions section for parity.
+- Import note: the classifier is a pure function in `@agenta/entity-ui`'s gatewayTrigger
+  shared module; the settings sections live in `web/oss` and already consume that package,
+  so a subpath export is the only wiring needed.
+
+---
+
+## Phase E — Op-catalog correctness fix + skill re-verify (rides existing lanes)
+
+File: `sdks/python/agenta/sdk/agents/platform/op_catalog.py` (PR #5105 lane).
+
+These are **correctness fixes, not wording polish** (research.md §9): post-revert, the
+current text tells the model the opposite of what the platform does for its own
+variant-bound triggers.
+
+- `_CREATE_SCHEDULE_DESCRIPTION` (`:861-866`): replace "binds to the variant's latest
+  revision **at creation time and does not follow later commits**" with follow-latest
+  wording, e.g. *"When no revision is specified, the schedule follows the variant's latest
+  revision, re-resolved on every run."*
+- `_CREATE_SUBSCRIPTION_DESCRIPTION` (`:905-910`): same change.
+- `_COMMIT_REVISION_DESCRIPTION` (`:699-701`): the sentence "existing schedules and
+  subscriptions keep pointing at the old revision until you re-point them" is **actively
+  wrong for the common agent case** — an agent's self-created schedule is variant-bound
+  and DOES pick up the new commit on its next fire. The replacement must distinguish the
+  two cases explicitly, e.g. *"revision-pinned schedules and subscriptions keep pointing
+  at the old revision until you re-point them; triggers bound to the variant (latest)
+  pick up the new revision on their next run."*
+
+File: `sdks/python/agenta/sdk/agents/adapters/agenta_builtins.py` (PR #5106 lane).
+
+- Re-grep the trigger sections (`:407-535`) for creation-time / freeze language and align
+  to follow-latest. As of 2026-07-07 there is nothing to change (research.md §9); confirm
+  at implementation time since the skill lane may have drifted. **Do not** touch the
+  `run_a_workflow` "does not change what runs" text at `:183-191` — that's a different
+  tool with an explicit version pin.
+
+---
+
+## Phase F — QA matrix (manual + automated)
+
+**Automated:**
+- API: `cd api && py-run-tests` — the reshaped triggers unit tests pass (Phase A3).
+- FE: add `web/packages/agenta-entity-ui/tests/unit/buildRunVersionReferences.test.ts`
+  (vitest, matching the existing pure-function suites — research.md §11) covering:
+  Latest → variant-only ref (no revision); Pinned → revision ref; Deployed →
+  environment ref; edit-without-repick fallback echoes stored refs verbatim (including a
+  `workflow_*` shape).
+- FE: unit-test the **shared classifier** (Phase B) — this is the blocker-C1 lock:
+  - `{application_revision}` → Pinned; `{application_variant}` (no revision) → Latest;
+    `{environment, application}` → Deployed.
+  - **`{workflow_variant}` → Latest** (agent-created trigger — the C1 case).
+  - `{workflow_variant, workflow_revision}` → Pinned (an `fe4a01f`-pinned agent trigger).
+  - `{evaluator_variant}` → Latest (prefix symmetry).
+  - empty/null refs → no mode.
+  Run `pnpm --filter @agenta/entity-ui test` (or the package's test script).
+- FE lint: `pnpm lint-fix` in `web`.
+
+**Manual (live stack — use the debug-local-deployment skill):**
+1. Create a **Latest** schedule on a variant → stored refs have `application_variant`, no
+   `application_revision`. Commit a new revision → fire → HEAD runs.
+2. Create a **Pinned** schedule → stored refs have `application_revision`. Commit a new
+   revision → fire → the pinned revision runs.
+3. Create a **Deployed** subscription → fires against the deployed revision; redeploy →
+   next fire follows.
+4. **Edit round-trip** each of the three: reopen the drawer → the correct rail item is
+   selected and the picker shows the current binding (no empty "Select workflow revision"
+   placeholder for a Latest trigger).
+5. **Settings list**: each trigger's "Bound workflow" column shows name + the right tag
+   (Latest / vN / @env).
+6. **Agent-created** schedule (via `create_schedule` op, stored as `workflow_variant`) →
+   settings list shows workflow name + Latest tag (not "-"), drawer opens in Latest mode
+   with the variant shown, a **name-only edit saves without touching the binding** (the
+   C1 regression scenario), and the trigger follows HEAD after a new commit.
+7. **422 path**: attempt to bind a variant with zero runnable revisions → 422, not 500
+   (subscription endpoints; schedules already had the handler).
+
+Record results in this workspace (append a QA section here or in status.md) before
+marking the PR ready.

--- a/docs/design/trigger-latest-binding/research.md
+++ b/docs/design/trigger-latest-binding/research.md
@@ -1,0 +1,288 @@
+# Research: verified findings
+
+All citations re-verified against the working tree on **2026-07-07**. Line numbers are
+current as of that date. Each claim is grounded in a file read, not memory.
+
+---
+
+## 1. Backend already follows-latest for variant-only references
+
+**The dispatcher rebuilds the invoke request from the RAW stored references on every
+fire.** `api/oss/src/tasks/asyncio/triggers/dispatcher.py:224-268`:
+
+- Lines 224-231 build `references` by dumping `entity.data.references` verbatim.
+- Lines 262-268 construct `WorkflowServiceRequest(references=references, ...)`.
+
+There is no revision resolution at store time in this path — it uses whatever is stored,
+each fire.
+
+**The workflow service resolves the variant HEAD fresh when no revision ref is present.**
+`api/oss/src/core/workflows/service.py:701-751` `_ensure_request_revision`:
+
+- Line 707-708: if `request.data.revision` is already set, return (nothing to resolve).
+- Lines 726-736: an `environment` ref resolves the environment's deployed revision.
+- Lines 738-744: otherwise a revision / variant / artifact ref is resolved via
+  `retrieve_workflow_revision` — for a variant-only ref this returns the variant HEAD.
+- Lines 746-751: the resolved revision is written into `request.data.revision` for this
+  invocation only (not persisted back to the trigger).
+
+**Conclusion:** a stored `{application_variant}` (no revision) is genuine follow-latest,
+re-resolved every fire. An `environment` ref follows the deployed revision. This is the
+behavior the feature surfaces in the UI.
+
+---
+
+## 2. The create-time pin to revert (commit `fe4a01f`, PR #5103)
+
+Lane `fix/trigger-revision-default-head`, commit **`fe4a01f1d2`** ("fix(api): pin trigger
+references to the variant HEAD revision when none is given"). The commit touches three
+files: `service.py` (+the pin), `router.py` (+422 handlers on the subscription
+endpoints — KEEP, see §3), and the test file (reshape).
+
+**The pin lives in** `api/oss/src/core/triggers/service.py` `_validate_references`:
+
+- Docstring `:756-773` was rewritten to describe pinning ("A `{prefix}_variant` reference
+  with no `{prefix}_revision` is pinned in-place to the resolved (HEAD) revision…").
+- The pin block is **`:820-829`**:
+
+  ```python
+  if (
+      environment_ref is None
+      and workflow_variant_ref is not None
+      and workflow_revision_ref is None
+  ):
+      references[f"{prefix}_revision"] = Reference(
+          id=revision.id,
+          slug=revision.slug,
+          version=revision.version,
+      )
+  ```
+
+**Revert target:** remove the `:820-829` pin block and restore the pre-`fe4a01f`
+validate-only docstring (the old text: *"Assert the bound reference family resolves —
+without pinning it. … we deliberately do NOT overwrite the stored references with the
+resolved revision: an environment slug, or an artifact/variant without a revision, means
+'resolve latest at trigger time.' … The dispatcher re-resolves from the raw references on
+every fire … so latest-tracking is preserved."*). The full old docstring is recoverable
+via `git show fe4a01f^:api/oss/src/core/triggers/service.py`.
+
+The commit also extracted `workflow_variant_ref` / `workflow_revision_ref` into locals
+(`:800-805`) that feed `retrieve_workflow_revision`. Those locals are harmless to keep;
+the revert only needs to drop the pin block and fix the docstring. The `retrieve` call at
+`:807-814` and the `revision is None → raise TriggerReferenceInvalid` guard at `:815-818`
+stay (that is the graceful-failure validation, still wanted).
+
+---
+
+## 3. Keep the same lane's 422 fix (subscription endpoints only)
+
+Also from `fe4a01f`, in `api/oss/src/apis/fastapi/triggers/router.py`:
+
+- `create_subscription`: `TriggerReferenceInvalid` → `HTTPException(422)` at
+  **`:1006-1007`**.
+- `edit_subscription`: the service call was wrapped in try/except and
+  `TriggerReferenceInvalid` → `HTTPException(422)` at **`:1126-1127`**.
+
+**Scope correction (review round 1):** the 500 gap was on the *subscription* endpoints
+only. The **schedule** endpoints already had `TriggerReferenceInvalid → 422` handlers
+before `fe4a01f` — `create_schedule` at `router.py:1283-1284` and `edit_schedule` at
+`:1379-1380` (each next to a `TriggerScheduleInvalid → 422`). Before this commit an
+invalid reference on the subscription endpoints surfaced as a 500. **Keep both new
+handlers.** They are independent of the pin and remain correct after the revert.
+
+`TriggerReferenceInvalid` is imported at `router.py:49` and defined in
+`api/oss/src/core/triggers/exceptions.py`.
+
+---
+
+## 4. Frontend reference assembly: `RunVersionField.tsx`
+
+`web/packages/agenta-entity-ui/src/gatewayTrigger/drawers/shared/RunVersionField.tsx`.
+
+- **Two-mode rail** at `:104-112`: `{value:"revision", label:"Pinned"}` and
+  `{value:"environment", label:"Deployed"}`. Type `RunVersionBindMode = "revision" |
+  "environment"` at `:10`.
+- Pinned mode `:113-125`: hint text (default `"Runs one exact variant + revision."`, prop
+  `revisionHint` `:79`) + an `EntityPicker variant="popover-cascader"` over the revision
+  adapter. **The picker gets NO `value`/`selectedValue` prop** (`:118-124`) — it only
+  shows a `placeholder`, never the current binding.
+- Deployed mode `:126-140`: hint + an environment `Select`.
+- **`buildRunVersionReferences` `:29-64`** assembles `data.references`:
+  - `environment` mode `:44-51` → `{environment:{slug}, application:{slug}?}`.
+  - `:52-62`: on a fresh pick with `workflowSelection.metadata`, `leafId =
+    selection.id ?? workflowRevId`; **`isRevision = !!meta.variantId && leafId !==
+    meta.variantId`** (`:55`). If `isRevision` → `{application:{id}, application_revision:
+    {id:leafId}}`; else → `{application:{id}, application_variant:{id: meta.variantId ||
+    leafId}}`.
+  - `:63`: edit-without-repick fallback → `fallbackReferences ?? {application_variant:
+    {id: workflowRevId}}`.
+
+**Implication for Latest:** the assembly already emits a variant-only ref when the picked
+leaf is the variant node. Latest mode mostly needs (a) a rail item, (b) a variant-level
+selection, and (c) prefill/validation that recognize the mode — not a new branch in
+`buildRunVersionReferences` (though a `latest` arm makes intent explicit and is cheap).
+
+---
+
+## 5. The edit-prefill bug (the core defect this feature fixes)
+
+**Schedule drawer** `TriggerScheduleDrawer.tsx`:
+
+- State `:381` `workflowRevId`, `:389` `bindMode` (`"revision" | "environment"`).
+- Prefill `:456-479`: on edit, if `refs.environment` → Deployed mode (`:465-468`); **else**
+  `:469-475` sets `workflowRevId = refs.application_revision?.id ?? refs.application_variant
+  ?.id ?? refs.workflow_revision?.id ?? null`. So a variant-only trigger stuffs the
+  **variant id** into `workflowRevId`.
+- `workflowRevId` then feeds **revision-only** selectors `:397-413`:
+  `workflowMolecule.selectors.artifactName(workflowRevId)`, `.variantLabel(workflowRevId)`,
+  `.data(workflowRevId)`. A variant id is not a revision id, so these return **null**,
+  `resolvedRevisionName` is null, and the picker shows its placeholder.
+- The section header `:795` is `<RequiredTitle>Which version runs?</RequiredTitle>`
+  (required asterisk via `RequiredTitle` `:71`), status `warning` when `versionChosen`
+  is false (`:796`, `versionChosen` computed `:700`).
+- Picker placeholder `:804-810`: `workflowLabel ?? resolvedRevisionName ?? "Select
+  workflow revision"`. With both null → the empty "Select workflow revision" placeholder
+  under a required asterisk, even though a valid follow-latest binding exists.
+- Submit validation `:595-596`: `if (bindMode === "revision" && !workflowRevId)
+  message.error("Bind a workflow")`.
+
+**Subscription drawer** `TriggerSubscriptionDrawer.tsx` mirrors this:
+
+- `extractBoundRevId` helper `:116-125` reads `application_revision?.id ??
+  application_variant?.id ?? workflow_revision?.id`.
+- Prefill `:526-550`: `refs.environment` → Deployed (`:533-537`); else `:538-543`
+  `workflowRevId = extractBoundRevId(refs)` (same variant-id-into-revision-slot bug),
+  `workflowLabel = null`.
+
+**The prefix gap (blocker C1, review round 1).** Look at those fallback chains: the
+drawers read `application_revision ?? application_variant ?? workflow_revision` — they
+never read **`workflow_variant`**. But agent-created triggers store exactly
+`{workflow_variant: {id}}` (§10). The `fe4a01f` pin masked this because, being
+prefix-agnostic, it wrote `references["workflow_revision"]` for those triggers — a key
+the drawers DO read. After the Phase A revert, without a prefix-symmetric FE classifier
+an agent trigger would: prefill null → render the empty required picker → **block even a
+name-only edit** at the `bindMode === "revision" && !workflowRevId` submit gate
+(`TriggerScheduleDrawer.tsx:595-596`) → and show "-" in the settings list (§8). The
+classifier must mirror the backend's own prefix detection
+(`api/oss/src/core/triggers/service.py:782-789`, prefixes `application` / `evaluator` /
+`workflow`) and be shared by both drawers and both settings sections (context.md D2,
+plan.md Phases B–D).
+
+**Resubmit is already prefix-safe.** Edit-without-repick echoes the stored references
+verbatim: `buildRunVersionReferences` falls back to `fallbackReferences`
+(`RunVersionField.tsx:63`), and both drawers pass the stored refs
+(`TriggerScheduleDrawer.tsx:622`, `TriggerSubscriptionDrawer.tsx:697`). So a
+`workflow_variant` trigger keeps its shape across a metadata-only edit. An active re-pick
+rewrites the refs to `application_*` — harmless (backend prefix-agnostic); accepted as a
+silent prefix migration (context.md D2).
+
+**Fix direction (Phase C):** prefill must classify via the shared prefix-symmetric
+helper — "any `{prefix}_variant` with no `{prefix}_revision`" → Latest mode with a
+separate `variantId`, not funneled into `workflowRevId`.
+
+---
+
+## 6. The `EntityPicker` never shows the current value
+
+`RunVersionField.tsx:118-124`: the `EntityPicker` receives `adapter`, `onSelect`,
+`className`, `placeholder` — no value. So even a correctly-pinned trigger shows only a
+placeholder-derived label, never a selected-state in the popover.
+
+**The picker CAN display a value.** `UnifiedEntityPicker` types
+(`web/packages/agenta-entity-ui/src/selection/components/UnifiedEntityPicker/types.ts`)
+expose `selectedValue?: string | null` (`:362-364`), `selectedParentId` / `selectedChildId`
+for highlighting (`:255-262`), and `displayRender` (`:401`, `:538-540`). Phase C can pass
+`selectedValue` (the revision id in Pinned mode) so the picker reflects the current
+binding. Latest mode won't use the revision cascader, so this only matters for Pinned.
+
+---
+
+## 7. The settings-mode picker is unscoped (defer — D5)
+
+`TriggerScheduleDrawer.tsx:66-68` and `TriggerSubscriptionDrawer.tsx:92`:
+`applicationRevisionAdapter = createWorkflowRevisionAdapter({workflowListAtom:
+appWorkflowsListQueryStateAtom})`. This lists **every** application workflow in the
+project (a 3-level workflow→variant→revision tree), not scoped to the trigger's app. In a
+playground the adapter is re-scoped to the agent's workflow (`:425-432` schedule /
+`:470-476` subscription), but the settings path is unscoped. This is the "weird options"
+complaint. Orthogonal to Latest → **deferred** (context.md D5).
+
+(The originally-cited `workflowRevisionRelationAdapter.ts:391-401` region is JSDoc for
+`filterWorkflows` / `skipVariantLevel`, not the scoping site. The actual unscoping is the
+`appWorkflowsListQueryStateAtom` list atom above. Citation corrected.)
+
+---
+
+## 8. Settings list "Bound workflow" column shows raw ids
+
+**Path drift from the original research:** the sections live under a `components/`
+subfolder, not directly under `Triggers/`.
+
+`web/oss/src/components/pages/settings/Triggers/components/GatewaySchedulesSection.tsx`:
+
+- Column def `:112-129`, title `"Bound workflow"` `:113`.
+- Render `:116-127`: `wfId = refs?.application?.id ?? refs?.application_variant?.id ??
+  refs?.application_revision?.id ?? null`, displayed as a raw id (`:124-125`, `{wfId ??
+  "-"}`). No version, no Latest/Deployed labeling — and **no `workflow_*` key is read at
+  all**, so an agent-created `{workflow_variant}` trigger renders as `-` (the §5 prefix
+  gap applies here too; the column must use the same shared classifier).
+
+The sibling `GatewaySubscriptionsSection.tsx` in the same folder follows the same shape.
+`GatewayTriggersSection.tsx` and `Triggers.tsx` are also in the tree.
+
+---
+
+## 9. Op-catalog + skill wording that contradicts follow-latest
+
+`sdks/python/agenta/sdk/agents/platform/op_catalog.py`:
+
+- **`_CREATE_SCHEDULE_DESCRIPTION` `:861-866`**: *"When no revision is specified, the
+  schedule binds to the variant's latest revision **at creation time and does not follow
+  later commits**."* — false once the pin is reverted; must become follow-latest.
+- **`_CREATE_SUBSCRIPTION_DESCRIPTION` `:905-910`**: same "at creation time and does not
+  follow later commits" wording — same fix.
+- **`_COMMIT_REVISION_DESCRIPTION` `:699-701`**: *"existing schedules and subscriptions
+  keep pointing at the old revision until you re-point them."* — post-revert this is
+  **actively wrong for the common agent case**, not merely imprecise: an agent's
+  self-created schedule is variant-bound (§10), so after `commit_revision` it DOES pick
+  up the new commit on its next fire. A model trusting this sentence would wrongly
+  conclude its schedule still runs the old behavior. The replacement must distinguish
+  the two cases explicitly: variant-bound (latest) triggers follow commits; only
+  revision-pinned triggers stay frozen until re-pointed. **This is a correctness fix,
+  not wording polish.**
+
+`sdks/python/agenta/sdk/agents/adapters/agenta_builtins.py` (the build-an-agent skill):
+
+- The trigger sections `:407-535` (`create_schedule` / `create_subscription` guidance) do
+  **not** currently contain "does not follow later commits" pinning language (grep clean).
+  The nearby `:183-191` "does not change what runs" text is about the `run_a_workflow`
+  tool with an explicit `version` / environment pin — **not** a trigger, do not touch.
+- **Action:** after rewording the op catalog, re-grep `agenta_builtins.py` for any
+  creation-time / freeze language in the trigger sections and align it. As of 2026-07-07
+  there is nothing to change there, but re-verify at implementation time (the skill lane,
+  PR #5106, may drift).
+
+---
+
+## 10. Agent-created triggers store `workflow_variant` and need zero op changes
+
+`create_schedule` / `create_subscription` context-bind only the variant id, under the
+**`workflow_*` prefix**: `context_bindings` set
+`schedule.data.references.workflow_variant.id` / `subscription.data.references.
+workflow_variant.id` to `$ctx.workflow.variant.id` (`op_catalog.py:1128-1130` and
+`:1140-1142`). The input schema is closed against a caller-supplied `references`
+(`op_catalog.py:869-871`), so `{workflow_variant: {id}}` is the exact stored shape for
+every agent-created trigger. Under follow-latest that variant-only binding becomes the
+**correct** default with no op changes — only the *descriptions* (§9) change. But it is
+also the shape the FE read paths currently never read (§5, §8), which is why the FE
+classifier must be prefix-symmetric.
+
+---
+
+## 11. FE test surface
+
+`web/packages/agenta-entity-ui/tests/unit/` holds pure-function vitest suites
+(`connectionUtils.test.ts`, `schemaPaths.test.ts`, etc.). There are **no** existing unit
+tests for the trigger drawers. `buildRunVersionReferences` is a pure function and is the
+natural unit-test target; an extracted prefill-classifier helper would be too. Full-drawer
+rendering tests are not the established pattern here.

--- a/docs/design/trigger-latest-binding/research.md
+++ b/docs/design/trigger-latest-binding/research.md
@@ -32,7 +32,11 @@ behavior the feature surfaces in the UI.
 
 ---
 
-## 2. The create-time pin to revert (commit `fe4a01f`, PR #5103)
+## 2. The create-time pin to remove (commit `fe4a01f`, PR #5103)
+
+**Update 2026-07-09: PR #5103 was closed unmerged (pinning is the wrong behavior). The
+pin never landed on `big-agents`; it exists only on the local lane below. Phase A
+removes it from that lane and opens a fresh backend PR.**
 
 Lane `fix/trigger-revision-default-head`, commit **`fe4a01f1d2`** ("fix(api): pin trigger
 references to the variant HEAD revision when none is given"). The commit touches three

--- a/docs/design/trigger-latest-binding/status.md
+++ b/docs/design/trigger-latest-binding/status.md
@@ -1,114 +1,93 @@
-# Status — source of truth
+# Status: source of truth
 
-**State: DESIGN DRAFT — review round 1 folded in; next step: draft PR for Mahmoud's
-review.**
+**State: DESIGN DRAFT, awaiting Mahmoud's review on PR #5113.**
 
-Do not start implementation until Mahmoud reviews and approves this design (the
-plan-feature → draft-PR → review workflow). This file is the single source of truth for
-project state; if it disagrees with any other note, this file wins.
+Do not start implementation until Mahmoud approves this design. This file is the single
+source of truth for project state; if it disagrees with any other note, this file wins.
 
-_Last updated: 2026-07-07._
+_Last updated: 2026-07-09._
+
+## Log
+
+- **2026-07-09**: Mahmoud closed PR #5103 (the create-time pin) as wrong behavior. The
+  plan no longer repurposes that PR; Phase A now reworks the leftover local lane
+  (`fix/trigger-revision-default-head`, which still carries the pin commit) and opens a
+  fresh backend PR. Same day: the workspace docs were rewritten in plain language on
+  Mahmoud's request. No design decision changed.
+- **2026-07-07**: adversarial review round 1 (UX plus correctness) folded in. Research
+  re-verified against the working tree; every plan claim cites `file:line`.
 
 ## Where things stand
 
-- Research complete and re-verified against the working tree (see research.md, dated
-  2026-07-07). Every plan claim is cited to `file:line`.
-- Plan drafted (plan.md), phases A–F.
-- **Adversarial review round 1 complete** (UX + correctness): UX verdict
-  SOUND-WITH-CHANGES, correctness verdict RETHINK-narrowly — one scope defect, mechanism
-  sound. **All findings are folded into this revision** (see "Review round 1" below); the
-  scope defect (blocker C1) is fixed in context.md D2 and plan.md Phases B–D/F.
-- No code written for this project yet. **No git/but/gitbutler writes have been made by
-  the planning agent.**
-- **Next step:** open the draft PR carrying this workspace for Mahmoud's review.
+- Research is complete and verified (research.md, dated 2026-07-07).
+- The plan is drafted (plan.md, phases A to F).
+- No implementation code has been written for this project.
+- Next step: Mahmoud reviews the design and answers the open questions below.
 
-## Review round 1 (folded into this revision)
+## What review round 1 changed (summary)
 
-**Blocker C1 (correctness scope defect — FIXED in this revision).** The original plan said
-"FE work stays on `application_*`", but the FE read paths never read the `workflow_*`
-reference family, and agent-created triggers store `{workflow_variant: {id}}`
-(op_catalog.py:1128-1130, :1140-1142). The `fe4a01f` pin masked this by writing
-`workflow_revision`, which the drawers do read. Post-revert, agent triggers would have
-prefilled null, blocked name-only edits, and shown "-" in the settings list. The design
-now requires **one shared prefix-symmetric classifier** (prefixes `application` /
-`workflow` / `evaluator`, mirroring the backend's own detection at
-`api/oss/src/core/triggers/service.py:782-789`) used by both drawers and both settings
-sections — context.md D2/D3/D4, plan.md cross-phase invariant + Phases B–D, and a
-`{workflow_variant} → Latest` unit-test case in Phase F. Resubmit was verified already
-prefix-safe (edit-without-repick echoes stored refs verbatim); an active re-pick rewrites
-to `application_*`, accepted as a silent prefix migration.
+The review found one real scope defect and several smaller fixes, all folded in:
 
-**UX changes folded:** settings list must classify + resolve names via the same
-classifier (U4 → D4/Phase D); Latest hint copy tightened to *"Always runs the newest
-committed revision of this variant (ignores environments)"* to disambiguate from
-Deployed (U2 → D1/Phase B); the default-mode decision is now an explicit open question,
-not silently decided (U3 → below); two pre-existing dangling-ref render gaps acknowledged
-as non-goals so they aren't mistaken for regressions (U5 → context.md non-goals).
+- **The prefix gap (the review's blocker).** The original plan kept frontend work on
+  `application_*` references only. But the frontend read paths never read the
+  `workflow_*` family, and agent-created triggers store exactly
+  `{workflow_variant: {id}}`. The pin PR had masked this by writing `workflow_revision`,
+  a key the drawers do read. Without a fix, agent triggers would prefill null, block
+  name-only edits, and show "-" in the settings list. The design now requires one
+  shared prefix-symmetric classifier for every frontend read (context.md D2, plan.md
+  Phases B to D), plus a `{workflow_variant} classifies as Latest` unit test (Phase F).
+  Resubmit was verified safe: an edit without a re-pick echoes the stored references
+  verbatim; an active re-pick rewrites them to `application_*`, accepted as a silent
+  migration.
+- **UX fixes.** The settings list must classify and resolve names with the same
+  classifier. The Latest hint copy now says "(ignores environments)" to separate it
+  from Deployed. The default-mode choice became an explicit open question instead of a
+  silent decision. Two pre-existing dangling-reference render gaps are listed as
+  non-goals so they are not mistaken for regressions.
+- **Corrections.** The 500-to-422 gap was on the subscription endpoints only; schedules
+  already had the handler. The `commit_revision` description fix is a correctness fix,
+  not polish. The explicit-revision-untouched tests were added to the Phase A3 keep
+  list, with a note that the subscription twin is missing and should be added.
 
-**Corrections folded:** the 422 "500 gap" was subscription-endpoints-only — schedules
-already had the handler at router.py:1283-1284 / :1379-1380 (C5 → research.md §3);
-the `commit_revision` description fix is a **correctness fix**, actively wrong for the
-common agent case post-revert, not polish (C4 → research.md §9, plan.md Phase E); the
-explicit-revision-untouched keeper tests added to the Phase A3 keep-list, noting the
-subscription twin doesn't exist yet and should be added (C6 → plan.md A3).
+## Lanes and PRs this project touches
 
-## Existing lanes / PRs this project touches
-
-- **PR #5103 / lane `fix/trigger-revision-default-head`** — added the create-time pin
-  (commit `fe4a01f`). **This project reverts the pin and repurposes this PR as the
-  backend implementation PR** (Phase A). Retitle it to describe follow-latest, not
-  pinning.
-- **PR #5105 lane** (op catalog) — Phase E correctness fixes ride here.
-- **PR #5106 lane** (build-an-agent skill / `agenta_builtins.py`) — Phase E re-verify /
-  align here.
-- **Issue #5110** (jp) — deliveries recording which revision ran. **Out of scope**
-  (non-goal). Latest triggers resolve HEAD at fire time; the delivery record does not yet
-  capture the resolved revision.
+- **Lane `fix/trigger-revision-default-head`**: carries the closed pin commit. Phase A
+  reworks it (remove the pin, keep the 422 handlers, reshape the tests) and opens a new
+  backend PR. PR #5103 itself stays closed.
+- **PR #5105 lane** (op catalog): Phase E description fixes ride here.
+- **PR #5106 lane** (build-an-agent skill): Phase E re-verify rides here.
+- **Issue #5110** (jp): deliveries should record which revision actually ran. Out of
+  scope here (non-goal).
 
 ## Open questions for Mahmoud
 
-1. **Default mode when a concrete revision is in context (U3 — his call, not decided).**
-   Recommendation: new triggers default to **Latest**; but when the drawer opens from a
-   context carrying a concrete revision (e.g. the playground positioned on a revision —
-   the current create-mode default-bind at `TriggerScheduleDrawer.tsx:496-507` discards it
-   and hardcodes `revision: 0`), should it open **Pinned** pre-selected to that revision?
-   Recommended: yes. Context.md D1 has the full framing; plan.md Phase C implements
-   whichever he picks.
-2. **Marker** — confirm we do **not** add an explicit `binding:"latest"` wire marker now,
-   relying on absence-of-revision as the policy signal (context.md D2). Flagged as the
+1. **Default mode on create.** Recommendation: new triggers default to Latest, but a
+   drawer opened from a context that carries a concrete revision (for example, the
+   playground positioned on a revision) opens Pinned, pre-selected to that revision.
+   Today the code discards that context and hardcodes `revision: 0`
+   (`TriggerScheduleDrawer.tsx:496-507`). Context.md D1 has the full framing; plan.md
+   Phase C implements whichever he picks.
+2. **Wire marker.** Confirm we do NOT add an explicit `binding: "latest"` field, and
+   keep the absence of a revision reference as the signal (context.md D2). This is the
    decision most worth a second opinion.
-3. **Rail choice** — confirm the third-peer-rail-item recommendation ("Latest | Pinned |
-   Deployed") over a picker leaf or a checkbox (context.md D1).
-4. **Cascader scoping** — confirm deferring the unscoped-picker fix to a follow-up issue
+3. **Rail choice.** Confirm the third peer rail item ("Latest | Pinned | Deployed")
+   over a picker leaf or a checkbox (context.md D1).
+4. **Picker scoping.** Confirm deferring the unscoped-picker fix to a follow-up issue
    (context.md D5).
 
-## Contradictions found vs. the original research brief
+## Citation corrections found during re-verification
 
-Re-verification agreed with the brief on all substantive backend/FE behavior. Citation
-corrections (behavior unchanged):
+Re-verification agreed with the original research brief on all behavior. Three
+citations were corrected, with no behavior change:
 
-1. **Settings-list path.** The sections live under a `components/` subfolder:
-   `web/oss/src/components/pages/settings/Triggers/components/GatewaySchedulesSection.tsx`
-   (not `.../Triggers/GatewaySchedulesSection.tsx`). "Bound workflow" column is at
-   `:112-129` (title `:113`, render `:116-127`).
-2. **Cascader scoping site.** The unscoping is `applicationRevisionAdapter` built on
-   `appWorkflowsListQueryStateAtom` (schedule `:66-68`, subscription `:92`), not
-   `workflowRevisionRelationAdapter.ts:391-401` (that region is unrelated JSDoc).
-3. **422 scope.** The pre-existing 500 gap was on the subscription endpoints only; the
-   schedule endpoints already handled `TriggerReferenceInvalid` → 422 (review C5).
+1. The settings sections live under a `components/` subfolder:
+   `web/oss/src/components/pages/settings/Triggers/components/GatewaySchedulesSection.tsx`.
+2. The unscoped picker comes from `applicationRevisionAdapter` built on
+   `appWorkflowsListQueryStateAtom`, not from `workflowRevisionRelationAdapter.ts`.
+3. The 500 gap was subscription-endpoints only (see above).
 
-Also confirmed, resolving open questions in the brief:
-
-4. **Reference prefix.** The drawers and `buildRunVersionReferences` *write* the
-   `application_*` family. Agent-created (op-catalog) triggers *store* `workflow_*`. The
-   backend is prefix-agnostic — but the FE **reads** were not, which became blocker C1
-   (see "Review round 1" above). FE reads are now specified prefix-symmetric.
-5. **EntityPicker value support.** `UnifiedEntityPicker` already exposes `selectedValue` /
-   `selectedParentId` / `selectedChildId` / `displayRender` — the drawer just never passes
-   them, so displaying the current binding (Phase C) is wiring, not new picker work.
-6. **`agenta_builtins.py` trigger wording.** No "does not follow later commits" text
-   currently exists in the trigger sections (grep clean); only the op catalog carries it.
-   Phase E's skill step is a re-verify, not a guaranteed edit.
-
-No finding contradicts the brief's core claim that the backend already follows-latest and
-the pin must be reverted.
+Also confirmed while resolving the brief's open questions: the backend is
+prefix-agnostic but the frontend reads were not (now the classifier requirement); the
+`EntityPicker` already supports `selectedValue` / `displayRender`, so showing the
+current binding is wiring, not new picker work; `agenta_builtins.py` has no freeze
+language in its trigger sections today.

--- a/docs/design/trigger-latest-binding/status.md
+++ b/docs/design/trigger-latest-binding/status.md
@@ -1,0 +1,114 @@
+# Status — source of truth
+
+**State: DESIGN DRAFT — review round 1 folded in; next step: draft PR for Mahmoud's
+review.**
+
+Do not start implementation until Mahmoud reviews and approves this design (the
+plan-feature → draft-PR → review workflow). This file is the single source of truth for
+project state; if it disagrees with any other note, this file wins.
+
+_Last updated: 2026-07-07._
+
+## Where things stand
+
+- Research complete and re-verified against the working tree (see research.md, dated
+  2026-07-07). Every plan claim is cited to `file:line`.
+- Plan drafted (plan.md), phases A–F.
+- **Adversarial review round 1 complete** (UX + correctness): UX verdict
+  SOUND-WITH-CHANGES, correctness verdict RETHINK-narrowly — one scope defect, mechanism
+  sound. **All findings are folded into this revision** (see "Review round 1" below); the
+  scope defect (blocker C1) is fixed in context.md D2 and plan.md Phases B–D/F.
+- No code written for this project yet. **No git/but/gitbutler writes have been made by
+  the planning agent.**
+- **Next step:** open the draft PR carrying this workspace for Mahmoud's review.
+
+## Review round 1 (folded into this revision)
+
+**Blocker C1 (correctness scope defect — FIXED in this revision).** The original plan said
+"FE work stays on `application_*`", but the FE read paths never read the `workflow_*`
+reference family, and agent-created triggers store `{workflow_variant: {id}}`
+(op_catalog.py:1128-1130, :1140-1142). The `fe4a01f` pin masked this by writing
+`workflow_revision`, which the drawers do read. Post-revert, agent triggers would have
+prefilled null, blocked name-only edits, and shown "-" in the settings list. The design
+now requires **one shared prefix-symmetric classifier** (prefixes `application` /
+`workflow` / `evaluator`, mirroring the backend's own detection at
+`api/oss/src/core/triggers/service.py:782-789`) used by both drawers and both settings
+sections — context.md D2/D3/D4, plan.md cross-phase invariant + Phases B–D, and a
+`{workflow_variant} → Latest` unit-test case in Phase F. Resubmit was verified already
+prefix-safe (edit-without-repick echoes stored refs verbatim); an active re-pick rewrites
+to `application_*`, accepted as a silent prefix migration.
+
+**UX changes folded:** settings list must classify + resolve names via the same
+classifier (U4 → D4/Phase D); Latest hint copy tightened to *"Always runs the newest
+committed revision of this variant (ignores environments)"* to disambiguate from
+Deployed (U2 → D1/Phase B); the default-mode decision is now an explicit open question,
+not silently decided (U3 → below); two pre-existing dangling-ref render gaps acknowledged
+as non-goals so they aren't mistaken for regressions (U5 → context.md non-goals).
+
+**Corrections folded:** the 422 "500 gap" was subscription-endpoints-only — schedules
+already had the handler at router.py:1283-1284 / :1379-1380 (C5 → research.md §3);
+the `commit_revision` description fix is a **correctness fix**, actively wrong for the
+common agent case post-revert, not polish (C4 → research.md §9, plan.md Phase E); the
+explicit-revision-untouched keeper tests added to the Phase A3 keep-list, noting the
+subscription twin doesn't exist yet and should be added (C6 → plan.md A3).
+
+## Existing lanes / PRs this project touches
+
+- **PR #5103 / lane `fix/trigger-revision-default-head`** — added the create-time pin
+  (commit `fe4a01f`). **This project reverts the pin and repurposes this PR as the
+  backend implementation PR** (Phase A). Retitle it to describe follow-latest, not
+  pinning.
+- **PR #5105 lane** (op catalog) — Phase E correctness fixes ride here.
+- **PR #5106 lane** (build-an-agent skill / `agenta_builtins.py`) — Phase E re-verify /
+  align here.
+- **Issue #5110** (jp) — deliveries recording which revision ran. **Out of scope**
+  (non-goal). Latest triggers resolve HEAD at fire time; the delivery record does not yet
+  capture the resolved revision.
+
+## Open questions for Mahmoud
+
+1. **Default mode when a concrete revision is in context (U3 — his call, not decided).**
+   Recommendation: new triggers default to **Latest**; but when the drawer opens from a
+   context carrying a concrete revision (e.g. the playground positioned on a revision —
+   the current create-mode default-bind at `TriggerScheduleDrawer.tsx:496-507` discards it
+   and hardcodes `revision: 0`), should it open **Pinned** pre-selected to that revision?
+   Recommended: yes. Context.md D1 has the full framing; plan.md Phase C implements
+   whichever he picks.
+2. **Marker** — confirm we do **not** add an explicit `binding:"latest"` wire marker now,
+   relying on absence-of-revision as the policy signal (context.md D2). Flagged as the
+   decision most worth a second opinion.
+3. **Rail choice** — confirm the third-peer-rail-item recommendation ("Latest | Pinned |
+   Deployed") over a picker leaf or a checkbox (context.md D1).
+4. **Cascader scoping** — confirm deferring the unscoped-picker fix to a follow-up issue
+   (context.md D5).
+
+## Contradictions found vs. the original research brief
+
+Re-verification agreed with the brief on all substantive backend/FE behavior. Citation
+corrections (behavior unchanged):
+
+1. **Settings-list path.** The sections live under a `components/` subfolder:
+   `web/oss/src/components/pages/settings/Triggers/components/GatewaySchedulesSection.tsx`
+   (not `.../Triggers/GatewaySchedulesSection.tsx`). "Bound workflow" column is at
+   `:112-129` (title `:113`, render `:116-127`).
+2. **Cascader scoping site.** The unscoping is `applicationRevisionAdapter` built on
+   `appWorkflowsListQueryStateAtom` (schedule `:66-68`, subscription `:92`), not
+   `workflowRevisionRelationAdapter.ts:391-401` (that region is unrelated JSDoc).
+3. **422 scope.** The pre-existing 500 gap was on the subscription endpoints only; the
+   schedule endpoints already handled `TriggerReferenceInvalid` → 422 (review C5).
+
+Also confirmed, resolving open questions in the brief:
+
+4. **Reference prefix.** The drawers and `buildRunVersionReferences` *write* the
+   `application_*` family. Agent-created (op-catalog) triggers *store* `workflow_*`. The
+   backend is prefix-agnostic — but the FE **reads** were not, which became blocker C1
+   (see "Review round 1" above). FE reads are now specified prefix-symmetric.
+5. **EntityPicker value support.** `UnifiedEntityPicker` already exposes `selectedValue` /
+   `selectedParentId` / `selectedChildId` / `displayRender` — the drawer just never passes
+   them, so displaying the current binding (Phase C) is wiring, not new picker work.
+6. **`agenta_builtins.py` trigger wording.** No "does not follow later commits" text
+   currently exists in the trigger sections (grep clean); only the op catalog carries it.
+   Phase E's skill step is a re-verify, not a guaranteed edit.
+
+No finding contradicts the brief's core claim that the backend already follows-latest and
+the pin must be reverted.


### PR DESCRIPTION
## Context

A trigger (a schedule or a subscription) can already follow a variant's latest revision. If the stored references name a variant and no revision, the backend resolves the variant's head revision fresh on every fire. Nothing extra is needed on the wire; leaving the revision out is the whole configuration.

The frontend does not know this binding exists. It cannot create it, and it renders triggers that use it as broken: editing one shows an empty required "Select workflow revision" field that blocks saving, and the settings list shows a raw id or "-". Agent-created triggers always use this shape (they store `workflow_variant`, a key the frontend never reads), so every one of them looks broken.

We first patched this in the backend: PR #5103 pinned the head revision into the references at save time so the UI would find a revision to show. That froze the binding, which defeats follow-latest. It was closed on 2026-07-09 as wrong behavior.

## What this PR contains

A design workspace, docs only, for fixing this on the frontend:

- **A Latest option** in the "Which version runs?" control, next to Pinned and Deployed. Picking Latest means picking a variant. The drawer submits a variant reference with no revision, the shape the backend already reads as follow-latest.
- **One shared classifier** for every frontend read of trigger references. It maps the stored shape to a mode (revision key = Pinned, variant key with no revision = Latest, environment key = Deployed) and accepts all three key prefixes (`application_*`, `workflow_*`, `evaluator_*`). Edit then opens in the right mode with the right value, and the settings list shows the workflow name plus a mode tag.
- **Backend cleanup:** remove the pin from the leftover #5103 lane and keep its one good piece, the 422 handlers on the subscription endpoints.
- **SDK wording:** fix op-catalog descriptions that tell agents a trigger "does not follow later commits".

Start with `README.md`. It explains the endpoint behavior and the fire-time resolution in about a page.

## Open questions for review (status.md)

1. Default mode on create: Latest everywhere, or Pinned when the drawer opens from a context that carries a concrete revision? Recommended: honor the revision as Pinned, default to Latest otherwise.
2. Confirm no explicit `binding` marker on the wire; the absence of a revision reference stays the signal.
3. Confirm the third rail item over a cascader leaf or a checkbox.
4. Confirm deferring the unscoped-picker fix to a follow-up issue.

https://claude.ai/code/session_01T7oSjou1EWXf6ECowRrDU4
