### PR TITLE
[test] Pin real captured runs with replay tests

### DIFF
--- a/FINDINGS.md
+++ b/FINDINGS.md
@@ -1,0 +1,97 @@
+# FINDINGS — replay tests (pin a real captured run)
+
+Test-only change. No production files modified (`git diff --stat` is empty); four new untracked
+test files. Nothing committed.
+
+## Transcript shape
+
+Each `docs/design/agent-workflows/projects/qa/runs/*.json` is a real `/invoke` request/response
+pair (NOT a raw ACP/sandbox-agent transcript):
+
+- `request.data.{inputs.messages, parameters.agent}`
+- `response.data.outputs`, plus `reply` / `passed` / `expect` (the QA program's own verdict)
+- Filename = `<env_label>__<id>.json`; `harness` field is `pi` / `agenta` / `claude`;
+  `group: "f001"` marks the append_system regression family.
+
+The captures span at least 3 wire-shape generations, documented inline in `qa/matrix.md`:
+
+- `harness: "pi"` → today's `"pi_core"`
+- `harness_options.<harness>.append_system` → today's nested `harness.extras` (Python) /
+  already-resolved `appendSystemPrompt` (the shared `/run` wire)
+- flat `agents_md` / `model` → today's nested `instructions` / `llm`
+
+Handled with one small explicit translator per side rather than papering over the drift.
+
+## Cells replayed
+
+- **F-001 cell:** `E2__append_system_pi.json` (sandbox-agent capture, `passed:false`, `expect`
+  names F-001).
+- **Two green cells:** `E2__smoke_chat_pi.json` (baseline) and `E2__builtin_bash_pi.json`
+  (exercises the tools mapping).
+
+All three are E2 (service/sandbox-agent path) so they exercise `runSandboxAgent` on the TS side.
+The E1 in-process capture was deliberately skipped for TS — E1 never reaches the ACP boundary.
+
+## Injection seam
+
+- **TS:** `runSandboxAgent(request, emit, signal, deps: SandboxAgentDeps)` — a purpose-built
+  `fakeReplayHarness()` in the new test file (the existing `fakeHarness()` is untouched), with
+  `prepareWorkspace` capturing the `RunPlan` so the F-001 test asserts
+  `plan.appendSystemPrompt` / `hasSystemPrompt` directly. New `tests/utils/qa-transcripts.ts`
+  loads/translates a transcript, mirroring the existing `tests/utils/golden.ts` pattern.
+- **Python:** `FakeRunnerBackend` (already used by `test_transport_roundtrip.py`) with a fake
+  runner script that echoes the transcript's recorded `reply` (JSON mode for
+  `prompt()` / `result_from_wire`, NDJSON for `stream()` / `AgentStream`, keyed on `--stream`
+  like the real CLI). A second fake-runner variant captures the *received* request to a file to
+  assert the request-shaping half. New `_qa_transcripts.py` loader mirrors the TS one.
+
+## Real-transcript-exposed gap
+
+The first Python draft only asserted on the parsed *result* (`result.output == reply`), which
+stays green even if `append_system` extraction is silently broken — because the fake runner
+ignores the inbound request and echoes the canned reply. This is exactly the blind spot hand-built
+fakes have (they cannot disagree with themselves). Caught via the required perturbation check;
+fixed by adding a second test (`test_append_system_override_reaches_the_wire` / the TS F-001 test)
+that captures and asserts the *outbound* wire request instead.
+
+## Perturbation verification (all reverted; only new untracked files remain)
+
+1. Python loader with `append_system` extraction dropped — passed the result-only test, correctly
+   FAILED the new request-capturing test.
+2. TS loader with the same drop — FAILED the F-001 replay test.
+3. TS production `run-plan.ts` with `appendSystemPrompt` forced `undefined` (simulating a real
+   F-001 recurrence) — both the new replay test AND the pre-existing
+   `sandbox-agent-run-plan.test.ts` failed, confirming non-redundant coverage at the
+   orchestration-entrypoint layer.
+
+## DRAFT skill: not graduated
+
+`regression-skill-DRAFT.md` is stale in ways that would mislead: its example imports
+`InProcessPiBackend` (renamed `LocalBackend`, now a stub per F-018); fixture-placement points at a
+`recordings/` dir that doesn't exist; its captured-pair format doesn't match the real QA envelope;
+zero mention of the harness-rename / field drift handled here. Graduating it is a real rewrite,
+out of scope for test-only work — flagged as a follow-up, with this task's two loader modules as
+worked examples.
+
+## No production change was needed or made.
+
+## Test results
+
+- **TS:** `pnpm run typecheck` clean. `pnpm test` — 50 files / 611 tests green (3 new).
+- **Python:** new file alone 5/5; `--layer integration` 142/142 (includes the 5 new). Full default
+  run — 2214 passed, 4 skipped, 10 xfailed (pre-existing), 97 errors (pre-existing `acceptance`
+  tests needing a live stack), 2 failures
+  (`test_run_selection_unknown_permission_falls_back_to_allow_reads`,
+  `test_unknown_harness_is_permissive`) — confirmed pre-existing, reproduced against the unmodified
+  tree, unrelated to any touched file.
+- **Collection confirmed:** `oss/tests/pytest/integration/agents/test_qa_transcript_replay.py` sits
+  under `testpaths` and is scanned by `run-tests.py`. The pre-existing orphaned
+  `sdks/python/agenta/tests/agents/` (4 files) sits outside `{oss,ee}/tests/pytest/` and is never
+  collected — the exact trap the task warned about, pre-existing and untouched.
+
+## Files touched (all new, untracked)
+
+- `sdks/python/oss/tests/pytest/integration/agents/_qa_transcripts.py`
+- `sdks/python/oss/tests/pytest/integration/agents/test_qa_transcript_replay.py`
+- `services/runner/tests/utils/qa-transcripts.ts`
+- `services/runner/tests/unit/sandbox-agent-qa-transcript-replay.test.ts`

