### PR TITLE
[fix] Clear orphan Redis locks and stop DAYTONA_API_KEY leaking into local daemons

### DIFF
--- a/api/entrypoints/routers.py
+++ b/api/entrypoints/routers.py
@@ -266,7 +266,9 @@ async def lifespan(*args, **kwargs):
         except Exception as e:  # noqa: BLE001
             log.warning("Store bucket ensure failed at startup: %s", e)
 
-    _orphan_sweep_task = asyncio.create_task(orphan_sweep_loop(_transactions_engine))
+    _orphan_sweep_task = asyncio.create_task(
+        orphan_sweep_loop(_transactions_engine, _lock_engine)
+    )
 
     # Best-effort: ingestion re-resolves on demand if this fails.
     if env.composio.enabled:

--- a/api/oss/src/tasks/asyncio/sessions/orphan_sweep.py
+++ b/api/oss/src/tasks/asyncio/sessions/orphan_sweep.py
@@ -17,6 +17,8 @@ from oss.src.dbs.postgres.sessions.streams.dbes import SessionStreamDBE
 from oss.src.core.sessions.streams.dtos import (
     SessionStreamFlags,
 )
+from oss.src.dbs.redis.shared.engine import LockEngine
+from oss.src.dbs.redis.sessions.locks import force_cancel_alive, clear_running
 
 from sqlalchemy import select
 
@@ -29,7 +31,7 @@ ORPHAN_THRESHOLD_SECONDS: int = 300  # 5 minutes
 SWEEP_INTERVAL_SECONDS: int = 60
 
 
-async def run_orphan_sweep(engine: TransactionsEngine) -> None:
+async def run_orphan_sweep(engine: TransactionsEngine, lock_engine: LockEngine) -> None:
     """Single sweep pass: mark stale is_alive rows as ended."""
     threshold = datetime.now(timezone.utc) - timedelta(seconds=ORPHAN_THRESHOLD_SECONDS)
 
@@ -57,14 +59,22 @@ async def run_orphan_sweep(engine: TransactionsEngine) -> None:
             )
 
         await session.commit()
+
+        # Bring the Redis locks the SEND gate reads in sync with the rows just written.
+        for row in orphans:
+            await force_cancel_alive(lock_engine, session_id=row.session_id)
+            await clear_running(lock_engine, session_id=row.session_id)
+
         log.info("orphan_sweep: marked %d orphans ended", len(orphans))
 
 
-async def orphan_sweep_loop(engine: TransactionsEngine) -> None:
+async def orphan_sweep_loop(
+    engine: TransactionsEngine, lock_engine: LockEngine
+) -> None:
     """Infinite loop; runs as a background asyncio task during app lifespan."""
     while True:
         try:
-            await run_orphan_sweep(engine)
+            await run_orphan_sweep(engine, lock_engine)
         except Exception:
             log.exception("orphan_sweep: error during sweep pass")
         await asyncio.sleep(SWEEP_INTERVAL_SECONDS)

