### PR TITLE
[fix] Keep the platform bearer out of the harness-readable environment

### DIFF
--- a/services/runner/src/engines/sandbox_agent.ts
+++ b/services/runner/src/engines/sandbox_agent.ts
@@ -78,6 +78,7 @@ import { findSwallowedPiError } from "./sandbox_agent/pi-error.ts";
 import {
   buildPiExtensionEnv,
   prepareLocalPiAssets,
+  writeOtlpAuthFile,
 } from "./sandbox_agent/pi-assets.ts";
 import {
   decide,
@@ -383,10 +384,21 @@ export async function runSandboxAgent(
   // Pi self-instruments locally: propagate the trace context + public tool metadata into Pi
   // via the Agenta extension. Tool execution always relays back to this runner, which keeps
   // private specs, scoped env, callback endpoints, and callback auth in memory.
+  // local Pi's OTLP bearer rides a runner-written 0600 file, never a plain env var —
+  // Daytona never receives telemetry env here at all (`!plan.isDaytona` gates it off above).
+  const otlpAuthFilePath =
+    plan.isPi && !plan.isDaytona
+      ? `${plan.relayDir}.otlp-auth`
+      : undefined;
+  const otlpAuthorization = request.telemetry?.exporters?.otlp?.headers?.authorization;
+  if (otlpAuthFilePath && otlpAuthorization) {
+    writeOtlpAuthFile(otlpAuthFilePath, otlpAuthorization, logger);
+  }
   const piExtEnv = plan.isPi
     ? buildPiExtensionEnv(request, !plan.isDaytona, {
         relayDir: plan.relayDir,
         usageOutPath: plan.usageOutPath,
+        otlpAuthFilePath,
         builtinGatingActive: plan.builtinGatingActive,
         builtinGrants: plan.builtinGrants,
         // The materialized skill names (author + forced `_agenta.*`) so Pi's own agent span
@@ -1014,6 +1026,9 @@ export async function runSandboxAgent(
     await workspace?.cleanup().catch(() => {});
     // The per-run Agenta agent dir (skills isolation) is throwaway; remove it too.
     if (runAgentDir) rmSync(runAgentDir, { recursive: true, force: true });
+    // Backstop: the extension deletes this on read; remove it here too in case the harness
+    // never started (or crashed before reading it), so the bearer never lingers.
+    if (otlpAuthFilePath) rmSync(otlpAuthFilePath, { force: true });
     // Remove the per-run skills temp root the materializer created (success or error).
     plan.skillsCleanup();
   }

--- a/services/runner/src/engines/sandbox_agent/pi-assets.ts
+++ b/services/runner/src/engines/sandbox_agent/pi-assets.ts
@@ -29,6 +29,12 @@ export const EXTENSION_BUNDLE =
 /**
  * Env the Agenta Pi extension reads. Tool env contains only public metadata plus the
  * relay directory; private specs/auth stay in the runner.
+ *
+ * The OTLP bearer is deliberately NOT placed in `OTEL_EXPORTER_OTLP_HEADERS` (or any other
+ * plain env var): that env is inherited by the harness process, so a prompt-injected sandbox
+ * could read/echo the caller's reusable Authorization bearer and impersonate the caller. It
+ * rides a runner-written 0600 read-once file whose PATH is the only thing env carries
+ * (`opts.otlpAuthFilePath` -> `AGENTA_AGENT_OTLP_AUTH_FILE`, see `writeOtlpAuthFile`).
  */
 export function buildPiExtensionEnv(
   request: AgentRunRequest,
@@ -36,6 +42,7 @@ export function buildPiExtensionEnv(
   opts: {
     relayDir?: string;
     usageOutPath?: string;
+    otlpAuthFilePath?: string;
     skills?: string[];
     builtinGatingActive?: boolean;
     builtinGrants?: string[];
@@ -47,8 +54,8 @@ export function buildPiExtensionEnv(
   const otlp = telemetry?.exporters?.otlp;
   if (propagation?.traceparent) env.TRACEPARENT = propagation.traceparent;
   if (otlp?.endpoint) env.OTEL_EXPORTER_OTLP_TRACES_ENDPOINT = otlp.endpoint;
-  if (otlp?.headers?.authorization)
-    env.OTEL_EXPORTER_OTLP_HEADERS = `Authorization=${otlp.headers.authorization}`;
+  if (otlp?.headers?.authorization && opts.otlpAuthFilePath)
+    env.AGENTA_AGENT_OTLP_AUTH_FILE = opts.otlpAuthFilePath;
   if (telemetry?.capture?.content?.enabled === false)
     env.AGENTA_AGENT_CONTENT_CAPTURE_ENABLED = "false";
   // The skills that materialized for this run (author + forced `_agenta.*`), so Pi's own agent
@@ -72,6 +79,25 @@ export function buildPiExtensionEnv(
   if (opts.usageOutPath)
     env.AGENTA_AGENT_USAGE_CAPTURE_PATH = opts.usageOutPath;
   return env;
+}
+
+/**
+ * Write the OTLP bearer to a 0600 file at `path`: the runner still holds this value
+ * in memory for its own out-of-band use (session/mount calls), but the harness process only
+ * ever gets a path, never the value, via env. Best-effort: a write failure just means the
+ * extension traces without export auth (falls back to its own env fallback, if any).
+ */
+export function writeOtlpAuthFile(
+  path: string,
+  authorization: string,
+  log: Log = () => {},
+): void {
+  try {
+    mkdirSync(dirname(path), { recursive: true });
+    writeFileSync(path, authorization, { encoding: "utf-8", mode: 0o600 });
+  } catch (err) {
+    log(`otlp auth file write skipped: ${(err as Error).message}`);
+  }
 }
 
 /** Install the extension bundle into a local Pi agent dir's extensions/. Best-effort. */

--- a/services/runner/src/extensions/agenta.ts
+++ b/services/runner/src/extensions/agenta.ts
@@ -13,7 +13,9 @@
  * remain in memory:
  *   TRACEPARENT                       W3C traceparent of the caller's /invoke span
  *   OTEL_EXPORTER_OTLP_TRACES_ENDPOINT  OTLP traces URL (e.g. https://host/api/otlp/v1/traces)
- *   OTEL_EXPORTER_OTLP_HEADERS        key=value list for export headers (e.g. Authorization=...)
+ *   AGENTA_AGENT_OTLP_AUTH_FILE       path to a runner-written, 0600, read-once file holding
+ *                                     the OTLP Authorization bearer (never a plain env
+ *                                     var — read once here, then deleted, see readOtlpAuthFile)
  *   AGENTA_AGENT_CONTENT_CAPTURE_ENABLED "false" to drop prompt/completion/tool I/O from spans
  *   AGENTA_AGENT_TOOLS_PUBLIC_SPECS   JSON [{ name, description, inputSchema }]
  *   AGENTA_AGENT_TOOLS_RELAY_DIR      relay tool calls through the runner via files here
@@ -23,7 +25,7 @@
  * it (local, the docker sidecar, a Daytona snapshot). Default export is the Pi
  * ExtensionFactory.
  */
-import { writeFileSync } from "node:fs";
+import { readFileSync, unlinkSync, writeFileSync } from "node:fs";
 
 import {
   isToolCallEventType,
@@ -37,17 +39,16 @@ import type { ResolvedToolSpec } from "../protocol.ts";
 import { EMPTY_OBJECT_SCHEMA } from "../tools/callback.ts";
 import { requiredFields, specInputSchema } from "../tools/spec-schema.ts";
 
-/** Pull the Authorization value out of an OTEL_EXPORTER_OTLP_HEADERS key=value list. */
-function authorizationFromOtlpHeaders(raw?: string): string | undefined {
-  if (!raw) return undefined;
-  for (const pair of raw.split(",")) {
-    const eq = pair.indexOf("=");
-    if (eq === -1) continue;
-    if (pair.slice(0, eq).trim().toLowerCase() === "authorization") {
-      return pair.slice(eq + 1).trim();
-    }
+/** Read the OTLP bearer from its runner-written file once, then delete it. */
+export function readOtlpAuthFile(path?: string): string | undefined {
+  if (!path) return undefined;
+  try {
+    const value = readFileSync(path, "utf-8").trim();
+    unlinkSync(path);
+    return value || undefined;
+  } catch {
+    return undefined;
   }
-  return undefined;
 }
 import { relayPermissionCheck, runResolvedTool } from "../tools/dispatch.ts";
 
@@ -309,9 +310,7 @@ const factory = (pi: ExtensionAPI): void => {
   const otel = createAgentaOtel({
     traceparent: process.env.TRACEPARENT,
     endpoint: process.env.OTEL_EXPORTER_OTLP_TRACES_ENDPOINT,
-    authorization: authorizationFromOtlpHeaders(
-      process.env.OTEL_EXPORTER_OTLP_HEADERS,
-    ),
+    authorization: readOtlpAuthFile(process.env.AGENTA_AGENT_OTLP_AUTH_FILE),
     captureContent:
       process.env.AGENTA_AGENT_CONTENT_CAPTURE_ENABLED !== "false",
     // The skills that loaded for this run (author + forced `_agenta.*`), stamped on the agent

--- a/services/runner/tests/unit/extension-tools.test.ts
+++ b/services/runner/tests/unit/extension-tools.test.ts
@@ -12,9 +12,13 @@
  */
 import { afterEach, describe, it } from "vitest";
 import assert from "node:assert/strict";
+import { existsSync, mkdtempSync, readFileSync, rmSync, writeFileSync } from "node:fs";
+import { tmpdir } from "node:os";
+import { join } from "node:path";
 
 import factory, {
   normalizeBuiltinGrants,
+  readOtlpAuthFile,
   replaceActiveBuiltinTools,
 } from "../../src/extensions/agenta.ts";
 
@@ -23,6 +27,7 @@ const TOOL_ENV = [
   "AGENTA_AGENT_TOOLS_RELAY_DIR",
   "TRACEPARENT",
   "OTEL_EXPORTER_OTLP_TRACES_ENDPOINT",
+  "AGENTA_AGENT_OTLP_AUTH_FILE",
   "AGENTA_AGENT_USAGE_CAPTURE_PATH",
   "AGENTA_AGENT_CONTENT_CAPTURE_ENABLED",
   "AGENTA_AGENT_BUILTIN_GATING",
@@ -239,5 +244,24 @@ describe("agenta extension tool registration", () => {
       0,
       "specs without a relay dir do not register (incomplete wiring is not honored)",
     );
+  });
+});
+
+describe("readOtlpAuthFile", () => {
+  it("reads the bearer once, then deletes the file so it cannot be re-read", () => {
+    const dir = mkdtempSync(join(tmpdir(), "agenta-otlp-auth-test-"));
+    const path = join(dir, "otlp-auth");
+    writeFileSync(path, "Bearer trace-token", "utf-8");
+
+    const value = readOtlpAuthFile(path);
+
+    assert.equal(value, "Bearer trace-token");
+    assert.equal(existsSync(path), false);
+    rmSync(dir, { recursive: true, force: true });
+  });
+
+  it("returns undefined for a missing path without throwing", () => {
+    assert.equal(readOtlpAuthFile(undefined), undefined);
+    assert.equal(readOtlpAuthFile("/nonexistent/agenta-otlp-auth"), undefined);
   });
 });

--- a/services/runner/tests/unit/sandbox-agent-orchestration.test.ts
+++ b/services/runner/tests/unit/sandbox-agent-orchestration.test.ts
@@ -805,6 +805,38 @@ describe("runSandboxAgent orchestration", () => {
     assert.equal(env.ENABLE_TOOL_SEARCH, undefined);
   });
 
+  it("never puts the OTLP bearer in the local Pi daemon's env", async () => {
+    const { calls, deps } = fakeHarness();
+
+    const result = await runSandboxAgent(
+      {
+        harness: "pi_core",
+        messages: [{ role: "user", content: "hello" }],
+        telemetry: {
+          exporters: {
+            otlp: {
+              endpoint: "https://otlp.example.test/v1/traces",
+              headers: { authorization: "Bearer reusable-caller-token" },
+            },
+          },
+        },
+      } as AgentRunRequest,
+      undefined,
+      undefined,
+      deps,
+    );
+
+    assert.equal(result.ok, true);
+    const env = calls.providerArgs[1] as Record<string, string>;
+    // The harness-readable env carries a file path, never the bearer itself.
+    assert.equal(env.OTEL_EXPORTER_OTLP_HEADERS, undefined);
+    assert.equal(typeof env.AGENTA_AGENT_OTLP_AUTH_FILE, "string");
+    assert.equal(
+      JSON.stringify(env).includes("reusable-caller-token"),
+      false,
+    );
+  });
+
   it("sets Claude Bedrock env and strict selected model pass-through", async () => {
     const { calls, deps } = fakeHarness();
 

--- a/services/runner/tests/unit/sandbox-agent-pi-assets.test.ts
+++ b/services/runner/tests/unit/sandbox-agent-pi-assets.test.ts
@@ -11,6 +11,7 @@ import {
   mkdtempSync,
   readFileSync,
   rmSync,
+  statSync,
   writeFileSync,
 } from "node:fs";
 import { tmpdir } from "node:os";
@@ -22,6 +23,7 @@ import {
   prepareLocalAgentDir,
   uploadDirToSandbox,
   uploadSkillsToSandbox,
+  writeOtlpAuthFile,
   writeSystemPromptLocal,
 } from "../../src/engines/sandbox_agent/pi-assets.ts";
 
@@ -85,6 +87,7 @@ describe("buildPiExtensionEnv", () => {
     const env = buildPiExtensionEnv(request, true, {
       relayDir: "/tmp/relay",
       usageOutPath: "/tmp/usage.json",
+      otlpAuthFilePath: "/tmp/otlp-auth",
     });
 
     assert.equal(env.TRACEPARENT, request.context?.propagation?.traceparent);
@@ -92,10 +95,9 @@ describe("buildPiExtensionEnv", () => {
       env.OTEL_EXPORTER_OTLP_TRACES_ENDPOINT,
       request.telemetry?.exporters?.otlp?.endpoint,
     );
-    assert.equal(
-      env.OTEL_EXPORTER_OTLP_HEADERS,
-      `Authorization=${request.telemetry?.exporters?.otlp?.headers?.authorization}`,
-    );
+    // the bearer rides a file path, never a plain env var the harness can read/echo.
+    assert.equal(env.AGENTA_AGENT_OTLP_AUTH_FILE, "/tmp/otlp-auth");
+    assert.equal(env.OTEL_EXPORTER_OTLP_HEADERS, undefined);
     assert.equal(env.AGENTA_AGENT_CONTENT_CAPTURE_ENABLED, "false");
     assert.equal(env.AGENTA_AGENT_TOOLS_RELAY_DIR, "/tmp/relay");
     assert.equal(env.AGENTA_AGENT_USAGE_CAPTURE_PATH, "/tmp/usage.json");
@@ -224,6 +226,38 @@ describe("buildPiExtensionEnv", () => {
         .AGENTA_AGENT_SKILLS_LOADED,
       undefined,
     );
+  });
+
+  it("never leaks the bearer into env when no auth file path is given", () => {
+    const env = buildPiExtensionEnv(
+      {
+        telemetry: {
+          exporters: {
+            otlp: {
+              endpoint: "https://otlp.example.test/v1/traces",
+              headers: { authorization: "Bearer trace-token" },
+            },
+          },
+        },
+      } as AgentRunRequest,
+      true,
+    );
+
+    assert.equal(env.AGENTA_AGENT_OTLP_AUTH_FILE, undefined);
+    assert.equal(env.OTEL_EXPORTER_OTLP_HEADERS, undefined);
+    assert.equal(JSON.stringify(env).includes("trace-token"), false);
+  });
+});
+
+describe("writeOtlpAuthFile", () => {
+  it("writes the bearer to a 0600 file, not env", () => {
+    const dir = tempDir("agenta-pi-otlp-auth-test-");
+    const path = join(dir, "nested", "otlp-auth");
+
+    writeOtlpAuthFile(path, "Bearer trace-token");
+
+    assert.equal(readFileSync(path, "utf-8"), "Bearer trace-token");
+    assert.equal(statSync(path).mode & 0o777, 0o600);
   });
 });
 


### PR DESCRIPTION
## Context

A local Pi run injected the caller's Authorization bearer into `OTEL_EXPORTER_OTLP_HEADERS`, plain environment the harness process inherits. A prompt-injected sandbox could read and echo it (via `env`, a subprocess, or a crash log) and, because that bearer is the caller's reusable token, impersonate the caller. Field evidence showed the bearer verbatim inside a harness process.

Re-verifying against current code corrected the finding's reach: the telemetry env is gated off for Daytona, so Daytona sandboxes never received the bearer at all. The live leak is local Pi runs only.

## Changes

The bearer no longer goes into any plain environment variable. The runner writes it to a `0600` runner-owned file and passes only the file path via `AGENTA_AGENT_OTLP_AUTH_FILE`. The Agenta extension reads the file once at init to build its exporter, then deletes it; the runner deletes it again in `finally` as a backstop in case the harness never started.

Tracing is unchanged. The two env vars the extension needs to trace, `TRACEPARENT` and `OTEL_EXPORTER_OTLP_TRACES_ENDPOINT`, still travel in plain env exactly as before, and `hasTracing` still activates on them. Only the auth bearer moved channels. The exporter the extension builds is the same; it sources the secret from the file instead of env.

Before: `env.OTEL_EXPORTER_OTLP_HEADERS = "Authorization=<bearer>"` (harness-readable).
After: `env.AGENTA_AGENT_OTLP_AUTH_FILE = "<path>"`; the bearer is only in the 0600 file.

This is step one of the finding. A first-class `platform` wire block and a short-lived audience-scoped trace-ingest token (so the reusable bearer stops traveling at all) are left as follow-ups. On a `local` run the host is unsandboxed, so a determined attacker with code execution could still race the file before deletion; the plain-env disclosure surface is what this closes.

## Tests / notes

- New regression test asserts the bearer never appears in the assembled daemon env; unit coverage for the write/read-once helpers.
- `pnpm test` green (including the full-path env assertion); `pnpm run typecheck` clean. No wire fields changed, so the golden fixtures and both contract tests are untouched.

## What to QA

- Run a local Pi agent from the playground with tracing on. The trace still appears in observability (the extension still exports).
- Inside a run, confirm the harness environment no longer contains the Authorization bearer (it holds a file path instead).
- Regression: a Daytona run traces as before (unaffected by this change).
