### PR TITLE
fix: update dark theme colors to match Figma design system

### DIFF
--- a/web/oss/src/components/Layout/ThemeContextProvider.tsx
+++ b/web/oss/src/components/Layout/ThemeContextProvider.tsx
@@ -79,7 +79,7 @@ const stripComponentColors = <T extends Record<string, Record<string, unknown>>>
 const DARK_TOKEN_OVERRIDES = {
     // Brand accent — the light navy primary (#1c2c3d) is invisible on dark, so the
     // accent becomes the Agenta brand yellow (logo color).
-    colorPrimary: "#f2f25c",
+    colorPrimary: "#F2F25C",
     colorSuccess: "#52c41a",
     colorWarning: "#faad14",
     colorError: "#ff4d4f",
@@ -87,9 +87,9 @@ const DARK_TOKEN_OVERRIDES = {
     // darkAlgorithm falls back to a harsh default blue. Pin a softer, dark-tuned
     // link blue (GitHub-style) so every antd link (Typography.Link, type="link",
     // anchors) reads as a clickable affordance without the jarring tone.
-    colorLink: "#58a6ff",
-    colorLinkHover: "#79b8ff",
-    colorLinkActive: "#3b8eea",
+    colorLink: "#F2F25C",
+    colorLinkHover: "#C2C24A",
+    colorLinkActive: "#919137",
     // Overlay elevation. antd's default drop-shadows are invisible on a dark
     // surface, so popovers/dropdowns/selects/tooltips/modals blended into the
     // page with no depth. Lead every elevation shadow with a 1px light ring
@@ -123,7 +123,7 @@ const DARK_TOKEN_OVERRIDES = {
     // Lift the overlay surface a touch more above the page so popups read as a
     // distinct layer, not just a ring (container is ~#141414; default elevated
     // ~#1f1f1f is only marginally lighter).
-    colorBgElevated: "#242424",
+    colorBgElevated: "#11100F",
     // Placeholder text. darkAlgorithm derives colorTextPlaceholder at 25% white,
     // which is barely legible against the dark input surface. Lift it to 38% so
     // placeholders read clearly everywhere (Input/Select/TextArea/DatePicker/
@@ -131,11 +131,15 @@ const DARK_TOKEN_OVERRIDES = {
     // all placeholders in one place instead of per-input patches.
     colorTextPlaceholder: "rgba(255, 255, 255, 0.38)",
     // Surfaces / text / border come from darkAlgorithm by default. Uncomment to tune:
-    // colorBgContainer: "#141414",
+    colorBgBase: "#000000",
+    colorBgContainer: "#11100F",
     // colorBgElevated: "#1f1f1f",
     // colorBgLayout: "#000000",
-    // colorText: "rgba(255, 255, 255, 0.85)",
-    // colorBorder: "#424242",
+    colorText: "#F6F4F3",
+    colorBorder: "#52504E",
+    colorBorderSecondary: "#1F1E1D",
+    colorSplit: "#1F1E1D",
+    colorPrimaryBg: "#303012",
 }
 // On a bright yellow primary, antd's default light-solid (#fff) label is unreadable —
 // force dark text on primary-colored buttons in dark mode.

--- a/web/oss/src/components/Layout/assets/styles.ts
+++ b/web/oss/src/components/Layout/assets/styles.ts
@@ -7,7 +7,7 @@ export type StyleProps = MainStyleProps
 export const useStyles = createUseStyles((theme: JSSTheme) => ({
     layout: ({themeMode}: StyleProps) => ({
         display: "flex",
-        background: themeMode === "dark" ? "#141414" : "#ffffff",
+        background: themeMode === "dark" ? "#000" : "#ffffff",
         height: "100%",
         minHeight: "100vh",
         position: "relative",
@@ -27,7 +27,7 @@ export const useStyles = createUseStyles((theme: JSSTheme) => ({
         justifyContent: "space-between",
         width: "100%",
         padding: "8px 1.5rem",
-        borderBottom: `1px solid ${theme.colorBorderSecondary}`,
+        borderBottom: `1px solid ${theme.colorSplit}`,
     },
     topRightBar: {
         display: "flex",

--- a/web/oss/src/components/Sidebar/Sidebar.tsx
+++ b/web/oss/src/components/Sidebar/Sidebar.tsx
@@ -90,7 +90,7 @@ const Sidebar: React.FC<{showSettingsView?: boolean; lastPath?: string}> = ({
     }, [openKeys[0]])
 
     return (
-        <div className="border-0 border-r border-solid border-gray-100">
+        <div className="border-0 border-r border-solid border-colorSplit">
             <Sider
                 theme={appTheme}
                 className="sticky top-0 bottom-0 h-screen bg-[var(--ag-sidebar-bg)]"

--- a/web/oss/src/components/SidebarBanners/SidebarBanner.tsx
+++ b/web/oss/src/components/SidebarBanners/SidebarBanner.tsx
@@ -29,7 +29,7 @@ const SidebarBanner = ({banner, onDismiss}: SidebarBannerProps) => {
     // If custom content is provided, render it instead
     if (banner.customContent) {
         return (
-            <section className="p-4 rounded-lg flex flex-col gap-2 bg-[var(--ag-c-F5F7FA)] relative">
+            <section className="p-4 rounded-lg flex flex-col gap-2 bg-colorPrimaryBg relative">
                 {banner.dismissible && onDismiss && (
                     <button
                         onClick={onDismiss}
@@ -45,7 +45,7 @@ const SidebarBanner = ({banner, onDismiss}: SidebarBannerProps) => {
     }
 
     return (
-        <section className="p-4 rounded-lg flex flex-col gap-2 bg-[var(--ag-c-F5F7FA)] relative">
+        <section className="p-4 rounded-lg flex flex-col gap-2 bg-colorPrimaryBg relative">
             {banner.dismissible && onDismiss && (
                 <button
                     onClick={onDismiss}

--- a/web/oss/src/components/pages/app-management/components/HelpAndSupportSection.tsx
+++ b/web/oss/src/components/pages/app-management/components/HelpAndSupportSection.tsx
@@ -8,7 +8,7 @@ const {Text, Title} = Typography
 // inherit antd's colorLink (blue in dark). Use neutral text color (text-colorText)
 // so the cards read as content, not links.
 const helperCardClass =
-    "max-w-[400px] flex-1 gap-3 cursor-pointer flex items-center transition-all duration-[25ms] ease-in border border-colorBorderSecondary rounded-md p-3 text-colorText [&_span.ant-typography]:overflow-hidden [&_span.ant-typography]:text-ellipsis [&_span.ant-typography]:whitespace-nowrap [&_span.ant-typography]:text-base [&_span.ant-typography]:font-medium [&_span.ant-typography]:leading-normal [&_span.ant-typography]:flex-1 hover:shadow-[0_1px_2px_0_rgba(0,0,0,0.03),0_1px_6px_-1px_rgba(0,0,0,0.02),0_2px_4px_0_rgba(0,0,0,0.02)]"
+    "max-w-[400px] flex-1 gap-3 cursor-pointer flex items-center transition-all duration-[25ms] ease-in border border-solid border-colorBorderSecondary rounded-md p-3 text-colorText [&_span.ant-typography]:overflow-hidden [&_span.ant-typography]:text-ellipsis [&_span.ant-typography]:whitespace-nowrap [&_span.ant-typography]:text-base [&_span.ant-typography]:font-medium [&_span.ant-typography]:leading-normal [&_span.ant-typography]:flex-1 hover:shadow-[0_1px_2px_0_rgba(0,0,0,0.03),0_1px_6px_-1px_rgba(0,0,0,0.02),0_2px_4px_0_rgba(0,0,0,0.02)]"
 
 const HelpAndSupportSection = () => {
     return (

--- a/web/oss/src/components/pages/app-management/components/WelcomeCardsSection/assets/components/WelcomeCard.tsx
+++ b/web/oss/src/components/pages/app-management/components/WelcomeCardsSection/assets/components/WelcomeCard.tsx
@@ -9,7 +9,7 @@ interface WelcomeCardProps {
 }
 
 const welcomeCardContainerClass =
-    "flex flex-col w-full flex-1 border border-colorBorderSecondary rounded-[10px] bg-colorBgContainer shadow-[0_1px_2px_0_rgba(0,0,0,0.03),0_1px_6px_-1px_rgba(0,0,0,0.02),0_2px_4px_0_rgba(0,0,0,0.02)] cursor-pointer transition-colors duration-200 hover:bg-colorFillTertiary"
+    "flex flex-col w-full flex-1 border border-solid border-colorBorderSecondary rounded-[10px] bg-colorBgContainer shadow-[0_1px_2px_0_rgba(0,0,0,0.03),0_1px_6px_-1px_rgba(0,0,0,0.02),0_2px_4px_0_rgba(0,0,0,0.02)] cursor-pointer transition-colors duration-200 hover:bg-colorFillTertiary"
 
 const WelcomeCard = ({title, subtitle, onClick, hidden}: WelcomeCardProps) => {
     return (

--- a/web/oss/src/styles/theme-variables.css
+++ b/web/oss/src/styles/theme-variables.css
@@ -41,6 +41,7 @@
     --ag-colorSplit: rgba(5, 23, 41, 0.06);
     --ag-colorPrimary: #1c2c3d;
     --ag-colorPrimaryText: #1c2c3d;
+    --ag-colorPrimaryBg: #f5f7fa;
     --ag-colorSuccess: #389e0d;
     --ag-colorWarning: #faad14;
     --ag-colorWarningText: #faad14;
@@ -123,6 +124,7 @@
     --ag-colorSplit: var(--ant-color-split);
     --ag-colorPrimary: var(--ant-color-primary);
     --ag-colorPrimaryText: var(--ant-color-primary-text);
+    --ag-colorPrimaryBg: var(--ant-color-primary-bg);
     --ag-colorSuccess: var(--ant-color-success);
     --ag-colorWarning: var(--ant-color-warning);
     --ag-colorWarningText: var(--ant-color-warning-text);
@@ -470,7 +472,7 @@
     --ag-sidebar-bg: #ffffff;
 }
 .dark {
-    --ag-sidebar-bg: #0d0d0d;
+    --ag-sidebar-bg: #11100F;
 }
 
 /* Evaluations "Application" cell (app name + variant slug + version chip). The

--- a/web/oss/src/styles/tokens/antd-themeConfig.json
+++ b/web/oss/src/styles/tokens/antd-themeConfig.json
@@ -940,7 +940,7 @@
             "colorBgContainer": "#ffffff",
             "subMenuItemBorderRadius": 6,
             "popupBg": "#ffffff",
-            "itemSelectedColor": "#1c2c3d",
+            "itemSelectedColor": "${colorText}",
             "itemSelectedBg": "#f5f7fa",
             "itemHoverColor": "#1c2c3d",
             "itemHoverBg": "rgba(5, 23, 41, 0.06)",

--- a/web/oss/tailwind.config.ts
+++ b/web/oss/tailwind.config.ts
@@ -103,6 +103,7 @@ const themeAwareColors = {
     colorSplit: v("colorSplit"),
     colorPrimary: v("colorPrimary"),
     colorPrimaryText: v("colorPrimaryText"),
+    colorPrimaryBg: v("colorPrimaryBg"),
     colorSuccess: v("colorSuccess"),
     colorWarning: v("colorWarning"),
     colorWarningText: v("colorWarningText"),


### PR DESCRIPTION
## Summary
Updated dark theme colors across the frontend to match the Figma design system. 
The previous dark theme colors were inconsistently applied ("vibe coded") and 
didn't align with the official design tokens. This PR replaces them with the 
correct values exported directly from Figma.

## Changes
- `ThemeContextProvider.tsx` — replaced DARK_TOKEN_OVERRIDES with Figma tokens
- `theme-variables.css` — updated .dark CSS variable values
- `antd-themeConfig.json` — updated token values
- `tailwind.config.ts` — updated theme-aware colors
- Various component files — fixed hardcoded dark mode colors

## Demo
<img width="2559" height="1266" alt="image" src="https://github.com/user-attachments/assets/da85dc19-b0e9-4101-aca5-1dc33555aafa" />

## Testing
- Ran the app locally
- Switched to dark mode and verified colors match Figma design system