--- a/api/oss/tests/pytest/unit/sessions/test_orphan_sweep_clears_redis.py
+++ b/api/oss/tests/pytest/unit/sessions/test_orphan_sweep_clears_redis.py
@@ -1,0 +1,137 @@
+"""RUN-28: the orphan sweep must clear the Redis locks the SEND gate reads.
+
+Before the fix, the sweep only flipped Postgres flags; the Redis alive lock
+(TTL 3600s) outlived the Postgres orphan-threshold (300s), so a crashed
+session kept refusing SEND with SessionTurnInUse for up to ~55 more minutes.
+
+No live Redis/Postgres: an in-memory fake stands in for both, mirroring the
+fake-engine pattern in test_streams_dao_conflict.py.
+"""
+
+from contextlib import asynccontextmanager
+from datetime import datetime, timezone, timedelta
+
+import pytest
+
+from oss.src.dbs.redis.sessions.locks import get_session_liveness
+from oss.src.core.sessions.streams.types import SessionTurnInUse
+from oss.src.tasks.asyncio.sessions.orphan_sweep import run_orphan_sweep
+
+_SESSION_ID = "sess-orphan-1"
+
+
+class _FakeRow:
+    def __init__(self, *, session_id: str, updated_at: datetime):
+        self.session_id = session_id
+        self.id = "stream-1"
+        self.deleted_at = None
+        self.flags = {"is_alive": True, "is_running": True, "is_attached": False}
+        self.updated_at = updated_at
+
+
+class _FakeScalars:
+    def __init__(self, rows):
+        self._rows = rows
+
+    def all(self):
+        return self._rows
+
+
+class _FakeResult:
+    def __init__(self, rows):
+        self._rows = rows
+
+    def scalars(self):
+        return _FakeScalars(self._rows)
+
+
+class _FakePgSession:
+    def __init__(self, rows):
+        self._rows = rows
+
+    async def execute(self, _stmt):
+        return _FakeResult(self._rows)
+
+    async def commit(self):
+        pass
+
+
+class _FakeTransactionsEngine:
+    """Mimics TransactionsEngine.session() yielding one stale orphan row."""
+
+    def __init__(self, rows):
+        self._rows = rows
+
+    @asynccontextmanager
+    async def session(self):
+        yield _FakePgSession(self._rows)
+
+
+class _FakeRedis:
+    """Dict-backed stand-in for the redis.asyncio client LockEngine proxies to."""
+
+    def __init__(self):
+        self._store: dict[str, bytes] = {}
+
+    async def get(self, key):
+        return self._store.get(key)
+
+    async def set(self, key, value, nx=False, ex=None):
+        if nx and key in self._store:
+            return None
+        self._store[key] = value
+        return True
+
+    async def delete(self, key):
+        self._store.pop(key, None)
+        return 1
+
+    async def expire(self, key, ttl):
+        return True
+
+
+@pytest.fixture
+def anyio_backend():
+    return "asyncio"
+
+
+@pytest.mark.anyio
+async def test_orphan_sweep_clears_alive_lock_and_unblocks_send(anyio_backend):
+    assert anyio_backend == "asyncio"
+
+    lock_engine = _FakeRedis()
+
+    # Seed the alive lock as a live runner would, past the Postgres orphan threshold.
+    # Keys are plain str (locks.py never encodes the key, only the value).
+    await lock_engine.set(f"alive:session:{_SESSION_ID}", b"turn-1", ex=3600)
+    await lock_engine.set(f"running:session:{_SESSION_ID}", b"turn-1", ex=3600)
+
+    stale_row = _FakeRow(
+        session_id=_SESSION_ID,
+        updated_at=datetime.now(timezone.utc) - timedelta(seconds=600),
+    )
+    pg_engine = _FakeTransactionsEngine([stale_row])
+
+    # Before the sweep: SEND gate sees alive=True and must refuse.
+    liveness_before = await get_session_liveness(lock_engine, session_id=_SESSION_ID)
+    assert liveness_before["alive"] is True
+
+    await run_orphan_sweep(pg_engine, lock_engine)
+
+    # Postgres side: flags collapsed as before the fix.
+    assert stale_row.flags == {
+        "is_alive": False,
+        "is_running": False,
+        "is_attached": False,
+    }
+
+    # Redis side (the fix): the locks the SEND gate reads are gone too.
+    liveness_after = await get_session_liveness(lock_engine, session_id=_SESSION_ID)
+    assert liveness_after == {"alive": False, "running": False, "attached": False}
+
+    # SEND gate logic (service.py:99-101): would raise if alive were still true.
+    def _send_gate(liveness):
+        if liveness["alive"]:
+            raise SessionTurnInUse(session_id=_SESSION_ID, liveness=liveness)
+
+    _send_gate(liveness_after)  # must not raise

--- a/services/runner/src/engines/sandbox_agent/daemon.ts
+++ b/services/runner/src/engines/sandbox_agent/daemon.ts
@@ -5,7 +5,9 @@ import { fileURLToPath } from "node:url";
 
 const require = createRequire(import.meta.url);
 // services/runner/src/engines/sandbox_agent/daemon.ts -> services/runner
