### PR TITLE
feat(agents): add GPT-5.6 to Pi model catalogs

### DIFF
--- a/docs/design/agent-workflows/projects/provider-model-auth/harness-provider-matrix.md
+++ b/docs/design/agent-workflows/projects/provider-model-auth/harness-provider-matrix.md
@@ -75,7 +75,11 @@ server-side reject rather than calling its own `/inspect`.
 
 ```
 pi:     providers = [openai, anthropic, google/gemini, mistral, groq, minimax, together_ai,
-                     openrouter]   (+ the ~24 no-vault-kind providers Pi also reaches)
+                     openrouter, openai-codex]   (+ the ~24 no-vault-kind providers Pi also reaches)
+                  // openai-codex = OpenAI's ChatGPT/Codex subscription; reached via an OAuth login
+                  // (no vault provider_key), so it is usable under self_managed and the agenta
+                  // default's runtime_provided fallback. Models (gpt-5.5/gpt-5.4/gpt-5.4-mini) are
+                  // carried explicitly in capabilities.py since the litellm catalog omits them.
         deployments = [direct]   (azure, bedrock, vertex declared; Pi consumption staged with
                                   model-config -> fail loud in v1)
         connection_modes = [agenta, self_managed]

--- a/docs/design/agent-workflows/projects/subscription-sidecar/README.md
+++ b/docs/design/agent-workflows/projects/subscription-sidecar/README.md
@@ -13,6 +13,19 @@ the playground's composite sidecar URI (`{mode, url}` → the agent config `uri`
 
 > **Status:** verified working on 2026-06-25. Two `/run` turns on `harness=claude`, `model=haiku`,
 > with no API key, returned correct output using only the mounted subscription OAuth.
+>
+> **Update 2026-06-30:** the same sidecar also serves the **OpenAI ChatGPT/Codex subscription**
+> for Pi. Mount the host's Pi login (`~/.pi/agent`, provider key `openai-codex`, from `pi` →
+> `/login`) alongside `~/.claude`, and run `harness=pi_core` with `model=openai-codex/<id>`
+> (`gpt-5.5`/`gpt-5.4`/`gpt-5.4-mini`/`gpt-5.3-codex-spark`) and `connection.mode=self_managed`.
+> Verified end to end through the live agent service. The full dual-login recipe, wiring, and
+> verification now live in the **`subscription-sidecar` skill** (`.agents/skills/subscription-sidecar/`);
+> this document keeps the Claude-specific rationale below.
+>
+> Note the app layer needs `openai-codex` in the per-harness capability table
+> (`sdks/python/agenta/sdk/agents/capabilities.py`); it was missing, so a codex `self_managed` run
+> was rejected before reaching the runner. Fixed 2026-06-30. See
+> [`../provider-model-auth/harness-provider-matrix.md`](../provider-model-auth/harness-provider-matrix.md).
 
 ## Why this works without a code change
 

--- a/hosting/docker-compose/ee/docker-compose.gh.local.yml
+++ b/hosting/docker-compose/ee/docker-compose.gh.local.yml
@@ -281,7 +281,7 @@ services:
             DAYTONA_TARGET: ${DAYTONA_TARGET:-}
             DAYTONA_SNAPSHOT: ${DAYTONA_SNAPSHOT:-}
             DAYTONA_IMAGE: ${DAYTONA_IMAGE:-}
-            AGENTA_AGENT_SANDBOX_PI_INSTALLED: ${AGENTA_AGENT_SANDBOX_PI_INSTALLED:-false}
+            AGENTA_AGENT_SANDBOX_PI_INSTALLED: ${AGENTA_AGENT_SANDBOX_PI_INSTALLED:-true}
         # === NETWORK ============================================== #
         networks:
             - agenta-ee-gh-network

--- a/hosting/docker-compose/ee/docker-compose.gh.yml
+++ b/hosting/docker-compose/ee/docker-compose.gh.yml
@@ -279,7 +279,7 @@ services:
             DAYTONA_TARGET: ${DAYTONA_TARGET:-}
             DAYTONA_SNAPSHOT: ${DAYTONA_SNAPSHOT:-}
             DAYTONA_IMAGE: ${DAYTONA_IMAGE:-}
-            AGENTA_AGENT_SANDBOX_PI_INSTALLED: ${AGENTA_AGENT_SANDBOX_PI_INSTALLED:-false}
+            AGENTA_AGENT_SANDBOX_PI_INSTALLED: ${AGENTA_AGENT_SANDBOX_PI_INSTALLED:-true}
         # === NETWORK ============================================== #
         networks:
             - agenta-ee-gh-network

--- a/hosting/docker-compose/ee/env.ee.dev.example
+++ b/hosting/docker-compose/ee/env.ee.dev.example
@@ -57,7 +57,7 @@ AGENTA_CRYPT_KEY=replace-me
 # AGENTA_API_KEY=
 # AGENTA_AGENT_MCPS_ENABLED=false
 # AGENTA_AGENT_SANDBOX_PI_DIR=/home/sandbox/.pi/agent
-# AGENTA_AGENT_SANDBOX_PI_VERSION=0.79.4
+# AGENTA_AGENT_SANDBOX_PI_VERSION=0.80.6
 # AGENTA_AGENT_SANDBOX_PI_INSTALLED=true
 
 # ================================================================== #

--- a/hosting/docker-compose/ee/env.ee.gh.example
+++ b/hosting/docker-compose/ee/env.ee.gh.example
@@ -59,7 +59,7 @@ AGENTA_CRYPT_KEY=replace-me
 # AGENTA_API_KEY=
 # AGENTA_AGENT_MCPS_ENABLED=false
 # AGENTA_AGENT_SANDBOX_PI_DIR=/home/sandbox/.pi/agent
-# AGENTA_AGENT_SANDBOX_PI_VERSION=0.79.4
+# AGENTA_AGENT_SANDBOX_PI_VERSION=0.80.6
 # AGENTA_AGENT_SANDBOX_PI_INSTALLED=true
 
 # ================================================================== #

--- a/hosting/docker-compose/oss/docker-compose.gh.local.yml
+++ b/hosting/docker-compose/oss/docker-compose.gh.local.yml
@@ -279,7 +279,7 @@ services:
             DAYTONA_TARGET: ${DAYTONA_TARGET:-}
             DAYTONA_SNAPSHOT: ${DAYTONA_SNAPSHOT:-}
             DAYTONA_IMAGE: ${DAYTONA_IMAGE:-}
-            AGENTA_AGENT_SANDBOX_PI_INSTALLED: ${AGENTA_AGENT_SANDBOX_PI_INSTALLED:-false}
+            AGENTA_AGENT_SANDBOX_PI_INSTALLED: ${AGENTA_AGENT_SANDBOX_PI_INSTALLED:-true}
         # === NETWORK ============================================== #
         networks:
             - agenta-oss-gh-network

--- a/hosting/docker-compose/oss/docker-compose.gh.ssl.yml
+++ b/hosting/docker-compose/oss/docker-compose.gh.ssl.yml
@@ -303,7 +303,7 @@ services:
             DAYTONA_TARGET: ${DAYTONA_TARGET:-}
             DAYTONA_SNAPSHOT: ${DAYTONA_SNAPSHOT:-}
             DAYTONA_IMAGE: ${DAYTONA_IMAGE:-}
-            AGENTA_AGENT_SANDBOX_PI_INSTALLED: ${AGENTA_AGENT_SANDBOX_PI_INSTALLED:-false}
+            AGENTA_AGENT_SANDBOX_PI_INSTALLED: ${AGENTA_AGENT_SANDBOX_PI_INSTALLED:-true}
         # === NETWORK ============================================== #
         networks:
             - agenta-gh-ssl-network

--- a/hosting/docker-compose/oss/docker-compose.gh.yml
+++ b/hosting/docker-compose/oss/docker-compose.gh.yml
@@ -296,7 +296,7 @@ services:
             DAYTONA_TARGET: ${DAYTONA_TARGET:-}
             DAYTONA_SNAPSHOT: ${DAYTONA_SNAPSHOT:-}
             DAYTONA_IMAGE: ${DAYTONA_IMAGE:-}
-            AGENTA_AGENT_SANDBOX_PI_INSTALLED: ${AGENTA_AGENT_SANDBOX_PI_INSTALLED:-false}
+            AGENTA_AGENT_SANDBOX_PI_INSTALLED: ${AGENTA_AGENT_SANDBOX_PI_INSTALLED:-true}
         # === NETWORK ============================================== #
         networks:
             - agenta-oss-gh-network

--- a/hosting/docker-compose/oss/env.oss.dev.example
+++ b/hosting/docker-compose/oss/env.oss.dev.example
@@ -57,7 +57,7 @@ AGENTA_CRYPT_KEY=replace-me
 # AGENTA_API_KEY=
 # AGENTA_AGENT_MCPS_ENABLED=false
 # AGENTA_AGENT_SANDBOX_PI_DIR=/home/sandbox/.pi/agent
-# AGENTA_AGENT_SANDBOX_PI_VERSION=0.79.4
+# AGENTA_AGENT_SANDBOX_PI_VERSION=0.80.6
 # AGENTA_AGENT_SANDBOX_PI_INSTALLED=true
 
 # ================================================================== #

--- a/hosting/docker-compose/oss/env.oss.gh.example
+++ b/hosting/docker-compose/oss/env.oss.gh.example
@@ -59,7 +59,7 @@ AGENTA_CRYPT_KEY=replace-me
 # AGENTA_API_KEY=
 # AGENTA_AGENT_MCPS_ENABLED=false
 # AGENTA_AGENT_SANDBOX_PI_DIR=/home/sandbox/.pi/agent
-# AGENTA_AGENT_SANDBOX_PI_VERSION=0.79.4
+# AGENTA_AGENT_SANDBOX_PI_VERSION=0.80.6
 # AGENTA_AGENT_SANDBOX_PI_INSTALLED=true
 
 # ================================================================== #

--- a/sdks/python/agenta/sdk/agents/capabilities.py
+++ b/sdks/python/agenta/sdk/agents/capabilities.py
@@ -13,11 +13,13 @@ The provider lists are the REAL harness facts, derived from
 ``docs/design/agent-workflows/projects/provider-model-auth/harness-provider-matrix.md``:
 
 - **Pi** reaches eight Agenta-vault-mapped providers directly (the ones whose ``provider_key``
-  secret drives a Pi provider via its env-key map). Pi also reaches ~24 more providers that have
-  no Agenta vault kind; those are out of scope unless a ``custom_provider`` secret is made for
-  them, so they are not enumerated here. Pi's cloud deployments (azure/bedrock/vertex) are
-  *declared* but Pi *consumption* of them stages with the model-config sibling, so v1 fails loud:
-  ``deployments`` is ``["direct"]`` for the live reach.
+  secret drives a Pi provider via its env-key map), plus ``openai-codex`` (OpenAI's ChatGPT/Codex
+  subscription), which Pi reaches through its own OAuth login rather than a vault key — usable
+  under ``self_managed`` (and the ``agenta`` default's ``runtime_provided`` fallback). Pi also
+  reaches ~24 more providers that have no Agenta vault kind; those are out of scope unless a
+  ``custom_provider`` secret is made for them, so they are not enumerated here. Pi's cloud
+  deployments (azure/bedrock/vertex) are *declared* but Pi *consumption* of them stages with the
+  model-config sibling, so v1 fails loud: ``deployments`` is ``["direct"]`` for the live reach.
 - **Claude** reaches anthropic only, direct, via a custom gateway, or through Anthropic on
   Bedrock/Vertex. The runner passes the selected model id through to Claude Code and lets the
   configured backend fail loudly if it rejects it.
@@ -50,6 +52,36 @@ PI_VAULT_PROVIDERS: List[str] = [
     "together_ai",
     "openrouter",
 ]
+
+# Subscription/OAuth-only providers Pi also reaches. ``openai-codex`` is OpenAI's ChatGPT/Codex
+# subscription: Pi authenticates it with an OAuth login (``~/.pi/agent/auth.json``, ``pi`` then
+# ``/login``), NOT an Agenta vault ``provider_key`` (no vault secret kind maps to it). ``self_managed``
+# is broader than this one provider: it covers any way a harness signs itself in without an
+# Agenta-stored key, including machine credentials such as environment variables. This provider's
+# on-ramp under ``self_managed`` happens to be the subscription OAuth. It is also reachable under
+# the ``agenta`` default's ``runtime_provided`` fallback, so it belongs in Pi's reachable providers
+# even though it carries no vault key. Its model ids are carried explicitly below because they are
+# not in the litellm-derived ``supported_llm_models`` catalog. See
+# ``docs/design/agent-workflows/projects/provider-model-auth/harness-provider-matrix.md`` and the
+# subscription-sidecar recipe.
+PI_SUBSCRIPTION_MODELS: Dict[str, List[str]] = {
+    # Bare ids (like the ``openai`` catalog); the ``openai-codex`` provider disambiguates from the
+    # plain ``openai`` models that share these names. The runner normalizes any of these onto the
+    # harness's ``openai-codex/<id>`` model. This is the full ``openai-codex`` model set Pi's
+    # vendored catalog exposes (``@earendil-works/pi-ai`` ``models.generated`` ->
+    # ``openai-codex``, served via ``chatgpt.com/backend-api``); keep it in sync when the pinned
+    # Pi version changes its codex model list.
+    "openai-codex": [
+        "gpt-5.6-sol",
+        "gpt-5.6-terra",
+        "gpt-5.6-luna",
+        "gpt-5.5",
+        "gpt-5.4",
+        "gpt-5.4-mini",
+        "gpt-5.3-codex-spark",
+    ],
+}
+PI_SUBSCRIPTION_PROVIDERS: List[str] = list(PI_SUBSCRIPTION_MODELS)
 
 # Claude Code selects a model by alias, not a ``provider/id`` string. These are the aliases the
 # Claude harness accepts (``default``/``sonnet``/``opus``/``haiku``) plus their ``[1m]``
@@ -88,17 +120,25 @@ PROVIDER_ENV_VARS: Dict[str, str] = {
 
 
 def _pi_models() -> Dict[str, List[str]]:
-    """The per-provider model ids Pi reaches: the catalog entry for each vault provider.
+    """The per-provider model ids Pi reaches: the catalog entry for each vault provider, plus the
+    explicit ids for the subscription/OAuth providers (``openai-codex``) that the shared catalog
+    does not list.
 
     Defensive against a provider missing from ``supported_llm_models`` (skip it) so a catalog
-    edit never breaks the capability document. The ids are provider-prefixed (``openai/gpt-...``),
+    edit never breaks the capability document. The ids match the shared catalog's shape (mostly
+    provider-prefixed like ``anthropic/...``; some, e.g. ``openai``, are bare like ``gpt-5.5``),
     the same shape the playground model picker already renders.
     """
-    return {
+    models = {
         provider: list(supported_llm_models[provider])
         for provider in PI_VAULT_PROVIDERS
         if provider in supported_llm_models
     }
+    # The subscription/OAuth providers are not in the litellm-derived catalog, so carry their ids
+    # explicitly (like the Claude alias set).
+    for provider, ids in PI_SUBSCRIPTION_MODELS.items():
+        models[provider] = list(ids)
+    return models
 
 
 class HarnessConnectionCapabilities(BaseModel):
@@ -127,14 +167,14 @@ class HarnessConnectionCapabilities(BaseModel):
 
 HARNESS_CONNECTION_CAPABILITIES: Dict[str, HarnessConnectionCapabilities] = {
     "pi_core": HarnessConnectionCapabilities(
-        providers=list(PI_VAULT_PROVIDERS),
+        providers=list(PI_VAULT_PROVIDERS) + list(PI_SUBSCRIPTION_PROVIDERS),
         deployments=["direct"],
         connection_modes=list(_ALL_MODES),
         model_selection="provider/id",
         models=_pi_models(),
     ),
     "pi_agenta": HarnessConnectionCapabilities(
-        providers=list(PI_VAULT_PROVIDERS),
+        providers=list(PI_VAULT_PROVIDERS) + list(PI_SUBSCRIPTION_PROVIDERS),
         deployments=["direct"],
         connection_modes=list(_ALL_MODES),
         model_selection="provider/id",

--- a/sdks/python/agenta/sdk/utils/assets.py
+++ b/sdks/python/agenta/sdk/utils/assets.py
@@ -87,6 +87,9 @@ supported_llm_models = {
         "mistral/open-mistral-nemo",
     ],
     "openai": [
+        "gpt-5.6-sol",
+        "gpt-5.6-terra",
+        "gpt-5.6-luna",
         "gpt-5.5-pro",
         "gpt-5.5",
         "gpt-5.4-pro",

--- a/sdks/python/oss/tests/pytest/unit/agents/connections/test_capabilities.py
+++ b/sdks/python/oss/tests/pytest/unit/agents/connections/test_capabilities.py
@@ -11,6 +11,8 @@ from __future__ import annotations
 from agenta.sdk.agents.capabilities import (
     CLAUDE_MODEL_ALIASES,
     HARNESS_CONNECTION_CAPABILITIES,
+    PI_SUBSCRIPTION_MODELS,
+    PI_SUBSCRIPTION_PROVIDERS,
     PI_VAULT_PROVIDERS,
     harness_allows_deployment,
     harness_allows_mode,
@@ -33,6 +35,23 @@ def test_pi_and_agenta_reach_the_vault_providers_not_arbitrary_ones():
             assert harness_allows_provider(harness, provider) is True
         # ...but an arbitrary unmapped provider is NOT (the old "*" wildcard is gone).
         assert harness_allows_provider(harness, "anything-custom") is False
+
+
+def test_pi_and_agenta_reach_the_openai_codex_subscription_provider():
+    """The ChatGPT/Codex subscription provider is reachable (OAuth login, no vault key).
+
+    Without this, an ``openai-codex`` model fails the agent-layer pre-resolve provider check
+    even though the runner drives the subscription fine. ``self_managed`` is the subscription
+    path; the provider must be allowed for that mode to ever reach the runner.
+    """
+    for harness in ("pi_core", "pi_agenta"):
+        for provider in PI_SUBSCRIPTION_PROVIDERS:
+            assert harness_allows_provider(harness, provider) is True
+        assert harness_allows_provider(harness, "openai-codex") is True
+        # case-insensitive, like the vault providers
+        assert harness_allows_provider(harness, "OpenAI-Codex") is True
+        # the subscription is a Pi reach only; Claude stays anthropic-only
+        assert harness_allows_provider("claude", "openai-codex") is False
 
 
 def test_unknown_harness_is_permissive():
@@ -68,7 +87,9 @@ def test_capabilities_document_shape():
     assert set(doc) == {"pi_core", "pi_agenta", "claude"}
     assert doc["claude"]["providers"] == ["anthropic"]
     assert doc["claude"]["model_selection"] == "alias"
-    assert doc["pi_core"]["providers"] == list(PI_VAULT_PROVIDERS)
+    assert doc["pi_core"]["providers"] == list(PI_VAULT_PROVIDERS) + list(
+        PI_SUBSCRIPTION_PROVIDERS
+    )
     assert doc["pi_core"]["connection_modes"] == ["agenta", "self_managed"]
     assert doc["pi_core"]["deployments"] == ["direct"]
     assert doc["claude"]["deployments"] == [
@@ -88,17 +109,32 @@ def test_every_harness_publishes_a_models_map():
 
 
 def test_pi_models_are_a_subset_of_the_shared_catalog():
-    # Each Pi harness publishes, per vault provider, exactly that provider's catalog ids.
+    # Each Pi harness publishes, per vault provider, exactly that provider's catalog ids, plus the
+    # subscription/OAuth providers' explicit ids (which the shared catalog does not list).
     for harness in ("pi_core", "pi_agenta"):
         models = HARNESS_CONNECTION_CAPABILITIES[harness].models
-        # Only the vault-mapped providers are published (no arbitrary catalog providers).
-        assert set(models) <= set(PI_VAULT_PROVIDERS)
-        assert set(models) == set(PI_VAULT_PROVIDERS)
-        for provider, ids in models.items():
+        # The published providers are the vault-mapped ones plus the subscription providers.
+        assert set(models) == set(PI_VAULT_PROVIDERS) | set(PI_SUBSCRIPTION_PROVIDERS)
+        for provider in PI_VAULT_PROVIDERS:
             # The published ids are exactly the shared catalog's ids for that provider
             # (verbatim — most are provider-prefixed like ``anthropic/...``, but some
             # providers, e.g. openai, list bare ids like ``gpt-5.5``).
-            assert ids == list(supported_llm_models[provider])
+            assert models[provider] == list(supported_llm_models[provider])
+        for provider, ids in PI_SUBSCRIPTION_MODELS.items():
+            # The subscription providers carry their explicit ids and are NOT in the shared
+            # catalog (they authenticate via OAuth, not a vault provider_key).
+            assert models[provider] == list(ids)
+            assert provider not in supported_llm_models
+
+
+def test_pi_publishes_concrete_gpt_5_6_models_for_both_openai_providers():
+    expected = ["gpt-5.6-sol", "gpt-5.6-terra", "gpt-5.6-luna"]
+
+    for harness in ("pi_core", "pi_agenta"):
+        models = HARNESS_CONNECTION_CAPABILITIES[harness].models
+        for provider in ("openai", "openai-codex"):
+            assert models[provider][:3] == expected
+            assert "gpt-5.6" not in models[provider]
 
 
 def test_claude_models_are_the_alias_set_under_anthropic():

--- a/services/oss/tests/pytest/unit/agent/test_invoke_handler.py
+++ b/services/oss/tests/pytest/unit/agent/test_invoke_handler.py
@@ -698,3 +698,46 @@ async def test_agent_flag_cube(multi_message_patched, stream, trim, force):
         assert result["messages"] == _TRIMMED_MESSAGES
     else:
         assert result["messages"] == _FULL_FOLDED_MESSAGES
+
+
+async def test_pi_openai_codex_self_managed_reaches_session(monkeypatch, fake_backend):
+    """Pi + the ``openai-codex`` subscription provider + ``self_managed`` is NOT rejected.
+
+    Before ``openai-codex`` joined Pi's capability providers, the agent-layer pre-resolve check
+    raised ``UnsupportedProviderError`` here even though the runner drives the ChatGPT/Codex
+    subscription fine — so the playground's self-managed (no-API-key) path was dead at the service
+    boundary. The ``self_managed`` connection resolves to a no-credential (``runtime_provided``)
+    plan: the harness authenticates with its own OAuth login and no key is injected.
+    """
+    backend = fake_backend(result=AgentResult(output="echo", usage={"total": 1}))
+    captured = {}
+
+    async def _resolve(*, model, context):
+        captured["model"] = model
+        # Mirror the VaultConnectionResolver's self_managed short-circuit (no vault, empty env).
+        return ResolvedConnection(
+            provider="openai-codex",
+            model=model.model,
+            credential_mode="runtime_provided",
+            env={},
+        )
+
+    built = _patch_resolution(monkeypatch, backend, resolve=_resolve)
+
+    body = await _invoke(
+        "pi_core",
+        model={
+            "provider": "openai-codex",
+            "model": "gpt-5.4-mini",
+            "connection": {"mode": "self_managed"},
+        },
+    )
+
+    assert body == {"messages": [{"role": "assistant", "content": "echo"}]}
+    # The pre-resolve provider check let openai-codex through, so the resolver ran.
+    assert captured["model"].provider == "openai-codex"
+    assert captured["model"].connection.mode == "self_managed"
+    # No key injected: the harness uses its own subscription login.
+    assert backend.created_secrets == [{}]
+    assert built[0].secrets == {}
+    assert built[0].resolved_connection.credential_mode == "runtime_provided"

--- a/services/runner/package.json
+++ b/services/runner/package.json
@@ -21,7 +21,7 @@
   },
   "dependencies": {
     "@daytonaio/sdk": "^0.187.0",
-    "@earendil-works/pi-coding-agent": "0.79.4",
+    "@earendil-works/pi-coding-agent": "0.80.6",
     "@opentelemetry/api": "1.9.0",
     "@opentelemetry/core": "1.28.0",
     "@opentelemetry/exporter-trace-otlp-proto": "0.54.0",

--- a/services/runner/pnpm-lock.yaml
+++ b/services/runner/pnpm-lock.yaml
@@ -12,8 +12,8 @@ importers:
         specifier: ^0.187.0
         version: 0.187.0(ws@8.21.0)
       '@earendil-works/pi-coding-agent':
-        specifier: 0.79.4
-        version: 0.79.4(ws@8.21.0)(zod@4.4.3)
+        specifier: 0.80.6
+        version: 0.80.6(ws@8.21.0)(zod@4.4.3)
       '@opentelemetry/api':
         specifier: 1.9.0
         version: 1.9.0
@@ -134,72 +134,36 @@ packages:
     resolution: {integrity: sha512-B/OUiCqGQ4Zr7v9gFFyiuitKN2c0PIgvOlQb5bYg1SM2y0F8a5JQ7FNsjRcl+d2PqYWLHwHx12CvZDyLn4KxIw==}
     engines: {node: '>=20.0.0'}
 
-  '@aws-sdk/core@3.974.20':
-    resolution: {integrity: sha512-7sDi2B2N3mc3nf1nz6FyEx/FCrJ1N1QnBmraHHQNabFaeAh2IaOOLml48/rHOD1bICHgTRkbBgNTvUzEr5Z35g==}
-    engines: {node: '>=20.0.0'}
-
   '@aws-sdk/core@3.974.21':
     resolution: {integrity: sha512-P5JAHvn4dTi96UsAGS67LVOqqpUNNRhnfFXqzCYtdBIGZtqBue4CXvRr9YenOO7PALj/Pn8uuyw53FBCiCYw8w==}
-    engines: {node: '>=20.0.0'}
-
-  '@aws-sdk/credential-provider-env@3.972.46':
-    resolution: {integrity: sha512-+GPXVS2srMOlH74S+SmC1gVuP2TvUZ0siuC0onKO93q+udP+M72dmY8wJfVQ5CX9z/9X5A1HHwz5yRIGBtskvQ==}
     engines: {node: '>=20.0.0'}
 
   '@aws-sdk/credential-provider-env@3.972.47':
     resolution: {integrity: sha512-3YoPwJczcc+MtX2xxXaYaOOWO6xKUJr1ZIIDIFuninr51BYONVVcF/CP8K2xfVRC/PztJjqKWxNGFH7BWQAw1Q==}
     engines: {node: '>=20.0.0'}
 
-  '@aws-sdk/credential-provider-http@3.972.48':
-    resolution: {integrity: sha512-fA5loSdlocacRxyUXtpoHSMuk5rsIKRDzQYVMnMxjcmFeZshaJlJ8lymy/hYKji6sne/UmNGj5pxuEs6kq/Qcg==}
-    engines: {node: '>=20.0.0'}
-
   '@aws-sdk/credential-provider-http@3.972.49':
     resolution: {integrity: sha512-2UtGUPy+x3lqyceHrtC1uEuVxBZbDalPF6KAFqBwYgm4edWdBrZKNnCqzDs7KynWUvEC6mrR+ojRk+ZgQz9C2w==}
-    engines: {node: '>=20.0.0'}
-
-  '@aws-sdk/credential-provider-ini@3.972.53':
-    resolution: {integrity: sha512-ZfdhIOR41q8TcWEnUac+gCOb+O2LBWdHLmjedXpXz4IEFW2ppNuFcm6p0sMTavpM+zD5TYfpH5Gp7guRyqSgsQ==}
     engines: {node: '>=20.0.0'}
 
   '@aws-sdk/credential-provider-ini@3.972.54':
     resolution: {integrity: sha512-Hx4gO4YRjFwitf3MVl3cDwYe1aryJthC4txVl9b+JAURovA50M2ywf9r8j1E/Q6SCTPT4qQpjOAbKYIC9CG+Vw==}
     engines: {node: '>=20.0.0'}
 
-  '@aws-sdk/credential-provider-login@3.972.52':
-    resolution: {integrity: sha512-9hu2oR0qH7Fst5Tzdx+UWxm+w5zCXtErTLtOOW5hwwQc170CLwOeniRxyFY6s9mHfGEfC5zFukNBdKBwJR8mhQ==}
-    engines: {node: '>=20.0.0'}
-
   '@aws-sdk/credential-provider-login@3.972.53':
     resolution: {integrity: sha512-+71sluhkgPqdhbbD3UDwUpj24GCkng9HQx6z7qoBFb8dwkF4ktpOcVKDeHpgg8PvBgLYwAnUYLTEGRC/PniCiQ==}
-    engines: {node: '>=20.0.0'}
-
-  '@aws-sdk/credential-provider-node@3.972.55':
-    resolution: {integrity: sha512-zMGLa/dhESVqmCD7mmIFFKSwSFrJGScvCXcjvBZEVOOMauFS5JRQvLTMukFpMEFWiV6dTAlsen2ATDBulLPtbg==}
     engines: {node: '>=20.0.0'}
 
   '@aws-sdk/credential-provider-node@3.972.56':
     resolution: {integrity: sha512-iI+4o0dvQQ4NHel4FMDiFy5q2gaU/ryLK3niOsoPccAt9WLFRkV4XTYPWRr9XvmBUqEzXG73S4p/8gm0Lu/W3A==}
     engines: {node: '>=20.0.0'}
 
-  '@aws-sdk/credential-provider-process@3.972.46':
-    resolution: {integrity: sha512-VUoNFBIjWrUN8NbFiQiuxQEgFjvziAlBRPK+ddh27aj65gk0BYu6bLZnrdrNZwpW6vAihtSUtEMQ1PUJ32QRPA==}
-    engines: {node: '>=20.0.0'}
-
   '@aws-sdk/credential-provider-process@3.972.47':
     resolution: {integrity: sha512-tAizPm9IFo/PHn06c+LQJlzfY2AGOlyF0CUljFejrU6LcZBjnk8pmbZK3/xoIDdnIzjEdbClfvY3mXfr818ZEg==}
     engines: {node: '>=20.0.0'}
 
-  '@aws-sdk/credential-provider-sso@3.972.52':
-    resolution: {integrity: sha512-nb2/n4o/HQf+FVpVbZe9vCTFngmuDoIsltMgLAtjixaKzvzhB4J8WSDFyWgnErgLHk55ctWH+I4PU+LIHhyffg==}
-    engines: {node: '>=20.0.0'}
-
   '@aws-sdk/credential-provider-sso@3.972.53':
     resolution: {integrity: sha512-pUXE3fu4tfEDV8BksIgf4dXvuIH10FhwHMl/wu8rBD5T1sMpryQWFVitH3kdPS90wlgrGYJQ/meQTSPacyZfeg==}
-    engines: {node: '>=20.0.0'}
-
-  '@aws-sdk/credential-provider-web-identity@3.972.52':
-    resolution: {integrity: sha512-lKj6aRSGbqLmpYmM24bY7a1Xmfcq2vkE3hv8CSPYfc1yCu0BPu/XEJ1L4Fm61MsU6ULLNSG8UGsffNoFUBjESA==}
     engines: {node: '>=20.0.0'}
 
   '@aws-sdk/credential-provider-web-identity@3.972.53':
@@ -232,16 +196,8 @@ packages:
     resolution: {integrity: sha512-SCW06Zjugn86pq7+dxGnFcyWJuEWHT753HTU/Vj/OzVxP+NoShwdAr4ynxAcvWL883OgRVbSqW3ohnjIxwXjjw==}
     engines: {node: '>= 14.0.0'}
 
-  '@aws-sdk/nested-clients@3.997.20':
-    resolution: {integrity: sha512-IYJuLpXp2DEILVQpQOy0PMpkftv0AHEOCn52o0atyOaumA0CdWQ3klPyXdViGYLbNpESsVFMVybvHUeZAuiGxA==}
-    engines: {node: '>=20.0.0'}
-
   '@aws-sdk/nested-clients@3.997.21':
     resolution: {integrity: sha512-eC7Vl7Qom/BGhZjG9GEqPwdQ/fk45hg1t5LP4EUxG5d1fdshLbaxCiwh/tszUzDX/4mW40mu2QsbeJJRPBbqUw==}
-    engines: {node: '>=20.0.0'}
-
-  '@aws-sdk/signature-v4-multi-region@3.996.34':
-    resolution: {integrity: sha512-mx1L5qlumSOt/nKM3BFaHE2HVkWwz0i4Bw0pyYO42FfX/FeLlo8YI6csC0gSPprEk6fTIqI+CZN9RwUwKd5krQ==}
     engines: {node: '>=20.0.0'}
 
   '@aws-sdk/signature-v4-multi-region@3.996.35':
@@ -250,10 +206,6 @@ packages:
 
   '@aws-sdk/token-providers@3.1048.0':
     resolution: {integrity: sha512-k0y/GcuesuSfWyUM0WamrGyeZmltRYaPbHO82UDA6mZ/doB+FOHKutikPAtSXMn/hDz970cF+iRuuiYO9VEbAA==}
-    engines: {node: '>=20.0.0'}
-
-  '@aws-sdk/token-providers@3.1066.0':
-    resolution: {integrity: sha512-UqEUJq7dqa44hneLDUcX7UJy95cg8YqEWyakRpvIPnrNS3Mq+UlQHgCDGu5pvwAPtlIW4qcYbvW6reG6++FyvA==}
     engines: {node: '>=20.0.0'}
 
   '@aws-sdk/token-providers@3.1069.0':
@@ -270,10 +222,6 @@ packages:
 
   '@aws-sdk/util-locate-window@3.965.7':
     resolution: {integrity: sha512-M0D6oIpohdNHjc7udzTHEQyot0+0iuA36jc2I9Hps+f/GtKi2HO/pyijQnCnNcwZqLB5+rtn81z3eZK/GyjAmA==}
-    engines: {node: '>=20.0.0'}
-
-  '@aws-sdk/xml-builder@3.972.29':
-    resolution: {integrity: sha512-fk0niuGFxfi8yIJuMVM4mhwObkiQSuwZFj3tAPrLVx64Pk3BkrEIpqjzHKY4hKoEBUD6Jg/S74Zj9jy+5F3DnQ==}
     engines: {node: '>=20.0.0'}
 
   '@aws-sdk/xml-builder@3.972.30':
@@ -319,22 +267,22 @@ packages:
     resolution: {integrity: sha512-j6PfT6735Uu34t4JoxBi4IMh1JLNrEDg5w3ZUaT0Mgkas2UfoAAhQ2Eg1LqMhy4n1CTffvCyJID9W6Ldi4xEGQ==}
     deprecated: 'Moved to @daytona/sdk, same API, no breaking changes. Please update: npm uninstall @daytonaio/sdk && npm i @daytona/sdk'
 
-  '@earendil-works/pi-agent-core@0.79.4':
-    resolution: {integrity: sha512-xkaZ3yK2XbP9HYdHrrdj/6HqZPM0o/mwbjMSU4RTJyR3HjDG0ZrPz76Hg6s0W+G4u6PpJr1mGx/srCG+3eQA8A==}
+  '@earendil-works/pi-agent-core@0.80.6':
+    resolution: {integrity: sha512-Lvn89ko42h5ETUb6Z0Ku6ldskEqXaTdQBYvSa0+7bdG9V6rUEpXptv5e0OVZ1HDcvi8s6/2lGCQWsxKX+DFHNw==}
     engines: {node: '>=22.19.0'}
 
-  '@earendil-works/pi-ai@0.79.4':
-    resolution: {integrity: sha512-Z1j+YP+6ZyPBKDUoc5m0GO/o1hPK17fWeErtDgegCTpm2dcKzuFvL/7GTqHeJkVkfpeXRwO37xOfgozQbK6EUw==}
-    engines: {node: '>=22.19.0'}
-    hasBin: true
-
-  '@earendil-works/pi-coding-agent@0.79.4':
-    resolution: {integrity: sha512-PthzVzM5m4XH/hrU+2fVjuwuH5M4eMFWbd0NCRScH14XKpwlPc8/Fh6JDz0jQb5kTBT9oQT183YLTHVVulFL9A==}
+  '@earendil-works/pi-ai@0.80.6':
+    resolution: {integrity: sha512-7xfLk8sANBp+bpPEbjoOZTbPxsa+++b1JXAoSJsNa3vbs9AHHEclmvg54XLQcxH+fuwaeti/g2jeIfJ+mVYLpA==}
     engines: {node: '>=22.19.0'}
     hasBin: true
 
-  '@earendil-works/pi-tui@0.79.4':
-    resolution: {integrity: sha512-/ZhfFiHSBMH7AbDrBQIN+UWlJnl9tSEpLYICRGGMzmNfyCqX+30NYacIhyOEaD8R5rS6wJZysAOPU0yNwigbXw==}
+  '@earendil-works/pi-coding-agent@0.80.6':
+    resolution: {integrity: sha512-vcfD6tOk402isLl3Cm/qbn2O10TvgroMp1+/fEGM24ZdvETFCdOYv5VZ7m59EI5fPsjfSJh+CpQ5bhBrhfOg7g==}
+    engines: {node: '>=22.19.0'}
+    hasBin: true
+
+  '@earendil-works/pi-tui@0.80.6':
+    resolution: {integrity: sha512-bSuzS4EVSqEPj/Qr/p9eqCESfKsGuDNbl77EGci8Iaqqt/C/XCBZL1MjXaxSWW1NsT5afjp/Cb0NTPzOLv/aPA==}
     engines: {node: '>=22.19.0'}
 
   '@emnapi/core@1.10.0':
@@ -695,8 +643,13 @@ packages:
     resolution: {integrity: sha512-ABnA53mdfkGZwOFUdZNv2S0CWGO/EIuPj8Vv9xmBFmSYg/qFc7ihO6q5FcQjvoE67kZpWkEc4AhD6B/os04yuA==}
     engines: {node: '>= 10'}
 
-  '@mistralai/mistralai@2.2.1':
-    resolution: {integrity: sha512-uKU8CZmL2RzYKmplsU01hii4p3pe4HqJefpWNRWXm1Tcm0Sm4xXfwSLIy4k7ZCPlbETCGcp69E7hZs+WOJ5itQ==}
+  '@mistralai/mistralai@2.2.6':
+    resolution: {integrity: sha512-W8pX7zHxjJvMIpw8JMxeJEleapXX0Q9NPszdNzqkM3MIEoIGPObdodujj+WHteXEvGfaP/AMwlNyRfEzSY6dQQ==}
+    peerDependencies:
+      '@opentelemetry/api': ^1.9.0
+    peerDependenciesMeta:
+      '@opentelemetry/api':
+        optional: true
 
   '@napi-rs/wasm-runtime@1.1.5':
     resolution: {integrity: sha512-AWPoBRJ9tsnVhor4sjO7rkni+7p+2IAEFj6cx06UgP10jkQHqay/36uRV/bFkgrh18D9vb4cr8Q0Pthskgzy+Q==}
@@ -1800,9 +1753,9 @@ packages:
     resolution: {integrity: sha512-hXdUTZYIVOt1Ex//jAQi+wTZZpUpwBj/0QsOzqegb3rGMMeJiSEu5xLHnYfBrRV4RH2+OCSOO95Is/7x1WJ4bw==}
     engines: {node: '>=10'}
 
-  marked@15.0.12:
-    resolution: {integrity: sha512-8dD6FusOQSrpv9Z1rdNMdlSgQOIP880DHqnohobOmYLElGEqAL/JvxvuxZO16r4HtjTlfPRDC1hbvxC9dPN2nA==}
-    engines: {node: '>= 18'}
+  marked@18.0.5:
+    resolution: {integrity: sha512-S6GcvALHg6K4ohtu4E7x0a1AqhAjp6cV8KhLSyN9qVapnzJkusVBxZRcIU9AeYsbe6P1hKDusSbEOzGyyuce6w==}
+    engines: {node: '>= 20'}
     hasBin: true
 
   math-intrinsics@1.1.0:
@@ -2114,6 +2067,10 @@ packages:
     resolution: {integrity: sha512-TkUDgb6tl7KOGZ+7e8E3d2FYgUQgF6z5YypqjWmixVQSQERFcVrVg0ySADm2LVLRh5ljAaHTCR5Fmz3Q34rB7Q==}
     engines: {node: '>=22.19.0'}
 
+  undici@8.5.0:
+    resolution: {integrity: sha512-xamtWoB1EshgjpmlXd7GGm2VfdDtw1+rD8uhry8pSNW3If6S8E0m2T2+orSKeZXEn/aPJMviCpDBA65WJt8zhg==}
+    engines: {node: '>=22.19.0'}
+
   util-deprecate@1.0.2:
     resolution: {integrity: sha512-EPD5q1uXyFxJpCrLnCc1nHnq3gOa6DZBocAIiI2TaSCA7VCJ1UJDMagCzIkXNsUYfD1daK//LTEQ8xiIbrHtcw==}
 
@@ -2363,16 +2320,16 @@ snapshots:
     dependencies:
       '@aws-crypto/sha256-browser': 5.2.0
       '@aws-crypto/sha256-js': 5.2.0
-      '@aws-sdk/core': 3.974.20
-      '@aws-sdk/credential-provider-node': 3.972.55
+      '@aws-sdk/core': 3.974.21
+      '@aws-sdk/credential-provider-node': 3.972.56
       '@aws-sdk/eventstream-handler-node': 3.972.21
       '@aws-sdk/middleware-eventstream': 3.972.17
       '@aws-sdk/middleware-websocket': 3.972.28
       '@aws-sdk/token-providers': 3.1048.0
-      '@aws-sdk/types': 3.973.12
+      '@aws-sdk/types': 3.973.13
       '@smithy/core': 3.24.7
       '@smithy/fetch-http-handler': 5.4.7
-      '@smithy/node-http-handler': 4.7.3
+      '@smithy/node-http-handler': 4.7.8
       '@smithy/types': 4.14.4
       tslib: 2.8.1
 
@@ -2393,17 +2350,6 @@ snapshots:
       '@smithy/types': 4.14.4
       tslib: 2.8.1
 
-  '@aws-sdk/core@3.974.20':
-    dependencies:
-      '@aws-sdk/types': 3.973.12
-      '@aws-sdk/xml-builder': 3.972.29
-      '@aws/lambda-invoke-store': 0.2.4
-      '@smithy/core': 3.24.7
-      '@smithy/signature-v4': 5.4.7
-      '@smithy/types': 4.14.4
-      bowser: 2.14.1
-      tslib: 2.8.1
-
   '@aws-sdk/core@3.974.21':
     dependencies:
       '@aws-sdk/types': 3.973.13
@@ -2415,29 +2361,11 @@ snapshots:
       bowser: 2.14.1
       tslib: 2.8.1
 
-  '@aws-sdk/credential-provider-env@3.972.46':
-    dependencies:
-      '@aws-sdk/core': 3.974.20
-      '@aws-sdk/types': 3.973.12
-      '@smithy/core': 3.24.7
-      '@smithy/types': 4.14.4
-      tslib: 2.8.1
-
   '@aws-sdk/credential-provider-env@3.972.47':
     dependencies:
       '@aws-sdk/core': 3.974.21
       '@aws-sdk/types': 3.973.13
       '@smithy/core': 3.24.7
-      '@smithy/types': 4.14.4
-      tslib: 2.8.1
-
-  '@aws-sdk/credential-provider-http@3.972.48':
-    dependencies:
-      '@aws-sdk/core': 3.974.20
-      '@aws-sdk/types': 3.973.12
-      '@smithy/core': 3.24.7
-      '@smithy/fetch-http-handler': 5.4.7
-      '@smithy/node-http-handler': 4.7.8
       '@smithy/types': 4.14.4
       tslib: 2.8.1
 
@@ -2448,22 +2376,6 @@ snapshots:
       '@smithy/core': 3.24.7
       '@smithy/fetch-http-handler': 5.4.7
       '@smithy/node-http-handler': 4.7.8
-      '@smithy/types': 4.14.4
-      tslib: 2.8.1
-
-  '@aws-sdk/credential-provider-ini@3.972.53':
-    dependencies:
-      '@aws-sdk/core': 3.974.20
-      '@aws-sdk/credential-provider-env': 3.972.46
-      '@aws-sdk/credential-provider-http': 3.972.48
-      '@aws-sdk/credential-provider-login': 3.972.52
-      '@aws-sdk/credential-provider-process': 3.972.46
-      '@aws-sdk/credential-provider-sso': 3.972.52
-      '@aws-sdk/credential-provider-web-identity': 3.972.52
-      '@aws-sdk/nested-clients': 3.997.20
-      '@aws-sdk/types': 3.973.12
-      '@smithy/core': 3.24.7
-      '@smithy/credential-provider-imds': 4.3.9
       '@smithy/types': 4.14.4
       tslib: 2.8.1
 
@@ -2483,35 +2395,12 @@ snapshots:
       '@smithy/types': 4.14.4
       tslib: 2.8.1
 
-  '@aws-sdk/credential-provider-login@3.972.52':
-    dependencies:
-      '@aws-sdk/core': 3.974.20
-      '@aws-sdk/nested-clients': 3.997.20
-      '@aws-sdk/types': 3.973.12
-      '@smithy/core': 3.24.7
-      '@smithy/types': 4.14.4
-      tslib: 2.8.1
-
   '@aws-sdk/credential-provider-login@3.972.53':
     dependencies:
       '@aws-sdk/core': 3.974.21
       '@aws-sdk/nested-clients': 3.997.21
       '@aws-sdk/types': 3.973.13
       '@smithy/core': 3.24.7
-      '@smithy/types': 4.14.4
-      tslib: 2.8.1
-
-  '@aws-sdk/credential-provider-node@3.972.55':
-    dependencies:
-      '@aws-sdk/credential-provider-env': 3.972.46
-      '@aws-sdk/credential-provider-http': 3.972.48
-      '@aws-sdk/credential-provider-ini': 3.972.53
-      '@aws-sdk/credential-provider-process': 3.972.46
-      '@aws-sdk/credential-provider-sso': 3.972.52
-      '@aws-sdk/credential-provider-web-identity': 3.972.52
-      '@aws-sdk/types': 3.973.12
-      '@smithy/core': 3.24.7
-      '@smithy/credential-provider-imds': 4.3.9
       '@smithy/types': 4.14.4
       tslib: 2.8.1
 
@@ -2529,28 +2418,10 @@ snapshots:
       '@smithy/types': 4.14.4
       tslib: 2.8.1
 
-  '@aws-sdk/credential-provider-process@3.972.46':
-    dependencies:
-      '@aws-sdk/core': 3.974.20
-      '@aws-sdk/types': 3.973.12
-      '@smithy/core': 3.24.7
-      '@smithy/types': 4.14.4
-      tslib: 2.8.1
-
   '@aws-sdk/credential-provider-process@3.972.47':
     dependencies:
       '@aws-sdk/core': 3.974.21
       '@aws-sdk/types': 3.973.13
-      '@smithy/core': 3.24.7
-      '@smithy/types': 4.14.4
-      tslib: 2.8.1
-
-  '@aws-sdk/credential-provider-sso@3.972.52':
-    dependencies:
-      '@aws-sdk/core': 3.974.20
-      '@aws-sdk/nested-clients': 3.997.20
-      '@aws-sdk/token-providers': 3.1066.0
-      '@aws-sdk/types': 3.973.12
       '@smithy/core': 3.24.7
       '@smithy/types': 4.14.4
       tslib: 2.8.1
@@ -2561,15 +2432,6 @@ snapshots:
       '@aws-sdk/nested-clients': 3.997.21
       '@aws-sdk/token-providers': 3.1069.0
       '@aws-sdk/types': 3.973.13
-      '@smithy/core': 3.24.7
-      '@smithy/types': 4.14.4
-      tslib: 2.8.1
-
-  '@aws-sdk/credential-provider-web-identity@3.972.52':
-    dependencies:
-      '@aws-sdk/core': 3.974.20
-      '@aws-sdk/nested-clients': 3.997.20
-      '@aws-sdk/types': 3.973.12
       '@smithy/core': 3.24.7
       '@smithy/types': 4.14.4
       tslib: 2.8.1
@@ -2585,7 +2447,7 @@ snapshots:
 
   '@aws-sdk/eventstream-handler-node@3.972.21':
     dependencies:
-      '@aws-sdk/types': 3.973.12
+      '@aws-sdk/types': 3.973.13
       '@smithy/core': 3.24.7
       '@smithy/types': 4.14.4
       tslib: 2.8.1
@@ -2602,7 +2464,7 @@ snapshots:
 
   '@aws-sdk/middleware-eventstream@3.972.17':
     dependencies:
-      '@aws-sdk/types': 3.973.12
+      '@aws-sdk/types': 3.973.13
       '@smithy/core': 3.24.7
       '@smithy/types': 4.14.4
       tslib: 2.8.1
@@ -2623,24 +2485,11 @@ snapshots:
 
   '@aws-sdk/middleware-websocket@3.972.28':
     dependencies:
-      '@aws-sdk/core': 3.974.20
-      '@aws-sdk/types': 3.973.12
+      '@aws-sdk/core': 3.974.21
+      '@aws-sdk/types': 3.973.13
       '@smithy/core': 3.24.7
       '@smithy/fetch-http-handler': 5.4.7
       '@smithy/signature-v4': 5.4.7
-      '@smithy/types': 4.14.4
-      tslib: 2.8.1
-
-  '@aws-sdk/nested-clients@3.997.20':
-    dependencies:
-      '@aws-crypto/sha256-browser': 5.2.0
-      '@aws-crypto/sha256-js': 5.2.0
-      '@aws-sdk/core': 3.974.20
-      '@aws-sdk/signature-v4-multi-region': 3.996.34
-      '@aws-sdk/types': 3.973.12
-      '@smithy/core': 3.24.7
-      '@smithy/fetch-http-handler': 5.4.7
-      '@smithy/node-http-handler': 4.7.8
       '@smithy/types': 4.14.4
       tslib: 2.8.1
 
@@ -2657,13 +2506,6 @@ snapshots:
       '@smithy/types': 4.14.4
       tslib: 2.8.1
 
-  '@aws-sdk/signature-v4-multi-region@3.996.34':
-    dependencies:
-      '@aws-sdk/types': 3.973.12
-      '@smithy/signature-v4': 5.4.7
-      '@smithy/types': 4.14.4
-      tslib: 2.8.1
-
   '@aws-sdk/signature-v4-multi-region@3.996.35':
     dependencies:
       '@aws-sdk/types': 3.973.13
@@ -2673,18 +2515,9 @@ snapshots:
 
   '@aws-sdk/token-providers@3.1048.0':
     dependencies:
-      '@aws-sdk/core': 3.974.20
-      '@aws-sdk/nested-clients': 3.997.20
-      '@aws-sdk/types': 3.973.12
-      '@smithy/core': 3.24.7
-      '@smithy/types': 4.14.4
-      tslib: 2.8.1
-
-  '@aws-sdk/token-providers@3.1066.0':
-    dependencies:
-      '@aws-sdk/core': 3.974.20
-      '@aws-sdk/nested-clients': 3.997.20
-      '@aws-sdk/types': 3.973.12
+      '@aws-sdk/core': 3.974.21
+      '@aws-sdk/nested-clients': 3.997.21
+      '@aws-sdk/types': 3.973.13
       '@smithy/core': 3.24.7
       '@smithy/types': 4.14.4
       tslib: 2.8.1
@@ -2710,12 +2543,6 @@ snapshots:
 
   '@aws-sdk/util-locate-window@3.965.7':
     dependencies:
-      tslib: 2.8.1
-
-  '@aws-sdk/xml-builder@3.972.29':
-    dependencies:
-      '@smithy/types': 4.14.4
-      fast-xml-parser: 5.7.3
       tslib: 2.8.1
 
   '@aws-sdk/xml-builder@3.972.30':
@@ -2787,9 +2614,9 @@ snapshots:
       - supports-color
       - ws
 
-  '@earendil-works/pi-agent-core@0.79.4(ws@8.21.0)(zod@4.4.3)':
+  '@earendil-works/pi-agent-core@0.80.6(ws@8.21.0)(zod@4.4.3)':
     dependencies:
-      '@earendil-works/pi-ai': 0.79.4(ws@8.21.0)(zod@4.4.3)
+      '@earendil-works/pi-ai': 0.80.6(ws@8.21.0)(zod@4.4.3)
       ignore: 7.0.5
       typebox: 1.1.38
       yaml: 2.9.0
@@ -2801,12 +2628,13 @@ snapshots:
       - ws
       - zod
 
-  '@earendil-works/pi-ai@0.79.4(ws@8.21.0)(zod@4.4.3)':
+  '@earendil-works/pi-ai@0.80.6(ws@8.21.0)(zod@4.4.3)':
     dependencies:
       '@anthropic-ai/sdk': 0.91.1(zod@4.4.3)
       '@aws-sdk/client-bedrock-runtime': 3.1048.0
       '@google/genai': 1.52.0
-      '@mistralai/mistralai': 2.2.1
+      '@mistralai/mistralai': 2.2.6(@opentelemetry/api@1.9.0)
+      '@opentelemetry/api': 1.9.0
       '@smithy/node-http-handler': 4.7.3
       http-proxy-agent: 7.0.2
       https-proxy-agent: 7.0.6
@@ -2821,11 +2649,11 @@ snapshots:
       - ws
       - zod
 
-  '@earendil-works/pi-coding-agent@0.79.4(ws@8.21.0)(zod@4.4.3)':
+  '@earendil-works/pi-coding-agent@0.80.6(ws@8.21.0)(zod@4.4.3)':
     dependencies:
-      '@earendil-works/pi-agent-core': 0.79.4(ws@8.21.0)(zod@4.4.3)
-      '@earendil-works/pi-ai': 0.79.4(ws@8.21.0)(zod@4.4.3)
-      '@earendil-works/pi-tui': 0.79.4
+      '@earendil-works/pi-agent-core': 0.80.6(ws@8.21.0)(zod@4.4.3)
+      '@earendil-works/pi-ai': 0.80.6(ws@8.21.0)(zod@4.4.3)
+      '@earendil-works/pi-tui': 0.80.6
       '@silvia-odwyer/photon-node': 0.3.4
       chalk: 5.6.2
       cross-spawn: 7.0.6
@@ -2839,7 +2667,7 @@ snapshots:
       proper-lockfile: 4.1.2
       semver: 7.8.0
       typebox: 1.1.38
-      undici: 8.3.0
+      undici: 8.5.0
       yaml: 2.9.0
     optionalDependencies:
       '@mariozechner/clipboard': 0.3.9
@@ -2851,10 +2679,10 @@ snapshots:
       - ws
       - zod
 
-  '@earendil-works/pi-tui@0.79.4':
+  '@earendil-works/pi-tui@0.80.6':
     dependencies:
       get-east-asian-width: 1.6.0
-      marked: 15.0.12
+      marked: 18.0.5
 
   '@emnapi/core@1.10.0':
     dependencies:
@@ -3090,11 +2918,14 @@ snapshots:
       '@mariozechner/clipboard-win32-x64-msvc': 0.3.9
     optional: true
 
-  '@mistralai/mistralai@2.2.1':
+  '@mistralai/mistralai@2.2.6(@opentelemetry/api@1.9.0)':
     dependencies:
+      '@opentelemetry/semantic-conventions': 1.41.1
       ws: 8.21.0
       zod: 4.4.3
       zod-to-json-schema: 3.25.2(zod@4.4.3)
+    optionalDependencies:
+      '@opentelemetry/api': 1.9.0
     transitivePeerDependencies:
       - bufferutil
       - utf-8-validate
@@ -4240,7 +4071,7 @@ snapshots:
     dependencies:
       semver: 7.8.0
 
-  marked@15.0.12: {}
+  marked@18.0.5: {}
 
   math-intrinsics@1.1.0: {}
 
@@ -4514,6 +4345,8 @@ snapshots:
   undici-types@7.18.2: {}
 
   undici@8.3.0: {}
+
+  undici@8.5.0: {}
 
   util-deprecate@1.0.2: {}
 


### PR DESCRIPTION
## Summary

- Add the concrete GPT-5.6 `sol`, `terra`, and `luna` models to the OpenAI model list.
- Expose the `openai-codex` provider and GPT-5.6 models through the Pi harness capability document.
- Align the runner dependency and compose environment examples with the pinned Pi version, `0.80.6`.
- Default Pi installation to enabled in the five non-snapshot GitHub compose examples.

## Context

PR #5046 now owns the Daytona snapshot and Pi installation behavior. This PR is rebased directly on that merged change and does not duplicate or override its snapshot logic.

The resulting contract is:

- non-snapshot GitHub compose files default `AGENTA_AGENT_SANDBOX_PI_INSTALLED=true`, so Pi is installed in each sandbox by default;
- the dev compose keeps `DAYTONA_SNAPSHOT=agenta-sandbox-pi` and `AGENTA_AGENT_SANDBOX_PI_INSTALLED=false`, because the selected snapshot already contains the pinned Pi version;
- `AGENTA_AGENT_SANDBOX_PI_VERSION` remains an optional override, documented as `0.80.6`;
- model catalogs use the concrete GPT-5.6 variant IDs only. The unsupported bare `gpt-5.6` alias is not advertised.

## Validation

- `pnpm install --offline --frozen-lockfile`
- Pi CLI version: `0.80.6`
- runner typecheck
- runner extension build
- Daytona unit tests: 7 passed
- runner unit tests excluding the known stale replay capture: 739 passed
- invoke-handler tests: 45 passed
- targeted SDK capability/model tests: 4 passed
- Ruff format and lint checks
- live Daytona snapshot smoke: Pi `0.80.6`, Claude/Codex/OpenCode/geesefs present, and both `openai` and `openai-codex` return the three GPT-5.6 variants
- active Daytona sandbox count returned to zero after the smoke test

The broader SDK test selection reports one unchanged baseline failure, `test_unknown_harness_is_permissive`, which is also failing on `big-agents`.