### PR TITLE
feat(frontend): agents table — Archive action, Created by, Last modified, column order

### DIFF
--- a/web/oss/src/components/pages/agent-home/components/YourAgentsTable/columns.tsx
+++ b/web/oss/src/components/pages/agent-home/components/YourAgentsTable/columns.tsx
@@ -23,9 +23,21 @@ export function createAgentColumns(actions: AgentColumnActions) {
             ),
         },
         {
+            type: "date",
+            key: "updatedAt",
+            title: "Last modified",
+            width: 220,
+        },
+        {
+            type: "date",
+            key: "createdAt",
+            title: "Created at",
+            width: 220,
+        },
+        {
             type: "text",
             key: "createdById",
-            title: "Created By",
+            title: "Created by",
             width: 160,
             render: (_, record) => (
                 <div className="h-full flex items-center">
@@ -38,18 +50,6 @@ export function createAgentColumns(actions: AgentColumnActions) {
                     />
                 </div>
             ),
-        },
-        {
-            type: "date",
-            key: "createdAt",
-            title: "Created At",
-            width: 220,
-        },
-        {
-            type: "date",
-            key: "updatedAt",
-            title: "Last modified",
-            width: 220,
         },
         {
             type: "actions",

--- a/web/oss/src/components/pages/agent-home/components/YourAgentsTable/columns.tsx
+++ b/web/oss/src/components/pages/agent-home/components/YourAgentsTable/columns.tsx
@@ -1,5 +1,5 @@
 import {createStandardColumns} from "@agenta/ui/table"
-import {Note, Rocket} from "@phosphor-icons/react"
+import {Note, Rocket, Trash} from "@phosphor-icons/react"
 
 import {
     AppNameCell,
@@ -10,6 +10,7 @@ import type {AppWorkflowRow} from "@/oss/components/pages/app-management/store"
 export interface AgentColumnActions {
     onOpen: (record: AppWorkflowRow) => void
     onOpenPlayground: (record: AppWorkflowRow) => void
+    onArchive: (record: AppWorkflowRow) => void
 }
 
 /** Lean read-only columns for the Home "Your agents" table: name + created + type. */
@@ -54,6 +55,14 @@ export function createAgentColumns(actions: AgentColumnActions) {
                     label: "Open in playground",
                     icon: <Rocket size={16} />,
                     onClick: (record) => actions.onOpenPlayground(record),
+                },
+                {type: "divider"},
+                {
+                    key: "archive",
+                    label: "Archive",
+                    icon: <Trash size={16} />,
+                    danger: true,
+                    onClick: (record) => actions.onArchive(record),
                 },
             ],
             showCopyId: false,

--- a/web/oss/src/components/pages/agent-home/components/YourAgentsTable/columns.tsx
+++ b/web/oss/src/components/pages/agent-home/components/YourAgentsTable/columns.tsx
@@ -1,10 +1,8 @@
+import {UserAuthorLabel} from "@agenta/entities/shared/user"
 import {createStandardColumns} from "@agenta/ui/table"
 import {Note, Rocket, Trash} from "@phosphor-icons/react"
 
-import {
-    AppNameCell,
-    AppTypeCell,
-} from "@/oss/components/pages/app-management/components/appWorkflowColumns"
+import {AppNameCell} from "@/oss/components/pages/app-management/components/appWorkflowColumns"
 import type {AppWorkflowRow} from "@/oss/components/pages/app-management/store"
 
 export interface AgentColumnActions {
@@ -13,7 +11,7 @@ export interface AgentColumnActions {
     onArchive: (record: AppWorkflowRow) => void
 }
 
-/** Lean read-only columns for the Home "Your agents" table: name + created + type. */
+/** Lean read-only columns for the Home "Your agents" table: name + creator + dates. */
 export function createAgentColumns(actions: AgentColumnActions) {
     return createStandardColumns<AppWorkflowRow>([
         {
@@ -25,21 +23,33 @@ export function createAgentColumns(actions: AgentColumnActions) {
             ),
         },
         {
+            type: "text",
+            key: "createdById",
+            title: "Created By",
+            width: 160,
+            render: (_, record) => (
+                <div className="h-full flex items-center">
+                    <UserAuthorLabel
+                        userId={record.createdById}
+                        showPrefix={false}
+                        showAvatar
+                        showYouLabel
+                        fallback="—"
+                    />
+                </div>
+            ),
+        },
+        {
             type: "date",
             key: "createdAt",
             title: "Created At",
             width: 220,
         },
         {
-            type: "text",
-            key: "appType",
-            title: "Type",
-            width: 160,
-            render: (_, record) => (
-                <div className="h-full flex items-center">
-                    <AppTypeCell workflowId={record.workflowId} />
-                </div>
-            ),
+            type: "date",
+            key: "updatedAt",
+            title: "Last modified",
+            width: 220,
         },
         {
             type: "actions",

--- a/web/oss/src/components/pages/agent-home/components/YourAgentsTable/index.tsx
+++ b/web/oss/src/components/pages/agent-home/components/YourAgentsTable/index.tsx
@@ -7,10 +7,15 @@ import {
 } from "@agenta/ui/table"
 import {Typography} from "antd"
 import type {TableProps} from "antd/es/table"
-import {useAtomValue} from "jotai"
+import {useAtomValue, useSetAtom} from "jotai"
 import {useRouter} from "next/router"
 
-import {agentsWorkflowsAtom, agentsWorkflowsLoadingAtom} from "@/oss/components/pages/agents/store"
+import {
+    agentsWorkflowsAtom,
+    agentsWorkflowsLoadingAtom,
+    invalidateAgentsWorkflowQueries,
+} from "@/oss/components/pages/agents/store"
+import {openDeleteAppModalAtom} from "@/oss/components/pages/app-management/modals/DeleteAppModal/store/deleteAppModalStore"
 import type {AppWorkflowRow} from "@/oss/components/pages/app-management/store"
 import {usePlaygroundNavigation} from "@/oss/hooks/usePlaygroundNavigation"
 import useURL from "@/oss/hooks/useURL"
@@ -32,20 +37,39 @@ const YourAgentsTable = ({forceEmpty = false}: YourAgentsTableProps) => {
     const router = useRouter()
     const {baseAppURL} = useURL()
     const {goToPlayground} = usePlaygroundNavigation()
+    const openDeleteAppModal = useSetAtom(openDeleteAppModalAtom)
     const rows = useAtomValue(agentsWorkflowsAtom)
     const isLoading = useAtomValue(agentsWorkflowsLoadingAtom)
 
-    const handleOpen = useCallback(
+    const handleOpenOverview = useCallback(
         (record: AppWorkflowRow) => router.push(`${baseAppURL}/${record.workflowId}/overview`),
         [router, baseAppURL],
     )
 
+    // Default open affordance (row click, name cell) — straight to the playground, not overview.
+    const handleOpenPlayground = useCallback(
+        (record: AppWorkflowRow) => goToPlayground(undefined, {appId: record.workflowId}),
+        [goToPlayground],
+    )
+
+    const handleArchive = useCallback(
+        (record: AppWorkflowRow) => {
+            openDeleteAppModal({
+                id: record.workflowId,
+                name: record.name,
+                onArchived: () => invalidateAgentsWorkflowQueries(),
+            })
+        },
+        [openDeleteAppModal],
+    )
+
     const actions: AgentColumnActions = useMemo(
         () => ({
-            onOpen: handleOpen,
-            onOpenPlayground: (record) => goToPlayground(undefined, {appId: record.workflowId}),
+            onOpen: handleOpenOverview,
+            onOpenPlayground: handleOpenPlayground,
+            onArchive: handleArchive,
         }),
-        [handleOpen, goToPlayground],
+        [handleOpenOverview, handleOpenPlayground, handleArchive],
     )
     const columns = useMemo(() => createAgentColumns(actions), [actions])
 
@@ -74,11 +98,11 @@ const YourAgentsTable = ({forceEmpty = false}: YourAgentsTableProps) => {
             bordered: true,
             loading: isLoading,
             onRow: (record) => ({
-                onClick: () => handleOpen(record),
+                onClick: () => handleOpenPlayground(record),
                 className: "cursor-pointer",
             }),
         }),
-        [handleOpen, isLoading],
+        [handleOpenPlayground, isLoading],
     )
 
     const showEmpty = forceEmpty || (!isLoading && rows.length === 0)

--- a/web/oss/src/components/pages/agents/store.ts
+++ b/web/oss/src/components/pages/agents/store.ts
@@ -22,6 +22,7 @@ const mapWorkflowToRow = (workflow: Workflow): AppWorkflowRow => ({
     isEvaluator: false,
     updatedAt: workflow.updated_at ?? workflow.created_at ?? null,
     createdAt: workflow.created_at ?? null,
+    createdById: workflow.created_by_id ?? null,
 })
 
 const agentsWorkflowsQueryAtom = atomWithQuery((get) => {

--- a/web/oss/src/components/pages/app-management/store/appWorkflowStore.ts
+++ b/web/oss/src/components/pages/app-management/store/appWorkflowStore.ts
@@ -55,6 +55,8 @@ export interface AppWorkflowRow {
     isEvaluator: boolean
     updatedAt: string | null
     createdAt: string | null
+    /** Creator user id (artifact `created_by_id`), resolved to a name via UserAuthorLabel. */
+    createdById?: string | null
     deletedAt?: string | null
     deletedById?: string | null
     [k: string]: unknown


### PR DESCRIPTION
## Context

The Home "Your agents" table shipped a lean read-only view: a **Type** column, a title-case **Created At** column, no way to archive a row, and a row click that opened the app **overview**.

These three commits improve that table. They were built on the parked design-era lane `feat/onboarding-home-ux`, which is never going to be PR'd on its own — the rest of that branch is superseded by the already-merged template strip (#5098) and onboarding work. This PR lifts only the three agents-table keepers, in dependency order, onto a clean branch off `big-agents`.

## Changes

The table now reads like the rest of the product: creator and recency instead of a redundant type, an archive affordance, and a click that lands you in the playground.

| | Before | After |
| --- | --- | --- |
| Columns | Name, Created At, **Type** | Name, **Last modified**, **Created at**, **Created by** |
| Headers | Title Case ("Created At") | Sentence case ("Created at") |
| Row click | opens app **overview** | opens the **playground** |
| Row actions | none | **Archive** (restored) |

Supporting data-layer edits expose the creator id (`created_by_id` → `createdById` on `AppWorkflowRow`) so the **Created by** column can resolve it to a name via `UserAuthorLabel` (`@agenta/entities/shared/user`).

Commits (dependency order):
- `row click opens playground, restore Archive action` — `index.tsx` + `columns.tsx`
- `drop Type column, add Created By and Last modified` — `columns.tsx` + two stores
- `column order (Last modified, Created at, Created by) + sentence-case headers` — `columns.tsx`

## Scope / risk

Small and contained. Four files, all agents-table:
- `web/oss/src/components/pages/agent-home/components/YourAgentsTable/columns.tsx`
- `web/oss/src/components/pages/agent-home/components/YourAgentsTable/index.tsx`
- `web/oss/src/components/pages/agents/store.ts`
- `web/oss/src/components/pages/app-management/store/appWorkflowStore.ts`

Classic Home still renders this table; strip mode is unaffected. No API, wire, or shared-component changes. Prettier and ESLint clean on all four files; the live dev web stack compiles the apps page (which renders the table) to 200 with no errors.

## How to QA

1. Open the agent Home "Your agents" table.
2. Confirm the columns are **Name, Last modified, Created at, Created by** (sentence case, no Type column), with **Created by** showing a user name.
3. Confirm each row has an **Archive** action and that archiving refreshes the list.
4. Click a row — it should open the **playground**, not the app overview.

https://claude.ai/code/session_01N2djTMgXnpk84EqtugHDJB
