### PR TITLE
[fix] Make sidebar rows and workflow picker items middle-clickable links

### DIFF
--- a/web/oss/src/components/Sidebar/engine/SidebarMenu.tsx
+++ b/web/oss/src/components/Sidebar/engine/SidebarMenu.tsx
@@ -11,8 +11,10 @@ import {SidebarConfig, SidebarMenuProps} from "./types"
 
 type MenuItem = NonNullable<MenuProps["items"]>[number]
 
+// The ::before stretches the anchor over the whole menu row (icon + padding),
+// so middle-click / ctrl+click open in a new tab anywhere on the item.
 const MENU_LINK_CLASS_NAME =
-    "w-full !text-inherit hover:!text-inherit focus:!text-inherit active:!text-inherit no-underline"
+    "w-full !text-inherit hover:!text-inherit focus:!text-inherit active:!text-inherit no-underline before:absolute before:inset-0 before:content-['']"
 
 const SidebarMenu: React.FC<SidebarMenuProps> = ({
     items,
@@ -129,7 +131,8 @@ const SidebarMenu: React.FC<SidebarMenuProps> = ({
                                 tabIndex={isInlineMode ? 0 : -1}
                                 aria-label={`${isExpanded ? "Collapse" : "Expand"} ${item.title}`}
                                 className={clsx(
-                                    "flex h-[22px] w-7 mr-1 shrink-0 items-center justify-center rounded-md text-gray-400 transition-colors",
+                                    // z-[1] keeps the toggle clickable above the stretched link anchor
+                                    "relative z-[1] flex h-[22px] w-7 mr-1 shrink-0 items-center justify-center rounded-md text-gray-400 transition-colors",
                                     isInlineMode
                                         ? "hover:bg-gray-200 hover:text-gray-700 dark:hover:bg-white/10"
                                         : "pointer-events-none",
@@ -167,6 +170,9 @@ const SidebarMenu: React.FC<SidebarMenuProps> = ({
                             label: submenuLabel,
                             children: transformItems(item.submenu),
                             popupClassName:
+                                // The popup is a portal, so the row-positioning rules on the root
+                                // Menu don't reach it; repeat them for the stretched link anchors.
+                                "[&_.ant-menu-item]:relative [&_.ant-menu-submenu-title]:relative [&_.ant-menu-item-disabled_a]:pointer-events-none [&_.ant-menu-submenu-disabled_a]:pointer-events-none " +
                                 "max-h-[min(70vh,560px)] max-w-[min(50vw,220px)] relative !overflow-visible !shadow-none before:pointer-events-none before:absolute before:left-[-6px] before:top-6 before:z-10 before:block before:size-3 before:rotate-45 before:border-b before:border-l before:border-solid before:border-[var(--ant-color-border-secondary)] before:bg-[var(--ant-color-bg-elevated)] before:content-[''] [&_.ant-menu]:max-h-[min(70vh,560px)] [&_.ant-menu]:overflow-y-auto [&_.ant-menu]:!shadow-[8px_8px_24px_rgba(15,23,42,0.10),0_2px_8px_rgba(15,23,42,0.06)] [&_.ant-menu-sub_>_.ant-menu-item]:flex [&_.ant-menu-sub_>_.ant-menu-item]:items-center",
                             className: clsx("ag-sidebar-submenu", {
                                 "ag-sidebar-submenu-inline": mode === "inline",
@@ -287,6 +293,10 @@ const SidebarMenu: React.FC<SidebarMenuProps> = ({
                 "!bg-transparent [&_.ant-menu-sub]:!bg-transparent",
                 "[&_.ant-menu-item]:flex [&_.ant-menu-item]:items-center",
                 "[&_.ant-menu-submenu-title]:flex [&_.ant-menu-submenu-title]:items-center",
+                // Anchor the links' stretched ::before to the row, and keep
+                // disabled rows inert even though they contain a full-row anchor.
+                "[&_.ant-menu-item]:relative [&_.ant-menu-submenu-title]:relative",
+                "[&_.ant-menu-item-disabled_a]:pointer-events-none [&_.ant-menu-submenu-disabled_a]:pointer-events-none",
                 "[&_.ant-menu-item]:!rounded-md [&_.ant-menu-submenu-title]:!rounded-md",
                 "[&_.ant-menu-item-icon]:!shrink-0",
                 "!border-0 [&_.ant-menu-item-divider]:!w-full [&_.ant-menu-item-divider]:!my-2",
@@ -301,7 +311,7 @@ const SidebarMenu: React.FC<SidebarMenuProps> = ({
                 {
                     "[&_.ant-menu-item]:!px-2 [&_.ant-menu-item]:!w-[28px] [&_.ant-menu-item]:!mx-auto [&_.ant-menu-item]:!flex [&_.ant-menu-item]:!items-center [&_.ant-menu-item]:!justify-center":
                         collapsed,
-                    "[&_.ant-menu-title-content]:!opacity-0 [&_.ant-menu-title-content]:!duration-0 [&_.ant-menu-title-content]:absolute [&_.ant-menu-title-content]:top-0 [&_.ant-menu-title-content]:left-0 [&_.ant-menu-title-content]:right-0 [&_.ant-menu-title-content]:bottom-0":
+                    "[&_.ant-menu-title-content]:!opacity-0 [&_.ant-menu-title-content]:!duration-0 [&_.ant-menu-title-content]:absolute [&_.ant-menu-title-content]:top-0 [&_.ant-menu-title-content]:left-0 [&_.ant-menu-title-content]:right-0 [&_.ant-menu-title-content]:bottom-0 [&_.ant-menu-title-content]:!w-full":
                         collapsed,
                     "[&_.ant-menu-submenu-title]:!w-[28px] [&_.ant-menu-submenu-title]:!mx-auto [&_.ant-menu-submenu-title]:!p-2 [&_.ant-menu-submenu-title]:!flex [&_.ant-menu-submenu-title]:!items-center [&_.ant-menu-submenu-title]:!justify-center":
                         collapsed,

--- a/web/oss/src/components/Sidebar/hooks/useWorkflowSwitcher.tsx
+++ b/web/oss/src/components/Sidebar/hooks/useWorkflowSwitcher.tsx
@@ -9,8 +9,13 @@ import {
 import type {MenuProps} from "antd"
 import clsx from "clsx"
 import {useAtomValue, useSetAtom} from "jotai"
+import Link from "next/link"
 
-import {recentAppIdAtom, routerAppNavigationAtom} from "@/oss/state/app/atoms/fetcher"
+import {
+    appSwitchHrefAtom,
+    recentAppIdAtom,
+    routerAppNavigationAtom,
+} from "@/oss/state/app/atoms/fetcher"
 import {
     currentWorkflowContextAtom,
     EVALUATOR_FULL_PAGE_NAV_ENABLED,
@@ -47,6 +52,7 @@ export const useWorkflowSwitcher = () => {
     const recentAppId = useAtomValue(recentAppIdAtom)
     const recentEvaluatorId = useAtomValue(recentEvaluatorIdAtom)
     const navigateToWorkflow = useSetAtom(routerAppNavigationAtom)
+    const buildWorkflowHref = useAtomValue(appSwitchHrefAtom)
     const [open, setOpen] = useState(false)
 
     // Product decision: the workflow switcher is intentionally narrower than
@@ -77,18 +83,41 @@ export const useWorkflowSwitcher = () => {
         evaluators,
     })
 
+    // Real anchor per item so middle-click / ctrl+click open a new tab; plain
+    // left clicks preventDefault and stay on the antd onClick (SPA) path.
+    const handleItemLinkClick = useCallback((event: React.MouseEvent) => {
+        if (event.metaKey || event.ctrlKey || event.shiftKey || event.altKey) {
+            event.stopPropagation()
+            setOpen(false)
+            return
+        }
+        event.preventDefault()
+    }, [])
+
     const menuItems = useMemo<MenuProps["items"]>(() => {
         const toMenuItem = (entity: Workflow, isEvaluator: boolean) => {
             const label = entity.name ?? entity.slug ?? entity.id
+            const identity = (
+                <WorkflowIdentity
+                    workflowId={entity.id}
+                    name={label}
+                    isEvaluator={isEvaluator}
+                    selected={entity.id === workflowId}
+                />
+            )
+            const href = buildWorkflowHref(entity.id)
             return {
                 key: entity.id,
-                label: (
-                    <WorkflowIdentity
-                        workflowId={entity.id}
-                        name={label}
-                        isEvaluator={isEvaluator}
-                        selected={entity.id === workflowId}
-                    />
+                label: href ? (
+                    <Link
+                        className="block w-full !text-inherit hover:!text-inherit no-underline"
+                        href={href}
+                        onClick={handleItemLinkClick}
+                    >
+                        {identity}
+                    </Link>
+                ) : (
+                    identity
                 ),
             }
         }
@@ -103,7 +132,7 @@ export const useWorkflowSwitcher = () => {
             .map(({entity, isEvaluator}) => toMenuItem(entity, isEvaluator))
 
         return children
-    }, [apps, switcherEvaluators, workflowId])
+    }, [apps, buildWorkflowHref, handleItemLinkClick, switcherEvaluators, workflowId])
 
     const handleMenuClick = useCallback<NonNullable<MenuProps["onClick"]>>(
         ({key}) => {

--- a/web/oss/src/state/app/atoms/fetcher.ts
+++ b/web/oss/src/state/app/atoms/fetcher.ts
@@ -43,6 +43,28 @@ export const routerAppIdAtom = atom(
     },
 )
 
+// Builds the href an app switch would navigate to. Shared by the imperative
+// navigation atom below and by anchors that expose the same target as a real
+// link (middle-click / open-in-new-tab in the workflow switcher).
+export const appSwitchHrefAtom = atom((get) => {
+    const {workspaceId, projectId} = get(appIdentifiersAtom)
+    const snapshot = get(appStateSnapshotAtom)
+
+    return (next: string): string | null => {
+        if (!workspaceId || !projectId) return null
+
+        const base = `/w/${encodeURIComponent(workspaceId)}/p/${encodeURIComponent(projectId)}/apps/${encodeURIComponent(next)}`
+        const rest = snapshot.routeLayer === "app" ? snapshot.restPath : []
+        const nextRest = shouldResetEvaluationContextOnAppSwitch({
+            restPath: rest,
+            pathname: snapshot.pathname,
+        })
+            ? ["evaluations"]
+            : rest
+        return nextRest.length ? `${base}/${nextRest.join("/")}` : `${base}/overview`
+    }
+})
+
 export const routerAppNavigationAtom = atom(null, (get, set, next: string | null) => {
     const identifiers = get(appIdentifiersAtom)
     const {workspaceId, projectId, appId: current} = identifiers
@@ -56,16 +78,8 @@ export const routerAppNavigationAtom = atom(null, (get, set, next: string | null
 
     if (next === current) return
 
-    const base = `/w/${encodeURIComponent(workspaceId)}/p/${encodeURIComponent(projectId)}/apps/${encodeURIComponent(next)}`
-    const snapshot = get(appStateSnapshotAtom)
-    const rest = snapshot.routeLayer === "app" ? snapshot.restPath : []
-    const nextRest = shouldResetEvaluationContextOnAppSwitch({
-        restPath: rest,
-        pathname: snapshot.pathname,
-    })
-        ? ["evaluations"]
-        : rest
-    const href = nextRest.length ? `${base}/${nextRest.join("/")}` : `${base}/overview`
+    const href = get(appSwitchHrefAtom)(next)
+    if (!href) return
     set(requestNavigationAtom, {type: "href", href, method: "push"})
 })
 


### PR DESCRIPTION
## Context
Middle-clicking (or ctrl+clicking) items in the sidebar did nothing for most of the clickable surface. Sidebar rows rendered a real anchor only around the title text; the icon and the rest of the row navigated through `router.push` in JavaScript, which the browser cannot open in a new tab. The workflow switcher dropdown (the agents list at the top of the sidebar) had no anchors at all, so none of its items could be opened in a new tab.

## Changes
**Sidebar menu rows** (`SidebarMenu.tsx`): each link's anchor now stretches over the whole row with an absolutely positioned `::before`, so the icon, the padding, and the text are all part of one real link. Rows (`.ant-menu-item`, `.ant-menu-submenu-title`) become the positioned containers. Submenu popups render in a portal, so they get the same positioning rules through `popupClassName`. Two guards keep behavior identical:

- the expand caret sits above the anchor (`z-[1]`), so it still toggles the group without navigating
- anchors inside disabled rows get `pointer-events: none`, so disabled items stay inert

In collapsed mode the invisible title overlay that covers each rail icon computed to width 0, so even the old text anchor never covered the icon. It now gets `w-full`, which makes the rail icons middle-clickable too.

**Workflow picker** (`useWorkflowSwitcher.tsx`): every dropdown item is now wrapped in a real `<Link>`. The href is the same URL a click would push, built by the new `appSwitchHrefAtom` (extracted from `routerAppNavigationAtom` in `fetcher.ts` so both share one URL source of truth, including the keep-current-subpage behavior). Plain left clicks `preventDefault()` and stay on the existing antd `onClick` path; modified clicks (middle, ctrl, cmd, shift) fall through to the native anchor.

## Scope / risk
Only the sidebar menu engine and the workflow picker are touched. Other JS-navigated surfaces (the projects and orgs lists in the sidebar header, table rows) are unchanged and still not middle-clickable. The stretched-anchor pattern covers the full row, so any future row content that needs its own click handler must be positioned above the anchor like the caret.

## Tests / notes
- `pnpm lint-fix` clean; `tsc` shows no new errors in the touched files (remaining errors are pre-existing in Playwright test helpers).
- Verified live on the EE dev stack via browser hit-testing: every linkable row (expanded and collapsed rail) resolves to its own anchor at icon, text, and row end, with no cross-row bleed; caret toggling, left-click SPA navigation, and dropdown open/close behave exactly as before.

## How to QA

**Prerequisites:** any running stack (the Hetzner dev box at the live port works). Log in and open a project.

**Steps:**
1. In the main sidebar, middle-click the Agents entry, once on its icon and once on its text.
2. Expand the Agents group with the caret and middle-click an agent row.
3. Collapse the sidebar and middle-click a rail icon (for example Observability).
4. Open an agent, click the workflow name at the top of the sidebar, and middle-click another agent in the dropdown.
5. Left-click the same items.

**Expected result:** every middle-click opens the target page in a new background tab. Every left-click navigates in place exactly as before (no full page reload, dropdown closes after switching, caret only toggles the group).

**Automated tests:** none; this is CSS/anchor wiring with no unit-testable logic. Coverage is the manual matrix above.

**Edge cases:** disabled items (cloud-only features in OSS) must stay unclickable. The expand caret must never navigate.

https://claude.ai/code/session_016NT3qqbMYQ97xFqVpbtbL1