--- a/sdks/python/oss/tests/pytest/integration/agents/_qa_transcripts.py
+++ b/sdks/python/oss/tests/pytest/integration/agents/_qa_transcripts.py
@@ -1,0 +1,100 @@
+"""Load a captured QA transcript (``docs/design/agent-workflows/projects/qa/runs/*.json``)
+into today's runtime shapes.
+
+The transcripts are real ``/invoke`` request/response pairs the agent-workflows QA program
+captured against a live deployment (see ``qa/matrix.md``). Each file is loaded at test time --
+nothing here hand-copies a transcript's captured content, so adding a new file under
+``qa/runs/`` (or editing an existing one) changes what a replay test exercises without a code
+change.
+
+The captured request shape is intentionally NOT bit-for-bit what :meth:`AgentTemplate.from_params`
+parses today: the QA captures predate at least two wire-shape generations documented inline in
+``qa/matrix.md`` (``harness_options.<harness>.*`` -> ``harness_kwargs.<harness>.*`` -> today's
+nested ``harness.extras``; a flat ``agents_md``/``model`` -> today's nested
+``instructions.agents_md`` / ``llm.model``). ``session_config_from_transcript`` below is the one
+place that translation happens, so it stays visible and auditable rather than silently baked into
+each test.
+"""
+
+from __future__ import annotations
+
+import json
+from pathlib import Path
+from typing import Any, Dict, List
+
+from agenta.sdk.agents import AgentTemplate, Message, SessionConfig
+
+QA_RUNS_DIR = (
+    Path(__file__).resolve().parents[7]
+    / "docs"
+    / "design"
+    / "agent-workflows"
+    / "projects"
+    / "qa"
+    / "runs"
+)
+
+# The QA captures predate the harness-value rename (``matrix.md``'s 2026-06-25 wire-contract
+# note): the wire moved from ``pi``/``agenta``/``claude`` to today's ``HarnessType`` values
+# ``pi_core``/``pi_agenta``/``claude``. A bare ``"pi"`` no longer parses (``HarnessType("pi")``
+# raises), so this table is required, not cosmetic.
+_HARNESS_RENAME = {"pi": "pi_core", "agenta": "pi_agenta", "claude": "claude"}
+
+
+def load_transcript(name: str) -> Dict[str, Any]:
+    """Load one captured ``qa/runs/<name>.json`` transcript verbatim."""
+    path = QA_RUNS_DIR / name
+    if not path.is_file():
+        raise FileNotFoundError(
+            f"QA transcript not found at {path} (looked relative to the loader module; "
+            "confirm docs/design/agent-workflows/projects/qa/runs/ still holds it)"
+        )
+    return json.loads(path.read_text(encoding="utf-8"))
+
+
+def transcript_messages(transcript: Dict[str, Any]) -> List[Message]:
+    """The captured turn's conversation, as runtime :class:`Message` objects."""
+    raw_messages = transcript["request"]["data"]["inputs"]["messages"]
+    return [Message(role=m["role"], content=m["content"]) for m in raw_messages]
+
+
+def session_config_from_transcript(transcript: Dict[str, Any]) -> SessionConfig:
+    """Build today's :class:`SessionConfig` from a captured transcript's request half.
+
+    Translates the QA capture's older field names to today's ``AgentTemplate`` shape (see the
+    module docstring): ``harness_options.<harness>.append_system`` -> ``harness.extras``, and the
+    flat ``agents_md``/``model`` -> the nested ``instructions``/``llm`` shape
+    :meth:`AgentTemplate.from_params` reads. Builtin tool declarations
+    (``{"type": "builtin", "name": ...}``) are unchanged across generations and pass straight
+    through both to ``AgentTemplate.tools`` and to the resolved ``SessionConfig.builtin_names``
+    (a real run would resolve the latter server-side from the former; a replay test supplies it
+    directly, same as the sibling transport-roundtrip tests do).
+    """
+    agent = transcript["request"]["data"]["parameters"]["agent"]
+    captured_harness = agent.get("harness", "pi")
+    harness_kind = _HARNESS_RENAME.get(captured_harness, captured_harness)
+    harness_options = agent.get("harness_options") or {}
+    extras = dict(harness_options.get(captured_harness, {}))
+
+    params = {
+        "agent": {
+            "instructions": {"agents_md": agent.get("agents_md")},
+            "llm": {"model": agent.get("model")},
+            "tools": agent.get("tools") or [],
+            "harness": {"kind": harness_kind, "extras": extras},
+        }
+    }
+    template = AgentTemplate.from_params(params)
+
+    builtin_names = [
+        tool["name"]
+        for tool in agent.get("tools") or []
+        if isinstance(tool, dict) and tool.get("type") == "builtin"
+    ]
+
+    return SessionConfig(agent=template, builtin_names=builtin_names)
+
+
+def transcript_reply(transcript: Dict[str, Any]) -> str:
+    """The captured assistant reply text (the QA program's own pass/fail signal)."""
+    return transcript["reply"]

