### PR TITLE
[docs] Plan: fork sandbox-agent to fix the runner orphan-process leak

### DIFF
--- a/docs/design/sandbox-agent-fork/README.md
+++ b/docs/design/sandbox-agent-fork/README.md
@@ -1,0 +1,28 @@
+# sandbox-agent fork — planning workspace
+
+Maintain a temporary fork of `rivet-dev/sandbox-agent` in the agenta-ai org so
+runner-critical fixes ship in hours instead of waiting on a dormant upstream. First fix:
+the orphaned `claude`/`claude-agent-acp` process leak that OOMs the runner (one leaked
+pair per run; 49.7 GiB / 7029 PIDs in 24h on the team dev box, 2026-07-09).
+
+## Files
+
+- [`context.md`](context.md) — the two incidents, the root cause, the fork decision and
+  its goals/non-goals.
+- [`research.md`](research.md) — leak mechanics with code references (runner + deployed
+  SDK + upstream Rust), local consumption map, upstream repo deep-dive, pkg.pr.new
+  assessment.
+- [`plan.md`](plan.md) — the fix design (process-group kill + SIGTERM handling), fork
+  mechanics (branching, fork CI, pkg.pr.new publishing, pnpm overrides), sync/exit
+  criteria, milestones M0–M5, leak-detection runbook.
+- [`status.md`](status.md) — current progress, open questions, blockers. Source of truth.
+
+## TL;DR of the design
+
+Fork from the `v0.4.2` tag onto an `agenta` branch. Fix in the Rust server: spawn each
+ACP adapter in its own process group and kill the group on shutdown; handle SIGTERM like
+SIGINT. Validate on the dev box via `SANDBOX_AGENT_BIN` before building any publishing.
+Publish linux binaries per-commit via pkg.pr.new (no npm); consume via two
+`pnpm.overrides` URLs in `services/runner`. Every fix also goes upstream as a PR
+(issue #201 is this exact leak, closed without a fix). The fork retires when upstream
+merges, releases, and shows signs of life.

--- a/docs/design/sandbox-agent-fork/context.md
+++ b/docs/design/sandbox-agent-fork/context.md
@@ -1,0 +1,65 @@
+# Context: forking sandbox-agent
+
+## Why this work exists
+
+The runner depends on the `sandbox-agent` npm package (JS SDK + platform CLI binaries) to
+spawn and drive coding-harness sessions. We hit a second production-grade incident caused
+by its process lifecycle, and we cannot fix it from our side of the API:
+
+- **2026-07-06 dev-box incident:** orphaned `claude-agent-acp` processes accumulated until
+  the runner container OOMed. Fixed in #5102 by sending a graceful `destroySession` before
+  `destroySandbox` at teardown.
+- **2026-07-09 recurrence:** `agenta-oss-team-runner-1` at 49.7 GiB / 7029 PIDs within 24h
+  of a restart. Diagnosis (this session): ~300 orphaned `claude` + `claude-agent-acp`
+  pairs, one per run — a 100% per-run leak rate.
+
+Root cause of the recurrence: the #5102 fix calls `SandboxAgent.destroySession()`, but in
+sandbox-agent 0.4.2 that method is a *logical* destroy only — it cancels pending
+permissions, sends ACP `session/cancel`, and stamps `destroyedAt` on the session record
+(`dist/chunk-TVCDKGSM.js:1366`). It never terminates the ACP adapter subprocess or the
+harness CLI it wraps. `destroySandbox` then kills only the sandbox-agent server pid, not
+its process tree, so the adapter and harness reparent to PID 1 and live forever. Every
+run leaks one pair (~80–160 MB each).
+
+The fix belongs inside sandbox-agent (the server spawns the adapter; only it can reliably
+kill the child process tree). Upstream is `rivet-dev/sandbox-agent`, Apache-2.0, with a
+single maintainer. We cannot block runner reliability on upstream review latency.
+
+## Decision (Mahmoud, 2026-07-09)
+
+Maintain a fork hosted in the agenta-ai GitHub org:
+
+- We land runner-critical fixes on the fork immediately and consume the fork in our npm
+  installs.
+- Every fix is also opened as a PR upstream (`rivet-dev/sandbox-agent`).
+- We keep the fork synced with upstream releases.
+- The fork is **temporary but real**: it retires when the issues are fixed upstream and we
+  trust the upstream project more. Mahmoud has already reached out to the founder
+  (Nathan Flurry).
+
+## Goals
+
+1. Unblock runner-critical fixes: hours, not upstream-review-latency.
+2. First fix shipped through the fork: `destroySession` / `destroySandbox` (or server
+   shutdown) must kill the ACP adapter + harness child process tree, so the orphan leak
+   stops at the source.
+3. Low-friction consumption: `services/runner` installs the fork like any npm dep, in dev,
+   Docker images, and (if applicable) Daytona sandboxes.
+4. Cheap upstream sync: pulling a new upstream release into the fork is a routine,
+   documented operation, not surgery.
+5. Clean exit: switching back to upstream is a version bump, not a migration.
+
+## Non-goals
+
+- Diverging the fork's API from upstream. The fork carries fixes we intend to upstream,
+  nothing Agenta-specific.
+- Rewriting or vendoring sandbox-agent into the monorepo.
+- Fixing the leak runner-side only (process-group kill in the runner is a possible
+  *backstop*, but the decided path is fixing it in sandbox-agent via the fork).
+
+## Related
+
+- Leak diagnosis and keep-alive interplay: see `research.md` (this workspace).
+- Session keep-alive pool: #5156 / #5158 (orthogonal — the pool never engages on the
+  affected box because mount signing 503s and every run degrades to cold).
+- #5102: the prior partial fix (graceful destroySession at teardown).

