### PR TITLE
[fix] Suppress CodeQL weak-crypto false positive in uuid5 helper

### DIFF
--- a/services/runner/src/sessions/record-id.ts
+++ b/services/runner/src/sessions/record-id.ts
@@ -7,8 +7,14 @@ function uuidToBytes(uuid: string): Buffer {
   return Buffer.from(uuid.replace(/-/g, ""), "hex");
 }
 
-/** RFC 4122 uuid5 (SHA-1) of `name` under `namespace`. */
+/**
+ * RFC 4122 uuid5 (SHA-1) of `name` under `namespace`. SHA-1 is mandated by the uuid5 spec
+ * itself (RFC 4122 §4.3), not a security choice: the output is a non-secret, non-collision-
+ * sensitive identifier for record dedup, never used for auth, integrity, or secrecy.
+ */
 function uuid5(name: string, namespace: string): string {
+  // codeql[js/weak-cryptographic-algorithm] SHA-1 is the RFC 4122 uuid5 algorithm; the
+  // digest is a public, deterministic id, not a security-sensitive value.
   const hash = createHash("sha1")
     .update(uuidToBytes(namespace))
     .update(name, "utf8")


### PR DESCRIPTION
## Context
CodeQL flagged the SHA-1 use inside `stableRecordId`'s uuid5 helper (`services/runner/src/sessions/record-id.ts`) as `js/weak-cryptographic-algorithm`, per review comment on [#4791](https://github.com/Agenta-AI/agenta/pull/4791#discussion_r3536326794).

SHA-1 is not a security choice here. It is the algorithm RFC 4122 §4.3 mandates for uuid5, and the output is a public, deterministic identifier used only to dedupe session records (a resumed/re-sent tool-call snapshot upserts onto the same row). It carries no secret, auth, or integrity guarantee, so the collision-resistance weakness CodeQL is warning about does not apply.

## Changes
Added a `codeql[js/weak-cryptographic-algorithm]` suppression comment on the exact flagged line, plus a short doc comment on `uuid5` explaining why SHA-1 is correct (spec-mandated) rather than incidental. No behavior change.

## Tests / notes
- `pnpm run typecheck` passes.
- No functional change; this only silences the false-positive scanner finding with an explanation for future readers.