### PR TITLE
[fix] Permissive-by-default sandbox/egress with a hardening gate

### DIFF
--- a/api/oss/src/utils/env.py
+++ b/api/oss/src/utils/env.py
@@ -352,14 +352,30 @@ class OTLPConfig(BaseModel):
 # ---------------------------------------------------------------------------
 
 
+_SANDBOX_RUNNER_LOCAL_WARNED = False
+
+
 class ServicesCodeConfig(BaseModel):
     sandbox_runner: str = (
         os.getenv("AGENTA_SERVICES_CODE_SANDBOX_RUNNER")
         or os.getenv("AGENTA_SERVICES_SANDBOX_RUNNER")
-        or "restricted"
+        or "local"
     )
 
     model_config = ConfigDict(extra="ignore")
+
+    @model_validator(mode="after")
+    def _warn_sandbox_runner_mode(self) -> "ServicesCodeConfig":
+        global _SANDBOX_RUNNER_LOCAL_WARNED
+        if self.sandbox_runner == "local" and not _SANDBOX_RUNNER_LOCAL_WARNED:
+            _SANDBOX_RUNNER_LOCAL_WARNED = True
+            warnings.warn(
+                "AGENTA_SERVICES_CODE_SANDBOX_RUNNER is 'local' (default): code execution "
+                "is not sandboxed from the host. Set it to 'restricted' to harden a "
+                "shared/multi-tenant deployment.",
+                stacklevel=2,
+            )
+        return self
 
 
 class ServicesMiddlewareConfig(BaseModel):
@@ -417,7 +433,7 @@ class WebhooksConfig(BaseModel):
         os.getenv("AGENTA_INSECURE_EGRESS_ALLOWED")
         or os.getenv("AGENTA_WEBHOOKS_ALLOW_INSECURE")
         or os.getenv("AGENTA_WEBHOOK_ALLOW_INSECURE")
-        or "false"
+        or "true"
     ).lower() in _TRUTHY
 
     model_config = ConfigDict(extra="ignore")
@@ -428,8 +444,9 @@ class WebhooksConfig(BaseModel):
         if self.allow_insecure and not _EGRESS_INSECURE_WARNED:
             _EGRESS_INSECURE_WARNED = True
             warnings.warn(
-                "AGENTA_INSECURE_EGRESS_ALLOWED is set: webhook/egress targets may include http "
-                "and private/loopback/metadata hosts. Use only for trusted/single-tenant deployments.",
+                "AGENTA_INSECURE_EGRESS_ALLOWED is on (default): webhook/egress targets may "
+                "include http and private/loopback/metadata hosts. Set it to false to harden "
+                "a shared/multi-tenant deployment.",
                 stacklevel=2,
             )
         return self
@@ -940,12 +957,33 @@ class LoopsConfig(BaseModel):
 # ---------------------------------------------------------------------------
 
 
+_SANDBOX_LOCAL_WARNED = False
+
+
 class RunnerConfig(BaseModel):
     """Agent runner (services/runner) sidecar configuration."""
 
     concurrency_limit: int = int(os.getenv("AGENTA_RUNNER_CONCURRENCY_LIMIT") or "1000")
 
+    # `local` sandbox runs unconfined host bash — not a tenant boundary; on by default
+    # for zero-config self-host. Canonical declaration; services/oss reads the same var directly.
+    sandbox_local_allowed: bool = (
+        os.getenv("AGENTA_SANDBOX_LOCAL_ALLOWED") or "true"
+    ).lower() in _TRUTHY
+
     model_config = ConfigDict(extra="ignore")
+
+    @model_validator(mode="after")
+    def _warn_local_sandbox(self) -> "RunnerConfig":
+        global _SANDBOX_LOCAL_WARNED
+        if self.sandbox_local_allowed and not _SANDBOX_LOCAL_WARNED:
+            _SANDBOX_LOCAL_WARNED = True
+            warnings.warn(
+                "AGENTA_SANDBOX_LOCAL_ALLOWED is on (default): local sandbox is not a "
+                "tenant boundary. Set it to false to harden a shared/multi-tenant deployment.",
+                stacklevel=2,
+            )
+        return self
 
 
 # ---------------------------------------------------------------------------

--- a/api/oss/tests/pytest/unit/utils/test_env_runner_config.py
+++ b/api/oss/tests/pytest/unit/utils/test_env_runner_config.py
@@ -1,0 +1,81 @@
+"""Unit tests for `RunnerConfig.sandbox_local_allowed` (api/oss/src/utils/env.py).
+
+Declarative config only: the value is a class-level default evaluated at import time
+(same pattern as `WebhooksConfig.allow_insecure`), so tests reload the module after
+setting/clearing the env var. See test_webhooks_utils.py for the precedent this mirrors.
+The actual runtime gate lives in services/oss/src/agent/app.py (this env var's canonical
+declaration only, not a second live enforcement point in the api service).
+"""
+
+import importlib
+
+import pytest
+
+
+def test_sandbox_local_allowed_defaults_true(monkeypatch):
+    monkeypatch.delenv("AGENTA_SANDBOX_LOCAL_ALLOWED", raising=False)
+    from oss.src.utils import env
+
+    importlib.reload(env)
+    assert env.RunnerConfig().sandbox_local_allowed is True
+
+
+@pytest.mark.parametrize("value", ["true", "1", "yes", "on"])
+def test_sandbox_local_allowed_true_values(monkeypatch, value):
+    from oss.src.utils import env
+
+    monkeypatch.setenv("AGENTA_SANDBOX_LOCAL_ALLOWED", value)
+    try:
+        importlib.reload(env)
+        assert env.RunnerConfig().sandbox_local_allowed is True
+    finally:
+        monkeypatch.delenv("AGENTA_SANDBOX_LOCAL_ALLOWED", raising=False)
+        importlib.reload(env)
+
+
+@pytest.mark.parametrize("value", ["false", "0", "no", "off"])
+def test_sandbox_local_allowed_false_values(monkeypatch, value):
+    from oss.src.utils import env
+
+    monkeypatch.setenv("AGENTA_SANDBOX_LOCAL_ALLOWED", value)
+    try:
+        importlib.reload(env)
+        assert env.RunnerConfig().sandbox_local_allowed is False
+    finally:
+        monkeypatch.delenv("AGENTA_SANDBOX_LOCAL_ALLOWED", raising=False)
+        importlib.reload(env)
+
+
+def test_sandbox_local_allowed_true_when_unset_after_reload(monkeypatch):
+    from oss.src.utils import env
+
+    monkeypatch.delenv("AGENTA_SANDBOX_LOCAL_ALLOWED", raising=False)
+    try:
+        importlib.reload(env)
+        assert env.RunnerConfig().sandbox_local_allowed is True
+    finally:
+        importlib.reload(env)
+
+
+def test_sandbox_runner_defaults_local_when_unset(monkeypatch):
+    from oss.src.utils import env
+
+    monkeypatch.delenv("AGENTA_SERVICES_CODE_SANDBOX_RUNNER", raising=False)
+    monkeypatch.delenv("AGENTA_SERVICES_SANDBOX_RUNNER", raising=False)
+    try:
+        importlib.reload(env)
+        assert env.ServicesCodeConfig().sandbox_runner == "local"
+    finally:
+        importlib.reload(env)
+
+
+def test_sandbox_runner_honors_explicit_restricted(monkeypatch):
+    from oss.src.utils import env
+
+    monkeypatch.setenv("AGENTA_SERVICES_CODE_SANDBOX_RUNNER", "restricted")
+    try:
+        importlib.reload(env)
+        assert env.ServicesCodeConfig().sandbox_runner == "restricted"
+    finally:
+        monkeypatch.delenv("AGENTA_SERVICES_CODE_SANDBOX_RUNNER", raising=False)
+        importlib.reload(env)

