### PR TITLE
[fix] Point agent template defaults at services/runner and sweep stale docs

### DIFF
--- a/sdks/python/agenta/sdk/agents/adapters/claude_settings.py
+++ b/sdks/python/agenta/sdk/agents/adapters/claude_settings.py
@@ -53,9 +53,9 @@ SETTINGS_PATH = ".claude/settings.json"
 # ``mcp__<server>__<tool>``, so a per-tool permission rule for a resolved tool is
 # ``mcp__agenta-tools__<tool>``. This name COUPLES to the runner constant and MUST stay in sync
 # with the TypeScript runner, which advertises the same server name in:
-#   - ``services/agent/src/tools/mcp-bridge.ts`` (``name: "agenta-tools"``)
-#   - ``services/agent/src/tools/relay-mcp-stdio.ts`` and ``tool-mcp-http.ts`` (``serverInfo.name``)
-#   - ``services/agent/src/engines/sandbox_agent/mcp.ts``
+#   - ``services/runner/src/tools/mcp-bridge.ts`` (``name: "agenta-tools"``)
+#   - ``services/runner/src/tools/relay.ts`` and ``tool-mcp-http.ts`` (``serverInfo.name``)
+#   - ``services/runner/src/engines/sandbox_agent/mcp.ts``
 # If the runner renames this server, this constant must change with it.
 INTERNAL_TOOL_MCP_SERVER = "agenta-tools"
 

--- a/sdks/python/agenta/sdk/agents/adapters/local.py
+++ b/sdks/python/agenta/sdk/agents/adapters/local.py
@@ -3,7 +3,7 @@
 This is the backend a standalone SDK user gets. It is two mechanisms, one per harness, which
 is exactly a backend's "plumbing per harness" job:
 
-- Pi   -> the Node agent runner (``services/agent``), driven over the subprocess transport.
+- Pi   -> the Node agent runner (``services/runner``), driven over the subprocess transport.
 - Claude -> the pure-Python ``claude-agent-sdk``, in-process, no TS bridge.
 
 NOTE on packaging: the Node runner is NOT part of this Python wheel (``pip install agenta``

--- a/sdks/python/agenta/sdk/agents/dtos.py
+++ b/sdks/python/agenta/sdk/agents/dtos.py
@@ -209,7 +209,7 @@ class ContentBlock(BaseModel):
     the ``/messages`` egress folds inbound UIMessage tool/approval parts into these so a
     cross-turn HITL reply replays as a real tool call plus its result, and the model resumes
     from the result instead of re-asking. Mirrors ``ContentBlock`` in
-    ``services/agent/src/protocol.ts``.
+    ``services/runner/src/protocol.ts``.
     """
 
     type: str  # "text" | "image" | "resource" | "tool_call" | "tool_result"

--- a/sdks/python/agenta/sdk/agents/interfaces.py
+++ b/sdks/python/agenta/sdk/agents/interfaces.py
@@ -236,7 +236,7 @@ class Harness(ABC):
         """Files this harness needs laid into the sandbox before the run.
 
         The instructions filename is harness-aware, mirroring the runner's workspace
-        materialization (``services/agent/.../workspace.ts``): Claude runs through
+        materialization (``services/runner/.../workspace.ts``): Claude runs through
         ``claude-agent-sdk``, whose memory loader auto-loads ``CLAUDE.md`` only and never reads
         ``AGENTS.md``, so the claude harness's instructions must land in ``CLAUDE.md``. Pi (and
         any other harness) reads ``AGENTS.md``.