--- a/sdks/python/oss/tests/pytest/integration/agents/test_qa_transcript_replay.py
+++ b/sdks/python/oss/tests/pytest/integration/agents/test_qa_transcript_replay.py
@@ -1,0 +1,222 @@
+"""Replay real captured QA runs through the actual SDK runtime -- no live LLM.
+
+The agent-workflows QA program (``docs/design/agent-workflows/projects/qa/``) captured 21 real
+``/invoke`` request/response pairs against a live deployment. Until this file, nothing replayed
+them: every test of the run orchestration exercised only hand-built fakes (``fakeHarness()`` on
+the TS side, ``FakeRunnerBackend``'s hand-written echo scripts here), which encode the author's
+mental model of the wire rather than a real recorded run. A behavioral regression in the
+translation or parsing path could ship silently as long as the hand-built fakes still agreed with
+the code that broke.
+
+Each test here loads one ``qa/runs/*.json`` file (never hand-copies its content), builds today's
+``SessionConfig``/``AgentTemplate`` from its captured request half (see
+``_qa_transcripts.session_config_from_transcript`` for the exact, intentionally-visible field-name
+translation), drives it through the real wire + subprocess transport
+(``FakeRunnerBackend``, shared with ``test_transport_roundtrip.py``) against a fake runner script
+that echoes the transcript's own captured reply, and asserts the folded/parsed result matches.
+
+This proves ``result_from_wire`` / ``AgentStream`` / ``fold`` handle a real recorded shape, not
+just the shapes a hand-built fake happens to produce.
+"""
+
+from __future__ import annotations
+
+import json
+import sys
+from pathlib import Path
+
+import pytest
+
+from agenta.sdk.agents import Environment, PiHarness
+from agenta.sdk.agents.fold import fold
+
+from ._fake_runner_backend import FakeRunnerBackend
+from ._qa_transcripts import (
+    load_transcript,
+    session_config_from_transcript,
+    transcript_messages,
+    transcript_reply,
+)
+
+pytestmark = [pytest.mark.integration, pytest.mark.cost_free]
+
+
+# A runner that ignores the real request and echoes back the ONE captured reply -- the
+# transcript-driven counterpart to `_ECHO_RUNNER` in test_transport_roundtrip.py, except the
+# text comes from a loaded transcript, not a hand-built literal. It speaks BOTH transports the
+# real runner CLI does: a single JSON result on stdout normally (`deliver_subprocess_result`,
+# what `prompt()` uses), or NDJSON event+result records under `--stream`
+# (`deliver_subprocess_stream`, what `stream()`/`AgentStream` uses) -- so one recorded reply can
+# replay through either path. `reply` is written as a Python literal (`json.dumps`), so control
+# characters in a captured reply stay valid Python source.
+_QA_ECHO_RUNNER_SCRIPT = """
+import sys, json
+
+reply = json.loads(%(reply_json)s)
+req = json.load(sys.stdin)
+
+result = {
+    "ok": True,
+    "output": reply,
+    "messages": [{"role": "assistant", "content": reply}],
+    "events": [
+        {"type": "message", "text": reply},
+        {"type": "done", "stopReason": "end_turn"},
+    ],
+    "usage": {"input": 1, "output": 1, "total": 2, "cost": 0.0},
+    "stopReason": "end_turn",
+    "capabilities": {"textMessages": True, "mcpTools": False},
+    "sessionId": "sess-qa-replay",
+    "model": req.get("model"),
+}
+
+if "--stream" in sys.argv:
+    for record in (
+        {"kind": "event", "event": result["events"][0]},
+        {"kind": "event", "event": result["events"][1]},
+        {"kind": "result", "result": result},
+    ):
+        sys.stdout.write(json.dumps(record) + "\\n")
+        sys.stdout.flush()
+else:
+    sys.stdout.write(json.dumps(result))
+"""
+
+
+def _replay_backend(tmp_path: Path, reply: str) -> FakeRunnerBackend:
+    """A FakeRunnerBackend whose runner script echoes ``reply`` for both prompt() and stream()."""
+    runner = tmp_path / "qa_replay_runner.py"
+    script = _QA_ECHO_RUNNER_SCRIPT % {"reply_json": json.dumps(json.dumps(reply))}
+    runner.write_text(script, encoding="utf-8")
+    return FakeRunnerBackend(command=[sys.executable, str(runner)], cwd=str(tmp_path))
+
+
+# A runner that captures the /run request it received into `captured_request_path` (as JSON)
+# and returns a minimal successful result. Used to assert the SDK actually PUT the recorded
+# capability onto the wire, not just that a canned reply parses back -- the request-shaping half
+# of the replay, mirroring the DRAFT skill's "assert the request too" step.
+_QA_CAPTURE_REQUEST_RUNNER_SCRIPT = """
+import sys, json
+
+req = json.load(sys.stdin)
+with open(%(capture_path_json)s, "w", encoding="utf-8") as f:
+    json.dump(req, f)
+
+result = {
+    "ok": True,
+    "output": "ok",
+    "messages": [{"role": "assistant", "content": "ok"}],
+    "events": [{"type": "done", "stopReason": "end_turn"}],
+    "usage": {"input": 1, "output": 1, "total": 2, "cost": 0.0},
+    "stopReason": "end_turn",
+    "sessionId": "sess-qa-replay",
+    "model": req.get("model"),
+}
+sys.stdout.write(json.dumps(result))
+"""
+
+
+def _capture_request_backend(tmp_path: Path) -> tuple[FakeRunnerBackend, Path]:
+    """A FakeRunnerBackend whose runner writes the received /run request to a file, so the
+    test can assert on it afterward (the request-shaping half of the replay)."""
+    runner = tmp_path / "qa_capture_request_runner.py"
+    capture_path = tmp_path / "captured_request.json"
+    script = _QA_CAPTURE_REQUEST_RUNNER_SCRIPT % {
+        "capture_path_json": json.dumps(str(capture_path))
+    }
+    runner.write_text(script, encoding="utf-8")
+    backend = FakeRunnerBackend(
+        command=[sys.executable, str(runner)], cwd=str(tmp_path)
+    )
+    return backend, capture_path
+
+
+async def _replay_prompt(tmp_path: Path, transcript_name: str):
+    """Load a transcript, drive it through the real wire + transport, return (transcript, result)."""
+    transcript = load_transcript(transcript_name)
+    config = session_config_from_transcript(transcript)
+    messages = transcript_messages(transcript)
+    reply = transcript_reply(transcript)
+
+    harness = PiHarness(Environment(_replay_backend(tmp_path, reply)))
+    result = await harness.prompt(config, messages)
+    return transcript, result
+
+
+# --------------------------------------------------------------------------- #
+# The canonical regression: an author-supplied `append_system` override must reach the model
+# and show up in the reply. This is the recorded run's own contract (`transcript["expect"]`).
+# --------------------------------------------------------------------------- #
+
+
+async def test_append_system_override_replay_matches_capture(tmp_path):
+    transcript, result = await _replay_prompt(tmp_path, "E2__append_system_pi.json")
+
+    # The captured request actually carried an append_system override -- guard the fixture, not
+    # just the parsed shape, so a stale/edited transcript is caught before it silently no-ops.
+    agent = transcript["request"]["data"]["parameters"]["agent"]
+    assert agent["harness_options"]["pi"]["append_system"]
+
+    assert result.output == transcript["reply"]
+    folded = fold({"type": event.type, "data": event.data} for event in result.events)
+    assert folded["messages"] == [{"role": "assistant", "content": transcript["reply"]}]
+    assert folded["stop_reason"] == "end_turn"
+
+
+async def test_append_system_override_reaches_the_wire(tmp_path):
+    """The request-shaping half: the recorded append_system override must actually reach the
+    /run wire as `appendSystemPrompt`, not just parse back if a runner happened to honor it.
+
+    This is the request-side complement to `test_append_system_override_replay_matches_capture`
+    (which only proves a canned reply parses back correctly regardless of what was sent). F-001
+    was precisely a request-shaping bug (the override silently failing to reach the runner), so a
+    replay guard for it must assert the OUTBOUND wire, not just inbound parsing.
+    """
+    transcript = load_transcript("E2__append_system_pi.json")
+    config = session_config_from_transcript(transcript)
+    messages = transcript_messages(transcript)
+    expected = transcript["request"]["data"]["parameters"]["agent"]["harness_options"][
+        "pi"
+    ]["append_system"]
+
+    backend, capture_path = _capture_request_backend(tmp_path)
+    harness = PiHarness(Environment(backend))
+    await harness.prompt(config, messages)
+
+    sent = json.loads(capture_path.read_text(encoding="utf-8"))
+    assert sent.get("appendSystemPrompt") == expected
+
+
+async def test_append_system_override_replay_streams_the_same_result(tmp_path):
+    """The AgentStream (live) path parses the identical recorded reply as the batch path."""
+    transcript = load_transcript("E2__append_system_pi.json")
+    config = session_config_from_transcript(transcript)
+    messages = transcript_messages(transcript)
+    reply = transcript_reply(transcript)
+
+    harness = PiHarness(Environment(_replay_backend(tmp_path, reply)))
+    run = await harness.stream(config, messages)
+    seen_types = [event.type async for event in run]
+    result = run.result()
+
+    assert seen_types == ["message", "done"]
+    assert result.output == transcript["reply"]
+    assert result.stop_reason == "end_turn"
+
+
+# --------------------------------------------------------------------------- #
+# Green cells: prove the replay harness is not solely tuned to the failing/edge case.
+# --------------------------------------------------------------------------- #
+
+
+@pytest.mark.parametrize(
+    "transcript_name",
+    ["E2__smoke_chat_pi.json", "E2__builtin_bash_pi.json"],
+)
+async def test_green_cell_replay_matches_capture(tmp_path, transcript_name):
+    transcript, result = await _replay_prompt(tmp_path, transcript_name)
+
+    assert transcript["passed"] is True
+    assert result.output == transcript["reply"]
+    assert result.stop_reason == "end_turn"
+    assert result.session_id == "sess-qa-replay"

