### PR TITLE
[fix] Re-export partitionElicitationDraft from the shared utils barrel

### DIFF
--- a/web/packages/agenta-shared/src/utils/index.ts
+++ b/web/packages/agenta-shared/src/utils/index.ts
@@ -227,6 +227,7 @@ export {
     deriveElicitationPartState,
     hasPriorElicitationDegradation,
     parseElicitationPayload,
+    partitionElicitationDraft,
     serializeElicitationContent,
     type ElicitationAction,
     type ElicitationFieldSchema,


### PR DESCRIPTION
## Context
`next dev` fails to build on `big-agents`: `ElicitationWidget` imports `partitionElicitationDraft` from `@agenta/shared/utils`, but the elicitation M1 follow-ups added the function to `elicitation.ts` (and used it in the widget) without adding it to the barrel's re-export list in `index.ts`. Turbopack treats the missing export as a build error, so any branch based on `big-agents` cannot start the dev server.

## Changes
Adds `partitionElicitationDraft` to the existing `./elicitation` re-export block in `web/packages/agenta-shared/src/utils/index.ts`. One line; no behavior change beyond making the already-used export resolvable.

## Tests
- `next dev` builds again on a branch based on `big-agents` with this line applied; without it, Turbopack fails on the missing export.
- Lint and prettier pass (pre-push hooks ran clean).