### PR TITLE
fix(runner): stop the 15s dead wait when geesefs cannot mount

### DIFF
--- a/services/runner/src/engines/sandbox_agent/mount.ts
+++ b/services/runner/src/engines/sandbox_agent/mount.ts
@@ -204,6 +204,64 @@ export interface MountStorageDeps {
   log?: (msg: string) => void;
 }
 
+/** The slice of `ChildProcess` the exit-race poll needs. */
+interface GeesefsChildHandle {
+  on(
+    event: "exit",
+    listener: (code: number | null, signal: NodeJS.Signals | null) => void,
+  ): void;
+}
+
+/**
+ * Poll `checkMounted` for the mount to come alive, racing each tick against the spawned
+ * child's `exit` event. `-f` mode never exits while successfully mounted, so a child that
+ * exits before the mount is alive has given up for good (e.g. FATAL: no /dev/fuse in the
+ * container) — further polling is dead time. Aborts as soon as that happens instead of
+ * riding out the full `maxAttempts * intervalMs` ceiling; the ceiling still applies to the
+ * genuine still-starting case (mount takes a moment to come up but the child stays alive).
+ *
+ * Exported so tests can drive it directly with a fake child (no real geesefs/fusermount).
+ */
+export async function pollGeesefsMount(
+  cwd: string,
+  child: GeesefsChildHandle,
+  opts: {
+    checkMounted?: (cwd: string) => Promise<boolean>;
+    maxAttempts?: number;
+    intervalMs?: number;
+    log?: (msg: string) => void;
+  } = {},
+): Promise<void> {
+  const log = opts.log ?? defaultLog;
+  const checkMounted = opts.checkMounted ?? ((c: string) => isMounted(c, log));
+  const maxAttempts = opts.maxAttempts ?? 30;
+  const intervalMs = opts.intervalMs ?? 500;
+
+  const exited = new Promise<{
+    code: number | null;
+    signal: NodeJS.Signals | null;
+  }>((resolve) => {
+    child.on("exit", (code, signal) => resolve({ code, signal }));
+  });
+
+  for (let i = 0; i < maxAttempts; i++) {
+    if (await checkMounted(cwd)) return;
+    const tick = await Promise.race([
+      exited.then((r) => ({ kind: "exited" as const, ...r })),
+      new Promise<{ kind: "tick" }>((resolve) =>
+        setTimeout(() => resolve({ kind: "tick" }), intervalMs),
+      ),
+    ]);
+    if (tick.kind === "exited") {
+      log(
+        `geesefs exited before mount came alive (code=${tick.code ?? "null"}` +
+          `${tick.signal ? ` signal=${tick.signal}` : ""}); giving up early`,
+      );
+      return;
+    }
+  }
+}
+
 /**
  * geesefs-mount the durable prefix at `cwd` on this host (LOCAL sandbox).
  *
@@ -239,8 +297,10 @@ export async function mountStorage(
   const env = credEnv(creds);
 
   // geesefs runs FOREGROUND (-f): spawn it as a long-lived child and poll for the mount to come
-  // alive, rather than awaiting exit (it never exits). Detached + unref'd so it is not killed when
-  // this call returns but survives for the run; teardown unmounts it (fusermount -uz reaps it).
+  // alive, rather than awaiting exit (it never exits while mounted). Detached + unref'd so it is
+  // not killed when this call returns but survives for the run; teardown unmounts it (fusermount
+  // -uz reaps it). Poll up to ~15s normally (geesefs logs "successfully mounted" within ~1s), but
+  // abort as soon as the child exits first — see `pollGeesefsMount`.
   const run =
     deps.runGeesefs ??
     (async (a: string[], e: Record<string, string>) => {
@@ -254,12 +314,7 @@ export async function mountStorage(
         if (s) log(`geesefs stderr: ${s.slice(0, 400)}`);
       });
       child.unref();
-      // Poll up to ~15s for the mountpoint to serve I/O; geesefs logs "successfully mounted"
-      // within ~1s normally. Resolve as soon as it's alive; the caller re-verifies after.
-      for (let i = 0; i < 30; i++) {
-        if (await isMounted(cwd, () => {})) return;
-        await new Promise((r) => setTimeout(r, 500));
-      }
+      await pollGeesefsMount(cwd, child, { log });
     });
 
   try {

--- a/services/runner/tests/unit/sandbox-agent-mount.test.ts
+++ b/services/runner/tests/unit/sandbox-agent-mount.test.ts
@@ -10,6 +10,7 @@
  */
 import { describe, it } from "vitest";
 import assert from "node:assert/strict";
