### PR TITLE
[#5162] fix(frontend): forward variant references on draft playground runs

### DIFF
--- a/docs/design/agent-workflows/projects/draft-run-references/README.md
+++ b/docs/design/agent-workflows/projects/draft-run-references/README.md
@@ -1,0 +1,35 @@
+# Draft-run references
+
+An agent that edits its own configuration can commit once, then every later commit in the
+same chat fails with `missing run-context value for direct-call binding
+'workflow_revision.workflow_variant_id'`. The page has to reload to recover. This workspace
+explains why and proposes the fix.
+
+The cause: on a run with unsaved config edits, the playground sends `references: null`, which
+drops the variant identity that the `commit_revision` tool needs. A successful commit is what
+flips the panel into the unsaved state, so the agent's own success breaks its next commit.
+
+The recommended fix: keep dropping the committed-revision reference on a dirty run (that is
+the correct draft signal), but keep forwarding the variant reference, because the variant is
+what `commit_revision` targets. Variant identity and draft-ness are independent.
+
+## Files
+
+- [context.md](context.md): what the user sees, why it matters, goals and non-goals, and the
+  three layers involved.
+- [research.md](research.md): the full trace of the bug through the frontend, the SDK and
+  service, and the runner. Includes the worked before/after reference blocks and the verified
+  proof that the frontend fix is safe. Read this to understand the mechanism.
+- [plan.md](plan.md): the two fix options, their trade-offs, the recommendation, the
+  draft-mode interaction, the acceptance checks, and the test plan.
+- [status.md](status.md): current state, decisions, verified citations, provenance, and
+  recorded follow-ups.
+
+## Start here
+
+Read context.md, then research.md (it proves the mechanism before anything is proposed), then
+plan.md.
+
+## Tracking
+
+Issue: https://github.com/Agenta-AI/agenta/issues/5162

--- a/docs/design/agent-workflows/projects/draft-run-references/context.md
+++ b/docs/design/agent-workflows/projects/draft-run-references/context.md
@@ -1,0 +1,71 @@
+# Context
+
+## The problem in one sentence
+
+An agent that edits its own configuration can commit the change once, then every later
+commit in the same chat fails with a run-context error, until the page reloads.
+
+## What the user sees
+
+You open an agent in the playground and chat with it. You ask it to add some tools. The
+agent calls the `commit_revision` tool to save the new configuration. The first commit
+works. A new version appears.
+
+Then you ask for another change in the same conversation. The agent calls `commit_revision`
+again. This time it fails. The error is:
+
+```
+missing run-context value for direct-call binding 'workflow_revision.workflow_variant_id'
+```
+
+Every commit after the first one fails the same way. The only fix is to reload the page.
+
+This was reproduced in two recorded sessions:
+
+- `c6de1865` on 2026-07-07.
+- `8110bba2` on 2026-07-08.
+
+Both timelines are saved at the repository root as `turn-*.md` files.
+
+## Why this matters
+
+Self-editing is the core loop of the builder agent. The whole point is that you talk to
+the agent and it configures itself: it adds tools, edits its prompt, changes its model,
+then commits the result. If the second commit in a conversation always fails, the agent
+can make exactly one change per page load. That breaks the core experience.
+
+## What this project delivers
+
+This is a design-only workspace. It explains the bug from the ground up, lays out two fixes
+with their trade-offs, recommends one, and defines how to verify it. No code changes here.
+Implementation follows after review.
+
+## Goals
+
+- Explain, for a reader who has never seen this code, exactly how a commit fails.
+- Recommend one fix with clear reasoning.
+- Make sure the fix does not break the draft-mode rules that the same code path relies on.
+- Define acceptance checks and a test plan.
+
+## Non-goals
+
+- Changing the wire contract between the frontend, the SDK, and the runner.
+- Redesigning how run context is assembled. That is a larger effort tracked separately (see
+  the related work in plan.md).
+- Fixing the case of a brand-new agent that has never been committed. That agent has no
+  variant yet, so its first commit is a different flow. This project targets the reported
+  loop: an agent that was committed once and then keeps failing.
+
+## Background: the three moving parts
+
+Three layers cooperate on every agent run. You need all three to understand the bug.
+
+1. **The playground (frontend).** It builds the `/invoke` request. It decides what identity
+   information to attach to the run, in a block called `references`.
+2. **The SDK and service (Python).** They receive the request, assemble a "run context" from
+   the references, and hand the run to the runner.
+3. **The runner (TypeScript).** It runs the agent loop. When the agent calls a platform tool
+   like `commit_revision`, the runner fills in server-owned fields from the run context.
+
+The bug is a disagreement between these layers about one field: which variant is running.
+research.md traces the field through all three layers. plan.md proposes the fix.

--- a/docs/design/agent-workflows/projects/draft-run-references/plan.md
+++ b/docs/design/agent-workflows/projects/draft-run-references/plan.md
@@ -6,9 +6,10 @@ Tracking issue: https://github.com/Agenta-AI/agenta/issues/5162
 
 ## The decision in one line
 
-Stop dropping the variant reference on a dirty run. Keep dropping only the revision
-reference, because the revision is what marks a run as non-draft. The variant says which
-variant is running, and `commit_revision` needs it.
+Stop dropping the variant and application references on a dirty run. Keep withholding only
+the revision reference, because the revision is what marks a run as non-draft. The variant
+says which variant is running, the application says which app it belongs to, and
+`commit_revision` needs the variant.
 
 ## What must stay true
 
@@ -134,15 +135,18 @@ follow.
    identity is forwarded on every run regardless of `isDirty`, so a second commit in the same
    conversation has its target. The loop described in research.md is broken at the source. No
    reload is required for correctness.
-2. **Should the frontend adopt the new revision so the panel re-syncs and `isDirty` resets?**
-   This is a display concern, not a correctness one. After a self-commit, the loaded panel
-   still shows the pre-commit inline edits, which now genuinely differ from the new HEAD, so
-   the run stays a draft (`is_draft` true). That is honest. Adopting the new revision (reload
-   or sync the panel, bump the version chip) would make the UI reflect the new committed state
-   and reset `isDirty`. It is a nice follow-up for UI accuracy, but it must stay decoupled
-   from the run-context fix. Option 1 makes the run robust whether or not the panel re-syncs,
-   so the two concerns do not entangle. We record the panel-adoption follow-up as optional in
-   status.md.
+2. **Does the panel re-sync to the new revision on its own?** Yes, in the common case it
+   already does. A mechanism added in issue #4920 repoints the panel after a self-commit: the
+   backend emits a `data-committed-revision` event from the `commit_revision` output, and the
+   chat panel reacts by switching the loaded entity to the new revision id (research.md,
+   "After a self-commit, the panel already repoints to the new revision"). The new revision
+   has no draft overlay, so `isDirty` resets to false and the version chip reflects the new
+   committed state. This is a display improvement, not a correctness requirement, and it is
+   not fully reliable: if the stream is aborted or the event is missed, the panel stays on the
+   old revision and reads as dirty. Option 1 is what makes the run correct in that case,
+   because it forwards the variant regardless of panel state. The two concerns stay decoupled:
+   the repointing keeps the UI honest, and Option 1 keeps `commit_revision` working even when
+   the repointing does not land.
 
 Draft-mode semantics do not regress under Option 1. A clean run sends all three references
 and stays non-draft. A dirty run sends the variant but not the revision and stays a draft.

--- a/docs/design/agent-workflows/projects/draft-run-references/plan.md
+++ b/docs/design/agent-workflows/projects/draft-run-references/plan.md
@@ -1,0 +1,212 @@
+# Plan: restore the variant identity on a draft run
+
+Read research.md first. It proves the mechanism. This document chooses the fix.
+
+Tracking issue: https://github.com/Agenta-AI/agenta/issues/5162
+
+## The decision in one line
+
+Stop dropping the variant reference on a dirty run. Keep dropping only the revision
+reference, because the revision is what marks a run as non-draft. The variant says which
+variant is running, and `commit_revision` needs it.
+
+## What must stay true
+
+Any fix has to hold three invariants at once. research.md shows how they interact.
+
+1. **A committed-revision run stays non-draft.** A clean run (no unsaved edits) must still
+   send all three references, so `is_draft` is false and the run is pinned to its committed
+   snapshot.
+2. **A dirty inline-config run stays a draft.** When the panel has unsaved edits, the run is
+   an inline draft. `is_draft` must stay true. Since `is_draft` keys only on the revision
+   reference (`tracing.py:165`), the run must not carry a revision reference.
+3. **`commit_revision` always has a variant target.** The run must carry the variant identity
+   whenever a real committed variant exists, draft or not.
+
+The current code satisfies 1 and 2 but breaks 3, because it drops the variant along with the
+revision.
+
+## Option 1 (recommended): fix the frontend read path
+
+### What changes
+
+In `agentRequest.ts`, replace the all-or-nothing gate with a field-level gate. Always forward
+the `application` and `application_variant` references when they exist. Forward
+`application_revision` only when the run is clean (`!isDirty`).
+
+Today:
+
+```typescript
+const references = isCommittedRevisionRun ? fullReferences : null
+```
+
+After (illustrative, final shape decided at implementation):
+
+```typescript
+// Always identify WHICH variant is running (well-defined even for a dirty draft).
+// Forward the committed-revision reference ONLY on a clean run, so a dirty run stays
+// is_draft=true. The variant is orthogonal to draft-ness (see research.md).
+const references = fullReferences
+    ? {
+          ...(fullReferences.application ? {application: fullReferences.application} : {}),
+          ...(fullReferences.application_variant
+              ? {application_variant: fullReferences.application_variant}
+              : {}),
+          ...(isCommittedRevisionRun
+              ? {application_revision: fullReferences.application_revision}
+              : {}),
+      }
+    : null
+```
+
+### The reference block, before and after the fix
+
+For a dirty run of an agent that was committed once:
+
+- **Before:** `references: null`. `commit_revision` throws.
+- **After:** `references: {application: {...}, application_variant: {...}}`. Run context has
+  `variant.id` set and `revision` unset, so `is_draft` is true and the commit works.
+
+A clean run is unchanged: it still sends all three families and stays non-draft.
+
+### Why this is the right layer
+
+- It matches the repo rule to normalize on the frontend read path. The frontend is where the
+  run identity is decided, and it is the layer that knows exactly which variant is loaded.
+- It is small. It touches one expression in one file.
+- It preserves `is_draft` by construction. The draft signal is the revision reference, and
+  the fix keeps gating that reference on `!isDirty`.
+- It needs no wire change, no SDK change, no runner change. The backend already reads the
+  variant reference it is handed (`tracing.py:155-158`).
+
+### Trade-offs and how we cover them
+
+- **It relies on a verified invariant.** research.md proves that a playground run always
+  sends `data.parameters`, so the backend never re-resolves the forwarded variant to a HEAD
+  revision (`resolver.py:577-582`). If a future change ever sent a references-only agent run
+  with no parameters, forwarding a bare variant would hydrate it to a HEAD revision and flip
+  `is_draft` to false. We lock this invariant with a unit test (see the test plan) so a
+  regression is caught in CI rather than in production.
+- **A never-committed local draft still cannot self-commit.** `buildAgentReferences` drops
+  non-UUID ids, so a brand-new agent that was never saved has no real variant id to forward,
+  and `commit_revision` still has no target. This is correct and out of scope: there is no
+  variant to commit to yet. The reported loop is about an agent that was committed once and
+  then keeps failing, and that agent has a real variant id. We note this edge here so the
+  reviewer knows it is deliberate, not missed.
+
+## Option 2: derive the variant in the service from the app id
+
+### What changes
+
+The service would look up the variant from `application_id` (which is on the URL query even
+for a draft run, `agentRequest.ts:378-386`) whenever the request carries no explicit variant
+reference. It would then fill `runContext.workflow.variant` from that lookup.
+
+### Trade-offs
+
+- **Larger blast radius.** The change spreads across the SDK reference assembly and the
+  service run-context builder, and it adds a database lookup on a path that today reads only
+  what the client sent.
+- **Ambiguous for multi-variant apps.** An app can have more than one variant. The app id
+  alone does not say which variant is running. The service could guess (for example, the most
+  recent variant), but a guess can bind the wrong variant and commit to it. That is a
+  correctness risk on a write operation.
+- **Wrong layer for a client-known fact.** The frontend already knows exactly which variant
+  is loaded. Recovering that identity in the backend from a weaker signal is more code to do
+  a worse job.
+
+Option 2 does have one attraction: it works even if the frontend never sends a variant. But
+the frontend does know the variant, so that robustness buys little and costs correctness.
+
+## Recommendation
+
+Take **Option 1**. It is the smallest change, it lives in the layer that owns the decision,
+it preserves `is_draft` by construction, and it avoids the multi-variant ambiguity that makes
+Option 2 risky on a write path. Option 2's only edge (surviving a frontend that sends no
+variant) does not apply, because the frontend has the variant and can send it.
+
+## What happens after a successful self-commit
+
+A successful `commit_revision` creates a new revision and moves the HEAD. Two questions
+follow.
+
+1. **Does the next commit work without a page reload?** With Option 1, yes. The variant
+   identity is forwarded on every run regardless of `isDirty`, so a second commit in the same
+   conversation has its target. The loop described in research.md is broken at the source. No
+   reload is required for correctness.
+2. **Should the frontend adopt the new revision so the panel re-syncs and `isDirty` resets?**
+   This is a display concern, not a correctness one. After a self-commit, the loaded panel
+   still shows the pre-commit inline edits, which now genuinely differ from the new HEAD, so
+   the run stays a draft (`is_draft` true). That is honest. Adopting the new revision (reload
+   or sync the panel, bump the version chip) would make the UI reflect the new committed state
+   and reset `isDirty`. It is a nice follow-up for UI accuracy, but it must stay decoupled
+   from the run-context fix. Option 1 makes the run robust whether or not the panel re-syncs,
+   so the two concerns do not entangle. We record the panel-adoption follow-up as optional in
+   status.md.
+
+Draft-mode semantics do not regress under Option 1. A clean run sends all three references
+and stays non-draft. A dirty run sends the variant but not the revision and stays a draft.
+The variant identity and the draft flag move independently, which is exactly what
+`tracing.py` already expects.
+
+## Adjacent work: server-stamped identity in run context
+
+A separate design, the session keep-alive project, is landing follow-ups that also enrich the
+run context. Its follow-up 5 (`docs/design/agent-workflows/projects/session-keepalive/status.md`,
+decision 1 and follow-up 5) moves the session pool's project scope off the sandbox mount and
+stamps a server-verified `project_id` into `runContext`. The two designs are adjacent because
+both add identity to `runContext`, but they do not overlap:
+
+- Follow-up 5 stamps **project identity**, server-side, from request auth state.
+- This design fixes **variant identity**, by forwarding the variant reference that the service
+  already resolves into `runContext.workflow`.
+
+They do not contradict each other. One fills the project scope; the other fills the variant
+scope.
+
+There is a natural long-term direction that unifies them. Today the variant identity is
+trusted from the client `references` block. The project identity in follow-up 5 is instead
+derived server-side from request state, which is stronger, because the server does not have to
+trust the client for it. The eventual end-state is a single "server-stamped identity in run
+context" where both the project and the workflow or variant identity are derived server-side
+from the authenticated request, so `commit_revision`'s variant binding is immune to whatever
+the client sends. That is a larger change and out of scope here. Option 1 is the correct
+minimal fix now, and it does not block that end-state; it fills the same `runContext.workflow`
+field the server-stamped version would later own.
+
+## Acceptance checks
+
+- A dirty run of a committed agent sends a `references` block that contains `application` and
+  `application_variant` and does **not** contain `application_revision`.
+- A clean run of a committed agent still sends all three reference families.
+- The run context for a dirty run has `workflow.variant.id` set and `workflow.is_draft` true.
+- `commit_revision` succeeds on the second and later calls within one conversation, with no
+  page reload.
+- A never-committed local draft still sends no variant (unchanged), because there is no real
+  variant id yet.
+
+## Test plan
+
+**Unit, frontend (`buildAgentRequest` reference gating).** Add cases to the request-builder
+tests:
+
+- Clean, committed revision: `references` contains all three families.
+- Dirty, committed revision: `references` contains `application` and `application_variant`,
+  and omits `application_revision`.
+- Local draft (non-UUID ids): `references` is null (no variant forwarded), unchanged.
+- Invariant guard: a dirty committed run still sets `data.parameters`, so the backend
+  hydration gate never fires. Assert the request carries `data.parameters` alongside the
+  bare-variant references, documenting the invariant Option 1 depends on.
+
+**Integration or replay, the self-commit loop.** Turn the reported failure into a regression
+test using the agent-replay approach (see the `agent-replay-test` skill). Capture a real run
+where the agent commits, then commits again in the same conversation. Assert:
+
+- The first `commit_revision` succeeds.
+- The second `commit_revision` in the same conversation succeeds (today it fails).
+- The second run's run context still reports `is_draft` true (the draft signal did not
+  regress when the variant was forwarded).
+
+**Live check (optional, during implementation).** Reproduce in the playground on the dev box:
+open a committed agent, ask for two changes in one conversation, confirm both commits land and
+two new versions appear without reloading.

