### PR TITLE
feat(frontend): hide demo workspaces and projects from the UI

### DIFF
--- a/web/oss/src/state/org/hooks.ts
+++ b/web/oss/src/state/org/hooks.ts
@@ -5,7 +5,7 @@ import {useAtom, useSetAtom, useAtomValue} from "jotai"
 import {useRouter} from "next/router"
 
 import {buildProjectSwitchHref} from "@/oss/lib/navigation/projectSwitchHref"
-import {OrgDetails} from "@/oss/lib/Types"
+import type {OrgDetails} from "@/oss/lib/Types"
 import {fetchSingleOrg} from "@/oss/services/organization/api"
 import {fetchAllProjects} from "@/oss/services/project"
 import type {ProjectsResponse} from "@/oss/services/project/types"
@@ -22,8 +22,6 @@ import {
     orgsAtom,
     selectedOrgAtom,
 } from "./selectors/org"
-
-const EmptyOrgs: OrgDetails[] = []
 
 const projectMatchesWorkspace = (
     project: {workspace_id?: string | null; organization_id?: string | null},
@@ -55,7 +53,9 @@ const pickPreferredProjectForWorkspace = (
 export const useOrgData = () => {
     const queryClient = useQueryClient()
     const router = useRouter()
-    const [{data: orgs, isPending: loadingOrgs, refetch: refetchOrgs}] = useAtom(orgsQueryAtom)
+    const [{isPending: loadingOrgs, refetch: refetchOrgs}] = useAtom(orgsQueryAtom)
+    // Read via orgsAtom (not raw query data) so demo orgs stay hidden
+    const orgs = useAtomValue(orgsAtom)
     const [{data: selectedOrg, isPending: loadingDetails, refetch: refetchSelectedOrg}] =
         useAtom(selectedOrgQueryAtom)
     const navigate = useSetAtom(requestNavigationAtom)
@@ -198,7 +198,7 @@ export const useOrgData = () => {
     }, [refetchOrgs, refetchSelectedOrg, queryClient])
 
     return {
-        orgs: orgs ?? EmptyOrgs,
+        orgs,
         selectedOrg: selectedOrg ?? null,
         loading: loadingOrgs || loadingDetails,
         changeSelectedOrg,

--- a/web/oss/src/state/org/selectors/org.ts
+++ b/web/oss/src/state/org/selectors/org.ts
@@ -137,8 +137,8 @@ logAtom(orgsQueryAtom, "orgsQueryAtom", logOrgs)
 export const orgsAtom = atom<Org[]>((get) => {
     const res = (get(orgsQueryAtom) as any)?.data
     const orgs = res ?? []
-    // Sort organizations to ensure demo orgs are always last
-    return sortOrgsWithDemoLast(orgs)
+    // Hide demo orgs from the UI unless they are the user's only orgs
+    return filterOutDemoOrgs(orgs)
 })
 
 export const selectedOrgIdAtom = atom((get) => {
@@ -246,13 +246,13 @@ const isDemoOrg = (org?: Partial<Org>): boolean => {
 }
 
 /**
- * Sorts organizations to ensure demo orgs are always last
- * Non-demo orgs maintain their original order, demo orgs are moved to the end
+ * Filters demo orgs out of the list. Falls back to the full list when the
+ * user has only demo orgs, so they are not left with an empty workspace UI.
+ * Exported for unit-test access (orgsDemoFilter.test.ts).
  */
-const sortOrgsWithDemoLast = (orgs: Org[]): Org[] => {
+export const filterOutDemoOrgs = (orgs: Org[]): Org[] => {
     const nonDemoOrgs = orgs.filter((org) => !isDemoOrg(org))
-    const demoOrgs = orgs.filter((org) => isDemoOrg(org))
-    return [...nonDemoOrgs, ...demoOrgs]
+    return nonDemoOrgs.length ? nonDemoOrgs : orgs
 }
 
 const pickFirstNonDemoOrg = (orgs?: Org[]) => {

--- a/web/oss/src/state/org/selectors/orgsDemoFilter.test.ts
+++ b/web/oss/src/state/org/selectors/orgsDemoFilter.test.ts
@@ -1,0 +1,56 @@
+/**
+ * Unit tests for filterOutDemoOrgs, the orgsAtom demo-org filter.
+ *
+ * Demo orgs (org.flags.is_demo) are hidden from the UI entirely, unless
+ * they are the user's only orgs (e.g. allowlisted users without
+ * org-creation rights whose only memberships are demo ones) — hiding
+ * them there would leave an empty, dead-end workspace UI.
+ */
+
+import {describe, expect, it} from "vitest"
+
+import type {Org} from "@/oss/lib/Types"
+
+import {filterOutDemoOrgs} from "./org"
+
+const ownOrg = {
+    id: "019315dc-a341-7edb-bed4-114f0d50c91a",
+    name: "mahmoud-renamed",
+    owner_id: "user-1",
+    flags: {},
+} as unknown as Org
+
+const demoOrg = {
+    id: "00000000-0000-0000-0000-00000000d3m0",
+    name: "Demo Workspace",
+    owner_id: "someone-else",
+    flags: {is_demo: true},
+} as unknown as Org
+
+const secondDemoOrg = {
+    id: "00000000-0000-0000-0000-00000000d3m1",
+    name: "Demo Workspace 2",
+    owner_id: "someone-else",
+    flags: {is_demo: true},
+} as unknown as Org
+
+describe("filterOutDemoOrgs", () => {
+    it("filters demo orgs out when the user has at least one non-demo org", () => {
+        const result = filterOutDemoOrgs([ownOrg, demoOrg])
+        expect(result).toEqual([ownOrg])
+    })
+
+    it("keeps demo orgs when they are the user's only orgs", () => {
+        const result = filterOutDemoOrgs([demoOrg, secondDemoOrg])
+        expect(result).toEqual([demoOrg, secondDemoOrg])
+    })
+
+    it("returns non-demo orgs unchanged", () => {
+        const result = filterOutDemoOrgs([ownOrg])
+        expect(result).toEqual([ownOrg])
+    })
+
+    it("returns an empty list unchanged", () => {
+        expect(filterOutDemoOrgs([])).toEqual([])
+    })
+})

--- a/web/oss/src/state/project/hooks.ts
+++ b/web/oss/src/state/project/hooks.ts
@@ -13,8 +13,9 @@ import {
 } from "./selectors/project"
 
 export const useProjectData = () => {
-    const [{data: projects, isPending: _isPending, isLoading, refetch: _refetch}] =
-        useAtom(projectsQueryAtom)
+    const [{isPending: _isPending, isLoading, refetch: _refetch}] = useAtom(projectsQueryAtom)
+    // Read via projectsAtom (not raw query data) so demo projects stay hidden
+    const projects = useAtomValue(projectsAtom)
     const project = useAtomValue(projectAtom)
     const projectId = useAtomValue(projectIdAtom)
     const isProjectId = !!projectId
@@ -50,7 +51,7 @@ export const useProjectData = () => {
 
     return {
         project: project ?? null,
-        projects: projects ?? [],
+        projects,
         isProjectId,
         projectId,
         // isLoading: isPending,

--- a/web/oss/src/state/project/selectors/project.ts
+++ b/web/oss/src/state/project/selectors/project.ts
@@ -119,9 +119,22 @@ const _debugProjectSelection = process.env.NEXT_PUBLIC_APP_STATE_DEBUG === "true
 logAtom(projectsQueryAtom, "projectsQueryAtom", logProjects)
 
 const EmptyProjects: ProjectsResponse[] = []
+
+/**
+ * Filters demo projects out of the list. Falls back to the full list when
+ * every project is a demo one, so the user is not left with an empty UI.
+ * Exported for unit-test access (projectsDemoFilter.test.ts).
+ */
+export const filterOutDemoProjects = (projects: ProjectsResponse[]): ProjectsResponse[] => {
+    const nonDemoProjects = projects.filter((project) => !project.is_demo)
+    return nonDemoProjects.length ? nonDemoProjects : projects
+}
+
 export const projectsAtom = atom((get) => {
     const res = get(projectsQueryAtom)
-    return (res as any)?.data ?? EmptyProjects
+    const projects = ((res as any)?.data ?? EmptyProjects) as ProjectsResponse[]
+    // Hide demo projects from the UI unless they are the user's only projects
+    return filterOutDemoProjects(projects)
 })
 
 const _projectBelongsToWorkspace = (project: ProjectsResponse, workspaceId: string) => {

--- a/web/oss/src/state/project/selectors/projectsDemoFilter.test.ts
+++ b/web/oss/src/state/project/selectors/projectsDemoFilter.test.ts
@@ -1,0 +1,56 @@
+/**
+ * Unit tests for filterOutDemoProjects, the projectsAtom demo-project filter.
+ *
+ * Demo projects (project.is_demo) are hidden from the UI entirely, unless
+ * every project the user can see is a demo one — hiding them there would
+ * leave an empty, dead-end project UI. Belt-and-suspenders with the
+ * demo-org filter in state/org/selectors/org.ts (demo projects live in
+ * demo orgs, which orgsAtom already hides).
+ */
+
+import {describe, expect, it} from "vitest"
+
+import type {ProjectsResponse} from "@/oss/services/project/types"
+
+import {filterOutDemoProjects} from "./project"
+
+const ownProject = {
+    organization_id: "019315dc-a341-7edb-bed4-114f0d50c91a",
+    workspace_id: "019315dc-a341-7edb-bed4-114f0d50c91a",
+    project_id: "00000000-0000-0000-0000-000000000001",
+    project_name: "Default",
+    is_default_project: true,
+    is_demo: null,
+    user_role: "owner",
+} as unknown as ProjectsResponse
+
+const demoProject = {
+    organization_id: "00000000-0000-0000-0000-00000000d3m0",
+    workspace_id: "00000000-0000-0000-0000-00000000d3m0",
+    project_id: "0193930d-83b6-7efa-a067-03056d548af4",
+    project_name: "Default",
+    is_default_project: false,
+    is_demo: true,
+    user_role: "viewer",
+} as unknown as ProjectsResponse
+
+describe("filterOutDemoProjects", () => {
+    it("filters demo projects out when a non-demo project exists", () => {
+        const result = filterOutDemoProjects([ownProject, demoProject])
+        expect(result).toEqual([ownProject])
+    })
+
+    it("keeps demo projects when they are all the user has", () => {
+        const result = filterOutDemoProjects([demoProject])
+        expect(result).toEqual([demoProject])
+    })
+
+    it("treats is_demo=null as non-demo", () => {
+        const result = filterOutDemoProjects([ownProject])
+        expect(result).toEqual([ownProject])
+    })
+
+    it("returns an empty list unchanged", () => {
+        expect(filterOutDemoProjects([])).toEqual([])
+    })
+})


### PR DESCRIPTION
## Context
Demo workspaces and projects still show up in the org switcher and project picker (sorted last), even though we no longer use them. They clutter the UI and can capture the "last used project", so redirects sometimes land users in the demo workspace.

## Changes
Demo orgs and demo projects are now filtered out of the two central atoms every picker and redirect reads from, instead of being sorted last.

Before: `orgsAtom` applied `sortOrgsWithDemoLast`, so demo orgs appeared at the bottom of the org switcher and demo projects appeared in the project picker.

After: `orgsAtom` applies `filterOutDemoOrgs` and `projectsAtom` applies `filterOutDemoProjects`. Both use the same rule: drop demo entries, unless they are all the user has, in which case keep them so the UI is not left empty.

Two real leaks needed fixing beyond the atoms: `useOrgData().orgs` and `useProjectData().projects` returned the raw query data, bypassing the atoms. The sidebar project picker and the EE post-signup flow read those. Both hooks now return the filtered atom values.

The fallback keeps one invariant: the filtered list is empty only when the raw list is empty, so the "no orgs, sign out" path and post-signup readiness gates behave exactly as before. The demo banner and "return to your workspace" machinery in Layout stays in place; it only activates in the demo-only fallback case, which is exactly when we still want it.

## Scope / risk
Frontend only. `AGENTA_DEMOS` seeding on the API is untouched; unsetting it on deployments stops new demo memberships but is a config change, not part of this PR. Users on an access allowlist whose only memberships are demo ones keep seeing the demo workspace (the fallback). One behavior change to know about: a user who has their own workspace can no longer enter a demo project via a direct `/w/<demo>/p/<id>` link, since the project is filtered from scope. That is consistent with hiding demo entirely.

## Tests
- 8 new unit tests (`orgsDemoFilter.test.ts`, `projectsDemoFilter.test.ts`): demo filtered out, kept when it is all the user has, empty in = empty out.
- Existing `projectAtom.race.test.ts` still passes (4/4); `pickPreferredProject` is unchanged.
- Note: web/oss has no vitest wiring yet (same as the pre-existing race test); the tests were verified with a scratch vitest config and run once wiring lands.
- `pnpm lint-fix` passes; `tsc` introduces zero new errors against the baseline.

## How to QA

**Prerequisites:** a stack with demo seeding configured (`AGENTA_DEMOS` set on the API) and an account that is a member of a demo org plus its own org.

**Steps:**
1. Log in and open the org switcher in the sidebar.
2. Open the project picker.
3. Log in with an account whose ONLY membership is the demo org (allowlisted user without org-creation rights).

**Expected result:** steps 1-2 show no demo org and no demo project anywhere. Step 3 still shows the demo workspace and the demo banner (the only-demo fallback).

**Automated tests:** `orgsDemoFilter.test.ts` and `projectsDemoFilter.test.ts` (pending vitest wiring in web/oss, see Tests).

**Edge cases:** an account with a stale "last used project" pointing at the demo project should silently resolve to its own default project on next login.

https://claude.ai/code/session_01DjaJLpnLtnoRhgbYe7NTC3
