### PR TITLE
fix(runner): cold-replay stopgaps — result caps, resume frame, arg parsing

### DIFF
--- a/docs/design/agent-workflows/projects/cold-replay-stopgaps/plan.md
+++ b/docs/design/agent-workflows/projects/cold-replay-stopgaps/plan.md
@@ -1,0 +1,60 @@
+# Cold-replay stopgaps
+
+## What and why
+
+The agent runtime cold-replays the whole conversation as flattened text on every turn
+(`services/runner/src/engines/sandbox_agent/transcript.ts`, `buildTurnText`). Two
+production failures on 2026-07-07 came from that path; the full analysis is in
+[../approval-boundary/cold-replay-failure-report.md](../approval-boundary/cold-replay-failure-report.md).
+Turn c6de1865 took three approval rounds because each fresh model rebuilt the tool
+arguments from the lossy text and drifted the approval key. Turn 6d34b1ea ran five rounds
+and executed zero commits: the resume prompt re-presented the stale user command as if
+just spoken, so each fresh model restarted the whole task, and one large tool output
+filled the 24K tail-sliced window and evicted the original goal.
+
+Session-based continuation (keep-alive plus native `session/load`) is the real fix and is
+coming next. The text-replay path stays as the fallback after sessions land, so it is
+worth fixing cheaply. The rule for this change set: no complexity that sessions will make
+unnecessary. Four small, runner-only changes.
+
+## The four changes
+
+1. **Per-result cap plus a bigger window** (`transcript.ts`). Each rendered tool RESULT
+   body is capped at 4,000 chars with an explicit elision marker that states the omitted
+   char count. Tool CALL args are never capped: the approval replay nudge tells the model
+   to re-issue the call "with the same arguments", so args must stay complete. User and
+   assistant text are not capped. The default `AGENTA_AGENT_HISTORY_MAX_CHARS` window
+   rises from 24,000 to 100,000 (still env-overridable, same tail-slice mechanics).
+2. **Resume closing frame** (`transcript.ts`, `buildTurnText`). An approval resume is
+   detected conservatively: an unresolved approved call (the existing `lastPending`
+   render hint) sits in a message after the last user message that carries text. In that
+   case the closing frame becomes an explicit resume instruction (execute exactly the
+   approved call, do not restart the task) instead of "The user now says: \<stale
+   command>". The stale command stays in the replayed history in its original position;
+   it just leaves the closing frame. A normal new user message keeps the old frame.
+3. **`normalizeJsonish` hardening** (`responder.ts`). The round-5 failure was a
+   stringified JSON object with one stray trailing `}`; `JSON.parse` threw and the raw
+   string hashed past the stored approval key. The parser now retries after trimming up
+   to three trailing `}` or `]` characters (plus whitespace). Only containers are
+   accepted, only trailing closers are trimmed, so genuinely non-JSON strings keep their
+   literal value and existing keys do not change.
+4. **Replay observability** (E8 from the report). Every cold replay logs one `[HITL]`
+   line through the engine's existing log seam: transcript chars before and after the
+   tail slice, messages fully evicted, whether the pending-approval nudge survived into
+   the rendered text, whether the resume frame fired, and the final turnText length.
+
+## Deferred to sessions
+
+These report items are deliberately not implemented, because session continuation
+replaces the mechanism they patch:
+
+- **Runner-side execution of approved calls.** Keep-alive slice 2 answers the parked
+  permission RPC directly, so the original byte-exact call runs without any replay.
+- **Name-level approval-key fallback matching.** Same: the parked RPC removes the
+  re-derivation step that makes keys miss.
+- **Session and keep-alive machinery.** That is the session work itself, planned
+  separately.
+- **The `get_revision` platform op.** A config read path is a build-kit concern, not a
+  replay stopgap; tracked in the build-kit backlog.
+- **Frontend changes.** The session-id fragilities in the report's Q3 belong to the
+  session project that will key state on the id.