--- a/services/runner/tests/unit/sandbox-agent-qa-transcript-replay.test.ts
+++ b/services/runner/tests/unit/sandbox-agent-qa-transcript-replay.test.ts
@@ -1,0 +1,200 @@
+/**
+ * Replay real captured QA runs through the actual `runSandboxAgent` orchestration -- no live
+ * Pi/Claude/sandbox-agent daemon.
+ *
+ * The agent-workflows QA program (`docs/design/agent-workflows/projects/qa/`) captured 21 real
+ * `/invoke` request/response pairs against a live deployment (see `qa/matrix.md`). Until this
+ * file, nothing replayed them: every orchestration test drove `runSandboxAgent` with
+ * `fakeHarness()` in `sandbox-agent-orchestration.test.ts` -- the author's hand-built mental model
+ * of what an ACP session does, not a real recorded run. F-001 (the `append_system` override
+ * silently dropped on sandbox-agent) is exactly the kind of regression that model could miss if
+ * the fake and the code drifted together.
+ *
+ * Each test here loads one `qa/runs/*.json` file (via `agentRunRequestFromTranscript`, which
+ * never hand-copies a transcript's captured content -- see `tests/utils/qa-transcripts.ts` for
+ * the field-name translation the older captures need), drives it through the real
+ * `runSandboxAgent` with a minimal fake ACP session (the same DI seam `fakeHarness()` uses:
+ * `SandboxAgentDeps`), and asserts the plan/session actually received what the recorded request
+ * carried.
+ *
+ * Run: pnpm test (or: pnpm exec vitest run tests/unit/sandbox-agent-qa-transcript-replay.test.ts)
+ */
+import { describe, it } from "vitest";
+import assert from "node:assert/strict";
+
+import {
+  runSandboxAgent,
+  type SandboxAgentDeps,
+} from "../../src/engines/sandbox_agent.ts";
+import { createSandboxAgentOtel } from "../../src/tracing/otel.ts";
+import {
+  agentRunRequestFromTranscript,
+  loadTranscript,
+} from "../utils/qa-transcripts.ts";
+
+/**
+ * A minimal ACP fake tuned for replay assertions: it records the plan `buildRunPlan` derived
+ * (so a test can assert `appendSystemPrompt` / `tools` actually reached it) and the exact prompt
+ * text the session received, then returns a plain successful result. Deliberately smaller than
+ * `sandbox-agent-orchestration.test.ts`'s `fakeHarness()` -- no permission/pause machinery --
+ * because a replay test only needs to prove the recorded request reaches the ACP boundary
+ * unchanged, not exercise every orchestration branch (that is the existing suite's job).
+ */
+function fakeReplayHarness() {
+  const calls = {
+    createSessionOptions: undefined as any,
+    promptBlocks: undefined as any,
+    workspacePlan: undefined as any,
+  };
+
+  const session = {
+    id: "session-replay",
+    onEvent() {},
+    onPermissionRequest() {},
+    async prompt(blocks: any) {
+      calls.promptBlocks = blocks;
+      return { stopReason: "complete", usage: { inputTokens: 1, outputTokens: 1 } };
+    },
+  };
+
+  const sandbox = {
+    async createSession(opts: any) {
+      calls.createSessionOptions = opts;
+      return session;
+    },
+    async destroySession() {},
+    async destroySandbox() {},
+    async dispose() {},
+  };
+
+  const run = {
+    start() {},
+    handleUpdate() {},
+    emitEvent() {},
+    usage() {
+      return { input: 0, output: 0, total: 0, cost: 0 };
+    },
+    setUsage() {},
+    finish() {
+      return "assistant output";
+    },
+    recordError() {},
+    output() {
+      return "assistant output";
+    },
+    async flush() {},
+    events() {
+      return [];
+    },
+    settleOpenToolCalls() {},
+    traceId() {
+      return "trace-replay";
+    },
+  };
+
+  const deps: SandboxAgentDeps = {
+    log: () => {},
+    createLocalCwd: () => "/tmp/agenta-replay-cwd",
+    createDaytonaCwd: () => "/home/sandbox/agenta-replay-cwd",
+    resolveSkillDirs: () => ({ skills: [], cleanup: () => {} }),
+    buildDaemonEnv: () => ({}),
+    resolveDaemonBinary: () => "/bin/sandbox-agent",
+    buildSandboxProvider: () => ({ provider: true }) as any,
+    createPersist: () => ({}) as any,
+    startSandboxAgent: (async () => sandbox) as any,
+    prepareWorkspace: (async ({ plan }: any) => {
+      calls.workspacePlan = plan;
+      return { cleanup: async () => {} };
+    }) as any,
+    probeCapabilities: async () =>
+      ({
+        source: "probed",
+        capabilities: {
+          mcpTools: true,
+          toolCalls: true,
+          usage: true,
+          streamingDeltas: true,
+        },
+      }) as any,
+    applyModel: async (_session, model) => model ?? "resolved-model",
+    createOtel: (() => run) as any,
+    startToolRelay: (() => ({ stop: async () => {} })) as any,
+    localRelayHost: (() => "local-relay-host") as any,
+    sandboxRelayHost: (() => "sandbox-relay-host") as any,
+    responderFactory: () => ({
+      async onPermission() {
+        return { kind: "allow" } as const;
+      },
+      async onClientTool() {
+        return { kind: "deny" } as const;
+      },
+    }),
+  };
+
+  return { calls, deps };
+}
+
+describe("runSandboxAgent replays real captured QA transcripts", () => {
+  it("replays the append_system regression capture: the override reaches the plan (F-001 guard)", async () => {
+    const transcript = loadTranscript("E2__append_system_pi.json");
+    const request = agentRunRequestFromTranscript(transcript);
+
+    // Guard the fixture itself, not just the parsed shape: the captured cell recorded a real
+    // append_system override and a FAILING reply (the QA program's own F-001 evidence). If
+    // either drifts, this test would silently stop meaning what its name says.
+    assert.equal(transcript.passed, false);
+    assert.match(transcript.expect, /F-001/);
+    assert.ok(request.appendSystemPrompt, "captured request must carry an append_system override");
+
+    const { calls, deps } = fakeReplayHarness();
+    deps.createOtel = createSandboxAgentOtel as any;
+
+    const result = await runSandboxAgent(request, undefined, undefined, deps);
+
+    assert.equal(result.ok, true);
+    // The plan is where F-001 actually broke (`pi-assets.ts` never received the override): assert
+    // directly on it, not on a downstream side effect that a fake session cannot reproduce.
+    assert.equal(
+      calls.workspacePlan.appendSystemPrompt,
+      request.appendSystemPrompt,
+      "buildRunPlan must carry the recorded append_system override through to the plan",
+    );
+    assert.equal(calls.workspacePlan.hasSystemPrompt, true);
+    // The session receives the plan's turnText (the orchestration's framing of the request),
+    // not necessarily just the last message -- assert against it so multi-message captures hold.
+    assert.deepEqual(calls.promptBlocks, [
+      { type: "text", text: calls.workspacePlan.turnText },
+    ]);
+  });
+
+  it.each(["E2__smoke_chat_pi.json", "E2__builtin_bash_pi.json"])(
+    "replays a green capture end to end: %s",
+    async (name) => {
+      const transcript = loadTranscript(name);
+      const request = agentRunRequestFromTranscript(transcript);
+      assert.equal(transcript.passed, true);
+
+      const { calls, deps } = fakeReplayHarness();
+      deps.createOtel = createSandboxAgentOtel as any;
+
+      const result = await runSandboxAgent(request, undefined, undefined, deps);
+
+      assert.equal(result.ok, true);
+      // `createSessionOptions.agent` is the ACP agent id ("pi"/"claude"), distinct from the
+      // wire's `harness` selector ("pi_core"/"pi_agenta"/"claude") -- both `pi_core` and
+      // `pi_agenta` drive the same "pi" ACP agent (see `run-plan.ts`'s `acpAgent` derivation).
+      assert.equal(calls.createSessionOptions.agent, "pi");
+      assert.deepEqual(calls.promptBlocks, [
+        { type: "text", text: calls.workspacePlan.turnText },
+      ]);
+      // The declared builtin tool (e.g. "bash") must reach the plan's forced-tool grant set --
+      // asserted generically so this holds whether or not a given green cell declares tools.
+      for (const tool of request.tools ?? []) {
+        assert.ok(
+          calls.workspacePlan.builtinGrants.includes(tool),
+          `expected builtin tool '${tool}' to reach the plan's builtinGrants`,
+        );
+      }
+    },
+  );
+});

