### PR TITLE
Plan: AI-configured triggers (Composio-free webhook provider, agent-driven setup)

### DIFF
--- a/docs/design/ai-configured-triggers/README.md
+++ b/docs/design/ai-configured-triggers/README.md
@@ -1,0 +1,38 @@
+# AI-configured triggers
+
+## What it is
+
+A new trigger provider — `webhook` — that lets users create event triggers for **any** service (GitHub, Telegram, Stripe, PostHog, internal systems, …) without going through Composio, with the builder agent doing the configuration work: picking the verification scheme, registering the webhook on the provider side, writing the payload→inputs transform, and iterating against real deliveries until it works.
+
+## Why
+
+Self-hosting users should not need a Composio account (a third-party SaaS and data processor) to use event triggers. The strategy is a two-plane split: **MCP covers the actions plane** (separate track), and **webhook/poll providers cover the events plane** — because MCP itself has no trigger primitive (an MCP Triggers & Events working group is incubating one; we align with it later). Composio stays as the managed option; nothing in this plan removes it.
+
+## What's already there (the good news)
+
+- The provider seam exists: `TriggersGatewayRegistry` with Composio as the only registered adapter.
+- Subscriptions, deliveries, dispatcher, catalog, `/subscriptions/test` — all reusable unchanged.
+- The vault already has a `webhook_provider` secret kind and Fernet encryption.
+- The frontend catalog UI renders integrations from a `logo` URL field (`AppLogo`) — recipe logos slot straight in, so AI-configured triggers look like first-class integrations.
+- The builder agent already has trigger ops (`discover_triggers`, `create_subscription`, …) in `build_kit.py` / `static_catalog.py` — we extend that surface, we don't invent a new one.
+
+## What we'll build
+
+1. **Webhook provider** (backend): signed ingress URL per subscription, ~5 verification schemes, raw-body handling, dedupe, feeding the existing deliveries pipeline.
+2. **Filter/transform step**: sandboxed expressions (not arbitrary code) that shape raw payloads into `inputs_fields`, plus delivery replay so transforms can be iterated safely.
+3. **Recipe catalog**: curated per-provider metadata (logo, verification scheme, registration hints, example events) served through the existing catalog endpoints so the UI needs almost nothing new.
+4. **Agent ops + instructions**: new build-kit ops and static-catalog prose so the builder agent can do the whole setup loop — including a `request_secret` op so **secrets never pass through the conversation**.
+5. **Frontend UX**: webhook sources in the existing drawers, transform editor, delivery debugging, and the secure secret-entry flow.
+
+## What it looks like when done
+
+A self-hosted user types "run this agent when someone messages my Telegram bot". The agent asks for the bot token via a secure form (value goes to the vault, not the chat), calls `setWebhook` server-side, generates the transform, has the user send a test message, verifies the delivery, and the trigger shows up in the Triggers page with the Telegram logo — indistinguishable from a Composio-backed one.
+
+## Read the rest in this order
+
+1. `context.md` — goals, non-goals, key decisions and trade-offs
+2. `research.md` — verified code findings with file paths
+3. `plan.md` — implementation phases A–F with exact files
+4. `agent-instructions.md` — the drafted op descriptions and static-catalog prose ("skill instructions") for the builder agent
+5. `secrets-and-ux.md` — secret handling (v1 vault, v2 direction) and the UI/UX spec
+6. `status.md` — current state and questions waiting on the owner

