### PR TITLE
[feat] discover_triggers: 30-60s to <1s via a cached trigger catalog

### DIFF
--- a/api/oss/src/core/triggers/dtos.py
+++ b/api/oss/src/core/triggers/dtos.py
@@ -100,6 +100,14 @@ class TriggerCatalogEventsPage(BaseModel):
     total: int = 0
 
 
+class TriggerCatalogEventsSnapshot(BaseModel):
+    """The full provider event catalog, cached for discovery; never crosses the API boundary."""
+
+    events: List[TriggerCatalogEventDetails] = []
+    # toolkit slug -> display name
+    integration_names: Dict[str, str] = {}
+
+
 # ---------------------------------------------------------------------------
 # Trigger discovery (discover_triggers)
 # ---------------------------------------------------------------------------

--- a/api/oss/src/core/triggers/providers/composio/catalog.py
+++ b/api/oss/src/core/triggers/providers/composio/catalog.py
@@ -20,6 +20,7 @@ from oss.src.core.triggers.dtos import (
     TriggerCatalogEvent,
     TriggerCatalogEventDetails,
     TriggerCatalogEventsPage,
+    TriggerCatalogEventsSnapshot,
 )
 from oss.src.core.triggers.exceptions import AdapterError
 
@@ -28,6 +29,10 @@ log = get_module_logger(__name__)
 
 DEFAULT_PAGE_SIZE = 20
 MAX_PAGE_SIZE = 1000
+# Composio clamps larger page limits to 50, so ask for exactly that.
+ALL_EVENTS_PAGE_SIZE = 50
+# Runaway-cursor guard for the full-catalog crawl (~8 pages live today).
+ALL_EVENTS_MAX_PAGES = 50
 
 
 class ComposioTriggersCatalogClient:
@@ -109,6 +114,73 @@ class ComposioTriggersCatalogClient:
             events=items,
             next_cursor=next_cursor,
             total=total_items,