--- a/docs/design/agent-workflows/projects/draft-run-references/research.md
+++ b/docs/design/agent-workflows/projects/draft-run-references/research.md
@@ -1,0 +1,281 @@
+# Research: how a self-commit fails
+
+This document traces the bug through all three layers. Read it top to bottom. Each section
+builds on the one before it. File and line citations are exact as of the commit recorded in
+status.md.
+
+## The tool that fails: commit_revision
+
+`commit_revision` is a platform op. A platform op is a tool whose call is turned into a
+direct HTTP request to the Agenta API, with some fields filled by the server instead of by
+the model.
+
+`commit_revision` needs to know which variant to commit to. That variant id is never
+supplied by the model. Two things make that true:
+
+1. The variant id is declared as a **context binding**, not a model input. The catalog entry
+   binds the request body field `workflow_revision.workflow_variant_id` to the run-context
+   token `$ctx.workflow.variant.id`:
+
+   ```python
+   PlatformOp(
+       op="commit_revision",
+       ...
+       context_bindings={
+           "workflow_revision.workflow_variant_id": "$ctx.workflow.variant.id"
+       },
+   )
+   ```
+
+   (`sdks/python/agenta/sdk/agents/platform/op_catalog.py:1090-1100`)
+
+2. The variant id is **stripped from the schema the model sees**. When the catalog builds the
+   model-visible input schema, it removes every field named in `context_bindings`, so the
+   model cannot and does not pass it:
+
+   ```python
+   for field in self.context_bindings:
+       _strip_field(schema, field)
+   ```
+
+   (`sdks/python/agenta/sdk/agents/platform/op_catalog.py:156-173`)
+
+So the variant id must come from the run context. If the run context does not carry it, the
+call has no target.
+
+## Where the runner throws
+
+When the runner executes a direct call, it fills each context binding last, after the model
+args and the static body. If a binding token resolves to `undefined`, the runner throws
+instead of sending a call with a missing field:
+
+```typescript
+if (call.context) {
+  for (const [bodyPath, token] of Object.entries(call.context)) {
+    deepDelete(body, bodyPath);
+    const value = resolveCtxToken(runContext, token);
+    if (value === undefined) {
+      throw new Error(
+        `missing run-context value for direct-call binding '${bodyPath}'`,
+      );
+    }
+    deepSet(body, bodyPath, value);
+  }
+}
+```
+
+(`services/runner/src/tools/direct.ts:226-236`)
+
+This is the exact error the user sees. The token `$ctx.workflow.variant.id` resolved to
+`undefined`. Failing closed here is deliberate: a direct call that declares a context binding
+must have that context, or it could target the wrong thing.
+
+So the question becomes: why is `runContext.workflow.variant.id` sometimes undefined?
+
+## Where run context comes from
+
+The runner receives the run context from the Python side. The workflow part of the run
+context is assembled from the tracing references:
+
+```python
+def _run_context_workflow() -> Optional[RunContextWorkflow]:
+    references = TracingContext.get().references
+    revision = _run_context_reference_from_any(
+        references,
+        ("workflow_revision", "application_revision", "evaluator_revision"),
+        with_version=True,
+    )
+    workflow = RunContextWorkflow(
+        artifact=_run_context_reference_from_any(
+            references, ("workflow", "application", "evaluator")
+        ),
+        variant=_run_context_reference_from_any(
+            references,
+            ("workflow_variant", "application_variant", "evaluator_variant"),
+        ),
+        revision=revision,
+    )
+    if not workflow.model_dump(exclude_none=True):
+        return None
+    workflow.is_draft = revision is None
+    return workflow
+```
+
+(`sdks/python/agenta/sdk/agents/tracing.py:135-166`)
+
+Read this carefully, because it holds the key to the whole design.
+
+- The **variant** comes from the `application_variant` reference (or `workflow_variant`, or
+  `evaluator_variant`).
+- The **revision** comes from the `application_revision` reference.
+- `is_draft` is `True` when there is **no revision reference**. Nothing else sets it.
+- If the references carry no workflow identity at all, the whole workflow context is `None`,
+  and `variant.id` is undefined.
+
+Two facts fall out of this, and they are the heart of the fix:
+
+1. **Variant identity and draft-ness are independent.** The variant reference decides which
+   variant is running. The revision reference decides whether the run is a draft. You can
+   have a variant with no revision. That is a draft run of a known variant.
+2. **Dropping the variant reference destroys the target for `commit_revision`.** With no
+   variant reference, `variant.id` is undefined, and the runner throws.
+
+## Where the references come from
+
+The tracing references are set from the `/invoke` request's `references` block. The running
+decorator merges the request references onto the tracing context:
+
+```python
+_references = {**(self.references or {}), **(request.references or {})}
+...
+tracing_ctx.references = _references
+```
+
+(`sdks/python/agenta/sdk/decorators/running.py:354, 376`)
+
+So whatever the frontend puts in `references` is what the run context is built from. If the
+frontend sends `references: null`, the tracing context has no references, the workflow
+context is `None`, and `commit_revision` has no variant to target.
+
+## The frontend decision that causes the bug
+
+The playground builds the references from the loaded revision entity. `buildAgentReferences`
+produces up to three families from the entity's ids: `application`, `application_variant`,
+and `application_revision` (`web/packages/agenta-playground/src/state/execution/agentRequest.ts:86-117`).
+
+Then the request builder decides whether to forward them:
+
+```typescript
+const fullReferences = buildAgentReferences(entity)
+const isDirty = store.get(workflowMolecule.selectors.isDirty(entityId)) as boolean
+const isCommittedRevisionRun =
+    !isDirty && typeof fullReferences?.application_revision?.id === "string"
+const references = isCommittedRevisionRun ? fullReferences : null
+```
+
+(`web/packages/agenta-playground/src/state/execution/agentRequest.ts:355-359`)
+
+This is an all-or-nothing gate. If the config panel is clean (no unsaved edits) and there is
+a real committed revision, the run forwards **all** references. Otherwise it forwards
+**none**.
+
+The intent is documented right above it: a dirty run is an inline-config draft, so forwarding
+the revision would wrongly mark the run as non-draft. The comment then goes one step further
+and drops the variant too. That extra step is what breaks `commit_revision`, because the
+variant is exactly what the tool needs.
+
+## Worked example: the reference block, clean versus dirty
+
+**Clean run (panel matches the committed HEAD, `isDirty` is false).** The request sends:
+
+```json
+"references": {
+  "application":          {"id": "<app-uuid>",     "slug": "my-agent"},
+  "application_variant":  {"id": "<variant-uuid>", "slug": "my-agent.default"},
+  "application_revision": {"id": "<rev-uuid>",     "slug": "...", "version": "3"}
+}
+```
+
+Run context: artifact set, variant set, revision set. `is_draft` is false. `variant.id` is
+bound. `commit_revision` works.
+
+**Dirty run today (panel has unsaved edits, `isDirty` is true).** The request sends:
+
+```json
+"references": null
+```
+
+Run context: no workflow identity at all. `variant.id` is undefined. `commit_revision`
+throws the reported error.
+
+## The loop: why it works, then stops
+
+This explains the "works, then stops working in the same conversation" symptom.
+
+1. You load the agent. The panel matches the committed HEAD. `isDirty` is false.
+2. You ask for a change. The agent calls `commit_revision`. References are sent in full.
+   The commit works and creates a **new** revision. The HEAD moves forward.
+3. The panel you loaded now lags the new HEAD. The dirty check compares the panel against
+   the current HEAD and flips `isDirty` to true.
+4. You ask for another change in the same conversation. Because `isDirty` is now true, the
+   request sends `references: null`. `commit_revision` fails.
+5. Every later commit fails the same way, until the page reloads and the panel re-syncs to
+   the new HEAD.
+
+The successful commit is what poisons the next one. The agent's own success flips the dirty
+flag, and the dirty flag drops the variant.
+
+## The claim we must verify before recommending the frontend fix
+
+The frontend comment gives a second reason for dropping the variant:
+
+> The resolver also re-resolves a bare variant ref to its latest revision, so the variant
+> must be dropped too.
+
+(`web/packages/agenta-playground/src/state/execution/agentRequest.ts:349-350`)
+
+If that were true for our case, the recommended fix would be wrong. Forwarding a bare variant
+would make the backend resolve it to the variant's HEAD revision, which would set
+`is_draft` back to false and defeat the whole point.
+
+We verified this claim in code. It does **not** apply to playground runs. Here is why.
+
+The re-resolution happens in `resolve_references_with_info`, which calls the retrieve endpoint
+to turn a variant reference into a concrete revision, then merges that resolved revision back
+into the tracing references (`sdks/python/agenta/sdk/middlewares/running/resolver.py:220-346`,
+merge at `:593`). But that function only runs when reference hydration is needed, and the
+gate for that is:
+
+```python
+request_has_parameters = bool(request.data and request.data.parameters)
+needs_reference_hydration = bool(
+    request.references
+    and not request_has_parameters
+    and (revision is None or not revision.parameters)
+)
+```
+
+(`sdks/python/agenta/sdk/middlewares/running/resolver.py:577-582`)
+
+Hydration needs `not request_has_parameters`. Every playground agent run sends its resolved
+configuration as `data.parameters`:
+
+```typescript
+requestBody: {
+    session_id: opts.sessionId,
+    references,
+    data: {inputs: {messages: history}, parameters},
+}
+```
+
+(`web/packages/agenta-playground/src/state/execution/agentRequest.ts:391-398`)
+
+So `request_has_parameters` is always true for a playground run, `needs_reference_hydration`
+is always false, and `resolve_references_with_info` never runs. The variant is never
+re-resolved to a revision. Only the raw request references reach the tracing context, through
+the direct assignment at `running.py:376`.
+
+**Conclusion.** For a playground run, forwarding a bare `application_variant` with no
+`application_revision` leaves the tracing references with a variant and no revision. The run
+context then has `variant.id` set and `revision` unset, so `is_draft` stays true and
+`commit_revision` gets its target. The comment's fear is real for a references-only run that
+carries no parameters, but a playground run is never that. This is what makes the frontend
+fix both small and correct.
+
+## App scoping is already safe on a draft run
+
+One more fact matters for the fix. Even today, a draft run stays associated with its app,
+because the app id rides the URL query independently of the `references` block:
+
+```typescript
+const appId = fullReferences?.application?.id
+const url = withQuery(invocationUrl, {
+    application_id: appId,
+    project_id: headers.Authorization ? projectId : undefined,
+})
+```
+
+(`web/packages/agenta-playground/src/state/execution/agentRequest.ts:378-386`)
+
+So the app is never lost on a dirty run. Only the variant and revision identities are
+dropped. The fix restores the variant while leaving the app scoping untouched.