--- a/docs/design/ai-configured-triggers/agent-instructions.md
+++ b/docs/design/ai-configured-triggers/agent-instructions.md
@@ -1,0 +1,45 @@
+# Agent instructions (drafts for `static_catalog.py` / `build_kit.py`)
+
+The builder agent's authoritative surface is the backend op catalog (`api/oss/src/core/workflows/build_kit.py`) plus prose in `static_catalog.py` — not runner-local skill files (research.md §6). This doc drafts both: op descriptions and the guidance prose. Wording should be reconciled with the op-catalog revisions in `docs/design/trigger-latest-binding/` before landing.
+
+## 1. Op descriptions (build_kit)
+
+| op | description (draft) |
+|---|---|
+| `create_webhook_subscription` | Create an event trigger fed by an inbound webhook. Provide `recipe_key` (from `discover_triggers` / the webhook catalog; use `custom` for unlisted systems), a short `event_description`, optional initial `filter`/`transform`, and `references` binding the run target. Returns the ingress URL, verification scheme, and registration mode. Never returns secret values. |
+| `register_webhook_upstream` | Register the subscription's ingress URL on the provider side (only for recipes with `registration: api`, e.g. GitHub, Telegram, Stripe). Requires a vaulted credential slug — if none exists, call `request_secret` first. Registration happens server-side; you will not see the credential. |
+| `request_secret` | Ask the user for a secret (bot token, API key). Takes `name`, `description`, `kind` — **no value parameter**. The user enters the value in a secure form outside this conversation; you receive only a vault `slug` to pass to other ops. NEVER ask the user to paste a secret into the chat. |
+| `update_trigger_transform` | Update the subscription's `filter` (boolean expression: deliver only when true), `transform` (expression mapping the raw payload to the run's `inputs_fields`), and/or `dedupe_key`. |
+| `list_trigger_deliveries` | List recent deliveries for a subscription, including verification failures, filter-dropped events, transform errors, raw payload, and transformed inputs. Your primary debugging surface. |
+| `replay_delivery` | Re-run a stored delivery's raw payload through the subscription's current filter/transform. Use `dry_run: true` to inspect the result without dispatching a run. |
+
+## 2. Guidance prose (static_catalog)
+
+> ### Choosing a trigger mechanism
+> - Run on a clock → `create_schedule` (no discovery needed).
+> - React to an outside event with a **ready Composio connection and a matching event** in `discover_triggers` → `create_subscription` (managed path).
+> - React to an outside event otherwise — provider not covered, self-hosted without Composio, or a custom/internal system → `create_webhook_subscription` (webhook path). Check the webhook catalog for a recipe first; fall back to `recipe_key: custom`.
+>
+> ### Configuring a webhook trigger (the loop)
+> 1. **Create** the subscription from the best-matching recipe. Read the returned ingress URL, scheme, and registration mode.
+> 2. **Register** upstream. `registration: api` → call `register_webhook_upstream` (call `request_secret` first if no credential slug exists). `registration: manual` → tell the user to paste the ingress URL into the provider's dashboard; the UI shows them the URL and any secret — do not read or repeat secret values.
+> 3. **Write the transform** using the recipe's `transform_hints` and the target's input schema. Keep the filter narrow (e.g. GitHub: `action = "opened"`) so unrelated events don't start runs.
+> 4. **Test with a real event.** Trigger one (GitHub sends `ping` on hook creation; Telegram: ask the user to message the bot; Stripe: a test-mode event) and read `list_trigger_deliveries`.
+> 5. **Iterate.** On verification failure: re-check scheme/registration — do not weaken verification to `none` to make errors go away. On filter-drop or transform error or schema mismatch: fix the expression with `update_trigger_transform`, then `replay_delivery` (`dry_run: true`) against the stored payload until the output matches the run's input schema. Re-test live once dry-run passes.
+> 6. **Confirm** to the user with the trigger name, the event it fires on, and one example of the mapped inputs — never with secret material.
+>
+> ### Secrets — hard rules
+> - Never ask the user to paste tokens, API keys, or signing secrets into the conversation. Always use `request_secret`.
+> - Never echo, log, or store secret values; ops accept and return vault slugs only.
+> - If the user pastes a secret into the chat unprompted: do not repeat it, tell them it should be rotated since it entered the transcript, and direct them to the secure form via `request_secret`.
+>
+> ### Caveats worth knowing
+> - Telegram allows **one webhook URL per bot** — creating this trigger repoints the bot; confirm with the user if the bot may already be in use.
+> - Stripe returns the endpoint signing secret only at creation; `register_webhook_upstream` vaults it automatically — never ask the user for it.
+> - Slack Events API performs a URL-verification handshake; the platform answers it automatically — a `url_verification` delivery is expected and is not an error.
+> - Ack semantics: the platform returns 2xx to providers immediately; processing failures appear in deliveries, not as provider-side retries.
+
+## 3. What we deliberately do NOT instruct
+
+- No per-provider payload documentation in the prose — recipes carry `transform_hints`, and the agent's own knowledge plus the replay loop covers the rest. Keeping prose short follows the house finding that over-prescriptive instructions reduce output quality.
+- No instruction to compose raw HTTP against provider APIs for registration — that path is server-side by design (secrets).