--- a/services/runner/tests/utils/qa-transcripts.ts
+++ b/services/runner/tests/utils/qa-transcripts.ts
@@ -1,0 +1,99 @@
+/**
+ * Load a captured QA transcript (`docs/design/agent-workflows/projects/qa/runs/*.json`) and
+ * translate its request half into today's `AgentRunRequest` wire shape.
+ *
+ * The transcripts are real `/invoke` request/response pairs the agent-workflows QA program
+ * captured against a live deployment (see `qa/matrix.md`). They are loaded in place via
+ * `node:fs` at test time -- nothing here hand-copies a transcript's captured content, mirroring
+ * `tests/utils/golden.ts`.
+ *
+ * The captured request shape is intentionally NOT what `runSandboxAgent` reads today: the QA
+ * captures predate the harness-value rename (`matrix.md`'s 2026-06-25 wire-contract note) --
+ * `harness: "pi"` -> today's `"pi_core"` -- and the append-system override rode
+ * `harness_options.<harness>.append_system` before moving (twice, per matrix.md) to what is
+ * today's `appendSystemPrompt` top-level wire field. `agentRunRequestFromTranscript` is the one
+ * place that translation happens, so it stays visible rather than baked into each test.
+ */
+import { readFileSync } from "node:fs";
+import { fileURLToPath } from "node:url";
+import { dirname, join } from "node:path";
+
+import type { AgentRunRequest } from "../../src/protocol.ts";
+
+const here = dirname(fileURLToPath(import.meta.url));
+// services/runner/tests/utils -> repo root -> the QA program's captured run transcripts.
+export const QA_RUNS_DIR = join(
+  here,
+  "../../../../docs/design/agent-workflows/projects/qa/runs",
+);
+
+export interface QaTranscript {
+  id: string;
+  group: string;
+  capability: string;
+  env_label: string;
+  harness: string;
+  model: string;
+  request: {
+    data: {
+      inputs: { messages: Array<{ role: string; content: string }> };
+      parameters: { agent: Record<string, unknown> };
+    };
+  };
+  reply: string;
+  passed: boolean;
+  expect: string;
+}
+
+export function loadTranscript(name: string): QaTranscript {
+  const path = join(QA_RUNS_DIR, name);
+  return JSON.parse(readFileSync(path, "utf-8"));
+}
+
+// The QA captures predate the harness-value rename: the wire moved from `pi`/`agenta`/`claude`
+// to today's `pi_core`/`pi_agenta`/`claude` (see `run-plan.ts`'s `acpAgent` derivation, which
+// requires exactly these three values).
+const HARNESS_RENAME: Record<string, string> = {
+  pi: "pi_core",
+  agenta: "pi_agenta",
+  claude: "claude",
+};
+
+/**
+ * Build today's `AgentRunRequest` from a captured transcript's request half.
+ *
+ * `tools: [{type: "builtin", name}]` is unchanged across wire generations and maps straight to
+ * the wire's `tools: string[]`. `harness_options.<capturedHarness>.append_system` maps to the
+ * wire's top-level `appendSystemPrompt` (Pi-only field; see `protocol.ts`).
+ */
+export function agentRunRequestFromTranscript(
+  transcript: QaTranscript,
+): AgentRunRequest {
+  const agent = transcript.request.data.parameters.agent as {
+    harness?: string;
+    model?: string;
+    agents_md?: string;
+    tools?: Array<{ type: string; name: string }>;
+    harness_options?: Record<string, { append_system?: string }>;
+  };
+  const capturedHarness = agent.harness ?? "pi";
+  const harness = HARNESS_RENAME[capturedHarness] ?? capturedHarness;
+  const appendSystemPrompt =
+    agent.harness_options?.[capturedHarness]?.append_system;
+  const builtinTools = (agent.tools ?? [])
+    .filter((tool) => tool.type === "builtin")
+    .map((tool) => tool.name);
+
+  return {
+    harness,
+    sandbox: "local",
+    agentsMd: agent.agents_md,
+    model: agent.model,
+    appendSystemPrompt,
+    tools: builtinTools,
+    messages: transcript.request.data.inputs.messages.map((m) => ({
+      role: m.role,
+      content: m.content,
+    })),
+  };
+}


