### PR TITLE
feat(frontend): browse and preview mount files in the session inspector

### DIFF
--- a/docs/design/mount-file-viewer/README.md
+++ b/docs/design/mount-file-viewer/README.md
@@ -1,0 +1,9 @@
+# Mount file viewer in the SessionInspector
+
+Let users browse a session mount's files in the playground SessionInspector drawer and
+click a file to preview it (text, markdown, images), instead of seeing only the mount's
+name and id.
+
+- Scope: frontend only. The backend endpoints already exist.
+- Surface: `web/oss/src/components/SessionInspector/` (Mounts tab).
+- Status: see `status.md`. Plan: `plan.md`. Findings: `research.md`.

--- a/docs/design/mount-file-viewer/context.md
+++ b/docs/design/mount-file-viewer/context.md
@@ -1,0 +1,37 @@
+# Context
+
+## Symptom
+
+The SessionInspector drawer (opened from the playground) has a Mounts tab. For a session
+with a durable cwd mount full of files, the tab shows only `name / slug / id` per mount.
+Users cannot see which files the agent wrote, let alone read them. The whole point of
+inspecting a mount is looking at its contents.
+
+## Why the content is missing today
+
+- `POST /sessions/mounts/query` returns `Mount` records only. A `Mount` is a pure
+  reference: `MountData` is an intentionally empty model
+  (`api/oss/src/core/mounts/dtos.py:15-33`). File bytes live in the object store
+  (SeaweedFS/S3) under `mounts/<project_id>/<mount_id>/<path>`.
+- The frontend (`MountsTab.tsx`) never calls any file endpoint.
+
+## Why this is frontend-only
+
+The standalone mounts router already exposes everything needed, registered in prod
+entrypoints (`api/entrypoints/routers.py:1461`) and present in the generated Fern client
+(`client.mounts.*`):
+
+- `GET /mounts/{mount_id}/files` — listing (`{path, size, is_folder}`), `path` param for
+  subfolders → `getMountFiles({mount_id, path})`
+- `GET /mounts/{mount_id}/files?read=<path>` — UTF-8 text content (lossy decode
+  server-side, so binaries cannot 500) → `getMountFiles({mount_id, read})`
+- `GET /mounts/{mount_id}/files/download?path=` — raw bytes, for images →
+  `downloadMountFile({mount_id, path})`
+
+Auth is `Permission.VIEW_SESSIONS`, the same permission the inspector already requires.
+The Mounts tab already holds each `mount.id`, which is all these routes need.
+
+## Non-goals
+
+- No new backend endpoints, no Fern regen, no agent/application-level mounts (separate
+  design discussion), no file editing, no full file-tree component, no download-folder.

