### PR TITLE
fix(web): serve /__env.js as no-store so runtime env config isn't CDN-cached

### DIFF
--- a/web/oss/next.config.ts
+++ b/web/oss/next.config.ts
@@ -55,6 +55,20 @@ const COMMON_CONFIG: NextConfig = {
             },
         ]
     },
+    async headers() {
+        return [
+            {
+                // `__env.js` is per-deployment RUNTIME config (regenerated on each container
+                // start by the web entrypoint), not an immutable build asset. Next serves
+                // `public/` files as `Cache-Control: public, max-age=0`, which CDNs cache by
+                // extension and pin to their own browser-cache TTL (Cloudflare's default is 4h)
+                // — so env/flag changes silently take hours to reach the browser. Force it
+                // uncacheable so every load reads the current runtime config.
+                source: "/__env.js",
+                headers: [{key: "Cache-Control", value: "no-store, must-revalidate"}],
+            },
+        ]
+    },
     // Enable package import optimization for workspace packages and icon libraries
     experimental: {
         optimizePackageImports: [


### PR DESCRIPTION
## Problem

`web/entrypoint.sh` writes `public/__env.js` on every container start — it's **per-deployment runtime config** (public URLs, auth-provider ids, `NEXT_PUBLIC_AGENT_*` feature flags) that the browser reads via `window.__env` (loaded by `_document.tsx`). But Next serves files in `public/` with `Cache-Control: public, max-age=0`, and CDNs cache `.js` by extension. Cloudflare (and other CDNs) treat `public, max-age=0` as cacheable and pin it to their **default browser-cache TTL — 4 hours for Cloudflare**.

Result: after changing an env var or feature flag and recreating `web`, the origin serves the new `__env.js` immediately, but browsers keep reading a **stale cached copy for up to 4h**. This surfaced as "flag changes / new UI don't show up" on a self-host behind a Cloudflare tunnel — the origin was correct the whole time; the CDN was serving a stale `__env.js`.

Observed: `curl -sD- https://<host>/__env.js` → `cf-cache-status: HIT`, `cache-control: public, max-age=14400`, stale body; a cache-buster (`?v=…`) → `MISS` → the correct current file.

## Fix

Serve `/__env.js` as `no-store` via a `headers()` rule in `next.config`. Runtime config should never be cached — every load must read the current file.

```ts
async headers() {
    return [{ source: "/__env.js", headers: [{ key: "Cache-Control", value: "no-store, must-revalidate" }] }]
}
```

The EE config spreads `...ossConfig` and doesn't override `headers`, so this single change covers both OSS and EE apps.

## Verification

The `no-store` mechanism was validated at the proxy layer on a live self-host: overriding `__env.js` to `Cache-Control: no-store` flipped Cloudflare from `cf-cache-status: HIT` (stale) to `BYPASS` (always refetch, correct current body) with no cache purge needed. This PR moves that fix into the app so it holds for any CDN/proxy, not just one Traefik setup.

> Please confirm in CI/build that the built standalone server emits `Cache-Control: no-store` for `/__env.js` (Next `headers()` applies to `public/` assets, but worth a smoke check).

## Impact

- No behavior change beyond caching. `__env.js` is tiny and loaded once per page; not caching it is negligible cost and the correct semantics for runtime config.
- Fixes silent multi-hour propagation delay for **any** env/flag change on CDN-fronted self-host deployments.