--- a/docs/design/agent-workflows/projects/draft-run-references/research.md
+++ b/docs/design/agent-workflows/projects/draft-run-references/research.md
@@ -157,16 +157,27 @@ const references = isCommittedRevisionRun ? fullReferences : null
 
 This is an all-or-nothing gate. If the config panel is clean (no unsaved edits) and there is
 a real committed revision, the run forwards **all** references. Otherwise it forwards
-**none**.
+**none**, including the `application` and `application_variant` references.
 
-The intent is documented right above it: a dirty run is an inline-config draft, so forwarding
-the revision would wrongly mark the run as non-draft. The comment then goes one step further
-and drops the variant too. That extra step is what breaks `commit_revision`, because the
-variant is exactly what the tool needs.
+Dropping those two on a dirty run is the bug. The gate had one good reason and one wrong
+reason to withhold the revision reference, and it then swept the variant and app references
+along with it:
+
+- The good reason: a dirty run is an inline-config draft, so forwarding the revision would
+  wrongly mark the run as non-draft. Draft-ness keys only on the revision reference
+  (`tracing.py:165`), so the revision must stay out of a dirty run. That part is correct.
+- The wrong reason: the code comment claimed the backend would re-resolve a bare variant
+  reference to its latest revision, so it dropped the variant too, out of caution. The next
+  section proves that claim does not hold for a playground run. The caution is what removed
+  the variant, and the variant is exactly what `commit_revision` needs.
+
+The application reference should never have been dropped at all. It carries no draft signal.
+This PR changes the gate to forward `application` and `application_variant` on every run and
+to gate only `application_revision` on cleanliness. See plan.md, Option 1.
 
 ## Worked example: the reference block, clean versus dirty
 
