### PR TITLE
Add MiniMax-M3 to SDK model choices

### DIFF
--- a/sdks/python/agenta/sdk/utils/assets.py
+++ b/sdks/python/agenta/sdk/utils/assets.py
@@ -184,6 +184,7 @@ supported_llm_models = {
         "together_ai/Qwen/Qwen2.5-72B-Instruct-Turbo",
     ],
     "minimax": [
+        "minimax/MiniMax-M3",
         "minimax/MiniMax-M2.5",
         "minimax/MiniMax-M2.5-lightning",
         "minimax/MiniMax-M2.1",


### PR DESCRIPTION
Reason: MiniMax is already registered as a first-class provider, but the SDK static supported_llm_models list still needs MiniMax-M3 so SDK configuration choices can pass through the LiteLLM minimax/ prefix.

## Summary
- Adds minimax/MiniMax-M3 to the SDK supported_llm_models MiniMax provider list.

## Checks
- python3 -m compileall -q sdks/python/agenta/sdk/utils/assets.py
- secret scan via git diff HEAD and configured regex