--- a/sdks/python/agenta/sdk/agents/skills/wire.py
+++ b/sdks/python/agenta/sdk/agents/skills/wire.py
@@ -2,7 +2,7 @@
 
 By the time the wire is built every entry is a concrete :class:`SkillTemplate` (references
 resolved server-side via ``@ag.embed``), so there is one shape to emit: ``WireSkill`` (see
-``services/agent/src/protocol.ts``).
+``services/runner/src/protocol.ts``).
 """
 
 from __future__ import annotations

--- a/sdks/python/agenta/sdk/agents/utils/wire.py
+++ b/sdks/python/agenta/sdk/agents/utils/wire.py
@@ -1,7 +1,7 @@
 """The ``/run`` wire contract: our DTOs <-> the runner's camelCase JSON.
 
 Used by the sandbox-agent backend. The TS side mirrors these names in
-``services/agent/src/protocol.ts``, and the contract is pinned by shared golden fixtures
+``services/runner/src/protocol.ts``, and the contract is pinned by shared golden fixtures
 under ``sdks/python/oss/tests/pytest/unit/agents/golden/`` (see ``test_wire_contract.py``).
 The runner drives one engine (the sandbox-agent ACP path); the ``harness`` field selects the
 agent, so there is no engine selector on the wire.

--- a/sdks/python/agenta/sdk/agents/wire_models.py
+++ b/sdks/python/agenta/sdk/agents/wire_models.py
@@ -2,7 +2,7 @@
 
 These models describe the EXACT camelCase JSON the Python producer emits and parses in
 ``utils/wire.py`` (``request_to_wire`` / ``result_from_wire``) and the TS runner mirrors in
-``services/agent/src/protocol.ts``. They are deliberately a SEPARATE set from the semantic
+``services/runner/src/protocol.ts``. They are deliberately a SEPARATE set from the semantic
 DTOs in ``dtos.py``: the DTOs are snake_case and intentionally loose (``Event`` is a free
 ``type: str`` + ``data`` bag), while the real wire is camelCase with a discriminated event
 union. Exporting ``model_json_schema()`` off the DTOs would produce the wrong schema, so the

--- a/sdks/python/agenta/sdk/utils/types.py
+++ b/sdks/python/agenta/sdk/utils/types.py
@@ -1354,7 +1354,7 @@ class _PermissionsSchema(BaseModel):
 
 
 class _RunnerSchema(BaseModel):
-    """The engine that drives the harness loop (the ``services/agent`` sidecar).
+    """The engine that drives the harness loop (the ``services/runner`` sidecar).
 
     ``kind`` names the engine; ``permissions`` is the runner-enforced tool execution policy.
     ``extras`` is the per-runner escape hatch. The rest of the runner surface (delivery channel,

--- a/sdks/python/oss/tests/pytest/unit/agents/skills/test_wire.py
+++ b/sdks/python/oss/tests/pytest/unit/agents/skills/test_wire.py
@@ -1,6 +1,6 @@
 """``skills_to_wire``: resolved ``SkillTemplate`` list -> the ``WireSkill[]`` runner contract.
 
-The wire is camelCase to match ``services/agent/src/protocol.ts``; optional flags and ``files``
+The wire is camelCase to match ``services/runner/src/protocol.ts``; optional flags and ``files``
 are omitted when unset so a minimal skill stays minimal.
 """
 

--- a/sdks/python/oss/tests/pytest/unit/agents/test_runner_batch_error_fidelity.py
+++ b/sdks/python/oss/tests/pytest/unit/agents/test_runner_batch_error_fidelity.py
@@ -1,7 +1,7 @@
 """The batch HTTP transport surfaces the runner's actionable error, not a generic HTTP 500.
 
 F-038: a run failure comes back from the runner as HTTP 500 with a *result* body
-(``{"ok": false, "error": <concise message>}``; see ``services/agent/src/server.ts``). That
+(``{"ok": false, "error": <concise message>}``; see ``services/runner/src/server.ts``). That
 ``error`` is the actionable, already-sanitized provider message and is the SAME body the
 streaming path surfaces. The batch path (``/invoke`` + the ``/messages`` JSON path) used to
 discard the body and raise a generic "Agent runner HTTP 500", losing the actionable text.

--- a/sdks/python/oss/tests/pytest/unit/agents/test_runner_transport_auth.py
+++ b/sdks/python/oss/tests/pytest/unit/agents/test_runner_transport_auth.py
@@ -1,7 +1,7 @@
 """The runner HTTP transport sends the optional shared-token header (Codex LOW-5).
 
 The runner's ``/run`` endpoint has an opt-in shared-token gate (``AGENTA_RUNNER_TOKEN``,
-default OFF; see ``services/agent/src/server.ts``). When the operator turns it on, an un-tokened
+default OFF; see ``services/runner/src/server.ts``). When the operator turns it on, an un-tokened
 POST from the co-located Python service is rejected with 401. These tests pin the Python side of
 that contract: ``deliver_http_result`` / ``deliver_http_stream`` attach ``Authorization: Bearer
 <token>`` when the same env var is set, and send no auth header when it is not (loopback default).

