### PR TITLE
feat(api,frontend): build kit served as the __ag__build_kit static workflow

### DIFF
--- a/api/oss/src/apis/fastapi/applications/overlay.py
+++ b/api/oss/src/apis/fastapi/applications/overlay.py
@@ -1,109 +1,12 @@
 """Read-only overlays attached to application inspect/fetch responses."""
 
-from typing import Any, Dict, List, Optional
+from typing import Any, Dict
 
-from agenta.sdk.agents.adapters.agenta_builtins import (
-    AGENTA_FORCED_TOOLS,
-    BUILD_AN_AGENT_SLUG,
-)
+from oss.src.core.workflows import build_kit as _build_kit
 
-from oss.src.core.workflows.static_catalog import StaticWorkflowCatalog
-
-# Cut ops stay catalog opt-ins.
-DEFAULT_BUILD_KIT_OPS: tuple[str, ...] = (
-    "discover_tools",
-    "commit_revision",
-    "annotate_trace",
-    "query_spans",
-    "test_run",
-    "discover_triggers",
-    "create_schedule",
-    "create_subscription",
-    "list_schedules",
-    "list_deliveries",
-    "test_subscription",
-    "remove_schedule",
-    "remove_subscription",
-)
-
-
-def _workflow_embed(
-    slug: str,
-    *,
-    name: Optional[str],
-    selector_path: str,
-) -> Dict[str, Any]:
-    # The selector is load-bearing: without it the embed resolves to the whole revision.data
-    # (``{uri, parameters: {skill|tool: ...}}``), which neither the SDK skill parser nor the tool
-    # coercer accepts. ``parameters.skill`` / ``parameters.tool`` extracts the flat inline value
-    # the agent template expects (see test_skill_template_catalog canonical embed shape).
-    embed: Dict[str, Any] = {
-        "@ag.embed": {
-            "@ag.references": {"workflow": {"slug": slug}},
-            "@ag.selector": {"path": selector_path},
-        }
-    }
-    # The display name rides alongside the embed so the playground shows the workflow's name, not
-    # the raw ``__ag__*`` slug. Resolution replaces the whole entry, so this sibling is discarded
-    # before the tool/skill parser ever sees it.
-    if name:
-        embed["name"] = name
-    return embed
-
-
-def _reserved_static_tool_embeds(
-    catalog: StaticWorkflowCatalog,
-) -> List[Dict[str, Any]]:
-    """Tool embeds for the reserved static workflows that are tools (not skills).
-
-    Only confirmed non-skill static workflows with a resolvable revision are included; a missing
-    revision or missing flags is skipped so an invalid tool embed can't leak into the playground.
-    """
-    embeds: List[Dict[str, Any]] = []
-    for slug in catalog.list_slugs():
-        revision = catalog.retrieve_revision(slug=slug)
-        if not revision or not revision.flags or revision.flags.is_skill:
-            continue
-        embeds.append(
-            _workflow_embed(
-                slug,
-                name=revision.name,
-                selector_path="parameters.tool",
-            )
-        )
-    return embeds
+DEFAULT_BUILD_KIT_OPS = _build_kit.DEFAULT_BUILD_KIT_OPS
 
 
 def build_agent_template_overlay() -> Dict[str, Any]:
     """Build the playground-only agent-template overlay from platform-owned sources."""
-
-    catalog = StaticWorkflowCatalog()
-
-    skills: List[Dict[str, Any]] = []
-    authoring_skill = catalog.retrieve_revision(slug=BUILD_AN_AGENT_SLUG)
-    if authoring_skill:
-        skills.append(
-            _workflow_embed(
-                BUILD_AN_AGENT_SLUG,
-                name=authoring_skill.name,
-                selector_path="parameters.skill",
-            )
-        )
-
-    return {
-        "tools": [
-            # Harness builtins must be granted by selection: any custom tool on the wire
-            # switches the runner's Pi builtin gating from "Pi defaults" to "granted only",
-            # and without `read` the skill below is announced but unloadable.
-            *[{"type": "builtin", "name": name} for name in AGENTA_FORCED_TOOLS],
-            *[{"type": "platform", "op": op_name} for op_name in DEFAULT_BUILD_KIT_OPS],
-            *_reserved_static_tool_embeds(catalog),
-        ],
-        "skills": skills,
-        "sandbox": {
-            "permissions": {
-                "write_files": "allow",
-                "execute_code": "allow",
-            }
-        },
-    }
+    return _build_kit.build_agent_template_overlay()

--- a/api/oss/src/apis/fastapi/workflows/exceptions.py
+++ b/api/oss/src/apis/fastapi/workflows/exceptions.py
@@ -9,6 +9,7 @@ from functools import wraps
 
 from fastapi import HTTPException
 
+from oss.src.core.embeds.exceptions import NonEmbeddableWorkflowReferenceError
 from oss.src.core.workflows.types import StaticWorkflowSlug
 
 
@@ -16,6 +17,14 @@ class StaticWorkflowSlugException(HTTPException):
     def __init__(
         self,
         message: str = "The slug prefix '__ag__' is reserved for static workflows.",
+    ):
+        super().__init__(status_code=400, detail=message)
+
+
+class NonEmbeddableWorkflowReferenceException(HTTPException):
+    def __init__(
+        self,
+        message: str = "This static workflow cannot be embedded.",
     ):
         super().__init__(status_code=400, detail=message)
 
@@ -28,6 +37,8 @@ def handle_workflow_exceptions():
                 return await func(*args, **kwargs)
             except StaticWorkflowSlug as e:
                 raise StaticWorkflowSlugException(message=e.message) from e
+            except NonEmbeddableWorkflowReferenceError as e:
+                raise NonEmbeddableWorkflowReferenceException(message=str(e)) from e
 
         return wrapper
 

--- a/api/oss/src/apis/fastapi/workflows/router.py
+++ b/api/oss/src/apis/fastapi/workflows/router.py
@@ -1766,6 +1766,7 @@ class WorkflowsRouter:
 
     @intercept_exceptions()
     @suppress_exceptions(default=WorkflowRevisionResponse(), exclude=[HTTPException])