--- a/docs/design/ai-configured-triggers/context.md
+++ b/docs/design/ai-configured-triggers/context.md
@@ -1,0 +1,65 @@
+# Context
+
+## Why this work exists
+
+Event triggers today are Composio-only: `TriggersGatewayRegistry` has exactly one adapter, and a subscription requires a Composio `connection_id`. For cloud users that's fine. For self-hosting users it means a hard dependency on a third-party SaaS that also sees their event payloads — which undermines the point of self-hosting. Known concrete gap: Telegram triggers are impossible today (no Composio trigger coverage), and PostHog trigger coverage is thin even though PostHog can natively POST to a webhook destination.
+
+The broader strategy (settled July 2026): **MCP = actions plane, own trigger providers = events plane**. MCP has no trigger primitive (client-driven protocol; the MCP Triggers & Events WG is incubating a webhook-like callback extension — `modelcontextprotocol/experimental-ext-triggers-events`). So "MCP + AI triggers" concretely means: MCP servers for tools (separate track), and this plan for events.
+
+## Goals
+
+- A self-hosted deployment can create event triggers for the major providers (GitHub, Telegram, Stripe, Slack events, PostHog, Shopify, Linear, …) and for arbitrary custom systems, **with zero Composio involvement**.
+- The builder agent can configure a trigger end-to-end from a plain-language request: choose webhook recipe, register upstream, generate filter/transform, test against real deliveries, fix, done.
+- Secrets (signing secrets, bot tokens, API keys) **never enter the agent's context or the chat transcript** — neither when the user provides them nor when the platform generates them.
+- AI-configured triggers are visually and operationally first-class: same catalog, same drawers, provider logos, same deliveries debugging.
+- Composio remains available and unchanged; both provider kinds coexist behind the same subscription/delivery model.
+
+## Non-goals (this iteration)
+
+- Polling providers (including "poll an MCP tool on a schedule") — designed for, explicitly deferred to v2. Egress-only polling matters for firewalled self-hosts, but webhooks cover the most-requested providers first.
+- MCP actions-plane work (credential store for MCP servers, activating the `mcps` field) — separate track.
+- Adopting the MCP triggers extension — not yet in the spec; the provider seam is where it will plug in later.
+- Marketplace/community-contributed recipes — recipes ship curated in-repo first.
+
+## Key decisions
+
+### D1. New provider behind the existing seam, not a parallel system
+The webhook provider is a second adapter in `TriggersGatewayRegistry`, and subscriptions/deliveries/catalog/test endpoints are reused as-is. Rationale: the pipeline (dedupe, dispatch, delivery logs, start/stop lifecycle) is provider-agnostic already; a parallel system would fork the UX and the agent ops. Consequence: `connection_id` must become provider-dependent (see open question Q2).
+
+### D2. Verification is a small closed set of schemes, not per-provider code
+Five schemes cover essentially every mainstream provider:
+
+| scheme | covers |
+|---|---|
+| `hmac_sha256_header` (`X-Hub-Signature-256`-style) | GitHub, Shopify, Linear, Cal.com, Typeform, … |
+| `stripe_signature` (`t=…,v1=…` HMAC over `t.rawbody`, tolerance window) | Stripe |
+| `static_token_header` | Telegram (`X-Telegram-Bot-Api-Secret-Token`), many SaaS |
+| `challenge_handshake` (echo challenge on first request) | Slack Events API, Dropbox, MS Graph |
+| `none` (+ optional IP allowlist) | PostHog destinations, internal systems, cron |
+
+Everything else about a provider (payload shape, registration, event filtering) is **configuration the agent generates**, not platform code. This is what makes the marginal cost of a new integration ~zero.
+
+### D3. Transforms are sandboxed expressions, not arbitrary code
+Filter, transform, and dedupe-key are expressions (JSONata or CEL — Q1) evaluated server-side over the verified payload. Rationale: agent-generated artifacts must be safe to run in the API process, cheap to evaluate per delivery, and displayable/editable in the UI. Arbitrary JS/Python would require a sandbox runtime and complicate self-hosting.
+
+### D4. Secrets never transit the conversation
+The agent operates on secret **references** (vault slugs), never values. Three mechanisms (full spec in `secrets-and-ux.md`):
+1. `request_secret` op → renders a secure form in the chat UI; the browser posts the value directly to the vault API; the agent receives only `{slug}`.
+2. Platform-generated signing secrets are created server-side inside `create_webhook_subscription`; verification reads them from the vault at ingress; the agent never sees them.
+3. Provider-side registration that needs the secret (e.g. GitHub create-hook) happens **server-side** in the provider adapter (the `ensure_webhook_registered` pattern already exists for Composio) — secret goes platform→provider directly.
+
+For manual-registration providers (no API), the UI shows the URL + secret in a reveal-once panel for the *user* to copy — displayed by the frontend from the vault endpoint, never echoed by the agent.
+
+### D5. Recipes are catalog data, so the existing UI renders them
+A recipe = `{integration_key, name, logo, verification_scheme, registration: api|manual, registration_hint, event_examples, docs_url}`. Served through the existing `/triggers/catalog/providers/{provider_key}/…` endpoints under provider key `webhook`, so `TriggerCatalogDrawer`/`AppLogo` show them exactly like Composio integrations. A generic "Custom webhook" entry covers the long tail.
+
+### D6. Ingress URLs must be unguessable independent of verification
+`POST /triggers/hooks/{ingress_token}` where `ingress_token` is a random opaque token (not the subscription UUID) — defense in depth for `none`-scheme subscriptions and against enumeration.
+
+## Open questions
+
+- **Q1 — Expression language**: JSONata (friendlier for JSON reshaping; `jsonata-python` maturity to verify) vs CEL (`cel-python`; better sandboxing story, clunkier for object construction). Recommendation: JSONata for transform, boolean JSONata for filter, single library. Needs a spike.
+- **Q2 — `connection_id` optionality**: make it nullable for webhook subscriptions, or auto-create a synthetic gateway connection per webhook subscription so downstream code paths keep their invariant? Leaning synthetic connection (keeps `gateway_connections` scoping/permissions uniform), but needs a look at how much code assumes Composio-shaped connection data.
+- **Q3 — Ingress deployment surface**: same FastAPI app vs the dedicated dispatcher entrypoint (`entrypoints/dispatcher_composio.py` precedent)? Ingress must read the **raw body** before JSON parsing (signature verification) and should be rate-limited; a dedicated router in the same app is likely enough for v1.
+- **Q4 — Recipe logos**: bundle SVGs in-repo (licensing review needed per logo) vs hotlink CDN URLs like the Composio catalog does. Leaning bundled, monochrome fallback monogram when absent.
+- **Q5 — Retry semantics to the upstream sender**: return 2xx immediately after enqueue (recommended — providers like Stripe retry on non-2xx and disable endpoints that keep failing) and rely on our own delivery retries, vs propagating processing failures.