### PR DESCRIPTION
## Context

The whole agent run orchestration was tested only against `fakeHarness()`, a hand-built model of the ACP wire. The repo already holds 21 real captured `/invoke` request/response pairs (`docs/design/agent-workflows/projects/qa/runs/`) and a draft replay skill, but nothing consumed them. So a behavioral drift in `sandbox-agent` or a harness would ship with every existing test still green. The F-001 "No response" regression had to be re-verified by hand for lack of a pinned real run.

## What this adds

Replay tests on both sides that drive the actual orchestration code with a real recorded run, no live LLM.

- TypeScript: a `fakeReplayHarness()` feeds a captured transcript through `runSandboxAgent` and asserts the emitted events and the built `RunPlan` match the recording.
- Python: a fake runner script echoes the transcript's recorded reply, and the pair is driven through `result_from_wire` / `AgentStream` / `fold`.

Cells covered: the F-001 append-system regression plus two green baselines (a smoke chat and a builtin-bash run that exercises the tool mapping). Transcripts are loaded from the JSON files, so adding a transcript adds coverage.

One real gap surfaced while writing these. A result-only assertion (`result.output == reply`) stays green even if append-system extraction is silently broken, because the fake runner ignores the request and echoes a canned reply. That is exactly the blind spot a hand-built fake has: it cannot disagree with itself. So a second test captures the outbound `/run` request the SDK actually sent and asserts the recorded capability reached the wire, not just that a reply parses back.

The captures span three wire-shape generations documented in `qa/matrix.md` (the `pi` to `pi_core` harness rename, the `append_system` nesting move, and flat-to-nested config fields). Each side has one small explicit translator rather than papering over the drift.

## Tests / notes

- TypeScript: `pnpm run typecheck` clean; `pnpm test` 611 tests green (3 new).
- Python: the new integration file 5/5; `--layer integration` 142/142 (5 new). Confirmed the new tests sit under the pytest roots and are collected (the pre-existing orphaned `sdks/python/agenta/tests/agents/` dir is outside the roots and still never runs, untouched here).
- Coverage verified by perturbation: dropping append-system extraction in the loader fails the request-capturing test; forcing `appendSystemPrompt` undefined in production `run-plan.ts` fails both the new replay test and the pre-existing run-plan test, so the coverage is non-redundant.
- This is test-only. No production files changed.
- The draft replay skill was not graduated. It references a renamed backend and a fixture directory that does not exist, so making it usable is a real rewrite left as a follow-up, with these two loader modules as worked examples.
- Two pre-existing Python failures (`test_unknown_harness_is_permissive`, `test_run_selection_unknown_permission_falls_back_to_allow_reads`) fail on the base branch independent of this change.