--- a/docs/design/agent-workflows/projects/cold-replay-stopgaps/status.md
+++ b/docs/design/agent-workflows/projects/cold-replay-stopgaps/status.md
@@ -1,0 +1,43 @@
+# Status
+
+## Implemented (2026-07-07)
+
+All four changes from [plan.md](plan.md), in `services/runner`:
+
+- Per-result render cap (`TOOL_RESULT_RENDER_MAX_CHARS = 4000`) with an elision marker;
+  call args, user text, and assistant text stay uncapped
+  (`src/engines/sandbox_agent/transcript.ts`).
+- Default history window raised to 100,000 chars (`DEFAULT_HISTORY_MAX_CHARS`),
+  `AGENTA_AGENT_HISTORY_MAX_CHARS` still overrides it (`transcript.ts`).
+- Approval-resume closing frame: `isApprovalResume` detects a `lastPending` approved call
+  newer than the last user text and swaps the "The user now says" frame for an explicit
+  execute-the-approved-call instruction. On resume the full message list is replayed
+  (the stale command stays in history position; a trailing user turn carrying only the
+  approval envelope is no longer dropped from the replay) (`transcript.ts`).
+- `normalizeJsonish` tolerates up to three stray trailing `}`/`]` closers via
+  `parseJsonContainer` (`src/responder.ts`).
+- One `[HITL] cold replay:` log line per replay with before/after transcript length,
+  evicted message count, pending-nudge presence, resume-frame flag, and turnText length;
+  wired through the existing `log` seam in `run-plan.ts`.
+
+## Test coverage
+
+- `tests/unit/transcript.test.ts`: result cap with marker and omitted count, small
+  results uncapped, call args never capped, 30K transcript survives the 100K default,
+  tail-slice eviction counting via the log line, pending-nudge logging, resume frame on
+  an assistant-carried envelope, resume frame on a trailing user-carried envelope, normal
+  frame for a new user message with a pending approval, normal frame when the approved
+  call already executed.
+- `tests/unit/responder.test.ts`: trailing `}` (the round-5 shape), mixed trailing
+  closers with whitespace, trailing `]` on arrays, non-JSON strings with trailing braces
+  stay literals, stringified scalars stay literals, non-trailing junk is not repaired.
+- Full suite: 620 tests, 49 files, green. `pnpm run typecheck` green.
+
+## Follow-ups
+
+- The deferred list in [plan.md](plan.md) lands with the session work (keep-alive
+  slices, native `session/load`).
+- Report experiments E1-E4 remain manual; the E8 log line makes E1/E4 a grep on the dev
+  box instead of code changes.
+- The 4,000-char per-result cap and the 100,000-char window are constants picked for
+  headroom, not measured; tune if the dev-box logs show evictions in normal use.