--- a/api/oss/tests/pytest/unit/webhooks/test_webhooks_utils.py
+++ b/api/oss/tests/pytest/unit/webhooks/test_webhooks_utils.py
@@ -165,17 +165,21 @@ def test_resolve_rejects_blocked_ip_before_pinning(monkeypatch):
 
 
 # ---------------------------------------------------------------------------
-# Default posture — allow_insecure defaults to False
+# Default posture — allow_insecure defaults to True (permissive, zero-config self-host)
 # ---------------------------------------------------------------------------
 
 
-def test_allow_insecure_defaults_false(monkeypatch):
+def test_allow_insecure_defaults_true(monkeypatch):
+    from oss.src.utils import env
+
     monkeypatch.delenv("AGENTA_INSECURE_EGRESS_ALLOWED", raising=False)
     monkeypatch.delenv("AGENTA_WEBHOOKS_ALLOW_INSECURE", raising=False)
     monkeypatch.delenv("AGENTA_WEBHOOK_ALLOW_INSECURE", raising=False)
-    from oss.src.utils.env import WebhooksConfig
-
-    assert WebhooksConfig().allow_insecure is False
+    try:
+        importlib.reload(env)
+        assert env.WebhooksConfig().allow_insecure is True
+    finally:
+        importlib.reload(env)
 
 
 def test_allow_insecure_canonical_env_var(monkeypatch):

--- a/docs/docs/evaluation/configure-evaluators/07-custom-evaluator.mdx
+++ b/docs/docs/evaluation/configure-evaluators/07-custom-evaluator.mdx
@@ -6,7 +6,7 @@ description: "Write custom evaluators in Python, JavaScript, or TypeScript with 
 Custom code evaluators let you write your own evaluation logic in Python, JavaScript, or TypeScript. Your code has access to the application inputs, outputs, and the full execution trace (spans, latency, token usage, costs).
 
 :::warning Self-hosted deployments only
-On self-hosted Agenta, custom evaluator code runs server-side. By default it runs in a restricted Python sandbox (no filesystem, network, or host access). Operators can change the runner with the `AGENTA_SERVICES_CODE_SANDBOX_RUNNER` environment variable: `local` runs code with no sandbox (trusted authors only), `daytona` runs it in an isolated remote sandbox. See [environment configuration](/self-host/configuration). Agenta Cloud is unaffected — it isolates evaluator execution.
+On self-hosted Agenta, custom evaluator code runs server-side. By default it runs with no sandbox in the services process (trusted, single-tenant use). Operators can change the runner with the `AGENTA_SERVICES_CODE_SANDBOX_RUNNER` environment variable: `restricted` runs code in an in-process Python sandbox (no filesystem, network, or host access), `daytona` runs it in an isolated remote sandbox. Set `restricted` or `daytona` to harden a shared/multi-tenant deployment. See [environment configuration](/self-host/configuration). Agenta Cloud is unaffected. It isolates evaluator execution.
 :::
 
 ## Function signature

--- a/docs/docs/self-host/02-configuration.mdx
+++ b/docs/docs/self-host/02-configuration.mdx
@@ -162,6 +162,7 @@ Services API. `SANDBOX_AGENT_*` variables are read by the separate `runner` serv
 | `AGENTA_RUNNER_INTERNAL_URL` | Services API | `agentRunner.externalUrl` or generated from `agentRunner.enabled` |
 | `AGENTA_RUNNER_TIMEOUT_SECONDS` | Services API / SDK | n/a |
 | `AGENTA_AGENT_MCPS_ENABLED` | Services API | `agentRunner.enableMcp` |
+| `AGENTA_SANDBOX_LOCAL_ALLOWED` | Services API, SDK | `agenta.sandboxLocalAllowed` |
 | `SANDBOX_AGENT_PROVIDER` | `runner` | `agentRunner.provider` |
 | `SANDBOX_AGENT_LOG_LEVEL` | `runner` | `agentRunner.logLevel` |
 | `DAYTONA_API_KEY` | `runner` | `agentRunner.daytona.apiKey` |
@@ -171,14 +172,25 @@ Services API. `SANDBOX_AGENT_*` variables are read by the separate `runner` serv
 | `DAYTONA_IMAGE` | `runner` | `agentRunner.daytona.image` |
 | `DAYTONA_AUTOSTOP` | `runner` | `agentRunner.daytona.autostopDelay` |
 | `AGENTA_AGENT_SANDBOX_PI_INSTALLED` | `runner` | `agentRunner.daytona.installPi` |
+
 :::warning Custom-code evaluator runner
 `AGENTA_SERVICES_CODE_SANDBOX_RUNNER` selects how [custom-code evaluators](/evaluation/configure-evaluators/custom-evaluator) execute:
 