-**Clean run (panel matches the committed HEAD, `isDirty` is false).** The request sends:
+**Clean run (the loaded revision has no unsaved edits, `isDirty` is false).** The request sends:
 
 ```json
 "references": {
@@ -179,7 +190,7 @@ variant is exactly what the tool needs.
 Run context: artifact set, variant set, revision set. `is_draft` is false. `variant.id` is
 bound. `commit_revision` works.
 
-**Dirty run today (panel has unsaved edits, `isDirty` is true).** The request sends:
+**Dirty run today (the loaded revision has unsaved edits, `isDirty` is true).** The request sends:
 
 ```json
 "references": null
@@ -188,22 +199,82 @@ bound. `commit_revision` works.
 Run context: no workflow identity at all. `variant.id` is undefined. `commit_revision`
 throws the reported error.
 
-## The loop: why it works, then stops
+## What "dirty" means, and why the loop happens
 
-This explains the "works, then stops working in the same conversation" symptom.
+This section answers the "works, then stops working in the same conversation" symptom. It
+first pins down what `isDirty` actually compares, because the mechanism is not the one an
+early reading of this bug assumed.
 
-1. You load the agent. The panel matches the committed HEAD. `isDirty` is false.
-2. You ask for a change. The agent calls `commit_revision`. References are sent in full.
-   The commit works and creates a **new** revision. The HEAD moves forward.
-3. The panel you loaded now lags the new HEAD. The dirty check compares the panel against
-   the current HEAD and flips `isDirty` to true.
-4. You ask for another change in the same conversation. Because `isDirty` is now true, the
-   request sends `references: null`. `commit_revision` fails.
-5. Every later commit fails the same way, until the page reloads and the panel re-syncs to
-   the new HEAD.
+### The dirty check compares a revision against its own snapshot
 
