### PR TITLE
chore(frontend): polish the draft-run references fix (doc accuracy and a test guard)

### DIFF
--- a/docs/design/agent-workflows/projects/draft-run-references/README.md
+++ b/docs/design/agent-workflows/projects/draft-run-references/README.md
@@ -5,9 +5,12 @@ same chat fails with `missing run-context value for direct-call binding
 'workflow_revision.workflow_variant_id'`. The page has to reload to recover. This workspace
 explains why and proposes the fix.
 
-The cause: on a run with unsaved config edits, the playground sends `references: null`, which
-drops the variant identity that the `commit_revision` tool needs. A successful commit is what
-flips the panel into the unsaved state, so the agent's own success breaks its next commit.
+The cause: `isDirty` means the loaded revision carries unsaved edits, a draft overlay.
+Whenever the panel is dirty, for any reason, the playground sends `references: null`, which
+drops the variant identity that the `commit_revision` tool needs. The panel goes dirty from a
+user editing the config, or from a missed `data-committed-revision` event that should have
+repointed the panel to the revision the agent just committed. Either way, the old
+all-or-nothing gate dropped every reference, so the agent's next commit failed.
 
 The recommended fix: keep dropping the committed-revision reference on a dirty run (that is
 the correct draft signal), but keep forwarding the variant reference, because the variant is

--- a/docs/design/agent-workflows/projects/draft-run-references/research.md
+++ b/docs/design/agent-workflows/projects/draft-run-references/research.md
@@ -153,7 +153,7 @@ const isCommittedRevisionRun =
 const references = isCommittedRevisionRun ? fullReferences : null
 ```
 
-(`web/packages/agenta-playground/src/state/execution/agentRequest.ts:355-359`)
+(`web/packages/agenta-playground/src/state/execution/agentRequest.ts`, before this fix)
 
 This is an all-or-nothing gate. If the config panel is clean (no unsaved edits) and there is
 a real committed revision, the run forwards **all** references. Otherwise it forwards
@@ -283,7 +283,7 @@ The frontend comment gives a second reason for dropping the variant:
 > The resolver also re-resolves a bare variant ref to its latest revision, so the variant
 > must be dropped too.
 
-(`web/packages/agenta-playground/src/state/execution/agentRequest.ts:349-350`)
+(`web/packages/agenta-playground/src/state/execution/agentRequest.ts`, before this fix)
 
 If that were true for our case, the recommended fix would be wrong. Forwarding a bare variant
 would make the backend resolve it to the variant's HEAD revision, which would set
@@ -319,7 +319,7 @@ requestBody: {
 }
 ```
 
-(`web/packages/agenta-playground/src/state/execution/agentRequest.ts:391-398`)
+(`web/packages/agenta-playground/src/state/execution/agentRequest.ts:406-410`)
 
 So `request_has_parameters` is always true for a playground run, `needs_reference_hydration`
 is always false, and `resolve_references_with_info` never runs. The variant is never