-- `restricted` (default) — in-process Python sandbox with limited builtins and an allowlist of pure-standard-library imports. No filesystem, network, or host access.
-- `local` — raw execution in the services process with **no sandbox**. Any author who can create a custom-code evaluator can run arbitrary code on the host. Use only for trusted, single-tenant deployments.
+- `local` (default) — raw execution in the services process with **no sandbox**. Any author who can create a custom-code evaluator can run arbitrary code on the host. This is what makes self-hosting work with zero configuration; the deployment logs a warning while it's active.
+- `restricted` — in-process Python sandbox with limited builtins and an allowlist of pure-standard-library imports. No filesystem, network, or host access. Set this to harden a shared/multi-tenant deployment.
 - `daytona` — isolated remote sandbox (strongest). Recommended when evaluator authors are not fully trusted. Requires the [daytona](#daytona) credentials below.
 
 The legacy `AGENTA_SERVICES_SANDBOX_RUNNER` is still accepted as a fallback.
+:::
+
+:::warning Agent sandbox
+`AGENTA_SANDBOX_LOCAL_ALLOWED` gates the `local` sandbox for agents (unconfined host bash,
+not a tenant boundary). It defaults to `true` so self-hosting works with zero
+configuration; the deployment logs a warning while `local` is active. Set it to `false`
+to harden a shared/multi-tenant deployment: requests for the `local` sandbox are then
+refused with an HTTP 403, and the web UI hides the `local` option
+(`NEXT_PUBLIC_AGENTA_SANDBOX_LOCAL_ENABLED`, derived automatically). The `daytona`
+sandbox is unaffected either way.
 :::
 
 ## Store (durable object store) {#store-durable-object-store}
@@ -276,13 +288,15 @@ cross into a remote sandbox.
 | `AGENTA_INSECURE_EGRESS_ALLOWED` | `agenta.webhooks.allow_insecure` (API); read directly by the SDK for workflow hooks and custom model provider endpoints | `agenta.insecureEgressAllowed` |
 
 :::note SSRF protection
-`AGENTA_INSECURE_EGRESS_ALLOWED` defaults to **false** (secure). Outbound requests that
-Agenta itself makes to a tenant-configured endpoint (webhooks, workflow hooks, custom
-model provider URLs) are blocked if they resolve to a private, loopback, or otherwise
-reserved IP address. This holds regardless of who configured the URL. Public URLs are
-never affected.
+`AGENTA_INSECURE_EGRESS_ALLOWED` defaults to `true`, so outbound requests that Agenta
+itself makes to a tenant-configured endpoint (webhooks, workflow hooks, custom model
+provider URLs) are allowed even when they resolve to a private, loopback, or otherwise
+reserved IP address. The deployment logs a warning while this default is active.
 
-Set it to `true` only for local development against services on your private network.
+If you're running a shared or multi-tenant deployment, set it to `false`. Agenta then
+blocks any such request that resolves to a private, loopback, or reserved IP address,
+regardless of who configured the URL. Public URLs are never affected either way.
+
 The old per-surface names (`AGENTA_WEBHOOKS_ALLOW_INSECURE`, `AGENTA_WEBHOOK_ALLOW_INSECURE`,
 `AGENTA_SERVICES_HOOK_ALLOW_INSECURE`, `AGENTA_CUSTOM_PROVIDER_ALLOW_INSECURE`) are
 deprecated aliases and still work, but new configuration should use the canonical name.

--- a/hosting/docker-compose/ee/env.ee.dev.example
+++ b/hosting/docker-compose/ee/env.ee.dev.example
@@ -100,9 +100,9 @@ AGENTA_CRYPT_KEY=replace-me
 # ================================================================== #
 # Agenta - Services (code/hook/middleware)
 # ================================================================== #
-# Custom-code evaluator runner: restricted (default, in-process sandbox) | local
-# (no sandbox, raw exec — trusted/single-tenant only) | daytona (isolated remote sandbox)
-# AGENTA_SERVICES_CODE_SANDBOX_RUNNER=restricted
+# Custom-code evaluator runner: local (default, no sandbox, raw exec — trusted/
+# single-tenant only) | restricted (in-process sandbox) | daytona (isolated remote sandbox)
+# AGENTA_SERVICES_CODE_SANDBOX_RUNNER=local
 # AGENTA_SERVICES_MIDDLEWARE_AUTH_ENABLED=true
 # AGENTA_SERVICES_MIDDLEWARE_CACHING_ENABLED=true
 
@@ -110,6 +110,13 @@ AGENTA_CRYPT_KEY=replace-me
 # Agenta - Egress (SSRF protection)
 # ================================================================== #
 AGENTA_INSECURE_EGRESS_ALLOWED=true
+
+# ================================================================== #
+# Agenta - Sandbox (agent runner)
+# ================================================================== #
+# `local` sandbox runs unconfined host bash; default true, set to false to harden a
+# shared/multi-tenant deployment.
+AGENTA_SANDBOX_LOCAL_ALLOWED=true
 
 # ================================================================== #
 # alembic

--- a/hosting/docker-compose/ee/env.ee.gh.example
+++ b/hosting/docker-compose/ee/env.ee.gh.example
@@ -102,9 +102,9 @@ AGENTA_CRYPT_KEY=replace-me
 # ================================================================== #
 # Agenta - Services (code/hook/middleware)
 # ================================================================== #
-# Custom-code evaluator runner: restricted (default, in-process sandbox) | local
-# (no sandbox, raw exec — trusted/single-tenant only) | daytona (isolated remote sandbox)
-# AGENTA_SERVICES_CODE_SANDBOX_RUNNER=restricted
+# Custom-code evaluator runner: local (default, no sandbox, raw exec — trusted/
+# single-tenant only) | restricted (in-process sandbox) | daytona (isolated remote sandbox)
+# AGENTA_SERVICES_CODE_SANDBOX_RUNNER=local
 # AGENTA_SERVICES_MIDDLEWARE_AUTH_ENABLED=true
 # AGENTA_SERVICES_MIDDLEWARE_CACHING_ENABLED=true
 
@@ -112,6 +112,13 @@ AGENTA_CRYPT_KEY=replace-me
 # Agenta - Egress (SSRF protection)
 # ================================================================== #
 # AGENTA_INSECURE_EGRESS_ALLOWED=true
+
+# ================================================================== #
+# Agenta - Sandbox (agent runner)
+# ================================================================== #
+# `local` sandbox runs unconfined host bash; default true, set to false to harden a
+# shared/multi-tenant deployment.
+# AGENTA_SANDBOX_LOCAL_ALLOWED=true
 
 # ================================================================== #
 # alembic

--- a/hosting/docker-compose/oss/env.oss.dev.example
+++ b/hosting/docker-compose/oss/env.oss.dev.example
@@ -100,9 +100,9 @@ AGENTA_CRYPT_KEY=replace-me
 # ================================================================== #
 # Agenta - Services (code/hook/middleware)
 # ================================================================== #
-# Custom-code evaluator runner: restricted (default, in-process sandbox) | local
-# (no sandbox, raw exec — trusted/single-tenant only) | daytona (isolated remote sandbox)
-# AGENTA_SERVICES_CODE_SANDBOX_RUNNER=restricted
+# Custom-code evaluator runner: local (default, no sandbox, raw exec — trusted/
+# single-tenant only) | restricted (in-process sandbox) | daytona (isolated remote sandbox)
+# AGENTA_SERVICES_CODE_SANDBOX_RUNNER=local
 # AGENTA_SERVICES_MIDDLEWARE_AUTH_ENABLED=true
 # AGENTA_SERVICES_MIDDLEWARE_CACHING_ENABLED=true
 
@@ -110,6 +110,13 @@ AGENTA_CRYPT_KEY=replace-me
 # Agenta - Egress (SSRF protection)
 # ================================================================== #
 AGENTA_INSECURE_EGRESS_ALLOWED=true
+
+# ================================================================== #
+# Agenta - Sandbox (agent runner)
+# ================================================================== #
+# `local` sandbox runs unconfined host bash; default true, set to false to harden a
+# shared/multi-tenant deployment.
+AGENTA_SANDBOX_LOCAL_ALLOWED=true
 
 # ================================================================== #
 # alembic

--- a/hosting/docker-compose/oss/env.oss.gh.example
+++ b/hosting/docker-compose/oss/env.oss.gh.example
@@ -102,9 +102,9 @@ AGENTA_CRYPT_KEY=replace-me
 # ================================================================== #
 # Agenta - Services (code/hook/middleware)
 # ================================================================== #
-# Custom-code evaluator runner: restricted (default, in-process sandbox) | local
-# (no sandbox, raw exec — trusted/single-tenant only) | daytona (isolated remote sandbox)
-# AGENTA_SERVICES_CODE_SANDBOX_RUNNER=restricted
+# Custom-code evaluator runner: local (default, no sandbox, raw exec — trusted/
+# single-tenant only) | restricted (in-process sandbox) | daytona (isolated remote sandbox)
+# AGENTA_SERVICES_CODE_SANDBOX_RUNNER=local
 # AGENTA_SERVICES_MIDDLEWARE_AUTH_ENABLED=true
 # AGENTA_SERVICES_MIDDLEWARE_CACHING_ENABLED=true
 
@@ -112,6 +112,13 @@ AGENTA_CRYPT_KEY=replace-me
 # Agenta - Egress (SSRF protection)
 # ================================================================== #
 # AGENTA_INSECURE_EGRESS_ALLOWED=true
+
+# ================================================================== #
+# Agenta - Sandbox (agent runner)
+# ================================================================== #
+# `local` sandbox runs unconfined host bash; default true, set to false to harden a
+# shared/multi-tenant deployment.
+# AGENTA_SANDBOX_LOCAL_ALLOWED=true
 
 # ================================================================== #
 # alembic

--- a/hosting/kubernetes/ee/values.ee.example.yaml
+++ b/hosting/kubernetes/ee/values.ee.example.yaml
@@ -112,24 +112,33 @@ global:
 # ================================================================== #
 # === agenta.services ===
 # Consumed by the agenta SDK running inside services pods:
-#   - code.sandboxRunner   → AGENTA_SERVICES_CODE_SANDBOX_RUNNER (restricted|local|daytona; default restricted. local = no sandbox, trusted only)
+#   - code.sandboxRunner   → AGENTA_SERVICES_CODE_SANDBOX_RUNNER (restricted|local|daytona; default local. local = no sandbox, trusted only)
 #   - middleware.authEnabled    → AGENTA_SERVICES_MIDDLEWARE_AUTH_ENABLED
 #   - middleware.cachingEnabled → AGENTA_SERVICES_MIDDLEWARE_CACHING_ENABLED
 # ================================================================== #
 # agenta:
 #   services:
 #     code:
-#       sandboxRunner: restricted
+#       sandboxRunner: local
 #     middleware:
 #       authEnabled: true
 #       cachingEnabled: true
 
 # ================================================================== #
 # === agenta.insecureEgressAllowed ===
-# default false (secure); true permits egress to private/loopback IPs — dev only.
+# default true (permissive, zero-config self-host); set false to harden a
+# shared/multi-tenant deployment.
 # ================================================================== #
 # agenta:
-#   insecureEgressAllowed: false
+#   insecureEgressAllowed: true
+
+# ================================================================== #
+# === agenta.sandboxLocalAllowed ===
+# default true (permissive, zero-config self-host); `local` sandbox runs unconfined
+# host bash. Set false to harden a shared/multi-tenant deployment.
+# ================================================================== #
+# agenta:
+#   sandboxLocalAllowed: true
 
 # ================================================================== #
 # === alembic ===

--- a/hosting/kubernetes/helm/templates/_helpers.tpl
+++ b/hosting/kubernetes/helm/templates/_helpers.tpl
@@ -1097,6 +1097,11 @@ imagePullSecrets:
 - name: AGENTA_SERVICES_CODE_SANDBOX_RUNNER
   value: {{ $svcCode.sandboxRunner | quote }}
 {{- end }}
+{{- /* agenta.sandboxLocalAllowed — agent runner `local` sandbox gate */}}
+{{- if hasKey $agenta "sandboxLocalAllowed" }}
+- name: AGENTA_SANDBOX_LOCAL_ALLOWED
+  value: {{ $agenta.sandboxLocalAllowed | quote }}
+{{- end }}
 {{- /* agenta.services.middleware — SDK middleware toggles */}}
 {{- if hasKey $svcMiddleware "authEnabled" }}
 - name: AGENTA_SERVICES_MIDDLEWARE_AUTH_ENABLED

--- a/hosting/kubernetes/helm/values.schema.json
+++ b/hosting/kubernetes/helm/values.schema.json
@@ -16,7 +16,8 @@
         "apiInternalUrl": { "type": "string", "description": "Internal API URL (in-cluster). Emitted as AGENTA_API_INTERNAL_URL." },
         "authKey": { "type": "string", "minLength": 1, "description": "Authorization key. Emitted as AGENTA_AUTH_KEY via Secret." },
         "cryptKey": { "type": "string", "minLength": 1, "description": "Encryption key. Emitted as AGENTA_CRYPT_KEY via Secret." },
-        "insecureEgressAllowed": { "type": ["boolean", "string"], "description": "AGENTA_INSECURE_EGRESS_ALLOWED — default false (secure); true permits egress to private/loopback IPs — dev only." },
+        "insecureEgressAllowed": { "type": ["boolean", "string"], "description": "AGENTA_INSECURE_EGRESS_ALLOWED — default true (permissive, zero-config self-host); set false to harden a shared/multi-tenant deployment." },
+        "sandboxLocalAllowed": { "type": ["boolean", "string"], "description": "AGENTA_SANDBOX_LOCAL_ALLOWED — default true (permissive, zero-config self-host); `local` sandbox runs unconfined host bash. Set false to harden a shared/multi-tenant deployment." },
         "access": {
           "type": "object",
           "additionalProperties": false,
@@ -102,7 +103,7 @@
               "type": "object",
               "additionalProperties": false,
               "properties": {
-                "sandboxRunner": { "type": "string", "enum": ["local", "daytona"], "description": "AGENTA_SERVICES_CODE_SANDBOX_RUNNER." }
+                "sandboxRunner": { "type": "string", "enum": ["restricted", "local", "daytona"], "description": "AGENTA_SERVICES_CODE_SANDBOX_RUNNER — default local." }
               }
             },
             "middleware": {

--- a/hosting/kubernetes/oss/values.oss.example.yaml
+++ b/hosting/kubernetes/oss/values.oss.example.yaml
@@ -99,24 +99,33 @@ agenta:
 # ================================================================== #
 # === agenta.services ===
 # Consumed by the agenta SDK running inside services pods:
-#   - code.sandboxRunner   → AGENTA_SERVICES_CODE_SANDBOX_RUNNER (restricted|local|daytona; default restricted. local = no sandbox, trusted only)
+#   - code.sandboxRunner   → AGENTA_SERVICES_CODE_SANDBOX_RUNNER (restricted|local|daytona; default local. local = no sandbox, trusted only)
 #   - middleware.authEnabled    → AGENTA_SERVICES_MIDDLEWARE_AUTH_ENABLED
 #   - middleware.cachingEnabled → AGENTA_SERVICES_MIDDLEWARE_CACHING_ENABLED
 # ================================================================== #
 # agenta:
 #   services:
 #     code:
-#       sandboxRunner: restricted
+#       sandboxRunner: local
 #     middleware:
 #       authEnabled: true
 #       cachingEnabled: true
 
 # ================================================================== #
 # === agenta.insecureEgressAllowed ===
-# default false (secure); true permits egress to private/loopback IPs — dev only.
+# default true (permissive, zero-config self-host); set false to harden a
+# shared/multi-tenant deployment.
 # ================================================================== #
 # agenta:
-#   insecureEgressAllowed: false
+#   insecureEgressAllowed: true
+
+# ================================================================== #
+# === agenta.sandboxLocalAllowed ===
+# default true (permissive, zero-config self-host); `local` sandbox runs unconfined
+# host bash. Set false to harden a shared/multi-tenant deployment.
+# ================================================================== #
+# agenta:
+#   sandboxLocalAllowed: true
 
 # ================================================================== #
 # === alembic ===

--- a/sdks/python/agenta/sdk/agents/__init__.py
+++ b/sdks/python/agenta/sdk/agents/__init__.py
@@ -82,6 +82,7 @@ from .dtos import (
 )
 from .errors import (
     AgentRunnerConfigurationError,
+    LocalSandboxNotAllowedError,
     ToolResolutionError,
     UnsupportedHarnessError,
 )
@@ -260,6 +261,7 @@ __all__ = [
     "Harness",
     # Errors
     "AgentRunnerConfigurationError",
+    "LocalSandboxNotAllowedError",
     "UnsupportedHarnessError",
     "ToolResolutionError",
     "InvalidPermissionDefaultError",

--- a/sdks/python/agenta/sdk/agents/errors.py
+++ b/sdks/python/agenta/sdk/agents/errors.py
@@ -4,11 +4,14 @@ from __future__ import annotations
 
 from typing import TYPE_CHECKING
 
+from agenta.sdk.engines.running.errors import ERRORS_BASE_URL, ErrorStatus
+
 from .dtos import HarnessType
 from .tools.errors import ToolResolutionError
 
 __all__ = [
     "AgentRunnerConfigurationError",
+    "LocalSandboxNotAllowedError",
     "UnsupportedHarnessError",
     "ToolResolutionError",
 ]
@@ -32,3 +35,19 @@ class UnsupportedHarnessError(RuntimeError):
 
 class AgentRunnerConfigurationError(RuntimeError):
     """Raised when a runner-backed adapter lacks a usable transport configuration."""
+
+
+class LocalSandboxNotAllowedError(ErrorStatus):
+    """`sandbox: "local"` requested while `AGENTA_SANDBOX_LOCAL_ALLOWED` is off; maps to HTTP 403."""
+
+    code: int = 403
+    type: str = f"{ERRORS_BASE_URL}#v0:agent:local-sandbox-not-allowed"
+
+    def __init__(
+        self,
+        message: str = (
+            "sandbox 'local' is not allowed on this deployment "
+            "(set AGENTA_SANDBOX_LOCAL_ALLOWED=true to enable)"
+        ),
+    ) -> None:
+        super().__init__(code=self.code, type=self.type, message=message)

--- a/sdks/python/agenta/sdk/agents/handler.py
+++ b/sdks/python/agenta/sdk/agents/handler.py
@@ -32,6 +32,7 @@ from agenta.sdk.agents.connections import (
 )
 from agenta.sdk.agents.tools import ResolvedToolSet
 from agenta.sdk.agents.adapters import SandboxAgentBackend, make_harness
+from agenta.sdk.agents.errors import LocalSandboxNotAllowedError
 from agenta.sdk.agents.mcp import MCPDisabledError, ResolvedMCPServer
 from agenta.sdk.agents.mcp.parsing import parse_mcp_server_configs
 from agenta.sdk.agents.platform import (
@@ -75,8 +76,21 @@ def _default_template() -> AgentTemplate:
     return AgentTemplate()
 
 
+def _sandbox_local_allowed() -> bool:
+    return (
+        os.getenv("AGENTA_SANDBOX_LOCAL_ALLOWED") or "true"
+    ).strip().lower() in TRUTHY
+
+
 def _default_select_backend(agent_template: AgentTemplate) -> Backend:
-    """Env-driven default: `AGENTA_RUNNER_INTERNAL_URL` picks HTTP transport; else local cwd."""
+    """Env-driven default: `AGENTA_RUNNER_INTERNAL_URL` picks HTTP transport; else local cwd.
+
+    `local` (unconfined host bash, not a tenant boundary) is refused unless
+    `AGENTA_SANDBOX_LOCAL_ALLOWED` is on — a bare `agent_v0` gets this protocol-level
+    safety behavior for free, same as capability gating and MCP gating above.
+    """
+    if agent_template.sandbox == "local" and not _sandbox_local_allowed():
+        raise LocalSandboxNotAllowedError()
     url = os.getenv("AGENTA_RUNNER_INTERNAL_URL", "").strip() or None
     return SandboxAgentBackend(sandbox=agent_template.sandbox, url=url, cwd=os.getcwd())
 

--- a/sdks/python/oss/tests/pytest/unit/agents/test_agent_composition_seam.py
+++ b/sdks/python/oss/tests/pytest/unit/agents/test_agent_composition_seam.py
@@ -388,5 +388,68 @@ async def test_composition_select_backend_is_deployment_specific():
     assert result_b["messages"][0]["content"] == "b"
 
 
+# --------------------------------------------------------------------------- #
+# Local-sandbox gate is the bare SDK default too (a composition-free `agent_v0` gets
+# this protocol-level safety behavior for free, same as capability/MCP gating above).
+# --------------------------------------------------------------------------- #
+async def test_default_select_backend_refuses_local_sandbox_when_knob_off(monkeypatch):
+    from agenta.sdk.agents import LocalSandboxNotAllowedError
+    from agenta.sdk.agents.dtos import AgentTemplate
+
+    monkeypatch.setenv("AGENTA_SANDBOX_LOCAL_ALLOWED", "false")
+    comp = AgentComposition(resolve_connection=_no_connection)
+    handler = make_agent_handler(comp)
+
+    with pytest.raises(LocalSandboxNotAllowedError):
+        await handler(
+            request=_request(),
+            messages=[{"role": "user", "content": "hi"}],
+            parameters={
+                "agent": {"harness": {"kind": "pi_core"}, "sandbox": {"kind": "local"}}
+            },
+        )
+
+    # sanity: the template really did carry "local" through to select_backend's input.
+    assert AgentTemplate(sandbox="local").sandbox == "local"
+
+
+async def test_default_select_backend_allows_local_sandbox_by_default(monkeypatch):
+    from agenta.sdk.agents.errors import AgentRunnerConfigurationError
+
+    monkeypatch.delenv("AGENTA_SANDBOX_LOCAL_ALLOWED", raising=False)
+    comp = AgentComposition(resolve_connection=_no_connection)
+    handler = make_agent_handler(comp)
+
+    # Past the gate, it hits the real SandboxAgentBackend construction, which fails on
+    # missing runner assets in this sandboxed test env -- proving the gate itself passed.
+    with pytest.raises(AgentRunnerConfigurationError):
+        await handler(
+            request=_request(),
+            messages=[{"role": "user", "content": "hi"}],
+            parameters={
+                "agent": {"harness": {"kind": "pi_core"}, "sandbox": {"kind": "local"}}
+            },
+        )
+
+
+async def test_default_select_backend_allows_daytona_sandbox_by_default(monkeypatch):
+    monkeypatch.delenv("AGENTA_SANDBOX_LOCAL_ALLOWED", raising=False)
+    backend = _FakeBackend()
+    comp = AgentComposition(
+        select_backend=lambda template: backend,
+        resolve_connection=_no_connection,
+    )
+    handler = make_agent_handler(comp)
+
+    result = await handler(
+        request=_request(),
+        messages=[{"role": "user", "content": "hi"}],
+        parameters={
+            "agent": {"harness": {"kind": "pi_core"}, "sandbox": {"kind": "daytona"}}
+        },
+    )
+    assert isinstance(result, dict)
+
+
 if __name__ == "__main__":
     pytest.main([__file__, "-q"])

--- a/services/oss/src/agent/app.py
+++ b/services/oss/src/agent/app.py
@@ -19,6 +19,7 @@ import agenta as ag
 from agenta.sdk.agents import (
     AgentTemplate,
     Backend,
+    LocalSandboxNotAllowedError,
     SandboxAgentBackend,
 )
 
@@ -42,7 +43,12 @@ from agenta.sdk.utils.logging import get_module_logger
 
 from agenta.sdk.agents.tracing import record_usage, run_context, trace_context
 
-from oss.src.agent.config import load_config, runner_dir, runner_url
+from oss.src.agent.config import (
+    load_config,
+    runner_dir,
+    runner_url,
+    sandbox_local_allowed,
+)
 from oss.src.agent.schemas import AGENT_SCHEMAS
 from oss.src.agent.tools import resolve_mcp_servers, resolve_tools
 
@@ -66,7 +72,13 @@ def select_backend(agent_template: AgentTemplate) -> Backend:
     selects HTTP transport in deployed containers. When it is unset, local development
     spawns the TypeScript runner CLI from the runner dir. Only ``sandbox`` is read here;
     it is a backend/environment concern that never enters ``SessionConfig``.
+
+    ``local`` is refused unless ``AGENTA_SANDBOX_LOCAL_ALLOWED`` is on: it is unconfined
+    host bash, not a tenant boundary, on a shared deployment. This is the producer-side
+    gate; the runner's own id whitelist is a second, independent layer.
     """
+    if agent_template.sandbox == "local" and not sandbox_local_allowed():
+        raise LocalSandboxNotAllowedError()
     return SandboxAgentBackend(
         sandbox=agent_template.sandbox,
         url=runner_url(),

--- a/services/oss/src/agent/config.py
+++ b/services/oss/src/agent/config.py
@@ -53,6 +53,29 @@ def runner_url() -> Optional[str]:
     return value.strip() if value and value.strip() else None
 
 
+_TRUTHY = {"true", "1", "t", "y", "yes", "on", "enable", "enabled"}
+_SANDBOX_LOCAL_WARNED = False
+
+
+def sandbox_local_allowed() -> bool:
+    """Whether `sandbox: "local"` (unconfined host bash) may be selected.
+
+    Mirrors `api/oss/src/utils/env.py`'s `RunnerConfig.sandbox_local_allowed`: same env
+    var, same permissive-by-default posture (zero-config self-host). This service does
+    not depend on `api`, so it reads the var directly (this package's own convention;
+    see `runner_dir`/`runner_url` above) rather than importing the shared `env` object.
+    """
+    global _SANDBOX_LOCAL_WARNED
+    allowed = (os.getenv("AGENTA_SANDBOX_LOCAL_ALLOWED") or "true").lower() in _TRUTHY
+    if allowed and not _SANDBOX_LOCAL_WARNED:
+        _SANDBOX_LOCAL_WARNED = True
+        log.warning(
+            "AGENTA_SANDBOX_LOCAL_ALLOWED is on (default): local sandbox is not a "
+            "tenant boundary. Set it to false to harden a shared/multi-tenant deployment."
+        )
+    return allowed
+
+
 def config_dir() -> Path:
     """Directory holding the static on-file agent template (AGENTS.md and agent.json)."""
     override = os.getenv("AGENTA_AGENT_TEMPLATE_DIR")

--- a/services/oss/tests/pytest/unit/agent/test_select_backend.py
+++ b/services/oss/tests/pytest/unit/agent/test_select_backend.py
@@ -9,6 +9,7 @@ import pytest
 from agenta.sdk.agents import (
     AgentTemplate,
     AgentRunnerConfigurationError,
+    LocalSandboxNotAllowedError,
     SandboxAgentBackend,
 )
 
@@ -25,9 +26,12 @@ def runner_wrapper(tmp_path: Path) -> Path:
 
 @pytest.fixture(autouse=True)
 def _clean_env(monkeypatch, runner_wrapper: Path):
-    # Start every case from a known-empty deployment environment.
+    # Start every case from a known-empty deployment environment. These tests exercise
+    # transport/harness selection, not the local-sandbox gate (on by default anyway), so
+    # pin it explicitly here for clarity; the gate itself has its own tests below.
     monkeypatch.delenv("AGENTA_RUNNER_INTERNAL_URL", raising=False)
     monkeypatch.setenv("AGENTA_RUNNER_DIR", str(runner_wrapper))
+    monkeypatch.setenv("AGENTA_SANDBOX_LOCAL_ALLOWED", "true")
 
 
 def _sel(harness="pi_core", sandbox="local"):
@@ -66,3 +70,43 @@ def test_no_runner_url_requires_runner_assets(monkeypatch, tmp_path: Path):
 
     with pytest.raises(AgentRunnerConfigurationError, match="src/cli.ts"):
         select_backend(_sel("pi_core", "local"))
+
+
+# ---------------------------------------------------------------------------
+# Local-sandbox gate: `sandbox: "local"` is unconfined host bash, not a tenant
+# boundary, so it is refused unless AGENTA_SANDBOX_LOCAL_ALLOWED is on.
+# ---------------------------------------------------------------------------
+
+
+def test_local_sandbox_refused_when_knob_off(monkeypatch):
+    monkeypatch.setenv("AGENTA_SANDBOX_LOCAL_ALLOWED", "false")
+
+    with pytest.raises(LocalSandboxNotAllowedError):
+        select_backend(_sel("pi_core", "local"))
+
+
+def test_local_sandbox_allowed_by_default_when_unset(monkeypatch):
+    monkeypatch.delenv("AGENTA_SANDBOX_LOCAL_ALLOWED", raising=False)
+
+    backend = select_backend(_sel("pi_core", "local"))
+
+    assert isinstance(backend, SandboxAgentBackend)
+    assert backend._sandbox == "local"
+
+
+def test_local_sandbox_allowed_when_knob_on(monkeypatch):
+    monkeypatch.setenv("AGENTA_SANDBOX_LOCAL_ALLOWED", "true")
+
+    backend = select_backend(_sel("pi_core", "local"))
+
+    assert isinstance(backend, SandboxAgentBackend)
+    assert backend._sandbox == "local"
+
+
+def test_daytona_sandbox_always_allowed(monkeypatch):
+    monkeypatch.setenv("AGENTA_SANDBOX_LOCAL_ALLOWED", "false")
+
+    backend = select_backend(_sel("pi_core", "daytona"))
+
+    assert isinstance(backend, SandboxAgentBackend)
+    assert backend._sandbox == "daytona"

--- a/web/entrypoint.sh
+++ b/web/entrypoint.sh
@@ -63,6 +63,12 @@ else
   export AGENTA_BILLING_ENABLED="false"
 fi
 
+# Mirror AGENTA_SANDBOX_LOCAL_ALLOWED (api/oss/src/utils/env.py _TRUTHY): unset -> enabled.
+case "$(printf '%s' "${AGENTA_SANDBOX_LOCAL_ALLOWED:-true}" | tr '[:upper:]' '[:lower:]')" in
+  true|1|t|y|yes|on|enable|enabled) export AGENTA_SANDBOX_LOCAL_ENABLED="true" ;;
+  *) export AGENTA_SANDBOX_LOCAL_ENABLED="false" ;;
+esac
+
 mkdir -p "${ENTRYPOINT_DIR}/${AGENTA_LICENSE}/public"
 
 # Derive frontend auth feature flags
@@ -202,6 +208,7 @@ window.__env = {
   NEXT_PUBLIC_SUPERTOKENS_PASSWORD_MIN_LENGTH: "${SUPERTOKENS_PASSWORD_MIN_LENGTH}",
   NEXT_PUBLIC_SUPERTOKENS_PASSWORD_MAX_LENGTH: "${SUPERTOKENS_PASSWORD_MAX_LENGTH}",
   NEXT_PUBLIC_SUPERTOKENS_PASSWORD_REGEX: "${SUPERTOKENS_PASSWORD_REGEX}",
+  NEXT_PUBLIC_AGENTA_SANDBOX_LOCAL_ENABLED: "${AGENTA_SANDBOX_LOCAL_ENABLED}",
 };
 EOF
 

--- a/web/oss/src/lib/helpers/dynamicEnv.ts
+++ b/web/oss/src/lib/helpers/dynamicEnv.ts
@@ -62,6 +62,7 @@ export const processEnv = {
         process.env.NEXT_PUBLIC_AGENTA_EMAIL_DELIVERY_ENABLED,
     NEXT_PUBLIC_AGENTA_TOOLS_ENABLED: process.env.NEXT_PUBLIC_AGENTA_TOOLS_ENABLED,
     NEXT_PUBLIC_AGENTA_BILLING_ENABLED: process.env.NEXT_PUBLIC_AGENTA_BILLING_ENABLED,
+    NEXT_PUBLIC_AGENTA_SANDBOX_LOCAL_ENABLED: process.env.NEXT_PUBLIC_AGENTA_SANDBOX_LOCAL_ENABLED,
     NEXT_PUBLIC_SUPERTOKENS_PASSWORD_MIN_LENGTH:
         process.env.NEXT_PUBLIC_SUPERTOKENS_PASSWORD_MIN_LENGTH,
     NEXT_PUBLIC_SUPERTOKENS_PASSWORD_MAX_LENGTH:
@@ -76,6 +77,14 @@ export const processEnv = {
 
 const normalizeBoolean = (value: string | undefined) => {
     return (value || "").toLowerCase() === "true"
+}
+
+// Mirror the API `_TRUTHY` rule: unset defaults to enabled, only truthy values enable.
+const SANDBOX_LOCAL_TRUTHY = new Set(["true", "1", "t", "y", "yes", "on", "enable", "enabled"])
+
+export const isSandboxLocalEnabled = () => {
+    const raw = getEnv("NEXT_PUBLIC_AGENTA_SANDBOX_LOCAL_ENABLED") || "true"
+    return SANDBOX_LOCAL_TRUTHY.has(raw.trim().toLowerCase())
 }
 
 export const getEffectiveAuthConfig = () => {

--- a/web/packages/agenta-entity-ui/src/DrillInView/SchemaControls/agentTemplate/useModelHarness.tsx
+++ b/web/packages/agenta-entity-ui/src/DrillInView/SchemaControls/agentTemplate/useModelHarness.tsx
@@ -11,6 +11,7 @@ import {
 } from "@agenta/entities/secret"
 import type {SchemaProperty} from "@agenta/entities/shared"
 import {harnessCapabilitiesAtomFamily} from "@agenta/entities/workflow"
+import {isSandboxLocalEnabled} from "@agenta/shared/api"
 import {normalizeProviderFamily} from "@agenta/shared/utils"
 import {ConfigAccordionSection} from "@agenta/ui/components/presentational"
 import {useDrillInUI} from "@agenta/ui/drill-in"
@@ -35,7 +36,7 @@ import {
     vaultPickedProviderFamily,
     type ConnectionMode,
 } from "../connectionUtils"
-import {EnumSelectControl} from "../EnumSelectControl"
+import {EnumSelectControl, getEnumOptions} from "../EnumSelectControl"
 import {GroupedChoiceControl} from "../GroupedChoiceControl"
 import {HarnessSelectControl} from "../HarnessSelectControl"
 import {PiSettingsControl} from "../PiSettingsControl"
@@ -95,6 +96,10 @@ export function useModelHarness({
     const harnessProps = subProps("harness")
     const runnerProps = subProps("runner")
     const sandboxProps = subProps("sandbox")
+    const sandboxOptions = useMemo(() => {
+        const options = getEnumOptions(sandboxProps.kind)
+        return isSandboxLocalEnabled() ? options : options.filter((o) => o.value !== "local")
+    }, [sandboxProps.kind])
 
     const asObject = useCallback(
         (key: string): Record<string, unknown> =>
@@ -699,6 +704,7 @@ export function useModelHarness({
                         <RailField label="Sandbox" align="center">
                             <EnumSelectControl
                                 schema={sandboxProps.kind}
+                                options={sandboxOptions}
                                 value={(sandbox.kind as string | null) ?? null}
                                 onChange={(v) => setSection("sandbox", {...sandbox, kind: v})}
                                 withTooltip={withTooltip}

--- a/web/packages/agenta-shared/src/api/env.ts
+++ b/web/packages/agenta-shared/src/api/env.ts
@@ -36,6 +36,7 @@ export const processEnv = {
         process.env.NEXT_PUBLIC_CLOUDFLARE_TURNSTILE_SITE_KEY,
     NEXT_PUBLIC_LOG_APP_ATOMS: process.env.NEXT_PUBLIC_LOG_APP_ATOMS,
     NEXT_PUBLIC_ENABLE_ATOM_LOGS: process.env.NEXT_PUBLIC_ENABLE_ATOM_LOGS,
+    NEXT_PUBLIC_AGENTA_SANDBOX_LOCAL_ENABLED: process.env.NEXT_PUBLIC_AGENTA_SANDBOX_LOCAL_ENABLED,
 }
 
 /**
@@ -71,4 +72,12 @@ export const getAgentaWebUrl = (): string => {
     const webUrl = getEnv("NEXT_PUBLIC_AGENTA_WEB_URL")
     if (webUrl) return webUrl
     return buildRuntimeOrigin() ?? ""
+}
+
+// Mirror the API `_TRUTHY` rule: unset defaults to enabled, only truthy values enable.
+const SANDBOX_LOCAL_TRUTHY = new Set(["true", "1", "t", "y", "yes", "on", "enable", "enabled"])
+
+export const isSandboxLocalEnabled = (): boolean => {
+    const raw = getEnv("NEXT_PUBLIC_AGENTA_SANDBOX_LOCAL_ENABLED") || "true"
+    return SANDBOX_LOCAL_TRUTHY.has(raw.trim().toLowerCase())
 }

--- a/web/packages/agenta-shared/src/api/index.ts
+++ b/web/packages/agenta-shared/src/api/index.ts
@@ -2,7 +2,7 @@
  * API utilities for Agenta packages.
  */
 
-export {getEnv, getAgentaApiUrl, getAgentaWebUrl, processEnv} from "./env"
+export {getEnv, getAgentaApiUrl, getAgentaWebUrl, isSandboxLocalEnabled, processEnv} from "./env"
 export {axios, createAxiosInstance, configureAxios, resetAxiosConfig} from "./axios"
 export type {AxiosInterceptorConfig} from "./axios"
 export type {


### PR DESCRIPTION
## Context

Two problems, one fix.

First, there was no server-side policy on which sandbox a run may use. A run could ask for `sandbox: "local"`, which runs as unconfined host bash, and nothing on the service refused it. `local` is not a tenant boundary on a shared deployment.

Second, and the reason the fix is shaped the way it is: the existing security knobs all defaulted to the secure-but-inconvenient value. Insecure egress defaulted to `false`, the code sandbox runner defaulted to `restricted`. A fresh self-host or someone just trying the product out could not run an agent locally without first setting environment variables. That friction is what we want to remove.

## What this adds

The product stance is: self-hosting and trying-it-out work with zero configuration. The permissive value is the default, and the deployment logs a warning while it is permissive. An operator hardens a shared or multi-tenant deployment by setting the environment variables to turn restrictions on. This is how many dev tools behave (permissive by default, loud warning), and cloud already sets the restrictive values in its own env files, which is the safety net.

Three defaults flip in `api/oss/src/utils/env.py`:

| Knob | Env var | Old default | New default |
| --- | --- | --- | --- |
| Insecure egress | `AGENTA_INSECURE_EGRESS_ALLOWED` | `false` | `true` |
| Code sandbox runner | `AGENTA_SERVICES_CODE_SANDBOX_RUNNER` | `restricted` | `local` |
| Sandbox `local` allowed | `AGENTA_SANDBOX_LOCAL_ALLOWED` | `false` | `true` |

Each warns once when permissive. The wording changed from "X is set" to "X is on (default)" since the warning now fires on the unset path.

The `local` gate still has teeth. It is a real gate, not just a log line:

- Default or on: `local` is allowed, with the one-time warning.
- Off (`AGENTA_SANDBOX_LOCAL_ALLOWED=false`, the hardened case): `local` is refused with a typed `LocalSandboxNotAllowedError` (HTTP 403).

The 403 detail matters. The SDK's HTTP boundary remaps a generic 401/403/429 to 424 as a "downstream error", so the exception subclasses `ErrorStatus` (not a plain error) to keep its own 403.

The web UI hides the `local` sandbox option when a deployment has it disabled, so users are not offered a choice the backend will reject. A new `NEXT_PUBLIC_AGENTA_SANDBOX_LOCAL_ENABLED` flag is derived from the server-side var in `web/entrypoint.sh`, exposed through `dynamicEnv.ts`, and read by the sandbox selector, which filters `local` out of its options when the flag is off. The backend refusal remains the real gate; hiding the option is UX. Default is shown.

All three read sites parse the env var with the same truthy rule (`(getenv or "true") in _TRUTHY`), so an unset var is permissive everywhere: the two `env.py` fields and the two independent helpers in `services/oss` and `sdks/python` (those are separate deployables that read `os.getenv` directly by their own convention). The shell mirrors the same rule so the frontend flag agrees with the backend.

The new variable is propagated everywhere its siblings live: the docker-compose env examples, the helm values examples and templates, `values.schema.json`, and the self-host configuration docs (which also had their now-wrong "defaults to false (secure)" prose corrected for all three knobs).

## Tests / notes

- Please read the default flips carefully. `AGENTA_INSECURE_EGRESS_ALLOWED=true` by default is the broadest-blast-radius change here. It affects webhook, hook, and custom-provider egress SSRF protection, not just sandboxes, with the log warning as the only guardrail if a self-hosted instance later becomes multi-tenant without revisiting the var. This is the deliberate convenience-first tradeoff; cloud hardens it in its own env files.
- api 78 passed, services 81 passed, sdk 584 passed. The env tests assert the unset case is now permissive for all three and that an explicit `false` hardens. `ruff` clean; `pnpm lint-fix` clean.
- Found and fixed a latent bug on a line being edited: `values.schema.json`'s `sandboxRunner` enum was missing `restricted` entirely (`["local","daytona"]`), which would have rejected the previously-default value.
- The dev env examples already set egress to `true` while the docs said the default was `false`. That drift is now reconciled.
- Two pre-existing SDK failures (`test_unknown_harness_is_permissive`, `test_run_selection_unknown_permission_falls_back_to_allow_reads`) fail on the base branch independent of this change.

## What to QA

- Fresh deploy with no sandbox/egress env vars set. An agent run with `sandbox: local` succeeds, and the server logs the "is on (default)" warnings. The sandbox selector in the agent template UI shows `local`.
- Set `AGENTA_SANDBOX_LOCAL_ALLOWED=false` and redeploy. A run requesting `local` is refused with a 403; `daytona` still runs. The sandbox selector no longer offers `local`.
- Regression: `daytona` runs are unaffected in every configuration.
