### PR TITLE
chore(frontend): template strip default-on — strip home is the default experience

### DIFF
--- a/web/oss/src/components/pages/agent-home/assets/constants.ts
+++ b/web/oss/src/components/pages/agent-home/assets/constants.ts
@@ -22,15 +22,15 @@ export const PLAYGROUND_NATIVE_ONBOARDING =
     (getEnv("NEXT_PUBLIC_AGENT_PLAYGROUND_ONBOARDING") || "").toLowerCase() !== "false"
 
 /**
- * Template-strip experience toggle (`NEXT_PUBLIC_AGENT_TEMPLATE_STRIP`). When true, Home,
+ * Template-strip experience toggle (`NEXT_PUBLIC_AGENT_TEMPLATE_STRIP`). On by default: Home,
  * playground onboarding, and every agent's empty chat render the shared `<TemplateStrip />`:
  * always visible, filterable in place, card click fills the composer + shows a provenance
- * chip (no drawer, no direct create). When false/unset (default), the current per-surface
- * template UIs (grid, quick-pick list, gallery) are unchanged. Both are kept so the new
- * experience can be A/B'd before the old flows are removed.
+ * chip (no drawer, no direct create). Set to "false" to fall back to the per-surface
+ * template UIs (grid, quick-pick list, gallery), kept so the experiences can still be
+ * compared before the old flows are removed.
  */
 export const TEMPLATE_STRIP_MODE =
-    (getEnv("NEXT_PUBLIC_AGENT_TEMPLATE_STRIP") || "").toLowerCase() === "true"
+    (getEnv("NEXT_PUBLIC_AGENT_TEMPLATE_STRIP") || "").toLowerCase() !== "false"
 
 export const HERO = {
     eyebrowNew: "New",


### PR DESCRIPTION
## Context

The homepage showed no templates for returning users: `ClassicAgentHome` renders the template gallery only on first run (zero agents), and the experience that shows templates to everyone — the `TemplateStrip` home — was still opt-in via `NEXT_PUBLIC_AGENT_TEMPLATE_STRIP`. The dev deployment has been running with the strip ON, and that is the intended default state; a zero-env deploy should match it.

## Change

One expression in `web/oss/src/components/pages/agent-home/assets/constants.ts`: `TEMPLATE_STRIP_MODE` flips from `=== "true"` (default off) to `!== "false"` (default on), with the comment rewritten to match. Same pattern as the other agent-experience flags (#5121, #5131). Opt-out stays available: set `NEXT_PUBLIC_AGENT_TEMPLATE_STRIP=false`.

With this, all four agent-experience flags are code-default ON and a fresh deploy with no env vars gets the complete experience: strip home with templates for new and returning users, playground-native onboarding, chat slice, template-builder flow.

## Scope / risk

- One constant in one file. No component changes; `StripHome`, the onboarding strip, and the empty-chat strip already exist behind this flag and have been the daily-driven experience on the dev box.
- Deploys that relied on the old default (strip off with no env set) will switch to the strip home; the old per-surface template UIs remain one env var away.

## How to QA

1. Deploy with NO `NEXT_PUBLIC_AGENT_TEMPLATE_STRIP` set.
2. Open the project home (`/apps`) with existing agents → the TemplateStrip renders above the agents table (returning-user path).
3. Set `NEXT_PUBLIC_AGENT_TEMPLATE_STRIP=false`, restart web → the classic home (gallery only on first run) returns.
4. `cd web && npx tsc --noEmit -p oss` unaffected (constant-only change); dev web compiles clean with the flip (verified live, HTTP 200, no compile errors).

https://claude.ai/code/session_01EcGku1uKvh1Yo48ZU2xN5e