### PR TITLE
fix(frontend): anchor Inspect turn before the working dots

### DIFF
--- a/web/oss/src/components/AgentChatSlice/AgentChatPanel.tsx
+++ b/web/oss/src/components/AgentChatSlice/AgentChatPanel.tsx
@@ -1458,15 +1458,16 @@ const AgentConversation = ({entityId, sessionId}: {entityId: string; sessionId: 
                         </Button>
                     </div>
                 )}
-                {/* Meta row: the working dots + "Inspect turn" share ONE compact line under the
+                {/* Meta row: "Inspect turn" + the working dots share ONE compact line under the
                     turn. The dots run for the WHOLE busy run — so gaps with no streaming output
                     (approval-resume cold-replay, between steps, server tool waits) never read as
-                    frozen — and drop the moment the run settles, leaving just the affordance. An
-                    EMPTY streaming assistant turn already renders its own loading bubble
-                    (AgentMessage), so the dots skip it — exactly one indicator while busy. */}
+                    frozen — and drop the moment the run settles. The affordance renders FIRST so
+                    its left edge stays put (and aligned with older turns') when the trailing dots
+                    unmount — no settle-time layout shift. An EMPTY streaming assistant turn
+                    already renders its own loading bubble (AgentMessage), so the dots skip it —
+                    exactly one indicator while busy. */}
                 {(showWorking || showInspect) && (
                     <div className="flex items-center gap-2 self-start">
-                        {showWorking && <WorkingDots />}
                         {showInspect && (
                             <button
                                 type="button"
@@ -1479,6 +1480,7 @@ const AgentConversation = ({entityId, sessionId}: {entityId: string; sessionId: 
                                 Inspect turn
                             </button>
                         )}
+                        {showWorking && <WorkingDots />}
                     </div>
                 )}
             </MessageRow>


### PR DESCRIPTION
## Context
Follow-up to #5159. The working dots rendered first in the meta row under the last turn, with "Inspect turn" after them. Two visual defects: when the run settled the dots unmounted and the button jumped left by the dots' width, and while a run was busy the last turn's button sat indented relative to the buttons on older turns above it.

## Changes
Pure JSX reorder in `AgentChatPanel`: the "Inspect turn" affordance now renders first and the dots trail it (`Inspect turn · · ·`). The button's left edge is anchored and aligned across all turns at all times; the dots appear and vanish at the trailing end of the line, where nothing follows them, so settling moves nothing. In chat mode (no inspect button) the dots stand alone as before.

Keeping the dots on the left with permanently reserved width was considered and rejected: it would indent every turn's button forever for a transient signal.

## Tests / notes
- `eslint` and `prettier` clean. The diff swaps two existing JSX blocks inside the same row; no logic or types changed.

## What to QA
- In Build mode, send a message and let the run finish. "Inspect turn" does not move when the dots disappear.
- While a run streams, compare the last turn's "Inspect turn" with older turns above: their left edges line up.
- Regression: in maximized chat mode the dots still show alone under the latest content while the run is busy.