-The successful commit is what poisons the next one. The agent's own success flips the dirty
-flag, and the dirty flag drops the variant.
+`isDirty` comes from `workflowMolecule.selectors.isDirty`, which reads
+`workflowIsDirtyAtomFamily`
+(`web/packages/agenta-entities/src/workflow/state/store.ts:1897-1934, 2011-2034`). For the
+loaded revision, it compares two things:
+
+- the draft overlay for that revision (`workflowBaseEntityAtomFamily(workflowId)`), which
+  holds the user's unsaved edits to the config panel, and
+- that same revision's own fetched server snapshot
+  (`workflowServerDataSelectorFamily(workflowId)` → `workflowQueryAtomFamily`, store.ts:2192-2221
+  and 1050-1077; react-query key `["workflows","revision",revisionId,projectId]`, staleTime 30s).
+
+Both sides are keyed by the **same** revision id. Revisions are immutable, so the snapshot
+never moves. There is no comparison against the variant's latest revision. That latest-revision
+query (`["workflows","latestRevision",...]`) is a different family used elsewhere. If the
+loaded revision has no draft overlay, `isDirty` returns false right away (store.ts:1903-1908).
+
+So "dirty" means one thing only: **the loaded revision carries a draft overlay.** It does not
+mean the panel lags a newer HEAD. A revision reads as dirty when the user edited the config
+panel, or when an event that should have repointed the panel was missed, or when the panel
+held unsaved edits before the conversation even started. Whenever the loaded revision is
+dirty, the old gate dropped every reference, and `commit_revision` failed.
+
+### After a self-commit, the panel already repoints to the new revision
+
+A self-commit creates a new revision. A mechanism added in issue #4920 already moves the panel
+onto that new revision, so the panel does not sit on a stale one.
+
+The backend's Vercel stream adapter derives a `data-committed-revision` event from the
+`commit_revision` tool output
+(`sdks/python/agenta/sdk/agents/adapters/vercel/stream.py:242-249, 729-756`). The chat panel
+reacts to that event (`web/oss/src/components/AgentChatSlice/AgentChatPanel.tsx:851-873`): it
+invalidates the latest-revision and inspect caches (store.ts:2632-2641) and calls
+`switchEntity`
+(`web/packages/agenta-playground/src/state/controllers/playgroundController.ts:2296-2308`) to
+repoint the loaded entity id to the new revision id. The new id has no draft overlay, so
+`isDirty` is false right away. The request builder reads the current entity through a ref at
+send time (`AgentChatPanel.tsx:380-386`), so the next run in the conversation uses the new
+revision.
+
+When everything goes right, one self-commit runs like this:
+
+1. You load a committed agent. The loaded revision has no draft overlay. `isDirty` is false.
+2. The agent calls `commit_revision`. A new revision is created.
+3. The `data-committed-revision` event arrives. `switchEntity` repoints the panel to the new
+   revision id. That id has no overlay, so `isDirty` stays false.
+4. The next commit in the same conversation runs against the new revision and works.
+
+### Why the loop was still reported
+
+The loop happens whenever the loaded revision is dirty at the moment a run is sent, for any
+reason. Two common causes:
+
+- The user edited the config panel before or during the conversation. The overlay makes the
+  revision dirty.
+- The `data-committed-revision` repointing did not complete. If the stream is aborted, the
+  event is missed, or the commit and the event race, the panel stays on the old revision id,
+  which still carries its overlay and reads as dirty.
+
+Either way, once the loaded revision is dirty, the old all-or-nothing gate sent
+`references: null`, the run context had no variant, and `commit_revision` threw the reported
+error. The observed failing turns carried `references: null` on the failing commit, which
+tells us the panel was dirty when the run was sent.
+
+This is why the run itself must always carry the variant identity, independent of panel state.
+The #4920 repointing removes one cause of a stale panel, but it depends on the stream event
+arriving and being processed by the panel's effect. Anything that interrupts the stream leaves
+the old revision loaded. The fix in plan.md makes `commit_revision` work regardless, by
+forwarding the variant on every run.
 
 ## The claim we must verify before recommending the frontend fix
 

--- a/docs/design/agent-workflows/projects/draft-run-references/status.md
+++ b/docs/design/agent-workflows/projects/draft-run-references/status.md
@@ -2,69 +2,108 @@
 
 ## State
 
