### PR TITLE
[fix] Delegate the agent service to the SDK composition seam

### DIFF
--- a/sdks/python/agenta/sdk/agents/handler.py
+++ b/sdks/python/agenta/sdk/agents/handler.py
@@ -1,7 +1,10 @@
 """``agent_v0``: the canonical agent handler, composition-injectable (specs.md `agent_v0`).
 
 Owns stream/trim/force; composition (template, tool/MCP/connection resolvers, backend
-selector) is injectable via `AgentComposition`, defaulting to env-driven SDK behavior.
+selector) is injectable via `AgentComposition`, defaulting to env-driven SDK behavior. The
+default composition also owns capability gating, degradation policy, and MCP gating:
+these are protocol-level safety behaviors, not service-specific, so a bare `agent_v0` (no
+composition override) gets them for free instead of a permissive fallback.
 """
 
 from __future__ import annotations
@@ -12,14 +15,25 @@ from typing import Any, Awaitable, Callable, Dict, List, Optional
 
 from agenta.sdk.agents.dtos import AgentTemplate, SessionConfig, to_messages
 from agenta.sdk.agents.interfaces import Backend, Environment
+from agenta.sdk.agents.capabilities import (
+    harness_allows_deployment,
+    harness_allows_mode,
+    harness_allows_provider,
+)
 from agenta.sdk.agents.connections import (
+    ConnectionResolutionError,
+    MissingProviderError,
     ModelRef,
     ResolvedConnection,
     RuntimeAuthContext,
+    UnsupportedConnectionModeError,
+    UnsupportedDeploymentError,
+    UnsupportedProviderError,
 )
 from agenta.sdk.agents.tools import ResolvedToolSet
 from agenta.sdk.agents.adapters import SandboxAgentBackend, make_harness
-from agenta.sdk.agents.mcp import ResolvedMCPServer
+from agenta.sdk.agents.mcp import MCPDisabledError, ResolvedMCPServer
+from agenta.sdk.agents.mcp.parsing import parse_mcp_server_configs
 from agenta.sdk.agents.platform import (
     resolve_connection as _platform_resolve_connection,
 )
@@ -32,12 +46,17 @@ from agenta.sdk.agents.tracing import (
     run_context as ambient_run_context,
     trace_context as ambient_trace_context,
 )
+from agenta.sdk.agents.dtos import RunContext, RunContextRun
 
 from agenta.sdk.engines.running.errors import ForceNotSupportedV0Error
 from agenta.sdk.models.workflows import (
     WorkflowInvokeRequestFlags,
     WorkflowServiceRequest,
 )
+from agenta.sdk.utils.constants import TRUTHY
+from agenta.sdk.utils.logging import get_module_logger
+
+log = get_module_logger(__name__)
 
 ResolveToolsFn = Callable[..., Awaitable[ResolvedToolSet]]
 ResolveMCPFn = Callable[..., Awaitable[List[ResolvedMCPServer]]]
@@ -66,14 +85,118 @@ async def _default_resolve_tools(tools, **kwargs) -> ResolvedToolSet:
     return await _platform_resolve_tools(tools, **kwargs)
 
 
+def _mcp_enabled() -> bool:
+    # MCP gating: off by default, deployment opts in via AGENTA_AGENT_MCPS_ENABLED.
+    return os.getenv("AGENTA_AGENT_MCPS_ENABLED", "").strip().lower() in TRUTHY
+
+
 async def _default_resolve_mcp_servers(
     mcp_servers, **kwargs
 ) -> List[ResolvedMCPServer]:
+    """Resolve MCP servers, gated by ``AGENTA_AGENT_MCPS_ENABLED`` (off by default).
+
+    Disabled + no servers declared -> ``[]`` (the common case, unchanged). Disabled + servers
+    declared -> :class:`MCPDisabledError`, so a caller's ignored MCP config fails loud instead
+    of silently running with none.
+    """
+    if not _mcp_enabled():
+        if not mcp_servers:
+            return []
+        names = [config.name for config in parse_mcp_server_configs(mcp_servers)]
+        raise MCPDisabledError(server_names=names)
     return await _platform_resolve_mcp(mcp_servers, **kwargs)
 
 
 async def _default_resolve_connection(*, model, context) -> ResolvedConnection:
     return await _platform_resolve_connection(model=model, context=context)