--- a/docs/design/ai-configured-triggers/plan.md
+++ b/docs/design/ai-configured-triggers/plan.md
@@ -1,0 +1,113 @@
+# Plan: AI-configured triggers
+
+Six phases, A to F. Each names exact files and is sized for a narrow subagent. Dependency order: A, then B, then C and D in parallel, then E, then F. v2 items are listed at the end and are explicitly out of scope for these phases.
+
+**The invariant every phase must respect:** the existing subscription → dispatch → delivery pipeline and the Composio provider are untouched. Everything lands behind the `TriggersGatewayRegistry` seam and the existing API surface; a deployment that never creates a webhook subscription behaves byte-for-byte as today.
+
+---
+
+## Phase A: Backend — webhook provider + verified ingress
+
+### A1. Provider adapter
+Files: `api/oss/src/core/triggers/providers/webhook/adapter.py` (new), `.../webhook/__init__.py` (new).
+- Implement the adapter contract from `core/triggers/interfaces.py` (mirror `providers/composio/adapter.py`, research.md §1): subscription create/start/stop/revoke, catalog hooks (Phase C).
+- On create: mint `ingress_token` (256-bit urlsafe random, context D6), generate a signing secret when the recipe's scheme needs one, store it via the vault (`SecretKind.webhook_provider`, research.md §4) — the secret value never leaves the service layer.
+- Register in `api/entrypoints/routers.py` next to the Composio adapter (`:159-165`).
+
+### A2. Connection handling (resolves Q2)
+Files: `api/oss/src/core/gateway/connections/…`, `api/oss/src/core/triggers/service.py`.
+- Spike first: enumerate call sites assuming Composio-shaped `connection_id`. Then either make it nullable for provider `webhook` or auto-create a synthetic gateway connection per webhook subscription. Record the decision in `status.md` before implementing.
+
+### A3. Ingress route
+Files: `api/oss/src/apis/fastapi/triggers/router.py`, new `api/oss/src/core/triggers/ingress.py`.
+- `POST /triggers/hooks/{ingress_token}`: resolve subscription by token; read **raw body bytes before any parsing** (research.md §8, Stripe); verify per scheme; handle `challenge_handshake` (echo Slack/Dropbox challenge without creating a delivery); ack 2xx immediately after enqueue (context Q5); enqueue into the dispatcher path from research.md §3.
+- Rate-limit per token; 404 (not 401) on unknown token to avoid oracle behavior.
+
+### A4. Verification schemes
+File: `api/oss/src/core/triggers/verification.py` (new).
+- The five schemes from context D2 as pure functions `(raw_body, headers, secret) -> Verdict`; constant-time comparison; Stripe timestamp tolerance (default 5 min). Secrets fetched via the secrets service by slug at ingress time.
+
+### A5. Data model
+Files: `api/oss/src/core/triggers/dtos.py`, `api/oss/src/apis/fastapi/triggers/models.py`, new migration in `api/oss/databases/postgres/migrations/core_oss/versions/`.
+- Extend subscription `data` (research.md §2): `verification {scheme, secret_slug?}`, `dedupe_key?`, `recipe_key?`, server-set `ingress_token`. Never serialize secret values into `data`.
+
+## Phase B: Filter / transform / replay
+
+### B1. Expression engine (resolves Q1)
+File: `api/oss/src/core/triggers/transform.py` (new).
+- Spike JSONata (`jsonata-python`) vs CEL (`cel-python`); pick one for `filter` (boolean), `transform` (payload → `inputs_fields` dict), `dedupe_key` (string). Enforce timeout + output-size cap; evaluation errors produce a **failed delivery with the error recorded**, not a dropped event — the agent debugs from deliveries.
+
+### B2. Apply in the delivery path
+Files: `api/oss/src/tasks/asyncio/triggers/dispatcher.py`, `api/oss/src/core/triggers/ingress.py`.
+- Order: verify → filter (drop-with-log when false) → dedupe (skip repeats within window) → transform → existing `inputs_fields` merge → dispatch. Store both raw payload and transformed result on the delivery for debugging/replay.
+
+### B3. Replay
+Files: `api/oss/src/apis/fastapi/triggers/router.py`, `api/oss/src/core/triggers/service.py`.
+- Extend `POST /triggers/subscriptions/test` (research.md §3): accept `delivery_id` to re-run a stored raw payload through the subscription's *current* filter/transform, with `dry_run` (return result, don't dispatch). This endpoint is what makes the agent's iterate loop cheap and safe.
+
+## Phase C: Recipe catalog + logos
+
+### C1. Recipes
+Files: `api/oss/src/core/triggers/providers/webhook/recipes.py` (new), assets under `api/oss/src/core/triggers/providers/webhook/logos/` (Q4).
+- Curated list, launch set: GitHub, Telegram, Stripe, Slack (Events API), PostHog, Shopify, Linear, Cal.com, Typeform + generic "Custom webhook". Each: `{integration_key, name, logo, verification_scheme, registration: api|manual, registration_hint, event_examples, transform_hints, docs_url}`.
+- `transform_hints` = known payload shapes / example filter+transform per common event, consumed by the agent (Phase D) and shown as UI presets (Phase E).
+
+### C2. Serve through the existing catalog
+Files: `api/oss/src/core/triggers/providers/webhook/adapter.py`, `api/oss/src/core/triggers/registry.py`.
+- Expose provider key `webhook` through `/triggers/catalog/providers/…` and `/triggers/discover` (research.md §1, §3) so `TriggerCatalogDrawer` + `AppLogo` (research.md §5) render recipes exactly like Composio integrations — logos are just the `logo` field, no new icon machinery.
+
+## Phase D: Agent ops + instructions
+
+### D1. New ops
+Files: `api/oss/src/core/workflows/build_kit.py`, `api/oss/src/core/triggers/service.py`.
+- `create_webhook_subscription(recipe_key, event_description, filter?, transform?, references)` — returns ingress URL + verification state, never secret values.
+- `register_webhook_upstream(subscription_id, target)` — server-side registration for `registration: api` recipes (GitHub create-hook, Telegram setWebhook, Stripe webhook_endpoints; research.md §8), following the `ensure_webhook_registered` precedent (research.md §1). Uses a vaulted token by slug; the secret goes platform→provider directly.
+- `update_trigger_transform(subscription_id, filter?, transform?, dedupe_key?)`.
+- `list_trigger_deliveries(subscription_id, limit)` and `replay_delivery(subscription_id, delivery_id, dry_run)` (wraps B3).
+- `request_secret(name, description, kind)` — **does not accept a value**; signals the UI to render a secure form (secrets-and-ux.md §2); returns `{slug}` once the user submits.
+
+### D2. Static-catalog prose
+File: `api/oss/src/core/workflows/static_catalog.py`.
+- Add the trigger-configuration guidance drafted in `agent-instructions.md` (decision table, configure→test→iterate loop, secrets guardrails). Keep wording consistent with the revisions underway in `docs/design/trigger-latest-binding/`.
+
+### D3. Runner-side plumbing for `request_secret`
+Files: `services/runner/src/tools/` (relay path), chat UI event handling (with E3).
+- `request_secret` is a relay op that blocks on out-of-band user input, analogous to existing confirmation-style interactions.
+
+## Phase E: Frontend
+
+### E1. Sources + creation flow
+Files: `web/packages/agenta-entity-ui/src/gatewayTrigger/drawers/shared/EventSourcePicker.tsx`, `TriggerCatalogDrawer.tsx`, `TriggerSubscriptionDrawer.tsx`.
+- Webhook recipes appear as sources with `AppLogo`; subscription drawer for webhook subscriptions shows: ingress URL (copy), verification status (last verified delivery), filter/transform editors (with recipe presets from C1), and registration state.
+
+### E2. Deliveries debugging
+Files: `web/packages/agenta-entity-ui/src/gatewayTrigger/drawers/TriggerDeliveriesDrawer.tsx`, `web/packages/agenta-entities/src/gatewayTrigger/`.
+- Show raw payload vs transformed `inputs_fields` side by side; "replay with current transform" button (B3); surface filter-dropped and verification-failed events distinctly.
+
+### E3. Secure secret entry
+Files: chat UI surface consuming runner events; reuse `ConfigureSecretModal` / `LabelInput` masked-input patterns (research.md §4).
+- Render `request_secret` as an inline secure form in the chat: masked input, posts directly to `vault/v1/secrets` from the browser, then acks the op with the slug. The value never appears in the transcript, agent context, or run traces. Reveal-once panel for platform-generated signing secrets on `registration: manual` recipes. Full spec: `secrets-and-ux.md`.
+
+### E4. API client regen
+File: `web/packages/agenta-api-client/src/generated/api/resources/triggers/` (regenerated).
+
+## Phase F: Tests + docs
+
+### F1. Acceptance
+Files: `api/oss/tests/pytest/acceptance/triggers/test_triggers_ingress.py` (extend), new `test_triggers_webhook_provider.py`.
+- Per-scheme signature vectors (valid/invalid/replayed-timestamp), challenge handshake, filter/transform/dedupe through to delivery, replay endpoint, secret-never-in-responses assertions (grep API responses for secret values in tests).
+
+### F2. Agent-loop QA
+- Lab-style E2E (see `agent-creation-lab` kit): builder agent configures GitHub, Telegram, Stripe from one-sentence prompts against a live deployment; measure toolcalls-to-working-trigger. Reuse `.agents/skills/agent-workflows-qa` where applicable.
+
+### F3. Docs
+- Self-hosting guide: "Triggers without Composio"; per-recipe how-tos (incl. tunnel/reverse-proxy guidance for firewalled self-hosts); security notes (scheme table, raw-body, ack semantics).
+
+---
+
+## Later (v2) — designed-for, not built now
+
+- **Poll provider**, including "call an MCP tool on a schedule + dedupe" — same registry seam; egress-only, so it covers firewalled self-hosts where inbound webhooks can't reach. One MCP connection then powers both actions and triggers.
+- **Vault v2**: named secret references in trigger/tool configs with egress-time substitution (builds on `docs/design/vault-named-secrets/`), rotation, audit trail of which subscription read which secret.
+- **MCP Triggers & Events extension**: when the spec lands, a native push adapter replaces/augments MCP-poll behind the same seam.
+- Community recipe contributions + logo pipeline.