+    @handle_workflow_exceptions()
     @handle_git_exceptions()
     async def retrieve_workflow_revision(
         self,
@@ -1887,6 +1888,7 @@ class WorkflowsRouter:
         return workflow_revision_response
 
     @intercept_exceptions()
+    @handle_workflow_exceptions()
     @handle_git_exceptions()
     async def resolve_workflow_revision_endpoint(
         self,

--- a/api/oss/src/core/embeds/exceptions.py
+++ b/api/oss/src/core/embeds/exceptions.py
@@ -37,6 +37,14 @@ class UnsupportedReferenceTypeError(EmbedError):
         super().__init__(f"Unsupported reference type: {ref_type}")
 
 
+class NonEmbeddableWorkflowReferenceError(EmbedError):
+    def __init__(self, slug: str):
+        self.slug = slug
+        super().__init__(
+            f"Static workflow '{slug}' is retrievable but cannot be embedded."
+        )
+
+
 class MixedEntityTypesError(EmbedError):
     def __init__(self, categories: List[str]):
         self.categories = categories

--- a/api/oss/src/core/embeds/utils.py
+++ b/api/oss/src/core/embeds/utils.py
@@ -24,6 +24,7 @@ from oss.src.core.embeds.exceptions import (
     MaxDepthExceededError,
     MaxEmbedsExceededError,
     MixedEntityTypesError,
+    NonEmbeddableWorkflowReferenceError,
     PathExtractionError,
     EmbedNotFoundError,
 )
@@ -274,6 +275,17 @@ def create_universal_resolver(
         revision_ref: Optional[Reference] = parsed.get("revision")
         artifact_ref: Optional[Reference] = parsed.get("artifact")
 
+        def _reject_non_embeddable_static_workflow(entity: Any) -> None:
+            catalog = getattr(workflows_service, "static_catalog", None)
+            if not catalog or not entity:
+                return
+            slug = getattr(entity, "slug", None) or getattr(
+                entity, "workflow_slug", None
+            )
+            entity_id = getattr(entity, "id", None)
+            if not catalog.is_embeddable(id=entity_id, slug=slug):
+                raise NonEmbeddableWorkflowReferenceError(slug or str(entity_id))
+
         # Route to appropriate service
         if category == "workflow":
             if not workflows_service:
@@ -298,6 +310,7 @@ def create_universal_resolver(
                     raise EmbedNotFoundError(
                         f"Workflow revision not found: {revision_ref}"
                     )
+                _reject_non_embeddable_static_workflow(entity)
                 return entity.model_dump(mode="json")
 
             elif deepest_level == "variant":
@@ -310,6 +323,7 @@ def create_universal_resolver(
                     raise EmbedNotFoundError(
                         f"Workflow revision not found for variant: {variant_ref}"
                     )
+                _reject_non_embeddable_static_workflow(entity)
                 return entity.model_dump(mode="json")
 
             elif deepest_level == "artifact":
@@ -322,6 +336,7 @@ def create_universal_resolver(
                     raise EmbedNotFoundError(
                         f"Workflow revision not found for workflow: {artifact_ref}"
                     )
+                _reject_non_embeddable_static_workflow(entity)
                 return entity.model_dump(mode="json")
 
             else:

--- a/api/oss/src/core/workflows/build_kit.py
+++ b/api/oss/src/core/workflows/build_kit.py
@@ -1,0 +1,94 @@
+"""Playground build-kit content served through the static workflow catalogue."""
+
+from typing import Any, Dict, List, Optional
+
+from agenta.sdk.agents.adapters.agenta_builtins import (
+    AGENTA_FORCED_TOOLS,
+    BUILD_AN_AGENT_SKILL,
+    BUILD_AN_AGENT_SLUG,
+)
+from agenta.sdk.agents.platform.workflow import (
+    REQUEST_CONNECTION_WORKFLOW_SLUG,
+)
+
+BUILD_KIT_WORKFLOW_SLUG = "__ag__build_kit"
+BUILD_KIT_WORKFLOW_NAME = "Playground build kit"
+BUILD_KIT_WORKFLOW_DESCRIPTION = (
+    "Playground-only agent build kit for authoring agents. It is retrievable as a "
+    "static workflow but cannot be embedded or committed into another workflow."
+)
+AGENTA_BUILTIN_AGENT_URI = "agenta:builtin:agent:v0"
+
+REQUEST_CONNECTION_WORKFLOW_NAME = "Request connection"
+
+# Cut ops stay catalog opt-ins.
+DEFAULT_BUILD_KIT_OPS: tuple[str, ...] = (
+    "discover_tools",
+    "commit_revision",
+    "annotate_trace",
+    "query_spans",
+    "test_run",
+    "discover_triggers",
+    "create_schedule",
+    "create_subscription",
+    "list_schedules",
+    "list_deliveries",
+    "test_subscription",
+    "remove_schedule",
+    "remove_subscription",
+)
+
+_STATIC_TOOL_EMBED_SLUGS = (REQUEST_CONNECTION_WORKFLOW_SLUG,)
+
+
+def _workflow_embed(
+    slug: str,
+    *,
+    name: Optional[str],
+    selector_path: str,
+) -> Dict[str, Any]:
+    # The selector is load-bearing: without it the embed resolves to the whole revision.data.
+    embed: Dict[str, Any] = {
+        "@ag.embed": {
+            "@ag.references": {"workflow": {"slug": slug}},
+            "@ag.selector": {"path": selector_path},
+        }
+    }
+    if name:
+        embed["name"] = name
+    return embed
+
+
+def _reserved_static_tool_embeds() -> List[Dict[str, Any]]:
+    return [
+        _workflow_embed(
+            slug,
+            name=REQUEST_CONNECTION_WORKFLOW_NAME,
+            selector_path="parameters.tool",
+        )
+        for slug in _STATIC_TOOL_EMBED_SLUGS
+    ]
+
+
+def build_agent_template_overlay() -> Dict[str, Any]:
+    """Build the playground-only agent-template overlay from platform-owned sources."""
+    return {
+        "tools": [
+            *[{"type": "builtin", "name": name} for name in AGENTA_FORCED_TOOLS],
+            *[{"type": "platform", "op": op_name} for op_name in DEFAULT_BUILD_KIT_OPS],
+            *_reserved_static_tool_embeds(),
+        ],
+        "skills": [
+            _workflow_embed(
+                BUILD_AN_AGENT_SLUG,
+                name=BUILD_AN_AGENT_SKILL.name,
+                selector_path="parameters.skill",
+            )
+        ],
+        "sandbox": {
+            "permissions": {
+                "write_files": "allow",
+                "execute_code": "allow",
+            }
+        },
+    }

--- a/api/oss/src/core/workflows/interfaces.py
+++ b/api/oss/src/core/workflows/interfaces.py
@@ -17,9 +17,8 @@ class StaticWorkflowProvider(ABC):
     """A read-only provider of synthetic, code-defined workflow revisions.
 
     Static workflows live under a reserved slug namespace and are served from code, never the
-    database. The provider answers two questions for ``WorkflowsService``: whether a slug belongs
-    to the reserved namespace (so the service short-circuits before any DB lookup and so user
-    create/edit/commit can be rejected), and what synthetic revision a reserved slug resolves to.
+    database. The provider answers whether a reference belongs to the reserved namespace, whether
+    it may be embedded, and what synthetic revision it resolves to.
     """
 
     @abstractmethod
@@ -36,6 +35,15 @@ class StaticWorkflowProvider(ABC):
         Lets an id-only reference short-circuit to the catalogue (deploy emits synthetic ids), so
         a static id never DB-queries.
         """
+
+    @abstractmethod
+    def is_embeddable(
+        self,
+        *,
+        id: Optional[UUID] = None,
+        slug: Optional[str] = None,
+    ) -> bool:
+        """Whether a static workflow reference may be used inside an embed."""
 
     @abstractmethod
     def retrieve_revision(

--- a/api/oss/src/core/workflows/service.py
+++ b/api/oss/src/core/workflows/service.py
@@ -93,6 +93,7 @@ from oss.src.core.git.types import (
     needs_default_variant_resolution,
     validate_retrieve_refs_consistent,
 )
+from oss.src.core.workflows.build_kit import BUILD_KIT_WORKFLOW_SLUG
 from oss.src.core.workflows.interfaces import StaticWorkflowProvider
 from oss.src.core.workflows.dtos import WorkflowServiceDetachedResponse
 from oss.src.core.workflows.types import (
@@ -106,6 +107,12 @@ from oss.src.core.workflows.types import (
 from oss.src.core.embeds.dtos import (
     ErrorPolicy,
     ResolutionInfo,
+)
+from oss.src.core.embeds.exceptions import NonEmbeddableWorkflowReferenceError
+from oss.src.core.embeds.utils import (
+    find_object_embeds,
+    find_snippet_embeds,
+    find_string_embeds,
 )
 
 from oss.src.middlewares.auth import sign_secret_token
@@ -1279,6 +1286,9 @@ class WorkflowsService:
         workflow_revision_create: WorkflowRevisionCreate,
     ) -> Optional[WorkflowRevision]:
         self._reject_static_slug(workflow_revision_create.slug)
+        self._reject_non_embeddable_workflow_embeds(
+            getattr(workflow_revision_create, "data", None)
+        )
 
         _revision_create = RevisionCreate(
             **workflow_revision_create.model_dump(
@@ -1313,6 +1323,48 @@ class WorkflowsService:
     @staticmethod
     def _ref_is_static(ref: Optional[Reference]) -> bool:
         return ref is not None and is_static_workflow_slug(ref.slug)
+
+    @staticmethod
+    def _reference_category(entity_type: str) -> str:
+        return entity_type.split("_", 1)[0] if "_" in entity_type else entity_type
+
+    def _non_embeddable_static_workflow_slug(
+        self,
+        ref: Reference,
+    ) -> Optional[str]:
+        if ref.slug == BUILD_KIT_WORKFLOW_SLUG:
+            return BUILD_KIT_WORKFLOW_SLUG
+
+        if not self.static_catalog:
+            return None
+
+        if ref.slug and not self.static_catalog.is_embeddable(slug=ref.slug):
+            return ref.slug
+        if ref.id and not self.static_catalog.is_embeddable(id=ref.id):
+            revision = self.static_catalog.retrieve_revision(id=ref.id)
+            return revision.slug if revision and revision.slug else str(ref.id)
+        return None
+
+    def _reject_non_embeddable_workflow_embeds(
+        self,
+        data: Optional[WorkflowRevisionData],
+    ) -> None:
+        if not data:
+            return
+
+        configuration = data.model_dump(mode="json", exclude_none=True)
+        embeds = (
+            *find_object_embeds(configuration),
+            *find_string_embeds(configuration),
+            *find_snippet_embeds(configuration),
+        )
+        for embed in embeds:
+            for entity_type, ref in embed.references.items():
+                if self._reference_category(entity_type) != "workflow":
+                    continue
+                slug = self._non_embeddable_static_workflow_slug(ref)
+                if slug:
+                    raise NonEmbeddableWorkflowReferenceError(slug)
 
     def _ref_has_static_id(self, ref: Optional[Reference]) -> bool:
         return (
@@ -1807,6 +1859,8 @@ class WorkflowsService:
                     data = data.model_copy(
                         update={"url": env.agenta.services_url.rstrip("/") + path}
                     )
+
+        self._reject_non_embeddable_workflow_embeds(data)
 
         if data and data.uri:
             interface = retrieve_interface(data.uri)

--- a/api/oss/src/core/workflows/static_catalog.py
+++ b/api/oss/src/core/workflows/static_catalog.py
@@ -1,7 +1,7 @@
 """The static workflow catalogue: code-defined, read-only static workflows.
 
-Agenta ships its own managed workflows (skills today, extensible to other static workflow kinds
-later) to every project without per-project seeding and without a migration. They are served from
+Agenta ships its own managed workflows to every project without per-project seeding or a
+migration. They are served from
 this catalogue under a reserved ``__ag__*`` slug namespace, never the database, and carry
 ``flags.is_static=True`` (slug-derived) so clients and the frontend treat them as read-only.
 
@@ -14,7 +14,7 @@ Trust comes from the platform authoring the content in code: the reserved namesp
 user cannot author or shadow it, and resolution never falls through to Postgres.
 """
 
-from typing import Any, Dict, List, Optional, Tuple
+from typing import Any, Callable, Dict, List, Optional, Tuple, Union
 from uuid import UUID, uuid5, NAMESPACE_DNS
 
 from agenta.sdk.agents.adapters.agenta_builtins import (
@@ -34,6 +34,14 @@ from agenta.sdk.engines.running.utils import (
     normalize_snippet_data,
 )
 
+from oss.src.core.workflows.build_kit import (
+    AGENTA_BUILTIN_AGENT_URI,
+    BUILD_KIT_WORKFLOW_DESCRIPTION,
+    BUILD_KIT_WORKFLOW_NAME,
+    BUILD_KIT_WORKFLOW_SLUG,
+    REQUEST_CONNECTION_WORKFLOW_NAME,
+    build_agent_template_overlay,
+)
 from oss.src.core.workflows.dtos import (
     WorkflowRevision,
     WorkflowRevisionData,
@@ -47,6 +55,7 @@ from oss.src.core.workflows.types import (
 
 
 __all__ = [
+    "BUILD_KIT_WORKFLOW_SLUG",
     "STATIC_SLUG_PREFIX",
     "StaticWorkflowCatalog",
 ]
@@ -55,6 +64,7 @@ __all__ = [
 # sub-namespaced under "catalog". Stable across instances/restarts so a static workflow keeps the
 # same artifact / variant / revision ids everywhere. Changing it re-keys every static workflow.
 _STATIC_NAMESPACE_UUID = uuid5(uuid5(NAMESPACE_DNS, "agenta"), "catalog")
+WorkflowRevisionDeclaration = Union[WorkflowRevision, Callable[[], WorkflowRevision]]
 
 
 # ---------------------------------------------------------------------------
@@ -65,8 +75,7 @@ _STATIC_NAMESPACE_UUID = uuid5(uuid5(NAMESPACE_DNS, "agenta"), "catalog")
 # A version payload is a FULL WorkflowRevision carrying the declared content (name, description,
 # data); the catalogue stamps the structural fields (ids / slug / version) and the inferred flags
 # on resolution. The catalogue is a FULL workflow catalogue, not skill-specific; what a given entry
-# *is* falls out of its ``data.uri`` (the only static workflow today happens to be a skill, hence a
-# snippet carrying uri + parameters).
+# *is* falls out of its ``data.uri`` and explicit catalogue metadata.
 
 
 def _skill_revision(skill_template: SkillTemplate) -> WorkflowRevision:
@@ -86,7 +95,7 @@ def _skill_revision(skill_template: SkillTemplate) -> WorkflowRevision:
 
 def _client_tool_revision() -> WorkflowRevision:
     return WorkflowRevision(
-        name="Request connection",
+        name=REQUEST_CONNECTION_WORKFLOW_NAME,
         description="Ask the user to connect an external account.",
         data=WorkflowRevisionData(
             uri="client:tool:request_connection:v0",
@@ -125,24 +134,49 @@ def _client_tool_revision() -> WorkflowRevision:
     )
 
 
-# Each entry: a reserved slug -> {latest: <ver>, versions: {<ver>: WorkflowRevision}}.
+def _build_kit_revision() -> WorkflowRevision:
+    return WorkflowRevision(
+        name=BUILD_KIT_WORKFLOW_NAME,
+        description=BUILD_KIT_WORKFLOW_DESCRIPTION,
+        data=WorkflowRevisionData(
+            uri=AGENTA_BUILTIN_AGENT_URI,
+            parameters={"agent": build_agent_template_overlay()},
+        ),
+    )
+
+
+# Each entry: a reserved slug -> {latest: <ver>, versions: {<ver>: WorkflowRevision factory}}.
 _STATIC_WORKFLOWS: Dict[str, Dict[str, Any]] = {
     GETTING_STARTED_WITH_AGENTA_SLUG: {
+        "kind": "skill",
+        "embeddable": True,
         "latest": "v1",
         "versions": {
             "v1": _skill_revision(GETTING_STARTED_WITH_AGENTA_SKILL),
         },
     },
     REQUEST_CONNECTION_WORKFLOW_SLUG: {
+        "kind": "tool",
+        "embeddable": True,
         "latest": "v1",
         "versions": {
             "v1": _client_tool_revision(),
         },
     },
     BUILD_AN_AGENT_SLUG: {
+        "kind": "skill",
+        "embeddable": True,
         "latest": "v1",
         "versions": {
             "v1": _skill_revision(BUILD_AN_AGENT_SKILL),
+        },
+    },
+    BUILD_KIT_WORKFLOW_SLUG: {
+        "kind": "agent_config",
+        "embeddable": False,
+        "latest": "v1",
+        "versions": {
+            "v1": _build_kit_revision,
         },
     },
 }
@@ -211,6 +245,8 @@ class StaticWorkflowCatalog(StaticWorkflowProvider):
                     f"{sorted(versions)}."
                 )
             for version, revision in versions.items():
+                if callable(revision):
+                    continue
                 if (
                     not isinstance(revision, WorkflowRevision)
                     or not revision.data
@@ -233,6 +269,26 @@ class StaticWorkflowCatalog(StaticWorkflowProvider):
 
     def is_static_id(self, entity_id: Optional[UUID]) -> bool:
         return entity_id is not None and entity_id in self._index_by_id
+
+    def is_embeddable(
+        self,
+        *,
+        id: Optional[UUID] = None,
+        slug: Optional[str] = None,
+    ) -> bool:
+        resolved_slug = slug
+        if id is not None:
+            match = self._index_by_id.get(id)
+            if match is not None:
+                resolved_slug = match[0]
+
+        if resolved_slug is None:
+            return True
+
+        entry = self._catalog.get(resolved_slug)
+        if not entry:
+            return True
+        return bool(entry.get("embeddable", True))
 
     def retrieve_revision(
         self,
@@ -271,13 +327,20 @@ class StaticWorkflowCatalog(StaticWorkflowProvider):
             declared=versions[resolved_version],
         )
 
+    @staticmethod
+    def _declared_revision(
+        declared: WorkflowRevisionDeclaration,
+    ) -> WorkflowRevision:
+        return declared() if callable(declared) else declared
+
     def _build_revision(
         self,
         *,
         slug: str,
         version: str,
-        declared: WorkflowRevision,
+        declared: WorkflowRevisionDeclaration,
     ) -> WorkflowRevision:
+        declared = self._declared_revision(declared)
         # A snippet (skill) keeps only uri + parameters; for runnable static workflows this is a
         # no-op. Flags are inferred: is_skill from the uri, is_static from the (reserved) slug.
         data = normalize_snippet_data(declared.data)

--- a/api/oss/tests/pytest/unit/applications/test_build_kit_overlay.py
+++ b/api/oss/tests/pytest/unit/applications/test_build_kit_overlay.py
@@ -9,6 +9,7 @@ from agenta.sdk.agents.adapters.agenta_builtins import (
     BUILD_AN_AGENT_SLUG,
     GETTING_STARTED_WITH_AGENTA_SLUG,
 )
+from agenta.sdk.agents.platform.workflow import REQUEST_CONNECTION_WORKFLOW_SLUG
 from agenta.sdk.agents.dtos import AgentTemplate
 from agenta.sdk.agents.platform import AgentaPlatformToolResolver, PlatformConnection
 from agenta.sdk.agents.platform.op_catalog import PLATFORM_OPS
@@ -18,6 +19,10 @@ from oss.src.apis.fastapi.applications import router as applications_router_modu
 from oss.src.apis.fastapi.applications.overlay import (
     DEFAULT_BUILD_KIT_OPS,
     build_agent_template_overlay,
+)
+from oss.src.core.workflows.build_kit import (
+    BUILD_KIT_WORKFLOW_SLUG,
+    build_agent_template_overlay as build_core_agent_template_overlay,
 )
 from oss.src.apis.fastapi.applications.router import SimpleApplicationsRouter
 from oss.src.core.applications.dtos import SimpleApplication
@@ -70,28 +75,24 @@ def test_agent_template_overlay_tools_list_is_pinned_with_builtin_grants_first()
     """
     overlay = build_agent_template_overlay()
 
-    catalog = StaticWorkflowCatalog()
-    expected_static_tool_embeds = []
-    for slug in catalog.list_slugs():
-        revision = catalog.retrieve_revision(slug=slug)
-        if not revision or not revision.flags or revision.flags.is_skill:
-            continue
-        expected_static_tool_embeds.append(
-            {
-                "@ag.embed": {
-                    "@ag.references": {"workflow": {"slug": slug}},
-                    "@ag.selector": {"path": "parameters.tool"},
-                },
-                "name": revision.name,
-            }
-        )
+    request_connection = StaticWorkflowCatalog().retrieve_revision(
+        slug=REQUEST_CONNECTION_WORKFLOW_SLUG
+    )
 
     assert AGENTA_FORCED_TOOLS == ["read", "bash"]
     assert overlay["tools"] == [
         {"type": "builtin", "name": "read"},
         {"type": "builtin", "name": "bash"},
         *[{"type": "platform", "op": op_name} for op_name in DEFAULT_BUILD_KIT_OPS],
-        *expected_static_tool_embeds,
+        {
+            "@ag.embed": {
+                "@ag.references": {
+                    "workflow": {"slug": REQUEST_CONNECTION_WORKFLOW_SLUG}
+                },
+                "@ag.selector": {"path": "parameters.tool"},
+            },
+            "name": request_connection.name,
+        },
     ]
 
 
@@ -130,7 +131,11 @@ def test_agent_template_overlay_contains_platform_ops_playbook_skill_and_permiss
     }
 
 
-def test_agent_template_overlay_includes_reserved_static_workflow_tool_embeds():
+def test_api_overlay_adapter_matches_core_build_kit_builder():
+    assert build_agent_template_overlay() == build_core_agent_template_overlay()
+
+
+def test_agent_template_overlay_includes_only_allowlisted_static_tool_embeds():
     overlay = build_agent_template_overlay()
     tool_embeds = [
         tool
@@ -153,13 +158,20 @@ def test_agent_template_overlay_includes_reserved_static_workflow_tool_embeds():
         revision = catalog.retrieve_revision(slug=_embed_slug(tool))
         assert tool.get("name") == revision.name
 
-    expected_slugs = set()
-    for slug in catalog.list_slugs():
-        revision = catalog.retrieve_revision(slug=slug)
-        if revision and revision.flags and not revision.flags.is_skill:
-            expected_slugs.add(slug)
+    assert tool_embed_slugs == {REQUEST_CONNECTION_WORKFLOW_SLUG}
 
-    assert tool_embed_slugs == expected_slugs
+
+def test_agent_template_overlay_does_not_embed_build_kit():
+    overlay = build_agent_template_overlay()
+
+    embedded_slugs = {
+        _embed_slug(entry)
+        for section in ("tools", "skills")
+        for entry in overlay[section]
+        if isinstance(entry, dict) and "@ag.embed" in entry
+    }
+
+    assert BUILD_KIT_WORKFLOW_SLUG not in embedded_slugs
 
 
 @pytest.mark.asyncio

--- a/api/oss/tests/pytest/unit/workflows/test_static_catalog.py
+++ b/api/oss/tests/pytest/unit/workflows/test_static_catalog.py
@@ -15,6 +15,7 @@ from uuid import uuid4
 
 import pytest
 
+from oss.src.core.embeds.exceptions import NonEmbeddableWorkflowReferenceError
 from oss.src.core.embeds.service import EmbedsService
 from oss.src.core.shared.dtos import Reference
 from oss.src.core.workflows.dtos import (
@@ -26,9 +27,17 @@ from oss.src.core.workflows.dtos import (
     WorkflowArtifactQueryFlags,
     WorkflowRevision,
     WorkflowRevisionCreate,
+    WorkflowRevisionCommit,
     WorkflowRevisionData,
     WorkflowVariantCreate,
     WorkflowVariantFork,
+)
+from oss.src.core.workflows.build_kit import (
+    BUILD_KIT_WORKFLOW_SLUG,
+    AGENTA_BUILTIN_AGENT_URI,
+    BUILD_KIT_WORKFLOW_DESCRIPTION,
+    BUILD_KIT_WORKFLOW_NAME,
+    build_agent_template_overlay,
 )
 from oss.src.core.workflows.static_catalog import (
     STATIC_SLUG_PREFIX,
@@ -128,6 +137,31 @@ def test_default_static_skill_catalog_replaces_old_authoring_skills():
     assert skill["body"].startswith("# Build an Agenta agent")
     assert "test_run" in skill["body"]
     assert "query_spans" in skill["body"]
+
+
+def test_build_kit_static_workflow_returns_agent_config_equivalent_to_overlay():
+    catalog = StaticWorkflowCatalog()
+
+    revision = catalog.retrieve_revision(slug=BUILD_KIT_WORKFLOW_SLUG)
+
+    assert revision is not None
+    assert revision.name == BUILD_KIT_WORKFLOW_NAME
+    assert revision.description == BUILD_KIT_WORKFLOW_DESCRIPTION
+    assert revision.slug == BUILD_KIT_WORKFLOW_SLUG
+    assert revision.version == "v1"
+    assert revision.data.uri == AGENTA_BUILTIN_AGENT_URI
+    assert revision.data.parameters["agent"] == build_agent_template_overlay()
+    assert revision.flags.is_static is True
+    assert revision.flags.is_agent is True
+    assert revision.flags.is_managed is True
+    assert revision.flags.is_skill is False
+    assert revision.flags.has_url is True
+    assert catalog.is_embeddable(slug=BUILD_KIT_WORKFLOW_SLUG) is False
+    assert catalog.is_embeddable(id=revision.id) is False
+    assert (
+        StaticWorkflowCatalog().retrieve_revision(slug=BUILD_KIT_WORKFLOW_SLUG).id
+        == revision.id
+    )
 
 
 def test_artifact_level_lookup_resolves_current():
@@ -325,6 +359,122 @@ async def test_request_connection_tool_embed_resolves_to_client_tool_config_with
     assert resolution_info.embeds_resolved == 1
     workflows_dao.fetch_revision.assert_not_awaited()
     workflows_dao.fetch_artifact.assert_not_awaited()
+
+
+@pytest.mark.asyncio
+async def test_fetch_build_kit_static_revision_by_slug_returns_agent_config_without_db():
+    workflows_dao = AsyncMock()
+    service = WorkflowsService(
+        workflows_dao=workflows_dao,
+        static_catalog=StaticWorkflowCatalog(),
+    )
+
+    (
+        revision,
+        resolution_info,
+        retrieval_info,
+    ) = await service.retrieve_workflow_revision(
+        project_id=uuid4(),
+        workflow_ref=Reference(slug=BUILD_KIT_WORKFLOW_SLUG),
+    )
+
+    assert revision is not None
+    assert revision.slug == BUILD_KIT_WORKFLOW_SLUG
+    assert revision.data.parameters["agent"] == build_agent_template_overlay()
+    assert revision.flags.is_static is True
+    assert revision.flags.is_agent is True
+    assert resolution_info is None
+    assert retrieval_info is not None
+    workflows_dao.fetch_revision.assert_not_awaited()
+    workflows_dao.fetch_artifact.assert_not_awaited()
+
+
+@pytest.mark.asyncio
+async def test_build_kit_embed_is_rejected_during_resolution():
+    workflows_dao = AsyncMock()
+    workflows_service = WorkflowsService(
+        workflows_dao=workflows_dao,
+        static_catalog=StaticWorkflowCatalog(),
+    )
+    workflows_service.embeds_service = EmbedsService(
+        workflows_service=workflows_service
+    )
+
+    revision = WorkflowRevision(
+        id=uuid4(),
+        workflow_id=uuid4(),
+        workflow_variant_id=uuid4(),
+        slug="agent-default-config",
+        data=WorkflowRevisionData(
+            parameters={
+                "agent": {
+                    "skills": [
+                        {
+                            "@ag.embed": {
+                                "@ag.references": {
+                                    "workflow": {"slug": BUILD_KIT_WORKFLOW_SLUG}
+                                },
+                                "@ag.selector": {"path": "parameters.agent"},
+                            }
+                        }
+                    ]
+                }
+            }
+        ),
+    )
+
+    with pytest.raises(NonEmbeddableWorkflowReferenceError) as exc_info:
+        await workflows_service.resolve_workflow_revision(
+            project_id=uuid4(),
+            workflow_revision=revision,
+        )
+
+    assert exc_info.value.slug == BUILD_KIT_WORKFLOW_SLUG
+    workflows_dao.fetch_revision.assert_not_awaited()
+    workflows_dao.fetch_artifact.assert_not_awaited()
+
+
+@pytest.mark.asyncio
+async def test_commit_rejects_build_kit_embed_before_persisting():
+    workflows_dao = AsyncMock()
+    service = WorkflowsService(
+        workflows_dao=workflows_dao,
+        static_catalog=StaticWorkflowCatalog(),
+    )
+
+    with pytest.raises(NonEmbeddableWorkflowReferenceError) as exc_info:
+        await service.commit_workflow_revision(
+            project_id=uuid4(),
+            user_id=uuid4(),
+            workflow_revision_commit=WorkflowRevisionCommit(
+                workflow_id=uuid4(),
+                workflow_variant_id=uuid4(),
+                slug="agent-config",
+                data=WorkflowRevisionData(
+                    uri=AGENTA_BUILTIN_AGENT_URI,
+                    parameters={
+                        "agent": {
+                            "tools": [
+                                {
+                                    "@ag.embed": {
+                                        "@ag.references": {
+                                            "workflow": {
+                                                "slug": BUILD_KIT_WORKFLOW_SLUG
+                                            }
+                                        },
+                                        "@ag.selector": {"path": "parameters.agent"},
+                                    }
+                                }
+                            ]
+                        }
+                    },
+                ),
+            ),
+            emit=False,
+        )
+
+    assert exc_info.value.slug == BUILD_KIT_WORKFLOW_SLUG
+    workflows_dao.commit_revision.assert_not_awaited()
 
 
 @pytest.mark.asyncio

--- a/docs/design/agent-workflows/documentation/tools.md
+++ b/docs/design/agent-workflows/documentation/tools.md
@@ -439,8 +439,13 @@ Each catalog entry (`PlatformOp`, a typed model validated at import) maps an `op
 
 Each op has a stable reserved id, `tools.agenta.<op>`. The catalog holds every exposable op
 (discovery, workflow reads/writes, tracing reads, and the trigger/schedule/subscription
-lifecycle). The playground **build-kit overlay** embeds an explicit default subset,
-`DEFAULT_BUILD_KIT_OPS` in `api/oss/src/apis/fastapi/applications/overlay.py`: `discover_tools`,
+lifecycle). The playground **build kit** is itself served as the reserved static workflow
+`__ag__build_kit` (a constant agent config in `api/oss/src/core/workflows/static_catalog.py`;
+content builder `api/oss/src/core/workflows/build_kit.py`) — the frontend resolves it by slug
+once per project and merges it as an overlay onto any agent-typed entity; it is retrievable
+but not embeddable/committable, and the legacy per-application `additional_context` rider
+remains one release as a fallback. It embeds an explicit default subset,
+`DEFAULT_BUILD_KIT_OPS` in `api/oss/src/core/workflows/build_kit.py`: `discover_tools`,
 `commit_revision`, `annotate_trace`, `query_spans`, `discover_triggers`, `create_schedule`,
 `create_subscription`, `list_schedules`, `list_deliveries`, `test_subscription`,
 `remove_schedule`, and `remove_subscription` (12 ops, plus the `request_connection` client

--- a/web/packages/agenta-entities/src/workflow/api/api.ts
+++ b/web/packages/agenta-entities/src/workflow/api/api.ts
@@ -14,6 +14,7 @@
  * - Create/Update: workflow + revision commit endpoints
  */
 
+import {getAgentaSdkClient} from "@agenta/sdk"
 import {getWorkflowsClient} from "@agenta/sdk/resources"
 import {getAgentaApiUrl, axios} from "@agenta/shared/api"
 import {dereferenceSchema, generateId} from "@agenta/shared/utils"
@@ -335,6 +336,44 @@ export async function retrieveWorkflowRevision({
         "[retrieveWorkflowRevision]",
     )
     return validated?.workflow_revision ?? null
+}
+
+// ============================================================================
+// AGENT BUILD-KIT OVERLAY (reserved static workflow)
+// ============================================================================
+
+export const AGENT_BUILD_KIT_WORKFLOW_SLUG = "__ag__build_kit"
+
+const agentBuildKitOverlaySchema = z
+    .object({
+        tools: z.array(z.unknown()).optional(),
+        skills: z.array(z.unknown()).optional(),
+        sandbox: z.record(z.string(), z.unknown()).optional(),
+    })
+    .passthrough()
+
+export type AgentBuildKitOverlay = z.infer<typeof agentBuildKitOverlaySchema>
+
+export async function fetchAgentBuildKitOverlay(
+    projectId: string,
+): Promise<AgentBuildKitOverlay | null> {
+    if (!projectId) return null
+
+    const revision = await retrieveWorkflowRevision({
+        projectId,
+        workflowRef: {slug: AGENT_BUILD_KIT_WORKFLOW_SLUG},
+    })
+    const overlay = revision?.data?.parameters?.agent
+    if (overlay == null) return null
+
+    const validated = safeParseWithLogging(
+        agentBuildKitOverlaySchema,
+        overlay,
+        "[fetchAgentBuildKitOverlay]",
+    )
+    if (!validated || Object.keys(validated).length === 0) return null
+
+    return validated
 }
 
 /**

--- a/web/packages/agenta-entities/src/workflow/api/index.ts
+++ b/web/packages/agenta-entities/src/workflow/api/index.ts
@@ -14,6 +14,10 @@ export {
     queryWorkflowRevisions,
     // Retrieve (single revision by ref — slug/version/id)
     retrieveWorkflowRevision,
+    // Agent build-kit overlay (reserved static workflow)
+    AGENT_BUILD_KIT_WORKFLOW_SLUG,
+    fetchAgentBuildKitOverlay,
+    type AgentBuildKitOverlay,
     // Fetch (single revision by ID)
     fetchWorkflowRevisionById,
     // Inspect (resolve full schema including inputs)

--- a/web/packages/agenta-entities/src/workflow/state/store.ts
+++ b/web/packages/agenta-entities/src/workflow/state/store.ts
@@ -28,11 +28,14 @@ import type {
     InterfaceSchemasResponse,
     AppOpenApiSchemas,
     SimpleApplicationFetchResponse,
+    AgentBuildKitOverlay,
 } from "../api"
 import {
+    AGENT_BUILD_KIT_WORKFLOW_SLUG,
     extractDefaultsFromSchema,
     fetchWorkflowRevisionsByIdsBatch,
     inspectWorkflow,
+    fetchAgentBuildKitOverlay,
     fetchSimpleApplication,
     fetchWorkflowAppOpenApiSchema,
     fetchAgTypeSchema,
@@ -1159,6 +1162,15 @@ export const workflowInspectAtomFamily = atomFamily((revisionId: string) =>
 
 export type AgentTemplate = Record<string, unknown>
 
+const AGENT_BUILTIN_URI_PREFIX = "agenta:builtin:agent"
+
+const isAgentBuiltinUri = (uri: unknown): boolean =>
+    typeof uri === "string" && uri.startsWith(AGENT_BUILTIN_URI_PREFIX)
+
+const isAgentTemplateOverlay = (
+    overlay: AgentBuildKitOverlay | AgentTemplate | null | undefined,
+): overlay is AgentTemplate => !!overlay && typeof overlay === "object" && !Array.isArray(overlay)
+
 /**
  * Fetch the simple-application envelope for one app id.
  *
@@ -1182,23 +1194,44 @@ export const simpleApplicationQueryAtomFamily = atomFamily((applicationId: strin
     }),
 )
 
+export const agentBuildKitOverlayAtom = atomWithQuery((get) => {
+    const projectId = get(workflowProjectIdAtom)
+    return {
+        queryKey: ["agentBuildKitOverlay", AGENT_BUILD_KIT_WORKFLOW_SLUG, projectId],
+        queryFn: async (): Promise<AgentBuildKitOverlay | null> => {
+            if (!projectId) return null
+            return fetchAgentBuildKitOverlay(projectId)
+        },
+        enabled: get(sessionAtom) && !!projectId,
+        staleTime: Infinity,
+        refetchOnWindowFocus: false,
+    }
+})
+
 export const workflowAgentTemplateOverlayAtomFamily = atomFamily((revisionId: string) =>
     atom<AgentTemplate | null>((get) => {
-        // The app id (workflow artifact id) the revision belongs to. Server data
-        // wins; fall back to the local base entity so a draft agent still resolves.
         const revisionData = get(workflowQueryAtomFamily(revisionId)).data ?? null
-        const applicationId =
-            revisionData?.workflow_id ??
-            get(workflowBaseEntityAtomFamily(revisionId))?.workflow_id ??
-            null
+        const baseEntity = get(workflowBaseEntityAtomFamily(revisionId))
+        const explicitIsAgent = revisionData?.flags?.is_agent ?? baseEntity?.flags?.is_agent
+        const targetUri = revisionData?.data?.uri ?? baseEntity?.data?.uri
+        const isAgent = explicitIsAgent ?? isAgentBuiltinUri(targetUri)
+        if (!isAgent || !get(sessionAtom)) return null
+
+        const slugQuery = get(agentBuildKitOverlayAtom)
+        if (isAgentTemplateOverlay(slugQuery.data)) {
+            return slugQuery.data
+        }
+
+        const applicationId = revisionData?.workflow_id ?? baseEntity?.workflow_id ?? null
         if (!applicationId) return null
+        const shouldUseFallback =
+            slugQuery.isError || (slugQuery.data === null && !slugQuery.isPending)
+        if (!shouldUseFallback) return null
 
         const appData = get(simpleApplicationQueryAtomFamily(applicationId)).data ?? null
         const overlay =
             appData?.additional_context?.playground_build_kit?.agent_template_overlay ?? null
-        return overlay && typeof overlay === "object" && !Array.isArray(overlay)
-            ? (overlay as AgentTemplate)
-            : null
+        return isAgentTemplateOverlay(overlay) ? overlay : null
     }),
 )
 

--- a/web/packages/agenta-entities/tests/unit/agent-build-kit-overlay-api.test.ts
+++ b/web/packages/agenta-entities/tests/unit/agent-build-kit-overlay-api.test.ts
@@ -1,0 +1,83 @@
+import {beforeEach, describe, expect, it, vi} from "vitest"
+
+const fernRetrieve = vi.fn()
+const fetchSimpleApplication = vi.fn()
+
+vi.mock("@agenta/sdk/resources", () => ({
+    getWorkflowsClient: () => ({
+        retrieveWorkflowRevision: fernRetrieve,
+    }),
+}))
+
+vi.mock("@agenta/sdk", () => ({
+    getAgentaSdkClient: () => ({
+        applications: {
+            fetchSimpleApplication,
+        },
+    }),
+}))
+
+import {AGENT_BUILD_KIT_WORKFLOW_SLUG, fetchAgentBuildKitOverlay} from "../../src/workflow/api/api"
+
+const OVERLAY = {
+    tools: [{op: "read_file", type: "platform"}],
+    skills: [{"@ag.embed": {workflow: {slug: "__ag__build_an_agent"}}}],
+    sandbox: {permissions: {write_files: "allow"}},
+}
+
+beforeEach(() => {
+    fernRetrieve.mockReset()
+    fetchSimpleApplication.mockReset()
+})
+
+describe("fetchAgentBuildKitOverlay", () => {
+    it("retrieves the reserved build-kit workflow by slug and returns parameters.agent", async () => {
+        fernRetrieve.mockResolvedValueOnce({
+            workflow_revision: {
+                id: "kit-rev-1",
+                data: {parameters: {agent: OVERLAY}},
+            },
+        })
+
+        const result = await fetchAgentBuildKitOverlay("proj-42")
+
+        expect(fernRetrieve).toHaveBeenCalledTimes(1)
+        const [body, opts] = fernRetrieve.mock.calls[0]
+        expect(body).toEqual({workflow_ref: {slug: AGENT_BUILD_KIT_WORKFLOW_SLUG}})
+        expect(opts).toEqual({queryParams: {project_id: "proj-42"}})
+        expect(result).toEqual(OVERLAY)
+    })
+
+    it("short-circuits without a project id", async () => {
+        const result = await fetchAgentBuildKitOverlay("")
+
+        expect(result).toBeNull()
+        expect(fernRetrieve).not.toHaveBeenCalled()
+    })
+
+    it("returns null when the revision carries no agent overlay", async () => {
+        fernRetrieve.mockResolvedValueOnce({
+            workflow_revision: {
+                id: "kit-rev-1",
+                data: {parameters: {}},
+            },
+        })
+
+        const result = await fetchAgentBuildKitOverlay("proj-1")
+
+        expect(result).toBeNull()
+    })
+
+    it("rejects a non-object overlay at the boundary", async () => {
+        fernRetrieve.mockResolvedValueOnce({
+            workflow_revision: {
+                id: "kit-rev-1",
+                data: {parameters: {agent: "nope"}},
+            },
+        })
+
+        const result = await fetchAgentBuildKitOverlay("proj-1")
+
+        expect(result).toBeNull()
+    })
+})

--- a/web/packages/agenta-entities/tests/unit/agent-build-kit-overlay-atom.test.ts
+++ b/web/packages/agenta-entities/tests/unit/agent-build-kit-overlay-atom.test.ts
@@ -1,0 +1,221 @@
+import {QueryClient} from "@tanstack/react-query"
+import {projectIdAtom, sessionAtom} from "@agenta/shared/state"
+import {createStore} from "jotai"
+import {queryClientAtom} from "jotai-tanstack-query"
+import {beforeEach, describe, expect, it, vi} from "vitest"
+
+const {fetchAgentBuildKitOverlayMock} = vi.hoisted(() => ({
+    fetchAgentBuildKitOverlayMock: vi.fn(),
+}))
+
+vi.mock("../../src/workflow/api", async (importOriginal) => {
+    const actual = await importOriginal<typeof import("../../src/workflow/api")>()
+    return {
+        ...actual,
+        fetchAgentBuildKitOverlay: fetchAgentBuildKitOverlayMock,
+    }
+})
+
+import {AGENT_BUILD_KIT_WORKFLOW_SLUG} from "../../src/workflow/api"
+import type {Workflow} from "../../src/workflow/core"
+import {
+    agentBuildKitOverlayAtom,
+    workflowAgentTemplateOverlayAtomFamily,
+    workflowLocalServerDataAtomFamily,
+} from "../../src/workflow/state/store"
+
+const PROJECT_ID = "proj-1"
+const SLUG_QUERY_KEY = ["agentBuildKitOverlay", AGENT_BUILD_KIT_WORKFLOW_SLUG, PROJECT_ID]
+
+const SLUG_OVERLAY = {
+    tools: [{op: "read_file", type: "platform"}],
+    sandbox: {permissions: {write_files: "allow"}},
+}
+
+const FALLBACK_OVERLAY = {
+    tools: [{op: "legacy_app_context", type: "platform"}],
+    sandbox: {permissions: {execute_code: "allow"}},
+}
+
+function makeStore({
+    session = true,
+    seedSlugOverlay = true,
+}: {session?: boolean; seedSlugOverlay?: boolean} = {}) {
+    const queryClient = new QueryClient()
+    const store = createStore()
+    store.set(queryClientAtom, queryClient)
+    store.set(projectIdAtom, PROJECT_ID)
+    store.set(sessionAtom, session)
+
+    if (seedSlugOverlay) {
+        queryClient.setQueryData(SLUG_QUERY_KEY, SLUG_OVERLAY)
+    }
+
+    return {store, queryClient}
+}
+
+function seedLocalDraft(
+    store: ReturnType<typeof createStore>,
+    id: string,
+    workflow: Partial<Workflow>,
+) {
+    store.set(workflowLocalServerDataAtomFamily(id), {
+        id,
+        flags: {},
+        data: {},
+        ...workflow,
+    } as Workflow)
+}
+
+function seedCommittedRevision(
+    queryClient: QueryClient,
+    revision: Pick<Workflow, "id"> & Partial<Workflow>,
+) {
+    queryClient.setQueryData(["workflows", "revision", revision.id, PROJECT_ID], {
+        flags: {},
+        data: {},
+        ...revision,
+    } as Workflow)
+}
+
+function seedFallbackApp(queryClient: QueryClient, applicationId: string) {
+    queryClient.setQueryData(["simpleApplication", applicationId, PROJECT_ID], {
+        count: 1,
+        additional_context: {
+            playground_build_kit: {
+                agent_template_overlay: FALLBACK_OVERLAY,
+            },
+        },
+    })
+}
+
+async function waitForAssertion(assertion: () => void) {
+    const startedAt = Date.now()
+    let lastError: unknown
+    while (Date.now() - startedAt < 1000) {
+        try {
+            assertion()
+            return
+        } catch (error) {
+            lastError = error
+            await new Promise((resolve) => setTimeout(resolve, 10))
+        }
+    }
+    throw lastError
+}
+
+describe("workflowAgentTemplateOverlayAtomFamily", () => {
+    beforeEach(() => {
+        fetchAgentBuildKitOverlayMock.mockReset()
+        workflowAgentTemplateOverlayAtomFamily.setShouldRemove(() => true)
+        workflowAgentTemplateOverlayAtomFamily.setShouldRemove(null)
+        workflowLocalServerDataAtomFamily.setShouldRemove(() => true)
+        workflowLocalServerDataAtomFamily.setShouldRemove(null)
+    })
+
+    it("returns the slug-fetched overlay for an agent-typed ephemeral draft", () => {
+        const {store} = makeStore()
+        seedLocalDraft(store, "local-agent-1", {
+            flags: {is_agent: true},
+            data: {uri: "agenta:builtin:agent:v0"},
+        })
+
+        const overlay = store.get(workflowAgentTemplateOverlayAtomFamily("local-agent-1"))
+
+        expect(overlay).toEqual(SLUG_OVERLAY)
+    })
+
+    it("returns the slug-fetched overlay for a committed agent revision", () => {
+        const {store, queryClient} = makeStore()
+        seedCommittedRevision(queryClient, {
+            id: "rev-agent-1",
+            workflow_id: "wf-agent-1",
+            flags: {is_agent: true},
+            data: {uri: "agenta:builtin:agent:v0"},
+        })
+
+        const overlay = store.get(workflowAgentTemplateOverlayAtomFamily("rev-agent-1"))
+
+        expect(overlay).toEqual(SLUG_OVERLAY)
+    })
+
+    it("uses the agent builtin URI fallback when flags are missing", () => {
+        const {store} = makeStore()
+        seedLocalDraft(store, "local-agent-uri-only", {
+            flags: {},
+            data: {uri: "agenta:builtin:agent:v0"},
+        })
+
+        const overlay = store.get(workflowAgentTemplateOverlayAtomFamily("local-agent-uri-only"))
+
+        expect(overlay).toEqual(SLUG_OVERLAY)
+    })
+
+    it("returns null for a non-agent entity", () => {
+        const {store} = makeStore()
+        seedLocalDraft(store, "local-prompt-1", {
+            flags: {is_agent: false, is_evaluator: true},
+            data: {uri: "agenta:builtin:auto_exact_match:v0"},
+        })
+
+        const overlay = store.get(workflowAgentTemplateOverlayAtomFamily("local-prompt-1"))
+
+        expect(overlay).toBeNull()
+    })
+
+    it("returns null when there is no session", () => {
+        const {store} = makeStore({session: false, seedSlugOverlay: false})
+        seedLocalDraft(store, "local-agent-no-session", {
+            flags: {is_agent: true},
+            data: {uri: "agenta:builtin:agent:v0"},
+        })
+
+        const overlay = store.get(workflowAgentTemplateOverlayAtomFamily("local-agent-no-session"))
+
+        expect(overlay).toBeNull()
+    })
+
+    it("uses the per-app fallback when the slug fetch returns empty and workflow_id exists", () => {
+        const {store, queryClient} = makeStore({seedSlugOverlay: false})
+        queryClient.setQueryData(SLUG_QUERY_KEY, null)
+        seedCommittedRevision(queryClient, {
+            id: "rev-agent-fallback",
+            workflow_id: "wf-agent-fallback",
+            flags: {is_agent: true},
+            data: {uri: "agenta:builtin:agent:v0"},
+        })
+        seedFallbackApp(queryClient, "wf-agent-fallback")
+
+        const overlay = store.get(workflowAgentTemplateOverlayAtomFamily("rev-agent-fallback"))
+
+        expect(overlay).toEqual(FALLBACK_OVERLAY)
+    })
+
+    it("uses the per-app fallback when the slug fetch errors and workflow_id exists", async () => {
+        const {store, queryClient} = makeStore({seedSlugOverlay: false})
+        fetchAgentBuildKitOverlayMock.mockRejectedValueOnce(new Error("slug fetch failed"))
+        seedCommittedRevision(queryClient, {
+            id: "rev-agent-error-fallback",
+            workflow_id: "wf-agent-error-fallback",
+            flags: {is_agent: true},
+            data: {uri: "agenta:builtin:agent:v0"},
+        })
+        seedFallbackApp(queryClient, "wf-agent-error-fallback")
+
+        const unsubscribe = store.sub(agentBuildKitOverlayAtom, () => {})
+        try {
+            store.get(workflowAgentTemplateOverlayAtomFamily("rev-agent-error-fallback"))
+            await waitForAssertion(() => {
+                expect(store.get(agentBuildKitOverlayAtom).isError).toBe(true)
+            })
+
+            const overlay = store.get(
+                workflowAgentTemplateOverlayAtomFamily("rev-agent-error-fallback"),
+            )
+
+            expect(overlay).toEqual(FALLBACK_OVERLAY)
+        } finally {
+            unsubscribe()
+        }
+    })
+})


### PR DESCRIPTION
## Context

Agents created through the template-builder and playground-native flows showed no build kit in Advanced and ran without its tools, even after committing. The kit was delivered solely as a rider on `GET /simple/applications/{id}`, keyed by a `workflow_id` that ephemeral drafts don't have. Design (reviewed by codex at xhigh, then implemented per the folded plan): the kit becomes the reserved static workflow `__ag__build_kit` — a constant agent configuration in the StaticWorkflowCatalog, same namespace as the other `__ag__*` platform constants. Stacked on the design-docs PR #5124.

## Changes

Backend:
- `core/workflows/build_kit.py` (new): the kit's content builder — forced builtins, the 13 `DEFAULT_BUILD_KIT_OPS`, the request-connection tool embed, the build-an-agent skill embed, sandbox permissions. Core owns the content; `apis/fastapi/applications/overlay.py` shrinks to a thin back-compat adapter (core never imports the API layer).
- `static_catalog.py`: the `__ag__build_kit` entry with explicit per-entry metadata (`kind`, `embeddable`) on every catalog entry, lazy revision factories, and an `is_embeddable` accessor. The old "non-skill means tool" inference is gone; only `request_connection` is a tool embed, so the kit cannot embed itself.
- Policy: `__ag__build_kit` is retrievable but not embeddable/committable — enforced with a typed error at the embed resolver AND the commit path (commits don't resolve embeds, so resolver-only enforcement wouldn't hold).

Frontend:
- `agentBuildKitOverlayAtom`: fetches the kit once per project by resolving the slug through the existing workflow-retrieve path; `staleTime: Infinity`.
- `workflowAgentTemplateOverlayAtomFamily`: gates on the target entity being agent-typed (flags on committed revisions, flags on ephemeral `local-*` drafts, builtin-URI fallback) and serves the slug-fetched kit; the legacy per-application chain is retained as a deployment-skew fallback (used only when the slug fetch definitively fails and a `workflow_id` exists).
- Fixes a pre-existing broken import in `fetchSimpleApplication` (used but never imported since merge `9cb1586329`) — the fallback needs it to compile.

## Scope / risk

The per-application `additional_context` rider is untouched this release (retirement is the planned follow-up once the FE migration has soaked). `useBuildKit` and the rendering are unchanged — only the data source moved. The kit content is byte-equivalent to the old overlay output (pinned by test). Risk to watch: any consumer that enumerated non-skill catalog entries as tools now needs the explicit allowlist (all in-repo consumers updated; the tests would catch a regression).

## Tests / verification

- 1250 api unit tests green, including 7 new pins: positive tool-embed allowlist, does-not-embed-itself, slug-retrieve content equivalence, embed rejection at resolve AND commit.
- `@agenta/entities`: 11 new tests (slug fetch shape, boundary validation, ephemeral/committed/non-agent gating, no-session, fallback on error and on null); lint, types, build green. Two pre-existing failing test files (`retrieveWorkflowRevision.test.ts`, `trace-migration-api.test.ts`, real-HTTP tests) unrelated and unchanged.
- Live API: slug retrieve returns the full 16-tool kit; committing a config embedding `__ag__build_kit` returns the typed 400.
- Browser QA on the dev stack: fresh AND committed agents render the full kit in Advanced; the network log shows the `__ag__build_kit` retrieve (proving the new path, not the fallback).

## How to QA

**Prerequisites:** any dev stack on this branch (api restart needed if the container predates the change — the bind-mount reload misses new modules).

**Steps:**
1. Create an agent from a template, open the playground config panel → Advanced → Playground build kit.
2. Expected: 13 platform tools, Request connection, the build-an-agent skill, sandbox permissions — before and after commit.
3. `POST /api/workflows/revisions/retrieve` with `{"workflow_ref": {"slug": "__ag__build_kit"}}` → the kit revision.
4. Commit a config whose skills embed `__ag__build_kit` → 400 "retrievable but cannot be embedded".

**Automated tests:** `cd api && uv run --no-sync python -m pytest oss/tests/pytest/unit/applications/ oss/tests/pytest/unit/workflows/ -q` and `cd web && pnpm --filter @agenta/entities test`.

**Edge cases:** a non-agent workflow (prompt/evaluator) must show no kit; an old cached frontend keeps working via the untouched rider.

https://claude.ai/code/session_01N2djTMgXnpk84EqtugHDJB