### PR TITLE
[fix] Gate cwd delete on a confirmed unmount and fix relay/mount ordering

### DIFF
--- a/services/runner/src/engines/sandbox_agent.ts
+++ b/services/runner/src/engines/sandbox_agent.ts
@@ -502,10 +502,15 @@ export async function runSandboxAgent(
       return false;
     });
   };
+  // Gates the cwd rmSync in the `finally` below: never delete through a mount we can't prove
+  // is gone. Checked at the call site, not here, since this placeholder can be replaced
+  // by prepareWorkspace's own cleanup before the gate is evaluated.
+  let durableCwdSafeToDelete = true;
   let workspace: { cleanup: () => Promise<void> } | undefined = plan.isDaytona
     ? undefined
     : {
-        cleanup: async () => rmSync(plan.cwd, { recursive: true, force: true }),
+        cleanup: async () =>
+          rmSync(plan.cwd, { recursive: true, force: true }),
       };
 
   try {
@@ -551,13 +556,35 @@ export async function runSandboxAgent(
     }
 
     // Durable cwd: reuse the pre-signed creds (signed before buildRunPlan so the prefix drove the
-    // cwd derivation). The mount lands BEFORE createSession so the session opens inside it.
+    // cwd derivation). The mount lands BEFORE createSession so the session opens inside it, and
+    // BEFORE workspace materialization on both providers so AGENTS.md, harness files, and skills
+    // land in the durable prefix instead of being hidden under the later FUSE mount.
     // Local: on-host geesefs; scoped creds never enter agent space.
     // Remote (Daytona): geesefs inside the sandbox over the ngrok tunnel.
     if (mountCreds && !plan.isDaytona) {
-      // Mount before local workspace materialization so AGENTS.md, harness files, and skills
-      // land in the durable prefix instead of being hidden under the later FUSE mount.
       await mountLocalDurableCwd("initial");
+    }
+    if (mountCreds && plan.isDaytona) {
+      const endpoint = await (
+        deps.discoverTunnelEndpoint ?? discoverTunnelEndpoint
+      )({
+        log: logger,
+      });
+      if (
+        endpoint &&
+        (await (deps.mountStorageRemote ?? mountStorageRemote)(
+          sandbox,
+          plan.cwd,
+          mountCreds,
+          {
+            endpoint,
+            log: logger,
+          },
+        ))
+      ) {
+        // Remote files live in the store; nothing on this host to unmount.
+        logger(`remote durable cwd active for session=${sessionForMount}`);
+      }
     }
 
     try {
@@ -583,31 +610,6 @@ export async function runSandboxAgent(
         });
       } else {
         throw err;
-      }
-    }
-
-    if (mountCreds) {
-      if (plan.isDaytona) {
-        const endpoint = await (
-          deps.discoverTunnelEndpoint ?? discoverTunnelEndpoint
-        )({
-          log: logger,
-        });
-        if (
-          endpoint &&
-          (await (deps.mountStorageRemote ?? mountStorageRemote)(
-            sandbox,
-            plan.cwd,
-            mountCreds,
-            {
-              endpoint,
-              log: logger,
-            },
-          ))
-        ) {
-          // Remote files live in the store; nothing on this host to unmount.
-          logger(`remote durable cwd active for session=${sessionForMount}`);
-        }
       }
     }
 
