### PR TITLE
[5083] fix(sdk): don't leak internal tracebacks in agent invoke errors

### DIFF
--- a/sdks/python/agenta/sdk/decorators/routing.py
+++ b/sdks/python/agenta/sdk/decorators/routing.py
@@ -27,6 +27,9 @@ from agenta.sdk.middlewares.running.vault import invalidate_secrets_cache
 from agenta.sdk.contexts.tracing import TracingContext, tracing_context_manager
 from agenta.sdk.decorators.running import auto_workflow, inspect_workflow, Workflow
 from agenta.sdk.engines.running.errors import ErrorStatus
+from agenta.sdk.utils.logging import get_module_logger
+
+log = get_module_logger(__name__)
 
 
 # ---------------------------------------------------------------------------
@@ -277,12 +280,15 @@ async def handle_invoke_success(
 async def handle_invoke_failure(exception: Exception) -> Response:
     status = None
 
+    # Traceback is logged server-side only, never returned to the client.
+    stacktrace = None
+
     if isinstance(exception, ErrorStatus):
+        stacktrace = exception.stacktrace
         status = WorkflowServiceStatus(
             type=exception.type,
             code=exception.code,
             message=exception.message,
-            stacktrace=exception.stacktrace,
         )
 
     else:
@@ -299,17 +305,18 @@ async def handle_invoke_failure(exception: Exception) -> Response:
 
         message = str(exception) or "Internal Server Error"
 
-        stacktrace = format_exception(
-            exception,  # type: ignore
-            value=exception,
-            tb=exception.__traceback__,
+        stacktrace = "".join(
+            format_exception(
+                exception,  # type: ignore
+                value=exception,
+                tb=exception.__traceback__,
+            )
         )
 
         status = WorkflowServiceStatus(
             type=type,
             code=code,
             message=message,
-            stacktrace=stacktrace,
         )
 
     trace_id = None
@@ -326,6 +333,16 @@ async def handle_invoke_failure(exception: Exception) -> Response:
 
     error = WorkflowBatchResponse(
         status=status,
+        trace_id=trace_id,
+        span_id=span_id,
+    )
+
+    log.warning(
+        "Workflow handler invocation failed",
+        status_code=status.code if status else None,
+        status_type=status.type if status else None,
+        message=status.message if status else None,
+        stacktrace=stacktrace,
         trace_id=trace_id,
         span_id=span_id,
     )

--- a/sdks/python/agenta/sdk/middlewares/running/normalizer.py
+++ b/sdks/python/agenta/sdk/middlewares/running/normalizer.py
@@ -212,13 +212,15 @@ class NormalizerMiddleware:
         exc: Exception,
     ) -> WorkflowServiceBatchResponse:
         error_status = None
+        # Traceback is logged server-side only, never returned to the client.
+        stacktrace = None
 
         if isinstance(exc, ErrorStatus):
+            stacktrace = exc.stacktrace
             error_status = WorkflowServiceStatus(
                 type=exc.type,
                 code=exc.code,
                 message=exc.message,
-                stacktrace=exc.stacktrace,
             )
         else:
             type = "https://agenta.ai/docs/errors#v1:sdk:unknown-workflow-invoke-error"
@@ -230,17 +232,18 @@ class NormalizerMiddleware:
 
             message = str(exc) or "Internal Server Error"
 
-            stacktrace = format_exception(
-                exc,  # type: ignore
-                value=exc,
-                tb=exc.__traceback__,
+            stacktrace = "".join(
+                format_exception(
+                    exc,  # type: ignore
+                    value=exc,
+                    tb=exc.__traceback__,
+                )
             )
 
             error_status = WorkflowServiceStatus(
                 type=type,
                 code=code,
                 message=message,
-                stacktrace=stacktrace,
             )
 
         trace_id = None
@@ -266,6 +269,7 @@ class NormalizerMiddleware:
             status_code=error_status.code if error_status else None,
             status_type=error_status.type if error_status else None,
             message=error_status.message if error_status else None,
+            stacktrace=stacktrace,
             trace_id=trace_id,
             span_id=span_id,
         )

--- a/sdks/python/oss/tests/pytest/unit/test_invoke_failure_no_traceback.py
+++ b/sdks/python/oss/tests/pytest/unit/test_invoke_failure_no_traceback.py
@@ -1,0 +1,38 @@
+import json
+
+import pytest
+
+from agenta.sdk.decorators.routing import handle_invoke_failure
+from agenta.sdk.engines.running.errors import ErrorStatus
+
+
+def _body(response):
+    return json.loads(response.body.decode())
+
+
+@pytest.mark.asyncio
+async def test_generic_exception_response_has_no_traceback():
+    try:
+        raise ValueError("boom")
+    except ValueError as exc:
+        response = await handle_invoke_failure(exc)
+
+    status = _body(response)["status"]
+    assert status["message"] == "boom"
+    assert status.get("stacktrace") is None
+    assert "Traceback" not in json.dumps(_body(response))
+
+
+@pytest.mark.asyncio
+async def test_error_status_response_drops_its_stacktrace():
+    exc = ErrorStatus(
+        code=500,
+        type="https://agenta.ai/docs/errors#test",
+        message="clean message",
+        stacktrace="Traceback (most recent call last): ...",
+    )
+    response = await handle_invoke_failure(exc)
+
+    status = _body(response)["status"]
+    assert status["message"] == "clean message"
+    assert status.get("stacktrace") is None


### PR DESCRIPTION
Fixes #5083

## Summary

When an agent invoke fails (`POST /services/agent/v0/invoke`), the JSON error body included the full Python traceback in `status.stacktrace`: file paths, line numbers, the whole call stack. A client can't do anything useful with that, and it exposes server internals to anyone who triggers an error.

This change sends the traceback to the server log and drops it from the response. The client still gets `code`, `message`, and the docs-link `type`.

Two places built the leaky error status, and both are fixed:

- `sdk/middlewares/running/normalizer.py`, `NormalizerMiddleware._normalize_exception` (the path in the reported traceback)
- `sdk/decorators/routing.py`, `handle_invoke_failure`

Both paths are covered: the generic exception path that called `format_exception`, and `ErrorStatus.stacktrace` (several `ErrorStatus` subclasses accept a stacktrace, which also reached the client). `routing.py` had no logger at all before, so this adds the module logger there.

Before:
```json
{"status":{"code":500,"message":"...","stacktrace":["Traceback (most recent call last):\n","  File \"/.../middlewares/running/normalizer.py\", line 292, ...]}}
```

After:
```json
{"status":{"code":500,"type":"https://agenta.ai/docs/errors#v1:sdk:unknown-workflow-invoke-error","message":"..."}}
```

The traceback now shows up only in the server log line `Workflow handler invocation failed`.

One scope note: the issue also mentions a possibly misleading "add the project's OpenAI key" message. The issue author couldn't reproduce that independently and traced it to a misconfigured agent, so it's left out here. This PR only fixes the traceback leak.

## Testing

### Verified locally
- `ruff format` and `ruff check` on the changed files pass.
- Changed files byte-compile.
- `uv sync` in `sdks/python`, then ran the new test: 2 passed.
- Ran a forced invoke failure against main and against this branch to capture the before/after responses shown in the demo.

### Added or updated tests
`oss/tests/pytest/unit/test_invoke_failure_no_traceback.py`: asserts the invoke error response carries a clean message and no `stacktrace`, for both the generic exception and `ErrorStatus` paths.

### QA follow-up
If possible, force an invoke failure against a self-hosted instance and check that the response is clean and the traceback lands in the server logs.

## Demo
Before and after, same forced invoke failure through `handle_invoke_failure`, plus the new test run:

![before and after: traceback removed from client response](https://raw.githubusercontent.com/wuisabel-gif/agenta/pr-5083-assets/demo-5083.png)

## Checklist
- [x] I have included a video or screen recording for UI changes, or marked Demo as N/A
- [x] Relevant tests pass locally
- [x] Relevant linting and formatting pass locally
- [x] I have signed the CLA, or I will sign it when the bot prompts me
