### PR TITLE
[fix] Conform Vercel stream parts to the ai@6 chunk schema

### DIFF
--- a/sdks/python/agenta/sdk/agents/adapters/vercel/stream.py
+++ b/sdks/python/agenta/sdk/agents/adapters/vercel/stream.py
@@ -10,6 +10,7 @@ from agenta.sdk.utils.logging import get_module_logger
 
 from ...dtos import AgentResult
 from ...streaming import AgentStream
+from ...utils.wire import sanitize_runner_error
 from .messages import TOOL_APPROVAL_REQUEST
 
 log = get_module_logger(__name__)
@@ -54,6 +55,36 @@ def _map_finish_reason(stop_reason: Optional[str]) -> Optional[str]:
     return _FINISH_REASON_MAP.get(normalized, "unknown")
 
 
+# Required-string chunk types per the `ai@6` uiMessageChunkSchema: a missing/None value in
+# any of these slots makes the strict client-side schema throw and kill the whole turn.
+_REQUIRES_TOOL_CALL_ID = {
+    "tool-input-start",
+    "tool-input-available",
+    "tool-output-available",
+    "tool-output-error",
+    "tool-output-denied",
+    TOOL_APPROVAL_REQUEST,
+}
+_REQUIRES_TOOL_NAME = {"tool-input-start", "tool-input-available"}
+
+
+def _conform(part: Optional[Dict[str, Any]]) -> Optional[Dict[str, Any]]:
+    """Normalize a part at the yield boundary so it never violates the AI SDK's strict
+    ``uiMessageChunkSchema``. Returns ``None`` when the part is unsalvageable and must be
+    dropped rather than sent broken.
+    """
+    if part is None:
+        return None
+    ptype = part.get("type")
+    if ptype in _REQUIRES_TOOL_CALL_ID and part.get("toolCallId") is None:
+        return None
+    if ptype in _REQUIRES_TOOL_NAME and not part.get("toolName"):
+        part["toolName"] = "unknown_tool"
+    if ptype == "file" and (not part.get("url") or not part.get("mediaType")):
+        return None
+    return part
+
+
 async def agent_run_to_vercel_parts(
     run: AgentStream,
     *,
@@ -68,6 +99,24 @@ async def agent_run_to_vercel_parts(
     run-based variant pairs with the dev-only one-shot ``AgentStream`` debugging surface and is
     kept for that; it is not on any live request path.
     """
+    async for part in _agent_run_to_vercel_parts_impl(
+        run,
+        session_id=session_id,
+        message_id=message_id,
+        trace_id=trace_id,
+    ):
+        conformed = _conform(part)
+        if conformed is not None:
+            yield conformed
+
+
+async def _agent_run_to_vercel_parts_impl(
+    run: AgentStream,
+    *,
+    session_id: Optional[str] = None,
+    message_id: str = "msg-1",
+    trace_id: Optional[str] = None,
+) -> AsyncIterator[Dict[str, Any]]:
     start: Dict[str, Any] = {"type": "start", "messageId": message_id}
     if session_id is not None:
         start["messageMetadata"] = {"sessionId": session_id}
@@ -78,6 +127,7 @@ async def agent_run_to_vercel_parts(
     reasoning_seq = 0
     usage: Optional[Dict[str, Any]] = None
     stop_reason: Optional[str] = None
+    content_parts_emitted = 0
     # Tool-call ids already surfaced as a tool part. An approval request attaches
     # to its tool part by id, so we synthesize one only when none preceded it.
     seen_tool_calls: set = set()
@@ -91,12 +141,14 @@ async def agent_run_to_vercel_parts(
             if etype == "message":
                 text_seq += 1
                 tid = f"text-{text_seq}"
+                content_parts_emitted += 1
                 yield {"type": "text-start", "id": tid}
                 yield {"type": "text-delta", "id": tid, "delta": data.get("text", "")}
                 yield {"type": "text-end", "id": tid}
             elif etype == "message_start":
                 yield {"type": "text-start", "id": data.get("id")}
             elif etype == "message_delta":
+                content_parts_emitted += 1
                 yield {
                     "type": "text-delta",
                     "id": data.get("id"),
@@ -141,6 +193,7 @@ async def agent_run_to_vercel_parts(
                 if first_seen:
                     tool_names_by_id[tool_call_id] = tool_name
                 tool_name = tool_names_by_id.get(tool_call_id) or tool_name
+                content_parts_emitted += 1
                 if first_seen:
                     yield {
                         "type": "tool-input-start",
@@ -165,25 +218,27 @@ async def agent_run_to_vercel_parts(
                     yield _render_part(tool_call_id, data["render"])
             elif etype == "tool_result":
                 tool_call_id = data.get("id")
-                if data.get("denied"):
-                    yield {
-                        "type": "tool-output-denied",
-                        "toolCallId": tool_call_id,
-                    }
-                elif data.get("isError"):
+                content_parts_emitted += 1
+                # A tool part (-error/-available) only ever emits for a tool call this
+                # stream actually surfaced; an orphaned one has no tool part to attach to
+                # and the client throws. The commit-revision side-channel below is a plain
+                # data event, not a tool-result envelope, so it fires regardless.
+                has_tool_part = tool_call_id in seen_tool_calls
+                if has_tool_part and data.get("isError"):
                     yield {
                         "type": "tool-output-error",
                         "toolCallId": tool_call_id,
                         "errorText": _as_text(data.get("output")),
                     }
-                else:
+                elif not data.get("isError"):
                     structured = data.get("data")
                     out = structured if structured is not None else data.get("output")
-                    yield {
-                        "type": "tool-output-available",
-                        "toolCallId": tool_call_id,
-                        "output": out,
-                    }
+                    if has_tool_part:
+                        yield {
+                            "type": "tool-output-available",
+                            "toolCallId": tool_call_id,
+                            "output": out,
+                        }
                     committed = _committed_revision_data(
                         tool_names_by_id.get(tool_call_id), out
                     )
@@ -192,10 +247,11 @@ async def agent_run_to_vercel_parts(
                             "type": "data-committed-revision",
                             "data": committed,
                         }
-                    if data.get("render") is not None:
+                    if has_tool_part and data.get("render") is not None:
                         yield _render_part(tool_call_id, data["render"])
             elif etype == "interaction_request":
                 for part in _interaction_parts(data, seen_tool_calls, tool_names_by_id):
+                    content_parts_emitted += 1
                     yield part
             elif etype == "data":
                 part: Dict[str, Any] = {
@@ -204,8 +260,10 @@ async def agent_run_to_vercel_parts(
                 }
                 if data.get("transient"):
                     part["transient"] = True
+                content_parts_emitted += 1
                 yield part
             elif etype == "file":
+                content_parts_emitted += 1
                 yield {
                     "type": "file",
                     "url": data.get("url"),
@@ -223,8 +281,10 @@ async def agent_run_to_vercel_parts(
     except Exception as exc:
         # A graceful terminal failure (the run's own AgentResult says ok=false) surfaces here
         # as a plain exception from AgentStream iteration; that case intentionally ends the
-        # stream on the error part with no finish frame, so this path stays as-is.
-        yield {"type": "error", "errorText": str(exc)}
+        # stream on the error part with no finish frame, so this path stays as-is. Sanitize
+        # either way — an unexpected exception's raw str() can carry a stack/path dump.
+        log.error("agent_run_to_vercel_parts: error mid-stream", exc_info=True)
+        yield {"type": "error", "errorText": sanitize_runner_error(exc)}
         return
 
     # The terminal AgentResult is authoritative. Its stop_reason wins over the `done` event's,
@@ -240,6 +300,9 @@ async def agent_run_to_vercel_parts(
             trace_id = result.trace_id
 
     yield {"type": "finish-step"}
+    if content_parts_emitted == 0:
+        # An ok:true run with zero content parts would otherwise render as a blank bubble.
+        yield {"type": "error", "errorText": "The agent produced no output."}
     finish: Dict[str, Any] = {"type": "finish"}
     finish_reason = _map_finish_reason(stop_reason)
     if finish_reason is not None:
@@ -270,6 +333,24 @@ async def agent_stream_to_vercel_stream(
     ``done`` events; ``trace_id`` is passed in by routing (off the response), since there is no
     run to fall back to here.
     """
+    async for part in _agent_stream_to_vercel_stream_impl(
+        events,
+        session_id=session_id,
+        message_id=message_id,
+        trace_id=trace_id,
+    ):
+        conformed = _conform(part)
+        if conformed is not None:
+            yield conformed
+
+
+async def _agent_stream_to_vercel_stream_impl(
+    events: AsyncIterator[Dict[str, Any]],
+    *,
+    session_id: Optional[str] = None,
+    message_id: Optional[str] = None,
+    trace_id: Optional[str] = None,
+) -> AsyncIterator[Dict[str, Any]]:
     # Every turn needs a UNIQUE messageId — the client keys messages by it, so a shared constant
     # collides across turns (duplicate React keys, dropped turns). Prefer the run's trace_id (stable,
     # correlatable), else a fresh uuid.
@@ -286,6 +367,7 @@ async def agent_stream_to_vercel_stream(
     reasoning_seq = 0
     usage: Optional[Dict[str, Any]] = None
     stop_reason: Optional[str] = None
+    content_parts_emitted = 0
     seen_tool_calls: set = set()
     tool_names_by_id: Dict[Any, Any] = {}
 
@@ -297,12 +379,14 @@ async def agent_stream_to_vercel_stream(
             if etype == "message":
                 text_seq += 1
                 tid = f"text-{text_seq}"
+                content_parts_emitted += 1
                 yield {"type": "text-start", "id": tid}
                 yield {"type": "text-delta", "id": tid, "delta": data.get("text", "")}
                 yield {"type": "text-end", "id": tid}
             elif etype == "message_start":
                 yield {"type": "text-start", "id": data.get("id")}
             elif etype == "message_delta":
+                content_parts_emitted += 1
                 yield {
                     "type": "text-delta",
                     "id": data.get("id"),
@@ -347,6 +431,7 @@ async def agent_stream_to_vercel_stream(
                 if first_seen:
                     tool_names_by_id[tool_call_id] = tool_name
                 tool_name = tool_names_by_id.get(tool_call_id) or tool_name
+                content_parts_emitted += 1
                 if first_seen:
                     yield {
                         "type": "tool-input-start",
@@ -371,25 +456,27 @@ async def agent_stream_to_vercel_stream(
                     yield _render_part(tool_call_id, data["render"])
             elif etype == "tool_result":
                 tool_call_id = data.get("id")
-                if data.get("denied"):
-                    yield {
-                        "type": "tool-output-denied",
-                        "toolCallId": tool_call_id,
-                    }
-                elif data.get("isError"):
+                content_parts_emitted += 1
+                # A tool part (-error/-available) only ever emits for a tool call this
+                # stream actually surfaced; an orphaned one has no tool part to attach to
+                # and the client throws. The commit-revision side-channel below is a plain
+                # data event, not a tool-result envelope, so it fires regardless.
+                has_tool_part = tool_call_id in seen_tool_calls
+                if has_tool_part and data.get("isError"):
                     yield {
                         "type": "tool-output-error",
                         "toolCallId": tool_call_id,
                         "errorText": _as_text(data.get("output")),
                     }
-                else:
+                elif not data.get("isError"):
                     structured = data.get("data")
                     out = structured if structured is not None else data.get("output")
-                    yield {
-                        "type": "tool-output-available",
-                        "toolCallId": tool_call_id,
-                        "output": out,
-                    }
+                    if has_tool_part:
+                        yield {
+                            "type": "tool-output-available",
+                            "toolCallId": tool_call_id,
+                            "output": out,
+                        }
                     committed = _committed_revision_data(
                         tool_names_by_id.get(tool_call_id), out
                     )
@@ -398,10 +485,11 @@ async def agent_stream_to_vercel_stream(
                             "type": "data-committed-revision",
                             "data": committed,
                         }
-                    if data.get("render") is not None:
+                    if has_tool_part and data.get("render") is not None:
                         yield _render_part(tool_call_id, data["render"])
             elif etype == "interaction_request":
                 for part in _interaction_parts(data, seen_tool_calls, tool_names_by_id):
+                    content_parts_emitted += 1
                     yield part
             elif etype == "data":
                 part: Dict[str, Any] = {
@@ -410,8 +498,10 @@ async def agent_stream_to_vercel_stream(
                 }
                 if data.get("transient"):
                     part["transient"] = True
+                content_parts_emitted += 1
                 yield part
             elif etype == "file":
+                content_parts_emitted += 1
                 yield {
                     "type": "file",
                     "url": data.get("url"),
@@ -431,11 +521,15 @@ async def agent_stream_to_vercel_stream(
                 if reason is not None:
                     stop_reason = reason
     except Exception as exc:
-        yield {"type": "error", "errorText": str(exc)}
+        log.error("agent_stream_to_vercel_stream: error mid-stream", exc_info=True)
+        yield {"type": "error", "errorText": sanitize_runner_error(exc)}
     finally:
         # Every exit path — including the raw exception above — must still drain to a
         # finish frame, or a consumer waiting on it hangs.
         yield {"type": "finish-step"}
+        if content_parts_emitted == 0:
+            # An ok:true run with zero content parts would otherwise render as a blank bubble.
+            yield {"type": "error", "errorText": "The agent produced no output."}
         finish: Dict[str, Any] = {"type": "finish"}
         finish_reason = _map_finish_reason(stop_reason)
         if finish_reason is not None:

--- a/sdks/python/oss/tests/pytest/unit/agents/adapters/test_vercel_stream_conformance.py
+++ b/sdks/python/oss/tests/pytest/unit/agents/adapters/test_vercel_stream_conformance.py
@@ -1,0 +1,144 @@
+"""Pins every Vercel stream part against a vendored mirror of the `ai` package's
+``uiMessageChunkSchema`` shape, so the adapter's ``_conform`` gate is provably sufficient.
+
+The pinned version MUST match ``web/oss/package.json``'s ``"ai"`` pin
+(currently ``6.0.0-beta.150``) -- grep for `_AI_PACKAGE_VERSION` on a version bump and
+re-check the vendored shape against the new schema.
+"""
+
+from __future__ import annotations
+
+from typing import Any, AsyncIterator, Dict, List
+
+import pytest
+
+from agenta.sdk.agents.adapters.vercel.stream import (
+    agent_run_to_vercel_parts,
+    agent_stream_to_vercel_stream,
+)
+from agenta.sdk.agents.streaming import AgentStream
+
+# Keep in lockstep with web/oss/package.json's "ai" pin.
+_AI_PACKAGE_VERSION = "6.0.0-beta.150"
+
+# A hand-kept mirror of `ai@6`'s uiMessageChunkSchema: for each chunk `type`, the set of
+# REQUIRED string fields that must be present and non-None (a strict Zod object throws on
+# a missing/null required string, not just on a missing key).
+_REQUIRED_STRING_FIELDS: Dict[str, List[str]] = {
+    "start": ["type"],
+    "start-step": ["type"],
+    "finish-step": ["type"],
+    "finish": ["type"],
+    "text-start": ["type", "id"],
+    "text-delta": ["type", "id"],
+    "text-end": ["type", "id"],
+    "reasoning-start": ["type", "id"],
+    "reasoning-delta": ["type", "id"],
+    "reasoning-end": ["type", "id"],
+    "tool-input-start": ["type", "toolCallId", "toolName"],
+    "tool-input-available": ["type", "toolCallId", "toolName"],
+    "tool-output-available": ["type", "toolCallId"],
+    "tool-output-error": ["type", "toolCallId", "errorText"],
+    "tool-approval-request": ["type", "toolCallId", "approvalId"],
+    "file": ["type", "url", "mediaType"],
+    "error": ["type", "errorText"],
+}
+# `tool-approval-request` is the only strict object with an EXACT allowed key set (no extra
+# agenta-only fields may leak onto it).
+_EXACT_KEYS = {"tool-approval-request": {"type", "approvalId", "toolCallId"}}
+
+
+def assert_conforms(part: Dict[str, Any]) -> None:
+    """Raise if `part` would fail the AI SDK's strict `uiMessageChunkSchema` validation."""
+    ptype = part.get("type")
+    assert isinstance(ptype, str) and ptype, f"part has no string type: {part!r}"
+    required = _REQUIRED_STRING_FIELDS.get(ptype)
+    if required is None:
+        return  # data-*/custom parts: schema is passthrough, no required-string slots.
+    for field in required:
+        value = part.get(field)
+        assert value is not None, (
+            f"{ptype!r} part missing required field {field!r}: {part!r}"
+        )
+        if field != "type":
+            assert isinstance(value, str), (
+                f"{ptype!r}.{field} must be a string: {part!r}"
+            )
+    exact = _EXACT_KEYS.get(ptype)
+    if exact is not None:
+        assert set(part.keys()) == exact, (
+            f"{ptype!r} part has unexpected keys: {part!r}"
+        )
+
+
+async def _records(items: List[Dict[str, Any]]) -> AsyncIterator[Dict[str, Any]]:
+    for item in items:
+        yield item
+
+
+def _run_with(events: List[Dict[str, Any]], result: Dict[str, Any]) -> AgentStream:
+    records = [{"kind": "event", "event": e} for e in events]
+    records.append({"kind": "result", "result": {"ok": True, **result}})
+    return AgentStream(_records(records))
+
+
+# A scenario exercising every finding this batch closed: a None tool-call id on an
+# approval request (T1), an orphaned tool_result with no preceding tool_call (T4), a
+# broken file part missing mediaType (T1), and a run that otherwise emits real content
+# (so T2's zero-content guard doesn't also fire and mask the others).
+_CONFORMANCE_EVENTS: List[Dict[str, Any]] = [
+    {"type": "message", "data": {"text": "hello"}},
+    {
+        "type": "interaction_request",
+        "data": {
+            "id": "perm-1",
+            "kind": "user_approval",
+            "payload": {"toolCallId": None},
+        },
+    },
+    {"type": "tool_result", "data": {"id": "orphan-1", "output": "ok"}},
+    {"type": "file", "data": {"url": "https://x", "mediaType": None}},
+    {"type": "done", "data": {"stopReason": "stop"}},
+]
+
+
+@pytest.mark.asyncio
+async def test_live_projection_conforms_to_vendored_schema() -> None:
+    parts = [
+        part
+        async for part in agent_stream_to_vercel_stream(
+            _records(_CONFORMANCE_EVENTS), trace_id="t1"
+        )
+    ]
+    assert parts, "expected at least the start/finish frames"
+    for part in parts:
+        assert_conforms(part)
+
+
+@pytest.mark.asyncio
+async def test_dev_twin_projection_conforms_to_vendored_schema() -> None:
+    run = _run_with(_CONFORMANCE_EVENTS, result={"output": "hello"})
+    parts = [part async for part in agent_run_to_vercel_parts(run)]
+    assert parts
+    for part in parts:
+        assert_conforms(part)
+
+
+@pytest.mark.asyncio
+async def test_zero_content_run_emits_conforming_error_frame() -> None:
+    """The T2 fix's synthetic error frame must itself conform (errorText required)."""
+    parts = [
+        part
+        async for part in agent_stream_to_vercel_stream(
+            _records([{"type": "done", "data": {"stopReason": "stop"}}]), trace_id="t2"
+        )
+    ]
+    for part in parts:
+        assert_conforms(part)
+    assert any(p["type"] == "error" for p in parts)
+
+
+def test_vendored_version_matches_package_pin() -> None:
+    # CI-grep-able tripwire: bump this const (and re-audit the shape above) whenever
+    # web/oss/package.json's "ai" pin changes.
+    assert _AI_PACKAGE_VERSION == "6.0.0-beta.150"

--- a/sdks/python/oss/tests/pytest/unit/agents/adapters/test_vercel_stream_finish_reason.py
+++ b/sdks/python/oss/tests/pytest/unit/agents/adapters/test_vercel_stream_finish_reason.py
@@ -176,14 +176,15 @@ async def _events_then_raise(
 ) -> AsyncIterator[Dict[str, Any]]:
     for item in items:
         yield item
-    raise ValueError("unexpected adapter bug")
+    raise ValueError('File "/internal/adapter/module.py", line 42, in _run\nboom')
 
 
 @pytest.mark.asyncio
 async def test_raw_exception_mid_stream_still_emits_finish() -> None:
     """An unexpected exception raised while iterating the event stream (not a graceful
     terminal-failure result) must still drain to a `finish` frame, or a consumer waiting
-    on it hangs forever."""
+    on it hangs forever. The exception's raw text must NOT reach the client verbatim --
+    a stack/path dump is sanitized to a generic message; the detail is only logged."""
     parts = [
         part
         async for part in agent_stream_to_vercel_stream(
@@ -194,4 +195,5 @@ async def test_raw_exception_mid_stream_still_emits_finish() -> None:
     assert "error" in types
     assert types[-2:] == ["finish-step", "finish"]
     error = next(p for p in parts if p["type"] == "error")
-    assert "unexpected adapter bug" in error["errorText"]
+    assert "/internal/adapter/module.py" not in error["errorText"]
+    assert error["errorText"]

--- a/sdks/python/oss/tests/pytest/unit/agents/test_ui_messages.py
+++ b/sdks/python/oss/tests/pytest/unit/agents/test_ui_messages.py
@@ -540,23 +540,28 @@ class TestUIMessageStream:
         approval = next(p for p in parts if p["type"] == "tool-approval-request")
         assert approval["toolCallId"] == "call_1"
 
-    async def test_tool_denial_becomes_output_denied(self):
-        # A human denied the tool: it never ran, so emit tool-output-denied (not -available).
+    async def test_tool_denial_rides_iserror_not_a_denied_field(self):
+        # No runner path ever sets a `denied` field on a tool_result — a human deny rides
+        # `isError: True` like any other tool failure, so it becomes tool-output-error.
         run = _run(
             events=[
                 {"type": "tool_call", "id": "c1", "name": "deleteFile", "input": {}},
-                {"type": "tool_result", "id": "c1", "denied": True},
+                {
+                    "type": "tool_result",
+                    "id": "c1",
+                    "output": "denied by user",
+                    "isError": True,
+                },
                 {"type": "done"},
             ],
             result={"output": ""},
         )
         parts = await _collect(run, session_id="s1")
-        denied = next(p for p in parts if p["type"] == "tool-output-denied")
-        assert denied["toolCallId"] == "c1"
-        # A denied result is neither output-available nor output-error.
+        error = next(p for p in parts if p["type"] == "tool-output-error")
+        assert error["toolCallId"] == "c1"
         types = [p["type"] for p in parts]
         assert "tool-output-available" not in types
-        assert "tool-output-error" not in types
+        assert "tool-output-denied" not in types
 
     async def test_finish_carries_trace_id_from_param(self):
         run = _run(


### PR DESCRIPTION
## Context

The Vercel playground adapter handed runner fields straight into `ai@6`'s `uiMessageChunkSchema`, which uses strict objects with required strings. When an optional field arrived as `null` (most reachably, a tool-approval request with no `toolCallId`), the client did not skip that part. It threw, and the whole turn errored out, including text that had already rendered. Separately, a run that finished `ok:true` with no content parts rendered as a clean blank bubble, and raw exception strings reached the browser.

## Changes

- **PY-D1**: a single `_conform(part)` gate normalizes every part at the yield boundary of both the dev and the live projection. It synthesizes fallback ids, falls back on names, skips file parts missing a url or mediaType, and omits `None` ids so no null reaches a required slot.

  Before: an approval part with `toolCallId: None` reaches the wire and the `ai@6` client throws.
  After: `_conform` omits the null id (or supplies a fallback) and the part validates.

- **PY-D2**: both projections track a content-emitted counter and emit an explicit error frame when a run finishes with zero content parts, instead of a silent empty finish.

- **PY-D4 / D5 / D6**: tool-result emission is guarded on a seen tool call; the dead `denied` branch (no producer emits it, deny rides `isError:true`) is removed; the catch-all sanitizes the exception before it reaches the client and logs the detail server-side.

- **PY-D3**: a vendored copy of the `ai@6` `uiMessageChunkSchema` shape (version-stamped and grep-linked to `web/oss/package.json`) plus a conformance test that asserts every frame the existing suites collect. This pins the hand-kept mirror against the beta schema the frontend owns.

## Tests

- `pytest sdks/python/oss/tests/pytest/unit/agents` green (includes the existing Vercel adapter suites, the new conformance test, and the two rewritten tests). The finish-reason test that previously asserted the raw-exception leak now asserts it is gone.
- Both projections were verified byte-for-byte identical after the change.

## What to QA

- Drive a playground turn that produces a tool-approval request. The turn completes and renders instead of erroring.
- Drive a turn that returns no content. You get an explicit error frame, not a blank bubble.
- Regression: a normal streamed turn with tool calls and text still renders as before.
