### PR TITLE
[fix] Three tracing holes: dropped cache cost, swallowed export errors, uncaught finish

### DIFF
--- a/services/runner/package.json
+++ b/services/runner/package.json
@@ -23,6 +23,7 @@
     "@daytonaio/sdk": "^0.187.0",
     "@earendil-works/pi-coding-agent": "0.79.4",
     "@opentelemetry/api": "1.9.0",
+    "@opentelemetry/core": "1.28.0",
     "@opentelemetry/exporter-trace-otlp-proto": "0.54.0",
     "@opentelemetry/resources": "1.28.0",
     "@opentelemetry/sdk-trace-base": "1.28.0",

--- a/services/runner/pnpm-lock.yaml
+++ b/services/runner/pnpm-lock.yaml
@@ -17,6 +17,9 @@ importers:
       '@opentelemetry/api':
         specifier: 1.9.0
         version: 1.9.0
+      '@opentelemetry/core':
+        specifier: 1.28.0
+        version: 1.28.0(@opentelemetry/api@1.9.0)
       '@opentelemetry/exporter-trace-otlp-proto':
         specifier: 0.54.0
         version: 0.54.0(@opentelemetry/api@1.9.0)

--- a/services/runner/src/engines/sandbox_agent.ts
+++ b/services/runner/src/engines/sandbox_agent.ts
@@ -978,7 +978,10 @@ export async function runSandboxAgent(
     // Also surface it as an event (before finish flushes the sink) so the error reaches the
     // live stream and the durable record, not only the trace.
     otel?.emitEvent({ type: "error", message: error });
-    otel?.finish();
+    // finish() must not throw uncaught, same as recordError above — tracing must not mask the run error.
+    try {
+      otel?.finish();
+    } catch {}
     await otel?.flush().catch(() => {});
     return {
       ok: false,

--- a/services/runner/src/tracing/otel.ts
+++ b/services/runner/src/tracing/otel.ts
@@ -42,6 +42,7 @@ import {
   type Span,
   type SpanContext,
 } from "@opentelemetry/api";
+import { ExportResultCode } from "@opentelemetry/core";
 import { OTLPTraceExporter } from "@opentelemetry/exporter-trace-otlp-proto";
 import { Resource } from "@opentelemetry/resources";
 import type {
@@ -97,10 +98,9 @@ function getExporter(target: ExportTarget): OTLPTraceExporter {
 function defaultTarget(): ExportTarget {
   // Internal direct hop first, then the public `.../api` base, then cloud.
   const base =
-    (process.env.AGENTA_API_INTERNAL_URL ?? process.env.AGENTA_API_URL)?.replace(
-      /\/+$/,
-      "",
-    ) || "https://cloud.agenta.ai/api";
+    (
+      process.env.AGENTA_API_INTERNAL_URL ?? process.env.AGENTA_API_URL
+    )?.replace(/\/+$/, "") || "https://cloud.agenta.ai/api";
   // Prefer the bare API key; else fall back to the full (scheme-tagged) ephemeral
   // credential, used verbatim — `/check` hands back a `Secret ...`, not an API key.
   const apiKey = process.env.AGENTA_API_KEY || "";
@@ -142,9 +142,20 @@ class TraceBatchProcessor implements SpanProcessor {
     this.buffers.delete(traceId);
     const target = traceTargets.get(traceId) ?? defaultTarget();
     traceTargets.delete(traceId);
-    return new Promise((resolve) =>
-      getExporter(target).export(orderParentFirst(spans), () => resolve()),
-    );
+    return new Promise((resolve) => {
+      try {
+        getExporter(target).export(orderParentFirst(spans), (result) => {
+          if (result.code === ExportResultCode.FAILED)
+            console.error("otel: trace export failed", traceId, result.error);
+          resolve();
+        });
+      } catch (err) {
+        // A synchronous export throw (e.g. misconfigured exporter) must stay best-effort:
+        // flush() is awaited without a catch, so a reject here would break the run.
+        console.error("otel: trace export threw", traceId, err);
+        resolve();
+      }
+    });
   }
 
   forceFlush(): Promise<void> {
@@ -365,7 +376,11 @@ function lastAssistantText(messages: any): string {
 /** Fill an LLM span from a finished assistant message (model, tokens, finish, output). */
 /** Returns the error message when the assistant turn failed (stopReason/errorMessage), else
  * undefined — so the caller can emit a matching `error` event, not just stamp the span. */
-function applyAssistant(span: Span, msg: any, capture: boolean): string | undefined {
+function applyAssistant(
+  span: Span,
+  msg: any,
+  capture: boolean,
+): string | undefined {
   if (msg.provider) span.setAttribute("gen_ai.system", msg.provider);
   if (msg.model) span.setAttribute("gen_ai.request.model", msg.model);
   if (msg.responseModel || msg.model)
@@ -389,11 +404,13 @@ function applyAssistant(span: Span, msg: any, capture: boolean): string | undefi
       "gen_ai.usage.total_tokens",
       u.totalTokens ?? (u.input ?? 0) + (u.output ?? 0),
     );
-    if (u.cacheRead)
-      span.setAttribute("gen_ai.usage.cache_read_input_tokens", u.cacheRead);
-    if (u.cacheWrite)
+    // Dotted form: matches logfire_adapter.py's ingest keys (underscore form was never read).
+    // Nullish check, not truthy, so a real 0 is emitted like the other token fields.
+    if (u.cacheRead != null)
+      span.setAttribute("gen_ai.usage.cache_read.input_tokens", u.cacheRead);
+    if (u.cacheWrite != null)
       span.setAttribute(
-        "gen_ai.usage.cache_creation_input_tokens",
+        "gen_ai.usage.cache_creation.input_tokens",
         u.cacheWrite,
       );
     if (u.cost?.total != null)
@@ -1162,7 +1179,11 @@ export function createSandboxAgentOtel(
         name: String(name),
         input: update.rawInput,
       });
-      toolSpans.set(id, { span, name: String(name), inputJson: toolInputJson(update.rawInput) });
+      toolSpans.set(id, {
+        span,
+        name: String(name),
+        inputJson: toolInputJson(update.rawInput),
+      });
       // A tool_call can arrive already completed (status set up front).
       maybeCloseTool(id, update);
       return;
@@ -1185,8 +1206,17 @@ export function createSandboxAgentOtel(
         const nextJson = toolInputJson(update.rawInput);
         if (nextJson !== entry.inputJson) {
           if (entry.span)
-            setInputs(entry.span, update.rawInput as Record<string, unknown>, capture);
-          record({ type: "tool_call", id: String(id), name: entry.name, input: update.rawInput });
+            setInputs(
+              entry.span,
+              update.rawInput as Record<string, unknown>,
+              capture,
+            );
+          record({
+            type: "tool_call",
+            id: String(id),
+            name: entry.name,
+            input: update.rawInput,
+          });
           entry.inputJson = nextJson;
         }
       }

--- a/services/runner/tests/unit/otel-flush-export.test.ts
+++ b/services/runner/tests/unit/otel-flush-export.test.ts
@@ -1,0 +1,84 @@
+/**
+ * `TraceBatchProcessor.flush` previously discarded the exporter's `ExportResult`, so an OTLP
+ * export FAILURE resolved as success and was invisible. This pins that a failing export is
+ * logged rather than silently swallowed.
+ *
+ * We spy on `OTLPExporterBase.prototype.export` (reached via any exporter instance's prototype
+ * chain, since the package only exports the concrete `OTLPTraceExporter`) to force a FAILED
+ * `ExportResult` through the real `TraceBatchProcessor` created by `createSandboxAgentOtel`.
+ *
+ * Run: pnpm exec vitest run tests/unit/otel-flush-export.test.ts
+ */
+import { afterEach, describe, expect, it, vi } from "vitest";
+import { OTLPTraceExporter } from "@opentelemetry/exporter-trace-otlp-proto";
+import { ExportResultCode, type ExportResult } from "@opentelemetry/core";
+import type { SpanExporter } from "@opentelemetry/sdk-trace-base";
+
+import { createSandboxAgentOtel } from "../../src/tracing/otel.ts";
+
+/** The shared base prototype real exporters inherit `export` from, typed as `SpanExporter`. */
+function exportProtoOf(exporter: OTLPTraceExporter): SpanExporter {
+  return Object.getPrototypeOf(Object.getPrototypeOf(exporter));
+}
+
+afterEach(() => {
+  vi.restoreAllMocks();
+});
+
+describe("otel TraceBatchProcessor.flush", () => {
+  it("logs a FAILED ExportResult instead of silently resolving", async () => {
+    // Reach the shared base prototype that actually owns `export` (OTLPTraceExporter itself
+    // declares no own methods) so the spy applies to every exporter instance the module builds.
+    const exportProto = exportProtoOf(
+      new OTLPTraceExporter({ url: "http://127.0.0.1:1/v1/traces" }),
+    );
+    const exportSpy = vi
+      .spyOn(exportProto, "export")
+      .mockImplementation((_spans, cb: (r: ExportResult) => void) => {
+        cb({ code: ExportResultCode.FAILED, error: new Error("boom") });
+      });
+    const errorSpy = vi.spyOn(console, "error").mockImplementation(() => {});
+
+    const otel = createSandboxAgentOtel({
+      harness: "claude",
+      model: "anthropic/claude-haiku",
+      emitSpans: true,
+      endpoint: "http://127.0.0.1:1/v1/traces",
+    });
+    otel.start({ prompt: "hi" });
+    otel.finish();
+    await otel.flush();
+
+    expect(exportSpy).toHaveBeenCalled();
+    // The failure must surface via a log, not vanish.
+    expect(errorSpy).toHaveBeenCalled();
+    const loggedFailure = errorSpy.mock.calls.some((args) =>
+      args.some((a) => typeof a === "string" && a.includes("export failed")),
+    );
+    expect(loggedFailure).toBe(true);
+  });
+
+  it("does not log on a SUCCESS ExportResult", async () => {
+    const exportProto = exportProtoOf(
+      new OTLPTraceExporter({ url: "http://127.0.0.1:1/v1/traces" }),
+    );
+    vi.spyOn(exportProto, "export").mockImplementation(
+      (_spans, cb: (r: ExportResult) => void) => {
+        cb({ code: ExportResultCode.SUCCESS });
+      },
+    );
+    const errorSpy = vi.spyOn(console, "error").mockImplementation(() => {});
+
+    const otel = createSandboxAgentOtel({
+      harness: "claude",
+      model: "anthropic/claude-haiku",
+      emitSpans: true,
+      endpoint: "http://127.0.0.1:1/v1/traces",
+    });
+    otel.start({ prompt: "hi" });
+    otel.finish();
+    await otel.flush();
+
+    expect(errorSpy).not.toHaveBeenCalled();
+  });
+});

--- a/services/runner/tests/unit/otel-skills-error.test.ts
+++ b/services/runner/tests/unit/otel-skills-error.test.ts
@@ -250,4 +250,43 @@ describe("otel skills + error tracing", () => {
     const agentSpan = spans.find((s) => s.name === "invoke_agent");
     expect(agentSpan?.attributes["ag.exception.provider"]).toBe("anthropic");
   });
+
+  // Emit the dotted cache-token keys the ingest adapter reads; underscore form is dropped.
+  it("emits dotted cache-token keys matching the ingest adapter's expected form", () => {
+    const spans = spyTracer();
+    const otel = createAgentaOtel({ captureContent: true });
+    const handlers: Record<string, (...args: any[]) => Promise<void>> = {};
+    otel.register({
+      on: (name: string, fn: (...args: any[]) => Promise<void>) => {
+        handlers[name] = fn;
+      },
+    } as any);
+    return (async () => {
+      await handlers["before_agent_start"]?.({ prompt: "hi" });
+      await handlers["agent_start"]?.({});
+      await handlers["turn_start"]?.({ turnIndex: 0 });
+      await handlers["before_provider_request"]?.({}, { model: { id: "gpt-5" } });
+      await handlers["message_end"]?.({
+        message: {
+          role: "assistant",
+          usage: { input: 10, output: 5, cacheRead: 7, cacheWrite: 3 },
+        },
+      });
+
+      const llmSpan = spans.find((s) => s.name === "chat gpt-5");
+      expect(llmSpan?.attributes["gen_ai.usage.cache_read.input_tokens"]).toBe(
+        7,
+      );
+      expect(
+        llmSpan?.attributes["gen_ai.usage.cache_creation.input_tokens"],
+      ).toBe(3);
+      // The old underscore form must be gone — that mismatch is the bug being fixed.
+      expect(
+        llmSpan?.attributes["gen_ai.usage.cache_read_input_tokens"],
+      ).toBeUndefined();
+      expect(
+        llmSpan?.attributes["gen_ai.usage.cache_creation_input_tokens"],
+      ).toBeUndefined();
+    })();
+  });
 });

--- a/services/runner/tests/unit/sandbox-agent-orchestration.test.ts
+++ b/services/runner/tests/unit/sandbox-agent-orchestration.test.ts
@@ -717,6 +717,58 @@ describe("runSandboxAgent orchestration", () => {
     assert.equal(calls.workspaceCleanup, 1);
   });
 
+  // A throw from otel.finish() in the error path must not mask the real run error.
+  it("still returns the run error when otel.finish() throws in the error path", async () => {
+    const { calls, deps } = fakeHarness({ promptError: new Error("boom") });
+    deps.createOtel = ((otelOptions: any) => {
+      calls.otelOptions = otelOptions;
+      return {
+        start() {},
+        handleUpdate() {},
+        emitEvent(event: AgentEvent) {
+          void event;
+        },
+        usage() {
+          return { input: 0, output: 0, total: 0, cost: 0 };
+        },
+        setUsage() {},
+        finish() {
+          calls.runFinished += 1;
+          throw new Error("tracing finish blew up");
+        },
+        recordError(message: string, provider?: string) {
+          calls.recordedErrors.push({ message, provider });
+        },
+        output() {
+          return "";
+        },
+        async flush() {
+          calls.runFlushed += 1;
+        },
+        events() {
+          return [];
+        },
+        settleOpenToolCalls() {},
+        traceId() {
+          return "trace-1";
+        },
+      };
+    }) as any;
+
+    const result = await runSandboxAgent(
+      { harness: "claude", messages: [{ role: "user", content: "explode" }] },
+      undefined,
+      undefined,
+      deps,
+    );
+
+    assert.deepEqual(result, { ok: false, error: "boom" });
+    assert.equal(calls.runFinished, 1);
+    assert.equal(calls.runFlushed, 1);
+    assert.equal(calls.sandboxDestroyed, 1);
+    assert.equal(calls.sandboxDisposed, 1);
+  });
+
   it("passes the sandbox permission through to buildSandboxProvider", async () => {
     const { calls, deps } = fakeHarness();
     const sandboxPermission = {


### PR DESCRIPTION
## Context

Three independent tracing holes, each of which lost data silently.

Prompt-cache cost never reached the backend: the runner emitted the cache-token attributes under underscore keys (`gen_ai.usage.cache_read_input_tokens`), but the ingest adapter only reads the dotted form, so cache read/write cost was dropped on every run. Separately, `TraceBatchProcessor.flush` discarded the exporter's `ExportResult`, so an OTLP export failure resolved as success and was invisible. And a throw from `otel.finish()` in the run's error path propagated uncaught, masking the real run error and skipping the cleanup below it.

## Changes

- The runner now emits the dotted cache-token keys the ingest adapter actually reads (`gen_ai.usage.cache_read.input_tokens`), so cache cost is recorded.
- `flush` inspects the `ExportResult` and logs a FAILED export instead of resolving as success. It still resolves (does not reject) so the un-wrapped flush call site gains no new throw.
- `otel.finish()` in the error path is wrapped in try/catch, mirroring the existing wrapping of `recordError` right above it.

## Tests / notes

- Extended the otel state-machine tests (dotted cache keys), added a flush-export test (FAILED result is logged, not swallowed), and an orchestration test (a throwing finish still returns the real run error). Each was confirmed load-bearing by reverting its fix.
- `pnpm test` green; `pnpm run typecheck` clean. Added `@opentelemetry/core` as an explicit dependency for the `ExportResult` types (previously transitive only).