@@ -346,7 +346,7 @@ const url = withQuery(invocationUrl, {
 })
 ```
 
-(`web/packages/agenta-playground/src/state/execution/agentRequest.ts:378-386`)
+(`web/packages/agenta-playground/src/state/execution/agentRequest.ts:393-398`)
 
 So the app is never lost on a dirty run. Only the variant and revision identities are
 dropped. The fix restores the variant while leaving the app scoping untouched.

--- a/web/packages/agenta-playground/src/state/execution/agentRequest.ts
+++ b/web/packages/agenta-playground/src/state/execution/agentRequest.ts
@@ -340,7 +340,7 @@ export async function buildAgentRequest(
         | undefined
 
     // Field-level reference gate. The service derives draft-ness purely from the revision
-    // reference — `services/oss/src/agent/tracing.py` `_run_context_workflow`:
+    // reference — `sdks/python/agenta/sdk/agents/tracing.py` `_run_context_workflow`:
     // `is_draft = revision is None` — so ONLY `application_revision` is gated on cleanliness:
     //  - dirty (unsaved left-panel edits) or an uncommitted local draft (no real revision UUID):
     //    the run is an inline-config draft, so the revision reference is withheld to keep

--- a/web/packages/agenta-playground/tests/unit/agentRequest.test.ts
+++ b/web/packages/agenta-playground/tests/unit/agentRequest.test.ts
@@ -419,7 +419,7 @@ describe("buildAgentRequest", () => {
         expect(refs).not.toBeNull()
         expect(refs.application.id).toBe(REAL_APP)
         expect(refs.application_variant.id).toBe(REAL_VARIANT)
-        expect(refs.application_revision).toBeUndefined()
+        expect(refs).not.toHaveProperty("application_revision")
         expect(req!.invocationUrl).toContain(`application_id=${REAL_APP}`)
     })
 
@@ -449,8 +449,20 @@ describe("buildAgentRequest", () => {
         expect(refs).not.toBeNull()
         expect(refs.application.id).toBe(REAL_APP)
         expect(refs.application_variant.id).toBe(REAL_VARIANT)
-        expect(refs.application_revision).toBeUndefined()
+        expect(refs).not.toHaveProperty("application_revision")
         expect(req!.invocationUrl).toContain(`application_id=${REAL_APP}`)
+    })
+
+    it("collapses to references: null for a DIRTY run whose only real identity is the revision (no app/variant)", async () => {
+        // `buildAgentReferences` would produce ONLY `application_revision` here (a real revision
+        // UUID, no real app/variant ids). The gate strips `application_revision` on a dirty run,
+        // so nothing survives the gate — references must fall back to null, not an empty object.
+        seed(store, "e", {
+            isDirty: true,
+            data: {id: REAL_REV, version: 3},
+        })
+        const req = await buildAgentRequest("e", [], {sessionId: "s1", store})
+        expect(req!.requestBody.references).toBeNull()
     })
 
     it("invariant guard: a dirty committed run still carries data.parameters alongside the bare-variant references", async () => {
@@ -474,7 +486,7 @@ describe("buildAgentRequest", () => {
         expect(Object.keys(data.parameters).length).toBeGreaterThan(0)
         const refs = req!.requestBody.references as any
         expect(refs.application_variant.id).toBe(REAL_VARIANT)
-        expect(refs.application_revision).toBeUndefined()
+        expect(refs).not.toHaveProperty("application_revision")
     })
 
     it("puts project_id + application_id in the URL QUERY, never the body", async () => {


### PR DESCRIPTION
Follow-up to #5163. A post-merge review found three accuracy gaps, all fixed here.

## What was wrong

- **README.md stated the debunked mechanism.** It still said a successful commit is what flips the panel into the unsaved state. The project's own research.md (rewritten in #5163) shows the real rule: `isDirty` means the loaded revision carries unsaved edits, from a user edit or a missed `data-committed-revision` repoint. The README now matches the research.
- **A code comment cited a file that does not exist.** The gate comment in `agentRequest.ts` pointed at `services/oss/src/agent/tracing.py`. The `is_draft = revision is None` logic actually lives in `sdks/python/agenta/sdk/agents/tracing.py:165`. The comment now points there.
- **One fallback path had no test.** A dirty run whose references contain only `application_revision` must collapse to `references: null` (the empty-object fallback). A new test pins that. The three key-absence assertions were also strengthened from `toBeUndefined()` to `not.toHaveProperty(...)`, which is the actual wire contract (key absent, not key undefined).
- research.md's self-citations were refreshed to the post-fix line numbers, and quotes of the old gate are now marked as the code before the fix instead of carrying stale line references.

## Tests

`pnpm run test:unit` in `web/packages/agenta-playground`: 197 passed (196 baseline + 1 new). `pnpm lint-fix` clean.

https://claude.ai/code/session_01CSTSEXSe4DDhoXCFjZpZ5W