+
+
+def _check_harness_pre_resolve(model_ref: ModelRef, harness: Optional[str]) -> None:
+    """The PRE-resolve half of the agent-layer capability check (design Concern 3b).
+
+    The provider and connection mode are known from the config alone, so reject them before the
+    vault resolve runs. The vault resolve itself is harness-agnostic; this guard (and the
+    post-resolve deployment guard) is the only place the harness gates a credential, and it runs
+    server-side so a direct API caller is checked too. An unset harness skips the check.
+    """
+    if not harness:
+        return
+    provider = model_ref.provider
+    if provider and not harness_allows_provider(harness, provider):
+        raise UnsupportedProviderError(provider=provider, harness=harness)
+    mode = model_ref.connection.mode
+    if not harness_allows_mode(harness, mode):
+        raise UnsupportedConnectionModeError(mode=mode, harness=harness)
+
+
+def _check_harness_post_resolve(
+    resolved: ResolvedConnection, harness: Optional[str]
+) -> None:
+    """The POST-resolve half of the capability check: reject an unconsumable deployment.
+
+    A slug-less ``agenta`` connection only reveals its deployment once the vault selects the
+    secret, so the deployment reject runs after the resolve returns.
+    """
+    if not harness:
+        return
+    if not harness_allows_deployment(harness, resolved.deployment):
+        raise UnsupportedDeploymentError(
+            deployment=resolved.deployment, harness=harness
+        )
+
+
+async def _default_resolve_session_connection(
+    model_ref: ModelRef,
+    context: RuntimeAuthContext,
+    *,
+    resolve_connection: ResolveConnectionFn = _default_resolve_connection,
+) -> ResolvedConnection:
+    """Resolve one least-privilege connection for the run, with graceful degradation.
+
+    Provider + mode are rejected BEFORE the vault resolve (known from the config), the resolved
+    deployment is rejected AFTER (only known once the vault picks the secret).
+
+    An EXPLICIT named ``agenta`` connection (``slug`` set) fails loud on a resolution failure: the
+    user named a connection, so a missing/ambiguous one is a real error they must fix.
+
+    A project-default connection (``agenta`` with no slug) or a ``self_managed`` connection is
+    TOLERANT of a resolution failure: most projects have no configured connection for the default
+    model and rely on the harness's own login / a self-managed sidecar, so a failed resolve
+    (including a network/HTTP error) degrades to an empty ``runtime_provided`` plan and the run
+    still works. A capability reject is NEVER tolerated — it is a misconfiguration the user must
+    fix, not a missing credential.
+    """
+    _check_harness_pre_resolve(model_ref, context.harness)
+
+    connection = model_ref.connection
+    is_named = connection.mode == "agenta" and bool(
+        connection.slug and connection.slug.strip()
+    )
+    if is_named:
+        resolved = await resolve_connection(model=model_ref, context=context)
+        _check_harness_post_resolve(resolved, context.harness)
+        return resolved
+    try:
+        resolved = await resolve_connection(model=model_ref, context=context)
+    except MissingProviderError:
+        # A bare model id with no provider is an underspecified config, not a missing
+        # credential, so it fails loud even on a default connection.
+        raise
+    except ConnectionResolutionError:
+        log.warning(
+            "agent: no connection resolved for provider %r (mode=%s); "
+            "running with no injected credential (harness login / self-managed)",
+            model_ref.provider,
+            connection.mode,
+        )
+        return ResolvedConnection(
+            provider=model_ref.provider or "",
+            model=model_ref.model,
+            credential_mode="runtime_provided",
+            env={},
+        )
+    _check_harness_post_resolve(resolved, context.harness)
+    return resolved
 
 
 @dataclass
@@ -84,14 +207,20 @@ class AgentComposition:
     to the ambient runtime captures in ``agents/tracing.py``: they read SDK-owned per-request
     state (the active span, the ``TracingContext`` ContextVar) at CALL time and degrade to
     ``None``/no-op when a run has no such state, so a bare ``agent_v0`` behaves correctly in
-    any process without composition."""
+    any process without composition.
+
+    ``resolve_session_connection`` / ``resolve_mcp_servers`` default to the SAFE behavior
+    (capability-gated + degrading connection resolve; MCP-gated server resolve) rather than
+    a bare fallback, so a composition-free ``agent_v0`` is not the permissive copy."""
 
     default_template: DefaultTemplateFn = field(default=_default_template)
     resolve_tools: ResolveToolsFn = field(default=_default_resolve_tools)
     resolve_mcp_servers: ResolveMCPFn = field(default=_default_resolve_mcp_servers)
     resolve_connection: ResolveConnectionFn = field(default=_default_resolve_connection)
-    # override for capability gating (pre/post-resolve harness checks); bare resolve by default.
-    resolve_session_connection: Optional[ResolveSessionConnectionFn] = None
+    # capability gating + degradation policy; override to replace, not just add to.
+    resolve_session_connection: Optional[ResolveSessionConnectionFn] = field(
+        default=None
+    )
     select_backend: SelectBackendFn = field(default=_default_select_backend)
     trace_context: TraceContextFn = field(default=ambient_trace_context)
     run_context: RunContextFn = field(default=ambient_run_context)
@@ -139,11 +268,24 @@ def make_agent_handler(composition: Optional[AgentComposition] = None):
             ctx = RuntimeAuthContext(
                 harness=agent_template.harness, backend=agent_template.sandbox
             )
+            # Default is the gated+degrading resolve, bound to comp.resolve_connection
+            # so an override of the plain resolver still flows through the capability check.
             resolve_session_connection = comp.resolve_session_connection or (
-                lambda m, c: comp.resolve_connection(model=m, context=c)
+                lambda m, c: _default_resolve_session_connection(
+                    m, c, resolve_connection=comp.resolve_connection
+                )
             )
             resolved_connection = await resolve_session_connection(model_ref, ctx)
             secrets = resolved_connection.env