-export const PKG_ROOT = dirname(dirname(dirname(dirname(fileURLToPath(import.meta.url)))));
+export const PKG_ROOT = dirname(
+  dirname(dirname(dirname(fileURLToPath(import.meta.url)))),
+);
 export const ADAPTER_BIN_DIR = join(PKG_ROOT, "node_modules", ".bin");
 
 /** Map node platform/arch to the @sandbox-agent CLI binary package. */
@@ -27,7 +29,8 @@ export function resolveDaemonBinary(): string | undefined {
 
   const pkg = CLI_PACKAGES[`${process.platform}-${process.arch}`];
   if (!pkg) return undefined;
-  const bin = process.platform === "win32" ? "sandbox-agent.exe" : "sandbox-agent";
+  const bin =
+    process.platform === "win32" ? "sandbox-agent.exe" : "sandbox-agent";
   try {
     const sdkRequire = createRequire(require.resolve("sandbox-agent"));
     const pkgJson = sdkRequire.resolve(`${pkg}/package.json`);
@@ -107,6 +110,14 @@ export const KNOWN_PROVIDER_ENV_VARS = [
   "AZURE_OPENAI_API_KEY",
 ] as const;
 
+// Sandbox-provider infra creds (never a harness concern): cleared on EVERY run, not just managed
+// ones. sandbox-agent's local() spawns `{...process.env, ...options.env}` (inherit-then-apply), so
+// an absent key here doesn't stop the leak — must be forced to "" to override the inherited value.
+export const KNOWN_SANDBOX_ENV_VARS = [
+  "DAYTONA_API_KEY",
+  "E2B_API_KEY",
+] as const;
+
 export interface BuildDaemonEnvOptions {
   /**
    * Clear-then-apply (Security rule 5): on a MANAGED run (`credentialMode === "env"`) the
@@ -136,7 +147,9 @@ export function buildDaemonEnv(
   const env: Record<string, string> = {};
 
   const extra = process.env.SANDBOX_AGENT_ADAPTER_PATH;
-  env.PATH = [ADAPTER_BIN_DIR, extra, process.env.PATH].filter(Boolean).join(":");
+  env.PATH = [ADAPTER_BIN_DIR, extra, process.env.PATH]
+    .filter(Boolean)
+    .join(":");
 
   env.PI_ACP_PI_COMMAND =
     process.env.SANDBOX_AGENT_PI_COMMAND ?? join(ADAPTER_BIN_DIR, "pi");
@@ -148,6 +161,10 @@ export function buildDaemonEnv(
     env.CLAUDE_CONFIG_DIR = process.env.CLAUDE_CONFIG_DIR;
 
   if (process.env.HOME) env.HOME = process.env.HOME;
+
+  // Force-blank sandbox infra creds on every run (see KNOWN_SANDBOX_ENV_VARS doc): the underlying
+  // spawn inherits process.env first, so an absent key here would NOT stop the leak.
+  for (const key of KNOWN_SANDBOX_ENV_VARS) env[key] = "";
 
   // Managed run: clear (inherit no provider keys); the caller applies only the resolved
   // `plan.secrets`. Non-managed run: keep the sidecar's own keys so its login works.

--- a/services/runner/tests/unit/sandbox-agent-daemon.test.ts
+++ b/services/runner/tests/unit/sandbox-agent-daemon.test.ts
@@ -9,6 +9,7 @@ import assert from "node:assert/strict";
 import {
   ADAPTER_BIN_DIR,
   buildDaemonEnv,
+  KNOWN_SANDBOX_ENV_VARS,
   KNOWN_PROVIDER_ENV_VARS,
 } from "../../src/engines/sandbox_agent/daemon.ts";
 
@@ -66,7 +67,8 @@ describe("buildDaemonEnv", () => {
     assert.equal(env.ANTHROPIC_API_KEY, "anthropic");
     assert.equal(env.CLAUDE_CODE_OAUTH_TOKEN, "claude-oauth");
     assert.equal(env.COMPOSIO_API_KEY, undefined);
-    assert.equal(env.DAYTONA_API_KEY, undefined);
+    // Force-blanked (not merely absent) — see the F-INFRA-ENV test below for why.
+    assert.equal(env.DAYTONA_API_KEY, "");
   });
 
   it("clears the COMPLETE provider env inventory on a managed run (clear-then-apply, rule 5)", () => {
@@ -90,7 +92,11 @@ describe("buildDaemonEnv", () => {
     const env = buildDaemonEnv("pi", { clearProviderEnv: true });
 
     for (const key of KNOWN_PROVIDER_ENV_VARS) {
-      assert.equal(env[key], undefined, `${key} must not be inherited on a managed run`);
+      assert.equal(
+        env[key],
+        undefined,
+        `${key} must not be inherited on a managed run`,
+      );
     }
     // The cloud groups are part of the inventory, so they are cleared too.
     assert.equal(env.AWS_ACCESS_KEY_ID, undefined);
@@ -103,5 +109,23 @@ describe("buildDaemonEnv", () => {
     // Non-credential launch vars are still present.
     assert.equal(env.HOME, "/home/runner");
     assert.ok(env.PATH);
+  });
+
+  it("force-blanks infra creds (DAYTONA_API_KEY) on every run, managed or not (F-INFRA-ENV)", () => {
+    process.env.DAYTONA_API_KEY = "org-key-should-not-leak";
+
+    // The underlying sandbox-agent local() provider spawns with
+    // {...process.env, ...options.env} (inherit-then-apply), so an ABSENT key here would not
+    // stop the leak — only a forced override does. Assert both run shapes.
+    for (const opts of [{}, { clearProviderEnv: true }]) {
+      const env = buildDaemonEnv("pi", opts);
+      for (const key of KNOWN_SANDBOX_ENV_VARS) {
+        assert.equal(
+          env[key],
+          "",
+          `${key} must be force-blanked, not merely absent`,
+        );
+      }
+    }
   });
 });


### PR DESCRIPTION
## Context

Two resource leaks, both severable from the deferred session-liveness redesign.

First, when a session's runner crashed mid-turn, the orphan sweep flipped only the Postgres `session_streams` flags. It never touched the Redis alive lock that the SEND gate actually reads. The Redis lock has a one-hour TTL while the sweep runs at five minutes, so the user's next message after a crash got `SessionTurnInUse` for up to an hour, even though the row the UI reads already said the session had ended.

Second, the local agent daemon inherited the platform's `DAYTONA_API_KEY` from the parent process environment. A prompt-injected local run could read it and mint or destroy sandboxes on the platform's Daytona account. This was seen in a real environment dump.

## Changes

- **RUN-28**: the orphan sweep now calls `force_cancel_alive` and `clear_running` for each reaped orphan, right after the Postgres commit, so the Redis store the SEND gate reads agrees with the rows the sweep writes. This is additive. The heartbeat and acquire paths (the deferred liveness spine) are untouched.

- **F-INFRA-ENV**: the daemon env now force-blanks `KNOWN_SANDBOX_ENV_VARS` (`DAYTONA_API_KEY`, and `E2B_API_KEY` listed for when E2B lands) to `""` on every run. Omitting the key is not enough: the underlying `sandbox-agent` `local()` provider spawns with `{...process.env, ...options.env}`, so it inherits the parent env first. The blank value overrides the inherited one.

  Before: local daemon env contains the platform's real `DAYTONA_API_KEY`.
  After: `DAYTONA_API_KEY=""` in the daemon env, overriding the inherited value.

A `TODO` marks the pre-existing gap that this clear list is hand-synced across codebases with no parity test.

## Tests

- `test_orphan_sweep_clears_redis.py`: an orphan past threshold has its alive lock cleared after a sweep tick, and SEND no longer raises `SessionTurnInUse`.
- Extended `sandbox-agent-daemon.test.ts` asserts the daemon env force-blanks the sandbox keys.
- API `sessions/` unit suite and the full runner suite pass; `tsc --noEmit` clean.