--- a/sdks/python/oss/tests/pytest/unit/agents/test_streaming.py
+++ b/sdks/python/oss/tests/pytest/unit/agents/test_streaming.py
@@ -9,7 +9,7 @@ Two layers:
 
 A final integration test drives the real ``cli.ts --stream`` when ``pnpm`` is available.
 
-Run: ``uv run pytest agenta/tests/agents/test_streaming.py`` from ``sdks/python``.
+Run: ``uv run pytest oss/tests/pytest/unit/agents/test_streaming.py`` from ``sdks/python``.
 """
 
 from __future__ import annotations
@@ -149,7 +149,7 @@ async def test_subprocess_stream_cancellation_kills_child() -> None:
 
 @pytest.mark.skipif(shutil.which("pnpm") is None, reason="pnpm not available")
 async def test_cli_stream_terminal_only_on_empty_request() -> None:
-    agent_dir = Path(__file__).resolve().parents[5] / "services" / "agent"
+    agent_dir = Path(__file__).resolve().parents[7] / "services" / "runner"
     cmd = ["pnpm", "exec", "tsx", "src/cli.ts"]
     records = []
     async for record in deliver_subprocess_stream(cmd, {}, cwd=str(agent_dir)):

--- a/sdks/python/oss/tests/pytest/unit/agents/test_wire_contract.py
+++ b/sdks/python/oss/tests/pytest/unit/agents/test_wire_contract.py
@@ -1,7 +1,7 @@
 """The ``/run`` wire contract: ``request_to_wire`` / ``result_from_wire``.
 
 This is the highest-value regression guard in the agent runtime. ``wire.py`` (the Python
-producer) and ``services/agent/src/protocol.ts`` (the TS consumer) are hand-mirrored, so the
+producer) and ``services/runner/src/protocol.ts`` (the TS consumer) are hand-mirrored, so the
 two can drift silently. The golden fixtures in ``golden/`` are the shared anchor: this file
 asserts the Python side against them, and the TS side asserts the same files (a later PR).
 

--- a/services/oss/src/agent/config.py
+++ b/services/oss/src/agent/config.py
@@ -1,4 +1,4 @@
-"""Static on-file agent template, read from ``services/agent/config``.
+"""Static on-file agent template, read from ``services/runner/config``.
 
 The template (AGENTS.md text, model, tools) lives in editable files so changing the
 agent does not need a code change. Paths can be overridden with env vars for Docker
@@ -11,9 +11,13 @@ from dataclasses import dataclass, field
 from pathlib import Path
 from typing import Any, List, Optional
 
+from agenta.sdk.utils.logging import get_module_logger
+
+log = get_module_logger(__name__)
+
 # services/oss/src/agent/config.py -> parents[3] == services/
 _SERVICES_DIR = Path(__file__).resolve().parents[3]
-_DEFAULT_AGENT_DIR = _SERVICES_DIR / "agent"
+_DEFAULT_AGENT_DIR = _SERVICES_DIR / "runner"
 
 # Fallback config used when the editable files are missing or a field is absent.
 # Kept in sync with the catalog template and the `/inspect` schema defaults
