### PR TITLE
fix(runner): lower the approval TTL default to 5 minutes

### DIFF
--- a/docs/design/agent-workflows/documentation/running-the-agent.md
+++ b/docs/design/agent-workflows/documentation/running-the-agent.md
@@ -184,7 +184,7 @@ sections).
 - `AGENTA_RUNNER_SESSION_TTL_MS`. How long an idle parked session lives before it is
   destroyed. Default `60000`.
 - `AGENTA_RUNNER_SESSION_APPROVAL_TTL_MS`. How long a session parked on a Claude ACP approval
-  gate holds its pending permission request open. Default `600000`. Expiry degrades to the
+  gate holds its pending permission request open. Default `300000`. Expiry degrades to the
   cold decision-map path.
 - `AGENTA_RUNNER_SESSION_POOL_MAX`. Maximum parked sessions per runner replica (LRU evicts
   idle sessions; busy and awaiting-approval sessions are never evicted). Default `8`.

--- a/services/runner/src/engines/sandbox_agent/session-pool.ts
+++ b/services/runner/src/engines/sandbox_agent/session-pool.ts
@@ -43,7 +43,7 @@ const APPROVAL_TTL_ENV = "AGENTA_RUNNER_SESSION_APPROVAL_TTL_MS";
 const POOL_MAX_ENV = "AGENTA_RUNNER_SESSION_POOL_MAX";
 
 const DEFAULT_TTL_MS = 60_000;
-const DEFAULT_APPROVAL_TTL_MS = 600_000;
+const DEFAULT_APPROVAL_TTL_MS = 300_000;
 const DEFAULT_POOL_MAX = 8;
 
 function positiveIntEnv(name: string, fallback: number): number {

--- a/services/runner/src/server.ts
+++ b/services/runner/src/server.ts
@@ -403,8 +403,8 @@ export async function runWithKeepalive(
   };
 
   // A parked prompt that REJECTS while the session sits in awaiting_approval means the harness
-  // or sandbox died mid-park; the dead session must not occupy a pool slot until the 10-minute
-  // approval TTL (plan Q4 lists a rejected parked prompt as a teardown trigger). Identity-checked:
+  // or sandbox died mid-park; the dead session must not occupy a pool slot until the approval TTL
+  // (5 minutes by default) (plan Q4 lists a rejected parked prompt as a teardown trigger). Identity-checked:
   // the handler evicts only while THIS exact entry is still parked at the key. A rejection that
   // lands after a successful checkout (the resume is in flight and owns the environment; its own
   // try/catch handles the failure) or after a supersede is not ours and does nothing. `evict` is

--- a/services/runner/tests/unit/session-pool.test.ts
+++ b/services/runner/tests/unit/session-pool.test.ts
@@ -127,11 +127,11 @@ describe("readKeepaliveConfig", () => {
     }
   });
 
-  it("defaults: off, 60s idle, 10m approval, cap 8", () => {
+  it("defaults: off, 60s idle, 5m approval, cap 8", () => {
     assert.deepEqual(readKeepaliveConfig(), {
       enabled: false,
       ttlMs: 60_000,
-      approvalTtlMs: 600_000,
+      approvalTtlMs: 300_000,
       poolMax: 8,
     });
   });


### PR DESCRIPTION
## Context

The session-keepalive design settled the approval TTL at 5 minutes (open-questions item 2). A session parked on an open approval gate holds a live harness process while it waits for a human. On Daytona that idle time is billed wall-clock time, not just RAM. Five minutes is long enough for a human who reads the request and clicks, and short enough to keep idle cost low. A human who steps away longer still gets a correct answer through the cold decision-map path.

The code default was still the earlier 10-minute working value.

## What changed

- `session-pool.ts`: `DEFAULT_APPROVAL_TTL_MS` 600000 -> 300000.
- `server.ts`: a comment that hardcoded "the 10-minute approval TTL" now says "the approval TTL (5 minutes by default)".
- `running-the-agent.md`: the documented default for `AGENTA_RUNNER_SESSION_APPROVAL_TTL_MS` is now 300000.
- `session-pool.test.ts`: the defaults test asserts the new built-in fallback (300000). Tests that pass 600000 as an explicit config value are unchanged on purpose.

Not in this PR: the follow-up row in the design workspace `status.md`. That file exists only on the `docs/session-keepalive-plan` lane (PR #5153), so the status update lands there once #5153 merges.

## Scope and risk

Default value only. The `AGENTA_RUNNER_SESSION_APPROVAL_TTL_MS` env var still overrides it per environment. No behavior change for any deployment that sets the variable.

## How to QA

```
grep -n "DEFAULT_APPROVAL_TTL_MS" services/runner/src/engines/sandbox_agent/session-pool.ts
cd services/runner && pnpm test
```

Expect `300_000` and a green suite (two pre-existing QA-transcript replay failures are unrelated fixture drift).

https://claude.ai/code/session_01AumZJ9xRd4XYNHThqy4rTv
