### PR TITLE
test(frontend): Repoint agenta-entities SDK mocks to per-resource getters

### DIFF
--- a/web/packages/agenta-entities/tests/unit/retrieveWorkflowRevision.test.ts
+++ b/web/packages/agenta-entities/tests/unit/retrieveWorkflowRevision.test.ts
@@ -12,15 +12,22 @@ import {beforeEach, describe, expect, it, vi} from "vitest"
 
 const fernRetrieve = vi.fn()
 
-// Mock `@agenta/sdk` so we can replace the Fern client method without
-// constructing a real client (which would try to read env vars and
-// initialize transport). `getAgentaSdkClient` returns the same fake
-// every call, so per-test state lives on `fernRetrieve`.
+// `workflow/api/api.ts` pulls from both SDK entrypoints: retrieveWorkflowRevision
+// goes through the per-resource getter (PR #4864), while fetchSimpleApplication
+// still uses the bare client. Mock both so no real transport is constructed.
+// The getters return the same fake every call, so per-test state lives on
+// `fernRetrieve`.
 vi.mock("@agenta/sdk", () => ({
     getAgentaSdkClient: () => ({
-        workflows: {
-            retrieveWorkflowRevision: fernRetrieve,
+        applications: {
+            fetchSimpleApplication: vi.fn(),
         },
+    }),
+}))
+
+vi.mock("@agenta/sdk/resources", () => ({
+    getWorkflowsClient: () => ({
+        retrieveWorkflowRevision: fernRetrieve,
     }),
 }))
 

--- a/web/packages/agenta-entities/tests/unit/trace-migration-api.test.ts
+++ b/web/packages/agenta-entities/tests/unit/trace-migration-api.test.ts
@@ -2,9 +2,9 @@
  * Unit tests for the AGE-3788 Phase 1/2 api functions (sessions + delete),
  * migrated to the Fern client.
  *
- * Mocks `@agenta/sdk` (not axios) so we assert the Fern method is called with
- * the right body + queryParams without constructing a real client, per the
- * pattern in retrieveWorkflowRevision.test.ts.
+ * Mocks `@agenta/sdk/resources` (not axios) so we assert the Fern method is
+ * called with the right body + queryParams without constructing a real client,
+ * per the pattern in retrieveWorkflowRevision.test.ts.
  */
 import {beforeEach, describe, expect, it, vi} from "vitest"
 
@@ -15,16 +15,15 @@ const querySpans = vi.fn()
 const queryTraces = vi.fn()
 const querySpansAnalytics = vi.fn()
 
-vi.mock("@agenta/sdk", () => ({
-    getAgentaSdkClient: () => ({
-        traces: {
-            querySpansSessions,
-            deleteTrace,
-            fetchTrace,
-            querySpans,
-            queryTraces,
-            querySpansAnalytics,
-        },
+// `trace/api` resolves its client via the per-resource getter (PR #4864).
+vi.mock("@agenta/sdk/resources", () => ({
+    getTracesClient: () => ({
+        querySpansSessions,
+        deleteTrace,
+        fetchTrace,
+        querySpans,
+        queryTraces,
+        querySpansAnalytics,
     }),
 }))
 


### PR DESCRIPTION
## Context
Since PR #4864 (bundle-size split) merged into `big-agents` on Jul 7, 22 unit tests in `packages/agenta-entities` fail in CI: 16 in `trace-migration-api.test.ts` and 6 in `retrieveWorkflowRevision.test.ts`. That PR moved `trace/api/client.ts` and `workflow/api/api.ts` off the bare SDK client onto per-resource getters (`getTracesClient`, `getWorkflowsClient` from `@agenta/sdk/resources`), but the tests still mocked the bare `@agenta/sdk` module. The mocks never intercepted anything, so the code under test made real HTTP calls that 404ed.

## Changes
Test-only change; no source code touched. The mocks now target the module the source actually imports.

Before (both files):
```ts
vi.mock("@agenta/sdk", () => ({
    getAgentaSdkClient: () => ({traces: {...}}),  // never resolved by the source anymore
}))
```

After:
```ts
vi.mock("@agenta/sdk/resources", () => ({
    getTracesClient: () => ({querySpans, queryTraces, ...}),  // methods sit directly on the resource client
}))
```

`retrieveWorkflowRevision.test.ts` keeps a bare `@agenta/sdk` mock as well, because its source module (`workflow/api/api.ts`) still uses `getAgentaSdkClient` for `fetchSimpleApplication`. Only the `retrieveWorkflowRevision` path moved to the resource getter.

## Tests
- `pnpm vitest run` in `web/packages/agenta-entities`: 56 files, 859 tests, all pass (the 22 previously failing ones included).
- Assertion shapes are unchanged; only the mock targets moved.

Fixes the failures in https://github.com/Agenta-AI/agenta/actions/runs/29028421021/job/86154338287.