@@ -66,6 +70,12 @@ def load_config() -> AgentTemplate:
         text = agents_path.read_text(encoding="utf-8").strip()
         if text:
             agents_md = text
+    else:
+        log.warning(
+            "agent: template not found at %s; falling back to the built-in hello-world "
+            "AGENTS.md (set AGENTA_AGENT_TEMPLATE_DIR if this path is unexpected)",
+            agents_path,
+        )
 
     model: str = DEFAULT_MODEL
     tools: List[str] = []
@@ -74,5 +84,12 @@ def load_config() -> AgentTemplate:
         meta = json.loads(meta_path.read_text(encoding="utf-8"))
         model = meta.get("model") or DEFAULT_MODEL
         tools = meta.get("tools", []) or []
+    else:
+        log.warning(
+            "agent: template not found at %s; falling back to the built-in default "
+            "model %r with no tools (set AGENTA_AGENT_TEMPLATE_DIR if this path is unexpected)",
+            meta_path,
+            DEFAULT_MODEL,
+        )
 
     return AgentTemplate(agents_md=agents_md, model=model, tools=tools)

--- a/services/oss/tests/pytest/unit/agent/test_config_template_fallback.py
+++ b/services/oss/tests/pytest/unit/agent/test_config_template_fallback.py
@@ -1,0 +1,43 @@
+"""``config.py``: the default template dir resolves under `services/runner`, and a missing
+template logs a warning instead of silently falling through to the hello-world constants
+(PY-A2)."""
+
+from __future__ import annotations
+
+import logging
+
+
+from oss.src.agent import config as agent_config
+
+
+def test_default_agent_dir_resolves_under_services_runner():
+    assert agent_config._DEFAULT_AGENT_DIR.name == "runner"
+    assert agent_config._DEFAULT_AGENT_DIR.parent.name == "services"
+
+
+def test_load_config_uses_real_template_when_present():
+    template = agent_config.load_config()
+
+    assert template.agents_md != agent_config.DEFAULT_AGENTS_MD
+
+
+def test_missing_template_logs_warning_and_falls_back(monkeypatch, tmp_path, caplog):
+    monkeypatch.setenv("AGENTA_AGENT_TEMPLATE_DIR", str(tmp_path / "does-not-exist"))
+
+    with caplog.at_level(logging.WARNING):
+        template = agent_config.load_config()
+
+    assert template.agents_md == agent_config.DEFAULT_AGENTS_MD
+    assert template.model == agent_config.DEFAULT_MODEL
+    assert template.tools == []
+
+    messages = [
+        record.message % record.args if record.args else record.message
+        for record in caplog.records
+    ]
+    assert any(
+        "AGENTS.md" in message and "falling back" in message for message in messages
+    )
+    assert any(
+        "agent.json" in message and "falling back" in message for message in messages
+    )

