### PR TITLE
feat(frontend): /settings short link redirects to the scoped settings page

### DIFF
--- a/web/ee/src/pages/settings/index.tsx
+++ b/web/ee/src/pages/settings/index.tsx
@@ -1,0 +1,3 @@
+import SettingsRedirect from "@/oss/components/pages/SettingsRedirect"
+
+export default SettingsRedirect

--- a/web/oss/src/components/pages/SettingsRedirect/index.tsx
+++ b/web/oss/src/components/pages/SettingsRedirect/index.tsx
@@ -1,0 +1,45 @@
+import {useEffect, useMemo} from "react"
+
+import {Spin} from "antd"
+import {useAtomValue} from "jotai"
+import {useRouter} from "next/router"
+
+import useURL from "@/oss/hooks/useURL"
+import {projectAtom} from "@/oss/state/project"
+
+const SettingsRedirect = () => {
+    const router = useRouter()
+
+    const {workspaceId} = useURL()
+    const project = useAtomValue(projectAtom)
+
+    // On a bare route urlAtom has no workspace; the project carries its own.
+    const resolvedWorkspaceId = project?.workspace_id || workspaceId
+
+    const targetPath = useMemo(() => {
+        if (!resolvedWorkspaceId || !project?.project_id) return null
+        return `/w/${encodeURIComponent(resolvedWorkspaceId)}/p/${encodeURIComponent(
+            project.project_id,
+        )}/settings`
+    }, [resolvedWorkspaceId, project?.project_id])
+
+    useEffect(() => {
+        if (!router.isReady) return
+        if (!targetPath) return
+
+        const currentPath = router.asPath.split("?")[0]
+        if (currentPath === targetPath) return
+
+        const searchIndex = router.asPath.indexOf("?")
+        const search = searchIndex >= 0 ? router.asPath.slice(searchIndex) : ""
+        void router.replace(`${targetPath}${search}`)
+    }, [router, targetPath])
+
+    return (
+        <section className="flex items-center justify-center w-full h-screen">
+            <Spin spinning={true} />
+        </section>
+    )
+}
+
+export default SettingsRedirect

--- a/web/oss/src/pages/settings/index.tsx
+++ b/web/oss/src/pages/settings/index.tsx
@@ -1,0 +1,3 @@
+import SettingsRedirect from "../../components/pages/SettingsRedirect"
+
+export default SettingsRedirect


### PR DESCRIPTION
## Context
Sharing a link to the settings page required knowing the workspace and project ids: `/w/<ws>/p/<proj>/settings?tab=apiKeys`. A bare `https://<host>/settings?tab=apiKeys` returned a 404, so there was no short, memorable URL you could give someone to open their own API keys page.

## Changes
A bare `/settings` route now resolves the visitor's workspace and project client-side and forwards to the scoped page, preserving the full query string.

Before: `/settings?tab=apiKeys` renders a 404.

After: `/settings?tab=apiKeys` redirects to `/w/<workspace_id>/p/<project_id>/settings?tab=apiKeys`.

The new `SettingsRedirect` component follows the same reactive pattern as the sibling `WorkspaceRedirect`: derive the target from atoms in a memo, redirect in an effect that re-runs as they populate. The project comes from `projectAtom` (last-used, then default, then first non-demo) and the workspace id from the project's own `workspace_id` field. That last part matters: `urlAtom`'s workspace and project ids are parsed from the URL, which a bare route does not have, so they stay empty here. Three new files: the component plus thin OSS and EE page entries at `pages/settings/index.tsx`.

Note for future bare-route redirects: a first version used a one-shot async wait (`waitForWorkspaceContext`) behind a `pendingRef` guard. Under React StrictMode's double-mount the first run gets cancelled and the second bails on the guard, so the redirect never fires. The reactive pattern avoids that class of bug entirely.

## Scope / risk
Only `/settings` is covered; other bare paths (`/observability`, `/playground`, ...) still 404 on purpose. Playground URLs are app-scoped, so a bare path has no unambiguous target there. No existing route or resolver logic changed; the risk surface is the new page only. Logged-out visitors go through the normal auth flow first and land via the standard post-login redirect, not the deep link (known limitation, small follow-up if we want it).

## Tests
- Verified live on the dev box (EE, dev mode): `/settings?tab=apiKeys` and bare `/settings` both redirect to the scoped settings page with the API Keys tab rendered; query string preserved.
- Logged-out: `/settings?tab=apiKeys` lands on `/auth?redirectToPath=%2Fsettings%3Ftab%3DapiKeys`, and after login the normal post-login flow takes over.
- `pnpm lint-fix` passes for OSS and EE.

## How to QA

**Prerequisites:** any running stack (local dev via `run.sh`, or the Hetzner dev box), logged in.

**Steps:**
1. Visit `https://<host>/settings?tab=apiKeys` directly (paste in the address bar).
2. Watch the URL after the spinner.

**Expected result:** you land on `/w/<your-ws>/p/<your-project>/settings?tab=apiKeys` with the API Keys tab active. The project is your last-used one.

**Automated tests:** none added; the component is a thin composition of already-tested selectors.

**Edge cases:** open the link in a fresh browser profile (logged out). You should get the login page, and after login land in your workspace normally (not on settings; see scope note).

https://claude.ai/code/session_01DjaJLpnLtnoRhgbYe7NTC3
