### PR TITLE
[fix] Refuse unknown sandbox ids and stop cross-request env bleed in the runner

### DIFF
--- a/hosting/docker-compose/ee/docker-compose.gh.local.yml
+++ b/hosting/docker-compose/ee/docker-compose.gh.local.yml
@@ -272,13 +272,10 @@ services:
         environment:
             AGENTA_RUNNER_PORT: "8765"
             AGENTA_RUNNER_HOST: ${AGENTA_RUNNER_HOST:-0.0.0.0}
-            # API as reached FROM this container: the compose service name over the network
-            # (http://api:8000, as the workers use), NOT the public http://localhost/api
-            # which does not resolve inside a container. Used by the OTLP tracing-export
-            # fallback AND the session heartbeat/record-persist calls.
             AGENTA_API_INTERNAL_URL: ${AGENTA_API_INTERNAL_URL:-http://api:8000}
             AGENTA_API_KEY: ${AGENTA_API_KEY:-}
             SANDBOX_AGENT_PROVIDER: ${SANDBOX_AGENT_PROVIDER:-local}
+            PI_CODING_AGENT_DIR: ${PI_CODING_AGENT_DIR:-/pi-agent}
             DAYTONA_API_KEY: ${DAYTONA_API_KEY:-}
             DAYTONA_API_URL: ${DAYTONA_API_URL:-}
             DAYTONA_TARGET: ${DAYTONA_TARGET:-}

--- a/hosting/docker-compose/ee/docker-compose.gh.yml
+++ b/hosting/docker-compose/ee/docker-compose.gh.yml
@@ -269,17 +269,11 @@ services:
         # === CONFIGURATION ======================================== #
         environment:
             AGENTA_RUNNER_PORT: "8765"
-            # Bind on all interfaces: the co-located Python `services` container reaches the
-            # sidecar over the compose network at `runner:8765`, so the trust-model
-            # default of `127.0.0.1` (same-host only) is unreachable cross-container.
             AGENTA_RUNNER_HOST: ${AGENTA_RUNNER_HOST:-0.0.0.0}
-            # API as reached FROM this container: the compose service name over the network
-            # (http://api:8000, as the workers use), NOT the public http://localhost/api
-            # which does not resolve inside a container. Used by the OTLP tracing-export
-            # fallback AND the session heartbeat/record-persist calls.
             AGENTA_API_INTERNAL_URL: ${AGENTA_API_INTERNAL_URL:-http://api:8000}
             AGENTA_API_KEY: ${AGENTA_API_KEY:-}
             SANDBOX_AGENT_PROVIDER: ${SANDBOX_AGENT_PROVIDER:-local}
+            PI_CODING_AGENT_DIR: ${PI_CODING_AGENT_DIR:-/pi-agent}
             DAYTONA_API_KEY: ${DAYTONA_API_KEY:-}
             DAYTONA_API_URL: ${DAYTONA_API_URL:-}
             DAYTONA_TARGET: ${DAYTONA_TARGET:-}

--- a/hosting/docker-compose/oss/docker-compose.gh.local.yml
+++ b/hosting/docker-compose/oss/docker-compose.gh.local.yml
@@ -270,13 +270,10 @@ services:
         environment:
             AGENTA_RUNNER_PORT: "8765"
             AGENTA_RUNNER_HOST: ${AGENTA_RUNNER_HOST:-0.0.0.0}
-            # API as reached FROM this container: the compose service name over the network
-            # (http://api:8000, as the workers use), NOT the public http://localhost/api
-            # which does not resolve inside a container. Used by the OTLP tracing-export
-            # fallback AND the session heartbeat/record-persist calls.
             AGENTA_API_INTERNAL_URL: ${AGENTA_API_INTERNAL_URL:-http://api:8000}
             AGENTA_API_KEY: ${AGENTA_API_KEY:-}
             SANDBOX_AGENT_PROVIDER: ${SANDBOX_AGENT_PROVIDER:-local}
+            PI_CODING_AGENT_DIR: ${PI_CODING_AGENT_DIR:-/pi-agent}
             DAYTONA_API_KEY: ${DAYTONA_API_KEY:-}
             DAYTONA_API_URL: ${DAYTONA_API_URL:-}
             DAYTONA_TARGET: ${DAYTONA_TARGET:-}

--- a/hosting/docker-compose/oss/docker-compose.gh.yml
+++ b/hosting/docker-compose/oss/docker-compose.gh.yml
@@ -286,17 +286,11 @@ services:
         # === CONFIGURATION ======================================== #
         environment:
             AGENTA_RUNNER_PORT: "8765"
-            # Bind on all interfaces: the co-located Python `services` container reaches the
-            # sidecar over the compose network at `runner:8765`, so the trust-model
-            # default of `127.0.0.1` (same-host only) is unreachable cross-container.
             AGENTA_RUNNER_HOST: ${AGENTA_RUNNER_HOST:-0.0.0.0}
-            # API as reached FROM this container: the compose service name over the network
-            # (http://api:8000, as the workers use), NOT the public http://localhost/api
-            # which does not resolve inside a container. Used by the OTLP tracing-export
-            # fallback AND the session heartbeat/record-persist calls.
             AGENTA_API_INTERNAL_URL: ${AGENTA_API_INTERNAL_URL:-http://api:8000}
             AGENTA_API_KEY: ${AGENTA_API_KEY:-}
             SANDBOX_AGENT_PROVIDER: ${SANDBOX_AGENT_PROVIDER:-local}
+            PI_CODING_AGENT_DIR: ${PI_CODING_AGENT_DIR:-/pi-agent}
             DAYTONA_API_KEY: ${DAYTONA_API_KEY:-}
             DAYTONA_API_URL: ${DAYTONA_API_URL:-}
             DAYTONA_TARGET: ${DAYTONA_TARGET:-}

--- a/hosting/kubernetes/helm/templates/runner-deployment.yaml
+++ b/hosting/kubernetes/helm/templates/runner-deployment.yaml
@@ -50,6 +50,10 @@ spec:
               value: {{ include "agenta.agentRunner.port" . | quote }}
             - name: SANDBOX_AGENT_PROVIDER
               value: {{ default "local" $runner.provider | quote }}
+            {{- if not (hasKey (default dict $runner.env) "PI_CODING_AGENT_DIR") }}
+            - name: PI_CODING_AGENT_DIR
+              value: {{ default "/pi-agent" $runner.piAgentDir | quote }}
+            {{- end }}
             {{- if $runner.logLevel }}
             - name: SANDBOX_AGENT_LOG_LEVEL
               value: {{ $runner.logLevel | quote }}

--- a/hosting/kubernetes/helm/values.schema.json
+++ b/hosting/kubernetes/helm/values.schema.json
@@ -305,6 +305,7 @@
         "externalUrl": { "type": "string", "description": "AGENTA_RUNNER_INTERNAL_URL override pointing at an external runner." },
         "enableMcp":   { "type": "boolean", "description": "AGENTA_AGENT_MCPS_ENABLED." },
         "provider":    { "type": "string", "description": "SANDBOX_AGENT_PROVIDER (e.g. local, daytona) read by the runner service." },
+        "piAgentDir":  { "type": "string", "description": "PI_CODING_AGENT_DIR for local Pi runs (default /pi-agent); unset means no Agenta extension for the run (the runner logs a warning)." },
         "logLevel":    { "type": "string", "description": "SANDBOX_AGENT_LOG_LEVEL read by the runner service." },
         "daytona":     { "type": "object", "additionalProperties": true, "description": "Daytona sandbox knobs (DAYTONA_* env on the runner service)." }
       }

--- a/services/runner/src/apiBase.ts
+++ b/services/runner/src/apiBase.ts
@@ -1,15 +1,27 @@
+import { AsyncLocalStorage } from "node:async_hooks";
+
 /**
  * The API base for runner→API calls (sessions, mounts, interactions).
  *
  * `AGENTA_API_INTERNAL_URL` is the direct in-network hop (`http://api:8000`) — the runner's
  * preferred route. `AGENTA_API_URL` is the platform-wide PUBLIC base (`http://<host>/api`,
  * proxy-shaped) and only a fallback: inside a container, a `localhost`-shaped public URL is
- * unreachable, which is why the two must stay distinct env vars.
+ * unreachable, which is why the two must stay distinct env vars. When neither is set, the base
+ * inferred from a request's telemetry is scoped to that request (not a process global), so
+ * concurrent requests with different bases never bleed into each other.
  */
+const requestApiBase = new AsyncLocalStorage<string>();
+
+/** Run `fn` with `base` as this request's inferred API base. */
+export function runWithRequestApiBase<T>(base: string, fn: () => T): T {
+  return requestApiBase.run(base, fn);
+}
+
 export function apiBase(): string {
   const base =
     process.env.AGENTA_API_INTERNAL_URL ??
     process.env.AGENTA_API_URL ??
+    requestApiBase.getStore() ??
     "http://api:8000";
   // Trim trailing slashes off the BASE only — callers append paths, and collection
   // endpoints keep their own trailing slash (`${base}/sessions/streams/`).

--- a/services/runner/src/engines/sandbox_agent/pi-assets.ts
+++ b/services/runner/src/engines/sandbox_agent/pi-assets.ts
@@ -253,6 +253,9 @@ export function prepareLocalPiAssets({
 
   if (process.env.PI_CODING_AGENT_DIR) {
     installPiExtensionLocal(process.env.PI_CODING_AGENT_DIR, log);
+  } else {
+    // unset here means this run has no Agenta extension (tracing + tools); warn so it's visible.
+    log("PI_CODING_AGENT_DIR is unset; plain local Pi run has no Agenta extension installed");
   }
   return undefined;
 }

--- a/services/runner/src/engines/sandbox_agent/provider.ts
+++ b/services/runner/src/engines/sandbox_agent/provider.ts
@@ -98,6 +98,12 @@ export function buildDaytonaCreate(
   };
 }
 
+/** Sandbox ids this runner can actually provision (the "expected one of" set). */
+export const KNOWN_SANDBOX_IDS = ["local", "daytona"] as const;
+
+/** Recognized ids that are planned but not yet provisionable (fail with a specific message). */
+export const PLANNED_SANDBOX_IDS = ["e2b"] as const;
+
 /**
  * Build the sandbox-agent provider for the requested axis.
  *
@@ -122,6 +128,19 @@ export function buildSandboxProvider(
       ...(image ? { image } : {}),
       create: buildDaytonaCreate(piExtEnv, secrets, sandboxPermission) as any,
     });
+  }
+
+  if ((PLANNED_SANDBOX_IDS as readonly string[]).includes(sandboxId)) {
+    throw new Error(
+      `The '${sandboxId}' sandbox is not yet supported in this runner; please use 'daytona' or 'local'.`,
+    );
+  }
+
+  if (sandboxId !== "local") {
+    // Refuse loud: an unrecognized id must not fall through to host execution.
+    throw new Error(
+      `Unknown sandbox id '${sandboxId}'; expected one of ${KNOWN_SANDBOX_IDS.join(", ")}`,
+    );
   }
 
   // local: spawn `sandbox-agent server` on this host with the daemon env merged in.

--- a/services/runner/src/server.ts
+++ b/services/runner/src/server.ts
@@ -13,7 +13,7 @@
  * `createAgentServer(run)` is the testable seam: it builds the server around an injectable
  * engine runner so the HTTP behavior can be tested with a fake engine (no live harness).
  */
-import { apiBase } from "./apiBase.ts";
+import { apiBase, runWithRequestApiBase } from "./apiBase.ts";
 import { randomUUID, timingSafeEqual } from "node:crypto";
 import {
   createServer,
@@ -201,6 +201,22 @@ async function runAndStream(
   request: AgentRunRequest,
   run: RunAgent,
 ): Promise<void> {
+  // scope the inferred api base to this request (AsyncLocalStorage), not a process
+  // global — a second concurrent request with a different base must not be pinned to the first.
+  const requestApiBase = apiBaseFromRequest(request);
+  if (requestApiBase) {
+    return runWithRequestApiBase(requestApiBase, () =>
+      runAndStreamWithApiBaseResolved(res, request, run),
+    );
+  }
+  return runAndStreamWithApiBaseResolved(res, request, run);
+}
+
+async function runAndStreamWithApiBaseResolved(
+  res: ServerResponse,
+  request: AgentRunRequest,
+  run: RunAgent,
+): Promise<void> {
   res.writeHead(200, {
     "content-type": "application/x-ndjson",
     "cache-control": "no-cache",
@@ -243,13 +259,8 @@ async function runAndStream(
   let aliveWatchdog: { release: () => Promise<void> } | undefined;
 
   if (sessionOwned) {
-    const requestApiBase = apiBaseFromRequest(request);
-    if (requestApiBase && !process.env.AGENTA_API_URL) {
-      process.env.AGENTA_API_URL = requestApiBase;
-      process.stderr.write(
-        `[sessions] inferred AGENTA_API_URL=${requestApiBase}\n`,
-      );
-    }
+    // The request's api base (if any) is already scoped for this call via
+    // runWithRequestApiBase in the outer runAndStream — apiBase() below sees it.
     // The runner authenticates session calls AS the invoke caller (the run credential),
     // refreshing it for the turn's lifetime — never the admin key. Project scope is
     // resolved server-side from the credential, so no project_id rides the request.
@@ -392,7 +403,10 @@ export function createRequestListener(
           // (Accept: application/x-ndjson) and the SDK coalesces the batch result from the
           // stream. This coalesced JSON response is kept only for local debugging of /run; no
           // live caller hits it. Do not build new behavior on this branch.
-          const result = await run(request);
+          const oneShotApiBase = apiBaseFromRequest(request);
+          const result = oneShotApiBase
+            ? await runWithRequestApiBase(oneShotApiBase, () => run(request))
+            : await run(request);
           return send(res, result.ok ? 200 : 500, result);
         } finally {
           inFlight -= 1;

--- a/services/runner/tests/unit/apibase-request-scope.test.ts
+++ b/services/runner/tests/unit/apibase-request-scope.test.ts
@@ -1,0 +1,139 @@
+/**
+ * Unit tests for the api base inferred from a request's telemetry must be scoped to
+ * that request, not cached onto `process.env` (a first-write-wins global that pinned every
+ * later request to the first caller's base).
+ *
+ * Run: pnpm test (or: pnpm exec vitest run tests/unit/apibase-request-scope.test.ts)
+ */
+import { afterEach, describe, it } from "vitest";
+import assert from "node:assert/strict";
+import type { AddressInfo } from "node:net";
+
+import { apiBase, runWithRequestApiBase } from "../../src/apiBase.ts";
+import { createAgentServer, type RunAgent } from "../../src/server.ts";
+
+const INTERNAL_ENV = "AGENTA_API_INTERNAL_URL";
+const PUBLIC_ENV = "AGENTA_API_URL";
+const previousInternal = process.env[INTERNAL_ENV];
+const previousPublic = process.env[PUBLIC_ENV];
+
+afterEach(() => {
+  if (previousInternal === undefined) delete process.env[INTERNAL_ENV];
+  else process.env[INTERNAL_ENV] = previousInternal;
+  if (previousPublic === undefined) delete process.env[PUBLIC_ENV];
+  else process.env[PUBLIC_ENV] = previousPublic;
+});
+
+async function listen(
+  run: RunAgent,
+): Promise<{ url: string; close: () => Promise<void> }> {
+  const server = createAgentServer(run);
+  await new Promise<void>((resolve) => server.listen(0, "127.0.0.1", resolve));
+  const { port } = server.address() as AddressInfo;
+  return {
+    url: `http://127.0.0.1:${port}`,
+    close: () => new Promise<void>((resolve) => server.close(() => resolve())),
+  };
+}
+
+// No sessionId: keep these non-session-owned so the server does not start the alive watchdog
+// (which would fire heartbeat/persist calls at the inferred base during the test).
+function requestWithOtlpBase(base: string): Record<string, unknown> {
+  return {
+    telemetry: { exporters: { otlp: { endpoint: `${base}/otlp/v1/traces` } } },
+  };
+}
+
+describe("apiBase (request-scoped, not a process-global first-write-wins pin)", () => {
+  it("two requests with different inferred api bases each see their own base", async () => {
+    delete process.env[INTERNAL_ENV];
+    delete process.env[PUBLIC_ENV];
+
+    const seenBases: string[] = [];
+    const echoRun: RunAgent = async () => {
+      seenBases.push(apiBase());
+      return { ok: true, output: "done", events: [] };
+    };
+    const s = await listen(echoRun);
+    try {
+      const first = await fetch(`${s.url}/run`, {
+        method: "POST",
+        headers: { accept: "application/x-ndjson" },
+        body: JSON.stringify(requestWithOtlpBase("http://first.internal")),
+      });
+      await first.text();
+
+      const second = await fetch(`${s.url}/run`, {
+        method: "POST",
+        headers: { accept: "application/x-ndjson" },
+        body: JSON.stringify(requestWithOtlpBase("http://second.internal")),
+      });
+      await second.text();
+
+      assert.deepEqual(seenBases, [
+        "http://first.internal",
+        "http://second.internal",
+      ]);
+
+      // The process-global fallback env is never mutated as a side effect.
+      assert.equal(process.env[PUBLIC_ENV], undefined);
+    } finally {
+      await s.close();
+    }
+  });
+
+  it("does not leak a request's inferred base to a later request with no telemetry base", async () => {
+    delete process.env[INTERNAL_ENV];
+    delete process.env[PUBLIC_ENV];
+
+    const seenBases: string[] = [];
+    const echoRun: RunAgent = async () => {
+      seenBases.push(apiBase());
+      return { ok: true, output: "done", events: [] };
+    };
+    const s = await listen(echoRun);
+    try {
+      const first = await fetch(`${s.url}/run`, {
+        method: "POST",
+        headers: { accept: "application/x-ndjson" },
+        body: JSON.stringify(requestWithOtlpBase("http://first.internal")),
+      });
+      await first.text();
+
+      // No telemetry endpoint on this one: must fall back to the hardcoded default, NOT the
+      // first request's inferred base.
+      const second = await fetch(`${s.url}/run`, {
+        method: "POST",
+        headers: { accept: "application/x-ndjson" },
+        body: JSON.stringify({}),
+      });
+      await second.text();
+
+      assert.deepEqual(seenBases, ["http://first.internal", "http://api:8000"]);
+    } finally {
+      await s.close();
+    }
+  });
+
+  it("keeps two overlapping request scopes isolated across await boundaries", async () => {
+    delete process.env[INTERNAL_ENV];
+    delete process.env[PUBLIC_ENV];
+
+    // Interleave two scopes so the second is entered while the first is suspended at an await.
+    // If the base were a process-global, the read after the yield would see the other's value.
+    const readAfterYield = (base: string) =>
+      runWithRequestApiBase(base, async () => {
+        await new Promise((r) => setTimeout(r, 0));
+        return apiBase();
+      });
+
+    const [a, b] = await Promise.all([
+      readAfterYield("http://a.internal"),
+      readAfterYield("http://b.internal"),
+    ]);
+
+    assert.equal(a, "http://a.internal");
+    assert.equal(b, "http://b.internal");
+    assert.equal(process.env[PUBLIC_ENV], undefined);
+  });
+});

--- a/services/runner/tests/unit/sandbox-agent-pi-assets.test.ts
+++ b/services/runner/tests/unit/sandbox-agent-pi-assets.test.ts
@@ -20,6 +20,7 @@ import type { AgentRunRequest } from "../../src/protocol.ts";
 import {
   buildPiExtensionEnv,
   prepareLocalAgentDir,
+  prepareLocalPiAssets,
   uploadDirToSandbox,
   uploadSkillsToSandbox,
   writeSystemPromptLocal,
@@ -269,6 +270,57 @@ describe("prepareLocalAgentDir", () => {
       readFileSync(join(runDir, "skills", "skill", "SKILL.md"), "utf-8"),
       "---\nname: skill\n---\n",
     );
+  });
+});
+
+describe("prepareLocalPiAssets (PI_CODING_AGENT_DIR guard)", () => {
+  const ENV_VAR = "PI_CODING_AGENT_DIR";
+  const previous = process.env[ENV_VAR];
+
+  afterEach(() => {
+    if (previous === undefined) delete process.env[ENV_VAR];
+    else process.env[ENV_VAR] = previous;
+  });
+
+  const plainPiPlan = {
+    isPi: true,
+    isDaytona: false,
+    skillDirs: [],
+    hasSystemPrompt: false,
+    systemPrompt: undefined,
+    appendSystemPrompt: undefined,
+    sourcePiAgentDir: "/unused",
+  };
+
+  it("logs a clear warning when a plain local Pi run has no PI_CODING_AGENT_DIR", () => {
+    delete process.env[ENV_VAR];
+    const logs: string[] = [];
+
+    const runDir = prepareLocalPiAssets({
+      plan: plainPiPlan,
+      env: {},
+      log: (msg) => logs.push(msg),
+    });
+
+    assert.equal(runDir, undefined);
+    assert.ok(
+      logs.some((m) => m.includes("PI_CODING_AGENT_DIR is unset")),
+      `expected a PI_CODING_AGENT_DIR warning, got: ${JSON.stringify(logs)}`,
+    );
+  });
+
+  it("installs the extension silently (no warning) when PI_CODING_AGENT_DIR is set", () => {
+    const dir = tempDir("agenta-pi-configured-dir-");
+    process.env[ENV_VAR] = dir;
+    const logs: string[] = [];
+
+    prepareLocalPiAssets({
+      plan: plainPiPlan,
+      env: {},
+      log: (msg) => logs.push(msg),
+    });
+
+    assert.ok(!logs.some((m) => m.includes("PI_CODING_AGENT_DIR is unset")));
   });
 });
 

--- a/services/runner/tests/unit/sandbox-agent-provider.test.ts
+++ b/services/runner/tests/unit/sandbox-agent-provider.test.ts
@@ -14,6 +14,7 @@ import assert from "node:assert/strict";
 import {
   DEFAULT_DAYTONA_AUTOSTOP_MINUTES,
   buildDaytonaCreate,
+  buildSandboxProvider,
   daytonaAutoStopMinutes,
   daytonaNetworkFields,
 } from "../../src/engines/sandbox_agent/provider.ts";
@@ -124,5 +125,30 @@ describe("buildDaytonaCreate (leak backstop on the create object)", () => {
     const create = buildDaytonaCreate({}, {}, undefined);
     assert.equal(create.autoStopInterval, 42);
     assert.equal(create.ephemeral, true);
+  });
+});
+
+describe("buildSandboxProvider (unknown sandbox id must refuse, not run local)", () => {
+  it("throws for an unrecognized sandbox id instead of falling back to local", () => {
+    assert.throws(
+      () => buildSandboxProvider("typo-sandbox", {}, undefined, {}, {}),
+      /Unknown sandbox id 'typo-sandbox'/,
+    );
+  });
+
+  it("still resolves 'local' without refusing (no widening/narrowing of the known set)", () => {
+    assert.doesNotThrow(() =>
+      buildSandboxProvider("local", {}, undefined, {}, {}),
+    );
+  });
+
+  it("'daytona' reaches the daytona() constructor, not the unknown-id refusal", () => {
+    // No DAYTONA_* credentials in this test env, so daytona() itself throws — proving the
+    // known-id branch was taken (the unknown-id error is never a credential error).
+    assert.throws(
+      () => buildSandboxProvider("daytona", {}, undefined, {}, {}),
+      (err: unknown) =>
+        err instanceof Error && !/Unknown sandbox id/.test(err.message),
+    );
   });
 });


### PR DESCRIPTION
## Context

The runner degraded silently in three places instead of refusing or logging.

An unrecognized `sandbox` id fell through to `local()` host execution and returned `ok:true`, so a typo'd or unknown sandbox ran unconfined on the runner host. The API base inferred from a request's telemetry was cached onto `process.env.AGENTA_API_URL`, a first-write-wins global that pinned every later request (even one with a different base) to the first caller's value. And a plain local Pi run with no `PI_CODING_AGENT_DIR` set installed no Agenta extension, with no signal that tracing and tools had been dropped.

## Changes

`buildSandboxProvider` now validates the sandbox id against the known set and throws for anything else, so an unknown id can no longer reach host execution.

Before: `sandbox: "e2b"` (unknown) falls through to `local()` and runs on the host.
After: it throws `Unknown sandbox id 'e2b'; expected one of local, daytona`, caught by the existing run try/catch and returned as `{ok:false, error}`.

The inferred API base is now request-scoped through `AsyncLocalStorage` (`runWithRequestApiBase`) rather than written to `process.env`. All `apiBase()` call sites already call with no arguments, so this needed no signature changes and gives true per-request isolation, including through the alive-watchdog's interval heartbeats. No environment variable is mutated as a side effect anymore.

For the dropped extension, `PI_CODING_AGENT_DIR` is now set in the `.gh` / `.gh.local` compose files (oss and ee) and the runner helm template (overridable via `agentRunner.piAgentDir`), matching the dev composes. When a local Pi run still has no dir, it logs a warning instead of silently skipping the extension.

## Tests / notes

- New unit tests: unknown-sandbox refusal, request-scoped api base isolation across two concurrent requests, and the extension-absent warning.
- `pnpm test` 590 passed; `pnpm run typecheck` clean. Helm render and compose YAML verified.
- The service-side sandbox policy gate is intentionally out of scope here (it is blocked on a separate open decision); this PR is the runner-side refusal only.