+import { EventEmitter } from "node:events";
 
 import {
   signSessionMountCredentials,
@@ -17,6 +18,7 @@ import {
   unmountStorage,
   discoverTunnelEndpoint,
   mountStorageRemote,
+  pollGeesefsMount,
   type MountCredentials,
 } from "../../src/engines/sandbox_agent/mount.ts";
 
@@ -203,6 +205,59 @@ describe("mountStorage", () => {
       log: SILENT,
     });
     assert.equal(ok, false);
+  });
+
+  // The dead-mount case: geesefs cannot mount at all (no /dev/fuse in the container) and exits
+  // FATAL within ~10ms. Before this fix, mountStorage's poll never noticed the child died and
+  // burned the full ~15s ceiling before falling back — measured live as 15.3s of a 24s cold
+  // start. These two tests drive the real `pollGeesefsMount` (not a fully-replaced fake) via the
+  // `runGeesefs` seam, so they exercise the production exit-race logic.
+  it("aborts fast when geesefs exits before the mount comes alive (dead mount)", async () => {
+    const fakeChild = new EventEmitter();
+    const start = Date.now();
+    const ok = await mountStorage("/work/cwd", CREDS, {
+      checkMounted: async () => false, // never comes alive
+      runGeesefs: async () => {
+        // geesefs FATAL-ed almost instantly (e.g. no /dev/fuse) — mirror that with a short delay.
+        setTimeout(() => fakeChild.emit("exit", 1, null), 5);
+        await pollGeesefsMount("/work/cwd", fakeChild, {
+          checkMounted: async () => false,
+          intervalMs: 500, // the real per-tick interval; the exit race must preempt it
+          maxAttempts: 30, // the real ~15s ceiling (30 x 500ms)
+          log: SILENT,
+        });
+      },
+      log: SILENT,
+    });
+    const elapsedMs = Date.now() - start;
+    assert.equal(ok, false);
+    // Must abort on the child's exit, nowhere near the 30 x 500ms = 15s poll ceiling.
+    assert.ok(
+      elapsedMs < 2000,
+      `expected an early abort well under the 15s ceiling, took ${elapsedMs}ms`,
+    );
+  });
+
+  it("returns true once the mount comes alive mid-poll (still-starting case preserved)", async () => {
+    let calls = 0;
+    const checkMounted = async () => {
+      calls += 1;
+      return calls >= 3; // not mounted for the first two checks, alive on the third
+    };
+    const fakeChild = new EventEmitter(); // never exits — mirrors a live -f process
+    const ok = await mountStorage("/work/cwd", CREDS, {
+      checkMounted,
+      runGeesefs: async () => {
+        await pollGeesefsMount("/work/cwd", fakeChild, {
+          checkMounted,
+          intervalMs: 5,
+          maxAttempts: 30,
+          log: SILENT,
+        });
+      },
+      log: SILENT,
+    });
+    assert.equal(ok, true);
   });
 });
 


### PR DESCRIPTION
## Summary

Measured live: a 24s first-message cold-start latency, 15.3s of it a dead poll in `mountStorage`.

`mountStorage` (`services/runner/src/engines/sandbox_agent/mount.ts`) spawns geesefs foreground (`-f`, detached) and polls `isMounted(cwd)` up to 30x500ms (~15s) waiting for the mount to come alive. When geesefs cannot mount at all — no `/dev/fuse` in the container — it exits FATAL within ~10ms. The poll never noticed the child had died, so every cold start burned the full 15s before falling back to a plain (ephemeral) cwd.

## Fix

- Extracted the poll loop into `pollGeesefsMount` (exported for tests): it now races each poll tick against the spawned child's `exit` event. `-f` mode never exits while successfully mounted, so a child that exits before the mount is alive has given up for good — the loop returns immediately instead of riding out the ceiling.
- The genuine still-starting case (mount takes a moment to come up, child stays alive) keeps the same ~15s ceiling and behavior.
- Logs the early abort distinctly: `geesefs exited before mount came alive (code=N); giving up early`.
- The `deps.runGeesefs` injection seam is untouched — existing injected-fake tests keep working; the new exit-tracking behavior lives only in the default (real `spawn`) implementation.

## Tests

Added two unit tests in `tests/unit/sandbox-agent-mount.test.ts`, driving the real `pollGeesefsMount` through the `runGeesefs` seam (not a fully-replaced fake), so they exercise production logic:
- child exits immediately (no `/dev/fuse`) -> `mountStorage` returns `false` in well under 1s, versus the old 15s ceiling.
- mount comes alive mid-poll (child stays alive) -> `mountStorage` returns `true`, preserving existing behavior.

`pnpm exec vitest run tests/unit/sandbox-agent-mount.test.ts`: 20/20 passed.

## Item 2 (investigated, not fixed here)

Also looked into the noisy `[sessions/interactions] resolve failed session=... token=...: HTTP 404` log that follows every instantly-allowed gate. The resolve-trigger call (`onResolveInteraction?.(id)`) lives in `services/runner/src/engines/sandbox_agent/acp-interactions.ts:198`, inside `replyPermission`, and fires unconditionally for every gate decision — including auto-allow outcomes that never created an interaction row via `onCreateInteraction`. That file is the active territory of another in-flight lane (`feat/pi-approval-parking`, currently has uncommitted WIP), so this PR does not touch it. Left as a finding for that lane's owner: skip the resolve (or downgrade the log) when the outcome was an auto-allow that never created a row.

## Test plan

- [x] `pnpm exec vitest run tests/unit/sandbox-agent-mount.test.ts` — 20/20 passed
- [x] `pnpm run typecheck` — no new errors (pre-existing errors in `acp-interactions`/`pi-assets`/`session-keepalive-approval` tests come from another lane's uncommitted WIP, unrelated to this change)
- [x] `pnpm test` (full suite) — 721/733 passed; the 12 failures are all in files this PR doesn't touch (2 are the known `qa-transcript-replay` fixture failures, the other 10 trace to the same in-flight WIP noted above)

https://claude.ai/code/session_01CSTSEXSe4DDhoXCFjZpZ5W