+        )
+
+    async def list_all_events(self) -> TriggerCatalogEventsSnapshot:
+        """Fetch the complete trigger-types catalog, following ``next_cursor`` to exhaustion.
+
+        LIST items carry ``config`` and ``payload`` (verified live), so the snapshot
+        holds full event details plus the toolkit slug -> display name map.
+        """
+        events: List[TriggerCatalogEventDetails] = []
+        integration_names: Dict[str, str] = {}
+        cursor: Optional[str] = None
+        seen_cursors: set = set()
+
+        for _ in range(ALL_EVENTS_MAX_PAGES):
+            params: Dict[str, Any] = {"limit": ALL_EVENTS_PAGE_SIZE}
+            if cursor:
+                params["cursor"] = cursor
+
+            try:
+                resp = await self._client.get(
+                    f"{self.api_url}/triggers_types",
+                    headers={
+                        "x-api-key": self.api_key,
+                        "Content-Type": "application/json",
+                    },
+                    params=params,
+                    timeout=30.0,
+                )
+                resp.raise_for_status()
+                data = resp.json()
+            except httpx.HTTPError as e:
+                raise AdapterError(
+                    provider_key="composio",
+                    operation="list_all_events",
+                    detail=str(e),
+                ) from e
+
+            items_raw: List[Dict[str, Any]] = (
+                data.get("items", []) if isinstance(data, dict) else data
+            )
+            for item in items_raw:
+                toolkit_slug = _toolkit_slug(item, "")
+                events.append(_parse_event_detail(item, toolkit_slug))
+                toolkit = item.get("toolkit")
+                if toolkit_slug and isinstance(toolkit, dict) and toolkit.get("name"):
+                    integration_names[toolkit_slug] = toolkit["name"]
+
+            next_cursor = data.get("next_cursor") if isinstance(data, dict) else None
+            if not next_cursor or next_cursor in seen_cursors:
+                break
+            seen_cursors.add(next_cursor)
+            cursor = next_cursor
+        else:
+            log.warning(
+                "[composio] list_all_events hit the %d-page cap; snapshot may be partial",
+                ALL_EVENTS_MAX_PAGES,
+            )
+
+        log.debug(
+            "[composio] list_all_events items=%d toolkits=%d",
+            len(events),
+            len(integration_names),
+        )
+
+        return TriggerCatalogEventsSnapshot(
+            events=events,
+            integration_names=integration_names,
         )
 
     async def get_event(

--- a/api/oss/src/core/triggers/service.py
+++ b/api/oss/src/core/triggers/service.py
@@ -9,6 +9,7 @@ from croniter import croniter
 
 from oss.src.utils.logging import get_module_logger
 from oss.src.utils.env import env
+from oss.src.utils.caching import get_cache, set_cache
 from oss.src.dbs.redis.shared.engine import get_cache_engine
 
 from oss.src.core.gateway.catalog.service import CatalogService
@@ -22,6 +23,7 @@ from oss.src.core.triggers.dtos import (
     TriggerCatalogEvent,
     TriggerCatalogEventDetails,
     TriggerCatalogEventsPage,
+    TriggerCatalogEventsSnapshot,
     TriggerCatalogIntegration,
     TriggerCatalogIntegrationsPage,
     TriggerCatalogProvider,
@@ -67,12 +69,11 @@ _ENQUEUE_TIMEOUT_SECONDS = 5.0
 # Seconds /subscriptions/test long-polls for a captured event before teardown.
 _TEST_TIMEOUT_SECONDS = 300
 
-_DISCOVERY_INTEGRATION_LIMIT = 10
-_DISCOVERY_EVENT_LIMIT = 8
+_CATALOG_CACHE_NAMESPACE = "triggers:catalog"
 # Minimum distinct use-case terms a candidate must match before it can be promoted to the
-# primary (capabilities[0]) result. The candidate loaders fall back to broad, unfiltered
-# catalog pages, so a single shared generic term ("issue", "email") is not strong enough
-# evidence to surface an integration as the best match; an exact phrase hit also clears this.
+# primary (capabilities[0]) result. Discovery scores the whole catalog, so a single shared
+# generic term ("issue", "email") is not strong enough evidence to surface an integration
+# as the best match; an exact phrase hit also clears this.
 _DISCOVERY_MIN_PRIMARY_TERMS = 2
 _DISCOVERY_STOPWORDS = {
     "a",
@@ -122,6 +123,13 @@ def _discovery_terms(value: str) -> List[str]:
     return deduped
 
 
+def _normalize_words(value: Optional[str]) -> str:
+    normalized = "".join(
+        char if char.isalnum() else " " for char in (value or "").lower()
+    )
+    return " ".join(normalized.split())
+
+
 def _match_signal(
     *,
     use_case: str,
@@ -152,7 +160,8 @@ def _match_signal(
     matched_terms = 0
     event_key = str(event.key or "").lower()
     integration_key = str(integration.key or "").lower()
-    for term in _discovery_terms(use_case):
+    terms = _discovery_terms(use_case)
+    for term in terms:
         hit = False
         if term in haystack:
             score += 5
@@ -165,6 +174,27 @@ def _match_signal(
             hit = True
         if hit:
             matched_terms += 1
+
+    # Adjacency bonus: consecutive CONTENT terms appearing side by side in the event
+    # key/name break score ties the paged provider search used to resolve via its own
+    # relevance ordering (e.g. "issue created" prefers ISSUE_CREATED over
+    # ISSUE_COMMENT_CREATED). Integration-name tokens are excluded before pairing:
+    # they prefix every event key of that integration, so a bigram like
+    # "slack message" would be a spurious adjacency. Score-only; matched_terms and
+    # exact_phrase stay untouched.
+    integration_name = str(integration.name or "").lower()
+    content_terms = [
+        term
+        for term in terms
+        if term not in integration_key and term not in integration_name
+    ]
+    normalized_key = _normalize_words(event.key)
+    normalized_name = _normalize_words(event.name)
+    for first, second in zip(content_terms, content_terms[1:]):
+        bigram = f"{first} {second}"
+        if bigram in normalized_key or bigram in normalized_name:
+            score += 4
+
     return score, matched_terms, exact_phrase
 
 
@@ -341,11 +371,12 @@ class TriggersService:
         states: Dict[str, TriggerConnectionRequirement] = {}
         state_order: List[str] = []
 
+        snapshot = await self._cached_event_catalog(provider_key=provider_key)
+
         for use_case in use_cases:
-            matches = await self._discover_events_for_use_case(
-                provider_key=provider_key,
+            matches = self._discover_events_for_use_case(
                 use_case=use_case,
-                limit_alternatives=limit_alternatives,
+                snapshot=snapshot,
             )
             surfaced = matches[: 1 + max(limit_alternatives, 0)]
 
@@ -380,12 +411,12 @@ class TriggersService:
 
             _score, event, integration = surfaced[0]
             integration_key = event.integration or integration.key
-            details = await self.get_event(
-                provider_key=provider_key,
-                integration_key=integration_key,
-                event_key=event.key,
+            # Catalog snapshot items already carry trigger_config/payload — no live call.
+            detailed_event = (
+                event
+                if isinstance(event, TriggerCatalogEventDetails)
+                else TriggerCatalogEventDetails(**event.model_dump())
             )
-            detailed_event = details or TriggerCatalogEventDetails(**event.model_dump())
             requirement = states.get(integration_key)
             connection = None
             if requirement is not None:
@@ -461,107 +492,76 @@ class TriggersService:
             notes=notes,
         )
 
-    async def _discover_events_for_use_case(
+    async def _cached_event_catalog(
         self,
         *,
         provider_key: str,
-        use_case: str,
-        limit_alternatives: int,
-    ) -> List[Tuple[int, TriggerCatalogEvent, TriggerCatalogIntegration]]:
-        integrations = await self._candidate_integrations(
-            provider_key=provider_key,
-            use_case=use_case,
+    ) -> TriggerCatalogEventsSnapshot:
+        # Provider-only key: the catalog is identical for every project, so the
+        # cache is project-agnostic on purpose (mirrors the tools-discovery cache).
+        cache_key = {"provider": provider_key}
+        cached = await get_cache(
+            namespace=_CATALOG_CACHE_NAMESPACE,
+            key=cache_key,
+            model=TriggerCatalogEventsSnapshot,
         )
-        event_limit = max(_DISCOVERY_EVENT_LIMIT, limit_alternatives + 1)
+        if cached is not None:
+            return cached
+
+        adapter = self.adapter_registry.get(provider_key)
+        try:
+            snapshot = await asyncio.wait_for(
+                adapter.list_all_events(),
+                timeout=env.composio.catalog_fetch_deadline_seconds,
+            )
+        except asyncio.TimeoutError as e:
+            raise AdapterError(
+                provider_key=provider_key,
+                operation="list_all_events",
+                detail="catalog fetch deadline exceeded",
+            ) from e
+
+        await set_cache(
+            namespace=_CATALOG_CACHE_NAMESPACE,
+            key=cache_key,
+            value=snapshot,
+            ttl=env.composio.catalog_cache_ttl_seconds,
+        )
+        return snapshot
+
+    @staticmethod
+    def _discover_events_for_use_case(
+        *,
+        use_case: str,
+        snapshot: TriggerCatalogEventsSnapshot,
+    ) -> List[Tuple[int, TriggerCatalogEvent, TriggerCatalogIntegration]]:
+        integrations: Dict[str, TriggerCatalogIntegration] = {}
         matches: List[Tuple[int, TriggerCatalogEvent, TriggerCatalogIntegration]] = []
         seen = set()
 
-        for integration in integrations:
-            events = await self._candidate_events(
-                provider_key=provider_key,
-                integration_key=integration.key,
-                use_case=use_case,
-                limit=event_limit,
-            )
-            for event in events:
-                key = (event.integration or integration.key, event.key)
-                if key in seen:
-                    continue
-                seen.add(key)
-                score = _score_trigger_match(
-                    use_case=use_case,
-                    event=event,
-                    integration=integration,
+        for event in snapshot.events:
+            slug = event.integration or ""
+            key = (slug, event.key)
+            if key in seen:
+                continue
+            seen.add(key)
+            integration = integrations.get(slug)
+            if integration is None:
+                integration = TriggerCatalogIntegration(
+                    key=slug,
+                    name=snapshot.integration_names.get(slug, slug),
                 )
-                # The candidate loaders fall back to unfiltered catalog pages, so drop
-                # score-0 events here rather than letting discover_triggers surface an
-                # arbitrary, unrelated event.
-                if score <= 0:
-                    continue
-                matches.append((score, event, integration))
+                integrations[slug] = integration
+            score = _score_trigger_match(
+                use_case=use_case,
+                event=event,
+                integration=integration,
+            )
+            if score <= 0:
+                continue
+            matches.append((score, event, integration))
 
         return sorted(matches, key=lambda item: item[0], reverse=True)
-
-    async def _candidate_integrations(
-        self,
-        *,
-        provider_key: str,
-        use_case: str,
-    ) -> List[TriggerCatalogIntegration]:
-        candidates: List[TriggerCatalogIntegration] = []
-        seen = set()
-
-        async def add_page(search: Optional[str]) -> None:
-            page = await self.list_integrations(
-                provider_key=provider_key,
-                search=search,
-                limit=_DISCOVERY_INTEGRATION_LIMIT,
-            )
-            for integration in page.integrations:
-                if integration.key not in seen:
-                    seen.add(integration.key)
-                    candidates.append(integration)
-
-        await add_page(use_case)
-        for term in _discovery_terms(use_case)[:3]:
-            if len(candidates) >= _DISCOVERY_INTEGRATION_LIMIT:
-                break
-            await add_page(term)
-        if not candidates:
-            await add_page(None)
-        return candidates[:_DISCOVERY_INTEGRATION_LIMIT]
-
-    async def _candidate_events(
-        self,
-        *,
-        provider_key: str,
-        integration_key: str,
-        use_case: str,
-        limit: int,
-    ) -> List[TriggerCatalogEvent]:
-        events: List[TriggerCatalogEvent] = []
-        seen = set()
-
-        async def add_page(query: Optional[str]) -> None:
-            page = await self.list_events(
-                provider_key=provider_key,
-                integration_key=integration_key,
-                query=query,
-                limit=limit,
-            )
-            for event in page.events:
-                if event.key not in seen:
-                    seen.add(event.key)
-                    events.append(event)
-
-        await add_page(use_case)
-        for term in _discovery_terms(use_case)[:3]:
-            if len(events) >= limit:
-                break
-            await add_page(term)
-        if not events:
-            await add_page(None)
-        return events[:limit]
 
     async def _trigger_discovery_connection_state(
         self,

--- a/api/oss/src/core/triggers/service.py
+++ b/api/oss/src/core/triggers/service.py
@@ -2,7 +2,7 @@ import asyncio
 import hashlib
 import hmac
 from datetime import datetime, timezone
-from typing import Any, Dict, List, Mapping, Optional, Tuple
+from typing import Any, Dict, List, Mapping, Optional, Set, Tuple
 from uuid import UUID
 
 from croniter import croniter
@@ -94,10 +94,36 @@ _DISCOVERY_STOPWORDS = {
     "when",
     "whenever",
     "with",
+    # Meta-vocabulary ("slack triggers") and question filler ("what can gmail do")
+    # add noise — "what" even substring-matches WHATSAPP, "can" matches CANVAS.
+    "anyone",
+    "can",
+    "could",
+    "did",
+    "do",
+    "does",
+    "how",
+    "my",
+    "should",
+    "someone",
+    "trigger",
+    "triggered",
+    "triggers",
+    "webhook",
+    "webhooks",
+    "what",
+    "whats",
+    "which",
+    "who",
 }
 _TRIGGER_DISCOVERY_NO_MATCH_NOTE = (
     "No trigger event matched this use case. Try a more specific integration name "
     "or browse the trigger catalog for available events."
+)
+_TRIGGER_DISCOVERY_NO_CONFIDENT_MATCH_NOTE = (
+    "No confident match for this use case. The closest catalog events are listed in "
+    "alternatives, capped by limit_alternatives (raise it to see more); check each "
+    "one's integration and description before using it."
 )
 
 
@@ -128,6 +154,36 @@ def _normalize_words(value: Optional[str]) -> str:
         char if char.isalnum() else " " for char in (value or "").lower()
     )
     return " ".join(normalized.split())
+
+
+def _named_integrations(
+    *,
+    terms: List[str],
+    integrations: Dict[str, TriggerCatalogIntegration],
+) -> Set[str]:
+    """Integration slugs the use case names explicitly: a use case that names a platform
+    is hard-constrained to it. Equality (not substring) so "dropbox" does not name "box".
+    Accepted risk: toolkits named after ordinary words ("linear", "box") restrict any use
+    case that mentions the word for another reason.
+    """
+    term_set = set(terms)
+    # Adjacent-term concatenations so "google calendar" names googlecalendar
+    # and "one drive" names one_drive.
+    joined = {a + b for a, b in zip(terms, terms[1:])}
+    named: Set[str] = set()
+    for slug, integration in integrations.items():
+        key = "".join(c for c in str(integration.key or "").lower() if c.isalnum())
+        name = "".join(c for c in str(integration.name or "").lower() if c.isalnum())
+        name_words = set(_normalize_words(integration.name).split())
+        if (
+            key in term_set
+            or name in term_set
+            or key in joined
+            or name in joined
+            or (name_words and name_words <= term_set)
+        ):
+            named.add(slug)
+    return named
 
 
 def _match_signal(
@@ -194,6 +250,12 @@ def _match_signal(
         bigram = f"{first} {second}"
         if bigram in normalized_key or bigram in normalized_name:
             score += 4
+
+    # Deprecated events lose term-level ties to their live replacement. Score-only:
+    # matched_terms/exact_phrase untouched, so an exact-phrase ask (+50) can still
+    # surface a deprecated event.
+    if str(event.description or "").lstrip().lower().startswith("deprecated"):
+        score -= 25
 
     return score, matched_terms, exact_phrase
 
@@ -390,6 +452,34 @@ class TriggersService:
             ):
                 surfaced = []
 
+            if not surfaced:
+                # Still hand the agent the closest scored events so a weak or
+                # browse-shaped ask gets something actionable; alternatives carry
+                # no connection info, so no state lookups here.
+                alternatives = [
+                    DiscoveredTriggerAlternative(
+                        integration=alt_event.integration or alt_integration.key,
+                        event_key=alt_event.key,
+                        description=alt_event.description,
+                        provider_event=alt_event.key,
+                    )
+                    for _alt_score, alt_event, alt_integration in matches[
+                        : max(limit_alternatives, 0)
+                    ]
+                ]
+                capabilities.append(
+                    TriggerCapability(
+                        use_case=use_case,
+                        alternatives=alternatives,
+                        note=(
+                            _TRIGGER_DISCOVERY_NO_CONFIDENT_MATCH_NOTE
+                            if alternatives
+                            else _TRIGGER_DISCOVERY_NO_MATCH_NOTE
+                        ),
+                    )
+                )
+                continue
+
             for _score, event, integration in surfaced:
                 key = event.integration or integration.key
                 if key not in states:
@@ -399,15 +489,6 @@ class TriggersService:
                         integration_key=key,
                     )
                     state_order.append(key)
-
-            if not surfaced:
-                capabilities.append(
-                    TriggerCapability(
-                        use_case=use_case,
-                        note=_TRIGGER_DISCOVERY_NO_MATCH_NOTE,
-                    )
-                )
-                continue
 
             _score, event, integration = surfaced[0]
             integration_key = event.integration or integration.key
@@ -560,6 +641,17 @@ class TriggersService:
             if score <= 0:
                 continue
             matches.append((score, event, integration))
+
+        # An event from the wrong platform is unusable no matter how well its words
+        # match ("discord message received" must never surface Slack).
+        named = _named_integrations(
+            terms=_discovery_terms(use_case),
+            integrations=integrations,
+        )
+        if named:
+            matches = [
+                match for match in matches if (match[1].integration or "") in named
+            ]
 
         return sorted(matches, key=lambda item: item[0], reverse=True)
 

--- a/api/oss/src/utils/env.py
+++ b/api/oss/src/utils/env.py
@@ -626,6 +626,13 @@ class ComposioConfig(BaseModel):
     webhook_replay_window_seconds: int = int(
         os.getenv("COMPOSIO_WEBHOOK_REPLAY_WINDOW_SECONDS") or 300
     )
+    # Full trigger-types catalog: project-agnostic cache TTL + whole-fetch deadline.
+    catalog_cache_ttl_seconds: int = int(
+        os.getenv("COMPOSIO_CATALOG_CACHE_TTL_SECONDS") or 24 * 60 * 60
+    )
+    catalog_fetch_deadline_seconds: float = float(
+        os.getenv("COMPOSIO_CATALOG_FETCH_DEADLINE_SECONDS") or 30
+    )
 
     @property
     def enabled(self) -> bool:

--- a/api/oss/tests/pytest/unit/triggers/test_triggers_catalog_client.py
+++ b/api/oss/tests/pytest/unit/triggers/test_triggers_catalog_client.py
@@ -1,0 +1,94 @@
+"""Unit tests for the Composio triggers catalog full crawl (list_all_events)."""
+
+from unittest.mock import AsyncMock, MagicMock
+
+import httpx
+import pytest
+
+from oss.src.core.triggers.exceptions import AdapterError
+from oss.src.core.triggers.providers.composio.catalog import (
+    ComposioTriggersCatalogClient,
+)
+
+
+def _response(items, next_cursor=None):
+    resp = MagicMock()
+    resp.raise_for_status = MagicMock()
+    resp.json.return_value = {
+        "items": items,
+        "next_cursor": next_cursor,
+        "total_items": len(items),
+    }
+    return resp
+
+
+def _client(side_effect):
+    client = ComposioTriggersCatalogClient()
+    client.api_key = "test-key"
+    client.api_url = "https://composio.test/api/v3"
+    client._client = MagicMock()
+    client._client.get = AsyncMock(side_effect=side_effect)
+    return client
+
+
+def _item(slug, toolkit_slug, toolkit_name=None):
+    toolkit = {"slug": toolkit_slug}
+    if toolkit_name:
+        toolkit["name"] = toolkit_name
+    return {
+        "slug": slug,
+        "name": slug.replace("_", " ").title(),
+        "description": f"Fires on {slug}",
+        "toolkit": toolkit,
+        "config": {"type": "object"},
+        "payload": {"sample": True},
+    }
+
+
+async def test_list_all_events_follows_cursor_to_exhaustion():
+    client = _client(
+        [
+            _response(
+                [_item("github_issue_opened", "github", "GitHub")],
+                next_cursor="page2",
+            ),
+            _response(
+                [_item("slack_message", "slack", "Slack")],
+                next_cursor=None,
+            ),
+        ]
+    )
+
+    snapshot = await client.list_all_events()
+
+    assert [event.key for event in snapshot.events] == [
+        "github_issue_opened",
+        "slack_message",
+    ]
+    assert snapshot.integration_names == {"github": "GitHub", "slack": "Slack"}
+    assert snapshot.events[0].trigger_config == {"type": "object"}
+    assert snapshot.events[0].payload == {"sample": True}
+    assert client._client.get.await_count == 2
+    assert client._client.get.await_args_list[1].kwargs["params"]["cursor"] == "page2"
+
+
+async def test_list_all_events_stops_on_repeated_cursor():
+    client = _client(
+        [
+            _response([_item("a_event", "a")], next_cursor="loop"),
+            _response([_item("b_event", "b")], next_cursor="loop"),
+            _response([_item("c_event", "c")], next_cursor="loop"),
+        ]
+    )
+
+    snapshot = await client.list_all_events()
+
+    assert client._client.get.await_count == 2
+    assert [event.key for event in snapshot.events] == ["a_event", "b_event"]
+
+
+async def test_list_all_events_wraps_http_errors():
+    client = _client(httpx.ConnectError("boom"))
+
+    with pytest.raises(AdapterError):
+        await client.list_all_events()

--- a/api/oss/tests/pytest/unit/triggers/test_triggers_discovery.py
+++ b/api/oss/tests/pytest/unit/triggers/test_triggers_discovery.py
@@ -1,5 +1,6 @@
 """Unit tests for trigger event discovery (discover_triggers)."""
 
+import asyncio
 from types import SimpleNamespace
 from uuid import uuid4
 
@@ -12,14 +13,13 @@ from oss.src.apis.fastapi.triggers.models import TriggerDiscoveryQuery
 from oss.src.apis.fastapi.triggers.router import TriggersRouter
 from oss.src.core.triggers.dtos import (
     TriggerCapabilitiesResult,
-    TriggerCatalogEvent,
     TriggerCatalogEventDetails,
-    TriggerCatalogEventsPage,
+    TriggerCatalogEventsSnapshot,
     TriggerCatalogIntegration,
-    TriggerCatalogIntegrationsPage,
     TriggerConnection,
     TriggerDiscoveryConnectionState,
 )
+from oss.src.core.triggers.exceptions import AdapterError
 from oss.src.core.triggers.service import (
     TriggersService,
     _discovery_terms,
@@ -27,6 +27,7 @@ from oss.src.core.triggers.service import (
     _match_signal,
     _score_trigger_match,
 )
+from oss.src.utils.env import env
 
 
 def _service(*, connections=None, integration=None):
@@ -62,48 +63,48 @@ def _ready_connection(connection_id):
     )
 
 
+def _snapshot(events, integration_names=None):
+    return TriggerCatalogEventsSnapshot(
+        events=events,
+        integration_names=(
+            integration_names if integration_names is not None else {"github": "GitHub"}
+        ),
+    )
+
+
+def _wire_catalog(service, snapshot):
+    adapter = SimpleNamespace(list_all_events=AsyncMock(return_value=snapshot))
+    service.adapter_registry.get = MagicMock(return_value=adapter)
+    return adapter
+
+
 async def test_discover_triggers_returns_event_details_and_ready_connection():
     connection_id = uuid4()
     service = _service(connections=[_ready_connection(connection_id)])
-    service.list_integrations = AsyncMock(
-        return_value=TriggerCatalogIntegrationsPage(
-            integrations=[TriggerCatalogIntegration(key="github", name="GitHub")],
-            total=1,
-        )
-    )
-    service.list_events = AsyncMock(
-        return_value=TriggerCatalogEventsPage(
-            events=[
-                TriggerCatalogEvent(
+    _wire_catalog(
+        service,
+        _snapshot(
+            [
+                TriggerCatalogEventDetails(
                     key="github_issue_opened",
                     name="Issue opened",
                     description="Triggers when a GitHub issue is opened.",
                     provider="composio",
                     integration="github",
+                    trigger_config={
+                        "type": "object",
+                        "properties": {"repo": {"type": "string"}},
+                    },
+                    payload={"issue": {"title": "Bug"}},
                 ),
-                TriggerCatalogEvent(
+                TriggerCatalogEventDetails(
                     key="github_comment_created",
                     name="Comment created",
                     provider="composio",
                     integration="github",
                 ),
-            ],
-            total=2,
-        )
-    )
-    service.get_event = AsyncMock(
-        return_value=TriggerCatalogEventDetails(
-            key="github_issue_opened",
-            name="Issue opened",
-            description="Triggers when a GitHub issue is opened.",
-            provider="composio",
-            integration="github",
-            trigger_config={
-                "type": "object",
-                "properties": {"repo": {"type": "string"}},
-            },
-            payload={"issue": {"title": "Bug"}},
-        )
+            ]
+        ),
     )
 
     result = await service.discover_triggers(
@@ -225,7 +226,8 @@ def test_trigger_discovery_query_rejects_scalar_string():
 
 
 def _event(key, name="", description="", integration="github", provider="composio"):
-    return TriggerCatalogEvent(
+    # Details subclass so the same helper feeds both scoring tests and snapshots.
+    return TriggerCatalogEventDetails(
         key=key,
         name=name,
         description=description,
@@ -334,31 +336,19 @@ def test_primary_evidence_false_for_single_generic_term():
 # ---------------------------------------------------------------------------
 
 
-async def test_discover_events_ranks_by_score_descending():
-    service = _service()
-    service.list_integrations = AsyncMock(
-        return_value=TriggerCatalogIntegrationsPage(
-            integrations=[_integration()], total=1
-        )
-    )
-    service.list_events = AsyncMock(
-        return_value=TriggerCatalogEventsPage(
-            events=[
+def test_discover_events_ranks_by_score_descending():
+    matches = TriggersService._discover_events_for_use_case(
+        use_case="github issue opened",
+        snapshot=_snapshot(
+            [
                 _event("github_comment_created", "Comment created"),
                 _event(
                     "github_issue_opened",
                     "Issue opened",
                     "Triggers when a github issue is opened",
                 ),
-            ],
-            total=2,
-        )
-    )
-
-    matches = await service._discover_events_for_use_case(
-        provider_key="composio",
-        use_case="github issue opened",
-        limit_alternatives=3,
+            ]
+        ),
     )
 
     keys = [event.key for _score, event, _integration in matches]
@@ -367,27 +357,15 @@ async def test_discover_events_ranks_by_score_descending():
     assert scores == sorted(scores, reverse=True)
 
 
-async def test_discover_events_drops_zero_score_candidates():
-    service = _service()
-    service.list_integrations = AsyncMock(
-        return_value=TriggerCatalogIntegrationsPage(
-            integrations=[_integration()], total=1
-        )
-    )
-    service.list_events = AsyncMock(
-        return_value=TriggerCatalogEventsPage(
-            events=[
+def test_discover_events_drops_zero_score_candidates():
+    matches = TriggersService._discover_events_for_use_case(
+        use_case="issue opened",
+        snapshot=_snapshot(
+            [
                 _event("github_issue_opened", "Issue opened", "An issue was opened"),
                 _event("github_push", "Push", "Code was pushed"),
-            ],
-            total=2,
-        )
-    )
-
-    matches = await service._discover_events_for_use_case(
-        provider_key="composio",
-        use_case="issue opened",
-        limit_alternatives=3,
+            ]
+        ),
     )
 
     keys = [event.key for _score, event, _integration in matches]
@@ -400,16 +378,9 @@ async def test_discover_events_drops_zero_score_candidates():
 # ---------------------------------------------------------------------------
 
 
-def _discovery_service(*, integrations, events, connections=None):
+def _discovery_service(*, events, integration_names=None, connections=None):
     service = _service(connections=connections)
-    service.list_integrations = AsyncMock(
-        return_value=TriggerCatalogIntegrationsPage(
-            integrations=integrations, total=len(integrations)
-        )
-    )
-    service.list_events = AsyncMock(
-        return_value=TriggerCatalogEventsPage(events=events, total=len(events))
-    )
+    _wire_catalog(service, _snapshot(events, integration_names))
     return service
 
 
@@ -417,7 +388,6 @@ async def test_discover_triggers_no_match_for_weak_single_term():
     # The only candidate shares a single generic term ("issue") with the use case, so it must
     # not be promoted to the primary match; the use case falls to the no-match path instead.
     service = _discovery_service(
-        integrations=[_integration("jira", "Jira")],
         events=[
             _event(
                 "jira_issue_created",
@@ -426,6 +396,7 @@ async def test_discover_triggers_no_match_for_weak_single_term():
                 integration="jira",
             )
         ],
+        integration_names={"jira": "Jira"},
     )
     service.get_event = AsyncMock()
 
@@ -446,7 +417,7 @@ async def test_discover_triggers_no_match_for_weak_single_term():
 
 
 async def test_discover_triggers_no_match_when_no_events():
-    service = _discovery_service(integrations=[], events=[])
+    service = _discovery_service(events=[], integration_names={})
 
     result = await service.discover_triggers(
         project_id=uuid4(),
@@ -462,25 +433,18 @@ async def test_discover_triggers_no_match_when_no_events():
 
 async def test_discover_triggers_mixed_match_and_no_match():
     service = _discovery_service(
-        integrations=[_integration()],
         events=[
-            _event(
-                "github_issue_opened",
-                "Issue opened",
-                "Triggers when a github issue is opened",
+            TriggerCatalogEventDetails(
+                key="github_issue_opened",
+                name="Issue opened",
+                description="Triggers when a github issue is opened",
+                provider="composio",
+                integration="github",
+                trigger_config={"type": "object"},
+                payload={},
             )
         ],
         connections=[],
-    )
-    service.get_event = AsyncMock(
-        return_value=TriggerCatalogEventDetails(
-            key="github_issue_opened",
-            name="Issue opened",
-            provider="composio",
-            integration="github",
-            trigger_config={"type": "object"},
-            payload={},
-        )
     )
 
     result = await service.discover_triggers(
@@ -497,6 +461,88 @@ async def test_discover_triggers_mixed_match_and_no_match():
     assert matched.connection.state == TriggerDiscoveryConnectionState.NEEDS_AUTH
     assert missed.event is None
     assert result.ready is False
+    # One catalog fetch per request, not per use case.
+    adapter = service.adapter_registry.get.return_value
+    adapter.list_all_events.assert_awaited_once()
+
+
+async def test_discover_triggers_adjacency_bonus_breaks_catalog_order_tie():
+    # Live regression: github/issue/created hit both events equally, and the comment
+    # event comes first in catalog order, so without the adjacency bonus the stable
+    # sort would surface it as primary.
+    service = _discovery_service(
+        events=[
+            _event(
+                "GITHUB_ISSUE_COMMENT_CREATED_TRIGGER",
+                "Issue Comment Created",
+                "Triggered when a comment is created on an issue",
+            ),
+            _event(
+                "GITHUB_ISSUE_CREATED_TRIGGER",
+                "Issue Created",
+                "Triggered when a new issue is created",
+            ),
+        ],
+    )
+
+    result = await service.discover_triggers(
+        project_id=uuid4(),
+        use_cases=["when a new GitHub issue is created"],
+        provider_key="composio",
+        limit_alternatives=2,
+    )
+
+    capability = result.capabilities[0]
+    assert capability.event.event_key == "GITHUB_ISSUE_CREATED_TRIGGER"
+    assert [alt.event_key for alt in capability.alternatives] == [
+        "GITHUB_ISSUE_COMMENT_CREATED_TRIGGER"
+    ]
+
+
+async def test_discover_triggers_adjacency_bonus_ignores_integration_name_bigrams():
+    # Live regression: "slack message" is adjacent in SLACK_MESSAGE_REACTION_ADDED's
+    # key only because every slack event key starts with the integration name. With
+    # integration-name tokens excluded from pairing, no event gets a bonus here and
+    # base scores surface the channel-message events over the reaction event.
+    service = _discovery_service(
+        events=[
+            _event(
+                "SLACK_MESSAGE_REACTION_ADDED",
+                "Message Reaction Added",
+                "Triggered when a reaction is added to a message in a channel",
+                integration="slack",
+            ),
+            _event(
+                "SLACKBOT_CHANNEL_MESSAGE_RECEIVED",
+                "Channel Message Received",
+                "Triggered when a message is posted to a channel",
+                integration="slackbot",
+            ),
+            _event(
+                "SLACK_CHANNEL_MESSAGE_RECEIVED",
+                "Channel Message Received",
+                "Triggered when a message is posted to a channel",
+                integration="slack",
+            ),
+        ],
+        integration_names={"slack": "Slack", "slackbot": "Slackbot"},
+    )
+
+    result = await service.discover_triggers(
+        project_id=uuid4(),
+        use_cases=["new Slack message in a channel"],
+        provider_key="composio",
+        limit_alternatives=2,
+    )
+
+    capability = result.capabilities[0]
+    assert capability.event.event_key in {
+        "SLACKBOT_CHANNEL_MESSAGE_RECEIVED",
+        "SLACK_CHANNEL_MESSAGE_RECEIVED",
+    }
+    assert "SLACK_MESSAGE_REACTION_ADDED" in [
+        alt.event_key for alt in capability.alternatives
+    ]
 
 
 async def test_discovery_connection_state_increments_slug_on_collision():
@@ -519,3 +565,68 @@ async def test_discovery_connection_state_increments_slug_on_collision():
 
     assert state.state == TriggerDiscoveryConnectionState.NEEDS_AUTH
     assert state.connect.body["connection"]["slug"] == "github-main-2"
+
+
+# ---------------------------------------------------------------------------
+# _cached_event_catalog: cache hit/miss + fetch deadline.
+# ---------------------------------------------------------------------------
+
+
+async def test_cached_event_catalog_hit_skips_adapter(monkeypatch):
+    service = _service()
+    adapter = _wire_catalog(service, _snapshot([]))
+    cached = _snapshot([_event("github_issue_opened", "Issue opened")])
+
+    async def _hit(**_kwargs):
+        return cached
+
+    async def _noop(**_kwargs):
+        return None
+
+    monkeypatch.setattr("oss.src.core.triggers.service.get_cache", _hit)
+    monkeypatch.setattr("oss.src.core.triggers.service.set_cache", _noop)
+
+    snapshot = await service._cached_event_catalog(provider_key="composio")
+
+    assert snapshot is cached
+    adapter.list_all_events.assert_not_called()
+
+
+async def test_cached_event_catalog_miss_fetches_once_and_caches(monkeypatch):
+    fetched = _snapshot([_event("github_issue_opened", "Issue opened")])
+    service = _service()
+    adapter = _wire_catalog(service, fetched)
+
+    writes = []
+
+    async def _miss(**_kwargs):
+        return None
+
+    async def _capture(**kwargs):
+        writes.append(kwargs)
+
+    monkeypatch.setattr("oss.src.core.triggers.service.get_cache", _miss)
+    monkeypatch.setattr("oss.src.core.triggers.service.set_cache", _capture)
+
+    snapshot = await service._cached_event_catalog(provider_key="composio")
+
+    assert snapshot == fetched
+    adapter.list_all_events.assert_awaited_once()
+    assert len(writes) == 1
+    assert writes[0]["value"] == fetched
+    assert writes[0]["ttl"] == env.composio.catalog_cache_ttl_seconds
+
+
+async def test_cached_event_catalog_deadline_raises_adapter_error(monkeypatch):
+    service = _service()
+
+    async def _hang():
+        await asyncio.sleep(60)
+
+    service.adapter_registry.get = MagicMock(
+        return_value=SimpleNamespace(list_all_events=_hang)
+    )
+    monkeypatch.setattr(env.composio, "catalog_fetch_deadline_seconds", 0.01)
+
+    with pytest.raises(AdapterError):
+        await service._cached_event_catalog(provider_key="composio")

--- a/api/oss/tests/pytest/unit/triggers/test_triggers_discovery.py
+++ b/api/oss/tests/pytest/unit/triggers/test_triggers_discovery.py
@@ -22,6 +22,7 @@ from oss.src.core.triggers.dtos import (
 from oss.src.core.triggers.exceptions import AdapterError
 from oss.src.core.triggers.service import (
     TriggersService,
+    _TRIGGER_DISCOVERY_NO_CONFIDENT_MATCH_NOTE,
     _discovery_terms,
     _has_primary_evidence,
     _match_signal,
@@ -543,6 +544,146 @@ async def test_discover_triggers_adjacency_bonus_ignores_integration_name_bigram
     assert "SLACK_MESSAGE_REACTION_ADDED" in [
         alt.event_key for alt in capability.alternatives
     ]
+
+
+async def test_discover_triggers_browse_query_returns_alternatives_without_primary():
+    # Browse-shaped ask: "triggers" is meta-vocabulary, so only "slack" remains as a
+    # term. The gate fails (one term, no exact phrase) but the closest slack events
+    # must still come back as alternatives instead of an empty capability.
+    service = _discovery_service(
+        events=[
+            _event(
+                "SLACK_NEW_CHANNEL_CREATED",
+                "Channel Created",
+                "Fires when a channel is created",
+                integration="slack",
+            ),
+            _event(
+                "SLACK_CHANNEL_MESSAGE_RECEIVED",
+                "Channel Message Received",
+                "Fires when a message is posted to a channel",
+                integration="slack",
+            ),
+            _event(
+                "GITHUB_ISSUE_CREATED_TRIGGER",
+                "Issue Created",
+                "Fires when a new issue is created",
+                integration="github",
+            ),
+        ],
+        integration_names={"slack": "Slack", "github": "GitHub"},
+    )
+
+    result = await service.discover_triggers(
+        project_id=uuid4(),
+        use_cases=["slack triggers"],
+        provider_key="composio",
+        limit_alternatives=3,
+    )
+
+    capability = result.capabilities[0]
+    assert capability.event is None
+    assert capability.alternatives
+    assert all(alt.integration == "slack" for alt in capability.alternatives)
+    assert capability.note == _TRIGGER_DISCOVERY_NO_CONFIDENT_MATCH_NOTE
+
+
+async def test_discover_triggers_named_integration_beats_cross_platform_keywords():
+    # Naming a platform hard-constrains discovery to it: slack's keyword-rich
+    # message event must not outrank (or even accompany) the discord event.
+    service = _discovery_service(
+        events=[
+            _event(
+                "SLACK_CHANNEL_MESSAGE_RECEIVED",
+                "Channel Message Received",
+                "Triggered when a message is received in a channel",
+                integration="slack",
+            ),
+            _event(
+                "DISCORD_NEW_MESSAGE_TRIGGER",
+                "New Message",
+                "Triggered when a message is received in a discord server",
+                integration="discord",
+            ),
+        ],
+        integration_names={"slack": "Slack", "discord": "Discord"},
+    )
+
+    result = await service.discover_triggers(
+        project_id=uuid4(),
+        use_cases=["discord message received"],
+        provider_key="composio",
+        limit_alternatives=3,
+    )
+
+    capability = result.capabilities[0]
+    assert capability.event.event_key == "DISCORD_NEW_MESSAGE_TRIGGER"
+    assert all("SLACK" not in alt.event_key for alt in capability.alternatives)
+
+
+async def test_discover_triggers_question_words_do_not_match_substrings():
+    # "what" is a substring of WHATSAPP and "can" of CANVAS; as stopwords they must
+    # not pull in the wrong integration when the agent asks a question about gmail.
+    service = _discovery_service(
+        events=[
+            _event(
+                "WHATSAPP_NEW_MESSAGE",
+                "New Message",
+                "Triggered when a new whatsapp message arrives",
+                integration="whatsapp",
+            ),
+            _event(
+                "GMAIL_NEW_GMAIL_MESSAGE",
+                "New Email",
+                "Triggered when a new email arrives in the inbox",
+                integration="gmail",
+            ),
+        ],
+        integration_names={"whatsapp": "WhatsApp", "gmail": "Gmail"},
+    )
+
+    result = await service.discover_triggers(
+        project_id=uuid4(),
+        use_cases=["what events can gmail trigger on"],
+        provider_key="composio",
+        limit_alternatives=3,
+    )
+
+    capability = result.capabilities[0]
+    surfaced_keys = ([capability.event.event_key] if capability.event else []) + [
+        alt.event_key for alt in capability.alternatives
+    ]
+    assert surfaced_keys[0] == "GMAIL_NEW_GMAIL_MESSAGE"
+    assert "WHATSAPP_NEW_MESSAGE" not in surfaced_keys
+
+
+async def test_discover_triggers_deprecated_event_ranks_below_live_equivalent():
+    # Equal term hits, deprecated event first in catalog order: without the demotion
+    # the stable sort would surface the deprecated event as primary.
+    service = _discovery_service(
+        events=[
+            _event(
+                "GITHUB_ISSUE_CREATED_LEGACY_TRIGGER",
+                "Issue Created (Legacy)",
+                "DEPRECATED: use GITHUB_ISSUE_CREATED_TRIGGER instead.",
+            ),
+            _event(
+                "GITHUB_ISSUE_CREATED_TRIGGER",
+                "Issue Created",
+                "Triggered when a new issue is created",
+            ),
+        ],
+    )
+
+    result = await service.discover_triggers(
+        project_id=uuid4(),
+        use_cases=["github issue created"],
+        provider_key="composio",
+        limit_alternatives=3,
+    )
+
+    capability = result.capabilities[0]
+    assert capability.event.event_key == "GITHUB_ISSUE_CREATED_TRIGGER"
 
 
 async def test_discovery_connection_state_increments_slug_on_collision():

--- a/docs/design/agent-workflows/projects/trigger-discovery-catalog/README.md
+++ b/docs/design/agent-workflows/projects/trigger-discovery-catalog/README.md
@@ -1,0 +1,30 @@
+# Trigger discovery: cached catalog dump
+
+Planning workspace for making `discover_triggers` fast. Today the operation takes 30 to 60
+seconds because it pages through the Composio catalog with up to 50 sequential HTTP calls
+per use case. The fix: fetch the full trigger catalog once (351 items, about 4 seconds),
+cache it in Redis for a day, and score every use case in memory. Warm calls drop to under
+a second.
+
+This is the triggers-side sibling of the `tool-discovery` workspace
+([`../tool-discovery/`](../tool-discovery/README.md)). Tools got fast through Composio's
+semantic search. Triggers have no such search, but their catalog is small enough to hold
+whole.
+
+## Files
+
+- [`context.md`](context.md) — why `discover_triggers` is slow, why `discover_tools`
+  isn't, and what outcome we want.
+- [`research.md`](research.md) — verified facts: catalog sizes, dump timings, what each
+  catalog item contains, and the Composio terms-of-service check. All run live on
+  2026-07-09 and 2026-07-10.
+- [`plan.md`](plan.md) — the design and the phased implementation plan.
+- [`status.md`](status.md) — current state and settled decisions (D1 to D5). Source of
+  truth.
+
+## One-line summary
+
+The whole Composio trigger catalog is 351 items across 41 toolkits, and each item already
+carries its config schema and a sample payload. Fetch it once, cache it for a day, score
+in memory: cold discovery costs one 4-second fetch per deployment per day, and every other
+call returns in under a second.

--- a/docs/design/agent-workflows/projects/trigger-discovery-catalog/README.md
+++ b/docs/design/agent-workflows/projects/trigger-discovery-catalog/README.md
@@ -1,7 +1,7 @@
 # Trigger discovery: cached catalog dump
 
 Planning workspace for making `discover_triggers` fast. Today the operation takes 30 to 60
-seconds because it pages through the Composio catalog with up to 50 sequential HTTP calls
+seconds because it pages through the Composio catalog with up to 60 sequential HTTP calls
 per use case. The fix: fetch the full trigger catalog once (351 items, about 4 seconds),
 cache it in Redis for a day, and score every use case in memory. Warm calls drop to under
 a second.
@@ -28,3 +28,6 @@ The whole Composio trigger catalog is 351 items across 41 toolkits, and each ite
 carries its config schema and a sample payload. Fetch it once, cache it for a day, score
 in memory: cold discovery costs one 4-second fetch per deployment per day, and every other
 call returns in under a second.
+
+Implemented and verified live on 2026-07-10: cold 5.06 s, warm 0.71 s, against 30 to 60
+seconds before. See [`status.md`](status.md).

--- a/docs/design/agent-workflows/projects/trigger-discovery-catalog/context.md
+++ b/docs/design/agent-workflows/projects/trigger-discovery-catalog/context.md
@@ -29,7 +29,7 @@ triggers. So the v1 implementation emulates search by paging the catalog with ke
 
 Every one of those calls is a live HTTP round trip. None are cached. None run
 concurrently: each `await` sits inside a plain `for` loop, so latencies add up instead of
-overlapping. The worst case is roughly 50 sequential round trips per use case. At 0.5
+overlapping. The worst case is up to 60 sequential round trips per use case. At 0.5
 seconds per round trip, three use cases cost over a minute.
 
 So the problem is not algorithmic complexity in CPU terms. It is a sequential HTTP

--- a/docs/design/agent-workflows/projects/trigger-discovery-catalog/context.md
+++ b/docs/design/agent-workflows/projects/trigger-discovery-catalog/context.md
@@ -1,0 +1,83 @@
+# Context: why `discover_triggers` is slow
+
+## The symptom
+
+An agent that calls `discover_tools` gets an answer in under a second (warm). The same
+agent calling `discover_triggers` waits 30 to 60 seconds. Both operations answer the same
+kind of question: "given this use case, which integration and which capability should I
+wire up?" The gap makes trigger setup feel broken next to tool setup.
+
+## Why the two operations differ
+
+`discover_tools` rides on Composio's semantic search. One HTTP call
+(`COMPOSIO_SEARCH_TOOLS`) takes all the use cases at once and returns tools, schemas, and
+guidance together. The service caches that result in Redis, keyed project-agnostically,
+so repeat discoveries skip Composio entirely
+(`api/oss/src/core/tools/service.py`, `discover_capabilities` and `_cached_search`).
+
+`discover_triggers` has no semantic search to ride on. Composio does not offer one for
+triggers. So the v1 implementation emulates search by paging the catalog with keywords
+(`api/oss/src/core/triggers/service.py`, `discover_triggers`):
+
+1. For each use case, `_candidate_integrations` runs up to five `GET /toolkits` searches
+   (the full phrase, then the first three keywords, then an unfiltered fallback).
+2. For each of up to ten candidate integrations, `_candidate_events` runs up to five
+   `GET /triggers_types` searches the same way.
+3. The primary match then costs one more `GET /triggers_types/{slug}` for its config
+   schema, and each surfaced integration costs a `GET /toolkits/{slug}` for its auth
+   schemes.
+
+Every one of those calls is a live HTTP round trip. None are cached. None run
+concurrently: each `await` sits inside a plain `for` loop, so latencies add up instead of
+overlapping. The worst case is roughly 50 sequential round trips per use case. At 0.5
+seconds per round trip, three use cases cost over a minute.
+
+So the problem is not algorithmic complexity in CPU terms. It is a sequential HTTP
+fan-out against a remote catalog, done fresh on every call.
+
+## The insight that unlocks the fix
+
+The trigger catalog is tiny and self-contained. Measured live (see
+[`research.md`](research.md)):
+
+- 351 trigger types total, across only 41 toolkits. Compare 23,790 action tools, which
+  is why the tools side genuinely needs Composio's search.
+- The full dump is 8 pages and 2.2 MB, and each item already includes everything
+  discovery needs: slug, name, description, toolkit, the `config` schema, and a sample
+  `payload`.
+- Fetching all 8 pages takes about 4.3 seconds.
+
+A catalog this small does not need remote search. We can hold the whole thing in memory
+and score it directly, with the same scoring functions the service already uses.
+
+## Why we download instead of shipping a JSON file
+
+Shipping the dump as a file in the repo was the first idea, and the repo has precedent
+for vendored catalogs (the LLM model list in `assets.py`). But Composio's terms of
+service rule it out. Section 3 of [composio.dev/terms](https://composio.dev/terms)
+excludes "any resale or commercial use of the platform or its contents, any derivative
+use of the platform or its contents, or any use of data mining, robots, or similar data
+gathering and extraction tools." Committing their catalog content (descriptions, schemas,
+sample payloads) into a public repo that ships in a commercial product reads as exactly
+that. Downloading the catalog at runtime with our own API key and caching it server-side
+is ordinary API usage, and it costs us almost nothing: one 4-second fetch per deployment
+per cache window instead of zero. Full analysis in [`research.md`](research.md), decision
+D1 in [`status.md`](status.md).
+
+## Goals
+
+- Warm `discover_triggers` returns in under a second.
+- Cold calls pay one catalog fetch (about 4 seconds), once per deployment per cache
+  window, not per request.
+- Discovery results stay at least as good as today: same scoring logic, same DTOs, no
+  wire change.
+- The agent-facing contract of the operation does not change at all.
+
+## Non-goals
+
+- No change to `discover_tools`. It is already fast.
+- No change to the public catalog browse endpoints (`list_events`, `get_event` routes) in
+  v1. They stay on the live adapter. Serving them from the cached dump is a possible
+  follow-up, noted in [`plan.md`](plan.md).
+- No vendored catalog file in the repo (ToS, see above).
+- No new agent-facing fields or behavior.

--- a/docs/design/agent-workflows/projects/trigger-discovery-catalog/plan.md
+++ b/docs/design/agent-workflows/projects/trigger-discovery-catalog/plan.md
@@ -5,10 +5,13 @@
 Fetch the complete Composio trigger-types catalog (351 items, 8 pages, ~4.3 s) through
 the existing adapter, cache it in Redis with a 24-hour TTL, and rewrite
 `_discover_events_for_use_case` to score all items in memory. The scoring functions
-(`_score_trigger_match`, `_has_primary_evidence`, `_discovery_terms`) stay as they are.
-The per-use-case keyword paging (`_candidate_integrations`, `_candidate_events`) and the
-follow-up `get_event` detail call all disappear. The wire contract of `discover_triggers`
-does not change: same request, same `TriggerCapabilitiesResult`.
+(`_score_trigger_match`, `_has_primary_evidence`, `_discovery_terms`) carry over, with
+one addition found during live verification: an adjacency bonus that replaces the
+provider's relevance ordering on score ties (decision D7 in
+[`status.md`](status.md)). The per-use-case keyword paging
+(`_candidate_integrations`, `_candidate_events`) and the follow-up `get_event` detail
+call all disappear. The wire contract of `discover_triggers` does not change: same
+request, same `TriggerCapabilitiesResult`.
 
 ## How the pieces map to the current code
 
@@ -83,7 +86,7 @@ note (existing `_TRIGGER_DISCOVERY_NO_MATCH_NOTE` path).
 
 **Phase 3 — verify against the live stack.** `cd api && py-run-tests` for the unit
 suite. Then on the dev stack: call `discover_triggers` twice with 2 to 3 realistic use
-cases ("when a new github issue is created", "new slack message in a channel"). Confirm
+cases ("when a new GitHub issue is created", "new Slack message in a channel"). Confirm
 cold call completes in single-digit seconds, warm call in under a second, and the
 surfaced events match a before/after capture from the current implementation.
 
@@ -101,8 +104,11 @@ lookup, per the keep-docs-in-sync skill.
   this; noted as optional hardening, not in v1.
 - **Scoring drift**: the integration description leaves the haystack (D5). The term
   weights already favor event fields (5) and event key (3) over integration key (2), and
-  toolkit slug + name remain. Phase 3's before/after capture is the check that ranking
-  did not regress on realistic queries.
+  toolkit slug + name remain. Phase 3's live capture was the check, and it caught a real
+  case: score ties that the provider's relevance ordering used to break now broke by
+  catalog order, surfacing the GitHub issue-comment event over the issue-created event.
+  Resolved with the adjacency bonus (D7 in [`status.md`](status.md)) plus a unit test
+  that pins the case.
 
 ## Verification summary
 

--- a/docs/design/agent-workflows/projects/trigger-discovery-catalog/plan.md
+++ b/docs/design/agent-workflows/projects/trigger-discovery-catalog/plan.md
@@ -1,0 +1,113 @@
+# Plan: score trigger discovery against a cached catalog dump
+
+## Design in one paragraph
+
+Fetch the complete Composio trigger-types catalog (351 items, 8 pages, ~4.3 s) through
+the existing adapter, cache it in Redis with a 24-hour TTL, and rewrite
+`_discover_events_for_use_case` to score all items in memory. The scoring functions
+(`_score_trigger_match`, `_has_primary_evidence`, `_discovery_terms`) stay as they are.
+The per-use-case keyword paging (`_candidate_integrations`, `_candidate_events`) and the
+follow-up `get_event` detail call all disappear. The wire contract of `discover_triggers`
+does not change: same request, same `TriggerCapabilitiesResult`.
+
+## How the pieces map to the current code
+
+All paths relative to `api/oss/src/core/triggers/`.
+
+### 1. Adapter: fetch the full catalog
+
+Add `list_all_events()` to `ComposioTriggersCatalogClient`
+(`providers/composio/catalog.py`). It loops the existing `list_events(...)` page by page,
+following `next_cursor` until exhausted, and returns `List[TriggerCatalogEventDetails]`.
+Sequential on purpose (decision D2): the cursor format is undocumented, and the fetch is
+rare enough that 4.3 seconds is fine.
+
+The list response already includes `config` and `payload` per item (research §2), so the
+existing `_parse_event` gets a sibling that parses list items into
+`TriggerCatalogEventDetails` instead of the slimmer `TriggerCatalogEvent`.
+
+### 2. Service: cache the dump
+
+Add `_cached_event_catalog(provider_key)` to `TriggersService` (`service.py`), mirroring
+`ToolsService._cached_search` (`core/tools/service.py`): try `get_cache`, on miss call
+the adapter's `list_all_events()` and `set_cache` the result. Cache properties:
+
+- **Key**: provider only. The catalog is the same for every project, so the cache is
+  project-agnostic, exactly like the tools-discovery cache (its D6 split).
+- **TTL**: 24 hours. The catalog moves slowly (351 mature items). A stale window of at
+  most a day is acceptable because the subscription-create path validates against the
+  live provider anyway; a removed trigger fails loudly at mint time, not silently.
+- **Serialization**: a small wrapper DTO holding `List[TriggerCatalogEventDetails]`, so
+  `get_cache(model=...)` can validate it. No new agent-facing fields; this type never
+  crosses the API boundary (interface review: it is pure catalog data plus nothing, no
+  config/policy/credential fields to misplace).
+
+### 3. Service: score in memory
+
+Rewrite `_discover_events_for_use_case`:
+
+- Load the catalog once per `discover_triggers` call (one awaited cache read).
+- Build a `TriggerCatalogIntegration` per distinct toolkit from the items' embedded
+  `toolkit` (slug + name; no description, see D5).
+- Score every item with the existing `_score_trigger_match`, keep score > 0, sort
+  descending. Same dedup, same `_has_primary_evidence` gate for the primary match.
+- The primary match's `trigger_config` and `payload` come straight from the dump item.
+  Delete the `get_event` call inside `discover_triggers`.
+
+Delete `_candidate_integrations` and `_candidate_events`. Nothing else uses them.
+
+`_trigger_discovery_connection_state` and `_trigger_connection_auth_state` stay
+unchanged. They are per-project (DB) plus at most one `get_integration` call per
+surfaced integration, at most four per use case, and they must stay fresh (a user who
+just finished connecting must see READY immediately). Not the bottleneck.
+
+### 4. What stays on the live adapter
+
+The public browse routes (`list_events`, `get_event` in
+`apis/fastapi/triggers/router.py`) keep calling the adapter directly. Their pagination
+semantics (Composio's native cursor) would change if we served them from the dump, and
+they are not slow today. Possible follow-up, out of scope (decision D4).
+
+## Phases
+
+**Phase 1 — catalog fetch and cache.** `list_all_events()` on the adapter, the wrapper
+DTO, `_cached_event_catalog()` on the service. Unit tests with a fake adapter: pages are
+followed to exhaustion, cache hit skips the adapter, cache miss populates it.
+
+**Phase 2 — in-memory discovery.** Rewrite `_discover_events_for_use_case`, delete the
+candidate loaders, drop the `get_event` call. Update
+`oss/tests/pytest/unit/triggers/test_triggers_discovery.py`: the scoring and
+primary-evidence tests keep their assertions but feed a fake catalog dump instead of
+paged fakes. Add one test that a use case matching nothing still returns the no-match
+note (existing `_TRIGGER_DISCOVERY_NO_MATCH_NOTE` path).
+
+**Phase 3 — verify against the live stack.** `cd api && py-run-tests` for the unit
+suite. Then on the dev stack: call `discover_triggers` twice with 2 to 3 realistic use
+cases ("when a new github issue is created", "new slack message in a channel"). Confirm
+cold call completes in single-digit seconds, warm call in under a second, and the
+surfaced events match a before/after capture from the current implementation.
+
+**Phase 4 — docs sync.** No wire change, so the interface inventory is untouched. Update
+any agent-workflows documentation that mentions trigger-discovery latency or the paged
+lookup, per the keep-docs-in-sync skill.
+
+## Risks and mitigations
+
+- **Cold-cache stampede**: several concurrent discoveries on an empty cache each trigger
+  the 4-second fetch. Harmless (last write wins, results identical) but wasteful. If it
+  shows up in practice, add a Redis `SET NX` single-flight lock. Not in v1.
+- **Composio outage with a cold cache**: the fetch raises `AdapterError`, which surfaces
+  exactly as today's per-page failures do. A stale-while-revalidate cache would mask
+  this; noted as optional hardening, not in v1.
+- **Scoring drift**: the integration description leaves the haystack (D5). The term
+  weights already favor event fields (5) and event key (3) over integration key (2), and
+  toolkit slug + name remain. Phase 3's before/after capture is the check that ranking
+  did not regress on realistic queries.
+
+## Verification summary
+
+1. Unit: `cd api && py-run-tests` green, including the rewritten discovery tests.
+2. Live: two consecutive `discover_triggers` calls on the dev stack; assert timings
+   (cold < 10 s, warm < 1 s) and stable results against a pre-change capture.
+3. Regression: the existing subscription-create flow against a discovered event still
+   works end to end (discover, connect, create_subscription).

--- a/docs/design/agent-workflows/projects/trigger-discovery-catalog/research.md
+++ b/docs/design/agent-workflows/projects/trigger-discovery-catalog/research.md
@@ -1,0 +1,105 @@
+# Research: verified facts
+
+Everything below was measured live against `https://backend.composio.dev/api/v3` with the
+dev-stack API key, on 2026-07-09 and 2026-07-10. Nothing here is estimated.
+
+## 1. Catalog sizes
+
+| Catalog | Endpoint | Count |
+| --- | --- | --- |
+| Toolkits (integrations) | `GET /toolkits` | 1,047 |
+| Trigger types (events) | `GET /triggers_types` | 351 |
+| Tools (actions) | `GET /tools` | 23,790 |
+
+Only **41 of the 1,047 toolkits have any trigger at all**. The distribution is heavily
+skewed toward a few large integrations:
+
+googlesuper 48, github 46, confluence 23, clickup 21, box 20, googlesheets 16,
+workday 13, linear 12, zoom 11, googledocs 10, one_drive 9, slackbot 9, slack 9,
+notion 8, googlecalendar 7, and a long tail of smaller ones.
+
+The takeaway: the trigger catalog is two orders of magnitude smaller than the tools
+catalog. Holding it whole is cheap. That option does not exist for tools, which is why
+the tools side uses Composio's semantic search instead.
+
+## 2. What a trigger-type item contains
+
+Each item in the `GET /triggers_types` list response carries:
+
+`slug`, `name`, `description`, `toolkit` (object with `slug` and `name`), `config`
+(the JSON Schema for the trigger's configuration), `payload` (a sample event payload),
+`instructions`, `requires_webhook_endpoint_setup`, `type`, `version`.
+
+This matters because the current `discover_triggers` makes a **separate**
+`GET /triggers_types/{slug}` call to fetch `config` and `payload` for the primary match.
+With the full dump in hand, that call disappears: the list items already contain both
+fields.
+
+One gap: the `toolkit` object inside an item has `slug` and `name` but no description.
+The current scorer includes the integration description in its haystack. Scoring from
+the dump loses that one signal. See decision D5 in [`status.md`](status.md).
+
+## 3. Dump size and fetch timings
+
+- Page size is capped at 50. A `limit=1000` request is silently clamped to 50, so the
+  full dump is 8 pages.
+- Full dump: **2.2 MB** of JSON. Stripped to only the fields the keyword scorer reads
+  (slug, name, description, toolkit, type): **139 KB**.
+- Sequential fetch, following `next_cursor` page by page: **4.26 seconds** (8 pages at a
+  steady ~0.55 s each).
+- Parallel fetch: the cursor is just base64 of `page-offset` (`"Mi01MA=="` decodes to
+  `2-50`), so all 8 cursors can be constructed upfront and fetched concurrently:
+  **0.86 seconds**, all 351 slugs identical to the sequential result.
+
+We decided against the parallel trick (decision D2). The cursor format is undocumented,
+so constructing cursors by hand leans on an implementation detail Composio can change
+without notice. The fetch runs once per cache window per deployment; 4.3 seconds there
+is not worth a fragile dependency.
+
+## 4. Why the current implementation is slow (call-count math)
+
+Per use case, worst case, all sequential:
+
+| Step | Calls |
+| --- | --- |
+| `_candidate_integrations`: phrase + 3 terms + fallback | up to 5 |
+| `_candidate_events` for each of up to 10 integrations | up to 10 × 5 |
+| `get_event` detail for the primary match | 1 |
+| `get_integration` auth-scheme check per surfaced integration | up to 4 |
+
+That is up to ~50 round trips per use case, each a live HTTP call with a 30-second
+timeout budget and no caching. Three use cases means ~150 sequential calls. At the
+measured ~0.55 s per Composio round trip, that is 30 to 80 seconds of pure network wait.
+
+`discover_tools`, for comparison, makes **one** Composio call for all use cases combined,
+and caches it (`_cached_search`, `api/oss/src/core/tools/service.py`).
+
+## 5. Composio SDK and static availability
+
+- Neither the API service nor the SDK depends on a Composio SDK package. Our adapters
+  call the REST API directly with httpx
+  (`api/oss/src/core/triggers/providers/composio/catalog.py`).
+- Composio's own SDKs (Python `composio`, TypeScript `@composio/core`) are thin API
+  clients. They bundle no catalog files.
+- Composio publishes no downloadable catalog dump. The paginated API is the only source.
+
+## 6. Terms-of-service check (can we vendor the dump?)
+
+Question: may we commit the downloaded catalog (descriptions, config schemas, sample
+payloads) as a JSON file in the Agenta repo?
+
+Section 3 (License Grant) of [composio.dev/terms](https://composio.dev/terms):
+
+> "This license does not include any resale or commercial use of the platform or its
+> contents, any derivative use of the platform or its contents, or any use of data
+> mining, robots, or similar data gathering and extraction tools."
+
+A vendored dump in a public repo that ships in a commercial product (Agenta EE) plausibly
+hits both the "derivative/commercial use of its contents" clause and the "data gathering
+and extraction" clause. No clause grants redistribution or offline storage of API
+responses. Conclusion: do not vendor. Fetch at runtime with our API key and cache
+server-side, which is ordinary API usage. This became decision D1.
+
+The practical loss is small. A vendored file would only have bought us discovery with
+zero Composio calls ever, and discovery is useless without a Composio key anyway (the
+connection-state half of the response needs one).

--- a/docs/design/agent-workflows/projects/trigger-discovery-catalog/research.md
+++ b/docs/design/agent-workflows/projects/trigger-discovery-catalog/research.md
@@ -67,9 +67,9 @@ Per use case, worst case, all sequential:
 | `get_event` detail for the primary match | 1 |
 | `get_integration` auth-scheme check per surfaced integration | up to 4 |
 
-That is up to ~50 round trips per use case, each a live HTTP call with a 30-second
-timeout budget and no caching. Three use cases means ~150 sequential calls. At the
-measured ~0.55 s per Composio round trip, that is 30 to 80 seconds of pure network wait.
+That sums to up to 60 round trips per use case, each a live HTTP call with a 30-second
+timeout budget and no caching. Three use cases means up to 180 sequential calls. At the
+measured ~0.55 s per Composio round trip, that is 30 to 90+ seconds of pure network wait.
 
 `discover_tools`, for comparison, makes **one** Composio call for all use cases combined,
 and caches it (`_cached_search`, `api/oss/src/core/tools/service.py`).

--- a/docs/design/agent-workflows/projects/trigger-discovery-catalog/research.md
+++ b/docs/design/agent-workflows/projects/trigger-discovery-catalog/research.md
@@ -103,3 +103,65 @@ server-side, which is ordinary API usage. This became decision D1.
 The practical loss is small. A vendored file would only have bought us discovery with
 zero Composio calls ever, and discovery is useless without a Composio key anyway (the
 connection-state half of the response needs one).
+
+## 7. Discovery quality experiment (891 queries, 2026-07-10)
+
+After the catalog cache shipped, a live check showed "slack triggers" returning nothing
+at all. Rather than patch that one case, we measured what agents actually get. The
+harness (`scripts/discovery_eval.py`) extracts the real scoring functions from
+`service.py` via AST, so there is no copy drift, and replays them over the real
+351-event catalog with four query families:
+
+- **usecase / fragment** (343 each): natural phrasings templated from every live
+  event's own name ("when a message is posted in slack", "slack channel message
+  received"). Ground truth is known by construction.
+- **browse** (164): menu-shaped asks agents genuinely type, with spaced names the way
+  people write them ("google calendar triggers", "what triggers does slack support").
+- **hand** (41): realistic asks written independently of the catalog, including
+  platforms the catalog does not have (telegram, dropbox) and vocabulary mismatches
+  ("when a pull request is merged" — Composio only has state-changed).
+
+What the baseline got wrong, with numbers:
+
+| Failure | Baseline | Cause |
+| --- | --- | --- |
+| Browse queries fully empty | 25% | "triggers"/"events" match nothing; 2-term gate fails; no-match path returns zero alternatives |
+| Browse queries wrong toolkit | 14% | "what" is a substring of WHATSAPP, "can" of CANVAS |
+| Wrong platform as primary | "discord message received" → Slack | event-key word hits outweigh platform identity |
+| Deprecated events surfaced | 6 corpus hits | nothing demotes "DEPRECATED: use X instead" items |
+| Hand asks with right answer nowhere in top 4 | 4.9% | combination of the above |
+
+Nine scorer variants were A/B tested on the same corpus. The winner (shipped) combines
+four changes: meta and question words become stopwords; a use case that names a
+platform is restricted to it; deprecated events lose 25 score points; and the no-match
+path returns the closest-scoring events as alternatives instead of nothing. Results:
+
+| Metric | Baseline | Shipped |
+| --- | --- | --- |
+| usecase/fragment top-1 | 98.0% | 98.0% (top-4 stays 100%) |
+| browse right toolkit | 61% | 100% |
+| browse empty | 25% | 0% |
+| hand: right answer missing from top 4 | 4.9% | 0% |
+| deprecated events surfaced | 6 | 0 |
+
+Variants that measured worse and were rejected, so nobody re-tries them blind:
+
+- **Singular/plural fallback matching**: hand top-1 dropped 46% → 41% (extra noise
+  outweighs the few plural saves).
+- **Treating "new" as a content word**: templated top-1 hit 100%, but it regressed the
+  pinned live case — "new slack message in a channel" flipped to the direct-message
+  event because its verbose description mentions "new" and "channels".
+- **Down-weighting description-only hits**: fixed the case above but dropped "when
+  someone stars my github repo" out of the top 4 entirely (the description is the only
+  place "stars" appears; the event is named STARGAZER). A right answer nowhere in the
+  surfaced set is the worst failure class, so this lost to keeping description weight.
+- **A large question-word stopword list** (list, show, get, support, have...): those
+  words appear inside real event names, and templated top-1 fell 2.7 points. Only the
+  minimal hazard set shipped.
+
+Residual, accepted: when the named platform has no triggers in the catalog at all
+("new telegram message received"), generic words can still pass the 2-term gate and
+surface a wrong-platform primary. The tool description and the build-agent skill both
+instruct the agent to confirm the integration and the event description before wiring
+anything, and the no-match note says explicitly that an absent integration means the
+provider has no triggers for it.

--- a/docs/design/agent-workflows/projects/trigger-discovery-catalog/scripts/discovery_eval.py
+++ b/docs/design/agent-workflows/projects/trigger-discovery-catalog/scripts/discovery_eval.py
@@ -1,0 +1,452 @@
+# /// script
+# requires-python = ">=3.11"
+# dependencies = []
+# ///
+"""Offline evaluation of discover_triggers over the real Composio catalog.
+
+Extracts the REAL scorer functions from api/oss/src/core/triggers/service.py via AST
+(no copy drift), replicates the surfacing pipeline of `discover_triggers`
+(_discover_events_for_use_case -> named-integration filter -> primary-evidence gate ->
+no-match alternatives), and measures behavior over a large realistic query corpus:
+
+- usecase/fragment: 800+ queries templated from real event names; measures top1/top4/miss.
+- browse: "slack triggers"-shaped asks per toolkit; measures right/wrong toolkit + empties.
+- hand: hand-written realistic asks with expected event keys, plus asks the catalog
+  genuinely cannot answer (honest no-match is correct there).
+- deprecated: whether DEPRECATED events surface anywhere.
+
+Run: COMPOSIO_API_KEY=... uv run scripts/discovery_eval.py
+(the key is only needed on the first run, to populate the local catalog cache).
+"""
+
+import json
+import os
+import sys
+import urllib.parse
+import urllib.request
+from collections import defaultdict
+from pathlib import Path
+from types import SimpleNamespace
+from typing import Dict, List, Optional, Tuple, Set
+
+import ast
+
+
+def _repo_root() -> Path:
+    path = Path(__file__).resolve()
+    for parent in path.parents:
+        if (
+            parent / "api" / "oss" / "src" / "core" / "triggers" / "service.py"
+        ).exists():
+            return parent
+    raise SystemExit("could not locate the agenta repo root above this script")
+
+
+SERVICE = _repo_root() / "api" / "oss" / "src" / "core" / "triggers" / "service.py"
+
+# The catalog dump must NEVER be committed to the repo (Composio ToS, decision D1 in
+# status.md). It lives only in this local cache and is fetched live when absent.
+CATALOG_CACHE = Path.home() / ".cache" / "agenta-discovery-eval" / "catalog.json"
+
+COMPOSIO_API_URL = "https://backend.composio.dev/api/v3"
+
+WANTED = {
+    "_DISCOVERY_MIN_PRIMARY_TERMS",
+    "_DISCOVERY_STOPWORDS",
+    "_discovery_terms",
+    "_normalize_words",
+    "_named_integrations",
+    "_match_signal",
+    "_score_trigger_match",
+    "_has_primary_evidence",
+}
+
+
+def load_scorer():
+    tree = ast.parse(SERVICE.read_text())
+    nodes = []
+    for node in tree.body:
+        name = None
+        if isinstance(node, (ast.FunctionDef, ast.AsyncFunctionDef)):
+            name = node.name
+        elif isinstance(node, ast.Assign) and isinstance(node.targets[0], ast.Name):
+            name = node.targets[0].id
+        if name in WANTED:
+            nodes.append(node)
+    mod = ast.Module(body=nodes, type_ignores=[])
+    ns = {
+        "List": List,
+        "Dict": Dict,
+        "Optional": Optional,
+        "Tuple": Tuple,
+        "Set": Set,
+        "TriggerCatalogEvent": object,
+        "TriggerCatalogIntegration": object,
+    }
+    exec(compile(mod, str(SERVICE), "exec"), ns)
+    assert all(w in ns for w in WANTED), [w for w in WANTED if w not in ns]
+    return ns
+
+
+def fetch_catalog() -> list:
+    api_key = os.environ.get("COMPOSIO_API_KEY")
+    if not api_key:
+        raise SystemExit(
+            f"no cached catalog at {CATALOG_CACHE} and COMPOSIO_API_KEY is not set; "
+            "export it to fetch the live catalog once"
+        )
+    items, cursor, seen = [], None, set()
+    for _ in range(200):
+        params = {"limit": "100"}
+        if cursor:
+            params["cursor"] = cursor
+        req = urllib.request.Request(
+            f"{COMPOSIO_API_URL}/triggers_types?{urllib.parse.urlencode(params)}",
+            headers={"x-api-key": api_key, "Content-Type": "application/json"},
+        )
+        with urllib.request.urlopen(req, timeout=30) as resp:
+            data = json.load(resp)
+        items.extend(data.get("items", []) if isinstance(data, dict) else data)
+        cursor = data.get("next_cursor") if isinstance(data, dict) else None
+        if not cursor or cursor in seen:
+            break
+        seen.add(cursor)
+    return items
+
+
+def load_catalog():
+    if not CATALOG_CACHE.exists():
+        CATALOG_CACHE.parent.mkdir(parents=True, exist_ok=True)
+        CATALOG_CACHE.write_text(json.dumps(fetch_catalog()))
+    raw = json.loads(CATALOG_CACHE.read_text())
+    events, integ_names = [], {}
+    for it in raw:
+        tk = it.get("toolkit") or {}
+        slug = tk.get("slug") or ""
+        integ_names[slug] = tk.get("name") or slug
+        events.append(
+            SimpleNamespace(
+                key=it["slug"],
+                name=it.get("name"),
+                description=it.get("description"),
+                integration=slug,
+            )
+        )
+    return events, integ_names
+
+
+# ---------------------------------------------------------------- discovery replica
+
+
+def discover(ns, events, integ_names, use_case, limit_alternatives=3):
+    """Faithful replica of discover_triggers surfacing for one use case.
+
+    Mirrors _discover_events_for_use_case (score + named-integration filter + sort),
+    the _has_primary_evidence gate, and the no-match alternatives path.
+    Returns (primary, alternatives, note) where primary/alternatives are event objects.
+    """
+    integrations = {}
+    matches = []
+    seen = set()
+    for event in events:
+        slug = event.integration or ""
+        # mirror _discover_events_for_use_case's (slug, key) dedup
+        if (slug, event.key) in seen:
+            continue
+        seen.add((slug, event.key))
+        integ = integrations.get(slug)
+        if integ is None:
+            integ = SimpleNamespace(
+                key=slug, name=integ_names.get(slug, slug), description=None
+            )
+            integrations[slug] = integ
+        score = ns["_score_trigger_match"](
+            use_case=use_case, event=event, integration=integ
+        )
+        if score <= 0:
+            continue
+        matches.append((score, event, integ))
+
+    named = ns["_named_integrations"](
+        terms=ns["_discovery_terms"](use_case), integrations=integrations
+    )
+    if named:
+        matches = [m for m in matches if (m[1].integration or "") in named]
+    matches.sort(key=lambda m: m[0], reverse=True)
+
+    surfaced = matches[: 1 + max(limit_alternatives, 0)]
+    if surfaced:
+        _score, matched_terms, exact = ns["_match_signal"](
+            use_case=use_case, event=surfaced[0][1], integration=surfaced[0][2]
+        )
+        if not (exact or matched_terms >= ns["_DISCOVERY_MIN_PRIMARY_TERMS"]):
+            surfaced = []
+
+    if not surfaced:
+        alts = [m[1] for m in matches[: max(limit_alternatives, 0)]]
+        return None, alts, "no-match+alts" if alts else "no-match"
+    return surfaced[0][1], [m[1] for m in surfaced[1:]], None
+
+
+# ---------------------------------------------------------------- corpus
+
+
+def build_corpus(events, integ_names):
+    """Returns list of dicts: {q, category, expect} where expect is a set of acceptable
+    event keys (None = we only measure behavior, not correctness)."""
+    corpus = []
+    by_integration = defaultdict(list)
+    for e in events:
+        by_integration[e.integration].append(e)
+
+    # A. ground-truth: natural phrasings templated from event name + toolkit name
+    for e in events:
+        if (e.description or "").strip().lower().startswith("deprecated"):
+            continue
+        name = (e.name or "").lower().replace("trigger", "").strip()
+        if not name:
+            continue
+        tk = integ_names.get(e.integration, e.integration).lower()
+        # acceptable: this event OR an event with identical name in a sibling toolkit
+        expect = {
+            o.key for o in events if (o.name or "").lower() == (e.name or "").lower()
+        }
+        corpus.append(
+            {"q": f"when {name} in {tk}", "category": "usecase", "expect": expect}
+        )
+        corpus.append({"q": f"{tk} {name}", "category": "fragment", "expect": expect})
+
+    # B. browse-shaped: agent asks for the menu; success = anything from that toolkit.
+    # Agents type spaced names ("google calendar"), not slugs ("googlecalendar").
+    SPACED = {
+        "googlecalendar": "google calendar",
+        "googledrive": "google drive",
+        "googlesheets": "google sheets",
+        "googledocs": "google docs",
+        "googleslides": "google slides",
+        "googletasks": "google tasks",
+        "one_drive": "one drive",
+        "agent_mail": "agent mail",
+    }
+    for slug in sorted(by_integration):
+        tk = SPACED.get(slug, integ_names.get(slug, slug).lower())
+        for q in (
+            f"{tk} triggers",
+            f"{tk} events",
+            f"list {tk} triggers",
+            f"what triggers does {tk} support",
+        ):
+            corpus.append(
+                {"q": q, "category": "browse", "expect": None, "toolkit": slug}
+            )
+
+    # C. hand-written realistic asks. expect = list of SUBSTRING patterns any one of
+    # which must appear in a surfaced key (robust to googlesuper twins / _TRIGGER
+    # suffixes). Empty list = catalog genuinely has nothing (honest no-match is right;
+    # closest-events alternatives still desirable). None = behavior-only browse row.
+    HAND = [
+        ("when a new github issue is created", ["GITHUB_ISSUE_CREATED"]),
+        ("new github issue opened", ["GITHUB_ISSUE_CREATED", "GITHUB_ISSUE_ADDED"]),
+        (
+            "when a pull request is merged",
+            ["PULL_REQUEST_STATE_CHANGED", "PULL_REQUEST_EVENT"],
+        ),
+        (
+            "github pr merged",
+            ["PULL_REQUEST_STATE_CHANGED", "PULL_REQUEST_EVENT", "PR_REVIEW"],
+        ),
+        ("when someone stars my github repo", ["STAR_ADDED", "STARGAZER"]),
+        ("new commit pushed to github", ["GITHUB_COMMIT_EVENT"]),
+        (
+            "new slack message in a channel",
+            ["SLACK_CHANNEL_MESSAGE_RECEIVED", "SLACKBOT_CHANNEL_MESSAGE_RECEIVED"],
+        ),
+        ("when i get a direct message in slack", ["DIRECT_MESSAGE_RECEIVED"]),
+        (
+            "slack reaction added to a message",
+            ["SLACK_MESSAGE_REACTION_ADDED", "SLACKBOT_MESSAGE_REACTION_ADDED"],
+        ),
+        ("when a new email arrives in gmail", ["GMAIL_NEW_GMAIL_MESSAGE"]),
+        ("new gmail email received", ["GMAIL_NEW_GMAIL_MESSAGE"]),
+        ("when a calendar event is about to start", ["EVENT_STARTING_SOON"]),
+        ("new event added to google calendar", ["CALENDAR_EVENT_CREATED"]),
+        ("when a notion page is created", ["NOTION_PAGE_CREATED"]),
+        ("new row added to google sheets", ["NEW_ROWS", "SPREADSHEET_ROW"]),
+        (
+            "when a linear issue is created",
+            ["LINEAR_ISSUE_CREATED", "TEAM_ISSUE_CREATED"],
+        ),
+        ("new jira ticket created", ["JIRA_NEW_ISSUE"]),
+        ("when a typeform gets a new response", ["TYPEFORM_NEW_RESPONSE"]),
+        (
+            "when a file is uploaded to google drive",
+            ["DRIVE_FILE_CREATED", "DRIVE_CHANGES", "NEW_FILE"],
+        ),
+        ("when a hubspot contact is created", ["HUBSPOT_CONTACT_CREATED"]),
+        (
+            "when a stripe payment fails",
+            ["STRIPE_PAYMENT_FAILED", "STRIPE_CHARGE_FAILED"],
+        ),
+        ("stripe checkout completed", ["CHECKOUT_SESSION_COMPLETED"]),
+        ("when an asana task is completed", ["ASANA_TASK_UPDATED", "ASANA_TASK_MOVED"]),
+        ("new trello card added", ["TRELLO_NEW_CARD"]),
+        ("discord message received", ["DISCORD_NEW_MESSAGE"]),
+        # asks with NO catalog answer: honest no-match is right, closest-events help
+        ("when someone mentions the bot in slack", []),
+        ("slack mention", []),
+        ("new whatsapp message", []),
+        ("when a tweet mentions my company", []),
+        ("new telegram message received", []),
+        ("new file in dropbox", []),
+        # browse phrasings agents genuinely type (behavior-only)
+        ("slack triggers", None),
+        ("github triggers", None),
+        ("what events can gmail trigger on", None),
+        ("triggers for notion", None),
+        # morphology traps
+        ("github issues created", ["GITHUB_ISSUE_CREATED"]),
+        ("slack trigger", None),
+        ("new slack messages", ["CHANNEL_MESSAGE_RECEIVED"]),
+        # whole-goal paste (agent includes the action part)
+        (
+            "send me an email when a new github issue is created",
+            ["GITHUB_ISSUE_CREATED"],
+        ),
+        ("post to slack when a stripe payment fails", None),
+        ("summarize new gmail emails every morning", ["GMAIL_NEW_GMAIL_MESSAGE"]),
+    ]
+    for q, expect in HAND:
+        corpus.append({"q": q, "category": "hand", "expect": expect})
+
+    return corpus
+
+
+# ---------------------------------------------------------------- evaluation
+
+
+def deprecated_keys(events):
+    return {
+        e.key
+        for e in events
+        if (e.description or "").strip().lower().startswith("deprecated")
+    }
+
+
+def evaluate(ns, events, integ_names, corpus):
+    dep = deprecated_keys(events)
+    stats = defaultdict(lambda: defaultdict(int))
+    failures = defaultdict(list)
+    hand_detail = []
+    for row in corpus:
+        cat, q, expect = row["category"], row["q"], row["expect"]
+        primary, alts, note = discover(ns, events, integ_names, q, 3)
+        s = stats[cat]
+        s["n"] += 1
+        surfaced_keys = ([primary.key] if primary else []) + [a.key for a in alts]
+        surfaced_toolkits = ([primary.integration] if primary else []) + [
+            a.integration for a in alts
+        ]
+        if primary is None and not alts:
+            s["empty"] += 1
+        if primary is None and alts:
+            s["nomatch_with_alts"] += 1
+        if primary and primary.key in dep:
+            s["deprecated_primary"] += 1
+        if any(k in dep for k in surfaced_keys):
+            s["deprecated_surfaced"] += 1
+        if cat == "hand":
+            hand_detail.append(
+                (q, primary.key if primary else None, [a.key for a in alts])
+            )
+        if cat == "browse":
+            if row["toolkit"] in surfaced_toolkits:
+                s["right_toolkit"] += 1
+            elif surfaced_keys:
+                s["wrong_toolkit"] += 1
+            continue
+        if expect is None:
+            if surfaced_keys:
+                s["got_something"] += 1
+            continue
+
+        def hits(key):
+            if isinstance(expect, set):
+                return key in expect
+            return any(p in key for p in expect)
+
+        if not expect:
+            if primary is None:
+                s["honest_nomatch"] += 1
+            else:
+                s["false_positive"] += 1
+                if len(failures[cat]) < 12:
+                    failures[cat].append((q, ["<nothing>"], surfaced_keys[:3]))
+            if alts:
+                s["nomatch_but_helpful"] += 1
+            continue
+        if primary and hits(primary.key):
+            s["top1"] += 1
+        elif any(hits(k) for k in surfaced_keys):
+            s["in_top4"] += 1
+        else:
+            s["miss"] += 1
+            if len(failures[cat]) < 12:
+                exp_show = sorted(expect)[:2] if isinstance(expect, set) else expect[:2]
+                failures[cat].append((q, exp_show, surfaced_keys[:3]))
+    return stats, failures, hand_detail
+
+
+def pct(a, b):
+    return f"{100 * a / b:5.1f}%" if b else "    -"
+
+
+def report(stats):
+    for cat in ("usecase", "fragment", "hand", "browse"):
+        s = stats[cat]
+        n = s["n"]
+        if not n:
+            continue
+        parts = [f"{cat:9s} n={n:4d}"]
+        if cat == "browse":
+            parts.append(f"right_toolkit={pct(s['right_toolkit'], n)}")
+            parts.append(f"wrong_toolkit={pct(s['wrong_toolkit'], n)}")
+            parts.append(f"empty={pct(s['empty'], n)}")
+        else:
+            parts.append(f"top1={pct(s['top1'], n)}")
+            parts.append(f"top4={pct(s['top1'] + s['in_top4'], n)}")
+            parts.append(f"miss={pct(s['miss'], n)}")
+            parts.append(f"empty={pct(s['empty'], n)}")
+        if s["honest_nomatch"] or s["false_positive"]:
+            parts.append(
+                f"honest_nomatch={s['honest_nomatch']} false_pos={s['false_positive']} helpful_alts={s['nomatch_but_helpful']}"
+            )
+        parts.append(
+            f"dep_primary={s['deprecated_primary']} dep_surfaced={s['deprecated_surfaced']}"
+        )
+        print("  " + "  ".join(parts))
+
+
+def main():
+    ns = load_scorer()
+    events, integ_names = load_catalog()
+    corpus = build_corpus(events, integ_names)
+    print(
+        f"catalog: {len(events)} events, {len(integ_names)} toolkits; corpus: {len(corpus)} queries"
+    )
+    print(f"deprecated events in catalog: {len(deprecated_keys(events))}")
+
+    stats, failures, hand_detail = evaluate(ns, events, integ_names, corpus)
+    report(stats)
+
+    if "-v" in sys.argv:
+        for cat, rows in failures.items():
+            print(f"\n--- misses / false positives [{cat}] ---")
+            for q, exp, got in rows:
+                print(f"  {q!r}\n    expected {exp} got {got}")
+        print("\n--- hand detail ---")
+        for q, prim, alts in hand_detail:
+            print(f"  {q!r}\n    primary={prim}  alts={alts}")
+
+
+if __name__ == "__main__":
+    main()

--- a/docs/design/agent-workflows/projects/trigger-discovery-catalog/status.md
+++ b/docs/design/agent-workflows/projects/trigger-discovery-catalog/status.md
@@ -1,0 +1,47 @@
+# Status
+
+**State: design ready for review. No implementation started.**
+
+Last updated: 2026-07-10.
+
+## Where things stand
+
+- Problem diagnosed and measured live (see [`research.md`](research.md)): the latency is
+  a sequential HTTP fan-out of up to ~50 uncached Composio calls per use case.
+- Full catalog dump measured: 351 trigger types, 8 pages, 2.2 MB, 4.3 s sequential fetch.
+- Composio ToS checked: vendoring the dump in-repo is not clearly permitted, so the
+  design fetches at runtime and caches in Redis.
+- Design and phased plan written ([`plan.md`](plan.md)). Awaiting review before
+  implementation.
+
+## Settled decisions
+
+- **D1 — Download at runtime, never vendor the dump.** Composio ToS §3 excludes
+  commercial/derivative use of platform contents and data extraction; a committed JSON
+  file in a commercial OSS repo is not defensible. A runtime fetch with our API key,
+  cached server-side, is ordinary API usage. Cost of compliance: one ~4 s fetch per
+  deployment per cache window.
+- **D2 — Sequential page fetch, no constructed cursors.** The pagination cursor decodes
+  to a predictable `page-offset` string, and constructing all 8 cursors upfront cuts the
+  fetch from 4.3 s to 0.9 s. Rejected: the format is undocumented and the fetch is rare.
+  Boring wins.
+- **D3 — Redis cache, project-agnostic key, 24 h TTL.** Same pattern and rationale as
+  tools discovery (`_cached_search`, D6 in the tool-discovery workspace): the catalog
+  half is global, the connection-state half is computed fresh per project on every call.
+- **D4 — Only discovery reads the dump; browse routes stay live.** `list_events` /
+  `get_event` HTTP routes keep their adapter-backed cursor pagination. Serving them from
+  the dump is a follow-up, not v1.
+- **D5 — Accept losing the integration description from the scoring haystack.** The
+  dump's embedded toolkit object has slug and name only. Event-level fields dominate the
+  score weights, and the phase-3 before/after capture guards against ranking regressions.
+
+## Open questions
+
+- None blocking. Optional hardening (single-flight lock, stale-while-revalidate) is
+  listed in [`plan.md`](plan.md) under risks and deliberately out of v1.
+
+## Next steps
+
+1. Review of this workspace (draft PR).
+2. Implement phases 1 to 4 from [`plan.md`](plan.md) on a GitButler lane over
+   `big-agents`.

--- a/docs/design/agent-workflows/projects/trigger-discovery-catalog/status.md
+++ b/docs/design/agent-workflows/projects/trigger-discovery-catalog/status.md
@@ -61,6 +61,25 @@ Last updated: 2026-07-10.
   the real channel-message events, because the integration name prefixes every event
   key of that integration. `matched_terms` and the primary-evidence gate are untouched.
   Two unit tests pin the GitHub and Slack cases with the wrong event listed first.
+- **D8 — Discovery quality pass, validated by an 891-query experiment.** A live check
+  after the cache shipped showed browse-shaped asks ("slack triggers") returning
+  nothing. We measured instead of patching: `scripts/discovery_eval.py` replays the
+  real scoring functions (AST-extracted, no copy drift) over the real catalog with
+  templated, browse, and hand-written query families (research §7). Four changes won
+  the A/B and shipped together: (1) meta and question words became stopwords —
+  "triggers" is noise, and "what"/"can" substring-match WHATSAPP/CANVAS; (2) a use case
+  that names a platform is restricted to that platform's events, because a
+  perfectly-worded event on the wrong platform is unusable ("discord message received"
+  must never return Slack); (3) events whose description starts with DEPRECATED lose 25
+  points, so live replacements always outrank them; (4) the no-match path returns the
+  closest-scoring events as alternatives with an honest note, instead of an empty list.
+  Browse queries went from 25% empty / 14% wrong toolkit to 100% right toolkit; the
+  templated ground-truth sets held at 98% top-1 / 100% top-4. Rejected with data (so
+  they are not re-tried blind): plural fallback, "new" as a content word, description
+  down-weighting, and a large question-word list — each regressed a measured case
+  (research §7). The tool description in the SDK op catalog and the build-agent skill
+  were updated in the same pass: matching is keyword search, confirm integration +
+  description before wiring, bare integration name browses its events.
 
 ## Notes for future sessions
 

--- a/docs/design/agent-workflows/projects/trigger-discovery-catalog/status.md
+++ b/docs/design/agent-workflows/projects/trigger-discovery-catalog/status.md
@@ -1,18 +1,25 @@
 # Status
 
-**State: design ready for review. No implementation started.**
+**State: implemented and verified live. On PR #5189 for review.**
 
 Last updated: 2026-07-10.
 
 ## Where things stand
 
-- Problem diagnosed and measured live (see [`research.md`](research.md)): the latency is
-  a sequential HTTP fan-out of up to ~50 uncached Composio calls per use case.
-- Full catalog dump measured: 351 trigger types, 8 pages, 2.2 MB, 4.3 s sequential fetch.
-- Composio ToS checked: vendoring the dump in-repo is not clearly permitted, so the
-  design fetches at runtime and caches in Redis.
-- Design and phased plan written ([`plan.md`](plan.md)). Awaiting review before
-  implementation.
+- Design reviewed and approved (PR #5189, lgtm on 2026-07-10). CodeRabbit's five review
+  comments are folded in (see the decision list and the arithmetic fix in
+  [`research.md`](research.md)).
+- Implementation landed per [`plan.md`](plan.md), phases 1 to 3. The catalog fetch, the
+  Redis cache, the in-memory scorer, and the whole-fetch deadline are in
+  `api/oss/src/core/triggers/`; the env knobs are `COMPOSIO_CATALOG_CACHE_TTL_SECONDS`
+  (default 86400) and `COMPOSIO_CATALOG_FETCH_DEADLINE_SECONDS` (default 30).
+- Measured on the live EE dev stack (2026-07-10): **cold call 5.06 s, warm calls 0.71 s
+  and 0.73 s** for two use cases, against 30 to 60 seconds before. One
+  `list_all_events` fetch on the cold call (351 items, 41 toolkits), zero Composio
+  catalog calls on warm ones. Cache key confirmed project-agnostic with a ~24 h TTL.
+- Unit suite: 193 triggers+tools tests green, full unit lane green except 6
+  pre-existing, unrelated failures in `secrets/test_dtos.py` (SSRF URL rejection;
+  present before this change).
 
 ## Settled decisions
 
@@ -25,23 +32,48 @@ Last updated: 2026-07-10.
   to a predictable `page-offset` string, and constructing all 8 cursors upfront cuts the
   fetch from 4.3 s to 0.9 s. Rejected: the format is undocumented and the fetch is rare.
   Boring wins.
-- **D3 — Redis cache, project-agnostic key, 24 h TTL.** Same pattern and rationale as
-  tools discovery (`_cached_search`, D6 in the tool-discovery workspace): the catalog
-  half is global, the connection-state half is computed fresh per project on every call.
+- **D3 — Redis cache, project-agnostic key, 24 h TTL.** Namespace `triggers:catalog`,
+  same pattern and rationale as tools discovery (`_cached_search`, D6 in the
+  tool-discovery workspace): the catalog half is global, the connection-state half is
+  computed fresh per project on every call. The shared cache helper's built-in lock also
+  single-flights concurrent cold callers, which retired the stampede risk from the plan.
 - **D4 — Only discovery reads the dump; browse routes stay live.** `list_events` /
-  `get_event` HTTP routes keep their adapter-backed cursor pagination. Serving them from
-  the dump is a follow-up, not v1.
-- **D5 — Accept losing the integration description from the scoring haystack.** The
-  dump's embedded toolkit object has slug and name only. Event-level fields dominate the
-  score weights, and the phase-3 before/after capture guards against ranking regressions.
+  `get_event` HTTP routes keep their adapter-backed cursor pagination. Verified
+  unaffected on the live stack. Serving them from the dump is a follow-up, not v1.
+- **D5 — Toolkit display names ride along in the snapshot; only the integration
+  description leaves the scoring haystack.** The snapshot carries an
+  `integration_names` map (slug to display name) parsed from the dump, so name-based
+  matching survived. The lost description signal is guarded by the live capture and the
+  pinned ranking test (see D7).
+- **D6 — Whole-fetch deadline (from review).** The full catalog crawl is wrapped in one
+  `asyncio.wait_for` deadline (`catalog_fetch_deadline_seconds`, default 30 s) converted
+  to the domain `AdapterError`, so one stalled page cannot hold a cold call for the sum
+  of per-page timeouts. The page loop is also capped at 50 pages with a warning log when
+  the cap truncates the snapshot.
+- **D7 — Content-term adjacency bonus in the scorer (from live verification).** With
+  provider relevance ordering gone, equal-score ties broke by catalog order, and "when a
+  new GitHub issue is created" surfaced `GITHUB_ISSUE_COMMENT_CREATED_TRIGGER` over
+  `GITHUB_ISSUE_CREATED_TRIGGER` (both scored 26). `_match_signal` now adds +4 per
+  consecutive pair of use-case terms found adjacent in the normalized event key or name
+  ("issue created" hits `ISSUE_CREATED`, not `ISSUE_COMMENT_CREATED`). Terms matching
+  the integration's own key or name are excluded from pair formation: a first version
+  that included them made "slack message" reward `SLACK_MESSAGE_REACTION_ADDED` over
+  the real channel-message events, because the integration name prefixes every event
+  key of that integration. `matched_terms` and the primary-evidence gate are untouched.
+  Two unit tests pin the GitHub and Slack cases with the wrong event listed first.
+
+## Notes for future sessions
+
+- The EE dev stack's uvicorn watchfiles does not pick up host-side writes under
+  `api/oss/src/core/triggers/` (it does for `oss/src/utils/env.py`). A byte-identical
+  rewrite of `env.py` forces a full reload when triggers changes must go live. Cause not
+  investigated; worth a look if it bites again.
 
 ## Open questions
 
-- None blocking. Optional hardening (single-flight lock, stale-while-revalidate) is
-  listed in [`plan.md`](plan.md) under risks and deliberately out of v1.
+- None blocking. Optional hardening (stale-while-revalidate on Composio outage with a
+  cold cache) remains listed in [`plan.md`](plan.md) and deliberately out of v1.
 
 ## Next steps
 
-1. Review of this workspace (draft PR).
-2. Implement phases 1 to 4 from [`plan.md`](plan.md) on a GitButler lane over
-   `big-agents`.
+1. Merge review of the implementation diff on PR #5189.

--- a/sdks/python/agenta/sdk/agents/adapters/agenta_builtins.py
+++ b/sdks/python/agenta/sdk/agents/adapters/agenta_builtins.py
@@ -647,10 +647,15 @@ Do not discover tools or triggers for an ask that does not need them.
 7. Add a trigger only if asked. For schedules, cron is UTC, five fields, with a one-minute floor;
    convert the user's timezone yourself, then stop for approval before `create_schedule`: say what
    you are about to create and wait for the gate. After approval, call `create_schedule`, then
-   confirm with `list_schedules`. For events, call `discover_triggers`, ensure the integration is
-   connected, then stop for approval before `create_subscription`: say what you are about to create
-   and wait for the gate. After approval, call `create_subscription`, and confirm with
-   `list_deliveries`. `test_subscription` waits for a real event, so warn the user before using it
+   confirm with `list_schedules`. For events, call `discover_triggers` and check that the returned
+   integration and event description actually fit the ask — matching is keyword search, not
+   semantic. A no-match still lists the closest events as alternatives, and a bare integration
+   name ("slack") browses its closest events — both capped by `limit_alternatives` (default 3),
+   so raise it before concluding an event does not exist. If the integration you asked about
+   never appears at all, the provider has no trigger for it: say so instead of wiring the
+   closest keyword hit. Then ensure the integration is connected, and stop for approval before
+   `create_subscription`: say what you are about to create and wait for the gate. After
+   approval, call `create_subscription`, and confirm with `list_deliveries`. `test_subscription` waits for a real event, so warn the user before using it
    in a chat turn. Use `remove_schedule` or `remove_subscription` only when cleaning up a wrong
    trigger. Shape the run's inputs with `inputs_fields` (see `references/trigger-inputs.md`).
    Triggers do NOT follow a new revision: after any later `commit_revision`, existing schedules and

--- a/sdks/python/agenta/sdk/agents/platform/op_catalog.py
+++ b/sdks/python/agenta/sdk/agents/platform/op_catalog.py
@@ -813,9 +813,18 @@ _ANNOTATE_TRACE_INPUT_SCHEMA: Dict[str, Any] = {
 }
 
 _DISCOVER_TRIGGERS_DESCRIPTION = (
-    "Discover trigger events that fit plain-language use cases. Returns the best-match "
-    "event per use case with event_key, trigger_config schema, sample payload, connection "
-    "state and connection instructions, alternatives, and setup guidance."
+    "Find trigger events (external happenings that can start this agent) for "
+    "plain-language use cases. Returns the best-match event per use case with "
+    "event_key, trigger_config schema, sample payload, connection state and "
+    "connection instructions, plus close alternatives. Matching is keyword search "
+    "over the provider catalog, not semantic: always confirm the returned "
+    "integration and event description actually fit the use case before wiring an "
+    "event_key. When nothing matches confidently, the closest events are returned "
+    "in alternatives with a note; if the integration you asked about never appears, "
+    "the provider has no triggers for it. To browse an integration, pass its name "
+    "alone as the use case (e.g. 'slack') and raise limit_alternatives (e.g. to 20): "
+    "results are always capped by limit_alternatives, so never treat the returned "
+    "list as complete."
 )
 _DISCOVER_TRIGGERS_INPUT_SCHEMA: Dict[str, Any] = {
     "type": "object",
@@ -823,8 +832,10 @@ _DISCOVER_TRIGGERS_INPUT_SCHEMA: Dict[str, Any] = {
         "use_cases": {
             "type": "array",
             "items": {"type": "string"},
-            "description": "One short fragment per trigger the agent needs "
-            "(e.g. 'new github issue opened').",
+            "description": "One short fragment per trigger the agent needs, naming "
+            "the integration and the event (e.g. 'new github issue created', "
+            "'slack channel message received'). An integration name alone returns "
+            "its closest events, capped by limit_alternatives.",
         },
         "provider": {
             "type": "string",
@@ -835,7 +846,8 @@ _DISCOVER_TRIGGERS_INPUT_SCHEMA: Dict[str, Any] = {
             "type": "integer",
             "default": 3,
             "minimum": 0,
-            "description": "Max alternative events to return per use case.",
+            "description": "Max alternative events to return per use case. Raise it "
+            "(e.g. to 20) when browsing an integration's catalog.",
         },
     },
     "required": ["use_cases"],


### PR DESCRIPTION
## Context

`discover_triggers` took 30 to 60 seconds while `discover_tools` answered in under a second. The trigger side had no semantic search to lean on, so it emulated one by paging the Composio catalog with keywords: up to 60 sequential, uncached HTTP calls per use case (integration searches, per-integration event searches, a detail fetch). Three use cases meant up to 180 round trips at ~0.55 s each.

The whole Composio trigger catalog is only 351 events across 41 toolkits, and every list item already carries its config schema and sample payload. So this PR fetches the catalog once, caches it, and scores in memory. The design was reviewed and approved on this PR first (the docs under `docs/design/agent-workflows/projects/trigger-discovery-catalog/`); the implementation now sits on top, with the five CodeRabbit review comments folded in.

Measured on the live EE dev stack: **cold call 5.06 s** (one 8-page catalog fetch), **warm calls 0.66 to 1.11 s** with zero Composio catalog calls. Before: 30 to 60 s on every call.

## Changes

**Catalog fetch** (`providers/composio/catalog.py`): new `list_all_events()` on the catalog client pages `GET /triggers_types` (50 per page, Composio's cap) to exhaustion into a `TriggerCatalogEventsSnapshot` (all events plus a toolkit slug-to-display-name map). Guards: 50-page cap with a warning log when it truncates, and a repeated-cursor break.

**Cache** (`service.py`): `_cached_event_catalog()` mirrors the tools-side `_cached_search`: Redis namespace `triggers:catalog`, provider-only key (project-agnostic on purpose; connection state stays per-project and fresh), TTL `COMPOSIO_CATALOG_CACHE_TTL_SECONDS` (default 24 h). The whole fetch runs under one `asyncio.wait_for` deadline, `COMPOSIO_CATALOG_FETCH_DEADLINE_SECONDS` (default 30 s), converted to the domain `AdapterError` so one stalled page cannot stack per-page timeouts.

**Discovery** (`service.py`): `discover_triggers` loads the snapshot once per request; `_discover_events_for_use_case` became a pure static function scoring all 351 events in memory with the existing scorer. The keyword paginators (`_candidate_integrations`, `_candidate_events`) and the per-primary `get_event` call are deleted; `trigger_config` and `payload` come straight from the snapshot.

Per-request Composio catalog calls, before and after:

```
Before:  up to 60 per use case  (5 integration searches + 10x5 event searches + 1 detail)
After:   0 warm  /  8 pages once per deployment per 24 h
```

**Scorer tie-break** (`service.py`, found in live verification): with the provider's relevance ordering gone, equal-score ties broke by catalog order, and "when a new GitHub issue is created" surfaced the ISSUE_COMMENT event over ISSUE_CREATED (both scored 26). `_match_signal` now adds +4 per consecutive pair of use-case terms found adjacent in the normalized event key or name ("issue created" hits `ISSUE_CREATED`, not `ISSUE_COMMENT_CREATED`). Terms matching the integration's own key or name are excluded from pairs; a first version without that exclusion made "slack message" reward `SLACK_MESSAGE_REACTION_ADDED`, since the integration name prefixes every key. Both cases are pinned by unit tests with the wrong event listed first.

The wire contract is unchanged: same request, same `TriggerCapabilitiesResult`, router untouched.

## Scope / risk

- Catalog browse routes (`list_events`, `get_event`) stay on the live adapter, verified regression-free. Serving them from the snapshot is a follow-up.
- The per-project connection-state joins are unchanged (still one live `get_integration` per surfaced, not-ready integration; bounded and needed for freshness).
- With `AGENTA_API_CACHING_ENABLED=false` every request pays one full crawl (~4-5 s) instead of a cache read. Still bounded by the deadline; no crash.
- Catalog staleness is at most the 24 h TTL; a removed trigger fails loudly at `create_subscription` time, which validates against the live provider.
- Ranking changes only through the adjacency bonus; the primary-evidence gate and no-match path are untouched and covered by the existing tests.
- Not vendored as a JSON file on purpose: Composio ToS §3 excludes derivative/commercial use of platform contents (see `research.md` §6). Runtime fetch with our own key is ordinary API usage.

## Tests

- 194 unit tests green in `oss/tests/pytest/unit/triggers/` + `unit/tools/`, including new ones: pagination and cursor-guard for `list_all_events`, cache hit skips the adapter, cache miss writes with the configured TTL, deadline converts to `AdapterError`, one-fetch-per-request memoization, and the two ranking pins (GitHub, Slack).
- Full unit lane green except 6 pre-existing failures in `secrets/test_dtos.py` (SSRF URL rejection), unrelated to this change.
- Live verification on the EE dev stack: timings above, plus Redis key `triggers:catalog:provider:composio` observed at TTL ~86400, byte-identical responses across warm calls, and the browse route returning 200 with 20 events.

## How to QA

**Prerequisites:** the EE dev stack (`load-env hosting/docker-compose/ee/.env.ee.dev.local` + `run.sh --ee --dev`) with `COMPOSIO_API_KEY` set. Mint credentials via `POST /api/admin/simple/accounts/` (the `accounts.py` fixture pattern).

**Steps:**
1. Clear the catalog cache to force a cold call: in the redis-volatile container, `redis-cli --scan --pattern '*triggers:catalog*'` and `DEL` the service key.
2. `POST /api/triggers/discover` with `{"use_cases": ["when a new GitHub issue is created", "new Slack message in a channel"]}` and your `ApiKey` header. Time it.
3. Repeat the same call twice more.
4. Watch the api container logs across the calls.

**Expected result:** call 1 completes in single-digit seconds and logs one `[composio] list_all_events items=351 toolkits=41`; calls 2-3 return in under ~1 s with no Composio fetch lines. The GitHub capability's primary is `GITHUB_ISSUE_CREATED_TRIGGER`, the Slack one `SLACKBOT_CHANNEL_MESSAGE_RECEIVED`, both with non-null `trigger_config`.

**Automated tests:**
```
cd api && uv run --no-sync pytest oss/tests/pytest/unit/triggers/ -q
```

**Edge cases:** the discover response for a nonsense use case must still return the no-match note rather than an arbitrary event (covered by tests). One environment gotcha found during QA: uvicorn watchfiles on the dev stack does not react to host-side writes under `api/oss/src/core/triggers/`, so live-testing an edit there needs a forced reload (a byte-identical rewrite of `oss/src/utils/env.py` works); details in `status.md`.

https://claude.ai/code/session_01LJaJ4hpJfTPULrnqKqtTHg