--- a/services/runner/src/engines/sandbox_agent/run-plan.ts
+++ b/services/runner/src/engines/sandbox_agent/run-plan.ts
@@ -429,7 +429,7 @@ export function buildRunPlan(
       isPi,
       isDaytona,
       prompt,
-      turnText: buildTurnText(request),
+      turnText: buildTurnText(request, log),
       agentsMd: request.agentsMd?.trim() || undefined,
       secrets,
       legacyHarnessApiKeyVar,

--- a/services/runner/src/engines/sandbox_agent/transcript.ts
+++ b/services/runner/src/engines/sandbox_agent/transcript.ts
@@ -9,6 +9,18 @@ import { approvalDecisionOf } from "../../responder.ts";
 
 export type ApprovalRenderHint = "executed" | "lastPending" | "stalePending";
 
+/**
+ * Cap for ONE rendered tool RESULT body inside the replayed transcript. Without it a single
+ * large tool output (a discover_tools dump renders at 30-60 KB) fills the tail-sliced window
+ * and evicts the conversation's beginning, so the model loses the original goal (cold-replay
+ * failure report, turn 6d34b1ea). Tool CALL args are NEVER capped: the approval replay nudge
+ * tells the model to re-issue the call "with the same arguments", so args must stay complete.
+ */
+export const TOOL_RESULT_RENDER_MAX_CHARS = 4000;
+
+/** Default tail-slice window for the replayed transcript (env-overridable). */
+export const DEFAULT_HISTORY_MAX_CHARS = 100_000;
+
 /** Prior turns (everything before the latest user message) for trace + history. */
 export function priorMessages(request: AgentRunRequest): ChatMessage[] {
   const messages = request.messages ?? [];
@@ -112,6 +124,13 @@ function safeJson(value: unknown): string {
   }
 }
 
+/** Truncate a rendered tool RESULT body with an explicit elision marker. */
+function capToolResultBody(body: string): string {
+  if (body.length <= TOOL_RESULT_RENDER_MAX_CHARS) return body;
+  const omitted = body.length - TOOL_RESULT_RENDER_MAX_CHARS;
+  return `${body.slice(0, TOOL_RESULT_RENDER_MAX_CHARS)} [... ${omitted} chars omitted]`;
+}
+
 /**
  * Render one message for the replayed transcript, including resolved tool turns. Under
  * the cold model, ACP prompt content blocks cannot carry tool calls/results, so resolved
@@ -149,7 +168,7 @@ export function messageTranscript(
           parts.push(`[user DENIED ${toolName}; the call was not executed.]`);
         }
       } else {
-        const body = safeJson(block.output);
+        const body = capToolResultBody(safeJson(block.output));
         parts.push(
           `[${block.toolName ?? "tool"} ${block.isError ? "error" : "returned"}: ${body}]`,
         );
@@ -163,26 +182,93 @@ export function messageTranscript(
   return parts.filter(Boolean).join("\n");
 }
 
+const APPROVAL_RESUME_CLOSING =
+  "The user has responded to the pending approval above. " +
+  "If a call is marked APPROVED and not yet run, execute exactly that call now with the " +
+  "same arguments; do not restart the task. If it was DENIED, continue without it.";
+
+/**
+ * An approval resume carries no NEW user text: the newest meaningful content is the
+ * approval-decision envelope, and `resolvePromptText` falls back to a STALE earlier user
+ * message. Closing the frame with that stale command makes a fresh model restart the whole
+ * task instead of re-issuing the approved call (cold-replay failure report, turn 6d34b1ea).
+ * Detected conservatively: an unresolved approved call (`lastPending`) sits in a message
+ * AFTER the last user message that carries text.
+ */
+function isApprovalResume(
+  request: AgentRunRequest,
+  hints: Map<ContentBlock, ApprovalRenderHint>,
+): boolean {
+  const messages = request.messages ?? [];
+  let lastUserTextIndex = -1;
+  let lastPendingIndex = -1;
+  for (let i = 0; i < messages.length; i++) {
+    const message = messages[i];
+    if (message.role === "user" && messageText(message.content)) {
+      lastUserTextIndex = i;
+    }
+    const content = message.content;
+    if (!Array.isArray(content)) continue;
+    if (content.some((block) => hints.get(block) === "lastPending")) {
+      lastPendingIndex = i;
+    }
+  }
+  return lastPendingIndex >= 0 && lastPendingIndex > lastUserTextIndex;
+}
+
 /**
  * Text sent over ACP for this turn. Each invoke is a cold sandbox, so prior turns are
- * replayed as transcript context ahead of the latest user message.
+ * replayed as transcript context ahead of the latest user message. On an approval resume
+ * the closing frame instructs the model to execute the approved pending call instead of
+ * re-presenting the stale user command; the full history (stale command included, in its
+ * original position) is replayed as context.
  */
-export function buildTurnText(request: AgentRunRequest): string {
+export function buildTurnText(
+  request: AgentRunRequest,
+  log?: (msg: string) => void,
+): string {
   const latest = resolvePromptText(request);
-  const prior = priorMessages(request);
+  const messages = request.messages ?? [];
+  const resume = isApprovalResume(request, approvalRenderHints(messages));
+  // Normal turn: drop the prompt user message from the replay (it closes the frame).
+  // Approval resume: nothing is re-presented in the frame, so replay every message —
+  // including the stale command in place and an approval envelope on a trailing user turn.
+  const prior = resume ? messages : priorMessages(request);
   const hints = approvalRenderHints(prior);
   const history = prior
     .map((m) => ({ message: m, text: messageTranscript(m.content, hints) }))
     .filter((entry) => entry.text);
   if (history.length === 0) return latest;
 
-  const maxChars = Number(process.env.AGENTA_AGENT_HISTORY_MAX_CHARS ?? 24000);
-  let transcript = history
-    .map(({ message, text }) => `${message.role}: ${text}`)
-    .join("\n");
-  if (transcript.length > maxChars) transcript = transcript.slice(-maxChars);
-  return (
-    `Conversation so far:\n${transcript}\n\n` +
-    `Continue the conversation. The user now says:\n${latest}`
+  const maxChars = Number(
+    process.env.AGENTA_AGENT_HISTORY_MAX_CHARS ?? DEFAULT_HISTORY_MAX_CHARS,
   );
+  const lines = history.map(
+    ({ message, text }) => `${message.role}: ${text}`,
+  );
+  const full = lines.join("\n");
+  let transcript = full;
+  let evicted = 0;
+  if (full.length > maxChars) {
+    transcript = full.slice(-maxChars);
+    // Count messages the tail slice fully evicted (their rendered text ends before the cut).
+    const cut = full.length - maxChars;
+    let offset = 0;
+    for (const line of lines) {
+      if (offset + line.length <= cut) evicted++;
+      offset += line.length + 1; // +1 for the "\n" join separator
+    }
+  }
+
+  const closing = resume
+    ? APPROVAL_RESUME_CLOSING
+    : `Continue the conversation. The user now says:\n${latest}`;
+  const turnText = `Conversation so far:\n${transcript}\n\n${closing}`;
+  log?.(
+    `[HITL] cold replay: transcript ${full.length}->${transcript.length} chars, ` +
+      `evicted ${evicted}/${history.length} messages, ` +
+      `pendingNudge=${transcript.includes("has NOT run yet")}, ` +
+      `resumeFrame=${resume}, turnText ${turnText.length} chars`,
+  );
+  return turnText;
 }

--- a/services/runner/src/responder.ts
+++ b/services/runner/src/responder.ts
@@ -100,12 +100,9 @@ function canonicalJson(value: unknown): string {
  */
 function normalizeJsonish(value: unknown): unknown {
   if (typeof value === "string") {
-    try {
-      const parsed = JSON.parse(value) as unknown;
-      if (isJsonContainer(parsed)) return normalizeJsonish(parsed);
-    } catch {
-      // Not a JSON-encoded object/array; keep the string literal.
-    }
+    const parsed = parseJsonContainer(value);
+    if (parsed !== undefined) return normalizeJsonish(parsed);
+    // Not a JSON-encoded object/array; keep the string literal.
     return value;
   }
   if (Array.isArray(value)) return value.map(normalizeJsonish);
@@ -124,6 +121,35 @@ function isJsonContainer(
   value: unknown,
 ): value is unknown[] | Record<string, unknown> {
   return Array.isArray(value) || isPlainObject(value);
+}
+
+/** How many stray trailing `}`/`]` characters `parseJsonContainer` tolerates. */
+const MAX_TRAILING_CLOSERS_TRIMMED = 3;
+
+/**
+ * Parse a string to a JSON object/array, tolerating a small trailing-closer imbalance.
+ * Models copying object args out of the flattened replay transcript sometimes add a stray
+ * trailing `}` or `]` (cold-replay failure report, turn 6d34b1ea round 5); a strict parse
+ * throws and the raw string hashes past the stored approval key. Only trailing whitespace
+ * and closers are trimmed, so a string that is genuinely not JSON still returns undefined
+ * and keeps its literal value.
+ */
+function parseJsonContainer(
+  value: string,
+): unknown[] | Record<string, unknown> | undefined {
+  let candidate = value;
+  for (let trimmed = 0; trimmed <= MAX_TRAILING_CLOSERS_TRIMMED; trimmed++) {
+    try {
+      const parsed = JSON.parse(candidate) as unknown;
+      return isJsonContainer(parsed) ? parsed : undefined;
+    } catch {
+      candidate = candidate.trimEnd();
+      const last = candidate[candidate.length - 1];
+      if (last !== "}" && last !== "]") return undefined;
+      candidate = candidate.slice(0, -1);
+    }
+  }
+  return undefined;
 }
 
 function isPlainObject(value: unknown): value is Record<string, unknown> {

--- a/services/runner/tests/unit/responder.test.ts
+++ b/services/runner/tests/unit/responder.test.ts
@@ -146,6 +146,56 @@ describe("approvedCallKey", () => {
     );
   });
 
+  it("tolerates stray trailing closers on stringified JSON args", () => {
+    const toolName = "mcp__agenta-tools__commit_revision";
+    const workflowRevision = { delta: { a: 1 } };
+    const objectKey = approvedCallKey(toolName, {
+      workflow_revision: workflowRevision,
+    });
+
+    // The turn-6d34b1ea round-5 shape: a JSON string with ONE stray trailing `}`.
+    assert.equal(
+      approvedCallKey(toolName, {
+        workflow_revision: `${JSON.stringify(workflowRevision)}}`,
+      }),
+      objectKey,
+    );
+    assert.equal(
+      approvedCallKey(toolName, {
+        workflow_revision: `${JSON.stringify(workflowRevision)} }]`,
+      }),
+      objectKey,
+    );
+    assert.equal(
+      approvedCallKey(toolName, {
+        workflow_revision: `${JSON.stringify([1, 2])}]`,
+      }),
+      approvedCallKey(toolName, { workflow_revision: [1, 2] }),
+    );
+  });
+
+  it("keeps genuinely non-JSON strings as literals, trailing brace or not", () => {
+    // A stray closer on a non-JSON string never turns into an object key.
+    assert.equal(
+      approvedCallKey("echo", { message: "oops}" }),
+      approvedCallKey("echo", { message: "oops}" }),
+    );
+    assert.notEqual(
+      approvedCallKey("echo", { message: "oops}" }),
+      approvedCallKey("echo", { message: "oops" }),
+    );
+    // A stringified scalar stays a string literal (containers only), as before.
+    assert.notEqual(
+      approvedCallKey("echo", { message: "5}" }),
+      approvedCallKey("echo", { message: 5 }),
+    );
+    // Non-trailing junk after the JSON value is not repaired.
+    assert.notEqual(
+      approvedCallKey("echo", { message: '{"a":1} trailing text' }),
+      approvedCallKey("echo", { message: { a: 1 } }),
+    );
+  });
+
   it("keeps plain non-JSON strings canonicalizable", () => {
     assert.equal(
       approvedCallKey("echo", { message: "hello world" }),

--- a/services/runner/tests/unit/transcript.test.ts
+++ b/services/runner/tests/unit/transcript.test.ts
@@ -4,6 +4,7 @@ import assert from "node:assert/strict";
 import {
   buildTurnText,
   messageTranscript,
+  TOOL_RESULT_RENDER_MAX_CHARS,
 } from "../../src/engines/sandbox_agent/transcript.ts";
 import type { AgentRunRequest, ContentBlock } from "../../src/protocol.ts";
 
@@ -101,6 +102,173 @@ describe("messageTranscript", () => {
 
     assert.match(transcript, /APPROVED approval_status/);
     assert.match(transcript, /NOT run yet/);
+  });
+});
+
+describe("tool result render cap", () => {
+  it("caps a huge tool RESULT body with an explicit elision marker", () => {
+    const big = "x".repeat(TOOL_RESULT_RENDER_MAX_CHARS + 500);
+    const transcript = messageTranscript([
+      { type: "tool_result", toolName: OTHER_TOOL, output: big },
+    ]);
+
+    assert.ok(transcript.length < big.length, "result body is truncated");
+    assert.match(transcript, /\[\.\.\. 500 chars omitted\]/);
+  });
+
+  it("keeps a small tool RESULT body whole, no marker", () => {
+    const transcript = messageTranscript([
+      { type: "tool_result", toolName: OTHER_TOOL, output: { ok: true } },
+    ]);
+
+    assert.match(transcript, /returned: \{"ok":true\}/);
+    assert.doesNotMatch(transcript, /chars omitted/);
+  });
+
+  it("never caps tool CALL args (approval replay needs the exact arguments)", () => {
+    const bigArg = "y".repeat(TOOL_RESULT_RENDER_MAX_CHARS + 1000);
+    const transcript = messageTranscript([
+      { type: "tool_call", toolName: COMMIT_TOOL, input: { blob: bigArg } },
+    ]);
+
+    assert.ok(transcript.includes(bigArg), "full call args survive the replay");
+    assert.doesNotMatch(transcript, /chars omitted/);
+  });
+});
+
+describe("buildTurnText history window", () => {
+  const saved = process.env.AGENTA_AGENT_HISTORY_MAX_CHARS;
+  function restoreEnv() {
+    if (saved === undefined) delete process.env.AGENTA_AGENT_HISTORY_MAX_CHARS;
+    else process.env.AGENTA_AGENT_HISTORY_MAX_CHARS = saved;
+  }
+
+  it("keeps a 30k transcript whole under the 100k default window", () => {
+    delete process.env.AGENTA_AGENT_HISTORY_MAX_CHARS;
+    try {
+      const goal = "goal: send one slack message";
+      const text = turnTextFor([
+        { role: "user", content: goal },
+        { role: "assistant", content: "z".repeat(30_000) },
+      ]);
+      assert.ok(text.includes(goal), "the original goal survives the window");
+    } finally {
+      restoreEnv();
+    }
+  });
+
+  it("tail-slices over the window and logs eviction counts", () => {
+    process.env.AGENTA_AGENT_HISTORY_MAX_CHARS = "1000";
+    try {
+      const logs: string[] = [];
+      const request: AgentRunRequest = {
+        messages: [
+          { role: "user", content: "old goal" },
+          { role: "assistant", content: "a".repeat(2000) },
+          { role: "user", content: "continue" },
+        ],
+      };
+      const text = buildTurnText(request, (msg) => logs.push(msg));
+
+      assert.ok(!text.includes("old goal"), "the oldest message is evicted");
+      assert.equal(logs.length, 1);
+      assert.match(logs[0], /^\[HITL\] cold replay: /);
+      assert.match(logs[0], /evicted 1\/2 messages/);
+      assert.match(logs[0], /pendingNudge=false/);
+      assert.match(logs[0], /resumeFrame=false/);
+      assert.match(logs[0], /turnText \d+ chars/);
+    } finally {
+      restoreEnv();
+    }
+  });
+
+  it("logs the pending-approval nudge presence", () => {
+    const logs: string[] = [];
+    buildTurnText(
+      {
+        messages: [
+          { role: "user", content: "do the thing" },
+          { role: "assistant", content: toolApprovalContent(true) },
+          { role: "user", content: "continue" },
+        ],
+      },
+      (msg) => logs.push(msg),
+    );
+
+    assert.equal(logs.length, 1);
+    assert.match(logs[0], /pendingNudge=true/);
+  });
+});
+
+describe("buildTurnText approval-resume closing frame", () => {
+  it("closes with the resume instruction when the newest content is an approved pending call", () => {
+    const staleCommand = "search for tools and add them if needed use the skill";
+    const request: AgentRunRequest = {
+      messages: [
+        { role: "user", content: staleCommand },
+        { role: "assistant", content: toolApprovalContent(true) },
+      ],
+    };
+    const text = buildTurnText(request);
+
+    assert.match(text, /responded to the pending approval above/);
+    assert.match(text, /execute exactly that call now/);
+    assert.match(text, /do not restart the task/);
+    assert.doesNotMatch(text, /The user now says/);
+    // The stale command stays in the replayed history, not in the closing frame.
+    const closing = text.slice(text.lastIndexOf("\n\n"));
+    assert.ok(!closing.includes(staleCommand), "stale command is out of the frame");
+    assert.ok(text.includes(`user: ${staleCommand}`), "stale command stays in history");
+  });
+
+  it("keeps the resume frame when the approval envelope rides a trailing user turn", () => {
+    const request: AgentRunRequest = {
+      messages: [
+        { role: "user", content: "do the thing" },
+        {
+          role: "assistant",
+          content: [
+            {
+              type: "tool_call",
+              toolCallId: "call-1",
+              toolName: COMMIT_TOOL,
+              input: { name: "draft" },
+            } as ContentBlock,
+          ],
+        },
+        { role: "user", content: [approvalResult("call-1", true)] },
+      ],
+    };
+    const text = buildTurnText(request);
+
+    assert.match(text, /responded to the pending approval above/);
+    assert.match(text, /NOT run yet/);
+    assert.doesNotMatch(text, /The user now says/);
+  });
+
+  it("keeps the normal closing frame for a new user message, even with a pending approval", () => {
+    const text = turnTextFor([
+      { role: "user", content: "do the thing" },
+      { role: "assistant", content: toolApprovalContent(true) },
+    ]);
+
+    assert.match(text, /Continue the conversation\. The user now says:\ncontinue/);
+    assert.doesNotMatch(text, /responded to the pending approval above/);
+  });
+
+  it("keeps the normal closing frame when the approved call already executed", () => {
+    const staleCommand = "do the thing";
+    const request: AgentRunRequest = {
+      messages: [
+        { role: "user", content: staleCommand },
+        { role: "assistant", content: toolApprovalContent(true) },
+        { role: "tool", content: [realResult(COMMIT_TOOL)] },
+      ],
+    };
+    const text = buildTurnText(request);
+
+    assert.doesNotMatch(text, /responded to the pending approval above/);
+    assert.match(text, /The user now says:\ndo the thing/);
   });
 });
 


### PR DESCRIPTION
Two production turns failed on 2026-07-07 because the runner cold-replays the conversation as flattened text every turn. Turn c6de1865 needed three approval rounds for one curl: each fresh model rebuilt the arguments from the text replay and drifted the approval key. Turn 6d34b1ea ran five rounds and executed zero commits: the resume prompt re-presented the stale user command as if just spoken, so each fresh model restarted the whole task, and one 30-60 KB tool dump filled the 24K window and evicted the original goal.

Full analysis: `docs/design/agent-workflows/projects/approval-boundary/cold-replay-failure-report.md`. Session-based continuation is the real fix and lands next; these are the cheap repairs to the text-replay path, which stays as the fallback after sessions.

### Replay framing, before/after

Before (approval resume, no new user text):

```
Conversation so far:
...
[user APPROVED commit_revision; the call has NOT run yet. ...]

Continue the conversation. The user now says:
search for tools and add them if needed use the skill   <- stale, restarts the task
```

After:

```
Conversation so far:
user: search for tools and add them if needed use the skill   <- stays in history position
...
[user APPROVED commit_revision; the call has NOT run yet. ...]

The user has responded to the pending approval above. If a call is marked APPROVED and not yet run, execute exactly that call now with the same arguments; do not restart the task. If it was DENIED, continue without it.
```

### The four changes (all `services/runner`)

1. **Per-result cap + bigger window** (`transcript.ts`): each rendered tool RESULT body caps at 4,000 chars with an explicit `[... N chars omitted]` marker. Tool CALL args are never capped (the resume nudge says "with the same arguments"). Default `AGENTA_AGENT_HISTORY_MAX_CHARS` raised 24,000 -> 100,000, still env-overridable.
2. **Resume closing frame** (`transcript.ts`): when an unresolved approved call is newer than the last user text, the closing frame becomes the execute-the-approved-call instruction above instead of the stale command. Normal new-user-message turns are unchanged.
3. **`normalizeJsonish` hardening** (`responder.ts`): tolerates up to three stray trailing `}`/`]` on stringified JSON args (the round-5 shape), so the honest re-issue matches the stored approval key. Non-JSON strings keep their literal value.
4. **Replay observability** (`transcript.ts` + `run-plan.ts`): one `[HITL] cold replay:` log line per replay with transcript length before/after the tail slice, fully evicted message count, pending-nudge presence, resume-frame flag, and turnText length.

### Deferred to the session work

- Runner-side execution of approved calls (keep-alive slice 2 answers the parked permission RPC directly).
- Name-level approval-key fallback matching (same).
- Session/keep-alive machinery (its own project).
- `get_revision` platform op (build-kit backlog).
- Frontend changes.

Tests: `pnpm test` 620/620 green, `pnpm run typecheck` green. Design doc: `docs/design/agent-workflows/projects/cold-replay-stopgaps/`.

https://claude.ai/code/session_01AumZJ9xRd4XYNHThqy4rTv