--- a/services/runner/AGENTS.md
+++ b/services/runner/AGENTS.md
@@ -18,7 +18,7 @@ dependency graph.
 ## Commands
 
 ```bash
-pnpm install              # from services/agent, with Node 24 on PATH
+pnpm install              # from services/runner, with Node 24 on PATH
 pnpm run serve            # HTTP sidecar on :8765 (GET /health, POST /run)
 pnpm run run:cli          # one JSON request on stdin -> one result on stdout
 pnpm test                 # vitest: all unit tests

--- a/services/runner/README.md
+++ b/services/runner/README.md
@@ -18,7 +18,8 @@ Two entrypoints, same `/run` contract (see `src/protocol.ts`):
   adapters call over HTTP when `AGENTA_RUNNER_INTERNAL_URL` points at it. The dev image
   (`docker/Dockerfile.dev`) runs `tsx watch src/server.ts`.
 
-Both route to an engine by the request's `backend` field.
+Both drive the request through the one engine (`engines/sandbox_agent.ts`); the request's
+`harness` field selects which harness runs inside it.
 
 ## Layout (`src/`)
 
@@ -28,30 +29,27 @@ src/
   server.ts           entrypoint: HTTP sidecar on :8765
   protocol.ts         the /run wire contract (request, result, events, capabilities)
   engines/
-    pi.ts             engine: drive the Pi SDK in-process
-    sandbox_agent.ts  engine: drive a harness over ACP through sandbox-agent
+    sandbox_agent.ts  the one engine: drive a harness over ACP through sandbox-agent
   tracing/
     otel.ts           turn a run into OpenTelemetry spans nested under /invoke
   tools/
     callback.ts       the one /tools/call HTTP client
     code.ts           execute resolved code tools in a scoped subprocess
     dispatch.ts       dispatch resolved tools by executor kind
-    mcp-bridge.ts     stdio MCP bridge — DISABLED (throws MCP_UNSUPPORTED_MESSAGE)
-    mcp-server.ts     the stdio MCP server — REMOVED (refuses to serve; no longer launched)
+    mcp-bridge.ts     the INTERNAL gateway-tool MCP channel (loopback HTTP) — live
+    mcp-server.ts     the OLD stdio MCP bridge — REMOVED (refuses to serve; no longer launched)
   extensions/
     agenta.ts         the Pi extension (tracing + tools), bundled into dist/ for Pi to load
 ```
 
-## Engines
+## Engine
 
-- **`pi`** (`engines/pi.ts`) — drives the Pi SDK directly in-process.
-- **`sandbox-agent`** (`engines/sandbox_agent.ts`) — drives any harness (`pi`, `claude`) over the Agent
-  Client Protocol through sandbox-agent, either local or in a Daytona
-  sandbox. This is the default on the platform.
+There is one engine, `sandbox_agent.ts`: it drives any harness (`pi`, `claude`) over the Agent
+Client Protocol through sandbox-agent, either local or in a Daytona sandbox.
 
-The engine is internal runner plumbing. The platform sends `sandbox-agent` by default.
 Harness choice (`pi`, `claude`, or experimental `agenta`) and sandbox (`local` or
-`daytona`, where supported) are per-run config from the Python service.
+`daytona`, where supported) are per-run config from the Python service, carried on the
+request's `harness` / `sandbox` fields.
 
 ## Result
 
@@ -87,13 +85,17 @@ live workflow span.
 Tools are resolved in the Python backend and arrive on the request as `customTools` plus a
 `toolCallback`. The Pi extension registers them natively, and each call POSTs back to Agenta's
 `/tools/call` (`tools/callback.ts`) so the provider key and connection auth stay server-side.
+Non-Pi harnesses (e.g. Claude) that only accept tools over MCP get these same resolved tools
+through an INTERNAL loopback HTTP MCP channel the runner serves (`tools/mcp-bridge.ts` +
+`tools/tool-mcp-http.ts`) — this channel is live and is how Claude runs take custom tools.
 
-The stdio MCP delivery path that exposed tools to non-Pi harnesses (`tools/mcp-bridge.ts` +
-`tools/mcp-server.ts`) is **disabled** in the sidecar — it launched an unconfined child process
-on the runner host, the same execution bypass that had code tools removed. Until the security is
-fixed, delivering a tool over MCP throws `MCP_UNSUPPORTED_MESSAGE`, so a non-Pi harness (e.g.
-Claude) cannot take custom tools, and the run plan refuses any request carrying a stdio MCP
-server. See `docs/design/agent-workflows/projects/sidecar-trust-and-sandbox-enforcement/`.
+This internal channel is a different thing from USER-declared MCP servers (a run request's own
+`mcpServers`), which stay gated: stdio user MCP servers are refused for every harness
+(`tools/mcp-server.ts`, the old stdio bridge, is REMOVED — it launched an unconfined child
+process on the runner host, the same execution bypass that had code tools removed), and it is
+_Pi_, not the sidecar broadly, that also refuses user _http_ MCP servers, because Pi delivers
+tools through its bundled extension rather than over ACP MCP. Claude accepts user http MCP
+servers. See `docs/design/agent-workflows/projects/sidecar-trust-and-sandbox-enforcement/`.
 
 ## The extension bundle
 
