### PR TITLE
feat(runner): session keep-alive across turn boundaries (flag off by default)

### DIFF
--- a/services/runner/src/engines/sandbox_agent.ts
+++ b/services/runner/src/engines/sandbox_agent.ts
@@ -19,6 +19,13 @@
  * harness (which engine). The ACP boundary is daemon-to-harness; the service-to-sandbox-agent
  * hop stays harness-agnostic behind the Harness port.
  *
+ * Session keep-alive (flag-gated, off by default) splits the per-invoke work into
+ * `acquireEnvironment` (session-scoped: sandbox, mount, session, MCP wiring) and `runTurn`
+ * (per-turn: otel run, prompt, usage, trace). `runSandboxAgent` composes them exactly as
+ * before (acquire -> runTurn -> destroy), so with the flag off behavior is byte-identical.
+ * The dispatch in `server.ts` reuses the two halves to continue a live session across a turn
+ * boundary. See docs/design/agent-workflows/projects/session-keepalive/plan.md.
+ *
  * Tracing is built here from the ACP event stream (see tracing/otel.ts createSandboxAgentOtel),
  * so it is uniform across every harness and always nests under the caller's /invoke
  * span. stdout is reserved for the JSON result (see cli.ts); logs go to stderr.
@@ -56,8 +63,10 @@ import {
   type AgentRunRequest,
   type AgentRunResult,
   type EmitEvent,
+  type HarnessCapabilities,
   type ToolCallbackContext,
   type ToolPermission,
+  resolvePromptText,
   resolveRunSessionId,
 } from "../protocol.ts";
 import {
@@ -103,6 +112,7 @@ import { buildSandboxProvider } from "./sandbox_agent/provider.ts";
 import {
   buildRunPlan,
   type BuildRunPlanDeps,
+  type RunPlan,
 } from "./sandbox_agent/run-plan.ts";
 import { priorMessages } from "./sandbox_agent/transcript.ts";
 import { resolveRunUsage } from "./sandbox_agent/usage.ts";
@@ -324,12 +334,123 @@ function containsTransportEndpointDisconnected(value: unknown): boolean {
   return visit(value);
 }
 
-export async function runSandboxAgent(
+/**
+ * Race sentinel: a run-limits deadline (total/idle/TTFB/per-tool-call) tripped mid-turn. Distinct
+ * from `PAUSED` so the prompt race can tell a human pause (keep the session) from a wedge deadline
+ * (end the turn as an error, letting the caller's teardown reclaim the sandbox).
+ */
+const RUN_LIMIT_TRIPPED = Symbol("run-limit-tripped");
+
+/**
+ * The per-turn sink the session-lifetime listeners demux into. `runTurn` swaps a fresh one in
+ * at turn start (`env.currentTurn`) and the dispatch clears it at turn end. The `sandbox-agent`
+ * listener registries are plain Sets — an event with no listener is dropped and a permission
+ * request with no listener is CANCELLED — so the listeners stay attached for the session's whole
+ * life and route into whichever turn is active, with no detach/attach window between turns.
+ */
+interface CurrentTurn {
+  run: ReturnType<typeof createSandboxAgentOtel>;
+  pause: PendingApprovalPauseController;
+  toolRelay?: { stop: () => Promise<void> };
+  /** Route a session/update for the active turn (suppress + handleUpdate + pause re-sweep). */
+  handleUpdate: (update: unknown) => void;
+  /** Route a permission reverse-RPC for the active turn (built by attachPermissionResponder). */
+  onPermissionRequest?: (req: unknown) => void;
+}
+
+/**
+ * A session-scoped environment that can serve many turns. Everything expensive to build lives
+ * here (sandbox, session, internal tool-MCP server, mounted cwd, relay/temp dirs); `destroy()`
+ * is the one complete idempotent teardown the pool, the shutdown handler, and the cold path all
+ * call. Per-turn state rides `currentTurn`, swapped in by `runTurn`.
+ */
+export interface SessionEnvironment {
+  plan: RunPlan;
+  logger: Log;
+  deps: SandboxAgentDeps;
+  sandbox: any;
+  session: any;
+  sessionId: string;
+  model: string | undefined;
+  capabilities: HarnessCapabilities;
+  strictModel: boolean;
+  toolCallIndex: ReturnType<typeof createToolCallCorrelationIndex>;
+  /** The current turn's client-tool relay, read by the deferred ref baked into the MCP server. */
+  clientToolRelayRef: { current?: ClientToolRelay };
+  mcpAbort: AbortController;
+  runAgentDir: string | undefined;
+  otlpAuthFilePath: string | undefined;
+  mountCreds: MountCredentials | null;
+  /** The mount's owning project id (keep-alive pool key scope); undefined when there is no mount. */
+  mountProjectId?: string;
+  // Mutable teardown/turn state shared across acquire, runTurn, and destroy.
+  sessionDestroyRequested: boolean;
+  mountedCwd: string | undefined;
+  durableCwdSafeToDelete: boolean;
+  workspace: { cleanup: () => Promise<void> } | undefined;
+  runtimeRemount: Promise<boolean> | undefined;
+  closeToolMcp: (() => Promise<void>) | undefined;
+  currentTurn?: CurrentTurn;
+  /**
+   * The unique ACP tool-call ids the LAST completed turn emitted (reset at each turn start).
+   * The keep-alive dispatch folds them into the expected next-history fingerprint at park time,
+   * so a tool-using turn still matches its own continuation (the FE keeps assistant tool parts).
+   */
+  lastTurnToolCallIds: string[];
+  destroyed: boolean;
+  /** Complete, idempotent teardown (all the finalizers the old per-run `finally` ran). */
+  destroy: () => Promise<void>;
+  /** End the active turn: clear the current-turn sink (called before a park). */
+  clearTurn: () => void;
+}
+
+export type AcquireEnvironmentResult =
+  { ok: true; env: SessionEnvironment } | { ok: false; error: string };
+
+/**
+ * Sign the session's durable mount up front so keep-alive can build a pool key (the mount's
+ * owning `projectId`) and credential epoch without acquiring the whole environment. Returns
+ * exactly what the sign yielded: `null` when there is no session/credential to sign with, or
+ * the sign returned no usable mount (store unconfigured, 503, ephemeral fallback). The caller
+ * threads the result — null included — into `acquireEnvironment` as `presignedMount`, so the
+ * mount is signed exactly once per run on every path; a null result additionally means there is
+ * NO safe project key and the request must never park.
+ */
+export async function resolveKeepaliveMount(
   request: AgentRunRequest,
-  emit?: EmitEvent,
-  signal?: AbortSignal,
   deps: SandboxAgentDeps = {},
-): Promise<AgentRunResult> {
+): Promise<MountCredentials | null> {
+  const logger = deps.log ?? log;
+  const sessionForMount = request.sessionId?.trim();
+  const runCred = runCredential(request);
+  if (!sessionForMount || !runCred) return null;
+  const signMount =
+    deps.signSessionMountCredentials ?? signSessionMountCredentials;
+  return signMount(sessionForMount, {
+    apiBase: apiBase(),
+    authorization: runCred,
+    log: logger,
+  });
+}
+
+/**
+ * Build the session-scoped environment: sign the mount, build the run plan, start the sandbox,
+ * mount the durable cwd, prepare the workspace, probe capabilities, wire the internal tool-MCP
+ * server, and open the ACP session. Session-lifetime `onEvent`/`onPermissionRequest` listeners
+ * are attached once here and demux into `env.currentTurn`.
+ *
+ * Finalizers register incrementally on `env` as each resource is acquired; a mid-acquire failure
+ * runs `env.destroy()` (which null-checks every resource, so a half-built environment cannot
+ * leak) and returns `{ ok: false }`, mirroring today's shared teardown. When `presignedMount` is
+ * supplied (the keep-alive cold path already signed to build the pool key) the initial sign is
+ * skipped so the mount is signed once per run.
+ */
+export async function acquireEnvironment(
+  request: AgentRunRequest,
+  deps: SandboxAgentDeps = {},
+  signal?: AbortSignal,
+  presignedMount?: MountCredentials | null,
+): Promise<AcquireEnvironmentResult> {
   const logger = deps.log ?? log;
 
   // Sign BEFORE buildRunPlan so the prefix is available for the durable cwd derivation.
@@ -340,13 +461,15 @@ export async function runSandboxAgent(
   const signMount =
     deps.signSessionMountCredentials ?? signSessionMountCredentials;
   let mountCreds: MountCredentials | null =
-    sessionForMount && runCred
-      ? await signMount(sessionForMount, {
-          apiBase: apiBase(),
-          authorization: runCred,
-          log: logger,
-        })
-      : null;
+    presignedMount !== undefined
+      ? presignedMount
+      : sessionForMount && runCred
+        ? await signMount(sessionForMount, {
+            apiBase: apiBase(),
+            authorization: runCred,
+            log: logger,
+          })
+        : null;
 
   // Derive the durable cwd from the sign prefix (one source of truth, both providers).
   // local: /tmp/agenta/<prefix>  —  daytona: /home/sandbox/agenta/<prefix>
@@ -393,10 +516,9 @@ export async function runSandboxAgent(
   // local Pi's OTLP bearer rides a runner-written 0600 file, never a plain env var —
   // Daytona never receives telemetry env here at all (`!plan.isDaytona` gates it off above).
   const otlpAuthFilePath =
-    plan.isPi && !plan.isDaytona
-      ? `${plan.relayDir}.otlp-auth`
-      : undefined;
-  const otlpAuthorization = request.telemetry?.exporters?.otlp?.headers?.authorization;
+    plan.isPi && !plan.isDaytona ? `${plan.relayDir}.otlp-auth` : undefined;
+  const otlpAuthorization =
+    request.telemetry?.exporters?.otlp?.headers?.authorization;
   if (otlpAuthFilePath && otlpAuthorization) {
     writeOtlpAuthFile(otlpAuthFilePath, otlpAuthorization, logger);
   }
@@ -433,61 +555,120 @@ export async function runSandboxAgent(
       `secretKeys=[${Object.keys(request.secrets ?? {}).join(",")}]`,
   );
 
-  // Pi traces itself via the extension under the propagated traceparent; for other
-  // harnesses we build the span tree here from the ACP event stream. Created below, once
-  // the model is resolved, so the chat span carries the harness's actual model rather
-  // than the requested one. Declared here so the catch can flush a partial trace.
-  let sandbox: any | undefined;
-  let otel: ReturnType<typeof createSandboxAgentOtel> | undefined;
-  // The live ACP session handle, set once `createSession` resolves. Declared here (not
-  // `const` inside the try) so the `finally` can always send a graceful `session/cancel`
-  // before tearing down the daemon (see the `finally` block below for why this matters).
-  // Typed `any` to match `sandbox` above: the real type comes from the `sandbox-agent`
-  // package's `createSession` return, which the rest of this function already treats loosely.
-  let session: any;
-  // Set true once the HITL pause controller has already sent `session/cancel` (below), so the
-  // `finally` block's own graceful-cancel step (added for the ACP child process leak) does not
-  // redundantly re-cancel an already-destroyed session.
-  let sessionDestroyRequested = false;
-  // Daytona tool relay loop (started once the session exists, stopped after the prompt).
-  let toolRelay: { stop: () => Promise<void> } | undefined;
-  // Internal gateway-tool MCP server closer (set when an internal channel is built for a non-Pi
-  // harness with executable tools; a no-op otherwise). Released in the `finally`.
-  let closeToolMcp: (() => Promise<void>) | undefined;
+  // The shared client-tool relay reference (the deferred ref baked into the MCP server reads it;
+  // each turn's `runTurn` sets `.current`). A `tools/call` can only arrive during a prompt —
+  // long after the relay is wired — so the server captures this reference and it resolves to the
+  // real relay before any call lands.
+  const clientToolRelayRef: { current?: ClientToolRelay } = {};
+  const deferredClientToolRelay: ClientToolRelay = {
+    onClientTool: (req) =>
+      clientToolRelayRef.current
+        ? clientToolRelayRef.current.onClientTool(req)
+        : Promise.resolve("deny" as ClientToolOutcome),
+    onPause: (req) => clientToolRelayRef.current?.onPause?.(req),
+  };
+
   // Aborts any in-flight loopback `tools/call` (a paused Claude client tool) on pause/teardown,
   // so its handler is torn down deterministically and cannot write a result after the turn ends.
-  // Fired by the pause controller's destroy path and, as a backstop, by the `finally`.
   const mcpAbort = new AbortController();
-  // Time-based run deadlines (total/idle/TTFB/per-tool-call): tripping one aborts the run the
-  // SAME way a client disconnect does, so this existing `finally` reclaims the sandbox — no new
-  // teardown. Merged with the caller's own signal (a client disconnect on a non-session run)
-  // so either source can end the run; whichever fires first wins.
-  const deadlineAbort = new AbortController();
-  const runLimits = (deps.createRunLimits ?? createRunLimits)(
-    (deps.resolveRunLimits ?? resolveRunLimits)(logger),
-    { log: logger },
-  );
-  runLimits.onTrip((reason) => {
-    logger(`run limit tripped: ${reason}`);
-    deadlineAbort.abort(new Error(reason));
-  });
-  const runSignal = signal
-    ? AbortSignal.any([signal, deadlineAbort.signal])
-    : deadlineAbort.signal;
-  // Durable cwd: set to the host mountpoint once a session-owned local run geesefs-mounts its
-  // store prefix, so the `finally` can unmount it. Undefined for non-session/remote/unmounted runs.
-  let mountedCwd: string | undefined;
+
+  const env2: SessionEnvironment = {
+    plan,
+    logger,
+    deps,
+    sandbox: undefined,
+    session: undefined,
+    sessionId: resolveRunSessionId(request, ""),
+    model: undefined,
+    capabilities: {},
+    strictModel,
+    toolCallIndex: createToolCallCorrelationIndex(),
+    clientToolRelayRef,
+    mcpAbort,
+    runAgentDir,
+    otlpAuthFilePath,
+    mountCreds,
+    mountProjectId: mountCreds?.projectId,
+    sessionDestroyRequested: false,
+    mountedCwd: undefined,
+    durableCwdSafeToDelete: true,
+    // Local runs get a plain rmSync cleanup for the throwaway cwd; Daytona has none on this host.
+    workspace: plan.isDaytona
+      ? undefined
+      : {
+          cleanup: async () =>
+            rmSync(plan.cwd, { recursive: true, force: true }),
+        },
+    runtimeRemount: undefined,
+    closeToolMcp: undefined,
+    currentTurn: undefined,
+    lastTurnToolCallIds: [],
+    destroyed: false,
+    destroy: async () => {},
+    clearTurn: () => {},
+  };
+
+  env2.clearTurn = () => {
+    env2.currentTurn = undefined;
+  };
+
+  // The one complete, idempotent teardown — the same steps the old per-run `finally` ran, in the
+  // same order. Every resource is null-checked, so it is safe after a partial acquire and safe to
+  // call twice (the guard returns on a second call). It must never throw.
+  env2.destroy = async () => {
+    if (env2.destroyed) return;
+    env2.destroyed = true;
+    await env2.runtimeRemount?.catch(() => {});
+    if (env2.sandbox) inFlightSandboxes.delete(env2.sandbox);
+    await env2.currentTurn?.toolRelay?.stop().catch(() => {});
+    // Teardown backstop: destroy any in-flight loopback `tools/call` before closing the server.
+    env2.mcpAbort.abort();
+    await env2.closeToolMcp?.().catch(() => {});
+    // Send a graceful `session/cancel` BEFORE tearing down the daemon (the ACP child process
+    // leak, dev-box incident 2026-07-06): destroySandbox hard-kills the sandbox-agent server but
+    // does not cascade to the ACP adapter subprocess it spawned, which then reparents to PID 1
+    // and never exits. Skip if the pause path already sent it (`sessionDestroyRequested`).
+    if (env2.session && !env2.sessionDestroyRequested)
+      await env2.sandbox?.destroySession?.(env2.session.id).catch(() => {});
+    await env2.sandbox?.destroySandbox().catch(() => {});
+    await env2.sandbox?.dispose().catch(() => {});
+    // Unmount the durable cwd BEFORE removing the dir: data lives in the store, only the host
+    // mountpoint is torn down. If unmount is not CONFIRMED gone, skip the delete: rmSync must
+    // never run against a possibly-live FUSE mount into the durable store.
+    if (env2.mountedCwd) {
+      env2.durableCwdSafeToDelete = await (
+        env2.deps.unmountStorage ?? unmountStorage
+      )(env2.mountedCwd, { log }).catch(() => false);
+    }
+    if (!env2.durableCwdSafeToDelete) {
+      logger(
+        `durable cwd unmount not confirmed, skipping workspace cleanup cwd=${plan.cwd}`,
+      );
+    } else {
+      await env2.workspace?.cleanup().catch(() => {});
+    }
+    // The per-run Agenta agent dir (skills isolation) is throwaway; remove it too.
+    if (env2.runAgentDir)
+      rmSync(env2.runAgentDir, { recursive: true, force: true });
+    // Backstop: the extension deletes this on read; remove it here too in case the harness never
+    // started (or crashed before reading it), so the bearer never lingers.
+    if (env2.otlpAuthFilePath) rmSync(env2.otlpAuthFilePath, { force: true });
+    // Remove the per-run skills temp root the materializer created (success or error).
+    plan.skillsCleanup();
+  };
+
+  // --- local durable cwd mount helpers (session-scoped, close over env2) ------ //
   const mountLocalDurableCwd = async (reason: string): Promise<boolean> => {
-    if (!mountCreds || plan.isDaytona) return false;
+    if (!env2.mountCreds || plan.isDaytona) return false;
     logger(
       `local durable cwd mount (${reason}) session=${sessionForMount} cwd=${plan.cwd}`,
     );
     if (
-      await (deps.mountStorage ?? mountStorage)(plan.cwd, mountCreds, {
+      await (deps.mountStorage ?? mountStorage)(plan.cwd, env2.mountCreds, {
         log: logger,
       })
     ) {
-      mountedCwd = plan.cwd;
+      env2.mountedCwd = plan.cwd;
       return true;
     }
     return false;
@@ -519,33 +700,23 @@ export async function runSandboxAgent(
       );
       return false;
     }
-    mountCreds = fresh;
+    env2.mountCreds = fresh;
     return mountLocalDurableCwd("enotconn-retry");
   };
-  let runtimeRemount: Promise<boolean> | undefined;
   const remountLocalCwdAfterRuntimeEnotconn = (event: unknown): void => {
-    if (plan.isDaytona || !mountCreds || !mountedCwd) return;
-    if (runtimeRemount || !containsTransportEndpointDisconnected(event)) return;
+    if (plan.isDaytona || !env2.mountCreds || !env2.mountedCwd) return;
+    if (env2.runtimeRemount || !containsTransportEndpointDisconnected(event))
+      return;
     logger(
       `local durable cwd ENOTCONN observed in ACP event session=${sessionForMount} cwd=${plan.cwd}; re-signing and remounting`,
     );
-    runtimeRemount = reSignAndRemountLocalCwd().catch((err) => {
+    env2.runtimeRemount = reSignAndRemountLocalCwd().catch((err) => {
       logger(
         `local durable cwd runtime remount failed session=${sessionForMount}: ${conciseError(err, plan.harness)}`,
       );
       return false;
     });
   };
-  // Gates the cwd rmSync in the `finally` below: never delete through a mount we can't prove
-  // is gone. Checked at the call site, not here, since this placeholder can be replaced
-  // by prepareWorkspace's own cleanup before the gate is evaluated.
-  let durableCwdSafeToDelete = true;
-  let workspace: { cleanup: () => Promise<void> } | undefined = plan.isDaytona
-    ? undefined
-    : {
-        cleanup: async () =>
-          rmSync(plan.cwd, { recursive: true, force: true }),
-      };
 
   try {
     // Persist events in-process so a follow-up turn can resume by session id.
@@ -555,7 +726,7 @@ export async function runSandboxAgent(
       deps.startSandboxAgent ??
       ((options: Parameters<typeof SandboxAgent.start>[0]) =>
         SandboxAgent.start(options));
-    sandbox = await startSandboxAgent({
+    env2.sandbox = await startSandboxAgent({
       sandbox: (deps.buildSandboxProvider ?? buildSandboxProvider)(
         plan.sandboxId,
         env,
@@ -565,42 +736,35 @@ export async function runSandboxAgent(
         plan.sandboxPermission,
       ),
       persist,
-      // Propagate caller cancellation (a client disconnect on the streaming HTTP edge) merged
-      // with the run-limits deadline signal, so either one aborts an in-flight run instead of
-      // it finishing unobserved. The `finally` still disposes. Always defined (unlike the raw
-      // `signal` param) because the deadline signal exists even with no caller signal.
-      signal: runSignal,
-      // Drive the ACP HTTP client through a long-timeout undici dispatcher so a paused HITL
-      // turn (the connection held open while a human approves a tool) is NOT reaped by
-      // undici's default `headersTimeout` (which would kill it with UND_ERR_HEADERS_TIMEOUT).
-      // Daytona additionally needs the per-sandbox auth cookie carried across requests, so it
-      // uses the cookie fetch — which itself layers on the same long-timeout ACP dispatcher.
+      // Propagate caller cancellation (a client disconnect on the streaming HTTP edge) so an
+      // in-flight run aborts instead of finishing unobserved. `destroy` still disposes.
+      ...(signal ? { signal } : {}),
+      // Long-timeout undici dispatcher so a paused HITL turn is not reaped by undici's default
+      // headersTimeout; Daytona additionally carries the per-sandbox auth cookie.
       fetch: plan.isDaytona
         ? (deps.createCookieFetch ?? createCookieFetch)()
         : (deps.createAcpFetch ?? createAcpFetch)(),
     });
-    // Track the live handle so a shutdown signal handler can delete it if the `finally` below is
-    // skipped by a process KILL (docker stop / SIGTERM / OOM); removed in the `finally` on every
-    // normal exit so it is never double-deleted.
-    if (sandbox) inFlightSandboxes.add(sandbox);
+    // Track the live handle so a shutdown signal handler can delete it if `destroy` is skipped by
+    // a process KILL; removed in `destroy` on every normal exit so it is never double-deleted.
+    if (env2.sandbox) inFlightSandboxes.add(env2.sandbox);
 
-    // On Daytona, push the harness login, the extension, and AGENTS.md into the remote
-    // sandbox via the filesystem API (nothing secret is baked into the image). Locally
-    // these use the host filesystem and the harness's own login (PI_CODING_AGENT_DIR).
+    // On Daytona, push the harness login, the extension, and AGENTS.md into the remote sandbox.
     if (plan.isDaytona) {
-      await prepareDaytonaPiAssets({ sandbox, plan, log: logger });
+      await prepareDaytonaPiAssets({
+        sandbox: env2.sandbox,
+        plan,
+        log: logger,
+      });
     }
 
-    // Durable cwd: reuse the pre-signed creds (signed before buildRunPlan so the prefix drove the
-    // cwd derivation). The mount lands BEFORE createSession so the session opens inside it, and
-    // BEFORE workspace materialization on both providers so AGENTS.md, harness files, and skills
-    // land in the durable prefix instead of being hidden under the later FUSE mount.
-    // Local: on-host geesefs; scoped creds never enter agent space.
-    // Remote (Daytona): geesefs inside the sandbox over the ngrok tunnel.
-    if (mountCreds && !plan.isDaytona) {
+    // Durable cwd: mount BEFORE createSession (so the session opens inside it) and BEFORE
+    // workspace materialization (so AGENTS.md, harness files, and skills land in the durable
+    // prefix instead of being hidden under the FUSE mount).
+    if (env2.mountCreds && !plan.isDaytona) {
       await mountLocalDurableCwd("initial");
     }
-    if (mountCreds && plan.isDaytona) {
+    if (env2.mountCreds && plan.isDaytona) {
       const endpoint = await (
         deps.discoverTunnelEndpoint ?? discoverTunnelEndpoint
       )({
@@ -609,38 +773,37 @@ export async function runSandboxAgent(
       if (
         endpoint &&
         (await (deps.mountStorageRemote ?? mountStorageRemote)(
-          sandbox,
+          env2.sandbox,
           plan.cwd,
-          mountCreds,
+          env2.mountCreds,
           {
             endpoint,
             log: logger,
           },
         ))
       ) {
-        // Remote files live in the store; nothing on this host to unmount.
         logger(`remote durable cwd active for session=${sessionForMount}`);
       }
     }
 
     try {
-      workspace = await (deps.prepareWorkspace ?? prepareWorkspace)({
-        sandbox,
+      env2.workspace = await (deps.prepareWorkspace ?? prepareWorkspace)({
+        sandbox: env2.sandbox,
         plan,
         log: logger,
       });
     } catch (err) {
       if (
         !plan.isDaytona &&
-        mountCreds &&
+        env2.mountCreds &&
         isTransportEndpointDisconnected(err) &&
         (await reSignAndRemountLocalCwd())
       ) {
         logger(
           `retrying workspace preparation after local durable cwd remount`,
         );
-        workspace = await (deps.prepareWorkspace ?? prepareWorkspace)({
-          sandbox,
+        env2.workspace = await (deps.prepareWorkspace ?? prepareWorkspace)({
+          sandbox: env2.sandbox,
           plan,
           log: logger,
         });
@@ -649,28 +812,22 @@ export async function runSandboxAgent(
       }
     }
 
-    // Sandbox-start invariant: `startSandboxAgent` must hand back a usable handle, or the
-    // probe/createSession below fail with an opaque "cannot read property of undefined".
+    // Sandbox-start invariant: `startSandboxAgent` must hand back a usable handle.
     assert(
-      sandbox && typeof sandbox.createSession === "function",
+      env2.sandbox && typeof env2.sandbox.createSession === "function",
       `sandbox provider '${plan.sandboxId}' returned no usable sandbox handle`,
     );
 
-    // Probe what this harness supports and branch on capabilities, not on the harness
-    // name. Tool delivery: Pi loads our extension (native tools, set up above); any other
-    // harness takes tools over MCP only when it advertises `mcpTools` (pi-acp does not
-    // forward MCP, Claude/Codex do).
+    // Probe what this harness supports and branch on capabilities, not on the harness name.
     const probed = await (deps.probeCapabilities ?? probeCapabilities)(
-      sandbox,
+      env2.sandbox,
       plan.acpAgent,
     );
     const capabilities = probed.capabilities;
+    env2.capabilities = capabilities;
 
-    // Fail loud (A7): a run that REQUIRES a capability the harness lacks errors with a
-    // specific message instead of silently dropping the behavior, the way the
-    // `*_UNSUPPORTED_MESSAGE` gates in `run-plan.ts` do. Today: tool delivery to a non-Pi
-    // harness whose probe reports `mcpTools:false` / `toolCalls:false`. The throw is caught
-    // below and returned as `{ ok: false, error }`.
+    // Fail loud (A7): a run that REQUIRES a capability the harness lacks errors specifically
+    // rather than silently dropping the behavior.
     assertRequiredCapabilities({
       harness: plan.harness,
       isPi: plan.isPi,
@@ -679,65 +836,148 @@ export async function runSandboxAgent(
       log: logger,
     });
 
-    // Correlate a Claude MCP `tools/call` (name + args only) to the real ACP tool-call id the
-    // event stream surfaces, so a paused `client_tool` widget attaches to Claude's tool bubble.
-    const toolCallIndex = createToolCallCorrelationIndex();
-    // The shared client-tool relay is only built AFTER the session/model resolve (it needs the
-    // responder + otel run + pause plumbing). But the internal MCP server is built HERE (its URL
-    // is handed to createSession) and pauses client tools through that relay. A `tools/call` can
-    // only arrive during `session.prompt()` — long after the relay is wired — so the server
-    // captures a DEFERRED reference that resolves to the real relay before any call lands.
-    let clientToolRelay: ClientToolRelay | undefined;
-    const deferredClientToolRelay: ClientToolRelay = {
-      onClientTool: (req) =>
-        clientToolRelay
-          ? clientToolRelay.onClientTool(req)
-          : Promise.resolve("deny" as ClientToolOutcome),
-      onPause: (req) => clientToolRelay?.onPause?.(req),
-    };
-
     const sessionMcp = await buildSessionMcpServers({
       isPi: plan.isPi,
       capabilities,
       harness: plan.harness,
-      // Daytona: skip the internal loopback HTTP MCP channel (unreachable from the in-sandbox
-      // harness); gateway tools are delivered through the Daytona file relay started below.
       isDaytona: plan.isDaytona,
       toolSpecs: plan.toolSpecs,
       userMcpServers: request.mcpServers,
       relayDir: plan.relayDir,
-      // Any LOCAL non-Pi harness (Claude today): lets the internal channel advertise + pause
-      // `client` tools. The deferred ref resolves before any `tools/call` arrives.
-      // buildSessionMcpServers ignores it for Pi / Daytona (no internal channel there).
       clientToolRelay: deferredClientToolRelay,
       signal: mcpAbort.signal,
       log: logger,
     });
-    // Close the internal gateway-tool MCP server (if one started) when the run ends.
-    closeToolMcp = sessionMcp.close;
+    // Close the internal gateway-tool MCP server (if one started) when the session is destroyed.
+    env2.closeToolMcp = sessionMcp.close;
 
-    session = await sandbox.createSession({
+    env2.session = await env2.sandbox.createSession({
       agent: plan.acpAgent,
       cwd: plan.cwd,
       sessionInit: { cwd: plan.cwd, mcpServers: sessionMcp.servers },
     });
-    const sessionId = resolveRunSessionId(request, session.id);
+    env2.sessionId = resolveRunSessionId(request, env2.session.id);
 
-    // Resolve the model first: when the harness rejects the requested id and keeps its
-    // own default (e.g. Claude ignores "gpt-5.5"), `model` is undefined and the chat span
-    // is labelled "chat" instead of falsely claiming the requested model.
-    const model = await (deps.applyModel ?? applyModel)(
-      session,
+    // Resolve the model first: when the harness rejects the requested id and keeps its own
+    // default, `model` is undefined and the chat span is labelled "chat".
+    env2.model = await (deps.applyModel ?? applyModel)(
+      env2.session,
       request.model,
       logger,
       { strict: strictModel },
     );
 
+    // Session-lifetime listeners: attach ONCE, demux into the active turn's sink. Non-throwing
+    // (the sandbox-agent registries are plain Sets; a thrown handler would corrupt the stream).
+    // Deliberate divergence from the old inline handler: a handler throw is swallowed + logged
+    // here instead of propagating, because the listener now outlives any single turn.
+    env2.session.onEvent((event: any) => {
+      try {
+        remountLocalCwdAfterRuntimeEnotconn(event);
+        const payload = event?.payload;
+        const update = payload?.params?.update ?? payload?.update;
+        if (!update) return;
+        // Record live ACP tool_call ids so a paused client_tool can correlate to Claude's bubble
+        // (session-scoped; a lookup CONSUMES its matched id).
+        env2.toolCallIndex.record(update);
+        const turn = env2.currentTurn;
+        if (turn) {
+          turn.handleUpdate(update);
+        } else {
+          // Between turns (parked/idle): no turn owns this event. Log and drop by decision.
+          logger(`[keepalive] between-turns event dropped`);
+        }
+      } catch (err) {
+        logger(
+          `session onEvent handler error: ${conciseError(err, plan.harness)}`,
+        );
+      }
+    });
+    env2.session.onPermissionRequest((req: any) => {
+      try {
+        const turn = env2.currentTurn;
+        if (turn?.onPermissionRequest) {
+          turn.onPermissionRequest(req);
+          return;
+        }
+        // Between turns: slice 1 never parks an approval, so no turn owns this. Cancel by policy
+        // so a stray gate cannot hang; slice 2 will extend this handler to park it.
+        logger(
+          `[keepalive] between-turns permission request, cancelling by policy id=${req?.id}`,
+        );
+        void Promise.resolve(
+          env2.session?.respondPermission?.(req?.id, "reject"),
+        ).catch(() => {});
+      } catch (err) {
+        logger(
+          `session onPermissionRequest handler error: ${conciseError(err, plan.harness)}`,
+        );
+      }
+    });
+
+    return { ok: true, env: env2 };
+  } catch (err) {
+    const error = conciseError(err, plan.harness, request.provider);
+    // Mirror today's shared teardown: no otel exists yet during acquire, so there is no partial
+    // trace to flush — just run the incrementally-registered finalizers and surface the error.
+    await env2.destroy();
+    return { ok: false, error };
+  }
+}
+
+/**
+ * Run one turn against an acquired environment: start a fresh otel run, wire this turn's pause
+ * controller / latch / decisions / responder into `env.currentTurn`, restart the tool relay,
+ * send the prompt, resolve usage, and finish + flush the trace. It does NOT tear down the
+ * environment (the caller owns `env.destroy`). On a continuation the prompt is only the new user
+ * text (`buildTurnText` does not run); on a cold turn it is `plan.turnText`, exactly as before.
+ */
+export async function runTurn(
+  env: SessionEnvironment,
+  request: AgentRunRequest,
+  emit?: EmitEvent,
+  signal?: AbortSignal,
+  opts: { continuation?: boolean } = {},
+): Promise<AgentRunResult> {
+  const { plan, logger, deps } = env;
+  const sessionId = env.sessionId;
+  // Reset the per-turn tool-call id record (the park folds the completed turn's ids into the
+  // expected next-history fingerprint).
+  env.lastTurnToolCallIds = [];
+  // Hoisted so the catch can flush a partial trace (mirroring the pre-split `otel?` handling —
+  // a createOtel throw must still return `{ ok: false }`, not propagate raw) and the finally can
+  // stop this turn's relay on EVERY exit path (a cleared sink must never orphan it).
+  let otel: ReturnType<typeof createSandboxAgentOtel> | undefined;
+  let activeTurn: CurrentTurn | undefined;
+
+  // Time-based run deadlines (total/idle/TTFB/per-tool-call) for THIS turn: an idle/wedged harness
+  // has no deadline anywhere, so a silent or hung turn would hold its sandbox forever. Tripping a
+  // limit resolves the prompt race with `RUN_LIMIT_TRIPPED`, which ends the turn as an error so the
+  // caller's teardown (`runSandboxAgent`'s `finally`, or the keep-alive dispatch's evict-on-failure)
+  // reclaims the sandbox exactly as any other error does. Disposed in the `finally` on every path.
+  // A human pause retires the deadlines (`notePaused`): a HITL wait is legitimate, not a wedge.
+  const runLimits = (deps.createRunLimits ?? createRunLimits)(
+    (deps.resolveRunLimits ?? resolveRunLimits)(logger),
+    { log: logger },
+  );
+  let runLimitTrip: (() => void) | undefined;
+  let runLimitReason: string | undefined;
+  const runLimitTripped = new Promise<void>((resolve) => {
+    runLimitTrip = resolve;
+  });
+  runLimits.onTrip((reason) => {
+    runLimitReason = reason;
+    runLimitTrip?.();
+  });
+
+  try {
+    const promptText = resolvePromptText(request);
+    // Cold: replay the full transcript (plan.turnText). Continuation: only the new user text.
+    const turnText = opts.continuation ? promptText : plan.turnText;
+
     const run = (deps.createOtel ?? createSandboxAgentOtel)({
       harness: plan.harness,
-      model,
-      // The names of every skill that materialized for this run (author + forced `_agenta.*`),
-      // stamped on the agent span so the trace shows which skills loaded (F-029).
+      model: env.model,
       skills: plan.skillDirs.map((s) => s.name),
       traceparent: request.context?.propagation?.traceparent,
       baggage: request.context?.propagation?.baggage,
@@ -746,18 +986,18 @@ export async function runSandboxAgent(
       captureContent: request.telemetry?.capture?.content?.enabled,
       emitSpans: !plan.isPi || plan.isDaytona,
       // Every emitted event is a progress signal for the idle/TTFB deadlines (message/thought
-      // deltas, tool calls and results, usage, ...) — this is the one seam every harness's
-      // output already flows through.
+      // deltas, tool calls and results, usage, ...) — the one seam every harness's output flows
+      // through. Per-tool-call timers are driven separately from `handleUpdate` below.
       emit: emit && runLimits.wrapEmit(emit),
     });
     otel = run;
 
     run.start({
-      prompt: plan.prompt,
+      prompt: promptText,
       sessionId,
       messages: [
         ...priorMessages(request),
-        { role: "user", content: plan.prompt },
+        { role: "user", content: promptText },
       ],
     });
 
@@ -768,39 +1008,55 @@ export async function runSandboxAgent(
       );
       // Abort any in-flight loopback `tools/call` (a paused Claude client tool) BEFORE the
       // session teardown, so its handler cannot write a result after the turn ends.
-      mcpAbort.abort();
-      sessionDestroyRequested = true;
-      return sandbox.destroySession?.(session.id);
+      env.mcpAbort.abort();
+      env.sessionDestroyRequested = true;
+      return env.sandbox.destroySession?.(env.session.id);
     });
-    // The pause signal resolves exactly once, the moment a turn parks for human input — that is
-    // the one place every pause path (ACP gate, relay, internal MCP) converges, so it is also
-    // the one place to retire the run-limits deadlines for good.
+    // A human pause resolves this signal exactly once, the moment the turn parks for input — the one
+    // place every pause path converges, so the one place to retire the run-limits deadlines for good.
     void pause.signal.then(() => runLimits.notePaused());
 
-    session.onEvent((event: any) => {
-      remountLocalCwdAfterRuntimeEnotconn(event);
-      const payload = event?.payload;
-      const update = payload?.params?.update ?? payload?.update;
-      if (update) {
-        // Record live ACP tool_call ids so a paused client_tool can correlate to Claude's
-        // bubble (recorded even for suppressed frames; a lookup CONSUMES its matched id).
-        toolCallIndex.record(update);
-        // Per-tool-call deadline: starts on the announcement, ends on a terminal status.
-        // Tracked regardless of pause-suppression below (a call already timed out must not
-        // linger just because a later sibling frame gets suppressed).
-        if (update.sessionUpdate === "tool_call" && update.toolCallId) {
-          runLimits.noteToolCallStart(String(update.toolCallId));
+    // Publish this turn's sink so the session-lifetime listeners route into it. handleUpdate
+    // reproduces the old per-event routing (suppress paused frames, handleUpdate, pause re-sweep).
+    const turn: CurrentTurn = {
+      run,
+      pause,
+      toolRelay: undefined,
+      handleUpdate: (update) => {
+        // Per-tool-call deadline: starts on the announcement, ends on a terminal status. Tracked
+        // regardless of the pause-suppression below (a call already timed out must not linger just
+        // because a later sibling frame gets suppressed).
+        const rawFrame = update as {
+          sessionUpdate?: unknown;
+          toolCallId?: unknown;
+          status?: unknown;
+        };
+        if (rawFrame?.sessionUpdate === "tool_call" && rawFrame.toolCallId) {
+          runLimits.noteToolCallStart(String(rawFrame.toolCallId));
         } else if (
-          update.sessionUpdate === "tool_call_update" &&
-          update.toolCallId &&
-          (update.status === "completed" || update.status === "failed")
+          rawFrame?.sessionUpdate === "tool_call_update" &&
+          rawFrame.toolCallId &&
+          (rawFrame.status === "completed" || rawFrame.status === "failed")
         ) {
-          runLimits.noteToolCallEnd(String(update.toolCallId));
+          runLimits.noteToolCallEnd(String(rawFrame.toolCallId));
         }
         if (!shouldSuppressPausedToolCallUpdate(update, pause)) {
+          // Record the emitted tool-call ids (unique, first-seen order): the park folds them
+          // into the expected next-history fingerprint so a tool-using turn continues live.
+          const frame = update as {
+            sessionUpdate?: unknown;
+            toolCallId?: unknown;
+          };
+          if (
+            frame?.sessionUpdate === "tool_call" &&
+            typeof frame.toolCallId === "string" &&
+            frame.toolCallId &&
+            !env.lastTurnToolCallIds.includes(frame.toolCallId)
+          ) {
+            env.lastTurnToolCallIds.push(frame.toolCallId);
+          }
           run.handleUpdate(update);
-          // A sibling announced AFTER the pause won the latch can never execute (the session
-          // is already being destroyed), and the pause-time sweep has already run — settle it
+          // A sibling announced AFTER the pause won the latch can never execute; settle it
           // immediately so the client never holds an orphaned part (idempotent re-sweep).
           if (pause.active) {
             run.settleOpenToolCalls(
@@ -809,8 +1065,12 @@ export async function runSandboxAgent(
             );
           }
         }
-      }
-    });
+      },
+      onPermissionRequest: undefined,
+    };
+    activeTurn = turn;
+    env.currentTurn = turn;
+
     const permissionPlan = permissionsFromRequest(request);
     const storedDecisionMap = extractApprovalDecisions(request);
     if (storedDecisionMap.size > 0) {
@@ -826,8 +1086,7 @@ export async function runSandboxAgent(
     const responder =
       deps.responderFactory?.(request) ??
       new ApprovalResponder(permissionPlan, decisions, logger);
-    // Every pause seeds the durable interactions plane, whichever gate paused (the ACP
-    // responder on Claude, the relay on Pi). Shared by both wiring sites below.
+    // Every pause seeds the durable interactions plane, whichever gate paused.
     const recordPendingInteraction = (
       token: string,
       toolName: string | undefined,
@@ -836,9 +1095,6 @@ export async function runSandboxAgent(
     ): void => {
       const cred = runCredential(request);
       if (!cred) return;
-      // The /interactions plane only works when respond can re-invoke THIS revision, which
-      // needs at least a committed workflow_revision reference. A draft (inline config, no
-      // committed revision) can't be re-resolved, so skip create and stay messages-only.
       const references = buildWorkflowReferences(request.runContext?.workflow);
       if (!references?.workflow_revision) return;
       void createInteraction(
@@ -850,8 +1106,7 @@ export async function runSandboxAgent(
         () => cred,
       );
     };
-    // Exactly one gate per call: the harness gate on Claude, the relay on Pi. If more
-    // harness families arrive, move this capability split to engines/sandbox_agent/capabilities.ts.
+    // Exactly one gate per call: the harness gate on Claude, the relay on Pi.
     const relayPermissions: RelayPermissions = {
       enforce: plan.isPi,
       decide: (gate) => decide(gate, permissionPlan, decisions),
@@ -880,8 +1135,18 @@ export async function runSandboxAgent(
       },
     };
     const serverPermissions = serverPermissionsFromRequest(request);
+    // Build the per-turn permission handler WITHOUT attaching to the live session: the
+    // session-lifetime `onPermissionRequest` (in acquireEnvironment) routes into it via
+    // `currentTurn`. A capturing shim reuses attachPermissionResponder unchanged; its
+    // respondPermission delegates to the real session.
     attachPermissionResponder({
-      session,
+      session: {
+        onPermissionRequest: (handler: (req: unknown) => void) => {
+          turn.onPermissionRequest = handler;
+        },
+        respondPermission: (id: string, reply: string) =>
+          env.session.respondPermission(id, reply),
+      },
       run,
       responder,
       latch,
@@ -893,7 +1158,6 @@ export async function runSandboxAgent(
       onResolveInteraction: (token) => {
         const cred = runCredential(request);
         if (!cred) return;
-        // Mirror the create guard: no interaction exists for a draft, so nothing to resolve.
         if (
           !buildWorkflowReferences(request.runContext?.workflow)
             ?.workflow_revision
@@ -903,65 +1167,56 @@ export async function runSandboxAgent(
       },
     });
 
-    // Resolve the ONE client-tool seam both delivery paths share: the Pi file relay (below)
-    // consumes it directly, and the Claude internal MCP server reaches it through the deferred
-    // ref captured above. Built here because it needs the responder, the otel run, and the pause
-    // plumbing. The correlation index is wired for Claude only — Pi's relay toolCallId is
-    // already exact, so it pauses with no index (behavior-preserving).
-    clientToolRelay = buildClientToolRelay({
+    // Resolve the ONE client-tool seam both delivery paths share. The correlation index is wired
+    // for Claude only — Pi's relay toolCallId is already exact.
+    env.clientToolRelayRef.current = buildClientToolRelay({
       responder,
       run,
       latch,
       pause,
       recordPendingInteraction,
-      toolCallIndex: plan.isPi ? undefined : toolCallIndex,
+      toolCallIndex: plan.isPi ? undefined : env.toolCallIndex,
       log: logger,
     });
 
     if (plan.useToolRelay) {
-      toolRelay = (deps.startToolRelay ?? startToolRelay)(
+      turn.toolRelay = (deps.startToolRelay ?? startToolRelay)(
         plan.isDaytona
-          ? (deps.sandboxRelayHost ?? sandboxRelayHost)(sandbox)
+          ? (deps.sandboxRelayHost ?? sandboxRelayHost)(env.sandbox)
           : (deps.localRelayHost ?? localRelayHost)(),
         plan.relayDir,
         plan.toolSpecs,
         request.toolCallback as ToolCallbackContext | undefined,
         relayPermissions,
         request.runContext,
-        clientToolRelay,
+        env.clientToolRelayRef.current,
       );
     }
 
-    // Race the prompt against the pause signal: on a HITL pause the prompt either resolves with
-    // a cancelled stop reason (the managed `session/cancel` landed) or never resolves at all
-    // (the harness ignores it) — either way the pause signal ends the turn so the runner returns
-    // promptly, the `finally` disposes the sandbox (no leak, F-040), and the egress emits a
-    // `finish` frame. When the pause wins, the orphaned `prompt()` may later reject as the
-    // cancelled/torn-down connection unwinds; swallow that so it is not an `unhandledRejection`
-    // (the daemon teardown's `fetch failed` is expected on a cancel, not a run error).
+    // Race the prompt against the pause signal: on a HITL pause the prompt either resolves with a
+    // cancelled stop reason or never resolves at all; either way the pause signal ends the turn.
     const promptPromise = Promise.resolve(
-      session.prompt([{ type: "text", text: plan.turnText }]),
+      env.session.prompt([{ type: "text", text: turnText }]),
     );
     promptPromise.catch(() => {});
     const raced = await Promise.race([
       promptPromise,
       pause.signal.then(() => PAUSED),
+      runLimitTripped.then(() => RUN_LIMIT_TRIPPED),
     ]);
-    // A paused turn is terminal-but-incomplete: stop reason `paused` tells the egress to emit
-    // a clean `finish` (the FE then resumes on the user's decision). A real prompt result keeps
-    // the harness's own stop reason.
+    // A tripped run-limit ends the turn as an error: throw into the shared catch below so the
+    // trace is flushed and the caller's teardown reclaims the (wedged) sandbox.
+    if (raced === RUN_LIMIT_TRIPPED) {
+      throw new Error(runLimitReason ?? "run limit tripped");
+    }
     const stopReason =
       raced === PAUSED || pause.active ? "paused" : (raced as any)?.stopReason;
     const result = raced === PAUSED ? undefined : raced;
-    await toolRelay?.stop();
+    await turn.toolRelay?.stop();
     logger(`prompt stopReason=${stopReason}`);
 
-    // Usage: Pi writes its totals to a file via the extension. Other harnesses report the
-    // input/output token split on the PromptResponse and the cost on ACP `usage_update`,
-    // so combine the two (the stream alone carries no per-call token split). Read and stamp
-    // this before finish/flush so exported spans and final events carry the final usage.
     const usage = await resolveRunUsage({
-      sandbox,
+      sandbox: env.sandbox,
       usageOutPath: plan.usageOutPath,
       isDaytona: plan.isDaytona,
       promptResult: result,
@@ -969,23 +1224,15 @@ export async function runSandboxAgent(
     });
     run.setUsage(usage);
 
-    // Peek for a swallowed model error BEFORE finishing the trace so the error message + provider
-    // can be stamped on the still-open agent span (F-030). When Pi's provider call fails
-    // (out-of-quota, bad key, rate limit, unknown model, ...), Pi's pi-acp bridge reports the
-    // turn as a plain `end_turn` with NO content, so without this the run would return an
-    // `ok:true` empty turn and the user would see a silent "No response" instead of the real
-    // failure. On the LOCAL Pi path the error is recoverable from Pi's own session transcript —
-    // which lives under `runAgentDir` (the per-run throwaway dir Pi was actually pointed at via
-    // PI_CODING_AGENT_DIR), NOT `plan.sourcePiAgentDir` (the static source login dir, which has
-    // no transcripts). Only checked when the turn produced no output and ran no tools (a real
-    // tool-only turn legitimately has empty text), and never on Daytona (the transcript lives in
-    // the remote sandbox).
     const swallowedPiError =
       plan.isPi &&
       !plan.isDaytona &&
       !run.output().trim() &&
       !run.events().some((e) => e.type === "tool_call")
-        ? findSwallowedPiError(runAgentDir ?? plan.sourcePiAgentDir, plan.cwd)
+        ? findSwallowedPiError(
+            env.runAgentDir ?? plan.sourcePiAgentDir,
+            plan.cwd,
+          )
         : undefined;
     let swallowedError: string | undefined;
     if (swallowedPiError) {
@@ -995,15 +1242,12 @@ export async function runSandboxAgent(
         request.provider,
       );
       run.recordError(swallowedError, request.provider);
-      // Emit it as an event too (before finish() flushes the sink), so it reaches the live
-      // stream and the durable record, not only the trace span.
       run.emitEvent({ type: "error", message: swallowedError });
     }
 
     const output = run.finish();
     await run.flush();
 
-    // Fail loud on the error detected above (A7 / "fail loud, not silent").
     if (swallowedError) {
       return { ok: false, error: swallowedError };
     }
@@ -1012,81 +1256,56 @@ export async function runSandboxAgent(
       ok: true,
       output,
       messages: output ? [{ role: "assistant", content: output }] : [],
-      // Streaming already delivered every event live, so the terminal result carries none
-      // (re-sending would double them on the consumer).
       events: emit ? [] : run.events(),
       usage,
       stopReason,
-      // `streamingDeltas` advertises end-to-end live deltas, which is only true when a live
-      // sink is wired. The one-shot path reports false even when the harness produces deltas.
       capabilities: {
-        ...capabilities,
-        streamingDeltas: !!emit && capabilities.streamingDeltas,
+        ...env.capabilities,
+        streamingDeltas: !!emit && env.capabilities.streamingDeltas,
       },
       sessionId,
-      model: model ?? request.model,
+      model: env.model ?? request.model,
       traceId: run.traceId(),
-    };
+    } as AgentRunResult;
   } catch (err) {
     const error = conciseError(err, plan.harness, request.provider);
-    // Stamp the error message + provider on the agent span before finishing it (F-030), so a
-    // trace carries the same diagnostic the response does (it previously held only a count).
     otel?.recordError(error, request.provider);
-    // Also surface it as an event (before finish flushes the sink) so the error reaches the
-    // live stream and the durable record, not only the trace.
     otel?.emitEvent({ type: "error", message: error });
-    // finish() must not throw uncaught, same as recordError above — tracing must not mask the run error.
+    // finish() must not throw uncaught — tracing must not mask the run error.
     try {
       otel?.finish();
     } catch {}
     await otel?.flush().catch(() => {});
-    return {
-      ok: false,
-      error,
-    };
+    return { ok: false, error };
   } finally {
+    // Release every run-limits timer (idempotent, never re-arms on a late event) on EVERY path.
     runLimits.dispose();
-    await runtimeRemount?.catch(() => {});
-    if (sandbox) inFlightSandboxes.delete(sandbox);
-    await toolRelay?.stop().catch(() => {});
-    // Teardown backstop: destroy any in-flight loopback `tools/call` before closing the server.
-    mcpAbort.abort();
-    await closeToolMcp?.().catch(() => {});
-    // Send a graceful `session/cancel` BEFORE tearing down the daemon (the ACP child process
-    // leak, dev-box incident 2026-07-06): on a normal/error completion this was the only path
-    // that never called `destroySession` (the HITL pause controller already does, above), so
-    // every such run went straight from a live session to `destroySandbox()` hard-killing the
-    // local `sandbox-agent`
-    // server. That kill only reaches the immediate child (the sandbox-agent server process,
-    // via SIGTERM/SIGKILL); it does not cascade to the ACP adapter subprocess (e.g.
-    // `claude-agent-acp`) the server spawned to drive the harness, which then gets reparented to
-    // the container's PID 1 and never exits (observed accumulating for hours in production).
-    // Skip if the pause path already sent it (`sessionDestroyRequested`) — best-effort either way.
-    if (session && !sessionDestroyRequested)
-      await sandbox?.destroySession?.(session.id).catch(() => {});
-    await sandbox?.destroySandbox().catch(() => {});
-    await sandbox?.dispose().catch(() => {});
-    // Unmount the durable cwd BEFORE removing the dir: data lives in the store, only the host
-    // mountpoint is torn down. If unmount is not CONFIRMED gone, skip the delete below:
-    // rmSync must never run against a possibly-live FUSE mount into the durable store.
-    if (mountedCwd) {
-      durableCwdSafeToDelete = await (
-        deps.unmountStorage ?? unmountStorage
-      )(mountedCwd, { log }).catch(() => false);
-    }
-    if (!durableCwdSafeToDelete) {
-      logger(
-        `durable cwd unmount not confirmed, skipping workspace cleanup cwd=${plan.cwd}`,
-      );
-    } else {
-      await workspace?.cleanup().catch(() => {});
-    }
-    // The per-run Agenta agent dir (skills isolation) is throwaway; remove it too.
-    if (runAgentDir) rmSync(runAgentDir, { recursive: true, force: true });
-    // Backstop: the extension deletes this on read; remove it here too in case the harness
-    // never started (or crashed before reading it), so the bearer never lingers.
-    if (otlpAuthFilePath) rmSync(otlpAuthFilePath, { force: true });
-    // Remove the per-run skills temp root the materializer created (success or error).
-    plan.skillsCleanup();
+    // This turn owns its relay: stop it on EVERY exit path (the happy path already stopped it
+    // after the prompt; stop is safe to repeat, matching the old finally). Null it afterwards so
+    // a later `destroy()` — possibly after the dispatch cleared the sink — cannot double-stop or
+    // orphan it.
+    await activeTurn?.toolRelay?.stop().catch(() => {});
+    if (activeTurn) activeTurn.toolRelay = undefined;
+  }
+}
+
+/**
+ * The cold, one-turn-per-environment entry (also the flag-off path). Acquire an environment, run
+ * one turn, then tear the environment down — exactly as the single `try/finally` did before the
+ * split, so behavior here is byte-identical to pre-keep-alive.
+ */
+export async function runSandboxAgent(
+  request: AgentRunRequest,
+  emit?: EmitEvent,
+  signal?: AbortSignal,
+  deps: SandboxAgentDeps = {},
+): Promise<AgentRunResult> {
+  const acquired = await acquireEnvironment(request, deps, signal);
+  if (!acquired.ok) return { ok: false, error: acquired.error };
+  const env = acquired.env;
+  try {
+    return await runTurn(env, request, emit, signal);
+  } finally {
+    await env.destroy();
   }
 }

--- a/services/runner/src/engines/sandbox_agent/mount.ts
+++ b/services/runner/src/engines/sandbox_agent/mount.ts
@@ -31,6 +31,13 @@ export interface MountCredentials {
   secretKey: string;
   sessionToken?: string;
   expiresAt?: string;
+  /**
+   * The mount's owning project id, surfaced from the sign response's `mount` object. It is the
+   * only project scope the runner can trust for this request (the /run wire carries no project
+   * id today), so session keep-alive keys its pool on `<projectId>:<sessionId>`. Absent when the
+   * response omitted the mount object; keep-alive then refuses to park (no safe key source).
+   */
+  projectId?: string;
 }
 
 export interface SignMountDeps {
@@ -74,6 +81,7 @@ export async function signSessionMountCredentials(
       return null;
     }
     const body = (await res.json()) as {
+      mount?: { project_id?: string };
       credentials?: {
         endpoint?: string;
         region?: string;
@@ -99,6 +107,12 @@ export async function signSessionMountCredentials(
       secretKey: c.secret_key,
       sessionToken: c.session_token,
       expiresAt: c.expires_at,
+      // The owning project id (from the `mount` object), used only as the keep-alive pool key
+      // scope. A string in JSON (the API serializes the UUID); undefined when omitted.
+      projectId:
+        typeof body.mount?.project_id === "string"
+          ? body.mount.project_id
+          : undefined,
     };
   } catch (err) {
     log(
@@ -160,7 +174,10 @@ function credEnv(creds: MountCredentials): Record<string, string> {
  * check trusts it, so `mountStorage` short-circuits and the next session inherits a dead cwd.
  * Probe with a real access (`ls -A`) and treat ENOTCONN as NOT-mounted so the caller remounts.
  */
-async function isMounted(cwd: string, log: (m: string) => void): Promise<boolean> {
+async function isMounted(
+  cwd: string,
+  log: (m: string) => void,
+): Promise<boolean> {
   try {
     await pExecFile("mountpoint", ["-q", cwd]);
   } catch {
@@ -270,7 +287,9 @@ export async function mountStorage(
 export interface UnmountStorageDeps {
   runUnmount?: (cwd: string) => Promise<void>;
   // Resolve to "gone" | "mounted" | "inconclusive"; only "gone" allows the caller to delete.
-  checkMountpoint?: (cwd: string) => Promise<"gone" | "mounted" | "inconclusive">;
+  checkMountpoint?: (
+    cwd: string,
+  ) => Promise<"gone" | "mounted" | "inconclusive">;
   log?: (msg: string) => void;
 }
 
@@ -349,7 +368,9 @@ export async function discoverTunnelEndpoint(
   const log = deps.log ?? defaultLog;
   const doFetch = deps.fetchImpl ?? fetch;
   const api =
-    deps.ngrokApi ?? process.env.AGENTA_MOUNTS_TUNNEL_API ?? "http://ngrok:4040";
+    deps.ngrokApi ??
+    process.env.AGENTA_MOUNTS_TUNNEL_API ??
+    "http://ngrok:4040";
   try {
     const res = await doFetch(`${api}/api/tunnels`);
     if (!res.ok) {

--- a/services/runner/src/engines/sandbox_agent/session-pool.ts
+++ b/services/runner/src/engines/sandbox_agent/session-pool.ts
@@ -1,0 +1,554 @@
+/**
+ * Session keep-alive pool (slice 1: normal turn boundaries, local sandbox, flag-gated off).
+ *
+ * Background: today the runner destroys the sandbox and harness session at the end of every
+ * turn (`sandbox_agent.ts` teardown). Keep-alive parks a live session for a short TTL so the
+ * next message in the same conversation continues the same live harness process, keeping its
+ * native memory. If the window expires or anything mismatches, the dispatch falls back to
+ * today's cold path. Nothing gets worse than today; with the flag off nothing here runs.
+ *
+ * This module is engine-agnostic: it holds opaque `environment` handles plus the metadata the
+ * dispatch needs to decide continue-versus-cold (two fingerprints, a credential epoch, an LRU
+ * timestamp, a state) and a complete idempotent `destroy()` closure the engine supplies. It
+ * never imports the engine, so it stays a pure map + timer + policy unit.
+ *
+ * See docs/design/agent-workflows/projects/session-keepalive/plan.md.
+ */
+import { createHash } from "node:crypto";
+
+import {
+  type AgentRunRequest,
+  type ChatMessage,
+  type ContentBlock,
+  messageText,
+} from "../../protocol.ts";
+
+function log(message: string): void {
+  process.stderr.write(`[keepalive] ${message}\n`);
+}
+
+// --- Config (read once, in one place; mirrors server.ts's env reads) --------- //
+
+export interface KeepaliveConfig {
+  enabled: boolean;
+  ttlMs: number;
+  approvalTtlMs: number;
+  poolMax: number;
+}
+
+const KEEPALIVE_ENV = "AGENTA_RUNNER_SESSION_KEEPALIVE";
+const TTL_ENV = "AGENTA_RUNNER_SESSION_TTL_MS";
+const APPROVAL_TTL_ENV = "AGENTA_RUNNER_SESSION_APPROVAL_TTL_MS";
+const POOL_MAX_ENV = "AGENTA_RUNNER_SESSION_POOL_MAX";
+
+const DEFAULT_TTL_MS = 60_000;
+const DEFAULT_APPROVAL_TTL_MS = 600_000;
+const DEFAULT_POOL_MAX = 8;
+
+function positiveIntEnv(name: string, fallback: number): number {
+  const raw = process.env[name];
+  const parsed = raw ? Number(raw) : NaN;
+  return Number.isFinite(parsed) && parsed > 0 ? Math.floor(parsed) : fallback;
+}
+
+/** The runner treats only a few explicit truthy spellings as on; default OFF. */
+function boolEnv(name: string): boolean {
+  const raw = (process.env[name] ?? "").trim().toLowerCase();
+  return raw === "1" || raw === "true" || raw === "yes" || raw === "on";
+}
+
+/** Read the keep-alive config from the environment. One place; the dispatch calls it per run. */
+export function readKeepaliveConfig(): KeepaliveConfig {
+  return {
+    enabled: boolEnv(KEEPALIVE_ENV),
+    ttlMs: positiveIntEnv(TTL_ENV, DEFAULT_TTL_MS),
+    approvalTtlMs: positiveIntEnv(APPROVAL_TTL_ENV, DEFAULT_APPROVAL_TTL_MS),
+    poolMax: positiveIntEnv(POOL_MAX_ENV, DEFAULT_POOL_MAX),
+  };
+}
+
+// --- Fingerprints and the pool key ------------------------------------------ //
+
+function sha256(value: string): string {
+  return createHash("sha256").update(value).digest("hex");
+}
+
+/** Deterministic JSON: object keys sorted recursively so equal values hash equal. */
+function canonicalJson(value: unknown): string {
+  if (value === null || typeof value !== "object") return JSON.stringify(value);
+  if (Array.isArray(value)) {
+    return `[${value.map(canonicalJson).join(",")}]`;
+  }
+  const entries = Object.entries(value as Record<string, unknown>)
+    .filter(([, v]) => v !== undefined)
+    .sort(([a], [b]) => (a < b ? -1 : a > b ? 1 : 0));
+  return `{${entries
+    .map(([k, v]) => `${JSON.stringify(k)}:${canonicalJson(v)}`)
+    .join(",")}}`;
+}
+
+/**
+ * A canonical hash over the config-bearing request fields (architecture-notes "Continuation
+ * versus cold decision"). Per-turn volatiles are excluded: `messages`, `turnId`, trace
+ * propagation (`context`), the rotating telemetry headers, and secret VALUES (`secrets` — the
+ * credential epoch covers rotation, and values must never enter any hash used for logging). The
+ * tool-callback ENDPOINT is included (routing config); its authorization is a credential and
+ * lives in the credential epoch instead.
+ */
+export function configFingerprint(request: AgentRunRequest): string {
+  const workflow = request.runContext?.workflow;
+  const shape = {
+    harness: request.harness ?? null,
+    sandbox: request.sandbox ?? null,
+    model: request.model ?? null,
+    provider: request.provider ?? null,
+    connection: request.connection ?? null,
+    deployment: request.deployment ?? null,
+    endpoint: request.endpoint ?? null,
+    credentialMode: request.credentialMode ?? null,
+    agentsMd: request.agentsMd ?? null,
+    systemPrompt: request.systemPrompt ?? null,
+    appendSystemPrompt: request.appendSystemPrompt ?? null,
+    tools: request.tools ?? null,
+    skills: request.skills ?? null,
+    customTools: request.customTools ?? null,
+    mcpServers: request.mcpServers ?? null,
+    toolCallbackEndpoint: request.toolCallback?.endpoint ?? null,
+    permissions: request.permissions ?? null,
+    sandboxPermission: request.sandboxPermission ?? null,
+    harnessFiles: request.harnessFiles ?? null,
+    workflowRevision: workflow?.revision
+      ? {
+          id: workflow.revision.id ?? null,
+          version: workflow.revision.version ?? null,
+        }
+      : null,
+    isDraft: workflow?.is_draft ?? null,
+  };
+  return sha256(canonicalJson(shape));
+}
+
+function collectToolCallIds(
+  content: string | ContentBlock[] | undefined,
+  into: string[],
+  seen: Set<string>,
+): void {
+  if (!Array.isArray(content)) return;
+  for (const block of content) {
+    if (!block) continue;
+    if (
+      (block.type === "tool_call" || block.type === "tool_result") &&
+      typeof block.toolCallId === "string" &&
+      block.toolCallId &&
+      !seen.has(block.toolCallId)
+    ) {
+      seen.add(block.toolCallId);
+      into.push(block.toolCallId);
+    }
+  }
+}
+
+/**
+ * A hash over the conversation the server received (the FE's pruned array): the ordered user
+ * message texts, the ordered tool-call ids across every message, and the user-message count.
+ * Assistant TEXT is deliberately ignored, so a live session that has already answered a plain
+ * user turn matches the next request's prefix (the FE's assistant turn contributes nothing).
+ * Tool-call ids ARE included, so an edited history trips a mismatch and degrades to cold
+ * replay rather than continuing wrongly. Ids are DEDUPED (unique, first-seen order): a resolved
+ * tool call rides the wire as a `tool_call` block PLUS a `tool_result` block sharing one id
+ * (vercel `messages.py` `_tool_part_blocks`), and the park-time prediction
+ * (`expectedNextHistoryFingerprint`) folds each emitted id in once — dedupe makes the two agree
+ * while a genuinely different id SET still mismatches.
+ *
+ * The dispatch stores the fingerprint the next request is EXPECTED to hash to (see
+ * `expectedNextHistoryFingerprint`), and checks the next request against the fingerprint of its
+ * PRIOR messages (everything before the new user tail), so a plain conversational continuation
+ * matches and any divergence falls to cold.
+ */
+export function historyFingerprint(messages: readonly ChatMessage[]): string {
+  const userTexts: string[] = [];
+  const toolCallIds: string[] = [];
+  const seenIds = new Set<string>();
+  let promptCount = 0;
+  for (const message of messages) {
+    if (message.role === "user") {
+      promptCount += 1;
+      userTexts.push(messageText(message.content));
+    }
+    collectToolCallIds(message.content, toolCallIds, seenIds);
+  }
+  return sha256(canonicalJson({ userTexts, toolCallIds, promptCount }));
+}
+
+/**
+ * The fingerprint a park should record so the NEXT request's prior conversation matches it:
+ * the full messages this turn ran, plus the tool-call ids the turn itself emitted, folded in
+ * as one synthetic trailing assistant message.
+ *
+ * Why: the FE keeps an assistant turn iff it has an answer part (`agentRequest.ts`
+ * `isAnswerPart`: non-empty text, `tool-*`/`dynamic-tool`, or file). So a tool-calling turn's
+ * ids ALWAYS appear in the next request's prior messages, and a fully empty assistant turn is
+ * pruned but contributes neither text nor ids — the prediction is deterministic either way
+ * (assistant text is not hashed). An id divergence still trips a mismatch and falls to cold.
+ */
+export function expectedNextHistoryFingerprint(
+  messages: readonly ChatMessage[],
+  emittedToolCallIds: readonly string[],
+): string {
+  if (emittedToolCallIds.length === 0) return historyFingerprint(messages);
+  const syntheticAssistantTurn: ChatMessage = {
+    role: "assistant",
+    content: emittedToolCallIds.map((id) => ({
+      type: "tool_call",
+      toolCallId: id,
+    })),
+  };
+  return historyFingerprint([...messages, syntheticAssistantTurn]);
+}
+
+/**
+ * The prior conversation for a continuation check: everything before the request's new user
+ * tail. Mirrors `transcript.priorMessages` for the trailing-user case (the playground always
+ * sends the new turn as the last user message), without importing that do-not-touch module.
+ */
+export function priorConversation(request: AgentRunRequest): ChatMessage[] {
+  const messages = request.messages ?? [];
+  if (messages.length && messages[messages.length - 1].role === "user") {
+    return messages.slice(0, -1);
+  }
+  return messages.slice();
+}
+
+/**
+ * True when the request's tail is a fresh user message with text and NOT an approval envelope.
+ * A continuation only takes the live path for a plain new user turn; an approval reply (a
+ * trailing tool-role message, or a user turn carrying a tool_result) is slice 2's concern and
+ * stays cold here.
+ */
+export function tailIsFreshUserMessage(request: AgentRunRequest): boolean {
+  const messages = request.messages ?? [];
+  const tail = messages[messages.length - 1];
+  if (!tail || tail.role !== "user") return false;
+  if (!messageText(tail.content).trim()) return false;
+  if (Array.isArray(tail.content)) {
+    const carriesToolTurn = tail.content.some(
+      (block) => block?.type === "tool_result" || block?.type === "tool_call",
+    );
+    if (carriesToolTurn) return false;
+  }
+  return true;
+}
+
+/**
+ * The credential epoch bounds how long a parked session may reuse its baked credentials. It is
+ * a PROCESS-LOCAL hash over the actual resolved secret VALUES plus the tool-callback auth (held
+ * only in runner memory — never logged, persisted, or emitted), combined with the mount
+ * credential expiry. A rotated same-slug secret changes the hash; an elapsed expiry invalidates
+ * the epoch. Either way the dispatch evicts and cold-starts with fresh credentials.
+ */
+export interface CredentialEpoch {
+  /** sha256 over canonical(secrets) + tool-callback auth. In-memory only; never surfaced. */
+  secretsHash: string;
+  /** Mount credential expiry as epoch millis, or undefined when the sign response had none. */
+  mountExpiresAtMs?: number;
+}
+
+export function computeCredentialEpoch(
+  request: AgentRunRequest,
+  mountExpiresAt?: string,
+): CredentialEpoch {
+  const material = canonicalJson({
+    secrets: request.secrets ?? {},
+    toolCallbackAuth: request.toolCallback?.authorization ?? null,
+  });
+  const parsed = mountExpiresAt ? Date.parse(mountExpiresAt) : NaN;
+  return {
+    secretsHash: sha256(material),
+    mountExpiresAtMs: Number.isFinite(parsed) ? parsed : undefined,
+  };
+}
+
+/**
+ * Whether a parked epoch is still valid for an incoming request's epoch. Invalid (evict, cold)
+ * when the mount credential expired, or the resolved secret/tool-auth material changed.
+ */
+export function credentialEpochValid(
+  parked: CredentialEpoch,
+  incoming: CredentialEpoch,
+  now = Date.now(),
+): boolean {
+  if (parked.mountExpiresAtMs !== undefined && now >= parked.mountExpiresAtMs) {
+    return false;
+  }
+  return parked.secretsHash === incoming.secretsHash;
+}
+
+/**
+ * The pool key: `<projectId>:<sessionId>`. The project scope is the mount's owning project id,
+ * the only project scope the runner can trust (the /run wire carries no project id). Returns
+ * null when there is no session id or no mount project id — such a request MUST NOT park (there
+ * is no safe key that separates callers), and the dispatch runs it fully cold.
+ */
+export function poolKeyFor(
+  request: AgentRunRequest,
+  mountProjectId: string | undefined,
+): string | null {
+  const sessionId = request.sessionId?.trim();
+  const project = mountProjectId?.trim();
+  if (!sessionId || !project) return null;
+  return `${project}:${sessionId}`;
+}
+
+// --- The pool --------------------------------------------------------------- //
+
+export type SessionState = "busy" | "idle" | "awaiting_approval" | "destroyed";
+
+/**
+ * One parked live session. `environment` is opaque to the pool (the engine reads it on a
+ * continuation). `destroy` is the engine's complete, idempotent teardown closure.
+ */
+export interface LiveSession<E = unknown> {
+  key: string;
+  environment: E;
+  configFingerprint: string;
+  historyFingerprint: string;
+  credentialEpoch: CredentialEpoch;
+  state: SessionState;
+  lastUsed: number;
+  destroy: () => Promise<void>;
+  /** Internal: the idle/approval TTL timer. */
+  ttlTimer?: ReturnType<typeof setTimeout>;
+}
+
+/** Fields the caller supplies to park a session (the pool arms the timer and state itself). */
+export interface ParkInput<E> {
+  key: string;
+  environment: E;
+  configFingerprint: string;
+  historyFingerprint: string;
+  credentialEpoch: CredentialEpoch;
+  destroy: () => Promise<void>;
+}
+
+/**
+ * A per-replica map of parked live sessions with an LRU cap and TTL reaping. Single-threaded
+ * (Node), so check-and-set on a key needs no lock. All teardown routes through the session's
+ * one idempotent `destroy`.
+ */
+export class SessionPool<E = unknown> {
+  private readonly sessions = new Map<string, LiveSession<E>>();
+
+  constructor(
+    private readonly config: Pick<KeepaliveConfig, "poolMax">,
+    private readonly logger: (message: string) => void = log,
+  ) {}
+
+  /** Peek without mutating. */
+  get(key: string): LiveSession<E> | undefined {
+    return this.sessions.get(key);
+  }
+
+  size(): number {
+    return this.sessions.size;
+  }
+
+  keys(): string[] {
+    return [...this.sessions.keys()];
+  }
+
+  /** Test/inspection snapshot: key -> state. */
+  snapshot(): Array<{ key: string; state: SessionState; lastUsed: number }> {
+    return [...this.sessions.values()].map((s) => ({
+      key: s.key,
+      state: s.state,
+      lastUsed: s.lastUsed,
+    }));
+  }
+
+  /**
+   * Check out an idle session for a continuation turn: clear its TTL timer, mark it busy, bump
+   * its LRU stamp, and return it. Returns undefined when the key is absent or not idle (a busy
+   * or awaiting_approval session is not checked out; the caller supersedes or falls to cold).
+   */
+  checkoutIdle(key: string): LiveSession<E> | undefined {
+    const session = this.sessions.get(key);
+    if (!session || session.state !== "idle") return undefined;
+    this.clearTimer(session);
+    session.state = "busy";
+    session.lastUsed = Date.now();
+    return session;
+  }
+
+  /**
+   * Return a checked-out (busy) session to idle after a successful continuation: refresh its
+   * fingerprints + credential epoch and re-arm the TTL timer, keeping the SAME live environment.
+   * Verifies identity so a session superseded mid-turn (its map slot taken by a racing turn) is
+   * NOT resurrected — returns false, and the caller tears its now-orphaned environment down.
+   */
+  repark(
+    session: LiveSession<E>,
+    update: {
+      configFingerprint: string;
+      historyFingerprint: string;
+      credentialEpoch: CredentialEpoch;
+    },
+    ttlMs: number,
+  ): boolean {
+    if (this.sessions.get(session.key) !== session) return false;
+    this.clearTimer(session);
+    session.configFingerprint = update.configFingerprint;
+    session.historyFingerprint = update.historyFingerprint;
+    session.credentialEpoch = update.credentialEpoch;
+    session.state = "idle";
+    session.lastUsed = Date.now();
+    session.ttlTimer = setTimeout(() => {
+      this.logger(`expire key=${session.key} (idle TTL ${ttlMs}ms)`);
+      void this.evict(session.key, "expire");
+    }, ttlMs);
+    session.ttlTimer.unref?.();
+    this.logger(
+      `park key=${session.key} ttl=${ttlMs}ms (re-park) poolSize=${this.sessions.size}`,
+    );
+    return true;
+  }
+
+  /**
+   * Best-effort park. LRU-evicts an idle entry when the pool is full; never evicts a busy or
+   * awaiting_approval session. If nothing evictable frees a slot, the session is NOT parked and
+   * the caller tears it down as today (parking is best-effort). Returns whether it parked.
+   */
+  park(input: ParkInput<E>, ttlMs: number): boolean {
+    // A supersede/re-park on the same key replaces any prior entry (destroy the old one first).
+    const existing = this.sessions.get(input.key);
+    if (existing) {
+      this.clearTimer(existing);
+      this.sessions.delete(input.key);
+      void this.safeDestroy(existing);
+    }
+
+    if (this.sessions.size >= this.config.poolMax && !this.evictLruIdle()) {
+      this.logger(
+        `park skipped (pool full, nothing idle to evict) key=${input.key}`,
+      );
+      return false;
+    }
+
+    const session: LiveSession<E> = {
+      key: input.key,
+      environment: input.environment,
+      configFingerprint: input.configFingerprint,
+      historyFingerprint: input.historyFingerprint,
+      credentialEpoch: input.credentialEpoch,
+      state: "idle",
+      lastUsed: Date.now(),
+      destroy: input.destroy,
+    };
+    session.ttlTimer = setTimeout(() => {
+      this.logger(`expire key=${input.key} (idle TTL ${ttlMs}ms)`);
+      void this.evict(input.key, "expire");
+    }, ttlMs);
+    // Do not let an idle TTL timer keep the process alive on its own.
+    session.ttlTimer.unref?.();
+    this.sessions.set(input.key, session);
+    this.logger(
+      `park key=${input.key} ttl=${ttlMs}ms poolSize=${this.sessions.size}`,
+    );
+    return true;
+  }
+
+  /**
+   * Remove a key and destroy it. Idempotent: a missing key is a no-op (resolves false).
+   * The returned promise resolves once the destroy completed, so a caller that reacquires the
+   * same key (same durable cwd / mount) MUST await it — the old teardown's unmount must not
+   * overlap the new acquire. Fire-and-forget callers (the TTL timer) `void` it.
+   * `reason` feeds the greppable `[keepalive] evict` log line.
+   */
+  async evict(key: string, reason: string): Promise<boolean> {
+    const session = this.sessions.get(key);
+    if (!session) return false;
+    this.clearTimer(session);
+    this.sessions.delete(key);
+    this.logger(`evict key=${key} reason=${reason}`);
+    await this.safeDestroy(session);
+    return true;
+  }
+
+  /**
+   * Identity-checked eviction for a session THIS caller checked out: removes the map entry only
+   * when the key still points at this exact session (a racing turn may have superseded it and
+   * parked its own session under the same key — that newer session must not be clobbered), then
+   * awaits the destroy of THIS session either way (its environment belongs to the caller and is
+   * dead; destroy is idempotent, so a supersede that already destroyed it is a no-op).
+   */
+  async evictIfCurrent(session: LiveSession<E>, reason: string): Promise<void> {
+    if (this.sessions.get(session.key) === session) {
+      this.clearTimer(session);
+      this.sessions.delete(session.key);
+      this.logger(`evict key=${session.key} reason=${reason}`);
+    }
+    await this.safeDestroy(session);
+  }
+
+  /** Remove a key and AWAIT its destroy. Idempotent. */
+  async destroy(key: string): Promise<void> {
+    const session = this.sessions.get(key);
+    if (!session) return;
+    this.clearTimer(session);
+    this.sessions.delete(key);
+    this.logger(`destroy key=${key}`);
+    await this.safeDestroy(session);
+  }
+
+  /**
+   * Destroy every parked session, timeout-bounded so it can never hang shutdown (mirrors
+   * `destroyInFlightSandboxes`). Drains the map first so a concurrent park cannot re-add.
+   */
+  async destroyAll(timeoutMs = 5000): Promise<void> {
+    const pending = [...this.sessions.values()];
+    this.sessions.clear();
+    if (pending.length === 0) return;
+    for (const session of pending) this.clearTimer(session);
+    this.logger(`destroyAll count=${pending.length}`);
+    const sweep = Promise.allSettled(
+      pending.map((session) => this.safeDestroy(session)),
+    );
+    await Promise.race([
+      sweep,
+      new Promise<void>((resolve) => setTimeout(resolve, timeoutMs)),
+    ]);
+  }
+
+  private evictLruIdle(): boolean {
+    let oldest: LiveSession<E> | undefined;
+    for (const session of this.sessions.values()) {
+      if (session.state !== "idle") continue;
+      if (!oldest || session.lastUsed < oldest.lastUsed) oldest = session;
+    }
+    if (!oldest) return false;
+    this.clearTimer(oldest);
+    this.sessions.delete(oldest.key);
+    this.logger(`evict key=${oldest.key} reason=lru`);
+    void this.safeDestroy(oldest);
+    return true;
+  }
+
+  private clearTimer(session: LiveSession<E>): void {
+    if (session.ttlTimer) {
+      clearTimeout(session.ttlTimer);
+      session.ttlTimer = undefined;
+    }
+  }
+
+  private async safeDestroy(session: LiveSession<E>): Promise<void> {
+    session.state = "destroyed";
+    try {
+      await session.destroy();
+    } catch (err) {
+      this.logger(
+        `destroy failed key=${session.key}: ${String(
+          err instanceof Error ? err.message : err,
+        ).slice(0, 200)}`,
+      );
+    }
+  }
+}

--- a/services/runner/src/server.ts
+++ b/services/runner/src/server.ts
@@ -30,9 +30,27 @@ import type {
 } from "./protocol.ts";
 import { resolvePromptText } from "./protocol.ts";
 import {
+  acquireEnvironment,
   destroyInFlightSandboxes,
+  resolveKeepaliveMount,
   runSandboxAgent,
+  runTurn,
+  type SessionEnvironment,
 } from "./engines/sandbox_agent.ts";
+import type { MountCredentials } from "./engines/sandbox_agent/mount.ts";
+import {
+  computeCredentialEpoch,
+  configFingerprint,
+  credentialEpochValid,
+  expectedNextHistoryFingerprint,
+  historyFingerprint,
+  poolKeyFor,
+  priorConversation,
+  readKeepaliveConfig,
+  SessionPool,
+  tailIsFreshUserMessage,
+  type KeepaliveConfig,
+} from "./engines/sandbox_agent/session-pool.ts";
 import { runnerInfo } from "./version.ts";
 import { isEntrypoint } from "./entry.ts";
 import { insecureEgressAllowed } from "./tools/ssrf-guard.ts";
@@ -106,11 +124,22 @@ function isAuthorized(req: IncomingMessage): boolean {
   return tokensMatch(presentedToken(req), expected);
 }
 
+/**
+ * Per-run flags the HTTP edge passes alongside the request. `clientGone` reports whether the
+ * streaming client has disconnected: session-owned runs survive disconnect (the run `signal` is
+ * deliberately NOT aborted), so the keep-alive park decision needs this separate channel to obey
+ * "disconnect means destroy, never park" (plan Q4).
+ */
+export interface RunAgentOptions {
+  clientGone?: () => boolean;
+}
+
 /** Run one request through an engine. Tests inject a fake to avoid a live harness. */
 export type RunAgent = (
   request: AgentRunRequest,
   emit?: EmitEvent,
   signal?: AbortSignal,
+  options?: RunAgentOptions,
 ) => Promise<AgentRunResult>;
 
 /**
@@ -180,10 +209,287 @@ async function persistSandboxId(
   }
 }
 
+// --- Session keep-alive dispatch (flag-gated OFF by default) ---------------- //
+
+function klog(message: string): void {
+  process.stderr.write(`[keepalive] ${message}\n`);
+}
+
+/**
+ * The engine seam the keep-alive dispatch drives. The default wires to the real engine; tests
+ * inject a fake to exercise the pool/dispatch policy without a live harness.
+ */
+export interface KeepaliveEngine {
+  /** Sign the session's durable mount once, up front. Null = no mount = never park. */
+  resolveKeepaliveMount(
+    request: AgentRunRequest,
+  ): Promise<MountCredentials | null>;
+  acquireEnvironment(
+    request: AgentRunRequest,
+    signal: AbortSignal | undefined,
+    presignedMount: MountCredentials | null,
+  ): Promise<
+    { ok: true; env: SessionEnvironment } | { ok: false; error: string }
+  >;
+  runTurn(
+    env: SessionEnvironment,
+    request: AgentRunRequest,
+    emit: EmitEvent | undefined,
+    signal: AbortSignal | undefined,
+    opts: { continuation?: boolean },
+  ): Promise<AgentRunResult>;
+  /**
+   * Today's cold path (acquire -> runTurn -> teardown). Used when a request must not park.
+   * `presignedMount` threads an already-signed mount in (null = signed, no mount — do not sign
+   * again; undefined = not signed — acquire signs itself), so the mount is signed exactly once.
+   */
+  runCold(
+    request: AgentRunRequest,
+    emit?: EmitEvent,
+    signal?: AbortSignal,
+    presignedMount?: MountCredentials | null,
+  ): Promise<AgentRunResult>;
+}
+
+const realKeepaliveEngine: KeepaliveEngine = {
+  resolveKeepaliveMount: (request) => resolveKeepaliveMount(request),
+  acquireEnvironment: (request, signal, presignedMount) =>
+    acquireEnvironment(request, {}, signal, presignedMount),
+  runTurn: (env, request, emit, signal, opts) =>
+    runTurn(env, request, emit, signal, opts),
+  // Same acquire -> runTurn -> destroy composition as `runSandboxAgent`, with the presigned
+  // mount threaded through so an up-front keep-alive sign is never repeated.
+  runCold: async (request, emit, signal, presignedMount) => {
+    const acquired = await acquireEnvironment(
+      request,
+      {},
+      signal,
+      presignedMount,
+    );
+    if (!acquired.ok) return { ok: false, error: acquired.error };
+    try {
+      return await runTurn(acquired.env, request, emit, signal, {});
+    } finally {
+      await acquired.env.destroy();
+    }
+  },
+};
+
+/**
+ * Whether a completed turn's environment may be parked: never on abort, client disconnect,
+ * pause, or failure. Session-owned streams survive disconnect WITHOUT aborting the run signal
+ * (server policy), so the disconnect check needs the separate `clientGone` flag.
+ */
+function shouldPark(
+  result: AgentRunResult,
+  signal: AbortSignal | undefined,
+  clientGone: (() => boolean) | undefined,
+): boolean {
+  if (signal?.aborted) return false; // aborted run: destroy, do not park
+  if (clientGone?.()) return false; // client disconnected mid-turn: destroy, do not park
+  if (!result.ok) return false; // failed turn: teardown as today
+  if (result.stopReason === "paused") return false; // slice 1 never parks a paused session
+  return true;
+}
+
+export interface KeepaliveContext {
+  engine: KeepaliveEngine;
+  pool: SessionPool<SessionEnvironment>;
+  config: KeepaliveConfig;
+  /** Reports a mid-turn client disconnect on the streaming edge (see `RunAgentOptions`). */
+  clientGone?: () => boolean;
+}
+
+/**
+ * True when the request resolves to exactly the `local` provider (the same resolution
+ * `buildRunPlan` uses). Keep-alive is local-only in slice 1, and an unknown/future REMOTE
+ * provider must fail closed to cold rather than park, so anything not literally "local" is out.
+ */
+function isLocalSandbox(request: AgentRunRequest): boolean {
+  const provider =
+    request.sandbox || process.env.SANDBOX_AGENT_PROVIDER || "local";
+  return provider === "local";
+}
+
+/**
+ * Keep-alive dispatch. A pool hit whose fingerprints + credential epoch match and whose tail is
+ * a fresh user message continues the live environment (`runTurn` with `continuation`); anything
+ * else (miss, mismatch, busy, no mount, remote) evicts as needed and runs today's cold path.
+ * A validation failure never fails the turn: it degrades to cold.
+ */
+export async function runWithKeepalive(
+  request: AgentRunRequest,
+  emit: EmitEvent | undefined,
+  signal: AbortSignal | undefined,
+  ctx: KeepaliveContext,
+): Promise<AgentRunResult> {
+  const { engine, pool, config, clientGone } = ctx;
+  const sessionId = request.sessionId?.trim();
+
+  // Eligibility: session-owned + local sandbox. Otherwise never park; run cold as today
+  // (no up-front sign happened, so the cold path signs itself: still exactly once).
+  if (!sessionId || !isLocalSandbox(request)) {
+    return engine.runCold(request, emit, signal);
+  }
+
+  // Sign the mount once, up front. The mount's owning project is the only trustworthy project
+  // scope; no mount (store unconfigured, 503) or no projectId => no safe pool key => never park,
+  // and the sign result — null included — is threaded into the cold path so it never re-signs.
+  let signed: MountCredentials | null | undefined;
+  try {
+    signed = await engine.resolveKeepaliveMount(request);
+  } catch {
+    signed = undefined; // sign attempt failed outright: let the cold acquire retry it
+  }
+  const key = poolKeyFor(request, signed?.projectId);
+  if (!key) {
+    klog(`miss (no mount project scope) session=${sessionId}; cold`);
+    return engine.runCold(request, emit, signal, signed);
+  }
+  const mountCreds = signed!;
+
+  const cfgFp = configFingerprint(request);
+  const incomingEpoch = computeCredentialEpoch(request, mountCreds.expiresAt);
+
+  const coldAndPark = async (): Promise<AgentRunResult> => {
+    const acq = await engine.acquireEnvironment(request, signal, mountCreds);
+    if (!acq.ok) return { ok: false, error: acq.error };
+    const env = acq.env;
+    let result: AgentRunResult;
+    try {
+      result = await engine.runTurn(env, request, emit, signal, {});
+    } catch (err) {
+      await env.destroy();
+      return {
+        ok: false,
+        error: String(err instanceof Error ? err.message : err),
+      };
+    }
+    // Record/settle pending state (none in slice 1) then clear the sink before parking.
+    env.clearTurn();
+    if (shouldPark(result, signal, clientGone)) {
+      const parked = pool.park(
+        {
+          key,
+          environment: env,
+          configFingerprint: cfgFp,
+          historyFingerprint: expectedNextHistoryFingerprint(
+            request.messages ?? [],
+            env.lastTurnToolCallIds ?? [],
+          ),
+          credentialEpoch: incomingEpoch,
+          destroy: env.destroy,
+        },
+        config.ttlMs,
+      );
+      if (!parked) await env.destroy();
+    } else {
+      await env.destroy();
+    }
+    return result;
+  };
+
+  const existing = pool.get(key);
+  if (existing && existing.state === "idle") {
+    // Validate the continuation. Any failure evicts and degrades to cold; never fails the turn.
+    const priorFp = historyFingerprint(priorConversation(request));
+    let mismatch: string | undefined;
+    if (cfgFp !== existing.configFingerprint) mismatch = "config";
+    else if (priorFp !== existing.historyFingerprint) mismatch = "history";
+    else if (!credentialEpochValid(existing.credentialEpoch, incomingEpoch))
+      mismatch = "credentials";
+    else if (!tailIsFreshUserMessage(request)) mismatch = "tail";
+
+    if (mismatch) {
+      klog(`mismatch (${mismatch}) key=${key}; evict + cold`);
+      // Await: the old teardown unmounts the same durable cwd the cold acquire is about to
+      // mount — they must never overlap.
+      await pool.evict(key, `mismatch:${mismatch}`);
+      return coldAndPark();
+    }
+
+    const live = pool.checkoutIdle(key);
+    if (live) {
+      klog(`hit-continue key=${key}`);
+      let result: AgentRunResult;
+      try {
+        result = await engine.runTurn(live.environment, request, emit, signal, {
+          continuation: true,
+        });
+      } catch (err) {
+        // A continuation that throws destroys the session and retries once cold. Identity-checked
+        // (a racing turn may have superseded this slot and parked its own session — never clobber
+        // it) and awaited (the teardown's unmount must finish before the cold acquire remounts).
+        klog(`evict (continuation-threw) key=${key}; retry cold`);
+        live.environment.clearTurn();
+        await pool.evictIfCurrent(live, "continuation-threw");
+        void err;
+        return coldAndPark();
+      }
+      if (!result.ok) {
+        // A failed continuation may mean a broken live session: destroy and retry once cold
+        // (identity-checked + awaited, same as the throw path above).
+        klog(`evict (continuation-failed) key=${key}; retry cold`);
+        live.environment.clearTurn();
+        await pool.evictIfCurrent(live, "continuation-failed");
+        return coldAndPark();
+      }
+      live.environment.clearTurn();
+      if (shouldPark(result, signal, clientGone)) {
+        const reparked = pool.repark(
+          live,
+          {
+            configFingerprint: cfgFp,
+            historyFingerprint: expectedNextHistoryFingerprint(
+              request.messages ?? [],
+              live.environment.lastTurnToolCallIds ?? [],
+            ),
+            credentialEpoch: incomingEpoch,
+          },
+          config.ttlMs,
+        );
+        if (!reparked) await live.destroy();
+      } else {
+        await pool.evictIfCurrent(
+          live,
+          `no-park:${result.stopReason ?? "failed"}`,
+        );
+      }
+      return result;
+    }
+    // checkout lost a race; fall through to cold.
+  } else if (existing) {
+    // Busy / awaiting_approval / destroyed: two turns racing one session. Supersede (destroy the
+    // parked one, cold-start the new turn) — awaited so its teardown cannot overlap our acquire.
+    klog(`evict (supersede-${existing.state}) key=${key}; cold`);
+    await pool.evict(key, `supersede-${existing.state}`);
+  } else {
+    klog(`miss key=${key}; cold`);
+  }
+
+  return coldAndPark();
+}
+
 // One engine: `sandbox-agent` drives a harness (Pi or Claude) over ACP. The harness is
 // selected by `request.harness`, not by an engine selector.
-const runAgent: RunAgent = (request, emit, signal) =>
-  runSandboxAgent(request, emit, signal);
+//
+// The keep-alive pool is a single per-replica singleton, consulted only when the flag is on.
+// With the flag off (default) the pool is never touched and the dispatch is byte-identical to
+// today (`runSandboxAgent`). `/kill` and shutdown drain it through `destroyAll`.
+const keepalivePool = new SessionPool<SessionEnvironment>(
+  readKeepaliveConfig(),
+);
+
+const runAgent: RunAgent = (request, emit, signal, options) => {
+  const config = readKeepaliveConfig();
+  if (!config.enabled) return runSandboxAgent(request, emit, signal);
+  return runWithKeepalive(request, emit, signal, {
+    engine: realKeepaliveEngine,
+    pool: keepalivePool,
+    config,
+    clientGone: options?.clientGone,
+  });
+};
 
 /**
  * Stream a run as NDJSON: one `{kind:"event"}` line per event the moment it is built, then
@@ -237,12 +543,22 @@ async function runAndStreamWithApiBaseResolved(
   // Session-owned runs survive client disconnect — the runner owns the run. Non-session
   // runs abort on disconnect (original behavior: caller drives, disconnect = cancel).
   const controller = new AbortController();
+  let clientDisconnected = false;
   if (!sessionOwned) {
     // Listen on the response, not the request: the request body is already fully read, so
     // its `close` can fire early on a keep-alive connection. `res` `close` fires when the
     // response connection ends — after a normal `res.end()` (harmless: the run is already
     // done) or when the client drops mid-stream (the case we want to cancel).
     res.on("close", () => controller.abort());
+  } else {
+    // Session-owned: the run signal is deliberately NOT aborted (the run must survive the
+    // disconnect and finish), but keep-alive's park decision must still see the disconnect —
+    // a disconnected client's session is destroyed at turn end, never parked (plan Q4). The
+    // flag is only read while the run is in flight, so the close that follows a normal
+    // `res.end()` (after the run resolved) can never affect a park decision.
+    res.on("close", () => {
+      clientDisconnected = true;
+    });
   }
 
   const writeRecord = (record: StreamRecord): void => {
@@ -296,7 +612,9 @@ async function runAndStreamWithApiBaseResolved(
 
   let result: AgentRunResult;
   try {
-    result = await run(request, emitFn, controller.signal);
+    result = await run(request, emitFn, controller.signal, {
+      clientGone: () => clientDisconnected,
+    });
     // A failed engine run ({ok:false}) already emitted its own error EVENT through the
     // persisting emitter (see sandbox_agent.ts), so no extra persist here (it would
     // duplicate the record).
@@ -304,7 +622,7 @@ async function runAndStreamWithApiBaseResolved(
     if (flushPersist) await flushPersist();
   } catch (err) {
     const message =
-      err instanceof Error ? err.stack ?? err.message : String(err);
+      err instanceof Error ? (err.stack ?? err.message) : String(err);
     // A throw escaping run() itself (outside the engine's own try/catch) emitted no error
     // event — persist it here as the backstop.
     if (persistError) persistError(message);
@@ -353,7 +671,10 @@ export function createRequestListener(
         }
         // Idempotent, best-effort: the API collapses the alive lock (the runner's
         // per-run finally then destroys its own sandbox); this endpoint lets the
-        // orphan sweeper force a process-wide teardown out-of-band. Always ok.
+        // orphan sweeper force a process-wide teardown out-of-band. Drain the keep-alive
+        // pool first (its complete per-session destroy), then the sandbox registry as a
+        // second line of defense. Always ok.
+        await keepalivePool.destroyAll();
         await destroyInFlightSandboxes();
         return send(res, 200, { ok: true });
       }
@@ -416,7 +737,7 @@ export function createRequestListener(
       return send(res, 404, { ok: false, error: "Not found" });
     } catch (err) {
       const message =
-        err instanceof Error ? err.stack ?? err.message : String(err);
+        err instanceof Error ? (err.stack ?? err.message) : String(err);
       return send(res, 500, { ok: false, error: message });
     }
   };
@@ -474,7 +795,7 @@ if (isEntrypoint(import.meta.url)) {
   // run still returns its own error to its caller.
   process.on("unhandledRejection", (reason) => {
     process.stderr.write(
-      `[sandbox-agent] unhandledRejection: ${reason instanceof Error ? reason.stack ?? reason.message : String(reason)}\n`,
+      `[sandbox-agent] unhandledRejection: ${reason instanceof Error ? (reason.stack ?? reason.message) : String(reason)}\n`,
     );
   });
   process.on("uncaughtException", (err) => {
@@ -483,10 +804,15 @@ if (isEntrypoint(import.meta.url)) {
     );
   });
 
-  // On `docker stop` (SIGTERM) / Ctrl-C (SIGINT), delete any sandbox a run created before the
-  // process exits, so a kill mid-run does not leak the sandbox (the per-run `finally` never
-  // runs when the process is killed).
-  registerShutdownHandler();
+  // On `docker stop` (SIGTERM) / Ctrl-C (SIGINT), drain the keep-alive pool (its complete
+  // per-session destroy) and then delete any sandbox a run created, so a kill does not leak a
+  // parked session or an in-flight sandbox (the per-run teardown never runs on a process kill).
+  registerShutdownHandler({
+    onCleanup: async (timeoutMs?: number) => {
+      await keepalivePool.destroyAll(timeoutMs);
+      await destroyInFlightSandboxes(timeoutMs);
+    },
+  });
 
   createAgentServer().listen(PORT, HOST, () => {
     process.stderr.write(

--- a/services/runner/tests/unit/server.test.ts
+++ b/services/runner/tests/unit/server.test.ts
@@ -192,6 +192,19 @@ describe("createAgentServer", () => {
     }
   });
 
+  it("POST /kill drains the pool + sandboxes and returns 200 (idempotent)", async () => {
+    // With keep-alive off (default) the pool is empty, so the drain is a no-op that still 200s.
+    const s = await listen(okRun);
+    try {
+      const res = await fetch(`${s.url}/kill`, { method: "POST" });
+      assert.equal(res.status, 200);
+      const body = (await res.json()) as { ok: boolean };
+      assert.equal(body.ok, true);
+    } finally {
+      await s.close();
+    }
+  });
+
   it("NDJSON stream: events first, then exactly one terminal result with no echoed events", async () => {
     const streamRun: RunAgent = async (_req, emit) => {
       emit?.({ type: "message", text: "a" });

--- a/services/runner/tests/unit/session-keepalive-dispatch.test.ts
+++ b/services/runner/tests/unit/session-keepalive-dispatch.test.ts
@@ -1,0 +1,626 @@
+/**
+ * Unit tests for the keep-alive dispatch (`runWithKeepalive`) via a fake engine seam.
+ *
+ * The dispatch owns the pool policy: continue a live environment on a validated hit, otherwise
+ * evict as needed and run the cold path. These tests inject a fake `KeepaliveEngine` (no live
+ * harness) and a real `SessionPool`, so they exercise the real orchestration + pool.
+ *
+ * Run: pnpm test (or: pnpm exec vitest run tests/unit/session-keepalive-dispatch.test.ts)
+ */
+import { describe, it } from "vitest";
+import assert from "node:assert/strict";
+
+import type { AgentRunRequest, AgentRunResult } from "../../src/protocol.ts";
+import {
+  runWithKeepalive,
+  type KeepaliveContext,
+  type KeepaliveEngine,
+} from "../../src/server.ts";
+import {
+  SessionPool,
+  type KeepaliveConfig,
+} from "../../src/engines/sandbox_agent/session-pool.ts";
+import type { MountCredentials } from "../../src/engines/sandbox_agent/mount.ts";
+import type { SessionEnvironment } from "../../src/engines/sandbox_agent.ts";
+
+function flush(): Promise<void> {
+  return new Promise((resolve) => setImmediate(resolve));
+}
+
+interface EngineOptions {
+  mountProjectId?: string | null; // null => the signed mount carries no project id
+  signReturnsNull?: boolean; // resolveKeepaliveMount resolves null (no mount at all)
+  mountExpiresAt?: string;
+  /** Per-call runTurn results (by 0-based call index); default ok/complete. */
+  turnResults?: AgentRunResult[];
+  /** Per-call emitted tool-call ids the fake runTurn records on the env (by call index). */
+  turnToolCallIds?: string[][];
+}
+
+interface FakeEnv {
+  id: number;
+  destroyed: number;
+  turnsCleared: number;
+  lastTurnToolCallIds: string[];
+  clearTurn: () => void;
+  /** Replaceable body so a test can slow the teardown down; `destroy` stays a stable closure. */
+  destroyImpl: () => Promise<void>;
+  destroy: () => Promise<void>;
+}
+
+function makeEngine(options: EngineOptions = {}) {
+  const calls = {
+    resolveMount: 0,
+    acquire: 0,
+    cold: 0,
+    coldPresigned: [] as Array<MountCredentials | null | undefined>,
+    turns: [] as Array<{
+      env: FakeEnv;
+      continuation: boolean;
+    }>,
+    acquiredEnvs: [] as FakeEnv[],
+  };
+
+  let nextEnvId = 1;
+  const makeEnv = (): FakeEnv => {
+    const env: FakeEnv = {
+      id: nextEnvId++,
+      destroyed: 0,
+      turnsCleared: 0,
+      lastTurnToolCallIds: [],
+      clearTurn: () => {
+        env.turnsCleared += 1;
+      },
+      destroyImpl: async () => {
+        env.destroyed += 1;
+      },
+      // Stable closure delegating to the replaceable body — the pool captures `destroy` at
+      // park time, so a test that swaps `destroyImpl` later still takes effect.
+      destroy: () => env.destroyImpl(),
+    };
+    return env;
+  };
+
+  const signedMount = (): MountCredentials => ({
+    region: "us-east-1",
+    bucket: "b",
+    prefix: "mounts/proj/mount",
+    accessKey: "AK",
+    secretKey: "SK",
+    expiresAt: options.mountExpiresAt,
+    projectId:
+      options.mountProjectId === null
+        ? undefined
+        : (options.mountProjectId ?? "proj-1"),
+  });
+
+  const runOneTurn = async (
+    env: FakeEnv,
+    continuation: boolean,
+  ): Promise<AgentRunResult> => {
+    const idx = calls.turns.length;
+    calls.turns.push({ env, continuation });
+    env.lastTurnToolCallIds = options.turnToolCallIds?.[idx] ?? [];
+    return (
+      options.turnResults?.[idx] ?? {
+        ok: true,
+        output: "ok",
+        stopReason: "complete",
+      }
+    );
+  };
+
+  const engine: KeepaliveEngine = {
+    async resolveKeepaliveMount(_request) {
+      calls.resolveMount += 1;
+      if (options.signReturnsNull) return null;
+      return signedMount();
+    },
+    async acquireEnvironment(_request, _signal, _presigned) {
+      calls.acquire += 1;
+      const env = makeEnv();
+      calls.acquiredEnvs.push(env);
+      return { ok: true, env: env as unknown as SessionEnvironment };
+    },
+    async runTurn(env, _request, _emit, _signal, opts) {
+      return runOneTurn(env as unknown as FakeEnv, !!opts.continuation);
+    },
+    async runCold(_request, _emit, _signal, presignedMount) {
+      calls.cold += 1;
+      calls.coldPresigned.push(presignedMount);
+      return { ok: true, output: "cold", stopReason: "complete" };
+    },
+  };
+
+  return { engine, calls };
+}
+
+function makeCtx(
+  engine: KeepaliveEngine,
+  overrides: Partial<KeepaliveConfig> = {},
+  clientGone?: () => boolean,
+) {
+  const config: KeepaliveConfig = {
+    enabled: true,
+    ttlMs: 60_000,
+    approvalTtlMs: 600_000,
+    poolMax: 8,
+    ...overrides,
+  };
+  const pool = new SessionPool<SessionEnvironment>(
+    { poolMax: config.poolMax },
+    () => {},
+  );
+  return { engine, pool, config, clientGone } satisfies KeepaliveContext;
+}
+
+const auth = {
+  telemetry: {
+    exporters: { otlp: { headers: { authorization: "ApiKey run" } } },
+  },
+};
+
+function turn1(sessionId = "s1"): AgentRunRequest {
+  return {
+    harness: "claude",
+    model: "m1",
+    sessionId,
+    ...auth,
+    messages: [{ role: "user", content: "hello" }],
+  };
+}
+
+// A plain continuation: turn-1 conversation + an (empty) assistant turn + a new user message.
+function turn2(
+  sessionId = "s1",
+  overrides: Partial<AgentRunRequest> = {},
+): AgentRunRequest {
+  return {
+    harness: "claude",
+    model: "m1",
+    sessionId,
+    ...auth,
+    messages: [
+      { role: "user", content: "hello" },
+      { role: "assistant", content: "hi" },
+      { role: "user", content: "more" },
+    ],
+    ...overrides,
+  };
+}
+
+describe("runWithKeepalive: park + hit", () => {
+  it("parks after a cold miss and continues the SAME env on the next turn (no re-acquire)", async () => {
+    const { engine, calls } = makeEngine();
+    const ctx = makeCtx(engine);
+
+    const r1 = await runWithKeepalive(turn1(), undefined, undefined, ctx);
+    assert.equal(r1.ok, true);
+    assert.equal(calls.acquire, 1, "cold miss acquires once");
+    assert.equal(calls.turns[0].continuation, false, "cold turn replays");
+    assert.equal(ctx.pool.size(), 1, "the successful turn parked");
+
+    const r2 = await runWithKeepalive(turn2(), undefined, undefined, ctx);
+    assert.equal(r2.ok, true);
+    assert.equal(calls.acquire, 1, "the continuation does NOT re-acquire");
+    assert.equal(calls.turns.length, 2);
+    assert.equal(
+      calls.turns[1].continuation,
+      true,
+      "the continuation sends only the new text",
+    );
+    assert.equal(
+      calls.turns[1].env,
+      calls.turns[0].env,
+      "the second turn runs on the same live environment",
+    );
+    assert.equal(
+      calls.acquiredEnvs[0].destroyed,
+      0,
+      "the live env is kept alive, not destroyed",
+    );
+    assert.equal(ctx.pool.size(), 1, "re-parked for the next turn");
+  });
+
+  it("a tool-using turn parks and the FE's next request (assistant tool parts kept) HITS live", async () => {
+    // The FE keeps an assistant turn iff it has an answer part; tool parts count, so a
+    // tool-calling turn's ids ALWAYS come back in the next request. The park folds the emitted
+    // ids into the expected fingerprint, so this — the feature's main audience — continues live.
+    const { engine, calls } = makeEngine({
+      turnToolCallIds: [["tc-1", "tc-2"]],
+    });
+    const ctx = makeCtx(engine);
+
+    await runWithKeepalive(turn1(), undefined, undefined, ctx);
+    assert.equal(ctx.pool.size(), 1, "the tool-using turn parked");
+
+    // The next request as the FE would send it: the assistant turn carries the tool parts
+    // (each folding to a tool_call + tool_result block pair sharing the id) plus text.
+    const next = turn2("s1", {
+      messages: [
+        { role: "user", content: "hello" },
+        {
+          role: "assistant",
+          content: [
+            { type: "tool_call", toolCallId: "tc-1", toolName: "read" },
+            { type: "tool_result", toolCallId: "tc-1", output: "a" },
+            { type: "tool_call", toolCallId: "tc-2", toolName: "edit" },
+            { type: "tool_result", toolCallId: "tc-2", output: "b" },
+            { type: "text", text: "done" },
+          ],
+        },
+        { role: "user", content: "more" },
+      ],
+    });
+    const r2 = await runWithKeepalive(next, undefined, undefined, ctx);
+    assert.equal(r2.ok, true);
+    assert.equal(
+      calls.acquire,
+      1,
+      "the tool-turn continuation did NOT re-acquire",
+    );
+    assert.equal(calls.turns[1].continuation, true, "continued live");
+    assert.equal(calls.turns[1].env, calls.turns[0].env);
+  });
+
+  it("an emitted-id mismatch (history edited or ids diverged) still evicts to cold", async () => {
+    const { engine, calls } = makeEngine({
+      turnToolCallIds: [["tc-1", "tc-2"]],
+    });
+    const ctx = makeCtx(engine);
+    await runWithKeepalive(turn1(), undefined, undefined, ctx);
+    const env1 = calls.acquiredEnvs[0];
+
+    const next = turn2("s1", {
+      messages: [
+        { role: "user", content: "hello" },
+        {
+          role: "assistant",
+          content: [
+            { type: "tool_call", toolCallId: "tc-1", toolName: "read" },
+            { type: "tool_call", toolCallId: "tc-DIFFERENT", toolName: "edit" },
+          ],
+        },
+        { role: "user", content: "more" },
+      ],
+    });
+    const r2 = await runWithKeepalive(next, undefined, undefined, ctx);
+    assert.equal(r2.ok, true);
+    assert.equal(env1.destroyed, 1, "the mismatched live env is destroyed");
+    assert.equal(calls.acquire, 2, "cold-started a fresh env");
+  });
+
+  it("a fully empty assistant turn pruned by the FE still hits (no ids, no text)", async () => {
+    // The park predicted no ids (the turn emitted none); the FE prunes the answer-less
+    // assistant turn, so the next request carries neither text nor ids for it. Deterministic hit.
+    const { engine, calls } = makeEngine();
+    const ctx = makeCtx(engine);
+    await runWithKeepalive(turn1(), undefined, undefined, ctx);
+
+    const prunedNext = turn2("s1", {
+      messages: [
+        { role: "user", content: "hello" },
+        { role: "user", content: "more" },
+      ],
+    });
+    const r2 = await runWithKeepalive(prunedNext, undefined, undefined, ctx);
+    assert.equal(r2.ok, true);
+    assert.equal(
+      calls.acquire,
+      1,
+      "the pruned continuation did NOT re-acquire",
+    );
+    assert.equal(calls.turns[1].continuation, true);
+  });
+
+  it("a different session id misses and cold-starts a separate env", async () => {
+    const { engine, calls } = makeEngine();
+    const ctx = makeCtx(engine);
+
+    await runWithKeepalive(turn1("sA"), undefined, undefined, ctx);
+    await runWithKeepalive(turn2("sB"), undefined, undefined, ctx);
+
+    assert.equal(calls.acquire, 2, "different session ids each cold-start");
+    assert.equal(
+      calls.turns.every((t) => t.continuation === false),
+      true,
+    );
+    assert.equal(ctx.pool.size(), 2);
+  });
+});
+
+describe("runWithKeepalive: validation mismatches degrade to cold", () => {
+  async function parkThen(
+    second: AgentRunRequest,
+    engineOpts: EngineOptions = {},
+  ) {
+    const { engine, calls } = makeEngine(engineOpts);
+    const ctx = makeCtx(engine);
+    await runWithKeepalive(turn1(), undefined, undefined, ctx);
+    const env1 = calls.acquiredEnvs[0];
+    await runWithKeepalive(second, undefined, undefined, ctx);
+    await flush();
+    return { calls, ctx, env1 };
+  }
+
+  it("config fingerprint mismatch evicts the live env and cold-starts", async () => {
+    const { calls, env1 } = await parkThen(turn2("s1", { model: "m2" }));
+    assert.equal(env1.destroyed, 1, "the mismatched live env is destroyed");
+    assert.equal(calls.acquire, 2, "cold-started a fresh env");
+  });
+
+  it("history fingerprint mismatch (edited history) evicts to cold", async () => {
+    const edited = turn2("s1", {
+      messages: [
+        { role: "user", content: "HELLO EDITED" },
+        { role: "assistant", content: "hi" },
+        { role: "user", content: "more" },
+      ],
+    });
+    const { calls, env1 } = await parkThen(edited);
+    assert.equal(env1.destroyed, 1);
+    assert.equal(calls.acquire, 2);
+  });
+
+  it("credential-epoch expiry evicts to cold", async () => {
+    // The parked mount expiry is in the past, so the next turn's epoch check fails.
+    const { calls, env1 } = await parkThen(turn2(), {
+      mountExpiresAt: "2000-01-01T00:00:00.000Z",
+    });
+    assert.equal(env1.destroyed, 1, "expired-credential session is destroyed");
+    assert.equal(calls.acquire, 2);
+  });
+
+  it("a changed secret value evicts to cold (same config, same history)", async () => {
+    const withSecret = turn2("s1", {
+      secrets: { ANTHROPIC_API_KEY: "rotated" },
+    });
+    const { engine, calls } = makeEngine();
+    const ctx = makeCtx(engine);
+    // Turn 1 with the original secret.
+    await runWithKeepalive(turn1(), undefined, undefined, ctx);
+    const env1 = calls.acquiredEnvs[0];
+    await runWithKeepalive(withSecret, undefined, undefined, ctx);
+    await flush();
+    assert.equal(
+      env1.destroyed,
+      1,
+      "a rotated secret invalidates the parked epoch",
+    );
+    assert.equal(calls.acquire, 2);
+  });
+
+  it("an approval-reply tail (not a fresh user message) stays cold", async () => {
+    const approvalTail = turn2("s1", {
+      messages: [
+        { role: "user", content: "hello" },
+        { role: "assistant", content: "hi" },
+        {
+          role: "user",
+          content: [
+            { type: "text", text: "ok" },
+            {
+              type: "tool_result",
+              toolCallId: "tc-1",
+              output: { approved: true },
+            },
+          ],
+        },
+      ],
+    });
+    const { calls, env1 } = await parkThen(approvalTail);
+    assert.equal(env1.destroyed, 1);
+    assert.equal(calls.acquire, 2);
+  });
+});
+
+describe("runWithKeepalive: never-park rules", () => {
+  it("no mount at all => never parks; runs cold with the null sign threaded (no re-sign)", async () => {
+    const { engine, calls } = makeEngine({ signReturnsNull: true });
+    const ctx = makeCtx(engine);
+    const r = await runWithKeepalive(turn1(), undefined, undefined, ctx);
+    assert.equal(r.output, "cold");
+    assert.equal(calls.resolveMount, 1, "signed exactly once");
+    assert.equal(calls.cold, 1);
+    assert.equal(
+      calls.coldPresigned[0],
+      null,
+      "the null sign result is threaded so the cold acquire does not sign again",
+    );
+    assert.equal(calls.acquire, 0);
+    assert.equal(ctx.pool.size(), 0, "nothing parked without a safe key");
+  });
+
+  it("a mount without a project id => never parks; the presigned creds are threaded (single sign)", async () => {
+    const { engine, calls } = makeEngine({ mountProjectId: null });
+    const ctx = makeCtx(engine);
+    const r = await runWithKeepalive(turn1(), undefined, undefined, ctx);
+    assert.equal(r.output, "cold");
+    assert.equal(calls.resolveMount, 1, "signed exactly once");
+    assert.equal(calls.cold, 1);
+    assert.ok(
+      calls.coldPresigned[0],
+      "the signed creds are threaded into the cold path",
+    );
+    assert.equal(calls.coldPresigned[0]?.accessKey, "AK");
+    assert.equal(ctx.pool.size(), 0);
+  });
+
+  it("a request without a session id runs cold, never parks", async () => {
+    const { engine, calls } = makeEngine();
+    const ctx = makeCtx(engine);
+    await runWithKeepalive(
+      { ...turn1(), sessionId: undefined },
+      undefined,
+      undefined,
+      ctx,
+    );
+    assert.equal(calls.cold, 1);
+    assert.equal(
+      calls.resolveMount,
+      0,
+      "eligibility is checked before signing",
+    );
+    assert.equal(
+      calls.coldPresigned[0],
+      undefined,
+      "no up-front sign happened, so the cold acquire signs itself (still once)",
+    );
+    assert.equal(ctx.pool.size(), 0);
+  });
+
+  it("a daytona (remote) sandbox runs cold, never parks", async () => {
+    const { engine, calls } = makeEngine();
+    const ctx = makeCtx(engine);
+    await runWithKeepalive(
+      { ...turn1(), sandbox: "daytona" },
+      undefined,
+      undefined,
+      ctx,
+    );
+    assert.equal(calls.cold, 1);
+    assert.equal(ctx.pool.size(), 0);
+  });
+
+  it("an unknown (future remote) provider fails closed to cold, never parks", async () => {
+    // The local-only gate keys on provider === "local" exactly, so a NEW remote provider
+    // (e2b et al.) cannot silently opt into parking before its lifecycle is proven.
+    const { engine, calls } = makeEngine();
+    const ctx = makeCtx(engine);
+    await runWithKeepalive(
+      { ...turn1(), sandbox: "e2b" },
+      undefined,
+      undefined,
+      ctx,
+    );
+    assert.equal(calls.cold, 1);
+    assert.equal(calls.resolveMount, 0);
+    assert.equal(ctx.pool.size(), 0);
+  });
+
+  it("a paused turn is NOT parked in slice 1 (destroyed as today)", async () => {
+    const { engine, calls } = makeEngine({
+      turnResults: [{ ok: true, stopReason: "paused" }],
+    });
+    const ctx = makeCtx(engine);
+    await runWithKeepalive(turn1(), undefined, undefined, ctx);
+    await flush();
+    assert.equal(calls.acquire, 1);
+    assert.equal(
+      calls.acquiredEnvs[0].destroyed,
+      1,
+      "a paused session is torn down, not parked",
+    );
+    assert.equal(ctx.pool.size(), 0);
+  });
+
+  it("an aborted run signal is not parked (destroy, do not park)", async () => {
+    const { engine, calls } = makeEngine();
+    const ctx = makeCtx(engine);
+    const controller = new AbortController();
+    controller.abort();
+    await runWithKeepalive(turn1(), undefined, controller.signal, ctx);
+    await flush();
+    assert.equal(calls.acquiredEnvs[0].destroyed, 1);
+    assert.equal(ctx.pool.size(), 0);
+  });
+
+  it("a session-owned client disconnect (clientGone, signal NOT aborted) completes the turn but is NOT parked", async () => {
+    // Session-owned streams survive disconnect: the run signal is never aborted, so the park
+    // decision consults the separate clientGone flag the HTTP edge flips on response close.
+    let gone = false;
+    const { engine, calls } = makeEngine();
+    const ctx = makeCtx(engine, {}, () => gone);
+    // The client drops mid-turn: the flag flips while the turn is in flight.
+    const origRunTurn = engine.runTurn.bind(engine);
+    engine.runTurn = async (env, request, emit, signal, opts) => {
+      gone = true; // disconnect lands during the turn
+      return origRunTurn(env, request, emit, signal, opts);
+    };
+    const r = await runWithKeepalive(turn1(), undefined, undefined, ctx);
+    await flush();
+    assert.equal(r.ok, true, "the turn still completes as today");
+    assert.equal(
+      calls.acquiredEnvs[0].destroyed,
+      1,
+      "the disconnected client's session is destroyed, not parked",
+    );
+    assert.equal(ctx.pool.size(), 0);
+  });
+});
+
+describe("runWithKeepalive: races and failures", () => {
+  it("a busy session is superseded (destroyed, awaited) and the new turn cold-starts", async () => {
+    const { engine, calls } = makeEngine();
+    const ctx = makeCtx(engine);
+    await runWithKeepalive(turn1(), undefined, undefined, ctx);
+    const env1 = calls.acquiredEnvs[0];
+    // Simulate an in-flight turn on the same session by checking the session out (busy).
+    const key = "proj-1:s1";
+    ctx.pool.checkoutIdle(key);
+    assert.equal(ctx.pool.get(key)!.state, "busy");
+
+    await runWithKeepalive(turn2(), undefined, undefined, ctx);
+    assert.equal(
+      env1.destroyed,
+      1,
+      "the busy (racing) session is superseded/destroyed (awaited, no flush needed)",
+    );
+    assert.equal(calls.acquire, 2, "the new turn cold-starts");
+  });
+
+  it("a continuation that returns a failed result destroys the session and retries once cold", async () => {
+    const { engine, calls } = makeEngine({
+      // turn 0 (cold) ok; turn 1 (continuation) fails; turn 2 (cold retry) ok.
+      turnResults: [
+        { ok: true, stopReason: "complete" },
+        { ok: false, error: "session died" },
+        { ok: true, output: "recovered", stopReason: "complete" },
+      ],
+    });
+    const ctx = makeCtx(engine);
+    await runWithKeepalive(turn1(), undefined, undefined, ctx);
+    const env1 = calls.acquiredEnvs[0];
+    const r2 = await runWithKeepalive(turn2(), undefined, undefined, ctx);
+    assert.equal(env1.destroyed, 1, "the broken live session is destroyed");
+    assert.equal(calls.acquire, 2, "retried once cold");
+    assert.equal(r2.ok, true);
+    assert.equal(r2.output, "recovered");
+    assert.equal(ctx.pool.size(), 1, "the cold retry re-parked");
+  });
+
+  it("eviction before a cold reacquire is AWAITED (teardown cannot overlap the new acquire)", async () => {
+    // The mismatch path evicts the old env (unmounting the shared durable cwd) and then
+    // cold-starts the same key. The acquire must observe the destroy as already complete.
+    let destroyResolved = false;
+    const { engine, calls } = makeEngine();
+    const ctx = makeCtx(engine);
+    await runWithKeepalive(turn1(), undefined, undefined, ctx);
+    const env1 = calls.acquiredEnvs[0];
+    // Make env1's destroy slow, and record its completion (the pool captured env1.destroy at
+    // park time; the stable closure delegates to this replaceable body).
+    env1.destroyImpl = async () => {
+      await new Promise((resolve) => setTimeout(resolve, 20));
+      env1.destroyed += 1;
+      destroyResolved = true;
+    };
+    let destroyDoneAtAcquire: boolean | undefined;
+    const origAcquire = engine.acquireEnvironment.bind(engine);
+    engine.acquireEnvironment = async (request, signal, presigned) => {
+      destroyDoneAtAcquire ??= destroyResolved;
+      return origAcquire(request, signal, presigned);
+    };
+
+    await runWithKeepalive(
+      turn2("s1", { model: "m2" }),
+      undefined,
+      undefined,
+      ctx,
+    );
+    assert.equal(
+      destroyDoneAtAcquire,
+      true,
+      "the old env's destroy completed BEFORE the cold acquire started",
+    );
+  });
+});

--- a/services/runner/tests/unit/session-keepalive-engine.test.ts
+++ b/services/runner/tests/unit/session-keepalive-engine.test.ts
@@ -1,0 +1,414 @@
+/**
+ * Engine-seam tests for the acquireEnvironment / runTurn split (keep-alive slice 1), through
+ * `SandboxAgentDeps` with fake sandbox/session handles (no live harness).
+ *
+ * These pin the properties the split exists for: one acquired environment serves many turns
+ * (the second turn does NOT re-acquire), the shared `destroy` is idempotent and runs after a
+ * mid-acquire failure, the session-lifetime listeners demux into exactly the ACTIVE turn's
+ * sink (between-turns events are dropped by decision, never routed to a dead turn), and the
+ * per-turn error boundary matches the pre-split shape (a createOtel throw returns `ok:false`).
+ *
+ * Run: pnpm test (or: pnpm exec vitest run tests/unit/session-keepalive-engine.test.ts)
+ */
+import { describe, it } from "vitest";
+import assert from "node:assert/strict";
+
+import type { AgentEvent, AgentRunRequest } from "../../src/protocol.ts";
+import {
+  acquireEnvironment,
+  runTurn,
+  type SandboxAgentDeps,
+} from "../../src/engines/sandbox_agent.ts";
+
+interface FakeOptions {
+  probeError?: Error;
+  createOtelError?: Error;
+}
+
+/** One fake otel run per createOtel call, recording which updates it handled. */
+interface FakeRun {
+  id: number;
+  handled: unknown[];
+  emitted: AgentEvent[];
+}
+
+function fakeHarness(options: FakeOptions = {}) {
+  const calls = {
+    createSessionCount: 0,
+    promptCount: 0,
+    sandboxDestroyed: 0,
+    sandboxDisposed: 0,
+    sessionDestroyed: 0,
+    permissionReplies: [] as Array<{ id: string; reply: string }>,
+    logs: [] as string[],
+    runs: [] as FakeRun[],
+  };
+
+  // Captured session-lifetime handlers, so tests can fire events/permissions at any moment
+  // (during a turn, between turns).
+  const captured = {
+    onEvent: undefined as ((event: any) => void) | undefined,
+    onPermissionRequest: undefined as ((req: any) => void) | undefined,
+  };
+
+  const session = {
+    id: "session-1",
+    onEvent(handler: (event: any) => void) {
+      captured.onEvent = handler;
+    },
+    onPermissionRequest(handler: (request: any) => void) {
+      captured.onPermissionRequest = handler;
+    },
+    async respondPermission(id: string, reply: string) {
+      calls.permissionReplies.push({ id, reply });
+    },
+    async prompt(_blocks: any) {
+      calls.promptCount += 1;
+      return {
+        stopReason: "complete",
+        usage: { inputTokens: 1, outputTokens: 1 },
+      };
+    },
+  };
+
+  const sandbox = {
+    async createSession(_opts: any) {
+      calls.createSessionCount += 1;
+      return session;
+    },
+    async destroySession(_id: string) {
+      calls.sessionDestroyed += 1;
+    },
+    async destroySandbox() {
+      calls.sandboxDestroyed += 1;
+    },
+    async dispose() {
+      calls.sandboxDisposed += 1;
+    },
+  };
+
+  const makeRun = (): FakeRun & Record<string, any> => {
+    const run: FakeRun & Record<string, any> = {
+      id: calls.runs.length + 1,
+      handled: [],
+      emitted: [],
+      start() {},
+      handleUpdate(update: unknown) {
+        run.handled.push(update);
+      },
+      emitEvent(event: AgentEvent) {
+        run.emitted.push(event);
+      },
+      usage() {
+        return { input: 0, output: 0, total: 0, cost: 0 };
+      },
+      setUsage() {},
+      finish() {
+        return "assistant output";
+      },
+      recordError() {},
+      output() {
+        return "assistant output";
+      },
+      async flush() {},
+      events() {
+        return run.emitted;
+      },
+      settleOpenToolCalls() {},
+      traceId() {
+        return "trace-1";
+      },
+    };
+    calls.runs.push(run);
+    return run;
+  };
+
+  const deps: SandboxAgentDeps = {
+    log: (message) => calls.logs.push(message),
+    createLocalCwd: (durable?: string) => durable ?? "/tmp/agenta-fake-cwd",
+    createDaytonaCwd: (durable?: string) =>
+      durable ?? "/home/sandbox/agenta-fake-cwd",
+    resolveSkillDirs: () => ({ skills: [], cleanup: () => {} }),
+    buildDaemonEnv: () => ({}),
+    resolveDaemonBinary: () => "/bin/sandbox-agent",
+    buildSandboxProvider: () => ({ provider: true }) as any,
+    createPersist: () => ({}) as any,
+    startSandboxAgent: (async () => sandbox) as any,
+    prepareWorkspace: (async () => ({ cleanup: async () => {} })) as any,
+    probeCapabilities: async () => {
+      if (options.probeError) throw options.probeError;
+      return {
+        source: "probed",
+        capabilities: {
+          mcpTools: true,
+          toolCalls: true,
+          usage: true,
+          streamingDeltas: true,
+        },
+      } as any;
+    },
+    applyModel: async (_session, model) => model ?? "resolved-model",
+    createOtel: (() => {
+      if (options.createOtelError) throw options.createOtelError;
+      return makeRun();
+    }) as any,
+    startToolRelay: (() => ({ stop: async () => {} })) as any,
+    localRelayHost: (() => "local-relay-host") as any,
+    sandboxRelayHost: (() => "sandbox-relay-host") as any,
+    responderFactory: () => ({
+      async onPermission() {
+        return { kind: "allow" } as const;
+      },
+      async onClientTool() {
+        return { kind: "deny" } as const;
+      },
+    }),
+  };
+
+  return { calls, deps, captured };
+}
+
+const request: AgentRunRequest = {
+  harness: "claude",
+  messages: [{ role: "user", content: "hello" }],
+};
+
+function updateEvent(update: Record<string, unknown>) {
+  return { payload: { update } };
+}
+
+describe("acquireEnvironment / runTurn split", () => {
+  it("one acquired environment serves two turns without re-acquiring the session", async () => {
+    const { calls, deps } = fakeHarness();
+
+    const acquired = await acquireEnvironment(request, deps);
+    assert.equal(acquired.ok, true);
+    if (!acquired.ok) return;
+    const env = acquired.env;
+    assert.equal(
+      calls.createSessionCount,
+      1,
+      "the session is created once, in acquire",
+    );
+
+    const r1 = await runTurn(env, request, undefined, undefined, {});
+    assert.equal(r1.ok, true);
+    const r2 = await runTurn(
+      env,
+      { harness: "claude", messages: [{ role: "user", content: "again" }] },
+      undefined,
+      undefined,
+      { continuation: true },
+    );
+    assert.equal(r2.ok, true);
+
+    assert.equal(
+      calls.promptCount,
+      2,
+      "both turns prompted the SAME live session",
+    );
+    assert.equal(
+      calls.createSessionCount,
+      1,
+      "the second turn did NOT re-acquire",
+    );
+    assert.equal(
+      calls.sandboxDestroyed,
+      0,
+      "the environment is still alive between turns",
+    );
+
+    await env.destroy();
+    assert.equal(calls.sandboxDestroyed, 1);
+  });
+
+  it("destroy is idempotent: a second destroy is a no-op", async () => {
+    const { calls, deps } = fakeHarness();
+    const acquired = await acquireEnvironment(request, deps);
+    assert.equal(acquired.ok, true);
+    if (!acquired.ok) return;
+
+    await acquired.env.destroy();
+    await acquired.env.destroy();
+    assert.equal(
+      calls.sandboxDestroyed,
+      1,
+      "the sandbox is destroyed exactly once",
+    );
+    assert.equal(calls.sandboxDisposed, 1);
+  });
+
+  it("a mid-acquire failure runs the already-registered finalizers (no leak) and returns ok:false", async () => {
+    const { calls, deps } = fakeHarness({
+      probeError: new Error("probe blew up"),
+    });
+
+    const acquired = await acquireEnvironment(request, deps);
+    assert.equal(acquired.ok, false);
+    if (acquired.ok) return;
+    assert.match(acquired.error, /probe blew up/);
+    // The sandbox was started before the probe failed, so its finalizer must have torn it down.
+    assert.equal(
+      calls.sandboxDestroyed,
+      1,
+      "the partially-acquired sandbox is destroyed",
+    );
+    assert.equal(calls.sandboxDisposed, 1);
+    assert.equal(calls.createSessionCount, 0, "the session was never created");
+  });
+
+  it("a createOtel throw returns { ok:false, error } (pre-split error frame), not a raw throw", async () => {
+    const { calls, deps } = fakeHarness({
+      createOtelError: new Error("otel exploded"),
+    });
+    const acquired = await acquireEnvironment(request, deps);
+    assert.equal(acquired.ok, true);
+    if (!acquired.ok) return;
+
+    const result = await runTurn(
+      acquired.env,
+      request,
+      undefined,
+      undefined,
+      {},
+    );
+    assert.equal(result.ok, false);
+    if (result.ok) return;
+    assert.match(result.error ?? "", /otel exploded/);
+    // The environment is untouched by the failed turn; the caller still owns destroy.
+    assert.equal(calls.sandboxDestroyed, 0);
+    await acquired.env.destroy();
+    assert.equal(calls.sandboxDestroyed, 1);
+  });
+});
+
+describe("session-lifetime listener demux (currentTurn swap)", () => {
+  it("each turn's sink sees only its own events; between-turns events are dropped by decision", async () => {
+    const { calls, deps, captured } = fakeHarness();
+    const acquired = await acquireEnvironment(request, deps);
+    assert.equal(acquired.ok, true);
+    if (!acquired.ok) return;
+    const env = acquired.env;
+    assert.ok(
+      captured.onEvent,
+      "the session-lifetime listener attached once, in acquire",
+    );
+
+    // Turn 1: an event fired during the turn routes to turn 1's otel run.
+    const r1 = await runTurn(env, request, undefined, undefined, {});
+    assert.equal(r1.ok, true);
+    // runTurn leaves the sink set (the dispatch clears it); fire while turn 1 is still current.
+    captured.onEvent!(
+      updateEvent({ sessionUpdate: "agent_message_chunk", text: "one" }),
+    );
+    const run1 = calls.runs[0];
+    assert.equal(run1.handled.length, 1, "turn 1's run received its event");
+
+    // The dispatch ends the turn: clear the sink. A stray event now hits the between-turns
+    // handler (log + drop), never a dead turn's closures.
+    env.clearTurn();
+    captured.onEvent!(
+      updateEvent({ sessionUpdate: "agent_message_chunk", text: "stray" }),
+    );
+    assert.equal(
+      run1.handled.length,
+      1,
+      "the dead turn's run received NOTHING new",
+    );
+    assert.ok(
+      calls.logs.some((l) => l.includes("between-turns event dropped")),
+      "the between-turns handler logged the deliberate drop",
+    );
+
+    // Turn 2: a fresh sink; its events route to turn 2's run only.
+    const r2 = await runTurn(
+      env,
+      { harness: "claude", messages: [{ role: "user", content: "again" }] },
+      undefined,
+      undefined,
+      { continuation: true },
+    );
+    assert.equal(r2.ok, true);
+    captured.onEvent!(
+      updateEvent({ sessionUpdate: "agent_message_chunk", text: "two" }),
+    );
+    const run2 = calls.runs[1];
+    assert.equal(run2.handled.length, 1, "turn 2's run received its event");
+    assert.equal(
+      run1.handled.length,
+      1,
+      "turn 1's run still received nothing new",
+    );
+
+    await env.destroy();
+  });
+
+  it("a between-turns permission request is cancelled by policy, not routed to a dead turn", async () => {
+    const { calls, deps, captured } = fakeHarness();
+    const acquired = await acquireEnvironment(request, deps);
+    assert.equal(acquired.ok, true);
+    if (!acquired.ok) return;
+    const env = acquired.env;
+
+    await runTurn(env, request, undefined, undefined, {});
+    env.clearTurn();
+
+    captured.onPermissionRequest!({ id: "perm-stray" });
+    await new Promise((resolve) => setImmediate(resolve));
+    assert.deepEqual(
+      calls.permissionReplies,
+      [{ id: "perm-stray", reply: "reject" }],
+      "the stray gate is cancelled by policy (slice 2 will park instead)",
+    );
+    assert.ok(
+      calls.logs.some((l) => l.includes("between-turns permission request")),
+      "the deliberate cancel is logged",
+    );
+
+    await env.destroy();
+  });
+
+  it("records the turn's emitted tool-call ids (unique, in order) on env.lastTurnToolCallIds", async () => {
+    const { deps, captured } = fakeHarness();
+    const acquired = await acquireEnvironment(request, deps);
+    assert.equal(acquired.ok, true);
+    if (!acquired.ok) return;
+    const env = acquired.env;
+
+    await runTurn(env, request, undefined, undefined, {});
+    // Fire tool_call frames while the turn is current (the fake prompt fires none itself).
+    captured.onEvent!(
+      updateEvent({ sessionUpdate: "tool_call", toolCallId: "tc-1" }),
+    );
+    captured.onEvent!(
+      updateEvent({
+        sessionUpdate: "tool_call_update",
+        toolCallId: "tc-1",
+        status: "completed",
+      }),
+    );
+    captured.onEvent!(
+      updateEvent({ sessionUpdate: "tool_call", toolCallId: "tc-2" }),
+    );
+    captured.onEvent!(
+      updateEvent({ sessionUpdate: "tool_call", toolCallId: "tc-2" }),
+    );
+    assert.deepEqual(
+      env.lastTurnToolCallIds,
+      ["tc-1", "tc-2"],
+      "unique tool_call ids in first-seen order (updates and repeats do not duplicate)",
+    );
+
+    // The next turn resets the record.
+    await runTurn(
+      env,
+      { harness: "claude", messages: [{ role: "user", content: "again" }] },
+      undefined,
+      undefined,
+      { continuation: true },
+    );
+    assert.deepEqual(env.lastTurnToolCallIds, [], "reset at turn start");
+
+    await env.destroy();
+  });
+});

--- a/services/runner/tests/unit/session-pool.test.ts
+++ b/services/runner/tests/unit/session-pool.test.ts
@@ -1,0 +1,506 @@
+/**
+ * Unit tests for the session keep-alive pool and its fingerprints (slice 1).
+ *
+ * Run: pnpm test (or: pnpm exec vitest run tests/unit/session-pool.test.ts)
+ */
+import { afterEach, beforeEach, describe, it, vi } from "vitest";
+import assert from "node:assert/strict";
+
+import type { AgentRunRequest } from "../../src/protocol.ts";
+import {
+  computeCredentialEpoch,
+  configFingerprint,
+  credentialEpochValid,
+  expectedNextHistoryFingerprint,
+  historyFingerprint,
+  poolKeyFor,
+  priorConversation,
+  readKeepaliveConfig,
+  SessionPool,
+  tailIsFreshUserMessage,
+  type CredentialEpoch,
+} from "../../src/engines/sandbox_agent/session-pool.ts";
+
+// A fake environment: only `destroy` matters to the pool; we count destroys. Idempotent like
+// the real engine `destroy()` closure (the pool's contract): a second call is a no-op.
+function fakeEnv() {
+  const state = { destroyed: 0 };
+  let done = false;
+  return {
+    state,
+    destroy: async () => {
+      if (done) return;
+      done = true;
+      state.destroyed += 1;
+    },
+  };
+}
+
+const epoch: CredentialEpoch = { secretsHash: "h" };
+
+function parkInput(key: string, env = fakeEnv()) {
+  return {
+    input: {
+      key,
+      environment: env,
+      configFingerprint: "cfg",
+      historyFingerprint: "hist",
+      credentialEpoch: epoch,
+      destroy: env.destroy,
+    },
+    env,
+  };
+}
+
+describe("readKeepaliveConfig", () => {
+  const KEYS = [
+    "AGENTA_RUNNER_SESSION_KEEPALIVE",
+    "AGENTA_RUNNER_SESSION_TTL_MS",
+    "AGENTA_RUNNER_SESSION_APPROVAL_TTL_MS",
+    "AGENTA_RUNNER_SESSION_POOL_MAX",
+  ];
+  const saved: Record<string, string | undefined> = {};
+  beforeEach(() => {
+    for (const k of KEYS) {
+      saved[k] = process.env[k];
+      delete process.env[k];
+    }
+  });
+  afterEach(() => {
+    for (const k of KEYS) {
+      if (saved[k] === undefined) delete process.env[k];
+      else process.env[k] = saved[k];
+    }
+  });
+
+  it("defaults: off, 60s idle, 10m approval, cap 8", () => {
+    assert.deepEqual(readKeepaliveConfig(), {
+      enabled: false,
+      ttlMs: 60_000,
+      approvalTtlMs: 600_000,
+      poolMax: 8,
+    });
+  });
+
+  it("reads truthy spellings for the flag and positive ints for the numbers", () => {
+    process.env.AGENTA_RUNNER_SESSION_KEEPALIVE = "true";
+    process.env.AGENTA_RUNNER_SESSION_TTL_MS = "5000";
+    process.env.AGENTA_RUNNER_SESSION_POOL_MAX = "3";
+    const cfg = readKeepaliveConfig();
+    assert.equal(cfg.enabled, true);
+    assert.equal(cfg.ttlMs, 5000);
+    assert.equal(cfg.poolMax, 3);
+
+    process.env.AGENTA_RUNNER_SESSION_KEEPALIVE = "off";
+    assert.equal(readKeepaliveConfig().enabled, false);
+    process.env.AGENTA_RUNNER_SESSION_TTL_MS = "-1";
+    assert.equal(
+      readKeepaliveConfig().ttlMs,
+      60_000,
+      "invalid falls back to default",
+    );
+  });
+});
+
+describe("configFingerprint", () => {
+  const base: AgentRunRequest = {
+    harness: "claude",
+    model: "m1",
+    messages: [{ role: "user", content: "hi" }],
+  };
+
+  it("ignores per-turn volatiles (messages, turnId, telemetry, secrets)", () => {
+    const a = configFingerprint(base);
+    const b = configFingerprint({
+      ...base,
+      messages: [{ role: "user", content: "totally different" }],
+      turnId: "t-2",
+      secrets: { ANTHROPIC_API_KEY: "sekret" },
+      telemetry: {
+        exporters: { otlp: { headers: { authorization: "Bearer x" } } },
+      },
+      context: { propagation: { traceparent: "00-abc-def-01" } },
+    });
+    assert.equal(
+      a,
+      b,
+      "config fingerprint is stable across per-turn volatiles",
+    );
+  });
+
+  it("changes when a config-bearing field changes (model)", () => {
+    assert.notEqual(
+      configFingerprint(base),
+      configFingerprint({ ...base, model: "m2" }),
+    );
+  });
+
+  it("changes when tools change", () => {
+    assert.notEqual(
+      configFingerprint(base),
+      configFingerprint({ ...base, tools: ["read"] }),
+    );
+  });
+});
+
+describe("historyFingerprint (pruned-array contract)", () => {
+  const u1 = { role: "user", content: "hello" };
+  const u2 = { role: "user", content: "again" };
+  const assistantEmpty = { role: "assistant", content: "" };
+  const assistantToolCall = {
+    role: "assistant",
+    content: [{ type: "tool_call", toolCallId: "tc-1", toolName: "edit" }],
+  };
+
+  it("an answer-less (empty) assistant turn is fingerprint-neutral: pruned == unpruned", () => {
+    assert.equal(
+      historyFingerprint([u1, assistantEmpty, u2]),
+      historyFingerprint([u1, u2]),
+      "assistant text is ignored, so pruning an empty assistant turn does not change the hash",
+    );
+  });
+
+  it("a tool-call id in the assistant turn IS captured: unpruned != pruned", () => {
+    assert.notEqual(
+      historyFingerprint([u1, assistantToolCall, u2]),
+      historyFingerprint([u1, u2]),
+      "tool-call ids are part of the fingerprint (edit/tool detection)",
+    );
+  });
+
+  it("edited user text changes the fingerprint", () => {
+    assert.notEqual(
+      historyFingerprint([u1]),
+      historyFingerprint([{ role: "user", content: "hello!" }]),
+    );
+  });
+
+  it("continuation symmetry: park(full [u1]) == check(prior of [u1,a1,u2]) for a plain turn", () => {
+    const parked = historyFingerprint([u1]);
+    const req: AgentRunRequest = {
+      messages: [u1, assistantEmpty, u2],
+    };
+    const check = historyFingerprint(priorConversation(req));
+    assert.equal(
+      parked,
+      check,
+      "a plain conversational continuation matches its parked prefix",
+    );
+  });
+
+  it("dedupes ids: a tool_call + tool_result PAIR sharing one id hashes like a single id", () => {
+    // The wire folds one FE tool part into a tool_call block plus a tool_result block sharing
+    // the toolCallId (vercel messages.py); the park-time prediction folds each emitted id in
+    // once. Dedupe makes the two shapes agree.
+    const pair = {
+      role: "assistant",
+      content: [
+        { type: "tool_call", toolCallId: "tc-1", toolName: "read" },
+        { type: "tool_result", toolCallId: "tc-1", output: "x" },
+      ],
+    };
+    const single = {
+      role: "assistant",
+      content: [{ type: "tool_call", toolCallId: "tc-1" }],
+    };
+    assert.equal(
+      historyFingerprint([u1, pair]),
+      historyFingerprint([u1, single]),
+    );
+  });
+
+  it("expectedNextHistoryFingerprint: park prediction matches the FE's next tool-turn shape", () => {
+    // Park time: the turn ran on [u1] and emitted tc-1 + tc-2.
+    const predicted = expectedNextHistoryFingerprint([u1], ["tc-1", "tc-2"]);
+    // Next request's prior conversation as the FE sends it: the kept assistant turn carries a
+    // call+result pair per tool plus answer text (text is not hashed).
+    const nextPrior = [
+      u1,
+      {
+        role: "assistant",
+        content: [
+          { type: "tool_call", toolCallId: "tc-1", toolName: "read" },
+          { type: "tool_result", toolCallId: "tc-1", output: "a" },
+          { type: "tool_call", toolCallId: "tc-2", toolName: "edit" },
+          { type: "tool_result", toolCallId: "tc-2", output: "b" },
+          { type: "text", text: "done" },
+        ],
+      },
+    ];
+    assert.equal(predicted, historyFingerprint(nextPrior));
+    // No emitted ids => identical to the plain history fingerprint.
+    assert.equal(
+      expectedNextHistoryFingerprint([u1], []),
+      historyFingerprint([u1]),
+    );
+    // A different id set still mismatches (the cold-fallback tripwire).
+    assert.notEqual(
+      expectedNextHistoryFingerprint([u1], ["tc-1"]),
+      historyFingerprint(nextPrior),
+    );
+  });
+});
+
+describe("tailIsFreshUserMessage", () => {
+  it("true for a plain trailing user message with text", () => {
+    assert.equal(
+      tailIsFreshUserMessage({ messages: [{ role: "user", content: "hi" }] }),
+      true,
+    );
+  });
+  it("false for an empty tail or non-user tail", () => {
+    assert.equal(tailIsFreshUserMessage({ messages: [] }), false);
+    assert.equal(
+      tailIsFreshUserMessage({
+        messages: [{ role: "assistant", content: "x" }],
+      }),
+      false,
+    );
+    assert.equal(
+      tailIsFreshUserMessage({ messages: [{ role: "user", content: "  " }] }),
+      false,
+    );
+  });
+  it("false when the tail user turn carries a tool_result (approval reply)", () => {
+    assert.equal(
+      tailIsFreshUserMessage({
+        messages: [
+          {
+            role: "user",
+            content: [
+              { type: "text", text: "ok" },
+              {
+                type: "tool_result",
+                toolCallId: "tc-1",
+                output: { approved: true },
+              },
+            ],
+          },
+        ],
+      }),
+      false,
+    );
+  });
+});
+
+describe("credential epoch", () => {
+  it("same secrets + tool-callback auth hash equal; a changed secret value differs", () => {
+    const a = computeCredentialEpoch({
+      secrets: { A: "1" },
+      toolCallback: { endpoint: "e", authorization: "z" },
+    });
+    const b = computeCredentialEpoch({
+      secrets: { A: "1" },
+      toolCallback: { endpoint: "e", authorization: "z" },
+    });
+    const c = computeCredentialEpoch({
+      secrets: { A: "2" },
+      toolCallback: { endpoint: "e", authorization: "z" },
+    });
+    assert.equal(a.secretsHash, b.secretsHash);
+    assert.notEqual(
+      a.secretsHash,
+      c.secretsHash,
+      "a rotated same-slug secret changes the hash",
+    );
+  });
+
+  it("valid until the mount expiry elapses; invalid once expired", () => {
+    const parked = computeCredentialEpoch(
+      { secrets: { A: "1" } },
+      "2026-01-01T00:00:10.000Z",
+    );
+    const incoming = computeCredentialEpoch({ secrets: { A: "1" } });
+    const before = Date.parse("2026-01-01T00:00:05.000Z");
+    const after = Date.parse("2026-01-01T00:00:15.000Z");
+    assert.equal(credentialEpochValid(parked, incoming, before), true);
+    assert.equal(
+      credentialEpochValid(parked, incoming, after),
+      false,
+      "expired mount evicts",
+    );
+  });
+
+  it("invalid when the secret material changed even if not expired", () => {
+    const parked = computeCredentialEpoch({ secrets: { A: "1" } });
+    const incoming = computeCredentialEpoch({ secrets: { A: "2" } });
+    assert.equal(credentialEpochValid(parked, incoming, Date.now()), false);
+  });
+});
+
+describe("poolKeyFor", () => {
+  it("is <projectId>:<sessionId> when both present", () => {
+    assert.equal(poolKeyFor({ sessionId: "s1" }, "proj-1"), "proj-1:s1");
+  });
+  it("is null without a session id or a mount project id (never park)", () => {
+    assert.equal(poolKeyFor({ sessionId: "s1" }, undefined), null);
+    assert.equal(poolKeyFor({}, "proj-1"), null);
+  });
+});
+
+describe("SessionPool", () => {
+  const cfg = { poolMax: 2 };
+
+  it("park then checkoutIdle returns the same session (busy) and clears the timer", () => {
+    const pool = new SessionPool(cfg, () => {});
+    const { input, env } = parkInput("k1");
+    assert.equal(pool.park(input, 10_000), true);
+    assert.equal(pool.size(), 1);
+    const live = pool.checkoutIdle("k1");
+    assert.ok(live);
+    assert.equal(live!.environment, env);
+    assert.equal(live!.state, "busy");
+    // A busy session is not checked out again (would supersede at the dispatch).
+    assert.equal(pool.checkoutIdle("k1"), undefined);
+  });
+
+  it("idle TTL expiry destroys the session", async () => {
+    vi.useFakeTimers();
+    try {
+      const pool = new SessionPool(cfg, () => {});
+      const { input, env } = parkInput("k1");
+      pool.park(input, 1000);
+      await vi.advanceTimersByTimeAsync(1001);
+      assert.equal(env.state.destroyed, 1, "expired session is destroyed");
+      assert.equal(pool.size(), 0);
+    } finally {
+      vi.useRealTimers();
+    }
+  });
+
+  it("LRU-evicts the oldest IDLE entry at the cap, never a busy one", async () => {
+    const pool = new SessionPool({ poolMax: 2 }, () => {});
+    const a = parkInput("a");
+    const b = parkInput("b");
+    const c = parkInput("c");
+    pool.park(a.input, 10_000);
+    // Make `a` busy so it can never be the LRU victim.
+    pool.checkoutIdle("a");
+    pool.park(b.input, 10_000);
+    // Pool now holds a(busy) + b(idle); parking c must evict b (the only idle), not a.
+    assert.equal(pool.park(c.input, 10_000), true);
+    await Promise.resolve();
+    assert.equal(b.env.state.destroyed, 1, "the idle entry was evicted");
+    assert.equal(a.env.state.destroyed, 0, "the busy entry is never evicted");
+    assert.deepEqual(pool.keys().sort(), ["a", "c"]);
+  });
+
+  it("does not park when the pool is full and nothing is idle to evict", async () => {
+    const pool = new SessionPool({ poolMax: 1 }, () => {});
+    const a = parkInput("a");
+    pool.park(a.input, 10_000);
+    pool.checkoutIdle("a"); // busy, not evictable
+    const b = parkInput("b");
+    assert.equal(
+      pool.park(b.input, 10_000),
+      false,
+      "park is best-effort; refused when full",
+    );
+    assert.equal(
+      b.env.state.destroyed,
+      0,
+      "the pool did not take ownership, so it did not destroy",
+    );
+    assert.equal(pool.size(), 1);
+  });
+
+  it("repark returns a busy session to idle; a superseded session is not resurrected", async () => {
+    const pool = new SessionPool(cfg, () => {});
+    const a = parkInput("k1");
+    pool.park(a.input, 10_000);
+    const live = pool.checkoutIdle("k1")!;
+    assert.equal(
+      pool.repark(
+        live,
+        {
+          configFingerprint: "c2",
+          historyFingerprint: "h2",
+          credentialEpoch: epoch,
+        },
+        10_000,
+      ),
+      true,
+    );
+    assert.equal(pool.get("k1")!.state, "idle");
+    assert.equal(pool.get("k1")!.historyFingerprint, "h2");
+
+    // Supersede: a new entry takes the slot; the old `live` must not be reparked.
+    const live2 = pool.checkoutIdle("k1")!;
+    await pool.evict("k1", "supersede");
+    assert.equal(
+      pool.repark(
+        live2,
+        {
+          configFingerprint: "c",
+          historyFingerprint: "h",
+          credentialEpoch: epoch,
+        },
+        10_000,
+      ),
+      false,
+      "a session whose slot was evicted is not resurrected",
+    );
+  });
+
+  it("evict awaits the destroy, and evict/destroy are idempotent (double destroy is safe)", async () => {
+    const pool = new SessionPool(cfg, () => {});
+    const a = parkInput("k1");
+    pool.park(a.input, 10_000);
+    assert.equal(await pool.evict("k1", "test"), true);
+    // Awaited: the destroy has already completed by the time evict resolves.
+    assert.equal(a.env.state.destroyed, 1);
+    // Second evict/destroy is a no-op.
+    assert.equal(await pool.evict("k1", "test"), false);
+    await pool.destroy("k1");
+    assert.equal(
+      a.env.state.destroyed,
+      1,
+      "the environment is destroyed exactly once",
+    );
+  });
+
+  it("evictIfCurrent never clobbers a racing turn's freshly parked session (B supersedes busy A)", async () => {
+    // The cross-turn interleaving from the review: A's continuation is in flight (busy) when B
+    // arrives, supersedes A (key-based evict), and parks its OWN session under the same key.
+    // A's failure cleanup must destroy only A's session — B's parked session must survive.
+    const pool = new SessionPool({ poolMax: 4 }, () => {});
+    const a = parkInput("k1");
+    pool.park(a.input, 10_000);
+    const liveA = pool.checkoutIdle("k1")!; // A's continuation begins (busy)
+
+    // B arrives, supersedes the busy A, and parks its own session under k1.
+    await pool.evict("k1", "supersede-busy");
+    assert.equal(a.env.state.destroyed, 1, "A was superseded and destroyed");
+    const b = parkInput("k1");
+    pool.park(b.input, 10_000);
+
+    // A's continuation now fails; its cleanup is identity-checked.
+    await pool.evictIfCurrent(liveA, "continuation-failed");
+
+    assert.equal(pool.size(), 1, "B's parked session is still in the pool");
+    assert.equal(
+      pool.get("k1")!.environment,
+      b.env,
+      "the slot still holds B's session, not A's",
+    );
+    assert.equal(b.env.state.destroyed, 0, "B's session was NOT destroyed");
+    assert.equal(
+      a.env.state.destroyed,
+      1,
+      "A's own destroy is idempotent (no double teardown)",
+    );
+  });
+
+  it("destroyAll drains every parked session", async () => {
+    const pool = new SessionPool({ poolMax: 8 }, () => {});
+    const envs = ["a", "b", "c"].map((k) => {
+      const p = parkInput(k);
+      pool.park(p.input, 10_000);
+      return p.env;
+    });
+    assert.equal(pool.size(), 3);
+    await pool.destroyAll();
+    assert.equal(pool.size(), 0);
+    for (const env of envs) assert.equal(env.state.destroyed, 1);
+  });
+});


### PR DESCRIPTION
## Context

On 2026-07-07 two production conversations failed the same way. In one, the user approved a curl command three times before it ran, because each approval round rebuilt the command with slightly different bytes. In the other, the agent restarted its task five times and executed zero commits. The root cause is shared: the runner destroys the harness session at the end of every turn, so each turn cold-starts a fresh agent that only sees a lossy text summary of its own history. Full analysis: [cold-replay-failure-report.md](https://github.com/Agenta-AI/agenta/blob/docs/session-keepalive-plan/docs/design/agent-workflows/projects/approval-boundary/cold-replay-failure-report.md). Design and review trail: #5153.

This PR is slice 1 of the fix: keep the harness session alive for a short TTL after a turn ends. If the next message in the same conversation arrives inside the window and nothing changed, the runner continues the live session and sends only the new user text. The harness keeps its full native memory because the process never died. Anything else falls back to today's cold replay. Approval parking is slice 2 (stacked on this branch).

## What changed

- New `services/runner/src/engines/sandbox_agent/session-pool.ts`: the session pool, the config and history fingerprints, the credential epoch, and the keep-alive config.
- `runSandboxAgent` split into `acquireEnvironment` (session-scoped; builds one idempotent `destroy()` incrementally, so a half-built environment cannot leak) and `runTurn` (per-turn). With the flag off, `runSandboxAgent` composes them and behaves exactly as before.
- Listeners attach once per session and route events into the active turn's sink. A per-turn detach/attach model would drop events and auto-cancel permission requests in the gap between turns.
- `services/runner/src/server.ts`: the continue-vs-cold dispatch, plus pool drains on `POST /kill` and on shutdown (the existing shutdown path only destroys sandboxes; the pool drain runs the full cleanup).
- `mount.ts` surfaces the mount's `project_id` so the pool key is project-scoped. No project scope means no parking.
- Rebased on current big-agents. The time-based run-limits controller (big-agents `8e99171aff`) is integrated at the `runTurn` level: a tripped total/idle/TTFB/per-tool-call limit ends the turn as an error so the caller's teardown reclaims the sandbox; a human pause retires the deadlines. The base branch's own run-limits tests pass against this placement.
- The session event demux was refactored for readability after review: `acquireEnvironment` names the environment explicitly and routes events through `routeSessionEventToActiveTurn` / `routePermissionRequestToActiveTurn`.

## Scope and risk

- Flag off by default (`AGENTA_RUNNER_SESSION_KEEPALIVE`). With the flag off, behavior is byte-identical to today: the pool is never consulted and teardown runs in the same place, in the same order. All 620 pre-existing tests pass unchanged.
- Local sandbox only. Daytona requests never park (an idle remote sandbox costs money; that is slice 3, deferred).
- Runner only. No wire change, no SDK change, no frontend change, no storage change.
- Not covered here: approval parking (slice 2), memory across runner restarts (the session-resume design), multi-replica routing (a pool miss just runs cold).
- A validation failure can never fail a turn. Every mismatch (config, history, credentials, busy, dead session) degrades to cold replay, which is today's path.
- Secret hygiene: the credential epoch hashes resolved secret values process-locally; the hash and the values never reach logs, events, or errors.

## How to QA

Prerequisites: a local dev stack with the runner, and a playground conversation on a local-sandbox agent. Confirm mount signing works first: without mount credentials keep-alive silently runs all-cold by design (no project scope means never park), so a broken mounts table (for example the oss000000006 meta-column drift on stale dev DBs) masks the feature. A `[keepalive] park` line in the runner log proves signing works.

1. Leave `AGENTA_RUNNER_SESSION_KEEPALIVE` unset. Run a two-turn conversation. Behavior and logs match today; no `[keepalive]` lines appear.
2. Set `AGENTA_RUNNER_SESSION_KEEPALIVE=true` on the runner and restart it.
3. Run turn 1 of a conversation. After the turn ends, the runner logs `[keepalive] park ...`.
4. Send turn 2 within 60 seconds. The runner logs `[keepalive] hit-continue ...` and the same live session answers (no new sandbox start in the logs). Ask the agent what it did in turn 1; it answers from native memory. This works after tool-using turns too. Measured on the dev box: turn 1 cold 25.61 s, turn 2 hit-continue 3.12 s.
5. Wait past 60 seconds (`AGENTA_RUNNER_SESSION_TTL_MS`) and send another message. The runner logs `[keepalive] expire ...` then `[keepalive] evict ... reason=expire` and runs cold, exactly as today (measured: 22.6 s, answer still correct).
6. Edit an earlier message and resend: `[keepalive] mismatch (history)`, then cold.
7. Change the model or tools between turns: `[keepalive] mismatch (config)`, then cold.
8. `POST /kill` drains the pool: `[keepalive] destroy ...` for every parked session.

Test command: `cd services/runner && pnpm test` (683 tests at this PR's head: 620 pre-existing unchanged, 56 new keep-alive tests, plus the run-limits tests that landed on big-agents) and `pnpm run typecheck`.

Edge cases covered by tests: TTL expiry, LRU eviction at pool-max (never evicts a busy session), a second request racing a busy session (supersede, identity-checked so cleanups cannot destroy a successor's session), fingerprint mismatches, credential rotation and expiry, no-mount-no-park, client disconnect never parks, a paused turn never parks in this slice, mid-acquire failure cleanup, double destroy, exactly-once mount signing, /kill and shutdown drains, and flag-off identity.

https://claude.ai/code/session_01AumZJ9xRd4XYNHThqy4rTv