### PR TITLE
[fix] Add time-based run limits to the runner

### DIFF
--- a/sdks/python/agenta/sdk/agents/adapters/vercel/sse.py
+++ b/sdks/python/agenta/sdk/agents/adapters/vercel/sse.py
@@ -2,6 +2,8 @@
 
 from __future__ import annotations
 
+import asyncio
+import os
 from json import dumps
 from typing import Any, AsyncGenerator
 
@@ -13,13 +15,64 @@ VERCEL_UI_MESSAGE_STREAM_HEADERS = {
     "x-accel-buffering": "no",
 }
 
+# An SSE comment line (starts with ``:``) — the client and the AI SDK ignore it, but a byte on
+# the wire keeps proxies/load-balancers from idle-killing a slow-but-alive run mid-completion.
+_KEEPALIVE_FRAME = ": keepalive\n\n"
+
+
+# Seconds of silence before a keepalive comment is sent; resets on every real data frame. Wide
+# default (well under a typical 30–60s proxy idle cutoff), env-overridable. ``0`` disables it.
+def _keepalive_interval_seconds() -> float:
+    try:
+        value = float(os.getenv("AGENTA_AGENT_SSE_KEEPALIVE_SECONDS", "15"))
+    except ValueError:
+        return 15.0
+    return value if value > 0 else 0.0
+
+
+_KEEPALIVE_INTERVAL_SECONDS = _keepalive_interval_seconds()
+
 
 def vercel_sse_stream(aiter: AsyncGenerator[Any, None]):
-    """Frame Vercel UI Message Stream parts as SSE and append ``[DONE]``."""
+    """Frame Vercel UI Message Stream parts as SSE and append ``[DONE]``.
+
+    During a silent gap between parts (e.g. a tool call running for minutes) a keepalive comment
+    is emitted on a periodic tick, so a proxy does not idle-kill a run that is still completing
+    (and still billing) server-side. The comment lines are inert — data frames are unchanged.
+    """
+    interval = _KEEPALIVE_INTERVAL_SECONDS
 
     async def gen():
-        async for chunk in aiter:
-            yield "data: " + dumps(chunk, ensure_ascii=False) + "\n\n"
+        if interval <= 0:
+            async for chunk in aiter:
+                yield "data: " + dumps(chunk, ensure_ascii=False) + "\n\n"
+            yield "data: [DONE]\n\n"
+            return
+
+        # Drive the iterator by hand so each pull can race a keepalive tick: on a silent gap the
+        # pull times out, we emit a comment, and re-await the SAME pending pull (never dropping or
+        # reordering a real part).
+        iterator = aiter.__aiter__()
+        pending: asyncio.Task | None = None
+        try:
+            while True:
+                if pending is None:
+                    pending = asyncio.ensure_future(iterator.__anext__())
+                try:
+                    chunk = await asyncio.wait_for(
+                        asyncio.shield(pending), timeout=interval
+                    )
+                except asyncio.TimeoutError:
+                    # Still waiting on the same part — keep the connection warm and retry.
+                    yield _KEEPALIVE_FRAME
+                    continue
+                except StopAsyncIteration:
+                    break
+                pending = None
+                yield "data: " + dumps(chunk, ensure_ascii=False) + "\n\n"
+        finally:
+            if pending is not None:
+                pending.cancel()
         yield "data: [DONE]\n\n"
 
     return gen()

--- a/sdks/python/agenta/sdk/agents/utils/ts_runner.py
+++ b/sdks/python/agenta/sdk/agents/utils/ts_runner.py
@@ -13,6 +13,13 @@ from typing import Any, AsyncIterator, Dict, Optional, Sequence
 
 from agenta.sdk.utils.logging import get_module_logger
 
+# AGENTA_RUNNER_TIMEOUT_SECONDS is an IDLE timeout on the streaming transports: it bounds the
+# gap between successive records, not the whole run. The runner now owns the true end-to-end run
+# deadline server-side (it aborts a wedged run and returns a terminal record), so a long-but-
+# progressing run must not be killed here just for running long — only a stalled connection
+# (no records flowing) should trip. The HTTP transport's httpx read timeout is already per-read
+# (idle); the subprocess transport resets its deadline on each received line to match. On the
+# one-shot (dev-only) result transports there is a single request, so idle and total coincide.
 _DEFAULT_TIMEOUT = float(os.getenv("AGENTA_RUNNER_TIMEOUT_SECONDS", "180"))
 
 log = get_module_logger(__name__)