--- a/docs/design/ai-configured-triggers/research.md
+++ b/docs/design/ai-configured-triggers/research.md
@@ -1,0 +1,61 @@
+# Research
+
+Verified findings from the codebase (exploration pass, 2026-07-10, against `origin/main`). Paths are repo-relative. §-references are used from `plan.md`.
+
+## §1. The provider seam already exists
+
+- `api/oss/src/core/triggers/registry.py` — `TriggersGatewayRegistry`; providers register adapters here. Composio is the only one today.
+- `api/oss/src/core/triggers/providers/composio/adapter.py` + `catalog.py` — the reference adapter to mirror: catalog listing, subscription lifecycle (`refresh`/`revoke`/`start`/`stop`), upstream registration.
+- `api/oss/src/core/triggers/{service.py,dtos.py,interfaces.py,exceptions.py,utils.py}` — `TriggersService` orchestrates; `interfaces.py` defines the adapter contract; `service.py` contains `_validate_references` and `ensure_webhook_registered` (precedent for server-side upstream registration).
+- Wiring: `api/entrypoints/routers.py:159-165` constructs DAO → adapter → registry → service → router → dispatcher → worker; `:276` calls `ensure_webhook_registered()` at startup.
+
+## §2. Subscription data model
+
+- `api/oss/src/apis/fastapi/triggers/models.py` + `core/triggers/dtos.py`: `TriggerSubscriptionCreate = {connection_id (required, uuid), data: {event_key (required), trigger_config?, inputs_fields?, references?, selector?}, name?, description?, flags?, tags?, meta?}`.
+- **Gap**: `connection_id` is required and Composio-shaped → plan Q2 (nullable vs synthetic connection).
+- `data` is where webhook-specific fields go: `verification`, `filter`, `transform`, `dedupe_key`, `ingress_token` (server-set), `recipe_key`.
+- Connections are a shared gateway concept: `api/oss/src/core/gateway/connections/` (+ `gateway/catalog/`), table renamed in `oss000000002_rename_tool_connections_to_gateway_connections.py` — one connection can serve both tools and triggers.
+
+## §3. Ingress + dispatch precedent
+
+- Provider webhook ingress precedent: the `/composio/events/` route in `api/oss/src/apis/fastapi/triggers/router.py` (class `TriggersRouter`, routes added via `add_api_route`).
+- Dispatch: `api/oss/src/tasks/asyncio/triggers/dispatcher.py` (delivery fan-out) and `api/oss/src/tasks/taskiq/triggers/worker.py`; dedicated entrypoint `api/entrypoints/dispatcher_composio.py`.
+- Deliveries: `/deliveries`, `/deliveries/query`, `/deliveries/{id}` routes; DB in `api/oss/src/dbs/postgres/triggers/`; migration `oss000000003_add_trigger_subscriptions_and_deliveries.py` (+ `oss000000004_add_webhook_subscription_flags.py` — flags already anticipate webhook-ish state).
+- Test endpoint exists: `POST /triggers/subscriptions/test` — extend for replay-through-transform rather than adding a new surface.
+
+## §4. Secrets vault
+
+- `api/oss/src/core/secrets/enums.py` — `SecretKind` already includes **`webhook_provider`** and `custom_secret`; `CustomSecretFormat = {text, json}`.
+- Encryption: `api/oss/src/utils/crypting.py` — Fernet, key derived from `AGENTA_CRYPT_KEY` (SHA-256 → base64url); `encrypt()`/`decrypt()`.
+- Storage: `api/oss/src/dbs/postgres/secrets/` — `secrets` table scoped by `project_id` + `organization_id`, unique `(project_id, slug)`.
+- API: `api/oss/src/apis/fastapi/vault/router.py`; frontend calls `vault/v1/secrets`.
+- Frontend secret entry (masked inputs): `web/oss/src/components/pages/settings/Vault/` (`Vault.tsx`, `ConfigureSecretModal/`, `NamedSecretTable/`), `web/oss/src/components/ModelRegistry/assets/LabelInput/index.tsx` (Ant `<Input.Password>` when `isPassword`).
+- Prior design workspace: `docs/design/vault-named-secrets/` — the v2 direction (named secrets, references) builds on this.
+
+## §5. Frontend triggers UI
+
+- Settings page: `web/oss/src/components/pages/settings/Triggers/Triggers.tsx` + `components/{GatewaySchedulesSection,GatewaySubscriptionsSection,GatewayTriggersSection}.tsx`.
+- Drawers: `web/packages/agenta-entity-ui/src/gatewayTrigger/drawers/` — `TriggerSubscriptionDrawer.tsx`, `TriggerScheduleDrawer.tsx`, `TriggerCatalogDrawer.tsx`, `TriggerConnectDrawer.tsx`, `TriggerEventsDrawer.tsx`, `TriggerDeliveriesDrawer.tsx`; shared `drawers/shared/{RunVersionField,EventSourcePicker,ScheduleBuilderField}.tsx`.
+- Logos: `AppLogo` component at `web/packages/agenta-entity-ui/src/drawers/shared/CatalogAppCard.tsx:48`; consumed e.g. `TriggerSubscriptionDrawer.tsx:1147`; logos are plain `logo` URL strings from catalog data (`TriggerCatalogDrawer.tsx:67`). **No bespoke icon registry** — recipes just need to supply `logo`.
+- Entity/data layer: `web/packages/agenta-entities/src/gatewayTrigger/` (hooks `useTriggerCatalogIntegrations`, `useTriggerCatalogEvents`, `useTriggerSubscriptions`, `useTriggerDeliveries`, …; `core/` has `eventMessageTemplate.ts`, `selectorPreview.ts`, `messageInputs.ts`).
+- Generated client: `web/packages/agenta-api-client/src/generated/api/resources/triggers/`.
+
+## §6. Builder-agent surface (where "skill instructions" live)
+
+- `api/oss/src/core/workflows/build_kit.py` (~lines 29-40) — the op catalog the product's builder agent sees: `discover_triggers`, `create_schedule`, `create_subscription`, `list_schedules`, `test_subscription`, `remove_schedule`, `remove_subscription`, `commit_revision`, ….
+- `api/oss/src/core/workflows/static_catalog.py` — companion prose (e.g. `:163-164` schedule-details guidance). This is the file `agent-instructions.md` drafts additions for.
+- Runtime: `services/runner/` (`src/tools/{direct.ts,relay.ts}`, `src/engines/sandbox_agent/`); `services/runner/skills/` is currently empty — op definitions in the backend catalog are authoritative, so we extend those rather than adding runner-local skill files.
+- Adjacent design docs worth reading: `docs/design/trigger-latest-binding/` (format exemplar + current op-catalog wording caveats), `docs/design/agent-workflows/projects/trigger-discovery-catalog/`, `docs/design/automations-ux-rework/`.
+
+## §7. Tests
+
+- Acceptance: `api/oss/tests/pytest/acceptance/triggers/` (`test_triggers_schedules.py`, `_subscriptions.py`, `_catalog.py`, `_connections.py`, `_ingress.py` — ingress test file already exists to extend).
+- Unit: `api/oss/tests/pytest/unit/triggers/`; manual: `api/oss/tests/manual/triggers/try_composio_triggers.py`.
+
+## §8. External facts the plan relies on
+
+- Provider webhook registration APIs (agent- or server-callable): GitHub `POST /repos/{owner}/{repo}/hooks`; Telegram `POST /bot<token>/setWebhook` (with `secret_token`; **one webhook per bot** — surface this caveat); Stripe `POST /v1/webhook_endpoints` (signing secret `whsec_…` returned **only** in the create response — must be vaulted immediately).
+- Stripe signature verification requires HMAC over the **raw request body** with a timestamp tolerance window → ingress route must read raw bytes before JSON parsing.
+- Slack Events API requires echoing a `url_verification` challenge on registration → the `challenge_handshake` scheme.
+- Providers (Stripe, GitHub) retry on non-2xx and may auto-disable persistently failing endpoints → ack-then-process (context Q5).
+- MCP has no trigger primitive; the Triggers & Events WG incubates one at `modelcontextprotocol/experimental-ext-triggers-events` → v2 poll/MCP provider plugs into the same registry seam.

