### PR TITLE
feat(sdk): build-an-agent skill tells the agent to read it at conversation start

### DIFF
--- a/sdks/python/agenta/sdk/agents/adapters/agenta_builtins.py
+++ b/sdks/python/agenta/sdk/agents/adapters/agenta_builtins.py
@@ -710,8 +710,10 @@ HTTP only when your wired tools cannot do the job, and say so when you do.
 BUILD_AN_AGENT_SKILL = SkillTemplate(
     name="build-an-agent",
     description=(
-        "Build or configure an Agenta agent end to end. Use when the user asks to set up, "
-        "automate, connect tools for, schedule, or subscribe an agent."
+        "Build or configure an Agenta agent end to end. ALWAYS read this skill at the start "
+        "of the conversation, before your first reply, to load context on what you are and "
+        "how you configure yourself. Then follow it when the user asks to set up, automate, "
+        "connect tools for, schedule, or subscribe an agent."
     ),
     body=_BUILD_AN_AGENT_BODY,
     files=[


### PR DESCRIPTION
## Context

Builder agents keep making first-turn mistakes (wrong commit formats, hand-rolled tool JSON) even though the `build-an-agent` skill body documents the correct procedure. The reason: the harness only loads a skill's body when the model decides to open it, and the model decides from the description alone. Nothing told it to open the skill before acting, so early turns ran without the skill's context.

## Change

One string: the `build-an-agent` skill description now instructs the agent to ALWAYS read the skill at the start of the conversation, before its first reply, then follow it for build/configure/automate asks.

Before:
> Build or configure an Agenta agent end to end. Use when the user asks to set up, automate, connect tools for, schedule, or subscribe an agent.

After:
> Build or configure an Agenta agent end to end. ALWAYS read this skill at the start of the conversation, before your first reply, to load context on what you are and how you configure yourself. Then follow it when the user asks to set up, automate, connect tools for, schedule, or subscribe an agent.

## Scope / risk

- Only the `description` field of `BUILD_AN_AGENT_SKILL` in `sdks/python/agenta/sdk/agents/adapters/agenta_builtins.py`. No body, reference-file, or wire changes.
- The description flows into the generated SKILL.md frontmatter wherever the skill is delivered (forced pi_agenta skills, the `__ag__build_an_agent` static workflow, the build-kit embed). All delivery paths pick it up automatically.
- Risk: none beyond slightly longer skill-list text shown to the model.

## How to QA

1. `cd sdks/python && uv run --no-sync python -m pytest oss/tests/pytest/unit/agents/test_agenta_builtins_reference_files.py -q` — 8 pass (run on this branch).
2. Optional live check: create a fresh agent in the playground, open Skills → build-an-agent, confirm the description shows the new text.

https://claude.ai/code/session_01EcGku1uKvh1Yo48ZU2xN5e