+
+        # run_kind rides the wire on `request.meta`: a wire-supplied run_kind must not
+        # be silently dropped, so it layers onto whatever run_context composition supplies.
+        # Copy before setting so a shared/cached RunContext can't leak run_kind across requests.
+        rc = comp.run_context()
+        run_kind = (request.meta or {}).get("run_kind")
+        if isinstance(run_kind, str) and run_kind:
+            base = rc or RunContext()
+            rc = base.model_copy(update={"run": RunContextRun(kind=run_kind)})
 
         session_config = SessionConfig(
             agent=agent_template,
@@ -151,7 +293,7 @@ def make_agent_handler(composition: Optional[AgentComposition] = None):
             resolved_connection=resolved_connection,
             permission_default=agent_template.permission_default,
             trace=comp.trace_context(),
-            run_context=comp.run_context(),
+            run_context=rc,
             session_id=session_id,
             builtin_names=resolved_tools.builtin_names,
             tool_specs=resolved_tools.tool_specs,

--- a/sdks/python/oss/tests/pytest/unit/agents/test_agent_composition_seam.py
+++ b/sdks/python/oss/tests/pytest/unit/agents/test_agent_composition_seam.py
@@ -1,0 +1,392 @@
+"""the unified composition seam (`agenta.sdk.agents.handler.AgentComposition` /
+`make_agent_handler`) owns the five drifts that used to differ between the SDK's bare
+default and the agent service's re-implementation. Each test below drives the seam
+directly (no HTTP routing -- that cube is covered by
+`test_invoke_real_handlers_negotiation_routing.py`) and proves the DEFAULT composition
+now carries the safe behavior, and that a composition can still override it.
+"""
+
+from __future__ import annotations
+
+from typing import Any, AsyncIterator, Dict, List, Optional
+
+import pytest
+
+from agenta.sdk.agents import AgentResult, HarnessType
+from agenta.sdk.agents.connections import (
+    ConnectionResolutionError,
+    ResolvedConnection,
+    UnsupportedDeploymentError,
+    UnsupportedProviderError,
+)
+from agenta.sdk.agents.handler import AgentComposition, make_agent_handler
+from agenta.sdk.agents.interfaces import Backend, Sandbox, Session
+from agenta.sdk.agents.mcp import MCPDisabledError
+from agenta.sdk.agents.streaming import AgentStream
+from agenta.sdk.models.workflows import WorkflowServiceRequest
+
+
+# --------------------------------------------------------------------------- #
+# Fakes (mirrors services/oss/tests/pytest/unit/agent/conftest.py's shape)
+# --------------------------------------------------------------------------- #
+class _FakeSandbox(Sandbox):
+    async def add_files(self, files) -> None:
+        return None
+
+    async def destroy(self) -> None:
+        return None
+
+
+class _FakeSession(Session):
+    def __init__(self, result: AgentResult) -> None:
+        self._result = result
+
+    @property
+    def id(self) -> Optional[str]:
+        return self._result.session_id
+
+    async def prompt(self, messages, *, on_event=None) -> AgentResult:
+        return self._result
+
+    def stream(self, messages) -> AgentStream:
+        result = self._result
+
+        async def _records() -> AsyncIterator[Dict[str, Any]]:
+            if result.events:
+                for event in result.events:
+                    yield {"kind": "event", "event": {"type": event.type, **event.data}}
+            elif result.output:
+                yield {
+                    "kind": "event",
+                    "event": {"type": "message", "text": result.output},
+                }
+            yield {
+                "kind": "result",
+                "result": {
+                    "ok": True,
+                    "output": result.output,
+                    "usage": result.usage,
+                    "sessionId": result.session_id,
+                },
+            }
+
+        return AgentStream(_records())
+
+    async def destroy(self) -> None:
+        return None
+
+
+class _FakeBackend(Backend):
+    supported_harnesses = frozenset(
+        {HarnessType.PI, HarnessType.CLAUDE, HarnessType.AGENTA}
+    )
+
+    def __init__(self, *, output: str = "hi") -> None:
+        self._output = output
+        self.created_run_contexts: List[Any] = []
+
+    async def create_sandbox(self) -> _FakeSandbox:
+        return _FakeSandbox()
+
+    async def create_session(
+        self,
+        sandbox,
+        config,
+        *,
+        harness,
+        secrets=None,
+        trace=None,
+        run_context=None,
+        session_id=None,
+    ) -> _FakeSession:
+        self.created_run_contexts.append(run_context)
+        return _FakeSession(AgentResult(output=self._output, events=[], usage={}))
+
+
+def _no_connection_result() -> ResolvedConnection:
+    return ResolvedConnection(
+        provider="openai", model="m", credential_mode="runtime_provided", env={}
+    )
+
+
+async def _no_connection(*, model, context) -> ResolvedConnection:
+    return _no_connection_result()
+
+
+def _request(*, meta=None) -> WorkflowServiceRequest:
+    return WorkflowServiceRequest(meta=meta)
+
+
+def _params(harness="pi_core", *, model=None):
+    template: Dict[str, Any] = {"harness": {"kind": harness}}
+    if model is not None:
+        template["llm"] = model
+    return {"agent": template}
+
+
+# --------------------------------------------------------------------------- #
+# Drift 4: run_kind from `request.meta` must reach RunContext (not silently dropped)
+# --------------------------------------------------------------------------- #
+async def test_run_kind_from_wire_reaches_run_context():
+    backend = _FakeBackend()
+    comp = AgentComposition(
+        select_backend=lambda template: backend,
+        resolve_connection=_no_connection,
+    )
+    handler = make_agent_handler(comp)
+
+    await handler(
+        request=_request(meta={"run_kind": "eval"}),
+        messages=[{"role": "user", "content": "hi"}],
+        parameters=_params(),
+    )
+
+    ctx = backend.created_run_contexts[0]
+    assert ctx is not None
+    assert ctx.to_wire() == {"run": {"kind": "eval"}}
+
+
+async def test_absent_run_kind_leaves_composition_run_context_untouched():
+    from agenta.sdk.agents.dtos import RunContext, RunContextTrace
+
+    backend = _FakeBackend()
+    base = RunContext(trace=RunContextTrace(trace_id="trace-1"))
+    comp = AgentComposition(
+        select_backend=lambda template: backend,
+        resolve_connection=_no_connection,
+        run_context=lambda: base,
+    )
+    handler = make_agent_handler(comp)
+
+    await handler(
+        request=_request(meta={}),
+        messages=[{"role": "user", "content": "hi"}],
+        parameters=_params(),
+    )
+
+    ctx = backend.created_run_contexts[0]
+    assert ctx is base
+    assert ctx.to_wire() == {"trace": {"trace_id": "trace-1"}}
+
+
+# --------------------------------------------------------------------------- #
+# Drift 1 + 2: capability gating and degradation policy are the SEAM DEFAULT now
+# (previously a bare fallback in handler.py with neither).
+# --------------------------------------------------------------------------- #
+async def test_default_composition_rejects_unsupported_provider_pre_resolve():
+    """Claude + a non-anthropic provider must fail loud even with NO composition override."""
+    backend = _FakeBackend()
+
+    async def _must_not_run(*, model, context):
+        raise AssertionError("vault resolve must not run on a pre-resolve reject")
+
+    comp = AgentComposition(
+        select_backend=lambda template: backend,
+        resolve_connection=_must_not_run,
+    )
+    handler = make_agent_handler(comp)
+
+    with pytest.raises(UnsupportedProviderError):
+        await handler(
+            request=_request(),
+            messages=[{"role": "user", "content": "hi"}],
+            parameters=_params(
+                "claude", model={"provider": "openai", "model": "gpt-5.5"}
+            ),
+        )
+
+
+async def test_default_composition_rejects_unconsumable_deployment_post_resolve():
+    """Pi resolving to bedrock must fail loud even with NO composition override."""
+    backend = _FakeBackend()
+
+    async def _resolve(*, model, context):
+        return ResolvedConnection(
+            provider="anthropic",
+            model="anthropic.claude-x",
+            deployment="bedrock",
+            credential_mode="env",
+            env={"AWS_ACCESS_KEY_ID": "AKIA"},
+        )
+
+    comp = AgentComposition(
+        select_backend=lambda template: backend,
+        resolve_connection=_resolve,
+    )
+    handler = make_agent_handler(comp)
+
+    with pytest.raises(UnsupportedDeploymentError):
+        await handler(
+            request=_request(),
+            messages=[{"role": "user", "content": "hi"}],
+            parameters=_params(
+                "pi_core",
+                model={"provider": "anthropic", "model": "anthropic.claude-x"},
+            ),
+        )
+
+
+async def test_default_composition_degrades_default_connection_failure():
+    """An unconfigured default-mode connection degrades to runtime_provided, no raise --
+    even with NO composition override (the SDK default now has the degradation policy
+    the old bare fallback lacked)."""
+    backend = _FakeBackend(output="echo")
+
+    async def _resolve(*, model, context):
+        raise ConnectionResolutionError("network unreachable")
+
+    comp = AgentComposition(
+        select_backend=lambda template: backend,
+        resolve_connection=_resolve,
+    )
+    handler = make_agent_handler(comp)
+
+    result = await handler(
+        request=_request(),
+        messages=[{"role": "user", "content": "hi"}],
+        parameters=_params("pi_core", model={"provider": "openai", "model": "gpt-5.5"}),
+    )
+
+    assert result == {"messages": [{"role": "assistant", "content": "echo"}]}
+
+
+async def test_composition_override_replaces_default_gating():
+    """A composition MAY still fully replace resolve_session_connection (bare passthrough),
+    proving the seam stays injectable rather than hardcoding the gate."""
+    backend = _FakeBackend()
+    calls = []
+
+    async def _bare(model_ref, context):
+        calls.append((model_ref, context))
+        return _no_connection_result()
+
+    comp = AgentComposition(
+        select_backend=lambda template: backend,
+        resolve_session_connection=_bare,
+    )
+    handler = make_agent_handler(comp)
+
+    # Claude + openai would be rejected by the default gate; the override bypasses it.
+    await handler(
+        request=_request(),
+        messages=[{"role": "user", "content": "hi"}],
+        parameters=_params("claude", model={"provider": "openai", "model": "gpt-5.5"}),
+    )
+
+    assert len(calls) == 1
+
+
+# --------------------------------------------------------------------------- #
+# Drift 3: MCP gating is the seam DEFAULT now (previously ungated in handler.py).
+# --------------------------------------------------------------------------- #
+async def test_default_composition_mcp_disabled_with_no_servers_is_empty(monkeypatch):
+    from agenta.sdk.agents import handler as handler_module
+
+    monkeypatch.delenv("AGENTA_AGENT_MCPS_ENABLED", raising=False)
+    backend = _FakeBackend()
+    comp = AgentComposition(
+        select_backend=lambda template: backend,
+        resolve_connection=_no_connection,
+    )
+    handler = make_agent_handler(comp)
+
+    result = await handler(
+        request=_request(),
+        messages=[{"role": "user", "content": "hi"}],
+        parameters=_params(),
+    )
+    assert isinstance(result, dict)
+    assert handler_module._mcp_enabled() is False
+
+
+async def test_default_composition_mcp_disabled_with_servers_fails_loud(monkeypatch):
+    monkeypatch.delenv("AGENTA_AGENT_MCPS_ENABLED", raising=False)
+    backend = _FakeBackend()
+    comp = AgentComposition(
+        select_backend=lambda template: backend,
+        resolve_connection=_no_connection,
+    )
+    handler = make_agent_handler(comp)
+
+    params = _params()
+    params["agent"]["mcps"] = [{"name": "github", "command": "npx"}]
+
+    with pytest.raises(MCPDisabledError) as excinfo:
+        await handler(
+            request=_request(),
+            messages=[{"role": "user", "content": "hi"}],
+            parameters=params,
+        )
+    assert "github" in str(excinfo.value)
+
+
+async def test_default_composition_mcp_enabled_resolves_servers(monkeypatch):
+    from agenta.sdk.agents import handler as handler_module
+
+    monkeypatch.setenv("AGENTA_AGENT_MCPS_ENABLED", "true")
+    assert handler_module._mcp_enabled() is True
+
+
+# --------------------------------------------------------------------------- #
+# Drift 5: backend/template defaults are per-composition (deployment-specific),
+# proving the seam is request/composition-aware rather than hardcoding one source.
+# --------------------------------------------------------------------------- #
+async def test_composition_default_template_overrides_bare_sdk_default():
+    from agenta.sdk.agents.dtos import AgentTemplate
+
+    backend = _FakeBackend(output="echo")
+    seen_templates = []
+
+    def _select_backend(template):
+        seen_templates.append(template)
+        return backend
+
+    comp = AgentComposition(
+        default_template=lambda: AgentTemplate(
+            instructions="deployment-specific", model="openai/gpt-5.5"
+        ),
+        select_backend=_select_backend,
+        resolve_connection=_no_connection,
+    )
+    handler = make_agent_handler(comp)
+
+    await handler(
+        request=_request(),
+        messages=[{"role": "user", "content": "hi"}],
+        parameters=None,
+    )
+
+    assert seen_templates[0].instructions == "deployment-specific"
+    assert seen_templates[0].model == "openai/gpt-5.5"
+
+
+async def test_composition_select_backend_is_deployment_specific():
+    """`select_backend` is a per-composition field; two compositions can pick different
+    backends for the identical template, proving the seam does not hardcode one source."""
+    backend_a = _FakeBackend(output="a")
+    backend_b = _FakeBackend(output="b")
+
+    comp_a = AgentComposition(
+        select_backend=lambda template: backend_a, resolve_connection=_no_connection
+    )
+    comp_b = AgentComposition(
+        select_backend=lambda template: backend_b, resolve_connection=_no_connection
+    )
+
+    result_a = await make_agent_handler(comp_a)(
+        request=_request(),
+        messages=[{"role": "user", "content": "hi"}],
+        parameters=_params(),
+    )
+    result_b = await make_agent_handler(comp_b)(
+        request=_request(),
+        messages=[{"role": "user", "content": "hi"}],
+        parameters=_params(),
+    )
+
+    assert result_a["messages"][0]["content"] == "a"
+    assert result_b["messages"][0]["content"] == "b"
+
+
+if __name__ == "__main__":
+    pytest.main([__file__, "-q"])

--- a/services/oss/src/agent/app.py
+++ b/services/oss/src/agent/app.py
@@ -2,8 +2,10 @@
 
 Mirrors the chat/completion services: an Agenta app exposing ``/invoke`` and ``/inspect``
 through ``ag.create_app`` + ``ag.workflow`` + ``ag.route``. Supplies service-specific
-composition (template, tool resolver, secret provider) over
-``agenta.sdk.agents.handler``, which owns the stream/batch/fold/trim/force contract.
+composition (on-file template default, sandbox-agent backend selection, MCP gate) over
+``agenta.sdk.agents.handler.AgentComposition``, which owns the stream/batch/fold/trim/force
+contract AND the capability-gating / degradation-policy / run_kind orchestration (this
+used to be re-implemented here; the service now builds one composition and delegates).
 
 The sandbox-agent-backed backend is the production path. The transport is a deployment
 choice: HTTP to `AGENTA_RUNNER_INTERNAL_URL`, or a local runner CLI in a source checkout.
@@ -17,41 +19,21 @@ import agenta as ag
 from agenta.sdk.agents import (
     AgentTemplate,
     Backend,
-    ConnectionResolutionError,
-    Environment,
-    MissingProviderError,
-    ModelRef,
-    ResolvedConnection,
-    RunContext,
-    RunContextRun,
-    RuntimeAuthContext,
     SandboxAgentBackend,
-    SessionConfig,
-    make_harness,
-    to_messages,
-)
-from agenta.sdk.agents.capabilities import (
-    harness_allows_deployment,
-    harness_allows_mode,
-    harness_allows_provider,
-)
-from agenta.sdk.agents.connections import (
-    UnsupportedConnectionModeError,
-    UnsupportedDeploymentError,
-    UnsupportedProviderError,
 )
 
-from agenta.sdk.agents.handler import agent_batch, agent_event_stream
+from agenta.sdk.agents.handler import (
+    AgentComposition,
+    make_agent_handler,
+)
 from agenta.sdk.agents.platform import resolve_connection
 
 from agenta.sdk.decorators.tracing import auto_instrument
-from agenta.sdk.engines.running.errors import ForceNotSupportedV0Error
 from agenta.sdk.engines.running.utils import (
     register_handler,
     register_interface,
 )
 from agenta.sdk.models.workflows import (
-    WorkflowInvokeRequestFlags,
     WorkflowRevisionData,
     WorkflowServiceRequest,
 )
@@ -77,121 +59,6 @@ def _default_agent_template() -> AgentTemplate:
     )
 
 