@@ -1006,12 +1008,20 @@ export async function runSandboxAgent(
     await sandbox?.destroySandbox().catch(() => {});
     await sandbox?.dispose().catch(() => {});
     // Unmount the durable cwd BEFORE removing the dir: data lives in the store, only the host
-    // mountpoint is torn down. Best-effort (the store keeps the files regardless).
-    if (mountedCwd)
-      await (deps.unmountStorage ?? unmountStorage)(mountedCwd, { log }).catch(
-        () => {},
+    // mountpoint is torn down. If unmount is not CONFIRMED gone, skip the delete below:
+    // rmSync must never run against a possibly-live FUSE mount into the durable store.
+    if (mountedCwd) {
+      durableCwdSafeToDelete = await (
+        deps.unmountStorage ?? unmountStorage
+      )(mountedCwd, { log }).catch(() => false);
+    }
+    if (!durableCwdSafeToDelete) {
+      logger(
+        `durable cwd unmount not confirmed, skipping workspace cleanup cwd=${plan.cwd}`,
       );
-    await workspace?.cleanup().catch(() => {});
+    } else {
+      await workspace?.cleanup().catch(() => {});
+    }
     // The per-run Agenta agent dir (skills isolation) is throwaway; remove it too.
     if (runAgentDir) rmSync(runAgentDir, { recursive: true, force: true });
     // Remove the per-run skills temp root the materializer created (success or error).

--- a/services/runner/src/engines/sandbox_agent/mount.ts
+++ b/services/runner/src/engines/sandbox_agent/mount.ts
@@ -269,6 +269,8 @@ export async function mountStorage(
 
 export interface UnmountStorageDeps {
   runUnmount?: (cwd: string) => Promise<void>;
+  // Resolve to "gone" | "mounted" | "inconclusive"; only "gone" allows the caller to delete.
+  checkMountpoint?: (cwd: string) => Promise<"gone" | "mounted" | "inconclusive">;
   log?: (msg: string) => void;
 }
 
@@ -277,11 +279,15 @@ export interface UnmountStorageDeps {
  * unmount loses nothing. Lazy unmount (`-uz`) so a still-busy mount (harness holding the cwd
  * at teardown) detaches now and reaps once released, instead of failing "busy" and leaking —
  * leaked geesefs mounts later go stale and serve ENOTCONN to any file op on the cwd.
+ *
+ * Returns true only when the mountpoint is CONFIRMED gone afterward. Callers that then delete
+ * the cwd MUST gate the delete on this return, not on fusermount merely not throwing — a lazy
+ * unmount can leave the FUSE node live, and deleting through it corrupts the durable store.
  */
 export async function unmountStorage(
   cwd: string,
   deps: UnmountStorageDeps = {},
-): Promise<void> {
+): Promise<boolean> {
   const log = deps.log ?? defaultLog;
   const run =
     deps.runUnmount ??
@@ -290,20 +296,35 @@ export async function unmountStorage(
     });
   try {
     await run(cwd);
-    // Lazy unmount can leave the node attached until the dead daemon's last ref drops; that
-    // residual node serves ENOTCONN and poisons the next session. Verify it's actually gone.
-    let stillMounted = false;
-    try {
-      await pExecFile("mountpoint", ["-q", cwd]);
-      stillMounted = true;
-    } catch {
-      stillMounted = false;
-    }
-    log(`unmounted ${cwd} (mountpoint still present after detach: ${stillMounted})`);
   } catch (err) {
     log(
       `unmount failed ${cwd}: ${String(err instanceof Error ? err.message : err).slice(0, 200)}`,
     );
+    return false;
+  }
+  // Lazy unmount can leave the node attached until the dead daemon's last ref drops; that
+  // residual node serves ENOTCONN and poisons the next session. Verify it's actually gone.
+  const check = deps.checkMountpoint ?? defaultCheckMountpoint;
+  const state = await check(cwd);
+  if (state === "gone") {
+    log(`unmounted ${cwd} (confirmed gone)`);
+    return true;
+  }
+  log(`unmount verify ${cwd}: ${state}; not deleting`);
+  return false;
+}
+
+// `mountpoint -q` exits 0 = still mounted, 1 = not a mountpoint (confirmed gone). Any other
+// failure (missing binary, unexpected error) is NOT confirmation, so the caller never deletes
+// through a possibly-live mount.
+async function defaultCheckMountpoint(
+  cwd: string,
+): Promise<"gone" | "mounted" | "inconclusive"> {
+  try {
+    await pExecFile("mountpoint", ["-q", cwd]);
+    return "mounted";
+  } catch (err) {
+    return (err as { code?: number }).code === 1 ? "gone" : "inconclusive";
   }
 }
 

--- a/services/runner/src/engines/sandbox_agent/workspace.ts
+++ b/services/runner/src/engines/sandbox_agent/workspace.ts
@@ -58,6 +58,16 @@ export async function prepareWorkspace({
       log(`workspace mkdir skipped: ${err.message}`);
     });
     if (plan.useToolRelay) {
+      // Clear stale .req.json/.res.json from a prior turn before recreating: the relay
+      // dir is keyed on the durable cwd and a fresh per-turn `seen` set would otherwise re-execute it.
+      if (typeof sandbox.runProcess === "function") {
+        // Direct argv, no shell, so an arbitrary path can't break or inject.
+        await sandbox
+          .runProcess({ command: "rm", args: ["-rf", "--", plan.relayDir] })
+          .catch((err: Error) => {
+            log(`tool relay dir clear skipped: ${err.message}`);
+          });
+      }
       await sandbox.mkdirFs({ path: plan.relayDir }).catch((err: Error) => {
         log(`tool relay dir mkdir skipped: ${err.message}`);
       });
@@ -92,7 +102,12 @@ export async function prepareWorkspace({
     return { cleanup: async () => {} };
   }
 
-  if (plan.useToolRelay) mkdirSync(plan.relayDir, { recursive: true });
+  if (plan.useToolRelay) {
+    // Clear stale .req.json from a prior turn: relayDir is keyed on the durable cwd and
+    // is never otherwise cleared, so an old request would be re-picked-up by the fresh `seen` set.
+    rmSync(plan.relayDir, { recursive: true, force: true });
+    mkdirSync(plan.relayDir, { recursive: true });
+  }
   if (plan.agentsMd)
     writeFileSync(join(plan.cwd, instructionsFile), plan.agentsMd, "utf-8");
   for (const file of harnessFiles) {

--- a/services/runner/tests/unit/sandbox-agent-mount.test.ts
+++ b/services/runner/tests/unit/sandbox-agent-mount.test.ts
@@ -218,15 +218,46 @@ describe("unmountStorage", () => {
     assert.equal(target, "/work/cwd");
   });
 
-  it("swallows unmount errors (data lives in the store)", async () => {
-    await unmountStorage("/work/cwd", {
+  it("swallows unmount errors (data lives in the store) and reports NOT confirmed", async () => {
+    const ok = await unmountStorage("/work/cwd", {
       runUnmount: async () => {
         throw new Error("not mounted");
       },
       log: SILENT,
     });
-    // No throw == pass.
-    assert.ok(true);
+    // No throw == pass, but callers must not treat this as safe to delete the cwd.
+    assert.equal(ok, false);
+  });
+});
+
+describe("unmountStorage confirmation", () => {
+  // A caller (workspace cleanup) must gate rmSync on this return value, not merely on
+  // fusermount not throwing — a lazy unmount (-uz) can leave the node attached.
+  it("returns true only when the mountpoint check confirms it is gone", async () => {
+    const gone = await unmountStorage("/work/cwd", {
+      runUnmount: async () => {},
+      checkMountpoint: async () => "gone",
+      log: SILENT,
+    });
+    assert.equal(gone, true);
+  });
+
+  it("returns false when the mountpoint is still mounted after detach", async () => {
+    const ok = await unmountStorage("/work/cwd", {
+      runUnmount: async () => {},
+      checkMountpoint: async () => "mounted",
+      log: SILENT,
+    });
+    assert.equal(ok, false);
+  });
+
+  it("returns false when the mountpoint check is inconclusive (never delete on doubt)", async () => {
+    const ok = await unmountStorage("/work/cwd", {
+      runUnmount: async () => {},
+      checkMountpoint: async () => "inconclusive",
+      log: SILENT,
+    });
+    assert.equal(ok, false);
   });
 });
 

--- a/services/runner/tests/unit/sandbox-agent-orchestration.test.ts
+++ b/services/runner/tests/unit/sandbox-agent-orchestration.test.ts
@@ -358,7 +358,7 @@ describe("runSandboxAgent orchestration", () => {
       seenMountAccessKeys.push(creds.accessKey);
       return true;
     }) as any;
-    deps.unmountStorage = (async () => {}) as any;
+    deps.unmountStorage = (async () => true) as any;
     deps.prepareWorkspace = (async ({ plan }: any) => {
       workspaceCalls += 1;
       if (workspaceCalls === 1) {
@@ -487,6 +487,126 @@ describe("runSandboxAgent orchestration", () => {
     );
     assert.deepEqual(seenMountAccessKeys, ["AK-1", "AK-2"]);
     assert.equal(unmountCalls, 1, "cleanup waits for runtime remount before unmount");
+  });
+
+  it("skips the durable cwd delete when unmount is not confirmed", async () => {
+    // A failed/still-mounted unmount must never be followed by rmSync on the cwd — that would
+    // delete through a possibly-live FUSE mount into the durable store.
+    const { calls, deps } = fakeHarness();
+    deps.signSessionMountCredentials = (async () => ({
+      endpoint: "http://seaweedfs:8333",
+      region: "us-east-1",
+      bucket: "agenta-store",
+      prefix: "mounts/proj-1/mount-1",
+      accessKey: "AK-1",
+      secretKey: "SK-1",
+    })) as any;
+    deps.mountStorage = (async () => true) as any;
+    // Simulate an unconfirmed unmount (still mounted after the detach attempt).
+    deps.unmountStorage = (async () => false) as any;
+
+    const result = await runSandboxAgent(
+      {
+        harness: "claude",
+        sessionId: "sess-1",
+        telemetry: {
+          exporters: { otlp: { headers: { authorization: "ApiKey run" } } },
+        },
+        messages: [{ role: "user", content: "hello" }],
+      } as AgentRunRequest,
+      undefined,
+      undefined,
+      deps,
+    );
+
+    assert.equal(result.ok, true);
+    assert.equal(
+      calls.workspaceCleanup,
+      0,
+      "cwd delete is skipped when unmount is not confirmed",
+    );
+  });
+
+  it("still deletes the cwd once unmount is confirmed gone", async () => {
+    const { calls, deps } = fakeHarness();
+    deps.signSessionMountCredentials = (async () => ({
+      endpoint: "http://seaweedfs:8333",
+      region: "us-east-1",
+      bucket: "agenta-store",
+      prefix: "mounts/proj-1/mount-1",
+      accessKey: "AK-1",
+      secretKey: "SK-1",
+    })) as any;
+    deps.mountStorage = (async () => true) as any;
+    deps.unmountStorage = (async () => true) as any;
+
+    const result = await runSandboxAgent(
+      {
+        harness: "claude",
+        sessionId: "sess-1",
+        telemetry: {
+          exporters: { otlp: { headers: { authorization: "ApiKey run" } } },
+        },
+        messages: [{ role: "user", content: "hello" }],
+      } as AgentRunRequest,
+      undefined,
+      undefined,
+      deps,
+    );
+
+    assert.equal(result.ok, true);
+    assert.equal(
+      calls.workspaceCleanup,
+      1,
+      "cwd delete proceeds once unmount is confirmed",
+    );
+  });
+
+  it("Daytona mounts the durable cwd before workspace materialization", async () => {
+    const { calls, deps } = fakeHarness();
+    let mountCallsBeforeWorkspace = 0;
+    deps.signSessionMountCredentials = (async () => ({
+      endpoint: "http://seaweedfs:8333",
+      region: "us-east-1",
+      bucket: "agenta-store",
+      prefix: "mounts/proj-1/mount-1",
+      accessKey: "AK-1",
+      secretKey: "SK-1",
+    })) as any;
+    deps.discoverTunnelEndpoint = (async () => "https://tunnel.example") as any;
+    let mountCalls = 0;
+    deps.mountStorageRemote = (async () => {
+      mountCalls += 1;
+      return true;
+    }) as any;
+    deps.prepareWorkspace = (async ({ plan }: any) => {
+      mountCallsBeforeWorkspace = mountCalls;
+      calls.workspacePlan = plan;
+      return { cleanup: async () => {} };
+    }) as any;
+
+    const result = await runSandboxAgent(
+      {
+        harness: "claude",
+        sandbox: "daytona",
+        sessionId: "sess-1",
+        telemetry: {
+          exporters: { otlp: { headers: { authorization: "ApiKey run" } } },
+        },
+        messages: [{ role: "user", content: "hello" }],
+      } as AgentRunRequest,
+      undefined,
+      undefined,
+      deps,
+    );
+
+    assert.equal(result.ok, true);
+    assert.equal(mountCalls, 1, "remote mount is attempted");
+    assert.equal(
+      mountCallsBeforeWorkspace,
+      1,
+      "the durable cwd is mounted before workspace materialization writes into it",
+    );
   });
 
   it("keeps terminal events empty on the streaming path", async () => {

--- a/services/runner/tests/unit/sandbox-agent-workspace.test.ts
+++ b/services/runner/tests/unit/sandbox-agent-workspace.test.ts
@@ -7,6 +7,7 @@ import { afterEach, describe, it } from "vitest";
 import assert from "node:assert/strict";
 import {
   existsSync,
+  mkdirSync,
   mkdtempSync,
   readFileSync,
   rmSync,
@@ -58,6 +59,85 @@ describe("prepareWorkspace", () => {
 
     await workspace.cleanup();
     assert.equal(existsSync(cwd), false);
+  });
+
+  it("clears a stale .req.json left from a prior turn before the next turn starts", async () => {
+    const cwd = tempDir();
+    const relayDir = join(cwd, ".agenta-tools");
+
+    // Simulate a prior turn's relay dir with an unconsumed (or already-answered) request.
+    mkdirSync(relayDir, { recursive: true });
+    writeFileSync(join(relayDir, "stale-call.req.json"), "{}", "utf-8");
+
+    const workspace = await prepareWorkspace({
+      sandbox: {},
+      plan: {
+        isDaytona: false,
+        cwd,
+        relayDir,
+        useToolRelay: true,
+        agentsMd: "agent instructions",
+        acpAgent: "pi",
+        isPi: true,
+        skillDirs: [],
+      },
+    });
+
+    assert.equal(
+      existsSync(join(relayDir, "stale-call.req.json")),
+      false,
+      "the stale request file from the prior turn must not survive into the next turn",
+    );
+    assert.equal(existsSync(relayDir), true, "the relay dir itself is recreated");
+
+    await workspace.cleanup();
+  });
+
+  it("clears the Daytona relay dir via runProcess before recreating it", async () => {
+    const calls: Array<{ op: string; path?: string; command?: string; args?: string[] }> =
+      [];
+    const sandbox = {
+      mkdirFs: async ({ path }: { path: string }) =>
+        calls.push({ op: "mkdir", path }),
+      writeFsFile: async ({ path }: { path: string }, _body: string) =>
+        calls.push({ op: "write", path }),
+      runProcess: async (opts: { command: string; args?: string[] }) =>
+        calls.push({ op: "run", command: opts.command, args: opts.args }),
+    };
+
+    await prepareWorkspace({
+      sandbox,
+      plan: {
+        isDaytona: true,
+        cwd: "/home/sandbox/agenta-fixed",
+        relayDir: "/home/sandbox/agenta-fixed/.agenta-tools",
+        useToolRelay: true,
+        agentsMd: "agent instructions",
+        acpAgent: "pi",
+        isPi: true,
+        skillDirs: [],
+      },
+    });
+
+    const runIndex = calls.findIndex((c) => c.op === "run");
+    const mkdirRelayIndex = calls.findIndex(
+      (c) => c.op === "mkdir" && c.path === "/home/sandbox/agenta-fixed/.agenta-tools",
+    );
+    assert.ok(runIndex !== -1, "the relay dir is cleared via runProcess");
+    assert.equal(
+      calls[runIndex]?.command,
+      "rm",
+      "clears with a direct rm exec, not a shell",
+    );
+    assert.deepEqual(
+      calls[runIndex]?.args,
+      ["-rf", "--", "/home/sandbox/agenta-fixed/.agenta-tools"],
+      "clears exactly the relay dir (argv, no shell interpolation), not the durable cwd",
+    );
+    assert.ok(
+      runIndex < mkdirRelayIndex,
+      "the clear happens before the relay dir is recreated",
+    );
   });
 
   it("writes claude instructions to CLAUDE.md, not AGENTS.md (local)", async () => {


### PR DESCRIPTION
## Context

Three runner teardown bugs, two of which could lose durable data.

Cleanup ran `rmSync(cwd, { recursive: true, force: true })` unconditionally after a best-effort unmount whose failure was swallowed. A lazy unmount (`fusermount -uz`) can leave the FUSE node live, so the delete could run through a still-mounted node straight into the durable store. Separately, the tool relay directory was keyed on the durable cwd and never cleared, so a stale `.req.json` from a prior turn re-executed on the next turn (duplicate external side effects, stale usage). And on Daytona the durable cwd was mounted after workspace materialization, so instructions and rendered permission settings written during materialization were hidden under the later mount.

## Changes

`unmountStorage` now returns a boolean that is true only when the mountpoint is confirmed gone afterward, not merely when `fusermount` did not throw. The cwd delete is gated on that value.

Before: unmount is best-effort, its result ignored, then `rmSync(cwd)` always runs.
After: if the unmount is not confirmed gone (a durable mount was attempted and the post-unmount check still sees it mounted), the delete is skipped and logged, so `rmSync` never runs against a possibly-live mount.

The relay directory is cleared before it is recreated at the start of each turn (local `rmSync`, Daytona `rm -rf` in-sandbox), scoped to the relay dir and never the durable cwd, so a prior turn's request cannot be re-picked-up.

On Daytona, the durable cwd is now mounted before workspace materialization, matching the local ordering, so materialized instructions and permission settings land in the mounted prefix instead of being hidden.

## Tests / notes

- New unit tests: delete-skipped on an unconfirmed unmount, delete-runs on a confirmed one, relay dir cleared before recreation (local and Daytona), and mount-before-materialize on Daytona.
- `pnpm test` 589 passed; `pnpm run typecheck` clean. Session-liveness and heartbeat code was not touched.
