### PR TITLE
fix(service): record only messages in the agent trace span's inputs

### DIFF
--- a/services/oss/src/agent/app.py
+++ b/services/oss/src/agent/app.py
@@ -29,7 +29,7 @@ from agenta.sdk.agents.handler import (
 )
 from agenta.sdk.agents.platform import resolve_connection
 
-from agenta.sdk.decorators.tracing import auto_instrument
+from agenta.sdk.decorators.tracing import instrument
 from agenta.sdk.engines.running.utils import (
     register_handler,
     register_interface,
@@ -147,8 +147,12 @@ def create_agent_app():
     # are resolved by the frontend via `x-ag-harness-ref` on the agent-config harness field — the
     # same catalog/ref mechanism as every other type. The agent service still imports the SDK
     # capability table directly for its server-side reject; it never publishes it on inspect.
+    # `ignore_inputs`: the normalizer fills `request`, `inputs`, and `parameters` from the
+    # same request body that `messages` comes from, so recording all four puts three extra
+    # copies of the conversation under `ag.data.inputs` (inputs.messages, request.data.
+    # inputs.messages) plus a duplicate of `ag.data.parameters`. Only `messages` is signal.
     register_handler(
-        auto_instrument(_agent),
+        instrument(ignore_inputs=["request", "inputs", "parameters"])(_agent),
         uri=AGENT_URI,
     )
     register_interface(


### PR DESCRIPTION
## Context

An agent run's root trace span showed the same conversation four times. The `@instrument` decorator records every handler argument by name into `ag.data.inputs`, and the running normalizer fills `request`, `inputs`, `messages`, and `parameters` all from the same request body. The chat and completion handlers don't take a `request` argument, which is why only the agent span was this noisy.

Before, the agent span's attributes looked like this:

```
ag.data.inputs.messages                        <- the conversation
ag.data.inputs.inputs.messages                 <- the conversation again
ag.data.inputs.request.data.inputs.messages    <- the conversation a third time
ag.data.inputs.parameters                      <- duplicate of ag.data.parameters
ag.data.parameters
ag.data.outputs
```

After:

```
ag.data.inputs.messages
ag.data.parameters
ag.data.outputs
```

## Changes

The agent service registered its handler as `auto_instrument(_agent)`. It now registers it as `instrument(ignore_inputs=["request", "inputs", "parameters"])(_agent)`, using the decorator's existing `ignore_inputs` mechanism. Only `messages` remains under `ag.data.inputs`.

## Scope / risk

One line of registration code in `services/oss/src/agent/app.py` plus a comment. No behavior change beyond span attributes: `ag.data.outputs` and `ag.data.parameters` were already correct and are untouched. The chat and completion services are not affected.

## Tests

- All 83 agent service unit tests pass (`services/oss/tests/pytest/unit/agent`).
- `ruff format` and `ruff check` clean.

## How to QA

**Prerequisites:** local dev stack with the agent service running.

**Steps:**
1. Run any agent from the playground.
2. Open the run's trace in Observability and select the root agent span.
3. Inspect the span's `ag.data.inputs`.

**Expected result:** `ag.data.inputs` contains only `messages`. No `inputs`, `request`, or `parameters` keys under it. `ag.data.parameters` and `ag.data.outputs` are unchanged.

**Automated tests:**
```
cd services && uv run pytest oss/tests/pytest/unit/agent
```

**Edge cases:** Chat and completion runs must trace exactly as before; they use a different registration path and are untouched.

https://claude.ai/code/session_01LhoaCCSpSYP5PoXmSTUzfA