-def _agent_model_ref(agent_template: AgentTemplate) -> Optional[ModelRef]:
-    """The structured model ref for the run, or ``None`` when no model is configured.
-
-    Prefer the parsed ``model_ref`` (populated only when the config's ``model`` arrived as a
-    dict/object carrying a connection); otherwise coerce the back-compat plain ``model`` string.
-    ``None`` means no model at all, in which case the harness uses its own default/login and no
-    connection is resolved.
-    """
-    if agent_template.model_ref is not None:
-        return agent_template.model_ref
-    if isinstance(agent_template.model, str) and agent_template.model.strip():
-        return ModelRef.coerce(agent_template.model)
-    return None
-
-
-def _check_harness_pre_resolve(model_ref: ModelRef, harness: Optional[str]) -> None:
-    """The PRE-resolve half of the agent-layer capability check (design Concern 3b).
-
-    The provider and connection mode are known from the config alone, so reject them before the
-    vault resolve runs. The vault resolve itself is harness-agnostic; this guard (and the
-    post-resolve deployment guard) is the only place the harness gates a credential, and it is
-    server-side so a direct API caller is checked too. An unset harness skips the check.
-    """
-    if not harness:
-        return
-    provider = model_ref.provider
-    if provider and not harness_allows_provider(harness, provider):
-        raise UnsupportedProviderError(provider=provider, harness=harness)
-    mode = model_ref.connection.mode
-    if not harness_allows_mode(harness, mode):
-        raise UnsupportedConnectionModeError(mode=mode, harness=harness)
-
-
-def _check_harness_post_resolve(
-    resolved: ResolvedConnection, harness: Optional[str]
-) -> None:
-    """The POST-resolve half of the capability check: reject an unconsumable deployment.
-
-    A slug-less ``agenta`` connection only reveals its deployment once the vault selects the
-    secret, so the deployment reject runs after the resolve returns (e.g. Claude resolving to
-    ``bedrock`` fails loud here; a Pi run resolving to a cloud deployment fails loud the same
-    way, since Pi cloud consumption stages with model-config in v1).
-    """
-    if not harness:
-        return
-    if not harness_allows_deployment(harness, resolved.deployment):
-        raise UnsupportedDeploymentError(
-            deployment=resolved.deployment, harness=harness
-        )
-
-
-async def _resolve_session_connection(
-    model_ref: ModelRef,
-    context: RuntimeAuthContext,
-) -> ResolvedConnection:
-    """Resolve exactly one least-privilege connection for the run, with graceful degradation.
-
-    The agent-layer capability check is split around the vault resolve: provider + mode are
-    rejected BEFORE the resolve (known from the config), the resolved deployment is rejected
-    AFTER (only known once the vault picks the secret). Both run here, against the SDK capability
-    table; the vault resolve stays harness-agnostic.
-
-    An EXPLICIT named ``agenta`` connection (``slug`` set) fails loud on a resolution failure: the
-    user named a connection, so a missing/ambiguous one is a real error they must fix.
-
-    A project-default connection (``agenta`` with no slug, the common unconfigured case the
-    playground hits on every run) or a ``self_managed`` connection is TOLERANT of a resolution
-    failure: most projects have no configured connection for the default model and rely on the
-    harness's own login / a self-managed sidecar. There a failed resolve (including a network/HTTP
-    error) degrades to an empty ``runtime_provided`` plan so the run still works, exactly as the
-    old whole-vault dump returned ``{}`` and the run proceeded. (A capability reject is NOT
-    tolerated — it is a misconfiguration the user must fix, not a missing credential.)
-
-    The tolerant default is intentional: the model-config staged rollout says NOT to flip
-    strict-fail on by default. When model-config lands its ``AGENTA_AGENT_MODEL_STRICT`` flag, a
-    default-connection resolution failure becomes fail-loud too; that flag is owned by
-    model-config, so no flag is added here.
-    """
-    # PRE-resolve capability reject (fail loud regardless of mode; not a missing-credential case).
-    _check_harness_pre_resolve(model_ref, context.harness)
-
-    connection = model_ref.connection
-    is_named = connection.mode == "agenta" and bool(
-        connection.slug and connection.slug.strip()
-    )
-    if is_named:
-        # Named connection: propagate ConnectionNotFoundError / AmbiguousConnectionError / any
-        # ConnectionResolutionError so the user sees the misconfiguration.
-        resolved = await resolve_connection(model=model_ref, context=context)
-        _check_harness_post_resolve(resolved, context.harness)
-        return resolved
-    try:
-        resolved = await resolve_connection(model=model_ref, context=context)
-    except MissingProviderError:
-        # A bare model id with no provider is an underspecified config, not a missing
-        # credential, so it fails loud even on a default connection (the user sees the clear
-        # "needs a provider prefix" message instead of a misleading "add your key" auth error).
-        raise
-    except ConnectionResolutionError:
-        log.warning(
-            "agent: no connection resolved for provider %r (mode=%s); "
-            "running with no injected credential (harness login / self-managed)",
-            model_ref.provider,
-            connection.mode,
-        )
-        return ResolvedConnection(
-            provider=model_ref.provider or "",
-            model=model_ref.model,
-            credential_mode="runtime_provided",
-            env={},
-        )
-    _check_harness_post_resolve(resolved, context.harness)
-    return resolved
-
-
 def select_backend(agent_template: AgentTemplate) -> Backend:
     """Pick the backend for a run from the agent config's run-selection fields.
 
@@ -207,83 +74,39 @@ def select_backend(agent_template: AgentTemplate) -> Backend:
     )
 
 
+def _composition() -> AgentComposition:
+    """Build the service's `AgentComposition` from the current (patchable) module names.
+
+    Built fresh per call so `monkeypatch.setattr(app, "resolve_tools", ...)`-style test
+    patches on this module keep working exactly as before the seam was unified: every
+    field below is a live lookup of a module-level name, not a value captured at import time.
+    """
+    return AgentComposition(
+        default_template=_default_agent_template,
+        resolve_tools=resolve_tools,
+        resolve_mcp_servers=resolve_mcp_servers,
+        resolve_connection=resolve_connection,
+        select_backend=select_backend,
+        trace_context=trace_context,
+        run_context=run_context,
+        record_usage=record_usage,
+    )
+
+
 async def _agent(
     request: WorkflowServiceRequest,
     inputs: Optional[Dict[str, Any]] = None,
     messages: Optional[List[Any]] = None,
     parameters: Optional[Dict] = None,
 ):
-    """Service composition over `agenta.sdk.agents.handler`'s stream/batch/fold/trim/force."""
-    flags = WorkflowInvokeRequestFlags(**(request.flags or {}))
-    if flags.force:
-        raise ForceNotSupportedV0Error()
-    # session_id is resolved (echoed/minted) by the normalizer onto the request.
-    session_id = request.session_id
+    """Service entrypoint: delegate to the SDK seam with the service's composition.
 
-    params = parameters or {}
-
-    agent_template = AgentTemplate.from_params(
-        params, defaults=_default_agent_template()
-    )
-
-    msgs = to_messages(messages or (inputs or {}).get("messages") or [])
-    # Three independent resolutions (tools, MCP, the model's one connection), not one aggregate:
-    # the boundary resolves; the backend later decides how each tool executes.
-    resolved_tools = await resolve_tools(agent_template.tools)
-    resolved_mcp = await resolve_mcp_servers(agent_template.mcp_servers)
-
-    # One least-privilege connection for the configured model. The connection rides the template
-    # (inside `parameters.agent` -> `agent.llm.connection`); there is no new request field and no
-    # project id from the body. project_id is filled server-side from the caller's auth on the
-    # resolve call, so the client-side context leaves it None.
-    model_ref = _agent_model_ref(agent_template)
-    resolved_connection: Optional[ResolvedConnection] = None
-    secrets: Dict[str, str] = {}
-    if model_ref is not None:
-        ctx = RuntimeAuthContext(
-            harness=agent_template.harness, backend=agent_template.sandbox
-        )
-        resolved_connection = await _resolve_session_connection(model_ref, ctx)
-        secrets = resolved_connection.env
-
-    rc = run_context()
-    run_kind = (request.meta or {}).get("run_kind")
-    if isinstance(run_kind, str) and run_kind:
-        rc = rc or RunContext()
-        rc.run = RunContextRun(kind=run_kind)
-
-    session_config = SessionConfig(
-        agent=agent_template,
-        secrets=secrets,  # the env compat alias the wire still reads
-        resolved_connection=resolved_connection,
-        permission_default=agent_template.permission_default,
-        trace=trace_context(),
-        # The run's own context (run kind, trace, and workflow identity), refreshed each turn
-        # and consumed by tool context bindings at dispatch. The conversation id is threaded
-        # separately as `session_id` below, not duplicated in here.
-        run_context=rc,
-        session_id=session_id,
-        builtin_names=resolved_tools.builtin_names,
-        tool_specs=resolved_tools.tool_specs,
-        tool_callback=resolved_tools.tool_callback,
-        mcp_servers=resolved_mcp,
-    )
-
-    # The harness validates that the chosen backend can drive it. An unknown harness value fails
-    # here instead of silently changing runtime behavior. The sandbox-agent backend supports all
-    # three harnesses (pi_core, pi_agenta, claude). setup/cleanup own the backend lifecycle;
-    # prompt/stream run one cold turn.
-    harness = make_harness(
-        agent_template.harness, Environment(select_backend(agent_template))
-    )
-
-    # stream -> event stream; batch -> fold(stream), trimmed when asked.
-    if flags.stream:
-        return agent_event_stream(
-            harness, session_config, msgs, record_usage=record_usage
-        )
-    return await agent_batch(
-        harness, session_config, msgs, trim=flags.trim, record_usage=record_usage
+    A fresh handler is built per call (cheap: composition is dataclass field assignment) so
+    the module-level names above stay the patch points every existing test uses.
+    """
+    handler = make_agent_handler(_composition())
+    return await handler(
+        request=request, inputs=inputs, messages=messages, parameters=parameters
     )
 
 