--- a/docs/design/sandbox-agent-fork/plan.md
+++ b/docs/design/sandbox-agent-fork/plan.md
@@ -1,0 +1,154 @@
+# Plan: agenta-ai/sandbox-agent fork
+
+Prereq reading: `context.md` (why), `research.md` (leak mechanics, upstream facts, local
+consumption map). Summary of the ground truth this plan builds on:
+
+- The fix must land in the **Rust server** (`acp-http-adapter`): only the adapter's
+  parent can kill the process tree. No SDK-side or runner-side change fully fixes it.
+- Upstream is effectively dormant (0 commits Apr–May 2026, issue #201 — this exact leak —
+  closed without a fix). PRs go upstream anyway; we don't wait on them.
+- We consume `sandbox-agent@0.4.2` via pnpm in `services/runner` only; the binaries are
+  transitive optionalDependencies. Daytona uses a separate Docker base image and is not
+  affected by the leak (deleting the remote sandbox kills its processes).
+- Publish channel for now: **pkg.pr.new** (Mahmoud's call) — no npm publishing.
+
+## The fix itself (fork commit 1, also the upstream PR)
+
+Two small, upstreamable changes to the Rust server, developed on the fork:
+
+1. **Spawn each ACP adapter in its own process group** and kill the group on shutdown.
+   `server/packages/acp-http-adapter/src/process.rs`: add `command.process_group(0)`
+   (Unix) at spawn; in `AdapterRuntime::shutdown`, signal the group — SIGTERM to `-pgid`,
+   bounded wait, then SIGKILL to `-pgid`. This makes the *existing* clean path
+   (`DELETE /v1/acp/{server_id}`, `shutdown_all`) take the `claude` child down with the
+   adapter.
+2. **Handle SIGTERM like SIGINT** for graceful shutdown.
+   `server/packages/sandbox-agent/src/cli.rs`: the graceful-shutdown future currently
+   awaits `ctrl_c()` only. Add a `signal(SignalKind::terminate())` branch so
+   `child.kill()` from the SDK's local provider (Node default = SIGTERM) triggers
+   `shutdown_servers` → adapters (and now their trees) die.
+
+Together these close the runner's leak on the normal teardown path: `destroySandbox`
+kills the server → server catches SIGTERM → kills every adapter's process group.
+A SIGKILL/OOM of the server itself still orphans (nothing a dead process can do); that
+residual risk is small and covered by the runbook below.
+
+Upstream PR: one PR against `rivet-dev/sandbox-agent` with both changes, referencing
+issue #201 and issue #6. Filed as soon as the fork validates the fix; we do not wait for
+review.
+
+Considered and rejected:
+
+- **Runner-only reorder** (call `dispose()` before `destroySandbox` so the DELETE lands
+  on a live server): even then the server kills only the adapter *pid*; `claude` still
+  orphans. Half a fix, and it papers over the real bug.
+- **Runner-side process-group kill of the server we spawn:** works for the local
+  provider, but it is the server's job, doesn't help any other consumer, and we'd carry
+  it forever. Kept in the back pocket as a backstop, not implemented in v1.
+- **SDK-side change (`destroySession` issues the DELETE):** conflates session teardown
+  with server-instance teardown (one server can host several sessions in other usage
+  patterns). Worth raising upstream as a discussion, not something we patch.
+
+## Fork mechanics
+
+**Repo:** GitHub fork `agenta-ai/sandbox-agent` (a true fork, so upstream PRs are
+one-click). Branch policy:
+
+- `main` — tracks upstream `main`, never carries our commits.
+- `agenta` — the default branch of the fork: upstream base (the `v0.4.2` tag) + our fix
+  commits + the fork's CI workflow. Rebases onto new upstream releases.
+- Feature branches off `agenta`; each fix lands on `agenta` and is cherry-picked into an
+  upstream PR branch cut from upstream `main`.
+
+Base = `v0.4.2` (what we run), not `main`/`0.5.0-rc.3`: the delta is 5 irrelevant
+commits, and basing on the tag we already validated keeps the fork's behavior identical
+to production except for our fix.
+
+**Build + publish (fork CI, GitHub Actions):** upstream's release pipeline is not
+reusable (Depot runners, Rivet's R2, 1Password), but the cross-compile is Dockerized.
+One workflow on the fork, on push to `agenta`:
+
+1. Build the Rust binary for `x86_64-unknown-linux-musl` (ubuntu-latest) and
+   `aarch64-unknown-linux-musl` (`ubuntu-24.04-arm`) via `docker/release/build.sh`.
+   Linux only for v1 — the runner images are linux amd64+arm64; darwin dev laptops can
+   use `SANDBOX_AGENT_BIN` with a local build if ever needed.
+2. Drop each binary into `sdks/cli/platforms/linux-*/bin/sandbox-agent`, `pnpm pack` the
+   two platform packages and the TS SDK into `./artifacts/*.tgz`.
+3. `pnpm exec pkg-pr-new publish './artifacts/*.tgz'` (pkg-pr-new installed as a dev
+   dep of the fork, per their CI guidance; GitHub App installed on agenta-ai).
+
+**Consume in services/runner:** pkg.pr.new does not rewrite cross-package references, so
+the wiring is explicit — `pnpm.overrides` in `services/runner/package.json`:
+
+```jsonc
+"pnpm": {
+  "overrides": {
+    "@sandbox-agent/cli-linux-x64": "https://pkg.pr.new/agenta-ai/sandbox-agent/@sandbox-agent/cli-linux-x64@<sha>",
+    "@sandbox-agent/cli-linux-arm64": "https://pkg.pr.new/agenta-ai/sandbox-agent/@sandbox-agent/cli-linux-arm64@<sha>"
+  }
+}
+```
+
+The `sandbox-agent` JS pin stays `0.4.2` from npm (the v1 fix is Rust-only; the SDK
+tarball from the fork is published but unused until we need an SDK change — then it
+becomes a URL dependency the same way). `onlyBuiltDependencies` already allowlists the
+cli packages. Lockfile regenerates once; `--frozen-lockfile` Docker/CI builds keep
+working. darwin/win32 optionalDependencies keep resolving from upstream npm.
+
+**Sync with upstream:** cheap by construction — rebase `agenta` onto the new upstream
+tag, CI republishes, we bump two override URLs. Upstream is dormant, so expect this
+rarely. A `FORK.md` at the fork root documents: why the fork exists, the patch list,
+the sync procedure, and the exit criteria.
+
+**Exit criteria (fork retires):** upstream merges the lifecycle fixes AND cuts a release
+containing them AND the project shows signs of life (reviews/releases resuming — Mahmoud
+is talking to the founder). Exit = delete the two overrides, bump the npm pin, one soak
+on the dev box.
+
+**pkg.pr.new → npm graduation trigger:** if the fork is still needed after ~a month, or
+the first time a pkg.pr.new URL 404s, publish `@agenta/sandbox-agent-cli-linux-*` to npm
+and point the overrides there. (Tracked in `status.md` open questions.)
+
+## Milestones
+
+- **M0 — done.** Root cause + upstream/local research (`research.md`); dev box restarted
+  2026-07-09 (49.7 GiB → 155 MiB) as interim relief.
+- **M1 — prove the fix before any infra.** Fork the repo, apply the two Rust changes on
+  `agenta`, build linux-x64 locally, deploy to the dev box via the existing
+  `SANDBOX_AGENT_BIN` override, run N agent turns, assert zero orphaned
+  `claude`/`claude-agent-acp` after each run. This validates the fix with no publishing
+  pipeline at all.
+- **M2 — publishing.** pkg.pr.new App + CI workflow on the fork; artifacts installable
+  by URL.
+- **M3 — consume.** `pnpm.overrides` in services/runner, lockfile regen, runner
+  unit/integration/acceptance CI green, deploy the dev stack, 24h soak with the
+  process-census runbook below.
+- **M4 — upstream PR** referencing #201/#6, linked from `FORK.md` and from this
+  workspace.
+- **M5 — docs.** `FORK.md` on the fork; `services/runner/AGENTS.md` note (where the
+  binary really comes from + how to bump the fork); keep-docs-in-sync sweep.
+
+M1 intentionally precedes M2: if the process-group kill doesn't clear the leak on the
+dev box, we want to learn that before building any publishing infrastructure.
+
+## Runbook: detecting the leak (until fixed, and as the M3 soak check)
+
+```bash
+docker exec agenta-oss-team-runner-1 sh -c 'ls /proc | grep -c "^[0-9]"'   # PID count
+docker top agenta-oss-team-runner-1 | grep -c claude-agent-acp             # orphan pairs
+docker stats agenta-oss-team-runner-1 --no-stream                          # memory
+```
+
+Healthy idle: ~20-30 PIDs, ~150 MiB. Every completed run adding a persistent
+`claude` + `claude-agent-acp` pair = the leak is back. Interim relief:
+`docker restart agenta-oss-team-runner-1` (~30s, drops active sessions).
+
+## Out of scope (tracked, not here)
+
+- The mount-sign 503 that silently disables the keep-alive pool on the dev box
+  (own investigation; keep-alive is orthogonal to this leak).
+- Stale-heartbeat 401 sessions (`[sessions/alive] … running=false`).
+- Reaping stale ACP server instances on SDK reconnect (upstream #201's original
+  scenario) — our runner spawns one server per run, so it's not our leak shape; goes in
+  the upstream conversation, not the fork's v1.
+- Moving the Daytona base image to the fork.

--- a/docs/design/sandbox-agent-fork/research.md
+++ b/docs/design/sandbox-agent-fork/research.md
@@ -1,0 +1,187 @@
+# Research
+
+## 1. The leak, precisely (diagnosed 2026-07-09 on the team dev box)
+
+Symptom: `agenta-oss-team-runner-1` at 49.7 GiB RSS / 7029 PIDs / 5.22 TB cumulative block
+reads, ~24h after a restart (container started 2026-07-08T16:04Z, image
+`agenta-allharness-sidecar:latest` built 2026-07-08T15:58Z — the image *includes* both
+#5102 and the keep-alive pool).
+
+Process census: ~304 `claude` CLI processes + ~305 `claude-agent-acp` node adapters, but
+only ~6 `sandbox-agent` server daemons. One orphan pair per run; the leak rate is 100% of
+runs.
+
+Chain of custody for the leak:
+
+1. Every run on this box degrades to the **cold path**. `AGENTA_RUNNER_SESSION_KEEPALIVE=1`
+   is set, but the mount-sign endpoint returns 503, so every dispatch logs
+   `[keepalive] miss (no mount project scope); cold` (`services/runner/src/server.ts:364`).
+   In 24h of logs there are **zero** `park`/`evict`/`expire` lines — the pool (which owns
+   the TTL reaper) never engages. Keep-alive is a red herring; the leak is per cold run.
+2. The cold path tears down correctly on its side:
+   `runCold = acquire → runTurn → finally env.destroy()` (`server.ts:266`).
+3. `env.destroy()` runs the #5102 fix: graceful `destroySession` before `destroySandbox`
+   (`services/runner/src/engines/sandbox_agent.ts:691-699`, comment cites the 2026-07-06
+   incident).
+4. **The fix's assumption is false.** `SandboxAgent.destroySession()` in sandbox-agent
+   0.4.2 is a logical destroy only (deployed
+   `sandbox-agent/dist/chunk-TVCDKGSM.js:1366-1379`):
+   - `cancelPendingPermissionsForSession(id)`
+   - send ACP `session/cancel` (aborts the in-flight *prompt*, not the process)
+   - stamp `destroyedAt` on the session record
+   It never terminates the ACP adapter subprocess or the harness CLI under it.
+5. `destroySandbox` then kills the sandbox-agent **server pid only**. The server's
+   children (`claude-agent-acp`, which itself wraps a `claude` process) are not killed as
+   a tree; they reparent to PID 1 and idle forever. This matches the census: servers die
+   (6 left), adapter+harness pairs accumulate (~300).
+
+Secondary signals observed in the same logs (same box, worth keeping in view):
+`[sessions/alive] heartbeat … running=false` on finished sessions, heartbeat HTTP 401
+after credential expiry, and the mount-sign HTTP 503 that disables keep-alive parking.
+The 503 deserves its own investigation; it is not part of this fork's scope.
+
+## 2. Why we can't fix it (only) runner-side
+
+The runner talks to the sandbox-agent server over its API; the server is the parent of
+the adapter subprocess. Options from our side of the API:
+
+- Spawn the server in its own process group and `process.kill(-pid)` in `destroySandbox`.
+  Works for the **local** provider (we spawn the binary) and is a legitimate backstop, but
+  it is a workaround for what is properly the server's responsibility, and it does nothing
+  for providers where we don't own the spawn (Daytona runs the server inside the remote
+  sandbox).
+- Pattern-match and kill orphans by scanning the process table. Fragile, provider-local,
+  and racy.
+
+The durable fix is in sandbox-agent itself: session destroy (and server shutdown) must
+kill the agent subprocess tree.
+
+## 3. Upstream facts
+
+- Repo: `github.com/rivet-dev/sandbox-agent` (Rivet). License: **Apache-2.0** — forking
+  and republishing is clean.
+- npm: `sandbox-agent` (JS SDK) + platform binaries `@sandbox-agent/cli-linux-x64`,
+  `cli-darwin-arm64`, `cli-darwin-x64`, `cli-linux-arm64`. Single npm maintainer:
+  `nathanflurry` (the founder Mahmoud contacted).
+- We pin `sandbox-agent: 0.4.2` (`services/runner/package.json:34`). Upstream has
+  `0.5.0-rc.1..rc.3` published — the delta needs checking for lifecycle changes before we
+  pick the fork's base.
+
+## 4. Upstream repo deep-dive
+
+*(pending — subagent in flight: repo layout, binary language/build, release CI
+reusability, 0.4.2→0.5.0-rc delta, adapter spawn/kill code paths, prior issues/PRs about
+process leaks)*
+
+## 5. Local consumption map (subagent report, condensed)
+
+`services/runner` is a standalone **pnpm** package (`packageManager: pnpm@10.30.0`,
+`pnpm-lock.yaml` is authoritative; the checked-in `package-lock.json` is stale/vestigial).
+
+**The package flows through exactly one npm channel and one Docker channel:**
+
+1. **npm channel (local provider — where the leak lives):**
+   - `services/runner/package.json:34` — `"sandbox-agent": "0.4.2"` (exact pin).
+   - The `@sandbox-agent/cli-*` binaries arrive **transitively** as optionalDependencies
+     of `sandbox-agent`; `pnpm.onlyBuiltDependencies` allowlists their install scripts.
+   - Both Dockerfiles (`docker/Dockerfile:51`, `Dockerfile.dev:39`) do
+     `COPY package.json pnpm-lock.yaml` + `pnpm install --frozen-lockfile`. No other pin.
+   - Runtime binary resolution (`src/engines/sandbox_agent/daemon.ts:26-53`):
+     `SANDBOX_AGENT_BIN` env override → the `@sandbox-agent/cli-<platform>` package
+     resolved relative to the `sandbox-agent` package → pnpm store scan. Never PATH.
+     The env override is a useful escape hatch for testing a locally built binary.
+   - CI: three runner test jobs in `12-check-unit-tests.yml` (cache keyed on
+     `pnpm-lock.yaml`) and the multi-arch (amd64+arm64) `agenta-runner` image build in
+     `42-railway-build.yml` — so a forked binary must cover linux-x64 AND linux-arm64.
+2. **Docker base-image channel (Daytona provider):**
+   - The Daytona snapshot builds FROM `rivetdev/sandbox-agent:0.5.0-rc.2-full`
+     (`sandbox-images/daytona/build_snapshot.py:43`) — independently versioned, not the
+     npm pin. Nothing installs sandbox-agent at runtime inside the remote sandbox (only
+     the `pi` CLI is layered/installed).
+   - **The orphan leak does not bite Daytona the same way:** deleting the remote sandbox
+     kills everything in it. The urgent fix targets the local provider inside the runner
+     container. The fork can leave the Daytona base image on upstream initially.
+
+Other references: one archived POC package.json and prose in docs — nothing else installs it.
+
+## 6. pkg.pr.new as the interim publish channel (Mahmoud's suggestion, 2026-07-09)
+
+[pkg.pr.new](https://github.com/stackblitz-labs/pkg.pr.new) (StackBlitz) publishes
+npm-installable tarballs per commit/PR from a repo's CI — no npm registry involved.
+Setup on the fork: install their GitHub App + one CI step (`pnpm exec pkg-pr-new publish
+<pkg dirs or prebuilt .tgz>`; they advise installing `pkg-pr-new` as a dep, not npx).
+Install side: `"sandbox-agent": "https://pkg.pr.new/agenta-ai/sandbox-agent/sandbox-agent@<sha>"`
+— a URL dependency, which pnpm locks fine, so `--frozen-lockfile` Docker builds keep working.
+
+Fit assessment:
+
+- **Great when the fix is JS-SDK-only.** The SDK tarball comes from pkg.pr.new; its
+  optionalDependencies on `@sandbox-agent/cli-*@0.4.2` still point at the public npm
+  registry (unchanged upstream binaries), which resolves normally.
+- **Caveat 1 — no cross-package rewriting.** pkg.pr.new explicitly does not rewrite one
+  published tarball's references to another tarball from the same publish. If the fix
+  must land in the **server binary**, we publish the prebuilt cli tarballs as-is
+  (`pkg-pr-new publish './artifacts/*.tgz'`) and add explicit `pnpm.overrides` in
+  services/runner mapping each `@sandbox-agent/cli-*` to its pkg.pr.new URL.
+- **Caveat 2 — retention is unspecified and it is positioned for previews.** A tarball
+  URL that 404s later would break `pnpm install --frozen-lockfile` (and thus Docker/CI
+  builds) retroactively. Acceptable for "for the moment" (user's framing), but if the
+  fork lives more than a few weeks we should graduate to publishing @agenta-scoped
+  packages on npm. Track this as an explicit exit trigger.
+- Fork CI must actually build the binary for the tarballs to exist (linux-x64 + arm64 at
+  minimum; darwin for dev laptops is nice-to-have since `SANDBOX_AGENT_BIN` covers local
+  testing).
+
+## 7. Upstream repo deep-dive (subagent report, condensed)
+
+Repo: monorepo, pnpm workspace + Cargo workspace, inspected at main HEAD `bbc195c`
+(2026-06-18).
+
+**Layout.** The server/CLI binary is **Rust** (`server/packages/*`: main crate
+`sandbox-agent` = axum HTTP server + CLI, plus `acp-http-adapter`, `agent-management`,
+…). `sdks/typescript/` builds the bare `sandbox-agent` npm package.
+`sdks/cli/platforms/*` build the `@sandbox-agent/cli-*` platform binary packages
+(linux-x64/arm64, darwin-x64/arm64, win32-x64 — five, not four).
+
+**The lifecycle bug, in the source:**
+
+- Adapter spawn (`server/packages/acp-http-adapter/src/process.rs:74`): plain
+  `Command::new(...)` with piped stdio. No process group, no `setsid`, no
+  `kill_on_drop`.
+- `AdapterRuntime::shutdown` (`process.rs:324-346`): `child.kill()` — SIGKILL to the
+  **single adapter pid**. Anything the adapter spawned (the `claude` CLI, tool shells,
+  MCP servers) is orphaned **even on the clean path**.
+- SDK `destroySession()` (`sdks/typescript/src/client.ts:1225-1242`) never kills the
+  process (confirms §1 item 4). The process dies only on `DELETE /v1/acp/{server_id}`,
+  which the SDK issues from `dispose()` → connection close, as a best-effort 2s-timeout
+  request.
+- Runner interplay: our `env.destroy()` calls `destroySession` → `destroySandbox` (kills
+  the server) → `dispose()`. By the time dispose's DELETE fires, the server is dead — the
+  DELETE no-ops. And even if reordered, the DELETE kills only the adapter pid, leaving
+  `claude` orphaned. Reordering alone is at most half a fix.
+- Server graceful shutdown hooks **SIGINT only** (`cli.rs:497-501`). SIGTERM, SIGKILL,
+  panic, or OOM-kill of the server cleans up nothing; adapters reparent to PID 1.
+
+**Upstream already knows:** issue #201 "ACP server processes leak on client reconnect"
+(2026-03-05) describes exactly this class of leak (9 reconnects → 9 live `pi-acp` trees,
+~8.6 GB). **Closed 2026-04-05 with no fix commit and no comment.** Related: open issue #6
+(server blocks ctrl+c, forcing the `kill -9` path that orphans everything).
+
+**Repo health:** Apache-2.0, 1,475 stars, 15 contributors but extremely concentrated
+(Nathan Flurry 708 commits, next 85). Commit activity: 178 (Jan), 133 (Feb), 108 (Mar),
+**0 (Apr), 0 (May), 7 docs-only (Jun)**. External PRs unreviewed since April. Active
+development effectively stopped end of March 2026. This validates the fork decision.
+
+**0.4.2 → 0.5.0-rc.3 delta:** 5 commits (a TS-only Agent Computer provider, docs, a
+history-restore header). Nothing touches process lifecycle. Oddly, 0.5.0-rc.1/rc.2 are
+*ancestors* of 0.4.2. → **Fork from the v0.4.2 tag we run.**
+
+**Release CI reusability:** upstream `release.yaml` is manual-dispatch and depends on
+Rivet-specific infra — Depot paid runners, a hard-coded Cloudflare R2 bucket, 1Password
+and Graphite for local phases. Not reusable verbatim. But the binary cross-compile itself
+is fully Dockerized (`docker/release/build.sh <target> <version>`), so a fork CI on
+plain `ubuntu-latest`/`ubuntu-24.04-arm` runners can build the linux binaries easily.
+
+**Published package set** (all from this repo): bare `sandbox-agent` and `acp-http-client`,
+`@sandbox-agent/cli` + 5 platform packages, `@sandbox-agent/react`, 4 persist packages,
+gigacode + 5 platform packages; Rust crates also on crates.io.

--- a/docs/design/sandbox-agent-fork/status.md
+++ b/docs/design/sandbox-agent-fork/status.md
@@ -1,0 +1,52 @@
+# Status
+
+**Phase:** plan complete — draft PR up for Mahmoud's review
+**Last update:** 2026-07-09 (session: runner memory-leak diagnosis → fork decision → plan)
+
+## Now
+
+- [x] Root cause of the runner orphan-process leak confirmed (see `research.md` §1)
+- [x] Decision made: fork sandbox-agent into agenta-ai, consume the fork, PR upstream
+- [x] Upstream repo research — condensed into `research.md` §7. Headlines: server is Rust;
+      adapter spawned with no process group and killed single-pid even on the clean path;
+      graceful shutdown hooks SIGINT only; upstream issue #201 IS this leak, closed
+      2026-04-05 without a fix; upstream dormant since April (0 commits Apr–May).
+- [x] Local consumption map — condensed into `research.md` §5. Key facts: pnpm-only,
+      exact pin 0.4.2, binaries transitive, Daytona uses a separate Docker base image and
+      is NOT urgent for the leak fix (deleting the sandbox kills its processes).
+- [x] Publish channel decision (Mahmoud, 2026-07-09): use **pkg.pr.new** for the moment so
+      we don't go through npm — assessment + caveats in `research.md` §6. Graduating to
+      @agenta-scoped npm packages is the exit path if the fork lives long.
+- [x] `plan.md` written: fix design (process-group kill + SIGTERM), fork mechanics,
+      pkg.pr.new CI, pnpm overrides, sync/exit criteria, milestones M0–M5, runbook.
+- [x] Dev box restarted 2026-07-09 (49.7 GiB / 7029 PIDs → 155 MiB / 23 PIDs).
+- [x] Draft PR with this workspace for Mahmoud's review: #5172.
+
+## Next (implementation order, after plan review)
+
+1. **M1**: fork repo, apply the two Rust fixes, build linux-x64 locally, validate on the
+   dev box via `SANDBOX_AGENT_BIN` (zero orphans after N runs).
+2. **M2**: pkg.pr.new App + fork CI (linux x64+arm64 tarballs).
+3. **M3**: `pnpm.overrides` in services/runner + lockfile + CI + 24h soak.
+4. **M4**: upstream PR referencing #201/#6.
+5. **M5**: FORK.md + AGENTS.md/docs sync.
+
+## Open questions (for Mahmoud on the draft PR)
+
+- OK to base the fork on the `v0.4.2` tag (not upstream main / 0.5.0-rc.3)? Rationale in
+  `plan.md` §Fork mechanics.
+- pkg.pr.new → npm graduation trigger: proposal is "fork still needed after ~a month, or
+  first 404". Fine?
+- Runner-side process-group-kill backstop: plan says skip in v1 (fix belongs in the
+  server). Veto if you want belt-and-braces.
+
+## Blockers
+
+- None. Upstream relationship being handled by Mahmoud directly (founder contacted).
+
+## Interim operational note
+
+Until the fix ships, `agenta-oss-team-runner-1` needs a periodic restart: it leaks one
+`claude` + `claude-agent-acp` pair per run (~49 GiB / 7029 PIDs per ~24h at current load).
+Restarted 2026-07-09; healthy idle is ~20-30 PIDs / ~150 MiB. Census commands: `plan.md`
+§Runbook.


### PR DESCRIPTION
## Context

The team runner OOMed again on 2026-07-09: 49.7 GiB and 7029 PIDs within 24 hours of a restart. The diagnosis found ~300 orphaned `claude` + `claude-agent-acp` process pairs, one per completed run. Our earlier fix (#5102, graceful `destroySession` before `destroySandbox`) is deployed and runs on every teardown, but it rests on a false assumption: in sandbox-agent 0.4.2, `destroySession()` only cancels the prompt and stamps a record. It never kills the adapter process. `destroySandbox` then kills the server pid alone, and the adapter plus the claude CLI under it reparent to PID 1 forever.

The real fix belongs in the sandbox-agent Rust server: it spawns the adapter as a plain piped child (no process group), kills single pids even on its clean path, and only hooks SIGINT for graceful shutdown. Upstream knows about this class of leak (issue rivet-dev/sandbox-agent#201 describes it exactly) and closed it in April without a fix. The project has been dormant since (0 commits in April and May). Mahmoud decided to maintain a fork in the agenta-ai org: land fixes there, consume them in our npm installs, PR everything upstream, and retire the fork when upstream is trusted again.

## Changes

This PR adds the design workspace `docs/design/sandbox-agent-fork/`:

- `context.md`: the two incidents, the root cause, the fork decision with goals and non-goals.
- `research.md`: the leak mechanics with code references on all three sides (our runner, the deployed SDK, the upstream Rust server), the local consumption map, the upstream repo deep-dive, and the pkg.pr.new assessment.
- `plan.md`: the fix (spawn each ACP adapter in its own process group and kill the group on shutdown; handle SIGTERM like SIGINT), the fork mechanics (fork from the v0.4.2 tag onto an `agenta` branch, fork CI publishing linux binaries per commit via pkg.pr.new, two `pnpm.overrides` URLs in services/runner), sync and exit criteria, milestones M0 to M5, and a leak-detection runbook.
- `status.md`: progress and the three open questions for review.
- `README.md`: workspace index.

Two design choices worth calling out. First, validation comes before infrastructure: M1 builds the fixed binary locally and proves it on the dev box through the existing `SANDBOX_AGENT_BIN` override, before any publishing pipeline exists. Second, the v1 fix is Rust-only, so the `sandbox-agent` npm pin stays at upstream 0.4.2 and only the two linux binary packages are overridden to fork builds.

## Scope / risk

Design-only. No code changes; the runner still leaks until M1 to M3 land. Interim relief is a container restart (done today, 49.7 GiB to 155 MiB). Out of scope and tracked separately in the plan: the mount-sign 503 that silently disables the keep-alive pool, the stale-heartbeat 401 sessions, and moving the Daytona base image to the fork.

## Notes for review

The three open questions are at the top of `status.md`: fork base = v0.4.2 tag, the pkg.pr.new-to-npm graduation trigger, and whether to skip the runner-side process-group backstop in v1.