-Design complete. Awaiting review on the draft PR. No code changed yet. Implementation follows
-after Mahmoud reviews the design.
-
-## Provenance
-
-- Created: 2026-07-08.
-- Author: Claude (design-first workflow via the plan-feature skill).
-- Session: https://claude.ai/code/session_01AumZJ9xRd4XYNHThqy4rTv
-- Tracking issue: https://github.com/Agenta-AI/agenta/issues/5162
-- Base branch for the PR lane: `big-agents`.
+Implemented. The design was reviewed and approved (Option 1). The frontend fix landed on the
+same PR lane. Unit tests are green. One follow-up test is deferred.
 
 ## What was done
 
 - Filed the tracking issue (#5162), reproduction-first, symptom only.
-- Verified every citation in the pre-existing diagnosis against the code at the current
-  workspace commit. All held.
-- Found one material refinement, recorded in research.md: the frontend comment's fear that
-  forwarding a bare variant re-resolves it to a HEAD revision does not apply to playground
-  runs. The re-resolution path is gated on the request having no `data.parameters`
-  (`resolver.py:577-582`), and every playground run sends `data.parameters`. This makes the
-  frontend fix both minimal and correct, and it removes the reason the comment gave for
-  dropping the variant.
+- Verified every citation in the pre-existing diagnosis against the code. Most held. One was
+  wrong and is corrected in research.md (see "Corrections after verification" below).
 - Wrote the two options, the trade-offs, and the recommendation (Option 1, the frontend fix).
+- Implemented Option 1 in `web/packages/agenta-playground/src/state/execution/agentRequest.ts`.
+  The all-or-nothing gate is now a field-level gate: `application` and `application_variant`
+  forward whenever they exist; `application_revision` forwards only on a clean run. An empty
+  gated result still falls back to `null`. The stale code comment was replaced.
+
+## Corrections after verification
+
+Two claims in the first draft of research.md were wrong. Both are fixed in the current
+research.md.
+
+- **What `isDirty` compares.** The first draft said the dirty check compares the loaded panel
+  against the variant's current HEAD, so a self-commit that moves the HEAD flips `isDirty` to
+  true. That is not what the code does. `isDirty` compares the loaded revision's draft overlay
+  against that same revision's own immutable server snapshot
+  (`web/packages/agenta-entities/src/workflow/state/store.ts:1897-1934`). There is no HEAD
+  comparison. "Dirty" means the loaded revision carries a draft overlay, for any reason.
+- **Panel re-sync after a self-commit already exists.** The reviewer suspected a stale-page
+  problem after a commit. It was real historically and is already handled by issue #4920: the
+  backend emits a `data-committed-revision` event and the chat panel calls `switchEntity` to
+  repoint onto the new revision id, which has no overlay. The residual risk is that the event
+  can be missed or the stream aborted, leaving the old revision loaded. That residual is one
+  more reason the run must carry the variant on every call, which is what this fix does.
 
 ## Key decisions
 
 - **Fix in the frontend, not the service.** The frontend owns the run identity and knows the
   loaded variant. The service option is larger and ambiguous for multi-variant apps. Full
   reasoning in plan.md.
-- **Gate the revision reference, not the variant.** Draft-ness keys only on the revision
-  reference (`tracing.py:165`), so gating the revision on `!isDirty` preserves `is_draft`
-  while the variant identity travels on every run.
-- **Panel re-sync after a self-commit is optional.** Option 1 makes the run robust with or
-  without a reload. Re-syncing the panel is a display improvement, decoupled from this fix.
+- **Gate the revision reference, not the variant or app.** Draft-ness keys only on the
+  revision reference (`tracing.py:165`), so gating the revision on `!isDirty` preserves
+  `is_draft` while the variant and app identities travel on every run.
 
-## Citations verified (at the current workspace commit)
+## Implementation
 
-- `sdks/python/agenta/sdk/agents/platform/op_catalog.py:1090-1100` — commit_revision binds the
-  variant id via context_bindings.
-- `sdks/python/agenta/sdk/agents/platform/op_catalog.py:156-173` — bound fields stripped from
-  the model-visible schema.
-- `services/runner/src/tools/direct.ts:226-236` — runner throws on a missing binding value.
-- `sdks/python/agenta/sdk/agents/tracing.py:135-166` — run-context workflow assembled from
-  references; `is_draft = revision is None`.
-- `sdks/python/agenta/sdk/decorators/running.py:354, 376` — request references merged onto the
-  tracing context.
-- `web/packages/agenta-playground/src/state/execution/agentRequest.ts:355-359` — the
-  all-or-nothing gate that drops references on a dirty run.
-- `web/packages/agenta-playground/src/state/execution/agentRequest.ts:86-117` —
-  `buildAgentReferences` builds the three families and drops non-UUID ids.
-- `web/packages/agenta-playground/src/state/execution/agentRequest.ts:378-386` — app id rides
-  the URL query even on a draft run.
-- `sdks/python/agenta/sdk/middlewares/running/resolver.py:577-582` — hydration gate that keeps
-  the bare-variant re-resolution from firing when parameters are present.
+- Code commit: `95d964f2de` (`fix(frontend): forward variant references on draft playground
+  runs`).
+- Changed file: `web/packages/agenta-playground/src/state/execution/agentRequest.ts` (the
+  reference gate and its comment).
+- Tests: `web/packages/agenta-playground/tests/unit/agentRequest.test.ts`.
+  - Dirty, committed revision: `references` carries `application` and `application_variant`,
+    omits `application_revision`.
+  - Truly-uncommitted local draft (non-UUID ids everywhere): `references` is null, unchanged.
+  - Mixed case: a local draft revision id under a committed variant still forwards
+    `application` and `application_variant`.
+  - Invariant guard: a dirty committed run still carries `data.parameters`, so the backend
+    hydration gate never fires.
+- Results: 31/31 in the file, 196/196 in the package. `pnpm lint-fix` clean.
 
-## Recorded follow-ups
+## Deferred follow-ups
 
-- **Optional panel adoption after a self-commit.** After `commit_revision` lands, sync the
-  loaded panel to the new HEAD so the version chip bumps and `isDirty` resets. Display
-  accuracy only; not required for the fix.
+- **Integration or replay test for the self-commit loop.** Turn the reported failure into a
+  replay regression test (see the `agent-replay-test` skill): the first `commit_revision`
+  succeeds, a second in the same conversation succeeds, and the second run still reports
+  `is_draft` true. Deferred as a follow-up; the unit tests cover the gate itself.
+- **Stream-event race on panel repointing.** The #4920 repointing depends on the
+  `data-committed-revision` event arriving and being processed. If the stream is aborted or
+  the event is missed, the panel stays on the old revision and reads as dirty. This fix makes
+  the run correct in that case, but the display can still lag until a reload. Tightening the
+  repointing is display accuracy only, not correctness.
 - **Long-term: server-stamped identity in run context.** Fold the client-forwarded variant
   identity into the same server-stamped `runContext` end-state that the session keep-alive
   follow-up 5 begins for project scope. See plan.md, "Adjacent work".
+
+## Citations verified
+
+- `sdks/python/agenta/sdk/agents/platform/op_catalog.py:1090-1100`: commit_revision binds the
+  variant id via context_bindings.
+- `sdks/python/agenta/sdk/agents/platform/op_catalog.py:156-173`: bound fields stripped from
+  the model-visible schema.
+- `services/runner/src/tools/direct.ts:226-236`: runner throws on a missing binding value.
+- `sdks/python/agenta/sdk/agents/tracing.py:135-166`: run-context workflow assembled from
+  references; `is_draft = revision is None`.
+- `sdks/python/agenta/sdk/decorators/running.py:354, 376`: request references merged onto the
+  tracing context.
+- `web/packages/agenta-playground/src/state/execution/agentRequest.ts`: the reference gate
+  (now field-level).
+- `web/packages/agenta-entities/src/workflow/state/store.ts:1897-1934, 2011-2034`: the
+  `isDirty` comparator: draft overlay versus the same revision's own snapshot.
+- `sdks/python/agenta/sdk/agents/adapters/vercel/stream.py:242-249, 729-756`: the
+  `data-committed-revision` event derived from the commit_revision output.
+- `web/oss/src/components/AgentChatSlice/AgentChatPanel.tsx:851-873`: the panel reacts and
+  repoints via `switchEntity`.
+- `sdks/python/agenta/sdk/middlewares/running/resolver.py:577-582`: hydration gate that keeps
+  the bare-variant re-resolution from firing when parameters are present.
+
+## Provenance
+
+- Design created: 2026-07-08. Implementation: 2026-07-09.
+- Author: Claude (design-first workflow via the plan-feature skill; implementation and
+  doc-correction pass).
+- Design session: https://claude.ai/code/session_01AumZJ9xRd4XYNHThqy4rTv
+- Tracking issue: https://github.com/Agenta-AI/agenta/issues/5162
+- Base branch for the PR lane: `big-agents`.
 
 ## Related work
 

--- a/docs/design/agent-workflows/projects/draft-run-references/status.md
+++ b/docs/design/agent-workflows/projects/draft-run-references/status.md
@@ -1,0 +1,76 @@
+# Status
+
+## State
+
+Design complete. Awaiting review on the draft PR. No code changed yet. Implementation follows
+after Mahmoud reviews the design.
+
+## Provenance
+
+- Created: 2026-07-08.
+- Author: Claude (design-first workflow via the plan-feature skill).
+- Session: https://claude.ai/code/session_01AumZJ9xRd4XYNHThqy4rTv
+- Tracking issue: https://github.com/Agenta-AI/agenta/issues/5162
+- Base branch for the PR lane: `big-agents`.
+
+## What was done
+
+- Filed the tracking issue (#5162), reproduction-first, symptom only.
+- Verified every citation in the pre-existing diagnosis against the code at the current
+  workspace commit. All held.
+- Found one material refinement, recorded in research.md: the frontend comment's fear that
+  forwarding a bare variant re-resolves it to a HEAD revision does not apply to playground
+  runs. The re-resolution path is gated on the request having no `data.parameters`
+  (`resolver.py:577-582`), and every playground run sends `data.parameters`. This makes the
+  frontend fix both minimal and correct, and it removes the reason the comment gave for
+  dropping the variant.
+- Wrote the two options, the trade-offs, and the recommendation (Option 1, the frontend fix).
+
+## Key decisions
+
+- **Fix in the frontend, not the service.** The frontend owns the run identity and knows the
+  loaded variant. The service option is larger and ambiguous for multi-variant apps. Full
+  reasoning in plan.md.
+- **Gate the revision reference, not the variant.** Draft-ness keys only on the revision
+  reference (`tracing.py:165`), so gating the revision on `!isDirty` preserves `is_draft`
+  while the variant identity travels on every run.
+- **Panel re-sync after a self-commit is optional.** Option 1 makes the run robust with or
+  without a reload. Re-syncing the panel is a display improvement, decoupled from this fix.
+
+## Citations verified (at the current workspace commit)
+
+- `sdks/python/agenta/sdk/agents/platform/op_catalog.py:1090-1100` — commit_revision binds the
+  variant id via context_bindings.
+- `sdks/python/agenta/sdk/agents/platform/op_catalog.py:156-173` — bound fields stripped from
+  the model-visible schema.
+- `services/runner/src/tools/direct.ts:226-236` — runner throws on a missing binding value.
+- `sdks/python/agenta/sdk/agents/tracing.py:135-166` — run-context workflow assembled from
+  references; `is_draft = revision is None`.
+- `sdks/python/agenta/sdk/decorators/running.py:354, 376` — request references merged onto the
+  tracing context.
+- `web/packages/agenta-playground/src/state/execution/agentRequest.ts:355-359` — the
+  all-or-nothing gate that drops references on a dirty run.
+- `web/packages/agenta-playground/src/state/execution/agentRequest.ts:86-117` —
+  `buildAgentReferences` builds the three families and drops non-UUID ids.
+- `web/packages/agenta-playground/src/state/execution/agentRequest.ts:378-386` — app id rides
+  the URL query even on a draft run.
+- `sdks/python/agenta/sdk/middlewares/running/resolver.py:577-582` — hydration gate that keeps
+  the bare-variant re-resolution from firing when parameters are present.
+
+## Recorded follow-ups
+
+- **Optional panel adoption after a self-commit.** After `commit_revision` lands, sync the
+  loaded panel to the new HEAD so the version chip bumps and `isDirty` resets. Display
+  accuracy only; not required for the fix.
+- **Long-term: server-stamped identity in run context.** Fold the client-forwarded variant
+  identity into the same server-stamped `runContext` end-state that the session keep-alive
+  follow-up 5 begins for project scope. See plan.md, "Adjacent work".
+
+## Related work
+
+- Session keep-alive, follow-up 5:
+  `docs/design/agent-workflows/projects/session-keepalive/status.md` (decision 1, follow-up 5).
+  Stamps a server-verified project scope into `runContext`. Adjacent to this design; both
+  enrich `runContext`. No contradiction: F5 fills project scope, this fills variant scope.
+- Reproduction timelines: `turn-c6de1865-timeline.md` and `turn-8110bba2-timeline*.md` at the
+  repository root (owned by Mahmoud; read-only here).

--- a/web/packages/agenta-playground/src/state/execution/agentRequest.ts
+++ b/web/packages/agenta-playground/src/state/execution/agentRequest.ts
@@ -339,24 +339,36 @@ export async function buildAgentRequest(
         | null
         | undefined
 
-    // Whether the run may CLAIM its committed identity. The service derives draft-ness purely
-    // from a resolved committed-revision reference — `services/oss/src/agent/tracing.py`
-    // `_run_context_workflow`: `is_draft = revision is None` — and a self-targeting "update myself"
-    // tool binds the revision/variant that reference resolves to. So the run may forward the
-    // reference family ONLY when it is actually running that committed revision unchanged:
-    //  - dirty (unsaved left-panel edits): the run is an inline-config draft; forwarding the
-    //    revision would wrongly mark it non-draft and bind a tool to a revision whose config
-    //    differs from what's running. The resolver also re-resolves a bare variant ref to its
-    //    latest revision, so the variant must be dropped too — send no references at all.
-    //  - uncommitted local draft (no real revision UUID): same inline-config-draft case.
-    // This matches the service's documented contract: "a playground run of an unsaved inline
-    // config carries no revision reference, so is_draft is True". App scoping rides the
-    // `application_id` URL query (derived below), so a draft run stays associated with its app.
+    // Field-level reference gate. The service derives draft-ness purely from the revision
+    // reference — `services/oss/src/agent/tracing.py` `_run_context_workflow`:
+    // `is_draft = revision is None` — so ONLY `application_revision` is gated on cleanliness:
+    //  - dirty (unsaved left-panel edits) or an uncommitted local draft (no real revision UUID):
+    //    the run is an inline-config draft, so the revision reference is withheld to keep
+    //    `is_draft` true.
+    // `application` and `application_variant` are forwarded whenever they exist, independent of
+    // dirtiness: the variant identifies WHICH variant is running, which is orthogonal to
+    // draft-ness, and a self-targeting tool (e.g. `commit_revision`) needs that variant to bind
+    // to even on a draft run. Forwarding a bare variant does not resurrect `is_draft`: the
+    // backend only re-resolves a variant reference to its HEAD revision when the request carries
+    // no `data.parameters` (`resolver.py` `needs_reference_hydration`), and a playground run
+    // always sends `data.parameters` — see the "invariant guard" test for this file.
     const fullReferences = buildAgentReferences(entity)
     const isDirty = store.get(workflowMolecule.selectors.isDirty(entityId)) as boolean
     const isCommittedRevisionRun =
         !isDirty && typeof fullReferences?.application_revision?.id === "string"
-    const references = isCommittedRevisionRun ? fullReferences : null
+    const gatedReferences = fullReferences
+        ? {
+              ...(fullReferences.application ? {application: fullReferences.application} : {}),
+              ...(fullReferences.application_variant
+                  ? {application_variant: fullReferences.application_variant}
+                  : {}),
+              ...(isCommittedRevisionRun
+                  ? {application_revision: fullReferences.application_revision}
+                  : {}),
+          }
+        : null
+    const references =
+        gatedReferences && Object.keys(gatedReferences).length > 0 ? gatedReferences : null
 
     const headersFactory = store.get(executionHeadersAtom)
     // Negotiation 1 (transport): the Accept header picks the response channel `/invoke`

--- a/web/packages/agenta-playground/tests/unit/agentRequest.test.ts
+++ b/web/packages/agenta-playground/tests/unit/agentRequest.test.ts
@@ -400,11 +400,11 @@ describe("buildAgentRequest", () => {
         expect(refs.application_revision).toMatchObject({id: REAL_REV, version: "3"})
     })
 
-    it("OMITS references for a DIRTY committed revision (inline-config draft), keeping app scoping", async () => {
-        // Unsaved left-panel edits make this an inline-config draft. Forwarding the committed
-        // revision would wrongly mark it non-draft and bind a self-targeting tool to a revision
-        // whose config differs from what's running, so references are dropped entirely. The app
-        // still scopes the run via the URL query.
+    it("keeps application + application_variant but OMITS application_revision for a DIRTY committed revision", async () => {
+        // Unsaved left-panel edits make this an inline-config draft, so the revision reference is
+        // withheld (keeps `is_draft` true). The variant identity is orthogonal to draft-ness — a
+        // self-targeting tool (e.g. `commit_revision`) still needs it to bind to — so it is
+        // forwarded along with the app. references is NOT null.
         seed(store, "e", {
             isDirty: true,
             data: {
@@ -415,19 +415,66 @@ describe("buildAgentRequest", () => {
             },
         })
         const req = await buildAgentRequest("e", [], {sessionId: "s1", store})
-        expect(req!.requestBody.references).toBeNull()
+        const refs = req!.requestBody.references as any
+        expect(refs).not.toBeNull()
+        expect(refs.application.id).toBe(REAL_APP)
+        expect(refs.application_variant.id).toBe(REAL_VARIANT)
+        expect(refs.application_revision).toBeUndefined()
         expect(req!.invocationUrl).toContain(`application_id=${REAL_APP}`)
     })
 
-    it("OMITS references for an UNCOMMITTED local draft (no real revision id), keeping app scoping", async () => {
-        // A never-committed local draft has no committed revision UUID, so it is an inline-config
-        // draft too — send no references, but keep the app scoping in the URL.
+    it("OMITS references entirely for a truly UNCOMMITTED local draft (no real app/variant/revision ids)", async () => {
+        // A brand-new agent that was never saved has no real ids anywhere, so `buildAgentReferences`
+        // drops every family and there is no variant to forward — references stays null, unchanged.
+        seed(store, "e", {
+            data: {
+                id: "draft-local-xyz",
+                workflow_id: "draft-app-xyz",
+                workflow_variant_id: "draft-variant-xyz",
+            },
+        })
+        const req = await buildAgentRequest("e", [], {sessionId: "s1", store})
+        expect(req!.requestBody.references).toBeNull()
+    })
+
+    it("forwards application + application_variant for a local draft revision id under an already-committed variant", async () => {
+        // The revision id is local (never committed), but the app/variant were loaded from a real
+        // committed variant. The variant is real, so it is forwarded even though there is no
+        // revision reference yet; app scoping also rides the URL query.
         seed(store, "e", {
             data: {id: "draft-local-xyz", workflow_id: REAL_APP, workflow_variant_id: REAL_VARIANT},
         })
         const req = await buildAgentRequest("e", [], {sessionId: "s1", store})
-        expect(req!.requestBody.references).toBeNull()
+        const refs = req!.requestBody.references as any
+        expect(refs).not.toBeNull()
+        expect(refs.application.id).toBe(REAL_APP)
+        expect(refs.application_variant.id).toBe(REAL_VARIANT)
+        expect(refs.application_revision).toBeUndefined()
         expect(req!.invocationUrl).toContain(`application_id=${REAL_APP}`)
+    })
+
+    it("invariant guard: a dirty committed run still carries data.parameters alongside the bare-variant references", async () => {
+        // Option 1 depends on the backend never re-resolving a bare variant reference to its HEAD
+        // revision. That re-resolution is gated on the request carrying no `data.parameters`
+        // (`resolver.py` `needs_reference_hydration`), and a playground run always sends
+        // `data.parameters`. Lock that invariant here so a regression is caught in CI.
+        seed(store, "e", {
+            isDirty: true,
+            config: {temperature: 0.9},
+            data: {
+                id: REAL_REV,
+                version: 3,
+                workflow_id: REAL_APP,
+                workflow_variant_id: REAL_VARIANT,
+            },
+        })
+        const req = await buildAgentRequest("e", [], {sessionId: "s1", store})
+        const data = req!.requestBody.data as any
+        expect(data.parameters).toBeDefined()
+        expect(Object.keys(data.parameters).length).toBeGreaterThan(0)
+        const refs = req!.requestBody.references as any
+        expect(refs.application_variant.id).toBe(REAL_VARIANT)
+        expect(refs.application_revision).toBeUndefined()
     })
 
     it("puts project_id + application_id in the URL QUERY, never the body", async () => {


### PR DESCRIPTION
## Context

When an agent commits itself in the playground, the first `commit_revision` works, but every
later `commit_revision` in the same conversation fails with:

```
missing run-context value for direct-call binding 'workflow_revision.workflow_variant_id'
```

The cause is on the frontend. `commit_revision` is a platform op whose target variant is a
context binding, filled from the run's `references` block, never by the model. The request
builder gated that whole block on an all-or-nothing rule: if the loaded revision had unsaved
edits (`isDirty`), it sent `references: null`. With no references, the run context has no
variant, and the runner throws.

"Dirty" here does not mean the panel lags a newer revision. It means the loaded revision
carries a draft overlay, for any reason: the user edited the config panel, or the panel had
edits before the conversation started, or the post-commit repointing added in #4920 did not
land. Whenever that was true, the old gate dropped the variant and the commit failed.

## Changes

The gate is now field-level instead of all-or-nothing. `application` and `application_variant`
forward whenever they exist. `application_revision` forwards only on a clean run, because the
revision reference is the one signal that marks a run as non-draft (`is_draft = revision is
None` in the SDK). An empty result still falls back to `null`.

The `references` block on a dirty run of a committed agent:

Before:

```json
"references": null
```

After:

```json
"references": {
  "application":         {"id": "<app-uuid>",     "slug": "my-agent"},
  "application_variant": {"id": "<variant-uuid>", "slug": "my-agent.default"}
}
```

The run context now has `variant.id` set and `revision` unset, so `is_draft` stays true and
`commit_revision` has its target. A clean run is unchanged: it still sends all three families
and stays non-draft.

This lives on the frontend read path because the frontend owns the run identity and knows
exactly which variant is loaded. It is one gate expression in one file, plus tests. No wire,
SDK, or runner change: the backend already reads the variant reference it is handed.

The design docs on this PR carry the full mechanism, the reasoning for the frontend layer, and
the verification that forwarding a bare variant does not re-resolve it to a HEAD revision:
`docs/design/agent-workflows/projects/draft-run-references/`.

## Scope / risk

- Only the playground reference gate changes. A never-committed local draft still forwards no
  variant, because it has no real variant id yet. That case is unchanged and out of scope.
- The #4920 post-commit repointing depends on a stream event arriving. If the stream aborts or
  the event is missed, the panel stays on the old revision and reads as dirty. This fix makes
  the run correct in that case; tightening the repointing is a separate display concern.
- Deferred follow-up: an integration or replay test for the full self-commit loop (first and
  second commit in one conversation), noted in status.md.

## Tests

- `web/packages/agenta-playground/tests/unit/agentRequest.test.ts`: dirty committed run
  (references carry app + variant, omit revision), truly-uncommitted local draft (references
  null), a mixed case (local draft revision id under a committed variant still forwards app +
  variant), and an invariant guard (a dirty run still carries `data.parameters`, so the
  backend hydration gate never fires).
- 31/31 in the file, 196/196 in the package. `pnpm lint-fix` clean.

## How to QA

**Prerequisites:** local dev stack, or any environment with an agent app that has been
committed at least once.

**Steps:**
1. Open the playground for a committed agent.
2. In one conversation, ask the agent to make a change and commit it.
3. Without reloading, ask for a second change and commit it in the same conversation.

**Expected result:** Both commits land and two new versions appear, with no page reload. The
second commit no longer fails with the `workflow_revision.workflow_variant_id` binding error.

**Automated tests:**

```
pnpm --filter @agenta/playground test -- agentRequest
```

**Edge cases:** A clean run (no unsaved edits) must still send all three reference families
and stay non-draft. A brand-new agent that was never committed still cannot self-commit, which
is correct: there is no variant to target yet.

Closes #5162.

https://claude.ai/code/session_01CSTSEXSe4DDhoXCFjZpZ5W