@@ -175,6 +182,8 @@ async def deliver_http_stream(
     url = base_url.rstrip("/") + "/run"
     headers = {"Accept": "application/x-ndjson", **_runner_auth_headers()}
     saw_result = False
+    # httpx applies `timeout` as a per-read timeout on a stream — i.e. an idle (between-record)
+    # bound, not a total wall-clock cap — matching the subprocess transport's per-line reset.
     async with httpx.AsyncClient(timeout=timeout) as client:
         async with client.stream(
             "POST", url, json=payload, headers=headers
@@ -239,17 +248,17 @@ async def deliver_subprocess_stream(
     # Drain stderr concurrently (mirrors communicate()'s sibling behavior) so a chatty child
     # never blocks on a full pipe while we're only reading stdout below.
     stderr_task = asyncio.create_task(_drain_stderr(proc.stderr))
-    loop = asyncio.get_running_loop()
-    deadline = loop.time() + timeout
     saw_result = False
     try:
         while True:
-            remaining = deadline - loop.time()
-            if remaining <= 0:
+            # Idle timeout: bound the gap until the NEXT record, resetting on each line, so a
+            # long-but-progressing run is never killed here (the runner owns the total deadline).
+            try:
+                raw = await asyncio.wait_for(proc.stdout.readline(), timeout=timeout)
+            except asyncio.TimeoutError:
                 raise RuntimeError(
-                    f"Agent runner stream timed out after {timeout}s: {' '.join(command)}"
+                    f"Agent runner stream stalled: no record for {timeout}s: {' '.join(command)}"
                 )
-            raw = await asyncio.wait_for(proc.stdout.readline(), timeout=remaining)
             if not raw:  # EOF
                 break
             line = raw.decode("utf-8", "replace").strip()

--- a/sdks/python/oss/tests/pytest/unit/agents/adapters/test_vercel_sse_keepalive.py
+++ b/sdks/python/oss/tests/pytest/unit/agents/adapters/test_vercel_sse_keepalive.py
@@ -1,0 +1,140 @@
+"""The Vercel SSE framing keeps a slow-but-alive run warm with keepalive comments.
+
+A proxy or load balancer idle-kills a connection with no bytes flowing. A run whose next part is
+minutes away (a long tool call) is still alive and still billing server-side, so the SSE framing
+emits an inert ``: keepalive`` comment on a periodic tick during silent gaps. These tests pin
+that a keepalive appears on a silent gap, that it never alters the data frames, and that the
+terminal ``[DONE]`` still lands.
+"""
+
+from __future__ import annotations
+
+import asyncio
+import importlib
+import json
+from typing import AsyncIterator, List
+
+import agenta.sdk.agents.adapters.vercel.sse as sse_module
+
+
+async def _collect(aiter) -> List[str]:
+    return [chunk async for chunk in aiter]
+
+
+def _reload_with_interval(monkeypatch, seconds: str):
+    """Reload the sse module so the module-level keepalive interval picks up the env override."""
+    monkeypatch.setenv("AGENTA_AGENT_SSE_KEEPALIVE_SECONDS", seconds)
+    return importlib.reload(sse_module)
+
+
+def _reload_default(monkeypatch):
+    """Reload the module back to its default interval so the override cannot leak (the read is
+    at import time; unset before reloading, since monkeypatch reverts only after the test)."""
+    monkeypatch.delenv("AGENTA_AGENT_SSE_KEEPALIVE_SECONDS", raising=False)
+    importlib.reload(sse_module)
+
+
+def _sse_payload(chunk: str) -> str:
+    assert chunk.startswith("data: ") and chunk.endswith("\n\n")
+    return chunk[len("data: ") : -2]
+
+
+async def test_keepalive_comment_is_emitted_during_a_silent_gap(monkeypatch):
+    mod = _reload_with_interval(monkeypatch, "0.02")
+    try:
+
+        async def parts() -> AsyncIterator[dict]:
+            yield {"type": "start"}
+            # A long gap (several keepalive intervals) before the next data frame.
+            await asyncio.sleep(0.1)
+            yield {"type": "finish"}
+
+        chunks = await _collect(mod.vercel_sse_stream(parts()))
+    finally:
+        _reload_default(monkeypatch)
+
+    keepalives = [c for c in chunks if c == ": keepalive\n\n"]
+    data_frames = [c for c in chunks if c.startswith("data: ")]
+
+    # At least one keepalive rode the silent gap.
+    assert len(keepalives) >= 1
+    # The data frames are exactly the two parts plus the terminal [DONE], in order and unaltered.
+    assert data_frames[0] == "data: " + json.dumps({"type": "start"}) + "\n\n"
+    assert data_frames[1] == "data: " + json.dumps({"type": "finish"}) + "\n\n"
+    assert data_frames[-1] == "data: [DONE]\n\n"
+
+
+async def test_no_keepalive_when_parts_flow_within_the_interval(monkeypatch):
+    mod = _reload_with_interval(monkeypatch, "5")
+    try:
+
+        async def parts() -> AsyncIterator[dict]:
+            yield {"type": "start"}
+            yield {"type": "text-delta", "id": "t1", "delta": "hi"}
+            yield {"type": "finish"}
+
+        chunks = await _collect(mod.vercel_sse_stream(parts()))
+    finally:
+        _reload_default(monkeypatch)
+
+    assert not any(c == ": keepalive\n\n" for c in chunks)
+    # Byte-for-byte the pre-keepalive framing: one data frame per part, then [DONE].
+    assert len(chunks) == 4
+    assert json.loads(_sse_payload(chunks[0])) == {"type": "start"}
+    assert json.loads(_sse_payload(chunks[1])) == {
+        "type": "text-delta",
+        "id": "t1",
+        "delta": "hi",
+    }
+    assert chunks[-1] == "data: [DONE]\n\n"
+
+
+async def test_keepalive_disabled_by_zero_still_frames_and_terminates(monkeypatch):
+    mod = _reload_with_interval(monkeypatch, "0")
+    try:
+
+        async def parts() -> AsyncIterator[dict]:
+            yield {"type": "start"}
+            yield {"type": "finish"}
+
+        chunks = await _collect(mod.vercel_sse_stream(parts()))
+    finally:
+        _reload_default(monkeypatch)
+
+    assert not any(c == ": keepalive\n\n" for c in chunks)
+    assert chunks == [
+        "data: " + json.dumps({"type": "start"}) + "\n\n",
+        "data: " + json.dumps({"type": "finish"}) + "\n\n",
+        "data: [DONE]\n\n",
+    ]
+
+
+async def test_empty_stream_still_emits_done_with_keepalive_enabled(monkeypatch):
+    mod = _reload_with_interval(monkeypatch, "0.02")
+    try:
+
+        async def parts() -> AsyncIterator[dict]:
+            return
+            yield  # pragma: no cover — makes this an async generator
+
+        chunks = await _collect(mod.vercel_sse_stream(parts()))
+    finally:
+        _reload_default(monkeypatch)
+
+    assert chunks == ["data: [DONE]\n\n"]
+
+
+def test_non_numeric_interval_falls_back_to_default(monkeypatch):
+    mod = _reload_with_interval(monkeypatch, "not-a-number")
+    try:
+        assert mod._KEEPALIVE_INTERVAL_SECONDS == 15.0
+    finally:
+        _reload_default(monkeypatch)
+
+
+def test_negative_interval_clamps_to_disabled(monkeypatch):
+    mod = _reload_with_interval(monkeypatch, "-5")
+    try:
+        assert mod._KEEPALIVE_INTERVAL_SECONDS == 0.0
+    finally:
+        _reload_default(monkeypatch)

--- a/sdks/python/oss/tests/pytest/unit/agents/test_runner_transport_timeout.py
+++ b/sdks/python/oss/tests/pytest/unit/agents/test_runner_transport_timeout.py
@@ -1,0 +1,177 @@
+"""The runner streaming transports treat ``AGENTA_RUNNER_TIMEOUT_SECONDS`` as an IDLE timeout.
+
+The env var means the same thing on both streaming transports: it bounds the gap between
+successive records (resets on each record), never the whole run. The runner owns the true
+end-to-end deadline server-side, so a long-but-progressing run must not be killed here — only a
+stalled connection with no records flowing should trip. These tests pin that unified semantics:
+a stream that keeps producing records within each idle window survives past the window in total,
+while a genuine stall raises.
+"""
+
+from __future__ import annotations
+
+import asyncio
+import json
+from typing import List, Optional
+
+import pytest
+
+from agenta.sdk.agents.utils import ts_runner
+
+
+class _FakeStdout:
+    """A fake ``proc.stdout`` whose ``readline`` returns queued lines on a schedule.
+
+    Each entry is ``(delay_seconds, line_bytes)``; ``readline`` sleeps ``delay`` before
+    returning the line, so ``asyncio.wait_for(readline(), timeout=...)`` sees a real gap and
+    trips only when a single gap exceeds the timeout. A trailing ``b""`` line signals EOF.
+    """
+
+    def __init__(self, script: List[tuple]) -> None:
+        self._script = list(script)
+
+    async def readline(self) -> bytes:
+        if not self._script:
+            return b""
+        delay, line = self._script.pop(0)
+        if delay:
+            await asyncio.sleep(delay)
+        return line
+
+
+class _FakeStderr:
+    async def read(self, _n: int = 65536) -> bytes:
+        return b""
+
+
+class _FakeProc:
+    def __init__(self, stdout: _FakeStdout) -> None:
+        self.stdin = _FakeStdin()
+        self.stdout = stdout
+        self.stderr = _FakeStderr()
+        self.returncode: Optional[int] = None
+
+    async def wait(self) -> int:
+        self.returncode = 0
+        return 0
+
+    def kill(self) -> None:
+        self.returncode = -9
+
+
+class _FakeStdin:
+    def write(self, _data: bytes) -> None:
+        pass
+
+    def close(self) -> None:
+        pass
+
+
+def _install_fake_subprocess(monkeypatch, script: List[tuple]) -> None:
+    async def _create(*_args, **_kwargs):
+        return _FakeProc(_FakeStdout(script))
+
+    monkeypatch.setattr(asyncio, "create_subprocess_exec", _create)
+
+
+async def _collect_subprocess(timeout: float) -> List[dict]:
+    records = []
+    async for record in ts_runner.deliver_subprocess_stream(
+        ["runner"], {"harness": "pi_core"}, timeout=timeout
+    ):
+        records.append(record)
+    return records
+
+
+# --- subprocess transport: idle (per-record) timeout ------------------------------
+
+
+async def test_subprocess_stream_survives_a_run_longer_than_the_idle_window(
+    monkeypatch,
+):
+    # Three records, each arriving 0.05s apart, with a 0.1s idle window. The total (0.15s+)
+    # exceeds the window, but no single gap does — an idle timeout must NOT fire.
+    result_line = json.dumps({"kind": "result", "result": {"ok": True}}).encode()
+    _install_fake_subprocess(
+        monkeypatch,
+        [
+            (0.05, json.dumps({"kind": "event", "event": {}}).encode() + b"\n"),
+            (0.05, json.dumps({"kind": "event", "event": {}}).encode() + b"\n"),
+            (0.05, result_line + b"\n"),
+        ],
+    )
+
+    records = await _collect_subprocess(timeout=0.1)
+
+    assert [r["kind"] for r in records] == ["event", "event", "result"]
+
+
+async def test_subprocess_stream_raises_on_a_stall_longer_than_the_idle_window(
+    monkeypatch,
+):
+    # One record arrives quickly, then a gap longer than the idle window: the transport must
+    # trip on the stall rather than hang.
+    _install_fake_subprocess(
+        monkeypatch,
+        [
+            (0.0, json.dumps({"kind": "event", "event": {}}).encode() + b"\n"),
+            (
+                0.3,
+                json.dumps({"kind": "result", "result": {"ok": True}}).encode() + b"\n",
+            ),
+        ],
+    )
+
+    with pytest.raises(RuntimeError, match="stalled"):
+        await _collect_subprocess(timeout=0.1)
+
+
+# --- HTTP transport: the timeout is handed to httpx as a per-read (idle) bound ----
+
+
+async def test_http_stream_passes_timeout_to_httpx_client(monkeypatch):
+    import httpx
+
+    captured = {}
+
+    class _Stream:
+        def __init__(self) -> None:
+            self.status_code = 200
+
+        async def __aenter__(self):
+            return self
+
+        async def __aexit__(self, *args):
+            return False
+
+        async def aiter_lines(self):
+            yield json.dumps({"kind": "result", "result": {"ok": True}})
+
+        async def aread(self) -> bytes:
+            return b""
+
+    class _Client:
+        def __init__(self, *args, **kwargs) -> None:
+            captured["timeout"] = kwargs.get("timeout")
+
+        async def __aenter__(self):
+            return self
+
+        async def __aexit__(self, *args):
+            return False
+
+        def stream(self, method, url, json=None, headers=None):
+            return _Stream()
+
+    monkeypatch.setattr(httpx, "AsyncClient", _Client)
+
+    records = [
+        record
+        async for record in ts_runner.deliver_http_stream(
+            "http://runner:8765", {"harness": "pi_core"}, timeout=7.5
+        )
+    ]
+
+    assert records == [{"kind": "result", "result": {"ok": True}}]
+    # The idle bound is handed to httpx, which applies it per-read on the stream.
+    assert captured["timeout"] == 7.5

--- a/services/runner/src/engines/sandbox_agent.ts
+++ b/services/runner/src/engines/sandbox_agent.ts
@@ -91,6 +91,10 @@ import {
   PendingApprovalPauseController,
 } from "./sandbox_agent/pause.ts";
 import {
+  createRunLimits,
+  resolveRunLimits,
+} from "./sandbox_agent/run-limits.ts";
+import {
   createInteraction,
   resolveInteraction,
   buildWorkflowReferences,
@@ -269,6 +273,8 @@ export interface SandboxAgentDeps extends BuildRunPlanDeps {
   unmountStorage?: typeof unmountStorage;
   discoverTunnelEndpoint?: typeof discoverTunnelEndpoint;
   responderFactory?: (request: AgentRunRequest) => Responder;
+  resolveRunLimits?: typeof resolveRunLimits;
+  createRunLimits?: typeof createRunLimits;
   log?: Log;
 }
 
@@ -452,6 +458,22 @@ export async function runSandboxAgent(
   // so its handler is torn down deterministically and cannot write a result after the turn ends.
   // Fired by the pause controller's destroy path and, as a backstop, by the `finally`.
   const mcpAbort = new AbortController();
+  // Time-based run deadlines (total/idle/TTFB/per-tool-call): tripping one aborts the run the
+  // SAME way a client disconnect does, so this existing `finally` reclaims the sandbox — no new
+  // teardown. Merged with the caller's own signal (a client disconnect on a non-session run)
+  // so either source can end the run; whichever fires first wins.
+  const deadlineAbort = new AbortController();
+  const runLimits = (deps.createRunLimits ?? createRunLimits)(
+    (deps.resolveRunLimits ?? resolveRunLimits)(logger),
+    { log: logger },
+  );
+  runLimits.onTrip((reason) => {
+    logger(`run limit tripped: ${reason}`);
+    deadlineAbort.abort(new Error(reason));
+  });
+  const runSignal = signal
+    ? AbortSignal.any([signal, deadlineAbort.signal])
+    : deadlineAbort.signal;
   // Durable cwd: set to the host mountpoint once a session-owned local run geesefs-mounts its
   // store prefix, so the `finally` can unmount it. Undefined for non-session/remote/unmounted runs.
   let mountedCwd: string | undefined;
@@ -543,9 +565,11 @@ export async function runSandboxAgent(
         plan.sandboxPermission,
       ),
       persist,
-      // Propagate caller cancellation (a client disconnect on the streaming HTTP edge) so an
-      // in-flight run aborts instead of finishing unobserved. The `finally` still disposes.
-      ...(signal ? { signal } : {}),
+      // Propagate caller cancellation (a client disconnect on the streaming HTTP edge) merged
+      // with the run-limits deadline signal, so either one aborts an in-flight run instead of
+      // it finishing unobserved. The `finally` still disposes. Always defined (unlike the raw
+      // `signal` param) because the deadline signal exists even with no caller signal.
+      signal: runSignal,
       // Drive the ACP HTTP client through a long-timeout undici dispatcher so a paused HITL
       // turn (the connection held open while a human approves a tool) is NOT reaped by
       // undici's default `headersTimeout` (which would kill it with UND_ERR_HEADERS_TIMEOUT).
@@ -721,7 +745,10 @@ export async function runSandboxAgent(
       authorization: request.telemetry?.exporters?.otlp?.headers?.authorization,
       captureContent: request.telemetry?.capture?.content?.enabled,
       emitSpans: !plan.isPi || plan.isDaytona,
-      emit,
+      // Every emitted event is a progress signal for the idle/TTFB deadlines (message/thought
+      // deltas, tool calls and results, usage, ...) — this is the one seam every harness's
+      // output already flows through.
+      emit: emit && runLimits.wrapEmit(emit),
     });
     otel = run;
 
@@ -745,6 +772,10 @@ export async function runSandboxAgent(
       sessionDestroyRequested = true;
       return sandbox.destroySession?.(session.id);
     });
+    // The pause signal resolves exactly once, the moment a turn parks for human input — that is
+    // the one place every pause path (ACP gate, relay, internal MCP) converges, so it is also
+    // the one place to retire the run-limits deadlines for good.
+    void pause.signal.then(() => runLimits.notePaused());
 
     session.onEvent((event: any) => {
       remountLocalCwdAfterRuntimeEnotconn(event);
@@ -754,6 +785,18 @@ export async function runSandboxAgent(
         // Record live ACP tool_call ids so a paused client_tool can correlate to Claude's
         // bubble (recorded even for suppressed frames; a lookup CONSUMES its matched id).
         toolCallIndex.record(update);
+        // Per-tool-call deadline: starts on the announcement, ends on a terminal status.
+        // Tracked regardless of pause-suppression below (a call already timed out must not
+        // linger just because a later sibling frame gets suppressed).
+        if (update.sessionUpdate === "tool_call" && update.toolCallId) {
+          runLimits.noteToolCallStart(String(update.toolCallId));
+        } else if (
+          update.sessionUpdate === "tool_call_update" &&
+          update.toolCallId &&
+          (update.status === "completed" || update.status === "failed")
+        ) {
+          runLimits.noteToolCallEnd(String(update.toolCallId));
+        }
         if (!shouldSuppressPausedToolCallUpdate(update, pause)) {
           run.handleUpdate(update);
           // A sibling announced AFTER the pause won the latch can never execute (the session
@@ -1002,6 +1045,7 @@ export async function runSandboxAgent(
       error,
     };
   } finally {
+    runLimits.dispose();
     await runtimeRemount?.catch(() => {});
     if (sandbox) inFlightSandboxes.delete(sandbox);
     await toolRelay?.stop().catch(() => {});

--- a/services/runner/src/engines/sandbox_agent/acp-fetch.ts
+++ b/services/runner/src/engines/sandbox_agent/acp-fetch.ts
@@ -8,30 +8,43 @@ import { Agent, fetch as undiciFetch } from "undici";
  * `failReadable()` and the ACP stream dies with `UND_ERR_HEADERS_TIMEOUT`, killing both the
  * paused turn and the resume turn. A plain chat completes in seconds so it never trips this.
  *
- * The fix is to drive the ACP HTTP client through an undici dispatcher whose timeouts are
- * disabled (0) or set to a long pause window, instead of the default. We scope it to the ACP
- * fetch the `sandbox-agent` SDK uses rather than touching the global dispatcher, so unrelated
- * HTTP keeps its safe defaults.
+ * The fix is to drive the ACP HTTP client through an undici dispatcher whose timeouts are wide
+ * (wider than the total run deadline in `run-limits.ts`, so a pause is never the one that trips
+ * this) or fully disabled (0), instead of undici's short default. We scope it to the ACP fetch the
+ * `sandbox-agent` SDK uses rather than touching the global dispatcher, so unrelated HTTP keeps its
+ * safe defaults. This is the low-level backstop UNDER the total deadline: the total deadline is
+ * what normally ends a wedged run; this only matters if the harness's own connection hangs in a
+ * way our abort signal can't reach.
  */
 
-/** Disabled by default (0 = no timeout). Override with a millisecond value if a bound is wanted. */
-function envTimeoutMs(name: string): number {
+/** `0` disables the timeout outright; otherwise the millisecond value (default or override). */
+function envTimeoutMs(name: string, defaultMs: number): number {
   const raw = process.env[name];
-  if (raw === undefined || raw === "") return 0;
+  if (raw === undefined || raw === "") return defaultMs;
   const parsed = Number(raw);
-  return Number.isFinite(parsed) && parsed >= 0 ? parsed : 0;
+  return Number.isFinite(parsed) && parsed >= 0 ? parsed : defaultMs;
 }
+
+/** Wider than the total run deadline default so an ordinary run/pause never trips this first. */
+const DEFAULT_ACP_HEADERS_TIMEOUT_MS = 60 * 60_000; // 60 min
+const DEFAULT_ACP_BODY_TIMEOUT_MS = 60 * 60_000; // 60 min
 
 /**
  * Build the long-timeout undici dispatcher used for ACP HTTP. `headersTimeout` is the one that
  * reaps a paused turn (no response headers arrive while the human deliberates); `bodyTimeout`
- * guards the streamed body. Both default to disabled so a pause held for any human-timescale
- * delay is never reaped. `keepAliveTimeout`/`keepAliveMaxTimeout` are raised so the connection
- * is not pooled-closed mid-pause either.
+ * guards the streamed body. Both default wide (not disabled) so they still backstop a truly
+ * stuck connection, without reaping a human-timescale pause. `keepAliveTimeout`/
+ * `keepAliveMaxTimeout` are raised so the connection is not pooled-closed mid-pause either.
  */
 export function createAcpDispatcher(): Agent {
-  const headersTimeout = envTimeoutMs("SANDBOX_AGENT_ACP_HEADERS_TIMEOUT_MS");
-  const bodyTimeout = envTimeoutMs("SANDBOX_AGENT_ACP_BODY_TIMEOUT_MS");
+  const headersTimeout = envTimeoutMs(
+    "SANDBOX_AGENT_ACP_HEADERS_TIMEOUT_MS",
+    DEFAULT_ACP_HEADERS_TIMEOUT_MS,
+  );
+  const bodyTimeout = envTimeoutMs(
+    "SANDBOX_AGENT_ACP_BODY_TIMEOUT_MS",
+    DEFAULT_ACP_BODY_TIMEOUT_MS,
+  );
   return new Agent({
     headersTimeout,
     bodyTimeout,

--- a/services/runner/src/engines/sandbox_agent/run-limits.ts
+++ b/services/runner/src/engines/sandbox_agent/run-limits.ts
@@ -1,0 +1,202 @@
+/**
+ * Time-based run limits: the runner had no deadline anywhere, so a wedged run (daemon up but
+ * never engaging, or a harness that stops making progress mid-turn) held its sandbox/mount/socket
+ * forever while the platform still reported the session healthy. This computes and enforces the
+ * time dimension only (no step/byte counting) and fires the caller's `abort()` when a limit trips,
+ * so the EXISTING `runSandboxAgent` `finally` reclaims exactly as it does for any other abort.
+ *
+ * Every limit is env-overridable with a wide default (see the `_ENV` constants below) and the
+ * whole thing goes inert once the run pauses for human input (`notePaused()`) — a HITL pause is a
+ * legitimate, human-timescale wait, not a wedge, and must never be reaped by these deadlines.
+ */
+
+export interface Clock {
+  now(): number;
+  setTimeout(fn: () => void, ms: number): NodeJS.Timeout;
+  clearTimeout(handle: NodeJS.Timeout): void;
+}
+
+const realClock: Clock = {
+  now: () => Date.now(),
+  setTimeout: (fn, ms) => setTimeout(fn, ms),
+  clearTimeout: (handle) => clearTimeout(handle),
+};
+
+function envMs(name: string, defaultMs: number): number {
+  const raw = process.env[name];
+  if (raw === undefined || raw === "") return defaultMs;
+  const parsed = Number(raw);
+  return Number.isFinite(parsed) && parsed >= 0 ? parsed : defaultMs;
+}
+
+export const TOTAL_DEADLINE_ENV = "AGENTA_RUNNER_RUN_TOTAL_TIMEOUT_MS";
+export const IDLE_TIMEOUT_ENV = "AGENTA_RUNNER_RUN_IDLE_TIMEOUT_MS";
+export const TTFB_TIMEOUT_ENV = "AGENTA_RUNNER_RUN_TTFB_TIMEOUT_MS";
+export const TOOL_CALL_TIMEOUT_ENV = "AGENTA_RUNNER_TOOL_CALL_TIMEOUT_MS";
+
+export const DEFAULT_TOTAL_DEADLINE_MS = 45 * 60_000; // 45 min
+export const DEFAULT_IDLE_TIMEOUT_MS = 5 * 60_000; // 5 min
+export const DEFAULT_TTFB_TIMEOUT_MS = 2 * 60_000; // 2 min
+export const DEFAULT_TOOL_CALL_TIMEOUT_MS = 5 * 60_000; // 5 min
+
+export interface ResolvedRunLimits {
+  totalMs: number;
+  idleMs: number;
+  ttfbMs: number;
+  toolCallMs: number;
+}
+
+/**
+ * Read every limit from its env var (wide default otherwise). `idle` must stay below `total` or
+ * the idle timer could never be the one that fires — a misconfigured env clamps `idle` down
+ * rather than throwing, since a bad override must not break every run in the process.
+ */
+export function resolveRunLimits(
+  log: (message: string) => void = () => {},
+): ResolvedRunLimits {
+  const totalMs = envMs(TOTAL_DEADLINE_ENV, DEFAULT_TOTAL_DEADLINE_MS);
+  let idleMs = envMs(IDLE_TIMEOUT_ENV, DEFAULT_IDLE_TIMEOUT_MS);
+  const ttfbMs = envMs(TTFB_TIMEOUT_ENV, DEFAULT_TTFB_TIMEOUT_MS);
+  const toolCallMs = envMs(TOOL_CALL_TIMEOUT_ENV, DEFAULT_TOOL_CALL_TIMEOUT_MS);
+  if (idleMs >= totalMs) {
+    log(
+      `[run-limits] idle timeout (${idleMs}ms) >= total deadline (${totalMs}ms); clamping idle to half the total`,
+    );
+    idleMs = Math.floor(totalMs / 2);
+  }
+  return { totalMs, idleMs, ttfbMs, toolCallMs };
+}
+
+export interface RunLimitsHandle {
+  /** Fires (once) the moment any limit trips; the caller wires this to its own `abort()`. */
+  onTrip(handler: (reason: string) => void): void;
+  /** Call on every tool call announcement; the per-tool-call timer keys off this id. */
+  noteToolCallStart(id: string): void;
+  /** Call once the tool call's result lands; clears its per-call timer. */
+  noteToolCallEnd(id: string): void;
+  /** Wrap an `EmitEvent` sink so every event it sees also resets idle/TTFB — the one
+   *  observation point every harness's progress already flows through. */
+  wrapEmit(emit: (event: any) => void): (event: any) => void;
+  /** The turn parked for human input: freeze every timer for good (the pause path owns the
+   *  turn's end from here; these deadlines must never re-fire on top of it). */
+  notePaused(): void;
+  /** Release every timer. Always call this once the run ends, on every path. */
+  dispose(): void;
+}
+
+/**
+ * Build the run-limit enforcement for one run. Arms the total deadline and the TTFB timer
+ * immediately; the first progress event (via `wrapEmit`) cancels TTFB and arms the recurring idle
+ * timer. Any of total/idle/ttfb/tool-call tripping calls the `onTrip` handler exactly once — after
+ * that (or after `dispose`) the instance is inert, so a caller can always safely `dispose()` in its
+ * own `finally` without double-firing or re-arming on a late event.
+ */
+export function createRunLimits(
+  limits: ResolvedRunLimits,
+  {
+    clock = realClock,
+    log = () => {},
+  }: { clock?: Clock; log?: (message: string) => void } = {},
+): RunLimitsHandle {
+  let tripped = false;
+  let paused = false;
+  let tripHandler: ((reason: string) => void) | undefined;
+  let sawFirstProgress = false;
+
+  let totalTimer: NodeJS.Timeout | undefined;
+  let idleTimer: NodeJS.Timeout | undefined;
+  let ttfbTimer: NodeJS.Timeout | undefined;
+  const toolCallTimers = new Map<string, NodeJS.Timeout>();
+
+  const clearAll = (): void => {
+    if (totalTimer) clock.clearTimeout(totalTimer);
+    if (idleTimer) clock.clearTimeout(idleTimer);
+    if (ttfbTimer) clock.clearTimeout(ttfbTimer);
+    for (const timer of toolCallTimers.values()) clock.clearTimeout(timer);
+    totalTimer = undefined;
+    idleTimer = undefined;
+    ttfbTimer = undefined;
+    toolCallTimers.clear();
+  };
+
+  const trip = (reason: string): void => {
+    if (tripped || paused) return;
+    tripped = true;
+    clearAll();
+    log(`[run-limits] ${reason}`);
+    tripHandler?.(reason);
+  };
+
+  const armIdle = (): void => {
+    if (tripped || paused) return;
+    if (idleTimer) clock.clearTimeout(idleTimer);
+    idleTimer = clock.setTimeout(
+      () => trip(`idle timeout after ${limits.idleMs}ms with no progress`),
+      limits.idleMs,
+    );
+  };
+
+  totalTimer = clock.setTimeout(
+    () => trip(`total run deadline of ${limits.totalMs}ms exceeded`),
+    limits.totalMs,
+  );
+  ttfbTimer = clock.setTimeout(
+    () => trip(`no first response within ${limits.ttfbMs}ms of run start`),
+    limits.ttfbMs,
+  );
+
+  const noteProgress = (): void => {
+    if (tripped || paused) return;
+    if (!sawFirstProgress) {
+      sawFirstProgress = true;
+      if (ttfbTimer) clock.clearTimeout(ttfbTimer);
+      ttfbTimer = undefined;
+    }
+    armIdle();
+  };
+
+  return {
+    onTrip(handler) {
+      tripHandler = handler;
+    },
+    noteToolCallStart(id) {
+      if (tripped || paused || !id) return;
+      noteProgress();
+      const existing = toolCallTimers.get(id);
+      if (existing) clock.clearTimeout(existing);
+      toolCallTimers.set(
+        id,
+        clock.setTimeout(() => {
+          toolCallTimers.delete(id);
+          trip(`tool call ${id} exceeded ${limits.toolCallMs}ms`);
+        }, limits.toolCallMs),
+      );
+    },
+    noteToolCallEnd(id) {
+      const timer = toolCallTimers.get(id);
+      if (timer) {
+        clock.clearTimeout(timer);
+        toolCallTimers.delete(id);
+      }
+      noteProgress();
+    },
+    wrapEmit(emit) {
+      // Every event is progress for idle/TTFB purposes; per-tool-call timers are driven
+      // separately by noteToolCallStart/End (called from the raw ACP update handler, which
+      // knows the harness's tool-call id before this typed event is even built).
+      return (event: any) => {
+        noteProgress();
+        emit(event);
+      };
+    },
+    notePaused() {
+      paused = true;
+      clearAll();
+    },
+    dispose() {
+      // Mark inert so a late ACP event cannot re-arm a timer after teardown.
+      tripped = true;
+      clearAll();
+    },
+  };
+}

--- a/services/runner/tests/unit/run-limits.test.ts
+++ b/services/runner/tests/unit/run-limits.test.ts
@@ -1,0 +1,283 @@
+/**
+ * Unit tests for the time-based run-limit engine (total/idle/TTFB/per-tool-call deadlines).
+ *
+ * A fake, manually-advanced clock stands in for real timers so every test is instant and
+ * deterministic (see `fakeClock()` below) — no test waits on a real setTimeout.
+ *
+ * Run: pnpm test (or: pnpm exec vitest run tests/unit/run-limits.test.ts)
+ */
+import { describe, it } from "vitest";
+import assert from "node:assert/strict";
+
+import {
+  createRunLimits,
+  resolveRunLimits,
+  DEFAULT_IDLE_TIMEOUT_MS,
+  DEFAULT_TOTAL_DEADLINE_MS,
+  DEFAULT_TTFB_TIMEOUT_MS,
+  DEFAULT_TOOL_CALL_TIMEOUT_MS,
+  TOTAL_DEADLINE_ENV,
+  IDLE_TIMEOUT_ENV,
+  TTFB_TIMEOUT_ENV,
+  TOOL_CALL_TIMEOUT_ENV,
+  type Clock,
+} from "../../src/engines/sandbox_agent/run-limits.ts";
+
+/** A manually-advanced fake clock: `advance(ms)` fires every timer now due, in schedule order. */
+function fakeClock() {
+  let now = 0;
+  let nextId = 1;
+  const pending = new Map<number, { at: number; fn: () => void }>();
+  const clock: Clock = {
+    now: () => now,
+    setTimeout: (fn, ms) => {
+      const id = nextId++;
+      pending.set(id, { at: now + ms, fn });
+      return id as unknown as NodeJS.Timeout;
+    },
+    clearTimeout: (handle) => {
+      pending.delete(handle as unknown as number);
+    },
+  };
+  const advance = (ms: number): void => {
+    now += ms;
+    for (const [id, entry] of [...pending.entries()].sort(
+      (a, b) => a[1].at - b[1].at,
+    )) {
+      if (entry.at <= now && pending.has(id)) {
+        pending.delete(id);
+        entry.fn();
+      }
+    }
+  };
+  return { clock, advance, pendingCount: () => pending.size };
+}
+
+const envKeys = [
+  TOTAL_DEADLINE_ENV,
+  IDLE_TIMEOUT_ENV,
+  TTFB_TIMEOUT_ENV,
+  TOOL_CALL_TIMEOUT_ENV,
+];
+
+function withEnv(overrides: Record<string, string | undefined>, fn: () => void): void {
+  const previous = new Map<string, string | undefined>();
+  for (const key of envKeys) previous.set(key, process.env[key]);
+  for (const [key, value] of Object.entries(overrides)) {
+    if (value === undefined) delete process.env[key];
+    else process.env[key] = value;
+  }
+  try {
+    fn();
+  } finally {
+    for (const key of envKeys) {
+      const value = previous.get(key);
+      if (value === undefined) delete process.env[key];
+      else process.env[key] = value;
+    }
+  }
+}
+
+describe("resolveRunLimits", () => {
+  it("defaults every limit wide with idle strictly under total", () => {
+    withEnv(
+      {
+        [TOTAL_DEADLINE_ENV]: undefined,
+        [IDLE_TIMEOUT_ENV]: undefined,
+        [TTFB_TIMEOUT_ENV]: undefined,
+        [TOOL_CALL_TIMEOUT_ENV]: undefined,
+      },
+      () => {
+        const limits = resolveRunLimits();
+        assert.equal(limits.totalMs, DEFAULT_TOTAL_DEADLINE_MS);
+        assert.equal(limits.idleMs, DEFAULT_IDLE_TIMEOUT_MS);
+        assert.equal(limits.ttfbMs, DEFAULT_TTFB_TIMEOUT_MS);
+        assert.equal(limits.toolCallMs, DEFAULT_TOOL_CALL_TIMEOUT_MS);
+        assert.ok(limits.idleMs < limits.totalMs);
+      },
+    );
+  });
+
+  it("honors env overrides for every limit", () => {
+    withEnv(
+      {
+        [TOTAL_DEADLINE_ENV]: "1000000",
+        [IDLE_TIMEOUT_ENV]: "100000",
+        [TTFB_TIMEOUT_ENV]: "5000",
+        [TOOL_CALL_TIMEOUT_ENV]: "200000",
+      },
+      () => {
+        const limits = resolveRunLimits();
+        assert.equal(limits.totalMs, 1000000);
+        assert.equal(limits.idleMs, 100000);
+        assert.equal(limits.ttfbMs, 5000);
+        assert.equal(limits.toolCallMs, 200000);
+      },
+    );
+  });
+
+  it("clamps idle below total instead of leaving idle unreachable when misconfigured", () => {
+    withEnv(
+      {
+        [TOTAL_DEADLINE_ENV]: "60000",
+        [IDLE_TIMEOUT_ENV]: "90000", // idle > total: must not survive as-is
+      },
+      () => {
+        const limits = resolveRunLimits();
+        assert.ok(limits.idleMs < limits.totalMs);
+        assert.equal(limits.idleMs, 30000); // clamped to half of total
+      },
+    );
+  });
+});
+
+describe("createRunLimits", () => {
+  it("trips the total deadline and reports the reason exactly once", () => {
+    const { clock, advance } = fakeClock();
+    const limits = createRunLimits(
+      { totalMs: 1000, idleMs: 500, ttfbMs: 2000, toolCallMs: 2000 },
+      { clock },
+    );
+    const trips: string[] = [];
+    limits.onTrip((reason) => trips.push(reason));
+
+    advance(999);
+    assert.equal(trips.length, 0, "must not trip before the deadline");
+    advance(2);
+    assert.equal(trips.length, 1);
+    assert.match(trips[0], /total run deadline/);
+
+    // Idempotent: nothing else should fire after the first trip (timers were cleared).
+    advance(100000);
+    assert.equal(trips.length, 1);
+  });
+
+  it("trips idle only after no progress for the idle window, resetting on each progress signal", () => {
+    const { clock, advance } = fakeClock();
+    const limits = createRunLimits(
+      { totalMs: 100000, idleMs: 1000, ttfbMs: 100000, toolCallMs: 100000 },
+      { clock },
+    );
+    const trips: string[] = [];
+    limits.onTrip((reason) => trips.push(reason));
+    const emit = limits.wrapEmit(() => {});
+
+    // Progress every 900ms keeps pushing the idle deadline out, so it never fires.
+    for (let i = 0; i < 5; i++) {
+      advance(900);
+      emit({ type: "message_delta", id: "m1", delta: "x" });
+    }
+    assert.equal(trips.length, 0, "idle must reset on each progress signal");
+
+    // Now stop making progress: the idle window elapses uninterrupted.
+    advance(1000);
+    assert.equal(trips.length, 1);
+    assert.match(trips[0], /idle timeout/);
+  });
+
+  it("trips TTFB when no event arrives before the first-response window, and cancels TTFB once one does", () => {
+    const { clock, advance } = fakeClock();
+    const limits = createRunLimits(
+      { totalMs: 100000, idleMs: 100000, ttfbMs: 1000, toolCallMs: 100000 },
+      { clock },
+    );
+    const trips: string[] = [];
+    limits.onTrip((reason) => trips.push(reason));
+
+    advance(1000);
+    assert.equal(trips.length, 1);
+    assert.match(trips[0], /first response/);
+  });
+
+  it("does not trip TTFB once the first progress event arrives before the window elapses", () => {
+    const { clock, advance } = fakeClock();
+    const limits = createRunLimits(
+      { totalMs: 100000, idleMs: 100000, ttfbMs: 1000, toolCallMs: 100000 },
+      { clock },
+    );
+    const trips: string[] = [];
+    limits.onTrip((reason) => trips.push(reason));
+    const emit = limits.wrapEmit(() => {});
+
+    advance(500);
+    emit({ type: "message_delta", id: "m1", delta: "x" });
+    advance(600); // would have tripped TTFB at 1000ms if not cancelled by the event above
+    assert.equal(trips.length, 0);
+  });
+
+  it("trips a per-tool-call timeout for a hung tool call without affecting a sibling", () => {
+    const { clock, advance } = fakeClock();
+    const limits = createRunLimits(
+      { totalMs: 100000, idleMs: 100000, ttfbMs: 100000, toolCallMs: 1000 },
+      { clock },
+    );
+    const trips: string[] = [];
+    limits.onTrip((reason) => trips.push(reason));
+
+    limits.noteToolCallStart("call-1");
+    advance(500);
+    limits.noteToolCallStart("call-2"); // a second, independent call
+    advance(400);
+    limits.noteToolCallEnd("call-2"); // call-2 finishes in time
+    assert.equal(trips.length, 0);
+
+    advance(600); // call-1 has now been open 1500ms > 1000ms
+    assert.equal(trips.length, 1);
+    assert.match(trips[0], /tool call call-1/);
+  });
+
+  it("does not trip a tool call that ends before its own deadline", () => {
+    const { clock, advance } = fakeClock();
+    const limits = createRunLimits(
+      { totalMs: 100000, idleMs: 100000, ttfbMs: 100000, toolCallMs: 1000 },
+      { clock },
+    );
+    const trips: string[] = [];
+    limits.onTrip((reason) => trips.push(reason));
+
+    limits.noteToolCallStart("call-1");
+    advance(900);
+    limits.noteToolCallEnd("call-1");
+    advance(1000); // long past the original deadline, but the call already ended
+    assert.equal(trips.length, 0);
+  });
+
+  it("a paused turn is never reaped by idle, total, or an in-flight tool-call timer", () => {
+    const { clock, advance } = fakeClock();
+    const limits = createRunLimits(
+      { totalMs: 2000, idleMs: 500, ttfbMs: 2000, toolCallMs: 500 },
+      { clock },
+    );
+    const trips: string[] = [];
+    limits.onTrip((reason) => trips.push(reason));
+
+    limits.noteToolCallStart("paused-call");
+    advance(100);
+    limits.notePaused(); // the turn parks for human input before any deadline elapses
+
+    // Every window that would otherwise fire elapses many times over.
+    advance(1_000_000);
+    assert.equal(
+      trips.length,
+      0,
+      "a paused turn must never trip total/idle/per-tool-call deadlines",
+    );
+  });
+
+  it("dispose() is safe to call on every path and prevents any later trip", () => {
+    const { clock, advance } = fakeClock();
+    const limits = createRunLimits(
+      { totalMs: 1000, idleMs: 500, ttfbMs: 1000, toolCallMs: 1000 },
+      { clock },
+    );
+    const trips: string[] = [];
+    limits.onTrip((reason) => trips.push(reason));
+
+    limits.dispose();
+    advance(1_000_000);
+    assert.equal(trips.length, 0);
+
+    // Calling dispose again (e.g. from a finally after an earlier explicit dispose) must not throw.
+    assert.doesNotThrow(() => limits.dispose());
+  });
+});

--- a/services/runner/tests/unit/sandbox-agent-acp-fetch.test.ts
+++ b/services/runner/tests/unit/sandbox-agent-acp-fetch.test.ts
@@ -3,8 +3,9 @@
  *
  * HITL parks the ACP connection open while a human approves a tool; the default undici
  * `headersTimeout` would reap it (UND_ERR_HEADERS_TIMEOUT) and kill the parked + resume turns.
- * These tests pin that the ACP dispatcher disables those timeouts by default and honors the
- * env overrides.
+ * These tests pin that the ACP dispatcher defaults to a wide (not short, not disabled) timeout —
+ * wide enough that an ordinary pause or run never trips it — and honors the env overrides,
+ * including `0` to disable outright.
  *
  * Run: pnpm test (or: pnpm exec vitest run tests/unit/sandbox-agent-acp-fetch.test.ts)
  */
@@ -41,12 +42,14 @@ function agentOptions(dispatcher: object): Record<string, unknown> {
 }
 
 describe("createAcpDispatcher", () => {
-  it("disables headers/body timeouts by default so a parked HITL turn is not reaped", () => {
+  it("defaults headers/body timeouts wide so a parked HITL turn is not reaped", () => {
     delete process.env.SANDBOX_AGENT_ACP_HEADERS_TIMEOUT_MS;
     delete process.env.SANDBOX_AGENT_ACP_BODY_TIMEOUT_MS;
     const opts = agentOptions(createAcpDispatcher());
-    assert.equal(opts.headersTimeout, 0);
-    assert.equal(opts.bodyTimeout, 0);
+    // Wide enough that no ordinary pause or run trips it (see run-limits.ts for the total
+    // deadline this backstops); not disabled outright, so a truly stuck connection still ends.
+    assert.equal(opts.headersTimeout, 60 * 60_000);
+    assert.equal(opts.bodyTimeout, 60 * 60_000);
   });
 
   it("honors a positive env override for the headers and body timeout", () => {
@@ -57,10 +60,16 @@ describe("createAcpDispatcher", () => {
     assert.equal(opts.bodyTimeout, 120000);
   });
 
-  it("falls back to disabled (0) for a non-numeric override", () => {
-    process.env.SANDBOX_AGENT_ACP_HEADERS_TIMEOUT_MS = "not-a-number";
+  it("honors an explicit 0 override to disable the timeout outright", () => {
+    process.env.SANDBOX_AGENT_ACP_HEADERS_TIMEOUT_MS = "0";
     const opts = agentOptions(createAcpDispatcher());
     assert.equal(opts.headersTimeout, 0);
+  });
+
+  it("falls back to the wide default for a non-numeric override", () => {
+    process.env.SANDBOX_AGENT_ACP_HEADERS_TIMEOUT_MS = "not-a-number";
+    const opts = agentOptions(createAcpDispatcher());
+    assert.equal(opts.headersTimeout, 60 * 60_000);
   });
 });
 

--- a/services/runner/tests/unit/sandbox-agent-orchestration.test.ts
+++ b/services/runner/tests/unit/sandbox-agent-orchestration.test.ts
@@ -48,6 +48,11 @@ interface FakeOptions {
   // Make the managed cancel reject (and NOT resolve the hung prompt), so the only thing that
   // ends the turn is the local park signal — proves the run still terminates if cancel fails.
   destroySessionError?: Error;
+  // Mirrors what the real sandbox-agent package does when the caller's AbortSignal fires mid-
+  // prompt: resolve the in-flight prompt with a cancelled stop reason. Lets a hung-prompt fixture
+  // stand in for a wedged harness that a run-limits deadline (which aborts `startOptions.signal`)
+  // must be able to unstick.
+  abortSignalCancelsHungPrompt?: boolean;
 }
 
 function fakeHarness(options: FakeOptions = {}) {
@@ -220,6 +225,11 @@ function fakeHarness(options: FakeOptions = {}) {
     createPersist: () => ({}) as any,
     startSandboxAgent: (async (opts: any) => {
       calls.startOptions = opts;
+      if (options.abortSignalCancelsHungPrompt && opts.signal) {
+        opts.signal.addEventListener("abort", () => {
+          resolveHungPrompt?.({ stopReason: "cancelled" });
+        });
+      }
       return sandbox;
     }) as any,
     prepareWorkspace: (async ({ plan }: any) => {
@@ -925,7 +935,12 @@ describe("runSandboxAgent orchestration", () => {
     );
 
     assert.equal(result.ok, true);
-    assert.equal(calls.startOptions.signal, controller.signal);
+    // The signal handed to the harness is merged with the run-limits deadline signal
+    // (AbortSignal.any), so it is no longer the identical object — but aborting the caller's
+    // controller must still abort the merged signal the harness observes.
+    assert.equal(calls.startOptions.signal.aborted, false);
+    controller.abort();
+    assert.equal(calls.startOptions.signal.aborted, true);
   });
 
   it("clears inherited provider env on a managed run and applies ANTHROPIC_BASE_URL for claude", async () => {
@@ -1668,5 +1683,77 @@ describe("runSandboxAgent default ApprovalResponder wiring", () => {
     assert.deepEqual(calls.permissionReplies, [
       { id: "perm-1", reply: "once" },
     ]);
+  });
+});
+
+describe("runSandboxAgent run-limits deadline", () => {
+  // Tiny real-ms limits: the run-limits DI seam overrides the whole resolve step, and the
+  // integration path needs the real createRunLimits (timers + abort wiring) rather than a fake
+  // clock, so the windows are set to a few ms and driven by real timers here.
+  const fastLimits = {
+    resolveRunLimits: () => ({
+      totalMs: 5,
+      idleMs: 5,
+      ttfbMs: 5,
+      toolCallMs: 5,
+    }),
+  };
+
+  it("aborts a wedged never-responding run so the existing finally reclaims the sandbox", async () => {
+    const { calls, deps } = fakeHarness({
+      // The harness comes up but the prompt never resolves on its own — a wedged run. Only an
+      // abort of the run signal (which a tripped deadline fires) can unstick it.
+      hangPrompt: true,
+      abortSignalCancelsHungPrompt: true,
+    });
+
+    const result = await runSandboxAgent(
+      { harness: "claude", messages: [{ role: "user", content: "hello" }] },
+      undefined,
+      undefined,
+      { ...deps, ...fastLimits },
+    );
+
+    // The run RETURNED (did not hang) and the teardown finally ran: sandbox destroyed + disposed.
+    assert.equal(calls.sandboxDestroyed, 1);
+    assert.equal(calls.sandboxDisposed, 1);
+    assert.equal(calls.runFinished, 1);
+    // The prompt resolved via the deadline-driven abort, so the turn ends cancelled, not a hang.
+    if (result.ok) assert.equal(result.stopReason, "cancelled");
+  });
+
+  it("does NOT abort a turn that paused for human input, even past every deadline window", async () => {
+    // A gated tool call parks the turn (pause path), which retires the deadlines. With tiny
+    // limits, a wedged turn WOULD trip almost immediately — so a clean `paused` finish (never a
+    // deadline `cancelled`) proves the pause exemption held. The prompt hangs; only the local
+    // park signal ends the turn. Setup mirrors the F-040 park test above (real ApprovalResponder).
+    const { calls, deps } = (() => {
+      const { calls, deps } = fakeHarness({
+        emitPermission: true,
+        hangPrompt: true,
+      });
+      delete deps.responderFactory; // engine ApprovalResponder -> pauses (effective ask, no decision)
+      return { calls, deps };
+    })();
+
+    const result = await runSandboxAgent(
+      {
+        harness: "claude",
+        sessionId: "conv-paused",
+        permissions: { default: "ask" },
+        messages: [{ role: "user", content: "edit the file" }],
+      },
+      undefined,
+      undefined,
+      { ...deps, ...fastLimits },
+    );
+    await flushPromises();
+
+    assert.equal(result.ok, true);
+    if (!result.ok) return;
+    // Paused, not cancelled: the pause path — not a deadline abort — ended the turn.
+    assert.equal(result.stopReason, "paused");
+    // The finally still reclaimed the sandbox on the pause path.
+    assert.equal(calls.sandboxDestroyed, 1);
   });
 });


### PR DESCRIPTION
## Context

A wedged agent run had no deadline anywhere in the execution chain. If a provider, adapter, or the ACP transport stalled, the run leaked its daemon, sandbox, mount, and socket forever while the platform still reported the session healthy, and it kept billing the whole time. The ACP fetch timeouts defaulted to `0` (off), and only non-session runs wired up an abort on client disconnect. Session-owned runs got no abort and no deadline at all.

## What this adds

Time-based run limits in the runner, each with its own bound, all env-overridable, all defaulting very wide so a legitimately long agent never trips them. The limits exist to catch wedged or runaway runs, not to shape normal ones.

| Limit | Env var | Default |
| --- | --- | --- |
| Total run deadline | `AGENTA_RUNNER_RUN_TOTAL_TIMEOUT_MS` | 45 min |
| Idle / no-progress | `AGENTA_RUNNER_RUN_IDLE_TIMEOUT_MS` | 5 min |
| First response (TTFB) | `AGENTA_RUNNER_RUN_TTFB_TIMEOUT_MS` | 2 min |
| Per-tool-call | `AGENTA_RUNNER_TOOL_CALL_TIMEOUT_MS` | 5 min |
| ACP headers backstop | `SANDBOX_AGENT_ACP_HEADERS_TIMEOUT_MS` | 60 min (was `0`) |
| ACP body backstop | `SANDBOX_AGENT_ACP_BODY_TIMEOUT_MS` | 60 min (was `0`) |
| SSE keepalive | `AGENTA_AGENT_SSE_KEEPALIVE_SECONDS` | 15 s |

When any limit trips, a `deadlineAbort` controller fires. It is merged with the caller's own signal via `AbortSignal.any`, so a trip aborts through the same cancellation path a client disconnect already uses. That throws into the engine's existing `catch`/`finally`, which already reclaims the daemon, sandbox, mount, and socket. No new teardown logic was written.

Before, session-owned runs called `session.start` with `signal: undefined`. Now they always get the merged `runSignal`, which is what closes the core leak.

A turn paused for human input is exempt. The moment it parks, `notePaused()` clears every timer and sets a flag that each trip guard checks, so total, idle, TTFB, and per-tool-call can never reap a parked turn. It ends through the existing pause-cancel path instead. The ACP backstops stay wider than the total deadline so they never fire first in normal operation.

The scope here is the time dimension only. Count limits (max steps, tool calls, consecutive errors) and size limits (output bytes, `/run` body) are tracked separately and are not in this PR.

Two SDK-side riders ship with it because they are the same time-semantics problem on the client:

- The one runner-timeout env var (`AGENTA_RUNNER_TIMEOUT_SECONDS`) meant a total deadline on the subprocess transport but an idle timeout on the HTTP transport. It now means an idle (between-record) timeout on both, since the runner owns the true end-to-end deadline server-side. The subprocess stream resets its per-line deadline on each received line; the HTTP transport already used httpx's per-read idle timeout.
- The Vercel SSE stream now emits a `: keepalive\n\n` comment on a silent gap (a long tool call or a long think), so a proxy does not idle-kill a run that is still completing and billing server-side. Data frames are unchanged.

## Tests / notes

- `pnpm run typecheck` clean; runner unit suite 622 passed / 50 files (14 new).
- SDK riders: 14 passed (SSE keepalive, transport idle timeout, transport auth kept green). Each new test verified to fail on drift.
- `idle < total` is enforced as a clamp with a log line, not a thrown error. A misconfigured env should never break every run; if idle is set at or above total it clamps to half the total.
- Reviewer note: the deadline-trip tests inject tiny limit values and let the real timers run at a few ms rather than plumbing a fake clock through the engine's DI seam, which only exposes whole-function overrides. The tight paused-turn guarantee is proven in the `run-limits` unit test; the engine-level pause test is a lighter integration check.
- Two pre-existing SDK test failures (`test_unknown_harness_is_permissive`, `test_run_selection_unknown_permission_falls_back_to_allow_reads`) fail on the base branch independent of this change.
