### PR TITLE
feat(frontend): copy raw config from the playground kebab menu

### DIFF
--- a/web/oss/src/components/Playground/Components/Menus/PlaygroundVariantHeaderMenu/index.tsx
+++ b/web/oss/src/components/Playground/Components/Menus/PlaygroundVariantHeaderMenu/index.tsx
@@ -4,9 +4,9 @@ import {workflowMolecule} from "@agenta/entities/workflow"
 import {isAgentModeAtomFamily, playgroundController} from "@agenta/playground"
 import {message} from "@agenta/ui/app-message"
 import {MoreOutlined} from "@ant-design/icons"
-import {ArrowCounterClockwise, Trash} from "@phosphor-icons/react"
+import {ArrowCounterClockwise, Copy, Trash} from "@phosphor-icons/react"
 import {Button, Dropdown, MenuProps} from "antd"
-import {useAtomValue, useSetAtom} from "jotai"
+import {getDefaultStore, useAtomValue, useSetAtom} from "jotai"
 
 import DeleteVariantButton from "../../Modals/DeleteVariantModal/assets/DeleteVariantButton"
 
@@ -42,8 +42,34 @@ const PlaygroundVariantHeaderMenu: React.FC<PlaygroundVariantHeaderMenuProps> = 
         }
     }
 
+    const handleCopyRawConfig: NonNullable<MenuProps["onClick"]> = (e) => {
+        e?.domEvent?.stopPropagation()
+        if (!variantId) return
+        // Read lazily so the menu doesn't re-render on every config edit.
+        const config = getDefaultStore().get(workflowMolecule.selectors.configuration(variantId))
+        if (!config) {
+            message.error("No raw configuration available to copy")
+            return
+        }
+        navigator.clipboard
+            .writeText(JSON.stringify(config, null, 2))
+            .then(() => message.success("Raw configuration copied to clipboard"))
+            .catch((err) => {
+                message.error("Failed to copy raw configuration")
+                console.error(err)
+            })
+    }
+
     const items: MenuProps["items"] = useMemo(
         () => [
+            {
+                key: "copy-raw-config",
+                label: "Copy raw config",
+                icon: <Copy size={14} />,
+                onClick: handleCopyRawConfig,
+                disabled: !variantId,
+            },
+            {type: "divider" as const},
             {
                 key: "revert",
                 label: "Revert Changes",
@@ -77,7 +103,15 @@ const PlaygroundVariantHeaderMenu: React.FC<PlaygroundVariantHeaderMenuProps> = 
                   ]
                 : []),
         ],
-        [handleClosePanel, closePanelDisabled, variantId, handleDiscardDraft, isDirty, isAgent],
+        [
+            handleClosePanel,
+            closePanelDisabled,
+            variantId,
+            handleDiscardDraft,
+            handleCopyRawConfig,
+            isDirty,
+            isAgent,
+        ],
     )
 
     return (

--- a/web/oss/src/components/Playground/Components/Menus/PlaygroundVariantHeaderMenu/index.tsx
+++ b/web/oss/src/components/Playground/Components/Menus/PlaygroundVariantHeaderMenu/index.tsx
@@ -30,35 +30,43 @@ const PlaygroundVariantHeaderMenu: React.FC<PlaygroundVariantHeaderMenuProps> = 
         removeVariantFromSelection(variantId)
     }, [removeVariantFromSelection, variantId])
 
-    const handleDiscardDraft: NonNullable<MenuProps["onClick"]> = (e) => {
-        e?.domEvent?.stopPropagation()
-        if (!variantId) return
-        try {
-            workflowMolecule.set.discard(variantId)
-            message.success("Draft changes discarded")
-        } catch (err) {
-            message.error("Failed to discard draft changes")
-            console.error(err)
-        }
-    }
-
-    const handleCopyRawConfig: NonNullable<MenuProps["onClick"]> = (e) => {
-        e?.domEvent?.stopPropagation()
-        if (!variantId) return
-        // Read lazily so the menu doesn't re-render on every config edit.
-        const config = getDefaultStore().get(workflowMolecule.selectors.configuration(variantId))
-        if (!config) {
-            message.error("No raw configuration available to copy")
-            return
-        }
-        navigator.clipboard
-            .writeText(JSON.stringify(config, null, 2))
-            .then(() => message.success("Raw configuration copied to clipboard"))
-            .catch((err) => {
-                message.error("Failed to copy raw configuration")
+    const handleDiscardDraft = useCallback<NonNullable<MenuProps["onClick"]>>(
+        (e) => {
+            e?.domEvent?.stopPropagation()
+            if (!variantId) return
+            try {
+                workflowMolecule.set.discard(variantId)
+                message.success("Draft changes discarded")
+            } catch (err) {
+                message.error("Failed to discard draft changes")
                 console.error(err)
-            })
-    }
+            }
+        },
+        [variantId],
+    )
+
+    const handleCopyRawConfig = useCallback<NonNullable<MenuProps["onClick"]>>(
+        (e) => {
+            e?.domEvent?.stopPropagation()
+            if (!variantId) return
+            // Read lazily so the menu doesn't re-render on every config edit.
+            const config = getDefaultStore().get(
+                workflowMolecule.selectors.configuration(variantId),
+            )
+            if (!config) {
+                message.error("No raw configuration available to copy")
+                return
+            }
+            navigator.clipboard
+                .writeText(JSON.stringify(config, null, 2))
+                .then(() => message.success("Raw configuration copied to clipboard"))
+                .catch((err) => {
+                    message.error("Failed to copy raw configuration")
+                    console.error(err)
+                })
+        },
+        [variantId],
+    )
 
     const items: MenuProps["items"] = useMemo(
         () => [


### PR DESCRIPTION
## Context
Debugging an agent failure in Slack meant screenshotting the config panel piece by piece. Mahmoud needed the exact tool definitions the agent was running with (suspected composio bug) and asked for "a way to share raw agent configs". There was no way to get the actual config payload out of the playground.

## Changes
The playground variant kebab menu gets a "Copy raw config" item. It copies the draft-aware configuration (`workflowMolecule.selectors.configuration`) as pretty-printed JSON. This is the same object `buildAgentRequest` sends as `data.parameters` on a run, so tool definitions and any uncommitted edits are included; what you copy is what a run would execute.

Details:

- The config is read lazily at click time via `getDefaultStore()`, so the menu does not subscribe to (and re-render on) every config keystroke.
- Toasts go through `message` from `@agenta/ui/app-message`, which is bound to antd's `App.useApp()` context and therefore themes correctly in dark mode. Success, clipboard failure, and empty-config cases each have their own message.
- The item shows for both agent and regular playground variants; the selector is generic.

## Tests / notes
- eslint, prettier, and `tsc --noEmit` on `oss` are clean (no errors reference the changed file; the remaining tsc noise is pre-existing Playwright test debt).
- Verified the copied output on a hello-world agent: the pasted JSON matches the `parameters.agent` shape (`instructions`, `llm`, `tools`, `mcps`, `harness`, `runner`, `sandbox`).

## What to QA
- Open an agent in the playground, kebab menu, "Copy raw config", paste somewhere. You get the full agent JSON, tools array included.
- Edit the config without committing, copy again. The paste reflects the draft edits.
- Switch to dark mode and copy. The toast renders dark, not light.
- Regression: "Revert Changes" and "Delete" in the same menu still behave as before.