--- a/docs/design/ai-configured-triggers/secrets-and-ux.md
+++ b/docs/design/ai-configured-triggers/secrets-and-ux.md
@@ -1,0 +1,61 @@
+# Secrets & UX
+
+Two coupled problems: (1) webhook triggers introduce secrets the platform must hold (signing secrets, provider tokens), and (2) the configuration is agent-driven, so the natural-but-wrong flow is the user pasting a token into the chat. The design principle: **the agent operates on secret references (vault slugs); secret values move only browser→vault and vault→provider, server-side.**
+
+## 1. Secret inventory
+
+| secret | who creates it | where it's used | agent visibility |
+|---|---|---|---|
+| Webhook signing secret (HMAC / static token) | platform, at subscription create | ingress verification; upstream registration payload | none — slug only |
+| Provider API token (GitHub PAT, Telegram bot token, Stripe key) | user, via secure form | server-side `register_webhook_upstream` | slug only |
+| Stripe endpoint secret (`whsec_…`) | Stripe, returned once at endpoint creation | ingress verification | none — vaulted server-side inside registration |
+
+Storage: existing vault (`SecretKind.webhook_provider`, Fernet via `AGENTA_CRYPT_KEY`, project-scoped — research.md §4). No new storage system in v1.
+
+## 2. The `request_secret` flow (agent asks, user answers out-of-band)
+
+```
+agent                    runner/chat UI                 browser                vault API
+  │ request_secret(name,      │                            │                       │
+  │  description, kind) ─────►│ render secure form ───────►│ user types value      │
+  │                           │   (masked input, inline    │ POST vault/v1/secrets─►│ encrypt, store
+  │                           │    in the chat thread)     │◄── {slug} ────────────│
+  │◄── {slug} ────────────────│◄── ack(slug) ──────────────│                       │
+```
+
+Properties:
+- The op schema has **no value parameter** — there is no way for the agent to receive the secret even if it asks wrong.
+- The form posts directly to `vault/v1/secrets` from the browser; the value never enters the runner, the transcript, run traces, or observability spans.
+- The rendered form reuses the existing masked-input patterns (`ConfigureSecretModal`, `LabelInput` with `Input.Password` — research.md §4) so it looks like the Vault settings page, signaling "this is a secure field, not a chat message".
+- Cancel/timeout → the op returns `{declined: true}` and the agent proceeds or asks for an alternative (e.g. manual registration).
+- If a user pastes a secret into chat anyway, the agent is instructed (agent-instructions.md §2) to not repeat it, recommend rotation, and re-route to the form. Optional hardening: transcript-side pattern redaction (`ghp_…`, `sk_live_…`, `xoxb-…`) before persistence — nice-to-have, not load-bearing.
+
+## 3. Platform-generated secrets
+
+- Created inside `create_webhook_subscription` in the service layer; vaulted immediately; API responses and op results carry `secret_slug` + scheme, never the value (asserted in tests, plan F1).
+- `registration: api` recipes: the secret goes platform→provider inside `register_webhook_upstream` (GitHub hook `config.secret`, Telegram `secret_token`, …). Stripe inverts it: the platform captures `whsec_…` from the create response and vaults it in the same transaction.
+- `registration: manual` recipes: the **user** needs the URL + secret to paste into a dashboard. The subscription drawer shows a **reveal-once panel** (fetches the value from a dedicated vault endpoint on explicit click, marks it revealed, offers regenerate). The agent's role ends at "I've created the endpoint — open the trigger panel to copy the URL and secret into <provider>."
+
+## 4. UI spec
+
+### Catalog & identity ("look like normal triggers")
+- Webhook recipes appear in `TriggerCatalogDrawer` / `EventSourcePicker` with their provider **logo via the existing `AppLogo`** component — same grid, same cards as Composio integrations. A small "via webhook" badge (or provider-key subtitle) distinguishes the mechanism without ghettoizing it; `custom` gets a generic webhook glyph or a monogram.
+- Subscriptions list (`GatewaySubscriptionsSection`) renders identically for both providers: logo, name, event, target, active toggle, last delivery.
+
+### Subscription drawer (webhook-specific section)
+- Ingress URL with copy button; verification scheme + status chip (`verified` after first valid delivery / `unverified` / `failing`); registration state (`registered via API`, `manual — pending`, with the reveal-once panel when manual).
+- Filter / transform editors (code inputs with recipe presets from `transform_hints`), with a live preview against the latest delivery ("this payload → these inputs").
+- "Configure with AI" entry point that opens the builder-agent chat scoped to this subscription — the same agent flow used at creation is available for repair.
+
+### Deliveries drawer
+- Raw payload and transformed `inputs_fields` side by side; distinct states for `verification_failed`, `filtered_out`, `transform_error`, `dispatched`; "replay with current transform" (dry-run) button. This is both the user's and the agent's debugging surface — one source of truth.
+
+### Anti-goals
+- No secret values in drawer state, entity atoms, or SWR caches — the reveal-once fetch bypasses the cache layer.
+- No "paste your token here" free-text step anywhere in the chat flow.
+
+## 5. v2 — vault evolution
+
+- **Named secret references with egress substitution**: trigger/tool configs reference `{{secrets.NAME}}`; the platform substitutes at the moment of the outbound call (poll providers' HTTP requests, MCP server auth). Builds on `docs/design/vault-named-secrets/`. This becomes necessary when the poll provider lands (v2 in plan.md) — polling specs are agent-generated config that must mention credentials without containing them.
+- **Rotation & audit**: per-secret last-used, which subscription/connection read it, one-click rotate with automatic upstream re-registration where `registration: api`.
+- **Scoping**: today secrets are project-scoped; v2 should let a secret be attached to exactly one subscription/connection (least privilege), matching how the synthetic-connection decision (Q2) lands.

--- a/docs/design/ai-configured-triggers/status.md
+++ b/docs/design/ai-configured-triggers/status.md
@@ -1,0 +1,29 @@
+# Status
+
+**2026-07-10** — Workspace created (draft PR). Plan drafted from a repo exploration pass against `origin/main` plus prior strategy discussion (self-hosters should not need Composio; MCP = actions plane, webhook/poll providers = events plane). No code written yet.
+
+## State
+
+- [x] Repo research (`research.md`) — triggers provider seam, vault (`webhook_provider` kind exists), frontend drawers/`AppLogo`, builder-agent op catalog all located
+- [x] Phased plan (`plan.md` A–F) with file-level targets
+- [x] Agent op + prose drafts (`agent-instructions.md`)
+- [x] Secrets model + UX spec (`secrets-and-ux.md`)
+- [ ] Owner review of open questions below
+- [ ] Spikes: expression engine (Q1), connection_id call-site audit (Q2)
+- [ ] Phase A start
+
+## Questions waiting on the owner
+
+1. **Q1 — JSONata vs CEL** for filter/transform. Recommendation: JSONata; needs a maturity spike on `jsonata-python` (timeout/size caps).
+2. **Q2 — connection_id**: nullable for webhook subscriptions vs synthetic gateway connection. Leaning synthetic; needs the call-site audit before committing.
+3. **Q4 — logos**: bundle SVGs (per-logo licensing check) vs hotlink URLs like the Composio catalog.
+4. **Launch recipe set**: proposed GitHub, Telegram, Stripe, Slack Events, PostHog, Shopify, Linear, Cal.com, Typeform + Custom — trim or extend?
+5. **Placement of `request_secret` UI work** relative to any in-flight chat-UI projects (`docs/design/agent-chat-*`) — who owns the inline secure-form pattern?
+6. Should Phase D wording land together with the `trigger-latest-binding` op-catalog revisions to avoid two consecutive rewrites of the same prose?
+
+## Decisions log
+
+- 2026-07-10 — Webhook provider behind the existing `TriggersGatewayRegistry` seam; no parallel system (context D1).
+- 2026-07-10 — Verification = closed set of 5 schemes; per-provider knowledge is recipe/agent config, not code (context D2).
+- 2026-07-10 — Secrets never transit the conversation; `request_secret` op with out-of-band browser→vault entry (context D4).
+- 2026-07-10 — Poll/MCP-poll provider and vault egress substitution deferred to v2, seam-compatible (plan.md "Later").


### PR DESCRIPTION
## What

`docs/design/ai-configured-triggers/` — a planning workspace (per `/plan-feature` conventions) for a new `webhook` trigger provider that lets self-hosting users create event triggers for GitHub, Telegram, Stripe, Slack, PostHog, etc. **without Composio**, with the builder agent doing the configuration: picking the verification scheme, registering the webhook upstream, generating the payload→inputs transform, and iterating against real deliveries.

## Why

Self-hosters shouldn't need a third-party SaaS (and data processor) for triggers. Strategy: MCP covers the actions plane (separate track); this covers the events plane, since MCP has no trigger primitive yet. Composio stays as the managed option — nothing is removed.

## Contents

- `README.md` / `context.md` — overview, goals, key decisions (provider seam reuse, 5 verification schemes, sandboxed expression transforms, secrets-never-in-conversation) and open questions
- `research.md` — verified code findings: `TriggersGatewayRegistry` seam, existing `SecretKind.webhook_provider`, `AppLogo`/catalog logo rendering, `build_kit.py`/`static_catalog.py` agent surface
- `plan.md` — phases A–F with file-level targets; v2 items (poll + MCP-poll provider, vault egress substitution) explicitly deferred
- `agent-instructions.md` — drafted op descriptions + static-catalog prose, incl. hard secrets guardrails
- `secrets-and-ux.md` — `request_secret` out-of-band flow (browser→vault, agent gets slug only), reveal-once panel, catalog/drawer UX so these triggers look first-class (provider logos via existing `AppLogo`)
- `status.md` — open questions waiting on review (expression engine, connection_id shape, logo sourcing, launch recipe set)

## Review focus

The six questions in `status.md` — especially JSONata vs CEL (Q1) and nullable-vs-synthetic `connection_id` (Q2), which gate Phase A.

https://claude.ai/code/session_01HbtYHq6RCG8mELkWRnBCbK