### PR TITLE
fix(sdk): stop span-attribute overflow from evicting trace references

### DIFF
--- a/sdks/python/agenta/sdk/decorators/tracing.py
+++ b/sdks/python/agenta/sdk/decorators/tracing.py
@@ -544,9 +544,15 @@ class instrument:  # pylint: disable=invalid-name
             )
 
             if span.parent is None:
+                # Unbounded flattening of a resolved agent config (tools with full JSON
+                # schemas) yields hundreds of leaf attributes, overflowing the span
+                # attribute limit and evicting the oldest attributes (ag.refs.*).
+                # Depth 3 keeps one `@ag.type=json:` attribute per config section
+                # (configuration.agent.tools, .llm, ...) instead of one per leaf.
                 span.set_attributes(
                     attributes={"configuration": context.parameters or {}},
                     namespace="meta",
+                    max_depth=3,
                 )
 
             _inputs = self._redact(

--- a/sdks/python/agenta/sdk/engines/tracing/tracing.py
+++ b/sdks/python/agenta/sdk/engines/tracing/tracing.py
@@ -13,7 +13,7 @@ from opentelemetry.trace import (
     StatusCode,
 )
 from opentelemetry.sdk import trace
-from opentelemetry.sdk.trace import Span, Tracer, TracerProvider
+from opentelemetry.sdk.trace import Span, SpanLimits, Tracer, TracerProvider
 from opentelemetry.sdk.resources import Resource
 
 
@@ -91,8 +91,12 @@ class Tracing(metaclass=Singleton):
             self.headers["Authorization"] = f"ApiKey {api_key}"
 
         # TRACER PROVIDER
+        # 256 doubles the OTel default (128). Attributes are set oldest-first and
+        # BoundedAttributes silently evicts the OLDEST on overflow, so a root span
+        # flooded by a large flattened config evicts its ag.refs.* references.
         self.tracer_provider = TracerProvider(
-            resource=Resource(attributes={"service.name": "agenta-sdk"})
+            resource=Resource(attributes={"service.name": "agenta-sdk"}),
+            span_limits=SpanLimits(max_attributes=256),
         )
 
         # TRACE PROCESSORS -- OTLP


### PR DESCRIPTION
## Symptom

Playground agent runs stopped showing any references (application / variant / revision) on their traces, even though the frontend forwards them correctly since #5163/#5179.

## Cause

The root agent span records the resolved configuration flattened one attribute per leaf (`ag.meta.configuration.agent.tools.16.input_schema.properties.message.type`, ...). A resolved agent config now carries ~17 tools with full JSON schemas, so the span blows past OTel's default **128** span-attribute limit. `BoundedAttributes` silently evicts the **oldest** attributes on overflow, and the oldest are exactly the `ag.refs.*` references stamped at span start. Small-config runs (triggers) kept their references; playground runs lost them.

Verified live on the dev stack: the broken root span holds exactly 128 attributes with zero `ag.refs.*`, while a small trigger run seconds earlier holds 43 and keeps them.

## Fix

Two independent guards:

- `SpanLimits(max_attributes=256)` on the `TracerProvider` (double the OTel default).
- Cap the root-span configuration flattening at `max_depth=3`, so each config section lands as one `@ag.type=json:` attribute (`configuration.agent.tools`, `.llm`, `.instructions`) instead of hundreds of leaves. Same mechanism `data.inputs` already uses.

## Before / after (live dev stack, same playground app)

Before: root span `references` column NULL, no `ag.refs.*` attributes, `ag.flags` also evicted.
After: root span carries all three reference families (application, application_variant, application_revision v1) plus flags; ingestion populates the `references` column again.

SDK unit suite: the only failures are the documented pre-existing base reds (secrets SSRF x6, sdk permission-defaults x2, one QA replay), reproduced identically with the change reverted.

https://claude.ai/code/session_01QSwVMKwo4FBZXkeTd4t3SP