### PR TITLE
docs(design): build kit as the reserved static workflow __ag__build_kit

### DIFF
--- a/docs/design/build-kit-overlay-delivery/README.md
+++ b/docs/design/build-kit-overlay-delivery/README.md
@@ -1,0 +1,67 @@
+# Build-kit overlay delivery — make the playground build kit reliably visible on every agent
+
+**Status:** DESIGN DRAFT (see [status.md](./status.md))
+**Owner:** onboarding / agent-workflows
+**Created:** 2026-07-07
+
+## The one-paragraph problem
+
+The playground's Advanced section shows a read-only "Playground build kit" overlay on
+agent configs — 16 platform ops, the read/bash builtins, `request_connection`, the
+build-an-agent skill, and the sandbox permissions the assistant uses to build and revise
+an agent. It is **missing** on agents created through the new template-builder /
+playground-native onboarding flow, both before the agent is committed AND after. Today
+the overlay is delivered by riding on a single application-fetch response
+(`GET /simple/applications/{id}` → `additional_context`) and resolved on the frontend
+through a fragile three-hop atom chain keyed on the open revision. The overlay content,
+however, is a **static function of the platform catalog** — `build_agent_template_overlay()`
+takes no application argument. Coupling it to a per-application fetch is the root of this
+whole bug class.
+
+## The fix in three sentences
+
+Make the build kit the reserved static workflow **`__ag__build_kit`** in the existing
+`StaticWorkflowCatalog` — a **plain agent config** whose `parameters.agent` carries the
+tools, skills, and sandbox elevation — and have the frontend resolve it **by slug** through
+the workflow retrieve path that already serves the other `__ag__*` constants, **once per
+project/session**. Merge it **client-side onto any agent-typed entity** open in the
+playground — ephemeral `local-*` drafts, onboarding-committed agents, classic template
+apps, and SDK-created apps alike — gated only by the target entity's type
+(`flags.is_agent`), never by a workflow/application id. Retire the per-application
+`additional_context` attachment once the frontend migrates.
+
+**Decision: Option F (Mahmoud, 2026-07-07).** No new endpoint and no new id — one namespace
+and one mental model shared with the other static constants, embed-ability left open as a
+future product choice. This supersedes the earlier "dedicated route" (A) and "rider on the
+catalog-template response" (B) doors. See
+[context.md](./context.md#delivery-door--decision-option-f-reserved-static-workflow) and
+[status.md](./status.md).
+
+## Why this matters now (the gate)
+
+This fix **gates the flags-default-on re-flip**. Mahmoud's requirement is that the new
+agent experience ship default-on with zero env configuration; the parked default work
+lives on the PR #5121 lane. We should not flip the new onboarding on by default while its
+signature affordance (the build kit) is invisible on the agents it creates. See
+[context.md](./context.md#the-gate-flags-default-on).
+
+## File index
+
+| File | What's in it |
+|------|--------------|
+| [context.md](./context.md) | Problem statement, background, the flag-default gate, constraints, the Option-F decision (with A–E for the record), glossary |
+| [research.md](./research.md) | Root-cause with live evidence, the old atom chain, the disproven "missing application row" theory, the Option-F verify-item findings, file/line map |
+| [plan.md](./plan.md) | Phased implementation sized for narrow subagents (catalog entry, FE slug retrieve, retire the rider, tests, live QA) |
+| [status.md](./status.md) | The Option-F decision, the parked lane's fate, root-cause verdict, what needs Mahmoud's confirmation, next steps |
+
+## TL;DR of the root cause
+
+The server is healthy for **every** creation path. Live-verified: an agent created the
+onboarding way (`POST /workflows/` + variant + two commits) resolves as a full simple
+application, and `GET /simple/applications/{workflow_id}` returns the identical 16-tool
+overlay that the classic path returns. **The "onboarding commits a bare workflow with no
+application row" theory is disproven.** The gap is entirely in the delivery/resolution
+coupling on the frontend: the overlay is only reachable through
+`revisionId → workflow_id → applicationId → app fetch`, and that chain short-circuits for
+ephemeral drafts (no `workflow_id`) and is identity/timing-fragile for the in-place
+onboarding swap. Because the overlay is catalog-static, the entire chain is unnecessary.

--- a/docs/design/build-kit-overlay-delivery/context.md
+++ b/docs/design/build-kit-overlay-delivery/context.md
@@ -1,0 +1,227 @@
+# Context
+
+## What the build kit is
+
+Every agent config in the playground carries a read-only **build kit** overlay, rendered
+as a "Playground build kit" accordion at the top of the Advanced section. It advertises
+the tools, skills, and elevated sandbox permissions the platform injects into the agent's
+runtime **while the user is building the agent in the playground** — so the assistant can
+create files, run code, inspect the platform, and edit the agent's own config. The
+current overlay contains:
+
+- 16 tools: 13 platform ops + read/bash builtins + `request_connection`
+- the build-an-agent skill
+- sandbox permission elevations (e.g. reads/writes the assistant needs)
+
+None of this is part of the *published* agent. The backend strips agent metadata on
+commit, so the overlay is a **playground-only, never-persisted** augmentation. It exists
+to make the in-playground building experience work; it must not leak into the committed
+revision's parameters.
+
+## The bug
+
+Mahmoud reports the build kit is **missing** on agents created through the new
+template-builder / playground-native onboarding flow — and, critically, **it stays
+missing after the agent is committed**. That post-commit datum is what makes this more
+than the already-understood "ephemeral draft has no server row yet" gap: it says the
+delivery mechanism fails even once a real, committed, server-backed agent exists.
+
+The classic path (create an app, land on its playground) shows the overlay correctly.
+
+## Why the current delivery is the root of the bug class
+
+`build_agent_template_overlay()` (`api/oss/src/apis/fastapi/applications/overlay.py`)
+takes **no arguments**. The overlay is a pure function of the platform catalog — the same
+16 tools for every agent, in every project (modulo future per-plan gating). Yet it is
+delivered by **attaching it to one specific application-fetch response** and resolved on
+the frontend by walking from the open revision up to its application and fetching that
+application. That coupling:
+
+- breaks for ephemeral drafts, which have no application/workflow id yet;
+- is identity- and timing-fragile for the onboarding in-place swap (the drill-in entity
+  id, the primed revision cache, and the app query all have to line up);
+- makes a global, static resource behave as if it were per-application data.
+
+The correct model is: fetch the catalog-static overlay **once per project**, and apply it
+**client-side by entity type**. See [research.md](./research.md) for the evidence.
+
+## The gate: flags-default-on
+
+This project **must land before** the new-experience-default-on re-flip. The requirement
+(Mahmoud) is: the new agent onboarding ships **default-on with zero env configuration**.
+The parked default-flip work is on the **PR #5121** lane. Shipping the new onboarding by
+default while the build kit — the visible signal that the playground gives the assistant
+building powers — is absent on freshly created agents would ship a visibly broken core
+affordance. So: fix delivery first, then flip the default.
+
+## Constraints that must hold
+
+These are fixed requirements for any design in this workspace:
+
+1. **Server-sourced.** The catalog stays the single source of truth. Tool/skill embeds
+   are resolved server-side. The frontend never hard-codes the overlay. This also keeps
+   the door open for **future per-plan gating** (an EE entitlement could shape the overlay
+   per subscription).
+2. **Agent-template-type-scoped.** The overlay applies only to agent-typed entities. The
+   frontend decides applicability by entity **type** (`flags.is_agent`), not by any id.
+3. **Never persisted.** The overlay is playground-only and stripped on commit. This
+   behavior is unchanged — commit already reads only the user-owned revision config
+   (`prepareCommitParameters` in `web/packages/agenta-entities/src/workflow/state/commit.ts`
+   strips agenta metadata), so the overlay never enters committed parameters. Do not
+   regress this. This now also covers the reserved workflow itself: `__ag__build_kit` is
+   retrievable by slug but must be **rejected** if referenced by `@ag.embed` from another
+   config's commit (the embeddability policy, codex review — see the delivery-door section
+   above and [plan.md](./plan.md)).
+4. **Cover every creation path** with no regression: ephemeral pre-commit, onboarding
+   post-commit, classic template flow, and SDK-created apps.
+
+## Coverage matrix (what "done" means)
+
+| Creation path | Entity in playground | Must show build kit |
+|---|---|---|
+| Ephemeral draft (onboarding, pre-commit) | `local-*` (no workflow_id), `is_agent: true` | Yes |
+| Onboarding-committed agent | real revision id, `is_agent: true` (inferred at commit) | Yes |
+| Classic template app | real revision id, `is_agent: true` | Yes (no regression) |
+| SDK-created agent app | real revision id, `is_agent: true` | Yes |
+| Non-agent entity (prompt, evaluator, chat) | any | No (unchanged) |
+
+## Delivery door — DECISION: Option F (reserved static workflow)
+
+**Decision (Mahmoud, 2026-07-07): Option F.** The build kit becomes a **reserved static
+workflow `__ag__build_kit`** in the existing `StaticWorkflowCatalog`
+(`api/oss/src/core/workflows/static_catalog.py`), joining the three constants already
+there (`__ag__getting_started_with_agenta`, `__ag__request_connection`,
+`__ag__build_an_agent`). The frontend resolves it **by slug** through the existing workflow
+retrieve path that already serves those other `__ag__*` slugs, fetches it **once per
+project/session**, and merges it as the overlay onto any agent-typed entity
+(`flags.is_agent`). Options A and B (below) are superseded; C/D/E stay rejected.
+
+### Mahmoud's two refinements (the load-bearing part of F)
+
+1. **The build kit is just an agent configuration.** The static workflow's revision data
+   carries `parameters.agent` populated with the kit fields — `tools` (the read/bash
+   forced builtins + the 13 platform ops + the `request_connection` embed), `skills` (the
+   build-an-agent embed), and `sandbox` (the permission elevations). That is the **same
+   shape any agent config already has** (`parameters.agent` is a partial/full
+   `AgentTemplate`; the FE already merges this exact shape — see
+   [research.md](./research.md) §Merge). There is **no new schema flavor, no
+   `parameters.overlay`, no new selector kind**. "Overlay" is only how the playground *uses*
+   this config (merge it into runs, strip it on commit), not a new type on the wire.
+2. **Nothing relocates *in the domain sense*.** The catalog entry is added where the catalog
+   already lives — `api/oss/src/core/workflows/static_catalog.py`, the **core** layer (this
+   file previously mislabeled that as "API layer"; corrected by the codex review below). The
+   platform-ops content itself is not rewritten or re-scoped to a new domain, and no SDK
+   migration is needed.
+
+   **Layering refinement (codex xhigh design review, 2026-07-07):** core code must never
+   import the API layer (`api/AGENTS.md` layering rule). `static_catalog.py` (core) cannot
+   therefore call `build_agent_template_overlay()` in
+   `apis/fastapi/applications/overlay.py` (API layer) the way the original plan assumed. The
+   content builder — the `DEFAULT_BUILD_KIT_OPS` list, the tool/skill/sandbox assembly, and
+   `_reserved_static_tool_embeds()` — **moves into `core/workflows`** (a new `build_kit`
+   module next to `static_catalog.py`, or folded into `static_catalog.py` itself).
+   `overlay.py` becomes a **thin back-compat adapter** that calls the relocated core
+   builder; the SDK-constant imports (`AGENTA_FORCED_TOOLS`, `BUILD_AN_AGENT_SLUG`,
+   `REQUEST_CONNECTION_WORKFLOW_SLUG`) move their import site to the new core module
+   accordingly. This still matches Mahmoud's intent — "wherever the static catalog is, we
+   would add this" — the content lives next to the catalog; the refinement is that "next to
+   the catalog" is a core-layer location, so the builder has to live there too, not that the
+   content changes ownership or domain. Full detail:
+   [plan.md](./plan.md#phase-be-1--add-__ag__build_kit-to-the-static-catalog-api).
+
+   **Embeddability policy (codex review, new constraint):** because `__ag__build_kit` is a
+   real catalog workflow addressable by slug, it must be **retrievable but not
+   embeddable/committable** — the embed resolver and/or commit path must reject any
+   `@ag.embed` reference to it, so no API caller can persist a reference that drags
+   playground-only tools into a published agent. See the embeddability policy and its test
+   in [plan.md](./plan.md#phase-be-1--add-__ag__build_kit-to-the-static-catalog-api).
+
+   **Rider compatibility window (codex review):** BE-2 (removing
+   `additional_context.playground_build_kit` from `fetch_simple_application`) is **deferred
+   to a follow-up release**, not shipped in this PR. This PR keeps the rider live
+   server-side; the FE goes **slug-first** (retrieve `__ag__build_kit` by slug) with the
+   existing per-app `additional_context` chain retained as a **fallback** for deploy skew —
+   an old API server paired with a new FE, or a cached old FE bundle paired with a new API.
+   See [plan.md](./plan.md#phase-fe-1--slug-retrieve--entity-type-gate-frontend) and
+   [plan.md](./plan.md#phase-be-2--retire-the-per-application-rider-api--deferred-to-a-follow-up-release).
+
+### Why F beats the earlier doors
+
+| Door | One-line reason F wins |
+|---|---|
+| **A — dedicated `GET /simple/applications/build-kit`** (built in BE-1, now discarded) | New route, new `operation_id`, new response model, new Fern surface for content that already has a home in the catalog. F adds **no endpoint and no id**. |
+| **B — rider field on `fetch_application_catalog_template`** (previously recommended) | Still a bespoke `agent_template_overlay` field grafted onto an unrelated response, and no FE caller of that route exists today. F puts the kit in the **same `__ag__*` namespace and one mental model** as the other three static constants, reached by the retrieve path the FE already uses. |
+
+F also leaves **embed-ability open as a future product choice**: because the kit is a real
+catalog workflow addressable by slug/id, it can later be embedded by reference from other
+configs the same way `__ag__build_an_agent` and `__ag__request_connection` already are — a
+door A/B rider on an inspect response could never offer. (For now, per the embeddability
+policy above, it must actively be **rejected** as an embed target — "open as a future
+choice" is a deliberate later decision, not the current default.)
+
+### Naming considered (codex xhigh design review, 2026-07-07)
+
+Codex suggested `__ag__playground_build_kit` for lifecycle clarity — the slug would signal
+"playground-only" the way `__ag__build_an_agent` signals its purpose. **Decision: stays
+`__ag__build_kit`** (Mahmoud's name). The playground-only lifecycle (never persisted, never
+embeddable) is documented at the catalog entry itself — its `description` field and a code
+comment in the core `build_kit` module/`static_catalog.py` — not encoded into the slug.
+
+### The three earlier options, kept for the record
+
+**Option A — dedicated route (implemented in BE-1, now DISCARDED).**
+`GET /simple/applications/build-kit` (`SimpleApplicationsRouter`, registered
+`api/oss/src/apis/fastapi/applications/router.py:1801-1809`, handler
+`router.py:1896-1932`, `operation_id="fetch_simple_application_build_kit"`, response model
+`SimpleApplicationBuildKitResponse` — `api/oss/src/apis/fastapi/applications/models.py:665-680`).
+Superseded by F: a whole new route/model/Fern surface for one catalog-static object. The
+parked BE code for it is **discarded** (see [status.md](./status.md)).
+
+**Option B — rider on `fetch_application_catalog_template` (Mahmoud's earlier suggestion).**
+`GET /applications/catalog/templates/{template_key}` (registered `router.py:140-148`,
+handler `router.py:470-495`, response model `ApplicationCatalogTemplateResponse` —
+`models.py:797-804`). Superseded by F: it still adds a bespoke overlay field to a template
+response, and no FE surface calls that fetch-by-key route today, so "the creation surfaces
+already call it" was never literally true. F needs no rider field at all.
+
+**Option C — the agent service `/inspect` channel.** Rejected (unchanged). The kit resolves
+`@ag.embed` references against the API-layer `StaticWorkflowCatalog`; serving it from the
+agent service would cross domain ownership.
+
+**Option D — FE hardcode.** Rejected (unchanged). Drift: the backend can add a platform op
+or skill and the FE would show a stale kit until a frontend deploy. The kit must stay
+server-sourced — and under F the catalog *is* that single server source.
+
+**Option E — persist into configs.** Rejected (unchanged). The overlay is playground-only
+and stripped on commit; it must not enter committed `data.parameters`. F preserves this:
+the catalog workflow is merged into runs client-side and never written to the user's
+revision.
+
+**Provisional parked work now resolved:** the BE-1 Option-A route/handler/model is
+**discarded**. The FE-1 half (project-scoped atom + `is_agent` gate) **transfers** — only
+its fetch swaps from the app-fetch chain to the slug-based retrieve of `__ag__build_kit`.
+See [plan.md](./plan.md) and [status.md](./status.md).
+
+## Glossary
+
+- **Build kit**: under Option F, the reserved static workflow `__ag__build_kit` whose
+  revision `data.parameters.agent` carries the platform tools, authoring skills, and
+  sandbox elevation. It is a plain agent config, not a new type.
+- **Overlay**: how the playground *uses* the build kit — merge its `parameters.agent` into
+  the per-run copy (client-side), render it read-only in the Advanced section, strip it on
+  commit. The FE object handed to the merger is still shaped `{tools, skills, sandbox}`.
+- **Reserved / static workflow**: a code-defined workflow served from
+  `StaticWorkflowCatalog` under the `__ag__*` slug namespace, never from Postgres. A user
+  cannot author or shadow one.
+- **Ephemeral / `local-*` entity**: a client-only draft minted from a catalog template
+  before any server write (`createEphemeralAppFromTemplate`).
+- **The old atom chain (removed by this design)**: the current 3-hop frontend resolution
+  `workflowAgentTemplateOverlayAtomFamily(revisionId)` →
+  `workflowQueryAtomFamily(revisionId).data.workflow_id` →
+  `simpleApplicationQueryAtomFamily(applicationId)` → `additional_context`. Option F
+  replaces it with a single project-scoped slug retrieve of `__ag__build_kit`, gated by the
+  target entity's `flags.is_agent`.
+- **Onboarding in-place swap**: after commit, onboarding does `setEntityIds([revisionId])`
+  + `history.replaceState` instead of a full page navigation, so the playground never
+  remounts (`useAgentOnboarding.ts`).
+</content>

--- a/docs/design/build-kit-overlay-delivery/plan.md
+++ b/docs/design/build-kit-overlay-delivery/plan.md
@@ -1,0 +1,261 @@
+# Plan
+
+Dependency order: BE-1 (catalog entry, core-layer builder + embeddability guard) → FE-1
+(slug retrieve + entity-type gate, rider kept as fallback) → TEST → QA. **BE-2 (retire the
+per-app rider) is deferred to a follow-up release** — see the compatibility-window note in
+Phase BE-2 below. FE-1 depends only on the shape of what `__ag__build_kit` returns, so the
+catalog entry and the FE atom scaffold can proceed in parallel once that shape is fixed.
+
+Every phase is verified against this tree. The delivery-door decision (Option F: the build
+kit is a reserved static workflow) is in
+[context.md](./context.md#delivery-door--decision-option-f-reserved-static-workflow). A
+codex xhigh design review of this plan (2026-07-07) folded six changes into the phases
+below — layering (BE-1), explicit entry metadata (BE-1), an embeddability policy
+(BE-1/TEST), a rider compatibility window (FE-1/BE-2), an RBAC verification
+(research.md §10), and positive test pinning (TEST). See
+[status.md](./status.md#review-rounds) for the round record.
+
+## Phase BE-1 — Add `__ag__build_kit` to the static catalog (API)
+
+**Goal:** serve the build kit as one more entry in `StaticWorkflowCatalog`, reached by slug
+through the retrieve path that already serves `__ag__build_an_agent` /
+`__ag__request_connection`. No new route, no new response model.
+
+**Layering (codex xhigh design review, 2026-07-07):** the content builder must live in
+`core/workflows` alongside `static_catalog.py` — core code can never import from the API
+layer (`apis/fastapi/**`, per `api/AGENTS.md`), and having `static_catalog.py` call into
+`apis/fastapi/applications/overlay.py` would do exactly that. `overlay.py` becomes a thin
+back-compat adapter instead. Details folded into the bullets below.
+
+Concrete edit points, verified against this tree:
+
+- **Catalog entry** — add `__ag__build_kit` to `_STATIC_WORKFLOWS`
+  (`api/oss/src/core/workflows/static_catalog.py:129`), next to the existing three entries,
+  with `{"latest": "v1", "versions": {"v1": _build_kit_revision()}}`. Add a slug constant
+  (e.g. `BUILD_KIT_WORKFLOW_SLUG = "__ag__build_kit"`); it must start with
+  `STATIC_SLUG_PREFIX` (`__ag__`) or `_validate_catalog` rejects it at construction
+  (`static_catalog.py:201-205`).
+- **Revision builder** — add `_build_kit_revision() -> WorkflowRevision` alongside
+  `_skill_revision` / `_client_tool_revision` (`static_catalog.py:72-125`). It returns a
+  `WorkflowRevision(name="Playground build kit", description=..., data=WorkflowRevisionData(
+  uri=<agent builtin uri>, parameters={"agent": <kit config>}))`. `_validate_catalog`
+  requires `data.uri` to be truthy (`static_catalog.py:213-222`), and `_build_revision`
+  infers flags from it (`static_catalog.py:283-284` → `infer_flags_from_data`). With
+  `uri = "agenta:builtin:agent:v0"` the kit revision infers `is_agent=True`,
+  `is_managed=True`, `is_skill=False`, `has_url=True`, and `is_static=True` (slug-derived)
+  — see `sdks/python/agenta/sdk/engines/running/utils.py:702-812`. The agent key must be in
+  `_AGENTA_ROLE_TABLE` or flag inference raises (it is; agents are a known key).
+- **Kit config = today's overlay output, builder relocated for layering** —
+  `parameters.agent` must equal exactly what `build_agent_template_overlay()` emits today
+  (originally `api/oss/src/apis/fastapi/applications/overlay.py:77-109`): `tools` = read/bash
+  forced builtins + the 13 `DEFAULT_BUILD_KIT_OPS` platform configs + the
+  `request_connection` `@ag.embed` (with `name` sibling); `skills` = the build-an-agent
+  `@ag.embed` (with `name` sibling); `sandbox.permissions = {write_files: allow,
+  execute_code: allow}`.
+
+  **Layering fix (codex xhigh design review, 2026-07-07):** `core/workflows/static_catalog.py`
+  cannot import from `apis/fastapi/applications/overlay.py` — core must never import the API
+  layer (`api/AGENTS.md`). So the content builder (the `DEFAULT_BUILD_KIT_OPS` list,
+  `build_agent_template_overlay()`'s tool/skill/sandbox assembly, and
+  `_reserved_static_tool_embeds()`) **moves into `core/workflows`** — either a new
+  `build_kit.py` module next to `static_catalog.py`, or folded directly into
+  `static_catalog.py`. `overlay.py` (`apis/fastapi/applications/`) becomes a **thin
+  back-compat adapter**: it calls the relocated core builder and returns the same shape any
+  existing caller expects, so no external contract changes. The SDK-constant imports
+  (`AGENTA_FORCED_TOOLS`, `BUILD_AN_AGENT_SLUG`, `REQUEST_CONNECTION_WORKFLOW_SLUG`) move
+  their import site from `overlay.py` to the new core module accordingly.
+
+  This **refines** context.md's "nothing relocates" (Mahmoud, Option F): the platform-ops
+  list and kit content are not rewritten, re-scoped, or moved to a different domain — they
+  move file location only, to sit at the core layer next to the catalog that serves them,
+  which matches Mahmoud's own framing ("wherever the static catalog is, we would add this").
+  See [context.md](./context.md#delivery-door--decision-option-f-reserved-static-workflow).
+
+  **Guards this builder needs (see [research.md](./research.md) §10 and verify item 2 — the
+  places the design as stated needs care), the self-reference guard now revised to an
+  explicit allowlist instead of inference (codex review):**
+  - **Explicit entry metadata, not inference:** `_reserved_static_tool_embeds()`
+    (relocating from `overlay.py:54-74`) currently builds tool embeds by iterating
+    `catalog.list_slugs()` and including every **non-skill** static workflow — an inference
+    ("non-skill means tool") that would embed `__ag__build_kit` **into itself** once the kit
+    itself is a non-skill catalog entry. Replace the inference with a **positive allowlist /
+    explicit per-entry kind metadata**: only `__ag__request_connection` is a tool embed. The
+    self-embed guard becomes **structural** (the builder only ever references the known
+    tool/skill slugs by name), not a special case bolted on afterward.
+  - **Import-time bootstrap:** `_build_kit_revision()` calling the relocated builder at
+    module load would construct a fresh `StaticWorkflowCatalog()` that reads
+    `_STATIC_WORKFLOWS` **while that dict is still being built** (the build-kit value is
+    mid-evaluation) → partial-dict / NameError. Build the kit revision **lazily** (compute
+    `parameters.agent` on first `retrieve_revision`, or via a module-level factory that runs
+    after `_STATIC_WORKFLOWS` is assigned), or pass the builder an explicit sub-catalog that
+    omits the build-kit entry. Either removes the cycle.
+
+  **Embeddability policy (codex review, new plan item):** `__ag__build_kit` must be
+  **retrievable but not embeddable/committable**. Being a real catalog workflow addressable
+  by slug must not let an API caller reference it via `@ag.embed` from another config and
+  have that reference persist — that would drag playground-only tools into a published
+  agent. The embed resolver (`api/oss/src/core/embeds/` — wherever workflow refs resolve)
+  and/or the commit path must **reject `__ag__build_kit` refs**. Add a unit test asserting a
+  commit containing an embed of `__ag__build_kit` is rejected (Phase TEST).
+- **No route changes.** The FE reaches the entry through the existing
+  `POST /workflows/revisions/retrieve` (`retrieve_workflow_revision`, router.py:341-349),
+  which resolves a reserved `__ag__*` slug through the catalog before any DB lookup
+  (`WorkflowsService.fetch_workflow_revision` → `_resolve_static_revision`,
+  `service.py:1460-1466`) and returns the synthetic revision directly, with
+  `data.parameters.agent` intact (no normalization, no DB). The catalog is already wired
+  into `workflows_service` at `api/entrypoints/routers.py:617-619`.
+
+**Discard the parked Option-A route.** Remove the `GET /simple/applications/build-kit`
+route registration (`router.py:1801-1809`), handler (`router.py:1896-1932`), and
+`SimpleApplicationBuildKitResponse` (`models.py:665-680`) from the parked lane — do not
+carry them forward. This is a straight drop of the discarded BE-1 diff.
+
+**Verify (live):** `POST /workflows/revisions/retrieve` with body
+`{"workflow_ref": {"slug": "__ag__build_kit"}}` and `?project_id=...` returns a revision
+whose `data.parameters.agent.tools` has 16 entries (2 builtins + 13 ops + 1
+request-connection embed) and `skills` has 1 embed, for a fresh account.
+
+## Phase FE-1 — Slug retrieve + entity-type gate (frontend)
+
+**Goal:** apply the kit to any agent-typed entity via the slug-first fetch, with the old
+app-fetch chain kept as a **compatibility fallback** until BE-2 ships (see the rider
+compatibility window below). The parked FE-1 work (`status.md`) **transfers**; only the
+primary fetch swaps to the slug retrieve.
+
+**Rider compatibility window (codex xhigh design review, 2026-07-07):** BE-2 (retiring
+`additional_context.playground_build_kit`) is **deferred to a follow-up release** — this PR
+keeps the rider live server-side. The FE must go **slug-first**: try
+`agentBuildKitOverlayAtom` (the `__ag__build_kit` slug retrieve) first, and only fall back to
+the existing per-app `additional_context.playground_build_kit` chain if the slug retrieve is
+unavailable. This covers the deploy-skew window — an old API server (no `__ag__build_kit`
+entry yet) paired with the new FE, or a cached old FE bundle paired with the new API. Do
+**not** delete `simpleApplicationQueryAtomFamily` / `fetchSimpleApplication` in this phase;
+that removal moves to BE-2.
+
+**Adapt from the parked lane:**
+
+- **Fetch** — replace the parked `fetchAgentBuildKitOverlay(projectId)` (which pointed at
+  the discarded Option-A route) with a call to the existing
+  `retrieveWorkflowRevision({projectId, workflowRef: {slug: "__ag__build_kit"}})`
+  (`web/packages/agenta-entities/src/workflow/api/api.ts:296`). It already goes through the
+  Fern client for `POST /workflows/revisions/retrieve`. **Do not** pass `resolve`: the FE
+  wants the **unresolved** `parameters.agent` (embeds + their `name` siblings) — that is
+  exactly what `useBuildKit` renders as embed-reference rows and what the run-time merger
+  passes through for the runner to resolve later. Read the overlay from
+  `revision.data.parameters.agent`.
+- **Project-scoped atom** — keep `agentBuildKitOverlayAtom` (project-scoped `atomWithQuery`,
+  `queryKey: ["agentBuildKitOverlay", projectId]`, `staleTime: Infinity`, `enabled: session
+  && projectId`) in `web/packages/agenta-entities/src/workflow/state/store.ts`. Its `queryFn`
+  now does the slug retrieve above and returns `revision.data.parameters.agent`.
+- **Entity-type gate** — rewrite `workflowAgentTemplateOverlayAtomFamily(revisionId)`
+  (currently the 3-hop app chain, `store.ts:1185-1203`) to gate purely on the **target
+  entity** type: `get(workflowQueryAtomFamily(revisionId)).data?.flags?.is_agent ??
+  get(workflowBaseEntityAtomFamily(revisionId))?.flags?.is_agent ?? false`; if not an agent,
+  return `null`; otherwise return `get(agentBuildKitOverlayAtom).data`. Keep the export
+  name/signature so `useBuildKit` (`useBuildKit.tsx:127`) and `agentRequest.ts` /
+  `buildKitOverlay.ts` are untouched. **Keep this distinct in the doc/code:** the
+  `flags.is_agent` gate reads the entity being edited, **not** the kit workflow's own flags.
+- **Keep the app-fetch chain as fallback (deferred removal, codex review)** — do not delete
+  `simpleApplicationQueryAtomFamily` / `fetchSimpleApplication` in FE-1 (grep confirmed the
+  overlay atom was their only reader — `status.md`). They become the skew-window fallback
+  path described above; their removal is now scoped to BE-2, once the rider is retired
+  server-side.
+- **Never-persisted invariant** — unchanged. The overlay stays client-side-merged
+  (`buildKitOverlay.ts`) and never enters `prepareCommitParameters` output.
+
+**Verify:** the kit renders for an ephemeral agent draft, after in-place onboarding commit,
+and on a classic app playground, with a single network fetch per project.
+
+## Phase BE-2 — Retire the per-application rider (API) — DEFERRED to a follow-up release
+
+**Deferred (codex xhigh design review, 2026-07-07).** This PR does **not** remove the
+`additional_context.playground_build_kit` rider on `fetch_simple_application`. Removing it
+now would break the FE's slug-first-with-fallback compatibility window (Phase FE-1) for the
+exact skew case it exists to cover — a cached old FE bundle (still reading the per-app
+rider) paired with a new API server. Keep the rider live through this release; run this
+phase in a **follow-up release** once the slug-first path has shipped long enough that skew
+is no longer a concern. The steps below are otherwise unchanged and ready to execute then.
+
+Do this only after FE-1 ships against `__ag__build_kit` (and after the compatibility window
+above has closed).
+
+- Remove overlay synthesis from `fetch_simple_application` (the
+  `additional_context.playground_build_kit` attach, `router.py:1960-1975`);
+  `additional_context` returns to `None` there. **Re-grep before editing** — line numbers
+  shift once the discarded Option-A route/model are dropped in BE-1.
+- The reader sweep already proved the FE overlay atom was the only consumer of
+  `additional_context.playground_build_kit` (`context.md`), so this is a straight removal,
+  not a phased deprecation.
+- Optionally trim the now-unused overlay response models
+  (`PlaygroundBuildKitContext`, `SimpleApplicationAdditionalContext`,
+  `models.py:627-642`) once no handler populates them. `AgentTemplateOverlay`
+  (`models.py:602-624`) can stay as documentation of the `parameters.agent` subset, or be
+  dropped if nothing references it.
+
+## Phase TEST — automated coverage
+
+**Codex xhigh design review (2026-07-07) revised this phase: positive pinning instead of
+enumeration, plus two new required tests (self-embed guard, embeddability guard).**
+
+- **API unit** (`api/oss/tests/pytest/unit/`):
+  - Content-equivalence: `StaticWorkflowCatalog().retrieve_revision(
+    slug="__ag__build_kit").data.parameters["agent"] == <core build-kit builder output>`
+    (post-layering-fix, the builder lives in `core/workflows`; `overlay.py`'s
+    `build_agent_template_overlay()` is the thin adapter and should itself assert equal to
+    the same core builder). Also: the kit revision carries `flags.is_static=True`,
+    `flags.is_agent=True`, and a stable synthetic id; and `_resolve_static_revision` returns
+    it for a `{slug: "__ag__build_kit"}` ref without a DB hit.
+  - **Positive pin on tool embeds (codex review — replaces enumeration):** assert the tool
+    embeds set is **exactly** `{"__ag__request_connection"}` — not "every non-skill static
+    workflow." Enumerating `catalog.list_slugs()` and asserting "all non-skill slugs are
+    tool embeds" would **pass even with the self-embed bug** (finding 2) once
+    `__ag__build_kit` exists, because the kit itself is a non-skill slug that enumeration
+    would then bless as a tool embed of itself. Update the existing enumeration-style
+    assertion in `applications/test_build_kit_overlay.py` to this positive/explicit form.
+  - **New: "does not embed itself" test** — assert `__ag__build_kit` does **not** appear
+    anywhere in its own `tools`/`skills` embed list. Guards finding 2's fix directly, not
+    just via the positive pin above.
+  - **New: embeddability/commit-rejection test (finding 3)** — assert that committing a
+    workflow revision whose `parameters` contains an `@ag.embed` reference to
+    `__ag__build_kit` is **rejected** (by the embed resolver and/or the commit path,
+    whichever enforces the policy — see Phase BE-1's embeddability policy). This is the
+    regression test for "no API caller can persist a reference that drags playground tools
+    into a published agent."
+- **API integration**:
+  - Hit `POST /workflows/revisions/retrieve` with the slug under an admin-minted account;
+    assert the 16-tool / 1-skill shape and that no DB row exists for the slug.
+  - **New: slug-retrieve content-equivalence test (codex review)** — assert the *retrieve
+    response* for `{slug: "__ag__build_kit"}` equals the core builder's direct output
+    end-to-end (not just the in-process catalog object), pinning the wire contract, not just
+    the internal builder.
+- **Delete** the discarded Option-A `fetch_simple_application_build_kit` tests.
+- **FE unit** (package `tests/unit/`): the rewritten overlay atom returns the kit for an
+  agent-typed entity and `null` for a non-agent entity, and does not depend on `workflow_id`.
+  **New:** a slug-first-with-fallback test (finding 4) — when the slug retrieve is
+  unavailable, the atom falls back to the per-app `additional_context.playground_build_kit`
+  chain.
+
+## Phase QA — live scripts, one per creation path
+
+Run against `:8280` (EE dev, hot-reloads this tree). Mint an ephemeral account, exercise,
+then archive every created entity (`POST /workflows/{id}/archive`).
+
+1. **Ephemeral pre-commit:** open onboarding, confirm the build kit is visible on the draft
+   agent's Advanced section.
+2. **Onboarding post-commit:** send a seed to commit in place; confirm the kit stays visible
+   on the committed agent without a reload (the reported bug — must go green).
+3. **Classic template app:** create an agent app the classic way; confirm no regression.
+4. **SDK-created app:** create an agent via SDK; open its playground; confirm the kit.
+5. **Non-agent entity:** open a prompt/evaluator; confirm no build kit (no false positive).
+
+## Docs / sync
+
+- Run `keep-docs-in-sync`: the new `__ag__build_kit` catalog entry and the retired
+  `additional_context.playground_build_kit` rider on `fetch_simple_application` are
+  interface changes. Update the agent-workflows interface inventory (the `__ag__*` static
+  workflow list) and any doc that described the build-kit-on-fetch delivery.
+
+## Gate reminder
+
+After all phases are green, the **flags-default-on re-flip (PR #5121 lane)** is unblocked.
+Note that in the merge/handoff so the default flip proceeds.

--- a/docs/design/build-kit-overlay-delivery/research.md
+++ b/docs/design/build-kit-overlay-delivery/research.md
@@ -1,0 +1,444 @@
+# Research — root cause with live evidence
+
+All findings below were re-verified against the source in this tree and, where marked
+LIVE, against the running EE dev stack at `http://localhost:8280` on 2026-07-07. Test
+entities were created under ephemeral admin-minted accounts and archived after use.
+
+## 1. The overlay is catalog-static (no application coupling is inherent)
+
+`build_agent_template_overlay()` —
+`api/oss/src/apis/fastapi/applications/overlay.py:77` — takes **no arguments**. It builds
+the same 16-tool overlay every call from the platform catalog. There is a unit test
+pinning the tool list and the platform-ops/skill/permissions content:
+`api/oss/tests/pytest/unit/applications/test_build_kit_overlay.py`.
+
+The overlay is a pure function of platform state, not of any app/variant/revision. This
+is the load-bearing fact for the whole design: **there is no per-application input to
+overlay content**, so per-application delivery is a convenience, not a requirement.
+
+## 2. Where the overlay attaches today (server)
+
+`fetch_simple_application` (handler for `GET /simple/applications/{application_id}`) —
+`api/oss/src/apis/fastapi/applications/router.py:1881-1932`. It attaches the overlay onto
+`additional_context.playground_build_kit.agent_template_overlay` **unconditionally**
+whenever the fetched `simple_application` is truthy. It does **not** inspect flags, type,
+or ownership — any resolvable application gets the overlay.
+
+Models: `SimpleApplicationAdditionalContext`, `PlaygroundBuildKitContext`,
+`AgentTemplateOverlay` in `api/oss/src/apis/fastapi/applications/models.py:627-662`.
+
+`simple_applications_service.fetch(application_id)` —
+`api/oss/src/core/applications/service.py:1219-1287` — resolves by reusing the workflows
+git storage: `fetch_application` (artifact) → `fetch_application_variant` → newest
+`fetch_application_revision`. It returns non-None for **any** workflow that has a variant
+and at least one revision. There is no "is this a *simple application* vs a *bare
+workflow*" gate.
+
+## 3. How the two creation paths actually build an agent
+
+Both the "classic" and "onboarding" agent creations ultimately go through
+**`POST /workflows/`**, not `POST /simple/applications/`:
+
+- `createAppFromTemplate` (`web/packages/agenta-entities/src/workflow/api/createFromTemplate.ts`)
+  → `createWorkflow(...)`.
+- Onboarding: `useAgentOnboarding.ts` → `useCreateAgent.ts` →
+  `createWorkflowFromEphemeralAtom` (`.../workflow/state/commit.ts:564`) →
+  `createWorkflow(...)`.
+
+`createWorkflow` (`web/packages/agenta-entities/src/workflow/api/api.ts:795-904`) issues:
+1. `POST /workflows/` (artifact, `flags: {is_application: true}`)
+2. `POST /workflows/variants/` (a `default` variant)
+3. `POST /workflows/revisions/commit` (v0 seed)
+4. `POST /workflows/revisions/commit` (v1 with `data.uri` = the agent builtin uri)
+
+So the resulting artifact/variant/revision trio is **identical in shape** to what the
+classic path produces. There is no structural difference in the created rows.
+
+## 4. LIVE: the "missing application row" theory is DISPROVEN
+
+Replicated the exact onboarding API sequence against `:8280` under a fresh account, then
+fetched the app by its workflow id:
+
+```
+AGENT_URI = agenta:builtin:agent:v0   (catalog template key "agent")
+POST /workflows/            -> 200  workflow_id = 019f3ce2-ce19-...
+POST /workflows/variants/   -> 200
+POST /workflows/revisions/commit (v0) -> 200
+POST /workflows/revisions/commit (v1) -> 200  revision.workflow_id = 019f3ce2-ce19-...
+
+[A: onboarding]  GET /simple/applications/{workflow_id}
+    status=200  overlay=YES  tools=16  app present=True  count=1
+    GET /workflows/revisions/{revision_id}.workflow_id = 019f3ce2-ce19-...   (present)
+
+[B: classic]     POST /simple/applications/  -> 200
+    GET /simple/applications/{id}
+    status=200  overlay=YES  tools=16
+```
+
+**Conclusion:** a POST /workflows/-created ("onboarding") agent resolves as a full simple
+application and its `GET /simple/applications/{workflow_id}` returns the same 16-tool
+overlay as the classic path. The revision also returns its `workflow_id` correctly. The
+server is healthy for every creation path. **Hypothesis (d) — onboarding commits a bare
+workflow with no application row, causing a 404 — is false.**
+
+This also answers the coordinator's dependency question: **nothing extra depends on a
+distinct "application row" existing.** Applications are just workflows with
+`is_application` flags; the fetch path is flag-agnostic.
+
+### LIVE: is_agent is inferred server-side at commit
+
+The onboarding commit forwards only `is_application` on the artifact, but the server
+infers the handler flags from the URI. The committed revision's flags:
+
+```
+is_application: true, is_agent: true, is_managed: true, has_url: true, is_chat: false ...
+```
+
+So **every committed agent carries `is_agent: true`** regardless of which path created it.
+This is what lets the frontend gate the global overlay purely on entity type. (Ephemeral
+drafts also carry `is_agent: true` locally — set in `appUtils.ts` `buildWorkflow`.)
+
+## 5. So where does the gap live? The frontend resolution chain
+
+The overlay reaches the UI through exactly one chain
+(`web/packages/agenta-entities/src/workflow/state/store.ts:1185-1203`):
+
+```
+workflowAgentTemplateOverlayAtomFamily(revisionId)
+  ├─ revisionData = workflowQueryAtomFamily(revisionId).data
+  ├─ applicationId = revisionData?.workflow_id
+  │                ?? workflowBaseEntityAtomFamily(revisionId)?.workflow_id
+  │                ?? null            ← if null, return null (no overlay)
+  └─ simpleApplicationQueryAtomFamily(applicationId).data
+        .additional_context.playground_build_kit.agent_template_overlay
+```
+
+Consumed by `useBuildKit`
+(`web/packages/agenta-entity-ui/src/DrillInView/SchemaControls/agentTemplate/useBuildKit.tsx`)
+via `useModelHarness.tsx:376-390`, with `revisionId = drillIn?.entityId`
+(`AgentTemplateControl.tsx:274`). `hasBuildKitOverlay` drives whether the Advanced section
+even renders the block.
+
+### Pre-commit (ephemeral) gap — CONFIRMED by reading the atom
+
+An ephemeral `local-*` entity has no `workflow_id` (its local `Workflow` object sets no
+`workflow_id`; `workflowQueryAtomFamily` is disabled for local draft ids —
+`store.ts:1070 !isLocalDraftId(revisionId)`). So `applicationId` is `null` and the atom
+short-circuits to `null`. No overlay. This is the already-understood pre-commit gap.
+
+### Post-commit gap — a client-state coupling failure, not a data gap
+
+For an onboarding-committed agent the chain **can** resolve on paper: the commit primes
+`["workflows","revision", revisionId, projectId]` with the full commit response
+(`primeWorkflowRevisionDetailCacheImperative`, `store.ts:136`), and that response carries
+`workflow_id` (verified LIVE in §4); `GET /simple/applications/{workflow_id}` returns the
+overlay (§4). So the persistent post-commit disappearance is a **client-state
+identity/timing failure in the in-place onboarding swap**, where one of these hops fails
+to line up:
+
+- **Entity identity:** `revisionId = drillIn?.entityId` must have switched from the
+  ephemeral `local-*` id to the committed revision id. Onboarding swaps via
+  `setEntityIds([revisionId])` + `history.replaceState` with **no page remount**
+  (`useAgentOnboarding.ts:158-175`). The classic path does a full navigation to
+  `/apps/{id}/playground`, which remounts and re-fetches the revision fresh (workflow_id
+  guaranteed present). The in-place swap has more ways to leave a stale/ephemeral id or a
+  half-primed cache in the drill-in.
+- **Primed shape:** the overlay atom reads `workflowQueryAtomFamily(revisionId).data`.
+  If the primed/normalized revision object dropped `workflow_id`, the fallback
+  (`workflowBaseEntityAtomFamily` — only populated for local drafts) yields `null` for a
+  committed revision → no overlay.
+- **App query firing:** `simpleApplicationQueryAtomFamily(applicationId)` is only enabled
+  once `applicationId` is non-null; any window where it's keyed with `""`/null and the
+  app query doesn't re-fire on transition would leave it empty.
+
+We did not pin the single exact failing hop in a live browser session (it needs a
+headed onboarding repro), because **the chosen design removes the entire chain**, making
+the distinction moot. What matters for the design is settled: the server is fine, the
+overlay is catalog-static, and the only thing that varies per entity is *whether it's an
+agent*.
+
+## 6. Never-persisted behavior (unchanged, must not regress)
+
+`prepareCommitParameters` (`.../workflow/state/commit.ts:68-87`) strips agenta metadata and
+commits only the user-owned revision config; the overlay lives in read-only
+`additional_context` / session atoms and never enters committed params. The global design
+keeps the overlay entirely client-side-applied and out of the committed `data.parameters`,
+so this is preserved by construction.
+
+## 7. File / line map (for implementers)
+
+Server:
+- `api/oss/src/apis/fastapi/applications/overlay.py:77` — `build_agent_template_overlay()` (static)
+- `api/oss/src/apis/fastapi/applications/router.py:1881-1932` — current attachment on fetch
+- `api/oss/src/apis/fastapi/applications/models.py:627-662` — overlay models
+- `api/oss/src/core/applications/service.py:1219-1287` — `SimpleApplicationsService.fetch`
+- `api/oss/tests/pytest/unit/applications/test_build_kit_overlay.py` — overlay content tests
+- `api/entrypoints/routers.py:630,928,1005` — service + router wiring
+
+Frontend:
+- `web/packages/agenta-entities/src/workflow/state/store.ts:1169-1207` — app query atom +
+  overlay atom + `workflowBuildKitEnabledAtomFamily`
+- `web/packages/agenta-entity-ui/src/DrillInView/SchemaControls/agentTemplate/useBuildKit.tsx` — consumer
+- `web/packages/agenta-entity-ui/src/DrillInView/SchemaControls/agentTemplate/useModelHarness.tsx:376-390`
+- `web/packages/agenta-entity-ui/src/DrillInView/SchemaControls/AgentTemplateControl.tsx:274`
+- `web/oss/src/components/pages/agent-home/PlaygroundOnboarding/useAgentOnboarding.ts` — in-place swap
+- `web/oss/src/components/pages/agent-home/hooks/useCreateAgent.ts` — commit path
+- `web/packages/agenta-entities/src/workflow/state/commit.ts:564` — `createWorkflowFromEphemeralAtom`
+- `web/packages/agenta-entities/src/workflow/state/appUtils.ts:126-294` — ephemeral factory (flags incl. is_agent)
+
+## 8. Design — the global model (original research trail; door superseded by §9 / Option F)
+
+> **Superseded door:** the endpoint options weighed below (dedicated route / catalog-template
+> rider) are kept for the record only. The delivery door is now **Option F** — the reserved
+> static workflow `__ag__build_kit`, resolved by slug through `POST /workflows/revisions/
+> retrieve`. See §9 above and
+> [context.md](./context.md#delivery-door--decision-option-f-reserved-static-workflow). The
+> *global model* itself (fetch-once-per-project, merge client-side by entity type) is
+> unchanged and is what Option F delivers.
+
+The global model below — fetch-once-per-project, apply client-side by entity type — is
+settled and unaffected by which door serves the overlay. **Which route carries it (the
+"delivery door") was re-opened after this research was first written**: the dedicated
+route below shipped as a first pass (BE-1), then Mahmoud's review challenged it in favor of
+reusing the existing catalog-template endpoint — and finally settled on Option F (the
+reserved static workflow). The full option comparison and verdict now live in
+[context.md](./context.md#delivery-door--decision-option-f-reserved-static-workflow)
+— that section is the source of truth for the door decision; what follows here is kept as
+the original research trail.
+
+### Endpoint (design-interfaces lens)
+
+Classify the payload by semantic role: it is **platform-provided config-overlay metadata**
+— server-sourced, project-scoped (tenant/routing dimension, and the natural seam for
+future per-plan gating), agent-template-typed. It is not credentials, not user data, not
+per-entity data.
+
+**Shape as first implemented (BE-1, now provisional) — a dedicated project-scoped GET in
+the applications domain:**
+
+```
+GET /api/simple/applications/build-kit?project_id={pid}
+  200 -> { "count": 1, "agent_template_overlay": { ...AgentTemplateOverlay } }
+```
+
+- Reuse the existing `AgentTemplateOverlay` model and `build_agent_template_overlay()`.
+- Project-scoped via the standard `project_id` (VIEW_APPLICATIONS access check, matching
+  the current handler). Project scope is what makes future per-plan gating a local change
+  (consult entitlements inside this one handler) rather than a cross-cutting one.
+- Named top-level field `agent_template_overlay` keeps the semantic role explicit and
+  matches the field the FE already reads; no nesting under `additional_context` (that
+  envelope existed only because it rode on the app response).
+- Verified in this tree: registered `api/oss/src/apis/fastapi/applications/router.py:1801-1809`,
+  handler `router.py:1896-1932`, response model `SimpleApplicationBuildKitResponse`
+  (`api/oss/src/apis/fastapi/applications/models.py:665-680`).
+
+**Alternative A considered at the time — catalog-scoped route** (e.g. surface the overlay
+on the agent entry of `GET /workflows/catalog/templates/`, or
+`GET /workflows/catalog/agent-build-kit`). The catalog is arguably the "truest" source
+since the overlay is template metadata. Rejected at the time because: (a) the builder and
+models already live in the applications domain and the FE already fetches there, so a
+same-domain route looked like the smallest, lowest-risk move; (b) the catalog templates
+list response is consumed by several create flows and widening its contract touches more
+surface.
+
+**Alternative B — reuse `fetch_application_catalog_template` (Mahmoud's suggestion,
+now recommended; grounding citation).** This endpoint already exists in the applications
+domain named in alternative A above, one level more specific than the list endpoint, and
+was not considered in the original pass. Verified in this tree:
+
+- Route: `GET /applications/catalog/templates/{template_key}` — registered
+  `api/oss/src/apis/fastapi/applications/router.py:140-148`
+  (`operation_id="fetch_application_catalog_template"`,
+  `response_model=ApplicationCatalogTemplateResponse`, `response_model_exclude_none=True`).
+- Handler: `router.py:470-495` — docstring: "Use this to inspect the exact `uri`, `data`,
+  and JSON Schemas for a template before creating an application from it."
+- Response model: `ApplicationCatalogTemplateResponse`
+  (`api/oss/src/apis/fastapi/applications/models.py:797-804`) — `{count: int, template:
+  Optional[ApplicationCatalogTemplate]}`.
+- This resolves alternative A's objection (b): the endpoint that would grow is the
+  fetch-by-key single-template endpoint, not the list endpoint several create flows
+  consume — confirmed no FE surface calls the fetch-by-key endpoint today (grepped
+  `web/oss/src` and `web/packages` for `CatalogTemplate` usage; only the list endpoint,
+  `fetchWorkflowCatalogTemplates` against `GET /workflows/catalog/templates/`, is called,
+  by `createFromTemplate.ts:173`). See context.md's Option B con for the implication: "the
+  creation surfaces already call it" is true of the sibling list endpoint, not literally of
+  this fetch-by-key one.
+
+### Frontend
+
+- Add a project-scoped atom `agentBuildKitOverlayAtom` (query keyed on `projectId` only,
+  `staleTime` high — the overlay changes only with a deploy) that fetches the new endpoint
+  once per project/session.
+- Replace `workflowAgentTemplateOverlayAtomFamily(revisionId)` with a derivation that
+  returns the project overlay **iff the entity is agent-typed**, else `null`:
+  `agentBuildKitOverlayAtom` gated by an `is_agent` check on the entity
+  (`workflowQueryAtomFamily(revisionId).data?.flags?.is_agent ??
+  workflowBaseEntityAtomFamily(revisionId)?.flags?.is_agent`). Keep the same atom-family
+  name/signature so `useBuildKit` needs no change, or point `useBuildKit` at the new atom.
+- Net effect: ephemeral drafts (agent-typed, no workflow_id) and committed agents alike
+  get the overlay; the `workflow_id → application fetch` hops are gone.
+
+### Retire the per-application attachment
+
+Remove the overlay synthesis from `fetch_simple_application` (router.py:1908-1932). If any
+other consumer of `additional_context.playground_build_kit` is found, keep it one release
+behind a deprecation comment and delete after the FE ships. (FE search shows the atom in
+§5 is the only reader.)
+
+## 9. Option F verify-item findings (2026-07-07)
+
+These four items were verified in this tree for the chosen design (build kit as the reserved
+static workflow `__ag__build_kit`). Verdicts with file:line.
+
+### Verify 1 — nested embed resolution inside a static workflow: WORKS (this was the risk)
+
+The kit's `parameters.agent` holds two `@ag.embed` entries: the `request_connection` tool
+and the `build_an_agent` skill, referenced **by slug** (`{"workflow": {"slug": "__ag__…"}}`
+— see `overlay.py:30-52`). Two separate facts confirm the design is safe:
+
+- **The FE display path does not need resolution.** `useBuildKit`
+  (`web/packages/agenta-entity-ui/.../agentTemplate/useBuildKit.tsx:42-78,156-160`) renders
+  `@ag.embed` entries **as reference rows**, reading the embed's sibling `name` (or the
+  ref'd workflow name). The run-time merger (`buildKitOverlay.ts`) also passes embeds
+  through untouched, identity-keyed on the embed slug, for the runner to resolve at
+  invocation. So the FE should call `POST /workflows/revisions/retrieve` **without
+  `resolve`** and read the raw `revision.data.parameters.agent` — embeds + `name` siblings
+  intact. A reserved slug returns the synthetic catalog revision **directly**, bypassing DB
+  and `_normalize_revision_for_read` (`service.py:1460-1466`), so `parameters.agent` comes
+  back exactly as authored.
+- **Full resolution also works, if ever needed.** `resolve=True` (or
+  `POST /workflows/revisions/resolve`) routes through
+  `WorkflowsService.resolve_workflow_revision` (`service.py:2286-2315`): it fetches the
+  static revision, then runs `embeds_service.resolve_configuration` over
+  `revision.data`. The embed resolver's universal callback routes `workflow`-category refs
+  back through `workflows_service.fetch_workflow_revision`
+  (`api/oss/src/core/embeds/utils.py:278-325`), and **that is the same `workflows_service`
+  that carries the static catalog** — wired at `api/entrypoints/routers.py:617-647`
+  (`WorkflowsService(static_catalog=StaticWorkflowCatalog())` and
+  `embeds_service.workflows_service = workflows_service`). So `__ag__request_connection` and
+  `__ag__build_an_agent` resolve through the catalog, not Postgres. **Nested resolution
+  genuinely works for static-catalog entries today; no gap.** The FE simply doesn't need it
+  for the kit — it wants the unresolved shape.
+
+### Verify 2 — catalog mechanics + the one place the design needs care
+
+`_STATIC_WORKFLOWS` (`static_catalog.py:129-148`) maps slug → `{latest, versions: {vN:
+WorkflowRevision}}`; revision builders (`_skill_revision`, `_client_tool_revision`,
+`static_catalog.py:72-125`) return a `WorkflowRevision(name, description,
+data=WorkflowRevisionData(uri, parameters))`, and `_build_revision`
+(`static_catalog.py:274-299`) stamps ids/slug/version and infers flags via
+`infer_flags_from_data(data, slug)`. A `_build_kit_revision()` with
+`uri="agenta:builtin:agent:v0"` and `parameters={"agent": <kit>}` infers `is_agent=True`,
+`is_managed=True`, `is_skill=False`, `has_url=True`, `is_static=True`
+(`sdks/python/agenta/sdk/engines/running/utils.py:702-812`); `_validate_catalog` only
+requires `data.uri` truthy and the slug prefixed `__ag__` (`static_catalog.py:201-222`).
+
+- **Gate distinction (keep straight):** the FE `flags.is_agent` gate reads the **target
+  entity** being edited, not the kit. The kit's own `is_agent` flag is irrelevant to the
+  gate.
+- **Two guards the content builder needs (the real risk of the design):**
+  (a) `_reserved_static_tool_embeds()` (`overlay.py:54-74`) builds tool embeds by iterating
+  `catalog.list_slugs()` and including every **non-skill** static workflow. `__ag__build_kit`
+  is a non-skill (agent), so it would embed the kit **into itself**. The builder must exclude
+  the build-kit slug (skip by name, or reference the two known tool/skill slugs explicitly).
+  (b) `_build_kit_revision()` calling `build_agent_template_overlay()` at import time
+  constructs a fresh `StaticWorkflowCatalog()` reading `_STATIC_WORKFLOWS` **while that dict
+  is mid-construction** → partial-dict / NameError. Build the kit revision lazily, or pass an
+  explicit sub-catalog omitting the build-kit entry. Both are simple; they are the only
+  places the design as stated cannot be a naive copy of the current builder.
+
+### Verify 3 — content equivalence
+
+The kit's `parameters.agent` must equal `build_agent_template_overlay()`
+(`overlay.py:77-109`): `tools` = `AGENTA_FORCED_TOOLS` (`["read","bash"]`,
+`agenta_builtins.py:63`) + the 13 `DEFAULT_BUILD_KIT_OPS` platform configs + the
+`request_connection` embed = **16 tools**; `skills` = the build-an-agent embed;
+`sandbox.permissions = {write_files: allow, execute_code: allow}`. Both embeds carry a
+`name` sibling for display. **overlay.py is absorbed as the kit's builder** (called from
+`_build_kit_revision()` with the guards above), not deleted and not duplicated — the
+platform-ops list stays put (Mahmoud: nothing relocates). A catalog unit test pins
+`retrieve_revision(slug="__ag__build_kit").data.parameters["agent"] ==
+build_agent_template_overlay()`.
+
+### Verify 4 — merge semantics at the consumer: unchanged
+
+The overlay is already a `Partial<AgentTemplate>` and is merged client-side in
+`web/packages/agenta-playground/src/state/execution/buildKitOverlay.ts`:
+`applyBuildKitOverlay(base, overlay)` deep-merges the object sections
+(`sandbox`/`runner`/`harness`/`llm`/`instructions`, overlay wins at the leaf) and
+identity-merges the list sections (`tools`/`skills`/`mcps`) keyed on `platform:<op>` |
+`workflow:<embed-slug>` | `name:<name>` — an overlay entry replaces a same-identity base
+entry, else appends. `withBuildKitOverlay` applies it to the per-run `parameters.agent` (or
+a bare template) only when the build-kit toggle is enabled. **None of this changes under
+Option F** — the atom still hands the merger the same `{tools, skills, sandbox}` object;
+only where the atom sources it (slug retrieve of `__ag__build_kit` instead of the app-fetch
+`additional_context`) changes. This is also the concrete evidence for Mahmoud's "it is just
+an agent configuration" framing: the merge target is literally `parameters.agent`.
+
+## 10. Codex xhigh design review — findings folded into the design (2026-07-07)
+
+A codex xhigh design review of this plan accepted six findings, folded into
+[plan.md](./plan.md) (phase changes) and [context.md](./context.md) (decision
+refinements). Full detail lives in those files; this section is the research-trail record
+plus the one live code verification done for this round.
+
+1. **Layering.** The content builder must live in `core/workflows` (a `build_kit` module
+   next to `static_catalog.py`, or inside it), not be imported from
+   `apis/fastapi/applications/overlay.py` — core must never import the API layer
+   (`api/AGENTS.md`). `overlay.py` becomes a thin back-compat adapter. See plan.md Phase
+   BE-1 and context.md's refined "nothing relocates."
+2. **Explicit entry metadata.** Replace the "non-skill means tool" inference in
+   `_reserved_static_tool_embeds()` with a positive allowlist / explicit per-entry kind
+   metadata — only `__ag__request_connection` is a tool embed. Makes the self-embed guard
+   structural. See plan.md Phase BE-1.
+3. **Embeddability policy.** `__ag__build_kit` is retrievable but not
+   embeddable/committable. The embed resolver and/or commit path must reject build-kit
+   refs. New plan item + test. See plan.md Phase BE-1 and Phase TEST.
+4. **Rider compatibility window.** BE-2 (retiring the per-app rider) is deferred to a
+   follow-up release; this PR keeps the rider, and the FE goes slug-first with the existing
+   per-app chain retained as a skew fallback. See plan.md Phase FE-1 / BE-2.
+5. **RBAC — verified in code, no gap found.** See below.
+6. **Tests.** Positive-pin the tool-embed set, add a self-embed-guard test and a
+   slug-retrieve content-equivalence test; the existing enumeration-style assertion in
+   `test_build_kit_overlay.py` would bless the self-embed bug as written. See plan.md Phase
+   TEST.
+
+### RBAC verification (finding 5) — no role gap
+
+**Question:** the new door (slug retrieve of `__ag__build_kit` via
+`POST /workflows/revisions/retrieve`) authorizes on `Permission.VIEW_WORKFLOWS`; the old
+door (`GET /simple/applications/{id}`) authorizes on `Permission.VIEW_APPLICATIONS`. Does
+every default role that has `VIEW_APPLICATIONS` also have `VIEW_WORKFLOWS`, so no role
+loses access to the build kit because of the door change?
+
+**Verified in this tree (2026-07-07):**
+
+- New door's check: `retrieve_workflow_revision` —
+  `api/oss/src/apis/fastapi/workflows/router.py:1770-1781` — calls `check_action_access(...,
+  permission=Permission.VIEW_WORKFLOWS)` at `router.py:1776-1779`.
+- Old door's check: `fetch_simple_application` —
+  `api/oss/src/apis/fastapi/applications/router.py:1898` —
+  `permission=Permission.VIEW_APPLICATIONS`.
+- Default role catalog: `api/oss/src/core/access/permissions/types.py`.
+  `VIEWER_PERMISSIONS` (`types.py:175-198`) includes **both** `cls.VIEW_APPLICATIONS`
+  (`types.py:176`) and `cls.VIEW_WORKFLOWS` (`types.py:181`). Every other default role
+  builds additively on top of `VIEWER_PERMISSIONS`: `ANNOTATOR_PERMISSIONS =
+  VIEWER_PERMISSIONS + [...]` (`types.py:199-209`), `EDITOR_PERMISSIONS =
+  ANNOTATOR_PERMISSIONS + [...]` (`types.py:210-225`), `DEVELOPER_PERMISSIONS =
+  EDITOR_PERMISSIONS + [...]` (`types.py:226-232`), `ADMIN_PERMISSIONS =
+  DEVELOPER_PERMISSIONS + [...]` (`types.py:233-240`), and `DefaultRole.OWNER: [p for p in
+  cls]` (`types.py:242`, every permission). So **every default role that has
+  `VIEW_APPLICATIONS` also has `VIEW_WORKFLOWS`**, because both are baseline
+  `VIEWER_PERMISSIONS` and no role above `viewer` drops a baseline permission. **No role gap
+  in the default catalog.**
+- **Caveat (not a plan item):** EE custom roles set via `AGENTA_ACCESS_ROLES` /
+  `AGENTA_ACCESS_ROLES_OVERLAY` (`api/ee/src/core/access/permissions/role_overrides.py`)
+  let an operator define a **custom** project role with an arbitrary permission list — an
+  operator could in principle grant `VIEW_APPLICATIONS` without `VIEW_WORKFLOWS` on a
+  hand-rolled role. This is pre-existing RBAC behavior (any two permissions can already be
+  split this way today for any other domain pair) and not something this design introduces
+  or worsens; no plan item needed.
+
+**Verdict: no plan item required for finding 5** — the default catalog has no gap; the door
+change from `VIEW_APPLICATIONS` to `VIEW_WORKFLOWS` does not strip build-kit access from any
+default role.

--- a/docs/design/build-kit-overlay-delivery/status.md
+++ b/docs/design/build-kit-overlay-delivery/status.md
@@ -1,0 +1,168 @@
+# Status
+
+**State:** IMPLEMENTED — awaiting Mahmoud's PR review. Codex-xhigh implemented both slices per
+this plan (Mahmoud authorized implementation with the codex design review as the gate); the
+orchestrator adversarially reviewed both diffs. Verified: 1250 api unit tests green (7 new
+build-kit tests incl. the self-embed and embed-rejection pins), entities package green (11 new
+FE tests), live API (slug retrieve returns the full kit; committing an embed of
+`__ag__build_kit` returns the typed 400), and browser QA (fresh AND committed agents render the
+kit in Advanced; the network log shows the `__ag__build_kit` retrieve, proving the new path
+fired). The legacy rider stays one release as fallback (BE-2 deferred as planned). The
+template-builder default-on flip rides a stacked PR on top.
+**Date:** 2026-07-07
+
+## Decision
+
+**Option F (Mahmoud, 2026-07-07):** the build kit becomes the reserved static workflow
+`__ag__build_kit` in `StaticWorkflowCatalog`, resolved by slug through the existing
+`POST /workflows/revisions/retrieve` path, fetched once per project, merged onto any
+agent-typed entity. It is a **plain agent config** (`parameters.agent`), and **nothing
+relocates**. Full rationale and the superseded A/B analysis:
+[context.md](./context.md#delivery-door--decision-option-f-reserved-static-workflow).
+
+## Fate of the parked lane
+
+The built BE-1(Option A) + FE-1 work lives on the UNAPPLIED, unpushed lane
+`feat/build-kit-overlay-impl-draft` (commit 7da032b). Under Option F:
+
+- **BE route DISCARDED.** The dedicated `GET /simple/applications/build-kit` route
+  (registration `router.py:1801-1809`, handler `router.py:1896-1932`,
+  `SimpleApplicationBuildKitResponse` model `models.py:665-680`) and its unit tests are
+  **dropped**, not carried forward. Option F adds no route.
+- **FE half ADAPTED.** The project-scoped `agentBuildKitOverlayAtom`, the rewritten
+  `workflowAgentTemplateOverlayAtomFamily` entity-type gate, and the removal of the
+  `simpleApplicationQueryAtomFamily` / `fetchSimpleApplication` chain all **transfer**. The
+  only change: the fetch swaps from the discarded Option-A route to
+  `retrieveWorkflowRevision({workflowRef: {slug: "__ag__build_kit"}})`, reading the overlay
+  from `revision.data.parameters.agent` (unresolved — the FE renders embeds as reference
+  rows; see [research.md](./research.md) verify item 1).
+- The FE-1 pass also incidentally fixed a pre-existing `types:check` break at `HEAD`
+  (`api.ts` called `getAgentaSdkClient` without importing it, from merge `9cb1586329`);
+  removing the dead `fetchSimpleApplication` removes that broken call site, so the fix rides
+  along with the FE-1 rewrite.
+
+Re-apply the parked lane to salvage the FE atom with
+`but apply feat/build-kit-overlay-impl-draft`.
+
+## Process note
+
+This design went to implementation (Option A) before Mahmoud reviewed the delivery door. He
+flagged that; the door was re-opened and, after the A→B discussion, settled on **Option F**
+(a reserved static workflow — neither a new route nor a rider field). Going forward: **the
+updated draft PR #5124 goes to Mahmoud before implementation resumes.**
+
+## Review rounds
+
+**Codex xhigh design review — round complete (2026-07-07).** Verdict: **right seam** (Option
+F confirmed) with **six changes folded** into plan.md/context.md/research.md:
+
+1. Layering — content builder moves to `core/workflows`; `overlay.py` becomes a thin
+   back-compat adapter.
+2. Explicit entry metadata — positive allowlist replaces the "non-skill means tool"
+   inference in `_reserved_static_tool_embeds()`.
+3. Embeddability policy — `__ag__build_kit` retrievable but not embeddable/committable;
+   new plan item + test.
+4. Rider compatibility window — BE-2 deferred to a follow-up release; FE goes slug-first
+   with the per-app chain kept as a skew fallback.
+5. RBAC — verified in code, no default-role gap (see
+   [research.md](./research.md#rbac-verification-finding-5--no-role-gap)).
+6. Tests — positive-pin tool embeds, add a self-embed-guard test and a slug-retrieve
+   content-equivalence test; update the enumeration-style assertion that would otherwise
+   bless the self-embed bug.
+
+Naming was also revisited: codex suggested `__ag__playground_build_kit` for lifecycle
+clarity; **decision stays `__ag__build_kit`** (Mahmoud's name), with the playground-only
+lifecycle documented at the catalog entry instead of encoded in the slug. See
+[context.md](./context.md#naming-considered-codex-xhigh-design-review-2026-07-07).
+
+**Next step:** codex-xhigh implementation of the revised plan, then the orchestrator's
+adversarial review, live QA, and PRs.
+
+## Root-cause verdict
+
+The build-kit gap is a **frontend delivery-coupling bug, not a server bug**, and the
+prior "onboarding creates a bare workflow with no application row" theory is **disproven
+live**.
+
+- Both creation paths (classic and onboarding) build the agent through `POST /workflows/`;
+  the resulting artifact/variant/revision trio is identical.
+- LIVE on `:8280`: an onboarding-style agent resolves as a full simple application, and
+  `GET /simple/applications/{workflow_id}` returns the identical 16-tool overlay the
+  classic path returns. The committed revision reports its `workflow_id` correctly and
+  carries `is_agent: true` (inferred server-side at commit).
+- The overlay is **catalog-static** — `build_agent_template_overlay()` takes no app
+  argument — yet it is delivered by attaching to one app-fetch response and resolved on the
+  FE through a 3-hop chain (`revisionId → workflow_id → applicationId → app fetch`). That
+  chain short-circuits for ephemeral drafts (no `workflow_id`) and is identity/timing-
+  fragile through the onboarding in-place swap. That coupling is the root of the bug class.
+
+**Chosen fix (Option F):** serve the build kit as the reserved static workflow
+`__ag__build_kit`, resolve it by slug through the existing workflow retrieve path, fetch it
+once per project/session, and merge it client-side onto any agent-typed entity; retire the
+per-application attachment. Full evidence in [research.md](./research.md).
+
+## What contradicts the prior findings
+
+- Prior diagnosis predicted a post-commit 404 / missing application row. **False** — the
+  app resolves and returns the overlay for onboarding-created agents (live-verified). Do
+  not build the fix around "create an application row on the commit path."
+- The prior "classic flow creates via `POST /simple/applications/`" framing is only
+  partly right: the classic *template* create (`createAppFromTemplate`) also uses
+  `POST /workflows/`. `POST /simple/applications/` is a separate entry that also works, but
+  it is not what distinguishes the working path from the broken one. What actually differs
+  is **full-navigation remount (classic) vs in-place swap (onboarding)**, plus the
+  ephemeral having no `workflow_id`.
+
+## What needs Mahmoud's confirmation
+
+The door is decided (F). Remaining confirmations for the draft PR #5124:
+
+1. **Retire the per-app rider (now deferred to a follow-up release — codex review).** BE-2
+   still plans to retire `additional_context.playground_build_kit` on
+   `fetch_simple_application`, but not in this PR — this PR keeps the rider live as the FE's
+   skew-window fallback (finding 4). Confirm nothing external (SDK, another surface) is
+   expected to keep reading it, ahead of the eventual BE-2 follow-up.
+2. **Per-plan gating.** Because `__ag__build_kit` resolves per project, a future EE
+   entitlement could shape/deny the kit at retrieve time (a local change in the catalog
+   resolve path). Confirm this is a wanted future extension (design leaves the seam; no
+   gating now).
+
+Not blockers, but noted:
+- The **content builder needs guards** — self-reference (now an explicit allowlist per
+  codex review, not just an exclusion), import-time bootstrap ordering, and (new) an
+  embeddability/commit-rejection guard — so the build kit doesn't embed itself, doesn't read
+  a half-built catalog, and can't be embedded into a published agent. See plan.md Phase BE-1
+  and research.md §10. The builder also now needs to live in `core/workflows` for layering
+  (finding 1) rather than `apis/fastapi/applications/overlay.py`.
+- We did not pin the single exact failing hop of the old post-commit chain in a headed
+  browser session — Option F removes the whole chain, so the distinction is moot.
+
+## Next steps
+
+1. **Mahmoud's review** of this design (context.md, this file, plan.md, research.md) as
+   draft PR #5124 — specifically the Option-F decision and the two confirmations above.
+2. **BE-1:** add `__ag__build_kit` to `StaticWorkflowCatalog` (with `build_agent_template_
+   overlay()` as the single builder + the two guards), and drop the discarded Option-A
+   route/handler/model/tests.
+3. **FE-1:** repoint the parked atom's fetch to `retrieveWorkflowRevision({slug:
+   "__ag__build_kit"})`; adapt tests.
+4. **Five-path live QA** (plan.md Phase QA), run against the slug-backed retrieve.
+5. **BE-2 (deferred to a follow-up release):** retire the per-app rider once the slug-first
+   path has shipped long enough that deploy skew is no longer a concern (codex review,
+   finding 4).
+6. **Build-kit PR:** commit BE-1 + FE-1 + TEST together once QA is green. BE-2 ships in a
+   separate follow-up-release PR (deferred, finding 4).
+7. **Unblock the PR #5121 lane** (flags-default-on re-flip) once the build-kit PR merges —
+   see [Gate](#gate).
+
+## Gate
+
+This project **gates the flags-default-on re-flip** (new experience default-on with zero
+env; parked on the **PR #5121** lane). Land this first.
+
+## Artifacts / cleanup
+
+- Live probes run under ephemeral admin-minted accounts; all created workflows archived
+  (`POST /workflows/{id}/archive`). No persistent test entities left behind.
+- Probe scripts kept only in the session scratchpad (not committed).
+</content>


### PR DESCRIPTION
## Context

Agents created through the new template-builder and playground-native flows show no build kit and run without its tools, even after commit. The server content was proven healthy; the root cause is delivery: the frontend fetched the kit exclusively as a rider on `GET /simple/applications/{id}`, keyed by a `workflow_id` that ephemeral drafts don't have and that onboarding's in-place swap doesn't re-resolve.

## The decision (Mahmoud, 2026-07-07)

The build kit becomes a **reserved static workflow, `__ag__build_kit`**, in the existing StaticWorkflowCatalog — the same home as `__ag__build_an_agent` and `__ag__request_connection`. Two refinements from review: it is **just an agent configuration** (`parameters.agent` with tools/skills/sandbox — no new schema flavor; "overlay" is how the playground uses it, not a type), and **nothing relocates** (the entry goes where the catalog lives; the ops list stays put; overlay.py is absorbed as the kit's content builder).

Delivery: the frontend resolves the slug through the existing workflow-retrieve path, fetches once per project, and merges it onto anything agent-typed (`flags.is_agent` — drafts and committed agents alike). The per-application rider retires after the FE migrates. Options A (dedicated route — provisionally built, parked unmerged on `feat/build-kit-overlay-impl-draft`, to be discarded) and B (template-response rider) are superseded; the analysis stays in context.md.

## Verified, not assumed

- **Nested embeds resolve**: reserved slugs return the synthetic catalog revision directly on retrieve, and the full resolver routes `workflow` refs back through the catalog, so the kit's internal embeds (request-connection, build-an-agent) work on both paths.
- **Content equivalence**: 16 tools + skill embed + sandbox permissions, byte-comparable to today's overlay output; a unit test pins it.
- **Two implementation guards** (the only sharp edges): the kit must be excluded from its own reserved-tool-embed iteration (or it embeds itself), and its revision must be built lazily (the builder can't read the catalog mid-construction).
- **Merge semantics unchanged**: the client merge target is literally `parameters.agent` — the concrete evidence for the "it's just an agent config" framing.

## Why this matters now

This gates flipping `NEXT_PUBLIC_AGENT_TEMPLATE_BUILDER` to default-on (the last piece of the zero-config new experience; the other two flags shipped in #5121).

https://claude.ai/code/session_01N2djTMgXnpk84EqtugHDJB