--- a/docs/design/mount-file-viewer/open-issues.md
+++ b/docs/design/mount-file-viewer/open-issues.md
@@ -1,0 +1,129 @@
+# Open issues
+
+Deferred TODOs and open questions for this project. Each entry carries enough context and
+provenance to act on cold. See the `defer-todo` skill for the format.
+
+## Open issues
+
+### Add one-level listing to the mount files endpoint
+
+**Status:** open
+**Added:** 2026-07-10
+**Commit:** aed3462c42 (branch `gitbutler/workspace`)
+**Project:** [Mount file viewer](README.md)
+**Source:** implement-feature session for the SessionInspector Mounts tab file browser
+
+**The problem.** `GET /mounts/{id}/files` lists a mount's whole subtree recursively in one
+response (`api/oss/src/core/store/storage.py:326`). It has no delimiter or pagination
+parameter. The frontend's `deriveRows` (`web/oss/src/components/SessionInspector/assets/mountBrowser.ts`)
+narrows this into a one-level (folder, file) view for display, so rendering stays bounded.
+The network call does not: opening the root of a large, repo-sized mount transfers the
+full recursive tree in a single request and response.
+
+**Why it is deferred.** This slice was scoped frontend-only. The existing backend
+endpoints already covered the acceptance checks (folder navigation, breadcrumbs, preview,
+download), so fixing the listing endpoint's shape was out of scope. It only matters for
+mounts large enough that the full-tree payload becomes slow or heavy, which the test mount
+used for this slice was not.
+
+**What to decide or do.** Add delimiter-based one-level listing to
+`GET /mounts/{id}/files` (the common S3-style `delimiter=/` pattern), or windowed
+pagination, so a folder view can fetch only its direct children. Once the backend
+supports it, drop the client-side flattening in `deriveRows` and call the endpoint once
+per folder instead of once per mount root.
+
+### Add inline preview for audio, PDF, and video files
+
+**Status:** open
+**Added:** 2026-07-10
+**Commit:** aed3462c42 (branch `gitbutler/workspace`)
+**Project:** [Mount file viewer](README.md)
+**Source:** live e2e verification of the SessionInspector Mounts tab file browser
+
+**The problem.** The preview panel in `MountsTab.tsx` only handles two kinds: text
+extensions render inline via the `read=` endpoint, and image extensions render inline via
+a blob object URL. Everything else falls to a "No preview available" message plus a
+Download button. The test mount used for e2e verification held mp3, wav, pdf, and mp4
+files, all of which currently fall to Download.
+
+**Why it is deferred.** The plan scoped preview to text and images only
+(`docs/design/mount-file-viewer/plan.md`). Audio, PDF, and video previews are each a
+different rendering strategy (an `<audio>`/`<video>` element from the same blob path
+already built, versus an embedded PDF viewer), and none were required by the acceptance
+checks.
+
+**What to decide or do.** Decide whether audio/video/PDF preview is worth the added
+surface. If yes, audio and video can likely reuse the existing blob-fetch path
+(`fetchMountFileBlob` in `SessionInspector/api.ts`) with `<audio>`/`<video>` elements added
+to `FilePreview`. PDF needs either a PDF.js-based viewer or an iframe pointed at the blob
+object URL; check the app for prior art before adding a dependency.
+
+### Wire colocated oss/src vitest files into CI
+
+**Status:** open
+**Added:** 2026-07-10
+**Commit:** aed3462c42 (branch `gitbutler/workspace`)
+**Project:** [Mount file viewer](README.md)
+**Source:** implement-feature session, Phase 4 (tests)
+
+**The problem.** This slice added
+`web/oss/src/components/SessionInspector/assets/mountBrowser.test.ts`, a colocated vitest
+file that follows repo precedent (`TemplateStrip/assets/pagerMath.test.ts`). It runs fine
+locally (`npx --yes vitest@4.1.10 run <path>` from `web/oss`), 9/9 passing. The CI unit-test
+harness only runs each package's `test:<layer>` script, so colocated `oss/src/**/*.test.ts`
+files, this new one included, never run in CI.
+
+**Why it is deferred.** This is a pre-existing gap, not something this slice introduced.
+`pagerMath.test.ts` has the same status today. Wiring an oss-app vitest layer into CI is
+infrastructure work independent of any one feature and affects every future colocated test
+in `web/oss/src`, not just this one.
+
+**What to decide or do.** Add a `test` (or `test:oss`) script and CI step that runs vitest
+across `web/oss/src/**/*.test.ts`, matching how package-level `test:<layer>` scripts run
+today. Until then, treat colocated oss/src tests as locally-verified only and say so in any
+PR that adds one.
+
+### Migrate off the deprecated antd List component in the Mounts tab
+
+**Status:** open
+**Added:** 2026-07-10
+**Commit:** aed3462c42 (branch `gitbutler/workspace`)
+**Project:** [Mount file viewer](README.md)
+**Source:** live e2e verification of the SessionInspector Mounts tab file browser
+
+**The problem.** The browser console shows an antd deprecation warning for the `List`
+component used to render mount file rows in `MountsTab.tsx`. The tab used `List` before
+this slice too, so the warning predates this change; this slice's `MountFilesPanel` keeps
+using it for the new file-row list.
+
+**Why it is deferred.** It is a pre-existing pattern across the tab, not a regression from
+this slice, and antd has not yet published a stable replacement pattern the rest of the
+codebase has adopted.
+
+**What to decide or do.** Migrate when antd's replacement guidance lands and other call
+sites in the codebase start moving off `List`, so the Mounts tab moves as part of a
+codebase-wide sweep rather than in isolation.
+
+### Include the file listing in the mount markdown dump
+
+**Status:** open
+**Added:** 2026-07-10
+**Commit:** aed3462c42 (branch `gitbutler/workspace`)
+**Project:** [Mount file viewer](README.md)
+**Source:** plan.md non-goals, carried forward at implementation time
+
+**The problem.** `dump.ts`'s `mountsMarkdown` renders mount metadata only (name, slug, id).
+It does not include the file listing this slice added to the Mounts tab UI, so the
+markdown dump (used wherever the session gets exported or summarized as text) still cannot
+show what files a mount holds.
+
+**Why it is deferred.** The plan scoped `dump.ts` as untouched for this slice
+(`docs/design/mount-file-viewer/plan.md`, "leave `mountsMarkdown` as is (metadata only) for
+this slice"). Extending it needs its own decision about how much of the listing to inline
+(the whole tree risks the same unbounded-payload problem as the one-level-listing issue
+above) and was not part of the reviewed scope.
+
+**What to decide or do.** Decide whether the markdown dump should show a bounded file tree
+(for example, first-level entries only, or a depth cap) and extend `mountsMarkdown` to call
+`fetchMountFiles` accordingly. Coordinate with the one-level-listing backend follow-up
+above so the dump does not fetch a full recursive tree either.

--- a/docs/design/mount-file-viewer/plan.md
+++ b/docs/design/mount-file-viewer/plan.md
@@ -1,0 +1,58 @@
+# Plan
+
+One shippable slice, frontend only.
+
+## Slice 1: Mounts tab file browser + preview
+
+### Changes
+
+All inside `web/oss/src/components/SessionInspector/`:
+
+1. **`api.ts`** — three new fetchers, following the file's existing style
+   (`getAgentaSdkClient`, `scope(projectId)` for `queryParams.project_id`):
+   - `fetchMountFiles(mountId, projectId, path?)` → `client().mounts.getMountFiles(...)`,
+     returns `{count, files: {path, size, is_folder}[]}`. The generated method is typed
+     `unknown`; declare a local response type and cast.
+   - `fetchMountFileText(mountId, projectId, path)` → same method with `read: path`,
+     returns `{path, content}`.
+   - `fetchMountFileBlob(mountId, projectId, path)` → the download route, returning a
+     `Blob`. Try the Fern `downloadMountFile(...).withRawResponse()` first; if the body is
+     already consumed/parsed, fall back to the shared axios instance
+     (`@/oss/lib/api/assets/axiosConfig`) with `responseType: "blob"` and a one-line
+     comment saying why Fern is bypassed (binary body).
+
+2. **`tabs/MountsTab.tsx`** — replace the flat `List` with:
+   - An antd `Collapse`, one panel per mount (header keeps `name ?? slug ?? id` + mono id).
+   - On panel expand, `useQuery` the root listing. Folders lazy-load on click by
+     re-querying with `path` (indent or breadcrumb navigation; no tree component).
+   - File rows show name + human-readable size.
+   - Clicking a file opens a preview inside the drawer (inline panel or `EnhancedModal`
+     from `@agenta/ui` — implementer's call, whichever reads better in the drawer):
+     - Text extensions (`md, txt, json, yaml, yml, py, ts, tsx, js, log, csv, toml, sh`,
+       and extensionless) → `read=` → `<pre>` with wrap. `.md` renders through the
+       markdown renderer already used in the app if trivially importable, else plain text.
+     - Image extensions (`png, jpg, jpeg, gif, svg, webp`) → blob → object URL → `<img>`.
+       Revoke object URLs on close/unmount.
+     - Anything else → "No preview" + a download link (same blob → anchor download).
+   - Guards: skip preview when `size > 2 MB` (show download instead); per-query loading
+     and error states; empty-folder state.
+
+3. **`dump.ts`** — leave `mountsMarkdown` as is (metadata only) for this slice.
+
+### Conventions that apply
+
+- `web/AGENTS.md`: Fern client for new API calls, TanStack Query via `useQuery` (the tab
+  already uses it), Tailwind classes, antd semantic color tokens, light + dark theme,
+  terse comments, `pnpm lint-fix` in `web/` before done.
+- State stays local to the tab (component state / `useQuery`), no new atoms needed.
+
+### Acceptance check
+
+Against a live session whose cwd mount contains files:
+1. Mounts tab lists the mount; expanding shows the file listing with sizes.
+2. Entering a folder shows its children; navigating back works.
+3. Clicking a `.md` or `.txt` file shows its text; clicking a `.png` shows the image.
+4. A file over 2 MB offers download instead of preview.
+5. Unknown binary (e.g. `.zip`) shows "No preview" + working download.
+6. No console errors; drawer still works for sessions with zero mounts.
+7. Both themes look right.

--- a/docs/design/mount-file-viewer/pr-body.md
+++ b/docs/design/mount-file-viewer/pr-body.md
@@ -1,0 +1,117 @@
+## Context
+
+The playground's SessionInspector drawer has a Mounts tab. For a session with a durable
+cwd mount full of files, the tab showed only each mount's `name / slug / id`. Users could
+see that a mount existed but not what the agent wrote into it, let alone read a file. The
+backend already exposed everything needed (`GET /mounts/{id}/files` for listing, `?read=`
+for text, `/files/download` for raw bytes), so the tab just never called it.
+
+Before: expanding a mount showed three lines of metadata.
+After: expanding a mount shows its files, folders first, with breadcrumb navigation.
+Clicking a file previews it inline (text or image) or offers a Download button.
+
+## Changes
+
+`api.ts` gained three fetchers: `fetchMountFiles`, `fetchMountFileText` (both through the
+Fern `mounts` client), and `fetchMountFileBlob`. The blob fetcher goes through the shared
+axios instance instead of Fern, because the generated `downloadMountFile` always
+text/JSON-parses the response body, so a `Blob` is unreachable through it. The function
+carries a one-line comment explaining why.
+
+`MountsTab.tsx` replaced the flat metadata `List` with a `Collapse`, one panel per mount.
+Expanding a panel queries the root listing; clicking a folder row re-queries with that
+folder's path. Clicking a file opens an inline preview: text extensions render through
+`read=`, image extensions fetch a blob and render it via an object URL, everything else
+(and anything over 2 MB) shows a Download button instead.
+
+The listing endpoint is recursive and flat: it returns every file under a path in one
+response, with paths relative to the mount root, and folders only show up as `is_folder`
+marker entries with no trailing slash. `deriveRows` (new file,
+`assets/mountBrowser.ts`) derives the one-level view the UI needs: it groups entries by
+their first path segment past the current folder into synthetic folder rows, merges those
+with any explicit folder markers so a folder never appears twice, and returns folders
+before files, both sorted alphabetically. It is unit-tested (9 tests,
+`assets/mountBrowser.test.ts`, colocated per repo precedent like
+`TemplateStrip/assets/pagerMath.test.ts`), including regression tests for the two bugs
+review caught (see below).
+
+## Scope / risk
+
+Frontend only. Files touched: `SessionInspector/api.ts`, `SessionInspector/tabs/MountsTab.tsx`,
+and the new `SessionInspector/assets/mountBrowser.ts` + `mountBrowser.test.ts`. No backend
+changes, no Fern regen, no new endpoints.
+
+`dump.ts` (the markdown export of a session's mounts) is untouched and still shows metadata
+only; it does not gain a file listing in this PR. Nothing outside the Mounts tab changes,
+so the only realistic regression surface is that tab itself: mounts with zero files, mounts
+that fail to load, and sessions with zero mounts all need to keep working (all three are
+covered in QA below).
+
+The blob-fetch axios exception is intentional, not a drift from the Fern convention:
+`web/AGENTS.md` requires Fern for new endpoint calls, and `fetchMountFiles` /
+`fetchMountFileText` follow that. `fetchMountFileBlob` calls the same endpoint Fern already
+wraps; it bypasses Fern only because Fern's generated method parses every response body as
+JSON before handing it back, which makes a binary `Blob` unreachable no matter how the
+call is made. The listing and text fetchers stay on Fern.
+
+One known v1 limit, tracked in `open-issues.md`: the listing endpoint has no one-level or
+delimiter mode, so a very large mount's root view transfers its full recursive tree in one
+response. The frontend derivation bounds what renders, not what is fetched.
+
+## Tests / notes
+
+- `npx --yes vitest@4.1.10 run src/components/SessionInspector/assets/mountBrowser.test.ts`
+  from `web/oss`: 9/9 passing.
+- Eslint clean, `tsc` clean on the touched files.
+- Colocated `web/oss/src/**/*.test.ts` vitest files, this one included, are not wired into
+  the CI unit-test harness (it runs package `test:<layer>` scripts only). Logged as a
+  deferred item in `open-issues.md`; same status as the existing colocated tests.
+- Review caught two real bugs before this landed: a first cut flattened nested files at
+  the mount root and duplicated them inside folders (the listing is recursive, not
+  one-level); a second cut keyed folder detection off a trailing slash the backend never
+  sends, so empty folders rendered as files and 404'd on preview, and a later one-line fix
+  for that unconditionally sliced a marker entry's last character, producing a phantom
+  folder row. All three are pinned as regression tests in `mountBrowser.test.ts`.
+
+## How to QA
+
+**Prerequisites:** local dev stack (`run.sh` with your usual OSS or EE flags), and a
+session whose cwd mount has nested files. If you don't have one, run a playground agent
+that writes a few files into its cwd, including a subfolder, a text file, an image, and a
+file over 2 MB.
+
+**Steps:**
+1. Open the playground, run or pick a session with that mount, and open the
+   SessionInspector drawer.
+2. Go to the Mounts tab and expand the mount panel.
+3. Click into a subfolder, then use the breadcrumb to navigate back to root.
+4. Click a `.md` or `.txt` file.
+5. Click a `.png` or other image file.
+6. Click a file over 2 MB.
+7. Click a file type with no preview support (for example `.mp3` or `.pdf`).
+8. Toggle dark mode and repeat steps 2-4.
+
+**Expected result:**
+- Step 2: the panel shows folders first, then files, each file with a human-readable size.
+- Step 3: the folder's children show; the breadcrumb takes you back to the same root view.
+- Step 4: the file's text content renders inline in a scrollable panel.
+- Step 5: the image renders inline.
+- Step 6: no preview; a Download button appears and downloads the file.
+- Step 7: "No preview available" plus a working Download button.
+- Throughout: no console errors, and the drawer still opens fine for sessions with zero
+  mounts.
+- Step 8: the tab and preview panel look correct in dark mode too.
+
+**Automated tests:**
+```
+npx --yes vitest@4.1.10 run src/components/SessionInspector/assets/mountBrowser.test.ts
+```
+(run from `web/oss`)
+
+**Edge cases:** a mount with an explicit empty-folder marker must show a folder row, not a
+file row and not a phantom row with a truncated name (both were real bugs, now pinned in
+`mountBrowser.test.ts`). A mount with a same-named file and folder at the same path (for
+example a file `a` and a folder `a/`) must show both as separate rows. Re-check dark mode
+on the preview panel specifically, not just the file list.
+
+https://claude.ai/code/session_018MaXPNpvzN22kngHno3VMj

--- a/docs/design/mount-file-viewer/pr-body.md
+++ b/docs/design/mount-file-viewer/pr-body.md
@@ -81,6 +81,7 @@ that writes a few files into its cwd, including a subfolder, a text file, an ima
 file over 2 MB.
 
 **Steps:**
+
 1. Open the playground, run or pick a session with that mount, and open the
    SessionInspector drawer.
 2. Go to the Mounts tab and expand the mount panel.
@@ -92,6 +93,7 @@ file over 2 MB.
 8. Toggle dark mode and repeat steps 2-4.
 
 **Expected result:**
+
 - Step 2: the panel shows folders first, then files, each file with a human-readable size.
 - Step 3: the folder's children show; the breadcrumb takes you back to the same root view.
 - Step 4: the file's text content renders inline in a scrollable panel.
@@ -103,9 +105,11 @@ file over 2 MB.
 - Step 8: the tab and preview panel look correct in dark mode too.
 
 **Automated tests:**
-```
+
+```shell
 npx --yes vitest@4.1.10 run src/components/SessionInspector/assets/mountBrowser.test.ts
 ```
+
 (run from `web/oss`)
 
 **Edge cases:** a mount with an explicit empty-folder marker must show a folder row, not a

--- a/docs/design/mount-file-viewer/research.md
+++ b/docs/design/mount-file-viewer/research.md
@@ -1,0 +1,48 @@
+# Research findings (2026-07-10)
+
+Condensed from two exploration passes (backend mounts subsystem; inspect UI).
+
+## Mounts subsystem
+
+- Mounts are a standalone session-scoped object-store domain, NOT part of the agent
+  config. A mount row holds metadata only; bytes live in the object store under
+  `[<namespace>/]mounts/<project_id>/<mount_id>/<path>`
+  (`api/oss/src/core/mounts/service.py:100-113`).
+- The runner materializes the mount as the sandbox cwd via geesefs (FUSE-over-S3) using
+  short-lived prefix-scoped STS credentials
+  (`services/runner/src/engines/sandbox_agent/mount.ts:62,274,480`;
+  signing: `api/oss/src/core/mounts/service.py:268-302`, TTL 3600s).
+- One durable `cwd` mount per session, minted idempotently
+  (`get_or_create_session_cwd`, `service.py:147-169`). Standalone project-scoped mounts
+  (`session_id=None`) also exist. No agent/application binding exists.
+- Skills are a different mechanism: inline content on the `/run` wire (200 KB cap),
+  materialized per run; mounts never carry content on the wire.
+
+## Endpoints and client (the reason this is FE-only)
+
+- `MountsRouter` file ops (`api/oss/src/apis/fastapi/mounts/router.py:403-432`):
+  `GET /mounts/{mount_id}/files` (listing; `path` param), `?read=<path>` (text content;
+  server does `body.decode("utf-8", "replace")` — `service.py:361-374`), and
+  `GET /mounts/{mount_id}/files/download?path=` (raw bytes via `read_file_bytes`).
+- Registered in `api/entrypoints/routers.py:1014,1461`. Permission: `VIEW_SESSIONS` for
+  reads.
+- Generated Fern client `web/packages/agenta-api-client/.../mounts/client/Client.ts` has
+  `getMountFiles`, `downloadMountFile` (both typed `unknown` — needs local casts).
+- The session-scoped router has query/sign/upload/download but NO list route; irrelevant
+  since the standalone routes accept the `mount.id` the tab already has.
+
+## Inspect UI
+
+- Two unrelated "inspect" surfaces exist. Workflow `/inspect` carries no mounts. The
+  mounts surface is the SessionInspector drawer
+  (`web/oss/src/components/SessionInspector/`), tabs Streams / Records / States /
+  Mounts / Interactions, opened from the playground
+  (`Playground.tsx:120`, `MainLayout/index.tsx:409`, `AgentChatSlice`).
+- `MountsTab.tsx` (48 lines) renders `name/slug/id` from
+  `fetchMounts` → `client().sessions.querySessionMounts`. No file endpoint is called
+  anywhere in the inspector. `dump.ts` `mountsMarkdown` mirrors the metadata-only view.
+
+## Size-cap rationale
+
+`read_file` loads the whole object into API memory. A client-side preview cap (2 MB by
+`size` from the listing) keeps previews cheap without backend changes.

--- a/docs/design/mount-file-viewer/status.md
+++ b/docs/design/mount-file-viewer/status.md
@@ -1,0 +1,70 @@
+# Status
+
+Source of truth for progress.
+
+- **2026-07-10** — Workspace created from in-conversation research (user approved the
+  minimal-scope plan in chat and asked to implement; plan-feature ran inline as part of
+  the same session rather than as a separate draft-PR round).
+- Phase 0 (refresh plan): done — citations verified against the working tree this session.
+- Phase 1 (implement slice 1): done. `api.ts` gained `fetchMountFiles` / `fetchMountFileText`
+  / `fetchMountFileBlob` (blob via shared axios: the generated Fern `downloadMountFile`
+  always JSON-parses the body, so a Blob is unreachable through it). `MountsTab.tsx`
+  rewritten: Collapse per mount, lazy listing per path with breadcrumbs, inline preview
+  panel (text/image/other + download), 2 MB cap. `.md` renders as plain text for now (the
+  app's markdown renderer is chat-bubble-specific). Lint clean; tsc clean on touched files.
+- Phase 2 (review): round 1 requested changes. Main finding (confirmed live by Mahmoud on
+  the dev box): the listing endpoint is recursive and flat with mount-root-relative paths,
+  and folder rows exist only for explicit marker objects — the first cut flattened nested
+  files at root and duplicated them inside folders. Fixed via client-side `deriveRows`
+  (prefix strip, synthetic folder rows by first segment, marker merge/dedupe, folders
+  first). Nits fixed: deferred object-URL revoke after download; object URL creation moved
+  from useMemo to useEffect. Re-review round 2: one real bug — `deriveRows` keyed folder
+  detection off a trailing slash the backend never sends instead of `entry.is_folder`
+  (empty folders rendered as files and 404'd on preview; marker-backed folders duplicated).
+  Fixed with the reviewer's one-liner (`entry.is_folder || relative.endsWith("/")`);
+  everything else in the derivation verified OK. Lint + tsc clean on touched files.
+- Phase 3 (e2e): live run on the dev box against Mahmoud's test session — 7/8 pass
+  (folder nav + breadcrumb, text preview, image preview, 2 MB cap, no-preview+download,
+  console clean of functional errors, dark mode). 1 fail: the round-2 one-line fix
+  unconditionally sliced the marker entry's last character (`is_folder` markers carry no
+  trailing slash), yielding a phantom `file_explorer_test_asset` folder row. Fixed (slice
+  only on an actual trailing slash); re-verification of the root listing in progress.
+  Screenshots in the session scratchpad `e2e/` dir. Note: antd `List` deprecation warning
+  in console — pre-existing pattern (the old tab used `List` too), no action this slice.
+- Phase 3 result: 8/8 acceptance checks pass live after the phantom-row fix (re-verified
+  in-browser on the same session).
+- Phase 4 (tests): done. `deriveRows` moved into `SessionInspector/assets/mountBrowser.ts`
+  with a colocated vitest file (repo precedent: `TemplateStrip/assets/pagerMath.test.ts`),
+  pinning the two bugs review found (an `is_folder` marker without a trailing slash; a
+  folder that never turns into a file row). 9/9 tests pass:
+  `npx --yes vitest@4.1.10 run src/components/SessionInspector/assets/mountBrowser.test.ts`
+  from `web/oss`. Eslint clean and `tsc` clean on the touched files. Note: colocated
+  `web/oss/src/**/*.test.ts` vitest files are not wired into the CI harness (it runs
+  package `test:<layer>` scripts only) — same status as the existing colocated tests; see
+  `open-issues.md`.
+- Note: known v1 limit — the backend has no true one-level listing, so a huge mount still
+  returns its full recursive listing (narrowed by `path`) in one response. Deferred:
+  see `open-issues.md`.
+- Phase 5 (docs + PR body): done. `status.md` updated, `open-issues.md` written with the
+  deferred items below, `pr-body.md` written for
+  `feat(frontend): browse and preview mount files in the session inspector`.
+- Phase 6 (GitButler lane over big-agents): pending.
+
+## Where this stands
+
+The slice is complete and verified (lint, tsc, 9/9 vitest, 8/8 live e2e). It has landed in
+the working tree pending commit and PR: Phase 6 (GitButler lane + PR) is the only step
+left.
+
+## Deferred / follow-ups
+
+Full context and provenance for each item lives in `open-issues.md`. Short list:
+
+- Agent/application-level mounts: separate design discussion (see conversation notes in
+  research.md scope), not this slice.
+- Backend one-level listing: the listing endpoint is recursive with no delimiter, so a
+  large mount transfers its full tree in one response.
+- Inline preview for more file types (audio, PDF, video).
+- Colocated oss/src vitest files, including `mountBrowser.test.ts`, are not wired into CI.
+- The antd `List` deprecation warning in the tab (pre-existing pattern).
+- `dump.ts` could include a file listing in the markdown dump later.

--- a/web/oss/src/components/SessionInspector/api.ts
+++ b/web/oss/src/components/SessionInspector/api.ts
@@ -1,11 +1,29 @@
 import {getAgentaSdkClient} from "@agenta/sdk"
 
+import axios from "@/oss/lib/api/assets/axiosConfig"
 import {getAgentaApiUrl} from "@/oss/lib/helpers/api"
 
 const client = () => getAgentaSdkClient({host: getAgentaApiUrl()})
 
 const scope = (projectId?: string | null) =>
     projectId ? {queryParams: {project_id: projectId}} : undefined
+
+// Fern types getMountFiles as `unknown`; declare the shapes locally.
+export interface MountFileEntry {
+    path: string
+    size: number
+    is_folder: boolean
+}
+
+export interface MountFileListing {
+    count: number
+    files: MountFileEntry[]
+}
+
+export interface MountFileText {
+    path: string
+    content: string
+}
 
 export async function fetchStream(sessionId: string, projectId?: string | null) {
     const res = await client().sessions.fetchSessionStream(
@@ -26,6 +44,40 @@ export async function fetchState(sessionId: string, projectId?: string | null) {
 
 export async function fetchMounts(sessionId: string, projectId?: string | null) {
     return client().sessions.querySessionMounts({session_id: sessionId}, scope(projectId))
+}
+
+export async function fetchMountFiles(
+    mountId: string,
+    projectId?: string | null,
+    path?: string,
+): Promise<MountFileListing> {
+    const data = await client().mounts.getMountFiles({mount_id: mountId, path}, scope(projectId))
+    return data as MountFileListing
+}
+
+export async function fetchMountFileText(
+    mountId: string,
+    projectId: string | null | undefined,
+    path: string,
+): Promise<MountFileText> {
+    const data = await client().mounts.getMountFiles(
+        {mount_id: mountId, read: path},
+        scope(projectId),
+    )
+    return data as MountFileText
+}
+
+/** Binary body — the Fern client always parses the response as JSON, so it can't yield a Blob. */
+export async function fetchMountFileBlob(
+    mountId: string,
+    projectId: string | null | undefined,
+    path: string,
+): Promise<Blob> {
+    const res = await axios.get<Blob>(`${getAgentaApiUrl()}/mounts/${mountId}/files/download`, {
+        params: {path, project_id: projectId},
+        responseType: "blob",
+    })
+    return res.data
 }
 
 export async function fetchInteractions(sessionId: string, projectId?: string | null) {

--- a/web/oss/src/components/SessionInspector/assets/mountBrowser.test.ts
+++ b/web/oss/src/components/SessionInspector/assets/mountBrowser.test.ts
@@ -1,0 +1,87 @@
+import {describe, expect, it} from "vitest"
+
+import type {MountFileEntry} from "../api"
+
+import {deriveRows, formatSize, type BrowserRow, type FolderRow} from "./mountBrowser"
+
+const file = (path: string, size = 0): MountFileEntry => ({path, size, is_folder: false})
+const folder = (path: string): MountFileEntry => ({path, size: 0, is_folder: true})
+
+const folderNames = (rows: BrowserRow[]): string[] =>
+    rows.filter((row): row is FolderRow => row.kind === "folder").map((row) => row.name)
+
+describe("deriveRows", () => {
+    it("derives synthetic folder rows only at root, alphabetically, with no file rows", () => {
+        const files = [file("src/main.py"), file("tests/main.py"), file("notes/todo.txt")]
+        const rows = deriveRows(files, "")
+
+        expect(rows).toHaveLength(3)
+        expect(rows.every((row) => row.kind === "folder")).toBe(true)
+        expect(rows.map((row) => row.name)).toEqual(["notes", "src", "tests"])
+    })
+
+    it("collapses a geesefs mkdir marker plus its contents into one full-name folder row", () => {
+        const files = [folder("workspace"), file("workspace/data.bin")]
+        const rows = deriveRows(files, "")
+
+        expect(rows).toHaveLength(1)
+        expect(rows[0]).toMatchObject({kind: "folder", name: "workspace"})
+        // Pins the phantom "workspace"-minus-last-char bug.
+        expect(folderNames(rows)).not.toContain("workspac")
+    })
+
+    it("shows an empty folder as a folder row, never a file row", () => {
+        const rows = deriveRows([folder("empty")], "")
+
+        expect(rows).toHaveLength(1)
+        expect(rows[0].kind).toBe("folder")
+    })
+
+    it("skips the current path's own marker entry and lists its children relative to it", () => {
+        const files = [folder("workspace"), file("workspace/data.bin")]
+        const rows = deriveRows(files, "workspace")
+
+        expect(rows).toHaveLength(1)
+        expect(rows[0]).toMatchObject({kind: "file", name: "data.bin"})
+    })
+
+    it("gives direct files at root a file row with the underlying entry preserved", () => {
+        const entry = file("readme.md", 42)
+        const rows = deriveRows([entry], "")
+
+        expect(rows).toHaveLength(1)
+        expect(rows[0]).toMatchObject({kind: "file", name: "readme.md", entry})
+    })
+
+    it("keeps a same-named file and folder as two distinct rows", () => {
+        const files = [file("a"), file("a/b.txt")]
+        const rows = deriveRows(files, "")
+
+        expect(rows).toHaveLength(2)
+        expect(rows.filter((row) => row.name === "a")).toHaveLength(2)
+        expect(rows.map((row) => row.kind).sort()).toEqual(["file", "folder"])
+    })
+
+    it("orders folders before files, both alphabetical", () => {
+        const files = [file("z.txt"), file("a.txt"), folder("m"), folder("b")]
+        const rows = deriveRows(files, "")
+
+        expect(rows.map((row) => row.name)).toEqual(["b", "m", "a.txt", "z.txt"])
+    })
+
+    it("excludes entries not under the current path", () => {
+        const files = [file("workspace/data.bin"), file("other/data.bin")]
+        const rows = deriveRows(files, "workspace")
+
+        expect(rows).toHaveLength(1)
+        expect(rows[0]).toMatchObject({kind: "file", name: "data.bin"})
+    })
+})
+
+describe("formatSize", () => {
+    it("formats bytes, kilobytes, and megabytes", () => {
+        expect(formatSize(820)).toBe("820 B")
+        expect(formatSize(4300)).toBe("4 KB")
+        expect(formatSize(4.2 * 1024 * 1024)).toBe("4.2 MB")
+    })
+})

--- a/web/oss/src/components/SessionInspector/assets/mountBrowser.test.ts
+++ b/web/oss/src/components/SessionInspector/assets/mountBrowser.test.ts
@@ -37,7 +37,7 @@ describe("deriveRows", () => {
         expect(rows[0].kind).toBe("folder")
     })
 
-    it("skips the current path's own marker entry and lists its children relative to it", () => {
+    it("lists current path children while excluding its unprefixed marker", () => {
         const files = [folder("workspace"), file("workspace/data.bin")]
         const rows = deriveRows(files, "workspace")
 

--- a/web/oss/src/components/SessionInspector/assets/mountBrowser.ts
+++ b/web/oss/src/components/SessionInspector/assets/mountBrowser.ts
@@ -1,0 +1,70 @@
+import type {MountFileEntry} from "../api"
+
+export interface FolderRow {
+    kind: "folder"
+    name: string
+    path: string
+}
+
+export interface FileRow {
+    kind: "file"
+    name: string
+    entry: MountFileEntry
+}
+
+export type BrowserRow = FolderRow | FileRow
+
+/**
+ * The API lists a path's subtree recursively and flat, with every entry's `path` relative
+ * to the mount root. Derive a one-level (folder, file) view for `currentPath` client-side:
+ * a further `/` past the current prefix means the entry belongs to a subfolder, so it
+ * contributes a synthetic folder row for its first segment instead of a file row. Explicit
+ * `is_folder` marker rows for a direct child folder are merged into the same synthetic set
+ * so a folder never appears twice.
+ */
+export const deriveRows = (files: MountFileEntry[], currentPath: string): BrowserRow[] => {
+    const prefix = currentPath ? `${currentPath}/` : ""
+    const folders = new Map<string, FolderRow>()
+    const fileRows: FileRow[] = []
+
+    for (const entry of files) {
+        if (prefix && !entry.path.startsWith(prefix)) continue
+        const relative = entry.path.slice(prefix.length)
+        if (!relative) continue // marker entry for the current path itself
+
+        const isMarker = entry.is_folder || relative.endsWith("/")
+        const cleanRelative = relative.endsWith("/") ? relative.slice(0, -1) : relative
+        if (!cleanRelative) continue
+
+        const slashIdx = cleanRelative.indexOf("/")
+        if (slashIdx === -1) {
+            if (isMarker) {
+                if (!folders.has(cleanRelative)) {
+                    folders.set(cleanRelative, {
+                        kind: "folder",
+                        name: cleanRelative,
+                        path: prefix + cleanRelative,
+                    })
+                }
+            } else {
+                fileRows.push({kind: "file", name: cleanRelative, entry})
+            }
+        } else {
+            const segment = cleanRelative.slice(0, slashIdx)
+            if (!folders.has(segment)) {
+                folders.set(segment, {kind: "folder", name: segment, path: prefix + segment})
+            }
+        }
+    }
+
+    const folderRows = Array.from(folders.values()).sort((a, b) => a.name.localeCompare(b.name))
+    fileRows.sort((a, b) => a.name.localeCompare(b.name))
+    return [...folderRows, ...fileRows]
+}
+
+/** Compact human size: `820 B`, `4.2 KB`. */
+export const formatSize = (n: number): string => {
+    if (n < 1024) return `${n} B`
+    if (n < 1024 * 1024) return `${Math.round(n / 1024)} KB`
+    return `${(n / (1024 * 1024)).toFixed(1)} MB`
+}

--- a/web/oss/src/components/SessionInspector/tabs/MountsTab.tsx
+++ b/web/oss/src/components/SessionInspector/tabs/MountsTab.tsx
@@ -210,21 +210,23 @@ const MountFilesPanel = ({mountId, projectId}: {mountId: string; projectId?: str
     return (
         <div className="flex flex-col gap-2">
             <div className="flex flex-wrap items-center gap-1 text-xs text-colorTextSecondary">
-                <span
-                    className="cursor-pointer hover:text-colorPrimary"
+                <button
+                    type="button"
+                    className="cursor-pointer border-0 bg-transparent p-0 text-inherit hover:text-colorPrimary focus-visible:outline"
                     onClick={() => navigateTo(0)}
                 >
                     root
-                </span>
+                </button>
                 {segments.map((segment, i) => (
                     <span key={i} className="flex items-center gap-1">
                         <span>/</span>
-                        <span
-                            className="cursor-pointer hover:text-colorPrimary"
+                        <button
+                            type="button"
+                            className="cursor-pointer border-0 bg-transparent p-0 text-inherit hover:text-colorPrimary focus-visible:outline"
                             onClick={() => navigateTo(i + 1)}
                         >
                             {segment}
-                        </span>
+                        </button>
                     </span>
                 ))}
             </div>
@@ -237,12 +239,20 @@ const MountFilesPanel = ({mountId, projectId}: {mountId: string; projectId?: str
                     renderItem={(row) => (
                         <List.Item
                             className="cursor-pointer"
+                            role="button"
+                            tabIndex={0}
                             onClick={() => {
                                 if (row.kind === "folder") {
                                     setPreviewEntry(null)
                                     setPath(row.path)
                                 } else {
                                     setPreviewEntry(row.entry)
+                                }
+                            }}
+                            onKeyDown={(event) => {
+                                if (event.key === "Enter" || event.key === " ") {
+                                    event.preventDefault()
+                                    event.currentTarget.click()
                                 }
                             }}
                         >

--- a/web/oss/src/components/SessionInspector/tabs/MountsTab.tsx
+++ b/web/oss/src/components/SessionInspector/tabs/MountsTab.tsx
@@ -1,12 +1,283 @@
+import {useEffect, useMemo, useState} from "react"
+
+import {message} from "@agenta/ui/app-message"
+import {File as FileIcon, FolderSimple} from "@phosphor-icons/react"
 import {useQuery} from "@tanstack/react-query"
-import {Alert, Empty, List, Skeleton, Typography} from "antd"
+import {Alert, Button, Collapse, Empty, List, Skeleton, Typography} from "antd"
 import {useAtomValue} from "jotai"
 
 import {projectIdAtom} from "@/oss/state/project"
 
-import {fetchMounts} from "../api"
+import {
+    fetchMountFileBlob,
+    fetchMountFiles,
+    fetchMountFileText,
+    fetchMounts,
+    type MountFileEntry,
+} from "../api"
+import {deriveRows, formatSize} from "../assets/mountBrowser"
 
 const {Text} = Typography
+
+const TEXT_EXTENSIONS = new Set([
+    "md",
+    "txt",
+    "json",
+    "yaml",
+    "yml",
+    "py",
+    "ts",
+    "tsx",
+    "js",
+    "jsx",
+    "log",
+    "csv",
+    "toml",
+    "sh",
+    "html",
+    "css",
+])
+const IMAGE_EXTENSIONS = new Set(["png", "jpg", "jpeg", "gif", "svg", "webp"])
+const MAX_PREVIEW_BYTES = 2 * 1024 * 1024
+
+const basename = (path: string): string => path.split("/").pop() || path
+
+const extOf = (path: string): string => {
+    const base = basename(path)
+    const idx = base.lastIndexOf(".")
+    return idx <= 0 ? "" : base.slice(idx + 1).toLowerCase()
+}
+
+const previewKind = (path: string): "text" | "image" | "other" => {
+    const ext = extOf(path)
+    if (!ext || TEXT_EXTENSIONS.has(ext)) return "text"
+    if (IMAGE_EXTENSIONS.has(ext)) return "image"
+    return "other"
+}
+
+const triggerDownload = (blob: Blob, filename: string): void => {
+    const url = URL.createObjectURL(blob)
+    const link = document.createElement("a")
+    link.href = url
+    link.download = filename
+    document.body.appendChild(link)
+    link.click()
+    document.body.removeChild(link)
+    // Defer revoke: Firefox can cancel the save if the URL is revoked synchronously.
+    setTimeout(() => URL.revokeObjectURL(url), 0)
+}
+
+const DownloadButton = ({
+    mountId,
+    projectId,
+    entry,
+}: {
+    mountId: string
+    projectId?: string | null
+    entry: MountFileEntry
+}) => {
+    const [downloading, setDownloading] = useState(false)
+
+    const onDownload = async () => {
+        setDownloading(true)
+        try {
+            const blob = await fetchMountFileBlob(mountId, projectId, entry.path)
+            triggerDownload(blob, basename(entry.path))
+        } catch {
+            message.error("Download failed")
+        } finally {
+            setDownloading(false)
+        }
+    }
+
+    return (
+        <Button size="small" loading={downloading} onClick={onDownload}>
+            Download
+        </Button>
+    )
+}
+
+const FilePreview = ({
+    mountId,
+    projectId,
+    entry,
+    onClose,
+}: {
+    mountId: string
+    projectId?: string | null
+    entry: MountFileEntry
+    onClose: () => void
+}) => {
+    const kind = previewKind(entry.path)
+    const tooLarge = entry.size > MAX_PREVIEW_BYTES
+
+    const textQuery = useQuery({
+        queryKey: ["session-inspector", "mount-file-text", projectId, mountId, entry.path],
+        queryFn: () => fetchMountFileText(mountId, projectId, entry.path),
+        enabled: kind === "text" && !tooLarge,
+        refetchOnWindowFocus: false,
+    })
+
+    const blobQuery = useQuery({
+        queryKey: ["session-inspector", "mount-file-blob", projectId, mountId, entry.path],
+        queryFn: () => fetchMountFileBlob(mountId, projectId, entry.path),
+        enabled: kind === "image" && !tooLarge,
+        refetchOnWindowFocus: false,
+    })
+
+    const [objectUrl, setObjectUrl] = useState<string | null>(null)
+    // Create the object URL as an effect (not in useMemo) so StrictMode's double-render
+    // can't orphan one; revoke the previous URL on every re-run and on unmount.
+    useEffect(() => {
+        if (!blobQuery.data) {
+            setObjectUrl(null)
+            return
+        }
+        const url = URL.createObjectURL(blobQuery.data)
+        setObjectUrl(url)
+        return () => URL.revokeObjectURL(url)
+    }, [blobQuery.data])
+
+    return (
+        <div className="mt-2 rounded border border-solid border-colorBorderSecondary p-2">
+            <div className="mb-2 flex items-center justify-between gap-2">
+                <span className="truncate font-mono text-xs">{basename(entry.path)}</span>
+                <Button type="text" size="small" onClick={onClose}>
+                    Close
+                </Button>
+            </div>
+            {tooLarge ? (
+                <div className="flex flex-col items-start gap-2">
+                    <Text type="secondary" className="text-xs">
+                        File too large to preview ({formatSize(entry.size)}).
+                    </Text>
+                    <DownloadButton mountId={mountId} projectId={projectId} entry={entry} />
+                </div>
+            ) : kind === "text" ? (
+                textQuery.isLoading ? (
+                    <Skeleton active />
+                ) : textQuery.error ? (
+                    <Alert type="error" message="Failed to load file" showIcon />
+                ) : (
+                    <pre className="m-0 max-h-[40vh] overflow-auto whitespace-pre-wrap break-words text-xs">
+                        {textQuery.data?.content}
+                    </pre>
+                )
+            ) : kind === "image" ? (
+                blobQuery.isLoading ? (
+                    <Skeleton active />
+                ) : blobQuery.error ? (
+                    <Alert type="error" message="Failed to load image" showIcon />
+                ) : objectUrl ? (
+                    // eslint-disable-next-line @next/next/no-img-element -- object URL, not a static asset
+                    <img src={objectUrl} className="max-w-full" alt={basename(entry.path)} />
+                ) : null
+            ) : (
+                <div className="flex flex-col items-start gap-2">
+                    <Text type="secondary" className="text-xs">
+                        No preview available.
+                    </Text>
+                    <DownloadButton mountId={mountId} projectId={projectId} entry={entry} />
+                </div>
+            )}
+        </div>
+    )
+}
+
+const MountFilesPanel = ({mountId, projectId}: {mountId: string; projectId?: string | null}) => {
+    const [path, setPath] = useState("")
+    const [previewEntry, setPreviewEntry] = useState<MountFileEntry | null>(null)
+
+    const queryKey = ["session-inspector", "mount-files", projectId, mountId, path]
+    const {data, isLoading, error} = useQuery({
+        queryKey,
+        queryFn: () => fetchMountFiles(mountId, projectId, path || undefined),
+        refetchOnWindowFocus: false,
+    })
+
+    const segments = path ? path.split("/") : []
+    const navigateTo = (depth: number) => {
+        setPreviewEntry(null)
+        setPath(segments.slice(0, depth).join("/"))
+    }
+
+    const files = data?.files ?? []
+    const rows = useMemo(() => deriveRows(files, path), [files, path])
+
+    if (isLoading) return <Skeleton active />
+    if (error) return <Alert type="error" message="Failed to load files" showIcon />
+
+    return (
+        <div className="flex flex-col gap-2">
+            <div className="flex flex-wrap items-center gap-1 text-xs text-colorTextSecondary">
+                <span
+                    className="cursor-pointer hover:text-colorPrimary"
+                    onClick={() => navigateTo(0)}
+                >
+                    root
+                </span>
+                {segments.map((segment, i) => (
+                    <span key={i} className="flex items-center gap-1">
+                        <span>/</span>
+                        <span
+                            className="cursor-pointer hover:text-colorPrimary"
+                            onClick={() => navigateTo(i + 1)}
+                        >
+                            {segment}
+                        </span>
+                    </span>
+                ))}
+            </div>
+            {rows.length === 0 ? (
+                <Empty description="Empty folder" image={Empty.PRESENTED_IMAGE_SIMPLE} />
+            ) : (
+                <List
+                    size="small"
+                    dataSource={rows}
+                    renderItem={(row) => (
+                        <List.Item
+                            className="cursor-pointer"
+                            onClick={() => {
+                                if (row.kind === "folder") {
+                                    setPreviewEntry(null)
+                                    setPath(row.path)
+                                } else {
+                                    setPreviewEntry(row.entry)
+                                }
+                            }}
+                        >
+                            <List.Item.Meta
+                                avatar={
+                                    row.kind === "folder" ? (
+                                        <FolderSimple size={16} />
+                                    ) : (
+                                        <FileIcon size={16} />
+                                    )
+                                }
+                                title={<span className="font-mono text-xs">{row.name}</span>}
+                                description={
+                                    row.kind === "file" && (
+                                        <Text type="secondary" className="text-xs">
+                                            {formatSize(row.entry.size)}
+                                        </Text>
+                                    )
+                                }
+                            />
+                        </List.Item>
+                    )}
+                />
+            )}
+            {previewEntry && (
+                <FilePreview
+                    mountId={mountId}
+                    projectId={projectId}
+                    entry={previewEntry}
+                    onClose={() => setPreviewEntry(null)}
+                />
+            )}
+        </div>
+    )
+}
 
 const MountsTab = ({sessionId}: {sessionId: string}) => {
     const projectId = useAtomValue(projectIdAtom)
@@ -25,22 +296,27 @@ const MountsTab = ({sessionId}: {sessionId: string}) => {
     const mounts = data?.mounts ?? []
     if (!mounts.length) return <Empty description="No mounts bound to this session" />
 
+    // File ops need a concrete mount id; a mount row without one can't be browsed.
+    const mountsWithId = mounts.filter((mount): mount is typeof mount & {id: string} =>
+        Boolean(mount.id),
+    )
+
     return (
-        <List
+        <Collapse
             size="small"
-            dataSource={mounts}
-            renderItem={(mount) => (
-                <List.Item>
-                    <List.Item.Meta
-                        title={mount.name ?? mount.slug ?? mount.id}
-                        description={
-                            <Text type="secondary" className="text-xs font-mono">
-                                {mount.id}
-                            </Text>
-                        }
-                    />
-                </List.Item>
-            )}
+            items={mountsWithId.map((mount) => ({
+                key: mount.id,
+                label: (
+                    <div className="flex flex-col">
+                        <span>{mount.name ?? mount.slug ?? mount.id}</span>
+                        <Text type="secondary" className="text-xs font-mono">
+                            {mount.id}
+                        </Text>
+                    </div>
+                ),
+                // Antd lazily mounts panel children on first expand, so this is when the listing query fires.
+                children: <MountFilesPanel mountId={mount.id} projectId={projectId} />,
+            }))}
         />
     )
 }


### PR DESCRIPTION
## Context

The playground's SessionInspector drawer has a Mounts tab. For a session with a durable
cwd mount full of files, the tab showed only each mount's `name / slug / id`. Users could
see that a mount existed but not what the agent wrote into it, let alone read a file. The
backend already exposed everything needed (`GET /mounts/{id}/files` for listing, `?read=`
for text, `/files/download` for raw bytes), so the tab just never called it.

Before: expanding a mount showed three lines of metadata.
After: expanding a mount shows its files, folders first, with breadcrumb navigation.
Clicking a file previews it inline (text or image) or offers a Download button.

## Changes

`api.ts` gained three fetchers: `fetchMountFiles`, `fetchMountFileText` (both through the
Fern `mounts` client), and `fetchMountFileBlob`. The blob fetcher goes through the shared
axios instance instead of Fern, because the generated `downloadMountFile` always
text/JSON-parses the response body, so a `Blob` is unreachable through it. The function
carries a one-line comment explaining why.

`MountsTab.tsx` replaced the flat metadata `List` with a `Collapse`, one panel per mount.
Expanding a panel queries the root listing; clicking a folder row re-queries with that
folder's path. Clicking a file opens an inline preview: text extensions render through
`read=`, image extensions fetch a blob and render it via an object URL, everything else
(and anything over 2 MB) shows a Download button instead.

The listing endpoint is recursive and flat: it returns every file under a path in one
response, with paths relative to the mount root, and folders only show up as `is_folder`
marker entries with no trailing slash. `deriveRows` (new file,
`assets/mountBrowser.ts`) derives the one-level view the UI needs: it groups entries by
their first path segment past the current folder into synthetic folder rows, merges those
with any explicit folder markers so a folder never appears twice, and returns folders
before files, both sorted alphabetically. It is unit-tested (9 tests,
`assets/mountBrowser.test.ts`, colocated per repo precedent like
`TemplateStrip/assets/pagerMath.test.ts`), including regression tests for the two bugs
review caught (see below).

## Scope / risk

Frontend only. Files touched: `SessionInspector/api.ts`, `SessionInspector/tabs/MountsTab.tsx`,
and the new `SessionInspector/assets/mountBrowser.ts` + `mountBrowser.test.ts`. No backend
changes, no Fern regen, no new endpoints.

`dump.ts` (the markdown export of a session's mounts) is untouched and still shows metadata
only; it does not gain a file listing in this PR. Nothing outside the Mounts tab changes,
so the only realistic regression surface is that tab itself: mounts with zero files, mounts
that fail to load, and sessions with zero mounts all need to keep working (all three are
covered in QA below).

The blob-fetch axios exception is intentional, not a drift from the Fern convention:
`web/AGENTS.md` requires Fern for new endpoint calls, and `fetchMountFiles` /
`fetchMountFileText` follow that. `fetchMountFileBlob` calls the same endpoint Fern already
wraps; it bypasses Fern only because Fern's generated method parses every response body as
JSON before handing it back, which makes a binary `Blob` unreachable no matter how the
call is made. The listing and text fetchers stay on Fern.

One known v1 limit, tracked in `open-issues.md`: the listing endpoint has no one-level or
delimiter mode, so a very large mount's root view transfers its full recursive tree in one
response. The frontend derivation bounds what renders, not what is fetched.

## Tests / notes

- `npx --yes vitest@4.1.10 run src/components/SessionInspector/assets/mountBrowser.test.ts`
  from `web/oss`: 9/9 passing.
- Eslint clean, `tsc` clean on the touched files.
- Colocated `web/oss/src/**/*.test.ts` vitest files, this one included, are not wired into
  the CI unit-test harness (it runs package `test:<layer>` scripts only). Logged as a
  deferred item in `open-issues.md`; same status as the existing colocated tests.
- Review caught two real bugs before this landed: a first cut flattened nested files at
  the mount root and duplicated them inside folders (the listing is recursive, not
  one-level); a second cut keyed folder detection off a trailing slash the backend never
  sends, so empty folders rendered as files and 404'd on preview, and a later one-line fix
  for that unconditionally sliced a marker entry's last character, producing a phantom
  folder row. All three are pinned as regression tests in `mountBrowser.test.ts`.

## How to QA

**Prerequisites:** local dev stack (`run.sh` with your usual OSS or EE flags), and a
session whose cwd mount has nested files. If you don't have one, run a playground agent
that writes a few files into its cwd, including a subfolder, a text file, an image, and a
file over 2 MB.

**Steps:**
1. Open the playground, run or pick a session with that mount, and open the
   SessionInspector drawer.
2. Go to the Mounts tab and expand the mount panel.
3. Click into a subfolder, then use the breadcrumb to navigate back to root.
4. Click a `.md` or `.txt` file.
5. Click a `.png` or other image file.
6. Click a file over 2 MB.
7. Click a file type with no preview support (for example `.mp3` or `.pdf`).
8. Toggle dark mode and repeat steps 2-4.

**Expected result:**
- Step 2: the panel shows folders first, then files, each file with a human-readable size.
- Step 3: the folder's children show; the breadcrumb takes you back to the same root view.
- Step 4: the file's text content renders inline in a scrollable panel.
- Step 5: the image renders inline.
- Step 6: no preview; a Download button appears and downloads the file.
- Step 7: "No preview available" plus a working Download button.
- Throughout: no console errors, and the drawer still opens fine for sessions with zero
  mounts.
- Step 8: the tab and preview panel look correct in dark mode too.

**Automated tests:**
```
npx --yes vitest@4.1.10 run src/components/SessionInspector/assets/mountBrowser.test.ts
```
(run from `web/oss`)

**Edge cases:** a mount with an explicit empty-folder marker must show a folder row, not a
file row and not a phantom row with a truncated name (both were real bugs, now pinned in
`mountBrowser.test.ts`). A mount with a same-named file and folder at the same path (for
example a file `a` and a folder `a/`) must show both as separate rows. Re-check dark mode
on the preview panel specifically, not just the file list.

https://claude.ai/code/session_018MaXPNpvzN22kngHno3VMj