@@ -122,5 +124,5 @@ revision's config, so these are rarely hit.
 
 ```bash
 pnpm install
-echo '{"backend":"sandbox-agent","harness":"pi","sandbox":"local","messages":[{"role":"user","content":"Hi"}]}' | pnpm run run:cli
+echo '{"harness":"pi","sandbox":"local","messages":[{"role":"user","content":"Hi"}]}' | pnpm run run:cli
 ```

--- a/services/runner/sandbox-images/daytona/build_snapshot.py
+++ b/services/runner/sandbox-images/daytona/build_snapshot.py
@@ -13,7 +13,7 @@ daemon, the Claude CLI, and CA certs) so Daytona runs don't pay a ~150s per-invo
 
 Run: DAYTONA_API_KEY=... DAYTONA_TARGET=eu uv run build_snapshot.py [--force]
 
-Licensing (see services/agent/docker/README.md):
+Licensing (see services/runner/docker/README.md):
     This script is the build recipe we ship, NOT a snapshot we distribute. Whoever
     runs it builds the snapshot in their own Daytona account: Agenta Cloud builds
     its own for internal use; self-hosters build their own. We never hand anyone a

--- a/services/runner/tests/utils/golden.ts
+++ b/services/runner/tests/utils/golden.ts
@@ -11,7 +11,7 @@ import { fileURLToPath } from "node:url";
 import { dirname, join } from "node:path";
 
 const here = dirname(fileURLToPath(import.meta.url));
-// services/agent/tests/utils -> repo root -> the shared Python golden fixtures.
+// services/runner/tests/utils -> repo root -> the shared Python golden fixtures.
 export const GOLDEN_DIR = join(
   here,
   "../../../../sdks/python/oss/tests/pytest/unit/agents/golden",


### PR DESCRIPTION
## Context

The `services/agent` directory was renamed to `services/runner`, but the editable-template feature never got the memo. Its default template path still pointed at `services/agent`, `load_config()` guarded on `.exists()`, and when the path was missing it silently fell through to the built-in hello-world constants with no log. So in every deployment the feature quietly no-oped, and there was no signal that it had. On top of that, the runner README and a scatter of docstrings described a system that no longer exists.

## Changes

- **PY-A2 (behavioral)**: the default template path now points at `services/runner`. When the path is missing, `load_config()` logs a warning naming the missing path before falling back to the constants, so a broken deploy is visible instead of silent. An orphaned test that lived outside the pytest roots (and referenced the stale path) moved under the roots and now runs in CI.

  Before: template dir missing → silently uses hello-world constants, no log.
  After: template dir missing → `log.warning` naming the path, then the constants.

- **RUN-24 (docs)**: the runner README no longer lists the removed `engines/pi.ts`, drops the phantom `request.backend` field, and corrects the inverted MCP claim (`mcp-bridge.ts` is a live internal loopback tool channel; it is Pi specifically that refuses user-declared HTTP MCP servers, not the sidecar broadly).

- **Docstring sweep**: 8 SDK files that referenced the phantom `services/agent` directory now point at `services/runner`, plus a few adjacent stale-path hits found in the same pass.

The MCP env var name `AGENTA_AGENT_MCPS_ENABLED` was already correct in every live location, and the off-by-default polarity was already described correctly, so neither was changed. The `docs/design/agent-workflows` archive and historical planning docs were left untouched on purpose.

## Tests

- New `test_config_template_fallback.py` covers the logged fallback and the `services/runner` path resolution.
- The moved `test_streaming.py` runs green under the pytest roots.
- `services/oss` agent unit suite, the SDK agents suite, and the runner `pnpm test` / `typecheck` all pass; `ruff` clean.
