### PR TITLE
fix(frontend): re-export partitionElicitationDraft from the shared utils barrel

### DIFF
--- a/web/packages/agenta-shared/src/utils/index.ts
+++ b/web/packages/agenta-shared/src/utils/index.ts
@@ -227,6 +227,7 @@ export {
     deriveElicitationPartState,
     hasPriorElicitationDegradation,
     parseElicitationPayload,
+    partitionElicitationDraft,
     serializeElicitationContent,
     type ElicitationAction,
     type ElicitationFieldSchema,


### PR DESCRIPTION
## Problem

Every page that mounts `AgentChatSlice` failed to build after the elicitation feature landed:

```
Build Error: Export partitionElicitationDraft doesn't exist in target module
./oss/src/components/AgentChatSlice/components/clientTools/ElicitationWidget.tsx (12:1)
```

`ElicitationWidget.tsx` imports `partitionElicitationDraft` from `@agenta/shared/utils`, and the function exists in `elicitation.ts`, but the barrel (`src/utils/index.ts`) never re-exported it. Turbopack resolves the barrel statically, so the missing name broke the whole `_app` tree — apps list and playground both showed the build-error overlay.

## Fix

One line: add `partitionElicitationDraft` to the barrel's elicitation export block.

## Verification

- Live EE dev stack (144.76.237.122:8280): apps page and agent playground (the two routes from the error traces) render clean after a web-container restart; zero compile errors in the container logs.
- `partitionElicitationDraft` unit tests already exist in `agenta-shared/tests/unit/elicitation.test.ts`.

https://claude.ai/code/session_01UEq8PbS6oBUTRH1sH6Ftej