### PR TITLE
fix(frontend): show waiting indicator while an approval resume streams

### DIFF
--- a/web/oss/src/components/AgentChatSlice/AgentChatPanel.tsx
+++ b/web/oss/src/components/AgentChatSlice/AgentChatPanel.tsx
@@ -286,6 +286,21 @@ const MessageRow = ({
     )
 }
 
+/** Compact three-dot pulse for the meta row under the last turn — the run-in-progress signal.
+ * Deliberately NOT a Bubble: it shares one line with "Inspect turn" instead of adding a
+ * bubble-sized row of its own. */
+const WorkingDots = () => (
+    <span
+        role="status"
+        aria-label="Agent is working"
+        className="flex items-center gap-1 px-1 py-0.5"
+    >
+        <span className="inline-block h-[5px] w-[5px] animate-pulse rounded-full bg-colorTextTertiary [animation-duration:1.2s]" />
+        <span className="inline-block h-[5px] w-[5px] animate-pulse rounded-full bg-colorTextTertiary [animation-delay:0.2s] [animation-duration:1.2s]" />
+        <span className="inline-block h-[5px] w-[5px] animate-pulse rounded-full bg-colorTextTertiary [animation-delay:0.4s] [animation-duration:1.2s]" />
+    </span>
+)
+
 const AgentConversation = ({entityId, sessionId}: {entityId: string; sessionId: string}) => {
     const store = useStore()
     const persistMessages = useSetAtom(persistSessionMessagesAtom)
@@ -1399,6 +1414,9 @@ const AgentConversation = ({entityId, sessionId}: {entityId: string; sessionId: 
             inspectorOpen && isAssistantTurn
                 ? () => openTurnInspector({sessionId, assistantMessageId: message.id})
                 : undefined
+        const showInspect = buildMode && isAssistantTurn
+        const showWorking =
+            isLast && busy && (!isAssistantTurn || message.parts.some(isVisiblePart))
         return (
             <MessageRow
                 key={message.id}
@@ -1421,17 +1439,6 @@ const AgentConversation = ({entityId, sessionId}: {entityId: string; sessionId: 
                     }
                     turnTraceId={turnTraceId}
                 />
-                {/* Working indicator: pinned under the latest content for the WHOLE run, so gaps
-                    with no streaming output (approval-resume cold-replay, between steps, server
-                    tool waits, post-tool thinking) never read as frozen. It stays inside the last
-                    message so the reserve keeps it on-screen, and drops the moment the run
-                    settles. An EMPTY streaming assistant turn already renders its own loading
-                    bubble (AgentMessage), so skip it there — exactly one indicator while busy. */}
-                {isLast &&
-                    busy &&
-                    (message.role !== "assistant" || message.parts.some(isVisiblePart)) && (
-                        <Bubble placement="start" variant="borderless" loading content="" />
-                    )}
                 {/* Stopped tag + Resend belong only to the LAST assistant turn (the one you cancelled),
                     gated on position so it can never smear onto past turns. Cleared on resend / ask. */}
                 {stopped && isLast && message.role === "assistant" && (
@@ -1451,17 +1458,28 @@ const AgentConversation = ({entityId, sessionId}: {entityId: string; sessionId: 
                         </Button>
                     </div>
                 )}
-                {buildMode && message.role === "assistant" && (
-                    <button
-                        type="button"
-                        onClick={() =>
-                            openTurnInspector({sessionId, assistantMessageId: message.id})
-                        }
-                        className="flex w-fit cursor-pointer items-center gap-1 self-start rounded border-0 bg-transparent px-1 py-0.5 text-xs text-colorTextSecondary transition-colors hover:text-colorPrimary"
-                    >
-                        <TreeStructure size={12} />
-                        Inspect turn
-                    </button>
+                {/* Meta row: the working dots + "Inspect turn" share ONE compact line under the
+                    turn. The dots run for the WHOLE busy run — so gaps with no streaming output
+                    (approval-resume cold-replay, between steps, server tool waits) never read as
+                    frozen — and drop the moment the run settles, leaving just the affordance. An
+                    EMPTY streaming assistant turn already renders its own loading bubble
+                    (AgentMessage), so the dots skip it — exactly one indicator while busy. */}
+                {(showWorking || showInspect) && (
+                    <div className="flex items-center gap-2 self-start">
+                        {showWorking && <WorkingDots />}
+                        {showInspect && (
+                            <button
+                                type="button"
+                                onClick={() =>
+                                    openTurnInspector({sessionId, assistantMessageId: message.id})
+                                }
+                                className="flex w-fit cursor-pointer items-center gap-1 rounded border-0 bg-transparent px-1 py-0.5 text-xs text-colorTextSecondary transition-colors hover:text-colorPrimary"
+                            >
+                                <TreeStructure size={12} />
+                                Inspect turn
+                            </button>
+                        )}
+                    </div>
                 )}
             </MessageRow>
         )

--- a/web/oss/src/components/AgentChatSlice/AgentChatPanel.tsx
+++ b/web/oss/src/components/AgentChatSlice/AgentChatPanel.tsx
@@ -156,9 +156,6 @@ const isVisiblePart = (p: UIMessage["parts"][number]): boolean =>
 const isEmptyAssistantTurn = (m: UIMessage): boolean =>
     m.role === "assistant" && !m.parts.some(isVisiblePart)
 
-/** Rendered-part count for a turn — the "has the resumed stream written anything yet" signal. */
-const visiblePartCount = (m: UIMessage): number => m.parts.filter(isVisiblePart).length
-
 interface ParsedRunError {
     message: string
     code?: number
@@ -428,25 +425,6 @@ const AgentConversation = ({entityId, sessionId}: {entityId: string; sessionId: 
     })
 
     const busy = status === "submitted" || status === "streaming"
-
-    // A settle-driven resume (approval approve/deny, client-tool result → `sendAutomaticallyWhen`)
-    // re-sends WITHOUT a new user turn: the last message stays the settled-looking assistant turn,
-    // so nothing in the transcript signals the in-flight run until its first new part streams in
-    // (the runner cold-replays first, which can take a while — the chat read as frozen). Snapshot
-    // the last turn while idle; while busy with that SAME turn unchanged, the waiting bubble in
-    // `renderMessage` bridges the gap. Render-time ref write, same pattern as `entityIdRef`.
-    const idleTurnSnapshotRef = useRef<{id: string; visible: number} | null>(null)
-    const lastMessage = messages[messages.length - 1]
-    if (!busy) {
-        idleTurnSnapshotRef.current = lastMessage
-            ? {id: lastMessage.id, visible: visiblePartCount(lastMessage)}
-            : null
-    }
-    const awaitingResumeContent =
-        busy &&
-        lastMessage?.role === "assistant" &&
-        idleTurnSnapshotRef.current?.id === lastMessage.id &&
-        visiblePartCount(lastMessage) === idleTurnSnapshotRef.current.visible
 
     // Settle a parked client tool (#4920). The dispatcher calls this from a widget (e.g. the connect
     // widget) with the structured reference; `addToolOutput` matches the part by `toolCallId` on the
@@ -1443,13 +1421,15 @@ const AgentConversation = ({entityId, sessionId}: {entityId: string; sessionId: 
                     }
                     turnTraceId={turnTraceId}
                 />
-                {/* Waiting indicator stays inside the last message so the reserve keeps it on-screen.
-                    Two cases: a fresh send (assistant turn not created yet), and a settle-driven
-                    resume streaming into the EXISTING assistant turn (`awaitingResumeContent`) —
-                    the first new part (thought/tool/text) dismisses it. */}
+                {/* Working indicator: pinned under the latest content for the WHOLE run, so gaps
+                    with no streaming output (approval-resume cold-replay, between steps, server
+                    tool waits, post-tool thinking) never read as frozen. It stays inside the last
+                    message so the reserve keeps it on-screen, and drops the moment the run
+                    settles. An EMPTY streaming assistant turn already renders its own loading
+                    bubble (AgentMessage), so skip it there — exactly one indicator while busy. */}
                 {isLast &&
-                    ((status === "submitted" && message.role !== "assistant") ||
-                        awaitingResumeContent) && (
+                    busy &&
+                    (message.role !== "assistant" || message.parts.some(isVisiblePart)) && (
                         <Bubble placement="start" variant="borderless" loading content="" />
                     )}
                 {/* Stopped tag + Resend belong only to the LAST assistant turn (the one you cancelled),

--- a/web/oss/src/components/AgentChatSlice/AgentChatPanel.tsx
+++ b/web/oss/src/components/AgentChatSlice/AgentChatPanel.tsx
@@ -141,20 +141,23 @@ const RAIL_WIDTH = 248
  *  - DT5 a11y: the message log is an aria-live region; controls are keyboard-operable.
  */
 
+/** A part the transcript actually renders — non-empty text/reasoning, files, sources, tools. */
+const isVisiblePart = (p: UIMessage["parts"][number]): boolean =>
+    (p.type === "text" && Boolean((p as {text?: string}).text?.trim())) ||
+    (p.type === "reasoning" && Boolean((p as {text?: string}).text?.trim())) ||
+    p.type === "file" ||
+    p.type === "source-url" ||
+    p.type.startsWith("tool-") ||
+    p.type === "dynamic-tool"
+
 /** A settled assistant turn with no content at all — no answer, reasoning, tool, file, or
  * source part. Mirrors AgentMessage's `!hasContent`; used to collapse a run of "no response"
  * bubbles (e.g. repeated failed runs) down to the first one. */
 const isEmptyAssistantTurn = (m: UIMessage): boolean =>
-    m.role === "assistant" &&
-    !m.parts.some(
-        (p) =>
-            (p.type === "text" && Boolean((p as {text?: string}).text?.trim())) ||
-            (p.type === "reasoning" && Boolean((p as {text?: string}).text?.trim())) ||
-            p.type === "file" ||
-            p.type === "source-url" ||
-            p.type.startsWith("tool-") ||
-            p.type === "dynamic-tool",
-    )
+    m.role === "assistant" && !m.parts.some(isVisiblePart)
+
+/** Rendered-part count for a turn — the "has the resumed stream written anything yet" signal. */
+const visiblePartCount = (m: UIMessage): number => m.parts.filter(isVisiblePart).length
 
 interface ParsedRunError {
     message: string
@@ -425,6 +428,25 @@ const AgentConversation = ({entityId, sessionId}: {entityId: string; sessionId: 
     })
 
     const busy = status === "submitted" || status === "streaming"
+
+    // A settle-driven resume (approval approve/deny, client-tool result → `sendAutomaticallyWhen`)
+    // re-sends WITHOUT a new user turn: the last message stays the settled-looking assistant turn,
+    // so nothing in the transcript signals the in-flight run until its first new part streams in
+    // (the runner cold-replays first, which can take a while — the chat read as frozen). Snapshot
+    // the last turn while idle; while busy with that SAME turn unchanged, the waiting bubble in
+    // `renderMessage` bridges the gap. Render-time ref write, same pattern as `entityIdRef`.
+    const idleTurnSnapshotRef = useRef<{id: string; visible: number} | null>(null)
+    const lastMessage = messages[messages.length - 1]
+    if (!busy) {
+        idleTurnSnapshotRef.current = lastMessage
+            ? {id: lastMessage.id, visible: visiblePartCount(lastMessage)}
+            : null
+    }
+    const awaitingResumeContent =
+        busy &&
+        lastMessage?.role === "assistant" &&
+        idleTurnSnapshotRef.current?.id === lastMessage.id &&
+        visiblePartCount(lastMessage) === idleTurnSnapshotRef.current.visible
 
     // Settle a parked client tool (#4920). The dispatcher calls this from a widget (e.g. the connect
     // widget) with the structured reference; `addToolOutput` matches the part by `toolCallId` on the
@@ -1421,10 +1443,15 @@ const AgentConversation = ({entityId, sessionId}: {entityId: string; sessionId: 
                     }
                     turnTraceId={turnTraceId}
                 />
-                {/* Waiting indicator stays inside the last message so the reserve keeps it on-screen. */}
-                {isLast && status === "submitted" && message.role !== "assistant" && (
-                    <Bubble placement="start" variant="borderless" loading content="" />
-                )}
+                {/* Waiting indicator stays inside the last message so the reserve keeps it on-screen.
+                    Two cases: a fresh send (assistant turn not created yet), and a settle-driven
+                    resume streaming into the EXISTING assistant turn (`awaitingResumeContent`) —
+                    the first new part (thought/tool/text) dismisses it. */}
+                {isLast &&
+                    ((status === "submitted" && message.role !== "assistant") ||
+                        awaitingResumeContent) && (
+                        <Bubble placement="start" variant="borderless" loading content="" />
+                    )}
                 {/* Stopped tag + Resend belong only to the LAST assistant turn (the one you cancelled),
                     gated on position so it can never smear onto past turns. Cleared on resend / ask. */}
                 {stopped && isLast && message.role === "assistant" && (


### PR DESCRIPTION
## Context
In the playground agent chat, long stretches of a run produce no visible output: the cold-replay after a HITL approval settle (approve or deny adds no new user message), the gaps between steps, server-side tool waits, and post-tool thinking. During those stretches the transcript does not move at all; the only sign of life is the composer's stop spinner, so the chat reads as frozen or stale.

The two existing loading affordances both miss these cases. The waiting bubble only rendered while `status === "submitted"` with a non-assistant last message, and the in-message loading state only shows while a streaming turn has no content yet. As soon as a turn has any content, every later silent gap in the same run showed nothing.

## Changes
`AgentChatPanel` now renders a persistent working indicator under the latest content for the entire busy run (`status` submitted or streaming), the way coding-agent UIs do. It drops the moment the run settles (done, error, stop, or an approval pause, which ends the stream). An empty streaming assistant turn already renders its own loading bubble in `AgentMessage`, so the indicator is skipped there: there is always exactly one indicator while the run is busy, and none once it settles.

Before: the indicator appeared only between sending a message and the start of the reply.
After: the indicator is visible from send to settle, including approval-resume cold-replays, between-step gaps, and server tool waits.

`isEmptyAssistantTurn`'s part predicate was extracted as `isVisiblePart` and shared with the indicator condition, so "visible content" means the same thing in both places.

## Tests / notes
- `eslint` and `prettier` clean; `tsc --noEmit` in `web/oss` stays at the pre-existing baseline (592 errors, none in AgentChatSlice).
- Verified live against a local run: the earlier snapshot-based version of this PR still left silent gaps after the first streamed part; this version keeps the indicator up through them.

## What to QA
- Send a message in the playground agent chat. The typing indicator shows immediately and stays visible under the newest content until the run fully settles, including while text streams in above it.
- Trigger a tool approval and Deny it. The indicator appears right away and stays through the resume until the agent continues (and through any later between-step gaps).
- Pause on an approval: while the approval card waits for you, the indicator is gone (the run is parked, not working).
- Regression: press Stop mid-run. The indicator disappears and the Stopped tag shows. After the run settles normally, no indicator lingers.
