### PR TITLE
[fix] Drain subprocess stderr so a chatty child cannot deadlock as a timeout

### DIFF
--- a/sdks/python/agenta/sdk/agents/utils/ts_runner.py
+++ b/sdks/python/agenta/sdk/agents/utils/ts_runner.py
@@ -196,6 +196,19 @@ async def deliver_http_stream(
         raise RuntimeError("Agent runner stream ended without a terminal result record")
 
 
+_STDERR_TAIL_BYTES = 2000
+
+
+async def _drain_stderr(stream: asyncio.StreamReader) -> bytes:
+    """Read stderr to EOF as it arrives so a full pipe never blocks the child; keep only the tail."""
+    tail = b""
+    while True:
+        chunk = await stream.read(65536)
+        if not chunk:
+            return tail
+        tail = (tail + chunk)[-_STDERR_TAIL_BYTES:]
+
+
 async def deliver_subprocess_stream(
     command: Sequence[str],
     payload: Dict[str, Any],
@@ -218,10 +231,15 @@ async def deliver_subprocess_stream(
         stdout=asyncio.subprocess.PIPE,
         stderr=asyncio.subprocess.PIPE,
     )
-    assert proc.stdin is not None and proc.stdout is not None
+    assert (
+        proc.stdin is not None and proc.stdout is not None and proc.stderr is not None
+    )
     proc.stdin.write(json.dumps(payload).encode("utf-8"))
     proc.stdin.close()
-    loop = asyncio.get_event_loop()
+    # Drain stderr concurrently (mirrors communicate()'s sibling behavior) so a chatty child
+    # never blocks on a full pipe while we're only reading stdout below.
+    stderr_task = asyncio.create_task(_drain_stderr(proc.stderr))
+    loop = asyncio.get_running_loop()
     deadline = loop.time() + timeout
     saw_result = False
     try:
@@ -244,15 +262,18 @@ async def deliver_subprocess_stream(
         # A clean drain that never produced a terminal result means the runner exited or
         # disconnected early; fail loud rather than leaving the consumer without a result.
         if not saw_result:
-            err = b""
-            if proc.stderr is not None:
-                err = await proc.stderr.read()
+            err = await stderr_task
             raise _transport_error(
                 "Agent runner stream ended without a terminal result record",
                 detail=f"exit={proc.returncode} "
-                f"stderr={err.decode('utf-8', 'replace')[-2000:]}",
+                f"stderr={err.decode('utf-8', 'replace')[-_STDERR_TAIL_BYTES:]}",
             )
     finally:
         if proc.returncode is None:
             proc.kill()
             await proc.wait()
+        if not stderr_task.done():
+            stderr_task.cancel()
+        # Await the drain task so an early consumer break doesn't leave it pending or drop
+        # its exception ("Task exception was never retrieved").
+        await asyncio.gather(stderr_task, return_exceptions=True)

--- a/sdks/python/oss/tests/pytest/integration/agents/test_transport_roundtrip.py
+++ b/sdks/python/oss/tests/pytest/integration/agents/test_transport_roundtrip.py
@@ -9,6 +9,7 @@ serialization or transport drift that per-side unit tests cannot, with no TS and
 
 from __future__ import annotations
 
+import asyncio
 import json
 import sys
 
@@ -22,6 +23,7 @@ from agenta.sdk.agents import (
     SessionConfig,
 )
 from agenta.sdk.agents.skills import SkillTemplate
+from agenta.sdk.agents.utils.ts_runner import deliver_subprocess_stream
 
 from ._fake_runner_backend import FakeRunnerBackend
 
@@ -75,6 +77,32 @@ sys.stdout.write(json.dumps({"ok": False, "error": "model exploded"}))
 _SILENT_RUNNER = """
 import sys, json
 json.load(sys.stdin)
+"""
+
+# Writes well past the OS pipe buffer (~64 KB) and asyncio's internal StreamReader pause
+# threshold (128 KB) to stderr before emitting the NDJSON result on stdout, so an undrained
+# stderr genuinely blocks the child's write() -- proving the streaming transport drains it.
+_NOISY_STDERR_RUNNER = """
+import sys, json
+
+json.load(sys.stdin)
+sys.stderr.write("x" * 5_000_000)
+sys.stderr.flush()
+out = {
+    "kind": "result",
+    "result": {
+        "ok": True,
+        "output": "done",
+        "messages": [{"role": "assistant", "content": "done"}],
+        "events": [{"type": "done", "stopReason": "end_turn"}],
+        "usage": {"input": 1, "output": 1, "total": 2, "cost": 0.0},
+        "stopReason": "end_turn",
+        "sessionId": "sess-fake",
+        "model": None,
+    },
+}
+sys.stdout.write(json.dumps(out) + "\\n")
+sys.stdout.flush()
 """
 
 # Reads the /run request and echoes back the `skills` it received in the result `output`, as
@@ -135,6 +163,25 @@ async def test_runner_empty_output_raises(tmp_path):
 
     with pytest.raises(RuntimeError, match="no output"):
         await harness.prompt(config, [Message(role="user", content="hi")])
+
+
+async def test_stream_drains_stderr_without_deadlock_or_fake_timeout(tmp_path):
+    # a child that fills the ~64 KB stderr pipe while streaming stdout must
+    # not block forever and must not surface as a timeout once it finishes.
+    runner = tmp_path / "noisy_runner.py"
+    runner.write_text(_NOISY_STDERR_RUNNER, encoding="utf-8")
+    command = [sys.executable, str(runner)]
+
+    records = []
+    coro = deliver_subprocess_stream(
+        command, {"harness": "pi_core"}, cwd=str(tmp_path), timeout=5.0
+    )
+    async with asyncio.timeout(5.0):
+        async for record in coro:
+            records.append(record)
+
+    assert [r["kind"] for r in records] == ["result"]
+    assert records[0]["result"]["ok"] is True
 
 
 async def test_resolved_skill_reaches_the_runner_over_the_wire(tmp_path):


### PR DESCRIPTION
## Context

The streaming subprocess transport in the SDK piped the child's stderr and never read it. The read loop only consumed stdout. Once the child wrote enough to stderr to fill the OS pipe (and asyncio's internal buffer past its pause threshold), the child blocked on `write()` and could never finish. The run hung and surfaced as a timeout, with the diagnostic stderr lost. The one-shot sibling path does not have this problem because it uses `proc.communicate()`, which drains both pipes.

## Changes

The streaming path now drains stderr concurrently: a background task reads stderr to EOF (keeping the last chunk for diagnostics on failure), spawned right after stdin is closed and awaited in the failure branch. This mirrors the sibling `communicate()` behavior, so a chatty child never blocks on a full stderr pipe.

`DEVNULL` was considered and rejected: the failure branch already surfaces a stderr tail as the diagnostic, which `DEVNULL` would drop.

## Tests / notes

- New integration test: a child that writes several megabytes to stderr while streaming stdout completes instead of deadlocking, and does not surface as a timeout. Verified the test reproduces the deadlock pre-fix (the earlier "64 KB" framing is imprecise; asyncio buffers to about 128 KB before the child blocks, so the test writes 5 MB to reliably trigger it).
- `pytest` for the transport suites green; `ruff` clean.
