### PR TITLE
Fix: everyday ui bugs

### DIFF
--- a/web/oss/src/components/AgentChatSlice/AgentChatPanel.tsx
+++ b/web/oss/src/components/AgentChatSlice/AgentChatPanel.tsx
@@ -741,9 +741,6 @@ const AgentConversation = ({entityId, sessionId}: {entityId: string; sessionId: 
         stopped,
         sendQueued,
     })
-    // Latch the last non-empty queue so the row keeps its content while it animates closed on release.
-    const shownQueuedRef = useRef(queued)
-    if (queued.length > 0) shownQueuedRef.current = queued
 
     // Pending HITL gates for the paused turn, surfaced in the persistent ApprovalDock above the
     // composer (not inline in the transcript, so a paused run can't scroll out of reach). Trace
@@ -1679,7 +1676,7 @@ const AgentConversation = ({entityId, sessionId}: {entityId: string; sessionId: 
                 <RevealCollapse open={queued.length > 0} className={CHAT_COLUMN}>
                     <div className="flex items-center gap-2 px-3 pb-2">
                         <QueuedMessages
-                            queued={shownQueuedRef.current}
+                            queued={queued}
                             onRemove={removeQueued}
                             onClear={clearQueue}
                         />

--- a/web/oss/src/components/AgentChatSlice/assets/markdown.tsx
+++ b/web/oss/src/components/AgentChatSlice/assets/markdown.tsx
@@ -131,12 +131,19 @@ const MD_COMPONENTS = {code: CodeBlock, pre: PreUnwrap}
  * (the streaming one), its already-settled parts — a reasoning block, text before a tool call —
  * keep the same `content` string, so this skips re-parsing + re-running Prism on them each token.
  * (Settled messages don't re-render at all; the stable-`onRewind` fix handles those.) */
+// Anchor component ensures all markdown-rendered links open in a new tab safely.
+const Anchor = ({href, children, ...rest}: any) => (
+    <a href={href} target="_blank" rel="noopener noreferrer" {...rest}>
+        {children}
+    </a>
+)
+
 const Markdown = ({content, className}: {content: string; className?: string}) => (
     <XMarkdown
         className={className ? `${MD_CLASS} ${className}` : MD_CLASS}
         content={content}
         config={LATEX_CONFIG}
-        components={MD_COMPONENTS}
+        components={{...MD_COMPONENTS, a: Anchor}}
     />
 )
 

--- a/web/oss/src/components/AgentChatSlice/components/AgentMessage.tsx
+++ b/web/oss/src/components/AgentChatSlice/components/AgentMessage.tsx
@@ -262,16 +262,6 @@ const AgentMessage = ({
         .filter((p) => p.type === "text")
         .map((p) => (p as {text: string}).text)
         .join("")
-    const handleCopy = async () => {
-        try {
-            await navigator.clipboard.writeText(fullText)
-            setCopied(true)
-            if (copyResetTimeoutRef.current) clearTimeout(copyResetTimeoutRef.current)
-            copyResetTimeoutRef.current = setTimeout(() => setCopied(false), 1500)
-        } catch {
-            setCopied(false)
-        }
-    }
     const sources = message.parts.filter((p) => p.type === "source-url") as {
         type: "source-url"
         url: string
@@ -311,6 +301,21 @@ const AgentMessage = ({
     // A settled no-answer turn whose trace recorded an error → render the bubble itself as a
     // failure (red), with the message inline — not a nested alert box.
     const isError = noResponse && showError
+
+    // Copy the answer; append the error on a failed turn (and copy it alone on an answer-less
+    // failure) so the button isn't a no-op when the agent only returned an error.
+    const copyText = [fullText, errorText].filter(Boolean).join("\n\n")
+    const handleCopy = async () => {
+        if (!copyText) return
+        try {
+            await navigator.clipboard.writeText(copyText)
+            setCopied(true)
+            if (copyResetTimeoutRef.current) clearTimeout(copyResetTimeoutRef.current)
+            copyResetTimeoutRef.current = setTimeout(() => setCopied(false), 1500)
+        } catch {
+            setCopied(false)
+        }
+    }
 
     // Dedup set of executed tool calls (by input identity), memoized on a cheap tool-parts signature
     // (id + state) that stays STABLE while text streams — so the tool-input JSON.stringify doesn't

--- a/web/oss/src/components/DrillInView/PrettyJsonView.tsx
+++ b/web/oss/src/components/DrillInView/PrettyJsonView.tsx
@@ -559,7 +559,10 @@ const CopyButton = ({value}: {value: unknown}) => {
 // interactive chevron; leaves get an invisible 14px spacer.
 
 const ROW_HEIGHT_PX = 28
-const ROW_HEIGHT_CLASS = "min-h-[28px] h-[28px]"
+// Sticky headers must be exactly ROW_HEIGHT so they stack flush; leaf rows may
+// grow so wrapped inline values don't overflow and overlap the next row.
+const ROW_HEIGHT_CLASS_FIXED = "min-h-[28px] h-[28px]"
+const ROW_HEIGHT_CLASS_FLEX = "min-h-[28px]"
 
 const NodeRow = memo(function NodeRow({
     keyLabel,
@@ -599,7 +602,7 @@ const NodeRow = memo(function NodeRow({
     return (
         <div className={isSection ? "pt-1 first:pt-0" : ""}>
             <div
-                className={`group/row flex items-baseline gap-2 py-0.5 px-1 rounded-sm ${ROW_HEIGHT_CLASS} select-none ${collapsible ? "cursor-pointer sticky z-[1] bg-colorBgContainer" : ""} hover:bg-[var(--ant-color-fill-quaternary)] focus-visible:ring-1 focus-visible:ring-[var(--ant-color-primary)] focus-visible:outline-none`}
+                className={`group/row flex items-baseline gap-2 py-0.5 px-1 rounded-sm ${collapsible ? ROW_HEIGHT_CLASS_FIXED : ROW_HEIGHT_CLASS_FLEX} select-none ${collapsible ? "cursor-pointer sticky z-[1] bg-colorBgContainer hover:bg-[linear-gradient(0deg,var(--ant-color-fill-quaternary),var(--ant-color-fill-quaternary))]" : "hover:bg-[var(--ant-color-fill-quaternary)]"} focus-visible:ring-1 focus-visible:ring-[var(--ant-color-primary)] focus-visible:outline-none`}
                 style={
                     collapsible
                         ? {
@@ -643,7 +646,7 @@ const NodeRow = memo(function NodeRow({
                 ) : null}
 
                 {inlineValue ? (
-                    <span className="font-mono text-[12.5px] break-all ml-1 min-w-0">
+                    <span className="font-mono text-[12.5px] break-words ml-1 min-w-0">
                         {inlineValue}
                     </span>
                 ) : null}


### PR DESCRIPTION
## Context
Three small AgentChat rough edges from QA:
- The copy button on an agent message did nothing when the turn returned only an error (no answer text to copy).
- Links inside markdown answers opened in the same tab, navigating you away from the chat.
- The queued messages were displayed even after deleting them
- Fixed trace drawer pretty data render issue