--- a/services/oss/tests/pytest/unit/agent/test_invoke_handler.py
+++ b/services/oss/tests/pytest/unit/agent/test_invoke_handler.py
@@ -367,12 +367,15 @@ def _patch_resolution(monkeypatch, backend, *, resolve):
     can inspect the ``ModelRef`` / ``RuntimeAuthContext`` it was called with.
 
     Returns a list that captures every ``SessionConfig`` the handler builds, so a test can
-    assert the resolved connection (and its env) was threaded onto the session. ``resolved_connection``
-    rides the ``SessionConfig``, not the harness-shaped config the backend records, so capturing it
-    here is the honest observable.
+    assert the resolved connection (and its env) was threaded onto the session.
+    ``_agent`` now delegates to the SDK seam (`agenta.sdk.agents.handler`), which is where
+    ``SessionConfig(...)`` is actually constructed, so the capture patches ``SessionConfig``
+    there rather than on this module.
     """
+    from agenta.sdk.agents import handler as sdk_handler
+
     built: list = []
-    real_session_config = app.SessionConfig
+    real_session_config = sdk_handler.SessionConfig
 
     def _capturing_session_config(**kwargs):
         cfg = real_session_config(**kwargs)
@@ -385,7 +388,7 @@ def _patch_resolution(monkeypatch, backend, *, resolve):
     async def _no_mcp(mcp_servers, **_kw):
         return []
 
-    monkeypatch.setattr(app, "SessionConfig", _capturing_session_config)
+    monkeypatch.setattr(sdk_handler, "SessionConfig", _capturing_session_config)
     monkeypatch.setattr(app, "resolve_tools", _tools)
     monkeypatch.setattr(app, "resolve_mcp_servers", _no_mcp)
     monkeypatch.setattr(app, "resolve_connection", resolve)


### PR DESCRIPTION
## Context

The agent service re-implemented the SDK's own composition orchestration. Both copies served the same public URI (the builtin `agent_v0` handler), and they had drifted in five behaviors: capability gating, degradation policy, MCP gating, `run_kind` extraction from the wire, and backend/template defaults. Which copy ran silently changed behavior. A bare `agent_v0` used without the service got the permissive fallback, not the gated one.

## Changes

The service now builds a single `AgentComposition` from its own (patchable) resolver functions and delegates to `make_agent_handler(composition)`. The duplicated orchestration body in `app.py` is deleted, and the safe behavior is promoted to the SDK default.

This is a consolidation, not new logic. `app.py` is net smaller (about 160 fewer lines); the capability-gating and degradation functions move into `handler.py` intact rather than being reinvented. The service keeps its module-level resolver names, so every existing test patches the same seams.

Per-drift resolution:
- Capability gating, degradation policy, MCP gating: the service's gated/degrading behavior wins and becomes the SDK default, so a composition-free `agent_v0` is no longer the permissive copy.
- `run_kind` from `request.meta`: now read by the seam itself; a wire-supplied `run_kind` is no longer dropped.
- Backend/template defaults: kept service-owned (genuinely deployment-specific), injected via the composition rather than reimplemented.

## Tests / notes

- New `test_agent_composition_seam.py`: 11 tests, at least one per drift area, driving the seam directly.
- Services agent unit suite: 77 passed, unchanged count (the tell that behavior did not shift while moving). SDK agents suite green apart from 3 failures verified pre-existing on the branch point. `ruff` clean.
- Reviewer note: the one behavioral change to weigh is that a bare `agent_v0` used by any other caller is now gated rather than permissive. That is the intended fix.
